### PR TITLE
ci: gate interactive changes behind PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # clawock intentionally has no Python dependency manifest today, so keep this
+  # focused on the Actions actually used by the repository.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      safe-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@
 
 - [ ] Required GitHub Actions checks pass
 - [ ] No secrets, scratch files, or unrelated generated data are included
-- [ ] High-risk logic received a second-agent review, or is marked not applicable
+- [ ] The non-authoring agent posted `AI-REVIEW: PASS` and owns the merge

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Outcome
+
+<!-- What changes for the user or runtime? -->
+
+## Risk
+
+<!-- Data integrity, publishing, scheduling, security, or rollback concerns. -->
+
+## Validation
+
+- [ ] Required GitHub Actions checks pass
+- [ ] No secrets, scratch files, or unrelated generated data are included
+- [ ] High-risk logic received a second-agent review, or is marked not applicable

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,9 +5,9 @@ on:
     branches: [master]
     paths:
       - '.github/workflows/**'
+  # Run on every PR so `lint` is a stable required check. Scanning all workflow
+  # files is cheap and avoids a path-filtered required check waiting forever.
   pull_request:
-    paths:
-      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -20,8 +20,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -98,6 +96,8 @@ jobs:
         # The publish gate distinguishes a legitimate warn from a crash-before-gate;
         # missing gate fails the job, while explicit publish_ok=false publishes nothing.
         if: steps.check.outputs.skip != 'true'
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           if [ ! -f "logs/brief_postflight_status.json" ]; then
             echo "postflight crashed before writing the publish gate (logs/brief_postflight_status.json) — refusing to publish"

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 9 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -19,8 +19,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 
@@ -72,6 +70,8 @@ jobs:
         run: python3 scripts/data/validate_sidecars.py eod-archive
 
       - name: Commit
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -16,6 +16,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -22,6 +22,41 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
+        with:
+          # PR file-policy checks compare the exact base and head commits.
+          fetch-depth: 0
+
+      - name: Reject conflict markers
+        run: |
+          if git grep -nE '^(<<<<<<< |>>>>>>> )' HEAD --; then
+            echo "::error::Tracked files contain unresolved git conflict markers"
+            exit 1
+          fi
+
+      - name: PR file safety policy
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+          bad=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              .api_keys|*/.api_keys|.openclaw/*|*/.openclaw/*|.clawhub/*|*/.clawhub/*|memory/.dreams/*|memory/.tmp/*)
+                bad+=("$f")
+                ;;
+              *.png|*.jpg|*.jpeg)
+                [[ "$f" == assets/* ]] || bad+=("$f")
+                ;;
+            esac
+          done
+          if ((${#bad[@]})); then
+            printf '::error::Forbidden PR path: %s\n' "${bad[@]}"
+            exit 1
+          fi
+          echo "PR file policy OK: ${#files[@]} changed paths"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -25,8 +25,6 @@ jobs:
     timeout-minutes: 8
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -50,5 +48,7 @@ jobs:
       - name: Commit + push
         # Shared helper commits only this workflow's sidecar. The frontend fetches
         # it directly; dashboard.json is not rebuilt for it.
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           bash scripts/data/gha_commit_push.sh "influence: Trump/Musk radar $(TZ=Asia/Hong_Kong date +%Y-%m-%d_%H:%M)" assets/data/influencer_feed.json

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 8
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -26,8 +26,6 @@ jobs:
     timeout-minutes: 4
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 
@@ -47,5 +45,7 @@ jobs:
       - name: Commit
         # Shared helper commits only this workflow's sidecar. The frontend fetches
         # it directly; dashboard.json is not rebuilt for it.
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           bash scripts/data/gha_commit_push.sh "macro: daily snapshot $(date -u +%Y-%m-%d)" assets/data/macro.json

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 4
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -16,8 +16,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -40,6 +38,8 @@ jobs:
         run: python3 scripts/data/validate_sidecars.py news-digest
 
       - name: Commit + push
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/screenshot-refresh.yml
+++ b/.github/workflows/screenshot-refresh.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/screenshot-refresh.yml
+++ b/.github/workflows/screenshot-refresh.yml
@@ -20,8 +20,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -64,6 +62,8 @@ jobs:
         run: python3 scripts/data/validate_sidecars.py screenshots
 
       - name: Commit if changed
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -25,8 +25,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
 
@@ -46,5 +44,7 @@ jobs:
       - name: Commit
         # Shared helper commits only this workflow's sidecar. The frontend fetches
         # it directly; dashboard.json is not rebuilt for it.
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           bash scripts/data/gha_commit_push.sh "sentiment: daily Reddit + Google News scan $(date -u +%Y-%m-%d)" assets/data/sentiment.json

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 23 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   health:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -16,8 +16,6 @@ jobs:
     timeout-minutes: 12
     permissions:
       contents: write
-    env:
-      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -40,6 +38,8 @@ jobs:
         run: python3 scripts/data/validate_sidecars.py weekly-review
 
       - name: Commit + push
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 12
     permissions:
       contents: write
+    env:
+      CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,13 @@ documentation:
 2. Make and commit the change in that worktree, then push the task branch and open a PR.
 3. Let GitHub Actions run the full test suite. Local full-suite runs are optional; the
    required remote checks are the merge gate.
-4. Do not merge while any required check is pending or failing. Fix the branch, push,
+4. The authoring agent must not merge its own PR. The other agent reviews the diff,
+   leaves a final `AI-REVIEW: PASS` comment only after findings are resolved, and owns
+   the merge: Claude reviews/merges Codex PRs; Codex reviews/merges Claude PRs.
+5. Do not merge while any required check is pending or failing. Fix the branch, push,
    and let the PR rerun its checks.
-5. Squash-merge only after required checks pass, then remove the task worktree/branch.
+6. The reviewing agent squash-merges only after required checks pass, then removes the
+   task worktree/branch.
 
 Runtime-generated market data, snapshots, reports, ledgers, and dashboard artifacts
 remain on the existing direct-to-`master` bot path. They do not open high-frequency PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ Override with `--no-verify` if false positive (rare).
 
 The workspace is a local git repo. **`origin` is the public repo `github.com/KCNyu/clawock`** — the
 contents (positions, plans, memory logs) are intentionally public per kcn's instruction.
+This table governs the live runtime workspace and its scheduled writers. Interactive
+Codex/Claude code changes follow the PR workflow in the next section.
 After any of the following changes, run a git commit automatically — no need to ask:
 
 | Change | Commit |
@@ -52,8 +54,31 @@ After any of the following changes, run a git commit automatically — no need t
 Message style: `<type>: <concise description>`, Chinese is fine.
 **Never commit:** `.api_keys`, scratch `*.png`/`*.jpg` outside the shipped `assets/`/`docs/` allowlists, `.openclaw/`, `.clawhub/`, `memory/.dreams/`, `memory/.tmp/` (gitignored). Shipped `assets/*.png` are committed; `screenshot-refresh.yml` commits `assets/shadow-backtest.png` and `assets/social-card.png`, plus `assets/dashboard.gif` on manual dispatch.
 
-Push: harness postflight now **auto-pushes** after commit (rebase+retry on race). 
-`git push` from chat / Telegram should still ask first — that's intentional human gating.
+Push: harness postflight now **auto-pushes** after commit (rebase+retry on race).
+Interactive Codex/Claude work must never push `master`; it may push only its task
+branch to create or update a PR.
+
+## Interactive Codex/Claude PR workflow
+
+The live checkout `/root/.openclaw/workspace` must stay on `master` because cron and
+OpenClaw write runtime data there throughout the day. Never switch that checkout to a
+feature branch and never make interactive code edits in it.
+
+For changes to code, scripts, workflows, skills, UI, configuration, or repository
+documentation:
+
+1. Create an isolated worktree from current `origin/master`, using a branch named
+   `codex/<task>` or `claude/<task>`.
+2. Make and commit the change in that worktree, then push the task branch and open a PR.
+3. Let GitHub Actions run the full test suite. Local full-suite runs are optional; the
+   required remote checks are the merge gate.
+4. Do not merge while any required check is pending or failing. Fix the branch, push,
+   and let the PR rerun its checks.
+5. Squash-merge only after required checks pass, then remove the task worktree/branch.
+
+Runtime-generated market data, snapshots, reports, ledgers, and dashboard artifacts
+remain on the existing direct-to-`master` bot path. They do not open high-frequency PRs.
+Never use the repository-admin bypass for an interactive code change.
 
 ## Memory
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Entry pointer for Claude Code in kcn's investment workspace. Same workflow as `A
 | Startup sequence | `INVESTMENT_SOP.md` |
 | Heartbeat workflow | `HEARTBEAT.md` (heartbeat poll only) |
 | Auto-commit rules | `AGENTS.md` |
+| Interactive code PR/worktree rules | `AGENTS.md` § Interactive Codex/Claude PR workflow |
 | Pages dashboard input | `assets/data/dashboard.json` (built by `scripts/data/build_dashboard.py`) |
 | Risk metrics snapshot | `assets/data/risk.json` (built by `scripts/data/portfolio_risk_metrics.py`, refreshed daily via brief preflight) |
 | Decision execution marking | `memory/decisions.jsonl` `execution.status`; manual override via `scripts/data/mark_followed.py DECISION_ID [--no]` |

--- a/scripts/data/safe_push.sh
+++ b/scripts/data/safe_push.sh
@@ -14,6 +14,20 @@ set -e
 MAX_RETRIES=3
 REMOTE="${1:-origin}"
 BRANCH="${2:-master}"
+TEMP_SSH_KEY=""
+
+# A protected master must still accept scheduled data writers. GitHub-hosted
+# workflows receive a write-enabled deploy key through this secret; using the
+# deploy key lets the repository ruleset distinguish automation from the shared
+# KCNyu identity used by interactive Codex/Claude sessions.
+if [ -n "${CLAWOCK_PUBLISH_SSH_KEY:-}" ]; then
+  TEMP_SSH_KEY=$(mktemp)
+  chmod 600 "$TEMP_SSH_KEY"
+  printf '%s\n' "$CLAWOCK_PUBLISH_SSH_KEY" > "$TEMP_SSH_KEY"
+  export GIT_SSH_COMMAND="ssh -i $TEMP_SSH_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+  REMOTE="${CLAWOCK_PUBLISH_REMOTE:-git@github.com:KCNyu/clawock.git}"
+  trap 'test -z "$TEMP_SSH_KEY" || { : > "$TEMP_SSH_KEY"; unlink "$TEMP_SSH_KEY"; }' EXIT
+fi
 
 # ── Conflict-marker guard (2026-06-03) ───────────────────────────────────────
 # A "merge fix" once committed dashboard.json WITH unresolved <<<<<<< / ======= /

--- a/scripts/data/safe_push.sh
+++ b/scripts/data/safe_push.sh
@@ -15,6 +15,7 @@ MAX_RETRIES=3
 REMOTE="${1:-origin}"
 BRANCH="${2:-master}"
 TEMP_SSH_KEY=""
+PUBLISH_SSH_KEY=""
 
 # A protected master must still accept scheduled data writers. GitHub-hosted
 # workflows receive a write-enabled deploy key through this secret; using the
@@ -24,8 +25,20 @@ if [ -n "${CLAWOCK_PUBLISH_SSH_KEY:-}" ]; then
   TEMP_SSH_KEY=$(mktemp)
   chmod 600 "$TEMP_SSH_KEY"
   printf '%s\n' "$CLAWOCK_PUBLISH_SSH_KEY" > "$TEMP_SSH_KEY"
-  export GIT_SSH_COMMAND="ssh -i $TEMP_SSH_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+  PUBLISH_SSH_KEY="$TEMP_SSH_KEY"
+elif [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "/root/.openclaw/workspace" ] && \
+     [ -r "/root/.ssh/clawock_runtime_publish" ]; then
+  # The live OpenClaw checkout uses a separate deploy key. Interactive agents
+  # work in isolated /root/.worktrees paths, so they never inherit this bypass.
+  PUBLISH_SSH_KEY="/root/.ssh/clawock_runtime_publish"
+fi
+
+if [ -n "$PUBLISH_SSH_KEY" ]; then
+  export GIT_SSH_COMMAND="ssh -i $PUBLISH_SSH_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
   REMOTE="${CLAWOCK_PUBLISH_REMOTE:-git@github.com:KCNyu/clawock.git}"
+fi
+
+if [ -n "$TEMP_SSH_KEY" ]; then
   trap 'test -z "$TEMP_SSH_KEY" || { : > "$TEMP_SSH_KEY"; unlink "$TEMP_SSH_KEY"; }' EXIT
 fi
 

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -1,0 +1,101 @@
+"""Contracts for the PR gate and the two automation-only publish identities."""
+
+from pathlib import Path
+import os
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+PUBLISH_CALLS = (
+    "scripts/data/safe_push.sh",
+    "scripts/data/gha_commit_push.sh",
+)
+SECRET_BINDING = (
+    "CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}"
+)
+
+
+def _publishing_workflows():
+    return [
+        path
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+        if any(call in path.read_text() for call in PUBLISH_CALLS)
+    ]
+
+
+def test_each_publishing_workflow_scopes_deploy_key_to_push_step():
+    writers = _publishing_workflows()
+    assert writers, "no GitHub-hosted publishing workflows found"
+
+    for workflow in writers:
+        lines = workflow.read_text().splitlines()
+        bindings = [
+            (index, line)
+            for index, line in enumerate(lines)
+            if line.strip() == SECRET_BINDING
+        ]
+        assert len(bindings) == 1, (
+            f"{workflow.name} must bind the publish key exactly once"
+        )
+
+        index, line = bindings[0]
+        assert len(line) - len(line.lstrip()) == 10, (
+            f"{workflow.name} exposes the deploy key above step scope"
+        )
+        assert lines[index - 1].strip() == "env:", (
+            f"{workflow.name} publish key is not in a step env block"
+        )
+
+
+def test_safe_push_uses_and_cleans_ephemeral_actions_key(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    git_log = tmp_path / "git.log"
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        """#!/bin/sh
+if [ "$1" = "grep" ]; then
+  exit 1
+fi
+if [ "$1" = "push" ]; then
+  printf '%s\\n' "$*" > "$FAKE_GIT_LOG"
+  printf '%s\\n' "$GIT_SSH_COMMAND" >> "$FAKE_GIT_LOG"
+  exit 0
+fi
+exit 1
+"""
+    )
+    fake_git.chmod(0o755)
+
+    fake_secret = "not-a-real-private-key"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "FAKE_GIT_LOG": str(git_log),
+            "CLAWOCK_PUBLISH_SSH_KEY": fake_secret,
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(ROOT / "scripts" / "data" / "safe_push.sh")],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_lines = git_log.read_text().splitlines()
+    assert log_lines[0] == "push git@github.com:KCNyu/clawock.git master"
+    assert "-i " in log_lines[1]
+    key_path = Path(log_lines[1].split("-i ", 1)[1].split(" ", 1)[0])
+    assert not key_path.exists(), "temporary deploy key survived safe_push exit"
+    assert fake_secret not in result.stdout
+    assert fake_secret not in result.stderr
+
+
+def test_live_runtime_key_is_limited_to_live_checkout():
+    safe_push = (ROOT / "scripts" / "data" / "safe_push.sh").read_text()
+    assert '"/root/.openclaw/workspace"' in safe_push
+    assert '"/root/.ssh/clawock_runtime_publish"' in safe_push


### PR DESCRIPTION
## Outcome

- route Codex/Claude code changes through isolated worktrees and PRs
- require remote Harness Regression, Actionlint, and CodeQL checks before merge
- reject conflict markers and forbidden scratch/secret paths
- enable weekly grouped GitHub Actions updates through Dependabot
- preserve scheduled data writers with ruleset-bypassed deploy keys

## GitHub-native security

Secret Scanning, Push Protection, Dependabot security updates, CodeQL, and free Copilot Autofix are enabled. No third-party AI reviewer is installed.

## Risk

Runtime-generated market data remains on the direct-to-master automation path. The live workspace was not switched or edited. GitHub-hosted writers use the Actions secret `CLAWOCK_PUBLISH_SSH_KEY`; the live runtime uses `/root/.ssh/clawock_runtime_publish`. Interactive worktrees use neither key.

## Validation

- [ ] Required GitHub Actions checks pass
- [x] Both deploy keys authenticate without exposing key material
- [x] No secrets, scratch files, or unrelated generated data are included
- [ ] Non-authoring agent posts `AI-REVIEW: PASS` and owns the merge