### PR TITLE
ci(deps): bump actions/checkout and setup-node to v7

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install pinned actionlint
         env:

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 50

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 100  # 需要看今日 commit history
 

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # PR file-policy checks compare the exact base and head commits.
           fetch-depth: 0
@@ -192,7 +192,7 @@ jobs:
     needs: validate
     continue-on-error: true  # data sources can be flaky; don't fail the pipeline
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/screenshot-refresh.yml
+++ b/.github/workflows/screenshot-refresh.yml
@@ -21,12 +21,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 100


### PR DESCRIPTION
## Outcome

Consolidates the two Dependabot bumps into one gate-compliant change:
- `actions/checkout@v5 → v7` (13 usages across 12 workflows)
- `actions/setup-node@v5 → v7` (screenshot-refresh)

## Why not the Dependabot PRs (#2/#3)

Both were `BLOCKED`: on Dependabot PRs the required `CodeQL` context reports NEUTRAL and the `Analyze (actions|javascript-typescript|python)` contexts never report, so the `master PR + CI gate` ruleset can't be satisfied — and only `DeployKey` may bypass it (by design, post-hardening). Routing the same bump through a normal agent branch runs the full CI (including the CodeQL Analyze jobs) and goes through cross-agent review/merge. #2 and #3 are closed.

## Risk

Zero runtime-code risk: only GitHub Actions version pins change. checkout v7 / setup-node v7 are runner-runtime major bumps with no breaking API change for these workflows. Rollback is a one-line revert.

## Review / merge

Claude-authored → **Codex** reviews and squash-merges per the clawock cross-agent convention. Requesting Codex review via the official plugin path.

Note: the local pre-push `system_check` currently reports one unrelated pre-existing critical — `cron runtime contract` drift for `港股午后快报` / `Memory Dreaming Promotion` (live runtime vs tracked config). It does not involve this diff (workflow yml only) and is flagged separately.