### PR TITLE
ci: scope validate's heavy steps to changed paths

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -79,20 +79,29 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # No --diff-filter: a deletion or rename of a script/test must also run
-          # the suite (it can break imports), same as the push trigger's paths.
-          mapfile -t files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          # --no-renames: a rename OUT of a watched dir (e.g. scripts/x.py ->
+          # docs/x.py) must still surface the old path and run the suite, since it
+          # can break imports. No --diff-filter, so deletions count too, matching
+          # the push trigger's paths. Capture separately (not via process
+          # substitution) so a git failure fails this step — fail-closed, validate
+          # goes red — instead of being read as an empty, docs-only diff and
+          # silently skipping the suite.
+          changed="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
+          # memory/decisions.jsonl is intentionally absent: like the push trigger,
+          # the ledger is automation-committed runtime data, not edited via
+          # interactive PRs.
           code=false
-          for f in "${files[@]}"; do
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
             case "$f" in
               scripts/*|tests/*|portfolio.json|memory/*-plan.json|assets/data/dashboard.json|config/cron-schedules.json|CRON_SCHEDULES.md|.github/workflows/*)
                 code=true
                 break
                 ;;
             esac
-          done
+          done <<< "$changed"
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "code changed: $code (${#files[@]} changed paths)"
+          echo "code changed: $code"
 
       - name: Set up Python
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -61,12 +61,47 @@ jobs:
           fi
           echo "PR file policy OK: ${#files[@]} changed paths"
 
+      - name: Detect code changes
+        # Scope the heavy Python steps to what a PR actually touches. This job
+        # (and the required `validate` context) always runs; a docs/markdown-only
+        # PR just skips the expensive steps and still reports green in seconds.
+        # We must NOT path-filter the pull_request trigger itself: a required
+        # check that is filtered out never reports and blocks the PR forever
+        # (see actionlint.yml). Skipped *steps* count as success, so we gate here.
+        # Only runs on PRs; non-PR events force the steps on via the `if:` below.
+        #
+        # Keep this path set in sync with the `push:` trigger `paths:` at the top
+        # of this file — both answer "does this change affect validate?".
+        id: changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # No --diff-filter: a deletion or rename of a script/test must also run
+          # the suite (it can break imports), same as the push trigger's paths.
+          mapfile -t files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          code=false
+          for f in "${files[@]}"; do
+            case "$f" in
+              scripts/*|tests/*|portfolio.json|memory/*-plan.json|assets/data/dashboard.json|config/cron-schedules.json|CRON_SCHEDULES.md|.github/workflows/*)
+                code=true
+                break
+                ;;
+            esac
+          done
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "code changed: $code (${#files[@]} changed paths)"
+
       - name: Set up Python
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install minimal deps
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         # numpy is required to *collect* tests/, not just to run one of them:
         # portfolio_risk_metrics imports it at module level, so without it pytest
         # aborts the whole run with a collection error and all 78 tests silently
@@ -74,12 +109,15 @@ jobs:
         run: pip install --quiet requests pytest numpy
 
       - name: Unit tests — money-integrity derivations
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: python3 -m pytest tests/ -q
 
       - name: Generated cron docs match contract
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: python3 scripts/data/generate_cron_docs.py --check
 
       - name: Import-check all scripts
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           set -e
           for f in scripts/data/*.py scripts/harness/*.py; do
@@ -88,6 +126,7 @@ jobs:
           done
 
       - name: argparse-check harness CLIs
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           set -e
           python3 scripts/harness/report_preflight.py --help > /dev/null
@@ -99,6 +138,7 @@ jobs:
           echo "OK: all argparse parsers loadable"
 
       - name: Schema-validate portfolio.json
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 << 'PY'
           import json, sys
@@ -115,6 +155,7 @@ jobs:
           PY
 
       - name: Schema-validate memory/*-plan.json
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 << 'PY'
           import json, glob, sys
@@ -128,6 +169,7 @@ jobs:
           PY
 
       - name: Decision v2 unit tests and ledger audit
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 -m unittest discover -s tests -p 'test_decision_v2.py' -v
           python3 << 'PY'
@@ -162,6 +204,7 @@ jobs:
           PY
 
       - name: Rebuild dashboard.json and validate
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 scripts/data/build_dashboard.py
           python3 << 'PY'
@@ -180,6 +223,7 @@ jobs:
           PY
 
       - name: Run build_dashboard sanity
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           # confirm it runs idempotently
           python3 scripts/data/build_dashboard.py


### PR DESCRIPTION
## What

Make the `validate` job skip its heavy Python work (pytest, dashboard rebuild, schema/ledger checks) on PRs that touch **only** docs/markdown. Any PR touching `scripts/**`, `tests/**`, data JSON, cron config, or workflows runs the **full** suite exactly as before.

## Why this shape (the footgun)

`validate` is a **required** status check. We can **not** add a `paths:` filter to the `pull_request` trigger: a required check that gets filtered out never reports and blocks the PR **forever** (same reason `actionlint.yml` is intentionally always-on). 

Instead the job always runs and its required context always reports; the expensive **steps** are gated with `if:` on an internal `git diff BASE..HEAD`. **Skipped steps count as success** for branch protection, so a docs-only PR reports `validate` green in seconds without ever hanging.

## Details

- New `Detect code changes` step (id `changes`, PR-only) sets output `code=true/false` from a pure `git diff --name-only BASE..HEAD` matched against the same path set as the `push:` trigger. No `--diff-filter`, so deletes/renames of scripts also trigger the suite. **No third-party action** — GitHub-native, per CI convention.
- Every heavy step gains `if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'`. Non-PR events (push to master, workflow_dispatch) force the full run.
- **Security gates stay unconditional:** `Reject conflict markers` and `PR file safety policy` always run on every PR.
- `smoke-data-fetch` (non-required, continue-on-error) left as-is.

This PR itself edits `.github/workflows/**` → `code=true` → the full validate suite runs here, exercising the unchanged path.

## Review
Claude-authored; per the clawock convention Codex reviews and squash-merges after the six required checks are green.