### PR TITLE
fix(cron): stop phantom cron-contract CRITICAL from slow gateway + stale fossil

### DIFF
--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -50,8 +50,12 @@ def _cron_cli_json(cli_args):
     This is the storage-agnostic path — 6.1 migrated cron from jobs.json/runs/*.jsonl
     into state/openclaw.sqlite, so direct file reads silently return nothing."""
     try:
+        # `cron list --json` round-trips through the gateway and has been observed
+        # at ~42s on a loaded host. A tight timeout here trips TimeoutExpired →
+        # None → silent fossil fallback in load_jobs(), which once masked a healthy
+        # fleet as "drifted" and blocked every push. Keep this well above real p99.
         r = subprocess.run([OPENCLAW_BIN, 'cron', *cli_args],
-                           capture_output=True, text=True, timeout=30)
+                           capture_output=True, text=True, timeout=120)
         txt = r.stdout
         i = txt.find('{')
         if i < 0:
@@ -61,17 +65,35 @@ def _cron_cli_json(cli_args):
         return None
 
 
+# Set by load_jobs() to record which source served the last call:
+#   'cli'    — live gateway (authoritative for payload/model/delivery)
+#   'fossil' — pre-6.1 jobs.json[.migrated] (STALE for payload — schedule only)
+#   'empty'  — nothing readable
+# Callers that assert on live payload state (e.g. the cron-contract check) MUST
+# consult this and refuse to report failures off a fossil.
+LAST_LOAD_SOURCE = None
+
+
 def load_jobs():
     # Primary: CLI (works on 6.1 SQLite). Fallback: pre-migration jobs.json[.migrated].
+    global LAST_LOAD_SOURCE
     d = _cron_cli_json(['list', '--json'])
     if isinstance(d, dict) and isinstance(d.get('jobs'), list):
+        LAST_LOAD_SOURCE = 'cli'
         return d['jobs']
+    # CLI unreadable (gateway slow/unreachable). The fallback files are 6.1-era
+    # fossils — fine for schedule shape, but STALE for model/delivery/message.
+    # Surface loudly so no caller mistakes fossil state for live state.
     for p in (JOBS_JSON, JOBS_JSON.with_suffix('.json.migrated')):
         try:
             data = json.loads(p.read_text())
+            LAST_LOAD_SOURCE = 'fossil'
+            print(f'warn: cron CLI unreadable; falling back to STALE {p.name} '
+                  '(pre-6.1 fossil — do not trust model/delivery/message)', file=sys.stderr)
             return data if isinstance(data, list) else data.get('jobs', data.get('items', []))
         except Exception:
             continue
+    LAST_LOAD_SOURCE = 'empty'
     return []
 
 

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -283,6 +283,7 @@ def check_cron_paths_exist(r):
     import re
     sys.path.insert(0, str(WS / 'scripts' / 'harness'))
     try:
+        import _watchdog_common as wc  # type: ignore
         from _watchdog_common import OPENCLAW_BIN, load_jobs  # type: ignore
         jobs = load_jobs()
     except Exception as e:
@@ -294,6 +295,16 @@ def check_cron_paths_exist(r):
             r.add('cron paths', OK, 'skipped (no openclaw CLI on this host)')
         else:
             r.add('cron paths', WARNING, 'openclaw CLI returned 0 cron jobs (storage regression? run doctor --fix)')
+        return
+    if getattr(wc, 'LAST_LOAD_SOURCE', None) == 'fossil':
+        # The live gateway was unreadable (slow/timeout) and load_jobs() served a
+        # pre-6.1 fossil that is STALE for model/delivery/message. Asserting the
+        # payload contract against it produces phantom CRITICALs that block every
+        # push (2026-07-18 incident). Report a WARNING and skip the assertion —
+        # a stale view must never fail the gate as if it were live.
+        r.add('cron runtime contract', WARNING,
+              'cron CLI unreadable (gateway slow?) — jobs came from a stale fallback; '
+              'skipping contract assertion, re-run when the gateway responds')
         return
 
     try:


### PR DESCRIPTION
## Outcome

The pre-push `system_check` was reporting a **phantom** `cron runtime contract` CRITICAL that blocked every local push (forcing `--no-verify`). Root cause:

1. `openclaw cron list --json` round-trips the gateway and has been seen at **~42s** on a loaded host.
2. `_cron_cli_json`'s **30s** timeout tripped → `None` → `load_jobs()` **silently fell back** to the pre-6.1 `cron/jobs.json.migrated` fossil (Jun-3 state: `model=None`, `delivery=announce`, old messages).
3. `system_check` asserted the payload contract against **6-week-old data** → 101-error CRITICAL.

The live fleet was fully migrated (`MiniMax-M3` + `delivery=none`) the whole time — verified via the raw CLI.

## Fix

- `_cron_cli_json`: timeout **30 → 120s** (well above observed p99) so the live CLI path succeeds.
- `load_jobs`: record `LAST_LOAD_SOURCE` (`cli`|`fossil`|`empty`) and warn loudly on fossil fallback.
- `system_check`: when jobs came from the fossil, report the cron-contract check as **WARNING** (CLI unreadable) instead of a phantom CRITICAL. A stale view must never fail the gate as if it were live.

## Verification

- With the fix, `load_jobs()` serves `source=cli`, all 11 jobs validate, **0 errors**.
- The pre-push `system_check` now passes cleanly (`cron runtime contract: 11 jobs · schedule+payload match`) — this branch pushed **without** `--no-verify`.

## Review

Per kcn's explicit call (Codex too slow this session), this skips the cross-agent Codex review; the required CI gate (validate/lint/Analyze/CodeQL) still runs and must pass. No live cron was mutated — this is an observability fix only.