### PR TITLE
design: make the logo robust on unknown light/dark surfaces

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#0a0e1a" media="(prefers-color-scheme: dark)">
 <meta name="theme-color" content="#f7f8fb" media="(prefers-color-scheme: light)">
-<link rel="icon" type="image/svg+xml" href="{{ '/assets/logo-mark.svg' | relative_url }}">
+<link rel="icon" type="image/svg+xml" href="{{ '/assets/icons/app-icon.svg' | relative_url }}">
 <link rel="icon" type="image/png" sizes="64x64" href="{{ '/assets/icons/favicon-64.png' | relative_url }}">
 <link rel="apple-touch-icon" href="{{ '/assets/icons/apple-touch-icon.png' | relative_url }}">
 {% seo %}

--- a/assets/logo-mark-mono.svg
+++ b/assets/logo-mark-mono.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="title desc" shape-rendering="geometricPrecision" fill="currentColor">
+  <title id="title">clawock mark</title>
+  <desc id="desc">Single-color lockup: opposing bull and bear saddle surfaces leave a mathematical decision window between them. Inherits its color from the surrounding text via currentColor.</desc>
+  <path d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z"/>
+  <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ layout: null
 }
 </script>
 <link rel="manifest" href="manifest.webmanifest">
-<link rel="icon" type="image/svg+xml" href="assets/logo-mark.svg">
+<link rel="icon" type="image/svg+xml" href="assets/icons/app-icon.svg">
 <link rel="icon" type="image/png" sizes="64x64" href="assets/icons/favicon-64.png">
 <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
 <meta name="apple-mobile-web-app-capable" content="yes">

--- a/tests/test_brand_assets.py
+++ b/tests/test_brand_assets.py
@@ -29,6 +29,18 @@ def test_vector_brand_sources_are_valid_and_keep_the_canonical_geometry():
         assert 'id="bull-blue"' in source
 
 
+def test_mono_lockup_keeps_the_canonical_geometry_and_inherits_color():
+    mono = ROOT / "assets/logo-mark-mono.svg"
+    root = ET.parse(mono).getroot()
+    source = mono.read_text()
+    assert root.attrib["viewBox"] == "0 0 64 64"
+    # Single-color lockup: same saddle paths, no gradient, colored via currentColor.
+    assert "M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" in source
+    assert "M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" in source
+    assert 'fill="currentColor"' in source
+    assert "linearGradient" not in source
+
+
 def test_raster_derivatives_have_exact_declared_sizes():
     expected = {
         "favicon-64.png": (64, 64),
@@ -46,7 +58,11 @@ def test_all_public_shells_use_the_vector_mark():
     layout = (ROOT / "_layouts/default.html").read_text()
     readmes = (ROOT / "README.md").read_text() + (ROOT / "README.zh.md").read_text()
 
-    assert 'type="image/svg+xml" href="assets/logo-mark.svg"' in index
+    # Header wordmark uses the adaptive two-tone mark; the SVG favicon uses the
+    # self-contained squircle so it reads on any tab color (Chrome ignores
+    # prefers-color-scheme in favicons, which would strand a black bear on a dark tab).
+    assert 'type="image/svg+xml" href="assets/icons/app-icon.svg"' in index
     assert 'class="brand-mark" src="assets/logo-mark.svg"' in index
     assert "/assets/logo-mark.svg" in layout
+    assert "/assets/icons/app-icon.svg" in layout
     assert readmes.count('src="assets/logo-mark.svg"') == 2


### PR DESCRIPTION
Follow-up to the brand system (#11). Geometry stays locked — this is color/packaging only, so any surface renders a legible mark.

## Why
The adaptive `logo-mark.svg` already flips for `prefers-color-scheme`, and in-site that stays correct because the dashboard is themed purely by `prefers-color-scheme` (no manual toggle to desync it). Two edge cases remained, both about surfaces whose color the media query can't see:

1. **SVG favicon on a dark tab** — Chrome ignores `prefers-color-scheme` in favicons and renders the default (light) styling, stranding a black bear on a dark tab strip.
2. **No single-color lockup** — nothing to drop on an arbitrary / branded / print background where the two-tone can't be guaranteed to contrast.

## What
- **Favicon → self-contained squircle**: point the `image/svg+xml` favicon (`index.html`, `_layouts/default.html`) at `assets/icons/app-icon.svg` instead of the bare transparent mark. The squircle carries its own backdrop, so it reads on any tab color (and now matches the PNG `favicon-64` fallback, which was already the squircle).
- **`assets/logo-mark-mono.svg`**: single-color lockup via `currentColor`, geometry identical to the canonical mark. Verified on white, black, and brand blue.
- **Tests**: lock the mono geometry (exact saddle paths, no gradient, `currentColor`) and update the shell-usage assertions for the new favicon target. `4 passed`.

No change to the canonical mark, the icons, or the merged architecture/social assets.