### PR TITLE
docs: inline logo (equal height) + motto caption between card and gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="assets/logo-mark.svg" alt="clawock logo" width="58">
-
-# clawock
+<h1><img src="assets/logo-mark.svg" alt="clawock logo" height="52">&nbsp;&nbsp;clawock</h1>
 
 ### An autonomous AI trading desk that grades its own calls — and publishes the losses.
 
@@ -22,7 +20,7 @@ Multi-agent LLMs debate a real Hong Kong + US stock portfolio. Python checks the
   <img src="assets/social-card.png" alt="clawock — an autonomous AI trading desk that grades its own calls" width="820">
 </a>
 
-<br>
+<sub><i>“Argue in public, settle in code.”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock dashboard cycling through its tabs" width="300"></a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="assets/logo-mark.svg" alt="clawock 标志" width="58">
-
-# clawock
+<h1><img src="assets/logo-mark.svg" alt="clawock 标志" height="52">&nbsp;&nbsp;clawock</h1>
 
 ### 一个会给自己打分、并把亏损一起公开的自主 AI 投研台。
 
@@ -22,7 +20,7 @@
   <img src="assets/social-card.png" alt="clawock — 会给自己打分的自主 AI 投研台" width="820">
 </a>
 
-<br>
+<sub><i>“公开争辩，代码结算。”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock 仪表盘循环切换各标签页" width="300"></a>
 


### PR DESCRIPTION
## What

README 头部两处视觉调整（双语同步）：

1. **Logo 内联横排 + 等高对齐** — bear mark 从纵向堆叠改为内联进 `<h1>`，`height="52"` 让可视图形与 `clawock` 字标等高、垂直居中（消掉 SVG 内部留白造成的浮空感）。GitHub markdown 兼容做法（strip `style`，不用 flexbox）。
2. **Motto 图例夹在 social-card 和 gif 之间** — 用一行小灰字 quote 把两张预览图隔开：
   - EN: *"Argue in public, settle in code."*
   - ZH: *"公开争辩，代码结算。"*

## Why honest

Quote 守 static-copy 无实时数字铁律（纯口号无数值），也不碰「代码强制」措辞——`settle`（逐条结算/打分）确实由 Python 执行，是站得住的诚实卖点。

## Constraints kept

- `test_brand_assets.py` 断言两个 README 各引用一次 `src="assets/logo-mark.svg"` → 内联保留原 src 字符串，4 passed。
- 未改 `social-card.png` / `dashboard.gif`（避免烤字重生成）。

## Diff

每个 README 各改 3 行 net，只动 `<div align="center">` 里 logo/标题与两图之间。

留给 kcn review / merge，未自 merge。