### PR TITLE
docs: compact README hero so the preview image sits higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A real Hong Kong + US stock portfolio, debated by multiple LLMs and graded by Py
   <img src="assets/social-card.png" alt="clawock — an autonomous AI trading desk that grades its own calls" width="820">
 </a>
 
-<sub><i>“Opinions are cheap; the tape keeps score.”</i></sub>
+<sub><i>“The market doesn't care how confident the model was.”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock dashboard cycling through its tabs" width="300"></a>
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <h1><img src="assets/logo-mark.svg" alt="clawock logo" height="52">&nbsp;&nbsp;clawock</h1>
 
-### An autonomous AI trading desk that grades its own calls — and publishes the losses.
+### AI argues. Code settles. The losses stay on the page.
 
-Multi-agent LLMs debate a real HK + US stock portfolio; Python settles each call against the tape and publishes the scorecard. **So far the active calls have yet to beat buy-and-hold — the dashboard shows it plainly.**
+A real Hong Kong + US stock portfolio, debated by multiple LLMs and graded by Python — every call scored in the open, and the active ones still behind buy-and-hold.
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A real Hong Kong + US stock portfolio, debated by multiple LLMs and graded by Py
   <img src="assets/social-card.png" alt="clawock — an autonomous AI trading desk that grades its own calls" width="820">
 </a>
 
-<sub><i>“Argue in public, settle in code.”</i></sub>
+<sub><i>“Opinions are cheap; the tape keeps score.”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock dashboard cycling through its tabs" width="300"></a>
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 ### An autonomous AI trading desk that grades its own calls — and publishes the losses.
 
-Multi-agent LLMs debate a real Hong Kong + US stock portfolio. Python checks the risk limits, settles each call against the tape, and publishes the scorecard — recommendations only, and no outcome is hand-picked.
-
-**The result so far: the active calls have yet to beat buy-and-hold. The dashboard shows it plainly.**
+Multi-agent LLMs debate a real HK + US stock portfolio; Python settles each call against the tape and publishes the scorecard. **So far the active calls have yet to beat buy-and-hold — the dashboard shows it plainly.**
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@
   <img src="assets/social-card.png" alt="clawock — 会给自己打分的自主 AI 投研台" width="820">
 </a>
 
-<sub><i>“公开争辩，代码结算。”</i></sub>
+<sub><i>“观点廉价，行情才算数。”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock 仪表盘循环切换各标签页" width="300"></a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,9 +2,9 @@
 
 <h1><img src="assets/logo-mark.svg" alt="clawock 标志" height="52">&nbsp;&nbsp;clawock</h1>
 
-### 一个会给自己打分、并把亏损一起公开的自主 AI 投研台。
+### AI 争辩。代码结算。连亏损都摆在明面上。
 
-多个 LLM Agent 辩论一个真实的港股 + 美股组合;Python 逐条对着行情结算并发布战绩。**目前主动判断尚未跑赢买入持有 —— 仪表盘把这点如实摆出来。**
+一个真实的港股 + 美股组合,由多个 LLM 辩论、交给 Python 打分 —— 每条判断都在明面上结算,而主动判断至今仍落后于买入持有。
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@
   <img src="assets/social-card.png" alt="clawock — 会给自己打分的自主 AI 投研台" width="820">
 </a>
 
-<sub><i>“观点廉价，行情才算数。”</i></sub>
+<sub><i>“市场不在乎模型有多自信。”</i></sub>
 
 <a href="https://kcnyu.github.io/clawock/"><img src="assets/dashboard.gif" alt="clawock 仪表盘循环切换各标签页" width="300"></a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,9 +4,7 @@
 
 ### 一个会给自己打分、并把亏损一起公开的自主 AI 投研台。
 
-多个 LLM Agent 辩论一个真实的港股 + 美股组合。Python 核查风控上限、逐条对着行情结算,并发布战绩 —— 只出建议、不下单,任何一条结果都不是人工挑选的。
-
-**目前的结果:主动判断尚未跑赢买入持有。仪表盘把这点如实摆出来。**
+多个 LLM Agent 辩论一个真实的港股 + 美股组合;Python 逐条对着行情结算并发布战绩。**目前主动判断尚未跑赢买入持有 —— 仪表盘把这点如实摆出来。**
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)


### PR DESCRIPTION
kcn feedback: the opening text was too tall and pushed the preview image below the fold.

**Change (hero only — nothing else touched):** fold the intro paragraph and the standalone bold result line into a single compact block in both README.md and README.zh.md, lifting the social-card image up ~2 rendered lines.

- Keeps the honest `active calls have yet to beat buy-and-hold` punch (still bold).
- Drops only the redundant `recommendations only / no outcome is hand-picked` phrasing from the hero — it remains in the Scope/disclaimer section.
- EN/ZH parity test still green (9/9); H2/details/asset skeleton unchanged.

Diff is 2 insertions / 6 deletions across the two files.