### PR TITLE
brand: wordmark lockup SVG so README header aligns like the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1><img src="assets/logo-mark.svg" alt="clawock logo" height="52">&nbsp;&nbsp;clawock</h1>
+<h1><img src="assets/logo-lockup.svg" alt="clawock" height="44"></h1>
 
 ### AI argues. Code settles. The losses stay on the page.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1><img src="assets/logo-mark.svg" alt="clawock 标志" height="52">&nbsp;&nbsp;clawock</h1>
+<h1><img src="assets/logo-lockup.svg" alt="clawock" height="44"></h1>
 
 ### AI 争辩。代码结算。连亏损都摆在明面上。
 

--- a/assets/logo-lockup.svg
+++ b/assets/logo-lockup.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="64" viewBox="0 0 200 64" role="img" aria-labelledby="title desc" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+  <title id="title">clawock</title>
+  <desc id="desc">clawock wordmark: opposing bull and bear saddle surfaces leave a mathematical decision window between them, beside the name.</desc>
+  <defs>
+    <linearGradient id="bull-blue" x1="14" y1="50" x2="51" y2="31" gradientUnits="userSpaceOnUse">
+      <stop class="b0" offset="0"/>
+      <stop class="b1" offset="1"/>
+    </linearGradient>
+  </defs>
+  <style>
+    .ink{fill:#10141a}.b0{stop-color:#245574}.b1{stop-color:#559ed1}
+    .word{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;font-weight:700;font-size:34px;letter-spacing:-1px}
+    @media (prefers-color-scheme:dark){
+      .ink{fill:#edf2f5}.b0{stop-color:#4b91c8}.b1{stop-color:#78c5f3}
+    }
+  </style>
+  <path class="ink" d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z"/>
+  <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" fill="url(#bull-blue)"/>
+  <text class="ink word" x="72" y="43">clawock</text>
+</svg>

--- a/tests/test_brand_assets.py
+++ b/tests/test_brand_assets.py
@@ -41,6 +41,21 @@ def test_mono_lockup_keeps_the_canonical_geometry_and_inherits_color():
     assert "linearGradient" not in source
 
 
+def test_wordmark_lockup_keeps_the_canonical_geometry_and_carries_the_name():
+    lockup = ROOT / "assets/logo-lockup.svg"
+    root = ET.parse(lockup).getroot()
+    source = lockup.read_text()
+    # Wide mark+wordmark lockup for the README header: same saddle geometry and
+    # adaptive two-tone treatment as the mark, with the "clawock" wordmark baked
+    # in so mark and name stay aligned wherever CSS can't run (GitHub, npm, IDEs).
+    assert root.attrib["viewBox"] == "0 0 200 64"
+    assert "M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" in source
+    assert "M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" in source
+    assert 'shape-rendering="geometricPrecision"' in source
+    assert 'id="bull-blue"' in source
+    assert ">clawock</text>" in source
+
+
 def test_raster_derivatives_have_exact_declared_sizes():
     expected = {
         "favicon-64.png": (64, 64),
@@ -65,4 +80,4 @@ def test_all_public_shells_use_the_vector_mark():
     assert 'class="brand-mark" src="assets/logo-mark.svg"' in index
     assert "/assets/logo-mark.svg" in layout
     assert "/assets/icons/app-icon.svg" in layout
-    assert readmes.count('src="assets/logo-mark.svg"') == 2
+    assert readmes.count('src="assets/logo-lockup.svg"') == 2


### PR DESCRIPTION
Follow-up to #16. kcn: the dashboard puts the mark and 'clawock' on one centerline but the README couldn't.

**Why the README couldn't:** the dashboard centers them with flexbox (`align-items:center`); GitHub's README sanitizer strips CSS, so an inline `<img>` in `<h1>` falls back to `vertical-align:baseline` and the tall mark floats above the text.

**Fix:** bake mark + 'clawock' into one adaptive lockup (`assets/logo-lockup.svg`) — locked saddle geometry, two-tone `prefers-color-scheme` — and use it in both README h1s, so alignment lives in the asset and renders identically on GitHub/npm/IDEs. Verified light + dark via headless render. Adds a geometry contract to `test_brand_assets.py`; parity + brand suites green (14/14).

kcn asked to land this directly, so enabling squash auto-merge.