### PR TITLE
brand: enlarge README wordmark lockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1><img src="assets/logo-lockup.svg" alt="clawock" height="44"></h1>
+<h1><img src="assets/logo-lockup.svg" alt="clawock" height="48"></h1>
 
 ### AI argues. Code settles. The losses stay on the page.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1><img src="assets/logo-lockup.svg" alt="clawock" height="44"></h1>
+<h1><img src="assets/logo-lockup.svg" alt="clawock" height="48"></h1>
 
 ### AI 争辩。代码结算。连亏损都摆在明面上。
 

--- a/assets/logo-lockup.svg
+++ b/assets/logo-lockup.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="64" viewBox="0 0 200 64" role="img" aria-labelledby="title desc" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="50" viewBox="4 7 208 50" role="img" aria-labelledby="title desc" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
   <title id="title">clawock</title>
   <desc id="desc">clawock wordmark: opposing bull and bear saddle surfaces leave a mathematical decision window between them, beside the name.</desc>
   <defs>
@@ -9,12 +9,12 @@
   </defs>
   <style>
     .ink{fill:#10141a}.b0{stop-color:#245574}.b1{stop-color:#559ed1}
-    .word{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;font-weight:700;font-size:34px;letter-spacing:-1px}
+    .word{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;font-weight:700;font-size:37px;letter-spacing:-1.2px}
     @media (prefers-color-scheme:dark){
       .ink{fill:#edf2f5}.b0{stop-color:#4b91c8}.b1{stop-color:#78c5f3}
     }
   </style>
   <path class="ink" d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z"/>
   <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" fill="url(#bull-blue)"/>
-  <text class="ink word" x="72" y="43">clawock</text>
+  <text class="ink word" x="70" y="45">clawock</text>
 </svg>

--- a/tests/test_brand_assets.py
+++ b/tests/test_brand_assets.py
@@ -48,7 +48,7 @@ def test_wordmark_lockup_keeps_the_canonical_geometry_and_carries_the_name():
     # Wide mark+wordmark lockup for the README header: same saddle geometry and
     # adaptive two-tone treatment as the mark, with the "clawock" wordmark baked
     # in so mark and name stay aligned wherever CSS can't run (GitHub, npm, IDEs).
-    assert root.attrib["viewBox"] == "0 0 200 64"
+    assert root.attrib["viewBox"] == "4 7 208 50"
     assert "M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" in source
     assert "M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" in source
     assert 'shape-rendering="geometricPrecision"' in source


### PR DESCRIPTION
kcn: the header logo + wordmark looked small. Cause: ~28% of the lockup's 200x64 viewBox was vertical padding, so `height=44` scaled the mark down to ~32px. Fix: tighten viewBox to hug the artwork (`4 7 208 50`), bump the wordmark to 37px, set the h1 to `height=48` — restores the old header's prominence, keeps the baked-in alignment. Verified light render vs the old 52px-mark header. Brand contract updated; parity + brand suites green (14/14). Squash auto-merge enabled.