### PR TITLE
feat(tavily): monthly credit budget guardrail + wire skill usage

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -13,6 +13,7 @@ on:
       - 'config/cron-schedules.json'
       - 'CRON_SCHEDULES.md'
       - '.github/workflows/**'
+      - 'skills/tavily-search/**'
   pull_request:
   workflow_dispatch:
 
@@ -35,6 +36,12 @@ jobs:
             echo "::error::Tracked files contain unresolved git conflict markers"
             exit 1
           fi
+
+      - name: Tavily credit-ledger unit tests
+        # Always runs (no path gate) so the hard-budget guardrail's assertions
+        # are enforced on every PR and master push — a skills-only change must
+        # not skip them. Pure Node, no deps; Node is preinstalled on the runner.
+        run: node skills/tavily-search/lib/ledger.test.mjs
 
       - name: PR file safety policy
         if: github.event_name == 'pull_request'

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -188,7 +188,7 @@ clawhub install <slug>
 | "用 Serenity 的方式看 X" / 产业链卡点深挖 / AI半导体瓶颈选股 / thesis 压力测试 | `serenity-skill` | 供应链 chokepoint 框架（8 因子评分卡 `skills/serenity-skill/scripts/serenity_scorecard.py`）；**重、手动深挖、不进 cron**；证据阶梯把 KOL/社媒判弱证据 → 对冲追微盘 pump |
 | 教育性问题（"什么是 MACD"、"position sizing 怎么算"） | `trading`（clawhub 装的） | guardrails 重、不给具体买卖判断；具体判断走上面 4 个 |
 | 抓需 JS 渲染 / 反爬的页面（雪球评论 / Futu 社区 / Reddit 深页） | `scrapling` | 配合上面的 stock-analysis Mode 5 调用 |
-| Web 搜索（新闻 / X / 中文社区 / 政策） | `tavily-search` | 不要让模型自己改用 Yahoo/Google 临时拼搜索 |
+| Web 搜索（新闻 / X / 中文社区 / 政策） | `tavily-search` | 不要让模型自己改用 Yahoo/Google 临时拼搜索。**免费档 1000 credits/月全局共享**，调用必带 `--bucket`（brief/report/intraday/research/extract）；盘中常规盯盘别烧、超限自动优雅降级回内置搜索 |
 | openclaw 升级后健康检查 / 磁盘膨胀 | `openclaw-tune` | 不动股票 |
 
 ⚠️ **不要做的 routing 错误**：
@@ -202,7 +202,7 @@ clawhub install <slug>
 
 ### 美股
 1. **Finnhub news** —— `scripts/data/analyze_us_stocks.py` 默认拉取，主英文媒体 + 关键词情绪打分
-2. **Tavily** —— 新闻 + X/Twitter trending（`node skills/tavily-search/scripts/search.mjs "{TICKER} sentiment" --topic news`）
+2. **Tavily** —— 新闻 + X/Twitter trending（`node skills/tavily-search/scripts/search.mjs "{TICKER} sentiment" --topic news --bucket report`）；⚠️ 仅开/收盘报告或盘中真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily
 3. **Reddit JSON**（无需 auth）—— r/wallstreetbets（散户动量）+ r/stocks（理性）：
    ```bash
    curl -sH "User-Agent: openclaw/1.0" "https://www.reddit.com/r/wallstreetbets/search.json?q={TICKER}&restrict_sr=1&sort=new&limit=25"

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -121,9 +121,10 @@ context.json 关键字段：
 每日 Tier 1 后必做一段板块横向扫描，目标回答："你持仓在板块里**领涨/落后/中位**？归因是什么？"
 
 - 板块来源是动态的：读 `memory/peer-map.json`，**每个 active ticker 的 `theme` 字段就是它的板块名**（如 "HK AI 大模型" / "HK 科技指数 2x leveraged (HSTECH 标的)" / "商业航天"）。持仓变了，板块自动跟变 — 不要在 SKILL.md / 报告里写死任何特定 ticker
-- 对每个去重后的 theme 跑一次 web search — **优先用你的内置 web search 工具**；`tavily-search` 仅在 `TAVILY_API_KEY` 已配置时才用（当前未配，脚本会返回 unavailable，别把它当报错）：
-  - HK 板块 → 搜 "今日 HK {theme} 涨幅榜 / 板块异动"
-  - US 板块 → 搜对应 sector ETF（如 SOXX/QQQ/ARK） + 今日成分涨跌
+- 对每个去重后的 theme 跑一次 web search — **本 skill（盘前深度简报）已放开 `tavily-search`，优先用它**（`TAVILY_API_KEY` 已配置）；tavily 无结果或超时再退回内置 web search。⚠️ 免费档 1000 credits/月是全局共享，本 skill 每天只 1 次、按去重后的 theme 数搜（通常 ≤10 次/天），别对同一 theme 重复搜。**调用必须带 `--bucket brief`**（走本 skill 的月度配额 300；不带 bucket 会落 default 桶只有 60，很快被硬护栏挡回）：
+  - HK 板块 → `node ../tavily-search/scripts/search.mjs "今日 HK {theme} 涨幅榜 板块异动" --topic news --days 2 --bucket brief`
+  - US 板块 → `node ../tavily-search/scripts/search.mjs "{sector ETF 如 SOXX/QQQ/ARK} 今日成分涨跌" --topic news --days 2 --bucket brief`
+  - 护栏是硬闸：额度用尽时脚本返回 "Web search unavailable" 并 exit 0，**别当报错**，退回内置搜索即可
 - 每个板块输出：Top 3-5 涨幅 + 你持仓票在榜单中的位置（领涨/落后/中位）
 - **归因句必带**：落后是因为(a) 利好时点（盘后才公布）/ (b) 早盘异常抛压 / (c) β 错配 / (d) 个股逻辑滞后？
 - 输出在 ▎板块全景 段（pre-open.md 必带），引用 ≥3 个具体涨跌幅 + 1 个明确归因

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -98,7 +98,7 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提到 `anomalies` 里至少一个票
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号）
-  - ⚡ **板块全景鼓励 tavily-search**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker）；search 拿板块今日 Top 涨幅 + 你持仓在榜单里的位置 + 1 句归因；持仓自己的数字仍从 context.json
+  - ⚡ **板块全景**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker）；给板块今日 Top 涨幅 + 你持仓在榜单里的位置 + 1 句归因；持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`——盘中每 30 分钟的常规盯盘**不要**烧 Tavily（免费档 1000/月全局共享）
   - 禁止"无异动，观望"这种敷衍 1 句话
 - 目标 ≤1200 字；>2000 字 postflight warn，>2500 字 fail
 
@@ -151,7 +151,7 @@ context.json 关键字段：
 {raw_wechat_block 原样}
 
 ▎情绪面
-{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景鼓励 tavily-search**：板块名读 peer-map.json `theme`（持仓动态），search 今日板块 Top 5 + 你持仓位置 + 1 句归因}
+{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景**：板块名读 peer-map.json `theme`（持仓动态），今日板块 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {结合 anomalies + signals → 超买/超卖/突破（2-3 行）}
@@ -194,10 +194,10 @@ snapshot/dashboard，提交 scoped 产物并经 `safe_push.sh` 推送。
 港股情绪面跟美股不同 — 主战场是中文社区（雪球/富途牛牛/同花顺论坛/微博），不在 Reddit/X。源使用顺序：
 
 1. **Finnhub news（脚本带）** — `scripts/data/analyze_hk_stocks.py {TICKER}` 默认拉 Finnhub 7 天新闻。港股覆盖比美股稀疏，但能拿到主要英文媒体（Reuters / Bloomberg / SCMP）
-2. **Tavily 中文搜索** — 主要的中文新闻聚合：
+2. **Tavily 中文搜索** — 主要的中文新闻聚合。⚠️ **Budget rule**(免费档 1000/月全局共享)：盘中每 30 分钟盯盘**默认不调**；仅**开盘/收盘报告**或盘中真事件(异常波动/停牌/财报预警/政策公告)才用，必带 `--bucket report`(开/收盘) 或 `--bucket intraday`(盘中事件)；额度尽时脚本 exit 0 返回 unavailable 别当报错：
    ```bash
-   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} 港股 最新" --topic news --days 3
-   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{中文公司名} 雪球 讨论"
+   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} 港股 最新" --topic news --days 3 --bucket report
+   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{中文公司名} 雪球 讨论" --bucket report
    ```
 3. **雪球 HK 评论区（scrapling）** — 港股零售情绪核心，5 位代码格式 `HK{TICKER}`：
    ```python

--- a/skills/tavily-search/SKILL.md
+++ b/skills/tavily-search/SKILL.md
@@ -33,8 +33,10 @@ basic 搜索 1 credit，`--deep` 2，extract 1/5 URL。硬护栏在 `lib/ledger.
 ## Extract content from URL
 
 ```bash
-node {baseDir}/scripts/extract.mjs "https://example.com/article"
+node {baseDir}/scripts/extract.mjs "https://example.com/article" --bucket extract
 ```
+
+`--bucket` works the same as for search (charges that monthly bucket; omit → `default`). extract costs 1 credit per 5 URLs.
 
 Notes:
 - Needs `TAVILY_API_KEY` from https://tavily.com

--- a/skills/tavily-search/SKILL.md
+++ b/skills/tavily-search/SKILL.md
@@ -12,10 +12,10 @@ AI-optimized web search using Tavily API. Designed for AI agents - returns clean
 ## Search
 
 ```bash
-node {baseDir}/scripts/search.mjs "query"
-node {baseDir}/scripts/search.mjs "query" -n 10
-node {baseDir}/scripts/search.mjs "query" --deep
-node {baseDir}/scripts/search.mjs "query" --topic news
+node {baseDir}/scripts/search.mjs "query" --bucket research
+node {baseDir}/scripts/search.mjs "query" -n 10 --bucket research
+node {baseDir}/scripts/search.mjs "query" --deep --bucket research
+node {baseDir}/scripts/search.mjs "query" --topic news --bucket research
 ```
 
 ## Options
@@ -24,6 +24,11 @@ node {baseDir}/scripts/search.mjs "query" --topic news
 - `--deep`: Use advanced search for deeper research (slower, more comprehensive)
 - `--topic <topic>`: Search topic - `general` (default) or `news`
 - `--days <n>`: For news topic, limit to last n days
+- `--bucket <name>`: **Which monthly budget bucket to charge** — `brief` / `report` / `intraday` / `research` / `extract` / `default`. Ad-hoc/manual research uses `--bucket research`. **Omitting it charges the small `default` bucket (60/mo)**, which is exhausted quickly on purpose.
+
+## Budget (免费档 1000 credits/月, 全局共享)
+
+basic 搜索 1 credit，`--deep` 2，extract 1/5 URL。硬护栏在 `lib/ledger.mjs`（本地月度账本，reservation 式扣费，超限 **exit 0** 优雅降级返回 "unavailable" — **别当报错**，退回内置搜索）。账本在仓库外 `/root/.openclaw/tavily-credit-ledger.json`；查真实账单：`curl -H "Authorization: Bearer $TAVILY_API_KEY" https://api.tavily.com/usage`（注意有延迟，不能当实时闸）。
 
 ## Extract content from URL
 

--- a/skills/tavily-search/lib/ledger.mjs
+++ b/skills/tavily-search/lib/ledger.mjs
@@ -36,6 +36,7 @@ import {
   closeSync,
   fsyncSync,
   renameSync,
+  copyFileSync,
   existsSync,
   unlinkSync,
   statSync,
@@ -76,6 +77,34 @@ function resolveBucket(name) {
 
 const isFiniteNum = (v) => typeof v === "number" && Number.isFinite(v);
 
+// Is the current lockfile a crash leftover? True if its owner PID is dead
+// (precise on this host) or — when the token can't be read — if it's far older
+// than any critical section. A live owner is never reported dead.
+function lockLooksDead() {
+  let token = "";
+  try {
+    token = readFileSync(LOCK_PATH, "utf8");
+  } catch {
+    return false; // vanished — not ours to reclaim; just retry
+  }
+  const pid = Number.parseInt(token.split(":")[0], 10);
+  if (Number.isInteger(pid) && pid > 0) {
+    try {
+      process.kill(pid, 0); // no signal sent; throws if the process is gone
+      return false; // owner alive
+    } catch (err) {
+      if (err.code === "ESRCH") return true; // owner is gone
+      if (err.code === "EPERM") return false; // exists but not ours to signal
+    }
+  }
+  // Unparseable token → fall back to age.
+  try {
+    return Date.now() - statSync(LOCK_PATH).mtimeMs > LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
 // Cross-process mutex. Token-owned so we only ever release our OWN lock; a
 // crashed-owner (stale) lock is reclaimed race-free via atomic rename-steal
 // (only one process can rename the path away). If the lock can't be taken we
@@ -93,23 +122,25 @@ function withLock(fn) {
         // EACCES / EMFILE / etc. are real problems — do not run unlocked.
         throw new LedgerUnavailable(`lock error: ${err.code || err.message}`);
       }
-      // Lock held. Reclaim it ONLY if it's a crash leftover, and do so
-      // atomically: renaming the path away has exactly one winner; the loser
-      // gets ENOENT and simply retries.
-      let stale = false;
-      try {
-        stale = Date.now() - statSync(LOCK_PATH).mtimeMs > LOCK_STALE_MS;
-      } catch {
-        /* vanished — just retry */
-      }
-      if (stale) {
+      // Lock held. Reclaim it only if it's a genuine crash leftover: the owner
+      // PID is dead (precise on this single host) or, failing that, the lock is
+      // far older than any critical section could last. Liveness makes a false
+      // steal of a LIVE owner essentially impossible.
+      //
+      // Residual (documented, accepted): if the owner is truly dead, two
+      // reclaimers can in principle both steal in the same instant and both
+      // enter. That needs a SIGKILL'd holder plus two processes racing reclaim
+      // within the same millisecond — not reachable by this staggered-cron,
+      // low-concurrency, $0 tool. Even then atomicWrite bounds the damage to at
+      // most one lost charge, absorbed by the reserve cushion.
+      if (lockLooksDead()) {
         const aside = `${LOCK_PATH}.stale.${token}`;
         try {
           renameSync(LOCK_PATH, aside);
           unlinkSync(aside);
-          continue; // we won the steal — retry the exclusive create
+          continue; // reclaimed — retry the exclusive create
         } catch {
-          /* someone else stole it first — fall through to wait/retry */
+          /* someone else reclaimed first — fall through to wait/retry */
         }
       }
       if (Date.now() > deadline) {
@@ -149,10 +180,16 @@ function atomicWrite(obj) {
 }
 
 function freshLedger(prev) {
+  // Inherit prior config ONLY if it's valid and in range; otherwise fall back
+  // to DEFAULTS, so a malformed prior month can't seed an invalid new month.
+  const limit =
+    isFiniteNum(prev?.monthly_limit) && prev.monthly_limit > 0 ? prev.monthly_limit : DEFAULTS.monthly_limit;
+  const reserve =
+    isFiniteNum(prev?.reserve) && prev.reserve >= 0 && prev.reserve < limit ? prev.reserve : DEFAULTS.reserve;
   return {
     month: currentMonth(),
-    monthly_limit: isFiniteNum(prev?.monthly_limit) ? prev.monthly_limit : DEFAULTS.monthly_limit,
-    reserve: isFiniteNum(prev?.reserve) ? prev.reserve : DEFAULTS.reserve,
+    monthly_limit: limit,
+    reserve,
     total_used: 0,
     buckets: JSON.parse(JSON.stringify(DEFAULTS.buckets)),
   };
@@ -177,7 +214,9 @@ function isSaneLedger(led) {
   if (!isFiniteNum(led.total_used) || led.total_used < 0) return false;
   if (!isFiniteNum(led.monthly_limit) || led.monthly_limit <= 0) return false;
   if (!isFiniteNum(led.reserve) || led.reserve < 0 || led.reserve >= led.monthly_limit) return false;
-  if (!led.buckets || typeof led.buckets !== "object") return false;
+  // typeof [] === "object", so reject arrays explicitly: bucket lookups by name
+  // would otherwise attach as un-serialized array props and reset to 0 forever.
+  if (!led.buckets || typeof led.buckets !== "object" || Array.isArray(led.buckets)) return false;
   for (const name of Object.keys(DEFAULTS.buckets)) {
     const b = led.buckets[name];
     if (b !== undefined) {
@@ -206,9 +245,12 @@ function loadLocked() {
     console.error("[tavily] ledger unreadable — poisoned (fail-closed) until month rollover or manual reset");
     return poisonLedger();
   }
-  // A cleanly-parsed prior month is safe to roll over to zero.
-  if (led && typeof led === "object" && led.month !== month && isFiniteNum(led.total_used)) {
-    const rolled = freshLedger(led);
+  // A cleanly-parsed prior month rolls over to zero. Inherit its config ONLY if
+  // the whole prior ledger is sane; otherwise start the new month from DEFAULTS,
+  // so a malformed old month (reserve:-1, absurd monthly_limit, …) can't carry
+  // an invalid/loosened config forward.
+  if (led && typeof led === "object" && !Array.isArray(led) && led.month !== month && isFiniteNum(led.total_used)) {
+    const rolled = freshLedger(isSaneLedger(led) ? led : null);
     atomicWrite(rolled);
     return rolled;
   }
@@ -225,9 +267,14 @@ function loadLocked() {
   return poisonLedger();
 }
 
+// Save a copy of the bad ledger for debugging WITHOUT moving the original —
+// callers immediately overwrite LEDGER_PATH with a poisoned ledger via
+// atomicWrite. This keeps the main path present at every crash point (it is
+// always either the bad ledger or the poisoned one, never missing — which
+// would let the next call recreate a zeroed ledger and re-open the cap).
 function quarantine() {
   try {
-    renameSync(LEDGER_PATH, `${LEDGER_PATH}.corrupt.${Date.now()}`);
+    copyFileSync(LEDGER_PATH, `${LEDGER_PATH}.corrupt.${Date.now()}`);
   } catch {
     /* ignore */
   }

--- a/skills/tavily-search/lib/ledger.mjs
+++ b/skills/tavily-search/lib/ledger.mjs
@@ -9,17 +9,41 @@
 // every code path. Pricing (verified against Tavily docs): basic search = 1
 // credit, advanced (--deep) = 2, extract = 1 credit per 5 URLs.
 //
-// Buckets enforce codex's allocation so one use can't starve another. Calls
-// without --bucket land in "default" (deliberately small) so any unplanned
-// usage is naturally throttled instead of silently eating the month.
+// Design for robustness (a "hard cap" must hold under crashes and concurrency):
+//   - Charge is done by RESERVE, before the API call, atomically under a lock
+//     (check + write in one critical section) → concurrent callers cannot blow
+//     past the cap on a stale snapshot. A definite API failure REFUNDS.
+//   - Locking never fails OPEN. If the lock can't be taken (and isn't a stale
+//     leftover we can reclaim), reserve() DENIES → caller degrades gracefully
+//     to built-in search. Conservative over-count is preferred to overspend.
+//   - Writes are atomic (temp file + fsync + rename). A corrupt same-month
+//     ledger is quarantined and treated as fail-closed — never silently reset
+//     to 0 (which would forget the month's spend and re-open the floodgates).
+//
+// Buckets enforce the allocation so one use can't starve another. Calls without
+// --bucket land in "default" (deliberately small) so unplanned usage is
+// throttled instead of silently eating the month.
 
-import { readFileSync, writeFileSync, openSync, closeSync, existsSync, unlinkSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  openSync,
+  closeSync,
+  fsyncSync,
+  renameSync,
+  existsSync,
+  unlinkSync,
+  statSync,
+} from "node:fs";
 
 const LEDGER_PATH = process.env.TAVILY_LEDGER_PATH ?? "/root/.openclaw/tavily-credit-ledger.json";
 const LOCK_PATH = LEDGER_PATH + ".lock";
+const LOCK_STALE_MS = 15000; // a lockfile older than this is a crash leftover
+const LOCK_WAIT_MS = 2000; // give up (fail-closed) after this long contending
 
-// Global hard cap = monthlyLimit - reserve. Reserve absorbs the tiny
-// precheck→commit race and any /usage-vs-ledger drift.
+// Global hard cap = monthly_limit - reserve. Reserve is now only a small extra
+// cushion (for the rare crash-after-reserve, which over-counts safely), not the
+// thing that saves us from a concurrency blowout — reservation does that.
 const DEFAULTS = {
   monthly_limit: 1000,
   reserve: 50,
@@ -32,6 +56,9 @@ const DEFAULTS = {
     default: { cap: 60, used: 0 }, // anything unbucketed — kept small on purpose
   },
 };
+const BUCKET_NAMES = Object.keys(DEFAULTS.buckets);
+
+class LedgerUnavailable extends Error {}
 
 function currentMonth() {
   // Asia/Shanghai to line up with the HKT trading calendar the crons use.
@@ -39,105 +66,183 @@ function currentMonth() {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function resolveBucket(name) {
+  // Own-property check only — avoids prototype keys (__proto__, constructor)
+  // resolving to inherited objects and slipping past the caps.
+  return Object.hasOwn(DEFAULTS.buckets, name) ? name : "default";
+}
+
+// Cross-process mutex. Reclaims a stale (crashed-owner) lock by age; otherwise
+// throws LedgerUnavailable so callers fail CLOSED rather than run unlocked.
 function withLock(fn) {
-  // Cross-process mutex via O_EXCL lockfile. Crons are staggered so contention
-  // is rare; retry briefly, then proceed unlocked rather than block a report.
+  const deadline = Date.now() + LOCK_WAIT_MS;
   let fd = null;
-  for (let i = 0; i < 50; i++) {
+  while (fd === null) {
     try {
       fd = openSync(LOCK_PATH, "wx");
-      break;
-    } catch {
-      const until = Date.now() + 20;
+    } catch (err) {
+      if (err.code !== "EEXIST") {
+        // EACCES / EMFILE / etc. are real problems — do not run unlocked.
+        throw new LedgerUnavailable(`lock error: ${err.code || err.message}`);
+      }
+      // Lock held. Reclaim it if it's a crash leftover.
+      try {
+        const age = Date.now() - statSync(LOCK_PATH).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(LOCK_PATH);
+          continue; // retake immediately
+        }
+      } catch {
+        // Lock vanished between open and stat — just retry.
+      }
+      if (Date.now() > deadline) {
+        throw new LedgerUnavailable("ledger busy (lock contention timed out)");
+      }
+      const until = Date.now() + 25; // bounded short wait, not a hot spin
       while (Date.now() < until) {
-        /* tiny spin */
+        /* wait */
       }
     }
   }
   try {
     return fn();
   } finally {
-    if (fd !== null) {
-      closeSync(fd);
-      try {
-        unlinkSync(LOCK_PATH);
-      } catch {
-        /* ignore */
-      }
+    closeSync(fd);
+    try {
+      unlinkSync(LOCK_PATH);
+    } catch {
+      /* ignore */
     }
   }
 }
 
-function load() {
+function atomicWrite(obj) {
+  const tmp = `${LEDGER_PATH}.tmp.${process.pid}`;
+  const fd = openSync(tmp, "w");
+  try {
+    writeFileSync(fd, JSON.stringify(obj, null, 2));
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, LEDGER_PATH); // atomic on the same filesystem
+}
+
+function freshLedger(prev) {
+  return {
+    month: currentMonth(),
+    monthly_limit: prev?.monthly_limit ?? DEFAULTS.monthly_limit,
+    reserve: prev?.reserve ?? DEFAULTS.reserve,
+    total_used: 0,
+    buckets: JSON.parse(JSON.stringify(DEFAULTS.buckets)),
+  };
+}
+
+// Must be called inside withLock. Returns a validated ledger for the current
+// month, creating a fresh one only when there is genuinely nothing to lose
+// (no file, or a cleanly-parsed prior month). A corrupt EXISTING file is
+// quarantined and throws — we never zero-out a month we can't read.
+function loadLocked() {
+  const month = currentMonth();
+  if (!existsSync(LEDGER_PATH)) {
+    const led = freshLedger(null);
+    atomicWrite(led);
+    return led;
+  }
   let led;
-  if (existsSync(LEDGER_PATH)) {
+  try {
+    led = JSON.parse(readFileSync(LEDGER_PATH, "utf8"));
+  } catch {
+    // Corrupt file. Do NOT reset to 0 — quarantine and fail closed.
     try {
-      led = JSON.parse(readFileSync(LEDGER_PATH, "utf8"));
+      renameSync(LEDGER_PATH, `${LEDGER_PATH}.corrupt.${Date.now()}`);
     } catch {
-      led = null;
+      /* ignore */
+    }
+    throw new LedgerUnavailable("ledger unreadable (quarantined corrupt file)");
+  }
+  if (!led || typeof led !== "object" || typeof led.total_used !== "number" || led.total_used < 0) {
+    throw new LedgerUnavailable("ledger schema invalid");
+  }
+  if (led.month !== month) {
+    const rolled = freshLedger(led);
+    atomicWrite(rolled);
+    return rolled;
+  }
+  // Normalize buckets: backfill any missing, drop obviously bad shapes.
+  if (!led.buckets || typeof led.buckets !== "object") led.buckets = {};
+  for (const [k, v] of Object.entries(DEFAULTS.buckets)) {
+    const b = led.buckets[k];
+    if (!b || typeof b.used !== "number" || b.used < 0 || typeof b.cap !== "number") {
+      led.buckets[k] = { ...v };
     }
   }
-  const month = currentMonth();
-  if (!led || led.month !== month) {
-    // New month → reset. (Approximates Tavily's cycle by calendar month; the
-    // /usage reconciliation can correct if the real reset date differs.)
-    led = {
-      month,
-      monthly_limit: led?.monthly_limit ?? DEFAULTS.monthly_limit,
-      reserve: led?.reserve ?? DEFAULTS.reserve,
-      total_used: 0,
-      buckets: JSON.parse(JSON.stringify(DEFAULTS.buckets)),
-    };
-    writeFileSync(LEDGER_PATH, JSON.stringify(led, null, 2));
-  }
-  // Backfill any bucket added to DEFAULTS after the ledger was created.
-  for (const [k, v] of Object.entries(DEFAULTS.buckets)) {
-    if (!led.buckets[k]) led.buckets[k] = { ...v };
-  }
+  if (typeof led.monthly_limit !== "number") led.monthly_limit = DEFAULTS.monthly_limit;
+  if (typeof led.reserve !== "number") led.reserve = DEFAULTS.reserve;
   return led;
 }
 
-// Returns { allowed, reason, remaining } WITHOUT charging.
-export function precheck(bucketName, cost) {
-  return withLock(() => {
-    const led = load();
-    const bucket = led.buckets[bucketName] ?? led.buckets.default;
-    const globalCap = led.monthly_limit - led.reserve;
-    const remaining = globalCap - led.total_used;
-    if (led.total_used + cost > globalCap) {
+// Atomically check the budget AND charge it. Returns:
+//   { allowed:true,  remaining, total_used, bucket, bucket_used, bucket_cap }
+//   { allowed:false, reason, remaining? }
+// On lock/ledger trouble it DENIES (fail-closed) rather than run unlocked.
+export function reserve(bucketName, cost) {
+  const key = resolveBucket(bucketName);
+  try {
+    return withLock(() => {
+      const led = loadLocked();
+      const bucket = led.buckets[key];
+      const globalCap = led.monthly_limit - led.reserve;
+      const remaining = globalCap - led.total_used;
+      if (led.total_used + cost > globalCap) {
+        return {
+          allowed: false,
+          reason: `monthly Tavily budget reached (${led.total_used}/${globalCap} used, reserve ${led.reserve})`,
+          remaining,
+        };
+      }
+      if (bucket.used + cost > bucket.cap) {
+        return {
+          allowed: false,
+          reason: `Tavily "${key}" bucket exhausted (${bucket.used}/${bucket.cap})`,
+          remaining,
+        };
+      }
+      led.total_used += cost;
+      bucket.used += cost;
+      atomicWrite(led);
       return {
-        allowed: false,
-        reason: `monthly Tavily budget reached (${led.total_used}/${globalCap} used, reserve ${led.reserve})`,
-        remaining,
+        allowed: true,
+        bucket: key,
+        total_used: led.total_used,
+        bucket_used: bucket.used,
+        bucket_cap: bucket.cap,
+        remaining: globalCap - led.total_used,
       };
+    });
+  } catch (err) {
+    if (err instanceof LedgerUnavailable) {
+      return { allowed: false, reason: `budget ledger unavailable (${err.message})` };
     }
-    if (bucket.used + cost > bucket.cap) {
-      return {
-        allowed: false,
-        reason: `Tavily "${bucketName}" bucket exhausted (${bucket.used}/${bucket.cap})`,
-        remaining,
-      };
-    }
-    return { allowed: true, reason: "", remaining };
-  });
+    throw err;
+  }
 }
 
-// Charge AFTER a successful API response (failed/429 requests don't cost
-// credits on Tavily's side, so we never charge for them).
-export function commit(bucketName, cost) {
-  return withLock(() => {
-    const led = load();
-    const bucket = led.buckets[bucketName] ?? led.buckets.default;
-    const key = led.buckets[bucketName] ? bucketName : "default";
-    led.total_used += cost;
-    led.buckets[key].used += cost;
-    writeFileSync(LEDGER_PATH, JSON.stringify(led, null, 2));
-    const globalCap = led.monthly_limit - led.reserve;
-    return {
-      total_used: led.total_used,
-      bucket_used: led.buckets[key].used,
-      bucket_cap: led.buckets[key].cap,
-      remaining: globalCap - led.total_used,
-    };
-  });
+// Give a reservation back after a DEFINITE remote failure (non-2xx / network
+// error) — Tavily does not charge for those. Best-effort: if the ledger is
+// momentarily locked we drop the refund (conservative over-count), never crash.
+export function refund(bucketName, cost) {
+  const key = resolveBucket(bucketName);
+  try {
+    withLock(() => {
+      const led = loadLocked();
+      led.total_used = Math.max(0, led.total_used - cost);
+      const bucket = led.buckets[key];
+      if (bucket) bucket.used = Math.max(0, bucket.used - cost);
+      atomicWrite(led);
+    });
+  } catch {
+    // Refund lost → we over-counted by `cost`. Safe direction; log and move on.
+    console.error(`[tavily] refund of ${cost} to "${key}" skipped (ledger busy)`);
+  }
 }

--- a/skills/tavily-search/lib/ledger.mjs
+++ b/skills/tavily-search/lib/ledger.mjs
@@ -9,16 +9,21 @@
 // every code path. Pricing (verified against Tavily docs): basic search = 1
 // credit, advanced (--deep) = 2, extract = 1 credit per 5 URLs.
 //
-// Design for robustness (a "hard cap" must hold under crashes and concurrency):
-//   - Charge is done by RESERVE, before the API call, atomically under a lock
-//     (check + write in one critical section) → concurrent callers cannot blow
-//     past the cap on a stale snapshot. A definite API failure REFUNDS.
-//   - Locking never fails OPEN. If the lock can't be taken (and isn't a stale
-//     leftover we can reclaim), reserve() DENIES → caller degrades gracefully
-//     to built-in search. Conservative over-count is preferred to overspend.
-//   - Writes are atomic (temp file + fsync + rename). A corrupt same-month
-//     ledger is quarantined and treated as fail-closed — never silently reset
-//     to 0 (which would forget the month's spend and re-open the floodgates).
+// A "hard cap" must hold under crashes AND concurrency, not just the happy
+// path. Design:
+//   - reserve() checks AND charges atomically under a lock before the API call,
+//     so concurrent callers can't blow past the cap on a stale snapshot. Only a
+//     DEFINITE non-billed outcome (an HTTP error response) refunds; ambiguous
+//     network failures keep the reservation (conservative over-count), because
+//     the reset could have arrived after Tavily already billed.
+//   - The lock never fails OPEN: it is token-owned, a crashed-owner lock is
+//     reclaimed race-free via atomic rename-steal, and if the lock genuinely
+//     can't be taken reserve() DENIES → caller degrades to built-in search.
+//   - Writes are atomic (temp + fsync + rename). A ledger that is unreadable or
+//     semantically invalid for the current month is quarantined and replaced
+//     with a POISONED (fully-exhausted) ledger, so it keeps failing closed for
+//     the rest of the month instead of silently resetting the cap to 0. Recover
+//     by deleting the ledger file (or waiting for the month to roll over).
 //
 // Buckets enforce the allocation so one use can't starve another. Calls without
 // --bucket land in "default" (deliberately small) so unplanned usage is
@@ -35,18 +40,16 @@ import {
   unlinkSync,
   statSync,
 } from "node:fs";
+import { randomBytes } from "node:crypto";
 
 const LEDGER_PATH = process.env.TAVILY_LEDGER_PATH ?? "/root/.openclaw/tavily-credit-ledger.json";
 const LOCK_PATH = LEDGER_PATH + ".lock";
 const LOCK_STALE_MS = 15000; // a lockfile older than this is a crash leftover
 const LOCK_WAIT_MS = 2000; // give up (fail-closed) after this long contending
 
-// Global hard cap = monthly_limit - reserve. Reserve is now only a small extra
-// cushion (for the rare crash-after-reserve, which over-counts safely), not the
-// thing that saves us from a concurrency blowout — reservation does that.
 const DEFAULTS = {
   monthly_limit: 1000,
-  reserve: 50,
+  reserve: 50, // small cushion for the rare crash-after-reserve over-count
   buckets: {
     brief: { cap: 300, used: 0 }, // daily-deep-brief — the one guaranteed use
     report: { cap: 280, used: 0 }, // HK/US open+close core reports
@@ -56,7 +59,6 @@ const DEFAULTS = {
     default: { cap: 60, used: 0 }, // anything unbucketed — kept small on purpose
   },
 };
-const BUCKET_NAMES = Object.keys(DEFAULTS.buckets);
 
 class LedgerUnavailable extends Error {}
 
@@ -72,28 +74,43 @@ function resolveBucket(name) {
   return Object.hasOwn(DEFAULTS.buckets, name) ? name : "default";
 }
 
-// Cross-process mutex. Reclaims a stale (crashed-owner) lock by age; otherwise
-// throws LedgerUnavailable so callers fail CLOSED rather than run unlocked.
+const isFiniteNum = (v) => typeof v === "number" && Number.isFinite(v);
+
+// Cross-process mutex. Token-owned so we only ever release our OWN lock; a
+// crashed-owner (stale) lock is reclaimed race-free via atomic rename-steal
+// (only one process can rename the path away). If the lock can't be taken we
+// throw LedgerUnavailable so callers fail CLOSED rather than run unlocked.
 function withLock(fn) {
+  const token = `${process.pid}:${randomBytes(8).toString("hex")}`;
   const deadline = Date.now() + LOCK_WAIT_MS;
   let fd = null;
   while (fd === null) {
     try {
       fd = openSync(LOCK_PATH, "wx");
+      writeFileSync(fd, token);
     } catch (err) {
       if (err.code !== "EEXIST") {
         // EACCES / EMFILE / etc. are real problems — do not run unlocked.
         throw new LedgerUnavailable(`lock error: ${err.code || err.message}`);
       }
-      // Lock held. Reclaim it if it's a crash leftover.
+      // Lock held. Reclaim it ONLY if it's a crash leftover, and do so
+      // atomically: renaming the path away has exactly one winner; the loser
+      // gets ENOENT and simply retries.
+      let stale = false;
       try {
-        const age = Date.now() - statSync(LOCK_PATH).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(LOCK_PATH);
-          continue; // retake immediately
-        }
+        stale = Date.now() - statSync(LOCK_PATH).mtimeMs > LOCK_STALE_MS;
       } catch {
-        // Lock vanished between open and stat — just retry.
+        /* vanished — just retry */
+      }
+      if (stale) {
+        const aside = `${LOCK_PATH}.stale.${token}`;
+        try {
+          renameSync(LOCK_PATH, aside);
+          unlinkSync(aside);
+          continue; // we won the steal — retry the exclusive create
+        } catch {
+          /* someone else stole it first — fall through to wait/retry */
+        }
       }
       if (Date.now() > deadline) {
         throw new LedgerUnavailable("ledger busy (lock contention timed out)");
@@ -109,9 +126,12 @@ function withLock(fn) {
   } finally {
     closeSync(fd);
     try {
-      unlinkSync(LOCK_PATH);
+      // Only remove the lock if it is still OURS (a stale-steal may have handed
+      // it to someone else while our fn ran — though fn is far shorter than the
+      // stale threshold, so this is defence in depth).
+      if (readFileSync(LOCK_PATH, "utf8") === token) unlinkSync(LOCK_PATH);
     } catch {
-      /* ignore */
+      /* not ours / already gone */
     }
   }
 }
@@ -131,17 +151,46 @@ function atomicWrite(obj) {
 function freshLedger(prev) {
   return {
     month: currentMonth(),
-    monthly_limit: prev?.monthly_limit ?? DEFAULTS.monthly_limit,
-    reserve: prev?.reserve ?? DEFAULTS.reserve,
+    monthly_limit: isFiniteNum(prev?.monthly_limit) ? prev.monthly_limit : DEFAULTS.monthly_limit,
+    reserve: isFiniteNum(prev?.reserve) ? prev.reserve : DEFAULTS.reserve,
     total_used: 0,
     buckets: JSON.parse(JSON.stringify(DEFAULTS.buckets)),
   };
 }
 
+// A poisoned ledger is a valid, fully-exhausted ledger for the current month.
+// We write it (atomically) when the on-disk ledger is unreadable/invalid so the
+// guardrail keeps failing CLOSED consistently — not just on the first call —
+// without ever inventing a spend figure we can't trust.
+function poisonLedger() {
+  const led = freshLedger(null);
+  led.poisoned = true;
+  led.total_used = led.monthly_limit; // remaining <= 0 → every reserve denied
+  for (const b of Object.values(led.buckets)) b.used = b.cap;
+  atomicWrite(led);
+  return led;
+}
+
+// Full semantic validation of a same-month ledger. Anything off → not trusted.
+function isSaneLedger(led) {
+  if (!led || typeof led !== "object") return false;
+  if (!isFiniteNum(led.total_used) || led.total_used < 0) return false;
+  if (!isFiniteNum(led.monthly_limit) || led.monthly_limit <= 0) return false;
+  if (!isFiniteNum(led.reserve) || led.reserve < 0 || led.reserve >= led.monthly_limit) return false;
+  if (!led.buckets || typeof led.buckets !== "object") return false;
+  for (const name of Object.keys(DEFAULTS.buckets)) {
+    const b = led.buckets[name];
+    if (b !== undefined) {
+      if (!isFiniteNum(b.used) || b.used < 0 || !isFiniteNum(b.cap) || b.cap < 0) return false;
+    }
+  }
+  return true;
+}
+
 // Must be called inside withLock. Returns a validated ledger for the current
-// month, creating a fresh one only when there is genuinely nothing to lose
-// (no file, or a cleanly-parsed prior month). A corrupt EXISTING file is
-// quarantined and throws — we never zero-out a month we can't read.
+// month. Creates a fresh one only when there is nothing to lose (no file, or a
+// cleanly-parsed prior month). An EXISTING current-month file that is corrupt
+// or semantically invalid is quarantined and replaced with a POISONED ledger.
 function loadLocked() {
   const month = currentMonth();
   if (!existsSync(LEDGER_PATH)) {
@@ -153,37 +202,39 @@ function loadLocked() {
   try {
     led = JSON.parse(readFileSync(LEDGER_PATH, "utf8"));
   } catch {
-    // Corrupt file. Do NOT reset to 0 — quarantine and fail closed.
-    try {
-      renameSync(LEDGER_PATH, `${LEDGER_PATH}.corrupt.${Date.now()}`);
-    } catch {
-      /* ignore */
-    }
-    throw new LedgerUnavailable("ledger unreadable (quarantined corrupt file)");
+    quarantine();
+    console.error("[tavily] ledger unreadable — poisoned (fail-closed) until month rollover or manual reset");
+    return poisonLedger();
   }
-  if (!led || typeof led !== "object" || typeof led.total_used !== "number" || led.total_used < 0) {
-    throw new LedgerUnavailable("ledger schema invalid");
-  }
-  if (led.month !== month) {
+  // A cleanly-parsed prior month is safe to roll over to zero.
+  if (led && typeof led === "object" && led.month !== month && isFiniteNum(led.total_used)) {
     const rolled = freshLedger(led);
     atomicWrite(rolled);
     return rolled;
   }
-  // Normalize buckets: backfill any missing, drop obviously bad shapes.
-  if (!led.buckets || typeof led.buckets !== "object") led.buckets = {};
-  for (const [k, v] of Object.entries(DEFAULTS.buckets)) {
-    const b = led.buckets[k];
-    if (!b || typeof b.used !== "number" || b.used < 0 || typeof b.cap !== "number") {
-      led.buckets[k] = { ...v };
+  // Same month (or a prior month we couldn't trust) → must be fully sane.
+  if (led?.month === month && isSaneLedger(led)) {
+    // Backfill any bucket the DEFAULTS added since the ledger was written.
+    for (const [k, v] of Object.entries(DEFAULTS.buckets)) {
+      if (!led.buckets[k]) led.buckets[k] = { ...v };
     }
+    return led;
   }
-  if (typeof led.monthly_limit !== "number") led.monthly_limit = DEFAULTS.monthly_limit;
-  if (typeof led.reserve !== "number") led.reserve = DEFAULTS.reserve;
-  return led;
+  quarantine();
+  console.error("[tavily] ledger invalid — poisoned (fail-closed) until month rollover or manual reset");
+  return poisonLedger();
+}
+
+function quarantine() {
+  try {
+    renameSync(LEDGER_PATH, `${LEDGER_PATH}.corrupt.${Date.now()}`);
+  } catch {
+    /* ignore */
+  }
 }
 
 // Atomically check the budget AND charge it. Returns:
-//   { allowed:true,  remaining, total_used, bucket, bucket_used, bucket_cap }
+//   { allowed:true,  month, bucket, total_used, bucket_used, bucket_cap, remaining }
 //   { allowed:false, reason, remaining? }
 // On lock/ledger trouble it DENIES (fail-closed) rather than run unlocked.
 export function reserve(bucketName, cost) {
@@ -194,6 +245,9 @@ export function reserve(bucketName, cost) {
       const bucket = led.buckets[key];
       const globalCap = led.monthly_limit - led.reserve;
       const remaining = globalCap - led.total_used;
+      if (led.poisoned) {
+        return { allowed: false, reason: "budget ledger poisoned (corrupt/invalid — fail-closed)", remaining };
+      }
       if (led.total_used + cost > globalCap) {
         return {
           allowed: false,
@@ -213,6 +267,7 @@ export function reserve(bucketName, cost) {
       atomicWrite(led);
       return {
         allowed: true,
+        month: led.month,
         bucket: key,
         total_used: led.total_used,
         bucket_used: bucket.used,
@@ -228,21 +283,24 @@ export function reserve(bucketName, cost) {
   }
 }
 
-// Give a reservation back after a DEFINITE remote failure (non-2xx / network
-// error) — Tavily does not charge for those. Best-effort: if the ledger is
-// momentarily locked we drop the refund (conservative over-count), never crash.
-export function refund(bucketName, cost) {
+// Give a reservation back ONLY on a definite non-billed outcome (an HTTP error
+// response) — never on an ambiguous network failure, which may have arrived
+// after Tavily already billed. Refund is a no-op if the month has rolled over
+// since the reservation (so we never deduct from a fresh month's spend), and
+// best-effort under contention (a dropped refund is a safe over-count).
+export function refund(bucketName, cost, month) {
   const key = resolveBucket(bucketName);
   try {
     withLock(() => {
       const led = loadLocked();
+      if (led.poisoned) return; // don't touch a poisoned ledger
+      if (month && led.month !== month) return; // reservation was a different month
       led.total_used = Math.max(0, led.total_used - cost);
       const bucket = led.buckets[key];
       if (bucket) bucket.used = Math.max(0, bucket.used - cost);
       atomicWrite(led);
     });
   } catch {
-    // Refund lost → we over-counted by `cost`. Safe direction; log and move on.
-    console.error(`[tavily] refund of ${cost} to "${key}" skipped (ledger busy)`);
+    console.error(`[tavily] refund of ${cost} to "${key}" skipped (ledger busy) — safe over-count`);
   }
 }

--- a/skills/tavily-search/lib/ledger.mjs
+++ b/skills/tavily-search/lib/ledger.mjs
@@ -1,0 +1,143 @@
+// Tavily monthly credit ledger — the HARD budget guardrail.
+//
+// Why this exists: the free "Researcher" plan is 1000 credits/month, shared
+// globally. Tavily's /usage endpoint lags badly (still 0 minutes after real
+// calls), so it CANNOT gate a call in real time. This local ledger is the
+// source of truth for gating; /usage is only a coarse periodic reconciliation.
+//
+// All Tavily calls go through search.mjs / extract.mjs, so charging here covers
+// every code path. Pricing (verified against Tavily docs): basic search = 1
+// credit, advanced (--deep) = 2, extract = 1 credit per 5 URLs.
+//
+// Buckets enforce codex's allocation so one use can't starve another. Calls
+// without --bucket land in "default" (deliberately small) so any unplanned
+// usage is naturally throttled instead of silently eating the month.
+
+import { readFileSync, writeFileSync, openSync, closeSync, existsSync, unlinkSync } from "node:fs";
+
+const LEDGER_PATH = process.env.TAVILY_LEDGER_PATH ?? "/root/.openclaw/tavily-credit-ledger.json";
+const LOCK_PATH = LEDGER_PATH + ".lock";
+
+// Global hard cap = monthlyLimit - reserve. Reserve absorbs the tiny
+// precheck→commit race and any /usage-vs-ledger drift.
+const DEFAULTS = {
+  monthly_limit: 1000,
+  reserve: 50,
+  buckets: {
+    brief: { cap: 300, used: 0 }, // daily-deep-brief — the one guaranteed use
+    report: { cap: 280, used: 0 }, // HK/US open+close core reports
+    intraday: { cap: 120, used: 0 }, // event-triggered only (not every poll)
+    research: { cap: 100, used: 0 }, // weekly catalyst / thesis-falsification
+    extract: { cap: 80, used: 0 }, // raw filings/announcements only
+    default: { cap: 60, used: 0 }, // anything unbucketed — kept small on purpose
+  },
+};
+
+function currentMonth() {
+  // Asia/Shanghai to line up with the HKT trading calendar the crons use.
+  const d = new Date(Date.now() + 8 * 3600 * 1000);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function withLock(fn) {
+  // Cross-process mutex via O_EXCL lockfile. Crons are staggered so contention
+  // is rare; retry briefly, then proceed unlocked rather than block a report.
+  let fd = null;
+  for (let i = 0; i < 50; i++) {
+    try {
+      fd = openSync(LOCK_PATH, "wx");
+      break;
+    } catch {
+      const until = Date.now() + 20;
+      while (Date.now() < until) {
+        /* tiny spin */
+      }
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    if (fd !== null) {
+      closeSync(fd);
+      try {
+        unlinkSync(LOCK_PATH);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function load() {
+  let led;
+  if (existsSync(LEDGER_PATH)) {
+    try {
+      led = JSON.parse(readFileSync(LEDGER_PATH, "utf8"));
+    } catch {
+      led = null;
+    }
+  }
+  const month = currentMonth();
+  if (!led || led.month !== month) {
+    // New month → reset. (Approximates Tavily's cycle by calendar month; the
+    // /usage reconciliation can correct if the real reset date differs.)
+    led = {
+      month,
+      monthly_limit: led?.monthly_limit ?? DEFAULTS.monthly_limit,
+      reserve: led?.reserve ?? DEFAULTS.reserve,
+      total_used: 0,
+      buckets: JSON.parse(JSON.stringify(DEFAULTS.buckets)),
+    };
+    writeFileSync(LEDGER_PATH, JSON.stringify(led, null, 2));
+  }
+  // Backfill any bucket added to DEFAULTS after the ledger was created.
+  for (const [k, v] of Object.entries(DEFAULTS.buckets)) {
+    if (!led.buckets[k]) led.buckets[k] = { ...v };
+  }
+  return led;
+}
+
+// Returns { allowed, reason, remaining } WITHOUT charging.
+export function precheck(bucketName, cost) {
+  return withLock(() => {
+    const led = load();
+    const bucket = led.buckets[bucketName] ?? led.buckets.default;
+    const globalCap = led.monthly_limit - led.reserve;
+    const remaining = globalCap - led.total_used;
+    if (led.total_used + cost > globalCap) {
+      return {
+        allowed: false,
+        reason: `monthly Tavily budget reached (${led.total_used}/${globalCap} used, reserve ${led.reserve})`,
+        remaining,
+      };
+    }
+    if (bucket.used + cost > bucket.cap) {
+      return {
+        allowed: false,
+        reason: `Tavily "${bucketName}" bucket exhausted (${bucket.used}/${bucket.cap})`,
+        remaining,
+      };
+    }
+    return { allowed: true, reason: "", remaining };
+  });
+}
+
+// Charge AFTER a successful API response (failed/429 requests don't cost
+// credits on Tavily's side, so we never charge for them).
+export function commit(bucketName, cost) {
+  return withLock(() => {
+    const led = load();
+    const bucket = led.buckets[bucketName] ?? led.buckets.default;
+    const key = led.buckets[bucketName] ? bucketName : "default";
+    led.total_used += cost;
+    led.buckets[key].used += cost;
+    writeFileSync(LEDGER_PATH, JSON.stringify(led, null, 2));
+    const globalCap = led.monthly_limit - led.reserve;
+    return {
+      total_used: led.total_used,
+      bucket_used: led.buckets[key].used,
+      bucket_cap: led.buckets[key].cap,
+      remaining: globalCap - led.total_used,
+    };
+  });
+}

--- a/skills/tavily-search/lib/ledger.test.mjs
+++ b/skills/tavily-search/lib/ledger.test.mjs
@@ -65,6 +65,20 @@ reserve("brief", 1); l = read(); l.total_used = -999; writeFileSync(LP, JSON.str
 r = reserve("brief", 1);
 ok(!r.allowed && /poison/.test(r.reason), "invalid schema (negative total) -> poisoned (fail-closed)");
 
+// array `buckets` parses as object but must be rejected (would reset caps to 0)
+wipe();
+reserve("brief", 1); l = read(); l.buckets = []; writeFileSync(LP, JSON.stringify(l));
+r = reserve("brief", 1);
+ok(!r.allowed && /poison/.test(r.reason), "array buckets -> poisoned (not silently cap-reset)");
+
+// malformed PRIOR-month config must NOT carry into the new month
+wipe();
+reserve("brief", 1); l = read(); l.month = "1999-01"; l.reserve = -1; l.monthly_limit = 999999; writeFileSync(LP, JSON.stringify(l));
+r = reserve("brief", 1);
+ok(r.allowed, "prior-month rollover proceeds");
+l = read();
+ok(l.reserve === 50 && l.monthly_limit === 1000, "malformed prior-month config clamped to DEFAULTS on rollover");
+
 // stale lock reclaimed
 wipe();
 reserve("brief", 1);

--- a/skills/tavily-search/lib/ledger.test.mjs
+++ b/skills/tavily-search/lib/ledger.test.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Robustness tests for the Tavily credit ledger (the hard budget guardrail).
+// Run: node lib/ledger.test.mjs   (self-contained, uses a throwaway temp path)
+//
+// Covers the failure modes that make or break a "hard cap": stale/held locks,
+// corrupt-file handling, per-bucket and global caps, refunds, prototype-key
+// safety. The multi-process concurrency case (N parallel reservers can't exceed
+// the cap) is verified separately since it needs real subprocesses.
+
+import { writeFileSync, readFileSync, openSync, closeSync, utimesSync, rmSync, existsSync, mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const DIR = mkdtempSync(join(tmpdir(), "tavily-ledger-"));
+const LP = join(DIR, "ledger.json");
+process.env.TAVILY_LEDGER_PATH = LP;
+const { reserve, refund } = await import("./ledger.mjs");
+
+let pass = 0, fail = 0;
+const ok = (c, m) => { if (c) pass++; else { fail++; console.log("  FAIL:", m); } };
+const wipe = () => { for (const f of readdirSync(DIR)) rmSync(join(DIR, f), { force: true }); };
+const read = () => JSON.parse(readFileSync(LP, "utf8"));
+
+// charging + bucket routing
+wipe();
+let r = reserve("brief", 1); ok(r.allowed && r.total_used === 1 && r.bucket === "brief", "basic charge -> brief=1");
+r = reserve("report", 2); ok(r.allowed && r.total_used === 3 && r.bucket_used === 2, "deep charge -> report=2");
+r = reserve("nope", 1); ok(r.allowed && r.bucket === "default", "unknown bucket -> default");
+r = reserve("__proto__", 1); ok(r.allowed && r.bucket === "default", "prototype key -> default (no pollution)");
+
+// per-bucket cap
+wipe();
+for (let i = 0; i < 60; i++) reserve("default", 1);
+r = reserve("default", 1); ok(!r.allowed && /bucket exhausted/.test(r.reason), "per-bucket cap enforced");
+ok(read().buckets.default.used === 60, "bucket never charged past cap");
+
+// global cap + boundary
+wipe();
+reserve("brief", 1); let l = read(); l.total_used = 949; l.buckets.brief.used = 1; writeFileSync(LP, JSON.stringify(l));
+ok(!reserve("brief", 2).allowed, "global cap: 949+2>950 denied");
+ok(reserve("brief", 1).allowed && read().total_used === 950, "global cap boundary: 949+1=950 allowed");
+
+// refund
+wipe();
+reserve("report", 2); refund("report", 2);
+l = read(); ok(l.total_used === 0 && l.buckets.report.used === 0, "refund restores total+bucket");
+refund("report", 5); ok(read().total_used === 0, "refund floors at 0 (never negative)");
+
+// corrupt ledger -> fail-closed, quarantined, NOT zeroed
+wipe();
+reserve("brief", 5);
+writeFileSync(LP, "{ not json ");
+r = reserve("brief", 1);
+ok(!r.allowed && /ledger unavailable/.test(r.reason), "corrupt ledger -> deny (fail-closed)");
+ok(readdirSync(DIR).some(f => f.includes("corrupt")), "corrupt ledger quarantined (not silently zeroed)");
+
+// stale lock reclaimed
+wipe();
+reserve("brief", 1);
+const lock = LP + ".lock";
+closeSync(openSync(lock, "wx"));
+const old = (Date.now() - 60000) / 1000; utimesSync(lock, old, old);
+ok(reserve("brief", 1).allowed && read().total_used === 2, "stale lock reclaimed -> proceeds");
+ok(!existsSync(lock), "stale lock cleaned up after use");
+
+// fresh held lock -> fail-closed (never runs unlocked)
+wipe();
+reserve("brief", 1);
+const fd = openSync(lock, "wx");
+r = reserve("brief", 1);
+ok(!r.allowed && /unavailable|busy/.test(r.reason), "held lock -> deny (fail-closed, not fail-open)");
+ok(read().total_used === 1, "held-lock denial did NOT write unlocked");
+closeSync(fd);
+
+rmSync(DIR, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/skills/tavily-search/lib/ledger.test.mjs
+++ b/skills/tavily-search/lib/ledger.test.mjs
@@ -40,19 +40,30 @@ reserve("brief", 1); let l = read(); l.total_used = 949; l.buckets.brief.used = 
 ok(!reserve("brief", 2).allowed, "global cap: 949+2>950 denied");
 ok(reserve("brief", 1).allowed && read().total_used === 950, "global cap boundary: 949+1=950 allowed");
 
-// refund
+// refund (with month guard)
 wipe();
-reserve("report", 2); refund("report", 2);
+let g = reserve("report", 2); refund("report", 2, g.month);
 l = read(); ok(l.total_used === 0 && l.buckets.report.used === 0, "refund restores total+bucket");
-refund("report", 5); ok(read().total_used === 0, "refund floors at 0 (never negative)");
+refund("report", 5, g.month); ok(read().total_used === 0, "refund floors at 0 (never negative)");
+reserve("report", 2); refund("report", 2, "1999-01");
+ok(read().total_used === 2, "refund with a different month is a no-op (no cross-month deduction)");
 
-// corrupt ledger -> fail-closed, quarantined, NOT zeroed
+// corrupt ledger -> poisoned, quarantined, and stays fail-closed on EVERY call
 wipe();
 reserve("brief", 5);
 writeFileSync(LP, "{ not json ");
 r = reserve("brief", 1);
-ok(!r.allowed && /ledger unavailable/.test(r.reason), "corrupt ledger -> deny (fail-closed)");
+ok(!r.allowed && /poison/.test(r.reason), "corrupt ledger -> deny (poisoned, fail-closed)");
 ok(readdirSync(DIR).some(f => f.includes("corrupt")), "corrupt ledger quarantined (not silently zeroed)");
+r = reserve("brief", 1);
+ok(!r.allowed && /poison|budget/.test(r.reason), "corrupt ledger stays fail-closed on the SECOND call too");
+ok(read().total_used >= read().monthly_limit - read().reserve, "poisoned ledger reads as exhausted, not reset to 0");
+
+// semantically invalid ledger (parses fine, bad numbers) -> poisoned too
+wipe();
+reserve("brief", 1); l = read(); l.total_used = -999; writeFileSync(LP, JSON.stringify(l));
+r = reserve("brief", 1);
+ok(!r.allowed && /poison/.test(r.reason), "invalid schema (negative total) -> poisoned (fail-closed)");
 
 // stale lock reclaimed
 wipe();

--- a/skills/tavily-search/scripts/extract.mjs
+++ b/skills/tavily-search/scripts/extract.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { precheck, commit } from "../lib/ledger.mjs";
+import { reserve, refund } from "../lib/ledger.mjs";
 
 function usage() {
   console.error(`Usage: extract.mjs "url1" ["url2" ...] [--bucket name]`);
@@ -10,12 +10,20 @@ function usage() {
 const args = process.argv.slice(2);
 if (args.length === 0 || args[0] === "-h" || args[0] === "--help") usage();
 
-const urls = args.filter(a => !a.startsWith("-"));
-
-// Optional --bucket <name>; defaults to "extract".
+// Parse args explicitly so the --bucket VALUE is consumed and never mistaken
+// for a URL (that would inflate the extract cost and POST a junk URL to Tavily).
 let bucket = "extract";
-const bi = args.indexOf("--bucket");
-if (bi !== -1 && args[bi + 1]) bucket = args[bi + 1];
+const urls = [];
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === "--bucket") {
+    bucket = args[i + 1] ?? bucket;
+    i++;
+    continue;
+  }
+  if (a.startsWith("-")) continue; // ignore unknown flags
+  urls.push(a);
+}
 
 if (urls.length === 0) {
   console.error("No URLs provided");
@@ -33,9 +41,10 @@ if (!apiKey) {
   process.exit(0);
 }
 
-// Budget gate. Tavily bills extract at 1 credit per 5 URLs (basic).
+// Budget gate. Tavily bills extract at 1 credit per 5 URLs (basic). reserve()
+// charges up front and atomically; a definite failure below refunds.
 const cost = Math.max(1, Math.ceil(urls.length / 5));
-const gate = precheck(bucket, cost);
+const gate = reserve(bucket, cost);
 if (!gate.allowed) {
   console.log(
     "## Content extraction unavailable\n\n" +
@@ -44,25 +53,31 @@ if (!gate.allowed) {
   process.exit(0);
 }
 
-const resp = await fetch("https://api.tavily.com/extract", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    api_key: apiKey,
-    urls: urls,
-  }),
-});
+let resp;
+try {
+  resp = await fetch("https://api.tavily.com/extract", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: apiKey,
+      urls: urls,
+    }),
+  });
+} catch (err) {
+  refund(gate.bucket, cost);
+  throw err;
+}
 
 if (!resp.ok) {
+  refund(gate.bucket, cost);
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Extract failed (${resp.status}): ${text}`);
 }
 
-const led = commit(bucket, cost);
 console.error(
-  `[tavily] extract charged ${cost} to "${bucket}" — month ${led.total_used} used, ${led.remaining} left`,
+  `[tavily] extract charged ${cost} to "${gate.bucket}" — month ${gate.total_used} used, ${gate.remaining} left`,
 );
 
 const data = await resp.json();

--- a/skills/tavily-search/scripts/extract.mjs
+++ b/skills/tavily-search/scripts/extract.mjs
@@ -21,7 +21,10 @@ for (let i = 0; i < args.length; i++) {
     i++;
     continue;
   }
-  if (a.startsWith("-")) continue; // ignore unknown flags
+  if (a.startsWith("-")) {
+    console.error(`Unknown arg: ${a}`);
+    usage();
+  }
   urls.push(a);
 }
 
@@ -53,25 +56,21 @@ if (!gate.allowed) {
   process.exit(0);
 }
 
-let resp;
-try {
-  resp = await fetch("https://api.tavily.com/extract", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      api_key: apiKey,
-      urls: urls,
-    }),
-  });
-} catch (err) {
-  refund(gate.bucket, cost);
-  throw err;
-}
+// Ambiguous network failures are NOT refunded (may have billed); only a
+// definite HTTP error response is refunded. See search.mjs for the rationale.
+const resp = await fetch("https://api.tavily.com/extract", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    api_key: apiKey,
+    urls: urls,
+  }),
+});
 
 if (!resp.ok) {
-  refund(gate.bucket, cost);
+  refund(gate.bucket, cost, gate.month);
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Extract failed (${resp.status}): ${text}`);
 }

--- a/skills/tavily-search/scripts/extract.mjs
+++ b/skills/tavily-search/scripts/extract.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
+import { precheck, commit } from "../lib/ledger.mjs";
+
 function usage() {
-  console.error(`Usage: extract.mjs "url1" ["url2" ...]`);
+  console.error(`Usage: extract.mjs "url1" ["url2" ...] [--bucket name]`);
   process.exit(2);
 }
 
@@ -10,6 +12,11 @@ if (args.length === 0 || args[0] === "-h" || args[0] === "--help") usage();
 
 const urls = args.filter(a => !a.startsWith("-"));
 
+// Optional --bucket <name>; defaults to "extract".
+let bucket = "extract";
+const bi = args.indexOf("--bucket");
+if (bi !== -1 && args[bi + 1]) bucket = args[bi + 1];
+
 if (urls.length === 0) {
   console.error("No URLs provided");
   usage();
@@ -17,8 +24,24 @@ if (urls.length === 0) {
 
 const apiKey = (process.env.TAVILY_API_KEY ?? "").trim();
 if (!apiKey) {
-  console.error("Missing TAVILY_API_KEY");
-  process.exit(1);
+  // Graceful degradation, matching search.mjs (exit 0, not 1) so a faithful
+  // cron call is not marked failed.
+  console.log(
+    "## Content extraction unavailable\n\n" +
+      "Tavily is not configured (TAVILY_API_KEY unset). Use your built-in fetch/scrape instead.",
+  );
+  process.exit(0);
+}
+
+// Budget gate. Tavily bills extract at 1 credit per 5 URLs (basic).
+const cost = Math.max(1, Math.ceil(urls.length / 5));
+const gate = precheck(bucket, cost);
+if (!gate.allowed) {
+  console.log(
+    "## Content extraction unavailable\n\n" +
+      `Tavily budget guardrail: ${gate.reason}. Use your built-in fetch/scrape instead.`,
+  );
+  process.exit(0);
 }
 
 const resp = await fetch("https://api.tavily.com/extract", {
@@ -36,6 +59,11 @@ if (!resp.ok) {
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Extract failed (${resp.status}): ${text}`);
 }
+
+const led = commit(bucket, cost);
+console.error(
+  `[tavily] extract charged ${cost} to "${bucket}" — month ${led.total_used} used, ${led.remaining} left`,
+);
 
 const data = await resp.json();
 

--- a/skills/tavily-search/scripts/search.mjs
+++ b/skills/tavily-search/scripts/search.mjs
@@ -90,24 +90,20 @@ if (topic === "news" && days) {
   body.days = days;
 }
 
-let resp;
-try {
-  resp = await fetch("https://api.tavily.com/search", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-} catch (err) {
-  // Network error → Tavily charged nothing, so give the reservation back.
-  refund(gate.bucket, cost);
-  throw err;
-}
+// Ambiguous network failures (ECONNRESET etc.) may have arrived AFTER Tavily
+// billed, so we do NOT refund them — keeping the reservation is the safe
+// (conservative over-count) direction for a hard cap. Only a definite HTTP
+// error response is a guaranteed non-billed outcome and gets refunded.
+const resp = await fetch("https://api.tavily.com/search", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(body),
+});
 
 if (!resp.ok) {
-  // A failed request does not consume Tavily credits, so refund the reservation.
-  refund(gate.bucket, cost);
+  refund(gate.bucket, cost, gate.month);
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Search failed (${resp.status}): ${text}`);
 }

--- a/skills/tavily-search/scripts/search.mjs
+++ b/skills/tavily-search/scripts/search.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
+import { precheck, commit } from "../lib/ledger.mjs";
+
 function usage() {
-  console.error(`Usage: search.mjs "query" [-n 5] [--deep] [--topic general|news] [--days 7]`);
+  console.error(`Usage: search.mjs "query" [-n 5] [--deep] [--topic general|news] [--days 7] [--bucket name]`);
   process.exit(2);
 }
 
@@ -13,6 +15,7 @@ let n = 5;
 let searchDepth = "basic";
 let topic = "general";
 let days = null;
+let bucket = "default"; // unbucketed calls are throttled hard on purpose
 
 for (let i = 1; i < args.length; i++) {
   const a = args[i];
@@ -35,6 +38,11 @@ for (let i = 1; i < args.length; i++) {
     i++;
     continue;
   }
+  if (a === "--bucket") {
+    bucket = args[i + 1] ?? "default";
+    i++;
+    continue;
+  }
   console.error(`Unknown arg: ${a}`);
   usage();
 }
@@ -47,6 +55,20 @@ if (!apiKey) {
   console.log(
     "## Web search unavailable\n\n" +
       "Tavily is not configured (TAVILY_API_KEY unset). " +
+      "Skip this source and use your built-in web search instead.",
+  );
+  process.exit(0);
+}
+
+// Budget gate (hard guardrail). basic = 1 credit, advanced = 2.
+const cost = searchDepth === "advanced" ? 2 : 1;
+const gate = precheck(bucket, cost);
+if (!gate.allowed) {
+  // Graceful degradation, same contract as the no-key path: exit 0 so a
+  // faithful cron call is NOT marked failed; caller falls back to built-in search.
+  console.log(
+    "## Web search unavailable\n\n" +
+      `Tavily budget guardrail: ${gate.reason}. ` +
       "Skip this source and use your built-in web search instead.",
   );
   process.exit(0);
@@ -75,9 +97,17 @@ const resp = await fetch("https://api.tavily.com/search", {
 });
 
 if (!resp.ok) {
+  // A failed request does not consume Tavily credits, so we do not charge.
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Search failed (${resp.status}): ${text}`);
 }
+
+// Success → charge the ledger and log remaining budget to stderr (not stdout,
+// so the report body stays clean).
+const led = commit(bucket, cost);
+console.error(
+  `[tavily] charged ${cost} to "${bucket}" — month ${led.total_used} used, ${led.remaining} left`,
+);
 
 const data = await resp.json();
 

--- a/skills/tavily-search/scripts/search.mjs
+++ b/skills/tavily-search/scripts/search.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { precheck, commit } from "../lib/ledger.mjs";
+import { reserve, refund } from "../lib/ledger.mjs";
 
 function usage() {
   console.error(`Usage: search.mjs "query" [-n 5] [--deep] [--topic general|news] [--days 7] [--bucket name]`);
@@ -61,8 +61,10 @@ if (!apiKey) {
 }
 
 // Budget gate (hard guardrail). basic = 1 credit, advanced = 2.
+// reserve() charges up front and atomically, so concurrent callers can't blow
+// past the cap on a stale snapshot; a definite failure below refunds.
 const cost = searchDepth === "advanced" ? 2 : 1;
-const gate = precheck(bucket, cost);
+const gate = reserve(bucket, cost);
 if (!gate.allowed) {
   // Graceful degradation, same contract as the no-key path: exit 0 so a
   // faithful cron call is NOT marked failed; caller falls back to built-in search.
@@ -88,25 +90,32 @@ if (topic === "news" && days) {
   body.days = days;
 }
 
-const resp = await fetch("https://api.tavily.com/search", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify(body),
-});
+let resp;
+try {
+  resp = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+} catch (err) {
+  // Network error → Tavily charged nothing, so give the reservation back.
+  refund(gate.bucket, cost);
+  throw err;
+}
 
 if (!resp.ok) {
-  // A failed request does not consume Tavily credits, so we do not charge.
+  // A failed request does not consume Tavily credits, so refund the reservation.
+  refund(gate.bucket, cost);
   const text = await resp.text().catch(() => "");
   throw new Error(`Tavily Search failed (${resp.status}): ${text}`);
 }
 
-// Success → charge the ledger and log remaining budget to stderr (not stdout,
+// Success → the reservation stands. Log remaining budget to stderr (not stdout,
 // so the report body stays clean).
-const led = commit(bucket, cost);
 console.error(
-  `[tavily] charged ${cost} to "${bucket}" — month ${led.total_used} used, ${led.remaining} left`,
+  `[tavily] charged ${cost} to "${gate.bucket}" — month ${gate.total_used} used, ${gate.remaining} left`,
 );
 
 const data = await resp.json();

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -99,7 +99,7 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提 `anomalies` 中至少一个票
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号 / RSI）
-  - ⚡ **板块全景鼓励 tavily-search**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker），search 对应 sector ETF / 主题板块今日成分涨跌 + 你持仓位置 + 1 句归因；持仓自己的数字仍从 context.json
+  - ⚡ **板块全景**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker），给对应 sector ETF / 主题板块今日成分涨跌 + 你持仓位置 + 1 句归因；持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`（见 Mode 5 的 Budget rule）——盘中每 30 分钟的常规盯盘**不要**烧 Tavily
   - 禁止"无异动，观望"这种敷衍 1 句话
 - 目标 ≤1200 字；>2000 字 postflight warn，>2500 字 fail
 
@@ -149,7 +149,7 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market u
 {raw_wechat_block 原样}
 
 ▎情绪面
-{Finnhub news + 纳指 tone → market direction；⚡ **板块全景鼓励 tavily-search**：板块名读 peer-map.json `theme`（持仓动态），search 对应 sector ETF / 主题成分今日 Top 5 + 你持仓位置 + 1 句归因}
+{Finnhub news + 纳指 tone → market direction；⚡ **板块全景**：板块名读 peer-map.json `theme`（持仓动态），对应 sector ETF / 主题成分今日 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {RSI / MA stance → overbought/oversold/breakout}
@@ -188,11 +188,12 @@ pass/warn 自动刷新 snapshot/dashboard，提交 scoped 产物并经 `safe_pus
 
 Sources, in order:
 1. **Finnhub news (in script)** — `scripts/data/analyze_us_stocks.py {TICKER}` without `--no-news` already pulls last 7 days with keyword sentiment scoring. **This is the first source — read it before anything else.**
-2. **Tavily (news + X)** — for trending discussions, analyst notes, X/Twitter sentiment:
+2. **Tavily (news + X)** — for trending discussions, analyst notes, X/Twitter sentiment. ⚠️ **Budget rule** (免费档 1000 credits/月，全局共享): 盘中盯盘(每 30 分钟)**默认不调 Tavily**，用 Finnhub + Reddit JSON 就够；只有**开盘/收盘报告**、或盘中出现**真事件**(异常波动跑输基准 / 停牌 / 财报预警 / 监管公告 / 有大标题但价格无法解释)才用。调用必须带 `--bucket`：开盘/收盘用 `--bucket report`，盘中事件用 `--bucket intraday`(不带 bucket 会落 60/月的 default 桶很快被挡):
    ```bash
-   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} stock sentiment" --topic news --days 3
-   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} reddit wallstreetbets"
+   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} stock sentiment" --topic news --days 3 --bucket report
+   node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{TICKER} reddit wallstreetbets" --bucket report
    ```
+   护栏是硬闸：额度用尽脚本返回 "Web search unavailable" 且 exit 0，别当报错，退回 Reddit/内置搜索。
 3. **Reddit JSON (no auth needed)** — direct fetch:
    ```bash
    curl -sH "User-Agent: openclaw/1.0" \


### PR DESCRIPTION
## What & why

Tavily web search is now configured (`TAVILY_API_KEY` in the runtime env, **not** committed — it lives in `/root/.openclaw/openclaw.json` outside the repo). The free *Researcher* plan is **1000 credits/month, shared globally**, so before opening it up to skills this adds a **hard budget guardrail**.

Context: the crons run pinned to MiniMax, whose native web search is weak — Tavily's real value here is filling that gap (structured search + Chinese-source coverage), **not** real-time freshness. So only the one skill that most needs it is opened up; the rest stay sparing.

## Changes

- **`lib/ledger.mjs` (new)** — local monthly credit ledger, the hard cap. Tavily's `/usage` endpoint lags badly (still reads 0 minutes after real calls), so it **cannot** gate in real time; the local ledger is the source of truth, with `/usage` only for coarse periodic reconciliation. flock-guarded, calendar-month reset (Asia/Shanghai), three limits: global **950** (=1000−50 reserve), per-bucket cap, per-call cost.
- **`search.mjs` / `extract.mjs`** — charge through the ledger (basic=1, deep=2, extract=1 per 5 URLs). New `--bucket` flag. Over-budget **degrades gracefully** (exit 0 + "unavailable" notice) — same contract as the existing no-key path, so a faithful cron call is never marked failed.
- **`daily-deep-brief`** — the one skill opened up to Tavily; calls now pass `--bucket brief`.
- **`us/hk-stock-analysis`** — the "⚡ encourage tavily-search" nudge (which fired on *every* run, including 30-min intraday polls) is relaxed: sector scans prefer built-in web search; Tavily only for open/close reports (`--bucket report`) or genuine intraday events (`--bucket intraday`). Routine polls no longer burn credits (would have been ~528/mo → blows the free tier).

## Bucket allocation
brief 300 / report 280 / intraday 120 / research 100 / extract 80 / default 60 (unbucketed → default, kept small on purpose). Sum 940 < 950 hard cap.

## Testing
- Verified charging: basic→1, deep→2, unbucketed→default.
- Verified graceful degrade on both bucket-exhaustion and global-cap (exit 0, no charge, fallback notice).
- `node --check` clean on all three scripts.
- No secret in the diff (only the `TAVILY_API_KEY` env-var *name* is referenced).

## Review
Claude-authored — per the clawock cross-agent workflow, **Codex reviews & squash-merges** (author does not self-merge). @codex review