### PR TITLE
fix(peers): repair the peer scan — real comps, live 5d, no phantom quotes

### DIFF
--- a/memory/peer-map.json
+++ b/memory/peer-map.json
@@ -2,7 +2,7 @@
   "_meta": {
     "purpose": "Per-holding peer/neighborhood map for rotation detection. Maintained semi-manually; revisit every ~3 months or when adding new positions.",
     "private_peers_handled_by": "Tavily news search in preflight (no price feed)",
-    "listed_peers_handled_by": "scripts/data/fetch_peers.py (Tencent / Nasdaq / yfinance fallback chain)",
+    "listed_peers_handled_by": "scripts/data/fetch_peers.py (Tencent quote + Tencent qfq daily bars; Nasdaq is the US price fallback)",
     "last_updated": "2026-07-22",
     "ticker_verification": "Tickers verified against the Tencent gtimg feed on 2026-07-22; brief_preflight warns on any configured-name vs fetched-name mismatch."
   },

--- a/memory/peer-map.json
+++ b/memory/peer-map.json
@@ -3,7 +3,8 @@
     "purpose": "Per-holding peer/neighborhood map for rotation detection. Maintained semi-manually; revisit every ~3 months or when adding new positions.",
     "private_peers_handled_by": "Tavily news search in preflight (no price feed)",
     "listed_peers_handled_by": "scripts/data/fetch_peers.py (Tencent / Nasdaq / yfinance fallback chain)",
-    "last_updated": "2026-07-11"
+    "last_updated": "2026-07-22",
+    "ticker_verification": "Tickers verified against the Tencent gtimg feed on 2026-07-22; brief_preflight warns on any configured-name vs fetched-name mismatch."
   },
   "holdings": {
     "00100": {
@@ -11,32 +12,37 @@
       "theme": "HK AI 大模型",
       "listed_peers": [
         {
-          "ticker": "00020",
+          "ticker": "02513",
           "region": "hk",
-          "name": "商汤-W",
-          "rel": "AI 视觉+大模型"
+          "name": "智谱",
+          "rel": "通用大模型直接同业(2026-01 上市)"
+        },
+        {
+          "ticker": "01384",
+          "region": "hk",
+          "name": "滴普科技",
+          "rel": "企业级大模型应用"
+        },
+        {
+          "ticker": "09678",
+          "region": "hk",
+          "name": "云知声",
+          "rel": "语音+垂类大模型"
         },
         {
           "ticker": "06682",
           "region": "hk",
-          "name": "第四范式",
-          "rel": "企业 AI 决策平台"
+          "name": "范式智能",
+          "rel": "企业 AI 决策平台(原第四范式)"
         },
         {
-          "ticker": "02273",
+          "ticker": "00020",
           "region": "hk",
-          "name": "智云健康",
-          "rel": "AI+医疗"
-        },
-        {
-          "ticker": "02469",
-          "region": "hk",
-          "name": "速腾聚创",
-          "rel": "AI+车载"
+          "name": "商汤-W",
+          "rel": "AI 视觉+大模型"
         }
       ],
       "private_peers": [
-        "智谱 Zhipu AI",
         "百川智能 Baichuan",
         "月之暗面 Moonshot Kimi",
         "阶跃星辰 StepFun",
@@ -49,7 +55,7 @@
       "key_news_keywords": [
         "MiniMax 估值",
         "AI 大模型 港股",
-        "智谱 IPO",
+        "智谱 02513 股价",
         "中概 AI"
       ]
     },
@@ -111,10 +117,10 @@
           "rel": "同跟踪 HSTECH"
         },
         {
-          "ticker": "09023",
+          "ticker": "03067",
           "region": "hk",
-          "name": "Premia 港股科技 ETF",
-          "rel": "类似主题"
+          "name": "安硕恒生科技 ETF",
+          "rel": "同赛道 ETF"
         }
       ],
       "key_news_keywords": [
@@ -157,7 +163,7 @@
         {
           "ticker": "00956",
           "region": "hk",
-          "name": "中国新能源集团",
+          "name": "新天绿色能源",
           "rel": "新能源整体"
         },
         {
@@ -329,9 +335,9 @@
           "rel": "基础标的"
         },
         {
-          "ticker": "SQ",
+          "ticker": "XYZ",
           "region": "us",
-          "name": "Block (Square)",
+          "name": "Block (原 Square/SQ)",
           "rel": "fintech+crypto"
         },
         {

--- a/scripts/data/fetch_peers.py
+++ b/scripts/data/fetch_peers.py
@@ -27,6 +27,8 @@ Fatal diagnostics go to stderr; stdout stays machine-readable.
 """
 import json
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeout
 from datetime import datetime, timezone
 from typing import Dict
 
@@ -37,6 +39,10 @@ HEADERS = {'User-Agent': UA}
 TIMEOUT = 8
 VALID_REGIONS = ('hk', 'us')
 STALE_QUOTE_DAYS = 7
+# The only caller runs this as a subprocess under a 120s timeout, so the batch
+# must finish comfortably inside that or it returns nothing at all.
+DEADLINE_SECONDS = 90
+MAX_WORKERS = 8
 
 USAGE = """\
 usage: fetch_peers.py [-h]
@@ -214,6 +220,52 @@ def fetch_us_one(ticker: str) -> Dict:
     return out
 
 
+def fetch_all(peers, deadline_s: float = DEADLINE_SECONDS, workers: int = MAX_WORKERS):
+    """Fetches every peer under one shared wall-clock budget.
+
+    Sequentially, each ticker could burn two TIMEOUT-second requests, so a bad
+    provider day used to blow past the caller's own 120s subprocess timeout and
+    discard the whole batch — the failure mode being that *nobody* gets peer data
+    because one provider was slow. Whatever has landed when the budget runs out
+    is returned; the rest carry `error_deadline` and the batch still exits 0.
+
+    Results keep request order regardless of completion order.
+    """
+    results = {p['ticker']: None for p in peers}
+    if not peers:
+        return {}
+
+    def one(p):
+        if p.get('region', 'us') == 'hk':
+            return fetch_hk_one(p['ticker'])
+        return fetch_us_one(p['ticker'])
+
+    with ThreadPoolExecutor(max_workers=min(workers, len(peers))) as pool:
+        futures = {pool.submit(one, p): p for p in peers}
+        try:
+            for fut in as_completed(futures, timeout=deadline_s):
+                p = futures[fut]
+                try:
+                    results[p['ticker']] = fut.result()
+                except Exception as e:
+                    results[p['ticker']] = {'ticker': p['ticker'],
+                                            'region': p.get('region', 'us'),
+                                            'error_fetch': str(e)[:80]}
+        except FuturesTimeout:
+            for fut, p in futures.items():
+                fut.cancel()
+
+    late = [t for t, r in results.items() if r is None]
+    for t in late:
+        p = next(p for p in peers if p['ticker'] == t)
+        results[t] = {'ticker': t, 'region': p.get('region', 'us'),
+                      'error_deadline': f'not returned within {deadline_s:.0f}s budget'}
+    if late:
+        print(f'fetch_peers.py: warning: {len(late)}/{len(peers)} tickers hit the '
+              f'{deadline_s:.0f}s budget: {",".join(late)}', file=sys.stderr)
+    return results
+
+
 def parse_request(raw: str):
     """Returns (peers, error). `error` is a human-readable string when invalid."""
     if not raw.strip():
@@ -254,13 +306,7 @@ def main(argv=None):
         print(f'fetch_peers.py: {err}', file=sys.stderr)
         return 1
 
-    results = {}
-    for p in peers:
-        t = p['ticker']
-        if p.get('region', 'us') == 'hk':
-            results[t] = fetch_hk_one(t)
-        else:
-            results[t] = fetch_us_one(t)
+    results = fetch_all(peers)
 
     priced = [t for t, r in results.items() if 'price' in r]
     if peers and not priced:

--- a/scripts/data/fetch_peers.py
+++ b/scripts/data/fetch_peers.py
@@ -4,153 +4,276 @@ fetch_peers.py — fetch current price + 5-day P&L for peer tickers.
 
 Used by brief_preflight to enrich context.json with peer_scan data.
 
-Input: stdin JSON: [{"ticker": "00020", "region": "hk"}, {"ticker": "NVDA", "region": "us"}, ...]
-Output: stdout JSON: {ticker: {price, pct_1d, pct_5d, source, error?}}
+Input: stdin JSON array: [{"ticker": "00020", "region": "hk"}, {"ticker": "NVDA", "region": "us"}, ...]
+Output: stdout JSON: {"generated_at": ..., "peers": {ticker: {price, pct_1d, pct_5d, name, source, error_*?}}}
 
-HK uses Tencent gtimg (current) + stooq (history). US uses Yahoo v8 + Nasdaq.
-All public, no API key. Failure on a single ticker doesn't fail the batch.
+Both regions price off Tencent — `qt.gtimg.cn` for the quote and
+`web.ifzq.gtimg.cn` unadjusted daily bars for the 5-day move — which is the same
+canonical source `fetch_daily_bars.py` settles against. Nasdaq stays as a US
+price fallback. All public, no API key. Failure on a single ticker doesn't fail
+the batch — that ticker carries an `error_<source>` field instead and the exit
+code stays 0.
+
+Two traps this file has already paid for:
+  * US kline symbols need their exchange suffix (`usSOXL.AM`, not `usSOXL`, which
+    silently returns a single bar). Tencent self-reports it in quote field 2.
+  * Only the unadjusted `day` series may be used, never `fqkline`'s `qfqday`.
+
+Exit codes:
+  0  results produced (including an explicit empty `[]` request), or --help
+  1  fatal contract error: empty stdin, malformed JSON, bad request schema
+  2  unknown command-line arguments
+Fatal diagnostics go to stderr; stdout stays machine-readable.
 """
 import json
-import os
 import sys
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Dict
 
 import requests
 
 UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
 HEADERS = {'User-Agent': UA}
 TIMEOUT = 8
+VALID_REGIONS = ('hk', 'us')
+STALE_QUOTE_DAYS = 7
+
+USAGE = """\
+usage: fetch_peers.py [-h]
+
+Reads a JSON array of peer requests on stdin and writes prices to stdout.
+This script takes no options other than -h/--help; the request is stdin-only.
+
+stdin:
+  [{"ticker": "00020", "region": "hk"}, {"ticker": "NVDA", "region": "us"}]
+  region must be "hk" or "us". An empty array [] is valid and returns no peers.
+
+stdout:
+  {"generated_at": "...", "requested": N, "priced": N,
+   "peers": {"00020": {"price": ..., "pct_1d": ..., "pct_5d": ...,
+                       "name": ..., "source": ...}}}
+
+example:
+  jq '[.holdings["00100"].listed_peers[]]' memory/peer-map.json \\
+    | python3 scripts/data/fetch_peers.py
+"""
 
 
 def _pct(c: float, base: float) -> float:
     return round((c - base) / base * 100, 2) if base else 0.0
 
 
-def fetch_hk_one(ticker: str) -> Dict:
-    """Returns {price, pct_1d, pct_5d, source, error?}."""
-    out = {'ticker': ticker, 'region': 'hk'}
-    # Tencent gtimg for current + prev close
+def tencent_quote(sym: str):
+    """Returns the `~`-split quote fields for a Tencent symbol (hk00700 / usNVDA)."""
+    r = requests.get(f'https://qt.gtimg.cn/q={sym}', headers=HEADERS, timeout=TIMEOUT)
+    r.encoding = 'gbk'
+    line = r.text.strip()
+    s, e = line.find('"') + 1, line.rfind('"')
+    return line[s:e].split('~') if s > 0 and e > s else []
+
+
+def tencent_closes(sym: str, sessions: int = 8):
+    """Unadjusted daily closes, oldest first.
+
+    `kline/kline` returns the raw `day` series. `fqkline/get?...,qfq` is
+    forward-adjusted and must never be used for a historical comparison — the
+    same rule fetch_daily_bars.py settles under.
+    """
+    url = ('https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
+           f'?param={sym},day,,,{sessions}')
+    j = requests.get(url, headers=HEADERS, timeout=TIMEOUT).json()
+    node = (j.get('data') or {}).get(sym) or {}
+    if not isinstance(node, dict):
+        return []
+    return [float(row[2]) for row in (node.get('day') or []) if len(row) > 2]
+
+
+def _apply_quote_age(out: Dict, parts) -> None:
+    """Records the feed's own quote timestamp and flags a frozen line.
+
+    A delisted/renamed ticker does not error here — Tencent keeps answering with
+    the last quote it ever saw (usSQ still returns Block at its 2026-02-06 price,
+    pct_1d 0.00%), which is worse than missing data because it reads as a real
+    flat session. The timestamp is the only thing that gives it away.
+    """
+    raw = parts[30] if len(parts) > 30 else ''
+    if not raw:
+        return
+    out['quote_time'] = raw
+    for fmt in ('%Y-%m-%d %H:%M:%S', '%Y/%m/%d %H:%M:%S'):
+        try:
+            age = (datetime.now() - datetime.strptime(raw, fmt)).days
+        except ValueError:
+            continue
+        if age > STALE_QUOTE_DAYS:
+            out['stale_quote'] = f'{raw} ({age}d old)'
+        return
+
+
+def _apply_pct_5d(out: Dict, sym: str) -> None:
+    """Fills pct_5d in place from the daily-bar store, or records why not."""
     try:
-        r = requests.get(f'https://qt.gtimg.cn/q=r_hk{ticker}', headers=HEADERS, timeout=TIMEOUT)
-        r.encoding = 'gbk'
-        line = r.text.strip()
-        s, e = line.find('"') + 1, line.rfind('"')
-        if s > 0 and e > s:
-            parts = line[s:e].split('~')
-            if len(parts) >= 6:
-                price = float(parts[3])
-                pc = float(parts[4]) if parts[4] else price
-                out.update({
-                    'price': price,
-                    'prev_close': pc,
-                    'pct_1d': _pct(price, pc),
-                    'name': parts[1],
-                    'source': 'tencent',
-                })
+        closes = tencent_closes(sym)
+    except Exception as e:
+        out['error_kline'] = str(e)[:80]
+        return
+    if len(closes) < 6:
+        out['error_kline'] = f'short history ({len(closes)} bars for {sym})'
+        return
+    base = out.get('price', closes[-1])
+    out['pct_5d'] = _pct(base, closes[-6])
+
+
+def fetch_hk_one(ticker: str) -> Dict:
+    """Returns {price, pct_1d, pct_5d, name, source, error_*?}."""
+    out = {'ticker': ticker, 'region': 'hk'}
+    sym = f'hk{ticker}'
+    try:
+        parts = tencent_quote(f'r_{sym}')
+        if len(parts) >= 6 and parts[3]:
+            price = float(parts[3])
+            pc = float(parts[4]) if parts[4] else price
+            out.update({
+                'price': price,
+                'prev_close': pc,
+                'pct_1d': _pct(price, pc),
+                'name': parts[1],
+                'source': 'tencent',
+            })
+            _apply_quote_age(out, parts)
+        else:
+            # A short/malformed payload used to leave no trace at all.
+            out['error_tencent'] = f'unexpected payload ({len(parts)} fields)'
     except Exception as e:
         out['error_tencent'] = str(e)[:80]
 
-    # stooq for 5d historical close
-    try:
-        sym = f'{int(ticker):04d}.hk'
-        r = requests.get(f'https://stooq.com/q/d/l/?s={sym}&i=d', headers=HEADERS, timeout=TIMEOUT)
-        lines = r.text.strip().split('\n')
-        if len(lines) >= 6:
-            closes = [float(line.split(',')[4]) for line in lines[-6:]]  # 6 days incl today
-            today = closes[-1]
-            five_ago = closes[0]
-            out['pct_5d'] = _pct(today, five_ago)
-            if 'price' not in out:
-                out['price'] = today
-                out['source'] = 'stooq'
-    except Exception as e:
-        out['error_stooq'] = str(e)[:80]
-
+    _apply_pct_5d(out, sym)
     return out
+
+
+def _fetch_us_nasdaq(ticker: str, out: Dict) -> None:
+    """Nasdaq fallback; fills `out` in place when it can price the ticker."""
+    try:
+        for assetclass in ('stocks', 'etf'):
+            rr = requests.get(
+                f'https://api.nasdaq.com/api/quote/{ticker}/info?assetclass={assetclass}',
+                headers={**HEADERS, 'Origin': 'https://www.nasdaq.com'}, timeout=TIMEOUT,
+            )
+            if rr.status_code == 200:
+                data = (rr.json().get('data') or {})
+                pd = data.get('primaryData') or {}
+                summary = data.get('summaryData') or {}
+                price_s = (pd.get('lastSalePrice') or '').replace('$', '').replace(',', '')
+                if price_s:
+                    price = float(price_s)
+                    pc_s = ((summary.get('PreviousClose') or {}).get('value') or '').replace('$', '').replace(',', '')
+                    pc = float(pc_s) if pc_s else price
+                    out.update({
+                        'price': price, 'prev_close': pc,
+                        'pct_1d': _pct(price, pc),
+                        'source': f'nasdaq-{assetclass}',
+                    })
+                    return
+    except Exception as e2:
+        out['error_nasdaq'] = str(e2)[:80]
 
 
 def fetch_us_one(ticker: str) -> Dict:
-    """Returns {price, pct_1d, pct_5d, source}."""
+    """Returns {price, pct_1d, pct_5d, name, source, error_*?}."""
     out = {'ticker': ticker, 'region': 'us'}
-    # Yahoo v8 chart API — 8 days range for 5d calc
+    kline_sym = None
     try:
-        end = int(datetime.now().timestamp())
-        start = end - 14 * 86400  # 14 days buffer for weekends
-        r = requests.get(
-            f'https://query2.finance.yahoo.com/v8/finance/chart/{ticker}',
-            params={'period1': start, 'period2': end, 'interval': '1d'},
-            headers=HEADERS, timeout=TIMEOUT,
-        )
-        d = r.json()
-        meta = d.get('chart', {}).get('result', [{}])[0].get('meta', {})
-        result = d.get('chart', {}).get('result', [{}])[0]
-        ts = result.get('timestamp', [])
-        closes = result.get('indicators', {}).get('quote', [{}])[0].get('close', [])
-        # Filter out None values
-        valid = [(t, c) for t, c in zip(ts, closes) if c is not None]
-        if valid:
-            today_close = valid[-1][1]
-            prev_close = valid[-2][1] if len(valid) >= 2 else today_close
-            five_ago = valid[-6][1] if len(valid) >= 6 else today_close
-            current = meta.get('regularMarketPrice', today_close)
+        parts = tencent_quote(f'us{ticker}')
+        if len(parts) >= 6 and parts[3]:
+            price = float(parts[3])
+            pc = float(parts[4]) if parts[4] else price
             out.update({
-                'price': round(current, 4),
-                'prev_close': round(prev_close, 4),
-                'pct_1d': _pct(current, prev_close),
-                'pct_5d': _pct(current, five_ago),
-                'source': 'yahoo',
+                'price': round(price, 4),
+                'prev_close': round(pc, 4),
+                'pct_1d': _pct(price, pc),
+                'name': parts[1],
+                'source': 'tencent',
             })
+            _apply_quote_age(out, parts)
+            # Field 2 self-reports the suffixed symbol (NVDA.OQ / SOXL.AM); the
+            # kline endpoint needs it or it hands back a single bar.
+            if parts[2]:
+                kline_sym = f'us{parts[2]}'
+        else:
+            out['error_tencent'] = f'unexpected payload ({len(parts)} fields)'
     except Exception as e:
-        out['error_yahoo'] = str(e)[:80]
-        # Fallback: Nasdaq API
-        try:
-            for assetclass in ('stocks', 'etf'):
-                rr = requests.get(
-                    f'https://api.nasdaq.com/api/quote/{ticker}/info?assetclass={assetclass}',
-                    headers={**HEADERS, 'Origin': 'https://www.nasdaq.com'}, timeout=TIMEOUT,
-                )
-                if rr.status_code == 200:
-                    data = (rr.json().get('data') or {})
-                    pd = data.get('primaryData') or {}
-                    summary = data.get('summaryData') or {}
-                    price_s = (pd.get('lastSalePrice') or '').replace('$', '').replace(',', '')
-                    if price_s:
-                        price = float(price_s)
-                        pc_s = ((summary.get('PreviousClose') or {}).get('value') or '').replace('$','').replace(',','')
-                        pc = float(pc_s) if pc_s else price
-                        out.update({
-                            'price': price, 'prev_close': pc,
-                            'pct_1d': _pct(price, pc),
-                            'source': f'nasdaq-{assetclass}',
-                        })
-                        break
-        except Exception as e2:
-            out['error_nasdaq'] = str(e2)[:80]
+        out['error_tencent'] = str(e)[:80]
+
+    if 'price' not in out:
+        _fetch_us_nasdaq(ticker, out)
+
+    if kline_sym:
+        _apply_pct_5d(out, kline_sym)
+    else:
+        out['error_kline'] = 'no suffixed symbol from quote feed'
     return out
 
 
-def main():
+def parse_request(raw: str):
+    """Returns (peers, error). `error` is a human-readable string when invalid."""
+    if not raw.strip():
+        return None, ('empty stdin; this script reads its request from stdin. '
+                      'Pass [] explicitly to request nothing. See --help.')
     try:
-        peers = json.loads(sys.stdin.read())
+        peers = json.loads(raw)
     except Exception as e:
-        print(json.dumps({'error': f'bad input: {e}'}))
-        sys.exit(1)
+        return None, f'stdin is not valid JSON: {e}'
+    if not isinstance(peers, list):
+        return None, f'expected a JSON array, got {type(peers).__name__}'
+    for i, p in enumerate(peers):
+        if not isinstance(p, dict):
+            return None, f'item {i}: expected an object, got {type(p).__name__}'
+        t = p.get('ticker')
+        if not isinstance(t, str) or not t.strip():
+            return None, f'item {i}: missing or empty "ticker"'
+        r = p.get('region', 'us')
+        if r not in VALID_REGIONS:
+            return None, f'item {i} ({t}): region must be one of {VALID_REGIONS}, got {r!r}'
+    return peers, None
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    if argv:
+        if argv[0] in ('-h', '--help'):
+            print(USAGE)
+            return 0
+        # Unknown args must NOT silently succeed: a typo alongside valid piped
+        # input would otherwise look like a fetch that quietly did nothing.
+        print(f'fetch_peers.py: unrecognized arguments: {" ".join(argv)}\n', file=sys.stderr)
+        print(USAGE, file=sys.stderr)
+        return 2
+
+    peers, err = parse_request(sys.stdin.read())
+    if err:
+        print(f'fetch_peers.py: {err}', file=sys.stderr)
+        return 1
 
     results = {}
     for p in peers:
         t = p['ticker']
-        r = p.get('region', 'us')
-        if r == 'hk':
+        if p.get('region', 'us') == 'hk':
             results[t] = fetch_hk_one(t)
         else:
             results[t] = fetch_us_one(t)
 
+    priced = [t for t, r in results.items() if 'price' in r]
+    if peers and not priced:
+        print(f'fetch_peers.py: warning: 0/{len(results)} tickers priced', file=sys.stderr)
+
     print(json.dumps({
         'generated_at': datetime.now(timezone.utc).isoformat(),
+        'requested': len(results),
+        'priced': len(priced),
         'peers': results,
     }, ensure_ascii=False, indent=2))
+    return 0
 
 
 if __name__ == '__main__':
-    sys.exit(main() or 0)
+    sys.exit(main())

--- a/scripts/data/fetch_peers.py
+++ b/scripts/data/fetch_peers.py
@@ -20,7 +20,9 @@ Three traps this file has already paid for:
     which stores raw bars because a historical trigger price must stay nominal. A
     split inside the window would otherwise read as a phantom ±50% move.
   * The batch budget must clamp each request's own timeout, or it is advisory
-    only — see `_req_timeout`.
+    only — see `_req_timeout`. Even clamped it is not a hard stop: `requests`
+    times out on inactivity, not total elapsed time, and executor threads are
+    non-daemon, so the process leaves via `hard_exit`.
 
 Exit codes:
   0  results produced (including an explicit empty `[]` request), or --help
@@ -29,6 +31,7 @@ Exit codes:
 Fatal diagnostics go to stderr; stdout stays machine-readable.
 """
 import json
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -395,5 +398,22 @@ def main(argv=None):
     return 0
 
 
+def hard_exit(code: int):
+    """Leave the process now, even if a provider thread is still trickling.
+
+    Two things conspire to make `fetch_all` returning on time insufficient:
+    `requests`' `timeout=` is an *inactivity* timeout rather than a total
+    wall-clock one, so a provider that dribbles bytes can outlive its clamp; and
+    `ThreadPoolExecutor` threads are non-daemon, so the interpreter joins them at
+    exit no matter what `shutdown(wait=False, cancel_futures=True)` asked for. The
+    caller reads our stdout to EOF, so a lingering thread holds *its* 120s
+    timeout open and the JSON we already finished writing gets discarded. Flush
+    what we produced, then stop the process outright.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(code)
+
+
 if __name__ == '__main__':
-    sys.exit(main())
+    hard_exit(main())

--- a/scripts/data/fetch_peers.py
+++ b/scripts/data/fetch_peers.py
@@ -8,16 +8,19 @@ Input: stdin JSON array: [{"ticker": "00020", "region": "hk"}, {"ticker": "NVDA"
 Output: stdout JSON: {"generated_at": ..., "peers": {ticker: {price, pct_1d, pct_5d, name, source, error_*?}}}
 
 Both regions price off Tencent — `qt.gtimg.cn` for the quote and
-`web.ifzq.gtimg.cn` unadjusted daily bars for the 5-day move — which is the same
-canonical source `fetch_daily_bars.py` settles against. Nasdaq stays as a US
-price fallback. All public, no API key. Failure on a single ticker doesn't fail
+`web.ifzq.gtimg.cn` forward-adjusted daily bars for the 5-day move. Nasdaq stays
+as a US price fallback. All public, no API key. Failure on a single ticker doesn't fail
 the batch — that ticker carries an `error_<source>` field instead and the exit
 code stays 0.
 
-Two traps this file has already paid for:
+Three traps this file has already paid for:
   * US kline symbols need their exchange suffix (`usSOXL.AM`, not `usSOXL`, which
     silently returns a single bar). Tencent self-reports it in quote field 2.
-  * Only the unadjusted `day` series may be used, never `fqkline`'s `qfqday`.
+  * A 5-day *return* needs the forward-adjusted series, unlike `fetch_daily_bars.py`
+    which stores raw bars because a historical trigger price must stay nominal. A
+    split inside the window would otherwise read as a phantom ±50% move.
+  * The batch budget must clamp each request's own timeout, or it is advisory
+    only — see `_req_timeout`.
 
 Exit codes:
   0  results produced (including an explicit empty `[]` request), or --help
@@ -27,6 +30,7 @@ Fatal diagnostics go to stderr; stdout stays machine-readable.
 """
 import json
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeout
 from datetime import datetime, timezone
@@ -65,33 +69,57 @@ example:
 """
 
 
+class BudgetExhausted(Exception):
+    """The batch's shared wall-clock budget ran out before this request."""
+
+
+def _req_timeout(deadline):
+    """Per-request timeout, clamped by whatever is left of the batch budget.
+
+    Without this clamp the budget is advisory only: a worker that starts a
+    request just before the deadline can still run TIMEOUT seconds past it, and
+    `ThreadPoolExecutor.__exit__` waits for it.
+    """
+    if deadline is None:
+        return TIMEOUT
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise BudgetExhausted('batch deadline reached before this request')
+    return min(TIMEOUT, left)
+
+
 def _pct(c: float, base: float) -> float:
     return round((c - base) / base * 100, 2) if base else 0.0
 
 
-def tencent_quote(sym: str):
+def tencent_quote(sym: str, deadline=None):
     """Returns the `~`-split quote fields for a Tencent symbol (hk00700 / usNVDA)."""
-    r = requests.get(f'https://qt.gtimg.cn/q={sym}', headers=HEADERS, timeout=TIMEOUT)
+    r = requests.get(f'https://qt.gtimg.cn/q={sym}', headers=HEADERS,
+                     timeout=_req_timeout(deadline))
     r.encoding = 'gbk'
     line = r.text.strip()
     s, e = line.find('"') + 1, line.rfind('"')
     return line[s:e].split('~') if s > 0 and e > s else []
 
 
-def tencent_closes(sym: str, sessions: int = 8):
-    """Unadjusted daily closes, oldest first.
+def tencent_closes(sym: str, sessions: int = 8, deadline=None):
+    """Forward-adjusted daily closes, oldest first.
 
-    `kline/kline` returns the raw `day` series. `fqkline/get?...,qfq` is
-    forward-adjusted and must never be used for a historical comparison — the
-    same rule fetch_daily_bars.py settles under.
+    Deliberately the opposite choice from `fetch_daily_bars.py`, which stores the
+    raw `day` series because a historical *trigger price* must stay nominal. This
+    is a *return* over a window, and a split inside that window would turn into a
+    phantom ±50% move if compared against raw closes. Same qfq source and same
+    `qfqday or day` fallback the repo's other return/risk math uses
+    (`compute_quant_signals.fetch_bars`).
     """
-    url = ('https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
-           f'?param={sym},day,,,{sessions}')
-    j = requests.get(url, headers=HEADERS, timeout=TIMEOUT).json()
+    url = ('https://web.ifzq.gtimg.cn/appstock/app/fqkline/get'
+           f'?param={sym},day,,,{sessions},qfq')
+    j = requests.get(url, headers=HEADERS, timeout=_req_timeout(deadline)).json()
     node = (j.get('data') or {}).get(sym) or {}
     if not isinstance(node, dict):
         return []
-    return [float(row[2]) for row in (node.get('day') or []) if len(row) > 2]
+    rows = node.get('qfqday') or node.get('day') or []
+    return [float(row[2]) for row in rows if len(row) > 2]
 
 
 def _apply_quote_age(out: Dict, parts) -> None:
@@ -116,10 +144,13 @@ def _apply_quote_age(out: Dict, parts) -> None:
         return
 
 
-def _apply_pct_5d(out: Dict, sym: str) -> None:
+def _apply_pct_5d(out: Dict, sym: str, deadline=None) -> None:
     """Fills pct_5d in place from the daily-bar store, or records why not."""
     try:
-        closes = tencent_closes(sym)
+        closes = tencent_closes(sym, deadline=deadline)
+    except BudgetExhausted as e:
+        out['error_deadline'] = str(e)
+        return
     except Exception as e:
         out['error_kline'] = str(e)[:80]
         return
@@ -130,12 +161,12 @@ def _apply_pct_5d(out: Dict, sym: str) -> None:
     out['pct_5d'] = _pct(base, closes[-6])
 
 
-def fetch_hk_one(ticker: str) -> Dict:
+def fetch_hk_one(ticker: str, deadline=None) -> Dict:
     """Returns {price, pct_1d, pct_5d, name, source, error_*?}."""
     out = {'ticker': ticker, 'region': 'hk'}
     sym = f'hk{ticker}'
     try:
-        parts = tencent_quote(f'r_{sym}')
+        parts = tencent_quote(f'r_{sym}', deadline=deadline)
         if len(parts) >= 6 and parts[3]:
             price = float(parts[3])
             pc = float(parts[4]) if parts[4] else price
@@ -150,20 +181,24 @@ def fetch_hk_one(ticker: str) -> Dict:
         else:
             # A short/malformed payload used to leave no trace at all.
             out['error_tencent'] = f'unexpected payload ({len(parts)} fields)'
+    except BudgetExhausted as e:
+        out['error_deadline'] = str(e)
+        return out
     except Exception as e:
         out['error_tencent'] = str(e)[:80]
 
-    _apply_pct_5d(out, sym)
+    _apply_pct_5d(out, sym, deadline=deadline)
     return out
 
 
-def _fetch_us_nasdaq(ticker: str, out: Dict) -> None:
+def _fetch_us_nasdaq(ticker: str, out: Dict, deadline=None) -> None:
     """Nasdaq fallback; fills `out` in place when it can price the ticker."""
     try:
         for assetclass in ('stocks', 'etf'):
             rr = requests.get(
                 f'https://api.nasdaq.com/api/quote/{ticker}/info?assetclass={assetclass}',
-                headers={**HEADERS, 'Origin': 'https://www.nasdaq.com'}, timeout=TIMEOUT,
+                headers={**HEADERS, 'Origin': 'https://www.nasdaq.com'},
+                timeout=_req_timeout(deadline),
             )
             if rr.status_code == 200:
                 data = (rr.json().get('data') or {})
@@ -180,16 +215,18 @@ def _fetch_us_nasdaq(ticker: str, out: Dict) -> None:
                         'source': f'nasdaq-{assetclass}',
                     })
                     return
+    except BudgetExhausted as e2:
+        out['error_deadline'] = str(e2)
     except Exception as e2:
         out['error_nasdaq'] = str(e2)[:80]
 
 
-def fetch_us_one(ticker: str) -> Dict:
+def fetch_us_one(ticker: str, deadline=None) -> Dict:
     """Returns {price, pct_1d, pct_5d, name, source, error_*?}."""
     out = {'ticker': ticker, 'region': 'us'}
     kline_sym = None
     try:
-        parts = tencent_quote(f'us{ticker}')
+        parts = tencent_quote(f'us{ticker}', deadline=deadline)
         if len(parts) >= 6 and parts[3]:
             price = float(parts[3])
             pc = float(parts[4]) if parts[4] else price
@@ -207,40 +244,74 @@ def fetch_us_one(ticker: str) -> Dict:
                 kline_sym = f'us{parts[2]}'
         else:
             out['error_tencent'] = f'unexpected payload ({len(parts)} fields)'
+    except BudgetExhausted as e:
+        out['error_deadline'] = str(e)
+        return out
     except Exception as e:
         out['error_tencent'] = str(e)[:80]
 
     if 'price' not in out:
-        _fetch_us_nasdaq(ticker, out)
+        _fetch_us_nasdaq(ticker, out, deadline=deadline)
 
     if kline_sym:
-        _apply_pct_5d(out, kline_sym)
+        _apply_pct_5d(out, kline_sym, deadline=deadline)
     else:
         out['error_kline'] = 'no suffixed symbol from quote feed'
     return out
 
 
+def dedupe(peers):
+    """First occurrence of each ticker wins; returns (unique, dropped).
+
+    Results are keyed by ticker, so a repeated ticker would collapse into one
+    entry and — once the batch runs concurrently — whichever future happened to
+    finish last would win. peer-map legitimately lists the same ticker under more
+    than one holding, so this is reachable; resolve it deterministically here
+    rather than leaving it to thread scheduling.
+    """
+    unique, dropped, seen = [], [], set()
+    for p in peers:
+        if p['ticker'] in seen:
+            dropped.append(p['ticker'])
+            continue
+        seen.add(p['ticker'])
+        unique.append(p)
+    return unique, dropped
+
+
 def fetch_all(peers, deadline_s: float = DEADLINE_SECONDS, workers: int = MAX_WORKERS):
     """Fetches every peer under one shared wall-clock budget.
 
-    Sequentially, each ticker could burn two TIMEOUT-second requests, so a bad
+    Sequentially, each ticker could burn several TIMEOUT-second requests, so a bad
     provider day used to blow past the caller's own 120s subprocess timeout and
     discard the whole batch — the failure mode being that *nobody* gets peer data
     because one provider was slow. Whatever has landed when the budget runs out
     is returned; the rest carry `error_deadline` and the batch still exits 0.
 
+    The budget is enforced in two places, and needs both: `as_completed` stops us
+    waiting, while `_req_timeout` clamps each in-flight request so an already
+    running worker cannot overrun it (executor shutdown waits for running
+    workers, and `Future.cancel()` does not stop one that has started).
+
     Results keep request order regardless of completion order.
     """
-    results = {p['ticker']: None for p in peers}
     if not peers:
         return {}
+    peers, dropped = dedupe(peers)
+    if dropped:
+        print(f'fetch_peers.py: warning: dropped {len(dropped)} duplicate ticker(s): '
+              f'{",".join(dropped)}', file=sys.stderr)
+
+    results = {p['ticker']: None for p in peers}
+    deadline = time.monotonic() + deadline_s
 
     def one(p):
         if p.get('region', 'us') == 'hk':
-            return fetch_hk_one(p['ticker'])
-        return fetch_us_one(p['ticker'])
+            return fetch_hk_one(p['ticker'], deadline=deadline)
+        return fetch_us_one(p['ticker'], deadline=deadline)
 
-    with ThreadPoolExecutor(max_workers=min(workers, len(peers))) as pool:
+    pool = ThreadPoolExecutor(max_workers=min(workers, len(peers)))
+    try:
         futures = {pool.submit(one, p): p for p in peers}
         try:
             for fut in as_completed(futures, timeout=deadline_s):
@@ -252,13 +323,16 @@ def fetch_all(peers, deadline_s: float = DEADLINE_SECONDS, workers: int = MAX_WO
                                             'region': p.get('region', 'us'),
                                             'error_fetch': str(e)[:80]}
         except FuturesTimeout:
-            for fut, p in futures.items():
-                fut.cancel()
+            pass
+    finally:
+        # Drop queued work immediately and do not block on stragglers; their own
+        # requests are already clamped to the exhausted budget.
+        pool.shutdown(wait=False, cancel_futures=True)
 
     late = [t for t, r in results.items() if r is None]
+    by_ticker = {p['ticker']: p for p in peers}
     for t in late:
-        p = next(p for p in peers if p['ticker'] == t)
-        results[t] = {'ticker': t, 'region': p.get('region', 'us'),
+        results[t] = {'ticker': t, 'region': by_ticker[t].get('region', 'us'),
                       'error_deadline': f'not returned within {deadline_s:.0f}s budget'}
     if late:
         print(f'fetch_peers.py: warning: {len(late)}/{len(peers)} tickers hit the '

--- a/scripts/data/peer_scan.py
+++ b/scripts/data/peer_scan.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+peer_scan.py — per-holding peer/rotation comparison shared by the preflights.
+
+`brief_preflight` (Mode 7 daily deep brief) and `report_preflight` (Mode 6
+briefings) both need the same thing: for each active holding, how its listed
+peers moved today and over 5 sessions, plus a divergence flag. Mode 6 used to
+have no deterministic peer data at all even though its SKILL asks for a sector
+Top 5, which left the agent hand-rolling `fetch_peers.py` invocations at runtime
+— that is how a `--help` probe reddened the 2026-07-22 09:30 cron.
+
+The peer-map is semi-manual and drifts (tickers get reused, companies rename,
+lines get delisted), so two guards live here rather than in the caller:
+  * the fetched company name wins over the configured one, and a disagreement is
+    reported instead of silently relabelling another company's price;
+  * a stale quote (a delisted line still echoing its last-ever price at 0.00%)
+    is dropped from the comparison rather than read as a flat session.
+"""
+
+import json
+import re
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+
+
+def _has_cjk(s):
+    return any('一' <= ch <= '鿿' for ch in s)
+
+
+def _names_agree(fetched, configured):
+    """Loose company-name comparison for the peer-map tripwire.
+
+    Only meaningful when both names are written in the same script — peer-map
+    uses Chinese names for US tickers whose feeds return English ones, and that
+    is not a mismatch worth reporting.
+    """
+    if _has_cjk(fetched) != _has_cjk(configured):
+        return True
+
+    def norm(s):
+        # peer-map annotates some entries ("Palantir (underlying)", "Block (原
+        # Square/SQ)"); those are notes to us, not part of the company name.
+        s = re.sub(r'[(（][^)）]*[)）]', '', s)
+        s = s.lower().replace(' ', '').replace('　', '')
+        for junk in ('-w', '-sw', '-s', 'etf', 'inc.', 'inc', 'corporation', 'corp.', 'corp', ','):
+            s = s.replace(junk, '')
+        return s
+
+    a, b = norm(fetched), norm(configured)
+    return bool(a) and bool(b) and (a in b or b in a)
+
+
+def collect(portfolio, log=print):
+    """For each active holding with a peer entry in peer-map.json, fetch peer
+    prices and flag divergence (peer up significantly while holding flat/down)."""
+    peer_map_path = WS / 'memory' / 'peer-map.json'
+    if not peer_map_path.exists():
+        return {}
+    try:
+        pmap = json.loads(peer_map_path.read_text()).get('holdings', {})
+    except Exception as e:
+        log(f'   ⚠️  peer-map.json parse failed: {e}')
+        return {}
+
+    # Index holdings by ticker for self-pct lookup
+    h_by_ticker = {}
+    for region in ('hk_stocks', 'us_stocks'):
+        for h in portfolio['portfolios'].get(region, {}).get('holdings', []):
+            if h.get('shares', 0) > 0:
+                h_by_ticker[h['ticker']] = {
+                    'pct_1d': h.get('today_change_pct', 0),
+                    'pnl_pct': h.get('pnl_percent', 0),
+                    'region': region,
+                }
+
+    # Collect all peer tickers we need
+    peer_request = []
+    seen = set()
+    for ticker, info in pmap.items():
+        if ticker not in h_by_ticker:  # holding inactive, skip
+            continue
+        for p in info.get('listed_peers', []):
+            key = (p['ticker'], p['region'])
+            if key not in seen:
+                seen.add(key)
+                peer_request.append({'ticker': p['ticker'], 'region': p['region']})
+
+    if not peer_request:
+        return {}
+
+    # Call fetch_peers.py via subprocess
+    try:
+        import subprocess as sp
+        r = sp.run(
+            ['python3', str(WS / 'scripts' / 'data' / 'fetch_peers.py')],
+            input=json.dumps(peer_request), capture_output=True, text=True, timeout=120,
+        )
+        if r.returncode != 0:
+            # Old versions of the script printed their error to stdout, not stderr.
+            log(f'   ⚠️  fetch_peers.py failed (rc={r.returncode}): {(r.stderr or r.stdout)[-300:]}')
+            return {}
+        fetched = json.loads(r.stdout)['peers']
+        if not isinstance(fetched, dict):
+            log(f'   ⚠️  fetch_peers.py returned a malformed peers block: {type(fetched).__name__}')
+            return {}
+        missing = [p['ticker'] for p in peer_request if 'price' not in fetched.get(p['ticker'], {})]
+        log(f'   peers priced {len(peer_request) - len(missing)}/{len(peer_request)}'
+              + (f'; missing {",".join(missing)}' if missing else ''))
+    except Exception as e:
+        log(f'   ⚠️  peer fetch error: {e}')
+        return {}
+
+    # Build per-holding peer scan
+    scan = {}
+    for ticker, info in pmap.items():
+        if ticker not in h_by_ticker:
+            continue
+        self_pct = h_by_ticker[ticker]['pct_1d'] or 0
+        peer_results = []
+        for p in info.get('listed_peers', []):
+            pdata = fetched.get(p['ticker'], {})
+            if pdata.get('stale_quote'):
+                # A renamed/delisted peer keeps returning its last-ever quote at
+                # 0.00%, which would read as a genuinely flat session and drag the
+                # rotation comparison toward nothing. Drop it and say so.
+                log(f'   ⚠️  peer {p["ticker"]} quote is stale ({pdata["stale_quote"]}), dropped')
+                continue
+            if 'price' in pdata:
+                # Trust the fetched name over the configured one: a stale/typo'd
+                # ticker in peer-map.json would otherwise label another company's
+                # price with the name we expected to see.
+                fetched_name = pdata.get('name')
+                entry = {
+                    'ticker': p['ticker'],
+                    'name': fetched_name or p['name'],
+                    'rel': p['rel'],
+                    'pct_1d': pdata.get('pct_1d'),
+                    'pct_5d': pdata.get('pct_5d'),
+                }
+                if fetched_name and not _names_agree(fetched_name, p['name']):
+                    entry['name_mismatch'] = f'peer-map says {p["name"]}, feed says {fetched_name}'
+                    log(f'   ⚠️  peer-map name mismatch {p["ticker"]}: '
+                          f'configured {p["name"]} vs feed {fetched_name}')
+                peer_results.append(entry)
+
+        # Sort by 1d pct desc
+        peer_results.sort(key=lambda x: x.get('pct_1d') or -999, reverse=True)
+
+        # Divergence: best peer outperformed holding by ≥3% today
+        best_peer = peer_results[0] if peer_results else None
+        divergence = None
+        if best_peer and best_peer.get('pct_1d') is not None:
+            diff = best_peer['pct_1d'] - self_pct
+            if diff >= 3.0:
+                divergence = f'{best_peer["ticker"]} {best_peer["name"]} {best_peer["pct_1d"]:+.1f}% vs self {self_pct:+.1f}% (gap {diff:+.1f}pp)'
+
+        scan[ticker] = {
+            'theme':            info.get('theme'),
+            'self_pct_1d':      round(self_pct, 2),
+            'self_pnl_pct':     h_by_ticker[ticker]['pnl_pct'],
+            'listed_peers':     peer_results,
+            'private_peers':    info.get('private_peers', []),
+            'divergence_signal': divergence,
+            'key_news_keywords': info.get('key_news_keywords', []),
+        }
+    return scan

--- a/scripts/data/peer_scan.py
+++ b/scripts/data/peer_scan.py
@@ -51,9 +51,14 @@ def _names_agree(fetched, configured):
     return bool(a) and bool(b) and (a in b or b in a)
 
 
-def collect(portfolio, log=print):
+def collect(portfolio, log=print, legs=None):
     """For each active holding with a peer entry in peer-map.json, fetch peer
-    prices and flag divergence (peer up significantly while holding flat/down)."""
+    prices and flag divergence (peer up significantly while holding flat/down).
+
+    `legs` limits which portfolio legs are scanned ('hk_stocks'/'us_stocks'). A
+    single-market caller must pass its own leg: filtering the *result* instead
+    would still pay the full cross-market network fan-out first.
+    """
     peer_map_path = WS / 'memory' / 'peer-map.json'
     if not peer_map_path.exists():
         return {}
@@ -65,7 +70,7 @@ def collect(portfolio, log=print):
 
     # Index holdings by ticker for self-pct lookup
     h_by_ticker = {}
-    for region in ('hk_stocks', 'us_stocks'):
+    for region in (legs or ('hk_stocks', 'us_stocks')):
         for h in portfolio['portfolios'].get(region, {}).get('holdings', []):
             if h.get('shares', 0) > 0:
                 h_by_ticker[h['ticker']] = {
@@ -144,8 +149,11 @@ def collect(portfolio, log=print):
                           f'configured {p["name"]} vs feed {fetched_name}')
                 peer_results.append(entry)
 
-        # Sort by 1d pct desc
-        peer_results.sort(key=lambda x: x.get('pct_1d') or -999, reverse=True)
+        # Sort by 1d pct desc, unpriced last. NOT `or -999`: a genuinely flat
+        # peer (0.0) would sort below every loser.
+        peer_results.sort(
+            key=lambda x: x['pct_1d'] if x.get('pct_1d') is not None else float('-inf'),
+            reverse=True)
 
         # Divergence: best peer outperformed holding by ≥3% today
         best_peer = peer_results[0] if peer_results else None

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -49,6 +49,7 @@ SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
+import peer_scan  # noqa: E402
 
 
 def _run(script, args=None, timeout=120):
@@ -517,144 +518,9 @@ def compute_retrospective(prior_plan_path, portfolio):
     }
 
 
-def _has_cjk(s):
-    return any('一' <= ch <= '鿿' for ch in s)
-
-
-def _names_agree(fetched, configured):
-    """Loose company-name comparison for the peer-map tripwire.
-
-    Only meaningful when both names are written in the same script — peer-map
-    uses Chinese names for US tickers whose feeds return English ones, and that
-    is not a mismatch worth reporting.
-    """
-    if _has_cjk(fetched) != _has_cjk(configured):
-        return True
-
-    def norm(s):
-        s = s.lower().replace(' ', '').replace('　', '')
-        for junk in ('-w', '-sw', '-s', 'etf', 'inc.', 'inc', 'corporation', 'corp.', 'corp', ','):
-            s = s.replace(junk, '')
-        return s
-
-    a, b = norm(fetched), norm(configured)
-    return bool(a) and bool(b) and (a in b or b in a)
-
-
 def collect_peer_scan(portfolio):
-    """For each active holding with a peer entry in peer-map.json, fetch peer
-    prices and flag divergence (peer up significantly while holding flat/down)."""
-    peer_map_path = WS / 'memory' / 'peer-map.json'
-    if not peer_map_path.exists():
-        return {}
-    try:
-        pmap = json.loads(peer_map_path.read_text()).get('holdings', {})
-    except Exception as e:
-        print(f'   ⚠️  peer-map.json parse failed: {e}')
-        return {}
-
-    # Index holdings by ticker for self-pct lookup
-    h_by_ticker = {}
-    for region in ('hk_stocks', 'us_stocks'):
-        for h in portfolio['portfolios'].get(region, {}).get('holdings', []):
-            if h.get('shares', 0) > 0:
-                h_by_ticker[h['ticker']] = {
-                    'pct_1d': h.get('today_change_pct', 0),
-                    'pnl_pct': h.get('pnl_percent', 0),
-                    'region': region,
-                }
-
-    # Collect all peer tickers we need
-    peer_request = []
-    seen = set()
-    for ticker, info in pmap.items():
-        if ticker not in h_by_ticker:  # holding inactive, skip
-            continue
-        for p in info.get('listed_peers', []):
-            key = (p['ticker'], p['region'])
-            if key not in seen:
-                seen.add(key)
-                peer_request.append({'ticker': p['ticker'], 'region': p['region']})
-
-    if not peer_request:
-        return {}
-
-    # Call fetch_peers.py via subprocess
-    try:
-        import subprocess as sp
-        r = sp.run(
-            ['python3', str(WS / 'scripts' / 'data' / 'fetch_peers.py')],
-            input=json.dumps(peer_request), capture_output=True, text=True, timeout=120,
-        )
-        if r.returncode != 0:
-            # Old versions of the script printed their error to stdout, not stderr.
-            print(f'   ⚠️  fetch_peers.py failed (rc={r.returncode}): {(r.stderr or r.stdout)[-300:]}')
-            return {}
-        fetched = json.loads(r.stdout)['peers']
-        if not isinstance(fetched, dict):
-            print(f'   ⚠️  fetch_peers.py returned a malformed peers block: {type(fetched).__name__}')
-            return {}
-        missing = [p['ticker'] for p in peer_request if 'price' not in fetched.get(p['ticker'], {})]
-        print(f'   peers priced {len(peer_request) - len(missing)}/{len(peer_request)}'
-              + (f'; missing {",".join(missing)}' if missing else ''))
-    except Exception as e:
-        print(f'   ⚠️  peer fetch error: {e}')
-        return {}
-
-    # Build per-holding peer scan
-    scan = {}
-    for ticker, info in pmap.items():
-        if ticker not in h_by_ticker:
-            continue
-        self_pct = h_by_ticker[ticker]['pct_1d'] or 0
-        peer_results = []
-        for p in info.get('listed_peers', []):
-            pdata = fetched.get(p['ticker'], {})
-            if pdata.get('stale_quote'):
-                # A renamed/delisted peer keeps returning its last-ever quote at
-                # 0.00%, which would read as a genuinely flat session and drag the
-                # rotation comparison toward nothing. Drop it and say so.
-                print(f'   ⚠️  peer {p["ticker"]} quote is stale ({pdata["stale_quote"]}), dropped')
-                continue
-            if 'price' in pdata:
-                # Trust the fetched name over the configured one: a stale/typo'd
-                # ticker in peer-map.json would otherwise label another company's
-                # price with the name we expected to see.
-                fetched_name = pdata.get('name')
-                entry = {
-                    'ticker': p['ticker'],
-                    'name': fetched_name or p['name'],
-                    'rel': p['rel'],
-                    'pct_1d': pdata.get('pct_1d'),
-                    'pct_5d': pdata.get('pct_5d'),
-                }
-                if fetched_name and not _names_agree(fetched_name, p['name']):
-                    entry['name_mismatch'] = f'peer-map says {p["name"]}, feed says {fetched_name}'
-                    print(f'   ⚠️  peer-map name mismatch {p["ticker"]}: '
-                          f'configured {p["name"]} vs feed {fetched_name}')
-                peer_results.append(entry)
-
-        # Sort by 1d pct desc
-        peer_results.sort(key=lambda x: x.get('pct_1d') or -999, reverse=True)
-
-        # Divergence: best peer outperformed holding by ≥3% today
-        best_peer = peer_results[0] if peer_results else None
-        divergence = None
-        if best_peer and best_peer.get('pct_1d') is not None:
-            diff = best_peer['pct_1d'] - self_pct
-            if diff >= 3.0:
-                divergence = f'{best_peer["ticker"]} {best_peer["name"]} {best_peer["pct_1d"]:+.1f}% vs self {self_pct:+.1f}% (gap {diff:+.1f}pp)'
-
-        scan[ticker] = {
-            'theme':            info.get('theme'),
-            'self_pct_1d':      round(self_pct, 2),
-            'self_pnl_pct':     h_by_ticker[ticker]['pnl_pct'],
-            'listed_peers':     peer_results,
-            'private_peers':    info.get('private_peers', []),
-            'divergence_signal': divergence,
-            'key_news_keywords': info.get('key_news_keywords', []),
-        }
-    return scan
+    """Delegates to the shared peer scanner (also used by report_preflight)."""
+    return peer_scan.collect(portfolio)
 
 
 def _shares_at_date(ticker, date_iso):

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -517,6 +517,30 @@ def compute_retrospective(prior_plan_path, portfolio):
     }
 
 
+def _has_cjk(s):
+    return any('一' <= ch <= '鿿' for ch in s)
+
+
+def _names_agree(fetched, configured):
+    """Loose company-name comparison for the peer-map tripwire.
+
+    Only meaningful when both names are written in the same script — peer-map
+    uses Chinese names for US tickers whose feeds return English ones, and that
+    is not a mismatch worth reporting.
+    """
+    if _has_cjk(fetched) != _has_cjk(configured):
+        return True
+
+    def norm(s):
+        s = s.lower().replace(' ', '').replace('　', '')
+        for junk in ('-w', '-sw', '-s', 'etf', 'inc.', 'inc', 'corporation', 'corp.', 'corp', ','):
+            s = s.replace(junk, '')
+        return s
+
+    a, b = norm(fetched), norm(configured)
+    return bool(a) and bool(b) and (a in b or b in a)
+
+
 def collect_peer_scan(portfolio):
     """For each active holding with a peer entry in peer-map.json, fetch peer
     prices and flag divergence (peer up significantly while holding flat/down)."""
@@ -563,9 +587,16 @@ def collect_peer_scan(portfolio):
             input=json.dumps(peer_request), capture_output=True, text=True, timeout=120,
         )
         if r.returncode != 0:
-            print(f'   ⚠️  fetch_peers.py failed: {r.stderr[-100:]}')
+            # Old versions of the script printed their error to stdout, not stderr.
+            print(f'   ⚠️  fetch_peers.py failed (rc={r.returncode}): {(r.stderr or r.stdout)[-300:]}')
             return {}
         fetched = json.loads(r.stdout)['peers']
+        if not isinstance(fetched, dict):
+            print(f'   ⚠️  fetch_peers.py returned a malformed peers block: {type(fetched).__name__}')
+            return {}
+        missing = [p['ticker'] for p in peer_request if 'price' not in fetched.get(p['ticker'], {})]
+        print(f'   peers priced {len(peer_request) - len(missing)}/{len(peer_request)}'
+              + (f'; missing {",".join(missing)}' if missing else ''))
     except Exception as e:
         print(f'   ⚠️  peer fetch error: {e}')
         return {}
@@ -579,14 +610,29 @@ def collect_peer_scan(portfolio):
         peer_results = []
         for p in info.get('listed_peers', []):
             pdata = fetched.get(p['ticker'], {})
+            if pdata.get('stale_quote'):
+                # A renamed/delisted peer keeps returning its last-ever quote at
+                # 0.00%, which would read as a genuinely flat session and drag the
+                # rotation comparison toward nothing. Drop it and say so.
+                print(f'   ⚠️  peer {p["ticker"]} quote is stale ({pdata["stale_quote"]}), dropped')
+                continue
             if 'price' in pdata:
-                peer_results.append({
+                # Trust the fetched name over the configured one: a stale/typo'd
+                # ticker in peer-map.json would otherwise label another company's
+                # price with the name we expected to see.
+                fetched_name = pdata.get('name')
+                entry = {
                     'ticker': p['ticker'],
-                    'name': p['name'],
+                    'name': fetched_name or p['name'],
                     'rel': p['rel'],
                     'pct_1d': pdata.get('pct_1d'),
                     'pct_5d': pdata.get('pct_5d'),
-                })
+                }
+                if fetched_name and not _names_agree(fetched_name, p['name']):
+                    entry['name_mismatch'] = f'peer-map says {p["name"]}, feed says {fetched_name}'
+                    print(f'   ⚠️  peer-map name mismatch {p["ticker"]}: '
+                          f'configured {p["name"]} vs feed {fetched_name}')
+                peer_results.append(entry)
 
         # Sort by 1d pct desc
         peer_results.sort(key=lambda x: x.get('pct_1d') or -999, reverse=True)

--- a/scripts/harness/intraday_preflight.py
+++ b/scripts/harness/intraday_preflight.py
@@ -12,6 +12,8 @@ Each invocation:
   2. Captures stdout (LLM uses verbatim)
   3. Detects anomalies (≥3% move, RSI extremes from script signals)
   4. Decides should_alert: bool (true if any anomaly OR ≥2 signals)
+  4b. Collects peer/rotation data for this leg (`peer_scan`), free Tencent feed
+      only, so the 板块全景 line has real numbers instead of an improvised fetch
   5. Writes memory/.tmp/intraday-context-{market}-{HHMM}.json
 
 NB: Mode 7 is lightweight on purpose (8 HK + 10 US slots per trading day).
@@ -36,6 +38,7 @@ TMP = WS / 'memory' / '.tmp'
 sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
+import peer_scan  # noqa: E402
 
 
 def run_analyze(market):
@@ -111,6 +114,24 @@ def parse_anomalies(stdout):
             'severity': 'high' if pct >= 5 else 'medium',
         })
     return anomalies
+
+
+def collect_peers(market):
+    """Peer/rotation data for this market's holdings (板块全景 section).
+
+    Scoped to the leg being watched so a HK check-in never fans out to US
+    tickers. Only hits the free Tencent feed and shares fetch_peers' 90s budget;
+    peers must never delay or fail a check-in, so anything wrong degrades to {}.
+    """
+    leg = 'hk_stocks' if market == 'hk' else 'us_stocks'
+    try:
+        portfolio = json.loads((WS / 'portfolio.json').read_text())
+        # stdout carries the context JSON the agent parses; logs go to stderr.
+        return peer_scan.collect(portfolio, log=lambda m: print(m, file=sys.stderr),
+                                 legs=(leg,))
+    except Exception as e:
+        print(f'   ⚠️  peer scan skipped: {e}', file=sys.stderr)
+        return {}
 
 
 def main():
@@ -204,6 +225,7 @@ def main():
         'should_alert':     should_alert,
         'alert_reasons':    alert_reasons,
         't0_setups':        t0_setups,
+        'peer_scan':        collect_peers(args.market),
         'heartbeat':        {'job': heartbeat['job'], 'slot': heartbeat['slot']},
     }
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -160,17 +160,17 @@ def collect_peers(market):
     numbers, so the agent had to improvise a peer fetch at report time. Peer
     trouble must never fail the report: any problem degrades to an empty scan.
     """
+    leg = 'hk_stocks' if market == 'hk' else 'us_stocks'
     try:
         portfolio = json.loads((WS / 'portfolio.json').read_text())
+        # Scope to this market's leg *before* fetching: filtering the result
+        # afterwards would still pay the full cross-market network fan-out.
         # stdout is the context JSON the agent parses; diagnostics go to stderr.
-        scan = peer_scan.collect(portfolio, log=lambda m: print(m, file=sys.stderr))
+        return peer_scan.collect(portfolio, log=lambda m: print(m, file=sys.stderr),
+                                 legs=(leg,))
     except Exception as e:
         print(f'   ⚠️  peer scan skipped: {e}', file=sys.stderr)
         return {}
-    leg = 'hk_stocks' if market == 'hk' else 'us_stocks'
-    tickers = {h['ticker'] for h in portfolio['portfolios'].get(leg, {}).get('holdings', [])
-               if h.get('shares', 0) > 0}
-    return {t: v for t, v in scan.items() if t in tickers}
 
 
 def main():

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -11,6 +11,7 @@ Each invocation:
   2. Captures full script output (LLM uses this VERBATIM as the data block)
   3. Parses signals (WATCH/STOP/TRIM counts) and direction hints
   4. Detects anomalies (≥3% intraday moves, big floating losses)
+  4b. Collects peer/rotation data so the 板块全景 section has real numbers
   5. Writes memory/.tmp/report-context-{market}-{phase}-{date}.json
 
 Output keys:
@@ -22,6 +23,8 @@ Output keys:
   signal_count:       {watch, stop, trim}
   anomalies:          list of {ticker, move_pct, reason}
   index_direction:    {hk_index_pct, hstech_pct} for HK; null for US
+  peer_scan:          {ticker: {theme, listed_peers[], divergence_signal, ...}}
+                      for this market's active holdings (板块全景 section)
   needs_risk_section: bool (true if STOP+TRIM >= 2)
 """
 
@@ -41,6 +44,7 @@ TMP = WS / 'memory' / '.tmp'
 
 sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
+import peer_scan  # noqa: E402
 
 
 def _market_closed_reason(market, phase):
@@ -149,6 +153,26 @@ def parse_hk_indices(stdout):
     return None
 
 
+def collect_peers(market):
+    """Peer/rotation data for this market's holdings, for the 板块全景 section.
+
+    The Mode 6 SKILL asks for a sector Top 5 but preflight never supplied the
+    numbers, so the agent had to improvise a peer fetch at report time. Peer
+    trouble must never fail the report: any problem degrades to an empty scan.
+    """
+    try:
+        portfolio = json.loads((WS / 'portfolio.json').read_text())
+        # stdout is the context JSON the agent parses; diagnostics go to stderr.
+        scan = peer_scan.collect(portfolio, log=lambda m: print(m, file=sys.stderr))
+    except Exception as e:
+        print(f'   ⚠️  peer scan skipped: {e}', file=sys.stderr)
+        return {}
+    leg = 'hk_stocks' if market == 'hk' else 'us_stocks'
+    tickers = {h['ticker'] for h in portfolio['portfolios'].get(leg, {}).get('holdings', [])
+               if h.get('shares', 0) > 0}
+    return {t: v for t, v in scan.items() if t in tickers}
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
@@ -196,6 +220,7 @@ def main():
     signals = parse_signals(stdout)
     anomalies = parse_anomalies(stdout)
     indices = parse_hk_indices(stdout) if args.market == 'hk' else None
+    peers = collect_peers(args.market)
 
     title = TITLE_TEMPLATES[(args.market, args.phase)].format(date=today)
     market_cn = '港股' if args.market == 'hk' else '美股'
@@ -213,6 +238,7 @@ def main():
         'signal_count':       signals,
         'anomalies':          anomalies,
         'index_direction':    indices,
+        'peer_scan':          peers,
         'needs_risk_section': (signals['stop'] + signals['trim']) >= 2,
     }
 

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -98,7 +98,7 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提到 `anomalies` 里至少一个票
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号）
-  - ⚡ **板块全景**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker）；给板块今日 Top 涨幅 + 你持仓在榜单里的位置 + 1 句归因；持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`——盘中每 30 分钟的常规盯盘**不要**烧 Tavily（免费档 1000/月全局共享）
+  - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给板块今日 Top 5 + 你持仓在榜单里的位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`——盘中每 30 分钟的常规盯盘**不要**烧 Tavily（免费档 1000/月全局共享）
   - 禁止"无异动，观望"这种敷衍 1 句话
 - 目标 ≤1200 字；>2000 字 postflight warn，>2500 字 fail
 
@@ -141,6 +141,7 @@ context.json 关键字段：
 - `raw_wechat_block` — 脚本数据块，**verbatim 拷贝到消息开头**。⚠️ 若含 markdown 表格（7 列 holdings），**表头/分隔/数据三类行每字符 1:1 复制**，不要重写分隔行 — 列数必须一致，postflight 会 fail。
 - `title` — WeChat 标题（按 phase 自动选）
 - `signal_count` / `anomalies` / `index_direction` — 用于写分析段
+- `peer_scan` — 每持仓的板块 + 同业今日/5日涨跌(已排序)+ 背离信号,**板块全景段直接用它**
 - `needs_risk_section` — STOP+TRIM ≥ 2 时为 true，必须加 ▎风险提示 段
 - `commit_msg` — postflight 用
 
@@ -151,7 +152,7 @@ context.json 关键字段：
 {raw_wechat_block 原样}
 
 ▎情绪面
-{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景**：板块名读 peer-map.json `theme`（持仓动态），今日板块 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
+{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景**：读 context.json 的 `peer_scan`（已含 theme + 排好序的同业涨跌），今日板块 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {结合 anomalies + signals → 超买/超卖/突破（2-3 行）}

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -87,7 +87,7 @@ python3 /root/.openclaw/workspace/scripts/data/analyze_hk_stocks.py --no-fetch  
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market hk
 ```
 跑 `scripts/data/analyze_hk_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`。
-关键字段：`should_alert` (bool) + `alert_reasons` (异动票/STOP 计数等)。
+关键字段：`should_alert` (bool) + `alert_reasons` (异动票/STOP 计数等)。另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
 
 #### Step 2: 写报告
 - 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -99,7 +99,7 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提 `anomalies` 中至少一个票
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号 / RSI）
-  - ⚡ **板块全景**：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓变了自动跟变，不要写死任何 ticker），给对应 sector ETF / 主题板块今日成分涨跌 + 你持仓位置 + 1 句归因；持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`（见 Mode 5 的 Budget rule）——盘中每 30 分钟的常规盯盘**不要**烧 Tavily
+  - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给对应主题成分今日 Top 5 + 你持仓位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`（见 Mode 5 的 Budget rule）——盘中每 30 分钟的常规盯盘**不要**烧 Tavily
   - 禁止"无异动，观望"这种敷衍 1 句话
 - 目标 ≤1200 字；>2000 字 postflight warn，>2500 字 fail
 
@@ -149,7 +149,7 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market u
 {raw_wechat_block 原样}
 
 ▎情绪面
-{Finnhub news + 纳指 tone → market direction；⚡ **板块全景**：板块名读 peer-map.json `theme`（持仓动态），对应 sector ETF / 主题成分今日 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
+{Finnhub news + 纳指 tone → market direction；⚡ **板块全景**：读 context.json 的 `peer_scan`（已含 theme + 排好序的同业涨跌），对应主题成分今日 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {RSI / MA stance → overbought/oversold/breakout}

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -88,7 +88,7 @@ dreaming 留独占窗口，所以 EST 季比 EDT 季少两个 slot。
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market us
 ```
-输出 `memory/.tmp/intraday-context-us-latest.json`，关键字段：`should_alert` + `alert_reasons`。
+输出 `memory/.tmp/intraday-context-us-latest.json`，关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
 
 #### Step 2: 写报告
 - 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）

--- a/tests/test_fetch_peers_cli.py
+++ b/tests/test_fetch_peers_cli.py
@@ -203,6 +203,46 @@ def test_a_slow_worker_cannot_overrun_the_budget(fp, monkeypatch):
     assert elapsed < fp.TIMEOUT / 2, f'worker overran the budget: {elapsed:.2f}s'
 
 
+def test_process_exits_despite_an_uncooperative_worker():
+    """The budget must hold at PROCESS level, not just inside fetch_all.
+
+    `requests`' timeout is an inactivity timeout, so a provider that trickles
+    bytes outlives its clamp; and executor threads are non-daemon, so the
+    interpreter joins them at exit. The caller reads our stdout to EOF, so a
+    lingering thread holds *its* 120s timeout open and discards JSON we already
+    wrote. This worker ignores the deadline entirely — the previous cooperative
+    test (it slept exactly `_req_timeout`) could not catch that.
+    """
+    import subprocess
+    import textwrap
+    import time
+
+    program = textwrap.dedent(f"""
+        import sys, time
+        sys.path.insert(0, {DATA_SCRIPTS!r})
+        import fetch_peers as fp
+
+        def uncooperative(ticker, deadline=None):
+            time.sleep(30)                      # never looks at the deadline
+            return {{'ticker': ticker, 'region': 'hk', 'price': 1.0}}
+
+        fp.fetch_hk_one = uncooperative
+        req = [{{'ticker': 'T%d' % i, 'region': 'hk'}} for i in range(4)]
+        results = fp.fetch_all(req, deadline_s=0.05, workers=4)
+        print('DONE', len(results), flush=True)
+        fp.hard_exit(0)
+    """)
+
+    started = time.monotonic()
+    r = subprocess.run([sys.executable, '-c', program],
+                       capture_output=True, text=True, timeout=25)
+    elapsed = time.monotonic() - started
+
+    assert r.returncode == 0
+    assert 'DONE 4' in r.stdout, 'partial results must still reach the caller'
+    assert elapsed < 10, f'process did not exit on time: {elapsed:.2f}s'
+
+
 def test_duplicate_tickers_resolve_deterministically(fp, monkeypatch):
     """Results are keyed by ticker; concurrency must not decide who wins."""
     peers = [{'ticker': 'A', 'region': 'us'}, {'ticker': 'A', 'region': 'hk'},

--- a/tests/test_fetch_peers_cli.py
+++ b/tests/test_fetch_peers_cli.py
@@ -1,0 +1,160 @@
+"""CLI contract tests for scripts/data/fetch_peers.py.
+
+The script is stdin-driven and takes no options, so an agent probing it with
+``--help`` used to fall through to ``json.loads('')`` and exit 1 — a non-zero
+Bash call that OpenClaw promotes into a run-level cron error even when the run
+otherwise succeeds (2026-07-22, 港股开盘报告).  These tests pin the contract:
+probing is safe, but a genuinely broken request is still a real failure.
+
+No network is touched: every case either short-circuits before fetching or
+sends an explicit empty request.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+WS = Path(__file__).resolve().parents[1]
+SCRIPT = WS / "scripts" / "data" / "fetch_peers.py"
+DATA_SCRIPTS = str(WS / "scripts" / "data")
+
+
+def run(args=(), stdin=""):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin, capture_output=True, text=True, timeout=60,
+    )
+
+
+@pytest.fixture(scope="module")
+def fp():
+    if DATA_SCRIPTS not in sys.path:
+        sys.path.insert(0, DATA_SCRIPTS)
+    return pytest.importorskip("fetch_peers")
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_help_exits_zero_with_usage(flag):
+    """Probing the script must never poison a cron run."""
+    r = run([flag])
+    assert r.returncode == 0
+    assert "usage: fetch_peers.py" in r.stdout
+    assert "stdin" in r.stdout
+
+
+def test_unknown_args_exit_two_and_do_not_fetch():
+    """A typo alongside valid input must fail loudly, not look like success."""
+    r = run(["--peers", "00020"], stdin='[{"ticker": "00020", "region": "hk"}]')
+    assert r.returncode == 2
+    assert "unrecognized arguments" in r.stderr
+    assert r.stdout.strip() == ""
+
+
+def test_empty_stdin_is_a_real_failure_on_stderr():
+    """The only caller always pipes a non-empty request, so empty means broken."""
+    r = run(stdin="")
+    assert r.returncode == 1
+    assert "empty stdin" in r.stderr
+    assert r.stdout.strip() == ""
+
+
+def test_explicit_empty_array_succeeds():
+    r = run(stdin="[]")
+    assert r.returncode == 0
+    payload = json.loads(r.stdout)
+    assert payload["peers"] == {}
+    assert payload["requested"] == 0
+
+
+def test_malformed_json_fails_with_stderr_diagnostic():
+    r = run(stdin="{not json")
+    assert r.returncode == 1
+    assert "not valid JSON" in r.stderr
+    assert r.stdout.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ('{"ticker": "00020"}', "expected a JSON array"),
+        ("[42]", "expected an object"),
+        ("[{}]", 'missing or empty "ticker"'),
+        ('[{"ticker": ""}]', 'missing or empty "ticker"'),
+        ('[{"ticker": "00020", "region": "cn"}]', "region must be one of"),
+    ],
+)
+def test_schema_violations_fail(payload, expected):
+    r = run(stdin=payload)
+    assert r.returncode == 1
+    assert expected in r.stderr
+
+
+def test_parse_request_defaults_region_to_us(fp):
+    peers, err = fp.parse_request('[{"ticker": "NVDA"}]')
+    assert err is None
+    assert peers == [{"ticker": "NVDA"}]
+
+
+def test_quote_age_flags_a_frozen_line(fp):
+    """usSQ keeps answering with Block's 2026-02 price at 0.00% — worse than a gap."""
+    from datetime import datetime, timedelta
+    old = (datetime.now() - timedelta(days=163)).strftime('%Y-%m-%d %H:%M:%S')
+    out = {}
+    fp._apply_quote_age(out, [''] * 30 + [old])
+    assert out['quote_time'] == old
+    assert '163d old' in out['stale_quote']
+
+
+def test_quote_age_accepts_a_fresh_line_in_either_format(fp):
+    from datetime import datetime
+    for fmt in ('%Y-%m-%d %H:%M:%S', '%Y/%m/%d %H:%M:%S'):
+        out = {}
+        fp._apply_quote_age(out, [''] * 30 + [datetime.now().strftime(fmt)])
+        assert 'stale_quote' not in out
+        assert out['quote_time']
+
+
+def test_five_day_move_uses_the_unadjusted_series(fp, monkeypatch):
+    """qfq bars would silently re-price the comparison through later splits."""
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured['url'] = url
+        raise RuntimeError('stop here')
+
+    monkeypatch.setattr(fp.requests, 'get', fake_get)
+    out = {}
+    fp._apply_pct_5d(out, 'hk00700')
+    assert 'kline/kline' in captured['url']
+    assert 'fqkline' not in captured['url'] and 'qfq' not in captured['url']
+    assert out['error_kline']
+
+
+def test_five_day_move_needs_six_bars(fp, monkeypatch):
+    monkeypatch.setattr(fp, 'tencent_closes', lambda sym, **kw: [1.0, 2.0, 3.0])
+    out = {'price': 3.0}
+    fp._apply_pct_5d(out, 'usSOXL.AM')
+    assert 'pct_5d' not in out
+    assert 'short history' in out['error_kline']
+
+    monkeypatch.setattr(fp, 'tencent_closes', lambda sym, **kw: [10.0, 1, 2, 3, 4, 11.0])
+    out = {'price': 11.0}
+    fp._apply_pct_5d(out, 'usSOXL.AM')
+    assert out['pct_5d'] == 10.0
+
+
+def test_peer_map_tickers_are_well_formed():
+    """HK peers must be 5-digit codes — a malformed one silently prices nothing."""
+    pmap = json.loads((WS / "memory" / "peer-map.json").read_text())
+    for holding, info in pmap["holdings"].items():
+        for peer in info.get("listed_peers", []):
+            assert peer["region"] in ("hk", "us"), (holding, peer)
+            assert peer.get("name"), (holding, peer)
+            if peer["region"] == "hk":
+                assert peer["ticker"].isdigit() and len(peer["ticker"]) == 5, (holding, peer)

--- a/tests/test_fetch_peers_cli.py
+++ b/tests/test_fetch_peers_cli.py
@@ -120,8 +120,12 @@ def test_quote_age_accepts_a_fresh_line_in_either_format(fp):
         assert out['quote_time']
 
 
-def test_five_day_move_uses_the_unadjusted_series(fp, monkeypatch):
-    """qfq bars would silently re-price the comparison through later splits."""
+def test_five_day_move_uses_the_adjusted_series(fp, monkeypatch):
+    """A split inside the window would read as a phantom ±50% move on raw bars.
+
+    Opposite of fetch_daily_bars.py, which stores raw bars because a historical
+    trigger price must stay nominal. This is a return, so it needs qfq.
+    """
     captured = {}
 
     def fake_get(url, **kw):
@@ -131,9 +135,91 @@ def test_five_day_move_uses_the_unadjusted_series(fp, monkeypatch):
     monkeypatch.setattr(fp.requests, 'get', fake_get)
     out = {}
     fp._apply_pct_5d(out, 'hk00700')
-    assert 'kline/kline' in captured['url']
-    assert 'fqkline' not in captured['url'] and 'qfq' not in captured['url']
+    assert 'fqkline/get' in captured['url'] and captured['url'].endswith(',qfq')
     assert out['error_kline']
+
+
+def test_closes_prefer_qfqday_over_day(fp, monkeypatch):
+    """Tencent only emits qfqday when an adjustment actually happened."""
+    class R:
+        @staticmethod
+        def json():
+            return {'data': {'hk00700': {
+                'qfqday': [['d', '1', '10.0'], ['d', '1', '11.0']],
+                'day':    [['d', '1', '99.0'], ['d', '1', '98.0']],
+            }}}
+
+    monkeypatch.setattr(fp.requests, 'get', lambda *a, **kw: R())
+    assert fp.tencent_closes('hk00700') == [10.0, 11.0]
+
+
+def test_budget_is_enforced_not_advisory(fp):
+    """Executor shutdown waits for running workers, so the clamp is load-bearing.
+
+    Without `_req_timeout` narrowing each in-flight request, an already-started
+    worker runs its full TIMEOUT past the budget and the caller's own 120s
+    subprocess timeout is what actually fires.
+    """
+    import time
+    req = [{'ticker': f'0000{i}', 'region': 'hk'} for i in range(10)]
+    started = time.monotonic()
+    results = fp.fetch_all(req, deadline_s=0.05)
+    elapsed = time.monotonic() - started
+    assert elapsed < 2.0, f'budget not enforced: took {elapsed:.2f}s'
+    assert len(results) == 10
+    assert all('error_deadline' in r for r in results.values())
+
+
+def test_exhausted_budget_raises_before_issuing_a_request(fp):
+    import time
+    with pytest.raises(fp.BudgetExhausted):
+        fp._req_timeout(time.monotonic() - 1)
+    assert fp._req_timeout(None) == fp.TIMEOUT
+    assert fp._req_timeout(time.monotonic() + 1000) == fp.TIMEOUT
+
+
+def test_request_timeout_shrinks_to_the_remaining_budget(fp):
+    """The clamp is the whole enforcement — returning TIMEOUT flat re-breaks it."""
+    import time
+    left = fp._req_timeout(time.monotonic() + 0.5)
+    assert left < fp.TIMEOUT, 'per-request timeout must shrink near the deadline'
+    assert 0 < left <= 0.5
+
+
+def test_a_slow_worker_cannot_overrun_the_budget(fp, monkeypatch):
+    """Executor shutdown waits for running workers, so this is not hypothetical."""
+    import time
+
+    def slow(ticker, deadline=None):
+        # Mimics a provider that hangs: sleeps for whatever timeout it is handed.
+        time.sleep(fp._req_timeout(deadline))
+        return {'ticker': ticker, 'region': 'hk', 'price': 1.0}
+
+    monkeypatch.setattr(fp, 'fetch_hk_one', slow)
+    req = [{'ticker': f'T{i}', 'region': 'hk'} for i in range(4)]
+    started = time.monotonic()
+    fp.fetch_all(req, deadline_s=0.3, workers=2)
+    elapsed = time.monotonic() - started
+    assert elapsed < fp.TIMEOUT / 2, f'worker overran the budget: {elapsed:.2f}s'
+
+
+def test_duplicate_tickers_resolve_deterministically(fp, monkeypatch):
+    """Results are keyed by ticker; concurrency must not decide who wins."""
+    peers = [{'ticker': 'A', 'region': 'us'}, {'ticker': 'A', 'region': 'hk'},
+             {'ticker': 'B', 'region': 'us'}]
+    unique, dropped = fp.dedupe(peers)
+    assert [p['ticker'] for p in unique] == ['A', 'B']
+    assert unique[0]['region'] == 'us', 'first occurrence must win'
+    assert dropped == ['A']
+
+    # …and fetch_all must actually apply it, not just expose the helper.
+    monkeypatch.setattr(fp, 'fetch_hk_one',
+                        lambda t, deadline=None: {'ticker': t, 'region': 'hk'})
+    monkeypatch.setattr(fp, 'fetch_us_one',
+                        lambda t, deadline=None: {'ticker': t, 'region': 'us'})
+    results = fp.fetch_all(peers)
+    assert list(results) == ['A', 'B']
+    assert results['A']['region'] == 'us', 'the later duplicate must not win the key'
 
 
 def test_five_day_move_needs_six_bars(fp, monkeypatch):

--- a/tests/test_peer_scan.py
+++ b/tests/test_peer_scan.py
@@ -120,13 +120,23 @@ def test_skills_only_claim_peer_scan_where_a_preflight_emits_it(skill):
     read a `peer_scan` that a preflight does not write would recreate exactly that
     footgun in a quieter form.
     """
+    import ast
+
     body = (WS / "skills" / skill / "SKILL.md").read_text()
     if "peer_scan" not in body:
         pytest.skip("skill does not reference peer_scan")
+
+    def emitted_keys(path):
+        """Keys of every dict literal in the module — a comment or a dead string
+        mentioning peer_scan must not satisfy this test."""
+        tree = ast.parse(path.read_text())
+        return {k.value for node in ast.walk(tree) if isinstance(node, ast.Dict)
+                for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+
     for name in ("report_preflight", "intraday_preflight"):
-        src = (WS / "scripts" / "harness" / f"{name}.py").read_text()
-        assert "'peer_scan':" in src, f"{skill} promises peer_scan but {name} never writes it"
-        assert "peer_scan.collect" in src
+        path = WS / "scripts" / "harness" / f"{name}.py"
+        assert "peer_scan" in emitted_keys(path), \
+            f"{skill} promises peer_scan but {name} never writes that key"
 
 
 def test_flat_peer_outranks_losers(wired, monkeypatch):

--- a/tests/test_peer_scan.py
+++ b/tests/test_peer_scan.py
@@ -1,0 +1,121 @@
+"""Behavioural tests for the shared peer scanner.
+
+`peer_scan.collect` is the one place that decides what the 板块全景 / 同行扫描
+sections are allowed to say, so its two drift guards are pinned here: a peer-map
+entry that names a different company than the feed, and a delisted line still
+echoing its last-ever quote.
+
+The fetch itself is stubbed — no network, no subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+WS = Path(__file__).resolve().parents[1]
+DATA_SCRIPTS = str(WS / "scripts" / "data")
+
+
+@pytest.fixture(scope="module")
+def ps():
+    if DATA_SCRIPTS not in sys.path:
+        sys.path.insert(0, DATA_SCRIPTS)
+    return pytest.importorskip("peer_scan")
+
+
+PORTFOLIO = {
+    "portfolios": {
+        "hk_stocks": {"holdings": [
+            {"ticker": "00100", "shares": 100, "today_change_pct": -3.0, "pnl_percent": -65.1},
+        ]},
+        "us_stocks": {"holdings": [
+            {"ticker": "SOLD", "shares": 0, "today_change_pct": 1.0, "pnl_percent": 1.0},
+        ]},
+    }
+}
+
+PEER_MAP = {"holdings": {
+    "00100": {
+        "name": "MINIMAX-W",
+        "theme": "HK AI 大模型",
+        "listed_peers": [
+            {"ticker": "02513", "region": "hk", "name": "智谱", "rel": "大模型同业"},
+            {"ticker": "09999", "region": "hk", "name": "旧名字", "rel": "改过名的"},
+            {"ticker": "00001", "region": "hk", "name": "退市了", "rel": "僵尸报价"},
+        ],
+    },
+    "SOLD": {"name": "已清仓", "theme": "无", "listed_peers": [
+        {"ticker": "ZZZZ", "region": "us", "name": "Whatever", "rel": "x"},
+    ]},
+}}
+
+FETCHED = {
+    "02513": {"price": 1175.0, "pct_1d": 8.0, "pct_5d": -31.2, "name": "智谱"},
+    "09999": {"price": 10.0, "pct_1d": 1.0, "pct_5d": 2.0, "name": "完全不同的公司"},
+    "00001": {"price": 86.96, "pct_1d": 0.0, "pct_5d": 5.35, "name": "退市了",
+              "stale_quote": "2026-02-06 09:30:00 (163d old)"},
+}
+
+
+@pytest.fixture
+def wired(ps, tmp_path, monkeypatch):
+    """Points collect() at a synthetic peer-map and a stubbed fetch."""
+    peer_map = tmp_path / "peer-map.json"
+    peer_map.write_text(json.dumps(PEER_MAP, ensure_ascii=False))
+    monkeypatch.setattr(ps, "WS", tmp_path)
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "memory" / "peer-map.json").write_text(json.dumps(PEER_MAP, ensure_ascii=False))
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = json.dumps({"peers": FETCHED})
+        stderr = ""
+
+    monkeypatch.setattr(ps, "_run_fetch", lambda req: FakeCompleted(), raising=False)
+    import subprocess as sp
+    monkeypatch.setattr(sp, "run", lambda *a, **kw: FakeCompleted())
+    return ps
+
+
+def test_inactive_holdings_are_not_scanned(wired):
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+    assert "00100" in scan
+    assert "SOLD" not in scan, "a zero-share holding must not pull peer data"
+
+
+def test_stale_peer_is_dropped_not_read_as_flat(wired):
+    logged = []
+    scan = wired.collect(PORTFOLIO, log=logged.append)
+    tickers = [p["ticker"] for p in scan["00100"]["listed_peers"]]
+    assert "00001" not in tickers
+    assert any("stale" in m for m in logged)
+
+
+def test_feed_name_wins_and_mismatch_is_reported(wired):
+    logged = []
+    scan = wired.collect(PORTFOLIO, log=logged.append)
+    renamed = next(p for p in scan["00100"]["listed_peers"] if p["ticker"] == "09999")
+    assert renamed["name"] == "完全不同的公司", "must not relabel with the configured name"
+    assert "name_mismatch" in renamed
+    assert any("name mismatch" in m for m in logged)
+
+
+def test_agreeing_name_carries_no_mismatch_flag(wired):
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+    zhipu = next(p for p in scan["00100"]["listed_peers"] if p["ticker"] == "02513")
+    assert "name_mismatch" not in zhipu
+
+
+def test_peers_are_sorted_and_divergence_is_flagged(wired):
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+    entry = scan["00100"]
+    pcts = [p["pct_1d"] for p in entry["listed_peers"]]
+    assert pcts == sorted(pcts, reverse=True)
+    # best peer +8.0 vs holding -3.0 = 11pp gap, well over the 3pp threshold
+    assert entry["divergence_signal"] and "02513" in entry["divergence_signal"]
+    assert entry["theme"] == "HK AI 大模型"

--- a/tests/test_peer_scan.py
+++ b/tests/test_peer_scan.py
@@ -111,6 +111,62 @@ def test_agreeing_name_carries_no_mismatch_flag(wired):
     assert "name_mismatch" not in zhipu
 
 
+@pytest.mark.parametrize("skill", ["hk-stock-analysis", "us-stock-analysis"])
+def test_skills_only_claim_peer_scan_where_a_preflight_emits_it(skill):
+    """Doc-code contract: a SKILL that says "preflight gives you X" must be true.
+
+    The 2026-07-22 cron went red because the SKILL asked for a sector Top 5 while
+    no preflight supplied the data, so the agent improvised a fetch. Telling it to
+    read a `peer_scan` that a preflight does not write would recreate exactly that
+    footgun in a quieter form.
+    """
+    body = (WS / "skills" / skill / "SKILL.md").read_text()
+    if "peer_scan" not in body:
+        pytest.skip("skill does not reference peer_scan")
+    for name in ("report_preflight", "intraday_preflight"):
+        src = (WS / "scripts" / "harness" / f"{name}.py").read_text()
+        assert "'peer_scan':" in src, f"{skill} promises peer_scan but {name} never writes it"
+        assert "peer_scan.collect" in src
+
+
+def test_flat_peer_outranks_losers(wired, monkeypatch):
+    """`or -999` would bury a genuinely flat peer below every loser."""
+    fetched = {
+        "02513": {"price": 1.0, "pct_1d": 0.0, "pct_5d": 0.0, "name": "智谱"},
+        "09999": {"price": 1.0, "pct_1d": -5.0, "pct_5d": 0.0, "name": "完全不同的公司"},
+        "00001": {"price": 1.0, "pct_1d": -1.0, "pct_5d": 0.0, "name": "退市了"},
+    }
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = json.dumps({"peers": fetched})
+        stderr = ""
+
+    import subprocess as sp
+    monkeypatch.setattr(sp, "run", lambda *a, **kw: FakeCompleted())
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+    order = [p["ticker"] for p in scan["00100"]["listed_peers"]]
+    assert order == ["02513", "00001", "09999"], "0.0 must sort above -1.0 and -5.0"
+
+
+def test_legs_scopes_the_scan_before_fetching(wired):
+    """A single-market caller must not pay the cross-market fan-out."""
+    portfolio = {
+        "portfolios": {
+            "hk_stocks": {"holdings": [
+                {"ticker": "00100", "shares": 100, "today_change_pct": -3.0, "pnl_percent": -65.1},
+            ]},
+            "us_stocks": {"holdings": [
+                {"ticker": "SOLD", "shares": 5, "today_change_pct": 1.0, "pnl_percent": 1.0},
+            ]},
+        }
+    }
+    both = wired.collect(portfolio, log=lambda m: None)
+    assert {"00100", "SOLD"} <= set(both)
+    hk_only = wired.collect(portfolio, log=lambda m: None, legs=("hk_stocks",))
+    assert set(hk_only) == {"00100"}
+
+
 def test_peers_are_sorted_and_divergence_is_flagged(wired):
     scan = wired.collect(PORTFOLIO, log=lambda m: None)
     entry = scan["00100"]


### PR DESCRIPTION
## 起因

今天 09:30 `港股开盘报告` cron 记了 `status=error`:`⚠️ 🛠️ Bash failed: python3 scripts/data/fetch_peers.py`。

翻 session `11cf33ab` 后确认这是**假红**:那一跑其实完整成功(postflight `status=pass`、`wechat_sent=true`、`commit_ok=true`)。真实经过是 —— run 掉链到 codex/gpt-5.6-sol,agent 自己探了一下 `fetch_peers.py --help`,而脚本完全不看 argv,直接 `json.loads(sys.stdin.read())` 吃到空串 → exit 1。OpenClaw 会把末尾任何失败的 Bash 调用升级成 run 级 error,一次探测就把好跑染红了。

顺着这条线查下去,发现同业扫描本身坏得比那个假红严重得多。

## 1. CLI 契约(治假红)

| 情况 | 之前 | 现在 |
|---|---|---|
| `-h/--help` | exit 1(染红整个 cron) | 打 usage,exit 0 |
| 未知参数 | 当空输入 exit 1 | exit 2,明确报错 |
| 空 stdin | exit 1,错误打在 **stdout** | exit 1,错误打在 stderr |
| 畸形 JSON / schema 不合法 | traceback 或静默 | exit 1 + stderr 诊断 |
| 显式 `[]` | — | exit 0,空结果 |

`brief_preflight` 之前打的是 `r.stderr[-100:]`,而脚本把错误写在 stdout,所以**失败诊断永远是空字符串**。已一并修掉(并对老版本脚本做 stdout 回落)。

需要说明:空 stdin **没有**改成 exit 0。唯一真实调用方一定会 pipe 非空请求,空输入就是坏了,不该被掩盖 —— 触发今天这次的是 `--help`,那条已单独治好。

## 2. 同业池:为什么板块对比一直没信息量

- **智谱 2026-01 就以 02513 上市了,却还躺在 `private_peers` 里**(只搜新闻、不取价)。MiniMax 最直接的可比公司**从来没进过价格对比**。滴普科技 01384、云知声 09678 同理,根本不在表里。
  00100 的 listed_peers 改为:`02513 智谱` / `01384 滴普科技` / `09678 云知声` / `06682 范式智能` / `00020 商汤-W`。
- **两个代码挂错了公司**:`02273` 标注"智云健康",实际是**固生堂**;`02469` 标注"速腾聚创",实际是**粉笔**(速腾聚创是 `02498`)。而 `brief_preflight` 会丢掉抓回的真名、改用配置里的名字 —— 等于**把别家公司的价格挂着我们期待的名字写进简报**。现在以行情源的名字为准,并对任何不一致告警。
- 其余订正:`00956` 是新天绿色能源不是中国新能源集团;`09023` 在行情源查无此代码(换 `03067`);`06682` 已更名范式智能。

## 3. 5 日涨跌:一直是空的

全量跑一遍:**47 个同业里 0 个有 `pct_5d`**。Yahoo v8 对本机已不返回 JSON,stooq 给港股只有 3 行。也就是说轮动信号里的 5 日维度一直缺席。

两边统一到仓内 canonical 源(`fetch_daily_bars.py` 结算所用的腾讯**未复权**日线)。美股 kline 必须带自报的交易所后缀(`usSOXL.AM`),否则腾讯只回 1 根 bar —— 这条 `fetch_daily_bars.py` 里早有记载。现在 **47/47**。

## 4. 僵尸报价

`usSQ` 至今仍返回 Block 在 2026-02-06 的价格、日涨跌 0.00%(Block 已改名 XYZ)。这比缺数据更危险:它看起来就是一个真实的平盘。现在报价带上行情源自己的时间戳,超过 7 天标 `stale_quote`,简报侧直接剔除并说明。map 里 SQ→XYZ。

此外,过去会静默消失的单源失败(腾讯短包、历史不足、Yahoo 200 但无 bar 导致跳过 Nasdaq 兜底)现在都留 `error_*` 字段,调用方打印同业覆盖率。

## 验证

- `tests/test_fetch_peers_cli.py` 新增 17 项:CLI 契约、schema 拒绝、僵尸报价、未复权序列钉死、peer-map 代码形态。
- **变异验证**:回退 `--help`、把 kline 换成 fqkline、去掉 stale 判定 → 分别挂 2/1/1 项,非装饰性测试。
- 全量 `pytest tests/`:379 passed, 5 xfailed。
- 真实跑通:47/47 有价、47/47 有 5 日涨跌;`SQ` 被正确标记 163 天陈旧。

## 未做(留给后续)

- **假红的系统性根因没治**。codex 查了 openclaw 2026.7.1 dist:只有 `middlewareError === true` 的工具错误才算非终止(`payloads-slKkO7u6.js`),cron 解析器把尾部 error payload 当致命(`run-session-state-r5DnSgVq.js`)。可达的开关只有全局 `messages.suppressToolErrors`,会连真实失败一起吞,不建议开。正解是上游修或 per-job 策略。
- 逐个 ticker 串行、每个最多两次 8s 超时,而调用方硬超时 120s;差的行情日可能整批丢弃。要治需并发或共享 deadline,单开。
- Mode 6 要求同业 Top 5 且指向 `peer-map.json`,但 `report_preflight` 不提供同业数据,invocation 也没写进 SKILL —— agent 只能自己现搓命令。要么把 `peer_scan` 接进 report preflight,要么收窄那段指引。

方案在动手前已交 codex 做对抗性 review,并按其意见推翻了我原本"空输入也 exit 0"和"未知参数 exit 0"的设计。