### PR TITLE
fix(security): make the secret scan actually scan, and fail closed

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,9 +20,20 @@ echo "▸ running clawock system_check.py before push…"
 RC=0
 python3 "$WS/scripts/system_check.py" || RC=$?
 
-if [ "$RC" = "1" ]; then
+# RC=0 all OK, RC=2 warnings only (must not block). ANY other code means the
+# checker did not deliver a verdict — interpreter missing (127), killed (137),
+# interrupted (130), unhandled traceback (1 is already blocked). Blocking only
+# RC=1 left every one of those as a silent pass, which is the same fail-open the
+# scan itself was just fixed for: a security gate that cannot run must not
+# certify. Override stays available via --no-verify.
+if [ "$RC" != "0" ] && [ "$RC" != "2" ]; then
   echo
-  echo "🚫 push blocked by clawock system_check (critical failures above)"
+  if [ "$RC" = "1" ]; then
+    echo "🚫 push blocked by clawock system_check (critical failures above)"
+  else
+    echo "🚫 push blocked — clawock system_check did not complete (exit $RC)"
+    echo "   it produced no verdict, so nothing here is certified clean"
+  fi
   echo "   fix the issue, OR override with: git push --no-verify"
   exit 1
 fi
@@ -37,12 +48,20 @@ fi
 # unreconciled book. WARN (staleness etc.) does NOT block. Override: --no-verify.
 IRC=0
 python3 "$WS/scripts/data/preflight_integrity.py" >/tmp/clawock_integrity.out 2>&1 || IRC=$?
-if [ "$IRC" = "2" ]; then
+# Same rule as above: 0 = clean, 2 = ERROR findings, anything else = the checker
+# never reached a verdict and must not be read as a pass.
+if [ "$IRC" != "0" ]; then
   echo
-  echo "🚫 push blocked — portfolio.json fails a money-conservation check:"
-  grep -E 'ERROR|❌|🔴' /tmp/clawock_integrity.out | head -12
-  echo "   run:  bash scripts/data/reconcile.sh   (recompute cash + realized, re-check)"
-  echo "   then re-commit portfolio.json. Override (rare): git push --no-verify"
+  if [ "$IRC" = "2" ]; then
+    echo "🚫 push blocked — portfolio.json fails a money-conservation check:"
+    grep -E 'ERROR|❌|🔴' /tmp/clawock_integrity.out | head -12
+    echo "   run:  bash scripts/data/reconcile.sh   (recompute cash + realized, re-check)"
+    echo "   then re-commit portfolio.json. Override (rare): git push --no-verify"
+  else
+    echo "🚫 push blocked — preflight_integrity.py did not complete (exit $IRC):"
+    tail -12 /tmp/clawock_integrity.out
+    echo "   the book was not verified. Override (rare): git push --no-verify"
+  fi
   exit 1
 fi
 

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -185,10 +185,16 @@ SECRET_PATTERNS_LOOSE = (
     # "risk-on-with-trend-conflict" in a plan.json reads as sk- + 21 legal
     # chars and blocked every push on 2026-07-15. A real key's sk-/tp- always
     # starts a word (line start, quote, '=', whitespace).
-    r'\bsk-[a-zA-Z0-9_-]{20,}'
-    r'|\btp-[a-zA-Z0-9_-]{20,}'
-    r'|FINNHUB_API_KEY\s*=\s*[a-zA-Z0-9]+'
-    r'|POLYGON_API_KEY\s*=\s*[a-zA-Z0-9]+'
+    r'\bsk-[a-zA-Z0-9_-]{20,}'          # OpenAI-style, incl. MiniMax sk-cp-…
+    r'|\btp-[a-zA-Z0-9_-]{20,}'         # Xiaomi tp-…
+    # Vendors whose keys carry no distinguishing prefix (Alpha Vantage, Mistral)
+    # can only be caught by the variable they are assigned to. Bound to '=' so a
+    # bare mention of the variable name in prose or a `${{ secrets.X }}` reference
+    # does not fire.
+    r'|(FINNHUB|POLYGON|ALPHA_VANTAGE|MISTRAL|TAVILY|MINIMAX|XIAOMI)_API_KEY\s*=\s*[A-Za-z0-9_-]{8,}'
+    # Nostr accepts a bare 64-hex private key. Raw 64-hex is far too common
+    # (sha256 sums, lockfiles) to match on its own, so require the variable name.
+    r'|NOSTR_PRIVATE_KEY\s*=\s*[0-9a-fA-F]{64}'
 )
 
 # Structurally unambiguous credential markers. A PEM header or a vendor key with a
@@ -203,6 +209,10 @@ SECRET_PATTERNS_STRICT = (
     r'|\bgh[pousr]_[A-Za-z0-9]{36}\b'               # GitHub PAT
     r'|\bAKIA[0-9A-Z]{16}\b'                        # AWS access key id
     r'|\bxox[baprs]-[A-Za-z0-9-]{10,}'              # Slack token
+    r'|\btvly-[A-Za-z0-9_-]{20,}'                   # Tavily search key
+    # Nostr nsec (bech32: fixed prefix, fixed length, no b/i/o/1 in the charset).
+    # nostr_publish.js signs with this — a leak lets anyone post as Rick.
+    r'|\bnsec1[02-9ac-hj-np-z]{58}\b'
 )
 
 # Never scan the pattern definitions themselves, the ignore list, or the local

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -178,28 +178,79 @@ def check_peer_map_coverage(r):
         r.add('peer-map coverage', OK, 'all active holdings mapped')
 
 
-def check_no_leaked_secrets(r):
-    """Tracked files must not contain raw API keys."""
-    bad = []
+# Loose key-ish shapes. These can collide with ordinary prose/slugs, so they skip
+# *.md — see the 2026-07-15 note below.
+SECRET_PATTERNS_LOOSE = (
+    # \b or the prefix matches mid-word: the charset includes '-', so
+    # "risk-on-with-trend-conflict" in a plan.json reads as sk- + 21 legal
+    # chars and blocked every push on 2026-07-15. A real key's sk-/tp- always
+    # starts a word (line start, quote, '=', whitespace).
+    r'\bsk-[a-zA-Z0-9_-]{20,}'
+    r'|\btp-[a-zA-Z0-9_-]{20,}'
+    r'|FINNHUB_API_KEY\s*=\s*[a-zA-Z0-9]+'
+    r'|POLYGON_API_KEY\s*=\s*[a-zA-Z0-9]+'
+)
+
+# Structurally unambiguous credential markers. A PEM header or a vendor key with a
+# fixed prefix + fixed length cannot plausibly occur in prose, so these also scan
+# *.md — which is exactly where the memory-promotion cron writes, and where a
+# credential pasted into a session could otherwise land in the public repo.
+SECRET_PATTERNS_STRICT = (
+    r'-----BEGIN [A-Z ]*PRIVATE KEY-----'          # any PEM private key
+    r'|"type"\s*:\s*"service_account"'              # GCP service-account JSON
+    r'|\bAIza[0-9A-Za-z_-]{35}\b'                   # Google/Gemini API key
+    r'|\b[0-9]{8,10}:AA[A-Za-z0-9_-]{33}\b'         # Telegram bot token
+    r'|\bgh[pousr]_[A-Za-z0-9]{36}\b'               # GitHub PAT
+    r'|\bAKIA[0-9A-Z]{16}\b'                        # AWS access key id
+    r'|\bxox[baprs]-[A-Za-z0-9-]{10,}'              # Slack token
+)
+
+# Never scan the pattern definitions themselves, the ignore list, or the local
+# runtime config (openclaw.json legitimately holds live keys and is untracked).
+_SCAN_EXCLUDES = [':!.gitignore', ':!openclaw.json*', ':!.githooks/*',
+                  ':!scripts/system_check.py']
+
+
+def _grep_tracked(pattern, extra_excludes=()):
+    """Run `git grep -nE` over tracked files.
+
+    Returns (lines, failure). `failure` is None on a real answer; on anything that
+    stops the scan from running it carries a reason. The distinction matters: a
+    security check that swallows its own errors reports OK while scanning nothing.
+    That is not hypothetical — the strict tier's PEM pattern starts with '-', which
+    git parsed as an option flag until `-e` was added below, and the old blanket
+    `except` turned that into a silent pass.
+    """
     try:
-        out = subprocess.check_output(
-            ['git', '-C', str(WS), 'grep', '-nE',
-             # \b or the prefix matches mid-word: the charset includes '-', so
-             # "risk-on-with-trend-conflict" in a plan.json reads as sk- + 21 legal
-             # chars and blocked every push on 2026-07-15. A real key's sk-/tp- always
-             # starts a word (line start, quote, '=', whitespace).
-             r'(\bsk-[a-zA-Z0-9_-]{20,}|\btp-[a-zA-Z0-9_-]{20,}|FINNHUB_API_KEY\s*=\s*[a-zA-Z0-9]+|POLYGON_API_KEY\s*=\s*[a-zA-Z0-9]+)',
-             '--', ':!*.md', ':!.gitignore', ':!openclaw.json*', ':!.githooks/*', ':!scripts/system_check.py'],
-            text=True, timeout=10, stderr=subprocess.DEVNULL,
+        p = subprocess.run(
+            # -e is required: a pattern starting with '-' is otherwise read as a flag.
+            ['git', '-C', str(WS), 'grep', '-nE', '-e', pattern,
+             '--', *_SCAN_EXCLUDES, *extra_excludes],
+            capture_output=True, text=True, timeout=10,
         )
-        if out.strip():
-            bad = out.strip().splitlines()[:3]
-    except subprocess.CalledProcessError:
-        pass  # git grep returns 1 when no match — that's the OK case
-    except Exception:
-        pass
+    except Exception as e:  # timeout, git missing, …
+        return [], f'{type(e).__name__}: {e}'
+    if p.returncode == 0:
+        return p.stdout.strip().splitlines(), None
+    if p.returncode == 1:
+        return [], None  # git grep returns 1 when no match — that's the OK case
+    return [], f'git grep rc={p.returncode}: {p.stderr.strip()[:160]}'
+
+
+def check_no_leaked_secrets(r):
+    """Tracked files must not contain raw API keys or private credentials."""
+    loose, err_loose = _grep_tracked(SECRET_PATTERNS_LOOSE,
+                                     extra_excludes=(':!*.md',))
+    strict, err_strict = _grep_tracked(SECRET_PATTERNS_STRICT)
+    failures = [e for e in (err_loose, err_strict) if e]
+    bad = loose + strict
     if bad:
-        r.add('secret leak scan', CRITICAL, f'{len(bad)} potential leaks: {bad}')
+        r.add('secret leak scan', CRITICAL,
+              f'{len(bad)} potential leaks: {bad[:3]}')
+    elif failures:
+        # Fail closed: an unusable scanner must never read as "no secrets found".
+        r.add('secret leak scan', CRITICAL,
+              f'scan did not run, cannot certify: {failures}')
     else:
         r.add('secret leak scan', OK, 'no leaked secrets in tracked files')
 

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -178,23 +178,27 @@ def check_peer_map_coverage(r):
         r.add('peer-map coverage', OK, 'all active holdings mapped')
 
 
-# Loose key-ish shapes. These can collide with ordinary prose/slugs, so they skip
-# *.md — see the 2026-07-15 note below.
+# Loose key-ish shapes: vendor prefixes and named assignments.
 SECRET_PATTERNS_LOOSE = (
-    # \b or the prefix matches mid-word: the charset includes '-', so
-    # "risk-on-with-trend-conflict" in a plan.json reads as sk- + 21 legal
-    # chars and blocked every push on 2026-07-15. A real key's sk-/tp- always
-    # starts a word (line start, quote, '=', whitespace).
-    r'\bsk-[a-zA-Z0-9_-]{20,}'          # OpenAI-style, incl. MiniMax sk-cp-…
-    r'|\btp-[a-zA-Z0-9_-]{20,}'         # Xiaomi tp-…
+    # \b is not a usable left anchor here: the charset includes '-', which is
+    # itself a non-word char, so \b sits inside every hyphenated slug.
+    # "risk-on-with-trend-conflict" in a plan.json read as sk- + 21 legal chars
+    # and blocked every push on 2026-07-15, and a news URL slug
+    # (".../update-5-sk-hynix-plunges-after-…") does the same inside *.md.
+    # A real key's prefix always opens a token: line start, whitespace, quote,
+    # '=', ':' or an opening bracket. Anchoring there is what lets this tier
+    # scan *.md at all — see the 2026-07-22 note on check_no_leaked_secrets.
+    r'(^|\s|["\'=:,({[])(sk|tp)-[a-zA-Z0-9_-]{20,}'   # OpenAI/MiniMax sk-, Xiaomi tp-
     # Vendors whose keys carry no distinguishing prefix (Alpha Vantage, Mistral)
     # can only be caught by the variable they are assigned to. Bound to '=' so a
     # bare mention of the variable name in prose or a `${{ secrets.X }}` reference
-    # does not fire.
-    r'|(FINNHUB|POLYGON|ALPHA_VANTAGE|MISTRAL|TAVILY|MINIMAX|XIAOMI)_API_KEY\s*=\s*[A-Za-z0-9_-]{8,}'
+    # does not fire. The optional quote matters: FINNHUB_API_KEY="…" in a .env,
+    # a JS config or a YAML value is the common shape, and without it the value
+    # started at a quote and never matched.
+    r'|(FINNHUB|POLYGON|ALPHA_VANTAGE|MISTRAL|TAVILY|MINIMAX|XIAOMI)_API_KEY\s*=\s*["\']?[A-Za-z0-9_-]{8,}'
     # Nostr accepts a bare 64-hex private key. Raw 64-hex is far too common
     # (sha256 sums, lockfiles) to match on its own, so require the variable name.
-    r'|NOSTR_PRIVATE_KEY\s*=\s*[0-9a-fA-F]{64}'
+    r'|NOSTR_PRIVATE_KEY\s*=\s*["\']?[0-9a-fA-F]{64}'
 )
 
 # Structurally unambiguous credential markers. A PEM header or a vendor key with a
@@ -203,9 +207,15 @@ SECRET_PATTERNS_LOOSE = (
 # credential pasted into a session could otherwise land in the public repo.
 SECRET_PATTERNS_STRICT = (
     r'-----BEGIN [A-Z ]*PRIVATE KEY-----'          # any PEM private key
-    r'|"type"\s*:\s*"service_account"'              # GCP service-account JSON
-    r'|\bAIza[0-9A-Za-z_-]{35}\b'                   # Google/Gemini API key
-    r'|\b[0-9]{8,10}:AA[A-Za-z0-9_-]{33}\b'         # Telegram bot token
+    # GCP service-account JSON. Keyed on private_key_id, not on
+    # "type": "service_account": that field is plain metadata that any setup doc
+    # or fixture may legitimately quote, while a real key file always carries a
+    # 40-hex private_key_id (and a PEM the line above catches anyway).
+    r'|"private_key_id"\s*:\s*"[0-9a-f]{40}"'
+    # No trailing \b on the two below: their charsets include '-' and '_', so a
+    # key ending in one had no word boundary after it and silently never matched.
+    r'|\bAIza[0-9A-Za-z_-]{35}'                     # Google/Gemini API key
+    r'|\b[0-9]{8,10}:AA[A-Za-z0-9_-]{33}'           # Telegram bot token
     r'|\bgh[pousr]_[A-Za-z0-9]{36}\b'               # GitHub PAT
     r'|\bAKIA[0-9A-Z]{16}\b'                        # AWS access key id
     r'|\bxox[baprs]-[A-Za-z0-9-]{10,}'              # Slack token
@@ -215,14 +225,16 @@ SECRET_PATTERNS_STRICT = (
     r'|\bnsec1[02-9ac-hj-np-z]{58}\b'
 )
 
-# Never scan the pattern definitions themselves, the ignore list, or the local
-# runtime config (openclaw.json legitimately holds live keys and is untracked).
-_SCAN_EXCLUDES = [':!.gitignore', ':!openclaw.json*', ':!.githooks/*',
-                  ':!scripts/system_check.py']
+# Never scan the pattern definitions themselves or the ignore list. The local
+# runtime config (/root/.openclaw/openclaw.json) legitimately holds live keys but
+# is not in the repo, so git grep cannot see it anyway — it is deliberately NOT
+# excluded here: an exclusion would only ever take effect on the one day someone
+# accidentally commits that file, which is precisely the day it must be caught.
+_SCAN_EXCLUDES = [':!.gitignore', ':!.githooks/*', ':!scripts/system_check.py']
 
 
-def _grep_tracked(pattern, extra_excludes=()):
-    """Run `git grep -nE` over tracked files.
+def _grep_tracked(pattern, extra_excludes=(), rev=None):
+    """Run `git grep -nE` over tracked files, or over `rev` when given.
 
     Returns (lines, failure). `failure` is None on a real answer; on anything that
     stops the scan from running it carries a reason. The distinction matters: a
@@ -235,6 +247,7 @@ def _grep_tracked(pattern, extra_excludes=()):
         p = subprocess.run(
             # -e is required: a pattern starting with '-' is otherwise read as a flag.
             ['git', '-C', str(WS), 'grep', '-nE', '-e', pattern,
+             *([rev] if rev else []),
              '--', *_SCAN_EXCLUDES, *extra_excludes],
             capture_output=True, text=True, timeout=10,
         )
@@ -247,13 +260,46 @@ def _grep_tracked(pattern, extra_excludes=()):
     return [], f'git grep rc={p.returncode}: {p.stderr.strip()[:160]}'
 
 
+def _head_exists():
+    """False in a repo with no commits — nothing committed can leak there.
+
+    Also False if git itself is unusable; that path is not swallowed, because the
+    worktree scans below then fail on the same cause and report CRITICAL.
+    """
+    try:
+        p = subprocess.run(['git', '-C', str(WS), 'rev-parse', '--verify', '-q', 'HEAD'],
+                           capture_output=True, text=True, timeout=10)
+    except Exception:
+        return False
+    return p.returncode == 0
+
+
 def check_no_leaked_secrets(r):
-    """Tracked files must not contain raw API keys or private credentials."""
-    loose, err_loose = _grep_tracked(SECRET_PATTERNS_LOOSE,
-                                     extra_excludes=(':!*.md',))
-    strict, err_strict = _grep_tracked(SECRET_PATTERNS_STRICT)
-    failures = [e for e in (err_loose, err_strict) if e]
-    bad = loose + strict
+    """Tracked files must not contain raw API keys or private credentials.
+
+    Scans both tiers over *.md too (2026-07-22). Markdown was previously exempt
+    from the loose tier because of hyphen-slug collisions, but memory/*.md is the
+    dreaming-write path straight into a public repo — the single most likely place
+    for a pasted credential to land. The prefix anchor in SECRET_PATTERNS_LOOSE
+    replaces the exemption: it is what makes slugs and URLs stop matching.
+
+    Scans the working tree *and* HEAD. `git grep` without a revision only sees the
+    working tree, so a credential that was committed and then edited out locally
+    would be pushed while the scan reported clean.
+    """
+    # The two tiers now cover the same files, so one grep per revision does the
+    # work of two. They stay separate constants because they are reasoned about
+    # and tested separately — only the scan is merged.
+    pattern = f'{SECRET_PATTERNS_LOOSE}|{SECRET_PATTERNS_STRICT}'
+    revs = [None] + (['HEAD'] if _head_exists() else [])
+
+    bad, failures = [], []
+    for rev in revs:
+        lines, err = _grep_tracked(pattern, rev=rev)
+        bad += lines
+        if err:
+            failures.append(err)
+
     if bad:
         r.add('secret leak scan', CRITICAL,
               f'{len(bad)} potential leaks: {bad[:3]}')
@@ -262,7 +308,8 @@ def check_no_leaked_secrets(r):
         r.add('secret leak scan', CRITICAL,
               f'scan did not run, cannot certify: {failures}')
     else:
-        r.add('secret leak scan', OK, 'no leaked secrets in tracked files')
+        r.add('secret leak scan', OK,
+              'no leaked secrets in tracked files (worktree + HEAD)')
 
 
 def check_openclaw_doctor(r):

--- a/tests/test_secret_leak_scan.py
+++ b/tests/test_secret_leak_scan.py
@@ -4,12 +4,15 @@ The scan runs in two tiers on purpose:
 
 * LOOSE  — key-ish shapes (`sk-`, `tp-`, `<VENDOR>_API_KEY=…`) that can collide
   with ordinary slugs. On 2026-07-15 the string "risk-on-with-trend-conflict" in
-  a plan.json matched `sk-` + 21 legal chars and blocked every push, so this tier
-  skips `*.md`.
+  a plan.json matched `sk-` + 21 legal chars and blocked every push; the fix is a
+  prefix anchor, not a file exemption.
 * STRICT — structurally unambiguous credential markers (PEM headers, vendor keys
-  with fixed prefix + fixed length). These cannot occur in prose, so they must
-  also scan `*.md` — that is where the memory-promotion cron writes, and it is a
-  live path from a credential pasted into a session into the public repo.
+  with fixed prefix + fixed length).
+
+Both tiers cover `*.md` — that is where the memory-promotion cron writes, and it
+is a live path from a credential pasted into a session into the public repo. Both
+also run against HEAD as well as the working tree, because a push carries commits,
+not the checkout.
 
 Most tests drive the scan against a throwaway git repo rather than mocking the
 internals, so a refactor that preserves behaviour stays green while any of the
@@ -46,7 +49,8 @@ def _pem() -> str:
 
 
 def _sa_json() -> str:
-    return '{"type"' + ': ' + '"service_account", "project_id": "x"}'
+    # keyed on private_key_id (40 hex), the field only a real key file carries
+    return '{"private_key_id"' + ': ' + '"' + "9f" * 20 + '"}'
 
 
 def _google_key() -> str:
@@ -153,8 +157,8 @@ def test_prose_slug_in_markdown_does_not_trip_the_scan(sc, monkeypatch, tmp_path
     assert _scan(sc, monkeypatch, repo).level == sc.OK
 
 
-def test_loose_tier_still_covers_non_markdown(sc, monkeypatch, tmp_path):
-    """Skipping *.md must not have quietly disarmed the sk-/tp- tier elsewhere."""
+def test_loose_tier_covers_non_markdown(sc, monkeypatch, tmp_path):
+    """The sk-/tp- tier must stay armed outside markdown too."""
     repo = _make_repo(tmp_path, {"config/keys.json": f'{{"k": "{_sk_key()}"}}\n'})
     rec = _scan(sc, monkeypatch, repo)
     assert rec.level == sc.CRITICAL
@@ -171,8 +175,7 @@ def test_this_repo_is_clean(sc):
     lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
     assert failure is None, f"strict scan failed to run: {failure}"
     assert lines == []
-    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE,
-                                      extra_excludes=(":!*.md",))
+    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE)
     assert failure is None, f"loose scan failed to run: {failure}"
     assert lines == []
 
@@ -238,6 +241,10 @@ def test_strict_patterns_catch_real_credential_shapes(sc, make):
         "AIzaSy is a prefix people mention in blog posts",
         "set TAVILY_API_KEY in the environment before running",  # name, no value
         "workflow passes TAVILY_API_KEY: ${{ secrets.TAVILY }}",  # ':' not '='
+        # a news URL slug: "-sk-" opens no token, and *.md is full of these
+        "see https://x.com/news/update-5-sk-hynix-plunges-after-nasdaq-debut-today",
+        # plain GCP metadata any setup doc may quote; not a credential by itself
+        'the fixture is {"type": "service_account", "project_id": "demo"}',
     ],
 )
 def test_patterns_do_not_fire_on_prose_or_references(sc, prose):
@@ -264,8 +271,97 @@ def test_bare_64_hex_alone_is_not_flagged(sc):
     assert not re.search(sc.SECRET_PATTERNS_LOOSE, "sha256: " + "a1b2c3d4" * 8)
 
 
-def test_config_and_self_are_always_excluded(sc):
-    """openclaw.json holds live keys; this scanner holds the patterns themselves."""
-    excludes = set(sc._SCAN_EXCLUDES)
-    assert ":!openclaw.json*" in excludes
-    assert ":!scripts/system_check.py" in excludes
+def test_scanner_does_not_exempt_itself_into_uselessness(sc, monkeypatch, tmp_path):
+    """openclaw.json is untracked in practice, so excluding it only ever takes
+    effect on the day it is committed by accident — exactly when it must fire."""
+    repo = _make_repo(tmp_path, {"openclaw.json": f'{{"apiKey": "{_sk_key()}"}}\n'})
+    rec = _scan(sc, monkeypatch, repo)
+    assert rec.level == sc.CRITICAL
+    assert "openclaw.json" in rec.msg
+
+
+# --------------------------------------------------------------------------
+# behaviour: markdown, quoting, and what is actually being pushed
+# --------------------------------------------------------------------------
+def _commit(repo: Path) -> None:
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "-q", "-m", "x"], cwd=repo, check=True,
+                   env={**__import__("os").environ, **env})
+
+
+def test_prefixed_key_in_markdown_is_caught(sc, monkeypatch, tmp_path):
+    """The loose tier used to skip *.md wholesale, so a pasted sk- key in the
+    dreaming-write path reached the public repo with the scan reporting clean."""
+    repo = _make_repo(tmp_path, {"memory/2026-07-22.md": f"note\nkey: {_sk_key()}\n"})
+    rec = _scan(sc, monkeypatch, repo)
+    assert rec.level == sc.CRITICAL
+    assert "memory/2026-07-22.md" in rec.msg
+
+
+def test_url_slug_in_markdown_stays_clean(sc, monkeypatch, tmp_path):
+    """Real content from memory/2026-07-15-pre-open.md: a news URL containing
+    '-sk-hynix-plunges-after-…'. Scanning *.md is only viable if this stays OK."""
+    repo = _make_repo(tmp_path, {"memory/n.md": (
+        "SK Hynix 弱利润预估（[Reuters](https://wealthinsights.metrobank.com.ph/"
+        "news/update-5-sk-hynix-plunges-after-nasdaq-debut-as-memory-cools)）\n")})
+    assert _scan(sc, monkeypatch, repo).level == sc.OK
+
+
+def test_quoted_assignment_is_caught(sc, monkeypatch, tmp_path):
+    """`KEY="value"` is the ordinary shape in .env/JS/YAML; binding the value
+    straight to '=' meant the quote ended the match before it began."""
+    repo = _make_repo(tmp_path, {".env.example": 'FINNHUB_API_KEY="' + "d1" * 12 + '"\n'})
+    assert _scan(sc, monkeypatch, repo).level == sc.CRITICAL
+
+
+def test_secret_committed_but_removed_from_worktree_is_caught(sc, monkeypatch, tmp_path):
+    """`git grep` without a revision reads the checkout, but a push carries the
+    commits. Editing the key out locally must not launder the commit that has it."""
+    repo = _make_repo(tmp_path, {"c.py": f'KEY = "{_sk_key()}"\n'})
+    _commit(repo)
+    (repo / "c.py").write_text('KEY = os.environ["K"]\n', encoding="utf-8")
+    rec = _scan(sc, monkeypatch, repo)
+    assert rec.level == sc.CRITICAL, "HEAD still carries the credential"
+    assert "HEAD" in rec.msg
+
+
+def test_clean_committed_repo_reports_ok(sc, monkeypatch, tmp_path):
+    """Scanning HEAD as well must not turn every ordinary repo red."""
+    repo = _make_repo(tmp_path, {"README.md": "# hello\n", "a.py": "x = 1\n"})
+    _commit(repo)
+    assert _scan(sc, monkeypatch, repo).level == sc.OK
+
+
+# --------------------------------------------------------------------------
+# behaviour: the hook that consumes the scan
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "rc,blocks",
+    [(0, False), (2, False), (1, True), (127, True), (137, True)],
+    ids=["ok", "warnings", "critical", "interpreter-missing", "killed"],
+)
+def test_pre_push_hook_blocks_unless_the_checker_gave_a_verdict(tmp_path, rc, blocks):
+    """RC=0/2 are verdicts (clean / warnings only). Anything else means the check
+    never ran; treating that as a pass is the fail-open this suite exists for."""
+    import os
+    repo = tmp_path / "r"
+    (repo / "scripts" / "data").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "scripts" / "system_check.py").write_text("")
+    (repo / "scripts" / "data" / "preflight_integrity.py").write_text("")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # first invocation (system_check) exits rc; the integrity call after it exits 0
+    stub = bin_dir / "python3"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$1" in *system_check.py) exit %d;; *) exit 0;; esac\n' % rc
+    )
+    stub.chmod(0o755)
+    p = subprocess.run(
+        ["bash", str(ROOT / ".githooks" / "pre-push")],
+        cwd=repo, capture_output=True, text=True,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+    )
+    assert (p.returncode != 0) is blocks, p.stdout + p.stderr

--- a/tests/test_secret_leak_scan.py
+++ b/tests/test_secret_leak_scan.py
@@ -2,20 +2,26 @@
 
 The scan runs in two tiers on purpose:
 
-* LOOSE  — key-ish shapes (`sk-`, `tp-`, …) that can collide with ordinary slugs.
-  On 2026-07-15 the string "risk-on-with-trend-conflict" in a plan.json matched
-  `sk-` + 21 legal chars and blocked every push, so this tier skips `*.md`.
+* LOOSE  — key-ish shapes (`sk-`, `tp-`, `<VENDOR>_API_KEY=…`) that can collide
+  with ordinary slugs. On 2026-07-15 the string "risk-on-with-trend-conflict" in
+  a plan.json matched `sk-` + 21 legal chars and blocked every push, so this tier
+  skips `*.md`.
 * STRICT — structurally unambiguous credential markers (PEM headers, vendor keys
   with fixed prefix + fixed length). These cannot occur in prose, so they must
   also scan `*.md` — that is where the memory-promotion cron writes, and it is a
   live path from a credential pasted into a session into the public repo.
 
-Credential literals below are assembled from fragments so this test file does not
-itself contain a matching string (the scan would flag its own fixtures).
+Most tests drive the scan against a throwaway git repo rather than mocking the
+internals, so a refactor that preserves behaviour stays green while any of the
+three defects this suite was written for turns it red.
+
+Credential literals are assembled from fragments so this file does not itself
+contain a matching string — the scan would otherwise flag its own fixtures.
 """
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -32,6 +38,9 @@ def sc():
     return pytest.importorskip("system_check")
 
 
+# --------------------------------------------------------------------------
+# credential fixtures, built so the literal never appears in this file
+# --------------------------------------------------------------------------
 def _pem() -> str:
     return "-----BEGIN" + " PRIVATE KEY" + "-----"
 
@@ -60,6 +69,19 @@ def _slack() -> str:
     return "xox" + "b-" + "1234567890-abcdef"
 
 
+def _tavily() -> str:
+    return "tvly" + "-" + "f" * 24
+
+
+def _nsec() -> str:
+    # bech32 payload: 58 chars from the charset (no b/i/o/1)
+    return "nsec" + "1" + ("qwertyu23456789acdefghjklmnpqrs" * 2)[:58]
+
+
+def _sk_key() -> str:
+    return "sk-" + "a" * 24
+
+
 STRICT_POSITIVES = [
     pytest.param(_pem, id="pem-private-key"),
     pytest.param(_sa_json, id="gcp-service-account-json"),
@@ -68,9 +90,137 @@ STRICT_POSITIVES = [
     pytest.param(_github_pat, id="github-pat"),
     pytest.param(_aws, id="aws-access-key-id"),
     pytest.param(_slack, id="slack-token"),
+    pytest.param(_tavily, id="tavily-key"),
+    pytest.param(_nsec, id="nostr-nsec"),
 ]
 
 
+# --------------------------------------------------------------------------
+# helpers: run the real check against a throwaway repo
+# --------------------------------------------------------------------------
+class _Rec:
+    def __init__(self):
+        self.entries = []
+
+    def add(self, name, level, msg):
+        self.entries.append((level, str(msg)))
+
+    @property
+    def level(self):
+        return self.entries[0][0]
+
+    @property
+    def msg(self):
+        return self.entries[0][1]
+
+
+def _make_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    for name, body in files.items():
+        p = repo / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    return repo
+
+
+def _scan(sc, monkeypatch, repo: Path) -> _Rec:
+    monkeypatch.setattr(sc, "WS", repo)
+    rec = _Rec()
+    sc.check_no_leaked_secrets(rec)
+    return rec
+
+
+# --------------------------------------------------------------------------
+# behaviour: what the scan does to a repo
+# --------------------------------------------------------------------------
+def test_credential_in_markdown_is_caught(sc, monkeypatch, tmp_path):
+    """memory/*.md is the public-repo leak path — markdown must be covered."""
+    repo = _make_repo(tmp_path, {"memory/2026-07-22.md": f"note\nkey: {_pem()}\n"})
+    rec = _scan(sc, monkeypatch, repo)
+    assert rec.level == sc.CRITICAL
+    assert "memory/2026-07-22.md" in rec.msg, "report must name the offending file"
+
+
+def test_prose_slug_in_markdown_does_not_trip_the_scan(sc, monkeypatch, tmp_path):
+    """The 2026-07-15 false positive: an sk--shaped slug blocked every push."""
+    repo = _make_repo(
+        tmp_path,
+        {"memory/note.md": "driven_by: risk-on-with-trend-conflict\n港股开盘报告掉链\n"},
+    )
+    assert _scan(sc, monkeypatch, repo).level == sc.OK
+
+
+def test_loose_tier_still_covers_non_markdown(sc, monkeypatch, tmp_path):
+    """Skipping *.md must not have quietly disarmed the sk-/tp- tier elsewhere."""
+    repo = _make_repo(tmp_path, {"config/keys.json": f'{{"k": "{_sk_key()}"}}\n'})
+    rec = _scan(sc, monkeypatch, repo)
+    assert rec.level == sc.CRITICAL
+    assert "config/keys.json" in rec.msg
+
+
+def test_clean_repo_reports_ok(sc, monkeypatch, tmp_path):
+    repo = _make_repo(tmp_path, {"README.md": "# hello\n", "a.py": "x = 1\n"})
+    assert _scan(sc, monkeypatch, repo).level == sc.OK
+
+
+def test_this_repo_is_clean(sc):
+    """The live tree must stay clean, and the scan must actually run on it."""
+    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
+    assert failure is None, f"strict scan failed to run: {failure}"
+    assert lines == []
+    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE,
+                                      extra_excludes=(":!*.md",))
+    assert failure is None, f"loose scan failed to run: {failure}"
+    assert lines == []
+
+
+# --------------------------------------------------------------------------
+# behaviour: fail closed when the scan cannot run
+# --------------------------------------------------------------------------
+def test_non_git_directory_reports_critical_not_ok(sc, monkeypatch, tmp_path):
+    """A real rc>1 path: git grep outside a repository. Must not read as clean."""
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    rec = _scan(sc, monkeypatch, plain)
+    assert rec.level == sc.CRITICAL
+    assert "cannot certify" in rec.msg
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.TimeoutExpired(cmd="git", timeout=10),
+        FileNotFoundError("git"),
+    ],
+    ids=["timeout", "git-missing"],
+)
+def test_subprocess_failures_report_critical(sc, monkeypatch, exc):
+    def boom(*a, **k):
+        raise exc
+
+    monkeypatch.setattr(sc.subprocess, "run", boom)
+    rec = _Rec()
+    sc.check_no_leaked_secrets(rec)
+    assert rec.level == sc.CRITICAL
+    assert "cannot certify" in rec.msg
+
+
+def test_grep_passes_pattern_after_dash_e(sc, monkeypatch, tmp_path):
+    """The PEM pattern starts with '-'; without -e git reads it as a flag (rc=129).
+
+    Asserted through behaviour: a PEM in a fresh repo must be found. If the flag
+    were dropped, git would error out instead of matching.
+    """
+    repo = _make_repo(tmp_path, {"k.md": _pem() + "\n"})
+    assert _scan(sc, monkeypatch, repo).level == sc.CRITICAL
+
+
+# --------------------------------------------------------------------------
+# pattern-level unit checks (cheap, precise)
+# --------------------------------------------------------------------------
 @pytest.mark.parametrize("make", STRICT_POSITIVES)
 def test_strict_patterns_catch_real_credential_shapes(sc, make):
     assert re.search(sc.SECRET_PATTERNS_STRICT, make()), (
@@ -82,107 +232,36 @@ def test_strict_patterns_catch_real_credential_shapes(sc, make):
     "prose",
     [
         "the plan is risk-on-with-trend-conflict for hstech",
-        "we rotated the service account yesterday",  # words, not JSON shape
-        "BEGIN PRIVATE KEY is discussed in the runbook",  # no PEM dashes
+        "we rotated the service account yesterday",
+        "BEGIN PRIVATE KEY is discussed in the runbook",
         "港股开盘报告掉链到 codex 之后 bash 炸了",
-        "AIzaSy is a prefix people mention in blog posts",  # too short
+        "AIzaSy is a prefix people mention in blog posts",
+        "set TAVILY_API_KEY in the environment before running",  # name, no value
+        "workflow passes TAVILY_API_KEY: ${{ secrets.TAVILY }}",  # ':' not '='
     ],
 )
-def test_strict_patterns_do_not_fire_on_prose(sc, prose):
-    assert not re.search(sc.SECRET_PATTERNS_STRICT, prose), (
-        "strict tier must not fire on ordinary prose — it scans *.md"
-    )
+def test_patterns_do_not_fire_on_prose_or_references(sc, prose):
+    assert not re.search(sc.SECRET_PATTERNS_STRICT, prose)
+    assert not re.search(sc.SECRET_PATTERNS_LOOSE, prose)
 
 
-def test_loose_tier_still_catches_prefixed_api_keys(sc):
-    assert re.search(sc.SECRET_PATTERNS_LOOSE, "key = " + "sk-" + "a" * 24)
-    assert re.search(sc.SECRET_PATTERNS_LOOSE, "key = " + "tp-" + "b" * 24)
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "ALPHA_VANTAGE_API_KEY=" + "Z" * 16,
+        "MISTRAL_API_KEY = " + "2xLUzf" + "q" * 26,
+        "NOSTR_PRIVATE_KEY=" + "a1b2c3d4" * 8,
+    ],
+    ids=["alpha-vantage", "mistral", "nostr-hex"],
+)
+def test_prefixless_vendor_keys_are_caught_by_variable_name(sc, assignment):
+    """These vendors' keys have no distinguishing prefix — only the name binds them."""
+    assert re.search(sc.SECRET_PATTERNS_LOOSE, assignment)
 
 
-def test_loose_tier_keeps_the_2026_07_15_false_positive_fix(sc):
-    """A hyphenated slug must not read as an sk- key (it blocked every push once)."""
-    assert not re.search(
-        sc.SECRET_PATTERNS_LOOSE, "driven_by: risk-on-with-trend-conflict"
-    )
-
-
-def test_strict_tier_scans_markdown_but_loose_tier_does_not(sc, monkeypatch):
-    """The tier split is the whole point: regressing it silently un-covers memory/*.md."""
-    calls = []
-
-    def fake_grep(pattern, extra_excludes=()):
-        calls.append((pattern, tuple(extra_excludes)))
-        return [], None
-
-    monkeypatch.setattr(sc, "_grep_tracked", fake_grep)
-
-    class _Rec:
-        def add(self, *a, **k):
-            pass
-
-    sc.check_no_leaked_secrets(_Rec())
-
-    assert len(calls) == 2, "expected one loose scan and one strict scan"
-    by_pattern = dict(calls)
-    assert ":!*.md" in by_pattern[sc.SECRET_PATTERNS_LOOSE], (
-        "loose tier must keep skipping *.md (2026-07-15 false-positive fix)"
-    )
-    assert ":!*.md" not in by_pattern[sc.SECRET_PATTERNS_STRICT], (
-        "strict tier must scan *.md — memory/*.md is the public-repo leak path"
-    )
-
-
-def test_scan_reports_critical_when_it_cannot_run(sc, monkeypatch):
-    """Fail closed. A scanner that swallows its own errors certifies nothing.
-
-    The old implementation caught every exception and returned "no matches", so a
-    pattern git refused to compile — or git being absent — read as a clean tree.
-    """
-    monkeypatch.setattr(sc, "_grep_tracked",
-                        lambda *a, **k: ([], "git grep rc=129: unknown option"))
-    seen = []
-
-    class _Rec:
-        def add(self, name, level, msg):
-            seen.append((level, msg))
-
-    sc.check_no_leaked_secrets(_Rec())
-    assert seen and seen[0][0] == sc.CRITICAL, "a broken scan must not report OK"
-    assert "cannot certify" in seen[0][1]
-
-
-def test_grep_passes_pattern_after_dash_e(sc):
-    """The PEM pattern starts with '-'; without -e git reads it as a flag."""
-    recorded = {}
-
-    class _P:
-        returncode = 1
-        stdout = ""
-        stderr = ""
-
-    def fake_run(cmd, **kw):
-        recorded["cmd"] = cmd
-        return _P()
-
-    monkeypatch_run = pytest.MonkeyPatch()
-    monkeypatch_run.setattr(sc.subprocess, "run", fake_run)
-    try:
-        sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
-    finally:
-        monkeypatch_run.undo()
-
-    cmd = recorded["cmd"]
-    assert "-e" in cmd, "pattern must be introduced with -e"
-    assert cmd[cmd.index("-e") + 1] == sc.SECRET_PATTERNS_STRICT
-
-
-def test_real_scan_runs_against_this_repo(sc):
-    """End-to-end: the scan must actually execute, not silently no-op."""
-    _, failure = sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
-    assert failure is None, f"strict scan failed to run: {failure}"
-    _, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE,
-                                  extra_excludes=(":!*.md",))
-    assert failure is None, f"loose scan failed to run: {failure}"
+def test_bare_64_hex_alone_is_not_flagged(sc):
+    """sha256 sums and lockfile hashes are 64-hex; only the Nostr variable counts."""
+    assert not re.search(sc.SECRET_PATTERNS_LOOSE, "sha256: " + "a1b2c3d4" * 8)
 
 
 def test_config_and_self_are_always_excluded(sc):

--- a/tests/test_secret_leak_scan.py
+++ b/tests/test_secret_leak_scan.py
@@ -1,0 +1,192 @@
+"""Guards for the pre-push secret scan in scripts/system_check.py.
+
+The scan runs in two tiers on purpose:
+
+* LOOSE  — key-ish shapes (`sk-`, `tp-`, …) that can collide with ordinary slugs.
+  On 2026-07-15 the string "risk-on-with-trend-conflict" in a plan.json matched
+  `sk-` + 21 legal chars and blocked every push, so this tier skips `*.md`.
+* STRICT — structurally unambiguous credential markers (PEM headers, vendor keys
+  with fixed prefix + fixed length). These cannot occur in prose, so they must
+  also scan `*.md` — that is where the memory-promotion cron writes, and it is a
+  live path from a credential pasted into a session into the public repo.
+
+Credential literals below are assembled from fragments so this test file does not
+itself contain a matching string (the scan would flag its own fixtures).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = str(ROOT / "scripts")
+
+
+@pytest.fixture(scope="module")
+def sc():
+    if SCRIPTS not in sys.path:
+        sys.path.insert(0, SCRIPTS)
+    return pytest.importorskip("system_check")
+
+
+def _pem() -> str:
+    return "-----BEGIN" + " PRIVATE KEY" + "-----"
+
+
+def _sa_json() -> str:
+    return '{"type"' + ': ' + '"service_account", "project_id": "x"}'
+
+
+def _google_key() -> str:
+    return "AIza" + "b" * 35
+
+
+def _telegram() -> str:
+    return "8832401234" + ":AA" + "c" * 33
+
+
+def _github_pat() -> str:
+    return "gh" + "p_" + "d" * 36
+
+
+def _aws() -> str:
+    return "AKIA" + "E" * 16
+
+
+def _slack() -> str:
+    return "xox" + "b-" + "1234567890-abcdef"
+
+
+STRICT_POSITIVES = [
+    pytest.param(_pem, id="pem-private-key"),
+    pytest.param(_sa_json, id="gcp-service-account-json"),
+    pytest.param(_google_key, id="google-api-key"),
+    pytest.param(_telegram, id="telegram-bot-token"),
+    pytest.param(_github_pat, id="github-pat"),
+    pytest.param(_aws, id="aws-access-key-id"),
+    pytest.param(_slack, id="slack-token"),
+]
+
+
+@pytest.mark.parametrize("make", STRICT_POSITIVES)
+def test_strict_patterns_catch_real_credential_shapes(sc, make):
+    assert re.search(sc.SECRET_PATTERNS_STRICT, make()), (
+        "strict tier must flag this credential shape"
+    )
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "the plan is risk-on-with-trend-conflict for hstech",
+        "we rotated the service account yesterday",  # words, not JSON shape
+        "BEGIN PRIVATE KEY is discussed in the runbook",  # no PEM dashes
+        "港股开盘报告掉链到 codex 之后 bash 炸了",
+        "AIzaSy is a prefix people mention in blog posts",  # too short
+    ],
+)
+def test_strict_patterns_do_not_fire_on_prose(sc, prose):
+    assert not re.search(sc.SECRET_PATTERNS_STRICT, prose), (
+        "strict tier must not fire on ordinary prose — it scans *.md"
+    )
+
+
+def test_loose_tier_still_catches_prefixed_api_keys(sc):
+    assert re.search(sc.SECRET_PATTERNS_LOOSE, "key = " + "sk-" + "a" * 24)
+    assert re.search(sc.SECRET_PATTERNS_LOOSE, "key = " + "tp-" + "b" * 24)
+
+
+def test_loose_tier_keeps_the_2026_07_15_false_positive_fix(sc):
+    """A hyphenated slug must not read as an sk- key (it blocked every push once)."""
+    assert not re.search(
+        sc.SECRET_PATTERNS_LOOSE, "driven_by: risk-on-with-trend-conflict"
+    )
+
+
+def test_strict_tier_scans_markdown_but_loose_tier_does_not(sc, monkeypatch):
+    """The tier split is the whole point: regressing it silently un-covers memory/*.md."""
+    calls = []
+
+    def fake_grep(pattern, extra_excludes=()):
+        calls.append((pattern, tuple(extra_excludes)))
+        return [], None
+
+    monkeypatch.setattr(sc, "_grep_tracked", fake_grep)
+
+    class _Rec:
+        def add(self, *a, **k):
+            pass
+
+    sc.check_no_leaked_secrets(_Rec())
+
+    assert len(calls) == 2, "expected one loose scan and one strict scan"
+    by_pattern = dict(calls)
+    assert ":!*.md" in by_pattern[sc.SECRET_PATTERNS_LOOSE], (
+        "loose tier must keep skipping *.md (2026-07-15 false-positive fix)"
+    )
+    assert ":!*.md" not in by_pattern[sc.SECRET_PATTERNS_STRICT], (
+        "strict tier must scan *.md — memory/*.md is the public-repo leak path"
+    )
+
+
+def test_scan_reports_critical_when_it_cannot_run(sc, monkeypatch):
+    """Fail closed. A scanner that swallows its own errors certifies nothing.
+
+    The old implementation caught every exception and returned "no matches", so a
+    pattern git refused to compile — or git being absent — read as a clean tree.
+    """
+    monkeypatch.setattr(sc, "_grep_tracked",
+                        lambda *a, **k: ([], "git grep rc=129: unknown option"))
+    seen = []
+
+    class _Rec:
+        def add(self, name, level, msg):
+            seen.append((level, msg))
+
+    sc.check_no_leaked_secrets(_Rec())
+    assert seen and seen[0][0] == sc.CRITICAL, "a broken scan must not report OK"
+    assert "cannot certify" in seen[0][1]
+
+
+def test_grep_passes_pattern_after_dash_e(sc):
+    """The PEM pattern starts with '-'; without -e git reads it as a flag."""
+    recorded = {}
+
+    class _P:
+        returncode = 1
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kw):
+        recorded["cmd"] = cmd
+        return _P()
+
+    monkeypatch_run = pytest.MonkeyPatch()
+    monkeypatch_run.setattr(sc.subprocess, "run", fake_run)
+    try:
+        sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
+    finally:
+        monkeypatch_run.undo()
+
+    cmd = recorded["cmd"]
+    assert "-e" in cmd, "pattern must be introduced with -e"
+    assert cmd[cmd.index("-e") + 1] == sc.SECRET_PATTERNS_STRICT
+
+
+def test_real_scan_runs_against_this_repo(sc):
+    """End-to-end: the scan must actually execute, not silently no-op."""
+    _, failure = sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
+    assert failure is None, f"strict scan failed to run: {failure}"
+    _, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE,
+                                  extra_excludes=(":!*.md",))
+    assert failure is None, f"loose scan failed to run: {failure}"
+
+
+def test_config_and_self_are_always_excluded(sc):
+    """openclaw.json holds live keys; this scanner holds the patterns themselves."""
+    excludes = set(sc._SCAN_EXCLUDES)
+    assert ":!openclaw.json*" in excludes
+    assert ":!scripts/system_check.py" in excludes


### PR DESCRIPTION
## 起因

kcn 在会话里贴了一把 GCP service-account 私钥。判断「CI 有 secret scan 兜底」时去核对实现，发现这把钥匙**能一路进公开仓库不被拦**。

## 三个独立缺陷，任一单独存在就足以漏

1. **扫描器出错 = 静默放行。** `_grep_tracked` 用 `except Exception: pass` 吞掉一切，返回「没匹配」。扫描根本没跑，报告却是 OK。
2. **正则被当成命令行 flag。** PEM 正则以 `-` 开头，`git grep` 解析成未知选项、`rc=129` → 正好掉进缺陷 1。加 `-e` 修复。
3. **模式覆盖面只有 `sk-`/`tp-`，且 `*.md` 被整体排除。** PEM 私钥、GCP service-account JSON、Google/Gemini key、Telegram bot token、GitHub PAT、AWS key id、Slack token 全部放行。而 `memory/*.md` 正是 memory-promotion cron 的写入目标，且发布到公开 Pages —— 最该覆盖的地方恰好被排除。

## 改法

正则分两档：

- **LOOSE**（`sk-`/`tp-`/两个变量名）继续跳过 `*.md`。这一档会跟中文正文和 slug 冲突 —— 2026-07-15 `risk-on-with-trend-conflict` 匹配上 `sk-` + 21 字符，卡死了所有 push，那个排除是有原因的，保留。
- **STRICT**（PEM 头、`"type": "service_account"`、固定前缀+固定长度的厂商 key）结构上不可能出现在散文里，因此**也扫 markdown**。

外加 fail-closed：扫描跑不起来时报 CRITICAL 而不是 OK。

## 验证

- 把真实 service-account JSON 放成 `memory/leak-test.md` 并 stage → 扫描 **CRITICAL，2 命中**；改前同样输入报 OK
- 干净树 → OK
- 新正则扫今天全部 tracked 文件（含 `.md`）→ **零命中，无误杀**
- 全量 `pytest tests/` → 414 passed, 5 xfailed
- **每条新测试都做了变异验证**：还原任一缺陷（去掉 `-e` / 去掉 fail-closed 分支 / strict 也排除 `*.md` / 删 PEM 正则 / loose 去掉 `\b`）都会让测试变红，不是装饰性测试

## 不在本 PR 范围

那把已泄露的 key 是否轮换由 kcn 决定，他已评估过风险并选择不轮换。本 PR 只修扫描器本身，跟那把 key 的处置无关。