### PR TITLE
harness: intraday postflight 改 --text-file，空/旧输入单独判 input_error

### DIFF
--- a/TOOLS_SCRIPTS.md
+++ b/TOOLS_SCRIPTS.md
@@ -43,7 +43,7 @@ title: clawock · scripts 详细参考
 
 **Mode 7 intraday**（HK + US 盘中盯盘 — 3 个 cron job 共享同一套脚本；季节化 slot 数和精确时间只看生成调度表，隔夜始终最晚 02:30 HKT）
 - **`scripts/harness/intraday_preflight.py --market {hk|us}`**：跑 analyze_*.py + 异动检测 + `should_alert` 决策；输出 `memory/.tmp/intraday-context-{market}-latest.json`
-- **`scripts/harness/intraday_postflight.py --market {hk|us}`**：校验 ▎我的看法 / 长度 / should_alert 触发时报告必须提异动票；不提交 `portfolio.json`，dashboard 仅在语义变化时 commit + push；无论有无 dashboard diff 都更新本地 slot heartbeat，交 single publisher 发布。
+- **`scripts/harness/intraday_postflight.py --market {hk|us} --text-file memory/.tmp/intraday-report-{hk|us}.md`**（**先写文件再调用，禁 heredoc/`<<<`**；空输入/超 20 分钟的旧文件判 `status: input_error` 并拒投）：校验 ▎我的看法 / 长度 / should_alert 触发时报告必须提异动票；不提交 `portfolio.json`，dashboard 仅在语义变化时 commit + push；无论有无 dashboard diff 都更新本地 slot heartbeat，交 single publisher 发布。
 
 **共通设计点**：
 - preflight 输出 `raw_wechat_block` 字段，LLM **必须 verbatim 拷贝**（不改时间戳/数字），postflight 用首行匹配验证

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -49,6 +49,8 @@
         "skills/{skill}/SKILL.md",
         "intraday_preflight.py --market {market}",
         "intraday_postflight.py --market {market}",
+        "--text-file",
+        "intraday-report-{market}.md",
         "intraday-insights-",
         "目标 ≤ 1200 字",
         ">2000 字 warn",
@@ -63,7 +65,8 @@
         "≤800",
         "≤ 600",
         "≤600",
-        "唯一发送路径"
+        "唯一发送路径",
+        "<<<"
       ]
     },
     "brief": {

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -100,7 +100,16 @@ def read_report_text(market, text_file):
 
 def input_error(market, err):
     """Exit path for empty/stale/missing input: loud, single-cause, still non-zero."""
-    cron_heartbeat.record(market, 'postflight_failed', failure_stage='input')
+    # Attribute the failure to the slot the preflight context was built for, not to
+    # whatever slot the wall clock happens to be in now. A run that starts at 10:00
+    # and hits empty input at 10:31 would otherwise stamp a phantom 10:30 failure,
+    # and the retry that succeeds would mark 10:00 completed — leaving a slot in the
+    # health ledger that never actually failed. Context is best-effort here: an
+    # input error must still be recorded when the context is missing too.
+    ctx, _ = load_context(market)
+    hb = (ctx or {}).get('heartbeat') or {}
+    cron_heartbeat.record(market, 'postflight_failed', failure_stage='input',
+                          job_name=hb.get('job'), slot=hb.get('slot'))
     print(f'error: {err}', file=sys.stderr)
     result = {
         'status':        'input_error',

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -4,7 +4,16 @@ intraday_postflight.py — Mode 7 (intraday) harness postflight.
 
 Validates the LLM-generated intraday check-in.
 
-Usage: pipe brief text via stdin, or --text-file PATH.
+Usage: `--text-file PATH` (canonical — write the report to a file first, then call
+this). Stdin is still accepted for manual runs, but the cron/SKILL path must use
+--text-file: heredoc/`<<<` plumbing has repeatedly failed (2026-07-23 10:00 HK:
+the model called postflight with no stdin at all, the empty read produced four
+misleading content issues, and the run was flagged error even though the retry
+delivered fine).
+
+Empty or stale input is reported as `status: input_error` — a plumbing failure,
+distinct from `fail` (the report itself is bad). It still exits non-zero: this is
+the delivery gate, and a false green is worse than a false red.
 
 Validates:
   1. ▎我的看法 段必须存在 + 段内容 ≥ 60 字（防敷衍 1 句话）
@@ -46,6 +55,11 @@ sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 
+# A report file older than this is assumed to be a previous slot's leftover. Kept
+# below the 30min slot cadence (and aligned with the already_delivered window) so a
+# forgotten write is refused instead of silently re-publishing a stale report.
+REPORT_MAX_AGE_MIN = 20
+
 REQUIRED_SECTION = '▎我的看法'
 FORBIDDEN_PHRASES = ['数据待获取', '等待数据', 'TODO', 'TBD']
 CRITICAL_KEYWORDS = ['缺段标记', '未包含原始数据块', '敷衍词', '表格行未 verbatim']
@@ -59,6 +73,48 @@ def load_context(market):
         return json.loads(path.read_text()), None
     except Exception as e:
         return None, f'context 解析失败: {e}'
+
+
+def read_report_text(market, text_file):
+    """Return (text, input_error). Plumbing failures never reach validate()."""
+    hint = (f'Step 3 应先把报告写入 memory/.tmp/intraday-report-{market}.md，'
+            f'再用 --text-file 调用 postflight；不要用 heredoc/<<< 喂 stdin')
+    if text_file:
+        path = Path(text_file)
+        if not path.exists():
+            return '', f'报告文件不存在: {path} — {hint}'
+        age_min = (datetime.now().timestamp() - path.stat().st_mtime) / 60
+        if age_min > REPORT_MAX_AGE_MIN:
+            return '', (f'报告文件 {path.name} 已 {age_min:.0f} 分钟未更新 '
+                        f'(> {REPORT_MAX_AGE_MIN} 分钟上限) — 疑似上一个 slot 的旧报告，'
+                        f'拒绝投递；{hint}')
+        text = path.read_text()
+    else:
+        text = sys.stdin.read()
+
+    if not text.strip():
+        src = f'--text-file {text_file}' if text_file else 'stdin'
+        return '', f'空输入 ({src}) — postflight 没收到任何报告文本；{hint}'
+    return text, None
+
+
+def input_error(market, err):
+    """Exit path for empty/stale/missing input: loud, single-cause, still non-zero."""
+    cron_heartbeat.record(market, 'postflight_failed', failure_stage='input')
+    print(f'error: {err}', file=sys.stderr)
+    result = {
+        'status':        'input_error',
+        'market':        market,
+        'time':          datetime.now().strftime('%H:%M'),
+        'issues':        [err],
+        'wechat_prefix': '',
+        'n_chars':       0,
+        'wechat_sent':   None,
+        'telegram_sent': None,
+        'dashboard_published': False,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 2
 
 
 def validate(text, ctx):
@@ -116,7 +172,8 @@ def categorize(issues):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
-    parser.add_argument('--text-file', help='briefing text file (default: stdin)')
+    parser.add_argument('--text-file',
+                        help='report text file (canonical path; stdin only for manual runs)')
     args = parser.parse_args()
 
     # Holiday/weekend gate: no send/publish on a closed market.
@@ -129,7 +186,9 @@ def main():
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 0
 
-    text = Path(args.text_file).read_text() if args.text_file else sys.stdin.read()
+    text, in_err = read_report_text(args.market, args.text_file)
+    if in_err:
+        return input_error(args.market, in_err)
 
     ctx, err = load_context(args.market)
     if ctx is None:

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -107,10 +107,19 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 **规范见 `skills/_shared/intraday-status-sidecar.md`**（hk/us 共用单一来源）—— 写 `memory/.tmp/intraday-insights-{date}.json`（status_banner + 每个异动票 movers 归因，只文本无 key）。
 - 本市场杠杆 ETF：**07226**（恒科 2x）等，归因要点明"杠杆放大"。
 
-#### Step 3: 跑 postflight
+#### Step 3: 跑 postflight（先写文件，再调用 —— 禁用 heredoc/`<<<`）
+**必须两步、按顺序**：先用文件写入工具把 Step 2 的报告原样写到
+`memory/.tmp/intraday-report-hk.md`，确认写入成功后再调用：
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py --market hk <<< "{报告}"
+python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py \
+  --market hk --text-file /root/.openclaw/workspace/memory/.tmp/intraday-report-hk.md
 ```
+❌ **不要用 `<<<` / heredoc 把报告塞进 stdin** —— 报告含 emoji、`$`、`|` 表格和换行，
+shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight 读到空串后吐出
+4 条"报告写错了"的假 issue，run 被标红（实际重试后投递正常）。
+postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
+文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧报告重发。
+
 校验段标记 + 长度 + 异动票提及。**不提交 `portfolio.json`**；若 dashboard
 有语义变化，postflight 会重建并提交 `assets/data/dashboard.json`。每个 slot 的
 完成/投递状态另写 heartbeat，由 single publisher 发布。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -108,10 +108,19 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 **规范见 `skills/_shared/intraday-status-sidecar.md`**（hk/us 共用单一来源）—— 写 `memory/.tmp/intraday-insights-{date}.json`（status_banner + 每个异动票 movers 归因，只文本无 key）。
 - 本市场杠杆 ETF：**ROBN/PLTU/MSFU/SOXL/TQQQ** 等（2x 标的），归因要点明"杠杆放大"、区分标的真涨还是纯 beta。
 
-#### Step 3: postflight
+#### Step 3: postflight（先写文件，再调用 —— 禁用 heredoc/`<<<`）
+**必须两步、按顺序**：先用文件写入工具把 Step 2 的报告原样写到
+`memory/.tmp/intraday-report-us.md`，确认写入成功后再调用：
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py --market us <<< "{报告}"
+python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py \
+  --market us --text-file /root/.openclaw/workspace/memory/.tmp/intraday-report-us.md
 ```
+❌ **不要用 `<<<` / heredoc 把报告塞进 stdin** —— 报告含 emoji、`$`、`|` 表格和换行，
+shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight 读到空串后吐出
+4 条"报告写错了"的假 issue，run 被标红（实际重试后投递正常）。
+postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
+文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧报告重发。
+
 **不提交 `portfolio.json`**；若 dashboard 有语义变化，postflight 会重建并提交
 `assets/data/dashboard.json`。每个 slot 的完成/投递状态另写 heartbeat，由 single
 publisher 发布。

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -298,6 +298,44 @@ def test_intraday_stale_report_file_is_refused(tmp_path):
     assert err_missing and '不存在' in err_missing
 
 
+def test_intraday_main_stops_on_empty_input_and_blames_the_context_slot(monkeypatch, capsys):
+    """End-to-end on main(): empty input must exit 2 without ever reaching content
+    validation or delivery, and the failure must be stamped on the slot the
+    preflight context was built for. A run that starts at 10:00 but hits empty
+    input at 10:31 would otherwise record a phantom 10:30 failure while the
+    successful retry marks 10:00 completed."""
+    import io
+
+    import intraday_postflight
+
+    recorded = {}
+    monkeypatch.setattr(sys, 'stdin', io.StringIO(''))
+    monkeypatch.setattr(sys, 'argv', ['intraday_postflight.py', '--market', 'hk'])
+    monkeypatch.setattr(intraday_postflight.trading_calendar, 'closed_reason', lambda m: None)
+    monkeypatch.setattr(intraday_postflight, 'load_context', lambda m: (
+        {'heartbeat': {'job': '盘中盯盘', 'slot': '2026-07-23T10:00:00+08:00'}}, None))
+    monkeypatch.setattr(intraday_postflight.cron_heartbeat, 'record',
+                        lambda *a, **kw: recorded.update(args=a, kwargs=kw))
+
+    def _never(*a, **kw):
+        raise AssertionError('empty input must not reach content validation/delivery')
+
+    monkeypatch.setattr(intraday_postflight, 'validate', _never)
+    monkeypatch.setattr(intraday_postflight, 'send_wechat', _never)
+
+    assert intraday_postflight.main() == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['status'] == 'input_error'
+    assert payload['n_chars'] == 0
+    assert payload['wechat_sent'] is None and payload['dashboard_published'] is False
+
+    assert recorded['args'] == ('hk', 'postflight_failed')
+    assert recorded['kwargs']['slot'] == '2026-07-23T10:00:00+08:00'
+    assert recorded['kwargs']['job_name'] == '盘中盯盘'
+    assert recorded['kwargs']['failure_stage'] == 'input'
+
+
 def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     """The live cron payload and the SKILL are two sources of truth for the same
     command. Pin the plumbing in the tracked contract so they cannot drift apart

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -257,6 +257,71 @@ def test_intraday_hard_length_limit_is_a_failure():
     ) == 'warn'
 
 
+def test_intraday_empty_input_is_an_input_error_not_a_content_failure(monkeypatch):
+    """2026-07-23 10:00 HK: postflight was called with no stdin at all. The empty
+    read went straight into validate() and produced four "you wrote the report
+    wrong" issues, hiding the real cause (missing plumbing). Empty input must be
+    reported as its own class, and must never reach content validation."""
+    import io
+    import intraday_postflight
+
+    monkeypatch.setattr(sys, 'stdin', io.StringIO(''))
+    text, err = intraday_postflight.read_report_text('hk', None)
+    assert text == ''
+    assert '空输入' in err and '--text-file' in err
+
+    monkeypatch.setattr(sys, 'stdin', io.StringIO('   \n\n  '))
+    _, err_ws = intraday_postflight.read_report_text('hk', None)
+    assert err_ws, 'whitespace-only input must be rejected too'
+
+
+def test_intraday_stale_report_file_is_refused(tmp_path):
+    """A forgotten Step 3 rewrite must not silently republish the previous slot's
+    report — the failure mode --text-file would otherwise introduce."""
+    import os
+
+    import intraday_postflight
+
+    report = tmp_path / 'intraday-report-hk.md'
+    report.write_text('🇭🇰 港股盯盘 | 07/23 10:03 HKT\n▎我的看法\n' + 'x' * 80)
+
+    text, err = intraday_postflight.read_report_text('hk', str(report))
+    assert err is None and text, 'a freshly written report must pass'
+
+    stale = (datetime.now().timestamp()
+             - (intraday_postflight.REPORT_MAX_AGE_MIN + 5) * 60)
+    os.utime(report, (stale, stale))
+    _, err_stale = intraday_postflight.read_report_text('hk', str(report))
+    assert err_stale and '旧报告' in err_stale
+
+    _, err_missing = intraday_postflight.read_report_text('hk', str(tmp_path / 'nope.md'))
+    assert err_missing and '不存在' in err_missing
+
+
+def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
+    """The live cron payload and the SKILL are two sources of truth for the same
+    command. Pin the plumbing in the tracked contract so they cannot drift apart
+    again."""
+    profile = contract()['payload_profiles']['intraday']
+    assert '--text-file' in profile['required_substrings']
+    assert 'intraday-report-{market}.md' in profile['required_substrings']
+    assert '<<<' in profile['forbidden_substrings']
+
+    vars_ = {'market': 'hk', 'skill': 'hk-stock-analysis'}
+    data = contract()
+    expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
+    message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    live = {
+        'payload': {'message': message, 'kind': 'agentTurn',
+                    'model': profile['model'], 'thinking': profile['thinking']},
+        'delivery': {'mode': 'none'},
+    }
+    assert cron_contract.payload_errors(data, expected, live) == []
+
+    live['payload']['message'] = message + '\nintraday_postflight.py --market hk <<< "{报告}"'
+    assert cron_contract.payload_errors(data, expected, live) != []
+
+
 def test_every_twenty_minutes_timeline_label_is_not_every_hour():
     timeline_spec = importlib.util.spec_from_file_location(
         'cron_timeline', ROOT / 'scripts' / 'data' / 'cron_timeline.py'


### PR DESCRIPTION
## 起因

2026-07-23 10:00 港股「盘中盯盘」cron 被记成 `status=error`，**但报告其实成功投递了**。

挖 session `9244a462` 得到的时间线（HKT）：

| 时刻 | 事件 |
|---|---|
| 10:04:54 | 模型调 `intraday_postflight.py --market hk`，**完全没喂 stdin**（无 heredoc、无 `--text-file`） |
| 10:04:54 | 空串进 `validate()` → 4 条"报告写错了"的假 issue → `fail` → `exit 2` → 记成 `Bash failed` |
| 10:05:21 | 模型用 heredoc 重试 |
| 10:05:53 | `status=pass`、`n_chars=921`、`wechat_sent`/`telegram_sent`/`dashboard_published` 全 true |
| 10:06:11 | run 收尾 `status=error` ← openclaw「中途任何一次 bash 非零即 error」，留下假红 |

所以这是**管道故障被伪装成内容故障**，再被 run 级规则放大成假红。

## 改了什么

1. **`intraday_postflight.py`** — 新增 `read_report_text()`：空输入 / whitespace-only / 文件不存在 / 文件超 20 分钟未更新 → `status: input_error`（**独立于 `fail`**）+ 单条明确 stderr，**不进内容校验**。
   仍 `exit 2`：这是投递闸，**假绿比假红危险**，不拿退出码换红灯消失。
2. **`--text-file` 成为 canonical 路径**（脚本本来就支持，一直没人用）。报告含 emoji、`$`、`|` 表格、换行，heredoc 引号极脆；改成"先写文件再调用"同时消除"忘喂 stdin"和"引号炸"两类失败。
3. **20 分钟新鲜度闸** — 这是 `--text-file` 自带的**新**失败面的对症闸：忘了重写文件就会静默重发上一个 slot 的旧报告。20 min < 30 min slot 周期，与 `already_delivered` 窗口对齐。
4. **hk/us SKILL.md Mode 7 Step 3 + TOOLS_SCRIPTS.md** 同步改写，明确禁 heredoc。
5. **tracked cron 契约**（`config/cron-schedules.json`）intraday profile：required 加 `--text-file` + `intraday-report-{market}.md`，forbidden 加 `<<<`。
   SKILL 和 live cron payload 是**同一条命令的两份真源**（payload 在 openclaw sqlite，不在 git 里），用契约钉死防再漂。

## live cron payload 已同步改（本 PR 之外的运行时改动）

三条 Mode 7 payload（`盘中盯盘` / `美股盘中盯盘` / `美股盘中盯盘-overnight`）已用 `openclaw cron edit --message` 改成 `--text-file`。
- 原文已备份，可原样还原。
- 改后 live workspace（master 契约）与本分支契约 `system_check` **均全绿**；先改 payload 是必需顺序——契约检查跑的是 live payload，不改会红。

## 测试

- 三条新测试：空输入 / 旧文件+缺文件 / 契约禁 heredoc，全部**已做变异验证**（把实现改回旧行为，三条全红）。
- 本地全量 `398 passed, 5 xfailed`。

## 没做 / 明确不做

- **消除假红本身做不到**。openclaw 现规则是「run 中途任何一次 bash 非零 → run error」，只要失败调用非零就会红。本 PR 走的是**预防该失败**这条路。真要治标得 openclaw 上游支持 `recovered/ok_with_retries`。
- 空输入**不返回 0**。那会把"没过闸也没投递"伪装成成功。
- 业务健康其实另有真源：10:00 那次 heartbeat 是 `completed + pass + wechat/telegram=true`，run 级 error 和业务健康本来就是两个维度。

---
设计经 Codex 对抗性讨论（`--text-file` 的 stale-file 风险、契约防漂移两条是它提出的）。按 clawock 约定：**作者不合自己的 PR**。