### PR TITLE
seo: make IndexNow submission incremental instead of one hardcoded URL

### DIFF
--- a/scripts/data/indexnow_submit.py
+++ b/scripts/data/indexnow_submit.py
@@ -6,9 +6,17 @@ Zero-touch indexing accelerator. Reads the IndexNow key from the repo-root
 
 Google does not consume IndexNow — for Google use GSC "Request Indexing".
 
+Default mode is incremental: only URLs never submitted before, plus the pages
+that genuinely change every day (dashboard + brief index). IndexNow asks
+publishers to submit on change, so re-POSTing every unchanged URL daily is both
+wasteful and spam-shaped. Submitted URLs are remembered in
+`logs/indexnow_seen.json` (machine-local, gitignored).
+
 Usage:
-  python3 scripts/data/indexnow_submit.py            # submit all sitemap URLs
+  python3 scripts/data/indexnow_submit.py            # new URLs + daily-changing pages
+  python3 scripts/data/indexnow_submit.py --all      # every sitemap URL (backfill)
   python3 scripts/data/indexnow_submit.py <url> ...  # submit specific URLs
+  python3 scripts/data/indexnow_submit.py --dry-run  # print, do not POST
 """
 import glob
 import json
@@ -20,6 +28,11 @@ import urllib.request
 HOST = "kcnyu.github.io"
 SITE = "https://kcnyu.github.io/clawock"
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATE = os.path.join(ROOT, "logs", "indexnow_seen.json")
+
+# Pages regenerated daily, so re-submitting them is a genuine "this changed"
+# signal rather than spam.
+ALWAYS = (f"{SITE}/", f"{SITE}/briefs.html")
 
 
 def find_key():
@@ -36,11 +49,55 @@ def sitemap_urls():
     return re.findall(r"<loc>([^<]+)</loc>", xml)
 
 
-def main():
-    key = find_key()
-    urls = sys.argv[1:] or sitemap_urls()
+def load_seen():
+    """Previously submitted URLs. A missing/corrupt ledger degrades to empty:
+    that re-submits once, which beats the cron dying on a bad file."""
+    try:
+        with open(STATE, encoding="utf-8") as f:
+            data = json.load(f)
+        return set(data["urls"])
+    except FileNotFoundError:
+        return set()
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        print(f"WARN: unreadable {STATE} ({e}) — treating as empty", file=sys.stderr)
+        return set()
+
+
+def save_seen(urls):
+    os.makedirs(os.path.dirname(STATE), exist_ok=True)
+    tmp = f"{STATE}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"urls": sorted(urls)}, f, indent=1)
+    os.replace(tmp, STATE)
+
+
+def select(argv):
+    """Return (urls_to_submit, ledger_after_success)."""
+    explicit = [a for a in argv if not a.startswith("--")]
+    if explicit:
+        return explicit, load_seen() | set(explicit)
+    urls = sitemap_urls()
     if not urls:
-        raise SystemExit("ERROR: no URLs to submit")
+        raise SystemExit("ERROR: sitemap returned no URLs")
+    if "--all" in argv:
+        return urls, set(urls)
+    seen = load_seen()
+    fresh = [u for u in urls if u not in seen]
+    daily = [u for u in ALWAYS if u in urls and u not in fresh]
+    return fresh + daily, seen | set(urls)
+
+
+def main():
+    argv = sys.argv[1:]
+    key = find_key()
+    urls, ledger = select(argv)
+    if not urls:
+        print("IndexNow — nothing new to submit")
+        return
+    if "--dry-run" in argv:
+        print(f"IndexNow dry-run — would submit {len(urls)} URL(s):")
+        print("\n".join(urls))
+        return
     payload = {
         "host": HOST,
         "key": key,
@@ -58,6 +115,8 @@ def main():
         body = r.read().decode("utf-8", "replace").strip()
         if body:
             print(body)
+    # Record only after the POST is accepted, so a failed run retries next time.
+    save_seen(ledger)
 
 
 if __name__ == "__main__":

--- a/scripts/data/indexnow_submit.py
+++ b/scripts/data/indexnow_submit.py
@@ -2,37 +2,38 @@
 """Submit clawock URLs to IndexNow (Bing / Yandex / Seznam — NOT Google).
 
 Zero-touch indexing accelerator. Reads the IndexNow key from the repo-root
-`<key>.txt` file (32-hex), pulls URLs from the live sitemap, and POSTs them.
+`<key>.txt` file (32-hex), pulls URLs from the live sitemap, and POSTs the ones
+that are new or whose content actually changed.
 
 Google does not consume IndexNow — for Google use GSC "Request Indexing".
 
-Default mode is incremental: only URLs never submitted before, plus the pages
-that genuinely change every day (dashboard + brief index). IndexNow asks
-publishers to submit on change, so re-POSTing every unchanged URL daily is both
-wasteful and spam-shaped. Submitted URLs are remembered in
-`logs/indexnow_seen.json` (machine-local, gitignored).
+Change detection uses each page's HTTP validator (ETag, else Last-Modified) from
+a cheap HEAD request, recorded per URL in `logs/indexnow_seen.json`
+(machine-local, gitignored). A URL-only ledger would mean an edited brief, a
+revised weekly, or a `_layouts/` change is never re-announced — silently, and
+forever. IndexNow asks publishers to submit on change, so re-POSTing unchanged
+URLs daily is equally wrong in the other direction.
 
 Usage:
-  python3 scripts/data/indexnow_submit.py            # new URLs + daily-changing pages
-  python3 scripts/data/indexnow_submit.py --all      # every sitemap URL (backfill)
-  python3 scripts/data/indexnow_submit.py <url> ...  # submit specific URLs
-  python3 scripts/data/indexnow_submit.py --dry-run  # print, do not POST
+  python3 scripts/data/indexnow_submit.py             # new + changed URLs
+  python3 scripts/data/indexnow_submit.py --all       # every sitemap URL
+  python3 scripts/data/indexnow_submit.py <url> ...   # submit specific URLs
+  python3 scripts/data/indexnow_submit.py --record-only  # seed ledger, no POST
+  python3 scripts/data/indexnow_submit.py --dry-run   # print, do not POST
 """
+import argparse
 import glob
 import json
 import os
 import re
 import sys
+import urllib.error
 import urllib.request
 
 HOST = "kcnyu.github.io"
 SITE = "https://kcnyu.github.io/clawock"
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 STATE = os.path.join(ROOT, "logs", "indexnow_seen.json")
-
-# Pages regenerated daily, so re-submitting them is a genuine "this changed"
-# signal rather than spam.
-ALWAYS = (f"{SITE}/", f"{SITE}/briefs.html")
 
 
 def find_key():
@@ -44,60 +45,80 @@ def find_key():
 
 
 def sitemap_urls():
-    with urllib.request.urlopen(f"{SITE}/sitemap.xml", timeout=20) as r:
-        xml = r.read().decode("utf-8", "replace")
+    try:
+        with urllib.request.urlopen(f"{SITE}/sitemap.xml", timeout=20) as r:
+            xml = r.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError) as e:
+        raise SystemExit(f"ERROR: cannot fetch {SITE}/sitemap.xml ({e})")
     return re.findall(r"<loc>([^<]+)</loc>", xml)
 
 
+def validator(url):
+    """ETag (preferred) or Last-Modified for a URL. None if unreachable — an
+    unreachable page is skipped rather than guessed at in either direction."""
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.headers.get("ETag") or r.headers.get("Last-Modified")
+    except (urllib.error.URLError, OSError) as e:
+        print(f"WARN: HEAD {url} failed ({e}) — skipping this URL", file=sys.stderr)
+        return None
+
+
 def load_seen():
-    """Previously submitted URLs. A missing/corrupt ledger degrades to empty:
-    that re-submits once, which beats the cron dying on a bad file."""
+    """URL -> validator. A missing/corrupt ledger degrades to empty: that
+    re-submits once, which beats the cron dying on a bad file."""
     try:
         with open(STATE, encoding="utf-8") as f:
             data = json.load(f)
-        return set(data["urls"])
+        seen = data["validators"]
+        if not isinstance(seen, dict):
+            raise TypeError("validators is not an object")
+        return seen
     except FileNotFoundError:
-        return set()
+        return {}
     except (OSError, ValueError, KeyError, TypeError) as e:
         print(f"WARN: unreadable {STATE} ({e}) — treating as empty", file=sys.stderr)
-        return set()
+        return {}
 
 
-def save_seen(urls):
+def save_seen(updates):
+    """Merge `updates` into whatever is on disk right now.
+
+    A concurrent run (daily cron overlapping a manual --all) must not clobber
+    the other's entries, so this re-reads before writing and uses a
+    PID-suffixed temp file — two processes sharing one `.tmp` path can make
+    os.replace race into FileNotFoundError.
+    """
+    merged = load_seen()
+    merged.update(updates)
     os.makedirs(os.path.dirname(STATE), exist_ok=True)
-    tmp = f"{STATE}.tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump({"urls": sorted(urls)}, f, indent=1)
-    os.replace(tmp, STATE)
+    tmp = f"{STATE}.{os.getpid()}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"validators": dict(sorted(merged.items()))}, f, indent=1)
+        os.replace(tmp, STATE)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
 
 
-def select(argv):
-    """Return (urls_to_submit, ledger_after_success)."""
-    explicit = [a for a in argv if not a.startswith("--")]
-    if explicit:
-        return explicit, load_seen() | set(explicit)
+def select(args):
+    """Return (urls_to_submit, {url: validator} to record on success)."""
+    if args.urls:
+        return args.urls, {u: v for u in args.urls if (v := validator(u))}
     urls = sitemap_urls()
     if not urls:
         raise SystemExit("ERROR: sitemap returned no URLs")
-    if "--all" in argv:
-        return urls, set(urls)
     seen = load_seen()
-    fresh = [u for u in urls if u not in seen]
-    daily = [u for u in ALWAYS if u in urls and u not in fresh]
-    return fresh + daily, seen | set(urls)
+    current = {u: v for u in urls if (v := validator(u)) is not None}
+    if args.all:
+        return urls, current
+    changed = [u for u in urls if u in current and current[u] != seen.get(u)]
+    return changed, {u: current[u] for u in changed}
 
 
-def main():
-    argv = sys.argv[1:]
-    key = find_key()
-    urls, ledger = select(argv)
-    if not urls:
-        print("IndexNow — nothing new to submit")
-        return
-    if "--dry-run" in argv:
-        print(f"IndexNow dry-run — would submit {len(urls)} URL(s):")
-        print("\n".join(urls))
-        return
+def post(key, urls):
     payload = {
         "host": HOST,
         "key": key,
@@ -115,8 +136,40 @@ def main():
         body = r.read().decode("utf-8", "replace").strip()
         if body:
             print(body)
-    # Record only after the POST is accepted, so a failed run retries next time.
-    save_seen(ledger)
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("urls", nargs="*", help="submit these URLs instead of the sitemap")
+    p.add_argument("--all", action="store_true", help="submit every sitemap URL")
+    p.add_argument("--dry-run", action="store_true", help="print, do not POST")
+    p.add_argument("--record-only", action="store_true",
+                   help="record current validators without submitting "
+                        "(seeds the ledger after a manual backfill)")
+    args = p.parse_args(argv)
+    if args.urls and args.all:
+        p.error("--all cannot be combined with explicit URLs")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    urls, record = select(args)
+    if args.record_only:
+        save_seen(record)
+        print(f"IndexNow — recorded {len(record)} validator(s), submitted nothing")
+        return
+    if not urls:
+        print("IndexNow — nothing new or changed to submit")
+        return
+    if args.dry_run:
+        print(f"IndexNow dry-run — would submit {len(urls)} URL(s):")
+        print("\n".join(urls))
+        return
+    post(find_key(), urls)
+    # Record only after the POST is accepted, so a failed run retries instead of
+    # marking the URLs as done forever.
+    save_seen(record)
 
 
 if __name__ == "__main__":

--- a/tests/test_indexnow_submit.py
+++ b/tests/test_indexnow_submit.py
@@ -1,0 +1,94 @@
+"""IndexNow submission must be incremental, not one hardcoded URL forever.
+
+From 2026-06-22 to 2026-07-23 the daily cron passed a single explicit URL, so the
+49 brief pages were never announced to Bing at all — the script was correct and
+the invocation was not. These tests pin the behaviour the cron now relies on:
+never-submitted URLs go out, the daily-regenerated pages go out, unchanged
+archive pages do not, and the ledger only advances after an accepted POST.
+
+Run: python3 -m pytest tests/test_indexnow_submit.py -q
+"""
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+import indexnow_submit as ins
+
+SITE = ins.SITE
+HOME = f'{SITE}/'
+BRIEFS = f'{SITE}/briefs.html'
+OLD = f'{SITE}/memory/2026-05-16-pre-open.html'
+NEW = f'{SITE}/memory/2026-07-24-pre-open.html'
+SITEMAP = [HOME, BRIEFS, OLD, NEW]
+
+
+def _seen(tmp_path, urls):
+    ins.STATE = str(tmp_path / 'indexnow_seen.json')
+    if urls is not None:
+        ins.save_seen(urls)
+    return ins.STATE
+
+
+def test_incremental_run_sends_new_and_daily_pages_but_not_stale_archive(tmp_path):
+    _seen(tmp_path, {HOME, BRIEFS, OLD})
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
+        urls, ledger = ins.select([])
+    assert NEW in urls, 'a never-submitted brief must be announced'
+    assert HOME in urls and BRIEFS in urls, 'daily-regenerated pages must be re-announced'
+    assert OLD not in urls, 'unchanged archive pages must not be re-POSTed every day'
+    assert ledger == set(SITEMAP)
+
+
+def test_new_url_is_not_duplicated_when_it_is_also_a_daily_page(tmp_path):
+    _seen(tmp_path, set())
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
+        urls, _ = ins.select([])
+    assert sorted(urls) == sorted(set(urls)), f'duplicate submission: {urls}'
+    assert set(urls) == set(SITEMAP), 'an empty ledger means everything is new'
+
+
+def test_all_flag_backfills_every_sitemap_url(tmp_path):
+    _seen(tmp_path, set(SITEMAP))
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
+        urls, ledger = ins.select(['--all'])
+    assert set(urls) == set(SITEMAP) and ledger == set(SITEMAP)
+
+
+def test_explicit_urls_bypass_the_sitemap_and_extend_the_ledger(tmp_path):
+    _seen(tmp_path, {OLD})
+    with mock.patch.object(ins, 'sitemap_urls', side_effect=AssertionError('must not fetch')):
+        urls, ledger = ins.select([NEW])
+    assert urls == [NEW] and ledger == {OLD, NEW}
+
+
+def test_corrupt_ledger_degrades_to_empty_instead_of_killing_the_cron(tmp_path):
+    path = _seen(tmp_path, None)
+    Path(path).write_text('{not json', encoding='utf-8')
+    assert ins.load_seen() == set()
+
+
+def test_ledger_is_not_advanced_when_the_post_fails(tmp_path):
+    """A failed POST that still recorded the URLs would silently drop them forever."""
+    _seen(tmp_path, set())
+    with mock.patch.object(sys, 'argv', ['indexnow_submit.py']), \
+            mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
+            mock.patch.object(ins.urllib.request, 'urlopen', side_effect=OSError('boom')):
+        try:
+            ins.main()
+        except OSError:
+            pass
+    assert ins.load_seen() == set(), 'ledger advanced despite a failed submission'
+
+
+def test_dry_run_never_posts(tmp_path):
+    _seen(tmp_path, set())
+    with mock.patch.object(sys, 'argv', ['indexnow_submit.py', '--dry-run']), \
+            mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
+            mock.patch.object(ins.urllib.request, 'urlopen',
+                              side_effect=AssertionError('dry-run must not POST')):
+        ins.main()
+    assert ins.load_seen() == set()

--- a/tests/test_indexnow_submit.py
+++ b/tests/test_indexnow_submit.py
@@ -1,13 +1,20 @@
-"""IndexNow submission must be incremental, not one hardcoded URL forever.
+"""IndexNow submission must be incremental and change-aware, not a hardcoded URL.
 
 From 2026-06-22 to 2026-07-23 the daily cron passed a single explicit URL, so the
-49 brief pages were never announced to Bing at all — the script was correct and
-the invocation was not. These tests pin the behaviour the cron now relies on:
-never-submitted URLs go out, the daily-regenerated pages go out, unchanged
-archive pages do not, and the ledger only advances after an accepted POST.
+49 brief pages were never announced to Bing — the script was correct, the
+invocation was not. These tests pin the behaviour the cron now relies on:
+
+- never-seen URLs go out; unchanged pages do not;
+- a page whose ETag/Last-Modified changed IS re-announced (a URL-only ledger
+  would silently drop every edit forever);
+- the ledger advances only after an accepted POST, and merges rather than
+  clobbers so a concurrent --all run cannot wipe the daily run's entries;
+- main() itself is exercised on the success path, so deleting save_seen() or
+  neutering select() fails a test instead of staying green.
 
 Run: python3 -m pytest tests/test_indexnow_submit.py -q
 """
+import json
 import sys
 from pathlib import Path
 from unittest import mock
@@ -24,71 +31,131 @@ NEW = f'{SITE}/memory/2026-07-24-pre-open.html'
 SITEMAP = [HOME, BRIEFS, OLD, NEW]
 
 
-def _seen(tmp_path, urls):
+def _ledger(tmp_path, mapping):
     ins.STATE = str(tmp_path / 'indexnow_seen.json')
-    if urls is not None:
-        ins.save_seen(urls)
+    if mapping is not None:
+        ins.save_seen(mapping)
     return ins.STATE
 
 
-def test_incremental_run_sends_new_and_daily_pages_but_not_stale_archive(tmp_path):
-    _seen(tmp_path, {HOME, BRIEFS, OLD})
-    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
-        urls, ledger = ins.select([])
-    assert NEW in urls, 'a never-submitted brief must be announced'
-    assert HOME in urls and BRIEFS in urls, 'daily-regenerated pages must be re-announced'
-    assert OLD not in urls, 'unchanged archive pages must not be re-POSTed every day'
-    assert ledger == set(SITEMAP)
+def _fixed_validators(mapping):
+    """Patch HEAD lookups so tests are deterministic and never hit the network."""
+    return mock.patch.object(ins, 'validator', side_effect=lambda u: mapping.get(u))
 
 
-def test_new_url_is_not_duplicated_when_it_is_also_a_daily_page(tmp_path):
-    _seen(tmp_path, set())
-    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
-        urls, _ = ins.select([])
-    assert sorted(urls) == sorted(set(urls)), f'duplicate submission: {urls}'
-    assert set(urls) == set(SITEMAP), 'an empty ledger means everything is new'
+# --- selection -------------------------------------------------------------
+
+def test_new_and_changed_go_out_unchanged_do_not(tmp_path):
+    _ledger(tmp_path, {HOME: 'v1', BRIEFS: 'v1', OLD: 'etagOLD'})
+    live = {HOME: 'v2', BRIEFS: 'v1', OLD: 'etagOLD', NEW: 'etagNEW'}
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), _fixed_validators(live):
+        urls, record = ins.select(ins.parse_args([]))
+    assert NEW in urls, 'a never-seen brief must be announced'
+    assert HOME in urls, 'a page whose validator changed must be re-announced'
+    assert BRIEFS not in urls, 'an unchanged page must not be re-POSTed'
+    assert OLD not in urls, 'an unchanged archive page must not be re-POSTed'
+    assert record == {HOME: 'v2', NEW: 'etagNEW'}
 
 
-def test_all_flag_backfills_every_sitemap_url(tmp_path):
-    _seen(tmp_path, set(SITEMAP))
-    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP):
-        urls, ledger = ins.select(['--all'])
-    assert set(urls) == set(SITEMAP) and ledger == set(SITEMAP)
+def test_unreachable_page_is_skipped_not_guessed(tmp_path):
+    _ledger(tmp_path, {})
+    with mock.patch.object(ins, 'sitemap_urls', return_value=[HOME, NEW]), \
+            _fixed_validators({HOME: 'v1'}):  # NEW -> None (HEAD failed)
+        urls, record = ins.select(ins.parse_args([]))
+    assert urls == [HOME] and NEW not in record
 
 
-def test_explicit_urls_bypass_the_sitemap_and_extend_the_ledger(tmp_path):
-    _seen(tmp_path, {OLD})
-    with mock.patch.object(ins, 'sitemap_urls', side_effect=AssertionError('must not fetch')):
-        urls, ledger = ins.select([NEW])
-    assert urls == [NEW] and ledger == {OLD, NEW}
+def test_all_flag_backfills_every_reachable_url(tmp_path):
+    _ledger(tmp_path, {HOME: 'v1', BRIEFS: 'v1', OLD: 'v1', NEW: 'v1'})
+    live = {u: 'v1' for u in SITEMAP}
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), _fixed_validators(live):
+        urls, record = ins.select(ins.parse_args(['--all']))
+    assert set(urls) == set(SITEMAP) and record == live
 
 
-def test_corrupt_ledger_degrades_to_empty_instead_of_killing_the_cron(tmp_path):
-    path = _seen(tmp_path, None)
-    Path(path).write_text('{not json', encoding='utf-8')
-    assert ins.load_seen() == set()
+def test_explicit_urls_bypass_the_sitemap(tmp_path):
+    _ledger(tmp_path, {OLD: 'v1'})
+    with mock.patch.object(ins, 'sitemap_urls', side_effect=AssertionError('must not fetch')), \
+            _fixed_validators({NEW: 'etagNEW'}):
+        urls, record = ins.select(ins.parse_args([NEW]))
+    assert urls == [NEW] and record == {NEW: 'etagNEW'}
 
 
-def test_ledger_is_not_advanced_when_the_post_fails(tmp_path):
-    """A failed POST that still recorded the URLs would silently drop them forever."""
-    _seen(tmp_path, set())
-    with mock.patch.object(sys, 'argv', ['indexnow_submit.py']), \
-            mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
-            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
-            mock.patch.object(ins.urllib.request, 'urlopen', side_effect=OSError('boom')):
+def test_all_with_explicit_urls_is_rejected():
+    with mock.patch.object(sys, 'exit', side_effect=SystemExit):
         try:
-            ins.main()
+            ins.parse_args(['--all', NEW])
+            assert False, 'expected argparse to reject --all + URL'
+        except SystemExit:
+            pass
+
+
+# --- ledger integrity ------------------------------------------------------
+
+def test_corrupt_ledger_degrades_to_empty(tmp_path):
+    path = _ledger(tmp_path, None)
+    Path(path).write_text('{not json', encoding='utf-8')
+    assert ins.load_seen() == {}
+
+
+def test_save_merges_instead_of_clobbering_a_concurrent_run(tmp_path):
+    _ledger(tmp_path, {HOME: 'v1'})
+    ins.save_seen({NEW: 'etagNEW'})  # simulates the other process's write
+    assert ins.load_seen() == {HOME: 'v1', NEW: 'etagNEW'}
+
+
+# --- main() success + mutation resistance ----------------------------------
+
+def _run_main(tmp_path, argv, live, seed=None):
+    _ledger(tmp_path, seed if seed is not None else {})
+    posted = {}
+    def fake_post(key, urls):
+        posted['urls'] = list(urls)
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            _fixed_validators(live), \
+            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
+            mock.patch.object(ins, 'post', side_effect=fake_post):
+        ins.main(argv)
+    return posted
+
+
+def test_main_posts_changed_urls_and_records_them(tmp_path):
+    live = {HOME: 'v2', BRIEFS: 'v1', OLD: 'v1', NEW: 'etagNEW'}
+    posted = _run_main(tmp_path, [], live, seed={HOME: 'v1', BRIEFS: 'v1', OLD: 'v1'})
+    # Deleting save_seen(record) or neutering select() breaks one of these:
+    assert set(posted['urls']) == {HOME, NEW}, 'must POST exactly the changed/new URLs'
+    assert ins.load_seen() == live, 'accepted POST must advance the ledger to current'
+
+
+def test_main_records_nothing_when_post_fails(tmp_path):
+    _ledger(tmp_path, {})
+    live = {u: 'v1' for u in SITEMAP}
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            _fixed_validators(live), \
+            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
+            mock.patch.object(ins, 'post', side_effect=OSError('boom')):
+        try:
+            ins.main([])
         except OSError:
             pass
-    assert ins.load_seen() == set(), 'ledger advanced despite a failed submission'
+    assert ins.load_seen() == {}, 'ledger advanced despite a failed submission'
 
 
 def test_dry_run_never_posts(tmp_path):
-    _seen(tmp_path, set())
-    with mock.patch.object(sys, 'argv', ['indexnow_submit.py', '--dry-run']), \
-            mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
-            mock.patch.object(ins, 'find_key', return_value='0' * 32), \
-            mock.patch.object(ins.urllib.request, 'urlopen',
-                              side_effect=AssertionError('dry-run must not POST')):
-        ins.main()
-    assert ins.load_seen() == set()
+    live = {u: 'v1' for u in SITEMAP}
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            _fixed_validators(live), \
+            mock.patch.object(ins, 'post', side_effect=AssertionError('dry-run must not POST')):
+        _ledger(tmp_path, {})
+        ins.main(['--dry-run'])
+    assert ins.load_seen() == {}
+
+
+def test_record_only_seeds_ledger_without_posting(tmp_path):
+    live = {u: 'v1' for u in SITEMAP}
+    with mock.patch.object(ins, 'sitemap_urls', return_value=SITEMAP), \
+            _fixed_validators(live), \
+            mock.patch.object(ins, 'post', side_effect=AssertionError('record-only must not POST')):
+        _ledger(tmp_path, {})
+        ins.main(['--record-only'])
+    assert ins.load_seen() == live, 'record-only must persist current validators'


### PR DESCRIPTION
## What was broken

The daily crontab invoked `indexnow_submit.py https://kcnyu.github.io/clawock/` — a single explicit URL. From 2026-06-22 to 2026-07-23 every run logged `IndexNow HTTP 200 — submitted 1 URL(s)`: a month of green logs while the 49 brief pages were **never announced to Bing**. Correct script, wrong invocation (same failure shape as an unwired writer).

## Change

No-arg mode is now **incremental and change-aware**:

- Submits sitemap URLs that are new **or whose content changed**, detected via each page's `ETag`/`Last-Modified` (cheap HEAD), recorded per URL in `logs/indexnow_seen.json` (`logs/*` is gitignored). A URL-only ledger would silently never re-announce an edited brief or weekly.
- `save_seen()` re-reads and **merges** under a PID-suffixed temp file, so the daily cron and a manual `--all` can't clobber each other or race `os.replace`.
- Ledger advances **only after an accepted POST** — a failed run retries.
- Real `argparse`: `--help`/unknown flags no longer fall through into a live POST; `--all` + explicit URLs is rejected; `--all` backfills; `--record-only` seeds the ledger after a manual backfill; `--dry-run` inspects.
- sitemap-fetch failure exits cleanly to stderr instead of an uncaught traceback.

`tests/test_indexnow_submit.py` (11 tests) covers `main()` on the success path and is **mutation-verified**: deleting `save_seen(record)` or neutering `select()` turns a test red.

## Required post-merge step (must NOT run before merge)

After merge, the live crontab must drop the hardcoded URL:

```
0 12 * * * /usr/bin/python3 /root/.openclaw/workspace/scripts/data/indexnow_submit.py >> /root/.openclaw/workspace/logs/indexnow.log 2>&1
```

Dropping it **before** merge would make the old script POST all 65 URLs daily. The first incremental run finds an empty ledger and submits everything once (expected), then settles into new+changed only.

## Honest caveat

A one-time `--all` backfill of all 65 URLs was already submitted manually today (HTTP 200). Bing currently indexes **0** pages of this site (`site:kcnyu.github.io` → no results) after a month of accepted IndexNow pings. `IndexNow 200` = accepted, not crawled, not indexed. This fixes a real defect but the binding constraint remains zero inbound links / zero crawl budget. See companion PR KCNyu/KCNyu.github.io#1 (origin-root robots.txt + sitemap, which have been 404 the whole time).