### PR TITLE
harness: kill the stale-report-context footgun (2026-07-24 美股收盘)

### DIFF
--- a/TOOLS_SCRIPTS.md
+++ b/TOOLS_SCRIPTS.md
@@ -37,7 +37,7 @@ title: clawock · scripts 详细参考
 - **`scripts/harness/brief_postflight.py`**：校验 `memory/{date}-pre-open.md` + `memory/{date}-plan.json`（段标记 / plan schema / HHI / FX / HKD+USD bug pattern）；pass/warn 自动 commit
 
 **Mode 6 briefing**（HK 开/午/午后/收盘 + US 开/收盘 — 6 个 cron 共享）
-- **`scripts/harness/report_preflight.py --market {hk|us} --phase {open|mid|pm|close}`**：跑 analyze_*.py + 抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 指数方向；输出 `memory/.tmp/report-context-{market}-{phase}-{date}.json`，含 `raw_wechat_block`（LLM verbatim 用）+ `title` + `needs_risk_section`
+- **`scripts/harness/report_preflight.py --market {hk|us} --phase {open|mid|pm|close}`**：跑 analyze_*.py + 抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 指数方向；输出 `memory/.tmp/report-context-{market}-{phase}-{date}.json`（`{date}` = 跑批当天），含 `raw_wechat_block`（LLM verbatim 用）+ `title` + `needs_risk_section`。**末行打印 `context_path: <绝对路径>`——读 context 一律照抄这行，别拼文件名**；同时清掉该 market+phase 其它日期的残留 context
 - **`scripts/harness/report_postflight.py --market {hk|us} --phase {phase}`**：校验三段标记 / 原始数据块 verbatim / 异动票必须被提及 / 长度 / 敷衍词；pass/warn 自动刷新 snapshot/dashboard、scoped commit + push，并主发 WeChat + 镜像 Telegram。
 - **`scripts/harness/report_watchdog.py --market {hk|us} --phase {phase} --job-name "{cron名}"`**：系统 crontab 的 LLM-free Telegram-only backstop。覆盖 HK 4 班 + US 开/收 2 班；读取 postflight delivery marker，只有 Telegram 未确认时才补投，绝不重发 WeChat。
 

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -142,7 +142,7 @@ from _harness_common import (  # noqa: E402
 from _watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
 
 
-def deliver_wechat(market, phase, date, wechat_prefix, text, block_first):
+def deliver_wechat(market, phase, date, wechat_prefix, text):
     """Primary WeChat send for staged reports — fresh-token `openclaw message send`,
     decoupled from the cron's announce.
 
@@ -157,8 +157,18 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, block_first):
     CONFIRMED failure (never doubles a report that went out here).
 
     Returns (sent_ok, out). Writes marker report-sent-{market}-{phase}-{date}.json.
+
+    The marker's `first_line` records the first line of the report body WE
+    ACTUALLY SENT — not the block the context expected. report_watchdog compares
+    it against the fresh context's `raw_wechat_block` first line to decide whether
+    Telegram already has *this* report; recording the expected line made that
+    comparison tautological, so a body built from a stale context still looked
+    delivered (2026-07-24 美股收盘报告: WeChat got 07/22 numbers and no backstop
+    ever fired). Deriving it from `text` makes the mismatch detectable.
     """
     message = (wechat_prefix + text).strip()
+    body_lines = text.strip().splitlines()
+    sent_first = body_lines[0].strip() if body_lines else ''
     try:
         channel, to, account = resolve_wechat_target(market)
         sent_ok, out = send_wechat(channel, to, account, message, dry_run=False)
@@ -176,7 +186,7 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, block_first):
             'ts': int(datetime.now().timestamp() * 1000),
             'sent_ok': bool(sent_ok),
             'tg_ok': bool(tg_ok),
-            'first_line': block_first,
+            'first_line': sent_first,
             'market': market,
             'phase': phase,
             'out': (out or '')[-200:],
@@ -297,8 +307,6 @@ def main():
     # with its banner (matches the old announce behavior); only the commit is
     # gated on not-fail. The staged crons run --no-deliver so this is the sole
     # send. See deliver_wechat() docstring for the #61174 long-turn-drop rationale.
-    block_first = (ctx.get('raw_wechat_block', '') or '').strip().splitlines()
-    block_first = block_first[0] if block_first else ''
     # Idempotency: this phase's marker is per market+phase+date and fires once/day,
     # so if it already shows a delivery this is an openclaw auto-retry of a run that
     # errored only in post-turn summary-gen — the report already went out. Skip the
@@ -309,7 +317,7 @@ def main():
               file=sys.stderr)
         wechat_sent = True
     else:
-        wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, text, block_first)
+        wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, text)
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -12,7 +12,11 @@ Each invocation:
   3. Parses signals (WATCH/STOP/TRIM counts) and direction hints
   4. Detects anomalies (≥3% intraday moves, big floating losses)
   4b. Collects peer/rotation data so the 板块全景 section has real numbers
-  5. Writes memory/.tmp/report-context-{market}-{phase}-{date}.json
+  5. Writes memory/.tmp/report-context-{market}-{phase}-{date}.json, where {date}
+     is the RUN date (not the market-session date), drops this market+phase's
+     contexts from every other date, and prints the absolute path as the final
+     stdout line (`context_path: ...`) — Step 2 must read THAT path, never a
+     reconstructed filename.
 
 Output keys:
   raw_wechat_block:   str (script stdout, paste verbatim)
@@ -51,6 +55,51 @@ def _market_closed_reason(market, phase):
     """None if the market trades now; else short reason (holiday/weekend)."""
     session = trading_calendar.phase_session(market, phase)
     return trading_calendar.closed_reason(market, session=session)
+
+
+def context_path(market, phase, date):
+    return TMP / f'report-context-{market}-{phase}-{date}.json'
+
+
+def drop_stale_contexts(market, phase, today):
+    """Delete this market+phase's context files from any OTHER date.
+
+    WHY (2026-07-24 美股收盘报告): the cron payload names the file as
+    `report-context-us-close-{date}.json` and the agent resolved `{date}` to the
+    *market close* date (07/23) instead of the *run* date (07/24). Yesterday's
+    leftover context sat at exactly that name, so the read succeeded and a
+    day-old portfolio was written into the report and pushed to WeChat. Nothing
+    reads a past-date context (postflight/watchdog both key on today), so the
+    leftovers are pure footgun ammunition: with them gone, the same mistake is a
+    loud `FileNotFoundError` instead of silently stale numbers.
+
+    Retention would not help — the file that got misread was one day old.
+    """
+    dropped = []
+    for path in TMP.glob(f'report-context-{market}-{phase}-*.json'):
+        if path.name != context_path(market, phase, today).name:
+            try:
+                path.unlink()
+                dropped.append(path.name)
+            except OSError as e:
+                print(f'   ⚠️  stale context cleanup failed for {path.name}: {e}',
+                      file=sys.stderr)
+    if dropped:
+        print(f'   🧹 dropped {len(dropped)} stale context file(s): {", ".join(sorted(dropped))}',
+              file=sys.stderr)
+    return dropped
+
+
+def announce_context_path(out_path):
+    """Print the canonical context path as the FINAL stdout line.
+
+    WHY: the agent pipes preflight through `| tail -80` (the JSON is ~350 lines
+    with peer_scan), which cut off the `date` field and left it guessing the
+    filename — see drop_stale_contexts. Printing the absolute path last means it
+    survives any `tail`, so Step 2 never has to reconstruct the name.
+    """
+    print(f'context_path: {out_path}')
+
 
 TITLE_TEMPLATES = {
     ('hk', 'open'):  '📊 港股开盘快报｜{date} 09:30',
@@ -194,12 +243,14 @@ def main():
         result = {'status': 'market_closed', 'market': args.market,
                   'phase': args.phase, 'date': today, 'reason': reason, 'skip': True}
         TMP.mkdir(parents=True, exist_ok=True)
-        (TMP / f'report-context-{args.market}-{args.phase}-{today}.json').write_text(
-            json.dumps(result, ensure_ascii=False, indent=2))
+        drop_stale_contexts(args.market, args.phase, today)
+        out_path = context_path(args.market, args.phase, today)
+        out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2))
         market_cn = '港股' if args.market == 'hk' else '美股'
         print(f'=== MARKET CLOSED — {market_cn}今日{reason} ({today}) ===')
         print('SKIP：不要生成报告、不要调用任何 send/postflight、本回合到此结束。')
         print(json.dumps(result, ensure_ascii=False, indent=2))
+        announce_context_path(out_path)
         return 0
 
     rc, stdout, stderr = run_analyze(args.market)
@@ -212,9 +263,11 @@ def main():
             'error':  stderr[-500:] if stderr else f'rc={rc}',
         }
         TMP.mkdir(parents=True, exist_ok=True)
-        (TMP / f'report-context-{args.market}-{args.phase}-{today}.json').write_text(
-            json.dumps(result, ensure_ascii=False, indent=2))
+        drop_stale_contexts(args.market, args.phase, today)
+        out_path = context_path(args.market, args.phase, today)
+        out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2))
         print(json.dumps(result, ensure_ascii=False, indent=2))
+        announce_context_path(out_path)
         return 1
 
     signals = parse_signals(stdout)
@@ -243,10 +296,12 @@ def main():
     }
 
     TMP.mkdir(parents=True, exist_ok=True)
-    out_path = TMP / f'report-context-{args.market}-{args.phase}-{today}.json'
+    drop_stale_contexts(args.market, args.phase, today)
+    out_path = context_path(args.market, args.phase, today)
     out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2))
 
     print(json.dumps(result, ensure_ascii=False, indent=2))
+    announce_context_path(out_path)
     return 0
 
 

--- a/scripts/harness/report_watchdog.py
+++ b/scripts/harness/report_watchdog.py
@@ -145,7 +145,11 @@ def main():
             marker = None
     now_ms = int(datetime.now(HKT).timestamp() * 1000)
     fresh = bool(marker) and (now_ms - marker.get('ts', 0)) < MARKER_FRESH_MS
-    matches = bool(marker) and (marker.get('first_line') == raw_block_first)
+    # `first_line` is the first line of the body postflight actually sent, so this
+    # catches a report built from a stale context (2026-07-24 美股收盘报告) as well
+    # as a leftover marker from an earlier slot. Compare stripped: postflight
+    # records a stripped line, the context block may carry trailing whitespace.
+    matches = bool(marker) and ((marker.get('first_line') or '').strip() == raw_block_first.strip())
     # TG is covered iff postflight's cosend confirmably delivered THIS report to
     # Telegram this slot (fresh marker, matching first line, tg_ok=true).
     if marker and marker.get('tg_ok') and fresh and matches:

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -139,12 +139,10 @@ postflight 现在把空输入/旧文件单独判成 `status: input_error`（不�
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market hk --phase {open|mid|pm|close}
 ```
-内部跑 `scripts/data/analyze_hk_stocks.py --wechat`，抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 恒指/恒科方向，输出 `memory/.tmp/report-context-hk-{phase}-{date}.json`。
+内部跑 `scripts/data/analyze_hk_stocks.py --wechat`，抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 恒指/恒科方向，输出 context JSON。
 
 #### Step 2: 读 context，写报告
-```bash
-cat /root/.openclaw/workspace/memory/.tmp/report-context-hk-{phase}-$(date +%Y-%m-%d).json
-```
+⚠️ **context 路径只认 preflight 最后一行打印的 `context_path: <绝对路径>`**，照抄它去 read，不要自己拼文件名。文件名里的日期是**跑批当天**，不是行情 session 那天 —— 2026-07-24 美股收盘就因为猜错日期读到隔夜残留、把一天前的数字发进了微信。`context_path:` 是最后一行，`| tail -N` 也切不掉。
 
 context.json 关键字段：
 - `raw_wechat_block` — 脚本数据块，**verbatim 拷贝到消息开头**。⚠️ 若含 markdown 表格（7 列 holdings），**表头/分隔/数据三类行每字符 1:1 复制**，不要重写分隔行 — 列数必须一致，postflight 会 fail。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -141,9 +141,11 @@ publisher 发布。
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market us --phase {open|close}
 ```
-跑 `scripts/data/analyze_us_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/report-context-us-{phase}-{date}.json`。
+跑 `scripts/data/analyze_us_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 context JSON。
 
 #### Step 2: 读 context，写报告
+⚠️ **context 路径只认 preflight 最后一行打印的 `context_path: <绝对路径>`**，照抄它去 read，不要自己拼文件名。文件名里的日期是**跑批当天**（美股收盘 cron 在 HKT 次日凌晨触发），不是行情 session 那天 —— 2026-07-24 就因为把它猜成 07-23，读到隔夜残留、把一天前的数字发进了微信。`context_path:` 是最后一行，`| tail -N` 也切不掉。
+
 关键字段：
 - `raw_wechat_block` — 脚本输出，**verbatim 拷贝到消息开头**。holdings 是 **markdown 表格** (7 列：代码/股/成本/现价/今日/浮%/浮$；2026-05-21 起 visual-width-aware 渲染走 `_wechat_table.py`，去 $ 前缀加 浮$ 金额列，mobile WeChat 不渲染表格但每行视觉宽度精确一致)。⚠️ **表头/分隔/数据三类行每字符 1:1 复制**，不要重写分隔行 — 列数必须一致，postflight 会 fail。
 - `title` — 自动选好

--- a/tests/test_report_context_path.py
+++ b/tests/test_report_context_path.py
@@ -1,0 +1,205 @@
+"""Regression tests for the 2026-07-24 美股收盘报告 stale-context incident.
+
+What happened: the cron payload named the preflight output as
+``report-context-us-close-{date}.json``. The agent resolved ``{date}`` to the
+*market close* date (07/23) instead of the *run* date (07/24), yesterday's
+leftover file sat at exactly that name, so a day-old portfolio was written into
+the report and pushed to WeChat. Postflight's verbatim check caught it and
+skipped the commit, but it sends on every status — so the stale body went out,
+the retry with fresh data was blocked by the idempotency marker, and the
+watchdog never backstopped because the marker recorded the *expected* first line
+rather than the one actually sent.
+
+Three defences, one test each:
+  1. preflight prints the absolute path as its final stdout line
+  2. preflight deletes this market+phase's contexts from other dates
+  3. postflight's marker records the first line of the body it really sent
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / 'scripts' / 'harness'
+
+
+def _load(name):
+    """Import a harness module by path — they are scripts, not a package."""
+    for extra in (ROOT / 'scripts' / 'data', HARNESS):
+        if str(extra) not in sys.path:
+            sys.path.insert(0, str(extra))
+    spec = importlib.util.spec_from_file_location(name, HARNESS / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def preflight():
+    return _load('report_preflight')
+
+
+@pytest.fixture
+def postflight():
+    return _load('report_postflight')
+
+
+@pytest.fixture
+def tmp_context_dir(tmp_path, monkeypatch, preflight):
+    monkeypatch.setattr(preflight, 'TMP', tmp_path)
+    return tmp_path
+
+
+# ── 2. stale-context cleanup ────────────────────────────────────────────────
+
+def test_drop_stale_contexts_removes_other_dates_only(preflight, tmp_context_dir):
+    """The exact file the agent misread (yesterday's us/close) must be gone,
+    and nothing else may be touched."""
+    names = [
+        'report-context-us-close-2026-07-22.json',   # stale — the footgun
+        'report-context-us-close-2026-07-23.json',   # stale — what was misread
+        'report-context-us-close-2026-07-24.json',   # today — keep
+        'report-context-us-open-2026-07-23.json',    # other phase — keep
+        'report-context-hk-close-2026-07-23.json',   # other market — keep
+        'report-sent-us-close-2026-07-23.json',      # different artifact — keep
+    ]
+    for name in names:
+        (tmp_context_dir / name).write_text('{}')
+
+    dropped = preflight.drop_stale_contexts('us', 'close', '2026-07-24')
+
+    assert sorted(dropped) == [
+        'report-context-us-close-2026-07-22.json',
+        'report-context-us-close-2026-07-23.json',
+    ]
+    survivors = sorted(p.name for p in tmp_context_dir.iterdir())
+    assert survivors == [
+        'report-context-hk-close-2026-07-23.json',
+        'report-context-us-close-2026-07-24.json',
+        'report-context-us-open-2026-07-23.json',
+        'report-sent-us-close-2026-07-23.json',
+    ]
+
+
+def test_drop_stale_contexts_is_noop_without_leftovers(preflight, tmp_context_dir):
+    (tmp_context_dir / 'report-context-us-close-2026-07-24.json').write_text('{}')
+    assert preflight.drop_stale_contexts('us', 'close', '2026-07-24') == []
+    assert (tmp_context_dir / 'report-context-us-close-2026-07-24.json').exists()
+
+
+# ── 1. the path is announced, and survives `| tail -N` ──────────────────────
+
+def test_market_closed_run_announces_context_path_as_final_line(
+    preflight, tmp_context_dir, monkeypatch, capsys
+):
+    """Drives the real main() through its holiday branch: the agent's own
+    `| tail -80` is why the JSON's `date` field was lost, so the guarantee under
+    test is positional — `context_path:` must be the LAST stdout line."""
+    monkeypatch.setattr(preflight, '_market_closed_reason', lambda m, p: '周末休市')
+    monkeypatch.setattr(sys, 'argv',
+                        ['report_preflight.py', '--market', 'us', '--phase', 'close'])
+    stale = tmp_context_dir / 'report-context-us-close-2026-07-23.json'
+    stale.write_text('{"stale": true}')
+
+    assert preflight.main() == 0
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[-1].startswith('context_path: ')
+    announced = Path(lines[-1].split('context_path: ', 1)[1])
+    assert announced.is_absolute()
+    assert announced.exists()
+    assert json.loads(announced.read_text())['status'] == 'market_closed'
+    # …and the holiday branch cleans up too, or the next run inherits the footgun
+    assert not stale.exists()
+
+
+def test_preflight_failure_run_also_announces_context_path(
+    preflight, tmp_context_dir, monkeypatch, capsys
+):
+    """The failure branch writes a context that postflight will read, so it owes
+    the same announcement — an unannounced path is what forces a guess."""
+    monkeypatch.setattr(preflight, '_market_closed_reason', lambda m, p: None)
+    monkeypatch.setattr(preflight, 'run_analyze', lambda market: (1, '', 'boom'))
+    monkeypatch.setattr(sys, 'argv',
+                        ['report_preflight.py', '--market', 'us', '--phase', 'close'])
+
+    assert preflight.main() == 1
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[-1].startswith('context_path: ')
+    assert json.loads(
+        Path(lines[-1].split('context_path: ', 1)[1]).read_text()
+    )['status'] == 'preflight_failed'
+
+
+# ── 3. the send marker records what was actually sent ──────────────────────
+
+def _capture_marker(postflight, tmp_path, monkeypatch, *, text, prefix=''):
+    monkeypatch.setattr(postflight, 'TMP', tmp_path)
+    monkeypatch.setattr(postflight, 'resolve_wechat_target',
+                        lambda market: ('weixin', 'kcn', 'acct'))
+    monkeypatch.setattr(postflight, 'send_wechat',
+                        lambda *a, **k: (True, 'sent'))
+    monkeypatch.setattr(postflight, 'cosend_telegram',
+                        lambda *a, **k: (True, 'sent'))
+    postflight.deliver_wechat('us', 'close', '2026-07-24', prefix, text)
+    return json.loads((tmp_path / 'report-sent-us-close-2026-07-24.json').read_text())
+
+
+FRESH_FIRST = '🇺🇸 美股盯盘 | 07/23 16:00 ET'
+STALE_FIRST = '🇺🇸 美股盯盘 | 07/22 16:02 ET'
+
+
+def test_marker_records_first_line_of_the_body_actually_sent(
+    postflight, tmp_path, monkeypatch
+):
+    marker = _capture_marker(
+        postflight, tmp_path, monkeypatch,
+        text=f'{FRESH_FIRST}\n\n📊 市值 $2,508\n')
+    assert marker['first_line'] == FRESH_FIRST
+    assert marker['sent_ok'] is True and marker['tg_ok'] is True
+
+
+def test_marker_exposes_a_stale_body_so_the_watchdog_can_backstop(
+    postflight, tmp_path, monkeypatch
+):
+    """The incident itself: a body built from yesterday's context, sent behind a
+    🔴 banner. The marker must carry the STALE line — recording the fresh line
+    the context expected made the watchdog's mismatch check tautological, so no
+    backstop ever fired and kcn's WeChat kept the wrong numbers."""
+    marker = _capture_marker(
+        postflight, tmp_path, monkeypatch,
+        prefix='🔴 Validation FAILED (2 issues), 报告仍发布但未 commit:\n- ...\n\n',
+        text=f'{STALE_FIRST}\n\n📊 市值 $2,495\n')
+
+    assert marker['first_line'] == STALE_FIRST
+    # what report_watchdog computes from the fresh context, and its `matches` test
+    assert marker['first_line'].strip() != FRESH_FIRST.strip()
+
+
+def test_marker_first_line_ignores_the_validation_banner(
+    postflight, tmp_path, monkeypatch
+):
+    """`wechat_prefix` leads the delivered message but is not part of the report;
+    keying on the prefixed message would make every warn/fail run look stale."""
+    marker = _capture_marker(
+        postflight, tmp_path, monkeypatch,
+        prefix='⚠️ Validation warnings (1): 报告长度 2409 字 > 2000 软上限 (warn)\n\n',
+        text=f'{FRESH_FIRST}\n\n📊 市值 $2,508\n')
+    assert marker['first_line'] == FRESH_FIRST
+
+
+def test_marker_survives_an_empty_body_without_crashing(
+    postflight, tmp_path, monkeypatch
+):
+    """main() gates on MIN_REPORT_CHARS before delivery, but deliver_wechat must
+    not be the thing that raises if that gate ever moves."""
+    marker = _capture_marker(postflight, tmp_path, monkeypatch, text='   \n')
+    assert marker['first_line'] == ''


### PR DESCRIPTION
## 事故

07-24 04:00 `美股收盘报告` run 记 ✅ ok，但发到微信/Telegram 的是 **07/22 的数据**，带 🔴 Validation FAILED 横幅。落盘数据是对的（`d07367a1` 提交的是 fresh 数据），**只有推送出去的那条消息是错的**。

链条（session `f5b8ed36`）：

1. preflight 被 agent 用 `| tail -80` 跑（JSON 含 peer_scan 约 350 行）→ 顶部的 `date` 字段被切掉，而 preflight **从不打印自己写到哪**。
2. cron payload 把输出写成 `report-context-us-close-{date}.json`，`{date}` 有歧义。agent 把它解成**行情收盘日 07/23**，而脚本用的是**跑批日 07/24**。
3. **昨天那跑的残留文件正好叫这个名字**（`memory/.tmp/` 里从 07-10 起一个没清）→ 猜错的读取变成了「成功加载」。
4. postflight 的 verbatim 校验抓到了（`status=fail`），但它**所有状态包括 fail 都发** → 旧数据进了微信；commit 被 fail 闸掉。
5. agent 用 fresh context 重写，第二次 postflight `pass` + commit + push 成功，但重发被幂等锁挡住 → 微信停在错版。
6. watchdog 也没兜底：marker 的 `first_line` 记的是 context **期望**的首行而不是**实际发出去**的首行，`matches` 判据恒真。

## 本 PR：三道防线，全部 harness 侧

| # | 改动 | 为什么这道能挡住 |
|---|---|---|
| 1 | preflight 三个出口都在 **stdout 最后一行**打印 `context_path: <绝对路径>` | 打印在最后 = `\| tail -N` 切不掉，正是当初丢 `date` 的那个动作 |
| 2 | preflight 清掉该 market+phase **其它日期**的 context | 没有残留 → 同样的猜错变成响亮的 `FileNotFoundError`。保留 N 天没用——被读错的文件只有一天 |
| 3 | marker 的 `first_line` 改记**实际发送正文**的首行；watchdog 两边 strip 后比较 | 让 watchdog 的错版检测真的能触发 |

`skills/{hk,us}-stock-analysis/SKILL.md` + `TOOLS_SCRIPTS.md` 同步说明「读 `context_path:` 那行，别拼文件名」。

**不改 `config/cron-schedules.json`，不需要动任何 live cron payload** —— 合并即生效，零协调。

## 这是过渡热修，不是终局

经与 codex 两轮对抗性评审，确定的durable 方案是**把确定性数据块彻底移出模型回路**：preflight 内联给模型一份精简 context（peer_scan 占了 ~330 行里的 298 行，是当初逼出 `tail -80` 的元凶），模型只产出 ▎情绪面/▎技术面/▎操作建议/▎风险提示 散文，postflight 自己拼 `title + raw_wechat_block + 散文`。届时：

- `{date}` 这一类 bug **结构性消失**，不再靠提示规避
- `validate()` 规则 1（verbatim + 表格 1:1）整条删除
- payload 可删掉约 61-68% 的行，每个 SKILL.md 约 35-45 行
- codex 的 fail-closed 结论并入其中：`pass/warn` 发全文，`fail` 只发数据块 + 横幅（绝不发被拒的散文），`market_closed`/preflight 失败不发
- 用 `context_id`（context 的 SHA-256）绑定，模型回传、postflight 校验，杜绝「新块 + 旧散文」的静默错配

那次改动会**一次性**重写 6 条 live payload。所以本 PR **故意不往契约里钉 `context_path`** —— 钉了就得在同一天改两遍 live payload，白白扩大暴露面。

## 测试

`tests/test_report_context_path.py`（8 个）。四处修改**逐个反向变异验证**：

| 变异 | 变红的测试 |
|---|---|
| 去掉 `context_path` 打印 | 2 个 announce 测试 |
| 停用残留清理 | 4 个 |
| marker 记回 context 期望首行（原 bug） | stale-body backstop 测试 |
| marker 改用带横幅的整条消息 | banner 测试 + stale-body 测试 |

本地 461 passed / 5 xfailed。
