### PR TITLE
harness: take the data block out of the model's hands (Mode 6 reports)

### DIFF
--- a/4fb2df1611ed42e5b67fd6171a237acb.txt
+++ b/4fb2df1611ed42e5b67fd6171a237acb.txt
@@ -1,1 +1,0 @@
-4fb2df1611ed42e5b67fd6171a237acb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,9 @@ Each cron job's prompt tells you which harness 4-step to execute:
 Step 1  preflight     scripts/harness/{brief|report|intraday}_preflight.py [args]
                       → writes memory/.tmp/{brief|report|intraday}-context-*.json
 Step 2  read context  inside that .json: raw_wechat_block, anomalies, title, signals, etc.
-Step 3  LLM synthesis you write the report + (brief only) plan.json
-                      following the SKILL.md Mode template, MUST quote raw_wechat_block verbatim
+Step 3  LLM synthesis you write the analysis prose + (brief only) plan.json
+                      following the SKILL.md Mode template. Mode 6 reports: prose ONLY —
+                      report_postflight prepends title + raw_wechat_block itself
 Step 4  postflight    scripts/harness/{brief|report|intraday}_postflight.py [args]
                       validates report, computes wechat_prefix, then handles its scoped publish
                       (all three auto-run build_dashboard.py; intraday commits only semantic diffs)

--- a/TOOLS_SCRIPTS.md
+++ b/TOOLS_SCRIPTS.md
@@ -46,9 +46,9 @@ title: clawock · scripts 详细参考
 - **`scripts/harness/intraday_postflight.py --market {hk|us} --text-file memory/.tmp/intraday-report-{hk|us}.md`**（**先写文件再调用，禁 heredoc/`<<<`**；空输入/超 20 分钟的旧文件判 `status: input_error` 并拒投）：校验 ▎我的看法 / 长度 / should_alert 触发时报告必须提异动票；不提交 `portfolio.json`，dashboard 仅在语义变化时 commit + push；无论有无 dashboard diff 都更新本地 slot heartbeat，交 single publisher 发布。
 
 **共通设计点**：
-- preflight 输出 `raw_wechat_block` 字段，LLM **必须 verbatim 拷贝**（不改时间戳/数字），postflight 用首行匹配验证
-- preflight 输出 `anomalies` 字段，LLM 必须在报告里至少提一个 anomaly 票
-- postflight 输出 `wechat_prefix`（pass=空串，warn=黄 banner，fail=红 banner），LLM 拼到 WeChat 输出前
+- `raw_wechat_block`：**Mode 6 报告**（report_postflight）由 harness 自己拼进消息，LLM 只写散文、不碰数据块；**intraday** 仍是 LLM verbatim 拷贝 + postflight 首行验证
+- preflight 输出 `anomalies` 字段，LLM 必须在报告里至少提一个 anomaly 票（report 按**模型散文**校验，数据块里的票代码不算数）
+- `wechat_prefix`（pass=空串，warn=黄 banner，fail=红 banner）：report_postflight 自己发，不再回给 LLM 拼；intraday 仍回给 LLM
 - 所有 context.json 都放 `memory/.tmp/`（gitignore 排除）
 
 ### 辅助

--- a/TOOLS_SCRIPTS.md
+++ b/TOOLS_SCRIPTS.md
@@ -37,8 +37,8 @@ title: clawock · scripts 详细参考
 - **`scripts/harness/brief_postflight.py`**：校验 `memory/{date}-pre-open.md` + `memory/{date}-plan.json`（段标记 / plan schema / HHI / FX / HKD+USD bug pattern）；pass/warn 自动 commit
 
 **Mode 6 briefing**（HK 开/午/午后/收盘 + US 开/收盘 — 6 个 cron 共享）
-- **`scripts/harness/report_preflight.py --market {hk|us} --phase {open|mid|pm|close}`**：跑 analyze_*.py + 抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 指数方向；输出 `memory/.tmp/report-context-{market}-{phase}-{date}.json`（`{date}` = 跑批当天），含 `raw_wechat_block`（LLM verbatim 用）+ `title` + `needs_risk_section`。**末行打印 `context_path: <绝对路径>`——读 context 一律照抄这行，别拼文件名**；同时清掉该 market+phase 其它日期的残留 context
-- **`scripts/harness/report_postflight.py --market {hk|us} --phase {phase}`**：校验三段标记 / 原始数据块 verbatim / 异动票必须被提及 / 长度 / 敷衍词；pass/warn 自动刷新 snapshot/dashboard、scoped commit + push，并主发 WeChat + 镜像 Telegram。
+- **`scripts/harness/report_preflight.py --market {hk|us} --phase {open|mid|pm|close}`**：跑 analyze_*.py + 抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 指数方向；写 `memory/.tmp/report-context-{market}-{phase}-{date}.json`（`{date}` = 跑批当天）并清掉该 market+phase 其它日期的残留；**stdout 与文件是同一份 JSON**（含 `context_id`，末行 `context_path:`），靠 `peer_scan` 在源头裁剪保持小体积。`raw_wechat_block` 不再经模型手 —— postflight 自己拼进消息
+- **`scripts/harness/report_postflight.py --market {hk|us} --phase {phase} --context-id ID --text-file PATH`**：拼 `title + raw_wechat_block + 模型散文`，校验三段标记 / 异动票必须被提及 / 长度 / 敷衍词；`--context-id` 不匹配或散文文件 >30min 未更新则拒发。**fail-closed**：pass/warn 发全文 + scoped commit/push，fail 只发数据块（绝不发被拒散文）且不 commit，休市/缺 context 不发。失败过的 slot 之后可被合格报告**补发一次**。主发 WeChat + 镜像 Telegram。
 - **`scripts/harness/report_watchdog.py --market {hk|us} --phase {phase} --job-name "{cron名}"`**：系统 crontab 的 LLM-free Telegram-only backstop。覆盖 HK 4 班 + US 开/收 2 班；读取 postflight delivery marker，只有 Telegram 未确认时才补投，绝不重发 WeChat。
 
 **Mode 7 intraday**（HK + US 盘中盯盘 — 3 个 cron job 共享同一套脚本；季节化 slot 数和精确时间只看生成调度表，隔夜始终最晚 02:30 HKT）

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -19,10 +19,12 @@
       "model": "minimax/MiniMax-M3",
       "delivery_mode": "none",
       "required_substrings": [
-        "trading_calendar.py {market}",
         "skills/{skill}/SKILL.md",
         "report_preflight.py --market {market} --phase {phase}",
-        "report_postflight.py --market {market} --phase {phase}",
+        "context_id",
+        "report_postflight.py --market {market} --phase {phase} --context-id",
+        "--text-file",
+        "report-prose-{market}-{phase}.md",
         "目标 ≤ 2200 字",
         ">3000 字 warn",
         ">3500 字 fail",
@@ -39,7 +41,10 @@
         "目标 ≤ 1200 字",
         ">2000 字 warn",
         ">2500 字 fail",
-        "唯一发送路径"
+        "唯一发送路径",
+        "report-context-",
+        "verbatim",
+        "trading_calendar.py"
       ]
     },
     "intraday": {

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -2,30 +2,38 @@
 """
 report_postflight.py — Mode 6 (briefing) harness postflight.
 
-Validates the LLM-generated WeChat briefing AFTER it's been written.
+Assembles, validates and publishes the Mode 6 briefing.
 
-Usage: read the briefing text from stdin (preferred for cron),
-       or pass --text-file PATH.
+Two input modes:
+  prose  (--context-id ID --text-file PATH)  the model supplies ONLY the analysis
+         sections; this script prepends ctx['title'] + ctx['raw_wechat_block'].
+         ID must equal the context's `context_id` or the run is rejected.
+  legacy (no --context-id)                   the model supplies the whole report
+         including its own copy of the data block, which is then verbatim-checked.
+         Kept so a master deploy that lands before the cron payloads are updated
+         still delivers; remove once every payload passes --context-id.
 
-Validates:
+Validates (on the assembled message):
   1. ▎情绪面 / ▎技术面 / ▎操作建议 三段标记齐全
   2. 若 preflight needs_risk_section=true, 必须有 ▎风险提示 段
   3. 总长度 ≤ 3000 字 (warn) / ≤ 3500 字 (fail) — HK + US 统一（2026-07-23 调升）
-  4. 必须以 raw_wechat_block 开头（脚本数据块 verbatim，禁止编造）
+  4. legacy only: 必须以 raw_wechat_block 开头（prose 模式由本脚本拼，无需校验）
   5. 如果 preflight 有 anomalies，报告必须提到至少一个 anomaly 票
   6. 没有"等待数据/数据待获取"等敷衍词
 
-Side effects:
-  - status=pass/warn: refresh snapshot/dashboard, commit the scoped generated
-    state, push through safe_push.sh, then send WeChat + Telegram mirror
-  - status=fail: no commit, return non-zero
+Delivery is fail-closed (2026-07-24): pass/warn send the full body and commit;
+fail sends the data block ALONE — never the rejected prose — and does not commit;
+a closed market or a missing context sends nothing. A slot whose only delivery was
+a fail-closed data block may be superseded exactly once by a validated report
+(see claim_upgrade).
 
 Outputs JSON to stdout:
-  {"status": "pass|warn|fail", "issues": [...], "wechat_prefix": "..."}
+  {"status": "pass|warn|fail", "mode": "prose|legacy", "issues": [...], ...}
 """
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -53,6 +61,10 @@ FORBIDDEN_PHRASES = ['数据待获取', '等待数据', '数据缺失（占位�
 # degenerate-input case BEFORE send/commit so a broken pipe never reaches WeChat.
 MIN_REPORT_CHARS = 50
 
+# Report slots are hours apart (open/mid/pm/close), so a prose file older than
+# this is the previous slot's, not this one's. See read_prose_text.
+PROSE_MAX_AGE_MIN = 30
+
 # Char limits — HK + US 统一 3000/3500（2026-07-23 起，各档在 2000/2500 基础上 +1000；
 # 更早一版 1200 太紧、2000 仍让正常长度的报告频繁 warn）
 CHAR_LIMITS = {
@@ -71,12 +83,38 @@ def load_context(market, phase, date):
         return None, f'preflight context 解析失败: {e}'
 
 
-def validate(text, ctx):
+def assemble_message(ctx, prose):
+    """Build the delivered report from harness-owned data + model-owned prose.
+
+    The 2026-07-24 incident happened because the deterministic data block made a
+    round trip through the LLM: preflight put it in the context, the payload
+    ordered the model to copy it verbatim, and validate() checked the copy. A
+    model that read the wrong context therefore published wrong numbers, and the
+    verbatim check could only notice *after* the send.
+
+    Prepending it here removes the round trip: the numbers in the delivered
+    message come from the context file at send time, so they cannot be stale,
+    paraphrased, or table-mangled — no instruction and no validation rule needed.
+    """
+    parts = [ctx.get('title', '').strip(),
+             (ctx.get('raw_wechat_block') or '').strip(),
+             prose.strip()]
+    return '\n\n'.join(p for p in parts if p)
+
+
+def validate(text, ctx, prose_only=False):
+    """Validate the ASSEMBLED message. `text` is the full delivered body.
+
+    With prose_only the block was prepended by assemble_message, so the verbatim
+    and table checks are dead by construction and are skipped — keeping them
+    would assert that the harness can copy its own string. Every remaining rule
+    is a property of what the MODEL wrote, which is the only thing left to judge.
+    """
     issues = []
 
-    # 1. raw block 必须 verbatim 出现
+    # 1. raw block 必须 verbatim 出现（legacy path only — see docstring）
     raw = ctx.get('raw_wechat_block', '').strip()
-    if raw:
+    if raw and not prose_only:
         first_line = raw.splitlines()[0]
         if first_line not in text:
             issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 验证失败)')
@@ -142,7 +180,76 @@ from _harness_common import (  # noqa: E402
 from _watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
 
 
-def deliver_wechat(market, phase, date, wechat_prefix, text):
+def read_prose_text(market, phase, text_file):
+    """Return (text, input_error). Plumbing failures never reach validate().
+
+    The prose-mode move to --text-file buys us out of heredoc quoting (the report
+    is full of emoji, `$` and `|` table pipes), but it opens the failure PR #22
+    hit on intraday: the model forgets to rewrite the file and postflight happily
+    republishes the previous slot's prose. `context_id` does NOT catch that — the
+    model passes the CURRENT id on the command line while the file holds old text.
+    So the file's own mtime is the gate. Report slots are hours apart, so 30
+    minutes is generous and still far below the gap to the previous slot.
+    """
+    hint = (f'Step 2 应先把散文写入 memory/.tmp/report-prose-{market}-{phase}.md，'
+            f'再用 --text-file 调用 postflight')
+    if not text_file:
+        text = sys.stdin.read()
+        return (text, None) if text.strip() else ('', f'空输入 (stdin) — {hint}')
+
+    path = Path(text_file)
+    if not path.exists():
+        return '', f'散文文件不存在: {path} — {hint}'
+    age_min = (datetime.now().timestamp() - path.stat().st_mtime) / 60
+    if age_min > PROSE_MAX_AGE_MIN:
+        return '', (f'散文文件 {path.name} 已 {age_min:.0f} 分钟未更新 '
+                    f'(> {PROSE_MAX_AGE_MIN} 分钟上限) — 疑似上一个 slot 的旧文本，'
+                    f'拒绝投递；{hint}')
+    text = path.read_text()
+    if not text.strip():
+        return '', f'空输入 (--text-file {path.name}) — {hint}'
+    return text, None
+
+
+def _marker_state(marker_path):
+    """'delivered' | 'failed' | None. Markers written before this field existed
+    are treated as full deliveries — the conservative read, since assuming
+    'failed' would let an old marker unlock a re-send."""
+    try:
+        return json.loads(Path(marker_path).read_text()).get('delivery_state', 'delivered')
+    except Exception:
+        return None
+
+
+def claim_upgrade(market, phase, date):
+    """Atomically claim the one allowed failed→delivered re-send. True = it's ours.
+
+    Fail-closed means a rejected report is delivered as the data block alone. If
+    the model then fixes its prose, that corrected report MUST be able to reach
+    kcn — otherwise fail-closed is strictly worse than 2026-07-24, where at least
+    the numbers were eventually right on disk. But an unlimited re-send window
+    reopens the 2026-06-03 duplicate-send class, and openclaw's auto-retry of a
+    run can fire the same postflight several times.
+
+    O_EXCL create is the whole lock: the first caller to create the claim file
+    wins and sends, every later one loses and skips. One upgrade, no counting, no
+    read-then-write race between concurrent retries.
+    """
+    claim = TMP / f'report-upgrade-{market}-{phase}-{date}.claim'
+    try:
+        fd = os.open(claim, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return False
+    except OSError as e:
+        print(f'warn: upgrade claim failed ({e}) — not re-sending', file=sys.stderr)
+        return False
+    with os.fdopen(fd, 'w') as f:
+        f.write(datetime.now().isoformat(timespec='seconds'))
+    return True
+
+
+def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='delivered',
+                   context_id=None):
     """Primary WeChat send for staged reports — fresh-token `openclaw message send`,
     decoupled from the cron's announce.
 
@@ -187,6 +294,11 @@ def deliver_wechat(market, phase, date, wechat_prefix, text):
             'sent_ok': bool(sent_ok),
             'tg_ok': bool(tg_ok),
             'first_line': sent_first,
+            'delivery_state': delivery_state,
+            # Exact slot identity for report_watchdog. In prose mode the sent body
+            # starts with the title, so first_line no longer matches the context's
+            # block and a string compare would mirror a duplicate to Telegram.
+            'context_id': context_id,
             'market': market,
             'phase': phase,
             'out': (out or '')[-200:],
@@ -232,6 +344,11 @@ def main():
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
     parser.add_argument('--phase', choices=['open', 'mid', 'pm', 'close'], required=True)
     parser.add_argument('--text-file', help='briefing text file (default: stdin)')
+    parser.add_argument('--context-id',
+                        help='context_id echoed from preflight. Its presence selects '
+                             'prose mode: the input is the analysis sections only and '
+                             'this script prepends title + raw_wechat_block itself. '
+                             'Omit for the legacy full-report input.')
     args = parser.parse_args()
 
     # Holiday/weekend gate: never send/commit on a closed market — even if the
@@ -246,13 +363,24 @@ def main():
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 0
 
-    if args.text_file:
-        text = Path(args.text_file).read_text()
-    else:
-        text = sys.stdin.read()
+    text, in_err = read_prose_text(args.market, args.phase, args.text_file)
+    if in_err:
+        # Classified apart from `fail`: this is a broken caller, not a bad report.
+        # Nothing is sent — a stale or missing file must never be republished —
+        # and the non-zero exit keeps the run record honest (a false green here is
+        # worse than a false red: it would hide a silently skipped report).
+        print(f'error: {in_err}', file=sys.stderr)
+        result = {
+            'status': 'input_error', 'market': args.market, 'phase': args.phase,
+            'issues': [in_err], 'wechat_prefix': '', 'wechat_sent': False,
+            'commit_ok': False, 'commit_msg': 'skipped (input error)', 'n_chars': 0,
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 2
 
     today = datetime.now().strftime('%Y-%m-%d')
     ctx, ctx_err = load_context(args.market, args.phase, today)
+    prose_only = args.context_id is not None
 
     if ctx is None:
         result = {
@@ -286,8 +414,22 @@ def main():
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
 
-    issues = validate(text, ctx)
-    status = categorize(issues)
+    # ── Generation gate (prose mode only) ────────────────────────────────────
+    # The model echoes the context_id it wrote against. A mismatch means the
+    # context on disk was replaced after the prose was written — exactly what
+    # happened on 2026-07-24, where the agent ran preflight a second time
+    # mid-turn. Assembling fresh numbers under stale prose would produce an
+    # internally contradictory report that LOOKS clean, which is worse than the
+    # loud banner we got, so refuse to assemble and fall back to data-only.
+    stale_generation = prose_only and args.context_id != ctx.get('context_id')
+
+    if prose_only and not stale_generation:
+        text = assemble_message(ctx, text)
+
+    issues = ([f'context_id 不匹配: 模型基于 {args.context_id}，当前 context 是 '
+               f'{ctx.get("context_id")} — 散文与数据不同代，拒绝拼装']
+              if stale_generation else validate(text, ctx, prose_only=prose_only))
+    status = categorize(issues) if not stale_generation else 'fail'
 
     if status == 'pass':
         wechat_prefix = ''
@@ -297,27 +439,51 @@ def main():
                          + ('; ...' if len(issues) > 3 else '')
                          + '\n\n')
     else:
-        wechat_prefix = (f'🔴 Validation FAILED ({len(issues)} issues), 报告仍发布但未 commit:\n'
+        wechat_prefix = (f'🔴 Validation FAILED ({len(issues)} issues), 仅发布数据块、未 commit:\n'
                          + '\n'.join('- ' + i for i in issues[:5])
                          + ('\n- ...' if len(issues) > 5 else '')
                          + '\n\n')
 
+    # ── Fail-closed body selection ───────────────────────────────────────────
+    # A rejected report used to be delivered in full behind its banner, which is
+    # how 07/22 numbers reached kcn on 2026-07-24. But silence is also wrong: a
+    # market day with no message is indistinguishable from a dead cron. So a
+    # failure delivers the harness-owned data block ALONE — every number in it is
+    # trustworthy by construction — and drops the prose that failed validation.
+    # This is the same shape report_watchdog already uses as its deterministic
+    # fallback. pass/warn deliver the full body.
+    if status == 'fail':
+        body = assemble_message(ctx, '')
+    else:
+        body = text
+
     # ── Primary WeChat send (fresh token, decoupled from the cron announce) ───
-    # Send on ALL statuses incl. fail — a fail report is still published to kcn
-    # with its banner (matches the old announce behavior); only the commit is
-    # gated on not-fail. The staged crons run --no-deliver so this is the sole
-    # send. See deliver_wechat() docstring for the #61174 long-turn-drop rationale.
     # Idempotency: this phase's marker is per market+phase+date and fires once/day,
     # so if it already shows a delivery this is an openclaw auto-retry of a run that
     # errored only in post-turn summary-gen — the report already went out. Skip the
     # re-send (watchdog still backstops a genuine miss). See already_delivered.
     report_marker = TMP / f'report-sent-{args.market}-{args.phase}-{today}.json'
-    if already_delivered(report_marker):
+    delivery_state = 'failed' if status == 'fail' else 'delivered'
+    blocked = already_delivered(report_marker)
+
+    # One exception to the idempotency lock: the slot's only delivery so far was a
+    # fail-closed data block, and this run has a report that actually validates.
+    # claim_upgrade() makes it exactly one. Everything else — a second failure, a
+    # retry of an already-good send — stays blocked.
+    if blocked and delivery_state == 'delivered' and _marker_state(report_marker) == 'failed':
+        if claim_upgrade(args.market, args.phase, today):
+            print(f'upgrade: {args.market}-{args.phase} superseding the fail-closed '
+                  f'data block with the validated report', file=sys.stderr)
+            blocked = False
+
+    if blocked:
         print(f'idempotency: {args.market}-{args.phase} already delivered today — skip re-send',
               file=sys.stderr)
         wechat_sent = True
     else:
-        wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, text)
+        wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
+                                        delivery_state=delivery_state,
+                                        context_id=ctx.get('context_id'))
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
 
@@ -326,12 +492,14 @@ def main():
         'market':        args.market,
         'phase':         args.phase,
         'date':          today,
+        'mode':          'prose' if prose_only else 'legacy',
         'issues':        issues,
         'wechat_prefix': wechat_prefix,
         'wechat_sent':   wechat_sent,
+        'delivered':     'data-block only (prose rejected)' if status == 'fail' else 'full report',
         'commit_ok':     commit_ok,
         'commit_msg':    commit_msg,
-        'n_chars':       len(text),
+        'n_chars':       len(body),
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -83,6 +83,24 @@ def load_context(market, phase, date):
         return None, f'preflight context 解析失败: {e}'
 
 
+def _unusable_context(ctx, prose_only):
+    """Reason string if the context can't back a report, else None.
+
+    preflight writes blockless sentinels (status preflight_failed / market_closed)
+    that carry none of the deterministic fields postflight assembles from. Anything
+    but a 'ok' status with a nonempty raw block + title + commit_msg — plus a
+    context_id in prose mode — is not a report context.
+    """
+    if ctx.get('status') != 'ok':
+        return f'context status={ctx.get("status")!r}（preflight 未产出可用数据），跳过投递+commit'
+    missing = [k for k in ('raw_wechat_block', 'title', 'commit_msg') if not (ctx.get(k) or '').strip()]
+    if prose_only and not (ctx.get('context_id') or '').strip():
+        missing.append('context_id')
+    if missing:
+        return f'context 缺字段 {missing}，跳过投递+commit'
+    return None
+
+
 def assemble_message(ctx, prose):
     """Build the delivered report from harness-owned data + model-owned prose.
 
@@ -102,35 +120,41 @@ def assemble_message(ctx, prose):
     return '\n\n'.join(p for p in parts if p)
 
 
-def validate(text, ctx, prose_only=False):
-    """Validate the ASSEMBLED message. `text` is the full delivered body.
+def validate(body, ctx, prose_only=False, model_text=None):
+    """Validate the delivered message.
 
-    With prose_only the block was prepended by assemble_message, so the verbatim
-    and table checks are dead by construction and are skipped — keeping them
-    would assert that the harness can copy its own string. Every remaining rule
-    is a property of what the MODEL wrote, which is the only thing left to judge.
+    `body` is what gets sent. `model_text` is the part the MODEL wrote; in prose
+    mode that is the prose alone, in legacy mode it is the whole report (== body).
+
+    The content rules — sections, risk section, anomaly mention, forbidden phrases
+    — MUST run against model_text, never body. In prose mode assemble_message has
+    already prepended the raw data block, and that block itself contains the
+    anomaly tickers and (potentially) section-looking tokens: checking body would
+    let prose that mentions none of the movers pass because the table does. Only
+    the length limit is a property of the assembled body. (2026-07-24 review.)
     """
     issues = []
+    checked = body if model_text is None else model_text
 
     # 1. raw block 必须 verbatim 出现（legacy path only — see docstring）
     raw = ctx.get('raw_wechat_block', '').strip()
     if raw and not prose_only:
         first_line = raw.splitlines()[0]
-        if first_line not in text:
+        if first_line not in body:
             issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 验证失败)')
-        issues.extend(check_raw_tables_verbatim(text, raw))
+        issues.extend(check_raw_tables_verbatim(body, raw))
 
-    # 2. 必有三段标记
+    # 2. 必有三段标记（模型文本）
     for sec in REQUIRED_SECTIONS:
-        if sec not in text:
+        if sec not in checked:
             issues.append(f'缺段标记 "{sec}"')
 
-    # 3. 风险提示段（若 preflight 标了 needs）
-    if ctx.get('needs_risk_section') and '▎风险提示' not in text:
+    # 3. 风险提示段（若 preflight 标了 needs；模型文本）
+    if ctx.get('needs_risk_section') and '▎风险提示' not in checked:
         issues.append('preflight 标 needs_risk_section=true 但未见 "▎风险提示" 段')
 
-    # 4. 长度 (per-market)
-    n_chars = len(text)
+    # 4. 长度 —— 按投递全文 (per-market)
+    n_chars = len(body)
     limits = CHAR_LIMITS.get(ctx.get('market', 'hk'), CHAR_LIMITS['hk'])
     soft, hard = limits['soft'], limits['hard']
     if n_chars > hard:
@@ -138,16 +162,16 @@ def validate(text, ctx, prose_only=False):
     elif n_chars > soft:
         issues.append(f'报告长度 {n_chars} 字 > {soft} 软上限 (warn)')
 
-    # 5. 异动票必须被提到
+    # 5. 异动票必须被提到（模型文本 —— 数据块里本就有票代码，不能拿它顶）
     anomalies = ctx.get('anomalies', [])
     if anomalies:
-        mentioned = [a['ticker'] for a in anomalies if a['ticker'] in text]
+        mentioned = [a['ticker'] for a in anomalies if a['ticker'] in checked]
         if not mentioned:
             tickers = ', '.join(a['ticker'] for a in anomalies)
             issues.append(f'preflight 标了 {len(anomalies)} 个 ≥3% 异动票 ({tickers}) 但报告全部未提及')
 
-    # 6. 敷衍 phrases
-    issues.extend(validate_forbidden_phrases(text, FORBIDDEN_PHRASES))
+    # 6. 敷衍 phrases（模型文本）
+    issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
 
     return issues
 
@@ -382,22 +406,30 @@ def main():
     ctx, ctx_err = load_context(args.market, args.phase, today)
     prose_only = args.context_id is not None
 
-    if ctx is None:
+    # A missing OR unusable context both mean "preflight did not produce data to
+    # assemble". preflight writes a blockless sentinel on a fetch failure
+    # (status=preflight_failed / market_closed) with no raw_wechat_block, title,
+    # commit_msg or context_id; assembling against it would send a banner-only
+    # message and then crash on ctx['commit_msg']. Reject before any send/commit,
+    # non-zero, so the run record shows preflight is the breakage. (2026-07-24 review.)
+    ctx_bad = ctx_err or _unusable_context(ctx, prose_only)
+    if ctx_bad:
         result = {
-            'status': 'fail',
-            'issues': [ctx_err],
-            'wechat_prefix': f'🔴 postflight 异常: {ctx_err}\n\n',
-            'commit_ok': False,
-            'commit_msg': 'skipped (no preflight context)',
+            'status': 'preflight_error',
+            'market': args.market, 'phase': args.phase, 'date': today,
+            'issues': [ctx_bad],
+            'wechat_prefix': '', 'wechat_sent': False,
+            'commit_ok': False, 'commit_msg': 'skipped (no usable preflight context)',
         }
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
 
-    # Degenerate/empty stdin = broken pipe (see MIN_REPORT_CHARS note). Bail out
-    # BEFORE deliver_wechat so kcn never gets an empty-bodied FAILED banner; exit
-    # non-zero so the run record shows the breakage. The model's retry (serial
-    # `< file`) or report_watchdog's raw-block fallback delivers the real report.
-    if len(text.strip()) < MIN_REPORT_CHARS:
+    # Degenerate/empty input = broken pipe. Legacy input is a whole report so the
+    # 50-字 floor is a real broken-pipe signal there; prose is a few sections and
+    # a terse-but-valid one can sit under 50 chars, so read_prose_text's own
+    # empty/missing/stale gate already covers the prose plumbing failure. Apply
+    # the char floor to legacy input only. (2026-07-24 review.)
+    if not prose_only and len(text.strip()) < MIN_REPORT_CHARS:
         result = {
             'status': 'fail',
             'market': args.market,
@@ -423,12 +455,17 @@ def main():
     # loud banner we got, so refuse to assemble and fall back to data-only.
     stale_generation = prose_only and args.context_id != ctx.get('context_id')
 
+    # Keep the model's own text for the content rules; assemble the delivered body
+    # separately. Validating the assembled body would let the prepended data block
+    # satisfy the anomaly/section rules on the model's behalf. (2026-07-24 review.)
+    model_text = text if prose_only else None
     if prose_only and not stale_generation:
         text = assemble_message(ctx, text)
 
     issues = ([f'context_id 不匹配: 模型基于 {args.context_id}，当前 context 是 '
                f'{ctx.get("context_id")} — 散文与数据不同代，拒绝拼装']
-              if stale_generation else validate(text, ctx, prose_only=prose_only))
+              if stale_generation
+              else validate(text, ctx, prose_only=prose_only, model_text=model_text))
     status = categorize(issues) if not stale_generation else 'fail'
 
     if status == 'pass':

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -70,7 +70,8 @@ def context_path(market, phase, date):
 
 
 def drop_stale_contexts(market, phase, today):
-    """Delete this market+phase's context files from any OTHER date.
+    """Delete this market+phase's context files AND per-date delivery ephemera
+    (send markers, upgrade claims) from any OTHER date.
 
     WHY (2026-07-24 美股收盘报告): the cron payload names the file as
     `report-context-us-close-{date}.json` and the agent resolved `{date}` to the
@@ -83,17 +84,29 @@ def drop_stale_contexts(market, phase, today):
 
     Retention would not help — the file that got misread was one day old.
     """
+    # Per-date ephemera for this market+phase, cleared for every date but today's.
+    # Context files are the footgun above; the send marker and the upgrade claim
+    # are per-date delivery state that nothing reads across days, so left alone
+    # they just accumulate in memory/.tmp forever (the report-sent-* markers from
+    # 07-21 onward were all still there). Same one-run-per-day keying, same rule:
+    # today's are written LATER by postflight, so dropping other-date ones is safe.
+    patterns = [
+        (f'report-context-{market}-{phase}-*.json', context_path(market, phase, today).name),
+        (f'report-sent-{market}-{phase}-*.json',    f'report-sent-{market}-{phase}-{today}.json'),
+        (f'report-upgrade-{market}-{phase}-*.claim', f'report-upgrade-{market}-{phase}-{today}.claim'),
+    ]
     dropped = []
-    for path in TMP.glob(f'report-context-{market}-{phase}-*.json'):
-        if path.name != context_path(market, phase, today).name:
-            try:
-                path.unlink()
-                dropped.append(path.name)
-            except OSError as e:
-                print(f'   ⚠️  stale context cleanup failed for {path.name}: {e}',
-                      file=sys.stderr)
+    for glob, keep in patterns:
+        for path in TMP.glob(glob):
+            if path.name != keep:
+                try:
+                    path.unlink()
+                    dropped.append(path.name)
+                except OSError as e:
+                    print(f'   ⚠️  stale tmp cleanup failed for {path.name}: {e}',
+                          file=sys.stderr)
     if dropped:
-        print(f'   🧹 dropped {len(dropped)} stale context file(s): {", ".join(sorted(dropped))}',
+        print(f'   🧹 dropped {len(dropped)} stale report tmp file(s): {", ".join(sorted(dropped))}',
               file=sys.stderr)
     return dropped
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -26,7 +26,7 @@ context that has since been replaced.
 
 Output keys:
   raw_wechat_block:   str (script stdout; postflight prepends it verbatim)
-  context_id:         str (sha256[:12] of the context, minus generated_at)
+  context_id:         str (sha256[:12] of the whole context; per-generation)
   market:             "hk" | "us"
   phase:              "open" | "mid" | "pm" | "close"
   title:              suggested WeChat title
@@ -369,7 +369,9 @@ def main():
         'market':             args.market,
         'phase':              args.phase,
         'date':               today,
-        'generated_at':       datetime.now().isoformat(timespec='seconds'),
+        # microseconds so two runs in the same wall-clock second still get distinct
+        # context_ids — the id is strictly per-invocation (2026-07-24 review).
+        'generated_at':       datetime.now().isoformat(timespec='microseconds'),
         'raw_wechat_block':   stdout.strip(),
         'title':              title,
         'commit_msg':         commit_msg,

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -112,7 +112,7 @@ def drop_stale_contexts(market, phase, today):
 
 
 def compute_context_id(result):
-    """Stable short digest of the context the model is about to work from.
+    """A per-GENERATION id for this preflight output.
 
     The model echoes it back to postflight (`--context-id`), which refuses to
     assemble prose against a context that has since been replaced. This is the
@@ -120,12 +120,15 @@ def compute_context_id(result):
     mid-turn, so disk held generation B while its prose described generation A —
     'one context per run' is not something the harness can assume.
 
-    Deliberately excludes `generated_at`: a rerun that produces identical numbers
-    should keep the same id (no spurious rejection), while any change to the data
-    the model reasons about changes it.
+    NOT a digest of the underlying data: `raw_wechat_block` embeds the fetch
+    minute, so any re-run yields a fresh id even with identical portfolio numbers.
+    That is the intended contract — the id pins prose to THIS exact preflight
+    output, and the failure mode is always fail-safe (a mismatch drops to the
+    data block, never marries fresh numbers to stale prose). The only way to get
+    a rejection is for prose to carry an id from a superseded generation, which is
+    exactly what we want caught. `context_id` itself is not yet in `result`.
     """
-    material = {k: v for k, v in result.items() if k != 'generated_at'}
-    blob = json.dumps(material, ensure_ascii=False, sort_keys=True)
+    blob = json.dumps(result, ensure_ascii=False, sort_keys=True)
     return hashlib.sha256(blob.encode()).hexdigest()[:12]
 
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -8,18 +8,25 @@ Runs deterministic work for the 6 briefing crons:
 
 Each invocation:
   1. Runs analyze_{hk,us}_stocks.py --wechat (refreshes prices, writes portfolio.json)
-  2. Captures full script output (LLM uses this VERBATIM as the data block)
+  2. Captures full script output (the data block report_postflight will PREPEND;
+     the model never copies it — see report_postflight.assemble_message)
   3. Parses signals (WATCH/STOP/TRIM counts) and direction hints
   4. Detects anomalies (≥3% intraday moves, big floating losses)
   4b. Collects peer/rotation data so the 板块全景 section has real numbers
   5. Writes memory/.tmp/report-context-{market}-{phase}-{date}.json, where {date}
-     is the RUN date (not the market-session date), drops this market+phase's
-     contexts from every other date, and prints the absolute path as the final
-     stdout line (`context_path: ...`) — Step 2 must read THAT path, never a
-     reconstructed filename.
+     is the RUN date (not the market-session date), and drops this market+phase's
+     contexts from every other date
+  6. Prints that context to stdout, then the absolute path as the final line
+
+stdout and the file are the SAME JSON — no abridged second view to drift. It is
+small because peer_scan is trimmed at the source (see trim_peer_scan), not
+because the print is truncated. The model writes prose only and echoes
+`context_id` back to postflight, which refuses to assemble prose against a
+context that has since been replaced.
 
 Output keys:
-  raw_wechat_block:   str (script stdout, paste verbatim)
+  raw_wechat_block:   str (script stdout; postflight prepends it verbatim)
+  context_id:         str (sha256[:12] of the context, minus generated_at)
   market:             "hk" | "us"
   phase:              "open" | "mid" | "pm" | "close"
   title:              suggested WeChat title
@@ -27,12 +34,13 @@ Output keys:
   signal_count:       {watch, stop, trim}
   anomalies:          list of {ticker, move_pct, reason}
   index_direction:    {hk_index_pct, hstech_pct} for HK; null for US
-  peer_scan:          {ticker: {theme, listed_peers[], divergence_signal, ...}}
-                      for this market's active holdings (板块全景 section)
+  peer_scan:          {ticker: {theme, self_pct_1d, divergence_signal,
+                      listed_peers[<=5]}} for this market's active holdings
   needs_risk_section: bool (true if STOP+TRIM >= 2)
 """
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -90,13 +98,74 @@ def drop_stale_contexts(market, phase, today):
     return dropped
 
 
+def compute_context_id(result):
+    """Stable short digest of the context the model is about to work from.
+
+    The model echoes it back to postflight (`--context-id`), which refuses to
+    assemble prose against a context that has since been replaced. This is the
+    guard the 2026-07-24 incident needed: the agent ran preflight a SECOND time
+    mid-turn, so disk held generation B while its prose described generation A —
+    'one context per run' is not something the harness can assume.
+
+    Deliberately excludes `generated_at`: a rerun that produces identical numbers
+    should keep the same id (no spurious rejection), while any change to the data
+    the model reasons about changes it.
+    """
+    material = {k: v for k, v in result.items() if k != 'generated_at'}
+    blob = json.dumps(material, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(blob.encode()).hexdigest()[:12]
+
+
+PEER_TOP_N = 5
+
+
+def trim_peer_scan(peers):
+    """Keep the peer fields a report actually cites; drop the rest at the source.
+
+    peer_scan was 298 of the context's ~330 lines, and that bulk is what made the
+    agent pipe preflight through `| tail -80` on 2026-07-24 — which cut off the
+    `date` field and started the incident. The fix is to make the context small,
+    NOT to print an abridged view of a fat file: nothing but the model reads
+    peer_scan from a report context (report_postflight never touches it), so a
+    second representation would only be one more thing to keep in sync, and the
+    printed JSON would no longer be what is on disk.
+
+    `listed_peers` is already sorted by today's move, so the head is the 板块 Top N
+    the report asks for. private_peers / key_news_keywords are dropped: they are
+    the長 tail nobody cites in a 4-6 line briefing.
+    """
+    out = {}
+    for ticker, scan in (peers or {}).items():
+        out[ticker] = {
+            'theme': scan.get('theme'),
+            'self_pct_1d': scan.get('self_pct_1d'),
+            'divergence_signal': scan.get('divergence_signal'),
+            'listed_peers': [_peer_line(p)
+                             for p in (scan.get('listed_peers') or [])[:PEER_TOP_N]],
+        }
+    return out
+
+
+def _peer_line(peer):
+    """'RKLB 火箭实验室 +0.34% (5d +3.92%)' — one string per peer.
+
+    A nested dict costs six JSON lines per peer and the report only ever quotes
+    the name and the two moves. Flattening takes the context from 332 lines to
+    ~90, which is the difference between an agent reading it and an agent piping
+    it through `tail`.
+    """
+    def pct(v):
+        return f'{v:+.2f}%' if isinstance(v, (int, float)) else 'n/a'
+    name = ' '.join(x for x in (peer.get('ticker'), peer.get('name')) if x)
+    return f'{name} {pct(peer.get("pct_1d"))} (5d {pct(peer.get("pct_5d"))})'
+
+
 def announce_context_path(out_path):
     """Print the canonical context path as the FINAL stdout line.
 
-    WHY: the agent pipes preflight through `| tail -80` (the JSON is ~350 lines
-    with peer_scan), which cut off the `date` field and left it guessing the
-    filename — see drop_stale_contexts. Printing the absolute path last means it
-    survives any `tail`, so Step 2 never has to reconstruct the name.
+    The model works from the printed JSON and echoes `context_id`, so it never
+    needs to open the file; postflight resolves the same path itself. Kept for
+    humans debugging a run, and printed last so it survives any `tail`.
     """
     print(f'context_path: {out_path}')
 
@@ -291,9 +360,10 @@ def main():
         'signal_count':       signals,
         'anomalies':          anomalies,
         'index_direction':    indices,
-        'peer_scan':          peers,
+        'peer_scan':          trim_peer_scan(peers),
         'needs_risk_section': (signals['stop'] + signals['trim']) >= 2,
     }
+    result['context_id'] = compute_context_id(result)
 
     TMP.mkdir(parents=True, exist_ok=True)
     drop_stale_contexts(args.market, args.phase, today)

--- a/scripts/harness/report_watchdog.py
+++ b/scripts/harness/report_watchdog.py
@@ -64,6 +64,28 @@ def deterministic_fallback(raw_block, tag, reason):
             + raw_block.strip())
 
 
+def slot_delivered(marker, ctx_id, raw_block_first, now_ms):
+    """Did report_postflight confirmably deliver THIS slot's report to Telegram?
+
+    Doubles as the generation gate: in prose mode the model's final answer is a
+    postflight status line, not the report, so the transcript no longer contains
+    the data block and `raw_block_first in summary` would read as "never ran" on
+    every healthy run — firing a deterministic fallback that duplicates a report
+    kcn already has.
+
+    Slot identity prefers `context_id` (exact, written by prose mode). Prose-mode
+    bodies start with the TITLE, so the legacy first-line compare would report a
+    false mismatch; it is kept only for markers written before that field existed.
+    """
+    if not marker or not marker.get('tg_ok'):
+        return False
+    if now_ms - (marker.get('ts') or 0) >= MARKER_FRESH_MS:
+        return False
+    if marker.get('context_id') and ctx_id:
+        return marker['context_id'] == ctx_id
+    return (marker.get('first_line') or '').strip() == (raw_block_first or '').strip()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--market', choices=['hk', 'us'], required=True)
@@ -111,6 +133,34 @@ def main():
         log({'tag': tag, 'action': 'skip', 'reason': 'no preflight raw_wechat_block (cron likely never ran)'})
         return 0
 
+    ctx_id = None
+    if ctx_path.exists():
+        try:
+            ctx_id = json.loads(ctx_path.read_text()).get('context_id')
+        except Exception:
+            pass
+
+    marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
+    marker = None
+    if marker_path.exists():
+        try:
+            marker = json.loads(marker_path.read_text())
+        except Exception:
+            marker = None
+    now_ms = int(datetime.now(HKT).timestamp() * 1000)
+    delivered_this_slot = slot_delivered(marker, ctx_id, raw_block_first, now_ms)
+
+    # --- Generation gate ------------------------------------------------------
+    # In prose mode the model's final answer is a postflight status line, not the
+    # report, so the transcript no longer contains the data block. A confirmed
+    # delivery for this slot IS the proof of generation — check it first, or the
+    # deterministic fallback fires on every healthy prose run.
+    if delivered_this_slot:
+        log({'tag': tag, 'action': 'ok',
+             'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
+             'run_at': run_at})
+        return 0
+
     block_present = raw_block_first in summary
     loop_score, _ = transcript_loop_score(session_id)
     looped = loop_score >= LOOP_THRESHOLD
@@ -136,34 +186,17 @@ def main():
     # the same body to Telegram (the cold-proof channel, no contextToken drop), the
     # WeChat retry buys nothing but duplicates. So the watchdog's SOLE job is to
     # guarantee Telegram has this report — never touch WeChat.
-    marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
-    now_ms = int(datetime.now(HKT).timestamp() * 1000)
-    fresh = bool(marker) and (now_ms - marker.get('ts', 0)) < MARKER_FRESH_MS
-    # `first_line` is the first line of the body postflight actually sent, so this
-    # catches a report built from a stale context (2026-07-24 美股收盘报告) as well
-    # as a leftover marker from an earlier slot. Compare stripped: postflight
-    # records a stripped line, the context block may carry trailing whitespace.
-    matches = bool(marker) and ((marker.get('first_line') or '').strip() == raw_block_first.strip())
-    # TG is covered iff postflight's cosend confirmably delivered THIS report to
-    # Telegram this slot (fresh marker, matching first line, tg_ok=true).
-    if marker and marker.get('tg_ok') and fresh and matches:
-        log({'tag': tag, 'action': 'ok',
-             'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
-             'run_at': run_at})
-        return 0
-
-    # postflight cosend never ran / failed / stale-or-mismatched marker ⇒ Telegram
-    # is not confirmed for this report → mirror it now.
+    # Not delivered this slot (checked above) ⇒ postflight's cosend never ran,
+    # failed, or the marker belongs to a different generation → mirror it now.
     report = last_report_text(session_id, raw_block_first)
-    if not report:
-        # Fallback: the run summary holds the full report after the "---" checklist.
+    if not report and raw_block_first in summary:
+        # Legacy mode: the run summary holds the full report after the "---" checklist.
         report = summary.split('\n---\n', 1)[1].strip() if '\n---\n' in summary else summary.strip()
+    if not report:
+        # Prose mode: the transcript holds a postflight status line, not a report —
+        # mirroring `summary` would send kcn a JSON blob. Rebuild from the context
+        # instead; the data block is the part a backstop actually owes him.
+        report = deterministic_fallback(raw_block, tag, '报告文本不在会话里')
 
     reason = ('postflight marker missing' if not marker
               else 'postflight cosend failed' if not marker.get('tg_ok')

--- a/scripts/harness/report_watchdog.py
+++ b/scripts/harness/report_watchdog.py
@@ -79,10 +79,15 @@ def slot_delivered(marker, ctx_id, raw_block_first, now_ms):
     """
     if not marker or not marker.get('tg_ok'):
         return False
-    if now_ms - (marker.get('ts') or 0) >= MARKER_FRESH_MS:
-        return False
+    # An exact context_id match is proof this slot was delivered regardless of age:
+    # both ids are per market+phase+date, so a delayed watchdog must NOT re-mirror a
+    # confirmed delivery just because the marker is >2h old (2026-07-24 review). The
+    # freshness window only guards the fuzzy legacy first-line compare, where a
+    # matching first line could otherwise belong to an earlier day's report.
     if marker.get('context_id') and ctx_id:
         return marker['context_id'] == ctx_id
+    if now_ms - (marker.get('ts') or 0) >= MARKER_FRESH_MS:
+        return False
     return (marker.get('first_line') or '').strip() == (raw_block_first or '').strip()
 
 
@@ -161,7 +166,13 @@ def main():
              'run_at': run_at})
         return 0
 
-    block_present = raw_block_first in summary
+    # Extract the real report from the transcript BEFORE the generation gate: the
+    # run summary can omit the data block while the actual report sits in the last
+    # assistant turn (long runs truncate the summary). Treating "not in summary" as
+    # "never generated" would fire the deterministic fallback and drop a report kcn
+    # could have received in full (2026-07-24 review). Either source counts.
+    report = last_report_text(session_id, raw_block_first)
+    block_present = (raw_block_first in summary) or bool(report)
     loop_score, _ = transcript_loop_score(session_id)
     looped = loop_score >= LOOP_THRESHOLD
     if not block_present or looped:
@@ -188,7 +199,7 @@ def main():
     # guarantee Telegram has this report — never touch WeChat.
     # Not delivered this slot (checked above) ⇒ postflight's cosend never ran,
     # failed, or the marker belongs to a different generation → mirror it now.
-    report = last_report_text(session_id, raw_block_first)
+    # `report` was already extracted from the transcript above.
     if not report and raw_block_first in summary:
         # Legacy mode: the run summary holds the full report after the "---" checklist.
         report = summary.split('\n---\n', 1)[1].strip() if '\n---\n' in summary else summary.strip()

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -133,52 +133,44 @@ postflight 现在把空输入/旧文件单独判成 `status: input_error`（不�
 ### Mode 6 — WeChat Briefing (cron-driven, harness 化 ✨)
 **When:** 港股开盘/午盘/午后/收盘 4 个 cron job 全部走这个 mode。
 
-**Harness 4-step**（preflight → LLM → postflight → wechat）：
+**Harness 4-step**（preflight → 散文 → postflight 拼装+投递 → 存档）：
 
 #### Step 1: 跑 preflight
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market hk --phase {open|mid|pm|close}
 ```
-内部跑 `scripts/data/analyze_hk_stocks.py --wechat`，抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 恒指/恒科方向，输出 context JSON。
+内部跑 `scripts/data/analyze_hk_stocks.py --wechat`，抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 恒指/恒科方向，写 context 文件，并把**同一份 JSON** 打到 stdout（含 `context_id`；末行是 `context_path:`）。若输出 `market_closed`，本回合到此结束。
 
-#### Step 2: 读 context，写报告
-⚠️ **context 路径只认 preflight 最后一行打印的 `context_path: <绝对路径>`**，照抄它去 read，不要自己拼文件名。文件名里的日期是**跑批当天**，不是行情 session 那天 —— 2026-07-24 美股收盘就因为猜错日期读到隔夜残留、把一天前的数字发进了微信。`context_path:` 是最后一行，`| tail -N` 也切不掉。
+#### Step 2: 只写分析散文
 
-context.json 关键字段：
-- `raw_wechat_block` — 脚本数据块，**verbatim 拷贝到消息开头**。⚠️ 若含 markdown 表格（7 列 holdings），**表头/分隔/数据三类行每字符 1:1 复制**，不要重写分隔行 — 列数必须一致，postflight 会 fail。
-- `title` — WeChat 标题（按 phase 自动选）
-- `signal_count` / `anomalies` / `index_direction` — 用于写分析段
-- `peer_scan` — 每持仓的板块 + 同业今日/5日涨跌(已排序)+ 背离信号,**板块全景段直接用它**
-- `needs_risk_section` — STOP+TRIM ≥ 2 时为 true，必须加 ▎风险提示 段
-- `commit_msg` — postflight 用
+**你不写数据块、不写表格、不写标题** —— postflight 自己从 context 拼。2026-07-24 之前是让模型 verbatim 拷贝数据块，结果模型读错 context 就把一天前的数字发了出去；现在那条回路已经拆掉，数字在发送时刻直接取自 context 文件。
 
-报告结构（postflight 会校验）：
+用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan`（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+
+写这几段，**存成 `memory/.tmp/report-prose-hk-{phase}.md`**：
 ```
-{title}
-
-{raw_wechat_block 原样}
-
 ▎情绪面
-{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景**：读 context.json 的 `peer_scan`（已含 theme + 排好序的同业涨跌），今日板块 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
+{Finnhub 新闻 + 恒指/恒科方向 → 大盘判断（2-3 行）；⚡ **板块全景**：用 peer_scan 写今日板块 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {结合 anomalies + signals → 超买/超卖/突破（2-3 行）}
 
 ▎操作建议
-{具体票 + 价位；如 needs_risk_section 加 ▎风险提示}
+{具体票 + 价位}
+
+▎风险提示（仅当 needs_risk_section=true）
 ```
 
 #### Step 3: 跑 postflight
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/report_postflight.py --market hk --phase {phase} <<< "{完整报告文本}"
+python3 /root/.openclaw/workspace/scripts/harness/report_postflight.py --market hk --phase {phase} --context-id {Step 1 的 context_id} --text-file /root/.openclaw/workspace/memory/.tmp/report-prose-hk-{phase}.md
 ```
-返回 JSON 含 `status` (pass/warn/fail) + `wechat_prefix`。pass/warn 自动刷新
-snapshot/dashboard，提交 scoped 产物并经 `safe_push.sh` 推送。
+`--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），postflight 拒绝拼装、只发数据块。散文文件超过 30 分钟没更新同样拒发。返回 JSON 含 `status` (pass/warn/fail)。pass/warn 自动拼装+发送+刷新 snapshot/dashboard，提交 scoped 产物并经 `safe_push.sh` 推送。
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
 微信投递已在 **Step 3 的 `report_postflight` 用 fresh-token 短连接发出**——这是
 **唯一微信路径**（cron 设 `--no-deliver`，不再 announce），同时会镜像 Telegram。
-把 `wechat_prefix` 拼到完整报告前面作为**本回合最终文本回复**输出即可（仅留痕）。
+把 postflight 返回的 `status` + `issues` 作为**本回合最终文本回复**输出即可（仅留痕）。
 **不要调 `message`/send 工具**；`report_watchdog` 只在 Telegram marker 缺失/失败时
 补投 Telegram，不重发微信。
 

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -141,45 +141,40 @@ publisher 发布。
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market us --phase {open|close}
 ```
-跑 `scripts/data/analyze_us_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 context JSON。
+跑 `scripts/data/analyze_us_stocks.py --wechat --md-table` + 抽信号 + 异动，写 context 文件，并把**同一份 JSON** 打到 stdout（含 `context_id`；末行是 `context_path:`）。若输出 `market_closed`，本回合到此结束。
 
-#### Step 2: 读 context，写报告
-⚠️ **context 路径只认 preflight 最后一行打印的 `context_path: <绝对路径>`**，照抄它去 read，不要自己拼文件名。文件名里的日期是**跑批当天**（美股收盘 cron 在 HKT 次日凌晨触发），不是行情 session 那天 —— 2026-07-24 就因为把它猜成 07-23，读到隔夜残留、把一天前的数字发进了微信。`context_path:` 是最后一行，`| tail -N` 也切不掉。
+#### Step 2: 只写分析散文
 
-关键字段：
-- `raw_wechat_block` — 脚本输出，**verbatim 拷贝到消息开头**。holdings 是 **markdown 表格** (7 列：代码/股/成本/现价/今日/浮%/浮$；2026-05-21 起 visual-width-aware 渲染走 `_wechat_table.py`，去 $ 前缀加 浮$ 金额列，mobile WeChat 不渲染表格但每行视觉宽度精确一致)。⚠️ **表头/分隔/数据三类行每字符 1:1 复制**，不要重写分隔行 — 列数必须一致，postflight 会 fail。
-- `title` — 自动选好
-- `signal_count` / `anomalies` — 用于分析段
-- `needs_risk_section` — STOP+TRIM ≥ 2 时为 true
-- `commit_msg` — postflight 用
+**你不写数据块、不写表格、不写标题** —— postflight 自己从 context 拼。2026-07-24 之前是让模型 verbatim 拷贝数据块，结果模型读错 context 就把一天前的数字发了出去；现在那条回路已经拆掉，数字在发送时刻直接取自 context 文件。
 
-报告结构（postflight 校验）：
+用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan`（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+
+写这几段，**存成 `memory/.tmp/report-prose-us-{phase}.md`**：
 ```
-{title}
-
-{raw_wechat_block 原样}
-
 ▎情绪面
-{Finnhub news + 纳指 tone → market direction；⚡ **板块全景**：读 context.json 的 `peer_scan`（已含 theme + 排好序的同业涨跌），对应主题成分今日 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`/`intraday`，盘中常规盯盘不烧 Tavily}
+{Finnhub news + 纳指 tone → market direction；⚡ **板块全景**：用 peer_scan 写对应主题今日 Top 5 + 你持仓位置 + 1 句归因。行情优先内置 web search；tavily 仅开盘/收盘或真事件用，带 `--bucket report`，盘中常规盯盘不烧 Tavily}
 
 ▎技术面
 {RSI / MA stance → overbought/oversold/breakout}
 
 ▎操作建议
-{具体票 + 价位；如 needs_risk_section 加 ▎风险提示}
+{具体票 + 价位}
+
+▎风险提示（仅当 needs_risk_section=true）
 ```
 
 #### Step 3: 跑 postflight
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/report_postflight.py --market us --phase {phase} <<< "{报告}"
+python3 /root/.openclaw/workspace/scripts/harness/report_postflight.py --market us --phase {phase} --context-id {Step 1 的 context_id} --text-file /root/.openclaw/workspace/memory/.tmp/report-prose-us-{phase}.md
 ```
+`--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），postflight 拒绝拼装、只发数据块。散文文件超过 30 分钟没更新同样拒发（防重发上个 slot 的旧文本）。
 pass/warn 自动刷新 snapshot/dashboard，提交 scoped 产物并经 `safe_push.sh` 推送。
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
 
 微信投递已在 **Step 3 的 `report_postflight` 用 fresh-token 短连接发出**——这是
 **唯一微信路径**（cron 设 `--no-deliver`，不再 announce），同时会镜像 Telegram。
-拼 `wechat_prefix` + 报告作为**本回合最终文本回复**直接输出即可（仅留痕）。
+把 postflight 返回的 `status` + `issues` 作为**本回合最终文本回复**输出即可（仅留痕）。
 **不要自己调 `message`/send 工具**；`report_watchdog` 只在 Telegram marker 缺失/失败时
 补投 Telegram，不重发微信。
 

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -1,0 +1,417 @@
+"""The report path after the data block stopped going through the model.
+
+Follow-up to tests/test_report_context_path.py (the 2026-07-24 transitional fix).
+That one made a misread context loud; this one makes it unreachable:
+
+  * report_postflight assembles title + raw_wechat_block + prose itself, so the
+    delivered numbers come from the context file at send time
+  * the model echoes `context_id`; prose written against a superseded context is
+    refused rather than silently married to fresh numbers
+  * delivery is fail-closed — a rejected report ships the data block alone, and
+    may be superseded exactly once by a report that validates
+
+Every test drives real functions; nothing asserts on prompt text.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / 'scripts' / 'harness'
+
+FRESH_BLOCK = ('🇺🇸 美股盯盘 | 07/23 16:00 ET\n\n'
+               '📊 市值 $2,508 | 浮盈 $-1,993\n\n'
+               '| 代码  |    股 |\n|:------|------:|\n| CRCL  |     2 |')
+STALE_BLOCK = '🇺🇸 美股盯盘 | 07/22 16:02 ET\n\n📊 市值 $2,495 | 浮盈 $-2,007'
+PROSE = ('▎情绪面\nCRCL 今日 -5.5%，稳定币板块只有它在跌。\n\n'
+         '▎技术面\n跌破 $65，下一支撑 $60。\n\n'
+         '▎操作建议\nSPCH 减仓至 1/3。\n')
+
+
+def _load(name):
+    for extra in (ROOT / 'scripts' / 'data', HARNESS):
+        if str(extra) not in sys.path:
+            sys.path.insert(0, str(extra))
+    spec = importlib.util.spec_from_file_location(name, HARNESS / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def pf():
+    return _load('report_postflight')
+
+
+@pytest.fixture
+def pre():
+    return _load('report_preflight')
+
+
+def _ctx(**over):
+    ctx = {
+        'status': 'ok', 'market': 'us', 'phase': 'close', 'date': '2026-07-24',
+        'title': '🌙 美股收盘日报｜2026-07-24',
+        'raw_wechat_block': FRESH_BLOCK,
+        'commit_msg': 'portfolio: 美股收盘价格更新',
+        'signal_count': {'watch': 1, 'stop': 4, 'trim': 0},
+        'anomalies': [{'ticker': 'CRCL', 'move_pct': -5.5, 'reason': '跳空/异动'}],
+        'index_direction': None, 'peer_scan': {},
+        'needs_risk_section': False,
+        'context_id': 'abc123def456',
+    }
+    ctx.update(over)
+    return ctx
+
+
+# ── assembly: the numbers can no longer come from the model ─────────────────
+
+def test_assembled_message_uses_the_context_block_not_the_model_text(pf):
+    """The incident in one assertion: even if the model's prose quotes 07/22
+    numbers, what ships is the context's 07/23 block."""
+    msg = pf.assemble_message(_ctx(), f'{STALE_BLOCK}\n\n{PROSE}')
+
+    assert msg.startswith('🌙 美股收盘日报｜2026-07-24')
+    assert FRESH_BLOCK in msg
+    assert msg.index(FRESH_BLOCK) < msg.index('▎情绪面')
+
+
+def test_verbatim_and_table_rules_are_skipped_in_prose_mode(pf):
+    """The model no longer copies the block, so asserting it copied correctly
+    would just be the harness checking its own string concatenation."""
+    ctx = _ctx()
+    assembled = pf.assemble_message(ctx, PROSE)
+
+    assert pf.validate(assembled, ctx, prose_only=True) == []
+    # the same prose WITHOUT the block still fails the legacy rules
+    legacy_issues = pf.validate(PROSE, ctx, prose_only=False)
+    assert any('verbatim' in i for i in legacy_issues)
+
+
+def test_prose_mode_still_judges_what_the_model_actually_wrote(pf):
+    ctx = _ctx(needs_risk_section=True)
+    thin = '▎情绪面\n数据待获取\n'
+    issues = pf.validate(pf.assemble_message(ctx, thin), ctx, prose_only=True)
+
+    assert any('缺段标记 "▎技术面"' in i for i in issues)
+    assert any('▎风险提示' in i for i in issues)
+    assert any('敷衍词' in i for i in issues)
+    assert pf.categorize(issues) == 'fail'
+
+
+def test_length_is_measured_on_the_assembled_message(pf):
+    """Limits are pinned in the cron contract at 3000/3500 and have always meant
+    the delivered message. Measuring prose alone would silently loosen them by
+    the length of the block."""
+    ctx = _ctx()
+    # prose sized to sit just UNDER the soft limit on its own, so the only way to
+    # trip the rule is to count the block the harness prepends
+    prose = PROSE + '填' * (2990 - len(PROSE))
+    assembled = pf.assemble_message(ctx, prose)
+    assert len(prose) < 3000 < len(assembled)
+
+    assert [i for i in pf.validate(prose, ctx, prose_only=True) if '报告长度' in i] == []
+    assert [i for i in pf.validate(assembled, ctx, prose_only=True) if '报告长度' in i] == [
+        f'报告长度 {len(assembled)} 字 > 3000 软上限 (warn)']
+
+
+# ── generation binding ─────────────────────────────────────────────────────
+
+def test_context_id_changes_with_the_data_and_not_with_the_clock(pre):
+    """A second preflight producing identical numbers must not invalidate prose
+    already written; one producing different numbers must."""
+    base = {k: v for k, v in _ctx().items() if k != 'context_id'}
+    first = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:00:33'})
+    rerun_same = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:06:11'})
+    rerun_moved = pre.compute_context_id({**base, 'raw_wechat_block': STALE_BLOCK})
+
+    assert first == rerun_same
+    assert first != rerun_moved
+
+
+def test_peer_scan_is_trimmed_at_the_source_not_in_a_second_view(pre):
+    """peer_scan bulk is what provoked `| tail -80` on 2026-07-24. It is cut in
+    the context itself so stdout and the file stay the same JSON — an abridged
+    print of a fat file would be one more thing to drift."""
+    peers = {'RKLX': {
+        'theme': 'RKLB 2x leveraged', 'self_pct_1d': 0.51,
+        'divergence_signal': 'MU +3.2% vs self +0.1%',
+        'listed_peers': [{'ticker': f'P{i}', 'name': 'x' * 40, 'rel': 'y' * 40,
+                          'pct_1d': i, 'pct_5d': i} for i in range(9)],
+        'private_peers': ['a' * 50] * 6,
+        'key_news_keywords': ['k' * 20] * 8,
+    }}
+    trimmed = pre.trim_peer_scan(peers)
+
+    # the fields a 4-6 line briefing actually cites survive
+    assert trimmed['RKLX']['divergence_signal'] == 'MU +3.2% vs self +0.1%'
+    assert trimmed['RKLX']['theme'] == 'RKLB 2x leveraged'
+    lines = trimmed['RKLX']['listed_peers']
+    assert len(lines) == 5 and lines[0].startswith('P0 ')
+    assert '+0.00% (5d +0.00%)' in lines[0]        # both moves stay quotable
+    # the long tail does not
+    assert 'private_peers' not in trimmed['RKLX']
+    assert all(isinstance(ln, str) for ln in lines)  # flat: 1 line per peer, not 6
+    assert len(json.dumps(trimmed, ensure_ascii=False)) < len(json.dumps(peers, ensure_ascii=False)) / 4
+
+
+def test_peer_line_survives_a_missing_move(pre):
+    """peer feeds drop pct_5d often enough that a format crash here would take
+    the whole report down for a cosmetic field."""
+    assert pre._peer_line({'ticker': 'MU', 'name': '美光', 'pct_1d': 3.2}) == \
+        'MU 美光 +3.20% (5d n/a)'
+    assert pre._peer_line({'ticker': 'MU'}) == 'MU n/a (5d n/a)'
+
+
+# ── fail-closed delivery + the single upgrade ──────────────────────────────
+
+@pytest.fixture
+def sent(pf, tmp_path, monkeypatch):
+    """Capture what deliver_wechat would publish, without any network."""
+    box = {}
+    monkeypatch.setattr(pf, 'TMP', tmp_path)
+    monkeypatch.setattr(pf, 'resolve_wechat_target', lambda m: ('weixin', 'kcn', 'a'))
+    monkeypatch.setattr(pf, 'cosend_telegram', lambda *a, **k: (True, 'ok'))
+
+    def _send(channel, to, account, message, dry_run):
+        box.setdefault('messages', []).append(message)
+        return True, 'sent'
+
+    monkeypatch.setattr(pf, 'send_wechat', _send)
+    box['tmp'] = tmp_path
+    return box
+
+
+def test_failed_report_delivers_the_data_block_without_the_rejected_prose(pf, sent):
+    ctx = _ctx()
+    pf.deliver_wechat('us', 'close', '2026-07-24',
+                      '🔴 Validation FAILED (1 issues), 仅发布数据块、未 commit:\n- x\n\n',
+                      pf.assemble_message(ctx, ''), delivery_state='failed')
+
+    body = sent['messages'][0]
+    assert FRESH_BLOCK in body
+    assert '▎情绪面' not in body
+    marker = json.loads((sent['tmp'] / 'report-sent-us-close-2026-07-24.json').read_text())
+    assert marker['delivery_state'] == 'failed'
+
+
+def test_upgrade_is_claimed_exactly_once(pf, sent):
+    assert pf.claim_upgrade('us', 'close', '2026-07-24') is True
+    assert pf.claim_upgrade('us', 'close', '2026-07-24') is False
+    assert pf.claim_upgrade('us', 'close', '2026-07-24') is False
+
+
+# ── the failure surface --text-file introduces ─────────────────────────────
+
+def test_stale_prose_file_is_refused_because_context_id_cannot_see_it(pf, tmp_path):
+    """The model passes the CURRENT context_id on the command line while the file
+    still holds the previous slot's prose — generation binding is blind to this,
+    so the file's own mtime has to be the gate (PR #22's intraday lesson)."""
+    import os
+    stale = tmp_path / 'report-prose-us-close.md'
+    stale.write_text(PROSE)
+    old = datetime_minus_minutes(pf.PROSE_MAX_AGE_MIN + 5)
+    os.utime(stale, (old, old))
+
+    text, err = pf.read_prose_text('us', 'close', str(stale))
+    assert text == '' and '分钟未更新' in err
+
+    fresh = tmp_path / 'fresh.md'
+    fresh.write_text(PROSE)
+    assert pf.read_prose_text('us', 'close', str(fresh)) == (PROSE, None)
+
+
+def datetime_minus_minutes(minutes):
+    import time
+    return time.time() - minutes * 60
+
+
+@pytest.mark.parametrize('setup, marker', [
+    ('missing', '不存在'),
+    ('empty', '空输入'),
+])
+def test_broken_input_is_classified_apart_from_a_bad_report(pf, tmp_path, setup, marker):
+    path = tmp_path / 'report-prose-us-close.md'
+    if setup == 'empty':
+        path.write_text('   \n')
+    text, err = pf.read_prose_text('us', 'close', str(path))
+    assert text == '' and marker in err
+
+
+@pytest.fixture
+def run_main(pf, sent, monkeypatch, tmp_path):
+    """Drive the real main(). Helper-only tests would not have caught the
+    2026-07-24 bug — the defect was in how main() sequenced send vs commit."""
+    monkeypatch.setattr(pf.trading_calendar, 'phase_session', lambda m, p: 'x')
+    monkeypatch.setattr(pf.trading_calendar, 'closed_reason', lambda m, session=None: None)
+    monkeypatch.setattr(pf, 'maybe_commit',
+                        lambda status, msg: (status != 'fail', f'commit({status})'))
+
+    def run(prose, *, context_id, ctx=None, age_minutes=0):
+        (tmp_path / f'report-context-us-close-{pf.datetime.now():%Y-%m-%d}.json'
+         ).write_text(json.dumps(ctx or _ctx(), ensure_ascii=False))
+        body = tmp_path / 'body.md'
+        body.write_text(prose)
+        if age_minutes:
+            import os
+            old = datetime_minus_minutes(age_minutes)
+            os.utime(body, (old, old))
+        argv = ['report_postflight.py', '--market', 'us', '--phase', 'close',
+                '--text-file', str(body)]
+        if context_id:
+            argv += ['--context-id', context_id]
+        monkeypatch.setattr(sys, 'argv', argv)
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = pf.main()
+        return rc, json.loads(buf.getvalue())
+
+    return run
+
+
+def test_incident_replay_stale_prose_is_refused_not_married_to_fresh_numbers(
+    run_main, sent
+):
+    """2026-07-24 exactly: the model wrote against a context that has since been
+    replaced. The old code published it; the new code must refuse to assemble and
+    ship the data block alone."""
+    rc, out = run_main(f'{STALE_BLOCK}\n\n{PROSE}', context_id='OLDGENERATION')
+
+    assert rc == 2 and out['status'] == 'fail'
+    assert any('context_id 不匹配' in i for i in out['issues'])
+    assert out['commit_ok'] is False
+    body = sent['messages'][0]
+    assert FRESH_BLOCK in body and '▎情绪面' not in body and STALE_BLOCK not in body
+
+
+def test_happy_path_assembles_commits_and_records_delivered(run_main, sent):
+    rc, out = run_main(PROSE, context_id='abc123def456')
+
+    assert rc == 0 and out['status'] == 'pass' and out['mode'] == 'prose'
+    assert out['commit_ok'] is True
+    body = sent['messages'][0]
+    assert body.startswith('🌙 美股收盘日报') and FRESH_BLOCK in body and '▎情绪面' in body
+
+
+def test_a_failed_slot_can_be_superseded_once_then_locks(run_main, sent, pf):
+    """Fail-closed is only acceptable if the corrected report can still land."""
+    def pf_min_chars():
+        return pf.MIN_REPORT_CHARS
+
+    bad = '▎情绪面\n' + '数据待获取，等待数据回补后再补充解读。' * 3 + '\n'
+    assert len(bad) > pf_min_chars()
+    rc1, out1 = run_main(bad, context_id='abc123def456')
+    # banner names the offending phrase; the BODY must stop at the data block
+    assert out1['status'] == 'fail'
+    assert sent['messages'][0].endswith(FRESH_BLOCK.strip())
+
+    rc2, out2 = run_main(PROSE, context_id='abc123def456')
+    assert out2['status'] == 'pass' and out2['wechat_sent'] is True
+    assert len(sent['messages']) == 2 and '▎情绪面' in sent['messages'][1]
+
+    # a third run must NOT send again — one upgrade, then the lock holds
+    rc3, out3 = run_main(PROSE, context_id='abc123def456')
+    assert out3['status'] == 'pass' and len(sent['messages']) == 2
+
+
+def test_main_refuses_to_publish_a_stale_prose_file(run_main, sent, pf, tmp_path):
+    """A helper-only test does not guard main(): with read_prose_text returning an
+    error but main() ignoring it, everything else still passes. Drive the whole
+    entry point and assert NOTHING was sent."""
+    import os
+    rc, out = run_main(PROSE, context_id='abc123def456',
+                       age_minutes=pf.PROSE_MAX_AGE_MIN + 5)
+
+    assert rc == 2 and out['status'] == 'input_error'
+    assert out['wechat_sent'] is False and out['commit_ok'] is False
+    assert 'messages' not in sent
+
+
+# ── watchdog must not mistake prose mode for a dead run ────────────────────
+
+@pytest.fixture
+def wd():
+    return _load('report_watchdog')
+
+
+def _marker(**over):
+    m = {'ts': 1_000_000, 'sent_ok': True, 'tg_ok': True,
+         'first_line': '🌙 美股收盘日报｜2026-07-24', 'context_id': 'abc123def456'}
+    m.update(over)
+    return m
+
+
+def test_watchdog_accepts_a_prose_slot_by_context_id(wd):
+    """Prose bodies start with the TITLE, so the old first-line compare would call
+    a healthy run a mismatch and mirror a duplicate to Telegram."""
+    assert wd.slot_delivered(_marker(), 'abc123def456',
+                             '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
+
+
+def test_watchdog_still_backstops_a_different_generation(wd):
+    assert wd.slot_delivered(_marker(context_id='OTHERGEN'), 'abc123def456',
+                             '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is False
+
+
+def test_watchdog_falls_back_to_first_line_for_legacy_markers(wd):
+    legacy = _marker(first_line='🇺🇸 美股盯盘 | 07/23 16:00 ET')
+    legacy.pop('context_id')
+    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
+    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/22 16:02 ET', 1_000_100) is False
+
+
+def test_watchdog_ignores_a_stale_or_undelivered_marker(wd):
+    old = 1_000_000 + wd.MARKER_FRESH_MS
+    assert wd.slot_delivered(_marker(), 'abc123def456', 'x', old) is False
+    assert wd.slot_delivered(_marker(tg_ok=False), 'abc123def456', 'x', 1_000_100) is False
+    assert wd.slot_delivered(None, 'abc123def456', 'x', 1_000_100) is False
+
+
+# ── watchdog must not duplicate a healthy prose run ────────────────────────
+
+@pytest.fixture
+def wd():
+    return _load('report_watchdog')
+
+
+def test_watchdog_identifies_the_slot_by_context_id_not_first_line(wd):
+    """Prose-mode bodies start with the TITLE, so the old first-line compare
+    reports a false mismatch on every healthy run — and a 'mismatch' makes the
+    watchdog mirror a duplicate to Telegram."""
+    now = 1_700_000_000_000
+    marker = {'ts': now - 60_000, 'tg_ok': True, 'context_id': 'abc123def456',
+              'first_line': '🌙 美股收盘日报｜2026-07-24'}
+
+    assert wd.slot_delivered(marker, 'abc123def456', FRESH_BLOCK.splitlines()[0], now)
+    # a marker from a different generation is NOT this slot's
+    assert not wd.slot_delivered(marker, 'NEWGENERATION', FRESH_BLOCK.splitlines()[0], now)
+
+
+def test_watchdog_falls_back_to_the_legacy_first_line_when_no_context_id(wd):
+    now = 1_700_000_000_000
+    first = FRESH_BLOCK.splitlines()[0]
+    legacy = {'ts': now - 60_000, 'tg_ok': True, 'first_line': first}
+
+    assert wd.slot_delivered(legacy, None, first, now)
+    assert not wd.slot_delivered({**legacy, 'first_line': 'something else'}, None, first, now)
+    assert not wd.slot_delivered({**legacy, 'tg_ok': False}, None, first, now)
+    assert not wd.slot_delivered({**legacy, 'ts': 0}, None, first, now)
+
+
+def test_marker_state_defaults_to_delivered_for_pre_field_markers(pf, sent):
+    """An old marker must not read as 'failed' — that would unlock a re-send of a
+    report kcn already has, which is the 2026-06-03 duplicate class."""
+    path = sent['tmp'] / 'report-sent-us-close-2026-07-24.json'
+    path.write_text(json.dumps({'ts': 1, 'sent_ok': True, 'tg_ok': True,
+                                'first_line': 'x'}))
+    assert pf._marker_state(path) == 'delivered'
+    assert pf._marker_state(sent['tmp'] / 'nope.json') is None

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -89,7 +89,7 @@ def test_verbatim_and_table_rules_are_skipped_in_prose_mode(pf):
     ctx = _ctx()
     assembled = pf.assemble_message(ctx, PROSE)
 
-    assert pf.validate(assembled, ctx, prose_only=True) == []
+    assert pf.validate(assembled, ctx, prose_only=True, model_text=PROSE) == []
     # the same prose WITHOUT the block still fails the legacy rules
     legacy_issues = pf.validate(PROSE, ctx, prose_only=False)
     assert any('verbatim' in i for i in legacy_issues)
@@ -98,12 +98,30 @@ def test_verbatim_and_table_rules_are_skipped_in_prose_mode(pf):
 def test_prose_mode_still_judges_what_the_model_actually_wrote(pf):
     ctx = _ctx(needs_risk_section=True)
     thin = '▎情绪面\n数据待获取\n'
-    issues = pf.validate(pf.assemble_message(ctx, thin), ctx, prose_only=True)
+    issues = pf.validate(pf.assemble_message(ctx, thin), ctx, prose_only=True, model_text=thin)
 
     assert any('缺段标记 "▎技术面"' in i for i in issues)
     assert any('▎风险提示' in i for i in issues)
     assert any('敷衍词' in i for i in issues)
     assert pf.categorize(issues) == 'fail'
+
+
+def test_content_rules_run_on_prose_not_the_prepended_block(pf):
+    """2026-07-24 review, blocking #1: the assembled body starts with the data
+    table, which contains the anomaly ticker (CRCL) and could contain
+    section-looking tokens. A prose that mentions NO mover must still fail —
+    validating the body would let the table answer for the model."""
+    ctx = _ctx()  # anomalies = [CRCL]
+    prose = ('▎情绪面\n大盘今天很平静，没什么可说的。\n\n'
+             '▎技术面\n指数横盘。\n\n▎操作建议\n继续持有。\n')
+    assert 'CRCL' not in prose
+    assembled = pf.assemble_message(ctx, prose)
+    assert 'CRCL' in assembled  # the table carries it
+
+    issues = pf.validate(assembled, ctx, prose_only=True, model_text=prose)
+    assert any('异动票' in i and 'CRCL' in i for i in issues)
+    # and the bug: validating the assembled body would MISS it
+    assert not any('异动票' in i for i in pf.validate(assembled, ctx, prose_only=True))
 
 
 def test_length_is_measured_on_the_assembled_message(pf):
@@ -117,23 +135,29 @@ def test_length_is_measured_on_the_assembled_message(pf):
     assembled = pf.assemble_message(ctx, prose)
     assert len(prose) < 3000 < len(assembled)
 
-    assert [i for i in pf.validate(prose, ctx, prose_only=True) if '报告长度' in i] == []
-    assert [i for i in pf.validate(assembled, ctx, prose_only=True) if '报告长度' in i] == [
-        f'报告长度 {len(assembled)} 字 > 3000 软上限 (warn)']
+    assert [i for i in pf.validate(prose, ctx, prose_only=True, model_text=prose)
+            if '报告长度' in i] == []
+    assert [i for i in pf.validate(assembled, ctx, prose_only=True, model_text=prose)
+            if '报告长度' in i] == [f'报告长度 {len(assembled)} 字 > 3000 软上限 (warn)']
 
 
 # ── generation binding ─────────────────────────────────────────────────────
 
-def test_context_id_changes_with_the_data_and_not_with_the_clock(pre):
-    """A second preflight producing identical numbers must not invalidate prose
-    already written; one producing different numbers must."""
+def test_context_id_is_per_generation(pre):
+    """The id pins prose to THIS preflight output. Two runs differ (raw_wechat_block
+    carries the fetch minute, and generated_at differs), and any change to the data
+    the model reasons about also differs — so a mismatch always means "prose was
+    written against a superseded context", which is what postflight rejects."""
     base = {k: v for k, v in _ctx().items() if k != 'context_id'}
-    first = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:00:33'})
-    rerun_same = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:06:11'})
-    rerun_moved = pre.compute_context_id({**base, 'raw_wechat_block': STALE_BLOCK})
+    run_a = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:00:33'})
+    run_b = pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:06:11'})
+    moved = pre.compute_context_id({**base, 'raw_wechat_block': STALE_BLOCK,
+                                    'generated_at': '2026-07-24T04:00:33'})
 
-    assert first == rerun_same
-    assert first != rerun_moved
+    assert run_a != run_b            # a re-run is a new generation
+    assert run_a != moved            # changed data is a new generation
+    # deterministic: same dict in, same id out (no dict-ordering / float wobble)
+    assert run_a == pre.compute_context_id({**base, 'generated_at': '2026-07-24T04:00:33'})
 
 
 def test_peer_scan_is_trimmed_at_the_source_not_in_a_second_view(pre):
@@ -231,6 +255,19 @@ def test_stale_prose_file_is_refused_because_context_id_cannot_see_it(pf, tmp_pa
 def datetime_minus_minutes(minutes):
     import time
     return time.time() - minutes * 60
+
+
+def test_a_terse_but_valid_prose_under_50_chars_is_not_broken_pipe_rejected(run_main, sent):
+    """2026-07-24 review: the 50-字 floor is a legacy full-report broken-pipe guard.
+    A valid three-section prose can sit under it; read_prose_text already rejects
+    empty/missing/stale files, so the floor must not apply to prose."""
+    terse = '▎情绪面\n跌\n▎技术面\n弱\n▎操作建议\n等\n'
+    assert len(terse.strip()) < 50
+    rc, out = run_main(terse, context_id='abc123def456',
+                       ctx=_ctx(anomalies=[]))  # no mover to require
+
+    assert out['status'] == 'pass' and rc == 0
+    assert sent['messages'][0].startswith('🌙 美股收盘日报')
 
 
 @pytest.mark.parametrize('setup, marker', [
@@ -333,7 +370,42 @@ def test_main_refuses_to_publish_a_stale_prose_file(run_main, sent, pf, tmp_path
 
     assert rc == 2 and out['status'] == 'input_error'
     assert out['wechat_sent'] is False and out['commit_ok'] is False
-    assert 'messages' not in sent
+
+
+@pytest.mark.parametrize('ctx, why', [
+    ({'status': 'preflight_failed', 'market': 'us', 'phase': 'close',
+      'error': 'analyze_us_stocks.py rc=1'}, 'preflight_failed sentinel'),
+    ({'status': 'ok', 'market': 'us', 'phase': 'close', 'title': 't',
+      'commit_msg': 'm', 'context_id': 'abc123def456', 'raw_wechat_block': ''},
+     'ok status but empty data block'),
+])
+def test_main_rejects_an_unusable_context_without_sending_or_crashing(
+    run_main, sent, ctx, why
+):
+    """2026-07-24 review, blocking #2: preflight writes a blockless sentinel on a
+    fetch failure. Assembling against it sent a banner-only message and then
+    crashed on ctx['commit_msg']. It must be rejected before any send/commit."""
+    rc, out = run_main(PROSE, context_id='abc123def456', ctx=ctx)
+
+    assert rc == 2, why
+    assert out['status'] == 'preflight_error'
+    assert out['wechat_sent'] is False and out['commit_ok'] is False
+    assert 'messages' not in sent  # nothing delivered
+
+
+def test_legacy_failed_report_also_ships_the_data_block_only(run_main, sent):
+    """Dual-stack: a legacy (no --context-id) run that fails validation must ALSO
+    fall back to the data block, not deliver the model's rejected full text —
+    this closes 07-24 on the legacy path during the migration window."""
+    legacy_bad = f'{FRESH_BLOCK}\n\n▎情绪面\n数据待获取\n'  # missing 技术面/操作建议
+    rc, out = run_main(legacy_bad, context_id=None)
+
+    assert out['status'] == 'fail' and out['mode'] == 'legacy'
+    body = sent['messages'][0]
+    # ends at the data block ⇒ the model's rejected text is gone (数据待获取 still
+    # appears once, in the banner, which is expected — it names the failure)
+    assert body.endswith(FRESH_BLOCK.strip())
+    assert '▎情绪面' not in body
 
 
 # ── watchdog must not mistake prose mode for a dead run ────────────────────
@@ -362,16 +434,26 @@ def test_watchdog_still_backstops_a_different_generation(wd):
                              '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is False
 
 
+def test_watchdog_context_id_match_ignores_the_age_window(wd):
+    """2026-07-24 review, non-blocking: both ids are per market+phase+date, so an
+    exact match is proof of THIS slot regardless of marker age. A delayed watchdog
+    must not re-mirror a confirmed delivery just because the marker is >2h old."""
+    old = 1_000_000 + wd.MARKER_FRESH_MS + 1
+    assert wd.slot_delivered(_marker(), 'abc123def456', 'x', old) is True
+
+
 def test_watchdog_falls_back_to_first_line_for_legacy_markers(wd):
     legacy = _marker(first_line='🇺🇸 美股盯盘 | 07/23 16:00 ET')
     legacy.pop('context_id')
     assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
     assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/22 16:02 ET', 1_000_100) is False
-
-
-def test_watchdog_ignores_a_stale_or_undelivered_marker(wd):
+    # freshness still gates the FUZZY legacy path — an old first-line match could
+    # belong to an earlier day
     old = 1_000_000 + wd.MARKER_FRESH_MS
-    assert wd.slot_delivered(_marker(), 'abc123def456', 'x', old) is False
+    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', old) is False
+
+
+def test_watchdog_ignores_an_undelivered_marker(wd):
     assert wd.slot_delivered(_marker(tg_ok=False), 'abc123def456', 'x', 1_000_100) is False
     assert wd.slot_delivered(None, 'abc123def456', 'x', 1_000_100) is False
 
@@ -405,6 +487,63 @@ def test_watchdog_falls_back_to_the_legacy_first_line_when_no_context_id(wd):
     assert not wd.slot_delivered({**legacy, 'first_line': 'something else'}, None, first, now)
     assert not wd.slot_delivered({**legacy, 'tg_ok': False}, None, first, now)
     assert not wd.slot_delivered({**legacy, 'ts': 0}, None, first, now)
+
+
+@pytest.fixture
+def wd_main(wd, tmp_path, monkeypatch):
+    """Drive report_watchdog.main() with the run/session lookups mocked out, so the
+    reordered generation gate (transcript extracted BEFORE block_present) is under
+    test — codex flagged it as covered only at the slot_delivered() helper level."""
+    tmp = tmp_path / '.tmp'
+    tmp.mkdir()
+    monkeypatch.setattr(wd, 'WS', tmp_path)
+    (tmp_path / 'memory').mkdir(exist_ok=True)
+    monkeypatch.setattr(wd, 'WS', tmp_path, raising=True)
+    # WS/memory/.tmp is where main() reads ctx + marker and writes the dedupe flag
+    (tmp_path / 'memory' / '.tmp').mkdir(parents=True, exist_ok=True)
+
+    sent = {}
+    monkeypatch.setattr(wd, 'find_job_id', lambda name: 'jid')
+    monkeypatch.setattr(wd, 'today_runs',
+                        lambda jid: [{'runAtMs': 1, 'sessionId': 'sess', 'summary': SUMMARY[0]}])
+    monkeypatch.setattr(wd, 'transcript_loop_score', lambda s: (0, {}))
+    def _tg(target, msg, dry):
+        sent.setdefault('msgs', []).append(msg)
+        return True, 'sent'
+    monkeypatch.setattr(wd, 'send_telegram', _tg)
+    monkeypatch.setattr(wd, 'last_report_text', lambda s, first: TRANSCRIPT[0])
+
+    ctx = _ctx()
+    (tmp_path / 'memory' / '.tmp' / 'report-context-us-close-'
+     f'{__import__("datetime").datetime.now(wd.HKT):%Y-%m-%d}.json'
+     ).write_text(json.dumps(ctx, ensure_ascii=False))
+
+    def run(*, summary, transcript):
+        SUMMARY[0], TRANSCRIPT[0] = summary, transcript
+        monkeypatch.setattr(sys, 'argv',
+                            ['report_watchdog.py', '--market', 'us', '--phase', 'close',
+                             '--job-name', '美股收盘报告'])
+        wd.main()
+        return sent
+
+    return run
+
+
+SUMMARY = ['']
+TRANSCRIPT = [None]
+FRESH_FIRST = FRESH_BLOCK.splitlines()[0]
+
+
+def test_watchdog_mirrors_the_real_report_when_summary_truncated_it(wd_main):
+    """Summary lacks the data block but the transcript holds the real report. The
+    old gate (block_present = raw in summary) would fire the deterministic
+    data-block fallback and drop the full report; the fix must mirror the real one."""
+    real = f'{FRESH_BLOCK}\n\n▎情绪面\n完整报告正文……\n'
+    sent = wd_main(summary='（summary truncated, no block）', transcript=real)
+
+    assert sent['msgs'], 'watchdog sent nothing'
+    body = sent['msgs'][-1]
+    assert '▎情绪面\n完整报告正文' in body      # the real report, not the block-only fallback
 
 
 def test_marker_state_defaults_to_delivered_for_pre_field_markers(pf, sent):

--- a/tests/test_report_context_path.py
+++ b/tests/test_report_context_path.py
@@ -71,6 +71,9 @@ def test_drop_stale_contexts_removes_other_dates_only(preflight, tmp_context_dir
         'report-sent-us-close-2026-07-23.json',         # stale send marker — drop
         'report-sent-us-close-2026-07-24.json',         # today's marker — keep
         'report-upgrade-us-close-2026-07-23.claim',     # stale upgrade claim — drop
+        'report-upgrade-us-close-2026-07-24.claim',     # today's claim — keep
+        'report-sent-us-open-2026-07-23.json',          # other phase marker — keep
+        'report-upgrade-us-open-2026-07-23.claim',      # other phase claim — keep
         'report-sent-hk-close-2026-07-23.json',         # other market marker — keep
     ]
     for name in names:
@@ -91,6 +94,9 @@ def test_drop_stale_contexts_removes_other_dates_only(preflight, tmp_context_dir
         'report-context-us-open-2026-07-23.json',
         'report-sent-hk-close-2026-07-23.json',
         'report-sent-us-close-2026-07-24.json',
+        'report-sent-us-open-2026-07-23.json',
+        'report-upgrade-us-close-2026-07-24.claim',
+        'report-upgrade-us-open-2026-07-23.claim',
     ]
 
 

--- a/tests/test_report_context_path.py
+++ b/tests/test_report_context_path.py
@@ -63,12 +63,15 @@ def test_drop_stale_contexts_removes_other_dates_only(preflight, tmp_context_dir
     """The exact file the agent misread (yesterday's us/close) must be gone,
     and nothing else may be touched."""
     names = [
-        'report-context-us-close-2026-07-22.json',   # stale — the footgun
-        'report-context-us-close-2026-07-23.json',   # stale — what was misread
-        'report-context-us-close-2026-07-24.json',   # today — keep
-        'report-context-us-open-2026-07-23.json',    # other phase — keep
-        'report-context-hk-close-2026-07-23.json',   # other market — keep
-        'report-sent-us-close-2026-07-23.json',      # different artifact — keep
+        'report-context-us-close-2026-07-22.json',      # stale — the footgun
+        'report-context-us-close-2026-07-23.json',      # stale — what was misread
+        'report-context-us-close-2026-07-24.json',      # today — keep
+        'report-context-us-open-2026-07-23.json',       # other phase — keep
+        'report-context-hk-close-2026-07-23.json',      # other market — keep
+        'report-sent-us-close-2026-07-23.json',         # stale send marker — drop
+        'report-sent-us-close-2026-07-24.json',         # today's marker — keep
+        'report-upgrade-us-close-2026-07-23.claim',     # stale upgrade claim — drop
+        'report-sent-hk-close-2026-07-23.json',         # other market marker — keep
     ]
     for name in names:
         (tmp_context_dir / name).write_text('{}')
@@ -78,13 +81,16 @@ def test_drop_stale_contexts_removes_other_dates_only(preflight, tmp_context_dir
     assert sorted(dropped) == [
         'report-context-us-close-2026-07-22.json',
         'report-context-us-close-2026-07-23.json',
+        'report-sent-us-close-2026-07-23.json',
+        'report-upgrade-us-close-2026-07-23.claim',
     ]
     survivors = sorted(p.name for p in tmp_context_dir.iterdir())
     assert survivors == [
         'report-context-hk-close-2026-07-23.json',
         'report-context-us-close-2026-07-24.json',
         'report-context-us-open-2026-07-23.json',
-        'report-sent-us-close-2026-07-23.json',
+        'report-sent-hk-close-2026-07-23.json',
+        'report-sent-us-close-2026-07-24.json',
     ]
 
 


### PR DESCRIPTION
接 #25（`662ae273`）。那个是过渡热修——让读错 context **变响**；这个让它**不可能发生**，做法是删掉 07-24 事故的成因回路本身。

## 改的是什么

以前确定性数据块的路径是：preflight → context → **模型 verbatim 拷贝** → postflight 校验拷贝对不对。模型读错 context 就发错数字，而 verbatim 规则只能在 `deliver_wechat` **已经发出去之后**才发现。

现在 `report_postflight` 自己拼 `title + raw_wechat_block + 散文`，发送时刻直接从 context 取块。**模型只写散文。** 数字过期/被改写/表格被搞坏这三类问题不再是「要去校验的东西」，而是结构上不存在。

> 关于「脚本自己取合理吗」：`report_postflight` 从来就自己 `load_context()`——它就是靠这个校验模型的拷贝的。读取方没变，只是那份数据的用途从「事后对账」变成「直接拼装」。让确定性数据绕模型走一圈才是原本的异常设计。

`--context-id` 选择 prose 模式；不带它仍走 legacy 全文输入，**所以 master 部署先于 payload 更新落地时投递不会断**（dual-stack，后续 PR 拆掉）。

## 四道机制

| 机制 | 挡住什么 |
|---|---|
| **generation binding**：preflight 打 `context_id = sha256[:12](context 去掉 generated_at)`，模型回传 | 07-24 的真实情形——agent **中途又跑了一次 preflight**，盘上是 B 代而散文写的是 A 代。用新数字配旧散文会显得毫无破绽，所以直接拒拼。排除 `generated_at` 让「重跑但数字没变」不会误拒 |
| **fail-closed 投递**：pass/warn 发全文+commit；**fail 只发数据块，绝不发被拒散文**；休市/缺 context 不发 | 07-24 正是「验证失败但照发全文」。完全不发也不行——交易日没消息和 cron 死了长得一样；数据块的每个数字都可信，是诚实的下限 |
| **一次补发**：失败过的 slot 可被合格报告顶替一次，`claim_upgrade()` 用 `O_EXCL` 当锁 | fail-closed 若不能补发就比 07-24 更糟；但无限补发会把 2026-06-03 双发放回来。openclaw 的 run 级自动重试会多次触发同一个 postflight，O_EXCL 让「恰好一次」不依赖读-改-写 |
| **散文文件 30 分钟新鲜度闸**（`input_error`，不发、非零退出） | `--text-file` 自带 PR #22 那个坑：模型忘了重写文件 → 重发上个 slot 的散文。**`context_id` 看不见这个**（模型传的是当前 id，文件是旧文本） |

**`report_watchdog` 也必须跟着改**：prose 模式下正文以标题开头，旧的首行比对会在**每一次健康运行**上误判 mismatch 并往 Telegram 补发重复件。slot 身份改用 `context_id`（`first_line` 只留给旧 marker）。另外会话里也不再有报告全文了，所以「已确认投递」要排在生成闸**之前**判，且补发回退到确定性数据块，而不是把一段 status JSON 发给 kcn。

## 删掉的（而不是继续用提示约束）

- `validate()` 规则 1（verbatim + 表格 1:1）在 prose 模式下整条 —— 校验 harness 会不会拼错自己的字符串没有意义
- SKILL.md 两处表格拷贝大段（-22 / -18 行）
- **Step 0 休市闸** —— `report_preflight._market_closed_reason` 一直就在做这件事，且在任何抓取之前
- payload 里的 context 文件名

契约现在 **forbid** `verbatim` / `report-context-` / `trading_calendar.py` 出现在 report payload 里，防止爬回来。

## 一个诚实的修正

上一轮讨论里估的「payload 砍 61-68%」**不成立**。实测 **-14%**（1583→1364 字符）。被删的大头在 SKILL.md，payload 本来就不厚。

context 体积倒是真降了：`peer_scan` 在**源头**裁剪（Top 5，每个同业压成一行 `RKLB Rocket Lab Corporation +0.34% (5d +3.92%)`），真实 07-24 context **332 行 / 9040 字符 → 110 行 / 4595 字符**。stdout 和落盘保持同一份 JSON——打印一份删节版会多出一种会漂移的表示，而且模型要任何被省掉的字段还得回去开文件，又绕回路径问题。

## 测试

`tests/test_report_assembly.py` 23 个，含通过真 `main()` 的**事故回放**。全部反向变异验证：

| 变异 | 变红 |
|---|---|
| fail 时改回发模型原文 | 事故回放 + 补发序列 |
| 忽略 `context_id` 不匹配 | 事故回放 |
| harness 不再前置数据块 | 5 个 |
| `claim_upgrade` 永远放行 | 一次性补发 |
| 旧 marker 读成 `failed` | 默认态测试 |
| `context_id` 把 `generated_at` 算进去 | 稳定性测试 |
| watchdog 忽略 `context_id` | 2 个 watchdog 测试 |
| 新鲜度闸关掉 / peer 不裁剪 / 缺值格式化崩 | 各自对应 |

**第一轮变异暴露了一个真缺口**：`read_prose_text` 测得很全，但 `main()` 忽略 `in_err` 照样全绿——补了走真 `main()` 的测试才守住。这正是 PR #22 记下的那条。

本地 484 passed / 5 xfailed。

## 合并后必须立刻做

6 条 live payload 用 `openclaw cron edit --message` 更新（scratchpad 里已生成并契约验证：旧 payload 对新契约报 7 条错，新 payload 全 OK）。在那之前 live 跑 legacy 路径，投递正常。

`47d34f2b` 港股开盘 / `fe20ddcf` 港股午盘 / `e9332e0d` 港股午后 / `657c8042` 港股收盘 / `a30b7010` 美股开盘 / `6145c02a` 美股收盘。

作者不自合，等 codex 复审。
