### PR TITLE
news-digest: accept h2 OR h3 headers, not just literal `### `

### DIFF
--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -239,7 +239,16 @@ def validate_news_digest(
     assert total_news > 0, 'no source news in generated digest'
     assert isinstance(digest, str) and len(digest.strip()) >= 100, (
         'LLM digest empty or implausibly short')
-    assert '### ' in digest, 'LLM digest is not the requested markdown structure'
+    # Structure proxy: a real digest is markdown headers + bullets, not a prose
+    # wall / refusal / JSON echo. Accept h2 OR h3 (`## ` / `### `) — pinning the
+    # literal `### ` broke the digest for 3 days from 2026-07-21 when MiniMax M3
+    # started emitting `## ` section headers with otherwise perfect content. The
+    # header level is cosmetic (build_dashboard renders the markdown either way);
+    # what the gate must catch is "no structure at all", so also require a bullet.
+    assert re.search(r'(?m)^#{2,3} ', digest), (
+        'LLM digest has no h2/h3 markdown header (## or ###)')
+    assert re.search(r'(?m)^\s*[-*] ', digest), (
+        'LLM digest has no bullet points')
     print(f'digest validation OK: {len(digest)} chars, {total_news} source items; '
           f'age={age.total_seconds() / 3600:.2f}h')
 

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -151,6 +151,36 @@ def test_real_committed_news_digest_passes():
     validators.validate_news_digest(news, now=generated_time(news) + timedelta(hours=1))
 
 
+@pytest.mark.parametrize('header', ['## Top 移动信号', '### Top 移动信号'])
+def test_news_digest_accepts_h2_and_h3_headers(tmp_path, header):
+    """2026-07-21: MiniMax M3 switched the section headers from `### ` to `## `
+    with otherwise-perfect content, and the literal `### ` check failed the digest
+    for 3 days. Both levels must pass."""
+    payload = news_payload()
+    payload['digest_markdown'] = (
+        f'{header}\n'
+        '- SPCX: SpaceX IPO 限售解锁,supply overhang 风险,减仓或对冲\n'
+        '- SKHY: 财报前动能强但预期已高,谨防 buy rumor sell fact\n')
+    snapshot = write_json(tmp_path / 'news.json', payload)
+    validators.validate_news_digest(
+        snapshot, now=generated_time(snapshot) + timedelta(hours=1))
+
+
+@pytest.mark.parametrize('bad,problem', [
+    ('一段没有任何 markdown 结构的散文，' * 8, 'no h2/h3 markdown header'),
+    ('## Only a header\n没有要点，只有一段话。' * 4, 'no bullet points'),
+])
+def test_news_digest_rejects_structureless_output(tmp_path, bad, problem):
+    """The gate must still catch a prose wall / refusal — accepting h2 only
+    loosens the header level, not the requirement for structure."""
+    payload = news_payload()
+    payload['digest_markdown'] = bad
+    snapshot = write_json(tmp_path / 'news.json', payload)
+    with pytest.raises(AssertionError, match=problem):
+        validators.validate_news_digest(
+            snapshot, now=generated_time(snapshot) + timedelta(hours=1))
+
+
 def test_real_committed_eod_archive_passes(tmp_path):
     archive = ROOT / 'memory/archive/eod-history.csv'
     with archive.open(newline='', encoding='utf-8') as handle:


### PR DESCRIPTION
## 问题

**US News Digest workflow 从 07-21 起每次都失败**（07-21/22/23，07-20 前一直绿），错误 `LLM digest is not the requested markdown structure`。后果:`assets/data/us_news_digest.json` 从 **07-20 起就 stale** 了。

## 真因:校验器脆,不是内容坏

用 live key 复现了今天的 digest —— 内容完全没问题（actionable bullets、结构清晰），只是 **MiniMax M3 把段落标题从 `### ` 换成了 `## `**。而 `validate_news_digest` 断言 digest 里必须含**字面** `### `，于是连续 3 天的好 digest 全被拦下不提交。

复现输出片段（现在的真实产出）:
```
## Top 移动信号

- **SPCX**: SpaceX 7/23 解锁 IPO 限售，supply overhang 风险极高 - 减仓或对冲
- **SKHY**: 财报前动能强，但 +14% 后预期已高 - 谨防 buy rumor sell fact
```

标题级别是**纯装饰** —— `build_dashboard` 渲染 markdown 时 h2/h3 都一样。所以这道闸该检的是「有没有结构」，而不是「是不是恰好这个级别」。

## 改法

把结构 proxy 从「字面 `### `」放宽为:
- 有 h2 或 h3 标题（`^#{2,3} `），**且**
- 至少一个要点（`^\s*[-*] `）

仍然挡得住这道断言本来要挡的东西（散文墙 / 拒答 / JSON 回显），但不再钉死一个模型已经不用的格式。

## 测试

- `## ` 和 `### ` 两种标题都通过
- 一段无标题散文墙 → 报 `no h2/h3 markdown header`
- 有标题但无要点 → 报 `no bullet points`
- 反向变异验证:还原字面 `### ` 检查 → h2 测试变红；去掉要点检查 → 无要点测试变红

本地全量 495 passed / 5 xfailed。

作者不自合，等 codex 复审。
