### PR TITLE
validators: match LLM section structure by concept, not literal format (#1/#2)

### DIFF
--- a/scripts/data/gh_action_brief_fallback.py
+++ b/scripts/data/gh_action_brief_fallback.py
@@ -24,52 +24,45 @@ import decision_v2
 def split_brief_and_plan(out):
     """(markdown, plan_json_str) from the model output.
 
-    The plan is the LAST fenced block; match the fence tolerantly —
-    `` ```json ``, `` ```JSON ``, `` ``` json `` all count. Pinning the exact
-    lowercase ` ```json ` discarded a valid plan the moment the model shifted case
-    or spacing, defeating the last automatic brief-recovery path (2026-07 audit).
-    With no fence at all, fall back to the last balanced {…}; a wrong grab is
-    rejected downstream by plan schema validation, so this never publishes junk.
+    The plan is the LAST valid JSON object in the output. _extract_last_json finds
+    it regardless of fence case/spacing, an EARLIER ```json example, or unbalanced
+    braces in the prose — the exact lowercase ` ```json ` split discarded a valid
+    plan the moment the model shifted case/spacing, defeating the last automatic
+    brief-recovery path (2026-07 audit). Markdown = everything before the plan,
+    with a trailing ```json/``` fence trimmed. A wrong grab is still rejected
+    downstream by plan schema validation, so this never publishes junk.
     """
-    fences = list(re.finditer(r'```[ \t]*json\b', out, re.IGNORECASE))
-    if fences:
-        last = fences[-1]
-        return out[:last.start()], out[last.end():].split('```', 1)[0].strip()
-    return out, _extract_last_json(out)
+    plan, start = _extract_last_json(out)
+    if start is None:
+        return out, '{}'
+    md = out[:start]
+    md = re.sub(r'```[ \t]*json\b[ \t]*\n?$', '', md, flags=re.IGNORECASE)
+    return md.rstrip().rstrip('`').rstrip(), plan
 
 
 def _extract_last_json(text):
-    """Return the last balanced top-level {…} object in text, or '{}' if none.
+    """(last_valid_top_level_JSON_object_str, start_index) or ('{}', None).
 
-    The brief plan is the final JSON in the output; a bare (unfenced) plan means
-    scanning from the last object start. Braces inside strings are ignored. A
-    wrong grab is caught downstream by plan schema validation, so this only has to
-    be right for well-formed trailing JSON."""
-    last = None
-    depth = 0
-    start = None
-    in_str = esc = False
-    for i, c in enumerate(text):
-        if in_str:
-            if esc:
-                esc = False
-            elif c == '\\':
-                esc = True
-            elif c == '"':
-                in_str = False
+    Uses json.raw_decode at each '{', keeping the LAST that parses — so it is
+    string-aware (braces inside JSON strings are handled by the decoder), skips an
+    earlier ```json example, and is immune to unbalanced braces in the surrounding
+    prose (a hand-rolled depth counter is not — an unmatched '{' in Markdown
+    poisons it; 2026-07 review)."""
+    decoder = json.JSONDecoder()
+    last, last_start = '{}', None
+    idx = 0
+    while True:
+        b = text.find('{', idx)
+        if b == -1:
+            break
+        try:
+            _, end = decoder.raw_decode(text, b)
+        except json.JSONDecodeError:
+            idx = b + 1
             continue
-        if c == '"':
-            in_str = True
-        elif c == '{':
-            if depth == 0:
-                start = i
-            depth += 1
-        elif c == '}':
-            if depth > 0:
-                depth -= 1
-                if depth == 0 and start is not None:
-                    last = text[start:i + 1]
-    return last or '{}'
+        last, last_start = text[b:end], b
+        idx = end
+    return last, last_start
 
 # Send the WHOLE preflight context. This was context[:30000] until 2026-07-16 — a cap
 # sized for an older, smaller context that had since grown to 194KB, so the brief got

--- a/scripts/data/gh_action_brief_fallback.py
+++ b/scripts/data/gh_action_brief_fallback.py
@@ -10,6 +10,7 @@ Env: MINIMAX_API_KEY required; XIAOMI_API_KEY optional fallback
 """
 import json
 import os
+import re
 import sys
 from copy import deepcopy
 from datetime import date
@@ -18,6 +19,57 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from xiaomi_llm import chat
 import decision_v2
+
+
+def split_brief_and_plan(out):
+    """(markdown, plan_json_str) from the model output.
+
+    The plan is the LAST fenced block; match the fence tolerantly —
+    `` ```json ``, `` ```JSON ``, `` ``` json `` all count. Pinning the exact
+    lowercase ` ```json ` discarded a valid plan the moment the model shifted case
+    or spacing, defeating the last automatic brief-recovery path (2026-07 audit).
+    With no fence at all, fall back to the last balanced {…}; a wrong grab is
+    rejected downstream by plan schema validation, so this never publishes junk.
+    """
+    fences = list(re.finditer(r'```[ \t]*json\b', out, re.IGNORECASE))
+    if fences:
+        last = fences[-1]
+        return out[:last.start()], out[last.end():].split('```', 1)[0].strip()
+    return out, _extract_last_json(out)
+
+
+def _extract_last_json(text):
+    """Return the last balanced top-level {…} object in text, or '{}' if none.
+
+    The brief plan is the final JSON in the output; a bare (unfenced) plan means
+    scanning from the last object start. Braces inside strings are ignored. A
+    wrong grab is caught downstream by plan schema validation, so this only has to
+    be right for well-formed trailing JSON."""
+    last = None
+    depth = 0
+    start = None
+    in_str = esc = False
+    for i, c in enumerate(text):
+        if in_str:
+            if esc:
+                esc = False
+            elif c == '\\':
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == '{':
+            if depth == 0:
+                start = i
+            depth += 1
+        elif c == '}':
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start is not None:
+                    last = text[start:i + 1]
+    return last or '{}'
 
 # Send the WHOLE preflight context. This was context[:30000] until 2026-07-16 — a cap
 # sized for an older, smaller context that had since grown to 194KB, so the brief got
@@ -228,13 +280,8 @@ def main():
     # ~20K tokens; the 180s default timed out 3x on 2026-07-16 and killed the run.
     out = chat(system=system, user=user, max_tokens=32000, temperature=0.6, timeout=900)
 
-    # Split markdown + plan.json
-    if '```json' in out:
-        md_part, json_part = out.rsplit('```json', 1)
-        json_part = json_part.split('```', 1)[0].strip()
-    else:
-        md_part = out
-        json_part = '{}'
+    # Split markdown + plan.json (see split_brief_and_plan for the tolerance rules).
+    md_part, json_part = split_brief_and_plan(out)
 
     desc = (f"clawock 盘前深度简报 {today}：港股 + 美股真实持仓的多空辩论、量化因子、"
             f"风控硬闸与 AI 自评战绩（诚实公开，主动建议平均方向分为负）。")

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -347,33 +347,42 @@ def validate_weekly_review(
     assert metadata.get('layout') == 'default', 'unexpected weekly review layout'
     assert metadata.get('title') == f'周复盘 · {week_id}', 'weekly review title/week mismatch'
     assert len(body) >= 1000, f'weekly review implausibly short: {len(body)} chars'
-    # Four semantic sections, each detected by a ZH/EN alias set rather than one
-    # literal phrase. The generator prompt asks for 本周净值/决策兑现/风险演变/下周关注
-    # as bold labels, but MiniMax M3 drifts to English `## Weekly NAV / Plan
-    # Adherence & Calibration / Risk Evolution / Next Week's Focus` (the committed
-    # 2026-W24.md does exactly this and the old literal-token gate rejected it).
-    # The analysis is present either way, so match concepts, not a fixed language.
-    low = body.lower()
+    # Four required sections, each proven by a distinct SECTION MARKER (a markdown
+    # heading `## …` OR a bold label `**…**` — the prompt asks for bold, MiniMax
+    # drifts to headings). Matching an alias anywhere in the body would let a
+    # counterfeit with four inline bold mentions pass; matching a distinct marker
+    # line ties each concept to a real section. Aliases are ZH/EN because the model
+    # drifts language (the committed 2026-W24.md uses English headers); ASCII
+    # aliases are word-bounded so 'nav' matches "NAV" but not "navigation".
     section_aliases = {
-        'NAV/净值':       ('本周净值', '周净值', 'weekly nav', 'nav'),
-        '决策/校准':      ('决策兑现', '决策校准', 'brier', 'calibration', '校准误差',
-                          'adherence', 'plan adherence'),
-        '风险演变':       ('风险演变', 'risk evolution', 'risk trend', 'β/vol', 'sharpe'),
-        '下周关注':       ('下周关注', '下周', 'next week', "next week's focus"),
+        'NAV/净值':   ('本周净值', '周净值', '净值', 'weekly nav', 'nav'),
+        '决策/校准':  ('决策兑现', '决策校准', '校准', 'brier', 'calibration',
+                      'adherence'),
+        '风险演变':   ('风险演变', '风险', 'risk evolution', 'risk trend'),
+        '下周关注':   ('下周关注', '下周', "next week's focus", 'next week', 'next-week'),
     }
-    missing = [concept for concept, aliases in section_aliases.items()
-               if not any(a in low for a in aliases)]
-    assert not missing, (
-        f'weekly review missing required section(s): {missing}; '
-        f'accepted aliases per section: {section_aliases}')
-    # Structure proxy: >=4 section markers, where a marker is a markdown heading
-    # OR a bold label (the prompt asks for `**本周净值**`-style bold, not `#`).
-    markers = [ln for ln in body.splitlines()
+
+    def _marker_matches(marker, alias):
+        if alias.isascii():  # word-bounded, case-insensitive (no CJK boundaries)
+            return re.search(rf'\b{re.escape(alias)}\b', marker, re.IGNORECASE) is not None
+        return alias in marker
+
+    markers = [ln.strip() for ln in body.splitlines()
                if re.match(r'^\s{0,3}#{1,6} \S', ln) or re.match(r'^\s{0,3}\*\*\S', ln)]
-    assert len(markers) >= 4, (
-        f'weekly review has only {len(markers)} section markers (heading or bold), '
-        f'need >= 4')
-    print(f'weekly review validation OK: {path} ({len(body)} chars)')
+    matched = {}  # concept -> the marker line that satisfied it (must be distinct)
+    for concept, aliases in section_aliases.items():
+        for m in markers:
+            if m in matched.values():
+                continue  # one marker can't cover two concepts
+            if any(_marker_matches(m, a) for a in aliases):
+                matched[concept] = m
+                break
+    missing = [c for c in section_aliases if c not in matched]
+    assert not missing, (
+        f'weekly review missing required section marker(s): {missing}; '
+        f'section markers found: {markers[:12]}')
+    print(f'weekly review validation OK: {path} ({len(body)} chars, '
+          f'{len(markers)} section markers)')
 
 
 DEFAULT_SCREENSHOTS = (

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -347,17 +347,32 @@ def validate_weekly_review(
     assert metadata.get('layout') == 'default', 'unexpected weekly review layout'
     assert metadata.get('title') == f'周复盘 · {week_id}', 'weekly review title/week mismatch'
     assert len(body) >= 1000, f'weekly review implausibly short: {len(body)} chars'
-    required_sections = ('本周净值', '风险演变', '下周关注')
-    normalized_body = re.sub(
-        r'下周(?:\s*\([^\n)]*\))?\s*关注', '下周关注', body)
-    missing = [section for section in required_sections if section not in normalized_body]
-    assert not missing, f'weekly review missing required sections: {missing}'
-    calibration_tokens = ('Brier', '校准误差', 'Calibration', '兑现')
-    assert any(token in body for token in calibration_tokens), (
-        f'weekly review missing decisions/calibration section; expected any of: '
-        f'{calibration_tokens}')
-    headings = [line for line in body.splitlines() if line.lstrip().startswith('#')]
-    assert len(headings) >= 4, 'weekly review does not contain four markdown sections'
+    # Four semantic sections, each detected by a ZH/EN alias set rather than one
+    # literal phrase. The generator prompt asks for 本周净值/决策兑现/风险演变/下周关注
+    # as bold labels, but MiniMax M3 drifts to English `## Weekly NAV / Plan
+    # Adherence & Calibration / Risk Evolution / Next Week's Focus` (the committed
+    # 2026-W24.md does exactly this and the old literal-token gate rejected it).
+    # The analysis is present either way, so match concepts, not a fixed language.
+    low = body.lower()
+    section_aliases = {
+        'NAV/净值':       ('本周净值', '周净值', 'weekly nav', 'nav'),
+        '决策/校准':      ('决策兑现', '决策校准', 'brier', 'calibration', '校准误差',
+                          'adherence', 'plan adherence'),
+        '风险演变':       ('风险演变', 'risk evolution', 'risk trend', 'β/vol', 'sharpe'),
+        '下周关注':       ('下周关注', '下周', 'next week', "next week's focus"),
+    }
+    missing = [concept for concept, aliases in section_aliases.items()
+               if not any(a in low for a in aliases)]
+    assert not missing, (
+        f'weekly review missing required section(s): {missing}; '
+        f'accepted aliases per section: {section_aliases}')
+    # Structure proxy: >=4 section markers, where a marker is a markdown heading
+    # OR a bold label (the prompt asks for `**本周净值**`-style bold, not `#`).
+    markers = [ln for ln in body.splitlines()
+               if re.match(r'^\s{0,3}#{1,6} \S', ln) or re.match(r'^\s{0,3}\*\*\S', ln)]
+    assert len(markers) >= 4, (
+        f'weekly review has only {len(markers)} section markers (heading or bold), '
+        f'need >= 4')
     print(f'weekly review validation OK: {path} ({len(body)} chars)')
 
 

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -354,30 +354,31 @@ def validate_weekly_review(
     # line ties each concept to a real section. Aliases are ZH/EN because the model
     # drifts language (the committed 2026-W24.md uses English headers); ASCII
     # aliases are word-bounded so 'nav' matches "NAV" but not "navigation".
-    section_aliases = {
-        'NAV/净值':   ('本周净值', '周净值', '净值', 'weekly nav', 'nav'),
-        '决策/校准':  ('决策兑现', '决策校准', '校准', 'brier', 'calibration',
-                      'adherence'),
-        '风险演变':   ('风险演变', '风险', 'risk evolution', 'risk trend'),
-        '下周关注':   ('下周关注', '下周', "next week's focus", 'next week', 'next-week'),
+    # Each concept is a set of regex patterns matched against a marker line
+    # (IGNORECASE). Patterns are FULL section phrases, not bare fragments: a bare
+    # 风险/净值/校准/下周 matched unrelated headings like `## 风险提示` or
+    # `## 净值口径说明` (2026-07 re-review). CJK phrases are literal; English uses
+    # `\b…\b` word boundaries so 'nav' ≠ 'navigation'. `下周…关注` allows an inline
+    # date range (`下周 (07/20-07/24) 关注`).
+    section_patterns = {
+        'NAV/净值':   (r'本周净值', r'周净值', r'\bweekly nav\b', r'\bnav\b'),
+        '决策/校准':  (r'决策兑现', r'决策校准', r'\bbrier\b', r'\bcalibration\b',
+                      r'\badherence\b'),
+        '风险演变':   (r'风险演变', r'\brisk evolution\b', r'\brisk trend\b'),
+        '下周关注':   (r'下周.{0,15}关注', r"\bnext week'?s? focus\b", r'\bnext week\b'),
     }
-
-    def _marker_matches(marker, alias):
-        if alias.isascii():  # word-bounded, case-insensitive (no CJK boundaries)
-            return re.search(rf'\b{re.escape(alias)}\b', marker, re.IGNORECASE) is not None
-        return alias in marker
 
     markers = [ln.strip() for ln in body.splitlines()
                if re.match(r'^\s{0,3}#{1,6} \S', ln) or re.match(r'^\s{0,3}\*\*\S', ln)]
-    matched = {}  # concept -> the marker line that satisfied it (must be distinct)
-    for concept, aliases in section_aliases.items():
-        for m in markers:
-            if m in matched.values():
-                continue  # one marker can't cover two concepts
-            if any(_marker_matches(m, a) for a in aliases):
-                matched[concept] = m
+    matched = {}  # concept -> index of the marker line that satisfied it (distinct)
+    for concept, patterns in section_patterns.items():
+        for i, m in enumerate(markers):
+            if i in matched.values():
+                continue  # one marker line can't cover two concepts
+            if any(re.search(p, m, re.IGNORECASE) for p in patterns):
+                matched[concept] = i
                 break
-    missing = [c for c in section_aliases if c not in matched]
+    missing = [c for c in section_patterns if c not in matched]
     assert not missing, (
         f'weekly review missing required section marker(s): {missing}; '
         f'section markers found: {markers[:12]}')

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -360,12 +360,17 @@ def validate_weekly_review(
     # `## 净值口径说明` (2026-07 re-review). CJK phrases are literal; English uses
     # `\b…\b` word boundaries so 'nav' ≠ 'navigation'. `下周…关注` allows an inline
     # date range (`下周 (07/20-07/24) 关注`).
+    # English aliases are CONTEXTUAL phrases, not bare words: bare nav/calibration/
+    # next week/risk trend let a fully-English counterfeit pass (`NAV Methodology /
+    # Model Calibration Method / Risk Trend Definitions / Next Week Calendar`,
+    # 2026-07 re-review). Calibration requires plan/decision context so
+    # `Plan Adherence & Calibration` passes but `Model Calibration Method` does not.
     section_patterns = {
-        'NAV/净值':   (r'本周净值', r'周净值', r'\bweekly nav\b', r'\bnav\b'),
-        '决策/校准':  (r'决策兑现', r'决策校准', r'\bbrier\b', r'\bcalibration\b',
-                      r'\badherence\b'),
-        '风险演变':   (r'风险演变', r'\brisk evolution\b', r'\brisk trend\b'),
-        '下周关注':   (r'下周.{0,15}关注', r"\bnext week'?s? focus\b", r'\bnext week\b'),
+        'NAV/净值':   (r'本周净值', r'周净值', r'\bweekly nav\b'),
+        '决策/校准':  (r'决策兑现', r'决策校准',
+                      r'\b(?:plan|decisions?)\b.{0,24}\b(?:adherence|calibration|brier)\b'),
+        '风险演变':   (r'风险演变', r'\brisk evolution\b'),
+        '下周关注':   (r'下周.{0,15}关注', r"\bnext week'?s? focus\b"),
     }
 
     markers = [ln.strip() for ln in body.splitlines()

--- a/tests/test_gh_action_brief_fallback.py
+++ b/tests/test_gh_action_brief_fallback.py
@@ -62,3 +62,35 @@ def test_missing_required_section_produces_zero_actions_and_explicit_brief():
     assert plan["data_complete"] is False
     assert "数据不完整，本次不生成交易动作" in markdown
     assert "us_stocks" in markdown
+
+
+import pytest
+
+
+@pytest.mark.parametrize('fence', ['```json', '```JSON', '``` json', '```\tjson'])
+def test_split_brief_and_plan_tolerates_fence_case_and_spacing(fence):
+    """2026-07 audit: pinning the exact lowercase ```json discarded a valid plan
+    the moment the model shifted case/spacing, killing the last brief-recovery."""
+    out = f'# 盘前简报\n正文……\n\n{fence}\n{{"decisions": [], "as_of": "x"}}\n```\n'
+    md, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan) == {'decisions': [], 'as_of': 'x'}
+    assert '盘前简报' in md and '```' not in md
+
+
+def test_split_brief_and_plan_uses_last_fence_not_first():
+    """Markdown may itself contain a ```json example; the plan is the LAST fence."""
+    out = ('示例：```json\n{"example": true}\n```\n正文\n\n'
+           '```json\n{"decisions": [1], "as_of": "real"}\n```')
+    _, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan) == {'decisions': [1], 'as_of': 'real'}
+
+
+def test_split_brief_and_plan_recovers_a_bare_trailing_plan():
+    out = '# 简报\n正文 {行内 brace 不是 plan}\n\n{"decisions": [], "as_of": "bare"}'
+    _, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan)['as_of'] == 'bare'
+
+
+def test_split_brief_and_plan_returns_empty_object_when_no_json():
+    _, plan = fallback.split_brief_and_plan('# 简报\n只有正文，没有计划。')
+    assert plan == '{}'

--- a/tests/test_gh_action_brief_fallback.py
+++ b/tests/test_gh_action_brief_fallback.py
@@ -94,3 +94,25 @@ def test_split_brief_and_plan_recovers_a_bare_trailing_plan():
 def test_split_brief_and_plan_returns_empty_object_when_no_json():
     _, plan = fallback.split_brief_and_plan('# 简报\n只有正文，没有计划。')
     assert plan == '{}'
+
+
+def test_split_recovers_bare_plan_after_an_earlier_fenced_example():
+    """2026-07 review: an earlier ```json example must not steal the plan when the
+    real plan is a bare trailing object — the LAST valid object wins."""
+    out = ('示例：\n```json\n{"example": 1}\n```\n正文\n\n'
+           '{"decisions": [], "as_of": "real"}')
+    _, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan)['as_of'] == 'real'
+
+
+def test_split_survives_unbalanced_brace_in_prose():
+    """An unmatched { in Markdown must not poison extraction of a valid trailing plan."""
+    out = '正文 { 未闭合花括号\n\n```json\n{"decisions": [], "as_of": "d"}\n```'
+    _, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan)['as_of'] == 'd'
+
+
+def test_split_is_string_aware_for_braces_inside_json_values():
+    out = '```json\n{"note": "a } b {", "as_of": "e"}\n```'
+    _, plan = fallback.split_brief_and_plan(out)
+    assert json.loads(plan) == {'note': 'a } b {', 'as_of': 'e'}

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -404,16 +404,48 @@ def test_weekly_accepts_bold_labels_without_hash_headings(tmp_path):
 def test_weekly_rejects_inline_bold_counterfeit_without_real_section_markers(tmp_path):
     """2026-07 review: aliases matched anywhere in the body let a counterfeit with
     four inline mentions pass. Each concept must tie to a DISTINCT section marker
-    (line-start heading or bold label). A word like 'navigation' must not satisfy
-    the 'nav' alias (word boundary)."""
+    (line-start heading or bold label). Real `**bold**` labels used inline
+    mid-sentence must not count."""
     body = '\n'.join((
         '# Summary',
-        'This week we discussed navigation of the portfolio and calibration of risk '
-        'appetite, with a nav overview woven into next week thoughts.',  # inline only
+        'This week we discussed **navigation** of the portfolio and **calibration** '
+        'of risk appetite, a **nav** overview woven into **next week** thoughts.',
         'x' * 1100))
     path = tmp_path / '2026-W40.md'
     path.write_text(_weekly('2026-W40', body), encoding='utf-8')
     with pytest.raises(AssertionError, match='missing required section marker'):
+        validators.validate_weekly_review(path)
+
+
+def test_weekly_rejects_generic_headings_that_are_not_the_required_sections(tmp_path):
+    """2026-07 re-review: bare 净值/校准/风险/下周 fragments matched unrelated
+    headings. `## 风险提示` (risk warning) is not 风险演变; `## 净值口径说明` is not
+    the NAV section; `## Next Week Calendar` is not necessarily 下周关注."""
+    body = '\n'.join((
+        '## 净值口径说明', 'p',
+        '## Model Calibration Method', 'p',
+        '## 风险提示', 'p',
+        '## Next Week Calendar', 'p',
+        'x' * 1100))
+    path = tmp_path / '2026-W44.md'
+    path.write_text(_weekly('2026-W44', body), encoding='utf-8')
+    # fails on NAV/净值 and 风险演变 (neither generic heading is the real section)
+    with pytest.raises(AssertionError, match='NAV/净值|风险演变'):
+        validators.validate_weekly_review(path)
+
+
+def test_weekly_risk_warning_heading_alone_does_not_satisfy_risk_evolution(tmp_path):
+    """Pin the 风险 tightening: a review that is otherwise complete but has only a
+    `## 风险提示` (risk warning) instead of a risk-evolution section fails on it."""
+    body = '\n'.join((
+        '## 本周净值', 'p',
+        '## 决策校准', 'Brier',
+        '## 风险提示', 'p',      # NOT 风险演变
+        '## 下周关注', 'p',
+        'x' * 1100))
+    path = tmp_path / '2026-W45.md'
+    path.write_text(_weekly('2026-W45', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='风险演变'):
         validators.validate_weekly_review(path)
 
 

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -401,6 +401,36 @@ def test_weekly_accepts_bold_labels_without_hash_headings(tmp_path):
     validators.validate_weekly_review(path)
 
 
+def test_weekly_rejects_inline_bold_counterfeit_without_real_section_markers(tmp_path):
+    """2026-07 review: aliases matched anywhere in the body let a counterfeit with
+    four inline mentions pass. Each concept must tie to a DISTINCT section marker
+    (line-start heading or bold label). A word like 'navigation' must not satisfy
+    the 'nav' alias (word boundary)."""
+    body = '\n'.join((
+        '# Summary',
+        'This week we discussed navigation of the portfolio and calibration of risk '
+        'appetite, with a nav overview woven into next week thoughts.',  # inline only
+        'x' * 1100))
+    path = tmp_path / '2026-W40.md'
+    path.write_text(_weekly('2026-W40', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='missing required section marker'):
+        validators.validate_weekly_review(path)
+
+
+def test_weekly_word_boundary_navigation_does_not_satisfy_nav(tmp_path):
+    """'navigation' in a heading must not count as the NAV section."""
+    body = '\n'.join((
+        '## Portfolio Navigation Notes', 'Prose.',
+        '## Plan Adherence & Calibration', 'Brier prose.',
+        '## Risk Evolution', 'Prose.',
+        "## Next Week's Focus", 'Prose.',
+        'x' * 1100))
+    path = tmp_path / '2026-W41.md'
+    path.write_text(_weekly('2026-W41', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='NAV/净值'):
+        validators.validate_weekly_review(path)
+
+
 def test_weekly_still_rejects_a_genuinely_missing_section(tmp_path):
     """Loosening the language must not loosen the requirement: a review with no
     risk section (any language) still fails, and the error names it."""

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -366,6 +366,55 @@ def test_weekly_calibration_token_and_next_week_variants_pass(tmp_path, token):
     validators.validate_weekly_review(path)
 
 
+def _weekly(week_id, body):
+    return f'---\nlayout: default\ntitle: 周复盘 · {week_id}\n---\n{body}\n'
+
+
+def test_weekly_accepts_all_english_headers(tmp_path):
+    """2026-07 audit: MiniMax M3 drifted to English section headers; the committed
+    2026-W24.md uses `## Weekly NAV / Plan Adherence & Calibration / Risk Evolution
+    / Next Week's Focus` and the old literal-ZH-token gate rejected it."""
+    body = '\n'.join((
+        '## Executive Summary', 'Overview.',
+        '## 1. Weekly NAV: Drawdown', 'Start vs end NAV analysis.',
+        '## 2. Plan Adherence & Calibration', 'Brier score and adherence.',
+        '## 3. Risk Evolution', 'Beta/Vol/Sharpe trend.',
+        "## 4. Next Week's Focus", 'Three actionable triggers.',
+        'x' * 1100))
+    path = tmp_path / '2026-W24.md'
+    path.write_text(_weekly('2026-W24', body), encoding='utf-8')
+    validators.validate_weekly_review(path)
+
+
+def test_weekly_accepts_bold_labels_without_hash_headings(tmp_path):
+    """The generator prompt asks for `**本周净值**`-style BOLD labels, not `#`
+    headings — a review that follows the prompt literally must not be failed by a
+    heading-count check."""
+    body = '\n'.join((
+        '**本周净值**', '组合回顾与净值。',
+        '**决策兑现**', 'Brier 与决策回看。',
+        '**风险演变**', '风险与仓位演变。',
+        '**下周关注**', '下周触发条件。',
+        'x' * 1100))
+    path = tmp_path / '2026-W30.md'
+    path.write_text(_weekly('2026-W30', body), encoding='utf-8')
+    validators.validate_weekly_review(path)
+
+
+def test_weekly_still_rejects_a_genuinely_missing_section(tmp_path):
+    """Loosening the language must not loosen the requirement: a review with no
+    risk section (any language) still fails, and the error names it."""
+    body = '\n'.join((
+        '## Weekly NAV', 'NAV analysis.',
+        '## Plan Adherence & Calibration', 'Brier and adherence.',
+        "## Next Week's Focus", 'Triggers.',
+        'x' * 1100))  # no risk-evolution section at all
+    path = tmp_path / '2026-W31.md'
+    path.write_text(_weekly('2026-W31', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='风险演变'):
+        validators.validate_weekly_review(path)
+
+
 def test_header_only_png_is_rejected_by_size_floor(tmp_path):
     path = tmp_path / 'image.png'
     path.write_bytes(

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -434,6 +434,48 @@ def test_weekly_rejects_generic_headings_that_are_not_the_required_sections(tmp_
         validators.validate_weekly_review(path)
 
 
+def test_weekly_rejects_fully_english_generic_counterfeit(tmp_path):
+    """2026-07 round-3 review: bare English aliases (nav/calibration/next week/
+    risk trend) let an all-English counterfeit pass. English aliases are now
+    contextual phrases."""
+    body = '\n'.join((
+        '## NAV Methodology', 'p',
+        '## Model Calibration Method', 'p',
+        '## Risk Trend Definitions', 'p',
+        '## Next Week Calendar', 'p',
+        'x' * 1100))
+    path = tmp_path / '2026-W46.md'
+    path.write_text(_weekly('2026-W46', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='missing required section marker'):
+        validators.validate_weekly_review(path)
+
+
+def test_weekly_nav_requires_weekly_context_not_bare_nav(tmp_path):
+    """A review valid except a `## NAV Methodology` heading fails on NAV — the real
+    section is 'Weekly NAV', bare 'nav' matched unrelated headings."""
+    body = '\n'.join(('## NAV Methodology', 'p', '## Plan Adherence & Calibration', 'p',
+                      '## Risk Evolution', 'p', "## Next Week's Focus", 'p', 'x' * 1100))
+    p = tmp_path / '2026-W49.md'
+    p.write_text(_weekly('2026-W49', body), encoding='utf-8')
+    with pytest.raises(AssertionError, match='NAV/净值'):
+        validators.validate_weekly_review(p)
+
+
+def test_weekly_calibration_requires_plan_or_decision_context(tmp_path):
+    """`Plan Adherence & Calibration` passes; a bare `Model Calibration Method`
+    heading does not satisfy the 决策/校准 section."""
+    def review(cal_heading, week):
+        body = '\n'.join(('## Weekly NAV', 'p', f'## {cal_heading}', 'p',
+                          '## Risk Evolution', 'p', "## Next Week's Focus", 'p', 'x' * 1100))
+        p = tmp_path / f'{week}.md'
+        p.write_text(_weekly(week, body), encoding='utf-8')
+        return p
+
+    validators.validate_weekly_review(review('Plan Adherence & Calibration', '2026-W47'))
+    with pytest.raises(AssertionError, match='决策/校准'):
+        validators.validate_weekly_review(review('Model Calibration Method', '2026-W48'))
+
+
 def test_weekly_risk_warning_heading_alone_does_not_satisfy_risk_evolution(tmp_path):
     """Pin the 风险 tightening: a review that is otherwise complete but has only a
     `## 风险提示` (risk warning) instead of a risk-evolution section fails on it."""


### PR DESCRIPTION
接 #27。CI 审计里的另外两处 news-digest 同型脆性 —— 语义正确的 LLM 产物被字面格式检查拦下，悄悄饿死下游。

## #1 weekly-review：中文字面 token + `#` 标题计数
旧闸要求字面 `本周净值 / 风险演变 / 下周关注` + `len(headings) >= 4`（只数 `#` 行）。MiniMax M3 已漂到英文标题 —— 仓里的 `memory/weekly/2026-W24.md` 用的是 `## Weekly NAV / Plan Adherence & Calibration / Risk Evolution / Next Week's Focus`，**旧闸直接拒掉它**（拿 validator 跑真实文件验证过）。而且生成 prompt 要的是 `**加粗**` 标签、不是 `#` 标题，照 prompt 写反而过不了标题计数。

改法：四个小节各用 ZH/EN 别名集匹配「概念」；结构 proxy 接受 markdown 标题**或**加粗标签。真缺某节仍然 fail，且报错点名是哪节。

## #2 brief-fallback：字面小写 ` ```json ` 围栏
plan 用 `if '```json' in out` 切分 —— 钉死小写。模型输出 ` ```JSON ` / ` ``` json ` / 末尾裸 JSON 时，plan 变成空 `{}` → schema 校验失败 → **最后一条自动兜底简报链产不出东西**。改成大小写/空格容忍（正则，取最后一个围栏），无围栏时回退到「最后一个平衡 `{…}`」；抓错仍由下游 plan schema 校验兜住。抽成 `split_brief_and_plan()` 便于测试。

## 不改：brief_postflight 的 `REQUIRED_MARKDOWN_TOKENS`
`Tier 1/2/3/Judge/…` 是 `daily-deep-brief/SKILL.md`（原文喂进 prompt）**强制的框架小节名**，不是模型自选的格式，所以那道闸是合法的模板一致性检查、不是脆性类。codex 提了这条，我带理由排除。

## 测试
EN 标题 + 加粗标签周复盘都通过，缺节按名 fail；围栏大小写/空格变体 + 取最后围栏 + 裸尾 JSON 都能解析。全部反向变异验证。本地 505 passed / 5 xfailed。

作者不自合，等 codex 复审。
