### PR TITLE
brief-preflight: judge sidecar freshness by generated_at, not file mtime (#5)

### DIFF
--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -146,15 +146,17 @@ def validate_markdown(path, context=None):
     if context and context.get('macro'):
         m = context['macro']
         age = m.get('age_hours')
-        # Only enforce when macro is reasonably fresh
-        if (age is None or age <= STALE_H) and m.get('vix') and '▎大盘速读' not in text:
+        # Only enforce when macro is known-fresh. age None = unknown/stale (preflight
+        # now omits stale sidecars, but if one reaches here, don't demand the section
+        # off unprovable-fresh data — that would fail a correctly-omitted section).
+        if (age is not None and age <= STALE_H) and m.get('vix') and '▎大盘速读' not in text:
             issues.append('pre-open.md 缺 ▎大盘速读 段（context.macro 有 fresh 数据 '
                           f'age={age}h 但 LLM 没写）')
     if context and context.get('sentiment'):
         s = context['sentiment']
         age = s.get('age_hours')
         tickers = s.get('tickers') or []
-        if (age is None or age <= STALE_H) and tickers and '▎社交舆情' not in text:
+        if (age is not None and age <= STALE_H) and tickers and '▎社交舆情' not in text:
             issues.append(f'pre-open.md 缺 ▎社交舆情速读 段（context.sentiment '
                           f'{len(tickers)} 个 ticker 有信号 age={age}h 但 LLM 没写）')
 

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -884,6 +884,21 @@ def _payload_age_hours(payload):
     return (datetime.now(timezone.utc) - t).total_seconds() / 3600
 
 
+# A materially future generated_at (beyond clock skew) is as untrustworthy as an
+# old one — it means a broken producer clock, not fresh data.
+_CLOCK_SKEW_H = 2
+
+
+def _is_stale(age, cutoff_h):
+    """True if age (hours, or None) is unusable: unknown, too old, or from the
+    future beyond clock skew. Callers omit stale data rather than feed it."""
+    return age is None or age > cutoff_h or age < -_CLOCK_SKEW_H
+
+
+def _age_str(age):
+    return f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
+
+
 def load_macro_and_sentiment(today, issues):
     """Read GH-Action-produced macro.json + sentiment.json; trim to LLM-friendly subset.
 
@@ -905,30 +920,34 @@ def load_macro_and_sentiment(today, issues):
         else:
             m = json.loads(macro_path.read_text())
             age = _payload_age_hours(m)
-            def _q(k):
-                v = m.get(k)
-                if not v: return None
-                return {'price': v.get('price'), 'change_pct': v.get('change_pct'),
-                        'source': v.get('source')}
-            macro_trim = {
-                'as_of':        m.get('generated_at'),
-                'age_hours':    round(age, 1) if age is not None else None,
-                'vix':          _q('vix'),
-                'dxy':          _q('dxy'),
-                'treasury_10y_yield_pct': (m.get('treasury_10y') or {}).get('yield_pct'),
-                'fear_greed':   m.get('fear_greed'),
-                'hsi':          _q('hsi'),
-                'hstech':       _q('hstech'),
-                'spx':          _q('spx'),
-                'nasdaq':       _q('nasdaq'),
-                'fed_press':    (m.get('fed_press') or [])[:3],
-            }
-            macro_trim['regime'] = _classify_regime(macro_trim)  # risk_on/neutral/risk_off
-            if age is None or age > stale_cutoff_h:
-                shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
-                print(f'   ⚠ macro stale ({shown}, cutoff {stale_cutoff_h}h)')
-                issues.append(f'macro snapshot stale {shown}')
+            if _is_stale(age, stale_cutoff_h):
+                # OMIT stale/unknown-age data — do NOT feed it as fresh, and do NOT
+                # append to `issues` (main() returns exit 1 on any issue, which
+                # under the fallback workflow's pipefail would hard-fail the entire
+                # brief — a worse outage than a missing macro section). The brief
+                # runs without macro; downstream postflight sees no macro context.
+                print(f'   ⚠ macro stale/unknown ({_age_str(age)}, cutoff '
+                      f'{stale_cutoff_h}h) — omitting from brief (non-fatal)')
             else:
+                def _q(k):
+                    v = m.get(k)
+                    if not v: return None
+                    return {'price': v.get('price'), 'change_pct': v.get('change_pct'),
+                            'source': v.get('source')}
+                macro_trim = {
+                    'as_of':        m.get('generated_at'),
+                    'age_hours':    round(age, 1),
+                    'vix':          _q('vix'),
+                    'dxy':          _q('dxy'),
+                    'treasury_10y_yield_pct': (m.get('treasury_10y') or {}).get('yield_pct'),
+                    'fear_greed':   m.get('fear_greed'),
+                    'hsi':          _q('hsi'),
+                    'hstech':       _q('hstech'),
+                    'spx':          _q('spx'),
+                    'nasdaq':       _q('nasdaq'),
+                    'fed_press':    (m.get('fed_press') or [])[:3],
+                }
+                macro_trim['regime'] = _classify_regime(macro_trim)  # risk_on/neutral/risk_off
                 fg = macro_trim['fear_greed'] or {}
                 print(f'   macro: VIX {(macro_trim["vix"] or {}).get("price","?")}, '
                       f'F&G {fg.get("score","?")} ({fg.get("rating","?")}), '
@@ -945,41 +964,41 @@ def load_macro_and_sentiment(today, issues):
         else:
             s = json.loads(sent_path.read_text())
             age = _payload_age_hours(s)
-            # price-in lens: recent 5-session move per signalled ticker (priced-in check)
-            signalled = [t.get('ticker') for t in s.get('tickers', [])
-                         if t.get('reddit_mentions_7d', 0) or t.get('google_news_en')
-                         or t.get('google_news_zh')]
-            moves = _recent_price_moves(signalled)
-            tickers_out = []
-            for t in s.get('tickers', []):
-                reddit_n  = t.get('reddit_mentions_7d', 0)
-                gn_en     = t.get('google_news_en') or []
-                gn_zh     = t.get('google_news_zh') or []
-                # Skip noise: 0 mention + 0 news
-                if reddit_n == 0 and not gn_en and not gn_zh:
-                    continue
-                tickers_out.append({
-                    'ticker': t.get('ticker'),
-                    'name':   t.get('name'),
-                    'region': t.get('region'),
-                    'reddit_mentions_7d': reddit_n,
-                    'reddit_top': [{'title': p.get('title'), 'score': p.get('score'),
-                                    'comments': p.get('num_comments')}
-                                   for p in (t.get('reddit_posts') or [])[:3]],
-                    'news_top':   [n.get('title') for n in (gn_en + gn_zh)[:3] if n.get('title')],
-                    'recent_move': moves.get(t.get('ticker')),  # {px_pct, n_sessions} or None — priced-in check
-                })
-            sentiment_trim = {
-                'as_of':       s.get('generated_at'),
-                'age_hours':   round(age, 1) if age is not None else None,
-                'sources':     s.get('sources', []),
-                'tickers':     tickers_out,
-            }
-            if age is None or age > stale_cutoff_h:
-                shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
-                print(f'   ⚠ sentiment stale ({shown}, cutoff {stale_cutoff_h}h)')
-                issues.append(f'sentiment snapshot stale {shown}')
+            if _is_stale(age, stale_cutoff_h):
+                # Omit stale/unknown sentiment (non-fatal — see macro note above).
+                print(f'   ⚠ sentiment stale/unknown ({_age_str(age)}, cutoff '
+                      f'{stale_cutoff_h}h) — omitting from brief (non-fatal)')
             else:
+                # price-in lens: recent 5-session move per signalled ticker (priced-in check)
+                signalled = [t.get('ticker') for t in s.get('tickers', [])
+                             if t.get('reddit_mentions_7d', 0) or t.get('google_news_en')
+                             or t.get('google_news_zh')]
+                moves = _recent_price_moves(signalled)
+                tickers_out = []
+                for t in s.get('tickers', []):
+                    reddit_n  = t.get('reddit_mentions_7d', 0)
+                    gn_en     = t.get('google_news_en') or []
+                    gn_zh     = t.get('google_news_zh') or []
+                    # Skip noise: 0 mention + 0 news
+                    if reddit_n == 0 and not gn_en and not gn_zh:
+                        continue
+                    tickers_out.append({
+                        'ticker': t.get('ticker'),
+                        'name':   t.get('name'),
+                        'region': t.get('region'),
+                        'reddit_mentions_7d': reddit_n,
+                        'reddit_top': [{'title': p.get('title'), 'score': p.get('score'),
+                                        'comments': p.get('num_comments')}
+                                       for p in (t.get('reddit_posts') or [])[:3]],
+                        'news_top':   [n.get('title') for n in (gn_en + gn_zh)[:3] if n.get('title')],
+                        'recent_move': moves.get(t.get('ticker')),  # {px_pct, n_sessions} or None — priced-in check
+                    })
+                sentiment_trim = {
+                    'as_of':       s.get('generated_at'),
+                    'age_hours':   round(age, 1),
+                    'sources':     s.get('sources', []),
+                    'tickers':     tickers_out,
+                }
                 with_signal = sum(1 for t in tickers_out if t['reddit_mentions_7d'] or t['news_top'])
                 print(f'   sentiment: {with_signal}/{len(s.get("tickers",[]))} tickers '
                       f'have reddit/news signal')
@@ -1004,6 +1023,12 @@ def load_influencer_feed(issues):
             return {}
         d = json.loads(path.read_text())
         age = _payload_age_hours(d)
+        if _is_stale(age, 36):
+            # Omit stale/unknown influencer feed (non-fatal — see macro note above);
+            # brief runs without the 名人异动 section rather than on stale statements.
+            print(f'   ⚠ influencer feed stale/unknown ({_age_str(age)}) '
+                  f'— omitting from brief (non-fatal)')
+            return {}
         # Trim each item to the fields the brief needs.
         def _trim(it):
             return {k: it.get(k) for k in
@@ -1011,20 +1036,15 @@ def load_influencer_feed(issues):
                      'sector_holdings', 'sectors', 'summary_cn')}
         out = {
             'as_of':     d.get('generated_at'),
-            'age_hours': round(age, 1) if age is not None else None,
+            'age_hours': round(age, 1),
             'counts':    d.get('counts', {}),
             'held_hits': [_trim(x) for x in d.get('held_hits', [])][:6],
             'new_ideas': [_trim(x) for x in d.get('new_ideas', [])][:6],
             'sector_hits': [_trim(x) for x in d.get('sector_hits', [])][:4],
         }
-        if age is None or age > 36:
-            shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
-            print(f'   ⚠ influencer feed stale ({shown})')
-            issues.append(f'influencer feed stale {shown}')
-        else:
-            c = out['counts']
-            print(f'   influencer: {c.get("held_hits",0)} held-hits, '
-                  f'{c.get("new_ideas",0)} new-ideas, {c.get("sector_hits",0)} sector')
+        c = out['counts']
+        print(f'   influencer: {c.get("held_hits",0)} held-hits, '
+              f'{c.get("new_ideas",0)} new-ideas, {c.get("sector_hits",0)} sector')
         return out
     except Exception as e:
         print(f'   ⚠ influencer feed load failed: {e}')

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -861,6 +861,29 @@ def load_em_news(issues):
         return {}
 
 
+def _payload_age_hours(payload):
+    """Age in hours from the payload's own `generated_at`, or None if absent/unparseable.
+
+    WHY NOT file mtime (2026-07 audit): `actions/checkout` stamps every tracked
+    file with a fresh checkout time, so a committed-days-ago sidecar reads as
+    seconds old. The off-host brief fallback used st_mtime and therefore fed
+    stale macro/sentiment/influencer into a live trading brief while labelling it
+    fresh. The producer stamps `generated_at`; that is the only honest clock.
+    Callers treat None (missing/bad stamp) as STALE — an unprovable age is not a
+    fresh one.
+    """
+    gen = (payload or {}).get('generated_at')
+    if not gen:
+        return None
+    try:
+        t = datetime.fromisoformat(str(gen).replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - t).total_seconds() / 3600
+
+
 def load_macro_and_sentiment(today, issues):
     """Read GH-Action-produced macro.json + sentiment.json; trim to LLM-friendly subset.
 
@@ -874,21 +897,14 @@ def load_macro_and_sentiment(today, issues):
     sent_path  = WS / 'assets' / 'data' / 'sentiment.json'
     stale_cutoff_h = 36
 
-    def _age_hours(path):
-        try:
-            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
-            return (datetime.now(timezone.utc) - mtime).total_seconds() / 3600
-        except Exception:
-            return None
-
     macro_trim = {}
     try:
         if not macro_path.exists():
             print(f'   ⚠ macro.json missing — sentiment-scan never ran')
             issues.append('macro snapshot missing')
         else:
-            age = _age_hours(macro_path)
             m = json.loads(macro_path.read_text())
+            age = _payload_age_hours(m)
             def _q(k):
                 v = m.get(k)
                 if not v: return None
@@ -908,9 +924,10 @@ def load_macro_and_sentiment(today, issues):
                 'fed_press':    (m.get('fed_press') or [])[:3],
             }
             macro_trim['regime'] = _classify_regime(macro_trim)  # risk_on/neutral/risk_off
-            if age and age > stale_cutoff_h:
-                print(f'   ⚠ macro stale ({age:.1f}h old, cutoff {stale_cutoff_h}h)')
-                issues.append(f'macro snapshot stale {age:.0f}h')
+            if age is None or age > stale_cutoff_h:
+                shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
+                print(f'   ⚠ macro stale ({shown}, cutoff {stale_cutoff_h}h)')
+                issues.append(f'macro snapshot stale {shown}')
             else:
                 fg = macro_trim['fear_greed'] or {}
                 print(f'   macro: VIX {(macro_trim["vix"] or {}).get("price","?")}, '
@@ -926,8 +943,8 @@ def load_macro_and_sentiment(today, issues):
             print(f'   ⚠ sentiment.json missing — sentiment-scan never ran')
             issues.append('sentiment snapshot missing')
         else:
-            age = _age_hours(sent_path)
             s = json.loads(sent_path.read_text())
+            age = _payload_age_hours(s)
             # price-in lens: recent 5-session move per signalled ticker (priced-in check)
             signalled = [t.get('ticker') for t in s.get('tickers', [])
                          if t.get('reddit_mentions_7d', 0) or t.get('google_news_en')
@@ -958,9 +975,10 @@ def load_macro_and_sentiment(today, issues):
                 'sources':     s.get('sources', []),
                 'tickers':     tickers_out,
             }
-            if age and age > stale_cutoff_h:
-                print(f'   ⚠ sentiment stale ({age:.1f}h old, cutoff {stale_cutoff_h}h)')
-                issues.append(f'sentiment snapshot stale {age:.0f}h')
+            if age is None or age > stale_cutoff_h:
+                shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
+                print(f'   ⚠ sentiment stale ({shown}, cutoff {stale_cutoff_h}h)')
+                issues.append(f'sentiment snapshot stale {shown}')
             else:
                 with_signal = sum(1 for t in tickers_out if t['reddit_mentions_7d'] or t['news_top'])
                 print(f'   sentiment: {with_signal}/{len(s.get("tickers",[]))} tickers '
@@ -984,9 +1002,8 @@ def load_influencer_feed(issues):
             print('   ⚠ influencer_feed.json missing — influencer-scan never ran')
             issues.append('influencer feed missing')
             return {}
-        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
-        age = (datetime.now(timezone.utc) - mtime).total_seconds() / 3600
         d = json.loads(path.read_text())
+        age = _payload_age_hours(d)
         # Trim each item to the fields the brief needs.
         def _trim(it):
             return {k: it.get(k) for k in
@@ -994,15 +1011,16 @@ def load_influencer_feed(issues):
                      'sector_holdings', 'sectors', 'summary_cn')}
         out = {
             'as_of':     d.get('generated_at'),
-            'age_hours': round(age, 1),
+            'age_hours': round(age, 1) if age is not None else None,
             'counts':    d.get('counts', {}),
             'held_hits': [_trim(x) for x in d.get('held_hits', [])][:6],
             'new_ideas': [_trim(x) for x in d.get('new_ideas', [])][:6],
             'sector_hits': [_trim(x) for x in d.get('sector_hits', [])][:4],
         }
-        if age > 36:
-            print(f'   ⚠ influencer feed stale ({age:.1f}h old)')
-            issues.append(f'influencer feed stale {age:.0f}h')
+        if age is None or age > 36:
+            shown = f'{age:.0f}h' if age is not None else 'unknown-age (no generated_at)'
+            print(f'   ⚠ influencer feed stale ({shown})')
+            issues.append(f'influencer feed stale {shown}')
         else:
             c = out['counts']
             print(f'   influencer: {c.get("held_hits",0)} held-hits, '

--- a/tests/test_brief_preflight_guardrail.py
+++ b/tests/test_brief_preflight_guardrail.py
@@ -384,3 +384,54 @@ def test_empty_or_all_cash_portfolio_has_no_breaches_and_no_crash(
     assert result["breach_count"] == 0
     assert result["eff_lev_caps"] == {}
     assert result["directive"] == "✅ 无仓位/杠杆硬闸触发，按常规决策。"
+
+
+# ── freshness must come from generated_at, not tracked-file mtime (2026-07 audit) ──
+
+def test_payload_age_uses_generated_at_not_file_mtime(preflight):
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc)
+    age = preflight._payload_age_hours(
+        {'generated_at': (now - timedelta(hours=50)).isoformat()})
+    assert 49 < age < 51
+
+
+def test_payload_age_is_none_for_missing_or_bad_stamp(preflight):
+    # None => callers treat as STALE; an unprovable age is not a fresh one.
+    assert preflight._payload_age_hours({}) is None
+    assert preflight._payload_age_hours({'generated_at': 'not-a-date'}) is None
+    assert preflight._payload_age_hours({'generated_at': ''}) is None
+
+
+def test_payload_age_accepts_zulu_and_naive_timestamps(preflight):
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc)
+    zulu = preflight._payload_age_hours(
+        {'generated_at': (now - timedelta(hours=3)).isoformat().replace('+00:00', 'Z')})
+    assert 2.5 < zulu < 3.5
+    # a naive stamp is assumed UTC, not crashed
+    naive = preflight._payload_age_hours(
+        {'generated_at': (now - timedelta(hours=3)).replace(tzinfo=None).isoformat()})
+    assert 2.5 < naive < 3.5
+
+
+def test_stale_committed_sidecar_with_fresh_mtime_is_flagged(preflight, tmp_path, monkeypatch):
+    """The integration bug: a sidecar committed days ago but freshly checked out
+    (current mtime) must be judged by its generated_at, not the file clock. Also
+    a sidecar with NO generated_at is treated as stale, never silently fresh."""
+    import json
+    from datetime import datetime, timezone, timedelta
+    data = tmp_path / 'assets' / 'data'
+    data.mkdir(parents=True)
+    old = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+    # macro: old generated_at, but the file itself is written now (fresh mtime)
+    (data / 'macro.json').write_text(json.dumps({'generated_at': old, 'vix': None}))
+    # sentiment: NO generated_at at all
+    (data / 'sentiment.json').write_text(json.dumps({'tickers': [], 'sources': []}))
+    monkeypatch.setattr(preflight, 'WS', tmp_path)
+
+    issues = []
+    preflight.load_macro_and_sentiment('2026-07-24', issues)
+
+    assert any('macro snapshot stale' in i for i in issues), issues
+    assert any('sentiment snapshot stale' in i and 'unknown-age' in i for i in issues), issues

--- a/tests/test_brief_preflight_guardrail.py
+++ b/tests/test_brief_preflight_guardrail.py
@@ -415,23 +415,50 @@ def test_payload_age_accepts_zulu_and_naive_timestamps(preflight):
     assert 2.5 < naive < 3.5
 
 
-def test_stale_committed_sidecar_with_fresh_mtime_is_flagged(preflight, tmp_path, monkeypatch):
+def test_stale_committed_sidecar_is_omitted_not_fed_and_never_hard_fails(
+        preflight, tmp_path, monkeypatch):
     """The integration bug: a sidecar committed days ago but freshly checked out
-    (current mtime) must be judged by its generated_at, not the file clock. Also
-    a sidecar with NO generated_at is treated as stale, never silently fresh."""
+    (current mtime) must be judged by generated_at, not the file clock. Stale /
+    no-generated_at data is OMITTED (not fed as fresh) and, critically, appends
+    NOTHING to `issues` — main() returns exit 1 on any issue and the fallback
+    workflow runs under pipefail, so a fatal stale-issue would hard-fail the whole
+    brief (2026-07 review, blocking #1)."""
     import json
     from datetime import datetime, timezone, timedelta
     data = tmp_path / 'assets' / 'data'
     data.mkdir(parents=True)
     old = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
-    # macro: old generated_at, but the file itself is written now (fresh mtime)
-    (data / 'macro.json').write_text(json.dumps({'generated_at': old, 'vix': None}))
-    # sentiment: NO generated_at at all
-    (data / 'sentiment.json').write_text(json.dumps({'tickers': [], 'sources': []}))
+    # macro: old generated_at, file written now (fresh mtime) → must read as stale
+    (data / 'macro.json').write_text(json.dumps({'generated_at': old, 'vix': {'price': 20}}))
+    # sentiment: NO generated_at at all → unknown age → stale
+    (data / 'sentiment.json').write_text(
+        json.dumps({'tickers': [{'ticker': 'X', 'reddit_mentions_7d': 5}], 'sources': ['reddit']}))
     monkeypatch.setattr(preflight, 'WS', tmp_path)
 
     issues = []
-    preflight.load_macro_and_sentiment('2026-07-24', issues)
+    macro_trim, sentiment_trim = preflight.load_macro_and_sentiment('2026-07-24', issues)
 
-    assert any('macro snapshot stale' in i for i in issues), issues
-    assert any('sentiment snapshot stale' in i and 'unknown-age' in i for i in issues), issues
+    assert macro_trim == {} and sentiment_trim == {}      # omitted, not fed as fresh
+    assert issues == []                                   # non-fatal → brief still runs
+
+
+def test_fresh_sidecar_is_fed_with_real_age(preflight, tmp_path, monkeypatch):
+    import json
+    from datetime import datetime, timezone, timedelta
+    data = tmp_path / 'assets' / 'data'
+    data.mkdir(parents=True)
+    fresh = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    (data / 'macro.json').write_text(json.dumps({'generated_at': fresh, 'vix': {'price': 20}}))
+    (data / 'sentiment.json').write_text(json.dumps({'generated_at': fresh, 'tickers': [], 'sources': []}))
+    monkeypatch.setattr(preflight, 'WS', tmp_path)
+
+    macro_trim, sentiment_trim = preflight.load_macro_and_sentiment('2026-07-24', [])
+    assert macro_trim.get('vix') == {'price': 20, 'change_pct': None, 'source': None}
+    assert 1.5 < macro_trim['age_hours'] < 2.5
+
+
+def test_future_timestamp_beyond_skew_is_stale(preflight):
+    from datetime import datetime, timezone, timedelta
+    future = (datetime.now(timezone.utc) + timedelta(hours=10)).isoformat()
+    age = preflight._payload_age_hours({'generated_at': future})
+    assert age < 0 and preflight._is_stale(age, 36)  # negative age must not read as fresh


### PR DESCRIPTION
CI 审计发现 #5(高 blast radius —— 把 stale 数据当当前喂进真金交易简报)。

## 问题
`load_macro_and_sentiment` / `load_influencer_feed` 用 `path.stat().st_mtime` 算 sidecar 年龄。**`actions/checkout` 会把每个 tracked 文件盖上新的 checkout 时间**,于是 off-host brief-fallback runner 上,一个几天前提交的 macro/sentiment/influencer sidecar 读出来只有几秒新。兜底简报就把**过期的宏观 regime、过期情绪、过期 Trump/Musk 表态**当当前数据喂进去,还标成 fresh —— 除非有人手动看 `as_of`,否则完全无感。

## 改法
生产者本就写了 `generated_at`(risk.json 的新鲜度检查早就在用它)。新增 `_payload_age_hours()` 解析这个戳;三个 sidecar loader 都改用它;每个 stale 闸改成 `age is None or age > cutoff` —— **戳缺失/解析不了 = 判 stale**,因为「证不出年龄」不等于「新鲜」。

这**不会 fail 简报**(stale 仍然跑,只是被标记),只是把「隐藏的过期」变成「可见的过期」。`as_of`/`age_hours` 现在反映真实生成时间。

## 测试
helper(新鲜/过期/缺失/垃圾/Zulu/naive)+ 集成测试:fresh-mtime 但 old-generated_at 的 macro、以及完全没有 generated_at 的 sentiment,都能通过 `load_macro_and_sentiment` 被判 stale。反向变异验证(None-as-fresh 回退、常量年龄 helper 各自变红一个测试)。本地 499 passed / 5 xfailed。

作者不自合,等 codex 复审。
