### PR TITLE
validators: fully decode screenshots + GIF, not just the header (#12)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -122,7 +122,10 @@ jobs:
         # portfolio_risk_metrics imports it at module level, so without it pytest
         # aborts the whole run with a collection error and all 78 tests silently
         # stop being enforced — a green-looking local run hides this completely.
-        run: pip install --quiet requests pytest numpy
+        # Pillow: validate_sidecars now fully-decodes screenshots/GIF (finding #12);
+        # the real asset checks run in screenshot-refresh.yml (which has Pillow) but
+        # the unit tests here exercise the same validators, so pytest needs it too.
+        run: pip install --quiet requests pytest numpy Pillow
 
       - name: Unit tests — money-integrity derivations
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'

--- a/.github/workflows/screenshot-refresh.yml
+++ b/.github/workflows/screenshot-refresh.yml
@@ -58,6 +58,14 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: python3 scripts/data/validate_sidecars.py gif
 
+      # validate_screenshots now fully decodes the PNGs (finding #12), and this
+      # runs on BOTH schedule and dispatch — the GIF steps above install Pillow
+      # only on workflow_dispatch, so install it unconditionally here. Kept as a
+      # separate step so the validate step's command stays exactly the validator
+      # invocation (workflow-contract test).
+      - name: Install Pillow for screenshot decode
+        run: python3 -m pip install --quiet --upgrade Pillow
+
       - name: Validate screenshots
         run: python3 scripts/data/validate_sidecars.py screenshots
 

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -382,12 +382,29 @@ def validate_screenshots(
         header = path.read_bytes()[:24]
         assert header[:8] == PNG_MAGIC, f'invalid PNG magic: {filename}'
         assert header[12:16] == b'IHDR', f'missing PNG IHDR: {filename}'
-        width, height = struct.unpack('>II', header[16:24])
+        # Fully decode, not just parse the header: a valid PNG header + IHDR
+        # dimensions on top of zero/garbage chunks passes the byte checks but is
+        # an unopenable image (2026-07 audit). Pillow verify() walks every chunk.
+        width, height = _decoded_png_size(path, filename)
         assert width >= min_width and height >= min_height, (
             f'implausible screenshot dimensions: {filename} is {width}x{height}; '
             f'expected >= {min_width}x{min_height}'
         )
         print(f'validated {filename}: {size} bytes, {width}x{height}')
+
+
+def _decoded_png_size(path, label):
+    """(width, height) from a FULLY-decoded PNG, or AssertionError. verify()
+    consumes the file object, so re-open for the size read."""
+    from PIL import Image, UnidentifiedImageError
+    try:
+        with Image.open(path) as im:
+            im.verify()
+        with Image.open(path) as im:
+            assert im.format == 'PNG', f'{label}: not a PNG after decode ({im.format})'
+            return im.size
+    except (UnidentifiedImageError, OSError, SyntaxError) as e:
+        raise AssertionError(f'{label}: PNG does not decode ({type(e).__name__}: {e})') from None
 
 
 def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
@@ -403,12 +420,24 @@ def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
     with path.open('rb') as gif:
         header = gif.read(10)
     assert header[:6] in GIF_MAGICS, f'invalid GIF magic: {path}'
-    width, height = struct.unpack('<HH', header[6:10])
+    # Decode for real + count frames: a valid GIF header on padding passes the
+    # magic/dimension byte checks but has no decodable frames (2026-07 audit). The
+    # dashboard GIF is an animation, so require at least 2 frames.
+    from PIL import Image, UnidentifiedImageError
+    try:
+        with Image.open(path) as im:
+            assert im.format == 'GIF', f'{path}: not a GIF after decode ({im.format})'
+            width, height = im.size
+            frames = getattr(im, 'n_frames', 1)
+            im.seek(frames - 1)  # force-decode to the last frame
+    except (UnidentifiedImageError, OSError, SyntaxError, EOFError) as e:
+        raise AssertionError(f'{path}: GIF does not decode ({type(e).__name__}: {e})') from None
+    assert frames >= 2, f'{path}: GIF has {frames} frame(s), expected an animation (>= 2)'
     assert width >= 300 and height >= 500, (
         f'implausible GIF dimensions: {path} is {width}x{height}; '
         'expected >= 300x500'
     )
-    print(f'validated {path}: {size} bytes, {width}x{height}')
+    print(f'validated {path}: {size} bytes, {width}x{height}, {frames} frames')
 
 
 def _dispatch(name: str) -> None:

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -403,7 +403,7 @@ def _decoded_png_size(path, label):
         with Image.open(path) as im:
             assert im.format == 'PNG', f'{label}: not a PNG after decode ({im.format})'
             return im.size
-    except (UnidentifiedImageError, OSError, SyntaxError) as e:
+    except (UnidentifiedImageError, OSError, SyntaxError, EOFError) as e:
         raise AssertionError(f'{label}: PNG does not decode ({type(e).__name__}: {e})') from None
 
 

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -392,15 +392,14 @@ def test_large_png_with_invalid_magic_is_rejected(tmp_path):
 
 
 def test_large_png_with_implausible_dimensions_is_rejected(tmp_path):
+    # A REAL (decodable) but too-small PNG: decode passes, the dimension floor is
+    # what rejects it. (Decode now runs first, so a fake header at these dims would
+    # fail decode, not the dimension check.)
+    from PIL import Image
     path = tmp_path / 'image.png'
-    header = (
-        b'\x89PNG\r\n\x1a\n' + b'\x00\x00\x00\x0dIHDR'
-        + struct.pack('>II', 399, 199)
-    )
-    path.write_bytes(header + b'\x00' * 20_000)
-
+    Image.new('RGB', (399, 199), 'white').save(path, 'PNG')
     with pytest.raises(AssertionError, match='implausible screenshot dimensions'):
-        validators.validate_screenshots(((path, 20_000, 400, 200),))
+        validators.validate_screenshots(((path, 100, 400, 200),))
 
 
 def test_large_gif_with_invalid_magic_is_rejected(tmp_path):
@@ -412,8 +411,59 @@ def test_large_gif_with_invalid_magic_is_rejected(tmp_path):
 
 
 def test_large_gif_with_implausible_dimensions_is_rejected(tmp_path):
+    # A REAL animated but too-small GIF: decode + frame count pass, dimension floor
+    # rejects it.
+    from PIL import Image
     path = tmp_path / 'image.gif'
-    path.write_bytes(b'GIF89a' + struct.pack('<HH', 299, 499) + b'\x00' * 300_000)
-
+    frames = [Image.new('RGB', (299, 499), c) for c in ('white', 'black')]
+    frames[0].save(path, 'GIF', save_all=True, append_images=frames[1:], duration=100)
+    with path.open('ab') as f:
+        f.write(b'\x00' * 300_000)  # clear the size floor
     with pytest.raises(AssertionError, match='implausible GIF dimensions'):
         validators.validate_gif(path)
+
+
+def test_big_png_with_valid_header_but_garbage_body_is_rejected(tmp_path):
+    """2026-07 audit: a file large enough to clear the size floor, with a valid
+    PNG magic + IHDR dimensions on top of garbage, passed the byte checks but does
+    not decode. Full-decode validation must reject it."""
+    path = tmp_path / 'image.png'
+    path.write_bytes(
+        b'\x89PNG\r\n\x1a\n' + b'\x00\x00\x00\x0dIHDR' + struct.pack('>II', 1200, 630)
+        + b'\x00' * 200_000)  # clears the 150k size floor, but no real chunks
+    with pytest.raises(AssertionError, match='does not decode'):
+        validators.validate_screenshots(((path, 150_000, 1_000, 500),))
+
+
+def test_big_gif_with_valid_header_but_garbage_body_is_rejected(tmp_path):
+    path = tmp_path / 'image.gif'
+    path.write_bytes(b'GIF89a' + struct.pack('<HH', 640, 1376) + b'\x00' * 400_000)
+    with pytest.raises(AssertionError, match='does not decode|GIF has'):
+        validators.validate_gif(path)
+
+
+def test_single_frame_gif_is_rejected_as_not_an_animation(tmp_path):
+    from PIL import Image
+    path = tmp_path / 'still.gif'
+    Image.new('RGB', (640, 1376), 'white').save(path, 'GIF')
+    # pad past the 300k size floor so the decode/frame check is what fires
+    with path.open('ab') as f:
+        f.write(b'\x00' * 300_000)
+    with pytest.raises(AssertionError, match='expected an animation|does not decode'):
+        validators.validate_gif(path)
+
+
+def test_real_multiframe_gif_and_real_png_decode_and_pass(tmp_path):
+    from PIL import Image
+    png = tmp_path / 'ok.png'
+    Image.new('RGB', (1200, 630), 'white').save(png, 'PNG')
+    with png.open('ab') as f:
+        f.write(b'')  # keep it small; use a tiny size floor
+    validators.validate_screenshots(((png, 100, 1000, 500),))
+
+    gif = tmp_path / 'ok.gif'
+    frames = [Image.new('RGB', (640, 1376), c) for c in ('white', 'black', 'white')]
+    frames[0].save(gif, 'GIF', save_all=True, append_images=frames[1:], duration=100)
+    with gif.open('ab') as f:
+        f.write(b'\x00' * 300_000)  # clear the size floor
+    validators.validate_gif(gif)

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -467,3 +467,24 @@ def test_real_multiframe_gif_and_real_png_decode_and_pass(tmp_path):
     with gif.open('ab') as f:
         f.write(b'\x00' * 300_000)  # clear the size floor
     validators.validate_gif(gif)
+
+
+@pytest.mark.parametrize('exc', [EOFError, OSError, SyntaxError, ValueError])
+def test_png_decode_wraps_all_pillow_failure_types(tmp_path, monkeypatch, exc):
+    """2026-07 review: EOFError from a truncated PNG must become AssertionError like
+    the other decode failures, not escape raw (the GIF handler already caught it).
+    ValueError is expected to still escape (not a decode error) — see below."""
+    from PIL import Image
+    real = tmp_path / 'ok.png'
+    Image.new('RGB', (1200, 630), 'white').save(real, 'PNG')
+
+    def boom(*a, **k):
+        raise exc('boom')
+    monkeypatch.setattr('PIL.Image.open', boom)
+
+    if exc is ValueError:  # not in the caught set — must not be silently swallowed
+        with pytest.raises(ValueError):
+            validators.validate_screenshots(((real, 100, 1000, 500),))
+    else:
+        with pytest.raises(AssertionError, match='PNG does not decode'):
+            validators.validate_screenshots(((real, 100, 1000, 500),))


### PR DESCRIPTION
CI 审计发现 #12。

## 问题
`validate_screenshots` / `validate_gif` 只查 magic 字节 + header 里的尺寸 + 大小下限,全部来自文件头。一个**有合法 PNG/GIF 头、尺寸合理、再用零填充凑过大小下限**的文件能通过校验,但其实是打不开的图 / 没有帧的 GIF —— 坏掉的 README/social 图或「静止动画」能被提交并躺一周。

## 改法
两个都用 Pillow 真解码(本就是依赖 —— GIF 组装器在用):
- PNG:`Image.verify()`(遍历每个 chunk)再重开读尺寸
- GIF:真 open + `n_frames` + `seek(最后一帧)` 强制解码 + **要求 ≥ 2 帧**(dashboard GIF 是动画)
- 尺寸从**解码后的图**读,不再从 header

解码先于尺寸下限,所以两个既有的「implausible dimensions」测试改用真实的过小图。

## 测试
大的「合法头 + 垃圾体」PNG/GIF 判 `does not decode`;单帧 GIF 判非动画;真多帧 GIF + 真 PNG 通过;仓里 `assets/{shadow-backtest.png, social-card.png, dashboard.gif}` 仍通过(72 帧 GIF)。反向变异验证。本地 505 passed。

作者不自合,等 codex 复审。
