### PR TITLE
brief-fallback: push any commit ahead of origin, not only a dirty index (#4)

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -114,14 +114,17 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "memory: brief-fallback (off-host-llm) $TODAY"
           fi
-          # Push whenever HEAD is ahead of origin/master, NOT only on a dirty index.
+          # Push whenever HEAD is ahead of the remote, NOT only on a dirty index.
           # postflight's maybe_commit already commits here, and its push can FAIL on
           # this ephemeral runner while still returning commit_ok=true; gating the
           # push on a dirty index then leaves that commit unpushed and the runner
           # discards it — green but nothing published (2026-07 audit finding #4).
-          git fetch origin master -q || true
-          if [ -n "$(git rev-list origin/master..HEAD 2>/dev/null)" ]; then
+          # Compare against FETCH_HEAD (always set by the fetch) rather than the
+          # remote-tracking ref origin/master, which `git fetch origin master` only
+          # updates opportunistically.
+          if git fetch origin master -q && \
+             [ -n "$(git rev-list FETCH_HEAD..HEAD 2>/dev/null)" ]; then
             bash scripts/data/safe_push.sh
           else
-            echo "nothing to push — HEAD not ahead of origin/master"
+            echo "nothing to push — HEAD not ahead of origin/master (or fetch failed)"
           fi

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -113,5 +113,15 @@ jobs:
           git add memory/ portfolio.json assets/data/ 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "memory: brief-fallback (off-host-llm) $TODAY"
+          fi
+          # Push whenever HEAD is ahead of origin/master, NOT only on a dirty index.
+          # postflight's maybe_commit already commits here, and its push can FAIL on
+          # this ephemeral runner while still returning commit_ok=true; gating the
+          # push on a dirty index then leaves that commit unpushed and the runner
+          # discards it — green but nothing published (2026-07 audit finding #4).
+          git fetch origin master -q || true
+          if [ -n "$(git rev-list origin/master..HEAD 2>/dev/null)" ]; then
             bash scripts/data/safe_push.sh
+          else
+            echo "nothing to push — HEAD not ahead of origin/master"
           fi

--- a/tests/test_brief_fallback_gate.py
+++ b/tests/test_brief_fallback_gate.py
@@ -89,7 +89,7 @@ def test_fallback_pushes_any_commit_ahead_of_origin_not_only_a_dirty_index():
     workflow push on a dirty index then discards that commit (green, unpublished).
     The commit step must push whenever HEAD is ahead of origin/master."""
     commit_run = _workflow_step_run('Commit + push')
-    assert 'rev-list origin/master..HEAD' in commit_run, (
-        'commit step does not push a commit that is ahead of origin (maybe_commit '
+    assert 'rev-list FETCH_HEAD..HEAD' in commit_run, (
+        'commit step does not push a commit that is ahead of the remote (maybe_commit '
         'push-failure would be discarded)')
     assert 'safe_push.sh' in commit_run, 'commit step no longer pushes via safe_push'

--- a/tests/test_brief_fallback_gate.py
+++ b/tests/test_brief_fallback_gate.py
@@ -81,3 +81,15 @@ def test_fallback_workflow_consults_the_gate_and_does_not_swallow_failure():
     assert all('|| true' not in l for l in invocations), 'postflight failure is being swallowed again'
     # ...but a publishable warn (exit 1) must NOT fail the job; only fail (>=2)/crash does.
     assert '-lt 2' in postflight_run, 'postflight step no longer tolerates a publishable warn (exit 1)'
+
+
+def test_fallback_pushes_any_commit_ahead_of_origin_not_only_a_dirty_index():
+    """2026-07 audit finding #4: postflight's maybe_commit already commits on the
+    ephemeral runner and its push can fail while reporting success; gating the
+    workflow push on a dirty index then discards that commit (green, unpublished).
+    The commit step must push whenever HEAD is ahead of origin/master."""
+    commit_run = _workflow_step_run('Commit + push')
+    assert 'rev-list origin/master..HEAD' in commit_run, (
+        'commit step does not push a commit that is ahead of origin (maybe_commit '
+        'push-failure would be discarded)')
+    assert 'safe_push.sh' in commit_run, 'commit step no longer pushes via safe_push'


### PR DESCRIPTION
CI 审计发现 #4(发布完整性:绿灯但没真发)。

## 问题
brief-fallback 在临时 runner 上,Postflight 步里 `maybe_commit` 已经 commit 了(并用 checkout 的 GITHUB_TOKEN push)。如果那次 push **失败**(safe_push 重试耗尽/瞬时错误),`maybe_commit` 仍返回 `commit_ok=true`,run 保持绿。随后「Commit + push」步发现 index 是干净的(commit 已存在),`if ! git diff --cached --quiet` 直接跳过 safe_push → 那个**未推送的 commit 随 runner 销毁丢失**:简报/plan/决策账本/dashboard 都没到 origin,Actions 却是绿的。

## 改法(workflow 侧,不动共享的 maybe_commit)
共享的 `maybe_commit` 在**常驻的 live host** 上 push 失败是可接受的(commit 留在本地,之后重推)——所以不改它。只改 workflow:commit 之后,只要 **HEAD 领先 origin/master** 就 push(`git fetch origin master` + `git rev-list origin/master..HEAD`)。覆盖两种情况:这里新建的 commit、以及 maybe_commit 建了但 push 失败的 commit。HEAD == origin(正常成功)时 rev-list 为空、不重推(不双推)。既有的 publish-gate 守卫全部不变。

## 测试
钉住「commit 步按 `rev-list origin/master..HEAD` 推送、而非只在 index 脏时推」;既有的 gate / fail-closed 契约测试仍通过。反向变异验证。本地 530 passed。

作者不自合,等 codex 复审。
