### PR TITLE
eod-archive: reject a held holding whose quote is stale (#9)

### DIFF
--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -262,14 +262,16 @@ def validate_eod_archive(
     portfolio_path = Path(portfolio_path)
     snapshot_date = snapshot_date or str(date.today())
     expected = None
+    held = []
     if portfolio_path.is_file():
         portfolio = json.loads(portfolio_path.read_text(encoding='utf-8'))
-        expected = {
-            holding['ticker']
+        held = [
+            holding
             for region in ('us_stocks', 'hk_stocks')
             for holding in portfolio['portfolios'].get(region, {}).get('holdings', [])
             if holding.get('shares', 0) > 0
-        }
+        ]
+        expected = {h['ticker'] for h in held}
         if not expected:
             print(f'EOD archive coverage validation OK: all-cash portfolio, 0 rows for {snapshot_date}')
             return
@@ -321,7 +323,60 @@ def validate_eod_archive(
                 f"invalid EOD {field} for {row['ticker']}: {row[field]!r}")
         assert finite_number(row['pnl_pct']), (
             f"invalid EOD pnl_pct for {row['ticker']}: {row['pnl_pct']!r}")
+
+    # Price freshness: the archive copies portfolio.json's current_price with no
+    # refresh, so a held holding whose price hasn't updated (a broken quote fetch)
+    # gets archived as this week's close (2026-07 audit finding #9). Each holding's
+    # data_source embeds the quote date; a held holding priced more than
+    # PRICE_STALE_DAYS before the snapshot is rejected. Fail-safe: a data_source
+    # whose date can't be parsed is skipped (never a false archive failure), and
+    # the window is generous enough to clear a long holiday weekend.
+    PRICE_STALE_DAYS = 5
+    snap = date.fromisoformat(snapshot_date)
+    stale = []
+    for h in held:
+        qd = _quote_date(h.get('data_source', ''), snap)
+        if qd is not None and (snap - qd).days > PRICE_STALE_DAYS:
+            stale.append(f"{h['ticker']} ({(snap - qd).days}d old: {h.get('data_source','')[:48]!r})")
+    assert not stale, (
+        f'EOD archive price is stale for {snapshot_date} — quote not refreshed for: '
+        + '; '.join(stale))
     print(f'EOD archive coverage validation OK: {len(today_rows)} rows for {snapshot_date}')
+
+
+_MONTHS = {m: i for i, m in enumerate(
+    ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'), start=1)}
+
+
+def _quote_date(data_source, ref):
+    """Best-effort quote date from a free-text data_source, or None if unparseable.
+
+    Handles the two live shapes — `... Jul 23, 2026 20:01 ET` and `Tencent Jul 24
+    16:00 HKT` (no year) — plus `YYYY/MM/DD` / `YYYY-MM-DD`. A missing year is
+    resolved to the most recent `Mon Day` at or before `ref` (so a Jan quote read
+    on a late-Dec snapshot doesn't jump a year forward). None on any failure —
+    callers must treat unparseable as 'skip', never 'stale'."""
+    if not data_source:
+        return None
+    iso = re.search(r'(\d{4})[/-](\d{2})[/-](\d{2})', data_source)
+    if iso:
+        try:
+            return date(int(iso[1]), int(iso[2]), int(iso[3]))
+        except ValueError:
+            return None
+    m = re.search(r'\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})'
+                  r'(?:,\s*(\d{4}))?', data_source)
+    if not m:
+        return None
+    mon, day = _MONTHS[m[1]], int(m[2])
+    try:
+        if m[3]:
+            return date(int(m[3]), mon, day)
+        cand = date(ref.year, mon, day)
+        return cand if cand <= ref else date(ref.year - 1, mon, day)
+    except ValueError:
+        return None
 
 
 def validate_weekly_review(

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -641,3 +641,70 @@ def test_png_decode_wraps_all_pillow_failure_types(tmp_path, monkeypatch, exc):
     else:
         with pytest.raises(AssertionError, match='PNG does not decode'):
             validators.validate_screenshots(((real, 100, 1000, 500),))
+
+
+def _portfolio_with_sources(path, holdings):
+    """holdings: list of (ticker, data_source). Builds a us_stocks portfolio."""
+    return write_json(path, {'portfolios': {
+        'us_stocks': {'holdings': [
+            {'ticker': t, 'shares': 1, 'data_source': ds} for t, ds in holdings]},
+        'hk_stocks': {'holdings': []}}})
+
+
+def test_eod_rejects_a_held_holding_whose_quote_is_stale(tmp_path):
+    """2026-07 audit #9: the archive copies portfolio.json current_price with no
+    refresh, so a holding whose quote fetch broke is archived as this week's close.
+    A held holding priced >5 days before the snapshot must fail, naming it."""
+    snap = '2026-07-24'
+    archive = write_eod(tmp_path / 'eod.csv', snap, ('CRCL', 'NVDA'))
+    portfolio = _portfolio_with_sources(tmp_path / 'pf.json', [
+        ('CRCL', 'Nasdaq API (stocks) Jul 23, 2026 20:01 ET'),   # fresh
+        ('NVDA', 'Eastmoney realtime quote May 7, 2026 09:30 ET'),  # 2.5 months stale
+    ])
+    with pytest.raises(AssertionError, match=r'stale.*NVDA'):
+        validators.validate_eod_archive(archive, portfolio, snapshot_date=snap)
+
+
+def test_eod_accepts_fresh_quotes_including_no_year_hk_format(tmp_path):
+    snap = '2026-07-25'  # Saturday archive after Fri Jul 24 close
+    archive = write_eod(tmp_path / 'eod.csv', snap, ('CRCL', '00100'))
+    portfolio = _portfolio_with_sources(tmp_path / 'pf.json', [
+        ('CRCL', 'Nasdaq API (stocks) Jul 24, 2026 20:01 ET'),
+        ('00100', 'Tencent Jul 24 16:00 HKT'),   # no year — must resolve to snapshot year
+    ])
+    validators.validate_eod_archive(archive, portfolio, snapshot_date=snap)
+
+
+def test_eod_skips_freshness_when_data_source_is_unparseable(tmp_path):
+    """Fail-safe: an unparseable data_source must never fail the archive (a parse
+    miss is not evidence of staleness)."""
+    snap = '2026-07-24'
+    archive = write_eod(tmp_path / 'eod.csv', snap, ('CRCL',))
+    portfolio = _portfolio_with_sources(tmp_path / 'pf.json', [
+        ('CRCL', 'some source with no recognizable date'),
+    ])
+    validators.validate_eod_archive(archive, portfolio, snapshot_date=snap)
+
+
+def test_eod_holiday_weekend_gap_within_window_passes(tmp_path):
+    """A 3-day gap (long weekend) is within PRICE_STALE_DAYS and must pass."""
+    snap = '2026-07-27'  # Monday
+    archive = write_eod(tmp_path / 'eod.csv', snap, ('CRCL',))
+    portfolio = _portfolio_with_sources(tmp_path / 'pf.json', [
+        ('CRCL', 'Nasdaq API (stocks) Jul 24, 2026 20:01 ET'),  # 3 days
+    ])
+    validators.validate_eod_archive(archive, portfolio, snapshot_date=snap)
+
+
+@pytest.mark.parametrize('ds,ref,expected', [
+    ('Nasdaq API Jul 23, 2026 20:01 ET', '2026-07-25', '2026-07-23'),
+    ('Tencent Jul 24 16:00 HKT', '2026-07-25', '2026-07-24'),
+    ('quote 2026-07-17', '2026-07-25', '2026-07-17'),
+    ('Tencent Jan 2 16:00 HKT', '2026-12-30', '2026-01-02'),  # no year, same year
+    ('Tencent Dec 31 16:00 HKT', '2026-01-02', '2025-12-31'),  # no year → prior year
+    ('no date at all', '2026-07-25', None),
+])
+def test_quote_date_parser(ds, ref, expected):
+    from datetime import date
+    got = validators._quote_date(ds, date.fromisoformat(ref))
+    assert got == (date.fromisoformat(expected) if expected else None)


### PR DESCRIPTION
CI 审计发现 #9(历史归档静默记录陈旧价)。

## 问题
EOD 归档 job 把 `portfolio.json` 的 `current_price` 原样抄进周度 CSV,**不刷新**,而 `validate_eod_archive` 只查 `current_price > 0`。所以某个持仓的报价抓取坏了(价格是正数但已过期几天),就会被当作「本周收盘价」归档并通过 —— 一条**永久错误的历史行**,只有日后审计/回测才发现。

## 改法
`validate_eod_archive` 现在按每个持仓的 `data_source` 日期查报价新鲜度(该字段本就带,如 `Nasdaq API ... Jul 23, 2026 20:01 ET` / `Tencent Jul 24 16:00 HKT`)。持仓报价比快照早超过 `PRICE_STALE_DAYS`(5 天,足够覆盖长假周末)则 fail、点名 ticker。`_quote_date` 是容错解析器,处理两种 live 自由文本格式 + ISO,缺年份的解析到快照前最近的 Mon-Day。**fail-safe**:data_source 解析不出日期就跳过,绝不误 fail —— 解析失败不等于过期。

**当前持仓全新鲜**(美股=前收、港股=当日),所以这不会把绿着的周度 job 变红;只在**未来真报价故障**时才触发。覆盖/schema/price>0 检查全不变。

## 测试
2.5 个月过期的持仓按名 fail;新鲜(含无年份 HK 格式)通过;解析不出跳过;3 天长周末间隔通过;解析器对所有 live 格式 + 无年份跨年做了单测;仓里真归档仍通过。反向变异验证。本地 539 passed。

作者不自合,等 codex 复审。
