### PR TITLE
producers: report source health so a total outage fails instead of publishing empty/stale (#6/#7/#8/#10/#11)

### DIFF
--- a/scripts/data/fetch_influencer_feed.py
+++ b/scripts/data/fetch_influencer_feed.py
@@ -99,14 +99,31 @@ def _within_lookback(dt, cutoff):
         return True  # keep if we can't parse the date rather than drop
 
 
+def _source_status(items):
+    return 'success' if items else 'success_empty'
+
+
+def _parse_published(value):
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+    return parsed.replace(tzinfo=parsed.tzinfo or timezone.utc)
+
+
 def fetch_trump(cutoff):
-    """trumpstruth.org RSS — full post text. Returns list of raw items."""
+    """trumpstruth.org RSS — full post text. Returns (items, source status)."""
     out = []
     try:
         r = requests.get('https://trumpstruth.org/feed', headers=HEADERS, timeout=TIMEOUT)
         if r.status_code != 200:
             print(f'  ⚠️ trump feed HTTP {r.status_code}', file=sys.stderr)
-            return out
+            return out, 'failed'
         root = ET.fromstring(r.text)
         for it in root.findall('.//item'):
             title = (it.findtext('title') or '').strip()
@@ -133,7 +150,8 @@ def fetch_trump(cutoff):
             })
     except Exception as e:
         print(f'  ⚠️ trump feed: {e}', file=sys.stderr)
-    return out
+        return out, 'failed'
+    return out, _source_status(out)
 
 
 MUSK_MAX = 8  # second-hand source — cap so SpaceX-IPO rehash doesn't drown Trump
@@ -147,7 +165,9 @@ def fetch_musk():
     """
     out, seen = [], set()
     query = 'Elon Musk (Tesla OR DOGE OR crypto OR stock OR buy OR SpaceX OR xAI)'
-    for it in fetch_google_news(query, hl='en-US', gl='US', limit=20):
+    news, fetch_status = fetch_google_news(
+        query, hl='en-US', gl='US', limit=20, return_status=True)
+    for it in news:
         title = it.get('title', '')
         if not _is_candidate(title) and 'musk' not in title.lower():
             continue
@@ -167,7 +187,9 @@ def fetch_musk():
         })
         if len(out) >= MUSK_MAX:
             break
-    return out
+    if fetch_status == 'failed':
+        return out, 'failed'
+    return out, _source_status(out)
 
 
 # Serenity (@aleabitoreddit) — her X firehose has no free RSS (same Musk dead-end)
@@ -205,7 +227,7 @@ def fetch_serenity(cutoff):
         r = requests.get(SERENITY_FEED, headers=SERENITY_HEADERS, timeout=TIMEOUT)
         if r.status_code != 200:
             print(f'  ⚠️ serenity feed HTTP {r.status_code}', file=sys.stderr)
-            return out
+            return out, 'failed'
         root = ET.fromstring(r.text)
         for it in root.findall('.//item'):
             title = (it.findtext('title') or '').strip()
@@ -233,7 +255,8 @@ def fetch_serenity(cutoff):
             })
     except Exception as e:
         print(f'  ⚠️ serenity feed: {e}', file=sys.stderr)
-    return out
+        return out, 'failed'
+    return out, _source_status(out)
 
 
 def _dedup_sig(text):
@@ -339,11 +362,17 @@ def llm_filter(candidates, held):
 
 
 def main():
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=LOOKBACK_HOURS)
+    generated = datetime.now(timezone.utc)
+    cutoff = generated - timedelta(hours=LOOKBACK_HOURS)
 
-    trump = fetch_trump(cutoff)
-    musk = fetch_musk()
-    serenity = fetch_serenity(cutoff)
+    trump, trump_status = fetch_trump(cutoff)
+    musk, musk_status = fetch_musk()
+    serenity, serenity_status = fetch_serenity(cutoff)
+    source_status = {
+        'trump': trump_status,
+        'musk': musk_status,
+        'serenity': serenity_status,
+    }
     print(f'  raw: trump={len(trump)} musk={len(musk)} serenity={len(serenity)} '
           f'(after keyword pre-filter)')
 
@@ -403,12 +432,21 @@ def main():
     # Serenity is deliberately NOT retained here: she posts publicly so rarely that
     # an empty fetch is her normal state, not an outage — retaining would pin a
     # weeks-old idea on the radar forever. She simply drops off until she posts again.
-    raw_empty = {'Trump': not trump, 'Musk': not musk}
-    for author in ('Trump', 'Musk'):
-        if raw_empty[author]:
-            retained = [it for it in prev_items if it.get('author') == author]
+    author_sources = {'Trump': 'trump', 'Musk': 'musk'}
+    for author, source in author_sources.items():
+        if source_status[source] == 'failed':
+            retained = []
+            for prior in prev_items:
+                if prior.get('author') != author:
+                    continue
+                published = _parse_published(prior.get('published'))
+                if published is None or published < cutoff:
+                    continue
+                item = dict(prior)
+                item['retained_from_previous'] = True
+                retained.append(item)
             if retained:
-                print(f'  ↻ {author} fetch empty — retaining {len(retained)} prior items',
+                print(f'  ↻ {author} fetch failed — retaining {len(retained)} prior items',
                       file=sys.stderr)
                 items.extend(retained)
 
@@ -431,13 +469,14 @@ def main():
                    if it.get('sector_holdings') and not it.get('held') and not it.get('new_ideas')]
 
     out = {
-        'generated_at':  datetime.now(timezone.utc).isoformat(),
+        'generated_at':  generated.isoformat(),
         'lookback_hours': LOOKBACK_HOURS,
         'sources': {
             'trump':    'trumpstruth.org/feed (primary)',
             'musk':     'google-news-rss (proxy)',
             'serenity': 'aleabitoreddit.substack.com/feed (public posts)',
         },
+        'source_status': source_status,
         'llm_filtered':  bool(scored),
         'counts': {
             'total':       len(items),

--- a/scripts/data/fetch_sentiment.py
+++ b/scripts/data/fetch_sentiment.py
@@ -28,6 +28,7 @@ HEADERS = {'User-Agent': UA}
 
 REDDIT_SUBS = ['wallstreetbets', 'stocks', 'investing']
 TIMEOUT = 10
+SOURCE_STATUS = {'reddit': 'failed', 'google_news': 'failed'}
 
 
 def load_tickers():
@@ -56,6 +57,7 @@ def fetch_reddit(ticker, mentions_only=False):
             r = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
             if r.status_code != 200:
                 continue
+            SOURCE_STATUS['reddit'] = 'ok'
             children = r.json().get('data', {}).get('children', [])
             total += len(children)
             if mentions_only:
@@ -75,13 +77,14 @@ def fetch_reddit(ticker, mentions_only=False):
     return total, posts[:6]
 
 
-def fetch_google_news(query, hl='en-US', gl='US', limit=8):
+def fetch_google_news(query, hl='en-US', gl='US', limit=8, return_status=False):
     """Returns up to `limit` recent headlines from Google News RSS."""
     try:
         url = f'https://news.google.com/rss/search?q={quote(query)}&hl={hl}&gl={gl}&ceid={gl}:{hl.split("-")[0]}'
         r = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
         if r.status_code != 200:
-            return []
+            return ([], 'failed') if return_status else []
+        SOURCE_STATUS['google_news'] = 'ok'
         root = ET.fromstring(r.text)
         items = []
         for it in root.findall('.//item')[:limit]:
@@ -95,10 +98,12 @@ def fetch_google_news(query, hl='en-US', gl='US', limit=8):
             if ' - ' in title:
                 title = title.rsplit(' - ', 1)[0]
             items.append({'title': title, 'source': src, 'published': pub})
+        if return_status:
+            return items, ('ok' if items else 'success_empty')
         return items
     except Exception as e:
         print(f'  ⚠️ google-news {query}: {e}', file=sys.stderr)
-        return []
+        return ([], 'failed') if return_status else []
 
 
 def scan_ticker(t):
@@ -134,6 +139,7 @@ def scan_ticker(t):
 
 
 def main():
+    SOURCE_STATUS.update(reddit='failed', google_news='failed')
     tickers = load_tickers()
     print(f'Scanning {len(tickers)} active tickers …')
 
@@ -146,6 +152,7 @@ def main():
     for t in tickers:
         out['tickers'].append(scan_ticker(t))
         time.sleep(0.3)  # global rate-limit safety
+    out['source_status'] = dict(SOURCE_STATUS)
 
     os.makedirs(os.path.dirname(OUT_FILE), exist_ok=True)
     # Atomic write

--- a/scripts/data/gh_action_news_digest.py
+++ b/scripts/data/gh_action_news_digest.py
@@ -53,8 +53,9 @@ def _fetch_finnhub(ticker, since, until, key):
 
 def _fetch_gnews(ticker):
     """Google News RSS fallback. Title-only; no summary."""
-    items = fetch_google_news(f'{ticker} stock', hl='en-US', gl='US', limit=5)
-    return [
+    items, status = fetch_google_news(
+        f'{ticker} stock', hl='en-US', gl='US', limit=5, return_status=True)
+    news = [
         {
             'headline': it.get('title', '')[:200],
             'summary':  '',  # GNews RSS doesn't carry body
@@ -64,6 +65,7 @@ def _fetch_gnews(ticker):
         }
         for it in items
     ]
+    return news, status
 
 
 def fetch_news(tickers, since_days=2):
@@ -72,19 +74,52 @@ def fetch_news(tickers, since_days=2):
     since = (today - timedelta(days=since_days)).isoformat()
     until = today.isoformat()
     out = {}
+    source_status = {}
     for t in tickers:
         items = None
+        statuses = {
+            'finnhub': 'not_configured' if not finnhub_key else 'not_attempted',
+            'google_news': 'not_attempted',
+        }
         if finnhub_key:
             items = _fetch_finnhub(t, since, until, finnhub_key)
+            statuses['finnhub'] = (
+                'failed' if items is None
+                else ('success' if items else 'success_empty')
+            )
         # Fall back to GNews if Finnhub absent, errored, or returned empty list
         if not items:
             why = 'no FINNHUB_KEY' if not finnhub_key else ('error' if items is None else 'empty')
-            gn = _fetch_gnews(t)
+            gn, gn_status = _fetch_gnews(t)
+            statuses['google_news'] = (
+                'success' if gn_status == 'ok' else gn_status)
             print(f'  {t}: 0 finnhub ({why}) → {len(gn)} gnews')
             out[t] = gn
         else:
             print(f'  {t}: {len(items)} finnhub')
             out[t] = items
+        source_status[t] = statuses
+    return out, source_status
+
+
+def _write_artifact(tickers, raw, source_status, *, digest='', no_material_news=False):
+    source_per_ticker = {
+        ticker: (items[0]['origin'] if items else 'none')
+        for ticker, items in raw.items()
+    }
+    out = {
+        'generated_at': datetime.now().isoformat(),
+        'lookback_hours': 48,
+        'tickers': tickers,
+        'digest_markdown': digest.strip(),
+        'raw_news_counts': {ticker: len(items) for ticker, items in raw.items()},
+        'news_source_per_ticker': source_per_ticker,
+        'source_status': source_status,
+        'no_material_news': no_material_news,
+    }
+    os.makedirs('assets/data', exist_ok=True)
+    with open('assets/data/us_news_digest.json', 'w') as handle:
+        json.dump(out, handle, ensure_ascii=False, indent=2)
     return out
 
 
@@ -93,10 +128,19 @@ def main():
     tickers = [h['ticker'] for h in pf['portfolios']['us_stocks']['holdings']
                if h.get('shares', 0) > 0]
 
-    raw = fetch_news(tickers, since_days=2)
+    raw, source_status = fetch_news(tickers, since_days=2)
     if not any(raw.values()):
-        print('all empty news — nothing to digest', file=sys.stderr)
-        return
+        successful_empty = any(
+            status == 'success_empty'
+            for ticker_status in source_status.values()
+            for status in ticker_status.values()
+        )
+        if tickers and not successful_empty:
+            raise RuntimeError('news: all sources failed')
+        _write_artifact(
+            tickers, raw, source_status, no_material_news=True)
+        print('all sources returned no material news — wrote explicit empty digest')
+        return 0
 
     system = "You are Rick, kcn's stock analyst. Distill US holding news into actionable bullets."
 
@@ -124,23 +168,9 @@ def main():
     # News digest: short output but enable thinking helps prioritize signal vs noise
     digest = chat(system=system, user=user, max_tokens=32000, temperature=0.5)
 
-    # Per-ticker provenance so dashboard can show "fallback used"
-    source_per_ticker = {
-        t: (items[0]['origin'] if items else 'none')
-        for t, items in raw.items()
-    }
-    out = {
-        'generated_at': datetime.now().isoformat(),
-        'lookback_hours': 48,
-        'tickers': tickers,
-        'digest_markdown': digest.strip(),
-        'raw_news_counts': {t: len(v) for t, v in raw.items()},
-        'news_source_per_ticker': source_per_ticker,
-    }
-    os.makedirs('assets/data', exist_ok=True)
-    with open('assets/data/us_news_digest.json', 'w') as f:
-        json.dump(out, f, ensure_ascii=False, indent=2)
+    _write_artifact(tickers, raw, source_status, digest=digest)
     print(f'  digest size: {len(digest)} chars')
+    return 0
 
 
 if __name__ == '__main__':

--- a/scripts/data/gh_action_weekly_review.py
+++ b/scripts/data/gh_action_weekly_review.py
@@ -46,7 +46,7 @@ def _snapshot_nav(snapshot, fx_rate):
             and not isinstance(fx_rate, bool)
             and math.isfinite(fx_rate)
             and fx_rate > 0):
-        raise ValueError('same-day plan FX rate missing or invalid')
+        raise ValueError('plan FX rate missing or invalid')
     portfolios = snapshot.get('portfolios')
     if not isinstance(portfolios, dict):
         raise ValueError('portfolios missing')
@@ -75,14 +75,30 @@ def _snapshot_nav(snapshot, fx_rate):
     }
 
 
+def _nearest_plan_fx(snapshot_date, plan_fx):
+    if snapshot_date in plan_fx:
+        return plan_fx[snapshot_date]
+    if not plan_fx:
+        return None
+    target = date.fromisoformat(snapshot_date)
+    _, fx_rate = min(
+        ((date.fromisoformat(plan_date), fx_rate)
+         for plan_date, fx_rate in plan_fx.items()),
+        key=lambda item: (abs((item[0] - target).days), item[0]),
+    )
+    return fx_rate
+
+
 def aggregate_week(today=None):
     today = today or date.today()
     iso_year, iso_week, _ = today.isocalendar()
     week_id = f"{iso_year}-W{iso_week:02d}"
     start = today - timedelta(days=7)
+    boundary = start - timedelta(days=1)
     input_errors = []
 
     plans = []
+    plan_fx = {}
     for f in sorted(glob.glob('memory/*-plan.json')):
         d_str = os.path.basename(f).split('-plan.json')[0]
         try:
@@ -90,10 +106,17 @@ def aggregate_week(today=None):
         except ValueError:
             input_errors.append(f'plan {f}: invalid date in filename')
             continue
-        if d >= start:
+        if boundary <= d <= today:
             plan = _load_json(f, 'plan', input_errors)
             if plan is not None:
-                plans.append({'date': d_str, 'data': plan})
+                fx_rate = plan.get('fx_rate_usdhkd')
+                if (isinstance(fx_rate, (int, float))
+                        and not isinstance(fx_rate, bool)
+                        and math.isfinite(fx_rate)
+                        and fx_rate > 0):
+                    plan_fx[d_str] = fx_rate
+                if d >= start:
+                    plans.append({'date': d_str, 'data': plan})
 
     decisions = decision_v2.load_decisions()
     decision_episodes = [r for r in decision_v2.episode_representatives(decisions, 't1')
@@ -108,7 +131,7 @@ def aggregate_week(today=None):
         except ValueError:
             input_errors.append(f'snapshot {f}: invalid date in filename')
             continue
-        if d >= start - timedelta(days=1):
+        if boundary <= d <= today:
             snapshot = _load_json(f, 'snapshot', input_errors)
             if snapshot is not None:
                 snapshots.append(snapshot)
@@ -120,7 +143,6 @@ def aggregate_week(today=None):
     else:
         input_errors.append('risk assets/data/risk.json: missing')
 
-    plan_fx = {}
     plan_decisions = 0
     valid_plan_days = 0
     for plan in plans:
@@ -132,17 +154,11 @@ def aggregate_week(today=None):
             continue
         valid_plan_days += 1
         plan_decisions += len(decisions_for_day)
-        fx_rate = data.get('fx_rate_usdhkd')
-        if (isinstance(fx_rate, (int, float))
-                and not isinstance(fx_rate, bool)
-                and math.isfinite(fx_rate)
-                and fx_rate > 0):
-            plan_fx[plan['date']] = fx_rate
 
     nav_points = []
     for d_str, snapshot in snapshot_records:
         try:
-            nav = _snapshot_nav(snapshot, plan_fx.get(d_str))
+            nav = _snapshot_nav(snapshot, _nearest_plan_fx(d_str, plan_fx))
         except ValueError as exc:
             input_errors.append(f'snapshot memory/snapshots/{d_str}.json: {exc}')
             continue

--- a/scripts/data/gh_action_weekly_review.py
+++ b/scripts/data/gh_action_weekly_review.py
@@ -10,6 +10,7 @@ Env: MINIMAX_API_KEY required; XIAOMI_API_KEY optional fallback
 """
 import glob
 import json
+import math
 import os
 import sys
 from datetime import date, timedelta
@@ -20,52 +21,184 @@ from xiaomi_llm import chat
 import decision_v2
 
 
-def aggregate_week():
-    today = date.today()
+def _load_json(path, kind, errors):
+    try:
+        with open(path, encoding='utf-8') as handle:
+            value = json.load(handle)
+    except Exception as exc:
+        errors.append(f'{kind} {path}: {type(exc).__name__}')
+        return None
+    if not isinstance(value, dict):
+        errors.append(f'{kind} {path}: top-level JSON must be an object')
+        return None
+    return value
+
+
+def _finite_nonnegative(value):
+    return (isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value >= 0)
+
+
+def _snapshot_nav(snapshot, fx_rate):
+    if not (isinstance(fx_rate, (int, float))
+            and not isinstance(fx_rate, bool)
+            and math.isfinite(fx_rate)
+            and fx_rate > 0):
+        raise ValueError('same-day plan FX rate missing or invalid')
+    portfolios = snapshot.get('portfolios')
+    if not isinstance(portfolios, dict):
+        raise ValueError('portfolios missing')
+    us = portfolios.get('us_stocks')
+    hk = portfolios.get('hk_stocks')
+    if not isinstance(us, dict) or not isinstance(hk, dict):
+        raise ValueError('US/HK portfolio books missing')
+    values = {
+        'us_value_usd': us.get('total_current_value'),
+        'us_cash_usd': us.get('cash_usd'),
+        'hk_value_hkd': hk.get('total_current_value'),
+        'hk_cash_hkd': hk.get('cash_hkd'),
+    }
+    invalid = [name for name, value in values.items()
+               if not _finite_nonnegative(value)]
+    if invalid:
+        raise ValueError(f'invalid NAV fields: {", ".join(invalid)}')
+    return {
+        **values,
+        'fx_rate_usdhkd': fx_rate,
+        'total_nav_usd': (
+            values['us_value_usd']
+            + values['us_cash_usd']
+            + (values['hk_value_hkd'] + values['hk_cash_hkd']) / fx_rate
+        ),
+    }
+
+
+def aggregate_week(today=None):
+    today = today or date.today()
     iso_year, iso_week, _ = today.isocalendar()
     week_id = f"{iso_year}-W{iso_week:02d}"
     start = today - timedelta(days=7)
+    input_errors = []
 
     plans = []
     for f in sorted(glob.glob('memory/*-plan.json')):
         d_str = os.path.basename(f).split('-plan.json')[0]
         try:
             d = date.fromisoformat(d_str)
-            if d >= start:
-                plans.append({'date': d_str, 'data': json.loads(open(f).read())})
-        except Exception:
-            pass
+        except ValueError:
+            input_errors.append(f'plan {f}: invalid date in filename')
+            continue
+        if d >= start:
+            plan = _load_json(f, 'plan', input_errors)
+            if plan is not None:
+                plans.append({'date': d_str, 'data': plan})
 
-    decision_episodes = [r for r in decision_v2.episode_representatives(decision_v2.load_decisions(), 't1')
+    decisions = decision_v2.load_decisions()
+    decision_episodes = [r for r in decision_v2.episode_representatives(decisions, 't1')
                          if r.get('plan_date', '') >= start.isoformat()]
 
     snapshots = []
+    snapshot_records = []
     for f in sorted(glob.glob('memory/snapshots/*.json')):
         d_str = os.path.basename(f).split('.json')[0]
         try:
             d = date.fromisoformat(d_str)
-            if d >= start - timedelta(days=1):
-                snapshots.append(json.loads(open(f).read()))
-        except Exception:
-            pass
+        except ValueError:
+            input_errors.append(f'snapshot {f}: invalid date in filename')
+            continue
+        if d >= start - timedelta(days=1):
+            snapshot = _load_json(f, 'snapshot', input_errors)
+            if snapshot is not None:
+                snapshots.append(snapshot)
+                snapshot_records.append((d_str, snapshot))
 
     risk = None
     if os.path.exists('assets/data/risk.json'):
-        risk = json.loads(open('assets/data/risk.json').read())
+        risk = _load_json('assets/data/risk.json', 'risk', input_errors)
+    else:
+        input_errors.append('risk assets/data/risk.json: missing')
 
+    plan_fx = {}
+    plan_decisions = 0
+    valid_plan_days = 0
+    for plan in plans:
+        data = plan['data']
+        decisions_for_day = data.get('decisions')
+        if not isinstance(decisions_for_day, list):
+            input_errors.append(
+                f"plan memory/{plan['date']}-plan.json: decisions must be a list")
+            continue
+        valid_plan_days += 1
+        plan_decisions += len(decisions_for_day)
+        fx_rate = data.get('fx_rate_usdhkd')
+        if (isinstance(fx_rate, (int, float))
+                and not isinstance(fx_rate, bool)
+                and math.isfinite(fx_rate)
+                and fx_rate > 0):
+            plan_fx[plan['date']] = fx_rate
+
+    nav_points = []
+    for d_str, snapshot in snapshot_records:
+        try:
+            nav = _snapshot_nav(snapshot, plan_fx.get(d_str))
+        except ValueError as exc:
+            input_errors.append(f'snapshot memory/snapshots/{d_str}.json: {exc}')
+            continue
+        nav_points.append({'date': d_str, **nav})
+
+    bundle_evidence = {
+        'plan_days': valid_plan_days,
+        'plan_decisions': plan_decisions,
+        'decision_episodes': len(decision_episodes),
+        'nav_points': nav_points[-7:],
+    }
     return {
         'week': week_id,
         'window': f'{start.isoformat()} -> {today.isoformat()}',
+        # Keep compact, deterministic evidence before bulky raw inputs: main()
+        # truncates the serialized bundle at 40k characters for the LLM prompt.
+        'bundle_evidence': bundle_evidence,
         'plans': plans,
         'decision_episodes': decision_episodes,
-        'decision_metrics': decision_v2.compute_metrics(decision_v2.load_decisions()),
+        'decision_metrics': decision_v2.compute_metrics(decisions),
         'snapshots': snapshots[-7:],
         'current_risk': risk,
+        'input_warnings': input_errors,
     }
+
+
+def validate_bundle(bundle):
+    evidence = bundle.get('bundle_evidence')
+    missing = []
+    if not isinstance(evidence, dict) or evidence.get('plan_days', 0) < 1:
+        missing.append('weekly plans with decision counts')
+    if not isinstance(bundle.get('decision_episodes'), list):
+        missing.append('decision episode count')
+    if not isinstance(bundle.get('decision_metrics'), dict):
+        missing.append('decision metrics')
+    nav_points = evidence.get('nav_points', []) if isinstance(evidence, dict) else []
+    dated_nav = (
+        [point for point in nav_points
+         if isinstance(point, dict) and isinstance(point.get('date'), str)]
+        if isinstance(nav_points, list) else []
+    )
+    if len(dated_nav) < 2 or dated_nav[0]['date'] == dated_nav[-1]['date']:
+        missing.append('start/end NAV from two dated snapshots')
+    if not isinstance(bundle.get('current_risk'), dict) or not bundle['current_risk']:
+        missing.append('current risk snapshot')
+    if missing:
+        warnings = bundle.get('input_warnings')
+        detail = f"; input errors: {'; '.join(warnings)}" if warnings else ''
+        raise RuntimeError(
+            f"weekly bundle incomplete: missing {', '.join(missing)}{detail}")
+    return evidence
 
 
 def main():
     bundle = aggregate_week()
+    validate_bundle(bundle)
     week_id = bundle['week']
 
     system = "You are Rick, kcn's HK+US stock analyst. Write a weekly portfolio review."

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -274,13 +274,34 @@ def validate_news_digest(
     tickers = data.get('tickers')
     counts = data.get('raw_news_counts')
     digest = data.get('digest_markdown')
-    assert isinstance(tickers, list) and tickers, 'tickers missing or empty'
+    assert isinstance(tickers, list), 'tickers must be a list'
     assert isinstance(counts, dict), 'raw_news_counts must be an object'
     invalid_counts = [key for key, value in counts.items()
                       if not isinstance(value, int) or isinstance(value, bool)]
     assert not invalid_counts, (
         f'raw_news_counts values must be integers: {invalid_counts}')
     total_news = sum(counts.values())
+    if data.get('no_material_news') is True:
+        assert total_news == 0, 'no_material_news digest contains source news'
+        assert isinstance(digest, str) and not digest.strip(), (
+            'no_material_news digest must not fabricate a narrative')
+        if tickers:
+            source_status = data.get('source_status')
+            assert isinstance(source_status, dict), (
+                'no_material_news source_status must be an object')
+            statuses = [
+                status
+                for per_ticker in source_status.values()
+                if isinstance(per_ticker, dict)
+                for status in per_ticker.values()
+            ]
+            assert 'success_empty' in statuses, (
+                'no_material_news has no successful empty source')
+        print(f'digest validation OK: explicit no-material-news artifact; '
+              f'age={age.total_seconds() / 3600:.2f}h')
+        return
+
+    assert tickers, 'tickers missing or empty'
     assert total_news > 0, 'no source news in generated digest'
     assert isinstance(digest, str) and len(digest.strip()) >= 100, (
         'LLM digest empty or implausibly short')

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -51,23 +51,25 @@ def validate_macro(path: Path | str, *, now: datetime | None = None) -> None:
 
     quote_fields = ('vix', 'treasury_10y', 'dxy', 'hsi', 'hstech', 'spx', 'nasdaq')
     quote_sources = ('stooq', 'tencent', 'yahoo')
-    successful = [
+    market_quotes = [
         field for field in quote_fields
         if isinstance(data.get(field), dict)
         and finite_number(data[field].get('price'))
         and data[field]['price'] > 0
         and data[field].get('source') in quote_sources
     ]
+    supplemental = []
     fear_greed = data.get('fear_greed')
     if isinstance(fear_greed, dict) and finite_number(fear_greed.get('score')):
-        successful.append('fear_greed')
+        supplemental.append('fear_greed')
     fed_press = data.get('fed_press')
     if (isinstance(fed_press, list)
             and any(isinstance(item, dict) and str(item.get('title', '')).strip()
                     for item in fed_press)):
-        successful.append('fed_press')
+        supplemental.append('fed_press')
 
-    assert successful, 'snapshot has zero successfully populated fields'
+    assert market_quotes, 'snapshot has zero successful market quotes'
+    successful = market_quotes + supplemental
     print(f'macro coverage validation OK: {", ".join(successful)}; '
           f'age={age.total_seconds() / 3600:.2f}h')
 

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -114,6 +114,7 @@ def validate_sentiment(
     tickers = data.get('tickers')
     assert isinstance(tickers, list), 'tickers must be a list'
     scanned = set()
+    result_count = 0
     for index, row in enumerate(tickers):
         assert isinstance(row, dict), f'ticker result {index} is not an object'
         ticker = row.get('ticker')
@@ -125,16 +126,23 @@ def validate_sentiment(
         mentions = row.get('reddit_mentions_7d')
         assert (isinstance(mentions, int) and not isinstance(mentions, bool)
                 and mentions >= 0), f'{ticker} has invalid reddit mention count'
+        result_count += mentions
         result_fields = ('reddit_posts', 'google_news_en', 'google_news_zh')
         for field in result_fields:
             results = row.get(field)
             assert isinstance(results, list), f'{ticker} {field} must be a list'
             assert all(isinstance(item, dict) for item in results), (
                 f'{ticker} {field} contains a malformed item')
+            result_count += len(results)
         scanned.add(ticker)
 
     missing = sorted(expected - scanned)
     assert not missing, f'sentiment snapshot missing active tickers: {", ".join(missing)}'
+    source_status = data.get('source_status')
+    if scanned and result_count == 0 and source_status is not None:
+        healthy = (isinstance(source_status, dict)
+                   and any(status == 'ok' for status in source_status.values()))
+        assert healthy, 'sentiment: all sources failed'
     print(f'sentiment structural validation OK: {len(scanned)} tickers (zero results allowed)')
 
 

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -10,6 +10,7 @@ import re
 import struct
 import sys
 from datetime import date, datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 
@@ -164,9 +165,10 @@ def validate_influencer(path: Path | str) -> None:
     generated_at = data.get('generated_at')
     assert isinstance(generated_at, str), 'generated_at missing'
     try:
-        datetime.fromisoformat(generated_at.replace('Z', '+00:00'))
+        generated = datetime.fromisoformat(generated_at.replace('Z', '+00:00'))
     except ValueError:
         raise AssertionError('generated_at is not a valid ISO timestamp') from None
+    generated = generated.replace(tzinfo=generated.tzinfo or timezone.utc)
 
     items = data.get('items')
     assert isinstance(items, list), 'items must be a list'
@@ -182,6 +184,29 @@ def validate_influencer(path: Path | str) -> None:
                     and not isinstance(relevance, bool)
                     and math.isfinite(relevance))), (
             f'item {index} has invalid relevance')
+        if item.get('retained_from_previous'):
+            lookback_hours = data.get('lookback_hours')
+            assert (isinstance(lookback_hours, (int, float))
+                    and not isinstance(lookback_hours, bool)
+                    and math.isfinite(lookback_hours)
+                    and lookback_hours > 0), 'lookback_hours missing or invalid'
+            published = item.get('published')
+            assert isinstance(published, str) and published.strip(), (
+                f'retained item {index} missing published timestamp')
+            try:
+                try:
+                    published_at = datetime.fromisoformat(
+                        published.replace('Z', '+00:00'))
+                except ValueError:
+                    published_at = parsedate_to_datetime(published)
+            except (TypeError, ValueError):
+                raise AssertionError(
+                    f'retained item {index} has invalid published timestamp') from None
+            published_at = published_at.replace(
+                tzinfo=published_at.tzinfo or timezone.utc)
+            age = generated.astimezone(timezone.utc) - published_at.astimezone(timezone.utc)
+            assert age <= timedelta(hours=lookback_hours), (
+                f'retained item {index} exceeds declared lookback window')
 
     sources = data.get('sources')
     assert isinstance(sources, dict) and sources, 'sources missing or empty'
@@ -189,6 +214,16 @@ def validate_influencer(path: Path | str) -> None:
                and isinstance(source, str) and source.strip()
                for name, source in sources.items()), (
         'sources must map non-empty names to non-empty descriptions')
+    source_status = data.get('source_status')
+    if source_status is not None:
+        allowed_statuses = {'success', 'success_empty', 'failed'}
+        assert isinstance(source_status, dict) and source_status, (
+            'source_status must be a non-empty object')
+        assert all(status in allowed_statuses for status in source_status.values()), (
+            'source_status contains an invalid status')
+        if not items:
+            assert any(status != 'failed' for status in source_status.values()), (
+                'influencer: all sources failed')
 
     counts = data.get('counts')
     assert isinstance(counts, dict), 'counts missing'

--- a/tests/test_producer_source_status.py
+++ b/tests/test_producer_source_status.py
@@ -8,6 +8,7 @@ import pytest
 
 from scripts.data import fetch_influencer_feed
 from scripts.data import fetch_sentiment
+from scripts.data import gh_action_news_digest
 from scripts.data import validate_sidecars
 
 
@@ -136,3 +137,59 @@ def test_influencer_retains_only_fresh_items_with_original_timestamp(
     ]
     assert payload['items'][0]['retained_from_previous'] is True
     validate_sidecars.validate_influencer(output)
+
+
+def _news_portfolio(path):
+    path.write_text(json.dumps({
+        'portfolios': {
+            'us_stocks': {'holdings': [{'ticker': 'AAPL', 'shares': 1}]},
+        },
+    }), encoding='utf-8')
+
+
+def test_news_producer_writes_explicit_quiet_artifact(tmp_path, monkeypatch):
+    _news_portfolio(tmp_path / 'portfolio.json')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        gh_action_news_digest, 'fetch_news',
+        lambda _tickers, since_days=2: (
+            {'AAPL': []},
+            {'AAPL': {
+                'finnhub': 'failed',
+                'google_news': 'success_empty',
+            }},
+        ))
+    monkeypatch.setattr(
+        gh_action_news_digest, 'chat',
+        lambda **kwargs: pytest.fail('quiet news run must not call the LLM'))
+
+    gh_action_news_digest.main()
+
+    output = tmp_path / 'assets/data/us_news_digest.json'
+    payload = json.loads(output.read_text(encoding='utf-8'))
+    assert payload['no_material_news'] is True
+    assert payload['digest_markdown'] == ''
+    validate_sidecars.validate_news_digest(
+        output,
+        now=datetime.fromisoformat(payload['generated_at']).replace(
+            tzinfo=timezone.utc) + timedelta(hours=1))
+
+
+def test_news_producer_total_source_outage_fails_without_writing(
+        tmp_path, monkeypatch):
+    _news_portfolio(tmp_path / 'portfolio.json')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        gh_action_news_digest, 'fetch_news',
+        lambda _tickers, since_days=2: (
+            {'AAPL': []},
+            {'AAPL': {
+                'finnhub': 'failed',
+                'google_news': 'failed',
+            }},
+        ))
+
+    with pytest.raises(RuntimeError, match='news: all sources failed'):
+        gh_action_news_digest.main()
+
+    assert not (tmp_path / 'assets/data/us_news_digest.json').exists()

--- a/tests/test_producer_source_status.py
+++ b/tests/test_producer_source_status.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from scripts.data import fetch_influencer_feed
 from scripts.data import fetch_sentiment
 from scripts.data import validate_sidecars
 
@@ -67,3 +69,70 @@ def test_sentiment_producer_marks_total_http_outage_failed(
     with pytest.raises(AssertionError, match='sentiment: all sources failed'):
         validate_sidecars.validate_sentiment(
             output, _portfolio(tmp_path / 'portfolio.json'))
+
+
+def _run_influencer(tmp_path, monkeypatch, statuses, previous=None):
+    output = tmp_path / 'influencer.json'
+    if previous is not None:
+        output.write_text(json.dumps(previous), encoding='utf-8')
+    monkeypatch.setattr(fetch_influencer_feed, 'OUT_FILE', str(output))
+    monkeypatch.setattr(
+        fetch_influencer_feed, 'fetch_trump',
+        lambda _cutoff: ([], statuses['trump']))
+    monkeypatch.setattr(
+        fetch_influencer_feed, 'fetch_musk',
+        lambda: ([], statuses['musk']))
+    monkeypatch.setattr(
+        fetch_influencer_feed, 'fetch_serenity',
+        lambda _cutoff: ([], statuses['serenity']))
+    monkeypatch.setattr(fetch_influencer_feed, 'load_holdings', lambda: [])
+    monkeypatch.setattr(
+        fetch_influencer_feed, 'llm_filter',
+        lambda _candidates, _held: {})
+    fetch_influencer_feed.main()
+    return output, json.loads(output.read_text(encoding='utf-8'))
+
+
+def test_influencer_producer_quiet_success_empty_passes(tmp_path, monkeypatch):
+    output, payload = _run_influencer(tmp_path, monkeypatch, {
+        'trump': 'success_empty',
+        'musk': 'success_empty',
+        'serenity': 'failed',
+    })
+
+    assert payload['items'] == []
+    validate_sidecars.validate_influencer(output)
+
+
+def test_influencer_producer_total_outage_is_rejected(tmp_path, monkeypatch):
+    output, payload = _run_influencer(tmp_path, monkeypatch, {
+        'trump': 'failed',
+        'musk': 'failed',
+        'serenity': 'failed',
+    })
+
+    assert payload['items'] == []
+    with pytest.raises(AssertionError, match='influencer: all sources failed'):
+        validate_sidecars.validate_influencer(output)
+
+
+def test_influencer_retains_only_fresh_items_with_original_timestamp(
+        tmp_path, monkeypatch):
+    fresh = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    stale = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+    previous = {
+        'items': [
+            {'author': 'Trump', 'text': 'fresh statement', 'published': fresh},
+            {'author': 'Musk', 'text': 'stale statement', 'published': stale},
+        ],
+    }
+    output, payload = _run_influencer(
+        tmp_path, monkeypatch,
+        {'trump': 'failed', 'musk': 'failed', 'serenity': 'failed'},
+        previous=previous)
+
+    assert [(item['text'], item['published']) for item in payload['items']] == [
+        ('fresh statement', fresh),
+    ]
+    assert payload['items'][0]['retained_from_previous'] is True
+    validate_sidecars.validate_influencer(output)

--- a/tests/test_producer_source_status.py
+++ b/tests/test_producer_source_status.py
@@ -1,0 +1,69 @@
+"""Focused producer tests for quiet runs versus genuine source outages."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.data import fetch_sentiment
+from scripts.data import validate_sidecars
+
+
+class _Empty200:
+    status_code = 200
+    text = '<rss><channel></channel></rss>'
+
+    @staticmethod
+    def json():
+        return {'data': {'children': []}}
+
+
+def _portfolio(path):
+    path.write_text(json.dumps({
+        'portfolios': {
+            'us_stocks': {'holdings': [{'ticker': 'AAPL', 'shares': 1}]},
+            'hk_stocks': {'holdings': []},
+        },
+    }), encoding='utf-8')
+    return path
+
+
+def _run_sentiment(tmp_path, monkeypatch, get):
+    output = tmp_path / 'sentiment.json'
+    monkeypatch.setattr(fetch_sentiment, 'OUT_FILE', str(output))
+    monkeypatch.setattr(fetch_sentiment, 'load_tickers', lambda: [{
+        'ticker': 'AAPL', 'name': 'Apple', 'region': 'us_stocks',
+    }])
+    monkeypatch.setattr(fetch_sentiment.requests, 'get', get)
+    monkeypatch.setattr(fetch_sentiment.time, 'sleep', lambda _seconds: None)
+    fetch_sentiment.main()
+    return output, json.loads(output.read_text(encoding='utf-8'))
+
+
+def test_sentiment_producer_marks_successful_empty_http_sources_ok(
+        tmp_path, monkeypatch):
+    output, payload = _run_sentiment(
+        tmp_path, monkeypatch, lambda *args, **kwargs: _Empty200())
+
+    assert payload['source_status'] == {
+        'reddit': 'ok',
+        'google_news': 'ok',
+    }
+    validate_sidecars.validate_sentiment(
+        output, _portfolio(tmp_path / 'portfolio.json'))
+
+
+def test_sentiment_producer_marks_total_http_outage_failed(
+        tmp_path, monkeypatch):
+    def fail(*args, **kwargs):
+        raise RuntimeError('network unavailable')
+
+    output, payload = _run_sentiment(tmp_path, monkeypatch, fail)
+
+    assert payload['source_status'] == {
+        'reddit': 'failed',
+        'google_news': 'failed',
+    }
+    with pytest.raises(AssertionError, match='sentiment: all sources failed'):
+        validate_sidecars.validate_sentiment(
+            output, _portfolio(tmp_path / 'portfolio.json'))

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -238,6 +238,25 @@ def test_json_artifacts_fail_clearly(
 
 def test_sentiment_quiet_day_with_zero_results_passes(tmp_path):
     portfolio = write_portfolio(tmp_path / 'portfolio.json', ('AAPL',))
+    payload = sentiment_payload(('AAPL',))
+    payload['source_status'] = {'reddit': 'ok', 'google_news': 'failed'}
+    snapshot = write_json(tmp_path / 'sentiment.json', payload)
+
+    validators.validate_sentiment(snapshot, portfolio)
+
+
+def test_sentiment_all_source_outage_with_zero_results_fails(tmp_path):
+    portfolio = write_portfolio(tmp_path / 'portfolio.json', ('AAPL',))
+    payload = sentiment_payload(('AAPL',))
+    payload['source_status'] = {'reddit': 'failed', 'google_news': 'failed'}
+    snapshot = write_json(tmp_path / 'sentiment.json', payload)
+
+    with pytest.raises(AssertionError, match='sentiment: all sources failed'):
+        validators.validate_sentiment(snapshot, portfolio)
+
+
+def test_sentiment_legacy_snapshot_without_source_status_still_passes(tmp_path):
+    portfolio = write_portfolio(tmp_path / 'portfolio.json', ('AAPL',))
     snapshot = write_json(tmp_path / 'sentiment.json', sentiment_payload(('AAPL',)))
 
     validators.validate_sentiment(snapshot, portfolio)

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -341,7 +341,21 @@ def test_macro_quote_failure_markers_do_not_count_as_coverage(tmp_path, quote):
 
     with pytest.raises(
             AssertionError,
-            match='snapshot has zero successfully populated fields'):
+            match='snapshot has zero successful market quotes'):
+        validators.validate_macro(
+            path, now=datetime(2026, 7, 17, 1, tzinfo=timezone.utc))
+
+
+def test_macro_supplemental_sources_cannot_replace_market_quotes(tmp_path):
+    payload = macro_payload()
+    payload['vix'] = None
+    payload['fear_greed'] = {'score': 55}
+    payload['fed_press'] = [{'title': 'Federal Reserve press release'}]
+    path = write_json(tmp_path / 'macro.json', payload)
+
+    with pytest.raises(
+            AssertionError,
+            match='snapshot has zero successful market quotes'):
         validators.validate_macro(
             path, now=datetime(2026, 7, 17, 1, tzinfo=timezone.utc))
 

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -55,10 +55,11 @@ def sentiment_payload(tickers: tuple[str, ...]) -> dict:
     }
 
 
-def influencer_payload(*, items=None) -> dict:
+def influencer_payload(*, items=None, source_status=None) -> dict:
     items = [] if items is None else items
-    return {
+    payload = {
         'generated_at': GENERATED,
+        'lookback_hours': 48,
         'items': items,
         'sources': {'truth_social': 'RSS feed'},
         'counts': {
@@ -71,6 +72,9 @@ def influencer_payload(*, items=None) -> dict:
         'new_ideas': [],
         'sector_hits': [],
     }
+    if source_status is not None:
+        payload['source_status'] = source_status
+    return payload
 
 
 def macro_payload(generated_at: str = GENERATED) -> dict:
@@ -263,9 +267,48 @@ def test_sentiment_legacy_snapshot_without_source_status_still_passes(tmp_path):
 
 
 def test_influencer_quiet_day_with_zero_items_passes(tmp_path):
-    feed = write_json(tmp_path / 'influencer.json', influencer_payload())
+    feed = write_json(tmp_path / 'influencer.json', influencer_payload(
+        source_status={
+            'trump': 'success_empty',
+            'musk': 'success_empty',
+            'serenity': 'failed',
+        }))
 
     validators.validate_influencer(feed)
+
+
+def test_influencer_all_source_outage_with_zero_items_fails(tmp_path):
+    feed = write_json(tmp_path / 'influencer.json', influencer_payload(
+        source_status={
+            'trump': 'failed',
+            'musk': 'failed',
+            'serenity': 'failed',
+        }))
+
+    with pytest.raises(AssertionError, match='influencer: all sources failed'):
+        validators.validate_influencer(feed)
+
+
+def test_influencer_stale_retained_item_fails(tmp_path):
+    item = {
+        'author': 'Trump',
+        'text': 'market statement',
+        'published': '2026-07-14T23:00:00+00:00',
+        'retained_from_previous': True,
+        'relevance': None,
+    }
+    feed = write_json(tmp_path / 'influencer.json', influencer_payload(
+        items=[item],
+        source_status={
+            'trump': 'failed',
+            'musk': 'failed',
+            'serenity': 'failed',
+        }))
+
+    with pytest.raises(
+            AssertionError,
+            match='retained item 0 exceeds declared lookback window'):
+        validators.validate_influencer(feed)
 
 
 def test_sentiment_missing_active_ticker_fails(tmp_path):

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -185,6 +185,49 @@ def test_news_digest_rejects_structureless_output(tmp_path, bad, problem):
             snapshot, now=generated_time(snapshot) + timedelta(hours=1))
 
 
+def test_news_digest_accepts_explicit_no_material_news(tmp_path):
+    payload = {
+        'generated_at': GENERATED,
+        'lookback_hours': 48,
+        'tickers': ['AAPL'],
+        'raw_news_counts': {'AAPL': 0},
+        'digest_markdown': '',
+        'news_source_per_ticker': {'AAPL': 'none'},
+        'source_status': {
+            'AAPL': {
+                'finnhub': 'failed',
+                'google_news': 'success_empty',
+            },
+        },
+        'no_material_news': True,
+    }
+    snapshot = write_json(tmp_path / 'news.json', payload)
+
+    validators.validate_news_digest(
+        snapshot, now=generated_time(snapshot) + timedelta(hours=1))
+
+
+def test_no_material_news_without_successful_empty_source_fails(tmp_path):
+    payload = {
+        'generated_at': GENERATED,
+        'lookback_hours': 48,
+        'tickers': ['AAPL'],
+        'raw_news_counts': {'AAPL': 0},
+        'digest_markdown': '',
+        'source_status': {
+            'AAPL': {'finnhub': 'failed', 'google_news': 'failed'},
+        },
+        'no_material_news': True,
+    }
+    snapshot = write_json(tmp_path / 'news.json', payload)
+
+    with pytest.raises(
+            AssertionError,
+            match='no_material_news has no successful empty source'):
+        validators.validate_news_digest(
+            snapshot, now=generated_time(snapshot) + timedelta(hours=1))
+
+
 def test_real_committed_eod_archive_passes(tmp_path):
     archive = ROOT / 'memory/archive/eod-history.csv'
     with archive.open(newline='', encoding='utf-8') as handle:

--- a/tests/test_weekly_review_bundle_gate.py
+++ b/tests/test_weekly_review_bundle_gate.py
@@ -80,6 +80,50 @@ def test_weekly_bundle_with_valid_minimum_inputs_passes(
     ]
 
 
+def test_weekly_nav_uses_boundary_and_nearest_fx_when_interior_fx_missing(
+        tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _stub_decisions(monkeypatch)
+    _write_json(tmp_path / 'memory/2026-07-20-plan.json',
+                _plan('2026-07-20', fx=7.80))
+    _write_json(tmp_path / 'memory/2026-07-22-plan.json',
+                _plan('2026-07-22', fx=None,
+                      decisions=[{'action': 'hold'}]))
+    _write_json(tmp_path / 'memory/2026-07-24-plan.json',
+                _plan('2026-07-24', fx=7.84))
+    for day in ('2026-07-20', '2026-07-22', '2026-07-24'):
+        _write_json(tmp_path / f'memory/snapshots/{day}.json', _snapshot())
+    _write_json(tmp_path / 'assets/data/risk.json',
+                {'combined': {'beta': 1.2}})
+
+    bundle = weekly.aggregate_week(today=date(2026, 7, 28))
+    evidence = weekly.validate_bundle(bundle)
+
+    assert [point['date'] for point in evidence['nav_points']] == [
+        '2026-07-20', '2026-07-22', '2026-07-24',
+    ]
+    assert [point['fx_rate_usdhkd'] for point in evidence['nav_points']] == [
+        7.80, 7.80, 7.84,
+    ]
+
+
+def test_weekly_nav_still_fails_when_no_valid_fx_exists(
+        tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _stub_decisions(monkeypatch)
+    for day in ('2026-07-22', '2026-07-24'):
+        _write_json(tmp_path / f'memory/{day}-plan.json',
+                    _plan(day, fx=None, decisions=[{'action': 'hold'}]))
+        _write_json(tmp_path / f'memory/snapshots/{day}.json', _snapshot())
+    _write_json(tmp_path / 'assets/data/risk.json',
+                {'combined': {'beta': 1.2}})
+
+    bundle = weekly.aggregate_week(today=date(2026, 7, 28))
+
+    with pytest.raises(RuntimeError, match='start/end NAV from two dated snapshots'):
+        weekly.validate_bundle(bundle)
+
+
 def test_weekly_malformed_snapshot_names_missing_nav_before_llm(
         tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_weekly_review_bundle_gate.py
+++ b/tests/test_weekly_review_bundle_gate.py
@@ -1,0 +1,107 @@
+"""Deterministic input sufficiency tests for the weekly review producer."""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from scripts.data import gh_action_weekly_review as weekly
+
+
+def _plan(day, fx=7.8, decisions=None):
+    return {
+        'date': day,
+        'fx_rate_usdhkd': fx,
+        'decisions': [] if decisions is None else decisions,
+    }
+
+
+def _snapshot():
+    return {
+        'portfolios': {
+            'us_stocks': {
+                'total_current_value': 1000.0,
+                'cash_usd': 100.0,
+            },
+            'hk_stocks': {
+                'total_current_value': 7800.0,
+                'cash_hkd': 780.0,
+            },
+        },
+    }
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding='utf-8')
+
+
+def _stub_decisions(monkeypatch):
+    monkeypatch.setattr(weekly.decision_v2, 'load_decisions', lambda: [])
+    monkeypatch.setattr(
+        weekly.decision_v2, 'episode_representatives',
+        lambda _decisions, _horizon: [])
+    monkeypatch.setattr(
+        weekly.decision_v2, 'compute_metrics',
+        lambda _decisions: {'total': 0})
+
+
+def test_real_committed_weekly_bundle_passes():
+    bundle = weekly.aggregate_week(today=date(2026, 7, 24))
+
+    evidence = weekly.validate_bundle(bundle)
+
+    assert evidence['plan_days'] >= 1
+    assert len(evidence['nav_points']) >= 2
+    serialized = json.dumps(bundle, ensure_ascii=False)
+    assert serialized.index('"bundle_evidence"') < serialized.index('"snapshots"')
+
+
+def test_weekly_bundle_with_valid_minimum_inputs_passes(
+        tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _stub_decisions(monkeypatch)
+    _write_json(tmp_path / 'memory/2026-07-20-plan.json',
+                _plan('2026-07-20', decisions=[{'action': 'hold'}]))
+    _write_json(tmp_path / 'memory/2026-07-24-plan.json',
+                _plan('2026-07-24'))
+    _write_json(tmp_path / 'memory/snapshots/2026-07-20.json', _snapshot())
+    _write_json(tmp_path / 'memory/snapshots/2026-07-24.json', _snapshot())
+    _write_json(tmp_path / 'assets/data/risk.json', {'combined': {'beta': 1.2}})
+
+    bundle = weekly.aggregate_week(today=date(2026, 7, 26))
+    evidence = weekly.validate_bundle(bundle)
+
+    assert evidence['plan_days'] == 2
+    assert evidence['plan_decisions'] == 1
+    assert [point['date'] for point in evidence['nav_points']] == [
+        '2026-07-20', '2026-07-24',
+    ]
+
+
+def test_weekly_malformed_snapshot_names_missing_nav_before_llm(
+        tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _stub_decisions(monkeypatch)
+    _write_json(tmp_path / 'memory/2026-07-20-plan.json',
+                _plan('2026-07-20', decisions=[{'action': 'hold'}]))
+    _write_json(tmp_path / 'memory/2026-07-24-plan.json',
+                _plan('2026-07-24'))
+    _write_json(tmp_path / 'memory/snapshots/2026-07-20.json', _snapshot())
+    malformed = tmp_path / 'memory/snapshots/2026-07-24.json'
+    malformed.parent.mkdir(parents=True, exist_ok=True)
+    malformed.write_text('{', encoding='utf-8')
+    _write_json(tmp_path / 'assets/data/risk.json', {'combined': {'beta': 1.2}})
+    bundle = weekly.aggregate_week(today=date(2026, 7, 26))
+    monkeypatch.setattr(weekly, 'aggregate_week', lambda: bundle)
+    monkeypatch.setattr(
+        weekly, 'chat',
+        lambda **kwargs: pytest.fail('thin bundle must not call the LLM'))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        weekly.main()
+
+    message = str(exc_info.value)
+    assert 'start/end NAV from two dated snapshots' in message
+    assert 'memory/snapshots/2026-07-24.json' in message


### PR DESCRIPTION
CI 审计的最后一簇 —— fail-open 生产者(源全挂时写「新鲜的空/旧快照」骗过弱校验)。codex 实现,我 review。

**贯穿原则 fail-safe**:每道闸只在**真·全源故障**时 fail,绝不在「安静日」或「单源抖动」时误红。所有真实产物仍绿(`test_real_committed_*`)。

- **#8 macro**(validator):`validate_macro` 现要求**至少一个真市场报价**(vix/指数/DXY/10Y),fed_press/fear_greed 降为 supplemental。全报价源挂但 Fed RSS 出一条旧稿的假绿被堵死。committed macro.json 仍过。
- **#6 sentiment**(producer+validator):`fetch_sentiment` 记录 reddit/gnews 的**实际 HTTP 健康**(200 才置 ok),写进 `source_status`。validator:零结果**且** source_status 全 failed → fail;安静日(有结果)或旧快照(无 source_status,向后兼容)仍过。
- **#7 influencer**(producer+validator):区分 `success` / `success_empty` / `failed`;保留的旧条目带**原始时间戳**,validator 校验它们在 `lookback_hours` 窗口内;全源挂+空 feed → fail。
- **#11 news**(producer):全源成功但空 → 写**显式 `no_material_news` 产物**(空 digest、不编造),让新鲜度闸看到诚实的新产物;全源**报错** → 不写、loudly fail。
- **#10 weekly**(producer):LLM 调用**前**加确定性 bundle 闸 —— 要求起止 NAV + plan/decision 计数 + 当前 risk;证据不足则点名缺失输入并 fail,而不是让 LLM 产出「漂亮但无支撑」的周报。

## 验证
codex 反向变异验证(逐个禁用闸 → 对应 5 个测试变红);真实产物全绿;我本地 `pytest tests/` **557 passed / 5 xfailed**。新增 3 个测试文件覆盖 outage-fail / quiet-day-pass / real-artifact-pass。

codex 作者,Claude review;等 codex 交叉复审 + CI 绿后合并。
