### PR TITLE
brief-postflight: match required sections by semantic alias, not literal English token (#3)

### DIFF
--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -23,6 +23,7 @@ Side effects:
 """
 
 import json
+import re
 import sys
 import subprocess
 from datetime import datetime, timedelta
@@ -37,13 +38,51 @@ sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 
-REQUIRED_MARKDOWN_TOKENS = [
-    'Header', 'Tier 1', 'Tier 2', 'Tier 3', 'Judge', 'Confidence', 'Next-Session',
-    '同行扫描',  # NEW: peer rotation section
-]
+# Required concepts and the section labels the brief model may legitimately emit.
+# The canonical keys preserve the existing missing-section issue text.  The aliases
+# come from the prompt that is sent verbatim to the model:
+#   skills/daily-deep-brief/SKILL.md
+#   - Header / Tier 1 / Tier 2 / Tier 3 / Confidence / Next-Session: lines 503-515
+#   - the Chinese Tier/Judge/Confidence/next-session semantics: lines 94, 155-174,
+#     296-306, and 480-495
+#   - 同行扫描 / Peer Rotation: lines 332-358 and 509
+# The Chinese labels are the direct localized renderings of those named concepts;
+# 盘前深度简报 is also the prompt's own report name (lines 3 and 635).
+REQUIRED_MARKDOWN_SECTIONS = {
+    'Header': ('Header', '盘前摘要', '盘前深度简报'),
+    'Tier 1': ('Tier 1', '第一层'),
+    'Tier 2': ('Tier 2', '第二层'),
+    'Tier 3': ('Tier 3', '第三层'),
+    'Judge': ('Judge', '裁决'),
+    'Confidence': ('Confidence', '信心'),
+    'Next-Session': ('Next-Session', 'Next Session', '下一交易时段'),
+    '同行扫描': ('同行扫描', 'Peer Rotation'),
+}
 HKD_USD_BUG_PATTERNS = [
     '合计 -4423', '合计 -4,423', '合计 -4423.0',
 ]
+
+
+def _section_markers(text):
+    """Return real section-marker lines, not incidental aliases in prose."""
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if (re.match(r'^\s{0,3}#{1,6}\s+\S', line)
+            or re.match(r'^\s{0,3}\*\*\S', line)
+            or re.match(r'^\s{0,3}▎\s*\S', line))
+    ]
+
+
+def _marker_has_alias(marker, alias):
+    """Match ASCII labels as words and CJK labels as literal phrases."""
+    if alias.isascii():
+        return re.search(
+            rf'(?<![A-Za-z0-9]){re.escape(alias)}(?![A-Za-z0-9])',
+            marker,
+            re.IGNORECASE,
+        ) is not None
+    return alias in marker
 
 
 def validate_plan_json(path, context=None):
@@ -103,9 +142,11 @@ def validate_markdown(path, context=None):
         return [f'pre-open.md 读取失败: {e}']
 
     issues = []
-    for token in REQUIRED_MARKDOWN_TOKENS:
-        if token not in text:
-            issues.append(f'pre-open.md 缺段标记 "{token}"')
+    markers = _section_markers(text)
+    for concept, aliases in REQUIRED_MARKDOWN_SECTIONS.items():
+        if not any(_marker_has_alias(marker, alias)
+                   for marker in markers for alias in aliases):
+            issues.append(f'pre-open.md 缺段标记 "{concept}"')
 
     for bug in HKD_USD_BUG_PATTERNS:
         if bug in text:

--- a/tests/test_brief_postflight_sections.py
+++ b/tests/test_brief_postflight_sections.py
@@ -1,0 +1,65 @@
+"""Semantic section-label coverage for the daily brief postflight."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
+import brief_postflight
+
+
+CHINESE_LOCALIZED_BRIEF = """\
+# 盘前摘要
+
+HHI 集中度已复核；USDHKD 汇率已复核。
+
+## 第一层
+四个分析师角度。
+
+## 第二层
+多空辩论。
+
+## 第三层
+三个风险声音。
+
+### 裁决
+最终动作。
+
+## 同行扫描
+板块相对强弱。
+
+## 信心
+动作信心校准。
+
+## 下一交易时段
+下一时段可执行计划。
+"""
+
+
+def _missing_section_issues(issues):
+    return [issue for issue in issues if '缺段标记' in issue]
+
+
+def test_fully_chinese_localized_brief_has_no_missing_sections(tmp_path):
+    path = tmp_path / 'pre-open.md'
+    path.write_text(CHINESE_LOCALIZED_BRIEF, encoding='utf-8')
+
+    issues = brief_postflight.validate_markdown(path)
+
+    assert _missing_section_issues(issues) == []
+
+
+def test_genuinely_omitted_section_still_raises_same_missing_issue(tmp_path):
+    path = tmp_path / 'pre-open.md'
+    path.write_text(
+        CHINESE_LOCALIZED_BRIEF.replace('## 第二层\n多空辩论。\n\n', ''),
+        encoding='utf-8',
+    )
+
+    issues = brief_postflight.validate_markdown(path)
+
+    assert _missing_section_issues(issues) == ['pre-open.md 缺段标记 "Tier 2"']
+    # Keep today's warn/fail threshold semantics: one non-critical issue is a warn;
+    # five such issues still fail. The section omission itself remains surfaced.
+    assert brief_postflight.categorize(issues) == 'warn'


### PR DESCRIPTION
Finding #3 from the 2026-07 CI audit. `brief_postflight.validate_markdown` required literal English tokens (Header/Tier 1/…/Next-Session) via substring match, so a semantically-complete brief that renders section labels in Chinese (盘前摘要/第一层/…/裁决) accumulated ≥5 missing-section issues and was categorized `fail` on the terminal off-host fallback path — a false-red that blocks the last automatic brief recovery and drops the trading-day brief.

Fix (mirrors PR #28's match-by-concept approach): each required concept now matches an alias set (English + the localized labels the model is actually told to emit in skills/daily-deep-brief/SKILL.md), and an alias only counts when it appears in a real section-marker line (heading / bold / ▎), not incidental prose. Canonical keys preserve the existing issue text; genuinely omitted sections still raise identically.

Verified: 5 recent real committed briefs still pass with 0 missing-section issues (no false-fail regression); reverse mutation makes the localized-brief test fail with 7 missing sections; full suite 541 passed.