### PR TITLE
tavily-search: degrade gracefully on runtime failure instead of redding the cron

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -43,6 +43,11 @@ jobs:
         # not skip them. Pure Node, no deps; Node is preinstalled on the runner.
         run: node skills/tavily-search/lib/ledger.test.mjs
 
+      - name: Tavily search degrade tests
+        # Guards the fail-safe: a Tavily runtime failure must exit 0 (graceful
+        # degrade), never a non-zero that reds the whole cron. Offline + pure Node.
+        run: node skills/tavily-search/scripts/search.test.mjs
+
       - name: PR file safety policy
         if: github.event_name == 'pull_request'
         env:

--- a/skills/tavily-search/scripts/search.mjs
+++ b/skills/tavily-search/scripts/search.mjs
@@ -90,22 +90,49 @@ if (topic === "news" && days) {
   body.days = days;
 }
 
-// Ambiguous network failures (ECONNRESET etc.) may have arrived AFTER Tavily
-// billed, so we do NOT refund them — keeping the reservation is the safe
-// (conservative over-count) direction for a hard cap. Only a definite HTTP
-// error response is a guaranteed non-billed outcome and gets refunded.
-const resp = await fetch("https://api.tavily.com/search", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify(body),
-});
+// A Tavily runtime failure (network error, HTTP error, or unparseable body)
+// must NOT exit non-zero: this script is invoked mid-turn as OPTIONAL search
+// enrichment, so a non-zero exit gets upgraded to a run-level "Bash failed" and
+// reds the whole cron (e.g. the 2026-07-20 08:19 盘前深度简报). Degrade with the
+// same stdout contract as the no-key / budget paths and exit 0 so the caller
+// falls back to its built-in web search.
+const degrade = (stdoutReason, stderrLine) => {
+  console.log(
+    "## Web search unavailable\n\n" +
+      stdoutReason +
+      " Skip this source and use your built-in web search instead.",
+  );
+  console.error(stderrLine);
+  process.exit(0);
+};
+
+let resp;
+try {
+  resp = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+} catch (err) {
+  // Ambiguous network failure (ECONNRESET/DNS/timeout) may have arrived AFTER
+  // Tavily billed, so we do NOT refund — keeping the reservation is the safe
+  // (conservative over-count) direction for a hard cap.
+  degrade(
+    `Tavily network error: ${err?.message ?? err}.`,
+    `[tavily] network failure (reservation kept): ${err?.message ?? err}`,
+  );
+}
 
 if (!resp.ok) {
+  // A definite HTTP error response is a guaranteed non-billed outcome → refund.
   refund(gate.bucket, cost, gate.month);
   const text = await resp.text().catch(() => "");
-  throw new Error(`Tavily Search failed (${resp.status}): ${text}`);
+  degrade(
+    `Tavily API returned HTTP ${resp.status}.`,
+    `[tavily] HTTP ${resp.status} (refunded ${cost}): ${text.slice(0, 200)}`,
+  );
 }
 
 // Success → the reservation stands. Log remaining budget to stderr (not stdout,
@@ -114,7 +141,17 @@ console.error(
   `[tavily] charged ${cost} to "${gate.bucket}" — month ${gate.total_used} used, ${gate.remaining} left`,
 );
 
-const data = await resp.json();
+let data;
+try {
+  data = await resp.json();
+} catch (err) {
+  // Body already delivered (billed) → keep the reservation, but still degrade
+  // rather than crash the caller mid-turn.
+  degrade(
+    "Tavily returned an unparseable response body.",
+    `[tavily] malformed JSON (reservation kept): ${err?.message ?? err}`,
+  );
+}
 
 // Print AI-generated answer if available
 if (data.answer) {

--- a/skills/tavily-search/scripts/search.test.fetchmock.mjs
+++ b/skills/tavily-search/scripts/search.test.fetchmock.mjs
@@ -1,0 +1,30 @@
+// Preloaded via `node --import` to stub the global fetch that search.mjs calls,
+// so search.test.mjs can exercise every Tavily runtime outcome deterministically
+// and offline. Behaviour is selected by TAVILY_TEST_FETCH_MODE.
+const mode = process.env.TAVILY_TEST_FETCH_MODE;
+
+const resp = (init, body) => ({
+  ok: init.ok,
+  status: init.status,
+  text: async () => body ?? "",
+  json: async () => {
+    if (init.badjson) throw new Error("Unexpected token < in JSON");
+    return JSON.parse(body);
+  },
+});
+
+globalThis.fetch = async () => {
+  if (mode === "network") throw new Error("ECONNRESET (simulated)");
+  if (mode === "httpError") return resp({ ok: false, status: 429 }, "rate limited");
+  if (mode === "badjson") return resp({ ok: true, status: 200, badjson: true }, "<<not json>>");
+  if (mode === "success") {
+    return resp(
+      { ok: true, status: 200 },
+      JSON.stringify({
+        answer: "ANS",
+        results: [{ title: "T1", url: "http://u", content: "C", score: 0.9 }],
+      }),
+    );
+  }
+  throw new Error(`unknown TAVILY_TEST_FETCH_MODE: ${mode}`);
+};

--- a/skills/tavily-search/scripts/search.test.mjs
+++ b/skills/tavily-search/scripts/search.test.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Tavily search.mjs failure-mode tests. A Tavily runtime failure (network error,
+// HTTP error, unparseable body) must degrade to exit 0 with the "Web search
+// unavailable" contract — never a non-zero exit, because search.mjs is invoked
+// mid-turn as OPTIONAL enrichment and a non-zero exit gets upgraded to a
+// run-level "Bash failed" that reds the whole cron (regression: 2026-07-20 08:19
+// 盘前深度简报). The success path and real caller-bug exit codes must stay intact.
+//
+// Deterministic + offline: global fetch is stubbed via an --import preload and
+// the credit ledger is redirected to a throwaway temp file.
+// Run: node scripts/search.test.mjs
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SEARCH = join(HERE, "search.mjs");
+const MOCK = join(HERE, "search.test.fetchmock.mjs");
+
+let pass = 0;
+let fail = 0;
+const ok = (cond, msg) => {
+  if (cond) pass++;
+  else {
+    fail++;
+    console.log("  FAIL:", msg);
+  }
+};
+
+function run(mode, args = ["hello world", "--bucket", "test"]) {
+  const dir = mkdtempSync(join(tmpdir(), "tavily-search-"));
+  const env = {
+    ...process.env,
+    TAVILY_API_KEY: "dummy-key",
+    TAVILY_LEDGER_PATH: join(dir, "ledger.json"),
+  };
+  const argv = [];
+  if (mode) {
+    env.TAVILY_TEST_FETCH_MODE = mode;
+    argv.push("--import", MOCK);
+  }
+  argv.push(SEARCH, ...args);
+  return spawnSync("node", argv, { env, encoding: "utf8" });
+}
+
+// 1. HTTP error → graceful degrade, exit 0 (not a run-redding non-zero)
+let r = run("httpError");
+ok(r.status === 0, "httpError: exits 0");
+ok(
+  /Web search unavailable/.test(r.stdout) && /HTTP 429/.test(r.stdout),
+  "httpError: degrade notice with status on stdout",
+);
+
+// 2. Network throw → graceful degrade, exit 0
+r = run("network");
+ok(r.status === 0, "network: exits 0");
+ok(
+  /Web search unavailable/.test(r.stdout) && /network error/.test(r.stdout),
+  "network: degrade notice on stdout",
+);
+
+// 3. Malformed JSON body → graceful degrade, exit 0
+r = run("badjson");
+ok(r.status === 0, "badjson: exits 0");
+ok(/unparseable/.test(r.stdout), "badjson: degrade notice on stdout");
+
+// 4. Success path unchanged → exit 0, real results, NO degrade notice
+r = run("success");
+ok(r.status === 0, "success: exits 0");
+ok(
+  /## Sources/.test(r.stdout) && /T1/.test(r.stdout) && /ANS/.test(r.stdout),
+  "success: prints answer + sources",
+);
+ok(!/Web search unavailable/.test(r.stdout), "success: no degrade notice");
+
+// 5. Real caller bug (no query) must stay LOUD (exit 2), never swallowed
+r = run(null, []);
+ok(r.status === 2, "usage: no-args exits 2 (caller bug stays non-zero)");
+
+console.log(`\nsearch.mjs degrade tests: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
**Cron reliability audit finding A.** `skills/tavily-search/scripts/search.mjs` is invoked mid-turn as OPTIONAL search enrichment, but its Tavily API-error path `throw`s → Node exits 1 → the single failed bash gets upgraded to a run-level `Bash failed` that reds the whole daily brief. Real evidence: 07-20 08:19 盘前深度简报 red `Bash failed: node skills/tavily-search/scripts/search.mjs (agent)`. The script's own no-key and budget-guardrail paths already degrade (exit 0) — this makes the three runtime-failure points match that contract.

Changes:
- Wrap the `fetch`, `!resp.ok`, and `resp.json()` failure points: emit the same `## Web search unavailable` notice on stdout + a diagnostic on stderr, then `exit 0` so the caller falls back to built-in web search.
- Refund only on a definite HTTP error (guaranteed non-billed); keep the reservation on ambiguous network / JSON failures (conservative over-count for the hard cap).
- Real caller bugs (usage / unknown args) still exit 2 — not swallowed.
- Success path is byte-identical (only failure branches changed).

Tests: new offline `search.test.mjs` (fetch stubbed via `--import` preload, ledger redirected to a temp file) covers HTTP-error / network-throw / malformed-JSON degrade, unchanged success output, and the exit-2 caller-bug path; wired into `harness-regression.yml`. Locally 10/10 pass; reverse mutation (revert to throwing) breaks all 6 failure-mode assertions.