### PR TITLE
peers: add auto same-industry bucket (US live; HK gated) — augments the curated map

### DIFF
--- a/scripts/data/peer_scan.py
+++ b/scripts/data/peer_scan.py
@@ -21,6 +21,8 @@ import json
 import re
 from pathlib import Path
 
+from suggest_peers import suggest_auto_peers
+
 WS = Path(__file__).resolve().parents[2]
 
 
@@ -51,6 +53,15 @@ def _names_agree(fetched, configured):
     return bool(a) and bool(b) and (a in b or b in a)
 
 
+def _run_fetch(peer_request):
+    """Price curated and auto peers in one existing-budget subprocess."""
+    import subprocess as sp
+    return sp.run(
+        ['python3', str(WS / 'scripts' / 'data' / 'fetch_peers.py')],
+        input=json.dumps(peer_request), capture_output=True, text=True, timeout=120,
+    )
+
+
 def collect(portfolio, log=print, legs=None):
     """For each active holding with a peer entry in peer-map.json, fetch peer
     prices and flag divergence (peer up significantly while holding flat/down).
@@ -79,7 +90,27 @@ def collect(portfolio, log=print, legs=None):
                     'region': region,
                 }
 
-    # Collect all peer tickers we need
+    # Suggest first, then price curated + auto peers in ONE fetch_peers.py batch.
+    # Curated requests remain first, so the existing 8-worker/90s budget gives
+    # the hand-maintained map priority if the combined list is large.
+    auto_by_ticker = {}
+    for ticker, info in pmap.items():
+        if ticker not in h_by_ticker:
+            continue
+        region = 'hk' if h_by_ticker[ticker]['region'] == 'hk_stocks' else 'us'
+        curated = [p.get('ticker') for p in info.get('listed_peers', [])]
+        try:
+            suggested = suggest_auto_peers(ticker, region, curated)
+            auto_by_ticker[ticker] = suggested if isinstance(suggested, list) else []
+            if not isinstance(suggested, list):
+                log(f'   ⚠️  auto peers {ticker} returned {type(suggested).__name__}, ignored')
+        except Exception as e:
+            # suggest_auto_peers itself is fail-safe; this second guard protects
+            # the curated scan from import/test/provider regressions around it.
+            log(f'   ⚠️  auto peers {ticker} failed: {e}')
+            auto_by_ticker[ticker] = []
+
+    # Collect all peer tickers we need.
     peer_request = []
     seen = set()
     for ticker, info in pmap.items():
@@ -90,17 +121,19 @@ def collect(portfolio, log=print, legs=None):
             if key not in seen:
                 seen.add(key)
                 peer_request.append({'ticker': p['ticker'], 'region': p['region']})
+    for ticker, suggestions in auto_by_ticker.items():
+        for p in suggestions:
+            key = (p['ticker'], p['region'])
+            if key not in seen:
+                seen.add(key)
+                peer_request.append({'ticker': p['ticker'], 'region': p['region']})
 
     if not peer_request:
         return {}
 
     # Call fetch_peers.py via subprocess
     try:
-        import subprocess as sp
-        r = sp.run(
-            ['python3', str(WS / 'scripts' / 'data' / 'fetch_peers.py')],
-            input=json.dumps(peer_request), capture_output=True, text=True, timeout=120,
-        )
+        r = _run_fetch(peer_request)
         if r.returncode != 0:
             # Old versions of the script printed their error to stdout, not stderr.
             log(f'   ⚠️  fetch_peers.py failed (rc={r.returncode}): {(r.stderr or r.stdout)[-300:]}')
@@ -163,11 +196,33 @@ def collect(portfolio, log=print, legs=None):
             if diff >= 3.0:
                 divergence = f'{best_peer["ticker"]} {best_peer["name"]} {best_peer["pct_1d"]:+.1f}% vs self {self_pct:+.1f}% (gap {diff:+.1f}pp)'
 
+        auto_results = []
+        for p in auto_by_ticker.get(ticker, []):
+            pdata = fetched.get(p['ticker'], {})
+            if pdata.get('stale_quote'):
+                log(f'   ⚠️  auto peer {p["ticker"]} quote is stale '
+                    f'({pdata["stale_quote"]}), dropped')
+                continue
+            if 'price' not in pdata:
+                continue
+            auto_results.append({
+                'ticker': p['ticker'],
+                'name': pdata.get('name') or p.get('name') or p['ticker'],
+                'label': '同行业·自动',
+                'source': p.get('source'),
+                'pct_1d': pdata.get('pct_1d'),
+                'pct_5d': pdata.get('pct_5d'),
+            })
+        auto_results.sort(
+            key=lambda x: x['pct_1d'] if x.get('pct_1d') is not None else float('-inf'),
+            reverse=True)
+
         scan[ticker] = {
             'theme':            info.get('theme'),
             'self_pct_1d':      round(self_pct, 2),
             'self_pnl_pct':     h_by_ticker[ticker]['pnl_pct'],
             'listed_peers':     peer_results,
+            'auto_peers':       auto_results,
             'private_peers':    info.get('private_peers', []),
             'divergence_signal': divergence,
             'key_news_keywords': info.get('key_news_keywords', []),

--- a/scripts/data/suggest_peers.py
+++ b/scripts/data/suggest_peers.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Suggest same-industry peers without changing the curated peer map.
+
+US suggestions come from Finnhub's peer-symbol endpoint. HK suggestions use
+East Money to resolve the holding's industry board and then list that board's
+HK constituents. This module is deliberately fail-safe: source failures are
+diagnosed on stderr and always become an empty suggestion list.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Iterable
+
+import requests
+
+from _em_http import em_get
+from fetch_us_stocks import load_api_keys
+
+
+MAX_AUTO_PEERS = 6
+TIMEOUT = 10
+
+FINNHUB_PEERS_URL = "https://finnhub.io/api/v1/stock/peers"
+EM_STOCK_INFO_URL = "https://push2.eastmoney.com/api/qt/stock/get"
+EM_STOCK_BOARDS_URL = "https://push2.eastmoney.com/api/qt/slist/get"
+EM_BOARD_CONSTITUENTS_URL = "https://push2.eastmoney.com/api/qt/clist/get"
+
+
+def _diag(ticker: str, message: str) -> None:
+    print(f"suggest_peers.py: {ticker}: {message}", file=sys.stderr)
+
+
+def _rows(payload):
+    diff = ((payload or {}).get("data") or {}).get("diff") or []
+    return list(diff.values()) if isinstance(diff, dict) else diff
+
+
+def _norm_hk(ticker: object) -> str:
+    value = str(ticker or "").strip()
+    return value.zfill(5) if value.isdigit() else value.upper()
+
+
+def _norm_us(ticker: object) -> str:
+    return str(ticker or "").strip().upper()
+
+
+def _excluded(ticker: str, region: str, curated_tickers: Iterable[object]) -> set[str]:
+    norm = _norm_hk if region == "hk" else _norm_us
+    return {norm(ticker), *(norm(value) for value in curated_tickers or [])}
+
+
+def _response_json(response, source: str):
+    if response is None:
+        raise RuntimeError(f"{source} returned no response")
+    status = getattr(response, "status_code", 200)
+    if status >= 400:
+        raise RuntimeError(f"{source} HTTP {status}")
+    return response.json()
+
+
+def _suggest_us(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
+    symbol = _norm_us(ticker)
+    key = load_api_keys().get("FINNHUB_API_KEY", "")
+    if not key:
+        _diag(symbol, "Finnhub API key unavailable")
+        return []
+
+    response = requests.get(
+        FINNHUB_PEERS_URL,
+        params={"symbol": symbol, "token": key},
+        timeout=TIMEOUT,
+    )
+    symbols = _response_json(response, "Finnhub peers")
+    if not isinstance(symbols, list) or not symbols:
+        _diag(symbol, "Finnhub peers returned an empty or malformed payload")
+        return []
+
+    blocked = _excluded(symbol, "us", curated_tickers)
+    out = []
+    seen = set()
+    for raw in symbols:
+        candidate = _norm_us(raw)
+        if not candidate or candidate in blocked or candidate in seen:
+            continue
+        seen.add(candidate)
+        # /stock/peers returns symbols only. fetch_peers.py supplies the feed
+        # company name during the shared pricing pass; the symbol is a safe
+        # fallback if that feed omits its name.
+        out.append({
+            "ticker": candidate,
+            "region": "us",
+            "name": candidate,
+            "source": "finnhub",
+        })
+        if len(out) == MAX_AUTO_PEERS:
+            break
+    if not out:
+        _diag(symbol, "Finnhub returned no additional uncurated peers")
+    return out
+
+
+def _suggest_hk(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
+    symbol = _norm_hk(ticker)
+    secid = f"116.{symbol}"
+
+    info_response = em_get(
+        EM_STOCK_INFO_URL,
+        params={
+            "fltt": "2",
+            "invt": "2",
+            "secid": secid,
+            "fields": "f57,f58,f127",
+        },
+        timeout=TIMEOUT,
+        label="auto-peer HK industry",
+    )
+    info = (_response_json(info_response, "East Money stock info").get("data") or {})
+    industry = str(info.get("f127") or "").strip()
+    if not industry:
+        _diag(symbol, "East Money returned no industry")
+        return []
+
+    boards_response = em_get(
+        EM_STOCK_BOARDS_URL,
+        params={
+            "fltt": "2",
+            "invt": "2",
+            "secid": secid,
+            "spt": "3",
+            "pi": "0",
+            "pz": "200",
+            "po": "1",
+            "fields": "f12,f14",
+        },
+        headers={"Referer": "https://quote.eastmoney.com/"},
+        timeout=TIMEOUT,
+        label="auto-peer HK board",
+    )
+    boards = _rows(_response_json(boards_response, "East Money stock boards"))
+    if not boards:
+        _diag(symbol, "East Money returned no board memberships")
+        return []
+
+    def board_match(row):
+        name = re.sub(r"\s+", "", str(row.get("f14") or ""))
+        target = re.sub(r"\s+", "", industry)
+        return name == target
+
+    board = next((row for row in boards if board_match(row)), None)
+    board_code = str((board or {}).get("f12") or "")
+    if not re.fullmatch(r"BK\d+", board_code):
+        _diag(symbol, f"East Money could not map industry {industry!r} to a board")
+        return []
+
+    constituents_response = em_get(
+        EM_BOARD_CONSTITUENTS_URL,
+        params={
+            "pn": "1",
+            "pz": "200",
+            "po": "1",
+            "np": "1",
+            "fltt": "2",
+            "invt": "2",
+            "fid": "f20",
+            "fs": f"b:{board_code}",
+            "fields": "f12,f13,f14",
+        },
+        headers={"Referer": f"https://quote.eastmoney.com/bk/90.{board_code}.html"},
+        timeout=TIMEOUT,
+        label="auto-peer HK constituents",
+    )
+    rows = _rows(_response_json(constituents_response, "East Money constituents"))
+    if not rows:
+        _diag(symbol, f"East Money board {board_code} returned no constituents")
+        return []
+
+    blocked = _excluded(symbol, "hk", curated_tickers)
+    out = []
+    seen = set()
+    for row in rows:
+        # f13 is East Money's market id. Requiring 116 prevents an A-share
+        # industry board with the same display name from leaking into HK peers.
+        if str(row.get("f13") or "") != "116":
+            continue
+        candidate = _norm_hk(row.get("f12"))
+        name = str(row.get("f14") or "").strip()
+        if not candidate or not name or candidate in blocked or candidate in seen:
+            continue
+        seen.add(candidate)
+        out.append({
+            "ticker": candidate,
+            "region": "hk",
+            "name": name,
+            "source": "eastmoney",
+        })
+        if len(out) == MAX_AUTO_PEERS:
+            break
+    if not out:
+        _diag(symbol, f"East Money board {board_code} returned no eligible HK peers")
+    return out
+
+
+def suggest_auto_peers(ticker, region, curated_tickers) -> list[dict]:
+    """Return up to six uncurated same-industry peers; never raise.
+
+    An unavailable key, timeout, HTTP/JSON/source-shape error, or empty source
+    all degrade to ``[]``. The curated caller can therefore continue unchanged.
+    """
+    try:
+        normalized_region = str(region or "").strip().lower()
+        if normalized_region == "us":
+            return _suggest_us(ticker, curated_tickers)
+        if normalized_region == "hk":
+            return _suggest_hk(ticker, curated_tickers)
+        _diag(str(ticker), f"unsupported region {region!r}")
+        return []
+    except Exception as exc:
+        _diag(str(ticker), f"auto peer source failed: {exc}")
+        return []

--- a/scripts/data/suggest_peers.py
+++ b/scripts/data/suggest_peers.py
@@ -22,6 +22,16 @@ from fetch_us_stocks import load_api_keys
 MAX_AUTO_PEERS = 6
 TIMEOUT = 10
 
+# US same-industry peers via Finnhub are live and verified. HK is NOT wired yet:
+# East Money HK industry boards use ``HK\d+`` codes (00100's 软件服务 board is
+# HK28), not the A-share ``BK\d+``, and the board-constituent endpoint
+# ``clist/get?fs=b:HK28`` returns no rows — the HK constituent query is still
+# unresolved against live data. ``_suggest_hk`` keeps the resolved parts (industry
+# lookup + board match with the corrected code shape) behind this flag so it is
+# ready once the constituent endpoint is confirmed; until then HK holdings get no
+# auto peers and, importantly, make no wasted East Money calls per scan.
+HK_AUTO_PEERS_ENABLED = False
+
 FINNHUB_PEERS_URL = "https://finnhub.io/api/v1/stock/peers"
 EM_STOCK_INFO_URL = "https://push2.eastmoney.com/api/qt/stock/get"
 EM_STOCK_BOARDS_URL = "https://push2.eastmoney.com/api/qt/slist/get"
@@ -150,7 +160,8 @@ def _suggest_hk(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
 
     board = next((row for row in boards if board_match(row)), None)
     board_code = str((board or {}).get("f12") or "")
-    if not re.fullmatch(r"BK\d+", board_code):
+    # HK industry boards are HK\d+ (e.g. HK28); A-share boards are BK\d+.
+    if not re.fullmatch(r"(?:BK|HK)\d+", board_code):
         _diag(symbol, f"East Money could not map industry {industry!r} to a board")
         return []
 
@@ -213,6 +224,11 @@ def suggest_auto_peers(ticker, region, curated_tickers) -> list[dict]:
         if normalized_region == "us":
             return _suggest_us(ticker, curated_tickers)
         if normalized_region == "hk":
+            if not HK_AUTO_PEERS_ENABLED:
+                _diag(str(ticker),
+                      "HK auto-peers not wired yet (East Money board-constituent "
+                      "endpoint unresolved); skipping")
+                return []
             return _suggest_hk(ticker, curated_tickers)
         _diag(str(ticker), f"unsupported region {region!r}")
         return []

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -133,6 +133,7 @@ def compute_context_id(result):
 
 
 PEER_TOP_N = 5
+AUTO_PEER_TOP_N = 3
 
 
 def trim_peer_scan(peers):
@@ -146,9 +147,10 @@ def trim_peer_scan(peers):
     second representation would only be one more thing to keep in sync, and the
     printed JSON would no longer be what is on disk.
 
-    `listed_peers` is already sorted by today's move, so the head is the 板块 Top N
-    the report asks for. private_peers / key_news_keywords are dropped: they are
-    the長 tail nobody cites in a 4-6 line briefing.
+    `listed_peers` and `auto_peers` are already sorted by today's move, so their
+    heads are the compact 板块 views the report asks for. private_peers /
+    key_news_keywords are dropped: they are the長 tail nobody cites in a 4-6
+    line briefing.
     """
     out = {}
     for ticker, scan in (peers or {}).items():
@@ -158,6 +160,10 @@ def trim_peer_scan(peers):
             'divergence_signal': scan.get('divergence_signal'),
             'listed_peers': [_peer_line(p)
                              for p in (scan.get('listed_peers') or [])[:PEER_TOP_N]],
+            'auto_peers': [
+                f'{p.get("label") or "同行业·自动"}｜{_peer_line(p)}'
+                for p in (scan.get('auto_peers') or [])[:AUTO_PEER_TOP_N]
+            ],
         }
     return out
 

--- a/tests/test_peer_scan.py
+++ b/tests/test_peer_scan.py
@@ -77,8 +77,7 @@ def wired(ps, tmp_path, monkeypatch):
         stderr = ""
 
     monkeypatch.setattr(ps, "_run_fetch", lambda req: FakeCompleted(), raising=False)
-    import subprocess as sp
-    monkeypatch.setattr(sp, "run", lambda *a, **kw: FakeCompleted())
+    monkeypatch.setattr(ps, "suggest_auto_peers", lambda ticker, region, curated: [])
     return ps
 
 
@@ -152,8 +151,7 @@ def test_flat_peer_outranks_losers(wired, monkeypatch):
         stdout = json.dumps({"peers": fetched})
         stderr = ""
 
-    import subprocess as sp
-    monkeypatch.setattr(sp, "run", lambda *a, **kw: FakeCompleted())
+    monkeypatch.setattr(wired, "_run_fetch", lambda req: FakeCompleted())
     scan = wired.collect(PORTFOLIO, log=lambda m: None)
     order = [p["ticker"] for p in scan["00100"]["listed_peers"]]
     assert order == ["02513", "00001", "09999"], "0.0 must sort above -1.0 and -5.0"
@@ -185,3 +183,83 @@ def test_peers_are_sorted_and_divergence_is_flagged(wired):
     # best peer +8.0 vs holding -3.0 = 11pp gap, well over the 3pp threshold
     assert entry["divergence_signal"] and "02513" in entry["divergence_signal"]
     assert entry["theme"] == "HK AI 大模型"
+
+
+def test_auto_source_outage_keeps_curated_scan_byte_identical(wired, monkeypatch):
+    """The auto bucket is additive: an outage cannot perturb curated fields."""
+    monkeypatch.setattr(wired, "suggest_auto_peers", lambda *args: [])
+
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+    entry = scan["00100"]
+    curated = {key: value for key, value in entry.items() if key != "auto_peers"}
+    expected = {
+        "theme": "HK AI 大模型",
+        "self_pct_1d": -3.0,
+        "self_pnl_pct": -65.1,
+        "listed_peers": [
+            {"ticker": "02513", "name": "智谱", "rel": "大模型同业",
+             "pct_1d": 8.0, "pct_5d": -31.2},
+            {"ticker": "09999", "name": "完全不同的公司", "rel": "改过名的",
+             "pct_1d": 1.0, "pct_5d": 2.0,
+             "name_mismatch": "peer-map says 旧名字, feed says 完全不同的公司"},
+        ],
+        "private_peers": [],
+        "divergence_signal": "02513 智谱 +8.0% vs self -3.0% (gap +11.0pp)",
+        "key_news_keywords": [],
+    }
+
+    assert json.dumps(curated, ensure_ascii=False) == json.dumps(expected, ensure_ascii=False)
+    assert entry["auto_peers"] == []
+
+
+def test_unpriced_auto_peer_drops_only_auto_bucket(wired, monkeypatch):
+    monkeypatch.setattr(wired, "suggest_auto_peers", lambda *args: [{
+        "ticker": "AUTO", "region": "hk", "name": "自动同行", "source": "eastmoney",
+    }])
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = json.dumps({"peers": {
+            **FETCHED,
+            "AUTO": {"ticker": "AUTO", "region": "hk", "error_tencent": "offline"},
+        }})
+        stderr = ""
+
+    monkeypatch.setattr(wired, "_run_fetch", lambda req: FakeCompleted())
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+
+    assert scan["00100"]["auto_peers"] == []
+    assert [p["ticker"] for p in scan["00100"]["listed_peers"]] == ["02513", "09999"]
+
+
+def test_auto_peers_share_pricing_batch_and_stay_labeled(wired, monkeypatch):
+    requests_seen = []
+    monkeypatch.setattr(wired, "suggest_auto_peers", lambda *args: [{
+        "ticker": "AUTO", "region": "hk", "name": "自动同行", "source": "eastmoney",
+    }])
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = json.dumps({"peers": {
+            **FETCHED,
+            "AUTO": {"price": 12.0, "pct_1d": 4.0, "pct_5d": 5.0, "name": "真实自动同行"},
+        }})
+        stderr = ""
+
+    def fake_fetch(request):
+        requests_seen.append(request)
+        return FakeCompleted()
+
+    monkeypatch.setattr(wired, "_run_fetch", fake_fetch)
+    scan = wired.collect(PORTFOLIO, log=lambda m: None)
+
+    assert len(requests_seen) == 1
+    assert requests_seen[0][-1] == {"ticker": "AUTO", "region": "hk"}
+    assert scan["00100"]["auto_peers"] == [{
+        "ticker": "AUTO",
+        "name": "真实自动同行",
+        "label": "同行业·自动",
+        "source": "eastmoney",
+        "pct_1d": 4.0,
+        "pct_5d": 5.0,
+    }]

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -169,6 +169,9 @@ def test_peer_scan_is_trimmed_at_the_source_not_in_a_second_view(pre):
         'divergence_signal': 'MU +3.2% vs self +0.1%',
         'listed_peers': [{'ticker': f'P{i}', 'name': 'x' * 40, 'rel': 'y' * 40,
                           'pct_1d': i, 'pct_5d': i} for i in range(9)],
+        'auto_peers': [{'ticker': f'A{i}', 'name': 'auto',
+                        'label': '同行业·自动', 'pct_1d': i, 'pct_5d': i}
+                       for i in range(7)],
         'private_peers': ['a' * 50] * 6,
         'key_news_keywords': ['k' * 20] * 8,
     }}
@@ -180,6 +183,9 @@ def test_peer_scan_is_trimmed_at_the_source_not_in_a_second_view(pre):
     lines = trimmed['RKLX']['listed_peers']
     assert len(lines) == 5 and lines[0].startswith('P0 ')
     assert '+0.00% (5d +0.00%)' in lines[0]        # both moves stay quotable
+    auto_lines = trimmed['RKLX']['auto_peers']
+    assert len(auto_lines) == 3
+    assert auto_lines[0].startswith('同行业·自动｜A0 auto ')
     # the long tail does not
     assert 'private_peers' not in trimmed['RKLX']
     assert all(isinstance(ln, str) for ln in lines)  # flat: 1 line per peer, not 6

--- a/tests/test_suggest_peers.py
+++ b/tests/test_suggest_peers.py
@@ -56,7 +56,21 @@ def test_us_outage_returns_empty_and_diagnoses(monkeypatch, capsys):
     assert "auto peer source failed" in capsys.readouterr().err
 
 
-def test_hk_resolves_industry_excludes_and_caps_six(monkeypatch):
+def test_hk_gated_off_by_default_makes_no_em_calls(monkeypatch, capsys):
+    # HK auto-peers ship disabled (East Money HK constituent endpoint unresolved).
+    # The gate must short-circuit BEFORE any East Money call so a HK-heavy scan
+    # is not slowed by wasted/failing requests every cycle.
+    calls = []
+    monkeypatch.setattr(sp, "em_get", lambda *a, **kw: calls.append(kw) or None)
+
+    assert sp.suggest_auto_peers("00700", "hk", ["09988"]) == []
+    assert calls == []
+    assert "not wired yet" in capsys.readouterr().err
+
+
+def test_hk_parser_resolves_industry_excludes_and_caps_six(monkeypatch):
+    # Guards `_suggest_hk` (called directly, bypassing the ship gate) so the parser
+    # is correct for when HK is enabled — using a realistic HK\d+ board code.
     calls = []
 
     def fake_em_get(url, **kwargs):
@@ -65,8 +79,8 @@ def test_hk_resolves_industry_excludes_and_caps_six(monkeypatch):
             return FakeResponse({"data": {"f57": "00700", "f58": "腾讯控股", "f127": "互联网服务"}})
         if url == sp.EM_STOCK_BOARDS_URL:
             return FakeResponse({"data": {"diff": [
-                {"f12": "BK9999", "f14": "腾讯概念"},
-                {"f12": "BK0447", "f14": "互联网服务"},
+                {"f12": "HK9999", "f14": "腾讯概念"},
+                {"f12": "HK28", "f14": "互联网服务"},
             ]}})
         assert url == sp.EM_BOARD_CONSTITUENTS_URL
         return FakeResponse({"data": {"diff": [
@@ -84,7 +98,7 @@ def test_hk_resolves_industry_excludes_and_caps_six(monkeypatch):
 
     monkeypatch.setattr(sp, "em_get", fake_em_get)
 
-    peers = sp.suggest_auto_peers("700", "hk", ["09988"])
+    peers = sp._suggest_hk("700", ["09988"])
 
     assert [p["ticker"] for p in peers] == [
         "03690", "01024", "09626", "09888", "09999", "03888"
@@ -93,10 +107,12 @@ def test_hk_resolves_industry_excludes_and_caps_six(monkeypatch):
     assert all(p["region"] == "hk" and p["source"] == "eastmoney" for p in peers)
     assert calls[0][0] == sp.EM_STOCK_INFO_URL
     assert calls[1][0] == sp.EM_STOCK_BOARDS_URL
-    assert calls[2][1]["fs"] == "b:BK0447"
+    assert calls[2][1]["fs"] == "b:HK28"
 
 
-def test_hk_outage_returns_empty_and_diagnoses(monkeypatch, capsys):
+def test_hk_outage_returns_empty_and_diagnoses_when_enabled(monkeypatch, capsys):
+    # When HK is enabled, a source outage must still degrade to [] (never raise).
+    monkeypatch.setattr(sp, "HK_AUTO_PEERS_ENABLED", True)
     monkeypatch.setattr(sp, "em_get", lambda *a, **kw: None)
 
     assert sp.suggest_auto_peers("00700", "hk", []) == []

--- a/tests/test_suggest_peers.py
+++ b/tests/test_suggest_peers.py
@@ -1,0 +1,103 @@
+"""Unit tests for fail-safe automatic peer suggestions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import requests
+
+
+WS = Path(__file__).resolve().parents[1]
+DATA_SCRIPTS = str(WS / "scripts" / "data")
+if DATA_SCRIPTS not in sys.path:
+    sys.path.insert(0, DATA_SCRIPTS)
+
+import suggest_peers as sp  # noqa: E402
+
+
+class FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+def test_us_excludes_self_and_curated_then_caps_six(monkeypatch):
+    monkeypatch.setattr(sp, "load_api_keys", lambda: {"FINNHUB_API_KEY": "test"})
+    monkeypatch.setattr(
+        sp.requests,
+        "get",
+        lambda *a, **kw: FakeResponse(
+            ["NVDA", "AMD", "CURATED", "AVGO", "QCOM", "INTC", "MU", "MRVL", "ARM", "TSM"]
+        ),
+    )
+
+    peers = sp.suggest_auto_peers("nvda", "us", ["amd", "CURATED"])
+
+    assert [p["ticker"] for p in peers] == ["AVGO", "QCOM", "INTC", "MU", "MRVL", "ARM"]
+    assert len(peers) == 6
+    assert all(p["region"] == "us" and p["source"] == "finnhub" for p in peers)
+    assert all(p["name"] == p["ticker"] for p in peers)
+
+
+def test_us_outage_returns_empty_and_diagnoses(monkeypatch, capsys):
+    monkeypatch.setattr(sp, "load_api_keys", lambda: {"FINNHUB_API_KEY": "test"})
+
+    def timeout(*args, **kwargs):
+        raise requests.Timeout("offline")
+
+    monkeypatch.setattr(sp.requests, "get", timeout)
+
+    assert sp.suggest_auto_peers("NVDA", "us", []) == []
+    assert "auto peer source failed" in capsys.readouterr().err
+
+
+def test_hk_resolves_industry_excludes_and_caps_six(monkeypatch):
+    calls = []
+
+    def fake_em_get(url, **kwargs):
+        calls.append((url, kwargs["params"]))
+        if url == sp.EM_STOCK_INFO_URL:
+            return FakeResponse({"data": {"f57": "00700", "f58": "腾讯控股", "f127": "互联网服务"}})
+        if url == sp.EM_STOCK_BOARDS_URL:
+            return FakeResponse({"data": {"diff": [
+                {"f12": "BK9999", "f14": "腾讯概念"},
+                {"f12": "BK0447", "f14": "互联网服务"},
+            ]}})
+        assert url == sp.EM_BOARD_CONSTITUENTS_URL
+        return FakeResponse({"data": {"diff": [
+            {"f12": "00700", "f13": 116, "f14": "腾讯控股"},
+            {"f12": "09988", "f13": 116, "f14": "阿里巴巴-W"},
+            {"f12": "03690", "f13": 116, "f14": "美团-W"},
+            {"f12": "01024", "f13": 116, "f14": "快手-W"},
+            {"f12": "09626", "f13": 116, "f14": "哔哩哔哩-W"},
+            {"f12": "09888", "f13": 116, "f14": "百度集团-SW"},
+            {"f12": "09999", "f13": 116, "f14": "网易-S"},
+            {"f12": "03888", "f13": 116, "f14": "金山软件"},
+            {"f12": "00772", "f13": 116, "f14": "阅文集团"},
+            {"f12": "600519", "f13": 1, "f14": "贵州茅台"},
+        ]}})
+
+    monkeypatch.setattr(sp, "em_get", fake_em_get)
+
+    peers = sp.suggest_auto_peers("700", "hk", ["09988"])
+
+    assert [p["ticker"] for p in peers] == [
+        "03690", "01024", "09626", "09888", "09999", "03888"
+    ]
+    assert len(peers) == 6
+    assert all(p["region"] == "hk" and p["source"] == "eastmoney" for p in peers)
+    assert calls[0][0] == sp.EM_STOCK_INFO_URL
+    assert calls[1][0] == sp.EM_STOCK_BOARDS_URL
+    assert calls[2][1]["fs"] == "b:BK0447"
+
+
+def test_hk_outage_returns_empty_and_diagnoses(monkeypatch, capsys):
+    monkeypatch.setattr(sp, "em_get", lambda *a, **kw: None)
+
+    assert sp.suggest_auto_peers("00700", "hk", []) == []
+    assert "auto peer source failed" in capsys.readouterr().err


### PR DESCRIPTION
Adds an `auto_peers` bucket to the peer scan that AUGMENTS (never replaces) the hand-curated `peer-map.json`, so kcn sees more same-industry peers Futu-style. Auto-excludes the holding itself and every already-curated ticker; capped at 6/holding; priced through the existing fetch_peers budget with curated requests first.

**Fail-safe (no negative optimization):** any auto-source failure returns `[]`; the curated scan stays byte-for-byte identical (test `test_auto_source_outage_keeps_curated_scan_byte_identical`), with a second try/except guard in peer_scan.

**US: live-verified working** — Finnhub `/stock/peers`: RKLB→6 defense/aerospace peers, CRCL→6 software peers; leveraged-ETF tickers (no company peers) degrade to `[]` cleanly.

**HK: honestly gated OFF** (`HK_AUTO_PEERS_ENABLED=False`). A live smoke test found codex's HK path was a silent no-op on real East Money data — mocked tests passed with an A-share `BK` board code, but real HK industry boards use `HK\d+` (00100 软件服务 = HK28) and the `clist?fs=b:HK28` constituent query returns no rows. The board-code regex is fixed to `(BK|HK)\d+` and `_suggest_hk` is kept behind the flag (with a direct parser test) so HK can be enabled once the constituent endpoint is reverse-engineered against live 东财 — which codex's offline sandbox cannot do. Until then HK holdings make zero East Money calls.

Full suite 569 passed, 5 xfailed.