### PR TITLE
Bind Intraday Watchdogs to Exact Slots

### DIFF
--- a/CRON_SCHEDULES.md
+++ b/CRON_SCHEDULES.md
@@ -32,7 +32,7 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
 | 美股收盘报告 | EDT `0 4 * * 2-6`<br>EST `0 5 * * 2-6` | Mode 6 | `report --us close` | EDT `20 4 * * 2-6`<br>EST `20 5 * * 2-6` |
 | 盘前深度简报 | `0 8 * * 1-5` · Asia/Shanghai | daily-deep-brief | `brief_*` | `30 8 * * 1-5` · Asia/Hong_Kong<br>`5 9 * * 1-5` · Asia/Hong_Kong · miss-detector: brief never written (08:30 is inside the landing window) |
 | 港股开盘报告 | `30 9 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk open` | `45 9 * * 1-5` · Asia/Hong_Kong |
-| 盘中盯盘 | `*/30 10-11,14-15 * * 1-5` · Asia/Shanghai | Mode 7 | `intraday --hk` | `4,34 10-11,14-15 * * 1-5` · Asia/Hong_Kong |
+| 盘中盯盘 | `*/30 10-11,14-15 * * 1-5` · Asia/Shanghai | Mode 7 | `intraday --hk` | `10,40 10-11,14-15 * * 1-5` · Asia/Hong_Kong |
 | 港股午盘报告 | `0 12 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk mid` | `12 12 * * 1-5` · Asia/Hong_Kong |
 | 港股午后快报 | `30 13 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk pm` | `42 13 * * 1-5` · Asia/Hong_Kong |
 | 港股收盘报告 | `0 16 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk close` | `15 16 * * 1-5` · Asia/Hong_Kong |

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -277,7 +277,7 @@
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "4,34 10-11,14-15 * * 1-5",
+          "expr": "10,40 10-11,14-15 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command_contains": [

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -178,6 +178,21 @@ def categorize(issues):
     )
 
 
+def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out):
+    """Build the watchdog marker with the preflight slot as its identity."""
+    heartbeat = ctx.get('heartbeat') or {}
+    return {
+        'ts': ts,
+        'sent_ok': bool(sent_ok),
+        'tg_ok': bool(tg_ok),
+        'first_line': first_line,
+        'market': market,
+        'job': heartbeat.get('job'),
+        'slot': heartbeat.get('slot'),
+        'out': (out or '')[-200:],
+    }
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
@@ -274,14 +289,15 @@ def main():
         # uses (no more WeChat resend), so it needs to know if TG already got this.
         tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
         try:
-            marker.write_text(json.dumps({
-                'ts': int(datetime.now().timestamp() * 1000),
-                'sent_ok': bool(wechat_sent),
-                'tg_ok': bool(tg_ok),
-                'first_line': block_first,
-                'market': args.market,
-                'out': (send_out or '')[-200:],
-            }, ensure_ascii=False))
+            marker.write_text(json.dumps(delivery_marker_payload(
+                ctx,
+                ts=int(datetime.now().timestamp() * 1000),
+                sent_ok=wechat_sent,
+                tg_ok=tg_ok,
+                first_line=block_first,
+                market=args.market,
+                out=send_out,
+            ), ensure_ascii=False))
         except Exception as e:
             print(f'warn: marker write failed: {e}', file=sys.stderr)
         if not wechat_sent:

--- a/scripts/harness/intraday_watchdog.py
+++ b/scripts/harness/intraday_watchdog.py
@@ -48,7 +48,7 @@ Exit 0 always (non-fatal cron); actions logged to logs/watchdog.jsonl.
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -62,6 +62,7 @@ import cron_heartbeat  # noqa: E402
 
 LOOP_THRESHOLD = 5         # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
 MARKER_FRESH_MS = 25 * 60 * 1000  # postflight send-marker older than this ⇒ treat as not-this-slot
+WATCHDOG_DELAY_MINUTES = 10
 
 
 def deterministic_fallback(raw_block, tag, reason):
@@ -69,6 +70,56 @@ def deterministic_fallback(raw_block, tag, reason):
     return (f'🧯 {tag} 确定性兜底（LLM {reason}）\n'
             '以下内容由 preflight 数据直接生成，未经过模型改写：\n\n'
             + raw_block.strip())
+
+
+def watchdog_target(market, now=None):
+    """Return the exact cron slot this watchdog invocation owns.
+
+    Watchdogs run ten minutes after each half-hour Mode 7 slot. Subtracting that
+    delay before applying the canonical slot mapping also handles midnight and a
+    modestly delayed system-cron invocation without selecting an adjacent run.
+    """
+    wall_now = now or datetime.now(HKT)
+    target_at = wall_now - timedelta(minutes=WATCHDOG_DELAY_MINUTES)
+    job_name, slot = cron_heartbeat.slot_for(market, target_at)
+    return wall_now, job_name, slot
+
+
+def run_for_slot(runs, market, job_name, slot):
+    """Select the newest completed run belonging to exactly ``job_name/slot``."""
+    matches = []
+    for run in runs:
+        run_at = run.get('runAtMs')
+        if not isinstance(run_at, (int, float)):
+            continue
+        run_dt = datetime.fromtimestamp(run_at / 1000, HKT)
+        if cron_heartbeat.slot_for(market, run_dt) == (job_name, slot):
+            matches.append(run)
+    return matches[-1] if matches else None
+
+
+def context_for_slot(path, job_name, slot):
+    """Load a preflight context only when its heartbeat identifies this slot."""
+    try:
+        context = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    heartbeat = context.get('heartbeat') or {}
+    if (heartbeat.get('job'), heartbeat.get('slot')) != (job_name, slot):
+        return None
+    return context
+
+
+def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms):
+    """Whether postflight confirmed Telegram delivery for this exact slot."""
+    if not isinstance(marker, dict) or not marker.get('tg_ok'):
+        return False
+    if (marker.get('job'), marker.get('slot')) != (job_name, slot):
+        return False
+    ts = marker.get('ts')
+    if not isinstance(ts, (int, float)) or now_ms - ts >= MARKER_FRESH_MS:
+        return False
+    return not raw_block_first or marker.get('first_line') == raw_block_first
 
 
 def main():
@@ -79,6 +130,12 @@ def main():
     args = ap.parse_args()
 
     tag = f'intraday-{args.market}'
+    watchdog_now, expected_job, expected_slot = watchdog_target(args.market)
+    if expected_job != args.job_name:
+        log({'tag': tag, 'action': 'skip', 'reason': 'watchdog invoked outside job window',
+             'expected_job': expected_job, 'configured_job': args.job_name,
+             'expected_slot': expected_slot})
+        return 0
 
     job_id = find_job_id(args.job_name)
     if not job_id:
@@ -89,30 +146,38 @@ def main():
     if not runs_today:
         log({'tag': tag, 'action': 'skip', 'reason': 'no run today yet'})
         return 0
-    last = runs_today[-1]
+    last = run_for_slot(runs_today, args.market, expected_job, expected_slot)
+    if not last:
+        log({'tag': tag, 'action': 'skip', 'reason': 'expected slot has no completed run',
+             'expected_job': expected_job, 'expected_slot': expected_slot})
+        return 0
     run_at = last.get('runAtMs')
     session_id = last.get('sessionId')
-    run_dt = (datetime.fromtimestamp(run_at / 1000, HKT)
-              if isinstance(run_at, (int, float)) else datetime.now(HKT))
-    heartbeat_job, heartbeat_slot = cron_heartbeat.slot_for(args.market, run_dt)
 
-    # Dedupe per slot (one re-send per intraday run, keyed by runAtMs).
-    flag = WS / 'memory' / '.tmp' / f'watchdog-{tag}-{run_at}.done'
+    # Dedupe by the schedule slot, not by retry attempt/runAtMs.
+    slot_key = datetime.fromisoformat(expected_slot).strftime('%Y%m%d-%H%M')
+    flag = WS / 'memory' / '.tmp' / f'watchdog-{tag}-{slot_key}.done'
     if flag.exists():
         log({'tag': tag, 'action': 'skip', 'reason': 'already handled this slot (dedupe flag)'})
         return 0
 
     # --- Generation gate: generated report or deterministic fallback ----------
     summary = last.get('summary', '')
-    raw_block = ''
-    raw_block_first = None
     ctx_path = WS / 'memory' / '.tmp' / f'intraday-context-{args.market}-latest.json'
-    if ctx_path.exists():
-        try:
-            raw_block = (json.loads(ctx_path.read_text()).get('raw_wechat_block') or '').strip()
-            raw_block_first = raw_block.splitlines()[0] if raw_block else None
-        except Exception:
-            pass
+    context = context_for_slot(ctx_path, expected_job, expected_slot)
+    if context is None:
+        cron_heartbeat.record(
+            args.market, 'watchdog_rejected', at=watchdog_now,
+            job_name=expected_job, slot=expected_slot,
+            watchdog_state='stale_context_rejected', telegram_sent=False,
+        )
+        log({'tag': tag, 'action': 'stale-backstop-rejected',
+             'reason': 'latest preflight context does not match expected slot',
+             'expected_job': expected_job, 'expected_slot': expected_slot,
+             'run_at': run_at})
+        return 0
+    raw_block = (context.get('raw_wechat_block') or '').strip()
+    raw_block_first = raw_block.splitlines()[0] if raw_block else None
     sent_via_tool = bool((last.get('delivery') or {}).get('messageToolSentTo'))
     block_present = bool(raw_block_first and raw_block_first in summary)
     delivered_clean = sent_via_tool or block_present
@@ -126,10 +191,10 @@ def main():
              'delivered_clean': delivered_clean, 'loop_score': loop_score, 'run_at': run_at,
              'target': KCN_TELEGRAM, 'out': tg_out})
         if tg_ok and not args.dry_run:
-            flag.write_text(datetime.now(HKT).isoformat())
+            flag.write_text(watchdog_now.isoformat())
             cron_heartbeat.record(
-                args.market, 'watchdog_backstop', at=run_dt,
-                job_name=heartbeat_job, slot=heartbeat_slot,
+                args.market, 'watchdog_backstop', at=watchdog_now,
+                job_name=expected_job, slot=expected_slot,
                 watchdog_state='deterministic_fallback', telegram_sent=True,
             )
         print(json.dumps({'tag': tag, 'deterministic_fallback': tg_ok,
@@ -152,17 +217,14 @@ def main():
             marker = json.loads(marker_path.read_text())
         except Exception:
             marker = None
-    now_ms = int(datetime.now(HKT).timestamp() * 1000)
-    fresh   = bool(marker) and (now_ms - marker.get('ts', 0)) < MARKER_FRESH_MS
-    # first_line guards against a stale marker from a previous slot; if we can't read
-    # the block, trust recency alone (avoid false-double).
-    matches = bool(marker) and (not raw_block_first or marker.get('first_line') == raw_block_first)
+    now_ms = int(watchdog_now.timestamp() * 1000)
     # TG is covered iff postflight's cosend confirmably delivered this report to
-    # Telegram this slot (fresh marker, matching first line, tg_ok=true).
-    if marker and marker.get('tg_ok') and fresh and matches:
+    # Telegram this exact slot (slot identity, freshness, first line, tg_ok=true).
+    if marker_covers_slot(
+            marker, expected_job, expected_slot, raw_block_first, now_ms):
         cron_heartbeat.record(
-            args.market, 'completed', at=run_dt,
-            job_name=heartbeat_job, slot=heartbeat_slot,
+            args.market, 'completed', at=watchdog_now,
+            job_name=expected_job, slot=expected_slot,
             watchdog_state='ok', telegram_sent=True,
         )
         log({'tag': tag, 'action': 'ok',
@@ -178,7 +240,7 @@ def main():
 
     reason = ('postflight marker missing' if not marker
               else 'postflight cosend failed' if not marker.get('tg_ok')
-              else 'marker stale/mismatch')
+              else 'marker slot stale/mismatch')
     tg_banner = f'📲 补投（{reason}，Telegram 兜底一份）\n\n'
     tg_ok, tg_out = send_telegram(KCN_TELEGRAM, tg_banner + report.strip(), args.dry_run)
     log({'tag': tag, 'action': 'mirror-telegram', 'dry_run': args.dry_run, 'sent_ok': tg_ok,
@@ -187,16 +249,16 @@ def main():
 
     # Slot handled once Telegram landed — don't keep retrying a report kcn has.
     if tg_ok and not args.dry_run:
-        flag.write_text(datetime.now(HKT).isoformat())
+        flag.write_text(watchdog_now.isoformat())
         cron_heartbeat.record(
-            args.market, 'watchdog_backstop', at=run_dt,
-            job_name=heartbeat_job, slot=heartbeat_slot,
+            args.market, 'watchdog_backstop', at=watchdog_now,
+            job_name=expected_job, slot=expected_slot,
             watchdog_state='telegram_mirror', telegram_sent=True,
         )
     elif not args.dry_run:
         cron_heartbeat.record(
-            args.market, 'watchdog_failed', at=run_dt,
-            job_name=heartbeat_job, slot=heartbeat_slot,
+            args.market, 'watchdog_failed', at=watchdog_now,
+            job_name=expected_job, slot=expected_slot,
             watchdog_state='telegram_mirror_failed', telegram_sent=False,
         )
 

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -1,0 +1,173 @@
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+
+HKT = ZoneInfo('Asia/Hong_Kong')
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
+
+
+def _ms(at):
+    return int(at.timestamp() * 1000)
+
+
+def _run(at, **extra):
+    return {'runAtMs': _ms(at), 'sessionId': f'session-{at:%H%M}', **extra}
+
+
+def test_watchdog_target_owns_the_slot_ten_minutes_earlier():
+    import intraday_watchdog as watchdog
+
+    now = datetime(2026, 7, 25, 0, 10, tzinfo=HKT)
+    wall, job, slot = watchdog.watchdog_target('us', now)
+
+    assert wall == now
+    assert job == '美股盘中盯盘-overnight'
+    assert slot == '2026-07-25T00:00:00+08:00'
+
+
+def test_hk_watchdog_runs_after_the_observed_long_turn_window():
+    contract = json.loads((ROOT / 'config' / 'cron-schedules.json').read_text())
+    job = next(item for item in contract['jobs'] if item['name'] == '盘中盯盘')
+
+    assert job['watchdog']['schedule'] == {
+        'kind': 'cron',
+        'expr': '10,40 10-11,14-15 * * 1-5',
+        'tz': 'Asia/Hong_Kong',
+    }
+
+
+def test_run_for_slot_rejects_the_latest_completed_prior_slot():
+    import intraday_watchdog as watchdog
+
+    prior = _run(datetime(2026, 7, 24, 10, 0, tzinfo=HKT))
+    expected = _run(datetime(2026, 7, 24, 10, 30, tzinfo=HKT))
+    runs = [prior, expected]
+
+    assert watchdog.run_for_slot(
+        runs, 'hk', '盘中盯盘', '2026-07-24T10:30:00+08:00') is expected
+    assert watchdog.run_for_slot(
+        [prior], 'hk', '盘中盯盘', '2026-07-24T10:30:00+08:00') is None
+
+
+def test_context_and_delivery_marker_must_match_the_exact_slot(tmp_path):
+    import intraday_watchdog as watchdog
+
+    current_slot = '2026-07-24T10:30:00+08:00'
+    path = tmp_path / 'context.json'
+    path.write_text(json.dumps({
+        'heartbeat': {'job': '盘中盯盘', 'slot': '2026-07-24T10:00:00+08:00'},
+        'raw_wechat_block': 'old block',
+    }))
+    marker = {
+        'ts': 1_000_000, 'tg_ok': True, 'first_line': 'same heading',
+        'job': '盘中盯盘', 'slot': '2026-07-24T10:00:00+08:00',
+    }
+
+    assert watchdog.context_for_slot(path, '盘中盯盘', current_slot) is None
+    assert not watchdog.marker_covers_slot(
+        marker, '盘中盯盘', current_slot, 'same heading', 1_000_100)
+
+
+def test_postflight_delivery_marker_carries_preflight_slot_identity():
+    import intraday_postflight as postflight
+
+    marker = postflight.delivery_marker_payload(
+        {
+            'heartbeat': {
+                'job': '盘中盯盘',
+                'slot': '2026-07-24T10:30:00+08:00',
+            },
+        },
+        ts=1_000_000,
+        sent_ok=True,
+        tg_ok=True,
+        first_line='current block',
+        market='hk',
+        out='ok',
+    )
+
+    assert marker['job'] == '盘中盯盘'
+    assert marker['slot'] == '2026-07-24T10:30:00+08:00'
+
+
+def test_main_does_not_assess_a_prior_completed_run(
+        tmp_path, monkeypatch):
+    import intraday_watchdog as watchdog
+
+    now = datetime(2026, 7, 24, 10, 40, tzinfo=HKT)
+    prior = _run(
+        datetime(2026, 7, 24, 10, 0, tzinfo=HKT),
+        summary='shared heading',
+        delivery={'messageToolSentTo': ['telegram']},
+    )
+    sent = []
+    recorded = []
+    events = []
+
+    monkeypatch.setattr(watchdog, 'WS', tmp_path)
+    monkeypatch.setattr(watchdog, 'watchdog_target',
+                        lambda market: (now, '盘中盯盘',
+                                        '2026-07-24T10:30:00+08:00'))
+    monkeypatch.setattr(watchdog, 'find_job_id', lambda name: 'job-hk')
+    monkeypatch.setattr(watchdog, 'today_runs', lambda job_id: [prior])
+    monkeypatch.setattr(watchdog, 'send_telegram',
+                        lambda *args: sent.append(args) or (True, 'ok'))
+    monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
+                        lambda *args, **kwargs: recorded.append((args, kwargs)))
+    monkeypatch.setattr(watchdog, 'log', events.append)
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['intraday_watchdog.py', '--job-name', '盘中盯盘', '--market', 'hk'],
+    )
+
+    assert watchdog.main() == 0
+    assert sent == []
+    assert recorded == []
+    assert events[-1]['reason'] == 'expected slot has no completed run'
+    assert events[-1]['expected_slot'] == '2026-07-24T10:30:00+08:00'
+
+
+def test_main_rejects_mismatched_context_and_uses_wall_clock_for_heartbeat(
+        tmp_path, monkeypatch):
+    import intraday_watchdog as watchdog
+
+    now = datetime(2026, 7, 24, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 24, 10, 30, tzinfo=HKT))
+    context_dir = tmp_path / 'memory' / '.tmp'
+    context_dir.mkdir(parents=True)
+    (context_dir / 'intraday-context-hk-latest.json').write_text(json.dumps({
+        'heartbeat': {'job': '盘中盯盘', 'slot': '2026-07-24T10:00:00+08:00'},
+        'raw_wechat_block': 'old block',
+    }))
+    recorded = []
+
+    monkeypatch.setattr(watchdog, 'WS', tmp_path)
+    monkeypatch.setattr(watchdog, 'watchdog_target',
+                        lambda market: (now, '盘中盯盘',
+                                        '2026-07-24T10:30:00+08:00'))
+    monkeypatch.setattr(watchdog, 'find_job_id', lambda name: 'job-hk')
+    monkeypatch.setattr(watchdog, 'today_runs', lambda job_id: [run])
+    monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
+                        lambda *args, **kwargs: recorded.append((args, kwargs)))
+    monkeypatch.setattr(watchdog, 'log', lambda event: None)
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['intraday_watchdog.py', '--job-name', '盘中盯盘', '--market', 'hk'],
+    )
+
+    assert watchdog.main() == 0
+    assert recorded == [(
+        ('hk', 'watchdog_rejected'),
+        {
+            'at': now,
+            'job_name': '盘中盯盘',
+            'slot': '2026-07-24T10:30:00+08:00',
+            'watchdog_state': 'stale_context_rejected',
+            'telegram_sent': False,
+        },
+    )]


### PR DESCRIPTION
Intraday watchdog 现在只评估其应负责的半小时时隙，并要求 run、preflight context 和 Telegram delivery marker 三者时隙一致。HK watchdog 延后至每档 +10 分钟，超过本周观测到的最长 493 秒运行时间。旧时隙或错配 context 会明确记录为 rejected，不再覆盖当前健康状态形成假绿。

**Category:** observability

**Tests:** pytest_passed=True — 新增 7 个离线测试，覆盖目标时隙计算、跨午夜、延后调度、精确 run/context/delivery-marker 匹配及 watchdog 墙钟归因。变异验证中临时恢复“取最新完成 run”的旧行为，2 个测试如期变红；恢复后全套 576 passed、5 xfailed。

**⚠️ NEEDS HUMAN REVIEW:** 合并后需将 live HK watchdog crontab 从 +4/+34 分钟同步为 +10/+40，并观察首个交易时隙。新逻辑在目标 run 尚未完成或 context 不匹配时 fail closed，不再用上一时隙制造假绿。

**Files:** scripts/harness/intraday_watchdog.py, scripts/harness/intraday_postflight.py, config/cron-schedules.json, CRON_SCHEDULES.md, tests/test_intraday_watchdog_slots.py

---
_Autonomous overnight iteration (salvaged after a driver push-hook/reflog bug). Stacked on #37 (hermetic-test-suite) — merge #37 first. Human merge required; CI is the gate._