### PR TITLE
fix: make brief miss recovery durable

### DIFF
--- a/scripts/harness/brief_watchdog.py
+++ b/scripts/harness/brief_watchdog.py
@@ -43,6 +43,7 @@ Usage: brief_watchdog.py [--check-missing] [--dry-run]
 """
 import argparse
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -54,6 +55,8 @@ from _watchdog_common import (  # noqa: E402
 )
 
 MARKER_FRESH_MS = 30 * 60 * 1000  # postflight send-marker older than this ⇒ not this slot
+MISSING_STATE_VERSION = 1
+NOTIFICATION_ATTEMPTS_PER_RUN = 2
 
 
 def inspect_brief_artifacts(today):
@@ -85,6 +88,53 @@ def inspect_brief_artifacts(today):
     return issues
 
 
+def missing_state_path(today):
+    return WS / 'memory' / '.tmp' / f'watchdog-brief-missing-{today}.json'
+
+
+def load_missing_state(today):
+    """Load durable 09:05 recovery state without risking a duplicate dispatch."""
+    path = missing_state_path(today)
+    base = {
+        'schema_version': MISSING_STATE_VERSION,
+        'date': today,
+        'issues': [],
+        'fallback_dispatch_attempted': False,
+        'fallback_dispatch_succeeded': False,
+        'dispatch_attempted_at': None,
+        'dispatch_out': None,
+        'notification_attempts': 0,
+        'notification_succeeded': False,
+        'notification_last_attempt_at': None,
+        'notification_out': None,
+    }
+    if not path.exists():
+        return base
+    try:
+        stored = json.loads(path.read_text())
+        if not isinstance(stored, dict) or stored.get('schema_version') != MISSING_STATE_VERSION:
+            raise ValueError('unsupported recovery-state schema')
+        return {**base, **stored}
+    except Exception as e:
+        # The dispatch may already have happened before a torn/corrupt state was
+        # observed. Fail safe against firing a second off-host workflow; the
+        # notification remains retryable and reports the corrupt state.
+        return {
+            **base,
+            'fallback_dispatch_attempted': True,
+            'state_error': f'{type(e).__name__}: {e}',
+        }
+
+
+def write_missing_state(today, state):
+    """Atomically persist recovery state before notification is attempted."""
+    path = missing_state_path(today)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f'.{path.name}.{os.getpid()}.tmp')
+    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2) + '\n')
+    tmp.replace(path)
+
+
 def alert_brief_missing(today, dry_run, issues=None):
     """09:05 HKT: landing artifacts are incomplete ⇒ page kcn + self-heal.
 
@@ -100,7 +150,30 @@ def alert_brief_missing(today, dry_run, issues=None):
         log({'tag': 'brief', 'action': 'skip', 'reason': 'brief-missing already handled today'})
         return 0
 
-    dispatched, out = dispatch_brief_fallback(dry_run)
+    state = load_missing_state(today)
+    if state.get('notification_succeeded'):
+        log({'tag': 'brief', 'action': 'skip',
+             'reason': 'brief-missing notification already succeeded today',
+             'recovery_state': state})
+        return 0
+
+    state['issues'] = list(issues)
+    if not state.get('fallback_dispatch_attempted'):
+        dispatched, out = dispatch_brief_fallback(dry_run)
+        state.update({
+            'fallback_dispatch_attempted': True,
+            'fallback_dispatch_succeeded': bool(dispatched),
+            'dispatch_attempted_at': datetime.now(HKT).isoformat(),
+            'dispatch_out': out,
+        })
+        # This ordering is the core invariant: a Telegram timeout must never
+        # erase the fact that the off-host fallback was already fired.
+        if not dry_run:
+            write_missing_state(today, state)
+    else:
+        dispatched = bool(state.get('fallback_dispatch_succeeded'))
+        out = state.get('dispatch_out') or '(prior dispatch attempt; outcome unavailable)'
+
     labels = {
         'brief_missing': f'brief 缺失：memory/{today}-pre-open.md 不存在',
         'plan_missing': f'plan 缺失：memory/{today}-plan.json 不存在',
@@ -117,11 +190,27 @@ def alert_brief_missing(today, dry_run, issues=None):
         + f'\n查因：openclaw cron runs --id $(openclaw cron list | grep 盘前深度简报) '
           f'/ sar -q 看 08:00 起的 blocked'
     )
-    tg_ok, tg_out = send_telegram(KCN_TELEGRAM, alert, dry_run)
+
+    tg_ok, tg_out = False, ''
+    for _ in range(NOTIFICATION_ATTEMPTS_PER_RUN):
+        try:
+            tg_ok, tg_out = send_telegram(KCN_TELEGRAM, alert, dry_run)
+        except Exception as e:
+            tg_ok, tg_out = False, f'{type(e).__name__}: {e}'[:300]
+        state['notification_attempts'] = int(state.get('notification_attempts') or 0) + 1
+        state['notification_succeeded'] = bool(tg_ok)
+        state['notification_last_attempt_at'] = datetime.now(HKT).isoformat()
+        state['notification_out'] = tg_out
+        if not dry_run:
+            write_missing_state(today, state)
+        if tg_ok:
+            break
+
     log({'tag': 'brief', 'action': 'alert-brief-missing', 'dry_run': dry_run,
          'issues': issues,
          'dispatched_fallback': dispatched, 'dispatch_out': out,
-         'sent_ok': tg_ok, 'target': KCN_TELEGRAM, 'out': tg_out})
+         'sent_ok': tg_ok, 'target': KCN_TELEGRAM, 'out': tg_out,
+         'recovery_state': state})
     if tg_ok and not dry_run:
         flag.parent.mkdir(parents=True, exist_ok=True)
         flag.write_text(datetime.now(HKT).isoformat())

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import subprocess
 import sys
 
 
@@ -67,3 +68,112 @@ def test_missing_alert_dispatches_only_once_after_success(tmp_path, monkeypatch)
     assert watchdog.alert_brief_missing(TODAY, False, issues) == 0
     assert watchdog.alert_brief_missing(TODAY, False, issues) == 0
     assert calls == {"dispatch": 1, "send": 1}
+
+
+def test_dispatch_state_is_persisted_before_notification_and_timeout_is_retried(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    calls = {"dispatch": 0, "send": 0}
+
+    def dispatch(_dry_run):
+        calls["dispatch"] += 1
+        return True, "workflow queued"
+
+    def send(_target, _message, _dry_run):
+        calls["send"] += 1
+        state = json.loads(watchdog.missing_state_path(TODAY).read_text())
+        assert state["fallback_dispatch_attempted"] is True
+        assert state["fallback_dispatch_succeeded"] is True
+        if calls["send"] == 1:
+            raise subprocess.TimeoutExpired(["openclaw", "message", "send"], 60)
+        return True, "telegram delivered"
+
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", dispatch)
+    monkeypatch.setattr(watchdog, "send_telegram", send)
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+    state = json.loads(watchdog.missing_state_path(TODAY).read_text())
+    assert calls == {"dispatch": 1, "send": 2}
+    assert state["notification_attempts"] == 2
+    assert state["notification_succeeded"] is True
+    assert "telegram delivered" in state["notification_out"]
+
+
+def test_failed_notification_can_retry_later_without_redispatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    calls = {"dispatch": 0, "send": 0}
+
+    def dispatch(_dry_run):
+        calls["dispatch"] += 1
+        return True, "workflow queued"
+
+    def send_fails(_target, _message, _dry_run):
+        calls["send"] += 1
+        return False, "telegram unavailable"
+
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", dispatch)
+    monkeypatch.setattr(watchdog, "send_telegram", send_fails)
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["plan_missing"]) == 0
+    assert calls == {"dispatch": 1, "send": 2}
+    state = json.loads(watchdog.missing_state_path(TODAY).read_text())
+    assert state["fallback_dispatch_succeeded"] is True
+    assert state["notification_succeeded"] is False
+
+    monkeypatch.setattr(
+        watchdog, "send_telegram",
+        lambda *_args: calls.__setitem__("send", calls["send"] + 1) or (True, "ok"),
+    )
+    assert watchdog.alert_brief_missing(TODAY, False, ["plan_missing"]) == 0
+    assert calls == {"dispatch": 1, "send": 3}
+    state = json.loads(watchdog.missing_state_path(TODAY).read_text())
+    assert state["notification_attempts"] == 3
+    assert state["notification_succeeded"] is True
+
+
+def test_dry_run_does_not_poison_recovery_state_or_dedupe(tmp_path, monkeypatch):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(
+        watchdog, "dispatch_brief_fallback", lambda _dry_run: (True, "dry dispatch")
+    )
+    monkeypatch.setattr(
+        watchdog, "send_telegram", lambda *_args: (True, "dry telegram")
+    )
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+
+    assert watchdog.alert_brief_missing(TODAY, True, ["brief_missing"]) == 0
+    assert not watchdog.missing_state_path(TODAY).exists()
+    assert not (
+        tmp_path / "memory" / ".tmp" / f"watchdog-brief-missing-{TODAY}.done"
+    ).exists()
+
+
+def test_corrupt_state_suppresses_duplicate_dispatch_but_still_notifies(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    path = watchdog.missing_state_path(TODAY)
+    path.parent.mkdir(parents=True)
+    path.write_text("{bad json")
+    calls = {"dispatch": 0, "send": 0}
+    monkeypatch.setattr(
+        watchdog,
+        "dispatch_brief_fallback",
+        lambda _dry_run: calls.__setitem__("dispatch", calls["dispatch"] + 1)
+        or (True, "should not run"),
+    )
+    monkeypatch.setattr(
+        watchdog,
+        "send_telegram",
+        lambda *_args: calls.__setitem__("send", calls["send"] + 1) or (True, "ok"),
+    )
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+    assert calls == {"dispatch": 0, "send": 1}
+    state = json.loads(path.read_text())
+    assert state["fallback_dispatch_attempted"] is True
+    assert "state_error" in state


### PR DESCRIPTION
Closes #50

## Summary
- persist fallback dispatch outcome before attempting Telegram notification
- retry notification independently without redispatching the off-host workflow
- catch notification timeouts and preserve durable recovery diagnostics
- keep dry-run side-effect free and fail safe on corrupt recovery state

## Validation
- `python3 -m pytest -q tests/test_brief_watchdog.py` (8 passed)
- `python3 -m pytest -q` (580 passed, 5 xfailed)
- `git diff --check`