### PR TITLE
fix: read cron state from live SQLite

### DIFF
--- a/check_crons.sh
+++ b/check_crons.sh
@@ -7,8 +7,10 @@
 #   ./check_crons.sh --status error  # only failures
 #   ./check_crons.sh --kind cron     # only auto-scheduled
 #   ./check_crons.sh --full          # no summary truncation
+#   ./check_crons.sh --openclaw-backend sqlite  # read live state without gateway
 #   ./check_crons.sh --timeline      # merged forward SCHEDULE (openclaw+GHA+crontab, HKT)
-#   ./check_crons.sh --timeline --source gha   # one scheduler only
+#   ./check_crons.sh --timeline --source gha    # one scheduler only
+#   ./check_crons.sh --timeline --openclaw-backend sqlite
 DIR="$(dirname "$0")/scripts/data"
 if [ "$1" = "--timeline" ]; then
   shift

--- a/scripts/data/cron_runs.py
+++ b/scripts/data/cron_runs.py
@@ -23,16 +23,19 @@ from pathlib import Path
 # Storage-agnostic cron readers (6.1 moved jobs.json/runs/*.jsonl into SQLite —
 # direct file reads silently return nothing). Same layer the watchdogs use.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'harness'))
-from _watchdog_common import load_jobs, read_runs  # noqa: E402
+import _watchdog_common as watchdog_common  # noqa: E402
 
 CRON_DIR = Path.home() / '.openclaw' / 'cron'
 RUNS_DIR = CRON_DIR / 'runs'
 HKT = timezone(timedelta(hours=8))
 
 
-def load_job_map():
+def load_job_map(backend='auto'):
     try:
-        return {j['id']: j.get('name', j['id'][:8]) for j in load_jobs()}
+        return {
+            j['id']: j.get('name', j['id'][:8])
+            for j in watchdog_common.load_jobs(backend)
+        }
     except Exception:
         return {}
 
@@ -42,12 +45,12 @@ def kind_of(entry):
     return 'manual' if rid.startswith('manual:') else 'cron'
 
 
-def load_entries(kind_filter, job_id_filter, status_filter, job_map):
+def load_entries(kind_filter, job_id_filter, status_filter, job_map, backend='auto'):
     out = []
     for job_id in sorted(job_map):
         if job_id_filter and job_id not in job_id_filter:
             continue
-        for d in read_runs(job_id):   # CLI(SQLite) primary, .jsonl[.migrated] fallback
+        for d in watchdog_common.read_runs(job_id, backend):
             if status_filter and d.get('status') != status_filter:
                 continue
             k = kind_of(d)
@@ -95,11 +98,22 @@ def main():
     p.add_argument('--kind', choices=['cron', 'manual', 'both'], default='both')
     p.add_argument('--full', action='store_true', help='no summary truncation')
     p.add_argument('--json', action='store_true', help='emit JSON instead of table')
+    p.add_argument(
+        '--openclaw-backend',
+        choices=['auto', 'cli', 'sqlite', 'fossil'],
+        default='auto',
+        help='state backend (sqlite is read-only and does not require the gateway)',
+    )
     args = p.parse_args()
 
-    jobs = load_job_map()
+    jobs = load_job_map(args.openclaw_backend)
     if not jobs:
-        print('❌ no cron jobs visible (openclaw CLI unavailable?)', file=sys.stderr)
+        print('❌ no live cron jobs visible (OpenClaw CLI/SQLite unavailable)',
+              file=sys.stderr)
+        return 2
+    if watchdog_common.LAST_LOAD_SOURCE == 'fossil':
+        print('❌ refusing stale pre-6.1 job metadata; use live CLI or SQLite',
+              file=sys.stderr)
         return 2
     job_id_filter = None
     if args.job:
@@ -110,7 +124,13 @@ def main():
                   ', '.join(sorted(jobs.values())), file=sys.stderr)
             return 2
 
-    entries = load_entries(args.kind, job_id_filter, args.status, jobs)[: args.n]
+    entries = load_entries(
+        args.kind, job_id_filter, args.status, jobs, args.openclaw_backend
+    )[: args.n]
+    if watchdog_common.LAST_RUNS_SOURCE == 'fossil':
+        print('❌ refusing stale pre-6.1 run history; use live CLI or SQLite',
+              file=sys.stderr)
+        return 2
 
     if args.json:
         slim = [{

--- a/scripts/data/cron_timeline.py
+++ b/scripts/data/cron_timeline.py
@@ -143,16 +143,22 @@ def sort_key(mins, hours):
 
 # ── source loaders ──────────────────────────────────────────────────────────
 
-def load_openclaw():
+LAST_OPENCLAW_SOURCE = None
+
+
+def load_openclaw(backend='auto'):
+    global LAST_OPENCLAW_SOURCE
     rows = []
     try:
         # 6.1 moved cron storage into SQLite — read via the storage-agnostic CLI
         # layer (the dead jobs.json silently returned [] and dropped all 11
         # openclaw jobs from the timeline, found 2026-06-10).
         sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'harness'))
-        from _watchdog_common import load_jobs
-        jobs = load_jobs()
+        import _watchdog_common as watchdog_common
+        jobs = watchdog_common.load_jobs(backend)
+        LAST_OPENCLAW_SOURCE = watchdog_common.LAST_LOAD_SOURCE
     except Exception:
+        LAST_OPENCLAW_SOURCE = 'empty'
         return rows
     for j in jobs:
         sch = j.get('schedule') or {}
@@ -253,12 +259,18 @@ TAG = {'openclaw': '🦞 openclaw', 'gha': '🐙 GH Action', 'crontab': '🛡 cr
 def main():
     p = argparse.ArgumentParser(description='Merged HKT schedule timeline (openclaw + GHA + crontab)')
     p.add_argument('--source', choices=['openclaw', 'gha', 'crontab', 'all'], default='all')
+    p.add_argument(
+        '--openclaw-backend',
+        choices=['auto', 'cli', 'sqlite', 'fossil'],
+        default='auto',
+        help='OpenClaw state backend (sqlite is a read-only gateway-independent view)',
+    )
     p.add_argument('--json', action='store_true')
     args = p.parse_args()
 
     rows = []
     if args.source in ('all', 'openclaw'):
-        rows += load_openclaw()
+        rows += load_openclaw(args.openclaw_backend)
     if args.source in ('all', 'gha'):
         rows += load_gha()
     if args.source in ('all', 'crontab'):
@@ -271,6 +283,11 @@ def main():
             'source': r[0], 'name': r[1], 'expr': r[2], 'tz': r[3],
             'hkt_time': time_label(r[4], r[5]), 'hkt_days': days_label(r[6]),
         } for r in rows], ensure_ascii=False, indent=2))
+        if LAST_OPENCLAW_SOURCE in {'fossil', 'empty'}:
+            detail = ('stale pre-6.1 fossil' if LAST_OPENCLAW_SOURCE == 'fossil'
+                      else 'no live CLI/SQLite state')
+            print(f'error: OpenClaw schedule unavailable ({detail})', file=sys.stderr)
+            return 2
         return 0
 
     print('📆 合并调度时间线（全部归一到 HKT，按当日触发时刻排序）')
@@ -286,6 +303,13 @@ def main():
         print(f'{vpad(time_label(mins, hours), 22)}  {vpad(TAG[src], 12)}  '
               f'{vpad(name, 22)}  {vpad(days_label(dow), 12)}  {expr}')
     print(f'\n共 {len(rows)} 个调度项。GH Action cron 是 UTC，已 +8h 折算并修正跨日星期。')
+    if LAST_OPENCLAW_SOURCE in {'fossil', 'empty'}:
+        detail = ('rows came from a stale pre-6.1 fossil'
+                  if LAST_OPENCLAW_SOURCE == 'fossil'
+                  else 'live CLI and SQLite state were both unavailable')
+        print(f'❌ OpenClaw schedule unavailable: {detail}; '
+              'contract/model/delivery inspection is invalid.', file=sys.stderr)
+        return 2
     return 0
 
 

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -17,6 +17,7 @@ session transcript. transcript_loop_score detects that directly and cleanly
 (observed: looped run score≈7 on a 97KB assistant blob; clean run score≈2 on 3KB).
 """
 import json
+import sqlite3
 import subprocess
 import sys
 from collections import Counter
@@ -27,6 +28,7 @@ WS = Path(__file__).resolve().parents[2]
 OC = Path('/root/.openclaw')
 RUNS_DIR = OC / 'cron' / 'runs'
 JOBS_JSON = OC / 'cron' / 'jobs.json'
+STATE_DB = OC / 'state' / 'openclaw.sqlite'
 SESSIONS_DIR = OC / 'agents' / 'main' / 'sessions'
 LOG = WS / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
@@ -67,32 +69,102 @@ def _cron_cli_json(cli_args):
 
 # Set by load_jobs() to record which source served the last call:
 #   'cli'    — live gateway (authoritative for payload/model/delivery)
+#   'sqlite' — live read-only state DB (authoritative, independent of gateway/temp dir)
 #   'fossil' — pre-6.1 jobs.json[.migrated] (STALE for payload — schedule only)
 #   'empty'  — nothing readable
 # Callers that assert on live payload state (e.g. the cron-contract check) MUST
 # consult this and refuse to report failures off a fossil.
 LAST_LOAD_SOURCE = None
+LAST_RUNS_SOURCE = None
 
 
-def load_jobs():
-    # Primary: CLI (works on 6.1 SQLite). Fallback: pre-migration jobs.json[.migrated].
-    global LAST_LOAD_SOURCE
-    d = _cron_cli_json(['list', '--json'])
-    if isinstance(d, dict) and isinstance(d.get('jobs'), list):
-        LAST_LOAD_SOURCE = 'cli'
-        return d['jobs']
-    # CLI unreadable (gateway slow/unreachable). The fallback files are 6.1-era
-    # fossils — fine for schedule shape, but STALE for model/delivery/message.
-    # Surface loudly so no caller mistakes fossil state for live state.
+def _open_state_db():
+    """Open the OpenClaw state DB read-only, including its live WAL."""
+    return sqlite3.connect(f'file:{STATE_DB}?mode=ro', uri=True, timeout=5)
+
+
+def _sqlite_store_key(conn):
+    row = conn.execute(
+        'SELECT store_key FROM cron_jobs '
+        'GROUP BY store_key ORDER BY MAX(updated_at) DESC LIMIT 1'
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _sqlite_jobs():
+    """Return live cron jobs from SQLite, or None when the DB/schema is unreadable."""
+    try:
+        with _open_state_db() as conn:
+            conn.execute('PRAGMA query_only = ON')
+            store_key = _sqlite_store_key(conn)
+            if store_key is None:
+                return []
+            rows = conn.execute(
+                'SELECT job_json, state_json FROM cron_jobs '
+                'WHERE store_key = ? ORDER BY sort_order, job_id',
+                (store_key,),
+            ).fetchall()
+        jobs = []
+        for raw_job, raw_state in rows:
+            job = json.loads(raw_job)
+            state = json.loads(raw_state or '{}')
+            if not isinstance(job, dict) or not isinstance(state, dict):
+                raise ValueError('cron SQLite row is not a JSON object')
+            # Runtime state is maintained separately from the declarative job
+            # JSON. Merge it so callers see the same current view as the CLI.
+            job['state'] = {**(job.get('state') or {}), **state}
+            jobs.append(job)
+        return jobs
+    except Exception:
+        return None
+
+
+def _fossil_jobs():
     for p in (JOBS_JSON, JOBS_JSON.with_suffix('.json.migrated')):
         try:
             data = json.loads(p.read_text())
-            LAST_LOAD_SOURCE = 'fossil'
-            print(f'warn: cron CLI unreadable; falling back to STALE {p.name} '
+            jobs = data if isinstance(data, list) else data.get('jobs', data.get('items', []))
+            if not isinstance(jobs, list):
+                continue
+            print(f'warn: live cron state unreadable; falling back to STALE {p.name} '
                   '(pre-6.1 fossil — do not trust model/delivery/message)', file=sys.stderr)
-            return data if isinstance(data, list) else data.get('jobs', data.get('items', []))
+            return jobs
         except Exception:
             continue
+    return None
+
+
+def load_jobs(source='auto'):
+    """Load cron jobs from auto|cli|sqlite|fossil.
+
+    Auto prefers the public CLI, then the same live SQLite state read-only. The
+    pre-6.1 JSON is retained only for watchdog compatibility and is explicitly
+    marked stale; contract/operator tools must reject it.
+    """
+    global LAST_LOAD_SOURCE
+    if source not in {'auto', 'cli', 'sqlite', 'fossil'}:
+        raise ValueError(f'unsupported cron source: {source}')
+    if source in {'auto', 'cli'}:
+        d = _cron_cli_json(['list', '--json'])
+        if isinstance(d, dict) and isinstance(d.get('jobs'), list):
+            LAST_LOAD_SOURCE = 'cli'
+            return d['jobs']
+        if source == 'cli':
+            LAST_LOAD_SOURCE = 'empty'
+            return []
+    if source in {'auto', 'sqlite'}:
+        jobs = _sqlite_jobs()
+        if jobs is not None:
+            LAST_LOAD_SOURCE = 'sqlite'
+            return jobs
+        if source == 'sqlite':
+            LAST_LOAD_SOURCE = 'empty'
+            return []
+    if source in {'auto', 'fossil'}:
+        jobs = _fossil_jobs()
+        if jobs is not None:
+            LAST_LOAD_SOURCE = 'fossil'
+            return jobs
     LAST_LOAD_SOURCE = 'empty'
     return []
 
@@ -104,15 +176,28 @@ def find_job_id(job_name):
     return None
 
 
-def read_runs(job_id):
-    """Finished-run records for a job, OLDEST→NEWEST (so callers' [-1] = newest).
-    Primary: `openclaw cron runs` CLI (SQLite-backed on 6.1). Fallback: the old
-    per-job JSONL (now *.jsonl.migrated after the 6.1 migration)."""
-    d = _cron_cli_json(['runs', '--id', job_id])
-    if isinstance(d, dict) and isinstance(d.get('entries'), list):
-        finished = [e for e in d['entries'] if e.get('action') in (None, 'finished')]
-        # CLI returns newest-first; reverse to match the old append-order contract.
-        return list(reversed(finished))
+def _sqlite_runs(job_id):
+    """Return one job's finished runs oldest→newest, or None if SQLite is unreadable."""
+    try:
+        with _open_state_db() as conn:
+            conn.execute('PRAGMA query_only = ON')
+            store_key = _sqlite_store_key(conn)
+            if store_key is None:
+                return []
+            rows = conn.execute(
+                'SELECT entry_json FROM cron_run_logs '
+                'WHERE store_key = ? AND job_id = ? ORDER BY ts, seq',
+                (store_key, job_id),
+            ).fetchall()
+        entries = [json.loads(row[0]) for row in rows]
+        if not all(isinstance(entry, dict) for entry in entries):
+            raise ValueError('cron run SQLite row is not a JSON object')
+        return [entry for entry in entries if entry.get('action') in (None, 'finished')]
+    except Exception:
+        return None
+
+
+def _fossil_runs(job_id):
     out = []
     for cand in (RUNS_DIR / f'{job_id}.jsonl', RUNS_DIR / f'{job_id}.jsonl.migrated'):
         if not cand.exists():
@@ -125,8 +210,43 @@ def read_runs(job_id):
                 out.append(json.loads(line))
             except Exception:
                 continue
-        break
-    return out
+        return out
+    return None
+
+
+def read_runs(job_id, source='auto'):
+    """Finished-run records for a job, OLDEST→NEWEST (so callers' [-1] = newest).
+    Auto uses CLI → read-only SQLite → migrated JSONL fossil."""
+    global LAST_RUNS_SOURCE
+    if source not in {'auto', 'cli', 'sqlite', 'fossil'}:
+        raise ValueError(f'unsupported cron source: {source}')
+    if source in {'auto', 'cli'}:
+        d = _cron_cli_json(['runs', '--id', job_id])
+        if isinstance(d, dict) and isinstance(d.get('entries'), list):
+            finished = [e for e in d['entries'] if e.get('action') in (None, 'finished')]
+            LAST_RUNS_SOURCE = 'cli'
+            # CLI returns newest-first; reverse to match the old append-order contract.
+            return list(reversed(finished))
+        if source == 'cli':
+            LAST_RUNS_SOURCE = 'empty'
+            return []
+    if source in {'auto', 'sqlite'}:
+        entries = _sqlite_runs(job_id)
+        if entries is not None:
+            LAST_RUNS_SOURCE = 'sqlite'
+            return entries
+        if source == 'sqlite':
+            LAST_RUNS_SOURCE = 'empty'
+            return []
+    if source in {'auto', 'fossil'}:
+        entries = _fossil_runs(job_id)
+        if entries is not None:
+            LAST_RUNS_SOURCE = 'fossil'
+            print(f'warn: live cron runs unreadable; using STALE migrated JSONL '
+                  f'for {job_id}', file=sys.stderr)
+            return entries
+    LAST_RUNS_SOURCE = 'empty'
+    return []
 
 
 def is_today_hkt(ts_ms):

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -384,9 +384,9 @@ def check_cron_paths_exist(r):
     """Live cron schedules match the tracked contract and payload scripts exist.
 
     6.1 migrated cron storage from cron/jobs.json into state/openclaw.sqlite, so
-    direct file reads silently return nothing. Read via _watchdog_common.load_jobs
-    (storage-agnostic: CLI `cron list --json` primary, pre-migration files fallback)
-    — the same path the watchdogs were fixed to use on 2026-06-04.
+    direct file reads silently return nothing. Read via _watchdog_common.load_jobs:
+    CLI first, then the live SQLite DB read-only, with pre-migration files kept
+    only as an explicitly rejected last-resort fossil.
     """
     import re
     sys.path.insert(0, str(WS / 'scripts' / 'harness'))
@@ -405,14 +405,12 @@ def check_cron_paths_exist(r):
             r.add('cron paths', WARNING, 'openclaw CLI returned 0 cron jobs (storage regression? run doctor --fix)')
         return
     if getattr(wc, 'LAST_LOAD_SOURCE', None) == 'fossil':
-        # The live gateway was unreadable (slow/timeout) and load_jobs() served a
-        # pre-6.1 fossil that is STALE for model/delivery/message. Asserting the
-        # payload contract against it produces phantom CRITICALs that block every
-        # push (2026-07-18 incident). Report a WARNING and skip the assertion —
-        # a stale view must never fail the gate as if it were live.
-        r.add('cron runtime contract', WARNING,
-              'cron CLI unreadable (gateway slow?) — jobs came from a stale fallback; '
-              'skipping contract assertion, re-run when the gateway responds')
+        # Both live sources were unreadable and load_jobs() served a pre-6.1
+        # fossil that is STALE for model/delivery/message. Refuse validation:
+        # passing or failing the payload contract against this view is a lie.
+        r.add('cron runtime contract', CRITICAL,
+              'live CLI + SQLite unreadable — jobs came from a stale pre-6.1 fossil; '
+              'contract validation refused')
         return
 
     try:

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "harness"))
+
+import _watchdog_common as common  # noqa: E402
+
+
+def _make_state_db(path):
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE cron_jobs (
+                store_key TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                job_json TEXT NOT NULL,
+                state_json TEXT NOT NULL,
+                sort_order INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+            CREATE TABLE cron_run_logs (
+                store_key TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                ts INTEGER NOT NULL,
+                entry_json TEXT NOT NULL
+            );
+            """
+        )
+        job = {
+            "id": "job-1",
+            "name": "live job",
+            "enabled": True,
+            "schedule": {"kind": "cron", "expr": "0 8 * * 1-5"},
+            "payload": {"model": "provider/current"},
+            "state": {"lastRunStatus": "old"},
+        }
+        state = {"lastRunStatus": "ok", "nextRunAtMs": 2000}
+        conn.execute(
+            "INSERT INTO cron_jobs VALUES (?, ?, ?, ?, ?, ?)",
+            ("store", "job-1", json.dumps(job), json.dumps(state), 0, 1),
+        )
+        for seq, ts, status in ((2, 200, "ok"), (1, 100, "error")):
+            entry = {
+                "jobId": "job-1",
+                "ts": ts,
+                "status": status,
+                "action": "finished",
+            }
+            conn.execute(
+                "INSERT INTO cron_run_logs VALUES (?, ?, ?, ?, ?)",
+                ("store", "job-1", seq, ts, json.dumps(entry)),
+            )
+
+
+def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
+    db = tmp_path / "openclaw.sqlite"
+    _make_state_db(db)
+    monkeypatch.setattr(common, "STATE_DB", db)
+    monkeypatch.setattr(common, "JOBS_JSON", tmp_path / "jobs.json")
+    monkeypatch.setattr(common, "_cron_cli_json", lambda _args: None)
+
+    jobs = common.load_jobs()
+
+    assert common.LAST_LOAD_SOURCE == "sqlite"
+    assert [job["name"] for job in jobs] == ["live job"]
+    assert jobs[0]["payload"]["model"] == "provider/current"
+    assert jobs[0]["state"] == {"lastRunStatus": "ok", "nextRunAtMs": 2000}
+
+
+def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
+    db = tmp_path / "openclaw.sqlite"
+    _make_state_db(db)
+    monkeypatch.setattr(common, "STATE_DB", db)
+    monkeypatch.setattr(
+        common,
+        "_cron_cli_json",
+        lambda _args: (_ for _ in ()).throw(AssertionError("CLI must not run")),
+    )
+
+    entries = common.read_runs("job-1", source="sqlite")
+
+    assert common.LAST_RUNS_SOURCE == "sqlite"
+    assert [entry["ts"] for entry in entries] == [100, 200]
+
+
+def test_fossil_source_is_marked_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(common, "STATE_DB", tmp_path / "missing.sqlite")
+    jobs_json = tmp_path / "jobs.json"
+    jobs_json.write_text(json.dumps([{"id": "old", "name": "stale"}]))
+    monkeypatch.setattr(common, "JOBS_JSON", jobs_json)
+    monkeypatch.setattr(common, "_cron_cli_json", lambda _args: None)
+
+    assert common.load_jobs() == [{"id": "old", "name": "stale"}]
+    assert common.LAST_LOAD_SOURCE == "fossil"
+
+
+def test_timeline_returns_nonzero_for_fossil(monkeypatch, capsys):
+    spec = importlib.util.spec_from_file_location(
+        "cron_timeline_live_state", ROOT / "scripts" / "data" / "cron_timeline.py"
+    )
+    timeline = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(timeline)
+    monkeypatch.setattr(
+        timeline,
+        "load_openclaw",
+        lambda _backend: setattr(timeline, "LAST_OPENCLAW_SOURCE", "fossil") or [],
+    )
+    monkeypatch.setattr(sys, "argv", ["cron_timeline.py", "--source", "openclaw"])
+
+    assert timeline.main() == 2
+    assert "stale pre-6.1 fossil" in capsys.readouterr().err
+
+
+def test_timeline_returns_nonzero_when_live_state_is_empty(monkeypatch, capsys):
+    spec = importlib.util.spec_from_file_location(
+        "cron_timeline_empty_state", ROOT / "scripts" / "data" / "cron_timeline.py"
+    )
+    timeline = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(timeline)
+    monkeypatch.setattr(
+        timeline,
+        "load_openclaw",
+        lambda _backend: setattr(timeline, "LAST_OPENCLAW_SOURCE", "empty") or [],
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["cron_timeline.py", "--source", "openclaw", "--json"]
+    )
+
+    assert timeline.main() == 2
+    assert "no live CLI/SQLite state" in capsys.readouterr().err


### PR DESCRIPTION
Closes #48

## Summary
- fall back from the gateway CLI to the live OpenClaw SQLite state in read-only mode
- expose `--openclaw-backend sqlite` for cron timeline and run-history inspection
- refuse stale pre-6.1 fossil data for timeline and runtime contract validation
- preserve fossil reads only for watchdog compatibility with an explicit stale marker
- repair the host fallback temp directory permissions from 0755 to 0700

## Validation
- `python3 -m pytest -q tests/test_cron_live_state.py tests/test_cron_contracts.py` (22 passed)
- `python3 -m pytest -q` (581 passed, 5 xfailed)
- live SQLite timeline: 11 jobs
- live SQLite run-history query: pass
- default `openclaw cron list --json`: 11 jobs
- `git diff --check`