### PR TITLE
fix: gate cron models on provider readiness

### DIFF
--- a/CRON_SCHEDULES.md
+++ b/CRON_SCHEDULES.md
@@ -23,6 +23,20 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
 切换。隔夜盯盘无论冬夏令时都在 02:30 HKT 截止，保留 03:00 dreaming 独占窗口；
 因此冬令时比夏令时少两个盘中 slot。
 
+## Provider readiness / 模型供应商探活
+
+`provider_health.py --apply` runs at `45 6 * * *` · Asia/Hong_Kong. It first checks
+configured authentication, then sends bounded one-token probes with exponential
+backoff. Market jobs are rotated to the first healthy candidate plus the remaining
+healthy candidates as ordered fallbacks; unconfigured or failed providers are omitted.
+If every provider is unavailable, the existing rotation is preserved and product
+generation retains deterministic local fallbacks.
+
+`provider_health.py --apply` 在 `45 6 * * *` · Asia/Hong_Kong 运行：先检查认证配置，
+再用有界的一 token 探针和指数退避验证可用性。市场任务选择首个健康候选作为主模型，
+其余健康候选作为有序 fallback；未配置或探活失败的供应商不会进入轮转。若所有供应商
+均不可用，则保留现有轮转，并由确定性的本地成品 fallback 托底。
+
 ## OpenClaw jobs + watchdogs
 
 | Job | OpenClaw schedule | Mode | Harness | System watchdog |
@@ -45,6 +59,7 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
 - Six report, three intraday, and two brief watchdog passes are tracked; the brief
   uses an 08:30 delivery backstop plus a 09:05 post-window miss detector.
 - Market payloads use deterministic preflight/postflight, `delivery.mode=none`,
-  MiniMax M3, the shared length limits, a unique WeChat path, and Telegram mirror.
+  a unique WeChat path, Telegram mirror, and an ordered unique subset of the
+  readiness-gated model candidates defined by the contract.
 - Mode 7 writes the public `assets/data/cron-heartbeats.json` ledger through the
   existing single publisher; cron health verifies every monitored slot.

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -13,10 +13,27 @@
       "--apply"
     ]
   },
+  "provider_health": {
+    "schedule": {
+      "kind": "cron",
+      "expr": "45 6 * * *",
+      "tz": "Asia/Hong_Kong"
+    },
+    "command_contains": [
+      "scripts/data/provider_health.py",
+      "--apply"
+    ]
+  },
   "payload_profiles": {
     "report": {
       "payload_kind": "agentTurn",
       "model": "minimax/MiniMax-M3",
+      "model_candidates": [
+        "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-sonnet-4-6"
+      ],
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
@@ -50,6 +67,12 @@
     "intraday": {
       "payload_kind": "agentTurn",
       "model": "minimax/MiniMax-M3",
+      "model_candidates": [
+        "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-sonnet-4-6"
+      ],
       "thinking": "medium",
       "delivery_mode": "none",
       "required_substrings": [
@@ -83,6 +106,12 @@
     "brief": {
       "payload_kind": "agentTurn",
       "model": "minimax/MiniMax-M3",
+      "model_candidates": [
+        "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-sonnet-4-6"
+      ],
       "delivery_mode": "none",
       "required_substrings": [
         "trading_calendar.py hk",

--- a/config/provider-health.json
+++ b/config/provider-health.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "candidates": [
+    {
+      "provider": "minimax",
+      "model": "minimax/MiniMax-M3"
+    },
+    {
+      "provider": "minimax-2",
+      "model": "minimax-2/MiniMax-M3"
+    },
+    {
+      "provider": "openai",
+      "model": "openai/gpt-5.6-sol"
+    },
+    {
+      "provider": "anthropic",
+      "model": "anthropic/claude-sonnet-4-6"
+    }
+  ],
+  "probe": {
+    "attempts": 2,
+    "initial_backoff_seconds": 2,
+    "timeout_ms": 15000,
+    "max_tokens": 1,
+    "max_age_hours": 26
+  },
+  "deterministic_product_fallbacks": [
+    "scripts/harness/_watchdog_common.py:build_brief_card",
+    "scripts/harness/report_watchdog.py:deterministic_fallback",
+    "scripts/harness/intraday_watchdog.py:deterministic_fallback"
+  ]
+}

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -24,6 +24,14 @@ def load_contract(path: str | Path | None = None) -> dict:
     if len(names) != len(set(names)) or any(not n for n in names):
         raise ValueError("cron contract job names must be non-empty and unique")
     profiles = data.get("payload_profiles") or {}
+    for profile_name, profile in profiles.items():
+        candidates = profile.get("model_candidates")
+        if candidates and (
+            not isinstance(candidates, list)
+            or len(candidates) != len(set(candidates))
+            or any(not model for model in candidates)
+        ):
+            raise ValueError(f"{profile_name}: model_candidates must be unique models")
     for job in jobs:
         if bool(job.get("schedule")) == bool(job.get("seasonal_schedules")):
             raise ValueError(f"{job['name']}: define exactly one schedule source")
@@ -41,6 +49,9 @@ def load_contract(path: str | Path | None = None) -> dict:
     sync = data.get("dst_sync") or {}
     if not sync.get("schedule") or not sync.get("command_contains"):
         raise ValueError("dst_sync schedule and command matcher are required")
+    health = data.get("provider_health") or {}
+    if not health.get("schedule") or not health.get("command_contains"):
+        raise ValueError("provider_health schedule and command matcher are required")
     return data
 
 
@@ -103,9 +114,29 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
     errors = []
     fields = {
         "kind": profile.get("payload_kind"),
-        "model": profile.get("model"),
         "thinking": profile.get("thinking"),
     }
+    candidates = profile.get("model_candidates")
+    if candidates:
+        fallbacks = payload.get("fallbacks") or []
+        if not isinstance(fallbacks, list):
+            errors.append("payload.fallbacks must be a list")
+            fallbacks = []
+        rotation = [payload.get("model"), *fallbacks]
+        if any(not model for model in rotation):
+            errors.append("payload model rotation contains an empty model")
+        if len(rotation) != len(set(rotation)):
+            errors.append("payload model rotation contains duplicates")
+        unknown = [model for model in rotation if model not in candidates]
+        if unknown:
+            errors.append(f"payload model rotation contains unknown models: {unknown}")
+        ordered = [model for model in candidates if model in rotation]
+        if rotation != ordered:
+            errors.append(
+                f"payload model rotation must preserve candidate order {candidates!r}"
+            )
+    else:
+        fields["model"] = profile.get("model")
     for field, expected in fields.items():
         if expected is not None and payload.get(field) != expected:
             errors.append(f"payload.{field} expected {expected!r}, got {payload.get(field)!r}")
@@ -205,4 +236,16 @@ def validate_watchdogs(contract: dict, crontab_text: str,
             expected = effective_schedule(sync, at).get("expr")
             if row["expr"] != expected:
                 errors.append(f"DST sync cron expected {expected!r}, got {row['expr']!r}")
+    health = contract.get("provider_health") or {}
+    if health:
+        tokens = health.get("command_contains") or []
+        row = find_crontab_row(rows, tokens)
+        if not row:
+            errors.append(f"provider health cron missing or ambiguous: {tokens}")
+        else:
+            expected = effective_schedule(health, at).get("expr")
+            if row["expr"] != expected:
+                errors.append(
+                    f"provider health cron expected {expected!r}, got {row['expr']!r}"
+                )
     return errors

--- a/scripts/data/generate_cron_docs.py
+++ b/scripts/data/generate_cron_docs.py
@@ -64,6 +64,8 @@ def render(contract: dict) -> str:
             f"| {job['name']} | {schedule_text(job)} | {job.get('mode', '—')} | "
             f"`{job.get('harness', '—')}` | {watchdog_text(job)} |"
         )
+    provider_health = contract["provider_health"]
+    provider_health_schedule = schedule_text(provider_health)
     return "\n".join([
         "# Cron schedule contract / 调度契约",
         "",
@@ -90,6 +92,20 @@ def render(contract: dict) -> str:
         "切换。隔夜盯盘无论冬夏令时都在 02:30 HKT 截止，保留 03:00 dreaming 独占窗口；",
         "因此冬令时比夏令时少两个盘中 slot。",
         "",
+        "## Provider readiness / 模型供应商探活",
+        "",
+        f"`provider_health.py --apply` runs at {provider_health_schedule}. It first checks",
+        "configured authentication, then sends bounded one-token probes with exponential",
+        "backoff. Market jobs are rotated to the first healthy candidate plus the remaining",
+        "healthy candidates as ordered fallbacks; unconfigured or failed providers are omitted.",
+        "If every provider is unavailable, the existing rotation is preserved and product",
+        "generation retains deterministic local fallbacks.",
+        "",
+        f"`provider_health.py --apply` 在 {provider_health_schedule} 运行：先检查认证配置，",
+        "再用有界的一 token 探针和指数退避验证可用性。市场任务选择首个健康候选作为主模型，",
+        "其余健康候选作为有序 fallback；未配置或探活失败的供应商不会进入轮转。若所有供应商",
+        "均不可用，则保留现有轮转，并由确定性的本地成品 fallback 托底。",
+        "",
         "## OpenClaw jobs + watchdogs",
         "",
         "| Job | OpenClaw schedule | Mode | Harness | System watchdog |",
@@ -102,7 +118,8 @@ def render(contract: dict) -> str:
         "- Six report, three intraday, and two brief watchdog passes are tracked; the brief",
         "  uses an 08:30 delivery backstop plus a 09:05 post-window miss detector.",
         "- Market payloads use deterministic preflight/postflight, `delivery.mode=none`,",
-        "  MiniMax M3, the shared length limits, a unique WeChat path, and Telegram mirror.",
+        "  a unique WeChat path, Telegram mirror, and an ordered unique subset of the",
+        "  readiness-gated model candidates defined by the contract.",
         "- Mode 7 writes the public `assets/data/cron-heartbeats.json` ledger through the",
         "  existing single publisher; cron health verifies every monitored slot.",
         "",

--- a/scripts/data/provider_health.py
+++ b/scripts/data/provider_health.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Probe provider readiness and apply an ordered healthy cron rotation."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+CONFIG_PATH = WS / "config" / "provider-health.json"
+STATE_PATH = WS / "memory" / ".tmp" / "provider-health.json"
+OPENCLAW = "/root/.local/share/pnpm/openclaw"
+
+sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(WS / "scripts" / "harness"))
+
+from cron_contract import load_contract  # noqa: E402
+from _watchdog_common import KCN_TELEGRAM, load_jobs, send_telegram  # noqa: E402
+
+
+def load_config(path=CONFIG_PATH):
+    data = json.loads(Path(path).read_text())
+    if data.get("schema_version") != 1:
+        raise ValueError("provider health schema_version must be 1")
+    candidates = data.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ValueError("provider health candidates must be non-empty")
+    providers = [candidate.get("provider") for candidate in candidates]
+    models = [candidate.get("model") for candidate in candidates]
+    if any(not value for value in providers + models):
+        raise ValueError("provider candidates need provider + model")
+    if len(providers) != len(set(providers)) or len(models) != len(set(models)):
+        raise ValueError("provider candidates must be unique")
+    probe = data.get("probe") or {}
+    attempts = probe.get("attempts")
+    if not isinstance(attempts, int) or not 1 <= attempts <= 4:
+        raise ValueError("probe attempts must be between 1 and 4")
+    for spec in data.get("deterministic_product_fallbacks") or []:
+        path_text, sep, symbol = spec.partition(":")
+        path = WS / path_text
+        if not sep or not symbol or not path.is_file() or f"def {symbol}" not in path.read_text():
+            raise ValueError(f"deterministic product fallback is unavailable: {spec}")
+    return data
+
+
+def _json_stdout(result):
+    start = result.stdout.find("{")
+    if start < 0:
+        return None
+    try:
+        return json.loads(result.stdout[start:])
+    except json.JSONDecodeError:
+        return None
+
+
+def model_status(*, provider=None, probe=None):
+    cmd = [OPENCLAW, "models", "status", "--json"]
+    timeout = 45
+    if provider:
+        probe = probe or {}
+        cmd += [
+            "--probe",
+            "--probe-provider", provider,
+            "--probe-max-tokens", str(probe["max_tokens"]),
+            "--probe-timeout", str(probe["timeout_ms"]),
+            "--probe-concurrency", "1",
+        ]
+        timeout = max(45, int(probe["timeout_ms"] / 1000) + 30)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return _json_stdout(result)
+
+
+def configured_providers(status):
+    auth = (status or {}).get("auth") or {}
+    return {
+        row["provider"]
+        for row in auth.get("providers") or []
+        if row.get("provider") and row.get("effective")
+    }
+
+
+def probe_one(provider, probe, *, sleep=time.sleep):
+    attempts = []
+    for index in range(probe["attempts"]):
+        started = time.monotonic()
+        data = model_status(provider=provider, probe=probe)
+        results = (((data or {}).get("auth") or {}).get("probes") or {}).get("results") or []
+        match = next((row for row in results if row.get("provider") == provider), None)
+        ok = bool(match and match.get("status") == "ok")
+        attempts.append({
+            "status": "ok" if ok else "failed",
+            "latency_ms": match.get("latencyMs") if match else round(
+                (time.monotonic() - started) * 1000
+            ),
+        })
+        if ok:
+            return True, attempts
+        if index + 1 < probe["attempts"]:
+            sleep(probe["initial_backoff_seconds"] * (2 ** index))
+    return False, attempts
+
+
+def evaluate(config, *, sleep=time.sleep):
+    configured = configured_providers(model_status())
+    rows = []
+    for candidate in config["candidates"]:
+        provider = candidate["provider"]
+        if provider not in configured:
+            rows.append({
+                **candidate,
+                "configured": False,
+                "healthy": False,
+                "status": "unconfigured",
+                "attempts": [],
+            })
+            continue
+        healthy, attempts = probe_one(provider, config["probe"], sleep=sleep)
+        rows.append({
+            **candidate,
+            "configured": True,
+            "healthy": healthy,
+            "status": "ok" if healthy else "probe_failed",
+            "attempts": attempts,
+        })
+    return rows
+
+
+def rotation(results):
+    """First item is primary; remaining unique healthy items are fallbacks."""
+    return [row["model"] for row in results if row.get("healthy")]
+
+
+def market_job_names(contract):
+    profiles = contract.get("payload_profiles") or {}
+    return {
+        job["name"]
+        for job in contract["jobs"]
+        if (profiles.get(job.get("payload_profile")) or {}).get("model_candidates")
+    }
+
+
+def desired_changes(live_jobs, models, names):
+    if not models:
+        return []
+    primary, fallbacks = models[0], models[1:]
+    changes = []
+    for job in live_jobs:
+        if job.get("name") not in names:
+            continue
+        payload = job.get("payload") or {}
+        current_fallbacks = payload.get("fallbacks") or []
+        if payload.get("model") == primary and current_fallbacks == fallbacks:
+            continue
+        changes.append({
+            "id": job.get("id"),
+            "name": job.get("name"),
+            "from": {
+                "model": payload.get("model"),
+                "fallbacks": current_fallbacks,
+            },
+            "to": {"model": primary, "fallbacks": fallbacks},
+        })
+    return changes
+
+
+def apply_changes(changes):
+    errors = []
+    for change in changes:
+        if not change.get("id"):
+            errors.append(f"{change['name']}: missing live job id")
+            continue
+        cmd = [
+            OPENCLAW, "cron", "edit", change["id"],
+            "--model", change["to"]["model"],
+        ]
+        fallbacks = change["to"]["fallbacks"]
+        cmd += (
+            ["--fallbacks", ",".join(fallbacks)]
+            if fallbacks else ["--clear-fallbacks"]
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=45)
+        if result.returncode != 0:
+            errors.append(f"{change['name']}: cron edit failed")
+    return errors
+
+
+def _atomic_write(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+    os.replace(tmp, path)
+
+
+def _prior_alert_state():
+    try:
+        prior = json.loads(STATE_PATH.read_text())
+        return prior.get("unhealthy_fingerprint"), prior.get("alert_sent")
+    except Exception:
+        return None, None
+
+
+def maybe_alert(state, prior_fingerprint, prior_alert_sent, no_alert):
+    fingerprint = state["unhealthy_fingerprint"]
+    retry_failed_alert = fingerprint == prior_fingerprint and prior_alert_sent is False
+    if (
+        no_alert
+        or not fingerprint
+        or (fingerprint == prior_fingerprint and not retry_failed_alert)
+    ):
+        return None
+    unhealthy = [
+        f"{row['provider']}={row['status']}"
+        for row in state["providers"] if not row["healthy"]
+    ]
+    message = (
+        "🟠 Provider readiness changed\n"
+        + "\n".join(f"• {item}" for item in unhealthy)
+        + f"\nActive rotation: {' → '.join(state['rotation']) or 'NONE'}"
+    )
+    try:
+        ok, _ = send_telegram(KCN_TELEGRAM, message, False)
+        return bool(ok)
+    except Exception:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--no-alert", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    config = load_config()
+    results = evaluate(config)
+    models = rotation(results)
+    prior_fingerprint, prior_alert_sent = _prior_alert_state()
+    unhealthy_fingerprint = ",".join(
+        f"{row['provider']}:{row['status']}"
+        for row in results if not row["healthy"]
+    )
+    errors = []
+    changes = []
+    applied = False
+    if not models:
+        errors.append("no healthy provider; existing cron rotation left unchanged")
+    else:
+        contract = load_contract()
+        changes = desired_changes(
+            load_jobs(), models, market_job_names(contract)
+        )
+        if args.apply:
+            errors.extend(apply_changes(changes))
+            applied = bool(changes) and not errors
+    state = {
+        "schema_version": 1,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "status": "error" if errors else (
+            "degraded" if unhealthy_fingerprint else "healthy"
+        ),
+        "providers": results,
+        "rotation": models,
+        "changes": changes,
+        "applied": applied,
+        "errors": errors,
+        "unhealthy_fingerprint": unhealthy_fingerprint,
+    }
+    # Persist readiness before notification so alert failure cannot erase the
+    # rotation or trigger the same notification on every scheduler retry.
+    _atomic_write(STATE_PATH, state)
+    state["alert_sent"] = maybe_alert(
+        state, prior_fingerprint, prior_alert_sent, args.no_alert
+    )
+    _atomic_write(STATE_PATH, state)
+    if args.json:
+        print(json.dumps(state, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"provider health: {state['status']} · "
+            f"rotation={' → '.join(models) or 'NONE'} · changes={len(changes)}"
+        )
+    return 2 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/sync_us_cron_dst.py
+++ b/scripts/data/sync_us_cron_dst.py
@@ -28,6 +28,12 @@ from cron_contract import (  # noqa: E402
 )
 from _watchdog_common import load_jobs  # noqa: E402
 
+PROVIDER_HEALTH_COMMAND = (
+    "/bin/bash -lc 'cd /root/.openclaw/workspace && "
+    "python3 scripts/data/provider_health.py --apply "
+    ">> logs/provider-health.log 2>&1'"
+)
+
 
 def parse_at(value: str | None) -> datetime:
     if not value:
@@ -74,6 +80,28 @@ def desired_changes(contract: dict, live_jobs: list[dict], crontab_text: str,
                 "name": job["name"], "line_index": row["index"],
                 "from": row["expr"], "to": desired_expr,
             })
+    # Bootstrap/repair the readiness gate from this already-scheduled 06:20
+    # maintenance job. This avoids a circular dependency where provider_health
+    # can never run because its own crontab row is missing.
+    health = contract.get("provider_health") or {}
+    tokens = health.get("command_contains") or []
+    row = find_crontab_row(cron_rows, tokens)
+    desired_expr = effective_schedule(health, at).get("expr")
+    if not row:
+        watchdog_changes.append({
+            "name": "Provider health",
+            "line_index": None,
+            "from": None,
+            "to": desired_expr,
+            "command": PROVIDER_HEALTH_COMMAND,
+        })
+    elif row["expr"] != desired_expr:
+        watchdog_changes.append({
+            "name": "Provider health",
+            "line_index": row["index"],
+            "from": row["expr"],
+            "to": desired_expr,
+        })
     return openclaw_changes, watchdog_changes, errors
 
 
@@ -100,6 +128,9 @@ def apply_crontab(text: str, changes: list[dict]) -> list[str]:
     lines = text.splitlines()
     for change in changes:
         index = change["line_index"]
+        if index is None:
+            lines.append(f"{change['to']} {change['command']}")
+            continue
         parts = lines[index].split(None, 5)
         if len(parts) < 6:
             return [f"cannot parse crontab line {index + 1}"]

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -16,6 +16,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 WS = Path(__file__).resolve().parent.parent
@@ -470,6 +471,42 @@ def check_generated_cron_docs(r):
               (result.stdout + result.stderr).strip()[-300:])
 
 
+def check_provider_health(r):
+    """Daily readiness probe must be fresh and leave a usable unique rotation."""
+    path = WS / 'memory' / '.tmp' / 'provider-health.json'
+    if not path.exists():
+        if not Path('/root/.local/share/pnpm/openclaw').exists():
+            r.add('provider health', OK, 'skipped (OpenClaw not installed on this host)')
+        else:
+            r.add('provider health', WARNING, 'no readiness state yet; run provider_health.py')
+        return
+    try:
+        state = json.loads(path.read_text())
+        config = json.loads((WS / 'config' / 'provider-health.json').read_text())
+        max_age_h = float(config['probe']['max_age_hours'])
+        checked = datetime.fromisoformat(state['checked_at'].replace('Z', '+00:00'))
+        if checked.tzinfo is None:
+            checked = checked.replace(tzinfo=timezone.utc)
+        age_h = (datetime.now(timezone.utc) - checked).total_seconds() / 3600
+    except Exception as e:
+        r.add('provider health', CRITICAL, f'unreadable readiness state: {e}')
+        return
+    rotation = state.get('rotation') or []
+    if not rotation or len(rotation) != len(set(rotation)):
+        r.add('provider health', CRITICAL, 'no usable unique provider rotation')
+    elif age_h > max_age_h:
+        r.add('provider health', CRITICAL, f'readiness probe stale ({age_h:.1f}h)')
+    elif state.get('status') == 'degraded':
+        bad = [row.get('provider') for row in state.get('providers', [])
+               if not row.get('healthy')]
+        r.add('provider health', WARNING,
+              f'rotation={rotation}; unavailable={bad}; age={age_h:.1f}h')
+    elif state.get('status') == 'error':
+        r.add('provider health', CRITICAL, '; '.join(state.get('errors') or ['probe error']))
+    else:
+        r.add('provider health', OK, f'{len(rotation)} healthy provider(s); age={age_h:.1f}h')
+
+
 def main():
     r = Result()
     checks = [
@@ -483,6 +520,7 @@ def main():
         check_openclaw_doctor,
         check_decision_ledger,
         check_cron_paths_exist,
+        check_provider_health,
         check_generated_cron_docs,
     ]
     for c in checks:

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -3,6 +3,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
 
@@ -104,7 +105,12 @@ def test_payload_semantic_contract_detects_deprecated_or_missing_rules():
     vars_ = expected['payload_vars']
     message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
     live = {
-        'payload': {'kind': 'agentTurn', 'model': profile['model'], 'message': message},
+        'payload': {
+            'kind': 'agentTurn',
+            'model': profile['model'],
+            'fallbacks': profile['model_candidates'][1:],
+            'message': message,
+        },
         'delivery': {'mode': 'none'},
     }
     assert cron_contract.payload_errors(data, expected, live) == []
@@ -112,6 +118,27 @@ def test_payload_semantic_contract_detects_deprecated_or_missing_rules():
     errors = cron_contract.payload_errors(data, expected, live)
     assert any('missing' in error and '唯一微信路径' in error for error in errors)
     assert any('deprecated' in error and '唯一发送路径' in error for error in errors)
+
+
+def test_provider_rotation_rejects_duplicate_primary_and_unknown_models():
+    data = contract()
+    expected = next(j for j in data['jobs'] if j['name'] == '美股开盘报告')
+    profile = data['payload_profiles']['report']
+    message = '\n'.join(
+        s.format(**expected['payload_vars']) for s in profile['required_substrings']
+    )
+    live = {
+        'payload': {
+            'kind': 'agentTurn',
+            'model': profile['model_candidates'][0],
+            'fallbacks': [profile['model_candidates'][0], 'dead/example'],
+            'message': message,
+        },
+        'delivery': {'mode': 'none'},
+    }
+    errors = cron_contract.payload_errors(data, expected, live)
+    assert any('duplicates' in error for error in errors)
+    assert any('unknown models' in error for error in errors)
 
 
 def _crontab_from_contract(data, at):
@@ -131,6 +158,11 @@ def _crontab_from_contract(data, at):
     rows.append(
         f"{cron_contract.effective_schedule(sync, at)['expr']} "
         + ' '.join(sync['command_contains'])
+    )
+    health = data['provider_health']
+    rows.append(
+        f"{cron_contract.effective_schedule(health, at)['expr']} "
+        + ' '.join(health['command_contains'])
     )
     return '\n'.join(rows) + '\n'
 
@@ -159,6 +191,61 @@ def test_watchdog_contract_and_dst_change_plan_cover_both_schedulers():
     assert {change['name'] for change in watchdogs} == {
         '美股开盘报告', '美股收盘报告', '美股盘中盯盘'
     }
+
+
+def test_dst_sync_bootstraps_missing_provider_health_cron():
+    data = contract()
+    july = datetime(2026, 7, 16, 0, tzinfo=timezone.utc)
+    crontab = _crontab_from_contract(data, july)
+    crontab = '\n'.join(
+        line for line in crontab.splitlines()
+        if 'provider_health.py' not in line
+    ) + '\n'
+    live = []
+    for job in data['jobs']:
+        live.append({
+            'id': f"id-{len(live)}", 'name': job['name'],
+            'enabled': job.get('enabled', True),
+            'schedule': cron_contract.effective_schedule(job, july),
+        })
+
+    _, changes, errors = sync_us_cron_dst.desired_changes(
+        data, live, crontab, july
+    )
+
+    assert errors == []
+    health_change = next(change for change in changes
+                         if change['name'] == 'Provider health')
+    assert health_change['line_index'] is None
+    assert health_change['to'] == '45 6 * * *'
+    assert 'provider_health.py --apply' in health_change['command']
+
+
+def test_dst_sync_can_install_provider_health_cron(monkeypatch):
+    captured = {}
+
+    def run(cmd, **kwargs):
+        captured['cmd'] = cmd
+        captured['input'] = kwargs['input']
+        return SimpleNamespace(returncode=0, stdout='', stderr='')
+
+    monkeypatch.setattr(sync_us_cron_dst.subprocess, 'run', run)
+    errors = sync_us_cron_dst.apply_crontab(
+        '20 6 * * * existing-command\n',
+        [{
+            'name': 'Provider health',
+            'line_index': None,
+            'from': None,
+            'to': '45 6 * * *',
+            'command': sync_us_cron_dst.PROVIDER_HEALTH_COMMAND,
+        }],
+    )
+
+    assert errors == []
+    assert captured['cmd'] == ['crontab', '-']
+    assert captured['input'].splitlines()[-1].startswith(
+        '45 6 * * * /bin/bash -lc'
+    )
 
 
 def test_intraday_heartbeat_is_slot_keyed_published_and_health_checked(tmp_path, monkeypatch):

--- a/tests/test_provider_health.py
+++ b/tests/test_provider_health.py
@@ -1,0 +1,139 @@
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import provider_health as health  # noqa: E402
+
+
+def test_config_has_unique_candidates_and_deterministic_fallbacks():
+    config = health.load_config(ROOT / "config" / "provider-health.json")
+    assert [row["provider"] for row in config["candidates"]] == [
+        "minimax", "minimax-2", "openai", "anthropic"
+    ]
+    assert config["probe"]["max_tokens"] == 1
+    assert len(config["deterministic_product_fallbacks"]) == 3
+    contract = health.load_contract(ROOT / "config" / "cron-schedules.json")
+    expected = [row["model"] for row in config["candidates"]]
+    for profile in ("brief", "report", "intraday"):
+        assert contract["payload_profiles"][profile]["model_candidates"] == expected
+
+
+def test_rotation_selects_first_healthy_and_omits_dead_entries():
+    results = [
+        {"model": "primary/model", "healthy": False},
+        {"model": "second/model", "healthy": True},
+        {"model": "dead/model", "healthy": False},
+        {"model": "last/model", "healthy": True},
+    ]
+    assert health.rotation(results) == ["second/model", "last/model"]
+
+
+def test_evaluate_skips_probe_for_unconfigured_provider(monkeypatch):
+    config = {
+        "candidates": [
+            {"provider": "ready", "model": "ready/model"},
+            {"provider": "missing", "model": "missing/model"},
+        ],
+        "probe": {"attempts": 2, "initial_backoff_seconds": 1,
+                  "timeout_ms": 10, "max_tokens": 1},
+    }
+    monkeypatch.setattr(
+        health,
+        "model_status",
+        lambda **_kwargs: {
+            "auth": {"providers": [{"provider": "ready", "effective": {"kind": "key"}}]}
+        },
+    )
+    calls = []
+    monkeypatch.setattr(
+        health,
+        "probe_one",
+        lambda provider, _probe, sleep=None: calls.append(provider) or (True, []),
+    )
+    rows = health.evaluate(config, sleep=lambda _seconds: None)
+    assert calls == ["ready"]
+    assert rows[0]["healthy"] is True
+    assert rows[1]["status"] == "unconfigured"
+
+
+def test_probe_retries_with_bounded_exponential_backoff(monkeypatch):
+    responses = [
+        {"auth": {"probes": {"results": [{"provider": "p", "status": "error"}]}}},
+        {"auth": {"probes": {"results": [{"provider": "p", "status": "error"}]}}},
+        {"auth": {"probes": {"results": [{"provider": "p", "status": "ok",
+                                           "latencyMs": 5}]}}},
+    ]
+    monkeypatch.setattr(health, "model_status", lambda **_kwargs: responses.pop(0))
+    sleeps = []
+    probe = {"attempts": 3, "initial_backoff_seconds": 2,
+             "timeout_ms": 10, "max_tokens": 1}
+    ok, attempts = health.probe_one("p", probe, sleep=sleeps.append)
+    assert ok is True
+    assert len(attempts) == 3
+    assert sleeps == [2, 4]
+
+
+def test_desired_changes_excludes_memory_and_removes_duplicate_fallback():
+    live = [
+        {
+            "id": "1",
+            "name": "market",
+            "payload": {
+                "model": "minimax/MiniMax-M3",
+                "fallbacks": ["minimax/MiniMax-M3", "dead/model"],
+            },
+        },
+        {
+            "id": "2",
+            "name": "memory",
+            "payload": {"model": "minimax/MiniMax-M3", "fallbacks": []},
+        },
+    ]
+    models = ["minimax/MiniMax-M3", "minimax-2/MiniMax-M3"]
+    changes = health.desired_changes(live, models, {"market"})
+    assert len(changes) == 1
+    assert changes[0]["name"] == "market"
+    assert changes[0]["to"] == {
+        "model": "minimax/MiniMax-M3",
+        "fallbacks": ["minimax-2/MiniMax-M3"],
+    }
+
+
+def test_state_file_contains_no_auth_material(tmp_path):
+    state = {
+        "schema_version": 1,
+        "providers": [{"provider": "p", "status": "ok", "healthy": True}],
+        "rotation": ["p/model"],
+    }
+    path = tmp_path / "provider-health.json"
+    health._atomic_write(path, state)
+    assert json.loads(path.read_text()) == state
+    assert "token" not in path.read_text().lower()
+
+
+def test_failed_alert_is_retried_for_same_failure(monkeypatch):
+    state = {
+        "unhealthy_fingerprint": "p:probe_failed",
+        "providers": [{"provider": "p", "status": "probe_failed", "healthy": False}],
+        "rotation": ["ready/model"],
+    }
+    calls = []
+    monkeypatch.setattr(
+        health,
+        "send_telegram",
+        lambda *args: calls.append(args) or (True, None),
+    )
+
+    sent = health.maybe_alert(
+        state,
+        prior_fingerprint="p:probe_failed",
+        prior_alert_sent=False,
+        no_alert=False,
+    )
+
+    assert sent is True
+    assert len(calls) == 1


### PR DESCRIPTION
Closes #47

## What changed
- add a daily 06:45 HKT authenticated one-token readiness probe with bounded exponential backoff
- skip unconfigured or failed providers and apply the first healthy model plus ordered healthy fallbacks to all ten market jobs
- remove duplicate/dead runtime entries through semantic cron-contract validation
- preserve the current rotation when every provider is unavailable and verify deterministic data-only product fallbacks
- persist a credential-free health state, alert only on readiness changes, and retry failed alerts
- bootstrap/repair the provider-health crontab row from the existing 06:20 DST maintenance job

## Live remediation
Ran the probe against the current host and applied the safe rotation immediately. MiniMax and MiniMax-2 passed; OpenAI is unconfigured; Anthropic failed both bounded probes. All ten market jobs now use minimax/MiniMax-M3 with only minimax-2/MiniMax-M3 as fallback. No Telegram alert was emitted by the manual remediation.

## Verification
- pytest -q: 586 passed, 5 xfailed
- focused provider/cron/secret tests: 69 passed
- generated cron docs check and Python compilation pass
- real no-alert readiness probe produced the expected two-provider healthy rotation