### PR TITLE
fix: make market-leg freshness gate dashboard health

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -16,8 +16,9 @@ import os
 import re
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import decision_v2
 
@@ -1641,6 +1642,95 @@ _FRESHNESS_SLA_H = {
 }
 
 
+def _latest_completed_session(market, calendar, at=None):
+    """Newest trading session that has conservatively finished in market time."""
+    tz = ZoneInfo(calendar.MARKET_TZ[market])
+    now = at.astimezone(tz) if at else datetime.now(tz)
+    current = now.date() if now.hour >= 17 else now.date() - timedelta(days=1)
+    for _ in range(14):
+        if calendar.is_trading_day(market, current):
+            return current
+        current -= timedelta(days=1)
+    return None
+
+
+def _quote_session(holding, reference):
+    """Extract the holding's own quote date, never a shared file/region timestamp."""
+    values = [
+        holding.get('quote_time'),
+        holding.get('as_of'),
+        holding.get('last_updated'),
+        holding.get('data_source'),
+    ]
+    parsed = []
+    for raw in values:
+        if not raw:
+            continue
+        text = str(raw)
+        match = re.search(r'(\d{4})[/-](\d{1,2})[/-](\d{1,2})', text)
+        if match:
+            try:
+                parsed.append(date(*(int(part) for part in match.groups())))
+            except ValueError:
+                pass
+            continue
+        match = re.search(
+            r'\b([A-Za-z]{3,9})\s+(\d{1,2})(?:,\s*|\s+)?(\d{4})?\b',
+            text,
+        )
+        if not match or reference is None:
+            continue
+        month, day, year = match.groups()
+        try:
+            candidate = datetime.strptime(
+                f'{month} {day} {year or reference.year}', '%b %d %Y'
+            ).date()
+        except ValueError:
+            try:
+                candidate = datetime.strptime(
+                    f'{month} {day} {year or reference.year}', '%B %d %Y'
+                ).date()
+            except ValueError:
+                continue
+        # A yearless Dec quote inspected in early Jan belongs to the prior year.
+        if year is None and candidate > reference + timedelta(days=7):
+            candidate = candidate.replace(year=candidate.year - 1)
+        parsed.append(candidate)
+    return max(parsed) if parsed else None
+
+
+def _market_leg_freshness(portfolio_leg, market, calendar, at=None):
+    expected = _latest_completed_session(market, calendar, at=at)
+    active = [
+        holding for holding in portfolio_leg.get('holdings', [])
+        if (holding.get('shares') or 0) > 0
+    ]
+    quotes = {}
+    missing = []
+    stale = []
+    for holding in active:
+        ticker = holding.get('ticker') or holding.get('code') or '?'
+        session = _quote_session(holding, expected)
+        quotes[ticker] = session.isoformat() if session else None
+        if session is None:
+            missing.append(ticker)
+        elif expected and session < expected:
+            stale.append(ticker)
+    dated = [value for value in quotes.values() if value]
+    fresh = expected is not None and not missing and not stale
+    return {
+        'last_updated': portfolio_leg.get('last_updated'),
+        'expected_completed_session': expected.isoformat() if expected else None,
+        'oldest_quote_session': min(dated) if dated else None,
+        'newest_quote_session': max(dated) if dated else None,
+        'active_holdings': len(active),
+        'missing_quote_timestamps': sorted(missing),
+        'stale_tickers': sorted(stale),
+        'quote_sessions': quotes,
+        'fresh': fresh,
+    }
+
+
 def compute_build_status(portfolio, data_dir):
     """A2 健康卡数据：每个数据文件的新鲜度 + 体检结论 + 每市场 data 时点。
 
@@ -1660,7 +1750,8 @@ def compute_build_status(portfolio, data_dir):
         else:
             files.append({'name': name, 'present': False, 'stale': True, 'sla_hours': sla})
 
-    # 每市场数据时点（用 trading_calendar 比上一交易日）
+    # 每市场数据时点：逐只活跃持仓的报价日期 vs 最近已完成 session。
+    # 不能信 region.last_updated 或 portfolio.json mtime；两者都会被另一条写入刷新。
     markets = {}
     try:
         sys.path.insert(0, str(WS_ROOT / 'scripts' / 'data'))
@@ -1669,8 +1760,15 @@ def compute_build_status(portfolio, data_dir):
         _tc = None
     for region, mkt in (('us_stocks', 'us'), ('hk_stocks', 'hk')):
         pf = portfolio.get('portfolios', {}).get(region, {})
-        markets[mkt] = {'last_updated': pf.get('last_updated'),
-                        'closed_today': (_tc.closed_reason(mkt) is not None) if _tc else None}
+        if _tc:
+            markets[mkt] = _market_leg_freshness(pf, mkt, _tc)
+            markets[mkt]['closed_today'] = _tc.closed_reason(mkt) is not None
+        else:
+            markets[mkt] = {
+                'last_updated': pf.get('last_updated'),
+                'fresh': False,
+                'error': 'trading_calendar unavailable',
+            }
 
     # 体检结论（A1）——纯文件运算，安全内联
     integrity = None
@@ -1686,9 +1784,13 @@ def compute_build_status(portfolio, data_dir):
         print(f'  warn: integrity check in build_status failed: {e}', file=sys.stderr)
 
     stale_files = [f['name'] for f in files if f.get('stale')]
-    healthy = (not stale_files) and (integrity is None or integrity.get('ok'))
+    stale_markets = [market for market, state in markets.items()
+                     if not state.get('fresh')]
+    healthy = (not stale_files) and (not stale_markets) and (
+        integrity is None or integrity.get('ok'))
     return {'generated_at': now.isoformat(timespec='seconds'), 'healthy': healthy,
-            'stale_files': stale_files, 'files': files, 'markets': markets,
+            'stale_files': stale_files, 'stale_markets': stale_markets,
+            'files': files, 'markets': markets,
             'integrity': integrity}
 
 

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -5,9 +5,12 @@ imports and its filesystem orchestration is guarded by ``main()``, so importing
 it does not read snapshots, portfolio data, or the network.
 """
 import json
+import os
 from pathlib import Path
 import sys
 from types import SimpleNamespace
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -358,6 +361,89 @@ def test_hhi_uses_value_weights_and_reports_top_two_concentration():
     assert result["hhi"] == 0.46  # .6^2 + .3^2 + .1^2
     assert result["top2"] == 0.9
     assert [row["ticker"] for row in result["positions"]] == ["A", "B", "C"]
+
+
+def test_latest_completed_session_skips_holiday_weekend_before_close():
+    import trading_calendar
+
+    before_close = datetime(
+        2026, 7, 6, 15, 0, tzinfo=ZoneInfo("America/New_York")
+    )
+    after_close = datetime(
+        2026, 7, 6, 17, 0, tzinfo=ZoneInfo("America/New_York")
+    )
+
+    assert dashboard._latest_completed_session(
+        "us", trading_calendar, before_close
+    ).isoformat() == "2026-07-02"
+    assert dashboard._latest_completed_session(
+        "us", trading_calendar, after_close
+    ).isoformat() == "2026-07-06"
+
+
+def test_market_leg_freshness_exposes_one_frozen_holding():
+    import trading_calendar
+
+    at = datetime(
+        2026, 7, 24, 17, 0, tzinfo=ZoneInfo("America/New_York")
+    )
+    leg = {
+        "last_updated": "Jun 24, 2026 16:00 ET close",
+        "holdings": [
+            {
+                "ticker": "FRESH",
+                "shares": 1,
+                "data_source": "Nasdaq API Jul 24, 2026 16:00 ET",
+            },
+            {
+                "ticker": "FROZEN",
+                "shares": 1,
+                "data_source": "Nasdaq API Jul 23, 2026 16:00 ET",
+            },
+            {"ticker": "EXITED", "shares": 0, "data_source": "old"},
+        ],
+    }
+
+    status = dashboard._market_leg_freshness(
+        leg, "us", trading_calendar, at=at
+    )
+
+    assert status["expected_completed_session"] == "2026-07-24"
+    assert status["fresh"] is False
+    assert status["stale_tickers"] == ["FROZEN"]
+    assert status["quote_sessions"]["FRESH"] == "2026-07-24"
+    assert "EXITED" not in status["quote_sessions"]
+
+
+def test_stale_market_leg_makes_build_unhealthy(monkeypatch, tmp_path):
+    data_dir = tmp_path / "assets" / "data"
+    data_dir.mkdir(parents=True)
+    for name in dashboard._FRESHNESS_SLA_H:
+        path = tmp_path / name if name == "portfolio.json" else data_dir / name
+        path.write_text("{}")
+        os.utime(path, None)
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    monkeypatch.setitem(
+        sys.modules,
+        "preflight_integrity",
+        SimpleNamespace(check=lambda: {
+            "ok": True, "error_count": 0, "warn_count": 0, "findings": [],
+        }),
+    )
+    portfolio = _portfolio(
+        us={"holdings": [{
+            "ticker": "US", "shares": 1, "data_source": "Nasdaq Jan 01, 2026"
+        }]},
+        hk={"holdings": [{
+            "ticker": "HK", "shares": 1, "data_source": "Tencent Jan 01 2026"
+        }]},
+    )
+
+    status = dashboard.compute_build_status(portfolio, data_dir)
+
+    assert status["stale_files"] == []
+    assert status["stale_markets"] == ["us", "hk"]
+    assert status["healthy"] is False
 
 
 @pytest.mark.parametrize("holdings", [[], [


### PR DESCRIPTION
Closes #52

## What changed
- derive US and HK freshness from every active holding own quote timestamp/data_source instead of portfolio.json mtime or the legacy region timestamp
- compare each quote against the latest calendar-valid completed session in that market timezone
- expose expected session, oldest/newest quote session, per-ticker sessions, missing timestamps, and stale tickers per leg
- add stale_markets and require both market legs to be fresh for the dashboard healthy predicate
- fail visibly if the trading calendar cannot be loaded

## Verification
- pytest -q: 579 passed, 5 xfailed
- focused dashboard tests: 27 passed, 1 xfailed
- production-shaped dashboard build succeeded at 190,620 bytes
- current live portfolio resolves all 7 US and 5 HK active holdings to 2026-07-24, the latest completed session
- synthetic frozen-ticker and US holiday/weekend boundary tests pass