### PR TITLE
feat: gate intraday reasoning on material deltas

### DIFF
--- a/CRON_SCHEDULES.md
+++ b/CRON_SCHEDULES.md
@@ -48,3 +48,6 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
   MiniMax M3, the shared length limits, a unique WeChat path, and Telegram mirror.
 - Mode 7 writes the public `assets/data/cron-heartbeats.json` ledger through the
   existing single publisher; cron health verifies every monitored slot.
+- Mode 7 agent turns are condition-triggered by normalized breach/event/regime
+  hashes and material repricing. Unchanged slots write an LLM-free `no_change`
+  heartbeat; every sixth evaluation forces a reasoning pass.

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -52,6 +52,10 @@
       "model": "minimax/MiniMax-M3",
       "thinking": "medium",
       "delivery_mode": "none",
+      "trigger": {
+        "script_path": "config/cron-triggers/intraday-{market}.js",
+        "once": false
+      },
       "required_substrings": [
         "trading_calendar.py {market}",
         "skills/{skill}/SKILL.md",

--- a/config/cron-triggers/intraday-hk.js
+++ b/config/cron-triggers/intraday-hk.js
@@ -1,0 +1,47 @@
+const result = await tools.call('exec', {
+  command: 'python3 /root/.openclaw/workspace/scripts/data/intraday_delta_gate.py --market hk'
+});
+const raw = String(result?.result?.details?.aggregated ?? result?.result?.stdout ?? '');
+let snap;
+try {
+  snap = JSON.parse(raw.trim());
+} catch {
+  json({ fire: true, message: 'Delta gate failed open: invalid snapshot.', state: trigger.state });
+  exit();
+}
+const prev = trigger.state ?? {};
+const priorPrices = prev.prices ?? {};
+const materiallyRepriced = Object.entries(snap.prices ?? {}).some(([ticker, row]) => {
+  const old = priorPrices[ticker];
+  if (!old || !old.price) return true;
+  return Math.abs(row.price / old.price - 1) >= 0.01 ||
+    Math.abs((row.pct_1d ?? 0) - (old.pct_1d ?? 0)) >= 1.0;
+});
+const evaluations = (prev.evaluationsSinceReasoning ?? 0) + 1;
+const conditionChanged = prev.conditionHash !== snap.condition_hash;
+const forced = !prev.conditionHash || prev.session !== snap.session || evaluations >= 6;
+const fire = !snap.market_closed &&
+  Boolean(snap.error || conditionChanged || materiallyRepriced || forced);
+const reasons = [
+  snap.error ? `gate_error:${snap.error}` : '',
+  conditionChanged ? 'condition_delta' : '',
+  materiallyRepriced ? 'material_reprice' : '',
+  forced ? 'scheduled_forced_review' : ''
+].filter(Boolean);
+if (!fire) {
+  const state = snap.market_closed ? 'market_closed' : 'no_change';
+  await tools.call('exec', {
+    command: `python3 /root/.openclaw/workspace/scripts/data/intraday_delta_gate.py --market hk --record ${state} --slot ${snap.slot} --reason unchanged --state-hash ${snap.condition_hash}`
+  });
+}
+json({
+  fire,
+  message: fire ? `Intraday delta trigger: ${reasons.join(', ')}. Snapshot slot=${snap.slot}.` : undefined,
+  state: {
+    conditionHash: snap.condition_hash,
+    prices: snap.prices,
+    session: snap.session,
+    lastSlot: snap.slot,
+    evaluationsSinceReasoning: fire ? 0 : evaluations
+  }
+});

--- a/config/cron-triggers/intraday-us.js
+++ b/config/cron-triggers/intraday-us.js
@@ -1,0 +1,47 @@
+const result = await tools.call('exec', {
+  command: 'python3 /root/.openclaw/workspace/scripts/data/intraday_delta_gate.py --market us'
+});
+const raw = String(result?.result?.details?.aggregated ?? result?.result?.stdout ?? '');
+let snap;
+try {
+  snap = JSON.parse(raw.trim());
+} catch {
+  json({ fire: true, message: 'Delta gate failed open: invalid snapshot.', state: trigger.state });
+  exit();
+}
+const prev = trigger.state ?? {};
+const priorPrices = prev.prices ?? {};
+const materiallyRepriced = Object.entries(snap.prices ?? {}).some(([ticker, row]) => {
+  const old = priorPrices[ticker];
+  if (!old || !old.price) return true;
+  return Math.abs(row.price / old.price - 1) >= 0.01 ||
+    Math.abs((row.pct_1d ?? 0) - (old.pct_1d ?? 0)) >= 1.0;
+});
+const evaluations = (prev.evaluationsSinceReasoning ?? 0) + 1;
+const conditionChanged = prev.conditionHash !== snap.condition_hash;
+const forced = !prev.conditionHash || prev.session !== snap.session || evaluations >= 6;
+const fire = !snap.market_closed &&
+  Boolean(snap.error || conditionChanged || materiallyRepriced || forced);
+const reasons = [
+  snap.error ? `gate_error:${snap.error}` : '',
+  conditionChanged ? 'condition_delta' : '',
+  materiallyRepriced ? 'material_reprice' : '',
+  forced ? 'scheduled_forced_review' : ''
+].filter(Boolean);
+if (!fire) {
+  const state = snap.market_closed ? 'market_closed' : 'no_change';
+  await tools.call('exec', {
+    command: `python3 /root/.openclaw/workspace/scripts/data/intraday_delta_gate.py --market us --record ${state} --slot ${snap.slot} --reason unchanged --state-hash ${snap.condition_hash}`
+  });
+}
+json({
+  fire,
+  message: fire ? `Intraday delta trigger: ${reasons.join(', ')}. Snapshot slot=${snap.slot}.` : undefined,
+  state: {
+    conditionHash: snap.condition_hash,
+    prices: snap.prices,
+    session: snap.session,
+    lastSlot: snap.slot,
+    evaluationsSinceReasoning: fire ? 0 : evaluations
+  }
+});

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -125,6 +125,23 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
     for forbidden in profile.get("forbidden_substrings", []):
         if forbidden in message:
             errors.append(f"payload contains deprecated {forbidden!r}")
+    expected_trigger = profile.get("trigger")
+    trigger = live_job.get("trigger")
+    if expected_trigger:
+        variables = expected_job.get("payload_vars") or {}
+        script_path = _format_required(expected_trigger["script_path"], variables)
+        expected_script = (WS / script_path).read_text().strip()
+        if not isinstance(trigger, dict):
+            errors.append("condition trigger missing")
+        else:
+            if (trigger.get("script") or "").strip() != expected_script:
+                errors.append(f"condition trigger does not match {script_path}")
+            if bool(trigger.get("once", False)) != bool(expected_trigger.get("once", False)):
+                errors.append(
+                    f"condition trigger once expected {expected_trigger.get('once', False)!r}"
+                )
+    elif trigger:
+        errors.append("unexpected condition trigger")
     return errors
 
 

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -32,7 +32,9 @@ from zoneinfo import ZoneInfo
 
 WS = Path(__file__).resolve().parents[2]
 HKT = ZoneInfo('Asia/Hong_Kong')
-TERMINAL_HEARTBEAT_STATES = {'completed', 'watchdog_backstop', 'market_closed'}
+TERMINAL_HEARTBEAT_STATES = {
+    'completed', 'watchdog_backstop', 'market_closed', 'no_change'
+}
 HEARTBEAT_GRACE_MINUTES = 25
 
 # Cron name → identifying commit msg patterns

--- a/scripts/data/generate_cron_docs.py
+++ b/scripts/data/generate_cron_docs.py
@@ -105,6 +105,9 @@ def render(contract: dict) -> str:
         "  MiniMax M3, the shared length limits, a unique WeChat path, and Telegram mirror.",
         "- Mode 7 writes the public `assets/data/cron-heartbeats.json` ledger through the",
         "  existing single publisher; cron health verifies every monitored slot.",
+        "- Mode 7 agent turns are condition-triggered by normalized breach/event/regime",
+        "  hashes and material repricing. Unchanged slots write an LLM-free `no_change`",
+        "  heartbeat; every sixth evaluation forces a reasoning pass.",
         "",
     ])
 

--- a/scripts/data/intraday_delta_gate.py
+++ b/scripts/data/intraday_delta_gate.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Cheap intraday state snapshot used by OpenClaw's pre-model cron trigger.
+
+The trigger evaluates this script before creating an agent turn. It compares the
+returned normalized state with its durable prior state and invokes the LLM only
+for a condition delta, a material reprice, or a low-frequency forced review.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+WS = Path(__file__).resolve().parents[2]
+HKT = ZoneInfo("Asia/Hong_Kong")
+PORTFOLIO = WS / "portfolio.json"
+
+sys.path.insert(0, str(WS / "scripts" / "data"))
+import cron_heartbeat  # noqa: E402
+import fetch_peers  # noqa: E402
+import trading_calendar  # noqa: E402
+
+
+def _load(path):
+    try:
+        value = json.loads(Path(path).read_text())
+        return value if isinstance(value, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _active_holdings(market):
+    portfolio = _load(PORTFOLIO)
+    leg = "hk_stocks" if market == "hk" else "us_stocks"
+    return [
+        holding for holding in
+        portfolio.get("portfolios", {}).get(leg, {}).get("holdings", [])
+        if (holding.get("shares") or 0) > 0
+    ]
+
+
+def _severity(pnl_pct):
+    if pnl_pct <= -18:
+        return "hard_stop"
+    if pnl_pct <= -12:
+        return "trim"
+    if pnl_pct <= -8:
+        return "watch"
+    return None
+
+
+def normalized_breaches(holdings, quotes):
+    """Stable condition set: no raw prices, only threshold buckets."""
+    rows = []
+    for holding in holdings:
+        ticker = holding.get("ticker")
+        quote = quotes.get(ticker) or {}
+        price = quote.get("price")
+        cost = holding.get("cost_basis")
+        if isinstance(price, (int, float)) and isinstance(cost, (int, float)) and cost > 0:
+            pnl_pct = (price / cost - 1) * 100
+            if level := _severity(pnl_pct):
+                rows.append({"ticker": ticker, "kind": "pnl", "level": level})
+        move = quote.get("pct_1d")
+        if isinstance(move, (int, float)) and abs(move) >= 3:
+            rows.append({
+                "ticker": ticker,
+                "kind": "move",
+                "level": "high" if abs(move) >= 5 else "medium",
+                "direction": "up" if move > 0 else "down",
+            })
+    return sorted(rows, key=lambda row: (
+        row["ticker"], row["kind"], row["level"], row.get("direction", "")
+    ))
+
+
+def _event_state(market, active_tickers):
+    """Local event provenance only; no extra news request in the cheap gate."""
+    paths = [WS / "assets" / "data" / "catalysts.json"]
+    if market == "us":
+        paths.append(WS / "assets" / "data" / "us_news_digest.json")
+    state = []
+    for path in paths:
+        doc = _load(path)
+        # generated_at changes when the event producer publishes new evidence.
+        # Matching ticker mentions makes a newly relevant held-name event visible
+        # even when a producer preserves its outer timestamp during retries.
+        raw = json.dumps(doc, ensure_ascii=False, sort_keys=True)
+        mentioned = sorted(ticker for ticker in active_tickers if ticker in raw)
+        state.append({
+            "source": path.name,
+            "generated_at": doc.get("generated_at"),
+            "mentioned": mentioned,
+            "content_hash": hashlib.sha256(raw.encode()).hexdigest(),
+        })
+    return state
+
+
+def _regime_state(market):
+    regime = _load(WS / "assets" / "data" / "lev_regime.json")
+    risk = _load(WS / "assets" / "data" / "risk.json")
+    leg = regime.get(market) or {}
+    names = [
+        {"etf": row.get("etf"), "state": row.get("state")}
+        for row in (leg.get("names") or [])
+    ]
+    alerts = sorted({
+        (row.get("type"), row.get("severity"))
+        for row in risk.get("alerts", [])
+        if row.get("type") and row.get("severity")
+    })
+    return {
+        "portfolio_tier": regime.get("tier"),
+        "leg_tier": leg.get("tier"),
+        "names": names,
+        "risk_alerts": [list(row) for row in alerts],
+    }
+
+
+def snapshot(market, *, at=None, fetcher=fetch_peers.fetch_all):
+    at = at or datetime.now(timezone.utc)
+    at = at if at.tzinfo else at.replace(tzinfo=timezone.utc)
+    local = at.astimezone(HKT)
+    job, slot = cron_heartbeat.slot_for(market, at)
+    closed = trading_calendar.closed_reason(market, local.date())
+    holdings = _active_holdings(market)
+    requests = [
+        {"ticker": holding["ticker"], "region": market}
+        for holding in holdings if holding.get("ticker")
+    ]
+    quotes = {} if closed else fetcher(requests, deadline_s=12, workers=8)
+    prices = {
+        ticker: {
+            "price": round(row["price"], 4),
+            "pct_1d": round(row.get("pct_1d") or 0, 2),
+        }
+        for ticker, row in sorted(quotes.items())
+        if isinstance(row.get("price"), (int, float)) and not row.get("stale_quote")
+    }
+    active_tickers = sorted(
+        holding["ticker"] for holding in holdings if holding.get("ticker")
+    )
+    conditions = {
+        "breaches": normalized_breaches(holdings, quotes),
+        "events": _event_state(market, active_tickers),
+        "regime": _regime_state(market),
+    }
+    condition_hash = hashlib.sha256(
+        json.dumps(conditions, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return {
+        "schema_version": 1,
+        "market": market,
+        "job": job,
+        "slot": slot,
+        "session": f"{market}:{local.date().isoformat()}",
+        "market_closed": bool(closed),
+        "closed_reason": closed,
+        "condition_hash": condition_hash,
+        "conditions": conditions,
+        "prices": prices,
+        "quote_coverage": {"priced": len(prices), "active": len(active_tickers)},
+        "error": None if closed or len(prices) == len(active_tickers) else (
+            f"quote coverage {len(prices)}/{len(active_tickers)}"
+        ),
+    }
+
+
+def record_gate(market, state, slot, reason, state_hash=None):
+    try:
+        slot_at = datetime.fromisoformat(slot)
+    except ValueError:
+        slot_at = None
+    return cron_heartbeat.record(
+        market,
+        state,
+        job_name=cron_heartbeat.slot_for(market, slot_at)[0],
+        slot=slot,
+        should_alert=False,
+        reasoning_invoked=False,
+        trigger_reason=reason,
+        state_hash=state_hash,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--market", choices=["hk", "us"], required=True)
+    parser.add_argument("--record", choices=["no_change", "market_closed"])
+    parser.add_argument("--slot")
+    parser.add_argument("--reason", default="unchanged")
+    parser.add_argument("--state-hash")
+    args = parser.parse_args()
+    if args.record:
+        if not args.slot:
+            parser.error("--slot is required with --record")
+        print(json.dumps(record_gate(
+            args.market, args.record, args.slot, args.reason, args.state_hash
+        ), ensure_ascii=False))
+        return 0
+    print(json.dumps(snapshot(args.market), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -186,6 +186,30 @@ def test_intraday_heartbeat_is_slot_keyed_published_and_health_checked(tmp_path,
     assert cron_heartbeat.publish() is False
 
 
+def test_delta_no_change_heartbeat_counts_as_healthy():
+    hkt = ZoneInfo('Asia/Hong_Kong')
+    at = datetime(2026, 7, 16, 10, 35, tzinfo=hkt)
+    ledger = {
+        'schema_version': 1,
+        'monitoring_started_at': '2026-07-16T09:00:00+08:00',
+        'events': [{
+            'job': '盘中盯盘',
+            'market': 'hk',
+            'slot': '2026-07-16T10:30:00+08:00',
+            'state': 'no_change',
+            'reasoning_invoked': False,
+        }],
+    }
+
+    coverage = cron_health.heartbeat_coverage(
+        '盘中盯盘', ['10:30'], 'Asia/Shanghai',
+        at.astimezone(timezone.utc), ledger,
+    )
+
+    assert coverage['healthy'] == ['10:30']
+    assert coverage['missing'] == []
+
+
 def test_record_keeps_existing_monitoring_epoch_for_valid_empty_ledger(tmp_path, monkeypatch):
     # A ledger that exists on disk with a real (earlier) monitoring epoch but no
     # live events must NOT be re-anchored to the first later slot — doing so would
@@ -392,12 +416,21 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
     message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    trigger_path = ROOT / profile['trigger']['script_path'].format(**vars_)
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking']},
         'delivery': {'mode': 'none'},
+        'trigger': {
+            'script': trigger_path.read_text(),
+            'once': profile['trigger']['once'],
+        },
     }
     assert cron_contract.payload_errors(data, expected, live) == []
+    del live['trigger']
+    assert cron_contract.payload_errors(data, expected, live) == [
+        'condition trigger missing'
+    ]
 
     live['payload']['message'] = message + '\nintraday_postflight.py --market hk <<< "{报告}"'
     assert cron_contract.payload_errors(data, expected, live) != []

--- a/tests/test_intraday_delta_gate.py
+++ b/tests/test_intraday_delta_gate.py
@@ -1,0 +1,93 @@
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import cron_heartbeat  # noqa: E402
+import intraday_delta_gate as gate  # noqa: E402
+
+
+def _portfolio(path):
+    path.write_text(json.dumps({
+        "portfolios": {
+            "us_stocks": {"holdings": [
+                {"ticker": "LOSS", "shares": 1, "cost_basis": 100},
+                {"ticker": "OK", "shares": 1, "cost_basis": 100},
+            ]},
+            "hk_stocks": {"holdings": []},
+        }
+    }))
+
+
+def test_normalized_breaches_change_only_at_material_buckets():
+    holdings = [
+        {"ticker": "LOSS", "cost_basis": 100},
+        {"ticker": "MOVE", "cost_basis": 100},
+    ]
+    rows = gate.normalized_breaches(holdings, {
+        "LOSS": {"price": 81.5, "pct_1d": -2.9},
+        "MOVE": {"price": 100, "pct_1d": 5.1},
+    })
+
+    assert rows == [
+        {"ticker": "LOSS", "kind": "pnl", "level": "hard_stop"},
+        {
+            "ticker": "MOVE", "kind": "move", "level": "high",
+            "direction": "up",
+        },
+    ]
+
+
+def test_snapshot_has_prices_condition_hash_and_exact_slot(monkeypatch, tmp_path):
+    _portfolio(tmp_path / "portfolio.json")
+    monkeypatch.setattr(gate, "WS", tmp_path)
+    monkeypatch.setattr(gate, "PORTFOLIO", tmp_path / "portfolio.json")
+    at = datetime(2026, 7, 24, 22, 34, tzinfo=ZoneInfo("Asia/Hong_Kong"))
+
+    snap = gate.snapshot(
+        "us",
+        at=at,
+        fetcher=lambda _requests, **_kwargs: {
+            "LOSS": {"price": 81, "pct_1d": -4},
+            "OK": {"price": 101, "pct_1d": 1},
+        },
+    )
+
+    assert snap["slot"] == "2026-07-24T22:30:00+08:00"
+    assert snap["quote_coverage"] == {"priced": 2, "active": 2}
+    assert snap["error"] is None
+    assert len(snap["condition_hash"]) == 64
+    assert any(
+        row["ticker"] == "LOSS" and row["level"] == "hard_stop"
+        for row in snap["conditions"]["breaches"]
+    )
+
+
+def test_no_change_heartbeat_is_terminal(monkeypatch, tmp_path):
+    monkeypatch.setattr(cron_heartbeat, "LOCAL_PATH", tmp_path / "local.json")
+    monkeypatch.setattr(cron_heartbeat, "PUBLIC_PATH", tmp_path / "public.json")
+    event = gate.record_gate(
+        "hk", "no_change", "2026-07-24T10:30:00+08:00",
+        "unchanged", "abc",
+    )
+
+    assert event["state"] == "no_change"
+    assert event["reasoning_invoked"] is False
+    assert event["should_alert"] is False
+
+
+def test_trigger_scripts_fail_open_and_force_low_frequency_review():
+    for market in ("hk", "us"):
+        script = (
+            ROOT / "config" / "cron-triggers" / f"intraday-{market}.js"
+        ).read_text()
+        assert "fire: true" in script
+        assert "evaluations >= 6" in script
+        assert ">= 0.01" in script
+        assert ">= 1.0" in script
+        assert "--record ${state}" in script


### PR DESCRIPTION
Closes #46

## What changed
- add native OpenClaw condition triggers in front of all three Mode 7 agentTurn jobs, so unchanged slots do not create a model-backed run
- build a bounded 12-second deterministic quote snapshot and normalized breach/event/regime hash before model selection
- fire for new/worsened/resolved conditions, >=1% price repricing, >=1pp daily-move acceleration, gate degradation, a new session, or every sixth evaluation as a forced blind-spot review
- fail open when the gate itself cannot produce valid state
- record skipped slots as LLM-free no_change heartbeats and count them as terminal healthy slots
- pin exact trigger source in the tracked cron contract and generated operations docs

## Live state
Enabled cron.triggers.enabled without a gateway restart and installed the tracked trigger scripts on all three live intraday jobs. The branch contract validates the live jobs with zero errors. Until this PR is merged and intraday_delta_gate.py exists in the live workspace, missing-gate evaluations fail open to the existing model run.

## Verification
- pytest -q: 581 passed, 5 xfailed
- focused delta/cron tests: 22 passed
- a production-shaped US gate snapshot completed in about two seconds with 7/7 quote coverage and the exact 22:30 slot
- Python compilation, Node syntax, generated-doc, live-contract, and diff checks pass