### PR TITLE
data: repair and refresh canonical daily bars

### DIFF
--- a/memory/bars/00100.json
+++ b/memory/bars/00100.json
@@ -510,6 +510,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:09+08:00"
+  },
+  "2026-07-24": {
+   "open": 195.0,
+   "high": 204.0,
+   "low": 188.3,
+   "close": 196.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/02208.json
+++ b/memory/bars/02208.json
@@ -510,6 +510,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:09+08:00"
+  },
+  "2026-07-24": {
+   "open": 10.05,
+   "high": 10.22,
+   "low": 9.71,
+   "close": 9.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/03032.json
+++ b/memory/bars/03032.json
@@ -510,6 +510,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 4.638,
+   "high": 4.646,
+   "low": 4.588,
+   "close": 4.626,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/03033.json
+++ b/memory/bars/03033.json
@@ -510,6 +510,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 4.538,
+   "high": 4.562,
+   "low": 4.504,
+   "close": 4.542,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
   }
  },
  "retired": false

--- a/memory/bars/07226.json
+++ b/memory/bars/07226.json
@@ -510,6 +510,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 3.304,
+   "high": 3.356,
+   "low": 3.27,
+   "close": 3.318,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
   }
  },
  "retired": false

--- a/memory/bars/07709.json
+++ b/memory/bars/07709.json
@@ -1,0 +1,525 @@
+{
+ "schema_version": 1,
+ "ticker": "07709",
+ "leg": "HK",
+ "tencent": "hk07709",
+ "em_audit_secid": "116.07709",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-04": {
+   "open": 52.76,
+   "high": 59.2,
+   "low": 52.76,
+   "close": 58.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-05": {
+   "open": 58.54,
+   "high": 60.6,
+   "low": 58.4,
+   "close": 60.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-06": {
+   "open": 69.0,
+   "high": 72.84,
+   "low": 69.0,
+   "close": 71.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-07": {
+   "open": 69.58,
+   "high": 77.62,
+   "low": 68.1,
+   "close": 76.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-08": {
+   "open": 76.42,
+   "high": 79.76,
+   "low": 72.76,
+   "close": 78.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-11": {
+   "open": 90.24,
+   "high": 103.7,
+   "low": 90.24,
+   "close": 97.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-12": {
+   "open": 99.0,
+   "high": 99.98,
+   "low": 87.82,
+   "close": 91.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-13": {
+   "open": 95.04,
+   "high": 106.85,
+   "low": 95.04,
+   "close": 105.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-14": {
+   "open": 106.0,
+   "high": 106.2,
+   "low": 101.5,
+   "close": 105.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-15": {
+   "open": 103.8,
+   "high": 104.0,
+   "low": 83.76,
+   "close": 90.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-18": {
+   "open": 86.0,
+   "high": 95.94,
+   "low": 86.0,
+   "close": 90.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-19": {
+   "open": 83.5,
+   "high": 85.12,
+   "low": 78.68,
+   "close": 81.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-20": {
+   "open": 79.2,
+   "high": 82.66,
+   "low": 76.28,
+   "close": 81.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-21": {
+   "open": 93.62,
+   "high": 98.88,
+   "low": 92.04,
+   "close": 93.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-22": {
+   "open": 96.0,
+   "high": 98.48,
+   "low": 95.3,
+   "close": 97.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-26": {
+   "open": 110.55,
+   "high": 112.5,
+   "low": 107.35,
+   "close": 108.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-27": {
+   "open": 124.85,
+   "high": 141.9,
+   "low": 124.85,
+   "close": 132.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-28": {
+   "open": 134.45,
+   "high": 137.4,
+   "low": 121.3,
+   "close": 133.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-29": {
+   "open": 142.0,
+   "high": 142.0,
+   "low": 135.6,
+   "close": 137.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-01": {
+   "open": 141.8,
+   "high": 148.65,
+   "low": 141.1,
+   "close": 144.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-02": {
+   "open": 136.75,
+   "high": 142.55,
+   "low": 129.8,
+   "close": 139.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-03": {
+   "open": 144.6,
+   "high": 147.95,
+   "low": 142.2,
+   "close": 146.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-04": {
+   "open": 131.95,
+   "high": 136.4,
+   "low": 130.3,
+   "close": 132.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-05": {
+   "open": 112.65,
+   "high": 123.0,
+   "low": 104.5,
+   "close": 106.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-08": {
+   "open": 95.66,
+   "high": 106.7,
+   "low": 85.7,
+   "close": 98.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-09": {
+   "open": 99.94,
+   "high": 119.6,
+   "low": 99.94,
+   "close": 113.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-10": {
+   "open": 110.0,
+   "high": 110.0,
+   "low": 93.96,
+   "close": 98.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-11": {
+   "open": 106.65,
+   "high": 107.65,
+   "low": 96.6,
+   "close": 106.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-12": {
+   "open": 121.85,
+   "high": 122.0,
+   "low": 98.2,
+   "close": 106.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-15": {
+   "open": 122.0,
+   "high": 123.4,
+   "low": 117.55,
+   "close": 121.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-16": {
+   "open": 123.0,
+   "high": 130.6,
+   "low": 123.0,
+   "close": 128.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-17": {
+   "open": 130.2,
+   "high": 145.4,
+   "low": 129.5,
+   "close": 144.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-18": {
+   "open": 152.8,
+   "high": 169.45,
+   "low": 152.1,
+   "close": 161.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-22": {
+   "open": 185.15,
+   "high": 191.5,
+   "low": 180.8,
+   "close": 187.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-23": {
+   "open": 179.0,
+   "high": 179.2,
+   "low": 134.85,
+   "close": 143.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-24": {
+   "open": 149.55,
+   "high": 157.4,
+   "low": 130.0,
+   "close": 154.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-25": {
+   "open": 167.3,
+   "high": 193.65,
+   "low": 165.2,
+   "close": 182.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-26": {
+   "open": 169.1,
+   "high": 169.1,
+   "low": 144.4,
+   "close": 157.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-29": {
+   "open": 141.1,
+   "high": 154.1,
+   "low": 136.6,
+   "close": 146.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-30": {
+   "open": 142.4,
+   "high": 159.2,
+   "low": 142.1,
+   "close": 149.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-02": {
+   "open": 126.65,
+   "high": 128.05,
+   "low": 103.45,
+   "close": 109.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-03": {
+   "open": 102.5,
+   "high": 122.95,
+   "low": 102.5,
+   "close": 116.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-06": {
+   "open": 118.45,
+   "high": 118.75,
+   "low": 103.0,
+   "close": 108.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-07": {
+   "open": 95.0,
+   "high": 98.74,
+   "low": 82.0,
+   "close": 91.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-08": {
+   "open": 100.0,
+   "high": 101.0,
+   "low": 80.3,
+   "close": 82.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-09": {
+   "open": 95.14,
+   "high": 97.22,
+   "low": 82.66,
+   "close": 96.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-10": {
+   "open": 93.0,
+   "high": 98.86,
+   "low": 89.32,
+   "close": 89.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-13": {
+   "open": 76.0,
+   "high": 76.0,
+   "low": 58.78,
+   "close": 59.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-14": {
+   "open": 63.18,
+   "high": 66.18,
+   "low": 48.72,
+   "close": 65.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-15": {
+   "open": 74.98,
+   "high": 81.5,
+   "low": 71.5,
+   "close": 71.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-16": {
+   "open": 61.02,
+   "high": 61.68,
+   "low": 55.1,
+   "close": 56.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-17": {
+   "open": 49.0,
+   "high": 50.0,
+   "low": 44.8,
+   "close": 44.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-20": {
+   "open": 51.52,
+   "high": 56.92,
+   "low": 50.44,
+   "close": 52.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-21": {
+   "open": 55.02,
+   "high": 60.0,
+   "low": 54.14,
+   "close": 57.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-22": {
+   "open": 66.46,
+   "high": 66.88,
+   "low": 55.24,
+   "close": 55.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-23": {
+   "open": 61.5,
+   "high": 62.0,
+   "low": 56.38,
+   "close": 60.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-24": {
+   "open": 56.22,
+   "high": 57.2,
+   "low": 50.64,
+   "close": 52.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  }
+ }
+}

--- a/memory/bars/07747.json
+++ b/memory/bars/07747.json
@@ -1,0 +1,525 @@
+{
+ "schema_version": 1,
+ "ticker": "07747",
+ "leg": "HK",
+ "tencent": "hk07747",
+ "em_audit_secid": "116.07747",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-04": {
+   "open": 96.2,
+   "high": 102.85,
+   "low": 96.2,
+   "close": 100.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-05": {
+   "open": 100.15,
+   "high": 103.8,
+   "low": 99.1,
+   "close": 103.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-06": {
+   "open": 119.35,
+   "high": 133.45,
+   "low": 119.35,
+   "close": 130.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-07": {
+   "open": 127.0,
+   "high": 139.0,
+   "low": 124.1,
+   "close": 138.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-08": {
+   "open": 132.0,
+   "high": 138.95,
+   "low": 125.65,
+   "close": 138.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-11": {
+   "open": 147.55,
+   "high": 151.6,
+   "low": 146.15,
+   "close": 147.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-12": {
+   "open": 147.0,
+   "high": 147.0,
+   "low": 128.3,
+   "close": 140.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-13": {
+   "open": 136.45,
+   "high": 149.8,
+   "low": 136.45,
+   "close": 149.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-14": {
+   "open": 162.0,
+   "high": 162.0,
+   "low": 151.7,
+   "close": 155.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-15": {
+   "open": 151.0,
+   "high": 152.25,
+   "low": 125.8,
+   "close": 136.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-18": {
+   "open": 136.0,
+   "high": 147.7,
+   "low": 135.0,
+   "close": 141.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-19": {
+   "open": 129.9,
+   "high": 140.9,
+   "low": 125.25,
+   "close": 138.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-20": {
+   "open": 136.05,
+   "high": 141.9,
+   "low": 124.4,
+   "close": 138.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-21": {
+   "open": 152.65,
+   "high": 158.9,
+   "low": 150.0,
+   "close": 153.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-22": {
+   "open": 153.7,
+   "high": 154.65,
+   "low": 149.7,
+   "close": 152.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-26": {
+   "open": 164.0,
+   "high": 164.0,
+   "low": 156.6,
+   "close": 157.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-27": {
+   "open": 177.45,
+   "high": 182.7,
+   "low": 165.15,
+   "close": 167.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-28": {
+   "open": 162.0,
+   "high": 162.5,
+   "low": 146.6,
+   "close": 158.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-05-29": {
+   "open": 170.1,
+   "high": 181.1,
+   "low": 168.7,
+   "close": 177.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-01": {
+   "open": 201.3,
+   "high": 219.3,
+   "low": 201.3,
+   "close": 218.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-02": {
+   "open": 222.7,
+   "high": 231.5,
+   "low": 208.9,
+   "close": 225.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-03": {
+   "open": 236.0,
+   "high": 243.1,
+   "low": 233.4,
+   "close": 238.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-04": {
+   "open": 225.0,
+   "high": 225.3,
+   "low": 212.5,
+   "close": 214.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-05": {
+   "open": 182.6,
+   "high": 205.2,
+   "low": 179.45,
+   "close": 185.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-08": {
+   "open": 159.95,
+   "high": 169.75,
+   "low": 140.05,
+   "close": 154.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-09": {
+   "open": 151.5,
+   "high": 176.25,
+   "low": 151.5,
+   "close": 168.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-10": {
+   "open": 156.85,
+   "high": 156.85,
+   "low": 141.2,
+   "close": 148.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-11": {
+   "open": 147.25,
+   "high": 152.1,
+   "low": 139.6,
+   "close": 147.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-12": {
+   "open": 169.5,
+   "high": 181.8,
+   "low": 156.3,
+   "close": 166.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-15": {
+   "open": 182.8,
+   "high": 187.0,
+   "low": 179.15,
+   "close": 187.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-16": {
+   "open": 180.5,
+   "high": 189.65,
+   "low": 180.5,
+   "close": 187.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-17": {
+   "open": 180.0,
+   "high": 196.5,
+   "low": 178.0,
+   "close": 193.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-18": {
+   "open": 197.55,
+   "high": 213.3,
+   "low": 193.0,
+   "close": 209.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-22": {
+   "open": 211.4,
+   "high": 212.3,
+   "low": 194.0,
+   "close": 203.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-23": {
+   "open": 187.35,
+   "high": 187.35,
+   "low": 143.95,
+   "close": 154.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-24": {
+   "open": 167.1,
+   "high": 179.55,
+   "low": 155.55,
+   "close": 179.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-25": {
+   "open": 198.0,
+   "high": 202.5,
+   "low": 193.3,
+   "close": 197.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-26": {
+   "open": 185.85,
+   "high": 185.85,
+   "low": 156.35,
+   "close": 176.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-29": {
+   "open": 159.95,
+   "high": 168.35,
+   "low": 151.7,
+   "close": 158.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-06-30": {
+   "open": 162.15,
+   "high": 177.45,
+   "low": 161.6,
+   "close": 167.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-02": {
+   "open": 142.4,
+   "high": 142.4,
+   "low": 115.7,
+   "close": 123.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-03": {
+   "open": 127.5,
+   "high": 141.7,
+   "low": 127.0,
+   "close": 137.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-06": {
+   "open": 146.45,
+   "high": 147.8,
+   "low": 132.25,
+   "close": 147.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-07": {
+   "open": 126.45,
+   "high": 129.6,
+   "low": 112.3,
+   "close": 123.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-08": {
+   "open": 123.15,
+   "high": 123.15,
+   "low": 104.6,
+   "close": 106.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-09": {
+   "open": 116.05,
+   "high": 116.05,
+   "low": 100.35,
+   "close": 112.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-10": {
+   "open": 116.4,
+   "high": 122.6,
+   "low": 111.05,
+   "close": 111.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-13": {
+   "open": 104.05,
+   "high": 104.1,
+   "low": 84.28,
+   "close": 89.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-14": {
+   "open": 96.6,
+   "high": 97.78,
+   "low": 82.38,
+   "close": 95.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-15": {
+   "open": 104.0,
+   "high": 109.35,
+   "low": 101.7,
+   "close": 103.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-16": {
+   "open": 87.82,
+   "high": 92.12,
+   "low": 82.28,
+   "close": 83.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-17": {
+   "open": 80.0,
+   "high": 80.0,
+   "low": 61.64,
+   "close": 67.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-20": {
+   "open": 77.28,
+   "high": 83.0,
+   "low": 76.1,
+   "close": 77.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-21": {
+   "open": 84.54,
+   "high": 90.5,
+   "low": 84.54,
+   "close": 89.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-22": {
+   "open": 98.3,
+   "high": 99.46,
+   "low": 88.28,
+   "close": 88.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-23": {
+   "open": 96.1,
+   "high": 96.58,
+   "low": 90.9,
+   "close": 95.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  },
+  "2026-07-24": {
+   "open": 88.46,
+   "high": 88.72,
+   "low": 79.52,
+   "close": 82.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
+  }
+ }
+}

--- a/memory/bars/CRCL.json
+++ b/memory/bars/CRCL.json
@@ -519,6 +519,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 61.62,
+   "high": 63.18,
+   "low": 59.96,
+   "close": 62.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:47+08:00"
   }
  },
  "retired": false

--- a/memory/bars/HOOD.json
+++ b/memory/bars/HOOD.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "HOOD",
+ "leg": "US",
+ "tencent": "usHOOD.OQ",
+ "em_audit_secid": "105.HOOD",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 73.78,
+   "high": 75.28,
+   "low": 73.06,
+   "close": 73.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-04": {
+   "open": 74.7,
+   "high": 78.29,
+   "low": 74.63,
+   "close": 76.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-05": {
+   "open": 77.62,
+   "high": 78.75,
+   "low": 76.49,
+   "close": 77.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-06": {
+   "open": 77.8,
+   "high": 79.49,
+   "low": 76.19,
+   "close": 79.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-07": {
+   "open": 78.96,
+   "high": 79.23,
+   "low": 75.46,
+   "close": 76.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-08": {
+   "open": 76.24,
+   "high": 77.07,
+   "low": 74.25,
+   "close": 77.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-11": {
+   "open": 76.79,
+   "high": 81.14,
+   "low": 74.8,
+   "close": 80.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-12": {
+   "open": 79.08,
+   "high": 80.18,
+   "low": 76.48,
+   "close": 78.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-13": {
+   "open": 77.07,
+   "high": 77.62,
+   "low": 75.34,
+   "close": 76.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-14": {
+   "open": 76.05,
+   "high": 81.93,
+   "low": 75.11,
+   "close": 80.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-15": {
+   "open": 78.54,
+   "high": 78.58,
+   "low": 76.41,
+   "close": 77.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-18": {
+   "open": 76.0,
+   "high": 79.92,
+   "low": 75.47,
+   "close": 77.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-19": {
+   "open": 76.15,
+   "high": 76.37,
+   "low": 73.18,
+   "close": 74.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-20": {
+   "open": 74.75,
+   "high": 76.35,
+   "low": 73.75,
+   "close": 75.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-21": {
+   "open": 74.95,
+   "high": 76.76,
+   "low": 74.65,
+   "close": 75.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-22": {
+   "open": 76.32,
+   "high": 77.11,
+   "low": 73.26,
+   "close": 73.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-26": {
+   "open": 74.5,
+   "high": 76.04,
+   "low": 73.46,
+   "close": 74.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-27": {
+   "open": 73.92,
+   "high": 76.64,
+   "low": 73.45,
+   "close": 76.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-28": {
+   "open": 74.85,
+   "high": 84.92,
+   "low": 73.53,
+   "close": 84.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-29": {
+   "open": 85.66,
+   "high": 94.4,
+   "low": 84.24,
+   "close": 94.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-01": {
+   "open": 89.94,
+   "high": 92.4,
+   "low": 85.56,
+   "close": 90.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-02": {
+   "open": 88.67,
+   "high": 89.43,
+   "low": 86.13,
+   "close": 88.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-03": {
+   "open": 86.45,
+   "high": 86.82,
+   "low": 82.41,
+   "close": 82.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-04": {
+   "open": 83.26,
+   "high": 88.62,
+   "low": 82.8,
+   "close": 88.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-05": {
+   "open": 86.57,
+   "high": 87.33,
+   "low": 79.49,
+   "close": 82.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-08": {
+   "open": 84.62,
+   "high": 85.63,
+   "low": 82.81,
+   "close": 85.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-09": {
+   "open": 85.87,
+   "high": 88.08,
+   "low": 78.93,
+   "close": 83.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-10": {
+   "open": 84.09,
+   "high": 91.46,
+   "low": 84.08,
+   "close": 86.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-11": {
+   "open": 87.08,
+   "high": 93.64,
+   "low": 85.72,
+   "close": 92.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-12": {
+   "open": 92.74,
+   "high": 96.1,
+   "low": 90.22,
+   "close": 93.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-15": {
+   "open": 98.72,
+   "high": 100.87,
+   "low": 97.45,
+   "close": 98.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-16": {
+   "open": 100.17,
+   "high": 101.88,
+   "low": 94.57,
+   "close": 96.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-17": {
+   "open": 95.94,
+   "high": 110.73,
+   "low": 95.76,
+   "close": 105.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-18": {
+   "open": 107.83,
+   "high": 109.08,
+   "low": 103.46,
+   "close": 108.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-22": {
+   "open": 108.0,
+   "high": 112.5,
+   "low": 105.28,
+   "close": 105.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-23": {
+   "open": 101.65,
+   "high": 105.99,
+   "low": 101.03,
+   "close": 103.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-24": {
+   "open": 102.35,
+   "high": 104.27,
+   "low": 96.3,
+   "close": 97.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-25": {
+   "open": 98.79,
+   "high": 99.19,
+   "low": 92.8,
+   "close": 93.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-26": {
+   "open": 93.22,
+   "high": 99.44,
+   "low": 93.08,
+   "close": 98.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-29": {
+   "open": 100.66,
+   "high": 102.85,
+   "low": 98.05,
+   "close": 101.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-30": {
+   "open": 101.87,
+   "high": 103.06,
+   "low": 99.66,
+   "close": 100.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-01": {
+   "open": 100.67,
+   "high": 109.53,
+   "low": 100.39,
+   "close": 108.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-02": {
+   "open": 112.76,
+   "high": 120.05,
+   "low": 110.93,
+   "close": 112.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-06": {
+   "open": 111.41,
+   "high": 118.65,
+   "low": 111.41,
+   "close": 117.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-07": {
+   "open": 115.78,
+   "high": 117.85,
+   "low": 112.53,
+   "close": 112.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-08": {
+   "open": 110.87,
+   "high": 114.13,
+   "low": 108.89,
+   "close": 113.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-09": {
+   "open": 112.23,
+   "high": 117.65,
+   "low": 111.63,
+   "close": 115.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-10": {
+   "open": 119.16,
+   "high": 119.43,
+   "low": 108.81,
+   "close": 111.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-13": {
+   "open": 111.27,
+   "high": 113.7,
+   "low": 108.84,
+   "close": 109.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-14": {
+   "open": 111.03,
+   "high": 113.69,
+   "low": 109.1,
+   "close": 113.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-15": {
+   "open": 114.97,
+   "high": 116.6,
+   "low": 112.12,
+   "close": 115.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-16": {
+   "open": 114.13,
+   "high": 114.52,
+   "low": 105.48,
+   "close": 106.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-17": {
+   "open": 100.37,
+   "high": 104.11,
+   "low": 96.59,
+   "close": 99.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-20": {
+   "open": 102.49,
+   "high": 102.6,
+   "low": 98.61,
+   "close": 99.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-21": {
+   "open": 102.82,
+   "high": 108.21,
+   "low": 102.82,
+   "close": 106.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-22": {
+   "open": 104.72,
+   "high": 106.89,
+   "low": 104.33,
+   "close": 104.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-23": {
+   "open": 101.88,
+   "high": 104.12,
+   "low": 99.32,
+   "close": 101.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-24": {
+   "open": 100.07,
+   "high": 100.08,
+   "low": 93.03,
+   "close": 94.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  }
+ }
+}

--- a/memory/bars/MSFT.json
+++ b/memory/bars/MSFT.json
@@ -519,6 +519,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 387.05,
+   "high": 389.03,
+   "low": 380.65,
+   "close": 381.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/MSFU.json
+++ b/memory/bars/MSFU.json
@@ -504,12 +504,20 @@
   },
   "2026-07-22": {
    "open": 25.18,
-   "high": 25.29,
+   "high": 25.3,
    "low": 23.57,
    "close": 23.99,
    "source": "tencent",
    "adjustment": "raw",
-   "fetched_at": "2026-07-23T08:02:38+08:00"
+   "fetched_at": "2026-07-26T15:09:48+08:00",
+   "revised_from": {
+    "open": 25.18,
+    "high": 25.29,
+    "low": 23.57,
+    "close": 23.99
+   },
+   "revised_at": "2026-07-26T15:09:48+08:00",
+   "revision_reason": "explicit --repair"
   },
   "2026-07-23": {
    "open": 23.93,
@@ -519,6 +527,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:10+08:00"
+  },
+  "2026-07-24": {
+   "open": 23.6,
+   "high": 23.77,
+   "low": 22.78,
+   "close": 22.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/NVDA.json
+++ b/memory/bars/NVDA.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "NVDA",
+ "leg": "US",
+ "tencent": "usNVDA.OQ",
+ "em_audit_secid": "105.NVDA",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 201.28,
+   "high": 203.0,
+   "low": 197.12,
+   "close": 198.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-04": {
+   "open": 199.5,
+   "high": 201.73,
+   "low": 194.74,
+   "close": 198.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-05": {
+   "open": 199.3,
+   "high": 200.24,
+   "low": 196.03,
+   "close": 196.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-06": {
+   "open": 199.89,
+   "high": 208.27,
+   "low": 198.61,
+   "close": 207.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-07": {
+   "open": 208.34,
+   "high": 214.2,
+   "low": 206.5,
+   "close": 211.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-08": {
+   "open": 213.03,
+   "high": 217.8,
+   "low": 212.89,
+   "close": 215.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-11": {
+   "open": 214.04,
+   "high": 222.3,
+   "low": 213.89,
+   "close": 219.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-12": {
+   "open": 218.55,
+   "high": 223.75,
+   "low": 214.92,
+   "close": 220.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-13": {
+   "open": 224.93,
+   "high": 227.84,
+   "low": 221.57,
+   "close": 225.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-14": {
+   "open": 229.85,
+   "high": 236.54,
+   "low": 229.3,
+   "close": 235.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-15": {
+   "open": 229.76,
+   "high": 231.5,
+   "low": 224.24,
+   "close": 225.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-18": {
+   "open": 229.87,
+   "high": 230.0,
+   "low": 218.37,
+   "close": 222.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-19": {
+   "open": 219.62,
+   "high": 224.48,
+   "low": 217.91,
+   "close": 220.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-20": {
+   "open": 223.18,
+   "high": 226.13,
+   "low": 220.5,
+   "close": 223.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-21": {
+   "open": 222.29,
+   "high": 227.4,
+   "low": 217.93,
+   "close": 219.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-22": {
+   "open": 220.9,
+   "high": 221.01,
+   "low": 214.8,
+   "close": 215.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-26": {
+   "open": 216.54,
+   "high": 218.18,
+   "low": 212.0,
+   "close": 214.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-27": {
+   "open": 214.12,
+   "high": 214.15,
+   "low": 208.78,
+   "close": 212.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-28": {
+   "open": 211.28,
+   "high": 215.52,
+   "low": 211.22,
+   "close": 214.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-29": {
+   "open": 214.58,
+   "high": 217.86,
+   "low": 211.13,
+   "close": 211.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-01": {
+   "open": 215.73,
+   "high": 224.87,
+   "low": 215.7,
+   "close": 224.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-02": {
+   "open": 227.18,
+   "high": 232.28,
+   "low": 221.35,
+   "close": 222.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-03": {
+   "open": 221.72,
+   "high": 222.82,
+   "low": 214.51,
+   "close": 214.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-04": {
+   "open": 213.91,
+   "high": 221.6,
+   "low": 210.97,
+   "close": 218.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-05": {
+   "open": 214.53,
+   "high": 214.87,
+   "low": 204.33,
+   "close": 205.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-08": {
+   "open": 210.18,
+   "high": 210.47,
+   "low": 206.0,
+   "close": 208.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-09": {
+   "open": 210.62,
+   "high": 211.4,
+   "low": 199.34,
+   "close": 208.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-10": {
+   "open": 204.43,
+   "high": 207.22,
+   "low": 199.92,
+   "close": 200.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-11": {
+   "open": 201.49,
+   "high": 205.66,
+   "low": 199.54,
+   "close": 204.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-12": {
+   "open": 204.86,
+   "high": 207.07,
+   "low": 203.44,
+   "close": 205.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-15": {
+   "open": 208.92,
+   "high": 212.71,
+   "low": 208.34,
+   "close": 212.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-16": {
+   "open": 211.18,
+   "high": 211.49,
+   "low": 207.29,
+   "close": 207.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-17": {
+   "open": 208.53,
+   "high": 209.21,
+   "low": 203.08,
+   "close": 204.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-18": {
+   "open": 207.33,
+   "high": 211.39,
+   "low": 206.5,
+   "close": 210.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-22": {
+   "open": 211.44,
+   "high": 213.99,
+   "low": 207.72,
+   "close": 208.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-23": {
+   "open": 202.17,
+   "high": 203.77,
+   "low": 200.0,
+   "close": 200.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-24": {
+   "open": 200.12,
+   "high": 201.67,
+   "low": 196.58,
+   "close": 199.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-25": {
+   "open": 200.08,
+   "high": 200.8,
+   "low": 192.13,
+   "close": 195.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-26": {
+   "open": 193.12,
+   "high": 195.55,
+   "low": 191.22,
+   "close": 192.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-29": {
+   "open": 193.85,
+   "high": 196.18,
+   "low": 189.8,
+   "close": 194.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-30": {
+   "open": 197.24,
+   "high": 200.63,
+   "low": 195.11,
+   "close": 200.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-01": {
+   "open": 196.2,
+   "high": 199.85,
+   "low": 193.45,
+   "close": 197.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-02": {
+   "open": 197.14,
+   "high": 200.06,
+   "low": 192.35,
+   "close": 194.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-06": {
+   "open": 194.42,
+   "high": 197.55,
+   "low": 193.99,
+   "close": 195.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-07": {
+   "open": 192.37,
+   "high": 198.41,
+   "low": 191.14,
+   "close": 196.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-08": {
+   "open": 195.18,
+   "high": 205.16,
+   "low": 195.06,
+   "close": 204.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-09": {
+   "open": 204.46,
+   "high": 204.59,
+   "low": 198.96,
+   "close": 202.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-10": {
+   "open": 202.0,
+   "high": 211.0,
+   "low": 201.92,
+   "close": 210.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-13": {
+   "open": 208.54,
+   "high": 210.57,
+   "low": 203.0,
+   "close": 203.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-14": {
+   "open": 208.2,
+   "high": 212.55,
+   "low": 203.8,
+   "close": 211.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-15": {
+   "open": 211.96,
+   "high": 213.81,
+   "low": 206.04,
+   "close": 212.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-16": {
+   "open": 210.17,
+   "high": 211.08,
+   "low": 205.85,
+   "close": 207.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-17": {
+   "open": 202.64,
+   "high": 206.65,
+   "low": 197.97,
+   "close": 202.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-20": {
+   "open": 205.87,
+   "high": 207.74,
+   "low": 202.28,
+   "close": 203.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-21": {
+   "open": 207.54,
+   "high": 208.65,
+   "low": 204.01,
+   "close": 207.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-22": {
+   "open": 205.81,
+   "high": 214.39,
+   "low": 204.95,
+   "close": 212.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-23": {
+   "open": 209.46,
+   "high": 210.87,
+   "low": 205.96,
+   "close": 208.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-24": {
+   "open": 207.45,
+   "high": 211.91,
+   "low": 204.81,
+   "close": 206.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  }
+ }
+}

--- a/memory/bars/OKLO.json
+++ b/memory/bars/OKLO.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "OKLO",
+ "leg": "US",
+ "tencent": "usOKLO.N",
+ "em_audit_secid": "106.OKLO",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 71.68,
+   "high": 71.68,
+   "low": 68.47,
+   "close": 70.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-04": {
+   "open": 70.45,
+   "high": 72.3,
+   "low": 68.5,
+   "close": 68.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-05": {
+   "open": 69.01,
+   "high": 69.24,
+   "low": 66.08,
+   "close": 68.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-06": {
+   "open": 71.21,
+   "high": 80.08,
+   "low": 69.25,
+   "close": 79.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-07": {
+   "open": 78.0,
+   "high": 79.5,
+   "low": 70.87,
+   "close": 71.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-08": {
+   "open": 73.7,
+   "high": 74.0,
+   "low": 70.0,
+   "close": 72.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-11": {
+   "open": 71.41,
+   "high": 79.65,
+   "low": 69.22,
+   "close": 78.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-12": {
+   "open": 75.73,
+   "high": 76.68,
+   "low": 70.3,
+   "close": 73.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-13": {
+   "open": 73.37,
+   "high": 73.4,
+   "low": 68.1,
+   "close": 69.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-14": {
+   "open": 67.39,
+   "high": 67.7,
+   "low": 64.66,
+   "close": 67.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-15": {
+   "open": 64.8,
+   "high": 65.0,
+   "low": 61.73,
+   "close": 62.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-18": {
+   "open": 62.45,
+   "high": 63.0,
+   "low": 56.8,
+   "close": 58.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-19": {
+   "open": 56.73,
+   "high": 57.77,
+   "low": 53.96,
+   "close": 55.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-20": {
+   "open": 57.56,
+   "high": 62.9,
+   "low": 56.64,
+   "close": 62.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-21": {
+   "open": 61.92,
+   "high": 65.29,
+   "low": 61.1,
+   "close": 65.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-22": {
+   "open": 66.82,
+   "high": 69.72,
+   "low": 65.13,
+   "close": 65.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-26": {
+   "open": 71.87,
+   "high": 73.29,
+   "low": 68.08,
+   "close": 68.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-27": {
+   "open": 69.34,
+   "high": 69.52,
+   "low": 65.37,
+   "close": 67.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-28": {
+   "open": 66.48,
+   "high": 70.98,
+   "low": 65.62,
+   "close": 68.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-05-29": {
+   "open": 68.09,
+   "high": 70.01,
+   "low": 64.28,
+   "close": 66.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-01": {
+   "open": 65.9,
+   "high": 70.6,
+   "low": 64.57,
+   "close": 66.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-02": {
+   "open": 67.1,
+   "high": 73.86,
+   "low": 65.66,
+   "close": 73.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-03": {
+   "open": 70.72,
+   "high": 70.85,
+   "low": 64.05,
+   "close": 65.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-04": {
+   "open": 64.51,
+   "high": 66.57,
+   "low": 63.33,
+   "close": 65.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-05": {
+   "open": 64.8,
+   "high": 64.81,
+   "low": 56.63,
+   "close": 58.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-08": {
+   "open": 60.1,
+   "high": 60.35,
+   "low": 58.0,
+   "close": 58.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-09": {
+   "open": 59.01,
+   "high": 59.88,
+   "low": 53.01,
+   "close": 56.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-10": {
+   "open": 55.43,
+   "high": 57.88,
+   "low": 53.83,
+   "close": 54.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-11": {
+   "open": 54.15,
+   "high": 58.24,
+   "low": 53.42,
+   "close": 57.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-12": {
+   "open": 58.05,
+   "high": 58.58,
+   "low": 55.88,
+   "close": 57.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-15": {
+   "open": 60.48,
+   "high": 61.98,
+   "low": 59.81,
+   "close": 60.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-16": {
+   "open": 59.94,
+   "high": 61.95,
+   "low": 57.33,
+   "close": 57.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-17": {
+   "open": 57.02,
+   "high": 61.69,
+   "low": 56.83,
+   "close": 58.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-18": {
+   "open": 59.83,
+   "high": 63.0,
+   "low": 58.56,
+   "close": 61.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-22": {
+   "open": 59.17,
+   "high": 59.88,
+   "low": 57.25,
+   "close": 58.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-23": {
+   "open": 55.88,
+   "high": 61.3,
+   "low": 55.39,
+   "close": 57.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-24": {
+   "open": 56.69,
+   "high": 56.69,
+   "low": 52.87,
+   "close": 54.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-25": {
+   "open": 55.56,
+   "high": 55.8,
+   "low": 50.43,
+   "close": 51.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-26": {
+   "open": 50.0,
+   "high": 51.35,
+   "low": 49.56,
+   "close": 50.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-29": {
+   "open": 51.4,
+   "high": 53.58,
+   "low": 50.51,
+   "close": 52.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-06-30": {
+   "open": 53.09,
+   "high": 53.23,
+   "low": 50.76,
+   "close": 52.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-01": {
+   "open": 53.63,
+   "high": 54.32,
+   "low": 51.51,
+   "close": 52.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-02": {
+   "open": 52.8,
+   "high": 56.34,
+   "low": 50.69,
+   "close": 52.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-06": {
+   "open": 51.4,
+   "high": 53.08,
+   "low": 50.25,
+   "close": 51.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-07": {
+   "open": 50.85,
+   "high": 51.38,
+   "low": 46.95,
+   "close": 47.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-08": {
+   "open": 47.54,
+   "high": 48.61,
+   "low": 45.83,
+   "close": 47.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-09": {
+   "open": 47.85,
+   "high": 50.23,
+   "low": 47.29,
+   "close": 49.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-10": {
+   "open": 49.44,
+   "high": 50.65,
+   "low": 47.63,
+   "close": 48.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-13": {
+   "open": 47.72,
+   "high": 48.12,
+   "low": 45.07,
+   "close": 45.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-14": {
+   "open": 46.96,
+   "high": 47.42,
+   "low": 45.44,
+   "close": 46.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-15": {
+   "open": 46.79,
+   "high": 47.52,
+   "low": 44.16,
+   "close": 45.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-16": {
+   "open": 44.3,
+   "high": 44.36,
+   "low": 40.98,
+   "close": 41.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-17": {
+   "open": 40.48,
+   "high": 42.59,
+   "low": 39.53,
+   "close": 41.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-20": {
+   "open": 41.25,
+   "high": 42.81,
+   "low": 40.75,
+   "close": 41.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-21": {
+   "open": 42.4,
+   "high": 44.19,
+   "low": 42.27,
+   "close": 44.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-22": {
+   "open": 45.2,
+   "high": 47.51,
+   "low": 44.08,
+   "close": 44.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-23": {
+   "open": 43.08,
+   "high": 44.59,
+   "low": 42.24,
+   "close": 44.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  },
+  "2026-07-24": {
+   "open": 43.59,
+   "high": 43.61,
+   "low": 40.15,
+   "close": 40.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
+  }
+ }
+}

--- a/memory/bars/PLTR.json
+++ b/memory/bars/PLTR.json
@@ -504,12 +504,20 @@
   },
   "2026-07-22": {
    "open": 132.22,
-   "high": 132.31,
+   "high": 132.35,
    "low": 123.45,
    "close": 124.57,
    "source": "tencent",
    "adjustment": "raw",
-   "fetched_at": "2026-07-23T08:02:38+08:00"
+   "fetched_at": "2026-07-26T15:09:48+08:00",
+   "revised_from": {
+    "open": 132.22,
+    "high": 132.31,
+    "low": 123.45,
+    "close": 124.57
+   },
+   "revised_at": "2026-07-26T15:09:48+08:00",
+   "revision_reason": "explicit --repair"
   },
   "2026-07-23": {
    "open": 125.94,
@@ -519,6 +527,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 125.17,
+   "high": 125.31,
+   "low": 122.02,
+   "close": 122.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/PLTU.json
+++ b/memory/bars/PLTU.json
@@ -496,20 +496,36 @@
   "2026-07-21": {
    "open": 32.66,
    "high": 33.0,
-   "low": 31.38,
+   "low": 31.36,
    "close": 32.02,
    "source": "tencent",
    "adjustment": "raw",
-   "fetched_at": "2026-07-22T08:02:42+08:00"
+   "fetched_at": "2026-07-26T15:09:49+08:00",
+   "revised_from": {
+    "open": 32.66,
+    "high": 33.0,
+    "low": 31.38,
+    "close": 32.02
+   },
+   "revised_at": "2026-07-26T15:09:49+08:00",
+   "revision_reason": "explicit --repair"
   },
   "2026-07-22": {
    "open": 31.94,
    "high": 31.95,
-   "low": 27.64,
+   "low": 27.62,
    "close": 28.15,
    "source": "tencent",
    "adjustment": "raw",
-   "fetched_at": "2026-07-23T08:02:39+08:00"
+   "fetched_at": "2026-07-26T15:09:49+08:00",
+   "revised_from": {
+    "open": 31.94,
+    "high": 31.95,
+    "low": 27.64,
+    "close": 28.15
+   },
+   "revised_at": "2026-07-26T15:09:49+08:00",
+   "revision_reason": "explicit --repair"
   },
   "2026-07-23": {
    "open": 28.74,
@@ -519,6 +535,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 28.32,
+   "high": 28.44,
+   "low": 26.97,
+   "close": 27.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/QQQ.json
+++ b/memory/bars/QQQ.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "QQQ",
+ "leg": "US",
+ "tencent": "usQQQ.OQ",
+ "em_audit_secid": "105.QQQ",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 669.16,
+   "high": 675.97,
+   "low": 668.8,
+   "close": 674.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-04": {
+   "open": 674.66,
+   "high": 676.73,
+   "low": 668.9,
+   "close": 672.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-05": {
+   "open": 677.96,
+   "high": 682.77,
+   "low": 677.51,
+   "close": 681.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-06": {
+   "open": 687.78,
+   "high": 695.93,
+   "low": 686.48,
+   "close": 695.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-07": {
+   "open": 696.58,
+   "high": 701.24,
+   "low": 691.77,
+   "close": 694.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-08": {
+   "open": 699.92,
+   "high": 711.23,
+   "low": 699.5,
+   "close": 711.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-11": {
+   "open": 710.36,
+   "high": 714.59,
+   "low": 708.91,
+   "close": 713.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-12": {
+   "open": 708.22,
+   "high": 710.18,
+   "low": 696.64,
+   "close": 707.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-13": {
+   "open": 709.96,
+   "high": 716.65,
+   "low": 704.83,
+   "close": 714.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-14": {
+   "open": 714.62,
+   "high": 722.03,
+   "low": 714.22,
+   "close": 719.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-15": {
+   "open": 710.14,
+   "high": 715.13,
+   "low": 705.55,
+   "close": 708.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-18": {
+   "open": 711.54,
+   "high": 712.07,
+   "low": 698.85,
+   "close": 705.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-19": {
+   "open": 699.81,
+   "high": 706.49,
+   "low": 695.25,
+   "close": 701.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-20": {
+   "open": 705.29,
+   "high": 713.15,
+   "low": 703.79,
+   "close": 713.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-21": {
+   "open": 708.99,
+   "high": 717.12,
+   "low": 706.77,
+   "close": 714.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-22": {
+   "open": 718.07,
+   "high": 722.12,
+   "low": 715.95,
+   "close": 717.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-26": {
+   "open": 725.96,
+   "high": 731.17,
+   "low": 724.16,
+   "close": 730.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-27": {
+   "open": 732.96,
+   "high": 733.32,
+   "low": 725.44,
+   "close": 729.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-28": {
+   "open": 729.73,
+   "high": 736.6,
+   "low": 726.41,
+   "close": 735.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-05-29": {
+   "open": 737.84,
+   "high": 741.63,
+   "low": 735.25,
+   "close": 738.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-01": {
+   "open": 737.04,
+   "high": 745.65,
+   "low": 735.99,
+   "close": 742.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-02": {
+   "open": 742.4,
+   "high": 746.44,
+   "low": 739.23,
+   "close": 746.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-03": {
+   "open": 747.31,
+   "high": 748.65,
+   "low": 741.01,
+   "close": 744.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-04": {
+   "open": 735.48,
+   "high": 743.5,
+   "low": 732.62,
+   "close": 740.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-05": {
+   "open": 730.06,
+   "high": 731.69,
+   "low": 704.32,
+   "close": 705.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-08": {
+   "open": 717.81,
+   "high": 723.03,
+   "low": 713.07,
+   "close": 716.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-09": {
+   "open": 722.98,
+   "high": 725.66,
+   "low": 686.37,
+   "close": 707.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-10": {
+   "open": 701.66,
+   "high": 711.28,
+   "low": 692.93,
+   "close": 693.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-11": {
+   "open": 699.29,
+   "high": 718.37,
+   "low": 695.0,
+   "close": 717.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-12": {
+   "open": 717.61,
+   "high": 724.01,
+   "low": 711.28,
+   "close": 721.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-15": {
+   "open": 738.1,
+   "high": 744.76,
+   "low": 737.38,
+   "close": 744.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-16": {
+   "open": 742.25,
+   "high": 744.22,
+   "low": 729.64,
+   "close": 729.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-17": {
+   "open": 735.19,
+   "high": 735.68,
+   "low": 720.85,
+   "close": 722.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-18": {
+   "open": 737.2,
+   "high": 741.82,
+   "low": 732.51,
+   "close": 740.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-22": {
+   "open": 742.02,
+   "high": 745.45,
+   "low": 734.39,
+   "close": 737.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-23": {
+   "open": 715.74,
+   "high": 723.61,
+   "low": 712.11,
+   "close": 713.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-24": {
+   "open": 715.37,
+   "high": 719.93,
+   "low": 704.45,
+   "close": 710.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-25": {
+   "open": 725.9,
+   "high": 726.83,
+   "low": 705.3,
+   "close": 716.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-26": {
+   "open": 707.13,
+   "high": 715.56,
+   "low": 702.81,
+   "close": 706.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-29": {
+   "open": 713.99,
+   "high": 724.58,
+   "low": 705.17,
+   "close": 724.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-06-30": {
+   "open": 724.18,
+   "high": 737.62,
+   "low": 723.91,
+   "close": 736.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-01": {
+   "open": 729.19,
+   "high": 731.92,
+   "low": 724.6,
+   "close": 725.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-02": {
+   "open": 725.58,
+   "high": 730.83,
+   "low": 707.56,
+   "close": 712.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-06": {
+   "open": 719.93,
+   "high": 726.08,
+   "low": 718.45,
+   "close": 722.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-07": {
+   "open": 714.17,
+   "high": 716.35,
+   "low": 704.9,
+   "close": 709.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-08": {
+   "open": 704.95,
+   "high": 712.26,
+   "low": 700.91,
+   "close": 711.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-09": {
+   "open": 718.33,
+   "high": 724.23,
+   "low": 715.13,
+   "close": 723.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-10": {
+   "open": 720.7,
+   "high": 726.39,
+   "low": 717.0,
+   "close": 725.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-13": {
+   "open": 717.72,
+   "high": 718.74,
+   "low": 710.08,
+   "close": 711.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-14": {
+   "open": 720.22,
+   "high": 722.29,
+   "low": 714.34,
+   "close": 719.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-15": {
+   "open": 723.85,
+   "high": 724.36,
+   "low": 710.23,
+   "close": 717.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-16": {
+   "open": 712.01,
+   "high": 713.6,
+   "low": 702.61,
+   "close": 705.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-17": {
+   "open": 691.65,
+   "high": 702.3,
+   "low": 686.76,
+   "close": 695.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-20": {
+   "open": 702.16,
+   "high": 705.8,
+   "low": 695.51,
+   "close": 696.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-21": {
+   "open": 706.57,
+   "high": 710.05,
+   "low": 702.8,
+   "close": 708.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-22": {
+   "open": 703.62,
+   "high": 709.65,
+   "low": 703.62,
+   "close": 705.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-23": {
+   "open": 694.67,
+   "high": 698.66,
+   "low": 687.79,
+   "close": 691.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  },
+  "2026-07-24": {
+   "open": 690.41,
+   "high": 692.63,
+   "low": 682.48,
+   "close": 684.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
+  }
+ }
+}

--- a/memory/bars/RKLB.json
+++ b/memory/bars/RKLB.json
@@ -519,6 +519,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 69.3,
+   "high": 69.55,
+   "low": 63.0,
+   "close": 63.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/RKLX.json
+++ b/memory/bars/RKLX.json
@@ -496,11 +496,19 @@
   "2026-07-21": {
    "open": 17.83,
    "high": 19.67,
-   "low": 17.63,
+   "low": 17.62,
    "close": 19.33,
    "source": "tencent",
    "adjustment": "raw",
-   "fetched_at": "2026-07-22T08:02:42+08:00"
+   "fetched_at": "2026-07-26T15:09:49+08:00",
+   "revised_from": {
+    "open": 17.83,
+    "high": 19.67,
+    "low": 17.63,
+    "close": 19.33
+   },
+   "revised_at": "2026-07-26T15:09:49+08:00",
+   "revision_reason": "explicit --repair"
   },
   "2026-07-22": {
    "open": 20.09,
@@ -519,6 +527,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 19.48,
+   "high": 19.48,
+   "low": 16.07,
+   "close": 16.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/ROBN.json
+++ b/memory/bars/ROBN.json
@@ -519,6 +519,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 28.74,
+   "high": 28.74,
+   "low": 24.68,
+   "close": 25.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SKHY.json
+++ b/memory/bars/SKHY.json
@@ -96,6 +96,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:11+08:00"
+  },
+  "2026-07-24": {
+   "open": 163.91,
+   "high": 164.2,
+   "low": 153.1,
+   "close": 154.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SOXL.json
+++ b/memory/bars/SOXL.json
@@ -519,6 +519,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:12+08:00"
+  },
+  "2026-07-24": {
+   "open": 151.45,
+   "high": 154.5,
+   "low": 132.55,
+   "close": 136.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SOXX.json
+++ b/memory/bars/SOXX.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "SOXX",
+ "leg": "US",
+ "tencent": "usSOXX.OQ",
+ "em_audit_secid": "105.SOXX",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 458.47,
+   "high": 466.91,
+   "low": 455.07,
+   "close": 465.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-04": {
+   "open": 467.93,
+   "high": 469.61,
+   "low": 457.81,
+   "close": 462.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-05": {
+   "open": 471.14,
+   "high": 486.18,
+   "low": 470.23,
+   "close": 482.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-06": {
+   "open": 497.96,
+   "high": 506.94,
+   "low": 487.86,
+   "close": 506.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-07": {
+   "open": 502.93,
+   "high": 503.68,
+   "low": 488.13,
+   "close": 492.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-08": {
+   "open": 504.24,
+   "high": 520.46,
+   "low": 502.75,
+   "close": 520.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-11": {
+   "open": 524.08,
+   "high": 533.74,
+   "low": 521.66,
+   "close": 532.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-12": {
+   "open": 520.85,
+   "high": 525.15,
+   "low": 495.71,
+   "close": 515.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-13": {
+   "open": 527.62,
+   "high": 532.25,
+   "low": 515.94,
+   "close": 528.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-14": {
+   "open": 526.5,
+   "high": 533.13,
+   "low": 522.21,
+   "close": 530.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-15": {
+   "open": 511.67,
+   "high": 518.79,
+   "low": 506.26,
+   "close": 508.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-18": {
+   "open": 518.02,
+   "high": 519.96,
+   "low": 486.92,
+   "close": 495.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-19": {
+   "open": 484.4,
+   "high": 506.04,
+   "low": 477.95,
+   "close": 496.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-20": {
+   "open": 507.73,
+   "high": 520.54,
+   "low": 506.55,
+   "close": 520.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-21": {
+   "open": 518.17,
+   "high": 526.78,
+   "low": 515.0,
+   "close": 524.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-22": {
+   "open": 531.88,
+   "high": 541.89,
+   "low": 530.17,
+   "close": 537.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-26": {
+   "open": 556.99,
+   "high": 572.95,
+   "low": 555.41,
+   "close": 570.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-27": {
+   "open": 584.38,
+   "high": 584.5,
+   "low": 551.89,
+   "close": 563.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-28": {
+   "open": 564.32,
+   "high": 575.8,
+   "low": 554.83,
+   "close": 569.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-29": {
+   "open": 576.44,
+   "high": 582.23,
+   "low": 564.6,
+   "close": 569.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-01": {
+   "open": 563.67,
+   "high": 577.99,
+   "low": 557.38,
+   "close": 571.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-02": {
+   "open": 585.17,
+   "high": 605.44,
+   "low": 581.93,
+   "close": 605.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-03": {
+   "open": 616.21,
+   "high": 618.84,
+   "low": 598.01,
+   "close": 615.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-04": {
+   "open": 587.64,
+   "high": 611.26,
+   "low": 577.54,
+   "close": 602.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-05": {
+   "open": 577.86,
+   "high": 580.5,
+   "low": 539.57,
+   "close": 539.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-08": {
+   "open": 569.77,
+   "high": 581.38,
+   "low": 560.79,
+   "close": 571.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-09": {
+   "open": 585.45,
+   "high": 588.58,
+   "low": 522.24,
+   "close": 562.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-10": {
+   "open": 551.66,
+   "high": 572.51,
+   "low": 539.38,
+   "close": 541.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-11": {
+   "open": 555.42,
+   "high": 588.0,
+   "low": 554.81,
+   "close": 586.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-12": {
+   "open": 584.11,
+   "high": 602.69,
+   "low": 578.53,
+   "close": 596.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-15": {
+   "open": 622.61,
+   "high": 629.72,
+   "low": 618.45,
+   "close": 628.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-16": {
+   "open": 623.84,
+   "high": 629.64,
+   "low": 590.63,
+   "close": 591.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-17": {
+   "open": 611.56,
+   "high": 621.99,
+   "low": 598.95,
+   "close": 599.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-18": {
+   "open": 626.52,
+   "high": 644.43,
+   "low": 626.15,
+   "close": 639.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-22": {
+   "open": 653.96,
+   "high": 655.95,
+   "low": 643.93,
+   "close": 655.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-23": {
+   "open": 607.64,
+   "high": 619.94,
+   "low": 598.19,
+   "close": 603.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-24": {
+   "open": 606.19,
+   "high": 609.69,
+   "low": 586.66,
+   "close": 601.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-25": {
+   "open": 637.33,
+   "high": 638.47,
+   "low": 598.83,
+   "close": 625.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-26": {
+   "open": 601.44,
+   "high": 605.89,
+   "low": 588.51,
+   "close": 589.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-29": {
+   "open": 593.71,
+   "high": 615.35,
+   "low": 571.6,
+   "close": 614.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-30": {
+   "open": 616.15,
+   "high": 644.94,
+   "low": 616.15,
+   "close": 640.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-01": {
+   "open": 616.82,
+   "high": 622.89,
+   "low": 597.88,
+   "close": 599.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-02": {
+   "open": 601.24,
+   "high": 608.11,
+   "low": 554.91,
+   "close": 566.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-06": {
+   "open": 583.15,
+   "high": 598.0,
+   "low": 580.48,
+   "close": 581.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-07": {
+   "open": 551.93,
+   "high": 558.06,
+   "low": 536.12,
+   "close": 551.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-08": {
+   "open": 544.66,
+   "high": 564.5,
+   "low": 543.87,
+   "close": 562.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-09": {
+   "open": 589.5,
+   "high": 594.99,
+   "low": 579.14,
+   "close": 581.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-10": {
+   "open": 571.99,
+   "high": 585.79,
+   "low": 566.67,
+   "close": 581.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-13": {
+   "open": 563.58,
+   "high": 566.65,
+   "low": 550.26,
+   "close": 553.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-14": {
+   "open": 580.51,
+   "high": 580.67,
+   "low": 560.24,
+   "close": 567.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-15": {
+   "open": 575.12,
+   "high": 575.88,
+   "low": 538.53,
+   "close": 555.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-16": {
+   "open": 539.05,
+   "high": 545.55,
+   "low": 525.43,
+   "close": 530.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-17": {
+   "open": 508.55,
+   "high": 533.19,
+   "low": 498.54,
+   "close": 521.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-20": {
+   "open": 534.0,
+   "high": 539.54,
+   "low": 522.84,
+   "close": 524.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-21": {
+   "open": 549.1,
+   "high": 555.16,
+   "low": 540.15,
+   "close": 552.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-22": {
+   "open": 538.75,
+   "high": 561.18,
+   "low": 538.72,
+   "close": 555.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-23": {
+   "open": 545.5,
+   "high": 558.09,
+   "low": 543.79,
+   "close": 551.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-24": {
+   "open": 544.36,
+   "high": 548.0,
+   "low": 522.21,
+   "close": 527.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  }
+ }
+}

--- a/memory/bars/SPCH.json
+++ b/memory/bars/SPCH.json
@@ -249,6 +249,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:12+08:00"
+  },
+  "2026-07-24": {
+   "open": 6.76,
+   "high": 6.84,
+   "low": 6.21,
+   "close": 6.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SPCX.json
+++ b/memory/bars/SPCX.json
@@ -258,6 +258,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-07-24T08:02:12+08:00"
+  },
+  "2026-07-24": {
+   "open": 116.01,
+   "high": 117.0,
+   "low": 111.4,
+   "close": 115.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/TCOM.json
+++ b/memory/bars/TCOM.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "TCOM",
+ "leg": "US",
+ "tencent": "usTCOM.OQ",
+ "em_audit_secid": "105.TCOM",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 54.46,
+   "high": 54.46,
+   "low": 53.98,
+   "close": 54.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-04": {
+   "open": 53.35,
+   "high": 53.43,
+   "low": 52.71,
+   "close": 52.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-05": {
+   "open": 52.44,
+   "high": 52.84,
+   "low": 52.29,
+   "close": 52.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-06": {
+   "open": 52.8,
+   "high": 54.5,
+   "low": 52.4,
+   "close": 54.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-07": {
+   "open": 54.36,
+   "high": 54.49,
+   "low": 53.05,
+   "close": 53.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-08": {
+   "open": 53.31,
+   "high": 53.75,
+   "low": 52.64,
+   "close": 52.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-11": {
+   "open": 51.27,
+   "high": 52.71,
+   "low": 51.21,
+   "close": 52.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-12": {
+   "open": 51.9,
+   "high": 52.2,
+   "low": 51.11,
+   "close": 52.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-13": {
+   "open": 51.91,
+   "high": 53.37,
+   "low": 51.6,
+   "close": 52.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-14": {
+   "open": 50.88,
+   "high": 51.19,
+   "low": 50.18,
+   "close": 50.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-15": {
+   "open": 49.63,
+   "high": 50.22,
+   "low": 49.54,
+   "close": 49.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-18": {
+   "open": 48.99,
+   "high": 49.66,
+   "low": 48.64,
+   "close": 49.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-19": {
+   "open": 49.58,
+   "high": 50.18,
+   "low": 48.94,
+   "close": 48.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-20": {
+   "open": 48.5,
+   "high": 48.57,
+   "low": 47.47,
+   "close": 48.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-21": {
+   "open": 47.87,
+   "high": 48.14,
+   "low": 47.39,
+   "close": 48.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-22": {
+   "open": 46.5,
+   "high": 47.49,
+   "low": 45.92,
+   "close": 46.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-26": {
+   "open": 46.65,
+   "high": 47.78,
+   "low": 46.62,
+   "close": 47.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-27": {
+   "open": 47.12,
+   "high": 48.04,
+   "low": 46.99,
+   "close": 47.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-28": {
+   "open": 46.58,
+   "high": 47.54,
+   "low": 46.3,
+   "close": 47.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-05-29": {
+   "open": 47.02,
+   "high": 48.23,
+   "low": 46.72,
+   "close": 47.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-01": {
+   "open": 48.0,
+   "high": 48.49,
+   "low": 47.91,
+   "close": 48.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-02": {
+   "open": 49.15,
+   "high": 49.34,
+   "low": 48.43,
+   "close": 48.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-03": {
+   "open": 47.71,
+   "high": 48.02,
+   "low": 47.37,
+   "close": 47.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-04": {
+   "open": 48.31,
+   "high": 49.23,
+   "low": 47.96,
+   "close": 48.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-05": {
+   "open": 48.0,
+   "high": 48.08,
+   "low": 47.21,
+   "close": 47.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-08": {
+   "open": 47.7,
+   "high": 47.91,
+   "low": 47.04,
+   "close": 47.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-09": {
+   "open": 47.46,
+   "high": 47.69,
+   "low": 46.92,
+   "close": 47.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-10": {
+   "open": 48.13,
+   "high": 48.83,
+   "low": 47.65,
+   "close": 47.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-11": {
+   "open": 46.94,
+   "high": 47.56,
+   "low": 46.61,
+   "close": 47.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-12": {
+   "open": 47.44,
+   "high": 47.56,
+   "low": 46.4,
+   "close": 46.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-15": {
+   "open": 47.02,
+   "high": 47.68,
+   "low": 47.01,
+   "close": 47.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-16": {
+   "open": 46.84,
+   "high": 47.12,
+   "low": 45.88,
+   "close": 46.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-17": {
+   "open": 46.67,
+   "high": 47.55,
+   "low": 46.54,
+   "close": 46.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-18": {
+   "open": 45.95,
+   "high": 46.27,
+   "low": 45.0,
+   "close": 45.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-22": {
+   "open": 44.94,
+   "high": 46.8,
+   "low": 44.94,
+   "close": 46.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-23": {
+   "open": 45.49,
+   "high": 45.59,
+   "low": 44.63,
+   "close": 45.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-24": {
+   "open": 45.34,
+   "high": 46.56,
+   "low": 45.3,
+   "close": 46.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-25": {
+   "open": 40.16,
+   "high": 40.62,
+   "low": 38.04,
+   "close": 40.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-26": {
+   "open": 39.33,
+   "high": 41.07,
+   "low": 39.03,
+   "close": 40.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-29": {
+   "open": 41.18,
+   "high": 41.24,
+   "low": 39.9,
+   "close": 39.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-06-30": {
+   "open": 39.96,
+   "high": 40.0,
+   "low": 39.32,
+   "close": 39.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-01": {
+   "open": 39.82,
+   "high": 41.57,
+   "low": 39.79,
+   "close": 41.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-02": {
+   "open": 40.36,
+   "high": 41.15,
+   "low": 40.27,
+   "close": 41.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-06": {
+   "open": 40.99,
+   "high": 41.59,
+   "low": 40.48,
+   "close": 40.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-07": {
+   "open": 41.39,
+   "high": 41.61,
+   "low": 40.46,
+   "close": 40.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-08": {
+   "open": 41.62,
+   "high": 42.17,
+   "low": 41.32,
+   "close": 41.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-09": {
+   "open": 41.05,
+   "high": 41.49,
+   "low": 41.05,
+   "close": 41.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-10": {
+   "open": 42.08,
+   "high": 42.9,
+   "low": 41.63,
+   "close": 42.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-13": {
+   "open": 42.78,
+   "high": 42.99,
+   "low": 42.17,
+   "close": 42.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-14": {
+   "open": 42.4,
+   "high": 42.85,
+   "low": 42.3,
+   "close": 42.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-15": {
+   "open": 42.7,
+   "high": 43.55,
+   "low": 42.6,
+   "close": 42.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-16": {
+   "open": 44.1,
+   "high": 44.22,
+   "low": 43.51,
+   "close": 43.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-17": {
+   "open": 42.92,
+   "high": 43.54,
+   "low": 42.13,
+   "close": 42.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-20": {
+   "open": 44.78,
+   "high": 44.94,
+   "low": 43.33,
+   "close": 44.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-21": {
+   "open": 44.01,
+   "high": 44.15,
+   "low": 43.54,
+   "close": 43.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-22": {
+   "open": 43.48,
+   "high": 43.48,
+   "low": 42.5,
+   "close": 42.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-23": {
+   "open": 43.51,
+   "high": 43.78,
+   "low": 42.76,
+   "close": 43.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  },
+  "2026-07-24": {
+   "open": 43.4,
+   "high": 44.06,
+   "low": 43.37,
+   "close": 43.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:50+08:00"
+  }
+ }
+}

--- a/memory/bars/TQQQ.json
+++ b/memory/bars/TQQQ.json
@@ -1,0 +1,534 @@
+{
+ "schema_version": 1,
+ "ticker": "TQQQ",
+ "leg": "US",
+ "tencent": "usTQQQ.OQ",
+ "em_audit_secid": "105.TQQQ",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-05-01": {
+   "open": 63.89,
+   "high": 65.84,
+   "low": 63.81,
+   "close": 65.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-04": {
+   "open": 65.44,
+   "high": 66.05,
+   "low": 63.78,
+   "close": 64.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-05": {
+   "open": 66.37,
+   "high": 67.77,
+   "low": 66.25,
+   "close": 67.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-06": {
+   "open": 69.26,
+   "high": 71.66,
+   "low": 68.88,
+   "close": 71.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-07": {
+   "open": 71.87,
+   "high": 73.3,
+   "low": 70.38,
+   "close": 71.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-08": {
+   "open": 72.82,
+   "high": 76.31,
+   "low": 72.7,
+   "close": 76.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-11": {
+   "open": 76.0,
+   "high": 77.36,
+   "low": 75.55,
+   "close": 76.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-12": {
+   "open": 75.3,
+   "high": 75.93,
+   "low": 71.55,
+   "close": 74.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-13": {
+   "open": 75.81,
+   "high": 77.94,
+   "low": 74.19,
+   "close": 77.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-14": {
+   "open": 77.29,
+   "high": 79.68,
+   "low": 77.16,
+   "close": 78.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-15": {
+   "open": 75.73,
+   "high": 77.37,
+   "low": 74.23,
+   "close": 75.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-18": {
+   "open": 76.13,
+   "high": 76.27,
+   "low": 72.1,
+   "close": 74.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-19": {
+   "open": 72.41,
+   "high": 74.5,
+   "low": 70.96,
+   "close": 72.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-20": {
+   "open": 74.09,
+   "high": 76.53,
+   "low": 73.62,
+   "close": 76.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-21": {
+   "open": 75.18,
+   "high": 77.79,
+   "low": 74.47,
+   "close": 76.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-22": {
+   "open": 78.04,
+   "high": 79.33,
+   "low": 77.33,
+   "close": 77.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-26": {
+   "open": 80.59,
+   "high": 82.27,
+   "low": 79.98,
+   "close": 81.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-27": {
+   "open": 82.87,
+   "high": 82.91,
+   "low": 80.33,
+   "close": 81.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-28": {
+   "open": 81.74,
+   "high": 84.05,
+   "low": 80.66,
+   "close": 83.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-05-29": {
+   "open": 84.41,
+   "high": 85.7,
+   "low": 83.53,
+   "close": 84.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-01": {
+   "open": 84.15,
+   "high": 87.06,
+   "low": 83.75,
+   "close": 86.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-02": {
+   "open": 85.94,
+   "high": 87.32,
+   "low": 84.83,
+   "close": 87.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-03": {
+   "open": 87.68,
+   "high": 88.09,
+   "low": 85.41,
+   "close": 86.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-04": {
+   "open": 83.47,
+   "high": 86.25,
+   "low": 82.48,
+   "close": 85.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-05": {
+   "open": 81.57,
+   "high": 82.08,
+   "low": 72.68,
+   "close": 73.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-08": {
+   "open": 76.86,
+   "high": 78.47,
+   "low": 75.38,
+   "close": 76.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-09": {
+   "open": 78.48,
+   "high": 79.34,
+   "low": 66.79,
+   "close": 73.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-10": {
+   "open": 71.68,
+   "high": 74.7,
+   "low": 69.0,
+   "close": 69.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-11": {
+   "open": 70.89,
+   "high": 76.6,
+   "low": 69.59,
+   "close": 76.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-12": {
+   "open": 76.34,
+   "high": 78.36,
+   "low": 74.29,
+   "close": 77.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-15": {
+   "open": 82.88,
+   "high": 85.03,
+   "low": 82.64,
+   "close": 84.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-16": {
+   "open": 84.19,
+   "high": 84.83,
+   "low": 79.86,
+   "close": 79.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-17": {
+   "open": 81.67,
+   "high": 81.81,
+   "low": 76.94,
+   "close": 77.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-18": {
+   "open": 82.1,
+   "high": 83.6,
+   "low": 80.63,
+   "close": 82.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-22": {
+   "open": 83.95,
+   "high": 85.11,
+   "low": 81.39,
+   "close": 82.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-23": {
+   "open": 75.12,
+   "high": 77.74,
+   "low": 73.91,
+   "close": 74.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-24": {
+   "open": 74.79,
+   "high": 76.18,
+   "low": 71.35,
+   "close": 73.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-25": {
+   "open": 77.96,
+   "high": 78.24,
+   "low": 71.6,
+   "close": 74.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-26": {
+   "open": 72.09,
+   "high": 74.69,
+   "low": 70.72,
+   "close": 71.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-29": {
+   "open": 74.12,
+   "high": 77.38,
+   "low": 71.45,
+   "close": 77.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-06-30": {
+   "open": 77.24,
+   "high": 81.54,
+   "low": 77.15,
+   "close": 81.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-01": {
+   "open": 78.72,
+   "high": 79.64,
+   "low": 77.23,
+   "close": 77.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-02": {
+   "open": 77.45,
+   "high": 79.14,
+   "low": 71.72,
+   "close": 73.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-06": {
+   "open": 75.54,
+   "high": 77.45,
+   "low": 75.11,
+   "close": 76.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-07": {
+   "open": 73.7,
+   "high": 74.39,
+   "low": 70.76,
+   "close": 72.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-08": {
+   "open": 70.8,
+   "high": 73.02,
+   "low": 69.57,
+   "close": 72.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-09": {
+   "open": 74.85,
+   "high": 76.69,
+   "low": 73.89,
+   "close": 76.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-10": {
+   "open": 75.53,
+   "high": 77.32,
+   "low": 74.33,
+   "close": 77.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-13": {
+   "open": 74.54,
+   "high": 74.85,
+   "low": 72.09,
+   "close": 72.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-14": {
+   "open": 75.2,
+   "high": 75.85,
+   "low": 73.41,
+   "close": 75.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-15": {
+   "open": 76.29,
+   "high": 76.47,
+   "low": 72.06,
+   "close": 74.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-16": {
+   "open": 72.61,
+   "high": 73.12,
+   "low": 69.69,
+   "close": 70.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-17": {
+   "open": 66.38,
+   "high": 69.56,
+   "low": 64.91,
+   "close": 67.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-20": {
+   "open": 69.47,
+   "high": 70.51,
+   "low": 67.5,
+   "close": 67.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-21": {
+   "open": 70.71,
+   "high": 71.72,
+   "low": 69.61,
+   "close": 71.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-22": {
+   "open": 69.77,
+   "high": 71.59,
+   "low": 69.77,
+   "close": 70.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-23": {
+   "open": 67.11,
+   "high": 68.27,
+   "low": 65.02,
+   "close": 66.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  },
+  "2026-07-24": {
+   "open": 65.78,
+   "high": 66.4,
+   "low": 63.49,
+   "close": 64.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-07-26T15:09:51+08:00"
+  }
+ }
+}


### PR DESCRIPTION
## Summary
- repair five audited Tencent OHLC revisions (0.01–0.04 high/low changes)
- append the 2026-07-24 closed session for existing instruments
- backfill canonical histories for newly registered look-through/peer instruments

## Why
A tomorrow-dated full brief preflight reproduced five immutable-store conflicts and exited 1 despite producing a valid context. After this audited repair, the same preflight completes all 14 stages with 0 issues.

## Verification
- tomorrow simulation: 14/14 preflight stages, 0 issues, 39/39 peers priced
- repeated `fetch_daily_bars.py`: 0 bars added, 0 revised, 0 conflicts
- `python3 -m pytest -q`: 671 passed, 5 xfailed
- system check: 0 critical (existing dashboard-size warning only)