### PR TITLE
Fix CodeQL DOM text reinterpretation alerts

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -1359,11 +1359,14 @@
         document.querySelectorAll("#holdings-table thead th").forEach(x => {
           const isActive = x.dataset.sort === holdingsSort.key;
           x.classList.toggle("active-sort", isActive);
-          let label = x.textContent.replace(/[▲▼]/g, "").trim();
+          const label = x.textContent.replace(/[▲▼]/g, "").trim();
+          x.replaceChildren();
+          x.append(label);
           if (isActive) {
-            x.innerHTML = label + ' <span class="arr">' + (holdingsSort.dir === "asc" ? "▲" : "▼") + "</span>";
-          } else {
-            x.innerHTML = label;
+            const arrow = document.createElement("span");
+            arrow.className = "arr";
+            arrow.textContent = holdingsSort.dir === "asc" ? "▲" : "▼";
+            x.append(" ", arrow);
           }
         });
         renderHoldings();

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sort_headers_never_reinterpret_dom_text_as_html():
+    renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+    sort_headers = renderer.split("// Wire sort headers", 1)[1].split(
+        "function renderShadowPortfolioCard", 1
+    )[0]
+
+    assert ".innerHTML" not in sort_headers
+    assert "x.replaceChildren()" in sort_headers
+    assert "x.append(label)" in sort_headers
+    assert 'document.createElement("span")' in sort_headers
+    assert "arrow.textContent" in sort_headers


### PR DESCRIPTION
## Summary

- replace holdings sort-header innerHTML writes with text nodes and an explicitly created arrow span
- add a regression contract that forbids reinterpreting DOM-derived labels as HTML
- addresses CodeQL alerts 9 and 10

## Verification

- python3 -m pytest tests/test_dashboard_security.py tests/test_workflow_outcomes.py -q (8 passed)
- node --check assets/js/dashboard.render.js
- git diff --check
- exact pre-push secret scans for worktree and HEAD: 0 matches; normal hook exceeded its 10-second wall under current host load