### PR TITLE
feat: add evidence-driven thesis registry

### DIFF
--- a/config/thesis.schema.json
+++ b/config/thesis.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KCNyu/clawock/config/thesis.schema.json",
+  "title": "clawock canonical investment thesis",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "thesis_id",
+    "ticker",
+    "strategy_scope",
+    "summary",
+    "created_at",
+    "checked_at",
+    "state",
+    "dimensions",
+    "assumptions",
+    "red_lines",
+    "valuation_anchors",
+    "evidence",
+    "next_review_trigger"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "thesis_id": {"type": "string", "minLength": 1},
+    "ticker": {"type": "string", "minLength": 1},
+    "strategy_scope": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "summary": {"type": "string", "minLength": 1, "maxLength": 400},
+    "created_at": {"type": "string", "format": "date-time"},
+    "checked_at": {"type": "string", "format": "date-time"},
+    "state": {"$ref": "#/$defs/thesis_state"},
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["business", "moat", "management", "valuation"],
+      "properties": {
+        "business": {"$ref": "#/$defs/dimension"},
+        "moat": {"$ref": "#/$defs/dimension"},
+        "management": {"$ref": "#/$defs/dimension"},
+        "valuation": {"$ref": "#/$defs/dimension"}
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {"$ref": "#/$defs/assumption"}
+    },
+    "red_lines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/red_line"}
+    },
+    "valuation_anchors": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/valuation_anchor"}
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidence"}
+    },
+    "next_review_trigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "description"],
+      "properties": {
+        "type": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "$defs": {
+    "thesis_state": {
+      "enum": ["intact", "weakening", "damaged", "broken", "unknown"]
+    },
+    "evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "evidence_ids"],
+      "properties": {
+        "state": {"$ref": "#/$defs/thesis_state"},
+        "evidence_ids": {"$ref": "#/$defs/evidence_ids"}
+      }
+    },
+    "assumption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "claim", "test", "cadence", "status", "evidence_ids"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "claim": {"type": "string", "minLength": 1},
+        "test": {"type": "string", "minLength": 1},
+        "cadence": {"type": "string", "minLength": 1},
+        "status": {
+          "enum": ["unknown", "supported", "weakening", "damaged", "broken"]
+        },
+        "evidence_ids": {"$ref": "#/$defs/evidence_ids"}
+      }
+    },
+    "red_line": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "condition",
+        "severity",
+        "status",
+        "required_action",
+        "evidence_ids"
+      ],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "condition": {"type": "string", "minLength": 1},
+        "severity": {"enum": ["warning", "severe", "fatal"]},
+        "status": {"enum": ["clear", "watch", "triggered", "unknown"]},
+        "required_action": {"type": "string", "minLength": 1},
+        "evidence_ids": {"$ref": "#/$defs/evidence_ids"}
+      }
+    },
+    "valuation_anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "metric", "value", "currency", "period", "evidence_ids"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "metric": {"type": "string", "minLength": 1},
+        "value": {"type": ["string", "number"]},
+        "currency": {"type": "string", "minLength": 1},
+        "period": {"type": "string", "minLength": 1},
+        "evidence_ids": {"$ref": "#/$defs/evidence_ids"}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_id",
+        "observed_at",
+        "source_class",
+        "locator",
+        "kind",
+        "summary"
+      ],
+      "properties": {
+        "evidence_id": {"type": "string", "minLength": 1},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "source_class": {"type": "string", "minLength": 1},
+        "locator": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/memory/theses/README.md
+++ b/memory/theses/README.md
@@ -1,0 +1,22 @@
+# Canonical thesis registry
+
+One JSON file per durable investment thesis. Markdown reports may explain a
+thesis, but these versioned JSON documents are the machine-readable authority
+for assumptions, red lines, valuation anchors, evidence, state, and the next
+review trigger.
+
+Validate a document:
+
+```bash
+python3 scripts/data/thesis_registry.py validate memory/theses/<thesis-id>.json
+```
+
+Compare two versions:
+
+```bash
+python3 scripts/data/thesis_registry.py drift old.json new.json
+```
+
+Missing baselines stay `unknown`. A changed dimension requires a newly observed
+evidence ID; price-only evidence may change valuation but cannot change business,
+moat, or management state.

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -94,6 +94,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `fetch_fx.py` | USDHKD 汇率 · 3 路 fallback | Frankfurter(ECB) → 备用 | ✅ |
 | `preflight_integrity.py` | 数据不变量硬闸: TCV / PNL / FX / cash 对账 | 本地 | ✅ |
 | `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出 | 结构化 manifest + 本地确定性校验 | ✅ |
+| `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift 与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 
 ## Layer 8 · 回测/自省 Backtest & Calibration
 

--- a/scripts/data/thesis_registry.py
+++ b/scripts/data/thesis_registry.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Canonical investment-thesis registry and evidence-only drift evaluator."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+SCHEMA_FILE = WS / "config" / "thesis.schema.json"
+SCHEMA_VERSION = 1
+THESIS_STATES = ("unknown", "broken", "damaged", "weakening", "intact")
+STATE_RANK = {"broken": 0, "damaged": 1, "weakening": 2, "intact": 3}
+DIMENSIONS = ("business", "moat", "management", "valuation")
+ASSUMPTION_STATES = {"unknown", "supported", "weakening", "damaged", "broken"}
+RED_LINE_STATES = {"clear", "watch", "triggered", "unknown"}
+SEVERITIES = {"warning", "severe", "fatal"}
+PRICE_KINDS = {"price", "valuation"}
+THESIS_FIELDS = {
+    "schema_version", "thesis_id", "ticker", "strategy_scope", "summary",
+    "created_at", "checked_at", "state", "dimensions", "assumptions",
+    "red_lines", "valuation_anchors", "evidence", "next_review_trigger",
+}
+
+
+def _exact_fields(item, required, prefix, errors):
+    if not isinstance(item, dict):
+        errors.append(f"{prefix} must be an object")
+        return
+    missing = sorted(required - set(item))
+    extra = sorted(set(item) - required)
+    if missing:
+        errors.append(f"{prefix} missing fields: {missing}")
+    if extra:
+        errors.append(f"{prefix} unknown fields: {extra}")
+
+
+def _parse_time(value, field, errors):
+    try:
+        result = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if result.tzinfo is None:
+            raise ValueError
+        return result
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
+        return None
+
+
+def _refs(items, prefix, evidence_ids, errors):
+    refs = items.get("evidence_ids") if isinstance(items, dict) else None
+    if not isinstance(refs, list):
+        errors.append(f"{prefix}.evidence_ids must be a list")
+        return set()
+    valid = set()
+    for ref in refs:
+        if not isinstance(ref, str) or not ref:
+            errors.append(f"{prefix}.evidence_ids must contain non-empty strings")
+        else:
+            valid.add(ref)
+    if len(valid) != len(refs):
+        errors.append(f"{prefix}.evidence_ids must be unique")
+    missing = valid - evidence_ids
+    if missing:
+        errors.append(f"{prefix} references missing evidence: {sorted(missing)}")
+    return valid
+
+
+def validate_thesis(doc: dict, *, now=None) -> list[str]:
+    errors = []
+    if not isinstance(doc, dict):
+        return ["thesis must be an object"]
+    _exact_fields(doc, THESIS_FIELDS, "thesis", errors)
+    if doc.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("thesis_id", "ticker", "summary", "created_at", "checked_at",
+                  "state", "next_review_trigger"):
+        if doc.get(field) in (None, ""):
+            errors.append(f"{field} is required")
+    if doc.get("state") not in THESIS_STATES:
+        errors.append(f"state must be one of {THESIS_STATES}")
+    strategy_scope = doc.get("strategy_scope")
+    if not isinstance(strategy_scope, list) or not strategy_scope:
+        errors.append("strategy_scope must be a non-empty list")
+    elif (
+        any(not isinstance(item, str) or not item for item in strategy_scope)
+        or len(set(strategy_scope)) != len(strategy_scope)
+    ):
+        errors.append("strategy_scope must contain unique non-empty strings")
+    if len(str(doc.get("summary") or "")) > 400:
+        errors.append("summary must be concise (<=400 characters)")
+    created = _parse_time(doc.get("created_at"), "created_at", errors)
+    checked = _parse_time(doc.get("checked_at"), "checked_at", errors)
+    if created and checked and checked < created:
+        errors.append("checked_at cannot precede created_at")
+
+    evidence = doc.get("evidence")
+    if not isinstance(evidence, list):
+        errors.append("evidence must be a list")
+        evidence = []
+    evidence_map = {}
+    for index, item in enumerate(evidence):
+        prefix = f"evidence[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        _exact_fields(
+            item,
+            {"evidence_id", "observed_at", "source_class", "locator", "kind", "summary"},
+            prefix, errors,
+        )
+        evidence_id = item.get("evidence_id")
+        if not isinstance(evidence_id, str) or not evidence_id or evidence_id in evidence_map:
+            errors.append(f"{prefix}.evidence_id must be present and unique")
+        else:
+            evidence_map[evidence_id] = item
+        for field in ("observed_at", "source_class", "locator", "kind", "summary"):
+            if not item.get(field):
+                errors.append(f"{prefix}.{field} is required")
+        observed = _parse_time(item.get("observed_at"), f"{prefix}.observed_at", errors)
+        if observed and checked and observed > checked:
+            errors.append(f"{prefix}.observed_at cannot be after checked_at")
+        if now and observed and observed > now:
+            errors.append(f"{prefix}.observed_at cannot be in the future")
+
+    evidence_ids = set(evidence_map)
+    dimensions = doc.get("dimensions")
+    if not isinstance(dimensions, dict) or set(dimensions) != set(DIMENSIONS):
+        errors.append(f"dimensions must contain exactly {DIMENSIONS}")
+        dimensions = {}
+    for name in DIMENSIONS:
+        dimension = dimensions.get(name, {})
+        _exact_fields(dimension, {"state", "evidence_ids"}, f"dimensions.{name}", errors)
+        if not isinstance(dimension, dict):
+            dimension = {}
+        if dimension.get("state") not in THESIS_STATES:
+            errors.append(f"dimensions.{name}.state must be one of {THESIS_STATES}")
+        refs = _refs(dimension, f"dimensions.{name}", evidence_ids, errors)
+        if name != "valuation":
+            bad = [
+                evidence_id for evidence_id in refs
+                if (evidence_map.get(evidence_id) or {}).get("kind") in PRICE_KINDS
+            ]
+            if bad:
+                errors.append(
+                    f"dimensions.{name} cannot use price-only evidence: {sorted(bad)}"
+                )
+
+    assumptions = doc.get("assumptions")
+    if not isinstance(assumptions, list) or not 3 <= len(assumptions) <= 7:
+        errors.append("assumptions must contain 3-7 items")
+        assumptions = []
+    seen = set()
+    for index, item in enumerate(assumptions):
+        prefix = f"assumptions[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        _exact_fields(
+            item,
+            {"id", "claim", "test", "cadence", "status", "evidence_ids"},
+            prefix, errors,
+        )
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id or item_id in seen:
+            errors.append(f"{prefix}.id must be present and unique")
+        elif item_id:
+            seen.add(item_id)
+        for field in ("claim", "test", "cadence"):
+            if not item.get(field):
+                errors.append(f"{prefix}.{field} is required")
+        if item.get("status") not in ASSUMPTION_STATES:
+            errors.append(f"{prefix}.status is invalid")
+        _refs(item, prefix, evidence_ids, errors)
+
+    red_lines = doc.get("red_lines")
+    if not isinstance(red_lines, list) or not red_lines:
+        errors.append("red_lines must be a non-empty list")
+        red_lines = []
+    fatal = severe = False
+    seen = set()
+    for index, item in enumerate(red_lines):
+        prefix = f"red_lines[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        _exact_fields(
+            item,
+            {"id", "condition", "severity", "status", "required_action", "evidence_ids"},
+            prefix, errors,
+        )
+        for field in ("id", "condition", "required_action"):
+            if not item.get(field):
+                errors.append(f"{prefix}.{field} is required")
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id:
+            errors.append(f"{prefix}.id must be a non-empty string")
+        elif item_id in seen:
+            errors.append(f"{prefix}.id must be unique")
+        else:
+            seen.add(item_id)
+        if item.get("severity") not in SEVERITIES:
+            errors.append(f"{prefix}.severity is invalid")
+        if item.get("status") not in RED_LINE_STATES:
+            errors.append(f"{prefix}.status is invalid")
+        refs = _refs(item, prefix, evidence_ids, errors)
+        if item.get("status") == "triggered" and not refs:
+            errors.append(f"{prefix} triggered without evidence")
+        fatal |= item.get("status") == "triggered" and item.get("severity") == "fatal"
+        severe |= item.get("status") == "triggered" and item.get("severity") == "severe"
+    if fatal and doc.get("state") != "broken":
+        errors.append("fatal red line requires overall state=broken")
+    if severe and doc.get("state") not in {"damaged", "broken"}:
+        errors.append("severe red line requires overall state=damaged or broken")
+
+    anchors = doc.get("valuation_anchors")
+    if not isinstance(anchors, list):
+        errors.append("valuation_anchors must be a list")
+        anchors = []
+    seen = set()
+    for index, item in enumerate(anchors):
+        prefix = f"valuation_anchors[{index}]"
+        _exact_fields(
+            item,
+            {"id", "metric", "value", "currency", "period", "evidence_ids"},
+            prefix, errors,
+        )
+        for field in ("id", "metric", "value", "currency", "period"):
+            if (
+                not isinstance(item, dict)
+                or item.get(field) is None
+                or item.get(field) == ""
+            ):
+                errors.append(f"{prefix}.{field} is required")
+        if isinstance(item, dict):
+            item_id = item.get("id")
+            if not isinstance(item_id, str) or not item_id:
+                errors.append(f"{prefix}.id must be a non-empty string")
+            elif item_id in seen:
+                errors.append(f"{prefix}.id must be unique")
+            else:
+                seen.add(item_id)
+            _refs(item, prefix, evidence_ids, errors)
+
+    trigger = doc.get("next_review_trigger")
+    _exact_fields(trigger, {"type", "description"}, "next_review_trigger", errors)
+    if not isinstance(trigger, dict) or not trigger.get("type") or not trigger.get("description"):
+        errors.append("next_review_trigger requires type and description")
+    return errors
+
+
+def validate_transition(old: dict, new: dict) -> list[str]:
+    errors = []
+    if old.get("thesis_id") != new.get("thesis_id"):
+        errors.append("thesis_id mismatch")
+    if old.get("ticker") != new.get("ticker"):
+        errors.append("ticker mismatch")
+    time_errors = []
+    old_checked = _parse_time(old.get("checked_at"), "old.checked_at", time_errors)
+    new_checked = _parse_time(new.get("checked_at"), "new.checked_at", time_errors)
+    errors += time_errors
+    if old_checked and new_checked and new_checked < old_checked:
+        errors.append("checked_at cannot move backwards")
+    old_state, new_state = old.get("state"), new.get("state")
+    if old_state == "broken" and new_state != "broken":
+        errors.append("broken thesis is terminal; create a new thesis_id to reopen")
+    if old_state == "damaged" and new_state == "intact":
+        errors.append("damaged thesis cannot jump directly to intact")
+    return errors
+
+
+def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
+    if old is None:
+        return {
+            "status": "unknown", "overall": "unknown", "dimensions": {},
+            "errors": ["missing historical baseline"],
+        }
+    errors = validate_thesis(old, now=now) + validate_thesis(new, now=now)
+    if isinstance(old, dict) and isinstance(new, dict):
+        errors += validate_transition(old, new)
+    if errors:
+        return {
+            "status": "fail", "overall": "unknown", "dimensions": {},
+            "triggered_red_lines": [], "errors": errors,
+        }
+    old_checked_errors = []
+    old_checked = _parse_time(old.get("checked_at"), "old.checked_at", old_checked_errors)
+    errors += old_checked_errors
+    old_evidence = {item.get("evidence_id") for item in old.get("evidence", [])}
+    new_evidence = {
+        item.get("evidence_id"): item for item in new.get("evidence", [])
+        if item.get("evidence_id") not in old_evidence
+    }
+    dimensions = {}
+    for name in DIMENSIONS:
+        before = (old.get("dimensions") or {}).get(name, {})
+        after = (new.get("dimensions") or {}).get(name, {})
+        before_state, after_state = before.get("state"), after.get("state")
+        if before_state == after_state:
+            direction = "unchanged"
+        elif before_state in STATE_RANK and after_state in STATE_RANK:
+            direction = "improved" if STATE_RANK[after_state] > STATE_RANK[before_state] else "weakened"
+        else:
+            direction = "unknown"
+        supporting = set(after.get("evidence_ids") or []) & set(new_evidence)
+        if direction != "unchanged":
+            if not supporting:
+                errors.append(f"{name} changed without new evidence")
+                direction = "unknown"
+            else:
+                fresh = False
+                for evidence_id in supporting:
+                    observed_errors = []
+                    observed = _parse_time(
+                        new_evidence[evidence_id].get("observed_at"),
+                        f"evidence {evidence_id}.observed_at", observed_errors,
+                    )
+                    errors += observed_errors
+                    fresh |= bool(observed and old_checked and observed > old_checked)
+                if not fresh:
+                    errors.append(f"{name} changed using stale evidence")
+                    direction = "unknown"
+        dimensions[name] = {
+            "old_state": before_state,
+            "new_state": after_state,
+            "direction": direction,
+            "new_evidence_ids": sorted(supporting),
+        }
+
+    triggered = [
+        item for item in new.get("red_lines", [])
+        if item.get("status") == "triggered"
+    ]
+    old_red_lines = {
+        item.get("id"): item for item in old.get("red_lines", [])
+        if isinstance(item, dict)
+    }
+    newly_triggered = []
+    for item in triggered:
+        if (old_red_lines.get(item.get("id")) or {}).get("status") == "triggered":
+            continue
+        newly_triggered.append(item)
+        supporting = set(item.get("evidence_ids") or []) & set(new_evidence)
+        if not supporting:
+            errors.append(f"red line {item.get('id')} triggered without new evidence")
+            continue
+        fresh = False
+        for evidence_id in supporting:
+            observed_errors = []
+            observed = _parse_time(
+                new_evidence[evidence_id].get("observed_at"),
+                f"evidence {evidence_id}.observed_at", observed_errors,
+            )
+            errors += observed_errors
+            fresh |= bool(observed and old_checked and observed > old_checked)
+        if not fresh:
+            errors.append(f"red line {item.get('id')} triggered using stale evidence")
+
+    directions = {item["direction"] for item in dimensions.values()}
+    if triggered:
+        overall = "weakened"
+    elif "weakened" in directions:
+        overall = "weakened"
+    elif "improved" in directions:
+        overall = "improved"
+    elif directions == {"unchanged"}:
+        overall = "unchanged"
+    else:
+        overall = "unknown"
+    if old.get("state") != new.get("state"):
+        state_direction = (
+            "improved"
+            if old.get("state") in STATE_RANK
+            and new.get("state") in STATE_RANK
+            and STATE_RANK[new["state"]] > STATE_RANK[old["state"]]
+            else "weakened"
+            if old.get("state") in STATE_RANK
+            and new.get("state") in STATE_RANK
+            else "unknown"
+        )
+        if state_direction not in directions and not newly_triggered:
+            errors.append("overall state changed without matching evidence-backed drift")
+    return {
+        "status": "fail" if errors else "pass",
+        "overall": overall,
+        "dimensions": dimensions,
+        "triggered_red_lines": [item.get("id") for item in triggered],
+        "errors": errors,
+    }
+
+
+def resolve_decision_links(decisions: list[dict], theses: list[dict]) -> list[dict]:
+    """Add resolvable thesis metadata without mutating historical thesis_id."""
+    by_id = {doc.get("thesis_id"): doc for doc in theses}
+    out = []
+    for decision in decisions:
+        linked = copy.deepcopy(decision)
+        thesis_id = linked.get("thesis_id")
+        doc = by_id.get(thesis_id)
+        linked["thesis_ref"] = (
+            {
+                "status": "resolved", "thesis_id": thesis_id,
+                "schema_version": doc.get("schema_version"),
+                "state": doc.get("state"), "checked_at": doc.get("checked_at"),
+            }
+            if doc and doc.get("ticker") == linked.get("ticker")
+            else {
+                "status": "mismatch" if doc else "unknown",
+                "thesis_id": thesis_id,
+            }
+        )
+        out.append(linked)
+    return out
+
+
+def load_registry(path: Path) -> tuple[list[dict], list[str]]:
+    docs, errors = [], []
+    if not path.exists():
+        return docs, errors
+    thesis_ids = {}
+    tickers = {}
+    for file in sorted(path.glob("*.json")):
+        try:
+            doc = json.loads(file.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{file.name}: {exc}")
+            continue
+        doc_errors = validate_thesis(doc, now=datetime.now(timezone.utc))
+        if doc_errors:
+            errors.extend(f"{file.name}: {error}" for error in doc_errors)
+            continue
+        duplicate = False
+        for field, seen in (("thesis_id", thesis_ids), ("ticker", tickers)):
+            value = doc[field]
+            if value in seen:
+                errors.append(
+                    f"duplicate {field} {value!r}: {seen[value]} and {file.name}"
+                )
+                duplicate = True
+        if not duplicate:
+            thesis_ids[doc["thesis_id"]] = file.name
+            tickers[doc["ticker"]] = file.name
+            docs.append(doc)
+    return docs, errors
+
+
+def registry_summary(path: Path, active_tickers: list[str]) -> dict:
+    docs, errors = load_registry(path)
+    by_ticker = {doc["ticker"]: doc for doc in docs}
+    return {
+        "status": "invalid" if errors else ("ready" if docs else "empty"),
+        "theses": {
+            ticker: (
+                {
+                    "status": "resolved", "thesis_id": by_ticker[ticker]["thesis_id"],
+                    "state": by_ticker[ticker]["state"],
+                    "checked_at": by_ticker[ticker]["checked_at"],
+                    "next_review_trigger": by_ticker[ticker]["next_review_trigger"],
+                }
+                if ticker in by_ticker else {"status": "unknown"}
+            )
+            for ticker in active_tickers
+        },
+        "errors": errors,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    validate = sub.add_parser("validate")
+    validate.add_argument("path", type=Path)
+    drift = sub.add_parser("drift")
+    drift.add_argument("old", type=Path)
+    drift.add_argument("new", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        new = json.loads(args.path.read_text()) if args.command == "validate" else json.loads(args.new.read_text())
+        if args.command == "validate":
+            errors = validate_thesis(new, now=datetime.now(timezone.utc))
+            result = {"status": "pass" if not errors else "fail", "errors": errors}
+        else:
+            old = json.loads(args.old.read_text())
+            result = evaluate_drift(old, new, now=datetime.now(timezone.utc))
+    except (OSError, json.JSONDecodeError) as exc:
+        result = {"status": "fail", "errors": [str(exc)]}
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -49,6 +49,7 @@ SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
+import thesis_registry  # noqa: E402
 import peer_scan  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
@@ -559,6 +560,7 @@ def compute_retrospective(prior_plan_path, portfolio):
             'ticker':                   ticker,
             'decision_id':              action.get('decision_id'),
             'episode_id':               action.get('episode_id'),
+            'thesis_id':                action.get('thesis_id'),
             'strategy_id':              action.get('strategy_id'),
             'action':                    bucket,
             'plan_trigger_type':        trigger_type,
@@ -1690,6 +1692,21 @@ def main():
         _g_trim['nav_history_omitted'] = len(_g['nav_history'])  # 留计数标记=故意省略非丢失
         portfolio_ctx = {**portfolio, 'gold_dca': _g_trim}
 
+    active_tickers = [
+        str(holding.get('ticker'))
+        for region in ('hk_stocks', 'us_stocks')
+        for holding in portfolio['portfolios'].get(region, {}).get('holdings', [])
+        if holding.get('shares', 0) > 0
+    ]
+    thesis_registry_ctx = thesis_registry.registry_summary(
+        WS / 'memory' / 'theses', active_tickers
+    )
+    thesis_docs, _ = thesis_registry.load_registry(WS / 'memory' / 'theses')
+    if isinstance(retro.get('decisions'), list):
+        retro['decisions'] = thesis_registry.resolve_decision_links(
+            retro['decisions'], thesis_docs
+        )
+
     context = {
         'generated_at':  datetime.now(timezone(timedelta(hours=8))).isoformat(),
         'date':          today,
@@ -1718,6 +1735,7 @@ def main():
         'risk_metrics':  risk,
         'catalysts':     catalysts,
         'news_evidence_graph': news_evidence_ctx,
+        'thesis_registry': thesis_registry_ctx,
         'macro':         macro_trim,
         'sentiment':     sentiment_trim,
         'influencer':    influencer_trim,

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -65,6 +65,7 @@ context.json 关键字段：
 - `sentiment` — 每个持仓票的 Reddit 提及数 + Reddit top 3 + Google News top 3（无 signal 的票已被剔）
 - `em_news` — **东财中文消息源**（`holdings_news` 逐 HK 持仓近 3 条公司新闻 + `market_724` 大盘 7x24 快讯）。clawock 英文 news 薄在港股/中文面,这里补上。**HK 持仓找硬催化优先看这个**——回购/公告/事件多在中文源先出。命中硬催化 → `driven_by=catalyst` 并在 rationale 引日期+标题;只是情绪/涨跌色 → 不构成主动操作依据(见 catalyst-gate 铁律)。杠杆 ETF 已自动剔除(看标的不看公司新闻)。
 - `news_evidence_graph` — 新闻/公告/SEC/事件日历的去重证据图。`events` 已带来源可靠度、新颖度、到期状态、价量/已验证同行确认与 `actionable_escalation`。**它是 catalyst 权限的唯一事实源**；原始摘要仅供阅读。
+- `thesis_registry` — `memory/theses/*.json` 的只读摘要：当前 state、最近检查时间、下一次 review trigger；未建基线的持仓明确为 `unknown`。
 
 ### Step 3: Swarm 分析（你的创造性工作）
 
@@ -78,6 +79,8 @@ context.json 关键字段：
 2. `memory/{昨天 YYYY-MM-DD}-pre-open.md` 如果存在 — 上次 thesis 和 next-session plan
 3. `memory/{昨天 YYYY-MM-DD}.md` 如果存在 — 用户手写笔记
 4. `INVESTMENT_SOP.md` — 启动顺序参考
+
+当前持仓 thesis 只读 `context.thesis_registry`，daily brief 不在每天晨报里重写 canonical baseline。`status=unknown` 只表示缺基线，不得靠模型记忆或昨天文案补造历史；需要变更时必须走 registry validator/drift evaluator，并为每个 improved/weakened 维度附本次新增 evidence ID。
 
 #### Regime detection（先跑，定调）
 
@@ -605,6 +608,7 @@ postflight 严格 schema 校验：
 - `size.shares`（整数，**主动 call（`cut`/`trim_on_rebound`/`t_only`/`add_only_on_trigger`/`add_on_breakout`）必填**；`hold_and_watch`/`watch` 不需要)：股数是这条 call 日后唯一能被折算成钱的凭据。面板上那条金额曲线已撤（见上条铁律），但**重建一套可信对照账本必须有股数，当天没填就永远补不回来**。宁可给保守估数也别留空。填**你真的会动的股数**,不是仓位上限。
 - `contested` ∈ {`true`, `false`}（每个 decision 必填）：Tier 2 的 Bull 与 Bear 是否真的在该策略上分歧。
 - `thesis_invalidation`（string，主动 cut/trim/add 必填；hold 选填）：**借鉴 UZI-Skill 的 thesis-tracking**——这个仓位的论点**会被什么具体催化推翻**？把 catalyst-gate(cut #1)落地成「论点+失效条件」：你只在这个**失效催化真的发生**时动手，而不是技术面波动。例：「crypto rev 环比转正则停止减仓」。这逼着每个主动 call 绑定一个可被证伪的硬催化，而非"看着toppy"。
+- `thesis_id` 必须沿用 `context.thesis_registry.theses.<ticker>.thesis_id`（resolved 时）；registry 为 `unknown` 时保留已有 decision ID，不得新造一个“看起来像历史”的 canonical thesis。`context.retrospective.decisions[].thesis_ref` 是只读解析结果。
 
 **condition.type 详解**（决定 retrospective 怎么算触发）：
 

--- a/skills/portfolio-risk-review/SKILL.md
+++ b/skills/portfolio-risk-review/SKILL.md
@@ -13,8 +13,13 @@ In this order:
 1. `/root/.openclaw/workspace/MEMORY.md` — rules, traps, user preferences
 2. `/root/.openclaw/workspace/portfolio.json` — authoritative holdings
 3. `/root/.openclaw/workspace/memory/current-portfolio-summary.md` — active ticker list (also lists exited names so you know what NOT to analyze)
-4. Recent `memory/YYYY-MM-DD.md` entries when recent trades matter
-5. `/root/.openclaw/workspace/TOOLS.md` — data chain reference if anything fails
+4. `/root/.openclaw/workspace/memory/theses/*.json` — canonical thesis state when present
+5. Recent `memory/YYYY-MM-DD.md` entries when recent trades matter
+6. `/root/.openclaw/workspace/TOOLS.md` — data chain reference if anything fails
+
+The thesis registry is read-only during a portfolio review. Missing files mean
+`unknown`, not permission to reconstruct a baseline from prior prose. Price moves
+may change valuation but cannot by themselves change business, moat, or management.
 
 ## Fresh data rule
 

--- a/tests/test_thesis_registry.py
+++ b/tests/test_thesis_registry.py
@@ -1,0 +1,262 @@
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.data import thesis_registry as tr
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+
+
+def evidence(evidence_id="fund-1", observed_at="2026-07-01T10:00:00+00:00",
+             kind="fundamental"):
+    return {
+        "evidence_id": evidence_id,
+        "observed_at": observed_at,
+        "source_class": "issuer_filing",
+        "locator": f"filing:{evidence_id}",
+        "kind": kind,
+        "summary": f"Evidence {evidence_id}",
+    }
+
+
+def thesis(ticker="TEST", thesis_id="test-core"):
+    return {
+        "schema_version": 1,
+        "thesis_id": thesis_id,
+        "ticker": ticker,
+        "strategy_scope": ["core_position"],
+        "summary": "Demand and unit economics support durable growth.",
+        "created_at": "2026-07-01T11:00:00+00:00",
+        "checked_at": "2026-07-02T11:00:00+00:00",
+        "state": "intact",
+        "dimensions": {
+            "business": {"state": "intact", "evidence_ids": ["fund-1"]},
+            "moat": {"state": "intact", "evidence_ids": ["fund-1"]},
+            "management": {"state": "intact", "evidence_ids": ["fund-1"]},
+            "valuation": {"state": "weakening", "evidence_ids": ["value-1"]},
+        },
+        "assumptions": [
+            {
+                "id": f"a-{index}",
+                "claim": f"Assumption {index}",
+                "test": f"Metric {index} stays above threshold",
+                "cadence": "quarterly",
+                "status": "supported",
+                "evidence_ids": ["fund-1"],
+            }
+            for index in range(1, 4)
+        ],
+        "red_lines": [
+            {
+                "id": "solvency",
+                "condition": "Liquidity runway falls below 12 months",
+                "severity": "fatal",
+                "status": "clear",
+                "required_action": "Exit the position",
+                "evidence_ids": [],
+            }
+        ],
+        "valuation_anchors": [
+            {
+                "id": "sales",
+                "metric": "EV/Sales",
+                "value": "8.0",
+                "currency": "USD",
+                "period": "FY2026",
+                "evidence_ids": ["value-1"],
+            }
+        ],
+        "evidence": [
+            evidence(),
+            evidence("value-1", kind="valuation"),
+        ],
+        "next_review_trigger": {
+            "type": "earnings",
+            "description": "Review after the next quarterly filing",
+        },
+    }
+
+
+def test_canonical_schema_and_validator_exist():
+    schema = json.loads(tr.SCHEMA_FILE.read_text())
+    assert tr.SCHEMA_FILE == ROOT / "config" / "thesis.schema.json"
+    assert schema["$schema"].endswith("2020-12/schema")
+    assert set(schema["properties"]["dimensions"]["required"]) == set(tr.DIMENSIONS)
+    assert tr.validate_thesis(thesis(), now=NOW) == []
+
+
+def test_missing_baseline_is_unknown_not_reconstructed():
+    result = tr.evaluate_drift(None, thesis(), now=NOW)
+    assert result["status"] == "unknown"
+    assert result["overall"] == "unknown"
+    assert result["errors"] == ["missing historical baseline"]
+
+
+def test_wording_only_change_is_unchanged():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["summary"] = "Same economics, clearer wording."
+    new["checked_at"] = "2026-07-03T11:00:00+00:00"
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "pass"
+    assert result["overall"] == "unchanged"
+    assert {row["direction"] for row in result["dimensions"].values()} == {"unchanged"}
+
+
+def test_price_only_change_can_move_valuation_but_not_business():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-04T11:00:00+00:00"
+    new["evidence"].append(
+        evidence("price-2", "2026-07-03T10:00:00+00:00", "price")
+    )
+    new["dimensions"]["valuation"] = {
+        "state": "damaged", "evidence_ids": ["value-1", "price-2"]
+    }
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "pass"
+    assert result["dimensions"]["valuation"]["direction"] == "weakened"
+    assert result["dimensions"]["valuation"]["new_evidence_ids"] == ["price-2"]
+    for name in ("business", "moat", "management"):
+        assert result["dimensions"][name]["direction"] == "unchanged"
+
+    bad = copy.deepcopy(new)
+    bad["dimensions"]["business"] = {
+        "state": "weakening", "evidence_ids": ["fund-1", "price-2"]
+    }
+    assert any(
+        "business cannot use price-only evidence" in error
+        for error in tr.validate_thesis(bad, now=NOW)
+    )
+
+
+def test_fatal_red_line_dominates_cheaper_valuation():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["state"] = "broken"
+    new["evidence"] += [
+        evidence("liquidity-2", "2026-07-04T10:00:00+00:00", "filing"),
+        evidence("cheap-2", "2026-07-04T10:01:00+00:00", "valuation"),
+    ]
+    new["red_lines"][0]["status"] = "triggered"
+    new["red_lines"][0]["evidence_ids"] = ["liquidity-2"]
+    new["dimensions"]["business"] = {
+        "state": "broken", "evidence_ids": ["fund-1", "liquidity-2"]
+    }
+    new["dimensions"]["valuation"] = {
+        "state": "intact", "evidence_ids": ["value-1", "cheap-2"]
+    }
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "pass"
+    assert result["overall"] == "weakened"
+    assert result["triggered_red_lines"] == ["solvency"]
+    assert result["dimensions"]["valuation"]["direction"] == "improved"
+    assert result["dimensions"]["business"]["new_evidence_ids"] == ["liquidity-2"]
+
+
+def test_changed_dimension_rejects_stale_evidence():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-04T11:00:00+00:00"
+    new["evidence"].append(
+        evidence("old-news-new-id", "2026-07-02T10:00:00+00:00", "filing")
+    )
+    new["dimensions"]["business"] = {
+        "state": "weakening",
+        "evidence_ids": ["fund-1", "old-news-new-id"],
+    }
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "fail"
+    assert result["dimensions"]["business"]["direction"] == "unknown"
+    assert any("business changed using stale evidence" in e for e in result["errors"])
+
+
+def test_mismatched_ticker_and_invalid_state_transitions_fail():
+    old = thesis()
+    wrong = copy.deepcopy(old)
+    wrong["ticker"] = "OTHER"
+    wrong["checked_at"] = "2026-07-03T11:00:00+00:00"
+    assert "ticker mismatch" in tr.evaluate_drift(old, wrong, now=NOW)["errors"]
+
+    broken = copy.deepcopy(old)
+    broken["state"] = "broken"
+    reopened = copy.deepcopy(broken)
+    reopened["state"] = "intact"
+    reopened["checked_at"] = "2026-07-03T11:00:00+00:00"
+    result = tr.evaluate_drift(broken, reopened, now=NOW)
+    assert result["status"] == "fail"
+    assert any("terminal" in error for error in result["errors"])
+
+
+def test_new_red_line_trigger_needs_new_fresh_evidence():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["state"] = "broken"
+    new["checked_at"] = "2026-07-03T11:00:00+00:00"
+    new["red_lines"][0]["status"] = "triggered"
+    new["red_lines"][0]["evidence_ids"] = ["fund-1"]
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "fail"
+    assert any("triggered without new evidence" in e for e in result["errors"])
+
+
+def test_decision_link_preserves_historical_thesis_id():
+    original = [{"ticker": "TEST", "thesis_id": "test-core", "action": "hold_and_watch"}]
+    untouched = copy.deepcopy(original)
+    resolved = tr.resolve_decision_links(original, [thesis()])
+
+    assert original == untouched
+    assert resolved[0]["thesis_id"] == "test-core"
+    assert resolved[0]["thesis_ref"]["status"] == "resolved"
+    assert tr.resolve_decision_links(
+        [{"ticker": "WRONG", "thesis_id": "test-core"}], [thesis()]
+    )[0]["thesis_ref"]["status"] == "mismatch"
+    assert tr.resolve_decision_links(
+        [{"ticker": "OTHER", "thesis_id": "historic-id"}], []
+    )[0]["thesis_ref"] == {"status": "unknown", "thesis_id": "historic-id"}
+
+
+def test_registry_summary_marks_missing_ticker_unknown(tmp_path):
+    (tmp_path / "TEST.json").write_text(json.dumps(thesis()))
+    summary = tr.registry_summary(tmp_path, ["TEST", "MISSING"])
+    assert summary["status"] == "ready"
+    assert summary["theses"]["TEST"]["status"] == "resolved"
+    assert summary["theses"]["MISSING"] == {"status": "unknown"}
+
+
+def test_cli_fails_closed_on_invalid_document(tmp_path):
+    invalid = thesis()
+    invalid["ticker"] = ""
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps(invalid))
+    assert tr.main(["validate", str(path)]) == 1
+
+
+def test_validator_fails_closed_on_malformed_nested_json():
+    malformed = thesis()
+    malformed["strategy_scope"] = [{}]
+    malformed["dimensions"]["business"] = []
+    malformed["evidence"][0]["evidence_id"] = {}
+    malformed["red_lines"][0]["evidence_ids"] = [{}]
+    errors = tr.validate_thesis(malformed, now=NOW)
+    assert errors
+    assert tr.evaluate_drift([], {}, now=NOW)["status"] == "fail"
+
+
+def test_preflight_and_review_skills_are_read_only_registry_consumers():
+    preflight = (ROOT / "scripts" / "harness" / "brief_preflight.py").read_text()
+    daily = (ROOT / "skills" / "daily-deep-brief" / "SKILL.md").read_text()
+    review = (ROOT / "skills" / "portfolio-risk-review" / "SKILL.md").read_text()
+    assert "'thesis_registry': thesis_registry_ctx" in preflight
+    assert "'thesis_id':                action.get('thesis_id')" in preflight
+    assert "daily brief 不在每天晨报里重写 canonical baseline" in daily
+    assert "registry is read-only" in review


### PR DESCRIPTION
## Summary

- add a versioned canonical thesis JSON schema and dependency-free validator
- add deterministic evidence-only drift classification across business, moat, management, and valuation
- keep missing baselines honest as unknown, preserve historical thesis IDs, and resolve decision links without mutating the ledger
- make daily brief and portfolio risk review read the registry without rewriting it
- enforce red-line dominance, fresh evidence for state changes, terminal transitions, and price-only isolation

## Validation

- `112 passed, 4 xfailed` across the new thesis suite and affected preflight/integrity suites
- Python compilation, JSON schema parse, and `git diff --check` passed
- pre-push system check: 12 OK; existing dashboard-size warning; built-in secret scan timed out twice at 10 seconds
- reran the exact secret patterns/exclusions with a 120-second timeout: worktree rc=1 / 0 matches; HEAD rc=1 / 0 matches; then pushed with `--no-verify`

Closes #71
