### PR TITLE
fix: make the research provenance and thesis drift gates fail closed

### DIFF
--- a/memory/theses/README.md
+++ b/memory/theses/README.md
@@ -20,3 +20,9 @@ python3 scripts/data/thesis_registry.py drift old.json new.json
 Missing baselines stay `unknown`. A changed dimension requires a newly observed
 evidence ID; price-only evidence may change valuation but cannot change business,
 moat, or management state.
+
+Red lines are symmetric: triggering one and leaving `triggered` both require new
+evidence observed after the baseline's `checked_at`, and a triggered red line may
+not simply be deleted from the next version. `drift` reports
+`newly_triggered_red_lines` and `resolved_red_lines` so a reversal is visible
+instead of dissolving into `unchanged`.

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -93,8 +93,8 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 |---|---|---|:---:|
 | `fetch_fx.py` | USDHKD 汇率 · 3 路 fallback | Frankfurter(ECB) → 备用 | ✅ |
 | `preflight_integrity.py` | 数据不变量硬闸: TCV / PNL / FX / cash 对账 | 本地 | ✅ |
-| `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出 | 结构化 manifest + 本地确定性校验 | ✅ |
-| `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift 与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
+| `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出（tolerance 上限 5%，算式异常也只输出结构化 fail） | 结构化 manifest + 本地确定性校验 | ✅ |
+| `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 
 ## Layer 8 · 回测/自省 Backtest & Calibration
 

--- a/scripts/data/research_provenance.py
+++ b/scripts/data/research_provenance.py
@@ -13,7 +13,16 @@ from pathlib import Path
 
 SCHEMA_VERSION = 1
 CURRENCIES = {"USD", "HKD", "CNY", "EUR", "JPY", "NONE"}
+# A manifest cannot authorize its own escape hatch: no metric may declare a
+# looser two-source agreement band than this.
+MAX_TOLERANCE_PCT = Decimal("5")
+# Powers must stay integer and small: a fractional exponent is not exact arithmetic,
+# and a large one pushes the result past Decimal's working precision, which would
+# silently round the "exact" number this module exists to protect.
+MAX_EXPONENT = 6
 _NUMBER = re.compile(r"(?<![\w.])(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?")
+_DECIMAL_TOKEN = re.compile(r"D\('[^']*'\)")
+_OPERATORS_ONLY = re.compile(r"[+\-*/%()\s]*")
 
 
 def decimal_value(value, field: str = "value") -> Decimal:
@@ -28,12 +37,40 @@ def decimal_value(value, field: str = "value") -> Decimal:
     return result
 
 
+def _exponent_value(node) -> Decimal | None:
+    """Return the literal Decimal an already-rewritten `D('n')` node evaluates to."""
+    if (
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        and node.func.id == "D" and len(node.args) == 1
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        try:
+            return Decimal(node.args[0].value)
+        except InvalidOperation:
+            return None
+    return None
+
+
 def exact_calculate(expression: str) -> Decimal:
-    """Evaluate arithmetic after replacing every numeric token with Decimal."""
+    """Evaluate arithmetic after replacing every numeric token with Decimal.
+
+    Every reachable failure raises ValueError so callers — and the CLI, whose
+    contract is one JSON object per run — never see a raw traceback instead of a
+    verdict.
+    """
     if not expression or not re.fullmatch(r"[\d.eE+\-*/()%\s]+", expression):
         raise ValueError("expression contains unsupported characters")
     rewritten = _NUMBER.sub(lambda m: f"D('{m.group(0)}')", expression)
-    tree = ast.parse(rewritten, mode="eval")
+    # `1e` and `ee` survive the character allow-list because `e` is legal inside a
+    # numeric exponent. Anything left over after removing the generated Decimal
+    # tokens must be operators, or the expression carries a bare identifier.
+    if not _OPERATORS_ONLY.fullmatch(_DECIMAL_TOKEN.sub("", rewritten)):
+        raise ValueError("expression contains a non-numeric token")
+    try:
+        tree = ast.parse(rewritten, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"expression is not valid arithmetic: {exc.msg}") from exc
     allowed = (
         ast.Expression, ast.BinOp, ast.UnaryOp, ast.Call, ast.Load, ast.Name,
         ast.Constant, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod, ast.Pow,
@@ -47,8 +84,30 @@ def exact_calculate(expression: str) -> Decimal:
             or len(node.args) != 1 or node.keywords
         ):
             raise ValueError("expression contains an invalid call")
-    return eval(compile(tree, "<decimal-expression>", "eval"),  # noqa: S307
-                {"__builtins__": {}, "D": Decimal}, {})
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow):
+            exponent = _exponent_value(node.right)
+            if exponent is None or exponent != exponent.to_integral_value():
+                raise ValueError("exponent must be an integer literal")
+            if abs(exponent) > MAX_EXPONENT:
+                raise ValueError(f"exponent must be within ±{MAX_EXPONENT}")
+    try:
+        return eval(compile(tree, "<decimal-expression>", "eval"),  # noqa: S307
+                    {"__builtins__": {}, "D": Decimal}, {})
+    except ArithmeticError as exc:
+        # decimal.DecimalException (DivisionUndefined, Overflow, InvalidOperation…)
+        # and ZeroDivisionError all land here.
+        raise ValueError(f"expression is not computable: {exc.__class__.__name__}") from exc
+    except NameError as exc:  # defence in depth behind the token check above
+        raise ValueError(f"expression contains an unknown name: {exc}") from exc
+
+
+def _tolerance(value, field: str) -> Decimal:
+    tolerance = decimal_value(value, field)
+    if tolerance < 0:
+        raise ValueError(f"{field} must be non-negative")
+    if tolerance > MAX_TOLERANCE_PCT:
+        raise ValueError(f"{field} must not exceed the {MAX_TOLERANCE_PCT}% cap")
+    return tolerance
 
 
 def market_cap_result(price: str, shares: str, reported: str, currency: str,
@@ -58,8 +117,8 @@ def market_cap_result(price: str, shares: str, reported: str, currency: str,
     p = decimal_value(price, "price")
     s = decimal_value(shares, "shares")
     r = decimal_value(reported, "reported")
-    tolerance = decimal_value(tolerance_pct, "tolerance_pct")
-    if p < 0 or s <= 0 or r <= 0 or tolerance < 0:
+    tolerance = _tolerance(tolerance_pct, "tolerance_pct")
+    if p < 0 or s <= 0 or r <= 0:
         raise ValueError("price must be non-negative; shares/reported positive; tolerance non-negative")
     calculated = p * s
     deviation = abs(calculated - r) / r * Decimal("100")
@@ -101,7 +160,8 @@ def validate_manifest(payload: dict) -> dict:
         metric_id = metric.get("id")
         if not metric_id or metric_id in ids:
             errors.append(f"{prefix}.id must be present and unique")
-        ids.add(metric_id)
+        if metric_id:
+            ids.add(metric_id)
         for field in ("name", "ticker", "period", "as_of", "unit", "basis"):
             if not metric.get(field):
                 errors.append(f"{prefix}.{field} is required")
@@ -135,8 +195,8 @@ def validate_manifest(payload: dict) -> dict:
                     errors.append(f"{prefix}.verification.{field} must match metric {field}")
             try:
                 fetched = decimal_value(check.get("value"), f"{prefix}.verification.value")
-                tolerance = decimal_value(metric.get("tolerance_pct", "1"),
-                                          f"{prefix}.tolerance_pct")
+                tolerance = _tolerance(metric.get("tolerance_pct", "1"),
+                                       f"{prefix}.tolerance_pct")
                 if reported is not None:
                     deviation = (abs(reported - fetched) / abs(reported) * 100
                                  if reported else (Decimal(0) if not fetched else Decimal("Infinity")))
@@ -184,7 +244,7 @@ def main(argv=None) -> int:
             )
         else:
             result = validate_manifest(json.loads(args.path.read_text()))
-    except (ValueError, OSError, json.JSONDecodeError, ZeroDivisionError) as exc:
+    except (ValueError, OSError, json.JSONDecodeError, ArithmeticError) as exc:
         result = {"status": "fail", "errors": [str(exc)]}
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))
     return 0 if result["status"] == "pass" else 1

--- a/scripts/data/thesis_registry.py
+++ b/scripts/data/thesis_registry.py
@@ -271,20 +271,42 @@ def validate_transition(old: dict, new: dict) -> list[str]:
     return errors
 
 
+def _drift_failure(status: str, errors: list[str]) -> dict:
+    """Same result shape as a passing drift run, so callers never key-miss."""
+    return {
+        "status": status, "overall": "unknown", "dimensions": {},
+        "triggered_red_lines": [], "newly_triggered_red_lines": [],
+        "resolved_red_lines": [], "errors": errors,
+    }
+
+
+def _has_fresh_support(supporting, new_evidence, old_checked, label, errors) -> bool:
+    """True when a change is backed by evidence first observed after the baseline."""
+    if not supporting:
+        errors.append(f"{label} without new evidence")
+        return False
+    fresh = False
+    for evidence_id in sorted(supporting):
+        observed_errors = []
+        observed = _parse_time(
+            new_evidence[evidence_id].get("observed_at"),
+            f"evidence {evidence_id}.observed_at", observed_errors,
+        )
+        errors += observed_errors
+        fresh |= bool(observed and old_checked and observed > old_checked)
+    if not fresh:
+        errors.append(f"{label} using stale evidence")
+    return fresh
+
+
 def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
     if old is None:
-        return {
-            "status": "unknown", "overall": "unknown", "dimensions": {},
-            "errors": ["missing historical baseline"],
-        }
+        return _drift_failure("unknown", ["missing historical baseline"])
     errors = validate_thesis(old, now=now) + validate_thesis(new, now=now)
     if isinstance(old, dict) and isinstance(new, dict):
         errors += validate_transition(old, new)
     if errors:
-        return {
-            "status": "fail", "overall": "unknown", "dimensions": {},
-            "triggered_red_lines": [], "errors": errors,
-        }
+        return _drift_failure("fail", errors)
     old_checked_errors = []
     old_checked = _parse_time(old.get("checked_at"), "old.checked_at", old_checked_errors)
     errors += old_checked_errors
@@ -305,23 +327,10 @@ def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
         else:
             direction = "unknown"
         supporting = set(after.get("evidence_ids") or []) & set(new_evidence)
-        if direction != "unchanged":
-            if not supporting:
-                errors.append(f"{name} changed without new evidence")
-                direction = "unknown"
-            else:
-                fresh = False
-                for evidence_id in supporting:
-                    observed_errors = []
-                    observed = _parse_time(
-                        new_evidence[evidence_id].get("observed_at"),
-                        f"evidence {evidence_id}.observed_at", observed_errors,
-                    )
-                    errors += observed_errors
-                    fresh |= bool(observed and old_checked and observed > old_checked)
-                if not fresh:
-                    errors.append(f"{name} changed using stale evidence")
-                    direction = "unknown"
+        if direction != "unchanged" and not _has_fresh_support(
+            supporting, new_evidence, old_checked, f"{name} changed", errors
+        ):
+            direction = "unknown"
         dimensions[name] = {
             "old_state": before_state,
             "new_state": after_state,
@@ -337,26 +346,41 @@ def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
         item.get("id"): item for item in old.get("red_lines", [])
         if isinstance(item, dict)
     }
+    new_red_lines = {
+        item.get("id"): item for item in new.get("red_lines", [])
+        if isinstance(item, dict)
+    }
     newly_triggered = []
     for item in triggered:
         if (old_red_lines.get(item.get("id")) or {}).get("status") == "triggered":
             continue
         newly_triggered.append(item)
         supporting = set(item.get("evidence_ids") or []) & set(new_evidence)
-        if not supporting:
-            errors.append(f"red line {item.get('id')} triggered without new evidence")
+        _has_fresh_support(
+            supporting, new_evidence, old_checked,
+            f"red line {item.get('id')} triggered", errors,
+        )
+
+    # Leaving `triggered` is a judgment too. Without the same evidence rule a
+    # triggered red line could be cleared out of thin air and the drift report
+    # would still say `unchanged`, erasing the most consequential state in the
+    # document.
+    resolved = []
+    for red_line_id, before in old_red_lines.items():
+        if before.get("status") != "triggered":
             continue
-        fresh = False
-        for evidence_id in supporting:
-            observed_errors = []
-            observed = _parse_time(
-                new_evidence[evidence_id].get("observed_at"),
-                f"evidence {evidence_id}.observed_at", observed_errors,
-            )
-            errors += observed_errors
-            fresh |= bool(observed and old_checked and observed > old_checked)
-        if not fresh:
-            errors.append(f"red line {item.get('id')} triggered using stale evidence")
+        after = new_red_lines.get(red_line_id)
+        if after is None:
+            errors.append(f"red line {red_line_id} was dropped while triggered")
+            continue
+        if after.get("status") == "triggered":
+            continue
+        resolved.append(red_line_id)
+        supporting = set(after.get("evidence_ids") or []) & set(new_evidence)
+        _has_fresh_support(
+            supporting, new_evidence, old_checked,
+            f"red line {red_line_id} left triggered", errors,
+        )
 
     directions = {item["direction"] for item in dimensions.values()}
     if triggered:
@@ -387,6 +411,8 @@ def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
         "overall": overall,
         "dimensions": dimensions,
         "triggered_red_lines": [item.get("id") for item in triggered],
+        "newly_triggered_red_lines": [item.get("id") for item in newly_triggered],
+        "resolved_red_lines": sorted(resolved),
         "errors": errors,
     }
 

--- a/tests/test_research_provenance.py
+++ b/tests/test_research_provenance.py
@@ -1,7 +1,14 @@
 import json
+import subprocess
+import sys
 from decimal import Decimal
+from pathlib import Path
+
+import pytest
 
 from scripts.data import research_provenance as rp
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "data" / "research_provenance.py"
 
 
 def metric():
@@ -104,3 +111,49 @@ def test_cli_returns_nonzero_for_failed_gate(tmp_path):
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest([])))
     assert rp.main(["verify-manifest", str(path)]) == 1
+
+
+@pytest.mark.parametrize(
+    "expression",
+    ["1e", "ee", "0/0", "5%0", "1/0", "9**999999999", "2**1.5", "(", "1+"],
+)
+def test_hostile_expressions_fail_closed_with_one_json_object(expression, capsys):
+    """A gate whose failure mode is a traceback cannot be parsed by its caller."""
+    assert rp.main(["calc", "--expr", expression]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "fail"
+    assert payload["errors"]
+
+
+def test_calc_cli_subprocess_prints_json_and_no_traceback():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "calc", "--expr", "0/0"],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert json.loads(result.stdout)["status"] == "fail"
+
+
+def test_small_exponents_still_evaluate_exactly():
+    assert rp.exact_calculate("1.1**2") == Decimal("1.21")
+
+
+def test_metric_cannot_authorize_its_own_tolerance():
+    loose = metric()
+    loose["tolerance_pct"] = "500"
+    loose["verification"]["value"] = "400"  # 300% away from reported "100.00"
+    result = rp.validate_manifest(manifest([loose]))
+    assert result["status"] == "fail"
+    assert result["verified_metrics"] == 0
+    assert any(f"{rp.MAX_TOLERANCE_PCT}% cap" in error for error in result["errors"])
+
+
+def test_market_cap_rejects_tolerance_above_cap():
+    assert rp.market_cap_result("10", "10", "100", "USD", "5")["status"] == "pass"
+    try:
+        rp.market_cap_result("10", "10", "10000", "USD", "500")
+    except ValueError as exc:
+        assert "cap" in str(exc)
+    else:
+        raise AssertionError("an out-of-cap tolerance was honored")

--- a/tests/test_thesis_registry.py
+++ b/tests/test_thesis_registry.py
@@ -260,3 +260,101 @@ def test_preflight_and_review_skills_are_read_only_registry_consumers():
     assert "'thesis_id':                action.get('thesis_id')" in preflight
     assert "daily brief 不在每天晨报里重写 canonical baseline" in daily
     assert "registry is read-only" in review
+
+
+def _triggered_baseline():
+    """A thesis whose severe red line is already triggered."""
+    old = thesis()
+    old["state"] = "damaged"
+    old["red_lines"][0]["severity"] = "severe"
+    old["red_lines"][0]["status"] = "triggered"
+    old["red_lines"][0]["evidence_ids"] = ["fund-1"]
+    assert tr.validate_thesis(old, now=NOW) == []
+    return old
+
+
+def test_clearing_a_red_line_without_new_evidence_fails():
+    old = _triggered_baseline()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["red_lines"][0]["status"] = "clear"
+    new["red_lines"][0]["evidence_ids"] = []
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "fail"
+    assert any(
+        "red line solvency left triggered without new evidence" in error
+        for error in result["errors"]
+    )
+
+
+def test_clearing_a_red_line_with_stale_evidence_fails():
+    old = _triggered_baseline()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["red_lines"][0]["status"] = "clear"
+    # observed before the baseline's checked_at, so it proves nothing new
+    new["evidence"].append(evidence("late-id-old-fact", "2026-07-01T12:00:00+00:00", "filing"))
+    new["red_lines"][0]["evidence_ids"] = ["late-id-old-fact"]
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "fail"
+    assert any("left triggered using stale evidence" in e for e in result["errors"])
+
+
+def test_resolved_red_line_with_fresh_evidence_passes_and_is_reported():
+    old = _triggered_baseline()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["evidence"].append(evidence("refinanced-2", "2026-07-04T10:00:00+00:00", "filing"))
+    new["red_lines"][0]["status"] = "clear"
+    new["red_lines"][0]["evidence_ids"] = ["refinanced-2"]
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "pass", result["errors"]
+    assert result["resolved_red_lines"] == ["solvency"]
+    assert result["triggered_red_lines"] == []
+    assert result["newly_triggered_red_lines"] == []
+
+
+def test_dropping_a_triggered_red_line_is_not_a_resolution():
+    old = _triggered_baseline()
+    new = copy.deepcopy(old)
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["red_lines"] = [
+        {
+            "id": "other",
+            "condition": "Customer concentration exceeds 40%",
+            "severity": "warning",
+            "status": "clear",
+            "required_action": "Reassess sizing",
+            "evidence_ids": [],
+        }
+    ]
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "fail"
+    assert any("dropped while triggered" in error for error in result["errors"])
+
+
+def test_newly_triggered_red_line_is_reported_separately():
+    old = thesis()
+    new = copy.deepcopy(old)
+    new["state"] = "broken"
+    new["checked_at"] = "2026-07-05T11:00:00+00:00"
+    new["evidence"].append(evidence("runway-2", "2026-07-04T10:00:00+00:00", "filing"))
+    new["red_lines"][0]["status"] = "triggered"
+    new["red_lines"][0]["evidence_ids"] = ["runway-2"]
+    new["dimensions"]["business"] = {"state": "broken", "evidence_ids": ["fund-1", "runway-2"]}
+
+    result = tr.evaluate_drift(old, new, now=NOW)
+    assert result["status"] == "pass", result["errors"]
+    assert result["newly_triggered_red_lines"] == ["solvency"]
+    assert result["resolved_red_lines"] == []
+    assert result["overall"] == "weakened"
+
+
+def test_failure_results_keep_the_full_drift_shape():
+    keys = set(tr.evaluate_drift(None, thesis(), now=NOW))
+    assert keys == set(tr.evaluate_drift([], {}, now=NOW))
+    assert {"resolved_red_lines", "newly_triggered_red_lines", "triggered_red_lines"} <= keys


### PR DESCRIPTION
Review follow-up on the just-merged research foundation (#79, #80). Both findings were reproduced before filing.

## research_provenance (#81)

- `calc` printed a Python traceback instead of a verdict for `1e`, `ee`, `0/0`, `5%0`, `9**999999999`, `(`, `1+`. `main()` caught only `ValueError/OSError/JSONDecodeError/ZeroDivisionError`, so `decimal.DecimalException`, `SyntaxError` and `NameError` escaped. A gate whose failure mode is "no parseable output" is fail-open for its caller.
- Bare identifiers could reach `ast.parse` because `e`/`E` are legal inside numeric exponents; residual tokens are now rejected before parsing.
- Powers must be integer literals within `±6`: a fractional exponent is not exact arithmetic and a large one silently rounds past Decimal's working precision.
- `tolerance_pct` was an unbounded self-authorized escape hatch — a metric declaring `500` "verified" a number 300% away from its second source. Capped at `MAX_TOLERANCE_PCT = 5`, in both `validate_manifest` and `market_cap_result`.
- `metrics[].id` no longer inserts `None` into the referenced-id set.

## thesis_registry (#82)

- Triggering a red line required new, post-baseline evidence; leaving `triggered` required nothing, and the drift result said `overall: unchanged` with an empty `triggered_red_lines`. A triggered severe red line could vanish with `status: pass`.
- Resolution is now symmetric with triggering, deleting a triggered red line from the next version is an error, and drift reports `newly_triggered_red_lines` / `resolved_red_lines`.
- Failure paths return the same result shape as a passing run, so consumers never key-miss.

## Validation

- `713 passed, 5 xfailed` (full `tests/`), up from 694 — 11 new provenance assertions and 6 new drift tests.
- Mutation proof: reverting `scripts/data/research_provenance.py` to its pre-fix content turns exactly the 11 new provenance tests red; reverting `scripts/data/thesis_registry.py` turns exactly the 6 new drift tests red. Both green again after restore.
- One test drives the CLI through a subprocess and asserts stdout is one JSON object with no `Traceback` in stderr, so the fix is proven at the process boundary the gate is actually called from.
- `git diff --check` clean.

Closes #81
Closes #82