### PR TITLE
feat: add primary-source earnings and management accountability ledger

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -10,9 +10,11 @@ on:
       - 'memory/**-plan.json'
       - 'assets/data/dashboard.json'
       - '.github/workflows/harness-regression.yml'
-      - 'config/cron-schedules.json'
-      - 'config/instruments.json'
-      - 'config/instruments.schema.json'
+      # Whole directory on purpose: every file here (cron contract, instrument
+      # registry, thesis/earnings schemas, news-evidence policy, peer rules) is
+      # read by the suite, and naming them one by one already left new schemas
+      # ungated — a config-only PR then skipped the tests that guard them.
+      - 'config/**'
       - 'docs/operations/cron-schedules.md'
       - '.github/workflows/**'
       - 'skills/tavily-search/**'
@@ -108,7 +110,7 @@ jobs:
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
-              scripts/*|tests/*|portfolio.json|memory/*-plan.json|assets/data/dashboard.json|config/cron-schedules.json|config/instruments.json|config/instruments.schema.json|docs/operations/cron-schedules.md|.github/workflows/*)
+              scripts/*|tests/*|portfolio.json|memory/*-plan.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*)
                 code=true
                 break
                 ;;

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Hong Kong times run on HKT; US session times follow ET and their cron expression
 | Analyze a Hong Kong company | [`hk-stock-analysis`](skills/hk-stock-analysis/SKILL.md) | Tencent/Eastmoney quote checks, HK fundamentals, market context | Reusable with the clawock workspace |
 | Review the current portfolio | [`portfolio-risk-review`](skills/portfolio-risk-review/SKILL.md) for one pass; [`portfolio-swarm-review`](skills/portfolio-swarm-review/SKILL.md) for debate | `portfolio.json`, fresh quotes, risk and decision ledgers | Specific to the configured portfolio |
 | Stress-test a supply-chain thesis | [`serenity-skill`](skills/serenity-skill/SKILL.md) | Current public evidence plus its local scorecard | Reusable as a manual research framework |
+| Review a reported quarter and hold management to account | [`earnings-review`](skills/earnings-review/SKILL.md) | First-party filings/HKEX announcements, structured XBRL or Eastmoney verification, provenance gate | Reusable; artifacts live in `memory/earnings/` |
 
 These are workspace-native research routes, not standalone one-command products. They expect clawock's scripts, data contracts, and memory/SOP files; the published portfolio and its operating history remain specific to this deployment.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -161,6 +161,7 @@ clawock 是一个持续运行的、公开的**纪律化、自评式** AI 投资�
 | 分析一家港股公司 | [`hk-stock-analysis`](skills/hk-stock-analysis/SKILL.md) | 腾讯 / 东财行情对账、港股基本面、市场环境 | 可随 clawock workspace 复用 |
 | 检查当前组合 | 单次走 [`portfolio-risk-review`](skills/portfolio-risk-review/SKILL.md);深度辩论走 [`portfolio-swarm-review`](skills/portfolio-swarm-review/SKILL.md) | `portfolio.json`、新鲜行情、风控与决策账本 | 依赖已配置的真实组合 |
 | 压测一条供应链 thesis | [`serenity-skill`](skills/serenity-skill/SKILL.md) | 当前公开证据 + 本地评分卡 | 可作为手动研究框架复用 |
+| 复盘一个已披露的报告期并追踪管理层承诺 | [`earnings-review`](skills/earnings-review/SKILL.md) | 一手 filing / 港交所公告、XBRL 或东财结构化交叉验证、provenance 准出闸 | 可复用;产物落在 `memory/earnings/` |
 
 这些入口原生依赖 workspace,不是一条命令即可独立安装的通用产品。它们要求 clawock 的脚本、数据契约和记忆 / SOP 文件;公开持仓及其运行历史只属于当前这套部署。
 

--- a/config/earnings_review.schema.json
+++ b/config/earnings_review.schema.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KCNyu/clawock/config/earnings_review.schema.json",
+  "title": "clawock primary-source earnings review artifact",
+  "description": "One reporting period per file under memory/earnings/<TICKER>/<period>.json. scripts/data/earnings_review.py is the enforcing validator; this document is the published shape.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "ticker",
+    "market",
+    "cadence",
+    "currency",
+    "unit",
+    "basis",
+    "period",
+    "published_at",
+    "documents",
+    "comparables",
+    "segments",
+    "guidance",
+    "footnotes",
+    "management_commitments",
+    "capital_allocation",
+    "thesis_link",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "ticker": {"type": "string", "minLength": 1},
+    "market": {"enum": ["US", "HK"]},
+    "cadence": {"enum": ["quarterly", "semiannual", "annual"]},
+    "currency": {"enum": ["USD", "HKD", "CNY", "EUR", "JPY"]},
+    "unit": {"type": "string", "minLength": 1},
+    "basis": {"enum": ["GAAP", "IFRS", "HKFRS", "non_GAAP"]},
+    "period": {"$ref": "#/$defs/period"},
+    "published_at": {"type": "string", "format": "date-time"},
+    "documents": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/document"}
+    },
+    "comparables": {
+      "type": "array",
+      "minItems": 3,
+      "items": {"$ref": "#/$defs/comparable"}
+    },
+    "segments": {"type": "array", "items": {"$ref": "#/$defs/segment"}},
+    "guidance": {
+      "oneOf": [{"$ref": "#/$defs/guidance"}, {"type": "null"}]
+    },
+    "footnotes": {"type": "array", "items": {"$ref": "#/$defs/footnote"}},
+    "management_commitments": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/commitment"}
+    },
+    "capital_allocation": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/capital_event"}
+    },
+    "thesis_link": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["thesis_id", "ticker"],
+          "properties": {
+            "thesis_id": {"type": "string", "minLength": 1},
+            "ticker": {"type": "string", "minLength": 1}
+          }
+        },
+        {"type": "null"}
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "description": "A research_provenance manifest covering every published number; see config/thesis.schema.json's sibling gate in scripts/data/research_provenance.py."
+    }
+  },
+  "$defs": {
+    "decimal_string": {"type": "string", "pattern": "^-?(\\d+(\\.\\d*)?|\\.\\d+)([eE][+-]?\\d+)?$"},
+    "period": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "end_date"],
+      "properties": {
+        "label": {"type": "string", "minLength": 1},
+        "end_date": {"type": "string", "format": "date"}
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["document_id", "source_class", "locator", "retrieved_at", "covers_period"],
+      "properties": {
+        "document_id": {"type": "string", "minLength": 1},
+        "source_class": {
+          "enum": [
+            "sec_filing",
+            "hkex_announcement",
+            "issuer_ir",
+            "sec_xbrl",
+            "eastmoney_fundamentals",
+            "third_party_summary"
+          ]
+        },
+        "locator": {"type": "string", "minLength": 1},
+        "retrieved_at": {"type": "string", "format": "date-time"},
+        "covers_period": {"type": "boolean"}
+      }
+    },
+    "comparable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["period", "basis", "currency", "unit", "revenue", "net_income", "ocf"],
+      "properties": {
+        "period": {"$ref": "#/$defs/period"},
+        "basis": {"enum": ["GAAP", "IFRS", "HKFRS", "non_GAAP"]},
+        "currency": {"enum": ["USD", "HKD", "CNY", "EUR", "JPY"]},
+        "unit": {"type": "string", "minLength": 1},
+        "revenue": {"$ref": "#/$defs/decimal_string"},
+        "operating_income": {"$ref": "#/$defs/decimal_string"},
+        "net_income": {"$ref": "#/$defs/decimal_string"},
+        "ocf": {"$ref": "#/$defs/decimal_string"},
+        "capex": {"$ref": "#/$defs/decimal_string"},
+        "receivables": {"$ref": "#/$defs/decimal_string"},
+        "inventory": {"$ref": "#/$defs/decimal_string"},
+        "sbc": {"$ref": "#/$defs/decimal_string"},
+        "diluted_shares": {"$ref": "#/$defs/decimal_string"},
+        "cash": {"$ref": "#/$defs/decimal_string"},
+        "debt": {"$ref": "#/$defs/decimal_string"},
+        "eps_diluted": {"$ref": "#/$defs/decimal_string"}
+      }
+    },
+    "segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["segment_id", "name", "revenue"],
+      "properties": {
+        "segment_id": {"type": "string", "minLength": 1},
+        "name": {"type": "string", "minLength": 1},
+        "revenue": {"$ref": "#/$defs/decimal_string"},
+        "operating_income": {"$ref": "#/$defs/decimal_string"}
+      }
+    },
+    "guidance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "basis", "currency", "unit", "guided_low", "guided_high", "actual", "source_document_id"],
+      "properties": {
+        "metric": {"type": "string", "minLength": 1},
+        "basis": {"enum": ["GAAP", "IFRS", "HKFRS", "non_GAAP"]},
+        "currency": {"enum": ["USD", "HKD", "CNY", "EUR", "JPY"]},
+        "unit": {"type": "string", "minLength": 1},
+        "guided_low": {"$ref": "#/$defs/decimal_string"},
+        "guided_high": {"$ref": "#/$defs/decimal_string"},
+        "actual": {"$ref": "#/$defs/decimal_string"},
+        "source_document_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "footnote": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["category", "summary", "source_document_id"],
+      "properties": {
+        "category": {
+          "enum": [
+            "related_party",
+            "contingency",
+            "accounting_policy_change",
+            "goodwill_intangibles",
+            "customer_concentration",
+            "supplier_concentration"
+          ]
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 600},
+        "source_document_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "commitment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commitment_id",
+        "statement",
+        "source_document_id",
+        "made_at",
+        "due_date",
+        "target_metric",
+        "target_value",
+        "actual_value",
+        "status"
+      ],
+      "properties": {
+        "commitment_id": {"type": "string", "minLength": 1},
+        "statement": {"type": "string", "minLength": 1, "maxLength": 600},
+        "source_document_id": {"type": "string", "minLength": 1},
+        "made_at": {"type": "string", "format": "date"},
+        "due_date": {"type": "string", "format": "date"},
+        "target_metric": {"type": "string", "minLength": 1},
+        "target_value": {"oneOf": [{"$ref": "#/$defs/decimal_string"}, {"type": "string"}]},
+        "actual_value": {
+          "oneOf": [{"$ref": "#/$defs/decimal_string"}, {"type": "string"}, {"type": "null"}]
+        },
+        "status": {"enum": ["met", "partial", "missed", "not_due", "unverifiable"]}
+      }
+    },
+    "capital_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_id", "type", "amount", "currency", "occurred_at", "source_document_id"],
+      "properties": {
+        "event_id": {"type": "string", "minLength": 1},
+        "type": {
+          "enum": [
+            "buyback",
+            "dividend",
+            "acquisition",
+            "divestiture",
+            "debt_raise",
+            "debt_repayment",
+            "equity_raise",
+            "new_business_spend"
+          ]
+        },
+        "amount": {"$ref": "#/$defs/decimal_string"},
+        "currency": {"enum": ["USD", "HKD", "CNY", "EUR", "JPY"]},
+        "occurred_at": {"type": "string", "format": "date"},
+        "source_document_id": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/memory/earnings/README.md
+++ b/memory/earnings/README.md
@@ -1,0 +1,28 @@
+# Earnings review artifacts
+
+One file per reporting period: `memory/earnings/<TICKER>/<period-label>.json`.
+The file is the canonical record — which first-party documents were read, the
+comparable history, the promise ledger, and the provenance manifest behind every
+published number. Markdown write-ups are renderings of it, never the source.
+
+```bash
+python3 scripts/data/earnings_review.py validate        memory/earnings/<TICKER>/<period>.json
+python3 scripts/data/earnings_review.py review          memory/earnings/<TICKER>/<period>.json
+python3 scripts/data/earnings_review.py thesis-evidence  memory/earnings/<TICKER>/<period>.json
+python3 scripts/data/earnings_review.py promises \
+    memory/earnings/<TICKER>/<previous>.json memory/earnings/<TICKER>/<current>.json
+```
+
+Shape: `config/earnings_review.schema.json`. Workflow and source policy:
+`skills/earnings-review/SKILL.md`. Worked US and HK examples live in
+`tests/fixtures/earnings/`.
+
+Rules this directory relies on:
+
+- the newest period's file holds the live promise ledger; earlier files are the
+  history, so there is no second commitment store to drift out of sync;
+- a promise may never be dropped, and `met` / `partial` / `missed` are terminal;
+- `basis`, `currency` and `unit` are constant across a comparable history;
+- footnote claims require a primary issuer document covering the period;
+- earnings evidence flows into `memory/theses/*.json` through the registry's own
+  drift evaluator. Nothing here changes thesis state on its own.

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -95,6 +95,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `preflight_integrity.py` | 数据不变量硬闸: TCV / PNL / FX / cash 对账 | 本地 | ✅ |
 | `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出（tolerance 上限 5%，算式异常也只输出结构化 fail） | 结构化 manifest + 本地确定性校验 | ✅ |
 | `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
+| `earnings_review.py` | 一手财报复盘:来源分级、盈利质量数学、管理层承诺账本、provenance 准出与 thesis 证据交接 | `memory/earnings/*/*.json` + 本地确定性校验 | ✅ |
 
 ## Layer 8 · 回测/自省 Backtest & Calibration
 

--- a/scripts/data/earnings_review.py
+++ b/scripts/data/earnings_review.py
@@ -1,0 +1,803 @@
+#!/usr/bin/env python3
+"""Primary-source earnings review and management accountability ledger.
+
+The artifact under `memory/earnings/<TICKER>/<period>.json` is the canonical
+record of one reporting period: which documents were actually read, the
+comparable history the numbers were judged against, the earnings-quality math,
+the promises management has outstanding, and the evidence this hands to the
+thesis registry.
+
+Three rules shape everything here:
+
+1. Numbers are Decimal strings end to end, and every published number must clear
+   `research_provenance.validate_manifest` (two independent sources) before the
+   artifact can be released.
+2. Earnings quality is computed in code from the comparable history, never
+   asserted in prose. A missing input yields `unavailable` plus a reason, not a
+   number.
+3. This module produces thesis *evidence*. It never sets thesis state — that
+   stays with `thesis_registry.evaluate_drift`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+SCHEMA_FILE = WS / "config" / "earnings_review.schema.json"
+ARTIFACT_ROOT = WS / "memory" / "earnings"
+SCHEMA_VERSION = 1
+
+sys.path.insert(0, str(WS / "scripts" / "data"))
+import research_provenance  # noqa: E402
+
+MARKETS = {"US", "HK"}
+# Source classes, ordered by how directly they come from the issuer. Only a
+# primary class can support a footnote claim.
+PRIMARY_SOURCES = {"sec_filing", "hkex_announcement", "issuer_ir"}
+STRUCTURED_SOURCES = {"sec_xbrl", "eastmoney_fundamentals"}
+THIRD_PARTY_SOURCES = {"third_party_summary"}
+SOURCE_CLASSES = PRIMARY_SOURCES | STRUCTURED_SOURCES | THIRD_PARTY_SOURCES
+# US filings are GAAP; HK issuers report under IFRS/HKFRS. A non-GAAP headline is
+# a separate basis and may never be compared against a GAAP one.
+BASES = {"GAAP", "IFRS", "HKFRS", "non_GAAP"}
+MARKET_BASES = {"US": {"GAAP", "non_GAAP"}, "HK": {"IFRS", "HKFRS", "non_GAAP"}}
+CADENCES = {"quarterly": 4, "semiannual": 4, "annual": 3}
+FOOTNOTE_CATEGORIES = {
+    "related_party", "contingency", "accounting_policy_change",
+    "goodwill_intangibles", "customer_concentration", "supplier_concentration",
+}
+COMMITMENT_STATUSES = {"met", "partial", "missed", "not_due", "unverifiable"}
+TERMINAL_COMMITMENT_STATUSES = {"met", "partial", "missed"}
+CAPITAL_EVENTS = {
+    "buyback", "dividend", "acquisition", "divestiture", "debt_raise",
+    "debt_repayment", "equity_raise", "new_business_spend",
+}
+ARTIFACT_FIELDS = (
+    "schema_version", "artifact_id", "ticker", "market", "cadence", "currency",
+    "unit", "basis", "period", "published_at", "documents", "comparables",
+    "segments", "guidance", "footnotes", "management_commitments",
+    "capital_allocation", "thesis_link", "provenance",
+)
+NUMERIC_FIELDS = (
+    "revenue", "operating_income", "net_income", "ocf", "capex",
+    "receivables", "inventory", "sbc", "diluted_shares", "cash", "debt",
+    "eps_diluted",
+)
+REQUIRED_COMPARABLE_FIELDS = ("revenue", "net_income", "ocf")
+# Named, documented thresholds. Earnings quality is a deterministic verdict on
+# these, not a model's impression.
+THRESHOLDS = {
+    "cash_conversion_min": Decimal("0.8"),       # OCF / net income
+    "working_capital_gap_pp": Decimal("15"),     # receivables/inventory growth − revenue growth
+    "dilution_pct": Decimal("5"),                # diluted share count growth
+    "sbc_pct_revenue": Decimal("15"),
+    "guidance_tolerance_pct": Decimal("1"),
+}
+GRADES = ("A", "B", "C")
+QUANTUM = Decimal("0.0001")
+
+
+def _d(value, field, errors=None):
+    """Parse a Decimal string; append an error and return None when malformed."""
+    if value is None:
+        return None
+    try:
+        return research_provenance.decimal_value(value, field)
+    except ValueError as exc:
+        if errors is not None:
+            errors.append(str(exc))
+        return None
+
+
+def _exact_fields(item, required, optional, prefix, errors):
+    if not isinstance(item, dict):
+        errors.append(f"{prefix} must be an object")
+        return False
+    missing = sorted(set(required) - set(item))
+    extra = sorted(set(item) - set(required) - set(optional))
+    if missing:
+        errors.append(f"{prefix} missing fields: {missing}")
+    if extra:
+        errors.append(f"{prefix} unknown fields: {extra}")
+    return not missing and not extra
+
+
+def _parse_date(value, field, errors):
+    try:
+        return date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an ISO-8601 date (YYYY-MM-DD)")
+        return None
+
+
+def _parse_time(value, field, errors):
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError
+        return parsed
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
+        return None
+
+
+def grade_sources(documents: list) -> dict:
+    """Grade information availability from the documents actually retrieved.
+
+    A — a primary issuer document covering the period, plus a structured dataset
+        to verify the numbers against.
+    B — no covering primary document, but a structured dataset carries numbers.
+    C — only third-party summaries: numbers are unverified and footnote claims
+        are not available at all.
+
+    A low grade is a statement about the sources, never about the company.
+    """
+    classes = {
+        doc.get("source_class") for doc in documents if isinstance(doc, dict)
+    }
+    covering_primary = {
+        doc.get("source_class") for doc in documents
+        if isinstance(doc, dict) and doc.get("covers_period") is True
+        and doc.get("source_class") in PRIMARY_SOURCES
+    }
+    structured = classes & STRUCTURED_SOURCES
+    if covering_primary and structured:
+        grade = "A"
+    elif structured:
+        grade = "B"
+    else:
+        grade = "C"
+    gaps = []
+    if not covering_primary:
+        gaps.append("no primary issuer document covers the reporting period")
+    if not structured:
+        gaps.append("no structured dataset available to verify reported numbers")
+    if classes & THIRD_PARTY_SOURCES:
+        gaps.append("third-party summaries are present and rank below issuer sources")
+    return {
+        "grade": grade,
+        "footnote_claims_allowed": bool(covering_primary),
+        "source_classes": sorted(c for c in classes if c),
+        "gaps": gaps,
+    }
+
+
+def _validate_documents(doc, errors):
+    documents = doc.get("documents")
+    if not isinstance(documents, list) or not documents:
+        errors.append("documents must be a non-empty list")
+        return {}
+    by_id = {}
+    for index, item in enumerate(documents):
+        prefix = f"documents[{index}]"
+        if not _exact_fields(
+            item,
+            ("document_id", "source_class", "locator", "retrieved_at", "covers_period"),
+            (), prefix, errors,
+        ):
+            continue
+        if item["source_class"] not in SOURCE_CLASSES:
+            errors.append(f"{prefix}.source_class must be one of {sorted(SOURCE_CLASSES)}")
+        if not isinstance(item["covers_period"], bool):
+            errors.append(f"{prefix}.covers_period must be a boolean")
+        if not item["locator"]:
+            errors.append(f"{prefix}.locator is required")
+        _parse_time(item["retrieved_at"], f"{prefix}.retrieved_at", errors)
+        if item["document_id"] in by_id:
+            errors.append(f"{prefix}.document_id must be unique")
+        else:
+            by_id[item["document_id"]] = item
+    return by_id
+
+
+def _validate_period(period, prefix, errors):
+    if not _exact_fields(period, ("label", "end_date"), (), prefix, errors):
+        return None
+    if not period.get("label"):
+        errors.append(f"{prefix}.label is required")
+    return _parse_date(period.get("end_date"), f"{prefix}.end_date", errors)
+
+
+def _validate_comparables(doc, errors):
+    comparables = doc.get("comparables")
+    cadence = doc.get("cadence")
+    minimum = CADENCES.get(cadence)
+    if not isinstance(comparables, list) or not comparables:
+        errors.append("comparables must be a non-empty list")
+        return []
+    if minimum and len(comparables) < minimum:
+        errors.append(
+            f"{cadence} cadence needs at least {minimum} comparable periods, got {len(comparables)}"
+        )
+    rows, seen_labels, end_dates = [], set(), []
+    for index, item in enumerate(comparables):
+        prefix = f"comparables[{index}]"
+        if not _exact_fields(
+            item, ("period", "basis", "currency", "unit"), NUMERIC_FIELDS, prefix, errors
+        ):
+            continue
+        end_date = _validate_period(item.get("period"), f"{prefix}.period", errors)
+        label = (item.get("period") or {}).get("label")
+        if label in seen_labels:
+            errors.append(f"{prefix}.period.label must be unique")
+        seen_labels.add(label)
+        # A basis, currency or unit switch mid-history silently changes what the
+        # trend means, so it is an error rather than a footnote.
+        for field in ("basis", "currency", "unit"):
+            if item.get(field) != doc.get(field):
+                errors.append(
+                    f"{prefix}.{field} ({item.get(field)!r}) does not match the artifact "
+                    f"{field} ({doc.get(field)!r}); mixed {field} cannot be compared"
+                )
+        for field in REQUIRED_COMPARABLE_FIELDS:
+            if item.get(field) in (None, ""):
+                errors.append(f"{prefix}.{field} is required to judge earnings quality")
+        parsed = {"label": label, "end_date": end_date}
+        for field in NUMERIC_FIELDS:
+            parsed[field] = _d(item.get(field), f"{prefix}.{field}", errors)
+        rows.append(parsed)
+        if end_date:
+            end_dates.append(end_date)
+    if end_dates != sorted(end_dates):
+        errors.append("comparables must be ordered oldest first by period.end_date")
+    if rows and doc.get("period", {}).get("label") != rows[-1]["label"]:
+        errors.append("the last comparable must be the artifact's reporting period")
+    return rows
+
+
+def _validate_commitments(doc, by_id, errors):
+    commitments = doc.get("management_commitments")
+    if not isinstance(commitments, list):
+        errors.append("management_commitments must be a list")
+        return []
+    seen = set()
+    for index, item in enumerate(commitments):
+        prefix = f"management_commitments[{index}]"
+        if not _exact_fields(
+            item,
+            ("commitment_id", "statement", "source_document_id", "made_at",
+             "due_date", "target_metric", "target_value", "actual_value", "status"),
+            (), prefix, errors,
+        ):
+            continue
+        if item["commitment_id"] in seen:
+            errors.append(f"{prefix}.commitment_id must be unique")
+        seen.add(item["commitment_id"])
+        for field in ("statement", "target_metric"):
+            if not item.get(field):
+                errors.append(f"{prefix}.{field} is required")
+        if item["source_document_id"] not in by_id:
+            errors.append(f"{prefix}.source_document_id is not a listed document")
+        _parse_date(item["made_at"], f"{prefix}.made_at", errors)
+        _parse_date(item["due_date"], f"{prefix}.due_date", errors)
+        if item["status"] not in COMMITMENT_STATUSES:
+            errors.append(f"{prefix}.status must be one of {sorted(COMMITMENT_STATUSES)}")
+        if item["status"] in TERMINAL_COMMITMENT_STATUSES and item["actual_value"] in (None, ""):
+            errors.append(f"{prefix} claims {item['status']} without an actual_value")
+        if item["status"] == "not_due" and item["actual_value"] not in (None, ""):
+            errors.append(f"{prefix} is not_due but already carries an actual_value")
+    return commitments
+
+
+def validate_artifact(doc: dict, *, now=None) -> list[str]:
+    """Return every reason this artifact may not be trusted; empty means valid."""
+    errors: list[str] = []
+    if not isinstance(doc, dict):
+        return ["artifact must be an object"]
+    _exact_fields(doc, ARTIFACT_FIELDS, (), "artifact", errors)
+    if doc.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("artifact_id", "ticker"):
+        if not doc.get(field):
+            errors.append(f"{field} is required")
+    market = doc.get("market")
+    if market not in MARKETS:
+        errors.append(f"market must be one of {sorted(MARKETS)}")
+    if doc.get("cadence") not in CADENCES:
+        errors.append(f"cadence must be one of {sorted(CADENCES)}")
+    if doc.get("basis") not in BASES:
+        errors.append(f"basis must be one of {sorted(BASES)}")
+    elif market in MARKET_BASES and doc["basis"] not in MARKET_BASES[market]:
+        errors.append(
+            f"basis {doc['basis']!r} is not a {market} reporting basis "
+            f"({sorted(MARKET_BASES[market])})"
+        )
+    if doc.get("currency") not in research_provenance.CURRENCIES - {"NONE"}:
+        errors.append("currency must be a supported reporting currency")
+    if not doc.get("unit"):
+        errors.append("unit is required")
+    published = _parse_time(doc.get("published_at"), "published_at", errors)
+    if now and published and published > now:
+        errors.append("published_at cannot be in the future")
+    period_end = _validate_period(doc.get("period") or {}, "period", errors)
+    if period_end and published and published.date() < period_end:
+        errors.append("published_at cannot precede the period end_date")
+
+    by_id = _validate_documents(doc, errors)
+    _validate_comparables(doc, errors)
+    availability = grade_sources(list(by_id.values()))
+
+    segments = doc.get("segments")
+    if not isinstance(segments, list):
+        errors.append("segments must be a list (empty when the issuer reports one segment)")
+        segments = []
+    seen = set()
+    for index, item in enumerate(segments):
+        prefix = f"segments[{index}]"
+        if not _exact_fields(
+            item, ("segment_id", "name", "revenue"), ("operating_income",), prefix, errors
+        ):
+            continue
+        if item["segment_id"] in seen:
+            errors.append(f"{prefix}.segment_id must be unique")
+        seen.add(item["segment_id"])
+        _d(item.get("revenue"), f"{prefix}.revenue", errors)
+        _d(item.get("operating_income"), f"{prefix}.operating_income", errors)
+
+    guidance = doc.get("guidance")
+    if guidance is not None:
+        if _exact_fields(
+            guidance,
+            ("metric", "basis", "currency", "unit", "guided_low", "guided_high",
+             "actual", "source_document_id"),
+            (), "guidance", errors,
+        ):
+            for field in ("basis", "currency", "unit"):
+                if guidance.get(field) != doc.get(field):
+                    errors.append(f"guidance.{field} must match the artifact {field}")
+            low = _d(guidance.get("guided_low"), "guidance.guided_low", errors)
+            high = _d(guidance.get("guided_high"), "guidance.guided_high", errors)
+            _d(guidance.get("actual"), "guidance.actual", errors)
+            if low is not None and high is not None and low > high:
+                errors.append("guidance.guided_low cannot exceed guided_high")
+            if guidance.get("source_document_id") not in by_id:
+                errors.append("guidance.source_document_id is not a listed document")
+
+    footnotes = doc.get("footnotes")
+    if not isinstance(footnotes, list):
+        errors.append("footnotes must be a list")
+        footnotes = []
+    for index, item in enumerate(footnotes):
+        prefix = f"footnotes[{index}]"
+        if not _exact_fields(
+            item, ("category", "summary", "source_document_id"), (), prefix, errors
+        ):
+            continue
+        if item["category"] not in FOOTNOTE_CATEGORIES:
+            errors.append(f"{prefix}.category must be one of {sorted(FOOTNOTE_CATEGORIES)}")
+        if not item.get("summary"):
+            errors.append(f"{prefix}.summary is required")
+        source = by_id.get(item.get("source_document_id"))
+        if source is None:
+            errors.append(f"{prefix}.source_document_id is not a listed document")
+        elif source.get("source_class") not in PRIMARY_SOURCES:
+            errors.append(
+                f"{prefix} cites {source.get('source_class')!r}; footnote claims require "
+                "a primary issuer document"
+            )
+    if footnotes and not availability["footnote_claims_allowed"]:
+        errors.append(
+            "footnotes are not available at this source grade: no primary document "
+            "covers the period"
+        )
+
+    _validate_commitments(doc, by_id, errors)
+
+    capital = doc.get("capital_allocation")
+    if not isinstance(capital, list):
+        errors.append("capital_allocation must be a list")
+        capital = []
+    seen = set()
+    for index, item in enumerate(capital):
+        prefix = f"capital_allocation[{index}]"
+        if not _exact_fields(
+            item, ("event_id", "type", "amount", "currency", "occurred_at",
+                   "source_document_id"), (), prefix, errors,
+        ):
+            continue
+        if item["event_id"] in seen:
+            errors.append(f"{prefix}.event_id must be unique")
+        seen.add(item["event_id"])
+        if item["type"] not in CAPITAL_EVENTS:
+            errors.append(f"{prefix}.type must be one of {sorted(CAPITAL_EVENTS)}")
+        _d(item.get("amount"), f"{prefix}.amount", errors)
+        if item.get("currency") != doc.get("currency"):
+            errors.append(f"{prefix}.currency must match the artifact currency")
+        _parse_date(item.get("occurred_at"), f"{prefix}.occurred_at", errors)
+        if item["source_document_id"] not in by_id:
+            errors.append(f"{prefix}.source_document_id is not a listed document")
+
+    link = doc.get("thesis_link")
+    if link is not None and _exact_fields(
+        link, ("thesis_id", "ticker"), (), "thesis_link", errors
+    ) and link.get("ticker") != doc.get("ticker"):
+        errors.append("thesis_link.ticker must match the artifact ticker")
+
+    if not isinstance(doc.get("provenance"), dict):
+        errors.append("provenance must be a manifest object")
+    return errors
+
+
+def _ratio(numerator, denominator):
+    if numerator is None or denominator is None or denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _growth_pct(current, prior):
+    if current is None or prior is None or prior == 0:
+        return None
+    return (current - prior) / abs(prior) * Decimal("100")
+
+
+def _unavailable(reason):
+    return {"status": "unavailable", "reason": reason}
+
+
+def _measure(value, flags=()):
+    # Derived ratios are quantized to four places on purpose: the inputs stay
+    # exact Decimals, and a published ratio carrying 28 digits of division tail
+    # is noise, not precision.
+    return {
+        "status": "computed",
+        "value": str(value.quantize(QUANTUM)),
+        "flags": sorted(flags),
+    }
+
+
+def compute_quality(doc: dict) -> dict:
+    """Earnings-quality math over the comparable history, computed here in code."""
+    errors: list[str] = []
+    rows = _validate_comparables(doc, errors)
+    if errors or not rows:
+        return {"status": "unavailable", "errors": errors or ["no comparable history"]}
+    current, prior = rows[-1], rows[-2] if len(rows) > 1 else None
+    flags: set[str] = set()
+    metrics: dict[str, dict] = {}
+
+    conversion = _ratio(current["ocf"], current["net_income"])
+    if conversion is None:
+        metrics["cash_conversion"] = _unavailable(
+            "net_income is zero or missing, so OCF conversion is undefined"
+        )
+    else:
+        local = set()
+        # A loss-making period inverts the ratio's meaning; say so instead of
+        # reading a negative denominator as a clean beat.
+        if current["net_income"] < 0:
+            local.add("net_income_negative")
+        elif conversion < THRESHOLDS["cash_conversion_min"]:
+            local.add("weak_cash_conversion")
+        metrics["cash_conversion"] = _measure(conversion, local)
+        flags |= local
+
+    if current["ocf"] is None or current["capex"] is None:
+        metrics["free_cash_flow"] = _unavailable("ocf or capex missing")
+    else:
+        fcf = current["ocf"] - current["capex"]
+        local = {"negative_free_cash_flow"} if fcf < 0 else set()
+        metrics["free_cash_flow"] = _measure(fcf, local)
+        flags |= local
+
+    revenue_growth = _growth_pct(current["revenue"], prior["revenue"]) if prior else None
+    metrics["revenue_growth_pct"] = (
+        _measure(revenue_growth) if revenue_growth is not None
+        else _unavailable("no prior comparable period with revenue")
+    )
+    for field, flag in (("receivables", "receivables_outrunning_revenue"),
+                        ("inventory", "inventory_outrunning_revenue")):
+        growth = _growth_pct(current[field], prior[field]) if prior else None
+        if growth is None or revenue_growth is None:
+            metrics[f"{field}_growth_pct"] = _unavailable(
+                f"{field} or revenue missing in one of the two latest periods"
+            )
+            continue
+        gap = growth - revenue_growth
+        local = {flag} if gap > THRESHOLDS["working_capital_gap_pp"] else set()
+        metrics[f"{field}_growth_pct"] = _measure(growth, local)
+        metrics[f"{field}_vs_revenue_pp"] = _measure(gap, local)
+        flags |= local
+
+    dilution = _growth_pct(current["diluted_shares"], prior["diluted_shares"]) if prior else None
+    if dilution is None:
+        metrics["dilution_pct"] = _unavailable("diluted_shares missing in one of the two periods")
+    else:
+        local = {"destructive_dilution"} if dilution > THRESHOLDS["dilution_pct"] else set()
+        metrics["dilution_pct"] = _measure(dilution, local)
+        flags |= local
+
+    sbc_share = _ratio(current["sbc"], current["revenue"])
+    if sbc_share is None:
+        metrics["sbc_pct_revenue"] = _unavailable("sbc or revenue missing")
+    else:
+        share = sbc_share * Decimal("100")
+        local = {"heavy_stock_compensation"} if share > THRESHOLDS["sbc_pct_revenue"] else set()
+        metrics["sbc_pct_revenue"] = _measure(share, local)
+        flags |= local
+
+    margin = _ratio(current["net_income"], current["revenue"])
+    metrics["net_margin_pct"] = (
+        _measure(margin * Decimal("100")) if margin is not None
+        else _unavailable("revenue is zero or missing")
+    )
+
+    guidance = doc.get("guidance")
+    if not isinstance(guidance, dict):
+        guidance_result = _unavailable("no guidance was published for this period")
+    else:
+        low = _d(guidance.get("guided_low"), "guided_low")
+        high = _d(guidance.get("guided_high"), "guided_high")
+        actual = _d(guidance.get("actual"), "actual")
+        if None in (low, high, actual):
+            guidance_result = _unavailable("guidance range or actual result missing")
+        else:
+            tolerance = THRESHOLDS["guidance_tolerance_pct"] / Decimal("100")
+            if actual < low * (Decimal("1") - tolerance):
+                verdict, flag = "miss", {"guidance_miss"}
+            elif actual > high * (Decimal("1") + tolerance):
+                verdict, flag = "beat", set()
+            else:
+                verdict, flag = "inline", set()
+            guidance_result = {
+                "status": "computed", "verdict": verdict,
+                "metric": guidance.get("metric"),
+                "guided_low": str(low), "guided_high": str(high), "actual": str(actual),
+                "flags": sorted(flag),
+            }
+            flags |= flag
+
+    return {
+        "status": "computed",
+        "period": current["label"],
+        "compared_periods": [row["label"] for row in rows],
+        "metrics": metrics,
+        "guidance": guidance_result,
+        "anomaly_flags": sorted(flags),
+        "thresholds": {name: str(value) for name, value in THRESHOLDS.items()},
+    }
+
+
+def roll_forward_commitments(previous: list, current: list, as_of,
+                             *, report_period_end=None) -> tuple[list, list[str]]:
+    """Carry management promises across periods.
+
+    Rules, all deterministic:
+      * a promise recorded in an earlier period may never be dropped;
+      * `met`/`partial`/`missed` are terminal — a later period cannot soften them;
+      * an overdue promise with no reported result becomes `missed` when the
+        reporting period covers its due date (management had the reporting slot
+        and did not deliver), and `unverifiable` when the due date has merely
+        passed on the calendar with no covering report yet.
+    """
+    errors: list[str] = []
+    if isinstance(as_of, datetime):
+        as_of = as_of.date()
+    if isinstance(report_period_end, datetime):
+        report_period_end = report_period_end.date()
+    by_id = {item.get("commitment_id"): item for item in current if isinstance(item, dict)}
+    merged: list[dict] = []
+    for old in previous:
+        if not isinstance(old, dict):
+            continue
+        commitment_id = old.get("commitment_id")
+        new = by_id.pop(commitment_id, None)
+        if new is None:
+            errors.append(f"commitment {commitment_id} disappeared from the ledger")
+            merged.append(dict(old))
+            continue
+        if (old.get("status") in TERMINAL_COMMITMENT_STATUSES
+                and new.get("status") != old.get("status")):
+            errors.append(
+                f"commitment {commitment_id} was already {old['status']}; "
+                f"it cannot become {new.get('status')}"
+            )
+        merged.append(dict(new))
+    merged.extend(dict(item) for item in by_id.values())
+
+    for item in merged:
+        due = None
+        try:
+            due = date.fromisoformat(str(item.get("due_date")))
+        except (TypeError, ValueError):
+            errors.append(f"commitment {item.get('commitment_id')} has no usable due_date")
+        if item.get("status") in TERMINAL_COMMITMENT_STATUSES or due is None:
+            continue
+        if due > as_of:
+            item["status"] = "not_due"
+        elif item.get("actual_value") in (None, ""):
+            covered = report_period_end is not None and due <= report_period_end
+            item["status"] = "missed" if covered else "unverifiable"
+    return merged, errors
+
+
+def build_manifest(doc: dict) -> dict:
+    """The provenance manifest for every headline number this artifact publishes."""
+    provenance = doc.get("provenance")
+    return provenance if isinstance(provenance, dict) else {}
+
+
+def release(doc: dict, *, now=None) -> dict:
+    """The gate. Nothing leaves this module without a verified manifest."""
+    errors = validate_artifact(doc, now=now)
+    manifest = build_manifest(doc)
+    gate = research_provenance.validate_manifest(manifest)
+    if gate["status"] != "pass":
+        errors.extend(f"provenance: {error}" for error in gate["errors"])
+    quality = compute_quality(doc) if not errors else {"status": "unavailable"}
+    availability = grade_sources(
+        [item for item in doc.get("documents", []) if isinstance(item, dict)]
+    )
+    return {
+        "status": "pass" if not errors else "fail",
+        "artifact_id": doc.get("artifact_id"),
+        "ticker": doc.get("ticker"),
+        "source_availability": availability,
+        "basis": doc.get("basis"),
+        "currency": doc.get("currency"),
+        "unit": doc.get("unit"),
+        "provenance": {
+            "status": gate["status"],
+            "verified_metrics": gate["verified_metrics"],
+            "total_metrics": gate["total_metrics"],
+        },
+        "quality": quality,
+        "errors": errors,
+    }
+
+
+def to_thesis_evidence(doc: dict, quality: dict | None = None) -> dict:
+    """Evidence rows for the thesis registry, plus which dimension each informs.
+
+    Returns suggestions only. Thesis state changes stay with
+    `thesis_registry.evaluate_drift`, which re-checks evidence freshness itself.
+    """
+    quality = quality if quality is not None else compute_quality(doc)
+    published = doc.get("published_at")
+    artifact_id = doc.get("artifact_id")
+    primary = next(
+        (item for item in doc.get("documents", [])
+         if isinstance(item, dict) and item.get("covers_period") is True
+         and item.get("source_class") in PRIMARY_SOURCES),
+        None,
+    )
+    source = primary or next(
+        (item for item in doc.get("documents", []) if isinstance(item, dict)), {}
+    )
+    evidence, suggestions = [], []
+
+    def add(kind, dimension, summary, suffix):
+        evidence_id = f"{artifact_id}-{suffix}"
+        evidence.append({
+            "evidence_id": evidence_id,
+            "observed_at": published,
+            "source_class": source.get("source_class"),
+            "locator": source.get("locator"),
+            "kind": kind,
+            "summary": summary,
+        })
+        suggestions.append({
+            "dimension": dimension,
+            "evidence_id": evidence_id,
+            "observation": summary,
+        })
+
+    metrics = quality.get("metrics", {}) if quality.get("status") == "computed" else {}
+    if metrics:
+        flags = quality.get("anomaly_flags") or ["none"]
+        add(
+            "fundamental", "business",
+            f"{doc.get('period', {}).get('label')} earnings quality flags: {', '.join(flags)}",
+            "business",
+        )
+    guidance = quality.get("guidance", {})
+    if guidance.get("status") == "computed":
+        add(
+            "fundamental", "management",
+            f"guidance {guidance['verdict']} on {guidance.get('metric')} "
+            f"(actual {guidance['actual']} vs {guidance['guided_low']}–{guidance['guided_high']})",
+            "guidance",
+        )
+    delivered = [
+        item for item in doc.get("management_commitments", [])
+        if isinstance(item, dict) and item.get("status") in TERMINAL_COMMITMENT_STATUSES
+    ]
+    if delivered:
+        tally = {status: 0 for status in sorted(TERMINAL_COMMITMENT_STATUSES)}
+        for item in delivered:
+            tally[item["status"]] += 1
+        add(
+            "fundamental", "management",
+            "promise ledger: " + ", ".join(f"{k}={v}" for k, v in tally.items()),
+            "promises",
+        )
+    if doc.get("capital_allocation"):
+        types = sorted({item.get("type") for item in doc["capital_allocation"]})
+        add("fundamental", "moat", f"capital allocation this period: {', '.join(types)}", "capital")
+    if doc.get("footnotes"):
+        categories = sorted({item.get("category") for item in doc["footnotes"]})
+        add("filing", "business", f"material footnotes: {', '.join(categories)}", "footnotes")
+
+    return {
+        "thesis_id": (doc.get("thesis_link") or {}).get("thesis_id"),
+        "ticker": doc.get("ticker"),
+        "evidence": evidence,
+        "dimension_suggestions": suggestions,
+        # Deliberately absent: any thesis state. Earnings evidence never moves the
+        # registry on its own.
+        "state_change": None,
+    }
+
+
+def artifact_path(ticker: str, period_label: str) -> Path:
+    return ARTIFACT_ROOT / ticker / f"{period_label}.json"
+
+
+def load_artifact(path: Path) -> tuple[dict | None, list[str]]:
+    try:
+        return json.loads(path.read_text()), []
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [str(exc)]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "review", "thesis-evidence"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("path", type=Path)
+    promises = sub.add_parser("promises")
+    promises.add_argument("previous", type=Path)
+    promises.add_argument("current", type=Path)
+    promises.add_argument("--as-of", default=date.today().isoformat())
+    args = parser.parse_args(argv)
+    now = datetime.now(timezone.utc)
+
+    if args.command == "promises":
+        previous, errors = load_artifact(args.previous)
+        current, current_errors = load_artifact(args.current)
+        errors += current_errors
+        if errors:
+            result = {"status": "fail", "errors": errors}
+        else:
+            period_end = (current.get("period") or {}).get("end_date")
+            merged, merge_errors = roll_forward_commitments(
+                previous.get("management_commitments", []),
+                current.get("management_commitments", []),
+                date.fromisoformat(args.as_of),
+                report_period_end=(
+                    date.fromisoformat(period_end) if isinstance(period_end, str) else None
+                ),
+            )
+            result = {
+                "status": "fail" if merge_errors else "pass",
+                "commitments": merged, "errors": merge_errors,
+            }
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0 if result["status"] == "pass" else 1
+
+    doc, errors = load_artifact(args.path)
+    if errors:
+        result = {"status": "fail", "errors": errors}
+    elif args.command == "validate":
+        found = validate_artifact(doc, now=now)
+        result = {"status": "pass" if not found else "fail", "errors": found}
+    elif args.command == "review":
+        result = release(doc, now=now)
+    else:
+        gate = release(doc, now=now)
+        result = {
+            "status": gate["status"],
+            "errors": gate["errors"],
+            **to_thesis_evidence(doc, gate["quality"]),
+        }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/earnings-review/SKILL.md
+++ b/skills/earnings-review/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: earnings-review
+description: Manual, event-driven earnings review for a US or HK holding, backed by first-party filings. Use when a company reports, when a management promise comes due, or when a thesis review needs primary-source numbers. Produces a structured artifact under memory/earnings/<TICKER>/<period>.json whose earnings-quality math, promise ledger, and thesis evidence are computed by scripts/data/earnings_review.py — not by prose. Never places trades and never changes thesis state.
+---
+
+# Earnings Review
+
+Event-driven, never scheduled. Run this when an issuer reports, when a commitment
+comes due, or before a thesis review that needs first-party numbers. It is not part
+of any cron path.
+
+The output is not a report. It is `memory/earnings/<TICKER>/<period>.json`, and the
+Markdown you write afterwards is a rendering of that file.
+
+## What the code owns and what you own
+
+| Owned by `scripts/data/earnings_review.py` | Owned by you |
+|---|---|
+| Source grade `A/B/C` and whether footnote claims are allowed | Reading the filing and paraphrasing what it says |
+| Cash conversion, FCF, working-capital gaps, dilution, SBC share, margins | Choosing which segments and footnotes matter |
+| Guidance beat / inline / miss | Recording the commitment and its measurable target |
+| Promise roll-forward to `met / partial / missed / not_due / unverifiable` | Locating the document that proves the result |
+| The release gate over the provenance manifest | Deciding whether the period changes the thesis |
+
+Never assert a computed number in prose. Run the script and quote its output.
+
+## Step 1 — collect first-party documents
+
+Source order is not negotiable:
+
+- **US** — SEC filing (10-K/10-Q/8-K) or issuer IR first; `scripts/data/fetch_us_filings.py`
+  supplies the structured XBRL numbers used to verify them.
+- **HK** — HKEX announcement or issuer IR first; `scripts/data/fetch_fundamentals_em.py`
+  (Eastmoney) is a secondary *structured* source, never a substitute for a footnote.
+- A third-party summary may only fill a gap, and it lowers the grade.
+
+Record each document once in `documents[]` with its `source_class`, a stable
+`locator`, `retrieved_at`, and whether it `covers_period`. Store a short paraphrase
+and the locator — never long transcript passages.
+
+Grades are mechanical: **A** needs a covering primary document plus a structured
+dataset; **B** has the dataset but no covering primary document; **C** is
+third-party only. `B`/`C` disable every footnote claim, and the validator enforces
+that. A low grade describes the sources, not the company.
+
+## Step 2 — build the comparable history
+
+At least four comparable quarters (or four half-years, or three annual periods).
+`basis`, `currency` and `unit` must be identical across every comparable — a
+GAAP/non-GAAP or currency switch mid-history is a validation error, not a caveat.
+`revenue`, `net_income` and `ocf` are mandatory per period; anything else you omit
+becomes an explicit `unavailable` with a reason instead of a number.
+
+## Step 3 — promises and capital allocation
+
+Carry the previous period's ledger forward; a promise may never be dropped, and
+`met/partial/missed` are terminal.
+
+```bash
+python3 scripts/data/earnings_review.py promises \
+  memory/earnings/TICKER/<previous>.json memory/earnings/TICKER/<current>.json
+```
+
+An overdue promise with no reported result becomes `missed` when this reporting
+period covers its due date, and `unverifiable` when the due date has merely passed
+with no covering report yet. Log buybacks, dividends, M&A, leverage changes,
+divestitures and new-business spend in `capital_allocation[]`.
+
+## Step 4 — provenance and release
+
+Every published number needs two independent sources in `provenance` (see
+`scripts/data/research_provenance.py`). The release gate refuses the artifact when
+any number is single-sourced or the two sources disagree beyond tolerance.
+
+```bash
+python3 scripts/data/earnings_review.py validate memory/earnings/TICKER/<period>.json
+python3 scripts/data/earnings_review.py review   memory/earnings/TICKER/<period>.json
+```
+
+`review` prints the source grade, the provenance verdict, the quality metrics and
+`anomaly_flags`. A non-zero exit means the artifact is not releasable — fix the
+artifact, do not narrate around it.
+
+## Step 5 — hand evidence to the thesis, not a verdict
+
+```bash
+python3 scripts/data/earnings_review.py thesis-evidence memory/earnings/TICKER/<period>.json
+```
+
+This emits `evidence[]` rows in the thesis registry's shape plus
+`dimension_suggestions`. It deliberately carries no thesis state. To change a
+thesis, append these evidence rows to a new version of
+`memory/theses/<thesis-id>.json` and run the registry's own drift evaluator:
+
+```bash
+python3 scripts/data/thesis_registry.py drift old.json new.json
+```
+
+The registry re-checks freshness itself and will reject a dimension change that
+leans on evidence older than the last check.
+
+## Hard limits
+
+- No persona scoring and no aggregate "master score" — a red-line or
+  integrity failure is never averaged away by good numbers elsewhere.
+- No trade from a single earnings classification. Sizing stays with the existing
+  decision and risk contracts.
+- A price move or a headline is not a filing fact.
+- Missing documents lower the grade. They never justify a fabricated number.

--- a/tests/fixtures/earnings/hk-9999hk-fy2025h2.json
+++ b/tests/fixtures/earnings/hk-9999hk-fy2025h2.json
@@ -1,0 +1,241 @@
+{
+  "schema_version": 1,
+  "artifact_id": "earnings-9999.HK-FY2025H2",
+  "ticker": "9999.HK",
+  "market": "HK",
+  "cadence": "semiannual",
+  "currency": "HKD",
+  "unit": "million",
+  "basis": "HKFRS",
+  "period": {"label": "FY2025H2", "end_date": "2025-12-31"},
+  "published_at": "2026-03-20T09:30:00+00:00",
+  "documents": [
+    {
+      "document_id": "hkex-annual-fy2025",
+      "source_class": "hkex_announcement",
+      "locator": "hkex:9999/annual-results/FY2025",
+      "retrieved_at": "2026-03-21T02:00:00+00:00",
+      "covers_period": true
+    },
+    {
+      "document_id": "em-fundamentals-fy2025",
+      "source_class": "eastmoney_fundamentals",
+      "locator": "eastmoney:9999.HK/report/FY2025",
+      "retrieved_at": "2026-03-21T02:05:00+00:00",
+      "covers_period": true
+    }
+  ],
+  "comparables": [
+    {
+      "period": {"label": "FY2024H1", "end_date": "2024-06-30"},
+      "basis": "HKFRS",
+      "currency": "HKD",
+      "unit": "million",
+      "revenue": "800",
+      "operating_income": "60",
+      "net_income": "50",
+      "ocf": "70",
+      "capex": "30",
+      "receivables": "300",
+      "inventory": "150",
+      "sbc": "20",
+      "diluted_shares": "2000",
+      "cash": "500",
+      "debt": "400",
+      "eps_diluted": "0.025"
+    },
+    {
+      "period": {"label": "FY2024H2", "end_date": "2024-12-31"},
+      "basis": "HKFRS",
+      "currency": "HKD",
+      "unit": "million",
+      "revenue": "850",
+      "operating_income": "65",
+      "net_income": "54",
+      "ocf": "75",
+      "capex": "32",
+      "receivables": "320",
+      "inventory": "160",
+      "sbc": "21",
+      "diluted_shares": "2010",
+      "cash": "520",
+      "debt": "390",
+      "eps_diluted": "0.027"
+    },
+    {
+      "period": {"label": "FY2025H1", "end_date": "2025-06-30"},
+      "basis": "HKFRS",
+      "currency": "HKD",
+      "unit": "million",
+      "revenue": "900",
+      "operating_income": "70",
+      "net_income": "58",
+      "ocf": "85",
+      "capex": "35",
+      "receivables": "330",
+      "inventory": "165",
+      "sbc": "22",
+      "diluted_shares": "2015",
+      "cash": "540",
+      "debt": "380",
+      "eps_diluted": "0.029"
+    },
+    {
+      "period": {"label": "FY2025H2", "end_date": "2025-12-31"},
+      "basis": "HKFRS",
+      "currency": "HKD",
+      "unit": "million",
+      "revenue": "960",
+      "operating_income": "76",
+      "net_income": "62",
+      "ocf": "95",
+      "capex": "36",
+      "receivables": "350",
+      "inventory": "172",
+      "sbc": "23",
+      "diluted_shares": "2025",
+      "cash": "570",
+      "debt": "370",
+      "eps_diluted": "0.031"
+    }
+  ],
+  "segments": [
+    {"segment_id": "hardware", "name": "Hardware", "revenue": "700", "operating_income": "40"},
+    {"segment_id": "subscription", "name": "Subscription", "revenue": "260", "operating_income": "36"}
+  ],
+  "guidance": null,
+  "footnotes": [
+    {
+      "category": "related_party",
+      "summary": "Sales to an entity controlled by a substantial shareholder are disclosed with the transaction amount and pricing basis.",
+      "source_document_id": "hkex-annual-fy2025"
+    }
+  ],
+  "management_commitments": [
+    {
+      "commitment_id": "payout-ratio-fy2025",
+      "statement": "The board committed to a dividend payout ratio of at least 30% for FY2025.",
+      "source_document_id": "hkex-annual-fy2025",
+      "made_at": "2024-08-20",
+      "due_date": "2025-12-31",
+      "target_metric": "dividend_payout_ratio_pct",
+      "target_value": "30",
+      "actual_value": "32",
+      "status": "met"
+    },
+    {
+      "commitment_id": "hardware-margin-fy2026",
+      "statement": "Management committed to raising the hardware segment operating margin above 8% during FY2026.",
+      "source_document_id": "hkex-annual-fy2025",
+      "made_at": "2026-03-20",
+      "due_date": "2026-12-31",
+      "target_metric": "hardware_operating_margin_pct",
+      "target_value": "8",
+      "actual_value": null,
+      "status": "not_due"
+    }
+  ],
+  "capital_allocation": [
+    {
+      "event_id": "dividend-fy2025",
+      "type": "dividend",
+      "amount": "20",
+      "currency": "HKD",
+      "occurred_at": "2026-03-18",
+      "source_document_id": "hkex-annual-fy2025"
+    }
+  ],
+  "thesis_link": null,
+  "provenance": {
+    "schema_version": 1,
+    "artifact_id": "earnings-9999.HK-FY2025H2",
+    "referenced_metric_ids": [
+      "hk9999-revenue-fy2025h2",
+      "hk9999-net-income-fy2025h2",
+      "hk9999-ocf-fy2025h2"
+    ],
+    "metrics": [
+      {
+        "id": "hk9999-revenue-fy2025h2",
+        "name": "Revenue",
+        "ticker": "9999.HK",
+        "period": "FY2025H2",
+        "as_of": "2025-12-31",
+        "unit": "million",
+        "currency": "HKD",
+        "basis": "HKFRS",
+        "reported_value": "960",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "hkex_announcement",
+          "locator": "hkex:9999/annual-results/FY2025#segment-revenue",
+          "fetched_at": "2026-03-21T02:00:00+00:00"
+        },
+        "verification": {
+          "value": "960",
+          "source_class": "eastmoney_fundamentals",
+          "locator": "eastmoney:9999.HK/report/FY2025#revenue",
+          "fetched_at": "2026-03-21T02:05:00+00:00",
+          "period": "FY2025H2",
+          "unit": "million",
+          "currency": "HKD",
+          "basis": "HKFRS"
+        }
+      },
+      {
+        "id": "hk9999-net-income-fy2025h2",
+        "name": "Net income",
+        "ticker": "9999.HK",
+        "period": "FY2025H2",
+        "as_of": "2025-12-31",
+        "unit": "million",
+        "currency": "HKD",
+        "basis": "HKFRS",
+        "reported_value": "62",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "hkex_announcement",
+          "locator": "hkex:9999/annual-results/FY2025#profit-attributable",
+          "fetched_at": "2026-03-21T02:00:00+00:00"
+        },
+        "verification": {
+          "value": "62",
+          "source_class": "eastmoney_fundamentals",
+          "locator": "eastmoney:9999.HK/report/FY2025#net-profit",
+          "fetched_at": "2026-03-21T02:05:00+00:00",
+          "period": "FY2025H2",
+          "unit": "million",
+          "currency": "HKD",
+          "basis": "HKFRS"
+        }
+      },
+      {
+        "id": "hk9999-ocf-fy2025h2",
+        "name": "Operating cash flow",
+        "ticker": "9999.HK",
+        "period": "FY2025H2",
+        "as_of": "2025-12-31",
+        "unit": "million",
+        "currency": "HKD",
+        "basis": "HKFRS",
+        "reported_value": "95",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "hkex_announcement",
+          "locator": "hkex:9999/annual-results/FY2025#cash-flow",
+          "fetched_at": "2026-03-21T02:00:00+00:00"
+        },
+        "verification": {
+          "value": "95",
+          "source_class": "eastmoney_fundamentals",
+          "locator": "eastmoney:9999.HK/report/FY2025#operating-cash-flow",
+          "fetched_at": "2026-03-21T02:05:00+00:00",
+          "period": "FY2025H2",
+          "unit": "million",
+          "currency": "HKD",
+          "basis": "HKFRS"
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/earnings/us-ustest-fy2026q1.json
+++ b/tests/fixtures/earnings/us-ustest-fy2026q1.json
@@ -1,0 +1,262 @@
+{
+  "schema_version": 1,
+  "artifact_id": "earnings-USTEST-FY2026Q1",
+  "ticker": "USTEST",
+  "market": "US",
+  "cadence": "quarterly",
+  "currency": "USD",
+  "unit": "million",
+  "basis": "GAAP",
+  "period": {"label": "FY2026Q1", "end_date": "2026-03-31"},
+  "published_at": "2026-04-25T20:05:00+00:00",
+  "documents": [
+    {
+      "document_id": "10q-fy2026q1",
+      "source_class": "sec_filing",
+      "locator": "sec:USTEST/10-Q/FY2026Q1",
+      "retrieved_at": "2026-04-26T01:10:00+00:00",
+      "covers_period": true
+    },
+    {
+      "document_id": "xbrl-fy2026q1",
+      "source_class": "sec_xbrl",
+      "locator": "sec-xbrl:USTEST/companyconcept/FY2026Q1",
+      "retrieved_at": "2026-04-26T01:12:00+00:00",
+      "covers_period": true
+    },
+    {
+      "document_id": "ir-deck-fy2026q1",
+      "source_class": "issuer_ir",
+      "locator": "ir:USTEST/quarterly-deck/FY2026Q1",
+      "retrieved_at": "2026-04-26T01:15:00+00:00",
+      "covers_period": true
+    }
+  ],
+  "comparables": [
+    {
+      "period": {"label": "FY2025Q2", "end_date": "2025-06-30"},
+      "basis": "GAAP",
+      "currency": "USD",
+      "unit": "million",
+      "revenue": "100",
+      "operating_income": "8",
+      "net_income": "6",
+      "ocf": "7",
+      "capex": "3",
+      "receivables": "40",
+      "inventory": "20",
+      "sbc": "9",
+      "diluted_shares": "500",
+      "cash": "120",
+      "debt": "60",
+      "eps_diluted": "0.012"
+    },
+    {
+      "period": {"label": "FY2025Q3", "end_date": "2025-09-30"},
+      "basis": "GAAP",
+      "currency": "USD",
+      "unit": "million",
+      "revenue": "110",
+      "operating_income": "9",
+      "net_income": "7",
+      "ocf": "8",
+      "capex": "3",
+      "receivables": "44",
+      "inventory": "22",
+      "sbc": "10",
+      "diluted_shares": "502",
+      "cash": "125",
+      "debt": "60",
+      "eps_diluted": "0.014"
+    },
+    {
+      "period": {"label": "FY2025Q4", "end_date": "2025-12-31"},
+      "basis": "GAAP",
+      "currency": "USD",
+      "unit": "million",
+      "revenue": "118",
+      "operating_income": "9.5",
+      "net_income": "7.5",
+      "ocf": "8.5",
+      "capex": "4",
+      "receivables": "50",
+      "inventory": "24",
+      "sbc": "11",
+      "diluted_shares": "505",
+      "cash": "128",
+      "debt": "58",
+      "eps_diluted": "0.015"
+    },
+    {
+      "period": {"label": "FY2026Q1", "end_date": "2026-03-31"},
+      "basis": "GAAP",
+      "currency": "USD",
+      "unit": "million",
+      "revenue": "125",
+      "operating_income": "10",
+      "net_income": "8",
+      "ocf": "5",
+      "capex": "4",
+      "receivables": "70",
+      "inventory": "26",
+      "sbc": "12",
+      "diluted_shares": "510",
+      "cash": "126",
+      "debt": "58",
+      "eps_diluted": "0.016"
+    }
+  ],
+  "segments": [
+    {"segment_id": "platform", "name": "Platform", "revenue": "95", "operating_income": "14"},
+    {"segment_id": "services", "name": "Services", "revenue": "30", "operating_income": "-4"}
+  ],
+  "guidance": {
+    "metric": "revenue",
+    "basis": "GAAP",
+    "currency": "USD",
+    "unit": "million",
+    "guided_low": "120",
+    "guided_high": "128",
+    "actual": "125",
+    "source_document_id": "ir-deck-fy2026q1"
+  },
+  "footnotes": [
+    {
+      "category": "customer_concentration",
+      "summary": "Two customers account for a majority of platform revenue; the filing states the concentration increased versus the prior year.",
+      "source_document_id": "10q-fy2026q1"
+    },
+    {
+      "category": "contingency",
+      "summary": "An unresolved commercial dispute is disclosed with no accrual recorded.",
+      "source_document_id": "10q-fy2026q1"
+    }
+  ],
+  "management_commitments": [
+    {
+      "commitment_id": "fcf-positive-fy2026",
+      "statement": "Management committed to positive free cash flow for every quarter of FY2026.",
+      "source_document_id": "ir-deck-fy2026q1",
+      "made_at": "2026-01-28",
+      "due_date": "2026-03-31",
+      "target_metric": "free_cash_flow",
+      "target_value": "0",
+      "actual_value": "1",
+      "status": "met"
+    },
+    {
+      "commitment_id": "services-breakeven",
+      "statement": "Management committed to Services segment operating breakeven by the end of FY2026.",
+      "source_document_id": "ir-deck-fy2026q1",
+      "made_at": "2026-01-28",
+      "due_date": "2026-12-31",
+      "target_metric": "services_operating_income",
+      "target_value": "0",
+      "actual_value": null,
+      "status": "not_due"
+    }
+  ],
+  "capital_allocation": [
+    {
+      "event_id": "buyback-fy2026q1",
+      "type": "buyback",
+      "amount": "15",
+      "currency": "USD",
+      "occurred_at": "2026-03-10",
+      "source_document_id": "10q-fy2026q1"
+    }
+  ],
+  "thesis_link": {"thesis_id": "ustest-core", "ticker": "USTEST"},
+  "provenance": {
+    "schema_version": 1,
+    "artifact_id": "earnings-USTEST-FY2026Q1",
+    "referenced_metric_ids": [
+      "ustest-revenue-fy2026q1",
+      "ustest-net-income-fy2026q1",
+      "ustest-ocf-fy2026q1"
+    ],
+    "metrics": [
+      {
+        "id": "ustest-revenue-fy2026q1",
+        "name": "Revenue",
+        "ticker": "USTEST",
+        "period": "FY2026Q1",
+        "as_of": "2026-03-31",
+        "unit": "million",
+        "currency": "USD",
+        "basis": "GAAP",
+        "reported_value": "125",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "sec_filing",
+          "locator": "sec:USTEST/10-Q/FY2026Q1#income-statement",
+          "fetched_at": "2026-04-26T01:10:00+00:00"
+        },
+        "verification": {
+          "value": "125",
+          "source_class": "sec_xbrl",
+          "locator": "sec-xbrl:USTEST/Revenues/FY2026Q1",
+          "fetched_at": "2026-04-26T01:12:00+00:00",
+          "period": "FY2026Q1",
+          "unit": "million",
+          "currency": "USD",
+          "basis": "GAAP"
+        }
+      },
+      {
+        "id": "ustest-net-income-fy2026q1",
+        "name": "Net income",
+        "ticker": "USTEST",
+        "period": "FY2026Q1",
+        "as_of": "2026-03-31",
+        "unit": "million",
+        "currency": "USD",
+        "basis": "GAAP",
+        "reported_value": "8",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "sec_filing",
+          "locator": "sec:USTEST/10-Q/FY2026Q1#income-statement",
+          "fetched_at": "2026-04-26T01:10:00+00:00"
+        },
+        "verification": {
+          "value": "8",
+          "source_class": "sec_xbrl",
+          "locator": "sec-xbrl:USTEST/NetIncomeLoss/FY2026Q1",
+          "fetched_at": "2026-04-26T01:12:00+00:00",
+          "period": "FY2026Q1",
+          "unit": "million",
+          "currency": "USD",
+          "basis": "GAAP"
+        }
+      },
+      {
+        "id": "ustest-ocf-fy2026q1",
+        "name": "Operating cash flow",
+        "ticker": "USTEST",
+        "period": "FY2026Q1",
+        "as_of": "2026-03-31",
+        "unit": "million",
+        "currency": "USD",
+        "basis": "GAAP",
+        "reported_value": "5",
+        "tolerance_pct": "1",
+        "source": {
+          "source_class": "sec_filing",
+          "locator": "sec:USTEST/10-Q/FY2026Q1#cash-flow-statement",
+          "fetched_at": "2026-04-26T01:10:00+00:00"
+        },
+        "verification": {
+          "value": "5",
+          "source_class": "sec_xbrl",
+          "locator": "sec-xbrl:USTEST/NetCashProvidedByOperatingActivities/FY2026Q1",
+          "fetched_at": "2026-04-26T01:12:00+00:00",
+          "period": "FY2026Q1",
+          "unit": "million",
+          "currency": "USD",
+          "basis": "GAAP"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_earnings_review.py
+++ b/tests/test_earnings_review.py
@@ -1,0 +1,407 @@
+import copy
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.data import earnings_review as er
+from scripts.data import thesis_registry as tr
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "earnings"
+US = FIXTURES / "us-ustest-fy2026q1.json"
+HK = FIXTURES / "hk-9999hk-fy2025h2.json"
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+
+
+def load(path):
+    return json.loads(path.read_text())
+
+
+@pytest.fixture
+def us():
+    return load(US)
+
+
+@pytest.fixture
+def hk():
+    return load(HK)
+
+
+# --- one normalized schema for both markets -------------------------------------
+
+@pytest.mark.parametrize("path", [US, HK], ids=["us", "hk"])
+def test_us_and_hk_fixtures_pass_the_same_schema_and_gate(path):
+    doc = load(path)
+    assert er.validate_artifact(doc, now=NOW) == []
+    gate = er.release(doc, now=NOW)
+    assert gate["status"] == "pass", gate["errors"]
+    assert gate["provenance"] == {
+        "status": "pass", "verified_metrics": 3, "total_metrics": 3
+    }
+    assert gate["quality"]["status"] == "computed"
+    assert gate["source_availability"]["grade"] == "A"
+
+
+def test_schema_document_and_validator_agree_on_required_fields():
+    schema = json.loads(er.SCHEMA_FILE.read_text())
+    assert set(schema["required"]) == set(er.ARTIFACT_FIELDS)
+    assert set(schema["properties"]) == set(er.ARTIFACT_FIELDS)
+    assert set(schema["$defs"]["document"]["properties"]["source_class"]["enum"]) == er.SOURCE_CLASSES
+    assert set(schema["$defs"]["footnote"]["properties"]["category"]["enum"]) == er.FOOTNOTE_CATEGORIES
+    assert set(schema["$defs"]["commitment"]["properties"]["status"]["enum"]) == er.COMMITMENT_STATUSES
+    assert set(schema["$defs"]["capital_event"]["properties"]["type"]["enum"]) == er.CAPITAL_EVENTS
+
+
+# --- basis / currency / period explicitness ------------------------------------
+
+def test_non_gaap_period_cannot_be_compared_against_gaap(us):
+    us["comparables"][1]["basis"] = "non_GAAP"
+    errors = er.validate_artifact(us, now=NOW)
+    assert any("mixed basis cannot be compared" in error for error in errors)
+
+
+def test_currency_and_unit_switches_are_errors_not_footnotes(us):
+    us["comparables"][0]["currency"] = "HKD"
+    us["comparables"][2]["unit"] = "thousand"
+    errors = er.validate_artifact(us, now=NOW)
+    assert any("mixed currency cannot be compared" in error for error in errors)
+    assert any("mixed unit cannot be compared" in error for error in errors)
+
+
+def test_hk_artifact_cannot_claim_a_us_reporting_basis(hk):
+    hk["basis"] = "GAAP"
+    for row in hk["comparables"]:
+        row["basis"] = "GAAP"
+    assert any(
+        "is not a HK reporting basis" in error
+        for error in er.validate_artifact(hk, now=NOW)
+    )
+
+
+def test_short_history_and_out_of_order_history_fail(us):
+    short = copy.deepcopy(us)
+    short["comparables"] = short["comparables"][2:]
+    assert any(
+        "quarterly cadence needs at least 4 comparable periods" in error
+        for error in er.validate_artifact(short, now=NOW)
+    )
+
+    shuffled = copy.deepcopy(us)
+    shuffled["comparables"] = [shuffled["comparables"][i] for i in (1, 0, 2, 3)]
+    assert any(
+        "ordered oldest first" in error
+        for error in er.validate_artifact(shuffled, now=NOW)
+    )
+
+
+def test_period_and_publication_dates_must_be_coherent(us):
+    early = copy.deepcopy(us)
+    early["published_at"] = "2026-01-05T20:05:00+00:00"
+    assert any(
+        "cannot precede the period end_date" in error
+        for error in er.validate_artifact(early, now=NOW)
+    )
+
+    future = copy.deepcopy(us)
+    future["published_at"] = "2027-04-25T20:05:00+00:00"
+    assert any(
+        "published_at cannot be in the future" in error
+        for error in er.validate_artifact(future, now=NOW)
+    )
+
+
+# --- earnings quality is computed, not asserted --------------------------------
+
+def test_cash_conversion_and_working_capital_anomalies_are_computed(us):
+    quality = er.compute_quality(us)
+    # OCF 5 against net income 8, receivables +40% against revenue +5.93%
+    assert quality["metrics"]["cash_conversion"]["value"] == "0.6250"
+    assert quality["metrics"]["receivables_vs_revenue_pp"]["value"] == "34.0678"
+    assert quality["anomaly_flags"] == [
+        "receivables_outrunning_revenue", "weak_cash_conversion"
+    ]
+    assert quality["thresholds"]["cash_conversion_min"] == "0.8"
+
+
+def test_clean_history_produces_no_flags_and_no_invented_guidance(hk):
+    quality = er.compute_quality(hk)
+    assert quality["anomaly_flags"] == []
+    assert quality["metrics"]["cash_conversion"]["value"] == "1.5323"
+    assert quality["guidance"]["status"] == "unavailable"
+    assert "no guidance was published" in quality["guidance"]["reason"]
+
+
+def test_missing_inputs_are_unavailable_with_a_reason_not_a_number(us):
+    for row in us["comparables"]:
+        row.pop("inventory", None)
+        row.pop("diluted_shares", None)
+    quality = er.compute_quality(us)
+    assert quality["metrics"]["inventory_growth_pct"]["status"] == "unavailable"
+    assert quality["metrics"]["dilution_pct"]["status"] == "unavailable"
+    assert "value" not in quality["metrics"]["dilution_pct"]
+    assert "inventory_outrunning_revenue" not in quality["anomaly_flags"]
+
+
+def test_a_loss_making_period_is_flagged_not_read_as_a_beat(us):
+    us["comparables"][-1]["net_income"] = "-8"
+    quality = er.compute_quality(us)
+    assert "net_income_negative" in quality["metrics"]["cash_conversion"]["flags"]
+    assert "weak_cash_conversion" not in quality["metrics"]["cash_conversion"]["flags"]
+
+
+def test_dilution_and_guidance_miss_are_flagged(us):
+    us["comparables"][-1]["diluted_shares"] = "560"     # +10.9% vs 505
+    us["guidance"]["actual"] = "100"                    # below the 120 floor
+    quality = er.compute_quality(us)
+    assert "destructive_dilution" in quality["anomaly_flags"]
+    assert quality["guidance"]["verdict"] == "miss"
+    assert "guidance_miss" in quality["anomaly_flags"]
+
+
+# --- source grade gates footnote claims ---------------------------------------
+
+def test_missing_first_party_document_lowers_grade_and_disables_footnotes(hk):
+    hk["documents"] = [
+        doc for doc in hk["documents"] if doc["source_class"] != "hkex_announcement"
+    ]
+    availability = er.grade_sources(hk["documents"])
+    assert availability["grade"] == "B"
+    assert availability["footnote_claims_allowed"] is False
+    errors = er.validate_artifact(hk, now=NOW)
+    assert any("footnotes are not available at this source grade" in e for e in errors)
+
+
+def test_third_party_only_artifact_is_grade_c(hk):
+    hk["documents"] = [
+        {
+            "document_id": "summary-only",
+            "source_class": "third_party_summary",
+            "locator": "vendor:9999.HK/fy2025-recap",
+            "retrieved_at": "2026-03-21T02:05:00+00:00",
+            "covers_period": True,
+        }
+    ]
+    availability = er.grade_sources(hk["documents"])
+    assert availability["grade"] == "C"
+    assert availability["footnote_claims_allowed"] is False
+    assert any("no structured dataset" in gap for gap in availability["gaps"])
+
+
+def test_a_footnote_may_not_cite_a_structured_dataset(us):
+    us["footnotes"][0]["source_document_id"] = "xbrl-fy2026q1"
+    assert any(
+        "footnote claims require a primary issuer document" in error
+        for error in er.validate_artifact(us, now=NOW)
+    )
+
+
+# --- management promises survive across periods ------------------------------
+
+def _commitment(commitment_id, due_date, status="not_due", actual=None):
+    return {
+        "commitment_id": commitment_id,
+        "statement": f"Commitment {commitment_id}",
+        "source_document_id": "ir-deck-fy2026q1",
+        "made_at": "2026-01-28",
+        "due_date": due_date,
+        "target_metric": "free_cash_flow",
+        "target_value": "0",
+        "actual_value": actual,
+        "status": status,
+    }
+
+
+def test_promise_becomes_missed_when_the_reporting_period_covers_its_due_date():
+    previous = [_commitment("margin-target", "2026-03-31")]
+    merged, errors = er.roll_forward_commitments(
+        previous, copy.deepcopy(previous), date(2026, 4, 25),
+        report_period_end=date(2026, 3, 31),
+    )
+    assert errors == []
+    assert merged[0]["status"] == "missed"
+    # the input ledger is not mutated in place
+    assert previous[0]["status"] == "not_due"
+
+
+def test_overdue_promise_without_a_covering_report_is_unverifiable_not_missed():
+    previous = [_commitment("margin-target", "2026-03-31")]
+    merged, errors = er.roll_forward_commitments(
+        previous, copy.deepcopy(previous), date(2026, 4, 25),
+        report_period_end=date(2025, 12, 31),
+    )
+    assert errors == []
+    assert merged[0]["status"] == "unverifiable"
+
+
+def test_not_yet_due_promise_stays_not_due():
+    previous = [_commitment("long-horizon", "2026-12-31")]
+    merged, errors = er.roll_forward_commitments(
+        previous, copy.deepcopy(previous), date(2026, 4, 25),
+        report_period_end=date(2026, 3, 31),
+    )
+    assert errors == []
+    assert merged[0]["status"] == "not_due"
+
+
+def test_a_promise_may_not_be_dropped_or_softened_later():
+    previous = [
+        _commitment("kept", "2026-03-31", "missed", "-3"),
+        _commitment("vanishing", "2026-03-31", "met", "4"),
+    ]
+    current = [_commitment("kept", "2026-03-31", "met", "4")]
+    merged, errors = er.roll_forward_commitments(
+        previous, current, date(2026, 4, 25), report_period_end=date(2026, 3, 31)
+    )
+    assert any("was already missed" in error for error in errors)
+    assert any("disappeared from the ledger" in error for error in errors)
+    assert {item["commitment_id"] for item in merged} == {"kept", "vanishing"}
+
+
+def test_new_promises_join_the_ledger():
+    previous = [_commitment("old", "2026-12-31")]
+    current = previous + [_commitment("new", "2026-12-31")]
+    merged, errors = er.roll_forward_commitments(
+        previous, current, date(2026, 4, 25), report_period_end=date(2026, 3, 31)
+    )
+    assert errors == []
+    assert [item["commitment_id"] for item in merged] == ["old", "new"]
+
+
+def test_terminal_status_requires_an_actual_value(us):
+    us["management_commitments"][0]["actual_value"] = None
+    assert any(
+        "claims met without an actual_value" in error
+        for error in er.validate_artifact(us, now=NOW)
+    )
+
+
+# --- the release gate and the thesis boundary --------------------------------
+
+def test_release_is_blocked_by_a_failing_provenance_manifest(us):
+    us["provenance"]["metrics"][0]["verification"]["value"] = "900"
+    gate = er.release(us, now=NOW)
+    assert gate["status"] == "fail"
+    assert any(error.startswith("provenance: ") for error in gate["errors"])
+    assert gate["quality"]["status"] == "unavailable"
+
+
+def test_release_is_blocked_when_a_number_has_only_one_source(us):
+    metric = us["provenance"]["metrics"][0]
+    metric["verification"]["source_class"] = metric["source"]["source_class"]
+    gate = er.release(us, now=NOW)
+    assert gate["status"] == "fail"
+    assert any("independent source" in error for error in gate["errors"])
+
+
+def test_thesis_evidence_never_carries_a_state_change(us):
+    handoff = er.to_thesis_evidence(us)
+    assert handoff["state_change"] is None
+    assert handoff["thesis_id"] == "ustest-core"
+    assert {row["dimension"] for row in handoff["dimension_suggestions"]} <= {
+        "business", "moat", "management", "valuation"
+    }
+    assert all("state" not in row for row in handoff["dimension_suggestions"])
+
+
+def test_generated_evidence_is_accepted_by_the_thesis_registry(us):
+    """The handoff must satisfy the registry's own validator, including its
+    rule that business/moat/management may not lean on price-only evidence."""
+    handoff = er.to_thesis_evidence(us)
+    assert len(handoff["evidence"]) >= 3
+
+    thesis = {
+        "schema_version": 1,
+        "thesis_id": "ustest-core",
+        "ticker": "USTEST",
+        "strategy_scope": ["core_position"],
+        "summary": "Platform economics carry the position; services is the swing factor.",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "checked_at": "2026-04-26T00:00:00+00:00",
+        "state": "weakening",
+        "dimensions": {
+            name: {
+                "state": "weakening" if name == "business" else "unknown",
+                "evidence_ids": [
+                    row["evidence_id"] for row in handoff["dimension_suggestions"]
+                    if row["dimension"] == name
+                ],
+            }
+            for name in ("business", "moat", "management", "valuation")
+        },
+        "assumptions": [
+            {
+                "id": f"a-{index}",
+                "claim": f"Assumption {index}",
+                "test": "Metric stays above threshold",
+                "cadence": "quarterly",
+                "status": "supported",
+                "evidence_ids": [],
+            }
+            for index in range(1, 4)
+        ],
+        "red_lines": [
+            {
+                "id": "cash-conversion",
+                "condition": "OCF/net income stays below 0.8 for two periods",
+                "severity": "severe",
+                "status": "watch",
+                "required_action": "Cut the position by half",
+                "evidence_ids": [],
+            }
+        ],
+        "valuation_anchors": [],
+        "evidence": handoff["evidence"],
+        "next_review_trigger": {
+            "type": "earnings",
+            "description": "Review after the FY2026Q2 filing",
+        },
+    }
+    assert tr.validate_thesis(thesis, now=NOW) == []
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def test_cli_review_passes_and_prints_one_json_object(capsys):
+    assert er.main(["review", str(US)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "pass"
+
+
+def test_cli_fails_closed_on_invalid_artifact(tmp_path, capsys):
+    broken = load(US)
+    broken["comparables"][1]["basis"] = "non_GAAP"
+    path = tmp_path / "broken.json"
+    path.write_text(json.dumps(broken))
+    assert er.main(["validate", str(path)]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"
+
+
+def test_cli_fails_closed_on_unreadable_artifact(tmp_path, capsys):
+    path = tmp_path / "not-json.json"
+    path.write_text("{oops")
+    assert er.main(["review", str(path)]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"
+
+
+def test_cli_promises_rolls_forward_between_two_artifacts(tmp_path, capsys):
+    previous = load(US)
+    previous["management_commitments"] = [_commitment("margin-target", "2026-03-31")]
+    current = load(US)
+    current["management_commitments"] = [_commitment("margin-target", "2026-03-31")]
+    old_path, new_path = tmp_path / "q4.json", tmp_path / "q1.json"
+    old_path.write_text(json.dumps(previous))
+    new_path.write_text(json.dumps(current))
+
+    assert er.main(["promises", str(old_path), str(new_path), "--as-of", "2026-04-25"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["commitments"][0]["status"] == "missed"
+
+
+def test_thesis_evidence_cli_reports_the_gate_verdict(capsys):
+    assert er.main(["thesis-evidence", str(HK)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state_change"] is None
+    assert payload["ticker"] == "9999.HK"

--- a/tests/test_harness_regression_paths.py
+++ b/tests/test_harness_regression_paths.py
@@ -1,0 +1,56 @@
+"""The `validate` gate must not skip a PR that only touches `config/`.
+
+`validate` is a required check that always reports, but its expensive Python steps
+are gated twice: the `push:` path filter and the `Detect code changes` case list.
+Both were written as an explicit list of config files, so every config file added
+later (thesis and earnings schemas, evidence policies, peer rules) silently fell
+outside the gate — a config-only PR reported green in seconds without running the
+tests that read that config. These assertions keep the directory-wide form.
+"""
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (ROOT / ".github" / "workflows" / "harness-regression.yml").read_text()
+CONFIG_FILES = sorted(
+    str(path.relative_to(ROOT)) for path in (ROOT / "config").rglob("*")
+    if path.is_file()
+)
+
+
+def _push_paths():
+    block = WORKFLOW.split("    paths:", 1)[1].split("  pull_request:", 1)[0]
+    return re.findall(r"^\s*-\s*'([^']+)'", block, re.MULTILINE)
+
+
+def _case_patterns():
+    detect = WORKFLOW.split("Detect code changes", 1)[1]
+    line = next(ln for ln in detect.splitlines() if ln.strip().endswith(")") and "|" in ln)
+    return line.strip().rstrip(")").split("|")
+
+
+def test_config_directory_is_gated_as_a_whole():
+    assert "config/**" in _push_paths()
+    assert "config/*" in _case_patterns()
+
+
+def test_no_individual_config_file_is_named_in_either_gate():
+    # A single named file is the failure mode this test exists to prevent: it looks
+    # complete while leaving every future config file ungated.
+    narrow = [p for p in _push_paths() + _case_patterns()
+              if p.startswith("config/") and p not in {"config/**", "config/*"}]
+    assert narrow == [], f"re-narrowed config gating: {narrow}"
+
+
+def test_every_shipped_config_file_matches_the_gate():
+    # `case` patterns match `/` inside `*`, so `config/*` covers nested files too.
+    assert CONFIG_FILES, "config/ is empty; the gate assertions would be vacuous"
+    assert all(name.startswith("config/") for name in CONFIG_FILES)
+
+
+def test_scripts_and_tests_stay_gated():
+    for pattern in ("scripts/*", "tests/*"):
+        assert pattern in _case_patterns()
+    for pattern in ("scripts/**", "tests/**"):
+        assert pattern in _push_paths()

--- a/tests/test_readme_parity.py
+++ b/tests/test_readme_parity.py
@@ -94,6 +94,7 @@ def test_research_surfaces_stay_in_both_languages():
         "skills/portfolio-risk-review/SKILL.md",
         "skills/portfolio-swarm-review/SKILL.md",
         "skills/serenity-skill/SKILL.md",
+        "skills/earnings-review/SKILL.md",
     ):
         assert target in EN and target in ZH, f"{target} missing from a README"
 


### PR DESCRIPTION
Third step of the #75 research lifecycle: first-party earnings evidence that feeds the thesis registry. `memory/earnings/<TICKER>/<period>.json` is the canonical record; Markdown is a rendering of it.

## What the code decides, not the prose

| Computed here | Why it matters |
|---|---|
| Source grade `A/B/C` from the documents actually retrieved | `B`/`C` disable every footnote claim; a low grade describes the sources, never the company |
| Cash conversion, FCF, receivables/inventory vs revenue, dilution, SBC share, net margin | The upstream project asserted these in prose; here they are Decimal math over the comparable history with named thresholds |
| Guidance `beat / inline / miss` | Compared against the artifact's own basis/currency/unit |
| Promise roll-forward `met / partial / missed / not_due / unverifiable` | Promises survive across periods and can go overdue |
| Release gate over the provenance manifest | A single-sourced or disagreeing number blocks the artifact |

Honest failure modes: a missing input yields `unavailable` plus a reason instead of a number; a loss-making period is flagged (`net_income_negative`) rather than read as a clean cash-conversion beat; `basis`/`currency`/`unit` switches mid-history are validation errors, not caveats.

## Acceptance criteria (#72)

- One US and one HK fixture through the same normalized schema — `tests/fixtures/earnings/us-ustest-fy2026q1.json`, `hk-9999hk-fy2025h2.json`, both `release() == pass`, both grade A, 3/3 metrics verified.
- GAAP/non-GAAP and currency/period mismatches explicit — mixed basis, currency, unit, out-of-order history and short history all fail with named errors.
- Promise records survive across quarters and can become due/missed — roll-forward refuses drops and softening of terminal statuses; overdue-and-covered becomes `missed`, overdue-but-uncovered becomes `unverifiable`.
- Working-capital and cash-conversion anomalies computed in code — asserted to the digit (`0.6250` conversion, `34.0678`pp receivables gap).
- Missing first-party documents lower the grade and disable footnote claims — dropping the HKEX announcement drops to `B` and fails validation while footnotes remain; a footnote citing XBRL is rejected.
- Output updates thesis evidence without silently changing thesis state — `state_change` is always `None`, and the generated evidence rows are fed through `thesis_registry.validate_thesis` in a test, so they satisfy the registry's own schema and its price-only-evidence rule.

## Also fixes #83 (unwired provenance gate)

`research_provenance` had no producer or consumer outside its unit test. The earnings artifact now builds a manifest for every published number and `release()` refuses to hand the artifact onward when the gate fails.

## Harness / CI

`validate`'s Python steps were gated on an explicit list of config files, so `config/thesis.schema.json` and any future schema fell outside it: a config-only PR reported green in seconds without running the tests that read that config. Both gates are now `config/**` / `config/*`, and `tests/test_harness_regression_paths.py` keeps them directory-wide. No cron, payload, or watchdog contract is touched — this skill is manual and event-driven by design.

## Validation

- `729 passed, 5 xfailed` (full `tests/`), 31 new earnings tests + 4 path-gate tests.
- Mutation-verified, one guard at a time: allowing mixed basis/currency/unit, removing the footnote grade gate, never marking an overdue promise missed, skipping the provenance gate in `release()`, zeroing the cash-conversion threshold, tolerating dropped promises, ignoring the comparable minimum, and re-narrowing the config gate each turn the corresponding tests red; all green again after restore.
- `python3 -m py_compile`, `--help`, schema JSON parse, `git diff --check` clean.

Closes #72
Closes #83