### PR TITLE
feat: add pre-investment entry gate before deep research or new exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Hong Kong times run on HKT; US session times follow ET and their cron expression
 | Review the current portfolio | [`portfolio-risk-review`](skills/portfolio-risk-review/SKILL.md) for one pass; [`portfolio-swarm-review`](skills/portfolio-swarm-review/SKILL.md) for debate | `portfolio.json`, fresh quotes, risk and decision ledgers | Specific to the configured portfolio |
 | Stress-test a supply-chain thesis | [`serenity-skill`](skills/serenity-skill/SKILL.md) | Current public evidence plus its local scorecard | Reusable as a manual research framework |
 | Review a reported quarter and hold management to account | [`earnings-review`](skills/earnings-review/SKILL.md) | First-party filings/HKEX announcements, structured XBRL or Eastmoney verification, provenance gate | Reusable; artifacts live in `memory/earnings/` |
+| Decide whether a new name is worth researching | [`entry-gate`](skills/entry-gate/SKILL.md) | Workspace quote pipelines, instrument registry, evidence source grading, deterministic hard vetoes | Reusable; artifacts live in `memory/entry-gates/` |
 
 These are workspace-native research routes, not standalone one-command products. They expect clawock's scripts, data contracts, and memory/SOP files; the published portfolio and its operating history remain specific to this deployment.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -162,6 +162,7 @@ clawock 是一个持续运行的、公开的**纪律化、自评式** AI 投资�
 | 检查当前组合 | 单次走 [`portfolio-risk-review`](skills/portfolio-risk-review/SKILL.md);深度辩论走 [`portfolio-swarm-review`](skills/portfolio-swarm-review/SKILL.md) | `portfolio.json`、新鲜行情、风控与决策账本 | 依赖已配置的真实组合 |
 | 压测一条供应链 thesis | [`serenity-skill`](skills/serenity-skill/SKILL.md) | 当前公开证据 + 本地评分卡 | 可作为手动研究框架复用 |
 | 复盘一个已披露的报告期并追踪管理层承诺 | [`earnings-review`](skills/earnings-review/SKILL.md) | 一手 filing / 港交所公告、XBRL 或东财结构化交叉验证、provenance 准出闸 | 可复用;产物落在 `memory/earnings/` |
+| 判断一个新标的值不值得做深度研究 | [`entry-gate`](skills/entry-gate/SKILL.md) | workspace 行情链、instrument registry、证据来源分级、确定性硬否决 | 可复用;产物落在 `memory/entry-gates/` |
 
 这些入口原生依赖 workspace,不是一条命令即可独立安装的通用产品。它们要求 clawock 的脚本、数据契约和记忆 / SOP 文件;公开持仓及其运行历史只属于当前这套部署。
 

--- a/config/entry-gate-vetoes.json
+++ b/config/entry-gate-vetoes.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "description": "Deterministic hard vetoes for the pre-investment entry gate. A veto cannot be outweighed by passing checks. Industry exceptions are encoded here so they are reviewable, never improvised in prose; every exception requires its own evidence row in the artifact.",
+  "vetoes": [
+    {
+      "id": "integrity_or_governance_red_flag",
+      "description": "Documented fraud, restatement, auditor resignation, undisclosed related-party dealing, or a regulator sanctioning management for disclosure conduct.",
+      "exceptions": []
+    },
+    {
+      "id": "unintelligible_revenue_mechanism",
+      "description": "Who pays, for what, and why it repeats cannot be stated in one sentence from primary sources.",
+      "exceptions": []
+    },
+    {
+      "id": "persistent_negative_cash_generation",
+      "description": "Operating cash flow negative across the available comparable history with no funded, dated path to positive.",
+      "exceptions": [
+        {
+          "sector": "biotechnology_clinical_stage",
+          "note": "Pre-approval clinical programs are expected to burn cash; the exception needs a funded runway through the next binary readout.",
+          "requires_evidence": true
+        },
+        {
+          "sector": "pre_revenue_infrastructure",
+          "note": "Capital-intensive build-out before first revenue; the exception needs a committed financing package and a dated commissioning schedule.",
+          "requires_evidence": true
+        }
+      ]
+    },
+    {
+      "id": "destructive_dilution",
+      "description": "Share count growing faster than the business it funds, or repeated below-market issuance without a stated accretive use.",
+      "exceptions": [
+        {
+          "sector": "biotechnology_clinical_stage",
+          "note": "Equity is the standard funding instrument pre-approval; the exception needs the raise tied to a named program milestone.",
+          "requires_evidence": true
+        }
+      ]
+    }
+  ]
+}

--- a/config/entry_gate.schema.json
+++ b/config/entry_gate.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KCNyu/clawock/config/entry_gate.schema.json",
+  "title": "clawock pre-investment entry gate artifact",
+  "description": "One assessment per file under memory/entry-gates/<TICKER>-<date>.json. scripts/data/entry_gate.py is the enforcing validator and recomputes verdict, routing and information grade; this document is the published shape. Hard vetoes and their encoded exceptions live in config/entry-gate-vetoes.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "gate_id",
+    "ticker",
+    "market",
+    "instrument_kind",
+    "sector",
+    "assessed_at",
+    "quote",
+    "information",
+    "mechanism",
+    "key_variables",
+    "checks",
+    "vetoes",
+    "mirror_test",
+    "evidence",
+    "next_evidence",
+    "verdict",
+    "routing"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "gate_id": {"type": "string", "minLength": 1},
+    "ticker": {"type": "string", "minLength": 1},
+    "market": {"enum": ["US", "HK"]},
+    "instrument_kind": {"enum": ["company", "leveraged_etf"]},
+    "sector": {"type": "string", "minLength": 1},
+    "assessed_at": {"type": "string", "format": "date-time"},
+    "quote": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["price", "currency", "as_of", "source_class"],
+      "properties": {
+        "price": {"type": "string", "minLength": 1},
+        "currency": {"enum": ["USD", "HKD", "CNY"]},
+        "as_of": {"type": "string", "format": "date-time"},
+        "source_class": {
+          "description": "Workspace quote pipelines only; a generic web price is rejected.",
+          "enum": [
+            "analyze_us_stocks",
+            "analyze_hk_stocks",
+            "tencent_quote",
+            "eastmoney_quote",
+            "canonical_daily_bars"
+          ]
+        }
+      }
+    },
+    "information": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["grade", "gaps", "source_classes"],
+      "properties": {
+        "grade": {"enum": ["A", "B", "C"]},
+        "gaps": {"type": "array", "items": {"type": "string"}},
+        "source_classes": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "mechanism": {
+      "description": "One sentence: who pays, why, and what makes it repeat.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 300
+    },
+    "key_variables": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "variable", "why_it_decides"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "variable": {"type": "string", "minLength": 1},
+          "why_it_decides": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "verdict", "finding", "evidence_ids"],
+        "properties": {
+          "id": {
+            "enum": [
+              "business_quality",
+              "moat",
+              "management_governance",
+              "valuation",
+              "dilution",
+              "downside",
+              "underlying_exposure",
+              "decay_and_regime",
+              "sizing_limit",
+              "liquidity"
+            ]
+          },
+          "verdict": {"enum": ["pass", "fail", "unknown"]},
+          "finding": {"type": "string", "minLength": 1, "maxLength": 600},
+          "evidence_ids": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "vetoes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status", "finding", "evidence_ids", "exception"],
+        "properties": {
+          "id": {
+            "enum": [
+              "integrity_or_governance_red_flag",
+              "unintelligible_revenue_mechanism",
+              "persistent_negative_cash_generation",
+              "destructive_dilution"
+            ]
+          },
+          "status": {"enum": ["clear", "triggered", "unknown"]},
+          "finding": {"type": "string", "minLength": 1, "maxLength": 600},
+          "evidence_ids": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "exception": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["reason", "evidence_id"],
+                "properties": {
+                  "reason": {"type": "string", "minLength": 1},
+                  "evidence_id": {"type": "string", "minLength": 1}
+                }
+              },
+              {"type": "null"}
+            ]
+          }
+        }
+      }
+    },
+    "mirror_test": {
+      "description": "Exactly five sentences: what it does, why it earns, what must stay true, what would break it, what you would do then.",
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {"type": "string", "minLength": 1, "maxLength": 300}
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["evidence_id", "observed_at", "source_class", "locator", "summary"],
+        "properties": {
+          "evidence_id": {"type": "string", "minLength": 1},
+          "observed_at": {"type": "string", "format": "date-time"},
+          "source_class": {
+            "enum": [
+              "sec_filing",
+              "hkex_announcement",
+              "issuer_ir",
+              "sec_xbrl",
+              "eastmoney_fundamentals",
+              "earnings_review_artifact",
+              "regulatory_database",
+              "exchange_data",
+              "workspace_dataset",
+              "news_media",
+              "third_party_summary",
+              "analyst_note"
+            ]
+          },
+          "locator": {"type": "string", "minLength": 1},
+          "summary": {"type": "string", "minLength": 1, "maxLength": 600}
+        }
+      }
+    },
+    "next_evidence": {
+      "description": "Required whenever the verdict is gray_needs_evidence.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["question", "where_to_look"],
+        "properties": {
+          "question": {"type": "string", "minLength": 1},
+          "where_to_look": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "verdict": {"enum": ["pass_to_deep_research", "reject", "gray_needs_evidence"]},
+    "routing": {"enum": ["us_full_report", "hk_full_report", "leverage_look_through"]}
+  }
+}

--- a/memory/entry-gates/README.md
+++ b/memory/entry-gates/README.md
@@ -1,0 +1,23 @@
+# Pre-investment entry gate artifacts
+
+One assessment per file: `memory/entry-gates/<TICKER>-<YYYY-MM-DD>.json`. The file
+is the record of why a name was or was not worth a deep-research run.
+
+```bash
+python3 scripts/data/entry_gate.py validate memory/entry-gates/<TICKER>-<date>.json
+python3 scripts/data/entry_gate.py assess   memory/entry-gates/<TICKER>-<date>.json
+```
+
+Shape: `config/entry_gate.schema.json`. Hard vetoes and their encoded industry
+exceptions: `config/entry-gate-vetoes.json`. Workflow:
+`skills/entry-gate/SKILL.md`. A worked example lives in
+`tests/fixtures/entry-gates/`.
+
+What the script decides regardless of what the artifact claims:
+
+- `verdict` and `routing` are recomputed; a stated verdict that disagrees is an error;
+- vetoes resolve before any check is counted, so a good tally cannot outweigh one;
+- `information.grade` comes from the cited evidence source classes — a `C` grade
+  yields `gray_needs_evidence`, never `reject`;
+- quotes must come from the workspace pipelines, and a stale quote makes the
+  verdict gray.

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -96,6 +96,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出（tolerance 上限 5%，算式异常也只输出结构化 fail） | 结构化 manifest + 本地确定性校验 | ✅ |
 | `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 | `earnings_review.py` | 一手财报复盘:来源分级、盈利质量数学、管理层承诺账本、provenance 准出与 thesis 证据交接 | `memory/earnings/*/*.json` + 本地确定性校验 | ✅ |
+| `entry_gate.py` | 建仓前研究闸:信息分级与投资质量分离、确定性硬否决(行业例外写进配置)、pass/reject/gray 判定与深研路由 | `memory/entry-gates/*.json` + `config/entry-gate-vetoes.json` | ✅ |
 
 ## Layer 8 · 回测/自省 Backtest & Calibration
 

--- a/scripts/data/entry_gate.py
+++ b/scripts/data/entry_gate.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Pre-investment entry gate: is this name understandable and researchable enough?
+
+This runs *before* a deep-research run or any new exposure, and it answers only
+that narrow question. It never sizes a position, never places a trade, and never
+overrides the decision, risk, or settlement contracts downstream.
+
+Two ideas are worth keeping from the upstream study, and both are enforced here
+rather than requested in prose:
+
+* information richness is graded separately from investment quality, so "few
+  public sources" can never read as "bad company"; and
+* the outcome is `pass_to_deep_research` / `reject` / `gray_needs_evidence` — a
+  gray verdict must name the evidence it is missing instead of guessing.
+
+The gate recomputes the verdict from the artifact's own checks and vetoes and
+rejects an artifact whose stated verdict disagrees. A hard veto is decided before
+any check is counted, so a high tally can never average one away.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+SCHEMA_FILE = WS / "config" / "entry_gate.schema.json"
+VETO_FILE = WS / "config" / "entry-gate-vetoes.json"
+ARTIFACT_ROOT = WS / "memory" / "entry-gates"
+SCHEMA_VERSION = 1
+
+sys.path.insert(0, str(WS / "scripts" / "data"))
+import instrument_registry  # noqa: E402
+
+MARKETS = {"US", "HK"}
+INSTRUMENT_KINDS = {"company", "leveraged_etf"}
+# Quotes must come from the workspace pipelines. A generic web price is not an
+# accepted input, at any grade.
+QUOTE_SOURCES = {
+    "analyze_us_stocks", "analyze_hk_stocks", "tencent_quote",
+    "eastmoney_quote", "canonical_daily_bars",
+}
+MAX_QUOTE_AGE_MINUTES = 1440
+PRIMARY_EVIDENCE = {
+    "sec_filing", "hkex_announcement", "issuer_ir", "sec_xbrl",
+    "eastmoney_fundamentals", "earnings_review_artifact",
+}
+SECONDARY_EVIDENCE = {"regulatory_database", "exchange_data", "workspace_dataset"}
+WEAK_EVIDENCE = {"news_media", "third_party_summary", "analyst_note"}
+EVIDENCE_CLASSES = PRIMARY_EVIDENCE | SECONDARY_EVIDENCE | WEAK_EVIDENCE
+COMPANY_CHECKS = (
+    "business_quality", "moat", "management_governance", "valuation",
+    "dilution", "downside",
+)
+LEVERAGED_CHECKS = ("underlying_exposure", "decay_and_regime", "sizing_limit", "liquidity")
+CHECKS_BY_KIND = {"company": COMPANY_CHECKS, "leveraged_etf": LEVERAGED_CHECKS}
+# A failure here says the name is not worth a research run. Everything else —
+# valuation, dilution, moat, decay, liquidity — is a sizing and timing input for
+# the existing risk contracts, not a reason to refuse to understand the company.
+DISQUALIFYING_CHECKS = {
+    "business_quality", "management_governance", "downside",
+    "underlying_exposure", "sizing_limit",
+}
+CHECK_VERDICTS = {"pass", "fail", "unknown"}
+VETO_STATUSES = {"clear", "triggered", "unknown"}
+VERDICTS = {"pass_to_deep_research", "reject", "gray_needs_evidence"}
+ROUTING = {
+    ("US", "company"): "us_full_report",
+    ("HK", "company"): "hk_full_report",
+    ("US", "leveraged_etf"): "leverage_look_through",
+    ("HK", "leveraged_etf"): "leverage_look_through",
+}
+ARTIFACT_FIELDS = (
+    "schema_version", "gate_id", "ticker", "market", "instrument_kind", "sector",
+    "assessed_at", "quote", "information", "mechanism", "key_variables", "checks",
+    "vetoes", "mirror_test", "evidence", "next_evidence", "verdict", "routing",
+)
+MIRROR_TEST_SENTENCES = 5
+
+
+def load_vetoes(path: Path = VETO_FILE) -> dict:
+    doc = json.loads(path.read_text())
+    return {item["id"]: item for item in doc["vetoes"]}
+
+
+VETOES = load_vetoes()
+
+
+def _exact_fields(item, required, prefix, errors) -> bool:
+    if not isinstance(item, dict):
+        errors.append(f"{prefix} must be an object")
+        return False
+    missing = sorted(set(required) - set(item))
+    extra = sorted(set(item) - set(required))
+    if missing:
+        errors.append(f"{prefix} missing fields: {missing}")
+    if extra:
+        errors.append(f"{prefix} unknown fields: {extra}")
+    return not missing and not extra
+
+
+def _parse_time(value, field, errors):
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError
+        return parsed
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
+        return None
+
+
+def grade_information(evidence: list) -> dict:
+    """Grade the sources, never the company.
+
+    A — at least two distinct primary/structured classes.
+    B — at least one primary/structured class.
+    C — media, analyst notes and third-party summaries only.
+    """
+    classes = {
+        item.get("source_class") for item in (evidence or []) if isinstance(item, dict)
+    }
+    strong = classes & PRIMARY_EVIDENCE
+    supporting = classes & SECONDARY_EVIDENCE
+    if len(strong) >= 2:
+        grade = "A"
+    elif strong:
+        grade = "B"
+    else:
+        grade = "C"
+    gaps = []
+    if not strong:
+        gaps.append("no primary issuer or structured source in the evidence set")
+    elif len(strong) < 2:
+        gaps.append("only one primary/structured source class; a second is needed to cross-check")
+    if not supporting and grade != "A":
+        gaps.append("no supporting regulatory/exchange dataset")
+    if classes & WEAK_EVIDENCE:
+        gaps.append("media or analyst material is present and ranks below issuer sources")
+    return {"grade": grade, "gaps": gaps, "source_classes": sorted(c for c in classes if c)}
+
+
+def quote_freshness(doc: dict) -> dict:
+    """Quote age against the assessment time, plus whether the source is allowed."""
+    quote = doc.get("quote")
+    if not isinstance(quote, dict):
+        return {"status": "missing", "reason": "no quote block"}
+    errors: list[str] = []
+    as_of = _parse_time(quote.get("as_of"), "quote.as_of", errors)
+    assessed = _parse_time(doc.get("assessed_at"), "assessed_at", errors)
+    if errors or as_of is None or assessed is None:
+        return {"status": "missing", "reason": "; ".join(errors) or "unparseable timestamps"}
+    age_minutes = int((assessed - as_of).total_seconds() // 60)
+    return {
+        "status": "stale" if age_minutes > MAX_QUOTE_AGE_MINUTES or age_minutes < 0 else "fresh",
+        "age_minutes": age_minutes,
+        "source_class": quote.get("source_class"),
+        "max_age_minutes": MAX_QUOTE_AGE_MINUTES,
+    }
+
+
+def _valid_exception(veto: dict, sector, evidence_ids) -> tuple[bool, str | None]:
+    """An exception counts only when this veto encodes it for this sector."""
+    definition = VETOES.get(veto.get("id"))
+    exception = veto.get("exception")
+    if not isinstance(exception, dict):
+        return False, None
+    if definition is None:
+        return False, f"veto {veto.get('id')!r} is not defined in {VETO_FILE.name}"
+    allowed = {
+        item["sector"]: item for item in definition.get("exceptions", [])
+    }
+    if not allowed:
+        return False, f"veto {veto['id']} does not encode any exception"
+    rule = allowed.get(sector)
+    if rule is None:
+        return False, (
+            f"veto {veto['id']} encodes no exception for sector {sector!r} "
+            f"(allowed: {sorted(allowed)})"
+        )
+    if rule.get("requires_evidence") and exception.get("evidence_id") not in evidence_ids:
+        return False, (
+            f"veto {veto['id']} exception needs an evidence_id present in evidence[]"
+        )
+    if not exception.get("reason"):
+        return False, f"veto {veto['id']} exception needs a stated reason"
+    return True, None
+
+
+def decide(doc: dict) -> dict:
+    """Recompute the verdict from the artifact's own checks, vetoes and sources.
+
+    Order matters and is the whole point: vetoes are resolved before any check is
+    counted, so `checks_passed` can never rescue a vetoed name.
+    """
+    kind = doc.get("instrument_kind")
+    required = CHECKS_BY_KIND.get(kind, ())
+    evidence_ids = {
+        item.get("evidence_id") for item in (doc.get("evidence") or [])
+        if isinstance(item, dict)
+    }
+    sector = doc.get("sector")
+    reasons: list[str] = []
+
+    triggered, unknown_vetoes = [], []
+    for veto in (doc.get("vetoes") or []):
+        if not isinstance(veto, dict):
+            continue
+        if veto.get("status") == "triggered":
+            excepted, _ = _valid_exception(veto, sector, evidence_ids)
+            if excepted:
+                reasons.append(
+                    f"veto {veto.get('id')} triggered but excepted for sector {sector!r}"
+                )
+            else:
+                triggered.append(veto.get("id"))
+        elif veto.get("status") == "unknown":
+            unknown_vetoes.append(veto.get("id"))
+
+    by_id = {
+        item.get("id"): item for item in (doc.get("checks") or [])
+        if isinstance(item, dict)
+    }
+    passed = sorted(k for k in required if (by_id.get(k) or {}).get("verdict") == "pass")
+    failed = sorted(k for k in required if (by_id.get(k) or {}).get("verdict") == "fail")
+    unknown = sorted(
+        k for k in required if (by_id.get(k) or {}).get("verdict") in (None, "unknown")
+    )
+    information = grade_information(doc.get("evidence") or [])
+    freshness = quote_freshness(doc)
+    disqualifying = sorted(set(failed) & DISQUALIFYING_CHECKS)
+
+    if triggered:
+        verdict = "reject"
+        reasons.append(f"hard veto triggered: {', '.join(triggered)}")
+    elif disqualifying:
+        verdict = "reject"
+        reasons.append(f"disqualifying check failed: {', '.join(disqualifying)}")
+    elif unknown_vetoes or unknown:
+        verdict = "gray_needs_evidence"
+        if unknown_vetoes:
+            reasons.append(f"veto status unknown: {', '.join(unknown_vetoes)}")
+        if unknown:
+            reasons.append(f"check unresolved: {', '.join(unknown)}")
+    elif information["grade"] == "C":
+        # Thin sourcing is a research problem, not a company verdict: gray, never
+        # a reject.
+        verdict = "gray_needs_evidence"
+        reasons.append("information grade C: no primary or structured source to cross-check")
+    elif freshness.get("status") != "fresh":
+        verdict = "gray_needs_evidence"
+        reasons.append(f"quote is {freshness.get('status')} against the workspace pipelines")
+    else:
+        verdict = "pass_to_deep_research"
+        if failed:
+            reasons.append(
+                "routed to research with open concerns "
+                f"({', '.join(failed)}); sizing stays with the risk contracts"
+            )
+    return {
+        "verdict": verdict,
+        "reasons": reasons,
+        "information": information,
+        "quote_freshness": freshness,
+        "checks_passed": f"{len(passed)}/{len(required)}",
+        "failed_checks": failed,
+        "unresolved_checks": unknown,
+        "triggered_vetoes": triggered,
+        "routing": ROUTING.get((doc.get("market"), kind)),
+    }
+
+
+def validate_artifact(doc: dict, *, now=None) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(doc, dict):
+        return ["artifact must be an object"]
+    _exact_fields(doc, ARTIFACT_FIELDS, "artifact", errors)
+    if doc.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("gate_id", "ticker", "sector", "mechanism"):
+        if not doc.get(field):
+            errors.append(f"{field} is required")
+    market, kind = doc.get("market"), doc.get("instrument_kind")
+    if market not in MARKETS:
+        errors.append(f"market must be one of {sorted(MARKETS)}")
+    if kind not in INSTRUMENT_KINDS:
+        errors.append(f"instrument_kind must be one of {sorted(INSTRUMENT_KINDS)}")
+    assessed = _parse_time(doc.get("assessed_at"), "assessed_at", errors)
+    if now and assessed and assessed > now:
+        errors.append("assessed_at cannot be in the future")
+    if len(str(doc.get("mechanism") or "")) > 300:
+        errors.append("mechanism must be one sentence (<=300 characters)")
+
+    # The canonical registry wins over a declaration whenever it knows the symbol.
+    known = instrument_registry.get(str(doc.get("ticker")))
+    if known is not None:
+        registry_leveraged = instrument_registry.is_leveraged(str(doc["ticker"]))
+        if registry_leveraged and kind != "leveraged_etf":
+            errors.append(
+                f"instrument registry lists {doc['ticker']} as leveraged "
+                f"(x{known.get('leverage_multiple')}); instrument_kind must be leveraged_etf"
+            )
+        if not registry_leveraged and kind == "leveraged_etf":
+            errors.append(
+                f"instrument registry lists {doc['ticker']} as unleveraged; "
+                "instrument_kind must be company"
+            )
+
+    quote = doc.get("quote")
+    if not _exact_fields(quote, ("price", "currency", "as_of", "source_class"), "quote", errors):
+        quote = {}
+    elif quote.get("source_class") not in QUOTE_SOURCES:
+        # Not a gray verdict — a generic web price breaks the data contract.
+        errors.append(
+            f"quote.source_class must be a workspace pipeline {sorted(QUOTE_SOURCES)}, "
+            f"got {quote.get('source_class')!r}"
+        )
+
+    evidence_ids = set()
+    evidence = doc.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        errors.append("evidence must be a non-empty list")
+        evidence = []
+    for index, item in enumerate(evidence):
+        prefix = f"evidence[{index}]"
+        if not _exact_fields(
+            item, ("evidence_id", "observed_at", "source_class", "locator", "summary"),
+            prefix, errors,
+        ):
+            continue
+        if item["source_class"] not in EVIDENCE_CLASSES:
+            errors.append(f"{prefix}.source_class must be one of {sorted(EVIDENCE_CLASSES)}")
+        if item["evidence_id"] in evidence_ids:
+            errors.append(f"{prefix}.evidence_id must be unique")
+        evidence_ids.add(item["evidence_id"])
+        observed = _parse_time(item["observed_at"], f"{prefix}.observed_at", errors)
+        if now and observed and observed > now:
+            errors.append(f"{prefix}.observed_at cannot be in the future")
+        if not item["locator"] or not item["summary"]:
+            errors.append(f"{prefix} needs a locator and a summary")
+
+    variables = doc.get("key_variables")
+    if not isinstance(variables, list) or not 3 <= len(variables) <= 7:
+        errors.append("key_variables must contain 3-7 items")
+        variables = []
+    seen = set()
+    for index, item in enumerate(variables):
+        prefix = f"key_variables[{index}]"
+        if not _exact_fields(item, ("id", "variable", "why_it_decides"), prefix, errors):
+            continue
+        if item["id"] in seen:
+            errors.append(f"{prefix}.id must be unique")
+        seen.add(item["id"])
+        if not item["variable"] or not item["why_it_decides"]:
+            errors.append(f"{prefix} needs a variable and why it decides the outcome")
+
+    required_checks = CHECKS_BY_KIND.get(kind, ())
+    checks = doc.get("checks")
+    if not isinstance(checks, list):
+        errors.append("checks must be a list")
+        checks = []
+    seen = set()
+    for index, item in enumerate(checks):
+        prefix = f"checks[{index}]"
+        if not _exact_fields(
+            item, ("id", "verdict", "finding", "evidence_ids"), prefix, errors
+        ):
+            continue
+        if item["id"] in seen:
+            errors.append(f"{prefix}.id must be unique")
+        seen.add(item["id"])
+        if kind in CHECKS_BY_KIND and item["id"] not in required_checks:
+            # A leveraged ETF has no company fundamentals to grade; it routes to
+            # the look-through path instead of pretending to read a moat.
+            errors.append(
+                f"{prefix}.id {item['id']!r} is not a {kind} check "
+                f"({sorted(required_checks)})"
+            )
+        if item["verdict"] not in CHECK_VERDICTS:
+            errors.append(f"{prefix}.verdict must be one of {sorted(CHECK_VERDICTS)}")
+        if not item["finding"]:
+            errors.append(f"{prefix}.finding is required")
+        refs = item.get("evidence_ids")
+        if not isinstance(refs, list):
+            errors.append(f"{prefix}.evidence_ids must be a list")
+        else:
+            missing = sorted(set(refs) - evidence_ids)
+            if missing:
+                errors.append(f"{prefix} references missing evidence: {missing}")
+            if item["verdict"] in {"pass", "fail"} and not refs:
+                errors.append(f"{prefix} claims {item['verdict']} without evidence")
+    if kind in CHECKS_BY_KIND:
+        for name in required_checks:
+            if name not in seen:
+                errors.append(f"checks is missing the required {kind} check {name!r}")
+
+    seen = set()
+    veto_ids = set(VETOES)
+    for index, item in enumerate(doc.get("vetoes") or []):
+        prefix = f"vetoes[{index}]"
+        if not _exact_fields(
+            item, ("id", "status", "finding", "evidence_ids", "exception"), prefix, errors
+        ):
+            continue
+        if item["id"] not in veto_ids:
+            errors.append(f"{prefix}.id must be one of {sorted(veto_ids)}")
+        if item["id"] in seen:
+            errors.append(f"{prefix}.id must be unique")
+        seen.add(item["id"])
+        if item["status"] not in VETO_STATUSES:
+            errors.append(f"{prefix}.status must be one of {sorted(VETO_STATUSES)}")
+        refs = item.get("evidence_ids")
+        if not isinstance(refs, list):
+            errors.append(f"{prefix}.evidence_ids must be a list")
+        elif item["status"] == "triggered" and not refs:
+            errors.append(f"{prefix} is triggered without evidence")
+        elif sorted(set(refs) - evidence_ids):
+            errors.append(f"{prefix} references missing evidence")
+        if item.get("exception") is not None:
+            excepted, reason = _valid_exception(item, doc.get("sector"), evidence_ids)
+            if not excepted:
+                errors.append(f"{prefix}: {reason or 'exception is not valid'}")
+    for name in sorted(veto_ids - seen):
+        errors.append(f"vetoes must state a status for {name!r}")
+
+    mirror = doc.get("mirror_test")
+    if not isinstance(mirror, list) or len(mirror) != MIRROR_TEST_SENTENCES:
+        errors.append(f"mirror_test must contain exactly {MIRROR_TEST_SENTENCES} sentences")
+    else:
+        for index, sentence in enumerate(mirror):
+            if not isinstance(sentence, str) or not sentence.strip():
+                errors.append(f"mirror_test[{index}] must be a non-empty sentence")
+            elif len(sentence) > 300:
+                errors.append(f"mirror_test[{index}] must stay under 300 characters")
+        if len({s.strip() for s in mirror if isinstance(s, str)}) != MIRROR_TEST_SENTENCES:
+            errors.append("mirror_test sentences must be distinct")
+
+    next_evidence = doc.get("next_evidence")
+    if not isinstance(next_evidence, list):
+        errors.append("next_evidence must be a list")
+        next_evidence = []
+    for index, item in enumerate(next_evidence):
+        prefix = f"next_evidence[{index}]"
+        if _exact_fields(item, ("question", "where_to_look"), prefix, errors) and not (
+            item["question"] and item["where_to_look"]
+        ):
+            errors.append(f"{prefix} needs a question and where to look")
+
+    if doc.get("verdict") not in VERDICTS:
+        errors.append(f"verdict must be one of {sorted(VERDICTS)}")
+    if not errors:
+        # Only meaningful once the artifact is structurally sound.
+        computed = decide(doc)
+        if doc["verdict"] != computed["verdict"]:
+            errors.append(
+                f"verdict {doc['verdict']!r} disagrees with the computed verdict "
+                f"{computed['verdict']!r}: {'; '.join(computed['reasons'])}"
+            )
+        if doc.get("routing") != computed["routing"]:
+            errors.append(
+                f"routing must be {computed['routing']!r} for a {market} {kind}"
+            )
+        if doc.get("information") != computed["information"]:
+            errors.append(
+                "information must match the grade computed from evidence source classes: "
+                f"{computed['information']}"
+            )
+        if computed["verdict"] == "gray_needs_evidence" and not next_evidence:
+            errors.append("a gray verdict must name the next evidence needed")
+    return errors
+
+
+def assess(doc: dict, *, now=None) -> dict:
+    errors = validate_artifact(doc, now=now)
+    computed = decide(doc) if isinstance(doc, dict) else {}
+    return {
+        "status": "pass" if not errors else "fail",
+        "gate_id": doc.get("gate_id") if isinstance(doc, dict) else None,
+        "ticker": doc.get("ticker") if isinstance(doc, dict) else None,
+        "instrument_kind": doc.get("instrument_kind") if isinstance(doc, dict) else None,
+        **{key: computed.get(key) for key in (
+            "verdict", "reasons", "information", "quote_freshness", "checks_passed",
+            "failed_checks", "unresolved_checks", "triggered_vetoes", "routing",
+        )},
+        "next_evidence": doc.get("next_evidence") if isinstance(doc, dict) else [],
+        "errors": errors,
+    }
+
+
+def artifact_path(ticker: str, assessed_on: str) -> Path:
+    return ARTIFACT_ROOT / f"{ticker}-{assessed_on}.json"
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "assess"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("path", type=Path)
+    args = parser.parse_args(argv)
+    now = datetime.now(timezone.utc)
+    try:
+        doc = json.loads(args.path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "fail", "errors": [str(exc)]}, ensure_ascii=False))
+        return 1
+    if args.command == "validate":
+        errors = validate_artifact(doc, now=now)
+        result = {"status": "pass" if not errors else "fail", "errors": errors}
+    else:
+        result = assess(doc, now=now)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/entry-gate/SKILL.md
+++ b/skills/entry-gate/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: entry-gate
+description: Pre-investment screening gate for a name that is not yet researched or held. Use before spending a deep-research run or opening new exposure, to answer only "is this understandable and researchable enough to proceed?". Grades information richness separately from investment quality, applies deterministic hard vetoes from config/entry-gate-vetoes.json, and returns pass_to_deep_research / reject / gray_needs_evidence via scripts/data/entry_gate.py. Recommends research; never sizes or places a trade.
+---
+
+# Entry Gate
+
+Manual, run once per candidate name. It is cheap on purpose: it decides whether the
+expensive work is worth doing, and its output routes straight into the full-report
+mode of the market's analysis skill.
+
+Write `memory/entry-gates/<TICKER>-<YYYY-MM-DD>.json` and let the script decide.
+You supply findings and evidence; the verdict is computed.
+
+## What the script computes, and will overrule you on
+
+- `information.grade` (A/B/C) from the evidence source classes you cite;
+- `quote_freshness` from `quote.as_of` against `assessed_at`;
+- `verdict` and `routing` — a stated verdict that disagrees with the computed one is
+  a validation error, not a note;
+- whether a hard veto's industry exception is actually encoded for this sector.
+
+Vetoes are resolved **before** any check is counted, so `checks_passed` can never
+rescue a vetoed name.
+
+## Step 1 — quote and instrument kind
+
+Use the workspace pipelines, never a web price:
+
+```bash
+python3 scripts/data/analyze_us_stocks.py {TICKER}   # US
+python3 scripts/data/analyze_hk_stocks.py {TICKER}   # HK
+```
+
+`quote.source_class` must be one of the pipeline names, or validation fails outright.
+A quote older than 24h makes the verdict gray rather than pass.
+
+Set `instrument_kind`. A leveraged ETF has **no** company fundamentals to grade: it
+takes the `underlying_exposure` / `decay_and_regime` / `sizing_limit` / `liquidity`
+checks and routes to `leverage_look_through`. When the ticker is in
+`config/instruments.json`, the registry's `leverage_multiple` overrules your
+declaration.
+
+## Step 2 — mechanism and key variables
+
+`mechanism` is one sentence: **who pays, why, and what makes it repeat.** If you
+cannot write it from primary sources, that is the `unintelligible_revenue_mechanism`
+veto, not a writing problem.
+
+Then 3–7 `key_variables`, each with why it decides the outcome — not a metric dump.
+
+## Step 3 — checks, each carrying evidence
+
+Company: `business_quality`, `moat`, `management_governance`, `valuation`,
+`dilution`, `downside`. Every `pass`/`fail` needs at least one `evidence_ids` entry;
+`unknown` is the honest answer when you have not verified it, and it makes the
+verdict gray.
+
+A failed `business_quality`, `management_governance` or `downside` (or, for a
+leveraged ETF, `underlying_exposure` or `sizing_limit`) is a reject. A failed
+`moat`, `valuation`, `dilution`, `decay_and_regime` or `liquidity` is not: an
+expensive or shallow-moat name is still worth understanding, and sizing stays with
+the existing risk and decision contracts.
+
+## Step 4 — the four hard vetoes
+
+State a status for every veto in `config/entry-gate-vetoes.json`:
+integrity/governance, unintelligible revenue mechanism, persistent negative cash
+generation, destructive dilution. `triggered` requires evidence.
+
+Two of them encode industry exceptions (clinical-stage biotech, pre-revenue
+infrastructure). An exception applies only when the artifact's `sector` matches the
+encoded one and the exception cites its own evidence row. Integrity and
+unintelligible-mechanism encode none — there is no sector where they are acceptable.
+
+## Step 5 — mirror test and verdict
+
+Exactly five distinct sentences: what it does, why it earns, what must stay true,
+what would break it, and what you would do then.
+
+```bash
+python3 scripts/data/entry_gate.py validate memory/entry-gates/<TICKER>-<date>.json
+python3 scripts/data/entry_gate.py assess   memory/entry-gates/<TICKER>-<date>.json
+```
+
+- `pass_to_deep_research` → go run `us-stock-analysis` / `hk-stock-analysis`
+  **Mode 4 (Full Report)**, or the leverage look-through path for a leveraged ETF.
+  Carry `key_variables` in as the questions the report must answer.
+- `gray_needs_evidence` → `next_evidence` must name the question and where to look.
+  Nothing else happens until that evidence exists.
+- `reject` → record it and stop. Thin sourcing alone never lands here; a `C` grade
+  is gray, because information richness is not investment quality.
+
+## Hard limits
+
+- A `C` information grade describes the sources, never the company.
+- No aggregate score, no persona voting, no "average" that can dilute a veto.
+- This gate opens no position and changes no thesis. A qualified name goes to full
+  research; exposure still goes through the decision, risk, and settlement chain.

--- a/tests/fixtures/entry-gates/ustest-2026-07-20.json
+++ b/tests/fixtures/entry-gates/ustest-2026-07-20.json
@@ -1,0 +1,146 @@
+{
+  "schema_version": 1,
+  "gate_id": "entry-USTEST-2026-07-20",
+  "ticker": "USTEST",
+  "market": "US",
+  "instrument_kind": "company",
+  "sector": "software",
+  "assessed_at": "2026-07-20T14:00:00+00:00",
+  "quote": {
+    "price": "12.34",
+    "currency": "USD",
+    "as_of": "2026-07-20T13:35:00+00:00",
+    "source_class": "analyze_us_stocks"
+  },
+  "information": {
+    "grade": "A",
+    "gaps": [
+      "media or analyst material is present and ranks below issuer sources"
+    ],
+    "source_classes": ["news_media", "sec_filing", "sec_xbrl"]
+  },
+  "mechanism": "Mid-market operators pay a recurring per-seat fee to keep their scheduling and payroll in one system, and they keep paying because the payroll record lives in it.",
+  "key_variables": [
+    {
+      "id": "kv-seats",
+      "variable": "Net seat additions per quarter",
+      "why_it_decides": "Revenue is per-seat, so seats decide growth more than pricing does."
+    },
+    {
+      "id": "kv-churn",
+      "variable": "Gross logo churn among sub-100-seat customers",
+      "why_it_decides": "The smallest cohort churns first and sets the floor on net retention."
+    },
+    {
+      "id": "kv-payroll-attach",
+      "variable": "Payroll module attach rate",
+      "why_it_decides": "Attach is what turns a schedule tool into a system of record and lifts switching cost."
+    },
+    {
+      "id": "kv-cash",
+      "variable": "Operating cash conversion",
+      "why_it_decides": "The story only works if collected cash follows booked revenue."
+    }
+  ],
+  "checks": [
+    {
+      "id": "business_quality",
+      "verdict": "pass",
+      "finding": "Recurring subscription revenue with disclosed seat counts and a stated retention figure in the latest filing.",
+      "evidence_ids": ["ev-10q", "ev-xbrl"]
+    },
+    {
+      "id": "moat",
+      "verdict": "fail",
+      "finding": "Switching cost is real but shallow; the filing names three competitors offering migration credits.",
+      "evidence_ids": ["ev-10q"]
+    },
+    {
+      "id": "management_governance",
+      "verdict": "pass",
+      "finding": "No restatement, no auditor change, related-party note is limited to a disclosed lease.",
+      "evidence_ids": ["ev-10q"]
+    },
+    {
+      "id": "valuation",
+      "verdict": "fail",
+      "finding": "Trades above its own three-year multiple range on structured data; expensive, not unintelligible.",
+      "evidence_ids": ["ev-xbrl"]
+    },
+    {
+      "id": "dilution",
+      "verdict": "pass",
+      "finding": "Diluted share count up about 1% year over year, consistent with disclosed SBC.",
+      "evidence_ids": ["ev-xbrl"]
+    },
+    {
+      "id": "downside",
+      "verdict": "pass",
+      "finding": "Net cash position covers more than two years of the current burn rate at the reported cash figure.",
+      "evidence_ids": ["ev-xbrl"]
+    }
+  ],
+  "vetoes": [
+    {
+      "id": "integrity_or_governance_red_flag",
+      "status": "clear",
+      "finding": "No enforcement action or restatement in the filing history reviewed.",
+      "evidence_ids": ["ev-10q"],
+      "exception": null
+    },
+    {
+      "id": "unintelligible_revenue_mechanism",
+      "status": "clear",
+      "finding": "Per-seat subscription pricing is stated in the filing.",
+      "evidence_ids": ["ev-10q"],
+      "exception": null
+    },
+    {
+      "id": "persistent_negative_cash_generation",
+      "status": "clear",
+      "finding": "Operating cash flow positive in each of the four reported periods.",
+      "evidence_ids": ["ev-xbrl"],
+      "exception": null
+    },
+    {
+      "id": "destructive_dilution",
+      "status": "clear",
+      "finding": "Share growth is roughly 1% against double-digit revenue growth.",
+      "evidence_ids": ["ev-xbrl"],
+      "exception": null
+    }
+  ],
+  "mirror_test": [
+    "It sells one subscription that mid-market operators use to schedule staff and run payroll.",
+    "It earns because the payroll record of employment lives inside the product and moving it is disruptive.",
+    "For the position to work, seat growth has to stay positive while the smallest customers keep renewing.",
+    "It breaks if a competitor's migration credit makes switching cheap enough that the payroll record stops being sticky.",
+    "If that happens the position is exited rather than averaged down, because the entire thesis was the switching cost."
+  ],
+  "evidence": [
+    {
+      "evidence_id": "ev-10q",
+      "observed_at": "2026-07-19T10:00:00+00:00",
+      "source_class": "sec_filing",
+      "locator": "sec:USTEST/10-Q/FY2026Q1",
+      "summary": "Latest quarterly filing: revenue recognition policy, seat disclosure, competitor discussion, related-party lease note."
+    },
+    {
+      "evidence_id": "ev-xbrl",
+      "observed_at": "2026-07-19T10:05:00+00:00",
+      "source_class": "sec_xbrl",
+      "locator": "sec-xbrl:USTEST/companyconcept/FY2026Q1",
+      "summary": "Structured four-period series for revenue, net income, operating cash flow, cash and diluted shares."
+    },
+    {
+      "evidence_id": "ev-news",
+      "observed_at": "2026-07-18T21:00:00+00:00",
+      "source_class": "news_media",
+      "locator": "news:USTEST/competitor-migration-credits",
+      "summary": "Trade press reports a competitor offering migration credits; read as context, not as a filing fact."
+    }
+  ],
+  "next_evidence": [],
+  "verdict": "pass_to_deep_research",
+  "routing": "us_full_report"
+}

--- a/tests/test_entry_gate.py
+++ b/tests/test_entry_gate.py
@@ -1,0 +1,427 @@
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.data import entry_gate as eg
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "entry-gates" / "ustest-2026-07-20.json"
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def us():
+    return json.loads(FIXTURE.read_text())
+
+
+def _clear_veto(veto_id, evidence_id="ev-filing"):
+    return {
+        "id": veto_id,
+        "status": "clear",
+        "finding": f"{veto_id} not present in the reviewed sources.",
+        "evidence_ids": [evidence_id],
+        "exception": None,
+    }
+
+
+def leveraged(ticker="LEVTEST"):
+    """A leveraged ETF assessment: no company fundamentals, look-through routing."""
+    return {
+        "schema_version": 1,
+        "gate_id": f"entry-{ticker}-2026-07-20",
+        "ticker": ticker,
+        "market": "HK",
+        "instrument_kind": "leveraged_etf",
+        "sector": "leveraged_etf",
+        "assessed_at": "2026-07-20T08:00:00+00:00",
+        "quote": {
+            "price": "4.56",
+            "currency": "HKD",
+            "as_of": "2026-07-20T07:50:00+00:00",
+            "source_class": "analyze_hk_stocks",
+        },
+        "information": {
+            "grade": "B",
+            "gaps": [
+                "only one primary/structured source class; a second is needed to cross-check",
+            ],
+            "source_classes": ["exchange_data", "hkex_announcement"],
+        },
+        "mechanism": "The fund pays a swap counterparty to deliver twice the daily return of a named index, and it earns nothing itself.",
+        "key_variables": [
+            {"id": "kv-index", "variable": "Underlying index composition",
+             "why_it_decides": "The exposure is the index, not a company."},
+            {"id": "kv-vol", "variable": "Realized volatility of the index",
+             "why_it_decides": "Daily rebalancing turns volatility into path decay."},
+            {"id": "kv-size", "variable": "Position size against the leverage cap",
+             "why_it_decides": "Sizing is the only real risk control on a 2x product."},
+        ],
+        "checks": [
+            {"id": "underlying_exposure", "verdict": "pass",
+             "finding": "Prospectus names the index and the 2x daily reset.",
+             "evidence_ids": ["ev-prospectus"]},
+            {"id": "decay_and_regime", "verdict": "pass",
+             "finding": "Regime and decay handled by the existing leverage look-through path.",
+             "evidence_ids": ["ev-exchange"]},
+            {"id": "sizing_limit", "verdict": "pass",
+             "finding": "Sized inside the existing leverage cap.",
+             "evidence_ids": ["ev-exchange"]},
+            {"id": "liquidity", "verdict": "pass",
+             "finding": "Average turnover supports the intended position size.",
+             "evidence_ids": ["ev-exchange"]},
+        ],
+        "vetoes": [
+            _clear_veto("integrity_or_governance_red_flag", "ev-prospectus"),
+            _clear_veto("unintelligible_revenue_mechanism", "ev-prospectus"),
+            _clear_veto("persistent_negative_cash_generation", "ev-prospectus"),
+            _clear_veto("destructive_dilution", "ev-prospectus"),
+        ],
+        "mirror_test": [
+            "It is a swap-based fund that delivers twice the daily move of one index.",
+            "It earns nothing on its own; the counterparty delivers the index return minus fees.",
+            "For it to work the index has to trend rather than chop.",
+            "It breaks in a choppy tape, where daily resets grind the position down even with a flat index.",
+            "If that happens the position is cut on the leverage rule, not on a view about any company.",
+        ],
+        "evidence": [
+            {"evidence_id": "ev-prospectus", "observed_at": "2026-07-19T02:00:00+00:00",
+             "source_class": "hkex_announcement", "locator": "hkex:LEVTEST/prospectus",
+             "summary": "Prospectus: named index, 2x daily reset, swap counterparty, fee schedule."},
+            {"evidence_id": "ev-exchange", "observed_at": "2026-07-19T02:05:00+00:00",
+             "source_class": "exchange_data", "locator": "exchange:LEVTEST/turnover",
+             "summary": "Exchange turnover and spread series used for the liquidity check."},
+        ],
+        "next_evidence": [],
+        "verdict": "pass_to_deep_research",
+        "routing": "leverage_look_through",
+    }
+
+
+# --- one schema, both markets, both instrument kinds --------------------------
+
+def test_us_company_fixture_passes_and_routes_to_full_report(us):
+    assert eg.validate_artifact(us, now=NOW) == []
+    result = eg.assess(us, now=NOW)
+    assert result["status"] == "pass"
+    assert result["verdict"] == "pass_to_deep_research"
+    assert result["routing"] == "us_full_report"
+    # An expensive, shallow-moat name is still worth researching; the concern is
+    # reported, not silently dropped.
+    assert result["failed_checks"] == ["moat", "valuation"]
+    assert result["checks_passed"] == "4/6"
+
+
+def test_the_same_schema_serves_an_hk_company(us):
+    hk = copy.deepcopy(us)
+    hk.update(gate_id="entry-HKTEST-2026-07-20", ticker="HKTEST", market="HK",
+              routing="hk_full_report")
+    hk["quote"] = {
+        "price": "45.6", "currency": "HKD",
+        "as_of": "2026-07-20T07:50:00+00:00", "source_class": "analyze_hk_stocks",
+    }
+    hk["evidence"][0]["source_class"] = "hkex_announcement"
+    hk["evidence"][1]["source_class"] = "eastmoney_fundamentals"
+    hk["information"]["source_classes"] = sorted(
+        {"news_media", "hkex_announcement", "eastmoney_fundamentals"}
+    )
+    assert eg.validate_artifact(hk, now=NOW) == []
+    assert eg.assess(hk, now=NOW)["routing"] == "hk_full_report"
+
+
+def test_leveraged_etf_routes_to_look_through_without_company_fundamentals():
+    doc = leveraged()
+    assert eg.validate_artifact(doc, now=NOW) == []
+    result = eg.assess(doc, now=NOW)
+    assert result["verdict"] == "pass_to_deep_research"
+    assert result["routing"] == "leverage_look_through"
+    assert result["checks_passed"] == "4/4"
+
+
+def test_a_leveraged_etf_may_not_carry_company_fundamental_checks():
+    doc = leveraged()
+    doc["checks"].append({
+        "id": "moat", "verdict": "pass", "finding": "A fund has no moat to grade.",
+        "evidence_ids": ["ev-prospectus"],
+    })
+    assert any(
+        "is not a leveraged_etf check" in error
+        for error in eg.validate_artifact(doc, now=NOW)
+    )
+
+
+def test_registry_overrides_a_wrong_instrument_kind_declaration():
+    doc = leveraged("07226")
+    doc["instrument_kind"] = "company"          # the registry knows better
+    doc["sector"] = "software"
+    errors = eg.validate_artifact(doc, now=NOW)
+    assert any("instrument_kind must be leveraged_etf" in error for error in errors)
+
+    unleveraged = leveraged("00100")
+    errors = eg.validate_artifact(unleveraged, now=NOW)
+    assert any("instrument_kind must be company" in error for error in errors)
+
+
+# --- information grade is about sources, not quality --------------------------
+
+def test_c_grade_company_is_gray_not_rejected(us):
+    thin = copy.deepcopy(us)
+    for item in thin["evidence"]:
+        item["source_class"] = "news_media"
+    thin["information"] = {
+        "grade": "C",
+        "gaps": [
+            "no primary issuer or structured source in the evidence set",
+            "no supporting regulatory/exchange dataset",
+            "media or analyst material is present and ranks below issuer sources",
+        ],
+        "source_classes": ["news_media"],
+    }
+    thin["verdict"] = "gray_needs_evidence"
+    thin["next_evidence"] = [{
+        "question": "Does the annual filing confirm the seat count and retention claim?",
+        "where_to_look": "SEC 10-K, Item 7 plus the revenue recognition note",
+    }]
+    assert eg.validate_artifact(thin, now=NOW) == []
+    result = eg.assess(thin, now=NOW)
+    assert result["verdict"] == "gray_needs_evidence"
+    assert result["verdict"] != "reject"
+    assert any("grade C" in reason for reason in result["reasons"])
+
+
+def test_a_gray_verdict_must_name_the_missing_evidence(us):
+    thin = copy.deepcopy(us)
+    thin["checks"][0]["verdict"] = "unknown"
+    thin["checks"][0]["evidence_ids"] = []
+    thin["verdict"] = "gray_needs_evidence"
+    assert any(
+        "must name the next evidence needed" in error
+        for error in eg.validate_artifact(thin, now=NOW)
+    )
+
+
+def test_unresolved_checks_never_produce_a_score_for_the_missing_part(us):
+    doc = copy.deepcopy(us)
+    doc["checks"][1]["verdict"] = "unknown"
+    doc["checks"][1]["evidence_ids"] = []
+    result = eg.decide(doc)
+    assert result["verdict"] == "gray_needs_evidence"
+    assert result["unresolved_checks"] == ["moat"]
+    assert result["checks_passed"] == "4/6"
+
+
+def test_information_grade_is_recomputed_not_taken_on_trust(us):
+    us["information"]["grade"] = "A"
+    for item in us["evidence"]:
+        item["source_class"] = "analyst_note"
+    assert any(
+        "information must match the grade computed" in error
+        for error in eg.validate_artifact(us, now=NOW)
+    )
+
+
+# --- hard vetoes cannot be outscored -----------------------------------------
+
+def test_a_triggered_veto_beats_a_perfect_check_tally(us):
+    doc = copy.deepcopy(us)
+    for check in doc["checks"]:
+        check["verdict"] = "pass"           # 6/6, the best possible tally
+    doc["vetoes"][0].update(
+        status="triggered",
+        finding="Auditor resigned citing unresolved related-party transfers.",
+        evidence_ids=["ev-10q"],
+    )
+    doc["verdict"] = "reject"
+    assert eg.validate_artifact(doc, now=NOW) == []
+    result = eg.assess(doc, now=NOW)
+    assert result["verdict"] == "reject"
+    assert result["checks_passed"] == "6/6"
+    assert result["triggered_vetoes"] == ["integrity_or_governance_red_flag"]
+
+
+def test_stated_verdict_cannot_disagree_with_the_computed_one(us):
+    doc = copy.deepcopy(us)
+    doc["vetoes"][3].update(
+        status="triggered",
+        finding="Share count up 40% year over year with no stated use of proceeds.",
+        evidence_ids=["ev-xbrl"],
+    )
+    doc["verdict"] = "pass_to_deep_research"     # the fudge
+    assert any(
+        "disagrees with the computed verdict" in error
+        for error in eg.validate_artifact(doc, now=NOW)
+    )
+
+
+def test_a_triggered_veto_needs_evidence(us):
+    doc = copy.deepcopy(us)
+    doc["vetoes"][1].update(status="triggered", evidence_ids=[])
+    doc["verdict"] = "reject"
+    assert any("triggered without evidence" in e for e in eg.validate_artifact(doc, now=NOW))
+
+
+def test_encoded_industry_exception_lifts_a_veto_but_an_improvised_one_does_not(us):
+    doc = copy.deepcopy(us)
+    doc["sector"] = "biotechnology_clinical_stage"
+    doc["vetoes"][2].update(
+        status="triggered",
+        finding="Operating cash flow negative in all four reported periods.",
+        evidence_ids=["ev-xbrl"],
+        exception={
+            "reason": "Clinical-stage program with financing through the next readout.",
+            "evidence_id": "ev-10q",
+        },
+    )
+    assert eg.validate_artifact(doc, now=NOW) == []
+    assert eg.decide(doc)["verdict"] == "pass_to_deep_research"
+
+    improvised = copy.deepcopy(doc)
+    improvised["sector"] = "software"          # no encoded exception for this sector
+    errors = eg.validate_artifact(improvised, now=NOW)
+    assert any("encodes no exception for sector 'software'" in error for error in errors)
+
+    unbacked = copy.deepcopy(doc)
+    unbacked["vetoes"][2]["exception"]["evidence_id"] = "ev-does-not-exist"
+    assert any(
+        "exception needs an evidence_id present in evidence[]" in error
+        for error in eg.validate_artifact(unbacked, now=NOW)
+    )
+
+
+def test_integrity_veto_encodes_no_exception_at_all(us):
+    doc = copy.deepcopy(us)
+    doc["vetoes"][0].update(
+        status="triggered",
+        finding="Regulator sanctioned the CFO over disclosure conduct.",
+        evidence_ids=["ev-10q"],
+        exception={"reason": "It was a long time ago.", "evidence_id": "ev-10q"},
+    )
+    errors = eg.validate_artifact(doc, now=NOW)
+    assert any("does not encode any exception" in error for error in errors)
+
+
+def test_a_disqualifying_check_failure_rejects_while_a_soft_one_does_not(us):
+    hard = copy.deepcopy(us)
+    hard["checks"][0]["verdict"] = "fail"        # business_quality
+    hard["verdict"] = "reject"
+    assert eg.validate_artifact(hard, now=NOW) == []
+    assert eg.decide(hard)["verdict"] == "reject"
+
+    soft = copy.deepcopy(us)
+    soft["checks"][4]["verdict"] = "fail"        # dilution
+    assert eg.decide(soft)["verdict"] == "pass_to_deep_research"
+
+
+# --- quotes come from the workspace pipelines --------------------------------
+
+def test_a_generic_web_price_is_a_hard_error_not_a_gray_verdict(us):
+    us["quote"]["source_class"] = "web_search"
+    errors = eg.validate_artifact(us, now=NOW)
+    assert any("must be a workspace pipeline" in error for error in errors)
+
+
+def test_a_stale_quote_downgrades_the_verdict_to_gray(us):
+    doc = copy.deepcopy(us)
+    doc["quote"]["as_of"] = "2026-07-15T13:35:00+00:00"     # five days before the assessment
+    freshness = eg.quote_freshness(doc)
+    assert freshness["status"] == "stale"
+    assert freshness["age_minutes"] > eg.MAX_QUOTE_AGE_MINUTES
+    assert eg.decide(doc)["verdict"] == "gray_needs_evidence"
+
+
+def test_quote_age_and_source_gaps_are_visible_in_the_output(us):
+    result = eg.assess(us, now=NOW)
+    assert result["quote_freshness"]["age_minutes"] == 25
+    assert result["quote_freshness"]["source_class"] == "analyze_us_stocks"
+    assert result["information"]["gaps"]
+
+
+# --- narrative discipline ----------------------------------------------------
+
+def test_mirror_test_must_be_five_distinct_sentences(us):
+    short = copy.deepcopy(us)
+    short["mirror_test"] = short["mirror_test"][:4]
+    assert any("exactly 5 sentences" in e for e in eg.validate_artifact(short, now=NOW))
+
+    repeated = copy.deepcopy(us)
+    repeated["mirror_test"][4] = repeated["mirror_test"][0]
+    assert any("must be distinct" in e for e in eg.validate_artifact(repeated, now=NOW))
+
+
+def test_key_variables_stay_between_three_and_seven(us):
+    doc = copy.deepcopy(us)
+    doc["key_variables"] = doc["key_variables"][:2]
+    assert any("3-7 items" in e for e in eg.validate_artifact(doc, now=NOW))
+
+
+def test_a_check_verdict_needs_evidence(us):
+    doc = copy.deepcopy(us)
+    doc["checks"][0]["evidence_ids"] = []
+    assert any("claims pass without evidence" in e for e in eg.validate_artifact(doc, now=NOW))
+
+
+def test_every_defined_veto_must_be_answered(us):
+    doc = copy.deepcopy(us)
+    doc["vetoes"] = doc["vetoes"][:2]
+    errors = eg.validate_artifact(doc, now=NOW)
+    assert sum("vetoes must state a status" in error for error in errors) == 2
+
+
+def test_evidence_cannot_be_observed_in_the_future(us):
+    doc = copy.deepcopy(us)
+    doc["evidence"][0]["observed_at"] = "2027-01-01T00:00:00+00:00"
+    assert any("cannot be in the future" in e for e in eg.validate_artifact(doc, now=NOW))
+
+
+# --- config and CLI ----------------------------------------------------------
+
+def test_schema_document_and_validator_agree(us):
+    schema = json.loads(eg.SCHEMA_FILE.read_text())
+    assert set(schema["required"]) == set(eg.ARTIFACT_FIELDS)
+    assert set(schema["properties"]) == set(eg.ARTIFACT_FIELDS)
+    assert set(schema["properties"]["verdict"]["enum"]) == eg.VERDICTS
+    assert set(schema["properties"]["quote"]["properties"]["source_class"]["enum"]) == eg.QUOTE_SOURCES
+    assert set(schema["properties"]["vetoes"]["items"]["properties"]["id"]["enum"]) == set(eg.VETOES)
+    assert set(schema["properties"]["checks"]["items"]["properties"]["id"]["enum"]) == set(
+        eg.COMPANY_CHECKS + eg.LEVERAGED_CHECKS
+    )
+    assert set(schema["properties"]["evidence"]["items"]["properties"]["source_class"]["enum"]) == eg.EVIDENCE_CLASSES
+
+
+def test_veto_config_exceptions_are_encoded_with_evidence_requirements():
+    vetoes = eg.load_vetoes()
+    assert set(vetoes) == {
+        "integrity_or_governance_red_flag", "unintelligible_revenue_mechanism",
+        "persistent_negative_cash_generation", "destructive_dilution",
+    }
+    assert vetoes["integrity_or_governance_red_flag"]["exceptions"] == []
+    assert vetoes["unintelligible_revenue_mechanism"]["exceptions"] == []
+    for veto in vetoes.values():
+        for exception in veto["exceptions"]:
+            assert exception["sector"] and exception["note"]
+            assert exception["requires_evidence"] is True
+
+
+def test_cli_passes_on_the_fixture_and_prints_one_json_object(capsys):
+    assert eg.main(["assess", str(FIXTURE)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "pass_to_deep_research"
+
+
+def test_cli_fails_closed_on_a_fudged_verdict(tmp_path, capsys):
+    doc = json.loads(FIXTURE.read_text())
+    doc["checks"][0]["verdict"] = "fail"        # business_quality → computed reject
+    path = tmp_path / "fudged.json"
+    path.write_text(json.dumps(doc))
+    assert eg.main(["validate", str(path)]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"
+
+
+def test_cli_fails_closed_on_unreadable_artifact(tmp_path, capsys):
+    path = tmp_path / "broken.json"
+    path.write_text("{nope")
+    assert eg.main(["assess", str(path)]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "fail"

--- a/tests/test_readme_parity.py
+++ b/tests/test_readme_parity.py
@@ -95,6 +95,7 @@ def test_research_surfaces_stay_in_both_languages():
         "skills/portfolio-swarm-review/SKILL.md",
         "skills/serenity-skill/SKILL.md",
         "skills/earnings-review/SKILL.md",
+        "skills/entry-gate/SKILL.md",
     ):
         assert target in EN and target in ZH, f"{target} missing from a README"
 


### PR DESCRIPTION
Fourth step of the #75 research lifecycle. A cheap gate that answers one narrow question — *is this name understandable and researchable enough to spend a deep-research run on* — and routes the answer into the existing full-report modes. It opens no position and changes no thesis.

`memory/entry-gates/<TICKER>-<date>.json` is the record; `scripts/data/entry_gate.py` decides.

## The two properties that make it a gate

**The verdict is recomputed, not accepted.** `verdict`, `routing` and `information.grade` are derived from the artifact's own checks, vetoes and evidence source classes. A stated verdict that disagrees with the computed one is a validation error, so an artifact cannot talk itself into `pass_to_deep_research`.

**Vetoes resolve before any check is counted.** A name with a perfect 6/6 tally and one triggered integrity veto returns `reject` with `checks_passed: "6/6"` — there is no aggregate score for a veto to hide inside. Industry exceptions live in `config/entry-gate-vetoes.json`, apply only when the artifact's `sector` matches an encoded one, and must cite their own evidence row. Integrity and unintelligible-revenue-mechanism encode no exception at all.

## Acceptance criteria (#70)

- Same schema for US and HK — the fixture is a US company; a test drives the identical artifact as an HK name with the HK quote pipeline and `hk_full_report` routing.
- Missing evidence yields `gray_needs_evidence`, never a fabricated score — an `unknown` check forces gray and reports `unresolved_checks` alongside an honest `4/6`; a gray verdict without `next_evidence` fails validation.
- A C-grade company is not auto-rejected — all-media evidence grades `C`, and the computed verdict is `gray_needs_evidence` with "information grade C" as the reason.
- A hard veto cannot be averaged away by a high total score — proven with 6/6 passing checks.
- Quote freshness and source gaps are visible in the artifact — `quote_freshness` reports age, source and the cap; `information.gaps` names each missing source class. A generic web price is a hard error, not a gray verdict; a stale quote downgrades to gray.
- The output routes directly into the existing deep-research mode — `routing` resolves to `us_full_report` / `hk_full_report` / `leverage_look_through`, and the skill hands `key_variables` to Mode 4.

Also per the issue: leveraged ETFs carry only `underlying_exposure` / `decay_and_regime` / `sizing_limit` / `liquidity` (a company check id on an ETF is rejected), and `config/instruments.json` overrules a wrong `instrument_kind` — declaring the registry's 2x `07226` a company fails, as does declaring unleveraged `00100` a leveraged ETF.

A failed `valuation`, `moat`, `dilution`, `decay_and_regime` or `liquidity` check does **not** block research: an expensive or shallow-moat name is still worth understanding, and sizing stays with the existing risk and decision contracts. Only `business_quality`, `management_governance`, `downside` (and for ETFs `underlying_exposure`, `sizing_limit`) are disqualifying.

## Validation

- `776 passed, 5 xfailed` (full `tests/`), 28 new tests.
- Mutation-verified one guard at a time: removing the verdict recompute, counting checks before vetoes, making grade C reject, dropping the instrument-registry cross-check, dropping the quote-source allow-list, merging the company/ETF check sets, tolerating a gray verdict with no `next_evidence`, and ignoring quote staleness each turn the corresponding test red; all green again after restore.
- Schema document and validator are asserted to agree on every enum (fields, verdicts, quote sources, veto ids, check ids, evidence classes), so the published shape cannot drift from the enforced one.
- `py_compile`, `--help`, both config JSON parses, `git diff --check` clean. No cron, payload or watchdog contract touched — the skill is manual.

Closes #70