### PR TITLE
feat: give the intraday and report paths the thesis of the names they flag

### DIFF
--- a/scripts/data/research_surface.py
+++ b/scripts/data/research_surface.py
@@ -251,6 +251,72 @@ def ungated_positions(positions, gates) -> list[dict]:
     return sorted(out, key=lambda row: row["ticker"])
 
 
+def movers_thesis_context(tickers, *, now=None, thesis_dir=THESIS_DIR,
+                          entry_gate_dir=ENTRY_GATE_DIR) -> dict:
+    """Thesis and gate state for the names a slot already flagged.
+
+    Built for the intraday and report preflights: local JSON only, scoped to the
+    tickers passed in, and silent when nothing moved. What comes back is
+    attribution context — a red line explains *why* a move matters and what the
+    thesis said to do about it. It is not a catalyst: the catalyst gate still
+    decides whether a discretionary action is allowed at all.
+
+    A missing or unreadable baseline reads `unknown`. Nothing here may raise, or a
+    research artifact could take down a market-reporting cron.
+    """
+    wanted = [str(ticker) for ticker in tickers or [] if ticker]
+    if not wanted:
+        return {}
+    try:
+        theses, thesis_errors = thesis_registry.load_registry(thesis_dir)
+        gates, gate_errors = load_entry_gates(entry_gate_dir, now=now)
+    except Exception as exc:  # noqa: BLE001 — last-resort guard, not the main path
+        # Malformed artifacts are already absorbed by the loaders above (they
+        # collect errors instead of raising), so this catches only the
+        # unexpected — a permissions error, a corrupt directory. A research
+        # artifact must never be able to take down a market-reporting cron.
+        return {ticker: {"status": "unknown", "reason": f"registry unreadable: {exc}"}
+                for ticker in wanted}
+    by_ticker = {doc["ticker"]: doc for doc in theses}
+    invalid = bool(thesis_errors or gate_errors)
+    out = {}
+    for ticker in wanted:
+        doc = by_ticker.get(ticker)
+        gate_docs = gates.get(ticker) or []
+        entry = {}
+        if doc is None:
+            entry = {
+                "status": "unknown",
+                "reason": "no canonical thesis baseline"
+                          + (" (some artifacts are invalid)" if invalid else ""),
+            }
+        else:
+            red_lines = [
+                {
+                    "id": line.get("id"),
+                    "status": line.get("status"),
+                    "severity": line.get("severity"),
+                    "required_action": line.get("required_action"),
+                }
+                for line in doc.get("red_lines") or []
+                if line.get("status") in {"triggered", "watch"}
+            ]
+            entry = {
+                "status": "resolved",
+                "thesis_id": doc["thesis_id"],
+                "state": doc["state"],
+                "checked_at": doc["checked_at"],
+                "red_lines": sorted(red_lines, key=lambda row: str(row["id"])),
+                "next_review_trigger": doc["next_review_trigger"],
+            }
+        if gate_docs and gate_docs[-1]["verdict"] == "reject":
+            entry["entry_gate"] = {
+                "verdict": "reject", "gate_id": gate_docs[-1]["gate_id"],
+            }
+        out[ticker] = entry
+    return out
+
+
 def summarize(*, portfolio=None, catalysts=None, today=None, now=None,
               thesis_dir=THESIS_DIR, earnings_dir=EARNINGS_DIR,
               entry_gate_dir=ENTRY_GATE_DIR) -> dict:

--- a/scripts/harness/intraday_preflight.py
+++ b/scripts/harness/intraday_preflight.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 import peer_scan  # noqa: E402
+import research_surface  # noqa: E402
 
 
 def run_analyze(market):
@@ -212,6 +213,13 @@ def main():
     if total_signals >= 2:
         alert_reasons.append(f'多重信号 (W{signals["watch"]} S{signals["stop"]} T{signals["trim"]})')
 
+    # Thesis/red-line state for the names this slot already flagged. Local JSON
+    # only, scoped to movers, and attribution context — never an action trigger
+    # on its own (the catalyst gate still decides that).
+    mover_thesis = research_surface.movers_thesis_context(
+        [a['ticker'] for a in anomalies]
+    )
+
     result = {
         'status':           'ok',
         'market':           args.market,
@@ -226,6 +234,7 @@ def main():
         'alert_reasons':    alert_reasons,
         't0_setups':        t0_setups,
         'peer_scan':        collect_peers(args.market),
+        'mover_thesis':     mover_thesis,
         'heartbeat':        {'job': heartbeat['job'], 'slot': heartbeat['slot']},
     }
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -57,6 +57,7 @@ TMP = WS / 'memory' / '.tmp'
 sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
 import peer_scan  # noqa: E402
+import research_surface  # noqa: E402
 import workflow_outcomes  # noqa: E402
 
 
@@ -381,6 +382,10 @@ def main():
     market_cn = '港股' if args.market == 'hk' else '美股'
     commit_msg = f'portfolio: {market_cn}{COMMIT_PHASE_CN[args.phase]}价格更新'
 
+    mover_thesis = research_surface.movers_thesis_context(
+        [a['ticker'] for a in anomalies]
+    )
+
     result = {
         'status':             'ok',
         'market':             args.market,
@@ -396,6 +401,7 @@ def main():
         'anomalies':          anomalies,
         'index_direction':    indices,
         'peer_scan':          trim_peer_scan(peers),
+        'mover_thesis':       mover_thesis,
         'needs_risk_section': (signals['stop'] + signals['trim']) >= 2,
     }
     result['context_id'] = compute_context_id(result)

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -87,6 +87,7 @@ python3 /root/.openclaw/workspace/scripts/data/analyze_hk_stocks.py --no-fetch  
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market hk
 ```
 跑 `scripts/data/analyze_hk_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`。
+- `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 关键字段：`should_alert` (bool) + `alert_reasons` (异动票/STOP 计数等)。另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
 
 #### Step 2: 写报告

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -89,6 +89,7 @@ dreaming 留独占窗口，所以 EST 季比 EDT 季少两个 slot。
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market us
 ```
 输出 `memory/.tmp/intraday-context-us-latest.json`，关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
+- `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 
 #### Step 2: 写报告
 - 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -330,3 +330,127 @@ def test_cli_check_exits_nonzero_only_on_integrity_failure(tmp_path, capsys, mon
     assert payload["status"] in {"pass", "warn"}
     assert rs.main([]) == 0
     assert json.loads(capsys.readouterr().out)["status"] == "ready"
+
+
+# --- mover-scoped thesis context (intraday + report paths) -------------------
+
+def _thesis(ticker="USTEST", state=None, red_line_status="triggered"):
+    # A triggered *severe* red line forces state damaged/broken — the registry
+    # validator enforces that, so the fixture has to respect it.
+    state = state or ("damaged" if red_line_status == "triggered" else "weakening")
+    return {
+        "schema_version": 1,
+        "thesis_id": f"{ticker.lower()}-core",
+        "ticker": ticker,
+        "strategy_scope": ["core_position"],
+        "summary": "Platform economics carry the position.",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "checked_at": "2026-04-26T00:00:00+00:00",
+        "state": state,
+        "dimensions": {
+            name: {"state": "unknown", "evidence_ids": []}
+            for name in ("business", "moat", "management", "valuation")
+        },
+        "assumptions": [
+            {"id": f"a-{i}", "claim": f"Assumption {i}", "test": "Metric holds",
+             "cadence": "quarterly", "status": "unknown", "evidence_ids": []}
+            for i in range(1, 4)
+        ],
+        "red_lines": [
+            {"id": "cash-conversion",
+             "condition": "OCF/net income below 0.8 for two periods",
+             "severity": "severe", "status": red_line_status,
+             "required_action": "Cut the position by half",
+             "evidence_ids": ["ev-1"] if red_line_status == "triggered" else []},
+            {"id": "dormant", "condition": "Customer concentration above 40%",
+             "severity": "warning", "status": "clear",
+             "required_action": "Reassess sizing", "evidence_ids": []},
+        ],
+        "valuation_anchors": [],
+        "evidence": [{
+            "evidence_id": "ev-1", "observed_at": "2026-04-25T00:00:00+00:00",
+            "source_class": "issuer_filing", "locator": "filing:ev-1",
+            "kind": "fundamental", "summary": "Cash conversion below threshold.",
+        }],
+        "next_review_trigger": {"type": "earnings", "description": "Next filing"},
+    }
+
+
+def test_nothing_moved_means_no_lookup(dirs):
+    assert rs.movers_thesis_context([], now=NOW, thesis_dir=dirs["thesis_dir"],
+                                    entry_gate_dir=dirs["entry_gate_dir"]) == {}
+    assert rs.movers_thesis_context(None, now=NOW) == {}
+
+
+def test_a_moving_name_surfaces_its_triggered_red_line_and_required_action(dirs):
+    (dirs["thesis_dir"] / "USTEST.json").write_text(json.dumps(_thesis()))
+    out = rs.movers_thesis_context(["USTEST"], now=NOW, thesis_dir=dirs["thesis_dir"],
+                                   entry_gate_dir=dirs["entry_gate_dir"])
+    entry = out["USTEST"]
+    assert entry["status"] == "resolved"
+    assert entry["state"] == "damaged"
+    assert entry["red_lines"] == [{
+        "id": "cash-conversion", "status": "triggered", "severity": "severe",
+        "required_action": "Cut the position by half",
+    }]
+    assert entry["next_review_trigger"]["type"] == "earnings"
+
+
+def test_clear_red_lines_are_left_out_of_a_report_sized_block(dirs):
+    (dirs["thesis_dir"] / "USTEST.json").write_text(
+        json.dumps(_thesis(red_line_status="watch")))
+    entry = rs.movers_thesis_context(["USTEST"], now=NOW, thesis_dir=dirs["thesis_dir"],
+                                     entry_gate_dir=dirs["entry_gate_dir"])["USTEST"]
+    assert [row["id"] for row in entry["red_lines"]] == ["cash-conversion"]
+    assert entry["red_lines"][0]["status"] == "watch"
+
+
+def test_a_mover_without_a_baseline_reads_unknown(dirs):
+    out = rs.movers_thesis_context(["NOBASELINE"], now=NOW,
+                                   thesis_dir=dirs["thesis_dir"],
+                                   entry_gate_dir=dirs["entry_gate_dir"])
+    assert out["NOBASELINE"]["status"] == "unknown"
+    assert "no canonical thesis baseline" in out["NOBASELINE"]["reason"]
+
+
+def test_a_rejected_gate_is_flagged_on_the_moving_name(dirs):
+    (dirs["thesis_dir"] / "USTEST.json").write_text(json.dumps(_thesis()))
+    doc = json.loads(GATE_FIXTURE.read_text())
+    doc["checks"][0]["verdict"] = "fail"
+    doc["verdict"] = "reject"
+    write_gate(dirs, doc)
+    entry = rs.movers_thesis_context(["USTEST"], now=NOW, thesis_dir=dirs["thesis_dir"],
+                                     entry_gate_dir=dirs["entry_gate_dir"])["USTEST"]
+    assert entry["entry_gate"] == {"verdict": "reject", "gate_id": "entry-USTEST-2026-07-20"}
+
+
+def test_a_broken_artifact_degrades_to_unknown_and_never_raises(dirs):
+    (dirs["thesis_dir"] / "USTEST.json").write_text("{not json")
+    out = rs.movers_thesis_context(["USTEST"], now=NOW, thesis_dir=dirs["thesis_dir"],
+                                   entry_gate_dir=dirs["entry_gate_dir"])
+    assert out["USTEST"]["status"] == "unknown"
+    assert "invalid" in out["USTEST"]["reason"]
+
+
+def test_a_missing_registry_directory_never_breaks_a_reporting_cron(tmp_path):
+    out = rs.movers_thesis_context(["USTEST"], now=NOW,
+                                   thesis_dir=tmp_path / "gone",
+                                   entry_gate_dir=tmp_path / "gone")
+    assert out["USTEST"]["status"] == "unknown"
+
+
+def test_intraday_and_report_preflights_carry_mover_thesis():
+    for name in ("intraday_preflight.py", "report_preflight.py"):
+        source = (ROOT / "scripts" / "harness" / name).read_text()
+        assert "import research_surface" in source, name
+        assert "research_surface.movers_thesis_context(" in source, name
+        assert "'mover_thesis'" in source, name
+        # scoped to the names the slot already flagged, never the whole book
+        assert "[a['ticker'] for a in anomalies]" in source, name
+
+
+def test_both_stock_skills_frame_it_as_attribution_not_a_trigger():
+    for name in ("us-stock-analysis", "hk-stock-analysis"):
+        skill = (ROOT / "skills" / name / "SKILL.md").read_text()
+        assert "mover_thesis" in skill, name
+        assert "catalyst-gate" in skill, name


### PR DESCRIPTION
Closes the gap #89 named: after #88 the research lifecycle reached the 08:00 brief and nothing else, so the two loops that actually detect a move — Mode 7 intraday every 30 minutes, and the four Mode 6 reports — could not see the thesis of the name they were flagging.

## What the flagged names now carry

`context.mover_thesis`, keyed by ticker, for the anomalies of that slot only:

- thesis `state` and `checked_at`;
- red lines in `triggered` or `watch`, each with `severity` and `required_action` — the clear ones are omitted so the block stays report-sized;
- `next_review_trigger`;
- `entry_gate: {verdict: reject, gate_id}` when the latest gate rejected the name that is nevertheless held.

## Deliberately narrow

- **Mover-scoped**: `movers_thesis_context([a['ticker'] for a in anomalies])`. An untouched book produces `{}` and does no work.
- **Local JSON only**: no network, no LLM, and explicitly no Tavily in an intraday path.
- **Attribution, not a trigger**: both stock skills now say a red line explains *why* a move matters and what the thesis already committed to do — the catalyst gate still decides whether a discretionary action is allowed at all.
- **Fails soft**: a missing baseline reads `unknown`; a malformed artifact degrades to `unknown` with a reason. A research artifact must never take down a market-reporting cron.
- No cron payload, watchdog or schedule contract touched.

## Validation

- `817 passed, 5 xfailed`; 9 new tests.
- Mutation-verified: dropping the triggered/watch red-line filter, un-scoping the lookup from `anomalies`, and no longer flagging a rejected gate each turn the matching test red; restored green.
- One honest note: the broad `except` around the loaders is last-resort defence, not the tested path — malformed artifacts are already absorbed by the loaders, which collect errors instead of raising. The comment says so rather than implying coverage.
- The test fixture caught a real registry rule while being written: a triggered *severe* red line requires state `damaged`/`broken`, so an invalid thesis is dropped by `load_registry` and correctly reads `unknown`.

Sibling issue #90 tracks the harder half of your question — capturing the real-time news *behind* an anomalous move — with measured latency per candidate source.

Closes #89