### PR TITLE
feat: probe the real catalyst behind an intraday anomaly

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -136,7 +136,7 @@ python3 scripts/data/fetch_us_stocks.py     # 仅刷美股价格
 
 **数据抓取/分析**：`fetch_us_stocks.py`(美股7路fallback,写回portfolio) · `analyze_us_stocks.py`(刷价+RSI/MA+新闻+信号) · `analyze_hk_stocks.py`(腾讯+东财双源对账→stooq/yf兜底) · `fetch_fx.py`(USDHKD 3路,**book total 必先调**) · `fetch_us_filings.py`(SEC EDGAR) · `fetch_fundamentals_em.py`(东财中文基本面,**港股财报**) · `fetch_catalysts.py`(14d催化→catalysts.json) · `fetch_influencer_feed.py`(Trump/Musk雷达→influencer_feed.json) · `portfolio_risk_metrics.py`(β/Vol/DD/Sharpe→risk.json) · `compute_quant_signals.py`(趋势/动量/RSI/z/ATR吊灯/vol-target→quant_signals.json+history.jsonl留痕,杠杆ETF按标的) · `quant_signal_review.py`(留痕vs前瞻收益→因子edge表,n<20不解锁,brief按edge取信)
 
-**研究生命周期（手动/事件驱动，产物即真源）**：`entry_gate.py`(建仓前研究闸,信息分级≠投资质量,硬否决先于计分→`memory/entry-gates/`) · `earnings_review.py`(一手财报复盘+管理层承诺账本,盈利质量由代码算→`memory/earnings/`) · `thesis_registry.py`(canonical thesis + 只认证据的 drift→`memory/theses/`) · `research_provenance.py`(数字两源+Decimal 精算,准出闸) · `research_surface.py`(把上面三类 artifact 汇成待办队列;brief preflight 读它,`--check` 进 system_check 与 CI)
+**研究生命周期（手动/事件驱动，产物即真源）**：`entry_gate.py`(建仓前研究闸,信息分级≠投资质量,硬否决先于计分→`memory/entry-gates/`) · `earnings_review.py`(一手财报复盘+管理层承诺账本,盈利质量由代码算→`memory/earnings/`) · `thesis_registry.py`(canonical thesis + 只认证据的 drift→`memory/theses/`) · `research_provenance.py`(数字两源+Decimal 精算,准出闸) · `research_surface.py`(把上面三类 artifact 汇成待办队列;brief preflight 读它,`--check` 进 system_check 与 CI) · `mover_news.py`(盘中异动票的一手催化探针:SEC/港交所公告分钟级,券商研报与 7×24 只作 supporting;有预算上限、失败降级、不碰 Tavily)
 
 **Harness（三明治：preflight 确定性 → LLM 合成 → postflight 校验+commit）**
 - brief：`brief_preflight.py` / `brief_postflight.py`（写 `memory/{date}-pre-open.md` + `-plan.json`；postflight 自动跑 build_dashboard + push）

--- a/scripts/data/mover_news.py
+++ b/scripts/data/mover_news.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Catalyst probe for the names an intraday slot flagged.
+
+When a holding moves abnormally, the loop that detects the move should also
+capture what was actually published — not leave the model to improvise a reason
+from a daily digest built hours earlier.
+
+Design constraints, all enforced here rather than requested in a prompt:
+
+* **Mover-scoped.** Nothing moved, nothing fetched. The caller passes the tickers
+  the slot already flagged, and the probe caps how many it will chase.
+* **Bounded.** Per-request timeout, a total wall-clock budget, a cap on items per
+  ticker and a truncated title. A 2200-character report cannot carry five
+  headlines, and a context nobody reads is waste.
+* **Primary versus supporting.** Exchange and regulator filings are `primary`;
+  broker notes, media and market flashes are `supporting`. Only a primary item may
+  ever be treated as a hard catalyst — the catalyst gate still decides whether an
+  action is allowed.
+* **Silence is stated, not implied.** No item found reads `no_recent_filing`, so an
+  empty block can never be mistaken for "no news".
+* **Fails soft.** Any endpoint failure degrades to `degraded` with a reason. A news
+  probe must never slow or red a market-reporting cron.
+
+Request budget at a 30-minute cadence: at most `MAX_MOVERS` tickers × 2 endpoints
+plus one shared market-flash call — a handful of requests per slot. SEC documents
+10 req/s (this repo throttles to 8), and the Tencent quote hosts are already
+called every slot by the analyze scripts, so the cadence is nowhere near any
+published limit. The real risks are shape changes and timeouts, which is why every
+path fails soft.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WS / "scripts" / "data"))
+
+HKT = timezone(timedelta(hours=8))
+MAX_MOVERS = 4
+MAX_ITEMS_PER_TICKER = 3
+MAX_FLASHES = 3
+TITLE_CHARS = 90
+WINDOW_MINUTES = 240
+PER_REQUEST_TIMEOUT_S = 5
+TOTAL_BUDGET_S = 20
+UA = "Mozilla/5.0 (clawock intraday catalyst probe)"
+TENCENT_NEWS = "https://web.ifzq.gtimg.cn/appstock/news/info/search"
+SEC_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
+# Tencent type=0 is the exchange/regulator filing feed (HKEX announcements for HK,
+# SEC forms for US), timestamped to the second. type=1 is broker research and media.
+TENCENT_FILINGS_TYPE = 0
+TENCENT_NEWS_TYPE = 1
+PRIMARY = "primary"
+SUPPORTING = "supporting"
+
+
+def _http_json(url: str, *, headers=None, timeout=PER_REQUEST_TIMEOUT_S):
+    """The single network seam, so tests never touch the network."""
+    request = urllib.request.Request(
+        url, headers={"User-Agent": UA, "Referer": "https://gu.qq.com/", **(headers or {})}
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8", "ignore"))
+
+
+def _truncate(text) -> str:
+    text = re.sub(r"\s+", " ", str(text or "")).strip()
+    return text if len(text) <= TITLE_CHARS else text[: TITLE_CHARS - 1] + "…"
+
+
+def _age_minutes(when: datetime, now: datetime) -> int:
+    return int((now - when).total_seconds() // 60)
+
+
+def _parse_tencent_time(value):
+    try:
+        return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(tzinfo=HKT)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_sec_time(value):
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def tencent_symbol(ticker: str, market: str) -> str | None:
+    """Map a workspace ticker onto the Tencent symbol space."""
+    ticker = str(ticker or "").strip()
+    if not ticker:
+        return None
+    if market == "hk":
+        digits = ticker.split(".")[0].zfill(5)
+        return f"hk{digits}" if digits.isdigit() else None
+    return f"us{ticker.upper()}"
+
+
+def _tencent_items(symbol, feed_type, tier, source_class, *, now, window, http):
+    payload = http(
+        f"{TENCENT_NEWS}?{urllib.parse.urlencode({'symbol': symbol, 'n': 8, 'page': 1, 'type': feed_type})}"
+    )
+    rows = ((payload or {}).get("data") or {}).get("data") or []
+    items = []
+    for row in rows:
+        when = _parse_tencent_time(row.get("time"))
+        if when is None:
+            continue
+        age = _age_minutes(when, now)
+        if age < 0 or age > window:
+            continue
+        items.append({
+            "published_at": when.isoformat(),
+            "age_minutes": age,
+            "title": _truncate(row.get("title")),
+            "tier": tier,
+            "source_class": source_class,
+            "url": row.get("url") or None,
+        })
+    return items
+
+
+def _sec_items(ticker, *, now, window, http):
+    import fetch_us_filings  # noqa: PLC0415 — optional, only needed on the US leg
+
+    cik = fetch_us_filings.lookup_cik(ticker)
+    if not cik:
+        return [], f"no CIK for {ticker}"
+    # lookup_cik already returns the `CIK##########` form; prepending our own
+    # prefix produced `CIKCIK…` and a silent 404 on every US mover.
+    digits = re.sub(r"\D", "", str(cik))
+    payload = http(
+        SEC_SUBMISSIONS.format(cik=digits.zfill(10)),
+        headers={"User-Agent": fetch_us_filings._load_user_agent()},
+    )
+    recent = ((payload or {}).get("filings") or {}).get("recent") or {}
+    forms = recent.get("form") or []
+    accepted = recent.get("acceptanceDateTime") or []
+    docs = recent.get("primaryDocDescription") or []
+    items = []
+    for index, form in enumerate(forms):
+        when = _parse_sec_time(accepted[index] if index < len(accepted) else None)
+        if when is None:
+            continue
+        age = _age_minutes(when, now)
+        if age < 0 or age > window:
+            continue
+        description = docs[index] if index < len(docs) else ""
+        items.append({
+            "published_at": when.isoformat(),
+            "age_minutes": age,
+            "title": _truncate(f"{form} {description}".strip()),
+            "tier": PRIMARY,
+            "source_class": "sec_filing",
+            "url": None,
+        })
+    return items, None
+
+
+def _market_flashes(names, *, now, window):
+    """Market-wide 7x24 flashes, kept only when they name a holding."""
+    try:
+        import fetch_em_news  # noqa: PLC0415
+
+        rows = fetch_em_news.em_fast_news(limit=20) or []
+    except Exception as exc:  # noqa: BLE001 — supporting colour, never fatal
+        return [], f"em flash unavailable: {type(exc).__name__}"
+    out = []
+    for row in rows:
+        title = str(row.get("title") or "")
+        matched = sorted({name for name in names if name and name in title})
+        if not matched:
+            continue
+        when = _parse_tencent_time(row.get("date") or row.get("time"))
+        age = _age_minutes(when, now) if when else None
+        if age is not None and (age < 0 or age > window):
+            continue
+        out.append({
+            "published_at": when.isoformat() if when else None,
+            "age_minutes": age,
+            "title": _truncate(title),
+            "tier": SUPPORTING,
+            "source_class": "market_flash",
+            "matched": matched,
+        })
+        if len(out) >= MAX_FLASHES:
+            break
+    return out, None
+
+
+def holding_names(tickers) -> dict:
+    """Ticker → display name, for matching a market-wide flash to a holding."""
+    try:
+        import instrument_registry  # noqa: PLC0415
+
+        return {
+            ticker: (instrument_registry.get(str(ticker)) or {}).get("name")
+            for ticker in tickers
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
+          budget_s=TOTAL_BUDGET_S, http=None, clock=None) -> dict:
+    """Catalyst evidence for the flagged tickers. Never raises."""
+    tickers = [str(t) for t in (movers or []) if t]
+    if not tickers:
+        return {}
+    now = now or datetime.now(timezone.utc)
+    http = http or _http_json
+    clock = clock or time.monotonic
+    started = clock()
+    chased, skipped = tickers[:MAX_MOVERS], tickers[MAX_MOVERS:]
+    names = holding_names(chased)
+
+    results = {}
+    for ticker in chased:
+        entry = {"status": "no_recent_filing", "items": [], "notes": []}
+        symbol = tencent_symbol(ticker, market)
+        # On the US leg SEC and Tencent report the same filing twice ("SCHEDULE
+        # 13G" / "Form SC 13G"). SEC is the authority, so Tencent's filing feed is
+        # only consulted when SEC produced nothing — one event, one line.
+        for label, call in (
+            ("sec", (lambda t=ticker: _sec_items(t, now=now, window=window_minutes, http=http))
+             if market == "us" else None),
+            ("filings", (lambda s=symbol: (_tencent_items(
+                s, TENCENT_FILINGS_TYPE, PRIMARY, "exchange_filing",
+                now=now, window=window_minutes, http=http), None)) if symbol else None),
+            ("research", (lambda s=symbol: (_tencent_items(
+                s, TENCENT_NEWS_TYPE, SUPPORTING, "broker_or_media",
+                now=now, window=window_minutes, http=http), None)) if symbol else None),
+        ):
+            if call is None:
+                continue
+            if (label == "filings" and market == "us"
+                    and any(row["source_class"] == "sec_filing" for row in entry["items"])):
+                continue
+            if clock() - started > budget_s:
+                entry["notes"].append(f"{label}: skipped, time budget spent")
+                entry["status"] = "degraded"
+                break
+            try:
+                items, note = call()
+            except Exception as exc:  # noqa: BLE001 — a dead endpoint must not red a cron
+                entry["notes"].append(f"{label}: {type(exc).__name__}")
+                entry["status"] = "degraded"
+                continue
+            if note:
+                entry["notes"].append(f"{label}: {note}")
+            entry["items"].extend(items)
+        entry["items"].sort(key=lambda row: (row["tier"] != PRIMARY, row["age_minutes"]))
+        entry["items"] = entry["items"][:MAX_ITEMS_PER_TICKER]
+        if entry["items"]:
+            entry["status"] = "found"
+        elif entry["status"] != "degraded":
+            entry["status"] = "no_recent_filing"
+        results[ticker] = entry
+
+    flashes, flash_note = _market_flashes(
+        [name for name in names.values() if name], now=now, window=window_minutes
+    )
+    payload = {
+        "as_of": now.isoformat(),
+        "window_minutes": window_minutes,
+        "elapsed_s": round(clock() - started, 2),
+        "tickers": results,
+        "market_flashes": flashes,
+    }
+    if skipped:
+        payload["not_chased"] = skipped
+    if flash_note:
+        payload["notes"] = [flash_note]
+    return payload
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--market", choices=("us", "hk"), required=True)
+    parser.add_argument("--tickers", required=True, help="comma-separated movers")
+    parser.add_argument("--window-minutes", type=int, default=WINDOW_MINUTES)
+    args = parser.parse_args(argv)
+    payload = probe(
+        [t.strip() for t in args.tickers.split(",") if t.strip()],
+        market=args.market, window_minutes=args.window_minutes,
+    )
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/intraday_preflight.py
+++ b/scripts/harness/intraday_preflight.py
@@ -40,6 +40,7 @@ import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 import peer_scan  # noqa: E402
 import research_surface  # noqa: E402
+import mover_news  # noqa: E402
 
 
 def run_analyze(market):
@@ -220,6 +221,13 @@ def main():
         [a['ticker'] for a in anomalies]
     )
 
+    # What was actually published behind those moves. Mover-scoped, bounded
+    # by a wall-clock budget, and fails soft — a news endpoint must never
+    # slow or red a reporting cron.
+    mover_news_ctx = mover_news.probe(
+        [a['ticker'] for a in anomalies], market=args.market,
+    )
+
     result = {
         'status':           'ok',
         'market':           args.market,
@@ -235,6 +243,7 @@ def main():
         't0_setups':        t0_setups,
         'peer_scan':        collect_peers(args.market),
         'mover_thesis':     mover_thesis,
+        'mover_news':       mover_news_ctx,
         'heartbeat':        {'job': heartbeat['job'], 'slot': heartbeat['slot']},
     }
 

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -58,6 +58,7 @@ sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
 import peer_scan  # noqa: E402
 import research_surface  # noqa: E402
+import mover_news  # noqa: E402
 import workflow_outcomes  # noqa: E402
 
 
@@ -386,6 +387,13 @@ def main():
         [a['ticker'] for a in anomalies]
     )
 
+    # What was actually published behind those moves. Mover-scoped, bounded
+    # by a wall-clock budget, and fails soft — a news endpoint must never
+    # slow or red a reporting cron.
+    mover_news_ctx = mover_news.probe(
+        [a['ticker'] for a in anomalies], market=args.market,
+    )
+
     result = {
         'status':             'ok',
         'market':             args.market,
@@ -402,6 +410,7 @@ def main():
         'index_direction':    indices,
         'peer_scan':          trim_peer_scan(peers),
         'mover_thesis':       mover_thesis,
+        'mover_news':         mover_news_ctx,
         'needs_risk_section': (signals['stop'] + signals['trim']) >= 2,
     }
     result['context_id'] = compute_context_id(result)

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -88,6 +88,10 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 ```
 跑 `scripts/data/analyze_hk_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
+- `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
+  - `status=no_recent_filing` 是**明确的空**：写「窗口内无一手公告」，不要改口编一个理由；`status=degraded` 说明源没抓到，同样如实写。
+  - 用法铁律：异动票必须给出归因或明写「无法归因」。**不要把 `mover_news` 整块抄进报告**——最多引 1–2 条最相关的标题+时间。
+  - 一手文件都没有、而异动又很大时，才允许用**内置 web search** 补一次（禁止 Tavily：盘中不烧额度）。
 关键字段：`should_alert` (bool) + `alert_reasons` (异动票/STOP 计数等)。另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
 
 #### Step 2: 写报告

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -90,6 +90,10 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 ```
 输出 `memory/.tmp/intraday-context-us-latest.json`，关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
+- `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
+  - `status=no_recent_filing` 是**明确的空**：写「窗口内无一手公告」，不要改口编一个理由；`status=degraded` 说明源没抓到，同样如实写。
+  - 用法铁律：异动票必须给出归因或明写「无法归因」。**不要把 `mover_news` 整块抄进报告**——最多引 1–2 条最相关的标题+时间。
+  - 一手文件都没有、而异动又很大时，才允许用**内置 web search** 补一次（禁止 Tavily：盘中不烧额度）。
 
 #### Step 2: 写报告
 - 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -1,0 +1,252 @@
+"""The intraday catalyst probe: bounded, mover-scoped, and honest about silence.
+
+Every test runs offline through the module's single HTTP seam. A test that needed
+the network would be untrustworthy exactly when the endpoints misbehave, which is
+the case this code exists to survive.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.data import mover_news as mn
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW = datetime(2026, 7, 24, 6, 0, tzinfo=timezone.utc)          # 14:00 HKT
+
+
+def tencent_payload(rows):
+    return {"code": 0, "data": {"data": rows}}
+
+
+def row(title, when, url=None):
+    return {"title": title, "time": when, "url": url}
+
+
+def fake_http(mapping, calls=None):
+    """Route by URL fragment; anything unmapped raises, like a dead endpoint."""
+    def _http(url, headers=None, timeout=None):
+        if calls is not None:
+            calls.append(url)
+        for fragment, payload in mapping.items():
+            if fragment in url:
+                if isinstance(payload, Exception):
+                    raise payload
+                return payload
+        raise OSError(f"unmapped url {url}")
+    return _http
+
+
+@pytest.fixture(autouse=True)
+def no_flashes(monkeypatch):
+    # The market-flash leg reaches Eastmoney through its own fetcher; silence it
+    # unless a test opts in.
+    monkeypatch.setattr(mn, "_market_flashes", lambda names, now, window: ([], None))
+    monkeypatch.setattr(mn, "holding_names", lambda tickers: {})
+
+
+# --- scope and budget --------------------------------------------------------
+
+def test_nothing_moved_means_no_requests():
+    calls = []
+    assert mn.probe([], market="hk", now=NOW, http=fake_http({}, calls)) == {}
+    assert mn.probe(None, market="us", now=NOW, http=fake_http({}, calls)) == {}
+    assert calls == []
+
+
+def test_only_the_first_few_movers_are_chased():
+    payload = tencent_payload([row("公告 A", "2026-07-24 13:50:00")])
+    result = mn.probe(
+        ["00100", "02208", "03032", "03033", "07226"], market="hk", now=NOW,
+        http=fake_http({"appstock/news": payload}),
+    )
+    assert len(result["tickers"]) == mn.MAX_MOVERS
+    assert result["not_chased"] == ["07226"]
+
+
+def test_items_are_capped_and_titles_truncated():
+    long_title = "港交所公告：" + "细节" * 200
+    rows = [row(f"{long_title} {i}", f"2026-07-24 13:5{i}:00") for i in range(6)]
+    result = mn.probe(["00100"], market="hk", now=NOW,
+                      http=fake_http({"appstock/news": tencent_payload(rows)}))
+    items = result["tickers"]["00100"]["items"]
+    assert len(items) == mn.MAX_ITEMS_PER_TICKER
+    assert all(len(item["title"]) <= mn.TITLE_CHARS for item in items)
+
+
+def test_the_time_budget_stops_further_calls():
+    ticks = iter([0, 0, 999, 999, 999, 999, 999, 999])
+    result = mn.probe(["00100", "02208"], market="hk", now=NOW,
+                      http=fake_http({"appstock/news": tencent_payload([])}),
+                      clock=lambda: next(ticks))
+    statuses = {t: e["status"] for t, e in result["tickers"].items()}
+    assert "degraded" in statuses.values()
+    assert any("time budget" in note
+               for entry in result["tickers"].values() for note in entry["notes"])
+
+
+# --- freshness and tiering ---------------------------------------------------
+
+def test_only_items_inside_the_window_survive():
+    rows = [
+        row("窗口内公告", "2026-07-24 13:30:00"),     # 30 min old
+        row("昨天的公告", "2026-07-23 09:00:00"),     # ~29h old
+        row("未来时间戳", "2026-07-24 23:00:00"),     # negative age
+    ]
+    def http(url, headers=None, timeout=None):
+        # only the filing feed answers, so each item appears once
+        return tencent_payload(rows if "type=0" in url else [])
+
+    items = mn.probe(["00100"], market="hk", now=NOW, http=http)["tickers"]["00100"]["items"]
+    assert [item["title"] for item in items] == ["窗口内公告"]
+    assert items[0]["age_minutes"] == 30
+
+
+def test_exchange_filings_outrank_broker_notes():
+    def http(url, headers=None, timeout=None):
+        if "type=0" in url:
+            return tencent_payload([row("翌日披露报表", "2026-07-24 13:00:00")])
+        return tencent_payload([row("券商研报：维持买入", "2026-07-24 13:55:00")])
+
+    items = mn.probe(["00100"], market="hk", now=NOW, http=http)["tickers"]["00100"]["items"]
+    assert [item["tier"] for item in items] == [mn.PRIMARY, mn.SUPPORTING]
+    # the primary item is older yet still first: tier beats recency
+    assert items[0]["age_minutes"] > items[1]["age_minutes"]
+    assert items[0]["source_class"] == "exchange_filing"
+    assert items[1]["source_class"] == "broker_or_media"
+
+
+def test_us_leg_prefers_sec_and_does_not_repeat_the_same_filing(monkeypatch):
+    sec = {
+        "filings": {"recent": {
+            "form": ["8-K", "4"],
+            "acceptanceDateTime": ["2026-07-24T05:30:00.000Z", "2026-07-20T12:00:00.000Z"],
+            "primaryDocDescription": ["Results of Operations", "FORM 4"],
+        }}
+    }
+    monkeypatch.setattr(mn, "_sec_items",
+                        lambda ticker, now, window, http: (
+                            mn._sec_items.__wrapped__(ticker, now=now, window=window, http=http)
+                            if hasattr(mn._sec_items, "__wrapped__") else
+                            ([{
+                                "published_at": "2026-07-24T05:30:00+00:00",
+                                "age_minutes": 30,
+                                "title": "8-K Results of Operations",
+                                "tier": mn.PRIMARY,
+                                "source_class": "sec_filing",
+                                "url": None,
+                            }], None)))
+    calls = []
+    result = mn.probe(["NVDA"], market="us", now=NOW,
+                      http=fake_http({"appstock/news": tencent_payload(
+                          [row("Form 8-K - Results", "2026-07-24 13:30:00")])}, calls))
+    items = result["tickers"]["NVDA"]["items"]
+    # the SEC filing is kept; Tencent's copy of the same filing is never fetched
+    assert items[0]["source_class"] == "sec_filing"
+    assert "exchange_filing" not in [item["source_class"] for item in items]
+    assert all("type=0" not in url for url in calls)
+    assert json.dumps(sec)  # fixture kept readable
+
+
+def test_sec_cik_is_not_double_prefixed(monkeypatch):
+    """`lookup_cik` already returns `CIK##########`; prefixing again 404s."""
+    seen = {}
+
+    class FakeFilings:
+        @staticmethod
+        def lookup_cik(ticker):
+            return "CIK0001045810"
+
+        @staticmethod
+        def _load_user_agent():
+            return "clawock test agent"
+
+    monkeypatch.setitem(__import__("sys").modules, "fetch_us_filings", FakeFilings)
+
+    def http(url, headers=None, timeout=None):
+        seen["url"] = url
+        return {"filings": {"recent": {"form": [], "acceptanceDateTime": [],
+                                       "primaryDocDescription": []}}}
+
+    mn._sec_items("NVDA", now=NOW, window=240, http=http)
+    assert seen["url"] == "https://data.sec.gov/submissions/CIK0001045810.json"
+    assert "CIKCIK" not in seen["url"]
+
+
+# --- silence and failure are stated ------------------------------------------
+
+def test_no_items_reads_no_recent_filing_rather_than_an_empty_block():
+    result = mn.probe(["00100"], market="hk", now=NOW,
+                      http=fake_http({"appstock/news": tencent_payload([])}))
+    entry = result["tickers"]["00100"]
+    assert entry["status"] == "no_recent_filing"
+    assert entry["items"] == []
+
+
+def test_a_dead_endpoint_degrades_with_a_reason_and_never_raises():
+    result = mn.probe(["00100"], market="hk", now=NOW,
+                      http=fake_http({"appstock/news": OSError("connection reset")}))
+    entry = result["tickers"]["00100"]
+    assert entry["status"] == "degraded"
+    assert any("OSError" in note for note in entry["notes"])
+
+
+def test_a_garbage_payload_is_survived():
+    for payload in ({}, {"data": None}, {"data": {"data": "nope"}}, []):
+        result = mn.probe(["00100"], market="hk", now=NOW,
+                          http=fake_http({"appstock/news": payload}))
+        assert result["tickers"]["00100"]["status"] in {"no_recent_filing", "degraded"}
+
+
+def test_market_flashes_only_survive_when_they_name_a_holding(monkeypatch):
+    monkeypatch.undo()
+    monkeypatch.setattr(mn, "holding_names", lambda tickers: {"00100": "MINIMAX-W"})
+    fake_rows = [
+        {"title": "MINIMAX-W 港股异动拉升", "date": "2026-07-24 13:40:00"},
+        {"title": "某地暴雨预警升级", "date": "2026-07-24 13:41:00"},
+    ]
+    monkeypatch.setitem(
+        __import__("sys").modules, "fetch_em_news",
+        type("M", (), {"em_fast_news": staticmethod(lambda limit=20: fake_rows)}),
+    )
+    result = mn.probe(["00100"], market="hk", now=NOW,
+                      http=fake_http({"appstock/news": tencent_payload([])}))
+    flashes = result["market_flashes"]
+    assert [f["title"] for f in flashes] == ["MINIMAX-W 港股异动拉升"]
+    assert flashes[0]["tier"] == mn.SUPPORTING
+    assert flashes[0]["matched"] == ["MINIMAX-W"]
+
+
+def test_symbol_mapping_covers_both_markets():
+    assert mn.tencent_symbol("00100", "hk") == "hk00100"
+    assert mn.tencent_symbol("2208", "hk") == "hk02208"
+    assert mn.tencent_symbol("nvda", "us") == "usNVDA"
+    assert mn.tencent_symbol("", "hk") is None
+
+
+# --- the consumers -----------------------------------------------------------
+
+def test_both_preflights_probe_only_the_flagged_names():
+    for name in ("intraday_preflight.py", "report_preflight.py"):
+        source = (ROOT / "scripts" / "harness" / name).read_text()
+        assert "import mover_news" in source, name
+        assert "mover_news.probe(" in source, name
+        assert "[a['ticker'] for a in anomalies]" in source, name
+        assert "'mover_news'" in source, name
+
+
+def test_both_skills_bound_how_the_block_may_be_used():
+    for name in ("us-stock-analysis", "hk-stock-analysis"):
+        skill = (ROOT / "skills" / name / "SKILL.md").read_text()
+        assert "mover_news" in skill, name
+        assert "no_recent_filing" in skill, name
+        assert "primary" in skill and "supporting" in skill, name
+        # Tavily must stay out of the intraday catalyst path
+        assert "禁止 Tavily" in skill or "禁止Tavily" in skill, name
+
+
+def test_tavily_is_never_called_from_this_module():
+    source = (ROOT / "scripts" / "data" / "mover_news.py").read_text().lower()
+    assert "tavily" not in source.replace("禁止 tavily", "")


### PR DESCRIPTION
Implements #90 with the two channels you picked, plus the HK answer that issue left open.

## Channels, chosen on measured freshness

| Channel | Measured | Role |
|---|---|---|
| SEC EDGAR `submissions` | `acceptanceDateTime` to the second | **US primary** |
| Tencent exchange feed (`type=0`) | HKEX announcements to the second (`2026-07-16 19:36:43 根据一般授权完成配售…`) | **HK primary** — this answers the "needs an endpoint probe" question in #90; it also relays SEC forms for US names |
| Tencent research/media (`type=1`) | minute precision for news, day-level for broker notes | supporting |
| Eastmoney 7×24 flashes | minute precision, market-wide | supporting, kept only when the headline names a holding |
| Yahoo RSS | **HTTP 429** from this host | rejected |
| Eastmoney per-stock search | **day granularity** | rejected for intraday |
| `news_evidence_graph.json` | rebuilt daily | rejected — stale by construction |
| Tavily | seconds | excluded by budget policy; a test asserts this module never calls it |

So Tencent turned out to cover **both** markets for filings, which is why the HK leg needed no new vendor.

## On rate limits at a 30-minute cadence

Worst case per slot: `MAX_MOVERS` (4) tickers × 2 endpoints + one shared flash call. SEC documents 10 req/s (this repo throttles to 8) and the Tencent hosts are already called every slot by the analyze scripts, so the cadence is nowhere near any published limit. The real risks are shape changes and timeouts, so every path fails soft with a stated reason rather than retrying.

## Keeping the context worth its space

You asked not to stuff the context with things that go unused, so the block is capped in code: ≤3 items per ticker, 90-character titles, ≤3 flashes, and nothing at all when nothing moved. Both stock skills now require the model to attribute the move or say explicitly that it cannot, and forbid pasting the block into the report — at most one or two headlines with their timestamps. `status: no_recent_filing` is an explicit statement of silence, so an empty block cannot be read as "no news", and one built-in web search is allowed as a last resort when a big move has no primary filing (never Tavily).

## Validation

- `833 passed, 5 xfailed`; 16 new tests, all offline through the module's single HTTP seam — a test that needed the network would be useless exactly when endpoints misbehave.
- Mutation-verified: removing the mover cap, the item cap, the freshness window, the primary-over-supporting ordering, the fail-soft handler, the explicit `no_recent_filing`, and the SEC/Tencent de-duplication each turn the matching test red.
- Live smoke against the real endpoints: 2–4s for 2–3 movers, both markets.
- That live run caught a real bug in this module: `lookup_cik` already returns `CIK##########`, so prefixing again produced `CIKCIK…` and quietly 404'd every US mover. Fixed, with a test pinning the URL shape.

Closes #90