### PR TITLE
feat: put anomaly attribution into the report and size the block by class

### DIFF
--- a/scripts/data/mover_news.py
+++ b/scripts/data/mover_news.py
@@ -45,8 +45,16 @@ sys.path.insert(0, str(WS / "scripts" / "data"))
 
 HKT = timezone(timedelta(hours=8))
 MAX_MOVERS = 4
-MAX_ITEMS_PER_TICKER = 3
+# Room is allocated by class, not evenly: an interrupt is what actually gets
+# written into the report, so it gets the slots and the characters. A context item
+# is background and keeps one slot. Titles are the payload — a HK placement notice
+# truncated at 90 characters ("…完成配售35,600,000股新A类股份；(2) 根据一般授权完成发行6,500百万…")
+# loses the number that made it matter.
+MAX_INTERRUPT_ITEMS = 3
+MAX_CONTEXT_ITEMS = 1
+MAX_ITEMS_PER_TICKER = MAX_INTERRUPT_ITEMS + MAX_CONTEXT_ITEMS
 MAX_FLASHES = 3
+INTERRUPT_TITLE_CHARS = 160
 TITLE_CHARS = 90
 WINDOW_MINUTES = 240
 PER_REQUEST_TIMEOUT_S = 5
@@ -83,9 +91,9 @@ def _http_text(url: str, *, timeout=PER_REQUEST_TIMEOUT_S) -> str:
         return response.read().decode("utf-8", "ignore")
 
 
-def _truncate(text) -> str:
+def _truncate(text, limit=TITLE_CHARS) -> str:
     text = re.sub(r"\s+", " ", str(text or "")).strip()
-    return text if len(text) <= TITLE_CHARS else text[: TITLE_CHARS - 1] + "…"
+    return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
 def _age_minutes(when: datetime, now: datetime) -> int:
@@ -134,6 +142,7 @@ def _tencent_items(symbol, feed_type, tier, source_class, *, now, window, http):
             "published_at": when.isoformat(),
             "age_minutes": age,
             "title": _truncate(row.get("title")),
+            "raw_title": str(row.get("title") or ""),
             "tier": tier,
             "source_class": source_class,
             "url": row.get("url") or None,
@@ -171,6 +180,7 @@ def _sec_items(ticker, *, now, window, http):
             "published_at": when.isoformat(),
             "age_minutes": age,
             "title": _truncate(f"{form} {description}".strip()),
+            "raw_title": f"{form} {description}".strip(),
             "tier": PRIMARY,
             "source_class": "sec_filing",
             "url": None,
@@ -405,19 +415,26 @@ def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
             if note:
                 entry["notes"].append(f"{label}: {note}")
             entry["items"].extend(items)
-        kept, suppressed = [], 0
+        interrupts, context_items, suppressed = [], [], 0
         for item in entry["items"]:
             signal, rule = classify(item["title"], market)
             if signal == NOISE:
                 suppressed += 1
                 continue
             item["signal"], item["triage_rule"] = signal, rule
-            kept.append(item)
-        # interrupt first, then context, each newest first
-        kept.sort(key=lambda row: (
-            row["signal"] != INTERRUPT, row["tier"] != PRIMARY, row["age_minutes"]
-        ))
-        entry["items"] = kept[:MAX_ITEMS_PER_TICKER]
+            if signal == INTERRUPT:
+                # re-truncate at the wider limit: this one goes in the report
+                item["title"] = _truncate(item.get("raw_title") or item["title"],
+                                          INTERRUPT_TITLE_CHARS)
+                interrupts.append(item)
+            else:
+                context_items.append(item)
+        for bucket in (interrupts, context_items):
+            bucket.sort(key=lambda row: (row["tier"] != PRIMARY, row["age_minutes"]))
+        entry["items"] = (interrupts[:MAX_INTERRUPT_ITEMS]
+                          + context_items[:MAX_CONTEXT_ITEMS])
+        if len(interrupts) > MAX_INTERRUPT_ITEMS:
+            entry["more_interrupts"] = len(interrupts) - MAX_INTERRUPT_ITEMS
         if suppressed:
             entry["suppressed_noise"] = suppressed
         if entry["items"]:
@@ -432,8 +449,13 @@ def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
     )
     halt_symbols = []
     if market == "us":
+        # A halt is a low-probability event for large caps, so this is not worth a
+        # request on every slot. The exception is the leveraged sleeve: a 2x
+        # single-stock ETF gets LULD-paused when its underlying gaps, which is the
+        # only realistic halt path in this book. Ask only then.
         halt_symbols = sorted({
             symbol for ticker in chased
+            if (results.get(ticker, {}).get("target") or {}).get("kind") == "look_through"
             for symbol in (ticker, (results.get(ticker, {}).get("target") or {}).get("issuer"))
             if symbol
         })

--- a/skills/_shared/intraday-status-sidecar.md
+++ b/skills/_shared/intraday-status-sidecar.md
@@ -14,5 +14,6 @@
 }
 ```
 - `movers` 覆盖 context 里 `anomalies` / today_movers 的**每个**票；**杠杆 ETF 要点明"杠杆放大"、区分标的真涨还是纯 beta**（本市场杠杆 ticker 见调用方 Step 2.5）。
+- **催化优先引 `context.mover_news`**：该票有 `signal=interrupt` 的条目就用它的标题要点 + `age_minutes` 写归因；`halts` 命中先写停牌；`no_recent_filing` / `index_fund_no_issuer` / `degraded` 各自照实说（分别是「无一手公告」「指数基金无发行人」「催化源未取到」）。
 - **只用 context.json 的真实数字**；不确定催化就写"无明确个股催化，纯 beta"，**不编造财报/新闻**。
 - HK / US 两个 intraday 共写这**同一个** per-date 文件，build_dashboard 取最新 mtime（当前在盘的市场覆盖横幅）。

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -105,6 +105,13 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - **`📉 亏损持仓 X/Y | 2x杠杆敞口 N%` 必须保留**，不要省
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提到 `anomalies` 里至少一个票
+  - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
+    「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
+    - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。
+    - 只有 `context` 没有 `interrupt` → 写「无一手催化，{context 标题}仅作背景」。
+    - `status=no_recent_filing` → 直接写「窗口内无一手公告，暂无法归因」，**不许改口编一个理由**；`index_fund_no_issuer` → 写「指数基金无发行人公告，看成分/板块」。
+    - `status=degraded` → 写「催化源未取到」，别把它说成「没有消息」。
+    - 引用**至多两条**、每条一行；`suppressed_noise` / `more_interrupts` 只是计数，不要写进报告。
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号）
   - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给板块今日 Top 5 + 你持仓在榜单里的位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`——盘中每 30 分钟的常规盯盘**不要**烧 Tavily（免费档 1000/月全局共享）
   - 禁止"无异动，观望"这种敷衍 1 句话

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -106,6 +106,13 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - **`📉 亏损持仓 X/Y | 杠杆ETF敞口 N%` 必须保留**，不要省
 - 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提 `anomalies` 中至少一个票
+  - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
+    「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
+    - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。
+    - 只有 `context` 没有 `interrupt` → 写「无一手催化，{context 标题}仅作背景」。
+    - `status=no_recent_filing` → 直接写「窗口内无一手公告，暂无法归因」，**不许改口编一个理由**；`index_fund_no_issuer` → 写「指数基金无发行人公告，看成分/板块」。
+    - `status=degraded` → 写「催化源未取到」，别把它说成「没有消息」。
+    - 引用**至多两条**、每条一行；`suppressed_noise` / `more_interrupts` 只是计数，不要写进报告。
   - 必须包含：今天该看/该等/该减 + 引用至少 1 个具体数字（票现价 / 异动幅度 / 信号 / RSI）
   - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给对应主题成分今日 Top 5 + 你持仓位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`（见 Mode 5 的 Budget rule）——盘中每 30 分钟的常规盯盘**不要**烧 Tavily
   - 禁止"无异动，观望"这种敷衍 1 句话

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -66,14 +66,33 @@ def test_only_the_first_few_movers_are_chased():
     assert result["not_chased"] == ["07226"]
 
 
-def test_items_are_capped_and_titles_truncated():
-    long_title = "港交所公告：" + "细节" * 200
+def test_context_items_keep_one_narrow_slot():
+    long_title = "港交所公告：" + "细节" * 200            # unmatched -> context
     rows = [row(f"{long_title} {i}", f"2026-07-24 13:5{i}:00") for i in range(6)]
     result = mn.probe(["00100"], market="hk", now=NOW,
                       http=fake_http({"appstock/news": tencent_payload(rows)}))
     items = result["tickers"]["00100"]["items"]
-    assert len(items) == mn.MAX_ITEMS_PER_TICKER
+    assert len(items) == mn.MAX_CONTEXT_ITEMS
     assert all(len(item["title"]) <= mn.TITLE_CHARS for item in items)
+
+
+def test_interrupts_get_the_slots_and_the_characters():
+    long_notice = ("(1) 根据一般授权完成配售35,600,000股新A类股份；"
+                   "(2) 根据一般授权完成发行6,500百万港元于2027年到期的可转换债券，"
+                   "所得款项净额约为62亿港元，将用于模型训练算力采购与一般营运资金")
+    rows = [row(f"{long_notice}{i}", f"2026-07-24 13:5{i}:00") for i in range(5)]
+    rows.append(row("董事会会议召开日期", "2026-07-24 13:59:00"))
+    def http(url, headers=None, timeout=None):
+        return tencent_payload(rows if "type=0" in url else [])
+
+    entry = mn.probe(["00100"], market="hk", now=NOW, http=http)["tickers"]["00100"]
+    signals = [item["signal"] for item in entry["items"]]
+    assert signals == [mn.INTERRUPT] * mn.MAX_INTERRUPT_ITEMS + [mn.CONTEXT]
+    assert entry["more_interrupts"] == 2
+    # the placement number survives, which is the whole point of the wider limit
+    kept = entry["items"][0]["title"]
+    assert "35,600,000" in kept and "6,500百万" in kept
+    assert mn.TITLE_CHARS < len(kept) <= mn.INTERRUPT_TITLE_CHARS
 
 
 def test_the_time_budget_stops_further_calls():
@@ -375,6 +394,22 @@ HALT_FEED = """<rss><channel>
 </channel></rss>"""
 
 
+def test_halts_are_only_asked_for_when_a_leveraged_fund_moved():
+    """A large-cap halt is too rare to spend a request on every slot."""
+    calls = []
+    def text(url, timeout=None):
+        calls.append(url)
+        return HALT_FEED
+
+    mn.probe(["CRCL"], market="us", now=NOW,
+             http=fake_http({"appstock/news": tencent_payload([])}), http_text=text)
+    assert calls == []                       # issuer-only mover: no halt request
+
+    mn.probe(["PLTU"], market="us", now=NOW,
+             http=fake_http({"appstock/news": tencent_payload([])}), http_text=text)
+    assert len(calls) == 1                   # 2x single-stock ETF: worth asking
+
+
 def test_a_halt_on_a_held_leveraged_etf_surfaces_with_its_reason_code():
     result = mn.halts(["PLTU", "CRCL"], now=NOW, window=240,
                       http_text=lambda url, timeout=None: HALT_FEED)
@@ -418,3 +453,25 @@ def test_hk_slots_do_not_call_the_us_halt_feed():
              http=fake_http({"appstock/news": tencent_payload([])}),
              http_text=lambda url, timeout=None: calls.append(url) or HALT_FEED)
     assert calls == []
+
+
+# --- the report actually consumes it -----------------------------------------
+
+def test_mode_7_requires_attribution_in_the_view_section():
+    for name in ("us-stock-analysis", "hk-stock-analysis"):
+        skill = (ROOT / "skills" / name / "SKILL.md").read_text()
+        view = skill.split("▎我的看法", 1)[1].split("#### Step 2.5", 1)[0]
+        assert "异动归因" in view, name
+        assert "signal=interrupt" in view, name
+        # every honest-failure state has a prescribed sentence
+        for state in ("no_recent_filing", "index_fund_no_issuer", "degraded"):
+            assert state in view, (name, state)
+        # counters stay out of the report
+        assert "suppressed_noise" in view and "不要写进报告" in view, name
+
+
+def test_the_movers_sidecar_quotes_the_same_evidence():
+    spec = (ROOT / "skills" / "_shared" / "intraday-status-sidecar.md").read_text()
+    assert "mover_news" in spec
+    assert "signal=interrupt" in spec
+    assert "no_recent_filing" in spec


### PR DESCRIPTION
The catalyst evidence was reaching the context but the skill was told to be sparing with it, so a flagged move could still be reported without saying what caused it. Now it has to land in `▎我的看法`.

## Into the report

When `should_alert` is true, one attribution line per flagged name:

> `{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）`

capped at three lines, at most two quoted items. Every honest-failure state gets a prescribed sentence rather than improvisation:

| State | What the report must say |
|---|---|
| `no_recent_filing` | 窗口内无一手公告，暂无法归因 — explicitly *not* a made-up reason |
| `index_fund_no_issuer` | 指数基金无发行人公告，看成分/板块 |
| `degraded` | 催化源未取到 — never phrased as "没有消息" |
| a halt on the name | written **first**; it explains a jump better than any headline |

`suppressed_noise` and `more_interrupts` are counters and stay out of the prose. The shared movers sidecar now quotes the same evidence, so the dashboard banner and the WeChat report cannot disagree about why something moved.

## Sizing by class, not a flat cap

You asked to revisit the limits. They are now allocated by what actually gets written:

- **interrupt**: 3 slots, 160 characters
- **context**: 1 slot, 90 characters
- overflow surfaces as `more_interrupts` instead of vanishing

The reason is concrete: 00100's placement notice was being cut at 90 characters right where the substance was. It now arrives whole —

> `(1) 根据一般授权完成配售35,600,000股新A类股份；(2) 根据一般授权完成发行6,500百万港元于2027年到期之零息有担保可转换债券`

— share count and amount intact, at 73 characters. The report budget is unchanged (2200 target / 3000 warn / 3500 fail) because attribution is one line per mover.

## Halts, narrowed per your call

A large-cap halt is too rare to spend a request on every slot, so the feed is now consulted **only when a leveraged fund moved** — the 2x single-stock ETFs that get LULD-paused when their underlying gaps, which is the only realistic halt path in this book. An issuer-only mover like CRCL makes zero halt requests; PLTU still makes one.

## Validation

- `880 passed, 5 xfailed`; new tests cover class-based slots, the wider interrupt title, the narrowed halt trigger, and that both skills plus the sidecar actually demand attribution.
- Mutation-verified: shrinking the interrupt title limit, flattening the class slots, asking for halts on every US mover, and softening the skill's attribution requirement each turn the matching test red.
- Live: 00100/02208 in 1.16s, 2 noise items suppressed each, `halts: not_checked` because neither is leveraged.

Refs #93