### PR TITLE
feat: make the open/mid/pm/close reports attribute their anomalies too

### DIFF
--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -160,7 +160,14 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market h
 
 **你不写数据块、不写表格、不写标题** —— postflight 自己从 context 拼。2026-07-24 之前是让模型 verbatim 拷贝数据块，结果模型读错 context 就把一天前的数字发了出去；现在那条回路已经拆掉，数字在发送时刻直接取自 context 文件。
 
-用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan`（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan` / `mover_news`（异动票的一手催化）/ `mover_thesis`（异动票的 thesis 与红线）（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+
+▎情绪面 里的**异动归因**（`anomalies` 非空时必写，最多 2 行，写在该段最前）：
+- 每只异动票一行：「{票} {幅度}% ← {mover_news 里 signal=interrupt 的标题要点}（{age_minutes} 分钟前 / {source_class}）」。
+- `halts` 命中该票 → 先写停牌（`reason_code` + 复牌时间）。
+- `mover_thesis` 里该票有 `triggered`/`watch` 红线 → 追一句「触及红线：{required_action}」——**这是归因语境，不是操作许可**，能不能动手仍由 catalyst-gate 与风控契约决定。
+- 没有 interrupt：`no_recent_filing` 写「窗口内无一手公告，暂无法归因」；`index_fund_no_issuer` 写「指数基金无发行人公告，看成分/板块」；`degraded` 写「催化源未取到」（**不等于「没有消息」**）。一律不许编理由。
+- 空间不够时**先砍板块全景的细节，不砍归因**——一次异动没解释，比少列两个同业更贵。
 
 写这几段，**存成 `memory/.tmp/report-prose-hk-{phase}.md`**：
 ```

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -162,7 +162,14 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market u
 
 **你不写数据块、不写表格、不写标题** —— postflight 自己从 context 拼。2026-07-24 之前是让模型 verbatim 拷贝数据块，结果模型读错 context 就把一天前的数字发了出去；现在那条回路已经拆掉，数字在发送时刻直接取自 context 文件。
 
-用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan`（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+用 stdout 里的字段：`signal_count` / `anomalies` / `index_direction` / `needs_risk_section` / `peer_scan` / `mover_news`（异动票的一手催化）/ `mover_thesis`（异动票的 thesis 与红线）（板块 + 同业 Top 5 今日/5日涨跌 + 背离信号，板块全景段直接用它）；`raw_wechat_block` 是给你参考数字用的，**不要抄进散文**。
+
+▎情绪面 里的**异动归因**（`anomalies` 非空时必写，最多 2 行，写在该段最前）：
+- 每只异动票一行：「{票} {幅度}% ← {mover_news 里 signal=interrupt 的标题要点}（{age_minutes} 分钟前 / {source_class}）」。
+- `halts` 命中该票 → 先写停牌（`reason_code` + 复牌时间）。
+- `mover_thesis` 里该票有 `triggered`/`watch` 红线 → 追一句「触及红线：{required_action}」——**这是归因语境，不是操作许可**，能不能动手仍由 catalyst-gate 与风控契约决定。
+- 没有 interrupt：`no_recent_filing` 写「窗口内无一手公告，暂无法归因」；`index_fund_no_issuer` 写「指数基金无发行人公告，看成分/板块」；`degraded` 写「催化源未取到」（**不等于「没有消息」**）。一律不许编理由。
+- 空间不够时**先砍板块全景的细节，不砍归因**——一次异动没解释，比少列两个同业更贵。
 
 写这几段，**存成 `memory/.tmp/report-prose-us-{phase}.md`**：
 ```

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -475,3 +475,50 @@ def test_the_movers_sidecar_quotes_the_same_evidence():
     assert "mover_news" in spec
     assert "signal=interrupt" in spec
     assert "no_recent_filing" in spec
+
+
+# --- Mode 6 (open / mid / pm / close, both markets) consumes it too ----------
+
+def _mode_6_prose_section(skill_name):
+    skill = (ROOT / "skills" / skill_name / "SKILL.md").read_text()
+    return skill.split("#### Step 2: 只写分析散文", 1)[1].split("#### Step 3", 1)[0]
+
+
+@pytest.mark.parametrize("skill_name", ["us-stock-analysis", "hk-stock-analysis"])
+def test_mode_6_reports_must_attribute_their_anomalies(skill_name):
+    """Six reports a day (HK open/mid/pm/close, US open/close) had the catalyst
+    context and no instruction to use it — dead context in the reports that
+    matter most."""
+    prose = _mode_6_prose_section(skill_name)
+    assert "mover_news" in prose
+    assert "异动归因" in prose
+    assert "signal=interrupt" in prose
+    for state in ("no_recent_filing", "index_fund_no_issuer", "degraded"):
+        assert state in prose, state
+    # a red line is context for the move, never permission to act
+    assert "mover_thesis" in prose and "catalyst-gate" in prose
+    # and when space runs out, the attribution is not what gets cut
+    assert "先砍板块全景" in prose
+
+
+def test_report_length_limits_are_unchanged_and_still_match_the_payload_contract():
+    """Attribution is ~1 line per mover; the measured worst case (a US close body
+    at 2898 chars) still clears the 3000 soft warn, and the numbers are pinned in
+    nine live cron payloads. Raising them is a live-payload migration, not a code
+    edit, so it is deliberately not done here."""
+    import json
+    import sys
+
+    sys.path.insert(0, str(ROOT / "scripts" / "harness"))
+    import report_postflight
+
+    assert report_postflight.CHAR_LIMITS == {
+        "hk": {"soft": 3000, "hard": 3500},
+        "us": {"soft": 3000, "hard": 3500},
+    }
+    contract = json.loads((ROOT / "config" / "cron-schedules.json").read_text())
+    for profile in ("report", "intraday"):
+        required = contract["payload_profiles"][profile]["required_substrings"]
+        assert "目标 ≤ 2200 字" in required
+        assert ">3000 字 warn" in required
+        assert ">3500 字 fail" in required


### PR DESCRIPTION
Answers both halves of your question.

## Coverage: yes both markets, and now every scheduled report

| Path | Cadence | Attribution |
|---|---|---|
| HK intraday | `*/30 10-11,14-15` HKT | since #95 |
| US intraday | `*/30 0-2` HKT (overnight) | since #95 |
| HK open / **midday** / afternoon / close | 09:30 / 12:00 / 13:30 / 16:00 | **this PR** |
| US open / close | — | **this PR** |

The HK lunch break is already covered by two jobs: 午盘报告 at 12:00 and 午后快报 at 13:30. Both are Mode 6, so both pick this up.

Mode 7 got attribution in #95, but those six scheduled reports already carried `mover_news` and `mover_thesis` in their context with no instruction to use them — dead context in the reports that matter most. Now the Mode 6 prose step requires an attribution line per anomaly at the top of `▎情绪面`, capped at two lines, with the same prescribed sentences for `no_recent_filing` / `index_fund_no_issuer` / `degraded`. A halt is written first; a `triggered`/`watch` red line adds one clause, explicitly marked as context rather than permission to act.

There is also an explicit priority when space is tight: **cut the sector-panorama detail, not the attribution.** An unexplained move costs more than two fewer peers.

## On raising the limits — measured answer: no, and here is why

I checked the real reports before deciding:

- largest recent full report: **2898 chars** (US close body) against a **3000 soft warn**;
- the soft cap only annotates, it never blocks delivery; the hard cap is 3500;
- attribution is ~1 line per mover, so a heavy US close might occasionally cross into a warn — not a failure.

And the cost side is not just a constant: `目标 ≤ 2200 字` / `>3000 字 warn` / `>3500 字 fail` are pinned as `required_substrings` in the tracked cron contract **and appear verbatim in nine live cron payloads**. Raising them means editing nine live payloads first, then the contract, then the postflights, then the skills — a live-payload migration for what is currently an occasional warn. Not worth it now.

So instead of raising the ceiling, this PR sets what gets cut when the ceiling is near. A new test records the decision and fails if the limits ever drift away from the payload contract.

## Validation

- `883 passed, 5 xfailed`; new tests assert both skills' Mode 6 sections demand attribution, name every honest-failure state, keep the red line non-actionable, and preserve the cut-order.
- Mutation-verified: removing the Mode 6 requirement, dropping the cut-order line, and silently raising the limits without the payload migration each turn the matching test red.

Refs #93