### PR TITLE
fix: track earnings for the companies behind the funds we hold

### DIFF
--- a/scripts/data/fetch_catalysts.py
+++ b/scripts/data/fetch_catalysts.py
@@ -24,9 +24,11 @@ import json
 import os
 import sys
 from datetime import datetime, timezone, timedelta, date
+from pathlib import Path
 
 import requests
 
+import instrument_registry
 from instrument_registry import leveraged_symbols
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -37,10 +39,53 @@ UA = 'clawock-catalysts/1.0 (github.com/KCNyu/clawock)'
 HEADERS = {'User-Agent': UA}
 TIMEOUT = 10
 
-# Active US holdings (synced from portfolio.json on 2026-05-19)
-# Leveraged ETFs don't issue earnings — skip the Finnhub call for them.
-US_TICKERS_ACTIVE = ['RKLB', 'CRCL', 'PLTU', 'SOXL', 'RKLX', 'ROBN', 'MSFU']
+# Earnings tickers are derived from portfolio.json, never hand-synced. The old
+# hardcoded list was stamped 2026-05-19 and had drifted: it still named exited
+# positions and, worse, dropped every leveraged ETF without substituting the
+# company whose earnings actually gaps it. Holding MSFU with MSFT's report date
+# missing is the failure this exists to prevent.
 LEVERAGED_ETFS = leveraged_symbols()
+FALLBACK_US_TICKERS = ['CRCL', 'RKLB']   # only if portfolio.json cannot be read
+PORTFOLIO_FILE = Path(__file__).resolve().parents[2] / 'portfolio.json'
+
+
+def earnings_issuer(ticker):
+    """The company whose earnings moves this holding, or None if there is none.
+
+    A 2x single-stock ETF reports nothing; its underlying does. An index or sector
+    fund has no issuer at all and is skipped rather than queried.
+    """
+    seen = set()
+    current = str(ticker)
+    for _ in range(3):                       # SOXL -> SOXX -> SEMICONDUCTOR
+        meta = instrument_registry.get(current) or {}
+        underlying = meta.get('underlying')
+        if not underlying or underlying in seen:
+            break
+        seen.add(current)
+        current = str(underlying)
+    meta = instrument_registry.get(current)
+    if meta is None or meta.get('venue') == 'INDEX' or (meta or {}).get('underlying'):
+        return None
+    return current
+
+
+def us_earnings_tickers(portfolio=None):
+    """US names to query, looked through to the issuer that actually reports."""
+    if portfolio is None:
+        try:
+            portfolio = json.loads(PORTFOLIO_FILE.read_text())
+        except (OSError, ValueError):
+            return list(FALLBACK_US_TICKERS)
+    holdings = ((portfolio.get('portfolios') or {}).get('us_stocks') or {}).get('holdings') or []
+    out = []
+    for holding in holdings:
+        if (holding.get('shares') or 0) <= 0:
+            continue
+        issuer = earnings_issuer(holding.get('ticker'))
+        if issuer and issuer not in out:
+            out.append(issuer)
+    return sorted(out)
 
 # 2026 FOMC meeting dates (rate-decision second day)
 # Source: federalreserve.gov/monetarypolicy/fomccalendars.htm
@@ -127,9 +172,9 @@ def fetch_earnings(window_start, window_end):
     out_rows = []
     errors = {}
     queried = []
-    for ticker in US_TICKERS_ACTIVE:
+    for ticker in us_earnings_tickers():
         if ticker in LEVERAGED_ETFS:
-            continue  # leveraged ETFs don't have own earnings
+            continue  # a leveraged ETF reports nothing; look-through already ran
         queried.append(ticker)
         rows, err = fetch_earnings_for_ticker(ticker, window_start, window_end, api_key)
         if err:

--- a/scripts/data/research_surface.py
+++ b/scripts/data/research_surface.py
@@ -149,9 +149,33 @@ def review_window_days(catalysts) -> int:
     return min(window, MAX_REVIEW_WINDOW_DAYS)
 
 
+def earnings_issuers(positions) -> dict:
+    """Held ticker → the issuer whose earnings moves it.
+
+    A catalyst arrives under the company's name (MSFT), while the position is the
+    fund that tracks it (MSFU). Matching on the held ticker alone silently misses
+    every earnings review for the leveraged sleeve.
+    """
+    try:
+        import fetch_catalysts  # noqa: PLC0415
+
+        resolve = fetch_catalysts.earnings_issuer
+    except Exception:  # noqa: BLE001
+        return {position["ticker"]: position["ticker"] for position in positions}
+    out = {}
+    for position in positions:
+        ticker = position["ticker"]
+        issuer = resolve(ticker)
+        if issuer:
+            out[ticker] = issuer
+    return out
+
+
 def earnings_reviews_due(positions, catalysts, artifacts, today: date) -> list[dict]:
     """A reported earnings date with no artifact published after it."""
-    held = {position["ticker"] for position in positions}
+    issuers = earnings_issuers(positions)
+    held = set(issuers.values()) | {position["ticker"] for position in positions}
+    via = {issuer: ticker for ticker, issuer in issuers.items() if issuer != ticker}
     window = review_window_days(catalysts)
     due = []
     for event in (catalysts or {}).get("earnings") or []:
@@ -166,12 +190,15 @@ def earnings_reviews_due(positions, catalysts, artifacts, today: date) -> list[d
         ]
         if any(day and day >= reported for day in published):
             continue
-        due.append({
+        row = {
             "ticker": ticker,
             "reported_on": reported.isoformat(),
             "days_since": (today - reported).days,
             "reason": "earnings reported with no primary-source artifact covering it",
-        })
+        }
+        if ticker in via:
+            row["held_via"] = via[ticker]      # we hold the fund, it reports
+        due.append(row)
     return sorted(due, key=lambda row: (row["ticker"], row["reported_on"]))
 
 

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -483,3 +483,65 @@ def test_system_check_watches_the_calendar_horizon():
     assert "check_trading_calendar_horizon" in _registered_system_checks()
     # the table is hand-maintained, so the gate must escalate rather than assume
     assert "covers_current_year" in check and "covers_next_year" in check
+
+
+# --- earnings look-through: we hold the fund, the company reports -------------
+
+def test_catalyst_tickers_come_from_holdings_not_a_hand_synced_list():
+    import sys
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import fetch_catalysts
+
+    source = (ROOT / "scripts" / "data" / "fetch_catalysts.py").read_text()
+    assert "US_TICKERS_ACTIVE" not in source, "the hand-synced list is back"
+
+    book = {"portfolios": {"us_stocks": {"holdings": [
+        {"ticker": "MSFU", "shares": 20},     # 2x MSFT
+        {"ticker": "PLTU", "shares": 14},     # 2x PLTR
+        {"ticker": "CRCL", "shares": 2},      # reports itself
+        {"ticker": "SOXL", "shares": 5},      # sector fund: nobody reports
+        {"ticker": "TQQQ", "shares": 3},      # index fund: nobody reports
+        {"ticker": "RKLX", "shares": 0},      # closed position
+    ]}}}
+    assert fetch_catalysts.us_earnings_tickers(book) == ["CRCL", "MSFT", "PLTR"]
+
+
+@pytest.mark.parametrize("ticker,issuer", [
+    ("MSFU", "MSFT"), ("PLTU", "PLTR"), ("RKLX", "RKLB"), ("SPCH", "SPCX"),
+    ("CRCL", "CRCL"), ("SOXL", None), ("TQQQ", None), ("07226", None),
+])
+def test_earnings_issuer_resolution(ticker, issuer):
+    import sys
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import fetch_catalysts
+
+    assert fetch_catalysts.earnings_issuer(ticker) == issuer
+
+
+def test_a_report_by_a_tracked_company_marks_the_fund_position_due(dirs):
+    book = {"portfolios": {"us_stocks": {"holdings": [
+        {"ticker": "MSFU", "shares": 20,
+         "trades": [{"date": "2026-01-05", "action": "buy", "shares": 20, "price": 40}]},
+    ]}, "hk_stocks": {"holdings": []}}}
+    surface = rs.summarize(
+        portfolio=book,
+        catalysts={"lookback_window_days": 14,
+                   "earnings": [{"ticker": "MSFT", "date": "2026-07-29"}]},
+        today=date(2026, 7, 30), now=datetime(2026, 7, 30, tzinfo=timezone.utc), **dirs,
+    )
+    due = surface["earnings"]["reviews_due"]
+    assert [row["ticker"] for row in due] == ["MSFT"]
+    assert due[0]["held_via"] == "MSFU"
+
+
+def test_a_fund_with_no_issuer_never_becomes_due(dirs):
+    book = {"portfolios": {"us_stocks": {"holdings": [
+        {"ticker": "TQQQ", "shares": 10, "trades": []},
+    ]}, "hk_stocks": {"holdings": []}}}
+    surface = rs.summarize(
+        portfolio=book,
+        catalysts={"lookback_window_days": 14,
+                   "earnings": [{"ticker": "NASDAQ_100", "date": "2026-07-29"}]},
+        today=date(2026, 7, 30), now=datetime(2026, 7, 30, tzinfo=timezone.utc), **dirs,
+    )
+    assert surface["earnings"]["reviews_due"] == []


### PR DESCRIPTION
Found while reviewing the weekend's work against next week's calendar.

## The gap

**MSFT reports Wednesday 2026-07-29 (after close) and we hold MSFU, its 2x ETF — that date is not in `assets/data/catalysts.json`.**

`fetch_catalysts.py` used a hardcoded list, commented *"synced from portfolio.json on 2026-05-19"*:

```python
US_TICKERS_ACTIVE = ['RKLB', 'CRCL', 'PLTU', 'SOXL', 'RKLX', 'ROBN', 'MSFU']
...
if ticker in LEVERAGED_ETFS:
    continue  # leveraged ETFs don't have own earnings
```

The skip is correct — a 2x ETF reports nothing — but nothing substituted the company it tracks. So PLTU and MSFU were dropped entirely, and the list had also drifted from the book (SPCX and SKHY are held and were never added; SOXL and ROBN are no longer active).

Verified against Finnhub for the next three weeks:

| Company | Reports | We hold | On master? |
|---|---|---|---|
| MSFT | 2026-07-29 amc | MSFU (2x) | **missing** |
| PLTR | 2026-08-03 | PLTU (2x) | **missing** |
| SPCX | 2026-08-06 | SPCX + SPCH (2x) | **missing** |
| SKHY | none in window | SKHY | **not queried** |
| RKLB | 2026-08-05 | RKLX (2x) | present, by luck of being listed |
| CRCL | 2026-08-05 | CRCL | present |

## The fix

- the list is derived from `portfolio.json` and looked through the instrument registry: `MSFU→MSFT`, `PLTU→PLTR`, `RKLX→RKLB`, `SPCH→SPCX`; index and sector funds (`SOXL→SOXX→SEMICONDUCTOR`, `TQQQ→QQQ→NASDAQ_100`, `07226→HSTECH`) have no issuer and are skipped; closed positions drop out on their own;
- `research_surface`'s review detection looks through the same way, so a company's report marks the *fund* position due and records `held_via: MSFU` — otherwise the queue would silently never fire for the leveraged sleeve;
- an unreadable `portfolio.json` falls back to a small static list rather than querying nothing.

Queried set on the current book goes from `['RKLB','CRCL']` to `['CRCL','MSFT','PLTR','RKLB','SKHY','SPCX']`.

## Validation

- `895 passed, 5 xfailed`; new tests cover the resolution table, the derived list (including a closed position and two fund types), and both look-through paths in the review queue.
- Mutation-verified: removing look-through from the list, querying index funds anyway, and reverting the review-side matching each turn the matching test red.
- Ran the fetcher end to end in a worktree without `.api_keys`: it degrades per ticker with `no FINNHUB_API_KEY` and still writes a valid file — the fail-soft path works.

Monday's 08:00 brief refreshes `catalysts.json`, so MSFT's Wednesday date lands in the pre-open context automatically once this is on master.