### PR TITLE
ci: gate test coverage and publish the badge

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -139,11 +139,34 @@ jobs:
         # Pillow: validate_sidecars now fully-decodes screenshots/GIF (finding #12);
         # the real asset checks run in screenshot-refresh.yml (which has Pillow) but
         # the unit tests here exercise the same validators, so pytest needs it too.
-        run: pip install --quiet requests pytest numpy Pillow
+        run: pip install --quiet requests pytest pytest-cov numpy Pillow
 
       - name: Unit tests — money-integrity derivations
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
-        run: python3 -m pytest tests/ -q
+        run: |
+          python3 -m pytest tests/ -q \
+            --cov=scripts \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=json:coverage-report.json
+
+      - name: Coverage floors
+        # Fails the PR when coverage drops below its floors — the badge is only a
+        # readout, this is the part that holds. Runs on PRs too (not just the
+        # publish job) so a regression is caught before merge, not after.
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        run: python3 scripts/data/coverage_badge.py --report coverage-report.json --check-only
+
+      - name: Upload coverage report
+        # The suite is measured once, here. publish-coverage consumes this artifact
+        # instead of running the tests again, so the published badge is the same
+        # number this job gated on — not a second, independently drifting
+        # measurement. Only master pushes have a consumer; PR runs skip the upload.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report.json
+          retention-days: 1
 
       - name: Generated cron docs match contract
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
@@ -274,6 +297,51 @@ jobs:
           python3 scripts/data/build_dashboard.py
           python3 scripts/data/build_dashboard.py
           echo "OK: build_dashboard idempotent"
+
+  publish-coverage:
+    # Master only: the README badge must show what is on master, never a number
+    # from an unmerged branch. PRs still get the floor gate in `validate` above.
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # Serialize with the other commit-pushing workflows (job-scoped, so PR runs of
+    # `validate` are never queued behind a data-write job).
+    concurrency:
+      group: data-write
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      # No dependency install and no second test run: the suite was already
+      # measured in `validate`. Everything below is stdlib.
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+
+      - name: Coverage floors and badge payload
+        run: python3 scripts/data/coverage_badge.py --report coverage-report.json --out assets/data/coverage.json
+
+      - name: Validate coverage badge
+        # shields.io renders this file verbatim; a malformed payload would show up
+        # as an "invalid" badge on the README instead of failing anything.
+        run: python3 scripts/data/validate_sidecars.py coverage
+
+      - name: Commit
+        # Commits only the badge payload. assets/data/coverage.json is not in this
+        # workflow's `push:` paths, so publishing it cannot retrigger this job.
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          pct=$(python3 -c "import json; print(json.load(open('assets/data/coverage.json'))['message'])")
+          bash scripts/data/gha_commit_push.sh "coverage: $pct at $(git rev-parse --short HEAD)" assets/data/coverage.json
 
   smoke-data-fetch:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ env/
 venv/
 .venv
 
+# Coverage measurement artifacts. The shields badge payload
+# (assets/data/coverage.json) IS tracked — it is what the README renders.
+.coverage
+.coverage.*
+/coverage-report.json
+htmlcov/
+
 # Data cache / temp
 data_cache/
 *.cache

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A real Hong Kong + US stock portfolio, debated by multiple LLMs and graded by Py
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**简体中文**](README.zh.md)
@@ -141,6 +142,8 @@ The model submits decisions; it can never write or amend its own evaluation. Tha
 ## What the code enforces
 
 The model writes opinions. The arithmetic that could corrupt the record runs in Python and is unit-tested.
+
+That path is covered by a large unit-test suite — it's what keeps the system stable.
 
 | Rule | What the code does |
 |---|---|

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,7 @@
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**English**](README.md)
@@ -141,6 +142,8 @@ clawock 是一个持续运行的、公开的**纪律化、自评式** AI 投资�
 ## 代码强制执行的规矩
 
 模型只写观点。可能污染记录的算术都跑在 Python 里、有单元测试。
+
+这条链路由大量单元测试覆盖 —— 系统的稳定就靠它。
 
 | 规矩 | 代码做的事 |
 |---|---|

--- a/assets/data/coverage.json
+++ b/assets/data/coverage.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "COVERAGE",
+  "message": "54%",
+  "color": "738391"
+}

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Turn a coverage.py JSON report into the shields.io endpoint badge the READMEs
+point at — and fail the run when coverage drops below its floors.
+
+Why a floor and not just a badge: a published number nobody gates on only ever
+ratchets down, and the badge would then advertise the decay. The badge is the
+readout; `--min-total` / `--min-core` are the part that actually holds.
+
+Why two floors. One aggregate would hide the split that matters here. Roughly a
+fifth of `scripts/` is network fetchers (`fetch_*` / `analyze_*`) whose bodies are
+vendor HTTP and parsing; they are exercised end-to-end by the live crons, not by
+unit tests, and they drag the total down. The modules that settle money — the
+ledger, the graders, the risk caps, the registries — are held to a separate,
+higher floor so a regression there cannot be papered over by adding tests to a
+fetcher.
+
+The badge colour is a constant from the README palette, not a red/amber/green
+scale: this repo does not grade itself with a mood ring. A real drop shows up as
+a red CI run here, not as a slightly worse shade on the README.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# The settlement core: everything whose arithmetic can corrupt the public record.
+# Paths are repo-relative and must all be present in the report — see
+# _core_summary() for why a missing one is an error rather than a skip.
+CORE_MODULES = (
+    'scripts/data/decision_v2.py',
+    'scripts/data/entry_gate.py',
+    'scripts/data/thesis_registry.py',
+    'scripts/data/earnings_review.py',
+    'scripts/data/research_provenance.py',
+    'scripts/data/research_surface.py',
+    'scripts/data/preflight_integrity.py',
+    'scripts/data/risk_discipline.py',
+    'scripts/data/shadow_portfolio.py',
+    'scripts/data/instrument_registry.py',
+    'scripts/data/recompute_aggregates.py',
+    'scripts/data/recompute_realized.py',
+    'scripts/data/portfolio_risk_metrics.py',
+    'scripts/data/intraday_delta_gate.py',
+    'scripts/data/workflow_outcomes.py',
+    'scripts/data/safe_io.py',
+    'scripts/data/trading_calendar.py',
+)
+
+# Floors sit a couple of points under the measured value: enough headroom that a
+# legitimate refactor (deleting well-covered dead code raises statements' weight)
+# does not false-fail, small enough that a real regression reds the run. Raise
+# them deliberately when the suite grows; never lower one to make a PR pass.
+DEFAULT_MIN_TOTAL = 52.0
+DEFAULT_MIN_CORE = 75.0
+
+# A report that measured almost nothing (mis-scoped `--cov`, an import error that
+# aborted collection) can still be internally consistent and score well. Statement
+# count is the cheapest tripwire for "this run did not actually measure the tree".
+MIN_STATEMENTS = 12000
+
+BADGE_LABEL = 'COVERAGE'
+BADGE_COLOR = '738391'  # same muted tone as the TESTS badge in the READMEs
+
+
+def load_report(path: Path | str) -> dict:
+    """Read a coverage.py JSON report, failing loudly on anything unusable."""
+    path = Path(path)
+    if not path.is_file():
+        raise SystemExit(f'coverage report not found: {path}')
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        raise SystemExit(f'coverage report is not valid UTF-8: {path}') from None
+    if not raw.strip():
+        raise SystemExit(f'coverage report is empty: {path}')
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'coverage report is not valid JSON: {path}: {exc}') from None
+    if not isinstance(data, dict) or 'files' not in data or 'totals' not in data:
+        raise SystemExit(
+            f'{path}: not a coverage.py JSON report (expected "files" and "totals")')
+    if not isinstance(data['files'], dict) or not data['files']:
+        raise SystemExit(f'{path}: report covers no files at all')
+    return data
+
+
+def _percent(covered: int, statements: int) -> float:
+    # coverage.py reports 100% for an empty file set; here an empty set means the
+    # measurement failed, so refuse to invent a number.
+    if statements <= 0:
+        raise SystemExit('coverage report contains zero statements')
+    return 100.0 * covered / statements
+
+
+def total_summary(report: dict) -> tuple[int, int, float]:
+    totals = report['totals']
+    statements = int(totals.get('num_statements', 0))
+    covered = int(totals.get('covered_lines', 0))
+    if statements < MIN_STATEMENTS:
+        raise SystemExit(
+            f'coverage report only measured {statements} statements '
+            f'(expected >= {MIN_STATEMENTS}) — the run did not cover scripts/')
+    return covered, statements, _percent(covered, statements)
+
+
+def core_summary(report: dict, modules=CORE_MODULES) -> tuple[int, int, float]:
+    """Aggregate the settlement core.
+
+    A module listed here but absent from the report is an error, not a skip: the
+    silent-drop path is exactly how a renamed or deleted core module would quietly
+    leave the gate while the group percentage went *up*.
+    """
+    files = report['files']
+    missing = [m for m in modules if m not in files]
+    if missing:
+        raise SystemExit(
+            'settlement-core modules missing from the coverage report '
+            f'(renamed or deleted? update CORE_MODULES): {", ".join(missing)}')
+    statements = sum(int(files[m]['summary']['num_statements']) for m in modules)
+    covered = sum(int(files[m]['summary']['covered_lines']) for m in modules)
+    return covered, statements, _percent(covered, statements)
+
+
+def badge_payload(total_pct: float) -> dict:
+    """Strict shields.io endpoint schema — no extra keys.
+
+    Detail (core split, statement counts) deliberately stays out of the file:
+    shields fetches it directly and unknown fields are not part of the contract.
+    The numbers live in the commit message and the job log instead.
+    """
+    return {
+        'schemaVersion': 1,
+        'label': BADGE_LABEL,
+        'message': f'{total_pct:.0f}%',
+        'color': BADGE_COLOR,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description='Enforce coverage floors and write the shields endpoint badge.')
+    parser.add_argument('--report', default='coverage-report.json',
+                        help='coverage.py JSON report (coverage json -o ...)')
+    parser.add_argument('--out', default='assets/data/coverage.json',
+                        help='shields.io endpoint payload to write (omit with --check-only)')
+    parser.add_argument('--min-total', type=float, default=DEFAULT_MIN_TOTAL)
+    parser.add_argument('--min-core', type=float, default=DEFAULT_MIN_CORE)
+    parser.add_argument('--check-only', action='store_true',
+                        help='enforce the floors without writing the badge payload')
+    args = parser.parse_args(argv)
+
+    report = load_report(args.report)
+    total_covered, total_statements, total_pct = total_summary(report)
+    core_covered, core_statements, core_pct = core_summary(report)
+
+    print(f'total:           {total_pct:5.1f}%  '
+          f'({total_covered}/{total_statements} statements, floor {args.min_total}%)')
+    print(f'settlement core: {core_pct:5.1f}%  '
+          f'({core_covered}/{core_statements} statements, floor {args.min_core}%)')
+
+    failures = []
+    if total_pct < args.min_total:
+        failures.append(f'total coverage {total_pct:.1f}% is below its {args.min_total}% floor')
+    if core_pct < args.min_core:
+        failures.append(
+            f'settlement-core coverage {core_pct:.1f}% is below its {args.min_core}% floor')
+    if failures:
+        for line in failures:
+            print(f'::error::{line}', file=sys.stderr)
+        return 1
+
+    if args.check_only:
+        return 0
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(badge_payload(total_pct), indent=2) + '\n', encoding='utf-8')
+    print(f'wrote {out}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -621,6 +621,48 @@ def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
     print(f'validated {path}: {size} bytes, {width}x{height}, {frames} frames')
 
 
+def validate_coverage_badge(path: Path | str = 'assets/data/coverage.json') -> None:
+    """The README badge is rendered by shields.io straight from this file.
+
+    A malformed payload does not break the build — it silently renders as an
+    "invalid" badge on the front page, which is the exact failure this gate
+    exists to catch before the commit.
+    """
+    path = Path(path)
+    assert path.is_file(), f'coverage badge missing: {path}'
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        raise AssertionError('file is not valid UTF-8') from None
+    assert raw.strip(), 'file is empty'
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f'invalid JSON at line {exc.lineno} column {exc.colno}') from None
+    assert isinstance(data, dict), 'top-level JSON must be an object'
+
+    # Strict shields endpoint schema: extra keys are not part of the contract, so
+    # reject them here rather than discover the rendering failure on the README.
+    assert set(data) == {'schemaVersion', 'label', 'message', 'color'}, (
+        f'unexpected badge fields: {sorted(data)}')
+    assert data['schemaVersion'] == 1, f'unsupported schemaVersion {data["schemaVersion"]!r}'
+    label = data['label']
+    assert isinstance(label, str) and label.strip(), 'label missing'
+    color = data['color']
+    assert isinstance(color, str) and color.strip(), 'color missing'
+
+    message = data['message']
+    assert isinstance(message, str), 'message must be a string'
+    match = re.fullmatch(r'(\d{1,3})%', message)
+    assert match, f'message is not a percentage: {message!r}'
+    percent = int(match.group(1))
+    # 0% and 100% are both real signals that the measurement broke rather than
+    # results worth publishing (nothing instrumented / everything ignored).
+    assert 0 < percent < 100, f'implausible coverage percentage: {percent}%'
+    print(f'validated {path}: {label} {message}')
+
+
 def _dispatch(name: str) -> None:
     os.chdir(ROOT)
     if name == 'macro':
@@ -644,9 +686,12 @@ def _dispatch(name: str) -> None:
         ))
     elif name == 'gif':
         validate_gif('assets/dashboard.gif')
+    elif name == 'coverage':
+        validate_coverage_badge('assets/data/coverage.json')
     else:
         choices = ('macro', 'sentiment', 'influencer', 'news-digest',
-                   'eod-archive', 'weekly-review', 'screenshots', 'gif')
+                   'eod-archive', 'weekly-review', 'screenshots', 'gif',
+                   'coverage')
         raise SystemExit(f'unknown validator {name!r}; choose one of: {", ".join(choices)}')
 
 
@@ -669,6 +714,7 @@ def main(argv: list[str] | None = None) -> int:
             'weekly-review': 'weekly review',
             'screenshots': 'screenshots',
             'gif': 'GIF assets/dashboard.gif',
+            'coverage': 'coverage badge assets/data/coverage.json',
         }
         label = failure_labels.get(argv[0], argv[0])
         print(f'ASSERTION FAILED: {label}: {exc}', file=sys.stderr)

--- a/tests/test_coverage_badge.py
+++ b/tests/test_coverage_badge.py
@@ -1,0 +1,277 @@
+"""Contracts for the published coverage badge and the floors behind it.
+
+Two halves have to stay honest here: the generator must refuse to publish a
+number it did not really measure, and the workflow must run the floor gate on
+every PR rather than only on the master push that writes the badge.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from workflow_contract_helpers import (
+    assert_validator_step, step_block, step_run, steps, strip_hash_comments)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+
+import coverage_badge  # noqa: E402
+import validate_sidecars  # noqa: E402
+
+WORKFLOW = ROOT / '.github' / 'workflows' / 'harness-regression.yml'
+BADGE_PATH = 'assets/data/coverage.json'
+
+
+def _file_entry(statements, covered):
+    return {'summary': {'num_statements': statements, 'covered_lines': covered}}
+
+
+def _report(*, core_pct=90.0, filler_statements=14000, filler_pct=50.0):
+    """A synthetic coverage.py report: every core module plus one filler file.
+
+    Core modules each get the same size, so the group percentage is exactly
+    `core_pct` and a test can move one knob at a time.
+    """
+    per_core = 200
+    files = {
+        module: _file_entry(per_core, round(per_core * core_pct / 100))
+        for module in coverage_badge.CORE_MODULES
+    }
+    files['scripts/data/fetch_us_stocks.py'] = _file_entry(
+        filler_statements, round(filler_statements * filler_pct / 100))
+    statements = sum(f['summary']['num_statements'] for f in files.values())
+    covered = sum(f['summary']['covered_lines'] for f in files.values())
+    return {
+        'files': files,
+        'totals': {'num_statements': statements, 'covered_lines': covered},
+    }
+
+
+def _write_report(tmp_path, report):
+    path = tmp_path / 'coverage-report.json'
+    path.write_text(json.dumps(report), encoding='utf-8')
+    return path
+
+
+def _run(tmp_path, report, *extra):
+    out = tmp_path / 'coverage.json'
+    argv = ['--report', str(_write_report(tmp_path, report)), '--out', str(out), *extra]
+    return coverage_badge.main(argv), out
+
+
+# --- the number on the badge -------------------------------------------------
+
+def test_badge_reports_the_measured_total(tmp_path):
+    code, out = _run(tmp_path, _report(core_pct=90.0, filler_pct=50.0))
+    assert code == 0
+    payload = json.loads(out.read_text())
+    report = _report(core_pct=90.0, filler_pct=50.0)
+    expected = round(
+        100 * report['totals']['covered_lines'] / report['totals']['num_statements'])
+    assert payload['message'] == f'{expected}%'
+    assert payload['label'] == coverage_badge.BADGE_LABEL
+
+
+def test_generated_badge_passes_the_publish_validator(tmp_path):
+    """Generator and validator must not drift: what one writes, the other accepts."""
+    _, out = _run(tmp_path, _report())
+    validate_sidecars.validate_coverage_badge(out)
+
+
+def test_badge_payload_is_strict_shields_schema(tmp_path):
+    _, out = _run(tmp_path, _report())
+    assert set(json.loads(out.read_text())) == {
+        'schemaVersion', 'label', 'message', 'color'}
+
+
+# --- the floors --------------------------------------------------------------
+
+def test_total_below_floor_fails_and_writes_nothing(tmp_path):
+    # Core stays healthy; only the aggregate falls through the floor.
+    code, out = _run(tmp_path, _report(core_pct=90.0, filler_pct=20.0))
+    assert code == 1
+    assert not out.exists(), 'a failing run must not publish a badge'
+
+
+def test_core_below_floor_fails_even_when_the_total_passes(tmp_path):
+    # The whole point of the second floor: a well-covered fetch layer must not be
+    # able to hide a regression in the modules that settle money.
+    report = _report(core_pct=40.0, filler_pct=60.0)
+    covered, statements, total_pct = coverage_badge.total_summary(report)
+    assert total_pct >= coverage_badge.DEFAULT_MIN_TOTAL, 'fixture no longer isolates core'
+    code, out = _run(tmp_path, report)
+    assert code == 1
+    assert not out.exists()
+
+
+def test_check_only_enforces_floors_without_writing(tmp_path):
+    code, out = _run(tmp_path, _report(), '--check-only')
+    assert code == 0
+    assert not out.exists()
+
+
+def test_floors_are_not_silently_lowered():
+    # A PR that fails the gate must fix the tests, not the floor. Pin the values so
+    # lowering one is a visible, reviewed edit to this file.
+    assert coverage_badge.DEFAULT_MIN_TOTAL == 52.0
+    assert coverage_badge.DEFAULT_MIN_CORE == 75.0
+
+
+# --- reports that must not be trusted ----------------------------------------
+
+def test_missing_core_module_is_an_error_not_a_skip(tmp_path):
+    report = _report()
+    dropped = coverage_badge.CORE_MODULES[0]
+    del report['files'][dropped]
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, report)
+    assert dropped in str(excinfo.value)
+
+
+def test_undersized_report_is_rejected(tmp_path):
+    # A mis-scoped --cov measures a handful of statements and can score 100%.
+    report = _report(filler_statements=50, filler_pct=100.0)
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, report)
+    assert 'did not cover scripts/' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('content', ['', 'not json', '{}', '{"files": {}, "totals": {}}'])
+def test_unusable_report_is_rejected(tmp_path, content):
+    path = tmp_path / 'coverage-report.json'
+    path.write_text(content, encoding='utf-8')
+    with pytest.raises(SystemExit):
+        coverage_badge.main(['--report', str(path), '--out', str(tmp_path / 'b.json')])
+
+
+def test_absent_report_is_rejected(tmp_path):
+    with pytest.raises(SystemExit):
+        coverage_badge.main(['--report', str(tmp_path / 'nope.json'), '--check-only'])
+
+
+def test_core_modules_all_exist_on_disk():
+    missing = [m for m in coverage_badge.CORE_MODULES if not (ROOT / m).is_file()]
+    assert not missing, f'CORE_MODULES lists files that no longer exist: {missing}'
+
+
+# --- the validator that guards the published file ----------------------------
+
+@pytest.mark.parametrize('payload', [
+    {'schemaVersion': 1, 'label': 'COVERAGE', 'message': '54%', 'color': '738391',
+     'extra': 'x'},
+    {'schemaVersion': 2, 'label': 'COVERAGE', 'message': '54%', 'color': '738391'},
+    {'schemaVersion': 1, 'label': 'COVERAGE', 'message': 'unknown', 'color': '738391'},
+    {'schemaVersion': 1, 'label': 'COVERAGE', 'message': '0%', 'color': '738391'},
+    {'schemaVersion': 1, 'label': 'COVERAGE', 'message': '100%', 'color': '738391'},
+    {'schemaVersion': 1, 'label': '', 'message': '54%', 'color': '738391'},
+])
+def test_validator_rejects_unrenderable_badges(tmp_path, payload):
+    path = tmp_path / 'coverage.json'
+    path.write_text(json.dumps(payload), encoding='utf-8')
+    with pytest.raises(AssertionError):
+        validate_sidecars.validate_coverage_badge(path)
+
+
+def test_validator_rejects_missing_and_empty_file(tmp_path):
+    with pytest.raises(AssertionError):
+        validate_sidecars.validate_coverage_badge(tmp_path / 'absent.json')
+    empty = tmp_path / 'coverage.json'
+    empty.write_text('   ', encoding='utf-8')
+    with pytest.raises(AssertionError):
+        validate_sidecars.validate_coverage_badge(empty)
+
+
+# --- workflow contract -------------------------------------------------------
+
+def _names():
+    return [name for _, name in steps(WORKFLOW)]
+
+
+def test_pr_run_measures_coverage_and_gates_on_it():
+    names = _names()
+    assert names.index('Unit tests — money-integrity derivations') < names.index('Coverage floors')
+
+    test_run = step_run(WORKFLOW, 'Unit tests — money-integrity derivations')
+    assert '--cov=scripts' in test_run
+    assert '--cov-report=json:coverage-report.json' in test_run
+
+    floors = step_block(WORKFLOW, 'Coverage floors')
+    assert 'continue-on-error' not in floors
+    assert step_run(WORKFLOW, 'Coverage floors') == (
+        'python3 scripts/data/coverage_badge.py --report coverage-report.json --check-only')
+
+
+def test_the_coverage_plugin_is_installed_where_it_is_used():
+    # Without pytest-cov the --cov flags are an unknown-argument error, not a
+    # silent skip.
+    installs = [line for line in strip_hash_comments(WORKFLOW.read_text()).splitlines()
+                if 'pip install' in line and 'pytest' in line]
+    assert len(installs) == 1
+    assert 'pytest-cov' in installs[0]
+
+
+def _publish_job():
+    text = WORKFLOW.read_text()
+    return text.split('  publish-coverage:', 1)[1].split('\n  smoke-data-fetch:', 1)[0]
+
+
+def test_publish_job_is_master_push_only_and_needs_validate():
+    job = _publish_job()
+    assert 'needs: validate' in job
+    assert ("if: github.event_name == 'push' && github.ref == 'refs/heads/master'") in job
+    assert 'group: data-write' in job, 'publish must serialize with the other writers'
+
+
+def test_the_suite_is_measured_once_and_the_result_reused():
+    # The badge must be the number `validate` gated on. Re-running pytest in the
+    # publish job would both double the CI cost and let the published percentage
+    # drift from the one that passed the floor.
+    job = strip_hash_comments(_publish_job())  # comments may name pytest; steps may not
+    assert 'pytest' not in job, 'publish-coverage must not re-run the suite'
+    assert 'pip install' not in job
+    assert 'actions/download-artifact' in job
+
+    upload = step_block(WORKFLOW, 'Upload coverage report')
+    assert 'name: coverage-report' in upload
+    assert "if: github.event_name == 'push' && github.ref == 'refs/heads/master'" in upload
+    assert 'name: coverage-report' in job, 'publish downloads a differently named artifact'
+
+
+def test_publish_job_validates_then_commits_one_exact_path():
+    names = _names()
+    assert (names.index('Coverage floors') < names.index('Upload coverage report')
+            < names.index('Coverage floors and badge payload')
+            < names.index('Validate coverage badge')
+            < names.index('Commit'))
+
+    badge_step = step_block(WORKFLOW, 'Coverage floors and badge payload')
+    assert 'continue-on-error' not in badge_step
+    assert f'--out {BADGE_PATH}' in step_run(WORKFLOW, 'Coverage floors and badge payload')
+
+    assert_validator_step(WORKFLOW, 'Validate coverage badge', 'coverage')
+
+    commit_run = step_run(WORKFLOW, 'Commit')
+    publish = [line.strip() for line in commit_run.splitlines()
+               if line.strip().startswith('bash scripts/data/gha_commit_push.sh')]
+    assert len(publish) == 1
+    assert publish[0].endswith(f' {BADGE_PATH}')
+    assert 'assets/' not in publish[0].removesuffix(BADGE_PATH), 'commit more than the badge'
+
+
+def test_publishing_the_badge_cannot_retrigger_the_workflow():
+    # The push trigger lists paths one by one; if the badge were ever added there,
+    # every publish would start another run that publishes again.
+    trigger = WORKFLOW.read_text().split('on:', 1)[1].split('permissions:', 1)[0]
+    assert BADGE_PATH not in trigger
+
+
+def test_readmes_render_the_badge_from_the_published_file():
+    # Both languages, and via the endpoint URL — never a hard-coded percentage,
+    # which would be stale the next time the suite changes.
+    for name in ('README.md', 'README.zh.md'):
+        text = (ROOT / name).read_text(encoding='utf-8')
+        assert 'img.shields.io/endpoint' in text, f'{name} has no endpoint badge'
+        assert 'coverage.json' in text, f'{name} does not point at the badge payload'


### PR DESCRIPTION
The suite is large (900+ tests) but nothing measured or published how much of `scripts/` it actually reaches. This adds the measurement, a gate on it, and the README badge.

## What it does

- `validate` runs the existing suite under coverage.py (`--cov=scripts`) — same single run, no extra job.
- **Two floors**, enforced on every PR by `scripts/data/coverage_badge.py --check-only`:
  - total tree ≥ 52% (measured: **54.3%**)
  - settlement core ≥ 75% (measured: **77.0%**) — ledger, graders, risk caps, registries, listed explicitly in `CORE_MODULES`
  - The split exists so a regression in the money path can't be offset by adding tests to a vendor fetcher. `fetch_*` / `analyze_*` are mostly vendor HTTP and are exercised by the live crons, not unit tests.
- **The badge is written from that same run.** `validate` uploads `coverage-report.json` as an artifact; a master-only `publish-coverage` job downloads it and writes `assets/data/coverage.json`. No second pytest run, so the published number is the one the gate passed.
- Badge payload is a strict shields.io endpoint file with its own publish validator (`validate_sidecars.py coverage`), so a malformed payload fails the job instead of silently rendering "invalid" on the front page.
- READMEs (EN + ZH) render it from the endpoint URL — no hard-coded percentage in evergreen copy.

## Guards

`tests/test_coverage_badge.py` (29 cases). Every one was mutation-verified — each mutation below reds at least one test:

| mutation | caught |
|---|---|
| drop `--cov=scripts` from the test step | ✔ |
| re-run pytest inside the publish job | ✔ |
| publish on any push instead of master-only | ✔ |
| lower `DEFAULT_MIN_CORE` | ✔ |
| silently skip a `CORE_MODULES` entry missing from the report | ✔ |
| accept an undersized report (mis-scoped `--cov`) | ✔ |
| validator stops rejecting extra badge fields | ✔ |
| drop the ZH badge | ✔ |

Also asserted: `assets/data/coverage.json` is not in this workflow's `push:` paths, so publishing the badge cannot retrigger the job.

## Notes for review

- The publish step reuses `gha_commit_push.sh` + the `CLAWOCK_PUBLISH_SSH_KEY` step-scoped deploy key, so `test_pr_publish_gate_contract.py` picks this workflow up automatically — it passes.
- `concurrency: data-write` is job-scoped, so PR runs of `validate` are never queued behind a data-writing job.
- The badge will 404 until the first master push after merge publishes the payload; an initial `assets/data/coverage.json` is committed here so there's no broken-badge window.
- Local: `937 passed, 5 xfailed`.