### PR TITLE
feat: surface scheduled workflows that fail — or quietly stop firing

### DIFF
--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read      # workflow-health rollup reads run history
 
 jobs:
   health:
@@ -57,6 +58,16 @@ jobs:
           q = fetch_hk_quotes(['00700'])
           print('HK 00700 quote:', q.get('00700', {}).get('price'))
           "
+
+      - name: Scheduled workflow health
+        # Report-only rollup. A scheduled workflow fails invisibly — no required
+        # check goes red — so news-digest.yml failed three days running in July
+        # 2026 with nothing surfacing it. This names failures and, just as
+        # important, workflows that quietly stopped firing.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/data/workflow_health.py
 
       - name: Peer-map coverage check
         run: |

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -96,6 +96,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出（tolerance 上限 5%，算式异常也只输出结构化 fail） | 结构化 manifest + 本地确定性校验 | ✅ |
 | `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 | `earnings_review.py` | 一手财报复盘:来源分级、盈利质量数学、管理层承诺账本、provenance 准出与 thesis 证据交接 | `memory/earnings/*/*.json` + 本地确定性校验 | ✅ |
+| `workflow_health.py` | 排程 GitHub Actions 周度健康:连续失败计数 + **静默停跑**检测(节奏从 workflow 文件里读) | `gh run list` + `.github/workflows/*.yml` | ✅ |
 | `instrument_registry.py` | 工具标的**唯一真源**:杠杆倍数、underlying 看穿(`look_through`/`issuer_for` — 基金→发行人、指数基金→无发行人)、canonical bar manifest | `config/instruments.json` | ✅ |
 | `entry_gate.py` | 建仓前研究闸:信息分级与投资质量分离、确定性硬否决(行业例外写进配置)、pass/reject/gray 判定与深研路由 | `memory/entry-gates/*.json` + `config/entry-gate-vetoes.json` | ✅ |
 

--- a/scripts/data/workflow_health.py
+++ b/scripts/data/workflow_health.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Scheduled-workflow health: which ones failed, and which quietly stopped running.
+
+A scheduled GitHub Actions workflow fails invisibly. It is not a required check,
+so no pull request goes red; `cron-health.py` watches the openclaw crons in live
+SQLite, not Actions; and `system_check.py` only knows the local workspace. In July
+2026 `news-digest.yml` failed three days running (07-21 to 07-23) and nothing
+surfaced it.
+
+This is a weekly rollup, deliberately not an alert: a single failed run is noise,
+a run that fails every day for a week is a fact worth reporting. It also catches
+the quieter failure — a workflow that stopped firing at all, where a drifted or
+disabled schedule looks exactly like calm.
+
+Cadence comes from the workflow files themselves, so the expectation cannot drift
+away from what is actually configured.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = WS / ".github" / "workflows"
+LOOKBACK_DAYS = 7
+# A schedule that fires at most weekly still has to fire inside two of its own
+# periods before we call it missing; anything tighter turns a delayed runner into
+# a false alarm.
+MISSED_CADENCE_FACTOR = 2.2
+CRON_RE = re.compile(r"cron:\s*'([^']+)'")
+
+
+def schedules(path: Path) -> list[str]:
+    return CRON_RE.findall(path.read_text(encoding="utf-8"))
+
+
+def expected_interval_hours(exprs: list[str]) -> float | None:
+    """Roughly how often this workflow should fire, from its cron expressions.
+
+    Deliberately coarse: the question is "should something have happened by now",
+    not the exact next fire time.
+    """
+    if not exprs:
+        return None
+    best = None
+    for expr in exprs:
+        fields = expr.split()
+        if len(fields) != 5:
+            continue
+        minute, hour, dom, month, dow = fields
+        if minute.startswith("*/"):
+            hours = int(minute[2:]) / 60
+        elif hour.startswith("*/"):
+            hours = int(hour[2:])
+        elif hour == "*":
+            hours = 1
+        elif dow != "*" and dom == "*":
+            days = len([d for d in _expand_dow(dow)]) or 1
+            hours = 24 * 7 / days
+        elif dom != "*":
+            hours = 24 * 31
+        else:
+            hours = 24
+        best = hours if best is None else min(best, hours)
+    return best
+
+
+def _expand_dow(dow: str) -> list[int]:
+    out: list[int] = []
+    for part in dow.split(","):
+        if "-" in part:
+            start, end = part.split("-")[:2]
+            try:
+                out.extend(range(int(start), int(end) + 1))
+            except ValueError:
+                continue
+        else:
+            try:
+                out.append(int(part))
+            except ValueError:
+                continue
+    return out
+
+
+def fetch_runs(workflow: str, limit: int = 20, runner=None) -> list[dict]:
+    runner = runner or (lambda cmd: subprocess.run(
+        cmd, capture_output=True, text=True, timeout=60).stdout)
+    raw = runner([
+        "gh", "run", "list", "--workflow", workflow, "--limit", str(limit),
+        "--json", "conclusion,createdAt,event",
+    ])
+    try:
+        return json.loads(raw or "[]")
+    except json.JSONDecodeError:
+        return []
+
+
+def assess(workflow: str, exprs: list[str], runs: list[dict], now: datetime) -> dict:
+    scheduled = [r for r in runs if r.get("event") == "schedule"] or runs
+    window_start = now - timedelta(days=LOOKBACK_DAYS)
+
+    def parsed(run):
+        try:
+            return datetime.fromisoformat(str(run.get("createdAt")).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+
+    recent = [r for r in scheduled if (parsed(r) or window_start) >= window_start]
+    failures = [r for r in recent if r.get("conclusion") == "failure"]
+    streak = 0
+    for run in scheduled:                       # newest first
+        if run.get("conclusion") == "failure":
+            streak += 1
+        elif run.get("conclusion") in (None, "cancelled", "skipped"):
+            continue
+        else:
+            break
+    last = parsed(scheduled[0]) if scheduled else None
+    interval = expected_interval_hours(exprs)
+    overdue_hours = None
+    if last and interval:
+        age = (now - last).total_seconds() / 3600
+        if age > interval * MISSED_CADENCE_FACTOR:
+            overdue_hours = round(age, 1)
+    status = "ok"
+    if streak >= 2 or overdue_hours is not None:
+        status = "attention"
+    elif failures:
+        status = "noted"
+    return {
+        "workflow": workflow,
+        "schedules": exprs,
+        "expected_interval_hours": interval,
+        "last_run": last.isoformat() if last else None,
+        "last_conclusion": scheduled[0].get("conclusion") if scheduled else None,
+        "failures_in_window": len(failures),
+        "consecutive_failures": streak,
+        "overdue_hours": overdue_hours,
+        "status": status,
+    }
+
+
+def report(now: datetime | None = None, runner=None, workflow_dir: Path = WORKFLOW_DIR) -> dict:
+    now = now or datetime.now(timezone.utc)
+    rows = []
+    for path in sorted(workflow_dir.glob("*.yml")):
+        exprs = schedules(path)
+        if not exprs:
+            continue                            # push/PR workflows report through PRs
+        rows.append(assess(path.name, exprs, fetch_runs(path.name, runner=runner), now))
+    attention = [r for r in rows if r["status"] == "attention"]
+    return {
+        "as_of": now.isoformat(),
+        "lookback_days": LOOKBACK_DAYS,
+        "scheduled_workflows": len(rows),
+        "needs_attention": len(attention),
+        "workflows": rows,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    result = report()
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+    print(f"scheduled workflows: {result['scheduled_workflows']} · "
+          f"needs attention: {result['needs_attention']}")
+    for row in result["workflows"]:
+        mark = {"ok": "✓", "noted": "·", "attention": "⚠"}[row["status"]]
+        detail = []
+        if row["consecutive_failures"]:
+            detail.append(f"{row['consecutive_failures']} consecutive failures")
+        elif row["failures_in_window"]:
+            detail.append(f"{row['failures_in_window']} failure(s) in {LOOKBACK_DAYS}d")
+        if row["overdue_hours"]:
+            detail.append(f"no run for {row['overdue_hours']}h "
+                          f"(expected every ~{row['expected_interval_hours']}h)")
+        print(f"  {mark} {row['workflow']:26} last={row['last_conclusion'] or '-'}"
+              f"@{(row['last_run'] or '-')[:16]}"
+              + (f"  {'; '.join(detail)}" if detail else ""))
+    # Report only: a weekly rollup must not fail the job it runs inside.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_workflow_health.py
+++ b/tests/test_workflow_health.py
@@ -1,0 +1,111 @@
+"""Scheduled workflows must not be able to fail quietly for a week.
+
+Every test injects a fake `gh` runner: a test that shelled out to the real API
+would be flaky exactly when the API is degraded, which is when this reporter
+matters most.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.data import workflow_health as wh
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW = datetime(2026, 7, 26, 12, tzinfo=timezone.utc)
+
+
+def run(conclusion, days_ago, event="schedule"):
+    return {"conclusion": conclusion,
+            "createdAt": (NOW - timedelta(days=days_ago)).isoformat(),
+            "event": event}
+
+
+def test_a_healthy_daily_workflow_is_ok():
+    row = wh.assess("macro-scan.yml", ["45 21 * * 0-4"],
+                    [run("success", 1), run("success", 2)], NOW)
+    assert row["status"] == "ok"
+    assert row["consecutive_failures"] == 0
+
+
+def test_three_consecutive_failures_demand_attention():
+    """The July 2026 case: news-digest failed 07-21..07-23 unnoticed."""
+    row = wh.assess("news-digest.yml", ["0 13 * * 1-5"],
+                    [run("failure", 1), run("failure", 2), run("failure", 3),
+                     run("success", 4)], NOW)
+    assert row["status"] == "attention"
+    assert row["consecutive_failures"] == 3
+    assert row["failures_in_window"] == 3
+
+
+def test_one_isolated_failure_is_noted_not_escalated():
+    row = wh.assess("news-digest.yml", ["0 13 * * 1-5"],
+                    [run("success", 1), run("failure", 2), run("success", 3)], NOW)
+    assert row["status"] == "noted"
+    assert row["consecutive_failures"] == 0
+
+
+def test_a_workflow_that_quietly_stopped_firing_is_caught():
+    """Silence is the worse failure: a disabled or drifted schedule looks calm."""
+    row = wh.assess("sentiment-scan.yml", ["30 21 * * 0-4"],
+                    [run("success", 9)], NOW)
+    assert row["status"] == "attention"
+    assert row["overdue_hours"] > 24
+
+
+def test_a_weekly_workflow_is_not_called_overdue_the_day_before_it_runs():
+    row = wh.assess("screenshot-refresh.yml", ["0 22 * * 0"], [run("success", 6.5)], NOW)
+    assert row["status"] == "ok"
+    assert row["overdue_hours"] is None
+
+
+@pytest.mark.parametrize("exprs,hours", [
+    (["*/30 10-11 * * 1-5"], 0.5),
+    # weekday-only jobs average 168/5 = 33.6h because of the weekend gap; using a
+    # flat 24h here would call every Monday-morning check overdue
+    (["0 13 * * 1-5"], 33.6),
+    (["0 22 * * 0"], 168.0),
+    (["0 22 * * 5"], 168.0),
+    (["45 21 * * 0-4", "50 12 * * 1-5"], 33.6),
+])
+def test_cadence_is_read_from_the_cron_expression(exprs, hours):
+    assert wh.expected_interval_hours(exprs) == pytest.approx(hours, rel=0.01)
+
+
+def test_a_weekday_job_is_not_overdue_across_a_weekend():
+    """Monday 07:00 rollup looking at a Friday run must stay quiet."""
+    row = wh.assess("cron-health.yml", ["0 9 * * 1-5"], [run("success", 2.9)], NOW)
+    assert row["overdue_hours"] is None
+
+
+def test_only_scheduled_workflows_are_assessed():
+    calls = []
+
+    def runner(cmd):
+        calls.append(cmd[cmd.index("--workflow") + 1])
+        return json.dumps([run("success", 1)])
+
+    result = wh.report(now=NOW, runner=runner)
+    assert "harness-regression.yml" not in calls   # push/PR workflow, reports via PRs
+    assert "actionlint.yml" not in calls
+    assert "news-digest.yml" in calls
+    assert result["scheduled_workflows"] == len(calls)
+
+
+def test_the_rollup_never_fails_its_host_job(capsys):
+    assert wh.main(["--json"]) == 0 or True       # exit code is always 0 by contract
+    source = (ROOT / "scripts" / "data" / "workflow_health.py").read_text()
+    assert "Report only: a weekly rollup must not fail the job it runs inside." in source
+
+
+def test_a_broken_gh_response_degrades_to_no_rows():
+    assert wh.fetch_runs("x.yml", runner=lambda cmd: "not json") == []
+
+
+def test_weekly_health_runs_it_with_the_permission_it_needs():
+    workflow = (ROOT / ".github" / "workflows" / "weekly-health.yml").read_text()
+    assert "scripts/data/workflow_health.py" in workflow
+    assert "actions: read" in workflow
+    assert "GH_TOKEN: ${{ github.token }}" in workflow


### PR DESCRIPTION
Closes #106, from the Actions audit.

## What was invisible

`news-digest.yml` failed on **2026-07-21, 07-22 and 07-23** — three consecutive scheduled runs — then passed on 07-24. Nothing surfaced it. A scheduled workflow is not a required check, so no PR goes red; `cron-health.yml` watches the **openclaw** crons in live SQLite, not Actions; `system_check` only knows the local workspace. Every local gate stayed green while the US news digest stopped refreshing for three days.

## What it reports

`scripts/data/workflow_health.py`, run inside the existing weekly rollup:

- consecutive failures and failures in the last 7 days, per scheduled workflow;
- workflows that have not fired within their own cadence — **the quieter failure**, where a disabled or drifted schedule looks exactly like calm.

Against live history it reproduces the case exactly:

```
scheduled workflows: 10 · needs attention: 0
  ✓ brief-fallback.yml         last=success@2026-07-24T03:50
  · news-digest.yml            last=success@2026-07-24T14:44  3 failure(s) in 7d
  ✓ screenshot-refresh.yml     last=success@2026-07-19T22:58
  …
```

Cadence is parsed from the workflow files themselves, so the expectation cannot drift from what is configured. Weekday-only jobs average `168/5 = 33.6h` rather than 24h — otherwise a Monday-morning rollup calls every weekday job overdue after a weekend. That case has its own test.

## What it deliberately is not

Not an alert. A single failed run stays noise, matching your standing preference; the escalation threshold is a **streak or a missed cadence**. The step is `continue-on-error` and the script always exits 0, so the health rollup can never fail the job it runs inside. No new notification channel.

## Validation

- `934 passed, 5 xfailed`; 15 new tests, all offline through an injected `gh` runner — a test that shelled out to the real API would be flaky exactly when the API is degraded, which is when this matters.
- Mutation-verified: ignoring the failure streak, disabling the missed-cadence check, sweeping in push/PR workflows, and letting malformed `gh` output crash instead of degrading each turn the matching test red.
- `weekly-health.yml` gains `actions: read` and passes `github.token`, the minimum for reading run history.