### PR TITLE
test: stop pinning the leveraged-ETF share to one day's quote

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -715,6 +715,23 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
 - `fail` — 缺文件/JSON 解析错/critical 字段缺失，**不 commit**、**不投递**
 - `wechat_sent` — postflight 自动投递结果（见下）
 
+**status 不是逐条 issue 判的，别自己猜哪条是硬闸。** `fail` 只由 critical 关键词
+（`缺失` / `解析失败` / `表格 #`）或 issues > 4 条触发；其余都是 warn，照样 commit + 投递。
+
+**改完任何一条 issue，立刻重跑一次 postflight 拿新 status，再决定还要不要继续改。**
+不要在一次 `fail` 之后一路埋头修到自己认为"干净"为止 —— 修掉 critical 那条以后往往
+已经是 warn，剩下的 issue 不阻塞交付。
+
+> **2026-07-27 实例**：首跑 `fail`，issues 是「表格 #1 列数不一致」+「pre-open.md 偏长
+> 35853 bytes」。表格那条是 critical，体积那条只是提醒。修好表格后没有重跑，误以为体积
+> 也是硬闸，从 35.8KB 一路裁到 23.7KB —— 多烧 6 分钟 / 约 13M tokens，中途还因为 `edit`
+> 的 `oldText` 打错中文字（`滴`/`滘`、`拉锅`/`拉锯`）连失败 3 次，把整跑染成
+> `status=error`（产物其实已正常交付）。
+
+`pre-open.md 偏长 … bytes` 永远是 warn：这个文件是 dashboard 全文，不受微信 16KB 限制，
+>24KB 只是"页面难读"的提醒。**不要为它裁剪已经写好的正文。** 要控体量就在 Step 4-A 写的
+时候写紧凑，而不是事后返工。
+
 ### 投递（Step 5 postflight 内自动，你什么都不用做）
 
 > **🔒 投递已解耦——你绝不要手动发微信、绝不调任何 message/send 工具、也不要把卡片当回复文本贴出来。**

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -92,8 +92,32 @@ def test_live_dashboard_exposure_has_no_other_and_matches_risk_leverage():
     }
 
     leveraged = build_dashboard.compute_leveraged_etf_exposure(portfolio, fx_rate=7.84)
-    assert leveraged["us_pct"] == 83.53
-    assert "SPCH" in leveraged["tickers"]
+    # us_pct is a share of live market value, so pinning today's quote (it was
+    # 83.53) goes red at the next close for no reason. Pin the derivation
+    # instead: active-only holdings, current_value denominator, registry-driven
+    # numerator. `compute_leveraged_etf_exposure` swallows exceptions and
+    # returns us_pct=None, so the not-None check is what keeps that fail-open
+    # from passing silently.
+    us_active = [
+        h
+        for h in portfolio["portfolios"]["us_stocks"]["holdings"]
+        if h.get("shares", 0) > 0
+    ]
+    us_total = sum(h.get("current_value", 0) or 0 for h in us_active)
+    us_lev = sum(
+        h.get("current_value", 0) or 0
+        for h in us_active
+        if h["ticker"] in instrument_registry.leveraged_symbols()
+    )
+    assert us_total > 0 and us_lev > 0
+    assert leveraged["us_pct"] is not None
+    assert leveraged["us_pct"] == round(us_lev / us_total * 100, 2)
+    assert set(leveraged["tickers"]) == {
+        h["ticker"]
+        for h in us_active + portfolio["portfolios"]["hk_stocks"]["holdings"]
+        if h.get("shares", 0) > 0
+        and h["ticker"] in instrument_registry.leveraged_symbols()
+    }
 
     lookthrough = build_dashboard.compute_lookthrough_exposure(portfolio)
     assert lookthrough["us"]["metadata_coverage_pct"] == 100.0
@@ -104,3 +128,24 @@ def test_live_dashboard_exposure_has_no_other_and_matches_risk_leverage():
     assert spacex["gross_value"] > spacex["capital_value"]
     assert lookthrough["us"]["factor_hhi"] > 0
     assert lookthrough["us"]["sector_hhi"] > 0
+
+
+def test_leveraged_exposure_ignores_closed_positions_with_stale_values():
+    """Live portfolio.json zeroes current_value on exit, so the active-only
+    filter in compute_leveraged_etf_exposure is unobservable there. Pin it on a
+    synthetic book where a closed leveraged position still carries a value."""
+    portfolio = _portfolio()
+    us = portfolio["portfolios"]["us_stocks"]["holdings"]
+    live = build_dashboard.compute_leveraged_etf_exposure(portfolio, fx_rate=7.84)
+
+    closed = next(h for h in us if (h.get("shares", 0) or 0) <= 0)
+    stale = copy.deepcopy(closed)
+    stale["ticker"] = sorted(instrument_registry.leveraged_symbols())[0]
+    stale["shares"] = 0
+    stale["current_value"] = 1_000_000.0
+    us.append(stale)
+
+    assert build_dashboard.compute_leveraged_etf_exposure(
+        portfolio, fx_rate=7.84
+    ) == live
+


### PR DESCRIPTION
## 为什么 CI 一直红

`Harness Regression` 在 07-27 的两次推送上都失败，同一个断言：

```
tests/test_instrument_registry.py:95
    assert leveraged["us_pct"] == 83.53
E   assert 83.54 == 83.53
```

`_portfolio()` 读的是**活的 `portfolio.json`**（`tests/test_instrument_registry.py:24`），
却把杠杆 ETF 在美股腿的占比写死成 `83.53`。今早的盘前简报把周五收盘价写进账本，占比漂到
83.54，CI 就红了 —— 而且**每次收盘都可能再红**：只要这个比例动到 ≥0.005pp 就会重现。
把常数改成 83.54 只能撑到下一次收盘。

## 改法

钉推导过程，不钉当天的报价：

- 只算 active（`shares > 0`）持仓，`current_value` 做分母，分子由 registry 的
  `leveraged_symbols()` 决定
- `leveraged["tickers"]` 必须正好等于账本里在册的 active 杠杆持仓
- 补一条 `us_pct is not None` —— `compute_leveraged_etf_exposure` 用
  `except Exception` 吞错并返回 `us_pct=None`，旧的常数断言是**碰巧**挡住了这个
  fail-open，换成推导式断言后必须显式补上

另外发现活账本查不出 active-only 过滤：已平仓的持仓 `current_value` 都是 `0.0`，
所以「去掉 active 过滤」这个变异在真实数据上是**等价变异**，测不出来。新增
`test_leveraged_exposure_ignores_closed_positions_with_stale_values`，在一份合成账本上
让已平仓的杠杆持仓仍带着市值，把这个过滤钉住。

## 变异验证

| 变异 | 结果 |
|---|---|
| us 分母去掉 active 过滤 | ✅ 红（新增的合成账本测试）|
| us 分子去掉 active 过滤 | ✅ 红（同上）|
| `tickers` 去掉 active 过滤 | ✅ 红 |
| compute 内部抛错（fail-open 路径）| ✅ 红 |
| SPCH 市值 +37%（us_pct 83.54 → 85.74）| ✅ 绿 —— 旧断言此时会红 |

全量 `964 passed, 5 xfailed`。

## 顺带：把「修完重跑 postflight」写进 SKILL

今早那跑 `status=error` 其实是假红 —— postflight 最终 `status: pass`、
`wechat_sent: true`、`commit_ok: true`、7 条 decision 已结算，产物正常交付。
但过程里有 6 分钟是白烧的：

首跑 `fail` 的 issues 是「表格 #1 列数不一致」（critical）+「pre-open.md 偏长 35853
bytes」（只是提醒）。agent 修好表格后**没有重跑 postflight**，误以为体积也是硬闸，
从 35.8KB 一路裁到 23.7KB，多花约 6 分钟 / 13M tokens；中途 `edit` 的 `oldText`
打错中文字（`滴`/`滘`、`拉锅`/`拉锯`）连失败 3 次，把整跑染成 `status=error`。

`skills/daily-deep-brief/SKILL.md` 的 Step 5 补上：status 由 critical 关键词或
issues > 4 判定，不是逐条 issue 判的；改完任何一条**立刻重跑**再决定要不要继续改；
`pre-open.md 偏长` 永远是 warn，不要为它返工已经写好的正文。

## 不在本 PR 范围

同一个测试里 `{"SPCX","SPCH","SKHY"} <= …` 和 `spacex["tickers"] == ["SPCH","SPCX"]`
也是钉在当前持仓上的，卖掉其中任何一只都会红。但那是随交易动作变的，跟着调整测试是合理的；
本 PR 只处理**每次收盘都会自己漂**的那一条。