### PR TITLE
ci: bump setup-python, upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 50
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 100  # 需要看今日 commit history
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Set up Python
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -162,7 +162,7 @@ jobs:
         # number this job gated on — not a second, independently drifting
         # measurement. Only master pushes have a consumer; PR runs skip the upload.
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage-report.json
@@ -314,14 +314,14 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
       # No dependency install and no second test run: the suite was already
       # measured in `validate`. Everything below is stdlib.
       - name: Download coverage report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-report
 
@@ -352,7 +352,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 100
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
Supersedes #116, #117, #118 — same diff, on a branch the required checks actually run on.

| action | from | to | dependabot PR |
|---|---|---|---|
| `actions/setup-python` | v6 | v7 | #117 |
| `actions/upload-artifact` | v4 | v7 | #116 |
| `actions/download-artifact` | v4 | v8 | #118 |

## Why not just merge the dependabot PRs

CodeQL runs here through **default setup**, not a workflow file. On a dependabot PR it reports one neutral `CodeQL` check and never starts `Analyze (actions)`, `Analyze (javascript-typescript)` or `Analyze (python)`; on a normal PR all four appear. All four are required contexts in the `master PR + CI gate` ruleset, whose only bypass actor is `DeployKey`, so a dependabot PR is permanently `BLOCKED` — no dependabot PR has ever merged in this repo.

## Note on the pair

`upload-artifact` and `download-artifact` are bumped in the same change because the coverage badge path depends on the round trip: `validate` uploads `coverage-report.json` and the master-only publish job downloads that exact measurement rather than re-running pytest.