### PR TITLE
feat: report a memory index that has silently fallen behind

### DIFF
--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -21,6 +21,18 @@ from pathlib import Path
 
 WS = Path(__file__).resolve().parent.parent
 
+# Live-box paths for the memory-index check. These are deliberately absolute and
+# not derived from WS: the semantic index only ever covers the live runtime
+# checkout, so an interactive worktree must judge that one, not its own copy.
+# All of them are absent in CI, where the check skips.
+LIVE_WORKSPACE = Path('/root/.openclaw/workspace')
+MEMORY_INDEX_DB = Path('/root/.openclaw/agents/main/agent/openclaw-agent.sqlite')
+OPENCLAW_INSTALL = Path('/root/.local/share/pnpm/global/5/node_modules/openclaw')
+MEMORY_INDEX_LOG = LIVE_WORKSPACE / 'logs' / 'memory_index.log'
+# Nightly reindex is 05:10 HKT; 30h lets one run slip into the next daily review
+# rather than firing on the normal gap between two runs.
+MEMORY_REINDEX_MAX_AGE_HOURS = 30
+
 # Check result severity
 CRITICAL = '✗ CRITICAL'
 WARNING  = '⚠ WARN'
@@ -522,6 +534,126 @@ def check_trading_calendar_horizon(r):
         r.add('trading calendar', OK, f'{horizon} · both markets')
 
 
+def _memory_index_backlog():
+    """(missing, stale, indexed) — what openclaw embeds vs what its index holds.
+
+    Measured from `memory_index_sources` rather than `openclaw memory status`,
+    for two reasons: the CLI call costs ~16s, which is too much for a pre-push
+    hook, and its `Dirty:` line clears after the cheap chunk/FTS pass and before
+    the expensive embed pass — so it reads healthy while vectors are missing.
+    Comparing the recorded size against the file on disk also catches a source
+    that was indexed once and has changed since, which the ratio cannot show.
+    """
+    import sqlite3
+    conn = sqlite3.connect(f'file:{MEMORY_INDEX_DB}?mode=ro', uri=True, timeout=10)
+    try:
+        indexed = {row[0]: int(row[1]) for row in
+                   conn.execute('select path, size from memory_index_sources')}
+    finally:
+        conn.close()
+
+    # openclaw's scope is `MEMORY.md` + every .md under memory/, including the
+    # gitignored .tmp and .dreams trees (verified against a clean 472/472 index).
+    on_disk = {}
+    root_doc = LIVE_WORKSPACE / 'MEMORY.md'
+    if root_doc.exists():
+        on_disk['MEMORY.md'] = root_doc.stat().st_size
+    for path in (LIVE_WORKSPACE / 'memory').rglob('*.md'):
+        try:
+            on_disk[path.relative_to(LIVE_WORKSPACE).as_posix()] = path.stat().st_size
+        except OSError:
+            continue  # written and removed underneath us; not a backlog
+
+    missing = sorted(p for p in on_disk if p not in indexed)
+    stale = sorted(p for p, size in on_disk.items() if p in indexed and indexed[p] != size)
+    return missing, stale, len(indexed)
+
+
+def _memory_index_patch_gaps():
+    """Local dist patches openclaw upgrades wipe, both silent at the point of use."""
+    try:
+        dist = OPENCLAW_INSTALL.resolve() / 'dist'
+    except OSError as e:  # noqa: BLE001
+        return [f'cannot resolve openclaw install: {e}']
+    if not dist.is_dir():
+        return [f'openclaw dist not found at {dist}']
+
+    def contains(pattern, needle):
+        for path in dist.glob(pattern):
+            try:
+                if needle in path.read_text(encoding='utf-8', errors='replace'):
+                    return True
+            except OSError:
+                continue
+        return False
+
+    gaps = []
+    if not contains('embeddings-*.js', 'threads: 1, batchSize: 512'):
+        gaps.append('threads:1 embedding patch missing (local embedding can deadlock)')
+    if contains('tools-*.js', 'MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15e3;'):
+        gaps.append('memory_search deadline back to stock 15s (this box needs ~27s cold)')
+    return gaps
+
+
+def _memory_reindex_age_hours():
+    """Hours since the nightly reindex last finished, or None if it never has."""
+    if not MEMORY_INDEX_LOG.exists():
+        return None
+    last = None
+    for line in MEMORY_INDEX_LOG.read_text(errors='replace').splitlines():
+        # The */15 reaper writes to the same log, so its mtime proves nothing.
+        if 'reindex done' in line:
+            last = line.split(' ', 1)[0]
+    if not last:
+        return None
+    try:
+        when = datetime.fromisoformat(last)
+    except ValueError:
+        return None
+    if when.tzinfo is None:
+        when = when.astimezone()
+    return (datetime.now(timezone.utc) - when).total_seconds() / 3600
+
+
+def check_memory_index(r):
+    """Semantic recall degrades silently; nothing else reports it.
+
+    On 2026-07-27 the index had been 23 files behind for five days — every
+    dreaming note since 07-23 and both recent weekly reviews were invisible to
+    recall — and it surfaced only because someone read `openclaw memory status`
+    by hand while chasing an unrelated bug. Warn, never block: a stale index
+    costs recall quality, and holding a publish over it would be the worse
+    trade.
+    """
+    if not MEMORY_INDEX_DB.exists() or not LIVE_WORKSPACE.is_dir():
+        r.add('memory index', OK, 'no live index on this host (skipped)')
+        return
+    try:
+        missing, stale, indexed = _memory_index_backlog()
+    except Exception as e:  # noqa: BLE001 — an unreadable index is the warning
+        r.add('memory index', WARNING, f'cannot read index: {e}')
+        return
+
+    problems = []
+    if missing:
+        problems.append(f'{len(missing)} file(s) never embedded (e.g. {missing[0]})')
+    if stale:
+        problems.append(f'{len(stale)} file(s) changed since indexing (e.g. {stale[0]})')
+    problems += _memory_index_patch_gaps()
+
+    age = _memory_reindex_age_hours()
+    if age is None:
+        problems.append('nightly reindex has never completed')
+    elif age > MEMORY_REINDEX_MAX_AGE_HOURS:
+        problems.append(f'nightly reindex last completed {age:.0f}h ago')
+
+    if problems:
+        r.add('memory index', WARNING, '; '.join(problems))
+    else:
+        r.add('memory index', OK,
+              f'{indexed} files embedded · patches applied · reindex {age:.0f}h ago')
+
+
 def check_research_artifacts(r):
     """Thesis, earnings and entry-gate artifacts must stay valid.
 
@@ -565,6 +697,7 @@ def main():
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,
+        check_memory_index,
     ]
     for c in checks:
         try:

--- a/tests/test_memory_index_check.py
+++ b/tests/test_memory_index_check.py
@@ -1,0 +1,209 @@
+"""Guards for the memory-index assertion in scripts/system_check.py.
+
+The index fell 23 files behind for five days in July 2026 and nothing reported
+it: every dreaming note since 07-23 and both weekly reviews were invisible to
+semantic recall, and it surfaced only because someone read `openclaw memory
+status` by hand while chasing a different bug.
+
+Two properties matter more than the individual cases below:
+
+* the check reads the index tables directly, because `openclaw memory status`
+  costs ~16s (too slow for a pre-push hook) and its `Dirty:` line clears before
+  the embed pass — so it says `no` while vectors are missing;
+* it can only ever WARN. Recall quality is not a publishing invariant, and per
+  kcn's standing preference this belongs on the daily-review line rather than in
+  a per-failure alert.
+
+Every fixture is a throwaway index + workspace, so a refactor that keeps the
+behaviour stays green while each defect the check exists for turns it red.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = str(ROOT / "scripts")
+
+
+@pytest.fixture(scope="module")
+def sc():
+    if SCRIPTS not in sys.path:
+        sys.path.insert(0, SCRIPTS)
+    return pytest.importorskip("system_check")
+
+
+def _write_index(db: Path, sources: dict[str, int]) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "create table memory_index_sources "
+        "(path TEXT, source TEXT, hash TEXT, mtime INTEGER, size INTEGER)"
+    )
+    conn.executemany(
+        "insert into memory_index_sources values (?, 'memory', 'h', 0, ?)",
+        list(sources.items()),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def box(tmp_path, sc, monkeypatch):
+    """A healthy live box: workspace, index, both dist patches, fresh reindex."""
+    workspace = tmp_path / "workspace"
+    (workspace / "memory" / "dreaming").mkdir(parents=True)
+    (workspace / "logs").mkdir()
+    (workspace / "MEMORY.md").write_text("index\n")
+    (workspace / "memory" / "2026-07-27.md").write_text("today\n")
+    (workspace / "memory" / "dreaming" / "2026-07-26.md").write_text("dreamt\n")
+
+    db = tmp_path / "agent.sqlite"
+    _write_index(db, {
+        "MEMORY.md": len("index\n"),
+        "memory/2026-07-27.md": len("today\n"),
+        "memory/dreaming/2026-07-26.md": len("dreamt\n"),
+    })
+
+    dist = tmp_path / "openclaw" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "embeddings-aaa.js").write_text("const o = { threads: 1, batchSize: 512 };")
+    (dist / "tools-bbb.js").write_text("const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 60000;")
+
+    log = workspace / "logs" / "memory_index.log"
+    stamp = (datetime.now().astimezone() - timedelta(hours=3)).isoformat(timespec="seconds")
+    log.write_text(f"{stamp} reindex done in 15s: indexed=3/3 counts=(9, 3) (chunk delta 0)\n")
+
+    monkeypatch.setattr(sc, "LIVE_WORKSPACE", workspace)
+    monkeypatch.setattr(sc, "MEMORY_INDEX_DB", db)
+    monkeypatch.setattr(sc, "OPENCLAW_INSTALL", tmp_path / "openclaw")
+    monkeypatch.setattr(sc, "MEMORY_INDEX_LOG", log)
+    return {"workspace": workspace, "db": db, "dist": dist, "log": log}
+
+
+def _run(sc):
+    r = sc.Result()
+    sc.check_memory_index(r)
+    assert len(r.checks) == 1
+    name, severity, message = r.checks[0]
+    assert name == "memory index"
+    return severity, message
+
+
+def test_healthy_box_reports_ok(sc, box):
+    severity, message = _run(sc)
+    assert severity == sc.OK, message
+    assert "3 files embedded" in message
+
+
+def test_unembedded_file_is_reported(sc, box):
+    """The July failure: dreaming notes written but never embedded."""
+    (box["workspace"] / "memory" / "dreaming" / "2026-07-27.md").write_text("new\n")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "never embedded" in message
+    assert "memory/dreaming/2026-07-27.md" in message
+
+
+def test_file_changed_since_indexing_is_reported(sc, box):
+    """A source indexed once and edited since is stale, and the ratio hides it."""
+    (box["workspace"] / "memory" / "2026-07-27.md").write_text("today, plus an edit\n")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "changed since indexing" in message
+    assert "memory/2026-07-27.md" in message
+
+
+def test_gitignored_trees_count_as_index_scope(sc, box):
+    """openclaw embeds memory/.tmp and memory/.dreams too — verified on a clean
+    472/472 index. Excluding them would under-report the backlog."""
+    tmp_dir = box["workspace"] / "memory" / ".tmp"
+    tmp_dir.mkdir()
+    (tmp_dir / "report-prose-hk-open.md").write_text("prose\n")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "memory/.tmp/report-prose-hk-open.md" in message
+
+
+def test_wiped_timeout_patch_is_reported(sc, box):
+    """Every openclaw upgrade restores the stock 15s deadline this box cannot meet."""
+    (box["dist"] / "tools-bbb.js").write_text("const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15e3;")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "stock 15s" in message
+
+
+def test_wiped_threads_patch_is_reported(sc, box):
+    (box["dist"] / "embeddings-aaa.js").write_text("const o = { threads: 4 };")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "threads:1" in message
+
+
+def test_stalled_nightly_reindex_is_reported(sc, box):
+    """The drain is a cron job; if it stops, the backlog returns silently."""
+    stamp = (datetime.now().astimezone() - timedelta(hours=40)).isoformat(timespec="seconds")
+    box["log"].write_text(f"{stamp} reindex done in 15s: indexed=3/3 counts=(9, 3)\n")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "40h ago" in message
+
+
+def test_normal_gap_between_nightly_runs_is_not_a_finding(sc, box):
+    """05:10 daily means a healthy box is routinely ~24h since the last run."""
+    stamp = (datetime.now().astimezone() - timedelta(hours=26)).isoformat(timespec="seconds")
+    box["log"].write_text(f"{stamp} reindex done in 15s: indexed=3/3 counts=(9, 3)\n")
+    severity, _ = _run(sc)
+    assert severity == sc.OK
+
+
+def test_reap_only_log_reads_as_never_reindexed(sc, box):
+    """The reaper writes to the same log every 15 min; its mtime proves nothing."""
+    box["log"].write_text("2026-07-27T11:00:00+08:00 reaped worker 528196\n")
+    severity, message = _run(sc)
+    assert severity == sc.WARNING
+    assert "never completed" in message
+
+
+def test_host_without_a_live_index_skips(sc, box, tmp_path, monkeypatch):
+    """CI and fresh checkouts have no openclaw install; that is not a finding."""
+    monkeypatch.setattr(sc, "MEMORY_INDEX_DB", tmp_path / "absent.sqlite")
+    severity, message = _run(sc)
+    assert severity == sc.OK
+    assert "skipped" in message
+
+
+def test_unreadable_index_warns_rather_than_crashing(sc, box):
+    box["db"].write_text("not a database")
+    severity, _ = _run(sc)
+    assert severity == sc.WARNING
+
+
+def test_check_can_never_block_a_push(sc, box):
+    """Everything wrong at once must still leave the exit code at warn.
+
+    A degraded index is a recall problem, not a correctness one — blocking a
+    publish over it would trade a real invariant for a soft one.
+    """
+    (box["workspace"] / "memory" / "unembedded.md").write_text("new\n")
+    (box["dist"] / "tools-bbb.js").write_text("const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15e3;")
+    (box["dist"] / "embeddings-aaa.js").write_text("const o = { threads: 4 };")
+    box["log"].unlink()
+
+    r = sc.Result()
+    sc.check_memory_index(r)
+    assert r.critical_count() == 0
+    assert r.warn_count() == 1
+
+
+def test_check_is_registered_in_main(sc):
+    """A check nobody runs is the failure mode this issue was about."""
+    source = (ROOT / "scripts" / "system_check.py").read_text()
+    # `self.checks = []` appears earlier in the Result class, so anchor on the
+    # registration list itself.
+    body = source.split("\n    checks = [", 1)[1].split("]", 1)[0]
+    registered = {line.strip().rstrip(",") for line in body.splitlines() if line.strip()}
+    assert "check_memory_index" in registered


### PR DESCRIPTION
Closes #128 — the visibility half of the 2026-07-27 recall failure. The draining half (nightly reindex, `*/15` reaper, `sync.onSearch: false`) is already live on the box; this is the part that belongs in the repo.

## What it asserts

| assertion | why it is not the obvious one |
|---|---|
| every `MEMORY.md` + `memory/**/*.md` is in `memory_index_sources` | `openclaw memory status` costs ~16s — too slow for a pre-push hook — and its `Dirty:` line clears *before* the embed pass, so it says `no` while vectors are missing |
| the recorded size matches the file on disk | catches a source indexed once and edited since; the `442/471` ratio cannot show that |
| both local dist patches survive | every openclaw upgrade wipes them, and both fail silently at the point of use |
| a `reindex done` line within 30h | the `*/15` reaper writes to the same log, so its mtime proves nothing |

Cost on the live box: **0.17s**, against 16.5s for the CLI probe.

## Severity

WARN, never CRITICAL. A degraded index costs recall quality, not correctness, and per the standing preference this belongs on the daily-review line rather than a per-failure push alert. `test_check_can_never_block_a_push` asserts that with everything broken at once.

## Scope note

The index scope is `MEMORY.md` + every `.md` under `memory/`, **including** the gitignored `.tmp` and `.dreams` trees — verified against a clean 472/472 index, where excluding them under-reported by 10 files. `test_gitignored_trees_count_as_index_scope` pins it.

Paths are absolute, not derived from `WS`: the index only covers the live runtime checkout, so an interactive worktree must judge that one. All are absent in CI, where the check skips (`test_host_without_a_live_index_skips`).

## Verification

13 tests, each assertion mutation-verified — removing the missing-file scan, the stale-size comparison, the patch probe or the age bound turns the suite red, as does escalating the severity. Live run: `✓ OK  memory index  472 files embedded · patches applied · reindex 2h ago`.