### PR TITLE
feat: extend the trading calendar through 2027

### DIFF
--- a/scripts/data/trading_calendar.py
+++ b/scripts/data/trading_calendar.py
@@ -9,10 +9,25 @@ corruption catalogued in memory. This module is the single source of truth both
 layers consult.
 
 Holiday tables are static and hand-maintained (the local IP blocks most data
-sources, and exchange calendars are published a year ahead). Update them each
-December for the next year. Sources:
-  HKEX: https://www.calendarlabs.com/hkex-market-holidays-2026/
-  US (NYSE/Nasdaq): https://www.aarp.org/money/personal-finance/stock-market-holidays/
+sources, and exchange calendars are published a year ahead). Extend them before
+the covered year runs out; `system_check` warns from October and goes critical
+once the current year is uncovered.
+
+US dates are rule-based but must still be read off the exchange calendar: the
+Saturday/Sunday observance shifts are what move them (2027 has two — Juneteenth
+back to Fri 18 Jun, Christmas back to Fri 24 Dec — and one forward, Independence
+Day to Mon 5 Jul). HK dates depend on the gazetted general holidays and the
+lunar calendar and cannot be computed at all: 2027 substitutes the 4th day of
+Lunar New Year because the 2nd falls on a Sunday.
+
+Sources (authoritative, re-checked 2026-07-27):
+  US (NYSE/Nasdaq) 2025-2027 holiday and early-closings calendar:
+    https://ir.theice.com/press/news-details/2024/NYSE-Group-Announces-2025-2026-and-2027-Holiday-and-Early-Closings-Calendar/default.aspx
+  HK general holidays, gazetted:
+    https://www.gov.hk/en/about/abouthk/holiday/2027.htm
+  HKEX half-day sessions (eves of LNY/Christmas/New Year, and the day of the
+  Mid-Autumn Festival — morning session only, no afternoon):
+    https://www.hkex.com.hk/Services/Trading-hours-and-Severe-Weather-Arrangements/Trading-Hours/Securities-Market?sc_lang=en
 
 CLI:
   python3 trading_calendar.py hk            -> prints OPEN/CLOSED, exit 0/1
@@ -47,6 +62,18 @@ US_HOLIDAYS = {
     "2026-09-07",  # Labor Day (Mon)
     "2026-11-26",  # Thanksgiving (Thu)
     "2026-12-25",  # Christmas (Fri)
+
+    # 2027 NYSE/Nasdaq — NYSE Group calendar (see module docstring).
+    "2027-01-01",  # New Year's Day (Fri)
+    "2027-01-18",  # Martin Luther King Jr. Day (Mon)
+    "2027-02-15",  # Washington's Birthday (Mon)
+    "2027-03-26",  # Good Friday (Fri)
+    "2027-05-31",  # Memorial Day (Mon)
+    "2027-06-18",  # Juneteenth observed (Fri; 19 Jun is a Sat)
+    "2027-07-05",  # Independence Day observed (Mon; 4 Jul is a Sun)
+    "2027-09-06",  # Labor Day (Mon)
+    "2027-11-25",  # Thanksgiving (Thu)
+    "2027-12-24",  # Christmas observed (Fri; 25 Dec is a Sat)
 }
 
 HK_HOLIDAYS = {
@@ -68,6 +95,25 @@ HK_HOLIDAYS = {
     "2026-10-19",  # Chung Yeung Festival (Mon)
     "2026-12-25",  # Christmas Day (Fri)
     "2026-12-26",  # Christmas observed (Sat - weekend)
+
+    # 2027 HKEX full-day closures — gazetted general holidays (see docstring).
+    "2027-01-01",  # New Year's Day (Fri)
+    "2027-02-06",  # Lunar New Year's Day (Sat - weekend)
+    "2027-02-08",  # LNY 3rd day (Mon)
+    "2027-02-09",  # LNY 4th day (Tue) — substitutes the 2nd day, which is a Sun
+    "2027-03-26",  # Good Friday (Fri)
+    "2027-03-27",  # Day following Good Friday (Sat - weekend)
+    "2027-03-29",  # Easter Monday (Mon)
+    "2027-04-05",  # Ching Ming Festival (Mon)
+    "2027-05-01",  # Labour Day (Sat - weekend)
+    "2027-05-13",  # Buddha's Birthday (Thu)
+    "2027-06-09",  # Tuen Ng / Dragon Boat (Wed)
+    "2027-07-01",  # HKSAR Establishment Day (Thu)
+    "2027-09-16",  # Day following Mid-Autumn Festival (Thu)
+    "2027-10-01",  # National Day (Fri)
+    "2027-10-08",  # Chung Yeung Festival (Fri)
+    "2027-12-25",  # Christmas Day (Sat - weekend)
+    "2027-12-27",  # First weekday after Christmas (Mon)
 }
 
 # HK half-days: morning session only (afternoon closed). Open for the morning,
@@ -77,11 +123,17 @@ HK_HALF_DAYS = {
     "2026-09-25",  # Day before Mid-Autumn (Fri)
     "2026-12-24",  # Christmas Eve (Thu)
     "2026-12-31",  # New Year's Eve (Thu)
+
+    # 2027
+    "2027-02-05",  # Lunar New Year's Eve (Fri)
+    "2027-09-15",  # Mid-Autumn Festival day (Wed) — the holiday is the day after
+    "2027-12-24",  # Christmas Eve (Fri) — US is shut, HK trades the morning
+    "2027-12-31",  # New Year's Eve (Fri)
 }
 
 MARKET_TZ = {"hk": "Asia/Hong_Kong", "us": "America/New_York"}
 HOLIDAYS = {"hk": HK_HOLIDAYS, "us": US_HOLIDAYS}
-LATEST_YEAR = 2026  # bump when tables are extended; guards warn past this
+LATEST_YEAR = 2027  # bump when tables are extended; guards warn past this
 
 
 def _today_in_market(market: str) -> date:

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -1,0 +1,133 @@
+"""Guards for the hand-maintained holiday tables in scripts/data/trading_calendar.py.
+
+The tables cannot be generated. US observance shifts move dates around the
+weekend, and HK dates come from the gazetted general holidays plus the lunar
+calendar — 2027 substitutes the *4th* day of Lunar New Year because the 2nd
+falls on a Sunday, which no rule in this repo could have derived.
+
+Past its horizon the module deliberately fails OPEN, so an unextended table does
+not skip a real session; it turns every public holiday into a trading day
+instead. These tests pin the dates that prove the 2027 extension is real, and
+the direction of the failure if it ever lapses again.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import trading_calendar  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# 2027 — the year this suite was written to land
+# --------------------------------------------------------------------------
+
+CLOSED_2027 = [
+    # (date, market, what it is)
+    ("2027-01-01", "us", "New Year's Day"),
+    ("2027-01-01", "hk", "New Year's Day"),
+    ("2027-02-08", "hk", "3rd day of Lunar New Year"),
+    ("2027-02-09", "hk", "4th day of LNY, substituted for the Sunday 2nd day"),
+    ("2027-03-26", "us", "Good Friday"),
+    ("2027-03-26", "hk", "Good Friday"),
+    ("2027-06-18", "us", "Juneteenth observed — 19 Jun is a Saturday"),
+    ("2027-07-01", "hk", "HKSAR Establishment Day"),
+    ("2027-07-05", "us", "Independence Day observed — 4 Jul is a Sunday"),
+    ("2027-09-16", "hk", "day following Mid-Autumn Festival"),
+    ("2027-10-01", "hk", "National Day"),
+    ("2027-12-24", "us", "Christmas observed — 25 Dec is a Saturday"),
+    ("2027-12-27", "hk", "first weekday after Christmas"),
+]
+
+
+@pytest.mark.parametrize("iso,market,what", CLOSED_2027,
+                         ids=[f"{m}-{d}" for d, m, _ in CLOSED_2027])
+def test_known_2027_holiday_is_closed(iso, market, what):
+    assert not trading_calendar.is_trading_day(market, date.fromisoformat(iso)), what
+
+
+def test_the_two_markets_do_not_share_a_calendar():
+    """A single merged table would close each market on the other's holidays."""
+    # HK trades through US Independence Day and Thanksgiving.
+    assert trading_calendar.is_trading_day("hk", date(2027, 7, 5))
+    assert trading_calendar.is_trading_day("hk", date(2027, 11, 25))
+    # The US trades through Ching Ming, Tuen Ng and National Day.
+    assert trading_calendar.is_trading_day("us", date(2027, 4, 5))
+    assert trading_calendar.is_trading_day("us", date(2027, 6, 9))
+    assert trading_calendar.is_trading_day("us", date(2027, 10, 1))
+
+
+def test_us_christmas_eve_is_shut_while_hk_trades_the_morning():
+    """25 Dec 2027 is a Saturday: the US observes on Friday, HK does not."""
+    eve = date(2027, 12, 24)
+    assert not trading_calendar.is_trading_day("us", eve)
+    assert trading_calendar.is_trading_day("hk", eve)
+    assert not trading_calendar.is_trading_day("hk", eve, session="afternoon")
+
+
+@pytest.mark.parametrize("iso,what", [
+    ("2027-02-05", "Lunar New Year's Eve"),
+    ("2027-09-15", "Mid-Autumn Festival day — the holiday is the day after"),
+    ("2027-12-24", "Christmas Eve"),
+    ("2027-12-31", "New Year's Eve"),
+])
+def test_2027_hk_half_days_trade_the_morning_only(iso, what):
+    d = date.fromisoformat(iso)
+    assert trading_calendar.is_trading_day("hk", d), f"{what}: morning is open"
+    assert not trading_calendar.is_trading_day("hk", d, session="afternoon"), what
+    assert trading_calendar.closed_reason("hk", d, session="afternoon") == "半日市·午后休市"
+
+
+def test_mid_autumn_is_a_half_day_and_the_day_after_is_the_closure():
+    """Getting these two the wrong way round loses a real trading session."""
+    assert trading_calendar.is_trading_day("hk", date(2027, 9, 15))
+    assert not trading_calendar.is_trading_day("hk", date(2027, 9, 16))
+
+
+def test_an_ordinary_2027_weekday_still_trades():
+    """A table that closed too much would be caught by nothing else here."""
+    for market in ("hk", "us"):
+        assert trading_calendar.is_trading_day(market, date(2027, 3, 3))
+
+
+# --------------------------------------------------------------------------
+# coverage + the deliberate fail-open past the horizon
+# --------------------------------------------------------------------------
+
+
+def test_coverage_reports_both_markets_through_2027():
+    coverage = trading_calendar.coverage(today=date(2026, 12, 1))
+    for market in ("hk", "us"):
+        assert 2027 in coverage[market]["years"]
+        assert coverage[market]["covers_next_year"], market
+
+
+def test_latest_year_matches_the_tables():
+    """LATEST_YEAR is what the guards read; tables and horizon must agree.
+
+    A table extended without bumping the constant is invisible — `closed_reason`
+    returns None for any date past LATEST_YEAR before it ever looks at the set.
+    """
+    for market in ("hk", "us"):
+        assert max(trading_calendar.covered_years(market)) == trading_calendar.LATEST_YEAR
+
+
+def test_past_the_horizon_the_calendar_fails_open():
+    """The point of the deadline: never skip a real session over a stale table."""
+    beyond = date(trading_calendar.LATEST_YEAR + 1, 1, 1)
+    assert trading_calendar.closed_reason("hk", beyond) is None
+    assert trading_calendar.closed_reason("us", beyond) is None
+
+
+def test_weekend_entries_are_harmless_but_kept():
+    """Gazetted holidays that land on a weekend stay in the table as a record;
+    they must not be mistaken for the reason the market is shut."""
+    saturday = date(2027, 2, 6)  # Lunar New Year's Day
+    assert saturday.weekday() == 5
+    assert trading_calendar.closed_reason("hk", saturday) == "周末休市"


### PR DESCRIPTION
Closes #101.

`system_check` reports `trading calendar — through 2027 · both markets`.

## Where the dates come from

| market | source | why it cannot be generated |
|---|---|---|
| US | [NYSE Group 2025–2027 holiday and early-closings calendar](https://ir.theice.com/press/news-details/2024/NYSE-Group-Announces-2025-2026-and-2027-Holiday-and-Early-Closings-Calendar/default.aspx) | three of ten dates move on the weekend observance: Juneteenth → Fri 18 Jun, Independence Day → Mon 5 Jul, Christmas → Fri 24 Dec |
| HK | [gazetted general holidays 2027](https://www.gov.hk/en/about/abouthk/holiday/2027.htm) | lunar-calendar dependent, and 2027 **substitutes the 4th day of Lunar New Year** because the 2nd falls on a Sunday |
| HK half-days | [HKEX securities trading hours](https://www.hkex.com.hk/Services/Trading-hours-and-Severe-Weather-Arrangements/Trading-Hours/Securities-Market?sc_lang=en) | eves of LNY / Christmas / New Year, **plus the day of the Mid-Autumn Festival** — the closure is the day after |

Both aggregator links in the old docstring are replaced with the primary sources.

## The date worth looking at twice

**24 Dec 2027**: the US is shut (observed Christmas, since the 25th is a Saturday) while **HK trades its morning session**. Any assumption of a shared calendar breaks there, so `test_us_christmas_eve_is_shut_while_hk_trades_the_morning` pins all three facts.

Likewise `test_mid_autumn_is_a_half_day_and_the_day_after_is_the_closure`: swapping 15 Sep and 16 Sep would silently drop a real trading session.

## Tests

25 cases in `tests/test_trading_calendar.py`, including the fail-open behaviour past the horizon and `test_latest_year_matches_the_tables` — a table extended without bumping `LATEST_YEAR` is invisible, because `closed_reason()` returns `None` for anything past the horizon before it ever reads the set.

Mutation-verified: dropping the substituted LNY 4th day, leaving `LATEST_YEAR` at 2026, or marking Mid-Autumn day as a full closure each turns the suite red.