### PR TITLE
fix: stop turning a detection into silence, in three places

### DIFF
--- a/scripts/data/plan_surface.py
+++ b/scripts/data/plan_surface.py
@@ -154,8 +154,14 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
         if exec_mode:
             context["exec_mode"] = exec_mode
         return context
-    except Exception:  # noqa: BLE001 — a plan artifact must never red a report cron
-        return {}
+    except Exception as exc:  # noqa: BLE001 — a plan artifact must never red a report cron
+        # Fail soft, but as a VALUE, not as silence (#136). `{}` is also the
+        # legitimate "no open decisions today" answer, so a read that throws used
+        # to be indistinguishable from a clean day — and the report would write
+        # prose accordingly. That is exactly the #119 defect coming back with no
+        # signal: on 2026-07-27 the 09:30 report advised waiting for a pullback
+        # while the day's plan held the same position as a risk_rule swap.
+        return {"error": f"{type(exc).__name__}: {exc}"[:200]}
 
 
 def main():

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -458,6 +458,33 @@ def is_advisory(issue):
     return ADVISORY_MARK in issue
 
 
+def split_advisory(issues):
+    """(escalating, advisory) — the banner must count and show them separately.
+
+    Both banners print a truncated list (`issues[:2]` intraday, `issues[:3]`
+    report). While advisory findings shared that list they were the ones most
+    likely to be cut, because they only appear on reports that already have
+    other findings — i.e. exactly the reports where an invented number matters
+    most. They get their own line instead.
+    """
+    return ([i for i in issues if not is_advisory(i)],
+            [i for i in issues if is_advisory(i)])
+
+
+def advisory_prefix(advisories, shown=2):
+    """A visible, non-blocking line for advisory findings ('' when there are none).
+
+    Deliberately not styled as a warning: it must read as information, or the
+    next person to see one will start treating it as a failure and the gate
+    becomes the blocker it was designed not to be.
+    """
+    if not advisories:
+        return ''
+    body = '; '.join(a.replace(ADVISORY_MARK, '').strip() for a in advisories[:shown])
+    more = f'；另 {len(advisories) - shown} 条' if len(advisories) > shown else ''
+    return f'ℹ️ 数字校验（不影响投递）：{body}{more}\n\n'
+
+
 def categorize_issues(issues, critical_substrings, warn_max=2, extra_critical=None):
     """Common pass/warn/fail decision used by all postflights.
 

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _harness_common import (  # noqa: E402
+    advisory_prefix,
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
@@ -43,6 +44,7 @@ from _harness_common import (  # noqa: E402
     push_with_rebase_retry,
     rebuild_dashboard,
     snapshot_date_for_now,
+    split_advisory,
     validate_forbidden_phrases,
 )
 from _watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
@@ -182,8 +184,14 @@ def categorize(issues):
     )
 
 
-def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out):
-    """Build the watchdog marker with the preflight slot as its identity."""
+def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out,
+                            delivery_state='delivered'):
+    """Build the watchdog marker with the preflight slot as its identity.
+
+    `delivery_state` distinguishes a full report from the fail-closed data block
+    (#135): both are real deliveries — the watchdog must not re-send either —
+    but only one of them carried the model's prose.
+    """
     heartbeat = ctx.get('heartbeat') or {}
     return {
         'ts': ts,
@@ -193,6 +201,7 @@ def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out)
         'market': market,
         'job': heartbeat.get('job'),
         'slot': heartbeat.get('slot'),
+        'delivery_state': delivery_state,
         'out': (out or '')[-200:],
     }
 
@@ -245,16 +254,20 @@ def main():
         print(f'warn: {insights_path.name} 未写 — dashboard status_banner 将过期隐藏 '
               f'(SKILL Mode 7 Step 2.5 / cron payload Step 2.5)', file=sys.stderr)
 
-    if status == 'pass':
-        wechat_prefix = ''
+    # The banner counts and lists ESCALATING issues only; advisory findings get
+    # their own line below, so a truncated list can never drop them (#134).
+    escalating, advisories = split_advisory(issues)
+    if status == 'pass' or not escalating:
+        banner = ''
     elif status == 'warn':
-        wechat_prefix = (f'⚠️ Validation warnings ({len(issues)}): '
-                         + '; '.join(issues[:2])
-                         + '\n\n')
+        banner = (f'⚠️ Validation warnings ({len(escalating)}): '
+                  + '; '.join(escalating[:2])
+                  + '\n\n')
     else:
-        wechat_prefix = (f'🔴 Validation FAILED ({len(issues)} issues):\n'
-                         + '\n'.join('- ' + i for i in issues[:4])
-                         + '\n\n')
+        banner = (f'🔴 Validation FAILED ({len(escalating)} issues), 仅发布数据块:\n'
+                  + '\n'.join('- ' + i for i in escalating[:4])
+                  + '\n\n')
+    wechat_prefix = banner + advisory_prefix(advisories)
 
     # ── WeChat delivery (decoupled from the cron's announce) ──────────────────
     # The cron's announce fires at the END of a long agent turn using a token
@@ -271,7 +284,7 @@ def main():
     # the report already went out on the prior attempt — skip the re-send. Intraday's
     # marker is per-market, so use a 20min window (< the 30min slot cadence, > the
     # few-min retry gap) to tell a retry from the next legit slot. See already_delivered.
-    if status in ('pass', 'warn') and already_delivered(marker, within_ms=20 * 60 * 1000):
+    if already_delivered(marker, within_ms=20 * 60 * 1000):
         print('idempotency: intraday already delivered this slot — skip re-send', file=sys.stderr)
         try:
             prior = json.loads(marker.read_text())
@@ -279,33 +292,51 @@ def main():
             tg_ok = prior.get('tg_ok')
         except Exception:
             pass
-    elif status in ('pass', 'warn'):
-        block_first = (ctx.get('raw_wechat_block', '') or '').strip().splitlines()
+    else:
+        # Fail-closed, not silent (#135). A rejected report used to send nothing
+        # at all, leaving a market slot indistinguishable from a dead cron until
+        # the watchdog mirrored a block to Telegram 10-40 minutes later. Deliver
+        # the harness-owned data block instead — every number in it is
+        # trustworthy by construction — and drop the prose that failed. Same
+        # shape as report_postflight's fail-closed body selection.
+        raw_block = (ctx.get('raw_wechat_block', '') or '').strip()
+        block_first = raw_block.splitlines()
         block_first = block_first[0] if block_first else ''
-        message = (wechat_prefix + text).strip()
-        try:
-            channel, to, account = resolve_wechat_target(args.market)
-            wechat_sent, send_out = send_wechat(channel, to, account, message, dry_run=False)
-        except Exception as e:
-            wechat_sent, send_out = False, str(e)[:300]
-        # Always co-send to Telegram (cold-proof) — WeChat can't confirm real delivery.
-        # Record the Telegram result: it's the sole backstop intraday_watchdog now
-        # uses (no more WeChat resend), so it needs to know if TG already got this.
-        tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
-        try:
-            marker.write_text(json.dumps(delivery_marker_payload(
-                ctx,
-                ts=int(datetime.now().timestamp() * 1000),
-                sent_ok=wechat_sent,
-                tg_ok=tg_ok,
-                first_line=block_first,
-                market=args.market,
-                out=send_out,
-            ), ensure_ascii=False))
-        except Exception as e:
-            print(f'warn: marker write failed: {e}', file=sys.stderr)
-        if not wechat_sent:
-            print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}', file=sys.stderr)
+        body = raw_block if status == 'fail' else text
+        if status == 'fail' and not raw_block:
+            # Nothing trustworthy to deliver: the banner alone is the scary empty
+            # send this harness already fixed once (2026-06-17). Leave it to the
+            # watchdog rather than push a message with no content.
+            print('warn: validation failed and the context carries no data block — '
+                  'nothing sent, watchdog owns this slot', file=sys.stderr)
+        else:
+            message = (wechat_prefix + body).strip()
+            try:
+                channel, to, account = resolve_wechat_target(args.market)
+                wechat_sent, send_out = send_wechat(channel, to, account, message, dry_run=False)
+            except Exception as e:
+                wechat_sent, send_out = False, str(e)[:300]
+            # Always co-send to Telegram (cold-proof) — WeChat can't confirm real
+            # delivery. Record the Telegram result: it's the sole backstop
+            # intraday_watchdog now uses (no more WeChat resend), so it needs to
+            # know if TG already got this.
+            tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
+            try:
+                marker.write_text(json.dumps(delivery_marker_payload(
+                    ctx,
+                    ts=int(datetime.now().timestamp() * 1000),
+                    sent_ok=wechat_sent,
+                    tg_ok=tg_ok,
+                    first_line=block_first,
+                    market=args.market,
+                    out=send_out,
+                    delivery_state='failed' if status == 'fail' else 'delivered',
+                ), ensure_ascii=False))
+            except Exception as e:
+                print(f'warn: marker write failed: {e}', file=sys.stderr)
+            if not wechat_sent:
+                print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}',
+                      file=sys.stderr)
 
     dashboard_published = False
     if status in ('pass', 'warn'):

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -196,6 +196,7 @@ def categorize(issues):
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _harness_common import (  # noqa: E402
+    advisory_prefix,
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
@@ -204,6 +205,7 @@ from _harness_common import (  # noqa: E402
     push_with_rebase_retry,
     rebuild_dashboard,
     snapshot_date_for_now,
+    split_advisory,
     validate_forbidden_phrases,
 )
 from _watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
@@ -504,18 +506,22 @@ def main():
         issue_count=len(issues),
     )
 
-    if status == 'pass':
-        wechat_prefix = ''
+    # The banner counts and lists ESCALATING issues only; advisory findings get
+    # their own line below, so a truncated list can never drop them (#134).
+    escalating, advisories = split_advisory(issues)
+    if status == 'pass' or not escalating:
+        banner = ''
     elif status == 'warn':
-        wechat_prefix = (f'⚠️ Validation warnings ({len(issues)}): '
-                         + '; '.join(issues[:3])
-                         + ('; ...' if len(issues) > 3 else '')
-                         + '\n\n')
+        banner = (f'⚠️ Validation warnings ({len(escalating)}): '
+                  + '; '.join(escalating[:3])
+                  + ('; ...' if len(escalating) > 3 else '')
+                  + '\n\n')
     else:
-        wechat_prefix = (f'🔴 Validation FAILED ({len(issues)} issues), 仅发布数据块、未 commit:\n'
-                         + '\n'.join('- ' + i for i in issues[:5])
-                         + ('\n- ...' if len(issues) > 5 else '')
-                         + '\n\n')
+        banner = (f'🔴 Validation FAILED ({len(escalating)} issues), 仅发布数据块、未 commit:\n'
+                  + '\n'.join('- ' + i for i in escalating[:5])
+                  + ('\n- ...' if len(escalating) > 5 else '')
+                  + '\n\n')
+    wechat_prefix = banner + advisory_prefix(advisories)
 
     # ── Fail-closed body selection ───────────────────────────────────────────
     # A rejected report used to be delivered in full behind its banner, which is

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -169,6 +169,7 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market h
 - `exec_mode.today_override` 说了 MOO 就不许改写成限价单口径。
 - 股数/比例**照抄 `shares`/`pct`，不许换算也不许心算**；`carried_over>0` 时点一句「{n} 条昨日挂单仍未成交」。
 - `plan_context` 为 `{}` 说明今天本腿没有未完成决策，按正常写，不要编一个计划出来。
+- `plan_context` 里带 `error` 字段说明**计划没读出来，不是今天没有计划**（issue #136）。此时必须在 ▎操作建议 开头写一行「今日计划未取到（{error}），以下建议未与 08:00 简报对账」，并且**不许**顺势断言「今天没有未完成决策」。
 
 🔢 **数字铁律（postflight 会查，见 `check_numeric_claims`）**：散文里出现的每个金额/股数**必须是 context 里已有的数字**，照抄不换算。
 - **禁止重述持仓股数、持仓市值、浮盈金额** —— 这些 postflight 已经拼在消息开头了，重述一遍只会多一次说错的机会（2026-07-27 就把 6200 股的仓位写成 1000 股）。**例外且仅此一个**：`plan_context.open[].shares` 是「这一单要动多少股」，照抄它是被要求的；被禁的是「这只票我持有多少股」。两者不是一回事——07226 持仓 6200 股、当日 swap 单 1000 股，同一天同一只票。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -171,6 +171,7 @@ python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market u
 - `exec_mode.today_override` 说了 MOO 就不许改写成限价单口径。
 - 股数/比例**照抄 `shares`/`pct`，不许换算也不许心算**；`carried_over>0` 时点一句「{n} 条昨日挂单仍未成交」。
 - `plan_context` 为 `{}` 说明今天本腿没有未完成决策，按正常写，不要编一个计划出来。
+- `plan_context` 里带 `error` 字段说明**计划没读出来，不是今天没有计划**（issue #136）。此时必须在 ▎操作建议 开头写一行「今日计划未取到（{error}），以下建议未与 08:00 简报对账」，并且**不许**顺势断言「今天没有未完成决策」。
 
 🔢 **数字铁律（postflight 会查，见 `check_numeric_claims`）**：散文里出现的每个金额/股数**必须是 context 里已有的数字**，照抄不换算。
 - **禁止重述持仓股数、持仓市值、浮盈金额** —— 这些 postflight 已经拼在消息开头了，重述一遍只会多一次说错的机会（2026-07-27 就把 6200 股的仓位写成 1000 股）。**例外且仅此一个**：`plan_context.open[].shares` 是「这一单要动多少股」，照抄它是被要求的；被禁的是「这只票我持有多少股」。两者不是一回事——07226 持仓 6200 股、当日 swap 单 1000 股，同一天同一只票。

--- a/tests/test_plan_surface.py
+++ b/tests/test_plan_surface.py
@@ -159,11 +159,20 @@ def test_corrupt_line_does_not_blind_the_rest(ledger, call, tmp_path):
     assert [d["ticker"] for d in call(path)["open"]] == ["07226"]
 
 
-def test_a_raising_loader_degrades_to_no_context(ps, monkeypatch, ledger, call):
+def test_a_raising_loader_degrades_to_an_error_not_to_silence(ps, monkeypatch,
+                                                              ledger, call):
+    """Still fail-soft — never raise into a market cron — but say so (#136).
+
+    This asserted `== {}` when it was written. That made a failed read identical
+    to the legitimate "no open decisions today", so the prose would state there
+    was no plan and the #119 contradiction could return unannounced.
+    """
     def boom(_path):
         raise RuntimeError("disk on fire")
     monkeypatch.setattr(ps, "_load_ledger", boom)
-    assert call(ledger([decision()])) == {}
+    context = call(ledger([decision()]))
+    assert context["error"].startswith("RuntimeError: disk on fire")
+    assert "open" not in context, "a failed read must not imply an empty plan"
 
 
 def test_context_is_bounded(ps, ledger, call):

--- a/tests/test_suppression_is_visible.py
+++ b/tests/test_suppression_is_visible.py
@@ -1,0 +1,192 @@
+"""Detection must never degrade into silence.
+
+Three separate ways the harness had learned to notice something and then not
+say it, all fixed together because they are the same mistake:
+
+* #134 — advisory findings shared the banner's truncated issue list, so the
+  invented-number line was cut precisely on reports that already had two or
+  three other findings;
+* #135 — a failed intraday validation sent nothing at all, while the staged
+  reports send the harness-owned data block behind a red banner. A market slot
+  with no message is indistinguishable from a dead cron;
+* #136 — `plan_surface` returned `{}` both when there were no open decisions and
+  when reading them threw, so a failed read reads as a clean day. That is the
+  #119 defect (a report contradicting the day's own discipline plan) coming back
+  with no signal.
+
+The tests assert on delivered output — prefix strings, the body handed to the
+sender, the returned context — not on internal helpers, because the defect in
+each case was that the internal state was right and nothing carried it out.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "harness"))
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import _harness_common as hc  # noqa: E402
+import plan_surface  # noqa: E402
+
+
+ADVISORY = f"07226 6200 股 未在 context 中 {hc.ADVISORY_MARK}"
+ADVISORY_2 = f"区间 +0.3~-0.4% 自相矛盾 {hc.ADVISORY_MARK}"
+
+
+# --------------------------------------------------------------------------
+# #134 — advisory findings get their own line
+# --------------------------------------------------------------------------
+
+
+def test_advisory_only_report_is_not_dressed_as_a_warning():
+    """It stays `warn` (delivered either way) but reads as information."""
+    escalating, advisories = hc.split_advisory([ADVISORY])
+    assert escalating == []
+    assert hc.advisory_prefix(advisories).startswith("ℹ️ 数字校验（不影响投递）")
+    assert "⚠️" not in hc.advisory_prefix(advisories)
+
+
+def test_advisory_survives_a_banner_full_of_other_issues():
+    """The defect: `issues[:2]` dropped the advisory on exactly the bad reports."""
+    issues = ["缺段标记 ▎技术面", "报告长度 3100 字 > 3000 软上限 (warn)", ADVISORY]
+    escalating, advisories = hc.split_advisory(issues)
+    assert len(escalating) == 2
+    prefix = hc.advisory_prefix(advisories)
+    assert "07226 6200 股" in prefix
+
+
+def test_advisory_line_bounds_itself():
+    many = [f"{i} 股 未在 context 中 {hc.ADVISORY_MARK}" for i in range(5)]
+    prefix = hc.advisory_prefix(many)
+    assert "另 3 条" in prefix
+    assert prefix.count(";") <= 2
+
+
+def test_no_advisory_means_no_line():
+    assert hc.advisory_prefix([]) == ""
+    assert hc.split_advisory(["缺段标记 ▎技术面"]) == (["缺段标记 ▎技术面"], [])
+
+
+def test_the_advisory_mark_is_not_shown_to_the_reader():
+    """`(advisory)` is a routing token for categorize_issues, not prose."""
+    assert hc.ADVISORY_MARK not in hc.advisory_prefix([ADVISORY])
+
+
+def test_advisory_still_cannot_change_the_verdict():
+    """The #123 guarantee, re-asserted here because this PR touches its callers."""
+    assert hc.categorize_issues([ADVISORY], ("必须",), warn_max=2) == "warn"
+    two_warnings = ["a", "b"]
+    assert hc.categorize_issues(two_warnings, ("必须",), warn_max=2) == "warn"
+    assert hc.categorize_issues(two_warnings + [ADVISORY, ADVISORY_2],
+                                ("必须",), warn_max=2) == "warn"
+
+
+# --------------------------------------------------------------------------
+# #135 — a rejected intraday report still delivers the data block
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def postflight():
+    return pytest.importorskip("intraday_postflight")
+
+
+def test_marker_records_whether_the_prose_actually_landed(postflight):
+    ctx = {"heartbeat": {"job": "盘中盯盘", "slot": "2026-07-27T14:00:00+08:00"}}
+    delivered = postflight.delivery_marker_payload(
+        ctx, ts=1, sent_ok=True, tg_ok=True, first_line="x", market="hk", out="")
+    failed = postflight.delivery_marker_payload(
+        ctx, ts=1, sent_ok=True, tg_ok=True, first_line="x", market="hk", out="",
+        delivery_state="failed")
+    assert delivered["delivery_state"] == "delivered"
+    assert failed["delivery_state"] == "failed"
+    # Both are real sends: the watchdog must not re-send either.
+    assert failed["sent_ok"] is True
+
+
+def test_failed_validation_sends_the_data_block_and_not_the_prose(postflight, tmp_path,
+                                                                 monkeypatch):
+    sent = _run_postflight(postflight, tmp_path, monkeypatch,
+                           prose="这份散文缺了必需的段标记", issues_status="fail")
+    assert sent, "a failed intraday validation must still deliver something"
+    body = sent[0]
+    assert "▎恒生科技" in body, "the harness-owned data block must be delivered"
+    assert "这份散文缺了必需的段标记" not in body, "the rejected prose must be dropped"
+    assert body.startswith("🔴")
+
+
+def test_passing_validation_still_sends_the_prose(postflight, tmp_path, monkeypatch):
+    sent = _run_postflight(postflight, tmp_path, monkeypatch,
+                           prose="▎盘中观察\n▎我的看法\n一切正常", issues_status="pass")
+    assert sent and "一切正常" in sent[0]
+
+
+def _run_postflight(module, tmp_path, monkeypatch, *, prose, issues_status):
+    """Drive main() with delivery and publishing stubbed, return sent messages."""
+    sent = []
+    monkeypatch.setattr(module, "TMP", tmp_path)
+    monkeypatch.setattr(module, "resolve_wechat_target", lambda m: ("c", "t", "a"))
+    monkeypatch.setattr(module, "send_wechat",
+                        lambda c, t, a, message, dry_run: (sent.append(message), (True, "ok"))[1])
+    monkeypatch.setattr(module, "cosend_telegram", lambda message, tag: (True, "ok"))
+    monkeypatch.setattr(module, "already_delivered", lambda *a, **k: False)
+    monkeypatch.setattr(module.trading_calendar, "closed_reason", lambda m: None)
+    monkeypatch.setattr(module, "rebuild_dashboard", lambda: (False, ""))
+    monkeypatch.setattr(module.cron_heartbeat, "record", lambda *a, **k: {})
+
+    ctx = {
+        "status": "ok",
+        "market": "hk",
+        "raw_wechat_block": "▎恒生科技 5,432.10 (+0.35%)\n00100 225.4 +15.51%",
+        "anomalies": [],
+        "should_alert": False,
+        "heartbeat": {"job": "盘中盯盘", "slot": "2026-07-27T14:00:00+08:00"},
+        "generated_at": "2026-07-27T06:00:00+00:00",
+    }
+    (tmp_path / "intraday-context-hk-latest.json").write_text(
+        json.dumps(ctx, ensure_ascii=False))
+    monkeypatch.setattr(module, "load_context", lambda market: (ctx, None))
+    monkeypatch.setattr(module, "read_report_text", lambda market, f: (prose, None))
+    monkeypatch.setattr(module, "validate",
+                        lambda text, c: [] if issues_status == "pass" else ["缺段标记 ▎我的看法"])
+    monkeypatch.setattr(module, "categorize", lambda issues: issues_status)
+    monkeypatch.setattr(sys, "argv", ["intraday_postflight.py", "--market", "hk"])
+    module.main()
+    return sent
+
+
+# --------------------------------------------------------------------------
+# #136 — "could not read it" is a value, not silence
+# --------------------------------------------------------------------------
+
+
+def test_a_broken_plan_read_is_reported_as_an_error(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("decisions.jsonl unreadable")
+
+    monkeypatch.setattr(plan_surface, "_load_ledger", boom)
+    ctx = plan_surface.open_decisions_context(leg="HK")
+    assert ctx.get("error"), "a failed read must not look like a clean day"
+    assert "unreadable" in ctx["error"]
+
+
+def test_a_genuinely_empty_plan_stays_empty(tmp_path):
+    """The other half of the contract: no false alarm on a quiet day."""
+    ledger = tmp_path / "decisions.jsonl"
+    ledger.write_text("")
+    ctx = plan_surface.open_decisions_context(leg="HK", ledger=ledger,
+                                              memory_dir=tmp_path)
+    assert ctx == {}
+
+
+def test_the_skill_tells_the_model_what_an_error_means():
+    """A context field nothing reads is the same as no field at all."""
+    for skill in ("hk-stock-analysis", "us-stock-analysis"):
+        body = (ROOT / "skills" / skill / "SKILL.md").read_text()
+        assert "`error` 字段" in body
+        assert "今日计划未取到" in body


### PR DESCRIPTION
Closes #134. Closes #135. Closes #136.

Same defect three times: something is detected and then not said. This is the generalisation of the #133 discussion — anomaly detection is welcome, silent downgrade is not.

| # | before | after |
|---|---|---|
| #134 | advisory findings competed for `issues[:2]` / `issues[:3]` in the banner and got cut on reports that already had other findings | own `ℹ️ 数字校验（不影响投递）` line; banner counts/lists escalating issues only |
| #135 | a `fail` intraday validation sent **nothing**; recovery was the watchdog mirroring a block to Telegram 10-40 min later | delivers the harness-owned data block behind the 🔴 banner, prose dropped, marker records `delivery_state: failed` |
| #136 | `plan_surface` returned `{}` for both "no open decisions" and "the read threw" | still fail-soft, but `{"error": …}`, carried into the context, with a SKILL rule requiring one line of prose |

## Correcting #134's premise

Filed as "the gate is invisible"; that was wrong and I said so on the issue. `categorize_issues` returns `pass` only for an **empty** issue list, so an advisory-only report was already `warn` and already shown:

```
only advisory      -> warn
advisory + 1 warn  -> warn
empty              -> pass
```

The real defect is truncation, which is narrower — and still worth fixing, because it drops the invented-number line exactly when the report has other problems.

## #135 detail

The staged path has done this since 2026-07-24, with the reasoning already in the comment: *"silence is also wrong: a market day with no message is indistinguishable from a dead cron"*. Mode 7 simply never got it. It matters more now that #133 removed the delta trigger — every slot runs, so every slot can fail validation.

Two guards kept: a failure whose context has **no** data block still sends nothing (the banner alone is the 2026-06-17 empty-send bug), and the 20-minute idempotency window now covers the failed path so a retry cannot double-send.

## #136 scope

Only `plan_surface` is changed. `mover_news.holding_names` degrades a display name and `research_surface`'s feed helper already reports per-ticker status — neither can silently rewrite an assertion in the report, so they stay as they are rather than growing an error channel nobody reads.

`tests/test_plan_surface.py::test_a_raising_loader_degrades_to_no_context` asserted the old `== {}` contract; it is rewritten (and renamed) to the new one, with the reason in its docstring.

## Verification

12 new tests, full suite **1072 passed, 5 xfailed**. Mutation-verified: restoring the prose on a failed slot, restoring the send-nothing branch, folding advisory back into the banner list, dropping the advisory line, and swallowing the plan error each turn the suite red.