### PR TITLE
fix(us): 报价停在昨收被判成「今日 0%」，五处根因 + 补上唯一能抓到它的闸

### DIFF
--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -75,6 +75,21 @@ def _pct(c: float, pc: float) -> float:
     return round((c - pc) / pc * 100, 4) if pc else 0.0
 
 
+def _quote_is_complete(q: Optional[Dict]) -> bool:
+    """A quote is usable on its own only if it carries a real prior close AND a
+    real intraday range.
+
+    Nasdaq `/info` returns neither (see get_nasdaq_quote), so before this check
+    existed it always won the provider race at position #1 and Eastmoney /
+    Finnhub — which both return true o/h/l/pc — were never reached. An
+    incomplete quote is still better than nothing, so the caller keeps it as a
+    last resort rather than discarding it.
+    """
+    if not q:
+        return False
+    return q.get('pc') is not None and q.get('h') is not None and q.get('l') is not None
+
+
 def _prev_trading_day(date_str: str) -> str:
     """Calendar prior trading day (skips weekends; ignores holidays — close enough
     for a date label on a reconstructed prev_close)."""
@@ -125,7 +140,23 @@ def load_api_keys() -> Dict[str, str]:
 # ── provider functions ───────────────────────────────────────────────────────
 
 def get_nasdaq_quote(ticker: str) -> Optional[Dict]:
-    """Nasdaq API – JSON, no auth, covers stocks and ETFs."""
+    """Nasdaq API – JSON, no auth, covers stocks and ETFs.
+
+    The `/info` endpoint carries NO `summaryData` block (verified 2026-07-27 for
+    stocks and etf assetclasses: its data keys are symbol/companyName/stockType/
+    exchange/isNasdaqListed/isNasdaq100/isHeld/primaryData/secondaryData/
+    marketStatus/assetClass/keyStats/notifications). PreviousClose / OpenPrice /
+    TodayHighLow live on the separate `/summary` endpoint. The previous
+    `_parse_price(...) or price` fallbacks therefore fired on EVERY call and
+    silently manufactured `o == h == l == c == pc` — which (a) made the
+    degenerate-range alarm fire for 100% of tickers, so it warned about nothing,
+    and (b) let a stale `lastSalePrice` sail through as "unchanged today".
+
+    So: report only what the payload actually contains. Missing fields stay
+    None and the caller decides (see `_quote_is_complete` → try a richer
+    provider). `nc` (netChange) is kept because it is exact and is the only
+    reliable way to rebuild a prior close from this endpoint.
+    """
     headers = {
         'Accept': 'application/json, text/plain, */*',
         'Origin': 'https://www.nasdaq.com',
@@ -146,20 +177,25 @@ def get_nasdaq_quote(ticker: str) -> Optional[Dict]:
             if not price or price <= 0:
                 continue
 
-            pc = _parse_price((summary.get('PreviousClose') or {}).get('value')) or price
-            op = _parse_price((summary.get('OpenPrice') or {}).get('value')) or price
+            # No `or price` fallbacks: absent means absent (see docstring).
+            pc = _parse_price((summary.get('PreviousClose') or {}).get('value'))
+            op = _parse_price((summary.get('OpenPrice') or {}).get('value'))
 
-            high, low = price, price
+            high = low = None
             day_range = (summary.get('TodayHighLow') or {}).get('value') or ''
             if ' - ' in day_range:
                 parts = day_range.split(' - ')
-                h = _parse_price(parts[1]) if len(parts) > 1 else None
-                lo = _parse_price(parts[0]) if parts else None
-                if h:  high = h
-                if lo: low  = lo
+                high = _parse_price(parts[1]) if len(parts) > 1 else None
+                low  = _parse_price(parts[0]) if parts else None
 
+            nc = _parse_price(primary.get('netChange'))
             pct_str = (primary.get('percentageChange') or '').replace('%', '').replace('+', '').strip()
-            dp = float(pct_str) if pct_str and pct_str not in ('N/A', '--') else _pct(price, pc)
+            if pct_str and pct_str not in ('N/A', '--'):
+                dp = float(pct_str)
+            elif pc:
+                dp = _pct(price, pc)
+            else:
+                dp = 0.0
 
             vol_str = (summary.get('ShareVolume') or {}).get('value') or ''
             volume = None
@@ -174,6 +210,8 @@ def get_nasdaq_quote(ticker: str) -> Optional[Dict]:
                 'dp': round(dp, 4),
                 'source': f'Nasdaq API ({assetclass})',
             }
+            if nc is not None:
+                result['nc'] = nc
             if volume:
                 result['volume'] = volume
             return result
@@ -493,8 +531,77 @@ def get_prev_close_polygon(ticker: str, api_key: str) -> Optional[tuple]:
         else:
             date_str = (datetime.now(timezone(timedelta(hours=-4))) - timedelta(days=1)).strftime('%Y-%m-%d')
         return (close, date_str)
-    except Exception:
+    except Exception as e:
+        print(f"  ⚠ Polygon prev-close {ticker} failed: {type(e).__name__}: {e}",
+              file=sys.stderr)
         return None
+
+
+def get_prev_closes_polygon_grouped(
+    tickers: List[str], api_key: str, today_et_date: str, max_lookback: int = 6,
+) -> tuple:
+    """Date-stamped prior closes for every ticker in ONE request.
+
+    Replaces a per-ticker loop over `/v2/aggs/ticker/{t}/prev` that quietly lost
+    most of its tickers: Polygon's free tier allows 5 requests/minute, the loop
+    fired ~15 back-to-back with no pacing, and `except: return None` swallowed
+    the 429s without a single log line. Only the first ~5 tickers ever got a
+    dated prev_close and *which* five drifted with ticker order, so the same bug
+    surfaced on different holdings each run (verified 2026-07-27: MSFU and SKHY
+    were positions 6 and 7 and silently got none).
+
+    `/v2/aggs/grouped/...` returns the whole US session — ~12.4k tickers — in a
+    single call, so the rate limit stops mattering. Walks back day by day
+    because the grouped endpoint returns an empty result set for weekends and
+    holidays rather than the last session.
+
+    Returns ({ticker: (close, date)}, rate_limited). `rate_limited` lets the
+    caller skip a per-ticker retry that would only burn the same exhausted quota.
+    """
+    out: Dict[str, tuple] = {}
+    if not api_key or not tickers:
+        return out, False
+    want = set(tickers)
+    probe = datetime.strptime(today_et_date, '%Y-%m-%d')
+    for _ in range(max_lookback):
+        probe -= timedelta(days=1)
+        if probe.weekday() >= 5:          # skip Sat/Sun without spending a call
+            continue
+        date_str = probe.strftime('%Y-%m-%d')
+        try:
+            r = SESSION.get(
+                f"https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/{date_str}",
+                params={'adjusted': 'true', 'apiKey': api_key},
+                timeout=max(TIMEOUT, 30),
+            )
+            if r.status_code == 429:
+                # Quota exhausted, not "this date has no data". Walking further
+                # back would spend the remaining budget on requests that are
+                # certain to fail too, so stop and let the caller know.
+                print(f"  ⚠ Polygon grouped {date_str}: HTTP 429 rate limited — "
+                      f"aborting prior-close lookup (prev_close falls back to the "
+                      f"provider's own field)", file=sys.stderr)
+                return out, True
+            if r.status_code != 200:
+                print(f"  ⚠ Polygon grouped {date_str}: HTTP {r.status_code} "
+                      f"{r.text[:120]}", file=sys.stderr)
+                continue
+            raw = r.json()
+        except Exception as e:
+            print(f"  ⚠ Polygon grouped {date_str} failed: {type(e).__name__}: {e}",
+                  file=sys.stderr)
+            continue
+        results = raw.get('results') or []
+        if not results:
+            continue                       # holiday / not yet published
+        _debug_dump('polygon_grouped', date_str, {'resultsCount': len(results)})
+        for res in results:
+            t = res.get('T')
+            if t in want and res.get('c'):
+                out[t] = (float(res['c']), date_str)
+        if out:
+            return out, False
+    return out, False
 
 
 # ── main fetch logic ─────────────────────────────────────────────────────────
@@ -503,21 +610,38 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
     """
     Fetch US stock quotes using multi-provider fallback.
     Returns {ticker: quote_dict} for all successfully fetched tickers.
+
+    A provider only *wins* a ticker with a complete quote (prior close + real
+    intraday range). Incomplete quotes are parked in `partial` and applied at
+    the end for whatever no richer provider could serve, so Nasdaq's
+    range-less payload no longer blocks Eastmoney/Finnhub.
     """
     results: Dict[str, Dict] = {}
+    partial: Dict[str, Dict] = {}
     remaining = list(tickers)
 
     def _done(ticker: str, quote: Dict):
         results[ticker] = quote
         remaining.remove(ticker)
 
+    def _offer(ticker: str, quote: Optional[Dict]) -> bool:
+        """Accept a complete quote; remember an incomplete one and keep looking."""
+        if not quote:
+            return False
+        if _quote_is_complete(quote):
+            _done(ticker, quote)
+            print(f"      ✓ {ticker}: ${quote['c']:.4f} ({quote['dp']:+.2f}%) [{quote['source']}]")
+            return True
+        partial.setdefault(ticker, quote)
+        missing = [k for k in ('pc', 'h', 'l') if quote.get(k) is None]
+        print(f"      ~ {ticker}: ${quote['c']:.4f} ({quote['dp']:+.2f}%) [{quote['source']}] "
+              f"incomplete (no {'/'.join(missing)}) — trying a richer provider")
+        return False
+
     # 1. Nasdaq API (per-ticker, handles stocks + ETFs without prefix guessing)
     print("  [1] Nasdaq API...")
     for t in list(remaining):
-        q = get_nasdaq_quote(t)
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+        _offer(t, get_nasdaq_quote(t))
     if not remaining:
         return results
 
@@ -526,49 +650,35 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
     em = get_eastmoney_batch(remaining)
     for t in list(remaining):
         if t in em:
-            q = em[t]
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+            _offer(t, em[t])
     if not remaining:
         return results
 
     # 3. Finnhub
     print(f"  [3] Finnhub for: {', '.join(remaining)}")
     for t in list(remaining):
-        q = get_finnhub_quote(t, keys.get('FINNHUB_API_KEY', ''))
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+        _offer(t, get_finnhub_quote(t, keys.get('FINNHUB_API_KEY', '')))
     if not remaining:
         return results
 
     # 4. Yahoo Finance v8 API
     print(f"  [4] Yahoo v8 for: {', '.join(remaining)}")
     for t in list(remaining):
-        q = get_yahoo_v8_quote(t)
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+        _offer(t, get_yahoo_v8_quote(t))
     if not remaining:
         return results
 
     # 5. yfinance library
     print(f"  [5] yfinance for: {', '.join(remaining)}")
     for t in list(remaining):
-        q = get_yfinance_quote(t)
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+        _offer(t, get_yfinance_quote(t))
     if not remaining:
         return results
 
     # 6. Alpha Vantage (slow, rate-limited at 25 calls/day on free tier)
     print(f"  [6] Alpha Vantage for: {', '.join(remaining)}")
     for t in list(remaining):
-        q = get_alpha_vantage_quote(t, keys.get('ALPHA_VANTAGE_API_KEY', ''))
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}]")
+        _offer(t, get_alpha_vantage_quote(t, keys.get('ALPHA_VANTAGE_API_KEY', '')))
     if not remaining:
         return results
 
@@ -579,6 +689,17 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
         if q:
             _done(t, q)
             print(f"      ✓ {t}: ${q['c']:.4f} (prev close) [{q['source']}]")
+
+    # 8. fall back to the best incomplete quote we saw — a price without a range
+    #    still beats no price, but it must be labelled so the caller does not
+    #    read the missing fields as "flat today".
+    for t in list(remaining):
+        if t in partial:
+            q = dict(partial[t])
+            q['incomplete'] = True
+            _done(t, q)
+            print(f"      ⚠ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}] "
+                  f"— incomplete quote, no richer provider answered")
 
     if remaining:
         print(f"  ✗ All providers failed: {', '.join(remaining)}")
@@ -645,12 +766,28 @@ def update_us_portfolio(
     prev_closes: Dict[str, tuple] = {}
     polygon_key = keys.get('POLYGON_API_KEY', '')
     if polygon_key:
-        print(f"  [PC] Polygon prev-close...")
-        for t in tickers:
-            result = get_prev_close_polygon(t, polygon_key)
-            if result:
-                prev_closes[t] = result
-                print(f"       ✓ {t}: ${result[0]:.4f} ({result[1]})")
+        print(f"  [PC] Polygon prev-close (grouped)...")
+        prev_closes, rate_limited = get_prev_closes_polygon_grouped(
+            tickers, polygon_key, today_et_date)
+        for t, result in prev_closes.items():
+            print(f"       ✓ {t}: ${result[0]:.4f} ({result[1]})")
+        # Per-ticker fallback for anything the grouped session did not list
+        # (rare: non-NMS venues). Bounded to the misses, so the 5/min free-tier
+        # limit stays out of reach — and skipped entirely once we know the quota
+        # is already gone, since those calls would just 429 as well.
+        missing = [t for t in tickers if t not in prev_closes]
+        if missing and rate_limited:
+            print(f"       ⚠ Polygon rate limited — no dated prior close for "
+                  f"{', '.join(missing)}; prev_close falls back to the quote "
+                  f"provider's own field", file=sys.stderr)
+        elif missing:
+            for t in missing:
+                result = get_prev_close_polygon(t, polygon_key)
+                if result:
+                    prev_closes[t] = result
+                    print(f"       ✓ {t}: ${result[0]:.4f} ({result[1]}) [per-ticker]")
+                else:
+                    print(f"       ✗ {t}: no Polygon prior close", file=sys.stderr)
 
     print(f"\n{'─'*62}")
     updated: List[str] = []
@@ -720,32 +857,88 @@ def update_us_portfolio(
                     pc_date = _prev_trading_day(today_et_date)
                 # else: leave pc = today's close (today_change falls back to 0, safe)
         else:
-            api_pc = q.get('pc', c)
+            # A prior close belongs to the PRIOR session, so it is stamped with
+            # _prev_trading_day() — never today. Stamping today_et_date here (the
+            # old behaviour) produced holdings whose prev_close_date equalled
+            # day_session_date, an impossible state that also tripped
+            # preflight_integrity's `opened_this_session` exemption and switched
+            # off the TODAY_LEG gate for exactly the rows this bug had touched.
+            prev_session = _prev_trading_day(today_et_date)
+            api_pc = q.get('pc')
             existing_pc      = holding.get('prev_close', 0)
             existing_pc_date = holding.get('prev_close_date', '')
             api_dp = q.get('dp', 0)
-            if api_pc != c:
-                pc, pc_date = api_pc, today_et_date
+            if api_pc is not None and api_pc != c:
+                pc, pc_date = api_pc, prev_session
             elif api_dp and abs(api_dp) > 0.01:
                 pc = round(c / (1 + api_dp / 100), 4)
-                pc_date = today_et_date
+                pc_date = prev_session
             elif existing_pc > 0 and existing_pc != c and existing_pc_date >= three_days_ago:
                 pc, pc_date = existing_pc, existing_pc_date
             else:
-                pc, pc_date = c, today_et_date
+                pc, pc_date = c, prev_session
+
+        # ── stale-last guard ④: last price identical to the PRIOR session close ──
+        # Nasdaq's lastSalePrice intermittently reverts to the prior close for
+        # thin / leveraged instruments. When it does, `c == pc` and every derived
+        # number agrees with every other one — today_change is 0, TODAY_LEG's
+        # `today_change == shares*(cur-prev_close)` holds exactly, and STALENESS
+        # passes because the data_source *timestamp* is fresh even though the
+        # *price* is not. A self-consistent lie clears every existing gate.
+        #
+        # Two independent prices matching to four decimals is ~impossible for a
+        # normally traded instrument, so treat it as stale whenever the provider
+        # itself reports a move. netChange rebuilds the true last exactly
+        # (2026-07-27 PLTU: pc 27.35 + nc 1.47 = 28.82, the real print, against a
+        # reported 27.35 that showed the position as flat on a +6.3% day);
+        # percentageChange is the rounder fallback.
+        stale_repair = None
+        api_dp_now = q.get('dp') or 0
+        if (pc and pc_date < today_et_date and abs(c - pc) < 1e-4
+                and abs(api_dp_now) > 0.05):
+            nc = q.get('nc')
+            if nc is not None and abs(nc) > 1e-9:
+                repaired = round(pc + nc, 4)
+                basis = 'netChange'
+            else:
+                repaired = round(pc * (1 + api_dp_now / 100), 4)
+                basis = 'percentageChange'
+            print(f"  ⚠ {t}: last ${c:.4f} == prior close ${pc:.4f} ({pc_date}) but "
+                  f"{q['source']} reports {api_dp_now:+.2f}% → stale last price; "
+                  f"rebuilt to ${repaired:.4f} from {basis} (stale-quote guard ④)",
+                  file=sys.stderr)
+            stale_repair = {'reported': c, 'repaired': repaired, 'basis': basis,
+                            'source': q['source'], 'at': now_et.strftime('%Y-%m-%d %H:%M ET')}
+            c = repaired
 
         # ③ degenerate-range warning: a live regular-session quote with
         # open==high==low==close has no intraday range → likely a stale/frozen
         # quote (the tell-tale signature of the 2026-05-29 swap). Warn-only.
+        # This alarm was dead until now: get_nasdaq_quote defaulted o/h/l to the
+        # last price, so it fired for every ticker on every fetch and meant
+        # nothing. Now that absent fields stay None, a flat range is once again
+        # a real signal from the provider rather than our own fabrication.
         if 9 <= now_et.hour < 16:
             o_, h_, l_ = q.get('o'), q.get('h'), q.get('l')
             if None not in (o_, h_, l_) and o_ == h_ == l_ == q['c']:
                 print(f"  ⚠ {t}: degenerate range (o=h=l=c=${q['c']:.4f}) mid-session "
-                      f"— possible stale quote (run with US_FETCH_DEBUG=1 to capture payload)")
+                      f"— possible stale quote (run with US_FETCH_DEBUG=1 to capture payload)",
+                      file=sys.stderr)
 
         holding['current_price']    = round(c, 4)
         holding['prev_close']       = round(pc, 4)
         holding['prev_close_date']  = pc_date
+        # Quality flags travel with the holding so downstream gates and the
+        # dashboard can see a repaired/incomplete quote instead of inferring
+        # health from numbers that were made to agree with each other.
+        if stale_repair:
+            holding['stale_price_repair'] = stale_repair
+        else:
+            holding.pop('stale_price_repair', None)
+        if q.get('incomplete'):
+            holding['quote_incomplete'] = True
+        else:
+            holding.pop('quote_incomplete', None)
         # Fresh-lot detection: when the ENTIRE current position was acquired
         # today, prev_close belongs to a lot you no longer hold — either an IPO
         # reference price you never got (SPCX 2026-06-12, prev_close was a stale

--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -75,6 +75,39 @@ def _pct(c: float, pc: float) -> float:
     return round((c - pc) / pc * 100, 4) if pc else 0.0
 
 
+def _parse_nasdaq_ts(s) -> Optional[str]:
+    """'Jul 27, 2026 9:34 AM ET' / 'Jul 23, 2026' -> '2026-07-27' / '2026-07-23'.
+
+    Nasdaq stamps every quote with the time of the print it is serving, and for
+    thin instruments that print can be days old (verified 2026-07-27 11:12 ET:
+    SPCH was still serving a Jul 22 10:22 ET trade, PLTU and CRCL a Jul 23 one).
+    This is the direct, unambiguous staleness signal and nothing was reading it.
+    """
+    if not s:
+        return None
+    text = str(s).strip().replace(' ET', '')
+    for fmt in ('%b %d, %Y %I:%M %p', '%b %d, %Y'):
+        try:
+            return datetime.strptime(text, fmt).strftime('%Y-%m-%d')
+        except ValueError:
+            continue
+    return None
+
+
+def _quote_is_fresh(q: Optional[Dict], today_et_date: str) -> bool:
+    """False only when the provider itself dates the print before today.
+
+    Deliberately not inferred from the numbers: a provider that tells you the
+    trade is four days old is stating a fact, whereas `current_price ==
+    prev_close` is only a strong hint. Quotes that carry no timestamp are
+    treated as fresh — absence of evidence must not fail a healthy provider.
+    """
+    if not q:
+        return False
+    asof = q.get('asof_date')
+    return not (asof and asof < today_et_date)
+
+
 def _quote_is_complete(q: Optional[Dict]) -> bool:
     """A quote is usable on its own only if it carries a real prior close AND a
     real intraday range.
@@ -212,6 +245,9 @@ def get_nasdaq_quote(ticker: str) -> Optional[Dict]:
             }
             if nc is not None:
                 result['nc'] = nc
+            asof = _parse_nasdaq_ts(primary.get('lastTradeTimestamp'))
+            if asof:
+                result['asof_date'] = asof
             if volume:
                 result['volume'] = volume
             return result
@@ -618,6 +654,8 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
     """
     results: Dict[str, Dict] = {}
     partial: Dict[str, Dict] = {}
+    stale: Dict[str, Dict] = {}
+    today_et_date = datetime.now(timezone(timedelta(hours=-4))).strftime('%Y-%m-%d')
     remaining = list(tickers)
 
     def _done(ticker: str, quote: Dict):
@@ -625,8 +663,17 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
         remaining.remove(ticker)
 
     def _offer(ticker: str, quote: Optional[Dict]) -> bool:
-        """Accept a complete quote; remember an incomplete one and keep looking."""
+        """Accept a fresh, complete quote; park anything else and keep looking."""
         if not quote:
+            return False
+        if not _quote_is_fresh(quote, today_et_date):
+            # The provider dated this print before today. Park it far behind an
+            # incomplete-but-current quote: a rangeless price from this session
+            # beats an exact price from four sessions ago.
+            stale.setdefault(ticker, quote)
+            print(f"      ✗ {ticker}: ${quote['c']:.4f} [{quote['source']}] "
+                  f"last trade dated {quote['asof_date']} (< {today_et_date}) "
+                  f"— stale print, rejected", file=sys.stderr)
             return False
         if _quote_is_complete(quote):
             _done(ticker, quote)
@@ -690,9 +737,10 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
             _done(t, q)
             print(f"      ✓ {t}: ${q['c']:.4f} (prev close) [{q['source']}]")
 
-    # 8. fall back to the best incomplete quote we saw — a price without a range
+    # 8. fall back to the best quote we had to reject — a price without a range
     #    still beats no price, but it must be labelled so the caller does not
-    #    read the missing fields as "flat today".
+    #    read the missing fields as "flat today". Current-but-incomplete first;
+    #    a print from an earlier session is the true last resort.
     for t in list(remaining):
         if t in partial:
             q = dict(partial[t])
@@ -700,6 +748,13 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
             _done(t, q)
             print(f"      ⚠ {t}: ${q['c']:.4f} ({q['dp']:+.2f}%) [{q['source']}] "
                   f"— incomplete quote, no richer provider answered")
+        elif t in stale:
+            q = dict(stale[t])
+            q['incomplete'] = True
+            q['stale_asof'] = q.get('asof_date')
+            _done(t, q)
+            print(f"      ⚠ {t}: ${q['c']:.4f} [{q['source']}] — every provider "
+                  f"failed; using a print dated {q['stale_asof']}", file=sys.stderr)
 
     if remaining:
         print(f"  ✗ All providers failed: {', '.join(remaining)}")

--- a/scripts/data/preflight_integrity.py
+++ b/scripts/data/preflight_integrity.py
@@ -32,6 +32,13 @@ cost_basis/prev_close/trades[])复原，且都有一道闸守着。计算链：
                  → HKD+USD 不能直接相加（fetch_fx 铁律）
   STALENESS      data_source / last_updated 不早于上一交易日              WARN
                  → 休市日写 stale 价当新 session（cac6222）
+  STALE_PRICE    current_price ≠ 上一交易日 prev_close（四位小数）         WARN
+                 → 上面每一条闸校的都是「内部算术自洽」或「时间戳标签」，
+                   而 stale 报价是自洽的：Nasdaq lastSalePrice 回退到昨收后
+                   today_change==0、TODAY_LEG 精确成立、data_source 戳还是今天
+                   → 全绿放行。2026-07-27 PLTU 账面 0.00%（实为 +6.3%）、
+                   SKHY 账面 -0.31%（实为 -6.2%）就是这么过闸的。
+                   两个独立价格四位小数完全相等 ≈ 不可能，本身即是最强判据。
   REALIZED_SUM   realized_pnl ≈ Σ(trades 里 realized_pnl)                WARN
   COST_BASIS     trades 账本完整(净股==shares)时 cost_basis==移动加权价  ERROR
                  → 算均价漏冲减 T+0 卖出 → 把已卖低价买单留在分母,均价偏低
@@ -381,6 +388,34 @@ def check(portfolio_path=PORTFOLIO):
                     add('STALENESS', 'WARN',
                         f'{t} data_source 日期 {iso} 早于上一交易日 {last}；可能 stale 价当新 session',
                         region, t)
+
+            # STALE_PRICE：现价与上一交易日前收四位小数完全相等
+            # 刻意不复用 opened_this_session 豁免：那条豁免的判据之一是
+            # prev_close_date == day_session_date，而写坏 prev_close_date 恰恰是同一个
+            # bug 的产物 → 会把这道闸对着「正需要拦的行」关掉。这里只认
+            # prev_close_date < day_session_date（真·上一交易日）这一种情况。
+            if (cur is not None and prev is not None and sh
+                    and h.get('prev_close_date') and sess_date
+                    and h['prev_close_date'] < sess_date
+                    and abs(cur - prev) < 1e-4):
+                add('STALE_PRICE', 'WARN',
+                    f'{t} current_price={cur:.4f} 与上一交易日前收 {prev:.4f}'
+                    f'（{h["prev_close_date"]}）四位小数完全相等；报价源大概率停在昨收，'
+                    f'当日涨跌被算成 0（today_change_pct={h.get("today_change_pct")}）',
+                    region, t)
+
+            # 数据源自己声明的质量降级，别让它只留在 stdout 里
+            if h.get('stale_price_repair'):
+                rp = h['stale_price_repair']
+                add('STALE_PRICE', 'WARN',
+                    f'{t} 报价源返回 {rp.get("reported")} == 昨收，已按 {rp.get("basis")} '
+                    f'重建为 {rp.get("repaired")}（{rp.get("source")} @ {rp.get("at")}）',
+                    region, t)
+            if h.get('quote_incomplete'):
+                add('STALE_PRICE', 'WARN',
+                    f'{t} 报价不完整（缺前收/日内区间），所有 provider 都没给全；'
+                    f'day_high/day_low 仅由本地累积器推得，别当真实区间读',
+                    region, t)
 
         # LEV_DIRECTION：恒科族两只以上且方向不一致
         nz = {k: v for k, v in sib_dirs.items() if abs(v) > 0.05}

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -1,0 +1,418 @@
+"""Regression net for the 2026-07-27 US quote incident.
+
+What actually shipped: PLTU sat on the dashboard at 0.00% on a +6.3% day and
+SKHY at -0.31% on a -6.2% day, and not one gate said a word. Five independent
+defects had to line up, so each gets a test:
+
+  1. Nasdaq `/info` carries no summaryData, but get_nasdaq_quote defaulted
+     pc/o/h/l to the last price -> every quote looked complete and flat.
+  2. Nasdaq is provider #1 and therefore always won, so Eastmoney/Finnhub
+     (which do return a real range) were never consulted.
+  3. Polygon's per-ticker prev-close loop burned through a 5 req/min free tier
+     and silently dropped everything past the fifth ticker.
+  4. A reconstructed prior close was stamped with *today's* date, which also
+     tripped preflight_integrity's `opened_this_session` exemption and switched
+     off TODAY_LEG for exactly the affected rows.
+  5. Nothing anywhere compared current_price against the prior close, so a last
+     price frozen at yesterday's close passed every check by being perfectly
+     self-consistent.
+
+Run: `python3 -m pytest tests/test_us_quote_staleness.py -q`
+"""
+import json
+import os
+import sys
+
+import pytest
+
+WS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(WS, "scripts", "data"))
+
+import fetch_us_stocks as F  # noqa: E402
+import preflight_integrity as pi  # noqa: E402
+
+
+# ── 1. the parser must not invent fields the payload does not have ───────────
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def json(self):
+        return self._payload
+
+
+# The real shape of api.nasdaq.com/api/quote/SPCX/info on 2026-07-27: rich
+# primaryData, and no summaryData key at all.
+NASDAQ_INFO_NO_SUMMARY = {
+    "data": {
+        "symbol": "PLTU",
+        "companyName": "Direxion Daily PLTR Bull 2X Shares",
+        "primaryData": {
+            "lastSalePrice": "$28.82",
+            "netChange": "+1.47",
+            "percentageChange": "+5.37%",
+            "deltaIndicator": "up",
+            "lastTradeTimestamp": "Jul 27, 2026 9:30 AM ET",
+            "isRealTime": True,
+        },
+        "assetClass": "ETF",
+    }
+}
+
+
+class TestNasdaqParserDoesNotFabricate:
+    def test_absent_summary_fields_stay_none(self, monkeypatch):
+        monkeypatch.setattr(F.SESSION, "get",
+                            lambda *a, **k: _FakeResp(NASDAQ_INFO_NO_SUMMARY))
+        q = F.get_nasdaq_quote("PLTU")
+        assert q is not None
+        assert q["c"] == 28.82
+        # The whole bug in one assertion: these used to silently become 28.82.
+        assert q["pc"] is None
+        assert q["o"] is None
+        assert q["h"] is None
+        assert q["l"] is None
+
+    def test_netchange_and_pct_are_kept(self, monkeypatch):
+        monkeypatch.setattr(F.SESSION, "get",
+                            lambda *a, **k: _FakeResp(NASDAQ_INFO_NO_SUMMARY))
+        q = F.get_nasdaq_quote("PLTU")
+        # netChange is the only exact way back to the prior close from /info.
+        assert q["nc"] == 1.47
+        assert q["dp"] == 5.37
+        assert round(q["c"] - q["nc"], 4) == 27.35   # the true prior close
+
+    def test_negative_netchange_parses(self, monkeypatch):
+        payload = json.loads(json.dumps(NASDAQ_INFO_NO_SUMMARY))
+        payload["data"]["primaryData"].update(
+            {"lastSalePrice": "$110.42", "netChange": "-5.50",
+             "percentageChange": "-4.78%"})
+        monkeypatch.setattr(F.SESSION, "get", lambda *a, **k: _FakeResp(payload))
+        q = F.get_nasdaq_quote("SPCX")
+        assert q["nc"] == -5.50 and q["dp"] == -4.78
+
+    def test_real_summary_payload_still_parses(self, monkeypatch):
+        payload = json.loads(json.dumps(NASDAQ_INFO_NO_SUMMARY))
+        payload["data"]["summaryData"] = {
+            "PreviousClose": {"value": "$27.35"},
+            "OpenPrice": {"value": "$28.00"},
+            "TodayHighLow": {"value": "$27.90 - $29.10"},
+            "ShareVolume": {"value": "2,703,700"},
+        }
+        monkeypatch.setattr(F.SESSION, "get", lambda *a, **k: _FakeResp(payload))
+        q = F.get_nasdaq_quote("PLTU")
+        assert (q["pc"], q["o"], q["l"], q["h"]) == (27.35, 28.00, 27.90, 29.10)
+        assert q["volume"] == 2703700
+
+
+class TestQuoteCompleteness:
+    def test_missing_range_is_incomplete(self):
+        assert not F._quote_is_complete({"c": 1.0, "pc": 1.0, "h": None, "l": None})
+
+    def test_missing_prev_close_is_incomplete(self):
+        assert not F._quote_is_complete({"c": 1.0, "pc": None, "h": 2.0, "l": 0.5})
+
+    def test_full_quote_is_complete(self):
+        assert F._quote_is_complete({"c": 1.0, "pc": 0.9, "h": 1.1, "l": 0.8})
+
+    def test_none_is_incomplete(self):
+        assert not F._quote_is_complete(None)
+
+
+# ── 2. an incomplete quote must not win the provider race ────────────────────
+class TestProviderRace:
+    def _silence(self, monkeypatch):
+        for name in ("get_eastmoney_batch",):
+            monkeypatch.setattr(F, name, lambda *a, **k: {})
+        for name in ("get_finnhub_quote", "get_yahoo_v8_quote",
+                     "get_yfinance_quote", "get_alpha_vantage_quote",
+                     "get_polygon_quote"):
+            monkeypatch.setattr(F, name, lambda *a, **k: None)
+
+    def test_richer_provider_overrides_rangeless_nasdaq(self, monkeypatch):
+        self._silence(monkeypatch)
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 28.82, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 5.37, "source": "Nasdaq API (etf)"})
+        monkeypatch.setattr(F, "get_finnhub_quote",
+                            lambda t, k: {"c": 29.07, "pc": 27.35, "h": 29.81,
+                                          "l": 28.41, "o": 28.515, "dp": 6.2888,
+                                          "source": "Finnhub"})
+        out = F.fetch_us_quotes(["PLTU"], {"FINNHUB_API_KEY": "x"})
+        assert out["PLTU"]["source"] == "Finnhub"
+        assert out["PLTU"]["l"] == 28.41
+        assert not out["PLTU"].get("incomplete")
+
+    def test_incomplete_quote_used_as_last_resort_and_flagged(self, monkeypatch):
+        self._silence(monkeypatch)
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 28.82, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 5.37, "source": "Nasdaq API (etf)"})
+        out = F.fetch_us_quotes(["PLTU"], {})
+        # Better than nothing, but it must say so rather than look healthy.
+        assert out["PLTU"]["c"] == 28.82
+        assert out["PLTU"]["incomplete"] is True
+
+    def test_complete_nasdaq_quote_short_circuits(self, monkeypatch):
+        self._silence(monkeypatch)
+        called = []
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 28.82, "pc": 27.35, "h": 29.0, "l": 28.0,
+                                       "o": 28.5, "dp": 5.37, "source": "Nasdaq API (etf)"})
+
+        def _spy(t, k):
+            called.append(t)
+            return None
+        monkeypatch.setattr(F, "get_finnhub_quote", _spy)
+        out = F.fetch_us_quotes(["PLTU"], {"FINNHUB_API_KEY": "x"})
+        assert out["PLTU"]["source"].startswith("Nasdaq")
+        assert called == []          # no wasted downstream calls
+
+
+# ── 3. one grouped request instead of a rate-limited per-ticker loop ─────────
+class TestPolygonGrouped:
+    def _grouped(self, monkeypatch, by_date, status=200):
+        seen = []
+
+        def _get(url, **kw):
+            date = url.rstrip("/").split("/")[-1]
+            seen.append(date)
+            if status != 200:
+                return _FakeResp({"status": "ERROR", "error": "rate limit"}, status)
+            return _FakeResp({"results": by_date.get(date, []), "status": "OK"})
+        monkeypatch.setattr(F.SESSION, "get", _get)
+        return seen
+
+    def test_all_tickers_from_a_single_request(self, monkeypatch):
+        seen = self._grouped(monkeypatch, {"2026-07-24": [
+            {"T": "SPCX", "c": 115.07}, {"T": "PLTU", "c": 27.35},
+            {"T": "MSFU", "c": 22.9}, {"T": "SKHY", "c": 154.57},
+            {"T": "RKLX", "c": 16.32}, {"T": "CRCL", "c": 62.36},
+            {"T": "NOISE", "c": 1.0},
+        ]})
+        out, limited = F.get_prev_closes_polygon_grouped(
+            ["SPCX", "PLTU", "MSFU", "SKHY", "RKLX", "CRCL"], "key", "2026-07-27")
+        # Positions 6 and 7 (MSFU/SKHY) are exactly what the old 5/min loop lost.
+        assert set(out) == {"SPCX", "PLTU", "MSFU", "SKHY", "RKLX", "CRCL"}
+        assert out["MSFU"] == (22.9, "2026-07-24")
+        assert out["SKHY"] == (154.57, "2026-07-24")
+        assert len(seen) == 1                      # one call, not one per ticker
+        assert limited is False
+
+    def test_weekend_is_skipped_without_spending_a_request(self, monkeypatch):
+        seen = self._grouped(monkeypatch, {"2026-07-24": [{"T": "SPCX", "c": 115.07}]})
+        out, _ = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
+        assert out["SPCX"] == (115.07, "2026-07-24")
+        assert "2026-07-25" not in seen and "2026-07-26" not in seen
+
+    def test_walks_back_over_an_empty_holiday_session(self, monkeypatch):
+        seen = self._grouped(monkeypatch, {
+            "2026-07-23": [{"T": "SPCX", "c": 120.0}],
+            "2026-07-24": [],                      # holiday / not yet published
+        })
+        out, _ = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
+        assert out["SPCX"] == (120.0, "2026-07-23")
+        assert seen == ["2026-07-24", "2026-07-23"]
+
+    def test_rate_limit_aborts_instead_of_burning_the_rest_of_the_quota(
+            self, monkeypatch):
+        # A 429 means "no budget left", not "this date has no data". Walking
+        # further back would spend the remaining requests on certain failures
+        # and starve the per-ticker fallback too.
+        seen = self._grouped(monkeypatch, {}, status=429)
+        out, limited = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
+        assert out == {} and limited is True
+        assert seen == ["2026-07-24"]              # exactly one attempt
+
+    def test_no_key_makes_no_request(self, monkeypatch):
+        seen = self._grouped(monkeypatch, {})
+        assert F.get_prev_closes_polygon_grouped(["SPCX"], "", "2026-07-27") == ({}, False)
+        assert seen == []
+
+
+# ── 4 + 5. end-to-end: the PLTU shape through update_us_portfolio ────────────
+def _portfolio(tmp_path, holding):
+    p = tmp_path / "portfolio.json"
+    p.write_text(json.dumps({
+        "last_updated": "2026/07/27 10:00 HKT",
+        "portfolios": {"us_stocks": {"currency": "USD", "holdings": [holding]}},
+    }), encoding="utf-8")
+    return str(p)
+
+
+@pytest.fixture
+def no_indices(monkeypatch):
+    monkeypatch.setattr(F, "fetch_us_indices", lambda: {})
+
+
+class TestStaleLastGuard:
+    BASE = {"ticker": "PLTU", "shares": 14, "cost_basis": 40.9571,
+            "trades": [{"date": "2026-04-16", "action": "buy", "shares": 14,
+                        "price": 40.9571}]}
+
+    def _run(self, monkeypatch, tmp_path, quote, prev_closes):
+        monkeypatch.setattr(F, "fetch_us_quotes", lambda t, k: {"PLTU": quote})
+        monkeypatch.setattr(F, "get_prev_closes_polygon_grouped",
+                            lambda t, k, d, **kw: (prev_closes, False))
+        monkeypatch.setattr(F, "get_prev_close_polygon", lambda t, k: None)
+        monkeypatch.setattr(F, "load_api_keys", lambda: {"POLYGON_API_KEY": "key"})
+        path = _portfolio(tmp_path, dict(self.BASE))
+        data = F.update_us_portfolio(portfolio_path=path, dry_run=True)
+        return data["portfolios"]["us_stocks"]["holdings"][0]
+
+    def test_frozen_last_is_rebuilt_from_netchange(self, monkeypatch, tmp_path,
+                                                   no_indices):
+        # Exactly 2026-07-27: Nasdaq served Friday's close as the last price
+        # while its own netChange still described a +5.37% day.
+        h = self._run(monkeypatch, tmp_path,
+                      {"c": 27.35, "pc": None, "h": None, "l": None, "o": None,
+                       "dp": 5.37, "nc": 1.47, "source": "Nasdaq API (etf)"},
+                      {"PLTU": (27.35, "2026-07-24")})
+        assert h["current_price"] == 28.82          # was 27.35 -> "flat today"
+        assert h["today_change_pct"] > 5.0          # was 0.0
+        assert h["today_change"] != 0
+        assert h["stale_price_repair"]["reported"] == 27.35
+        assert h["stale_price_repair"]["basis"] == "netChange"
+
+    def test_falls_back_to_percentage_change_without_netchange(
+            self, monkeypatch, tmp_path, no_indices):
+        h = self._run(monkeypatch, tmp_path,
+                      {"c": 27.35, "pc": None, "h": None, "l": None, "o": None,
+                       "dp": 5.37, "source": "Nasdaq API (etf)"},
+                      {"PLTU": (27.35, "2026-07-24")})
+        assert h["current_price"] == pytest.approx(28.8187, abs=1e-3)
+        assert h["stale_price_repair"]["basis"] == "percentageChange"
+
+    def test_genuinely_flat_day_is_left_alone(self, monkeypatch, tmp_path,
+                                              no_indices):
+        # c == pc with the provider ALSO reporting ~0% is a real flat day, not a
+        # stale print. Repairing it would invent movement that never happened.
+        h = self._run(monkeypatch, tmp_path,
+                      {"c": 27.35, "pc": 27.35, "h": 27.40, "l": 27.30,
+                       "o": 27.35, "dp": 0.0, "source": "Finnhub"},
+                      {"PLTU": (27.35, "2026-07-24")})
+        assert h["current_price"] == 27.35
+        assert "stale_price_repair" not in h
+
+    def test_healthy_quote_is_untouched(self, monkeypatch, tmp_path, no_indices):
+        h = self._run(monkeypatch, tmp_path,
+                      {"c": 29.25, "pc": 27.35, "h": 29.81, "l": 28.41,
+                       "o": 28.515, "dp": 6.95, "source": "Finnhub"},
+                      {"PLTU": (27.35, "2026-07-24")})
+        assert h["current_price"] == 29.25
+        assert "stale_price_repair" not in h
+
+    def test_reconstructed_prev_close_is_never_stamped_today(
+            self, monkeypatch, tmp_path, no_indices):
+        # No Polygon bar -> prev_close gets rebuilt from dp. It describes the
+        # PRIOR session, so it must not carry today's date: that impossible
+        # state is what disabled TODAY_LEG for MSFU/SKHY.
+        h = self._run(monkeypatch, tmp_path,
+                      {"c": 23.85, "pc": 22.9, "h": 24.28, "l": 23.64,
+                       "o": 23.65, "dp": 4.15, "source": "Finnhub"},
+                      {})
+        assert h["prev_close"] == 22.9
+        assert h["prev_close_date"] < h["day_session_date"]
+
+
+# ── the gate that should have caught it ──────────────────────────────────────
+def _mini_portfolio(holding):
+    return {
+        "portfolios": {
+            "us_stocks": {
+                "currency": "USD", "holdings": [holding],
+                "total_cost": round(holding["shares"] * holding["cost_basis"], 2),
+                "total_current_value": holding["current_value"],
+                "total_pnl": round(holding["current_value"]
+                                   - holding["shares"] * holding["cost_basis"], 2),
+                "today_total_change": holding["today_change"],
+            }
+        }
+    }
+
+
+PLTU_STALE = {
+    "ticker": "PLTU", "shares": 14, "cost_basis": 40.9571,
+    "current_price": 27.35, "current_value": 382.9,
+    "pnl_abs": round((27.35 - 40.9571) * 14, 2),
+    "pnl_percent": -33.2229,
+    "prev_close": 27.35, "prev_close_date": "2026-07-24",
+    "day_session_date": "2026-07-27",
+    "day_high": 28.82, "day_low": 27.35, "day_open": 28.82,
+    "today_change": 0.0, "today_change_pct": 0.0,
+    "data_source": "Nasdaq API (etf) Jul 27, 2026 10:33 ET",
+    "trades": [{"date": "2026-04-16", "action": "buy", "shares": 14,
+                "price": 40.9571}],
+}
+
+
+class TestIntegrityGateCatchesStalePrice:
+    def _findings(self, tmp_path, holding):
+        p = tmp_path / "portfolio.json"
+        p.write_text(json.dumps(_mini_portfolio(holding)), encoding="utf-8")
+        return pi.check(p)["findings"]
+
+    def test_stale_price_is_reported(self, tmp_path):
+        codes = {f["code"] for f in self._findings(tmp_path, dict(PLTU_STALE))}
+        assert "STALE_PRICE" in codes
+
+    def test_arithmetic_gates_stay_green_on_the_same_row(self, tmp_path):
+        # The point of the incident: everything else genuinely balances, which
+        # is why the row sailed through. If TODAY_LEG had caught it we would not
+        # have needed a new check.
+        codes = {f["code"] for f in self._findings(tmp_path, dict(PLTU_STALE))}
+        assert "TODAY_LEG" not in codes
+        assert "STALENESS" not in codes
+
+    def test_stale_price_is_warn_not_error(self, tmp_path):
+        p = tmp_path / "portfolio.json"
+        p.write_text(json.dumps(_mini_portfolio(dict(PLTU_STALE))), encoding="utf-8")
+        rep = pi.check(p)
+        stale = [f for f in rep["findings"] if f["code"] == "STALE_PRICE"]
+        assert stale and all(f["level"] == "WARN" for f in stale)
+        # Detection must never silence a report: publishing stays allowed.
+        assert rep["ok"] is True
+
+    def test_healthy_row_does_not_trip_it(self, tmp_path):
+        good = dict(PLTU_STALE)
+        good.update({"current_price": 29.25, "current_value": 409.5,
+                     "pnl_abs": round((29.25 - 40.9571) * 14, 2),
+                     "day_low": 28.41, "day_high": 29.81,
+                     "today_change": round((29.25 - 27.35) * 14, 2),
+                     "today_change_pct": 6.9469})
+        codes = {f["code"] for f in self._findings(tmp_path, good)}
+        assert "STALE_PRICE" not in codes
+
+    def test_ipo_style_row_is_not_flagged(self, tmp_path):
+        # prev_close_date == day_session_date means there is no real prior close
+        # (fresh IPO / same-session re-entry). Not a stale print -> stay quiet.
+        ipo = dict(PLTU_STALE)
+        ipo["prev_close_date"] = "2026-07-27"
+        codes = {f["code"] for f in self._findings(tmp_path, ipo)}
+        assert "STALE_PRICE" not in codes
+
+    def test_repair_flag_surfaces_in_the_gate(self, tmp_path):
+        repaired = dict(PLTU_STALE)
+        repaired.update({
+            "current_price": 28.82, "current_value": 403.48,
+            "pnl_abs": round((28.82 - 40.9571) * 14, 2),
+            "today_change": round((28.82 - 27.35) * 14, 2), "today_change_pct": 5.37,
+            "stale_price_repair": {"reported": 27.35, "repaired": 28.82,
+                                   "basis": "netChange", "source": "Nasdaq API (etf)",
+                                   "at": "2026-07-27 10:33 ET"},
+        })
+        msgs = [f["msg"] for f in self._findings(tmp_path, repaired)
+                if f["code"] == "STALE_PRICE"]
+        assert msgs and "netChange" in msgs[0]
+
+    def test_incomplete_quote_flag_surfaces(self, tmp_path):
+        incomplete = dict(PLTU_STALE)
+        incomplete.update({
+            "current_price": 28.82, "current_value": 403.48,
+            "pnl_abs": round((28.82 - 40.9571) * 14, 2),
+            "today_change": round((28.82 - 27.35) * 14, 2), "today_change_pct": 5.37,
+            "quote_incomplete": True,
+        })
+        codes = {f["code"] for f in self._findings(tmp_path, incomplete)}
+        assert "STALE_PRICE" in codes

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -106,6 +106,45 @@ class TestNasdaqParserDoesNotFabricate:
         assert q["volume"] == 2703700
 
 
+class TestLastTradeTimestamp:
+    """The provider states the age of its own print — read it.
+
+    2026-07-27 11:12 ET, live: SPCH was serving a Jul 22 10:22 ET trade, PLTU
+    and CRCL a Jul 23 one. Four and five sessions stale, said out loud in the
+    payload, and nothing in the pipeline looked. `current_price == prev_close`
+    only catches the subset where the frozen print happens to equal the prior
+    close — SPCH's did not, so that heuristic alone would have missed it.
+    """
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("Jul 27, 2026 9:34 AM ET", "2026-07-27"),
+        ("Jul 22, 2026 10:22 AM ET", "2026-07-22"),
+        ("Jul 23, 2026", "2026-07-23"),
+        ("Jan 05, 2026 4:00 PM ET", "2026-01-05"),
+        (None, None),
+        ("", None),
+        ("garbage", None),
+    ])
+    def test_timestamp_parsing(self, raw, expected):
+        assert F._parse_nasdaq_ts(raw) == expected
+
+    def test_quote_from_an_earlier_session_is_not_fresh(self):
+        assert not F._quote_is_fresh({"asof_date": "2026-07-23"}, "2026-07-27")
+
+    def test_todays_quote_is_fresh(self):
+        assert F._quote_is_fresh({"asof_date": "2026-07-27"}, "2026-07-27")
+
+    def test_missing_timestamp_is_treated_as_fresh(self):
+        # Providers that publish no timestamp must not be penalised.
+        assert F._quote_is_fresh({"c": 1.0}, "2026-07-27")
+
+    def test_asof_date_is_captured_from_the_payload(self, monkeypatch):
+        payload = json.loads(json.dumps(NASDAQ_INFO_NO_SUMMARY))
+        payload["data"]["primaryData"]["lastTradeTimestamp"] = "Jul 23, 2026"
+        monkeypatch.setattr(F.SESSION, "get", lambda *a, **k: _FakeResp(payload))
+        assert F.get_nasdaq_quote("PLTU")["asof_date"] == "2026-07-23"
+
+
 class TestQuoteCompleteness:
     def test_missing_range_is_incomplete(self):
         assert not F._quote_is_complete({"c": 1.0, "pc": 1.0, "h": None, "l": None})
@@ -153,6 +192,49 @@ class TestProviderRace:
         # Better than nothing, but it must say so rather than look healthy.
         assert out["PLTU"]["c"] == 28.82
         assert out["PLTU"]["incomplete"] is True
+
+    def test_days_old_print_loses_to_a_current_one(self, monkeypatch):
+        # The exact SPCH shape: Nasdaq's price is precise but five sessions old,
+        # Finnhub's is this session. Recency wins.
+        self._silence(monkeypatch)
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 7.595, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 0.0, "asof_date": "2026-07-22",
+                                       "source": "Nasdaq API (etf)"})
+        monkeypatch.setattr(F, "get_finnhub_quote",
+                            lambda t, k: {"c": 6.15, "pc": 6.65, "h": 6.65, "l": 5.9,
+                                          "o": 6.5, "dp": -7.52, "source": "Finnhub"})
+        out = F.fetch_us_quotes(["SPCH"], {"FINNHUB_API_KEY": "x"})
+        assert out["SPCH"]["c"] == 6.15
+        assert out["SPCH"]["source"] == "Finnhub"
+
+    def test_days_old_print_also_loses_to_an_incomplete_current_one(self, monkeypatch):
+        # A rangeless price from this session still beats an exact price from
+        # four sessions ago, so the stale one must rank below `partial`.
+        self._silence(monkeypatch)
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 27.35, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 0.0, "asof_date": "2026-07-23",
+                                       "source": "Nasdaq API (etf)"})
+        monkeypatch.setattr(F, "get_yahoo_v8_quote",
+                            lambda t: {"c": 29.52, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 7.93, "source": "Yahoo v8"})
+        out = F.fetch_us_quotes(["PLTU"], {})
+        assert out["PLTU"]["c"] == 29.52
+        assert out["PLTU"]["incomplete"] is True
+
+    def test_stale_print_is_last_resort_and_labelled(self, monkeypatch):
+        # Nothing else answered at all -> use it, but say how old it is rather
+        # than let it look like a live quote.
+        self._silence(monkeypatch)
+        monkeypatch.setattr(F, "get_nasdaq_quote",
+                            lambda t: {"c": 7.595, "pc": None, "h": None, "l": None,
+                                       "o": None, "dp": 0.0, "asof_date": "2026-07-22",
+                                       "source": "Nasdaq API (etf)"})
+        out = F.fetch_us_quotes(["SPCH"], {})
+        assert out["SPCH"]["c"] == 7.595
+        assert out["SPCH"]["stale_asof"] == "2026-07-22"
+        assert out["SPCH"]["incomplete"] is True
 
     def test_complete_nasdaq_quote_short_circuits(self, monkeypatch):
         self._silence(monkeypatch)


### PR DESCRIPTION
## 触发

2026-07-27 盘中，dashboard 上 **PLTU 在 +6.3% 的一天里显示 `today_change: 0`**，**SKHY 在 -6.2% 的一天里显示 -0.31%**（账面 $154.0951 ≈ 周五收盘，实时 $139.57）。全链**一声告警都没有**。

kcn 的原话是「我其实只是好奇为什么会拉错数字但是又没告警」——所以这个 PR 有两半：**为什么拉错**，和**为什么没拦住**。

## 为什么拉错（4 处）

### ① `/info` 端点根本没有 `summaryData` 键

实测 `api.nasdaq.com/api/quote/{t}/info`（stocks 与 etf 两种 assetclass），返回的 `data` 键是：

```
symbol, companyName, stockType, exchange, isNasdaqListed, isNasdaq100,
isHeld, primaryData, secondaryData, marketStatus, assetClass, keyStats, notifications
```

**没有 `summaryData`** —— `PreviousClose` / `OpenPrice` / `TodayHighLow` 在另一个端点 `/summary`。而解析器写的是：

```python
pc = _parse_price(...PreviousClose...) or price
op = _parse_price(...OpenPrice...)    or price
high, low = price, price
```

三个兜底**每次必然命中** → 每条 Nasdaq 报价都是 `o == h == l == c == pc`，唯一真值只有 `percentageChange` / `netChange`。

> 这里最值得记的一点：**那个 `o=h=l=c` 的退化区间不是数据源给的 stale quote，是我们自己造的。** 一开始按「Nasdaq 返回了 stale 报价」去查，方向是反的。

**连带后果**：`degenerate range` 那条 mid-session 警告本来是抓 2026-05-29 stale-swap 的哨兵，但它对**每个 ticker 每次 fetch** 都会喊 → 纯噪音，狼来了。修完才重新变成真信号。

### ② Nasdaq 是 provider #1 且几乎永不失败

`fetch_us_quotes` 顺序是 Nasdaq → Eastmoney → Finnhub → …，只要 `lastSalePrice` 能解析就 `return`。所以**自带真实 o/h/l/pc 的源永远够不着**。新增 `_quote_is_complete`：缺前收或缺日内区间的报价不再赢下 ticker，只作最后兜底并打 `incomplete` 标。

### ③ Polygon 免费档 5 请求/分钟，超限被静默吞

前收是对 ~15 个 ticker **裸循环无间隔**打 `/v2/aggs/ticker/{t}/prev`，`except: return None` 连一行日志都不打。实测连打 7 个：前 5 个 200，第 6、7 个返回 None，隔 65s 单独再打立刻 200。→ **每轮只有前 ~5 个 ticker 拿得到日期戳前收，且「哪五个」随 ticker 顺序漂移**，所以同一个 bug 在不同 ticker 上时隐时现（MSFU/SKHY 正好排第 6、7 位）。

改走 grouped 端点：**一次请求返回全场 ~12,410 个 ticker**，限流不再相关。429 现在打 stderr 并**中止回溯**——rate limit 不是「这天没数据」，继续往前走只会把剩余额度烧在必然失败的日期上。

### ④ 重建的前收被盖上「今天」的日期戳

`pc_date = today_et_date`（而并行的 Polygon 分支用的是 `_prev_trading_day()`），产出 `prev_close_date == day_session_date` 这种逻辑上不可能的状态。已统一。

## 为什么没拦住（这才是重点）

四道本该拦住它的闸全部结构性失效：

| 闸 | 为什么没响 |
|---|---|
| `degenerate range` 警告 | 只是 stdout 一句 `print`，从不上报；且因 ① 对 100% ticker 都喊 |
| Polygon 429 | `except: return None` 吞掉，零日志 |
| `TODAY_LEG` | 校 `today_change == shares×(cur−prev_close)`。PLTU 是 `0 == 14×(27.35−27.35)` → **完美通过**。stale 价被一致地抄进所有派生字段后是**数学自洽**的 |
| `STALENESS` | 比的是 `data_source` 里的**日期字符串**（"Jul 27, 2026 10:33 ET" → 今天 → 过）。**价是周五的，标签是今天的；闸看标签不看值** |

最阴的一条：**④ 的产物会把唯一可能抓到它的闸关掉**。`opened_this_session` 的判据之一就是 `prev_close_date == day_session_date`，命中即跳过 `TODAY_LEG`——而 MSFU/SKHY 的 `prev_close_date` 正是被 ④ 错标成今天的，于是自动豁免。

### 新增两道

**`stale-last guard`（fetcher 侧）**：现价与上一交易日前收**四位小数完全相等**、而报价源自己却报了涨跌 → 判定停滞报价，按 `netChange` 精确重建（PLTU：`27.35 + 1.47 = 28.82`，正是真实成交价），并把 `stale_price_repair` 写进 holding。**真·平盘（源也报 ~0%）不动**，否则就是凭空造出没发生过的波动。

**`STALE_PRICE`（体检侧）**：直接校 `current_price` vs 上一交易日前收。刻意**不复用** `opened_this_session` 豁免，避免重蹈「被同一个 bug 的产物关掉」。等级 `WARN`——按既有约定，检测可以有，但不许降级成「整档不发」，`ok` 仍只看 ERROR。

## 验证

- 新增 `tests/test_us_quote_staleness.py`，28 条。**逐条做过变异验证**：把每个修复单独改回旧行为（恢复 `or price`、让不完整报价赢下 race、关掉 stale 重建、把重建前收改回盖今天、grouped 只返回前 5 个、删掉 STALE_PRICE、把 429 当成「换个日期重试」），确认对应用例转红后再还原。
- 全套 **1100 passed / 5 xfailed**。
- 真实 API dry-run：7 个持仓全部被正确判为 Nasdaq 不完整 → 落 Finnhub 拿到真区间；**grouped 一次请求给全 7 个日期戳前收**（含旧代码一直丢失的 MSFU/SKHY/RKLX/CRCL）。

## 已单独止血

`portfolio.json` / `dashboard.json` 已用非 Nasdaq 源刷过（PLTU `0.00% → +6.95%`，SKHY `-0.31% → -6.24%`，当日合计 `+5.83 → -40.21`，符号是反的），并清掉了被假价污染的 `day_low`（PLTU 27.35 是个从未成交过的「低点」）。体检 0 ERROR / 0 WARN。**那部分走 automation 的直推路径，不在本 PR 内。**

## 复核建议

- ⑤ 的重建用 `netChange` 优先、`percentageChange` 兜底。前者精确，后者因为百分比只有两位小数会有 ~0.005% 误差 —— 这个取舍是否接受？
- `STALE_PRICE` 用 `WARN` 而非 `ERROR`：stale 报价确实会污染当日 P&L，但设成 ERROR 会阻止发布，与「不许降级成不发」冲突。
- ③ 的 grouped 端点在免费档可用性已实测确认，但它是**日线**数据；只用于前收，不碰盘中价。
