### PR TITLE
fix(intraday): 数据块不再经模型往返，一个空格不该丢掉整段分析

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -68,9 +68,10 @@
         "trading_calendar.py {market}",
         "skills/{skill}/SKILL.md",
         "intraday_preflight.py --market {market}",
-        "intraday_postflight.py --market {market}",
+        "context_id",
+        "intraday_postflight.py --market {market} --context-id",
         "--text-file",
-        "intraday-report-{market}.md",
+        "intraday-prose-{market}.md",
         "intraday-insights-",
         "目标 ≤ 2200 字",
         ">3000 字 warn",
@@ -89,7 +90,9 @@
         ">2000 字 warn",
         ">2500 字 fail",
         "唯一发送路径",
-        "<<<"
+        "<<<",
+        "verbatim",
+        "intraday-report-"
       ]
     },
     "brief": {

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -43,7 +43,7 @@ title: clawock · scripts 详细参考
 
 **Mode 7 intraday**（HK + US 盘中盯盘 — 3 个 cron job 共享同一套脚本；季节化 slot 数和精确时间只看生成调度表，隔夜始终最晚 02:30 HKT）
 - **`scripts/harness/intraday_preflight.py --market {hk|us}`**：跑 analyze_*.py + 异动检测 + `should_alert` 决策；输出 `memory/.tmp/intraday-context-{market}-latest.json`
-- **`scripts/harness/intraday_postflight.py --market {hk|us} --text-file memory/.tmp/intraday-report-{hk|us}.md`**（**先写文件再调用，禁 heredoc/`<<<`**；空输入/超 20 分钟的旧文件判 `status: input_error` 并拒投）：校验 ▎我的看法 / 长度 / should_alert 触发时报告必须提异动票；不提交 `portfolio.json`，dashboard 仅在语义变化时 commit + push；无论有无 dashboard diff 都更新本地 slot heartbeat，交 single publisher 发布。
+- **`scripts/harness/intraday_postflight.py --market {hk|us} --context-id {preflight 的 context_id} --text-file memory/.tmp/intraday-prose-{hk|us}.md`**（**先写文件再调用，禁 heredoc/`<<<`**；空输入/超 20 分钟的旧文件判 `status: input_error` 并拒投）：模型只写 `▎我的看法` 散文，`assemble_message()` 在发送时把 `raw_wechat_block` 拼在前面 —— 数据块不再经模型往返，也就不会被重排版打坏。`--context-id` 不匹配 = 散文与数据不同代，拒绝拼装只发数据块。校验 ▎我的看法 / should_alert 异动票提及只针对模型写的那段（长度算拼装后的整条）；不提交 `portfolio.json`，dashboard 仅在语义变化时 commit + push；无论有无 dashboard diff 都更新本地 slot heartbeat，交 single publisher 发布。省略 `--context-id` 回落到 legacy 整报告模式（保留 verbatim 校验），供未迁移的 payload 过渡。
 
 **共通设计点**：
 - `raw_wechat_block`：**Mode 6 报告**（report_postflight）由 harness 自己拼进消息，LLM 只写散文、不碰数据块；**intraday** 仍是 LLM verbatim 拷贝 + postflight 首行验证

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -5,6 +5,7 @@ Extracted to avoid duplicating _git / rebuild_dashboard / push retry logic
 across multiple postflight scripts. All functions accept the workspace root
 as path argument or default to the resolved workspace root.
 """
+import hashlib
 import json
 import re
 import subprocess
@@ -28,6 +29,30 @@ DASHBOARD_PUBLISH_LOCK = '/tmp/dashboard_publish.lock'
 # check can surface silent build failures / degradations (kcn doesn't want
 # per-cron alerts — see feedback_no_individual_cron_alerts).
 DASHBOARD_BUILD_STATUS = 'logs/dashboard_build_status.json'
+
+
+def compute_context_id(result):
+    """A per-GENERATION id for a preflight output.
+
+    The model echoes it back to postflight (`--context-id`), which refuses to
+    assemble prose against a context that has since been replaced. This is the
+    guard the 2026-07-24 incident needed: the agent ran preflight a SECOND time
+    mid-turn, so disk held generation B while its prose described generation A —
+    'one context per run' is not something the harness can assume.
+
+    NOT a digest of the underlying data: `raw_wechat_block` embeds the fetch
+    minute, so any re-run yields a fresh id even with identical portfolio numbers.
+    That is the intended contract — the id pins prose to THIS exact preflight
+    output, and the failure mode is always fail-safe (a mismatch drops to the
+    data block, never marries fresh numbers to stale prose). The only way to get
+    a rejection is for prose to carry an id from a superseded generation, which is
+    exactly what we want caught. `context_id` itself is not yet in `result`.
+
+    Shared by report_preflight (Mode 6) and intraday_preflight (Mode 7) so both
+    legs pin prose the same way.
+    """
+    blob = json.dumps(result, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(blob.encode()).hexdigest()[:12]
 
 
 def pct(c, pc):

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -15,10 +15,18 @@ Empty or stale input is reported as `status: input_error` — a plumbing failure
 distinct from `fail` (the report itself is bad). It still exits non-zero: this is
 the delivery gate, and a false green is worse than a false red.
 
+Two input modes, selected by `--context-id`:
+  prose (canonical, with --context-id): the model writes ONLY the ▎我的看法 prose;
+      assemble_message() prepends the harness-owned data block at send time.
+  legacy (no --context-id): the model's text IS the whole message and the data
+      block is checked for a byte-exact copy. Kept so a cron payload that has not
+      been migrated yet still delivers.
+
 Validates:
   1. ▎我的看法 段必须存在 + 段内容 ≥ 60 字（防敷衍 1 句话）
   2. 总长度 ≤ 3000 字 (warn), ≤ 3500 字 (fail) — 与 Mode 6 US 对齐
-  3. 必须以 raw_wechat_block 开头 (verbatim)
+  3. legacy 模式：必须以 raw_wechat_block 开头且表格逐字符复制
+     prose 模式：数据块由 harness 拼装，无往返可校验
   4. 若 preflight should_alert=true：报告必须提到至少一个异动票或 alert_reason
   5. 无敷衍 phrases
 
@@ -80,8 +88,9 @@ def load_context(market):
 
 def read_report_text(market, text_file):
     """Return (text, input_error). Plumbing failures never reach validate()."""
-    hint = (f'Step 3 应先把报告写入 memory/.tmp/intraday-report-{market}.md，'
-            f'再用 --text-file 调用 postflight；不要用 heredoc/<<< 喂 stdin')
+    hint = (f'Step 3 应先把 ▎我的看法 散文写入 memory/.tmp/intraday-prose-{market}.md，'
+            f'再用 --text-file + --context-id 调用 postflight；'
+            f'不要用 heredoc/here-string 重定向喂 stdin')
     if text_file:
         path = Path(text_file)
         if not path.exists():
@@ -129,21 +138,56 @@ def input_error(market, err):
     return 2
 
 
-def validate(text, ctx):
+def assemble_message(ctx, prose):
+    """Build the delivered check-in from harness-owned data + model-owned prose.
+
+    Mode 7 used to make the deterministic data block round-trip through the LLM:
+    preflight put it in the context, the payload ordered the model to retype it
+    character for character, and validate() diffed the copy. Mode 6 dropped that
+    on 2026-07-24; Mode 7 was left behind and kept paying for it — on 2026-07-28
+    00:30 the model padded RKLX's 浮$ cell with one extra space, the strict
+    substring check raised a CRITICAL, and the whole ▎我的看法 段 was dropped in
+    favour of the bare data block. The table was correct; only its whitespace
+    was not.
+
+    Prepending here removes the round trip: the numbers in the delivered message
+    come from the context file at send time, so they cannot be paraphrased or
+    table-mangled — no copy instruction and no verbatim rule needed. Mode 7 has
+    no separate `title`; raw_wechat_block already opens with the titled first
+    line, so the block alone is the prefix.
+    """
+    parts = [(ctx.get('raw_wechat_block') or '').strip(), (prose or '').strip()]
+    return '\n\n'.join(p for p in parts if p)
+
+
+def validate(text, ctx, prose_only=False, model_text=None):
+    """Validate the delivered check-in.
+
+    `text` is what gets sent. `model_text` is the part the MODEL wrote; in prose
+    mode that is the prose alone, in legacy mode it is the whole report.
+
+    The content rules — 我的看法 段, anomaly mention, forbidden phrases, numeric
+    claims — MUST run against model_text, never the assembled body. The prepended
+    block itself contains the anomaly tickers and section-looking tokens, so
+    checking the body would let prose that names none of the movers pass because
+    the table does. Only the length limit is a property of the assembled body.
+    (Same split as report_postflight.validate — see its docstring.)
+    """
     issues = []
+    checked = text if model_text is None else model_text
 
     raw = ctx.get('raw_wechat_block', '').strip()
-    if raw:
+    if raw and not prose_only:
         first_line = raw.splitlines()[0]
         if first_line not in text:
             issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 失败)')
         issues.extend(check_raw_tables_verbatim(text, raw))
 
-    if REQUIRED_SECTION not in text:
+    if REQUIRED_SECTION not in checked:
         issues.append(f'缺段标记 "{REQUIRED_SECTION}"')
     else:
         # 我的看法 段必须 ≥ 60 字（否则就是敷衍 1 句结案）
-        section_body = text.split(REQUIRED_SECTION, 1)[1].strip()
+        section_body = checked.split(REQUIRED_SECTION, 1)[1].strip()
         # cut to next section (▎XXX) or end
         next_marker = section_body.find('\n▎')
         if next_marker > 0:
@@ -155,6 +199,8 @@ def validate(text, ctx):
                 f'(< 60 软下限)；需引用具体票 + 一行判断'
             )
 
+    # Length is a property of what actually gets pushed to WeChat, so it — and
+    # only it — measures the assembled body.
     n = len(text)
     if n > 3500:
         issues.append(f'报告长度 {n} 字 > 3500 上限')
@@ -163,14 +209,14 @@ def validate(text, ctx):
 
     if ctx.get('should_alert'):
         anomaly_tickers = [a['ticker'] for a in ctx.get('anomalies', [])]
-        mentioned = [t for t in anomaly_tickers if t in text]
+        mentioned = [t for t in anomaly_tickers if t in checked]
         if anomaly_tickers and not mentioned:
             issues.append(f'should_alert=true 但报告未提任何异动票 ({", ".join(anomaly_tickers)})')
 
-    issues.extend(validate_forbidden_phrases(text, FORBIDDEN_PHRASES))
+    issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
 
     # 数字必须来自 context —— 一条聚合 warn，见 check_numeric_claims
-    issues.extend(check_numeric_claims(text, ctx))
+    issues.extend(check_numeric_claims(checked, ctx))
 
     return issues
 
@@ -211,6 +257,11 @@ def main():
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
     parser.add_argument('--text-file',
                         help='report text file (canonical path; stdin only for manual runs)')
+    parser.add_argument('--context-id',
+                        help='the context_id printed by intraday_preflight. Passing it '
+                             'selects prose mode: the file holds ONLY the ▎我的看法 prose '
+                             'and the harness prepends the data block. Omit for legacy '
+                             'whole-report input.')
     args = parser.parse_args()
 
     # Holiday/weekend gate: no send/publish on a closed market.
@@ -240,8 +291,28 @@ def main():
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
 
-    issues = validate(text, ctx)
-    status = categorize(issues)
+    prose_only = args.context_id is not None
+
+    # ── Generation gate (prose mode only) ────────────────────────────────────
+    # The model echoes the context_id it wrote against. A mismatch means the
+    # context on disk was replaced after the prose was written — the agent ran
+    # preflight a second time mid-turn. Assembling fresh numbers under stale
+    # prose would produce an internally contradictory check-in that LOOKS clean,
+    # so refuse to assemble and fall through to the data-block-only path.
+    stale_generation = prose_only and args.context_id != ctx.get('context_id')
+
+    # Keep the model's own text for the content rules; assemble the delivered
+    # body separately, so the prepended block never satisfies a rule on the
+    # model's behalf.
+    model_text = text if prose_only else None
+    if prose_only and not stale_generation:
+        text = assemble_message(ctx, text)
+
+    issues = ([f'context_id 不匹配: 模型基于 {args.context_id}，当前 context 是 '
+               f'{ctx.get("context_id")} — 散文与数据不同代，拒绝拼装']
+              if stale_generation
+              else validate(text, ctx, prose_only=prose_only, model_text=model_text))
+    status = 'fail' if stale_generation else categorize(issues)
 
     # Step 2.5 sidecar liveness (warn-only, stderr — NOT in the WeChat report):
     # the dashboard status banner went dark 06-04→06-10 when a payload rewrite
@@ -362,10 +433,12 @@ def main():
     result = {
         'status':        status,
         'market':        args.market,
+        'mode':          'prose' if prose_only else 'legacy',
         'time':          datetime.now().strftime('%H:%M'),
         'issues':        issues,
         'wechat_prefix': wechat_prefix,
         'n_chars':       len(text),
+        'n_chars_model': len(model_text) if model_text is not None else len(text),
         'wechat_sent':   wechat_sent,
         'telegram_sent': tg_ok,
         'dashboard_published': dashboard_published,

--- a/scripts/harness/intraday_preflight.py
+++ b/scripts/harness/intraday_preflight.py
@@ -9,7 +9,10 @@ Runs deterministic work for the 3 intraday cron jobs (every 30 min):
 
 Each invocation:
   1. Runs analyze_{hk,us}_stocks.py --wechat
-  2. Captures stdout (LLM uses verbatim)
+  2. Captures stdout as `raw_wechat_block` — the harness owns it end to end:
+     intraday_postflight prepends it to the model's prose at send time, so it
+     never makes a round trip through the LLM (see that module's
+     assemble_message docstring for the 2026-07-28 mangling this removed)
   3. Detects anomalies (≥3% move, RSI extremes from script signals)
   4. Decides should_alert: bool (true if any anomaly OR ≥2 signals)
   4b. Collects peer/rotation data for this leg (`peer_scan`), free Tencent feed
@@ -36,6 +39,9 @@ from pathlib import Path
 WS = Path(__file__).resolve().parents[2]
 DATA_DIR = WS / 'scripts' / 'data'
 TMP = WS / 'memory' / '.tmp'
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _harness_common import compute_context_id  # noqa: E402
 
 sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
@@ -259,6 +265,10 @@ def main():
         'mover_news':       mover_news_ctx,
         'heartbeat':        {'job': heartbeat['job'], 'slot': heartbeat['slot']},
     }
+    # Last field: the id digests everything above it, and the model echoes it to
+    # postflight so prose can never be assembled onto a context that was
+    # regenerated mid-turn. Must stay after the dict is otherwise complete.
+    result['context_id'] = compute_context_id(result)
 
     cron_heartbeat.record(
         args.market, 'preflight_ok', job_name=heartbeat['job'],

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -43,7 +43,6 @@ Output keys:
 """
 
 import argparse
-import hashlib
 import json
 import re
 import subprocess
@@ -56,6 +55,9 @@ from pathlib import Path
 WS = Path(__file__).resolve().parents[2]
 DATA_DIR = WS / 'scripts' / 'data'
 TMP = WS / 'memory' / '.tmp'
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _harness_common import compute_context_id  # noqa: E402,F401 — re-exported for callers/tests
 
 sys.path.insert(0, str(DATA_DIR))
 import trading_calendar  # noqa: E402
@@ -116,27 +118,6 @@ def drop_stale_contexts(market, phase, today):
         print(f'   🧹 dropped {len(dropped)} stale report tmp file(s): {", ".join(sorted(dropped))}',
               file=sys.stderr)
     return dropped
-
-
-def compute_context_id(result):
-    """A per-GENERATION id for this preflight output.
-
-    The model echoes it back to postflight (`--context-id`), which refuses to
-    assemble prose against a context that has since been replaced. This is the
-    guard the 2026-07-24 incident needed: the agent ran preflight a SECOND time
-    mid-turn, so disk held generation B while its prose described generation A —
-    'one context per run' is not something the harness can assume.
-
-    NOT a digest of the underlying data: `raw_wechat_block` embeds the fetch
-    minute, so any re-run yields a fresh id even with identical portfolio numbers.
-    That is the intended contract — the id pins prose to THIS exact preflight
-    output, and the failure mode is always fail-safe (a mismatch drops to the
-    data block, never marries fresh numbers to stale prose). The only way to get
-    a rejection is for prose to carry an id from a superseded generation, which is
-    exactly what we want caught. `context_id` itself is not yet in `result`.
-    """
-    blob = json.dumps(result, ensure_ascii=False, sort_keys=True)
-    return hashlib.sha256(blob.encode()).hexdigest()[:12]
 
 
 PEER_TOP_N = 5

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -86,7 +86,7 @@ python3 /root/.openclaw/workspace/scripts/data/analyze_hk_stocks.py --no-fetch  
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market hk
 ```
-跑 `scripts/data/analyze_hk_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`。
+跑 `scripts/data/analyze_hk_stocks.py --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`，并把**同一份 JSON** 打到 stdout（含 `context_id` —— Step 3 要原样回传）。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 - `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
   - `status=no_recent_filing` 是**明确的空**：写「窗口内无一手公告」，不要改口编一个理由；`status=degraded` 说明源没抓到，同样如实写。
@@ -97,13 +97,11 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - `halts`（仅美股，每 slot 一次共享请求）：持仓或其标的被停牌时给出 `reason_code`（LULD 的 `LUDP` 最常打到 2x ETF）与复牌时间；港股停牌走公告（已在 triage 里判 interrupt）。
 关键字段：`should_alert` (bool) + `alert_reasons` (异动票/STOP 计数等)。另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）和 `plan_context`（08:00 简报为本腿定下、尚未成交的决策）。
 
-#### Step 2: 写报告
-- 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）
-  - intraday 的 holdings 是 **markdown 表格**（7 列：代码/股/成本/现价/今日/浮%/浮$，右对齐数字。走 `scripts/data/_wechat_table.py` 的 visual-width-aware 渲染，去 HK$ 前缀 + 加 浮$ 金额列）
-  - ⚠️ **表格的 3 类行（表头 / 分隔 `|:--|--:|...|` / 每条数据）每一字符 1:1 复制**，不要数列重写分隔行 — 5/21 后多次因 LLM 自己写分隔行少一段 `--:|` 导致渲染失败（postflight 会 fail）
-  - **市值/浮盈/今日 已经是单行用 `|` 分隔的格式** — 不要拆 3 行
-  - **`📉 亏损持仓 X/Y | 2x杠杆敞口 N%` 必须保留**，不要省
-- 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
+#### Step 2: 只写 `▎我的看法` 散文（数据块归 harness）
+- ❌ **不要抄 `raw_wechat_block`，不要重画那张表** —— postflight 在发送时自己把它拼在你的散文前面。
+  你抄一遍只会引入排版误差：2026-07-28 00:30 就因为一格多打了一个空格，整段分析被丢掉只发了数据块。
+  数据块里的市值/持仓表/亏损持仓行**已经在消息里了**，你的输出从 `▎我的看法` 开始。
+- 你交付的就是这一段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提到 `anomalies` 里至少一个票
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
@@ -117,35 +115,38 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - 🔢 **数字铁律**：金额/股数一律**照抄 context**，不换算不心算；**别在 `▎我的看法` 里重述持仓股数或市值**（数据块里已经有了，但 `plan_context.open[].shares` 这种「本单动多少股」是要写的）；前瞻性数字要么给算式要么不写。postflight 的 `check_numeric_claims` 会把 context 里没有的数字和自相矛盾的区间标成 warn（issue #120）。
   - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给板块今日 Top 5 + 你持仓在榜单里的位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`——盘中每 30 分钟的常规盯盘**不要**烧 Tavily（免费档 1000/月全局共享）
   - 禁止"无异动，观望"这种敷衍 1 句话
-- 目标 ≤2200 字；>3000 字 postflight warn，>3500 字 fail
+- 目标 ≤2200 字；>3000 字 postflight warn，>3500 字 fail（长度算的是拼装后的整条消息）
 
 #### Step 2.5: 写 dashboard 状态横幅 sidecar
 
 **规范见 `skills/_shared/intraday-status-sidecar.md`**（hk/us 共用单一来源）—— 写 `memory/.tmp/intraday-insights-{date}.json`（status_banner + 每个异动票 movers 归因，只文本无 key）。
 - 本市场杠杆 ETF：**07226**（恒科 2x）等，归因要点明"杠杆放大"。
 
-#### Step 3: 跑 postflight（先写文件，再调用 —— 禁用 heredoc/`<<<`）
-**必须两步、按顺序**：先用文件写入工具把 Step 2 的报告原样写到
-`memory/.tmp/intraday-report-hk.md`，确认写入成功后再调用：
+#### Step 3: 跑 postflight（先写文件，再调用 —— 禁用 heredoc / here-string 重定向）
+**必须两步、按顺序**：先用文件写入工具把 Step 2 的散文写到
+`memory/.tmp/intraday-prose-hk.md`，确认写入成功后再调用（命令写成一行）：
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py \
-  --market hk --text-file /root/.openclaw/workspace/memory/.tmp/intraday-report-hk.md
+python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py --market hk --context-id {Step 1 的 context_id} --text-file /root/.openclaw/workspace/memory/.tmp/intraday-prose-hk.md
 ```
-❌ **不要用 `<<<` / heredoc 把报告塞进 stdin** —— 报告含 emoji、`$`、`|` 表格和换行，
+`--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），
+postflight 拒绝拼装、只发数据块。
+
+❌ **不要用 here-string / heredoc 重定向把散文塞进 stdin** —— 内容含 emoji、`$` 和换行，
 shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight 读到空串后吐出
 4 条"报告写错了"的假 issue，run 被标红（实际重试后投递正常）。
 postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
-文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧报告重发。
+文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧散文重发。
 
-校验段标记 + 长度 + 异动票提及。**不提交 `portfolio.json`**；若 dashboard
-有语义变化，postflight 会重建并提交 `assets/data/dashboard.json`。每个 slot 的
-完成/投递状态另写 heartbeat，由 single publisher 发布。
+校验段标记 + 长度 + 异动票提及（都只校验你写的那段，不校验拼进来的数据块）。
+**不提交 `portfolio.json`**；若 dashboard 有语义变化，postflight 会重建并提交
+`assets/data/dashboard.json`。每个 slot 的完成/投递状态另写 heartbeat，由 single publisher 发布。
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
-微信投递已在 **Step 3 的 `intraday_postflight` 用 fresh-token 短连接发出**（cron `--no-deliver`，不 announce）——唯一路径。拼 `wechat_prefix` + 报告，**无标题**（高频推送避免刷屏），作为**本回合最终文本回复**输出（仅存档）。**不要调 `message`/send 工具**（postflight 已发，再调会双发）；`intraday_watchdog` 只在 Telegram marker 缺失/失败时补投 Telegram，不重发微信。
+微信投递已在 **Step 3 的 `intraday_postflight` 用 fresh-token 短连接发出**（cron `--no-deliver`，不 announce）——唯一路径。拼 `wechat_prefix` + 你的散文，**无标题**（高频推送避免刷屏），作为**本回合最终文本回复**输出（仅存档）。**不要调 `message`/send 工具**（postflight 已发，再调会双发）；`intraday_watchdog` 只在 Telegram marker 缺失/失败时补投 Telegram，不重发微信。
 
 **和 Mode 6 的区别**：单段 `▎我的看法` 取代三段；无 ▎风险提示；不提交
 `portfolio.json`（但会发布 dashboard 语义变化 + slot heartbeat）；holdings 用 markdown 表格。
+**相同点**：两者都是散文模式 —— 数据块由 postflight 拼装，你只写分析。
 
 ### Mode 6 — WeChat Briefing (cron-driven, harness 化 ✨)
 **When:** 港股开盘/午盘/午后/收盘 4 个 cron job 全部走这个 mode。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -88,7 +88,7 @@ dreaming 留独占窗口，所以 EST 季比 EDT 季少两个 slot。
 ```bash
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market us
 ```
-输出 `memory/.tmp/intraday-context-us-latest.json`，关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）和 `plan_context`（08:00 简报为本腿定下、尚未成交的决策）。
+输出 `memory/.tmp/intraday-context-us-latest.json`，并把**同一份 JSON** 打到 stdout（含 `context_id` —— Step 3 要原样回传）。关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）和 `plan_context`（08:00 简报为本腿定下、尚未成交的决策）。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 - `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
   - `status=no_recent_filing` 是**明确的空**：写「窗口内无一手公告」，不要改口编一个理由；`status=degraded` 说明源没抓到，同样如实写。
@@ -98,13 +98,11 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - 基金看穿：2x 单票 ETF 查的是**它跟踪的公司**（`target.kind=look_through`，如 PLTU→PLTR）；指数/板块基金没有发行人，直接标 `index_fund_no_issuer`，不会假装「公司没公告」。
   - `halts`（仅美股，每 slot 一次共享请求）：持仓或其标的被停牌时给出 `reason_code`（LULD 的 `LUDP` 最常打到 2x ETF）与复牌时间；港股停牌走公告（已在 triage 里判 interrupt）。
 
-#### Step 2: 写报告
-- 拷贝 `raw_wechat_block` 到消息开头（**verbatim — 不许改格式不许 trim**）
-  - intraday 的 holdings 是 **markdown 表格**（7 列：代码/股/成本/现价/今日/浮%/浮$，右对齐数字。走 `scripts/data/_wechat_table.py` 的 visual-width-aware 渲染，去 $ 前缀 + 加 浮$ 金额列；RSI 在信号段不再占表头）
-  - ⚠️ **表格的 3 类行（表头 / 分隔 `|:--|--:|...|` / 每条数据）每一字符 1:1 复制**，不要数列重写分隔行 — 5/21 后多次因 LLM 自己写分隔行少一段 `--:|` 导致渲染失败（postflight 会 fail）
-  - **市值/浮盈/今日/已实现 已经是单行用 `|` 分隔的格式** — 不要拆 3 行
-  - **`📉 亏损持仓 X/Y | 杠杆ETF敞口 N%` 必须保留**，不要省
-- 加 `▎我的看法` 段：**至少 60 字（postflight 软下限），目标 2-3 行**
+#### Step 2: 只写 `▎我的看法` 散文（数据块归 harness）
+- ❌ **不要抄 `raw_wechat_block`，不要重画那张表** —— postflight 在发送时自己把它拼在你的散文前面。
+  你抄一遍只会引入排版误差：2026-07-28 00:30 就因为一格多打了一个空格，整段分析被丢掉只发了数据块。
+  数据块里的市值/持仓表/亏损持仓行**已经在消息里了**，你的输出从 `▎我的看法` 开始。
+- 你交付的就是这一段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `should_alert=true`，**必须**提 `anomalies` 中至少一个票
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
@@ -118,36 +116,40 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
   - 🔢 **数字铁律**：金额/股数一律**照抄 context**，不换算不心算；**别在 `▎我的看法` 里重述持仓股数或市值**（数据块里已经有了，但 `plan_context.open[].shares` 这种「本单动多少股」是要写的）；前瞻性数字要么给算式要么不写。postflight 的 `check_numeric_claims` 会把 context 里没有的数字和自相矛盾的区间标成 warn（issue #120）。
   - ⚡ **板块全景**：数据**已由 preflight 备好**在 context.json 的 `peer_scan` 里（每个 active ticker 一项：`theme` 板块名、`listed_peers` 已按今日涨幅降序、含 `pct_1d`/`pct_5d`、`divergence_signal`、`self_pct_1d`）。**直接引用它,不要自己去读 peer-map.json、也不要自己调 `fetch_peers.py`**；给对应主题成分今日 Top 5 + 你持仓位置 + 1 句归因;`peer_scan` 为空或缺项时才回退 web search。若某条带 `name_mismatch`,以 feed 名为准并在报告里提一句。持仓自己的数字仍从 context.json。板块行情**优先用内置 web search**；`tavily-search` 仅在**开盘/收盘报告**或盘中真事件时才用，且必带 `--bucket report`/`--bucket intraday`（见 Mode 5 的 Budget rule）——盘中每 30 分钟的常规盯盘**不要**烧 Tavily
   - 禁止"无异动，观望"这种敷衍 1 句话
-- 目标 ≤2200 字；>3000 字 postflight warn，>3500 字 fail
+- 目标 ≤2200 字；>3000 字 postflight warn，>3500 字 fail（长度算的是拼装后的整条消息）
 
 #### Step 2.5: 写 dashboard 状态横幅 sidecar
 
 **规范见 `skills/_shared/intraday-status-sidecar.md`**（hk/us 共用单一来源）—— 写 `memory/.tmp/intraday-insights-{date}.json`（status_banner + 每个异动票 movers 归因，只文本无 key）。
 - 本市场杠杆 ETF：**ROBN/PLTU/MSFU/SOXL/TQQQ** 等（2x 标的），归因要点明"杠杆放大"、区分标的真涨还是纯 beta。
 
-#### Step 3: postflight（先写文件，再调用 —— 禁用 heredoc/`<<<`）
-**必须两步、按顺序**：先用文件写入工具把 Step 2 的报告原样写到
-`memory/.tmp/intraday-report-us.md`，确认写入成功后再调用：
+#### Step 3: postflight（先写文件，再调用 —— 禁用 heredoc / here-string 重定向）
+**必须两步、按顺序**：先用文件写入工具把 Step 2 的散文写到
+`memory/.tmp/intraday-prose-us.md`，确认写入成功后再调用（命令写成一行）：
 ```bash
-python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py \
-  --market us --text-file /root/.openclaw/workspace/memory/.tmp/intraday-report-us.md
+python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py --market us --context-id {Step 1 的 context_id} --text-file /root/.openclaw/workspace/memory/.tmp/intraday-prose-us.md
 ```
-❌ **不要用 `<<<` / heredoc 把报告塞进 stdin** —— 报告含 emoji、`$`、`|` 表格和换行，
+`--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），
+postflight 拒绝拼装、只发数据块。
+
+❌ **不要用 here-string / heredoc 重定向把散文塞进 stdin** —— 内容含 emoji、`$` 和换行，
 shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight 读到空串后吐出
 4 条"报告写错了"的假 issue，run 被标红（实际重试后投递正常）。
 postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
-文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧报告重发。
+文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧散文重发。
 
+校验段标记 + 长度 + 异动票提及（都只校验你写的那段，不校验拼进来的数据块）。
 **不提交 `portfolio.json`**；若 dashboard 有语义变化，postflight 会重建并提交
 `assets/data/dashboard.json`。每个 slot 的完成/投递状态另写 heartbeat，由 single
 publisher 发布。
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
-微信投递已在 **Step 3 的 `intraday_postflight` 用 fresh-token 短连接发出**（cron `--no-deliver`，不 announce）——唯一路径。拼 `wechat_prefix` + 报告，**无标题**，作为**本回合最终文本回复**直接输出（仅存档）。
+微信投递已在 **Step 3 的 `intraday_postflight` 用 fresh-token 短连接发出**（cron `--no-deliver`，不 announce）——唯一路径。拼 `wechat_prefix` + 你的散文，**无标题**，作为**本回合最终文本回复**直接输出（仅存档）。
 - ❌ **禁止调用 `message`/send 工具** — postflight 已发，手动再调会**双发**；`intraday_watchdog` 只在 Telegram marker 缺失/失败时补投 Telegram，不重发微信。整轮只输出一次，发完即停。
 
 **和 Mode 6 的区别**：单段 `▎我的看法` 取代三段；无 ▎风险提示；不提交
 `portfolio.json`（但会发布 dashboard 语义变化 + slot heartbeat）；holdings 用 markdown 表格。
+**相同点**：两者都是散文模式 —— 数据块由 postflight 拼装，你只写分析。
 
 ### Mode 6 — WeChat Briefing (cron-driven, harness 化 ✨)
 **When:** 美股开盘 / 美股收盘 两个 cron 走这个 mode。

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -439,7 +439,9 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     again."""
     profile = contract()['payload_profiles']['intraday']
     assert '--text-file' in profile['required_substrings']
-    assert 'intraday-report-{market}.md' in profile['required_substrings']
+    assert 'intraday-prose-{market}.md' in profile['required_substrings']
+    assert 'intraday_postflight.py --market {market} --context-id' in profile['required_substrings']
+    assert 'verbatim' in profile['forbidden_substrings']
     assert '<<<' in profile['forbidden_substrings']
 
     vars_ = {'market': 'hk', 'skill': 'hk-stock-analysis'}

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -1,0 +1,220 @@
+"""Mode 7 after the data block stopped going through the model.
+
+The 2026-07-28 00:30 US slot delivered its holdings table correctly and still
+raised `🔴 Validation FAILED`: the model had retyped the RKLX row with one extra
+space in the 浮$ cell, `check_raw_tables_verbatim` is a strict substring match,
+and the whole ▎我的看法 段 was dropped in favour of the bare data block. Mode 6
+removed that round trip on 2026-07-24; these tests pin the same contract for
+Mode 7:
+
+  * intraday_postflight assembles raw_wechat_block + prose itself, so table
+    whitespace is no longer something the model can get wrong
+  * the model echoes `context_id`; prose written against a superseded context is
+    refused rather than married to fresh numbers
+  * the content rules read the model's prose, never the prepended block — a
+    block that names the movers must not satisfy the anomaly rule for prose that
+    does not
+
+Every test drives real functions; nothing asserts on prompt text.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / 'scripts' / 'harness'
+
+# The real 2026-07-28 00:30 block, trimmed to the rows that matter.
+BLOCK = ('🇺🇸 美股盯盘 | 07/27 12:30 ET\n\n'
+         '📊 市值 $2,403 | 浮盈 $-2,098 (-46.6%) | 今日 +$7\n\n'
+         '| 代码  |    股 |   成本 |   现价 |   今日 |    浮% |     浮$ |\n'
+         '|:------|------:|-------:|-------:|-------:|-------:|--------:|\n'
+         '| CRCL  |     2 |  87.00 |  64.13 |  +2.8% | -26.3% |     -46 |\n'
+         '| RKLX  |    10 |  49.69 |  17.07 |  +4.6% | -65.6% |    -326 |')
+
+# What the model actually produced that slot: same numbers, one extra space.
+MANGLED_ROW = '| RKLX  |    10 |  49.69 |  17.07 |  +4.6% | -65.6% |     -326 |'
+
+PROSE = ('▎我的看法\n'
+         'SKHY 存储链 risk-off 未止，杠杆放大伤口；RKLX 反弹到区间顶部不是加仓信号，'
+         '继续按计划减。CRCL 跌破 MA50 后先观察，不追。\n')
+
+
+def _load(name):
+    for extra in (ROOT / 'scripts' / 'data', HARNESS):
+        if str(extra) not in sys.path:
+            sys.path.insert(0, str(extra))
+    spec = importlib.util.spec_from_file_location(name, HARNESS / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def pf():
+    return _load('intraday_postflight')
+
+
+def _ctx(**over):
+    ctx = {
+        'status': 'ok', 'market': 'us', 'date': '2026-07-28', 'time': '00:30',
+        'raw_wechat_block': BLOCK,
+        'signal_count': {'watch': 2, 'stop': 3, 'trim': 0},
+        'anomalies': [{'ticker': 'SKHY', 'move_pct': -9.0, 'severity': 'high'}],
+        'should_alert': True,
+        'context_id': 'abc123def456',
+    }
+    ctx.update(over)
+    return ctx
+
+
+# ── assembly: the table is no longer the model's to get wrong ────────────────
+
+def test_assembled_message_takes_the_table_from_the_context(pf):
+    """The incident in one assertion: prose alone goes in, the context's exact
+    table comes out."""
+    msg = pf.assemble_message(_ctx(), PROSE)
+
+    for line in BLOCK.splitlines():
+        assert line in msg, f'assembled message dropped a context line: {line!r}'
+    assert msg.startswith('🇺🇸 美股盯盘 | 07/27 12:30 ET')
+    assert '▎我的看法' in msg
+    # The mangled row can only appear if the model's copy leaked through.
+    assert MANGLED_ROW not in msg
+
+
+def test_the_same_slot_that_failed_on_a_space_now_passes(pf):
+    """The 2026-07-28 00:30 incident, both ways round.
+
+    Legacy: the model retypes the table, pads RKLX's 浮$ cell one space wider,
+    and the strict substring match escalates to `fail` — which ships the data
+    block alone and drops the analysis. Prose: the model never types the row, so
+    the identical slot delivers the identical numbers AND the prose.
+    """
+    legacy_text = BLOCK.replace(
+        '| RKLX  |    10 |  49.69 |  17.07 |  +4.6% | -65.6% |    -326 |',
+        MANGLED_ROW) + '\n\n' + PROSE
+    legacy_issues = pf.validate(legacy_text, _ctx())
+
+    assert [i for i in legacy_issues if 'verbatim' in i], legacy_issues
+    assert pf.categorize(legacy_issues) == 'fail'
+
+    body = pf.assemble_message(_ctx(), PROSE)
+    prose_issues = pf.validate(body, _ctx(), prose_only=True, model_text=PROSE)
+
+    assert pf.categorize(prose_issues) == 'pass', prose_issues
+    assert PROSE.strip() in body
+
+
+# ── the block must not answer the content rules on the model's behalf ────────
+
+def test_anomaly_rule_reads_the_prose_not_the_prepended_block(pf):
+    """SKHY is named in the block's own table. Prose that never mentions it must
+    still fail the should_alert rule — otherwise the check is decorative."""
+    silent = '▎我的看法\n' + '大盘窄幅震荡，持仓按既定纪律执行，今天没有需要改的动作。' * 2
+    ctx = _ctx(raw_wechat_block=BLOCK + '\n| SKHY  |     1 | 169.19 | 140.72 |')
+
+    issues = pf.validate(pf.assemble_message(ctx, silent), ctx,
+                         prose_only=True, model_text=silent)
+
+    assert [i for i in issues if 'should_alert' in i], issues
+
+
+def test_length_limit_measures_the_delivered_body(pf):
+    """Length is a property of what WeChat receives, so it — unlike the content
+    rules — is measured on the assembled message."""
+    prose = '▎我的看法\n' + 'x' * 3400
+    body = pf.assemble_message(_ctx(), prose)
+
+    issues = pf.validate(body, _ctx(), prose_only=True, model_text=prose)
+
+    assert [i for i in issues if '3500' in i], issues
+    assert len(body) > len(prose)
+
+
+# ── generation gate ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sent(pf, tmp_path, monkeypatch):
+    """Capture what would go to WeChat/Telegram instead of sending it."""
+    box = {'messages': []}
+    monkeypatch.setattr(pf, 'TMP', tmp_path)
+    monkeypatch.setattr(pf, 'resolve_wechat_target', lambda m: ('weixin', 'kcn', 'acct'))
+    monkeypatch.setattr(pf, 'cosend_telegram', lambda *a, **k: (True, 'ok'))
+
+    def _send(channel, to, account, message, dry_run=False):
+        box['messages'].append(message)
+        return True, 'ok'
+
+    monkeypatch.setattr(pf, 'send_wechat', _send)
+    return box
+
+
+@pytest.fixture
+def run_main(pf, sent, monkeypatch, tmp_path):
+    """Drive the real main(). Helper-only tests do not guard the wiring — the
+    2026-07-23 input_error fix needed the same lesson (a perfect
+    read_report_text() still went green while main() ignored its error)."""
+    monkeypatch.setattr(pf.trading_calendar, 'closed_reason', lambda m: None)
+    monkeypatch.setattr(pf.cron_heartbeat, 'record', lambda *a, **k: None)
+    monkeypatch.setattr(pf, 'rebuild_dashboard', lambda *a, **k: (False, 'skipped'))
+
+    def run(prose, *, context_id, ctx=None):
+        (tmp_path / 'intraday-context-us-latest.json').write_text(
+            json.dumps(ctx or _ctx(), ensure_ascii=False))
+        body = tmp_path / 'intraday-prose-us.md'
+        body.write_text(prose)
+        argv = ['intraday_postflight.py', '--market', 'us', '--text-file', str(body)]
+        if context_id:
+            argv += ['--context-id', context_id]
+        monkeypatch.setattr(sys, 'argv', argv)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = pf.main()
+        return rc, json.loads(buf.getvalue())
+
+    return run
+
+
+def test_main_delivers_block_plus_prose_on_the_happy_path(run_main, sent):
+    rc, out = run_main(PROSE, context_id='abc123def456')
+
+    assert rc == 0 and out['status'] == 'pass' and out['mode'] == 'prose'
+    body = sent['messages'][0]
+    assert body.startswith('🇺🇸 美股盯盘 | 07/27 12:30 ET')
+    assert '▎我的看法' in body
+    for line in BLOCK.splitlines():
+        assert line in body
+
+
+def test_main_refuses_to_marry_stale_prose_to_fresh_numbers(run_main, sent):
+    """The model wrote against a context that has since been regenerated. Ship
+    the data block alone rather than a check-in that looks clean and is not."""
+    rc, out = run_main(PROSE, context_id='OLDGENERATION')
+
+    assert rc == 2 and out['status'] == 'fail'
+    assert any('context_id 不匹配' in i for i in out['issues'])
+    body = sent['messages'][0]
+    assert BLOCK.splitlines()[0] in body and '▎我的看法' not in body
+
+
+def test_preflight_stamps_a_per_generation_context_id():
+    """Two preflight runs of the same slot produce different ids, so prose can
+    always be pinned to the generation it described."""
+    common = _load('_harness_common')
+
+    a = common.compute_context_id({'raw_wechat_block': BLOCK, 'time': '00:30'})
+    b = common.compute_context_id({'raw_wechat_block': BLOCK, 'time': '01:00'})
+
+    assert a != b
+    assert a == common.compute_context_id({'raw_wechat_block': BLOCK, 'time': '00:30'})
+    assert len(a) == 12

--- a/tests/test_suppression_is_visible.py
+++ b/tests/test_suppression_is_visible.py
@@ -153,7 +153,7 @@ def _run_postflight(module, tmp_path, monkeypatch, *, prose, issues_status):
     monkeypatch.setattr(module, "load_context", lambda market: (ctx, None))
     monkeypatch.setattr(module, "read_report_text", lambda market, f: (prose, None))
     monkeypatch.setattr(module, "validate",
-                        lambda text, c: [] if issues_status == "pass" else ["缺段标记 ▎我的看法"])
+                        lambda text, c, **kw: [] if issues_status == "pass" else ["缺段标记 ▎我的看法"])
     monkeypatch.setattr(module, "categorize", lambda issues: issues_status)
     monkeypatch.setattr(sys, "argv", ["intraday_postflight.py", "--market", "hk"])
     module.main()

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -22,6 +22,7 @@ Run: `python3 -m pytest tests/test_us_quote_staleness.py -q`
 import json
 import os
 import sys
+from datetime import date, timedelta
 
 import pytest
 
@@ -30,6 +31,7 @@ sys.path.insert(0, os.path.join(WS, "scripts", "data"))
 
 import fetch_us_stocks as F  # noqa: E402
 import preflight_integrity as pi  # noqa: E402
+import trading_calendar as tc  # noqa: E402
 
 
 # ── 1. the parser must not invent fields the payload does not have ───────────
@@ -414,16 +416,35 @@ def _mini_portfolio(holding):
     }
 
 
+def _session_dates():
+    """The two session dates STALE_PRICE needs, resolved at run time.
+
+    The fixture used to hardcode the incident's own 2026-07-27/24 pair. That
+    made the row genuinely stale one day later: STALENESS compares data_source
+    against `_last_session()`, so from 2026-07-28 the arithmetic-gates test
+    started failing on every branch for a reason that has nothing to do with the
+    branch. A fixture that asserts a wall-clock-relative property has to compute
+    it — see clawock-no-live-numbers-in-static-copy.
+    """
+    today = date.fromisoformat(pi._last_session("us"))
+    prev = today - timedelta(days=1)
+    while not tc.is_trading_day("us", prev):
+        prev -= timedelta(days=1)
+    return today, prev
+
+
+_SESSION, _PREV_SESSION = _session_dates()
+
 PLTU_STALE = {
     "ticker": "PLTU", "shares": 14, "cost_basis": 40.9571,
     "current_price": 27.35, "current_value": 382.9,
     "pnl_abs": round((27.35 - 40.9571) * 14, 2),
     "pnl_percent": -33.2229,
-    "prev_close": 27.35, "prev_close_date": "2026-07-24",
-    "day_session_date": "2026-07-27",
+    "prev_close": 27.35, "prev_close_date": _PREV_SESSION.isoformat(),
+    "day_session_date": _SESSION.isoformat(),
     "day_high": 28.82, "day_low": 27.35, "day_open": 28.82,
     "today_change": 0.0, "today_change_pct": 0.0,
-    "data_source": "Nasdaq API (etf) Jul 27, 2026 10:33 ET",
+    "data_source": f"Nasdaq API (etf) {_SESSION:%b %-d, %Y} 10:33 ET",
     "trades": [{"date": "2026-04-16", "action": "buy", "shares": 14,
                 "price": 40.9571}],
 }
@@ -470,7 +491,7 @@ class TestIntegrityGateCatchesStalePrice:
         # prev_close_date == day_session_date means there is no real prior close
         # (fresh IPO / same-session re-entry). Not a stale print -> stay quiet.
         ipo = dict(PLTU_STALE)
-        ipo["prev_close_date"] = "2026-07-27"
+        ipo["prev_close_date"] = ipo["day_session_date"]
         codes = {f["code"] for f in self._findings(tmp_path, ipo)}
         assert "STALE_PRICE" not in codes
 


### PR DESCRIPTION
## 触发的实况

2026-07-28 00:30 美股盯盘：表格里每个数字都对，仍然报 `🔴 Validation FAILED (1 issues), 仅发布数据块`。

```
raw : | RKLX  | ... | -65.6% |    -326 |     ← 63 字符
sent: | RKLX  | ... | -65.6% |     -326 |    ← 64 字符
```

模型重打表格时给 RKLX 的 `浮$` 一格多打了一个空格。其余 8 行逐字节吻合。
`check_raw_tables_verbatim` 是严格 substring 比对 → CRITICAL → fail-soft 只发数据块 → `▎我的看法` 整段丢失。

## 为什么会走到这一步

Mode 7 还停在 legacy 路径：preflight 把对齐好的 7 列表放进 context，payload 要求模型**原样重打一遍**，postflight 再验模型打得对不对。模型是在"重排版"而不是"复制"，按自己推断的列宽对齐就会差一格。

Mode 6 在 2026-07-24 已经把这条往返拆掉了 —— `report_postflight.assemble_message()` 的注释写得很清楚：

> Prepending it here removes the round trip: the numbers in the delivered message come from the context file at send time, so they cannot be stale, paraphrased, or table-mangled — **no instruction and no validation rule needed.**

Mode 7 当时没一起迁移，于是每 30 分钟掷一次骰子。

## 改了什么

- `intraday_preflight` 产出 `context_id`（`compute_context_id` 从 `report_preflight` 提到 `_harness_common`，两腿共用）
- `intraday_postflight` 新增 `--context-id` → **prose 模式**：模型只写 `▎我的看法`，`assemble_message()` 在发送时把 `raw_wechat_block` 拼在前面。Mode 7 没有独立 `title`，数据块首行本身就是标题
- **换代闸**：`context_id` 不匹配 = 散文与数据不同代 → 拒绝拼装、只发数据块（沿用 07-24 那次的判据）
- **校验对象拆开**：段标记 / 异动票提及 / 敷衍词 / `check_numeric_claims` 只读模型写的那段。拼进来的数据块里本来就有异动票代码，拿整条去校验会让"一个票都没提"的散文靠表格蒙混过关。只有长度限制量拼装后的整条消息（那是微信真正收到的东西）
- **legacy 保留**：省略 `--context-id` 走原路径（含 verbatim 校验），未迁移的 payload 不会断
- 散文文件改名 `intraday-prose-{market}.md`；契约 `required` 加 `--context-id`，`forbidden` 加 `verbatim` / `intraday-report-`
- SKILL Mode 7 Step 2 从「拷贝 raw_wechat_block（verbatim 不许改格式）」改成「不要抄，不要重画那张表」

## 测试

`tests/test_intraday_prose_assembly.py` 7 条，**逐条变异验证**（拆掉 assemble / 关掉 verbatim / 异动票读整条 / 长度读散文 / 拿掉换代闸，各自都有测试变红）。含两条走**真 `main()`** 的：happy path 与 `context_id` 不匹配 —— 只测 helper 守不住 `main()`，这是 PR #22 那次的教训。

其中一条直接复刻事故：同一份数据，legacy 模式 `fail`（丢分析），prose 模式 `pass`（数字和分析都在）。

全套 1121 passed。

## 顺带修的既有红灯（不修则所有 PR 都进不来）

`tests/test_us_quote_staleness.py` 的 `PLTU_STALE` 把事故当天日期写死成 `2026-07-27`，而 `STALENESS` 闸拿 `data_source` 跟 `_last_session()` 比 —— **从 07-28 起这条在任何分支上都必红**，与分支内容无关。改成运行时按交易日历推导。（同 `clawock-no-live-numbers-in-static-copy`：断言 wall-clock 相对属性的 fixture 必须自己算。）

## 合并后必须做的事

契约变了但 **live cron payload 还没动**，`system_check` 的 `cron runtime contract` 会 CRITICAL。按既定顺序：merge 后立刻 `git pull --rebase --autostash`，再批量 `openclaw cron edit --message` 更新三条 Mode 7 payload（`盘中盯盘` / `美股盘中盯盘` / `美股盘中盯盘-overnight`），把窗口压到一两分钟。契约钉住的命令必须单行。

作者不自合。