### PR TITLE
fix: decouple data publication from prose validation

### DIFF
--- a/scripts/data/workflow_outcomes.py
+++ b/scripts/data/workflow_outcomes.py
@@ -280,12 +280,18 @@ def record_from_heartbeat(event):
         record_stage(job, "postflight", "failed", slot=slot, **details)
     elif state == "completed":
         postflight = event.get("postflight_status")
-        llm_status = "warning" if postflight == "warn" else "success"
+        data_plane = event.get("data_plane_status")
+        data_plane_ok = data_plane in {None, "published", "current"}
+        llm_status = {
+            "pass": "success",
+            "warn": "warning",
+            "fail": "failed",
+        }.get(postflight, "warning")
         record_stage(job, "llm", llm_status, slot=slot, **details)
         record_stage(
             job,
             "postflight",
-            "warning" if postflight == "warn" else "success",
+            "success" if postflight == "pass" and data_plane_ok else "warning",
             slot=slot,
             **details,
         )

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -30,8 +30,9 @@ Validates:
   4. 若 preflight should_alert=true：报告必须提到至少一个异动票或 alert_reason
   5. 无敷衍 phrases
 
-Note: Mode 7 does NOT commit portfolio.json. It rebuilds dashboard.json and commits
-only semantic changes; every slot also updates the local heartbeat ledger, which
+Note: Mode 7 does NOT commit portfolio.json. For every usable preflight context,
+including a slot whose prose is rejected, it rebuilds dashboard.json and commits
+only semantic changes. Every slot also updates the local heartbeat ledger, which
 the existing single publisher exposes without introducing another git writer.
 """
 
@@ -252,6 +253,37 @@ def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out,
     }
 
 
+def publish_data_plane(market):
+    """Publish deterministic dashboard outputs, independent of prose quality."""
+    try:
+        ok, _ = rebuild_dashboard()
+        if not ok:
+            return 'rebuild_failed', False
+        paths = [*dashboard_output_changes(), 'logs/dashboard_build_status.json']
+        snap = snapshot_date_for_now()
+        if snap:
+            paths.append(f'memory/snapshots/{snap}.json')
+        added, _ = git_cmd('add', '--', *paths)
+        if not added:
+            return 'git_add_failed', False
+        # git diff --cached --quiet returns 0 when there is NO diff
+        clean, _ = git_cmd('diff', '--cached', '--quiet', '--', *paths)
+        if clean:
+            return 'current', False
+        msg = (
+            f"dashboard: intraday refresh "
+            f"({market} {datetime.now().strftime('%H:%M HKT')})"
+        )
+        committed, _ = git_cmd('commit', '-m', msg, '--', *paths)
+        if not committed:
+            return 'commit_failed', False
+        pushed, _ = push_with_rebase_retry()
+        return ('published', True) if pushed else ('committed_local', False)
+    except Exception as exc:
+        print(f'warn: dashboard auto-publish failed: {exc}', file=sys.stderr)
+        return 'publish_failed', False
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
@@ -409,26 +441,12 @@ def main():
                 print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}',
                       file=sys.stderr)
 
-    dashboard_published = False
-    if status in ('pass', 'warn'):
-        try:
-            ok, _ = rebuild_dashboard()
-            if ok:
-                paths = [*dashboard_output_changes(), 'logs/dashboard_build_status.json']
-                snap = snapshot_date_for_now()
-                if snap:
-                    paths.append(f'memory/snapshots/{snap}.json')
-                git_cmd('add', '--', *paths)
-                # git diff --cached --quiet returns 0 when there is NO diff
-                clean, _ = git_cmd('diff', '--cached', '--quiet', '--', *paths)
-                if not clean:
-                    msg = f"dashboard: intraday refresh ({args.market} {datetime.now().strftime('%H:%M HKT')})"
-                    c_ok, _ = git_cmd('commit', '-m', msg, '--', *paths)
-                    if c_ok:
-                        push_ok, _ = push_with_rebase_retry()
-                        dashboard_published = push_ok
-        except Exception as e:
-            print(f'warn: dashboard auto-publish failed: {e}', file=sys.stderr)
+    raw_block = (ctx.get('raw_wechat_block', '') or '').strip()
+    data_plane_ready = ctx.get('status') == 'ok' and bool(raw_block)
+    if data_plane_ready:
+        data_plane_status, dashboard_published = publish_data_plane(args.market)
+    else:
+        data_plane_status, dashboard_published = 'unavailable', False
 
     result = {
         'status':        status,
@@ -442,20 +460,26 @@ def main():
         'wechat_sent':   wechat_sent,
         'telegram_sent': tg_ok,
         'dashboard_published': dashboard_published,
+        'data_plane_status': data_plane_status,
+        'narrative_status': {
+            'pass': 'success', 'warn': 'warning', 'fail': 'failed',
+        }[status],
         'insights_sidecar': insights_written,
     }
     heartbeat = ctx.get('heartbeat') or {}
+    heartbeat_state = 'completed' if data_plane_ready else 'postflight_failed'
     cron_heartbeat.record(
         args.market,
-        'completed' if status in ('pass', 'warn') else 'postflight_failed',
+        heartbeat_state,
         job_name=heartbeat.get('job'), slot=heartbeat.get('slot'),
         postflight_status=status, wechat_sent=wechat_sent,
         telegram_sent=tg_ok, dashboard_published=dashboard_published,
+        data_plane_status=data_plane_status,
         insights_sidecar=insights_written, issue_count=len(issues),
     )
     result['heartbeat'] = {
         'job': heartbeat.get('job'), 'slot': heartbeat.get('slot'),
-        'state': 'completed' if status in ('pass', 'warn') else 'postflight_failed',
+        'state': heartbeat_state,
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -21,11 +21,12 @@ Validates (on the assembled message):
   5. 如果 preflight 有 anomalies，报告必须提到至少一个 anomaly 票
   6. 没有"等待数据/数据待获取"等敷衍词
 
-Delivery is fail-closed (2026-07-24): pass/warn send the full body and commit;
-fail sends the data block ALONE — never the rejected prose — and does not commit;
-a closed market or a missing context sends nothing. A slot whose only delivery was
-a fail-closed data block may be superseded exactly once by a validated report
-(see claim_upgrade).
+Delivery is fail-closed (2026-07-24): pass/warn send the full body; fail sends
+the data block ALONE — never the rejected prose. Deterministic data publication
+is independent of that narrative decision, so every usable context can refresh
+the dashboard and commit. A closed market or a missing context sends/publishes
+nothing. A slot whose only delivery was a fail-closed data block may be
+superseded exactly once by a validated report (see claim_upgrade).
 
 Outputs JSON to stdout:
   {"status": "pass|warn|fail", "mode": "prose|legacy", "issues": [...], ...}
@@ -342,11 +343,12 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
 
 
 def maybe_commit(status, commit_msg):
-    if status == 'fail':
-        return False, 'skipped (status=fail)'
-    rebuild_dashboard()
+    rebuild_ok, _ = rebuild_dashboard()
     dashboard_paths = dashboard_output_changes()
-    suffix = ' (validation warnings)' if status == 'warn' else ''
+    suffix = {
+        'warn': ' (validation warnings)',
+        'fail': ' (data only; prose rejected)',
+    }.get(status, '')
     snap_date = snapshot_date_for_now()
     # logs/dashboard_build_status.json rides along: its only scheduled reader is
     # the GHA cron-health runner (fresh checkout), so it must reach origin.
@@ -357,7 +359,8 @@ def maybe_commit(status, commit_msg):
     ok, _ = _git(*add_args)
     if not ok:
         return False, 'git add failed'
-    ok, out = _git('commit', '-m', f'{commit_msg}{suffix}')
+    commit_paths = add_args[1:]
+    ok, out = _git('commit', '-m', f'{commit_msg}{suffix}', '--', *commit_paths)
     if not ok and 'nothing to commit' in out:
         return True, 'nothing to commit (idempotent)'
     if not ok:
@@ -366,8 +369,23 @@ def maybe_commit(status, commit_msg):
     # Push so Pages updates; rebase+retry handles races with GH Action commits
     push_ok, push_out = push_with_rebase_retry()
     if push_ok:
-        return True, 'committed + pushed'
+        if rebuild_ok:
+            return True, 'committed + pushed'
+        return True, 'committed + pushed (dashboard rebuild failed)'
     return True, f'committed (push failed: {push_out[-150:]})'
+
+
+def classify_data_plane(commit_ok, commit_msg):
+    """Return an explicit publication state independent of prose validation."""
+    if not commit_ok:
+        return 'failed'
+    if 'push failed' in commit_msg:
+        return 'committed_local'
+    if 'rebuild failed' in commit_msg:
+        return 'published_degraded'
+    if 'nothing to commit' in commit_msg:
+        return 'current'
+    return 'published'
 
 
 def main():
@@ -565,6 +583,7 @@ def main():
                                         context_id=ctx.get('context_id'))
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
+    data_plane_status = classify_data_plane(commit_ok, commit_msg)
 
     result = {
         'status':        status,
@@ -578,6 +597,10 @@ def main():
         'delivered':     'data-block only (prose rejected)' if status == 'fail' else 'full report',
         'commit_ok':     commit_ok,
         'commit_msg':    commit_msg,
+        'data_plane_status': data_plane_status,
+        'narrative_status': {
+            'pass': 'success', 'warn': 'warning', 'fail': 'failed',
+        }[status],
         'n_chars':       len(body),
     }
     # Even a rejected prose report can have a successful postflight: the harness
@@ -586,9 +609,12 @@ def main():
     workflow_outcomes.record_stage(
         job_name,
         'postflight',
-        'success' if status == 'pass' else 'warning',
+        'success'
+        if status == 'pass' and data_plane_status in {'published', 'current'}
+        else 'warning',
         slot=slot,
         delivered=result['delivered'],
+        data_plane_status=data_plane_status,
         issue_count=len(issues),
     )
     primary_delivery_ok = bool(wechat_sent)

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -166,7 +166,7 @@ def run_main(pf, sent, monkeypatch, tmp_path):
     read_report_text() still went green while main() ignored its error)."""
     monkeypatch.setattr(pf.trading_calendar, 'closed_reason', lambda m: None)
     monkeypatch.setattr(pf.cron_heartbeat, 'record', lambda *a, **k: None)
-    monkeypatch.setattr(pf, 'rebuild_dashboard', lambda *a, **k: (False, 'skipped'))
+    monkeypatch.setattr(pf, 'publish_data_plane', lambda market: ('published', True))
 
     def run(prose, *, context_id, ctx=None):
         (tmp_path / 'intraday-context-us-latest.json').write_text(
@@ -203,6 +203,9 @@ def test_main_refuses_to_marry_stale_prose_to_fresh_numbers(run_main, sent):
 
     assert rc == 2 and out['status'] == 'fail'
     assert any('context_id 不匹配' in i for i in out['issues'])
+    assert out['data_plane_status'] == 'published'
+    assert out['dashboard_published'] is True
+    assert out['heartbeat']['state'] == 'completed'
     body = sent['messages'][0]
     assert BLOCK.splitlines()[0] in body and '▎我的看法' not in body
 

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -295,7 +295,7 @@ def run_main(pf, sent, monkeypatch, tmp_path):
     monkeypatch.setattr(pf.trading_calendar, 'phase_session', lambda m, p: 'x')
     monkeypatch.setattr(pf.trading_calendar, 'closed_reason', lambda m, session=None: None)
     monkeypatch.setattr(pf, 'maybe_commit',
-                        lambda status, msg: (status != 'fail', f'commit({status})'))
+                        lambda status, msg: (True, f'commit({status})'))
 
     def run(prose, *, context_id, ctx=None, age_minutes=0):
         (tmp_path / f'report-context-us-close-{pf.datetime.now():%Y-%m-%d}.json'
@@ -331,7 +331,9 @@ def test_incident_replay_stale_prose_is_refused_not_married_to_fresh_numbers(
 
     assert rc == 2 and out['status'] == 'fail'
     assert any('context_id 不匹配' in i for i in out['issues'])
-    assert out['commit_ok'] is False
+    assert out['commit_ok'] is True
+    assert out['data_plane_status'] == 'published'
+    assert out['narrative_status'] == 'failed'
     body = sent['messages'][0]
     assert FRESH_BLOCK in body and '▎情绪面' not in body and STALE_BLOCK not in body
 
@@ -343,6 +345,34 @@ def test_happy_path_assembles_commits_and_records_delivered(run_main, sent):
     assert out['commit_ok'] is True
     body = sent['messages'][0]
     assert body.startswith('🌙 美股收盘日报') and FRESH_BLOCK in body and '▎情绪面' in body
+
+
+def test_failed_narrative_still_commits_only_the_data_plane_paths(pf, monkeypatch):
+    calls = []
+    monkeypatch.setattr(pf, 'rebuild_dashboard', lambda: (True, 'ok'))
+    monkeypatch.setattr(pf, 'dashboard_output_changes',
+                        lambda: ['assets/data/dashboard.json'])
+    monkeypatch.setattr(pf, 'snapshot_date_for_now', lambda: None)
+    monkeypatch.setattr(pf, 'push_with_rebase_retry', lambda: (True, 'ok'))
+
+    def fake_git(*args):
+        calls.append(args)
+        return True, 'ok'
+
+    monkeypatch.setattr(pf, '_git', fake_git)
+
+    ok, message = pf.maybe_commit('fail', 'portfolio: refresh')
+
+    assert ok is True and message == 'committed + pushed'
+    assert calls[0] == (
+        'add', 'portfolio.json', 'assets/data/dashboard.json',
+        'logs/dashboard_build_status.json',
+    )
+    assert calls[1] == (
+        'commit', '-m', 'portfolio: refresh (data only; prose rejected)', '--',
+        'portfolio.json', 'assets/data/dashboard.json',
+        'logs/dashboard_build_status.json',
+    )
 
 
 def test_a_failed_slot_can_be_superseded_once_then_locks(run_main, sent, pf):

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -117,6 +117,51 @@ def test_heartbeat_bridge_maps_completed_and_watchdog_to_separate_stages(
     assert record["final_product"]["status"] == "recovered"
 
 
+def test_heartbeat_bridge_preserves_data_only_fallback_as_degraded(
+    tmp_path, monkeypatch
+):
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat(
+        {
+            "job": "美股盘中盯盘",
+            "market": "us",
+            "slot": "2026-07-24T22:00:00+08:00",
+            "state": "completed",
+            "postflight_status": "fail",
+            "data_plane_status": "published",
+            "wechat_sent": True,
+            "telegram_sent": True,
+        }
+    )
+
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["llm"]["status"] == "failed"
+    assert record["stages"]["postflight"]["status"] == "warning"
+    assert record["stages"]["primary_delivery"]["status"] == "success"
+    assert record["final_product"]["status"] == "degraded"
+
+
+def test_heartbeat_bridge_marks_data_publish_failure_as_postflight_warning(
+    tmp_path, monkeypatch
+):
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat(
+        {
+            "job": "美股盘中盯盘",
+            "slot": "2026-07-24T22:00:00+08:00",
+            "state": "completed",
+            "postflight_status": "pass",
+            "data_plane_status": "rebuild_failed",
+            "wechat_sent": True,
+        }
+    )
+
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["llm"]["status"] == "success"
+    assert record["stages"]["postflight"]["status"] == "warning"
+    assert record["final_product"]["status"] == "degraded"
+
+
 def test_market_closed_is_a_skipped_product_not_a_failure(tmp_path, monkeypatch):
     _isolate(tmp_path, monkeypatch)
     record = outcomes.record_stage(


### PR DESCRIPTION
Closes #143

## What changed
- publish deterministic portfolio/dashboard outputs even when LLM prose is rejected
- expose independent data_plane_status and narrative_status fields
- record successful data-block fallback as a completed, degraded product
- constrain report commits to explicit generated-data pathspecs

## Validation
- python3 -m pytest tests/ -q (1126 passed, 5 xfailed)
- python3 -m py_compile on changed scripts
- pre-push system check: 15 ok, 2 existing warnings, 0 critical