### PR TITLE
perf: enforce a lazy daily brief context budget

### DIFF
--- a/scripts/data/brief_context.py
+++ b/scripts/data/brief_context.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Budgeted, generation-bound context artifacts for the daily deep brief.
+
+The complete preflight context remains the audit record. The model-facing
+boundary is a compact manifest plus a fixed core and independently loadable
+feature bundles. Adding a new feature therefore cannot silently grow the
+always-loaded prompt: unassigned fields go to the ``extras`` bundle.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from copy import deepcopy
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+ALWAYS_LOADED_BUDGET_BYTES = 128 * 1024
+SINGLE_BUNDLE_BUDGET_BYTES = 96 * 1024
+TARGET_REDUCTION_PCT = 60.0
+
+# These fields are required for every decision. They are copied byte-for-byte
+# (as JSON values) into core; budget enforcement may never trim them.
+CORE_FIELDS = (
+    "generated_at",
+    "date",
+    "fx",
+    "portfolio_path",
+    "snapshot_path",
+    "portfolio",
+    "book_totals",
+    "concentration",
+    "lookthrough_exposure",
+    "risk_guardrail",
+    "risk_discipline",
+    "integrity",
+    "thesis_registry",
+    "research_surface",
+    "issues",
+)
+
+BUNDLE_FIELDS = {
+    "risk_detail": (
+        "breakeven_math",
+        "risk_metrics",
+    ),
+    "research": (
+        "quant_signals",
+        "quant_signal_review",
+        "cross_sectional_factor",
+        "peer_residual",
+        "t0_setups",
+        "t0_setup_review",
+        "us_fundamentals",
+        "peer_scan",
+    ),
+    "evidence": (
+        "catalysts",
+        "news_evidence_graph",
+    ),
+    "market": (
+        "macro",
+        "sentiment",
+        "influencer",
+        "em_news",
+    ),
+    "calibration": (
+        "retrospective",
+        "decision_metrics",
+        "reflections",
+    ),
+}
+
+
+def _compact(value) -> str:
+    return json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+
+
+def _bytes(value) -> int:
+    return len(_compact(value).encode("utf-8"))
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _write_immutable(path: Path, text: str) -> None:
+    """Create a content-addressed run artifact; never replace different bytes."""
+    if path.exists():
+        if path.read_text(encoding="utf-8") != text:
+            raise ValueError(f"immutable brief context artifact changed: {path}")
+        return
+    _atomic_write(path, text)
+
+
+def compute_generation_id(context: dict) -> str:
+    source = {key: value for key, value in context.items() if key != "generation_id"}
+    return _sha256_text(_compact(source))[:16]
+
+
+def _field_summary(field: str, value):
+    if not isinstance(value, dict):
+        return {"type": type(value).__name__, "items": len(value)} if isinstance(
+            value, list
+        ) else {"type": type(value).__name__}
+    summary = {
+        key: value[key]
+        for key in (
+            "status",
+            "ok",
+            "as_of",
+            "generated_at",
+            "fetched_at",
+            "error_count",
+            "warn_count",
+            "breach_count",
+            "open_count",
+            "prior_plan_date",
+            "settled_episodes",
+        )
+        if key in value and not isinstance(value[key], (dict, list))
+    }
+    for key in ("events", "decisions", "rows", "findings", "errors"):
+        if isinstance(value.get(key), list):
+            summary[f"{key}_count"] = len(value[key])
+    if field == "news_evidence_graph":
+        summary["actionable_event_ids"] = [
+            event.get("event_id")
+            for event in value.get("events") or []
+            if event.get("actionable_escalation") and event.get("event_id")
+        ]
+    return summary
+
+
+def _artifact(path: Path, fields: tuple[str, ...], context: dict, generation_id: str):
+    payload = {
+        "_meta": {
+            "schema_version": SCHEMA_VERSION,
+            "generation_id": generation_id,
+            "fields": list(fields),
+        },
+        **{field: deepcopy(context[field]) for field in fields if field in context},
+    }
+    text = _compact(payload) + "\n"
+    _write_immutable(path, text)
+    summaries = {
+        field: _field_summary(field, context[field])
+        for field in fields
+        if field in context
+    }
+    freshness = {
+        field: {
+            key: summary[key]
+            for key in ("as_of", "generated_at", "fetched_at")
+            if key in summary
+        }
+        for field, summary in summaries.items()
+        if any(key in summary for key in ("as_of", "generated_at", "fetched_at"))
+    }
+    return {
+        "path": str(path),
+        "generation_id": generation_id,
+        "fields": [field for field in fields if field in context],
+        "bytes": len(text.encode("utf-8")),
+        "sha256": _sha256_text(text),
+        "freshness": freshness,
+        "summary": summaries,
+    }
+
+
+def write_run_bundle(context: dict, audit_path: Path) -> tuple[dict, dict]:
+    """Write full audit JSON plus budgeted model-facing artifacts.
+
+    Returns ``(generation-stamped context, manifest)``. Raises ValueError when
+    action-critical core + manifest exceeds the model boundary budget.
+    """
+    stamped = deepcopy(context)
+    generation_id = compute_generation_id(stamped)
+    stamped["generation_id"] = generation_id
+
+    audit_text = json.dumps(stamped, ensure_ascii=False, indent=2) + "\n"
+    _atomic_write(audit_path, audit_text)
+    run_root = audit_path.with_suffix("")
+    artifact_dir = run_root / generation_id
+    immutable_audit_path = artifact_dir / "audit.json"
+    _write_immutable(immutable_audit_path, audit_text)
+
+    core_fields = tuple(field for field in CORE_FIELDS if field in stamped)
+    core = _artifact(
+        artifact_dir / "core.json", core_fields, stamped, generation_id
+    )
+
+    bundles = {}
+    assigned = set(core_fields) | {"generation_id"}
+    for name, configured_fields in BUNDLE_FIELDS.items():
+        fields = tuple(field for field in configured_fields if field in stamped)
+        assigned.update(fields)
+        bundles[name] = _artifact(
+            artifact_dir / f"{name}.json", fields, stamped, generation_id
+        )
+
+    extras = tuple(sorted(set(stamped) - assigned))
+    if extras:
+        bundles["extras"] = _artifact(
+            artifact_dir / "extras.json", extras, stamped, generation_id
+        )
+    oversized = {
+        name: entry["bytes"]
+        for name, entry in bundles.items()
+        if entry["bytes"] > SINGLE_BUNDLE_BUDGET_BYTES
+    }
+    if oversized:
+        raise ValueError(
+            "daily brief lazy bundle exceeds per-load budget "
+            f"({SINGLE_BUNDLE_BUDGET_BYTES} bytes): {oversized}"
+        )
+
+    section_bytes = {
+        key: _bytes(value)
+        for key, value in stamped.items()
+        if key != "generation_id"
+    }
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "generation_id": generation_id,
+        "date": stamped.get("date"),
+        "audit": {
+            "path": str(immutable_audit_path),
+            "latest_path": str(audit_path),
+            "bytes": len(audit_text.encode("utf-8")),
+            "sha256": _sha256_text(audit_text),
+        },
+        "core": core,
+        "bundles": bundles,
+        "source_section_bytes": section_bytes,
+        "budget": {
+            "max_always_loaded_bytes": ALWAYS_LOADED_BUDGET_BYTES,
+            "max_single_bundle_bytes": SINGLE_BUNDLE_BUDGET_BYTES,
+            "always_loaded_bytes": 0,
+            "estimated_tokens": 0,
+            "target_reduction_pct": TARGET_REDUCTION_PCT,
+            "actual_reduction_pct": 0,
+            "target_met": False,
+        },
+    }
+
+    # The manifest describes its own boundary size. Iterate until the digit count
+    # stabilizes, then write exactly the bytes that were measured.
+    manifest_path = run_root / "manifest.json"
+    for _ in range(6):
+        manifest_text = _compact(manifest) + "\n"
+        always_loaded = core["bytes"] + len(manifest_text.encode("utf-8"))
+        audit_bytes = len(audit_text.encode("utf-8"))
+        reduction = 100.0 * (1.0 - always_loaded / audit_bytes) if audit_bytes else 0.0
+        next_budget = {
+            **manifest["budget"],
+            "always_loaded_bytes": always_loaded,
+            # Stable same-fixture estimate for the mixed CJK/ASCII payload. The
+            # hard invariant remains serialized UTF-8 bytes.
+            "estimated_tokens": math.ceil(always_loaded / 3),
+            "actual_reduction_pct": round(reduction, 1),
+            "target_met": (
+                reduction >= TARGET_REDUCTION_PCT
+                or audit_bytes <= ALWAYS_LOADED_BUDGET_BYTES
+            ),
+        }
+        if next_budget == manifest["budget"]:
+            break
+        manifest["budget"] = next_budget
+    manifest_text = _compact(manifest) + "\n"
+    measured = core["bytes"] + len(manifest_text.encode("utf-8"))
+    if measured > ALWAYS_LOADED_BUDGET_BYTES:
+        raise ValueError(
+            "daily brief always-loaded context exceeds budget: "
+            f"{measured}>{ALWAYS_LOADED_BUDGET_BYTES} bytes"
+        )
+    _atomic_write(manifest_path, manifest_text)
+    manifest["manifest_path"] = str(manifest_path)
+    return stamped, manifest
+
+
+def validate_run_bundle(audit_path: Path, manifest_path: Path) -> list[str]:
+    """Validate hashes and generation identity across one preflight run."""
+    issues = []
+    try:
+        audit_text = audit_path.read_text(encoding="utf-8")
+        audit = json.loads(audit_text)
+        manifest_text = manifest_path.read_text(encoding="utf-8")
+        manifest = json.loads(manifest_text)
+    except Exception as exc:
+        return [f"context generation bundle 解析失败: {exc}"]
+
+    generation_id = audit.get("generation_id")
+    if not generation_id or manifest.get("generation_id") != generation_id:
+        issues.append("context generation_id 缺失或 manifest 跨代")
+    if manifest.get("audit", {}).get("sha256") != _sha256_text(audit_text):
+        issues.append("context generation audit hash 不匹配")
+
+    core_entry = manifest.get("core") or {}
+    entries = [core_entry, *(manifest.get("bundles") or {}).values()]
+    covered = set()
+    core_payload = None
+    for entry in entries:
+        path = Path(entry.get("path") or "")
+        try:
+            text = path.read_text(encoding="utf-8")
+            payload = json.loads(text)
+        except Exception as exc:
+            issues.append(f"context generation artifact 不可读: {path}: {exc}")
+            continue
+        if entry.get("sha256") != _sha256_text(text):
+            issues.append(f"context generation artifact hash 不匹配: {path.name}")
+        if payload.get("_meta", {}).get("generation_id") != generation_id:
+            issues.append(f"context generation artifact 跨代: {path.name}")
+        covered.update(entry.get("fields") or [])
+        if entry is core_entry:
+            core_payload = payload
+
+    expected = set(audit) - {"generation_id"}
+    if covered != expected:
+        issues.append(
+            "context generation manifest 字段覆盖不完整: "
+            f"missing={sorted(expected - covered)}, extra={sorted(covered - expected)}"
+        )
+    if core_payload is not None:
+        for field in CORE_FIELDS:
+            if field in audit and core_payload.get(field) != audit[field]:
+                issues.append(
+                    f"context generation core 行动字段与 audit 不一致: {field}"
+                )
+    measured = core_entry.get("bytes", 0) + len(manifest_text.encode("utf-8"))
+    budget = manifest.get("budget") or {}
+    if (
+        measured != budget.get("always_loaded_bytes")
+        or measured > budget.get("max_always_loaded_bytes", 0)
+    ):
+        issues.append(
+            "context generation always-loaded budget 记录不匹配或已超限"
+        )
+    oversized = {
+        name: entry.get("bytes", 0)
+        for name, entry in (manifest.get("bundles") or {}).items()
+        if entry.get("bytes", 0) > budget.get("max_single_bundle_bytes", 0)
+    }
+    if oversized:
+        issues.append(
+            f"context generation lazy bundle 已超单次加载预算: {oversized}"
+        )
+    return issues
+
+
+def read_artifact(manifest_path: Path, kind: str) -> str:
+    """Read one generation-checked core/bundle for model consumption."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entry = (
+        manifest.get("core") or {}
+        if kind == "core"
+        else (manifest.get("bundles") or {}).get(kind) or {}
+    )
+    if not entry:
+        raise ValueError(f"unknown brief context artifact: {kind}")
+    path = Path(entry["path"])
+    text = path.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    generation_id = manifest.get("generation_id")
+    if (
+        entry.get("generation_id") != generation_id
+        or payload.get("_meta", {}).get("generation_id") != generation_id
+        or entry.get("sha256") != _sha256_text(text)
+    ):
+        raise ValueError(f"brief context artifact failed generation/hash check: {kind}")
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--core", action="store_true")
+    group.add_argument("--bundle", choices=tuple(BUNDLE_FIELDS) + ("extras",))
+    args = parser.parse_args()
+    print(read_artifact(args.manifest, "core" if args.core else args.bundle), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/gh_action_brief_fallback.py
+++ b/scripts/data/gh_action_brief_fallback.py
@@ -236,6 +236,9 @@ def fail_closed_artifacts(today, prepared):
         'decisions': [],
         'section_manifest': prepared.get('manifest') or {},
     }
+    generation_id = (prepared.get('payload') or {}).get('generation_id')
+    if generation_id:
+        plan['context_generation_id'] = generation_id
     return md, plan
 
 
@@ -298,6 +301,8 @@ def main():
     if 'actions' in plan:
         raise SystemExit('LLM returned forbidden v1 actions field')
     plan['date'] = plan.get('date') or today
+    if prepared['payload'].get('generation_id'):
+        plan['context_generation_id'] = prepared['payload']['generation_id']
     plan = decision_v2.normalize_authored_plan(plan)
     errors = decision_v2.validate_plan(plan)
     if errors:

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -39,6 +39,7 @@ import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
+import brief_context  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases
@@ -87,6 +88,41 @@ def _marker_has_alias(marker, alias):
     return alias in marker
 
 
+def validate_generation_references(plan, context=None):
+    """Require every plan generation reference to belong to this preflight run."""
+    expected_generation = (context or {}).get('generation_id')
+    if not expected_generation:
+        return []
+    cited = []
+
+    def collect_generation_ids(value):
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key.endswith('generation_id'):
+                    cited.append(nested)
+                collect_generation_ids(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                collect_generation_ids(nested)
+
+    collect_generation_ids(plan)
+    issues = []
+    if plan.get('context_generation_id') != expected_generation:
+        issues.append(
+            'plan.json context generation_id 缺失或跨代: '
+            f'expected={expected_generation}, '
+            f'got={plan.get("context_generation_id")}'
+        )
+    foreign = sorted({
+        str(value) for value in cited if value != expected_generation
+    })
+    if foreign:
+        issues.append(
+            f'plan.json context generation_id 跨代引用: {foreign}'
+        )
+    return issues
+
+
 def validate_plan_json(path, context=None):
     if not path.exists():
         return ['plan.json 缺失（critical）']
@@ -96,6 +132,7 @@ def validate_plan_json(path, context=None):
         return [f'plan.json 解析失败: {e}']
 
     issues = [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
+    issues += validate_generation_references(plan, context)
     decisions = plan.get('decisions', []) if isinstance(plan.get('decisions'), list) else []
     # Unpriceable calls score for direction but never reach the money chart.
     issues += [f'plan.json size: {x}' for x in decision_v2.missing_size_warnings(decisions)]
@@ -254,7 +291,9 @@ def validate_markdown(path, context=None):
     return issues
 
 
-CRITICAL_KEYWORDS = ['缺失', '解析失败', '表格 #']  # table column-mismatch is critical
+CRITICAL_KEYWORDS = [
+    '缺失', '解析失败', '表格 #', 'generation_id',
+]  # table mismatch and cross-generation output are critical
 
 
 def categorize(issues):
@@ -473,6 +512,9 @@ def main():
             pass
 
     issues = []
+    manifest_path = ctx_path.with_suffix('') / 'manifest.json'
+    if context and context.get('generation_id'):
+        issues += brief_context.validate_run_bundle(ctx_path, manifest_path)
     issues += validate_markdown(md_path, context=context)
     issues += validate_plan_json(plan_path, context=context)
 

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -2,9 +2,10 @@
 """
 brief_preflight.py — deterministic data collection for daily-deep-brief harness.
 
-Runs everything that must happen BEFORE LLM analysis. LLM reads the resulting
-brief-context.json to get all deterministic facts (FX rate, concentration,
-retrospective) so it can't forget steps.
+Runs everything that must happen BEFORE LLM analysis. It keeps a complete audit
+context, then emits a budgeted core plus generation-bound lazy bundles for the
+LLM (FX rate, concentration, retrospective, etc.) so it cannot forget steps or
+silently absorb an unbounded monolith.
 
 Steps:
   1. Refresh US + HK prices (mutates portfolio.json)
@@ -20,7 +21,7 @@ Steps:
  11. Catalyst calendar (next 14d earnings + FOMC + macro)
  12. Benchmark history (SPY + HSI/HSTECH) for equity curve overlay
  13. Load macro + sentiment snapshots (read assets/data/{macro,sentiment}.json)
- 14. Write memory/.tmp/brief-context-{date}.json
+ 14. Write the full audit context + model-facing manifest/core/bundles
 
 Output (stdout): step-by-step progress; final summary with issue count.
 Exit: 0 if no issues, 1 if any data leg failed.
@@ -54,6 +55,7 @@ import research_surface  # noqa: E402
 import peer_scan  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
+import brief_context  # noqa: E402
 from instrument_registry import get as get_instrument  # noqa: E402
 from instrument_registry import compute_lookthrough_exposure  # noqa: E402
 from instrument_registry import one_x_swap_map  # noqa: E402
@@ -1738,7 +1740,9 @@ def main():
     influencer_trim = load_influencer_feed(issues)
     em_news_trim = load_em_news(issues)
 
-    # Write context.json
+    # Write the complete audit context plus a budgeted, generation-bound model
+    # boundary. The full JSON remains available for postflight/audit; the skill
+    # reads manifest+core and lazy-loads feature bundles.
     # 简报上下文里的 portfolio 拷贝去掉 gold_dca.nav_history(~140条/3.3KB 黄金每日净值流水):
     # 简报 LLM 不逐日分析黄金(黄金有独立 cron)，dashboard 🥇卡也是直接读 portfolio.json，
     # 都用不到这段 → 纯占 token。浅拷贝只替换 gold_dca 键，不改原始 portfolio(下游仍用全量)。
@@ -1810,10 +1814,29 @@ def main():
         'issues':        issues,
     }
     ctx_path = TMP_DIR / f'brief-context-{today}.json'
-    ctx_path.write_text(json.dumps(context, ensure_ascii=False, indent=2))
+    try:
+        context, bundle_manifest = brief_context.write_run_bundle(context, ctx_path)
+    except Exception as exc:
+        print(f'FATAL: brief context boundary failed: {exc}', file=sys.stderr)
+        workflow_outcomes.record_stage(
+            job_name, 'preflight', 'failed', slot=slot,
+            reason='context_budget', detail=str(exc),
+        )
+        return 2
 
     print(f'\n═════ preflight done | {len(issues)} issues ═════')
     print(f'context: {ctx_path}')
+    print(
+        'model context: '
+        f'{bundle_manifest["budget"]["always_loaded_bytes"]:,} / '
+        f'{bundle_manifest["budget"]["max_always_loaded_bytes"]:,} bytes '
+        f'({bundle_manifest["budget"]["actual_reduction_pct"]}% reduction; '
+        f'≈{bundle_manifest["budget"]["estimated_tokens"]:,} est. tokens)'
+    )
+    for section, size in sorted(
+            bundle_manifest['source_section_bytes'].items(),
+            key=lambda item: item[1], reverse=True):
+        print(f'  context bytes {section}: {size:,}')
     if issues:
         for i in issues:
             print(f'  ⚠️  {i}')
@@ -1824,6 +1847,8 @@ def main():
         slot=slot,
         issue_count=len(issues),
         context_path=str(ctx_path),
+        context_generation_id=context['generation_id'],
+        model_context_bytes=bundle_manifest['budget']['always_loaded_bytes'],
     )
     return 0 if not issues else 1
 

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -15,7 +15,7 @@ description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分
 │ scripts/harness/brief_preflight.py │ ──► │ LLM (你 / Rick)│ ──► │ brief_postflight.py│
 │  (确定性 + 幂等)   │     │  (Tier 1/2/3) │     │ 验证+commit+投递微信│
 └────────────────────┘     └───────────────┘     └────────────────────┘
-   刷价/FX/snapshot/         读 context.json        校验 md+plan schema，
+   刷价/FX/snapshot/         读 core + 按需 bundles 校验 md+plan schema，
    HHI/EDGAR/retro           写 md+plan+            fresh-token 发 brief-card
                              brief-card 微信卡       (唯一投递, 见 Step 6)
 ```
@@ -47,30 +47,59 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_preflight.py
    - 不在文档硬编码 ticker；实际名单以当天持仓和上述动态过滤结果为准
 7. **Retrospective**：读 prior v2 plan，对每个 decision 按 strategy 检查 condition 是否触发、模拟 benefit 与 confidence calibration
 
-输出：`memory/.tmp/brief-context-{date}.json` —— 所有数据准备好的单一 JSON。
+输出分两层：
 
-### Step 2: 读 context.json
+- `memory/.tmp/brief-context-{date}.json` —— 完整、不可裁剪的审计事实；供 postflight 校验，**不要整份 cat 进模型上下文**。
+- `memory/.tmp/brief-context-{date}/manifest.json` + `core.json` + feature bundles —— 同一 `generation_id` 下的模型输入边界。manifest 记录路径、hash、字段、逐 section 大小和预算。
+
+### Step 2: 读 manifest + core（常驻输入）
 
 ```bash
-cat /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d).json
+cat /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --core
 ```
 
-context.json 关键字段：
+`manifest + core` 是唯一常驻输入，合计硬上限 128 KiB；每个 lazy bundle 另有 96 KiB 单次加载上限。preflight 超限就直接失败，绝不静默裁字段。完整 audit 只给 postflight 和排障使用，正常分析禁止 `cat brief-context-{date}.json`。
+
+core 关键字段：
 - `prices_refreshed_at` / `fx`（`rate`, `source`, `fetched_at`）
 - `book` — `usd_total_pnl`, `hkd_total_pnl`, `hk_leg_hkd`, `us_leg_usd`（FX 已换算）
 - `concentration` — `{hk: {hhi, top2_pct, weights, verdict}, us: {...}}`
-- `edgar_summaries` — 单股最新 quarter 财报关键数字
-- `retrospective` — 上次 plan.json 每个 strategy decision 的触发结果 + 模拟 benefit
-- `macro` — VIX / DXY / 10Y / F&G / HSI / HSTECH / SPX / NASDAQ + Fed press top 3（GH Action 周日–四 21:45 UTC，即工作日 05:45 HKT 名义刷新）
-- `sentiment` — 每个持仓票的 Reddit 提及数 + Reddit top 3 + Google News top 3（无 signal 的票已被剔）
-- `em_news` — **东财中文消息源**（`holdings_news` 逐 HK 持仓近 3 条公司新闻 + `market_724` 大盘 7x24 快讯）。clawock 英文 news 薄在港股/中文面,这里补上。**HK 持仓找硬催化优先看这个**——回购/公告/事件多在中文源先出。命中硬催化 → `driven_by=catalyst` 并在 rationale 引日期+标题;只是情绪/涨跌色 → 不构成主动操作依据(见 catalyst-gate 铁律)。杠杆 ETF 已自动剔除(看标的不看公司新闻)。
-- `news_evidence_graph` — 新闻/公告/SEC/事件日历的去重证据图。`events` 已带来源可靠度、新颖度、到期状态、价量/已验证同行确认与 `actionable_escalation`。**它是 catalyst 权限的唯一事实源**；原始摘要仅供阅读。
+- `portfolio` / `lookthrough_exposure` / `risk_guardrail` / `risk_discipline` —— 行动所需持仓与完整风险规则，按 JSON 值原样保留，不参与裁剪
+- `integrity` / `issues` —— 数据完整性结果
 - `thesis_registry` — `memory/theses/*.json` 的只读摘要：当前 state、最近检查时间、下一次 review trigger；未建基线的持仓明确为 `unknown`。
 - `research_surface` — 研究生命周期的**待办队列**（只读）：`earnings.hk_results_expected`（港股已公告董事会会议→业绩临近；**只有「临近」没有日期**，日期在公告文件里，任何免费源都没有，别编一个出来）、`earnings.reviews_due`（已披露财报但没有一手 artifact 覆盖）、`earnings.overdue_commitments`（管理层承诺过期且没结果）、`entry_gates.ungated_positions`（建仓后没有 gate 或 gate 判 reject 仍在持有）、`entry_gates.open_questions`（gray 判定还缺的证据）。`errors` 非空 = 有 artifact 失效，先说这件事。
 
+### Step 2.5: 按消费者 lazy-load bundles
+
+每个命令会同时校验 manifest hash 与 `generation_id`。**每个 bundle 最多读一次，紧挨着消费它的章节读；不要预先全读，也不要回头重读。** 读出的字段与 core 合并后，下面统称 `context`。
+
+```bash
+# 风险情景 / 解套数学使用前
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle risk_detail
+# Tier 1 / 同行扫描 / 因子研究使用前
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle research
+# 任何 catalyst 主动动作裁决前（news_evidence_graph 是唯一权限源）
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle evidence
+# 大盘、舆情、东财、名人段使用前
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle market
+# Retrospective / Decision v2 校准段使用前
+python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle calibration
+```
+
+bundle 路由：
+
+- `risk_detail`: `breakeven_math`, `risk_metrics`
+- `research`: `quant_signals`, `cross_sectional_factor`, `peer_residual`, `t0_setups`, `us_fundamentals`, `peer_scan` 及对应 review
+- `evidence`: `catalysts`, `news_evidence_graph`
+- `market`: `macro`, `sentiment`, `influencer`, `em_news`
+- `calibration`: `retrospective`, `decision_metrics`, `reflections`
+
+manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 core；只有下面明确要求消费该字段时才读。任一 bundle 的 `_meta.generation_id` 与 manifest 不同，立即停止，不得把不同 preflight run 的事实拼在一起。
+
 ### Step 3: Swarm 分析（你的创造性工作）
 
-按下面这个 3-tier 流程做分析。所有数字**只能从 context.json 取**，不要凭空造。
+按下面这个 3-tier 流程做分析。所有数字**只能从本次 generation 的 core / 已加载 bundle 取**，不要凭空造。
 
 #### Required reads (delta vs `AGENTS.md` baseline)
 
@@ -140,7 +169,7 @@ context.json 关键字段：
 - 每个板块输出：Top 3-5 涨幅 + 你持仓票在榜单中的位置（领涨/落后/中位）
 - **归因句必带**：落后是因为(a) 利好时点（盘后才公布）/ (b) 早盘异常抛压 / (c) β 错配 / (d) 个股逻辑滞后？
 - 输出在 ▎板块全景 段（pre-open.md 必带），引用 ≥3 个具体涨跌幅 + 1 个明确归因
-- ⚠️ **持仓自己的数字** (RSI/MA/PnL) 仍然从 context.json 取，板块这段只 search 板块/同行公开行情
+- ⚠️ **持仓自己的数字** (RSI/MA/PnL) 仍然从 core 取，板块这段只 search 板块/同行公开行情
 - **同时落盘到** `memory/.tmp/sector-scan-{date}.json`（build_dashboard 会读，让 GH Pages dashboard 同步显示）。schema：
   ```json
   {
@@ -338,7 +367,7 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 
 #### Retrospective markdown 模板
 
-把 context.json 的 `retrospective` 字段渲染成下面这段，**插在 brief 顶部**（TL;DR 之后，Header 之前）：
+把 calibration bundle 的 `retrospective` 字段渲染成下面这段，**插在 brief 顶部**（TL;DR 之后，Header 之前）：
 
 ```
 ▎昨日 plan 兑现度（{上次 plan 日期}）
@@ -477,7 +506,7 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 
 #### ▎Confidence / episode 校准（REQUIRED）
 
-context.json 的 `decision_metrics` 是 v2 唯一口径：只结算**条件实际触发**的决策；同一 `ticker + strategy_id` 的连续同类决策合并为一个 episode，只取一次代表样本，避免每日重复建议放大样本量。
+calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条件实际触发**的决策；同一 `ticker + strategy_id` 的连续同类决策合并为一个 episode，只取一次代表样本，避免每日重复建议放大样本量。
 
 格式：
 ```
@@ -532,8 +561,8 @@ context.json 的 `decision_metrics` 是 v2 唯一口径：只结算**条件实�
 结构（**postflight 会校验这些段标记**，缺哪个 fail）：
 
 - `# Header`（regime US/HK 分开 + FX rate + book USD/HKD 双视角）
-- `## ▎仓位明细` —— HK + US 各一张 7 列 markdown 表 `代码 | 股 | 成本 | 现价 | 今日 | 浮% | 浮$`（与 Mode 6/7 cron 完全一致；数据从 context.json 的 `portfolio.portfolios.{hk,us}_stocks.holdings` 直接取，**只列 shares>0 的**。2026-05-21 起的 visual-width-aware 渲染推荐 import `scripts.data._wechat_table.render_holdings_table`，省得手算 CJK 对齐）
-- `## Retrospective`（来自 context.json 的 retrospective）
+- `## ▎仓位明细` —— HK + US 各一张 7 列 markdown 表 `代码 | 股 | 成本 | 现价 | 今日 | 浮% | 浮$`（与 Mode 6/7 cron 完全一致；数据从 core 的 `portfolio.portfolios.{hk,us}_stocks.holdings` 直接取，**只列 shares>0 的**。2026-05-21 起的 visual-width-aware 渲染推荐 import `scripts.data._wechat_table.render_holdings_table`，省得手算 CJK 对齐）
+- `## Retrospective`（来自 calibration bundle 的 retrospective）
 - `## Tier 1` 大表
 - `## Tier 2` Bull vs Bear
 - `## Tier 3` Aggressive/Conservative/Neutral + Judge
@@ -558,6 +587,7 @@ postflight 严格 schema 校验：
 {
   "schema_version": 2,
   "date": "2026-05-18",
+  "context_generation_id": "照抄 manifest.generation_id",
   "fx_rate_usdhkd": 7.8315,
   "fx_source": "Frankfurter",
   "regime": {"us": "trending-up", "hk": "trending-down"},
@@ -607,6 +637,7 @@ postflight 严格 schema 校验：
 
 合法 enum：
 - `strategy_id` ∈ {`core_position`, `risk_rebalance`, `intraday_t`, `event_trade`, `tactical_entry`}；迁移历史才允许 `legacy_unknown`
+- `context_generation_id`：必填，逐字符照抄本次 `manifest.generation_id`；postflight 会递归检查 plan 内所有 `*generation_id`，跨代引用直接 fail。
 - `action` ∈ {`cut`, `trim_on_rebound`, `hold_and_watch`, `t_only`, `add_only_on_trigger`, `watch`}
 - `condition.type` ∈ {`open`, `price_above`, `price_below`, `index_breakdown`, `event`, `manual`}
 - `driven_by` ∈ {`technical`, `catalyst`, `sentiment`, `influencer`, `macro`, `peer`, `risk_rule`}（每个 decision 必填）
@@ -635,7 +666,7 @@ postflight 严格 schema 校验：
 
 build_dashboard 会读它，让 dashboard 上 **行为复盘 / 唱反调 Pre-mortem / 隐藏集中度** 三张卡同步刷新（缺失/解析失败容错，卡自动隐藏，不影响 brief 投递）。这是 dashboard 上唯一由你（LLM）写的"对决策本身的反思"层 —— 数字算不出来、只有你能写。
 
-**铁律（accuracy）**：所有数字只能引 `brief-context-{date}.json` 里**真实出现过的** win_rate / Brier / 仓位权重 / HHI / pnl%。**绝不编造 context 里没有的具体美元金额或未发生的交易**。宁可不写一条，也不要编数字。
+**铁律（accuracy）**：所有数字只能引本次 manifest 所属的 `core.json` / 已加载 bundle 里**真实出现过的** win_rate / Brier / 仓位权重 / HHI / pnl%。完整 audit 只用于 postflight 交叉校验，不能靠整份 cat 绕过预算。**绝不编造 context 里没有的具体美元金额或未发生的交易**。宁可不写一条，也不要编数字。
 
 ```json
 {
@@ -666,7 +697,7 @@ build_dashboard 会读它，让 dashboard 上 **行为复盘 / 唱反调 Pre-mor
 
 #### D. 微信卡 → `memory/.tmp/brief-card-{YYYY-MM-DD}.txt`
 
-**这是真正发到 kcn 微信的内容**（投递由 Step 5 的 postflight 自动完成，原样发这个文件），所以必须自洽完整、≤1.5KB。数字全来自 `plan.json` + context.json，不现编：
+**这是真正发到 kcn 微信的内容**（投递由 Step 5 的 postflight 自动完成，原样发这个文件），所以必须自洽完整、≤1.5KB。数字全来自 `plan.json` + 本次 generation 的 core/bundles，不现编：
 
 ```
 📊 盘前深度简报｜{日期 周X} 08:00 HKT  (USDHKD={rate})
@@ -753,9 +784,9 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
 - 每个 claim 钉到具体 ticker + 数字，没有泛论
 - Bull/Bear/Aggressive/Conservative 必须真的不同观点
 - Judge 不重复 Bull/Bear，是合成不是复述
-- **FX 换算永远显式标注 source + timestamp**（context.json 里已有）
+- **FX 换算永远显式标注 source + timestamp**（core 里已有）
 
-## 集中度阈值表（解读 context.json `concentration` 字段）
+## 集中度阈值表（解读 core 的 `concentration` 字段）
 
 ### 算法（preflight 已经算了，这里只是参考）
 
@@ -787,7 +818,7 @@ US: HHI 0.171 偏集中 | SOXL 22.2% + ROBN 21.1% = Top2 43.3%
 历史教训：港股 book 双仓集中 86% 是 2026-05-16 之前 brief **漏报的盲点** — preflight 现在
 强制算这个，brief 必须显式引用 `concentration.{hk,us}.verdict`。
 
-## ⚠️ 货币铁律（context.json 已换算，但你输出时仍要双视角）
+## ⚠️ 货币铁律（core 已换算，但你输出时仍要双视角）
 
 港币 + 美元 **不能直接相加**。book 段必须**两个 view 都给**：
 

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -1,0 +1,147 @@
+"""The daily brief's model boundary is budgeted without trimming audit facts."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+sys.path.insert(0, str(ROOT / "scripts" / "harness"))
+
+import brief_context  # noqa: E402
+import brief_postflight  # noqa: E402
+
+
+def _fixture():
+    return {
+        "generated_at": "2026-07-28T08:00:00+08:00",
+        "date": "2026-07-28",
+        "fx": {"rate": 7.84, "source": "test"},
+        "portfolio_path": "portfolio.json",
+        "snapshot_path": "memory/snapshots/2026-07-28.json",
+        "portfolio": {
+            "portfolios": {
+                "hk_stocks": {"holdings": [{"ticker": "00100", "shares": 100}]},
+                "us_stocks": {"holdings": [{"ticker": "MSFT", "shares": 2}]},
+            }
+        },
+        "book_totals": {"usd_total_pnl": -10},
+        "concentration": {"hk": {"hhi": 0.5}, "us": {"hhi": 0.2}},
+        "lookthrough_exposure": {"total": 1},
+        "risk_guardrail": {"directive": "must preserve", "rules": "R" * 8_000},
+        "risk_discipline": {"records": [{"status": "open", "detail": "D" * 8_000}]},
+        "integrity": {"ok": True, "findings": []},
+        "thesis_registry": {"status": "ok"},
+        "research_surface": {"status": "ok", "errors": []},
+        "issues": [],
+        "breakeven_math": {"rows": [{"ticker": "00100"}]},
+        "risk_metrics": {"detail": "X" * 25_000},
+        "quant_signals": {"detail": "Q" * 25_000},
+        "news_evidence_graph": {
+            "as_of": "2026-07-28",
+            "events": [{
+                "event_id": "evt-1",
+                "actionable_escalation": True,
+                "detail": "N" * 70_000,
+            }],
+        },
+        "macro": {"detail": "M" * 25_000},
+        "retrospective": {"detail": "C" * 25_000},
+        "new_feature_surface": {"detail": "E" * 25_000},
+    }
+
+
+def test_same_fixture_reduces_always_loaded_input_and_preserves_action_fields(tmp_path):
+    source = _fixture()
+    audit_path = tmp_path / "brief-context-2026-07-28.json"
+
+    stamped, manifest = brief_context.write_run_bundle(source, audit_path)
+    core = json.loads(Path(manifest["core"]["path"]).read_text())
+
+    assert manifest["budget"]["always_loaded_bytes"] <= 128 * 1024
+    assert manifest["budget"]["actual_reduction_pct"] >= 60
+    assert manifest["budget"]["target_met"] is True
+    for field in brief_context.CORE_FIELDS:
+        assert core[field] == stamped[field], field
+    assert "new_feature_surface" not in core
+    assert manifest["bundles"]["extras"]["fields"] == ["new_feature_surface"]
+    assert manifest["bundles"]["evidence"]["freshness"] == {
+        "news_evidence_graph": {"as_of": "2026-07-28"}
+    }
+    assert manifest["bundles"]["evidence"]["summary"][
+        "news_evidence_graph"
+    ]["actionable_event_ids"] == ["evt-1"]
+    assert Path(manifest["audit"]["path"]).parent.name == stamped["generation_id"]
+    assert brief_context.validate_run_bundle(
+        audit_path, Path(manifest["manifest_path"])
+    ) == []
+
+
+def test_new_optional_feature_cannot_grow_the_always_loaded_core(tmp_path):
+    baseline = _fixture()
+    baseline.pop("new_feature_surface")
+    _, before = brief_context.write_run_bundle(
+        baseline, tmp_path / "before.json"
+    )
+    baseline["another_feature"] = {"rows": ["z" * 25_000]}
+    _, after = brief_context.write_run_bundle(
+        baseline, tmp_path / "after.json"
+    )
+
+    assert after["core"]["bytes"] == before["core"]["bytes"]
+    assert after["bundles"]["extras"]["fields"] == ["another_feature"]
+
+
+def test_new_feature_cannot_silently_create_an_unbounded_lazy_load(tmp_path):
+    source = _fixture()
+    source["new_feature_surface"] = {"rows": ["z" * 100_000]}
+
+    with pytest.raises(ValueError, match="lazy bundle exceeds per-load budget"):
+        brief_context.write_run_bundle(source, tmp_path / "bundle-oversize.json")
+
+
+def test_action_critical_growth_fails_the_final_boundary(tmp_path):
+    source = _fixture()
+    source["portfolio"]["raw_history"] = "P" * (140 * 1024)
+
+    with pytest.raises(ValueError, match="always-loaded context exceeds budget"):
+        brief_context.write_run_bundle(source, tmp_path / "oversize.json")
+
+
+def test_bundle_read_and_postflight_reject_cross_generation(tmp_path):
+    stamped, manifest = brief_context.write_run_bundle(
+        _fixture(), tmp_path / "brief.json"
+    )
+    manifest_path = Path(manifest["manifest_path"])
+    research = json.loads(brief_context.read_artifact(manifest_path, "research"))
+    assert research["_meta"]["generation_id"] == stamped["generation_id"]
+
+    good = {
+        "context_generation_id": stamped["generation_id"],
+        "decisions": [{"source_generation_id": stamped["generation_id"]}],
+    }
+    assert brief_postflight.validate_generation_references(good, stamped) == []
+
+    bad = {
+        "context_generation_id": stamped["generation_id"],
+        "decisions": [{"source_generation_id": "older-run"}],
+    }
+    issues = brief_postflight.validate_generation_references(bad, stamped)
+    assert any("跨代引用" in issue for issue in issues)
+
+
+def test_tampered_bundle_is_detected(tmp_path):
+    _, manifest = brief_context.write_run_bundle(
+        _fixture(), tmp_path / "brief.json"
+    )
+    bundle = Path(manifest["bundles"]["evidence"]["path"])
+    bundle.write_text(bundle.read_text() + " ")
+
+    issues = brief_context.validate_run_bundle(
+        tmp_path / "brief.json", Path(manifest["manifest_path"])
+    )
+    assert any("hash 不匹配" in issue for issue in issues)


### PR DESCRIPTION
Closes #144

## What changed
- preserve a generation-scoped immutable full audit while splitting model input into manifest, core, and independently loadable bundles
- enforce 128 KiB for manifest+core and 96 KiB per lazy bundle
- route unknown features to extras so they cannot silently grow the always-loaded prompt
- include paths, hashes, generation IDs, freshness, summaries, and per-section byte telemetry
- make postflight reject tampered, incomplete, or cross-generation plans

## Measured result (same 2026-07-28 fixture)
- previous full input: 369,549 bytes
- manifest + core: 83,979 bytes
- reduction: 77.3%
- largest lazy bundle: 69,246 bytes

## Validation
- targeted regression: 88 passed, 1 xfailed
- full suite before final documentation pass: 1129 passed, 5 xfailed
- all Python scripts compile
- pre-push system check: 15 ok, 2 existing warnings, 0 critical