### PR TITLE
perf: cache Polygon prior closes by US session

### DIFF
--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -19,19 +19,25 @@ Usage:
 """
 
 import json
+import fcntl
 import os
 import sys
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional
+from zoneinfo import ZoneInfo
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _em_http import em_get  # noqa: E402
 from instrument_registry import INSTRUMENTS  # noqa: E402
+import trading_calendar  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PORTFOLIO_PATH = os.path.join(WS_ROOT, 'portfolio.json')
 API_KEYS_PATH  = os.path.join(WS_ROOT, '.api_keys')
+POLYGON_PREV_CACHE_DIR = Path(WS_ROOT) / 'memory' / '.tmp' / 'polygon-prev-close'
+POLYGON_CACHE_SCHEMA_VERSION = 1
 
 # Eastmoney exchange prefix: 105=NASDAQ, 106=NYSE/ARCA
 EASTMONEY_PREFIX: Dict[str, str] = {
@@ -124,12 +130,26 @@ def _quote_is_complete(q: Optional[Dict]) -> bool:
 
 
 def _prev_trading_day(date_str: str) -> str:
-    """Calendar prior trading day (skips weekends; ignores holidays — close enough
-    for a date label on a reconstructed prev_close)."""
-    d = datetime.strptime(date_str, '%Y-%m-%d') - timedelta(days=1)
-    while d.weekday() >= 5:  # Sat=5, Sun=6
-        d -= timedelta(days=1)
-    return d.strftime('%Y-%m-%d')
+    """Actual prior US trading session from the shared exchange calendar."""
+    return trading_calendar.previous_trading_day(
+        'us', date.fromisoformat(date_str)
+    ).isoformat()
+
+
+def _us_quote_session_date(at: Optional[datetime] = None) -> str:
+    """US session represented by a live/latest quote at wall-clock ``at``.
+
+    Before 09:30 ET (and on closed days), providers still describe the latest
+    completed session. Treating midnight Tuesday as Tuesday's session stamps a
+    Monday close against Monday itself and rejects Friday's valid prior close.
+    """
+    et = at.astimezone(ZoneInfo('America/New_York')) if at else \
+        datetime.now(ZoneInfo('America/New_York'))
+    current = et.date()
+    regular_open = (et.hour, et.minute) >= (9, 30)
+    if regular_open and trading_calendar.is_trading_day('us', current):
+        return current.isoformat()
+    return trading_calendar.previous_trading_day('us', current).isoformat()
 
 
 # ── debug instrumentation (③) ──────────────────────────────────────────────────
@@ -573,71 +593,159 @@ def get_prev_close_polygon(ticker: str, api_key: str) -> Optional[tuple]:
         return None
 
 
+def _polygon_cache_path(session_date: str, cache_dir: Optional[Path] = None) -> Path:
+    return Path(cache_dir or POLYGON_PREV_CACHE_DIR) / f'{session_date}.json'
+
+
+def _load_polygon_cache(session_date: str, cache_dir: Optional[Path] = None):
+    path = _polygon_cache_path(session_date, cache_dir)
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        closes = payload.get('closes')
+        if (
+            payload.get('schema_version') != POLYGON_CACHE_SCHEMA_VERSION
+            or payload.get('session_date') != session_date
+            or payload.get('source') != 'Polygon grouped'
+            or not isinstance(closes, dict)
+            or not closes
+            or payload.get('result_count') != len(closes)
+            or any(not isinstance(value, (int, float)) or value <= 0
+                   for value in closes.values())
+        ):
+            return None
+        datetime.fromisoformat(payload['fetched_at'])
+        return payload
+    except (FileNotFoundError, json.JSONDecodeError, OSError, KeyError, ValueError,
+            TypeError):
+        return None
+
+
+def _write_polygon_cache(payload: Dict, cache_dir: Optional[Path] = None) -> None:
+    path = _polygon_cache_path(payload['session_date'], cache_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f'.tmp.{os.getpid()}')
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, separators=(',', ':')) + '\n',
+        encoding='utf-8',
+    )
+    os.replace(tmp, path)
+
+
+def _cached_polygon_result(payload: Dict, tickers: List[str], cache_hit: bool):
+    session_date = payload['session_date']
+    fetched = datetime.fromisoformat(payload['fetched_at'])
+    if fetched.tzinfo is None:
+        fetched = fetched.replace(tzinfo=timezone.utc)
+    age = max(0, int((datetime.now(timezone.utc) - fetched).total_seconds()))
+    print(
+        f"  [PC] cache_hit={str(cache_hit).lower()} session={session_date} "
+        f"source={payload['source']} age={age}s "
+        f"rows={payload.get('result_count', len(payload['closes']))} "
+        f"bytes={payload.get('response_bytes', 0)}"
+    )
+    return {
+        ticker: (float(payload['closes'][ticker]), session_date)
+        for ticker in tickers
+        if ticker in payload['closes']
+    }
+
+
 def get_prev_closes_polygon_grouped(
-    tickers: List[str], api_key: str, today_et_date: str, max_lookback: int = 6,
+    tickers: List[str], api_key: str, quote_session_date: str,
+    max_lookback: int = 6, cache_dir: Optional[Path] = None,
 ) -> tuple:
-    """Date-stamped prior closes for every ticker in ONE request.
+    """Return prior closes from one session-keyed grouped snapshot.
 
-    Replaces a per-ticker loop over `/v2/aggs/ticker/{t}/prev` that quietly lost
-    most of its tickers: Polygon's free tier allows 5 requests/minute, the loop
-    fired ~15 back-to-back with no pacing, and `except: return None` swallowed
-    the 429s without a single log line. Only the first ~5 tickers ever got a
-    dated prev_close and *which* five drifted with ticker order, so the same bug
-    surfaced on different holdings each run (verified 2026-07-27: MSFU and SKHY
-    were positions 6 and 7 and silently got none).
+    ``quote_session_date`` is the trading session represented by current quotes,
+    not necessarily today's wall-clock date. Its actual previous US session is
+    resolved before selecting the cache. The cache stores the complete Polygon
+    map (not only today's holdings), so every scheduled/manual caller shares one
+    immutable download.
 
-    `/v2/aggs/grouped/...` returns the whole US session — ~12.4k tickers — in a
-    single call, so the rate limit stops mattering. Walks back day by day
-    because the grouped endpoint returns an empty result set for weekends and
-    holidays rather than the last session.
-
-    Returns ({ticker: (close, date)}, rate_limited). `rate_limited` lets the
-    caller skip a per-ticker retry that would only burn the same exhausted quota.
+    Returns ``(ticker_map, rate_limited, snapshot_valid)``. Per-ticker fallback
+    is allowed only when ``snapshot_valid`` is true and the symbol is genuinely
+    absent from that grouped snapshot.
     """
-    out: Dict[str, tuple] = {}
+    del max_lookback  # retained for call compatibility; calendar owns lookback
     if not api_key or not tickers:
-        return out, False
-    want = set(tickers)
-    probe = datetime.strptime(today_et_date, '%Y-%m-%d')
-    for _ in range(max_lookback):
-        probe -= timedelta(days=1)
-        if probe.weekday() >= 5:          # skip Sat/Sun without spending a call
-            continue
-        date_str = probe.strftime('%Y-%m-%d')
+        return {}, False, False
+    session_date = _prev_trading_day(quote_session_date)
+    cached = _load_polygon_cache(session_date, cache_dir)
+    if cached:
+        return _cached_polygon_result(cached, tickers, True), False, True
+
+    cache_path = _polygon_cache_path(session_date, cache_dir)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_path.with_suffix('.lock')
+    with lock_path.open('a+') as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        # Another process may have populated the session while this caller waited.
+        cached = _load_polygon_cache(session_date, cache_dir)
+        if cached:
+            return _cached_polygon_result(cached, tickers, True), False, True
         try:
             r = SESSION.get(
-                f"https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/{date_str}",
+                f"https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/{session_date}",
                 params={'adjusted': 'true', 'apiKey': api_key},
                 timeout=max(TIMEOUT, 30),
             )
             if r.status_code == 429:
-                # Quota exhausted, not "this date has no data". Walking further
-                # back would spend the remaining budget on requests that are
-                # certain to fail too, so stop and let the caller know.
-                print(f"  ⚠ Polygon grouped {date_str}: HTTP 429 rate limited — "
-                      f"aborting prior-close lookup (prev_close falls back to the "
-                      f"provider's own field)", file=sys.stderr)
-                return out, True
+                print(
+                    f"  ⚠ Polygon grouped {session_date}: HTTP 429 rate limited — "
+                    "cache unchanged",
+                    file=sys.stderr,
+                )
+                return {}, True, False
             if r.status_code != 200:
-                print(f"  ⚠ Polygon grouped {date_str}: HTTP {r.status_code} "
-                      f"{r.text[:120]}", file=sys.stderr)
-                continue
+                print(
+                    f"  ⚠ Polygon grouped {session_date}: HTTP {r.status_code} "
+                    f"{getattr(r, 'text', '')[:120]} — cache unchanged",
+                    file=sys.stderr,
+                )
+                return {}, False, False
             raw = r.json()
-        except Exception as e:
-            print(f"  ⚠ Polygon grouped {date_str} failed: {type(e).__name__}: {e}",
-                  file=sys.stderr)
-            continue
+        except Exception as exc:
+            print(
+                f"  ⚠ Polygon grouped {session_date} failed: "
+                f"{type(exc).__name__}: {exc} — cache unchanged",
+                file=sys.stderr,
+            )
+            return {}, False, False
+
         results = raw.get('results') or []
-        if not results:
-            continue                       # holiday / not yet published
-        _debug_dump('polygon_grouped', date_str, {'resultsCount': len(results)})
-        for res in results:
-            t = res.get('T')
-            if t in want and res.get('c'):
-                out[t] = (float(res['c']), date_str)
-        if out:
-            return out, False
-    return out, False
+        closes = {}
+        for result in results:
+            ticker, close = result.get('T'), result.get('c')
+            try:
+                close = float(close)
+            except (TypeError, ValueError):
+                continue
+            if ticker and close > 0:
+                closes[str(ticker)] = close
+        if not closes:
+            print(
+                f"  ⚠ Polygon grouped {session_date}: empty/invalid snapshot — "
+                "cache unchanged",
+                file=sys.stderr,
+            )
+            return {}, False, False
+
+        try:
+            response_bytes = len(r.content)
+        except Exception:
+            response_bytes = len(json.dumps(raw, separators=(',', ':')).encode())
+        payload = {
+            'schema_version': POLYGON_CACHE_SCHEMA_VERSION,
+            'session_date': session_date,
+            'source': 'Polygon grouped',
+            'fetched_at': datetime.now(timezone.utc).isoformat(),
+            'result_count': len(closes),
+            'response_bytes': response_bytes,
+            'closes': closes,
+        }
+        _write_polygon_cache(payload, cache_dir)
+        _debug_dump('polygon_grouped', session_date, {'resultsCount': len(closes)})
+        return _cached_polygon_result(payload, tickers, False), False, True
 
 
 # ── main fetch logic ─────────────────────────────────────────────────────────
@@ -655,7 +763,7 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
     results: Dict[str, Dict] = {}
     partial: Dict[str, Dict] = {}
     stale: Dict[str, Dict] = {}
-    today_et_date = datetime.now(timezone(timedelta(hours=-4))).strftime('%Y-%m-%d')
+    today_et_date = _us_quote_session_date()
     remaining = list(tickers)
 
     def _done(ticker: str, quote: Dict):
@@ -797,13 +905,16 @@ def update_us_portfolio(
                     h[k] = 0
 
     # Timezone helpers
-    et_tz  = timezone(timedelta(hours=-4))   # EDT; adjust to -5 for EST
-    hkt_tz = timezone(timedelta(hours=8))
+    et_tz  = ZoneInfo('America/New_York')
+    hkt_tz = ZoneInfo('Asia/Hong_Kong')
     now_et  = datetime.now(et_tz)
     now_hkt = datetime.now(hkt_tz)
 
-    today_et_date  = now_et.strftime('%Y-%m-%d')
-    three_days_ago = (now_et - timedelta(days=3)).strftime('%Y-%m-%d')
+    # The quote's session can differ from the wall-clock date before 09:30 ET,
+    # on weekends, and after holidays. Every range/prev-close date below is keyed
+    # to the quote session, never to midnight.
+    today_et_date = _us_quote_session_date(now_et)
+    expected_prev_session = _prev_trading_day(today_et_date)
 
     et_str  = now_et.strftime('%Y-%m-%d %H:%M %Z')
     hkt_str = now_hkt.strftime('%Y/%m/%d %H:%M HKT')
@@ -822,7 +933,7 @@ def update_us_portfolio(
     polygon_key = keys.get('POLYGON_API_KEY', '')
     if polygon_key:
         print(f"  [PC] Polygon prev-close (grouped)...")
-        prev_closes, rate_limited = get_prev_closes_polygon_grouped(
+        prev_closes, rate_limited, snapshot_valid = get_prev_closes_polygon_grouped(
             tickers, polygon_key, today_et_date)
         for t, result in prev_closes.items():
             print(f"       ✓ {t}: ${result[0]:.4f} ({result[1]})")
@@ -835,14 +946,27 @@ def update_us_portfolio(
             print(f"       ⚠ Polygon rate limited — no dated prior close for "
                   f"{', '.join(missing)}; prev_close falls back to the quote "
                   f"provider's own field", file=sys.stderr)
-        elif missing:
+        elif missing and snapshot_valid:
             for t in missing:
                 result = get_prev_close_polygon(t, polygon_key)
-                if result:
+                if result and result[1] == expected_prev_session:
                     prev_closes[t] = result
                     print(f"       ✓ {t}: ${result[0]:.4f} ({result[1]}) [per-ticker]")
+                elif result:
+                    print(
+                        f"       ✗ {t}: per-ticker Polygon bar {result[1]} "
+                        f"does not match expected prior session "
+                        f"{expected_prev_session}",
+                        file=sys.stderr,
+                    )
                 else:
                     print(f"       ✗ {t}: no Polygon prior close", file=sys.stderr)
+        elif missing:
+            print(
+                f"       ⚠ Polygon grouped snapshot unavailable — skip per-ticker "
+                f"fallback because absence of {', '.join(missing)} is unproven",
+                file=sys.stderr,
+            )
 
     print(f"\n{'─'*62}")
     updated: List[str] = []
@@ -876,8 +1000,9 @@ def update_us_portfolio(
         # dated weeks ago is the *old* instrument that used to own this ticker —
         # a day-change computed against it is fiction (SPCX showed +637%).
         poly_pc = prev_closes.get(t)
-        if poly_pc and poly_pc[1] < three_days_ago:
-            print(f"  ⚠ {t}: Polygon prev_close dated {poly_pc[1]} (< {three_days_ago}) "
+        if poly_pc and poly_pc[1] < expected_prev_session:
+            print(f"  ⚠ {t}: Polygon prev_close dated {poly_pc[1]} "
+                  f"(< expected session {expected_prev_session}) "
                   f"— stale bar / ticker reuse, ignoring")
             poly_pc = None
         if poly_pc:
@@ -905,11 +1030,11 @@ def update_us_portfolio(
                 existing_pc_date = holding.get('prev_close_date', '')
                 api_dp           = q.get('dp', 0)
                 if existing_pc > 0 and existing_pc_date and \
-                        three_days_ago <= existing_pc_date < today_et_date:
+                        existing_pc_date == expected_prev_session:
                     pc, pc_date = existing_pc, existing_pc_date
                 elif api_dp and abs(api_dp) > 0.01:
                     pc = round(c / (1 + api_dp / 100), 4)
-                    pc_date = _prev_trading_day(today_et_date)
+                    pc_date = expected_prev_session
                 # else: leave pc = today's close (today_change falls back to 0, safe)
         else:
             # A prior close belongs to the PRIOR session, so it is stamped with
@@ -918,7 +1043,7 @@ def update_us_portfolio(
             # day_session_date, an impossible state that also tripped
             # preflight_integrity's `opened_this_session` exemption and switched
             # off the TODAY_LEG gate for exactly the rows this bug had touched.
-            prev_session = _prev_trading_day(today_et_date)
+            prev_session = expected_prev_session
             api_pc = q.get('pc')
             existing_pc      = holding.get('prev_close', 0)
             existing_pc_date = holding.get('prev_close_date', '')
@@ -928,7 +1053,8 @@ def update_us_portfolio(
             elif api_dp and abs(api_dp) > 0.01:
                 pc = round(c / (1 + api_dp / 100), 4)
                 pc_date = prev_session
-            elif existing_pc > 0 and existing_pc != c and existing_pc_date >= three_days_ago:
+            elif (existing_pc > 0 and existing_pc != c
+                  and existing_pc_date == expected_prev_session):
                 pc, pc_date = existing_pc, existing_pc_date
             else:
                 pc, pc_date = c, prev_session

--- a/scripts/data/trading_calendar.py
+++ b/scripts/data/trading_calendar.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 # --- Full-day market closures (weekday ones are what matter; weekend-falling
@@ -180,6 +180,16 @@ def is_trading_day(market: str, d: date | None = None, session: str = "full") ->
     if market == "hk" and session == "afternoon" and iso in HK_HALF_DAYS:
         return False
     return True
+
+
+def previous_trading_day(market: str, d: date) -> date:
+    """Most recent trading day strictly before ``d``."""
+    probe = d - timedelta(days=1)
+    for _ in range(14):
+        if is_trading_day(market, probe):
+            return probe
+        probe -= timedelta(days=1)
+    raise ValueError(f"no {market} trading day found before {d}")
 
 
 def closed_reason(market: str, d: date | None = None,

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -96,6 +96,15 @@ def test_an_ordinary_2027_weekday_still_trades():
         assert trading_calendar.is_trading_day(market, date(2027, 3, 3))
 
 
+def test_previous_us_session_skips_weekend_and_exchange_holiday():
+    assert trading_calendar.previous_trading_day(
+        "us", date(2026, 7, 27)
+    ) == date(2026, 7, 24)
+    assert trading_calendar.previous_trading_day(
+        "us", date(2026, 9, 8)
+    ) == date(2026, 9, 4)
+
+
 # --------------------------------------------------------------------------
 # coverage + the deliberate fail-open past the horizon
 # --------------------------------------------------------------------------

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -22,7 +22,10 @@ Run: `python3 -m pytest tests/test_us_quote_staleness.py -q`
 import json
 import os
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -256,6 +259,10 @@ class TestProviderRace:
 
 # ── 3. one grouped request instead of a rate-limited per-ticker loop ─────────
 class TestPolygonGrouped:
+    @pytest.fixture(autouse=True)
+    def isolated_cache(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(F, "POLYGON_PREV_CACHE_DIR", tmp_path)
+
     def _grouped(self, monkeypatch, by_date, status=200):
         seen = []
 
@@ -275,7 +282,7 @@ class TestPolygonGrouped:
             {"T": "RKLX", "c": 16.32}, {"T": "CRCL", "c": 62.36},
             {"T": "NOISE", "c": 1.0},
         ]})
-        out, limited = F.get_prev_closes_polygon_grouped(
+        out, limited, valid = F.get_prev_closes_polygon_grouped(
             ["SPCX", "PLTU", "MSFU", "SKHY", "RKLX", "CRCL"], "key", "2026-07-27")
         # Positions 6 and 7 (MSFU/SKHY) are exactly what the old 5/min loop lost.
         assert set(out) == {"SPCX", "PLTU", "MSFU", "SKHY", "RKLX", "CRCL"}
@@ -283,36 +290,145 @@ class TestPolygonGrouped:
         assert out["SKHY"] == (154.57, "2026-07-24")
         assert len(seen) == 1                      # one call, not one per ticker
         assert limited is False
+        assert valid is True
 
     def test_weekend_is_skipped_without_spending_a_request(self, monkeypatch):
         seen = self._grouped(monkeypatch, {"2026-07-24": [{"T": "SPCX", "c": 115.07}]})
-        out, _ = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
+        out, _, _ = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
         assert out["SPCX"] == (115.07, "2026-07-24")
         assert "2026-07-25" not in seen and "2026-07-26" not in seen
 
-    def test_walks_back_over_an_empty_holiday_session(self, monkeypatch):
+    def test_empty_expected_session_is_not_replaced_by_an_older_bar(self, monkeypatch):
         seen = self._grouped(monkeypatch, {
             "2026-07-23": [{"T": "SPCX", "c": 120.0}],
-            "2026-07-24": [],                      # holiday / not yet published
+            "2026-07-24": [],
         })
-        out, _ = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
-        assert out["SPCX"] == (120.0, "2026-07-23")
-        assert seen == ["2026-07-24", "2026-07-23"]
+        out, _, valid = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+        assert out == {} and valid is False
+        assert seen == ["2026-07-24"]
 
     def test_rate_limit_aborts_instead_of_burning_the_rest_of_the_quota(
-            self, monkeypatch):
+            self, monkeypatch, tmp_path):
         # A 429 means "no budget left", not "this date has no data". Walking
         # further back would spend the remaining requests on certain failures
         # and starve the per-ticker fallback too.
         seen = self._grouped(monkeypatch, {}, status=429)
-        out, limited = F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
-        assert out == {} and limited is True
+        out, limited, valid = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+        assert out == {} and limited is True and valid is False
         assert seen == ["2026-07-24"]              # exactly one attempt
+        assert not (tmp_path / "2026-07-24.json").exists()
+
+    def test_http_error_never_poison_the_cache(
+            self, monkeypatch, tmp_path):
+        seen = self._grouped(monkeypatch, {}, status=503)
+        out, limited, valid = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+
+        assert out == {} and limited is False and valid is False
+        assert seen == ["2026-07-24"]
+        assert not (tmp_path / "2026-07-24.json").exists()
 
     def test_no_key_makes_no_request(self, monkeypatch):
         seen = self._grouped(monkeypatch, {})
-        assert F.get_prev_closes_polygon_grouped(["SPCX"], "", "2026-07-27") == ({}, False)
+        assert F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "", "2026-07-27") == ({}, False, False)
         assert seen == []
+
+    def test_sequential_callers_download_once_and_emit_cache_metadata(
+            self, monkeypatch, capsys):
+        seen = self._grouped(
+            monkeypatch, {"2026-07-24": [{"T": "SPCX", "c": 115.07}]})
+
+        first = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+        second = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+
+        assert first[0] == second[0] == {"SPCX": (115.07, "2026-07-24")}
+        assert seen == ["2026-07-24"]
+        diagnostics = capsys.readouterr().out
+        assert "cache_hit=false session=2026-07-24 source=Polygon grouped" in diagnostics
+        assert "cache_hit=true session=2026-07-24 source=Polygon grouped" in diagnostics
+
+    def test_concurrent_callers_cannot_stampede_polygon(self, monkeypatch):
+        seen = self._grouped(
+            monkeypatch, {"2026-07-24": [{"T": "SPCX", "c": 115.07}]})
+        start = threading.Barrier(2)
+
+        def fetch():
+            start.wait()
+            return F.get_prev_closes_polygon_grouped(
+                ["SPCX"], "key", "2026-07-27")
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: fetch(), range(2)))
+
+        assert [result[0] for result in results] == [
+            {"SPCX": (115.07, "2026-07-24")},
+            {"SPCX": (115.07, "2026-07-24")},
+        ]
+        assert seen == ["2026-07-24"]
+
+    def test_session_rollover_downloads_exactly_one_new_snapshot(
+            self, monkeypatch):
+        seen = self._grouped(monkeypatch, {
+            "2026-07-24": [{"T": "SPCX", "c": 115.07}],
+            "2026-07-27": [{"T": "SPCX", "c": 116.50}],
+        })
+        F.get_prev_closes_polygon_grouped(["SPCX"], "key", "2026-07-27")
+        monday, _, _ = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-28")
+        again, _, _ = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-28")
+
+        assert monday == again == {"SPCX": (116.50, "2026-07-27")}
+        assert seen == ["2026-07-24", "2026-07-27"]
+
+    def test_corrupt_cache_is_ignored_and_atomically_replaced(
+            self, monkeypatch, tmp_path):
+        (tmp_path / "2026-07-24.json").write_text("{partial")
+        seen = self._grouped(
+            monkeypatch, {"2026-07-24": [{"T": "SPCX", "c": 115.07}]})
+
+        out, _, valid = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+
+        assert valid is True and out["SPCX"] == (115.07, "2026-07-24")
+        assert seen == ["2026-07-24"]
+        repaired = json.loads((tmp_path / "2026-07-24.json").read_text())
+        assert repaired["session_date"] == "2026-07-24"
+
+    def test_valid_snapshot_can_prove_a_symbol_is_genuinely_absent(
+            self, monkeypatch):
+        self._grouped(
+            monkeypatch, {"2026-07-24": [{"T": "NOISE", "c": 1.0}]})
+
+        out, limited, valid = F.get_prev_closes_polygon_grouped(
+            ["SPCX"], "key", "2026-07-27")
+
+        assert out == {} and limited is False and valid is True
+
+
+def test_quote_and_prior_sessions_are_calendar_aware_before_tuesday_open():
+    at = F.datetime(2026, 7, 28, 0, 15, tzinfo=ZoneInfo("America/New_York"))
+    quote_session = F._us_quote_session_date(at)
+
+    assert quote_session == "2026-07-27"
+    assert F._prev_trading_day(quote_session) == "2026-07-24"
+
+
+def test_tuesday_after_monday_holiday_resolves_real_sessions():
+    before_open = F.datetime(
+        2026, 9, 8, 0, 15, tzinfo=ZoneInfo("America/New_York"))
+    after_open = F.datetime(
+        2026, 9, 8, 10, 0, tzinfo=ZoneInfo("America/New_York"))
+
+    assert F._us_quote_session_date(before_open) == "2026-09-04"
+    assert F._prev_trading_day("2026-09-04") == "2026-09-03"
+    assert F._us_quote_session_date(after_open) == "2026-09-08"
+    assert F._prev_trading_day("2026-09-08") == "2026-09-04"
 
 
 # ── 4 + 5. end-to-end: the PLTU shape through update_us_portfolio ────────────
@@ -338,9 +454,10 @@ class TestStaleLastGuard:
     def _run(self, monkeypatch, tmp_path, quote, prev_closes):
         monkeypatch.setattr(F, "fetch_us_quotes", lambda t, k: {"PLTU": quote})
         monkeypatch.setattr(F, "get_prev_closes_polygon_grouped",
-                            lambda t, k, d, **kw: (prev_closes, False))
+                            lambda t, k, d, **kw: (prev_closes, False, True))
         monkeypatch.setattr(F, "get_prev_close_polygon", lambda t, k: None)
         monkeypatch.setattr(F, "load_api_keys", lambda: {"POLYGON_API_KEY": "key"})
+        monkeypatch.setattr(F, "_us_quote_session_date", lambda at=None: "2026-07-27")
         path = _portfolio(tmp_path, dict(self.BASE))
         data = F.update_us_portfolio(portfolio_path=path, dry_run=True)
         return data["portfolios"]["us_stocks"]["holdings"][0]
@@ -437,16 +554,8 @@ _SESSION, _PREV_SESSION = _session_dates()
 
 
 def _fresh_prev_bar_date():
-    """A Polygon prev-close bar date `update_us_portfolio` will still accept.
-
-    Same class of rot as `_session_dates`, one rule further down: the fetcher
-    drops any prev-close bar older than three calendar days (the SPCX
-    ticker-reuse trap), so the incident's own `2026-07-24` literal stopped
-    being a usable bar on 2026-07-28 — prev_close went `None` and the two
-    repair tests failed with no prior close to repair against. Clamp to the
-    acceptance window so a long weekend or holiday cannot reintroduce it.
-    """
-    return max(_PREV_SESSION, date.today() - timedelta(days=3)).isoformat()
+    """The real prior session for the deterministic Monday quote fixture."""
+    return "2026-07-24"
 
 
 PLTU_STALE = {


### PR DESCRIPTION
Closes #145
Closes #142

## What changed
- resolve the quote session and its prior close through the shared US exchange calendar, including pre-open Tuesday and Monday-holiday boundaries
- cache the complete Polygon grouped snapshot by resolved prior session
- serialize writers with flock, recheck after lock acquisition, and publish cache files atomically
- ignore corrupt/partial cache files; never write HTTP errors, empty responses, or 429s
- allow per-ticker fallback only when a valid grouped snapshot proves the symbol is absent
- emit cache_hit, session, source, age, row count, and response bytes

## Live benchmark
One real 2026-07-24 grouped snapshot:
- 12,410 rows / 1,351,572 response bytes
- cold: 1.763s
- cache hit: 0.0062s (163,226-byte local compact cache)

For 13 scheduled refreshes in one US night:
- network bytes: about 17.6MB to 1.35MB (-92.3%)
- acquisition wait: about 22.9s to 1.84s (-92.0%)
- grouped HTTP calls: 13 to 1

## Validation
- full suite: 1132 passed, 5 xfailed
- focused quote/calendar suite: 76 passed
- sequential, concurrent, rollover, corrupt-cache, HTTP-error, and 429 cases covered
- all Python scripts compile
- pre-push system check: 15 ok, 2 existing warnings, 0 critical