### PR TITLE
test(dashboard): 载荷闸按字节量，别再按字符——三处闸两种单位

### DIFF
--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -15,7 +15,14 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "assets" / "data" / "dashboard.json"
-SIZE_CAP = 200_000            # the same cap scripts/system_check.py enforces
+# Bytes, not characters — the unit build_dashboard's MAX_OUT_BYTES and
+# system_check both use, and the only one a visitor actually downloads. This
+# file used to measure `len(read_text())`, and because the payload is heavily
+# CJK (3 bytes per character in UTF-8) it read 4.8% low: 186,308 "bytes" for a
+# 195,234-byte file. That made the CI gate the loosest of the three and its
+# headroom number a lie — 2026-07-28 it reported 13.7KB left when 4.7KB
+# remained.
+SIZE_CAP = 200_000            # == build_dashboard.MAX_OUT_BYTES
 RENDERERS = ("dashboard.render.js", "dashboard.charts.js")
 
 
@@ -28,9 +35,35 @@ def _size(obj):
     return len(json.dumps(obj, ensure_ascii=False))
 
 
+def _published_size():
+    """Single source of truth for "how big is it" — see SIZE_CAP on the unit."""
+    return len(DASHBOARD.read_bytes())
+
+
 def test_payload_stays_under_the_published_cap():
-    size = len(DASHBOARD.read_text())
+    size = _published_size()
     assert size < SIZE_CAP, f"{size:,} bytes; trim or move detail to a sidecar"
+
+
+def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces():
+    """Three gates, one unit. The drift here was silent for a reason: on an
+    ASCII payload the two units agree exactly, so nothing catches it until the
+    content is non-ASCII — which this payload has always been."""
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    assert SIZE_CAP == build_dashboard.MAX_OUT_BYTES
+
+    # The payload is CJK-heavy, so the two units are ~5% apart. Pinning the
+    # gate's measurement to the byte count is what stops anyone quietly putting
+    # `read_text()` back: on this content the assertion below can only hold for
+    # the byte reading.
+    characters = len(DASHBOARD.read_text())
+    assert _published_size() > characters
+    assert _published_size() == len(DASHBOARD.read_bytes())
+
+    check = (ROOT / "scripts" / "system_check.py").read_text()
+    assert "out.stat().st_size" in check, "system_check must stay on bytes too"
 
 
 def test_no_sub_object_is_embedded_twice(payload):
@@ -129,7 +162,7 @@ def test_rebuild_is_idempotent_and_keeps_the_trim():
     assert "regime_history" not in rebuilt["lev_regime"]
     assert "current_group_calibrators" not in rebuilt["decision_metrics"]["hierarchical_calibration"]
     assert all("stages" not in r for r in rebuilt["workflow_outcomes"]["recent"])
-    assert len(DASHBOARD.read_text()) < SIZE_CAP
+    assert len(DASHBOARD.read_bytes()) < SIZE_CAP
 
 
 def test_the_brief_still_gets_the_calibrators_the_dashboard_no_longer_ships():


### PR DESCRIPTION
接 #146 的后续。只统一单位，**不动页面上任何内容**。

## 问题

`tests/test_dashboard_payload_size.py` 用 `len(read_text())` 量大小 —— 那是**字符数**；而 `build_dashboard.MAX_OUT_BYTES` 和 `system_check` 量的是**字节**。载荷大量中文（UTF-8 一个字 3 字节），两者差 4.8%：

```
186,308 字符   ← CI 闸看到的
195,234 字节   ← builder 硬帽 / system_check / 访客真实下载的
```

后果两条：

1. **CI 那道闸是三者里最松的**，字节口径会比它早约 9KB 触发。#146 里那次 203,734「字符」的失败，真实体积其实已经 ~213KB。
2. **它报的余量是假的**：07-28 显示「还剩 13.7KB」时实际只剩 4.7KB。

文件里那句注释 `# the same cap scripts/system_check.py enforces` 是错的，一直没人对过。

## 改动

- 测量收敛到 `_published_size()` 一个入口，读字节；两处 gate 都走它
- 新增 `test_the_cap_is_measured_in_the_same_unit_the_builder_enforces`，钉住三件事：
  - `SIZE_CAP == build_dashboard.MAX_OUT_BYTES`
  - 本文件量的确实是字节（在 CJK 内容上「字节 > 字符」只有读字节才成立）
  - `system_check` 仍走 `st_size`

## 变异验证

三条都验过会红：

| 变异 | 结果 |
|---|---|
| `_published_size` 改回 `read_text()` | ✅ 红 |
| `system_check` 改回字符口径 | ✅ 红 |
| `MAX_OUT_BYTES` 与 `SIZE_CAP` 脱钩 | ✅ 红 |

第一版守卫是裸子串扫源码（`"len(DASHBOARD.read_text())" not in source`），被自己的比较行命中而假红 —— 这类扫描的老坑，已换成基于行为的断言。

## 状态

改完仍然是绿的（**194,211 < 200,000**），但余量从此显示真值 **5,789 字节**。

余量本身没在这个 PR 里处理（kcn 明确选了「只统一单位，不动内容」）。真实情况是 `snapshots` 现在 55 条、上限 90，按每条约 490 字节还有 ~17KB 要来，5.8KB 撑不到那时候；`system_check` 的 180KB 预警线会先响。要腾余量时的候选：`snapshots`（26.8KB）改成只嵌最近 N 条、老的走 sidecar，或 `episode_backtest.horizons`（29.8KB）—— 两块图表都真在读，属于产品取舍。

全量套件 `1133 passed, 5 xfailed`；覆盖率 57.6%（floor 52）/ 结算核心 77.2%（floor 75）。