### PR TITLE
perf: compile typed brief decisions for agents and Pages

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -1228,14 +1228,18 @@
     return [...us, ...hk].filter(h => h.is_active !== false && (h.shares ?? 0) > 0);
   }
 
-  // 持仓决策矩阵：每个活跃持仓一行，把散在 Holdings / 量化因子 / 硬闸 三处的
-  // per-name 信号 join 到一张表（纯前端聚合，数据全在 dashboard.json）。
+  // 持仓决策矩阵优先消费 harness 编译的 versioned projection。旧 dashboard
+  // join 仅作跨版本部署期间的 fallback；Pages 不再是投资规则的 owner。
   function renderDecisionMatrix() {
     const card = document.getElementById('decision-matrix-card');
     if (!card) return;
+    const projection = safe(DATA, "brief_projection") || {};
+    const projected = projection.schema_version === 1
+      ? (projection.tickers || [])
+      : [];
     const H = safe(DATA, "holdings") || {};
     const holds = [...(H.us || []), ...(H.hk || [])].filter(h => h && h.is_active);
-    if (!holds.length) { card.style.display = 'none'; return; }
+    if (!projected.length && !holds.length) { card.style.display = 'none'; return; }
     card.style.display = '';
     const qrows = ((safe(DATA, "quant_signals") || {}).rows) || {};
     // 杠杆 ETF→底层标的映射（量化按标的算，ETF 本身无 quant 行）。
@@ -1275,15 +1279,40 @@
       if (q.tag || q.rsi14 != null) return { rank: 3, txt: '趋势off·观望', state: 'neutral' };
       return { rank: 5, txt: '—', state: 'neutral' };
     };
-    const enriched = holds.map(h => {
-      const usable = r => r && (!r.status || r.status === 'fresh');
-      const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
-      const proxy = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : '';
-      if (proxy) usedProxy = true;
-      const q = direct || (proxy ? qrows[proxy] : {}) || {};
-      const a = action[h.ticker];
-      return { h, q, a, proxy, v: verdict(q, a) };
-    });
+    const enriched = projected.length
+      ? projected.map(row => {
+          const q = row.technical || {};
+          const proxy = q.is_proxy ? q.source_ticker : '';
+          if (proxy) usedProxy = true;
+          const riskAction = (row.risk || {}).action;
+          const a = riskAction ? {
+            txt: riskAction.label,
+            col: riskAction.kind === 'stop' ? 'var(--negative)' : 'var(--warning)',
+            kind: riskAction.kind,
+          } : null;
+          const live = holds.find(h => h.ticker === row.ticker) || {};
+          return {
+            h: {
+              ticker: row.ticker,
+              // Projection owns analysis; current marks remain live intraday.
+              today_change_pct: live.today_change_pct ?? (row.facts || {}).today_change_pct,
+              pnl_percent: live.pnl_percent ?? (row.facts || {}).pnl_pct,
+            },
+            q,
+            a,
+            proxy,
+            v: row.status || verdict(q, a),
+          };
+        })
+      : holds.map(h => {
+          const usable = r => r && (!r.status || r.status === 'fresh');
+          const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
+          const proxy = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : '';
+          if (proxy) usedProxy = true;
+          const q = direct || (proxy ? qrows[proxy] : {}) || {};
+          const a = action[h.ticker];
+          return { h, q, a, proxy, v: verdict(q, a) };
+        });
     // 排序：需要动作的优先(rank 升序)，同级浮亏深的在前 → 最该看的在最上面
     enriched.sort((x, y) => (x.v.rank - y.v.rank) || ((x.h.pnl_percent ?? 0) - (y.h.pnl_percent ?? 0)));
     document.getElementById('decision-matrix-tbody').innerHTML = enriched.map(({ h, q, a, proxy, v }) => {
@@ -1302,6 +1331,7 @@
     document.getElementById('decision-matrix-note').textContent =
       '综合：止损/减仓=硬闸规则(必动)，观望/趋势ON=技术状态(非买卖建议)。按需动作优先排序。'
       + '52w位置：绿=近一年低位(便宜)、红=高位(追高警惕)。'
+      + (projected.length ? '数据由 harness projection 编译，页面不重算规则。' : '兼容模式：等待 projection。')
       + (usedProxy ? '▵=杠杆ETF量化列取底层标的。' : '');
   }
 

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -253,6 +253,7 @@
         macro: "market", sentiment: "market", influencer_feed: "market",
         us_news_digest: "market", em_news: "market",
         decision_audit: "reflect", shadow_portfolio: "drill",
+        brief_projection: "drill",
       };
       const _cache = triggeredByUser ? "no-store" : "no-cache";
       const _bust = triggeredByUser ? "?t=" + Date.now() : "";

--- a/scripts/data/brief_context.py
+++ b/scripts/data/brief_context.py
@@ -180,7 +180,34 @@ def _artifact(path: Path, fields: tuple[str, ...], context: dict, generation_id:
     }
 
 
-def write_run_bundle(context: dict, audit_path: Path) -> tuple[dict, dict]:
+def _tool_artifact(path: Path, payload: dict, generation_id: str):
+    meta = payload.get("_meta") if isinstance(payload, dict) else None
+    if not isinstance(meta, dict) or meta.get("generation_id") != generation_id:
+        raise ValueError(f"brief tool artifact generation mismatch: {path.name}")
+    text = _compact(payload) + "\n"
+    size = len(text.encode("utf-8"))
+    if size > SINGLE_BUNDLE_BUDGET_BYTES:
+        raise ValueError(
+            "daily brief tool artifact exceeds per-query source budget "
+            f"({SINGLE_BUNDLE_BUDGET_BYTES} bytes): {path.name}={size}"
+        )
+    _write_immutable(path, text)
+    return {
+        "path": str(path),
+        "generation_id": generation_id,
+        "schema_version": meta.get("schema_version"),
+        "kind": meta.get("kind"),
+        "bytes": size,
+        "sha256": _sha256_text(text),
+    }
+
+
+def write_run_bundle(
+    context: dict,
+    audit_path: Path,
+    *,
+    tool_artifacts: dict[str, dict] | None = None,
+) -> tuple[dict, dict]:
     """Write full audit JSON plus budgeted model-facing artifacts.
 
     Returns ``(generation-stamped context, manifest)``. Raises ValueError when
@@ -227,6 +254,13 @@ def write_run_bundle(context: dict, audit_path: Path) -> tuple[dict, dict]:
             f"({SINGLE_BUNDLE_BUDGET_BYTES} bytes): {oversized}"
         )
 
+    tools = {
+        name: _tool_artifact(
+            artifact_dir / f"{name}.json", payload, generation_id
+        )
+        for name, payload in (tool_artifacts or {}).items()
+    }
+
     section_bytes = {
         key: _bytes(value)
         for key, value in stamped.items()
@@ -244,6 +278,7 @@ def write_run_bundle(context: dict, audit_path: Path) -> tuple[dict, dict]:
         },
         "core": core,
         "bundles": bundles,
+        "tools": tools,
         "source_section_bytes": section_bytes,
         "budget": {
             "max_always_loaded_bytes": ALWAYS_LOADED_BUDGET_BYTES,
@@ -358,6 +393,21 @@ def validate_run_bundle(audit_path: Path, manifest_path: Path) -> list[str]:
         issues.append(
             f"context generation lazy bundle 已超单次加载预算: {oversized}"
         )
+    for name, entry in (manifest.get("tools") or {}).items():
+        path = Path(entry.get("path") or "")
+        try:
+            text = path.read_text(encoding="utf-8")
+            payload = json.loads(text)
+        except Exception as exc:
+            issues.append(f"context tool artifact 不可读: {name}: {exc}")
+            continue
+        if entry.get("sha256") != _sha256_text(text):
+            issues.append(f"context tool artifact hash 不匹配: {name}")
+        if (
+            entry.get("generation_id") != generation_id
+            or payload.get("_meta", {}).get("generation_id") != generation_id
+        ):
+            issues.append(f"context tool artifact 跨代: {name}")
     return issues
 
 

--- a/scripts/data/brief_decision_packet.py
+++ b/scripts/data/brief_decision_packet.py
@@ -1,0 +1,737 @@
+#!/usr/bin/env python3
+"""Typed, queryable decision boundary for the daily deep brief.
+
+The expensive producers remain authoritative for prices, technical indicators,
+quant factors, evidence and risk.  This module only projects those results into
+a compact contract:
+
+* code owns facts, classifications and action bounds;
+* the model owns a small judgment overlay made only of opinions;
+* Pages receives a stable view-model and never re-implements the joins.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+JUDGMENT_SCHEMA_VERSION = 1
+PAGES_SCHEMA_VERSION = 1
+MAX_PACKET_BYTES = 96 * 1024
+MAX_QUERY_BYTES = 24 * 1024
+VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
+TEXT_LIMITS = {
+    "portfolio_assessment": 800,
+    "portfolio_counterargument": 800,
+    "assessment": 500,
+    "counterargument": 500,
+    "rationale": 500,
+}
+
+
+def _compact(value) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _atomic_write(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _number(value, digits=4):
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return round(value, digits)
+
+
+def _active_holdings(context: dict):
+    portfolios = (context.get("portfolio") or {}).get("portfolios") or {}
+    for region, leg in (("us_stocks", "US"), ("hk_stocks", "HK")):
+        for holding in (portfolios.get(region) or {}).get("holdings") or []:
+            if _number(holding.get("shares")) and _number(holding.get("shares")) > 0:
+                yield leg, holding
+
+
+def _proxy_map(context: dict) -> dict[str, str]:
+    names = (
+        ((context.get("risk_guardrail") or {}).get("lev_regime") or {})
+        .get("us", {})
+        .get("names", [])
+    )
+    out = {
+        str(row.get("etf")): str(row.get("underlying"))
+        for row in names
+        if row.get("etf") and row.get("underlying")
+    }
+    for ticker, row in ((context.get("quant_signals") or {}).get("rows") or {}).items():
+        note = str(row.get("note") or "")
+        marker = " 的标的"
+        if marker in note:
+            out[note.split(marker, 1)[0].strip()] = str(ticker)
+    return out
+
+
+def _rsi_state(value):
+    value = _number(value, 1)
+    if value is None:
+        return "unknown"
+    if value <= 30:
+        return "oversold"
+    if value < 45:
+        return "weak"
+    if value <= 60:
+        return "neutral"
+    if value < 70:
+        return "strong"
+    return "overbought"
+
+
+def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
+    row = row if isinstance(row, dict) else {}
+    fresh = row.get("status") in (None, "fresh")
+    trend = (
+        "on" if row.get("trend_on") is True
+        else "off" if row.get("trend_on") is False or row.get("tag")
+        else "unknown"
+    )
+    stop_distance = _number(row.get("stop_distance_pct"), 1)
+    return {
+        "source_ticker": source_ticker,
+        "is_proxy": bool(proxy),
+        "status": row.get("status") or ("available" if row else "unavailable"),
+        "as_of": row.get("row_as_of"),
+        "tag": row.get("tag"),
+        "trend": trend,
+        "rsi14": _number(row.get("rsi14"), 1),
+        "rsi_state": _rsi_state(row.get("rsi14")),
+        "dist_ma200_pct": _number(row.get("dist_ma200_pct"), 1),
+        "pct_52w_range": _number(row.get("pct_52w_range"), 1),
+        "mom_1m_pct": _number(row.get("mom_1m"), 1),
+        "mom_3m_pct": _number(row.get("mom_3m"), 1),
+        "vol20_annualized": _number(row.get("vol20_annualized"), 4),
+        "atr14_pct": _number(row.get("atr14_pct"), 2),
+        "stop_distance_pct": stop_distance,
+        "stop_state": (
+            "breached" if stop_distance is not None and stop_distance < 0
+            else "intact" if stop_distance is not None
+            else "unknown"
+        ),
+        "usable": bool(row) and fresh,
+    }
+
+
+def _factor_view(row: dict) -> dict:
+    row = row if isinstance(row, dict) else {}
+    return {
+        "as_of": row.get("feature_as_of"),
+        "sector": row.get("sector"),
+        "composite_score": _number(row.get("composite_score"), 4),
+        "coverage_pct": _number(row.get("factor_coverage_pct"), 1),
+        "relative_strength": _number(row.get("relative_strength"), 4),
+        "breadth": _number(row.get("breadth"), 4),
+        "usable_for_decisions": bool(row.get("usable_for_decisions")),
+    }
+
+
+def _peer_view(row: dict) -> dict:
+    row = row if isinstance(row, dict) else {}
+    return {
+        "as_of": row.get("feature_as_of"),
+        "sector_regime": row.get("sector_regime"),
+        "residual_1d": _number(row.get("residual_blend_1d"), 4),
+        "residual_5d": _number(row.get("residual_blend_5d"), 4),
+        "residual_20d": _number(row.get("residual_blend_20d"), 4),
+        "leadership_persistence": row.get("leadership_persistence"),
+        "laggard_persistence": row.get("laggard_persistence"),
+        "usable_for_decisions": bool(row.get("usable_for_decisions")),
+    }
+
+
+def _sentiment_view(rows: list[dict], ticker: str, source_ticker: str) -> dict:
+    row = next(
+        (
+            item for item in rows
+            if str(item.get("ticker")) in {ticker, source_ticker}
+        ),
+        {},
+    )
+    headlines = [
+        str(item)[:240] for item in (row.get("news_top") or [])[:5] if item
+    ]
+    return {
+        "as_of": row.get("as_of"),
+        "source_ticker": row.get("ticker") or source_ticker,
+        "reddit_mentions_7d": int(row.get("reddit_mentions_7d") or 0),
+        "recent_move": row.get("recent_move") if isinstance(row.get("recent_move"), dict) else {},
+        "headline_count": len(headlines),
+        "headlines": headlines,
+        "coverage": "available" if row else "missing",
+    }
+
+
+def _event_view(event: dict) -> dict:
+    return {
+        key: event.get(key)
+        for key in (
+            "event_id",
+            "ticker",
+            "reported_ticker",
+            "event_type",
+            "canonical_headline",
+            "headline",
+            "summary",
+            "source_tier",
+            "confidence_tier",
+            "actionable_escalation",
+            "actionable_reasons",
+        )
+        if event.get(key) not in (None, "", [])
+    }
+
+
+def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
+    guardrail = context.get("risk_guardrail") or {}
+    out = {ticker: [] for ticker in active}
+    for row in guardrail.get("breaches") or []:
+        reduction = row.get("required_reduction") or {}
+        targets = set(str(x) for x in reduction.get("target_tickers") or [])
+        if row.get("ticker"):
+            targets.add(str(row["ticker"]))
+        for ticker in sorted(targets & active):
+            out[ticker].append({
+                "kind": "breach",
+                "scope": "ticker" if row.get("ticker") else "candidate",
+                "breach_id": row.get("breach_id"),
+                "type": row.get("type"),
+                "severity": row.get("severity") or "high",
+                "detail": row.get("detail"),
+                "action_text": row.get("action"),
+                "required_reduction": {
+                    key: reduction.get(key)
+                    for key in (
+                        "kind", "minimum_value", "minimum_shares", "currency",
+                        "target_pct", "swap_to",
+                    )
+                    if reduction.get(key) is not None
+                },
+            })
+    for row in guardrail.get("hard_stop_watch") or []:
+        ticker = str(row.get("ticker") or "")
+        if ticker not in active:
+            continue
+        reduction = row.get("required_reduction") or {}
+        out[ticker].append({
+            "kind": "hard_stop",
+            "scope": "ticker",
+            "breach_id": row.get("breach_id"),
+            "type": "leveraged_hard_stop",
+            "severity": "critical",
+            "detail": row.get("detail"),
+            "action_text": row.get("action"),
+            "required_reduction": {
+                key: reduction.get(key)
+                for key in (
+                    "kind", "minimum_value", "minimum_shares", "currency",
+                    "target_pct", "swap_to",
+                )
+                if reduction.get(key) is not None
+            },
+        })
+    return out
+
+
+def _status(technical: dict, risks: list[dict]) -> dict:
+    if any(item.get("kind") == "hard_stop" for item in risks):
+        return {"rank": 0, "label": "止损/换1x", "state": "critical"}
+    if any(item.get("scope") == "ticker" for item in risks):
+        return {"rank": 1, "label": "减仓", "state": "elevated"}
+    if technical.get("trend") == "on":
+        return {"rank": 4, "label": "趋势ON", "state": "positive"}
+    if technical.get("rsi_state") == "oversold":
+        return {"rank": 2, "label": "超卖·观望", "state": "elevated"}
+    if technical.get("usable"):
+        return {"rank": 3, "label": "趋势off·观望", "state": "neutral"}
+    return {"rank": 5, "label": "数据不足", "state": "neutral"}
+
+
+def _constraints(shares: int, risks: list[dict], actionable_ids: list[str]) -> dict:
+    hard_stop = any(row.get("kind") == "hard_stop" for row in risks)
+    direct_risk = any(row.get("scope") == "ticker" for row in risks)
+    if hard_stop:
+        allowed = ["cut"]
+        forced = ["cut"]
+    elif direct_risk:
+        allowed = ["trim_on_rebound", "cut"]
+        forced = ["trim_on_rebound", "cut"]
+    else:
+        allowed = ["hold_and_watch", "watch"]
+        forced = []
+        if risks:
+            allowed += ["trim_on_rebound", "cut"]
+    if actionable_ids and not risks:
+        allowed += [
+            "trim_on_rebound", "cut", "t_only",
+            "add_only_on_trigger", "add_on_breakout",
+        ]
+    return {
+        "allowed_actions": allowed,
+        "forced_action_one_of": forced,
+        "max_sell_shares": shares,
+        "active_action_requires_evidence": True,
+        "actionable_evidence_ids": actionable_ids,
+    }
+
+
+def compile_packet(context: dict, generation_id: str | None = None) -> dict:
+    generation_id = generation_id or context.get("generation_id")
+    if not generation_id:
+        raise ValueError("decision packet requires context generation_id")
+    quant_rows = (context.get("quant_signals") or {}).get("rows") or {}
+    cross_rows = (context.get("cross_sectional_factor") or {}).get("held_rankings") or {}
+    peer_rows = (context.get("peer_residual") or {}).get("held") or {}
+    sentiment_rows = (context.get("sentiment") or {}).get("tickers") or []
+    events = (context.get("news_evidence_graph") or {}).get("events") or []
+    proxies = _proxy_map(context)
+    holdings = list(_active_holdings(context))
+    active = {str(holding.get("ticker")) for _, holding in holdings}
+    risks = _risk_map(context, active)
+    tickers = {}
+
+    for leg, holding in holdings:
+        ticker = str(holding.get("ticker"))
+        source_ticker = ticker if ticker in quant_rows else proxies.get(ticker, ticker)
+        technical = _technical(
+            quant_rows.get(source_ticker) or {},
+            source_ticker,
+            source_ticker != ticker,
+        )
+        matching_events = [
+            _event_view(event) for event in events
+            if str(event.get("ticker") or event.get("reported_ticker") or "")
+            in {ticker, source_ticker}
+        ]
+        actionable_ids = [
+            event.get("event_id") for event in matching_events
+            if event.get("actionable_escalation") and event.get("event_id")
+        ]
+        shares = int(_number(holding.get("shares"), 0) or 0)
+        ticker_risks = risks.get(ticker) or []
+        tickers[ticker] = {
+            "ticker": ticker,
+            "name": holding.get("name") or holding.get("stock_name") or "",
+            "leg": leg,
+            "facts": {
+                "shares": shares,
+                "cost_basis": _number(holding.get("cost_basis"), 4),
+                "current_price": _number(holding.get("current_price"), 4),
+                "pnl_pct": _number(holding.get("pnl_percent"), 2),
+                "today_change_pct": _number(holding.get("today_change_pct"), 2),
+                "day_high": _number(holding.get("day_high"), 4),
+                "day_low": _number(holding.get("day_low"), 4),
+                "data_source": holding.get("data_source"),
+            },
+            "technical": technical,
+            "quant": {
+                "factor": _factor_view(cross_rows.get(source_ticker) or cross_rows.get(ticker)),
+                "peer_residual": _peer_view(peer_rows.get(source_ticker) or peer_rows.get(ticker)),
+                "activation": {
+                    "factor": bool(
+                        ((context.get("cross_sectional_factor") or {}).get("activation") or {})
+                        .get("usable_for_decisions")
+                    ),
+                    "peer": bool(
+                        ((context.get("peer_residual") or {}).get("rule_activation") or {})
+                        .get("active")
+                    ),
+                },
+            },
+            "sentiment": _sentiment_view(sentiment_rows, ticker, source_ticker),
+            "evidence": matching_events,
+            "risk": ticker_risks,
+            "status": _status(technical, ticker_risks),
+            "constraints": _constraints(shares, ticker_risks, actionable_ids),
+        }
+
+    packet = {
+        "_meta": {
+            "schema_version": SCHEMA_VERSION,
+            "kind": "brief_decision_packet",
+            "generation_id": generation_id,
+        },
+        "date": context.get("date"),
+        "generated_at": context.get("generated_at"),
+        "integrity": {
+            key: (context.get("integrity") or {}).get(key)
+            for key in ("ok", "error_count", "warn_count")
+            if key in (context.get("integrity") or {})
+        },
+        "portfolio": {
+            "book_totals": context.get("book_totals") or {},
+            "concentration": context.get("concentration") or {},
+            "risk_directive": (context.get("risk_guardrail") or {}).get("directive"),
+            "regime": {
+                "hk": (
+                    ((context.get("risk_guardrail") or {}).get("lev_regime") or {})
+                    .get("hk", {})
+                    .get("tier")
+                ),
+                "us": (
+                    ((context.get("risk_guardrail") or {}).get("lev_regime") or {})
+                    .get("us", {})
+                    .get("tier")
+                ),
+            },
+        },
+        "tickers": tickers,
+        "judgment_contract": {
+            "schema_version": JUDGMENT_SCHEMA_VERSION,
+            "verdicts": sorted(VERDICTS),
+            "model_owned_fields": [
+                "verdict", "confidence", "assessment", "counterargument", "rationale",
+            ],
+            "harness_owned_fields": [
+                "facts", "technical", "quant", "sentiment collection",
+                "evidence IDs", "risk", "status", "constraints",
+            ],
+        },
+    }
+    size = len(_compact(packet).encode("utf-8"))
+    if size > MAX_PACKET_BYTES:
+        raise ValueError(f"decision packet exceeds {MAX_PACKET_BYTES} bytes: {size}")
+    return packet
+
+
+def summary_view(packet: dict) -> dict:
+    return {
+        "_meta": packet.get("_meta"),
+        "date": packet.get("date"),
+        "integrity": packet.get("integrity"),
+        "portfolio": packet.get("portfolio"),
+        "tickers": [
+            {
+                "ticker": row.get("ticker"),
+                "name": row.get("name"),
+                "leg": row.get("leg"),
+                "status": row.get("status"),
+                "technical": {
+                    key: (row.get("technical") or {}).get(key)
+                    for key in ("source_ticker", "is_proxy", "as_of", "tag", "trend",
+                                "rsi_state", "stop_state", "usable")
+                },
+                "quant_usable": {
+                    "factor": ((row.get("quant") or {}).get("factor") or {})
+                    .get("usable_for_decisions"),
+                    "peer": ((row.get("quant") or {}).get("peer_residual") or {})
+                    .get("usable_for_decisions"),
+                },
+                "risk_count": len(row.get("risk") or []),
+                "constraints": row.get("constraints"),
+            }
+            for row in packet.get("tickers", {}).values()
+        ],
+        "judgment_contract": packet.get("judgment_contract"),
+    }
+
+
+def judgment_template(packet: dict) -> dict:
+    generation_id = (packet.get("_meta") or {}).get("generation_id")
+    return {
+        "schema_version": JUDGMENT_SCHEMA_VERSION,
+        "context_generation_id": generation_id,
+        "portfolio_assessment": "",
+        "portfolio_counterargument": "",
+        "ticker_judgments": [
+            {
+                "ticker": ticker,
+                "verdict": "neutral",
+                "confidence": 0.5,
+                "assessment": "",
+                "counterargument": "",
+                "rationale": "",
+            }
+            for ticker in packet.get("tickers", {})
+        ],
+    }
+
+
+def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
+    issues = []
+    top_allowed = {
+        "schema_version", "context_generation_id", "portfolio_assessment",
+        "portfolio_counterargument", "ticker_judgments",
+    }
+    row_allowed = {
+        "ticker", "verdict", "confidence", "assessment",
+        "counterargument", "rationale",
+    }
+    if not isinstance(overlay, dict):
+        return ["judgment overlay must be an object"]
+    extra = sorted(set(overlay) - top_allowed)
+    if extra:
+        issues.append(f"judgment overlay unknown fields: {extra}")
+    if overlay.get("schema_version") != JUDGMENT_SCHEMA_VERSION:
+        issues.append(f"judgment schema_version must be {JUDGMENT_SCHEMA_VERSION}")
+    expected_generation = (packet.get("_meta") or {}).get("generation_id")
+    if overlay.get("context_generation_id") != expected_generation:
+        issues.append("judgment context_generation_id missing or stale")
+    for field in ("portfolio_assessment", "portfolio_counterargument"):
+        value = overlay.get(field)
+        if not isinstance(value, str) or not value.strip():
+            issues.append(f"judgment {field} must be non-empty text")
+        elif len(value) > TEXT_LIMITS[field]:
+            issues.append(f"judgment {field} exceeds {TEXT_LIMITS[field]} chars")
+
+    rows = overlay.get("ticker_judgments")
+    if not isinstance(rows, list):
+        issues.append("judgment ticker_judgments must be a list")
+        return issues
+    known = set(packet.get("tickers") or {})
+    seen = set()
+    for index, row in enumerate(rows):
+        label = f"judgment ticker_judgments[{index}]"
+        if not isinstance(row, dict):
+            issues.append(f"{label} must be an object")
+            continue
+        unknown = sorted(set(row) - row_allowed)
+        if unknown:
+            issues.append(f"{label} unknown fields: {unknown}")
+        ticker = str(row.get("ticker") or "")
+        if ticker not in known:
+            issues.append(f"{label} unknown ticker {ticker!r}")
+        if ticker in seen:
+            issues.append(f"{label} duplicate ticker {ticker!r}")
+        seen.add(ticker)
+        if row.get("verdict") not in VERDICTS:
+            issues.append(f"{label} invalid verdict {row.get('verdict')!r}")
+        confidence = _number(row.get("confidence"))
+        if confidence is None or not 0 <= confidence <= 1:
+            issues.append(f"{label} confidence must be in [0,1]")
+        for field in ("assessment", "counterargument", "rationale"):
+            value = row.get(field)
+            if not isinstance(value, str) or not value.strip():
+                issues.append(f"{label} {field} must be non-empty text")
+            elif len(value) > TEXT_LIMITS[field]:
+                issues.append(f"{label} {field} exceeds {TEXT_LIMITS[field]} chars")
+    missing = sorted(known - seen)
+    if missing:
+        issues.append(f"judgment missing active tickers: {missing}")
+    return issues
+
+
+def validate_plan_constraints(plan: dict, packet: dict) -> list[str]:
+    issues = []
+    rows = packet.get("tickers") or {}
+    for index, decision in enumerate(plan.get("decisions") or []):
+        ticker = str(decision.get("ticker") or "")
+        tag = f"decision[{index}] {ticker}"
+        row = rows.get(ticker)
+        if not row:
+            issues.append(f"{tag}: ticker is outside current decision packet")
+            continue
+        constraints = row.get("constraints") or {}
+        action = decision.get("action")
+        if action not in (constraints.get("allowed_actions") or []):
+            issues.append(
+                f"{tag}: action {action!r} outside harness allowed_actions "
+                f"{constraints.get('allowed_actions') or []}"
+            )
+        evidence_id = decision.get("evidence_event_id")
+        if decision.get("driven_by") == "catalyst" and evidence_id not in (
+            constraints.get("actionable_evidence_ids") or []
+        ):
+            issues.append(f"{tag}: evidence_event_id is outside harness evidence gate")
+        shares = _number((decision.get("size") or {}).get("shares"), 0)
+        max_sell = _number(constraints.get("max_sell_shares"), 0)
+        if (
+            shares is not None and max_sell is not None
+            and action in {"cut", "trim_on_rebound", "t_only"}
+            and shares > max_sell
+        ):
+            issues.append(f"{tag}: size.shares {shares:g} exceeds holding {max_sell:g}")
+    return issues
+
+
+def compile_pages_projection(
+    packet: dict,
+    overlay: dict | None = None,
+    overlay_issues: list[str] | None = None,
+) -> dict:
+    overlay_issues = list(overlay_issues or [])
+    valid_overlay = overlay if overlay and not overlay_issues else {}
+    judgments = {
+        str(row.get("ticker")): row
+        for row in valid_overlay.get("ticker_judgments") or []
+    }
+    rows = []
+    for ticker, row in packet.get("tickers", {}).items():
+        risks = row.get("risk") or []
+        hard = any(item.get("kind") == "hard_stop" for item in risks)
+        direct = any(item.get("scope") == "ticker" for item in risks)
+        rows.append({
+            "ticker": ticker,
+            "name": row.get("name"),
+            "leg": row.get("leg"),
+            "facts": {
+                key: (row.get("facts") or {}).get(key)
+                for key in ("today_change_pct", "pnl_pct")
+            },
+            "technical": {
+                key: (row.get("technical") or {}).get(key)
+                for key in (
+                    "source_ticker", "is_proxy", "as_of", "tag", "trend",
+                    "rsi14", "rsi_state", "dist_ma200_pct", "pct_52w_range",
+                    "stop_state", "usable",
+                )
+            },
+            "quant": {
+                "factor_usable": ((row.get("quant") or {}).get("factor") or {})
+                .get("usable_for_decisions"),
+                "peer_usable": ((row.get("quant") or {}).get("peer_residual") or {})
+                .get("usable_for_decisions"),
+            },
+            "sentiment": {
+                key: (row.get("sentiment") or {}).get(key)
+                for key in (
+                    "source_ticker", "reddit_mentions_7d", "headline_count", "coverage",
+                )
+            },
+            "risk": {
+                "count": len(risks),
+                "severity": (
+                    "critical" if hard else "high" if risks else "none"
+                ),
+                "action": (
+                    {"kind": "stop", "label": "止损"}
+                    if hard else {"kind": "trim", "label": "减仓"}
+                    if direct else None
+                ),
+                "breach_ids": [
+                    item.get("breach_id") for item in risks if item.get("breach_id")
+                ],
+            },
+            "status": row.get("status"),
+            "judgment": judgments.get(ticker),
+        })
+    rows.sort(
+        key=lambda row: (
+            (row.get("status") or {}).get("rank", 99),
+            (row.get("facts") or {}).get("pnl_pct") or 0,
+            row.get("ticker") or "",
+        )
+    )
+    return {
+        "schema_version": PAGES_SCHEMA_VERSION,
+        "generated_at": packet.get("generated_at"),
+        "as_of": packet.get("date"),
+        "context_generation_id": (packet.get("_meta") or {}).get("generation_id"),
+        "judgment_status": (
+            "valid" if valid_overlay
+            else "invalid" if overlay is not None
+            else "missing"
+        ),
+        "judgment_issues": overlay_issues[:10],
+        "portfolio_judgment": {
+            "assessment": valid_overlay.get("portfolio_assessment"),
+            "counterargument": valid_overlay.get("portfolio_counterargument"),
+        } if valid_overlay else None,
+        "tickers": rows,
+    }
+
+
+def write_pages_projection(
+    packet: dict,
+    overlay_path: Path,
+    output_path: Path,
+) -> tuple[dict, list[str]]:
+    """Publish deterministic Pages data even when the model overlay is unusable."""
+    overlay = None
+    issues = []
+    if overlay_path.exists():
+        try:
+            overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
+            issues = validate_judgment_overlay(packet, overlay)
+        except Exception as exc:
+            issues = [f"judgment overlay parse failed: {exc}"]
+            overlay = {}
+    projection = compile_pages_projection(packet, overlay, issues)
+    _atomic_write(output_path, projection)
+    return projection, issues
+
+
+def read_packet(manifest_path: Path) -> dict:
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    manifest = json.loads(manifest_text)
+    entry = (manifest.get("tools") or {}).get("decision_packet") or {}
+    if not entry:
+        raise ValueError("manifest has no decision_packet tool artifact")
+    path = Path(entry.get("path") or "")
+    text = path.read_text(encoding="utf-8")
+    packet = json.loads(text)
+    generation_id = manifest.get("generation_id")
+    if (
+        entry.get("sha256") != _sha256(text)
+        or entry.get("generation_id") != generation_id
+        or (packet.get("_meta") or {}).get("generation_id") != generation_id
+    ):
+        raise ValueError("decision packet failed generation/hash check")
+    return packet
+
+
+def _print_bounded(value) -> None:
+    text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+    size = len(text.encode("utf-8"))
+    if size > MAX_QUERY_BYTES:
+        raise ValueError(f"decision packet query exceeds {MAX_QUERY_BYTES} bytes: {size}")
+    print(text, end="")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--summary", action="store_true")
+    group.add_argument("--ticker")
+    group.add_argument("--judgment-template", action="store_true")
+    parser.add_argument(
+        "--section",
+        choices=("facts", "technical", "quant", "sentiment", "evidence", "risk",
+                 "constraints"),
+    )
+    args = parser.parse_args()
+    packet = read_packet(args.manifest)
+    if args.summary:
+        value = summary_view(packet)
+    elif args.judgment_template:
+        value = judgment_template(packet)
+    else:
+        value = (packet.get("tickers") or {}).get(str(args.ticker))
+        if value is None:
+            raise ValueError(f"unknown ticker: {args.ticker}")
+        if args.section:
+            value = {
+                "_meta": packet.get("_meta"),
+                "ticker": str(args.ticker),
+                args.section: value.get(args.section),
+            }
+    _print_bounded(value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -40,6 +40,7 @@ import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 import brief_context  # noqa: E402
+import brief_decision_packet  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases
@@ -123,7 +124,7 @@ def validate_generation_references(plan, context=None):
     return issues
 
 
-def validate_plan_json(path, context=None):
+def validate_plan_json(path, context=None, decision_packet=None):
     if not path.exists():
         return ['plan.json 缺失（critical）']
     try:
@@ -133,6 +134,13 @@ def validate_plan_json(path, context=None):
 
     issues = [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
     issues += validate_generation_references(plan, context)
+    if decision_packet:
+        issues += [
+            f'plan.json harness: {item}'
+            for item in brief_decision_packet.validate_plan_constraints(
+                plan, decision_packet
+            )
+        ]
     decisions = plan.get('decisions', []) if isinstance(plan.get('decisions'), list) else []
     # Unpriceable calls score for direction but never reach the money chart.
     issues += [f'plan.json size: {x}' for x in decision_v2.missing_size_warnings(decisions)]
@@ -293,6 +301,7 @@ def validate_markdown(path, context=None):
 
 CRITICAL_KEYWORDS = [
     '缺失', '解析失败', '表格 #', 'generation_id',
+    'plan.json harness', 'decision packet 不可用',
 ]  # table mismatch and cross-generation output are critical
 
 
@@ -429,6 +438,7 @@ def maybe_commit(status, today, dry_run=False):
                             'assets/data/t0_setups.json',
                             'assets/data/t0_setups_history.jsonl',
                             'assets/data/t0_setup_review.json',
+                            'assets/data/brief_projection.json',
                             'logs/dashboard_build_status.json')
     if not add_ok:
         return False, f'git add failed: {add_out[-200:]}'
@@ -513,10 +523,17 @@ def main():
 
     issues = []
     manifest_path = ctx_path.with_suffix('') / 'manifest.json'
+    decision_packet = None
     if context and context.get('generation_id'):
         issues += brief_context.validate_run_bundle(ctx_path, manifest_path)
+        try:
+            decision_packet = brief_decision_packet.read_packet(manifest_path)
+        except Exception as exc:
+            issues.append(f'decision packet 不可用: {exc}')
     issues += validate_markdown(md_path, context=context)
-    issues += validate_plan_json(plan_path, context=context)
+    issues += validate_plan_json(
+        plan_path, context=context, decision_packet=decision_packet
+    )
 
     status = categorize(issues)
     workflow_outcomes.record_stage(
@@ -539,6 +556,27 @@ def main():
     # off-host workflow's committer has an explicit verdict (and a crash leaves no
     # file → fail-closed).
     write_publish_gate(status, today)
+
+    # Pages consumes a versioned projection, not the model's raw files.  Missing
+    # or invalid prose is isolated: deterministic technical/risk rows still
+    # publish with judgment_status=missing/invalid, and a projection exception
+    # never blocks the report/plan commit.
+    projection_path = WS / 'assets' / 'data' / 'brief_projection.json'
+    judgment_path = WS / 'memory' / '.tmp' / f'brief-judgment-{today}.json'
+    projection_status = 'skipped'
+    projection_issues = []
+    if status in ('pass', 'warn') and decision_packet and not args.dry_run:
+        try:
+            projection, projection_issues = (
+                brief_decision_packet.write_pages_projection(
+                    decision_packet, judgment_path, projection_path
+                )
+            )
+            projection_status = projection.get('judgment_status') or 'written'
+        except Exception as exc:
+            projection_status = 'failed'
+            projection_issues = [str(exc)]
+            print(f'warn: brief Pages projection failed: {exc}', file=sys.stderr)
 
     if status == 'pass':
         wechat_prefix = ''
@@ -626,9 +664,13 @@ def main():
         'wechat_sent':   wechat_sent,
         'commit_ok':     commit_ok,
         'commit_msg':    commit_msg,
+        'projection_status': projection_status,
+        'projection_issues': projection_issues,
         'files_checked': {
             'pre_open_md':  str(md_path),
             'plan_json':    str(plan_path),
+            'judgment_json': str(judgment_path),
+            'pages_projection': str(projection_path),
         },
     }
     workflow_outcomes.record_stage(

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -56,6 +56,7 @@ import peer_scan  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 import brief_context  # noqa: E402
+import brief_decision_packet  # noqa: E402
 from instrument_registry import get as get_instrument  # noqa: E402
 from instrument_registry import compute_lookthrough_exposure  # noqa: E402
 from instrument_registry import one_x_swap_map  # noqa: E402
@@ -1815,7 +1816,15 @@ def main():
     }
     ctx_path = TMP_DIR / f'brief-context-{today}.json'
     try:
-        context, bundle_manifest = brief_context.write_run_bundle(context, ctx_path)
+        generation_id = brief_context.compute_generation_id(context)
+        decision_packet = brief_decision_packet.compile_packet(
+            context, generation_id=generation_id
+        )
+        context, bundle_manifest = brief_context.write_run_bundle(
+            context,
+            ctx_path,
+            tool_artifacts={"decision_packet": decision_packet},
+        )
     except Exception as exc:
         print(f'FATAL: brief context boundary failed: {exc}', file=sys.stderr)
         workflow_outcomes.record_stage(

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-deep-brief
-description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分析。harness 化：`scripts/harness/brief_preflight.py` 跑所有确定性步骤（刷价 / FX / snapshot / HHI / SEC EDGAR / retrospective），LLM 只做 swarm 创造性（Tier 1/2/3/Judge），`scripts/harness/brief_postflight.py` 验证 + commit + 自动投递微信。**输出**：完整 markdown 落盘 `memory/{date}-pre-open.md` + 结构化 `memory/{date}-plan.json` + 紧凑微信卡 `memory/.tmp/brief-card-{date}.txt`（postflight 用 fresh token 自动投递，cron 设 delivery=none，LLM 不手动发）。**只在每日 8 点 cron 触发时使用；手动深度分析仍走 portfolio-swarm-review。**
+description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分析。harness 化：`scripts/harness/brief_preflight.py` 计算并编译 typed decision packet，LLM 只做 Tier 1/2/3/Judge 与受限 judgment overlay，`scripts/harness/brief_postflight.py` 验证、生成 Pages projection、commit 并自动投递微信。**输出**：完整 markdown、结构化 plan、受限 judgment JSON 与紧凑微信卡。**只在每日 8 点 cron 触发时使用；手动深度分析仍走 portfolio-swarm-review。**
 ---
 
 # Daily Deep Brief (08:00 HKT, weekday)
@@ -13,11 +13,10 @@ description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分
 ```
 ┌────────────────────┐     ┌───────────────┐     ┌────────────────────┐
 │ scripts/harness/brief_preflight.py │ ──► │ LLM (你 / Rick)│ ──► │ brief_postflight.py│
-│  (确定性 + 幂等)   │     │  (Tier 1/2/3) │     │ 验证+commit+投递微信│
+│  (确定性 + 幂等)   │     │ (只写判断/反方)│     │ 验证+projection+投递│
 └────────────────────┘     └───────────────┘     └────────────────────┘
-   刷价/FX/snapshot/         读 core + 按需 bundles 校验 md+plan schema，
-   HHI/EDGAR/retro           写 md+plan+            fresh-token 发 brief-card
-                             brief-card 微信卡       (唯一投递, 见 Step 6)
+   指标/因子/风险/evidence   查 packet summary/ticker 校验 md+plan+judgment，
+   编译 typed packet         写判断与解释            Pages 只读稳定 projection
 ```
 
 **为什么这样分**：之前完全交给 LLM，模型可能漏快照、漏 HHI、漏 FX、漏 retrospective。
@@ -47,41 +46,44 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_preflight.py
    - 不在文档硬编码 ticker；实际名单以当天持仓和上述动态过滤结果为准
 7. **Retrospective**：读 prior v2 plan，对每个 decision 按 strategy 检查 condition 是否触发、模拟 benefit 与 confidence calibration
 
-输出分两层：
+输出分三层：
 
 - `memory/.tmp/brief-context-{date}.json` —— 完整、不可裁剪的审计事实；供 postflight 校验，**不要整份 cat 进模型上下文**。
 - `memory/.tmp/brief-context-{date}/manifest.json` + `core.json` + feature bundles —— 同一 `generation_id` 下的模型输入边界。manifest 记录路径、hash、字段、逐 section 大小和预算。
+- manifest 的 `tools.decision_packet` —— harness 编译的 typed 决策边界；技术分类、量化可用性、风险动作、证据 ID 与 action bounds 都由代码拥有。
 
-### Step 2: 读 manifest + core（常驻输入）
+### Step 2: 只读 decision packet summary（唯一常驻输入）
 
 ```bash
-cat /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --core
+python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
+  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
+  --summary
 ```
 
-`manifest + core` 是唯一常驻输入，合计硬上限 128 KiB；每个 lazy bundle 另有 96 KiB 单次加载上限。preflight 超限就直接失败，绝不静默裁字段。完整 audit 只给 postflight 和排障使用，正常分析禁止 `cat brief-context-{date}.json`。
+summary 包含 book/concentration、每票 deterministic status、技术/因子可用性、风险计数、allowed actions 与 evidence IDs。它不要求模型加载原始持仓交易流水或整张因子表。
 
-core 关键字段：
-- `prices_refreshed_at` / `fx`（`rate`, `source`, `fetched_at`）
-- `book` — `usd_total_pnl`, `hkd_total_pnl`, `hk_leg_hkd`, `us_leg_usd`（FX 已换算）
-- `concentration` — `{hk: {hhi, top2_pct, weights, verdict}, us: {...}}`
-- `portfolio` / `lookthrough_exposure` / `risk_guardrail` / `risk_discipline` —— 行动所需持仓与完整风险规则，按 JSON 值原样保留，不参与裁剪
-- `integrity` / `issues` —— 数据完整性结果
-- `thesis_registry` — `memory/theses/*.json` 的只读摘要：当前 state、最近检查时间、下一次 review trigger；未建基线的持仓明确为 `unknown`。
-- `research_surface` — 研究生命周期的**待办队列**（只读）：`earnings.hk_results_expected`（港股已公告董事会会议→业绩临近；**只有「临近」没有日期**，日期在公告文件里，任何免费源都没有，别编一个出来）、`earnings.reviews_due`（已披露财报但没有一手 artifact 覆盖）、`earnings.overdue_commitments`（管理层承诺过期且没结果）、`entry_gates.ungated_positions`（建仓后没有 gate 或 gate 判 reject 仍在持有）、`entry_gates.open_questions`（gray 判定还缺的证据）。`errors` 非空 = 有 artifact 失效，先说这件事。
+需要分析某票时才查该票；需要单一维度时必须带 `--section`：
+
+```bash
+python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
+  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
+  --ticker 00100 --section technical
+```
+
+可选 section：`facts|technical|quant|sentiment|evidence|risk|constraints`。一次查询硬上限 24 KiB，并同时校验 manifest hash 与 generation。正常分析禁止 `cat brief-context-{date}.json`，也禁止为了省一次查询而整份读 core/research/market bundle。
 
 ### Step 2.5: 按消费者 lazy-load bundles
 
-每个命令会同时校验 manifest hash 与 `generation_id`。**每个 bundle 最多读一次，紧挨着消费它的章节读；不要预先全读，也不要回头重读。** 读出的字段与 core 合并后，下面统称 `context`。
+bundle 是审计深钻，不是默认模型输入。只有 packet 没有提供某个报告必须字段时才加载；每个 bundle 最多一次，紧挨消费者读取。
 
 ```bash
 # 风险情景 / 解套数学使用前
 python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle risk_detail
-# Tier 1 / 同行扫描 / 因子研究使用前
+# EDGAR / 同行明细确需原始研究记录时
 python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle research
-# 任何 catalyst 主动动作裁决前（news_evidence_graph 是唯一权限源）
+# 需要查看事件图完整 provenance 时（action 权限仍以 packet constraints 为准）
 python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle evidence
-# 大盘、舆情、东财、名人段使用前
+# 需要市场级而非 per-ticker 的宏观/名人记录时
 python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle market
 # Retrospective / Decision v2 校准段使用前
 python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle calibration
@@ -99,7 +101,7 @@ manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 c
 
 ### Step 3: Swarm 分析（你的创造性工作）
 
-按下面这个 3-tier 流程做分析。所有数字**只能从本次 generation 的 core / 已加载 bundle 取**，不要凭空造。
+按下面这个 3-tier 流程做分析。所有数字只能从本次 generation 的 packet 查询或确有必要时加载的 bundle 取；技术指标、因子分数、风险分类和 action bounds 一律引用 harness 结果，不重新计算。
 
 #### Required reads (delta vs `AGENTS.md` baseline)
 
@@ -554,7 +556,7 @@ calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条�
 - US 开盘后 09:30 ET 关注什么
 - Book-level metric 红线（例：港股浮亏到 X% 触发 forced derisk）
 
-### Step 4: 写输出文件（A 报告 / B plan / C insights sidecar / D 微信卡）
+### Step 4: 写输出文件（A 报告 / B plan / C judgment / D insights / E 微信卡）
 
 #### A. Markdown 报告 → `memory/{YYYY-MM-DD}-pre-open.md`
 
@@ -638,6 +640,7 @@ postflight 严格 schema 校验：
 合法 enum：
 - `strategy_id` ∈ {`core_position`, `risk_rebalance`, `intraday_t`, `event_trade`, `tactical_entry`}；迁移历史才允许 `legacy_unknown`
 - `context_generation_id`：必填，逐字符照抄本次 `manifest.generation_id`；postflight 会递归检查 plan 内所有 `*generation_id`，跨代引用直接 fail。
+- 每条 `action` 必须出现在该 ticker packet 的 `constraints.allowed_actions`；卖出股数不得超过 `max_sell_shares`，catalyst 只能引用 `actionable_evidence_ids`。postflight 会二次校验，模型不能扩大边界。
 - `action` ∈ {`cut`, `trim_on_rebound`, `hold_and_watch`, `t_only`, `add_only_on_trigger`, `watch`}
 - `condition.type` ∈ {`open`, `price_above`, `price_below`, `index_breakdown`, `event`, `manual`}
 - `driven_by` ∈ {`technical`, `catalyst`, `sentiment`, `influencer`, `macro`, `peer`, `risk_rule`}（每个 decision 必填）
@@ -662,7 +665,32 @@ postflight 严格 schema 校验：
 
 禁止输出顶层 `actions`。postflight 会生成稳定的 `decision_id` / `episode_id` 并写入 `memory/decisions.jsonl`。同股同日的不同 strategy 必须保留为不同 decision；同策略连续同 action 才可归入同一 episode。
 
-#### C. LLM 复盘 sidecar → `memory/.tmp/insights-{YYYY-MM-DD}.json`
+#### C. 受限判断 overlay → `memory/.tmp/brief-judgment-{YYYY-MM-DD}.json`
+
+先生成模板，再只回填观点字段：
+
+```bash
+python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
+  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
+  --judgment-template
+```
+
+schema 只允许顶层 `schema_version/context_generation_id/portfolio_assessment/portfolio_counterargument/ticker_judgments`；每票只允许：
+
+```json
+{
+  "ticker": "00100",
+  "verdict": "bullish|neutral|bearish|mixed",
+  "confidence": 0.62,
+  "assessment": "你的评价",
+  "counterargument": "最强反方",
+  "rationale": "为何在冲突信号中这样判断"
+}
+```
+
+禁止加入价格、RSI、MA、因子分、股数、action、evidence 内容或其他字段。postflight 严格校验后才会把这些文字并入 `assets/data/brief_projection.json`；overlay 缺失/非法时 Pages 仍发布 deterministic rows，只把 `judgment_status` 标为 missing/invalid。
+
+#### D. LLM 复盘 sidecar → `memory/.tmp/insights-{YYYY-MM-DD}.json`
 
 build_dashboard 会读它，让 dashboard 上 **行为复盘 / 唱反调 Pre-mortem / 隐藏集中度** 三张卡同步刷新（缺失/解析失败容错，卡自动隐藏，不影响 brief 投递）。这是 dashboard 上唯一由你（LLM）写的"对决策本身的反思"层 —— 数字算不出来、只有你能写。
 
@@ -695,7 +723,7 @@ build_dashboard 会读它，让 dashboard 上 **行为复盘 / 唱反调 Pre-mor
 - **hidden_concentration**：看 sector_exposure + leveraged_etf + 持仓权重，识别表面分散实际同因子；`exposure_pct` 给该因子占组合的估算整数。
 - 全部中文，口吻直接、像私人交易教练，指出问题不安慰。
 
-#### D. 微信卡 → `memory/.tmp/brief-card-{YYYY-MM-DD}.txt`
+#### E. 微信卡 → `memory/.tmp/brief-card-{YYYY-MM-DD}.txt`
 
 **这是真正发到 kcn 微信的内容**（投递由 Step 5 的 postflight 自动完成，原样发这个文件），所以必须自洽完整、≤1.5KB。数字全来自 `plan.json` + 本次 generation 的 core/bundles，不现编：
 
@@ -774,7 +802,7 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
 >
 > **为什么这样改（2026-06-08）**：旧的 `delivery=announce` 在长 turn 末尾用 turn 起点抓的 token 投递，brief turn 恒 >160s（173–975s）→ token 必过期 → 静默丢、`delivered=true` 是假信号（见 memory: openclaw-wechat-longturn-token-expiry）。短命 message send 每次抓新 token，且独立于 turn 时长，kcn 实测可靠（同 intraday 架构）。
 >
-> **你的职责到 Step 5 跑完 postflight 为止**：产出 A/B/C/D 四个文件 + 跑 postflight。看到 `wechat_sent: true` 即大功告成，**立即结束本轮，不要再追加任何思考或内容**。
+> **你的职责到 Step 5 跑完 postflight 为止**：产出 A/B/C/D/E 五个文件 + 跑 postflight。看到 `wechat_sent: true` 即大功告成，**立即结束本轮，不要再追加任何思考或内容**。
 
 ## Style rules
 

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -104,6 +104,25 @@ def test_new_feature_cannot_silently_create_an_unbounded_lazy_load(tmp_path):
         brief_context.write_run_bundle(source, tmp_path / "bundle-oversize.json")
 
 
+def test_tool_artifact_cannot_create_an_unbounded_query_source(tmp_path):
+    source = _fixture()
+    generation_id = brief_context.compute_generation_id(source)
+    tool = {
+        "_meta": {
+            "schema_version": 1,
+            "kind": "test",
+            "generation_id": generation_id,
+        },
+        "payload": "T" * (brief_context.SINGLE_BUNDLE_BUDGET_BYTES + 1),
+    }
+    with pytest.raises(ValueError, match="tool artifact exceeds"):
+        brief_context.write_run_bundle(
+            source,
+            tmp_path / "tool-oversize.json",
+            tool_artifacts={"test": tool},
+        )
+
+
 def test_action_critical_growth_fails_the_final_boundary(tmp_path):
     source = _fixture()
     source["portfolio"]["raw_history"] = "P" * (140 * 1024)

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -1,0 +1,262 @@
+"""Contracts for harness-owned analysis and the Pages projection boundary."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import brief_context  # noqa: E402
+import brief_decision_packet as packet_mod  # noqa: E402
+
+
+def _context():
+    return {
+        "generated_at": "2026-07-28T08:00:00+08:00",
+        "date": "2026-07-28",
+        "portfolio": {
+            "portfolios": {
+                "us_stocks": {
+                    "holdings": [{
+                        "ticker": "LEVX", "name": "2x Example", "shares": 10,
+                        "cost_basis": 20, "current_price": 12,
+                        "pnl_percent": -40, "today_change_pct": -3,
+                        "data_source": "fixture",
+                    }]
+                },
+                "hk_stocks": {
+                    "holdings": [{
+                        "ticker": "00100", "name": "Example HK", "shares": 100,
+                        "cost_basis": 10, "current_price": 11,
+                        "pnl_percent": 10, "today_change_pct": 2,
+                        "data_source": "fixture",
+                    }]
+                },
+            }
+        },
+        "book_totals": {"usd_total_pnl": -10},
+        "concentration": {"us": {"hhi": 1}, "hk": {"hhi": 1}},
+        "risk_guardrail": {
+            "directive": "delever",
+            "lev_regime": {
+                "us": {
+                    "tier": "red",
+                    "names": [{"etf": "LEVX", "underlying": "BASE"}],
+                },
+                "hk": {"tier": "green"},
+            },
+            "breaches": [],
+            "hard_stop_watch": [{
+                "ticker": "LEVX",
+                "breach_id": "risk-hard",
+                "detail": "hard stop",
+                "action": "swap to BASE",
+                "required_reduction": {
+                    "kind": "full_leveraged_position",
+                    "minimum_shares": 10,
+                    "target_tickers": ["LEVX"],
+                    "swap_to": "BASE",
+                },
+            }],
+        },
+        "quant_signals": {
+            "rows": {
+                "BASE": {
+                    "status": "fresh", "row_as_of": "2026-07-27",
+                    "trend_on": False, "rsi14": 28,
+                    "dist_ma200_pct": -12, "pct_52w_range": 9,
+                    "stop_distance_pct": -2, "tag": "趋势OFF",
+                    "note": "LEVX 的标的",
+                },
+                "00100": {
+                    "status": "fresh", "row_as_of": "2026-07-28",
+                    "trend_on": True, "rsi14": 55,
+                    "dist_ma200_pct": 8, "pct_52w_range": 70,
+                    "stop_distance_pct": 5, "tag": "趋势ON",
+                },
+            }
+        },
+        "cross_sectional_factor": {
+            "activation": {"usable_for_decisions": False},
+            "held_rankings": {
+                "BASE": {
+                    "feature_as_of": "2026-07-27",
+                    "composite_score": 0.4,
+                    "factor_coverage_pct": 90,
+                    "usable_for_decisions": False,
+                }
+            },
+        },
+        "peer_residual": {
+            "rule_activation": {"active": False},
+            "held": {
+                "BASE": {
+                    "feature_as_of": "2026-07-27",
+                    "residual_blend_1d": 0.1,
+                    "usable_for_decisions": False,
+                }
+            },
+        },
+        "sentiment": {
+            "tickers": [{
+                "ticker": "BASE",
+                "reddit_mentions_7d": 4,
+                "news_top": ["headline one", "headline two"],
+            }]
+        },
+        "news_evidence_graph": {
+            "events": [{
+                "event_id": "evt_good",
+                "ticker": "00100",
+                "headline": "primary event",
+                "actionable_escalation": True,
+            }]
+        },
+        "integrity": {"ok": True, "error_count": 0, "warn_count": 0},
+    }
+
+
+def _compiled():
+    context = _context()
+    generation = brief_context.compute_generation_id(context)
+    return packet_mod.compile_packet(context, generation)
+
+
+def _valid_overlay(packet):
+    overlay = packet_mod.judgment_template(packet)
+    overlay["portfolio_assessment"] = "风险规则优先。"
+    overlay["portfolio_counterargument"] = "反方认为超卖可能快速反弹。"
+    for row in overlay["ticker_judgments"]:
+        row["assessment"] = "结构化信号支持当前判断。"
+        row["counterargument"] = "短线可能反向波动。"
+        row["rationale"] = "在趋势和风险约束冲突时优先风险。"
+    return overlay
+
+
+def test_compiler_owns_proxy_join_risk_status_and_action_bounds():
+    packet = _compiled()
+    lev = packet["tickers"]["LEVX"]
+    hk = packet["tickers"]["00100"]
+
+    assert lev["technical"]["source_ticker"] == "BASE"
+    assert lev["technical"]["is_proxy"] is True
+    assert lev["technical"]["rsi_state"] == "oversold"
+    assert lev["status"] == {
+        "rank": 0, "label": "止损/换1x", "state": "critical",
+    }
+    assert lev["constraints"]["allowed_actions"] == ["cut"]
+    assert lev["constraints"]["max_sell_shares"] == 10
+
+    assert hk["status"]["label"] == "趋势ON"
+    assert "cut" in hk["constraints"]["allowed_actions"]
+    assert hk["constraints"]["actionable_evidence_ids"] == ["evt_good"]
+    assert len(packet_mod._compact(packet).encode()) < packet_mod.MAX_PACKET_BYTES
+    assert len(
+        json.dumps(packet_mod.summary_view(packet), ensure_ascii=False).encode()
+    ) < packet_mod.MAX_QUERY_BYTES
+
+
+def test_packet_is_deterministic_and_manifest_hash_bound(tmp_path):
+    context = _context()
+    generation = brief_context.compute_generation_id(context)
+    packet = packet_mod.compile_packet(context, generation)
+    audit_path = tmp_path / "brief-context-2026-07-28.json"
+
+    stamped, manifest = brief_context.write_run_bundle(
+        context,
+        audit_path,
+        tool_artifacts={"decision_packet": packet},
+    )
+    manifest_path = Path(manifest["manifest_path"])
+    assert packet_mod.read_packet(manifest_path) == packet
+    assert brief_context.validate_run_bundle(audit_path, manifest_path) == []
+    assert stamped["generation_id"] == generation
+
+    tool_path = Path(manifest["tools"]["decision_packet"]["path"])
+    tool_path.write_text(tool_path.read_text() + " ", encoding="utf-8")
+    assert any(
+        "tool artifact hash" in issue
+        for issue in brief_context.validate_run_bundle(audit_path, manifest_path)
+    )
+
+
+def test_judgment_schema_allows_opinions_but_rejects_market_fields():
+    packet = _compiled()
+    overlay = _valid_overlay(packet)
+    assert packet_mod.validate_judgment_overlay(packet, overlay) == []
+
+    overlay["ticker_judgments"][0]["rsi14"] = 28
+    issues = packet_mod.validate_judgment_overlay(packet, overlay)
+    assert any("unknown fields" in issue and "rsi14" in issue for issue in issues)
+
+    overlay = _valid_overlay(packet)
+    overlay["context_generation_id"] = "stale"
+    assert any(
+        "generation" in issue
+        for issue in packet_mod.validate_judgment_overlay(packet, overlay)
+    )
+
+
+def test_invalid_overlay_cannot_corrupt_deterministic_pages_rows(tmp_path):
+    packet = _compiled()
+    overlay = _valid_overlay(packet)
+    overlay["ticker_judgments"][0]["current_price"] = 999999
+    overlay_path = tmp_path / "judgment.json"
+    output_path = tmp_path / "brief_projection.json"
+    overlay_path.write_text(json.dumps(overlay), encoding="utf-8")
+
+    projection, issues = packet_mod.write_pages_projection(
+        packet, overlay_path, output_path
+    )
+    assert issues
+    assert projection["judgment_status"] == "invalid"
+    assert all(row["judgment"] is None for row in projection["tickers"])
+    lev = next(row for row in projection["tickers"] if row["ticker"] == "LEVX")
+    assert lev["facts"]["pnl_pct"] == -40
+    assert lev["status"]["label"] == "止损/换1x"
+    assert json.loads(output_path.read_text()) == projection
+
+
+def test_plan_is_constrained_by_harness_actions_evidence_and_inventory():
+    packet = _compiled()
+    good = {
+        "decisions": [{
+            "ticker": "LEVX",
+            "action": "cut",
+            "driven_by": "risk_rule",
+            "evidence_event_id": None,
+            "size": {"shares": 10},
+        }]
+    }
+    assert packet_mod.validate_plan_constraints(good, packet) == []
+
+    bad = {
+        "decisions": [{
+            "ticker": "LEVX",
+            "action": "add_only_on_trigger",
+            "driven_by": "catalyst",
+            "evidence_event_id": "evt_fake",
+            "size": {"shares": 11},
+        }]
+    }
+    issues = packet_mod.validate_plan_constraints(bad, packet)
+    assert any("allowed_actions" in issue for issue in issues)
+    assert any("evidence gate" in issue for issue in issues)
+
+
+def test_pages_prefers_projection_and_keeps_a_backward_fallback():
+    ui = (ROOT / "assets" / "js" / "dashboard.ui.js").read_text()
+    renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+    skill = (ROOT / "skills" / "daily-deep-brief" / "SKILL.md").read_text()
+
+    assert 'brief_projection: "drill"' in ui
+    assert 'safe(DATA, "brief_projection")' in renderer
+    assert "projection.schema_version === 1" in renderer
+    assert "projected.length" in renderer
+    assert ": holds.map" in renderer
+    assert "--summary" in skill
+    assert "--judgment-template" in skill
+    assert "禁止加入价格、RSI、MA" in skill

--- a/tests/test_brief_postflight_sections.py
+++ b/tests/test_brief_postflight_sections.py
@@ -63,3 +63,9 @@ def test_genuinely_omitted_section_still_raises_same_missing_issue(tmp_path):
     # Keep today's warn/fail threshold semantics: one non-critical issue is a warn;
     # five such issues still fail. The section omission itself remains surfaced.
     assert brief_postflight.categorize(issues) == 'warn'
+
+
+def test_harness_action_boundary_is_fail_closed():
+    assert brief_postflight.categorize([
+        "plan.json harness: decision[0] ABC action outside harness allowed_actions"
+    ]) == "fail"


### PR DESCRIPTION
## What changed

- compile the existing technical, factor, peer, sentiment-collection, evidence and risk outputs into a generation-bound typed decision packet
- expose bounded `--summary`, `--ticker`, `--section` and `--judgment-template` queries instead of loading broad audit/core JSON
- constrain the model overlay to opinions only: verdict, confidence, assessment, counterargument and rationale
- fail closed when a plan selects an action outside harness bounds, cites an unapproved event, or exceeds current inventory
- publish a versioned `brief_projection.json`; Pages renders the projection and keeps the old client join only as a schema/freshness fallback
- keep the existing GitHub-managed Jekyll branch deployment after checking the current GitHub Pages recommendations; this PR changes the data contract, not the publishing source

## Measured on the 2026-07-28 production context

| Boundary | Bytes |
|---|---:|
| full audit | 369,549 |
| previous manifest + core | 84,334 |
| new default summary output | 13,569 |
| largest per-ticker query | 6,455 |
| full packet (not loaded by default) | 36,934 |
| Pages projection | 13,705 |

Default model input is 96.3% smaller than the full audit and 83.9% smaller than the previous always-loaded boundary. Thirty fresh-process CLI runs measured 56.7 ms median / 57.6 ms p95.

The Pages projection is a decoupling/failure-isolation improvement, not claimed as a first-paint bandwidth reduction: live P&L continues to come from the frequently refreshed holdings payload.

## Validation

- `python3 -m pytest tests/ -q` → 1150 passed, 5 xfailed
- Python compile + Node syntax checks
- pre-push system check → 15 ok, 2 pre-existing warnings, 0 critical
- current production plan → zero decision-packet constraint conflicts

Closes #151