### PR TITLE
perf: lazy-load Reflect backtest from audit sidecar

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -278,9 +278,13 @@ jobs:
           python3 << 'PY'
           import json
           with open('assets/data/dashboard.json') as f: d = json.load(f)
-          needed = ['generated_at','fx','totals','concentration','holdings','snapshots','decision_metrics','episode_backtest','decision_delta']
+          with open('assets/data/decision_audit.json') as f: audit = json.load(f)
+          needed = ['generated_at','fx','totals','concentration','holdings','snapshots','decision_metrics','decision_delta']
           missing = [k for k in needed if k not in d]
           assert not missing, f'missing keys: {missing}'
+          assert 'episode_backtest' not in d, 'Reflect backtest leaked into first-paint payload'
+          assert audit.get('episode_backtest', {}).get('horizons', {}).get('t1'), \
+              'decision_audit.json missing Reflect episode backtest'
           for leg in ('us', 'hk'):
               assert leg in d['holdings'], f'holdings.{leg} missing'
               assert leg in d['concentration'], f'concentration.{leg} missing'

--- a/assets/js/dashboard.charts.js
+++ b/assets/js/dashboard.charts.js
@@ -28,6 +28,15 @@
       CHART_FNS[t]();
     });
   }
+
+  // Reflect owns the episode backtest. Prefer its lazy sidecar, with the old
+  // dashboard.json location as a cross-version fallback while a code deploy and
+  // the next cron-generated data deploy can briefly straddle schemas.
+  function episodeBacktest() {
+    return safe(DATA, "decision_audit", "episode_backtest")
+      || safe(DATA, "episode_backtest")
+      || {};
+  }
   function ensureTabCharts(t) {
     if (!CHART_FNS[t]) return;
     _chartTabsShown.add(t);
@@ -273,7 +282,7 @@
     if (!card) return;
     // decision_money_impact is no longer published at all — not just unplotted — so
     // the card's visibility keys off the win-rate record that it still shows.
-    const hasRecord = safe(DATA, "episode_backtest", "horizons", "t1") != null;
+    const hasRecord = safe(episodeBacktest(), "horizons", "t1") != null;
     card.style.display = hasRecord ? "" : "none";
     if (!window.echarts) return;
     const green = getCSS("--positive") || "#28C08D";
@@ -286,7 +295,7 @@
     const wrEl = document.getElementById("chart-ai-winrate");
     if (wrEl) {
       if (!charts.aiWinRate) charts.aiWinRate = echarts.init(wrEl, null, { renderer: "canvas" });
-      const t1 = safe(DATA, "episode_backtest", "horizons", "t1") || {};
+      const t1 = safe(episodeBacktest(), "horizons", "t1") || {};
       const allWrCurve = t1.all_win_rate_curve || [];
       const activeWrCurve = t1.active_win_rate_curve || [];
       const wrDates = [...new Set([...allWrCurve, ...activeWrCurve].map(p => p.date))].sort();
@@ -934,4 +943,3 @@
     }
     charts.weightConf.setOption(opt, true);
   }
-

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -241,10 +241,10 @@
       // absent (same `null` contract the old build_dashboard _embed used). Each is
       // a separate conditional GET → 304 headers-only when unchanged.
       //
-      // Scoped to the tab that consumes each one (map below). The big one,
-      // decision_audit.json (~700KB), only feeds Reflect; awaiting all seven before
-      // the first render used to block Overview — which reads none of them — on that
-      // download+parse. Now we await only the sidecars the LANDING tab needs (so a
+      // Scoped to the tab that consumes each one (map below). Reflect's audit and
+      // backtest belong in decision_audit.json; awaiting every sidecar before the
+      // first render used to block Overview on data it never reads. Now we await
+      // only the sidecars the LANDING tab needs (so a
       // deep-linked #market/#reflect/#drill still shows a COMPLETE tab, never a
       // partial shell), render, then load the rest in the background and refresh only
       // their own tab. Overview has no sidecar dependency, so a background arrival

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -113,6 +113,26 @@ def trim_workflow_outcomes(summary):
     return summary
 
 
+def build_decision_audit_payload(decisions, portfolio):
+    """Compile the complete Reflect sidecar from one settled decision set.
+
+    ``episode_backtest`` is rendered only on Reflect, whose existing
+    ``decision_audit.json`` dependency is already fetched before that tab
+    paints. Keeping it here avoids taxing every other tab while preserving one
+    logical dashboard build and the existing three-output publication contract.
+    """
+    payload = decision_v2.build_audit_sidecar(
+        decisions, portfolio, include_records=False
+    )
+    payload['episode_backtest'] = decision_v2.compute_backtest(decisions)
+    return payload
+
+
+def serialize_dashboard_payload(value):
+    """Serialize the first-paint document without spending headroom on whitespace."""
+    return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+
 def compute_guardrail_outputs(portfolio, risk, lev_regime=None):
     """Compute the two live risk cards without ever failing the dashboard build.
 
@@ -2045,15 +2065,13 @@ def main():
     audit_file = Path(os.environ.get('DECISION_AUDIT_OUT')
                       or (out_file.parent / AUDIT_FILE.name))
     from safe_io import safe_write_text
-    # The dashboard only reads timing_diagnostic from this sidecar; the full
-    # per-decision `records` trail (~700KB, recomputable from decisions) is not
-    # rendered or linked anywhere, so it is dropped from the published file to keep
-    # the payload tiny. Flip include_records back on to republish the full trail.
+    # Reflect reads timing_diagnostic plus its episode backtest from this sidecar.
+    # The full per-decision `records` trail (~700KB, recomputable from decisions)
+    # is not rendered or linked anywhere, so it stays unpublished.
     safe_write_text(
         str(audit_file),
         json.dumps(
-            decision_v2.build_audit_sidecar(
-                _decisions, portfolio, include_records=False),
+            build_decision_audit_payload(_decisions, portfolio),
             ensure_ascii=False, separators=(',', ':')))
     # Shadow-portfolio policy simulation (模拟·非实盘): fetched sidecar, NOT embedded
     # in dashboard.json. Two cash+inventory ledgers (follow-all-triggered vs
@@ -2065,7 +2083,6 @@ def main():
     out['decision_schema_version'] = 2
     out['decision_metrics'] = trim_decision_metrics(
         decision_v2.compute_metrics(_decisions))
-    out['episode_backtest'] = decision_v2.compute_backtest(_decisions)
     # decision_money_impact is deliberately NOT published (2026-07-15). Pulling the
     # chart while still shipping the numbers would be a distinction only a reader of
     # this file could make: dashboard.json is public, so the retired figure was still
@@ -2262,10 +2279,10 @@ def main():
     if brief_ctx_path:
         print(f'  brief-context source: {os.path.basename(brief_ctx_path)}')
 
-    # Serialize with no indentation to save bytes; pretty-print only if under budget
-    payload_min = json.dumps(out, ensure_ascii=False)
-    payload_pretty = json.dumps(out, ensure_ascii=False, indent=2)
-    payload = payload_pretty if len(payload_pretty.encode('utf-8')) <= MAX_OUT_BYTES else payload_min
+    # dashboard.json is a machine-consumed first-paint document. Always keep it
+    # compact: spending newly recovered headroom on indentation made the cap
+    # oscillate without adding user value.
+    payload = serialize_dashboard_payload(out)
     size_bytes = len(payload.encode('utf-8'))
 
     if size_bytes > MAX_OUT_BYTES:
@@ -2273,7 +2290,7 @@ def main():
         print(f'⚠️  payload still {size_bytes} bytes > {MAX_OUT_BYTES} cap — dropping recent_plans', file=sys.stderr)
         out['recent_plans'] = []
         out['recent_plans_dropped'] = True
-        payload = json.dumps(out, ensure_ascii=False)
+        payload = serialize_dashboard_payload(out)
         size_bytes = len(payload.encode('utf-8'))
         if size_bytes > MAX_OUT_BYTES:
             # Dropping the plans is the only lever here; publishing an oversized

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -110,6 +110,19 @@ def test_real_sidecar_change_is_returned_with_exact_path(tmp_path):
     ) == original["assets/data/decision_audit.json"]
 
 
+def test_reflect_backtest_change_publishes_the_existing_audit_sidecar(tmp_path):
+    original = _repo(tmp_path)
+    _write(tmp_path, "assets/data/decision_audit.json", {
+        **original["assets/data/decision_audit.json"],
+        "as_of": "new",
+        "episode_backtest": {"horizons": {"t1": {"settled": 3}}},
+    })
+
+    assert dashboard_outputs.semantic_changed_paths(tmp_path) == [
+        "assets/data/decision_audit.json"
+    ]
+
+
 def test_every_dashboard_committer_uses_the_shared_contract():
     assert set(dashboard_outputs.DASHBOARD_OUTPUTS) == EXPECTED
 

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -66,6 +66,18 @@ def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces():
     assert "out.stat().st_size" in check, "system_check must stay on bytes too"
 
 
+def test_builder_does_not_spend_recovered_headroom_on_indentation():
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    value = {"中文": {"rows": [1, 2]}, "status": "ok"}
+    serialized = build_dashboard.serialize_dashboard_payload(value)
+    assert serialized == '{"中文":{"rows":[1,2]},"status":"ok"}'
+    assert len(serialized.encode("utf-8")) < len(
+        json.dumps(value, ensure_ascii=False, indent=2).encode("utf-8")
+    )
+
+
 def test_no_sub_object_is_embedded_twice(payload):
     """The dial was embedded at top level and again inside risk_guardrail."""
     import hashlib
@@ -141,12 +153,14 @@ def test_dropped_blocks_are_still_reachable_elsewhere():
 
 
 def test_what_the_charts_actually_read_is_still_present(payload):
-    """Guards against over-trimming: a name-based scan once called
-    `episode_backtest.horizons` unread because it lives in dashboard.charts.js,
-    not the renderer."""
+    """Guards against over-trimming across the main payload/sidecar boundary."""
     js = "".join((ROOT / "assets" / "js" / name).read_text() for name in RENDERERS)
-    assert 'safe(DATA, "episode_backtest", "horizons", "t1")' in js
-    assert payload["episode_backtest"]["horizons"]["t1"]
+    assert 'safe(DATA, "decision_audit", "episode_backtest")' in js
+    assert 'safe(DATA, "episode_backtest")' in js  # rollout fallback
+    # The tracked artifact may still be from the pre-migration cron build on a
+    # feature branch. The builder contract below forbids re-embedding it.
+    if payload.get("episode_backtest"):
+        assert payload["episode_backtest"]["horizons"]["t1"]
     assert payload["snapshots"]
     # the dial card reads these off the trimmed copy
     assert 'safe(DATA, "lev_regime")' in js

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +20,33 @@ def test_reflect_loads_audit_as_sidecar_and_not_dashboard_field():
     assert "assets/data/" in HTML
     assert "build_audit_sidecar" in BUILD
     assert "out['decision_audit']" not in BUILD
+    assert "out['episode_backtest']" not in BUILD
+
+
+def test_reflect_sidecar_compiles_backtest_from_the_same_decisions(monkeypatch):
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    decisions = [{"decision_id": "d1"}]
+    monkeypatch.setattr(
+        build_dashboard.decision_v2,
+        "build_audit_sidecar",
+        lambda rows, portfolio, include_records: {
+            "schema_version": 1,
+            "decision_ids": [row["decision_id"] for row in rows],
+            "records_included": include_records,
+        },
+    )
+    monkeypatch.setattr(
+        build_dashboard.decision_v2,
+        "compute_backtest",
+        lambda rows: {"decision_ids": [row["decision_id"] for row in rows]},
+    )
+
+    sidecar = build_dashboard.build_decision_audit_payload(decisions, {})
+    assert sidecar["decision_ids"] == ["d1"]
+    assert sidecar["records_included"] is False
+    assert sidecar["episode_backtest"] == {"decision_ids": ["d1"]}
 
 
 def test_reflect_card_keeps_timing_claims_narrow():

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -13,6 +13,9 @@ HTML = (ROOT / "index.html").read_text() + "".join(
     )
 )
 BUILD = (ROOT / "scripts" / "data" / "build_dashboard.py").read_text()
+HARNESS_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "harness-regression.yml"
+).read_text()
 
 
 def test_reflect_loads_audit_as_sidecar_and_not_dashboard_field():
@@ -47,6 +50,15 @@ def test_reflect_sidecar_compiles_backtest_from_the_same_decisions(monkeypatch):
     assert sidecar["decision_ids"] == ["d1"]
     assert sidecar["records_included"] is False
     assert sidecar["episode_backtest"] == {"decision_ids": ["d1"]}
+
+
+def test_remote_rebuild_gate_validates_the_new_payload_boundary():
+    gate = HARNESS_WORKFLOW.split(
+        "- name: Rebuild dashboard.json and validate", 1
+    )[1].split("- name: Run build_dashboard sanity", 1)[0]
+    assert "assets/data/decision_audit.json" in gate
+    assert "'episode_backtest' not in d" in gate
+    assert "audit.get('episode_backtest'" in gate
 
 
 def test_reflect_card_keeps_timing_claims_narrow():


### PR DESCRIPTION
Part of #100.

## What changed

- compile `episode_backtest` into the existing `decision_audit.json` Reflect sidecar
- stop embedding that Reflect-only block in first-paint `dashboard.json`
- keep a top-level fallback so code/data deployments can straddle the migration safely
- keep dashboard serialization compact instead of spending recovered headroom on indentation
- reuse the existing three-output ownership contract; no new artifact, cron path or committing workflow

## Measured result

Fresh build from this branch with the current runtime inputs:

- `dashboard.json`: 195,213 → 152,622 bytes
- `decision_audit.json`: 1,247 → 29,003 bytes, fetched before Reflect only
- dashboard remains under the 200,000-byte hard cap with about 47 KB headroom

Lighthouse mobile, three local runs each (median):

| metric | before | after |
|---|---:|---:|
| Performance | 61 | 63 |
| LCP | 3.99 s | 3.86 s |
| TBT | 1.57 s | 1.25 s |
| CLS | 0.0097 | 0.0097 |

This PR primarily fixes payload ownership/headroom; #153 targets the larger ECharts first-load cost.

## Verification

- 88 passed, 1 expected xfail across dashboard, Reflect, ownership, publisher, cron, generated-doc and screenshot workflow contracts
- six tabs × light/dark Chromium smoke passed; every active ECharts canvas had a real size
- pre-push system check: 16 OK, 1 existing memory-index warning, 0 critical
- JS syntax and Python compile checks passed

Generated market/dashboard artifacts are intentionally not committed in this PR. The first normal host dashboard build after merge will atomically publish the migrated `dashboard.json` and `decision_audit.json` through the existing `DASHBOARD_OUTPUTS` path.
