### PR TITLE
fix(harness): 只修构造上无损的 JSON 缺陷，其余一律响亮失败

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -22,6 +22,7 @@ from zoneinfo import ZoneInfo
 
 import decision_v2
 import instrument_registry
+import json_repair
 
 # Strict YYYY-MM-DD.json — rejects baselines/backups/archives that share the
 # snapshots dir (e.g. 2026-05-16-saturday-baseline.json caused duplicate 5-16
@@ -708,13 +709,25 @@ def load_tmp_sidecar(prefix, max_age_days=None):
     Non-fatal on any error (returns {}). If max_age_days is set, marks _stale=True
     when the file's mtime is older, so the frontend can grey it out instead of
     showing day-old critique as if it were current.
+
+    Hand-authored JSON goes through json_repair: on 2026-07-28 a single missing
+    closing quote cost the whole behavioural-review card. Repairs are reported on
+    stderr as `repair:` — a distinct prefix from `warn:`, because the section did
+    render and is not degraded, but the producer still shipped invalid JSON and
+    that must stay visible in the daily review.
     """
     try:
         paths = glob.glob(str(WS_ROOT / 'memory' / '.tmp' / f'{prefix}-*.json'))
         if not paths:
             return {}
         latest = max(paths, key=os.path.getmtime)
-        data = load_json(latest)
+        data, repairs = json_repair.load_json_repaired(latest)
+        if repairs:
+            print(f'  repair: {os.path.basename(latest)} — '
+                  f'{json_repair.describe(repairs)}', file=sys.stderr)
+        if data is None:
+            print(f'  warn: failed to load {latest}: unrepairable JSON',
+                  file=sys.stderr)
         if not isinstance(data, dict):
             return {}
         data.setdefault('_source', os.path.basename(latest))

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -706,9 +706,9 @@ def load_tmp_sidecar(prefix, max_age_days=None):
     review / bear cases / status banner / movers attribution). The LLM runs inside
     the gateway/GHA where API keys live — those keys NEVER touch these files or
     dashboard.json (published to public Pages), only the narrative text does.
-    Non-fatal on any error (returns {}). If max_age_days is set, marks _stale=True
-    when the file's mtime is older, so the frontend can grey it out instead of
-    showing day-old critique as if it were current.
+    Non-fatal on any error. If max_age_days is set, marks _stale=True when the
+    file's mtime is older, so the frontend can grey it out instead of showing
+    day-old critique as if it were current.
 
     Hand-authored JSON goes through json_repair: on 2026-07-28 a single missing
     closing quote cost the whole behavioural-review card group. A repair is
@@ -716,17 +716,24 @@ def load_tmp_sidecar(prefix, max_age_days=None):
     section did render and the build is not degraded — but it is still reported,
     because a producer shipping invalid JSON every morning is a bug.
 
-    A file that exists but cannot be trusted returns `{'_source': ..., '_invalid':
-    True}` rather than `{}`. The difference matters: callers pass `bool(result)`
-    to `_preserve_absent`, and an empty dict means "this checkout has no sidecar"
-    — which republishes *yesterday's* card. Doing that for a file that is present
-    but unreadable would show stale critique as if it were today's.
+    Anything short of "there is no sidecar in this checkout" returns
+    `{'_source': ..., '_invalid': True}` rather than `{}`. The difference
+    matters: callers pass `bool(result)` to `_preserve_absent`, and an empty dict
+    means "this checkout has no sidecar" — which republishes *yesterday's* card.
+    Only proven absence may do that. A file we found but could not read, and even
+    a directory listing that failed outright, are both uncertainty, not absence.
     """
-    latest = None
+    name = None
     try:
         paths = glob.glob(str(WS_ROOT / 'memory' / '.tmp' / f'{prefix}-*.json'))
-        if not paths:
-            return {}
+    except Exception as e:
+        # Cannot even enumerate: we do not know whether a sidecar exists, so we
+        # must not claim it is absent.
+        print(f'  warn: load_tmp_sidecar({prefix}) could not list: {e}', file=sys.stderr)
+        return {'_source': None, '_invalid': True}
+    if not paths:
+        return {}
+    try:
         latest = max(paths, key=os.path.getmtime)
         name = os.path.basename(latest)
         data, repairs, status = json_repair.load_json_repaired(latest)
@@ -748,12 +755,10 @@ def load_tmp_sidecar(prefix, max_age_days=None):
         return data
     except Exception as e:
         print(f'  warn: load_tmp_sidecar({prefix}) failed: {e}', file=sys.stderr)
-        # A file we found but could not read (bad encoding, I/O error) is just as
-        # untrustworthy as one that failed to parse, and must not fall through to
-        # the absent case that republishes the previous day's card.
-        if latest is not None:
-            return {'_source': os.path.basename(latest), '_invalid': True}
-        return {}
+        # Reached only with `paths` non-empty, so a sidecar does exist and we
+        # failed to read it — bad encoding, an I/O error, or an mtime that could
+        # not be stat'd. Every one of those is untrustworthy, never absent.
+        return {'_source': name, '_invalid': True}
 
 
 _REVIEW_TAGS = {'edge', 'bias', 'warning'}

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -711,26 +711,36 @@ def load_tmp_sidecar(prefix, max_age_days=None):
     showing day-old critique as if it were current.
 
     Hand-authored JSON goes through json_repair: on 2026-07-28 a single missing
-    closing quote cost the whole behavioural-review card. Repairs are reported on
-    stderr as `repair:` — a distinct prefix from `warn:`, because the section did
-    render and is not degraded, but the producer still shipped invalid JSON and
-    that must stay visible in the daily review.
+    closing quote cost the whole behavioural-review card group. A repair is
+    reported on stderr as `repair:` — deliberately not `warn:`, because the
+    section did render and the build is not degraded — but it is still reported,
+    because a producer shipping invalid JSON every morning is a bug.
+
+    A file that exists but cannot be trusted returns `{'_source': ..., '_invalid':
+    True}` rather than `{}`. The difference matters: callers pass `bool(result)`
+    to `_preserve_absent`, and an empty dict means "this checkout has no sidecar"
+    — which republishes *yesterday's* card. Doing that for a file that is present
+    but unreadable would show stale critique as if it were today's.
     """
     try:
         paths = glob.glob(str(WS_ROOT / 'memory' / '.tmp' / f'{prefix}-*.json'))
         if not paths:
             return {}
         latest = max(paths, key=os.path.getmtime)
-        data, repairs = json_repair.load_json_repaired(latest)
-        if repairs:
-            print(f'  repair: {os.path.basename(latest)} — '
-                  f'{json_repair.describe(repairs)}', file=sys.stderr)
-        if data is None:
-            print(f'  warn: failed to load {latest}: unrepairable JSON',
+        name = os.path.basename(latest)
+        data, repairs, status = json_repair.load_json_repaired(latest)
+        if status == json_repair.REPAIRED:
+            print(f'  repair: {name} — {json_repair.describe(repairs, status)}',
                   file=sys.stderr)
+        elif status != json_repair.CLEAN:
+            print(f'  warn: failed to load {latest}: '
+                  f'{json_repair.describe(repairs, status)}', file=sys.stderr)
+            return {'_source': name, '_invalid': True}
         if not isinstance(data, dict):
-            return {}
-        data.setdefault('_source', os.path.basename(latest))
+            print(f'  warn: {name}: top level is {type(data).__name__}, not object',
+                  file=sys.stderr)
+            return {'_source': name, '_invalid': True}
+        data.setdefault('_source', name)
         if max_age_days is not None:
             age_days = (time.time() - os.path.getmtime(latest)) / 86400.0
             data['_stale'] = age_days > max_age_days
@@ -2033,7 +2043,11 @@ def main():
     # daily insights (brief): behavioral_review / bear_cases / hidden_concentration.
     # 7d stale guard so a missed brief doesn't show week-old critique as current.
     _insights = load_tmp_sidecar('insights', max_age_days=7)
-    insights_present = bool(_insights)  # file existed in this checkout (vs. GHA-absent)
+    # True when the file existed at all — including when it existed but was
+    # unreadable. Only genuine absence (a GHA checkout, where memory/.tmp is
+    # gitignored) may republish the previous card; an unreadable file must let
+    # the card hide rather than show yesterday's critique as today's.
+    insights_present = bool(_insights)
     _ins = validate_insights({} if _insights.get('_stale') else _insights, known_tickers)
     out['behavioral_review'] = _ins['behavioral_review']
     out['bear_cases'] = _ins['bear_cases']

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -722,6 +722,7 @@ def load_tmp_sidecar(prefix, max_age_days=None):
     — which republishes *yesterday's* card. Doing that for a file that is present
     but unreadable would show stale critique as if it were today's.
     """
+    latest = None
     try:
         paths = glob.glob(str(WS_ROOT / 'memory' / '.tmp' / f'{prefix}-*.json'))
         if not paths:
@@ -747,6 +748,11 @@ def load_tmp_sidecar(prefix, max_age_days=None):
         return data
     except Exception as e:
         print(f'  warn: load_tmp_sidecar({prefix}) failed: {e}', file=sys.stderr)
+        # A file we found but could not read (bad encoding, I/O error) is just as
+        # untrustworthy as one that failed to parse, and must not fall through to
+        # the absent case that republishes the previous day's card.
+        if latest is not None:
+            return {'_source': os.path.basename(latest), '_invalid': True}
         return {}
 
 

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -241,19 +241,20 @@ def heartbeat_coverage(job_name, slots, tz_name, now, ledger):
 def check_dashboard_build():
     """Read logs/dashboard_build_status.json (written by _harness_common.rebuild_dashboard).
 
-    Returns a dict with keys: state ('ok'|'degraded'|'stale'|'failed'|'absent'),
-    detail, ok, warn_count, age_hours. A 'failed' build means dashboard.json is
+    Returns a dict with keys: state
+    ('ok'|'repaired'|'degraded'|'stale'|'failed'|'absent'), detail, ok,
+    warn_count, repair_count, age_hours. A 'failed' build means dashboard.json is
     frozen while commits keep flowing — the silent-freeze case this guards against.
     """
     path = WS / 'logs' / 'dashboard_build_status.json'
     if not path.exists():
         return {'state': 'absent', 'detail': 'no build status file yet', 'ok': None,
-                'warn_count': 0, 'age_hours': None}
+                'warn_count': 0, 'repair_count': 0, 'age_hours': None}
     try:
         st = json.loads(path.read_text())
     except Exception as e:
         return {'state': 'failed', 'detail': f'status file unreadable: {e}', 'ok': False,
-                'warn_count': 0, 'age_hours': None}
+                'warn_count': 0, 'repair_count': 0, 'age_hours': None}
     age_hours = None
     try:
         ts = datetime.strptime(st['checked_at'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
@@ -262,16 +263,26 @@ def check_dashboard_build():
         pass
     if not st.get('ok'):
         return {'state': 'failed', 'detail': f"build FAILED — dashboard.json frozen. tail: {st.get('tail','')[-160:]}",
-                'ok': False, 'warn_count': st.get('warn_count', 0), 'age_hours': age_hours}
+                'ok': False, 'warn_count': st.get('warn_count', 0),
+                'repair_count': st.get('repair_count', 0), 'age_hours': age_hours}
     if st.get('warn_count'):
         return {'state': 'degraded', 'detail': f"{st['warn_count']} degraded section(s) on last build",
-                'ok': True, 'warn_count': st['warn_count'], 'age_hours': age_hours}
+                'ok': True, 'warn_count': st['warn_count'],
+                'repair_count': st.get('repair_count', 0), 'age_hours': age_hours}
+    # Repairs are reported, never escalated: the sidecar parsed after repair, so
+    # every card rendered. This state exists so a producer that ships invalid
+    # JSON daily is visible in the review instead of being quietly patched.
+    if st.get('repair_count'):
+        return {'state': 'repaired',
+                'detail': f"{st['repair_count']} sidecar(s) JSON-repaired on last build",
+                'ok': True, 'warn_count': 0, 'repair_count': st['repair_count'],
+                'age_hours': age_hours}
     # Build OK; flag only if very stale (weekend gaps are normal, so 24h threshold)
     if age_hours is not None and age_hours > 24:
         return {'state': 'stale', 'detail': f'last successful build {age_hours}h ago',
-                'ok': True, 'warn_count': 0, 'age_hours': age_hours}
+                'ok': True, 'warn_count': 0, 'repair_count': 0, 'age_hours': age_hours}
     return {'state': 'ok', 'detail': f'last build ok ({age_hours}h ago)' if age_hours is not None else 'last build ok',
-            'ok': True, 'warn_count': 0, 'age_hours': age_hours}
+            'ok': True, 'warn_count': 0, 'repair_count': 0, 'age_hours': age_hours}
 
 
 def _market_closed_today(market):
@@ -422,7 +433,8 @@ def main():
                     'ok-heartbeat':'✓','monitoring-grace':'·','running':'…',
                     'holiday':'🏖'}.get(r['status'], '·')
             print(f"  {icon} {r['name']:25s}  {r['detail']}")
-        dash_icon = {'ok':'✓','degraded':'⚠','stale':'⚠','failed':'✗','absent':'·'}[dash['state']]
+        dash_icon = {'ok':'✓','repaired':'🔧','degraded':'⚠','stale':'⚠',
+                     'failed':'✗','absent':'·'}[dash['state']]
         print(f"  {dash_icon} {'dashboard build':25s}  {dash['detail']}")
         for line in cron_token_audit.format_lines(token_regressions):
             print(f"  {line}")

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -40,6 +40,14 @@ TERMINAL_HEARTBEAT_STATES = {
 }
 HEARTBEAT_GRACE_MINUTES = 25
 
+# Indexed directly (not .get) so a state added to check_dashboard_build without
+# an icon fails here loudly instead of printing a blank cell. Module-level so the
+# tests can index the real map rather than restate it.
+DASHBOARD_STATE_ICONS = {
+    'ok': '✓', 'repaired': '🔧', 'degraded': '⚠', 'stale': '⚠',
+    'failed': '✗', 'absent': '·',
+}
+
 # Cron name → identifying commit msg patterns
 COMMIT_PATTERNS = {
     '港股开盘报告': r'港股开盘',
@@ -433,8 +441,7 @@ def main():
                     'ok-heartbeat':'✓','monitoring-grace':'·','running':'…',
                     'holiday':'🏖'}.get(r['status'], '·')
             print(f"  {icon} {r['name']:25s}  {r['detail']}")
-        dash_icon = {'ok':'✓','repaired':'🔧','degraded':'⚠','stale':'⚠',
-                     'failed':'✗','absent':'·'}[dash['state']]
+        dash_icon = DASHBOARD_STATE_ICONS[dash['state']]
         print(f"  {dash_icon} {'dashboard build':25s}  {dash['detail']}")
         for line in cron_token_audit.format_lines(token_regressions):
             print(f"  {line}")

--- a/scripts/data/json_repair.py
+++ b/scripts/data/json_repair.py
@@ -1,70 +1,67 @@
 #!/usr/bin/env python3
 """
-json_repair.py — bounded, named recovery for LLM-authored JSON.
+json_repair.py — bounded, lossless recovery for hand-authored JSON sidecars.
 
-Every JSON file an agent writes by hand (the daily insights sidecar, the intraday
-status sidecar, plan.json) is one unescaped newline away from being unreadable.
-On 2026-07-28 the brief dropped the closing quote on the last `data_caveats`
-entry; `json.load` raised `Invalid control character at line 48`, build_dashboard
-lost the whole behavioural-review card, and the daily Cron Health Check went red
-for a file that was 3038 of 3039 bytes correct.
+Every JSON file an agent writes by hand is one unescaped newline away from being
+unreadable. On 2026-07-28 the brief dropped the closing quote on the last
+`data_caveats` entry of `memory/.tmp/insights-2026-07-28.json`; `json.load`
+raised `Invalid control character at line 48`, `build_dashboard` lost the whole
+behavioural-review card group, and the daily health check went red — for one
+absent byte in 4,361.
 
-Design rules, in priority order:
+## The invariant, stated so it can be tested
 
-1. **Never touch valid JSON.** Strict `json.loads` runs first; if it succeeds the
-   input is returned untouched with zero repairs. A repair pass can only ever run
-   on text that already failed to parse.
-2. **Never invent data.** Every pass either deletes a syntactic artefact (fence,
-   trailing comma) or closes a structure the author left open, preserving the
-   partial text as written. No pass rewrites, guesses at, or completes a *value*.
-3. **Never repair silently.** `repair_json` returns the list of pass names that
-   fired. Callers must surface it — a file that needs repairing every day is a
-   producer bug, and a silent fixer would hide it forever (see the shared-memory
-   note `feedback-detect-but-never-silence`).
+A pass may only:
 
-Repairs are advisory, not warnings: the section rendered, so it is not degraded.
-See `_record_dashboard_build` (repair_count) and `cron_health_check` for how it
-reaches the daily review without turning the run red.
+  * **insert** a delimiter the author owed (a closing quote), or
+  * **escape**, in place, a character that JSON forbids raw inside a string, or
+  * **delete** a character that is outside every string literal and carries no
+    value (a fence line, a comma before a closer).
+
+No pass may delete a character that is inside a string literal, and no pass may
+delete a *value*. This rules out two tempting repairs that earlier versions of
+this module shipped, both of which silently destroyed data:
+
+  * **prose stripping** — cutting to the outermost balanced value looks lossless
+    but is not: `{"kept": 1}\\n{"lost": 2}` is balanced, and cutting to the first
+    match deletes the second document. Bracket-matching only moves where the
+    deletion ends; it cannot prove the discarded suffix was noise.
+  * **closing a truncated document** — the tail is already gone; appending `]}`
+    converts "this file was cut off" into "a valid document with fewer items".
+    For a plan that is decisions silently disappearing. Truncation must fail
+    loudly, so it is not repaired here.
+
+## Ambiguity is refused, not guessed
+
+A missing quote and a raw newline inside a string are indistinguishable by
+scanning: a dropped quote mispairs every quote after it, so the opener on the
+broken line pairs with the next line's opener. Both readings can parse and yield
+*different objects*, and no amount of parser agreement establishes which one the
+author meant. So every accepting branch is enumerated; if two of them disagree,
+the result is `ambiguous` and no object is returned. Parser acceptance proves
+syntax, never intent.
+
+## Nothing is repaired silently
+
+`repair_json` returns a status alongside the object. `clean` is the only status a
+caller may treat as unremarkable — a file needing repair every day is a producer
+bug, and a silent fixer would hide it forever (shared memory:
+`feedback-detect-but-never-silence`).
 """
 import json
 import re
 
-# A file can carry more than one defect (a fence around a truncated body), so
-# passes compose — but only up to this depth, and a composition is kept only if
-# it parses. With 6 passes that bounds the search at 6·5·4 = 120 candidates,
-# microseconds on files this size, and makes "repaired" mean "the parser
-# accepted it", never "our heuristic liked it".
+# A file can carry more than one defect, so passes compose — but only to this
+# depth, and only through branches the parser accepts. With 4 passes that bounds
+# the search at 4·3·2 = 24 candidates.
 _MAX_DEPTH = 3
 
+CLEAN = 'clean'
+REPAIRED = 'repaired'
+AMBIGUOUS = 'ambiguous'
+UNREPAIRABLE = 'unrepairable'
+
 _FENCE_RE = re.compile(r'^\s*```(?:json|JSON)?\s*\n(.*?)\n?\s*```\s*$', re.DOTALL)
-_TRAILING_COMMA_RE = re.compile(r',(\s*[}\]])')
-
-
-def _strip_code_fence(text):
-    """```json … ``` → the payload. Models fence a file write surprisingly often."""
-    m = _FENCE_RE.match(text)
-    return m.group(1) if m else None
-
-
-def _strip_prose_wrapper(text):
-    """Drop chatter outside the outermost {...} / [...] the document starts with.
-
-    Only trims at the boundaries — the first opening brace/bracket and its last
-    matching partner by character. Interior content is never touched.
-    """
-    starts = [i for i in (text.find('{'), text.find('[')) if i != -1]
-    if not starts:
-        return None
-    start = min(starts)
-    closer = '}' if text[start] == '{' else ']'
-    end = text.rfind(closer)
-    if end <= start:
-        return None
-    # Surrounding whitespace is not prose; treating it as such would burn a pass
-    # (and a reported repair name) on a file whose only sin is a trailing \n.
-    if not text[:start].strip() and not text[end + 1:].strip():
-        return None
-    return text[start:end + 1]
 
 
 def _iter_string_spans(text):
@@ -72,7 +69,7 @@ def _iter_string_spans(text):
 
     Walks the raw text tracking escapes so a `\\"` inside a string does not read
     as a terminator. A trailing None close means the last string was never
-    closed — the truncation/missing-quote case.
+    closed.
     """
     i, n = 0, len(text)
     while i < n:
@@ -95,29 +92,36 @@ def _iter_string_spans(text):
         i = j + 1
 
 
-def _close_unterminated_string(text):
-    """Close a string whose author dropped the final quote before a newline.
+def _outside_string(text):
+    """Set of indices that are not inside any string literal (quotes included)."""
+    inside = set()
+    for start, end in _iter_string_spans(text):
+        stop = len(text) if end is None else end + 1
+        inside.update(range(start, stop))
+    return set(range(len(text))) - inside
 
-    The 2026-07-28 case: `"…决策应等数据真口径` followed by `\n  ],`. Repaired by
-    inserting `"` at the end of that line — the text written stays exactly as
-    written, only the delimiter the author owed is supplied. Refuses when the
-    line looks mid-value (ends in `\\`) so a genuinely multi-line value is left
-    for `_escape_control_chars` instead.
+
+def _strip_code_fence(text):
+    """```json … ``` → the payload. Deletes only the fence lines themselves."""
+    m = _FENCE_RE.match(text)
+    return m.group(1) if m else None
+
+
+def _close_unterminated_string(text):
+    """Insert the closing quote the author owed, at the end of that line.
+
+    Handles both a span that never closes and a span that swallowed a newline —
+    the two shapes a missing quote produces. Nothing is deleted; the text as
+    written is preserved and only the delimiter is supplied. Declines when the
+    line ends in a backslash, where the author was plainly still mid-value.
     """
     for start, end in _iter_string_spans(text):
-        # A span that swallowed a newline is indistinguishable from a missing
-        # quote by scanning alone: the opener on the broken line simply pairs
-        # with the *next* line's opener. Both readings are handled — this pass
-        # takes the missing-quote reading, `_escape_control_chars` takes the
-        # multi-line-value reading, and `repair_json` keeps whichever parses.
         if end is not None and '\n' not in text[start:end]:
             continue
         nl = text.find('\n', start + 1)
         tail = text[start:] if nl == -1 else text[start:nl]
         if tail.rstrip().endswith('\\'):
             return None
-        # Insert the quote after the last non-blank character the author wrote,
-        # so trailing indentation stays outside the string.
         cut = start + len(tail.rstrip())
         return text[:cut] + '"' + text[cut:]
     return None
@@ -126,10 +130,9 @@ def _close_unterminated_string(text):
 def _escape_control_chars(text):
     """Escape raw newlines/tabs that sit inside a string literal.
 
-    A model writing a multi-line quote produces a literal 0x0A between the
-    quotes, which is exactly what `Invalid control character` reports. Only
-    characters strictly inside a span from `_iter_string_spans` are escaped, so
-    the newlines that format the document are untouched.
+    In place and value-preserving: the character survives as its JSON escape.
+    Only characters strictly inside a closed span are touched, so the newlines
+    that format the document are untouched.
     """
     out, last, changed = [], 0, False
     for start, end in _iter_string_spans(text):
@@ -151,71 +154,64 @@ def _escape_control_chars(text):
 
 
 def _drop_trailing_comma(text):
-    """`[1, 2, ]` → `[1, 2]`. Purely artefact removal."""
-    repaired = _TRAILING_COMMA_RE.sub(r'\1', text)
-    return repaired if repaired != text else None
+    """`[1, 2, ]` → `[1, 2]`, for commas that are outside every string.
 
-
-def _close_open_containers(text):
-    """Append the `}`/`]` a truncated document never got to write.
-
-    Counts unclosed containers outside string literals and closes them in the
-    right order. Also drops a dangling `"key":` or trailing comma at the cut
-    point, since neither can be completed without inventing a value.
+    String-aware by construction. A blanket regex deletes the comma in
+    `[\"a\", \",\"]`-shaped input — where the comma is a string's *value*, not a
+    separator — which is a value deletion, not an artefact removal.
     """
-    spans = [(s, e) for s, e in _iter_string_spans(text) if e is not None]
-
-    def in_string(idx):
-        return any(s <= idx <= e for s, e in spans)
-
-    stack = []
+    outside = _outside_string(text)
+    drop = []
     for i, ch in enumerate(text):
-        if in_string(i):
+        if ch != ',' or i not in outside:
             continue
-        if ch in '{[':
-            stack.append(ch)
-        elif ch in '}]':
-            if stack and stack[-1] == ('{' if ch == '}' else '['):
-                stack.pop()
-    if not stack:
+        j = i + 1
+        while j < len(text) and text[j] in ' \t\r\n':
+            j += 1
+        if j < len(text) and text[j] in ']}' and j in outside:
+            drop.append(i)
+    if not drop:
         return None
-    body = text.rstrip()
-    # A cut mid-pair leaves `"k":` or `"k": ` with nothing after it, and a cut
-    # right after an element leaves the separator. Neither is completable.
-    body = re.sub(r',\s*$', '', body)
-    body = re.sub(r'"[^"\n]*"\s*:\s*$', '', body).rstrip().rstrip(',')
-    return body + ''.join('}' if ch == '{' else ']' for ch in reversed(stack))
+    cut = set(drop)
+    return ''.join(c for i, c in enumerate(text) if i not in cut)
 
 
-# Name → pass. Cheapest and most localised first; `unterminated_string` precedes
-# `control_chars_in_string` because it is the likelier authoring slip, but that
-# preference is only a tiebreak. Correctness comes from the parser, not the
-# order: a dropped quote mispairs every quote after it, so the escaping reading
-# of such a file does not parse and the driver backs out of it. Verified by
-# mutation — swapping these two changes no test outcome.
+# Tried in this order, but order is only a tiebreak: correctness comes from
+# enumerating every accepting branch and refusing disagreement, not from
+# guessing well.
 _PASSES = (
     ('code_fence', _strip_code_fence),
-    ('prose_wrapper', _strip_prose_wrapper),
     ('trailing_comma', _drop_trailing_comma),
     ('unterminated_string', _close_unterminated_string),
     ('control_chars_in_string', _escape_control_chars),
-    ('truncated_document', _close_open_containers),
 )
 
 
-def _search(text, used, depth):
-    """Depth-first over unused passes; a branch counts only when it parses.
+def _json_equal(a, b):
+    """Type-sensitive structural equality.
 
-    Returns (obj, repairs) for the first branch the parser accepts, else
-    (None, []) — deliberately not the deepest partial attempt, because a list of
-    repairs that did not produce valid JSON would misreport what happened.
+    Plain `==` calls `True == 1` and `1 == 1.0` equal, which would let two
+    branches that disagree about a value's JSON *type* pass as agreeing.
     """
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, dict):
+        return (a.keys() == b.keys()
+                and all(_json_equal(a[k], b[k]) for k in a))
+    if isinstance(a, list):
+        return len(a) == len(b) and all(_json_equal(x, y) for x, y in zip(a, b))
+    return a == b
+
+
+def _accepting_branches(text, used, depth, found):
+    """Collect (object, repairs) for every accepting branch within the bound."""
     try:
-        return json.loads(text), []
+        found.append((json.loads(text), []))
+        return
     except (json.JSONDecodeError, ValueError):
         pass
     if depth <= 0:
-        return None, []
+        return
     for name, fn in _PASSES:
         if name in used:
             continue
@@ -225,37 +221,55 @@ def _search(text, used, depth):
             candidate = None
         if candidate is None or candidate == text:
             continue
-        obj, rest = _search(candidate, used | {name}, depth - 1)
-        if obj is not None:
-            return obj, [name] + rest
-    return None, []
+        nested = []
+        _accepting_branches(candidate, used | {name}, depth - 1, nested)
+        found.extend((obj, [name] + rest) for obj, rest in nested)
 
 
 def repair_json(text):
-    """Parse `text`, repairing bounded syntax defects. → (obj_or_None, repairs).
+    """Parse `text`, repairing bounded syntax defects. → (obj, repairs, status).
 
-    `repairs` is the ordered list of pass names that fired; it is empty when the
-    input parsed strictly, which is the only case where the caller may stay
-    quiet. A None object means the text was beyond these passes — the caller
-    keeps its existing failure path.
+    status is one of:
+      `clean`        — parsed as written; `repairs` is empty and the caller may
+                       stay quiet. The only status that means "nothing happened".
+      `repaired`     — every accepting branch agreed; `obj` is that object and
+                       `repairs` names the passes that fired.
+      `ambiguous`    — accepting branches disagreed about the resulting object.
+                       No object is returned: the reading cannot be established
+                       from syntax alone, and picking one would be a guess.
+      `unrepairable` — no branch parsed. `obj` is None.
     """
     if not isinstance(text, str) or not text.strip():
-        return None, []
-    # The strict-parse guarantee lives in `_search`'s first statement, so valid
-    # input returns before any pass runs. Do not re-add it here: a duplicate
-    # fast path reads like a safety net while being unreachable, and a mutation
-    # run proved deleting it changed nothing.
-    return _search(text, frozenset(), _MAX_DEPTH)
+        return None, [], UNREPAIRABLE
+    try:
+        return json.loads(text), [], CLEAN
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    found = []
+    _accepting_branches(text, frozenset(), _MAX_DEPTH, found)
+    if not found:
+        return None, [], UNREPAIRABLE
+    first = found[0][0]
+    if any(not _json_equal(first, obj) for obj, _ in found[1:]):
+        return None, [], AMBIGUOUS
+    return first, found[0][1], REPAIRED
 
 
 def load_json_repaired(path, encoding='utf-8'):
-    """`repair_json` over a file. → (obj_or_None, repairs). Never raises on
-    malformed content; an unreadable path still raises, since that is not a
-    syntax defect and must not be mistaken for one."""
+    """`repair_json` over a file. → (obj, repairs, status). Never raises on
+    malformed content; an unreadable path still raises, since absence is not a
+    syntax defect and must not be reported as one."""
     with open(path, encoding=encoding) as f:
         return repair_json(f.read())
 
 
-def describe(repairs):
-    """One-line advisory text for a repair list ('' when nothing fired)."""
-    return f"repaired JSON ({', '.join(repairs)})" if repairs else ''
+def describe(repairs, status=REPAIRED):
+    """One-line advisory text ('' when there is nothing to report)."""
+    if status == AMBIGUOUS:
+        return 'ambiguous JSON — competing repairs disagree, refusing to guess'
+    if status == UNREPAIRABLE:
+        return 'unrepairable JSON'
+    if not repairs:
+        return ''
+    return f"repaired JSON ({', '.join(repairs)})"

--- a/scripts/data/json_repair.py
+++ b/scripts/data/json_repair.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+json_repair.py — bounded, named recovery for LLM-authored JSON.
+
+Every JSON file an agent writes by hand (the daily insights sidecar, the intraday
+status sidecar, plan.json) is one unescaped newline away from being unreadable.
+On 2026-07-28 the brief dropped the closing quote on the last `data_caveats`
+entry; `json.load` raised `Invalid control character at line 48`, build_dashboard
+lost the whole behavioural-review card, and the daily Cron Health Check went red
+for a file that was 3038 of 3039 bytes correct.
+
+Design rules, in priority order:
+
+1. **Never touch valid JSON.** Strict `json.loads` runs first; if it succeeds the
+   input is returned untouched with zero repairs. A repair pass can only ever run
+   on text that already failed to parse.
+2. **Never invent data.** Every pass either deletes a syntactic artefact (fence,
+   trailing comma) or closes a structure the author left open, preserving the
+   partial text as written. No pass rewrites, guesses at, or completes a *value*.
+3. **Never repair silently.** `repair_json` returns the list of pass names that
+   fired. Callers must surface it — a file that needs repairing every day is a
+   producer bug, and a silent fixer would hide it forever (see the shared-memory
+   note `feedback-detect-but-never-silence`).
+
+Repairs are advisory, not warnings: the section rendered, so it is not degraded.
+See `_record_dashboard_build` (repair_count) and `cron_health_check` for how it
+reaches the daily review without turning the run red.
+"""
+import json
+import re
+
+# A file can carry more than one defect (a fence around a truncated body), so
+# passes compose — but only up to this depth, and a composition is kept only if
+# it parses. With 6 passes that bounds the search at 6·5·4 = 120 candidates,
+# microseconds on files this size, and makes "repaired" mean "the parser
+# accepted it", never "our heuristic liked it".
+_MAX_DEPTH = 3
+
+_FENCE_RE = re.compile(r'^\s*```(?:json|JSON)?\s*\n(.*?)\n?\s*```\s*$', re.DOTALL)
+_TRAILING_COMMA_RE = re.compile(r',(\s*[}\]])')
+
+
+def _strip_code_fence(text):
+    """```json … ``` → the payload. Models fence a file write surprisingly often."""
+    m = _FENCE_RE.match(text)
+    return m.group(1) if m else None
+
+
+def _strip_prose_wrapper(text):
+    """Drop chatter outside the outermost {...} / [...] the document starts with.
+
+    Only trims at the boundaries — the first opening brace/bracket and its last
+    matching partner by character. Interior content is never touched.
+    """
+    starts = [i for i in (text.find('{'), text.find('[')) if i != -1]
+    if not starts:
+        return None
+    start = min(starts)
+    closer = '}' if text[start] == '{' else ']'
+    end = text.rfind(closer)
+    if end <= start:
+        return None
+    # Surrounding whitespace is not prose; treating it as such would burn a pass
+    # (and a reported repair name) on a file whose only sin is a trailing \n.
+    if not text[:start].strip() and not text[end + 1:].strip():
+        return None
+    return text[start:end + 1]
+
+
+def _iter_string_spans(text):
+    """Yield (open_quote_index, close_quote_index_or_None) for every JSON string.
+
+    Walks the raw text tracking escapes so a `\\"` inside a string does not read
+    as a terminator. A trailing None close means the last string was never
+    closed — the truncation/missing-quote case.
+    """
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] != '"':
+            i += 1
+            continue
+        j = i + 1
+        while j < n:
+            c = text[j]
+            if c == '\\':
+                j += 2
+                continue
+            if c == '"':
+                break
+            j += 1
+        if j >= n:
+            yield i, None
+            return
+        yield i, j
+        i = j + 1
+
+
+def _close_unterminated_string(text):
+    """Close a string whose author dropped the final quote before a newline.
+
+    The 2026-07-28 case: `"…决策应等数据真口径` followed by `\n  ],`. Repaired by
+    inserting `"` at the end of that line — the text written stays exactly as
+    written, only the delimiter the author owed is supplied. Refuses when the
+    line looks mid-value (ends in `\\`) so a genuinely multi-line value is left
+    for `_escape_control_chars` instead.
+    """
+    for start, end in _iter_string_spans(text):
+        # A span that swallowed a newline is indistinguishable from a missing
+        # quote by scanning alone: the opener on the broken line simply pairs
+        # with the *next* line's opener. Both readings are handled — this pass
+        # takes the missing-quote reading, `_escape_control_chars` takes the
+        # multi-line-value reading, and `repair_json` keeps whichever parses.
+        if end is not None and '\n' not in text[start:end]:
+            continue
+        nl = text.find('\n', start + 1)
+        tail = text[start:] if nl == -1 else text[start:nl]
+        if tail.rstrip().endswith('\\'):
+            return None
+        # Insert the quote after the last non-blank character the author wrote,
+        # so trailing indentation stays outside the string.
+        cut = start + len(tail.rstrip())
+        return text[:cut] + '"' + text[cut:]
+    return None
+
+
+def _escape_control_chars(text):
+    """Escape raw newlines/tabs that sit inside a string literal.
+
+    A model writing a multi-line quote produces a literal 0x0A between the
+    quotes, which is exactly what `Invalid control character` reports. Only
+    characters strictly inside a span from `_iter_string_spans` are escaped, so
+    the newlines that format the document are untouched.
+    """
+    out, last, changed = [], 0, False
+    for start, end in _iter_string_spans(text):
+        if end is None:
+            break
+        body = text[start:end + 1]
+        escaped = (body.replace('\n', '\\n')
+                       .replace('\r', '\\r')
+                       .replace('\t', '\\t'))
+        if escaped != body:
+            changed = True
+        out.append(text[last:start])
+        out.append(escaped)
+        last = end + 1
+    if not changed:
+        return None
+    out.append(text[last:])
+    return ''.join(out)
+
+
+def _drop_trailing_comma(text):
+    """`[1, 2, ]` → `[1, 2]`. Purely artefact removal."""
+    repaired = _TRAILING_COMMA_RE.sub(r'\1', text)
+    return repaired if repaired != text else None
+
+
+def _close_open_containers(text):
+    """Append the `}`/`]` a truncated document never got to write.
+
+    Counts unclosed containers outside string literals and closes them in the
+    right order. Also drops a dangling `"key":` or trailing comma at the cut
+    point, since neither can be completed without inventing a value.
+    """
+    spans = [(s, e) for s, e in _iter_string_spans(text) if e is not None]
+
+    def in_string(idx):
+        return any(s <= idx <= e for s, e in spans)
+
+    stack = []
+    for i, ch in enumerate(text):
+        if in_string(i):
+            continue
+        if ch in '{[':
+            stack.append(ch)
+        elif ch in '}]':
+            if stack and stack[-1] == ('{' if ch == '}' else '['):
+                stack.pop()
+    if not stack:
+        return None
+    body = text.rstrip()
+    # A cut mid-pair leaves `"k":` or `"k": ` with nothing after it, and a cut
+    # right after an element leaves the separator. Neither is completable.
+    body = re.sub(r',\s*$', '', body)
+    body = re.sub(r'"[^"\n]*"\s*:\s*$', '', body).rstrip().rstrip(',')
+    return body + ''.join('}' if ch == '{' else ']' for ch in reversed(stack))
+
+
+# Name → pass. Cheapest and most localised first; `unterminated_string` precedes
+# `control_chars_in_string` because it is the likelier authoring slip, but that
+# preference is only a tiebreak. Correctness comes from the parser, not the
+# order: a dropped quote mispairs every quote after it, so the escaping reading
+# of such a file does not parse and the driver backs out of it. Verified by
+# mutation — swapping these two changes no test outcome.
+_PASSES = (
+    ('code_fence', _strip_code_fence),
+    ('prose_wrapper', _strip_prose_wrapper),
+    ('trailing_comma', _drop_trailing_comma),
+    ('unterminated_string', _close_unterminated_string),
+    ('control_chars_in_string', _escape_control_chars),
+    ('truncated_document', _close_open_containers),
+)
+
+
+def _search(text, used, depth):
+    """Depth-first over unused passes; a branch counts only when it parses.
+
+    Returns (obj, repairs) for the first branch the parser accepts, else
+    (None, []) — deliberately not the deepest partial attempt, because a list of
+    repairs that did not produce valid JSON would misreport what happened.
+    """
+    try:
+        return json.loads(text), []
+    except (json.JSONDecodeError, ValueError):
+        pass
+    if depth <= 0:
+        return None, []
+    for name, fn in _PASSES:
+        if name in used:
+            continue
+        try:
+            candidate = fn(text)
+        except Exception:
+            candidate = None
+        if candidate is None or candidate == text:
+            continue
+        obj, rest = _search(candidate, used | {name}, depth - 1)
+        if obj is not None:
+            return obj, [name] + rest
+    return None, []
+
+
+def repair_json(text):
+    """Parse `text`, repairing bounded syntax defects. → (obj_or_None, repairs).
+
+    `repairs` is the ordered list of pass names that fired; it is empty when the
+    input parsed strictly, which is the only case where the caller may stay
+    quiet. A None object means the text was beyond these passes — the caller
+    keeps its existing failure path.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None, []
+    # The strict-parse guarantee lives in `_search`'s first statement, so valid
+    # input returns before any pass runs. Do not re-add it here: a duplicate
+    # fast path reads like a safety net while being unreachable, and a mutation
+    # run proved deleting it changed nothing.
+    return _search(text, frozenset(), _MAX_DEPTH)
+
+
+def load_json_repaired(path, encoding='utf-8'):
+    """`repair_json` over a file. → (obj_or_None, repairs). Never raises on
+    malformed content; an unreadable path still raises, since that is not a
+    syntax defect and must not be mistaken for one."""
+    with open(path, encoding=encoding) as f:
+        return repair_json(f.read())
+
+
+def describe(repairs):
+    """One-line advisory text for a repair list ('' when nothing fired)."""
+    return f"repaired JSON ({', '.join(repairs)})" if repairs else ''

--- a/scripts/data/json_repair.py
+++ b/scripts/data/json_repair.py
@@ -5,9 +5,9 @@ json_repair.py — bounded, lossless recovery for hand-authored JSON sidecars.
 Every JSON file an agent writes by hand is one unescaped newline away from being
 unreadable. On 2026-07-28 the brief dropped the closing quote on the last
 `data_caveats` entry of `memory/.tmp/insights-2026-07-28.json`; `json.load`
-raised `Invalid control character at line 48`, `build_dashboard` lost the whole
-behavioural-review card group, and the daily health check went red — for one
-absent byte in 4,361.
+raised `Invalid control character at line 48`; `build_dashboard` fell through to
+its absent-source path and **republished the previous day's** behavioural-review
+cards, and the daily health check went red — for one absent byte in 4,361.
 
 ## The invariant, stated so it can be tested
 
@@ -53,14 +53,69 @@ import json
 import re
 
 # A file can carry more than one defect, so passes compose — but only to this
-# depth, and only through branches the parser accepts. With 4 passes that bounds
-# the search at 4·3·2 = 24 candidates.
+# depth, and only through branches the parser accepts. A pass may offer more than
+# one candidate, so the bound is depth × passes × candidates-per-pass rather than
+# a flat 4·3·2; `seen` keeps repeated texts from being re-explored.
 _MAX_DEPTH = 3
 
 CLEAN = 'clean'
 REPAIRED = 'repaired'
 AMBIGUOUS = 'ambiguous'
 UNREPAIRABLE = 'unrepairable'
+
+
+class _Rejected(ValueError):
+    """Parsed as JSON, but carries something no consumer of ours can accept."""
+
+
+def _no_duplicate_keys(pairs):
+    """`json.loads` keeps the last of duplicate keys and drops the rest silently.
+
+    That is a value deletion performed by the parser rather than by a pass, so it
+    slips past the invariant every pass is written to satisfy: `{"a":1,"a":"x"}`
+    would be reported as a successful repair having thrown away `1`.
+    """
+    seen = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise _Rejected(f'duplicate key {key!r}')
+        seen.add(key)
+    return dict(pairs)
+
+
+def _no_non_finite(token):
+    """`NaN`/`Infinity` are Python extensions, not JSON. Accepting them puts a
+    token no strict parser can read into the published dashboard payload."""
+    raise _Rejected(f'non-finite constant {token}')
+
+
+def _reject_lone_surrogates(value):
+    """A lone surrogate parses fine and then kills `payload.encode('utf-8')`.
+
+    `build_dashboard` encodes the finished payload, so one malformed sidecar
+    could abort the entire build — a strictly worse outcome than the missing
+    card this module exists to prevent. Valid surrogate *pairs* are untouched:
+    Python has already combined them into one astral character by this point, so
+    anything still in the surrogate range is unpaired.
+    """
+    if isinstance(value, str):
+        if any('\ud800' <= ch <= '\udfff' for ch in value):
+            raise _Rejected('lone surrogate')
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            _reject_lone_surrogates(k)
+            _reject_lone_surrogates(v)
+    elif isinstance(value, list):
+        for v in value:
+            _reject_lone_surrogates(v)
+    return value
+
+
+def _strict_loads(text):
+    """`json.loads` plus the three things it accepts that we cannot publish."""
+    return _reject_lone_surrogates(json.loads(
+        text, object_pairs_hook=_no_duplicate_keys, parse_constant=_no_non_finite,
+    ))
 
 _FENCE_RE = re.compile(r'^\s*```(?:json|JSON)?\s*\n(.*?)\n?\s*```\s*$', re.DOTALL)
 
@@ -245,7 +300,7 @@ def _accepting_branches(text, used, depth, found, seen):
         return
     seen.add(text)
     try:
-        found.append((json.loads(text), []))
+        found.append((_strict_loads(text), []))
         return
     except (json.JSONDecodeError, ValueError):
         pass
@@ -285,7 +340,7 @@ def repair_json(text):
     if not isinstance(text, str) or not text.strip():
         return None, [], UNREPAIRABLE
     try:
-        return json.loads(text), [], CLEAN
+        return _strict_loads(text), [], CLEAN
     except (json.JSONDecodeError, ValueError):
         pass
 

--- a/scripts/data/json_repair.py
+++ b/scripts/data/json_repair.py
@@ -48,6 +48,7 @@ caller may treat as unremarkable — a file needing repair every day is a produc
 bug, and a silent fixer would hide it forever (shared memory:
 `feedback-detect-but-never-silence`).
 """
+import bisect
 import json
 import re
 
@@ -93,12 +94,21 @@ def _iter_string_spans(text):
 
 
 def _outside_string(text):
-    """Set of indices that are not inside any string literal (quotes included)."""
-    inside = set()
+    """Predicate: is this index outside every string literal (quotes included)?
+
+    Returns a callable over sorted spans rather than a materialised index set —
+    the set cost O(len(text)) memory and dominated the runtime on large inputs.
+    """
+    starts, stops = [], []
     for start, end in _iter_string_spans(text):
-        stop = len(text) if end is None else end + 1
-        inside.update(range(start, stop))
-    return set(range(len(text))) - inside
+        starts.append(start)
+        stops.append(len(text) if end is None else end + 1)
+
+    def outside(i):
+        pos = bisect.bisect_right(starts, i) - 1
+        return pos < 0 or i >= stops[pos]
+
+    return outside
 
 
 def _strip_code_fence(text):
@@ -108,44 +118,64 @@ def _strip_code_fence(text):
 
 
 def _close_unterminated_string(text):
-    """Insert the closing quote the author owed, at the end of that line.
+    """Insert the closing quote the author owed. → every plausible position.
 
     Handles both a span that never closes and a span that swallowed a newline —
-    the two shapes a missing quote produces. Nothing is deleted; the text as
-    written is preserved and only the delimiter is supplied. Declines when the
-    line ends in a backslash, where the author was plainly still mid-value.
+    the two shapes a missing quote produces. Nothing is deleted; only the
+    delimiter is supplied.
+
+    Where the line has trailing whitespace the position is *itself* ambiguous:
+    `{"a":"kept   \\n}` can close before or after the spaces, both parse, and the
+    two disagree about whether the spaces are in the value. Returning only the
+    trimmed candidate silently deleted characters from inside a string — exactly
+    what this module forbids. Both are returned so the caller sees the
+    disagreement and refuses.
+
+    Declines on an *odd* run of trailing backslashes, where the author was still
+    mid-escape. An even run is a finished escaped backslash and is fine.
     """
     for start, end in _iter_string_spans(text):
         if end is not None and '\n' not in text[start:end]:
             continue
         nl = text.find('\n', start + 1)
         tail = text[start:] if nl == -1 else text[start:nl]
-        if tail.rstrip().endswith('\\'):
+        trimmed = tail.rstrip()
+        if (len(trimmed) - len(trimmed.rstrip('\\'))) % 2:
             return None
-        cut = start + len(tail.rstrip())
-        return text[:cut] + '"' + text[cut:]
+        cuts = {start + len(trimmed), start + len(tail)}
+        return [text[:c] + '"' + text[c:] for c in sorted(cuts)]
     return None
 
 
+_SHORT_ESCAPE = {'\n': '\\n', '\r': '\\r', '\t': '\\t',
+                 '\b': '\\b', '\f': '\\f'}
+
+
 def _escape_control_chars(text):
-    """Escape raw newlines/tabs that sit inside a string literal.
+    """Escape every raw U+0000–U+001F that sits inside a string literal.
 
     In place and value-preserving: the character survives as its JSON escape.
     Only characters strictly inside a closed span are touched, so the newlines
     that format the document are untouched.
+
+    All of C0 is covered, not just the three that are easy to picture: JSON
+    forbids the whole range raw, so handling `\\n`/`\\r`/`\\t` alone left NUL,
+    backspace, form feed and the separators reported as unrepairable while the
+    module claimed to escape "a character JSON forbids raw inside a string".
     """
     out, last, changed = [], 0, False
     for start, end in _iter_string_spans(text):
         if end is None:
             break
         body = text[start:end + 1]
-        escaped = (body.replace('\n', '\\n')
-                       .replace('\r', '\\r')
-                       .replace('\t', '\\t'))
-        if escaped != body:
+        if any(ch < ' ' for ch in body):
+            body = ''.join(
+                _SHORT_ESCAPE.get(ch, f'\\u{ord(ch):04x}') if ch < ' ' else ch
+                for ch in body
+            )
             changed = True
         out.append(text[last:start])
-        out.append(escaped)
+        out.append(body)
         last = end + 1
     if not changed:
         return None
@@ -161,19 +191,18 @@ def _drop_trailing_comma(text):
     separator — which is a value deletion, not an artefact removal.
     """
     outside = _outside_string(text)
-    drop = []
+    drop = set()
     for i, ch in enumerate(text):
-        if ch != ',' or i not in outside:
+        if ch != ',' or not outside(i):
             continue
         j = i + 1
         while j < len(text) and text[j] in ' \t\r\n':
             j += 1
-        if j < len(text) and text[j] in ']}' and j in outside:
-            drop.append(i)
+        if j < len(text) and text[j] in ']}' and outside(j):
+            drop.add(i)
     if not drop:
         return None
-    cut = set(drop)
-    return ''.join(c for i, c in enumerate(text) if i not in cut)
+    return ''.join(c for i, c in enumerate(text) if i not in drop)
 
 
 # Tried in this order, but order is only a tiebreak: correctness comes from
@@ -203,8 +232,18 @@ def _json_equal(a, b):
     return a == b
 
 
-def _accepting_branches(text, used, depth, found):
-    """Collect (object, repairs) for every accepting branch within the bound."""
+def _accepting_branches(text, used, depth, found, seen):
+    """Collect (object, repairs) for every accepting branch within the bound.
+
+    A pass may offer several candidates — a missing quote has more than one
+    plausible insertion point — and each is explored, because a disagreement
+    *within* one pass is exactly as much of a guess as a disagreement between
+    two. `seen` dedupes texts so the same document reached by two pass orderings
+    is not enumerated (or reported) twice.
+    """
+    if text in seen:
+        return
+    seen.add(text)
     try:
         found.append((json.loads(text), []))
         return
@@ -216,14 +255,18 @@ def _accepting_branches(text, used, depth, found):
         if name in used:
             continue
         try:
-            candidate = fn(text)
+            produced = fn(text)
         except Exception:
-            candidate = None
-        if candidate is None or candidate == text:
+            produced = None
+        if produced is None:
             continue
-        nested = []
-        _accepting_branches(candidate, used | {name}, depth - 1, nested)
-        found.extend((obj, [name] + rest) for obj, rest in nested)
+        candidates = produced if isinstance(produced, list) else [produced]
+        for candidate in candidates:
+            if candidate == text:
+                continue
+            nested = []
+            _accepting_branches(candidate, used | {name}, depth - 1, nested, seen)
+            found.extend((obj, [name] + rest) for obj, rest in nested)
 
 
 def repair_json(text):
@@ -247,7 +290,7 @@ def repair_json(text):
         pass
 
     found = []
-    _accepting_branches(text, frozenset(), _MAX_DEPTH, found)
+    _accepting_branches(text, frozenset(), _MAX_DEPTH, found, set())
     if not found:
         return None, [], UNREPAIRABLE
     first = found[0][0]

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -206,10 +206,19 @@ def _record_dashboard_build(ok, output, ws=None):
             1 for ln in (output or '').splitlines()
             if 'warn:' in ln or '⚠' in ln or 'FATAL' in ln
         )
+        # Counted apart from warn_count on purpose: a repaired sidecar rendered
+        # its card, so the build is not degraded and must not ride the health
+        # check's exit 2. But an agent that ships invalid JSON every morning is a
+        # producer bug, and a repair nobody ever sees is the silent fixer this
+        # was explicitly not supposed to become.
+        repair_count = sum(
+            1 for ln in (output or '').splitlines() if 'repair:' in ln
+        )
         status = {
             'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
             'ok': bool(ok),
             'warn_count': warn_count,
+            'repair_count': repair_count,
             'tail': (output or '')[-500:],
         }
         path = ws / DASHBOARD_BUILD_STATUS
@@ -222,6 +231,9 @@ def _record_dashboard_build(ok, output, ws=None):
         elif warn_count:
             print(f'⚠️  build_dashboard ok but {warn_count} degraded section(s) — '
                   f'see {DASHBOARD_BUILD_STATUS}', file=sys.stderr)
+        elif repair_count:
+            print(f'🔧 build_dashboard ok, {repair_count} sidecar(s) needed JSON '
+                  f'repair — see {DASHBOARD_BUILD_STATUS}', file=sys.stderr)
     except Exception as e:
         print(f'(could not record dashboard build status: {e})', file=sys.stderr)
 

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -41,6 +41,7 @@ import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 import brief_context  # noqa: E402
 import brief_decision_packet  # noqa: E402
+import json_repair  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases
@@ -127,12 +128,22 @@ def validate_generation_references(plan, context=None):
 def validate_plan_json(path, context=None, decision_packet=None):
     if not path.exists():
         return ['plan.json 缺失（critical）']
-    try:
-        plan = json.loads(path.read_text())
-    except json.JSONDecodeError as e:
-        return [f'plan.json 解析失败: {e}']
+    # The whole day's plan is hand-written by the model; before json_repair a
+    # dropped quote in one rationale threw away every decision in the file and
+    # the brief died on a syntax error. Repair recovers the decisions, and says
+    # so — advisory, because the plan then validates like any other (an actually
+    # unrepairable plan keeps the original hard failure below).
+    plan, repairs = json_repair.load_json_repaired(path)
+    if plan is None:
+        return ['plan.json 解析失败: 语法错误无法自动修复']
+    if not isinstance(plan, dict):
+        return [f'plan.json 解析失败: 顶层应为 object，实际是 {type(plan).__name__}']
 
-    issues = [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
+    issues = []
+    if repairs:
+        issues.append(f'plan.json JSON 语法有缺陷，已自动修复后校验'
+                      f'（{", ".join(repairs)}）{ADVISORY_MARK}')
+    issues += [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
     issues += validate_generation_references(plan, context)
     if decision_packet:
         issues += [
@@ -311,6 +322,7 @@ def categorize(issues):
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _harness_common import (  # noqa: E402
+    ADVISORY_MARK,
     categorize_issues,
     dashboard_output_changes,
     git_cmd as _git,

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -41,7 +41,6 @@ import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 import brief_context  # noqa: E402
 import brief_decision_packet  # noqa: E402
-import json_repair  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases
@@ -128,22 +127,12 @@ def validate_generation_references(plan, context=None):
 def validate_plan_json(path, context=None, decision_packet=None):
     if not path.exists():
         return ['plan.json 缺失（critical）']
-    # The whole day's plan is hand-written by the model; before json_repair a
-    # dropped quote in one rationale threw away every decision in the file and
-    # the brief died on a syntax error. Repair recovers the decisions, and says
-    # so — advisory, because the plan then validates like any other (an actually
-    # unrepairable plan keeps the original hard failure below).
-    plan, repairs = json_repair.load_json_repaired(path)
-    if plan is None:
-        return ['plan.json 解析失败: 语法错误无法自动修复']
-    if not isinstance(plan, dict):
-        return [f'plan.json 解析失败: 顶层应为 object，实际是 {type(plan).__name__}']
+    try:
+        plan = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return [f'plan.json 解析失败: {e}']
 
-    issues = []
-    if repairs:
-        issues.append(f'plan.json JSON 语法有缺陷，已自动修复后校验'
-                      f'（{", ".join(repairs)}）{ADVISORY_MARK}')
-    issues += [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
+    issues = [f'plan.json v2: {x}' for x in decision_v2.validate_plan(plan, path)]
     issues += validate_generation_references(plan, context)
     if decision_packet:
         issues += [
@@ -322,7 +311,6 @@ def categorize(issues):
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _harness_common import (  # noqa: E402
-    ADVISORY_MARK,
     categorize_issues,
     dashboard_output_changes,
     git_cmd as _git,

--- a/tests/fixtures/insights-unterminated-quote.json
+++ b/tests/fixtures/insights-unterminated-quote.json
@@ -1,0 +1,83 @@
+{
+  "generated_at": "2026-07-28T08:09:00+08:00",
+  "date": "2026-07-28",
+  "behavioral_review": {
+    "verdict": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "points": [
+      {
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "tag": "xxxx"
+      },
+      {
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "tag": "xxxx"
+      },
+      {
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "tag": "xxxxxxx"
+      },
+      {
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "tag": "xxxxxxx"
+      },
+      {
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "tag": "xxxx"
+      }
+    ]
+  },
+  "bear_cases": [
+    {
+      "ticker": "xxxxx",
+      "thesis": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "falsifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "watch": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    {
+      "ticker": "xxxx",
+      "thesis": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "falsifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "watch": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    {
+      "ticker": "xxxx",
+      "thesis": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "falsifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "watch": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    }
+  ],
+  "hidden_concentration": {
+    "headline": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "factor": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "exposure_pct": 88,
+    "detail": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  },
+  "thesis_uncertainty": {
+    "note": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "affected_tickers": [
+      "xxxxx",
+      "xxxxx",
+      "xxxxx",
+      "xxxxx",
+      "xxxxx",
+      "xxxx",
+      "xxxx",
+      "xxxx",
+      "xxxx",
+      "xxxx",
+      "xxxx",
+      "xxxx"
+    ],
+    "next_step": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  },
+  "data_caveats": [
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  ],
+  "watchlist_for_kcn_review": [
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  ]
+}

--- a/tests/fixtures/insights-unterminated-quote.json
+++ b/tests/fixtures/insights-unterminated-quote.json
@@ -49,7 +49,7 @@
   "hidden_concentration": {
     "headline": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "factor": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "exposure_pct": 88,
+    "exposure_pct": 0,
     "detail": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   },
   "thesis_uncertainty": {
@@ -73,11 +73,11 @@
   "data_caveats": [
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   ],
   "watchlist_for_kcn_review": [
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   ]
 }

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -1,0 +1,170 @@
+"""json_repair — recovery of LLM-authored JSON, and the limits of that recovery.
+
+The failure this exists for (2026-07-28): the daily brief wrote
+`memory/.tmp/insights-2026-07-28.json` with the closing quote missing from the
+last `data_caveats` entry. `json.load` raised, build_dashboard dropped the
+behavioural-review / bear-case / concentration cards, and the daily Cron Health
+Check went red — for one absent byte.
+
+Tests are grouped by the property they defend, because two of them matter more
+than any single repair case:
+  * valid JSON is returned byte-identical, with zero repairs reported;
+  * a repair never invents a value, and never silently changes the *shape* of
+    the document (the unterminated-vs-multiline ambiguity below).
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts' / 'data'))
+import json_repair  # noqa: E402
+
+
+# ── The production failure, verbatim ──────────────────────────────────────────
+
+BROKEN_INSIGHTS = '''{
+  "generated_at": "2026-07-28T08:09:00+08:00",
+  "date": "2026-07-28",
+  "behavioral_review": [
+    {"tag": "bias", "text": "\\u8ffd\\u9ad8"}
+  ],
+  "data_caveats": [
+    "US 7 \\u4e2a\\u6301\\u4ed3 data_source \\u6807 2026-07-27",
+    "FOMC 7/29 + MSFT AMC 7/29 \\u90fd\\u5728\\u4eca\\u665a\\u7f8e\\u80a1\\u7a97\\u53e3
+  ],
+  "watchlist_for_kcn_review": [
+    "MSFU swap"
+  ]
+}
+'''
+
+
+def test_missing_closing_quote_recovers_every_key():
+    """The 07-28 shape: the repair must not eat the key that follows."""
+    obj, repairs = json_repair.repair_json(BROKEN_INSIGHTS)
+
+    assert repairs == ['unterminated_string']
+    # Pinning the whole key list, not just the caveat: any repair that recovers
+    # the file by folding following lines into the broken string would still
+    # produce a parseable object, and only the shape shows it went wrong.
+    assert list(obj) == ['generated_at', 'date', 'behavioral_review',
+                         'data_caveats', 'watchlist_for_kcn_review']
+    assert len(obj['data_caveats']) == 2
+    assert obj['data_caveats'][1].endswith('窗口')
+    assert obj['watchlist_for_kcn_review'] == ['MSFU swap']
+
+
+# ── Property: valid input is never touched ────────────────────────────────────
+
+@pytest.mark.parametrize('text', [
+    '{"a": [1, 2], "b": "x"}',
+    '{"a": "he said \\"hi\\", then left"}',
+    '{"a": "escaped\\nnewline is fine"}',
+    '[]',
+    '{}',
+    '  {"padded": true}\n\n',
+    '{"unicode": "港股 25,236 ▲0.11%"}',
+])
+def test_valid_json_reports_no_repairs(text):
+    obj, repairs = json_repair.repair_json(text)
+    assert repairs == []
+    assert obj == json.loads(text)
+
+
+def test_a_string_containing_braces_is_not_treated_as_prose():
+    """`_strip_prose_wrapper` must not cut inside a string value."""
+    text = '{"note": "use {a: 1} as the shape"}'
+    obj, repairs = json_repair.repair_json(text)
+    assert repairs == []
+    assert obj['note'] == 'use {a: 1} as the shape'
+
+
+# ── Each repair pass, on the defect it owns ───────────────────────────────────
+
+@pytest.mark.parametrize('name,text,expected', [
+    ('code_fence', '```json\n{"a": 1}\n```', {'a': 1}),
+    ('code_fence', '```\n{"a": 1}\n```', {'a': 1}),
+    ('prose_wrapper', 'Sure, here it is:\n{"a": 1}\nlet me know', {'a': 1}),
+    ('trailing_comma', '{"a": [1, 2,],}', {'a': [1, 2]}),
+    ('unterminated_string', '{\n "a": [\n  "one",\n  "two\n ]\n}',
+     {'a': ['one', 'two']}),
+    ('control_chars_in_string', '{"a": "line1\nline2"}', {'a': 'line1\nline2'}),
+    ('truncated_document', '{"a": [1, 2, 3], "b": {"c": ', {'a': [1, 2, 3], 'b': {}}),
+    ('truncated_document', '{"a": ["x", "y",', {'a': ['x', 'y']}),
+    ('truncated_document', '{"a": 1, "b":', {'a': 1}),
+])
+def test_single_defect_is_repaired_and_named(name, text, expected):
+    obj, repairs = json_repair.repair_json(text)
+    assert obj == expected
+    assert repairs == [name]
+
+
+def test_passes_compose_when_a_file_carries_two_defects():
+    obj, repairs = json_repair.repair_json('```json\n{"a": [1, 2\n```')
+    assert obj == {'a': [1, 2]}
+    assert repairs == ['code_fence', 'truncated_document']
+
+
+def test_multiline_value_keeps_the_multiline_reading():
+    """The mirror of the 07-28 case: here the newline really is inside the value.
+
+    Closing the string at the line break would leave `line2", "b": 2}` dangling,
+    so that branch does not parse and the driver backs out of it. This is the
+    property the whole design rests on — the parser picks the reading, the pass
+    order is only a tiebreak — so it is asserted directly rather than inferred
+    from the ordering of `_PASSES`.
+    """
+    obj, repairs = json_repair.repair_json('{"a": "line1\nline2", "b": 2}')
+    assert obj == {'a': 'line1\nline2', 'b': 2}
+    assert repairs == ['control_chars_in_string']
+
+    # Same driver, opposite verdict, on the same class of defect.
+    obj, repairs = json_repair.repair_json('{"a": "line1\n, "b": 2}')
+    assert obj == {'a': 'line1', 'b': 2}
+    assert repairs == ['unterminated_string']
+
+
+# ── Property: unrepairable stays unrepairable ─────────────────────────────────
+
+@pytest.mark.parametrize('text', [
+    'not json at all',
+    '',
+    '   ',
+    'null and then some',
+    '{"a": 1} {"b": 2}',   # two documents — no single object to recover
+])
+def test_beyond_repair_returns_none_and_claims_nothing(text):
+    obj, repairs = json_repair.repair_json(text)
+    assert obj is None
+    # A repair list on a failed parse would misreport what happened: nothing was
+    # recovered, so nothing may be claimed.
+    assert repairs == []
+
+
+def test_non_string_input_is_rejected_rather_than_coerced():
+    assert json_repair.repair_json(None) == (None, [])
+    assert json_repair.repair_json(b'{"a": 1}') == (None, [])
+
+
+# ── File helper + reporting ───────────────────────────────────────────────────
+
+def test_load_json_repaired_reads_and_reports(tmp_path):
+    p = tmp_path / 'insights-2026-07-28.json'
+    p.write_text(BROKEN_INSIGHTS, encoding='utf-8')
+    obj, repairs = json_repair.load_json_repaired(p)
+    assert obj['date'] == '2026-07-28'
+    assert repairs == ['unterminated_string']
+
+
+def test_a_missing_file_still_raises():
+    """Absence is not a syntax defect; swallowing it here would hide a producer
+    that stopped writing at all behind a 'repaired' label."""
+    with pytest.raises(OSError):
+        json_repair.load_json_repaired('/nonexistent/insights.json')
+
+
+def test_describe_is_empty_for_clean_input():
+    assert json_repair.describe([]) == ''
+    assert 'unterminated_string' in json_repair.describe(['unterminated_string'])

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -163,6 +163,51 @@ def test_every_c0_control_character_is_escaped(raw):
     assert obj == {'a': f'x{raw}y'}
 
 
+# ── Refusal: what the parser accepts but we cannot publish ───────────────────
+
+def test_duplicate_keys_are_rejected_rather_than_collapsed():
+    """`json.loads` keeps the last duplicate and drops the rest without a word.
+
+    That is a value deletion carried out by the parser instead of by a pass, so
+    it slips past every invariant the passes were written to satisfy: the input
+    below would otherwise report a successful repair having thrown away `1`.
+    """
+    obj, repairs, status = json_repair.repair_json('{"a":1,"a":"x\n}')
+
+    assert status == UNREPAIRABLE
+    assert obj is None
+
+
+@pytest.mark.parametrize('text', ['{"a": NaN}', '{"a": Infinity}', '{"a": -Infinity}'])
+def test_non_finite_constants_are_rejected(text):
+    """Python extensions, not JSON. Accepting them writes a token no strict
+    parser can read into the published dashboard payload."""
+    obj, repairs, status = json_repair.repair_json(text)
+
+    assert status == UNREPAIRABLE
+
+
+def test_a_lone_surrogate_is_rejected_before_it_can_abort_the_build():
+    """`"\\ud800"` parses fine, then kills `payload.encode('utf-8')` in
+    build_dashboard — one malformed sidecar aborting the entire build is
+    strictly worse than the missing card this module exists to prevent."""
+    obj, repairs, status = json_repair.repair_json('{"status_banner": "\\ud800"}')
+
+    assert status == UNREPAIRABLE
+    assert obj is None
+
+
+def test_a_valid_surrogate_pair_still_loads():
+    """The rejection must not catch astral characters — kcn's sidecars carry
+    emoji. By this point Python has already combined a valid pair into one
+    character, so anything left in the surrogate range is genuinely unpaired."""
+    obj, repairs, status = json_repair.repair_json('{"a": "\\ud83d\\ude00 ok"}')
+
+    assert status == CLEAN
+    assert obj == {'a': '😀 ok'}
+    json.dumps(obj, ensure_ascii=False).encode('utf-8')   # the call that crashed
+
+
 def test_competing_readings_are_refused_not_guessed():
     """A dropped quote and a raw newline are indistinguishable by scanning, and
     here both readings parse to *different* objects. Picking one would be a
@@ -290,10 +335,12 @@ FIXTURE = Path(__file__).parent / 'fixtures' / 'insights-unterminated-quote.json
 def test_the_full_production_shape_recovers_whole():
     """The inline fixture above is reduced to the defect and its neighbours; this
     is the whole 2026-07-28 document — all eight keys, the real nesting, the
-    defect in its original position — with every string value replaced by
-    placeholders, because this repository is public and the sidecar carries kcn's
-    portfolio commentary. Verified to produce the same status, the same pass list
-    and the same key count as the file that actually broke."""
+    defect in its original position — with every narrative string and every
+    number replaced by placeholders, because this repository is public and the
+    sidecar carries kcn's portfolio commentary. `generated_at` and `date` are
+    kept as schema-shaped literals so the document still looks like what the
+    brief writes. Verified to produce the same status, the same pass list and the
+    same key count as the file that actually broke."""
     obj, repairs, status = json_repair.load_json_repaired(FIXTURE)
 
     assert status == REPAIRED
@@ -314,9 +361,14 @@ def test_the_fixture_keeps_the_defect_where_it_really_was():
     one.
     """
     raw = FIXTURE.read_text(encoding='utf-8')
-    defect = next(i for i, line in enumerate(raw.split('\n'))
-                  if line.count('"') % 2)
-    before, after = raw.split('\n')[:defect], raw.split('\n')[defect:]
+    # Locate the defect the way the repairer does. Counting raw quotes per line
+    # is unsound: a valid string holding one escaped quote also has an odd count,
+    # so that heuristic can point at a healthy line and pass while the real
+    # defect sits somewhere else entirely.
+    start = next(s for s, end in json_repair._iter_string_spans(raw)
+                 if end is None or '\n' in raw[s:end])
+    lines = raw.split('\n')
+    defect = raw[:start].count('\n')
 
-    assert any('"data_caveats"' in line for line in before)
-    assert any('"watchlist_for_kcn_review"' in line for line in after)
+    assert any('"data_caveats"' in line for line in lines[:defect])
+    assert any('"watchlist_for_kcn_review"' in line for line in lines[defect:])

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -113,6 +113,56 @@ def test_a_comma_value_survives_alongside_a_real_defect():
 
 # ── Refusal: competing readings ──────────────────────────────────────────────
 
+def test_an_ambiguous_insertion_point_is_refused_too():
+    """Ambiguity inside ONE pass counts, not just between two passes.
+
+    `{"a":"kept   \\n}` can be closed before or after the trailing spaces. Both
+    parse; they disagree about whether the spaces belong to the value. Emitting
+    only the trimmed candidate deleted characters from inside a string literal —
+    the exact thing the module's invariant forbids — while reporting `repaired`.
+    """
+    obj, repairs, status = json_repair.repair_json('{"a":"kept   \n}')
+
+    assert status == AMBIGUOUS
+    assert obj is None
+
+
+def test_a_line_without_trailing_space_has_only_one_insertion_point():
+    """The common case must not become ambiguous just because the search widened."""
+    obj, repairs, status = json_repair.repair_json('{"a": 1, "b": "tail\n}')
+
+    assert status == REPAIRED
+    assert obj == {'a': 1, 'b': 'tail'}
+
+
+@pytest.mark.parametrize('text,expected', [
+    ('{"path":"C:\\\\\n}', {'path': 'C:\\'}),          # even run: escape finished
+    ('{"path":"C:\\\\\\\\\n}', {'path': 'C:\\\\'}),
+])
+def test_an_even_backslash_run_is_a_finished_escape(text, expected):
+    """`endswith('\\\\')` rejected even runs as if mid-escape. Only odd parity is."""
+    obj, repairs, status = json_repair.repair_json(text)
+
+    assert status == REPAIRED
+    assert obj == expected
+
+
+def test_an_odd_backslash_run_still_declines():
+    obj, repairs, status = json_repair.repair_json('{"path":"C:\\\n}')
+
+    assert status == UNREPAIRABLE
+
+
+@pytest.mark.parametrize('raw', ['\x00', '\x08', '\x0b', '\x0c', '\x1f', '\t', '\n', '\r'])
+def test_every_c0_control_character_is_escaped(raw):
+    """JSON forbids all of U+0000–U+001F raw. Handling only \\n/\\r/\\t left NUL,
+    backspace, form feed and the separators reported as unrepairable."""
+    obj, repairs, status = json_repair.repair_json('{"a": "x%sy"}' % raw)
+
+    assert status == REPAIRED
+    assert obj == {'a': f'x{raw}y'}
+
+
 def test_competing_readings_are_refused_not_guessed():
     """A dropped quote and a raw newline are indistinguishable by scanning, and
     here both readings parse to *different* objects. Picking one would be a
@@ -253,3 +303,20 @@ def test_the_full_production_shape_recovers_whole():
                          'data_caveats', 'watchlist_for_kcn_review']
     # The key after the broken array is the one a folding repair would eat.
     assert obj['watchlist_for_kcn_review']
+
+
+def test_the_fixture_keeps_the_defect_where_it_really_was():
+    """The defect must sit in `data_caveats`, with a sibling key still after it.
+
+    An earlier fixture moved it to the final key, which quietly removed the very
+    shape the test above exists to defend — with nothing following the defect,
+    a repair that swallows the rest of the document looks identical to a correct
+    one.
+    """
+    raw = FIXTURE.read_text(encoding='utf-8')
+    defect = next(i for i, line in enumerate(raw.split('\n'))
+                  if line.count('"') % 2)
+    before, after = raw.split('\n')[:defect], raw.split('\n')[defect:]
+
+    assert any('"data_caveats"' in line for line in before)
+    assert any('"watchlist_for_kcn_review"' in line for line in after)

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -234,17 +234,22 @@ def test_describe_is_empty_for_clean_input():
     assert 'unterminated_string' in json_repair.describe(['unterminated_string'])
 
 
-REAL_BROKEN = Path('/root/.openclaw/workspace/memory/.tmp/'
-                   'insights-2026-07-28.json.broken.bak')
+FIXTURE = Path(__file__).parent / 'fixtures' / 'insights-unterminated-quote.json'
 
 
-@pytest.mark.skipif(not REAL_BROKEN.exists(), reason='host-only artefact')
-def test_the_real_production_file_recovers_whole():
-    """The reduced fixture above proves the shape; this proves the real 4,361-byte
-    nested document, kept on the host after the incident."""
-    obj, repairs, status = json_repair.load_json_repaired(REAL_BROKEN)
+def test_the_full_production_shape_recovers_whole():
+    """The inline fixture above is reduced to the defect and its neighbours; this
+    is the whole 2026-07-28 document — all eight keys, the real nesting, the
+    defect in its original position — with every string value replaced by
+    placeholders, because this repository is public and the sidecar carries kcn's
+    portfolio commentary. Verified to produce the same status, the same pass list
+    and the same key count as the file that actually broke."""
+    obj, repairs, status = json_repair.load_json_repaired(FIXTURE)
 
     assert status == REPAIRED
     assert repairs == ['unterminated_string']
-    assert len(obj) == 8
+    assert list(obj) == ['generated_at', 'date', 'behavioral_review', 'bear_cases',
+                         'hidden_concentration', 'thesis_uncertainty',
+                         'data_caveats', 'watchlist_for_kcn_review']
+    # The key after the broken array is the one a folding repair would eat.
     assert obj['watchlist_for_kcn_review']

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -1,16 +1,22 @@
-"""json_repair — recovery of LLM-authored JSON, and the limits of that recovery.
+"""json_repair — what it recovers, and the far more important list of what it refuses.
 
 The failure this exists for (2026-07-28): the daily brief wrote
 `memory/.tmp/insights-2026-07-28.json` with the closing quote missing from the
-last `data_caveats` entry. `json.load` raised, build_dashboard dropped the
+last `data_caveats` entry. `json.load` raised, `build_dashboard` dropped the
 behavioural-review / bear-case / concentration cards, and the daily Cron Health
-Check went red — for one absent byte.
+Check went red — for one absent byte in 4,361.
 
-Tests are grouped by the property they defend, because two of them matter more
-than any single repair case:
-  * valid JSON is returned byte-identical, with zero repairs reported;
-  * a repair never invents a value, and never silently changes the *shape* of
-    the document (the unterminated-vs-multiline ambiguity below).
+Two earlier designs of this module were rejected for silently destroying data,
+and the tests that would have caught them are the point of this file:
+
+  * cutting to the outermost balanced value ("strip the prose") deletes a whole
+    second document in `{"kept":1}\\n{"lost":2}`;
+  * closing a truncated document turns "the file was cut off" into "a valid
+    document with fewer items" — for a plan, decisions silently vanishing.
+
+Both are now non-goals: those inputs must fail loudly. The suite is organised by
+the property defended, not by function, because the refusals are what keep the
+recoveries safe.
 """
 import json
 import sys
@@ -20,151 +26,225 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts' / 'data'))
 import json_repair  # noqa: E402
+from json_repair import AMBIGUOUS, CLEAN, REPAIRED, UNREPAIRABLE  # noqa: E402
 
 
-# ── The production failure, verbatim ──────────────────────────────────────────
-
+# The 2026-07-28 shape, reduced to the defect and its neighbours: a caveat whose
+# closing quote is missing, with a further key after the array. The real file is
+# larger; `test_the_real_production_file_recovers_whole` reads it when present.
 BROKEN_INSIGHTS = '''{
   "generated_at": "2026-07-28T08:09:00+08:00",
-  "date": "2026-07-28",
   "behavioral_review": [
-    {"tag": "bias", "text": "\\u8ffd\\u9ad8"}
+    {"tag": "bias", "text": "chased the gap"}
   ],
   "data_caveats": [
-    "US 7 \\u4e2a\\u6301\\u4ed3 data_source \\u6807 2026-07-27",
-    "FOMC 7/29 + MSFT AMC 7/29 \\u90fd\\u5728\\u4eca\\u665a\\u7f8e\\u80a1\\u7a97\\u53e3
+    "US data_source stamped 2026-07-27",
+    "FOMC 7/29 + MSFT AMC 7/29 both land in tonight's US window
   ],
-  "watchlist_for_kcn_review": [
-    "MSFU swap"
-  ]
+  "watchlist_for_kcn_review": ["MSFU swap"]
 }
 '''
 
 
 def test_missing_closing_quote_recovers_every_key():
-    """The 07-28 shape: the repair must not eat the key that follows."""
-    obj, repairs = json_repair.repair_json(BROKEN_INSIGHTS)
+    obj, repairs, status = json_repair.repair_json(BROKEN_INSIGHTS)
 
+    assert status == REPAIRED
     assert repairs == ['unterminated_string']
-    # Pinning the whole key list, not just the caveat: any repair that recovers
-    # the file by folding following lines into the broken string would still
-    # produce a parseable object, and only the shape shows it went wrong.
-    assert list(obj) == ['generated_at', 'date', 'behavioral_review',
-                         'data_caveats', 'watchlist_for_kcn_review']
+    # The key list, not just parseability: a repair that folded the following
+    # lines into the broken string would also parse, and would silently eat
+    # `watchlist_for_kcn_review`. Only the shape shows the difference.
+    assert list(obj) == ['generated_at', 'behavioral_review', 'data_caveats',
+                         'watchlist_for_kcn_review']
     assert len(obj['data_caveats']) == 2
-    assert obj['data_caveats'][1].endswith('窗口')
+    assert obj['data_caveats'][1].endswith("tonight's US window")
     assert obj['watchlist_for_kcn_review'] == ['MSFU swap']
 
 
-# ── Property: valid input is never touched ────────────────────────────────────
+# ── Refusals: the passes that were removed must stay removed ─────────────────
+
+def test_two_balanced_documents_are_not_silently_truncated_to_one():
+    """The input that killed the prose-stripping pass.
+
+    The whole text is bracket-balanced, so matching brackets from the first `{`
+    yields a document that parses — while deleting the second one. Parser
+    acceptance says nothing about whether the discarded suffix was noise, so
+    this must fail rather than pick.
+    """
+    obj, repairs, status = json_repair.repair_json(
+        'model output:\n{"kept": 1}\n{"lost": 2}'
+    )
+
+    assert status == UNREPAIRABLE
+    assert obj is None
+
+
+@pytest.mark.parametrize('text', [
+    '[[1],2',                                  # inner closer is not the document's
+    '{"a": [1, 2, 3], "b": {"c": ',
+    '{"decisions": [{"ticker": "PLTU"}, {"ticker": "SPCH"',
+    '{"a": 1, "b":',
+])
+def test_a_truncated_document_fails_loudly(text):
+    """Truncation means data is already gone. Closing over the loss would
+    republish a shorter document as if it were whole — for a day's plan, that is
+    decisions disappearing with nothing to show for it."""
+    obj, repairs, status = json_repair.repair_json(text)
+
+    assert status == UNREPAIRABLE
+    assert obj is None
+
+
+def test_a_comma_that_is_a_value_is_not_deleted():
+    """A blanket trailing-comma regex deletes the second element here, because a
+    string containing a comma sits immediately before the closer."""
+    obj, repairs, status = json_repair.repair_json('["a", ","]')
+
+    assert status == CLEAN
+    assert obj == ['a', ',']
+
+
+def test_a_comma_value_survives_alongside_a_real_defect():
+    obj, repairs, status = json_repair.repair_json('[\n  "a\n",\n  ",\n]')
+
+    assert status == REPAIRED
+    assert obj == ['a\n', ',']
+
+
+# ── Refusal: competing readings ──────────────────────────────────────────────
+
+def test_competing_readings_are_refused_not_guessed():
+    """A dropped quote and a raw newline are indistinguishable by scanning, and
+    here both readings parse to *different* objects. Picking one would be a
+    guess dressed as a repair."""
+    obj, repairs, status = json_repair.repair_json('[\n "a\n,",\n "\n]')
+
+    assert status == AMBIGUOUS
+    assert obj is None
+    assert 'ambiguous' in json_repair.describe(repairs, status)
+
+
+def test_type_differences_count_as_disagreement():
+    """`True == 1` and `1 == 1.0` in Python. If branch comparison used plain
+    equality, two readings that disagree about a value's JSON type would pass as
+    agreeing."""
+    assert json_repair._json_equal({'a': True}, {'a': 1}) is False
+    assert json_repair._json_equal({'a': 1}, {'a': 1.0}) is False
+    assert json_repair._json_equal({'a': [1, {'b': None}]}, {'a': [1, {'b': None}]})
+
+
+# ── Property: valid input is never touched ───────────────────────────────────
 
 @pytest.mark.parametrize('text', [
     '{"a": [1, 2], "b": "x"}',
     '{"a": "he said \\"hi\\", then left"}',
     '{"a": "escaped\\nnewline is fine"}',
-    '[]',
-    '{}',
-    '  {"padded": true}\n\n',
+    '{"note": "use {a: 1} as the shape"}',
+    '{"csv": "a,b,c"}',
+    '[]', '{}', '  {"padded": true}\n\n',
     '{"unicode": "港股 25,236 ▲0.11%"}',
 ])
-def test_valid_json_reports_no_repairs(text):
-    obj, repairs = json_repair.repair_json(text)
+def test_valid_json_is_clean_and_unchanged(text):
+    obj, repairs, status = json_repair.repair_json(text)
+
+    assert status == CLEAN
     assert repairs == []
     assert obj == json.loads(text)
 
 
-def test_a_string_containing_braces_is_not_treated_as_prose():
-    """`_strip_prose_wrapper` must not cut inside a string value."""
-    text = '{"note": "use {a: 1} as the shape"}'
-    obj, repairs = json_repair.repair_json(text)
-    assert repairs == []
-    assert obj['note'] == 'use {a: 1} as the shape'
-
-
-# ── Each repair pass, on the defect it owns ───────────────────────────────────
+# ── Each surviving pass, on the defect it owns ───────────────────────────────
 
 @pytest.mark.parametrize('name,text,expected', [
     ('code_fence', '```json\n{"a": 1}\n```', {'a': 1}),
     ('code_fence', '```\n{"a": 1}\n```', {'a': 1}),
-    ('prose_wrapper', 'Sure, here it is:\n{"a": 1}\nlet me know', {'a': 1}),
     ('trailing_comma', '{"a": [1, 2,],}', {'a': [1, 2]}),
+    ('trailing_comma', '[1, 2,]', [1, 2]),
     ('unterminated_string', '{\n "a": [\n  "one",\n  "two\n ]\n}',
      {'a': ['one', 'two']}),
+    ('unterminated_string', '{"a": 1, "b": "tail\n}', {'a': 1, 'b': 'tail'}),
     ('control_chars_in_string', '{"a": "line1\nline2"}', {'a': 'line1\nline2'}),
-    ('truncated_document', '{"a": [1, 2, 3], "b": {"c": ', {'a': [1, 2, 3], 'b': {}}),
-    ('truncated_document', '{"a": ["x", "y",', {'a': ['x', 'y']}),
-    ('truncated_document', '{"a": 1, "b":', {'a': 1}),
+    ('control_chars_in_string', '{"a": "col1\tcol2"}', {'a': 'col1\tcol2'}),
 ])
 def test_single_defect_is_repaired_and_named(name, text, expected):
-    obj, repairs = json_repair.repair_json(text)
+    obj, repairs, status = json_repair.repair_json(text)
+
+    assert status == REPAIRED
     assert obj == expected
     assert repairs == [name]
 
 
 def test_passes_compose_when_a_file_carries_two_defects():
-    obj, repairs = json_repair.repair_json('```json\n{"a": [1, 2\n```')
+    obj, repairs, status = json_repair.repair_json('```json\n{"a": [1, 2,],}\n```')
+
+    assert status == REPAIRED
     assert obj == {'a': [1, 2]}
-    assert repairs == ['code_fence', 'truncated_document']
+    assert repairs == ['code_fence', 'trailing_comma']
 
 
-def test_multiline_value_keeps_the_multiline_reading():
-    """The mirror of the 07-28 case: here the newline really is inside the value.
+def test_a_genuine_multiline_value_keeps_the_multiline_reading():
+    """The mirror of the 07-28 case: closing the string at the break leaves
+    `line2", "b": 2}` dangling, so that branch never parses and only the
+    escaping reading survives."""
+    obj, repairs, status = json_repair.repair_json('{"a": "line1\nline2", "b": 2}')
 
-    Closing the string at the line break would leave `line2", "b": 2}` dangling,
-    so that branch does not parse and the driver backs out of it. This is the
-    property the whole design rests on — the parser picks the reading, the pass
-    order is only a tiebreak — so it is asserted directly rather than inferred
-    from the ordering of `_PASSES`.
-    """
-    obj, repairs = json_repair.repair_json('{"a": "line1\nline2", "b": 2}')
+    assert status == REPAIRED
     assert obj == {'a': 'line1\nline2', 'b': 2}
     assert repairs == ['control_chars_in_string']
 
-    # Same driver, opposite verdict, on the same class of defect.
-    obj, repairs = json_repair.repair_json('{"a": "line1\n, "b": 2}')
-    assert obj == {'a': 'line1', 'b': 2}
-    assert repairs == ['unterminated_string']
 
+# ── Beyond repair ────────────────────────────────────────────────────────────
 
-# ── Property: unrepairable stays unrepairable ─────────────────────────────────
+@pytest.mark.parametrize('text', ['not json at all', '', '   ', 'null and then some'])
+def test_beyond_repair_claims_nothing(text):
+    obj, repairs, status = json_repair.repair_json(text)
 
-@pytest.mark.parametrize('text', [
-    'not json at all',
-    '',
-    '   ',
-    'null and then some',
-    '{"a": 1} {"b": 2}',   # two documents — no single object to recover
-])
-def test_beyond_repair_returns_none_and_claims_nothing(text):
-    obj, repairs = json_repair.repair_json(text)
+    assert status == UNREPAIRABLE
     assert obj is None
-    # A repair list on a failed parse would misreport what happened: nothing was
-    # recovered, so nothing may be claimed.
+    # A repair list on a failed parse would misreport what happened.
     assert repairs == []
 
 
 def test_non_string_input_is_rejected_rather_than_coerced():
-    assert json_repair.repair_json(None) == (None, [])
-    assert json_repair.repair_json(b'{"a": 1}') == (None, [])
+    assert json_repair.repair_json(None) == (None, [], UNREPAIRABLE)
+    assert json_repair.repair_json(b'{"a": 1}') == (None, [], UNREPAIRABLE)
 
 
-# ── File helper + reporting ───────────────────────────────────────────────────
+# ── File helper ──────────────────────────────────────────────────────────────
 
 def test_load_json_repaired_reads_and_reports(tmp_path):
     p = tmp_path / 'insights-2026-07-28.json'
     p.write_text(BROKEN_INSIGHTS, encoding='utf-8')
-    obj, repairs = json_repair.load_json_repaired(p)
-    assert obj['date'] == '2026-07-28'
+
+    obj, repairs, status = json_repair.load_json_repaired(p)
+
+    assert status == REPAIRED
+    assert obj['generated_at'].startswith('2026-07-28')
     assert repairs == ['unterminated_string']
 
 
 def test_a_missing_file_still_raises():
-    """Absence is not a syntax defect; swallowing it here would hide a producer
-    that stopped writing at all behind a 'repaired' label."""
+    """Absence is not a syntax defect; swallowing it would hide a producer that
+    stopped writing at all behind a 'repaired' label."""
     with pytest.raises(OSError):
         json_repair.load_json_repaired('/nonexistent/insights.json')
 
 
 def test_describe_is_empty_for_clean_input():
-    assert json_repair.describe([]) == ''
+    assert json_repair.describe([], CLEAN) == ''
     assert 'unterminated_string' in json_repair.describe(['unterminated_string'])
+
+
+REAL_BROKEN = Path('/root/.openclaw/workspace/memory/.tmp/'
+                   'insights-2026-07-28.json.broken.bak')
+
+
+@pytest.mark.skipif(not REAL_BROKEN.exists(), reason='host-only artefact')
+def test_the_real_production_file_recovers_whole():
+    """The reduced fixture above proves the shape; this proves the real 4,361-byte
+    nested document, kept on the host after the incident."""
+    obj, repairs, status = json_repair.load_json_repaired(REAL_BROKEN)
+
+    assert status == REPAIRED
+    assert repairs == ['unterminated_string']
+    assert len(obj) == 8
+    assert obj['watchlist_for_kcn_review']

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -111,6 +111,21 @@ def test_an_unusable_sidecar_must_not_look_absent(tmp_path, monkeypatch, capsys)
     capsys.readouterr()
 
 
+def test_an_unreadable_file_is_invalid_not_absent(tmp_path, monkeypatch, capsys):
+    """The exception path, not the parser path: a sidecar that exists but cannot
+    even be decoded used to fall through to `{}` and republish yesterday's card.
+    Bad encoding is exactly as untrustworthy as bad syntax."""
+    tmp = tmp_path / 'memory' / '.tmp'
+    tmp.mkdir(parents=True)
+    (tmp / 'insights-2026-07-28.json').write_bytes(b'{"a": "\xff\xfe not utf-8"}')
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data['_invalid'] is True
+    assert 'warn:' in capsys.readouterr().err
+
+
 def test_a_genuinely_absent_sidecar_is_still_falsy(tmp_path, monkeypatch):
     """The GHA case: memory/.tmp is gitignored, so a fresh checkout has no file
     at all. That one may republish the previous card."""

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -1,0 +1,172 @@
+"""Where json_repair is actually plugged in, and how a repair stays visible.
+
+A correct repair function that nothing calls fixes nothing, and a repair nobody
+can see is worse than the crash it replaced: the 2026-07-28 sidecar defect was
+only ever noticed *because* it turned the daily health check red. These tests
+pin the three-stage path that keeps it observable without keeping it fatal:
+
+    build_dashboard  →  `repair:` on stderr   (distinct from `warn:`)
+    _harness_common  →  repair_count in dashboard_build_status.json
+    cron_health_check→  state 'repaired', its own line, exit code unchanged
+
+and the boundary that must NOT move: an unrepairable file still degrades.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
+
+import build_dashboard as dashboard  # noqa: E402
+import cron_health_check  # noqa: E402
+import _harness_common  # noqa: E402
+
+
+# The 2026-07-28 shape: a well-formed document whose last string value lost its
+# closing quote. Everything before the defect must survive the repair.
+BROKEN = ('{\n  "behavioral_review": [{"tag": "bias", "text": "chased"}],\n'
+          '  "data_caveats": [\n    "US quotes are yesterday\n  ]\n}\n')
+VALID = '{"behavioral_review": [{"tag": "bias", "text": "chased"}]}'
+
+
+def _sidecar(tmp_path, monkeypatch, body, name='insights-2026-07-28.json'):
+    tmp = tmp_path / 'memory' / '.tmp'
+    tmp.mkdir(parents=True)
+    (tmp / name).write_text(body, encoding='utf-8')
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+
+
+# ── build_dashboard: the card survives, the defect is announced ───────────────
+
+def test_broken_sidecar_still_yields_its_content(tmp_path, monkeypatch, capsys):
+    _sidecar(tmp_path, monkeypatch, BROKEN)
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data['behavioral_review'] == [{'tag': 'bias', 'text': 'chased'}]
+    assert data['_source'] == 'insights-2026-07-28.json'
+    err = capsys.readouterr().err
+    assert 'repair:' in err
+    assert 'unterminated_string' in err
+
+
+def test_a_repair_is_not_reported_as_a_warning(tmp_path, monkeypatch, capsys):
+    """`warn:` is what makes the build degraded and the health check red.
+
+    A repaired sidecar rendered every card, so it must not use that prefix — the
+    whole point of the fallback is that a recoverable typo stops costing a red
+    run. This is the assertion that fails if someone 'simplifies' the two
+    prefixes into one.
+    """
+    _sidecar(tmp_path, monkeypatch, BROKEN)
+
+    dashboard.load_tmp_sidecar('insights')
+
+    assert 'warn:' not in capsys.readouterr().err
+
+
+def test_valid_sidecar_stays_silent(tmp_path, monkeypatch, capsys):
+    _sidecar(tmp_path, monkeypatch, VALID)
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data['behavioral_review'][0]['text'] == 'chased'
+    assert capsys.readouterr().err == ''
+
+
+def test_unrepairable_sidecar_still_degrades_the_build(tmp_path, monkeypatch, capsys):
+    """The boundary: repair widens what survives, it must not hide a real loss."""
+    _sidecar(tmp_path, monkeypatch, 'this was never JSON')
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data == {}
+    assert 'warn:' in capsys.readouterr().err
+
+
+# ── _harness_common: repairs counted apart from degradations ─────────────────
+
+def test_repairs_and_warnings_are_counted_separately(tmp_path):
+    output = (
+        '  repair: insights-2026-07-28.json — repaired JSON (unterminated_string)\n'
+        '  warn: something genuinely degraded\n'
+        '  repair: intraday-insights-2026-07-28.json — repaired JSON (trailing_comma)\n'
+    )
+    _harness_common._record_dashboard_build(True, output, ws=tmp_path)
+
+    status = json.loads(
+        (tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text()
+    )
+    assert status['repair_count'] == 2
+    assert status['warn_count'] == 1
+
+
+def test_a_clean_build_records_zero_repairs(tmp_path):
+    _harness_common._record_dashboard_build(True, '  wrote dashboard.json\n', ws=tmp_path)
+
+    status = json.loads(
+        (tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text()
+    )
+    assert status['repair_count'] == 0
+    assert status['warn_count'] == 0
+
+
+# ── cron_health_check: reported, never escalated ─────────────────────────────
+
+def _status_file(tmp_path, monkeypatch, **fields):
+    logs = tmp_path / 'logs'
+    logs.mkdir(parents=True, exist_ok=True)
+    payload = {'checked_at': '2999-01-01T00:00:00Z', 'ok': True,
+               'warn_count': 0, 'repair_count': 0, 'tail': ''}
+    payload.update(fields)
+    (logs / 'dashboard_build_status.json').write_text(json.dumps(payload))
+    monkeypatch.setattr(cron_health_check, 'WS', tmp_path)
+
+
+def test_repairs_get_their_own_state_not_a_degradation(tmp_path, monkeypatch):
+    _status_file(tmp_path, monkeypatch, repair_count=2)
+
+    result = cron_health_check.check_dashboard_build()
+
+    assert result['state'] == 'repaired'
+    assert result['warn_count'] == 0          # would ride exit 2
+    assert result['repair_count'] == 2
+    assert '2 sidecar' in result['detail']    # visible, with a count
+
+
+def test_a_real_degradation_still_outranks_a_repair(tmp_path, monkeypatch):
+    _status_file(tmp_path, monkeypatch, warn_count=1, repair_count=3)
+
+    result = cron_health_check.check_dashboard_build()
+
+    assert result['state'] == 'degraded'
+    assert result['repair_count'] == 3        # carried, not dropped
+
+
+@pytest.mark.parametrize('fields,state', [
+    ({}, 'ok'),
+    ({'repair_count': 1}, 'repaired'),
+    ({'warn_count': 2}, 'degraded'),
+    ({'ok': False}, 'failed'),
+])
+def test_every_state_carries_the_repair_count_key(tmp_path, monkeypatch, fields, state):
+    """One schema across all branches: a caller reading `repair_count` must never
+    have to guess which branch produced the dict."""
+    _status_file(tmp_path, monkeypatch, **fields)
+
+    result = cron_health_check.check_dashboard_build()
+
+    assert result['state'] == state
+    assert 'repair_count' in result
+
+
+def test_the_repaired_state_has_a_console_icon():
+    """`cron_health_check` indexes its icon map directly, so a state without an
+    entry is a KeyError that takes down the whole daily check."""
+    source = (ROOT / 'scripts' / 'data' / 'cron_health_check.py').read_text()
+    icon_line = source[source.index("dash_icon = {"):]
+    assert "'repaired'" in icon_line[:200]

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -126,6 +126,39 @@ def test_an_unreadable_file_is_invalid_not_absent(tmp_path, monkeypatch, capsys)
     assert 'warn:' in capsys.readouterr().err
 
 
+def test_an_unstattable_file_is_invalid_not_absent(tmp_path, monkeypatch, capsys):
+    """The failure happens while *selecting* the newest file, before any parse.
+
+    `glob` found a sidecar, so one exists; if `getmtime` then raises we know
+    nothing about its content — and must not answer "absent", which republishes
+    yesterday's card.
+    """
+    tmp = tmp_path / 'memory' / '.tmp'
+    tmp.mkdir(parents=True)
+    (tmp / 'insights-2026-07-28.json').write_text(VALID, encoding='utf-8')
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+    monkeypatch.setattr(dashboard.os.path, 'getmtime',
+                        lambda p: (_ for _ in ()).throw(OSError('stat failed')))
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data['_invalid'] is True
+    assert 'warn:' in capsys.readouterr().err
+
+
+def test_an_unlistable_directory_is_invalid_not_absent(tmp_path, monkeypatch, capsys):
+    """Cannot even enumerate: we do not know whether a sidecar exists, so
+    claiming absence — and republishing the old card — is not available."""
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+    monkeypatch.setattr(dashboard.glob, 'glob',
+                        lambda p: (_ for _ in ()).throw(OSError('listing failed')))
+
+    data = dashboard.load_tmp_sidecar('insights')
+
+    assert data['_invalid'] is True
+    assert 'warn:' in capsys.readouterr().err
+
+
 def test_a_genuinely_absent_sidecar_is_still_falsy(tmp_path, monkeypatch):
     """The GHA case: memory/.tmp is gitignored, so a fresh checkout has no file
     at all. That one may republish the previous card."""

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -1,15 +1,19 @@
-"""Where json_repair is actually plugged in, and how a repair stays visible.
+"""Where json_repair is plugged in, and how each outcome stays visible.
 
-A correct repair function that nothing calls fixes nothing, and a repair nobody
-can see is worse than the crash it replaced: the 2026-07-28 sidecar defect was
-only ever noticed *because* it turned the daily health check red. These tests
-pin the three-stage path that keeps it observable without keeping it fatal:
+A correct repairer that nothing calls fixes nothing, and a repair nobody can see
+is worse than the crash it replaced: the 2026-07-28 sidecar defect was noticed
+only *because* it turned the daily health check red. These tests pin the path
+that keeps it observable without keeping it fatal:
 
-    build_dashboard  →  `repair:` on stderr   (distinct from `warn:`)
+    build_dashboard  →  `repair:` on stderr, distinct from `warn:`
     _harness_common  →  repair_count in dashboard_build_status.json
     cron_health_check→  state 'repaired', its own line, exit code unchanged
 
-and the boundary that must NOT move: an unrepairable file still degrades.
+and two boundaries that must not move:
+
+  * an unrepairable or ambiguous file still degrades the build, and
+  * it must NOT look like an absent file, because absence republishes the
+    previous day's card — showing yesterday's critique as today's.
 """
 import json
 import sys
@@ -26,11 +30,11 @@ import cron_health_check  # noqa: E402
 import _harness_common  # noqa: E402
 
 
-# The 2026-07-28 shape: a well-formed document whose last string value lost its
-# closing quote. Everything before the defect must survive the repair.
 BROKEN = ('{\n  "behavioral_review": [{"tag": "bias", "text": "chased"}],\n'
           '  "data_caveats": [\n    "US quotes are yesterday\n  ]\n}\n')
 VALID = '{"behavioral_review": [{"tag": "bias", "text": "chased"}]}'
+AMBIGUOUS_TEXT = '[\n "a\n,",\n "\n]'
+UNREPAIRABLE_TEXT = 'this was never JSON'
 
 
 def _sidecar(tmp_path, monkeypatch, body, name='insights-2026-07-28.json'):
@@ -40,7 +44,7 @@ def _sidecar(tmp_path, monkeypatch, body, name='insights-2026-07-28.json'):
     monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
 
 
-# ── build_dashboard: the card survives, the defect is announced ───────────────
+# ── build_dashboard: the card survives, the defect is announced ──────────────
 
 def test_broken_sidecar_still_yields_its_content(tmp_path, monkeypatch, capsys):
     _sidecar(tmp_path, monkeypatch, BROKEN)
@@ -48,6 +52,7 @@ def test_broken_sidecar_still_yields_its_content(tmp_path, monkeypatch, capsys):
     data = dashboard.load_tmp_sidecar('insights')
 
     assert data['behavioral_review'] == [{'tag': 'bias', 'text': 'chased'}]
+    assert data['data_caveats'] == ['US quotes are yesterday']
     assert data['_source'] == 'insights-2026-07-28.json'
     err = capsys.readouterr().err
     assert 'repair:' in err
@@ -55,13 +60,9 @@ def test_broken_sidecar_still_yields_its_content(tmp_path, monkeypatch, capsys):
 
 
 def test_a_repair_is_not_reported_as_a_warning(tmp_path, monkeypatch, capsys):
-    """`warn:` is what makes the build degraded and the health check red.
-
-    A repaired sidecar rendered every card, so it must not use that prefix — the
-    whole point of the fallback is that a recoverable typo stops costing a red
-    run. This is the assertion that fails if someone 'simplifies' the two
-    prefixes into one.
-    """
+    """`warn:` is what makes the build degraded and the health check red. A
+    repaired sidecar rendered every card, so it must not use that prefix — the
+    whole point is that a recoverable typo stops costing a red run."""
     _sidecar(tmp_path, monkeypatch, BROKEN)
 
     dashboard.load_tmp_sidecar('insights')
@@ -78,17 +79,48 @@ def test_valid_sidecar_stays_silent(tmp_path, monkeypatch, capsys):
     assert capsys.readouterr().err == ''
 
 
-def test_unrepairable_sidecar_still_degrades_the_build(tmp_path, monkeypatch, capsys):
-    """The boundary: repair widens what survives, it must not hide a real loss."""
-    _sidecar(tmp_path, monkeypatch, 'this was never JSON')
+# ── The boundary: unreadable is neither repaired nor absent ──────────────────
+
+@pytest.mark.parametrize('body,marker', [
+    (UNREPAIRABLE_TEXT, 'unrepairable'),
+    (AMBIGUOUS_TEXT, 'ambiguous'),
+    ('[1, 2, 3]', 'top level is list'),
+])
+def test_an_unusable_sidecar_warns_and_is_marked_invalid(tmp_path, monkeypatch,
+                                                         capsys, body, marker):
+    _sidecar(tmp_path, monkeypatch, body)
 
     data = dashboard.load_tmp_sidecar('insights')
 
-    assert data == {}
-    assert 'warn:' in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert 'warn:' in err
+    assert marker in err
+    assert data['_invalid'] is True
 
 
-# ── _harness_common: repairs counted apart from degradations ─────────────────
+def test_an_unusable_sidecar_must_not_look_absent(tmp_path, monkeypatch, capsys):
+    """`insights_present = bool(load_tmp_sidecar(...))` decides whether
+    `_preserve_absent` republishes the previous day's card. Returning `{}` for a
+    file that exists but is unreadable would show yesterday's critique as today's
+    — this is the assertion that keeps the two cases apart."""
+    _sidecar(tmp_path, monkeypatch, UNREPAIRABLE_TEXT)
+
+    present = bool(dashboard.load_tmp_sidecar('insights'))
+
+    assert present is True
+    capsys.readouterr()
+
+
+def test_a_genuinely_absent_sidecar_is_still_falsy(tmp_path, monkeypatch):
+    """The GHA case: memory/.tmp is gitignored, so a fresh checkout has no file
+    at all. That one may republish the previous card."""
+    (tmp_path / 'memory' / '.tmp').mkdir(parents=True)
+    monkeypatch.setattr(dashboard, 'WS_ROOT', tmp_path)
+
+    assert dashboard.load_tmp_sidecar('insights') == {}
+
+
+# ── _harness_common: repairs counted apart from degradations ────────────────
 
 def test_repairs_and_warnings_are_counted_separately(tmp_path):
     output = (
@@ -96,11 +128,10 @@ def test_repairs_and_warnings_are_counted_separately(tmp_path):
         '  warn: something genuinely degraded\n'
         '  repair: intraday-insights-2026-07-28.json — repaired JSON (trailing_comma)\n'
     )
+
     _harness_common._record_dashboard_build(True, output, ws=tmp_path)
 
-    status = json.loads(
-        (tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text()
-    )
+    status = json.loads((tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text())
     assert status['repair_count'] == 2
     assert status['warn_count'] == 1
 
@@ -108,14 +139,12 @@ def test_repairs_and_warnings_are_counted_separately(tmp_path):
 def test_a_clean_build_records_zero_repairs(tmp_path):
     _harness_common._record_dashboard_build(True, '  wrote dashboard.json\n', ws=tmp_path)
 
-    status = json.loads(
-        (tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text()
-    )
+    status = json.loads((tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text())
     assert status['repair_count'] == 0
     assert status['warn_count'] == 0
 
 
-# ── cron_health_check: reported, never escalated ─────────────────────────────
+# ── cron_health_check: reported, never escalated ────────────────────────────
 
 def _status_file(tmp_path, monkeypatch, **fields):
     logs = tmp_path / 'logs'
@@ -135,7 +164,7 @@ def test_repairs_get_their_own_state_not_a_degradation(tmp_path, monkeypatch):
     assert result['state'] == 'repaired'
     assert result['warn_count'] == 0          # would ride exit 2
     assert result['repair_count'] == 2
-    assert '2 sidecar' in result['detail']    # visible, with a count
+    assert '2 sidecar' in result['detail']
 
 
 def test_a_real_degradation_still_outranks_a_repair(tmp_path, monkeypatch):
@@ -154,8 +183,6 @@ def test_a_real_degradation_still_outranks_a_repair(tmp_path, monkeypatch):
     ({'ok': False}, 'failed'),
 ])
 def test_every_state_carries_the_repair_count_key(tmp_path, monkeypatch, fields, state):
-    """One schema across all branches: a caller reading `repair_count` must never
-    have to guess which branch produced the dict."""
     _status_file(tmp_path, monkeypatch, **fields)
 
     result = cron_health_check.check_dashboard_build()
@@ -164,9 +191,18 @@ def test_every_state_carries_the_repair_count_key(tmp_path, monkeypatch, fields,
     assert 'repair_count' in result
 
 
-def test_the_repaired_state_has_a_console_icon():
-    """`cron_health_check` indexes its icon map directly, so a state without an
-    entry is a KeyError that takes down the whole daily check."""
-    source = (ROOT / 'scripts' / 'data' / 'cron_health_check.py').read_text()
-    icon_line = source[source.index("dash_icon = {"):]
-    assert "'repaired'" in icon_line[:200]
+@pytest.mark.parametrize('fields', [{}, {'repair_count': 1}, {'warn_count': 2},
+                                     {'ok': False}, {'absent': True}])
+def test_every_reachable_state_has_an_icon(tmp_path, monkeypatch, fields):
+    """`cron_health_check` indexes `DASHBOARD_STATE_ICONS` directly, so a state
+    without an entry is a KeyError that takes down the whole daily check. The
+    real map is indexed here — restating it in the test would pass even after
+    the mapping was deleted."""
+    if fields.pop('absent', None):
+        monkeypatch.setattr(cron_health_check, 'WS', tmp_path)
+    else:
+        _status_file(tmp_path, monkeypatch, **fields)
+
+    state = cron_health_check.check_dashboard_build()['state']
+
+    assert cron_health_check.DASHBOARD_STATE_ICONS[state]


### PR DESCRIPTION
Fixes the 2026-07-28 red on `Cron Health Check`. **Rewritten** after an adversarial review found five blocks-merge defects in the first version — three of which silently destroyed data while the PR body claimed no pass could delete a value. That claim was false; this version makes it true and testable.

## The failure

The 08:09 brief wrote `memory/.tmp/insights-2026-07-28.json` with the closing quote missing from the last `data_caveats` entry. `json.load` raised, `build_dashboard` lost the whole `behavioral_review` / `bear_cases` / `hidden_concentration` group, and the daily health check went red. 4,361 bytes, one of them absent.

## The invariant, stated so it can be tested

A pass may only **insert** a delimiter the author owed, **escape in place** a character JSON forbids raw inside a string, or **delete** a character that is outside every string literal and carries no value.

Two passes from the first version are gone because they cannot satisfy it:

- **`prose_wrapper`** — cutting to the outermost balanced value looks lossless and is not. `{"kept":1}\n{"lost":2}` is bracket-balanced; cutting to the first match parses while deleting the second document. Bracket-matching only moves where the deletion ends.
- **`truncated_document`** — the tail is already gone; appending `]}` turns "this file was cut off" into "a valid document with fewer items". Reproduced against the real `memory/2026-07-27-plan.json`: truncated mid-array it recovered 2 of 7 decisions and `validate_plan` still returned `[]`.

`trailing_comma` is now string-aware; the blanket regex deleted the comma that is the *value* in `["a", ","]`.

## Ambiguity is refused, not guessed

A dropped quote mispairs every quote after it, so both the missing-quote and the raw-newline reading can parse to **different objects**. Parser acceptance proves syntax, never intent. Every accepting branch within the depth bound is enumerated; if two disagree the result is `ambiguous` and no object is returned. Comparison is type-sensitive — `True == 1` and `1 == 1.0` in Python, so plain `==` would let a type disagreement pass as agreement.

Empirically this does not cost the common case: on the real broken file there is exactly **one** accepting branch, and a sweep of 515 single-quote deletions produced 72 repairable cases and **zero** ambiguities.

## Removed: the plan.json wiring

It never worked. `validate_plan_json` repaired into a local object; `log_decisions` then re-read the raw file strictly twice — warning once during normalization, returning silently on the second failure — while `maybe_commit` still committed the malformed plan. Net effect: published malformed plan, zero ledger decisions, validator reporting recovery. `plan.json` is too expensive for heuristic repair.

## Fixed: an unreadable sidecar no longer republishes yesterday

I had described the fallback as leaving the "existing hard-failure path" intact. It does not: `load_tmp_sidecar` returned `{}`, `insights_present` went false, and `_preserve_absent` restored the *previous day's* card. Absence (a GHA checkout, where `memory/.tmp` is gitignored) may republish; a file that exists but cannot be trusted now returns `_invalid` so the card hides instead of showing stale critique as current.

## Not attempted: consecutive-day escalation

`dashboard_build_status.json` is last-write-wins and there are many postflights per day, so a counter in it would turn one bad day into several and let a clean afternoon erase a bad morning — and `publish_dashboard.sh` rebuilds every 20 minutes without recording at all. Doing this properly needs an HKT-keyed daily observation store; out of scope here. `repair_count` is still reported, just never escalated.

## Validation

- `python3 -m pytest tests/ -q` → 1224 passed, 5 xfailed
- 59 tests, mutation-verified — all six mutations killed: re-adding `prose_wrapper`, re-adding `truncated_document`, taking the first branch on ambiguity, degrading `_json_equal` to `==`, reverting `trailing_comma` to the blanket regex, and returning `{}` for an unreadable sidecar.
- The two decorative tests called out in review are fixed: the wrapper test fed valid JSON and never reached the wrapper; the icon test grepped source text, and now indexes the real `DASHBOARD_STATE_ICONS` map, which was extracted to module level for that purpose.