### PR TITLE
intraday watchdog: let the delivery marker decide before the run record

### DIFF
--- a/scripts/harness/intraday_watchdog.py
+++ b/scripts/harness/intraday_watchdog.py
@@ -36,7 +36,8 @@ but duplicates, so it's gone. Telegram is the sole backstop channel.
 Healthy runs use their generated report; stalled/looped runs fall back to the
 deterministic preflight block on Telegram. Dedupe remains per slot.
 
-MARKER FIRST (2026-07-29): the gates are ordered marker → generation → mirror,
+MARKER FIRST (2026-07-29): the gates are ordered loop → marker → generation →
+mirror,
 and that order is the fix, not an accident. The generation gate used to run
 first and duplicated a perfectly delivered 10:30 HK report, because its two
 signals are both weak: `delivery.messageToolSentTo` has been structurally empty
@@ -45,6 +46,10 @@ since the 2026-06-03 double-send fix took sending away from the model, and
 the analysis, not the data block, so `raw_block_first in summary` is a coin
 flip (10:00 hit, 10:30 missed, same day). The marker is the only positive proof
 of delivery, so it is consulted before any inference over the run record.
+
+The loop gate stays ABOVE the marker on purpose: `tg_ok` proves a send exited 0,
+never that the body was sane, so a confirmed delivery must not suppress a
+detected loop.
 
 (Shared run-record / send helpers live in _watchdog_common.py.)
 
@@ -72,6 +77,7 @@ import cron_heartbeat  # noqa: E402
 
 LOOP_THRESHOLD = 5         # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
 MARKER_FRESH_MS = 25 * 60 * 1000  # postflight send-marker older than this ⇒ treat as not-this-slot
+MARKER_FUTURE_SKEW_MS = 5 * 60 * 1000  # marker written just after the watchdog's clock read
 WATCHDOG_DELAY_MINUTES = 10
 
 
@@ -80,6 +86,38 @@ def deterministic_fallback(raw_block, tag, reason):
     return (f'🧯 {tag} 确定性兜底（LLM {reason}）\n'
             '以下内容由 preflight 数据直接生成，未经过模型改写：\n\n'
             + raw_block.strip())
+
+
+def deliver_fallback(raw_block, tag, reason, args, watchdog_now, flag,
+                     expected_job, expected_slot, run_at, extra=None):
+    """Send the deterministic block and record the outcome — success OR failure.
+
+    The failure branch records `watchdog_failed` deliberately: a fallback that
+    could not be sent is the one state nobody downstream can infer, so it must
+    leave the same kind of trace the mirror path already leaves.
+    """
+    body = deterministic_fallback(raw_block, tag, reason)
+    tg_ok, tg_out = send_telegram(KCN_TELEGRAM, body, args.dry_run)
+    log({'tag': tag, 'action': 'deterministic-fallback', 'sent_ok': tg_ok,
+         'fail_kind': reason, 'run_at': run_at, 'target': KCN_TELEGRAM,
+         'out': tg_out, **(extra or {})})
+    if not args.dry_run:
+        if tg_ok:
+            flag.write_text(watchdog_now.isoformat())
+            cron_heartbeat.record(
+                args.market, 'watchdog_backstop', at=watchdog_now,
+                job_name=expected_job, slot=expected_slot,
+                watchdog_state='deterministic_fallback', telegram_sent=True,
+            )
+        else:
+            cron_heartbeat.record(
+                args.market, 'watchdog_failed', at=watchdog_now,
+                job_name=expected_job, slot=expected_slot,
+                watchdog_state='deterministic_fallback_failed', telegram_sent=False,
+            )
+    print(json.dumps({'tag': tag, 'deterministic_fallback': tg_ok,
+                      'dry_run': args.dry_run}, ensure_ascii=False))
+    return tg_ok
 
 
 def watchdog_target(market, now=None):
@@ -127,7 +165,17 @@ def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms):
     if (marker.get('job'), marker.get('slot')) != (job_name, slot):
         return False
     ts = marker.get('ts')
-    if not isinstance(ts, (int, float)) or now_ms - ts >= MARKER_FRESH_MS:
+    # Both bounds matter now that the marker is the primary judge: a wildly
+    # future-dated ts (clock skew, corrupted or hand-edited marker) would
+    # otherwise read as infinitely fresh and suppress every backstop.
+    # The tolerance is not symmetric on purpose — postflight can legitimately
+    # finish its send in the seconds AFTER the watchdog reads its own wall clock,
+    # and that marker is fresher evidence, not staler. Rejecting it would re-open
+    # the duplicate this ordering fix exists to close.
+    if not isinstance(ts, (int, float)):
+        return False
+    age_ms = now_ms - ts
+    if not -MARKER_FUTURE_SKEW_MS <= age_ms < MARKER_FRESH_MS:
         return False
     return not raw_block_first or marker.get('first_line') == raw_block_first
 
@@ -191,7 +239,22 @@ def main():
     loop_score, _ = transcript_loop_score(session_id)
     looped = loop_score >= LOOP_THRESHOLD
 
-    # --- Delivery evidence gate: the postflight marker decides first ----------
+    # --- Loop gate: a detected loop always reaches kcn, delivered or not ------
+    # A confirmed marker does NOT suppress this. `tg_ok` only proves the send
+    # subprocess exited 0 — it never inspects the body. postflight's length cap
+    # catches most repeat-loops (they blow the 3500-char limit → fail-closed data
+    # block + a 🔴 banner kcn can see), but a loop that stays under the cap can
+    # pass validation and be delivered as normal-looking prose. A line in
+    # watchdog.jsonl is not something kcn reads, so treating it as "surfaced"
+    # would be exactly the silent downgrade that is forbidden here.
+    if looped:
+        deliver_fallback(
+            raw_block, tag, '循环', args, watchdog_now, flag,
+            expected_job, expected_slot, run_at,
+            extra={'loop_score': loop_score, 'delivered_clean': None})
+        return 0
+
+    # --- Delivery evidence gate: the postflight marker decides -----------------
     # ORDER MATTERS (2026-07-29): this used to sit BELOW the generation gate, so a
     # slot whose report postflight had verifiably delivered still got a duplicate
     # deterministic fallback whenever the run-record heuristics below happened to
@@ -215,40 +278,36 @@ def main():
             job_name=expected_job, slot=expected_slot,
             watchdog_state='ok', telegram_sent=True,
         )
-        # Still surface a degraded turn — kcn has the report, so re-sending buys
-        # nothing, but the loop must stay visible instead of being swallowed.
+        # `delivery_state` rides along for traceability: postflight records
+        # 'failed' when it fell back to the data block alone. That case needs no
+        # backstop — kcn already got the 🔴 banner in the message itself — but the
+        # watchdog log should not claim a clean run either.
         log({'tag': tag, 'action': 'ok',
              'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
-             'loop_score': loop_score, 'looped_but_delivered': looped,
+             'loop_score': loop_score,
+             'delivery_state': (marker or {}).get('delivery_state'),
              'run_at': run_at})
         return 0
 
     # --- Generation gate: generated report or deterministic fallback ----------
-    # Reached only when the marker did NOT prove delivery. Both signals here are
-    # weak by construction: `messageToolSentTo` is structurally empty since the
-    # 2026-06-03 double-send fix moved sending out of the model's hands, and the
-    # run-record `summary` is openclaw's truncated meta-prose, which under Mode 7
-    # prose mode usually holds analysis rather than the data block. They are kept
-    # as a last resort for the marker-missing case only.
-    sent_via_tool = bool((last.get('delivery') or {}).get('messageToolSentTo'))
+    # Reached only when the marker did NOT prove delivery. The run-record
+    # `summary` is openclaw's truncated meta-prose, which under Mode 7 prose mode
+    # usually holds analysis rather than the data block — a weak signal kept only
+    # as a last resort for the marker-missing case.
+    #
+    # `delivery.messageToolSentTo` used to be OR'd in here and was deleted
+    # (2026-07-29): the 2026-06-03 double-send fix took sending away from the
+    # model and the cron contract forbids the `message` tool outright, so no
+    # canonical path can set it truthfully. A permanently-false term in an `or`
+    # is not redundancy — if it ever did fire it would mark a contract-violating
+    # run as delivered and mirror a truncated summary as if it were the report.
     block_present = bool(raw_block_first and raw_block_first in summary)
-    delivered_clean = sent_via_tool or block_present
-    if not delivered_clean or looped:
-        reason = '循环' if looped else '未完成'
-        body = deterministic_fallback(raw_block, tag, reason)
-        tg_ok, tg_out = send_telegram(KCN_TELEGRAM, body, args.dry_run)
-        log({'tag': tag, 'action': 'deterministic-fallback', 'sent_ok': tg_ok,
-             'delivered_clean': delivered_clean, 'loop_score': loop_score, 'run_at': run_at,
-             'target': KCN_TELEGRAM, 'out': tg_out})
-        if tg_ok and not args.dry_run:
-            flag.write_text(watchdog_now.isoformat())
-            cron_heartbeat.record(
-                args.market, 'watchdog_backstop', at=watchdog_now,
-                job_name=expected_job, slot=expected_slot,
-                watchdog_state='deterministic_fallback', telegram_sent=True,
-            )
-        print(json.dumps({'tag': tag, 'deterministic_fallback': tg_ok,
-                          'dry_run': args.dry_run}, ensure_ascii=False))
+    delivered_clean = block_present
+    if not delivered_clean:
+        deliver_fallback(
+            raw_block, tag, '未完成', args, watchdog_now, flag,
+            expected_job, expected_slot, run_at,
+            extra={'loop_score': loop_score, 'delivered_clean': delivered_clean})
         return 0
 
     # --- Delivery backstop: Telegram only (no WeChat resend) ------------------

--- a/scripts/harness/intraday_watchdog.py
+++ b/scripts/harness/intraday_watchdog.py
@@ -36,6 +36,16 @@ but duplicates, so it's gone. Telegram is the sole backstop channel.
 Healthy runs use their generated report; stalled/looped runs fall back to the
 deterministic preflight block on Telegram. Dedupe remains per slot.
 
+MARKER FIRST (2026-07-29): the gates are ordered marker → generation → mirror,
+and that order is the fix, not an accident. The generation gate used to run
+first and duplicated a perfectly delivered 10:30 HK report, because its two
+signals are both weak: `delivery.messageToolSentTo` has been structurally empty
+since the 2026-06-03 double-send fix took sending away from the model, and
+`summary` is openclaw's truncated meta-prose — under Mode 7 prose mode it holds
+the analysis, not the data block, so `raw_block_first in summary` is a coin
+flip (10:00 hit, 10:30 missed, same day). The marker is the only positive proof
+of delivery, so it is consulted before any inference over the run record.
+
 (Shared run-record / send helpers live in _watchdog_common.py.)
 
 Usage:
@@ -161,7 +171,7 @@ def main():
         log({'tag': tag, 'action': 'skip', 'reason': 'already handled this slot (dedupe flag)'})
         return 0
 
-    # --- Generation gate: generated report or deterministic fallback ----------
+    # --- Context gate: only assess this slot's own preflight data -------------
     summary = last.get('summary', '')
     ctx_path = WS / 'memory' / '.tmp' / f'intraday-context-{args.market}-latest.json'
     context = context_for_slot(ctx_path, expected_job, expected_slot)
@@ -178,11 +188,51 @@ def main():
         return 0
     raw_block = (context.get('raw_wechat_block') or '').strip()
     raw_block_first = raw_block.splitlines()[0] if raw_block else None
+    loop_score, _ = transcript_loop_score(session_id)
+    looped = loop_score >= LOOP_THRESHOLD
+
+    # --- Delivery evidence gate: the postflight marker decides first ----------
+    # ORDER MATTERS (2026-07-29): this used to sit BELOW the generation gate, so a
+    # slot whose report postflight had verifiably delivered still got a duplicate
+    # deterministic fallback whenever the run-record heuristics below happened to
+    # miss. The marker is positive proof — postflight itself recorded tg_ok for
+    # this exact job/slot/first_line within the freshness window — and positive
+    # proof of delivery outranks any inference drawn from the run record.
+    marker_path = WS / 'memory' / '.tmp' / f'intraday-sent-{args.market}.json'
+    marker = None
+    if marker_path.exists():
+        try:
+            marker = json.loads(marker_path.read_text())
+        except Exception:
+            marker = None
+    now_ms = int(watchdog_now.timestamp() * 1000)
+    # TG is covered iff postflight's cosend confirmably delivered this report to
+    # Telegram this exact slot (slot identity, freshness, first line, tg_ok=true).
+    if marker_covers_slot(
+            marker, expected_job, expected_slot, raw_block_first, now_ms):
+        cron_heartbeat.record(
+            args.market, 'completed', at=watchdog_now,
+            job_name=expected_job, slot=expected_slot,
+            watchdog_state='ok', telegram_sent=True,
+        )
+        # Still surface a degraded turn — kcn has the report, so re-sending buys
+        # nothing, but the loop must stay visible instead of being swallowed.
+        log({'tag': tag, 'action': 'ok',
+             'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
+             'loop_score': loop_score, 'looped_but_delivered': looped,
+             'run_at': run_at})
+        return 0
+
+    # --- Generation gate: generated report or deterministic fallback ----------
+    # Reached only when the marker did NOT prove delivery. Both signals here are
+    # weak by construction: `messageToolSentTo` is structurally empty since the
+    # 2026-06-03 double-send fix moved sending out of the model's hands, and the
+    # run-record `summary` is openclaw's truncated meta-prose, which under Mode 7
+    # prose mode usually holds analysis rather than the data block. They are kept
+    # as a last resort for the marker-missing case only.
     sent_via_tool = bool((last.get('delivery') or {}).get('messageToolSentTo'))
     block_present = bool(raw_block_first and raw_block_first in summary)
     delivered_clean = sent_via_tool or block_present
-    loop_score, _ = transcript_loop_score(session_id)
-    looped = loop_score >= LOOP_THRESHOLD
     if not delivered_clean or looped:
         reason = '循环' if looped else '未完成'
         body = deterministic_fallback(raw_block, tag, reason)
@@ -210,28 +260,7 @@ def main():
     # same body to Telegram (cold-proof, no contextToken drop), the WeChat retry
     # bought nothing but duplicates. So the watchdog's SOLE job is to guarantee
     # Telegram has this report — never touch WeChat.
-    marker_path = WS / 'memory' / '.tmp' / f'intraday-sent-{args.market}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
-    now_ms = int(watchdog_now.timestamp() * 1000)
-    # TG is covered iff postflight's cosend confirmably delivered this report to
-    # Telegram this exact slot (slot identity, freshness, first line, tg_ok=true).
-    if marker_covers_slot(
-            marker, expected_job, expected_slot, raw_block_first, now_ms):
-        cron_heartbeat.record(
-            args.market, 'completed', at=watchdog_now,
-            job_name=expected_job, slot=expected_slot,
-            watchdog_state='ok', telegram_sent=True,
-        )
-        log({'tag': tag, 'action': 'ok',
-             'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
-             'run_at': run_at})
-        return 0
-
+    #
     # postflight cosend never ran / failed / stale-or-mismatched marker ⇒ Telegram
     # is not confirmed for this report → mirror it now.
     report = last_report_text(session_id, raw_block_first) if raw_block_first else None

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -236,9 +236,14 @@ def test_confirmed_marker_outranks_a_run_record_that_looks_undelivered(
     assert heartbeats[-1][1]['telegram_sent'] is True
 
 
-def test_a_delivered_but_looped_run_stays_visible_without_a_duplicate(
+def test_a_confirmed_marker_does_not_suppress_a_detected_loop(
         tmp_path, monkeypatch):
-    """A loop must not be silenced — but kcn already has the report, so no re-send."""
+    """`tg_ok` proves the send exited 0, never that the body was sane.
+
+    postflight's length cap catches most repeat-loops, but one that stays under
+    the limit is delivered as normal-looking prose. A watchdog.jsonl line is not
+    something kcn reads, so the loop has to reach Telegram.
+    """
     now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
     run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
                summary='▎我的看法', delivery={'messageToolSentTo': None})
@@ -249,9 +254,80 @@ def test_a_delivered_but_looped_run_stays_visible_without_a_duplicate(
         monkeypatch, tmp_path, run=run, now=now, marker=marker, loop_score=49)
 
     assert watchdog.main() == 0
-    assert sends == []
-    assert events[-1]['looped_but_delivered'] is True
+    assert len(sends) == 1
+    assert sends[0].startswith('🧯 intraday-hk 确定性兜底（LLM 循环）')
     assert events[-1]['loop_score'] == 49
+    assert events[-1]['fail_kind'] == '循环'
+
+
+def test_a_run_that_sent_via_the_forbidden_message_tool_is_not_trusted(
+        tmp_path, monkeypatch):
+    """`messageToolSentTo` is gone: the cron contract forbids that path entirely."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法',
+               delivery={'messageToolSentTo': ['telegram']})
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None)
+
+    assert watchdog.main() == 0
+    assert len(sends) == 1                  # not upgraded to "delivered"
+    assert events[-1]['action'] == 'deterministic-fallback'
+
+
+def test_a_marker_written_just_after_the_watchdog_clock_read_still_counts(
+        tmp_path, monkeypatch):
+    """postflight may land seconds late — fresher evidence, not stale."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法', delivery={'messageToolSentTo': None})
+    marker = {'ts': int(datetime(2026, 7, 29, 10, 40, 20, tzinfo=HKT).timestamp() * 1000),
+              'tg_ok': True, 'first_line': HEADING, 'job': '盘中盯盘', 'slot': SLOT}
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=marker)
+
+    assert watchdog.main() == 0
+    assert sends == []
+    assert events[-1]['action'] == 'ok'
+
+
+def test_an_absurdly_future_marker_cannot_suppress_the_backstop(
+        tmp_path, monkeypatch):
+    """A corrupt/skewed ts must not read as infinitely fresh."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法', delivery={'messageToolSentTo': None})
+    marker = {'ts': int(datetime(2026, 7, 29, 18, 0, tzinfo=HKT).timestamp() * 1000),
+              'tg_ok': True, 'first_line': HEADING, 'job': '盘中盯盘', 'slot': SLOT}
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=marker)
+
+    assert watchdog.main() == 0
+    assert len(sends) == 1
+    assert events[-1]['action'] == 'deterministic-fallback'
+
+
+def test_a_fallback_that_could_not_be_sent_records_a_failure(
+        tmp_path, monkeypatch):
+    """The one state nobody downstream can infer must leave its own trace."""
+    import intraday_watchdog as watchdog_mod
+
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法', delivery={'messageToolSentTo': None})
+
+    watchdog, _, heartbeats, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None)
+    monkeypatch.setattr(watchdog_mod, 'send_telegram',
+                        lambda target, body, dry: (False, 'boom'))
+
+    assert watchdog.main() == 0
+    assert events[-1]['sent_ok'] is False
+    assert heartbeats[-1][0] == ('hk', 'watchdog_failed')
+    assert heartbeats[-1][1]['telegram_sent'] is False
 
 
 def test_missing_marker_still_gets_the_deterministic_fallback(

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -198,6 +198,10 @@ def _wire_watchdog(monkeypatch, tmp_path, *, run, now, marker, loop_score=1):
     monkeypatch.setattr(watchdog, 'today_runs', lambda job_id: [run])
     monkeypatch.setattr(watchdog, 'transcript_loop_score',
                         lambda session_id: (loop_score, ''))
+    # Keep the tests hermetic: both of these read /root/.openclaw/agents/... on a
+    # real box, which is unreadable on the CI runner.
+    monkeypatch.setattr(watchdog, 'last_report_text',
+                        lambda session_id, first_line: None)
     monkeypatch.setattr(watchdog, 'send_telegram',
                         lambda target, body, dry: sends.append(body) or (True, 'ok'))
     monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
@@ -363,5 +367,6 @@ def test_a_marker_that_failed_telegram_still_gets_mirrored(
 
     assert watchdog.main() == 0
     assert len(sends) == 1
+    assert HEADING in sends[0]              # the report reaches kcn, not just a banner
     assert events[-1]['action'] == 'mirror-telegram'
     assert events[-1]['reason'] == 'postflight cosend failed'

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -171,3 +171,121 @@ def test_main_rejects_mismatched_context_and_uses_wall_clock_for_heartbeat(
             'telegram_sent': False,
         },
     )]
+
+
+SLOT = '2026-07-29T10:30:00+08:00'
+HEADING = '🇭🇰 港股盯盘 | 07/29 10:32 HKT'
+
+
+def _wire_watchdog(monkeypatch, tmp_path, *, run, now, marker, loop_score=1):
+    """Set up main() against a tmp workspace; returns (sends, heartbeats, events)."""
+    import intraday_watchdog as watchdog
+
+    context_dir = tmp_path / 'memory' / '.tmp'
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / 'intraday-context-hk-latest.json').write_text(json.dumps({
+        'heartbeat': {'job': '盘中盯盘', 'slot': SLOT},
+        'raw_wechat_block': f'{HEADING}\n恒指 25,713 ▲1.59%',
+    }))
+    if marker is not None:
+        (context_dir / 'intraday-sent-hk.json').write_text(json.dumps(marker))
+
+    sends, heartbeats, events = [], [], []
+    monkeypatch.setattr(watchdog, 'WS', tmp_path)
+    monkeypatch.setattr(watchdog, 'watchdog_target',
+                        lambda market: (now, '盘中盯盘', SLOT))
+    monkeypatch.setattr(watchdog, 'find_job_id', lambda name: 'job-hk')
+    monkeypatch.setattr(watchdog, 'today_runs', lambda job_id: [run])
+    monkeypatch.setattr(watchdog, 'transcript_loop_score',
+                        lambda session_id: (loop_score, ''))
+    monkeypatch.setattr(watchdog, 'send_telegram',
+                        lambda target, body, dry: sends.append(body) or (True, 'ok'))
+    monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
+                        lambda *args, **kwargs: heartbeats.append((args, kwargs)))
+    monkeypatch.setattr(watchdog, 'log', events.append)
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['intraday_watchdog.py', '--job-name', '盘中盯盘', '--market', 'hk'],
+    )
+    return watchdog, sends, heartbeats, events
+
+
+def test_confirmed_marker_outranks_a_run_record_that_looks_undelivered(
+        tmp_path, monkeypatch):
+    """The 2026-07-29 10:30 HK duplicate: postflight had delivered, watchdog re-sent.
+
+    Both run-record signals miss here exactly as they did live — Mode 7 prose puts
+    analysis in `summary` (no data-block heading) and postflight, not the model,
+    does the sending (`messageToolSentTo` empty). Only the marker proves delivery,
+    so it has to be consulted before either of them.
+    """
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法\n\n今天恒指 +1.59%,是一波 beta 修复。',
+               delivery={'messageToolSentTo': None})
+    marker = {'ts': int(datetime(2026, 7, 29, 10, 34, tzinfo=HKT).timestamp() * 1000),
+              'tg_ok': True, 'first_line': HEADING, 'job': '盘中盯盘', 'slot': SLOT}
+
+    watchdog, sends, heartbeats, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=marker)
+
+    assert watchdog.main() == 0
+    assert sends == []                      # no duplicate of any kind
+    assert events[-1]['action'] == 'ok'
+    assert heartbeats[-1][0] == ('hk', 'completed')
+    assert heartbeats[-1][1]['telegram_sent'] is True
+
+
+def test_a_delivered_but_looped_run_stays_visible_without_a_duplicate(
+        tmp_path, monkeypatch):
+    """A loop must not be silenced — but kcn already has the report, so no re-send."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法', delivery={'messageToolSentTo': None})
+    marker = {'ts': int(datetime(2026, 7, 29, 10, 34, tzinfo=HKT).timestamp() * 1000),
+              'tg_ok': True, 'first_line': HEADING, 'job': '盘中盯盘', 'slot': SLOT}
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=marker, loop_score=49)
+
+    assert watchdog.main() == 0
+    assert sends == []
+    assert events[-1]['looped_but_delivered'] is True
+    assert events[-1]['loop_score'] == 49
+
+
+def test_missing_marker_still_gets_the_deterministic_fallback(
+        tmp_path, monkeypatch):
+    """Marker-first must not disarm the backstop when delivery is unproven."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary='▎我的看法', delivery={'messageToolSentTo': None})
+
+    watchdog, sends, heartbeats, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=None)
+
+    assert watchdog.main() == 0
+    assert len(sends) == 1
+    assert sends[0].startswith('🧯 intraday-hk 确定性兜底')
+    assert HEADING in sends[0]
+    assert events[-1]['action'] == 'deterministic-fallback'
+    assert heartbeats[-1][1]['watchdog_state'] == 'deterministic_fallback'
+
+
+def test_a_marker_that_failed_telegram_still_gets_mirrored(
+        tmp_path, monkeypatch):
+    """tg_ok=false is not proof of delivery — the mirror path must still fire."""
+    now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
+    run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),
+               summary=f'{HEADING}\n恒指 25,713 ▲1.59%',
+               delivery={'messageToolSentTo': None})
+    marker = {'ts': int(datetime(2026, 7, 29, 10, 34, tzinfo=HKT).timestamp() * 1000),
+              'tg_ok': False, 'first_line': HEADING, 'job': '盘中盯盘', 'slot': SLOT}
+
+    watchdog, sends, _, events = _wire_watchdog(
+        monkeypatch, tmp_path, run=run, now=now, marker=marker)
+
+    assert watchdog.main() == 0
+    assert len(sends) == 1
+    assert events[-1]['action'] == 'mirror-telegram'
+    assert events[-1]['reason'] == 'postflight cosend failed'


### PR DESCRIPTION
## What happened

The 2026-07-29 10:30 HK slot was delivered correctly — `intraday_postflight` wrote `memory/.tmp/intraday-sent-hk.json` at 10:34:23 with `tg_ok: true`, matching `job`/`slot`/`first_line` — and the watchdog still pushed a duplicate deterministic fallback at 10:40:25 (`loop_score: 1`, so not even a loop).

## Cause: gate ordering, not detection

The generation gate ran before the marker gate, and both of its signals are structurally weak:

| signal | why it fails |
|---|---|
| `delivery.messageToolSentTo` | empty **by design** since the 2026-06-03 double-send fix moved sending out of the model's hands. Can never be true again for these crons. |
| `raw_block_first in summary` | `summary` is openclaw's truncated meta-prose; under Mode 7 prose mode it carries the analysis, not the data block. |

Same morning, same code, opposite outcomes — which is what makes it a coin flip rather than a detector:

| slot | summary starts | contains heading | result |
|---|---|---|---|
| 10:00 | `Postflight 通过。微信 + Telegram 已发…` | yes | ok |
| 10:30 | `▎我的看法\n\n今天恒指 +1.59%…` | no | duplicate fallback |

Because the gate above returned first, the one piece of *positive* delivery proof — the marker — was never read.

This is the 2026-06-01 `report_watchdog` Bug A recurring: run-record `summary` was judged unreliable back then and demoted to a fallback judge, with `messageToolSentTo` promoted to primary. Two days later the double-send fix silently killed the primary, leaving the known-unreliable one carrying the gate alone.

## Change

Reorder the gates to **marker → generation → mirror**. A confirmed marker means kcn already has the report and no backstop can improve on it. Everything below is untouched and still fires whenever delivery is unproven: marker missing, `tg_ok: false`, stale or mismatched slot.

A loop on an already-delivered run is logged with `loop_score` + `looped_but_delivered` instead of re-sent — detection stays visible, the duplicate does not.

## Verification

- 4 tests added, **mutation-verified**: restoring the old ordering turns the two marker-first tests red with exactly the live symptom (`deterministic_fallback: true`). The other two guard against over-fixing — missing marker and `tg_ok: false` must still send.
- **Replayed against the real 10:30 files** (actual marker, run record, session transcript; only wall clock and slot pinned): `action: ok`, zero sends.
- Full local suite: 1251 passed, 5 xfailed.

## Review notes for Codex

Two judgement calls worth a second opinion:

1. **Loop + confirmed marker ⇒ no re-send.** Rationale: postflight assembles the data block itself and the marker's `first_line` match proves this slot's block went out, so a fallback would only duplicate the same numbers with less prose. Counter-argument to weigh: a repeat-loop can still poison the prose half of a delivered message, and the log line is a weaker signal than a Telegram message.
2. **`messageToolSentTo` kept rather than deleted.** It is dead for these crons under the current architecture. I left it as a marker-missing last resort instead of removing it — arguably it should go, since a permanently-false signal in a boolean `or` is noise.

---

## Second pass (`faab08a7`) — hardening after cross-review

The two judgement calls above were resolved against my first cut, plus two extra guards:

**1. A confirmed marker no longer suppresses a detected loop.** `tg_ok` only proves the send subprocess exited 0 — it never inspects the body. postflight's 3500-char cap does catch most repeat-loops (fail-closes to the data block plus a 🔴 banner kcn can see), but a loop that stays under the cap passes validation and goes out as normal-looking prose. Since `watchdog.jsonl` is not something kcn reads, logging it was the silent downgrade the standing rule forbids. The loop gate now sits **above** the marker gate: `loop → marker → generation → mirror`.

**2. `messageToolSentTo` deleted** rather than kept as a last resort. No canonical path can set it truthfully, and if it ever did fire it would mark a contract-violating run as delivered and mirror a truncated summary as the report.

**3. Marker freshness is now bounded on both sides.** A corrupt or clock-skewed future `ts` could otherwise read as infinitely fresh and suppress every backstop. The tolerance is deliberately **asymmetric** (5 min of future skew allowed): postflight can legitimately finish its send in the seconds *after* the watchdog reads its own wall clock, and that marker is fresher evidence, not staler. A symmetric `0 <=` bound would have reintroduced this PR's duplicate in a narrow window — there is a test pinning that.

**4. A fallback that could not be sent records `watchdog_failed`,** matching what the mirror path already did. It was the one state nobody downstream could infer.

### Considered and not done

**Binding the marker to a `context_id` / body digest.** The risk raised was a same-slot rerun inside the 25-min window matching a stale marker. `marker_covers_slot` already compares `first_line`, and that heading carries the quote minute (`🇭🇰 港股盯盘 | 07/29 10:32 HKT`), so a rerun regenerates it at a different minute and the marker stops matching. A digest would be real hardening but is not a gap this PR opens.

**Two pre-existing silent-return paths**, both a different failure class (the run never happened, vs. the run happened and delivery is in question): `expected slot has no completed run` returns with no fallback, no retry and no heartbeat; and the stale-context race returns after logging. I hit the second live while re-replaying — by ~11:05 the context had rolled to the 11:00 slot. Both deserve their own PR rather than widening this one.

### Verification

4 more tests, each mutation-verified: reverting any one of the four changes above turns exactly one test red. Full suite 1255 passed, 5 xfailed. Replayed against the captured real 10:30 marker/context/run-record: `action: ok`, `delivery_state: delivered`, zero sends.
