### PR TITLE
fix(calendar): keep Mid-Autumn sessions open

### DIFF
--- a/scripts/data/trading_calendar.py
+++ b/scripts/data/trading_calendar.py
@@ -27,6 +27,8 @@ Sources (authoritative, re-checked 2026-07-27):
     https://www.gov.hk/en/about/abouthk/holiday/2027.htm
   HKEX Rule 501 half-day sessions (eves of LNY/Christmas/New Year only):
     https://www.hkex.com.hk/-/media/hkex-market/services/trading-hours-and-severe-weather-arrangements/severe-weather-arrangements/trading/chap-5_eng
+  HKEX 2027 holiday/half-day circular (pins the three concrete half-days):
+    https://www.hkex.com.hk/-/media/HKEX-Market/Services/Circulars-and-Notices/Participant-and-Members-Circulars/SEHK/2026/MO_DT_133_26_e1.pdf
 
 CLI:
   python3 trading_calendar.py hk            -> prints OPEN/CLOSED, exit 0/1
@@ -89,7 +91,7 @@ HK_HOLIDAYS = {
     "2026-05-25",  # Buddha's Birthday (Mon)
     "2026-06-19",  # Tuen Ng / Dragon Boat (Fri)
     "2026-07-01",  # HKSAR Establishment Day (Wed)
-    "2026-09-26",  # Mid-Autumn Festival (Sat - weekend)
+    "2026-09-26",  # Day following Mid-Autumn Festival (Sat - weekend)
     "2026-10-01",  # National Day (Thu)
     "2026-10-19",  # Chung Yeung Festival (Mon)
     "2026-12-25",  # Christmas Day (Fri)

--- a/scripts/data/trading_calendar.py
+++ b/scripts/data/trading_calendar.py
@@ -25,9 +25,8 @@ Sources (authoritative, re-checked 2026-07-27):
     https://ir.theice.com/press/news-details/2024/NYSE-Group-Announces-2025-2026-and-2027-Holiday-and-Early-Closings-Calendar/default.aspx
   HK general holidays, gazetted:
     https://www.gov.hk/en/about/abouthk/holiday/2027.htm
-  HKEX half-day sessions (eves of LNY/Christmas/New Year, and the day of the
-  Mid-Autumn Festival — morning session only, no afternoon):
-    https://www.hkex.com.hk/Services/Trading-hours-and-Severe-Weather-Arrangements/Trading-Hours/Securities-Market?sc_lang=en
+  HKEX Rule 501 half-day sessions (eves of LNY/Christmas/New Year only):
+    https://www.hkex.com.hk/-/media/hkex-market/services/trading-hours-and-severe-weather-arrangements/severe-weather-arrangements/trading/chap-5_eng
 
 CLI:
   python3 trading_calendar.py hk            -> prints OPEN/CLOSED, exit 0/1
@@ -120,13 +119,11 @@ HK_HOLIDAYS = {
 # so a trading day, but afternoon-session crons should treat them as closed.
 HK_HALF_DAYS = {
     "2026-02-16",  # Lunar New Year's Eve (Mon)
-    "2026-09-25",  # Day before Mid-Autumn (Fri)
     "2026-12-24",  # Christmas Eve (Thu)
     "2026-12-31",  # New Year's Eve (Thu)
 
     # 2027
     "2027-02-05",  # Lunar New Year's Eve (Fri)
-    "2027-09-15",  # Mid-Autumn Festival day (Wed) — the holiday is the day after
     "2027-12-24",  # Christmas Eve (Fri) — US is shut, HK trades the morning
     "2027-12-31",  # New Year's Eve (Fri)
 }

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -73,7 +73,6 @@ def test_us_christmas_eve_is_shut_while_hk_trades_the_morning():
 
 @pytest.mark.parametrize("iso,what", [
     ("2027-02-05", "Lunar New Year's Eve"),
-    ("2027-09-15", "Mid-Autumn Festival day — the holiday is the day after"),
     ("2027-12-24", "Christmas Eve"),
     ("2027-12-31", "New Year's Eve"),
 ])
@@ -84,10 +83,28 @@ def test_2027_hk_half_days_trade_the_morning_only(iso, what):
     assert trading_calendar.closed_reason("hk", d, session="afternoon") == "半日市·午后休市"
 
 
-def test_mid_autumn_is_a_half_day_and_the_day_after_is_the_closure():
-    """Getting these two the wrong way round loses a real trading session."""
-    assert trading_calendar.is_trading_day("hk", date(2027, 9, 15))
-    assert not trading_calendar.is_trading_day("hk", date(2027, 9, 16))
+@pytest.mark.parametrize("festival,holiday", [
+    ("2026-09-25", "2026-09-26"),
+    ("2027-09-15", "2027-09-16"),
+])
+def test_mid_autumn_trades_a_full_day_and_the_day_after_is_closed(festival, holiday):
+    """HKEX Rule 501 does not make Mid-Autumn Festival day a half-day."""
+    festival_day = date.fromisoformat(festival)
+    assert trading_calendar.is_trading_day("hk", festival_day)
+    assert trading_calendar.is_trading_day("hk", festival_day, session="afternoon")
+    assert trading_calendar.closed_reason(
+        "hk", festival_day, session="afternoon"
+    ) is None
+    assert not trading_calendar.is_trading_day("hk", date.fromisoformat(holiday))
+
+
+@pytest.mark.parametrize("iso", ["2026-09-25", "2027-09-15"])
+@pytest.mark.parametrize("phase", ["pm", "close"])
+def test_mid_autumn_keeps_hk_pm_and_close_report_gates_open(iso, phase):
+    d = date.fromisoformat(iso)
+    session = trading_calendar.phase_session("hk", phase)
+    assert session == "afternoon"
+    assert trading_calendar.closed_reason("hk", d, session=session) is None
 
 
 def test_an_ordinary_2027_weekday_still_trades():

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -95,6 +95,9 @@ def test_mid_autumn_trades_a_full_day_and_the_day_after_is_closed(festival, holi
     assert trading_calendar.closed_reason(
         "hk", festival_day, session="afternoon"
     ) is None
+    # 2026's gazetted holiday falls on Saturday, so behavior alone would only
+    # prove the weekend branch. Pin both concrete holiday-table entries too.
+    assert holiday in trading_calendar.HK_HOLIDAYS
     assert not trading_calendar.is_trading_day("hk", date.fromisoformat(holiday))
 
 


### PR DESCRIPTION
Closes #141

## Summary
- remove the two incorrect Mid-Autumn dates from `HK_HALF_DAYS`
- align the module documentation with HKEX Rule 501
- pin full-session and report-gate behavior for 2026-09-25 and 2027-09-15

## Verification
- `python3 -m pytest tests/test_trading_calendar.py -q` (30 passed)
- `git diff --check`