### PR TITLE
fix(dashboard): repair wide desktop composition

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -304,7 +304,7 @@
     .swipe-hint { display: none; }
     main {
       display: block;
-      max-width: 1280px; margin: 0 auto;
+      max-width: 1600px; margin: 0 auto;
       padding: 24px 28px 40px;
     }
     .pager { display: block; }
@@ -322,10 +322,34 @@
     .panel.active > * { break-inside: avoid; }
     .panel.active > .card { margin: 0 0 22px; }
     .panel.active > .card.lead,
+    .panel.active > .card.desktop-wide,
     .panel.active > .sect-divider,
     .panel.active > .today-highlights,
     .panel.active > h2 { column-span: all; }
     .panel.active > .sect-divider { margin: 6px 0 18px; }
+    /* Holdings needs one continuous masonry flow. Full-width dividers used to
+       partition it into rigid mini-flows, leaving a 659px blank band beside the
+       tall tables. Keep the labels in flow so later cards can fill that space. */
+    .panel.active[data-panel="drill"] > .sect-divider {
+      column-span: none;
+      break-after: avoid;
+      margin: 6px 2px 14px;
+    }
+    .panel.active[data-panel="drill"] > .holdings-section-heading {
+      column-span: all;
+    }
+    .panel.active[data-panel="drill"] > .price-section-heading,
+    .panel.active[data-panel="drill"] > .policy-section-heading {
+      display: none;
+    }
+    .panel.active[data-panel="drill"] .desktop-section-kicker {
+      display: block;
+      margin-bottom: 10px;
+      color: var(--text-dim);
+      font: 700 10px var(--mono);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
     .panel.active > .today-highlights { margin-bottom: 20px; }
     /* Tab already names the view → panel <h2> stays in the a11y tree only. */
     .panel.active > h2 { width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%);
@@ -348,6 +372,7 @@
       break-inside: avoid; margin-bottom: var(--space-2);
     }
   }
+  .desktop-section-kicker { display: none; }
   /* =========================================================
      Card primitives
      ========================================================= */
@@ -1633,6 +1658,17 @@
   @media (min-width: 1024px) {
     .panel.active[data-panel="hero"] { column-count: auto; }
     .panel.active[data-panel="hero"] > .overview-command { column-span: all; }
+    .overview-command > .hero-honesty-card { align-self: start; }
+    .profit-extremes-card .ext-row .v {
+      white-space: nowrap;
+      overflow-wrap: normal;
+    }
+    .desktop-wide .holdings-table th,
+    .desktop-wide .holdings-table td {
+      height: 36px;
+      padding-top: 6px;
+      padding-bottom: 6px;
+    }
   }
   .overview-command {
     display: grid; grid-template-columns: repeat(12, minmax(0, 1fr));

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1660,8 +1660,12 @@
     .panel.active[data-panel="hero"] > .overview-command { column-span: all; }
     .overview-command > .hero-honesty-card { align-self: start; }
     .profit-extremes-card .ext-row .v {
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
       white-space: nowrap;
       overflow-wrap: normal;
+      text-overflow: ellipsis;
     }
     .desktop-wide .holdings-table th,
     .desktop-wide .holdings-table td {

--- a/index.html
+++ b/index.html
@@ -284,9 +284,9 @@ layout: null
   <section class="panel" data-panel="drill">
     <h2>Holdings</h2>
 
-    <div class="sect-divider">持仓明细</div>
+    <div class="sect-divider holdings-section-heading">持仓明细</div>
 
-    <div class="card" id="decision-matrix-card">
+    <div class="card desktop-wide" id="decision-matrix-card">
       <h3>持仓决策矩阵 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">每持仓一行 · 价/量化/52w位置/硬闸 汇总</span></h3>
       <div class="table-wrap">
         <table class="holdings-table" id="decision-matrix-table" style="min-width:560px;font-size:12px">
@@ -301,7 +301,7 @@ layout: null
       <div class="muted" id="decision-matrix-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
     </div>
 
-    <div class="card">
+    <div class="card desktop-wide" id="holdings-card">
       <h3>Holdings <span class="muted" id="holdings-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
       <div class="table-wrap">
         <table class="holdings-table" id="holdings-table">
@@ -350,16 +350,18 @@ layout: null
       </div>
     </div>
 
-    <div class="sect-divider">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">latest local session · US / HK 各取最近本地交易时段</span></div>
+    <div class="sect-divider price-section-heading">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">latest local session · US / HK 各取最近本地交易时段</span></div>
 
-    <div class="card">
+    <div class="card" id="movers-card">
+      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
       <h3>Today's Movers <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500">(≥3% · latest local session)</span></h3>
       <div class="movers-scroll" id="movers-scroll">
         <div class="empty-state">No movers ≥3% today.</div>
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" id="anomalies-card">
+      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
       <h3>Anomalies <span class="badge muted" id="anom-count"></span></h3>
       <div class="anomaly-list" id="anomaly-list">
         <div class="empty-state">No anomalies detected.</div>
@@ -381,9 +383,10 @@ layout: null
       </div>
     </div>
 
-    <div class="sect-divider">政策模拟</div>
+    <div class="sect-divider policy-section-heading">政策模拟</div>
 
     <div class="card" id="shadow-portfolio-card">
+      <div class="desktop-section-kicker" aria-hidden="true">政策模拟 · Policy replay</div>
       <button type="button" class="shadow-toggle" id="shadow-portfolio-toggle"
               aria-expanded="false" aria-controls="shadow-portfolio-expanded">
         <span class="shadow-toggle-title">Shadow Portfolio · Policy Replay</span>
@@ -548,7 +551,7 @@ layout: null
       <div class="muted" id="breakeven-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
     </div>
 
-    <div class="card">
+    <div class="card lead profit-extremes-card">
       <h3>历史利润极值 & 回撤恢复 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(峰值 / 谷底 / 最大回撤 / 恢复)</span></h3>
       <p class="chart-hint">主口径 = <b>总利润（浮盈＋已实现，净化本金）</b>：<b>加减仓不会影响它</b>，所以它的<b>峰值才是"真·赚最多"那天</b>。<b>历史最高/最低利润</b> = 有快照以来的利润峰值与谷底；<b>最大回撤</b> = 从利润峰到其后最深谷的跌幅（% 仅在利润全程为正时给出，否则只报金额）；<b>距利润峰值</b> = 今天离它还差多少；<b>恢复%</b> = 从最深处反弹回来多少（100%＝已回峰值，0%＝仍在底部）。<br>下半区灰色 = <b>净值口径（市值＋已实现）</b>，<b>仅供参考</b>：买入会把它抬高（花掉的现金不计入净值），所以它常显示"假新高"——别把它当真峰值。<span id="extremes-window" class="muted"></span></p>
       <div class="ext-grid" id="ext-grid">

--- a/index.html
+++ b/index.html
@@ -353,7 +353,7 @@ layout: null
     <div class="sect-divider price-section-heading">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">latest local session · US / HK 各取最近本地交易时段</span></div>
 
     <div class="card" id="movers-card">
-      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
+      <div class="desktop-section-kicker" role="heading" aria-level="2">价格动态 · Price action</div>
       <h3>Today's Movers <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500">(≥3% · latest local session)</span></h3>
       <div class="movers-scroll" id="movers-scroll">
         <div class="empty-state">No movers ≥3% today.</div>
@@ -369,6 +369,7 @@ layout: null
     </div>
 
     <div class="card">
+      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
       <h3>8日走势热力 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(近 8 日走势 + 收益 · 按强弱排序)</span></h3>
       <p class="chart-hint">每格一只持仓：<b>背景色</b> = 8 日回报（绿 = 在跑、红 = 在拖），<b>白色折线</b> = 这 8 日的价格走势形状，下方小字 = 各自市场 leg 内权重（不是组合权重）。颜色看强弱、折线看路径，重仓 + 大红块 = 优先审视。</p>
       <div class="ret-heatmap" id="ret-heatmap">
@@ -377,6 +378,7 @@ layout: null
     </div>
 
     <div class="card">
+      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
       <h3>Today's Range <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500">(high-low ÷ price · latest local session)</span></h3>
       <div class="range-list" id="range-list">
         <div class="empty-state">No range data yet.</div>
@@ -386,7 +388,7 @@ layout: null
     <div class="sect-divider policy-section-heading">政策模拟</div>
 
     <div class="card" id="shadow-portfolio-card">
-      <div class="desktop-section-kicker" aria-hidden="true">政策模拟 · Policy replay</div>
+      <div class="desktop-section-kicker" role="heading" aria-level="2">政策模拟 · Policy replay</div>
       <button type="button" class="shadow-toggle" id="shadow-portfolio-toggle"
               aria-expanded="false" aria-controls="shadow-portfolio-expanded">
         <span class="shadow-toggle-title">Shadow Portfolio · Policy Replay</span>

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -12,6 +12,22 @@ HTML = (ROOT / "index.html").read_text()
 CSS = (ROOT / "assets" / "css" / "dashboard.css").read_text()
 
 
+def enclosing_desktop_block(rule_start):
+    """Return the nearest 1024px media block containing a rule."""
+    block_start = CSS.rindex("@media (min-width: 1024px)", 0, rule_start)
+    brace_start = CSS.index("{", block_start)
+    depth = 0
+    for index in range(brace_start, len(CSS)):
+        if CSS[index] == "{":
+            depth += 1
+        elif CSS[index] == "}":
+            depth -= 1
+            if depth == 0:
+                assert block_start < rule_start < index
+                return CSS[block_start:index + 1]
+    raise AssertionError("desktop media block is not closed")
+
+
 def test_wide_table_and_profit_cards_own_desktop_width():
     assert 'class="card desktop-wide" id="decision-matrix-card"' in HTML
     assert 'class="card desktop-wide" id="holdings-card"' in HTML
@@ -29,18 +45,23 @@ def test_holdings_dividers_do_not_partition_the_masonry_flow():
     assert ".price-section-heading," in CSS
     assert 'id="movers-card"' in HTML
     assert 'id="anomalies-card"' in HTML
-    assert HTML.count('class="desktop-section-kicker"') == 3
+    assert HTML.count('class="desktop-section-kicker"') == 5
+    assert HTML.count(
+        'class="desktop-section-kicker" role="heading" aria-level="2"'
+    ) == 2
 
 
 def test_desktop_numeric_and_overview_height_rules_are_scoped_to_desktop():
-    desktop = CSS.index("@media (min-width: 1024px)")
     honesty = CSS.index(
         ".overview-command > .hero-honesty-card { align-self: start; }"
     )
     nowrap = CSS.index(".profit-extremes-card .ext-row .v {", honesty)
-    assert desktop < honesty < nowrap
+    block = enclosing_desktop_block(honesty)
+    assert ".overview-command > .hero-honesty-card { align-self: start; }" in block
+    assert ".profit-extremes-card .ext-row .v {" in block
     rule = CSS[nowrap:CSS.index("}", nowrap)]
     assert "white-space: nowrap" in rule
     assert "overflow-wrap: normal" in rule
-    assert ".desktop-wide .holdings-table th," in CSS[desktop:]
-    assert "height: 36px" in CSS[desktop:]
+    assert "text-overflow: ellipsis" in rule
+    assert ".desktop-wide .holdings-table th," in block
+    assert "height: 36px" in block

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -1,0 +1,46 @@
+"""Static guardrails for the desktop-only layout fixes.
+
+Rendered Chromium smoke tests remain the visual proof. These checks make the
+intentional ownership classes and desktop scope hard to lose in a later CSS
+refactor.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = (ROOT / "index.html").read_text()
+CSS = (ROOT / "assets" / "css" / "dashboard.css").read_text()
+
+
+def test_wide_table_and_profit_cards_own_desktop_width():
+    assert 'class="card desktop-wide" id="decision-matrix-card"' in HTML
+    assert 'class="card desktop-wide" id="holdings-card"' in HTML
+    assert 'class="card lead profit-extremes-card"' in HTML
+    assert ".panel.active > .card.desktop-wide," in CSS
+
+
+def test_holdings_dividers_do_not_partition_the_masonry_flow():
+    selector = '.panel.active[data-panel="drill"] > .sect-divider'
+    start = CSS.index(selector)
+    rule = CSS[start:CSS.index("}", start)]
+    assert "column-span: none" in rule
+    assert "break-after: avoid" in rule
+    assert ".holdings-section-heading" in CSS
+    assert ".price-section-heading," in CSS
+    assert 'id="movers-card"' in HTML
+    assert 'id="anomalies-card"' in HTML
+    assert HTML.count('class="desktop-section-kicker"') == 3
+
+
+def test_desktop_numeric_and_overview_height_rules_are_scoped_to_desktop():
+    desktop = CSS.index("@media (min-width: 1024px)")
+    honesty = CSS.index(
+        ".overview-command > .hero-honesty-card { align-self: start; }"
+    )
+    nowrap = CSS.index(".profit-extremes-card .ext-row .v {", honesty)
+    assert desktop < honesty < nowrap
+    rule = CSS[nowrap:CSS.index("}", nowrap)]
+    assert "white-space: nowrap" in rule
+    assert "overflow-wrap: normal" in rule
+    assert ".desktop-wide .holdings-table th," in CSS[desktop:]
+    assert "height: 36px" in CSS[desktop:]


### PR DESCRIPTION
Closes #109
Closes #110
Closes #111
Closes #112
Closes #113

## Summary
- expand the desktop canvas from 1280px to 1600px while leaving the mobile pager untouched
- give the decision matrix, holdings table, and profit-extremes card the width their content requires
- keep Holdings masonry continuous across editorial section labels, with per-column section kickers preserving context
- stop the Overview self-grading card from stretching to Gold DCA height
- keep desktop currency values on one line and compact wide-table rows

## Same-host Chromium evidence (before -> after at 1920px)
- main width: 1280 -> 1600px
- self-grading card: 929 -> 265px (703px blank area removed)
- holdings table client/scroll width: 567/940 -> 1510/1510px
- Position-to-heatmap blank band: 675 -> -93px (continuous staggered flow)
- profit-extremes column width: 178 -> 493px; split values 60 -> 30px single-line height
- mobile 390px document width remains 390/390; table inner scrolling remains enabled

## Verification
- `python3 -m pytest tests/test_dashboard_desktop_layout_contract.py tests/test_dashboard_hero_native_chart.py tests/test_dashboard_security.py tests/test_pages_deployment_contract.py -q` (15 passed)
- light-mode Chromium visual smoke: Overview, Holdings, Risk at 1920px
- responsive geometry probe: 390, 1280, 1920, 2560px
- `git diff --check`