### PR TITLE
perf(dashboard): render detail tabs on activation

### DIFF
--- a/assets/js/dashboard.charts.js
+++ b/assets/js/dashboard.charts.js
@@ -11,16 +11,25 @@
     reflect: () => { renderShadowChart(); renderRealizedChart(); renderDailyPnlChart(); },
   };
   const _chartTabsShown = new Set();
-  let _echartsLoading = false;
+  let _echartsPromise = null;
   function whenEcharts(cb) {
     if (window.echarts) return cb();
-    if (!_echartsLoading) {  // first chart tab shown → fetch the ~1MB bundle now, once
-      _echartsLoading = true;
-      const s = document.createElement("script");
-      s.src = "assets/js/echarts.min.js";
-      document.head.appendChild(s);
+    if (!_echartsPromise) {  // first chart tab shown → fetch the bundle once
+      _echartsPromise = new Promise((resolve, reject) => {
+        const s = document.createElement("script");
+        s.src = "assets/js/echarts.min.js";
+        s.onload = () => window.echarts
+          ? resolve(true)
+          : reject(new Error("ECharts loaded without a global"));
+        s.onerror = () => reject(new Error("ECharts bundle failed to load"));
+        document.head.appendChild(s);
+      }).catch(error => {
+        console.error(error);
+        _echartsPromise = null;       // a later activation may retry
+        return false;
+      });
     }
-    const iv = setInterval(() => { if (window.echarts) { clearInterval(iv); cb(); } }, 50);
+    _echartsPromise.then(ready => { if (ready && window.echarts) cb(); });
   }
   function paintCharts(t) {
     if (!DATA) return;

--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -371,47 +371,11 @@
     if (t === "risk" || t === "market") updateFoldPeeks();
   }
 
-  function scheduleDeferredTabs(version, activeTab) {
-    const jobs = TAB_ORDER
-      .filter(t => t !== activeTab)
-      .flatMap(t => TAB_RENDERERS[t].map(fn => ({ t, fn })));
-    const remaining = new Map(
-      TAB_ORDER.filter(t => t !== activeTab).map(t => [t, TAB_RENDERERS[t].length])
-    );
-    const schedule = window.requestIdleCallback
-      ? cb => requestIdleCallback(cb, { timeout: 2000 })
-      : cb => setTimeout(() => cb({ didTimeout: true, timeRemaining: () => 0 }), 32);
-    const runOne = () => {
-      if (version !== RENDER_VERSION || !DATA) return;
-      const job = jobs.shift();
-      if (job && _tabRenderVersion.get(job.t) !== version) {
-        job.fn();
-        const left = (remaining.get(job.t) || 1) - 1;
-        remaining.set(job.t, left);
-        if (left === 0) {
-          _tabRenderVersion.set(job.t, version);
-          if (job.t === "risk" || job.t === "market") updateFoldPeeks();
-        }
-      }
-      if (jobs.length) {
-        // One renderer per idle slice. A whole hidden tab used to become a second
-        // long task even after render() was split by tab.
-        schedule(runOne);
-      } else {
-        syncDeskRail();             // refresh after all canonical cells exist
-      }
-    };
-    if (jobs.length) schedule(runOne);
-  }
-
-  // Re-render ONE tab's DOM in place after a sidecar it depends on arrives, without
-  // bumping the global RENDER_VERSION or touching any other tab. Overview (hero) has
-  // no sidecar dependency, so a background sidecar can never re-render or re-animate
-  // it — its equity chart stays put. If the refreshed tab happens to be the visible
-  // one (a deep link that landed before its data, or a poll on that tab), its charts
-  // repaint; animationDurationUpdate:0 keeps that repaint flicker-free.
+  // Re-render the visible tab after its sidecars revalidate. Hidden tabs are
+  // never runtime consumers: their cached data is marked stale by the poll and
+  // they render only when activated.
   function refreshTab(t) {
-    if (!DATA || !TAB_RENDERERS[t]) return;
+    if (!DATA || !TAB_RENDERERS[t] || currentTab() !== t) return;
     TAB_RENDERERS[t].forEach(fn => fn());
     _tabRenderVersion.set(t, RENDER_VERSION);
     const panel = document.querySelector(`.panel[data-panel="${t}"]`);
@@ -432,7 +396,6 @@
     renderBuildStatus();
     syncDeskRail();
     ensureVisibleCharts();
-    scheduleDeferredTabs(version, activeTab);
   }
 
   // ── A2 系统健康卡（页脚）──

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -55,16 +55,10 @@
       p.classList.toggle("active", p.dataset.panel === t);
     });
     if (DATA) {
-      renderTab(t);                 // a fast switch can beat the idle renderer
-      const activePanel = document.querySelector(`.panel[data-panel="${t}"]`);
-      if (activePanel) activePanel.querySelectorAll(".card.is-pending").forEach(card =>
-        card.classList.remove("is-pending"));
-      ensureTabCharts(t);           // lazy: draw this tab's charts the first time it's shown
-      // Desktop shows one panel at a time now: the newly-visible panel may have
-      // initialized its charts at a container size that only just settled → nudge
-      // ECharts to fill it. (Mobile does this off the pager scroll-settle instead.)
-      if (!pagerLive()) requestAnimationFrame(() =>
-        requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))));
+      // Activation is the consumer boundary: mapped sidecars load first, then
+      // this tab alone renders. Rapid swipes share in-flight fetches and the last
+      // visible tab wins, so no hidden panel receives runtime DOM.
+      activateTabData(t);
     }
     const btn = document.querySelector(`.tab-btn[data-tab="${t}"]`);
     if (btn) btn.scrollIntoView({ block: "nearest", inline: "center", behavior: SCROLL_BEHAVIOR });
@@ -196,6 +190,101 @@
   // user whether a refresh actually pulled new data vs. they got the same JSON.
   let LAST_LOADED_AT = null;
   let AUTO_REFRESH_TIMER = null;
+  const SIDECAR_TAB = {
+    macro: "market", sentiment: "market", influencer_feed: "market",
+    us_news_digest: "market", em_news: "market",
+    decision_audit: "reflect", shadow_portfolio: "drill",
+    brief_projection: "drill",
+  };
+  const SIDECAR_STATE = new Map();
+  let TAB_ACTIVATION_VERSION = 0;
+
+  function _sidecarsForTab(t) {
+    return Object.keys(SIDECAR_TAB).filter(k => SIDECAR_TAB[k] === t);
+  }
+
+  function _sidecarState(k) {
+    if (!SIDECAR_STATE.has(k)) {
+      SIDECAR_STATE.set(k, {
+        value: null, ready: false, stale: true, inFlight: null,
+      });
+    }
+    return SIDECAR_STATE.get(k);
+  }
+
+  function _applySidecars(target) {
+    Object.keys(SIDECAR_TAB).forEach(k => {
+      const state = _sidecarState(k);
+      target[k] = state.ready ? state.value : null;
+    });
+  }
+
+  function _markLoadedSidecarsStale() {
+    SIDECAR_STATE.forEach(state => {
+      // An in-flight request is already revalidating this consumer. Do not make
+      // a second request race it merely because dashboard.json landed first.
+      if (state.ready && !state.inFlight) state.stale = true;
+    });
+  }
+
+  function _fetchSidecar(k, triggeredByUser, requestStamp) {
+    const state = _sidecarState(k);
+    if (state.inFlight) return state.inFlight;
+    if (state.ready && !state.stale) return Promise.resolve(state.value);
+
+    const bust = triggeredByUser ? "?t=" + requestStamp : "";
+    state.inFlight = fetch("assets/data/" + k + ".json" + bust, {
+      cache: triggeredByUser ? "no-store" : "no-cache",
+    }).then(async response => response.ok ? await response.json() : null)
+      .catch(() => null)
+      .then(value => {
+        state.value = value;
+        state.ready = true;
+        state.stale = false;
+        return value;
+      })
+      .finally(() => { state.inFlight = null; });
+    return state.inFlight;
+  }
+
+  async function _loadTabSidecars(t, triggeredByUser = false) {
+    const keys = _sidecarsForTab(t);
+    if (!keys.length) return;
+    const requestStamp = Date.now();
+    await Promise.all(keys.map(k => _fetchSidecar(k, triggeredByUser, requestStamp)));
+  }
+
+  function _paintActivatedTab(t) {
+    if (!DATA || currentTab() !== t) return;
+    renderTab(t);
+    ensureTabCharts(t);
+    const panel = document.querySelector(`.panel[data-panel="${t}"]`);
+    if (panel) panel.removeAttribute("aria-busy");
+    // Desktop shows one panel at a time. Let its layout settle before resizing
+    // an existing chart; mobile's scroll-settle listener owns the same nudge.
+    if (!pagerLive()) requestAnimationFrame(() =>
+      requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))));
+  }
+
+  function activateTabData(t) {
+    const version = ++TAB_ACTIVATION_VERSION;
+    const keys = _sidecarsForTab(t);
+    const needsFetch = keys.some(k => {
+      const state = _sidecarState(k);
+      return !state.ready || state.stale || state.inFlight;
+    });
+    const panel = document.querySelector(`.panel[data-panel="${t}"]`);
+    if (needsFetch && panel) panel.setAttribute("aria-busy", "true");
+    if (!needsFetch) {
+      _paintActivatedTab(t);
+      return;
+    }
+    _loadTabSidecars(t).then(() => {
+      if (version !== TAB_ACTIVATION_VERSION || !DATA || currentTab() !== t) return;
+      _applySidecars(DATA);
+      _paintActivatedTab(t);
+    });
+  }
 
   function _formatRelative(iso) {
     if (!iso) return "—";
@@ -234,50 +323,35 @@
       const res = await fetch(url, { cache: triggeredByUser ? "no-store" : "no-cache" });
       if (!res.ok) throw new Error("HTTP " + res.status);
       const json = await res.json();
-      // Option 2 decouple (2026-07-04): the GH-Action scan sidecars are no longer
-      // embedded server-side into dashboard.json — fetch them directly here so a
-      // scan shows up the instant its bot commit lands, with no dashboard rebuild.
-      // Parallel + failure-tolerant: a missing/parse-failed sidecar renders as
-      // absent (same `null` contract the old build_dashboard _embed used). Each is
-      // a separate conditional GET → 304 headers-only when unchanged.
-      //
-      // Scoped to the tab that consumes each one (map below). Reflect's audit and
-      // backtest belong in decision_audit.json; awaiting every sidecar before the
-      // first render used to block Overview on data it never reads. Now we await
-      // only the sidecars the LANDING tab needs (so a
-      // deep-linked #market/#reflect/#drill still shows a COMPLETE tab, never a
-      // partial shell), render, then load the rest in the background and refresh only
-      // their own tab. Overview has no sidecar dependency, so a background arrival
-      // never re-renders or re-animates it.
-      const SIDECAR_TAB = {
-        macro: "market", sentiment: "market", influencer_feed: "market",
-        us_news_digest: "market", em_news: "market",
-        decision_audit: "reflect", shadow_portfolio: "drill",
-        brief_projection: "drill",
-      };
-      const _cache = triggeredByUser ? "no-store" : "no-cache";
-      const _bust = triggeredByUser ? "?t=" + Date.now() : "";
-      const fetchSidecar = async (k) => {
-        try {
-          const r = await fetch("assets/data/" + k + ".json" + _bust, { cache: _cache });
-          json[k] = r.ok ? await r.json() : null;
-        } catch (_e) { json[k] = null; }
-      };
-      const landing = currentTab();
-      const critical = [], deferred = [];
-      for (const k of Object.keys(SIDECAR_TAB)) {
-        (SIDECAR_TAB[k] === landing ? critical : deferred).push(k);
+      // Tab activation is the only sidecar consumer boundary. A normal Hero
+      // landing therefore makes no sidecar requests; a deep link waits for its
+      // mapped dependencies before the first render. Later polls retain the
+      // last good inactive-tab values, mark them stale, and revalidate only the
+      // active tab. The next activation refreshes any inactive stale tab.
+      let landing = currentTab();
+      const firstLoad = DATA == null;
+      if (firstLoad) {
+        // A user can click/swipe while dashboard.json is in flight. Keep the
+        // first paint complete for whichever tab is actually visible when its
+        // dependencies finish, rather than rendering a partial new landing tab.
+        do {
+          landing = currentTab();
+          await _loadTabSidecars(landing, triggeredByUser);
+        } while (currentTab() !== landing);
+      } else {
+        _markLoadedSidecarsStale();
       }
-      await Promise.all(critical.map(fetchSidecar));
+      _applySidecars(json);
       const newAt = json.generated_at;
       const hasNew = newAt && newAt !== LAST_LOADED_AT;
       DATA = json;
       render();
       _updateAgeLabel();
-      if (deferred.length) {
-        Promise.all(deferred.map(fetchSidecar)).then(() => {
-          if (DATA !== json) return;   // a newer load superseded this payload
-          new Set(deferred.map((k) => SIDECAR_TAB[k])).forEach((t) => refreshTab(t));
+      if (!firstLoad && _sidecarsForTab(landing).length) {
+        _loadTabSidecars(landing, triggeredByUser).then(() => {
+          if (DATA !== json || currentTab() !== landing) return;
+          _applySidecars(json);
+          refreshTab(landing);
         });
       }
       if (btn) {

--- a/tests/test_dashboard_tab_lifecycle.py
+++ b/tests/test_dashboard_tab_lifecycle.py
@@ -1,0 +1,67 @@
+"""Consumer-boundary contracts for the tab-lazy dashboard lifecycle."""
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI = (ROOT / "assets" / "js" / "dashboard.ui.js").read_text()
+RENDER = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+CHARTS = (ROOT / "assets" / "js" / "dashboard.charts.js").read_text()
+
+
+def _sidecar_keys() -> set[str]:
+    block = UI.split("const SIDECAR_TAB = {", 1)[1].split("};", 1)[0]
+    return set(re.findall(r"([a-z][a-z0-9_]+)\s*:", block))
+
+
+def test_every_mapped_sidecar_has_a_valid_seed_before_browser_fetches_it():
+    """A new optional producer must not ship a first-party 404 window."""
+    for key in _sidecar_keys():
+        path = ROOT / "assets" / "data" / f"{key}.json"
+        assert path.is_file(), f"{path} needs a schema-valid seed before mapping"
+        assert isinstance(json.loads(path.read_text()), dict)
+
+
+def test_hidden_tabs_have_no_idle_or_timeout_renderer():
+    assert "scheduleDeferredTabs" not in RENDER
+    assert "requestIdleCallback" not in RENDER
+    assert "didTimeout" not in RENDER
+    assert "renderTab(activeTab, version)" in RENDER
+    assert "currentTab() !== t" in RENDER
+
+
+def test_tab_activation_owns_sidecar_fetch_and_inflight_deduplication():
+    for contract in (
+        "const SIDECAR_STATE = new Map()",
+        "function activateTabData(t)",
+        "function _loadTabSidecars(t",
+        "if (state.inFlight) return state.inFlight",
+        "if (state.ready && !state.stale)",
+        "_applySidecars(DATA)",
+        "version !== TAB_ACTIVATION_VERSION",
+    ):
+        assert contract in UI
+    assert "deferred.map(fetchSidecar)" not in UI
+    assert "new Set(deferred" not in UI
+
+
+def test_poll_marks_inactive_data_stale_and_refreshes_only_the_active_tab():
+    load = UI.split("async function loadData", 1)[1].split(
+        "function _scheduleAutoRefresh", 1
+    )[0]
+    assert "_markLoadedSidecarsStale()" in load
+    assert "_loadTabSidecars(landing, triggeredByUser)" in load
+    assert "currentTab() !== landing" in load
+    assert "refreshTab(landing)" in load
+
+
+def test_echarts_uses_one_shared_load_promise_without_polling():
+    loader = CHARTS.split("let _echartsPromise", 1)[1].split(
+        "function paintCharts", 1
+    )[0]
+    assert "new Promise" in loader
+    assert "s.onload" in loader
+    assert "s.onerror" in loader
+    assert "_echartsPromise.then" in loader
+    assert "setInterval" not in loader


### PR DESCRIPTION
Closes #160

## Summary
- make tab activation the only sidecar fetch and runtime-render boundary
- cache sidecars with shared in-flight deduplication and explicit stale state
- remove every idle/timeout hidden-tab renderer
- keep deep links complete by awaiting only their mapped dependencies
- make 60-second polling refresh Hero immediately, revalidate the active tab, and defer inactive refresh until activation
- load ECharts through one shared Promise and allow safe retry on failure
- require every mapped sidecar to have a valid tracked JSON seed before browser code may request it

Producer ownership, dashboard outputs, cron payloads, automation, and Pages artifact flow are unchanged.

## Browser lifecycle evidence
- Hero landing: only `dashboard.json`; zero sidecars, zero ECharts, hidden Holdings DOM stayed empty
- first Holdings activation: only `shadow_portfolio.json`, `brief_projection.json`, and ECharts
- repeat Holdings activation: zero new requests
- Market activation: only its five mapped sidecars
- Reflect activation: only `decision_audit.json`; ECharts reused
- Hero poll: only `dashboard.json`; next Holdings activation revalidated its two stale sidecars
- all six direct hashes rendered complete with zero first-party 4xx/console errors; every active chart canvas had real dimensions
- active Market poll requested dashboard + Market sidecars only

## Same-host Lighthouse mobile (three alternating runs, median)
| metric | baseline | this PR |
|---|---:|---:|
| Performance | 65 | 72 |
| LCP | 3.846s | 3.831s |
| TBT | 1192ms | 774ms |
| CLS | 0.0097 | 0.0097 |
| transfer | 824KB | 527KB |
| requests | 20 | 12 |
| Style & Layout | 2484ms | 1742ms |
| Script Evaluation | 622ms | 319ms |

## Verification
- `node --check` on all three changed JS modules
- 22 targeted pytest contracts passed
- light/dark/deep-link request + DOM smoke in Chromium
- GIF capture `6,6,6,6,6,6`; assembled and fully decoded 72 frames, 640x1376
- screenshot validators: social card 1280x640, backtest 1134x422
- `git diff --check`