### PR TITLE
perf(intraday): remove redundant model round trips

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -63,12 +63,21 @@
         "anthropic/claude-sonnet-4-6"
       ],
       "thinking": "medium",
+      "tools_allow": [
+        "exec",
+        "read",
+        "write",
+        "web_search",
+        "web_fetch"
+      ],
       "delivery_mode": "none",
       "required_substrings": [
-        "trading_calendar.py {market}",
         "skills/{skill}/SKILL.md",
         "intraday_preflight.py --market {market}",
+        "market_closed",
+        "所有脚本 exec 调用都显式设置 `timeout: 300`",
         "context_id",
+        "同一条回复内并行发出两个 `write` 工具调用",
         "intraday_postflight.py --market {market} --context-id",
         "--text-file",
         "intraday-prose-{market}.md",
@@ -92,7 +101,8 @@
         "唯一发送路径",
         "<<<",
         "verbatim",
-        "intraday-report-"
+        "intraday-report-",
+        "trading_calendar.py"
       ]
     },
     "brief": {

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -32,6 +32,16 @@ def load_contract(path: str | Path | None = None) -> dict:
             or any(not model for model in candidates)
         ):
             raise ValueError(f"{profile_name}: model_candidates must be unique models")
+        tools_allow = profile.get("tools_allow")
+        if tools_allow is not None and (
+            not isinstance(tools_allow, list)
+            or not tools_allow
+            or len(tools_allow) != len(set(tools_allow))
+            or any(not isinstance(tool, str) or not tool for tool in tools_allow)
+        ):
+            raise ValueError(
+                f"{profile_name}: tools_allow must be non-empty unique tool names"
+            )
     for job in jobs:
         if bool(job.get("schedule")) == bool(job.get("seasonal_schedules")):
             raise ValueError(f"{job['name']}: define exactly one schedule source")
@@ -148,6 +158,19 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
             f"payload.timeoutSeconds expected {expected_timeout!r}, "
             f"got {payload.get('timeoutSeconds')!r}"
         )
+    expected_tools = profile.get("tools_allow")
+    if expected_tools is not None:
+        live_tools = payload.get("toolsAllow")
+        if not isinstance(live_tools, list):
+            errors.append(
+                f"payload.toolsAllow expected {expected_tools!r}, got {live_tools!r}"
+            )
+        elif len(live_tools) != len(set(live_tools)):
+            errors.append("payload.toolsAllow contains duplicates")
+        elif set(live_tools) != set(expected_tools):
+            errors.append(
+                f"payload.toolsAllow expected {expected_tools!r}, got {live_tools!r}"
+            )
     expected_delivery = profile.get("delivery_mode")
     if expected_delivery is not None and delivery.get("mode") != expected_delivery:
         errors.append(

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -443,6 +443,17 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert 'intraday_postflight.py --market {market} --context-id' in profile['required_substrings']
     assert 'verbatim' in profile['forbidden_substrings']
     assert '<<<' in profile['forbidden_substrings']
+    assert 'trading_calendar.py' in profile['forbidden_substrings']
+    assert 'market_closed' in profile['required_substrings']
+    assert '所有脚本 exec 调用都显式设置 `timeout: 300`' in profile['required_substrings']
+    assert '同一条回复内并行发出两个 `write` 工具调用' in profile['required_substrings']
+    assert profile['tools_allow'] == [
+        'exec', 'read', 'write', 'web_search', 'web_fetch'
+    ]
+    assert 'process' not in profile['tools_allow']
+    # 300s is a per-exec bound. A 300s whole-turn timeout would kill normal
+    # 4–6 minute check-ins before postflight can deliver them.
+    assert 'timeout_seconds' not in profile
 
     vars_ = {'market': 'hk', 'skill': 'hk-stock-analysis'}
     data = contract()
@@ -450,7 +461,8 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
-                    'model': profile['model'], 'thinking': profile['thinking']},
+                    'model': profile['model'], 'thinking': profile['thinking'],
+                    'toolsAllow': profile['tools_allow']},
         'delivery': {'mode': 'none'},
     }
     assert cron_contract.payload_errors(data, expected, live) == []
@@ -479,13 +491,35 @@ def test_intraday_slots_are_unconditional_again():
     message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
-                    'model': profile['model'], 'thinking': profile['thinking']},
+                    'model': profile['model'], 'thinking': profile['thinking'],
+                    'toolsAllow': profile['tools_allow']},
         'delivery': {'mode': 'none'},
         'trigger': {'script': 'json({ fire: false });', 'once': False},
     }
     assert cron_contract.payload_errors(data, expected, live) == [
         'unexpected condition trigger'
     ]
+
+
+def test_intraday_payload_rejects_tool_surface_drift():
+    data = contract()
+    expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
+    profile = data['payload_profiles']['intraday']
+    message = '\n'.join(
+        s.format(**expected['payload_vars']) for s in profile['required_substrings']
+    )
+    live = {
+        'payload': {
+            'message': message,
+            'kind': profile['payload_kind'],
+            'model': profile['model'],
+            'thinking': profile['thinking'],
+            'toolsAllow': [*profile['tools_allow'], 'process'],
+        },
+        'delivery': {'mode': profile['delivery_mode']},
+    }
+    errors = cron_contract.payload_errors(data, expected, live)
+    assert any('toolsAllow expected' in error for error in errors), errors
 
 
 def test_every_twenty_minutes_timeline_label_is_not_every_hour():


### PR DESCRIPTION
Closes #163

## What changes
- constrain Mode 7 tools to `exec,read,write,web_search,web_fetch`, intentionally excluding `process` so long exec calls wait synchronously
- require an explicit per-exec `timeout: 300` without imposing a 300s whole-turn cutoff
- remove the redundant standalone `trading_calendar.py` call; preflight and postflight retain deterministic market-closed gates
- require prose and status-sidecar writes in one assistant response
- enforce tool-surface and payload semantics in the tracked cron contract

## Verification
- `pytest -q tests/test_cron_contracts.py` (24 passed)
- `git diff --check`

## Deployment
After merge, update the three live Mode 7 payload messages and `toolsAllow` through `openclaw cron edit`, then run the full runtime contract check. No light context or output/context trimming is introduced.