### PR TITLE
fix(gold): stabilize settled London history

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -1815,6 +1815,21 @@
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
                · USDCNY ${num(ld.usdcny, 4)}
              </div>`;
+        const histSource = ld.hist_source || {};
+        const histNames = {
+          sina_global_futures_xau: '新浪 XAU 现货',
+          eastmoney_gc00y_fallback: '东财 GC00Y 兜底',
+          unavailable: '历史抓取失败',
+          not_attempted: '历史未抓取',
+        };
+        html += `<div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+          历史源 ${escapeHtml(histNames[histSource.name] || histSource.name || '未知')} · ${num(histSource.points || 0)} 点
+        </div>`;
+        if (ld.hist_advisory) {
+          html += `<div role="status" style="font-size:10px;color:var(--warning);margin-top:4px;text-transform:none;letter-spacing:0">
+            ℹ️ ${escapeHtml(ld.hist_advisory)}
+          </div>`;
+        }
         // DCA 平均成本：同样的钱、同样的定投日子，改买伦敦金现货 → 我的均价是多少（对标基金卡的「平均成本」）
         const de = ld.dca_equiv;
         if (de && de.avg_cost_usd_oz != null) {

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -2309,6 +2309,7 @@ def main():
             # 结算窗的原始参考序列只属于 fetcher 持久状态；dashboard 只需要
             # 来源、点数和可见 advisory，不把整条内部校验账本发到浏览器。
             _gold['london'].pop('hist_series', None)
+            _gold['london'].pop('fx_hist_series', None)
     out['gold_dca'] = _gold
 
     # A2 健康卡：数据新鲜度 + 体检结论（纯文件运算，零网络）

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -2304,6 +2304,11 @@ def main():
         _gold.pop('parent_backtest', None)  # ETF 回测段 2026-06-11 撤除（kcn：没用，就是黄金本身）
         if isinstance(_gold.get('nav_history'), list):
             _gold['nav_history'] = _gold['nav_history'][-90:]  # 迷你图够用，控体积
+        if isinstance(_gold.get('london'), dict):
+            _gold['london'] = dict(_gold['london'])
+            # 结算窗的原始参考序列只属于 fetcher 持久状态；dashboard 只需要
+            # 来源、点数和可见 advisory，不把整条内部校验账本发到浏览器。
+            _gold['london'].pop('hist_series', None)
     out['gold_dca'] = _gold
 
     # A2 健康卡：数据新鲜度 + 体检结论（纯文件运算，零网络）

--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -228,7 +228,8 @@ def fetch_xau_history(start):
     return [], {'name': 'unavailable', 'points': 0}
 
 
-def stabilize_xau_history(fresh, previous, fresh_source, previous_source=None):
+def stabilize_history(fresh, previous, fresh_source, previous_source=None,
+                      label='伦敦金历史'):
     """Accept revisions in the latest settlement window; quarantine old outliers.
 
     A current close can legitimately settle on the next day, so the newest five
@@ -242,12 +243,12 @@ def stabilize_xau_history(fresh, previous, fresh_source, previous_source=None):
     source_name = (fresh_source or {}).get('name', 'unavailable')
     prior_name = (previous_source or {}).get('name')
     if not prior_map:
-        advisory = None if fresh_map else '伦敦金历史抓取失败，暂无可用参考点'
+        advisory = None if fresh_map else f'{label}抓取失败，暂无可用参考点'
         return sorted(fresh_map.items()), advisory
     if not fresh_map:
         return (
             sorted(prior_map.items()),
-            f'伦敦金历史抓取失败，沿用上次 {len(prior_map)} 个参考点',
+            f'{label}抓取失败，沿用上次 {len(prior_map)} 个参考点',
         )
     if source_name == XAU_PRIMARY_SOURCE and prior_name == XAU_FALLBACK_SOURCE:
         return sorted(fresh_map.items()), None
@@ -266,7 +267,7 @@ def stabilize_xau_history(fresh, previous, fresh_source, previous_source=None):
     if quarantined:
         worst_day, worst_pct = max(quarantined, key=lambda item: item[1])
         advisory = (
-            f'伦敦金历史校验：沿用 {len(quarantined)} 个已结算点；'
+            f'{label}校验：沿用 {len(quarantined)} 个已结算点；'
             f'最大新旧偏差 {worst_pct:.2f}%（{worst_day}，源 {source_name}）'
         )
     return sorted(merged.items()), advisory
@@ -366,7 +367,7 @@ def build_london_dca(nav_history, xau_hist, usdcny_hist, xau_cur, usdcny_cur, st
 
 
 def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
-                   hist_source=None, hist_advisory=None):
+                   hist_source=None, fx_hist_source=None, hist_advisory=None):
     """折算 + 对比线 + DCA 对应现值。任一关键源缺失 → 保留旧 london（merge-not-overwrite）。"""
     if not spot or not spot.get('xau_usd') or not usdcny:
         return gold.get('london')  # 抓空：沿用旧值，绝不清空
@@ -400,6 +401,10 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         'dca_equiv': dca_equiv,
         'hist_source': hist_source or {'name': 'unavailable', 'points': 0},
         'hist_series': [[d, round(v, 4)] for d, v in (xau_hist or [])],
+        'fx_hist_source': fx_hist_source or {'name': 'unavailable', 'points': 0},
+        'fx_hist_series': [
+            [d, round(v, 6)] for d, v in sorted((usdcny_hist or {}).items())
+        ],
         'hist_advisory': hist_advisory,
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
     }
@@ -427,7 +432,8 @@ def project_dca(units, principal, nav, daily, horizons=(20, 40, 60, 120, 250)):
 
 
 def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None,
-            xau_hist=None, xau_hist_source=None, xau_hist_advisory=None):
+            xau_hist=None, xau_hist_source=None, fx_hist_source=None,
+            hist_advisory=None):
     base_principal = float(gold['principal_invested'])
     base_units = float(gold['units_held'])
     daily = float(gold.get('daily_amount', 200))
@@ -484,7 +490,7 @@ def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None,
     }
     derived['london'] = compute_london(
         derived, gold, spot, usdcny, usdcny_hist, xau_hist,
-        xau_hist_source, xau_hist_advisory,
+        xau_hist_source, fx_hist_source, hist_advisory,
     )
     return derived
 
@@ -514,22 +520,37 @@ def main():
     else:
         xau_fresh, xau_source = [], {'name': 'not_attempted', 'points': 0}
     old_london = gold.get('london') or {}
-    xau_hist, xau_advisory = stabilize_xau_history(
+    xau_hist, xau_advisory = stabilize_history(
         xau_fresh,
         old_london.get('hist_series') or [],
         xau_source,
         old_london.get('hist_source') or {},
     )
+    fx_source = {
+        'name': 'frankfurter_usdcny',
+        'points': len(usdcny_hist or {}),
+    }
+    fx_hist, fx_advisory = stabilize_history(
+        sorted((usdcny_hist or {}).items()),
+        old_london.get('fx_hist_series') or [],
+        fx_source,
+        old_london.get('fx_hist_source') or {},
+        label='USDCNY 历史',
+    )
+    usdcny_hist = dict(fx_hist)
+    history_advisory = '；'.join(
+        advisory for advisory in (xau_advisory, fx_advisory) if advisory
+    ) or None
     if not spot:
         print('  warn: 伦敦金现货(hf_XAU)抓空，沿用旧 london', file=sys.stderr)
     elif not xau_fresh:
         print('  warn: 伦敦金历史(GC00Y)限流抓空，对比线沿用旧线', file=sys.stderr)
-    if xau_advisory:
-        print(f'  advisory: {xau_advisory}', file=sys.stderr)
+    if history_advisory:
+        print(f'  advisory: {history_advisory}', file=sys.stderr)
 
     derived = compute(
         gold, history, realtime, spot, usdcny, usdcny_hist, xau_hist,
-        xau_source, xau_advisory,
+        xau_source, fx_source, history_advisory,
     )
 
     # merge：真值字段原样保留，派生字段更新；nav_history 抓空时不清空

--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -65,6 +65,10 @@ SEED = {
 
 HISTORY_PAGES = 8     # 8×20 = 160 交易日，够画迷你图 + 取区间高低
 HISTORY_KEEP = 140    # 写回 portfolio.json 的最大点数（控体积）
+XAU_SETTLEMENT_DAYS = 5
+XAU_SETTLED_DRIFT_PCT = 0.3
+XAU_PRIMARY_SOURCE = 'sina_global_futures_xau'
+XAU_FALLBACK_SOURCE = 'eastmoney_gc00y_fallback'
 
 
 def _curl(url, referer):
@@ -186,7 +190,8 @@ def fetch_usdcny(start):
 
 
 def fetch_xau_history(start):
-    """伦敦金现货 XAU 日线收盘，返回 [(date, usd)] 升序、>= start，抓空 []。
+    """伦敦金现货 XAU 日线收盘，返回 ([(date, usd)], source metadata)。
+
     主源 = 新浪全球期货（真·伦敦金现货，回溯 2006，稳）；兜底 = 东财 101.GC00Y（COMEX 连续，会限流）。"""
     s = start or ''
     # ① 新浪 GlobalFutures XAU
@@ -200,7 +205,8 @@ def fetch_xau_history(start):
         out = [(x['date'], float(x['close'])) for x in arr
                if x.get('date', '') >= s and x.get('close')]
         if out:
-            return sorted(out)
+            out = sorted(out)
+            return out, {'name': XAU_PRIMARY_SOURCE, 'points': len(out)}
     except Exception:
         pass
     # ② 兜底 东财 GC00Y（限流时退避重试）
@@ -216,9 +222,54 @@ def fetch_xau_history(start):
     except Exception:
         kl = []
     if kl:
-        return sorted((p[0], float(p[1])) for p in (r.split(',') for r in kl)
-                      if len(p) >= 2 and p[0] >= s and p[1])
-    return []
+        out = sorted((p[0], float(p[1])) for p in (r.split(',') for r in kl)
+                     if len(p) >= 2 and p[0] >= s and p[1])
+        return out, {'name': XAU_FALLBACK_SOURCE, 'points': len(out)}
+    return [], {'name': 'unavailable', 'points': 0}
+
+
+def stabilize_xau_history(fresh, previous, fresh_source, previous_source=None):
+    """Accept revisions in the latest settlement window; quarantine old outliers.
+
+    A current close can legitimately settle on the next day, so the newest five
+    trading dates always win. Older points may revise normally up to 0.3%; a
+    larger move keeps the prior value and emits an advisory instead of silently
+    changing every historical DCA purchase. When the authoritative Sina XAU feed
+    returns after a GC00Y fallback, it replaces the fallback reference outright.
+    """
+    fresh_map = {str(d): float(v) for d, v in (fresh or []) if d and v is not None}
+    prior_map = {str(d): float(v) for d, v in (previous or []) if d and v is not None}
+    source_name = (fresh_source or {}).get('name', 'unavailable')
+    prior_name = (previous_source or {}).get('name')
+    if not prior_map:
+        advisory = None if fresh_map else '伦敦金历史抓取失败，暂无可用参考点'
+        return sorted(fresh_map.items()), advisory
+    if not fresh_map:
+        return (
+            sorted(prior_map.items()),
+            f'伦敦金历史抓取失败，沿用上次 {len(prior_map)} 个参考点',
+        )
+    if source_name == XAU_PRIMARY_SOURCE and prior_name == XAU_FALLBACK_SOURCE:
+        return sorted(fresh_map.items()), None
+
+    recent = set(sorted(fresh_map)[-XAU_SETTLEMENT_DAYS:])
+    merged = dict(prior_map)
+    quarantined = []
+    for day, value in fresh_map.items():
+        old = prior_map.get(day)
+        drift_pct = abs(value / old - 1) * 100 if old else 0
+        if day in recent or old is None or drift_pct <= XAU_SETTLED_DRIFT_PCT:
+            merged[day] = value
+        else:
+            quarantined.append((day, drift_pct))
+    advisory = None
+    if quarantined:
+        worst_day, worst_pct = max(quarantined, key=lambda item: item[1])
+        advisory = (
+            f'伦敦金历史校验：沿用 {len(quarantined)} 个已结算点；'
+            f'最大新旧偏差 {worst_pct:.2f}%（{worst_day}，源 {source_name}）'
+        )
+    return sorted(merged.items()), advisory
 
 
 def _xau_at(xau_sorted_dates, xau_vals, d):
@@ -314,7 +365,8 @@ def build_london_dca(nav_history, xau_hist, usdcny_hist, xau_cur, usdcny_cur, st
     }
 
 
-def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist):
+def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
+                   hist_source=None, hist_advisory=None):
     """折算 + 对比线 + DCA 对应现值。任一关键源缺失 → 保留旧 london（merge-not-overwrite）。"""
     if not spot or not spot.get('xau_usd') or not usdcny:
         return gold.get('london')  # 抓空：沿用旧值，绝不清空
@@ -346,6 +398,9 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist):
         'intl_value_usd': round(intl_usd, 2) if intl_usd else None,
         'compare_series': compare,
         'dca_equiv': dca_equiv,
+        'hist_source': hist_source or {'name': 'unavailable', 'points': 0},
+        'hist_series': [[d, round(v, 4)] for d, v in (xau_hist or [])],
+        'hist_advisory': hist_advisory,
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
     }
 
@@ -371,7 +426,8 @@ def project_dca(units, principal, nav, daily, horizons=(20, 40, 60, 120, 250)):
     return out
 
 
-def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None, xau_hist=None):
+def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None,
+            xau_hist=None, xau_hist_source=None, xau_hist_advisory=None):
     base_principal = float(gold['principal_invested'])
     base_units = float(gold['units_held'])
     daily = float(gold.get('daily_amount', 200))
@@ -426,7 +482,10 @@ def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None, x
         'nav_history': [[d, round(n, 4)] for d, n, _ in history[-HISTORY_KEEP:]],
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
     }
-    derived['london'] = compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist)
+    derived['london'] = compute_london(
+        derived, gold, spot, usdcny, usdcny_hist, xau_hist,
+        xau_hist_source, xau_hist_advisory,
+    )
     return derived
 
 
@@ -450,13 +509,28 @@ def main():
     # 伦敦金类比口径（best-effort，抓空各自沿用旧值）
     spot = fetch_london_spot()
     usdcny, usdcny_hist = fetch_usdcny(gold.get('start_date', ''))
-    xau_hist = fetch_xau_history(gold.get('start_date', '')) if spot and usdcny else []
+    if spot and usdcny:
+        xau_fresh, xau_source = fetch_xau_history(gold.get('start_date', ''))
+    else:
+        xau_fresh, xau_source = [], {'name': 'not_attempted', 'points': 0}
+    old_london = gold.get('london') or {}
+    xau_hist, xau_advisory = stabilize_xau_history(
+        xau_fresh,
+        old_london.get('hist_series') or [],
+        xau_source,
+        old_london.get('hist_source') or {},
+    )
     if not spot:
         print('  warn: 伦敦金现货(hf_XAU)抓空，沿用旧 london', file=sys.stderr)
-    elif not xau_hist:
+    elif not xau_fresh:
         print('  warn: 伦敦金历史(GC00Y)限流抓空，对比线沿用旧线', file=sys.stderr)
+    if xau_advisory:
+        print(f'  advisory: {xau_advisory}', file=sys.stderr)
 
-    derived = compute(gold, history, realtime, spot, usdcny, usdcny_hist, xau_hist)
+    derived = compute(
+        gold, history, realtime, spot, usdcny, usdcny_hist, xau_hist,
+        xau_source, xau_advisory,
+    )
 
     # merge：真值字段原样保留，派生字段更新；nav_history 抓空时不清空
     merged = {k: gold[k] for k in GROUND_TRUTH_FIELDS if k in gold}
@@ -481,6 +555,10 @@ def main():
         print(f"  伦敦金 ${ld.get('xau_usd')}/oz ({(ld.get('xau_change_pct') or 0):+.2f}%) "
               f"USDCNY {ld.get('usdcny')} → 折 {ld.get('grams_equiv')} 克 / {ld.get('oz_equiv')} oz "
               f"(国际口径 ${ld.get('intl_value_usd'):,.0f})  对比线 {len(ld.get('compare_series') or [])} 点")
+        hs = ld.get('hist_source') or {}
+        print(f"  ↳ 历史源 {hs.get('name', 'unknown')} · {hs.get('points', 0)} 点")
+        if ld.get('hist_advisory'):
+            print(f"  ℹ️ {ld['hist_advisory']}")
         de = ld.get('dca_equiv')
         if de:
             print(f"  ↳ 同额定投伦敦金：平均成本 ${de['avg_cost_usd_oz']:,.2f}/oz "

--- a/tests/test_data_source_unification.py
+++ b/tests/test_data_source_unification.py
@@ -115,7 +115,9 @@ def test_gold_eastmoney_legs_use_shared_client_and_keep_truth_separate(monkeypat
 
     assert gold.fetch_nav_history("000217", pages=1) == [("2026-07-15", 3.5, 0.5)]
     assert gold.fetch_realtime("000217")["est_nav"] == 3.51
-    assert gold.fetch_xau_history("2026-07-01") == [("2026-07-15", 3300.0)]
+    history, source = gold.fetch_xau_history("2026-07-01")
+    assert history == [("2026-07-15", 3300.0)]
+    assert source == {"name": gold.XAU_FALLBACK_SOURCE, "points": 1}
     assert any("api.fund.eastmoney.com" in url for url in calls)
     assert any("fundgz.1234567.com.cn" in url for url in calls)
     assert any("push2his.eastmoney.com" in url for url in calls)
@@ -127,4 +129,3 @@ def test_gold_eastmoney_legs_use_shared_client_and_keep_truth_separate(monkeypat
     }
     derived = gold.compute(seed, [("2026-07-15", 3.5, 0.5)], None)
     assert gold.GROUND_TRUTH_FIELDS.isdisjoint(derived)
-

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -1,0 +1,126 @@
+"""Regression coverage for London-gold history provenance and settlement."""
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import fetch_gold_dca as gold  # noqa: E402
+
+
+def rows(values):
+    return [(f"2026-07-{day:02d}", value) for day, value in values]
+
+
+def test_settled_outlier_is_quarantined_but_latest_five_dates_win():
+    previous = rows((day, 100.0 + day) for day in range(1, 11))
+    fresh = list(previous)
+    fresh[1] = ("2026-07-02", 130.0)  # settled: reject 27% rewrite
+    fresh[-1] = ("2026-07-10", 140.0)  # latest five: accept provisional close
+
+    stable, advisory = gold.stabilize_xau_history(
+        fresh,
+        previous,
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
+    )
+
+    stable = dict(stable)
+    assert stable["2026-07-02"] == 102.0
+    assert stable["2026-07-10"] == 140.0
+    assert "沿用 1 个已结算点" in advisory
+    assert "2026-07-02" in advisory
+
+
+def test_small_settled_revision_is_accepted():
+    previous = rows((day, 100.0) for day in range(1, 8))
+    fresh = list(previous)
+    fresh[0] = ("2026-07-01", 100.2)
+
+    stable, advisory = gold.stabilize_xau_history(
+        fresh,
+        previous,
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
+    )
+
+    assert dict(stable)["2026-07-01"] == 100.2
+    assert advisory is None
+
+
+def test_primary_feed_recovery_replaces_fallback_reference():
+    fallback = rows((day, 200.0) for day in range(1, 8))
+    primary = rows((day, 100.0) for day in range(1, 8))
+
+    stable, advisory = gold.stabilize_xau_history(
+        primary,
+        fallback,
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(primary)},
+        {"name": gold.XAU_FALLBACK_SOURCE, "points": len(fallback)},
+    )
+
+    assert dict(stable)["2026-07-01"] == 100.0
+    assert advisory is None
+
+
+def test_empty_fetch_preserves_reference_and_emits_advisory():
+    previous = rows((day, 100.0 + day) for day in range(1, 4))
+
+    stable, advisory = gold.stabilize_xau_history(
+        [],
+        previous,
+        {"name": "unavailable", "points": 0},
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
+    )
+
+    assert stable == previous
+    assert "抓取失败" in advisory
+    assert "3 个参考点" in advisory
+
+
+def test_first_empty_fetch_is_also_visible():
+    stable, advisory = gold.stabilize_xau_history(
+        [],
+        [],
+        {"name": "unavailable", "points": 0},
+    )
+
+    assert stable == []
+    assert advisory == "伦敦金历史抓取失败，暂无可用参考点"
+
+
+def test_london_payload_persists_reference_and_visible_provenance():
+    xau = [("2026-07-01", 100.0), ("2026-07-02", 101.0)]
+    derived = {"current_value": 1000.0, "nav_history": [
+        ["2026-07-01", 3.0], ["2026-07-02", 3.1],
+    ]}
+    source = {"name": gold.XAU_PRIMARY_SOURCE, "points": len(xau)}
+
+    london = gold.compute_london(
+        derived,
+        {"start_date": "2026-07-01", "daily_amount": 200},
+        {"xau_usd": 102.0, "change_pct": 1.0},
+        7.0,
+        {"2026-07-01": 7.0, "2026-07-02": 7.0},
+        xau,
+        source,
+        "test advisory",
+    )
+
+    assert london["hist_source"] == source
+    assert london["hist_series"] == [
+        ["2026-07-01", 100.0], ["2026-07-02", 101.0],
+    ]
+    assert london["hist_advisory"] == "test advisory"
+    assert london["dca_equiv"]["oz_held"] > 0
+
+
+def test_dashboard_drops_internal_history_but_keeps_provenance_contract():
+    builder = (ROOT / "scripts" / "data" / "build_dashboard.py").read_text()
+    renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+
+    assert "_gold['london'].pop('hist_series', None)" in builder
+    assert "历史源 ${escapeHtml(" in renderer
+    assert 'role="status"' in renderer
+    assert "ld.hist_advisory" in renderer

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -19,7 +19,7 @@ def test_settled_outlier_is_quarantined_but_latest_five_dates_win():
     fresh[1] = ("2026-07-02", 130.0)  # settled: reject 27% rewrite
     fresh[-1] = ("2026-07-10", 140.0)  # latest five: accept provisional close
 
-    stable, advisory = gold.stabilize_xau_history(
+    stable, advisory = gold.stabilize_history(
         fresh,
         previous,
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
@@ -38,7 +38,7 @@ def test_small_settled_revision_is_accepted():
     fresh = list(previous)
     fresh[0] = ("2026-07-01", 100.2)
 
-    stable, advisory = gold.stabilize_xau_history(
+    stable, advisory = gold.stabilize_history(
         fresh,
         previous,
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
@@ -53,7 +53,7 @@ def test_primary_feed_recovery_replaces_fallback_reference():
     fallback = rows((day, 200.0) for day in range(1, 8))
     primary = rows((day, 100.0) for day in range(1, 8))
 
-    stable, advisory = gold.stabilize_xau_history(
+    stable, advisory = gold.stabilize_history(
         primary,
         fallback,
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(primary)},
@@ -67,7 +67,7 @@ def test_primary_feed_recovery_replaces_fallback_reference():
 def test_empty_fetch_preserves_reference_and_emits_advisory():
     previous = rows((day, 100.0 + day) for day in range(1, 4))
 
-    stable, advisory = gold.stabilize_xau_history(
+    stable, advisory = gold.stabilize_history(
         [],
         previous,
         {"name": "unavailable", "points": 0},
@@ -80,7 +80,7 @@ def test_empty_fetch_preserves_reference_and_emits_advisory():
 
 
 def test_first_empty_fetch_is_also_visible():
-    stable, advisory = gold.stabilize_xau_history(
+    stable, advisory = gold.stabilize_history(
         [],
         [],
         {"name": "unavailable", "points": 0},
@@ -104,13 +104,17 @@ def test_london_payload_persists_reference_and_visible_provenance():
         7.0,
         {"2026-07-01": 7.0, "2026-07-02": 7.0},
         xau,
-        source,
-        "test advisory",
+        hist_source=source,
+        fx_hist_source={"name": "frankfurter_usdcny", "points": 2},
+        hist_advisory="test advisory",
     )
 
     assert london["hist_source"] == source
     assert london["hist_series"] == [
         ["2026-07-01", 100.0], ["2026-07-02", 101.0],
+    ]
+    assert london["fx_hist_series"] == [
+        ["2026-07-01", 7.0], ["2026-07-02", 7.0],
     ]
     assert london["hist_advisory"] == "test advisory"
     assert london["dca_equiv"]["oz_held"] > 0
@@ -121,6 +125,7 @@ def test_dashboard_drops_internal_history_but_keeps_provenance_contract():
     renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
 
     assert "_gold['london'].pop('hist_series', None)" in builder
+    assert "_gold['london'].pop('fx_hist_series', None)" in builder
     assert "历史源 ${escapeHtml(" in renderer
     assert 'role="status"' in renderer
     assert "ld.hist_advisory" in renderer


### PR DESCRIPTION
Closes #138

## What changes
- record the successful London-history provider and fetched point count
- persist internal XAU and USDCNY reference series; accept the newest five trading dates, but quarantine older revisions above 0.3%
- trust the authoritative Sina XAU feed when it recovers from a GC00Y fallback
- emit a visible dashboard/log advisory whenever settled points are retained or either history fetch fails
- strip both internal reference series from browser payloads while retaining provenance and advisory

## Verification
- `pytest -q tests/test_gold_dca_history_stability.py tests/test_data_source_unification.py tests/test_dashboard_output_ownership.py` (16 passed)
- JS/Python syntax checks and `git diff --check`
- live-source dry-run: Sina XAU primary, 134 points, full DCA calculation completed; no files written