### PR TITLE
config(cron): pin strategy tasks to high reasoning

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -23,6 +23,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
+      "thinking": "high",
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
@@ -115,6 +116,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
+      "thinking": "high",
       "delivery_mode": "none",
       "required_substrings": [
         "trading_calendar.py hk",

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -62,7 +62,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
-      "thinking": "medium",
+      "thinking": "high",
       "tools_allow": [
         "exec",
         "read",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -108,6 +108,7 @@ def test_payload_semantic_contract_detects_deprecated_or_missing_rules():
             'kind': 'agentTurn',
             'model': profile['model'],
             'fallbacks': profile['model_candidates'][1:],
+            'thinking': profile['thinking'],
             'message': message,
         },
         'delivery': {'mode': 'none'},
@@ -472,6 +473,18 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert cron_contract.payload_errors(data, expected, live) != []
 
 
+def test_strategy_crons_explicitly_pin_high_reasoning():
+    profiles = contract()['payload_profiles']
+    assert {
+        name: profiles[name].get('thinking')
+        for name in ('report', 'intraday', 'brief')
+    } == {
+        'report': 'high',
+        'intraday': 'high',
+        'brief': 'high',
+    }
+
+
 def test_intraday_slots_are_unconditional_again():
     """Every Mode 7 slot runs the turn; no pre-model condition gate.
 
@@ -545,6 +558,7 @@ def _brief_live_payload(data, *, timeout=1800):
             'kind': profile['payload_kind'],
             'model': profile['model'],
             'fallbacks': profile['model_candidates'][1:2],
+            'thinking': profile['thinking'],
             'message': message,
         },
         'delivery': {'mode': profile['delivery_mode']},

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -450,6 +450,7 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert profile['tools_allow'] == [
         'exec', 'read', 'write', 'web_search', 'web_fetch'
     ]
+    assert profile['thinking'] == 'high'
     assert 'process' not in profile['tools_allow']
     # 300s is a per-exec bound. A 300s whole-turn timeout would kill normal
     # 4–6 minute check-ins before postflight can deliver them.


### PR DESCRIPTION
User-directed quality preference: strategy-bearing scheduled tasks should use high reasoning, with token and latency secondary.

- explicitly pin `report`, `brief`, and `intraday` payload profiles to `high`
- add a contract assertion so strategy cron jobs cannot silently regress to a lower level even if the global default changes
- preserve the full bootstrap context and skills; no light-context or output trimming
- retain #163 round-trip reductions, which remove polling overhead without reducing reasoning or content
- leave Memory Dreaming unchanged because it is not a user-facing strategy task

Verification: `pytest -q tests/test_cron_contracts.py` (25 passed), `git diff --check`.