### PR TITLE
fix(research): wait for earnings event maturity

### DIFF
--- a/scripts/data/research_surface.py
+++ b/scripts/data/research_surface.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 WS = Path(__file__).resolve().parents[2]
 THESIS_DIR = WS / "memory" / "theses"
@@ -55,6 +56,15 @@ CADENCE_DAYS = {"quarterly": 92, "semiannual": 183, "annual": 366}
 # 1.6 periods: one full period late is a miss, but a late filing inside the normal
 # reporting lag must not be called stale.
 STALE_LEDGER_FACTOR = 1.6
+
+# `fetch_catalysts` currently sources the earnings calendar for US-listed
+# issuers. Calendar dates and BMO/AMC labels therefore belong to New York time,
+# even though the recurring jobs and `today` run in HKT.
+US_EARNINGS_TZ = ZoneInfo("America/New_York")
+US_MARKET_OPEN = time(9, 30)
+# An AMC label promises only "after close", not a precise release minute.
+# Waiting 15 minutes avoids creating work at the closing bell itself.
+US_AFTER_CLOSE_MATURE = time(16, 15)
 
 
 def _load_json(path: Path):
@@ -171,8 +181,34 @@ def earnings_issuers(positions) -> dict:
     return out
 
 
-def earnings_reviews_due(positions, catalysts, artifacts, today: date) -> list[dict]:
-    """A reported earnings date with no artifact published after it."""
+def earnings_event_mature(event: dict, *, now: datetime) -> bool:
+    """Whether a scheduled US earnings event can truthfully be called reported."""
+    reported = _parse_date(event.get("date"))
+    if reported is None:
+        return False
+    # A populated actual is stronger evidence than a coarse calendar label.
+    if event.get("eps_actual") is not None:
+        return True
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    local_now = now.astimezone(US_EARNINGS_TZ)
+    session = str(event.get("time") or "unknown").strip().lower()
+    if session == "bmo":
+        mature_at = datetime.combine(reported, US_MARKET_OPEN, US_EARNINGS_TZ)
+    elif session in {"amc", "dmh"}:
+        mature_at = datetime.combine(reported, US_AFTER_CLOSE_MATURE, US_EARNINGS_TZ)
+    else:
+        mature_at = datetime.combine(
+            reported + timedelta(days=1), time.min, US_EARNINGS_TZ
+        )
+    return local_now >= mature_at
+
+
+def earnings_reviews_due(
+    positions, catalysts, artifacts, today: date, *, now: datetime | None = None
+) -> list[dict]:
+    """A matured earnings event with no artifact published after it."""
+    now = now or datetime.now(timezone.utc)
     issuers = earnings_issuers(positions)
     held = set(issuers.values()) | {position["ticker"] for position in positions}
     via = {issuer: ticker for ticker, issuer in issuers.items() if issuer != ticker}
@@ -184,6 +220,8 @@ def earnings_reviews_due(positions, catalysts, artifacts, today: date) -> list[d
         if ticker not in held or reported is None:
             continue
         if not 0 <= (today - reported).days <= window:
+            continue
+        if not earnings_event_mature(event, now=now):
             continue
         published = [
             _parse_date(doc.get("published_at")) for doc in artifacts.get(ticker) or []
@@ -425,7 +463,7 @@ def summarize(*, portfolio=None, catalysts=None, today=None, now=None,
     theses, thesis_errors = thesis_registry.load_registry(thesis_dir)
     errors = earnings_errors + gate_errors + [f"theses: {e}" for e in thesis_errors]
 
-    due = earnings_reviews_due(positions, catalysts, earnings, today)
+    due = earnings_reviews_due(positions, catalysts, earnings, today, now=now)
     stale = stale_ledgers(positions, earnings, today)
     hk_expected = hk_results_expected(positions, today, artifacts=earnings) if hk_watch else []
     overdue = overdue_commitments(earnings, today)

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -6,7 +6,7 @@ the `validate` workflow) actually call it.
 """
 import copy
 import json
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -77,6 +77,53 @@ def test_reported_earnings_without_an_artifact_is_due(dirs):
         "reason": "earnings reported with no primary-source artifact covering it",
     }]
     assert surface["earnings"]["detection_window_days"] == 14
+
+
+@pytest.mark.parametrize(
+    "event_time,now,expected",
+    [
+        # 00:28 HKT is still 12:28 ET on the event date: an AMC report has not
+        # happened merely because the HKT calendar rolled over.
+        ("amc", datetime(2026, 7, 30, 0, 28, tzinfo=timezone(timedelta(hours=8))), False),
+        ("amc", datetime(2026, 7, 30, 4, 16, tzinfo=timezone(timedelta(hours=8))), True),
+        ("bmo", datetime(2026, 7, 29, 9, 29, tzinfo=timezone(timedelta(hours=-4))), False),
+        ("bmo", datetime(2026, 7, 29, 9, 30, tzinfo=timezone(timedelta(hours=-4))), True),
+        ("unknown", datetime(2026, 7, 29, 23, 59, tzinfo=timezone(timedelta(hours=-4))), False),
+        ("unknown", datetime(2026, 7, 30, 0, 0, tzinfo=timezone(timedelta(hours=-4))), True),
+    ],
+)
+def test_earnings_queue_waits_for_the_event_to_mature(dirs, event_time, now, expected):
+    event = {
+        "ticker": "USTEST",
+        "date": "2026-07-29",
+        "time": event_time,
+        "eps_actual": None,
+    }
+    surface = rs.summarize(
+        portfolio=portfolio(),
+        catalysts={"lookback_window_days": 14, "earnings": [event]},
+        today=date(2026, 7, 30),
+        now=now,
+        **dirs,
+    )
+    assert bool(surface["earnings"]["reviews_due"]) is expected
+
+
+def test_an_actual_result_matures_the_event_before_the_calendar_boundary(dirs):
+    event = {
+        "ticker": "USTEST",
+        "date": "2026-07-29",
+        "time": "amc",
+        "eps_actual": 3.65,
+    }
+    surface = rs.summarize(
+        portfolio=portfolio(),
+        catalysts={"lookback_window_days": 14, "earnings": [event]},
+        today=date(2026, 7, 30),
+        now=datetime(2026, 7, 30, 0, 28, tzinfo=timezone(timedelta(hours=8))),
+        **dirs,
+    )
+    assert [row["ticker"] for row in surface["earnings"]["reviews_due"]] == ["USTEST"]
 
 
 def test_an_artifact_published_after_the_report_clears_the_queue(dirs):
@@ -526,7 +573,8 @@ def test_a_report_by_a_tracked_company_marks_the_fund_position_due(dirs):
     surface = rs.summarize(
         portfolio=book,
         catalysts={"lookback_window_days": 14,
-                   "earnings": [{"ticker": "MSFT", "date": "2026-07-29"}]},
+                   "earnings": [{"ticker": "MSFT", "date": "2026-07-29",
+                                 "eps_actual": 1.0}]},
         today=date(2026, 7, 30), now=datetime(2026, 7, 30, tzinfo=timezone.utc), **dirs,
     )
     due = surface["earnings"]["reviews_due"]


### PR DESCRIPTION
Closes #171.

Scheduled earnings only enter the research-review queue once the event can truthfully have occurred in America/New_York time. BMO matures at market open, AMC/DMH after close, unknown after the local day, while a populated actual remains definitive.

Preserves full context/skills and the existing issuer look-through/artifact/window behavior.

Local verification:
- `pytest tests/test_research_surface.py -q` — 70 passed
- `python3 scripts/system_check.py` — 16 ok, 1 unrelated memory-index warning, 0 critical
- `git diff --check`