### PR TITLE
fix(intraday): restore supported process polling

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -66,6 +66,7 @@
       "thinking": "high",
       "tools_allow": [
         "exec",
+        "process",
         "read",
         "write",
         "web_search",
@@ -77,6 +78,7 @@
         "intraday_preflight.py --market {market}",
         "market_closed",
         "所有脚本 exec 调用都显式设置 `timeout: 300`",
+        "若 exec 返回 `Command still running`，只用 `process` poll 对应 session；禁止新开 exec 用 sleep/ps/ls/grep 探测进度",
         "context_id",
         "同一条回复内并行发出两个 `write` 工具调用",
         "intraday_postflight.py --market {market} --context-id",
@@ -89,6 +91,7 @@
         "唯一微信路径",
         "同步 Telegram",
         "禁用 message",
+        "postflight 返回 pass/warn 后直接输出其 `wechat_prefix` + 散文并结束；禁止再读、搜或重建临时文件来确认送达",
         "--no-deliver"
       ],
       "forbidden_substrings": [

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -447,12 +447,20 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert 'trading_calendar.py' in profile['forbidden_substrings']
     assert 'market_closed' in profile['required_substrings']
     assert '所有脚本 exec 调用都显式设置 `timeout: 300`' in profile['required_substrings']
+    assert any(
+        '只用 `process` poll' in line and 'sleep/ps/ls/grep' in line
+        for line in profile['required_substrings']
+    )
     assert '同一条回复内并行发出两个 `write` 工具调用' in profile['required_substrings']
+    assert any(
+        'postflight 返回 pass/warn 后直接输出' in line and '禁止再读、搜或重建' in line
+        for line in profile['required_substrings']
+    )
     assert profile['tools_allow'] == [
-        'exec', 'read', 'write', 'web_search', 'web_fetch'
+        'exec', 'process', 'read', 'write', 'web_search', 'web_fetch'
     ]
     assert profile['thinking'] == 'high'
-    assert 'process' not in profile['tools_allow']
+    assert 'process' in profile['tools_allow']
     # 300s is a per-exec bound. A 300s whole-turn timeout would kill normal
     # 4–6 minute check-ins before postflight can deliver them.
     assert 'timeout_seconds' not in profile
@@ -515,7 +523,7 @@ def test_intraday_slots_are_unconditional_again():
     ]
 
 
-def test_intraday_payload_rejects_tool_surface_drift():
+def test_intraday_payload_rejects_missing_process_tool():
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
     profile = data['payload_profiles']['intraday']
@@ -528,7 +536,9 @@ def test_intraday_payload_rejects_tool_surface_drift():
             'kind': profile['payload_kind'],
             'model': profile['model'],
             'thinking': profile['thinking'],
-            'toolsAllow': [*profile['tools_allow'], 'process'],
+            'toolsAllow': [
+                tool for tool in profile['tools_allow'] if tool != 'process'
+            ],
         },
         'delivery': {'mode': profile['delivery_mode']},
     }


### PR DESCRIPTION
Closes #173.

The first live run after #168 showed that its fallback path still backgrounded long exec calls while `process` was unavailable, causing 13 shell-based polling probes and a post-delivery false red.

This restores only the supported process completion mechanism while keeping the duplicate-calendar removal and same-response prose/sidecar writes. The payload now forbids shell sleep/ps/ls/grep polling and forbids artifact reconstruction after a pass/warn postflight.

Verification:
- `pytest tests/test_cron_contracts.py -q` — 25 passed
- live payload updated on all 3 Mode 7 jobs
- `python3 scripts/system_check.py` — 16 ok, 1 unrelated memory-index warning, 0 critical
- no context, skill, token, or whole-turn timeout reduction