### PR TITLE
fix(cron): use MiniMax-M3 adaptive reasoning

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -23,7 +23,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
-      "thinking": "high",
+      "thinking": "adaptive",
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
@@ -63,7 +63,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
-      "thinking": "high",
+      "thinking": "adaptive",
       "tools_allow": [
         "exec",
         "process",
@@ -119,7 +119,7 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
-      "thinking": "high",
+      "thinking": "adaptive",
       "delivery_mode": "none",
       "required_substrings": [
         "trading_calendar.py hk",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -459,7 +459,7 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert profile['tools_allow'] == [
         'exec', 'process', 'read', 'write', 'web_search', 'web_fetch'
     ]
-    assert profile['thinking'] == 'high'
+    assert profile['thinking'] == 'adaptive'
     assert 'process' in profile['tools_allow']
     # 300s is a per-exec bound. A 300s whole-turn timeout would kill normal
     # 4–6 minute check-ins before postflight can deliver them.
@@ -481,15 +481,21 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     assert cron_contract.payload_errors(data, expected, live) != []
 
 
-def test_strategy_crons_explicitly_pin_high_reasoning():
+def test_strategy_crons_pin_minimax_m3_adaptive_reasoning():
+    """M3 exposes only off/adaptive; high is a budgeted M2.x level.
+
+    Adaptive is M3's reasoning-enabled mode, not a context or output reduction.
+    Keeping the supported value explicit prevents every live run from silently
+    rewriting the tracked contract while emitting an unsupported-level warning.
+    """
     profiles = contract()['payload_profiles']
     assert {
         name: profiles[name].get('thinking')
         for name in ('report', 'intraday', 'brief')
     } == {
-        'report': 'high',
-        'intraday': 'high',
-        'brief': 'high',
+        'report': 'adaptive',
+        'intraday': 'adaptive',
+        'brief': 'adaptive',
     }
 
 


### PR DESCRIPTION
Closes #174.

MiniMax-M3 exposes `off` and `adaptive`; `high` is a budgeted M2.x level. OpenClaw was silently mapping every strategy run from unsupported `high` to `adaptive` while warning. This makes all three strategy profiles truthful and pins M3's reasoning-enabled mode directly.

No context, skills, output budget, deterministic gate, or timeout is reduced.

Verification:
- `pytest tests/test_cron_contracts.py -q` — 25 passed
- all 10 live user-facing strategy jobs now report `thinking: adaptive`; memory job unchanged
- `python3 scripts/system_check.py` — 16 ok, 1 unrelated memory-index warning, 0 critical