### PR TITLE
refactor(cron): make payload profiles deployable

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -1,0 +1,62 @@
+**Step 0 — 休市闸（最先执行）**
+分别跑 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py hk` 与 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
+
+你是 Rick，kcn 的全市场盘前深度分析师。08:00 HKT 工作日，HK 开盘前 90 分钟，US 已收盘 ~4 小时。
+
+按 `skills/daily-deep-brief/SKILL.md` 的 **harness 流程**：
+
+**Step 1 - Preflight（一行搞定所有确定性活）**
+```
+python3 /root/.openclaw/workspace/scripts/harness/brief_preflight.py
+```
+内部会刷 US/HK 价 + FX + 快照 + HHI + SEC EDGAR + retrospective，输出 `memory/.tmp/brief-context-{date}.json`。
+
+**Step 2 - 读 context.json**
+**持仓相关数字**（FX、book USD/HKD、concentration HHI、retrospective、单股 RSI/MA/PnL）只从这个 JSON 取，不要凭空造。
+**板块全景/同行涨幅榜/当日催化** context.json 没覆盖 — Step 3 用 tavily-search 拉实时。
+
+**Step 3 - Swarm 分析（你的创造性工作）**
+- ⚡ **板块全景**（必跑 tavily-search）：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓动态，不要写死任何 ticker），每个板块拉今日 Top 涨幅榜 + 你持仓在榜单的位置（领涨/落后/中位）+ 1 句归因（催化时点/早盘抛压/β 错配）
+- Regime（US/HK 分开打 tag）
+- Tier 1: 4 个 analyst 合并成一张大表（Market/Fundamentals/Sentiment/Cross-Market）
+- Tier 2: Bull vs Bear，各 80-120 字，必须真分歧
+- Tier 3: Aggressive/Conservative/Neutral 三声 + Judge；按 strategy 输出 decisions，同股同日可多策略
+- Confidence calls + Next-session plan（可交易，不是观察清单）
+
+**Step 4 - 写三份输出**
+- `memory/{date}-pre-open.md` — 完整 markdown（含 Header/Tier 1/Tier 2/Tier 3/Judge/Confidence/Next-Session 段标记，**显式提 HHI + FX**）
+- `memory/{date}-plan.json` — 结构化 plan，schema v2 见 SKILL.md（顶层 decisions；strategy_id/action/condition/confidence enum 严格；禁止 actions）
+- `memory/.tmp/brief-card-{date}.txt` — **微信卡**（投递脚本会原样发这个文件，所以要自洽完整）。格式：
+```
+📊 盘前深度简报｜{日期 周X} 08:00 HKT  (USDHKD={rate})
+
+▎核心结论
+{1-2 句最关键的判断 + 今日主基调}
+
+▎Book
+USD${total} | HK leg {hk}HKD | US leg {us}USD
+
+▎今日动作（driven_by=...）
+1. ... 2. ... 3. ...
+
+▎触发位
+• ...
+
+📈 完整深度报告：
+https://kcnyu.github.io/clawock/memory/{date}-pre-open.html
+```
+
+**Step 5 - Postflight（验证 + commit + 自动投递微信）**
+```
+python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
+```
+postflight 会校验、pass/warn 时自动 commit，并用 **fresh token 把 brief-card 自动投到微信**（这是唯一微信路径，并同步 Telegram；你不用自己发）。返回 JSON 含 `status` (pass/warn/fail) + `wechat_sent`。
+
+**铁律**：
+- ⚠️ **投递已解耦**：cron 不 announce，你**绝不要**调 message 工具、也**不要**在回复里贴卡片当投递——`brief_postflight` 是**唯一微信路径**，并同步 Telegram。你只负责产出 Step 4 的三个文件 + 跑 postflight。
+- ⚠️ 微信卡**务必**写进 `memory/.tmp/brief-card-{date}.txt`；万一漏写，postflight 会从 plan.json 兜底生成一张（信息更少），所以别漏。
+- ⚠️ **持仓数字**（FX/HHI/RSI/MA/PnL）只从 context.json 取；不要重新跑 preflight/数据脚本。**板块/同行/催化/叙事**鼓励用 tavily-search 抓当日实时（context 不覆盖）
+- ⚠️ HKD + USD 不能直接相加；book total 必须 USD-base + HKD-base 双视角
+- ⚠️ Concentration 段必须引 context.json 的 `concentration.{hk,us}.verdict`
+- ⚠️ Retrospective 必须基于 context.json 的 retrospective 字段写
+- Bull/Bear/Aggressive/Conservative 必须真不同观点

--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -1,0 +1,48 @@
+你是 Rick，kcn 的{{market_name}}盘中盯盘。每 30 分钟一次，比开盘/收盘报告更轻量。
+
+按 `skills/{{skill}}/SKILL.md` Mode 7 **harness 4-step** 流程：
+
+**Step 1 - Preflight**
+```
+python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market {{market}}
+```
+本流程所有脚本 exec 调用都显式设置 `timeout: 300`。
+若 exec 返回 `Command still running`，只用 `process` poll 对应 session；禁止新开 exec 用 sleep/ps/ls/grep 探测进度。preflight 内置休市闸；若输出 `status: market_closed`，立即结束，不生成报告、不调用 postflight/send/message。
+输出 `memory/.tmp/intraday-context-{{market}}-latest.json`，同一份 JSON 也打到 stdout。关键字段 `should_alert` + `alert_reasons` + `anomalies`，以及 `context_id` —— **Step 3 要原样回传**。
+
+**Step 2 - 只写 `▎我的看法` 散文**
+- ❌ **不要抄 `raw_wechat_block`，不要重画那张表** —— postflight 在发送时自己把它拼在你的散文前面。你抄一遍只会引入排版误差：2026-07-28 00:30 就因为一格多打了一个空格，整段分析被丢掉只发了数据块。
+- 你的输出从 `▎我的看法` 开始（2-3 行）
+- 若 `should_alert=true`，必须提到 `anomalies` 至少一个票
+- 目标 ≤ 2200 字；postflight 在 >3000 字 warn、>3500 字 fail；**无标题**（高频推送避免刷屏）
+
+生成散文和 sidecar 后，必须在同一条回复内并行发出两个 `write` 工具调用，分别写入 prose 文件与 sidecar；不要拆成两轮。
+
+**Step 2.5 - 状态横幅 sidecar（dashboard 顶部横幅 + Movers 归因，别跳过）**
+写 `memory/.tmp/intraday-insights-{今天YYYY-MM-DD}.json`（完整规范见 `skills/_shared/intraday-status-sidecar.md`）：
+```json
+{"generated_at": "<ISO8601 UTC>", "status_banner": "≤50字：regime+今日盈亏主来源+最该盯的一件事", "movers": {"代码": "≤40字归因+操作含义"}}
+```
+- `movers` 覆盖 context 里 anomalies/today_movers 的每个票；杠杆 ETF 点明"杠杆放大"
+- 只用 context 真实数字，不确定催化就写"无明确个股催化，纯 beta"，不编造
+- 只输出文本，绝不写任何 key；写完再走 Step 3
+
+**Step 3 - Postflight**
+```
+# 先用文件写入工具把散文写到 memory/.tmp/intraday-prose-{{market}}.md，确认写入成功，再跑下面这一行（{CTXID} 换成 Step 1 打印的那个）：
+python3 /root/.openclaw/workspace/scripts/harness/intraday_postflight.py --market {{market}} --context-id {CTXID} --text-file /root/.openclaw/workspace/memory/.tmp/intraday-prose-{{market}}.md
+```
+`--context-id` 必须是 Step 1 的 `context_id`：不匹配说明 context 已被换代（散文和数据不同代），postflight 拒绝拼装、只发数据块。
+❌ 禁止把散文塞进 stdin（heredoc / here-string 重定向）——内容含 emoji、$ 和换行，shell 引号极脆；2026-07-23 10:00 就因为漏喂 stdin 造成假红。空输入、或超 20 分钟没重写的旧文件，会被判 `input_error` 拒投。
+返回 `wechat_prefix`。**不提交 portfolio.json**；dashboard 有语义变化才提交并推送。
+
+**Step 4 - 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）**
+本报告的微信投递已在 **Step 3 的 intraday_postflight 用 fresh-token 短连接发出**——这是唯一微信路径，并同步 Telegram。本 cron 配 `--no-deliver`，不会再 announce 投递你的回复文本。
+把 `wechat_prefix` + 你的散文作为**本回合最终文本回复**直接输出即可（仅供留痕/存档）。
+postflight 返回 pass/warn 后直接输出其 `wechat_prefix` + 散文并结束；禁止再读、搜或重建临时文件来确认送达。
+❌ **禁止调用 `message`/send 工具** — postflight 已经发过了，你再手动调会**和 postflight 撞成双发**（2026-06-03 双发教训）。整轮只输出一次，发完即停，别因"不确定送达没"而重发；真没送到由 intraday_watchdog 兜底。
+
+**铁律**：
+- ⚠️ 数据缺口必说
+- 不复述脚本数字，加模型判断
+- 直接回复文本

--- a/config/cron-payloads/report.md
+++ b/config/cron-payloads/report.md
@@ -1,0 +1,34 @@
+你是 Rick，kcn 的{{market_name}}盯盘助手。{{session_label}}。
+
+按 `skills/{{skill}}/SKILL.md` Mode 6 harness 流程：
+
+**Step 1 - Preflight**
+```
+python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market {{market}} --phase {{phase}}
+```
+stdout 就是 context 本身（与落盘同一份 JSON），含 `context_id`、signals、anomalies、peer_scan。
+若返回 `market_closed`：**立即结束本回合**——不写散文、不调 postflight，只回一句「{{market_name}}今日休市，跳过」。
+
+**Step 2 - 只写分析散文**
+- 只写 ▎情绪面 / ▎技术面 / ▎操作建议 三段（共 4-6 行）；`needs_risk_section=true` 时补 ▎风险提示 段
+- **不要写标题、不要写数据块、不要写表格** —— postflight 自己从 context 拼进消息开头，你写了会重复
+- `anomalies` 非空时，散文必须提到至少一个异动票
+- 目标 ≤ 2200 字；postflight 按拼装后的全文在 >3000 字 warn、>3500 字 fail
+- 用文件写入工具存到 `/root/.openclaw/workspace/memory/.tmp/report-prose-{{market}}-{{phase}}.md`
+
+**Step 3 - Postflight**
+```
+python3 /root/.openclaw/workspace/scripts/harness/report_postflight.py --market {{market}} --phase {{phase}} --context-id <Step 1 的 context_id> --text-file /root/.openclaw/workspace/memory/.tmp/report-prose-{{market}}-{{phase}}.md
+```
+`--context-id` 必须照抄 Step 1 打印的那个。pass/warn 自动拼装+发送+刷新 snapshot/dashboard+提交推送。
+这是**唯一微信路径**，并同步 Telegram；本 cron 配 `--no-deliver`，不会再 announce 你的回复文本。
+
+**Step 4 - 输出**
+把 postflight 返回的 `status` + `issues` 作为本回合最终文本回复（仅留痕）。
+❌ **禁用 message/send 工具** —— postflight 已经发过了，你再手动调会撞成双发（2026-06-03 教训）。
+
+**铁律**：
+- ⚠️ 数据缺口必说，禁止编造（postflight 扫敷衍词）
+- 不简单复述数字，必须做模型自己的解读
+- {{market_rule}}
+- 直接回复文本

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -23,7 +23,11 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
+      "fallbacks": [
+        "minimax-2/MiniMax-M3"
+      ],
       "thinking": "adaptive",
+      "message_template": "config/cron-payloads/report.md",
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
@@ -63,7 +67,11 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
+      "fallbacks": [
+        "minimax-2/MiniMax-M3"
+      ],
       "thinking": "adaptive",
+      "message_template": "config/cron-payloads/intraday.md",
       "tools_allow": [
         "exec",
         "process",
@@ -119,7 +127,11 @@
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
+      "fallbacks": [
+        "minimax-2/MiniMax-M3"
+      ],
       "thinking": "adaptive",
+      "message_template": "config/cron-payloads/brief.md",
       "delivery_mode": "none",
       "required_substrings": [
         "trading_calendar.py hk",
@@ -139,6 +151,7 @@
     "memory": {
       "payload_kind": "agentTurn",
       "model": "minimax/MiniMax-M3",
+      "fallbacks": [],
       "delivery_mode": "none",
       "exact_message": "__openclaw_memory_core_short_term_promotion_dream__"
     }
@@ -153,6 +166,7 @@
       "payload_profile": "intraday",
       "payload_vars": {
         "market": "us",
+        "market_name": "美股",
         "skill": "us-stock-analysis"
       },
       "schedule": {
@@ -194,7 +208,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "us",
+        "market_name": "美股",
+        "market_rule": "杠杆 ETF (SOXL/MSFU/RKLX/PLTU) 不读 SEC EDGAR，看 underlying 走势",
         "phase": "close",
+        "session_label": "美股收盘（16:00 ET）",
         "skill": "us-stock-analysis"
       },
       "seasonal_schedules": {
@@ -274,7 +291,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "hk",
+        "market_name": "港股",
+        "market_rule": "00100 MINIMAX 只有 Tencent 一个源，失败必须明说\"实时价获取失败\"",
         "phase": "open",
+        "session_label": "港股开盘（09:30 HKT）",
         "skill": "hk-stock-analysis"
       },
       "schedule": {
@@ -304,6 +324,7 @@
       "payload_profile": "intraday",
       "payload_vars": {
         "market": "hk",
+        "market_name": "港股",
         "skill": "hk-stock-analysis"
       },
       "schedule": {
@@ -334,7 +355,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "hk",
+        "market_name": "港股",
+        "market_rule": "00100 MINIMAX 只有 Tencent 一个源，失败必须明说\"实时价获取失败\"",
         "phase": "mid",
+        "session_label": "港股午盘（12:00 HKT）",
         "skill": "hk-stock-analysis"
       },
       "schedule": {
@@ -365,7 +389,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "hk",
+        "market_name": "港股",
+        "market_rule": "00100 MINIMAX 只有 Tencent 一个源，失败必须明说\"实时价获取失败\"",
         "phase": "pm",
+        "session_label": "港股午后（13:30 HKT）",
         "skill": "hk-stock-analysis"
       },
       "schedule": {
@@ -396,7 +423,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "hk",
+        "market_name": "港股",
+        "market_rule": "00100 MINIMAX 只有 Tencent 一个源，失败必须明说\"实时价获取失败\"",
         "phase": "close",
+        "session_label": "港股收盘（16:00 HKT）",
         "skill": "hk-stock-analysis"
       },
       "schedule": {
@@ -427,7 +457,10 @@
       "payload_profile": "report",
       "payload_vars": {
         "market": "us",
+        "market_name": "美股",
+        "market_rule": "杠杆 ETF (SOXL/MSFU/RKLX/PLTU) 不读 SEC EDGAR，看 underlying 走势",
         "phase": "open",
+        "session_label": "美股开盘（09:30 ET）",
         "skill": "us-stock-analysis"
       },
       "seasonal_schedules": {
@@ -471,6 +504,7 @@
       "payload_profile": "intraday",
       "payload_vars": {
         "market": "us",
+        "market_name": "美股",
         "skill": "us-stock-analysis"
       },
       "seasonal_schedules": {

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -76,17 +76,20 @@ title: clawock · scripts 详细参考
 都会重建 dashboard；Mode 7 不提交 `portfolio.json`，dashboard 只发布语义变化，但每个
 受监控 slot 的 heartbeat 都会发布并由 cron health 对账。
 
-cron payload 是真实执行面，会为隔离 session 自包含关键步骤；SKILL.md 是详细规范。改格式时
-必须同时 diff payload 与对应 Mode，尤其 Step 2.5 sidecar。schedule 的 runtime 真值来自 CLI，
-tracked contract 在 `config/cron-schedules.json`；schedule、payload、watchdog 或生成文档漂移
-都会被 `scripts/system_check.py` / CI 拦截。
+cron payload 是真实执行面，会为隔离 session 自包含关键步骤；SKILL.md 是详细规范。完整 prompt
+模板在 `config/cron-payloads/`，job 变量、model/fallback/thinking/tools/schedule 则由
+`config/cron-schedules.json` 单源声明；改格式时必须同时 diff payload 与对应 Mode，尤其
+Step 2.5 sidecar。schedule、payload、watchdog 或生成文档漂移都会被
+`scripts/system_check.py` / CI 拦截。
 
-**改 cron prompt 的安全步骤**（6.1 后只走 CLI，不碰文件）：
+**改 cron 配置的安全步骤**（默认只检查，显式 apply；不覆盖投递目标/account/failure alert）：
 ```bash
-# 读：openclaw cron list --json | python3 -c '...'   （JSON 前可能有 Config warnings 噪音，find('{') 起切）
-# 写：openclaw cron edit <job-id> --message "$NEW_MSG"   （只 patch message，schedule/tz 不动）
+python3 scripts/data/sync_cron_payloads.py --json
+python3 scripts/data/sync_cron_payloads.py --apply --json
 ```
-改 `--cron` 表达式时必须同时带 `--tz Asia/Shanghai`（否则 tz 被重置）。升级大版本后先 `openclaw cron list` 数 job 个数（应为 11），少了跑 `openclaw doctor --fix`。
+同步器按精确 job 名/ID 规划最小 patch，发现重复/缺失/额外 job 或目标 job 正在运行时不写，
+逐 job 失败即停，apply 后重新读取验证。升级大版本后仍应先 `openclaw cron list` 数 job 个数
+（应为 11），少了跑 `openclaw doctor --fix`。
 
 ### Cron 运行历史（自动 + 手动跨 job 聚合）
 

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -11,6 +12,7 @@ WS = Path(__file__).resolve().parents[2]
 DEFAULT_CONTRACT = WS / "config" / "cron-schedules.json"
 HKT = ZoneInfo("Asia/Hong_Kong")
 ET = ZoneInfo("America/New_York")
+TEMPLATE_TOKEN = re.compile(r"\{\{([a-z][a-z0-9_]*)\}\}")
 
 
 def load_contract(path: str | Path | None = None) -> dict:
@@ -32,6 +34,26 @@ def load_contract(path: str | Path | None = None) -> dict:
             or any(not model for model in candidates)
         ):
             raise ValueError(f"{profile_name}: model_candidates must be unique models")
+        fallbacks = profile.get("fallbacks")
+        if fallbacks is not None and (
+            not isinstance(fallbacks, list)
+            or len(fallbacks) != len(set(fallbacks))
+            or any(not isinstance(model, str) or not model for model in fallbacks)
+        ):
+            raise ValueError(f"{profile_name}: fallbacks must be unique models")
+        if fallbacks is not None:
+            rotation = [profile.get("model"), *fallbacks]
+            if any(not model for model in rotation):
+                raise ValueError(
+                    f"{profile_name}: model is required when fallbacks are declared"
+                )
+            if len(rotation) != len(set(rotation)):
+                raise ValueError(f"{profile_name}: model rotation contains duplicates")
+            if candidates and rotation != candidates[:len(rotation)]:
+                raise ValueError(
+                    f"{profile_name}: configured rotation must be a fixed prefix "
+                    f"of model_candidates"
+                )
         tools_allow = profile.get("tools_allow")
         if tools_allow is not None and (
             not isinstance(tools_allow, list)
@@ -42,6 +64,15 @@ def load_contract(path: str | Path | None = None) -> dict:
             raise ValueError(
                 f"{profile_name}: tools_allow must be non-empty unique tool names"
             )
+        template = profile.get("message_template")
+        if template is not None and (
+            not isinstance(template, str)
+            or not template.startswith("config/cron-payloads/")
+            or not template.endswith(".md")
+        ):
+            raise ValueError(
+                f"{profile_name}: message_template must be a config/cron-payloads/*.md path"
+            )
     for job in jobs:
         if bool(job.get("schedule")) == bool(job.get("seasonal_schedules")):
             raise ValueError(f"{job['name']}: define exactly one schedule source")
@@ -50,6 +81,7 @@ def load_contract(path: str | Path | None = None) -> dict:
             raise ValueError(f"{job['name']}: seasonal schedules require daylight+standard")
         if job.get("payload_profile") not in profiles:
             raise ValueError(f"{job['name']}: unknown payload profile")
+        render_payload_message(data, job)
         watchdog = job.get("watchdog")
         if watchdog:
             if bool(watchdog.get("schedule")) == bool(watchdog.get("seasonal_schedules")):
@@ -109,6 +141,44 @@ def _format_required(text: str, variables: dict) -> str:
         raise ValueError(f"missing payload variable {exc.args[0]!r}") from exc
 
 
+def render_payload_message(contract: dict, expected_job: dict) -> str | None:
+    """Render the exact reviewed message for one tracked agent job."""
+    profile_name = expected_job.get("payload_profile")
+    profile = (contract.get("payload_profiles") or {}).get(profile_name) or {}
+    exact = profile.get("exact_message")
+    template_path = profile.get("message_template")
+    if exact is not None and template_path is not None:
+        raise ValueError(f"{profile_name}: use exact_message or message_template, not both")
+    if exact is not None:
+        return str(exact).strip()
+    if template_path is None:
+        return None
+
+    path = (WS / template_path).resolve()
+    try:
+        path.relative_to(WS.resolve())
+    except ValueError as exc:
+        raise ValueError(f"{profile_name}: message template escapes workspace") from exc
+    try:
+        template = path.read_text().rstrip("\n")
+    except OSError as exc:
+        raise ValueError(f"{profile_name}: cannot read message template: {exc}") from exc
+
+    variables = expected_job.get("payload_vars") or {}
+    tokens = set(TEMPLATE_TOKEN.findall(template))
+    missing = sorted(tokens - set(variables))
+    unused = sorted(set(variables) - tokens)
+    if missing:
+        raise ValueError(
+            f"{expected_job['name']}: missing template variables {missing!r}"
+        )
+    if unused:
+        raise ValueError(
+            f"{expected_job['name']}: unused template variables {unused!r}"
+        )
+    return TEMPLATE_TOKEN.sub(lambda match: str(variables[match.group(1)]), template)
+
+
 def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[str]:
     profile_name = expected_job.get("payload_profile")
     profiles = contract.get("payload_profiles") or {}
@@ -121,6 +191,7 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
     errors = []
     fields = {
         "kind": profile.get("payload_kind"),
+        "model": profile.get("model"),
         "thinking": profile.get("thinking"),
     }
     candidates = profile.get("model_candidates")
@@ -142,8 +213,12 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
             errors.append(
                 f"payload model rotation must be a fixed prefix of {candidates!r}"
             )
-    else:
-        fields["model"] = profile.get("model")
+    expected_fallbacks = profile.get("fallbacks")
+    if expected_fallbacks is not None and payload.get("fallbacks", []) != expected_fallbacks:
+        errors.append(
+            f"payload.fallbacks expected {expected_fallbacks!r}, "
+            f"got {payload.get('fallbacks', [])!r}"
+        )
     for field, expected in fields.items():
         if expected is not None and payload.get(field) != expected:
             errors.append(f"payload.{field} expected {expected!r}, got {payload.get(field)!r}")
@@ -176,9 +251,9 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
         errors.append(
             f"delivery.mode expected {expected_delivery!r}, got {delivery.get('mode')!r}"
         )
-    exact = profile.get("exact_message")
-    if exact is not None and message.strip() != exact:
-        errors.append("payload message does not match exact contract")
+    rendered = render_payload_message(contract, expected_job)
+    if rendered is not None and message.strip() != rendered:
+        errors.append("payload message does not match rendered contract")
     variables = expected_job.get("payload_vars") or {}
     for raw in profile.get("required_substrings", []):
         required = _format_required(raw, variables)

--- a/scripts/data/sync_cron_payloads.py
+++ b/scripts/data/sync_cron_payloads.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Reconcile tracked OpenClaw jobs with the reviewed cron contract.
+
+The default mode is read-only and exits 1 when drift exists. ``--apply`` edits
+only declared fields, one job at a time, and stops at the first failed edit.
+Delivery destinations, accounts, failure alerts, and other runtime-only fields
+are deliberately preserved.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+WS = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WS / "scripts" / "data"))
+
+from cron_contract import (  # noqa: E402
+    effective_schedule,
+    load_contract,
+    render_payload_message,
+)
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def parse_at(value: str | None) -> datetime:
+    if not value:
+        return datetime.now(timezone.utc)
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _json_object(text: str) -> dict:
+    """Decode CLI JSON even when a version warning precedes it."""
+    start = text.find("{")
+    if start < 0:
+        raise ValueError("OpenClaw CLI returned no JSON object")
+    value = json.loads(text[start:])
+    if not isinstance(value, dict):
+        raise ValueError("OpenClaw CLI JSON root must be an object")
+    return value
+
+
+def load_live_jobs(runner: Runner = subprocess.run) -> list[dict]:
+    result = runner(
+        ["openclaw", "cron", "list", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        detail = (result.stdout + result.stderr).strip()[-500:]
+        raise RuntimeError(f"openclaw cron list failed: {detail}")
+    value = _json_object(result.stdout)
+    jobs = value.get("jobs")
+    if not isinstance(jobs, list):
+        raise ValueError("OpenClaw CLI JSON has no jobs list")
+    return jobs
+
+
+def _value_summary(value: object) -> object:
+    if isinstance(value, str) and ("\n" in value or len(value) > 120):
+        digest = hashlib.sha256(value.encode()).hexdigest()[:12]
+        return {"sha256": digest, "chars": len(value)}
+    return value
+
+
+def _record(patch: dict, diffs: list[dict], field: str,
+            current: object, desired: object) -> None:
+    if current == desired:
+        return
+    patch[field] = desired
+    diffs.append({
+        "field": field,
+        "from": _value_summary(current),
+        "to": _value_summary(desired),
+    })
+
+
+def desired_changes(contract: dict, live_jobs: list[dict],
+                    at: datetime) -> tuple[list[dict], list[str]]:
+    """Return an exact, non-mutating edit plan and precondition errors."""
+    expected_names = [job["name"] for job in contract["jobs"]]
+    live_names = [job.get("name") for job in live_jobs]
+    counts = Counter(live_names)
+    errors = [
+        f"duplicate live job name {name!r} ({count} matches)"
+        for name, count in sorted(counts.items(), key=lambda item: str(item[0]))
+        if count > 1
+    ]
+    for name in sorted(set(expected_names) - set(live_names)):
+        errors.append(f"missing live job {name}")
+    for name in sorted(set(live_names) - set(expected_names), key=str):
+        errors.append(f"unexpected live job {name}")
+    if errors:
+        return [], errors
+
+    live_by_name = {job["name"]: job for job in live_jobs}
+    profiles = contract["payload_profiles"]
+    changes = []
+    for spec in contract["jobs"]:
+        name = spec["name"]
+        live = live_by_name[name]
+        profile = profiles[spec["payload_profile"]]
+        payload = live.get("payload") or {}
+        delivery = live.get("delivery") or {}
+        patch: dict = {}
+        diffs: list[dict] = []
+
+        expected_kind = profile.get("payload_kind")
+        if payload.get("kind") != expected_kind:
+            errors.append(
+                f"{name}: payload kind {payload.get('kind')!r} cannot be "
+                f"safely changed to {expected_kind!r}"
+            )
+            continue
+
+        schedule = effective_schedule(spec, at)
+        current_schedule = live.get("schedule") or {}
+        if current_schedule.get("kind") != schedule.get("kind"):
+            errors.append(
+                f"{name}: schedule kind {current_schedule.get('kind')!r} cannot "
+                f"be safely changed to {schedule.get('kind')!r}"
+            )
+            continue
+        _record(
+            patch, diffs, "schedule",
+            {
+                "expr": current_schedule.get("expr"),
+                "tz": current_schedule.get("tz"),
+                "exact": current_schedule.get("staggerMs") in (None, 0),
+            },
+            {"expr": schedule.get("expr"), "tz": schedule.get("tz"), "exact": True},
+        )
+        _record(
+            patch, diffs, "enabled",
+            live.get("enabled", True), spec.get("enabled", True),
+        )
+        for contract_field, live_field in (
+            ("model", "model"),
+            ("fallbacks", "fallbacks"),
+            ("thinking", "thinking"),
+            ("tools_allow", "toolsAllow"),
+            ("timeout_seconds", "timeoutSeconds"),
+        ):
+            if contract_field in profile:
+                current = payload.get(live_field, [] if live_field == "fallbacks" else None)
+                _record(patch, diffs, live_field, current, profile[contract_field])
+
+        message = render_payload_message(contract, spec)
+        if message is not None:
+            _record(patch, diffs, "message", payload.get("message", ""), message)
+
+        if "delivery_mode" in profile:
+            _record(
+                patch, diffs, "deliveryMode",
+                delivery.get("mode"), profile["delivery_mode"],
+            )
+
+        trigger = profile.get("trigger")
+        if trigger:
+            variables = spec.get("payload_vars") or {}
+            script_path = trigger["script_path"].format(**variables)
+            desired_trigger = {
+                "scriptPath": script_path,
+                "once": bool(trigger.get("once", False)),
+            }
+            current_trigger = live.get("trigger")
+            current_summary = None
+            if isinstance(current_trigger, dict):
+                current_summary = {
+                    "script": _value_summary(
+                        (current_trigger.get("script") or "").strip()
+                    ),
+                    "once": bool(current_trigger.get("once", False)),
+                }
+            desired_script = (WS / script_path).read_text().strip()
+            if current_summary != {
+                "script": _value_summary(desired_script),
+                "once": desired_trigger["once"],
+            }:
+                patch["trigger"] = desired_trigger
+                diffs.append({
+                    "field": "trigger",
+                    "from": current_summary,
+                    "to": {
+                        "scriptPath": script_path,
+                        "once": desired_trigger["once"],
+                    },
+                })
+        elif live.get("trigger"):
+            patch["clearTrigger"] = True
+            diffs.append({
+                "field": "trigger",
+                "from": "configured",
+                "to": None,
+            })
+
+        if not diffs:
+            continue
+        if not live.get("id"):
+            errors.append(f"{name}: missing runtime id")
+            continue
+        state = live.get("state") or {}
+        if live.get("status") == "running" or state.get("runningAtMs"):
+            errors.append(f"{name}: job is currently running; retry after it finishes")
+            continue
+        changes.append({
+            "id": live["id"],
+            "name": name,
+            "patch": patch,
+            "diffs": diffs,
+        })
+    return changes, errors
+
+
+def build_edit_command(change: dict) -> list[str]:
+    patch = change["patch"]
+    command = ["openclaw", "cron", "edit", change["id"]]
+    if "schedule" in patch:
+        schedule = patch["schedule"]
+        if not schedule.get("tz"):
+            raise ValueError(
+                f"{change['name']}: clearing a cron timezone is not supported safely"
+            )
+        command.extend([
+            "--cron", schedule["expr"], "--tz", schedule["tz"], "--exact",
+        ])
+    if "enabled" in patch:
+        command.append("--enable" if patch["enabled"] else "--disable")
+    if "model" in patch:
+        command.extend(["--model", patch["model"]])
+    if "fallbacks" in patch:
+        if patch["fallbacks"]:
+            command.extend(["--fallbacks", ",".join(patch["fallbacks"])])
+        else:
+            command.append("--clear-fallbacks")
+    if "thinking" in patch:
+        command.extend(["--thinking", patch["thinking"]])
+    if "toolsAllow" in patch:
+        tools = patch["toolsAllow"]
+        command.extend(["--tools", ",".join(tools)]) if tools else command.append(
+            "--clear-tools"
+        )
+    if "timeoutSeconds" in patch:
+        command.extend(["--timeout-seconds", str(patch["timeoutSeconds"])])
+    if "message" in patch:
+        command.extend(["--message", patch["message"]])
+    if "deliveryMode" in patch:
+        mode = patch["deliveryMode"]
+        if mode == "none":
+            command.append("--no-deliver")
+        elif mode == "announce":
+            command.append("--announce")
+        else:
+            raise ValueError(
+                f"{change['name']}: unsupported delivery mode {mode!r}"
+            )
+    if patch.get("clearTrigger"):
+        command.append("--clear-trigger")
+    if "trigger" in patch:
+        trigger = patch["trigger"]
+        command.extend(["--trigger-script", trigger["scriptPath"]])
+        if trigger["once"]:
+            command.append("--trigger-once")
+    command.extend(["--timeout", "120000"])
+    return command
+
+
+def apply_changes(changes: list[dict], runner: Runner = subprocess.run,
+                  live_loader: Callable[[], list[dict]] | None = None) -> list[str]:
+    """Apply sequentially and stop immediately after the first failed edit."""
+    for change in changes:
+        if live_loader is not None:
+            try:
+                matches = [
+                    job for job in live_loader()
+                    if job.get("id") == change["id"] and job.get("name") == change["name"]
+                ]
+            except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as exc:
+                return [f"{change['name']}: cannot recheck runtime state: {exc}"]
+            if len(matches) != 1:
+                return [
+                    f"{change['name']}: runtime identity changed before apply "
+                    f"({len(matches)} matches)"
+                ]
+            state = matches[0].get("state") or {}
+            if matches[0].get("status") == "running" or state.get("runningAtMs"):
+                return [
+                    f"{change['name']}: job started running before apply; stopped"
+                ]
+        try:
+            command = build_edit_command(change)
+        except ValueError as exc:
+            return [str(exc)]
+        result = runner(
+            command,
+            cwd=WS,
+            capture_output=True,
+            text=True,
+            timeout=130,
+        )
+        if result.returncode != 0:
+            detail = (result.stdout + result.stderr).strip()[-500:]
+            return [f"{change['name']}: cron edit failed: {detail}"]
+    return []
+
+
+def public_changes(changes: list[dict]) -> list[dict]:
+    """Return a plan safe for logs: no full prompts or delivery metadata."""
+    return [
+        {"id": change["id"], "name": change["name"], "diffs": change["diffs"]}
+        for change in changes
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="apply tracked fields; default is a read-only drift check",
+    )
+    parser.add_argument("--at", help="ISO timestamp override (tests/audits)")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    at = parse_at(args.at)
+    errors: list[str] = []
+    changes: list[dict] = []
+    applied = False
+    try:
+        contract = load_contract()
+        changes, errors = desired_changes(contract, load_live_jobs(), at)
+        if args.apply and not errors and changes:
+            errors = apply_changes(changes, live_loader=load_live_jobs)
+            if not errors:
+                remaining, verify_errors = desired_changes(
+                    contract, load_live_jobs(), at
+                )
+                errors.extend(verify_errors)
+                if remaining:
+                    errors.append(
+                        f"post-apply verification found {len(remaining)} remaining change(s)"
+                    )
+                applied = not errors
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as exc:
+        errors.append(str(exc))
+
+    result = {
+        "status": "error" if errors else (
+            "applied" if applied else ("drift" if changes else "ok")
+        ),
+        "checked_at": at.isoformat(),
+        "apply": args.apply,
+        "change_count": len(changes),
+        "changes": public_changes(changes),
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"Cron payload sync: {result['status']} · "
+            f"changes={len(changes)} errors={len(errors)}"
+        )
+        for change in public_changes(changes):
+            fields = ", ".join(diff["field"] for diff in change["diffs"])
+            print(f"  {change['name']}: {fields}")
+        for error in errors:
+            print(f"  ERROR: {error}", file=sys.stderr)
+    if errors:
+        return 2
+    if changes and not args.apply:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -101,13 +101,12 @@ def test_payload_semantic_contract_detects_deprecated_or_missing_rules():
     data = contract()
     expected = next(j for j in data['jobs'] if j['name'] == '美股开盘报告')
     profile = data['payload_profiles']['report']
-    vars_ = expected['payload_vars']
-    message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    message = cron_contract.render_payload_message(data, expected)
     live = {
         'payload': {
             'kind': 'agentTurn',
             'model': profile['model'],
-            'fallbacks': profile['model_candidates'][1:],
+            'fallbacks': profile['fallbacks'],
             'thinking': profile['thinking'],
             'message': message,
         },
@@ -465,13 +464,13 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     # 4–6 minute check-ins before postflight can deliver them.
     assert 'timeout_seconds' not in profile
 
-    vars_ = {'market': 'hk', 'skill': 'hk-stock-analysis'}
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
-    message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    message = cron_contract.render_payload_message(data, expected)
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking'],
+                    'fallbacks': profile['fallbacks'],
                     'toolsAllow': profile['tools_allow']},
         'delivery': {'mode': 'none'},
     }
@@ -515,11 +514,11 @@ def test_intraday_slots_are_unconditional_again():
     assert not (ROOT / 'config' / 'cron-triggers').exists()
 
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
-    vars_ = {'market': 'hk', 'skill': 'hk-stock-analysis'}
-    message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    message = cron_contract.render_payload_message(data, expected)
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking'],
+                    'fallbacks': profile['fallbacks'],
                     'toolsAllow': profile['tools_allow']},
         'delivery': {'mode': 'none'},
         'trigger': {'script': 'json({ fire: false });', 'once': False},
@@ -533,14 +532,13 @@ def test_intraday_payload_rejects_missing_process_tool():
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
     profile = data['payload_profiles']['intraday']
-    message = '\n'.join(
-        s.format(**expected['payload_vars']) for s in profile['required_substrings']
-    )
+    message = cron_contract.render_payload_message(data, expected)
     live = {
         'payload': {
             'message': message,
             'kind': profile['payload_kind'],
             'model': profile['model'],
+            'fallbacks': profile['fallbacks'],
             'thinking': profile['thinking'],
             'toolsAllow': [
                 tool for tool in profile['tools_allow'] if tool != 'process'
@@ -567,13 +565,12 @@ def _brief_live_payload(data, *, timeout=1800):
     """A live 盘前深度简报 job that satisfies every other clause of its profile."""
     expected = next(j for j in data['jobs'] if j['name'] == '盘前深度简报')
     profile = data['payload_profiles']['brief']
-    vars_ = expected.get('payload_vars') or {}
-    message = '\n'.join(s.format(**vars_) for s in profile['required_substrings'])
+    message = cron_contract.render_payload_message(data, expected)
     live = {
         'payload': {
             'kind': profile['payload_kind'],
             'model': profile['model'],
-            'fallbacks': profile['model_candidates'][1:2],
+            'fallbacks': profile['fallbacks'],
             'thinking': profile['thinking'],
             'message': message,
         },

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -1,0 +1,217 @@
+import copy
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import cron_contract
+import sync_cron_payloads
+
+
+JULY = datetime(2026, 7, 30, 0, tzinfo=timezone.utc)
+
+
+def contract():
+    return cron_contract.load_contract(ROOT / "config" / "cron-schedules.json")
+
+
+def live_from_contract(data):
+    live = []
+    for index, spec in enumerate(data["jobs"]):
+        profile = data["payload_profiles"][spec["payload_profile"]]
+        payload = {
+            "kind": profile["payload_kind"],
+            "model": profile["model"],
+            "message": cron_contract.render_payload_message(data, spec),
+        }
+        for contract_field, live_field in (
+            ("fallbacks", "fallbacks"),
+            ("thinking", "thinking"),
+            ("tools_allow", "toolsAllow"),
+            ("timeout_seconds", "timeoutSeconds"),
+        ):
+            if contract_field in profile:
+                payload[live_field] = copy.deepcopy(profile[contract_field])
+        live.append({
+            "id": f"id-{index}",
+            "name": spec["name"],
+            "enabled": spec.get("enabled", True),
+            "schedule": copy.deepcopy(cron_contract.effective_schedule(spec, JULY)),
+            "payload": payload,
+            "delivery": {"mode": profile["delivery_mode"]},
+            "status": "ok",
+            "state": {},
+        })
+    return live
+
+
+def test_exact_contract_is_an_idempotent_noop():
+    data = contract()
+    changes, errors = sync_cron_payloads.desired_changes(
+        data, live_from_contract(data), JULY
+    )
+    assert changes == []
+    assert errors == []
+
+
+def test_drift_plan_and_command_patch_only_declared_fields():
+    data = contract()
+    live = live_from_contract(data)
+    job = next(item for item in live if item["name"] == "美股盘中盯盘")
+    job["payload"]["thinking"] = "high"
+    job["payload"]["fallbacks"] = []
+    job["payload"]["toolsAllow"].remove("process")
+    job["payload"]["message"] += "\nmanual drift"
+    job["delivery"]["to"] = "preserve-me"
+
+    changes, errors = sync_cron_payloads.desired_changes(data, live, JULY)
+    assert errors == []
+    assert len(changes) == 1
+    change = changes[0]
+    assert {diff["field"] for diff in change["diffs"]} == {
+        "thinking", "fallbacks", "toolsAllow", "message"
+    }
+    command = sync_cron_payloads.build_edit_command(change)
+    assert command[:4] == ["openclaw", "cron", "edit", job["id"]]
+    assert command[command.index("--thinking") + 1] == "adaptive"
+    assert command[command.index("--fallbacks") + 1] == "minimax-2/MiniMax-M3"
+    assert "process" in command[command.index("--tools") + 1].split(",")
+    assert "--message" in command
+    assert "preserve-me" not in command
+
+
+def test_nonzero_scheduler_stagger_is_reset_to_exact():
+    data = contract()
+    live = live_from_contract(data)
+    job = next(item for item in live if item["name"] == "美股开盘报告")
+    job["schedule"]["staggerMs"] = 60_000
+    changes, errors = sync_cron_payloads.desired_changes(data, live, JULY)
+    assert errors == []
+    assert len(changes) == 1
+    assert changes[0]["patch"]["schedule"]["exact"] is True
+    command = sync_cron_payloads.build_edit_command(changes[0])
+    assert "--exact" in command
+
+
+def test_rendering_changes_only_double_brace_contract_tokens():
+    data = contract()
+    intraday = next(
+        job for job in data["jobs"] if job["name"] == "美股盘中盯盘"
+    )
+    brief = next(job for job in data["jobs"] if job["name"] == "盘前深度简报")
+    intraday_message = cron_contract.render_payload_message(data, intraday)
+    brief_message = cron_contract.render_payload_message(data, brief)
+
+    assert "{{" not in intraday_message
+    assert "{CTXID}" in intraday_message
+    assert "${total}" in brief_message
+
+    missing = copy.deepcopy(intraday)
+    missing["payload_vars"].pop("market_name")
+    try:
+        cron_contract.render_payload_message(data, missing)
+    except ValueError as exc:
+        assert "missing template variables" in str(exc)
+    else:
+        raise AssertionError("missing template variable was accepted")
+
+    unused = copy.deepcopy(intraday)
+    unused["payload_vars"]["unused"] = "x"
+    try:
+        cron_contract.render_payload_message(data, unused)
+    except ValueError as exc:
+        assert "unused template variables" in str(exc)
+    else:
+        raise AssertionError("unused template variable was accepted")
+
+
+def test_duplicate_or_missing_jobs_abort_before_planning_mutations():
+    data = contract()
+    live = live_from_contract(data)
+    live.append(copy.deepcopy(live[0]))
+    changes, errors = sync_cron_payloads.desired_changes(data, live, JULY)
+    assert changes == []
+    assert any("duplicate live job name" in error for error in errors)
+
+    live = live_from_contract(data)[1:]
+    changes, errors = sync_cron_payloads.desired_changes(data, live, JULY)
+    assert changes == []
+    assert any("missing live job" in error for error in errors)
+
+
+def test_running_changed_job_is_a_precondition_error():
+    data = contract()
+    live = live_from_contract(data)
+    live[0]["payload"]["thinking"] = "high"
+    live[0]["status"] = "running"
+    live[0]["state"]["runningAtMs"] = 123
+    changes, errors = sync_cron_payloads.desired_changes(data, live, JULY)
+    assert changes == []
+    assert errors == [
+        f"{live[0]['name']}: job is currently running; retry after it finishes"
+    ]
+
+
+def test_apply_stops_at_first_failure_and_uses_argv():
+    changes = [
+        {
+            "id": "one",
+            "name": "first",
+            "patch": {"thinking": "adaptive"},
+            "diffs": [],
+        },
+        {
+            "id": "two",
+            "name": "second",
+            "patch": {"thinking": "adaptive"},
+            "diffs": [],
+        },
+    ]
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 9, stdout="", stderr="boom")
+
+    errors = sync_cron_payloads.apply_changes(changes, runner=runner)
+    assert len(calls) == 1
+    assert isinstance(calls[0][0], list)
+    assert calls[0][0][:4] == ["openclaw", "cron", "edit", "one"]
+    assert "first" in errors[0]
+    assert "boom" in errors[0]
+
+
+def test_apply_rechecks_running_state_before_each_edit():
+    change = {
+        "id": "one",
+        "name": "first",
+        "patch": {"thinking": "adaptive"},
+        "diffs": [],
+    }
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    errors = sync_cron_payloads.apply_changes(
+        [change],
+        runner=runner,
+        live_loader=lambda: [{
+            "id": "one",
+            "name": "first",
+            "status": "running",
+            "state": {"runningAtMs": 123},
+        }],
+    )
+    assert errors == ["first: job started running before apply; stopped"]
+    assert calls == []
+
+
+def test_cli_json_parser_tolerates_leading_warning():
+    parsed = sync_cron_payloads._json_object('Config warning\n{"jobs": []}\n')
+    assert parsed == {"jobs": []}


### PR DESCRIPTION
Closes #178

## Outcome
- track byte-exact report, intraday, and brief payload templates with job variables
- declare exact primary/fallback rotations instead of validation-only candidate sets
- add a default-read-only reconciler for schedule, model, fallbacks, thinking, tools, timeout, message, delivery mode, and triggers
- preserve destinations/accounts/failure alerts; abort on duplicate/missing jobs, running targets, or first edit failure; verify after apply
- make system_check use the same exact renderer as deployment

## Verification
- `pytest -q` — 1290 passed, 5 xfailed
- `python3 scripts/system_check.py` — 16 ok, 1 pre-existing memory-index warning, 0 critical
- `python3 scripts/data/sync_cron_payloads.py --json` — 11 live jobs, 0 drift
- live 01:00 Mode 7 run — success in 278s; exec=2, process=2, write=2, no shell polling or postflight re-check