### PR TITLE
perf(cron): promote healthy MiniMax route

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -16,15 +16,15 @@
   "payload_profiles": {
     "report": {
       "payload_kind": "agentTurn",
-      "model": "minimax/MiniMax-M3",
+      "model": "minimax-2/MiniMax-M3",
       "model_candidates": [
-        "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "minimax/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/report.md",
@@ -60,15 +60,15 @@
     },
     "intraday": {
       "payload_kind": "agentTurn",
-      "model": "minimax/MiniMax-M3",
+      "model": "minimax-2/MiniMax-M3",
       "model_candidates": [
-        "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "minimax/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
@@ -120,15 +120,15 @@
     "brief": {
       "timeout_seconds": 1800,
       "payload_kind": "agentTurn",
-      "model": "minimax/MiniMax-M3",
+      "model": "minimax-2/MiniMax-M3",
       "model_candidates": [
-        "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "minimax/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/brief.md",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -496,6 +496,19 @@ def test_strategy_crons_pin_minimax_m3_adaptive_reasoning():
         'intraday': 'adaptive',
         'brief': 'adaptive',
     }
+    assert {
+        name: (
+            profiles[name].get('model'),
+            profiles[name].get('fallbacks'),
+        )
+        for name in ('report', 'intraday', 'brief')
+    } == {
+        name: (
+            'minimax-2/MiniMax-M3',
+            ['minimax/MiniMax-M3'],
+        )
+        for name in ('report', 'intraday', 'brief')
+    }
 
 
 def test_intraday_slots_are_unconditional_again():

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -78,7 +78,10 @@ def test_drift_plan_and_command_patch_only_declared_fields():
     command = sync_cron_payloads.build_edit_command(change)
     assert command[:4] == ["openclaw", "cron", "edit", job["id"]]
     assert command[command.index("--thinking") + 1] == "adaptive"
-    assert command[command.index("--fallbacks") + 1] == "minimax-2/MiniMax-M3"
+    profile = data["payload_profiles"]["intraday"]
+    assert command[command.index("--fallbacks") + 1] == ",".join(
+        profile["fallbacks"]
+    )
     assert "process" in command[command.index("--tools") + 1].split(",")
     assert "--message" in command
     assert "preserve-me" not in command


### PR DESCRIPTION
Closes #182

## Outcome
- promote `minimax-2/MiniMax-M3`, which returned 200 in 1.3–2.3s after repeated primary overloads
- retain `minimax/MiniMax-M3` as the only fallback
- leave adaptive reasoning, complete prompts, tools, context, skills, timeout, delivery, and token/output budgets unchanged
- keep Codex/Claude out of the live rotation

## Evidence
- 01:30 natural run: old primary waited 101.5s then 429; promoted route returned 200 in 1.3s
- `pytest -q`: 1292 passed, 5 xfailed
- reconciler apply: 10 jobs changed, only model/fallback fields, post-apply 0 drift
- system check: 17 ok, 0 warn, 0 critical

The next 02:00 natural Mode 7 run will be used for end-to-end latency verification.