### PR TITLE
fix(cron): revert duplicate MiniMax route swap

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -16,15 +16,15 @@
   "payload_profiles": {
     "report": {
       "payload_kind": "agentTurn",
-      "model": "minimax-2/MiniMax-M3",
+      "model": "minimax/MiniMax-M3",
       "model_candidates": [
-        "minimax-2/MiniMax-M3",
         "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax/MiniMax-M3"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/report.md",
@@ -60,15 +60,15 @@
     },
     "intraday": {
       "payload_kind": "agentTurn",
-      "model": "minimax-2/MiniMax-M3",
+      "model": "minimax/MiniMax-M3",
       "model_candidates": [
-        "minimax-2/MiniMax-M3",
         "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax/MiniMax-M3"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
@@ -120,15 +120,15 @@
     "brief": {
       "timeout_seconds": 1800,
       "payload_kind": "agentTurn",
-      "model": "minimax-2/MiniMax-M3",
+      "model": "minimax/MiniMax-M3",
       "model_candidates": [
-        "minimax-2/MiniMax-M3",
         "minimax/MiniMax-M3",
+        "minimax-2/MiniMax-M3",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax/MiniMax-M3"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/brief.md",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -496,21 +496,6 @@ def test_strategy_crons_pin_minimax_m3_adaptive_reasoning():
         'intraday': 'adaptive',
         'brief': 'adaptive',
     }
-    assert {
-        name: (
-            profiles[name].get('model'),
-            profiles[name].get('fallbacks'),
-        )
-        for name in ('report', 'intraday', 'brief')
-    } == {
-        name: (
-            'minimax-2/MiniMax-M3',
-            ['minimax/MiniMax-M3'],
-        )
-        for name in ('report', 'intraday', 'brief')
-    }
-
-
 def test_intraday_slots_are_unconditional_again():
     """Every Mode 7 slot runs the turn; no pre-model condition gate.
 


### PR DESCRIPTION
Closes #184

## Outcome
- restores the established `minimax/MiniMax-M3` primary and `minimax-2/MiniMax-M3` fallback order
- removes the non-causal regression assertion introduced by #183
- preserves adaptive thinking, complete prompts, tools, context, skills, schedules, delivery, and timeouts

## Why
A redacted full-field audit proved both aliases share the exact same endpoint, protocol, API key, model, auth mode, and transport timeout. The sequential 429→200 observation was temporal recovery, not a provider-route distinction.

## Verification
- targeted cron tests: 34 passed
- live declarative sync: 0 drift
- system check: 17 ok, 0 warn, 0 critical
- `git diff --check`: clean