### PR TITLE
fix(intraday): require exact context numbers

### DIFF
--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -14,6 +14,7 @@ python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market
 - ❌ **不要抄 `raw_wechat_block`，不要重画那张表** —— postflight 在发送时自己把它拼在你的散文前面。你抄一遍只会引入排版误差：2026-07-28 00:30 就因为一格多打了一个空格，整段分析被丢掉只发了数据块。
 - 你的输出从 `▎我的看法` 开始（2-3 行）
 - 若 `should_alert=true`，必须提到 `anomalies` 至少一个票
+- 数字必须原样照抄 context 的完整字面值；禁止四舍五入、取整或改写成“约/近”等近似数，找不到原值就省略
 - 目标 ≤ 2200 字；postflight 在 >3000 字 warn、>3500 字 fail；**无标题**（高频推送避免刷屏）
 
 生成散文和 sidecar 后，必须在同一条回复内并行发出两个 `write` 工具调用，分别写入 prose 文件与 sidecar；不要拆成两轮。

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -89,6 +89,7 @@
         "若 exec 返回 `Command still running`，只用 `process` poll 对应 session；禁止新开 exec 用 sleep/ps/ls/grep 探测进度",
         "context_id",
         "同一条回复内并行发出两个 `write` 工具调用",
+        "数字必须原样照抄 context 的完整字面值；禁止四舍五入、取整或改写成“约/近”等近似数，找不到原值就省略",
         "intraday_postflight.py --market {market} --context-id",
         "--text-file",
         "intraday-prose-{market}.md",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -451,6 +451,11 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
         for line in profile['required_substrings']
     )
     assert '同一条回复内并行发出两个 `write` 工具调用' in profile['required_substrings']
+    exact_number_rule = (
+        '数字必须原样照抄 context 的完整字面值；'
+        '禁止四舍五入、取整或改写成“约/近”等近似数，找不到原值就省略'
+    )
+    assert exact_number_rule in profile['required_substrings']
     assert any(
         'postflight 返回 pass/warn 后直接输出' in line and '禁止再读、搜或重建' in line
         for line in profile['required_substrings']
@@ -467,6 +472,7 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
     message = cron_contract.render_payload_message(data, expected)
+    assert exact_number_rule in message
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking'],


### PR DESCRIPTION
Closes #187.

## What changed
- require intraday prose to copy numeric literals exactly from preflight context
- explicitly forbid rounding, integer approximation, and “约/近” rewrites
- pin the rule in the generated cron contract and regression test

## Safety
- numeric validation remains strict and visible
- no model, fallback, thinking, tools, skills, context, timeout, or delivery changes
- live cron payload sync is already at 0 drift

## Validation
- `python3 -m pytest -q tests/test_cron_contracts.py tests/test_sync_cron_payloads.py` (34 passed)
- pre-push `system_check.py`: 16 ok, 1 unrelated runtime-memory warning, 0 critical