### PR TITLE
fix(cron): load strategy skills and expose full tools

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -1,3 +1,5 @@
+**第一轮强制动作（不能跳过）**：在同一条回复中并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令。`read` 成功前不得进入分析；skills catalog 只有索引，不含 SKILL.md 正文。
+
 **Step 0 — 休市闸（最先执行）**
 分别跑 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py hk` 与 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
 

--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -2,6 +2,8 @@
 
 按 `skills/{{skill}}/SKILL.md` Mode 7 **harness 4-step** 流程：
 
+**第一轮强制动作（不能跳过）**：在同一条回复中并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{{skill}}/SKILL.md` 与 Step 1 preflight。`read` 成功前不得生成分析；skills catalog 只有索引，不含 SKILL.md 正文。
+
 **Step 1 - Preflight**
 ```
 python3 /root/.openclaw/workspace/scripts/harness/intraday_preflight.py --market {{market}}

--- a/config/cron-payloads/report.md
+++ b/config/cron-payloads/report.md
@@ -2,6 +2,8 @@
 
 按 `skills/{{skill}}/SKILL.md` Mode 6 harness 流程：
 
+**第一轮强制动作（不能跳过）**：在同一条回复中并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{{skill}}/SKILL.md` 与 Step 1 preflight。`read` 成功前不得生成分析；skills catalog 只有索引，不含 SKILL.md 正文。
+
 **Step 1 - Preflight**
 ```
 python3 /root/.openclaw/workspace/scripts/harness/report_preflight.py --market {{market}} --phase {{phase}}

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -31,6 +31,8 @@
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
+        "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{skill}/SKILL.md` 与 Step 1 preflight",
+        "skills catalog 只有索引，不含 SKILL.md 正文",
         "report_preflight.py --market {market} --phase {phase}",
         "context_id",
         "report_postflight.py --market {market} --phase {phase} --context-id",
@@ -72,17 +74,12 @@
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
-      "tools_allow": [
-        "exec",
-        "process",
-        "read",
-        "write",
-        "web_search",
-        "web_fetch"
-      ],
+      "tools_allow": null,
       "delivery_mode": "none",
       "required_substrings": [
         "skills/{skill}/SKILL.md",
+        "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/{skill}/SKILL.md` 与 Step 1 preflight",
+        "skills catalog 只有索引，不含 SKILL.md 正文",
         "intraday_preflight.py --market {market}",
         "market_closed",
         "所有脚本 exec 调用都显式设置 `timeout: 300`",
@@ -138,6 +135,8 @@
         "trading_calendar.py hk",
         "trading_calendar.py us",
         "skills/daily-deep-brief/SKILL.md",
+        "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令",
+        "skills catalog 只有索引，不含 SKILL.md 正文",
         "brief_preflight.py",
         "brief_postflight.py",
         "唯一微信路径",

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -234,7 +234,13 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
             f"got {payload.get('timeoutSeconds')!r}"
         )
     expected_tools = profile.get("tools_allow")
-    if expected_tools is not None:
+    if "tools_allow" in profile and expected_tools is None:
+        if payload.get("toolsAllow") is not None:
+            errors.append(
+                "payload.toolsAllow expected unrestricted tools, "
+                f"got {payload.get('toolsAllow')!r}"
+            )
+    elif expected_tools is not None:
         live_tools = payload.get("toolsAllow")
         if not isinstance(live_tools, list):
             errors.append(

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -460,11 +460,8 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
         'postflight 返回 pass/warn 后直接输出' in line and '禁止再读、搜或重建' in line
         for line in profile['required_substrings']
     )
-    assert profile['tools_allow'] == [
-        'exec', 'process', 'read', 'write', 'web_search', 'web_fetch'
-    ]
+    assert profile['tools_allow'] is None
     assert profile['thinking'] == 'adaptive'
-    assert 'process' in profile['tools_allow']
     # 300s is a per-exec bound. A 300s whole-turn timeout would kill normal
     # 4–6 minute check-ins before postflight can deliver them.
     assert 'timeout_seconds' not in profile
@@ -476,8 +473,7 @@ def test_intraday_payload_contract_bans_heredoc_and_requires_text_file():
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking'],
-                    'fallbacks': profile['fallbacks'],
-                    'toolsAllow': profile['tools_allow']},
+                    'fallbacks': profile['fallbacks']},
         'delivery': {'mode': 'none'},
     }
     assert cron_contract.payload_errors(data, expected, live) == []
@@ -502,6 +498,46 @@ def test_strategy_crons_pin_minimax_m3_adaptive_reasoning():
         'intraday': 'adaptive',
         'brief': 'adaptive',
     }
+
+
+def test_strategy_crons_require_skill_body_read_in_first_tool_batch():
+    """The skills system prompt is a catalog, not the SKILL.md body.
+
+    Saying "follow this skill" is therefore insufficient: a model can go
+    straight to preflight and never receive the strategy rules.  Pin an
+    explicit read in the first parallel tool batch so loading the real body
+    does not add another model round trip.
+    """
+    data = contract()
+    jobs = {job['name']: job for job in data['jobs']}
+
+    report = cron_contract.render_payload_message(data, jobs['美股开盘报告'])
+    assert (
+        '并行调用 `read` 读取 '
+        '`/root/.openclaw/workspace/skills/us-stock-analysis/SKILL.md` '
+        '与 Step 1 preflight'
+    ) in report
+
+    intraday = cron_contract.render_payload_message(data, jobs['美股盘中盯盘'])
+    assert (
+        '并行调用 `read` 读取 '
+        '`/root/.openclaw/workspace/skills/us-stock-analysis/SKILL.md` '
+        '与 Step 1 preflight'
+    ) in intraday
+
+    brief = cron_contract.render_payload_message(data, jobs['盘前深度简报'])
+    assert (
+        '并行调用 `read` 读取 '
+        '`/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` '
+        '与下方 Step 0 的两个休市闸命令'
+    ) in brief
+
+    assert all(
+        'skills catalog 只有索引，不含 SKILL.md 正文' in message
+        for message in (report, intraday, brief)
+    )
+
+
 def test_intraday_slots_are_unconditional_again():
     """Every Mode 7 slot runs the turn; no pre-model condition gate.
 
@@ -522,8 +558,7 @@ def test_intraday_slots_are_unconditional_again():
     live = {
         'payload': {'message': message, 'kind': 'agentTurn',
                     'model': profile['model'], 'thinking': profile['thinking'],
-                    'fallbacks': profile['fallbacks'],
-                    'toolsAllow': profile['tools_allow']},
+                    'fallbacks': profile['fallbacks']},
         'delivery': {'mode': 'none'},
         'trigger': {'script': 'json({ fire: false });', 'once': False},
     }
@@ -532,7 +567,7 @@ def test_intraday_slots_are_unconditional_again():
     ]
 
 
-def test_intraday_payload_rejects_missing_process_tool():
+def test_intraday_payload_rejects_stale_restricted_tool_override():
     data = contract()
     expected = {job['name']: job for job in data['jobs']}['盘中盯盘']
     profile = data['payload_profiles']['intraday']
@@ -544,14 +579,15 @@ def test_intraday_payload_rejects_missing_process_tool():
             'model': profile['model'],
             'fallbacks': profile['fallbacks'],
             'thinking': profile['thinking'],
-            'toolsAllow': [
-                tool for tool in profile['tools_allow'] if tool != 'process'
-            ],
+            'toolsAllow': ['exec', 'process', 'read', 'write'],
         },
         'delivery': {'mode': profile['delivery_mode']},
     }
     errors = cron_contract.payload_errors(data, expected, live)
-    assert any('toolsAllow expected' in error for error in errors), errors
+    assert errors == [
+        "payload.toolsAllow expected unrestricted tools, "
+        "got ['exec', 'process', 'read', 'write']"
+    ]
 
 
 def test_every_twenty_minutes_timeline_label_is_not_every_hour():

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -35,7 +35,9 @@ def live_from_contract(data):
             ("timeout_seconds", "timeoutSeconds"),
         ):
             if contract_field in profile:
-                payload[live_field] = copy.deepcopy(profile[contract_field])
+                value = profile[contract_field]
+                if value is not None:
+                    payload[live_field] = copy.deepcopy(value)
         live.append({
             "id": f"id-{index}",
             "name": spec["name"],
@@ -64,7 +66,7 @@ def test_drift_plan_and_command_patch_only_declared_fields():
     job = next(item for item in live if item["name"] == "美股盘中盯盘")
     job["payload"]["thinking"] = "high"
     job["payload"]["fallbacks"] = []
-    job["payload"]["toolsAllow"].remove("process")
+    job["payload"]["toolsAllow"] = ["exec", "process", "read", "write"]
     job["payload"]["message"] += "\nmanual drift"
     job["delivery"]["to"] = "preserve-me"
 
@@ -82,7 +84,8 @@ def test_drift_plan_and_command_patch_only_declared_fields():
     assert command[command.index("--fallbacks") + 1] == ",".join(
         profile["fallbacks"]
     )
-    assert "process" in command[command.index("--tools") + 1].split(",")
+    assert "--clear-tools" in command
+    assert "--tools" not in command
     assert "--message" in command
     assert "preserve-me" not in command
 


### PR DESCRIPTION
Closes #189.
Closes #190.

## What changed
- require report, intraday, and brief cron turns to read the referenced SKILL.md in the first parallel tool batch
- state explicitly that the OpenClaw skills catalog is metadata, not the skill body
- remove the narrow intraday toolsAllow override so OpenClaw exposes its full tool set
- make the tracked contract actively clear/reject stale restricted tool overrides

## Safety
- no model, fallback, thinking, context, skill catalog, timeout, delivery, max-token, or output-budget reductions
- skill read runs alongside deterministic preflight/calendar calls, so it does not add a model round trip
- direct message/send remains prohibited by payload; postflight remains the idempotent delivery owner
- live payload sync is 0 drift

## Validation
- targeted contract/sync tests: 35 passed
- pre-push system check: 16 ok, 1 unrelated runtime-memory warning, 0 critical