### PR TITLE
fix(upgrade): preserve local OpenClaw patches

### DIFF
--- a/scripts/ops/reapply_openclaw_patches.sh
+++ b/scripts/ops/reapply_openclaw_patches.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Reapply and verify every host-local OpenClaw dist patch that an upgrade wipes.
+#
+# This script intentionally does not restart the gateway. The upgrade operator
+# must first prove that no cron run is in flight, then restart exactly once.
+set -euo pipefail
+
+RUN_MODE="${1:-apply}"
+PATCH_ROOT="/root/tools/openclaw/current"
+PATCH_SCRIPTS=(
+  "$PATCH_ROOT/patch-embedding-threads1.sh"
+  "$PATCH_ROOT/patch-memory-search-timeout.sh"
+  "$PATCH_ROOT/patch-minimax-m3-priority.sh"
+  "$PATCH_ROOT/patch-minimax-response-header-timeout.sh"
+)
+
+case "$RUN_MODE" in
+  apply)
+    for patch_script in "${PATCH_SCRIPTS[@]}"; do
+      if [[ ! -x "$patch_script" ]]; then
+        echo "[openclaw-patches] ERROR: missing executable $patch_script" >&2
+        exit 1
+      fi
+      "$patch_script"
+    done
+    ;;
+  --check-only)
+    ;;
+  *)
+    echo "usage: $0 [--check-only]" >&2
+    exit 2
+    ;;
+esac
+
+OCLAW_REAL="$(realpath /root/.local/share/pnpm/global/5/node_modules/openclaw)"
+DIST="$OCLAW_REAL/dist"
+if [[ ! -d "$DIST" ]]; then
+  echo "[openclaw-patches] ERROR: OpenClaw dist directory missing: $DIST" >&2
+  exit 1
+fi
+
+PATCH_MARKERS=(
+  "threads: 1, batchSize: 512"
+  "const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 60000;"
+  "clawock-minimax-m3-priority"
+  "clawock-minimax-response-header-timeout-v2"
+)
+PATCH_LABELS=(
+  "single-thread local embeddings"
+  "60s memory_search deadline"
+  "MiniMax-M3 priority admission"
+  "MiniMax 30s response-header deadline"
+)
+
+declare -a syntax_targets=()
+for index in "${!PATCH_MARKERS[@]}"; do
+  marker="${PATCH_MARKERS[$index]}"
+  label="${PATCH_LABELS[$index]}"
+  mapfile -t matches < <(
+    grep -rlF --include='*.js' -- "$marker" "$DIST" 2>/dev/null || true
+  )
+  if [[ "${#matches[@]}" -eq 0 ]]; then
+    echo "[openclaw-patches] ERROR: marker missing for $label" >&2
+    exit 1
+  fi
+  syntax_targets+=("${matches[@]}")
+  echo "[openclaw-patches] marker ok: $label"
+done
+
+mapfile -t unique_targets < <(printf '%s\n' "${syntax_targets[@]}" | sort -u)
+for target in "${unique_targets[@]}"; do
+  node --check "$target"
+done
+python3 -m py_compile "$PATCH_ROOT/memory_index_maintenance.py"
+
+echo "[openclaw-patches] all four patches and modified bundles verified"
+echo "[openclaw-patches] gateway was not restarted"

--- a/skills/openclaw-upgrade/SKILL.md
+++ b/skills/openclaw-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-upgrade
-description: Safe OpenClaw version upgrade with regression checklist. Use when kcn says "升级 openclaw" / "openclaw 有没有更新" / "/openclaw-upgrade", or after noticing a newer npm version. Encodes the validated 6.8 flow — checks for in-flight crons before restart, uses the built-in updater, and runs the full regression gate (cron count, embedding, weixin delivery, model chain). Different from `openclaw-tune` (periodic maintenance, no version bump).
+description: Safe OpenClaw version upgrade with regression checklist. Use when kcn says "升级 openclaw" / "openclaw 有没有更新" / "/openclaw-upgrade", or after noticing a newer npm version. Checks for in-flight crons, uses the built-in updater, reapplies all host-local dist patches, and runs the full regression gate without reducing context, skills, tools, thinking, or token budgets. Different from `openclaw-tune` (periodic maintenance, no version bump).
 ---
 
 # OpenClaw Safe Upgrade
@@ -12,7 +12,16 @@ Kcn runs a live automated trading system on OpenClaw. An upgrade that loses cron
 2. Read auto-memory `openclaw-update-missing-deps.md` for that version's traps.
 
 ## 1. 🔴 Never restart the gateway while a cron is in-flight
-`openclaw cron list | grep running` — if anything is **running**, WAIT (a SIGTERM mid-run orphans it into permanent `running`). Use `--no-restart` and pick a quiet window between cron slots (`./check_crons.sh --timeline`).
+Use the structured runtime field, not a text grep:
+
+```bash
+openclaw cron list --json \
+  | jq -e '[.jobs[] | select(.state.runningAtMs != null)] | length == 0'
+```
+
+If this is not `true`, wait. A SIGTERM mid-run can orphan the cron into
+permanent `running`. Use `--no-restart` and pick a quiet window between slots
+(`./check_crons.sh --timeline`).
 
 ## 2. Update (built-in updater, since 6.x)
 ```
@@ -20,20 +29,65 @@ openclaw update --tag <version> --no-restart --yes
 ```
 This auto-reinstalls/links managed plugins (weixin, llama-cpp, codex) — no manual `pnpm add`, no systemd edits, no `restore-llama-embeddings.sh` needed. (Pre-6.x manual flow is in the memory file.)
 
-## 3. Restart in a clean window
-Re-confirm nothing running → `openclaw gateway restart`.
+## 3. 🔴 Reapply all upgrade-sensitive local patches before restart
+The updater replaces the installed `dist/` tree. From the live workspace run:
 
-## 4. Regression gate (ALL must pass before declaring done)
+```bash
+bash scripts/ops/reapply_openclaw_patches.sh
+```
+
+The wrapper applies these idempotent host scripts in order:
+
+1. `/root/tools/openclaw/current/patch-embedding-threads1.sh`
+2. `/root/tools/openclaw/current/patch-memory-search-timeout.sh`
+3. `/root/tools/openclaw/current/patch-minimax-m3-priority.sh`
+4. `/root/tools/openclaw/current/patch-minimax-response-header-timeout.sh`
+
+It then verifies all four markers, runs `node --check` on every modified bundle,
+and compiles the maintenance detector. It does **not** restart the gateway.
+
+Any missing script, changed source anchor, syntax error, or missing marker is a
+hard stop: do not restart and do not declare the upgrade complete. Inspect the
+new OpenClaw source, revise the relevant patch script deliberately, and rerun
+the wrapper. Never skip a failed patch just to make the new version start.
+
+## 4. Restart once, in a clean window
+Re-run the structured no-in-flight check from step 1, then:
+
+```bash
+openclaw gateway restart
+bash scripts/ops/reapply_openclaw_patches.sh --check-only
+```
+
+## 5. Regression gate (ALL must pass before declaring done)
 | Check | Command | Pass = |
 |---|---|---|
 | version | `openclaw --version` | shows target |
 | **cron count** | `openclaw cron list \| grep -c isolated` | **11** (SQLite→SQLite keeps them; if lost → `openclaw doctor --fix` imports legacy jobs.json) |
 | embedding | `openclaw memory search "<q>" --max-results 2 --json` | returns results, no `Unknown memory embedding provider` (6.8 has no `--limit`) |
+| local patches | `bash scripts/ops/reapply_openclaw_patches.sh --check-only` | all four markers and JS/Python syntax pass |
+| MiniMax transport | transport log + fallback smoke | Anthropic protocol; `priority` present; a no-header timeout is retryable; the 300s generation timeout remains |
 | weixin delivery | tail `/tmp/openclaw/openclaw-*.log` | `weixin monitor started` + `gateway ready`, no crash loop |
 | model chain | the cron run log / a throwaway `openclaw agent` call | a model answers (⚠️ see note) |
 | clean startup | gateway log | `cron: started jobs:11`, no plugin load errors |
 
-## 5. Known-benign post-6.8 noise (don't chase)
+Run one complete isolated cron after the cheap checks. Inspect its actual
+session and `systemPromptReport`, not only the final summary. Pass means:
+
+- all allowed workspace bootstrap files are present with `truncatedFiles=0`
+- the full skill catalog is present and the payload-required `SKILL.md` body
+  was actually read before analysis
+- the full tool set is present (no stale cron `tools` allowlist)
+- normal prompt/context window, output budget, thinking level, and whole-turn
+  timeout are unchanged
+- postflight reports zero issues and the expected delivery/dashboard results
+- the model fallback chain still advances on a retryable provider failure
+
+Do not use `--light-context`, a tool allowlist, lower thinking, smaller token
+budgets, or prompt trimming as an upgrade workaround. MiniMax token usage is
+not a constraint for this deployment.
+
+## 6. Known-benign post-6.8 noise (don't chase)
 - `adp-openclaw` plugin disabled (ships TS source, no `dist/`) — stale `plugins.entries` warning; harmless, offer to delete the entry.
 - systemd unit shows "installed by <old ver>" — cosmetic metadata; daemon runs the new global package. `openclaw doctor --repair` fixes it (non-blocking).
 - `plugins.allow is empty` audit WARN — long-standing, harmless.

--- a/tests/test_openclaw_upgrade_skill_contract.py
+++ b/tests/test_openclaw_upgrade_skill_contract.py
@@ -1,0 +1,71 @@
+"""Guard the upgrade path that preserves host-local OpenClaw dist fixes."""
+
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "openclaw-upgrade" / "SKILL.md"
+WRAPPER = ROOT / "scripts" / "ops" / "reapply_openclaw_patches.sh"
+
+PATCH_SCRIPTS = (
+    "/root/tools/openclaw/current/patch-embedding-threads1.sh",
+    "/root/tools/openclaw/current/patch-memory-search-timeout.sh",
+    "/root/tools/openclaw/current/patch-minimax-m3-priority.sh",
+    "/root/tools/openclaw/current/patch-minimax-response-header-timeout.sh",
+)
+PATCH_BASENAMES = tuple(Path(script).name for script in PATCH_SCRIPTS)
+PATCH_MARKERS = (
+    "threads: 1, batchSize: 512",
+    "const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 60000;",
+    "clawock-minimax-m3-priority",
+    "clawock-minimax-response-header-timeout-v2",
+)
+
+
+def test_upgrade_skill_patches_after_update_and_before_restart():
+    text = SKILL.read_text()
+    update_at = text.index("openclaw update --tag <version> --no-restart --yes")
+    patch_at = text.index("bash scripts/ops/reapply_openclaw_patches.sh")
+    restart_at = text.index("openclaw gateway restart")
+
+    assert update_at < patch_at < restart_at
+    assert "runningAtMs != null" in text
+    assert text.count("scripts/ops/reapply_openclaw_patches.sh") >= 3
+    for patch_script in PATCH_SCRIPTS:
+        assert patch_script in text
+
+
+def test_wrapper_owns_all_current_patches_in_stable_order():
+    text = WRAPPER.read_text()
+    positions = [text.index(script) for script in PATCH_BASENAMES]
+
+    assert positions == sorted(positions)
+    for marker in PATCH_MARKERS:
+        assert marker in text
+    assert "node --check" in text
+    assert "python3 -m py_compile" in text
+    assert "gateway restart" not in text
+
+
+def test_upgrade_contract_preserves_rich_agent_context():
+    text = SKILL.read_text()
+
+    for required in (
+        "systemPromptReport",
+        "truncatedFiles=0",
+        "full skill catalog",
+        "SKILL.md",
+        "full tool set",
+        "output budget",
+        "thinking level",
+        "whole-turn",
+    ):
+        assert required in text
+    assert "Do not use `--light-context`" in text
+    assert "a tool allowlist" in text
+    assert "prompt trimming" in text
+
+
+def test_patch_wrapper_has_valid_shell_syntax():
+    subprocess.run(["bash", "-n", str(WRAPPER)], check=True)


### PR DESCRIPTION
Closes #193.

## What changed

- add a tracked `reapply_openclaw_patches.sh` wrapper for all four upgrade-sensitive host patches
- run them after `openclaw update --no-restart` and before the single clean-window restart
- fail closed on missing scripts, changed anchors, missing markers, or JS/Python syntax errors
- replace the fragile textual cron-running check with structured `state.runningAtMs`
- require a complete post-upgrade cron smoke that proves system context, skill-body loading, full tools, thinking/token budgets, delivery, and fallback remain intact
- add contract tests that prevent later upgrade docs from silently dropping a patch or context-preservation gate

## Verification

- `pytest -q`: 1297 passed, 5 xfailed
- `python3 scripts/system_check.py`: 17 ok, 0 warn, 0 critical
- wrapper apply mode: all four scripts idempotent, all markers and bundle syntax pass
- wrapper check-only mode: pass
- `git diff --check`: pass

No prompt, context, skill, tool, thinking, token, model, cron, or delivery configuration is reduced by this change.