### PR TITLE
fix(brief): normalize machine fields before validation

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -26,6 +26,7 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_preflight.py
 - Confidence calls + Next-session plan（可交易，不是观察清单）
 
 **Step 4 - 写三份输出**
+- 首次生成和 postflight 修复 Step 4 产物都只用 `write` 完整覆盖；禁止 `edit` 精确文本替换。若 postflight 返回 fail，先 `read` 当前文件，根据 issues 在内存中修正，再用 `write` 一次覆盖完整文件后重跑 postflight；一次已恢复的 `edit` 工具错误仍会把整个 cron 记成 error。
 - `memory/{date}-pre-open.md` — 完整 markdown（含 Header/Tier 1/Tier 2/Tier 3/Judge/Confidence/Next-Session 段标记，**显式提 HHI + FX**）
 - `memory/{date}-plan.json` — 结构化 plan，schema v2 见 SKILL.md（顶层 decisions；strategy_id/action/condition/confidence enum 严格；禁止 actions）
 - `memory/.tmp/brief-card-{date}.txt` — **微信卡**（投递脚本会原样发这个文件，所以要自洽完整）。格式：

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -139,6 +139,7 @@
         "skills catalog 只有索引，不含 SKILL.md 正文",
         "brief_preflight.py",
         "brief_postflight.py",
+        "首次生成和 postflight 修复 Step 4 产物都只用 `write` 完整覆盖；禁止 `edit` 精确文本替换",
         "唯一微信路径",
         "同步 Telegram",
         "绝不要",

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -17,9 +17,9 @@ Side effects:
   - status=pass: rebuild dashboard, commit scoped report artifacts, deliver WeChat + Telegram
   - status=warn: same as pass but commit msg flags validation warnings
   - status=fail: no commit or delivery (preserve commit history clean); print issues
-  - --dry-run: validate, add missing Jekyll front matter, and write the publish-gate status;
-    do not write the decision ledger, rebuild/commit the dashboard, push, deliver messages,
-    or write the delivery marker
+  - --dry-run: normalize the authored plan, validate, add missing Jekyll front matter,
+    and write the publish-gate status; do not write the decision ledger, rebuild/commit
+    the dashboard, push, deliver messages, or write the delivery marker
 """
 
 import json
@@ -122,6 +122,68 @@ def validate_generation_references(plan, context=None):
             f'plan.json context generation_id 跨代引用: {foreign}'
         )
     return issues
+
+
+_NORMALIZATION_OWNED_PLAN_ERRORS = (
+    re.compile(
+        r'^decision\[\d+\] missing '
+        r'(decision_id|episode_id|plan_date|created_at)$'
+    ),
+    re.compile(r'^decision\[\d+\] schema_version must be 2$'),
+)
+
+
+def _normalization_owned_plan_error(issue):
+    """Whether deterministic v2 normalization, rather than the model, owns it."""
+    if issue in ('duplicate decision_id None', 'duplicate decision_id '):
+        return True
+    return any(pattern.fullmatch(issue)
+               for pattern in _NORMALIZATION_OWNED_PLAN_ERRORS)
+
+
+def normalize_plan_json(path, ledger_path=None):
+    """Fill only machine-owned v2 fields before validation.
+
+    ``normalize_authored_plan`` also canonicalizes legacy/default values.  Never
+    run it over an authored semantic error: doing so could turn a bad action or
+    condition into a valid default and let a retry pass without the model
+    actually fixing its plan.  Raw v2 validation therefore runs first and only
+    missing deterministic ids/linkage/timestamps are exempted.
+
+    JSON parse/missing-file diagnostics remain owned by ``validate_plan_json``
+    so callers do not receive duplicate issues.
+    """
+    if not path.exists():
+        return []
+    try:
+        authored = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+
+    if (authored.get('schema_version') != 2
+            or not isinstance(authored.get('decisions'), list)):
+        return []
+
+    authored_issues = decision_v2.validate_plan(authored, path)
+    semantic_issues = [
+        issue for issue in authored_issues
+        if not _normalization_owned_plan_error(issue)
+    ]
+    if semantic_issues:
+        return [f'plan.json authored: {issue}' for issue in semantic_issues]
+
+    try:
+        normalized = decision_v2.normalize_authored_plan(
+            authored,
+            ledger_path or (WS / 'memory' / 'decisions.jsonl'),
+        )
+        if normalized != authored:
+            path.write_text(
+                json.dumps(normalized, ensure_ascii=False, indent=2) + '\n'
+            )
+    except Exception as exc:
+        return [f'plan.json 标准化失败: {exc}']
+    return []
 
 
 def validate_plan_json(path, context=None, decision_packet=None):
@@ -301,7 +363,7 @@ def validate_markdown(path, context=None):
 
 CRITICAL_KEYWORDS = [
     '缺失', '解析失败', '表格 #', 'generation_id',
-    'plan.json harness', 'decision packet 不可用',
+    'plan.json harness', 'plan.json 标准化失败', 'decision packet 不可用',
 ]  # table mismatch and cross-generation output are critical
 
 
@@ -341,19 +403,9 @@ def _current_price_for(ticker):
 
 
 def log_decisions(today):
-    """Normalize and upsert today's plan into the v2 decision ledger."""
+    """Upsert today's validated, normalized plan into the v2 decision ledger."""
     plan_path = WS / 'memory' / f'{today}-plan.json'
 
-    # V2 authoring keeps semantic fields human/LLM-readable; deterministic ids,
-    # episode linkage and evaluation defaults are filled here before validation.
-    if plan_path.exists():
-        try:
-            authored = json.loads(plan_path.read_text())
-            if authored.get('schema_version') == 2 and isinstance(authored.get('decisions'), list):
-                authored = decision_v2.normalize_authored_plan(authored)
-                plan_path.write_text(json.dumps(authored, ensure_ascii=False, indent=2) + '\n')
-        except Exception as e:
-            print(f'warn: v2 plan normalization failed: {e}', file=sys.stderr)
     if not plan_path.exists():
         return
     try:
@@ -485,9 +537,9 @@ def main():
     import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('--dry-run', action='store_true',
-                    help='validate without ledger writes, dashboard rebuild/commit, push, '
-                         'message delivery, or delivery-marker writes; still adds missing '
-                         'Jekyll front matter and writes the publish-gate status')
+                    help='normalize/validate without ledger writes, dashboard rebuild/commit, '
+                         'push, message delivery, or delivery-marker writes; still adds '
+                         'missing Jekyll front matter and writes the publish-gate status')
     args = ap.parse_args()
 
     today = datetime.now().strftime('%Y-%m-%d')
@@ -531,6 +583,7 @@ def main():
         except Exception as exc:
             issues.append(f'decision packet 不可用: {exc}')
     issues += validate_markdown(md_path, context=context)
+    issues += normalize_plan_json(plan_path)
     issues += validate_plan_json(
         plan_path, context=context, decision_packet=decision_packet
     )

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -1,0 +1,161 @@
+"""Regression coverage for brief plan normalization before validation."""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "harness"))
+
+import brief_postflight  # noqa: E402
+
+
+def _authored_decision(**updates):
+    decision = {
+        "ticker": "AAA",
+        "strategy_id": "risk_rebalance",
+        "action": "cut",
+        "condition": {
+            "type": "manual",
+            "price": None,
+            "description": "risk rule",
+        },
+        "size": {"shares": 1, "pct": None, "note": ""},
+        "confidence": 0.8,
+        "driven_by": "risk_rule",
+        "evidence_event_id": None,
+        "regime": "neutral",
+        "rationale": "reduce exposure",
+    }
+    decision.update(updates)
+    return decision
+
+
+def _write_authored_plan(tmp_path, decision):
+    path = tmp_path / "2026-07-30-plan.json"
+    path.write_text(json.dumps({
+        "schema_version": 2,
+        "date": "2026-07-30",
+        "decisions": [decision],
+    }))
+    return path
+
+
+def test_machine_owned_fields_are_normalized_before_validation(tmp_path):
+    path = _write_authored_plan(tmp_path, _authored_decision())
+    ledger = tmp_path / "decisions.jsonl"
+
+    assert brief_postflight.normalize_plan_json(path, ledger) == []
+
+    normalized = json.loads(path.read_text())
+    decision = normalized["decisions"][0]
+    assert decision["decision_id"].startswith("dec-")
+    assert decision["episode_id"].startswith("ep-")
+    assert decision["plan_date"] == "2026-07-30"
+    assert decision["created_at"] == "2026-07-30T08:00:00+08:00"
+    assert brief_postflight.validate_plan_json(path) == []
+
+
+def test_semantic_authoring_error_is_not_rewritten_into_a_valid_default(tmp_path):
+    path = _write_authored_plan(
+        tmp_path,
+        _authored_decision(condition={"type": "not-a-real-trigger"}),
+    )
+
+    issues = brief_postflight.normalize_plan_json(
+        path, tmp_path / "decisions.jsonl"
+    )
+
+    assert any("bad condition.type" in issue for issue in issues)
+    assert json.loads(path.read_text())["decisions"][0]["condition"] == {
+        "type": "not-a-real-trigger"
+    }
+
+
+def test_harness_constraint_still_fails_after_normalization(tmp_path):
+    path = _write_authored_plan(
+        tmp_path,
+        _authored_decision(action="add_only_on_trigger"),
+    )
+    packet = {
+        "tickers": {
+            "AAA": {
+                "constraints": {
+                    "allowed_actions": ["cut"],
+                    "actionable_evidence_ids": [],
+                    "max_sell_shares": 1,
+                }
+            }
+        }
+    }
+
+    assert brief_postflight.normalize_plan_json(
+        path, tmp_path / "decisions.jsonl"
+    ) == []
+    issues = brief_postflight.validate_plan_json(
+        path, decision_packet=packet
+    )
+    assert any(
+        "plan.json harness" in issue and "outside harness allowed_actions" in issue
+        for issue in issues
+    )
+    assert brief_postflight.categorize(issues) == "fail"
+
+
+def test_normalization_failure_is_fail_closed(tmp_path, monkeypatch):
+    path = _write_authored_plan(tmp_path, _authored_decision())
+
+    def fail_normalization(*_args, **_kwargs):
+        raise ValueError("broken ledger")
+
+    monkeypatch.setattr(
+        brief_postflight.decision_v2,
+        "normalize_authored_plan",
+        fail_normalization,
+    )
+    issues = brief_postflight.normalize_plan_json(
+        path, tmp_path / "decisions.jsonl"
+    )
+
+    assert issues == ["plan.json 标准化失败: broken ledger"]
+    assert brief_postflight.categorize(issues) == "fail"
+
+
+def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
+    today = datetime.now().strftime("%Y-%m-%d")
+    plan_path = tmp_path / "memory" / f"{today}-plan.json"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text(json.dumps({
+        "schema_version": 2,
+        "date": today,
+        "decisions": [_authored_decision()],
+    }))
+    observed = {}
+
+    def assert_normalized(path, **_kwargs):
+        decision = json.loads(path.read_text())["decisions"][0]
+        observed["decision_id"] = decision["decision_id"]
+        observed["episode_id"] = decision["episode_id"]
+        return []
+
+    monkeypatch.setattr(brief_postflight, "WS", tmp_path)
+    monkeypatch.setattr(
+        brief_postflight.trading_calendar, "closed_reason", lambda _market: None
+    )
+    monkeypatch.setattr(
+        brief_postflight.workflow_outcomes, "slot_for_job", lambda _job: "slot"
+    )
+    monkeypatch.setattr(
+        brief_postflight.workflow_outcomes, "record_stage", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(brief_postflight, "validate_markdown", lambda *_a, **_k: [])
+    monkeypatch.setattr(brief_postflight, "validate_plan_json", assert_normalized)
+    monkeypatch.setattr(brief_postflight, "already_delivered", lambda _path: True)
+    monkeypatch.setattr(sys, "argv", ["brief_postflight.py", "--dry-run"])
+
+    assert brief_postflight.main() == 0
+    assert observed["decision_id"].startswith("dec-")
+    assert observed["episode_id"].startswith("ep-")

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -538,6 +538,21 @@ def test_strategy_crons_require_skill_body_read_in_first_tool_batch():
     )
 
 
+def test_brief_repair_uses_whole_file_write_instead_of_brittle_edit():
+    data = contract()
+    profile = data['payload_profiles']['brief']
+    brief = next(job for job in data['jobs'] if job['name'] == '盘前深度简报')
+    message = cron_contract.render_payload_message(data, brief)
+    rule = (
+        '首次生成和 postflight 修复 Step 4 产物都只用 `write` 完整覆盖；'
+        '禁止 `edit` 精确文本替换'
+    )
+
+    assert rule in profile['required_substrings']
+    assert rule in message
+    assert '一次已恢复的 `edit` 工具错误仍会把整个 cron 记成 error' in message
+
+
 def test_intraday_slots_are_unconditional_again():
     """Every Mode 7 slot runs the turn; no pre-model condition gate.
 


### PR DESCRIPTION
Relates to #195; the issue stays open until the natural 08:00 HKT production run passes.

## Why
The latest brief recovered from a plan repair and completed postflight delivery, but an avoidable failed exact-text `edit` left the whole cron run red. The first postflight also rejected raw schema-v2 authoring before the existing deterministic normalizer had filled machine-owned IDs and episode linkage.

## What
- normalize deterministic v2 IDs/linkage/timestamps before plan validation
- preserve fail-closed authored semantics: invalid action/strategy/condition/confidence is never normalized away
- retain all decision-packet action/evidence/inventory constraints
- make normalization errors critical
- require whole-file `write` for initial outputs and repairs; forbid brittle exact-text `edit`

## Verification
- `pytest -q`: 1303 passed, 5 xfailed
- live drift preview changes only the brief message; deployment waits for merge
- local pre-push system check: 16/17, with the sole expected failure being that production still has the pre-PR brief message
- all remote required checks passed

A natural 08:00 HKT full cron run will be used for production acceptance so today’s brief is not sent early or duplicated.