### PR TITLE
test(cron): pin the fixed MiniMax provider order as policy

### DIFF
--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -500,6 +500,52 @@ def test_strategy_crons_pin_minimax_m3_adaptive_reasoning():
     }
 
 
+def test_strategy_cron_provider_order_is_fixed_policy():
+    profiles = contract()['payload_profiles']
+
+    # This concrete order is policy. Reordering it requires a deliberate human
+    # decision; do not make this expectation follow the contract dynamically.
+    assert {
+        name: {
+            'model': profiles[name].get('model'),
+            'fallbacks': profiles[name].get('fallbacks'),
+            'model_candidates': profiles[name].get('model_candidates'),
+        }
+        for name in ('report', 'intraday', 'brief')
+    } == {
+        'report': {
+            'model': 'minimax/MiniMax-M3',
+            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'model_candidates': [
+                'minimax/MiniMax-M3',
+                'minimax-2/MiniMax-M3',
+                'openai/gpt-5.6-sol',
+                'anthropic/claude-sonnet-4-6',
+            ],
+        },
+        'intraday': {
+            'model': 'minimax/MiniMax-M3',
+            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'model_candidates': [
+                'minimax/MiniMax-M3',
+                'minimax-2/MiniMax-M3',
+                'openai/gpt-5.6-sol',
+                'anthropic/claude-sonnet-4-6',
+            ],
+        },
+        'brief': {
+            'model': 'minimax/MiniMax-M3',
+            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'model_candidates': [
+                'minimax/MiniMax-M3',
+                'minimax-2/MiniMax-M3',
+                'openai/gpt-5.6-sol',
+                'anthropic/claude-sonnet-4-6',
+            ],
+        },
+    }
+
+
 def test_strategy_crons_require_skill_body_read_in_first_tool_batch():
     """The skills system prompt is a catalog, not the SKILL.md body.
 


### PR DESCRIPTION
Closes #197.

Adds `test_strategy_cron_provider_order_is_fixed_policy`, which pins the literal
provider strings for `report`, `intraday`, and `brief` — `model`, `fallbacks`,
and the full `model_candidates` order — with no indirection through
`profile[...]` for the values under test. A comment states that the order is
policy and must not be made to follow the contract dynamically.

**Mutation proof** (independently re-run by the reviewer, not only by the author):

Baseline, unmodified contract:

```
pytest tests/test_cron_contracts.py -q
28 passed
```

With `report`/`intraday`/`brief` swapped to the `minimax-2`-first order in
`config/cron-schedules.json` (`model`, `fallbacks`, `model_candidates`):

```
pytest tests/test_cron_contracts.py -q
tests/test_cron_contracts.py:508: AssertionError
FAILED tests/test_cron_contracts.py::test_strategy_cron_provider_order_is_fixed_policy
1 failed, 27 passed
```

Before this change the same mutation was fully green (36 passed across
`test_cron_contracts.py` + `test_sync_cron_payloads.py`), which is what #197
documents.

Scope held to the issue: no change to the actual provider order, to
`sync_cron_payloads.py`, or to any contract abstraction. The `payload.model`
enforcement question is explicitly left out of scope per the issue.
