### PR TITLE
fix(brief): keep dry-run plan normalization in memory

### DIFF
--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -17,9 +17,10 @@ Side effects:
   - status=pass: rebuild dashboard, commit scoped report artifacts, deliver WeChat + Telegram
   - status=warn: same as pass but commit msg flags validation warnings
   - status=fail: no commit or delivery (preserve commit history clean); print issues
-  - --dry-run: normalize the authored plan, validate, add missing Jekyll front matter,
-    and write the publish-gate status; do not write the decision ledger, rebuild/commit
-    the dashboard, push, deliver messages, or write the delivery marker
+  - --dry-run: normalize the authored plan in memory, validate, add missing Jekyll
+    front matter, and write the publish-gate status; do not rewrite the authored
+    plan, write the decision ledger, rebuild/commit the dashboard, push, deliver
+    messages, or write the delivery marker
 """
 
 import json
@@ -141,7 +142,28 @@ def _normalization_owned_plan_error(issue):
                for pattern in _NORMALIZATION_OWNED_PLAN_ERRORS)
 
 
-def normalize_plan_json(path, ledger_path=None):
+def _normalization_result(issues, normalized, return_plan):
+    return (issues, normalized) if return_plan else issues
+
+
+class _InMemoryPlanPath:
+    """Path-compatible validation input backed by a normalized in-memory plan."""
+
+    def __init__(self, path, plan):
+        self._path = Path(path)
+        self._body = json.dumps(plan, ensure_ascii=False, indent=2) + '\n'
+
+    def exists(self):
+        return self._path.exists()
+
+    def read_text(self, *args, **kwargs):
+        return self._body
+
+    def __fspath__(self):
+        return str(self._path)
+
+
+def normalize_plan_json(path, ledger_path=None, *, write=True, return_plan=False):
     """Fill only machine-owned v2 fields before validation.
 
     ``normalize_authored_plan`` also canonicalizes legacy/default values.  Never
@@ -151,18 +173,20 @@ def normalize_plan_json(path, ledger_path=None):
     missing deterministic ids/linkage/timestamps are exempted.
 
     JSON parse/missing-file diagnostics remain owned by ``validate_plan_json``
-    so callers do not receive duplicate issues.
+    so callers do not receive duplicate issues. With ``write=False`` the
+    normalized document stays in memory; ``return_plan=True`` exposes it to the
+    validator while preserving the default issue-list return contract.
     """
     if not path.exists():
-        return []
+        return _normalization_result([], None, return_plan)
     try:
         authored = json.loads(path.read_text())
     except json.JSONDecodeError:
-        return []
+        return _normalization_result([], None, return_plan)
 
     if (authored.get('schema_version') != 2
             or not isinstance(authored.get('decisions'), list)):
-        return []
+        return _normalization_result([], authored, return_plan)
 
     authored_issues = decision_v2.validate_plan(authored, path)
     semantic_issues = [
@@ -170,20 +194,23 @@ def normalize_plan_json(path, ledger_path=None):
         if not _normalization_owned_plan_error(issue)
     ]
     if semantic_issues:
-        return [f'plan.json authored: {issue}' for issue in semantic_issues]
+        issues = [f'plan.json authored: {issue}' for issue in semantic_issues]
+        return _normalization_result(issues, authored, return_plan)
 
     try:
         normalized = decision_v2.normalize_authored_plan(
             authored,
             ledger_path or (WS / 'memory' / 'decisions.jsonl'),
         )
-        if normalized != authored:
+        if write and normalized != authored:
             path.write_text(
                 json.dumps(normalized, ensure_ascii=False, indent=2) + '\n'
             )
     except Exception as exc:
-        return [f'plan.json 标准化失败: {exc}']
-    return []
+        return _normalization_result(
+            [f'plan.json 标准化失败: {exc}'], authored, return_plan
+        )
+    return _normalization_result([], normalized, return_plan)
 
 
 def validate_plan_json(path, context=None, decision_packet=None):
@@ -537,9 +564,10 @@ def main():
     import argparse
     ap = argparse.ArgumentParser()
     ap.add_argument('--dry-run', action='store_true',
-                    help='normalize/validate without ledger writes, dashboard rebuild/commit, '
-                         'push, message delivery, or delivery-marker writes; still adds '
-                         'missing Jekyll front matter and writes the publish-gate status')
+                    help='normalize in memory and validate without rewriting plan.json, '
+                         'ledger writes, dashboard rebuild/commit, push, message delivery, '
+                         'or delivery-marker writes; still adds missing Jekyll front matter '
+                         'and writes the publish-gate status')
     args = ap.parse_args()
 
     today = datetime.now().strftime('%Y-%m-%d')
@@ -583,9 +611,19 @@ def main():
         except Exception as exc:
             issues.append(f'decision packet 不可用: {exc}')
     issues += validate_markdown(md_path, context=context)
-    issues += normalize_plan_json(plan_path)
+    normalization_issues, normalized_plan = normalize_plan_json(
+        plan_path,
+        write=not args.dry_run,
+        return_plan=True,
+    )
+    issues += normalization_issues
+    validation_path = (
+        _InMemoryPlanPath(plan_path, normalized_plan)
+        if args.dry_run and normalized_plan is not None
+        else plan_path
+    )
     issues += validate_plan_json(
-        plan_path, context=context, decision_packet=decision_packet
+        validation_path, context=context, decision_packet=decision_packet
     )
 
     status = categorize(issues)

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -159,3 +159,49 @@ def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
     assert brief_postflight.main() == 0
     assert observed["decision_id"].startswith("dec-")
     assert observed["episode_id"].startswith("ep-")
+
+
+def test_dry_run_validates_normalized_plan_without_rewriting_source(
+    tmp_path, monkeypatch
+):
+    today = datetime.now().strftime("%Y-%m-%d")
+    plan_path = tmp_path / "memory" / f"{today}-plan.json"
+    plan_path.parent.mkdir(parents=True)
+    authored = json.dumps({
+        "schema_version": 2,
+        "date": today,
+        "decisions": [_authored_decision()],
+    })
+    plan_path.write_text(authored)
+    before_mtime = plan_path.stat().st_mtime_ns
+    observed = {}
+    validate = brief_postflight.validate_plan_json
+
+    def capture_validation(path, **kwargs):
+        decision = json.loads(path.read_text())["decisions"][0]
+        observed["decision_id"] = decision["decision_id"]
+        observed["issues"] = validate(path, **kwargs)
+        return observed["issues"]
+
+    monkeypatch.setattr(brief_postflight, "WS", tmp_path)
+    monkeypatch.setattr(
+        brief_postflight.trading_calendar, "closed_reason", lambda _market: None
+    )
+    monkeypatch.setattr(
+        brief_postflight.workflow_outcomes, "slot_for_job", lambda _job: "slot"
+    )
+    monkeypatch.setattr(
+        brief_postflight.workflow_outcomes, "record_stage", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(brief_postflight, "validate_markdown", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        brief_postflight, "validate_plan_json", capture_validation
+    )
+    monkeypatch.setattr(brief_postflight, "already_delivered", lambda _path: True)
+    monkeypatch.setattr(sys, "argv", ["brief_postflight.py", "--dry-run"])
+
+    assert brief_postflight.main() == 0
+    assert observed["decision_id"].startswith("dec-")
+    assert observed["issues"] == []
+    assert plan_path.read_text() == authored
+    assert plan_path.stat().st_mtime_ns == before_mtime


### PR DESCRIPTION
Closes #199. Implements **option (a)** — `--dry-run` no longer writes.

`normalize_plan_json` gains `write=False` / `return_plan=True`. With
`--dry-run`, the normalized document is computed in memory and handed to
`validate_plan_json` through `_InMemoryPlanPath`, a small shim exposing
`exists()`, `read_text()`, and `__fspath__`. `decision_v2.validate_plan`
resolves the filename via `Path(path).name[:10]`, which works through
`__fspath__`, so the date-matches-filename check still applies. The
non-dry-run path is unchanged and still writes.

All five pre-existing tests in `tests/test_brief_plan_normalization.py` pass
unmodified — in particular
`test_semantic_authoring_error_is_not_rewritten_into_a_valid_default` and
`test_normalization_failure_is_fail_closed`. `plan.json 标准化失败` stays in
`CRITICAL_KEYWORDS` and normalization failure stays fail-closed.

Reviewer-verified locally:

```
pytest tests/test_cron_contracts.py tests/test_gold_dca_history_stability.py \
       tests/test_brief_plan_normalization.py tests/test_data_source_unification.py -q
45 passed
```

Scope held: the normalization ordering (raw validate → exempt only
machine-owned ids → normalize) is untouched.
