### PR TITLE
fix(gold): bound retained London history by a sliding coverage anchor

### DIFF
--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -66,6 +66,9 @@ SEED = {
 HISTORY_PAGES = 8     # 8×20 = 160 交易日，够画迷你图 + 取区间高低
 HISTORY_KEEP = 140    # 写回 portfolio.json 的最大点数（控体积）
 XAU_SETTLEMENT_DAYS = 5
+# compute_london consumes the full retained NAV history for the DCA comparison;
+# keep that window plus the dates still allowed to settle.
+LONDON_HISTORY_KEEP = HISTORY_KEEP + XAU_SETTLEMENT_DAYS
 XAU_SETTLED_DRIFT_PCT = 0.3
 XAU_PRIMARY_SOURCE = 'sina_global_futures_xau'
 XAU_FALLBACK_SOURCE = 'eastmoney_gc00y_fallback'
@@ -228,6 +231,15 @@ def fetch_xau_history(start):
     return [], {'name': 'unavailable', 'points': 0}
 
 
+def _bounded_london_history(rows):
+    normalized = {
+        str(day): float(value)
+        for day, value in (rows or [])
+        if day and value is not None
+    }
+    return sorted(normalized.items())[-LONDON_HISTORY_KEEP:]
+
+
 def stabilize_history(fresh, previous, fresh_source, previous_source=None,
                       label='伦敦金历史'):
     """Accept revisions in the latest settlement window; quarantine old outliers.
@@ -238,20 +250,21 @@ def stabilize_history(fresh, previous, fresh_source, previous_source=None,
     changing every historical DCA purchase. When the authoritative Sina XAU feed
     returns after a GC00Y fallback, it replaces the fallback reference outright.
     """
-    fresh_map = {str(d): float(v) for d, v in (fresh or []) if d and v is not None}
-    prior_map = {str(d): float(v) for d, v in (previous or []) if d and v is not None}
+    fresh_map = dict(_bounded_london_history(fresh))
+    prior_map = dict(_bounded_london_history(previous))
     source_name = (fresh_source or {}).get('name', 'unavailable')
     prior_name = (previous_source or {}).get('name')
     if not prior_map:
         advisory = None if fresh_map else f'{label}抓取失败，暂无可用参考点'
-        return sorted(fresh_map.items()), advisory
+        return _bounded_london_history(fresh_map.items()), advisory
     if not fresh_map:
+        retained = _bounded_london_history(prior_map.items())
         return (
-            sorted(prior_map.items()),
-            f'{label}抓取失败，沿用上次 {len(prior_map)} 个参考点',
+            retained,
+            f'{label}抓取失败，沿用上次 {len(retained)} 个参考点',
         )
     if source_name == XAU_PRIMARY_SOURCE and prior_name == XAU_FALLBACK_SOURCE:
-        return sorted(fresh_map.items()), None
+        return _bounded_london_history(fresh_map.items()), None
 
     recent = set(sorted(fresh_map)[-XAU_SETTLEMENT_DAYS:])
     merged = dict(prior_map)
@@ -270,7 +283,7 @@ def stabilize_history(fresh, previous, fresh_source, previous_source=None,
             f'{label}校验：沿用 {len(quarantined)} 个已结算点；'
             f'最大新旧偏差 {worst_pct:.2f}%（{worst_day}，源 {source_name}）'
         )
-    return sorted(merged.items()), advisory
+    return _bounded_london_history(merged.items()), advisory
 
 
 def _xau_at(xau_sorted_dates, xau_vals, d):
@@ -400,10 +413,13 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         'compare_series': compare,
         'dca_equiv': dca_equiv,
         'hist_source': hist_source or {'name': 'unavailable', 'points': 0},
-        'hist_series': [[d, round(v, 4)] for d, v in (xau_hist or [])],
+        'hist_series': [
+            [d, round(v, 4)] for d, v in _bounded_london_history(xau_hist)
+        ],
         'fx_hist_source': fx_hist_source or {'name': 'unavailable', 'points': 0},
         'fx_hist_series': [
-            [d, round(v, 6)] for d, v in sorted((usdcny_hist or {}).items())
+            [d, round(v, 6)]
+            for d, v in _bounded_london_history((usdcny_hist or {}).items())
         ],
         'hist_advisory': hist_advisory,
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),

--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -66,11 +66,6 @@ SEED = {
 HISTORY_PAGES = 8     # 8×20 = 160 交易日，够画迷你图 + 取区间高低
 HISTORY_KEEP = 140    # 写回 portfolio.json 的最大点数（控体积）
 XAU_SETTLEMENT_DAYS = 5
-# Measured portfolio spans: 140 NAV points cover 212 calendar days, while XAU
-# averages 134 / 188 = 0.713 points/day. Matching 212 days therefore needs
-# ceil(212 * 134 / 188) = 152 XAU points, or 157 with the settlement window.
-# Date-aware callers are authoritative; 180 is only the context-free fallback.
-LONDON_HISTORY_FALLBACK_KEEP = 180
 XAU_SETTLED_DRIFT_PCT = 0.3
 XAU_PRIMARY_SOURCE = 'sina_global_futures_xau'
 XAU_FALLBACK_SOURCE = 'eastmoney_gc00y_fallback'
@@ -237,12 +232,12 @@ def _london_history_coverage_start(nav_history, start):
     """Oldest date whose XAU/FX coverage may be consumed by London metrics."""
     nav_dates = [
         str(row[0]) for row in (nav_history or [])
-        if row and row[0]
+        if row and len(row) > 1 and row[0] and row[1] is not None
     ]
     candidates = [str(start)] if start else []
     if nav_dates:
         candidates.append(min(nav_dates))
-    return min(candidates) if candidates else None
+    return max(candidates) if candidates else None
 
 
 def _bounded_london_history(rows, coverage_start=None):
@@ -253,7 +248,7 @@ def _bounded_london_history(rows, coverage_start=None):
     }
     ordered = sorted(normalized.items())
     if not coverage_start:
-        return ordered[-LONDON_HISTORY_FALLBACK_KEEP:]
+        return ordered
     dates = [day for day, _ in ordered]
     first_required = bisect.bisect_left(dates, str(coverage_start))
     first_retained = max(0, first_required - XAU_SETTLEMENT_DAYS)

--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -66,9 +66,11 @@ SEED = {
 HISTORY_PAGES = 8     # 8×20 = 160 交易日，够画迷你图 + 取区间高低
 HISTORY_KEEP = 140    # 写回 portfolio.json 的最大点数（控体积）
 XAU_SETTLEMENT_DAYS = 5
-# compute_london consumes the full retained NAV history for the DCA comparison;
-# keep that window plus the dates still allowed to settle.
-LONDON_HISTORY_KEEP = HISTORY_KEEP + XAU_SETTLEMENT_DAYS
+# Measured portfolio spans: 140 NAV points cover 212 calendar days, while XAU
+# averages 134 / 188 = 0.713 points/day. Matching 212 days therefore needs
+# ceil(212 * 134 / 188) = 152 XAU points, or 157 with the settlement window.
+# Date-aware callers are authoritative; 180 is only the context-free fallback.
+LONDON_HISTORY_FALLBACK_KEEP = 180
 XAU_SETTLED_DRIFT_PCT = 0.3
 XAU_PRIMARY_SOURCE = 'sina_global_futures_xau'
 XAU_FALLBACK_SOURCE = 'eastmoney_gc00y_fallback'
@@ -231,17 +233,35 @@ def fetch_xau_history(start):
     return [], {'name': 'unavailable', 'points': 0}
 
 
-def _bounded_london_history(rows):
+def _london_history_coverage_start(nav_history, start):
+    """Oldest date whose XAU/FX coverage may be consumed by London metrics."""
+    nav_dates = [
+        str(row[0]) for row in (nav_history or [])
+        if row and row[0]
+    ]
+    candidates = [str(start)] if start else []
+    if nav_dates:
+        candidates.append(min(nav_dates))
+    return min(candidates) if candidates else None
+
+
+def _bounded_london_history(rows, coverage_start=None):
     normalized = {
         str(day): float(value)
         for day, value in (rows or [])
         if day and value is not None
     }
-    return sorted(normalized.items())[-LONDON_HISTORY_KEEP:]
+    ordered = sorted(normalized.items())
+    if not coverage_start:
+        return ordered[-LONDON_HISTORY_FALLBACK_KEEP:]
+    dates = [day for day, _ in ordered]
+    first_required = bisect.bisect_left(dates, str(coverage_start))
+    first_retained = max(0, first_required - XAU_SETTLEMENT_DAYS)
+    return ordered[first_retained:]
 
 
 def stabilize_history(fresh, previous, fresh_source, previous_source=None,
-                      label='伦敦金历史'):
+                      label='伦敦金历史', coverage_start=None):
     """Accept revisions in the latest settlement window; quarantine old outliers.
 
     A current close can legitimately settle on the next day, so the newest five
@@ -250,21 +270,21 @@ def stabilize_history(fresh, previous, fresh_source, previous_source=None,
     changing every historical DCA purchase. When the authoritative Sina XAU feed
     returns after a GC00Y fallback, it replaces the fallback reference outright.
     """
-    fresh_map = dict(_bounded_london_history(fresh))
-    prior_map = dict(_bounded_london_history(previous))
+    fresh_map = dict(_bounded_london_history(fresh, coverage_start))
+    prior_map = dict(_bounded_london_history(previous, coverage_start))
     source_name = (fresh_source or {}).get('name', 'unavailable')
     prior_name = (previous_source or {}).get('name')
     if not prior_map:
         advisory = None if fresh_map else f'{label}抓取失败，暂无可用参考点'
-        return _bounded_london_history(fresh_map.items()), advisory
+        return _bounded_london_history(fresh_map.items(), coverage_start), advisory
     if not fresh_map:
-        retained = _bounded_london_history(prior_map.items())
+        retained = _bounded_london_history(prior_map.items(), coverage_start)
         return (
             retained,
             f'{label}抓取失败，沿用上次 {len(retained)} 个参考点',
         )
     if source_name == XAU_PRIMARY_SOURCE and prior_name == XAU_FALLBACK_SOURCE:
-        return _bounded_london_history(fresh_map.items()), None
+        return _bounded_london_history(fresh_map.items(), coverage_start), None
 
     recent = set(sorted(fresh_map)[-XAU_SETTLEMENT_DAYS:])
     merged = dict(prior_map)
@@ -283,7 +303,7 @@ def stabilize_history(fresh, previous, fresh_source, previous_source=None,
             f'{label}校验：沿用 {len(quarantined)} 个已结算点；'
             f'最大新旧偏差 {worst_pct:.2f}%（{worst_day}，源 {source_name}）'
         )
-    return _bounded_london_history(merged.items()), advisory
+    return _bounded_london_history(merged.items(), coverage_start), advisory
 
 
 def _xau_at(xau_sorted_dates, xau_vals, d):
@@ -399,6 +419,10 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
                                  float(gold.get('daily_amount', 200)))
     if not dca_equiv and gold.get('london', {}).get('dca_equiv'):
         dca_equiv = gold['london']['dca_equiv']  # 历史限流 → 沿用旧值
+    coverage_start = _london_history_coverage_start(
+        derived.get('nav_history') or [],
+        gold.get('start_date', ''),
+    )
     return {
         'xau_usd': round(xau, 2),
         'xau_change_pct': spot.get('change_pct'),
@@ -414,12 +438,16 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         'dca_equiv': dca_equiv,
         'hist_source': hist_source or {'name': 'unavailable', 'points': 0},
         'hist_series': [
-            [d, round(v, 4)] for d, v in _bounded_london_history(xau_hist)
+            [d, round(v, 4)]
+            for d, v in _bounded_london_history(xau_hist, coverage_start)
         ],
         'fx_hist_source': fx_hist_source or {'name': 'unavailable', 'points': 0},
         'fx_hist_series': [
             [d, round(v, 6)]
-            for d, v in _bounded_london_history((usdcny_hist or {}).items())
+            for d, v in _bounded_london_history(
+                (usdcny_hist or {}).items(),
+                coverage_start,
+            )
         ],
         'hist_advisory': hist_advisory,
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
@@ -536,11 +564,16 @@ def main():
     else:
         xau_fresh, xau_source = [], {'name': 'not_attempted', 'points': 0}
     old_london = gold.get('london') or {}
+    london_coverage_start = _london_history_coverage_start(
+        history[-HISTORY_KEEP:] if history else gold.get('nav_history') or [],
+        gold.get('start_date', ''),
+    )
     xau_hist, xau_advisory = stabilize_history(
         xau_fresh,
         old_london.get('hist_series') or [],
         xau_source,
         old_london.get('hist_source') or {},
+        coverage_start=london_coverage_start,
     )
     fx_source = {
         'name': 'frankfurter_usdcny',
@@ -552,6 +585,7 @@ def main():
         fx_source,
         old_london.get('fx_hist_source') or {},
         label='USDCNY 历史',
+        coverage_start=london_coverage_start,
     )
     usdcny_hist = dict(fx_hist)
     history_advisory = '；'.join(

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -1,5 +1,6 @@
 """Regression coverage for London-gold history provenance and settlement."""
 from datetime import date, timedelta
+from math import ceil
 from pathlib import Path
 import sys
 
@@ -22,10 +23,23 @@ def dated_rows(count):
     ]
 
 
-def test_london_retention_is_derived_from_consumed_history_windows():
-    assert gold.LONDON_HISTORY_KEEP == (
-        gold.HISTORY_KEEP + gold.XAU_SETTLEMENT_DAYS
-    )
+def spaced_rows(count, span_days):
+    start = date(2025, 1, 1)
+    return [
+        (
+            (start + timedelta(days=offset * span_days // (count - 1))).isoformat(),
+            100.0 + offset,
+        )
+        for offset in range(count)
+    ]
+
+
+def test_london_fallback_bound_covers_measured_calendar_span():
+    measured_required = ceil(212 * 134 / 188) + gold.XAU_SETTLEMENT_DAYS
+
+    assert measured_required == 157
+    assert gold.LONDON_HISTORY_FALLBACK_KEEP == 180
+    assert gold.LONDON_HISTORY_FALLBACK_KEEP >= measured_required
 
 
 def test_settled_outlier_is_quarantined_but_latest_five_dates_win():
@@ -106,7 +120,7 @@ def test_first_empty_fetch_is_also_visible():
 
 
 def test_stale_date_absent_from_fresh_feed_is_evicted_outside_bound():
-    previous = dated_rows(gold.LONDON_HISTORY_KEEP + 1)
+    previous = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 1)
     fresh = previous[1:]
 
     stable, advisory = gold.stabilize_history(
@@ -116,9 +130,24 @@ def test_stale_date_absent_from_fresh_feed_is_evicted_outside_bound():
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
     )
 
-    assert len(stable) == gold.LONDON_HISTORY_KEEP
+    assert len(stable) == gold.LONDON_HISTORY_FALLBACK_KEEP
     assert previous[0][0] not in dict(stable)
     assert stable == fresh
+    assert advisory is None
+
+
+def test_date_bound_keeps_coverage_and_preceding_settlement_window():
+    fresh = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 20)
+    coverage_start = fresh[40][0]
+
+    stable, advisory = gold.stabilize_history(
+        fresh,
+        [],
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
+        coverage_start=coverage_start,
+    )
+
+    assert stable == fresh[40 - gold.XAU_SETTLEMENT_DAYS:]
     assert advisory is None
 
 
@@ -153,22 +182,49 @@ def test_london_payload_persists_reference_and_visible_provenance():
 
 
 def test_london_payload_serializes_both_histories_within_bound():
-    oversized = dated_rows(gold.LONDON_HISTORY_KEEP + 7)
+    oversized = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 7)
     nav = [[day, 3.0] for day, _ in oversized[-gold.HISTORY_KEEP:]]
+    start = oversized[-(gold.HISTORY_KEEP + 10)][0]
 
     london = gold.compute_london(
         {"current_value": 1000.0, "nav_history": nav},
-        {"start_date": nav[0][0], "daily_amount": 200},
+        {"start_date": start, "daily_amount": 200},
         {"xau_usd": oversized[-1][1], "change_pct": 1.0},
         7.0,
         dict((day, 7.0) for day, _ in oversized),
         oversized,
     )
 
-    assert len(london["hist_series"]) == gold.LONDON_HISTORY_KEEP
-    assert len(london["fx_hist_series"]) == gold.LONDON_HISTORY_KEEP
-    assert london["hist_series"][0][0] == oversized[-gold.LONDON_HISTORY_KEEP][0]
-    assert london["fx_hist_series"][0][0] == oversized[-gold.LONDON_HISTORY_KEEP][0]
+    expected = oversized[
+        -(gold.HISTORY_KEEP + 10 + gold.XAU_SETTLEMENT_DAYS):
+    ]
+    assert london["hist_series"] == [[day, round(value, 4)] for day, value in expected]
+    assert london["fx_hist_series"] == [[day, 7.0] for day, _ in expected]
+
+
+def test_retention_does_not_starve_oldest_nav_purchases():
+    daily = 200
+    nav = [[day, 3.0] for day, _ in spaced_rows(gold.HISTORY_KEEP, 212)]
+    xau = spaced_rows(152, 212)
+    retained, advisory = gold.stabilize_history(
+        xau,
+        [],
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(xau)},
+    )
+
+    dca = gold.build_london_dca(
+        nav,
+        retained,
+        {day: 7.0 for day, _ in xau},
+        xau_cur=xau[-1][1],
+        usdcny_cur=7.0,
+        start=nav[0][0],
+        daily=daily,
+    )
+
+    assert advisory is None
+    assert retained[0][0] == nav[0][0]
+    assert dca["principal_cny"] == daily * len(nav)
 
 
 def test_dashboard_drops_internal_history_but_keeps_provenance_contract():

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -1,6 +1,5 @@
 """Regression coverage for London-gold history provenance and settlement."""
 from datetime import date, timedelta
-from math import ceil
 from pathlib import Path
 import sys
 
@@ -32,14 +31,6 @@ def spaced_rows(count, span_days):
         )
         for offset in range(count)
     ]
-
-
-def test_london_fallback_bound_covers_measured_calendar_span():
-    measured_required = ceil(212 * 134 / 188) + gold.XAU_SETTLEMENT_DAYS
-
-    assert measured_required == 157
-    assert gold.LONDON_HISTORY_FALLBACK_KEEP == 180
-    assert gold.LONDON_HISTORY_FALLBACK_KEEP >= measured_required
 
 
 def test_settled_outlier_is_quarantined_but_latest_five_dates_win():
@@ -120,24 +111,25 @@ def test_first_empty_fetch_is_also_visible():
 
 
 def test_stale_date_absent_from_fresh_feed_is_evicted_outside_bound():
-    previous = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 1)
+    previous = dated_rows(200)
     fresh = previous[1:]
+    coverage_start = previous[40][0]
 
     stable, advisory = gold.stabilize_history(
         fresh,
         previous,
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
+        coverage_start=coverage_start,
     )
 
-    assert len(stable) == gold.LONDON_HISTORY_FALLBACK_KEEP
     assert previous[0][0] not in dict(stable)
-    assert stable == fresh
+    assert stable == fresh[40 - gold.XAU_SETTLEMENT_DAYS - 1:]
     assert advisory is None
 
 
 def test_date_bound_keeps_coverage_and_preceding_settlement_window():
-    fresh = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 20)
+    fresh = dated_rows(200)
     coverage_start = fresh[40][0]
 
     stable, advisory = gold.stabilize_history(
@@ -182,7 +174,7 @@ def test_london_payload_persists_reference_and_visible_provenance():
 
 
 def test_london_payload_serializes_both_histories_within_bound():
-    oversized = dated_rows(gold.LONDON_HISTORY_FALLBACK_KEEP + 7)
+    oversized = dated_rows(gold.HISTORY_KEEP + 47)
     nav = [[day, 3.0] for day, _ in oversized[-gold.HISTORY_KEEP:]]
     start = oversized[-(gold.HISTORY_KEEP + 10)][0]
 
@@ -195,21 +187,49 @@ def test_london_payload_serializes_both_histories_within_bound():
         oversized,
     )
 
-    expected = oversized[
-        -(gold.HISTORY_KEEP + 10 + gold.XAU_SETTLEMENT_DAYS):
-    ]
+    expected = oversized[-(gold.HISTORY_KEEP + gold.XAU_SETTLEMENT_DAYS):]
     assert london["hist_series"] == [[day, round(value, 4)] for day, value in expected]
     assert london["fx_hist_series"] == [[day, 7.0] for day, _ in expected]
+
+
+def test_sliding_coverage_anchor_bounds_retained_london_history():
+    start = "2026-01-22"
+    first_day = date(2026, 1, 22)
+    last_day = date(2029, 7, 30)
+    xau = []
+    day = first_day
+    while day <= last_day:
+        if day.weekday() < 5:
+            xau.append((day.isoformat(), 2000.0))
+        day += timedelta(days=1)
+    nav = []
+    day = last_day
+    while len(nav) < gold.HISTORY_KEEP:
+        if day.weekday() < 5:
+            nav.append([day.isoformat(), 3.0])
+        day -= timedelta(days=1)
+    nav.sort()
+
+    coverage_start = gold._london_history_coverage_start(nav, start)
+    retained = gold._bounded_london_history(xau, coverage_start)
+    max_retained = gold.HISTORY_KEEP + gold.XAU_SETTLEMENT_DAYS
+
+    assert len(xau) == 918
+    # Same weekday calendar: 140 NAV dates plus five preceding settlement points.
+    assert len(retained) <= max_retained == 145
+    assert coverage_start == nav[0][0]
 
 
 def test_retention_does_not_starve_oldest_nav_purchases():
     daily = 200
     nav = [[day, 3.0] for day, _ in spaced_rows(gold.HISTORY_KEEP, 212)]
     xau = spaced_rows(152, 212)
+    coverage_start = gold._london_history_coverage_start(nav, nav[0][0])
     retained, advisory = gold.stabilize_history(
         xau,
         [],
         {"name": gold.XAU_PRIMARY_SOURCE, "points": len(xau)},
+        coverage_start=coverage_start,
     )
 
     dca = gold.build_london_dca(

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -1,4 +1,5 @@
 """Regression coverage for London-gold history provenance and settlement."""
+from datetime import date, timedelta
 from pathlib import Path
 import sys
 
@@ -11,6 +12,20 @@ import fetch_gold_dca as gold  # noqa: E402
 
 def rows(values):
     return [(f"2026-07-{day:02d}", value) for day, value in values]
+
+
+def dated_rows(count):
+    start = date(2025, 1, 1)
+    return [
+        ((start + timedelta(days=offset)).isoformat(), 100.0 + offset)
+        for offset in range(count)
+    ]
+
+
+def test_london_retention_is_derived_from_consumed_history_windows():
+    assert gold.LONDON_HISTORY_KEEP == (
+        gold.HISTORY_KEEP + gold.XAU_SETTLEMENT_DAYS
+    )
 
 
 def test_settled_outlier_is_quarantined_but_latest_five_dates_win():
@@ -90,6 +105,23 @@ def test_first_empty_fetch_is_also_visible():
     assert advisory == "伦敦金历史抓取失败，暂无可用参考点"
 
 
+def test_stale_date_absent_from_fresh_feed_is_evicted_outside_bound():
+    previous = dated_rows(gold.LONDON_HISTORY_KEEP + 1)
+    fresh = previous[1:]
+
+    stable, advisory = gold.stabilize_history(
+        fresh,
+        previous,
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(fresh)},
+        {"name": gold.XAU_PRIMARY_SOURCE, "points": len(previous)},
+    )
+
+    assert len(stable) == gold.LONDON_HISTORY_KEEP
+    assert previous[0][0] not in dict(stable)
+    assert stable == fresh
+    assert advisory is None
+
+
 def test_london_payload_persists_reference_and_visible_provenance():
     xau = [("2026-07-01", 100.0), ("2026-07-02", 101.0)]
     derived = {"current_value": 1000.0, "nav_history": [
@@ -118,6 +150,25 @@ def test_london_payload_persists_reference_and_visible_provenance():
     ]
     assert london["hist_advisory"] == "test advisory"
     assert london["dca_equiv"]["oz_held"] > 0
+
+
+def test_london_payload_serializes_both_histories_within_bound():
+    oversized = dated_rows(gold.LONDON_HISTORY_KEEP + 7)
+    nav = [[day, 3.0] for day, _ in oversized[-gold.HISTORY_KEEP:]]
+
+    london = gold.compute_london(
+        {"current_value": 1000.0, "nav_history": nav},
+        {"start_date": nav[0][0], "daily_amount": 200},
+        {"xau_usd": oversized[-1][1], "change_pct": 1.0},
+        7.0,
+        dict((day, 7.0) for day, _ in oversized),
+        oversized,
+    )
+
+    assert len(london["hist_series"]) == gold.LONDON_HISTORY_KEEP
+    assert len(london["fx_hist_series"]) == gold.LONDON_HISTORY_KEEP
+    assert london["hist_series"][0][0] == oversized[-gold.LONDON_HISTORY_KEEP][0]
+    assert london["fx_hist_series"][0][0] == oversized[-gold.LONDON_HISTORY_KEEP][0]
 
 
 def test_dashboard_drops_internal_history_but_keeps_provenance_contract():


### PR DESCRIPTION
Closes #198. Took three rounds; the two intermediate rounds each fixed one half
of the invariant and broke the other, so the history is kept for the record.

- `753e65ad` — count cap `HISTORY_KEEP + XAU_SETTLEMENT_DAYS` = 145. Bounded,
  but the count was derived on the wrong trading calendar: 145 XAU points span
  ~203 calendar days while 140 NAV points span 212, so once the cap engaged the
  retained window would start ~9 days after the oldest date `build_london_dca`
  queries. `if not x: continue` there drops a purchase from **both** `oz` and
  `principal_cny`, silently shifting `avg_cost_usd_oz`.
- `42c940ec` — switched to a date anchor, but used `min(start_date,
  oldest_nav_date)`. `start_date` never moves, so the anchor froze and retention
  became unbounded again — the original #198 bug. The 180-point fallback was
  also unreachable in production.
- `0fba236a` — anchor is `max(start_date, oldest_valid_nav_date)`, which is the
  oldest date any London consumer actually queries (`build_london_dca` filters
  `d >= start` over the newest `HISTORY_KEEP` NAV points; `build_compare_series`
  takes the same two inputs). That anchor slides with `nav_history`, so
  retention is bounded. `LONDON_HISTORY_FALLBACK_KEEP` deleted rather than left
  unreachable.

## Both invariants, verified by the reviewer independently

Steady state, three years out, ~900 input points:

```
input=918  anchor=2029-01-16  oldest_queried=2029-01-16  retained=145  from=2029-01-09
```

Bound is `HISTORY_KEEP + XAU_SETTLEMENT_DAYS` = 145 — now a *consequence* of the
sliding anchor rather than an assumed count.

Both new tests go red against `42c940ec` and green at `0fba236a`:

```
git checkout 42c940ec -- scripts/data/fetch_gold_dca.py
pytest tests/test_gold_dca_history_stability.py -q -k "bound or starve"
FAILED test_london_payload_serializes_both_histories_within_bound
FAILED test_sliding_coverage_anchor_bounds_retained_london_history
2 failed, 3 passed

# at HEAD
pytest tests/test_gold_dca_history_stability.py -q
12 passed
```

`test_retention_does_not_starve_oldest_nav_purchases` keeps the strict
assertion `principal_cny == daily * len(dates)` — boundedness was not bought by
weakening it.

## No behavior change today

Against the live `portfolio.json`: anchor `2026-01-22`, 134 points in, 134 out,
retained series byte-identical to what is already published. The cap was never
engaged, so this is a pure future-proofing change.

The five pre-existing quarantine tests are byte-identical to `master` (verified
by AST extraction, not by eyeball) and all pass.

## Known residual, not a blocker

`_bounded_london_history` still returns the full input when `coverage_start` is
`None`. That requires a falsy `start_date` **and** an empty `nav_history`
simultaneously — `start_date` is a ground-truth field present in `SEED`, and an
empty `nav_history` already makes `build_london_dca` bail at `len(dates) < 2`.
Worth a follow-up nit if `gold_dca` ever gains a code path that constructs the
series without a start date.
