### PR TITLE
fix: make dashboard freshness schedule-aware

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -434,6 +434,15 @@
     const lines = [];
     (bs.files || []).forEach(f => {
       if (!f.present) lines.push(`✗ ${f.name} 缺失`);
+      else if (f.freshness_mode === 'scheduled_fire') {
+        const deadline = f.deadline_at
+          ? new Date(f.deadline_at).toLocaleString('zh-CN', {
+              month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+              hour12: false, timeZone: 'Asia/Hong_Kong',
+            })
+          : '未知';
+        lines.push(`${f.stale ? '⚠' : '·'} ${f.name}  ${f.age_hours}h · 应于 ${deadline} HKT 前刷新`);
+      }
       else lines.push(`${f.stale ? '⚠' : '·'} ${f.name}  ${f.age_hours}h / SLA ${f.sla_hours}h`);
     });
     (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '🔴' : '🟡'} ${t.code}: ${t.msg}`));

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -1737,25 +1737,142 @@ def compute_net_principal_return(portfolio, fx_rate):
     return out
 
 
-# 期望刷新节奏（小时）——超过即标 stale。值取「正常情况下两次成功刷新的最大间隔 +
-# 容忍隔夜/周末」，不是硬 SLA。盘中/收盘类短，GHA 扫描类长。
-_FRESHNESS_SLA_H = {
-    'portfolio.json': 26,
-    'quant_signals.json': 30,
-    'quant_signal_review.json': 30,
-    'cross_sectional_factor.json': 30,
-    'peer_residual.json': 30,
-    'news_evidence_graph.json': 30,
-    'risk.json': 30,
-    'lev_regime.json': 30,
-    'benchmark.json': 80,          # 偶发限流，宽容
-    'macro.json': 30,
-    'sentiment.json': 30,
-    'catalysts.json': 30,
-    'us_news_digest.json': 30,
-    'em_news.json': 30,
-    'influencer_feed.json': 30,
+# Freshness policy.  Runtime-written artifacts keep the historical max-age
+# behavior.  GitHub weekday scans instead compare mtime with the latest cron
+# fire that should have completed: a Friday artifact is valid all weekend, but
+# becomes stale on Monday shortly after the next expected run.  Per-fire grace
+# absorbs measured GitHub schedule delay plus commit serialization.
+_MON_FRI = (0, 1, 2, 3, 4)           # datetime.weekday(): Monday == 0
+_UTC_SUN_THU = (0, 1, 2, 3, 6)
+
+
+def _scheduled_fire(weekdays, hour, minute, grace_hours, *, tz='UTC',
+                    required_when=None):
+    if not weekdays:
+        raise ValueError('scheduled freshness fire needs at least one weekday')
+    if not (0 <= hour <= 23 and 0 <= minute <= 59 and grace_hours >= 0):
+        raise ValueError('invalid scheduled freshness fire')
+    return {
+        'weekdays': tuple(sorted(weekdays)),
+        'hour': hour,
+        'minute': minute,
+        'grace_hours': grace_hours,
+        'timezone': tz,
+        **({'required_when': required_when} if required_when else {}),
+    }
+
+
+def _scheduled_policy(sla_hours, *fires):
+    if not fires:
+        raise ValueError('scheduled freshness policy needs at least one fire')
+    return {
+        'sla_hours': sla_hours,
+        'schedule': {'fires': tuple(fires)},
+    }
+
+
+_BRIEF_FRESHNESS_ARTIFACTS = frozenset({
+    'quant_signals.json',
+    'quant_signal_review.json',
+    'cross_sectional_factor.json',
+    'peer_residual.json',
+    'news_evidence_graph.json',
+    'risk.json',
+    'lev_regime.json',
+    'catalysts.json',
+    'em_news.json',
+})
+
+# The local brief normally commits in minutes but has a remote fallback and a
+# 10:00 HKT landing window.  Do not declare it missed until 14:00 HKT.  Unlike
+# GitHub scans, the brief intentionally skips a fire when both covered markets
+# are closed, so its descriptor mirrors that producer gate.
+_BRIEF_FIRE = _scheduled_fire(
+    _MON_FRI, 8, 0, 6, tz='Asia/Shanghai', required_when='any_market_open'
+)
+
+
+_FRESHNESS_POLICY = {
+    'portfolio.json': {'sla_hours': 26},
+    **{
+        name: _scheduled_policy(30, _BRIEF_FIRE)
+        for name in _BRIEF_FRESHNESS_ARTIFACTS
+    },
+    'benchmark.json': {'sla_hours': 80},  # 偶发限流，宽容
+    # Grace is per fire, rounded above producer-only history (max observed:
+    # macro 4.32h, sentiment 4.60h, influencer 5.04h, digest 5.57h).
+    'macro.json': _scheduled_policy(
+        30, _scheduled_fire(_UTC_SUN_THU, 21, 45, 5)
+    ),
+    'sentiment.json': _scheduled_policy(
+        30, _scheduled_fire(_UTC_SUN_THU, 21, 30, 6)
+    ),
+    'us_news_digest.json': _scheduled_policy(
+        30, _scheduled_fire(_MON_FRI, 13, 0, 7)
+    ),
+    'influencer_feed.json': _scheduled_policy(
+        30,
+        _scheduled_fire(_UTC_SUN_THU, 21, 40, 6),
+        _scheduled_fire(_MON_FRI, 12, 50, 6),
+    ),
 }
+
+# Compatibility/readability alias for callers that only need the max-age
+# metadata.  `_FRESHNESS_POLICY` is the single source of truth.
+_FRESHNESS_SLA_H = {
+    name: policy['sla_hours'] for name, policy in _FRESHNESS_POLICY.items()
+}
+
+
+def _fire_is_expected(fire, candidate, calendar):
+    """Mirror producer-side skip rules; unavailable calendars fail closed."""
+    if fire.get('required_when') != 'any_market_open' or calendar is None:
+        return True
+    return any(
+        calendar.closed_reason(
+            market,
+            candidate.astimezone(ZoneInfo(calendar.MARKET_TZ[market])).date(),
+        ) is None
+        for market in ('hk', 'us')
+    )
+
+
+def _latest_due_fire(schedule, at, calendar=None):
+    """Latest fire whose own grace deadline has elapsed, normalized to UTC."""
+    if at.tzinfo is None:
+        raise ValueError('freshness reference time must be timezone-aware')
+    latest = None
+    for fire in schedule['fires']:
+        fire_tz = ZoneInfo(fire['timezone'])
+        cutoff = at.astimezone(fire_tz) - timedelta(hours=fire['grace_hours'])
+        for days_back in range(8):
+            candidate_date = cutoff.date() - timedelta(days=days_back)
+            if candidate_date.weekday() not in fire['weekdays']:
+                continue
+            candidate = datetime(
+                candidate_date.year,
+                candidate_date.month,
+                candidate_date.day,
+                fire['hour'],
+                fire['minute'],
+                tzinfo=fire_tz,
+            )
+            if candidate > cutoff or not _fire_is_expected(
+                fire, candidate, calendar
+            ):
+                continue
+            scheduled_at = candidate.astimezone(timezone.utc)
+            due = {
+                'scheduled_at': scheduled_at,
+                'deadline_at': scheduled_at + timedelta(
+                    hours=fire['grace_hours']
+                ),
+                'grace_hours': fire['grace_hours'],
+            }
+            if latest is None or scheduled_at > latest['scheduled_at']:
+                latest = due
+            break
+    return latest
 
 
 def _latest_completed_session(market, calendar, at=None):
@@ -1847,38 +1964,68 @@ def _market_leg_freshness(portfolio_leg, market, calendar, at=None):
     }
 
 
-def compute_build_status(portfolio, data_dir):
+def compute_build_status(portfolio, data_dir, at=None):
     """A2 健康卡数据：每个数据文件的新鲜度 + 体检结论 + 每市场 data 时点。
 
     纯文件运算、零网络。被动暴露 staleness 给前端（不推送，遵 feedback_no_individual_cron_alerts）。
     内联跑一次 preflight_integrity 取新鲜体检结论嵌进来。
     """
-    now = datetime.now().astimezone()
-    files = []
-    targets = ['portfolio.json'] + sorted(_FRESHNESS_SLA_H.keys() - {'portfolio.json'})
-    for name in targets:
-        path = (WS_ROOT / name) if name == 'portfolio.json' else (data_dir / name)
-        sla = _FRESHNESS_SLA_H.get(name, 30)
-        if path.exists():
-            age_h = (time.time() - path.stat().st_mtime) / 3600.0
-            files.append({'name': name, 'age_hours': round(age_h, 1),
-                          'sla_hours': sla, 'stale': age_h > sla, 'present': True})
-        else:
-            files.append({'name': name, 'present': False, 'stale': True, 'sla_hours': sla})
-
-    # 每市场数据时点：逐只活跃持仓的报价日期 vs 最近已完成 session。
-    # 不能信 region.last_updated 或 portfolio.json mtime；两者都会被另一条写入刷新。
-    markets = {}
+    now = at if at is not None else datetime.now().astimezone()
+    if now.tzinfo is None:
+        now = now.astimezone()
     try:
         sys.path.insert(0, str(WS_ROOT / 'scripts' / 'data'))
         import trading_calendar as _tc
     except Exception:
         _tc = None
+    files = []
+    targets = ['portfolio.json'] + sorted(_FRESHNESS_POLICY.keys() - {'portfolio.json'})
+    for name in targets:
+        path = (WS_ROOT / name) if name == 'portfolio.json' else (data_dir / name)
+        policy = _FRESHNESS_POLICY.get(name, {'sla_hours': 30})
+        sla = policy['sla_hours']
+        schedule = policy.get('schedule')
+        due = _latest_due_fire(schedule, now, _tc) if schedule else None
+        freshness_mode = 'scheduled_fire' if schedule else 'max_age'
+        if path.exists():
+            mtime = path.stat().st_mtime
+            age_h = (now.timestamp() - mtime) / 3600.0
+            stale = (
+                mtime < due['scheduled_at'].timestamp()
+                if due else age_h > sla
+            )
+            files.append({'name': name, 'age_hours': round(age_h, 1),
+                          'sla_hours': sla, 'stale': stale, 'present': True,
+                          'freshness_mode': freshness_mode,
+                          **({'latest_due_at': due['scheduled_at'].isoformat(),
+                              'deadline_at': due['deadline_at'].isoformat(),
+                              'grace_hours': due['grace_hours']}
+                             if due else {})})
+        else:
+            files.append({'name': name, 'present': False, 'stale': True,
+                          'sla_hours': sla, 'freshness_mode': freshness_mode,
+                          **({'latest_due_at': (
+                                  due['scheduled_at'].isoformat() if due else None
+                              ),
+                              'deadline_at': (
+                                  due['deadline_at'].isoformat() if due else None
+                              ),
+                              'grace_hours': (
+                                  due['grace_hours'] if due else None
+                              )}
+                             if schedule else {})})
+
+    # 每市场数据时点：逐只活跃持仓的报价日期 vs 最近已完成 session。
+    # 不能信 region.last_updated 或 portfolio.json mtime；两者都会被另一条写入刷新。
+    markets = {}
     for region, mkt in (('us_stocks', 'us'), ('hk_stocks', 'hk')):
         pf = portfolio.get('portfolios', {}).get(region, {})
         if _tc:
-            markets[mkt] = _market_leg_freshness(pf, mkt, _tc)
-            markets[mkt]['closed_today'] = _tc.closed_reason(mkt) is not None
+            markets[mkt] = _market_leg_freshness(pf, mkt, _tc, at=now)
+            market_date = now.astimezone(ZoneInfo(_tc.MARKET_TZ[mkt])).date()
+            markets[mkt]['closed_today'] = (
+                _tc.closed_reason(mkt, market_date) is not None
+            )
         else:
             markets[mkt] = {
                 'last_updated': pf.get('last_updated'),

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -7,9 +7,10 @@ it does not read snapshots, portfolio data, or the network.
 import json
 import os
 from pathlib import Path
+import re
 import sys
 from types import SimpleNamespace
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -38,6 +39,31 @@ def _snapshot(day, *, us_equity, hk_equity, us_profit=None, hk_profit=None):
         "us_profit": us_profit,
         "hk_profit": hk_profit,
     }
+
+
+def test_session_asof_without_a_dated_active_holding_is_none():
+    assert dashboard._session_asof({"holdings": []}, 2026) is None
+    assert dashboard._session_asof({
+        "holdings": [{"shares": 1, "data_source": "fallback without a date"}],
+    }, 2026) is None
+
+
+def _fresh_build_status_fixture(monkeypatch, tmp_path, at):
+    data_dir = tmp_path / "assets" / "data"
+    data_dir.mkdir(parents=True)
+    for name in dashboard._FRESHNESS_POLICY:
+        path = tmp_path / name if name == "portfolio.json" else data_dir / name
+        path.write_text("{}")
+        os.utime(path, (at.timestamp(), at.timestamp()))
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    monkeypatch.setitem(
+        sys.modules,
+        "preflight_integrity",
+        SimpleNamespace(check=lambda: {
+            "ok": True, "error_count": 0, "warn_count": 0, "findings": [],
+        }),
+    )
+    return _portfolio(), data_dir
 
 
 def test_guardrail_compute_exception_is_an_explicit_failure_dict(monkeypatch):
@@ -444,6 +470,337 @@ def test_stale_market_leg_makes_build_unhealthy(monkeypatch, tmp_path):
     assert status["stale_files"] == []
     assert status["stale_markets"] == ["us", "hk"]
     assert status["healthy"] is False
+
+
+@pytest.mark.parametrize("at", [
+    datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc),
+    datetime(2026, 8, 2, 6, 0, tzinfo=timezone.utc),
+])
+def test_weekday_scan_newer_than_friday_fire_stays_fresh_on_weekend(
+    monkeypatch, tmp_path, at,
+):
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    # Friday-HKT producers fire Thursday UTC.  These commits landed after their
+    # nominal fires but are 31-55h old when inspected over the weekend.
+    mtimes = {
+        "macro.json": datetime(2026, 7, 30, 22, 15, tzinfo=timezone.utc),
+        "sentiment.json": datetime(2026, 7, 30, 22, 0, tzinfo=timezone.utc),
+        "us_news_digest.json": datetime(2026, 7, 31, 15, 15, tzinfo=timezone.utc),
+        "influencer_feed.json": datetime(2026, 7, 31, 15, 15, tzinfo=timezone.utc),
+    }
+    friday_brief = datetime(2026, 7, 31, 1, 0, tzinfo=timezone.utc)
+    mtimes.update({name: friday_brief for name in dashboard._BRIEF_FRESHNESS_ARTIFACTS})
+    for name, mtime in mtimes.items():
+        os.utime(data_dir / name, (mtime.timestamp(), mtime.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+
+    assert "macro.json" not in status["stale_files"]
+    assert "sentiment.json" not in status["stale_files"]
+    assert status["healthy"] is True
+
+
+def test_scan_does_not_become_due_inside_its_measured_grace(monkeypatch, tmp_path):
+    at = datetime(2026, 8, 3, 2, 30, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    friday_commit = datetime(2026, 7, 30, 22, 15, tzinfo=timezone.utc)
+    os.utime(
+        data_dir / "macro.json",
+        (friday_commit.timestamp(), friday_commit.timestamp()),
+    )
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    macro = next(row for row in status["files"] if row["name"] == "macro.json")
+
+    assert macro["latest_due_at"] == "2026-07-30T21:45:00+00:00"
+    assert macro["stale"] is False
+
+
+def test_missed_monday_scan_becomes_stale_after_grace(monkeypatch, tmp_path):
+    at = datetime(2026, 8, 3, 2, 46, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    friday_commit = datetime(2026, 7, 30, 22, 15, tzinfo=timezone.utc)
+    os.utime(
+        data_dir / "macro.json",
+        (friday_commit.timestamp(), friday_commit.timestamp()),
+    )
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    macro = next(row for row in status["files"] if row["name"] == "macro.json")
+
+    assert macro["stale"] is True
+    assert macro["latest_due_at"] == "2026-08-02T21:45:00+00:00"
+    assert macro["deadline_at"] == "2026-08-03T02:45:00+00:00"
+    assert macro["grace_hours"] == 5
+    assert "macro.json" in status["stale_files"]
+    assert status["healthy"] is False
+
+
+@pytest.mark.parametrize("at", [
+    datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc),
+    datetime(2026, 8, 2, 6, 0, tzinfo=timezone.utc),
+])
+def test_genuine_friday_miss_remains_stale_through_weekend(
+    monkeypatch, tmp_path, at,
+):
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    thursday_commit = datetime(2026, 7, 29, 22, 15, tzinfo=timezone.utc)
+    os.utime(
+        data_dir / "macro.json",
+        (thursday_commit.timestamp(), thursday_commit.timestamp()),
+    )
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+
+    assert "macro.json" in status["stale_files"]
+
+
+def test_missed_friday_brief_artifact_remains_stale_through_weekend(
+    monkeypatch, tmp_path,
+):
+    at = datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    old = datetime(2026, 7, 30, 1, 0, tzinfo=timezone.utc)
+    os.utime(data_dir / "risk.json", (old.timestamp(), old.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+
+    assert "risk.json" in status["stale_files"]
+
+
+def test_flat_sla_portfolio_keeps_age_based_behavior_on_weekend(monkeypatch, tmp_path):
+    at = datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    old = at - timedelta(hours=27)
+    os.utime(tmp_path / "portfolio.json", (old.timestamp(), old.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    row = next(row for row in status["files"] if row["name"] == "portfolio.json")
+
+    assert row["freshness_mode"] == "max_age"
+    assert row["sla_hours"] == 26
+    assert row["stale"] is True
+
+
+def test_weekday_market_holiday_still_expects_scan(monkeypatch, tmp_path):
+    # Christmas is a market holiday, but the GitHub scan cron still fires.
+    at = datetime(2026, 12, 25, 3, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    old = datetime(2026, 12, 23, 22, 15, tzinfo=timezone.utc)
+    os.utime(data_dir / "macro.json", (old.timestamp(), old.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+
+    assert "macro.json" in status["stale_files"]
+
+
+def test_brief_fire_is_skipped_when_both_covered_markets_are_closed(
+    monkeypatch, tmp_path,
+):
+    # Monday 2026-04-06 is an HK holiday; at 08:00 HKT the US date is Sunday.
+    # The producer skips, so Friday's successful brief remains the latest due.
+    at = datetime(2026, 4, 6, 7, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    friday_commit = datetime(2026, 4, 3, 1, 0, tzinfo=timezone.utc)
+    os.utime(data_dir / "risk.json", (friday_commit.timestamp(), friday_commit.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    risk = next(row for row in status["files"] if row["name"] == "risk.json")
+
+    assert risk["latest_due_at"] == "2026-04-03T00:00:00+00:00"
+    assert risk["stale"] is False
+
+
+def test_brief_artifact_turns_stale_after_next_required_fire(monkeypatch, tmp_path):
+    # Tuesday's HK leg is closed too, but Monday's US session is open, so the
+    # two-market brief runs and must supersede Friday after its grace window.
+    at = datetime(2026, 4, 7, 7, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    friday_commit = datetime(2026, 4, 3, 1, 0, tzinfo=timezone.utc)
+    os.utime(data_dir / "risk.json", (friday_commit.timestamp(), friday_commit.timestamp()))
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    risk = next(row for row in status["files"] if row["name"] == "risk.json")
+
+    assert risk["latest_due_at"] == "2026-04-07T00:00:00+00:00"
+    assert risk["stale"] is True
+
+
+def test_multiple_daily_fires_use_latest_due_schedule(monkeypatch, tmp_path):
+    at = datetime(2026, 7, 31, 19, 0, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    after_early_fire = datetime(2026, 7, 30, 22, 0, tzinfo=timezone.utc)
+    os.utime(
+        data_dir / "influencer_feed.json",
+        (after_early_fire.timestamp(), after_early_fire.timestamp()),
+    )
+
+    status = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    influencer = next(
+        row for row in status["files"] if row["name"] == "influencer_feed.json"
+    )
+
+    assert influencer["latest_due_at"] == "2026-07-31T12:50:00+00:00"
+    assert influencer["deadline_at"] == "2026-07-31T18:50:00+00:00"
+    assert influencer["grace_hours"] == 6
+    assert influencer["stale"] is True
+
+
+def test_digest_uses_its_own_seven_hour_grace(monkeypatch, tmp_path):
+    friday_commit = datetime(2026, 7, 31, 15, 15, tzinfo=timezone.utc)
+    before_deadline = datetime(2026, 8, 3, 19, 59, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(
+        monkeypatch, tmp_path, before_deadline
+    )
+    os.utime(
+        data_dir / "us_news_digest.json",
+        (friday_commit.timestamp(), friday_commit.timestamp()),
+    )
+
+    before = dashboard.compute_build_status(portfolio, data_dir, at=before_deadline)
+    row = next(r for r in before["files"] if r["name"] == "us_news_digest.json")
+    assert row["latest_due_at"] == "2026-07-31T13:00:00+00:00"
+    assert row["stale"] is False
+
+    after_deadline = datetime(2026, 8, 3, 20, 1, tzinfo=timezone.utc)
+    after = dashboard.compute_build_status(portfolio, data_dir, at=after_deadline)
+    row = next(r for r in after["files"] if r["name"] == "us_news_digest.json")
+    assert row["latest_due_at"] == "2026-08-03T13:00:00+00:00"
+    assert row["deadline_at"] == "2026-08-03T20:00:00+00:00"
+    assert row["stale"] is True
+
+
+def test_scheduled_mtime_boundary_and_missing_file(monkeypatch, tmp_path):
+    at = datetime(2026, 8, 3, 2, 46, tzinfo=timezone.utc)
+    portfolio, data_dir = _fresh_build_status_fixture(monkeypatch, tmp_path, at)
+    due = datetime(2026, 8, 2, 21, 45, tzinfo=timezone.utc)
+    macro = data_dir / "macro.json"
+
+    os.utime(macro, (due.timestamp(), due.timestamp()))
+    exact = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    row = next(r for r in exact["files"] if r["name"] == "macro.json")
+    assert row["stale"] is False
+
+    os.utime(macro, (due.timestamp() - 1, due.timestamp() - 1))
+    one_second_old = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    row = next(r for r in one_second_old["files"] if r["name"] == "macro.json")
+    assert row["stale"] is True
+
+    macro.unlink()
+    missing = dashboard.compute_build_status(portfolio, data_dir, at=at)
+    row = next(r for r in missing["files"] if r["name"] == "macro.json")
+    assert row["present"] is False
+    assert row["stale"] is True
+    assert "macro.json" in missing["stale_files"]
+
+
+def _cron_python_weekdays(field):
+    names = {name: i for i, name in enumerate(
+        ("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN")
+    )}
+
+    def cron_day(value):
+        value = value.upper()
+        if value in names:
+            return names[value]
+        number = int(value)
+        return 6 if number in (0, 7) else number - 1
+
+    if field == "*":
+        return tuple(range(7))
+    days = set()
+    for part in field.split(","):
+        start, sep, end = part.partition("-")
+        if sep:
+            first, last = cron_day(start), cron_day(end)
+            if first <= last:
+                days.update(range(first, last + 1))
+            else:
+                days.update(range(first, 7))
+                days.update(range(0, last + 1))
+        else:
+            days.add(cron_day(start))
+    return tuple(sorted(days))
+
+
+def test_gha_freshness_registry_matches_workflow_crons():
+    workflow_for_artifact = {
+        "macro.json": "macro-scan.yml",
+        "sentiment.json": "sentiment-scan.yml",
+        "us_news_digest.json": "news-digest.yml",
+        "influencer_feed.json": "influencer-scan.yml",
+    }
+    expected_graces = {
+        "macro.json": [5],
+        "sentiment.json": [6],
+        "us_news_digest.json": [7],
+        "influencer_feed.json": [6, 6],
+    }
+
+    scheduled = {
+        name for name, policy in dashboard._FRESHNESS_POLICY.items()
+        if policy.get("schedule")
+    }
+    assert scheduled - dashboard._BRIEF_FRESHNESS_ARTIFACTS == set(
+        workflow_for_artifact
+    )
+
+    for artifact, workflow in workflow_for_artifact.items():
+        text = (ROOT / ".github" / "workflows" / workflow).read_text()
+        expressions = re.findall(
+            r"^\s*-\s+cron:\s*['\"]([^'\"]+)['\"]\s*$", text, re.MULTILINE
+        )
+        assert len(expressions) == text.count("- cron:"), (
+            f"unsupported cron syntax in {workflow}"
+        )
+        actual = set()
+        for expression in expressions:
+            minute, hour, dom, month, dow = expression.split()
+            assert dom == month == "*"
+            assert minute.isdigit() and hour.isdigit()
+            actual.add(("UTC", _cron_python_weekdays(dow), int(hour), int(minute)))
+
+        policy = dashboard._FRESHNESS_POLICY[artifact]["schedule"]
+        expected = {
+            (fire["timezone"], tuple(fire["weekdays"]), fire["hour"], fire["minute"])
+            for fire in policy["fires"]
+        }
+        assert actual == expected, f"{artifact} cadence drifted from {workflow}"
+        assert sorted(fire["grace_hours"] for fire in policy["fires"]) == (
+            expected_graces[artifact]
+        )
+
+
+def test_brief_freshness_registry_matches_host_cron_contract():
+    contract = json.loads((ROOT / "config" / "cron-schedules.json").read_text())
+    job = next(job for job in contract["jobs"] if job["name"] == "盘前深度简报")
+
+    assert job["schedule"] == {
+        "kind": "cron",
+        "expr": "0 8 * * 1-5",
+        "tz": "Asia/Shanghai",
+    }
+    assert dashboard._BRIEF_FIRE == {
+        "weekdays": (0, 1, 2, 3, 4),
+        "hour": 8,
+        "minute": 0,
+        "grace_hours": 6,
+        "timezone": "Asia/Shanghai",
+        "required_when": "any_market_open",
+    }
+
+
+def test_dashboard_tooltip_distinguishes_schedule_deadlines_from_age_slas():
+    renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+    block = renderer.split("// tooltip：逐文件年龄", 1)[1].split(
+        "(ig.top || [])", 1
+    )[0]
+
+    assert "f.freshness_mode === 'scheduled_fire'" in block
+    assert "f.deadline_at" in block
+    assert "timeZone: 'Asia/Hong_Kong'" in block
+    assert "HKT 前刷新" in block
+    assert "/ SLA ${f.sla_hours}h" in block
 
 
 @pytest.mark.parametrize("holdings", [[], [


### PR DESCRIPTION
## Summary

- replace flat age checks for scheduled artifacts with producer-aware cron deadlines
- cover all four GitHub scan sidecars plus the nine weekday brief artifacts that caused the same weekend false-yellow
- calibrate per-fire grace from producing-job history and mirror the brief's two-market holiday skip
- keep `portfolio.json` and other non-scheduled artifacts on their existing max-age semantics
- show schedule deadlines in the dashboard tooltip instead of contradictory age/SLA text

At the reported 2026-08-01 14:20 HKT failure point, replaying the live artifact mtimes changes `stale_files` from 11 to 0 while still flagging a genuine missed Friday or Monday producer run.

No network/API polling or new VPS job is added; this is deterministic build-time calculation only.

## Verification

- `python3 -m pytest tests/test_build_dashboard.py tests/test_macro_scan_workflow_contract.py tests/test_sentiment_scan_workflow_contract.py tests/test_influencer_scan_workflow_contract.py -q` — 48 passed, 1 existing xfail
- `python3 -m py_compile scripts/data/build_dashboard.py`
- `node --check assets/js/dashboard.render.js`
- pre-push `scripts/system_check.py` — 17 OK, 0 warn, 0 critical
- adversarial Opus 5 review: initial NOT PASS findings resolved; exact live failure replay verified 11 stale → 0

Closes #204
