### PR TITLE
CI: split dashboard artifact validation from the heavy harness

### DIFF
--- a/.github/workflows/dashboard-artifact-gate.yml
+++ b/.github/workflows/dashboard-artifact-gate.yml
@@ -1,0 +1,20 @@
+name: Dashboard Artifact Gate
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'assets/data/dashboard.json'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-dashboard-artifact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate committed dashboard payload
+        run: python3 scripts/data/validate_sidecars.py dashboard

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -13,7 +13,6 @@ on:
       - 'memory/theses/**'
       - 'memory/earnings/**'
       - 'memory/entry-gates/**'
-      - 'assets/data/dashboard.json'
       - '.github/workflows/harness-regression.yml'
       # Whole directory on purpose: every file here (cron contract, instrument
       # registry, thesis/earnings schemas, news-evidence policy, peer rules) is
@@ -92,7 +91,9 @@ jobs:
         # Only runs on PRs; non-PR events force the steps on via the `if:` below.
         #
         # Keep this path set in sync with the `push:` trigger `paths:` at the top
-        # of this file — both answer "does this change affect validate?".
+        # of this file, except dashboard.json: its frequent automation commits use
+        # the cheap dashboard-artifact-gate on master, while a rare dashboard PR
+        # still gets the full suite here.
         id: changes
         if: github.event_name == 'pull_request'
         env:
@@ -275,23 +276,13 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 scripts/data/build_dashboard.py
+          python3 scripts/data/validate_sidecars.py dashboard
           python3 << 'PY'
           import json
-          with open('assets/data/dashboard.json') as f: d = json.load(f)
           with open('assets/data/decision_audit.json') as f: audit = json.load(f)
-          needed = ['generated_at','fx','totals','concentration','holdings','snapshots','decision_metrics','decision_delta']
-          missing = [k for k in needed if k not in d]
-          assert not missing, f'missing keys: {missing}'
-          assert 'episode_backtest' not in d, 'Reflect backtest leaked into first-paint payload'
           assert audit.get('episode_backtest', {}).get('horizons', {}).get('t1'), \
               'decision_audit.json missing Reflect episode backtest'
-          for leg in ('us', 'hk'):
-              assert leg in d['holdings'], f'holdings.{leg} missing'
-              assert leg in d['concentration'], f'concentration.{leg} missing'
-              c = d['concentration'][leg]
-              assert 'hhi' in c and 'top2' in c and 'verdict' in c, f'{leg} concentration incomplete'
-              assert c['verdict']['level'] in ('healthy','moderate','concentrated','danger'), f'bad verdict level'
-          print('dashboard.json: schema OK')
+          print('decision_audit.json: Reflect backtest OK')
           PY
 
       - name: Run build_dashboard sanity

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A real Hong Kong + US stock portfolio, debated by multiple LLMs and graded by Py
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,7 @@
 
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -24,7 +24,8 @@
 
 | Workflow | 触发 | 写文件 | 备注 |
 |---|---|---|---|
-| `harness-regression.yml` | push to master | (read-only) | 每次 push 跑 schema/import 校验 |
+| `harness-regression.yml` | 代码/配置 push to master + 每个 PR | (read-only) | 完整 schema/import/pytest 校验；自动生成的 dashboard-only push 走下方轻量门禁 |
+| `dashboard-artifact-gate.yml` | dashboard.json push to master | (read-only) | GitHub runner 上零依赖校验已提交首屏 payload，不占 VPS |
 | `actionlint.yml` | workflow 变更的 push/PR | (read-only) | pinned actionlint 校验 GHA expression/YAML/shell |
 | `weekly-health.yml` | 周日 23:00 UTC | (read-only) | 综合健康检查（含公网数据源活体） |
 | `eod-archive.yml` | 周五 22:00 UTC | `memory/archive/eod-history.csv` | 每周持仓快照 audit trail |

--- a/scripts/data/preflight_integrity.py
+++ b/scripts/data/preflight_integrity.py
@@ -244,7 +244,7 @@ def check(portfolio_path=PORTFOLIO):
         # FX_TAG ---------------------------------------------------------
         ccy = port.get('currency')
         want = region_ccy.get(region)
-        if want and ccy and ccy != want:
+        if want and ccy != want:
             add('FX_TAG', 'ERROR', f'{region} currency={ccy} 应为 {want}（HKD/USD 不能混加）', region)
 
         # TCV_SUM --------------------------------------------------------

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -16,6 +16,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 DASHBOARD_MAX_BYTES = 200_000
+DASHBOARD_MONEY_INTEGRITY_CODES = frozenset({
+    'VALUE_LEG', 'TCV_SUM', 'COST_TOTAL', 'PNL_TOTAL', 'PNL_PCT',
+    'PNL_LEG', 'TODAY_LEG', 'TODAY_TOTAL', 'CASH_RECON', 'CASH_SANITY',
+    'REALIZED_SUM', 'COST_BASIS', 'FX_TAG', 'TRUE_PRINCIPAL', 'GOLD_RECON',
+})
 
 
 def validate_macro(path: Path | str, *, now: datetime | None = None) -> None:
@@ -622,8 +627,168 @@ def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
     print(f'validated {path}: {size} bytes, {width}x{height}, {frames} frames')
 
 
+def _assert_dashboard_money_reconciles(
+        data: dict, portfolio_path: Path | str,
+        fx_path: Path | str | None = None) -> None:
+    """Reconcile public first-paint money against the canonical source book."""
+    portfolio_path = Path(portfolio_path)
+    assert portfolio_path.is_file(), f'portfolio missing: {portfolio_path}'
+    try:
+        portfolio = json.loads(portfolio_path.read_text(encoding='utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AssertionError(f'portfolio is not valid JSON/UTF-8: {exc}') from None
+
+    # Reuse the same conservation rules that protect local pre-push and brief
+    # generation. Only arithmetic/accounting findings are fatal here; quote
+    # freshness and market-data advisories remain visible in the dashboard.
+    try:
+        from scripts.data import preflight_integrity
+    except ImportError:  # direct script execution from scripts/data
+        import preflight_integrity  # type: ignore
+    report = preflight_integrity.check(portfolio_path)
+    money_findings = [
+        finding for finding in report['findings']
+        if finding.get('code') in DASHBOARD_MONEY_INTEGRITY_CODES
+    ]
+    assert not money_findings, (
+        'portfolio money integrity failed: '
+        + '; '.join(f"{finding['code']} {finding['msg']}"
+                    for finding in money_findings[:6]))
+
+    def finite(value):
+        return (isinstance(value, (int, float))
+                and not isinstance(value, bool) and math.isfinite(value))
+
+    def same_number(actual, expected, label, tolerance=0.005):
+        assert finite(actual), f'{label} must be a finite number'
+        assert finite(expected), f'portfolio source for {label} must be a finite number'
+        assert abs(actual - expected) <= tolerance, (
+            f'{label}={actual} does not reconcile to portfolio.json={expected}')
+
+    def same_optional_number(actual, expected, label, tolerance=0.005):
+        if expected is None:
+            assert actual is None, (
+                f'{label}={actual} does not reconcile to portfolio.json=null')
+            return
+        same_number(actual, expected, label, tolerance)
+
+    regions = {
+        'us': ('us_stocks', 'USD', {
+            'value_usd': 'total_current_value',
+            'cost_usd': 'total_cost',
+            'pnl_usd': 'total_pnl',
+            'pnl_pct': 'total_pnl_percent',
+            'today_change_usd': 'today_total_change',
+            'realized_usd': 'realized_pnl',
+            'cash_usd': 'cash_usd',
+        }),
+        'hk': ('hk_stocks', 'HKD', {
+            'value_hkd': 'total_current_value',
+            'cost_hkd': 'total_cost',
+            'pnl_hkd': 'total_pnl',
+            'pnl_pct': 'total_pnl_percent',
+            'today_change_hkd': 'today_total_change',
+            'realized_hkd': 'realized_pnl',
+            'cash_hkd': 'cash_hkd',
+        }),
+    }
+    holding_fields = {
+        'shares': ('shares', None),
+        'cost_basis': ('cost_basis', 4),
+        'current_price': ('current_price', 4),
+        'current_value': ('current_value', 2),
+        'today_change': ('today_change', 2),
+        'today_change_pct': ('today_change_pct', 2),
+        'day_high': ('day_high', 4),
+        'day_low': ('day_low', 4),
+        'pnl_abs': ('pnl_abs', 2),
+        'pnl_percent': ('pnl_percent', 2),
+    }
+
+    for leg, (region, currency, total_fields) in regions.items():
+        source_leg = portfolio.get('portfolios', {}).get(region)
+        assert isinstance(source_leg, dict), f'portfolio missing {region}'
+        for public_field, source_field in total_fields.items():
+            same_optional_number(
+                data['totals'][leg].get(public_field),
+                source_leg.get(source_field),
+                f'totals.{leg}.{public_field}',
+            )
+
+        source_rows = {
+            row.get('ticker') or row.get('code'): row
+            for row in source_leg.get('holdings', [])
+            if isinstance(row, dict) and (row.get('shares') or 0) > 0
+        }
+        public_rows = data['holdings'][leg]
+        public_by_ticker = {
+            row.get('ticker'): row for row in public_rows if isinstance(row, dict)
+        }
+        assert len(public_by_ticker) == len(public_rows), (
+            f'holdings.{leg} has duplicate or malformed tickers')
+        assert set(public_by_ticker) == set(source_rows), (
+            f'holdings.{leg} ticker coverage mismatch: '
+            f'missing={sorted(set(source_rows) - set(public_by_ticker))}, '
+            f'extra={sorted(set(public_by_ticker) - set(source_rows))}')
+
+        for ticker, source in source_rows.items():
+            public = public_by_ticker[ticker]
+            expected_name = source.get('name') or source.get('stock_name', '')
+            assert public.get('name') == expected_name, (
+                f'holdings.{leg}.{ticker}.name does not reconcile')
+            assert public.get('currency') == currency, (
+                f'holdings.{leg}.{ticker}.currency must be {currency}')
+            assert public.get('is_active') is True, (
+                f'holdings.{leg}.{ticker}.is_active must be true')
+            assert public.get('trades_count') == len(source.get('trades') or []), (
+                f'holdings.{leg}.{ticker}.trades_count does not reconcile')
+            for public_field, (source_field, places) in holding_fields.items():
+                source_value = source.get(source_field)
+                expected = source_value if places is None else round(source_value or 0, places)
+                tolerance = 1e-9 if places is None else 0.5 * (10 ** -places)
+                same_number(
+                    public.get(public_field), expected,
+                    f'holdings.{leg}.{ticker}.{public_field}', tolerance,
+                )
+
+        # Recompute the public concentration card from the public holding rows.
+        positive = [row for row in public_rows if row.get('current_value', 0) > 0]
+        total = sum(row['current_value'] for row in positive)
+        positions = [{
+            'ticker': row['ticker'],
+            'name': row['name'],
+            'value': row['current_value'],
+            'weight': round(row['current_value'] / total, 4),
+        } for row in positive] if total > 0 else []
+        positions.sort(key=lambda row: -row['weight'])
+        expected_hhi = round(sum(row['weight'] ** 2 for row in positions), 4)
+        expected_top2 = round(sum(row['weight'] for row in positions[:2]), 4)
+        concentration = data['concentration'][leg]
+        same_number(concentration.get('total'), round(total, 2),
+                    f'concentration.{leg}.total')
+        same_number(concentration.get('hhi'), expected_hhi,
+                    f'concentration.{leg}.hhi', 0.00005)
+        same_number(concentration.get('top2'), expected_top2,
+                    f'concentration.{leg}.top2', 0.00005)
+        assert concentration.get('positions') == positions, (
+            f'concentration.{leg}.positions do not reconcile to holdings.{leg}')
+
+    fx_rate = data['fx'].get('usdhkd')
+    assert finite(fx_rate) and fx_rate > 0, 'fx.usdhkd must be a positive finite number'
+    if fx_path is not None and Path(fx_path).is_file():
+        fx_source = json.loads(Path(fx_path).read_text(encoding='utf-8'))
+        same_number(fx_rate, fx_source.get('rate'), 'fx.usdhkd', 0.00005)
+
+    embedded = (data.get('build_status') or {}).get('integrity')
+    assert isinstance(embedded, dict), 'build_status.integrity missing'
+    assert embedded.get('ok') is True and embedded.get('error_count') == 0, (
+        'build_status.integrity is not clean')
+
+
 def validate_dashboard(
-        path: Path | str = 'assets/data/dashboard.json') -> None:
+        path: Path | str = 'assets/data/dashboard.json', *,
+        portfolio_path: Path | str | None = None,
+        fx_path: Path | str | None = None) -> None:
     """Validate the committed, public first-paint dashboard payload.
 
     This intentionally uses only the standard library so a dashboard-only push
@@ -707,7 +872,11 @@ def validate_dashboard(
         assert verdict.get('level') in allowed_levels, (
             f'concentration.{leg} has invalid verdict level')
 
-    print(f'dashboard structural validation OK: {path}')
+    if portfolio_path is not None:
+        _assert_dashboard_money_reconciles(data, portfolio_path, fx_path)
+
+    suffix = ' + money reconciliation' if portfolio_path is not None else ''
+    print(f'dashboard structural validation{suffix} OK: {path}')
 
 
 def validate_coverage_badge(path: Path | str = 'assets/data/coverage.json') -> None:
@@ -776,7 +945,11 @@ def _dispatch(name: str) -> None:
     elif name == 'gif':
         validate_gif('assets/dashboard.gif')
     elif name == 'dashboard':
-        validate_dashboard('assets/data/dashboard.json')
+        validate_dashboard(
+            'assets/data/dashboard.json',
+            portfolio_path='portfolio.json',
+            fx_path='.cache/fx_rate.json',
+        )
     elif name == 'coverage':
         validate_coverage_badge('assets/data/coverage.json')
     else:

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_MAX_BYTES = 200_000
 
 
 def validate_macro(path: Path | str, *, now: datetime | None = None) -> None:
@@ -621,6 +622,94 @@ def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
     print(f'validated {path}: {size} bytes, {width}x{height}, {frames} frames')
 
 
+def validate_dashboard(
+        path: Path | str = 'assets/data/dashboard.json') -> None:
+    """Validate the committed, public first-paint dashboard payload.
+
+    This intentionally uses only the standard library so a dashboard-only push
+    can fail closed on a stock GitHub runner without installing the full test
+    environment. Freshness is schedule-aware in the UI and is not a schema
+    property, so this gate validates the timestamp but does not compare it with
+    wall-clock time.
+    """
+    path = Path(path)
+    assert path.is_file(), f'dashboard payload missing: {path}'
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        raise AssertionError('file is not valid UTF-8') from None
+    assert raw.strip(), 'file is empty'
+    size = path.stat().st_size
+    assert size < DASHBOARD_MAX_BYTES, (
+        f'{size:,} bytes exceeds the {DASHBOARD_MAX_BYTES:,}-byte '
+        'first-paint cap')
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f'invalid JSON at line {exc.lineno} column {exc.colno}') from None
+    assert isinstance(data, dict), 'top-level JSON must be an object'
+
+    required = (
+        'generated_at', 'fx', 'totals', 'concentration', 'holdings',
+        'snapshots', 'decision_metrics', 'decision_delta',
+    )
+    missing = [key for key in required if key not in data]
+    assert not missing, f'missing keys: {missing}'
+    assert 'episode_backtest' not in data, (
+        'Reflect backtest leaked into first-paint payload')
+
+    generated_at = data['generated_at']
+    assert isinstance(generated_at, str), 'generated_at missing'
+    try:
+        datetime.fromisoformat(generated_at.replace('Z', '+00:00'))
+    except ValueError:
+        raise AssertionError(
+            'generated_at is not a valid ISO timestamp') from None
+
+    assert isinstance(data['fx'], dict), 'fx must be an object'
+    assert isinstance(data['totals'], dict), 'totals must be an object'
+    assert isinstance(data['holdings'], dict), 'holdings must be an object'
+    assert isinstance(data['concentration'], dict), (
+        'concentration must be an object')
+    assert isinstance(data['snapshots'], list), 'snapshots must be a list'
+    assert data['snapshots'], 'snapshots is empty — dashboard would render blank'
+    assert isinstance(data['decision_metrics'], dict), (
+        'decision_metrics must be an object')
+    assert isinstance(data['decision_delta'], dict), (
+        'decision_delta must be an object')
+
+    def finite_number(value):
+        return (isinstance(value, (int, float))
+                and not isinstance(value, bool) and math.isfinite(value))
+
+    allowed_levels = {'healthy', 'moderate', 'concentrated', 'danger'}
+    for leg in ('us', 'hk'):
+        assert isinstance(data['totals'].get(leg), dict), (
+            f'totals.{leg} must be an object')
+        assert isinstance(data['holdings'].get(leg), list), (
+            f'holdings.{leg} must be a list')
+        concentration = data['concentration'].get(leg)
+        assert isinstance(concentration, dict), (
+            f'concentration.{leg} must be an object')
+        required_concentration = {'hhi', 'top2', 'positions', 'total', 'verdict'}
+        missing_concentration = sorted(required_concentration - concentration.keys())
+        assert not missing_concentration, (
+            f'concentration.{leg} missing keys: {missing_concentration}')
+        for field in ('hhi', 'top2', 'total'):
+            assert finite_number(concentration[field]), (
+                f'concentration.{leg}.{field} must be a finite number')
+        assert isinstance(concentration['positions'], list), (
+            f'concentration.{leg}.positions must be a list')
+        verdict = concentration['verdict']
+        assert isinstance(verdict, dict), (
+            f'concentration.{leg}.verdict must be an object')
+        assert verdict.get('level') in allowed_levels, (
+            f'concentration.{leg} has invalid verdict level')
+
+    print(f'dashboard structural validation OK: {path}')
+
+
 def validate_coverage_badge(path: Path | str = 'assets/data/coverage.json') -> None:
     """The README badge is rendered by shields.io straight from this file.
 
@@ -686,12 +775,14 @@ def _dispatch(name: str) -> None:
         ))
     elif name == 'gif':
         validate_gif('assets/dashboard.gif')
+    elif name == 'dashboard':
+        validate_dashboard('assets/data/dashboard.json')
     elif name == 'coverage':
         validate_coverage_badge('assets/data/coverage.json')
     else:
         choices = ('macro', 'sentiment', 'influencer', 'news-digest',
                    'eod-archive', 'weekly-review', 'screenshots', 'gif',
-                   'coverage')
+                   'dashboard', 'coverage')
         raise SystemExit(f'unknown validator {name!r}; choose one of: {", ".join(choices)}')
 
 
@@ -714,6 +805,7 @@ def main(argv: list[str] | None = None) -> int:
             'weekly-review': 'weekly review',
             'screenshots': 'screenshots',
             'gif': 'GIF assets/dashboard.gif',
+            'dashboard': 'dashboard payload assets/data/dashboard.json',
             'coverage': 'coverage badge assets/data/coverage.json',
         }
         label = failure_labels.get(argv[0], argv[0])

--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -774,8 +774,11 @@ def _assert_dashboard_money_reconciles(
             f'concentration.{leg}.positions do not reconcile to holdings.{leg}')
 
     fx_rate = data['fx'].get('usdhkd')
-    assert finite(fx_rate) and fx_rate > 0, 'fx.usdhkd must be a positive finite number'
-    if fx_path is not None and Path(fx_path).is_file():
+    fx_source_available = fx_path is not None and Path(fx_path).is_file()
+    if fx_rate is not None:
+        assert finite(fx_rate) and fx_rate > 0, (
+            'fx.usdhkd must be null or a positive finite number')
+    if fx_source_available:
         fx_source = json.loads(Path(fx_path).read_text(encoding='utf-8'))
         same_number(fx_rate, fx_source.get('rate'), 'fx.usdhkd', 0.00005)
 

--- a/tests/test_dashboard_artifact_gate_contract.py
+++ b/tests/test_dashboard_artifact_gate_contract.py
@@ -1,0 +1,57 @@
+"""Contracts for the cheap dashboard-only master-push validation lane."""
+from pathlib import Path
+import re
+
+from workflow_contract_helpers import (
+    assert_validator_step,
+    case_patterns,
+    push_paths,
+    step_block,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / '.github' / 'workflows'
+HARNESS = WORKFLOWS / 'harness-regression.yml'
+GATE = WORKFLOWS / 'dashboard-artifact-gate.yml'
+DASHBOARD = 'assets/data/dashboard.json'
+
+
+def test_dashboard_commits_leave_the_heavy_master_push_lane():
+    assert DASHBOARD not in push_paths(HARNESS)
+    harness = HARNESS.read_text(encoding='utf-8')
+    assert re.search(r'^  pull_request:\s*$', harness, re.MULTILINE), (
+        'required validate context must still report for every PR')
+    assert DASHBOARD in case_patterns(HARNESS), (
+        'dashboard changes in a PR must still run the full regression suite')
+
+
+def test_dashboard_gate_is_master_only_and_path_exact():
+    text = GATE.read_text(encoding='utf-8')
+    trigger = text.split('on:', 1)[1].split('permissions:', 1)[0]
+    assert 'branches: [master]' in trigger
+    assert re.findall(r"^\s*-\s*'([^']+)'", trigger, re.MULTILINE) == [DASHBOARD]
+    assert 'pull_request:' not in trigger
+
+
+def test_dashboard_gate_is_read_only_stdlib_validation():
+    text = GATE.read_text(encoding='utf-8')
+    assert 'contents: read' in text
+    assert 'contents: write' not in text
+    assert 'pip install' not in text
+    assert 'actions/setup-python' not in text
+    assert 'safe_push.sh' not in text
+    assert 'gha_commit_push.sh' not in text
+    assert 'CLAWOCK_PUBLISH_SSH_KEY' not in text
+    assert_validator_step(GATE, 'Validate committed dashboard payload', 'dashboard')
+    assert 'continue-on-error' not in step_block(
+        GATE, 'Validate committed dashboard payload')
+
+
+def test_dashboard_gate_failure_is_visible_and_documented():
+    for readme_name in ('README.md', 'README.zh.md'):
+        readme = (ROOT / readme_name).read_text(encoding='utf-8')
+        assert 'dashboard-artifact-gate.yml?label=DATA' in readme
+        assert '/actions/workflows/dashboard-artifact-gate.yml' in readme
+    tools = (ROOT / 'TOOLS.md').read_text(encoding='utf-8')
+    assert '`dashboard-artifact-gate.yml`' in tools

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -51,8 +51,10 @@ def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces():
     content is non-ASCII — which this payload has always been."""
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
     import build_dashboard
+    import validate_sidecars
 
     assert SIZE_CAP == build_dashboard.MAX_OUT_BYTES
+    assert SIZE_CAP == validate_sidecars.DASHBOARD_MAX_BYTES
 
     # The payload is CJK-heavy, so the two units are ~5% apart. Pinning the
     # gate's measurement to the byte count is what stops anyone quietly putting

--- a/tests/test_harness_regression_paths.py
+++ b/tests/test_harness_regression_paths.py
@@ -7,38 +7,29 @@ later (thesis and earnings schemas, evidence policies, peer rules) silently fell
 outside the gate — a config-only PR reported green in seconds without running the
 tests that read that config. These assertions keep the directory-wide form.
 """
-import re
 from pathlib import Path
+
+from workflow_contract_helpers import case_patterns, push_paths
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = (ROOT / ".github" / "workflows" / "harness-regression.yml").read_text()
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "harness-regression.yml"
+WORKFLOW = WORKFLOW_PATH.read_text()
 CONFIG_FILES = sorted(
     str(path.relative_to(ROOT)) for path in (ROOT / "config").rglob("*")
     if path.is_file()
 )
 
 
-def _push_paths():
-    block = WORKFLOW.split("    paths:", 1)[1].split("  pull_request:", 1)[0]
-    return re.findall(r"^\s*-\s*'([^']+)'", block, re.MULTILINE)
-
-
-def _case_patterns():
-    detect = WORKFLOW.split("Detect code changes", 1)[1]
-    line = next(ln for ln in detect.splitlines() if ln.strip().endswith(")") and "|" in ln)
-    return line.strip().rstrip(")").split("|")
-
-
 def test_config_directory_is_gated_as_a_whole():
-    assert "config/**" in _push_paths()
-    assert "config/*" in _case_patterns()
+    assert "config/**" in push_paths(WORKFLOW_PATH)
+    assert "config/*" in case_patterns(WORKFLOW_PATH)
 
 
 def test_no_individual_config_file_is_named_in_either_gate():
     # A single named file is the failure mode this test exists to prevent: it looks
     # complete while leaving every future config file ungated.
-    narrow = [p for p in _push_paths() + _case_patterns()
+    narrow = [p for p in push_paths(WORKFLOW_PATH) + case_patterns(WORKFLOW_PATH)
               if p.startswith("config/") and p not in {"config/**", "config/*"}]
     assert narrow == [], f"re-narrowed config gating: {narrow}"
 
@@ -51,6 +42,6 @@ def test_every_shipped_config_file_matches_the_gate():
 
 def test_scripts_and_tests_stay_gated():
     for pattern in ("scripts/*", "tests/*"):
-        assert pattern in _case_patterns()
+        assert pattern in case_patterns(WORKFLOW_PATH)
     for pattern in ("scripts/**", "tests/**"):
-        assert pattern in _push_paths()
+        assert pattern in push_paths(WORKFLOW_PATH)

--- a/tests/test_preflight_integrity.py
+++ b/tests/test_preflight_integrity.py
@@ -307,13 +307,6 @@ def test_fx_tag_accepts_canonical_currency_and_rejects_wrong_currency(run_check)
     _assert_only(run_check(bad), "FX_TAG", "ERROR", "currency=HKD 应为 USD")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "genuine bug (high confidence): FX_TAG uses `and ccy`, so a missing required "
-        "region currency silently passes despite the documented USD/HKD invariant"
-    ),
-)
 def test_fx_tag_rejects_missing_required_currency(run_check):
     data = _portfolio_data()
     del _port(data)["currency"]

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -16,6 +16,9 @@ BUILD = (ROOT / "scripts" / "data" / "build_dashboard.py").read_text()
 HARNESS_WORKFLOW = (
     ROOT / ".github" / "workflows" / "harness-regression.yml"
 ).read_text()
+SIDECAR_VALIDATORS = (
+    ROOT / "scripts" / "data" / "validate_sidecars.py"
+).read_text()
 
 
 def test_reflect_loads_audit_as_sidecar_and_not_dashboard_field():
@@ -56,8 +59,12 @@ def test_remote_rebuild_gate_validates_the_new_payload_boundary():
     gate = HARNESS_WORKFLOW.split(
         "- name: Rebuild dashboard.json and validate", 1
     )[1].split("- name: Run build_dashboard sanity", 1)[0]
+    dashboard_validator = SIDECAR_VALIDATORS.split(
+        'def validate_dashboard', 1
+    )[1].split('def validate_coverage_badge', 1)[0]
     assert "assets/data/decision_audit.json" in gate
-    assert "'episode_backtest' not in d" in gate
+    assert "validate_sidecars.py dashboard" in gate
+    assert "'episode_backtest' not in data" in dashboard_validator
     assert "audit.get('episode_backtest'" in gate
 
 

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -86,6 +86,28 @@ def macro_payload(generated_at: str = GENERATED) -> dict:
     }
 
 
+def dashboard_payload() -> dict:
+    return {
+        'generated_at': GENERATED,
+        'fx': {'usdhkd': 7.8, 'source': 'test', 'fetched_at': GENERATED},
+        'totals': {'us': {}, 'hk': {}},
+        'holdings': {'us': [], 'hk': []},
+        'concentration': {
+            leg: {
+                'hhi': 0.0,
+                'top2': 0.0,
+                'positions': [],
+                'total': 0.0,
+                'verdict': {'level': 'healthy'},
+            }
+            for leg in ('us', 'hk')
+        },
+        'snapshots': [{'date': '2026-07-17'}],
+        'decision_metrics': {},
+        'decision_delta': {},
+    }
+
+
 def news_payload(generated_at: str = GENERATED) -> dict:
     return {
         'generated_at': generated_at,
@@ -255,6 +277,10 @@ def test_real_committed_gif_passes():
     validators.validate_gif(ROOT / 'assets/dashboard.gif')
 
 
+def test_real_committed_dashboard_passes():
+    validators.validate_dashboard(ROOT / 'assets/data/dashboard.json')
+
+
 JSON_VALIDATORS = (
     ('macro', lambda path, portfolio: validators.validate_macro(
         path, now=datetime(2026, 7, 17, 1, tzinfo=timezone.utc))),
@@ -262,6 +288,7 @@ JSON_VALIDATORS = (
     ('influencer', lambda path, portfolio: validators.validate_influencer(path)),
     ('news', lambda path, portfolio: validators.validate_news_digest(
         path, now=datetime(2026, 7, 17, 1, tzinfo=timezone.utc))),
+    ('dashboard', lambda path, portfolio: validators.validate_dashboard(path)),
 )
 
 
@@ -281,6 +308,52 @@ def test_json_artifacts_fail_clearly(
 
     with pytest.raises(AssertionError, match=problem):
         validator(path, portfolio)
+
+
+@pytest.mark.parametrize('missing', (
+    'generated_at', 'fx', 'totals', 'holdings', 'concentration', 'snapshots',
+    'decision_metrics', 'decision_delta',
+))
+def test_dashboard_rejects_missing_first_paint_contract_key(tmp_path, missing):
+    payload = dashboard_payload()
+    payload.pop(missing)
+    path = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match='missing keys'):
+        validators.validate_dashboard(path)
+
+
+@pytest.mark.parametrize('mutation,problem', (
+    (lambda payload: payload.update(generated_at='not-a-date'),
+     'generated_at is not a valid ISO timestamp'),
+    (lambda payload: payload['holdings'].update(us={}),
+     'holdings.us must be a list'),
+    (lambda payload: payload['concentration']['hk'].pop('top2'),
+     'concentration.hk missing keys'),
+    (lambda payload: payload['concentration']['us']['verdict'].update(level='unknown'),
+     'concentration.us has invalid verdict level'),
+    (lambda payload: payload.update(snapshots=[]),
+     'snapshots is empty'),
+    (lambda payload: payload.update(episode_backtest={}),
+     'Reflect backtest leaked into first-paint payload'),
+))
+def test_dashboard_rejects_incomplete_or_unsafe_payload(
+        tmp_path, mutation, problem):
+    payload = dashboard_payload()
+    mutation(payload)
+    path = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match=problem):
+        validators.validate_dashboard(path)
+
+
+def test_dashboard_rejects_payload_at_or_above_first_paint_cap(tmp_path):
+    payload = dashboard_payload()
+    payload['padding'] = 'x' * validators.DASHBOARD_MAX_BYTES
+    path = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match='first-paint cap'):
+        validators.validate_dashboard(path)
 
 
 def test_sentiment_quiet_day_with_zero_results_passes(tmp_path):

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -278,7 +278,63 @@ def test_real_committed_gif_passes():
 
 
 def test_real_committed_dashboard_passes():
-    validators.validate_dashboard(ROOT / 'assets/data/dashboard.json')
+    validators.validate_dashboard(
+        ROOT / 'assets/data/dashboard.json', portfolio_path=ROOT / 'portfolio.json')
+
+
+@pytest.mark.parametrize('mutation,problem', (
+    (lambda payload: payload['holdings']['us'][0].update(current_value=-999),
+     r'holdings\.us\..*\.current_value=.*does not reconcile'),
+    (lambda payload: payload['totals']['hk'].update(pnl_hkd=-999),
+     r'totals\.hk\.pnl_hkd=.*does not reconcile'),
+    (lambda payload: payload['holdings']['us'].pop(),
+     r'holdings\.us ticker coverage mismatch'),
+    (lambda payload: payload['concentration']['us'].update(hhi=0.9999),
+     r'concentration\.us\.hhi=.*does not reconcile'),
+    (lambda payload: payload['build_status']['integrity'].update(ok=False),
+     r'build_status\.integrity is not clean'),
+))
+def test_dashboard_money_reconciliation_rejects_public_drift(
+        tmp_path, mutation, problem):
+    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    mutation(payload)
+    dashboard = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match=problem):
+        validators.validate_dashboard(
+            dashboard, portfolio_path=ROOT / 'portfolio.json')
+
+
+def test_dashboard_money_reconciliation_rejects_source_integrity_failure(tmp_path):
+    portfolio = json.loads((ROOT / 'portfolio.json').read_text())
+    portfolio['portfolios']['us_stocks']['total_pnl'] += 100
+    source = write_json(tmp_path / 'portfolio.json', portfolio)
+
+    with pytest.raises(AssertionError, match='portfolio money integrity failed: PNL_TOTAL'):
+        validators.validate_dashboard(
+            ROOT / 'assets/data/dashboard.json', portfolio_path=source)
+
+
+def test_dashboard_money_reconciliation_checks_fx_cache_when_available(tmp_path):
+    fx = write_json(tmp_path / 'fx.json', {'rate': 7.0})
+
+    with pytest.raises(AssertionError, match=r'fx\.usdhkd=.*does not reconcile'):
+        validators.validate_dashboard(
+            ROOT / 'assets/data/dashboard.json',
+            portfolio_path=ROOT / 'portfolio.json',
+            fx_path=fx,
+        )
+
+
+def test_dashboard_money_reconciliation_allows_untracked_cash_as_null(tmp_path):
+    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    portfolio = json.loads((ROOT / 'portfolio.json').read_text())
+    payload['totals']['hk']['cash_hkd'] = None
+    portfolio['portfolios']['hk_stocks']['cash_hkd'] = None
+    dashboard = write_json(tmp_path / 'dashboard.json', payload)
+    source = write_json(tmp_path / 'portfolio.json', portfolio)
+
+    validators.validate_dashboard(dashboard, portfolio_path=source)
 
 
 JSON_VALIDATORS = (

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -318,7 +318,7 @@ def test_dashboard_money_reconciliation_rejects_source_integrity_failure(tmp_pat
 def test_dashboard_money_reconciliation_checks_fx_cache_when_available(tmp_path):
     fx = write_json(tmp_path / 'fx.json', {'rate': 7.0})
 
-    with pytest.raises(AssertionError, match=r'fx\.usdhkd=.*does not reconcile'):
+    with pytest.raises(AssertionError, match=r'fx\.usdhkd'):
         validators.validate_dashboard(
             ROOT / 'assets/data/dashboard.json',
             portfolio_path=ROOT / 'portfolio.json',

--- a/tests/workflow_contract_helpers.py
+++ b/tests/workflow_contract_helpers.py
@@ -3,9 +3,23 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+import re
 
 
 VALIDATOR_COMMAND = 'python3 scripts/data/validate_sidecars.py'
+
+
+def push_paths(workflow: Path) -> list[str]:
+    text = workflow.read_text(encoding='utf-8')
+    block = text.split('    paths:', 1)[1].split('\n  pull_request:', 1)[0]
+    return re.findall(r"^\s*-\s*'([^']+)'", block, re.MULTILINE)
+
+
+def case_patterns(workflow: Path, step_name: str = 'Detect code changes') -> list[str]:
+    detect = workflow.read_text(encoding='utf-8').split(step_name, 1)[1]
+    line = next(ln for ln in detect.splitlines()
+                if ln.strip().endswith(')') and '|' in ln)
+    return line.strip().rstrip(')').split('|')
 
 
 def steps(workflow: Path):


### PR DESCRIPTION
## Outcome
- dashboard-only master publishes leave the full Harness Regression lane
- a read-only, stdlib-only GitHub-hosted gate checks the committed first-paint payload
- the gate reconciles Dashboard against portfolio.json: money conservation, ticker coverage, per-holding values, leg totals, concentration math, optional FX cache, and embedded integrity state
- malformed/empty/oversized payloads and leaked backtest data fail closed
- every PR still runs the stable full validate context

## Measured ROI
The latest 500 Harness runs cover 2026-07-26 16:15Z through 2026-08-01 08:26Z. Of those, 335 (67%) were dashboard scheduled-publish commits. They occupied 68,959 seconds of aggregate workflow wall time, averaging 206 seconds each. This PR moves those repetitive artifact-only pushes to one stock Ubuntu job with no dependency install and a 2-minute hard timeout. The post-merge result will be checked against the next 24 hours of runs; the test count is not the success metric.

## Load boundary
- no VPS cron, service, publisher, fallback cadence, or model-call change
- all reconciliation is pure file arithmetic on GitHub-hosted runners
- the full regression remains for PRs and real code/config changes

## Verification
- current committed dashboard passes structural and money reconciliation at 152KB with 58 snapshots
- focused artifact/integrity/contract checks pass
- broader Dashboard/derivation checks pass
- local system check: 17 OK, 0 WARN, 0 critical
- Claude Opus 5 identified the initial missing size/non-empty checks; the corrected current head awaits final re-review

Closes #205
Closes #211