### PR TITLE
Fix brief readability advice without degrading delivered products

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -454,7 +454,11 @@
       const raw = (r.raw_execution || {}).status || 'unknown';
       const final = (r.final_product || {}).status || 'pending';
       const slot = (r.slot || '').replace('T', ' ').slice(5, 16);
-      lines.push(`流程 ${r.job} ${slot}: 执行=${raw} / 成品=${final}`);
+      const readability = r.readability || {};
+      const readabilityDetail = readability.status
+        ? ` / 可读性=${readability.status}${Number.isFinite(readability.bytes) ? ` ${(readability.bytes / 1000).toFixed(1)}KB` : ''}`
+        : '';
+      lines.push(`流程 ${r.job} ${slot}: 执行=${raw} / 成品=${final}${readabilityDetail}`);
     });
     const gen = bs.generated_at ? bs.generated_at.replace('T', ' ').slice(0, 16) : '';
     el.innerHTML = `<span class="bs-dot">${dot}</span> <span class="bs-label">${label}</span>` +

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -85,15 +85,16 @@ def trim_lev_regime(lev_regime):
 
 
 def trim_workflow_outcomes(summary):
-    """Keep the two fields the build-status dot reads; drop the stage detail.
+    """Keep build-status fields and compact readability; drop stage detail.
 
     `recent[].stages` is five stage objects per slot, each carrying the full
     heartbeat detail (market, anomaly_count, wechat_sent, …) — 24KB across a
     36h window, and the renderer touches none of it: the dot reads `counts`
     and `raw_error_but_product_usable`, the tooltip reads only `job`, `slot`,
-    `raw_execution.status` and `final_product.status`. The complete ledger is
-    published on its own at assets/data/workflow-outcomes.json, so this is the
-    same duplication the calibrator and regime-history trims removed.
+    `raw_execution.status`, `final_product.status`, and the compact readability
+    assessment. The complete ledger is published on its own at
+    assets/data/workflow-outcomes.json, so this is the same duplication the
+    calibrator and regime-history trims removed.
     """
     if not isinstance(summary, dict):
         return summary
@@ -106,8 +107,20 @@ def trim_workflow_outcomes(summary):
         if not isinstance(record, dict):
             trimmed.append(record)
             continue
+        stages = record.get('stages')
+        compact = {k: v for k, v in record.items() if k != 'stages'}
+        if isinstance(stages, dict):
+            # llm is written immediately before the dashboard build, so it is
+            # current even on a same-slot retry whose older postflight detail is
+            # still present. Both stages carry the same assessment on first run.
+            for stage_name in ('llm', 'postflight'):
+                stage = stages.get(stage_name)
+                candidate = stage.get('readability') if isinstance(stage, dict) else None
+                if isinstance(candidate, dict):
+                    compact['readability'] = candidate
+                    break
         dropped = dropped or 'stages' in record
-        trimmed.append({k: v for k, v in record.items() if k != 'stages'})
+        trimmed.append(compact)
     summary = {**summary, 'recent': trimmed}
     if dropped:
         summary['stages_source'] = 'assets/data/workflow-outcomes.json'

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -67,6 +67,50 @@ HKD_USD_BUG_PATTERNS = [
     '合计 -4423', '合计 -4,423', '合计 -4423.0',
 ]
 
+# Readability is measured separately from substantive validation. A modestly
+# long brief remains a usable product; only extreme size becomes a warning.
+BRIEF_READABILITY_TARGET_BYTES = 28_000
+BRIEF_READABILITY_EXTREME_BYTES = 40_000
+
+
+def assess_brief_readability(path):
+    """Return structured size health without changing the authored brief."""
+    try:
+        nbytes = Path(path).stat().st_size
+    except OSError:
+        nbytes = None
+
+    if nbytes is None:
+        status = 'unavailable'
+        over_by = None
+    elif nbytes >= BRIEF_READABILITY_EXTREME_BYTES:
+        status = 'extreme'
+        over_by = max(0, nbytes - BRIEF_READABILITY_TARGET_BYTES)
+    elif nbytes > BRIEF_READABILITY_TARGET_BYTES:
+        status = 'advisory'
+        over_by = nbytes - BRIEF_READABILITY_TARGET_BYTES
+    else:
+        status = 'within_budget'
+        over_by = max(0, nbytes - BRIEF_READABILITY_TARGET_BYTES)
+
+    return {
+        'status': status,
+        'bytes': nbytes,
+        'target_bytes': BRIEF_READABILITY_TARGET_BYTES,
+        'extreme_bytes': BRIEF_READABILITY_EXTREME_BYTES,
+        'over_by_bytes': over_by,
+    }
+
+
+def readability_issues(readability):
+    """Promote only an extreme overage into normal validation semantics."""
+    if readability.get('status') != 'extreme':
+        return []
+    return [
+        'pre-open.md 极端超长 '
+        f'{readability.get("bytes")} bytes（≥40KB，完整保留但下次生成须按分段预算收敛）'
+    ]
+
 
 def _section_markers(text):
     """Return real section-marker lines, not incidental aliases in prose."""
@@ -342,12 +386,6 @@ def validate_markdown(path, context=None):
     if 'USDHKD' not in text and 'FX' not in text and '汇率' not in text:
         issues.append('pre-open.md 未提及 FX rate / 汇率')
 
-    # 体量卫生 (2026-05-31): WeChat 只发紧凑结论卡（Step 4-D），pre-open.md 仅作 dashboard
-    # 全文，不再受 16KB 微信上限约束 → 不 fail。但过长 briefs 页难读，>24KB 给个 warn 提醒精简。
-    nbytes = len(text.encode('utf-8'))
-    if nbytes > 24000:
-        issues.append(f'pre-open.md 偏长 {nbytes} bytes（dashboard 全文，建议精简到 ≤24KB 便于阅读）')
-
     # Markdown table column consistency — Pages renderer breaks if header/sep/data
     # rows diverge in pipe-segment count (same class of bug as the WeChat one
     # caught by intraday/report postflights).
@@ -601,6 +639,7 @@ def main():
         except Exception:
             pass
 
+    readability = assess_brief_readability(md_path)
     issues = []
     manifest_path = ctx_path.with_suffix('') / 'manifest.json'
     decision_packet = None
@@ -611,6 +650,7 @@ def main():
         except Exception as exc:
             issues.append(f'decision packet 不可用: {exc}')
     issues += validate_markdown(md_path, context=context)
+    issues += readability_issues(readability)
     normalization_issues, normalized_plan = normalize_plan_json(
         plan_path,
         write=not args.dry_run,
@@ -642,6 +682,7 @@ def main():
         slot=slot,
         dry_run=args.dry_run,
         issue_count=len(issues),
+        readability=readability,
     )
     # Emit the cross-process publish gate BEFORE anything else can raise, so the
     # off-host workflow's committer has an explicit verdict (and a crash leaves no
@@ -757,6 +798,7 @@ def main():
         'commit_msg':    commit_msg,
         'projection_status': projection_status,
         'projection_issues': projection_issues,
+        'readability': readability,
         'files_checked': {
             'pre_open_md':  str(md_path),
             'plan_json':    str(plan_path),
@@ -772,6 +814,7 @@ def main():
         dry_run=args.dry_run,
         issue_count=len(issues),
         commit_ok=commit_ok,
+        readability=readability,
     )
     workflow_outcomes.record_stage(
         job_name,

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -581,6 +581,20 @@ calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条�
 - "USDHKD" 或 "FX" 或 "汇率" — FX 段
 - 不能出现 "合计 -4423" / "合计 -4,423" 这种 HKD+USD 直接相加的历史 bug
 
+**写作时体量预算（在 Step 4-A 内完成，不是 postflight 返工）**：目标 ≤28KB；≥40KB
+属于极端超长，会让成品健康状态降级。按以下分段预算写初稿，给 Markdown 标记留出余量：
+
+- Header + book/仓位表 + 核心结论：≤5KB
+- Retrospective + Tier 1：≤6KB
+- Tier 2 + Tier 3/Judge：≤6KB
+- 同行 + macro + sentiment + influencer：≤5KB
+- Confidence + Decision v2 + Next-Session：≤4KB
+
+初稿写完但仍在 Step 4-A 时，运行 `wc -c memory/{YYYY-MM-DD}-pre-open.md`。若 >28KB，
+在定稿前删除重复解释、缩短逐票叙述、合并同义句；所有必需段落、证据、风险闸和行动必须完整
+保留。若 ≥40KB，必须先按分段预算收敛再跑 postflight。**禁止**用 `head`、`truncate`、
+字符串切片或其他事后硬**截断**；也禁止为了压体量删除证据、风险闸或行动段。
+
 #### B. 结构化 plan → `memory/{YYYY-MM-DD}-plan.json`
 
 postflight 严格 schema 校验：
@@ -770,7 +784,7 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
 ```
 
 - `pass` — 全部 OK，已 `git commit`
-- `warn` — 有非 critical 问题（≤4 个），已 commit 但标 `(validation warnings)`
+- `warn` — 有非 critical 实质问题或 ≥40KB 极端超长（≤4 个），已 commit 但标 `(validation warnings)`
 - `fail` — 缺文件/JSON 解析错/critical 字段缺失，**不 commit**、**不投递**
 - `wechat_sent` — postflight 自动投递结果（见下）
 
@@ -781,15 +795,11 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_postflight.py
 不要在一次 `fail` 之后一路埋头修到自己认为"干净"为止 —— 修掉 critical 那条以后往往
 已经是 warn，剩下的 issue 不阻塞交付。
 
-> **2026-07-27 实例**：首跑 `fail`，issues 是「表格 #1 列数不一致」+「pre-open.md 偏长
-> 35853 bytes」。表格那条是 critical，体积那条只是提醒。修好表格后没有重跑，误以为体积
-> 也是硬闸，从 35.8KB 一路裁到 23.7KB —— 多烧 6 分钟 / 约 13M tokens，中途还因为 `edit`
-> 的 `oldText` 打错中文字（`滴`/`滘`、`拉锅`/`拉锯`）连失败 3 次，把整跑染成
-> `status=error`（产物其实已正常交付）。
-
-`pre-open.md 偏长 … bytes` 永远是 warn：这个文件是 dashboard 全文，不受微信 16KB 限制，
->24KB 只是"页面难读"的提醒。**不要为它裁剪已经写好的正文。** 要控体量就在 Step 4-A 写的
-时候写紧凑，而不是事后返工。
+> **2026-07-27 教训**：旧规则把 35.8KB 和表格 critical 混在同一个 issues 列表里，模型误把
+> 体量当硬闸，事后一路裁到 23.7KB，既浪费时间/tokens 又引入编辑错误。新规则把体量单独记录：
+> 28–40KB 是结构化 `advisory`，不计入 issues、不让已交付成品变黄；≥40KB 才是实际 `warn`。
+> 无论哪档都保留完整正文，绝不在 postflight 后硬截断。体量应按 Step 4-A 的分段预算在定稿前
+> 收敛，不能牺牲必需段落、证据、风险闸或行动。
 
 ### 投递（Step 5 postflight 内自动，你什么都不用做）
 

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -587,13 +587,15 @@ calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条�
 - Header + book/仓位表 + 核心结论：≤5KB
 - Retrospective + Tier 1：≤6KB
 - Tier 2 + Tier 3/Judge：≤6KB
-- 同行 + macro + sentiment + influencer：≤5KB
+- 同行明细完整 + macro + sentiment + influencer：≤5KB（空间不足时先压后三者的重复解释）
 - Confidence + Decision v2 + Next-Session：≤4KB
 
 初稿写完但仍在 Step 4-A 时，运行 `wc -c memory/{YYYY-MM-DD}-pre-open.md`。若 >28KB，
 在定稿前删除重复解释、缩短逐票叙述、合并同义句；所有必需段落、证据、风险闸和行动必须完整
-保留。若 ≥40KB，必须先按分段预算收敛再跑 postflight。**禁止**用 `head`、`truncate`、
-字符串切片或其他事后硬**截断**；也禁止为了压体量删除证据、风险闸或行动段。
+保留。**同行明细不是压缩对象**：同行枚举、相对涨跌、持仓位置和归因必须保留；同行组超预算
+时先压 macro / sentiment / influencer 的重复解释。若 ≥40KB，必须先按分段预算收敛再跑
+postflight。**禁止**用 `head`、`truncate`、字符串切片或其他事后硬**截断**；也禁止为了压
+体量删除证据、风险闸或行动段。
 
 #### B. 结构化 plan → `memory/{YYYY-MM-DD}-plan.json`
 

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -1,0 +1,101 @@
+"""Brief readability is observable, but modest overage is not product failure."""
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
+import brief_postflight as postflight  # noqa: E402
+
+
+def _write_size(path: Path, size: int) -> Path:
+    path.write_bytes(b'x' * size)
+    return path
+
+
+def test_clean_brief_is_within_budget_and_passes(tmp_path):
+    path = _write_size(
+        tmp_path / 'brief.md', postflight.BRIEF_READABILITY_TARGET_BYTES)
+
+    readability = postflight.assess_brief_readability(path)
+
+    assert readability['status'] == 'within_budget'
+    assert readability['bytes'] == postflight.BRIEF_READABILITY_TARGET_BYTES
+    assert postflight.readability_issues(readability) == []
+    assert postflight.categorize([]) == 'pass'
+
+
+def test_modest_overage_is_separate_advisory_not_validation_warning(tmp_path):
+    size = postflight.BRIEF_READABILITY_TARGET_BYTES + 1_234
+    path = _write_size(tmp_path / 'brief.md', size)
+    before = path.read_bytes()
+
+    readability = postflight.assess_brief_readability(path)
+
+    assert readability == {
+        'status': 'advisory',
+        'bytes': size,
+        'target_bytes': postflight.BRIEF_READABILITY_TARGET_BYTES,
+        'extreme_bytes': postflight.BRIEF_READABILITY_EXTREME_BYTES,
+        'over_by_bytes': 1_234,
+    }
+    assert postflight.readability_issues(readability) == []
+    assert postflight.categorize([]) == 'pass'
+    assert path.read_bytes() == before, 'readability assessment truncated the brief'
+
+
+def test_readability_advisory_cannot_hide_substantive_failure(tmp_path):
+    path = _write_size(
+        tmp_path / 'brief.md', postflight.BRIEF_READABILITY_TARGET_BYTES + 100)
+    readability = postflight.assess_brief_readability(path)
+    substantive = ['pre-open.md 缺失（critical）']
+
+    issues = substantive + postflight.readability_issues(readability)
+
+    assert readability['status'] == 'advisory'
+    assert issues == substantive
+    assert postflight.categorize(issues) == 'fail'
+
+
+def test_extreme_oversize_remains_a_real_degradation(tmp_path):
+    path = _write_size(
+        tmp_path / 'brief.md', postflight.BRIEF_READABILITY_EXTREME_BYTES)
+
+    readability = postflight.assess_brief_readability(path)
+    issues = postflight.readability_issues(readability)
+
+    assert readability['status'] == 'extreme'
+    assert len(issues) == 1 and '极端超长' in issues[0]
+    assert postflight.categorize(issues) == 'warn'
+
+
+def test_recent_real_briefs_stop_producing_systematic_false_yellow():
+    expected = {
+        '2026-07-28': ('advisory', 29_109),
+        '2026-07-29': ('advisory', 28_592),
+        '2026-07-30': ('within_budget', 26_728),
+        '2026-07-31': ('within_budget', 26_099),
+    }
+    for day, (status, size) in expected.items():
+        path = ROOT / 'memory' / f'{day}-pre-open.md'
+        readability = postflight.assess_brief_readability(path)
+        issues = postflight.validate_markdown(path)
+
+        assert readability['status'] == status, day
+        assert readability['bytes'] == size, day
+        assert postflight.readability_issues(readability) == [], day
+        assert issues == [], (day, issues)
+        assert postflight.categorize(issues) == 'pass', day
+
+
+def test_generation_instructions_budget_sections_before_postflight():
+    skill = (ROOT / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
+        encoding='utf-8')
+    report = skill.split('#### A. Markdown 报告', 1)[1].split(
+        '#### B. 结构化 plan', 1)[0]
+
+    assert '28KB' in report
+    assert '40KB' in report
+    assert 'wc -c' in report
+    assert '分段预算' in report
+    assert '禁止' in report and '截断' in report

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -69,25 +69,6 @@ def test_extreme_oversize_remains_a_real_degradation(tmp_path):
     assert postflight.categorize(issues) == 'warn'
 
 
-def test_recent_real_briefs_stop_producing_systematic_false_yellow():
-    expected = {
-        '2026-07-28': ('advisory', 29_109),
-        '2026-07-29': ('advisory', 28_592),
-        '2026-07-30': ('within_budget', 26_728),
-        '2026-07-31': ('within_budget', 26_099),
-    }
-    for day, (status, size) in expected.items():
-        path = ROOT / 'memory' / f'{day}-pre-open.md'
-        readability = postflight.assess_brief_readability(path)
-        issues = postflight.validate_markdown(path)
-
-        assert readability['status'] == status, day
-        assert readability['bytes'] == size, day
-        assert postflight.readability_issues(readability) == [], day
-        assert issues == [], (day, issues)
-        assert postflight.categorize(issues) == 'pass', day
-
-
 def test_generation_instructions_budget_sections_before_postflight():
     skill = (ROOT / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
         encoding='utf-8')
@@ -99,3 +80,5 @@ def test_generation_instructions_budget_sections_before_postflight():
     assert 'wc -c' in report
     assert '分段预算' in report
     assert '禁止' in report and '截断' in report
+    assert '同行明细不是压缩对象' in report
+    assert '同行枚举、相对涨跌、持仓位置和归因必须保留' in report

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -141,6 +141,48 @@ def test_the_unread_workflow_stage_detail_stays_out(payload):
         assert record["final_product"]["status"]
 
 
+def test_dashboard_trim_keeps_readability_without_full_stage_detail():
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    readability = {
+        "status": "advisory", "bytes": 29_109,
+        "target_bytes": 28_000, "extreme_bytes": 40_000,
+        "over_by_bytes": 1_109,
+    }
+    summary = {
+        "recent": [{
+            "job": "盘前深度简报",
+            "stages": {"llm": {"status": "success", "readability": readability}},
+            "final_product": {"status": "success"},
+        }],
+    }
+
+    trimmed = build_dashboard.trim_workflow_outcomes(summary)
+
+    assert "stages" not in trimmed["recent"][0]
+    assert trimmed["recent"][0]["readability"] == readability
+    assert trimmed["stages_source"] == "assets/data/workflow-outcomes.json"
+
+
+def test_dashboard_trim_prefers_current_llm_readability_on_same_slot_retry():
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    current = {"status": "within_budget", "bytes": 27_000}
+    stale = {"status": "advisory", "bytes": 29_000}
+    summary = {"recent": [{
+        "stages": {
+            "llm": {"status": "success", "readability": current},
+            "postflight": {"status": "success", "readability": stale},
+        },
+    }]}
+
+    trimmed = build_dashboard.trim_workflow_outcomes(summary)
+
+    assert trimmed["recent"][0]["readability"] == current
+
+
 def test_dropped_blocks_are_still_reachable_elsewhere():
     """Trimming the payload must not lose the data — only relocate it."""
     standalone = json.loads((ROOT / "assets" / "data" / "lev_regime.json").read_text())

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -50,6 +50,31 @@ def test_stages_remain_independent_and_primary_delivery_can_be_degraded(
     assert record["stages"]["watchdog_delivery"]["status"] == "unknown"
 
 
+def test_readability_advisory_detail_does_not_degrade_a_delivered_product(
+    tmp_path, monkeypatch
+):
+    _isolate(tmp_path, monkeypatch)
+    slot = "2026-07-24T08:00:00+08:00"
+    job = "盘前深度简报"
+    readability = {
+        "status": "advisory", "bytes": 29_109,
+        "target_bytes": 28_000, "extreme_bytes": 40_000,
+        "over_by_bytes": 1_109,
+    }
+
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(
+        job, "llm", "success", slot=slot, readability=readability)
+    outcomes.record_stage(
+        job, "postflight", "success", slot=slot, readability=readability)
+    record = outcomes.record_stage(
+        job, "primary_delivery", "success", slot=slot)
+
+    assert record["final_product"]["status"] == "success"
+    assert record["stages"]["postflight"]["readability"] == readability
+    assert outcomes.summarize(hours=100000)["counts"] == {"success": 1}
+
+
 def test_watchdog_recovery_does_not_erase_failed_primary_delivery(tmp_path, monkeypatch):
     _isolate(tmp_path, monkeypatch)
     slot = "2026-07-24T10:00:00+08:00"
@@ -242,4 +267,5 @@ def test_dashboard_renderer_labels_raw_and_final_status_separately():
     renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
 
     assert "执行=${raw} / 成品=${final}" in renderer
+    assert "可读性=${readability.status}" in renderer
     assert "raw_error_but_product_usable" in renderer


### PR DESCRIPTION
## Outcome
- brief size becomes structured readability health instead of every modest overage turning a successfully delivered brief yellow
- 28KB to under 40KB stays visible as advisory; 40KB and above remains a real degraded-product warning
- the model receives section budgets before writing; no postflight rewrite or truncation occurs
- peer detail is explicitly preserved: enumeration, relative moves, held-name position, and attribution are not compression targets
- compact readability metadata appears in the Dashboard tooltip without retaining full workflow stages

## Observable baseline and acceptance
The retained 2026-07-28 through 2026-07-31 briefs were 29,109, 28,592, 26,728, and 26,099 bytes. The two modest overages were substantively clean but displayed as degraded. After merge, a 28-40KB clean delivered brief must remain product-success while keeping its advisory visible; a 40KB+ brief must still degrade. Content must remain intact, especially peer detail, evidence, risks, and actions.

## Load boundary
- no generated brief is rewritten or truncated
- no delivery, fallback cadence, cron, VPS job, or model call changes
- tests cover only the status boundary, failure non-masking, metadata selection, and content-preservation contract

Closes #207

## Runtime baseline
Across the latest seven calendar days, successful raw brief attempts had a 626.5s median (541.1-692.0s observed). This PR does not change the model, provider, network calls, or tool round trips, so it makes no latency claim. Its measurable benefit is accurate product-health classification and avoiding destructive length rework while preserving content.