### PR TITLE
fix: show canonical quote sessions in dashboard health

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -398,6 +398,15 @@
     ensureVisibleCharts();
   }
 
+  function quoteSessionLabel(market) {
+    const oldest = market && market.oldest_quote_session;
+    const newest = market && market.newest_quote_session;
+    if (!oldest && !newest) return '行情会话未知';
+    if (!oldest) return String(newest);
+    if (!newest) return String(oldest);
+    return oldest === newest ? String(newest) : `${oldest} → ${newest}`;
+  }
+
   // ── A2 系统健康卡（页脚）──
   // 数据新鲜度 + 体检结论（A1）的被动展示。不推送（遵 feedback_no_individual_cron_alerts），
   // 让 stale / 体检异常一眼可见。绿=全新鲜且体检过；黄=有 stale 或 WARN；红=体检 ERROR。
@@ -448,7 +457,7 @@
     (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '🔴' : '🟡'} ${t.code}: ${t.msg}`));
     if (bs.markets) {
       Object.entries(bs.markets).forEach(([m, v]) =>
-        lines.push(`${m.toUpperCase()}: ${v.last_updated || '?'}${v.closed_today ? ' (休市)' : ''}`));
+        lines.push(`${m.toUpperCase()}: 行情会话 ${quoteSessionLabel(v)}${v.closed_today ? ' (休市)' : ''}`));
     }
     (wf.recent || []).slice(0, 8).forEach(r => {
       const raw = (r.raw_execution || {}).status || 'unknown';

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -803,6 +803,25 @@ def test_dashboard_tooltip_distinguishes_schedule_deadlines_from_age_slas():
     assert "/ SLA ${f.sla_hours}h" in block
 
 
+def test_dashboard_market_tooltip_uses_canonical_quote_sessions():
+    renderer = (ROOT / "assets" / "js" / "dashboard.render.js").read_text()
+    helper = renderer.split("function quoteSessionLabel", 1)[1].split(
+        "// ── A2 系统健康卡", 1
+    )[0]
+    market_block = renderer.split("if (bs.markets)", 1)[1].split(
+        "(wf.recent || [])", 1
+    )[0]
+
+    assert "market.oldest_quote_session" in helper
+    assert "market.newest_quote_session" in helper
+    assert "oldest === newest" in helper
+    assert "${oldest} → ${newest}" in helper
+    assert "行情会话未知" in helper
+    assert "quoteSessionLabel(v)" in market_block
+    assert "v.closed_today" in market_block
+    assert "last_updated" not in market_block
+
+
 @pytest.mark.parametrize("holdings", [[], [
     {"ticker": "ZERO", "name": "Z", "is_active": True, "current_value": 0.0},
 ]])


### PR DESCRIPTION
Closes #215

## Outcome

The dashboard health tooltip now shows the same per-holding quote sessions that determine freshness, instead of the stale legacy portfolio last_updated label. Same-session books show one date, mixed-session books show an oldest-to-newest range, missing metadata is explicit, and the closed-market annotation is preserved.

## ROI

This fixes a current user-visible contradiction with one small renderer helper and one focused regression test. It adds no cron, service, network call, model call, or VPS work.

## Verification

- python3 -m pytest tests/test_build_dashboard.py -q --tb=short: 46 passed, 1 expected xfail
- node --check assets/js/dashboard.render.js
- git diff --check