### PR TITLE
fix(ci): restore Cron Health pre-open window

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -1,11 +1,12 @@
 name: Cron Health Check
 
-# 17:00 HKT = 09:00 UTC 工作日 — 港股收盘后、美股开盘前 一窗口
+# 17:17 HKT = 09:17 UTC 工作日 — 港股收盘后、美股开盘前 一窗口。
+# 避开整点：GitHub 官方说明整点高负载会延迟甚至丢弃 scheduled runs。
 # 报告任务对 git 产物；盘中任务对逐 slot heartbeat
 # 缺漏 → workflow fail（Actions 可见；不做 README 首屏 badge）
 on:
   schedule:
-    - cron: '0 9 * * 1-5'
+    - cron: '17 9 * * 1-5'
   workflow_dispatch:
 
 permissions:

--- a/tests/test_workflow_health.py
+++ b/tests/test_workflow_health.py
@@ -76,7 +76,7 @@ def test_cadence_is_read_from_the_cron_expression(exprs, hours):
 
 def test_a_weekday_job_is_not_overdue_across_a_weekend():
     """Monday 07:00 rollup looking at a Friday run must stay quiet."""
-    row = wh.assess("cron-health.yml", ["0 9 * * 1-5"], [run("success", 2.9)], NOW)
+    row = wh.assess("cron-health.yml", ["17 9 * * 1-5"], [run("success", 2.9)], NOW)
     assert row["overdue_hours"] is None
 
 


### PR DESCRIPTION
Closes #217.

Moves only Cron Health Check from minute 0 to 09:17 UTC / 17:17 HKT. The five latest weekday runs were delayed 125-200 minutes (median about 144 minutes), matching GitHub documented top-of-hour congestion behavior.

Scope is intentionally narrow:
- same weekday cadence and health semantics
- no extra Actions runs
- no VPS changes
- no changes to Brief Fallback or any off-host fallback schedule
- updates the existing schedule assertion instead of adding a new test family

Local verification: 15 workflow-health tests passed; diff check passed. Actionlint runs in GitHub CI.