### PR TITLE
perf(dashboard): skip off-screen mobile panel layout

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -279,8 +279,18 @@
       overflow-x: hidden; overflow-y: auto; overscroll-behavior-y: contain;
       scroll-snap-align: start; scroll-snap-stop: always;
       padding: var(--space-4);
+      /* Keep every panel box in the horizontal pager so native swipe/snap geometry
+         stays intact, but let Chromium skip inner work for off-screen panels. Keep
+         a viewport-height intrinsic block so revealing a skipped subtree cannot
+         momentarily collapse its scroll geometry and create a layout shift. */
+      content-visibility: auto;
+      contain-intrinsic-block-size: auto 100dvh;
       -webkit-overflow-scrolling: touch;
     }
+    /* The current page must be visible from the first layout. Leaving `auto` on
+       Hero can make Chrome reveal the whole pager a frame late under CPU load,
+       which is observable as a large CLS even though the inactive pages benefit. */
+    .panel.active { content-visibility: visible; }
     /* visually hidden but kept in the a11y tree so the heading sequence stays h1→h2→h3
        (display:none would drop the h2 → axe/screen-readers see an h1→h3 skip). NOTE: must
        stay IN FLOW — position:absolute here escapes the horizontal scroll-snap pager and


### PR DESCRIPTION
Closes #221.

## What changed

- Keep all six mobile panel boxes in the native horizontal scroll-snap pager.
- Let Chromium skip style/layout/paint for off-screen panel contents with `content-visibility:auto`.
- Preserve stable skipped geometry with a viewport-height intrinsic block size.
- Force the active panel visible from the first layout; this avoids the large pager CLS observed in the first containment experiment.

No data, renderer, chart, schedule, publishing, or desktop layout behavior changes.

## Measured result

Sequential Lighthouse mobile runs against the same localhost server/Chromium, three before and three after:

| metric | before median | after median | change |
|---|---:|---:|---:|
| Performance | 58 | 64 | +6 |
| LCP | 3.52s | 3.02s | -14% |
| TBT | 4.99s | 3.29s | -34% |
| main-thread work | 12.47s | 9.08s | -27% |
| Style & Layout | 6.84s | 5.44s | -20% |
| CLS | 0.0097 | 0.0097 | unchanged |

The discarded first experiment is important: `content-visibility:auto` without stable intrinsic/active geometry improved TBT but produced CLS as high as 1.0. The final rules were retained only after all three runs returned to baseline CLS.

## Verification

- `pytest -q tests/test_dashboard_desktop_layout_contract.py tests/test_dashboard_payload_size.py` — 19 passed (generated build outputs restored; not included in the commit).
- Existing `shoot_dashboard.js` against the branch: all six mobile tabs captured 6/6/6/6/6/6 scroll frames; desktop Reflect chart and light social-card capture completed.
- Playwright mobile traversal: every tab snapped to the exact 400px page boundary, became `content-visibility:visible`, had complete text, and had zero horizontal overflow.
- Playwright desktop deep link `#market`: exactly one panel displayed and zero page overflow.
- `git diff --check` clean.
- Pre-push system check: 16 checks passed; the fail-closed secret scan alone timed out at its 10s process deadline. Re-ran the identical worktree + HEAD patterns with a 120s deadline: both returned rc=1 / zero matches. GitHub Secret Scanning and Push Protection are enabled.

No new test family or committed performance artifact was added.
