### PR TITLE
perf(dashboard): skip unchanged poll renders

### DIFF
--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -230,7 +230,7 @@
   function _fetchSidecar(k, triggeredByUser, requestStamp) {
     const state = _sidecarState(k);
     if (state.inFlight) return state.inFlight;
-    if (state.ready && !state.stale) return Promise.resolve(state.value);
+    if (state.ready && !state.stale) return Promise.resolve(false);
 
     const bust = triggeredByUser ? "?t=" + requestStamp : "";
     state.inFlight = fetch("assets/data/" + k + ".json" + bust, {
@@ -238,10 +238,14 @@
     }).then(async response => response.ok ? await response.json() : null)
       .catch(() => null)
       .then(value => {
+        // Sidecars publish independently from dashboard.json. Revalidate them,
+        // but do not replay a tab's DOM when its serialized value is identical
+        // to the value it already rendered.
+        const changed = !state.ready || JSON.stringify(value) !== JSON.stringify(state.value);
         state.value = value;
         state.ready = true;
         state.stale = false;
-        return value;
+        return changed;
       })
       .finally(() => { state.inFlight = null; });
     return state.inFlight;
@@ -249,9 +253,11 @@
 
   async function _loadTabSidecars(t, triggeredByUser = false) {
     const keys = _sidecarsForTab(t);
-    if (!keys.length) return;
+    if (!keys.length) return false;
     const requestStamp = Date.now();
-    await Promise.all(keys.map(k => _fetchSidecar(k, triggeredByUser, requestStamp)));
+    const changed = await Promise.all(
+      keys.map(k => _fetchSidecar(k, triggeredByUser, requestStamp)));
+    return changed.some(Boolean);
   }
 
   function _paintActivatedTab(t) {
@@ -341,16 +347,21 @@
       } else {
         _markLoadedSidecarsStale();
       }
-      _applySidecars(json);
       const newAt = json.generated_at;
       const hasNew = newAt && newAt !== LAST_LOADED_AT;
-      DATA = json;
-      render();
+      if (firstLoad || hasNew) {
+        _applySidecars(json);
+        DATA = json;
+        render();
+      }
+      // An unchanged generation still updates relative-time copy and refresh
+      // feedback, but must not replace DATA or replay the same DOM every minute.
       _updateAgeLabel();
       if (!firstLoad && _sidecarsForTab(landing).length) {
-        _loadTabSidecars(landing, triggeredByUser).then(() => {
-          if (DATA !== json || currentTab() !== landing) return;
-          _applySidecars(json);
+        const expectedData = DATA;
+        _loadTabSidecars(landing, triggeredByUser).then(sidecarsChanged => {
+          if (!sidecarsChanged || DATA !== expectedData || currentTab() !== landing) return;
+          _applySidecars(DATA);
           refreshTab(landing);
         });
       }

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -206,7 +206,7 @@
   function _sidecarState(k) {
     if (!SIDECAR_STATE.has(k)) {
       SIDECAR_STATE.set(k, {
-        value: null, ready: false, stale: true, inFlight: null,
+        value: null, serialized: null, ready: false, stale: true, inFlight: null,
       });
     }
     return SIDECAR_STATE.get(k);
@@ -241,8 +241,10 @@
         // Sidecars publish independently from dashboard.json. Revalidate them,
         // but do not replay a tab's DOM when its serialized value is identical
         // to the value it already rendered.
-        const changed = !state.ready || JSON.stringify(value) !== JSON.stringify(state.value);
+        const serialized = JSON.stringify(value);
+        const changed = !state.ready || serialized !== state.serialized;
         state.value = value;
+        state.serialized = serialized;
         state.ready = true;
         state.stale = false;
         return changed;

--- a/tests/test_dashboard_tab_lifecycle.py
+++ b/tests/test_dashboard_tab_lifecycle.py
@@ -46,12 +46,19 @@ def test_tab_activation_owns_sidecar_fetch_and_inflight_deduplication():
     assert "new Set(deferred" not in UI
 
 
-def test_poll_marks_inactive_data_stale_and_refreshes_only_the_active_tab():
+def test_poll_skips_unchanged_core_and_refreshes_only_changed_active_sidecars():
     load = UI.split("async function loadData", 1)[1].split(
         "function _scheduleAutoRefresh", 1
     )[0]
+    changed_core = load.split("if (firstLoad || hasNew) {", 1)[1].split(
+        "\n      }", 1
+    )[0]
+    assert "DATA = json" in changed_core
+    assert "render()" in changed_core
     assert "_markLoadedSidecarsStale()" in load
     assert "_loadTabSidecars(landing, triggeredByUser)" in load
+    assert "if (!sidecarsChanged" in load
+    assert "return changed.some(Boolean)" in UI
     assert "currentTab() !== landing" in load
     assert "refreshTab(landing)" in load
 


### PR DESCRIPTION
Closes #222.

## What changed

- Treat an already-rendered `dashboard.json` generation as a metadata-only result: keep `DATA`, skip `render()`, and update only relative time / refresh feedback.
- Keep independent sidecar freshness: loaded sidecars are still marked for revalidation, but only the active tab is fetched.
- Have sidecar fetches report whether their serialized value changed; replay only the active tab renderer when at least one active sidecar actually changed.
- Extend the existing tab-lifecycle contract with this one no-op boundary; no new test file or matrix.

The 60-second cadence, pause-while-hidden behavior, manual cache-buster, first load, new-generation render, and inactive-tab activation behavior are unchanged.

## Browser behavior proof

A Playwright route harness served controlled generations and counted the real global `render` / `refreshTab` calls:

| scenario | core `render()` | active `refreshTab()` |
|---|---:|---:|
| same core on Hero | 0 | 0 |
| newer core on Hero | 1 | 0 |
| same core + unchanged five Market sidecars | 0 | 0 |
| same core + macro sidecar only changed | 0 | 1 |

The last scenario also verified `DATA.macro.generated_at` advanced to the independently published generation. All intercepted first-party responses were successful.

## Verification

- `node --check assets/js/dashboard.ui.js`
- `pytest -q tests/test_dashboard_tab_lifecycle.py tests/test_dashboard_desktop_layout_contract.py` — 11 passed
- `git diff --check`
- Pre-push system check: 16 checks passed; the fail-closed repository secret grep again exceeded its 10s subprocess deadline. The identical worktree + HEAD patterns completed with a 120s deadline, both rc=1 / zero matches. GitHub Secret Scanning and Push Protection remain enabled.

## Issue clarification

The original acceptance wording said not to mark unrelated inactive sidecars stale. Investigation showed that boolean stale marker is what makes the next activation revalidate an independently published sidecar; removing it would trade performance for stale data. The issue was corrected before implementation: unchanged polls do not *fetch or render* inactive sidecars, while retaining the cheap stale marker.
