### PR TITLE
fix(dashboard): show HK drawdown amount fallback

### DIFF
--- a/assets/js/dashboard.charts.js
+++ b/assets/js/dashboard.charts.js
@@ -587,7 +587,15 @@
         return `<span style="color:${line.color}">●</span> ${escapeHtml(line.name)}: <b>${finite(v) ? moneyTip(v, model.cur) : DASH}</b>`;
       });
       const dd = model.dd[hoverIndex];
-      rows.push(`<span style="color:${model.negative}">●</span> 回撤: <b>${finite(dd) ? Number(dd).toFixed(2) + "%" : DASH}</b>`);
+      const ddAbs = model.ddAbs[hoverIndex];
+      let ddText = DASH;
+      if (finite(dd)) ddText = Number(dd).toFixed(2) + "%";
+      else if (finite(ddAbs)) {
+        const amount = Number(ddAbs);
+        ddText = `${amount < 0 ? "−" : ""}${moneyTip(Math.abs(amount), model.cur)}` +
+          ` <span class="muted">(% 不适用)</span>`;
+      }
+      rows.push(`<span style="color:${model.negative}">●</span> 回撤: <b>${ddText}</b>`);
       const change = model.change[hoverIndex];
       if (finite(change)) {
         const sign = Number(change) >= 0 ? "+" : "-";
@@ -740,11 +748,17 @@
 
     // 回撤 — 用 PROFIT(净化本金) 口径而非 净值。净值会被加仓虚抬(花掉的现金不计),
     // 使回撤恒显示 ~0%(假新高);profit 是 trade-invariant 的真回撤,与下方"历史利润极值"
-    // 卡一致。% 仅在利润全程为正时给(running peak>0 且当前>0),否则 null=无红色填充。
+    // 卡一致。% 仅在利润峰值和当前利润都为正时给，否则 null=无红色填充。
+    // 负利润阶段仍保留“峰值至当前”的金额差，tooltip 用它代替误导的负分母 %。
     let peak = -Infinity;
+    const ddAbs = [];
     const ddPct = profit.map(v => {
-      if (v == null) return null;
+      if (v == null) {
+        ddAbs.push(null);
+        return null;
+      }
       if (v > peak) peak = v;
+      ddAbs.push(r2(v - peak));
       return (peak > 0 && v > 0) ? Math.round(((v - peak) / peak) * 10000) / 100 : null;
     });
     // 总利润较昨日 — 用总利润(trade-invariant)算日变化，在 tooltip 与"回撤"分列，
@@ -810,7 +824,7 @@
       `恒科200线触发 ${Math.round(hstech200)}` +
       (reclaimPct != null ? `（需${reclaimPct >= 0 ? "+" : ""}${reclaimPct.toFixed(0)}%）` : "");
     charts.equity.setModel({
-      view, dates, lines, dd: ddPct, change: chg, changePct: chgPct, cur,
+      view, dates, lines, dd: ddPct, ddAbs, change: chg, changePct: chgPct, cur,
       positive: green, negative: red, warning: hkColor,
       triggerLevel: triggerLvl, triggerLabel,
     });

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -173,6 +173,18 @@ async function testEquityTouch(browser, base) {
   await page.waitForTimeout(100);
   assert(await page.locator(".native-equity-tooltip").isVisible(), "chart tap did not open its tooltip");
 
+  await page.locator('.mkt-seg-btn[data-mkt="hk"]').first().click();
+  await page.waitForFunction(() =>
+    document.querySelector("#equity-title")?.textContent.includes("港股 HKD"));
+  await dispatchTouch(session, "touchStart", [{ x: box.x + box.width / 2, y }]);
+  await dispatchTouch(session, "touchEnd", []);
+  await page.waitForTimeout(100);
+  const hkTooltip = await page.locator(".native-equity-tooltip").innerText();
+  assert.match(hkTooltip, /回撤:\s*(?:−?HK\$[\d,]+|[-\d.]+%)/,
+    "HK drawdown still rendered as an empty dash");
+  assert.match(hkTooltip, /% 不适用/,
+    "negative-profit HK drawdown did not explain its amount fallback");
+
   const xs = [box.x + box.width - 5, 300, 250, 200, 150, 100, 45];
   await dispatchTouch(session, "touchStart", [{ x: xs[0], y }]);
   for (const x of xs.slice(1)) {


### PR DESCRIPTION
## Why

The Equity Curve intentionally suppresses percentage drawdown when the running profit peak or current profit is non-positive. HK profit is underwater across the visible history, so a percentage would use a negative denominator and can produce economically misleading values such as -600% — but the tooltip rendered that valid “not applicable” state as an unexplained dash on every point.

## What changed

- retain the existing profit-based drawdown semantics and percentage guard
- carry the absolute peak-to-current profit difference alongside the percentage series
- show the HKD amount plus `% 不适用` when the percentage is not meaningful
- add a mobile Chromium assertion that selects 港股 HKD, taps the canvas, verifies a non-empty amount fallback, then still swipes the pager cleanly

## Verification

- Chromium runtime spec passed (Overview/detail lifecycle, deep links, generation retry, Equity tap/HK fallback/swipe)
- 16 targeted tests passed
- JS syntax and diff checks passed
- pre-push system check: 16 OK; built-in 10 s secret scan timed out, exact worktree + HEAD scans rerun with 120 s and returned zero matches
