### PR TITLE
data: share one bar-validation contract across fetchers (#236)

### DIFF
--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -93,6 +93,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 |---|---|---|:---:|
 | `fetch_fx.py` | USDHKD 汇率 · 3 路 fallback | Frankfurter(ECB) → 备用 | ✅ |
 | `preflight_integrity.py` | 数据不变量硬闸: TCV / PNL / FX / cash 对账 | 本地 | ✅ |
+| `bar_checks.py` | bar/quote **判据唯一真源**:结构不可能(fatal) vs 可疑(flag,含 o==h==l==c 退化区间)、同源区间越界、gap-safe 收益(停牌不填 0)。策略仍由各 fetcher 自己定 | 纯本地(无 I/O) | ✅ |
 | `research_provenance.py` | 研究报告 Decimal 计算、两源数字溯源与 fail-closed 准出（tolerance 上限 5%，算式异常也只输出结构化 fail） | 结构化 manifest + 本地确定性校验 | ✅ |
 | `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 | `earnings_review.py` | 一手财报复盘:来源分级、盈利质量数学、管理层承诺账本、provenance 准出与 thesis 证据交接 | `memory/earnings/*/*.json` + 本地确定性校验 | ✅ |

--- a/scripts/data/analyze_hk_stocks.py
+++ b/scripts/data/analyze_hk_stocks.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bar_checks  # noqa: E402  shared "is this bar believable" contract
 from _em_http import em_get  # noqa: E402
 from instrument_registry import INSTRUMENTS  # noqa: E402
 
@@ -402,12 +403,12 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
         # 07226 +2.64% 方向相反）。非致命：照常写入但收集告警，刷新结束打印汇总，靠人工
         # 体检 / dashboard 异常卡兜底（kcn 不要单次 cron 即时推送告警）。
         lo_q, hi_q = q.get('l'), q.get('h')
-        if lo_q and hi_q and c:
-            tol = max(0.005, c * 0.002)   # 容差，防浮点/取整误报
-            if c < lo_q - tol or c > hi_q + tol:
-                range_warns.append(
-                    f"{code} {q.get('name','')[:6]}: current {c} 越出当日区间 "
-                    f"[{lo_q}, {hi_q}]（prev_close {pc}，疑似坏 tick）")
+        # 判据搬到 bar_checks（同一套容差、同一套定义），策略仍留在这里：告警不致命。
+        breach = bar_checks.price_outside_quoted_range(c, lo_q, hi_q)
+        if breach:
+            range_warns.append(
+                f"{code} {q.get('name','')[:6]}: current {c} 越出当日区间 "
+                f"[{lo_q}, {hi_q}]（prev_close {pc}，疑似坏 tick — {breach}）")
 
         h['current_price']    = round(c, 3)
         h['prev_close']       = round(pc, 3)

--- a/scripts/data/bar_checks.py
+++ b/scripts/data/bar_checks.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""One shared contract for "is this bar believable", used by every fetcher.
+
+Why this exists
+---------------
+Each fetcher grew its own idea of a bad bar, and the strongest check ended up
+guarding the weakest place:
+
+* `fetch_daily_bars.sane()` — the gate on the **canonical** store the decision
+  ledger settles against — only checked ordering (`low <= open,close <= high`,
+  positive prices). A bar where `open == high == low == close` passes that
+  cleanly.
+* `fetch_us_stocks` has warned about exactly that shape mid-session since the
+  2026-05-29 stale-quote swap, because a provider that manufactures it is how
+  the US zero-change bug happened.
+* `analyze_hk_stocks` carries a third rule: the live price must fall inside the
+  same quote's own `[low, high]`, after a provider bad tick put 03033 below its
+  day range while its 2x sibling moved the other way.
+
+Three detectors, three files, no shared definition — so the canonical store
+accepted the very shape the live path alarms on.
+
+What is shared, and what is not
+-------------------------------
+**Detection** is shared: this module decides what is structurally impossible and
+what is merely suspicious. **Policy** stays with the caller, because it really
+does differ — a degenerate bar is a bug in a live regular-session quote and is
+perfectly legitimate for a halted or untraded session.
+
+Findings are graded:
+
+* `fatal` — the bar cannot be true of any real session (close outside
+  `[low, high]`, non-positive price, a non-finite number). Callers reject.
+* `flags` — the bar may be true but is worth carrying forward
+  (`degenerate_range`, `implausible_move`, `stale_session`). Callers record and
+  surface; they must not silently drop the bar, and they must not silently
+  invent a range for it either.
+
+Stdlib only, no I/O: every fetcher imports this, including the ones that run
+before numpy is available.
+"""
+from __future__ import annotations
+
+import math
+
+# Scripts that ingest bars or quotes and must route detection through this
+# module. `tests/test_bar_checks.py` fails when one of them stops importing it,
+# so a future fetcher cannot quietly re-grow a private copy of these rules.
+BAR_CONSUMERS = (
+    'fetch_daily_bars.py',
+    'fetch_us_stocks.py',
+    'analyze_hk_stocks.py',
+)
+
+# A live quote may sit this far outside its own reported [low, high] before it
+# counts as a bad tick — absolute floor plus a relative term, so a HK$0.5 name
+# is not flagged by rounding alone. Taken from the existing analyze_hk_stocks
+# guard so behaviour there is unchanged.
+RANGE_TOLERANCE_ABS = 0.005
+RANGE_TOLERANCE_REL = 0.002
+
+# Session-over-session move beyond this is flagged, never rejected: real names
+# do move 50% on a takeover. It is here so one definition covers every market.
+IMPLAUSIBLE_MOVE_PCT = 50.0
+
+_OHLC_KEYS = ('open', 'high', 'low', 'close')
+
+
+def _finite_number(value):
+    """Return the value as a finite float, or None if it is not one."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+def range_tolerance(price: float) -> float:
+    """Absolute tolerance allowed when testing a price against a quoted range."""
+    return max(RANGE_TOLERANCE_ABS, abs(price) * RANGE_TOLERANCE_REL)
+
+
+def is_degenerate(bar) -> bool:
+    """True when open == high == low == close.
+
+    Not an error on its own. It is what a halted or never-traded session looks
+    like, and it is also what a frozen provider quote looks like — which is why
+    the caller, not this function, decides what to do about it.
+    """
+    values = [_finite_number(bar.get(k)) for k in _OHLC_KEYS]
+    if any(v is None for v in values):
+        return False
+    return values[0] == values[1] == values[2] == values[3]
+
+
+def check_bar(bar, *, prev_close=None, session_date=None, last_closed=None):
+    """Grade one OHLC bar. Returns `{'fatal': [...], 'flags': [...]}`.
+
+    Args:
+        bar: mapping with `open`/`high`/`low`/`close`, optionally `date`.
+        prev_close: previous session's close, for the move check.
+        session_date: the session this bar claims to belong to; compared with
+            `bar['date']` when both are present.
+        last_closed: newest session that has finished. A bar dated after it is
+            a live bar wearing a completed session's clothes.
+    """
+    fatal: list[str] = []
+    flags: list[str] = []
+
+    values = {}
+    for key in _OHLC_KEYS:
+        value = _finite_number(bar.get(key))
+        if value is None:
+            fatal.append(f'{key} is missing or not a finite number: {bar.get(key)!r}')
+        else:
+            values[key] = value
+
+    if len(values) == len(_OHLC_KEYS):
+        low, high = values['low'], values['high']
+        if low > high:
+            fatal.append(f'low {low} above high {high}')
+        for key in ('open', 'close'):
+            if not (low <= values[key] <= high):
+                fatal.append(f'{key} {values[key]} outside [{low}, {high}]')
+        if low <= 0 or high <= 0:
+            fatal.append(f'non-positive price in [{low}, {high}]')
+
+        if not fatal and is_degenerate(bar):
+            flags.append('degenerate_range')
+
+        previous = _finite_number(prev_close)
+        if previous and previous > 0 and not fatal:
+            move_pct = abs(values['close'] / previous - 1) * 100
+            if move_pct > IMPLAUSIBLE_MOVE_PCT:
+                flags.append(f'implausible_move {move_pct:.1f}%')
+
+    bar_date = bar.get('date')
+    if bar_date and session_date and str(bar_date)[:10] != str(session_date)[:10]:
+        flags.append(f'session_mismatch bar={bar_date} session={session_date}')
+    if bar_date and last_closed and str(bar_date)[:10] > str(last_closed)[:10]:
+        flags.append(f'unfinished_session bar={bar_date} last_closed={last_closed}')
+
+    return {'fatal': fatal, 'flags': flags}
+
+
+def is_structurally_sane(bar) -> bool:
+    """The old `fetch_daily_bars.sane()` predicate, now one call site of many."""
+    return not check_bar(bar)['fatal']
+
+
+def price_outside_quoted_range(price, low, high):
+    """Reason string when a live price falls outside its own quote's range.
+
+    Same-quote comparison only: a stored `day_low`/`day_high` from an earlier
+    fetch is a different vintage and cannot judge this print.
+    """
+    price = _finite_number(price)
+    low = _finite_number(low)
+    high = _finite_number(high)
+    if price is None or low is None or high is None:
+        return None
+    if low <= 0 or high <= 0:
+        return None
+    tol = range_tolerance(price)
+    if price < low - tol:
+        return f'{price} below quoted low {low}'
+    if price > high + tol:
+        return f'{price} above quoted high {high}'
+    return None
+
+
+def gap_safe_returns(bars, *, skip_degenerate: bool = True):
+    """Close-to-close returns with halted sessions omitted, not zeroed.
+
+    A halted or untraded session has no return to observe. Emitting `0.0` for it
+    — which is what forward-filling a close does — is not a neutral choice: it
+    injects a zero-variance observation and deflates realised volatility, and
+    volatility is an input to the leverage dial. Omitting the session says "no
+    observation" instead of "the price did not move".
+
+    Args:
+        bars: date-ordered sequence of bar mappings, or a `{date: bar}` mapping.
+        skip_degenerate: drop sessions whose OHLC has collapsed to one price.
+
+    Returns:
+        List of `(date, return)` pairs. The return spans whatever gap the
+        omissions leave, so it stays a true close-to-close move.
+    """
+    if isinstance(bars, dict):
+        ordered = [dict(bar, date=date) for date, bar in sorted(bars.items())]
+    else:
+        ordered = list(bars)
+
+    usable = []
+    for bar in ordered:
+        close = _finite_number(bar.get('close'))
+        if close is None or close <= 0:
+            continue
+        if skip_degenerate and is_degenerate(bar):
+            continue
+        usable.append((bar.get('date'), close))
+
+    out = []
+    for (_, previous), (date, close) in zip(usable, usable[1:]):
+        out.append((date, close / previous - 1))
+    return out

--- a/scripts/data/fetch_daily_bars.py
+++ b/scripts/data/fetch_daily_bars.py
@@ -55,6 +55,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bar_checks  # noqa: E402  shared "is this bar believable" contract
 from _em_http import em_get  # noqa: E402  统一请求节流出口
 
 WS = Path(__file__).resolve().parents[2]
@@ -185,9 +186,15 @@ def fetch_em_audit(secid: str, beg: str, end: str) -> list[dict]:
 
 
 def sane(b: dict) -> bool:
-    """low <= open,close <= high, and nothing free."""
-    return (b["low"] <= b["open"] <= b["high"] and b["low"] <= b["close"] <= b["high"]
-            and b["low"] > 0 and b["high"] > 0)
+    """low <= open,close <= high, and nothing free.
+
+    Detection now lives in `bar_checks` so this store and the live-quote paths
+    share one definition. The policy stays here and is unchanged: a bar that
+    cannot be true of any session is refused. What changed is that a *degenerate*
+    bar (o==h==l==c) is no longer indistinguishable from a healthy one — see
+    `merge`, which stores it with a flag instead of pretending it had a range.
+    """
+    return bar_checks.is_structurally_sane(b)
 
 
 def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[str]]:
@@ -204,11 +211,20 @@ def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[
         d = b["date"]
         if d > last_closed:
             continue                      # session not finished — never store a live bar
-        if not sane(b):
-            conflicts.append(f"{d}: insane OHLC {b}")
+        verdict = bar_checks.check_bar(b)
+        if verdict["fatal"]:
+            conflicts.append(f"{d}: insane OHLC {b} ({'; '.join(verdict['fatal'])})")
             continue
         rec = {"open": b["open"], "high": b["high"], "low": b["low"], "close": b["close"],
                "source": "tencent", "adjustment": "raw", "fetched_at": now}
+        # A bar whose OHLC collapsed to a single price is legitimate for a halted
+        # or untraded session and is also the signature of a frozen provider
+        # quote. We cannot tell which from the bar alone, so it is stored with
+        # the flag rather than dropped (settlement still needs the close) — and
+        # never silently, because a trigger that "fired" inside a zero-width
+        # range is not evidence of anything.
+        if "degenerate_range" in verdict["flags"]:
+            rec["degenerate"] = True
         old = bars.get(d)
         if old is None:
             bars[d] = rec

--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -29,6 +29,7 @@ from zoneinfo import ZoneInfo
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bar_checks  # noqa: E402  shared "is this bar believable" contract
 from _em_http import em_get  # noqa: E402
 from instrument_registry import INSTRUMENTS  # noqa: E402
 import trading_calendar  # noqa: E402
@@ -1101,7 +1102,8 @@ def update_us_portfolio(
         # a real signal from the provider rather than our own fabrication.
         if 9 <= now_et.hour < 16:
             o_, h_, l_ = q.get('o'), q.get('h'), q.get('l')
-            if None not in (o_, h_, l_) and o_ == h_ == l_ == q['c']:
+            if None not in (o_, h_, l_) and bar_checks.is_degenerate(
+                    {'open': o_, 'high': h_, 'low': l_, 'close': q['c']}):
                 print(f"  ⚠ {t}: degenerate range (o=h=l=c=${q['c']:.4f}) mid-session "
                       f"— possible stale quote (run with US_FETCH_DEBUG=1 to capture payload)",
                       file=sys.stderr)

--- a/tests/test_bar_checks.py
+++ b/tests/test_bar_checks.py
@@ -1,0 +1,259 @@
+"""One definition of "bad bar", shared by every fetcher.
+
+The defect this guards: `fetch_daily_bars.sane()` — the gate on the canonical
+store the decision ledger settles against — accepted `open == high == low ==
+close` without comment, while `fetch_us_stocks` has alarmed on exactly that
+shape since the 2026-05-29 stale-quote swap. The strongest detector guarded the
+live path; the weakest one guarded the store that settles trigger verdicts.
+
+Run: python3 -m pytest tests/test_bar_checks.py -q
+"""
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / 'scripts' / 'data'
+sys.path.insert(0, str(DATA))
+
+import bar_checks  # noqa: E402
+
+
+def _bar(o, h, l, c, **extra):
+    return {'open': o, 'high': h, 'low': l, 'close': c, **extra}
+
+
+# ── structural checks ───────────────────────────────────────────────────────
+
+def test_a_healthy_bar_has_no_findings():
+    assert bar_checks.check_bar(_bar(10, 12, 9, 11)) == {'fatal': [], 'flags': []}
+
+
+@pytest.mark.parametrize('bar, needle', [
+    (_bar(10, 9, 11, 10), 'above high'),          # low > high
+    (_bar(13, 12, 9, 11), 'open 13.0 outside'),   # open above high
+    (_bar(10, 12, 9, 8), 'close 8.0 outside'),    # close below low
+    (_bar(0, 0, 0, 0), 'non-positive'),
+    (_bar(10, 12, -1, 11), 'non-positive'),
+])
+def test_impossible_bars_are_fatal(bar, needle):
+    fatal = bar_checks.check_bar(bar)['fatal']
+    assert fatal, f'{bar} was accepted'
+    assert any(needle in reason for reason in fatal), fatal
+
+
+@pytest.mark.parametrize('value', [None, 'n/a', float('nan'), float('inf')])
+def test_a_missing_or_non_finite_price_is_fatal(value):
+    assert bar_checks.check_bar(_bar(10, 12, 9, value))['fatal']
+
+
+# ── the gap this issue is about ─────────────────────────────────────────────
+
+def test_a_degenerate_bar_is_flagged_not_silently_accepted():
+    """o==h==l==c passes every ordering rule. That is exactly why the old
+    `sane()` let it into the canonical store without a word."""
+    verdict = bar_checks.check_bar(_bar(4.2, 4.2, 4.2, 4.2))
+
+    assert verdict['fatal'] == [], 'a halted session is not an impossible bar'
+    assert 'degenerate_range' in verdict['flags']
+
+
+def test_the_old_ordering_predicate_still_accepts_a_degenerate_bar():
+    """Pins why the flag had to be added: the structural predicate cannot see
+    this shape, so anything relying on it alone stays blind."""
+    assert bar_checks.is_structurally_sane(_bar(4.2, 4.2, 4.2, 4.2))
+
+
+def test_a_flagged_bar_is_never_reported_as_fatal():
+    """Detection must not become suppression: a halted session is real data and
+    the caller still needs its close to settle against."""
+    for bar in (_bar(4.2, 4.2, 4.2, 4.2), _bar(10, 12, 9, 20.0, )):
+        verdict = bar_checks.check_bar(bar, prev_close=10.0)
+        assert not (verdict['flags'] and verdict['fatal']), verdict
+
+
+def test_an_implausible_move_is_flagged_but_allowed():
+    verdict = bar_checks.check_bar(_bar(10, 21, 10, 20), prev_close=10.0)
+
+    assert verdict['fatal'] == []
+    assert any(f.startswith('implausible_move') for f in verdict['flags'])
+
+
+def test_an_ordinary_move_is_not_flagged():
+    assert bar_checks.check_bar(_bar(10, 11, 10, 10.8), prev_close=10.0)['flags'] == []
+
+
+def test_a_bar_dated_after_the_last_closed_session_is_flagged():
+    verdict = bar_checks.check_bar(
+        _bar(10, 12, 9, 11, date='2026-08-02'), last_closed='2026-08-01')
+
+    assert any('unfinished_session' in f for f in verdict['flags'])
+
+
+def test_a_bar_dated_to_another_session_is_flagged():
+    verdict = bar_checks.check_bar(
+        _bar(10, 12, 9, 11, date='2026-07-30'), session_date='2026-07-31')
+
+    assert any('session_mismatch' in f for f in verdict['flags'])
+
+
+# ── the HK live-quote rule, now shared ──────────────────────────────────────
+
+def test_a_price_below_its_own_quoted_range_is_named():
+    # The 2026-06-15 03033 bad tick: 4.5 printed against a [4.644, 4.696] range.
+    assert bar_checks.price_outside_quoted_range(4.5, 4.644, 4.696)
+
+
+def test_a_price_inside_the_range_or_within_tolerance_is_clean():
+    assert bar_checks.price_outside_quoted_range(4.67, 4.644, 4.696) is None
+    # Rounding must not manufacture a bad tick.
+    assert bar_checks.price_outside_quoted_range(4.6939, 4.644, 4.694) is None
+
+
+def test_an_incomplete_quote_cannot_produce_a_verdict():
+    assert bar_checks.price_outside_quoted_range(4.5, None, 4.696) is None
+    assert bar_checks.price_outside_quoted_range(4.5, 0, 0) is None
+
+
+# ── gap-safe returns ────────────────────────────────────────────────────────
+
+def test_a_halted_session_produces_no_return_instead_of_a_zero():
+    bars = [
+        _bar(10, 10.5, 9.8, 10.0, date='2026-01-02'),
+        _bar(4.2, 4.2, 4.2, 4.2, date='2026-01-03'),   # halted
+        _bar(10.2, 11.0, 10.1, 11.0, date='2026-01-06'),
+    ]
+
+    out = bar_checks.gap_safe_returns(bars)
+
+    assert [d for d, _ in out] == ['2026-01-06']
+    # The surviving return spans the gap, so it is still a true close-to-close move.
+    assert out[0][1] == pytest.approx(11.0 / 10.0 - 1)
+
+
+def test_treating_a_halt_as_a_zero_return_deflates_realised_volatility():
+    """The reason this matters: volatility feeds the leverage dial, so a
+    forward-filled halt does not just add a harmless row — it lowers the number
+    the dial is compared against."""
+    np = pytest.importorskip('numpy')
+    traded = [10.0, 10.6, 9.9, 10.4, 10.1, 10.9]
+    bars = []
+    for i, close in enumerate(traded):
+        bars.append(_bar(close, close * 1.01, close * 0.99, close,
+                         date=f'2026-01-{i + 1:02d}'))
+    # Insert three halted sessions in the middle.
+    for j in range(3):
+        flat = traded[2]
+        bars.insert(3 + j, _bar(flat, flat, flat, flat, date=f'2026-02-{j + 1:02d}'))
+
+    gap_safe = [r for _, r in bar_checks.gap_safe_returns(bars)]
+    forward_filled = [r for _, r in bar_checks.gap_safe_returns(
+        bars, skip_degenerate=False)]
+
+    assert len(forward_filled) > len(gap_safe)
+    assert np.std(forward_filled, ddof=1) < np.std(gap_safe, ddof=1), (
+        'zero-return halt days must deflate measured volatility — if they do '
+        'not, this fixture no longer demonstrates the defect')
+
+
+def test_gap_safe_returns_accept_a_date_keyed_store():
+    """`memory/bars/*.json` stores `{date: bar}`, not a list."""
+    store = {
+        '2026-01-02': _bar(10, 10.5, 9.8, 10.0),
+        '2026-01-03': _bar(10.1, 11.0, 10.0, 11.0),
+    }
+
+    assert bar_checks.gap_safe_returns(store) == [('2026-01-03', pytest.approx(0.1))]
+
+
+def test_a_zero_or_missing_close_cannot_enter_the_return_series():
+    bars = [
+        _bar(10, 10.5, 9.8, 10.0, date='2026-01-02'),
+        _bar(0, 0, 0, 0, date='2026-01-03'),
+        _bar(10.1, 11.0, 10.0, 11.0, date='2026-01-06'),
+    ]
+
+    assert [d for d, _ in bar_checks.gap_safe_returns(bars)] == ['2026-01-06']
+
+
+# ── the flag has to reach the store, not just the checker ───────────────────
+
+def _bars_module(tmp_path, monkeypatch):
+    import fetch_daily_bars
+
+    monkeypatch.setattr(fetch_daily_bars, 'BARS_DIR', tmp_path)
+    monkeypatch.setitem(
+        fetch_daily_bars.MANIFEST, 'TEST',
+        {'leg': 'hk', 'tencent': 'hkTEST', 'em': None, 'retired': False})
+    monkeypatch.setattr(fetch_daily_bars, '_last_closed_session',
+                        lambda leg: '2026-01-31')
+    return fetch_daily_bars
+
+
+def test_a_degenerate_bar_reaches_the_canonical_store_carrying_its_flag(
+        tmp_path, monkeypatch):
+    """It must be stored — settlement needs the close — but never as a bar with
+    a range, because a trigger that "fired" inside a zero-width range is not
+    evidence of anything."""
+    mod = _bars_module(tmp_path, monkeypatch)
+    fresh = [
+        {'date': '2026-01-05', 'open': 10, 'high': 11, 'low': 9.5, 'close': 10.5},
+        {'date': '2026-01-06', 'open': 4.2, 'high': 4.2, 'low': 4.2, 'close': 4.2},
+    ]
+
+    added, revised, conflicts = mod.merge('TEST', fresh, repair=False)
+
+    assert (added, revised, conflicts) == (2, 0, [])
+    stored = mod.load_bars('TEST')['bars']
+    assert stored['2026-01-06']['degenerate'] is True
+    assert 'degenerate' not in stored['2026-01-05']
+
+
+def test_an_impossible_bar_is_still_refused_with_the_reason_named(
+        tmp_path, monkeypatch):
+    mod = _bars_module(tmp_path, monkeypatch)
+    fresh = [{'date': '2026-01-05', 'open': 10, 'high': 9, 'low': 11, 'close': 10}]
+
+    added, _, conflicts = mod.merge('TEST', fresh, repair=False)
+
+    assert added == 0
+    assert conflicts and 'above high' in conflicts[0]
+
+
+# ── the structural gate: nobody re-grows a private copy ─────────────────────
+
+def test_every_declared_consumer_still_routes_through_the_shared_module():
+    for name in bar_checks.BAR_CONSUMERS:
+        path = DATA / name
+        assert path.exists(), f'{name} is registered as a bar consumer but is gone'
+        assert re.search(r'^import bar_checks', path.read_text(), re.M), (
+            f'{name} no longer imports bar_checks — the shared contract has a '
+            'hole exactly where it used to have three private ones')
+
+
+def test_no_script_re_implements_the_degenerate_check_privately():
+    """The failure this whole module exists to prevent: three files, three
+    definitions, and the weakest one guarding the canonical store."""
+    # A chained `a == b == c == d` is the shape of a hand-rolled degenerate-range
+    # test. Matched through the AST, not the text: the prose in these files
+    # legitimately quotes `o == h == l == c` when explaining the bug it caused.
+    offenders = []
+    for path in sorted(DATA.glob('*.py')):
+        if path.name == 'bar_checks.py':
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - the import check owns this
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare) or len(node.ops) < 3:
+                continue
+            if all(isinstance(op, ast.Eq) for op in node.ops):
+                offenders.append(f'{path.name}:{node.lineno}')
+
+    assert not offenders, (
+        'private degenerate-range check(s) outside bar_checks.py:\n'
+        + '\n'.join(offenders))


### PR DESCRIPTION
Closes #236.

Three fetchers had three private definitions of "bad bar", and the strongest detector guarded the weakest place: `fetch_daily_bars.sane()` — the gate on the canonical store the ledger settles against — accepted `open == high == low == close` cleanly, while `fetch_us_stocks` has alarmed on that exact shape since the 2026-05-29 stale-quote swap.

## Design

**Detection is shared, policy is not.** `scripts/data/bar_checks.py` decides what is structurally impossible (`fatal`) versus merely suspicious (`flags`). Each caller keeps its own response, because it genuinely differs: a degenerate bar is a bug in a live regular-session quote and completely legitimate for a halted session.

| caller | policy (unchanged) |
|---|---|
| `fetch_daily_bars` | fatal → refuse with the reason named; degenerate → **store with `degenerate: true`** |
| `fetch_us_stocks` | degenerate mid-session → warn |
| `analyze_hk_stocks` | price outside its own quoted range → collect warning, non-fatal |

A degenerate bar is stored rather than dropped: settlement needs the close, and dropping it would be detection turning into suppression. What it must not do is pass as a bar that had a range — a trigger that "fired" inside a zero-width range is not evidence of anything.

`gap_safe_returns()` gives a halted session no return observation instead of `0.0`. That is not cosmetic: forward-filling injects zero-variance rows and deflates realised volatility, and volatility is one of the two inputs to the leverage dial.

## Two structural gates

- every script in `BAR_CONSUMERS` must still import `bar_checks`;
- no script outside `bar_checks.py` may contain a four-operand chained equality — matched through the **AST**, not the text, because the prose in these files legitimately quotes `o == h == l == c` when explaining the bug it caused. (The regex version of this test failed on its own docstrings.)

## Verification

- All **1499** stored canonical bars pass: 0 fatal, 0 degenerate — this changes no existing settlement.
- `1408 passed, 4 xfailed` locally.
- Mutation-verified: removing the degenerate flag fails 2 tests; keeping halts as zero returns fails 2 more.

## Not done here

Retroactive flagging of already-stored bars. `merge()` short-circuits on an unchanged bar, so the flag only attaches going forward. With 0 degenerate bars in the store today there is nothing to backfill.