### PR TITLE
shadow-portfolio: decompose the policy-vs-buy-and-hold gap into auditable contributions (#232)

### DIFF
--- a/scripts/data/shadow_portfolio.py
+++ b/scripts/data/shadow_portfolio.py
@@ -253,6 +253,26 @@ def _requested_shares(
     return int(math.floor(raw / lot)) * lot
 
 
+def _leg_provenance(decision: dict) -> dict:
+    """The two labels a fill needs to be attributable back to a rule.
+
+    Without them a leg is an anonymous cash movement: the sidecar could say the
+    plan beat buy-and-hold but not which kind of decision did it. `driven_by` is
+    the canonical strategy label (`risk_rule` for disciplinary rebalancing);
+    `execution_status` is whether the real book actually followed.
+
+    `decision_id` is deliberately not published here. Visitors download this
+    sidecar, it measured 7KB across ~200 legs, and nothing reads it — the same
+    argument that removed 27KB of consumer-less calibrator state from the
+    dashboard payload.
+    """
+    return {
+        "driven_by": str(decision.get("driven_by") or "unknown"),
+        "execution_status": str(
+            (decision.get("execution") or {}).get("status") or "unknown"),
+    }
+
+
 def _execute_sell(
     state: dict,
     decision: dict,
@@ -272,6 +292,7 @@ def _execute_sell(
             "ticker": ticker, "direction": "sell", "requested_shares": requested,
             "filled_shares": 0, "price": fill["price"], "status": "skipped_no_inventory",
             "fill_type": fill["type"], "fill_model": fill["model"],
+            **_leg_provenance(decision),
         }
     inventory[ticker] = available - qty
     state["cash"] += qty * fill["price"]
@@ -280,6 +301,7 @@ def _execute_sell(
         "filled_shares": qty, "price": fill["price"], "notional": round(qty * fill["price"], 6),
         "status": "filled" if qty == requested else "partial_inventory_cap",
         "fill_type": fill["type"], "fill_model": fill["model"],
+        **_leg_provenance(decision),
     }
 
 
@@ -303,6 +325,7 @@ def _execute_buy(
             "ticker": ticker, "direction": "buy", "requested_shares": requested,
             "filled_shares": 0, "price": fill["price"], "status": "skipped_no_cash",
             "fill_type": fill["type"], "fill_model": fill["model"],
+            **_leg_provenance(decision),
         }
     cost = qty * fill["price"]
     state["cash"] -= cost
@@ -312,6 +335,7 @@ def _execute_buy(
         "filled_shares": qty, "price": fill["price"], "notional": round(cost, 6),
         "status": "filled" if qty == requested else "partial_cash_cap",
         "fill_type": fill["type"], "fill_model": fill["model"],
+        **_leg_provenance(decision),
     }
 
 
@@ -396,6 +420,131 @@ def _expected_trading_dates(
             dates.append(current.isoformat())
         current += timedelta(days=1)
     return dates
+
+
+def attribute_fills(events: list[dict], final_prices: dict[str, float]) -> dict:
+    """Split the policy-vs-buy-and-hold gap into per-fill contributions.
+
+    Both books start from the same seed and only the followed book trades, so
+    the final gap is exactly the sum of what each fill did to it. For a fill of
+    `q` shares against a final mark `P`:
+
+        buy   →  q·P − notional   (paid `notional`, holds shares worth q·P)
+        sell  →  notional − q·P   (banked `notional`, gave up q·P of stock)
+
+    External cash flows are applied to both books and cancel; every traded
+    ticker is still held by one of the two books at the end, so it always has a
+    final mark. That makes this an identity, not an estimate — which is the
+    whole point. `identity.residual` is published rather than absorbed: a
+    non-zero residual means the simulation and this decomposition disagree, and
+    that is information, not a rounding nuisance.
+
+    Arithmetic only — no LLM, no re-simulation — so every number here is
+    reproducible from the sidecar it ships in.
+
+    Args:
+        events: the `events` list from `simulate_leg`.
+        final_prices: `{ticker: close}` on the final published mark date.
+
+    Returns:
+        JSON-safe dict of contributions grouped by driver, direction, execution
+        status and ticker, plus turnover and the identity check.
+    """
+    by_driver: dict[str, float] = defaultdict(float)
+    by_direction: dict[str, float] = defaultdict(float)
+    by_execution: dict[str, float] = defaultdict(float)
+    by_ticker: dict[str, dict] = {}
+    unpriced: set[str] = set()
+    sell_notional = buy_notional = 0.0
+    filled_legs = 0
+    total = 0.0
+
+    for event in events:
+        for leg_fill in event.get("legs") or []:
+            qty = leg_fill.get("filled_shares") or 0
+            if qty <= 0:
+                continue
+            ticker = str(leg_fill.get("ticker") or "")
+            notional = _number(leg_fill.get("notional")) or 0.0
+            filled_legs += 1
+            if leg_fill.get("direction") == "sell":
+                sell_notional += notional
+            else:
+                buy_notional += notional
+
+            price = _number(final_prices.get(ticker))
+            if price is None or price <= 0:
+                # Never guess a mark: an unpriced ticker breaks the identity and
+                # must say so instead of contributing a silent zero.
+                unpriced.add(ticker)
+                continue
+
+            terminal = qty * price
+            contribution = (
+                notional - terminal if leg_fill.get("direction") == "sell"
+                else terminal - notional
+            )
+            total += contribution
+            by_driver[str(leg_fill.get("driven_by") or "unknown")] += contribution
+            by_direction[str(leg_fill.get("direction") or "unknown")] += contribution
+            by_execution[str(leg_fill.get("execution_status") or "unknown")] += contribution
+            row = by_ticker.setdefault(
+                ticker, {"ticker": ticker, "contribution": 0.0, "fills": 0,
+                         "gross_notional": 0.0})
+            row["contribution"] += contribution
+            row["fills"] += 1
+            row["gross_notional"] += notional
+
+    ranked = sorted(
+        ({**row, "contribution": round(row["contribution"], 2),
+          "gross_notional": round(row["gross_notional"], 2)}
+         for row in by_ticker.values()),
+        key=lambda row: -abs(row["contribution"]),
+    )
+    return {
+        "basis": "per-fill contribution to the final gap, marked to the same "
+                 "canonical closes both books are marked to",
+        "filled_legs": filled_legs,
+        "total_contribution": round(total, 2),
+        "by_driver": {k: round(v, 2) for k, v in sorted(by_driver.items())},
+        "by_direction": {k: round(v, 2) for k, v in sorted(by_direction.items())},
+        "by_execution_status": {k: round(v, 2) for k, v in sorted(by_execution.items())},
+        "by_ticker": ranked,
+        "turnover": {
+            "sell_notional": round(sell_notional, 2),
+            "buy_notional": round(buy_notional, 2),
+            "gross_notional": round(sell_notional + buy_notional, 2),
+        },
+        "unpriced_tickers": sorted(unpriced),
+    }
+
+
+def _attribution_identity(attribution: dict, cumulative_diff) -> dict:
+    """Does the decomposition reproduce the published gap?
+
+    Tolerance is 1 currency unit: the curve is published rounded to cents and
+    every fill contributes its own rounding. Anything larger is a real
+    disagreement between the simulation and this decomposition, and it is
+    published as `closes: false` rather than quietly rescaled to fit.
+    """
+    total = attribution.get("total_contribution")
+    if cumulative_diff is None or total is None:
+        return {"closes": None, "reason": "no published final point"}
+    residual = round(float(cumulative_diff) - float(total), 2)
+    closes = abs(residual) <= 1.0 and not attribution.get("unpriced_tickers")
+    out = {
+        "cumulative_diff": round(float(cumulative_diff), 2),
+        "sum_of_contributions": round(float(total), 2),
+        "residual": residual,
+        "tolerance": 1.0,
+        "closes": closes,
+    }
+    if attribution.get("unpriced_tickers"):
+        out["reason"] = (
+            "traded tickers without a final mark: "
+            + ", ".join(attribution["unpriced_tickers"])
+        )
+    return out
 
 
 def simulate_leg(
@@ -510,6 +659,7 @@ def simulate_leg(
                             "status": "skipped_no_fill_price",
                             "fill_type": "missing",
                             "fill_model": "none",
+                            **_leg_provenance(row),
                         })
                         continue
                     if row.get("action") in SELL_ACTIONS:
@@ -632,6 +782,25 @@ def simulate_leg(
     ]
     final_point = published[-1] if published else None
     final_diff = final_point["cumulative_diff"] if final_point else None
+
+    # Attribution marks every fill to the same closes the final curve point uses,
+    # so the buckets and the headline number cannot drift apart.
+    traded_tickers = {
+        str(leg_fill.get("ticker") or "")
+        for event in events
+        for leg_fill in event.get("legs") or []
+        if (leg_fill.get("filled_shares") or 0) > 0
+    }
+    final_prices = {}
+    if final_point:
+        for ticker in traded_tickers:
+            close = _number((bar_loader(ticker, final_point["date"]) or {}).get("close"))
+            if close is not None:
+                final_prices[ticker] = close
+    attribution = attribute_fills(events, final_prices)
+    attribution["as_of"] = final_point["date"] if final_point else None
+    attribution["identity"] = _attribution_identity(attribution, final_diff)
+
     return {
         "leg": leg,
         "currency": LEG_CONFIG[leg]["currency"],
@@ -640,6 +809,7 @@ def simulate_leg(
         "initial": seed,
         "curve": curve,
         "cumulative_diff": final_diff,
+        "attribution": attribution,
         "final": {
             "followed_sim": final_point["followed_sim"] if final_point else None,
             "buy_and_hold": final_point["buy_and_hold"] if final_point else None,

--- a/tests/test_shadow_portfolio.py
+++ b/tests/test_shadow_portfolio.py
@@ -330,6 +330,153 @@ def test_cumulative_diff_is_followed_minus_buy_hold_with_both_signs():
     assert final_diff(15) == -50
 
 
+# ── attribution: the gap has to say *why*, not just *how much* ──────────────
+
+def _leg(ticker, direction, shares, notional, *, driven_by="technical",
+         execution_status="not_followed"):
+    return {
+        "ticker": ticker, "direction": direction, "filled_shares": shares,
+        "notional": notional, "driven_by": driven_by,
+        "execution_status": execution_status,
+    }
+
+
+def test_attribution_reproduces_the_published_gap_exactly():
+    """The identity is the point: both books start from the same seed and only
+    the followed book trades, so the gap IS the sum of the fills."""
+    portfolio = _portfolio(us_cash=200, us_holdings=[_holding("AAA", 10)])
+    decisions = [_decision("sell", "AAA", "cut", 10, price=10)]
+    bars = {"AAA": {DAY_1: {"close": 10}, DAY_2: {"close": 5}}}
+    bar_loader, bar_map_loader = _loaders(bars)
+
+    result = shadow.simulate_leg(
+        deepcopy(portfolio), decisions, "US",
+        bar_loader=bar_loader, bar_map_loader=bar_map_loader, matched={})
+
+    identity = result["attribution"]["identity"]
+    assert identity["closes"] is True
+    assert identity["residual"] == 0.0
+    assert identity["sum_of_contributions"] == result["cumulative_diff"] == 50.0
+
+
+def test_selling_before_a_fall_contributes_positively_and_a_buy_negatively():
+    sold = shadow.attribute_fills(
+        [{"legs": [_leg("AAA", "sell", 10, 100.0)]}], {"AAA": 5.0})
+    bought = shadow.attribute_fills(
+        [{"legs": [_leg("AAA", "buy", 10, 100.0)]}], {"AAA": 5.0})
+
+    # Banked 100, gave up stock now worth 50.
+    assert sold["total_contribution"] == 50.0
+    # Paid 100 for stock now worth 50.
+    assert bought["total_contribution"] == -50.0
+
+
+def test_buckets_sum_to_the_total_on_every_dimension():
+    events = [{"legs": [
+        _leg("AAA", "sell", 10, 100.0, driven_by="risk_rule",
+             execution_status="followed"),
+        _leg("BBB", "buy", 4, 80.0, driven_by="technical",
+             execution_status="not_followed"),
+    ]}]
+
+    out = shadow.attribute_fills(events, {"AAA": 5.0, "BBB": 30.0})
+
+    total = out["total_contribution"]
+    for dimension in ("by_driver", "by_direction", "by_execution_status"):
+        assert sum(out[dimension].values()) == pytest.approx(total), dimension
+    assert sum(row["contribution"] for row in out["by_ticker"]) == pytest.approx(total)
+
+
+def test_perturbing_one_fill_moves_only_its_own_buckets():
+    base = [{"legs": [
+        _leg("AAA", "sell", 10, 100.0, driven_by="risk_rule"),
+        _leg("BBB", "sell", 10, 100.0, driven_by="technical"),
+    ]}]
+    prices = {"AAA": 5.0, "BBB": 5.0}
+
+    before = shadow.attribute_fills(deepcopy(base), prices)
+    moved = deepcopy(base)
+    moved[0]["legs"][0]["notional"] = 130.0
+    after = shadow.attribute_fills(moved, prices)
+
+    assert after["by_driver"]["risk_rule"] == before["by_driver"]["risk_rule"] + 30
+    assert after["by_driver"]["technical"] == before["by_driver"]["technical"]
+    assert after["total_contribution"] == before["total_contribution"] + 30
+
+
+def test_an_unpriced_ticker_breaks_the_identity_instead_of_contributing_zero():
+    """A silent zero would let the buckets look complete while missing a leg."""
+    events = [{"legs": [_leg("AAA", "sell", 10, 100.0),
+                        _leg("GONE", "sell", 10, 500.0)]}]
+
+    out = shadow.attribute_fills(events, {"AAA": 5.0})
+    identity = shadow._attribution_identity(out, cumulative_diff=50.0)
+
+    assert out["unpriced_tickers"] == ["GONE"]
+    # The unpriced leg contributes nothing at all — not a fabricated mark of 0,
+    # which would have booked its whole notional as if the stock went to zero.
+    assert out["total_contribution"] == 50.0
+    assert [row["ticker"] for row in out["by_ticker"]] == ["AAA"]
+    assert identity["closes"] is False
+    assert "GONE" in identity["reason"]
+
+
+def test_turnover_counts_gross_notional_on_both_sides():
+    events = [{"legs": [_leg("AAA", "sell", 10, 100.0),
+                        _leg("BBB", "buy", 2, 40.0)]}]
+
+    turnover = shadow.attribute_fills(events, {"AAA": 5.0, "BBB": 30.0})["turnover"]
+
+    assert turnover == {"sell_notional": 100.0, "buy_notional": 40.0,
+                        "gross_notional": 140.0}
+
+
+def test_unfilled_legs_contribute_nothing_and_are_not_counted_as_turnover():
+    events = [{"legs": [
+        {"ticker": "AAA", "direction": "sell", "filled_shares": 0,
+         "status": "skipped_no_inventory", "driven_by": "risk_rule"},
+    ]}]
+
+    out = shadow.attribute_fills(events, {"AAA": 5.0})
+
+    assert out["filled_legs"] == 0
+    assert out["total_contribution"] == 0.0
+    assert out["turnover"]["gross_notional"] == 0.0
+
+
+def test_attribution_is_skipped_with_a_reason_when_nothing_was_published():
+    out = shadow.attribute_fills([], {})
+
+    identity = shadow._attribution_identity(out, cumulative_diff=None)
+
+    assert identity["closes"] is None
+    assert "no published final point" in identity["reason"]
+
+
+def test_every_fill_carries_the_provenance_attribution_needs():
+    """Without driven_by and execution_status a leg is an anonymous cash move
+    and the sidecar cannot say which kind of rule earned the gap."""
+    portfolio = _portfolio(us_holdings=[_holding("AAA", 10)])
+    state = {"cash": 0.0, "inventory": {"AAA": 10}}
+    decision = _decision("sell-1", "AAA", "cut", 10)
+    decision["driven_by"] = "risk_rule"
+    fill = {"price": 10.0, "type": "ohlc_assumption", "model": "fixture"}
+
+    leg = shadow._execute_sell(state, decision, fill, portfolio)
+
+    assert leg["driven_by"] == "risk_rule"
+    assert leg["execution_status"] == "not_followed"
+    # decision_id is intentionally absent: 7KB across ~200 legs with no consumer.
+    assert "decision_id" not in leg
+
+
+def test_a_decision_without_a_driver_is_labelled_unknown_not_dropped():
+    leg = shadow._leg_provenance({"decision_id": "x"})
+
+    assert leg["driven_by"] == "unknown"
+    assert leg["execution_status"] == "unknown"
+
+
 def test_expected_sessions_disclose_missing_marks_and_emit_curve_gaps():
     days = [
         "2026-07-13",


### PR DESCRIPTION
Closes #232.

The sidecar published one scalar and nothing about *why*. When the answer came out at "the timing edge is worth 139 HKD" there was no way to see which behaviour produced it.

## The identity

Both books start from the same seed and only the followed book trades, so the final gap **is** the sum of what each fill did to it. For `q` shares against a final mark `P`:

| | contribution |
|---|---|
| buy | `q·P − notional` (paid `notional`, holds stock worth `q·P`) |
| sell | `notional − q·P` (banked `notional`, gave up `q·P` of stock) |

External flows hit both books and cancel; every traded ticker is still held by one of the two books at the end, so it always has a final mark. That makes this an identity rather than an estimate — **arithmetic only**, no LLM, no re-simulation.

**On the live ledger it closes exactly: residual 0.00 on both legs.**

## What it says about the current book

| | USD | HKD |
|---|---|---|
| published gap | −50.35 | +30,096.67 |
| by driver | risk_rule −260.76 · technical +241.17 · catalyst −30.76 | technical +11,696 · peer +9,224 · catalyst +8,592 · risk_rule +585 |
| by execution status | followed +171.56 · not_followed −248.97 · unknown +27.06 | **not_followed +30,096.67** |
| gross turnover | 4,861 | 107,277 |

The HKD line is the finding: the entire simulated HK advantage sits in decisions the real book did **not** execute. That is exactly the kind of statement the old scalar could not make, and it is worth reading before anyone quotes the HK gap as evidence the plan works.

## Honesty properties

- The residual is **published, not absorbed**. An unpriced traded ticker contributes nothing and sets `closes: false` with the ticker named, instead of being marked at a fabricated zero — which would have booked its whole notional as if the stock went to zero while the buckets still looked complete. (The first version of that test passed under a mutant that did exactly this; it now asserts the total too.)
- `turnover` is new — nothing in the repo measured churn before.

## Scope

Buckets are by driver / direction / execution status / ticker. The issue also floated early-exit and late-exit buckets; those need each decision's stated exit condition and a counterfactual hold, which the ledger does not carry, so they are **not** implemented rather than approximated.

## Cost

Sidecar 168.8KB → 191.0KB. `decision_id` is deliberately not published on legs: 7KB across ~200 legs with no consumer — the same argument that removed 27KB of calibrator state from the dashboard payload.

## Verification

`1390 passed, 4 xfailed`. Mutation-verified: collapsing the buy/sell sign fails 3 tests; marking an unpriced ticker at zero fails 1.