### PR TITLE
backtest: emit a run card so quoted numbers can be re-derived (#234)

### DIFF
--- a/memory/backtests/hstech_regime-20260802-f7d80e00.json
+++ b/memory/backtests/hstech_regime-20260802-f7d80e00.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "run_id": "hstech_regime-20260802-f7d80e00",
+  "backtest": "hstech_regime",
+  "generated_at": "2026-08-02T05:41:37+00:00",
+  "git_commit": "3a4047c8",
+  "reproduction_key": "sha256:f7d80e00731db356",
+  "params": {
+    "ma": 200,
+    "vol_cap": 0.5,
+    "vol_n": 20,
+    "crash_window": [
+      "2021-02-01",
+      "2022-10-31"
+    ]
+  },
+  "inputs": [
+    {
+      "symbol": "hkHSTECH",
+      "source": "tencent kline (day, unadjusted)",
+      "bars": 1370,
+      "first_session": "2021-01-04",
+      "last_session": "2026-07-31",
+      "digest": "sha256:3715c002b9d71428"
+    }
+  ],
+  "code": [
+    {
+      "file": "backtest_hstech_regime.py",
+      "digest": "sha256:c3bac1ba94cca7a1"
+    },
+    {
+      "file": "compute_regime.py",
+      "digest": "sha256:f8e8aba58a0629c4"
+    }
+  ],
+  "metrics": {
+    "Buy&Hold 1x (index)": {
+      "total_return": -0.431167,
+      "cagr": -0.096346,
+      "max_drawdown": -0.743999,
+      "max_dd_window": "2021-02-17→2022-10-24",
+      "crash_2021_2022_drawdown": -0.743999,
+      "pct_time_in_market": 100.0,
+      "switches": 0
+    },
+    "Buy&Hold 2x ETF": {
+      "total_return": -0.859672,
+      "cagr": -0.29717,
+      "max_drawdown": -0.95487,
+      "max_dd_window": "2021-02-17→2024-01-31",
+      "crash_2021_2022_drawdown": -0.952912,
+      "pct_time_in_market": 100.0,
+      "switches": 0
+    },
+    "Regime 2x (200DMA)": {
+      "total_return": -0.595986,
+      "cagr": -0.150194,
+      "max_drawdown": -0.704985,
+      "max_dd_window": "2023-01-27→2024-07-16",
+      "crash_2021_2022_drawdown": 0.0,
+      "pct_time_in_market": 35.43,
+      "switches": 56
+    },
+    "Regime+Vol 2x (200DMA,<50%)": {
+      "total_return": -0.495943,
+      "cagr": -0.115753,
+      "max_drawdown": -0.704985,
+      "max_dd_window": "2023-01-27→2024-07-16",
+      "crash_2021_2022_drawdown": 0.0,
+      "pct_time_in_market": 30.53,
+      "switches": 60
+    },
+    "Regime 1x (200DMA, de-levered)": {
+      "total_return": -0.272299,
+      "cagr": -0.055481,
+      "max_drawdown": -0.442024,
+      "max_dd_window": "2023-01-27→2024-07-16",
+      "crash_2021_2022_drawdown": 0.0,
+      "pct_time_in_market": 35.43,
+      "switches": 56
+    }
+  },
+  "notes": [
+    "thresholds are calibrated on this same window; see #233"
+  ],
+  "data_boundary": "derived metrics and source names only; no raw vendor bars"
+}

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -105,6 +105,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 
 | 端点 | 数据 | 源 | 可达 |
 |---|---|---|:---:|
+| `run_card.py` | 每次回测留证：输入序列身份(source/窗口/bar 数/摘要) + 参数 + 代码哈希 + 指标 JSON；`--list` / `--run-id` 复查。落 `memory/backtests/` | 纯本地 | ✅ |
 | `backtest_hstech_regime.py` | 恒科 regime 去杠杆回测(2021→今) | 腾讯 kline | ✅ |
 | `backtest_us_leverage.py` | 美股 2x ETF regime 回测 | 日线模拟 | ✅ |
 | `backtest_combined_regime.py` | 全组合 regime vs buy&hold vs 全 1x | 因子代理历史 | ✅ |

--- a/scripts/data/backtest_combined_regime.py
+++ b/scripts/data/backtest_combined_regime.py
@@ -20,6 +20,8 @@ Run: python3 scripts/data/backtest_combined_regime.py
 """
 import json
 import math
+import os
+import sys
 from datetime import date
 from pathlib import Path
 
@@ -35,6 +37,9 @@ for _fp in ('/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',):
         font_manager.fontManager.addfont(_fp)
         plt.rcParams['font.family'] = font_manager.FontProperties(fname=_fp).get_name()
 plt.rcParams['axes.unicode_minus'] = False
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_card  # noqa: E402  every backtest leaves evidence behind
 
 WS = Path(__file__).resolve().parent.parent.parent
 OUT = WS / 'memory' / '.tmp'
@@ -192,11 +197,20 @@ def main():
     CLR = {'bh': '#ef4444', 'regime': '#22c55e', 'all1x': '#64748b'}
     print(f'{"strategy":<22}{"totRet":>9}{"CAGR":>8}{"ann.vol":>9}{"maxDD":>9}{"21-22DD":>9}')
     print('-' * 66)
+    measured = {}
     for mode in ('bh', 'regime', 'all1x'):
         nav = navs[mode]
         cdd = mdd([v for v, d in zip(nav, dates) if crash0 <= d <= crash1])
         print(f'{LBL[mode]:<22}{ (nav[-1]-1)*100:>8.0f}%{cagr(nav,dates)*100:>7.1f}%'
               f'{ann_vol(rets_book[mode])*100:>8.0f}%{mdd(nav)*100:>8.1f}%{cdd*100:>8.1f}%')
+        measured[mode] = {
+            'label': LBL[mode],
+            'total_return': round(nav[-1] - 1, 6),
+            'cagr': round(cagr(nav, dates), 6),
+            'annualised_vol': round(ann_vol(rets_book[mode]), 6),
+            'max_drawdown': round(mdd(nav), 6),
+            'crash_2021_2022_drawdown': round(cdd, 6),
+        }
 
     # ---- charts: equity (log) + underwater
     dts = [date.fromisoformat(d) for d in dates]
@@ -216,6 +230,27 @@ def main():
     fig.tight_layout()
     p = OUT / 'combined_regime.png'; fig.savefig(p, dpi=110); plt.close(fig)
     print(f'\n chart → {p}')
+
+    card = run_card.record(
+        'combined_regime',
+        params={'ma_window': MA_WIN, 'vol_window': VOL_WIN, 'vol_hot': VOL_HOT,
+                'crash_window': [crash0, crash1],
+                'weights_usd': {tk: round(wt, 6) for tk, wt in sorted(w.items())},
+                'holding_map': {tk: list(spec) for tk, spec in sorted(HOLDING_MAP.items())}},
+        inputs=[{
+            'symbol': 'union-calendar book', 'source': 'tencent kline/fqkline via PROXIES',
+            'bars': n, 'first_session': dates[0], 'last_session': dates[-1],
+            'digest': run_card.series_digest(
+                [(d, sum(ff[proxy][i] for proxy in sorted(ff)))
+                 for i, d in enumerate(dates)]),
+            'note': 'closes are forward-filled onto a union calendar; see #233',
+        }],
+        metrics=measured,
+        code_files=[__file__, Path(__file__).with_name('compute_regime.py')],
+        notes=['book weights are current, applied to history — this is a '
+               'fixed-weight simulation, not a replay of what was held'],
+    )
+    print(f' run card → {card.relative_to(WS)}')
 
 
 if __name__ == '__main__':

--- a/scripts/data/backtest_hstech_regime.py
+++ b/scripts/data/backtest_hstech_regime.py
@@ -17,10 +17,17 @@ Run:
 """
 import argparse
 import math
+import os
+import sys
 from datetime import date
+from pathlib import Path
 
 import requests
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_card  # noqa: E402  every backtest leaves evidence behind
+
+WS = Path(__file__).resolve().parents[2]
 TENCENT = 'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
 
 
@@ -138,6 +145,7 @@ def run(ma=200, vol_cap=0.50, vol_n=20):
     ]
     print(f'{"strategy":<36}{"totRet":>8}{"CAGR":>7}{"maxDD":>8}{"21-22DD":>9}{"%inMkt":>7}{"sw":>4}  maxDD window')
     print('-' * 96)
+    measured = {}
     for name, nav, pos in rows:
         tot = nav[-1] / nav[0] - 1
         cg = cagr(nav, dates)
@@ -146,6 +154,12 @@ def run(ma=200, vol_cap=0.50, vol_n=20):
         inmkt = (sum(pos) / len(pos) * 100) if pos else 100.0
         sw = switches(pos) if pos else 0
         print(f'{name:<36}{tot*100:>7.0f}%{cg*100:>6.1f}%{mdd*100:>7.1f}%{cdd*100:>8.1f}%{inmkt:>6.0f}%{sw:>4}  {dp}→{dt}')
+        measured[name] = {
+            'total_return': round(tot, 6), 'cagr': round(cg, 6),
+            'max_drawdown': round(mdd, 6), 'max_dd_window': f'{dp}→{dt}',
+            'crash_2021_2022_drawdown': round(cdd, 6),
+            'pct_time_in_market': round(inmkt, 2), 'switches': sw,
+        }
 
     # What does the rule say RIGHT NOW?
     print('\n--- current regime read (as of last bar) ---')
@@ -156,6 +170,22 @@ def run(ma=200, vol_cap=0.50, vol_n=20):
     print(f'  20d realized vol  : {vols[-1]*100:.0f}% annualised' if vols[-1] else '  vol: n/a')
     if vols[-1] is not None:
         print(f'  vol vs {int(vol_cap*100)}% cap     : {"OK ✅" if vols[-1] < vol_cap else "HOT ⛔ decay tax high"}')
+
+    card = run_card.record(
+        'hstech_regime',
+        params={'ma': ma, 'vol_cap': vol_cap, 'vol_n': vol_n,
+                'crash_window': [crash0, crash1]},
+        inputs=[{
+            'symbol': 'hkHSTECH', 'source': 'tencent kline (day, unadjusted)',
+            'bars': n, 'first_session': dates[0], 'last_session': dates[-1],
+            'digest': run_card.series_digest(data),
+        }],
+        metrics=measured,
+        code_files=[__file__, Path(__file__).with_name('compute_regime.py')],
+        notes=['thresholds are calibrated on this same window; see #233'],
+    )
+    print(f'\nrun card: {card.relative_to(WS)}')
+    return measured
 
 
 if __name__ == '__main__':

--- a/scripts/data/backtest_us_leverage.py
+++ b/scripts/data/backtest_us_leverage.py
@@ -14,6 +14,8 @@ Outputs:
 Run: python3 scripts/data/backtest_us_leverage.py
 """
 import math
+import os
+import sys
 from datetime import date
 from pathlib import Path
 
@@ -36,6 +38,9 @@ for _fp in ('/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
         except Exception:
             pass
 plt.rcParams['axes.unicode_minus'] = False
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_card  # noqa: E402  every backtest leaves evidence behind
 
 WS = Path(__file__).resolve().parent.parent.parent
 OUT = WS / 'memory' / '.tmp'
@@ -129,11 +134,18 @@ def main():
                          'ytick.color': '#94a3b8', 'grid.color': '#1e293b',
                          'font.size': 9, 'axes.titlesize': 11})
     sims, allrows = {}, []
+    measured, series_inputs = {}, []
     print(f'{"ETF/标的":<14}{"strategy":<20}{"totRet":>9}{"CAGR":>8}{"maxDD":>9}{"%inMkt":>8}{"sw":>5}')
     print('-' * 76)
     for etf, ul, sym in NAMES:
         data = fetch(sym)
         dates = [d for d, _ in data]; closes = [c for _, c in data]
+        series_inputs.append({
+            'symbol': sym, 'etf': etf, 'underlying': ul,
+            'source': 'tencent fqkline (qfq-adjusted)',
+            'bars': len(data), 'first_session': dates[0], 'last_session': dates[-1],
+            'digest': run_card.series_digest(data),
+        })
         s = simulate(closes); s['dates'] = dates; s['last_close'] = closes[-1]; sims[etf] = s
         for key in ('bh1', 'bh2', 'reg', 'rgv', 'r1x'):
             nav = s[key]
@@ -143,6 +155,12 @@ def main():
             sw = sum(1 for a, b in zip(s['pos'], s['pos'][1:]) if a != b) if key in ('reg', 'rgv', 'r1x') else 0
             print(f'{(etf+"/"+ul):<14}{LBL[key]:<20}{tot*100:>8.0f}%{cg*100:>7.1f}%{m*100:>8.1f}%{inmkt:>7.0f}%{sw:>5}')
             allrows.append((etf, ul, key, tot, cg, m))
+            measured[f'{etf}:{key}'] = {
+                'strategy': LBL[key], 'underlying': ul,
+                'total_return': round(tot, 6), 'cagr': round(cg, 6),
+                'max_drawdown': round(m, 6),
+                'pct_time_in_market': round(inmkt, 2), 'switches': sw,
+            }
         print('-' * 76)
 
     # ---- Figure 1: per-name equity (log) + underwater drawdown (3 rows × 2 cols)
@@ -191,6 +209,18 @@ def main():
         trend = 'ABOVE ✅' if (ma and c > ma) else 'BELOW ⛔'
         print(f'  {etf}/{ul}: close {c:.1f} vs 200DMA {ma:.1f} → {trend} ({(c/ma-1)*100:+.0f}%) | 20d vol {vol*100:.0f}%')
     print(f'\n charts → {p1}\n          {p2}')
+
+    card = run_card.record(
+        'us_leverage_regime',
+        params={'ma_window': MA_WIN, 'vol_window': VOL_WIN, 'vol_cap': VOL_CAP,
+                'names': [list(n) for n in NAMES]},
+        inputs=series_inputs,
+        metrics=measured,
+        code_files=[__file__, Path(__file__).with_name('compute_regime.py')],
+        notes=['charts are written to memory/.tmp/ and are not evidence — '
+               'they are regenerated on every run and never committed'],
+    )
+    print(f' run card → {card.relative_to(WS)}')
 
 
 if __name__ == '__main__':

--- a/scripts/data/compute_regime.py
+++ b/scripts/data/compute_regime.py
@@ -7,6 +7,17 @@ Verified in backtest_hstech_regime.py on 2021→now real HSTECH data: an index-l
 drawdown on a 2x-HSTECH sleeve from -95% to 0% (fully de-risked through the crash),
 and de-levering on the same signal cut full-period maxDD from -95% → -44%.
 
+Evidence: run card `hstech_regime-20260802-f7d80e00` (1370 HSTECH bars,
+2021-01-04 → 2026-07-31). It reproduces both figures — crash-window drawdown
+-95.3% for buy-and-hold 2x against 0.0% for the regime sleeve, and full-period
+maxDD -95.5% against -44.2% for the de-levered 1x variant. Re-derive with
+`python3 scripts/data/run_card.py --run-id hstech_regime-20260802-f7d80e00`.
+
+Two caveats the card makes visible and this docstring previously did not:
+the thresholds were calibrated on the same window they are scored on (#233),
+and no backtested row is exactly this module's production dial — the card's
+"Regime 2x" goes to cash when trend-off, while production de-levers 2x→1x.
+
 The single biggest lever was LEVERAGE (2x→1x→cash), not timing. So this module
 emits a leverage-cap MULTIPLIER that tightens the guardrail's leveraged-ETF leg cap
 when the regime turns hostile — it does NOT generate buy/sell calls.

--- a/scripts/data/run_card.py
+++ b/scripts/data/run_card.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Evidence a backtest actually ran, and against what.
+
+Why this exists
+---------------
+The three backtests wrote PNGs into `memory/.tmp/` and printed a table. Nothing
+durable survived the run. Their conclusions, meanwhile, are quoted as fact in
+permanent prose — `compute_regime.py` opens by justifying the production
+leverage dial with "-95% to 0%" and "-95% → -44%". Those numbers could not be
+re-derived: the scripts refetch a live upstream that has since moved, so a rerun
+covers a different window and may not even see the same bars.
+
+That is the static-copy-quoting-live-numbers problem one level down. The copy is
+honest about being a backtest; the backtest just left no evidence behind.
+
+A run card records what would otherwise be lost:
+
+* **input identity** — source name, symbols, first/last session, bar count, and
+  a digest of the exact series used, so a silently revised upstream is visible;
+* **parameters** — the thresholds the run actually used, not the defaults in the
+  signature;
+* **code identity** — a hash of the backtest script and of any module whose
+  behaviour the result depends on;
+* **metrics** — the numbers the prose quotes, as JSON rather than as stdout.
+
+What it deliberately does not record
+------------------------------------
+Raw vendor bars. The card carries derived metrics and source *names* only, which
+keeps it publishable under the third-party data boundary. The series digest
+identifies the input without republishing it.
+
+One expected asymmetry
+----------------------
+A card's code digests describe the code **as it ran**. Editing a file afterwards
+to cite the card — which is the whole point of having one — changes that file's
+digest, so the citing source no longer matches the digest inside the card it
+cites. That is not a mismatch to fix; re-running to "correct" it would produce a
+new run_id and a new citation, forever. The digest answers "what produced these
+metrics", not "what does the repo look like now".
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from safe_io import safe_write_json  # noqa: E402
+
+WS = Path(__file__).resolve().parents[2]
+CARDS_DIR = WS / 'memory' / 'backtests'
+SCHEMA_VERSION = 1
+
+
+def series_digest(series) -> str:
+    """Stable digest of a (date, value) series.
+
+    Identifies the input without republishing it: two runs over the same bars
+    agree, and a provider revision that changes one close does not.
+    """
+    hasher = hashlib.sha256()
+    for item in series:
+        if isinstance(item, (tuple, list)) and len(item) >= 2:
+            date, value = item[0], item[1]
+        elif isinstance(item, dict):
+            date, value = item.get('date'), item.get('close')
+        else:
+            date, value = None, item
+        hasher.update(f'{date}|{float(value):.6f}\n'.encode())
+    return f'sha256:{hasher.hexdigest()[:16]}'
+
+
+def file_digest(path) -> str | None:
+    path = Path(path)
+    if not path.exists():
+        return None
+    return f'sha256:{hashlib.sha256(path.read_bytes()).hexdigest()[:16]}'
+
+
+def _git_commit() -> str | None:
+    try:
+        out = subprocess.run(
+            ['git', 'rev-parse', '--short', 'HEAD'], cwd=WS,
+            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None if out.returncode == 0 else None
+
+
+def _canonical(payload) -> str:
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False,
+                      separators=(',', ':'))
+
+
+def build_card(name: str, *, params: dict, inputs: list, metrics: dict,
+               code_files=(), notes=(), generated_at: str | None = None) -> dict:
+    """Assemble the card. Pure — writing is a separate step, so it is testable."""
+    code = []
+    for path in code_files:
+        path = Path(path)
+        code.append({'file': path.name, 'digest': file_digest(path)})
+
+    # The reproduction key covers everything that can change the answer:
+    # parameters, the exact input series, and the code that consumed them. Two
+    # runs sharing it must produce the same metrics; if they do not, the
+    # difference is somewhere this card fails to describe.
+    reproduction_key = 'sha256:' + hashlib.sha256(_canonical({
+        'params': params,
+        'inputs': [{k: v for k, v in row.items() if k != 'note'} for row in inputs],
+        'code': code,
+    }).encode()).hexdigest()[:16]
+
+    stamp = generated_at or datetime.now(timezone.utc).isoformat(timespec='seconds')
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'run_id': f'{name}-{stamp[:10].replace("-", "")}-{reproduction_key[7:15]}',
+        'backtest': name,
+        'generated_at': stamp,
+        'git_commit': _git_commit(),
+        'reproduction_key': reproduction_key,
+        'params': params,
+        'inputs': inputs,
+        'code': code,
+        'metrics': metrics,
+        'notes': list(notes),
+        'data_boundary': 'derived metrics and source names only; no raw vendor bars',
+    }
+
+
+def write_card(card: dict, cards_dir: Path | None = None) -> Path:
+    """Persist one card. Returns the path written."""
+    cards_dir = Path(cards_dir or CARDS_DIR)
+    path = cards_dir / f'{card["run_id"]}.json'
+    # strict=True: a card is evidence. A non-finite metric in it means the run
+    # produced something the card cannot faithfully describe, and silently
+    # publishing null would make the evidence lie. Nothing downstream depends on
+    # the card existing, so failing here costs nothing but the card.
+    safe_write_json(str(path), card, strict=True)
+    return path
+
+
+def record(name: str, *, params: dict, inputs: list, metrics: dict,
+           code_files=(), notes=(), cards_dir: Path | None = None) -> Path:
+    """Build and write in one call — what the backtest scripts use."""
+    return write_card(
+        build_card(name, params=params, inputs=inputs, metrics=metrics,
+                   code_files=code_files, notes=notes),
+        cards_dir=cards_dir)
+
+
+def load_cards(cards_dir: Path | None = None) -> list[dict]:
+    cards_dir = Path(cards_dir or CARDS_DIR)
+    if not cards_dir.exists():
+        return []
+    out = []
+    for path in sorted(cards_dir.glob('*.json')):
+        try:
+            out.append(json.loads(path.read_text()))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--list', action='store_true', help='list stored run cards')
+    ap.add_argument('--run-id', help='print one card')
+    args = ap.parse_args()
+
+    cards = load_cards()
+    if args.run_id:
+        for card in cards:
+            if card.get('run_id') == args.run_id:
+                print(json.dumps(card, ensure_ascii=False, indent=2))
+                return 0
+        print(f'no such run card: {args.run_id}', file=sys.stderr)
+        return 1
+
+    if not cards:
+        print('no run cards stored yet')
+        return 0
+    for card in cards:
+        metrics = card.get('metrics') or {}
+        print(f'{card["run_id"]}  {card.get("generated_at", "")}  '
+              f'{len(metrics)} metric group(s)  {card.get("git_commit") or "-"}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_run_card.py
+++ b/tests/test_run_card.py
@@ -1,0 +1,175 @@
+"""A backtest has to leave evidence behind.
+
+The defect: the three backtest scripts wrote PNGs to `memory/.tmp/` and printed
+a table, while their conclusions are quoted as permanent justification — the
+production leverage dial is introduced with "-95% to 0%" in
+`compute_regime.py`'s own docstring. Those numbers could not be re-derived,
+because a rerun refetches a live upstream that has since moved.
+
+Run: python3 -m pytest tests/test_run_card.py -q
+"""
+import ast
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "scripts" / "data"
+sys.path.insert(0, str(DATA))
+
+import run_card  # noqa: E402
+
+BACKTESTS = (
+    "backtest_hstech_regime.py",
+    "backtest_us_leverage.py",
+    "backtest_combined_regime.py",
+)
+
+
+def _card(**overrides):
+    payload = dict(
+        params={"ma": 200, "vol_cap": 0.5},
+        inputs=[{"symbol": "hkHSTECH", "source": "tencent", "bars": 3,
+                 "first_session": "2021-01-04", "last_session": "2021-01-06",
+                 "digest": "sha256:deadbeef"}],
+        metrics={"regime": {"max_drawdown": -0.44}},
+    )
+    payload.update(overrides)
+    return run_card.build_card("fixture", **payload)
+
+
+def test_a_card_records_what_a_rerun_would_otherwise_lose():
+    card = _card()
+
+    assert card["backtest"] == "fixture"
+    assert card["params"]["ma"] == 200
+    assert card["inputs"][0]["first_session"] == "2021-01-04"
+    assert card["metrics"]["regime"]["max_drawdown"] == -0.44
+    assert card["run_id"].startswith("fixture-")
+
+
+def test_the_series_digest_identifies_the_input_without_republishing_it():
+    series = [("2021-01-04", 10.0), ("2021-01-05", 10.5)]
+
+    digest = run_card.series_digest(series)
+
+    assert digest == run_card.series_digest(list(series)), "must be stable"
+    # A provider revision to one close changes it.
+    assert digest != run_card.series_digest(
+        [("2021-01-04", 10.0), ("2021-01-05", 10.51)])
+    # And no price survives into the digest itself.
+    assert "10.5" not in digest
+
+
+def test_the_series_digest_reads_bar_dicts_as_well_as_pairs():
+    assert run_card.series_digest([{"date": "2021-01-04", "close": 10.0}]) == \
+        run_card.series_digest([("2021-01-04", 10.0)])
+
+
+def test_the_reproduction_key_covers_params_inputs_and_code():
+    base = _card()
+
+    assert _card()["reproduction_key"] == base["reproduction_key"]
+    assert _card(params={"ma": 150, "vol_cap": 0.5})["reproduction_key"] \
+        != base["reproduction_key"]
+    moved = [dict(base["inputs"][0], digest="sha256:cafe")]
+    assert _card(inputs=moved)["reproduction_key"] != base["reproduction_key"]
+
+
+def test_a_metric_change_alone_does_not_change_the_reproduction_key():
+    """The key answers "same run?", not "same answer?" — that separation is what
+    makes a mismatch meaningful: identical key + different metrics means the
+    result is not reproducible, and that must be visible rather than hidden by
+    folding metrics into the key."""
+    base = _card()
+    other = _card(metrics={"regime": {"max_drawdown": -0.10}})
+
+    assert other["reproduction_key"] == base["reproduction_key"]
+    assert other["metrics"] != base["metrics"]
+
+
+def test_code_identity_travels_with_the_card():
+    card = _card(code_files=[DATA / "compute_regime.py"])
+
+    entry = card["code"][0]
+    assert entry["file"] == "compute_regime.py"
+    assert entry["digest"].startswith("sha256:")
+
+
+def test_a_missing_code_file_is_recorded_as_missing_not_silently_dropped():
+    card = _card(code_files=[DATA / "does_not_exist.py"])
+
+    assert card["code"] == [{"file": "does_not_exist.py", "digest": None}]
+
+
+def test_a_written_card_round_trips_as_strict_json(tmp_path):
+    path = run_card.write_card(_card(), cards_dir=tmp_path)
+
+    raw = path.read_text()
+    assert "NaN" not in raw and "Infinity" not in raw
+    assert json.loads(raw)["metrics"]["regime"]["max_drawdown"] == -0.44
+
+
+def test_a_non_finite_metric_refuses_to_become_a_card(tmp_path):
+    """A card is evidence. Publishing `null` for a metric the run actually
+    produced would make the evidence lie, and nothing downstream depends on the
+    card existing, so failing costs only the card."""
+    with pytest.raises(ValueError, match="non-finite"):
+        run_card.write_card(
+            _card(metrics={"regime": {"max_drawdown": float("nan")}}),
+            cards_dir=tmp_path)
+
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_cards_can_be_listed_back(tmp_path):
+    run_card.write_card(_card(), cards_dir=tmp_path)
+
+    loaded = run_card.load_cards(cards_dir=tmp_path)
+
+    assert len(loaded) == 1 and loaded[0]["backtest"] == "fixture"
+
+
+def test_load_cards_is_empty_rather_than_failing_on_a_fresh_checkout(tmp_path):
+    assert run_card.load_cards(cards_dir=tmp_path / "nope") == []
+
+
+# ── the structural gate ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("script", BACKTESTS)
+def test_every_backtest_records_a_run_card(script):
+    """The whole defect was that the runs left nothing behind, so this is the
+    load-bearing assertion. Checked through the AST rather than by searching the
+    text, so a mention in a docstring cannot satisfy it."""
+    tree = ast.parse((DATA / script).read_text())
+
+    imports_it = any(
+        isinstance(node, ast.Import)
+        and any(alias.name == "run_card" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    calls_record = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "record"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "run_card"
+        for node in ast.walk(tree)
+    )
+
+    assert imports_it, f"{script} does not import run_card"
+    assert calls_record, f"{script} never calls run_card.record — it leaves no evidence"
+
+
+@pytest.mark.parametrize("script", BACKTESTS)
+def test_each_backtest_hashes_the_code_its_result_depends_on(script):
+    """A card that pins the inputs but not the code cannot tell you why two runs
+    with the same reproduction key disagreed."""
+    source = (DATA / script).read_text()
+
+    assert "code_files=" in source, f"{script} records no code identity"
+    assert "compute_regime.py" in source, (
+        f"{script} does not hash compute_regime.py, whose thresholds it is "
+        "measuring")


### PR DESCRIPTION
Closes #234.

The three backtests wrote PNGs into `memory/.tmp/` and printed a table — nothing durable survived the run. Their conclusions are quoted as permanent justification: `compute_regime.py` opens by defending the production leverage dial with "-95% to 0%" and "-95% → -44%", numbers that could not be re-derived because a rerun refetches a live upstream that has since moved.

## What a card records

Input series identity (source, symbols, first/last session, bar count, digest), the parameters actually used, hashes of the backtest script and of `compute_regime.py`, and the metrics as JSON.

The **reproduction key** covers params + inputs + code but deliberately **not** metrics. That separation is the point: identical key with different metrics means the result is not reproducible, and that has to stay visible rather than be folded away.

Cards carry derived metrics and source *names* only — no raw vendor bars — so they stay publishable under the third-party data boundary. `write_card` uses `strict=True`: a card is evidence, and publishing `null` for a metric the run actually produced would make the evidence lie.

## I ran it, and the quoted numbers hold

`hstech_regime-20260802-f7d80e00` — 1370 HSTECH bars, 2021-01-04 → 2026-07-31, committed under `memory/backtests/`:

| strategy | totRet | maxDD | 21-22 crash DD |
|---|---|---|---|
| Buy&Hold 1x (index) | −43% | −74.4% | −74.4% |
| Buy&Hold 2x ETF | −86% | **−95.5%** | **−95.3%** |
| Regime 2x (200DMA) | −60% | −70.5% | **0.0%** |
| Regime+Vol 2x | −50% | −70.5% | 0.0% |
| Regime 1x (de-levered) | −27% | **−44.2%** | 0.0% |

Both docstring claims reproduce. I went in expecting to find the headline overstated; it is not.

The docstring now cites the run_id, plus two caveats the card makes visible and it previously did not: the thresholds were calibrated on the same window they are scored on (#233), and **no backtested row is exactly the production dial** — the card's "Regime 2x" goes to cash when trend-off, while production de-levers 2x→1x.

## One expected asymmetry, documented in the module

A card's code digests describe the code *as it ran*. Editing a file afterwards to cite the card — the whole point of having one — changes that file's digest, so the citing source no longer matches the digest inside the card. Re-running to "fix" that mints a new run_id and a new citation, forever. The digest answers "what produced these metrics", not "what does the repo look like now".

## Verification

- `1438 passed, 4 xfailed`.
- Structural gate: an **AST** check that each backtest imports `run_card` and actually calls `run_card.record`, so a mention in prose cannot satisfy it.
- `python3 scripts/data/run_card.py --list` / `--run-id <id>` reads them back.