### PR TITLE
risk: measure holding co-movement instead of proxying it with Top2 (#231)

### DIFF
--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -83,7 +83,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `compute_quant_signals.py` | 双均线 / 动量 / RSI / ATR / vol-target(杠杆 ETF 按标的) | 派生 | ✅ |
 | `compute_regime.py` | 杠杆刻度盘: 200DMA 趋势 + 20d 波动带 | 派生 | ✅ |
 | `compute_t0_setups.py` | T+0 牌面评级 + 追高检测 | 派生 | ✅ |
-| `portfolio_risk_metrics.py` | β / Cov-Var / 回撤 / 集中度 | Yahoo 30d + 派生 | ✅ |
+| `portfolio_risk_metrics.py` | β / Cov-Var / 回撤 / 集中度 + **相关性 x-ray**(effective bets、分散比、聚类、VaR95/ES95) | Yahoo 30d/60d + 派生 | ✅ |
 | `cross_sectional_factor.py` | 同行/1x 标的行业中性排名、杠杆 decay 对比（激活闸前仅研究） | 腾讯 qfq + SEC XBRL | ✅ |
 | `peer_residual_engine.py` | 人工同行篮子等权/流动性权重残差、breadth/dispersion/leadership（HK 禁自动发现） | 腾讯 qfq + peer-map | ✅ |
 

--- a/scripts/data/portfolio_risk_metrics.py
+++ b/scripts/data/portfolio_risk_metrics.py
@@ -19,6 +19,7 @@ import math
 import os
 import sys
 import time
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
@@ -69,6 +70,19 @@ MIN_ACTION_RETURNS = 20
 MIN_DATE_COVERAGE = 0.80
 NEW_LISTING_RETURNS = 20
 EWMA_LAMBDA = 0.94
+
+# Correlation x-ray. `MIN_CORR_SESSIONS` matches MIN_ACTION_RETURNS so a
+# correlation number can never be acted on with a thinner sample than a beta.
+# `CLUSTER_RHO` is the level at which two names stop being separate bets;
+# `CLUSTER_WEIGHT_ALERT_PCT` reuses the existing declared appetite for
+# single-factor exposure (brief_preflight's `top2_factor_pct` cap) rather than
+# inventing a second, unexplained threshold.
+MIN_CORR_SESSIONS = 20
+# Correlation deserves a longer sample than the 30-day risk window, and
+# fetch_history already returns 60 sessions, so this costs no extra request.
+CORR_WINDOW_SESSIONS = 60
+CLUSTER_RHO = 0.80
+CLUSTER_WEIGHT_ALERT_PCT = 70.0
 
 
 # ----------------------------------------------------------------------------
@@ -708,6 +722,10 @@ def compute_bucket(holdings: list, bench_series, label: str, sleep_between: floa
 
     meta = {
         'fetched': list(fetched.keys()),
+        # Per-ticker close series, for callers that need co-movement rather than
+        # the aggregated stream. Internal only — `main` publishes named keys from
+        # meta, never meta itself, so this never reaches risk.json.
+        'series': fetched,
         'failed': failed,
         'n_holdings': len(holdings),
         'n_returns': stats['n_returns'],
@@ -716,6 +734,191 @@ def compute_bucket(holdings: list, bench_series, label: str, sleep_between: floa
         **stream,
     }
     return bucket_out, meta
+
+
+def correlation_xray(holdings_by_leg, series_by_leg, fx_hkd_to_usd):
+    """Measure how many *bets* the book holds, not how many tickers.
+
+    Concentration here has always been weight-only: HHI and Top2 over dollar
+    weights, with `top2_factor_pct` standing in as a proxy for "these are one
+    factor". That proxy fails in both directions. Two names that are the same
+    bet — a 2x ETF and its 1x underlying, or the 07226 / 03033 / 00100 HSTECH
+    cluster — look diversified the moment a third name pushes them out of the
+    Top 2, and two genuinely unrelated leaders trip the cap for no reason. The
+    2026-06 drawdown is on record as a construction problem ("HK 85% one
+    factor"), which is precisely the quantity that was never measured.
+
+    Everything here is computed from realised returns, so it is descriptive, not
+    predictive:
+
+      effective_names   1/HHI — the old weight-only count, kept for contrast
+      effective_bets    1/(wᵀρw) — collapses toward 1 as the book co-moves
+      diversification_ratio  Σwᵢσᵢ / σ_portfolio — 1.0 means no diversification
+      clusters          single-linkage groups at |ρ| ≥ CLUSTER_RHO, by weight
+      var_95 / es_95    historical tail of the weighted book
+
+    Both legs are converted to USD before weighting, per the standing rule that
+    HKD and USD are never added. Correlation needs contemporaneous returns, so
+    the sample is the *intersection* of sessions both markets traded.
+    """
+    weights, returns_by_ticker = {}, {}
+    for leg, holdings in holdings_by_leg.items():
+        rate = 1.0 if leg == 'us' else fx_hkd_to_usd
+        series_map = series_by_leg.get(leg) or {}
+        for holding in holdings:
+            ticker = holding['ticker']
+            series = series_map.get(ticker)
+            if not series:
+                continue
+            value_usd = float(holding['current_value']) * float(rate)
+            if value_usd <= 0:
+                continue
+            weights[ticker] = value_usd
+            returns_by_ticker[ticker] = {
+                date: row['return'] for date, row in _return_map(series).items()
+            }
+
+    book_value = sum(weights.values())
+    excluded = sorted(
+        holding['ticker']
+        for leg, holdings in holdings_by_leg.items()
+        for holding in holdings
+        if holding['ticker'] not in weights
+    )
+
+    # A recent listing must not truncate the established names — the same rule
+    # `build_dynamic_return_stream` already follows. Requiring every holding to
+    # share every session let one 16-session name (SKHY) cap the whole sample at
+    # 15 and produce nothing at all.
+    short_history = sorted(
+        ticker for ticker, returns in returns_by_ticker.items()
+        if len(returns) < MIN_CORR_SESSIONS
+    )
+    for ticker in short_history:
+        returns_by_ticker.pop(ticker)
+
+    def _unavailable(reason):
+        return {
+            'effective_names': None, 'effective_bets': None,
+            'diversification_ratio': None, 'var_95': None,
+            'expected_shortfall_95': None, 'clusters': [], 'top_pairs': [],
+            'n_common_sessions': 0, 'tickers': sorted(returns_by_ticker),
+            'excluded_no_history': excluded,
+            'excluded_short_history': short_history,
+            'reason': reason,
+        }
+
+    if len(returns_by_ticker) < 2:
+        return _unavailable('needs at least two holdings with enough history')
+
+    common = sorted(set.intersection(
+        *(set(dates) for dates in returns_by_ticker.values())))[-CORR_WINDOW_SESSIONS:]
+    if len(common) < MIN_CORR_SESSIONS:
+        return _unavailable(
+            f'{len(common)} sessions common to the {len(returns_by_ticker)} '
+            f'holdings with history; {MIN_CORR_SESSIONS} required')
+
+    tickers = sorted(returns_by_ticker)
+    total = sum(weights[t] for t in tickers)
+    w = np.array([weights[t] / total for t in tickers], dtype=float)
+    matrix = np.array(
+        [[returns_by_ticker[t][d] for t in tickers] for d in common], dtype=float)
+    if not np.isfinite(matrix).all():
+        return _unavailable('non-finite return in the aligned matrix')
+
+    sigmas = matrix.std(axis=0, ddof=1)
+    if not (sigmas > 0).all():
+        # A name that never moved has undefined correlation; naming it beats
+        # publishing a matrix with silent NaN columns.
+        flat = [t for t, s in zip(tickers, sigmas) if not s > 0]
+        return _unavailable(f'zero-variance holding(s): {", ".join(flat)}')
+
+    rho = np.corrcoef(matrix, rowvar=False)
+    portfolio = matrix @ w
+    sigma_p = float(portfolio.std(ddof=1))
+
+    hhi = float(np.sum(w ** 2))
+    quadratic = float(w @ rho @ w)
+    weighted_sigma = float(np.sum(w * sigmas))
+
+    pairs = []
+    for i in range(len(tickers)):
+        for j in range(i + 1, len(tickers)):
+            pairs.append({'pair': [tickers[i], tickers[j]],
+                          'rho': _round_finite(rho[i, j], 3),
+                          'combined_weight_pct': _round_finite(
+                              (w[i] + w[j]) * 100, 2)})
+    pairs = [p for p in pairs if p['rho'] is not None]
+    pairs.sort(key=lambda p: -abs(p['rho']))
+
+    return {
+        'effective_names': _round_finite(1.0 / hhi if hhi > 0 else None, 2),
+        'effective_bets': _round_finite(
+            1.0 / quadratic if quadratic > 0 else None, 2),
+        'diversification_ratio': _round_finite(
+            weighted_sigma / sigma_p if sigma_p > 0 else None, 3),
+        'var_95': _round_finite(float(np.percentile(portfolio, 5))),
+        'expected_shortfall_95': _round_finite(_tail_mean(portfolio, 0.05)),
+        'clusters': _correlation_clusters(tickers, rho, w),
+        'top_pairs': pairs[:5],
+        'n_common_sessions': len(common),
+        'first_session': common[0],
+        'last_session': common[-1],
+        'tickers': tickers,
+        'excluded_no_history': excluded,
+        'excluded_short_history': short_history,
+        # How much of the book the numbers above actually describe. Excluding a
+        # name is not free, and a reader must be able to see that a 60%-covered
+        # x-ray is a different claim from a 99%-covered one.
+        'covered_weight_pct': _round_finite(
+            100 * total / book_value if book_value > 0 else None, 2),
+        'cluster_rho': CLUSTER_RHO,
+        'basis': 'USD-converted current weights over sessions both legs traded',
+    }
+
+
+def _tail_mean(returns: np.ndarray, alpha: float):
+    """Mean of the worst `alpha` tail — expected shortfall, historical."""
+    if returns.size < 2:
+        return None
+    cutoff = max(1, int(math.ceil(alpha * returns.size)))
+    return float(np.sort(returns)[:cutoff].mean())
+
+
+def _correlation_clusters(tickers, rho, weights):
+    """Single-linkage groups at |ρ| >= CLUSTER_RHO, heaviest first.
+
+    Single linkage on purpose: A~B and B~C makes one cluster even when A and C
+    are not directly correlated, because that is still one chain of shared
+    exposure. It over-groups rather than under-groups, and for a risk readout
+    the conservative error is the right one.
+    """
+    parent = list(range(len(tickers)))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(len(tickers)):
+        for j in range(i + 1, len(tickers)):
+            if abs(rho[i, j]) >= CLUSTER_RHO:
+                parent[find(i)] = find(j)
+
+    grouped = defaultdict(list)
+    for index, ticker in enumerate(tickers):
+        grouped[find(index)].append(index)
+
+    clusters = []
+    for members in grouped.values():
+        clusters.append({
+            'tickers': [tickers[i] for i in sorted(members)],
+            'weight_pct': _round_finite(
+                sum(weights[i] for i in members) * 100, 2),
+        })
+    clusters.sort(key=lambda c: -(c['weight_pct'] or 0))
+    return clusters
 
 
 def compute_combined(us_meta, hk_meta, holdings_all, fx_hkd_to_usd=None):
@@ -815,7 +1018,7 @@ def compute_leverage(holdings_all, fx_hkd_to_usd):
     }
 
 
-def build_alerts(us, hk, combined, leverage):
+def build_alerts(us, hk, combined, leverage, correlation=None):
     alerts = []
     for label, block in (('US', us), ('HK', hk)):
         if not isinstance(block, dict):
@@ -882,6 +1085,52 @@ def build_alerts(us, hk, combined, leverage):
             and combined['sharpe_30d'] < 0):
         alerts.append({'type': 'negative_sharpe', 'severity': 'medium',
                        'detail': f'Combined 30d Sharpe = {combined["sharpe_30d"]} (< 0)'})
+    alerts.extend(_correlation_alerts(correlation))
+    return alerts
+
+
+def _correlation_alerts(correlation):
+    """Co-movement findings. Reports, never suppresses.
+
+    This is deliberately an alert and not a hard cap. The guardrail's caps are
+    mandatory trim directives the brief must act on; changing what the book is
+    required to sell is kcn's call on thresholds, not a side effect of adding a
+    measurement. What this can say is that the measured cluster is larger than
+    the declared appetite for single-factor exposure.
+    """
+    if not correlation:
+        return []
+    if correlation.get('reason'):
+        return [{
+            'type': 'insufficient_observations', 'severity': 'medium',
+            'detail': f'correlation x-ray unavailable: {correlation["reason"]}',
+        }]
+
+    alerts = []
+    clusters = correlation.get('clusters') or []
+    biggest = clusters[0] if clusters else None
+    if (biggest and len(biggest.get('tickers') or []) > 1
+            and (biggest.get('weight_pct') or 0) > CLUSTER_WEIGHT_ALERT_PCT):
+        alerts.append({
+            'type': 'correlated_cluster', 'severity': 'high',
+            'detail': (
+                f'{biggest["weight_pct"]}% of the book moves as one cluster '
+                f'({", ".join(biggest["tickers"])}) at |ρ| ≥ '
+                f'{correlation.get("cluster_rho", CLUSTER_RHO)} '
+                f'(> {CLUSTER_WEIGHT_ALERT_PCT}%)'
+            ),
+        })
+
+    names = correlation.get('effective_names')
+    bets = correlation.get('effective_bets')
+    if names is not None and bets is not None and bets < names / 2:
+        alerts.append({
+            'type': 'diversification_illusion', 'severity': 'medium',
+            'detail': (
+                f'{names} effective names but only {bets} effective bets — '
+                'weight-based concentration understates the real exposure'
+            ),
+        })
     return alerts
 
 
@@ -987,7 +1236,14 @@ def main():
                                     fx_hkd_to_usd=fx_hkd_to_usd)
     leverage_out = compute_leverage({'us': us_holdings, 'hk': hk_holdings},
                                     fx_hkd_to_usd=fx_hkd_to_usd)
-    alerts = build_alerts(us_out, hk_out, combined_out, leverage_out)
+    correlation_out = correlation_xray(
+        {'us': us_holdings, 'hk': hk_holdings},
+        {'us': (us_meta or {}).get('series') or {},
+         'hk': (hk_meta or {}).get('series') or {}},
+        fx_hkd_to_usd,
+    )
+    alerts = build_alerts(us_out, hk_out, combined_out, leverage_out,
+                          correlation_out)
 
     out = {
         'generated_at': datetime.now(timezone.utc).isoformat(),
@@ -995,6 +1251,7 @@ def main():
         'us': us_out,
         'hk': hk_out,
         'combined': combined_out,
+        'correlation': correlation_out,
         'leveraged_exposure': leverage_out,
         'alerts': alerts,
         'meta': {

--- a/tests/test_risk_correlation_xray.py
+++ b/tests/test_risk_correlation_xray.py
@@ -1,0 +1,242 @@
+"""Concentration has to measure bets, not tickers.
+
+`brief_preflight.compute_concentration` grades the book on dollar weights alone
+and then uses `top2_factor_pct` as a stand-in for "these are one factor". The
+comment above `GUARDRAIL_CAPS` records that the 2026-06 drawdown was a
+construction problem — "HK 85% one factor" — which is exactly the quantity the
+proxy was standing in for and nothing was measuring.
+
+Run: python3 -m pytest tests/test_risk_correlation_xray.py -q
+"""
+import json
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import portfolio_risk_metrics as risk  # noqa: E402
+
+START = datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+
+def _series(returns, start_price=100.0, offset_days=0):
+    """Build a (ts, close) series whose close-to-close returns are `returns`."""
+    out, price = [], start_price
+    for index, ret in enumerate([0.0, *returns]):
+        price *= (1 + ret)
+        day = START + timedelta(days=index + offset_days)
+        out.append((int(day.timestamp()), price))
+    return out
+
+
+def _holding(ticker, value):
+    return {"ticker": ticker, "current_value": float(value)}
+
+
+def _walk(seed, n=40, scale=0.02):
+    rng = np.random.default_rng(seed)
+    return list(rng.normal(0, scale, n))
+
+
+def _xray(us=(), hk=(), series=None, fx=0.128):
+    series = series or {}
+    return risk.correlation_xray(
+        {"us": list(us), "hk": list(hk)},
+        {"us": {t: s for t, s in series.items() if t in {h["ticker"] for h in us}},
+         "hk": {t: s for t, s in series.items() if t in {h["ticker"] for h in hk}}},
+        fx,
+    )
+
+
+# ── the headline claim ──────────────────────────────────────────────────────
+
+def test_duplicate_exposure_reports_far_fewer_bets_than_names():
+    """A 2x ETF held alongside its 1x underlying is two tickers and one bet.
+    Weight-only concentration cannot see the difference."""
+    base = _walk(1)
+    out = _xray(
+        us=[_holding("PLTR", 1000), _holding("PLTU", 1000)],
+        series={"PLTR": _series(base), "PLTU": _series([2 * r for r in base])},
+    )
+
+    assert out["effective_names"] == pytest.approx(2.0, abs=0.01)
+    assert out["effective_bets"] == pytest.approx(1.0, abs=0.05), (
+        "perfectly co-moving holdings must collapse to ~1 effective bet")
+
+
+def test_an_uncorrelated_book_keeps_its_bets():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000), _holding("CCC", 1000)],
+        series={"AAA": _series(_walk(11)), "BBB": _series(_walk(22)),
+                "CCC": _series(_walk(33))},
+    )
+
+    assert out["effective_names"] == pytest.approx(3.0, abs=0.01)
+    assert out["effective_bets"] > 2.0, out["effective_bets"]
+
+
+def test_the_diversification_ratio_is_near_one_when_everything_moves_together():
+    base = _walk(4)
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000)],
+        series={"AAA": _series(base), "BBB": _series(base)},
+    )
+
+    assert out["diversification_ratio"] == pytest.approx(1.0, abs=0.01)
+
+
+# ── clusters, and what the Top2 proxy misses ────────────────────────────────
+
+def test_clusters_group_names_that_move_together():
+    base = _walk(5)
+    out = _xray(
+        hk=[_holding("07226", 4000), _holding("03033", 3000),
+            _holding("02208", 3000)],
+        series={"07226": _series([2 * r for r in base]),
+                "03033": _series(base), "02208": _series(_walk(6))},
+    )
+
+    biggest = out["clusters"][0]
+    assert set(biggest["tickers"]) == {"07226", "03033"}
+    assert biggest["weight_pct"] == pytest.approx(70.0, abs=0.01)
+
+
+def test_the_cluster_alert_fires_where_a_top2_weight_check_would_not():
+    """Three correlated names at 30/30/25 make a 85% single-factor cluster while
+    any two of them are only 60% — under the 70% Top2 cap that stands in for
+    factor exposure today."""
+    base = _walk(7)
+    holdings = [_holding("A", 3000), _holding("B", 3000), _holding("C", 2500),
+                _holding("D", 1500)]
+    series = {name: _series([base[i] * (1 + 0.01 * k) for i in range(len(base))])
+              for k, name in enumerate(("A", "B", "C"))}
+    series["D"] = _series(_walk(8))
+
+    out = _xray(hk=holdings, series=series)
+    alerts = risk._correlation_alerts(out)
+
+    biggest = out["clusters"][0]
+    assert set(biggest["tickers"]) == {"A", "B", "C"}
+    top2 = sorted((h["current_value"] for h in holdings), reverse=True)[:2]
+    assert sum(top2) / sum(h["current_value"] for h in holdings) * 100 < 70, (
+        "fixture no longer demonstrates the gap: Top2 alone would have fired")
+    assert biggest["weight_pct"] > 70
+    assert [a["type"] for a in alerts if a["type"] == "correlated_cluster"]
+
+
+def test_a_single_name_cluster_never_raises_a_cluster_alert():
+    """One heavy name is a concentration finding the existing caps already own;
+    duplicating it here would just add noise."""
+    out = {"clusters": [{"tickers": ["AAA"], "weight_pct": 95.0}],
+           "effective_names": 1.0, "effective_bets": 1.0}
+
+    assert not [a for a in risk._correlation_alerts(out)
+                if a["type"] == "correlated_cluster"]
+
+
+# ── currency, coverage and the honest failure paths ─────────────────────────
+
+def test_both_legs_are_converted_to_usd_before_weighting():
+    """HKD and USD are never added. At 0.125, HK$8000 is US$1000 — equal weight
+    with the US leg, so effective_names must be 2.0, not lopsided."""
+    out = _xray(
+        us=[_holding("AAA", 1000)], hk=[_holding("00100", 8000)],
+        series={"AAA": _series(_walk(9)), "00100": _series(_walk(10))},
+        fx=0.125,
+    )
+
+    assert out["effective_names"] == pytest.approx(2.0, abs=0.01)
+
+
+def test_a_new_listing_is_excluded_instead_of_truncating_everyone_else():
+    """The real book has a 16-session holding. Requiring every name to share
+    every session capped the sample at 15 and produced nothing at all."""
+    out = _xray(
+        us=[_holding("OLD1", 1000), _holding("OLD2", 1000), _holding("NEW", 100)],
+        series={"OLD1": _series(_walk(12)), "OLD2": _series(_walk(13)),
+                "NEW": _series(_walk(14, n=5))},
+    )
+
+    assert out["excluded_short_history"] == ["NEW"]
+    assert "reason" not in out, "the x-ray computed, so it must not report a refusal"
+    assert out["effective_bets"] is not None
+    assert out["n_common_sessions"] >= risk.MIN_CORR_SESSIONS
+    # And the reader can see how much of the book the answer covers.
+    assert out["covered_weight_pct"] == pytest.approx(95.24, abs=0.05)
+
+
+def test_a_book_of_only_new_listings_says_so_instead_of_guessing():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000)],
+        series={"AAA": _series(_walk(15, n=8)), "BBB": _series(_walk(16, n=8))},
+    )
+
+    assert out["effective_bets"] is None
+    assert out["excluded_short_history"] == ["AAA", "BBB"]
+    assert "enough history" in out["reason"]
+    assert [a["type"] for a in risk._correlation_alerts(out)] == [
+        "insufficient_observations"]
+
+
+def test_too_few_shared_sessions_states_the_reason_and_publishes_no_number():
+    """Each name has plenty of its own history; they barely overlap. Correlation
+    needs contemporaneous returns, so this is a real refusal, not a shortcut."""
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000)],
+        series={"AAA": _series(_walk(15, n=30)),
+                "BBB": _series(_walk(16, n=30), offset_days=25)},
+    )
+
+    assert out["effective_bets"] is None
+    assert "required" in out["reason"]
+    # Unavailable must still be *visible*, not silently absent.
+    assert [a["type"] for a in risk._correlation_alerts(out)] == [
+        "insufficient_observations"]
+
+
+def test_a_zero_variance_holding_is_named_rather_than_becoming_nan():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("FLAT", 1000)],
+        series={"AAA": _series(_walk(17)), "FLAT": _series([0.0] * 40)},
+    )
+
+    assert out["effective_bets"] is None
+    assert "FLAT" in out["reason"]
+
+
+def test_a_holding_with_no_price_history_is_listed_not_dropped_in_silence():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000), _holding("GONE", 500)],
+        series={"AAA": _series(_walk(18)), "BBB": _series(_walk(19))},
+    )
+
+    assert out["excluded_no_history"] == ["GONE"]
+    assert out["effective_bets"] is not None
+
+
+def test_every_published_number_survives_a_strict_json_writer():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000)],
+        series={"AAA": _series(_walk(20)), "BBB": _series(_walk(21))},
+    )
+
+    json.dumps(out, allow_nan=False)
+    for key in ("effective_names", "effective_bets", "diversification_ratio",
+                "var_95", "expected_shortfall_95"):
+        assert out[key] is None or math.isfinite(out[key]), key
+
+
+def test_expected_shortfall_is_at_least_as_bad_as_var():
+    out = _xray(
+        us=[_holding("AAA", 1000), _holding("BBB", 1000)],
+        series={"AAA": _series(_walk(23)), "BBB": _series(_walk(24))},
+    )
+
+    assert out["expected_shortfall_95"] <= out["var_95"]


### PR DESCRIPTION
Closes #231.

Concentration was weight-only — HHI and Top2 over dollar weights, with `top2_factor_pct` standing in for "these are one factor". The comment above `GUARDRAIL_CAPS` records that the 2026-06 drawdown was a construction problem ("HK 85% one factor"), which is exactly the quantity the proxy stood in for and nothing measured.

## What risk.json gains

| field | meaning |
|---|---|
| `effective_names` | 1/HHI — the old weight-only count, kept for contrast |
| `effective_bets` | 1/(wᵀρw) — collapses toward 1 as the book co-moves |
| `diversification_ratio` | Σwᵢσᵢ / σ_p; 1.0 means no diversification at all |
| `clusters` | single-linkage groups at \|ρ\| ≥ 0.80, by weight |
| `var_95` / `expected_shortfall_95` | historical tail of the weighted book |
| `top_pairs` | most correlated pairs and their combined weight |

Both legs are converted to USD before weighting (HKD and USD are never added), and the sample is the intersection of sessions both legs traded, because correlation needs contemporaneous returns.

## What it says about the live book

- **4.43 effective names, 2.36 effective bets** — roughly half the diversification the weights imply.
- The HSTECH cluster **03032 / 03033 / 07226 = 39%** of the book, moving at ρ ≥ 0.995.
- **SPCH / SPCX = 12%** at ρ **0.999** — two tickers, one position.
- **00100 does not join the HK cluster** (ρ below 0.41 against everything). The concentration is real but not where a factor *guess* would have put it — which is the argument for measuring instead of proxying.
- Coverage 98.45%, 31 shared sessions. The cross-market intersection costs about half the available history; that is disclosed rather than hidden.

## A bug I introduced and then fixed

The first version required every holding to share every session. One 16-session name (SKHY) capped the sample at 15 and the block produced nothing at all — reintroducing precisely the defect this file already fixed for the return stream, where there is a test literally named *"a new listing does not truncate established names"*. Short-history names are now excluded by that same rule, and `covered_weight_pct` publishes how much of the book the answer describes.

## Alerts, not caps — deliberately

The issue proposed feeding this into the guardrail's hard caps. I did not. Those caps are mandatory trim directives the brief must act on, and changing what the book is required to sell is a threshold decision that belongs to kcn, not a side effect of adding a measurement. So:

- `correlated_cluster` — fires when a measured cluster exceeds the **existing** 70% single-factor appetite (reusing that number rather than inventing a second unexplained threshold);
- `diversification_illusion` — fires when effective bets fall below half of effective names.

Neither fires on the book today. `test_the_cluster_alert_fires_where_a_top2_weight_check_would_not` proves the gap on a 30/30/25 correlated triple: 85% single-factor cluster while any two names are only 60%, i.e. invisible to Top2.

## Verification

- `1435 passed, 4 xfailed`.
- Every refusal path names its reason and still raises `insufficient_observations` — unavailable stays visible.
- Mutation-verified: computing `effective_bets` from HHI fails 1 test; skipping the short-history exclusion fails 2; never merging clusters fails 2.