### PR TITLE
regime: validate the leverage dial out of sample (#233)

### DIFF
--- a/memory/backtests/combined_regime-20260802-b6c7f1c1.json
+++ b/memory/backtests/combined_regime-20260802-b6c7f1c1.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": 1,
+  "run_id": "combined_regime-20260802-b6c7f1c1",
+  "backtest": "combined_regime",
+  "generated_at": "2026-08-02T06:00:10+00:00",
+  "git_commit": "18a0e7d0",
+  "reproduction_key": "sha256:b6c7f1c1b2b2a763",
+  "params": {
+    "ma_window": 200,
+    "vol_window": 20,
+    "vol_hot": 0.7,
+    "crash_window": [
+      "2021-08-01",
+      "2022-10-31"
+    ],
+    "weights_usd": {
+      "00100": 0.377751,
+      "02208": 0.06339,
+      "03032": 0.015589,
+      "03033": 0.07652,
+      "07226": 0.361133,
+      "CRCL": 0.015784,
+      "MSFU": 0.041908,
+      "PLTU": 0.047925
+    },
+    "holding_map": {
+      "00100": [
+        "HSTECH",
+        1,
+        null
+      ],
+      "02208": [
+        "GF",
+        1,
+        null
+      ],
+      "03032": [
+        "HSTECH",
+        1,
+        null
+      ],
+      "03033": [
+        "HSTECH",
+        1,
+        null
+      ],
+      "07226": [
+        "HSTECH",
+        2,
+        "hk2x"
+      ],
+      "CRCL": [
+        "RKLB",
+        1,
+        null
+      ],
+      "MSFU": [
+        "MSFT",
+        2,
+        "us2x"
+      ],
+      "PLTU": [
+        "PLTR",
+        2,
+        "us2x"
+      ],
+      "RKLB": [
+        "RKLB",
+        1,
+        null
+      ],
+      "ROBN": [
+        "HOOD",
+        2,
+        "us2x"
+      ]
+    }
+  },
+  "inputs": [
+    {
+      "symbol": "union-calendar book",
+      "source": "tencent kline/fqkline via PROXIES",
+      "bars": 1291,
+      "first_session": "2021-07-29",
+      "last_session": "2026-07-31",
+      "digest": "sha256:8dddd1c757e7666b",
+      "note": "closes are forward-filled onto a union calendar; see #233"
+    }
+  ],
+  "code": [
+    {
+      "file": "backtest_combined_regime.py",
+      "digest": "sha256:15fb7da855debbb7"
+    },
+    {
+      "file": "compute_regime.py",
+      "digest": "sha256:4c3526b901d26081"
+    }
+  ],
+  "metrics": {
+    "bh": {
+      "label": "死扛(原杠杆)",
+      "total_return": -0.154086,
+      "cagr": -0.032883,
+      "annualised_vol": 0.485805,
+      "max_drawdown": -0.719895,
+      "crash_2021_2022_drawdown": -0.719895
+    },
+    "regime": {
+      "label": "刻度盘(降杠杆)",
+      "total_return": -0.056693,
+      "cagr": -0.011594,
+      "annualised_vol": 0.40186,
+      "max_drawdown": -0.603319,
+      "crash_2021_2022_drawdown": -0.591673
+    },
+    "all1x": {
+      "label": "全1x(从不加杠杆)",
+      "total_return": -0.029059,
+      "cagr": -0.005875,
+      "annualised_vol": 0.340829,
+      "max_drawdown": -0.569473,
+      "crash_2021_2022_drawdown": -0.569473
+    }
+  },
+  "notes": [
+    "book weights are current, applied to history — this is a fixed-weight simulation, not a replay of what was held"
+  ],
+  "data_boundary": "derived metrics and source names only; no raw vendor bars"
+}

--- a/memory/backtests/regime_dial_validation-20260802-896b2145.json
+++ b/memory/backtests/regime_dial_validation-20260802-896b2145.json
@@ -1,0 +1,375 @@
+{
+  "schema_version": 1,
+  "run_id": "regime_dial_validation-20260802-896b2145",
+  "backtest": "regime_dial_validation",
+  "generated_at": "2026-08-02T05:58:57+00:00",
+  "git_commit": "18a0e7d0",
+  "reproduction_key": "sha256:896b21453c34d0b3",
+  "params": {
+    "folds": 4,
+    "permutations": 2000,
+    "ma_grid": [
+      100,
+      150,
+      200,
+      250
+    ],
+    "vol_cap_grid": [
+      0.4,
+      0.5,
+      0.6,
+      0.7
+    ],
+    "production": {
+      "ma": 200,
+      "vol_cap": 0.5,
+      "vol_window": 20
+    },
+    "base_leverage": 2.0,
+    "tier_mult": {
+      "green": 1.0,
+      "amber": 0.5,
+      "red": 0.0
+    }
+  },
+  "inputs": [
+    {
+      "symbol": "hkHSTECH",
+      "source": "tencent kline (day, unadjusted)",
+      "bars": 1370,
+      "first_session": "2021-01-04",
+      "last_session": "2026-07-31",
+      "digest": "sha256:3715c002b9d71428"
+    }
+  ],
+  "code": [
+    {
+      "file": "validate_regime_dial.py",
+      "digest": "sha256:6abe837747d67548"
+    },
+    {
+      "file": "compute_regime.py",
+      "digest": "sha256:0d55c686b98f39f1"
+    }
+  ],
+  "metrics": {
+    "in_sample": {
+      "n_sessions": 1369,
+      "dial_total_return": -0.851718,
+      "hold_total_return": -0.859672,
+      "dial_max_drawdown": -0.916061,
+      "hold_max_drawdown": -0.95487,
+      "drawdown_improvement": 0.038809,
+      "return_improvement": 0.007954,
+      "pct_time_at_full_leverage": 30.53
+    },
+    "tier_distribution": {
+      "sessions": 1369,
+      "counts": {
+        "green": 418,
+        "amber": 814,
+        "red": 137
+      },
+      "pct": {
+        "green": 30.5,
+        "amber": 59.5,
+        "red": 10.0
+      }
+    },
+    "walk_forward": {
+      "folds": [
+        {
+          "fold": 1,
+          "train": [
+            "2021-01-04",
+            "2022-12-23"
+          ],
+          "test": [
+            "2022-12-28",
+            "2023-11-20"
+          ],
+          "chosen_ma": 250,
+          "chosen_vol_cap": 0.4,
+          "chosen_matches_production": false,
+          "out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": -0.38083,
+            "hold_total_return": -0.113113,
+            "dial_max_drawdown": -0.500412,
+            "hold_max_drawdown": -0.476693,
+            "drawdown_improvement": -0.023719,
+            "return_improvement": -0.267717,
+            "pct_time_at_full_leverage": 40.45
+          },
+          "production_thresholds_out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": -0.332677,
+            "hold_total_return": -0.113113,
+            "dial_max_drawdown": -0.509216,
+            "hold_max_drawdown": -0.476693,
+            "drawdown_improvement": -0.032523,
+            "return_improvement": -0.219564,
+            "pct_time_at_full_leverage": 49.55
+          }
+        },
+        {
+          "fold": 2,
+          "train": [
+            "2021-01-04",
+            "2023-11-20"
+          ],
+          "test": [
+            "2023-11-21",
+            "2024-10-15"
+          ],
+          "chosen_ma": 250,
+          "chosen_vol_cap": 0.7,
+          "chosen_matches_production": false,
+          "out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": 0.187899,
+            "hold_total_return": 0.050456,
+            "dial_max_drawdown": -0.306064,
+            "hold_max_drawdown": -0.478468,
+            "drawdown_improvement": 0.172403,
+            "return_improvement": 0.137443,
+            "pct_time_at_full_leverage": 16.82
+          },
+          "production_thresholds_out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": 0.215584,
+            "hold_total_return": 0.050456,
+            "dial_max_drawdown": -0.346774,
+            "hold_max_drawdown": -0.478468,
+            "drawdown_improvement": 0.131693,
+            "return_improvement": 0.165128,
+            "pct_time_at_full_leverage": 21.82
+          }
+        },
+        {
+          "fold": 3,
+          "train": [
+            "2021-01-04",
+            "2024-10-15"
+          ],
+          "test": [
+            "2024-10-16",
+            "2025-09-04"
+          ],
+          "chosen_ma": 250,
+          "chosen_vol_cap": 0.7,
+          "chosen_matches_production": false,
+          "out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": 0.277667,
+            "hold_total_return": 0.383202,
+            "dial_max_drawdown": -0.505401,
+            "hold_max_drawdown": -0.505401,
+            "drawdown_improvement": 0.0,
+            "return_improvement": -0.105535,
+            "pct_time_at_full_leverage": 87.27
+          },
+          "production_thresholds_out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": 0.199243,
+            "hold_total_return": 0.383202,
+            "dial_max_drawdown": -0.487525,
+            "hold_max_drawdown": -0.505401,
+            "drawdown_improvement": 0.017876,
+            "return_improvement": -0.183959,
+            "pct_time_at_full_leverage": 80.0
+          }
+        },
+        {
+          "fold": 4,
+          "train": [
+            "2021-01-04",
+            "2025-09-04"
+          ],
+          "test": [
+            "2025-09-05",
+            "2026-07-31"
+          ],
+          "chosen_ma": 250,
+          "chosen_vol_cap": 0.7,
+          "chosen_matches_production": false,
+          "out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": -0.18494,
+            "hold_total_return": -0.303374,
+            "dial_max_drawdown": -0.49607,
+            "hold_max_drawdown": -0.616676,
+            "drawdown_improvement": 0.120606,
+            "return_improvement": 0.118434,
+            "pct_time_at_full_leverage": 45.0
+          },
+          "production_thresholds_out_of_sample": {
+            "n_sessions": 220,
+            "dial_total_return": -0.260415,
+            "hold_total_return": -0.303374,
+            "dial_max_drawdown": -0.542735,
+            "hold_max_drawdown": -0.616676,
+            "drawdown_improvement": 0.073942,
+            "return_improvement": 0.042959,
+            "pct_time_at_full_leverage": 38.64
+          }
+        }
+      ],
+      "n_folds": 4,
+      "folds_with_shallower_drawdown": 2,
+      "mean_drawdown_improvement": 0.067323,
+      "production_mean_drawdown_improvement": 0.047747,
+      "threshold_stability": "unstable"
+    },
+    "permutation": {
+      "permutations": 2000,
+      "observed_drawdown_improvement": 0.038809,
+      "observed_return_improvement": 0.007954,
+      "p_value_drawdown": 0.92454,
+      "p_value_return": 0.97001,
+      "null_drawdown_improvement_median": 0.102316,
+      "null_drawdown_improvement_p95": 0.305674,
+      "null": "circular shift of the exposure path against returns",
+      "observed_switches": 79,
+      "null_switch_counts": [
+        79
+      ]
+    },
+    "sensitivity": {
+      "grid": [
+        {
+          "ma": 250,
+          "vol_cap": 0.7,
+          "drawdown_improvement": 0.120731,
+          "return_improvement": 0.182179,
+          "dial_max_drawdown": -0.83414
+        },
+        {
+          "ma": 200,
+          "vol_cap": 0.7,
+          "drawdown_improvement": 0.104912,
+          "return_improvement": 0.110287,
+          "dial_max_drawdown": -0.849958
+        },
+        {
+          "ma": 250,
+          "vol_cap": 0.4,
+          "drawdown_improvement": 0.100717,
+          "return_improvement": 0.119214,
+          "dial_max_drawdown": -0.854153
+        },
+        {
+          "ma": 100,
+          "vol_cap": 0.7,
+          "drawdown_improvement": 0.099388,
+          "return_improvement": 0.074749,
+          "dial_max_drawdown": -0.855482
+        },
+        {
+          "ma": 200,
+          "vol_cap": 0.4,
+          "drawdown_improvement": 0.085872,
+          "return_improvement": 0.063482,
+          "dial_max_drawdown": -0.868998
+        },
+        {
+          "ma": 100,
+          "vol_cap": 0.4,
+          "drawdown_improvement": 0.084571,
+          "return_improvement": 0.039337,
+          "dial_max_drawdown": -0.870299
+        },
+        {
+          "ma": 150,
+          "vol_cap": 0.7,
+          "drawdown_improvement": 0.078423,
+          "return_improvement": 0.063058,
+          "dial_max_drawdown": -0.876447
+        },
+        {
+          "ma": 250,
+          "vol_cap": 0.6,
+          "drawdown_improvement": 0.066012,
+          "return_improvement": 0.057609,
+          "dial_max_drawdown": -0.888858
+        },
+        {
+          "ma": 150,
+          "vol_cap": 0.4,
+          "drawdown_improvement": 0.063319,
+          "return_improvement": 0.02571,
+          "dial_max_drawdown": -0.891552
+        },
+        {
+          "ma": 200,
+          "vol_cap": 0.6,
+          "drawdown_improvement": 0.055838,
+          "return_improvement": 0.013932,
+          "dial_max_drawdown": -0.899032
+        },
+        {
+          "ma": 100,
+          "vol_cap": 0.6,
+          "drawdown_improvement": 0.053217,
+          "return_improvement": -0.006545,
+          "dial_max_drawdown": -0.901653
+        },
+        {
+          "ma": 250,
+          "vol_cap": 0.5,
+          "drawdown_improvement": 0.046735,
+          "return_improvement": 0.048844,
+          "dial_max_drawdown": -0.908135
+        },
+        {
+          "ma": 200,
+          "vol_cap": 0.5,
+          "drawdown_improvement": 0.038809,
+          "return_improvement": 0.007954,
+          "dial_max_drawdown": -0.916061
+        },
+        {
+          "ma": 150,
+          "vol_cap": 0.6,
+          "drawdown_improvement": 0.038013,
+          "return_improvement": -0.015222,
+          "dial_max_drawdown": -0.916857
+        },
+        {
+          "ma": 100,
+          "vol_cap": 0.5,
+          "drawdown_improvement": 0.036831,
+          "return_improvement": -0.011412,
+          "dial_max_drawdown": -0.918039
+        },
+        {
+          "ma": 150,
+          "vol_cap": 0.5,
+          "drawdown_improvement": 0.02399,
+          "return_improvement": -0.020069,
+          "dial_max_drawdown": -0.93088
+        }
+      ],
+      "best": {
+        "ma": 250,
+        "vol_cap": 0.7,
+        "drawdown_improvement": 0.120731,
+        "return_improvement": 0.182179,
+        "dial_max_drawdown": -0.83414
+      },
+      "production": {
+        "ma": 200,
+        "vol_cap": 0.5,
+        "drawdown_improvement": 0.038809,
+        "return_improvement": 0.007954,
+        "dial_max_drawdown": -0.916061
+      },
+      "production_rank": 13,
+      "neighbourhood_spread": 0.096741
+    }
+  },
+  "notes": [
+    "models the production tier mapping (green/amber/red -> 1.0/0.5/0.0) applied to a 2x sleeve, not 2x->cash"
+  ],
+  "data_boundary": "derived metrics and source names only; no raw vendor bars"
+}

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -108,7 +108,8 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `run_card.py` | 每次回测留证：输入序列身份(source/窗口/bar 数/摘要) + 参数 + 代码哈希 + 指标 JSON；`--list` / `--run-id` 复查。落 `memory/backtests/` | 纯本地 | ✅ |
 | `backtest_hstech_regime.py` | 恒科 regime 去杠杆回测(2021→今) | 腾讯 kline | ✅ |
 | `backtest_us_leverage.py` | 美股 2x ETF regime 回测 | 日线模拟 | ✅ |
-| `backtest_combined_regime.py` | 全组合 regime vs buy&hold vs 全 1x | 因子代理历史 | ✅ |
+| `backtest_combined_regime.py` | 全组合 regime vs buy&hold vs 全 1x（MA/vol 在各代理**原生交易日**上算，不用 union 日历填充值） | 因子代理历史 | ✅ |
+| `validate_regime_dial.py` | 杠杆刻度盘样本外验证：walk-forward + 环形位移置换检验 + 阈值敏感面；建模的是**生产 tier 映射**(1.0/0.5/0.0)而非 2x→cash | 腾讯 kline | ✅ |
 | `decision_v2.py` | strategy episode 结算、coverage、严格前向分层 confidence 校准、方向命中审计 | decisions ledger + canonical bars | ✅ |
 | `risk_discipline.py` | 持久 breach 账本、确认/限时 override、成交证据与同风险增仓冻结 | guardrail + portfolio trades | ✅ |
 | `quant_signal_review.py` · `t0_setup_review.py` | 因子 / 牌面 edge 自检(T+1/T+5 命中率) | 本地留痕 | ✅ |

--- a/scripts/data/backtest_combined_regime.py
+++ b/scripts/data/backtest_combined_regime.py
@@ -157,10 +157,36 @@ def main():
         ff[k] = out
     n = len(dates)
 
-    # per-proxy daily returns (a market closed that day carries its price → 0 ret), 200DMA, 20d vol
+    # per-proxy daily returns (a market closed that day carries its price → 0 ret)
     ret = {k: [0.0] + [ff[k][i] / ff[k][i-1] - 1 if ff[k][i-1] else 0.0 for i in range(1, n)] for k in raw}
-    ma = {k: sma(ff[k], MA_WIN) for k in raw}
-    vol = {k: [rvol(ret[k], VOL_WIN, i) for i in range(n)] for k in raw}
+
+    # The dial's inputs are computed on each proxy's NATIVE sessions and then
+    # mapped onto the union calendar — not on the forward-filled series. A closed
+    # market contributes a 0% return on the union calendar, and those injected
+    # zero-variance days deflate 20d realised vol, which is one of the two dial
+    # inputs. Production (compute_regime) reads HSTECH's own sessions, so
+    # measuring vol here on the union calendar meant the backtest and the live
+    # dial were reading different numbers from the same rule.
+    ma, vol = {}, {}
+    for k, s in raw.items():
+        native_dates = sorted(s)
+        native_closes = [s[d] for d in native_dates]
+        native_rets = [0.0] + [native_closes[i] / native_closes[i-1] - 1
+                               for i in range(1, len(native_closes))]
+        native_ma = sma(native_closes, MA_WIN)
+        native_vol = [rvol(native_rets, VOL_WIN, i) for i in range(len(native_closes))]
+        by_date_ma = dict(zip(native_dates, native_ma))
+        by_date_vol = dict(zip(native_dates, native_vol))
+        # Carry the last native reading forward across a closed session: the dial
+        # does not update on a day the market did not trade, and it does not go
+        # blind either.
+        ma[k], vol[k] = [], []
+        last_ma = last_vol = None
+        for d in dates:
+            if d in by_date_ma:
+                last_ma, last_vol = by_date_ma[d], by_date_vol[d]
+            ma[k].append(last_ma)
+            vol[k].append(last_vol)
 
     w, tot_usd = weights_usd()
     print(f'Combined book ≈ ${tot_usd:,.0f}  · 共 {len(w)} 持仓 · 窗口 {dates[0]} → {dates[-1]} ({n} 交易日)')

--- a/scripts/data/compute_regime.py
+++ b/scripts/data/compute_regime.py
@@ -13,10 +13,37 @@ Evidence: run card `hstech_regime-20260802-f7d80e00` (1370 HSTECH bars,
 maxDD -95.5% against -44.2% for the de-levered 1x variant. Re-derive with
 `python3 scripts/data/run_card.py --run-id hstech_regime-20260802-f7d80e00`.
 
-Two caveats the card makes visible and this docstring previously did not:
-the thresholds were calibrated on the same window they are scored on (#233),
-and no backtested row is exactly this module's production dial — the card's
-"Regime 2x" goes to cash when trend-off, while production de-levers 2x→1x.
+READ THIS BEFORE QUOTING THE NUMBERS ABOVE. Neither of them describes the dial
+this module actually ships. Both come from rows that switch a 2x sleeve to
+*cash* (or hold a 1x sleeve) on the trend signal alone. What ships is the tier
+mapping below: `amber` only halves the cap, and `red` needs trend-off AND
+vol-hot together. HSTECH's 20d vol sits under 50% through much of a slow
+decline, so the common crash state is amber — 1x on a 2x sleeve, not cash.
+
+`validate_regime_dial.py` models that shipped mapping and reports
+(run card `regime_dial_validation-20260802-896b2145`, 1370 bars,
+2021-01-04 → 2026-07-31):
+
+  in-sample     maxDD -91.6% vs always-2x -95.5% — an improvement of +3.9pp,
+                not the -95%→-44% the rows above suggest
+  tiers fired   green 30.5% · amber 59.5% · red 10.0%
+  permutation   p = 0.92 for drawdown, 0.97 for return. The observed
+                improvement is WORSE than the median random re-timing of the
+                same exposure path (+10.2pp), so on this window the dial's
+                timing is not distinguishable from chance
+  walk-forward  2 of 4 out-of-sample folds improved drawdown; the calibrated
+                thresholds were unstable and never chose 200/0.50
+  sensitivity   200/0.50 ranks 13th of 16 on the grid
+
+The dial is deliberately still here and unchanged. One index and one crash
+cannot support "this does not work" any more than they supported "this does";
+p = 0.92 is a failure to reject, not a refutation, and the module's other job —
+capping leveraged exposure when the regime turns hostile — is a risk-appetite
+rule that does not need a timing edge to be worth keeping. What is no longer
+defensible is the previous framing, in which a -95%→-44% figure from a
+different strategy read as evidence for this one.
+
+Re-derive: `python3 scripts/data/validate_regime_dial.py`.
 
 The single biggest lever was LEVERAGE (2x→1x→cash), not timing. So this module
 emits a leverage-cap MULTIPLIER that tightens the guardrail's leveraged-ETF leg cap

--- a/scripts/data/validate_regime_dial.py
+++ b/scripts/data/validate_regime_dial.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Is the leverage dial evidence, or one lucky crash?
+
+The problem
+-----------
+`compute_regime.py` gates the largest exposure in the book, and its justification
+is a single in-sample number: the 200DMA / 20d-vol thresholds were chosen on the
+same 2021→now HSTECH window the improvement is reported on, and the effective
+sample contains roughly *one* crash. A -95% → -44% headline from a fit over one
+regime transition is exactly the kind of number that does not survive contact
+with the next one.
+
+The repo already holds itself to a higher bar elsewhere: `cross_sectional_factor`
+refuses to activate a rule on retrospective evidence and validates walk-forward,
+and `quant_signal_review` gates factors on a clustered bootstrap CI that must not
+cross 50%. The dial is the one place where the strongest claim rested on the
+weakest evidence.
+
+What this measures
+------------------
+1. **Walk-forward** — thresholds are chosen on a training window and scored on
+   the *next* window only, rolling forward. Per-window out-of-sample results, not
+   one full-period headline.
+2. **Permutation** — the null is "the dial's timing carries no information". The
+   exposure path is circularly shifted against the returns, which preserves its
+   length, its time-in-market and its autocorrelation while destroying the
+   alignment. The p-value is where the observed improvement lands in that null.
+3. **Sensitivity** — the metric surface over the (MA, vol-cap) grid, so a
+   knife-edge fit is visible rather than implied.
+
+It models the *production* dial
+-------------------------------
+Existing backtests model 2x→cash or 2x→1x. Neither is what ships:
+`compute_regime.classify` emits a tier multiplier (green 1.0 / amber 0.5 / red
+0.0) that scales the leveraged-ETF cap. This module applies that same mapping to
+a 2x sleeve, so the thing being validated is the thing in production.
+
+This never writes to the live pipeline. It prints, and it leaves a run card.
+
+Run:
+  python3 scripts/data/validate_regime_dial.py
+  python3 scripts/data/validate_regime_dial.py --folds 4 --permutations 5000
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import random
+import sys
+from datetime import date
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_card  # noqa: E402
+
+WS = Path(__file__).resolve().parents[2]
+TENCENT = 'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
+
+# Production defaults, imported in spirit from compute_regime so the validated
+# object is the shipped one. Kept as literals rather than an import so this
+# script stays runnable when compute_regime's module-level fetch is unavailable.
+PROD_MA, PROD_VOL_CAP, PROD_VOL_WINDOW = 200, 0.50, 20
+BASE_LEVERAGE = 2.0
+TIER_MULT = {'green': 1.0, 'amber': 0.5, 'red': 0.0}
+
+MA_GRID = (100, 150, 200, 250)
+VOL_CAP_GRID = (0.40, 0.50, 0.60, 0.70)
+
+
+# ── data ────────────────────────────────────────────────────────────────────
+
+def fetch_hstech(start='2021-01-01', end=None, lim=2000):
+    end = end or date.today().isoformat()
+    url = f'{TENCENT}?param=hkHSTECH,day,{start},{end},{lim}'
+    payload = requests.get(url, timeout=20).json()
+    rows = (payload.get('data') or {}).get('hkHSTECH', {})
+    out = []
+    for row in rows.get('day') or rows.get('qfqday') or []:
+        try:
+            out.append((row[0], float(row[2])))
+        except (IndexError, ValueError, TypeError):
+            continue
+    return out
+
+
+# ── the dial, as production defines it ──────────────────────────────────────
+
+def trailing_mean(values, window):
+    out, total = [None] * len(values), 0.0
+    for i, value in enumerate(values):
+        total += value
+        if i >= window:
+            total -= values[i - window]
+        if i >= window - 1:
+            out[i] = total / window
+    return out
+
+
+def realized_vol(returns, window, i):
+    """Annualised stdev of the trailing `window` returns ending at `i`."""
+    if i < window:
+        return None
+    sample = returns[i - window + 1:i + 1]
+    mean = sum(sample) / window
+    variance = sum((x - mean) ** 2 for x in sample) / (window - 1)
+    return math.sqrt(variance) * math.sqrt(252)
+
+
+def tier_for(trend_on, vol_ok):
+    """compute_regime.classify's mapping, isolated so drift is visible."""
+    if trend_on and vol_ok:
+        return 'green'
+    if (not trend_on) and (not vol_ok):
+        return 'red'
+    return 'amber'
+
+
+def exposure_path(closes, *, ma_window=PROD_MA, vol_cap=PROD_VOL_CAP,
+                  vol_window=PROD_VOL_WINDOW, base=BASE_LEVERAGE):
+    """Daily leverage the dial would have permitted. Index i uses data up to i-1.
+
+    Look-ahead is structurally impossible: the signal for day i is built from
+    closes and vols through i-1, exactly as the live dial reads yesterday's bar.
+    """
+    n = len(closes)
+    returns = [0.0] + [closes[i] / closes[i - 1] - 1 for i in range(1, n)]
+    ma = trailing_mean(closes, ma_window)
+    vols = [realized_vol(returns, vol_window, i) for i in range(n)]
+
+    exposure, tiers = [], []
+    for i in range(1, n):
+        trend_on = ma[i - 1] is not None and closes[i - 1] > ma[i - 1]
+        vol_ok = vols[i - 1] is not None and vols[i - 1] < vol_cap
+        tier = tier_for(trend_on, vol_ok)
+        tiers.append(tier)
+        exposure.append(base * TIER_MULT[tier])
+    return returns[1:], exposure, tiers
+
+
+def nav_from(returns, exposure):
+    nav = [1.0]
+    for ret, lev in zip(returns, exposure):
+        nav.append(nav[-1] * (1 + lev * ret))
+    return nav
+
+
+def max_drawdown(nav):
+    peak, worst = -1e9, 0.0
+    for value in nav:
+        peak = max(peak, value)
+        worst = min(worst, value / peak - 1)
+    return worst
+
+
+def tier_distribution(tiers):
+    """How often each tier actually fires — the mechanism behind the result.
+
+    The dial only reaches `red` when trend-off AND vol-hot coincide. HSTECH's
+    20d vol sits below 50% for much of a slow decline, so `amber` (half the cap,
+    i.e. 1x on a 2x sleeve) is the common crash state, not cash.
+    """
+    total = len(tiers)
+    counts = {tier: tiers.count(tier) for tier in ('green', 'amber', 'red')}
+    return {
+        'sessions': total,
+        'counts': counts,
+        'pct': {tier: round(100 * n / total, 1) if total else None
+                for tier, n in counts.items()},
+    }
+
+
+def summarize(returns, exposure, base=BASE_LEVERAGE):
+    """Dial vs an always-on sleeve over the same returns."""
+    dial = nav_from(returns, exposure)
+    hold = nav_from(returns, [base] * len(returns))
+    dial_dd, hold_dd = max_drawdown(dial), max_drawdown(hold)
+    return {
+        'n_sessions': len(returns),
+        'dial_total_return': round(dial[-1] - 1, 6),
+        'hold_total_return': round(hold[-1] - 1, 6),
+        'dial_max_drawdown': round(dial_dd, 6),
+        'hold_max_drawdown': round(hold_dd, 6),
+        # Positive = the dial made the drawdown shallower.
+        'drawdown_improvement': round(dial_dd - hold_dd, 6),
+        'return_improvement': round(dial[-1] - hold[-1], 6),
+        'pct_time_at_full_leverage': round(
+            100 * sum(1 for e in exposure if e >= base) / len(exposure), 2)
+        if exposure else None,
+    }
+
+
+# ── 1. walk-forward ─────────────────────────────────────────────────────────
+
+def _score(returns, exposure):
+    """Calibration objective: shallower drawdown first, return as tie-break.
+
+    The dial exists to control drawdown, so it is selected on drawdown. Choosing
+    on return instead would validate a different instrument than the one shipped.
+    """
+    stats = summarize(returns, exposure)
+    return (stats['drawdown_improvement'], stats['return_improvement'])
+
+
+def best_thresholds(closes, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID):
+    best, best_score = None, None
+    for ma_window in ma_grid:
+        for vol_cap in vol_grid:
+            returns, exposure, _ = exposure_path(
+                closes, ma_window=ma_window, vol_cap=vol_cap)
+            if not returns:
+                continue
+            score = _score(returns, exposure)
+            if best_score is None or score > best_score:
+                best, best_score = (ma_window, vol_cap), score
+    return best
+
+
+def walk_forward(dates, closes, *, folds=4, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID):
+    """Calibrate on a leading window, score on the next one, roll forward.
+
+    Warmup matters: a fold shorter than the longest MA in the grid cannot form a
+    signal, so the split is over the usable tail and each training window keeps
+    every bar before it.
+    """
+    longest = max(ma_grid)
+    usable_start = longest + max(VOL_CAP_GRID and [PROD_VOL_WINDOW] or [0])
+    if len(closes) <= usable_start + folds * 2:
+        return {'folds': [], 'reason': (
+            f'{len(closes)} bars cannot support {folds} folds after a '
+            f'{usable_start}-bar warmup')}
+
+    span = len(closes) - usable_start
+    edges = [usable_start + round(span * k / (folds + 1)) for k in range(folds + 2)]
+
+    results = []
+    for k in range(1, folds + 1):
+        train_end, test_end = edges[k], edges[k + 1]
+        chosen = best_thresholds(closes[:train_end], ma_grid, vol_grid)
+        if chosen is None:
+            continue
+        ma_window, vol_cap = chosen
+
+        # Score on the test slice only, but build the signal from the full
+        # history up to each point — otherwise the first 200 test bars have no
+        # MA and the fold would measure warmup, not the rule.
+        returns, exposure, _ = exposure_path(
+            closes[:test_end], ma_window=ma_window, vol_cap=vol_cap)
+        offset = train_end - 1
+        oos = summarize(returns[offset:], exposure[offset:])
+
+        prod_returns, prod_exposure, _ = exposure_path(closes[:test_end])
+        prod = summarize(prod_returns[offset:], prod_exposure[offset:])
+
+        results.append({
+            'fold': k,
+            'train': [dates[0], dates[train_end - 1]],
+            'test': [dates[train_end], dates[test_end - 1]],
+            'chosen_ma': ma_window,
+            'chosen_vol_cap': vol_cap,
+            'chosen_matches_production': bool(
+                ma_window == PROD_MA and abs(vol_cap - PROD_VOL_CAP) < 1e-9),
+            'out_of_sample': oos,
+            'production_thresholds_out_of_sample': prod,
+        })
+
+    improvements = [r['out_of_sample']['drawdown_improvement'] for r in results]
+    prod_improvements = [
+        r['production_thresholds_out_of_sample']['drawdown_improvement']
+        for r in results]
+    return {
+        'folds': results,
+        'n_folds': len(results),
+        'folds_with_shallower_drawdown': sum(1 for x in improvements if x > 0),
+        'mean_drawdown_improvement': (
+            round(sum(improvements) / len(improvements), 6) if improvements else None),
+        'production_mean_drawdown_improvement': (
+            round(sum(prod_improvements) / len(prod_improvements), 6)
+            if prod_improvements else None),
+        'threshold_stability': (
+            'stable' if len({(r['chosen_ma'], r['chosen_vol_cap']) for r in results}) == 1
+            else 'unstable'),
+    }
+
+
+# ── 2. permutation ──────────────────────────────────────────────────────────
+
+def permutation_test(returns, exposure, *, permutations=2000, seed=20260802):
+    """Circular-shift null: same exposure path, wrong place in time.
+
+    Shuffling the exposure vector outright would destroy its autocorrelation and
+    make almost any real signal look significant. A circular shift keeps the
+    path's shape, its time-in-market and its clustering, and only breaks the
+    alignment with returns — which is precisely the thing being claimed.
+    """
+    if len(returns) < 30 or len(returns) != len(exposure):
+        return {'p_value_drawdown': None, 'p_value_return': None,
+                'reason': 'need at least 30 aligned sessions'}
+
+    observed = summarize(returns, exposure)
+    rng = random.Random(seed)
+    n = len(exposure)
+    dd_at_least, ret_at_least = 0, 0
+    null_dd = []
+    switch_counts = set()
+    for _ in range(permutations):
+        shift = rng.randrange(1, n)
+        shifted = exposure[shift:] + exposure[:shift]
+        switch_counts.add(circular_switches(shifted))
+        stats = summarize(returns, shifted)
+        null_dd.append(stats['drawdown_improvement'])
+        if stats['drawdown_improvement'] >= observed['drawdown_improvement']:
+            dd_at_least += 1
+        if stats['return_improvement'] >= observed['return_improvement']:
+            ret_at_least += 1
+
+    null_dd.sort()
+    # +1 in numerator and denominator: the observed path is itself one draw from
+    # the null, so a p-value of exactly 0 is not a claim the data can support.
+    return {
+        'permutations': permutations,
+        'observed_drawdown_improvement': observed['drawdown_improvement'],
+        'observed_return_improvement': observed['return_improvement'],
+        'p_value_drawdown': round((dd_at_least + 1) / (permutations + 1), 5),
+        'p_value_return': round((ret_at_least + 1) / (permutations + 1), 5),
+        'null_drawdown_improvement_median': round(null_dd[len(null_dd) // 2], 6),
+        'null_drawdown_improvement_p95': round(null_dd[int(0.95 * len(null_dd))], 6),
+        'null': 'circular shift of the exposure path against returns',
+        # Published as proof the null is the hard one. A circular shift cannot
+        # change how many times the exposure path switches level (counted
+        # around the wrap), so every draw shares the observed count. A plain
+        # shuffle would shatter it — and would make almost any real signal look
+        # significant by comparison.
+        'observed_switches': circular_switches(exposure),
+        'null_switch_counts': sorted(switch_counts),
+    }
+
+
+def circular_switches(path):
+    """How many times the path changes level, counted around the wrap."""
+    if not path:
+        return 0
+    return sum(1 for a, b in zip(path, path[1:] + path[:1]) if a != b)
+
+
+# ── 3. sensitivity ──────────────────────────────────────────────────────────
+
+def sensitivity_surface(closes, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID):
+    surface = []
+    for ma_window in ma_grid:
+        for vol_cap in vol_grid:
+            returns, exposure, _ = exposure_path(
+                closes, ma_window=ma_window, vol_cap=vol_cap)
+            if not returns:
+                continue
+            stats = summarize(returns, exposure)
+            surface.append({
+                'ma': ma_window, 'vol_cap': vol_cap,
+                'drawdown_improvement': stats['drawdown_improvement'],
+                'return_improvement': stats['return_improvement'],
+                'dial_max_drawdown': stats['dial_max_drawdown'],
+            })
+    surface.sort(key=lambda row: -row['drawdown_improvement'])
+    best = surface[0] if surface else None
+    production = next(
+        (row for row in surface
+         if row['ma'] == PROD_MA and abs(row['vol_cap'] - PROD_VOL_CAP) < 1e-9),
+        None)
+    return {
+        'grid': surface,
+        'best': best,
+        'production': production,
+        'production_rank': (surface.index(production) + 1) if production else None,
+        'neighbourhood_spread': (
+            round(max(r['drawdown_improvement'] for r in surface)
+                  - min(r['drawdown_improvement'] for r in surface), 6)
+            if surface else None),
+    }
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--folds', type=int, default=4)
+    ap.add_argument('--permutations', type=int, default=2000)
+    ap.add_argument('--no-card', action='store_true',
+                    help='skip writing a run card (for ad-hoc exploration)')
+    args = ap.parse_args()
+
+    data = fetch_hstech()
+    if len(data) < 400:
+        print(f'HSTECH fetch returned {len(data)} bars — not enough to validate',
+              file=sys.stderr)
+        return 1
+    dates = [d for d, _ in data]
+    closes = [c for _, c in data]
+    print(f'HSTECH {len(closes)} bars  {dates[0]} → {dates[-1]}\n')
+
+    full_returns, full_exposure, full_tiers = exposure_path(closes)
+    in_sample = summarize(full_returns, full_exposure)
+    tiers = tier_distribution(full_tiers)
+    print('--- in-sample, production thresholds (this is the weak claim) ---')
+    print(f'  dial maxDD {in_sample["dial_max_drawdown"]*100:.1f}%  vs '
+          f'always-2x {in_sample["hold_max_drawdown"]*100:.1f}%  '
+          f'(improvement {in_sample["drawdown_improvement"]*100:+.1f}pp)')
+    print(f'  dial totRet {in_sample["dial_total_return"]*100:.0f}%  vs '
+          f'always-2x {in_sample["hold_total_return"]*100:.0f}%')
+    print(f'  tiers: green {tiers["pct"]["green"]}% (2x) · '
+          f'amber {tiers["pct"]["amber"]}% (1x) · red {tiers["pct"]["red"]}% (cash)')
+
+    wf = walk_forward(dates, closes, folds=args.folds)
+    print('\n--- walk-forward (thresholds chosen on the past, scored on the next window) ---')
+    if not wf.get('folds'):
+        print(f'  unavailable: {wf.get("reason")}')
+    else:
+        print(f'{"fold":<6}{"test window":<26}{"chosen":<14}{"OOS ΔmaxDD":>12}'
+              f'{"prod ΔmaxDD":>13}')
+        for fold in wf['folds']:
+            chosen = f'{fold["chosen_ma"]}/{fold["chosen_vol_cap"]:.2f}'
+            print(f'{fold["fold"]:<6}{fold["test"][0]}→{fold["test"][1]:<14}'
+                  f'{chosen:<14}'
+                  f'{fold["out_of_sample"]["drawdown_improvement"]*100:>11.1f}pp'
+                  f'{fold["production_thresholds_out_of_sample"]["drawdown_improvement"]*100:>12.1f}pp')
+        print(f'  {wf["folds_with_shallower_drawdown"]}/{wf["n_folds"]} folds '
+              f'improved drawdown out of sample · thresholds {wf["threshold_stability"]}')
+
+    perm = permutation_test(full_returns, full_exposure,
+                            permutations=args.permutations)
+    print('\n--- permutation test (null: the timing carries no information) ---')
+    if perm.get('reason'):
+        print(f'  unavailable: {perm["reason"]}')
+    else:
+        print(f'  observed ΔmaxDD {perm["observed_drawdown_improvement"]*100:+.1f}pp · '
+              f'null median {perm["null_drawdown_improvement_median"]*100:+.1f}pp · '
+              f'null p95 {perm["null_drawdown_improvement_p95"]*100:+.1f}pp')
+        print(f'  p(drawdown) = {perm["p_value_drawdown"]:.4f}   '
+              f'p(return) = {perm["p_value_return"]:.4f}')
+
+    surface = sensitivity_surface(closes)
+    print('\n--- threshold sensitivity (is 200/0.50 a peak or a plateau?) ---')
+    if surface['production']:
+        print(f'  production 200/0.50 ranks {surface["production_rank"]}'
+              f'/{len(surface["grid"])} on drawdown improvement; '
+              f'grid spread {surface["neighbourhood_spread"]*100:.1f}pp')
+        print(f'  best on this window: {surface["best"]["ma"]}/'
+              f'{surface["best"]["vol_cap"]:.2f} '
+              f'({surface["best"]["drawdown_improvement"]*100:+.1f}pp)')
+
+    if not args.no_card:
+        card = run_card.record(
+            'regime_dial_validation',
+            params={'folds': args.folds, 'permutations': args.permutations,
+                    'ma_grid': list(MA_GRID), 'vol_cap_grid': list(VOL_CAP_GRID),
+                    'production': {'ma': PROD_MA, 'vol_cap': PROD_VOL_CAP,
+                                   'vol_window': PROD_VOL_WINDOW},
+                    'base_leverage': BASE_LEVERAGE, 'tier_mult': TIER_MULT},
+            inputs=[{'symbol': 'hkHSTECH', 'source': 'tencent kline (day, unadjusted)',
+                     'bars': len(closes), 'first_session': dates[0],
+                     'last_session': dates[-1],
+                     'digest': run_card.series_digest(data)}],
+            metrics={'in_sample': in_sample, 'tier_distribution': tiers,
+                     'walk_forward': wf, 'permutation': perm,
+                     'sensitivity': surface},
+            code_files=[__file__, Path(__file__).with_name('compute_regime.py')],
+            notes=['models the production tier mapping (green/amber/red -> '
+                   '1.0/0.5/0.0) applied to a 2x sleeve, not 2x->cash'],
+        )
+        print(f'\nrun card: {card.relative_to(WS)}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_validate_regime_dial.py
+++ b/tests/test_validate_regime_dial.py
@@ -1,0 +1,281 @@
+"""The leverage dial's justification was one in-sample number over one crash.
+
+`compute_regime.py` gates the largest exposure in the book on thresholds chosen
+over the same window the improvement is reported on. The repo already refuses
+retrospective activation elsewhere (`cross_sectional_factor`) and gates factors
+on a clustered CI (`quant_signal_review`); the dial was the exception.
+
+These tests hold the validator itself honest: no look-ahead, a null that is hard
+rather than easy to beat, and a tier mapping that cannot drift away from the one
+in production.
+
+Run: python3 -m pytest tests/test_validate_regime_dial.py -q
+"""
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "scripts" / "data"
+sys.path.insert(0, str(DATA))
+
+import validate_regime_dial as dial  # noqa: E402
+
+
+def _ramp(n, step=0.01, start=100.0):
+    """A monotonically rising series — trend-on everywhere once the MA forms."""
+    closes, price = [], start
+    for _ in range(n):
+        closes.append(price)
+        price *= (1 + step)
+    return closes
+
+
+def _crash(n_up=300, n_down=300, step=0.01):
+    closes = _ramp(n_up, step)
+    price = closes[-1]
+    for _ in range(n_down):
+        price *= (1 - step)
+        closes.append(price)
+    return closes
+
+
+# ── the mapping must be production's, not a lookalike ───────────────────────
+
+@pytest.mark.parametrize("trend_on", [True, False])
+@pytest.mark.parametrize("vol_ok", [True, False])
+def test_the_tier_mapping_matches_the_shipped_classifier(trend_on, vol_ok):
+    """If compute_regime.classify changes and this does not, the validator
+    silently starts validating a rule nobody ships."""
+    import compute_regime
+
+    close = 110.0 if trend_on else 90.0
+    vol = 0.10 if vol_ok else 0.90
+    _, _, prod_tier, prod_mult, _ = compute_regime.classify(close, 100.0, vol)
+
+    assert dial.tier_for(trend_on, vol_ok) == prod_tier
+    assert dial.TIER_MULT[prod_tier] == prod_mult
+
+
+def test_the_production_constants_match_compute_regime():
+    import compute_regime
+
+    assert dial.PROD_MA == compute_regime.MA_WINDOW
+    assert dial.PROD_VOL_CAP == compute_regime.VOL_CAP
+    assert dial.PROD_VOL_WINDOW == compute_regime.VOL_WINDOW
+
+
+# ── no look-ahead ───────────────────────────────────────────────────────────
+
+def test_the_signal_for_a_day_cannot_see_that_day():
+    """Exposure for session i must be a function of closes through i-1 only.
+
+    Two series identical except for the final bar must produce the same exposure
+    for that final session — a rule that peeked at today's close would size
+    itself differently once today's close changed. (Checking that appending a
+    bar leaves earlier exposures alone does NOT catch this: a trailing MA never
+    depends on the future either way.)
+    """
+    # A flat series puts the MA exactly at the price, so the two variants land on
+    # opposite sides of it and a peeking rule is forced to disagree with itself.
+    # (A crash fixture does not work here: deep in a downtrend both variants are
+    # still below the MA, so look-ahead changes nothing and the test passes.)
+    flat = [100.0] * 400
+    crashed = flat[:-1] + [50.0]
+    mooned = flat[:-1] + [150.0]
+
+    _, exposure_flat, _ = dial.exposure_path(flat)
+    _, exposure_crashed, _ = dial.exposure_path(crashed)
+    _, exposure_mooned, _ = dial.exposure_path(mooned)
+
+    assert exposure_crashed[-1] == exposure_mooned[-1], (
+        "the last session's exposure moved with the last session's own close — "
+        "the trend leg is reading the bar it is supposed to precede")
+    # Compared against the untouched history too, so the *volatility* leg is
+    # pinned as well: a final -50% bar blows the 20d vol past the cap, and a rule
+    # that reads vols[i] instead of vols[i-1] would de-risk on a day it could not
+    # yet have seen. Comparing the two shocked variants alone misses that,
+    # because both shocks move vol the same way.
+    assert exposure_crashed == exposure_flat == exposure_mooned
+
+
+def test_a_rising_series_is_held_at_full_leverage():
+    closes = _ramp(400)
+    _, exposure, tiers = dial.exposure_path(closes)
+
+    tail = exposure[-50:]
+    assert all(e == dial.BASE_LEVERAGE for e in tail), set(tail)
+    assert tiers[-1] == "green"
+
+
+def test_a_collapsing_series_ends_de_risked():
+    closes = _crash()
+    _, exposure, tiers = dial.exposure_path(closes)
+
+    assert exposure[-1] < dial.BASE_LEVERAGE
+    assert tiers[-1] in {"amber", "red"}
+
+
+# ── the arithmetic ──────────────────────────────────────────────────────────
+
+def test_nav_compounds_the_levered_return():
+    nav = dial.nav_from([0.10, -0.10], [2.0, 2.0])
+
+    assert nav[-1] == pytest.approx(1.2 * 0.8)
+
+
+def test_max_drawdown_is_peak_to_trough():
+    assert dial.max_drawdown([1.0, 1.5, 0.75, 1.0]) == pytest.approx(-0.5)
+
+
+def test_summarize_reports_improvement_as_dial_minus_hold():
+    returns = [0.05, -0.20, 0.05]
+    stats = dial.summarize(returns, [2.0, 0.0, 2.0])
+
+    assert stats["dial_max_drawdown"] > stats["hold_max_drawdown"]
+    assert stats["drawdown_improvement"] > 0
+
+
+def test_a_dial_that_never_de_risks_shows_no_improvement():
+    returns = [0.05, -0.20, 0.05]
+
+    stats = dial.summarize(returns, [2.0, 2.0, 2.0])
+
+    assert stats["drawdown_improvement"] == 0.0
+    assert stats["return_improvement"] == 0.0
+
+
+def test_tier_distribution_sums_to_the_sample():
+    _, _, tiers = dial.exposure_path(_crash())
+
+    out = dial.tier_distribution(tiers)
+
+    assert sum(out["counts"].values()) == out["sessions"] == len(tiers)
+    assert sum(out["pct"].values()) == pytest.approx(100.0, abs=0.2)
+
+
+# ── the null has to be hard to beat ─────────────────────────────────────────
+
+def test_the_permutation_null_preserves_time_in_market():
+    """A plain shuffle would destroy the exposure path's autocorrelation and make
+    almost any signal look significant. A circular shift keeps the shape and only
+    breaks the alignment — which is the thing under test."""
+    closes = _crash()
+    returns, exposure, _ = dial.exposure_path(closes)
+
+    out = dial.permutation_test(returns, exposure, permutations=200)
+
+    assert out["null"].startswith("circular shift")
+    assert 0 < out["p_value_drawdown"] <= 1
+    # The load-bearing part: a circular shift cannot change how many times the
+    # path switches level, so every draw shares the observed count. A shuffle
+    # would shatter it, and an easy null makes any signal look significant.
+    assert out["null_switch_counts"] == [out["observed_switches"]]
+    assert out["observed_switches"] > 1, "fixture must actually switch levels"
+
+
+def test_a_p_value_of_zero_is_impossible_even_for_a_perfectly_timed_dial():
+    """One session carries the entire crash and the dial is flat exactly there.
+    No shift can match it, so the raw count is 0 — and 0/N would publish p=0.0,
+    a claim no finite sample supports."""
+    returns = [0.002] * 60
+    returns[30] = -0.45
+    exposure = [2.0] * 60
+    exposure[30] = 0.0
+
+    out = dial.permutation_test(returns, exposure, permutations=100, seed=3)
+
+    assert out["p_value_drawdown"] == pytest.approx(1 / 101, abs=1e-6)
+    assert out["observed_drawdown_improvement"] > 0
+
+
+def test_a_p_value_can_never_be_exactly_zero():
+    """The observed path is itself one draw from the null, so 0.0 is a claim the
+    data cannot support."""
+    closes = _crash()
+    returns, exposure, _ = dial.exposure_path(closes)
+
+    out = dial.permutation_test(returns, exposure, permutations=50)
+
+    assert out["p_value_drawdown"] >= 1 / 51
+
+
+def test_the_permutation_test_is_deterministic_for_a_seed():
+    closes = _crash()
+    returns, exposure, _ = dial.exposure_path(closes)
+
+    first = dial.permutation_test(returns, exposure, permutations=100, seed=7)
+    second = dial.permutation_test(returns, exposure, permutations=100, seed=7)
+
+    assert first == second
+
+
+def test_a_short_sample_refuses_rather_than_returning_a_number():
+    out = dial.permutation_test([0.01] * 10, [2.0] * 10, permutations=100)
+
+    assert out["p_value_drawdown"] is None
+    assert "at least 30" in out["reason"]
+
+
+# ── walk-forward ────────────────────────────────────────────────────────────
+
+def test_walk_forward_scores_only_the_window_after_the_training_one():
+    closes = _crash(400, 400)
+    dates = [f"d{i:04d}" for i in range(len(closes))]
+
+    out = dial.walk_forward(dates, closes, folds=2, ma_grid=(100, 200),
+                            vol_grid=(0.4, 0.6))
+
+    assert out["n_folds"] == 2
+    for fold in out["folds"]:
+        assert fold["train"][1] < fold["test"][0], "test window overlaps training"
+    # Folds must not overlap each other either.
+    first, second = out["folds"]
+    assert first["test"][1] < second["test"][0]
+
+
+def test_walk_forward_says_so_when_the_series_is_too_short():
+    closes = _ramp(120)
+    dates = [f"d{i:04d}" for i in range(len(closes))]
+
+    out = dial.walk_forward(dates, closes, folds=4)
+
+    assert out["folds"] == []
+    assert "warmup" in out["reason"]
+
+
+def test_walk_forward_reports_the_production_thresholds_alongside_the_chosen_ones():
+    """The interesting question is not "what would have been best" but "how did
+    the shipped thresholds do out of sample"."""
+    closes = _crash(400, 400)
+    dates = [f"d{i:04d}" for i in range(len(closes))]
+
+    out = dial.walk_forward(dates, closes, folds=2, ma_grid=(100, 200),
+                            vol_grid=(0.4, 0.6))
+
+    for fold in out["folds"]:
+        assert "production_thresholds_out_of_sample" in fold
+        assert isinstance(fold["chosen_matches_production"], bool)
+
+
+# ── sensitivity ─────────────────────────────────────────────────────────────
+
+def test_the_sensitivity_surface_ranks_production_against_the_whole_grid():
+    closes = _crash(400, 400)
+
+    out = dial.sensitivity_surface(closes, ma_grid=(100, dial.PROD_MA),
+                                   vol_grid=(0.4, dial.PROD_VOL_CAP))
+
+    assert out["production"] is not None
+    assert 1 <= out["production_rank"] <= len(out["grid"])
+    assert out["neighbourhood_spread"] >= 0
+
+
+def test_every_reported_number_is_finite():
+    closes = _crash()
+    returns, exposure, _ = dial.exposure_path(closes)
+
+    for value in dial.summarize(returns, exposure).values():
+        assert value is None or isinstance(value, int) or math.isfinite(value)


### PR DESCRIPTION
Closes #233.

The dial gates the largest exposure in the book, and its justification was a single in-sample number over a single crash. This adds walk-forward calibration, a permutation test and a sensitivity surface — and the result is not what the docstring implied.

## The key move: it validates what actually ships

The existing backtests score rows that switch a 2x sleeve to **cash** on the trend signal. That is not the production dial. `compute_regime.classify` emits a tier multiplier — green 1.0 / amber 0.5 / **red 0.0** — where `red` requires trend-off **and** vol-hot together. HSTECH's 20d vol sits under 50% through much of a slow decline, so the common crash state is *amber*: 1x on a 2x sleeve, never cash.

Sanity check before trusting any of this: reconfiguring the tier map to 2x→cash reproduces the existing script's published rows **exactly** (−70.5% and −44.2%). The engine is right; the difference is the mapping.

## Findings — run card `regime_dial_validation-20260802-896b2145`

1370 bars, 2021-01-04 → 2026-07-31.

| | result |
|---|---|
| in-sample | maxDD **−91.6%** vs always-2x −95.5% → **+3.9pp**, not the −95%→−44% the docstring implied |
| tiers fired | green 30.5% (2x) · **amber 59.5% (1x)** · red 10.0% (cash) |
| permutation | **p = 0.92** (drawdown), 0.97 (return) |
| walk-forward | **2 of 4** OOS folds improved drawdown; thresholds unstable, never chose 200/0.50 |
| sensitivity | 200/0.50 ranks **13th of 16** on the grid |

The permutation line is the sharp one: the observed improvement (+3.9pp) is **worse than the median random re-timing** of the very same exposure path (+10.2pp). On this window the dial's timing is not distinguishable from chance.

## What I did *not* do

**I left the dial in place and unchanged.** One index and one crash cannot support "this does not work" any more than they supported "this does" — p = 0.92 is a failure to reject, not a refutation. And capping leveraged exposure in a hostile regime is a risk-appetite rule that does not need a timing edge to be worth keeping. Changing the tiers is kcn's call; publishing the evidence is mine. `compute_regime.py`'s docstring now leads with what the numbers do and do not show.

## Also fixed: the calendar mismatch

`backtest_combined_regime` computed MA and 20d vol on **union-calendar forward-filled** closes. Injected zero-return days deflate realised vol — and vol is one of the two dial inputs — while production reads HSTECH's native sessions. Both are now computed on native sessions and carried forward across closed ones, so the backtest and the live dial finally read the same number from the same rule.

## Verification

- `1471 passed, 4 xfailed`.
- The null is the hard one: a circular shift preserves the exposure path's length, time-in-market and autocorrelation, breaking only its alignment with returns. The result publishes `null_switch_counts` as proof every draw shares the observed switch count — a plain shuffle would shatter it.
- **Mutation-verified after two rounds.** The first four mutants all survived, which is the reason for the second round. Now caught: trend look-ahead, vol look-ahead, swapping the circular-shift null for a plain shuffle, and dropping the `+1` that makes `p = 0` impossible. The look-ahead test needed a *flat* price fixture — on a crash fixture both variants stay below the MA, so a peeking rule changes nothing and the test passes while proving nothing.