### PR TITLE
provenance: backtest claims must cite a run card that still matches (#245)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -199,6 +199,13 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: python3 scripts/data/generate_cron_docs.py --check
 
+      - name: Backtest claims cite a run card that still matches
+        # A stale citation is the failure that matters: it points at real
+        # evidence which no longer says what the claim says, so it reads as
+        # maximally credible while being wrong.
+        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        run: python3 scripts/data/claim_provenance.py --check
+
       - name: Validate research lifecycle artifacts
         # Every thesis, earnings and entry-gate artifact on disk must still be
         # valid — including that a gate's stated verdict matches the recomputed

--- a/config/claim-allowlist.json
+++ b/config/claim-allowlist.json
@@ -1,0 +1,7 @@
+{
+  "_doc": "Backtest figures that appear in prose without being asserted as this project's own result. Each entry needs a reason. An empty file is the healthy state — reach for this only when prose must quote a number in order to correct or retire it.",
+  "scripts/data/compute_regime.py": {
+    "values": [],
+    "reason": "The superseded -95%/-44% framing is quoted here in order to correct it, and both figures still resolve to the hstech run card, so no exemption is needed yet."
+  }
+}

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -105,6 +105,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 
 | 端点 | 数据 | 源 | 可达 |
 |---|---|---|:---:|
+| `claim_provenance.py` | 回测结论必须引用 run card，且卡里仍要含这个数字：**失效引用**（指向真证据但已对不上）比缺引用更危险 | `memory/backtests/*.json` | ✅ |
 | `run_card.py` | 每次回测留证：输入序列身份(source/窗口/bar 数/摘要) + 参数 + 代码哈希 + 指标 JSON；`--list` / `--run-id` 复查。落 `memory/backtests/` | 纯本地 | ✅ |
 | `backtest_hstech_regime.py` | 恒科 regime 去杠杆回测(2021→今) | 腾讯 kline | ✅ |
 | `backtest_us_leverage.py` | 美股 2x ETF regime 回测 | 日线模拟 | ✅ |

--- a/scripts/data/claim_provenance.py
+++ b/scripts/data/claim_provenance.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Backtest claims must cite a run card, and the card must still agree.
+
+The gap this closes
+-------------------
+Three provenance gates already exist and none of them can see a backtest claim:
+
+* `test_numeric_claims` catches report prose quoting magnitudes the harness
+  context never contained (#120);
+* `research_provenance.py` is fail-closed — for thesis and earnings artifacts;
+* `test_no_live_numbers_in_static_copy` keeps moving figures out of README.
+
+#234 gave every backtest a run card and #233 cited one from `compute_regime.py`.
+Nothing checks that a cited `run_id` exists, or that its metrics still match the
+sentence quoting them. The `-95% → -44%` framing survived for months precisely
+because no gate could see it — and the failure mode that matters is not a
+missing citation but a **stale** one: a claim that points at real evidence which
+no longer says what the claim says. That looks maximally credible and is wrong.
+
+What counts as a claim
+----------------------
+Deliberately narrow, because a fuzzy scanner that cries wolf gets disabled. A
+claim is a percentage or p-value on a line that also names a backtest quantity
+(`maxDD`, `drawdown`, `CAGR`, `p =`, `improvement`, `totRet`). Prose that merely
+discusses a number without asserting it is exempted through the allowlist.
+
+Fail-closed: a scanner error is a red gate, never "no claims found".
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+WS = Path(__file__).resolve().parents[2]
+CARDS_DIR = WS / 'memory' / 'backtests'
+ALLOWLIST = WS / 'config' / 'claim-allowlist.json'
+
+# Files whose prose makes backtest claims. Explicit, so adding a new claim
+# surface is a decision rather than an accident.
+SCANNED = (
+    'scripts/data/compute_regime.py',
+    'scripts/data/validate_regime_dial.py',
+    'scripts/data/backtest_hstech_regime.py',
+    'scripts/data/backtest_us_leverage.py',
+    'scripts/data/backtest_combined_regime.py',
+)
+
+QUANTITY = re.compile(
+    r'\b(maxDD|max_drawdown|drawdown|CAGR|totRet|total_return|improvement|'
+    r'p\s*[=＝]|p-value)\b', re.I)
+# -95%, +3.9pp, 0.92 after "p ="
+PERCENT = re.compile(r'([+-]?\d+(?:\.\d+)?)\s*(%|pp)')
+PVALUE = re.compile(r'p\s*[=＝]\s*([01](?:\.\d+)?)', re.I)
+RUN_ID = re.compile(r'\b([a-z_]+-\d{8}-[0-9a-f]{8})\b')
+
+TOLERANCE = 0.006   # 0.6pp — prose rounds to one decimal
+
+
+def load_cards(cards_dir: Path | None = None) -> dict:
+    cards_dir = Path(cards_dir or CARDS_DIR)
+    out = {}
+    for path in sorted(cards_dir.glob('*.json')):
+        card = json.loads(path.read_text())
+        out[card['run_id']] = card
+    return out
+
+
+def _numbers_in(node, acc: list) -> list:
+    """Every numeric value anywhere in a card's metrics."""
+    if isinstance(node, dict):
+        for value in node.values():
+            _numbers_in(value, acc)
+    elif isinstance(node, list):
+        for value in node:
+            _numbers_in(value, acc)
+    elif isinstance(node, (int, float)) and not isinstance(node, bool):
+        acc.append(float(node))
+    return acc
+
+
+def load_allowlist(path: Path | None = None) -> dict:
+    path = Path(path or ALLOWLIST)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def scan_text(text: str, *, source: str) -> list[dict]:
+    """Numeric backtest claims in one document, with their cited run_ids."""
+    cited = RUN_ID.findall(text)
+    claims = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if not QUANTITY.search(line):
+            continue
+        values = []
+        for raw, unit in PERCENT.findall(line):
+            values.append(float(raw) / 100.0)
+        for raw in PVALUE.findall(line):
+            values.append(float(raw))
+        for value in values:
+            claims.append({
+                'source': source, 'line': lineno, 'value': value,
+                'text': line.strip()[:120], 'cited': cited,
+            })
+    return claims
+
+
+def _matches_card(value: float, cards: list[dict]) -> bool:
+    for card in cards:
+        for number in _numbers_in(card.get('metrics'), []):
+            if abs(abs(number) - abs(value)) <= TOLERANCE:
+                return True
+    return False
+
+
+def check(root: Path | None = None, cards_dir: Path | None = None,
+          allowlist: Path | None = None) -> list[str]:
+    root = Path(root or WS)
+    cards = load_cards(cards_dir)
+    allowed = load_allowlist(allowlist)
+    problems = []
+
+    for rel in SCANNED:
+        path = root / rel
+        if not path.exists():
+            problems.append(f'{rel}: declared claim surface is missing')
+            continue
+        text = path.read_text()
+        claims = scan_text(text, source=rel)
+        if not claims:
+            continue
+
+        exempt = {float(v) for v in (allowed.get(rel) or {}).get('values', [])}
+        cited_cards = [cards[rid] for rid in set(
+            RUN_ID.findall(text)) if rid in cards]
+        unknown = [rid for rid in set(RUN_ID.findall(text)) if rid not in cards]
+        for rid in unknown:
+            problems.append(f'{rel}: cites run card {rid}, which does not exist')
+
+        for claim in claims:
+            if any(abs(claim['value'] - value) <= 1e-9 for value in exempt):
+                continue
+            if not cited_cards:
+                problems.append(
+                    f"{rel}:{claim['line']}: claims {claim['value']:+.4f} but the "
+                    f"file cites no run card — {claim['text']}")
+                continue
+            if not _matches_card(claim['value'], cited_cards):
+                problems.append(
+                    f"{rel}:{claim['line']}: claims {claim['value']:+.4f}, which "
+                    f"no cited run card contains — {claim['text']}")
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--check', action='store_true', help='exit non-zero on problems')
+    args = ap.parse_args()
+
+    try:
+        problems = check()
+    except Exception as exc:  # fail-closed: a broken scanner is a red gate
+        print(f'claim provenance scanner failed: {exc!r}', file=sys.stderr)
+        return 2
+
+    if problems:
+        print(f'❌ {len(problems)} unbacked backtest claim(s):', file=sys.stderr)
+        for problem in problems:
+            print(f'   · {problem}', file=sys.stderr)
+        return 1 if args.check else 0
+    print(f'✅ backtest claims in {len(SCANNED)} file(s) resolve to stored run cards')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_claim_provenance.py
+++ b/tests/test_claim_provenance.py
@@ -1,0 +1,94 @@
+"""The failure that matters is a stale citation, not a missing one.
+
+A claim pointing at a run card that no longer contains its number reads as
+maximally credible and is wrong. Three tests: the mismatch case, the
+non-existent-card case, and the real repository staying green.
+
+Run: python3 -m pytest tests/test_claim_provenance.py -q
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import claim_provenance as cp  # noqa: E402
+
+
+def _workspace(tmp_path, prose, metrics, run_id="fixture-20260802-abcdef12"):
+    (tmp_path / "scripts" / "data").mkdir(parents=True)
+    (tmp_path / "memory" / "backtests").mkdir(parents=True)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "scripts" / "data" / "compute_regime.py").write_text(prose)
+    (tmp_path / "memory" / "backtests" / f"{run_id}.json").write_text(
+        json.dumps({"run_id": run_id, "metrics": metrics}))
+    return tmp_path
+
+
+def _check(root):
+    return cp.check(root=root,
+                    cards_dir=root / "memory" / "backtests",
+                    allowlist=root / "config" / "claim-allowlist.json")
+
+
+def test_a_claim_whose_card_says_something_else_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(cp, "SCANNED", ("scripts/data/compute_regime.py",))
+    root = _workspace(
+        tmp_path,
+        prose='"""Evidence: run card fixture-20260802-abcdef12.\nmaxDD -55.5%\n"""\n',
+        metrics={"regime": {"max_drawdown": -0.916}})
+
+    problems = _check(root)
+
+    assert problems and "no cited run card contains" in problems[0]
+
+
+def test_the_same_claim_passes_when_the_card_agrees(tmp_path, monkeypatch):
+    monkeypatch.setattr(cp, "SCANNED", ("scripts/data/compute_regime.py",))
+    root = _workspace(
+        tmp_path,
+        prose='"""Evidence: run card fixture-20260802-abcdef12.\nmaxDD -91.6%\n"""\n',
+        metrics={"regime": {"max_drawdown": -0.916}})
+
+    assert _check(root) == []
+
+
+def test_citing_a_card_that_does_not_exist_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(cp, "SCANNED", ("scripts/data/compute_regime.py",))
+    root = _workspace(
+        tmp_path,
+        prose='"""Evidence: run card fixture-20260802-99999999.\nmaxDD -91.6%\n"""\n',
+        metrics={"regime": {"max_drawdown": -0.916}})
+
+    problems = _check(root)
+
+    assert any("does not exist" in problem for problem in problems)
+
+
+def test_the_allowlist_exempts_a_figure_quoted_in_order_to_correct_it(
+        tmp_path, monkeypatch):
+    """`compute_regime` quotes the superseded -95%/-44% framing precisely to
+    retire it. Corrective prose must stay legal, and the mechanism has to be
+    tested rather than assumed."""
+    monkeypatch.setattr(cp, "SCANNED", ("scripts/data/compute_regime.py",))
+    root = _workspace(
+        tmp_path,
+        prose='"""Evidence: run card fixture-20260802-abcdef12.\n'
+              'the old framing said maxDD -44.0%, which this replaces\n"""\n',
+        metrics={"regime": {"max_drawdown": -0.916}})
+    (root / "config" / "claim-allowlist.json").write_text(json.dumps({
+        "scripts/data/compute_regime.py": {"values": [-0.44], "reason": "retired"}
+    }))
+
+    assert _check(root) == []
+
+
+def test_the_repository_itself_is_green_and_the_scan_is_not_vacuous():
+    """A scanner that finds nothing passes trivially; assert it sees the real
+    claims in compute_regime.py as well as that they resolve."""
+    text = (ROOT / "scripts" / "data" / "compute_regime.py").read_text()
+    claims = cp.scan_text(text, source="compute_regime.py")
+
+    assert len(claims) >= 5, "the scanner stopped seeing real claims"
+    assert cp.check() == []


### PR DESCRIPTION
Closes #245.

Three provenance gates exist and **none can see a backtest claim**: `test_numeric_claims` covers report prose against harness context, `research_provenance` covers thesis/earnings artifacts, and the static-copy rule covers README. #234 gave every backtest a run card and #233 cited one — but nothing checked that a cited `run_id` resolves, or that the card still says what the sentence says. The `-95% → -44%` framing survived for months because no gate could see it.

## The failure this is actually about

Not a *missing* citation — a **stale** one. A claim pointing at real evidence that no longer contains its number reads as maximally credible and is wrong. That is the case the tests lead with.

## Scope, deliberately narrow

A claim is a percentage or p-value on a line that also names a backtest quantity (`maxDD`/`drawdown`/`CAGR`/`totRet`/`improvement`/`p =`), in a **declared** list of files. A fuzzy scanner that cries wolf gets disabled, so this one stays boring: cite a card, and the card must contain the figure within 0.6pp (prose rounds to one decimal).

Corrective prose stays legal — `compute_regime.py` quotes the superseded −95%/−44% framing precisely in order to retire it — via `config/claim-allowlist.json`. The exemption mechanism is **tested rather than assumed**.

Fail-closed: a scanner exception exits 2, never "no claims found".

## On the repository today

Finds **10 real claims** in `compute_regime.py`; all resolve to stored cards. Wired into `validate`.

Mutation-verified: changing `-91.6%` → `-55.5%` reds it; repointing the citation at a non-existent card reds it. One of the five tests asserts the scan is **not vacuous** (≥5 claims seen), because a scanner that finds nothing passes trivially.

`1495 passed, 4 xfailed` after rebasing onto #243.