### PR TITLE
integrity: run the money-conservation gate on the Actions publish path (#253)

### DIFF
--- a/scripts/data/safe_push.sh
+++ b/scripts/data/safe_push.sh
@@ -57,6 +57,38 @@ if git grep -nE '^(<<<<<<< |>>>>>>> )' HEAD -- 2>/dev/null | grep -q .; then
   exit 3
 fi
 
+# ── Money-conservation gate (2026-08-02) ─────────────────────────────────────
+# The integrity check used to live ONLY in .githooks/pre-push, which is active
+# solely where core.hooksPath=.githooks is configured. A fresh actions/checkout
+# carries no local git config, so the hook does not exist on a runner — and
+# brief-fallback.yml stages portfolio.json and pushes through this script. The
+# money file could therefore reach master with cash, positions and P&L never
+# reconciled, purely because of where the push originated.
+#
+# Scoped deliberately: it runs only when portfolio.json is actually part of what
+# is being pushed. A dashboard-only publish is never blocked by it, which keeps
+# the "detection must not degrade into not-publishing" rule intact for everything
+# except the one file where an unbalanced write must not be published at all.
+# `|| true` on both: under `set -e` a failing command substitution aborts the
+# whole script, which would turn any git hiccup into "push silently skipped".
+REPO_TOP="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+INTEGRITY_SCRIPT="${REPO_TOP:-.}/scripts/data/preflight_integrity.py"
+if git fetch "$REMOTE" "$BRANCH" -q 2>/dev/null; then
+  PORTFOLIO_TOUCHED="$(git diff --name-only FETCH_HEAD..HEAD -- portfolio.json 2>/dev/null || true)"
+else
+  # Cannot tell what is new; assume the money file is in scope rather than skip.
+  PORTFOLIO_TOUCHED="portfolio.json"
+fi
+if [ -n "$PORTFOLIO_TOUCHED" ] && [ -f "$INTEGRITY_SCRIPT" ]; then
+  echo "▸ portfolio.json is in this push — running money-conservation check…"
+  if ! python3 "$INTEGRITY_SCRIPT"; then
+    echo "✗ REFUSING TO PUSH — portfolio.json does not reconcile."
+    echo "  Cash, positions and P&L must balance before the money file is published."
+    echo "  Fix the ledger (see the findings above) and re-commit."
+    exit 4
+  fi
+fi
+
 for i in $(seq 1 $MAX_RETRIES); do
   if git push "$REMOTE" "$BRANCH"; then
     echo "✓ pushed on attempt $i"

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -99,3 +99,37 @@ def test_live_runtime_key_is_limited_to_live_checkout():
     safe_push = (ROOT / "scripts" / "data" / "safe_push.sh").read_text()
     assert '"/root/.openclaw/workspace"' in safe_push
     assert '"/root/.ssh/clawock_runtime_publish"' in safe_push
+
+
+def test_every_workflow_that_stages_the_money_file_pushes_through_the_gate():
+    """The money-conservation check lived only in .githooks/pre-push, which a
+    fresh actions/checkout never installs (no workflow sets core.hooksPath). So
+    brief-fallback could stage portfolio.json and push it with cash, positions
+    and P&L never reconciled — purely because of where the push originated.
+
+    The gate now lives in safe_push.sh; this asserts nothing can route around it.
+    """
+    workflows = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    offenders = []
+    for path in workflows:
+        text = path.read_text()
+        stages_money = any(
+            "portfolio.json" in line and line.strip().startswith(("git add", "- git add"))
+            or ("git add" in line and "portfolio.json" in line)
+            for line in text.splitlines())
+        if stages_money and "safe_push.sh" not in text:
+            offenders.append(path.name)
+
+    assert not offenders, (
+        "these workflows stage portfolio.json but do not push through "
+        f"safe_push.sh, so the money gate is not on their path: {offenders}")
+
+
+def test_safe_push_runs_the_money_check_when_the_money_file_moves():
+    text = (ROOT / "scripts" / "data" / "safe_push.sh").read_text()
+
+    assert "preflight_integrity.py" in text, (
+        "safe_push.sh no longer runs the money-conservation check — the Actions "
+        "publish path is unprotected again")
+    # Scoped, not blanket: a dashboard-only publish must not be blocked by it.
+    assert "portfolio.json" in text and "PORTFOLIO_TOUCHED" in text


### PR DESCRIPTION
Refs #253 (deliberately not closing — see below).

## The hole

The money-conservation check existed **only** in `.githooks/pre-push`, which is active solely where `core.hooksPath=.githooks` is configured. A fresh `actions/checkout` carries no local git config, so **the hook does not exist on a runner** — and `safe_push.sh` had *zero* references to `system_check` or `preflight_integrity`.

Meanwhile `.github/workflows/brief-fallback.yml:113` stages `portfolio.json` and line 127 pushes through `safe_push.sh`.

So the money file could reach `master` with cash, positions and P&L never reconciled — purely because of where the push originated. The `publish_ok` gate above it validates prose and plan, not arithmetic.

Found by Codex during the decoupling design review; verified here (`core.hooksPath` set in no workflow, 0 integrity references in `safe_push.sh`).

## Fix

`safe_push.sh` runs `preflight_integrity.py` before pushing, in the same place and style as the existing conflict-marker guard, refusing with exit 4.

**Scoped deliberately:** only when `portfolio.json` is actually part of the push. A dashboard-only publish is never blocked — which keeps *detection must not degrade into not-publishing* intact everywhere except the one file where an unbalanced write must not be published at all.

## A bug the existing tests caught

The first version used `INTEGRITY_SCRIPT="$(git rev-parse --show-toplevel)/..."`. Under `set -e`, a failing command substitution aborts the whole script — so any git hiccup would have become a **silently skipped push**. `test_safe_push_uses_and_cleans_ephemeral_actions_key` reds immediately on that. Both substitutions now end in `|| true`.

## What I did NOT do, on purpose

The issue also asks that a non-money CRITICAL stop blocking the pre-push hook (today it runs the full `system_check`, so an unrelated OpenClaw-health or cron-contract failure blocks a data publish). That is a **loosening of an existing gate on a live money system**, and it is kcn's call — not something to slip in while closing a hardening issue. #253 stays open for that half.

## Verification

`1508 passed, 4 xfailed`. Two contract tests, mutation-verified: no workflow may stage `portfolio.json` without `safe_push.sh` on its path, and `safe_push.sh` must keep running the check.