### PR TITLE
report: extract the deterministic core into the package (#251, slice 1)

### DIFF
--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -49,6 +49,47 @@ def _doctor(args) -> int:
     return 1
 
 
+
+def _report(args) -> int:
+    """Assemble and judge a market report, in-process.
+
+    Deliberately does NOT invoke scripts/harness/report_postflight.py. A CLI that
+    re-executes the same scripts is a rename, not independence — so this calls the
+    extracted core directly and works from an installed wheel with no repository
+    checkout, no `openclaw`, no `git`.
+
+    Delivery and publication are not done here: those are capability providers,
+    and a report you can render without them is exactly the point of the split.
+    """
+    from clawock.report import assemble_message, categorize, validate
+
+    context = json.loads(Path(args.context).read_text())
+    prose = Path(args.prose).read_text() if args.prose else sys.stdin.read()
+
+    body = assemble_message(context, prose)
+    issues = validate(body, context, prose_only=True, model_text=prose)
+    verdict = categorize(issues)
+
+    result = {
+        "market": context.get("market"),
+        "phase": context.get("phase"),
+        "context_id": context.get("context_id"),
+        "chars": len(body),
+        "status": verdict,
+        "issues": issues,
+        "body": body,
+    }
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(body)
+        if issues:
+            print(f"\n--- {verdict}: {len(issues)} issue(s) ---", file=sys.stderr)
+            for issue in issues:
+                print(f"  · {issue}", file=sys.stderr)
+    return 0 if verdict == "pass" else 1
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="clawock", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -57,6 +98,15 @@ def main(argv=None) -> int:
     doctor.add_argument("--workspace", type=Path, default=None)
     doctor.add_argument("--json", action="store_true")
     doctor.set_defaults(func=_doctor)
+
+    report = sub.add_parser(
+        "report", help="assemble and validate a market report from a context file")
+    report.add_argument("--context", type=Path, required=True,
+                        help="preflight context JSON")
+    report.add_argument("--prose", type=Path, default=None,
+                        help="model prose; reads stdin when omitted")
+    report.add_argument("--json", action="store_true")
+    report.set_defaults(func=_report)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/clawock/report.py
+++ b/clawock/report.py
@@ -1,0 +1,145 @@
+"""The deterministic core of a market report: assemble, then judge.
+
+Moved out of `scripts/harness/report_postflight.py` so it can run from the
+installed package with no repository checkout. This is the part `clawock report`
+executes directly — it does not shell out to the harness script, because a CLI
+that re-invokes the same scripts would be a rename, not independence.
+
+Pure functions over a context dict and the model's prose: no I/O, no git, no
+delivery, no workspace paths. The postflight script re-exports them, so its own
+twenty-odd regression tests keep exercising exactly this code.
+"""
+from __future__ import annotations
+
+import re
+
+from clawock.validation import (
+    ADVISORY_MARK,
+    REPORT_CHAR_LIMITS as CHAR_LIMITS,
+    categorize_issues,
+    check_md_table_column_consistency,
+    check_numeric_claims,
+    check_raw_tables_verbatim,
+    validate_forbidden_phrases,
+)
+
+REQUIRED_SECTIONS = ['▎情绪面', '▎技术面', '▎操作建议']
+FORBIDDEN_PHRASES = ['数据待获取', '等待数据', '数据缺失（占位）', 'TODO', 'TBD']
+
+# A real report is always >500 字 (raw_wechat_block alone ≈600). Anything this
+# short is a broken pipe, not a report — never deliver it. 2026-06-17: the cron
+# LLM issued the file-write and `report_postflight ... <<< "$(cat report.txt)"`
+# as PARALLEL tool calls in one turn; cat raced the write, read a missing file →
+# empty stdin (n_chars=1). The validator (correctly) failed it, but deliver_wechat
+# sends on ALL statuses incl. fail → kcn got a scary empty "🔴 Validation FAILED"
+# banner before the model's serial retry delivered the real report. Guard the
+# degenerate-input case BEFORE send/commit so a broken pipe never reaches WeChat.
+MIN_REPORT_CHARS = 50
+def _unusable_context(ctx, prose_only):
+    """Reason string if the context can't back a report, else None.
+
+    preflight writes blockless sentinels (status preflight_failed / market_closed)
+    that carry none of the deterministic fields postflight assembles from. Anything
+    but a 'ok' status with a nonempty raw block + title + commit_msg — plus a
+    context_id in prose mode — is not a report context.
+    """
+    if ctx.get('status') != 'ok':
+        return f'context status={ctx.get("status")!r}（preflight 未产出可用数据），跳过投递+commit'
+    missing = [k for k in ('raw_wechat_block', 'title', 'commit_msg') if not (ctx.get(k) or '').strip()]
+    if prose_only and not (ctx.get('context_id') or '').strip():
+        missing.append('context_id')
+    if missing:
+        return f'context 缺字段 {missing}，跳过投递+commit'
+    return None
+
+
+def assemble_message(ctx, prose):
+    """Build the delivered report from harness-owned data + model-owned prose.
+
+    The 2026-07-24 incident happened because the deterministic data block made a
+    round trip through the LLM: preflight put it in the context, the payload
+    ordered the model to copy it verbatim, and validate() checked the copy. A
+    model that read the wrong context therefore published wrong numbers, and the
+    verbatim check could only notice *after* the send.
+
+    Prepending it here removes the round trip: the numbers in the delivered
+    message come from the context file at send time, so they cannot be stale,
+    paraphrased, or table-mangled — no instruction and no validation rule needed.
+    """
+    parts = [ctx.get('title', '').strip(),
+             (ctx.get('raw_wechat_block') or '').strip(),
+             prose.strip()]
+    return '\n\n'.join(p for p in parts if p)
+
+
+def validate(body, ctx, prose_only=False, model_text=None):
+    """Validate the delivered message.
+
+    `body` is what gets sent. `model_text` is the part the MODEL wrote; in prose
+    mode that is the prose alone, in legacy mode it is the whole report (== body).
+
+    The content rules — sections, risk section, anomaly mention, forbidden phrases
+    — MUST run against model_text, never body. In prose mode assemble_message has
+    already prepended the raw data block, and that block itself contains the
+    anomaly tickers and (potentially) section-looking tokens: checking body would
+    let prose that mentions none of the movers pass because the table does. Only
+    the length limit is a property of the assembled body. (2026-07-24 review.)
+    """
+    issues = []
+    checked = body if model_text is None else model_text
+
+    # 1. raw block 必须 verbatim 出现（legacy path only — see docstring）
+    raw = ctx.get('raw_wechat_block', '').strip()
+    if raw and not prose_only:
+        first_line = raw.splitlines()[0]
+        if first_line not in body:
+            issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 验证失败)')
+        issues.extend(check_raw_tables_verbatim(body, raw))
+
+    # 2. 必有三段标记（模型文本）
+    for sec in REQUIRED_SECTIONS:
+        if sec not in checked:
+            issues.append(f'缺段标记 "{sec}"')
+
+    # 3. 风险提示段（若 preflight 标了 needs；模型文本）
+    if ctx.get('needs_risk_section') and '▎风险提示' not in checked:
+        issues.append('preflight 标 needs_risk_section=true 但未见 "▎风险提示" 段')
+
+    # 4. 长度 —— 按投递全文 (per-market)
+    n_chars = len(body)
+    limits = CHAR_LIMITS.get(ctx.get('market', 'hk'), CHAR_LIMITS['hk'])
+    soft, hard = limits['soft'], limits['hard']
+    if n_chars > hard:
+        issues.append(f'报告长度 {n_chars} 字 > {hard} 上限')
+    elif n_chars > soft:
+        issues.append(f'报告长度 {n_chars} 字 > {soft} 软上限 (warn)')
+
+    # 5. 异动票必须被提到（模型文本 —— 数据块里本就有票代码，不能拿它顶）
+    anomalies = ctx.get('anomalies', [])
+    if anomalies:
+        mentioned = [a['ticker'] for a in anomalies if a['ticker'] in checked]
+        if not mentioned:
+            tickers = ', '.join(a['ticker'] for a in anomalies)
+            issues.append(f'preflight 标了 {len(anomalies)} 个 ≥3% 异动票 ({tickers}) 但报告全部未提及')
+
+    # 6. 敷衍 phrases（模型文本）
+    issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
+
+    # 7. 数字必须来自 context（模型文本）—— 一条聚合 warn，见 check_numeric_claims
+    issues.extend(check_numeric_claims(checked, ctx))
+
+    return issues
+
+
+CRITICAL_KEYWORDS = ['缺段标记', '未包含原始数据块', '敷衍词', '表格行未 verbatim']
+
+
+def _is_hard_char_limit(issue):
+    """Hard char limit (e.g. '字 > 3500 上限') is critical; soft is not."""
+    return '字 >' in issue and '上限' in issue and '软上限' not in issue
+
+
+def categorize(issues):
+    return categorize_issues(
+        issues, CRITICAL_KEYWORDS, warn_max=3, extra_critical=_is_hard_char_limit,
+    )

--- a/clawock/validation.py
+++ b/clawock/validation.py
@@ -1,0 +1,282 @@
+"""Text and numeric validation primitives shared by every report path.
+
+Moved out of `scripts/harness/_harness_common.py` so the report core can live in
+the installed package: a wheel cannot reach `scripts/`, and `clawock report` must
+work with no repository checkout at all.
+
+These are pure functions over text and context dicts — no I/O, no git, no
+workspace. `_harness_common` re-exports them, so all ten in-repo importers are
+untouched.
+"""
+from __future__ import annotations
+
+import re
+
+
+def _extract_md_tables(text):
+    """Yield lists of consecutive lines that look like markdown table rows."""
+    cur = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if s.startswith('|') and s.endswith('|'):
+            cur.append(ln)
+        elif cur:
+            yield cur
+            cur = []
+    if cur:
+        yield cur
+
+
+def check_raw_tables_verbatim(text, raw_wechat_block):
+    """Verify every markdown-table line in raw_wechat_block appears verbatim in text.
+
+    preflight builds the holdings table via _wechat_table.py (7-col, known correct).
+    LLMs sometimes paraphrase rows or drop a separator segment when "copying" —
+    e.g. 5/21+ regression where header had 7 cols but separator only 6, breaking
+    markdown renderers. Strict substring match catches that.
+
+    Returns list of issue strings (empty = pass).
+    """
+    if not raw_wechat_block:
+        return []
+    issues = []
+    for tbl in _extract_md_tables(raw_wechat_block):
+        for ln in tbl:
+            if ln not in text:
+                issues.append(f'表格行未 verbatim 复制: "{ln.strip()[:50]}..."')
+                break  # one issue per table is enough
+    return issues
+
+
+def check_md_table_column_consistency(text):
+    """Verify every markdown table inside text has uniform pipe-segment counts
+    across its header/separator/data rows.
+
+    Use this when there's no canonical `raw_wechat_block` to compare against —
+    e.g. LLM-authored pre-open.md where tables are composed (not copied).
+    A diverging segment count breaks markdown renderers.
+
+    Returns list of issue strings.
+    """
+    issues = []
+    for i, tbl in enumerate(_extract_md_tables(text), start=1):
+        counts = {ln.count('|') for ln in tbl}
+        if len(counts) > 1:
+            issues.append(f'markdown 表格 #{i} 列数不一致: pipe-segments={sorted(counts)}')
+    return issues
+
+
+def validate_forbidden_phrases(text, phrases, label='报告'):
+    """Return one issue per forbidden phrase found in text."""
+    return [f'{label}含敷衍词 "{p}"' for p in phrases if p in text]
+# SCOPE, stated plainly: this catches magnitudes that appear NOWHERE in the
+# context. It cannot catch a real number attached to the wrong thing — the same
+# report's "07226 + 03033 各 1000 股" quotes a share count that genuinely exists
+# (03033 holds 1000), it is simply not 07226's. That class is addressed by not
+# restating position sizes at all (SKILL rule) and by handing the prose the plan's
+# own numbers (plan_context, issue #119), not by a regex.
+_MAGNITUDE = {'万': 10_000, '亿': 100_000_000, 'w': 10_000}
+_CURRENCY = r'(?:HK\$|US\$|RMB|\$|¥|港元|美元|港币)'
+_NUM = r'-?\d[\d,]*(?:\.\d+)?'
+_SHARE_CLAIM = re.compile(rf'({_NUM})\s*(万|亿)?\s*(?:股|shares?\b)')
+_CURRENCY_CLAIM = re.compile(
+    rf'{_CURRENCY}\s*({_NUM})\s*(万|亿)?|({_NUM})\s*(万|亿)?\s*{_CURRENCY}'
+)
+# A range whose endpoints run backwards describes nothing real. The ASCII hyphen is
+# deliberately NOT a separator here: HK tickers are numeric, so "07226 -3.5%" —
+# the most common phrase in these reports — parsed as a range from 07226 to 3.5.
+# Checked against 23 real sent reports: that one character was every false
+# positive. `~` is what the observed defect ("+0.3~-0.4%") actually used.
+_RANGE = re.compile(rf'({_NUM})\s*(?:~|～|—|–|到|至)\s*({_NUM})\s*%')
+MAX_NUMERIC_SAMPLES = 4
+# Only book-scale currency figures are checked. US price talk is conventionally
+# written with the symbol — "跌破 $65，下一支撑 $60" is a level, not a claim about
+# the book, and flagging it would make the gate noise on ordinary technical
+# analysis. Book amounts in this portfolio are five figures; the fabricated
+# estimate this gate exists for (1.5-2 万 HK$ = 20,000) is far above the line.
+MIN_CHECKED_AMOUNT = 1_000
+
+
+def _as_number(raw, magnitude=None):
+    try:
+        value = float(str(raw).replace(',', ''))
+    except (TypeError, ValueError):
+        return None
+    return value * _MAGNITUDE.get(magnitude, 1)
+
+
+def _context_numbers(ctx):
+    """Every number the context states, in every form it states it.
+
+    Walks the whole context rather than a chosen subset: the data block, peer
+    percentages, plan sizes and index levels are all legitimate things for prose
+    to quote, and a hand-picked list would silently make new context fields
+    unquotable the day they are added.
+    """
+    seen = set()
+
+    def add(value):
+        number = _as_number(value)
+        if number is not None:
+            seen.add(round(abs(number), 4))
+
+    def walk(node):
+        if isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, (list, tuple)):
+            for value in node:
+                walk(value)
+        elif isinstance(node, bool):
+            return
+        elif isinstance(node, (int, float)):
+            add(node)
+        elif isinstance(node, str):
+            for token in re.findall(_NUM, node):
+                add(token)
+
+    walk(ctx)
+    return seen
+
+
+def check_numeric_claims(text, ctx):
+    """Flag share/currency magnitudes the context never states, and impossible
+    percentage ranges.
+
+    Returns at most ONE issue on purpose. Every postflight turns a small number of
+    non-critical issues into `warn` (still delivered) and a larger number into
+    `fail` (not delivered): a chatty new heuristic that pushed a good report over
+    that line would convert a cosmetic problem into a missed report, which is the
+    strictly worse failure. One aggregated line keeps the gate advisory.
+    """
+    known = _context_numbers(ctx)
+    unverified = []
+
+    def check(value, label):
+        if value is None or round(abs(value), 4) in known:
+            return
+        if label not in unverified:
+            unverified.append(label)
+
+    for raw, magnitude in _SHARE_CLAIM.findall(text):
+        check(_as_number(raw, magnitude), f'{raw}{magnitude or ""}股')
+    for cur_num, cur_mag, num_cur, mag_cur in _CURRENCY_CLAIM.findall(text):
+        raw, magnitude = (cur_num, cur_mag) if cur_num else (num_cur, mag_cur)
+        amount = _as_number(raw, magnitude)
+        if amount is not None and abs(amount) >= MIN_CHECKED_AMOUNT:
+            check(amount, f'{raw}{magnitude or ""}')
+
+    impossible = [
+        f'{lo}~{hi}%' for lo, hi in _RANGE.findall(text)
+        if (_as_number(lo) is not None and _as_number(hi) is not None
+            and (_as_number(lo) > _as_number(hi)))
+    ]
+
+    parts = []
+    if unverified:
+        shown = ', '.join(unverified[:MAX_NUMERIC_SAMPLES])
+        parts.append(f'context 里没有的数字: {shown}')
+    if impossible:
+        parts.append(f'区间自相矛盾: {", ".join(impossible[:MAX_NUMERIC_SAMPLES])}')
+    if not parts:
+        return []
+    return [f'{"；".join(parts)} —— 数字只能引用 context，不许心算 {ADVISORY_MARK}']
+
+ADVISORY_MARK = '(advisory)'
+
+
+def is_advisory(issue):
+    """An advisory issue is reported but never escalates.
+
+    Without this, an advisory check still counts toward `warn_max` and can push a
+    report from `warn` (delivered) to `fail` (not delivered) purely by coexisting
+    with two unrelated soft issues — verified: intraday `[soft-length, thin
+    section, numeric]` categorised as `fail` while the same list minus the numeric
+    line categorised as `warn`. An advisory heuristic that can silently cost kcn a
+    report is worse than the cosmetic problem it reports.
+    """
+    return ADVISORY_MARK in issue
+
+
+def split_advisory(issues):
+    """(escalating, advisory) — the banner must count and show them separately.
+
+    Both banners print a truncated list (`issues[:2]` intraday, `issues[:3]`
+    report). While advisory findings shared that list they were the ones most
+    likely to be cut, because they only appear on reports that already have
+    other findings — i.e. exactly the reports where an invented number matters
+    most. They get their own line instead.
+    """
+    return ([i for i in issues if not is_advisory(i)],
+            [i for i in issues if is_advisory(i)])
+
+
+def advisory_prefix(advisories, shown=2):
+    """A visible, non-blocking line for advisory findings ('' when there are none).
+
+    Deliberately not styled as a warning: it must read as information, or the
+    next person to see one will start treating it as a failure and the gate
+    becomes the blocker it was designed not to be.
+    """
+    if not advisories:
+        return ''
+    body = '; '.join(a.replace(ADVISORY_MARK, '').strip() for a in advisories[:shown])
+    more = f'；另 {len(advisories) - shown} 条' if len(advisories) > shown else ''
+    return f'ℹ️ 数字校验（不影响投递）：{body}{more}\n\n'
+
+
+def categorize_issues(issues, critical_substrings, warn_max=2, extra_critical=None):
+    """Common pass/warn/fail decision used by all postflights.
+
+    - empty issues → pass
+    - any issue containing any critical_substring OR matching extra_critical(i) → fail
+    - advisory issues (see is_advisory) are reported but never counted or escalated
+    - otherwise warn if ≤ warn_max non-advisory issues else fail
+
+    extra_critical: optional callable(issue_str) -> bool for compound checks
+    (e.g. hard char limit detection that can't be a simple substring).
+    """
+    if not issues:
+        return 'pass'
+    escalating = [i for i in issues if not is_advisory(i)]
+    has_critical = any(
+        any(c in i for c in critical_substrings)
+        or (extra_critical is not None and extra_critical(i))
+        for i in escalating
+    )
+    if has_critical:
+        return 'fail'
+    if not escalating:
+        return 'warn'
+    return 'warn' if len(escalating) <= warn_max else 'fail'
+
+
+
+# Mode 6 report size is measured on title + harness-owned data block + model
+# prose. Keep the thresholds in one place so preflight can tell the model its
+# exact remaining prose budget and postflight can enforce the same arithmetic.
+REPORT_ASSEMBLED_TARGET_CHARS = 2_800
+REPORT_CHAR_LIMITS = {
+    'hk': {'soft': 3_000, 'hard': 3_500},
+    'us': {'soft': 3_000, 'hard': 3_500},
+}
+
+
+def report_prose_budget(title, raw_wechat_block, market='hk'):
+    """Exact remaining prose room under Mode 6 assembled-message limits."""
+    title_chars = len((title or '').strip())
+    raw_chars = len((raw_wechat_block or '').strip())
+    # assemble_message joins three non-empty parts with two ``\n\n`` separators.
+    separator_chars = 4
+    fixed_chars = title_chars + raw_chars + separator_chars
+    limits = REPORT_CHAR_LIMITS.get(market, REPORT_CHAR_LIMITS['hk'])
+    return {
+        'assembled_target_chars': REPORT_ASSEMBLED_TARGET_CHARS,
+        'title_chars': title_chars,
+        'raw_block_chars': raw_chars,
+        'separator_chars': separator_chars,
+        'fixed_chars': fixed_chars,
+        'prose_target_chars': max(0, REPORT_ASSEMBLED_TARGET_CHARS - fixed_chars),
+        'prose_soft_limit_chars': max(0, limits['soft'] - fixed_chars),
+        'prose_hard_limit_chars': max(0, limits['hard'] - fixed_chars),
+    }

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -19,6 +19,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# The text/numeric validation primitives moved into the installed package so the
+# report core can run without a repository checkout. Re-exported here so all ten
+# in-repo importers keep working unchanged.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from clawock.validation import (  # noqa: E402,F401
+    REPORT_ASSEMBLED_TARGET_CHARS,
+    REPORT_CHAR_LIMITS,
+    report_prose_budget,
+    ADVISORY_MARK,
+    MAX_NUMERIC_SAMPLES,
+    MIN_CHECKED_AMOUNT,
+    advisory_prefix,
+    categorize_issues,
+    check_md_table_column_consistency,
+    check_numeric_claims,
+    check_raw_tables_verbatim,
+    is_advisory,
+    split_advisory,
+    validate_forbidden_phrases,
+)
+
 WS = workspace_root(Path(__file__).resolve().parents[2])
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
 from dashboard_outputs import semantic_changed_paths as dashboard_output_changes  # noqa: E402
@@ -32,35 +53,6 @@ DASHBOARD_PUBLISH_LOCK = '/tmp/dashboard_publish.lock'
 # check can surface silent build failures / degradations (kcn doesn't want
 # per-cron alerts — see feedback_no_individual_cron_alerts).
 DASHBOARD_BUILD_STATUS = 'logs/dashboard_build_status.json'
-
-# Mode 6 report size is measured on title + harness-owned data block + model
-# prose. Keep the thresholds in one place so preflight can tell the model its
-# exact remaining prose budget and postflight can enforce the same arithmetic.
-REPORT_ASSEMBLED_TARGET_CHARS = 2_800
-REPORT_CHAR_LIMITS = {
-    'hk': {'soft': 3_000, 'hard': 3_500},
-    'us': {'soft': 3_000, 'hard': 3_500},
-}
-
-
-def report_prose_budget(title, raw_wechat_block, market='hk'):
-    """Exact remaining prose room under Mode 6 assembled-message limits."""
-    title_chars = len((title or '').strip())
-    raw_chars = len((raw_wechat_block or '').strip())
-    # assemble_message joins three non-empty parts with two ``\n\n`` separators.
-    separator_chars = 4
-    fixed_chars = title_chars + raw_chars + separator_chars
-    limits = REPORT_CHAR_LIMITS.get(market, REPORT_CHAR_LIMITS['hk'])
-    return {
-        'assembled_target_chars': REPORT_ASSEMBLED_TARGET_CHARS,
-        'title_chars': title_chars,
-        'raw_block_chars': raw_chars,
-        'separator_chars': separator_chars,
-        'fixed_chars': fixed_chars,
-        'prose_target_chars': max(0, REPORT_ASSEMBLED_TARGET_CHARS - fixed_chars),
-        'prose_soft_limit_chars': max(0, limits['soft'] - fixed_chars),
-        'prose_hard_limit_chars': max(0, limits['hard'] - fixed_chars),
-    }
 
 
 def compute_context_id(result):
@@ -332,64 +324,6 @@ def push_with_rebase_retry(remote='origin', branch='master', attempts=3):
         return False, str(e)
 
 
-def _extract_md_tables(text):
-    """Yield lists of consecutive lines that look like markdown table rows."""
-    cur = []
-    for ln in text.splitlines():
-        s = ln.strip()
-        if s.startswith('|') and s.endswith('|'):
-            cur.append(ln)
-        elif cur:
-            yield cur
-            cur = []
-    if cur:
-        yield cur
-
-
-def check_raw_tables_verbatim(text, raw_wechat_block):
-    """Verify every markdown-table line in raw_wechat_block appears verbatim in text.
-
-    preflight builds the holdings table via _wechat_table.py (7-col, known correct).
-    LLMs sometimes paraphrase rows or drop a separator segment when "copying" —
-    e.g. 5/21+ regression where header had 7 cols but separator only 6, breaking
-    markdown renderers. Strict substring match catches that.
-
-    Returns list of issue strings (empty = pass).
-    """
-    if not raw_wechat_block:
-        return []
-    issues = []
-    for tbl in _extract_md_tables(raw_wechat_block):
-        for ln in tbl:
-            if ln not in text:
-                issues.append(f'表格行未 verbatim 复制: "{ln.strip()[:50]}..."')
-                break  # one issue per table is enough
-    return issues
-
-
-def check_md_table_column_consistency(text):
-    """Verify every markdown table inside text has uniform pipe-segment counts
-    across its header/separator/data rows.
-
-    Use this when there's no canonical `raw_wechat_block` to compare against —
-    e.g. LLM-authored pre-open.md where tables are composed (not copied).
-    A diverging segment count breaks markdown renderers.
-
-    Returns list of issue strings.
-    """
-    issues = []
-    for i, tbl in enumerate(_extract_md_tables(text), start=1):
-        counts = {ln.count('|') for ln in tbl}
-        if len(counts) > 1:
-            issues.append(f'markdown 表格 #{i} 列数不一致: pipe-segments={sorted(counts)}')
-    return issues
-
-
-def validate_forbidden_phrases(text, phrases, label='报告'):
-    """Return one issue per forbidden phrase found in text."""
-    return [f'{label}含敷衍词 "{p}"' for p in phrases if p in text]
-
-
 # --- numeric claims -------------------------------------------------------
 # Prose may quote the context; it may not compute. On 2026-07-27 the 09:30 report
 # shipped "日内可能再伤 1.5-2 万 HK$" for an exposure whose actual -2% impact was
@@ -397,187 +331,7 @@ def validate_forbidden_phrases(text, phrases, label='报告'):
 # put at +0.3% each. Both passed every existing check, because nothing looked at a
 # numeral (issue #120).
 #
-# SCOPE, stated plainly: this catches magnitudes that appear NOWHERE in the
-# context. It cannot catch a real number attached to the wrong thing — the same
-# report's "07226 + 03033 各 1000 股" quotes a share count that genuinely exists
-# (03033 holds 1000), it is simply not 07226's. That class is addressed by not
-# restating position sizes at all (SKILL rule) and by handing the prose the plan's
-# own numbers (plan_context, issue #119), not by a regex.
-_MAGNITUDE = {'万': 10_000, '亿': 100_000_000, 'w': 10_000}
-_CURRENCY = r'(?:HK\$|US\$|RMB|\$|¥|港元|美元|港币)'
-_NUM = r'-?\d[\d,]*(?:\.\d+)?'
-_SHARE_CLAIM = re.compile(rf'({_NUM})\s*(万|亿)?\s*(?:股|shares?\b)')
-_CURRENCY_CLAIM = re.compile(
-    rf'{_CURRENCY}\s*({_NUM})\s*(万|亿)?|({_NUM})\s*(万|亿)?\s*{_CURRENCY}'
-)
-# A range whose endpoints run backwards describes nothing real. The ASCII hyphen is
-# deliberately NOT a separator here: HK tickers are numeric, so "07226 -3.5%" —
-# the most common phrase in these reports — parsed as a range from 07226 to 3.5.
-# Checked against 23 real sent reports: that one character was every false
-# positive. `~` is what the observed defect ("+0.3~-0.4%") actually used.
-_RANGE = re.compile(rf'({_NUM})\s*(?:~|～|—|–|到|至)\s*({_NUM})\s*%')
-MAX_NUMERIC_SAMPLES = 4
-# Only book-scale currency figures are checked. US price talk is conventionally
-# written with the symbol — "跌破 $65，下一支撑 $60" is a level, not a claim about
-# the book, and flagging it would make the gate noise on ordinary technical
-# analysis. Book amounts in this portfolio are five figures; the fabricated
-# estimate this gate exists for (1.5-2 万 HK$ = 20,000) is far above the line.
-MIN_CHECKED_AMOUNT = 1_000
 
-
-def _as_number(raw, magnitude=None):
-    try:
-        value = float(str(raw).replace(',', ''))
-    except (TypeError, ValueError):
-        return None
-    return value * _MAGNITUDE.get(magnitude, 1)
-
-
-def _context_numbers(ctx):
-    """Every number the context states, in every form it states it.
-
-    Walks the whole context rather than a chosen subset: the data block, peer
-    percentages, plan sizes and index levels are all legitimate things for prose
-    to quote, and a hand-picked list would silently make new context fields
-    unquotable the day they are added.
-    """
-    seen = set()
-
-    def add(value):
-        number = _as_number(value)
-        if number is not None:
-            seen.add(round(abs(number), 4))
-
-    def walk(node):
-        if isinstance(node, dict):
-            for value in node.values():
-                walk(value)
-        elif isinstance(node, (list, tuple)):
-            for value in node:
-                walk(value)
-        elif isinstance(node, bool):
-            return
-        elif isinstance(node, (int, float)):
-            add(node)
-        elif isinstance(node, str):
-            for token in re.findall(_NUM, node):
-                add(token)
-
-    walk(ctx)
-    return seen
-
-
-def check_numeric_claims(text, ctx):
-    """Flag share/currency magnitudes the context never states, and impossible
-    percentage ranges.
-
-    Returns at most ONE issue on purpose. Every postflight turns a small number of
-    non-critical issues into `warn` (still delivered) and a larger number into
-    `fail` (not delivered): a chatty new heuristic that pushed a good report over
-    that line would convert a cosmetic problem into a missed report, which is the
-    strictly worse failure. One aggregated line keeps the gate advisory.
-    """
-    known = _context_numbers(ctx)
-    unverified = []
-
-    def check(value, label):
-        if value is None or round(abs(value), 4) in known:
-            return
-        if label not in unverified:
-            unverified.append(label)
-
-    for raw, magnitude in _SHARE_CLAIM.findall(text):
-        check(_as_number(raw, magnitude), f'{raw}{magnitude or ""}股')
-    for cur_num, cur_mag, num_cur, mag_cur in _CURRENCY_CLAIM.findall(text):
-        raw, magnitude = (cur_num, cur_mag) if cur_num else (num_cur, mag_cur)
-        amount = _as_number(raw, magnitude)
-        if amount is not None and abs(amount) >= MIN_CHECKED_AMOUNT:
-            check(amount, f'{raw}{magnitude or ""}')
-
-    impossible = [
-        f'{lo}~{hi}%' for lo, hi in _RANGE.findall(text)
-        if (_as_number(lo) is not None and _as_number(hi) is not None
-            and (_as_number(lo) > _as_number(hi)))
-    ]
-
-    parts = []
-    if unverified:
-        shown = ', '.join(unverified[:MAX_NUMERIC_SAMPLES])
-        parts.append(f'context 里没有的数字: {shown}')
-    if impossible:
-        parts.append(f'区间自相矛盾: {", ".join(impossible[:MAX_NUMERIC_SAMPLES])}')
-    if not parts:
-        return []
-    return [f'{"；".join(parts)} —— 数字只能引用 context，不许心算 {ADVISORY_MARK}']
-
-
-ADVISORY_MARK = '(advisory)'
-
-
-def is_advisory(issue):
-    """An advisory issue is reported but never escalates.
-
-    Without this, an advisory check still counts toward `warn_max` and can push a
-    report from `warn` (delivered) to `fail` (not delivered) purely by coexisting
-    with two unrelated soft issues — verified: intraday `[soft-length, thin
-    section, numeric]` categorised as `fail` while the same list minus the numeric
-    line categorised as `warn`. An advisory heuristic that can silently cost kcn a
-    report is worse than the cosmetic problem it reports.
-    """
-    return ADVISORY_MARK in issue
-
-
-def split_advisory(issues):
-    """(escalating, advisory) — the banner must count and show them separately.
-
-    Both banners print a truncated list (`issues[:2]` intraday, `issues[:3]`
-    report). While advisory findings shared that list they were the ones most
-    likely to be cut, because they only appear on reports that already have
-    other findings — i.e. exactly the reports where an invented number matters
-    most. They get their own line instead.
-    """
-    return ([i for i in issues if not is_advisory(i)],
-            [i for i in issues if is_advisory(i)])
-
-
-def advisory_prefix(advisories, shown=2):
-    """A visible, non-blocking line for advisory findings ('' when there are none).
-
-    Deliberately not styled as a warning: it must read as information, or the
-    next person to see one will start treating it as a failure and the gate
-    becomes the blocker it was designed not to be.
-    """
-    if not advisories:
-        return ''
-    body = '; '.join(a.replace(ADVISORY_MARK, '').strip() for a in advisories[:shown])
-    more = f'；另 {len(advisories) - shown} 条' if len(advisories) > shown else ''
-    return f'ℹ️ 数字校验（不影响投递）：{body}{more}\n\n'
-
-
-def categorize_issues(issues, critical_substrings, warn_max=2, extra_critical=None):
-    """Common pass/warn/fail decision used by all postflights.
-
-    - empty issues → pass
-    - any issue containing any critical_substring OR matching extra_critical(i) → fail
-    - advisory issues (see is_advisory) are reported but never counted or escalated
-    - otherwise warn if ≤ warn_max non-advisory issues else fail
-
-    extra_critical: optional callable(issue_str) -> bool for compound checks
-    (e.g. hard char limit detection that can't be a simple substring).
-    """
-    if not issues:
-        return 'pass'
-    escalating = [i for i in issues if not is_advisory(i)]
-    has_critical = any(
-        any(c in i for c in critical_substrings)
-        or (extra_critical is not None and extra_critical(i))
-        for i in escalating
-    )
-    if has_critical:
-        return 'fail'
-    if not escalating:
-        return 'warn'
-    return 'warn' if len(escalating) <= warn_max else 'fail'
 
 
 def safe_write_text(path, text):

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -53,18 +53,26 @@ sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import workflow_outcomes  # noqa: E402
 
-REQUIRED_SECTIONS = ['▎情绪面', '▎技术面', '▎操作建议']
-FORBIDDEN_PHRASES = ['数据待获取', '等待数据', '数据缺失（占位）', 'TODO', 'TBD']
+# The deterministic report core moved into the installed package so `clawock
+# report` can run it without a repository checkout. Re-exported here so this
+# module's own regression suite keeps exercising exactly that code.
+sys.path.insert(0, str(WS))
+from clawock.report import (  # noqa: E402,F401
+    CRITICAL_KEYWORDS,
+    FORBIDDEN_PHRASES,
+    MIN_REPORT_CHARS,
+    REQUIRED_SECTIONS,
+    _is_hard_char_limit,
+    _unusable_context,
+    assemble_message,
+    categorize,
+    validate,
+)
 
-# A real report is always >500 字 (raw_wechat_block alone ≈600). Anything this
-# short is a broken pipe, not a report — never deliver it. 2026-06-17: the cron
-# LLM issued the file-write and `report_postflight ... <<< "$(cat report.txt)"`
-# as PARALLEL tool calls in one turn; cat raced the write, read a missing file →
-# empty stdin (n_chars=1). The validator (correctly) failed it, but deliver_wechat
-# sends on ALL statuses incl. fail → kcn got a scary empty "🔴 Validation FAILED"
-# banner before the model's serial retry delivered the real report. Guard the
-# degenerate-input case BEFORE send/commit so a broken pipe never reaches WeChat.
-MIN_REPORT_CHARS = 50
+# Report slots are hours apart (open/mid/pm/close), so a prose file older than
+# this is the previous slot's, not this one's. See read_prose_text.
+PROSE_MAX_AGE_MIN = 30
+
 
 # Report slots are hours apart (open/mid/pm/close), so a prose file older than
 # this is the previous slot's, not this one's. See read_prose_text.
@@ -80,114 +88,6 @@ def load_context(market, phase, date):
         return None, f'preflight context 解析失败: {e}'
 
 
-def _unusable_context(ctx, prose_only):
-    """Reason string if the context can't back a report, else None.
-
-    preflight writes blockless sentinels (status preflight_failed / market_closed)
-    that carry none of the deterministic fields postflight assembles from. Anything
-    but a 'ok' status with a nonempty raw block + title + commit_msg — plus a
-    context_id in prose mode — is not a report context.
-    """
-    if ctx.get('status') != 'ok':
-        return f'context status={ctx.get("status")!r}（preflight 未产出可用数据），跳过投递+commit'
-    missing = [k for k in ('raw_wechat_block', 'title', 'commit_msg') if not (ctx.get(k) or '').strip()]
-    if prose_only and not (ctx.get('context_id') or '').strip():
-        missing.append('context_id')
-    if missing:
-        return f'context 缺字段 {missing}，跳过投递+commit'
-    return None
-
-
-def assemble_message(ctx, prose):
-    """Build the delivered report from harness-owned data + model-owned prose.
-
-    The 2026-07-24 incident happened because the deterministic data block made a
-    round trip through the LLM: preflight put it in the context, the payload
-    ordered the model to copy it verbatim, and validate() checked the copy. A
-    model that read the wrong context therefore published wrong numbers, and the
-    verbatim check could only notice *after* the send.
-
-    Prepending it here removes the round trip: the numbers in the delivered
-    message come from the context file at send time, so they cannot be stale,
-    paraphrased, or table-mangled — no instruction and no validation rule needed.
-    """
-    parts = [ctx.get('title', '').strip(),
-             (ctx.get('raw_wechat_block') or '').strip(),
-             prose.strip()]
-    return '\n\n'.join(p for p in parts if p)
-
-
-def validate(body, ctx, prose_only=False, model_text=None):
-    """Validate the delivered message.
-
-    `body` is what gets sent. `model_text` is the part the MODEL wrote; in prose
-    mode that is the prose alone, in legacy mode it is the whole report (== body).
-
-    The content rules — sections, risk section, anomaly mention, forbidden phrases
-    — MUST run against model_text, never body. In prose mode assemble_message has
-    already prepended the raw data block, and that block itself contains the
-    anomaly tickers and (potentially) section-looking tokens: checking body would
-    let prose that mentions none of the movers pass because the table does. Only
-    the length limit is a property of the assembled body. (2026-07-24 review.)
-    """
-    issues = []
-    checked = body if model_text is None else model_text
-
-    # 1. raw block 必须 verbatim 出现（legacy path only — see docstring）
-    raw = ctx.get('raw_wechat_block', '').strip()
-    if raw and not prose_only:
-        first_line = raw.splitlines()[0]
-        if first_line not in body:
-            issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 验证失败)')
-        issues.extend(check_raw_tables_verbatim(body, raw))
-
-    # 2. 必有三段标记（模型文本）
-    for sec in REQUIRED_SECTIONS:
-        if sec not in checked:
-            issues.append(f'缺段标记 "{sec}"')
-
-    # 3. 风险提示段（若 preflight 标了 needs；模型文本）
-    if ctx.get('needs_risk_section') and '▎风险提示' not in checked:
-        issues.append('preflight 标 needs_risk_section=true 但未见 "▎风险提示" 段')
-
-    # 4. 长度 —— 按投递全文 (per-market)
-    n_chars = len(body)
-    limits = CHAR_LIMITS.get(ctx.get('market', 'hk'), CHAR_LIMITS['hk'])
-    soft, hard = limits['soft'], limits['hard']
-    if n_chars > hard:
-        issues.append(f'报告长度 {n_chars} 字 > {hard} 上限')
-    elif n_chars > soft:
-        issues.append(f'报告长度 {n_chars} 字 > {soft} 软上限 (warn)')
-
-    # 5. 异动票必须被提到（模型文本 —— 数据块里本就有票代码，不能拿它顶）
-    anomalies = ctx.get('anomalies', [])
-    if anomalies:
-        mentioned = [a['ticker'] for a in anomalies if a['ticker'] in checked]
-        if not mentioned:
-            tickers = ', '.join(a['ticker'] for a in anomalies)
-            issues.append(f'preflight 标了 {len(anomalies)} 个 ≥3% 异动票 ({tickers}) 但报告全部未提及')
-
-    # 6. 敷衍 phrases（模型文本）
-    issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
-
-    # 7. 数字必须来自 context（模型文本）—— 一条聚合 warn，见 check_numeric_claims
-    issues.extend(check_numeric_claims(checked, ctx))
-
-    return issues
-
-
-CRITICAL_KEYWORDS = ['缺段标记', '未包含原始数据块', '敷衍词', '表格行未 verbatim']
-
-
-def _is_hard_char_limit(issue):
-    """Hard char limit (e.g. '字 > 3500 上限') is critical; soft is not."""
-    return '字 >' in issue and '上限' in issue and '软上限' not in issue
-
-
-def categorize(issues):
-    return categorize_issues(
-        issues, CRITICAL_KEYWORDS, warn_max=3, extra_critical=_is_hard_char_limit,
-    )
 
 
 sys.path.insert(0, str(Path(__file__).parent))

--- a/tests/test_report_core_is_independent.py
+++ b/tests/test_report_core_is_independent.py
@@ -1,0 +1,75 @@
+"""The report core must run without the repository, OpenClaw, or git.
+
+Codex's bar for this slice: a CLI that shells out to
+`scripts/harness/report_postflight.py` is a rename, not independence. So the
+test forces the ways out to be unavailable and asserts a validated report is
+still produced.
+
+Two tests only — these are the two things that would actually make the claim
+false.
+"""
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CONTEXT = {
+    "market": "hk", "phase": "close", "context_id": "hk-close-fixture",
+    "title": "港股收盘 08/02",
+    "raw_wechat_block": "恒指 25,031 ▲0.27%",
+}
+PROSE = "▎情绪面\n市场情绪平稳。\n\n▎技术面\n07226 收 4.20。\n\n▎操作建议\n维持观望。\n"
+
+
+def test_report_runs_with_no_openclaw_no_git_and_no_scripts_directory(tmp_path):
+    (tmp_path / "ctx.json").write_text(json.dumps(CONTEXT, ensure_ascii=False))
+    (tmp_path / "prose.txt").write_text(PROSE)
+
+    empty_bin = tmp_path / "bin"
+    empty_bin.mkdir()
+    env = {
+        "PATH": str(empty_bin),          # no openclaw, no git, no gh
+        "PYTHONPATH": str(ROOT),         # the package; `scripts/` is not importable
+        "HOME": str(tmp_path),
+        "LC_ALL": "C.UTF-8", "PYTHONIOENCODING": "utf-8",
+    }
+    done = subprocess.run(
+        [sys.executable, "-c",
+         "from clawock.cli import main; import sys; sys.exit(main(sys.argv[1:]))",
+         "report", "--context", str(tmp_path / "ctx.json"),
+         "--prose", str(tmp_path / "prose.txt"), "--json"],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=90)
+
+    assert done.returncode == 0, done.stderr
+    result = json.loads(done.stdout)
+    assert result["status"] == "pass"
+    # The delivered body is harness-owned data + model prose, not the prose alone.
+    assert CONTEXT["raw_wechat_block"] in result["body"]
+    assert "▎操作建议" in result["body"]
+
+
+def test_the_core_never_re_invokes_the_harness_scripts():
+    """The facade this slice exists to avoid. Checked through the AST, because
+    both modules legitimately *mention* report_postflight.py in prose."""
+    offenders = []
+    for name in ("report.py", "cli.py", "validation.py"):
+        tree = ast.parse((ROOT / "clawock" / name).read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in {"run", "Popen",
+                                                                 "check_output"}:
+                value = node.value
+                if isinstance(value, ast.Name) and value.id == "subprocess":
+                    offenders.append(f"{name}:{node.lineno}")
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                mod = getattr(node, "module", "") or ""
+                names = {a.name for a in node.names}
+                if mod == "subprocess" or "subprocess" in names:
+                    offenders.append(f"{name}:{node.lineno} imports subprocess")
+
+    assert not offenders, (
+        "the package core shells out — that is the facade this slice rejects: "
+        f"{offenders}")


### PR DESCRIPTION
Refs #251 — the first slice, done to Codex's bar rather than mine.

Codex's standard: **a CLI that shells out to `scripts/harness/report_postflight.py` is a rename, not independence.** So this moves the phase logic into importable API instead of wrapping it.

## What moved

| new | from | what |
|---|---|---|
| `clawock/validation.py` | `_harness_common.py` | markdown-table checks, forbidden phrases, the numeric-claim gate, advisory/critical categorisation, report char limits + prose budget |
| `clawock/report.py` | `report_postflight.py` | `assemble_message`, `validate`, `categorize`, section / forbidden-phrase / char-limit constants |

Both old modules **re-export** what moved, so all ten in-repo importers and the twenty-odd report regression tests are untouched — and still exercise exactly this code, which is why the extraction is safe rather than a rewrite.

`clawock report --context CTX --prose FILE [--json]` runs that core in-process.

## Proof it is not a facade

The report renders from an **installed wheel**, in a temp cwd outside any checkout, with `PATH` containing no `openclaw`, `git` or `gh`, and `scripts/` not importable. Verified as a test *and* by hand against a real built wheel:

```
$ cd /tmp && .../bin/clawock report --context ctx.json --prose p.txt --json
{ "status": "pass", "chars": 57,
  "body": "港股收盘\n\n恒指 25,031 ▲0.27%\n\n▎情绪面…" }
```

The body is harness-owned data **plus** model prose — the 2026-07-24 round-trip fix is preserved, and a prose file missing a section is still judged `fail`.

## Deliberately not in scope

Delivery and publication. Those are capability providers; a report you can render without them is the entire point of the split.

## Tests

Two, both mutation-verified: the no-openclaw/no-git/no-scripts run, and an **AST** check that the package core never imports `subprocess` — adding one reds it. Text matching would not work here: both modules legitimately mention `report_postflight.py` in their prose.

`1510 passed, 4 xfailed` · `system_check` 17/17.