### PR TITLE
providers: delivery and run history as interchangeable capabilities (#251)

### DIFF
--- a/clawock/providers/__init__.py
+++ b/clawock/providers/__init__.py
@@ -1,0 +1,39 @@
+"""Capability providers: OpenClaw and GitHub as peers, not as the substrate.
+
+Two capabilities bind this repository to OpenClaw today, and neither is the LLM
+step everyone reaches for first:
+
+* **delivery** — `_watchdog_common.send_wechat/send_telegram` shell out to
+  `openclaw message send`, and all three postflights deliver through them;
+* **run history** — `_cron_cli_json` reads `openclaw cron …`, and the watchdogs,
+  `cron_health_check`, `cron_timeline` and `system_check` all depend on it.
+
+Remove OpenClaw and reports stop being delivered and every watchdog goes blind,
+before anything about prose generation matters.
+
+Both are already narrow, JSON-returning subprocess calls, and run history
+already has two independent implementations — `_watchdog_common.read_runs`
+(OpenClaw, with a cli → sqlite → fossil fallback chain) and
+`workflow_health.fetch_runs` (GitHub Actions, via `gh run list --json`). They
+simply had no common shape. This package is mostly collecting implementations
+that exist, not inventing abstractions.
+"""
+from __future__ import annotations
+
+from clawock.providers.delivery import (  # noqa: F401
+    DeliveryProvider,
+    DeliveryResult,
+    NullDelivery,
+    OpenClawDelivery,
+)
+from clawock.providers.runs import (  # noqa: F401
+    GitHubRuns,
+    OpenClawRuns,
+    Run,
+    RunHistoryProvider,
+)
+
+__all__ = [
+    "DeliveryProvider", "DeliveryResult", "NullDelivery", "OpenClawDelivery",
+    "GitHubRuns", "OpenClawRuns", "Run", "RunHistoryProvider",
+]

--- a/clawock/providers/delivery.py
+++ b/clawock/providers/delivery.py
@@ -1,0 +1,141 @@
+"""Delivery, with a status a boolean cannot express.
+
+`send_wechat()` returns `(ok, tail)` today, and `ok` means "the CLI exited 0" —
+which is not the same as "kcn saw it". WeChat has a documented cold-session
+silent drop (upstream wontfix, #81096/#81316): the send is accepted and the
+message never arrives, which is exactly why `intraday_watchdog` mirrors to
+Telegram when it *judges* a push probably dropped.
+
+So a two-state result is a lie by construction. Four states:
+
+    accepted   handed to the transport; it did not object
+    confirmed  the transport says it reached the target
+    unknown    accepted, but this channel cannot confirm — WeChat's normal case
+    failed     refused, with a reason
+
+`unknown` is the important one. Collapsing it into `accepted` is what makes a
+dropped report look delivered; collapsing it into `failed` would trigger
+duplicate sends. It has to be its own state.
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from typing import Protocol
+
+# Channels that can tell us a message arrived. WeChat cannot: the CLI reports
+# success for a send the cold session silently drops.
+CONFIRMING_CHANNELS = frozenset({"telegram"})
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    status: str                     # accepted | confirmed | unknown | failed
+    channel: str
+    target: str
+    detail: str = ""
+    receipt: str | None = None
+    idempotency_key: str | None = None
+
+    STATES = ("accepted", "confirmed", "unknown", "failed")
+
+    def __post_init__(self) -> None:
+        if self.status not in self.STATES:
+            raise ValueError(
+                f"unknown delivery status {self.status!r}; "
+                f"expected one of {', '.join(self.STATES)}")
+
+    @property
+    def reached_target(self) -> bool:
+        """True only when the transport actually confirmed it.
+
+        Deliberately not true for `accepted`/`unknown`: a caller that wants to
+        know whether kcn saw the message must not get a yes from a channel that
+        cannot answer.
+        """
+        return self.status == "confirmed"
+
+    @property
+    def worth_mirroring(self) -> bool:
+        """Whether a backup channel should carry the same message."""
+        return self.status in ("unknown", "failed")
+
+
+class DeliveryProvider(Protocol):
+    name: str
+
+    def send(self, channel: str, target: str, message: str, *,
+             dry_run: bool = False,
+             idempotency_key: str | None = None) -> DeliveryResult:
+        ...
+
+
+class OpenClawDelivery:
+    """Today's path: `openclaw message send --json`, unchanged."""
+
+    name = "openclaw"
+
+    def __init__(self, binary: str = "openclaw", account: str | None = None,
+                 timeout: int = 60, runner=None) -> None:
+        self.binary = binary
+        self.account = account
+        self.timeout = timeout
+        self._runner = runner or self._run
+
+    def _run(self, cmd):
+        done = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=self.timeout)
+        return done.returncode, (done.stdout + done.stderr)
+
+    def send(self, channel: str, target: str, message: str, *,
+             dry_run: bool = False,
+             idempotency_key: str | None = None) -> DeliveryResult:
+        cmd = [self.binary, "message", "send", "--channel", channel,
+               "--target", str(target), "-m", message, "--json"]
+        if self.account:
+            cmd[3:3] = ["--account", self.account]
+        if dry_run:
+            cmd.append("--dry-run")
+
+        try:
+            code, output = self._runner(cmd)
+        except FileNotFoundError:
+            return DeliveryResult("failed", channel, str(target),
+                                  detail=f"{self.binary} is not installed",
+                                  idempotency_key=idempotency_key)
+        except subprocess.TimeoutExpired:
+            # Timed out after handing over the message: it may well have gone.
+            # Calling this `failed` would invite a duplicate send.
+            return DeliveryResult("unknown", channel, str(target),
+                                  detail="timed out waiting for the transport",
+                                  idempotency_key=idempotency_key)
+
+        tail = (output or "").strip()[-400:]
+        if code != 0:
+            return DeliveryResult("failed", channel, str(target), detail=tail,
+                                  idempotency_key=idempotency_key)
+        status = "confirmed" if channel in CONFIRMING_CHANNELS else "unknown"
+        return DeliveryResult(status, channel, str(target), detail=tail,
+                              idempotency_key=idempotency_key)
+
+
+@dataclass
+class NullDelivery:
+    """Records instead of sending — foreign workspaces, dry runs, tests.
+
+    Reports `accepted`, never `confirmed`: nothing was delivered, and a provider
+    that claimed otherwise would make a dry run indistinguishable from a send.
+    """
+
+    name: str = "null"
+    sent: list = field(default_factory=list)
+
+    def send(self, channel: str, target: str, message: str, *,
+             dry_run: bool = False,
+             idempotency_key: str | None = None) -> DeliveryResult:
+        self.sent.append({"channel": channel, "target": target,
+                          "message": message, "dry_run": dry_run,
+                          "idempotency_key": idempotency_key})
+        return DeliveryResult("accepted", channel, str(target),
+                              detail="recorded by the null provider; not sent",
+                              idempotency_key=idempotency_key)

--- a/clawock/providers/runs.py
+++ b/clawock/providers/runs.py
@@ -1,0 +1,126 @@
+"""Run history, normalised across the two implementations we already had.
+
+`_watchdog_common.read_runs` reads OpenClaw's cron records (with its own
+cli → sqlite → fossil fallback chain) and `workflow_health.fetch_runs` reads
+GitHub Actions via `gh run list --json`. Both answer "did the scheduled thing
+run, and how did it end" — in different shapes, so nothing could consume them
+interchangeably.
+
+Normalising is what makes GitHub and OpenClaw peers rather than one being the
+substrate. It is also why `Run.status` is a small closed set: a caller deciding
+whether to fire a fallback must not have to know which scheduler answered.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Protocol
+
+# Deliberately small and closed. `unknown` is a real answer — a run that is
+# recorded but whose outcome the source cannot state must not be silently
+# rounded to success.
+STATUSES = ("ok", "error", "running", "unknown")
+
+_GITHUB_CONCLUSIONS = {
+    "success": "ok",
+    "failure": "error",
+    "cancelled": "error",
+    "timed_out": "error",
+    "startup_failure": "error",
+    None: "running",
+    "": "running",
+}
+
+
+@dataclass(frozen=True)
+class Run:
+    job: str
+    started_at: str | None       # ISO 8601
+    status: str                  # one of STATUSES
+    duration_ms: int | None = None
+    source: str = ""             # which provider answered
+    reference: str | None = None  # session id / run id, for tracing back
+
+    def __post_init__(self) -> None:
+        if self.status not in STATUSES:
+            raise ValueError(f"unknown run status {self.status!r}")
+
+
+class RunHistoryProvider(Protocol):
+    name: str
+
+    def history(self, job: str, limit: int = 20) -> list[Run]:
+        ...
+
+
+class OpenClawRuns:
+    """Wraps `_watchdog_common.read_runs`, which keeps its own fallback chain."""
+
+    name = "openclaw"
+
+    def __init__(self, reader=None) -> None:
+        self._reader = reader
+
+    def _read(self, job: str):
+        if self._reader is not None:
+            return self._reader(job)
+        import _watchdog_common  # resolved from the workspace's scripts/harness
+        return _watchdog_common.read_runs(job) or []
+
+    def history(self, job: str, limit: int = 20) -> list[Run]:
+        entries = list(self._read(job))[-limit:]
+        out = []
+        for entry in entries:
+            # `action` distinguishes a finished record from a lifecycle event;
+            # `status` carries the outcome when the record has one.
+            raw = (entry.get("status") or "").lower()
+            if entry.get("action") not in (None, "finished"):
+                status = "running"
+            elif raw in ("ok", "success", "succeeded"):
+                status = "ok"
+            elif raw in ("error", "failed", "failure"):
+                status = "error"
+            else:
+                status = "unknown"
+            out.append(Run(
+                job=entry.get("jobName") or job,
+                started_at=entry.get("runAtIso"),
+                status=status,
+                duration_ms=entry.get("durationMs"),
+                source=self.name,
+                reference=entry.get("sessionId"),
+            ))
+        return out
+
+
+class GitHubRuns:
+    """Wraps `gh run list --json`, the shape `workflow_health` already uses."""
+
+    name = "github"
+
+    def __init__(self, runner=None, timeout: int = 60) -> None:
+        self.timeout = timeout
+        self._runner = runner or self._run
+
+    def _run(self, cmd):
+        return subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=self.timeout).stdout
+
+    def history(self, job: str, limit: int = 20) -> list[Run]:
+        raw = self._runner([
+            "gh", "run", "list", "--workflow", job, "--limit", str(limit),
+            "--json", "conclusion,createdAt,event,databaseId",
+        ])
+        try:
+            entries = json.loads(raw or "[]")
+        except json.JSONDecodeError:
+            return []
+        return [
+            Run(job=job,
+                started_at=entry.get("createdAt"),
+                status=_GITHUB_CONCLUSIONS.get(entry.get("conclusion"), "unknown"),
+                source=self.name,
+                reference=str(entry["databaseId"]) if entry.get("databaseId") else None)
+            for entry in entries
+        ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,114 @@
+"""Three things that would make these providers worse than the status quo.
+
+1. Delivery collapsing back to a boolean. WeChat's CLI reports success for a
+   send its cold session silently drops (upstream wontfix), which is why the
+   intraday watchdog mirrors to Telegram on suspicion. `unknown` has to be its
+   own state: folded into success a dropped report looks delivered; folded into
+   failure it triggers duplicate sends.
+2. The two run-history sources not actually normalising — the point of the
+   interface is that a caller need not know which scheduler answered.
+3. A missing binary raising instead of reporting.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from clawock.providers import (  # noqa: E402
+    DeliveryResult, GitHubRuns, NullDelivery, OpenClawDelivery, OpenClawRuns, Run,
+)
+
+
+def test_wechat_success_is_unknown_not_confirmed():
+    sent = OpenClawDelivery(runner=lambda cmd: (0, '{"ok":true}')).send(
+        "wechat", "kcn", "hello")
+
+    assert sent.status == "unknown"
+    assert sent.reached_target is False, (
+        "a channel that cannot confirm must never report the message arrived")
+    assert sent.worth_mirroring is True
+
+
+def test_telegram_success_is_confirmed_and_needs_no_mirror():
+    sent = OpenClawDelivery(runner=lambda cmd: (0, "{}")).send(
+        "telegram", "123", "hello")
+
+    assert sent.status == "confirmed"
+    assert sent.reached_target is True
+    assert sent.worth_mirroring is False
+
+
+def test_a_timeout_is_unknown_because_the_message_may_have_gone():
+    import subprocess
+
+    def boom(cmd):
+        raise subprocess.TimeoutExpired(cmd, 60)
+
+    sent = OpenClawDelivery(runner=boom).send("wechat", "kcn", "hi")
+
+    # Calling this `failed` would invite a duplicate send of a report that
+    # possibly arrived.
+    assert sent.status == "unknown"
+
+
+def test_a_missing_binary_reports_instead_of_raising():
+    def missing(cmd):
+        raise FileNotFoundError(cmd[0])
+
+    sent = OpenClawDelivery(runner=missing).send("wechat", "kcn", "hi")
+
+    assert sent.status == "failed"
+    assert "not installed" in sent.detail
+
+
+def test_the_null_provider_never_claims_delivery():
+    provider = NullDelivery()
+
+    sent = provider.send("wechat", "kcn", "hi")
+
+    assert sent.status == "accepted"
+    assert sent.reached_target is False
+    assert provider.sent[0]["message"] == "hi"
+
+
+def test_an_invalid_status_cannot_be_constructed():
+    with pytest.raises(ValueError, match="unknown delivery status"):
+        DeliveryResult("delivered", "wechat", "kcn")
+
+
+def test_both_run_sources_normalise_to_the_same_shape():
+    openclaw = OpenClawRuns(reader=lambda job: [
+        {"jobName": "brief", "runAtIso": "2026-08-01T08:00:00+08:00",
+         "durationMs": 1167, "action": "finished", "status": "ok",
+         "sessionId": "abc"},
+    ]).history("brief")
+    github = GitHubRuns(runner=lambda cmd: (
+        '[{"conclusion":"success","createdAt":"2026-08-01T00:00:00Z",'
+        '"event":"schedule","databaseId":42}]')).history("brief-fallback.yml")
+
+    assert [type(r) for r in openclaw + github] == [Run, Run]
+    assert openclaw[0].status == github[0].status == "ok"
+    # A caller must not have to know which scheduler answered.
+    assert {r.source for r in openclaw + github} == {"openclaw", "github"}
+    assert openclaw[0].reference == "abc" and github[0].reference == "42"
+
+
+def test_an_unfinished_github_run_is_running_not_success():
+    runs = GitHubRuns(runner=lambda cmd: (
+        '[{"conclusion":null,"createdAt":"2026-08-02T00:00:00Z",'
+        '"event":"schedule","databaseId":7}]')).history("x")
+
+    assert runs[0].status == "running"
+
+
+def test_an_outcome_the_source_cannot_state_is_unknown_not_ok():
+    runs = OpenClawRuns(reader=lambda job: [
+        {"jobName": "brief", "runAtIso": "2026-08-01T08:00:00+08:00",
+         "action": "finished"},          # no status field at all
+    ]).history("brief")
+
+    assert runs[0].status == "unknown", (
+        "a recorded run with no stated outcome must not round to success")


### PR DESCRIPTION
Refs #251.

Two capabilities bind this repo to OpenClaw, and **neither is the LLM step**: every postflight delivers through `openclaw message send`, and every watchdog plus `cron_health_check`, `cron_timeline` and `system_check` read `openclaw cron`. Remove OpenClaw and reports stop being delivered and the watchdogs go blind — before prose generation matters at all.

## Mostly collecting what already existed

Both bindings were already narrow, JSON-returning subprocess calls. And run history already had **two independent implementations**: `_watchdog_common.read_runs` (OpenClaw, with its own cli → sqlite → fossil chain) and `workflow_health.fetch_runs` (GitHub Actions, `gh run list --json`). They just had no common shape, so nothing could treat the two schedulers as peers.

## Delivery is deliberately not a boolean

`openclaw message send` exits 0 for a WeChat send the cold session silently drops (upstream wontfix) — which is exactly why `intraday_watchdog` mirrors to Telegram *on suspicion*. So `(ok, tail)` is a lie by construction. Four states:

| | |
|---|---|
| `accepted` | handed over, transport did not object |
| `confirmed` | the transport says it arrived |
| `unknown` | accepted but unconfirmable — **WeChat's normal case** |
| `failed` | refused, with a reason |

`unknown` has to be its own state: folded into success a dropped report looks delivered; folded into failure it triggers a duplicate send. A timeout is `unknown` for the same reason — the message may well have gone.

Run status is closed for the same reason: a recorded run whose outcome the source cannot state is `unknown`, **never** `ok`.

## Scope

This lands the interfaces plus OpenClaw / GitHub / null implementations. **Nothing is rewired yet** — moving the postflights onto them changes live delivery behaviour and is its own slice.

## Tests

Nine, mutation-verified: marking WeChat confirmable reds `test_wechat_success_is_unknown_not_confirmed`; rounding a statusless run to `ok` reds `test_an_outcome_the_source_cannot_state_is_unknown_not_ok`. `1523 passed, 4 xfailed`.