### PR TITLE
architecture: ratchet the runtime coupling count (#261)

### DIFF
--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -1,0 +1,108 @@
+"""How many places know which agent runtime we are on.
+
+The goal is a standard, migratable harness — not something parasitic on one
+runtime. That is either a fact or a wish, and the difference is countable: if
+every module knows it is on OpenClaw, "it happens to run on OpenClaw" is
+marketing; if only the adapter knows, it is architecture.
+
+This is a ratchet, not a rewrite. Rewriting all the sites at once would touch
+the watchdogs and system_check — the parts that tell us the live system is
+healthy — which is a bad trade on a money system. So: record the count, fail if
+it rises, lower it as consumers move behind `clawock.providers`.
+
+Counting rule, and it matters
+-----------------------------
+A *label* naming `openclaw` as one source among several is the pattern we want,
+not debt: `cron_timeline.py` already takes `--source gha|openclaw|crontab` and
+treats all three as peers. A text matcher would punish that file and reward
+deleting the wrong thing. So the classifier walks the AST and only counts a site
+where the name is used to *invoke the binary or read its state*.
+"""
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Where knowing about OpenClaw is correct: that is what an adapter is for.
+ADAPTER = ROOT / "clawock" / "providers"
+
+# Lower this as consumers move behind clawock.providers. It must never rise.
+#
+#   scripts/system_check.py                 7
+#   scripts/harness/_watchdog_common.py     6
+#   scripts/data/sync_cron_payloads.py      1
+BASELINE = 14
+
+
+def _is_invocation(source_lines: list[str], node: ast.AST, lineno: int) -> bool:
+    """Whether this use of the name drives the binary rather than labels a source."""
+    line = source_lines[lineno - 1] if lineno <= len(source_lines) else ""
+    return any(marker in line for marker in ("subprocess", "cmd", "BIN", "run("))
+
+
+def coupling_sites() -> dict[str, list[int]]:
+    """Files outside the adapter that invoke OpenClaw or read its state."""
+    sites: dict[str, list[int]] = {}
+    for path in sorted(ROOT.glob("scripts/**/*.py")) + sorted(ROOT.glob("clawock/**/*.py")):
+        if ADAPTER in path.parents:
+            continue
+        try:
+            source = path.read_text()
+            tree = ast.parse(source)
+        except (OSError, SyntaxError):
+            continue
+        lines = source.splitlines()
+        found: list[int] = []
+        for node in ast.walk(tree):
+            # `OPENCLAW_BIN` is unambiguous: it exists to be executed.
+            if isinstance(node, ast.Name) and node.id == "OPENCLAW_BIN":
+                found.append(node.lineno)
+                continue
+            if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            value = node.value.strip()
+            # `"openclaw cron runs …"` is a command however it is assembled.
+            if value.startswith("openclaw "):
+                found.append(node.lineno)
+            elif value == "openclaw" and _is_invocation(lines, node, node.lineno):
+                found.append(node.lineno)
+        if found:
+            sites[path.relative_to(ROOT).as_posix()] = sorted(set(found))
+    return sites
+
+
+def test_the_runtime_coupling_count_never_rises():
+    sites = coupling_sites()
+    total = sum(len(lines) for lines in sites.values())
+
+    detail = "\n".join(f"  {name}: {len(lines)} — lines {lines}"
+                       for name, lines in sorted(sites.items()))
+    assert total <= BASELINE, (
+        f"runtime coupling rose to {total} (baseline {BASELINE}). New code must "
+        f"go through clawock.providers, not call OpenClaw directly:\n{detail}")
+
+    # A drop is the point of the exercise; make the reminder to lower the
+    # baseline impossible to miss, so the ratchet cannot silently go slack.
+    assert total >= BASELINE, (
+        f"runtime coupling fell to {total} — lower BASELINE to {total} in this "
+        "file so the gain is locked in")
+
+
+def test_a_multi_source_label_is_not_counted_as_coupling():
+    """`--source gha|openclaw|crontab` is the design we want. If the counter
+    punished it, the cheapest way to go green would be to delete the wrong
+    thing."""
+    sites = coupling_sites()
+
+    assert "scripts/data/cron_timeline.py" not in sites, (
+        "cron_timeline treats openclaw as one source among three — counting it "
+        "would reward removing multi-source support")
+
+
+def test_the_adapter_is_exempt_because_that_is_what_an_adapter_is_for():
+    sites = coupling_sites()
+
+    assert not [name for name in sites if name.startswith("clawock/providers/")]
+    # And the adapter must actually exist, or the exemption is hiding nothing.
+    assert (ADAPTER / "delivery.py").exists()


### PR DESCRIPTION
Closes #261.

The goal is a standard, migratable harness — not something parasitic on one runtime. That is either a fact or a wish, and the difference is countable: if every module knows it is on OpenClaw, "it happens to run on OpenClaw" is marketing; if only the adapter knows, it is architecture.

## Baseline: 14 real sites in 3 files

| file | sites |
|---|---|
| `scripts/system_check.py` | 7 |
| `scripts/harness/_watchdog_common.py` | 6 |
| `scripts/data/sync_cron_payloads.py` | 1 |

That corrects the 21 I first reported in the issue. I had counted string literals, which over-counts: naming `openclaw` as **one label among several supported sources** is the opposite of coupling. `cron_timeline.py` already takes `--source gha|openclaw|crontab` and treats all three as peers — a text matcher would punish that file, and the cheapest way to make it pass would be deleting multi-source support. So the classifier walks the AST and counts a site only where the name drives the binary or reads its state.

## Why a ratchet rather than a rewrite

Migrating all 14 at once touches the watchdogs and `system_check`, which are what tell us the live system is healthy. That is a bad trade on a money system. The test fails if the count rises — and equally if it falls without lowering `BASELINE`, so a gain gets locked in instead of leaving slack for the next regression.

`clawock/providers/` is exempt, because that is what an adapter is for. The test also asserts the adapter actually exists, so the exemption cannot end up hiding an empty directory.

## Tests

Three, mutation-verified: adding one direct `subprocess.run(["openclaw", ...])` reds the ratchet. `1526 passed, 4 xfailed`.
