### PR TITLE
watchdog: route delivery and cron reads through the providers (#251)

### DIFF
--- a/clawock/providers/delivery.py
+++ b/clawock/providers/delivery.py
@@ -75,9 +75,12 @@ class OpenClawDelivery:
 
     name = "openclaw"
 
-    def __init__(self, binary: str = "openclaw", account: str | None = None,
+    def __init__(self, binary: str | None = None, account: str | None = None,
                  timeout: int = 60, runner=None) -> None:
-        self.binary = binary
+        # Default to the adapter's own constant so callers do not have to know
+        # the path — that knowledge is what this package exists to contain.
+        from clawock.providers.openclaw import OPENCLAW_BIN
+        self.binary = binary or OPENCLAW_BIN
         self.account = account
         self.timeout = timeout
         self._runner = runner or self._run

--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -1,0 +1,52 @@
+"""The one place that knows where the OpenClaw binary lives and how to call it.
+
+Everything OpenClaw-specific belongs here so the rest of the tree can be counted
+as runtime-agnostic — see `tests/test_runtime_coupling_ratchet.py`, which exempts
+`clawock/providers/` precisely because that is what an adapter is for.
+
+Moved out of `scripts/harness/_watchdog_common.py`, which held the binary path
+and the cron CLI call and was therefore the largest single consumer that knew
+which runtime it was on.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+# pnpm's global bin. Kept as one constant rather than resolved through PATH: the
+# cron environment is not a login shell, and PATH resolution has bitten this
+# before.
+OPENCLAW_BIN = "/root/.local/share/pnpm/openclaw"
+
+# `cron list --json` round-trips through the gateway and has been observed at
+# ~42s on a loaded host. A tight timeout trips TimeoutExpired, which callers
+# read as "no data" and quietly fall back to a stale source.
+CRON_TIMEOUT_SECONDS = 120
+
+
+def cron_cli_json(cli_args, *, binary: str = OPENCLAW_BIN,
+                  timeout: int = CRON_TIMEOUT_SECONDS, runner=None):
+    """Run `openclaw cron <args> --json` and parse the object it prints.
+
+    Returns the dict, or None on any failure — the caller decides what an
+    unavailable runtime means, because for a watchdog it is not the same as an
+    empty result.
+
+    Leading `Config warnings:` noise is skipped: the CLI prints it before the
+    JSON body and it is not an error.
+    """
+    run = runner or (lambda cmd: subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout))
+    try:
+        done = run([binary, "cron", *cli_args])
+        # Deliberately NOT gated on returncode: the original helper parsed
+        # stdout regardless, and a command that exits non-zero while still
+        # printing a valid object was treated as data. Preserving that keeps
+        # this a move rather than a behaviour change.
+        text = done.stdout
+        start = text.find("{")
+        if start < 0:
+            return None
+        return json.loads(text[start:])
+    except Exception:
+        return None

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -35,7 +35,10 @@ STATE_DB = OC / 'state' / 'openclaw.sqlite'
 SESSIONS_DIR = OC / 'agents' / 'main' / 'sessions'
 LOG = WS / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
-OPENCLAW_BIN = '/root/.local/share/pnpm/openclaw'
+# The binary path and the cron CLI call moved into clawock/providers/openclaw.py
+# so this module stops being the largest consumer that knows which runtime it is
+# on. Re-exported: callers that import OPENCLAW_BIN from here keep working.
+from clawock.providers.openclaw import OPENCLAW_BIN, cron_cli_json as _adapter_cron_json  # noqa: E402
 
 
 def log(event):
@@ -94,20 +97,7 @@ def _cron_cli_json(cli_args):
     leading 'Config warnings:' noise). Returns the dict, or None on any failure.
     This is the storage-agnostic path — 6.1 migrated cron from jobs.json/runs/*.jsonl
     into state/openclaw.sqlite, so direct file reads silently return nothing."""
-    try:
-        # `cron list --json` round-trips through the gateway and has been observed
-        # at ~42s on a loaded host. A tight timeout here trips TimeoutExpired →
-        # None → silent fossil fallback in load_jobs(), which once masked a healthy
-        # fleet as "drifted" and blocked every push. Keep this well above real p99.
-        r = subprocess.run([OPENCLAW_BIN, 'cron', *cli_args],
-                           capture_output=True, text=True, timeout=120)
-        txt = r.stdout
-        i = txt.find('{')
-        if i < 0:
-            return None
-        return json.loads(txt[i:])
-    except Exception:
-        return None
+    return _adapter_cron_json(cli_args)
 
 
 # Set by load_jobs() to record which source served the last call:
@@ -370,30 +360,36 @@ def resolve_wechat_target(market=None):
     return KCN_WECHAT
 
 
+def _delivery(account=None):
+    """The delivery provider for this workspace. OpenClaw today, by construction
+    swappable — that is the whole point of the interface."""
+    from clawock.providers.delivery import OpenClawDelivery
+    return OpenClawDelivery(account=account)
+
+
 def send_wechat(channel, to, account, message, dry_run):
-    """openclaw message send. Returns (ok, tail_of_output)."""
-    cmd = [OPENCLAW_BIN, 'message', 'send',
-           '--channel', channel, '--target', to, '-m', message, '--json']
-    if account:
-        cmd[3:3] = ['--account', account]
-    if dry_run:
-        cmd.append('--dry-run')
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    return r.returncode == 0, (r.stdout + r.stderr)[-400:]
+    """Deliver to WeChat through the delivery provider. Returns (ok, tail).
+
+    Now routed through clawock.providers.delivery. `ok` is unchanged: the
+    provider reports `failed` exactly where this used to see a non-zero exit,
+    so every caller keeps the same two-state answer. The richer status —
+    WeChat's success is `unknown`, never `confirmed`, because the cold session
+    can drop it silently — is available to callers that ask for it, and
+    migrating the watchdogs' mirror-on-suspicion logic onto it is a separate
+    change with live delivery consequences.
+    """
+    result = _delivery(account).send(channel, str(to), message, dry_run=dry_run)
+    return result.status != 'failed', result.detail
 
 
 def send_telegram(target, message, dry_run):
-    """openclaw message send to Telegram. Returns (ok, tail_of_output).
+    """Deliver to Telegram through the delivery provider. Returns (ok, tail).
 
     Telegram is the cold-session-proof backup channel: unlike WeChat it has no
     idle-session silent-drop (the #81096/#81316 wontfix), so when the intraday
     watchdog judges a WeChat push probably dropped it mirrors here instead."""
-    cmd = [OPENCLAW_BIN, 'message', 'send',
-           '--channel', 'telegram', '--target', str(target), '-m', message, '--json']
-    if dry_run:
-        cmd.append('--dry-run')
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    return r.returncode == 0, (r.stdout + r.stderr)[-400:]
+    result = _delivery().send('telegram', str(target), message, dry_run=dry_run)
+    return result.status != 'failed', result.detail
 
 
 def dispatch_brief_fallback(dry_run=False):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -112,3 +112,19 @@ def test_an_outcome_the_source_cannot_state_is_unknown_not_ok():
 
     assert runs[0].status == "unknown", (
         "a recorded run with no stated outcome must not round to success")
+
+
+def test_delivery_rewire_preserves_the_ok_contract_callers_depend_on():
+    """Every caller reads `(ok, tail)`. The provider has four states; `ok` must
+    still mean exactly what a non-zero exit meant before, or a WeChat send that
+    the cold session drops starts reading as a failure and triggers a duplicate.
+    """
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from clawock.providers.delivery import OpenClawDelivery
+
+    for code, expected_ok in ((0, True), (1, False)):
+        result = OpenClawDelivery(
+            runner=lambda cmd, c=code: (c, '{"ok":1}')).send("wechat", "kcn", "hi")
+        assert (result.status != "failed") is expected_ok, result

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -30,9 +30,11 @@ ADAPTER = ROOT / "clawock" / "providers"
 # Lower this as consumers move behind clawock.providers. It must never rise.
 #
 #   scripts/system_check.py                 7
-#   scripts/harness/_watchdog_common.py     6
 #   scripts/data/sync_cron_payloads.py      1
-BASELINE = 14
+#
+# _watchdog_common reached 0 when delivery and the cron CLI moved behind
+# clawock/providers/ (its 6 were the largest single block).
+BASELINE = 8
 
 
 def _is_invocation(source_lines: list[str], node: ast.AST, lineno: int) -> bool:
@@ -53,6 +55,19 @@ def coupling_sites() -> dict[str, list[int]]:
         except (OSError, SyntaxError):
             continue
         lines = source.splitlines()
+        # Docstrings are ast.Constant too. A docstring that *describes* an
+        # OpenClaw call is documentation, not a call — counting it punishes
+        # writing the comment, and the cheapest way to go green is deleting the
+        # explanation. Collect their node ids and skip them.
+        docstrings = set()
+        for holder in ast.walk(tree):
+            if isinstance(holder, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                   ast.AsyncFunctionDef)):
+                body = getattr(holder, "body", None)
+                if (body and isinstance(body[0], ast.Expr)
+                        and isinstance(body[0].value, ast.Constant)
+                        and isinstance(body[0].value.value, str)):
+                    docstrings.add(id(body[0].value))
         found: list[int] = []
         for node in ast.walk(tree):
             # `OPENCLAW_BIN` is unambiguous: it exists to be executed.
@@ -60,6 +75,8 @@ def coupling_sites() -> dict[str, list[int]]:
                 found.append(node.lineno)
                 continue
             if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            if id(node) in docstrings:
                 continue
             value = node.value.strip()
             # `"openclaw cron runs …"` is a command however it is assembled.


### PR DESCRIPTION
Refs #251. Second slice of the coupling work.

`_watchdog_common` was the largest single module that knew which runtime it was on: the OpenClaw binary path, the cron CLI call, and both message senders — **6 of the 14 sites** the ratchet counts. It is now **0**, and the baseline drops **14 → 8**.

## What moved

- **`clawock/providers/openclaw.py`** owns `OPENCLAW_BIN` and `cron_cli_json`.
- **`send_wechat` / `send_telegram`** go through `clawock.providers.delivery` and keep their `(ok, tail)` signature, so **no caller changes**.
- `OpenClawDelivery` defaults its binary to the adapter's constant, so callers no longer need to know the path.

## Preserving semantics that look like bugs

The cron helper keeps the original behaviour **exactly**, including two things I was tempted to "fix":

- the **120s** timeout (a tight one trips `TimeoutExpired`, which callers read as "no data" and silently fall back to a stale source — that once masked a healthy fleet as drifted and blocked every push);
- **no returncode gate** — the old helper parsed stdout regardless, so a command exiting non-zero while printing a valid object was treated as data.

Changing either would have made this a behaviour change rather than a move.

`ok` is likewise unchanged **by construction**: the provider reports `failed` exactly where the old code saw a non-zero exit. Verified both directions and pinned by a test:

| exit | provider status | `ok` | old `ok` |
|---|---|---|---|
| 0 | `unknown` | True | True |
| 1 | `failed` | False | False |

## A false positive in the ratchet I merged an hour ago

Docstrings are `ast.Constant` too, so a docstring *describing* an OpenClaw call was counted as one. That punishes writing the explanation, and the cheapest way to go green would be deleting it. Docstring nodes are now excluded.

## Deliberately not consumed yet

The richer delivery status. WeChat success is `unknown`, never `confirmed`, and migrating the watchdogs' mirror-on-suspicion logic onto that changes live delivery — its own slice.

## Verification

Against the **live gateway** after the rewire: `load_jobs` returns 11 jobs and `read_runs` 50 records, both through source `cli`. Both watchdogs run and exit 0 from a clean CWD. `1526 passed, 4 xfailed`, `system_check` 16 ok / 0 critical.
