### PR TITLE
harness: import clawock from the checkout, not by side effect (#265)

### DIFF
--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -38,6 +38,15 @@ HKT = timezone(timedelta(hours=8))
 # The binary path and the cron CLI call moved into clawock/providers/openclaw.py
 # so this module stops being the largest consumer that knows which runtime it is
 # on. Re-exported: callers that import OPENCLAW_BIN from here keep working.
+#
+# `clawock` is not installed on the live host, so the repository root has to be on
+# sys.path for this import to resolve. Say so here rather than inheriting it: the
+# `workspace` shim above also inserts the root, and relying on that side effect
+# makes every watchdog's import depend on an unrelated module keeping a line it
+# only has for its own 53 consumers. Import-time failure is the worst shape for a
+# watchdog — the backstop that exists to notice a missing report goes missing
+# first, and the crontab entry only logs a traceback.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from clawock.providers.openclaw import OPENCLAW_BIN, cron_cli_json as _adapter_cron_json  # noqa: E402
 
 

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -56,7 +56,12 @@ import workflow_outcomes  # noqa: E402
 # The deterministic report core moved into the installed package so `clawock
 # report` can run it without a repository checkout. Re-exported here so this
 # module's own regression suite keeps exercising exactly that code.
-sys.path.insert(0, str(WS))
+#
+# The *checkout* root, not `WS`: `WS` is the workspace, and CLAWOCK_WORKSPACE can
+# point it at someone else's data directory — a foreign workspace holds market
+# data, not our package. Identical to the old line whenever the override is unset,
+# i.e. on every live run, and correct when it is set.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from clawock.report import (  # noqa: E402,F401
     CRITICAL_KEYWORDS,
     FORBIDDEN_PHRASES,

--- a/tests/test_harness_import_independence.py
+++ b/tests/test_harness_import_independence.py
@@ -1,0 +1,82 @@
+"""A module that imports `clawock` must put the checkout on the path itself.
+
+`clawock` is not installed on the live host. Modules under `scripts/` reach it
+only because something inserted the repository root into `sys.path` first. Two of
+the three live importers did that explicitly; `_watchdog_common` inherited it as a
+side effect of importing the `scripts/data/workspace.py` shim, which inserts the
+root for its own 53 consumers.
+
+That is a live hazard and a migration blocker at the same time. `_watchdog_common`
+is imported by 15 modules including all three watchdogs, driven by 28 crontab
+entries; if the shim's insert goes away — which is exactly what retiring the shim
+means — every watchdog fails at *import* time. The backstop that exists to notice
+a missing report goes missing first, and the crontab entry logs a traceback into
+watchdog.cron.log.
+
+Why this is a source-shape test and not an "import it in a subprocess" test: CI
+installs the package (`pip install -e '.[test]'`), so the repository root is on
+`sys.path` there no matter what any module does. A runtime import test would pass
+in CI while the live host — the only environment without the install — is the one
+at risk. It would look like coverage and protect nothing. The defect is visible in
+the source, so the test reads the source.
+
+Mutation check: deleting either insert turns this red, and so does resolving the
+insert from `WS` (the workspace, which CLAWOCK_WORKSPACE may point elsewhere)
+instead of from the checkout.
+"""
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Expressions that denote the checkout root itself. `parents[2]` from a file two
+# directories down is the root; the shim names it. `WS` is deliberately absent:
+# it is the workspace, and a foreign workspace holds market data, not our package.
+CHECKOUT_ROOT_FORMS = ("parents[2]", "_REPO_ROOT")
+
+
+def _inserts_checkout_root(node: ast.Call, source: str) -> bool:
+    """Whether this call is `sys.path.insert(..., <checkout root>)`."""
+    func = node.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "insert"):
+        return False
+    if not (isinstance(func.value, ast.Attribute) and func.value.attr == "path"):
+        return False
+    if len(node.args) < 2:
+        return False
+    arg = ast.get_source_segment(source, node.args[1]) or ""
+    # A path *below* the root (…/'scripts'/'data') does not make clawock
+    # importable, so a join disqualifies the call however it is spelled.
+    if "/" in arg:
+        return False
+    return any(form in arg for form in CHECKOUT_ROOT_FORMS)
+
+
+def test_clawock_importers_do_not_inherit_their_sys_path():
+    offenders = []
+    for path in sorted(ROOT.glob("scripts/**/*.py")):
+        source = path.read_text()
+        if "clawock" not in source:
+            continue
+        tree = ast.parse(source)
+        import_line = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("clawock"):
+                import_line = node.lineno if import_line is None else min(import_line, node.lineno)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("clawock"):
+                        import_line = node.lineno if import_line is None else min(import_line, node.lineno)
+        if import_line is None:
+            continue
+        inserts = [
+            node.lineno for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and _inserts_checkout_root(node, source)
+        ]
+        if not any(lineno < import_line for lineno in inserts):
+            offenders.append(f"{path.relative_to(ROOT)}:{import_line}")
+
+    assert not offenders, (
+        "these modules import clawock without putting the checkout root on "
+        f"sys.path first, so the import resolves only by side effect: {offenders}"
+    )


### PR DESCRIPTION
Closes #265.

## What was wrong

`clawock` is not installed on the live host:

```
$ cd /tmp && python3 -c "import clawock"
ModuleNotFoundError: No module named 'clawock'
```

Modules under `scripts/` reach it only because something inserted the repository
root into `sys.path` first. `_harness_common` and `report_postflight` did that
explicitly. `_watchdog_common` did not — it inserted `scripts/data`, imported the
`workspace` shim, and the shim's own root insert (a line it carries for its 53
consumers) is what made `from clawock.providers.openclaw import ...` resolve.

So the import graph of the live delivery path depended on an unrelated module's
side effect, and nothing stated the dependency.

`report_postflight` had the same defect spelled differently: it resolved the
package from `WS`, the *workspace*, which `CLAWOCK_WORKSPACE` can point at
someone else's data directory — the point of the portable engine (#246). A
foreign workspace holds market data, not our package.

## Why it mattered enough to fix before the dashboard work

`_watchdog_common` is imported by 15 modules including all three watchdogs, driven
by 28 crontab entries. Retiring the `workspace` shim (#267) means removing its
root insert — which would have failed every watchdog at **import** time. That is
the worst shape for a watchdog: the backstop that exists to notice a missing
report goes missing first, and the crontab entry only logs a traceback into
`watchdog.cron.log`. The shim removal and the watchdog outage look like unrelated
changes.

## Live safety

Both edits are no-ops on today's live path — they add an insert the shim already
performed. Behaviour is unchanged; the guarantee is now stated where it is relied
on. Verified:

- full suite: `1528 passed, 4 xfailed`
- cron-shaped import smoke for all six harness entry points (`cwd` outside the
  repository, `PYTHONPATH` unset, only the script directory on `sys.path`): all OK
- coupling ratchet unchanged at 8

## About the test

It reads source shape instead of importing in a subprocess. CI installs the
package (`pip install -e '.[test]'`), so the repository root is on `sys.path`
there no matter what any module does — a runtime import test would pass in CI
while the live host, the only environment without the install, stayed exposed. It
would look like coverage and protect nothing.

Mutation-verified both ways: dropping the insert in `_watchdog_common` turns it
red, and resolving the insert from `WS` instead of the checkout turns it red.

One test, because one is what backstops this.

## Deliberately not in scope

29 files resolve *code* imports through `WS / 'scripts' / 'data'` — the same
workspace-versus-checkout confusion. Fixing one of them here would make the
pattern look handled. Filed separately.
