### PR TITLE
packaging: ship the subpackages that the watchdogs import (#270)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,11 @@ clawock = "clawock.cli:main"
 # scripts/ is still deliberately unpackaged — it is the operator-side
 # implementation of this desk, and the coupling there is inside modules rather
 # than between them.
-packages = ["clawock"]
+#
+# Discovered rather than listed. `packages = ["clawock"]` is an *exact* list in
+# setuptools, so `clawock.providers` and `clawock.tools` were silently left out of
+# the wheel the moment they were added — the rule two paragraphs up, broken by the
+# next two PRs that obeyed it in spirit. A pattern brings a new subpackage in by
+# construction; a list brings it in only if someone remembers.
+[tool.setuptools.packages.find]
+include = ["clawock*"]

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -10,6 +10,13 @@ installability proved nothing.
 
 Structural rather than a real wheel build, so it stays cheap enough to run on
 every PR while still catching that exact class.
+
+It did not catch the recurrence. `clawock.providers` and `clawock.tools` were
+missing from every wheel built after they were added, and this file could not see
+it: the scan globbed `clawock/*.py`, top level only, and the declaration check
+read the package list rather than the artifact. `tests/test_wheel_contains_the_
+package.py` now builds and imports the real thing; these checks stay for the
+cheap, fast signal, corrected to walk the whole package.
 """
 import ast
 import sys
@@ -32,25 +39,39 @@ def _first_party_imports(path: Path) -> set[str]:
     return {name for name in names if name not in stdlib}
 
 
+# One escape is known and tracked, not tolerated: `OpenClawRuns.list_runs()`
+# lazily imports `_watchdog_common`, which lives in `scripts/harness/` and is not
+# in the wheel. The module still imports from an installation — the import is
+# inside the method — but calling it there raises. Pinned rather than hidden so a
+# *new* escape fails while this one stays visible until the read moves into the
+# package.
+KNOWN_ESCAPES = {"providers/runs.py": {"_watchdog_common"}}
+
+
 def test_nothing_the_package_imports_lives_outside_it():
     escapes = {}
-    for path in sorted(PKG.glob("*.py")):
+    for path in sorted(PKG.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
         for name in _first_party_imports(path):
             if name != "clawock":
-                escapes.setdefault(path.name, set()).add(name)
+                escapes.setdefault(
+                    path.relative_to(PKG).as_posix(), set()).add(name)
 
-    assert not escapes, (
-        "the installed wheel contains only the clawock package, so a first-party "
-        f"import that resolves outside it crashes on install: {escapes}")
+    assert escapes == KNOWN_ESCAPES, (
+        "the wheel contains only the clawock package, so a first-party import "
+        "that resolves outside it crashes on install. Expected only the tracked "
+        f"escape {KNOWN_ESCAPES}, found {escapes}")
 
 
-def test_the_entry_point_and_the_packaged_directory_agree():
+def test_the_entry_point_is_inside_the_package():
     config = tomllib.load(open(ROOT / "pyproject.toml", "rb"))["project"]
-    packages = tomllib.load(open(ROOT / "pyproject.toml", "rb"))[
-        "tool"]["setuptools"]["packages"]
-
     module = config["scripts"]["clawock"].split(":")[0]
 
-    assert module.split(".")[0] in packages, (
-        f"entry point {module} is not inside a packaged directory {packages}")
+    # Deliberately no longer compares against the declared package list. That
+    # check read the declaration and passed for as long as the declaration was
+    # wrong; whether the entry point is really shipped is now settled by building
+    # the wheel and importing out of it.
+    assert module.split(".")[0] == PKG.name, (
+        f"entry point {module} is not inside the package directory {PKG.name}")
     assert (PKG / "__init__.py").exists(), "clawock must be a real package"

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -1,0 +1,102 @@
+"""What we ship must contain what we claim to ship.
+
+`packages = ["clawock"]` is an exact list in setuptools, so `clawock.providers`
+and `clawock.tools` were absent from every wheel built after they were added.
+`pip install clawock` followed by `import clawock.providers.openclaw` raised
+ModuleNotFoundError, and `scripts/harness/_watchdog_common.py` — imported by all
+three watchdogs — imports exactly that.
+
+Nothing caught it, for three separate reasons, and each one is a lesson about
+where to point a test:
+
+* every workflow installs with `pip install -e .`, and an editable install leaves
+  the source tree on `sys.path`, so the wheel's contents never matter in CI;
+* the live host does not install the package at all — it reaches the source
+  through `sys.path` inserts;
+* `test_package_surface.py` reads `clawock/*.py` in the source tree, and
+  `test_report_core_is_independent.py` proves independence with
+  `PYTHONPATH=<repo root>` — also the source tree. Both assert things about code
+  we did not ship.
+
+So this test builds the artifact and imports out of it. Nothing that reads the
+source tree can replace it, because the source tree is the thing that lied.
+
+Mutation check: pin the declaration back to `packages = ["clawock"]` and this
+goes red on the first subpackage.
+"""
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Everything the wheel build reads. Copied to a clean directory first, because a
+# leftover `clawock.egg-info` in the checkout makes setuptools reuse the previous
+# build's package list — which masks a wrong declaration completely. That is how
+# this test passed under mutation the first time it was written.
+BUILD_INPUTS = ("pyproject.toml", "README.md", "LICENSE", "NOTICE")
+
+
+def _modules_in_source() -> set[str]:
+    """Importable dotted names for every module under clawock/ in the checkout."""
+    names = set()
+    for path in sorted((ROOT / "clawock").rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(ROOT).with_suffix("")
+        parts = list(rel.parts)
+        if parts[-1] == "__init__":
+            parts.pop()
+        names.add(".".join(parts))
+    return names
+
+
+def test_every_module_imports_from_a_non_editable_install(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    shutil.copytree(ROOT / "clawock", source / "clawock",
+                    ignore=shutil.ignore_patterns("__pycache__"))
+    for name in BUILD_INPUTS:
+        origin = ROOT / name
+        assert origin.exists(), f"{name} is declared as a build input but is missing"
+        shutil.copy2(origin, source / name)
+
+    build = tmp_path / "wheel"
+    done = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "--no-cache-dir",
+         "-w", str(build), str(source)],
+        capture_output=True, text=True, timeout=300)
+    assert done.returncode == 0, f"wheel build failed:\n{done.stderr[-2000:]}"
+
+    wheels = list(build.glob("clawock-*.whl"))
+    assert len(wheels) == 1, f"expected one wheel, got {wheels}"
+
+    site = tmp_path / "site"
+    done = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-deps", "--no-index",
+         "--target", str(site), str(wheels[0])],
+        capture_output=True, text=True, timeout=300)
+    assert done.returncode == 0, f"install failed:\n{done.stderr[-2000:]}"
+
+    modules = sorted(_modules_in_source())
+    assert "clawock.providers.openclaw" in modules, (
+        "the module the watchdogs import went missing from the source tree — "
+        "fix this test's expectations deliberately, not reflexively")
+
+    # cwd is tmp_path and PYTHONPATH is the install target only: the checkout is
+    # not reachable, so an import can only succeed out of the installed artifact.
+    done = subprocess.run(
+        [sys.executable, "-c",
+         "import importlib, sys\n"
+         "for name in sys.argv[1:]:\n"
+         "    importlib.import_module(name)\n"
+         "print('ok')"] + modules,
+        cwd=tmp_path,
+        env={"PYTHONPATH": str(site), "PATH": "/usr/bin:/bin",
+             "LC_ALL": "C.UTF-8", "PYTHONIOENCODING": "utf-8"},
+        capture_output=True, text=True, timeout=120)
+
+    assert done.returncode == 0, (
+        "a module in the source tree is not importable from the built wheel — "
+        f"the shipped package is not the package:\n{done.stderr[-2000:]}")


### PR DESCRIPTION
Closes #270.

## The bug

`packages = ["clawock"]` is an exact list in setuptools, not a prefix. Every wheel
built after `clawock/providers/` (#260) and `clawock/tools/` (#258) were added was
missing both:

```
$ unzip -l clawock-0.1.0-py3-none-any.whl | grep '\.py$'
   clawock/__init__.py  cli.py  report.py  validation.py  workspace.py
```

`pip install clawock` then `import clawock.providers.openclaw` → ModuleNotFoundError.
`scripts/harness/_watchdog_common.py`, imported by all three watchdogs, imports
exactly that.

The comment directly above the broken line already stated the rule — *"Anything the
CLI imports has to live in here"* — and describes this same failure from the first
time it happened. It was re-broken by the next two PRs that added subpackages.

## Why nothing caught it

Three independent blind spots, and each one is a lesson about where to point a test:

1. Every workflow installs with `pip install -e .`. An editable install leaves the
   source tree on `sys.path`, so the wheel's contents never mattered in CI.
2. The live host does not install the package at all — it reaches the source
   through `sys.path` inserts.
3. Both existing guards read the **source tree**, which is the thing that lied.
   `test_package_surface` globbed `clawock/*.py` (top level only, so the missing
   subpackages were literally invisible) and compared the entry point against the
   *declared* package list — an assertion that passed for exactly as long as the
   declaration was wrong. `test_report_core_is_independent` proves independence
   with `PYTHONPATH=<repo root>`: also the source tree.

It also narrows a claim we have made. #256's proof was "a real wheel outside the
source tree produces a validated report with no OpenClaw, git or gh." That proof
predates `providers/` and `tools/` and never covered them.

## The change

- Declare by pattern (`[tool.setuptools.packages.find] include = ["clawock*"]`) so
  a new subpackage ships by construction rather than by memory.
- New test builds the wheel, installs it **non-editable** into a `--target`
  directory, and imports every module under `clawock/` with the checkout
  unreachable.
- `test_package_surface` corrected rather than deleted — it walks the whole package
  now, and the declaration comparison is gone, because building the artifact
  answers that question properly.

## One thing worth reading in the test

It builds from a clean copy of the build inputs, not from the checkout. A leftover
`clawock.egg-info` makes setuptools reuse the previous build's package list, which
masks a wrong declaration completely — **that is how this test passed under
mutation the first time I wrote it.** The green was an artifact of my own earlier
build sitting in the worktree. Building in a temp directory is what makes the
mutation check meaningful.

## Known escape, pinned not hidden

Walking the whole package surfaces a real gap: `OpenClawRuns.list_runs()` lazily
imports `_watchdog_common` from `scripts/harness/`, which is not in the wheel. The
module imports fine from an installation (the import is inside the method) but the
call raises. Pinned as a tracked escape so a *new* one fails while this one stays
visible. Filed separately — moving that read into the package is #251 work, not
packaging work.

## Verification

- full suite: `1528 passed, 4 xfailed`
- mutation: pinning back to `packages = ["clawock"]` fails with *"the shipped
  package is not the package"*
- the new test runs in ~4s
