### PR TITLE
dashboard_outputs: publish overview and dashboard as one generation

### DIFF
--- a/scripts/data/dashboard_outputs.py
+++ b/scripts/data/dashboard_outputs.py
@@ -47,6 +47,17 @@ _TOP_LEVEL_CLOCK_FIELDS = {
     "assets/data/shadow_portfolio.json": {"as_of"},
 }
 
+# overview.json is a projection of dashboard.json and pins
+# ``overview.generation_id == dashboard.generated_at``.  Per-file clock-only
+# restores break that parity whenever the full payload changes in a field the
+# projection does not carry: the projection is byte-identical, gets restored to
+# HEAD, and stays one generation behind the payload published beside it.  These
+# two publish together or not at all.
+_GENERATION_LINKED = frozenset({
+    "assets/data/overview.json",
+    "assets/data/dashboard.json",
+})
+
 
 def _strip_recursive(value, fields):
     if isinstance(value, dict):
@@ -96,22 +107,34 @@ def semantic_changed_paths(root: Path | str = ROOT, *, restore_clock_only=True):
     Clock-only rebuilds are restored to ``HEAD`` by default.  Missing/untracked
     outputs, invalid JSON, or a missing ``HEAD`` version are conservatively
     treated as real changes so they cannot disappear from publication.
+    Generation-linked outputs are decided as a group, so a projection is never
+    restored while the payload it is stamped from gets published.
     """
     root = Path(root)
-    changed = []
+    changed = set()
+    clock_only = set()
     for path in DASHBOARD_OUTPUTS:
         try:
             current = json.loads((root / path).read_text(encoding="utf-8"))
             previous = _head_json(root, path)
         except (FileNotFoundError, json.JSONDecodeError, subprocess.SubprocessError):
-            changed.append(path)
+            changed.add(path)
             continue
 
         if semantic_value(path, current) != semantic_value(path, previous):
-            changed.append(path)
-        elif restore_clock_only:
-            _restore_head_worktree(root, path)
-    return changed
+            changed.add(path)
+        else:
+            clock_only.add(path)
+
+    if changed & _GENERATION_LINKED:
+        changed |= clock_only & _GENERATION_LINKED
+        clock_only -= _GENERATION_LINKED
+
+    if restore_clock_only:
+        for path in DASHBOARD_OUTPUTS:
+            if path in clock_only:
+                _restore_head_worktree(root, path)
+    return [path for path in DASHBOARD_OUTPUTS if path in changed]
 
 
 def main():

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -123,6 +123,34 @@ def test_real_sidecar_change_is_returned_with_exact_path(tmp_path):
     ) == original["assets/data/decision_audit.json"]
 
 
+def test_payload_change_outside_the_projection_republishes_the_projection(tmp_path):
+    """The failure that reddened master on 2026-08-03.
+
+    ``workflow_outcomes`` moved, the overview projection did not carry it, so the
+    projection looked clock-only and was restored to HEAD — leaving its
+    ``generation_id`` one build behind the payload committed beside it.
+    """
+    original = _repo(tmp_path)
+    _write(tmp_path, "assets/data/overview.json", {
+        **original["assets/data/overview.json"],
+        "generation_id": "new",
+        "generated_at": "new",
+    })
+    _write(tmp_path, "assets/data/dashboard.json", {
+        **original["assets/data/dashboard.json"],
+        "generated_at": "new",
+        "workflow_outcomes": {"failures": 1},
+    })
+
+    assert dashboard_outputs.semantic_changed_paths(tmp_path) == [
+        "assets/data/overview.json",
+        "assets/data/dashboard.json",
+    ]
+    overview = json.loads((tmp_path / "assets/data/overview.json").read_text())
+    dashboard = json.loads((tmp_path / "assets/data/dashboard.json").read_text())
+    assert overview["generation_id"] == dashboard["generated_at"]
+
+
 def test_reflect_backtest_change_publishes_the_existing_audit_sidecar(tmp_path):
     original = _repo(tmp_path)
     _write(tmp_path, "assets/data/decision_audit.json", {


### PR DESCRIPTION
Fixes #277.

## 问题

`semantic_changed_paths()` 对四个产物逐文件独立判定，语义没变就 restore 回 HEAD。但 `overview.json` 是 `dashboard.json` 的投影，`tests/test_dashboard_payload_size.py:54` 钉着跨文件不变量 `overview.generation_id == dashboard.generated_at` —— 两者互相矛盾。

当 dashboard.json 的语义变化落在投影不携带的字段上（`workflow_outcomes` 最常见），投影逐字节相同 → 被 restore → 代次落后一代 → `Dashboard Artifact Gate` 与所有 PR 的 `validate` 变红。

## 改动

把 `overview.json` + `dashboard.json` 作为一个 generation-linked 组判定：任一语义变化，两个都进发布 pathspec。`decision_audit.json` / `shadow_portfolio.json` 保持各自独立判定，行为不变。

纯时钟重建仍然两个都 restore，不产生 no-op commit。

## 测试

新增一条回归测试复现 8-03 那次故障（dashboard 在投影外字段变化 → 两个路径都返回 → parity 成立）。

变异验证：移除分组逻辑后，只有这条新测试变红，其余四条仍绿。

## master 数据修复

代码修复不追溯已提交的坏数据。已按生成数据的自动化直发路径，用 `compile_overview_projection(committed dashboard.json)` 重算并发布 `7205bb98`，master 已恢复绿。顺带发现落后的那一代 overview 除代次外还带着过期的 `build_status`。
