### PR TITLE
pages contract: assert the official action, not which major

### DIFF
--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -81,13 +81,16 @@ def test_all_action_data_and_rendered_briefs_trigger_pages_build():
 
 
 def test_workflow_uses_official_non_committing_pages_flow():
+    # Assert the official action and a pinned major, not which major. The
+    # invariant here is the non-committing flow below; pinning the digits made
+    # every dependabot major bump a guaranteed red that said nothing about it.
     for action in (
-        "actions/configure-pages@v5",
-        "actions/jekyll-build-pages@v1",
-        "actions/upload-pages-artifact@v4",
-        "actions/deploy-pages@v4",
+        "actions/configure-pages",
+        "actions/jekyll-build-pages",
+        "actions/upload-pages-artifact",
+        "actions/deploy-pages",
     ):
-        assert action in WORKFLOW
+        assert re.search(rf"uses: {re.escape(action)}@v\d+\b", WORKFLOW), action
     assert "pages: write" in WORKFLOW
     assert "id-token: write" in WORKFLOW
     assert "git push" not in WORKFLOW


### PR DESCRIPTION
Fixes #278.

## 问题

`test_workflow_uses_official_non_committing_pages_flow` 把四个官方 Pages action 的主版本号写死在断言里，于是每一次官方 action 主版本升级都变成一条必然的假红——而这条红并不代表这个测试真正要守的东西（非提交式流程：无 `git push`、无 `CLAWOCK_PUBLISH_SSH_KEY`、`pages: write` + `id-token: write`）被破坏。

三个 dependabot PR 全挂在这一条上。

## 改动

改成匹配 `uses: <action>@v<N>`：官方 action 必须在场且必须 pin 到某个主版本，但**是哪个主版本不归这条契约管**。真实的升级兼容性由 `Deploy GitHub Pages` workflow 自己实跑证明。

同函数内其余四条断言原样保留。

## 变异验证

| 变异 | 期望 | 实测 |
|---|---|---|
| 三个 action 主版本 +1（模拟 dependabot） | 绿 | 绿 |
| `deploy-pages@v5` → `@main`（浮动 ref） | 红 | 红 |
| `upload-pages-artifact` 换成第三方 action | 红 | 红 |

## 范围外

三个 dependabot PR 本身仍然合不了（既有情况，与本 PR 无关），需要搬到 `claude/…` 分支重开；本 PR 只拆掉「测试必然红」这一层。
