### PR TITLE
validate_sidecars: reconcile dashboard money within one book generation

### DIFF
--- a/scripts/data/validate_sidecars.py
+++ b/scripts/data/validate_sidecars.py
@@ -630,6 +630,20 @@ def validate_gif(path: Path | str = 'assets/dashboard.gif') -> None:
     print(f'validated {path}: {size} bytes, {width}x{height}, {frames} frames')
 
 
+def _book_generation(stamp: object, label: str) -> datetime:
+    """Parse a book stamp (``2026/08/03 12:00 HKT``) into a comparable time.
+
+    Unparseable is fatal, not skipped: an unreadable stamp would otherwise turn
+    the cross-generation direction check below into a silent pass.
+    """
+    assert isinstance(stamp, str) and stamp.strip(), f'{label} missing'
+    text = stamp.strip().removesuffix('HKT').strip()
+    try:
+        return datetime.strptime(text, '%Y/%m/%d %H:%M')
+    except ValueError:
+        raise AssertionError(f'{label} is unparseable: {stamp!r}') from None
+
+
 def _assert_dashboard_money_reconciles(
         data: dict, portfolio_path: Path | str,
         fx_path: Path | str | None = None) -> None:
@@ -657,6 +671,28 @@ def _assert_dashboard_money_reconciles(
         'portfolio money integrity failed: '
         + '; '.join(f"{finding['code']} {finding['msg']}"
                     for finding in money_findings[:6]))
+
+    # The dashboard and portfolio.json have deliberately different commit
+    # cadences. Mode 7 and the scheduled publisher rebuild the dashboard from
+    # the live book every slot but never commit portfolio.json — that is an
+    # explicit design decision (intraday_postflight.py header), because the book
+    # can be mid-refresh when a postflight commits. The price updaters own it and
+    # publish at open/midday/close. During a session the committed dashboard is
+    # therefore legitimately built from a NEWER book than the committed
+    # portfolio, and comparing their totals field by field compares two
+    # generations — which reddened the gate on every intraday tick.
+    #
+    # Reconcile field by field only within one book generation. Across
+    # generations, assert the direction instead: a dashboard built from an OLDER
+    # book than the committed one is real staleness and still fails here.
+    book_stamp = data.get('last_updated')
+    source_stamp = portfolio.get('last_updated')
+    same_book = book_stamp == source_stamp
+    if not same_book:
+        assert _book_generation(book_stamp, 'dashboard.last_updated') >= \
+            _book_generation(source_stamp, 'portfolio.last_updated'), (
+                f'dashboard was built from an older book than the committed '
+                f'portfolio.json: dashboard={book_stamp} < portfolio={source_stamp}')
 
     def finite(value):
         return (isinstance(value, (int, float))
@@ -711,48 +747,54 @@ def _assert_dashboard_money_reconciles(
     for leg, (region, currency, total_fields) in regions.items():
         source_leg = portfolio.get('portfolios', {}).get(region)
         assert isinstance(source_leg, dict), f'portfolio missing {region}'
-        for public_field, source_field in total_fields.items():
-            same_optional_number(
-                data['totals'][leg].get(public_field),
-                source_leg.get(source_field),
-                f'totals.{leg}.{public_field}',
-            )
-
-        source_rows = {
-            row.get('ticker') or row.get('code'): row
-            for row in source_leg.get('holdings', [])
-            if isinstance(row, dict) and (row.get('shares') or 0) > 0
-        }
         public_rows = data['holdings'][leg]
         public_by_ticker = {
             row.get('ticker'): row for row in public_rows if isinstance(row, dict)
         }
         assert len(public_by_ticker) == len(public_rows), (
             f'holdings.{leg} has duplicate or malformed tickers')
-        assert set(public_by_ticker) == set(source_rows), (
-            f'holdings.{leg} ticker coverage mismatch: '
-            f'missing={sorted(set(source_rows) - set(public_by_ticker))}, '
-            f'extra={sorted(set(public_by_ticker) - set(source_rows))}')
 
-        for ticker, source in source_rows.items():
-            public = public_by_ticker[ticker]
-            expected_name = source.get('name') or source.get('stock_name', '')
-            assert public.get('name') == expected_name, (
-                f'holdings.{leg}.{ticker}.name does not reconcile')
-            assert public.get('currency') == currency, (
-                f'holdings.{leg}.{ticker}.currency must be {currency}')
-            assert public.get('is_active') is True, (
-                f'holdings.{leg}.{ticker}.is_active must be true')
-            assert public.get('trades_count') == len(source.get('trades') or []), (
-                f'holdings.{leg}.{ticker}.trades_count does not reconcile')
-            for public_field, (source_field, places) in holding_fields.items():
-                source_value = source.get(source_field)
-                expected = source_value if places is None else round(source_value or 0, places)
-                tolerance = 1e-9 if places is None else 0.5 * (10 ** -places)
-                same_number(
-                    public.get(public_field), expected,
-                    f'holdings.{leg}.{ticker}.{public_field}', tolerance,
+        # Everything from here to the concentration card compares the published
+        # view against the source book, so it is only meaningful within one book
+        # generation. See the `same_book` note above.
+        if same_book:
+            for public_field, source_field in total_fields.items():
+                same_optional_number(
+                    data['totals'][leg].get(public_field),
+                    source_leg.get(source_field),
+                    f'totals.{leg}.{public_field}',
                 )
+
+            source_rows = {
+                row.get('ticker') or row.get('code'): row
+                for row in source_leg.get('holdings', [])
+                if isinstance(row, dict) and (row.get('shares') or 0) > 0
+            }
+            assert set(public_by_ticker) == set(source_rows), (
+                f'holdings.{leg} ticker coverage mismatch: '
+                f'missing={sorted(set(source_rows) - set(public_by_ticker))}, '
+                f'extra={sorted(set(public_by_ticker) - set(source_rows))}')
+
+            for ticker, source in source_rows.items():
+                public = public_by_ticker[ticker]
+                expected_name = source.get('name') or source.get('stock_name', '')
+                assert public.get('name') == expected_name, (
+                    f'holdings.{leg}.{ticker}.name does not reconcile')
+                assert public.get('currency') == currency, (
+                    f'holdings.{leg}.{ticker}.currency must be {currency}')
+                assert public.get('is_active') is True, (
+                    f'holdings.{leg}.{ticker}.is_active must be true')
+                assert public.get('trades_count') == len(source.get('trades') or []), (
+                    f'holdings.{leg}.{ticker}.trades_count does not reconcile')
+                for public_field, (source_field, places) in holding_fields.items():
+                    source_value = source.get(source_field)
+                    expected = (source_value if places is None
+                                else round(source_value or 0, places))
+                    tolerance = 1e-9 if places is None else 0.5 * (10 ** -places)
+                    same_number(
+                        public.get(public_field), expected,
+                        f'holdings.{leg}.{ticker}.{public_field}', tolerance,
+                    )
 
         # Recompute the public concentration card from the public holding rows.
         positive = [row for row in public_rows if row.get('current_value', 0) > 0]

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -305,6 +305,52 @@ def test_dashboard_money_reconciliation_rejects_public_drift(
             dashboard, portfolio_path=ROOT / 'portfolio.json')
 
 
+def _book(payload, stamp):
+    payload['last_updated'] = stamp
+    return payload
+
+
+def test_intraday_dashboard_ahead_of_the_committed_book_is_not_a_failure(tmp_path):
+    """The intraday publishing model: every slot rebuilds the dashboard from the
+    live book, but portfolio.json is committed only at open/midday/close. The
+    committed dashboard is then legitimately a newer generation, and comparing
+    the two field by field reddened the gate on every tick of 2026-08-03."""
+    portfolio = json.loads((ROOT / 'portfolio.json').read_text())
+    source = write_json(
+        tmp_path / 'portfolio.json', _book(portfolio, '2026/08/03 09:30 HKT'))
+
+    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload['last_updated'] = '2026/08/03 12:00 HKT'
+    payload['totals']['hk']['value_hkd'] += 1688.0
+    dashboard = write_json(tmp_path / 'dashboard.json', payload)
+
+    validators.validate_dashboard(dashboard, portfolio_path=source)
+
+
+def test_dashboard_built_from_an_older_book_than_the_committed_one_fails(tmp_path):
+    portfolio = json.loads((ROOT / 'portfolio.json').read_text())
+    source = write_json(
+        tmp_path / 'portfolio.json', _book(portfolio, '2026/08/03 12:00 HKT'))
+
+    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload['last_updated'] = '2026/08/03 09:30 HKT'
+    dashboard = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match='older book than the committed'):
+        validators.validate_dashboard(dashboard, portfolio_path=source)
+
+
+def test_same_book_still_reconciles_field_by_field(tmp_path):
+    """The relaxation above must not reach inside a single generation."""
+    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload['totals']['hk']['value_hkd'] += 1688.0
+    dashboard = write_json(tmp_path / 'dashboard.json', payload)
+
+    with pytest.raises(AssertionError, match=r'totals\.hk\.value_hkd'):
+        validators.validate_dashboard(
+            dashboard, portfolio_path=ROOT / 'portfolio.json')
+
+
 def test_dashboard_money_reconciliation_rejects_source_integrity_failure(tmp_path):
     portfolio = json.loads((ROOT / 'portfolio.json').read_text())
     portfolio['portfolios']['us_stocks']['total_pnl'] += 100


### PR DESCRIPTION
Fixes #281.

## 问题

`Dashboard Artifact Gate` 在港股盘中**每个 tick 都红**（2026-08-03 02:00Z–04:00Z 连续 12 次）：

```
totals.hk.value_hkd=57263.6 does not reconcile to portfolio.json=55574.4
```

这不是数据错，是两个**刻意不同步**的提交节奏被拿来互相对账：

- `publish_dashboard.sh`（每 20 分钟）和 `intraday_postflight`（盘中每档）从 worktree 的实时账本重建 dashboard，但**只提交 `assets/data/*`**。「Mode 7 不提交 portfolio.json」是明写的设计决定（`intraday_postflight.py:33`），因为 postflight 提交时账本可能正在半写入（`_harness_common.py:310`）。价格提交归开盘/午盘/收盘的 updater。
- `_assert_dashboard_money_reconciles()` 却把已提交的 dashboard 和已提交的 portfolio 逐字段对账 —— 盘中这两者本来就不同代。

gate 和这条断言都是 08-01 加的，08-01/08-02 是周末，**08-03 是它上线后第一个港股交易日**，所以现在才炸。

## 改动

`dashboard.last_updated` 就是它构建时用的账本出处。用它分流：

- **同代** → 逐字段严格对账，一分不放松
- **不同代** → 逐字段对账不成立，改断言**方向**：dashboard 的账本不得旧于已提交的 portfolio。用比已提交账本还旧的数据发布是真 bug，仍然红

无条件继续跑：`preflight_integrity.check(portfolio)`、concentration 由公开行自 recompute、fx、`build_status.integrity`。账本时间戳解析失败判定为失败，避免跨代方向检查静默通过。

## 验证

拿**真实那次红的提交** `88654937`（04:00Z）跑修复后的校验器：

```
dashboard book: 2026/08/03 11:32 HKT | portfolio book: 2026/08/03 09:32 HKT
totals.hk.value_hkd: 57263.6
=> 通过
```

dashboard 账本比已提交 portfolio 新两小时，正是盘中发布模型。

## 变异验证

| 变异 | 变红的测试 | 期望 |
|---|---|---|
| 去掉分代闸（永远严格对账） | `intraday_dashboard_ahead...` + `built_from_an_older_book...` | ✅ |
| 去掉方向断言 | `built_from_an_older_book...` | ✅ |
| 闸开太大（永远跳过严格对账） | `same_book_still_reconciles_field_by_field` + 既有的 drift 测试 | ✅ |

121 passed。
