### PR TITLE
pages: bump configure-pages v6, upload-pages-artifact v5, deploy-pages v5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -81,7 +81,7 @@ jobs:
           --output-dir _pages
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./_pages
 
@@ -99,4 +99,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
把 dependabot #274 / #275 / #276 搬到 `claude/` 分支重开 —— 这是这个仓库唯一能合进去的路径。

## 为什么合成一个 PR

`upload-pages-artifact@v5` 把内部换成了 `upload-artifact@v7`，它产出的 artifact 只保证被对应大版本的 `deploy-pages` 读得懂。拆成三个 PR 会在 master 上留下**上传端和部署端不配对**的中间状态。

## 变更内容

| action | 版本 | 性质 |
|---|---|---|
| `actions/configure-pages` | v5 → v6 | node 24 运行时 + 依赖升级 |
| `actions/upload-pages-artifact` | v4 → v5 | 内部换 `upload-artifact@v7`，新增 `include-hidden-files` 输入 |
| `actions/deploy-pages` | v4 → v5 | node 24 运行时 + 依赖升级 |

三个 release notes 都没有改动本 workflow 用到的 input/output。

## 排查过的风险

**`upload-artifact@v7` 默认排除隐藏文件** —— 对本仓库不影响：`_config.yml` 已 exclude 掉 `.gitignore` / `.api_keys` / `.cache`，且 `prepare_pages_artifact.py` 是 allowlist 驱动的（`config/pages-public.json`），产物里没有 dotfile。

## 验证边界（重要）

`pull_request` 会触发本 workflow，所以 **`build` job 在这个 PR 上真跑**：`configure-pages@v6` + `jekyll-build-pages@v1` + `upload-pages-artifact@v5` 三步都能得到真实验证。

**但 `deploy` job 是 `github.event_name == 'push' && ref == master` 门控的，`deploy-pages@v5` 在合并前证不了。** 合并后要盯第一次 `Deploy GitHub Pages`，红了就回滚这一行。

#280 已经把契约测试从钉死主版本改成匹配 `@v<N>`，所以这次升级不会再撞上那条假红。
