### PR TITLE
money gates: a missing checker must refuse, not pass

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,8 +7,24 @@
 set -e
 WS="$(git rev-parse --show-toplevel)"
 
+# A missing checker used to `exit 0` here, which did two wrong things at once:
+# it read "the checker is absent" as "the checks passed", and because this sits
+# ABOVE the money gate it also took preflight_integrity down with it — two
+# independent gates disarmed by one unrelated file's absence. Verified: with
+# system_check.py removed and portfolio.json failing its arithmetic, the push
+# went through.
+#
+# A repo carrying portfolio.json is a ledger workspace, so a missing checker
+# there is a broken install, not a bootstrap. Say so and refuse. A repo without
+# the money file keeps the original permissive behaviour.
 if [ ! -f "$WS/scripts/system_check.py" ]; then
-  # No checker yet — let push through
+  if [ -f "$WS/portfolio.json" ]; then
+    echo "🚫 push blocked — scripts/system_check.py is missing from a workspace"
+    echo "   that carries portfolio.json. The book was not verified."
+    echo "   Override (rare): git push --no-verify"
+    exit 1
+  fi
+  # No money file and no checker — not a ledger workspace, let push through.
   exit 0
 fi
 

--- a/scripts/data/safe_push.sh
+++ b/scripts/data/safe_push.sh
@@ -79,7 +79,17 @@ else
   # Cannot tell what is new; assume the money file is in scope rather than skip.
   PORTFOLIO_TOUCHED="portfolio.json"
 fi
-if [ -n "$PORTFOLIO_TOUCHED" ] && [ -f "$INTEGRITY_SCRIPT" ]; then
+if [ -n "$PORTFOLIO_TOUCHED" ] && [ ! -f "$INTEGRITY_SCRIPT" ]; then
+  # `-f` used to be a precondition of running the gate, so a checker that was
+  # not where we looked read as "nothing to check" and the money file shipped
+  # unverified. It is an assertion now: the file is in this push and we cannot
+  # verify it, so we do not push it.
+  echo "✗ REFUSING TO PUSH — portfolio.json is in this push but the"
+  echo "  money-conservation checker is missing: $INTEGRITY_SCRIPT"
+  echo "  The book cannot be verified from here."
+  exit 4
+fi
+if [ -n "$PORTFOLIO_TOUCHED" ]; then
   echo "▸ portfolio.json is in this push — running money-conservation check…"
   if ! python3 "$INTEGRITY_SCRIPT"; then
     echo "✗ REFUSING TO PUSH — portfolio.json does not reconcile."

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -125,6 +125,67 @@ def test_every_workflow_that_stages_the_money_file_pushes_through_the_gate():
         f"safe_push.sh, so the money gate is not on their path: {offenders}")
 
 
+def _ledger_repo(tmp_path, *, with_portfolio=True):
+    def git(*args):
+        subprocess.run(["git", "-C", str(tmp_path), *args],
+                       check=True, capture_output=True, text=True)
+    git("init", "-q")
+    git("config", "user.name", "test")
+    git("config", "user.email", "test@example.com")
+    if with_portfolio:
+        (tmp_path / "portfolio.json").write_text("{}\n")
+    else:
+        (tmp_path / "README.md").write_text("no money here\n")
+    git("add", "-A")
+    git("commit", "-qm", "seed")
+    return tmp_path
+
+
+def test_pre_push_refuses_a_ledger_workspace_whose_checker_is_missing(tmp_path):
+    """A missing checker used to `exit 0` — reading "absent" as "passed", and
+    because that sits above the money gate it disarmed preflight_integrity too.
+    Verified before the fix: system_check.py removed + an unreconciled book
+    pushed clean."""
+    repo = _ledger_repo(tmp_path)
+    hook = repo / "pre-push"
+    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+
+    result = subprocess.run(["bash", str(hook)], cwd=repo, capture_output=True,
+                            text=True, input="")
+
+    assert result.returncode != 0, (
+        "a workspace carrying portfolio.json pushed with no checker installed")
+    assert "system_check.py is missing" in result.stdout
+
+
+def test_pre_push_still_allows_a_repo_that_carries_no_money_file(tmp_path):
+    """The fail-closed branch must not turn into a blanket block on any repo
+    without the checker — only a ledger workspace is a broken install."""
+    repo = _ledger_repo(tmp_path, with_portfolio=False)
+    hook = repo / "pre-push"
+    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+
+    result = subprocess.run(["bash", str(hook)], cwd=repo, capture_output=True,
+                            text=True, input="")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_safe_push_refuses_the_money_file_when_the_checker_is_missing(tmp_path):
+    """`-f` was a precondition of running the gate, so a checker that was not
+    where we looked read as "nothing to check" and the book shipped unverified."""
+    repo = _ledger_repo(tmp_path)
+    script = repo / "safe_push.sh"
+    script.write_text((ROOT / "scripts" / "data" / "safe_push.sh").read_text())
+
+    result = subprocess.run(["bash", str(script)], cwd=repo, capture_output=True,
+                            text=True, input="")
+
+    assert result.returncode == 4, (
+        f"expected the push refused, got rc={result.returncode}\n{result.stdout}")
+    assert "checker is missing" in result.stdout
+
+
 def test_safe_push_runs_the_money_check_when_the_money_file_moves():
     text = (ROOT / "scripts" / "data" / "safe_push.sh").read_text()
 


### PR DESCRIPTION
Fixes #284.

## 问题

两道钱闸都把「检查器脚本存在」当成**运行的前置条件**，于是脚本不在预期位置 = 「没什么要查的」，账本原样放行。

一次性仓库 + 一份账对不上的 `portfolio.json` 实测：

| 场景 | 修复前 |
|---|---|
| `scripts/system_check.py` 存在且报 CRITICAL | 拦截 ✅ |
| `scripts/system_check.py` **缺失**，账依然对不上 | **放行 ❌** |
| `safe_push.sh` 钱闸，checker 路径不存在 | **静默跳过 ❌** |

`.githooks/pre-push` 那个 `exit 0` 还在钱闸**上面**，所以一个不相干文件的缺失同时解除了两道独立的闸。

## 改动

**`.githooks/pre-push`** — 带 `portfolio.json` 的仓库是账本 workspace，检查器缺失是坏安装而不是 bootstrap，拦下并说明原因；不带钱文件的仓库保持原来的宽松路径。

**`scripts/data/safe_push.sh`** — `-f` 从前置条件改成断言：钱文件在这次推送里、而我们验不了它，那就不推。

**行为变化只发生在「检查器缺失」这一个分支**。检查器齐全的所有路径（live workspace、全部 CI）完全不变。

## 变异验证

| 变异 | 变红的测试 |
|---|---|
| pre-push 恢复成无条件 `exit 0` | `refuses_a_ledger_workspace_whose_checker_is_missing` |
| safe_push 恢复成 `-f` 前置条件 | `refuses_the_money_file_when_the_checker_is_missing` |
| pre-push 改成无条件拦截 | `still_allows_a_repo_that_carries_no_money_file` |

三条各自只打红一条，测试都是**跑真脚本看可观察行为**，不断言实现细节。1536 passed。

## 刻意不做的两件事

1. **#253 剩下的一半**（pre-push 跑完整 `system_check`，不相干的 CRITICAL 会挡住数据发布）是**放松**一道跑在钱系统上的闸。kcn 2026-08-03 明确表态：偏严的不动。#253 继续开着。
2. pre-push 里 `preflight_integrity.py` 缺失时，`python3` 返回 2，而 hook 把 2 当「有 ERROR」→ **已经是 fail-closed**，只是提示语会说成「账对不上」而非「检查器不在」。往活的钱闸里再加分支的风险大于这点提示准确度的收益。
