### PR TITLE
providers: move the cron-state chain into the adapter (#273)

### DIFF
--- a/clawock/providers/__init__.py
+++ b/clawock/providers/__init__.py
@@ -12,11 +12,16 @@ Remove OpenClaw and reports stop being delivered and every watchdog goes blind,
 before anything about prose generation matters.
 
 Both are already narrow, JSON-returning subprocess calls, and run history
-already has two independent implementations — `_watchdog_common.read_runs`
-(OpenClaw, with a cli → sqlite → fossil fallback chain) and
+already has two independent implementations — the OpenClaw cli → sqlite →
+fossil chain (now `openclaw.read_runs`, moved here from `_watchdog_common`) and
 `workflow_health.fetch_runs` (GitHub Actions, via `gh run list --json`). They
 simply had no common shape. This package is mostly collecting implementations
 that exist, not inventing abstractions.
+
+Where a capability physically lives decides whether it is a capability at all:
+while the OpenClaw chain sat in `scripts/harness/`, which the wheel does not
+ship, `OpenClawRuns` imported cleanly from an installation and raised the first
+time it was called (#273).
 """
 from __future__ import annotations
 

--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -173,9 +173,19 @@ def _sqlite_runs(job_id):
 def _fossil_runs(job_id):
     out = []
     for cand in (CRON_RUNS_DIR / f"{job_id}.jsonl", CRON_RUNS_DIR / f"{job_id}.jsonl.migrated"):
-        if not cand.exists():
-            continue
-        for line in cand.read_text().splitlines():
+        try:
+            if not cand.exists():
+                continue
+            text = cand.read_text()
+        except OSError:
+            # Unreadable is not the same as absent, and neither is a crash.
+            # `Path.exists()` swallows ENOENT but re-raises EACCES, so this
+            # blew up for any process that is not the user owning the runtime's
+            # home — which is every process outside the live host, i.e. exactly
+            # the installed-elsewhere case this provider is supposed to serve.
+            # None means "this layer cannot answer"; the chain ends at empty.
+            return None
+        for line in text.splitlines():
             line = line.strip()
             if not line:
                 continue

--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -1,22 +1,38 @@
-"""The one place that knows where the OpenClaw binary lives and how to call it.
+"""The one place that knows where the OpenClaw binary lives, how to call it, and
+where it keeps its cron state.
 
 Everything OpenClaw-specific belongs here so the rest of the tree can be counted
 as runtime-agnostic — see `tests/test_runtime_coupling_ratchet.py`, which exempts
 `clawock/providers/` precisely because that is what an adapter is for.
 
-Moved out of `scripts/harness/_watchdog_common.py`, which held the binary path
-and the cron CLI call and was therefore the largest single consumer that knew
-which runtime it was on.
+Moved out of `scripts/harness/_watchdog_common.py`, which held the binary path,
+the cron CLI call and the run-history fallback chain, and was therefore the
+largest single consumer that knew which runtime it was on. `_watchdog_common`
+lives in `scripts/harness/`, which is deliberately not in the wheel, so anything
+left there was unreachable from an installation — `OpenClawRuns.list_runs()`
+imported it at call time and raised `ModuleNotFoundError` outside the checkout.
 """
 from __future__ import annotations
 
 import json
+import sqlite3
 import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
 
 # pnpm's global bin. Kept as one constant rather than resolved through PATH: the
 # cron environment is not a login shell, and PATH resolution has bitten this
 # before.
 OPENCLAW_BIN = "/root/.local/share/pnpm/openclaw"
+
+# Where the runtime keeps its own state. 6.1 migrated cron out of the JSONL
+# files into SQLite; both are still read, newest first, because the fossil is
+# the only thing left when the gateway and the DB are both unreadable.
+OPENCLAW_HOME = Path("/root/.openclaw")
+CRON_RUNS_DIR = OPENCLAW_HOME / "cron" / "runs"
+CRON_JOBS_JSON = OPENCLAW_HOME / "cron" / "jobs.json"
+STATE_DB = OPENCLAW_HOME / "state" / "openclaw.sqlite"
 
 # `cron list --json` round-trips through the gateway and has been observed at
 # ~42s on a loaded host. A tight timeout trips TimeoutExpired, which callers
@@ -50,3 +66,178 @@ def cron_cli_json(cli_args, *, binary: str = OPENCLAW_BIN,
         return json.loads(text[start:])
     except Exception:
         return None
+
+
+# ── Cron state ───────────────────────────────────────────────────────────────
+# Moved verbatim from `_watchdog_common`, with one shape change: which source
+# answered is returned instead of being left in a module global. A watchdog that
+# reports a failure off the pre-6.1 fossil is reporting on stale payloads, so
+# that fact is part of the answer, not a side channel the caller has to
+# remember to consult.
+
+SOURCES = ("auto", "cli", "sqlite", "fossil")
+
+
+@dataclass(frozen=True)
+class CronRead:
+    """What the runtime's cron storage returned, and which layer answered.
+
+    `source` is one of:
+      'cli'    — live gateway (authoritative for payload/model/delivery)
+      'sqlite' — live read-only state DB (authoritative, gateway-independent)
+      'fossil' — pre-6.1 jobs.json[.migrated] (STALE for payload — schedule only)
+      'empty'  — nothing readable
+    """
+
+    entries: list
+    source: str
+
+
+def _open_state_db():
+    """Open the OpenClaw state DB read-only, including its live WAL."""
+    return sqlite3.connect(f"file:{STATE_DB}?mode=ro", uri=True, timeout=5)
+
+
+def _sqlite_store_key(conn):
+    row = conn.execute(
+        "SELECT store_key FROM cron_jobs "
+        "GROUP BY store_key ORDER BY MAX(updated_at) DESC LIMIT 1"
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _sqlite_jobs():
+    """Return live cron jobs from SQLite, or None when the DB/schema is unreadable."""
+    try:
+        with _open_state_db() as conn:
+            conn.execute("PRAGMA query_only = ON")
+            store_key = _sqlite_store_key(conn)
+            if store_key is None:
+                return []
+            rows = conn.execute(
+                "SELECT job_json, state_json FROM cron_jobs "
+                "WHERE store_key = ? ORDER BY sort_order, job_id",
+                (store_key,),
+            ).fetchall()
+        jobs = []
+        for raw_job, raw_state in rows:
+            job = json.loads(raw_job)
+            state = json.loads(raw_state or "{}")
+            if not isinstance(job, dict) or not isinstance(state, dict):
+                raise ValueError("cron SQLite row is not a JSON object")
+            # Runtime state is maintained separately from the declarative job
+            # JSON. Merge it so callers see the same current view as the CLI.
+            job["state"] = {**(job.get("state") or {}), **state}
+            jobs.append(job)
+        return jobs
+    except Exception:
+        return None
+
+
+def _fossil_jobs():
+    for path in (CRON_JOBS_JSON, CRON_JOBS_JSON.with_suffix(".json.migrated")):
+        try:
+            data = json.loads(path.read_text())
+            jobs = data if isinstance(data, list) else data.get("jobs", data.get("items", []))
+            if not isinstance(jobs, list):
+                continue
+            print(f"warn: live cron state unreadable; falling back to STALE {path.name} "
+                  "(pre-6.1 fossil — do not trust model/delivery/message)", file=sys.stderr)
+            return jobs
+        except Exception:
+            continue
+    return None
+
+
+def _sqlite_runs(job_id):
+    """Return one job's finished runs oldest→newest, or None if SQLite is unreadable."""
+    try:
+        with _open_state_db() as conn:
+            conn.execute("PRAGMA query_only = ON")
+            store_key = _sqlite_store_key(conn)
+            if store_key is None:
+                return []
+            rows = conn.execute(
+                "SELECT entry_json FROM cron_run_logs "
+                "WHERE store_key = ? AND job_id = ? ORDER BY ts, seq",
+                (store_key, job_id),
+            ).fetchall()
+        entries = [json.loads(row[0]) for row in rows]
+        if not all(isinstance(entry, dict) for entry in entries):
+            raise ValueError("cron run SQLite row is not a JSON object")
+        return [entry for entry in entries if entry.get("action") in (None, "finished")]
+    except Exception:
+        return None
+
+
+def _fossil_runs(job_id):
+    out = []
+    for cand in (CRON_RUNS_DIR / f"{job_id}.jsonl", CRON_RUNS_DIR / f"{job_id}.jsonl.migrated"):
+        if not cand.exists():
+            continue
+        for line in cand.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except Exception:
+                continue
+        return out
+    return None
+
+
+def read_jobs(source: str = "auto") -> CronRead:
+    """Cron jobs from auto|cli|sqlite|fossil.
+
+    Auto prefers the public CLI, then the same live SQLite state read-only. The
+    pre-6.1 JSON is retained only for watchdog compatibility and is explicitly
+    marked stale; contract/operator tools must reject it.
+    """
+    if source not in SOURCES:
+        raise ValueError(f"unsupported cron source: {source}")
+    if source in {"auto", "cli"}:
+        data = cron_cli_json(["list", "--json"])
+        if isinstance(data, dict) and isinstance(data.get("jobs"), list):
+            return CronRead(data["jobs"], "cli")
+        if source == "cli":
+            return CronRead([], "empty")
+    if source in {"auto", "sqlite"}:
+        jobs = _sqlite_jobs()
+        if jobs is not None:
+            return CronRead(jobs, "sqlite")
+        if source == "sqlite":
+            return CronRead([], "empty")
+    if source in {"auto", "fossil"}:
+        jobs = _fossil_jobs()
+        if jobs is not None:
+            return CronRead(jobs, "fossil")
+    return CronRead([], "empty")
+
+
+def read_runs(job_id: str, source: str = "auto") -> CronRead:
+    """Finished-run records for a job, OLDEST→NEWEST (so callers' [-1] = newest).
+    Auto uses CLI → read-only SQLite → migrated JSONL fossil."""
+    if source not in SOURCES:
+        raise ValueError(f"unsupported cron source: {source}")
+    if source in {"auto", "cli"}:
+        data = cron_cli_json(["runs", "--id", job_id])
+        if isinstance(data, dict) and isinstance(data.get("entries"), list):
+            finished = [e for e in data["entries"] if e.get("action") in (None, "finished")]
+            # CLI returns newest-first; reverse to match the old append-order contract.
+            return CronRead(list(reversed(finished)), "cli")
+        if source == "cli":
+            return CronRead([], "empty")
+    if source in {"auto", "sqlite"}:
+        entries = _sqlite_runs(job_id)
+        if entries is not None:
+            return CronRead(entries, "sqlite")
+        if source == "sqlite":
+            return CronRead([], "empty")
+    if source in {"auto", "fossil"}:
+        entries = _fossil_runs(job_id)
+        if entries is not None:
+            print(f"warn: live cron runs unreadable; using STALE migrated JSONL "
+                  f"for {job_id}", file=sys.stderr)
+            return CronRead(entries, "fossil")
+    return CronRead([], "empty")

--- a/clawock/providers/runs.py
+++ b/clawock/providers/runs.py
@@ -17,6 +17,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import Protocol
 
+from . import openclaw
+
 # Deliberately small and closed. `unknown` is a real answer — a run that is
 # recorded but whose outcome the source cannot state must not be silently
 # rounded to success.
@@ -55,7 +57,7 @@ class RunHistoryProvider(Protocol):
 
 
 class OpenClawRuns:
-    """Wraps `_watchdog_common.read_runs`, which keeps its own fallback chain."""
+    """Wraps the adapter's cron-state chain: CLI → read-only SQLite → fossil."""
 
     name = "openclaw"
 
@@ -65,8 +67,11 @@ class OpenClawRuns:
     def _read(self, job: str):
         if self._reader is not None:
             return self._reader(job)
-        import _watchdog_common  # resolved from the workspace's scripts/harness
-        return _watchdog_common.read_runs(job) or []
+        # Previously `import _watchdog_common`, which lives in scripts/harness
+        # and is not in the wheel: this class was importable but not callable
+        # from an installation, so "interchangeable providers" held only where
+        # the checkout happened to be on sys.path.
+        return openclaw.read_runs(job).entries
 
     def history(self, job: str, limit: int = 20) -> list[Run]:
         entries = list(self._read(job))[-limit:]

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -17,7 +17,6 @@ session transcript. transcript_loop_score detects that directly and cleanly
 (observed: looped run score≈7 on a 97KB assistant blob; clean run score≈2 on 3KB).
 """
 import json
-import sqlite3
 import subprocess
 import sys
 from collections import Counter
@@ -29,15 +28,15 @@ from workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 OC = Path('/root/.openclaw')
-RUNS_DIR = OC / 'cron' / 'runs'
-JOBS_JSON = OC / 'cron' / 'jobs.json'
-STATE_DB = OC / 'state' / 'openclaw.sqlite'
 SESSIONS_DIR = OC / 'agents' / 'main' / 'sessions'
 LOG = WS / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
-# The binary path and the cron CLI call moved into clawock/providers/openclaw.py
-# so this module stops being the largest consumer that knows which runtime it is
-# on. Re-exported: callers that import OPENCLAW_BIN from here keep working.
+# The binary path, the cron CLI call and the cron-state fallback chain moved
+# into clawock/providers/openclaw.py so this module stops being the largest
+# consumer that knows which runtime it is on — and so the chain is reachable
+# from an installation, which it was not while it lived in this file: the wheel
+# ships `clawock`, not `scripts/harness`. Re-exported: callers that import
+# OPENCLAW_BIN from here keep working.
 #
 # `clawock` is not installed on the live host, so the repository root has to be on
 # sys.path for this import to resolve. Say so here rather than inheriting it: the
@@ -47,6 +46,7 @@ HKT = timezone(timedelta(hours=8))
 # watchdog — the backstop that exists to notice a missing report goes missing
 # first, and the crontab entry only logs a traceback.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from clawock.providers import openclaw as _openclaw  # noqa: E402
 from clawock.providers.openclaw import OPENCLAW_BIN, cron_cli_json as _adapter_cron_json  # noqa: E402
 
 
@@ -120,95 +120,18 @@ LAST_LOAD_SOURCE = None
 LAST_RUNS_SOURCE = None
 
 
-def _open_state_db():
-    """Open the OpenClaw state DB read-only, including its live WAL."""
-    return sqlite3.connect(f'file:{STATE_DB}?mode=ro', uri=True, timeout=5)
-
-
-def _sqlite_store_key(conn):
-    row = conn.execute(
-        'SELECT store_key FROM cron_jobs '
-        'GROUP BY store_key ORDER BY MAX(updated_at) DESC LIMIT 1'
-    ).fetchone()
-    return row[0] if row else None
-
-
-def _sqlite_jobs():
-    """Return live cron jobs from SQLite, or None when the DB/schema is unreadable."""
-    try:
-        with _open_state_db() as conn:
-            conn.execute('PRAGMA query_only = ON')
-            store_key = _sqlite_store_key(conn)
-            if store_key is None:
-                return []
-            rows = conn.execute(
-                'SELECT job_json, state_json FROM cron_jobs '
-                'WHERE store_key = ? ORDER BY sort_order, job_id',
-                (store_key,),
-            ).fetchall()
-        jobs = []
-        for raw_job, raw_state in rows:
-            job = json.loads(raw_job)
-            state = json.loads(raw_state or '{}')
-            if not isinstance(job, dict) or not isinstance(state, dict):
-                raise ValueError('cron SQLite row is not a JSON object')
-            # Runtime state is maintained separately from the declarative job
-            # JSON. Merge it so callers see the same current view as the CLI.
-            job['state'] = {**(job.get('state') or {}), **state}
-            jobs.append(job)
-        return jobs
-    except Exception:
-        return None
-
-
-def _fossil_jobs():
-    for p in (JOBS_JSON, JOBS_JSON.with_suffix('.json.migrated')):
-        try:
-            data = json.loads(p.read_text())
-            jobs = data if isinstance(data, list) else data.get('jobs', data.get('items', []))
-            if not isinstance(jobs, list):
-                continue
-            print(f'warn: live cron state unreadable; falling back to STALE {p.name} '
-                  '(pre-6.1 fossil — do not trust model/delivery/message)', file=sys.stderr)
-            return jobs
-        except Exception:
-            continue
-    return None
-
-
 def load_jobs(source='auto'):
-    """Load cron jobs from auto|cli|sqlite|fossil.
+    """Cron jobs from auto|cli|sqlite|fossil, recording which source answered.
 
-    Auto prefers the public CLI, then the same live SQLite state read-only. The
-    pre-6.1 JSON is retained only for watchdog compatibility and is explicitly
-    marked stale; contract/operator tools must reject it.
+    The chain itself lives in `clawock.providers.openclaw` so it is reachable
+    from an installation. This wrapper exists for the module global: five
+    callers read `_watchdog_common.LAST_LOAD_SOURCE` after the call, and the
+    cron-contract check refuses to report failures off a fossil.
     """
     global LAST_LOAD_SOURCE
-    if source not in {'auto', 'cli', 'sqlite', 'fossil'}:
-        raise ValueError(f'unsupported cron source: {source}')
-    if source in {'auto', 'cli'}:
-        d = _cron_cli_json(['list', '--json'])
-        if isinstance(d, dict) and isinstance(d.get('jobs'), list):
-            LAST_LOAD_SOURCE = 'cli'
-            return d['jobs']
-        if source == 'cli':
-            LAST_LOAD_SOURCE = 'empty'
-            return []
-    if source in {'auto', 'sqlite'}:
-        jobs = _sqlite_jobs()
-        if jobs is not None:
-            LAST_LOAD_SOURCE = 'sqlite'
-            return jobs
-        if source == 'sqlite':
-            LAST_LOAD_SOURCE = 'empty'
-            return []
-    if source in {'auto', 'fossil'}:
-        jobs = _fossil_jobs()
-        if jobs is not None:
-            LAST_LOAD_SOURCE = 'fossil'
-            return jobs
-    LAST_LOAD_SOURCE = 'empty'
-    return []
+    read = _openclaw.read_jobs(source)
+    LAST_LOAD_SOURCE = read.source
+    return read.entries
 
 
 def find_job_id(job_name):
@@ -218,77 +141,16 @@ def find_job_id(job_name):
     return None
 
 
-def _sqlite_runs(job_id):
-    """Return one job's finished runs oldest→newest, or None if SQLite is unreadable."""
-    try:
-        with _open_state_db() as conn:
-            conn.execute('PRAGMA query_only = ON')
-            store_key = _sqlite_store_key(conn)
-            if store_key is None:
-                return []
-            rows = conn.execute(
-                'SELECT entry_json FROM cron_run_logs '
-                'WHERE store_key = ? AND job_id = ? ORDER BY ts, seq',
-                (store_key, job_id),
-            ).fetchall()
-        entries = [json.loads(row[0]) for row in rows]
-        if not all(isinstance(entry, dict) for entry in entries):
-            raise ValueError('cron run SQLite row is not a JSON object')
-        return [entry for entry in entries if entry.get('action') in (None, 'finished')]
-    except Exception:
-        return None
-
-
-def _fossil_runs(job_id):
-    out = []
-    for cand in (RUNS_DIR / f'{job_id}.jsonl', RUNS_DIR / f'{job_id}.jsonl.migrated'):
-        if not cand.exists():
-            continue
-        for line in cand.read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                out.append(json.loads(line))
-            except Exception:
-                continue
-        return out
-    return None
-
-
 def read_runs(job_id, source='auto'):
     """Finished-run records for a job, OLDEST→NEWEST (so callers' [-1] = newest).
-    Auto uses CLI → read-only SQLite → migrated JSONL fossil."""
+
+    Same shape as load_jobs: the CLI → SQLite → fossil chain lives in the
+    provider, this keeps LAST_RUNS_SOURCE for the callers that branch on it.
+    """
     global LAST_RUNS_SOURCE
-    if source not in {'auto', 'cli', 'sqlite', 'fossil'}:
-        raise ValueError(f'unsupported cron source: {source}')
-    if source in {'auto', 'cli'}:
-        d = _cron_cli_json(['runs', '--id', job_id])
-        if isinstance(d, dict) and isinstance(d.get('entries'), list):
-            finished = [e for e in d['entries'] if e.get('action') in (None, 'finished')]
-            LAST_RUNS_SOURCE = 'cli'
-            # CLI returns newest-first; reverse to match the old append-order contract.
-            return list(reversed(finished))
-        if source == 'cli':
-            LAST_RUNS_SOURCE = 'empty'
-            return []
-    if source in {'auto', 'sqlite'}:
-        entries = _sqlite_runs(job_id)
-        if entries is not None:
-            LAST_RUNS_SOURCE = 'sqlite'
-            return entries
-        if source == 'sqlite':
-            LAST_RUNS_SOURCE = 'empty'
-            return []
-    if source in {'auto', 'fossil'}:
-        entries = _fossil_runs(job_id)
-        if entries is not None:
-            LAST_RUNS_SOURCE = 'fossil'
-            print(f'warn: live cron runs unreadable; using STALE migrated JSONL '
-                  f'for {job_id}', file=sys.stderr)
-            return entries
-    LAST_RUNS_SOURCE = 'empty'
-    return []
+    read = _openclaw.read_runs(job_id, source)
+    LAST_RUNS_SOURCE = read.source
+    return read.entries
 
 
 def is_today_hkt(ts_ms):

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "harness"))
 
 import _watchdog_common as common  # noqa: E402
+from clawock.providers import openclaw as provider  # noqa: E402
 
 
 def _make_state_db(path):
@@ -61,9 +62,9 @@ def _make_state_db(path):
 def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
     db = tmp_path / "openclaw.sqlite"
     _make_state_db(db)
-    monkeypatch.setattr(common, "STATE_DB", db)
-    monkeypatch.setattr(common, "JOBS_JSON", tmp_path / "jobs.json")
-    monkeypatch.setattr(common, "_cron_cli_json", lambda _args: None)
+    monkeypatch.setattr(provider, "STATE_DB", db)
+    monkeypatch.setattr(provider, "CRON_JOBS_JSON", tmp_path / "jobs.json")
+    monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
     jobs = common.load_jobs()
 
@@ -76,10 +77,10 @@ def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
 def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
     db = tmp_path / "openclaw.sqlite"
     _make_state_db(db)
-    monkeypatch.setattr(common, "STATE_DB", db)
+    monkeypatch.setattr(provider, "STATE_DB", db)
     monkeypatch.setattr(
-        common,
-        "_cron_cli_json",
+        provider,
+        "cron_cli_json",
         lambda _args: (_ for _ in ()).throw(AssertionError("CLI must not run")),
     )
 
@@ -90,11 +91,11 @@ def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
 
 
 def test_fossil_source_is_marked_stale(tmp_path, monkeypatch):
-    monkeypatch.setattr(common, "STATE_DB", tmp_path / "missing.sqlite")
+    monkeypatch.setattr(provider, "STATE_DB", tmp_path / "missing.sqlite")
     jobs_json = tmp_path / "jobs.json"
     jobs_json.write_text(json.dumps([{"id": "old", "name": "stale"}]))
-    monkeypatch.setattr(common, "JOBS_JSON", jobs_json)
-    monkeypatch.setattr(common, "_cron_cli_json", lambda _args: None)
+    monkeypatch.setattr(provider, "CRON_JOBS_JSON", jobs_json)
+    monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
     assert common.load_jobs() == [{"id": "old", "name": "stale"}]
     assert common.LAST_LOAD_SOURCE == "fossil"

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -39,13 +39,13 @@ def _first_party_imports(path: Path) -> set[str]:
     return {name for name in names if name not in stdlib}
 
 
-# One escape is known and tracked, not tolerated: `OpenClawRuns.list_runs()`
-# lazily imports `_watchdog_common`, which lives in `scripts/harness/` and is not
-# in the wheel. The module still imports from an installation — the import is
-# inside the method — but calling it there raises. Pinned rather than hidden so a
-# *new* escape fails while this one stays visible until the read moves into the
-# package.
-KNOWN_ESCAPES = {"providers/runs.py": {"_watchdog_common"}}
+# Empty, and asserted empty rather than deleted: the one tracked escape was
+# `OpenClawRuns.list_runs()` lazily importing `_watchdog_common` from
+# `scripts/harness/`, which is not in the wheel — importable from an
+# installation, raising the first time it was called. The cron-state chain moved
+# into `clawock.providers.openclaw` (#273), so the set is empty and stays the
+# thing a new escape has to break.
+KNOWN_ESCAPES: dict[str, set[str]] = {}
 
 
 def test_nothing_the_package_imports_lives_outside_it():

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -53,8 +53,9 @@ RUNTIME = "openclaw"
 # This baseline is not comparable to the 8 the substring classifier reported:
 # that number counted six error strings and missed both cron writes. Nothing
 # regressed between the two — the earlier count was measuring the wrong thing,
-# so it is the first number here that is worth quoting.
-BASELINE = 14
+# so 14 was the first number here worth quoting. 14 → 13 when the cron-state
+# chain moved into the adapter (#273).
+BASELINE = 13
 
 _SPAWNERS = {"run", "call", "check_call", "check_output", "Popen", "system", "getoutput"}
 

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -99,4 +99,26 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
 
     assert done.returncode == 0, (
         "a module in the source tree is not importable from the built wheel — "
-        f"the shipped package is not the package:\n{done.stderr[-2000:]}")
+        "the shipped package is not the package:\n" + done.stderr[-2000:])
+
+    # Importable was never the claim. `OpenClawRuns` used to import
+    # `_watchdog_common` — which lives in scripts/harness and is not shipped —
+    # *inside* the method, so it imported cleanly from an installation and
+    # raised ModuleNotFoundError the first time anyone called it. The chain has
+    # no runtime to talk to here, so the answer is an empty history; that it
+    # answers at all is the point.
+    done = subprocess.run(
+        [sys.executable, "-c",
+         "from clawock.providers.runs import OpenClawRuns\n"
+         "runs = OpenClawRuns().history('any-job')\n"
+         "assert isinstance(runs, list), runs\n"
+         "print('ok')"],
+        cwd=tmp_path,
+        env={"PYTHONPATH": str(site), "PATH": "/usr/bin:/bin",
+             "LC_ALL": "C.UTF-8", "PYTHONIOENCODING": "utf-8"},
+        capture_output=True, text=True, timeout=120)
+
+    assert done.returncode == 0, (
+        "the run-history provider is importable from the wheel but not callable "
+        "there, so it is a provider only where the checkout happens to be:\n"
+        + done.stderr[-2000:])


### PR DESCRIPTION
Closes #273. **Stacked on #286** — base is `claude/coupling-classifier`, which
GitHub will retarget to `master` once that merges. Review the second commit.

## The defect

`OpenClawRuns.list_runs()` did `import _watchdog_common` inside the method.
That module lives in `scripts/harness/`, which the wheel deliberately does not
ship — so the class imported fine from an installation and raised
`ModuleNotFoundError` the first time it was called. Run history was an
"interchangeable capability provider" only where the checkout happened to be on
`sys.path`.

## The move

The CLI → read-only SQLite → pre-6.1 fossil chain goes verbatim into
`clawock/providers/openclaw.py`, next to the binary path and cron CLI call that
#264 already put there.

One shape change: **which source answered is returned** (`CronRead.source`)
rather than left in a module global. A watchdog reporting off the fossil is
reporting on stale payloads, so that fact belongs in the answer.
`_watchdog_common.load_jobs/read_runs` stay as wrappers that set
`LAST_LOAD_SOURCE` / `LAST_RUNS_SOURCE`, because five callers branch on those
after the call and the cron-contract check refuses to report failures off a
fossil. No behaviour change on the live path.

## Acceptance

- `OpenClawRuns().history()` is **called** from the non-editable install in
  `test_wheel_contains_the_package.py` — importable was never the claim.
  Mutation-verified: restoring `import _watchdog_common` makes it red with the
  exact `ModuleNotFoundError`.
- The fallback chain is unchanged and still proven per source by
  `test_cron_live_state.py`, now patching the provider — the chain's new home.
- `KNOWN_ESCAPES` in `test_package_surface.py` is empty and **asserted** empty,
  not deleted.
- Coupling ratchet 14 → 13 (the `openclaw.sqlite` read leaves
  `_watchdog_common`), baseline lowered in the same commit.

Full suite: 1538 passed, 4 xfailed.
