### PR TITLE
harness: report_watchdog 的投递证据要扛得住 cron 重试

### DIFF
--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -182,7 +182,7 @@ def claim_upgrade(market, phase, date):
 
 
 def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='delivered',
-                   context_id=None):
+                   context_id=None, context_generated_at=None):
     """Primary WeChat send for staged reports — fresh-token `openclaw message send`,
     decoupled from the cron's announce.
 
@@ -232,6 +232,16 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
             # starts with the title, so first_line no longer matches the context's
             # block and a string compare would mirror a duplicate to Telegram.
             'context_id': context_id,
+            # When the id alone can't decide, this dates the DATA we sent, not the
+            # send. `context_id` is strictly per-preflight-invocation, so an
+            # openclaw auto-retry (which re-runs preflight but is blocked from
+            # re-sending by the idempotency lock above) leaves the marker pointing
+            # at a generation the context file no longer holds — an id compare then
+            # reads a healthy delivery as "never delivered" (2026-08-03 hk-open +
+            # hk-pm, both double-sent a deterministic fallback). The watchdog needs
+            # to tell that two-minute regeneration apart from the genuinely stale
+            # body of 2026-07-24, and only the source context's own timestamp can.
+            'context_generated_at': context_generated_at,
             'market': market,
             'phase': phase,
             'out': (out or '')[-200:],
@@ -481,7 +491,8 @@ def main():
     else:
         wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
                                         delivery_state=delivery_state,
-                                        context_id=ctx.get('context_id'))
+                                        context_id=ctx.get('context_id'),
+                                        context_generated_at=ctx.get('generated_at'))
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
     data_plane_status = classify_data_plane(commit_ok, commit_msg)

--- a/scripts/harness/report_watchdog.py
+++ b/scripts/harness/report_watchdog.py
@@ -55,6 +55,8 @@ from _watchdog_common import (  # noqa: E402
 
 LOOP_THRESHOLD = 5                 # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
 MARKER_FRESH_MS = 120 * 60 * 1000  # postflight send-marker older than this ⇒ treat as not-this-slot
+REGEN_WINDOW_S = 30 * 60           # context rebuilt within this of the delivered one ⇒ same slot
+REGEN_BACKWARD_S = 60              # tolerance for a context timestamped just before the marker's
 
 
 def deterministic_fallback(raw_block, tag, reason):
@@ -64,7 +66,34 @@ def deterministic_fallback(raw_block, tag, reason):
             + raw_block.strip())
 
 
-def slot_delivered(marker, ctx_id, raw_block_first, now_ms):
+def _same_generation_window(marker, ctx_generated_at):
+    """Was the delivered report built from THIS slot's data, a regeneration apart?
+
+    `context_id` is a per-preflight-invocation hash, so an openclaw auto-retry
+    (re-runs preflight, then hits postflight's idempotency lock and deliberately
+    does NOT rewrite the marker) guarantees the two ids differ — the one case the
+    id compare exists to survive. Both 2026-08-03 HK false backstops were exactly
+    that: delivered at 13:31 from a 13:30 context, watchdog at 13:42 reading the
+    retry's 13:32:59 context.
+
+    Comparing the source contexts' own timestamps separates that from the failure
+    the id compare was added for (2026-07-24 美股收盘报告 delivered 07/22 numbers):
+    a retry regenerates minutes later, a genuinely stale body is hours or days
+    behind. The window is asymmetric — a retry's context is always the NEWER one,
+    so only a small backward tolerance is allowed for clock/write ordering.
+    """
+    marker_at = marker.get('context_generated_at')
+    if not marker_at or not ctx_generated_at:
+        return False
+    try:
+        delta = (datetime.fromisoformat(ctx_generated_at)
+                 - datetime.fromisoformat(marker_at)).total_seconds()
+    except (TypeError, ValueError):
+        return False
+    return -REGEN_BACKWARD_S <= delta <= REGEN_WINDOW_S
+
+
+def slot_delivered(marker, ctx_id, raw_block_first, now_ms, ctx_generated_at=None):
     """Did report_postflight confirmably deliver THIS slot's report to Telegram?
 
     Doubles as the generation gate: in prose mode the model's final answer is a
@@ -73,22 +102,35 @@ def slot_delivered(marker, ctx_id, raw_block_first, now_ms):
     every healthy run — firing a deterministic fallback that duplicates a report
     kcn already has.
 
-    Slot identity prefers `context_id` (exact, written by prose mode). Prose-mode
-    bodies start with the TITLE, so the legacy first-line compare would report a
-    false mismatch; it is kept only for markers written before that field existed.
+    Slot identity prefers `context_id` (exact, written by prose mode), then the
+    regeneration window when the ids differ because the cron retried, then — only
+    for markers predating both fields — the legacy first-line compare. Prose-mode
+    bodies start with the TITLE, so that legacy compare reports a false mismatch
+    on every healthy prose run and cannot be the primary judge.
+
+    Returns (delivered, judge) — the judge names which rule decided, so the log
+    can show why no backstop fired instead of leaving that to a second,
+    drift-prone recomputation at the call site.
     """
     if not marker or not marker.get('tg_ok'):
-        return False
+        return False, 'no-marker'
     # An exact context_id match is proof this slot was delivered regardless of age:
     # both ids are per market+phase+date, so a delayed watchdog must NOT re-mirror a
     # confirmed delivery just because the marker is >2h old (2026-07-24 review). The
     # freshness window only guards the fuzzy legacy first-line compare, where a
     # matching first line could otherwise belong to an earlier day's report.
     if marker.get('context_id') and ctx_id:
-        return marker['context_id'] == ctx_id
+        if marker['context_id'] == ctx_id:
+            return True, 'context_id'
+        # Ids differ. That is the normal shape of a cron retry, not of a miss —
+        # see _same_generation_window. Markers written before that field existed
+        # fall through to the legacy compare below rather than to a false miss.
+        if marker.get('context_generated_at'):
+            return _same_generation_window(marker, ctx_generated_at), 'regenerated-context'
     if now_ms - (marker.get('ts') or 0) >= MARKER_FRESH_MS:
-        return False
-    return (marker.get('first_line') or '').strip() == (raw_block_first or '').strip()
+        return False, 'marker-stale'
+    same_line = (marker.get('first_line') or '').strip() == (raw_block_first or '').strip()
+    return same_line, 'legacy-first-line'
 
 
 def main():
@@ -126,24 +168,20 @@ def main():
     # The clean report block's first line comes from the preflight context. If the
     # context is missing, preflight never ran → nothing to resend.
     ctx_path = WS / 'memory' / '.tmp' / f'report-context-{args.market}-{args.phase}-{today}.json'
-    raw_block = ''
-    raw_block_first = None
-    if ctx_path.exists():
-        try:
-            raw_block = (json.loads(ctx_path.read_text()).get('raw_wechat_block') or '').strip()
-            raw_block_first = raw_block.splitlines()[0] if raw_block else None
-        except Exception:
-            pass
+    # One read, one generation: a cron retry rewrites this file mid-flight, so
+    # re-reading it per field could mix two generations' block and id.
+    ctx = {}
+    try:
+        ctx = json.loads(ctx_path.read_text())
+    except Exception:
+        ctx = {}
+    raw_block = (ctx.get('raw_wechat_block') or '').strip()
+    raw_block_first = raw_block.splitlines()[0] if raw_block else None
     if not raw_block_first:
         log({'tag': tag, 'action': 'skip', 'reason': 'no preflight raw_wechat_block (cron likely never ran)'})
         return 0
 
-    ctx_id = None
-    if ctx_path.exists():
-        try:
-            ctx_id = json.loads(ctx_path.read_text()).get('context_id')
-        except Exception:
-            pass
+    ctx_id = ctx.get('context_id')
 
     marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
     marker = None
@@ -153,7 +191,9 @@ def main():
         except Exception:
             marker = None
     now_ms = int(datetime.now(HKT).timestamp() * 1000)
-    delivered_this_slot = slot_delivered(marker, ctx_id, raw_block_first, now_ms)
+    delivered_this_slot, delivery_judge = slot_delivered(
+        marker, ctx_id, raw_block_first, now_ms,
+        ctx_generated_at=ctx.get('generated_at'))
 
     # --- Generation gate ------------------------------------------------------
     # In prose mode the model's final answer is a postflight status line, not the
@@ -163,6 +203,9 @@ def main():
     if delivered_this_slot:
         log({'tag': tag, 'action': 'ok',
              'reason': 'postflight cosend already delivered Telegram this slot — no backstop',
+             # Which rule accepted it. `regenerated-context` recurring here means
+             # the cron keeps retrying — visible instead of inferred.
+             'match': delivery_judge,
              'run_at': run_at})
         return 0
 

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -458,15 +458,20 @@ def _marker(**over):
     return m
 
 
+def _delivered(wd, *args, **kwargs):
+    """slot_delivered returns (verdict, judge); these tests assert the verdict."""
+    return wd.slot_delivered(*args, **kwargs)[0]
+
+
 def test_watchdog_accepts_a_prose_slot_by_context_id(wd):
     """Prose bodies start with the TITLE, so the old first-line compare would call
     a healthy run a mismatch and mirror a duplicate to Telegram."""
-    assert wd.slot_delivered(_marker(), 'abc123def456',
+    assert _delivered(wd, _marker(), 'abc123def456',
                              '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
 
 
 def test_watchdog_still_backstops_a_different_generation(wd):
-    assert wd.slot_delivered(_marker(context_id='OTHERGEN'), 'abc123def456',
+    assert _delivered(wd, _marker(context_id='OTHERGEN'), 'abc123def456',
                              '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is False
 
 
@@ -475,23 +480,23 @@ def test_watchdog_context_id_match_ignores_the_age_window(wd):
     exact match is proof of THIS slot regardless of marker age. A delayed watchdog
     must not re-mirror a confirmed delivery just because the marker is >2h old."""
     old = 1_000_000 + wd.MARKER_FRESH_MS + 1
-    assert wd.slot_delivered(_marker(), 'abc123def456', 'x', old) is True
+    assert _delivered(wd, _marker(), 'abc123def456', 'x', old) is True
 
 
 def test_watchdog_falls_back_to_first_line_for_legacy_markers(wd):
     legacy = _marker(first_line='🇺🇸 美股盯盘 | 07/23 16:00 ET')
     legacy.pop('context_id')
-    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
-    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/22 16:02 ET', 1_000_100) is False
+    assert _delivered(wd, legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', 1_000_100) is True
+    assert _delivered(wd, legacy, None, '🇺🇸 美股盯盘 | 07/22 16:02 ET', 1_000_100) is False
     # freshness still gates the FUZZY legacy path — an old first-line match could
     # belong to an earlier day
     old = 1_000_000 + wd.MARKER_FRESH_MS
-    assert wd.slot_delivered(legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', old) is False
+    assert _delivered(wd, legacy, None, '🇺🇸 美股盯盘 | 07/23 16:00 ET', old) is False
 
 
 def test_watchdog_ignores_an_undelivered_marker(wd):
-    assert wd.slot_delivered(_marker(tg_ok=False), 'abc123def456', 'x', 1_000_100) is False
-    assert wd.slot_delivered(None, 'abc123def456', 'x', 1_000_100) is False
+    assert _delivered(wd, _marker(tg_ok=False), 'abc123def456', 'x', 1_000_100) is False
+    assert _delivered(wd, None, 'abc123def456', 'x', 1_000_100) is False
 
 
 # ── watchdog must not duplicate a healthy prose run ────────────────────────
@@ -509,9 +514,9 @@ def test_watchdog_identifies_the_slot_by_context_id_not_first_line(wd):
     marker = {'ts': now - 60_000, 'tg_ok': True, 'context_id': 'abc123def456',
               'first_line': '🌙 美股收盘日报｜2026-07-24'}
 
-    assert wd.slot_delivered(marker, 'abc123def456', FRESH_BLOCK.splitlines()[0], now)
+    assert _delivered(wd, marker, 'abc123def456', FRESH_BLOCK.splitlines()[0], now)
     # a marker from a different generation is NOT this slot's
-    assert not wd.slot_delivered(marker, 'NEWGENERATION', FRESH_BLOCK.splitlines()[0], now)
+    assert not _delivered(wd, marker, 'NEWGENERATION', FRESH_BLOCK.splitlines()[0], now)
 
 
 def test_watchdog_falls_back_to_the_legacy_first_line_when_no_context_id(wd):
@@ -519,10 +524,10 @@ def test_watchdog_falls_back_to_the_legacy_first_line_when_no_context_id(wd):
     first = FRESH_BLOCK.splitlines()[0]
     legacy = {'ts': now - 60_000, 'tg_ok': True, 'first_line': first}
 
-    assert wd.slot_delivered(legacy, None, first, now)
-    assert not wd.slot_delivered({**legacy, 'first_line': 'something else'}, None, first, now)
-    assert not wd.slot_delivered({**legacy, 'tg_ok': False}, None, first, now)
-    assert not wd.slot_delivered({**legacy, 'ts': 0}, None, first, now)
+    assert _delivered(wd, legacy, None, first, now)
+    assert not _delivered(wd, {**legacy, 'first_line': 'something else'}, None, first, now)
+    assert not _delivered(wd, {**legacy, 'tg_ok': False}, None, first, now)
+    assert not _delivered(wd, {**legacy, 'ts': 0}, None, first, now)
 
 
 @pytest.fixture

--- a/tests/test_report_watchdog_retry_parity.py
+++ b/tests/test_report_watchdog_retry_parity.py
@@ -1,0 +1,104 @@
+"""report_watchdog delivery evidence must survive an openclaw cron retry.
+
+2026-08-03: 港股开盘报告 and 港股午后快报 each errored only in post-turn summary
+generation (MiniMax response-header timeout), openclaw auto-retried, the retry's
+preflight rewrote the context file with a fresh per-invocation `context_id`, and
+its postflight correctly declined to re-send. The watchdog then compared the
+marker's id against the retry's id, read "never delivered", and pushed kcn a
+duplicate deterministic fallback for a report already sitting in his Telegram.
+
+The opposite failure must stay caught: 2026-07-24 delivered 07/22 numbers behind
+a fresh-looking marker and no backstop ever fired. Both invariants are pinned
+here — a fix for either one that breaks the other fails this file.
+"""
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
+
+SENT_AT = datetime(2026, 8, 3, 13, 31, 24)
+NOW_MS = int(datetime(2026, 8, 3, 13, 42).timestamp() * 1000)
+TITLE = '🌤 港股午后快报｜2026-08-03 13:30'
+BLOCK_FIRST = '🇭🇰 港股盯盘 | 08/03 13:30 HKT'
+
+
+def _marker(context_id, generated_at, **extra):
+    return {
+        'ts': int(SENT_AT.timestamp() * 1000),
+        'tg_ok': True,
+        'first_line': TITLE,
+        'context_id': context_id,
+        'context_generated_at': generated_at.isoformat(),
+        **extra,
+    }
+
+
+def test_retry_regenerated_context_still_counts_as_delivered():
+    import report_watchdog as watchdog
+
+    # The retry's preflight rebuilt the context 2m35s after the delivered one.
+    marker = _marker('af4310c68bbf', datetime(2026, 8, 3, 13, 30, 24))
+    retry_ctx_at = datetime(2026, 8, 3, 13, 32, 59)
+
+    delivered, judge = watchdog.slot_delivered(
+        marker, 'e3d82a1c096e', BLOCK_FIRST, NOW_MS,
+        ctx_generated_at=retry_ctx_at.isoformat())
+
+    assert delivered is True
+    assert judge == 'regenerated-context'
+
+
+def test_stale_body_behind_a_fresh_marker_still_gets_a_backstop():
+    import report_watchdog as watchdog
+
+    # 2026-07-24 shape: the marker was written today, but the report it sent was
+    # built from a context two days old. That must remain a miss.
+    marker = _marker('af4310c68bbf', SENT_AT - timedelta(days=2))
+
+    delivered, judge = watchdog.slot_delivered(
+        marker, 'e3d82a1c096e', BLOCK_FIRST, NOW_MS,
+        ctx_generated_at=SENT_AT.isoformat())
+
+    assert delivered is False
+    assert judge == 'regenerated-context'
+
+
+def test_context_older_than_the_delivered_one_is_not_a_retry():
+    import report_watchdog as watchdog
+
+    # A retry always regenerates FORWARD. A context materially older than the
+    # delivered generation means the watchdog is reading someone else's file,
+    # not a retry, so the delivery is not proven for what is on disk now.
+    marker = _marker('af4310c68bbf', SENT_AT)
+
+    delivered, _ = watchdog.slot_delivered(
+        marker, 'e3d82a1c096e', BLOCK_FIRST, NOW_MS,
+        ctx_generated_at=(SENT_AT - timedelta(minutes=20)).isoformat())
+
+    assert delivered is False
+
+
+def test_postflight_records_the_source_context_timestamp(tmp_path, monkeypatch):
+    """Without this field on the marker the window above can never engage."""
+    import report_postflight as postflight
+
+    monkeypatch.setattr(postflight, 'TMP', tmp_path)
+    monkeypatch.setattr(postflight, 'resolve_wechat_target',
+                        lambda market: ('wechat', 'kcn', 'acct'))
+    monkeypatch.setattr(postflight, 'send_wechat',
+                        lambda *a, **kw: (True, 'sent'))
+    monkeypatch.setattr(postflight, 'cosend_telegram',
+                        lambda *a, **kw: (True, 'sent'))
+
+    postflight.deliver_wechat('hk', 'pm', '2026-08-03', '', f'{TITLE}\nbody',
+                              context_id='af4310c68bbf',
+                              context_generated_at='2026-08-03T13:30:24.100000')
+
+    marker = json.loads((tmp_path / 'report-sent-hk-pm-2026-08-03.json').read_text())
+    assert marker['context_generated_at'] == '2026-08-03T13:30:24.100000'
+    assert marker['context_id'] == 'af4310c68bbf'


### PR DESCRIPTION
Fixes #288.

## 问题

2026-08-03 港股 hk-open / hk-pm 两档各收到一份重复的 🧯 确定性兜底，而两份报告都已经正常投递（09:31:50 / 13:31:24，marker `tg_ok:true`）。

链条（hk-pm）：run1 13:30 发出报告 → 13:32:09 只在 turn 结束后的 summary 生成上报错（`FallbackSummaryError: MiniMax response-header timeout after 30000ms`）→ openclaw 13:32:39 自动重试 → 重试的 preflight 13:32:59 覆写 context，`context_id` 从 `af4310c6` 变成 `e3d82a1c` → 重试的 postflight 撞上幂等锁、正确地不重发，**marker 因此仍指向 `af4310c6`** → 13:42 watchdog 精确比对两个 id，判「未投递」，加上散文模式 transcript 里没有数据块（`block_present:false`），发出兜底。

`context_id` 是 per-preflight-invocation 的哈希，所以**只要发生重试就必然错开**——而重试正是这个判据唯一需要正确处理的场景。当天只跑一次 run 的 hk-mid 判 `ok`，未误发；盘中盯盘同日重试 5 次也没假红，因为 `intraday_watchdog` 用 `(job, slot)` 做身份，跨重试稳定。

## 改动

- `report_postflight.deliver_wechat()` 在 marker 里记 `context_generated_at`（源 context 自己的 `generated_at`），即「投出去那份数据的年龄」，区别于 `ts`（发送时刻）。
- `report_watchdog.slot_delivered()` 判据顺序：`context_id` 精确相等 → 重试再生成窗口（当前 context 比已投递那代新，且在 30 分钟内，向后只留 60s 时钟容差）→ 旧 marker 的 legacy first-line 比较。
- `slot_delivered` 改为返回 `(verdict, judge)`，日志里记 `match` 字段，说明是哪条规则放行的；`regenerated-context` 反复出现就意味着 cron 在反复重试，可见而非靠推断。
- watchdog 对 context 文件改为一次读取：重试会在飞行中覆写它，逐字段重读可能把两代的 block 和 id 混在一起。

## 为什么不是简单放宽成「只看 tg_ok」

`context_id` 精确匹配是 2026-07-24 引入的，用来抓「正文基于陈旧 context 构建」（美股收盘报告发出 07/22 的数字，却没有任何兜底）。两个失败形状的区别是数据年龄：重试相差两三分钟，真 stale 相差小时/天。所以判据换成比源 context 的时间，而不是删掉。

## 测试（全部做过变异验证）

`tests/test_report_watchdog_retry_parity.py` 4 条，各自钉住一个变异：

| 用例 | 钉住的变异 |
|---|---|
| 重试再生成（相差 2m35s）仍判已投递 | 退回纯 `context_id` 精确匹配 → 红 |
| 陈旧正文（相差 2 天）仍然兜底 | 窗口放宽到 3 天 → 红 |
| context 比已投递那代更旧不算重试 | 窗口改成对称 `abs()` → 红 |
| postflight 确实写入 `context_generated_at` | 删掉该字段 → 红 |

`tests/test_report_assembly.py` 既有 14 处调用改为解包 verdict（tuple 恒 truthy，会让 `assert not` 静默失效）；改造后仍有效：把 legacy 路径改成恒真，4 条既有用例变红。

本地全量 1540 passed / 4 xfailed。
