### PR TITLE
workspace: the money CLIs stop naming the operator's ledger absolutely (#290)

### DIFF
--- a/scripts/data/recompute_realized.py
+++ b/scripts/data/recompute_realized.py
@@ -21,12 +21,21 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from safe_io import safe_write_json
+from workspace import workspace_root
 
-PORTFOLIO_PATH = '/root/.openclaw/workspace/portfolio.json'
+# The ledger of whichever workspace this file sits in — the same resolution the
+# other 42 modules use. It was the live absolute path, which made
+# `python3 recompute_realized.py` in a worktree rewrite the operator's real
+# portfolio.json: the library callers pass their own dict, so the constant only
+# ever served the command line, and the command line was pointed at production
+# no matter where it ran from. On the live host this resolves to the same file.
+PORTFOLIO_PATH = os.path.join(workspace_root(Path(__file__).resolve().parents[2]),
+                              'portfolio.json')
 
 
 def _aggregate(holdings: List[Dict]) -> Tuple[float, str, List[Dict]]:

--- a/scripts/data/snapshot_realized.py
+++ b/scripts/data/snapshot_realized.py
@@ -24,7 +24,10 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-PORTFOLIO_PATH = '/root/.openclaw/workspace/portfolio.json'
+# There was a `PORTFOLIO_PATH` here naming the live ledger absolutely. Nothing
+# in this module read it, and both importers (`build_dashboard`, the legacy
+# backfill) take only the two pure functions below, so it is deleted rather
+# than re-pointed: an unused constant naming production is a loaded gun.
 
 
 def _ledger_sells(holdings):

--- a/scripts/legacy/backfill_snapshot_realized.py
+++ b/scripts/legacy/backfill_snapshot_realized.py
@@ -16,12 +16,24 @@ import json
 import os
 import re
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# `safe_io`, `snapshot_realized` and `workspace` all live in scripts/data. This
+# inserted *this* directory instead, so the module has not been importable on
+# its own since it was moved into scripts/legacy — `python3 -c "import
+# backfill_snapshot_realized"` raises ModuleNotFoundError on the first line
+# below. It only ever ran when something else had already put scripts/data on
+# the path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'data'))
 from safe_io import safe_write_json
 from snapshot_realized import realized_as_of, snapshot_shares
+from workspace import workspace_root
 
-WS = '/root/.openclaw/workspace'
+# The workspace this file sits in, not the operator's. As an absolute live path
+# it made `--portfolio` default to the real ledger *and* pointed SNAP_DIR at the
+# real memory/snapshots/, so a backfill run from a review checkout rewrote
+# production snapshots in place.
+WS = str(workspace_root(Path(__file__).resolve().parents[2]))
 SNAP_DIR = os.path.join(WS, 'memory', 'snapshots')
 DATE_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})')
 

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -54,8 +54,9 @@ RUNTIME = "openclaw"
 # that number counted six error strings and missed both cron writes. Nothing
 # regressed between the two — the earlier count was measuring the wrong thing,
 # so 14 was the first number here worth quoting. 14 → 13 when the cron-state
-# chain moved into the adapter (#273).
-BASELINE = 13
+# chain moved into the adapter (#273); 13 → 10 when the two money CLIs and the
+# legacy backfill stopped naming the runtime's workspace absolutely (#290).
+BASELINE = 10
 
 _SPAWNERS = {"run", "call", "check_call", "check_output", "Popen", "system", "getoutput"}
 

--- a/tests/test_workspace_portability.py
+++ b/tests/test_workspace_portability.py
@@ -103,6 +103,36 @@ def test_the_default_workspace_is_unchanged_when_the_override_is_unset(monkeypat
     assert workspace.workspace_root(ROOT) == Path("/tmp").resolve()
 
 
+def test_the_money_clis_target_the_checkout_they_are_in(monkeypatch):
+    """`python3 recompute_realized.py` from a worktree rewrote the live ledger.
+
+    Its `--path` default was `/root/.openclaw/workspace/portfolio.json`, so the
+    command line pointed at production wherever it ran; the library callers
+    were never affected because they pass their own dict. The legacy backfill
+    was worse — the same absolute root also aimed `SNAP_DIR` at the real
+    `memory/snapshots/`, which it rewrites in place.
+    """
+    probe = (
+        "import sys; sys.path[:0] = [%r, %r];"
+        "import recompute_realized as rr, snapshot_realized as sr,"
+        " backfill_snapshot_realized as bf;"
+        "print(rr.PORTFOLIO_PATH); print(bf.SNAP_DIR);"
+        "print(hasattr(sr, 'PORTFOLIO_PATH'))"
+    ) % (str(ROOT / "scripts" / "data"), str(ROOT / "scripts" / "legacy"))
+    env = {k: v for k, v in os.environ.items() if k != workspace.ENV_VAR}
+
+    done = subprocess.run([sys.executable, "-c", probe], cwd=str(ROOT), env=env,
+                          capture_output=True, text=True, timeout=60)
+
+    assert done.returncode == 0, done.stderr
+    ledger, snapshots, dead_constant = done.stdout.split()
+    assert Path(ledger) == ROOT / "portfolio.json"
+    assert Path(snapshots) == ROOT / "memory" / "snapshots"
+    assert dead_constant == "False", (
+        "snapshot_realized's unused PORTFOLIO_PATH named production and had no "
+        "reader; re-adding one is re-adding a loaded gun")
+
+
 def test_the_entry_point_imports_without_the_scripts_directory(tmp_path):
     """The defect this file failed to catch once already.
 


### PR DESCRIPTION
Closes #290.

## The defect

`recompute_realized.py` and `backfill_snapshot_realized.py` are CLIs whose
default target was an absolute path into one operator's home:

```python
PORTFOLIO_PATH = '/root/.openclaw/workspace/portfolio.json'   # --path default
WS = '/root/.openclaw/workspace'                              # --portfolio default + SNAP_DIR
```

So `python3 recompute_realized.py` in a review worktree rewrites the **live**
ledger, and the legacy backfill rewrites the **live** `memory/snapshots/`, in
place. The library callers were never exposed — `analyze_hk_stocks` and
`fetch_us_stocks` call `recompute(data)` with a dict and do their own
`mutate_json` on their own resolved path — which is exactly why this survived:
the only pointed-at-production path is the one a human types.

`snapshot_realized.PORTFOLIO_PATH` was the same string with **no reader at
all**; both importers take only the two pure functions. Deleted rather than
re-pointed.

## The change

The same resolution the other 42 modules use:

```python
PORTFOLIO_PATH = os.path.join(workspace_root(Path(__file__).resolve().parents[2]),
                              'portfolio.json')
```

On the live host that file sits at `/root/.openclaw/workspace/scripts/data/`,
so `parents[2]` is `/root/.openclaw/workspace` and the resolved value is the
same string as before. No cron path, no live behaviour, changes.

One thing came out with it: `backfill_snapshot_realized` inserted **its own**
directory on `sys.path` while importing three modules that live in
`scripts/data`, so it has not been importable on its own since it moved into
`scripts/legacy` — it only ran when something else had already put that
directory on the path. Fixed in the same commit because the new import would
otherwise fail at the same line the existing two already did.

## Verification

- New test in `test_workspace_portability.py` runs all three modules in a
  subprocess and asserts the resolved ledger and snapshot directory are inside
  *this* checkout, and that the dead constant stays dead. Mutation-verified:
  restoring the absolute path turns it red, restoring the fix turns it green.
- Coupling ratchet **13 → 10**, baseline lowered in the same commit. The three
  removed sites were counted as "reads another runtime's private files", which
  is what they were.
- `gc_sessions.py` keeps its `OPENCLAW_HOME` deliberately: it garbage-collects
  the runtime's own session files. That is runtime housekeeping and it belongs
  with the runtime — if it moves, it moves behind `clawock/providers/`.
