### PR TITLE
ledger: the follow-through rate has to show what it never verified (#294)

### DIFF
--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -2461,7 +2461,14 @@
       const passiveNote = pas.rate != null
         ? ` · 不用动的 hold ${Math.round(pas.rate * 100)}% 是坐着没动自动算听了`
         : "";
-      setSub("plan-followed-sub", `${act.followed}/${act.known} 条要动手的${passiveNote}`);
+      // Rows whose verification window closed without an answer never resolve —
+      // the ticker is in no holdings list, which is what a plan on a spot ticker
+      // held through a 2x ETF looks like. They are out of the denominator above,
+      // so the count has to be visible or the rate is quietly censored. Same
+      // shape as the win-rate card's 「另有 N 条判不了」 note.
+      const stranded = (act.stranded || 0) + (pas.stranded || 0);
+      const strandedNote = stranded ? ` · 另有 ${stranded} 条永远验不了（不在分母）` : "";
+      setSub("plan-followed-sub", `${act.followed}/${act.known} 条要动手的${passiveNote}${strandedNote}`);
       setClass("plan-followed", "neutral");
     }
 

--- a/scripts/data/decision_v2.py
+++ b/scripts/data/decision_v2.py
@@ -70,6 +70,21 @@ PASSIVE_ACTIONS = {"hold_and_watch", "watch"}
 ADD_ACTIONS = ACTIVE_ACTIONS - SELL_ACTIONS
 AUDIT_SCHEMA_VERSION = 1
 
+# How long after plan_date an execution verdict is allowed to still be pending.
+# Sitting still is verifiable the next day; acting gets a working day to reach
+# the book. Same reason as PASSIVE_ACTIONS above: this used to live inline in
+# `brief_preflight._detect_followed`, and _exec_rate needs the identical rule to
+# tell "not verifiable yet" from "will never be verified". Two copies of a rule
+# nobody looks at drift, and the drift is invisible — the first measurement for
+# #294 read `bucket` instead of `action`, got the wrong window for every passive
+# row, and produced a plausible answer that was wrong by 6 points.
+SAME_DAY_STANCES = {"hold_and_watch", "watch", "t_only"}
+
+
+def verification_window_days(action: str | None) -> int:
+    """Days after plan_date before an unresolved execution is permanent."""
+    return 1 if (action or "").lower() in SAME_DAY_STANCES else 2
+
 # Confidence is calibrated prospectively over strategy episodes, never by fitting
 # and scoring the same row. Sparse leaves borrow pseudo-observations from their
 # parent rather than pretending a 1/1 subgroup is a stable 100% signal.
@@ -1261,23 +1276,54 @@ def _cumulative_win_rate_curve(rows: list[dict], benefit_key: str) -> list[dict]
     return curve
 
 
-def _exec_rate(rows: list[dict]) -> dict:
+def _exec_rate(rows: list[dict], today: date | None = None) -> dict:
     """Follow-through over rows whose execution is actually known.
 
-    ``unknown`` means unverified, not ignored — marking is partly manual
-    (``mark_followed.py``), so an unknown row is a gap in the record rather than
-    evidence of a miss, and it stays out of the denominator. That censoring does
-    not manufacture the result: every unknown row is from the last three days,
-    and counting them all as misses moves the active rate 2.65% -> 2.26%.
-    ``known`` is emitted so the coverage is visible next to the rate.
+    ``unknown`` stays out of the denominator, but it is two different things
+    wearing one label, and only one of them is temporary:
+
+    * ``pending`` — the verification window has not closed, so the next
+      preflight can still resolve it. A genuine gap in the record.
+    * ``stranded`` — the window closed days ago and ``_detect_followed`` returns
+      ``unknown`` on every retry. It never resolves. `_shares_at_date` answers
+      ``None`` when the ticker is in no ``holdings`` list, which is what a plan
+      naming a spot ticker held through a 2x ETF looks like (PLTR/MSFT vs
+      PLTU/MSFU, #162). Those rows are **not a random sample**: a plan that was
+      never acted on is exactly the kind whose ticker never enters the book, so
+      dropping them biases the rate upward.
+
+    This docstring used to assert that "every unknown row is from the last three
+    days". On 2026-08-04 that was false — 37 of 42 unknown rows were stranded,
+    the oldest from 2026-07-13, and on the passive leg *nothing* was pending:
+    98.8% was computed on 83 of 97 rows, against a floor of 84.5%. The claim had
+    silently expired, which is why the counts are emitted instead of argued.
+
+    Emitting both is the whole fix. The rate is unchanged and no verdict moves;
+    what changes is that the censoring is now a number a reader can see.
     """
+    today = today or date.today()
     c = Counter((r.get("execution") or {}).get("status", "unknown") for r in rows)
     known = c["followed"] + c["not_followed"]
+    pending = 0
+    for row in rows:
+        if (row.get("execution") or {}).get("status", "unknown") != "unknown":
+            continue
+        try:
+            planned = date.fromisoformat(row.get("plan_date") or "")
+        except ValueError:
+            # No usable plan_date, so the window cannot be said to be open.
+            # Counting it as pending would let an unparseable row hide forever
+            # in the bucket that means "wait and it will resolve".
+            continue
+        if planned + timedelta(days=verification_window_days(row.get("action"))) > today:
+            pending += 1
     return {
         "n": len(rows),
         "followed": c["followed"],
         "not_followed": c["not_followed"],
         "unknown": c["unknown"],
+        "pending": pending,
+        "stranded": c["unknown"] - pending,
         "known": known,
         "rate": round(c["followed"] / known, 4) if known else None,
     }

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -645,7 +645,7 @@ def _detect_followed(row, min_window_days=None):
       add_only_on_trigger / add_on_breakout → shares should INCREASE
       hold_and_watch / watch / t_only → shares should be UNCHANGED
 
-    min_window_days defaults to bucket-specific:
+    min_window_days defaults to `decision_v2.verification_window_days`:
       hold_and_watch / watch / t_only → T+1 (held by next day = followed)
       cut / trim / add → T+2 (give user a working day to actually trade)
     """
@@ -656,7 +656,10 @@ def _detect_followed(row, min_window_days=None):
         return 'unknown'
 
     if min_window_days is None:
-        min_window_days = 1 if bucket in ('hold_and_watch', 'watch', 't_only') else 2
+        # One definition, in decision_v2: _exec_rate needs the identical rule to
+        # separate "not verifiable yet" from "never will be", and a second copy
+        # here would drift without anything failing.
+        min_window_days = decision_v2.verification_window_days(bucket)
 
     # Day BEFORE plan_date (last commit before plan was created)
     try:

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -1,6 +1,7 @@
 import copy
 import sys
 import unittest
+from datetime import date, timedelta
 from pathlib import Path
 from unittest import mock
 
@@ -653,6 +654,55 @@ class HierarchicalCalibrationTest(unittest.TestCase):
             dv2.missing_regime_warnings([row]),
             ["regime missing/unknown for T1/core_position"],
         )
+
+
+class ExecutionCoverageTests(unittest.TestCase):
+    """An unknown that will never resolve is censoring, not a pending gap."""
+
+    def _unknown(self, days_ago, action):
+        row = decision((date.today() - timedelta(days=days_ago)).isoformat(), action=action)
+        row["execution"] = {"status": "unknown", "detected_at": None, "source": None}
+        return row
+
+    def test_an_unknown_past_its_window_is_stranded_and_the_window_is_per_action(self):
+        # A cut gets T+2 and a hold gets T+1, so one day back separates them:
+        # the hold can never resolve again, the cut still can.
+        rows = [self._unknown(1, "cut"), self._unknown(1, "hold_and_watch")]
+        dv2.assign_episode_ids(rows)
+
+        by_kind = dv2.compute_metrics(rows, window_days=365)["execution_by_kind"]
+
+        self.assertEqual((by_kind["active"]["pending"], by_kind["active"]["stranded"]), (1, 0))
+        self.assertEqual((by_kind["passive"]["pending"], by_kind["passive"]["stranded"]), (0, 1))
+        for leg in by_kind.values():
+            self.assertEqual(leg["unknown"], leg["pending"] + leg["stranded"])
+
+    def test_an_unusable_plan_date_cannot_hide_in_pending(self):
+        """`pending` means "wait and it resolves". A row with no readable date
+        never will, so it must not sit in the bucket that promises it might.
+        Exercised on `_exec_rate` directly: such a row cannot reach the ledger,
+        and the surrounding metrics parse plan_date for their own reasons."""
+        row = self._unknown(30, "cut")
+        row["plan_date"] = "not-a-date"
+
+        self.assertEqual(dv2._exec_rate([row])["pending"], 0)
+        self.assertEqual(dv2._exec_rate([row])["stranded"], 1)
+
+    def test_the_verification_window_has_a_single_definition(self):
+        """`_detect_followed` must read the rule, not keep its own copy.
+
+        Two copies drift silently — the first measurement for #294 read the
+        wrong field, got the wrong window for every passive row and produced a
+        plausible answer that was off by six points.
+        """
+        import brief_preflight
+
+        row = {"plan_date": (date.today() - timedelta(days=10)).isoformat(),
+               "ticker": "AAA", "bucket": "cut"}
+        with mock.patch.object(brief_preflight, "_shares_at_date", return_value=5):
+            self.assertEqual(brief_preflight._detect_followed(row), "false")
+            with mock.patch.object(dv2, "verification_window_days", return_value=3650):
+                self.assertEqual(brief_preflight._detect_followed(row), "unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #294.

## What was wrong

`_exec_rate` kept `unknown` rows out of the follow-through denominator and
justified it in its own docstring: *"every unknown row is from the last three
days, and counting them all as misses moves the active rate 2.65% -> 2.26%"*.

Measured on the live ledger today (566 decisions, 30-day window):

| leg | known | published rate | pending | **stranded** | floor if stranded were misses |
|---|---|---|---|---|---|
| active | 118 | 2.54% | 5 | **23** | 2.13% |
| passive | 83 | **98.8%** | **0** | **14** | **84.5%** |

37 of the 42 unknown rows will never resolve — `_shares_at_date` returns `None`
for a ticker that is in no `holdings` list, which is what a plan on a spot
ticker held through a 2x ETF looks like (PLTR/MSFT vs PLTU/MSFU, #162). They are
not a random sample: a plan that was never acted on is exactly the kind whose
ticker never enters the book, so dropping them biases the rate upward. On the
passive leg *nothing* is pending — every unknown there is permanent, and the
oldest is 2026-07-13, not "the last three days".

This is not a re-open of "absent means 0 shares" (#162, closed, still wrong).
No verdict moves and no rate changes. What changes is that the censoring is a
number you can see.

## The change

- `_exec_rate` emits `pending` and `stranded`. `unknown` stays and still equals
  their sum, so no consumer breaks.
- The T+1/T+2 rule gets **one** home, `decision_v2.verification_window_days`.
  `brief_preflight._detect_followed` now reads it instead of keeping its own
  copy. This is not tidiness: the first measurement for #294 read `bucket` —
  a plan-row field absent from all 566 ledger rows — gave every passive row the
  T+2 window and produced a plausible answer that was off by six points. A rule
  in two places drifts, and the drift looks like an answer.
- The follow-through card shows `另有 N 条永远验不了（不在分母）` when N > 0,
  the same shape the win-rate card already uses for its unresolved episodes.
- The docstring now records what was measured instead of a claim that expired.

## Verification

Three tests, each mutation-verified against exactly one mutation:

| mutation | killed by |
|---|---|
| window rule flattened to T+2 for every action | the per-action pending/stranded split |
| unparseable `plan_date` counted as pending | the "cannot hide in pending" test |
| `_detect_followed` restored to its inline copy of the rule | the single-definition test |

`unknown == pending + stranded` is asserted, so the new fields cannot drift
away from the one they decompose.
