### PR TITLE
tests: the payload-size suite stops rewriting the published artifacts (#296)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+"""Session-level guarantees that belong to no single test module.
+
+Right now there is one: the suite must not leave the publish-owned dashboard
+artifacts rewritten.
+
+`test_dashboard_payload_size.test_rebuild_is_idempotent_and_keeps_the_trim`
+runs the real `build_dashboard.py` against the real tree, which is deliberate —
+`test_validate_sidecars` then reconciles that fresh payload against
+`portfolio.json`, and at any given commit the *tracked* dashboard.json is
+older than the tracked portfolio.json (the publisher commits them on different
+cadences), so a rebuild is what makes the money check meaningful. The rebuild
+is load-bearing; only its residue is the problem.
+
+The residue is not cosmetic. #295 was pushed carrying four regenerated
+artifacts because the suite had been run and `git add -A` swept them up; the
+stale copies collided with the 20-minute publisher and GitHub marked the PR
+DIRTY. A conflict caught that one. A generated file that happened to be
+*newer* than master's would have merged silently and published a payload
+nobody built on purpose. In `/root/.openclaw/workspace` the same rebuild
+rewrites the live artifacts outside the publish lock.
+
+So: snapshot before, restore after, and verify the restore actually worked.
+Restoring to the session's starting bytes rather than to HEAD keeps a
+developer's own uncommitted edits intact.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git_status(paths):
+    """Porcelain status for `paths`, or None where git cannot answer."""
+    try:
+        done = subprocess.run(["git", "status", "--porcelain", "--", *paths],
+                              cwd=ROOT, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return done.stdout if done.returncode == 0 else None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def publish_owned_artifacts_are_left_as_found():
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    from dashboard_outputs import DASHBOARD_OUTPUTS
+
+    before = {path: (ROOT / path).read_bytes() for path in DASHBOARD_OUTPUTS
+              if (ROOT / path).exists()}
+    status_before = _git_status(DASHBOARD_OUTPUTS)
+
+    yield
+
+    for path, blob in before.items():
+        (ROOT / path).write_bytes(blob)
+
+    status_after = _git_status(DASHBOARD_OUTPUTS)
+    if status_before is not None:
+        assert status_after == status_before, (
+            "the suite changed the publish-owned artifacts and the restore did "
+            "not put them back; a later `git add -A` would carry them into a "
+            f"code PR:\n{status_after}")


### PR DESCRIPTION
Closes #296.

## The defect

`test_rebuild_is_idempotent_and_keeps_the_trim` runs the real builder against
the real tree and leaves its output there:

```
$ git status --short          # clean
$ python3 -m pytest tests/test_dashboard_payload_size.py -q
14 passed
$ git status --short
 M assets/data/dashboard.json
 M assets/data/decision_audit.json
 M assets/data/overview.json
 M assets/data/shadow_portfolio.json
```

Those four paths are exactly `dashboard_outputs.DASHBOARD_OUTPUTS`, the
publish-owned set. **PR #295 was pushed carrying them**, because the suite had
been run and `git add -A` swept them up; GitHub marked it `DIRTY` where the
stale copies met the 20-minute publisher's newer ones. A conflict caught that
one. A generated file that happened to be *newer* than master's would have
merged quietly and published a payload nobody built on purpose. In
`/root/.openclaw/workspace` the same test rewrites the live artifacts outside
the publish lock.

## The rebuild is load-bearing — only its residue is the problem

The first attempt restored the artifacts inside the payload-size module, and CI
went red in `test_validate_sidecars`: four money-reconciliation tests read the
tracked `dashboard.json` and reconcile it against the tracked `portfolio.json`.
At any given commit those two disagree — the publisher commits them on
different cadences, and at this HEAD it is `concentration.us.total=2358.43`
against `portfolio.json=2237.17`. The suite passes because the payload-size
module rebuilds the dashboard first, alphabetically before
`test_validate_sidecars` runs.

That dependency is real and undeclared, and it is not this PR's job to
re-architect it. What this PR must not do is break it.

## The change

One session-scoped autouse fixture in a new `tests/conftest.py`: snapshot the
publish-owned artifacts at session start, restore them at session end, then
verify the restore worked. Nothing about the run changes — the rebuild still
happens where it always did, and every test still sees the payload it expects.
Only the residue is gone.

Two details that matter:

- It restores to the **session's starting bytes**, not to `HEAD`, so a
  developer's own uncommitted edits to those files survive their test run.
- The verification compares `git status --porcelain` before and after rather
  than asserting "empty", for the same reason, and degrades to no assertion
  where git cannot answer.

The paths come from `DASHBOARD_OUTPUTS`, so a fifth artifact is covered the day
it is added.

## Verification

- After `pytest tests/test_dashboard_payload_size.py`, `git status` is clean.
- Mutation-verified: dropping the restore turns the session teardown into an
  error naming the four files; putting it back leaves the tree clean and the
  suite green.
