### PR TITLE
ledger: the first-paint card and the brief carry the coverage too (#299)

### DIFF
--- a/assets/js/dashboard.hero.js
+++ b/assets/js/dashboard.hero.js
@@ -266,7 +266,13 @@
       followed.className = "overview-discipline-value neutral";
     }
     if (followedMeta) {
-      followedMeta.textContent = activeExec.known == null ? "known sample —" : `known n=${activeExec.known}`;
+      // The denominator and what it drops, together. `stranded` rows are calls
+      // whose verification window closed without an answer and never resolves,
+      // so a bare `known n=` overstates how much of the record this rate covers.
+      const stranded = activeExec.stranded;
+      followedMeta.textContent = activeExec.known == null
+        ? "known sample —"
+        : `known n=${activeExec.known}` + (stranded ? ` · ${stranded} unverifiable` : "");
     }
     if (brier) {
       brier.textContent = metrics.brier == null ? DASH : metrics.brier.toFixed(3);

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -81,8 +81,12 @@ def compile_overview_projection(dashboard):
                       ('win_rate', 'cluster_ci95'))
         for name in ('catalyst', 'technical', 'macro', 'peer')
     }
+    # `stranded` travels with `rate`: it is how many rows the denominator drops
+    # and never gets back (#294). Shipping the rate without it is what the
+    # detail card was already fixed for; the Hero is the copy people see first.
     execution = _fields(
-        (metrics.get('execution_by_kind') or {}).get('active'), ('rate', 'known'))
+        (metrics.get('execution_by_kind') or {}).get('active'),
+        ('rate', 'known', 'stranded'))
     active_calibration = _fields(
         (metrics.get('calibration') or {}).get('active'), ('baseline_loo', 'n'))
     compact_recent = [

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -518,7 +518,7 @@ calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条�
 - 主动决策：n=N，平均 benefit=X%，date-cluster CI=[L,U]
 - 信心校准：嘴上平均 {mean_confidence}，实际胜率 {base_rate}；Brier {brier} vs 闭眼总报 {base_rate} 的 {brier_baseline_loo}
 - 按 strategy / action / driven_by 点出最强与最弱各一项
-- 执行状态：**要动手的** {execution_by_kind.active.rate}（{followed}/{known}）与 **不用动的** {execution_by_kind.passive.rate} 分开写；执行率不等于建议质量
+- 执行状态：**要动手的** {execution_by_kind.active.rate}（{followed}/{known}）与 **不用动的** {execution_by_kind.passive.rate} 分开写；执行率不等于建议质量。两条腿各自的 `{stranded}` **必须同句写出来**（「另有 N 条永远验不了，不在分母」）——那是窗口早已关闭、`_detect_followed` 每次重试都答 unknown 的行，标的从没进过 holdings，被丢掉的样本偏向「没执行」，所以裸报的执行率系统性偏高
 ```
 
 规则：

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -5,6 +5,7 @@ Two historical regressions had crept in: the leverage dial shipped twice in one
 document, and 27KB of calibrator posterior state shipped with no consumer at all.
 """
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -55,6 +56,37 @@ def test_overview_projection_keeps_canonical_money_health_and_generation_parity(
     for field in ("generated_at", "fx", "totals", "build_status"):
         assert overview[field] == full[field]
     assert len(OVERVIEW.read_bytes()) < 80_000
+
+
+def test_the_overview_projection_ships_every_execution_field_the_hero_renders():
+    """The Hero is the first-paint copy of a number the projection trims.
+
+    `compile_overview_projection` deliberately keeps overview.json small, so the
+    execution leg is a hand-listed field tuple. When `stranded` was added to the
+    metric (#294) the detail card picked it up automatically and the Hero could
+    not — it renders whatever `overview.json` happens to carry, which was
+    `rate` and `known` only, i.e. the rate without the count of rows dropped
+    from its denominator.
+
+    Asserted against the projection function rather than the committed
+    artifact, so it holds on the PR that changes the trim and not one publish
+    later.
+    """
+    sys.path.insert(0, str(ROOT / "scripts" / "data"))
+    import build_dashboard
+
+    full = json.loads(DASHBOARD.read_text())
+    projected = build_dashboard.compile_overview_projection(full)
+    shipped = ((projected.get("decision_metrics") or {})
+               .get("execution_by_kind") or {}).get("active") or {}
+    hero = (ROOT / "assets" / "js" / "dashboard.hero.js").read_text()
+    rendered = set(re.findall(r"activeExec\.(\w+)", hero))
+
+    assert rendered, "the Hero stopped reading the execution leg; update this test"
+    missing = sorted(rendered - set(shipped))
+    assert not missing, (
+        f"the Hero renders {missing} but the overview projection does not ship "
+        "them; it would silently show a rate with less context than the detail card")
 
 
 def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces():


### PR DESCRIPTION
Closes #299. Finishes what #294 started.

## What was still bare

#294 put the stranded count on the detail card. The two surfaces that reach
more readers kept publishing the rate without it:

- **Hero / first paint.** `compile_overview_projection` hand-lists the fields
  it keeps, so `overview.json` carried `{"rate": 0.0254, "known": 118}` and
  `dashboard.hero.js` rendered `known n=118` — the denominator, with no sign
  that 23 rows were dropped from it and never come back.
- **The 08:00 brief.** `daily-deep-brief/SKILL.md` asked for
  `{rate}（{followed}/{known}）`. The brief computes its metrics in-process, so
  `stranded` was already in the dict it reads; the template just never asked.

## The change

- `stranded` travels with `rate` in the overview projection (one integer).
- The Hero meta reads `known n=118 · 23 unverifiable` when the count is
  non-zero, and is unchanged when it is zero.
- The brief template now requires both legs' stranded count **in the same
  sentence** as the rate, with the reason: those rows are biased toward
  "not executed", so a bare rate reads high.

## Verification

- New contract test derives what the Hero reads (`activeExec.<field>` in
  `dashboard.hero.js`) and asserts the projection ships all of it. It runs
  `compile_overview_projection` on the tracked payload rather than reading
  `overview.json`, so it is true on this PR rather than one publish later.
- Mutation-verified: dropping `stranded` from the trim fails the test naming
  the missing field. The reverse mutation (Hero stops reading it) correctly
  does **not** fail it — the test is about the projection not dropping what the
  Hero asks for, and a test that also failed there would be pinning the copy,
  not the contract.
- 15 passed, payload cap unaffected.
