### PR TITLE
tests: declare the dashboard rebuild instead of relying on file order

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,28 @@
 """Session-level guarantees that belong to no single test module.
 
-Right now there is one: the suite must not leave the publish-owned dashboard
-artifacts rewritten.
+There are two, and both exist because a test module must not depend on which
+other module happened to run first.
 
-`test_dashboard_payload_size.test_rebuild_is_idempotent_and_keeps_the_trim`
-runs the real `build_dashboard.py` against the real tree, which is deliberate —
-`test_validate_sidecars` then reconciles that fresh payload against
-`portfolio.json`, and at any given commit the *tracked* dashboard.json is
-older than the tracked portfolio.json (the publisher commits them on different
-cadences), so a rebuild is what makes the money check meaningful. The rebuild
-is load-bearing; only its residue is the problem.
+**The rebuild.** The money-reconciliation tests compare the dashboard payload
+against `portfolio.json`, and at any given commit the *tracked* dashboard.json
+may be older than the tracked portfolio.json (the publisher commits them on
+different cadences), so a rebuild is what makes the money check meaningful. The
+rebuild used to live inside `test_dashboard_payload_size`, and
+`test_validate_sidecars` reconciled whatever that module had left behind —
+correct only because `test_dashboard_...` sorts before `test_validate_...`.
+Nothing stated it, so running the money gate on its own was not a valid
+invocation, and any rename, split-by-file or shuffled ordering would have
+reported "money does not reconcile" for what was really an ordering accident.
+It is a session fixture now: requested by name, built once, at most one
+subprocess per session either way. The rebuild is load-bearing; only its
+residue is the problem.
+
+**The import path.** `scripts/data` modules import their siblings by bare name
+(`from workspace import workspace_root`), so that directory has to be on
+`sys.path` before collection imports anything. Roughly twenty test modules
+insert it at import time, which made a single-module run work or fail on
+alphabetical luck: `pytest tests/test_validate_sidecars.py` alone died in
+collection. Doing it here covers every module and every invocation.
 
 The residue is not cosmetic. #295 was pushed carrying four regenerated
 artifacts because the suite had been run and `git add -A` swept them up; the
@@ -30,6 +43,12 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "assets" / "data" / "dashboard.json"
+
+# Import time, not fixture time: collection imports the test modules, which
+# import `scripts.data.validate_sidecars`, which imports `workspace` by bare
+# name. See the module docstring.
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
 
 
 def _git_status(paths):
@@ -44,7 +63,6 @@ def _git_status(paths):
 
 @pytest.fixture(scope="session", autouse=True)
 def publish_owned_artifacts_are_left_as_found():
-    sys.path.insert(0, str(ROOT / "scripts" / "data"))
     from dashboard_outputs import DASHBOARD_OUTPUTS
 
     before = {path: (ROOT / path).read_bytes() for path in DASHBOARD_OUTPUTS
@@ -62,3 +80,22 @@ def publish_owned_artifacts_are_left_as_found():
             "the suite changed the publish-owned artifacts and the restore did "
             "not put them back; a later `git add -A` would carry them into a "
             f"code PR:\n{status_after}")
+
+
+@pytest.fixture(scope="session")
+def freshly_built_dashboard(publish_owned_artifacts_are_left_as_found):
+    """The real builder run once, against the real tree, before anything reads
+    the payload it produces.
+
+    Depends on the restore guard by name so the snapshot is always taken before
+    the first byte is rewritten — the ordering that keeps the rebuild's residue
+    out of a code PR.
+
+    Returns the path rather than the parsed payload: the callers that matter
+    read it as bytes (the size cap) as well as as JSON, and taking the path
+    from the fixture is what makes each of them state the dependency instead of
+    reaching for a module constant that may or may not be fresh.
+    """
+    subprocess.run([sys.executable, "scripts/data/build_dashboard.py"],
+                   cwd=ROOT, check=True, capture_output=True)
+    return DASHBOARD

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -6,7 +6,6 @@ document, and 27KB of calibrator posterior state shipped with no consumer at all
 """
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -28,8 +27,8 @@ RENDERERS = ("dashboard.render.js", "dashboard.charts.js")
 
 
 @pytest.fixture(scope="module")
-def payload():
-    return json.loads(DASHBOARD.read_text())
+def payload(freshly_built_dashboard):
+    return json.loads(freshly_built_dashboard.read_text())
 
 
 def _size(obj):
@@ -41,13 +40,14 @@ def _published_size():
     return len(DASHBOARD.read_bytes())
 
 
-def test_payload_stays_under_the_published_cap():
+def test_payload_stays_under_the_published_cap(freshly_built_dashboard):
     size = _published_size()
     assert size < SIZE_CAP, f"{size:,} bytes; trim or move detail to a sidecar"
 
 
-def test_overview_projection_keeps_canonical_money_health_and_generation_parity():
-    full = json.loads(DASHBOARD.read_text())
+def test_overview_projection_keeps_canonical_money_health_and_generation_parity(
+        freshly_built_dashboard):
+    full = json.loads(freshly_built_dashboard.read_text())
     overview = json.loads(OVERVIEW.read_text())
 
     assert overview["schema_version"] == 1
@@ -58,7 +58,8 @@ def test_overview_projection_keeps_canonical_money_health_and_generation_parity(
     assert len(OVERVIEW.read_bytes()) < 80_000
 
 
-def test_the_overview_projection_ships_every_execution_field_the_hero_renders():
+def test_the_overview_projection_ships_every_execution_field_the_hero_renders(
+        freshly_built_dashboard):
     """The Hero is the first-paint copy of a number the projection trims.
 
     `compile_overview_projection` deliberately keeps overview.json small, so the
@@ -75,7 +76,7 @@ def test_the_overview_projection_ships_every_execution_field_the_hero_renders():
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
     import build_dashboard
 
-    full = json.loads(DASHBOARD.read_text())
+    full = json.loads(freshly_built_dashboard.read_text())
     projected = build_dashboard.compile_overview_projection(full)
     shipped = ((projected.get("decision_metrics") or {})
                .get("execution_by_kind") or {}).get("active") or {}
@@ -89,7 +90,8 @@ def test_the_overview_projection_ships_every_execution_field_the_hero_renders():
         "them; it would silently show a rate with less context than the detail card")
 
 
-def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces():
+def test_the_cap_is_measured_in_the_same_unit_the_builder_enforces(
+        freshly_built_dashboard):
     """Three gates, one unit. The drift here was silent for a reason: on an
     ASCII payload the two units agree exactly, so nothing catches it until the
     content is non-ASCII — which this payload has always been."""
@@ -268,10 +270,12 @@ def test_what_the_charts_actually_read_is_still_present(payload):
     assert payload["lev_regime"]["us"]["names"]
 
 
-def test_rebuild_is_idempotent_and_keeps_the_trim():
-    subprocess.run([sys.executable, "scripts/data/build_dashboard.py"],
-                   cwd=ROOT, check=True, capture_output=True)
-    rebuilt = json.loads(DASHBOARD.read_text())
+def test_the_trim_survives_a_real_rebuild(freshly_built_dashboard):
+    """The builder is run by the `freshly_built_dashboard` session fixture, not
+    here: the money-reconciliation gate in `test_validate_sidecars` reads the
+    same artifact and used to depend on this test having run first, which only
+    held because `test_dashboard_...` sorts before `test_validate_...` (#298)."""
+    rebuilt = json.loads(freshly_built_dashboard.read_text())
     assert "regime_history" not in rebuilt["lev_regime"]
     assert "current_group_calibrators" not in rebuilt["decision_metrics"]["hierarchical_calibration"]
     assert all("stages" not in r for r in rebuilt["workflow_outcomes"]["recent"])

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -277,9 +277,9 @@ def test_real_committed_gif_passes():
     validators.validate_gif(ROOT / 'assets/dashboard.gif')
 
 
-def test_real_committed_dashboard_passes():
+def test_real_committed_dashboard_passes(freshly_built_dashboard):
     validators.validate_dashboard(
-        ROOT / 'assets/data/dashboard.json', portfolio_path=ROOT / 'portfolio.json')
+        freshly_built_dashboard, portfolio_path=ROOT / 'portfolio.json')
 
 
 @pytest.mark.parametrize('mutation,problem', (
@@ -295,8 +295,8 @@ def test_real_committed_dashboard_passes():
      r'build_status\.integrity is not clean'),
 ))
 def test_dashboard_money_reconciliation_rejects_public_drift(
-        tmp_path, mutation, problem):
-    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+        tmp_path, freshly_built_dashboard, mutation, problem):
+    payload = json.loads(freshly_built_dashboard.read_text())
     mutation(payload)
     dashboard = write_json(tmp_path / 'dashboard.json', payload)
 
@@ -310,7 +310,8 @@ def _book(payload, stamp):
     return payload
 
 
-def test_intraday_dashboard_ahead_of_the_committed_book_is_not_a_failure(tmp_path):
+def test_intraday_dashboard_ahead_of_the_committed_book_is_not_a_failure(
+        tmp_path, freshly_built_dashboard):
     """The intraday publishing model: every slot rebuilds the dashboard from the
     live book, but portfolio.json is committed only at open/midday/close. The
     committed dashboard is then legitimately a newer generation, and comparing
@@ -319,7 +320,7 @@ def test_intraday_dashboard_ahead_of_the_committed_book_is_not_a_failure(tmp_pat
     source = write_json(
         tmp_path / 'portfolio.json', _book(portfolio, '2026/08/03 09:30 HKT'))
 
-    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload = json.loads(freshly_built_dashboard.read_text())
     payload['last_updated'] = '2026/08/03 12:00 HKT'
     payload['totals']['hk']['value_hkd'] += 1688.0
     dashboard = write_json(tmp_path / 'dashboard.json', payload)
@@ -327,12 +328,13 @@ def test_intraday_dashboard_ahead_of_the_committed_book_is_not_a_failure(tmp_pat
     validators.validate_dashboard(dashboard, portfolio_path=source)
 
 
-def test_dashboard_built_from_an_older_book_than_the_committed_one_fails(tmp_path):
+def test_dashboard_built_from_an_older_book_than_the_committed_one_fails(
+        tmp_path, freshly_built_dashboard):
     portfolio = json.loads((ROOT / 'portfolio.json').read_text())
     source = write_json(
         tmp_path / 'portfolio.json', _book(portfolio, '2026/08/03 12:00 HKT'))
 
-    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload = json.loads(freshly_built_dashboard.read_text())
     payload['last_updated'] = '2026/08/03 09:30 HKT'
     dashboard = write_json(tmp_path / 'dashboard.json', payload)
 
@@ -340,9 +342,9 @@ def test_dashboard_built_from_an_older_book_than_the_committed_one_fails(tmp_pat
         validators.validate_dashboard(dashboard, portfolio_path=source)
 
 
-def test_same_book_still_reconciles_field_by_field(tmp_path):
+def test_same_book_still_reconciles_field_by_field(tmp_path, freshly_built_dashboard):
     """The relaxation above must not reach inside a single generation."""
-    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+    payload = json.loads(freshly_built_dashboard.read_text())
     payload['totals']['hk']['value_hkd'] += 1688.0
     dashboard = write_json(tmp_path / 'dashboard.json', payload)
 
@@ -351,29 +353,32 @@ def test_same_book_still_reconciles_field_by_field(tmp_path):
             dashboard, portfolio_path=ROOT / 'portfolio.json')
 
 
-def test_dashboard_money_reconciliation_rejects_source_integrity_failure(tmp_path):
+def test_dashboard_money_reconciliation_rejects_source_integrity_failure(
+        tmp_path, freshly_built_dashboard):
     portfolio = json.loads((ROOT / 'portfolio.json').read_text())
     portfolio['portfolios']['us_stocks']['total_pnl'] += 100
     source = write_json(tmp_path / 'portfolio.json', portfolio)
 
     with pytest.raises(AssertionError, match='portfolio money integrity failed: PNL_TOTAL'):
         validators.validate_dashboard(
-            ROOT / 'assets/data/dashboard.json', portfolio_path=source)
+            freshly_built_dashboard, portfolio_path=source)
 
 
-def test_dashboard_money_reconciliation_checks_fx_cache_when_available(tmp_path):
+def test_dashboard_money_reconciliation_checks_fx_cache_when_available(
+        tmp_path, freshly_built_dashboard):
     fx = write_json(tmp_path / 'fx.json', {'rate': 7.0})
 
     with pytest.raises(AssertionError, match=r'fx\.usdhkd'):
         validators.validate_dashboard(
-            ROOT / 'assets/data/dashboard.json',
+            freshly_built_dashboard,
             portfolio_path=ROOT / 'portfolio.json',
             fx_path=fx,
         )
 
 
-def test_dashboard_money_reconciliation_allows_untracked_cash_as_null(tmp_path):
-    payload = json.loads((ROOT / 'assets/data/dashboard.json').read_text())
+def test_dashboard_money_reconciliation_allows_untracked_cash_as_null(
+        tmp_path, freshly_built_dashboard):
+    payload = json.loads(freshly_built_dashboard.read_text())
     portfolio = json.loads((ROOT / 'portfolio.json').read_text())
     payload['totals']['hk']['cash_hkd'] = None
     portfolio['portfolios']['hk_stocks']['cash_hkd'] = None


### PR DESCRIPTION
Closes #298.

## What was undeclared

`tests/test_validate_sidecars.py` reconciles the tracked `assets/data/dashboard.json`
against the tracked `portfolio.json`. Those two do not reconcile at an arbitrary
commit — the publisher commits them on different cadences. The gate was meaningful
only because `tests/test_dashboard_payload_size.py` rebuilt the artifact in place
first, and it ran first only because `test_dashboard_` sorts before `test_validate_`.

Second, smaller instance of the same accident: `scripts/data` modules import their
siblings by bare name, and ~20 test modules put that directory on `sys.path` at
import time. So `pytest tests/test_validate_sidecars.py` on its own did not merely
fail — it died in collection.

## What changed

- `tests/conftest.py` gains `freshly_built_dashboard`, a session fixture that runs
  the real `build_dashboard.py` once and returns the artifact path. It depends on
  the existing restore guard **by name**, so the snapshot is still taken before the
  first byte is rewritten (#297's guarantee is untouched).
- Both modules request it, and read the payload through the returned path instead
  of a module constant — the dependency is now expressed in code, not in filename
  order.
- The builder call moves out of `test_rebuild_is_idempotent_and_keeps_the_trim`
  (renamed `test_the_trim_survives_a_real_rebuild`, same assertions). Still exactly
  one builder run per session.
- `conftest` inserts `scripts/data` on `sys.path` at import time rather than inside
  the fixture, which is what makes a single-module run collect at all.

## Verification

| check | result |
|---|---|
| `pytest tests/test_validate_sidecars.py` alone | 121 passed |
| `pytest tests/test_dashboard_payload_size.py` alone | 15 passed |
| both modules, money module **first** | 136 passed |
| single money test alone | 1 passed |
| full suite | 1548 passed, 4 xfailed |
| publish-owned artifacts after every run | `git status` clean |

**Mutation, against acceptance criterion 2** — adding `+ 1688` to `totals.hk.value_hkd`
inside `build_dashboard.py` turns 5 money tests red *while running
`test_validate_sidecars.py` on its own*. That is the proof the gate reconciles a
freshly built payload rather than the tracked one; before this change that
invocation could not even reach the assertions.

## Not changed

The money check itself. Same validator, same comparison, same failure messages —
only which payload it is guaranteed to be looking at.
