### PR TITLE
dashboard: make the previous published payload an explicit input, and measure it

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -9,6 +9,7 @@ Outputs: assets/data/overview.json, assets/data/dashboard.json,
 
 Run after each portfolio mutation (cron commit) so Pages stays fresh.
 """
+import argparse
 import glob
 import json
 import math
@@ -807,16 +808,115 @@ def _latest_brief_context():
         return None, None
 
 
-def _load_existing_dashboard():
-    """Return the currently-published dashboard.json as a dict (or None). Used to
-    preserve brief-derived fields across a fresh-checkout rebuild where memory/.tmp
-    is absent — see the merge-not-overwrite guard at the anomalies assignment."""
+def load_previous_payload(path):
+    """Return a previously published dashboard payload as a dict, or None.
+
+    `path` is an explicit input, not an ambient lookup: the values this file
+    contributes are the only part of the output that does not come from the
+    workspace, so which file supplied them has to be a stated argument and is
+    reported in `build_status.previous_payload` (#262). `None` means the caller
+    asked for a build that depends on nothing but the workspace.
+    """
+    if path is None:
+        return None
     try:
-        if OUT_FILE.exists():
-            return load_json(str(OUT_FILE))
+        path = Path(path)
+        if path.exists():
+            return load_json(str(path))
     except Exception as e:
-        print(f'  warn: _load_existing_dashboard failed: {e}', file=sys.stderr)
+        print(f'  warn: load_previous_payload({path}) failed: {e}', file=sys.stderr)
     return None
+
+
+def merge_previous_payload(out, previous, presence, usable=None):
+    """Fill in `out` keys whose source context was absent from this checkout.
+
+    A context-less rebuild (memory/.tmp is gitignored, so brief-context and the
+    insights / intraday sidecars are ABSENT — meaning "not in THIS checkout",
+    NOT "no insight today") must not blank the cards the last build published,
+    or Pages flickers empty. `presence[key]` is False for exactly that case, and
+    the last non-empty published value is restored.
+
+    `usable[key]` overrides what counts as a value worth restoring. Truthiness is
+    the default, but `peer_divergence` is a wrapper dict that is truthy even when
+    its `items` list is empty, and republishing an empty card is not preservation.
+
+    Returns the sorted keys taken from `previous`, which is what makes this
+    dependency measurable rather than invisible: on the live host every source
+    is present, so the correct value is `[]`.
+    """
+    taken = []
+    for key, source_present in presence.items():
+        if source_present:
+            continue
+        value = (previous or {}).get(key)
+        if ((usable or {}).get(key) or bool)(value):
+            out[key] = value
+            taken.append(key)
+    return sorted(taken)
+
+
+def workspace_relative(path):
+    """Path as written inside the workspace, so a published value does not carry
+    the absolute location of whichever machine built it.
+
+    `/root/.openclaw/workspace/assets/data/dashboard.json` on the live host and
+    `/home/runner/work/clawock/clawock/assets/data/dashboard.json` on an Actions
+    runner name the same input; publishing the raw string would make the two
+    publishers alternate a field that `semantic_value()` does not strip, i.e.
+    a real commit for no reader-visible change.
+    """
+    if not path:
+        return None
+    try:
+        return str(Path(path).resolve().relative_to(Path(WS_ROOT).resolve()))
+    except (ValueError, OSError):
+        return str(path)
+
+
+def record_preservation(presence, taken, source, out_file, at=None):
+    """Append one line per build to memory/.tmp/preserve-absent-YYYY-MM-DD.jsonl.
+
+    The merge has exactly one known publishing consumer: `brief-fallback.yml`
+    runs `brief_postflight`, which rebuilds and commits the dashboard from an
+    Actions checkout. `brief_preflight` writes a brief-context there, but the
+    off-host generator writes no insights / intraday / sector-scan sidecars, so
+    those cards would publish blank without the merge — the 2026-06-21
+    regression. The scans stopped rebuilding dashboard.json on 2026-07-04
+    (gha_commit_push.sh header) and the other two Actions builders never commit.
+
+    What is not known is how much else reaches it: the pre-commit hook rebuilds
+    on any `portfolio.json` commit, and a developer clone has no memory/.tmp
+    either. So this measures rather than assumes, and records the empty case too,
+    so "it has not fired in N days" has a denominator.
+
+    One file per day, because `gc_sessions` ages memory/.tmp out by whole-file
+    mtime (KEEP_TMP_DAYS=14) — a single append-only file refreshes its own mtime
+    on every build and would never be collected.
+
+    Deliberately not in the payload and deliberately not created if the directory
+    is absent — memory/.tmp is gitignored and only exists on a real workspace.
+    Never raises: measurement must not be able to fail a publish.
+    """
+    try:
+        tmp_dir = Path(WS_ROOT) / 'memory' / '.tmp'
+        if not tmp_dir.is_dir():
+            return
+        at = at or datetime.now(timezone.utc)
+        line = json.dumps({
+            'at': at.isoformat(timespec='seconds'),
+            'out_file': str(out_file),
+            # Absolute here on purpose: unlike the published field, this file is
+            # local and knowing which checkout built it is the point.
+            'previous_source': str(source) if source else None,
+            'absent_sources': sorted(k for k, present in presence.items() if not present),
+            'preserved': taken,
+        }, ensure_ascii=False)
+        daily = tmp_dir / f'preserve-absent-{at.date().isoformat()}.jsonl'
+        with daily.open('a', encoding='utf-8') as handle:
+            handle.write(line + '\n')
+    except Exception as e:
+        print(f'  warn: preservation telemetry failed: {e}', file=sys.stderr)
 
 
 def load_sector_scan():
@@ -2212,13 +2312,31 @@ def compute_workflow_outcomes():
         return None
 
 
-def main():
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description='Build the public dashboard payloads from the workspace.')
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        '--previous', metavar='PATH', default=None,
+        help='dashboard payload to restore card values from when their source '
+             'context is absent from this checkout (default: the published '
+             f'{OUT_FILE.name})')
+    source.add_argument(
+        '--no-previous', action='store_true',
+        help='build from the workspace alone; no output may come from a '
+             'previously published file')
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
     # BUILD_DASHBOARD_OUT: redirect the WRITE target only. Verification callers
     # (system_check's buildability gate, run by the pre-push hook) build to a
     # temp file so a *check* never mutates the published artifact — before
     # 2026-06-10 every pre-push run rewrote dashboard.json in place, leaving
-    # the working tree perpetually dirty. Reads that merge previous values
-    # (load_prev_dashboard) still come from the real OUT_FILE on purpose.
+    # the working tree perpetually dirty. The previous-payload read stays on the
+    # real OUT_FILE on purpose, so a redirected build still sees what is live.
+    args = parse_args(argv)
+    previous_source = None if args.no_previous else Path(args.previous or OUT_FILE)
     out_file = Path(os.environ.get('BUILD_DASHBOARD_OUT') or OUT_FILE)
     out_file.parent.mkdir(parents=True, exist_ok=True)
     portfolio = load_json(WS_ROOT / 'portfolio.json')
@@ -2306,35 +2424,33 @@ def main():
     out['today_movers'] = compute_today_movers(us_h, hk_h)
 
     # merge-not-overwrite guard for sidecar-derived cards. A context-less rebuild
-    # (GHA fresh-checkout: memory/.tmp is gitignored, so brief-context + insights/
+    # (fresh checkout: memory/.tmp is gitignored, so brief-context + insights/
     # intraday sidecars are ABSENT — meaning "not in THIS checkout", NOT "no insight
     # today") must NOT blank the cards the last local build published, or Pages
-    # flickers empty several times a day (every macro/sentiment/influencer GHA scan
-    # rebuilds dashboard.json via gha_commit_push.sh). Restore the last non-empty
-    # published value whenever the source context is absent. This regressed to
-    # anomalies-only at some point; restored to all sidecar fields 2026-06-21 —
-    # see memory: openclaw-gha-sidecar-strip-and-prepush-seterr.
-    _prev_dash = _load_existing_dashboard() or {}
-
-    def _preserve_absent(key, source_present):
-        """Keep the freshly-computed value when its source context was present in
-        this checkout; otherwise fall back to the last non-empty published value."""
-        if not source_present:
-            prev = _prev_dash.get(key)
-            if prev:
-                out[key] = prev
+    # flickers empty. Restore the last non-empty published value whenever the
+    # source context is absent. This regressed to anomalies-only at some point;
+    # restored to all sidecar fields 2026-06-21 — see memory:
+    # openclaw-gha-sidecar-strip-and-prepush-seterr.
+    #
+    # This is the one part of the output that does not come from the workspace,
+    # so the file it comes from is an argument (`--previous` / `--no-previous`)
+    # and the keys it supplied are reported in build_status (#262). It is NOT
+    # dead code: brief-fallback.yml publishes a dashboard rebuilt on an Actions
+    # checkout that has a brief-context but no insights / intraday / sector-scan
+    # sidecars, which is exactly the case this restores. See record_preservation.
+    _prev_dash = load_previous_payload(previous_source) or {}
+    _presence = {}
 
     out['anomalies'] = extract_anomalies(brief_ctx, us_h, hk_h)
-    _preserve_absent('anomalies', bool(brief_ctx))
+    _presence['anomalies'] = bool(brief_ctx)
 
     # market_context is sector-scan-derived (load_sector_scan reads memory/.tmp,
-    # absent on a GHA checkout) and portfolio.market_context is usually empty — so
-    # a context-less rebuild would blank the 大盘速读 card. Preserve last good,
-    # same merge-not-overwrite contract as the sidecar fields above.
-    if not out.get('market_context'):
-        _prev_mc = _prev_dash.get('market_context')
-        if _prev_mc:
-            out['market_context'] = _prev_mc
+    # absent on a fresh checkout) and portfolio.market_context is usually empty —
+    # so a context-less rebuild would blank the 大盘速读 card. Preserve last good,
+    # same merge-not-overwrite contract as the sidecar fields above. Its presence
+    # test is the computed value itself rather than a source flag, because both
+    # of its sources are optional.
+    _presence['market_context'] = bool(out.get('market_context'))
 
     # ── LLM narrative sidecars (agent-written in Step 3; text-only, no keys) ──
     # Each sidecar is validated (validate_insights / validate_intraday_insights)
@@ -2359,7 +2475,7 @@ def main():
         'stale': _insights.get('_stale', True if not _insights else False),
     }
     for _k in ('behavioral_review', 'bear_cases', 'hidden_concentration', 'insights_meta'):
-        _preserve_absent(_k, insights_present)
+        _presence[_k] = insights_present
     # intraday insights (every 30min): status_banner + per-mover attribution.
     _intra = load_tmp_sidecar('intraday-insights', max_age_days=1)
     intra_present = bool(_intra)  # file existed in this checkout (vs. GHA-absent)
@@ -2370,8 +2486,9 @@ def main():
         'generated_at': _intra.get('generated_at'),
         'stale': _intra.get('_stale', True if not _intra else False),
     }
-    _preserve_absent('status_banner', intra_present)
-    _preserve_absent('status_banner_meta', intra_present)
+    _presence['status_banner'] = intra_present
+    _presence['status_banner_meta'] = intra_present
+
     # Merge validated mover attribution onto the deterministic movers list (by ticker).
     for _m in out['today_movers']:
         _note = _intra_v['movers'].get(_m.get('ticker'))
@@ -2383,10 +2500,19 @@ def main():
         'items': extract_peer_divergence(brief_ctx, us_h, hk_h),
     }
     # peer_divergence is brief-context-derived → preserve last good when absent.
-    if not brief_ctx and not out['peer_divergence']['items']:
-        _prev_pd = _prev_dash.get('peer_divergence')
-        if isinstance(_prev_pd, dict) and _prev_pd.get('items'):
-            out['peer_divergence'] = _prev_pd
+    # Its wrapper dict is truthy even with an empty items list, so restoring it
+    # needs a stricter test than the other cards — hence `usable` below.
+    _presence['peer_divergence'] = bool(brief_ctx) or bool(out['peer_divergence']['items'])
+
+    # One merge, after every card above has been computed: the nine keys are
+    # disjoint from everything read in between, so applying them together changes
+    # nothing except that the set of restored keys can now be named. Anything
+    # added later that falls back to `_prev_dash` belongs in this map, or the
+    # payload will under-report what it copied.
+    _preserved = merge_previous_payload(
+        out, _prev_dash, _presence,
+        usable={'peer_divergence': lambda v: isinstance(v, dict) and bool(v.get('items'))})
+    record_preservation(_presence, _preserved, previous_source, out_file)
     # Decision system v2 is the only live scoring path. No CSV/signal-row
     # compatibility keys are emitted: frontend, README and harness share this.
     _decisions = decision_v2.load_decisions()
@@ -2609,6 +2735,17 @@ def main():
     except Exception as e:
         print(f'  warn: compute_build_status failed: {e}', file=sys.stderr)
         out['build_status'] = None
+    if isinstance(out.get('build_status'), dict):
+        # Provenance for the only values that did not come from the workspace.
+        # `preserved: []` is the healthy reading and the one the live host is
+        # expected to publish; a non-empty list means this payload is partly a
+        # copy of an older one, which a reader is entitled to know. Attached only
+        # when the health card was computed — a failed build_status is already
+        # its own signal and must keep its `null`.
+        out['build_status']['previous_payload'] = {
+            'source': workspace_relative(previous_source),
+            'preserved': _preserved,
+        }
     out['workflow_outcomes'] = compute_workflow_outcomes()
 
     if brief_ctx_path:

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -943,3 +943,114 @@ def test_today_ranges_uses_current_price_denominator_and_strict_top_n():
         "current": 10.0,
         "range_pct": 40.0,
     }]
+
+
+# ── the previous published payload as an explicit input (#262) ──────────────
+#
+# The merge is the one part of the output that does not come from the workspace,
+# so what it took and where it came from have to be answerable. These pin the
+# contract; the live default (restore from the published dashboard.json) is
+# unchanged.
+
+
+def test_merge_takes_only_the_keys_whose_source_was_absent_and_names_them():
+    out = {"anomalies": [], "status_banner": "fresh"}
+    previous = {"anomalies": ["yesterday"], "status_banner": "stale", "totals": {"hk": 1}}
+
+    taken = dashboard.merge_previous_payload(
+        out, previous, {"anomalies": False, "status_banner": True})
+
+    assert out["anomalies"] == ["yesterday"], "absent source must not blank the card"
+    assert out["status_banner"] == "fresh", "a present source must win over the old payload"
+    assert taken == ["anomalies"]
+    assert "totals" not in out, "only the listed cards may come from the previous payload"
+
+
+def test_an_absent_source_with_nothing_published_before_stays_absent():
+    """The fallback is 'keep the last non-empty value', not 'invent one'."""
+    out = {"anomalies": []}
+
+    taken = dashboard.merge_previous_payload(out, {"anomalies": []}, {"anomalies": False})
+
+    assert out["anomalies"] == []
+    assert taken == []
+
+
+def test_no_previous_builds_from_the_workspace_alone():
+    """`--no-previous` is the acceptance criterion: no output may come from a
+    previously published file. It resolves to no source at all, and the merge is
+    then a no-op even for absent sidecars."""
+    args = dashboard.parse_args(["--no-previous"])
+    assert args.no_previous is True
+
+    out = {"anomalies": []}
+    assert dashboard.load_previous_payload(None) is None
+    assert dashboard.merge_previous_payload(out, None, {"anomalies": False}) == []
+    assert out["anomalies"] == []
+
+    assert dashboard.parse_args([]).previous is None, (
+        "the default has to stay 'the published file' in main(), not a parsed value")
+
+
+def test_a_wrapper_card_is_not_restored_when_its_previous_items_were_empty():
+    """peer_divergence is a dict that stays truthy after its items list empties;
+    republishing that is not preservation, it is publishing an empty card as if
+    it had been kept."""
+    out = {"peer_divergence": {"as_of": "2026-08-04", "items": []}}
+    usable = {"peer_divergence": lambda v: isinstance(v, dict) and bool(v.get("items"))}
+
+    empty = dashboard.merge_previous_payload(
+        out, {"peer_divergence": {"as_of": "2026-08-01", "items": []}},
+        {"peer_divergence": False}, usable=usable)
+    assert empty == []
+    assert out["peer_divergence"]["as_of"] == "2026-08-04", "must not adopt an empty older card"
+
+    filled = dashboard.merge_previous_payload(
+        out, {"peer_divergence": {"as_of": "2026-08-01", "items": [{"ticker": "AAPL"}]}},
+        {"peer_divergence": False}, usable=usable)
+    assert filled == ["peer_divergence"]
+    assert out["peer_divergence"]["items"] == [{"ticker": "AAPL"}]
+
+
+def test_the_published_source_is_workspace_relative(monkeypatch, tmp_path):
+    """Two publishers build this file — the live host and the brief-fallback
+    Actions job. An absolute path would differ between them, and semantic_value()
+    does not strip it, so the two would alternate a commit for no reader-visible
+    change."""
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+
+    assert dashboard.workspace_relative(
+        tmp_path / "assets" / "data" / "dashboard.json") == "assets/data/dashboard.json"
+    assert dashboard.workspace_relative(None) is None
+
+
+def test_the_empty_case_is_recorded_so_never_fired_has_a_denominator(tmp_path, monkeypatch):
+    """Telemetry answers 'has the merge fired in N days'. A line only on the
+    interesting case would make silence ambiguous between 'did not fire' and
+    'did not build'."""
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    (tmp_path / "memory" / ".tmp").mkdir(parents=True)
+
+    at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    dashboard.record_preservation(
+        {"anomalies": True}, [], Path("dashboard.json"), "out.json", at=at)
+
+    # Dated, because gc_sessions ages memory/.tmp out by whole-file mtime: one
+    # append-only file would refresh its own mtime forever and never be collected.
+    written = sorted(p.name for p in (tmp_path / "memory" / ".tmp").iterdir())
+    assert written == ["preserve-absent-2026-08-04.jsonl"]
+
+    line = json.loads((tmp_path / "memory" / ".tmp" / written[0]).read_text())
+    assert line["preserved"] == []
+    assert line["absent_sources"] == []
+    assert line["previous_source"] == "dashboard.json"
+
+
+def test_telemetry_never_creates_the_directory_or_raises(tmp_path, monkeypatch):
+    """A fresh checkout has no memory/.tmp — measurement must not manufacture a
+    workspace, and must never be able to fail a publish."""
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+
+    dashboard.record_preservation({"anomalies": False}, ["anomalies"], None, "out.json")
+
+    assert not (tmp_path / "memory").exists()

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -356,3 +356,22 @@ def test_the_brief_only_ships_calibrator_rows_that_can_move_size():
     for field in ("method", "hierarchy", "abstain_rule", "sizing_rule",
                   "all_predictions", "after_warmup"):
         assert field in calibration, field
+
+
+def test_the_published_provenance_names_a_workspace_relative_source(freshly_built_dashboard):
+    """The payload states which previously published file it borrowed from (#262).
+
+    Asserted on a real build because the value is only correct if `main()` passes
+    it through `workspace_relative`: the live host and the brief-fallback Actions
+    job build this file from different absolute roots, and `semantic_value()`
+    does not strip the field, so an absolute path makes the two publishers
+    alternate a commit that changes nothing a reader can see.
+    """
+    provenance = (json.loads(freshly_built_dashboard.read_text())
+                  .get("build_status") or {}).get("previous_payload")
+
+    assert provenance is not None, "a published payload must say what it reused"
+    assert isinstance(provenance["preserved"], list)
+    source = provenance["source"]
+    assert source is None or not Path(source).is_absolute(), (
+        f"provenance source {source!r} is machine-specific")


### PR DESCRIPTION
First slice of #262. It does not remove the dependency on the previously published payload — it makes it an argument, gives it provenance in the artifact, and measures it.

## The dependency

`build_dashboard.py` restores nine card keys from the previously published `assets/data/dashboard.json` whenever their source context is missing from the checkout (`memory/.tmp` is gitignored, so on any fresh checkout it is). That is the specific behaviour that makes the output a function of this repository's history rather than of a workspace, and it is what #262's `ProjectionBuilder` has to end.

## What changed

| before | after |
|---|---|
| `_load_existing_dashboard()` reaches for `OUT_FILE` | `load_previous_payload(path)` takes it as an argument, `None` = workspace-only |
| a `_preserve_absent` closure called at 8 sites, plus a 9th hand-rolled fallback for `peer_divergence` | one `presence` map, one `merge_previous_payload(...)`, which **returns the keys it took** |
| nothing states which file the payload borrowed from | `build_status.previous_payload = {source, preserved}`, workspace-relative |
| no way to build without it | `--no-previous` (and `--previous PATH`) |
| unmeasured | one JSONL line per build in `memory/.tmp/preserve-absent-YYYY-MM-DD.jsonl`, empty case included |

Every existing caller passes no arguments and is unchanged: `publish_dashboard.sh`, the three postflights, the pre-commit hook, `gold_dca_refresh.sh`, `update_gold_dca.py --publish`, `system_check`'s `BUILD_DASHBOARD_OUT` gate, and the two Actions validation jobs.

## The merge is not dead code

Worth stating plainly, because the comment it carried implied the opposite and I initially believed it. The scans did stop rebuilding `dashboard.json` on 2026-07-04 (`gha_commit_push.sh` header), and the two Actions jobs that still run the builder never commit the result — but:

- **`brief-fallback.yml` publishes one.** It runs `brief_postflight`, which calls `rebuild_dashboard()` and commits the dashboard outputs from an Actions checkout. `brief_preflight` writes a brief-context there, but the off-host generator writes only `pre-open.md` and `plan.json` — no insights / intraday / sector-scan sidecars. Those cards would publish **blank**, which is exactly the 2026-06-21 regression.
- **The pre-commit hook** rebuilds and stages the dashboard on any `portfolio.json` commit, so a developer clone is another checkout without `memory/.tmp`.

So the telemetry is not "confirm it never fires" — it is "measure how much reaches it", and deleting the merge is now explicitly blocked on `brief-fallback` producing its own sidecars or accepting blank cards.

## Verification

- `dashboard.json` and `overview.json` are **semantically identical** — by `dashboard_outputs.semantic_value()`, the publisher's own rule — to a build from origin/master's builder run back to back against the same tree, with only the new provenance key set aside. `decision_audit.json` and `shadow_portfolio.json` byte-identical.
- `BUILD_DASHBOARD_OUT` still redirects the write while reading the live file.
- `--no-previous` produces a workspace-only payload (`preserved: []`, cards empty) — the shape #262's acceptance criterion asks for.
- Full suite: 1556 passed, 4 xfailed.
- Seven of the eight new tests are mutation-verified: ignoring `presence`, restoring falsy values, ignoring `usable`, creating `memory/.tmp`, logging only non-empty cases, and reverting the workspace-relative path each turn exactly one red.

## Review credit

A Codex review of the first version of this commit found the `peer_divergence` gap (telemetry could report `preserved: []` while a ninth key was copied), the absolute-path churn, the unbounded log (`gc_sessions` ages `memory/.tmp` by whole-file mtime, so one append-only file is never collected), and falsified my claim that no Actions path publishes a rebuilt dashboard. All four are fixed or recorded above.

## Not in this PR

Removing the merge, touching `brief-fallback.yml`, the leg-shape parameterisation, or anything about rendering and publishing.
