### PR TITLE
dashboard: a build reads no previously published payload unless asked (#262)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -75,7 +75,11 @@ fi
 # ──────────────────────────────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE '^portfolio\.json$'; then
   echo "  ▸ rebuilding dashboard outputs (portfolio.json was staged)…"
-  python3 scripts/data/build_dashboard.py > /dev/null
+  # --previous: this rebuild is STAGED into the commit, so it is a publishing
+  # path, and it runs in whatever checkout the committer has. A worktree has no
+  # memory/.tmp (gitignored), so without the opt-in this hook would commit blank
+  # narrative cards. Workspace-only is the builder's default since #262 slice 2.
+  python3 scripts/data/build_dashboard.py --previous assets/data/dashboard.json > /dev/null
   dashboard_paths_output="$(python3 scripts/data/dashboard_outputs.py)"
   dashboard_paths=()
   if [ -n "$dashboard_paths_output" ]; then

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -2319,13 +2319,35 @@ def parse_args(argv=None):
     source.add_argument(
         '--previous', metavar='PATH', default=None,
         help='dashboard payload to restore card values from when their source '
-             'context is absent from this checkout (default: the published '
-             f'{OUT_FILE.name})')
+             'context is absent from this checkout. Opt-in: a build that is '
+             'going to be published from a checkout without the memory/.tmp '
+             f'sidecars passes the published {OUT_FILE.name} here')
     source.add_argument(
         '--no-previous', action='store_true',
         help='build from the workspace alone; no output may come from a '
-             'previously published file')
+             'previously published file. This is the default — pass it to state '
+             'the guarantee explicitly')
     return parser.parse_args(argv)
+
+
+def resolve_previous_source(args):
+    """The payload file this build may restore absent cards from, or None.
+
+    Workspace-only is the DEFAULT (#262 slice 2). Reading the last published
+    dashboard makes the output depend on this repository's own history, so the
+    builder does not do it unless a caller names the file. The callers that
+    still want it are the ones that publish from a checkout which may lack the
+    memory/.tmp sidecars — `publish_dashboard.sh`, `rebuild_dashboard()` (which
+    covers all three postflights, and through them `brief-fallback.yml`) and the
+    pre-commit hook. Every other caller either has the sidecars or never
+    publishes, and gets the workspace-only build.
+
+    Inverting this is the point of the slice: before, a silent default meant a
+    fresh checkout could publish yesterday's cards without anyone asking it to.
+    """
+    if args.no_previous:
+        return None
+    return Path(args.previous) if args.previous else None
 
 
 def main(argv=None):
@@ -2333,10 +2355,10 @@ def main(argv=None):
     # (system_check's buildability gate, run by the pre-push hook) build to a
     # temp file so a *check* never mutates the published artifact — before
     # 2026-06-10 every pre-push run rewrote dashboard.json in place, leaving
-    # the working tree perpetually dirty. The previous-payload read stays on the
-    # real OUT_FILE on purpose, so a redirected build still sees what is live.
+    # the working tree perpetually dirty. A redirected build still reads whatever
+    # `--previous` names, so the redirect never changes which cards are restored.
     args = parse_args(argv)
-    previous_source = None if args.no_previous else Path(args.previous or OUT_FILE)
+    previous_source = resolve_previous_source(args)
     out_file = Path(os.environ.get('BUILD_DASHBOARD_OUT') or OUT_FILE)
     out_file.parent.mkdir(parents=True, exist_ok=True)
     portfolio = load_json(WS_ROOT / 'portfolio.json')
@@ -2433,8 +2455,10 @@ def main(argv=None):
     # openclaw-gha-sidecar-strip-and-prepush-seterr.
     #
     # This is the one part of the output that does not come from the workspace,
-    # so the file it comes from is an argument (`--previous` / `--no-previous`)
-    # and the keys it supplied are reported in build_status (#262). It is NOT
+    # so the file it comes from is an opt-in argument (`--previous`, default off
+    # since #262 slice 2) and the keys it supplied are reported in build_status.
+    # `_prev_dash` is `{}` for every caller that did not ask, which is what makes
+    # a workspace the complete input to a build. Restoration is NOT
     # dead code: brief-fallback.yml publishes a dashboard rebuilt on an Actions
     # checkout that has a brief-context but no insights / intraday / sector-scan
     # sidecars, which is exactly the case this restores. See record_preservation.

--- a/scripts/data/publish_dashboard.sh
+++ b/scripts/data/publish_dashboard.sh
@@ -35,7 +35,11 @@ fi
 git fetch -q origin master || true
 git merge -q --ff-only origin/master 2>/dev/null || true
 
-python3 scripts/data/build_dashboard.py
+# --previous: this build is published, so it opts in to restoring cards whose
+# memory/.tmp sidecar is missing (#262 slice 2 made workspace-only the default).
+# On this host the sidecars are present, so it is a no-op — it is here so a
+# degraded run publishes the last good cards instead of blanking them.
+python3 scripts/data/build_dashboard.py --previous assets/data/dashboard.json
 python3 scripts/data/cron_heartbeat.py --publish
 python3 scripts/data/workflow_outcomes.py --publish
 

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -285,9 +285,17 @@ def rebuild_dashboard(ws=None):
         # the rare off-host brief fallback reuses this same harness path.
         # flock serializes the build so a harness run and
         # the publisher can't interleave writes to the same generated file.
+        # --previous: all three postflights publish what they build, so they opt
+        # in to restoring cards whose memory/.tmp sidecar is absent (#262 slice 2
+        # made workspace-only the builder's default). This is the ONE caller
+        # where the flag does something: brief-fallback.yml reaches here through
+        # brief_postflight on an Actions checkout that has a brief-context but no
+        # insights / intraday / sector-scan sidecars — without it those cards
+        # publish blank, the 2026-06-21 regression. On the host it is a no-op.
         r = subprocess.run(
             ['flock', DASHBOARD_PUBLISH_LOCK,
-             'python3', str(ws / 'scripts' / 'data' / 'build_dashboard.py')],
+             'python3', str(ws / 'scripts' / 'data' / 'build_dashboard.py'),
+             '--previous', str(ws / 'assets' / 'data' / 'dashboard.json')],
             capture_output=True, text=True, timeout=30, cwd=str(ws),
         )
         ok = r.returncode == 0

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -948,9 +948,9 @@ def test_today_ranges_uses_current_price_denominator_and_strict_top_n():
 # ── the previous published payload as an explicit input (#262) ──────────────
 #
 # The merge is the one part of the output that does not come from the workspace,
-# so what it took and where it came from have to be answerable. These pin the
-# contract; the live default (restore from the published dashboard.json) is
-# unchanged.
+# so what it took and where it came from have to be answerable. Since slice 2 it
+# is also opt-in: a build reads a previously published payload only when a caller
+# names the file.
 
 
 def test_merge_takes_only_the_keys_whose_source_was_absent_and_names_them():
@@ -976,20 +976,51 @@ def test_an_absent_source_with_nothing_published_before_stays_absent():
     assert taken == []
 
 
-def test_no_previous_builds_from_the_workspace_alone():
-    """`--no-previous` is the acceptance criterion: no output may come from a
-    previously published file. It resolves to no source at all, and the merge is
-    then a no-op even for absent sidecars."""
-    args = dashboard.parse_args(["--no-previous"])
-    assert args.no_previous is True
+def test_the_default_build_reads_no_previously_published_file():
+    """Acceptance criterion for #262: no output depends on a previously published
+    file unless that file is passed in explicitly. A bare invocation resolves to
+    no source at all, so the merge is a no-op even where every sidecar is absent
+    — which is what makes a workspace the complete input to a build."""
+    assert dashboard.resolve_previous_source(dashboard.parse_args([])) is None
+    assert dashboard.resolve_previous_source(dashboard.parse_args(["--no-previous"])) is None
+    assert dashboard.resolve_previous_source(
+        dashboard.parse_args(["--previous", "assets/data/dashboard.json"])
+    ) == Path("assets/data/dashboard.json"), "a named file must still be honoured"
 
     out = {"anomalies": []}
     assert dashboard.load_previous_payload(None) is None
     assert dashboard.merge_previous_payload(out, None, {"anomalies": False}) == []
     assert out["anomalies"] == []
 
-    assert dashboard.parse_args([]).previous is None, (
-        "the default has to stay 'the published file' in main(), not a parsed value")
+
+def test_every_publishing_caller_opts_into_preservation():
+    """The default is safe for a build, but silent for a *publisher*: a fresh
+    checkout has no memory/.tmp, so a publishing caller that forgets `--previous`
+    commits blank narrative cards (the 2026-06-21 regression). Exactly three
+    callers put their build into a commit, and each has to ask.
+
+    Every other caller — system_check's buildability gate, the two Actions
+    validation jobs, the gold refresh path — either never publishes or runs only
+    on the host, and is deliberately left bare.
+    """
+    publishers = [
+        "scripts/data/publish_dashboard.sh",   # host crontab, every 20 minutes
+        "scripts/harness/_harness_common.py",  # all three postflights → brief-fallback.yml
+        ".githooks/pre-commit",                # stages its rebuild into the commit
+    ]
+    for rel in publishers:
+        lines = (ROOT / rel).read_text(encoding="utf-8").splitlines()
+        invocations = [
+            i for i, line in enumerate(lines)
+            if "build_dashboard.py" in line and "python3" in line
+            and not line.lstrip().startswith("#")
+        ]
+        assert invocations, f"{rel} no longer invokes build_dashboard.py"
+        for i in invocations:
+            window = "\n".join(lines[i:i + 3])
+            assert "--previous" in window, (
+                f"{rel}:{i + 1} publishes its build but does not opt into "
+                "restoring cards whose sidecar is absent from this checkout")
 
 
 def test_a_wrapper_card_is_not_restored_when_its_previous_items_were_empty():


### PR DESCRIPTION
Slice 2 of #262, exactly as specified in the issue’s “Where this stands after #302” comment.

## What changes

#302 made the previously published `dashboard.json` an explicit argument and started measuring what it supplied — but left **the default pointing at it**. So a checkout that had never published anything still inherited a dependency on this repository's own history, silently.

This inverts it. `build_dashboard.py` with no arguments builds from the workspace alone. The callers that put their build into a commit ask for restoration by name:

| caller | flag | why |
|---|---|---|
| `scripts/data/publish_dashboard.sh` | `--previous` | host crontab every 20 min; no-op here (sidecars present), present so a degraded run does not blank cards |
| `_harness_common.rebuild_dashboard()` | `--previous` | all three postflights, and through `brief_postflight` the `brief-fallback.yml` runner — **the one caller where the flag actually does something** |
| `.githooks/pre-commit` | `--previous` | stages its rebuild into the commit |
| `system_check`, the two Actions validation jobs, `gold_dca_refresh.sh`, `update_gold_dca.py` | bare | never publish, or run only on the host |

## One deviation from the issue's table, stated

The issue listed `.githooks/pre-commit` under "leave bare — they either have the sidecars or never publish". **It does publish**: it rebuilds on any staged `portfolio.json` and `git add`s the four outputs into that commit. And it runs in whatever checkout the committer has — an agent worktree has no `memory/.tmp`, which is gitignored, so bare it would commit blank narrative cards. That is the same population the issue's own risk section names. Made explicit instead.

## Acceptance

Run in a worktree with **no `memory/.tmp`**, i.e. the fresh-checkout publisher shape.

- **Bare build depends on nothing published.** `build_status.previous_payload` = `{"source": null, "preserved": []}`; `behavioral_review` / `bear_cases` / `hidden_concentration` / `status_banner` / `market_context` all empty. `anomalies` carries its computed `no_context` placeholder — workspace-derived, not restored.
- **The live publishing path is unchanged.** `origin/master`'s `build_dashboard.py` run bare, and this one run with `--previous assets/data/dashboard.json`, back to back against the same tree: **identical** under the publisher's own `dashboard_outputs.semantic_value()`. Both report the same eight preserved keys.
- **A brief-fallback shape still recovers.** brief-context present, insights / intraday / sector-scan absent: with `--previous`, seven cards restored (`anomalies` and `peer_divergence` correctly computed from the context instead); without it, `preserved: []` and the cards blank.

## Tests

Two, both mutation-verified — no net growth in the suite (one existing test was rewritten, since its assertion pinned the old default).

- `test_the_default_build_reads_no_previously_published_file` — flipping the default back to `OUT_FILE` fails it.
- `test_every_publishing_caller_opts_into_preservation` — dropping the flag from any one of the three callers fails it, individually verified for all three. This is the backstop for the one real risk: a forgotten publisher loses preservation silently.

`1557 passed, 4 xfailed` locally; the tree was clean afterwards.

## Not in scope

Deleting the merge, changing what `brief-fallback` generates, the leg shape, rendering, publishing. Slice 3 (ProjectionBuilder) is next.
