### PR TITLE
dashboard: the four outputs are published as one write set (#262)

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import NamedTuple
 from zoneinfo import ZoneInfo
 
+import dashboard_outputs
 import decision_v2
 import instrument_registry
 import json_repair
@@ -3001,15 +3002,21 @@ def main(argv=None):
         print(f'FATAL: {e}', file=sys.stderr)
         return 1
 
-    from safe_io import safe_write_text
-    # Both files are compiled from the same in-memory generation and enter the
-    # shared publication pathspec together. The browser still verifies their
-    # generation IDs because intermediary caches need not be atomic.
-    safe_write_text(str(overview_file), projection['overview'])
-    safe_write_text(str(out_file), projection['dashboard'])
-    safe_write_text(str(audit_file), projection['audit'])
-    shadow_file.parent.mkdir(parents=True, exist_ok=True)
-    safe_write_text(str(shadow_file), projection['shadow'])
+    # All four are compiled from the same in-memory generation and enter the
+    # shared publication pathspec together, so they are published as one write
+    # set: every file is staged on disk before any of them is swapped in. A
+    # failure part-way now publishes nothing instead of two new files beside two
+    # old ones (#262 slice 3 step 3). The browser still verifies their generation
+    # IDs, because intermediary caches need not be atomic either way.
+    #
+    # Order is the ownership contract's, so the pathspec and the write set cannot
+    # drift apart.
+    dashboard_outputs.write_generation({
+        str(overview_file): projection['overview'],
+        str(out_file): projection['dashboard'],
+        str(audit_file): projection['audit'],
+        str(shadow_file): projection['shadow'],
+    })
 
     record_preservation(
         projection['preservation']['presence'],

--- a/scripts/data/dashboard_outputs.py
+++ b/scripts/data/dashboard_outputs.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -57,6 +59,62 @@ _GENERATION_LINKED = frozenset({
     "assets/data/overview.json",
     "assets/data/dashboard.json",
 })
+
+
+def write_generation(writes):
+    """Publish the four outputs as ONE write set: stage every file, then swap.
+
+    `writes` maps path -> already-serialized text. `safe_write_text` is atomic
+    per file, so no single output can be torn — but four sequential calls are not
+    atomic ACROSS files: a failure on the third leaves two files from the new
+    generation beside two from the old, and every consumer of these payloads
+    (the browser, the semantic diff, the publication pathspec) treats them as one
+    generation.
+
+    Staging every file first shrinks the window from "serialize + write + fsync,
+    four times" down to the `os.replace` calls themselves, and converts the
+    common failures — a full disk, a read-only mount, an unwritable directory —
+    from "publish a mixed generation" into "publish nothing and raise".
+
+    Targets are checked before anything is staged, because a target that cannot
+    be replaced at all (one that is a directory) would otherwise fail in the swap
+    loop, i.e. after earlier files had already been published — the exact outcome
+    this exists to prevent.
+
+    What remains is genuinely irreducible: the swap loop itself. If the directory
+    is removed between staging and replacing, some files can land and others not.
+    Four files cannot be swapped atomically without a transactional filesystem;
+    this narrows the window to consecutive `os.replace` calls rather than closing
+    it, and the payloads carry generation IDs so a reader can still tell.
+
+    Returns the paths written, in the order given.
+    """
+    for path in map(Path, writes):
+        if path.is_dir():
+            raise IsADirectoryError(
+                f"{path} is a directory; the write set cannot be swapped in")
+    staged = []
+    try:
+        for path, text in writes.items():
+            path = Path(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".staged-")
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            staged.append((tmp, path))
+    except BaseException:
+        for tmp, _ in staged:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+        raise
+    # Every byte is on disk; only the swaps remain.
+    for tmp, path in staged:
+        os.replace(tmp, path)
+    return [str(path) for _, path in staged]
 
 
 def _strip_recursive(value, fields):

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -1,5 +1,6 @@
 """One build, four public outputs, one semantic publication contract."""
 import json
+import pytest
 import subprocess
 import sys
 from pathlib import Path
@@ -184,3 +185,41 @@ def test_every_dashboard_committer_uses_the_shared_contract():
     assert "semantic_changed_paths(WS_ROOT)" in (
         ROOT / "scripts/data/update_gold_dca.py"
     ).read_text()
+
+
+def test_a_failed_write_set_publishes_nothing(tmp_path):
+    """#262 slice 3 step 3: the four outputs are one generation, so a failure
+    part-way must leave the old generation intact rather than mix them.
+
+    `safe_write_text` is atomic per file, which is why this is not already true:
+    four successful-then-failing calls each land atomically, and the reader gets
+    two new files beside two old ones.
+    """
+    for name in ("overview.json", "dashboard.json"):
+        (tmp_path / name).write_text("OLD", encoding="utf-8")
+    # A directory where a file must go: the staged write fails, and it fails
+    # after the first two payloads have already been staged.
+    (tmp_path / "decision_audit.json").mkdir()
+
+    with pytest.raises(OSError):
+        dashboard_outputs.write_generation({
+            str(tmp_path / "overview.json"): "NEW",
+            str(tmp_path / "dashboard.json"): "NEW",
+            str(tmp_path / "decision_audit.json"): "NEW",
+        })
+
+    assert (tmp_path / "overview.json").read_text(encoding="utf-8") == "OLD"
+    assert (tmp_path / "dashboard.json").read_text(encoding="utf-8") == "OLD"
+    assert not list(tmp_path.glob(".staged-*")), "staged temporaries must be cleaned up"
+
+
+def test_a_complete_write_set_swaps_every_file(tmp_path):
+    written = dashboard_outputs.write_generation({
+        str(tmp_path / "overview.json"): "A",
+        str(tmp_path / "nested" / "shadow_portfolio.json"): "B",
+    })
+
+    assert [Path(p).name for p in written] == ["overview.json", "shadow_portfolio.json"]
+    assert (tmp_path / "overview.json").read_text(encoding="utf-8") == "A"
+    assert (tmp_path / "nested" / "shadow_portfolio.json").read_text(encoding="utf-8") == "B"
+    assert not list(tmp_path.glob(".staged-*"))


### PR DESCRIPTION
Slice 3 **step 3** of #262 — "Four outputs as one write set; a partial write must fail rather than publish mixed generations."

## Why this was not already true

Since #304 all four payloads are computed before anything is written. But `main()` still issued **four separate `safe_write_text` calls**.

`safe_write_text` is atomic *per file* — temp file, fsync, `os.replace`. That is exactly why the gap was invisible: a failure on the third call leaves two files from the new generation beside two from the old, each of them perfectly intact. There is no torn file to point at, and every consumer of these payloads (the browser, `semantic_changed_paths`, the publication pathspec) treats them as one generation.

## The change

`write_generation()` lives in `dashboard_outputs.py`, next to the ownership contract it belongs to. Stage every file on disk with fsync, then swap. A full disk, a read-only mount or an unwritable directory now publishes **nothing** and raises.

## The bug in my first version, and what caught it

Staging only converts *write* failures. A target that cannot be replaced at all — one that is a directory — stages fine and then fails inside the **swap loop**, after earlier files have already been published. That is precisely the outcome this change exists to prevent, and version one still had it.

The test asserted the property rather than the implementation, so it failed. Targets are now checked before anything is staged.

## What remains, stated rather than glossed

The swap loop itself. Four files cannot be swapped atomically without a transactional filesystem. If the directory disappears between staging and replacing, some can land and others not. This narrows the window from "serialize + write + fsync, four times" to consecutive `os.replace` calls; it does not close it. The payloads carry generation IDs, so a reader can still tell.

I would rather this be in the docstring than have the PR claim atomicity it does not have.

## Verification

`origin/master`'s builder and this one, back to back against the same tree — four outputs, zero differences excluding build-clock fields, identical key order. `1567 passed, 4 xfailed`, tree clean.

Two tests:
- `test_a_failed_write_set_publishes_nothing` — mutation-verified by reverting `write_generation` to four sequential `safe_write_text` calls.
- `test_a_complete_write_set_swaps_every_file` — covers the ordinary path and the nested-directory case, and asserts no `.staged-*` temporaries survive either way.

## Next

Step 4 — output directory as a parameter, with `BUILD_DASHBOARD_OUT`'s redirect behaviour surviving. Then slice 4 (StaticRenderer / Publisher).
