### PR TITLE
decisions: an empty calibration population is a report, not a crash (#309)

### DIFF
--- a/scripts/data/decision_v2.py
+++ b/scripts/data/decision_v2.py
@@ -1654,8 +1654,15 @@ def compute_metrics(decisions: list[dict], window_days: int = 30) -> dict:
         cr = [r for r in rows if _float(r.get("confidence")) is not None
               and (r.get("evaluation") or {}).get("outcome") in ("win", "loss", "flat")]
         if not cr:
-            return {"n": 0, "brier": None, "baseline_loo": None, "base_rate": None,
-                    "mean_confidence": None, "beats_baseline": None, "high_confidence": None}
+            # Same key set as the populated branch below — the caller reads every
+            # baseline unconditionally, so a branch that drops one aborts the whole
+            # dashboard build rather than degrading a card (#309). An empty
+            # population is not an error: a fresh workspace, or a window in which
+            # nothing settled, has no Brier score to report and says so with None.
+            return {"n": 0, "brier": None, "baseline_loo": None,
+                    "baseline_constant": None, "baseline_coinflip": None,
+                    "base_rate": None, "mean_confidence": None,
+                    "beats_baseline": None, "high_confidence": None}
         ys = [1 if (r.get("evaluation") or {}).get("outcome") == "win" else 0 for r in cr]
         ps = [float(r["confidence"]) for r in cr]
         n = len(ys)

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -707,3 +707,35 @@ class ExecutionCoverageTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class EmptyCalibrationPopulation(unittest.TestCase):
+    """#309: a ledger with nothing scored must not abort the dashboard build.
+
+    `compute_metrics` reads every Brier baseline unconditionally, and
+    `build_dashboard.build_projection` calls it outside any per-card try — so a
+    calibration branch that returns fewer keys than its sibling takes down the
+    whole build, not one card. A fresh workspace and any window in which nothing
+    settled both land on that branch.
+
+    These two cases are the guard: a baseline added to the populated branch and
+    read by `compute_metrics`, but forgotten in the empty branch, raises KeyError
+    here. Comparing the two branches' key sets directly is not possible — `_calib`
+    is nested, and `compute_metrics` re-projects explicit field names, so an
+    unused extra key is invisible (and harmless).
+    """
+
+    def test_an_empty_ledger_reports_no_calibration_instead_of_raising(self):
+        metrics = dv2.compute_metrics([])
+
+        self.assertIsNone(metrics["brier"])
+        self.assertIsNone(metrics["brier_baseline_constant"])
+        self.assertIsNone(metrics["brier_baseline_coinflip"])
+        self.assertEqual(metrics["settled_episodes"], 0)
+
+    def test_an_unsettled_ledger_reports_no_calibration_instead_of_raising(self):
+        today = date.today().isoformat()
+        unsettled = decision(today)
+        unsettled["evaluation"] = {}
+
+        self.assertIsNone(dv2.compute_metrics([unsettled])["brier"])


### PR DESCRIPTION
Fixes #309.

## The defect

`_calib()`'s empty-population early return omitted `baseline_constant` and `baseline_coinflip`; `compute_metrics` reads both unconditionally. Any ledger with nothing scored raised `KeyError`.

`build_dashboard.build_projection` calls `compute_metrics` **outside any per-card `try`**, so this aborted the whole dashboard build rather than degrading one card. It never fires on this workspace — 584 decisions, 89 settled episodes in window — and fires immediately on a fresh one.

## How it surfaced

Building #262's acceptance criterion 1 end to end for the first time: a fully synthetic workspace whose books are `jp_stocks` / `eu_stocks`, pointed at with `CLAWOCK_WORKSPACE`.

Every part of the projection handled the unfamiliar legs. **This** is what stopped the build. With it fixed, that workspace produces all four payloads:

```
totals:                 ['jp', 'eu']        jp fields: value_jpy, cost_jpy, …, cash_jpy
realized_vs_unrealized: ['jp', 'eu', 'combined_jpy']
drawdown:               [max_pct_30d_eu, max_pct_30d_jp, current_pct_eu, current_pct_jp,
                         jp, eu, combined, profit, basis]   combined.currency == 'EUR'
overview_equity rows:   date, jp_asof, eu_asof, jp_equity, eu_equity, jp_profit, eu_profit, …
```

## The fix

Both branches return the same key set, all `None`. An empty population is not an error — a fresh workspace, or a window in which nothing settled, has no Brier score to report and now says so.

## Verification

- The live ledger's `decision_metrics` is **byte-identical** to master's (`settled_episodes=89`, `brier=0.3255`), checked by importing master's `decision_v2` alongside this one and comparing the serialized metrics.
- The synthetic workspace builds all four payloads, exit 0.
- `1569 passed, 4 xfailed`.

## On the issue's third acceptance item

> a test pins that the two `_calib` return branches carry the **same key set**

I wrote that test, then deleted it, because it does not work and I could prove it does not: `_calib` is nested inside `compute_metrics`, and `compute_metrics` re-projects **explicit** field names into its output. A key present in only one branch is invisible unless something reads it. Mutating the code to add a key to one branch alone left the test green.

The two empty-ledger tests are the real guard, and are mutation-verified: restoring the short return makes both fail with the original `KeyError`. That is also the exact production failure mode — a baseline that is *read* going missing — so the protection the acceptance item wanted is there; the key-set comparison just was not the thing providing it.
