### PR TITLE
dashboard: the output directory is a parameter, completing slice 3 (#262)

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -2452,7 +2452,48 @@ def parse_args(argv=None):
         help='build from the workspace alone; no output may come from a '
              'previously published file. This is the default — pass it to state '
              'the guarantee explicitly')
+    parser.add_argument(
+        '--out-dir', metavar='DIR', default=None,
+        help='write the four outputs of this generation into DIR instead of the '
+             'published location. Beats the BUILD_DASHBOARD_OUT / '
+             'DECISION_AUDIT_OUT / SHADOW_PORTFOLIO_OUT redirects')
     return parser.parse_args(argv)
+
+
+def resolve_output_paths(out_dir=None):
+    """The four files one generation lands in, keyed by payload name.
+
+    Precedence: an explicit `--out-dir` beats the per-file environment redirects,
+    which beat the published locations. Explicit beats ambient — a caller that
+    named a directory should not have an inherited env var silently move one of
+    the four files out of it and split the generation across two places.
+
+    The env vars stay because they are what system_check's buildability gate and
+    the Actions validation jobs already use. `--out-dir` is the form a caller
+    outside this repository wants, and is what makes a projection buildable
+    anywhere (#262 slice 3 step 4).
+
+    Note the old `OVERVIEW_FILE if out_file == OUT_FILE else …` conditional is
+    gone: `OVERVIEW_FILE` is `OUT_FILE.parent / 'overview.json'`, so both arms
+    always produced the same path.
+    """
+    if out_dir:
+        directory = Path(out_dir)
+        return {
+            'overview': directory / OVERVIEW_FILE.name,
+            'dashboard': directory / OUT_FILE.name,
+            'audit': directory / AUDIT_FILE.name,
+            'shadow': directory / 'shadow_portfolio.json',
+        }
+    out_file = Path(os.environ.get('BUILD_DASHBOARD_OUT') or OUT_FILE)
+    return {
+        'overview': out_file.parent / OVERVIEW_FILE.name,
+        'dashboard': out_file,
+        'audit': Path(os.environ.get('DECISION_AUDIT_OUT')
+                      or (out_file.parent / AUDIT_FILE.name)),
+        'shadow': Path(os.environ.get('SHADOW_PORTFOLIO_OUT')
+                       or (out_file.parent / 'shadow_portfolio.json')),
+    }
 
 
 def resolve_previous_source(args):
@@ -2977,17 +3018,13 @@ def main(argv=None):
     # `--previous` names, so the redirect never changes which cards are restored.
     args = parse_args(argv)
     previous_source = resolve_previous_source(args)
-    out_file = Path(os.environ.get('BUILD_DASHBOARD_OUT') or OUT_FILE)
-    out_file.parent.mkdir(parents=True, exist_ok=True)
     # The four outputs are one logical generation (dashboard_outputs.py owns that
     # contract). Their paths are resolved together, here, so that the projection
     # never learns where it is going to land.
-    overview_file = (
-        OVERVIEW_FILE if out_file == OUT_FILE else out_file.parent / 'overview.json')
-    audit_file = Path(os.environ.get('DECISION_AUDIT_OUT')
-                      or (out_file.parent / AUDIT_FILE.name))
-    shadow_file = Path(os.environ.get('SHADOW_PORTFOLIO_OUT')
-                       or (out_file.parent / 'shadow_portfolio.json'))
+    paths = resolve_output_paths(args.out_dir)
+    out_file, overview_file = paths['dashboard'], paths['overview']
+    audit_file, shadow_file = paths['audit'], paths['shadow']
+    out_file.parent.mkdir(parents=True, exist_ok=True)
 
     try:
         projection = build_projection(

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -1255,3 +1255,43 @@ def test_the_legacy_drawdown_keys_keep_their_quote_leg_first_order():
         "max_pct_30d_eu", "max_pct_30d_jp", "current_pct_eu", "current_pct_jp",
     ]
     assert keys[4:6] == ["jp", "eu"], "the per-leg block stays in ledger order"
+
+
+def test_an_explicit_out_dir_keeps_the_generation_together(monkeypatch, tmp_path):
+    """#262 slice 3 step 4. The four outputs are one generation, so the thing
+    that can actually break here is not "does --out-dir work" but "can a stray
+    environment variable move one of the four somewhere else".
+
+    The env redirects are inherited from whatever invoked the build —
+    system_check sets one, the Actions validation jobs set others — so a caller
+    that named a directory must win over all of them.
+    """
+    monkeypatch.setenv("BUILD_DASHBOARD_OUT", str(tmp_path / "env" / "dashboard.json"))
+    monkeypatch.setenv("DECISION_AUDIT_OUT", str(tmp_path / "env" / "decision_audit.json"))
+    monkeypatch.setenv("SHADOW_PORTFOLIO_OUT", str(tmp_path / "env" / "shadow.json"))
+
+    paths = dashboard.resolve_output_paths(tmp_path / "cli")
+
+    assert set(paths) == {"overview", "dashboard", "audit", "shadow"}
+    assert {p.parent for p in paths.values()} == {tmp_path / "cli"}, (
+        "an inherited redirect must not split one generation across two directories")
+    assert sorted(p.name for p in paths.values()) == [
+        "dashboard.json", "decision_audit.json", "overview.json", "shadow_portfolio.json",
+    ]
+
+
+def test_without_an_out_dir_the_environment_redirects_still_hold(monkeypatch, tmp_path):
+    """system_check's buildability gate redirects the write target so a *check*
+    never mutates the published artifact. That behaviour predates --out-dir and
+    has to survive it."""
+    monkeypatch.setenv("BUILD_DASHBOARD_OUT", str(tmp_path / "check.json"))
+    monkeypatch.delenv("DECISION_AUDIT_OUT", raising=False)
+    monkeypatch.delenv("SHADOW_PORTFOLIO_OUT", raising=False)
+
+    paths = dashboard.resolve_output_paths()
+
+    assert paths["dashboard"] == tmp_path / "check.json"
+    assert paths["overview"] == tmp_path / "overview.json", (
+        "the siblings follow the redirected target, not the published directory")
+    assert paths["audit"].parent == tmp_path
+    assert paths["shadow"].parent == tmp_path


### PR DESCRIPTION
Slice 3 **step 4** — "Output directory as a parameter, so the projection can be built anywhere. `BUILD_DASHBOARD_OUT` already redirects the write target and its behaviour must survive."

This completes slice 3.

## The change

`main()` resolved four paths inline from three environment variables. There was no way to ask for a generation somewhere else without setting all of them — and setting only *some* split one generation across two directories.

`resolve_output_paths(out_dir=None)` returns the four files keyed by payload. `--out-dir DIR` puts all four in `DIR`. The environment redirects stay — `system_check`'s buildability gate and the Actions validation jobs already use them — and still apply when no directory is named.

## Explicit beats ambient, and that is the part worth a test

`--out-dir` **overrides** the env vars rather than merging with them.

The env redirects are inherited from whatever invoked the build. A caller that named a directory should not have a `BUILD_DASHBOARD_OUT` set two layers up silently move one of the four files out of it — that is not a wrong path, it is a **split generation**, which is the thing #308 just spent a PR making impossible at the write layer.

## Dead conditional removed

```python
OVERVIEW_FILE if out_file == OUT_FILE else out_file.parent / 'overview.json'
```

`OVERVIEW_FILE` **is** `OUT_FILE.parent / 'overview.json'`, so both arms always produced the same path.

## Verification

Against the live workspace:

- back to back with `origin/master`'s builder: four outputs, zero differences excluding build-clock fields, identical key order;
- `--out-dir` lands all four in a fresh directory;
- a bare `BUILD_DASHBOARD_OUT` build still redirects all four exactly as before;
- with **both** set, the env location stays empty.

`1571 passed, 4 xfailed`, tree clean.

## Tests

Two, both mutation-verified:

- `test_an_explicit_out_dir_keeps_the_generation_together` — verified by letting `SHADOW_PORTFOLIO_OUT` pull the shadow sidecar back out of the named directory.
- `test_without_an_out_dir_the_environment_redirects_still_hold` — verified by ignoring `BUILD_DASHBOARD_OUT`, which is the regression that would make every pre-push check dirty the working tree again (the 2026-06-10 bug).

## Where slice 3 stands after this

All four steps are in: compute split from IO (#304), leg shape from the ledger (#305/#306/#307), one write set (#308), output directory a parameter (this).

Acceptance criterion 1 is proven end to end, not just at the function level: a synthetic workspace whose books are `jp_stocks`/`eu_stocks`, reached with `CLAWOCK_WORKSPACE`, produces all four payloads keyed `jp`/`eu` with `combined_jpy` and `drawdown.combined.currency == 'EUR'`. Getting there also turned up #309 — an empty decision ledger aborted the whole build — fixed in #310.

Next is slice 4: `StaticRenderer` consuming only the projection directory, and `Publisher` defaulting to the filesystem.
