### PR TITLE
dashboard: the semantic-diff baseline is a parameter, not this repository (#262)

### DIFF
--- a/scripts/data/dashboard_outputs.py
+++ b/scripts/data/dashboard_outputs.py
@@ -141,40 +141,92 @@ def semantic_value(path: str, value):
     return value
 
 
-def _head_json(root: Path, path: str):
-    raw = subprocess.check_output(
-        ["git", "-C", str(root), "show", f"HEAD:{path}"],
-        text=True,
-        stderr=subprocess.DEVNULL,
-    )
-    return json.loads(raw)
+class GitBaseline:
+    """The generation currently committed at `rev`, and this repository's worktree.
+
+    This is what the semantic diff has always compared against, now named so it
+    can be replaced. `restore` is the part that is genuinely git-specific: it
+    un-dirties the working tree after a rebuild that changed only build clocks,
+    which only means anything where the outputs are tracked files.
+    """
+
+    name = "git"
+
+    def __init__(self, root: Path | str = ROOT, rev: str = "HEAD") -> None:
+        self.root = Path(root)
+        self.rev = rev
+
+    def load(self, path: str):
+        raw = subprocess.check_output(
+            ["git", "-C", str(self.root), "show", f"{self.rev}:{path}"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return json.loads(raw)
+
+    def restore(self, root: Path, path: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(root), "restore", f"--source={self.rev}",
+             "--worktree", "--", path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
 
-def _restore_head_worktree(root: Path, path: str):
-    subprocess.run(
-        ["git", "-C", str(root), "restore", "--source=HEAD", "--worktree", "--", path],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+class DirectoryBaseline:
+    """The generation as last published into a directory. No git, no worktree.
+
+    What a filesystem publisher compares against once the outputs stop being
+    repository history (#262). `restore` copies the previous bytes back over a
+    clock-only rebuild, which is the same guarantee `git restore` gives — the
+    publisher must not ship a file whose only change is when it was built.
+    """
+
+    name = "directory"
+
+    def __init__(self, directory: Path | str) -> None:
+        self.directory = Path(directory)
+
+    def _file(self, path: str) -> Path:
+        # Outputs are named by their workspace-relative path; a published
+        # directory holds them flat, by basename.
+        return self.directory / Path(path).name
+
+    def load(self, path: str):
+        return json.loads(self._file(path).read_text(encoding="utf-8"))
+
+    def restore(self, root: Path, path: str) -> None:
+        (Path(root) / path).write_text(
+            self._file(path).read_text(encoding="utf-8"), encoding="utf-8")
 
 
-def semantic_changed_paths(root: Path | str = ROOT, *, restore_clock_only=True):
-    """Return generated outputs whose public meaning differs from ``HEAD``.
+def semantic_changed_paths(root: Path | str = ROOT, *, restore_clock_only=True,
+                           baseline=None):
+    """Return generated outputs whose public meaning differs from the baseline.
 
-    Clock-only rebuilds are restored to ``HEAD`` by default.  Missing/untracked
-    outputs, invalid JSON, or a missing ``HEAD`` version are conservatively
-    treated as real changes so they cannot disappear from publication.
-    Generation-linked outputs are decided as a group, so a projection is never
-    restored while the payload it is stamped from gets published.
+    The baseline is what the last published generation was — `GitBaseline(root)`
+    by default, which is this repository's ``HEAD`` and the behaviour every
+    caller has today. It is a parameter because the outputs are on their way out
+    of repository history (#262): once they are published to a directory or an
+    object store, "what did we publish last time" stops being a git question,
+    and this helper is the one place that assumed otherwise.
+
+    Clock-only rebuilds are restored from the baseline by default. Missing
+    outputs, invalid JSON, or a baseline that has no version of a file are
+    conservatively treated as real changes so they cannot disappear from
+    publication. Generation-linked outputs are decided as a group, so a
+    projection is never restored while the payload it is stamped from gets
+    published.
     """
     root = Path(root)
+    baseline = baseline if baseline is not None else GitBaseline(root)
     changed = set()
     clock_only = set()
     for path in DASHBOARD_OUTPUTS:
         try:
             current = json.loads((root / path).read_text(encoding="utf-8"))
-            previous = _head_json(root, path)
+            previous = baseline.load(path)
         except (FileNotFoundError, json.JSONDecodeError, subprocess.SubprocessError):
             changed.add(path)
             continue
@@ -191,7 +243,7 @@ def semantic_changed_paths(root: Path | str = ROOT, *, restore_clock_only=True):
     if restore_clock_only:
         for path in DASHBOARD_OUTPUTS:
             if path in clock_only:
-                _restore_head_worktree(root, path)
+                baseline.restore(root, path)
     return [path for path in DASHBOARD_OUTPUTS if path in changed]
 
 

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -223,3 +223,70 @@ def test_a_complete_write_set_swaps_every_file(tmp_path):
     assert (tmp_path / "overview.json").read_text(encoding="utf-8") == "A"
     assert (tmp_path / "nested" / "shadow_portfolio.json").read_text(encoding="utf-8") == "B"
     assert not list(tmp_path.glob(".staged-*"))
+
+
+def _generation(directory, *, clock, value):
+    """One generation of the four outputs, each stamped with its own clock field.
+
+    overview/dashboard carry `generated_at`; the two sidecars carry `as_of`.
+    Using one field for all four would make the sidecars look semantically
+    changed and quietly stop the test from exercising the clock-only path.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    # `generation_id` is stripped for overview.json only — dashboard.json does
+    # not carry it in the clock-field set, so putting it there would read as a
+    # semantic change.
+    (directory / "overview.json").write_text(
+        json.dumps({"generated_at": clock, "generation_id": clock, "totals": value}),
+        encoding="utf-8")
+    (directory / "dashboard.json").write_text(
+        json.dumps({"generated_at": clock, "totals": value}), encoding="utf-8")
+    for name in ("decision_audit.json", "shadow_portfolio.json"):
+        (directory / name).write_text(
+            json.dumps({"as_of": clock, "totals": value}), encoding="utf-8")
+
+
+def test_the_diff_baseline_can_be_a_directory_instead_of_this_repository(tmp_path):
+    """#262: the outputs are on their way out of repository history, so "what did
+    we publish last time" stops being a git question. This helper was the one
+    place that assumed otherwise."""
+    published = tmp_path / "published"
+    _generation(published, clock="2026-08-05T00:00:00Z", value=1)
+    worktree = tmp_path / "worktree" / "assets" / "data"
+    _generation(worktree, clock="2026-08-05T03:00:00Z", value=1)
+    # Exactly one output genuinely changed. Asserting the precise subset is what
+    # makes this test mean anything: `tmp_path` is not a git repository, so the
+    # default GitBaseline cannot read any previous version and conservatively
+    # reports ALL FOUR as changed. A test that expected "everything" would pass
+    # with the baseline argument ignored entirely.
+    (worktree / "dashboard.json").write_text(
+        json.dumps({"generated_at": "2026-08-05T03:00:00Z", "totals": 2}),
+        encoding="utf-8")
+
+    changed = dashboard_outputs.semantic_changed_paths(
+        tmp_path / "worktree", restore_clock_only=False,
+        baseline=dashboard_outputs.DirectoryBaseline(published))
+
+    assert changed == ["assets/data/overview.json", "assets/data/dashboard.json"], (
+        "only the changed payload and its generation-linked projection publish, "
+        "decided with no git involved")
+
+
+def test_a_clock_only_rebuild_is_restored_from_whatever_the_baseline_is(tmp_path):
+    """The restore is what keeps a publisher from shipping a file whose only
+    change is when it was built. A directory baseline has to give the same
+    guarantee `git restore` does, or moving the data plane reintroduces the
+    no-op publish this contract exists to stop."""
+    published = tmp_path / "published"
+    _generation(published, clock="2026-08-05T00:00:00Z", value=1)
+    root = tmp_path / "worktree"
+    _generation(root / "assets" / "data", clock="2026-08-05T03:00:00Z", value=1)
+
+    changed = dashboard_outputs.semantic_changed_paths(
+        root, baseline=dashboard_outputs.DirectoryBaseline(published))
+
+    assert changed == []
+    restored = json.loads(
+        (root / "assets" / "data" / "dashboard.json").read_text(encoding="utf-8"))
+    assert restored["generated_at"] == "2026-08-05T00:00:00Z", (
+        "the clock-only rebuild must be rolled back, not left dirty")


### PR DESCRIPTION
The third of the four prerequisites #262 lists for moving the data plane off `master`.

> the semantic-diff target becomes a parameter rather than `HEAD` of this repository

## What reached git

`semantic_changed_paths` did it twice:

- `git show HEAD:<path>` — the previous generation, i.e. the comparison baseline;
- `git restore --source=HEAD --worktree` — rolling back a rebuild that changed only build clocks.

Both are now behind a baseline object:

| | |
|---|---|
| `GitBaseline(root, rev="HEAD")` | what every caller gets today, unchanged |
| `DirectoryBaseline(directory)` | the last generation as published into a directory — no git, no worktree |

## The restore matters as much as the read

It is easy to treat `git restore` as an implementation detail of "we happen to use git". It is not: it is what stops a publisher shipping a file whose **only** change is when it was built. A directory baseline has to give the same guarantee, or moving the data plane quietly reintroduces the no-op publish this whole contract exists to prevent. `DirectoryBaseline.restore` copies the previous bytes back, and a test pins it.

## The first test was worthless and I had to rewrite it

The obvious version put a changed value in the worktree and asserted all four outputs were reported as changed.

That passes with the `baseline` argument **ignored entirely**. `tmp_path` is not a git repository, so the default `GitBaseline` cannot read any previous version, and the conservative branch reports all four as changed. Same answer, completely different reason. I only found it by mutating `baseline = baseline if … else GitBaseline(root)` down to `baseline = GitBaseline(root)` and watching the test stay green.

It now changes **exactly one** output and asserts the precise subset — `["overview.json", "dashboard.json"]`, the changed payload plus its generation-linked projection. Only the directory baseline can produce that; the git default still reports all four, and the mutation now fails.

## Verification

- Live path unchanged: the default baseline is still this repository at `HEAD`, and `dashboard_outputs.py --root /root/.openclaw/workspace --keep-clock-only` reports the same empty set as before.
- `1573 passed, 4 xfailed`, tree clean.

Both tests mutation-verified: one against ignoring the baseline argument, one against making `DirectoryBaseline.restore` a no-op.

## Where this leaves the prerequisites

From #262's own list, before any output leaves `master`:

1. ~~the builder must not read its own published output by default~~ — #303
2. `cron_health_check` moves onto the run-history provider — **not done**
3. ~~the semantic-diff target becomes a parameter~~ — this PR
4. the four Actions-written sidecars get an explicit decision — **not done, and it is a decision, not code**

On (2): it is worth flagging that run history and commit counting answer **different questions** — "did the job run" versus "did the job produce". A run that finishes clean but writes nothing counts as healthy under the first and missing under the second, and per the cron-review notes a cron status can itself be falsely red. That one should land as an advisory second signal first, measured for agreement, rather than a straight swap of the evidence a live alerting path depends on.
