### PR TITLE
cron health: the run-history provider becomes a second, advisory signal (#262)

### DIFF
--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -33,6 +33,13 @@ from zoneinfo import ZoneInfo
 from workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
+# The checkout root, so `clawock` is importable regardless of where the WORKSPACE
+# points. WS can be redirected with CLAWOCK_WORKSPACE and is a data directory;
+# the package lives in the checkout. Inserting it here rather than inside the
+# function is what test_harness_import_independence requires — an import that
+# resolves only because some other module happened to widen sys.path first is a
+# side effect, not a dependency (#265).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
 import cron_token_audit  # noqa: E402
 
@@ -121,6 +128,47 @@ def parse_cron_slots(expr, tz_name, target_date_utc):
         return []
 
     return [f"{h:02d}:{m:02d}" for h in hours for m in mins]
+
+
+def runs_finished_today(job_id, provider=None):
+    """How many times the job finished OK today, per the run-history provider.
+
+    ADVISORY ONLY. It answers a different question from counting commits — "did
+    the job run" rather than "did the job produce" — and the two can legitimately
+    disagree: a run that finishes clean but writes nothing is healthy here and
+    missing there, and a cron status can itself be falsely red when a mid-run
+    failure gets recovered (see the 2026-07-22 false-red postmortem).
+
+    Migrating this check onto the provider is a prerequisite of moving the
+    outputs off `master`, because today the commit IS the receipt (#262). But a
+    straight swap would silently change what a live alerting path means, so this
+    is reported beside the commit count and measured for agreement first.
+
+    Never raises and never influences status: an advisory signal that can fail
+    the health check is worse than no advisory signal.
+    """
+    if not job_id:
+        return None
+    try:
+        if provider is None:
+            from clawock.providers.runs import OpenClawRuns
+            provider = OpenClawRuns()
+        today = datetime.now(HKT).date()
+        count = 0
+        for run in provider.history(job_id, limit=200):
+            if run.status != 'ok' or not run.started_at:
+                continue
+            try:
+                started = datetime.fromisoformat(run.started_at)
+            except ValueError:
+                continue
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            if started.astimezone(HKT).date() == today:
+                count += 1
+        return count
+    except Exception:
+        return None
 
 
 def commit_count_today(commit_pattern):
@@ -346,6 +394,8 @@ def main():
         expected_past = [s for s in expected if s <= now_local]
         commit_pat = COMMIT_PATTERNS.get(name)
         commit_n = commit_count_today(commit_pat)
+        # Advisory second evidence source (#262). Reported, never acted on.
+        runs_n = runs_finished_today(job.get('id'))
 
         # Holiday gate: don't expect a commit from a 港股*/美股* report on that market's
         # holiday — preflight skips the run by design (the 6-19 端午+Juneteenth double
@@ -407,6 +457,12 @@ def main():
             'tz': tz,
             'expected_today': len(expected_past),
             'commits_today': commit_n,
+            # `runs_today` is the run-history provider's answer and is advisory:
+            # it is here to be compared with `commits_today` over time, not to
+            # decide anything. `None` = the provider had nothing to say.
+            'runs_today': runs_n,
+            'runs_agree': (None if runs_n is None or commit_n is None
+                           else runs_n == commit_n),
             'status': status,
             'detail': detail,
         })

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -1,0 +1,56 @@
+"""Cron health: what counts as evidence that a scheduled job did its work."""
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "data"))
+
+import cron_health_check  # noqa: E402
+
+HKT = ZoneInfo("Asia/Hong_Kong")
+
+
+class _Runs:
+    def __init__(self, runs):
+        self._runs = runs
+
+    def history(self, job, limit=20):
+        return self._runs
+
+
+def _run(status, when):
+    return SimpleNamespace(status=status, started_at=when.isoformat())
+
+
+def test_the_run_provider_is_advisory_and_can_never_fail_the_check():
+    """#262 prerequisite. Today the commit IS the receipt, so moving the outputs
+    off master makes every job with a commit contract report a false miss.
+
+    The provider answers a DIFFERENT question though — "did the job run", not
+    "did the job produce" — so it lands as a second signal to be compared before
+    anything depends on it. An advisory signal that can break the health check is
+    worse than no advisory signal.
+    """
+    class Exploding:
+        def history(self, job, limit=20):
+            raise RuntimeError("provider down")
+
+    assert cron_health_check.runs_finished_today("job", Exploding()) is None
+    assert cron_health_check.runs_finished_today(None) is None, (
+        "a job with no id has no provider evidence, which is not the same as zero")
+
+
+def test_only_todays_finished_runs_count_as_evidence():
+    today = datetime.now(HKT)
+    provider = _Runs([
+        _run("ok", today),
+        _run("ok", today),
+        _run("error", today),                      # ran, did not succeed
+        _run("running", today),                    # not finished
+        _run("ok", today - timedelta(days=1)),     # yesterday is not today's evidence
+    ])
+
+    assert cron_health_check.runs_finished_today("job", provider) == 2


### PR DESCRIPTION
The second of #262's four prerequisites for moving the data plane off `master`.

> `cron_health_check.commit_count_today()` counts commits whose subject matches a per-job pattern to decide whether a scheduled job produced its output today. **It treats a generated commit on `master` as the receipt.** Move the outputs and every job whose evidence is a commit reports a false miss.

## This does not swap the evidence, and that is deliberate

The issue calls migrating this onto the run-history provider a prerequisite. It is — but the two answer **different questions**:

| | asks | a clean run that writes nothing | a mid-run failure that got recovered |
|---|---|---|---|
| `commits_today` | did the job **produce** | missing | ok |
| `runs_today` | did the job **run** | ok | possibly error |

Both readings are defensible; they are not interchangeable. Swapping outright would silently change what a live alerting path means, and per the cron-review notes a cron status can itself be falsely red.

So this lands as a **second signal to be compared**. `runs_today` and `runs_agree` sit beside `commits_today` in every report entry, and **nothing reads them** — `runs_finished_today` never raises, and never touches `status`, `has_missing` or `has_warn`. An advisory signal that can break the health check is worse than no advisory signal.

## First live reading

Run on the host, against the real run store:

```
job                        exp commits  runs  agree  status
盘中盯盘                      4    None     3   None  running
港股午盘报告/午后/收盘            0       0     0   True  idle
美股开盘报告                    0       0     0   True  idle
美股盘中盯盘                    0    None     0   None  idle
美股盘中盯盘-overnight          6    None     6   None  ok-heartbeat
Memory Dreaming Promotion   1    None     1   None  ok-no-track
美股收盘报告                    1       1     1   True  ok
盘前深度简报                    1       1     1   True  ok
港股开盘报告                    1       1     1   True  ok

一致 7 · 不一致 0 · 无可比 4
```

**7 agree, 0 disagree.** The four "not comparable" are exactly the jobs with `COMMIT_PATTERNS[name] = None` — the two intraday modes, the overnight mode, and dreaming — where the provider supplies evidence the commit path never had at all.

That is the reading that should decide the swap, after it has been watched for more than one day.

## The import goes through the checkout root, not `WS`

`WS` is a data directory and can be redirected with `CLAWOCK_WORKSPACE`; the `clawock` package lives in the **checkout**. My first version inserted `WS` on `sys.path` inside the function, and `test_harness_import_independence` failed it — that is precisely the side-effect import #265 removed, and the distinction #269 is about. Now a module-level insert of `parents[2]`, matching `_watchdog_common`.

## Tests

Two, both mutation-verified:

- `test_the_run_provider_is_advisory_and_can_never_fail_the_check` — verified by narrowing the `except` so the provider's exception escapes.
- `test_only_todays_finished_runs_count_as_evidence` — verified by dropping the status filter, so failed and still-running runs would count.

`1573 passed, 4 xfailed`; live host re-run clean, working tree untouched.

## What is left before outputs can leave `master`

1. ~~builder must not read its own published output by default~~ — #303
2. `cron_health_check` — this PR is the **measurement**, not the migration. The swap is a follow-up once the agreement reading holds over several days.
3. ~~semantic-diff target becomes a parameter~~ — #312
4. the four Actions-written sidecars get an explicit decision — a decision for kcn, not code.
