### PR TITLE
publish: an artifact store, so a generation can go somewhere other than the worktree it was built in (#314)

### DIFF
--- a/clawock/publish/__init__.py
+++ b/clawock/publish/__init__.py
@@ -1,0 +1,27 @@
+"""Where a generation of build outputs is stored — separately from how it is built.
+
+`build_dashboard.py` writes four files that are one logical generation (#308).
+Where that generation *went* was never a decision: it went into the worktree it
+was built in, and got committed, which is why 71% of the commits on `master`
+are `dashboard:` publishes (#314).
+
+This package is the missing seam. A store answers "put this generation
+somewhere"; it does not build it, render it, or deploy a site. Git is
+simultaneously audit log, concurrency protocol, state replication, auth boundary
+and Pages trigger (#203) — a store that also triggered a deploy would fuse two of
+those into one thing that can only be replaced as a unit.
+"""
+from __future__ import annotations
+
+from clawock.publish.store import (  # noqa: F401
+    ArtifactStore,
+    FilesystemStore,
+    GitBranchStore,
+    PublishResult,
+    write_generation,
+)
+
+__all__ = [
+    "ArtifactStore", "FilesystemStore", "GitBranchStore", "PublishResult",
+    "write_generation",
+]

--- a/clawock/publish/store.py
+++ b/clawock/publish/store.py
@@ -1,0 +1,316 @@
+"""Artifact stores: a generation of files, put somewhere, as one write set.
+
+Two implementations, and the difference between them is the whole point of the
+seam:
+
+* `FilesystemStore` — the default, and the only thing a third party gets without
+  configuring anything. Writing the files where they were built is a store, not
+  the absence of one; a clawock that defaults to pushing somewhere would be
+  wrong.
+* `GitBranchStore` — one instance configuration. An orphan, force-updated ref in
+  a repository, built entirely with plumbing so it never touches the caller's
+  index or worktree. That constraint is not stylistic: the live publisher runs
+  inside the workspace checkout, which must stay on `master` and keeps a dirty
+  tree of other in-flight files while it publishes.
+
+Neither store deploys anything, and neither decides *what* a generation is.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Protocol
+
+
+def write_generation(writes: Mapping[str, str]) -> list[str]:
+    """Publish files as ONE write set: stage every file, then swap.
+
+    `writes` maps path -> already-serialized text. `os.replace` is atomic per
+    file, so no single output can be torn — but four sequential writes are not
+    atomic ACROSS files: a failure on the third leaves two files from the new
+    generation beside two from the old, and every consumer of a dashboard
+    generation (the browser, the semantic diff, the publication pathspec) treats
+    them as one thing.
+
+    Staging every file first shrinks the window from "serialize + write + fsync,
+    four times" down to the `os.replace` calls themselves, and converts the
+    common failures — a full disk, a read-only mount, an unwritable directory —
+    from "publish a mixed generation" into "publish nothing and raise".
+
+    Targets are checked before anything is staged, because a target that cannot
+    be replaced at all (one that is a directory) would otherwise fail in the swap
+    loop, i.e. after earlier files had already been published — the exact outcome
+    this exists to prevent.
+
+    What remains is genuinely irreducible: the swap loop itself. If the directory
+    is removed between staging and replacing, some files can land and others not.
+    Files cannot be swapped atomically as a group without a transactional
+    filesystem; this narrows the window to consecutive `os.replace` calls rather
+    than closing it, and the payloads carry generation IDs so a reader can still
+    tell.
+
+    Returns the paths written, in the order given.
+    """
+    for path in map(Path, writes):
+        if path.is_dir():
+            raise IsADirectoryError(
+                f"{path} is a directory; the write set cannot be swapped in")
+    staged: list[tuple[str, Path]] = []
+    try:
+        for raw, text in writes.items():
+            path = Path(raw)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".staged-")
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            staged.append((tmp, path))
+    except BaseException:
+        for tmp, _ in staged:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+        raise
+    # Every byte is on disk; only the swaps remain.
+    for tmp, path in staged:
+        os.replace(tmp, path)
+    return [str(path) for _, path in staged]
+
+
+def _check_names(files: Mapping[str, str]) -> None:
+    """Reject a write set that cannot be stored as a self-contained generation.
+
+    An empty mapping is refused rather than treated as "nothing to do": for a
+    store that replaces its whole state — `GitBranchStore` does — publishing
+    zero files means publishing an empty generation over a good one.
+    """
+    if not files:
+        raise ValueError("refusing to publish an empty generation")
+    for name in files:
+        path = Path(name)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(
+                f"generation member must be a relative path inside the store: {name!r}")
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """What the store holds now, and whether this call is what put it there.
+
+    `changed` is not decoration. A publisher has to answer "did anything move?"
+    to decide whether to ask for a deploy, and a store that always claimed yes
+    would make every tick request one. It is also the honest answer to the
+    reverse question: a store already holding this exact generation was not
+    written to.
+    """
+
+    receipt: str
+    changed: bool
+
+
+class ArtifactStore(Protocol):
+    """Somewhere a generation can be put, addressed by relative path."""
+
+    name: str
+
+    def publish(self, files: Mapping[str, str], *, label: str = "") -> PublishResult:
+        """Store `files` (relative path -> text) as one generation.
+
+        Idempotent: storing a generation the store already holds is a no-op that
+        reports `changed=False`, not a second write of the same bytes. `label` is
+        a human description of the generation; a store with nowhere to put one is
+        free to ignore it.
+        """
+
+
+class FilesystemStore:
+    """A directory. The default, and what publishing means with no remote.
+
+    `label` is dropped: a directory has nowhere to record why a generation was
+    written. The payloads carry their own generation IDs, so nothing is lost that
+    a reader needs.
+    """
+
+    name = "filesystem"
+
+    def __init__(self, directory: Path | str) -> None:
+        self.directory = Path(directory)
+
+    def _current(self, name: str) -> str | None:
+        try:
+            return (self.directory / name).read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    def publish(self, files: Mapping[str, str], *, label: str = "") -> PublishResult:
+        _check_names(files)
+        if all(self._current(name) == text for name, text in files.items()):
+            return PublishResult(str(self.directory), changed=False)
+        write_generation(
+            {str(self.directory / name): text for name, text in files.items()})
+        return PublishResult(str(self.directory), changed=True)
+
+
+class GitBranchStore:
+    """An orphan, force-updated branch: the generation, and nothing else.
+
+    Force-updated because this branch is state, not history. Each publish is a
+    parentless commit whose tree is exactly the generation, so the branch never
+    accumulates the 72 commits/day that put the outputs on `master` in the first
+    place. Nothing rebases onto it and nothing merges it, which is what makes
+    discarding its history safe — and what makes pointing it at a branch someone
+    *does* build on catastrophic, hence `_reject_protected`.
+
+    Everything is built with plumbing (`hash-object`, `update-index` against a
+    throwaway index file, `write-tree`, `commit-tree`), so the caller's index,
+    worktree, HEAD and stash are untouched. The live publisher calls this from
+    inside the workspace checkout while that checkout is on `master` with a dirty
+    tree; a `checkout`/`add`/`commit` implementation would be publishing by
+    disturbing the thing it publishes from.
+    """
+
+    name = "git-branch"
+
+    # Never force-update a branch other refs are built on. `HEAD` is here
+    # because it is accepted where a branch name is expected and would resolve
+    # to whatever the repository is currently on.
+    ALWAYS_PROTECTED = frozenset({"master", "main", "HEAD"})
+
+    def __init__(
+        self,
+        repo: Path | str,
+        branch: str,
+        *,
+        remote: str = "origin",
+        author_name: str | None = None,
+        author_email: str | None = None,
+    ) -> None:
+        self.repo = Path(repo)
+        self.branch = branch
+        self.remote = remote
+        self.author_name = author_name
+        self.author_email = author_email
+
+    # ── git plumbing ────────────────────────────────────────────────────────
+    def _git(self, *args: str, env: dict | None = None, stdin: str | None = None) -> str:
+        identity: list[str] = []
+        if self.author_name:
+            identity += ["-c", f"user.name={self.author_name}"]
+        if self.author_email:
+            identity += ["-c", f"user.email={self.author_email}"]
+        result = subprocess.run(
+            ["git", "-C", str(self.repo), *identity, *args],
+            input=stdin, capture_output=True, text=True, env=env, check=True,
+        )
+        return result.stdout.strip()
+
+    def _default_branch(self) -> str | None:
+        """The remote's own default branch, asked of the remote.
+
+        `refs/remotes/<remote>/HEAD` is a local convenience that plenty of
+        checkouts do not have — a bare local remote, `clone --no-tags`, a remote
+        added by hand, or `remote` given as a bare URL. Falling back to the
+        static `master`/`main` list there would leave a repository whose default
+        is `trunk` unprotected, which is the whole point of asking. `ls-remote`
+        answers over ssh and https alike; the local ref is the fallback, not the
+        source.
+        """
+        try:
+            listing = self._git("ls-remote", "--symref", self.remote, "HEAD")
+        except subprocess.CalledProcessError:
+            listing = ""
+        for line in listing.splitlines():
+            if line.startswith("ref:"):
+                ref = line.split()[1]
+                return ref.removeprefix("refs/heads/")
+        try:
+            ref = self._git(
+                "symbolic-ref", "--short", f"refs/remotes/{self.remote}/HEAD")
+        except subprocess.CalledProcessError:
+            return None
+        return ref.split("/", 1)[1] if "/" in ref else ref
+
+    def _reject_protected(self) -> None:
+        if not self.branch or self.branch.startswith("refs/"):
+            # A fully-qualified ref would be pushed to `refs/heads/refs/heads/…`
+            # rather than the branch the caller meant, so the guard below would
+            # be inspecting a name nothing is published to.
+            raise ValueError(
+                f"expected a branch name, got {self.branch!r}")
+        protected = set(self.ALWAYS_PROTECTED)
+        default = self._default_branch()
+        if default:
+            protected.add(default)
+        if self.branch in protected:
+            raise ValueError(
+                f"refusing to force-update {self.branch!r}: this store replaces "
+                f"the branch's entire history on every publish")
+
+    def _stored_tree(self) -> str | None:
+        """The tree the branch holds right now, or None if it holds nothing.
+
+        Fetched at full depth, which for a parentless branch is one commit — the
+        same cost `--depth=1` would have. `--depth=1` is not merely redundant
+        here, it is harmful: it writes a shallow boundary into the CALLER's
+        repository, and a shallow repository has its pushes rejected ("shallow
+        update not allowed"). The caller is the live workspace checkout, and the
+        push it would break is the one that publishes `master`.
+        """
+        try:
+            self._git("fetch", self.remote, self.branch)
+        except subprocess.CalledProcessError:
+            return None                      # branch does not exist yet
+        try:
+            return self._git("rev-parse", "FETCH_HEAD^{tree}")
+        except subprocess.CalledProcessError:
+            return None
+
+    # ── ArtifactStore ───────────────────────────────────────────────────────
+    def publish(self, files: Mapping[str, str], *, label: str = "",
+                attempts: int = 3) -> PublishResult:
+        _check_names(files)
+        self._reject_protected()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # A scratch index, so `update-index` cannot touch the real one. It
+            # also builds subdirectory trees for us, which hand-rolled `mktree`
+            # would not.
+            env = {**os.environ, "GIT_INDEX_FILE": str(Path(tmp) / "index")}
+            for name, text in sorted(files.items()):
+                blob = self._git("hash-object", "-w", "--stdin", stdin=text)
+                self._git("update-index", "--add",
+                          "--cacheinfo", f"100644,{blob},{name}", env=env)
+            tree = self._git("write-tree", env=env)
+
+        # Compare against what the BRANCH holds, not against what the caller
+        # thinks changed. Those are different questions, and the difference is
+        # the only thing that makes a failed publish self-healing: a caller that
+        # skipped this tick because "nothing changed locally" would never notice
+        # that last tick's generation never arrived, and the branch would sit
+        # stale until the next genuine change — indefinitely, on a quiet day.
+        # It also covers the first publish, where there is no branch at all.
+        if self._stored_tree() == tree:
+            return PublishResult(self._git("rev-parse", "FETCH_HEAD"), changed=False)
+
+        # No `-p`: parentless, so the branch is a snapshot and not a log.
+        commit = self._git("commit-tree", tree, "-m", label or "generation")
+        # Retried like every other publish here. There is nothing to rebase onto
+        # a force-updated orphan ref, so `safe_push.sh`'s rebase machinery has
+        # nothing to do — but its retry answers the transient failure that would
+        # otherwise leave the branch a generation behind.
+        for attempt in range(1, attempts + 1):
+            try:
+                self._git("push", "--force", self.remote,
+                          f"{commit}:refs/heads/{self.branch}")
+                break
+            except subprocess.CalledProcessError:
+                if attempt == attempts:
+                    raise
+                time.sleep(attempt * 3)
+        return PublishResult(commit, changed=True)

--- a/scripts/data/dashboard_outputs.py
+++ b/scripts/data/dashboard_outputs.py
@@ -18,15 +18,20 @@ from __future__ import annotations
 import argparse
 import copy
 import json
-import os
 import subprocess
-import tempfile
+import sys
 from pathlib import Path
 
 
 from workspace import workspace_root  # noqa: E402
 
 ROOT = workspace_root(Path(__file__).resolve().parents[2])
+# The checkout root, so `clawock` is importable regardless of where WS points:
+# WS is a data directory and can be redirected with CLAWOCK_WORKSPACE, while the
+# package lives in the checkout (#265, #313).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from clawock.publish import write_generation  # noqa: E402,F401
 
 # Keep this tuple explicit and ordered: callers use it as the exact publication
 # pathspec, and the contract test fails when build_dashboard gains a new sidecar
@@ -61,60 +66,11 @@ _GENERATION_LINKED = frozenset({
 })
 
 
-def write_generation(writes):
-    """Publish the four outputs as ONE write set: stage every file, then swap.
-
-    `writes` maps path -> already-serialized text. `safe_write_text` is atomic
-    per file, so no single output can be torn — but four sequential calls are not
-    atomic ACROSS files: a failure on the third leaves two files from the new
-    generation beside two from the old, and every consumer of these payloads
-    (the browser, the semantic diff, the publication pathspec) treats them as one
-    generation.
-
-    Staging every file first shrinks the window from "serialize + write + fsync,
-    four times" down to the `os.replace` calls themselves, and converts the
-    common failures — a full disk, a read-only mount, an unwritable directory —
-    from "publish a mixed generation" into "publish nothing and raise".
-
-    Targets are checked before anything is staged, because a target that cannot
-    be replaced at all (one that is a directory) would otherwise fail in the swap
-    loop, i.e. after earlier files had already been published — the exact outcome
-    this exists to prevent.
-
-    What remains is genuinely irreducible: the swap loop itself. If the directory
-    is removed between staging and replacing, some files can land and others not.
-    Four files cannot be swapped atomically without a transactional filesystem;
-    this narrows the window to consecutive `os.replace` calls rather than closing
-    it, and the payloads carry generation IDs so a reader can still tell.
-
-    Returns the paths written, in the order given.
-    """
-    for path in map(Path, writes):
-        if path.is_dir():
-            raise IsADirectoryError(
-                f"{path} is a directory; the write set cannot be swapped in")
-    staged = []
-    try:
-        for path, text in writes.items():
-            path = Path(path)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".staged-")
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(text)
-                handle.flush()
-                os.fsync(handle.fileno())
-            staged.append((tmp, path))
-    except BaseException:
-        for tmp, _ in staged:
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
-        raise
-    # Every byte is on disk; only the swaps remain.
-    for tmp, path in staged:
-        os.replace(tmp, path)
-    return [str(path) for _, path in staged]
+# `write_generation` is re-exported from `clawock.publish`, not defined here.
+# "Publish N files as one write set" stopped being specific to these four the
+# moment the generation could go somewhere other than this worktree (#314), and
+# `FilesystemStore` is the same operation with a directory in front of it. Two
+# copies of a staging-then-swap loop is exactly the shape that drifts.
 
 
 def _strip_recursive(value, fields):
@@ -189,9 +145,12 @@ class DirectoryBaseline:
         self.directory = Path(directory)
 
     def _file(self, path: str) -> Path:
-        # Outputs are named by their workspace-relative path; a published
-        # directory holds them flat, by basename.
-        return self.directory / Path(path).name
+        # Same layout `FilesystemStore` publishes and the same layout the data
+        # branch holds: outputs keep their workspace-relative path. Flattening to
+        # basename here would mean the baseline looked in one place and the store
+        # wrote to another, which is only discoverable once they are wired to
+        # each other.
+        return self.directory / path
 
     def load(self, path: str):
         return json.loads(self._file(path).read_text(encoding="utf-8"))

--- a/scripts/data/publish_dashboard.sh
+++ b/scripts/data/publish_dashboard.sh
@@ -52,6 +52,36 @@ if [ -n "$dashboard_paths_output" ]; then
   mapfile -t dashboard_paths <<< "$dashboard_paths_output"
 fi
 
+# ── Data plane (#314) ────────────────────────────────────────────────────────
+# The same generation, also published to the orphan data branch. Dual write
+# while the migration is in flight: `master` stays the served source until the
+# Pages input and `--previous` are repointed, which makes this step verifiable
+# the only way that matters — the branch's four files must be byte-identical to
+# the ones this tick commits to `master`.
+#
+# Runs EVERY tick, deliberately NOT gated on the local semantic diff. The store
+# compares against what the branch actually holds and no-ops when it matches, so
+# the gate would only ever suppress a publish the store was going to skip anyway
+# — while costing the one thing that matters: a tick that failed to reach the
+# branch is retried by the next one. Gated on "nothing changed locally", a failed
+# publish would sit stale until the next genuine change, which on a quiet day is
+# indefinitely. It also covers the first tick, where there is no branch yet.
+#
+# Before the push, and its failure is deliberately non-fatal here — a fault in
+# the new destination must not stop the live site from being published, but it
+# must not be silent either, so the exit code carries it out at the end.
+data_plane_failed=0
+# Sourced for GIT_SSH_COMMAND/PUBLISH_REMOTE — the same deploy-key identity
+# safe_push.sh uses. Sourcing (not exporting from a subshell) is why this is in
+# the parent shell.
+# shellcheck source=scripts/data/publish_identity.sh
+. scripts/data/publish_identity.sh
+if ! python3 scripts/data/publish_data_branch.py \
+     --remote "${PUBLISH_REMOTE:-origin}"; then
+  echo "✗ publish_dashboard: data-plane publish failed (master publish continues)" >&2
+  data_plane_failed=1
+fi
+
 heartbeat_changed=1
 if git diff --quiet -- assets/data/cron-heartbeats.json; then
   heartbeat_changed=0
@@ -63,7 +93,10 @@ fi
 
 if [ "${#dashboard_paths[@]}" -eq 0 ] && [ "$heartbeat_changed" -eq 0 ] && [ "$outcomes_changed" -eq 0 ]; then
   echo "publish_dashboard: no semantic or heartbeat change"
-  exit 0
+  # Nothing to commit here, but the data-plane step above ran on this tick and
+  # may have failed — this is the branch a stale data plane is most likely to
+  # exit through, since a quiet tick is exactly when nothing else forces a retry.
+  exit "$data_plane_failed"
 fi
 
 paths=("${dashboard_paths[@]}")
@@ -79,3 +112,8 @@ git add -- "${paths[@]}"
 # staging files at publish time), mislabeling them "scheduled publish" — happened once.
 git "${BOT_ID[@]}" commit -q -m "dashboard: scheduled publish $(date -u +%Y-%m-%dT%H:%MZ)" -- "${paths[@]}"
 bash scripts/data/safe_push.sh
+
+# A tick that reached only one of its two destinations is degraded, and the cron
+# health check is where that belongs. Reported after the master publish so the
+# failing half cannot take the working half down with it.
+exit "$data_plane_failed"

--- a/scripts/data/publish_data_branch.py
+++ b/scripts/data/publish_data_branch.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Publish the current dashboard generation to the orphan data branch (#314).
+
+The four outputs `build_dashboard.py` writes are build products: nothing in the
+live loop reads them back, and they account for 71% of the commits on `master`.
+They belong on a branch that holds state rather than history.
+
+This is the instance wiring, not the mechanism — `clawock.publish.GitBranchStore`
+is the mechanism, and its default sibling `FilesystemStore` is what a third party
+gets without configuring a remote. What lives here is the choice of *these four
+files, this branch, this repository*.
+
+Reads the outputs from the worktree exactly as they stand, so whatever the
+semantic diff decided to publish (including clock-only files it restored to their
+previous bytes) is what the data branch receives — byte-identical to what the
+same generation puts on `master`. That equality is the acceptance criterion while
+both destinations are written.
+
+Usage:
+  python3 scripts/data/publish_data_branch.py                # publish HEAD-of-worktree
+  python3 scripts/data/publish_data_branch.py --branch other --remote origin
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from workspace import workspace_root  # noqa: E402
+
+ROOT = workspace_root(Path(__file__).resolve().parents[2])
+# The checkout root, so `clawock` is importable regardless of where WS points
+# (#265, #313).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from clawock.publish import GitBranchStore  # noqa: E402
+from dashboard_outputs import DASHBOARD_OUTPUTS  # noqa: E402
+
+# The one place this name is decided. `.github/workflows/pages.yml` fetches the
+# same branch and `tests/test_pages_deployment_contract.py` asserts the two agree,
+# because a rename that updated only one of them would serve stale data with
+# every gate still green.
+DATA_BRANCH = "data-plane"
+
+# Same bot identity the scheduled publisher commits under. Injected per
+# invocation by the store (`git -c`), never written to git config — a persistent
+# identity would clobber kcn's interactive one.
+BOT_NAME = "github-actions[bot]"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+def generation_label(root: Path) -> str:
+    """Describe the generation being published, for the commit subject.
+
+    Falls back to a bare label rather than failing: the branch is state, and the
+    payloads carry their own generation IDs, so an unreadable subject line is not
+    a reason to withhold a publish.
+    """
+    try:
+        payload = json.loads(
+            (root / "assets/data/dashboard.json").read_text(encoding="utf-8"))
+        stamp = payload.get("generated_at")
+    except (OSError, ValueError):
+        stamp = None
+    return f"data: dashboard generation {stamp}" if stamp else "data: dashboard generation"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT,
+                        help="workspace holding the outputs to publish")
+    parser.add_argument("--repo", type=Path, default=None,
+                        help="repository to publish from (default: --root)")
+    parser.add_argument("--branch", default=DATA_BRANCH)
+    parser.add_argument("--remote", default="origin",
+                        help="an ssh URL when a deploy key was selected; "
+                             "publish_identity.sh exports the matching GIT_SSH_COMMAND")
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    files = {}
+    for path in DASHBOARD_OUTPUTS:
+        try:
+            files[path] = (root / path).read_text(encoding="utf-8")
+        except OSError as exc:
+            # Refuse rather than publish a partial generation: the branch is
+            # replaced wholesale, so a missing member is not "unchanged", it is
+            # deleted from the data plane.
+            print(f"✗ data-plane: cannot read {path}: {exc}", file=sys.stderr)
+            return 1
+
+    store = GitBranchStore(
+        args.repo or root, args.branch, remote=args.remote,
+        author_name=BOT_NAME, author_email=BOT_EMAIL,
+    )
+    try:
+        result = store.publish(files, label=generation_label(root))
+    except subprocess.CalledProcessError as exc:
+        print(f"✗ data-plane: git failed: {exc.stderr or exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"✗ data-plane: {exc}", file=sys.stderr)
+        return 1
+    if not result.changed:
+        print(f"· data-plane: {args.remote}/{args.branch} already holds this "
+              f"generation ({result.receipt[:12]})")
+        return 0
+    print(f"✓ data-plane: published {len(files)} outputs as "
+          f"{result.receipt[:12]} → {args.remote} {args.branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/publish_identity.sh
+++ b/scripts/data/publish_identity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# publish_identity.sh — select the publishing identity. SOURCE this; do not run it.
+#
+# A protected master must still accept scheduled data writers, and from 2026-08-05
+# there is a second publication target (the orphan data branch, #314). Both go out
+# under the same deploy-key identity, so the selection lives in one file rather
+# than being restated by every publisher: `safe_push.sh` sources it, and so does
+# `publish_dashboard.sh` before it publishes a generation to the data branch.
+#
+# Sets, for the sourcing shell:
+#   PUBLISH_SSH_KEY   path to the key in use, or empty for "whatever git is configured with"
+#   PUBLISH_REMOTE    remote to push to — an ssh URL when a deploy key was selected
+#   GIT_SSH_COMMAND   exported, so any git child process inherits the identity
+#
+# Registers its own EXIT trap to wipe an ephemeral key file. That is deliberate:
+# the Actions secret is materialised on disk for the duration of a push, and a
+# caller that forgot to clean it up would leave a write-enabled deploy key in the
+# runner's temp directory.
+
+# shellcheck disable=SC2034  # PUBLISH_REMOTE is read by the sourcing shell.
+PUBLISH_SSH_KEY=""
+PUBLISH_REMOTE=""
+_PUBLISH_TEMP_SSH_KEY=""
+
+if [ -n "${CLAWOCK_PUBLISH_SSH_KEY:-}" ]; then
+  # GitHub-hosted workflows receive a write-enabled deploy key through this
+  # secret; using the deploy key lets the repository ruleset distinguish
+  # automation from the shared KCNyu identity used by interactive sessions.
+  _PUBLISH_TEMP_SSH_KEY=$(mktemp)
+  chmod 600 "$_PUBLISH_TEMP_SSH_KEY"
+  printf '%s\n' "$CLAWOCK_PUBLISH_SSH_KEY" > "$_PUBLISH_TEMP_SSH_KEY"
+  PUBLISH_SSH_KEY="$_PUBLISH_TEMP_SSH_KEY"
+elif [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "/root/.openclaw/workspace" ] && \
+     [ -r "/root/.ssh/clawock_runtime_publish" ]; then
+  # The live OpenClaw checkout uses a separate deploy key. Interactive agents
+  # work in isolated worktree paths, so they never inherit this bypass.
+  PUBLISH_SSH_KEY="/root/.ssh/clawock_runtime_publish"
+fi
+
+if [ -n "$PUBLISH_SSH_KEY" ]; then
+  export GIT_SSH_COMMAND="ssh -i $PUBLISH_SSH_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+  PUBLISH_REMOTE="${CLAWOCK_PUBLISH_REMOTE:-git@github.com:KCNyu/clawock.git}"
+fi
+
+if [ -n "$_PUBLISH_TEMP_SSH_KEY" ]; then
+  trap 'test -z "$_PUBLISH_TEMP_SSH_KEY" || { : > "$_PUBLISH_TEMP_SSH_KEY"; unlink "$_PUBLISH_TEMP_SSH_KEY"; }' EXIT
+fi

--- a/scripts/data/safe_push.sh
+++ b/scripts/data/safe_push.sh
@@ -14,32 +14,14 @@ set -e
 MAX_RETRIES=3
 REMOTE="${1:-origin}"
 BRANCH="${2:-master}"
-TEMP_SSH_KEY=""
-PUBLISH_SSH_KEY=""
 
-# A protected master must still accept scheduled data writers. GitHub-hosted
-# workflows receive a write-enabled deploy key through this secret; using the
-# deploy key lets the repository ruleset distinguish automation from the shared
-# KCNyu identity used by interactive Codex/Claude sessions.
-if [ -n "${CLAWOCK_PUBLISH_SSH_KEY:-}" ]; then
-  TEMP_SSH_KEY=$(mktemp)
-  chmod 600 "$TEMP_SSH_KEY"
-  printf '%s\n' "$CLAWOCK_PUBLISH_SSH_KEY" > "$TEMP_SSH_KEY"
-  PUBLISH_SSH_KEY="$TEMP_SSH_KEY"
-elif [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "/root/.openclaw/workspace" ] && \
-     [ -r "/root/.ssh/clawock_runtime_publish" ]; then
-  # The live OpenClaw checkout uses a separate deploy key. Interactive agents
-  # work in isolated /root/.worktrees paths, so they never inherit this bypass.
-  PUBLISH_SSH_KEY="/root/.ssh/clawock_runtime_publish"
-fi
-
-if [ -n "$PUBLISH_SSH_KEY" ]; then
-  export GIT_SSH_COMMAND="ssh -i $PUBLISH_SSH_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-  REMOTE="${CLAWOCK_PUBLISH_REMOTE:-git@github.com:KCNyu/clawock.git}"
-fi
-
-if [ -n "$TEMP_SSH_KEY" ]; then
-  trap 'test -z "$TEMP_SSH_KEY" || { : > "$TEMP_SSH_KEY"; unlink "$TEMP_SSH_KEY"; }' EXIT
+# Identity selection (deploy key vs. whatever git is configured with) is shared
+# with the data-branch publisher, so it lives in one sourceable file rather than
+# being restated per publisher. It also owns wiping an ephemeral Actions key.
+# shellcheck source=scripts/data/publish_identity.sh
+. "$(dirname "${BASH_SOURCE[0]}")/publish_identity.sh"
+if [ -n "$PUBLISH_REMOTE" ]; then
+  REMOTE="$PUBLISH_REMOTE"
 fi
 
 # ── Conflict-marker guard (2026-06-03) ───────────────────────────────────────

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,0 +1,219 @@
+"""Where a generation goes, and what it must not disturb on the way (#314)."""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from clawock.publish import FilesystemStore, GitBranchStore  # noqa: E402
+
+
+GENERATION = {
+    "assets/data/dashboard.json": '{"totals": 1}',
+    "assets/data/overview.json": '{"generation_id": "one"}',
+}
+
+
+def _git(root, *args, **kwargs):
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True, capture_output=True, text=True, **kwargs,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A working checkout with a real remote, so pushes are exercised for real."""
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", "-b", "master", str(origin))
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-b", "master")
+    _git(work, "config", "user.name", "test")
+    _git(work, "config", "user.email", "test@example.invalid")
+    _git(work, "remote", "add", "origin", str(origin))
+    (work / "README.md").write_text("source\n", encoding="utf-8")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-m", "source")
+    _git(work, "push", "-u", "origin", "master")
+    return work
+
+
+def _branch_tree(repo, branch):
+    """path -> contents, as the data branch actually holds them."""
+    names = _git(repo, "ls-tree", "-r", "--name-only", f"origin/{branch}").split()
+    return {n: _git(repo, "show", f"origin/{branch}:{n}") for n in names}
+
+
+def test_the_data_branch_is_a_snapshot_not_a_log(repo):
+    """Force-updated and parentless: the branch holds the current generation and
+    nothing else. If publishing appended, this branch would grow the same 72
+    commits/day that put the outputs on `master` in the first place."""
+    store = GitBranchStore(repo, "data-plane")
+
+    store.publish(GENERATION, label="first")
+    store.publish({**GENERATION, "assets/data/dashboard.json": '{"totals": 2}'},
+                  label="second")
+    _git(repo, "fetch", "origin", "data-plane")
+
+    assert _git(repo, "rev-list", "--count", "origin/data-plane") == "1"
+    assert _branch_tree(repo, "data-plane") == {
+        "assets/data/dashboard.json": '{"totals": 2}',
+        "assets/data/overview.json": '{"generation_id": "one"}',
+    }, "the branch holds exactly the latest generation, at its published paths"
+
+
+def test_publishing_leaves_the_caller_checkout_alone(repo):
+    """The live publisher runs inside the workspace checkout while it is on
+    `master` with other files in flight. A store that reached the branch by
+    checking out, adding and committing would publish by disturbing the very tree
+    it publishes from — so this asserts HEAD, the index and the worktree are
+    exactly as they were."""
+    (repo / "dirty.txt").write_text("uncommitted\n", encoding="utf-8")
+    (repo / "staged.txt").write_text("mid-edit\n", encoding="utf-8")
+    _git(repo, "add", "staged.txt")
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    before_status = _git(repo, "status", "--porcelain")
+
+    GitBranchStore(repo, "data-plane").publish(GENERATION, label="x")
+
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == before_branch
+    assert _git(repo, "status", "--porcelain") == before_status
+    assert not (repo / "assets").exists(), (
+        "the published paths must not appear in the caller's worktree")
+
+
+def test_publishing_does_not_leave_the_caller_repository_shallow(repo):
+    """Reading the branch fetches it, and `--depth=1` there writes a shallow
+    boundary into the CALLER's repository — repository-wide state, not
+    per-ref. A shallow repository has its pushes rejected ("shallow update not
+    allowed"), so the next thing to break is not the data plane but the `master`
+    publish this same script performs three lines later.
+
+    Not hypothetical: it took a full publish, an unchanged republish and a lost
+    branch to surface, which is why the unit tests missed it and an end-to-end
+    run did not.
+    """
+    store = GitBranchStore(repo, "data-plane")
+    store.publish(GENERATION, label="first")
+    store.publish(GENERATION, label="unchanged")           # the read that fetches
+
+    assert _git(repo, "rev-parse", "--is-shallow-repository") == "false"
+    _git(repo, "push", "origin", "master")                  # the master publish
+
+
+@pytest.mark.parametrize("branch", ["master", "main", "HEAD"])
+def test_a_branch_that_is_built_on_is_refused(repo, branch):
+    """Every publish discards the target's history. Pointed at `master` that is
+    not a bad publish, it is the repository."""
+    with pytest.raises(ValueError, match="force-update"):
+        GitBranchStore(repo, branch).publish(GENERATION, label="x")
+
+
+def test_the_default_branch_is_refused_under_any_name(repo, tmp_path):
+    """`master`/`main` are a static guess; the remote's own default branch is the
+    real answer, and it is asked OF THE REMOTE.
+
+    `refs/remotes/origin/HEAD` is a local convenience that plenty of checkouts do
+    not have — this one included until something creates it. Reading only that
+    would leave a repository whose default is `trunk` protected by nothing but
+    the static list, which is the case this exists for.
+    """
+    _git(repo, "push", "origin", "master:refs/heads/trunk")
+    _git(tmp_path / "origin.git", "symbolic-ref", "HEAD", "refs/heads/trunk")
+    assert "origin/HEAD" not in _git(repo, "branch", "-r"), (
+        "the local remote-HEAD ref must be absent, or this proves nothing")
+
+    with pytest.raises(ValueError, match="force-update"):
+        GitBranchStore(repo, "trunk").publish(GENERATION, label="x")
+
+
+@pytest.mark.parametrize("branch", ["refs/heads/master", ""])
+def test_something_that_is_not_a_branch_name_is_refused(repo, branch):
+    """A fully-qualified ref would be pushed to `refs/heads/refs/heads/master`,
+    so the guard above would be inspecting a name nothing is published to — the
+    caller asked for one branch and got a different one, silently."""
+    with pytest.raises(ValueError, match="expected a branch name"):
+        GitBranchStore(repo, branch).publish(GENERATION, label="x")
+
+
+def test_republishing_the_same_generation_does_not_write(repo):
+    """The store compares against the branch, so an unchanged generation is a
+    no-op it reports rather than a second commit of the same bytes. Callers use
+    `changed` to decide whether anything needs deploying."""
+    store = GitBranchStore(repo, "data-plane")
+    first = store.publish(GENERATION, label="first")
+
+    again = store.publish(GENERATION, label="second")
+
+    assert first.changed and not again.changed
+    assert again.receipt == first.receipt, "the branch tip must not move"
+
+
+def test_a_publish_that_never_arrived_is_retried_by_the_next_one(repo):
+    """The self-healing property, and the reason the caller must NOT gate this on
+    its own "did anything change locally".
+
+    Generation N reaches `master` but not the branch. Nothing changes locally
+    afterwards, so a caller gated on its own diff would never try again and the
+    branch would sit a generation behind until the next genuine change — on a
+    quiet day, indefinitely. Comparing against the branch instead makes the next
+    tick repair it with no new information.
+    """
+    store = GitBranchStore(repo, "data-plane")
+    store.publish(GENERATION, label="generation N")
+    _git(repo, "push", "origin", "--delete", "data-plane")   # the publish is lost
+
+    repaired = store.publish(GENERATION, label="generation N")
+
+    assert repaired.changed, "an absent branch must be republished, not skipped"
+    _git(repo, "fetch", "origin", "data-plane")
+    assert _branch_tree(repo, "data-plane") == GENERATION
+
+
+def test_the_filesystem_default_is_idempotent_too(tmp_path):
+    """Same contract on both sides of the seam, so a caller reading `changed`
+    behaves the same whichever store it was configured with."""
+    store = FilesystemStore(tmp_path / "out")
+    assert store.publish(GENERATION).changed
+    assert not store.publish(GENERATION).changed
+
+
+def test_an_empty_generation_is_refused_rather_than_treated_as_a_no_op(repo):
+    """`GitBranchStore` replaces its whole state, so publishing zero files is not
+    "nothing changed" — it is deleting the data plane. Refused in the shared
+    check, so the filesystem default cannot drift away from it either."""
+    with pytest.raises(ValueError, match="empty generation"):
+        GitBranchStore(repo, "data-plane").publish({}, label="x")
+    with pytest.raises(ValueError, match="empty generation"):
+        FilesystemStore(repo / "out").publish({}, label="x")
+
+
+def test_a_generation_member_cannot_escape_the_store(tmp_path):
+    """Members are addressed by relative path in both stores; an absolute path or
+    a `..` would write outside the store in the filesystem case and commit a path
+    git would refuse in the other."""
+    store = FilesystemStore(tmp_path / "out")
+    with pytest.raises(ValueError, match="relative path"):
+        store.publish({"../escape.json": "{}"})
+    with pytest.raises(ValueError, match="relative path"):
+        store.publish({str(tmp_path / "escape.json"): "{}"})
+
+
+def test_the_filesystem_default_keeps_the_published_layout(tmp_path):
+    """The layout is the contract shared with `DirectoryBaseline` and with the
+    data branch: outputs keep their workspace-relative path rather than being
+    flattened, so "what did we publish last time" resolves the same way wherever
+    the generation was stored."""
+    out = tmp_path / "out"
+
+    result = FilesystemStore(out).publish(GENERATION, label="ignored")
+
+    assert result.receipt == str(out) and result.changed
+    assert (out / "assets/data/dashboard.json").read_text(encoding="utf-8") == '{"totals": 1}'
+    assert (out / "assets/data/overview.json").read_text(encoding="utf-8") == '{"generation_id": "one"}'

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -251,7 +251,9 @@ def test_the_diff_baseline_can_be_a_directory_instead_of_this_repository(tmp_pat
     we publish last time" stops being a git question. This helper was the one
     place that assumed otherwise."""
     published = tmp_path / "published"
-    _generation(published, clock="2026-08-05T00:00:00Z", value=1)
+    # Laid out the way `FilesystemStore` and the data branch hold a
+    # generation: by workspace-relative path, not flattened to basename.
+    _generation(published / "assets" / "data", clock="2026-08-05T00:00:00Z", value=1)
     worktree = tmp_path / "worktree" / "assets" / "data"
     _generation(worktree, clock="2026-08-05T03:00:00Z", value=1)
     # Exactly one output genuinely changed. Asserting the precise subset is what
@@ -278,7 +280,9 @@ def test_a_clock_only_rebuild_is_restored_from_whatever_the_baseline_is(tmp_path
     guarantee `git restore` does, or moving the data plane reintroduces the
     no-op publish this contract exists to stop."""
     published = tmp_path / "published"
-    _generation(published, clock="2026-08-05T00:00:00Z", value=1)
+    # Laid out the way `FilesystemStore` and the data branch hold a
+    # generation: by workspace-relative path, not flattened to basename.
+    _generation(published / "assets" / "data", clock="2026-08-05T00:00:00Z", value=1)
     root = tmp_path / "worktree"
     _generation(root / "assets" / "data", clock="2026-08-05T03:00:00Z", value=1)
 

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -96,9 +96,38 @@ exit 1
 
 
 def test_live_runtime_key_is_limited_to_live_checkout():
-    safe_push = (ROOT / "scripts" / "data" / "safe_push.sh").read_text()
-    assert '"/root/.openclaw/workspace"' in safe_push
-    assert '"/root/.ssh/clawock_runtime_publish"' in safe_push
+    identity = (ROOT / "scripts" / "data" / "publish_identity.sh").read_text()
+    assert '"/root/.openclaw/workspace"' in identity
+    assert '"/root/.ssh/clawock_runtime_publish"' in identity
+
+
+def test_a_checkout_that_is_not_the_live_workspace_gets_no_publish_identity(tmp_path):
+    """Interactive worktrees must not inherit the live deploy key.
+
+    Both selection branches are refused here: no Actions secret in the
+    environment, and a checkout that is not `/root/.openclaw/workspace`. On the
+    live host `/root/.ssh/clawock_runtime_publish` is readable, so the toplevel
+    comparison is the only thing standing between an interactive worktree and a
+    key that bypasses the ruleset — this exercises it. On a runner the key is
+    absent as well, so the assertion holds for a second reason.
+
+    Behavioural rather than a grep, because the selection now lives in a file
+    that two publishers source: a text assertion would keep passing if only one
+    of them still consulted it.
+    """
+    subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+    probe = subprocess.run(
+        ["bash", "-c",
+         f". {ROOT / 'scripts' / 'data' / 'publish_identity.sh'}; "
+         'printf "%s|%s|%s" "$PUBLISH_SSH_KEY" "$PUBLISH_REMOTE" "${GIT_SSH_COMMAND:-}"'],
+        cwd=tmp_path,
+        env={k: v for k, v in os.environ.items() if k != "CLAWOCK_PUBLISH_SSH_KEY"},
+        check=True, capture_output=True, text=True,
+    )
+
+    assert probe.stdout == "||", (
+        "an interactive checkout selected a publishing identity: "
+        f"{probe.stdout!r}")
 
 
 def test_every_workflow_that_stages_the_money_file_pushes_through_the_gate():
@@ -177,6 +206,12 @@ def test_safe_push_refuses_the_money_file_when_the_checker_is_missing(tmp_path):
     repo = _ledger_repo(tmp_path)
     script = repo / "safe_push.sh"
     script.write_text((ROOT / "scripts" / "data" / "safe_push.sh").read_text())
+    # safe_push.sh sources its sibling for identity selection, so a deployment
+    # of it is both files. Not tolerating an absent one is deliberate: an
+    # unreadable identity helper must fail here, not silently push under
+    # whatever git happens to be configured with.
+    (repo / "publish_identity.sh").write_text(
+        (ROOT / "scripts" / "data" / "publish_identity.sh").read_text())
 
     result = subprocess.run(["bash", str(script)], cwd=repo, capture_output=True,
                             text=True, input="")


### PR DESCRIPTION
First slice of #314 (the Publisher axis kcn picked on 2026-08-05).

Before the four dashboard outputs can leave `master`, **"where a generation goes" has to stop being "the worktree it was built in."** That was never a decision anywhere in the code — the builder wrote files into `assets/data/`, and three publishers committed them. This adds the seam and wires one real caller to it.

## What is here

**`clawock/publish`** — an `ArtifactStore`, two implementations:

- **`FilesystemStore`** is the default and the only thing a third party gets without configuring a remote. Writing the files where they were built is a store, not the absence of one; a clawock whose default was "push somewhere" would be wrong (#203 constraint).
- **`GitBranchStore`** is *one instance configuration*: an orphan, force-updated ref. Built entirely with plumbing (`hash-object` → scratch `GIT_INDEX_FILE` → `write-tree` → parentless `commit-tree` → `push --force`), so the caller's index, HEAD, stash and worktree are untouched. That is not stylistic: the live publisher runs **inside the workspace checkout while it is on `master` with other files in flight**. A `checkout`/`add`/`commit` implementation would publish by disturbing the tree it publishes from.

Force-updated because the branch is **state, not history**. Each publish is a parentless commit whose tree is exactly the generation, so the data branch never accumulates the ~72 commits/day that put these outputs on `master` in the first place. Nothing rebases onto it and nothing merges it — which is what makes discarding its history safe, and what makes pointing it at a branch someone *does* build on catastrophic. Hence the refusal on `master` / `main` / `HEAD` / **the remote's own default branch**.

**`write_generation` moves into the package**; `dashboard_outputs.py` re-exports it. "Publish N files as one write set" stopped being specific to these four the moment a generation could go somewhere else, and `FilesystemStore` is the same operation with a directory in front of it. Two copies of a stage-then-swap loop is the shape that drifts.

**`DirectoryBaseline` now uses the layout the store publishes** — workspace-relative path, not flattened to basename. It had no production caller yet (#312 added it), so this is free now and a silent mismatch later: the baseline would look in one place and the store write to another, discoverable only once they are wired to each other, which is the very next slice (`--previous`).

**`publish_identity.sh`** — the deploy-key selection extracted out of `safe_push.sh`. There are two publication targets now and they must not drift into two auth paths. It also owns wiping the ephemeral Actions key, so a caller cannot forget.

## Wiring: dual write, deliberately

`publish_dashboard.sh` publishes the same generation to `data-plane` **in addition to** committing it to `master`. Master stays the served source until the Pages input and `--previous` are repointed, which makes this slice verifiable the only way that matters: **the branch's four files must be byte-identical to the ones the same tick commits to `master`.** They are read straight off the worktree after the semantic diff has run, so clock-only files it restored to their previous bytes go out as those same bytes.

Three placement details that are not incidental:

- **Gated on the same semantic decision as the master commit**, not run every tick. The branch is force-updated, so an unchanged generation would still mint a new commit — and that ref becomes the Pages trigger later in this migration.
- **Before the push, not after.** After, a failed master push would leave the branch permanently behind: the next tick sees no semantic change against `HEAD` and skips again.
- **Non-fatal, but not silent.** A fault in the new destination must not stop the live site from publishing, so the failure is captured and carried out in the exit code at the end. Per `feedback-detect-but-never-silence`, a tick that reached one of its two destinations is degraded and cron health is where that belongs.

## Verification

Six behavioural tests, all mutation-verified — real git repos, real pushes to a real (local, bare) remote:

| mutation | caught by |
|---|---|
| use the real index instead of a scratch `GIT_INDEX_FILE` | snapshot + checkout-untouched |
| `commit-tree -p HEAD` (append instead of snapshot) | `rev-list --count == 1` |
| drop `_reject_protected()` | 4 refusal tests |
| default-branch lookup returns `None` | the non-`master` default-branch test |
| flatten `FilesystemStore` to basename | layout test |
| drop the `/root/.openclaw/workspace` toplevel check in identity selection | both identity tests |

`test_live_runtime_key_is_limited_to_live_checkout` was a grep against `safe_push.sh`; it now points at the extracted file **and** gained a behavioural sibling, because a text assertion would keep passing if only one of the two publishers still consulted the helper. On this host `/root/.ssh/clawock_runtime_publish` is readable, so the toplevel comparison is genuinely the only thing between an interactive worktree and a ruleset-bypassing key — the new test exercises it rather than asserting the source contains a string.

End-to-end in a sandbox clone with a throwaway origin: all four outputs byte-identical on the branch, one parentless commit under the bot identity, still one commit after a second publish, `master` refused, and the caller's checkout clean with no `assets/` written into it. `safe_push.sh` re-verified pushing normally after the extraction, and the ephemeral key confirmed wiped on exit.

Full suite: **1586 passed, 4 xfailed**, working tree clean afterwards.

## Not in this slice

Nothing is served from the branch yet, and nothing stops being committed to `master`. Still ahead, in #314's order: the Pages trigger + Jekyll input (must land together), `--previous` repointed at the fetched copy, `.githooks/pre-commit` staging, the #302 fresh-checkout detector decision, and `CommitCoordinator` / `SiteDeployer`.
