### PR TITLE
publish: ask for the site deploy, instead of a commit accidentally being the trigger (#314)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,14 @@ on:
       - 'memory/weekly/**'
       - 'config/pages-public.json'
       - 'scripts/build/prepare_pages_artifact.py'
+  # The publisher asks for a deploy once a generation reaches the data branch
+  # (#314). A push to that branch cannot do it: `push` runs the workflows on the
+  # ref that was pushed, and an orphan data branch carries none. GitHub
+  # documents `repository_dispatch` as creating a run even when sent with the
+  # automatic GITHUB_TOKEN, so every publisher can ask — the host through its
+  # own login, an Actions publisher through the token it already has.
+  repository_dispatch:
+    types: [data-plane-published]
   workflow_dispatch:
 
 permissions:
@@ -94,7 +102,16 @@ jobs:
           path: ./_pages
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # A dispatched run deploys too — that is the entire point of the dispatch.
+    # `workflow_dispatch` is included as the manual recourse: once dashboard
+    # publishes stop landing on `master`, "push something to force a rebuild"
+    # stops being available, and a lost dispatch would otherwise need a dummy
+    # commit to recover from. `pull_request` still must not deploy: it is the one
+    # event whose build comes from untrusted content.
+    if: >-
+      github.event_name == 'repository_dispatch'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/clawock/publish/__init__.py
+++ b/clawock/publish/__init__.py
@@ -13,6 +13,11 @@ those into one thing that can only be replaced as a unit.
 """
 from __future__ import annotations
 
+from clawock.publish.deploy import (  # noqa: F401
+    GitHubDispatchDeployer,
+    NullDeployer,
+    SiteDeployer,
+)
 from clawock.publish.store import (  # noqa: F401
     ArtifactStore,
     FilesystemStore,
@@ -24,4 +29,5 @@ from clawock.publish.store import (  # noqa: F401
 __all__ = [
     "ArtifactStore", "FilesystemStore", "GitBranchStore", "PublishResult",
     "write_generation",
+    "GitHubDispatchDeployer", "NullDeployer", "SiteDeployer",
 ]

--- a/clawock/publish/deploy.py
+++ b/clawock/publish/deploy.py
@@ -1,0 +1,85 @@
+"""Asking for the site to be rebuilt — the third thing git was doing at once.
+
+Storing a generation and making it visible are different jobs, and in this
+repository they were the same act: a `dashboard:` commit on `master` matched the
+Pages workflow's `paths:` filter, so pushing the data *was* the deploy trigger.
+Take the data off `master` (#314) and the trigger silently goes with it — the
+site keeps serving the last generation it happened to build, with no failure
+anywhere.
+
+So the trigger has to be asked for explicitly, and by something that is not the
+store. Git is simultaneously audit log, concurrency protocol, state replication,
+auth boundary and Pages trigger (#203); this is the seam that separates the last
+of those from the rest.
+
+An orphan branch cannot carry the trigger itself: a `push` event runs the
+workflows *on the pushed ref*, and a data branch has none. `repository_dispatch`
+is the one mechanism that works from every publisher this repository has —
+GitHub documents it and `workflow_dispatch` as the two events that create a run
+**even when sent with the automatic `GITHUB_TOKEN`**, so the Actions publishers
+need no extra secret and the host needs no special case.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Protocol
+
+
+class SiteDeployer(Protocol):
+    """Makes the stored generation visible, or knows there is nothing to do."""
+
+    name: str
+
+    def request(self, reason: str = "") -> str:
+        """Ask for the site to be rebuilt from what the store now holds.
+
+        Returns a receipt for the caller to log. Raises if the request could not
+        be made — a deploy that was never asked for must not read as success,
+        because the failure it hides is a site frozen on an old generation while
+        every other gate stays green.
+        """
+
+
+class NullDeployer:
+    """No deploy step. The default, and correct for a filesystem store.
+
+    Publishing into a directory that something else serves needs nothing asked
+    of anyone. This exists so "no deployer configured" is a decision the code
+    states rather than a branch every caller writes.
+    """
+
+    name = "null"
+
+    def request(self, reason: str = "") -> str:
+        return "no deploy step configured"
+
+
+class GitHubDispatchDeployer:
+    """`repository_dispatch`, sent through `gh`.
+
+    `gh` rather than a hand-rolled HTTPS call because it already resolves an
+    identity in both places this runs: the host's stored login, and
+    `GITHUB_TOKEN`/`GH_TOKEN` on a runner. One transport, no token handling here,
+    and nothing new to keep out of a log.
+
+    Deliberately *not* the deploy itself. This asks; GitHub Actions builds and
+    deploys. Doing the build here would put the Pages artifact's contents at the
+    mercy of whichever machine happened to publish.
+    """
+
+    name = "github-dispatch"
+
+    def __init__(self, repository: str, event_type: str = "data-plane-published") -> None:
+        self.repository = repository
+        self.event_type = event_type
+
+    def request(self, reason: str = "") -> str:
+        payload = json.dumps({"reason": reason} if reason else {})
+        subprocess.run(
+            ["gh", "api", f"repos/{self.repository}/dispatches",
+             "-f", f"event_type={self.event_type}",
+             "--raw-field", f"client_payload={payload}"],
+            check=True, capture_output=True, text=True,
+        )
+        return f"{self.event_type} → {self.repository}"

--- a/scripts/data/publish_dashboard.sh
+++ b/scripts/data/publish_dashboard.sh
@@ -53,34 +53,38 @@ if [ -n "$dashboard_paths_output" ]; then
 fi
 
 # ── Data plane (#314) ────────────────────────────────────────────────────────
-# The same generation, also published to the orphan data branch. Dual write
-# while the migration is in flight: `master` stays the served source until the
-# Pages input and `--previous` are repointed, which makes this step verifiable
-# the only way that matters — the branch's four files must be byte-identical to
-# the ones this tick commits to `master`.
+# The same generation, also published to the orphan data branch, and the site
+# deploy asked for explicitly. Dual write while the migration is in flight:
+# `master` stays the served source until the outputs stop being tracked, which
+# makes this verifiable the only way that matters — the branch's four files must
+# be byte-identical to the ones this tick commits to `master`.
 #
-# Runs EVERY tick, deliberately NOT gated on the local semantic diff. The store
-# compares against what the branch actually holds and no-ops when it matches, so
-# the gate would only ever suppress a publish the store was going to skip anyway
-# — while costing the one thing that matters: a tick that failed to reach the
-# branch is retried by the next one. Gated on "nothing changed locally", a failed
-# publish would sit stale until the next genuine change, which on a quiet day is
-# indefinitely. It also covers the first tick, where there is no branch yet.
+# Runs on EVERY path, deliberately NOT gated on the local semantic diff. The
+# store compares against what the branch actually holds and no-ops when it
+# matches, so a gate could only ever suppress a publish the store was going to
+# skip anyway — while costing the one thing that matters: a tick that failed to
+# reach the branch is repaired by the next one with no new information. Gated on
+# "nothing changed locally", a failed publish would sit stale until the next
+# genuine change, which on a quiet day is indefinitely. It also covers the first
+# tick, where there is no branch yet.
 #
-# Before the push, and its failure is deliberately non-fatal here — a fault in
-# the new destination must not stop the live site from being published, but it
-# must not be silent either, so the exit code carries it out at the end.
+# AFTER the master publish, not before. Both destinations trigger a Pages run
+# during the dual write, and `concurrency: pages` cancels the older one — going
+# second is what leaves the dispatched run to finish, so the path that has to
+# work after the cut is the one actually exercised now. Ordering is otherwise
+# free precisely because the store is self-healing.
 data_plane_failed=0
-# Sourced for GIT_SSH_COMMAND/PUBLISH_REMOTE — the same deploy-key identity
-# safe_push.sh uses. Sourcing (not exporting from a subshell) is why this is in
-# the parent shell.
-# shellcheck source=scripts/data/publish_identity.sh
-. scripts/data/publish_identity.sh
-if ! python3 scripts/data/publish_data_branch.py \
-     --remote "${PUBLISH_REMOTE:-origin}"; then
-  echo "✗ publish_dashboard: data-plane publish failed (master publish continues)" >&2
-  data_plane_failed=1
-fi
+publish_data_plane() {
+  # Sourced for GIT_SSH_COMMAND/PUBLISH_REMOTE — the same deploy-key identity
+  # safe_push.sh uses, selected in one place rather than restated per publisher.
+  # shellcheck source=scripts/data/publish_identity.sh
+  . scripts/data/publish_identity.sh
+  if ! python3 scripts/data/publish_data_branch.py \
+       --deploy --remote "${PUBLISH_REMOTE:-origin}"; then
+    echo "✗ publish_dashboard: data plane not published or not deployed" >&2
+    return 1
+  fi
+}
 
 heartbeat_changed=1
 if git diff --quiet -- assets/data/cron-heartbeats.json; then
@@ -93,9 +97,10 @@ fi
 
 if [ "${#dashboard_paths[@]}" -eq 0 ] && [ "$heartbeat_changed" -eq 0 ] && [ "$outcomes_changed" -eq 0 ]; then
   echo "publish_dashboard: no semantic or heartbeat change"
-  # Nothing to commit here, but the data-plane step above ran on this tick and
-  # may have failed — this is the branch a stale data plane is most likely to
-  # exit through, since a quiet tick is exactly when nothing else forces a retry.
+  # Nothing to commit, but the data plane still gets checked: a quiet tick is
+  # exactly when nothing else would force a retry of a publish that never
+  # arrived, so this is the branch a stale data plane would exit through.
+  publish_data_plane || data_plane_failed=1
   exit "$data_plane_failed"
 fi
 
@@ -113,7 +118,8 @@ git add -- "${paths[@]}"
 git "${BOT_ID[@]}" commit -q -m "dashboard: scheduled publish $(date -u +%Y-%m-%dT%H:%MZ)" -- "${paths[@]}"
 bash scripts/data/safe_push.sh
 
+publish_data_plane || data_plane_failed=1
 # A tick that reached only one of its two destinations is degraded, and the cron
-# health check is where that belongs. Reported after the master publish so the
-# failing half cannot take the working half down with it.
+# health check is where that belongs. Non-zero only after `master` was published,
+# so the failing half cannot take the working half down with it.
 exit "$data_plane_failed"

--- a/scripts/data/publish_data_branch.py
+++ b/scripts/data/publish_data_branch.py
@@ -35,7 +35,7 @@ ROOT = workspace_root(Path(__file__).resolve().parents[2])
 # (#265, #313).
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from clawock.publish import GitBranchStore  # noqa: E402
+from clawock.publish import GitBranchStore, GitHubDispatchDeployer  # noqa: E402
 from dashboard_outputs import DASHBOARD_OUTPUTS  # noqa: E402
 
 # The one place this name is decided. The reader imports it from here rather
@@ -48,6 +48,10 @@ DATA_BRANCH = "data-plane"
 # identity would clobber kcn's interactive one.
 BOT_NAME = "github-actions[bot]"
 BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+# This instance's site. A third party publishing to a filesystem asks nobody for
+# a deploy, which is why `--deploy` is opt-in rather than the default.
+REPOSITORY = "KCNyu/clawock"
 
 
 def generation_label(root: Path) -> str:
@@ -76,6 +80,9 @@ def main() -> int:
     parser.add_argument("--remote", default="origin",
                         help="an ssh URL when a deploy key was selected; "
                              "publish_identity.sh exports the matching GIT_SSH_COMMAND")
+    parser.add_argument("--deploy", action="store_true",
+                        help="ask GitHub to rebuild the site when this publish "
+                             "changed the branch")
     args = parser.parse_args()
 
     root = Path(args.root)
@@ -103,11 +110,29 @@ def main() -> int:
         print(f"✗ data-plane: {exc}", file=sys.stderr)
         return 1
     if not result.changed:
+        # No deploy request either: the site already serves this generation, and
+        # asking on every quiet tick would rebuild it 72 times a day for nothing.
         print(f"· data-plane: {args.remote}/{args.branch} already holds this "
               f"generation ({result.receipt[:12]})")
         return 0
     print(f"✓ data-plane: published {len(files)} outputs as "
           f"{result.receipt[:12]} → {args.remote} {args.branch}")
+
+    if not args.deploy:
+        return 0
+    try:
+        receipt = GitHubDispatchDeployer(REPOSITORY).request(
+            reason=f"data-plane {result.receipt[:12]}")
+    except (subprocess.CalledProcessError, OSError) as exc:
+        # Loud, and non-zero. A generation that reached the branch but never
+        # reached the site is the failure this whole seam exists to make
+        # visible: nothing else in the system notices a site frozen on an old
+        # generation.
+        detail = getattr(exc, "stderr", "") or exc
+        print(f"✗ data-plane: published, but the site deploy was not requested: "
+              f"{detail}", file=sys.stderr)
+        return 1
+    print(f"✓ data-plane: requested {receipt}")
     return 0
 
 

--- a/tests/test_site_deploy.py
+++ b/tests/test_site_deploy.py
@@ -1,0 +1,150 @@
+"""Storing a generation and making it visible are different jobs (#314).
+
+They were the same act here: a `dashboard:` commit matched the Pages workflow's
+`paths:` filter, so pushing the data *was* the trigger. Once the data leaves
+`master` the trigger leaves with it, and the failure mode is the quiet one — the
+site keeps serving the last generation it happened to build, with every gate
+green.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from clawock.publish import GitHubDispatchDeployer, NullDeployer  # noqa: E402
+
+WORKFLOW = (ROOT / ".github/workflows/pages.yml").read_text()
+
+
+def _git(root, *args):
+    return subprocess.run(["git", "-C", str(root), *args],
+                          check=True, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A checkout with a remote and a fake `gh`, so a publish can run for real."""
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", "-b", "master", str(origin))
+    work = tmp_path / "work"
+    (work / "assets" / "data").mkdir(parents=True)
+    _git(work, "init", "-b", "master")
+    _git(work, "config", "user.name", "test")
+    _git(work, "config", "user.email", "test@example.invalid")
+    _git(work, "remote", "add", "origin", str(origin))
+    for name in ("overview", "dashboard", "decision_audit", "shadow_portfolio"):
+        (work / "assets" / "data" / f"{name}.json").write_text(
+            json.dumps({"generated_at": "2026-08-05T00:00:00Z", "name": name}),
+            encoding="utf-8")
+    (work / "README.md").write_text("source\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "seed")
+    _git(work, "push", "-u", "origin", "master")
+    return work
+
+
+def _fake_gh(tmp_path, *, exit_code=0):
+    """A `gh` that records its arguments instead of talking to GitHub."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    log = tmp_path / "gh.log"
+    (bin_dir / "gh").write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> {log}\nexit {exit_code}\n',
+        encoding="utf-8")
+    (bin_dir / "gh").chmod(0o755)
+    return bin_dir, log
+
+
+def _publish(workspace, bin_dir, *extra):
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts/data/publish_data_branch.py"),
+         "--root", str(workspace), "--remote", "origin", *extra],
+        cwd=workspace, env=env, capture_output=True, text=True)
+
+
+def test_the_dispatch_names_the_event_the_workflow_listens_for(tmp_path):
+    """Two files have to agree on a string neither can validate at runtime. A
+    rename on one side alone leaves the publisher reporting a successful request
+    for an event nothing handles — every gate green, site frozen."""
+    bin_dir, log = _fake_gh(tmp_path)
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    subprocess.run([sys.executable, "-c",
+                    "import sys; sys.path.insert(0, %r);"
+                    "from clawock.publish import GitHubDispatchDeployer as D;"
+                    "D('KCNyu/clawock').request('why')" % str(ROOT)],
+                   env=env, check=True, capture_output=True, text=True)
+
+    sent = log.read_text()
+    event = re.search(r"event_type=(\S+)", sent).group(1)
+    declared = re.search(r"repository_dispatch:\s*\n\s*types:\s*\[([^\]]+)\]",
+                         WORKFLOW).group(1)
+
+    assert event in [name.strip() for name in declared.split(",")]
+    assert "repos/KCNyu/clawock/dispatches" in sent
+
+
+def test_a_dispatched_run_is_allowed_to_deploy():
+    """The build job runs for pull requests too, so the deploy job's condition is
+    the only thing deciding what reaches the site. Adding the trigger without
+    adding it here would build the new generation and deploy nothing."""
+    block = WORKFLOW.split("  deploy:", 1)[1].split("needs:", 1)[0]
+    condition = "\n".join(line for line in block.splitlines()
+                          if not line.strip().startswith("#"))
+
+    assert "github.event_name == 'repository_dispatch'" in condition
+    assert "pull_request" not in condition, (
+        "a pull request build must never reach the live site")
+
+
+def test_a_publish_that_could_not_ask_for_a_deploy_is_not_success(workspace, tmp_path):
+    """A generation on the branch that never reached the site is exactly the
+    failure this seam exists to surface — nothing else in the system notices a
+    frozen site. It must not exit 0."""
+    bin_dir, _ = _fake_gh(tmp_path, exit_code=1)
+
+    result = _publish(workspace, bin_dir, "--deploy")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "site deploy was not requested" in result.stderr
+    assert "published" in result.stdout, (
+        "the publish itself succeeded and must still be reported")
+
+
+def test_an_unchanged_generation_asks_for_nothing(workspace, tmp_path):
+    """72 ticks a day, and most change nothing. Asking every time would rebuild
+    and redeploy the site for a generation it already serves."""
+    bin_dir, log = _fake_gh(tmp_path)
+
+    first = _publish(workspace, bin_dir, "--deploy")
+    second = _publish(workspace, bin_dir, "--deploy")
+
+    assert first.returncode == 0 and second.returncode == 0
+    assert "already holds this generation" in second.stdout
+    assert len(log.read_text().splitlines()) == 1, (
+        "the unchanged republish must not have asked for a deploy")
+
+
+def test_publishing_without_the_flag_asks_no_one(workspace, tmp_path):
+    """A third party publishing to a filesystem has nobody to ask. The deploy
+    request is this instance's configuration, so it is opt-in."""
+    bin_dir, log = _fake_gh(tmp_path)
+
+    result = _publish(workspace, bin_dir)
+
+    assert result.returncode == 0
+    assert not log.exists(), "a publish without --deploy must not invoke gh"
+
+
+def test_the_null_deployer_reports_rather_than_pretends():
+    """"No deploy step" is a decision the code states once, not a branch every
+    caller writes."""
+    assert NullDeployer().request("anything")
+    assert GitHubDispatchDeployer("owner/repo").event_type == "data-plane-published"


### PR DESCRIPTION
Third slice of #314. Stacked on #316 and #317, both merged.

A `dashboard:` commit on `master` matched the Pages workflow's `paths:` filter, so **pushing the data *was* the deploy trigger** — nobody ever decided that, it was a side effect of where the data lived. Take the data off `master` and the trigger goes with it, silently: the site keeps serving the last generation it happened to build, and nothing anywhere goes red.

## The trigger question, settled by a fact worth writing down

A push to the data branch **cannot** trigger anything. `push` runs the workflows found *on the ref that was pushed*, and an orphan data branch carries none. That ruled out the obvious answer and left two candidates I had been weighing: ship a workflow file inside the orphan tree, or add a PAT so an Actions publisher can dispatch.

Neither is needed. GitHub documents `repository_dispatch` and `workflow_dispatch` as **the two events that create a workflow run even when sent with the automatic `GITHUB_TOKEN`** — the explicit exceptions to the recursion-prevention rule. So the host dispatches through its own login, an Actions publisher dispatches through the token it already has, no new secret and no special case.

## What is here

**`clawock/publish/deploy.py`** — `SiteDeployer`, with `NullDeployer` as the default (a filesystem publisher has nobody to ask; "no deploy step" should be a decision the code states once, not a branch every caller writes) and `GitHubDispatchDeployer` as this instance's.

It **asks**; it does not deploy. Doing the build here would put the Pages artifact's contents at the mercy of whichever machine happened to publish. `gh` is the transport because it already resolves an identity in both places this runs — the host's stored login and `GITHUB_TOKEN`/`GH_TOKEN` on a runner — so no token handling lands in this file and nothing new has to be kept out of a log.

**`pages.yml`** gains `repository_dispatch: types: [data-plane-published]`, and the **deploy** job's condition accepts it. Both halves matter: the build job runs for pull requests too, so that condition is the only thing deciding what reaches the site — adding the trigger without adding it there would build the new generation and deploy nothing.

`workflow_dispatch` is now allowed to deploy as well, deliberately: once dashboard publishes stop landing on `master`, "push something to force a rebuild" stops being available, and a lost dispatch would otherwise need a dummy commit to recover from. `pull_request` still must not — it is the one event whose build comes from untrusted content.

**Asked for only when the publish actually changed the branch.** 72 ticks a day, most changing nothing; `PublishResult.changed` from #316 is what makes that decidable. And a request that could not be made **exits non-zero** — a generation sitting on the branch that never reached the site is precisely the failure this seam exists to surface, because nothing else in the system notices a frozen site.

## One ordering detail that is not incidental

The data-plane step moves to **after** the master publish, on both exit paths. During the dual write both destinations trigger a Pages run and `concurrency: pages` cancels the older one — going second is what leaves the *dispatched* run to finish, so the path that has to work after the cut is the one actually being exercised now. Ordering is free precisely because #316 made the store self-healing; before that, going second risked a permanently stale branch.

Both exit paths call it, including the quiet "no semantic or heartbeat change" one — a quiet tick is exactly when nothing else would force a retry of a publish that never arrived.

## Verification

Six behavioural tests, all mutation-verified with a fake `gh` on `PATH` and a real local origin: renaming the event type on the sender alone, dropping `repository_dispatch` from the deploy condition, swallowing a failed dispatch, asking for a deploy on an unchanged republish, and making `--deploy` the default each turn exactly the intended test red.

Full suite: 1604 passed, 4 xfailed.

## Live state going in

`data-plane` has been written every 20 minutes since #316 merged, byte-identical to what the same tick commits to `master` (verified against the live branch, first generation `f3cc941e` — parentless, bot identity, exactly four files). #317's Pages build fetches it in CI and passes. This PR is what makes the trigger survive the cut; the cut itself is still ahead.
