### PR TITLE
publish: the deploy request was rejected 422 — client_payload must be an object (#314)

### DIFF
--- a/clawock/publish/deploy.py
+++ b/clawock/publish/deploy.py
@@ -75,11 +75,18 @@ class GitHubDispatchDeployer:
         self.event_type = event_type
 
     def request(self, reason: str = "") -> str:
-        payload = json.dumps({"reason": reason} if reason else {})
+        # The whole body as one JSON document on stdin, not `-f`/`--raw-field`
+        # pairs. `client_payload` has to arrive as an OBJECT, and both of those
+        # flags send their value as a string — GitHub answers 422 ("is not an
+        # object") and the deploy is never requested. A fake `gh` that only
+        # checks the command exits 0 cannot see this; the test below parses the
+        # body it was handed.
+        body = {"event_type": self.event_type}
+        if reason:
+            body["client_payload"] = {"reason": reason}
         subprocess.run(
-            ["gh", "api", f"repos/{self.repository}/dispatches",
-             "-f", f"event_type={self.event_type}",
-             "--raw-field", f"client_payload={payload}"],
-            check=True, capture_output=True, text=True,
+            ["gh", "api", "--method", "POST",
+             f"repos/{self.repository}/dispatches", "--input", "-"],
+            input=json.dumps(body), check=True, capture_output=True, text=True,
         )
         return f"{self.event_type} → {self.repository}"

--- a/tests/test_site_deploy.py
+++ b/tests/test_site_deploy.py
@@ -51,15 +51,25 @@ def workspace(tmp_path):
 
 
 def _fake_gh(tmp_path, *, exit_code=0):
-    """A `gh` that records its arguments instead of talking to GitHub."""
+    """A `gh` that records its arguments AND the request body it was handed.
+
+    Recording only the arguments is what let a real 422 through: the body was
+    being sent as `--raw-field client_payload={...}`, which GitHub receives as a
+    *string*, and it requires an object. A fake that just exits 0 agrees with
+    anything — the assertions below parse what it captured.
+    """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     log = tmp_path / "gh.log"
+    body = tmp_path / "gh.body"
     (bin_dir / "gh").write_text(
-        f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> {log}\nexit {exit_code}\n',
+        f'#!/usr/bin/env bash\n'
+        f'printf "%s\\n" "$*" >> {log}\n'
+        f'if [ -t 0 ]; then :; else cat > {body}; fi\n'
+        f'exit {exit_code}\n',
         encoding="utf-8")
     (bin_dir / "gh").chmod(0o755)
-    return bin_dir, log
+    return bin_dir, log, body
 
 
 def _publish(workspace, bin_dir, *extra):
@@ -74,7 +84,7 @@ def test_the_dispatch_names_the_event_the_workflow_listens_for(tmp_path):
     """Two files have to agree on a string neither can validate at runtime. A
     rename on one side alone leaves the publisher reporting a successful request
     for an event nothing handles — every gate green, site frozen."""
-    bin_dir, log = _fake_gh(tmp_path)
+    bin_dir, log, body = _fake_gh(tmp_path)
     env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
     subprocess.run([sys.executable, "-c",
                     "import sys; sys.path.insert(0, %r);"
@@ -82,13 +92,16 @@ def test_the_dispatch_names_the_event_the_workflow_listens_for(tmp_path):
                     "D('KCNyu/clawock').request('why')" % str(ROOT)],
                    env=env, check=True, capture_output=True, text=True)
 
-    sent = log.read_text()
-    event = re.search(r"event_type=(\S+)", sent).group(1)
+    assert "repos/KCNyu/clawock/dispatches" in log.read_text()
+    sent = json.loads(body.read_text())
     declared = re.search(r"repository_dispatch:\s*\n\s*types:\s*\[([^\]]+)\]",
                          WORKFLOW).group(1)
 
-    assert event in [name.strip() for name in declared.split(",")]
-    assert "repos/KCNyu/clawock/dispatches" in sent
+    assert sent["event_type"] in [name.strip() for name in declared.split(",")]
+    # GitHub rejects a `client_payload` that is not an object, with a 422 the
+    # publisher reports as "the site deploy was not requested" — a real failure
+    # that a fake `gh` exiting 0 was perfectly happy with.
+    assert isinstance(sent.get("client_payload"), dict), sent
 
 
 def test_a_dispatched_run_is_allowed_to_deploy():
@@ -108,7 +121,7 @@ def test_a_publish_that_could_not_ask_for_a_deploy_is_not_success(workspace, tmp
     """A generation on the branch that never reached the site is exactly the
     failure this seam exists to surface — nothing else in the system notices a
     frozen site. It must not exit 0."""
-    bin_dir, _ = _fake_gh(tmp_path, exit_code=1)
+    bin_dir, _, _ = _fake_gh(tmp_path, exit_code=1)
 
     result = _publish(workspace, bin_dir, "--deploy")
 
@@ -121,7 +134,7 @@ def test_a_publish_that_could_not_ask_for_a_deploy_is_not_success(workspace, tmp
 def test_an_unchanged_generation_asks_for_nothing(workspace, tmp_path):
     """72 ticks a day, and most change nothing. Asking every time would rebuild
     and redeploy the site for a generation it already serves."""
-    bin_dir, log = _fake_gh(tmp_path)
+    bin_dir, log, body = _fake_gh(tmp_path)
 
     first = _publish(workspace, bin_dir, "--deploy")
     second = _publish(workspace, bin_dir, "--deploy")
@@ -135,7 +148,7 @@ def test_an_unchanged_generation_asks_for_nothing(workspace, tmp_path):
 def test_publishing_without_the_flag_asks_no_one(workspace, tmp_path):
     """A third party publishing to a filesystem has nobody to ask. The deploy
     request is this instance's configuration, so it is opt-in."""
-    bin_dir, log = _fake_gh(tmp_path)
+    bin_dir, log, body = _fake_gh(tmp_path)
 
     result = _publish(workspace, bin_dir)
 


### PR DESCRIPTION
Fixes a real defect in #318, found by **firing a dispatch against real GitHub instead of trusting the test**.

```
422 Invalid request.
For 'properties/client_payload', "{\"reason\":\"x\"}" is not an object.
```

`gh api -f` and `--raw-field` both send their value as a **string**. The dispatch API requires `client_payload` to be an **object**. So every publish since #318 merged would have exited non-zero with `✗ data-plane: published, but the site deploy was not requested` — correctly *reported*, which is the part that worked, but the deploy was never actually asked for.

The body now goes as a single JSON document on stdin (`--input -`, explicit `--method POST`).

## Why the test did not catch it, and what changed

The fake `gh` recorded its **arguments** and exited 0. A fake that exits 0 agrees with anything — it can confirm the command was assembled, never that GitHub would accept it. That is the "the function is right but the wiring is broken" shape, one layer further out than usual: the wiring was right too, and the *payload encoding* was wrong.

The fake now also captures the request **body** and the test parses it, asserting `client_payload` arrives as an object and that `event_type` matches the workflow's declared `types:`. Mutation-verified by restoring the exact broken call — it turns the test red.

## Verification

Fired against `KCNyu/clawock` after the fix:

```
data-plane-published → KCNyu/clawock
2026-08-05T09:28:08Z repository_dispatch in_progress
```

That is the trigger for the whole migration proven end to end in production — the thing that has to replace the `master` push once #319 lands.

Full suite: 1604 passed, 4 xfailed.
