### PR TITLE
postflights: staging an untracked output aborts the commit that carries the money file (#314)

### DIFF
--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -42,7 +42,6 @@ from clawock.validation import (  # noqa: E402,F401
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
-from dashboard_outputs import semantic_changed_paths as dashboard_output_changes  # noqa: E402
 
 # Single-publisher mutex for all dashboard build outputs (Option 1, 2026-07-04).
 # Shared by the host harness rebuild and publish_dashboard.sh crontab so the two

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -442,7 +442,6 @@ def categorize(issues):
 sys.path.insert(0, str(Path(__file__).parent))
 from _harness_common import (  # noqa: E402
     categorize_issues,
-    dashboard_output_changes,
     git_cmd as _git,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -522,7 +521,6 @@ def maybe_commit(status, today, dry_run=False):
 
     log_decisions(today)   # upsert today's v2 plan (idempotent)
     rebuild_dashboard()
-    dashboard_paths = dashboard_output_changes()
 
     msg_suffix = ' (validation warnings)' if status == 'warn' else ''
     # risk.json / lev_regime.json / benchmark.json are rebuilt fresh by this
@@ -540,7 +538,11 @@ def maybe_commit(status, today, dry_run=False):
     # silently lost samples on every fresh checkout. macro/sentiment/influencer/
     # us_news_digest are deliberately NOT here: GH Actions own those, preflight only
     # reads them, and committing them from this side would fight the workflow.
-    add_ok, add_out = _git('add', 'memory/', 'portfolio.json', *dashboard_paths,
+    # The four dashboard outputs are deliberately absent: #314 untracked them,
+    # and `git add` on a gitignored path fails rather than skipping — it would
+    # abort this entire commit, which carries portfolio.json, the decision
+    # ledger and the whole preflight write set.
+    add_ok, add_out = _git('add', 'memory/', 'portfolio.json',
                             'memory/decisions.jsonl', 'assets/data/risk.json',
                             'assets/data/lev_regime.json', 'assets/data/benchmark.json',
                             'assets/data/quant_signals.json',

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -48,7 +48,6 @@ from _harness_common import (  # noqa: E402
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
-    dashboard_output_changes,
     git_cmd,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -262,7 +261,10 @@ def publish_data_plane(market):
         ok, _ = rebuild_dashboard()
         if not ok:
             return 'rebuild_failed', False
-        paths = [*dashboard_output_changes(), 'logs/dashboard_build_status.json']
+        # No dashboard outputs here: #314 untracked them, and `git add` on a
+        # gitignored path fails rather than skipping, which would abort the
+        # snapshot commit too.
+        paths = ['logs/dashboard_build_status.json']
         snap = snapshot_date_for_now()
         if snap:
             paths.append(f'memory/snapshots/{snap}.json')

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -102,7 +102,6 @@ from _harness_common import (  # noqa: E402
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
-    dashboard_output_changes,
     git_cmd as _git,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -255,7 +254,6 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
 
 def maybe_commit(status, commit_msg):
     rebuild_ok, _ = rebuild_dashboard()
-    dashboard_paths = dashboard_output_changes()
     suffix = {
         'warn': ' (validation warnings)',
         'fail': ' (data only; prose rejected)',
@@ -263,7 +261,12 @@ def maybe_commit(status, commit_msg):
     snap_date = snapshot_date_for_now()
     # logs/dashboard_build_status.json rides along: its only scheduled reader is
     # the GHA cron-health runner (fresh checkout), so it must reach origin.
-    add_args = ['add', 'portfolio.json', *dashboard_paths,
+    # The four dashboard outputs are NOT staged: #314 took them out of the
+    # repository, and `git add` on a gitignored path FAILS rather than skipping
+    # — which would abort this commit and take portfolio.json and the snapshot
+    # down with it. The rebuild above still refreshes them in the worktree; the
+    # scheduled publisher puts them on the data branch within 20 minutes.
+    add_args = ['add', 'portfolio.json',
                 'logs/dashboard_build_status.json']
     if snap_date:
         add_args.append(f'memory/snapshots/{snap_date}.json')

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -1,5 +1,6 @@
 """One build, four public outputs, one semantic publication contract."""
 import json
+import re
 import pytest
 import subprocess
 import sys
@@ -166,33 +167,60 @@ def test_reflect_backtest_change_publishes_the_existing_audit_sidecar(tmp_path):
 
 
 def test_nothing_stages_the_outputs_into_a_commit_any_more():
-    """#314 took the four outputs out of repository history, so every path that
-    added them to a commit had to stop.
+    """#314 untracked the four outputs, so every path that added them to a commit
+    had to stop. `git add` on a gitignored path FAILS rather than skipping, and
+    these commits carry `portfolio.json`, the decision ledger and the daily
+    snapshot — so a leftover stager does not publish a stale dashboard, it stops
+    the money file from being committed at all.
 
-    `git add` on a gitignored path FAILS rather than skipping, so a missed one is
-    a red publish rather than a quiet one — but "the publisher is red every 20
-    minutes" is not a discovery mechanism, and two of these five were found only
-    because a contract test named them. This is that test, inverted: it used to
-    assert they all staged, and now asserts none does.
+    DISCOVERED, not listed. The first version of this test named five files by
+    hand and passed while three postflights still staged them; they were found
+    only when the daily brief was hours from failing. So it walks every committer
+    and asks a structural question: does this file both derive dashboard output
+    paths and hand paths to `git add`?
     """
-    assert set(dashboard_outputs.DASHBOARD_OUTPUTS) == EXPECTED
-
-    stagers = (
-        ".githooks/pre-commit",
-        "scripts/data/gold_dca_refresh.sh",
-        "scripts/data/publish_dashboard.sh",
-        "scripts/data/update_gold_dca.py",
-        "scripts/harness/_harness_common.py",
-    )
+    owner = "scripts/data/dashboard_outputs.py"
+    derives = ("dashboard_output_changes", "semantic_changed_paths",
+               "DASHBOARD_OUTPUTS")
     offenders = []
-    for rel in stagers:
-        for line in (ROOT / rel).read_text().splitlines():
-            code = line.split("#", 1)[0]
-            if "git" in code and "add" in code and "dashboard_paths" in code:
-                offenders.append(f"{rel}: {line.strip()}")
+    for root in ("scripts", ".githooks"):
+        for path in sorted(ROOT.joinpath(root).rglob("*")):
+            if not path.is_file() or path.suffix not in ("", ".py", ".sh"):
+                continue
+            rel = path.relative_to(ROOT).as_posix()
+            if rel == owner:
+                continue
+            code = "\n".join(line.split("#", 1)[0] for line in
+                              path.read_text(errors="ignore").splitlines())
+            if not any(name in code for name in derives):
+                continue
+            # `git add` as an actual invocation, in shell or argv form —
+            # not the substring, which matches half the file.
+            if re.search(r"""git[^\n]{0,24}['"\s]add\b""", code):
+                offenders.append(rel)
 
     assert not offenders, (
-        f"these still stage outputs that are no longer tracked: {offenders}")
+        "these both derive dashboard output paths and run `git add`, which is "
+        f"how an untracked output gets staged again: {offenders}")
+
+
+def test_the_publish_path_for_the_outputs_is_the_data_branch_alone():
+    """One publisher for the generation, and it is not a committer.
+
+    Stated as a test because the three postflights used to publish these by
+    committing them, and 'rebuild then let the scheduled publisher pick it up'
+    is a quieter contract than it looks — nothing errors if a postflight starts
+    staging them again, until `git add` refuses and takes the whole commit down.
+    """
+    publisher = (ROOT / "scripts/data/publish_data_branch.py").read_text()
+    assert "DASHBOARD_OUTPUTS" in publisher
+    for rel in ("scripts/harness/brief_postflight.py",
+                "scripts/harness/report_postflight.py",
+                "scripts/harness/intraday_postflight.py"):
+        text = (ROOT / rel).read_text()
+        assert "dashboard_output_changes" not in text, (
+            f"{rel} still derives dashboard output paths; its only former use "
+            "was staging them")
 
 
 def test_the_publisher_compares_against_what_was_published():

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -347,11 +347,16 @@ def test_happy_path_assembles_commits_and_records_delivered(run_main, sent):
     assert body.startswith('🌙 美股收盘日报') and FRESH_BLOCK in body and '▎情绪面' in body
 
 
-def test_failed_narrative_still_commits_only_the_data_plane_paths(pf, monkeypatch):
+def test_failed_narrative_still_commits_the_money_file_and_nothing_ignored(pf, monkeypatch):
+    """A rejected narrative must not cost the deterministic half of the run.
+
+    It used to stage the dashboard outputs alongside `portfolio.json`. Since #314
+    those are gitignored, and `git add` on an ignored path FAILS — which would
+    have aborted this commit and taken the money file with it. The rebuild still
+    happens; only the staging is gone.
+    """
     calls = []
     monkeypatch.setattr(pf, 'rebuild_dashboard', lambda: (True, 'ok'))
-    monkeypatch.setattr(pf, 'dashboard_output_changes',
-                        lambda: ['assets/data/dashboard.json'])
     monkeypatch.setattr(pf, 'snapshot_date_for_now', lambda: None)
     monkeypatch.setattr(pf, 'push_with_rebase_retry', lambda: (True, 'ok'))
 
@@ -365,13 +370,11 @@ def test_failed_narrative_still_commits_only_the_data_plane_paths(pf, monkeypatc
 
     assert ok is True and message == 'committed + pushed'
     assert calls[0] == (
-        'add', 'portfolio.json', 'assets/data/dashboard.json',
-        'logs/dashboard_build_status.json',
+        'add', 'portfolio.json', 'logs/dashboard_build_status.json',
     )
     assert calls[1] == (
         'commit', '-m', 'portfolio: refresh (data only; prose rejected)', '--',
-        'portfolio.json', 'assets/data/dashboard.json',
-        'logs/dashboard_build_status.json',
+        'portfolio.json', 'logs/dashboard_build_status.json',
     )
 
 


### PR DESCRIPTION
**Urgent.** Three stagers survived #314 — all three postflights, through `dashboard_output_changes()`. I claimed five and there were eight.

## What actually breaks

Not a stale dashboard. The chain:

1. `dashboard_output_changes()` is `semantic_changed_paths()` with the default `GitBaseline(HEAD)`.
2. HEAD no longer carries these four files, so `git show HEAD:assets/data/dashboard.json` fails, the `SubprocessError` branch catches it, and all four are **conservatively reported as changed**.
3. `git add` on a gitignored path **exits 1** rather than skipping.
4. Every one of these call sites treats a failed add as "skip the commit":

```
report_postflight.py:275    if not ok: return False, 'git add failed'
intraday_postflight.py:272  if not added: return 'git_add_failed', False
brief_postflight.py:566     return False, f'git add failed: …'
```

So the commit that carries **`portfolio.json`, `memory/decisions.jsonl`, the daily snapshot and the entire preflight write set** simply does not happen. The money file stops being committed, and the only symptom is a line in a log.

Timing: the cut landed 18:15 HKT, after the HK close. The next US intraday slot (00:00 HKT) was about two hours away when this was found. It has not fired yet.

## The fix

The rebuild stays; only the staging goes. The scheduled publisher puts the generation on the data branch within 20 minutes, which is where it belongs now.

`_harness_common`'s re-export of `semantic_changed_paths` is removed too — staging was its only consumer.

## The test that let this through, and what replaced it

`test_nothing_stages_the_outputs_into_a_commit_any_more` named five files **by hand**. It passed, green, while three postflights still staged them. A list is only as good as the moment it was written, and I wrote it while looking at the wrong five files.

It is discovered now: it walks every file under `scripts/` and `.githooks/` and asks a structural question — *does this file both derive dashboard output paths and invoke `git add`?* The regex matches `git add` as an invocation (shell or argv form) rather than as a substring, so the data-plane publisher and reader, which legitimately reference `DASHBOARD_OUTPUTS`, are not false positives.

Mutation-verified: restoring `dashboard_paths` into `report_postflight`'s `add_args` turns both new tests red.

`test_failed_narrative_still_commits_only_the_data_plane_paths` also had to change — it asserted the old staging set exactly. Renamed to say what it now protects: a rejected narrative must not cost the deterministic half of the run.

Full suite: 1607 passed, 4 xfailed.

## What this says about #319

The contract test in #319 was the thing meant to catch exactly this class, and it caught two of five and missed three of eight. The lesson is not "look harder" — it is that a test enumerating call sites has the same failure mode as the code it guards. Worth remembering the next time a migration needs "and make sure nothing else does X".
