### PR TITLE
recovery: the fresh-checkout population reports itself, instead of being scanned for (#302, #314)

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -91,6 +91,43 @@ jobs:
           tail -20 "${RUNNER_TEMP:-/tmp}/postflight.log"
           [ "$code" -lt 2 ] || exit "$code"
 
+      - name: Report which cards the recovery restored
+        # #302's detector was "scan master's history for a build whose payload
+        # has a non-empty build_status.previous_payload.preserved". #314 replaced
+        # that history with a force-updated branch holding one generation, so the
+        # scan cannot be moved — only replaced.
+        #
+        # Replaced here, and better than what it replaced: this workflow is the
+        # ONLY producer of that population (the one caller where `--previous`
+        # does anything), so it answers for itself, on the run that did it,
+        # instead of a corpus scan days later. Not a gate — recovering those
+        # cards is this job's purpose; this is the record that it happened.
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          payload = pathlib.Path('assets/data/dashboard.json')
+          if not payload.is_file():
+              print('### Recovery\n\nNo payload was built.')
+              raise SystemExit(0)
+          status = json.loads(payload.read_text()).get('build_status', {})
+          previous = status.get('previous_payload', {}) or {}
+          preserved = previous.get('preserved') or []
+          print('### Recovery')
+          print()
+          if previous.get('missing'):
+              print(f"Recovery source **did not resolve**: `{previous.get('source')}`.")
+              print('This build is workspace-only; every card came from this checkout.')
+          elif preserved:
+              print(f'Restored **{len(preserved)}** card(s) from the last published')
+              print('generation, because this checkout has no `memory/.tmp` sidecars:')
+              print()
+              for key in preserved:
+                  print(f'- `{key}`')
+          else:
+              print('Nothing restored — every source was present in this checkout.')
+          PY
+
       - name: Commit + push
         # Reached when postflight exits <2: pass/warn, or an uncaught exception (exit 1).
         # The publish gate distinguishes a legitimate warn from a crash-before-gate;

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -1318,3 +1318,30 @@ def test_a_named_previous_that_is_not_there_is_reported_not_swallowed(tmp_path, 
     present = tmp_path / "there.json"
     present.write_text('{"anomalies": ["kept"]}', encoding="utf-8")
     assert dashboard.load_previous_payload(present) == ({"anomalies": ["kept"]}, False)
+
+
+def test_the_fresh_checkout_population_is_reported_by_its_only_producer():
+    """#302's detector was "scan master's history for a build whose payload has a
+    non-empty `build_status.previous_payload.preserved`". #314 replaced that
+    history with a force-updated branch holding one generation, so the scan
+    cannot be moved — only replaced.
+
+    The replacement is better than what it replaced, and this pins it: the
+    population has exactly ONE producer — `brief-fallback.yml`, the only caller
+    where `--previous` does anything — so it reports on itself, on the run that
+    did it, instead of a corpus scan days later. The host telemetry
+    (`memory/.tmp/preserve-absent-*.jsonl`) is blind to this population by
+    construction: a runner has no `memory/.tmp`.
+    """
+    workflow = (ROOT / ".github/workflows/brief-fallback.yml").read_text()
+
+    assert "previous_payload" in workflow, (
+        "brief-fallback no longer reports what the recovery restored; the "
+        "fresh-checkout population is unobservable again")
+    assert "GITHUB_STEP_SUMMARY" in workflow
+    # It must run whether or not the build published, and must not be able to
+    # fail the job — this is a record, not a gate. Recovering the cards is this
+    # workflow's purpose, so doing it is not an error condition.
+    report = workflow.split("Report which cards the recovery restored", 1)[1]
+    assert "raise SystemExit(0)" in report.split("Commit + push", 1)[0], (
+        "a missing payload must end the report, not fail the run")


### PR DESCRIPTION
Closes the last open item on **#314**'s acceptance list.

#302's detector was *"scan `master`'s history for a build whose payload has a non-empty `build_status.previous_payload.preserved`"* — the only way to find publishers that built without the `memory/.tmp` sidecars and relied on the recovery merge. #314 replaced that history with a force-updated branch holding a single generation, so the scan cannot be moved. Only replaced, or dropped with a reason.

## Replaced, and better than what it replaced

The population has exactly **one** producer: `brief-fallback.yml`, the one caller where `--previous` does anything. So it can answer for itself, **on the run that did it**, instead of a corpus scan days later — same information, no dependence on repository history, and it appears in the run's own summary rather than needing someone to go looking.

Three states, all exercised against real payloads before shipping:

- cards restored → lists them by name
- recovery source did not resolve → reports it (this is #315's signal surfacing where a human will see it)
- nothing restored → says so, which is the live host's normal case and the one that gives "it has not fired" a denominator

**Not a gate.** Recovering those cards is that workflow's entire purpose, so doing it is not an error condition. A missing payload ends the report rather than failing the run.

## What is unchanged

The host telemetry, `memory/.tmp/preserve-absent-*.jsonl`, is untouched. It stays blind to this population by construction — a runner has no `memory/.tmp` — and that blindness is precisely why the detector existed in the first place. The two are complements: the JSONL answers "is the live host clean", this answers "did the fallback path rely on recovery".

## Verification

Executed the step body as bash actually would — extracted from the YAML, run with `GITHUB_STEP_SUMMARY` pointed at a temp file, against the live host's real payload. Exit 0, correct summary. The nested heredoc inside `run: |` is the part worth having actually run rather than eyeballed.

A contract test pins that the step exists, writes to the step summary, and cannot fail the job; mutation-verified by deleting the step.

One thing the workflow itself taught me: the comment block belongs **inside** the step, after `- name:`, not above it. `tests/test_brief_fallback_gate.py` slices `run:` bodies by indentation, and a step-level comment at 6 spaces silently truncated the *previous* step's parsed body. The file's existing convention was already right; I had put mine in the wrong place.

Full suite: 1615 passed, 4 xfailed.
