### PR TITLE
intraday: a postflight publishes what it rebuilt, instead of waiting for the next tick (#328)

### DIFF
--- a/scripts/data/publish_dashboard.sh
+++ b/scripts/data/publish_dashboard.sh
@@ -103,12 +103,9 @@ python3 scripts/data/dashboard_outputs.py --baseline-dir "$PREVIOUS_DIR" > /dev/
 # destination is the data branch (#325).
 data_plane_failed=0
 publish_data_plane() {
-  # Sourced for GIT_SSH_COMMAND/PUBLISH_REMOTE — the same deploy-key identity
-  # safe_push.sh uses, selected in one place rather than restated per publisher.
-  # shellcheck source=scripts/data/publish_identity.sh
-  . scripts/data/publish_identity.sh
-  if ! python3 scripts/data/publish_data_branch.py \
-       --deploy --remote "${PUBLISH_REMOTE:-origin}"; then
+  # One entry point, shared with the harness postflights (#328) — identity
+  # selection and the publish itself must not drift between the two callers.
+  if ! bash scripts/data/publish_generation.sh; then
     echo "✗ publish_dashboard: data plane not published or not deployed" >&2
     return 1
   fi

--- a/scripts/data/publish_generation.sh
+++ b/scripts/data/publish_generation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# publish_generation.sh — put the generation currently in the workspace on the
+# data branch, and ask for the site to be rebuilt.
+#
+# THE single entry point for that, because there are two kinds of caller and they
+# must not drift: the scheduled publisher (`publish_dashboard.sh`, every 20
+# minutes) and the harness postflights, which rebuild after a report and used to
+# publish by committing (#328). Before #326 the commit itself matched
+# `pages.yml`'s `paths:` and triggered the deploy; with the outputs untracked
+# that path is gone, and a postflight's generation would otherwise sit in the
+# worktree until the next scheduled tick — up to 20 minutes on every intraday
+# slot, which is the opposite of what intraday monitoring is for.
+#
+# Identity selection lives here rather than in each caller: a Python caller
+# cannot source a shell file, and restating the deploy-key logic is exactly the
+# duplication #316 removed for safe_push.sh.
+#
+# Idempotent and self-healing by construction — the store compares against what
+# the branch actually holds, so a redundant call is a no-op and a call that
+# failed last time repairs itself with no new information.
+set -uo pipefail
+
+WS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$WS_ROOT"
+
+# shellcheck source=scripts/data/publish_identity.sh
+. "$WS_ROOT/scripts/data/publish_identity.sh"
+
+exec python3 "$WS_ROOT/scripts/data/publish_data_branch.py" \
+  --deploy --remote "${PUBLISH_REMOTE:-origin}"

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -312,11 +312,49 @@ def rebuild_dashboard(ws=None):
         )
         ok = r.returncode == 0
         full = r.stdout + r.stderr
+        if ok:
+            full += _publish_generation(ws)
         _record_dashboard_build(ok, full, ws)
         return ok, full[-300:]
     except Exception as e:
         _record_dashboard_build(False, str(e), ws)
         return False, str(e)
+
+
+def _publish_generation(ws):
+    """Put the generation this rebuild just produced on the data branch.
+
+    Here rather than in each postflight on purpose. Before #326 a postflight
+    published by committing — the commit matched `pages.yml`'s `paths:` and the
+    deploy followed. With the outputs untracked that path is gone, so a
+    generation built by an intraday slot would sit in the worktree until the next
+    scheduled tick: up to 20 minutes, on every slot, which is the opposite of
+    what intraday monitoring is for (#328).
+
+    On the shared path every generation-builder already goes through, so a fourth
+    postflight gets this by construction. A hand-maintained list of callers is
+    exactly what missed three postflights in #319 and had to be repaired in #322.
+
+    Non-fatal, and loud. These callers deliver reports; a publishing fault must
+    not take the report's own commit and push down with it. The outcome rides in
+    the build record, so a failure is visible to the daily cron health check
+    rather than only in a log nobody opens.
+
+    Idempotent: the store compares against what the branch actually holds, so an
+    interleaved scheduled tick makes this a no-op rather than a conflict — which
+    is why it does not need to hold the build lock.
+    """
+    try:
+        r = subprocess.run(
+            ['bash', str(ws / 'scripts' / 'data' / 'publish_generation.sh')],
+            capture_output=True, text=True, timeout=120, cwd=str(ws),
+        )
+    except Exception as e:                       # noqa: BLE001 - reported, not raised
+        return f'\n  data-plane publish failed: {e}'
+    tail = (r.stdout + r.stderr).strip()[-200:]
+    if r.returncode != 0:
+        return f'\n  data-plane publish failed: {tail}'
+    return f'\n  {tail}'
 
 
 def push_with_rebase_retry(remote='origin', branch='master', attempts=3):

--- a/tests/test_dashboard_output_ownership.py
+++ b/tests/test_dashboard_output_ownership.py
@@ -419,3 +419,41 @@ def test_a_fresh_checkout_can_still_restore_the_workflow_card():
 
     assert "_presence['workflow_outcomes']" in builder, (
         "the workflow card has no recovery path on a fresh checkout")
+
+
+def test_every_generation_builder_publishes_what_it_built():
+    """#326 stopped the scheduled publisher committing; nothing replaced the
+    postflights' publish, so an intraday generation sat in the worktree until the
+    next 20-minute tick (#328). Measured at the time: disk 15:05, branch and site
+    15:00.
+
+    Pinned on the SHARED path, not on a list of postflights. A caller list is
+    what missed three of them in #319 and had to be repaired in #322 — the same
+    failure mode, twice in one day. `rebuild_dashboard` is the one function every
+    generation-builder already goes through, so a fourth postflight gets this by
+    construction.
+    """
+    harness = (ROOT / "scripts/harness/_harness_common.py").read_text()
+    rebuild = harness.split("def rebuild_dashboard", 1)[1].split("\ndef ", 1)[0]
+
+    assert "_publish_generation(ws)" in rebuild, (
+        "a rebuild no longer publishes what it built; its generation reaches the "
+        "site only when the next scheduled tick happens to run")
+
+
+def test_the_publish_path_is_shared_and_not_restated():
+    """Two kinds of caller reach the data branch — the scheduled publisher and
+    the postflights — and both need the deploy-key identity. A Python caller
+    cannot source a shell file, so restating the selection is the obvious wrong
+    turn; it is the duplication #316 removed for `safe_push.sh`."""
+    entry = ROOT / "scripts/data/publish_generation.sh"
+    assert entry.is_file()
+    body = entry.read_text()
+    assert "publish_identity.sh" in body and "publish_data_branch.py" in body
+
+    for rel in ("scripts/data/publish_dashboard.sh",
+                "scripts/harness/_harness_common.py"):
+        text = (ROOT / rel).read_text()
+        assert "publish_generation.sh" in text, f"{rel} does not use the shared entry"
+        assert "publish_identity.sh" not in text, (
+            f"{rel} restates the identity selection instead of sharing it")


### PR DESCRIPTION
Closes #328. A regression from #326, found by looking at what the intraday slot actually did rather than at whether it errored.

## Measured

23:05 HKT, immediately after the US intraday slot ran:

```
本机磁盘   2026-08-05T15:05:02   ← what the slot just built
data-plane 2026-08-05T15:00:03
线上站点   2026-08-05T15:00:03   ← a generation behind
```

Its commit carried `logs/dashboard_build_status.json` and `memory/snapshots/2026-08-05.json`. **Neither matches `pages.yml`'s `paths:`** — checked against the workflow, not assumed — so it triggered no deploy at all.

Before #326 the same commit carried `assets/data/dashboard.json`, matched `assets/data/**`, and the site refreshed within a couple of minutes. Nothing replaced that when the outputs were untracked: the argument for "the publisher stops committing" was complete, and the question *"then who publishes the generation the postflights build?"* was never asked.

Every US intraday slot from 00:00–02:30 HKT would have been up to 20 minutes stale. Not a data error — the site served a correct, complete, older generation — but directly against what intraday monitoring is for, and it breaks the second half of #314's own freshness criterion ("every 20 minutes on the host, **plus intraday and postflight publishes**").

## Where the call goes, and why that is the whole design decision

`rebuild_dashboard` — the one function every generation-builder already goes through — **not** each postflight.

A hand-maintained caller list is what missed three postflights in #319 and had to be repaired in #322. That is the same failure mode twice in one day, and adding a fourth list here would be inviting it a third time. On the shared path, a future postflight gets this by construction, and the test pins the shared path rather than enumerating callers.

## `publish_generation.sh`

One entry point, because there are now two kinds of caller and they must not drift: the scheduled publisher and the postflights. Identity selection lives inside it — a Python caller cannot source a shell file, and restating the deploy-key logic is exactly the duplication #316 removed for `safe_push.sh`. `publish_dashboard.sh` now goes through it too, so there is one path, not two that happen to agree today.

## Three properties it needs and has

- **Non-fatal, and loud.** These callers deliver reports. A publishing fault must not take the report's own commit and push down with it, so the failure rides in the build record — where the daily cron health check already looks — instead of raising.
- **Idempotent.** The store compares against what the branch actually holds, so a redundant call is a no-op.
- **No lock.** Follows from the above: an interleaved scheduled tick makes this a no-op rather than a conflict, so it does not need to hold the build lock and cannot deadlock against it.

## Verification

Two contract tests, both mutation-verified: removing the publish from `rebuild_dashboard`, and making the publisher bypass the shared entry to source the identity itself, each turn exactly the intended test red.

Full suite 1620 passed, 4 xfailed — and re-run with both sidecars moved out of the worktree, which is the condition CI actually runs under. (That check exists because the last two PRs were green locally and red in CI for precisely this reason.)

End-to-end on the live host has to wait for deployment: a worktree has never built these six files, so the shared entry correctly refuses there. It will be exercised by the next US intraday slot, and I will confirm the three clocks agree.
