### PR TITLE
us quotes: a daily-bar provider's %change is not today's, so stop composing it into a price (#332)

### DIFF
--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -433,7 +433,22 @@ def get_yfinance_quote(ticker: str) -> Optional[Dict]:
 
 
 def get_alpha_vantage_quote(ticker: str, api_key: str) -> Optional[Dict]:
-    """Alpha Vantage GLOBAL_QUOTE – needs key, slow (~15s)."""
+    """Alpha Vantage GLOBAL_QUOTE – needs key, slow (~15s).
+
+    GLOBAL_QUOTE is a DAILY-BAR endpoint, not a live tick: mid-session it can
+    still be serving yesterday's completed bar, and every field in the payload
+    then belongs to that prior session — including `10. change percent`, whose
+    baseline is the close *before* it. 2026-08-05 12:01 ET it answered PLTU with
+    the 08-04 bar (price 44.82, previous close 28.39, +57.87%) while the stock
+    was actually trading at 43.65.
+
+    `07. latest trading day` is the payload's own statement of which session it
+    describes, and nothing was reading it — so the quote carried no `asof_date`
+    and `_quote_is_fresh` (correctly) treated a timestamp-less quote as current.
+    Reporting it lets the freshness gate do its job, and lets the stale-last
+    guard see that this quote's %change is measured against a different close
+    than ours (see the baseline check in update_us_portfolio).
+    """
     if not api_key:
         return None
     try:
@@ -447,7 +462,7 @@ def get_alpha_vantage_quote(ticker: str, api_key: str) -> Optional[Dict]:
         if not c:
             return None
         pc = _parse_price(q.get('08. previous close')) or c
-        return {
+        quote = {
             'c': c, 'pc': pc,
             'h': _parse_price(q.get('03. high')) or c,
             'l': _parse_price(q.get('04. low')) or c,
@@ -455,6 +470,10 @@ def get_alpha_vantage_quote(ticker: str, api_key: str) -> Optional[Dict]:
             'dp': _pct(c, pc),
             'source': 'Alpha Vantage',
         }
+        asof = (q.get('07. latest trading day') or '').strip()
+        if asof:
+            quote['asof_date'] = asof
+        return quote
     except Exception:
         return None
 
@@ -1074,10 +1093,29 @@ def update_us_portfolio(
         # (2026-07-27 PLTU: pc 27.35 + nc 1.47 = 28.82, the real print, against a
         # reported 27.35 that showed the position as flat on a +6.3% day);
         # percentageChange is the rounder fallback.
+        #
+        # The rebuild is arithmetic only while the provider measured its move
+        # against the SAME prior close we hold. When it did not, `pc + nc` /
+        # `pc × (1+dp)` composes two different sessions and INVENTS a price that
+        # never traded — a far worse failure than the flat reading this guard
+        # exists to fix, and one that is just as self-consistent afterwards
+        # (2026-08-06 PLTU, #332: Alpha Vantage served the 08-04 daily bar —
+        # price 44.82, its own previous close 28.39, +57.87% — against our
+        # correct 08-04 close of 44.82, and the guard rebuilt $70.7585 on a day
+        # the stock traded 42.61–46.76). So the repair requires the provider's
+        # own prior close to agree with ours, and refuses outright on a quote
+        # the fetch layer already knows is a print from an earlier session.
+        # A refused repair still surfaces: `current_price == prev_close` is
+        # exactly what preflight_integrity's STALE_PRICE gate reports.
         stale_repair = None
         api_dp_now = q.get('dp') or 0
+        provider_pc = q.get('pc')
+        prior_session_print = bool(q.get('stale_asof'))
+        baseline_matches = provider_pc is None or (
+            pc and abs(provider_pc - pc) / pc <= 0.005)
         if (pc and pc_date < today_et_date and abs(c - pc) < 1e-4
-                and abs(api_dp_now) > 0.05):
+                and abs(api_dp_now) > 0.05
+                and not prior_session_print and baseline_matches):
             nc = q.get('nc')
             if nc is not None and abs(nc) > 1e-9:
                 repaired = round(pc + nc, 4)
@@ -1092,6 +1130,15 @@ def update_us_portfolio(
             stale_repair = {'reported': c, 'repaired': repaired, 'basis': basis,
                             'source': q['source'], 'at': now_et.strftime('%Y-%m-%d %H:%M ET')}
             c = repaired
+        elif (pc and pc_date < today_et_date and abs(c - pc) < 1e-4
+                and abs(api_dp_now) > 0.05):
+            why = (f"the quote is a print dated {q.get('stale_asof')}"
+                   if prior_session_print else
+                   f"its %change is measured against ${provider_pc:.4f}, not ${pc:.4f}")
+            print(f"  ⚠ {t}: last ${c:.4f} == prior close ${pc:.4f} ({pc_date}) and "
+                  f"{q['source']} reports {api_dp_now:+.2f}%, but {why} → NOT rebuilding "
+                  f"(would compose two sessions, #332); today reads flat and "
+                  f"preflight's STALE_PRICE will say so", file=sys.stderr)
 
         # ③ degenerate-range warning: a live regular-session quote with
         # open==high==low==close has no intraday range → likely a stale/frozen
@@ -1150,7 +1197,17 @@ def update_us_portfolio(
         # high/low with both the API values and the live price. The live price
         # only grows the range during regular session hours so a stray
         # pre/post-market print doesn't fake an intraday extreme.
-        api_h, api_l, api_o = q.get('h'), q.get('l'), q.get('o')
+        # A quote the fetch layer already identified as an earlier session's
+        # print describes THAT session's envelope, not today's. Feeding its
+        # o/h/l in here writes a price that never traded today into the running
+        # range, and the accumulator then keeps it for the rest of the session —
+        # 2026-08-06 PLTU carried day_low 36.265 (the 08-04 bar's low) on a day
+        # whose real low was 42.61. Its last price is still the best number we
+        # have, so keep that and drop only the range fields.
+        if q.get('stale_asof'):
+            api_h = api_l = api_o = None
+        else:
+            api_h, api_l, api_o = q.get('h'), q.get('l'), q.get('o')
         in_session   = 9 <= now_et.hour < 16
         same_session = holding.get('day_session_date') == today_et_date
         cands_h = [v for v in (api_h, c if in_session else None) if v]

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -517,6 +517,66 @@ class TestStaleLastGuard:
         assert h["prev_close_date"] < h["day_session_date"]
 
 
+# ── 2026-08-06 (#332): the guard above, pointed at a daily-bar provider ──────
+# The 07-27 net above assumed the provider's %change and our prev_close share a
+# baseline. Alpha Vantage's GLOBAL_QUOTE is a daily endpoint: mid-session it can
+# serve YESTERDAY's whole bar, whose %change is measured against the close
+# before it. Composing the two rebuilt PLTU to $70.7585 — a price that never
+# traded — and every derived field agreed with it afterwards.
+AV_PRIOR_SESSION_BAR = {   # verbatim, 2026-08-05 12:01 ET, PLTU
+    "Global Quote": {
+        "01. symbol": "PLTU", "02. open": "36.9800", "03. high": "45.7100",
+        "04. low": "36.2650", "05. price": "44.8200", "06. volume": "12549412",
+        "07. latest trading day": "2026-08-04",
+        "08. previous close": "28.3900", "09. change": "16.4300",
+        "10. change percent": "57.8725%",
+    }
+}
+
+
+class TestDailyBarProviderIsNotComposed:
+    def test_alpha_vantage_reports_the_session_its_bar_belongs_to(self, monkeypatch):
+        monkeypatch.setattr(F.SESSION, "get",
+                            lambda *a, **k: _FakeResp(AV_PRIOR_SESSION_BAR))
+        q = F.get_alpha_vantage_quote("PLTU", "key")
+        # Without this the quote carries no date, and _quote_is_fresh's "no
+        # timestamp means current" contract lets an overnight bar win a ticker.
+        assert q["asof_date"] == "2026-08-04"
+        assert not F._quote_is_fresh(q, "2026-08-05")
+
+    def test_prior_session_bar_is_never_rebuilt_into_a_price(
+            self, monkeypatch, tmp_path, no_indices):
+        # c == our prev_close and the provider shouts +57.87%, which is the
+        # guard's exact trigger — but that 57.87% is measured against 28.39,
+        # not against the 44.82 we hold. Refusing leaves today reading flat,
+        # which preflight's STALE_PRICE gate reports; inventing $70.7585 was
+        # silent and moved the whole US day-change from -265 to +7.
+        h = TestStaleLastGuard()._run(
+            monkeypatch, tmp_path,
+            {"c": 44.82, "pc": 28.39, "h": 45.71, "l": 36.265, "o": 36.98,
+             "dp": 57.8725, "asof_date": "2026-08-04",
+             "source": "Alpha Vantage"},
+            {"PLTU": (44.82, _fresh_prev_bar_date())})
+        assert h["current_price"] == 44.82
+        assert "stale_price_repair" not in h
+
+    def test_known_old_print_keeps_its_price_but_not_its_range(
+            self, monkeypatch, tmp_path, no_indices):
+        # Step 8's last resort: every provider failed and we knowingly use an
+        # earlier session's print. Its last price is still the best number we
+        # have; its high/low belong to that session and must not seed today's
+        # range (PLTU carried day_low 36.265 into a 42.61-46.76 day).
+        h = TestStaleLastGuard()._run(
+            monkeypatch, tmp_path,
+            {"c": 27.35, "pc": None, "h": 29.9, "l": 26.1, "o": 26.4,
+             "dp": 5.37, "nc": 1.47, "stale_asof": "2026-07-23",
+             "incomplete": True, "source": "Nasdaq API (etf)"},
+            {"PLTU": (27.35, _fresh_prev_bar_date())})
+        assert h["current_price"] == 27.35        # not rebuilt to 28.82
+        assert "stale_price_repair" not in h
+        assert h["day_low"] != 26.1 and h["day_high"] != 29.9
+
+
 # ── the gate that should have caught it ──────────────────────────────────────
 def _mini_portfolio(holding):
     return {


### PR DESCRIPTION
Closes #332.

2026-08-06 00:04 HKT 的盘中把 PLTU 报成 `$70.7585 / +57.87%`，当天真实区间是
42.61–46.76。这个价**从未成交过**，它是被我们自己算出来的：美股当日合计因此从
-265.45 翻成 +7.13。

## 两段根因

**① Alpha Vantage 的 `GLOBAL_QUOTE` 是日线接口，盘中会给隔夜的整根 bar。**
实测 08-05 12:01 ET 的原始返回是 08-04 那根：price 44.82 / previous close 28.39 /
`07. latest trading day` = 2026-08-04 / +57.8725%。适配器不读那个日期字段，quote 里
就没有 `asof_date`，而 `_quote_is_fresh()` 的契约是「没时间戳当新鲜」——这条本身对
（不能因为 provider 不报时间戳就判它故障），坏在没人把 provider 明说的日期喂给它。

**② stale-quote guard ④ 把这根 bar 的涨幅叠在了它自己的收盘上。**
Polygon 给的前收是**正确**的 44.82，于是 `c == pc` 命中 stale 判据、provider 自报
+57.87% 又坐实「明明动了」→ 重建出 `44.82 × 1.5787 = 70.7585`。guard 成立的前提是
provider 的 `dp/nc` 与我们的 `pc` **同一个基准**；这次 AV 的基准是 28.39，我们的是
44.82，**基准不同，重建就是造价**。#139 加这道 guard 时只见过 Nasdaq `/info`
那种「只给 nc/dp、不给 pc」的形状，从没见过自带另一个基准的 provider。

它比 #139 修的那个 bug 更危险：那次的失败模式是**少算**（涨跌归零），这次是**造价**，
而且造完仍然完全自洽——`today_change == shares × (cur − prev_close)` 精确成立，
preflight 的 TODAY_LEG / STALENESS 全绿。

## 改了三处

1. `get_alpha_vantage_quote()` 解析 `07. latest trading day` → `asof_date`，
   隔夜 bar 由既有的新鲜度闸挡进 `stale` 池（仍可兜底，但会被标记）。
2. guard ④ 增加基准一致性前提：provider 自己的 `pc` 缺失（Nasdaq `/info` 的形状）
   或与我们的 `pc` 一致（0.5% 容差，和 guard ① 同口径）才允许重建；不一致或
   quote 已被标成 `stale_asof`（明知是旧 session 的成交）就**拒绝重建并告警**。
   拒绝之后 `current_price == prev_close` 仍在，preflight 的 STALE_PRICE 会照报
   ——不是静默放过。
3. 已知是旧 session 的报价，其 `o/h/l` 不再喂进当日区间累积器。这是 `day_low
   36.265`（08-04 那根的低点）被写进 08-05 区间的路径，累积器一旦吃进去当天擦不掉。

## 测试

`tests/test_us_quote_staleness.py` +3 条，用的是本次真实 AV payload 原文：

- AV 适配器报出 `asof_date`，且该 quote 过不了 `_quote_is_fresh`
- 基准不一致时拒绝重建（`current_price` 停在 44.82，无 `stale_price_repair`）
- 明知旧 print 时保留价格但不接受它的区间

四处逐条变异验证，各自只被对应那条抓到：AV 丢日期 → 第 1 条红；去掉基准检查 →
第 2 条红；去掉 `stale_asof` 拒绝 → 第 3 条红；去掉区间抑制 → 第 3 条红。
全量 1623 passed / 4 xfailed。

## 已止血

线上数据已在 00:10–00:15 HKT 修正并重新发布（PLTU 43.50 / -2.95%，快照、T0 扫描、
history 里那 2 条造出来的观测都清了，parity 通过）。**止血不等于修好**——根因在
master 上，这个 PR 才是防复发的部分。
