### PR TITLE
us quotes: a prev-close endpoint is not a live quote, so it joins the provider race like everyone else (#336)

### DIFF
--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -479,7 +479,25 @@ def get_alpha_vantage_quote(ticker: str, api_key: str) -> Optional[Dict]:
 
 
 def get_polygon_quote(ticker: str, api_key: str) -> Optional[Dict]:
-    """Polygon.io prev-close – needs key, last resort."""
+    """Polygon.io prev-close – needs key, last resort.
+
+    This endpoint returns the PRIOR SESSION's daily bar. Every field it gives
+    back therefore describes that session: `c` is yesterday's close, `o/h/l` is
+    yesterday's range. Reported as-is it reads exactly like a healthy live quote
+    that happens to be flat, which is what it did on 2026-08-05 14:30 ET when it
+    was the only provider left standing: PLTU showed 44.82 / +0.00% against a
+    real 43.04 / -3.97%, and yesterday's low (36.265) went into today's range
+    accumulator, where it survives the rest of the session (#336).
+
+    So it states its own age (`asof_date` from the bar's timestamp) and lets the
+    freshness gate decide. Two related corrections:
+
+    * `pc` is None, not `vw`. The volume-weighted average price of the prior
+      session is not the close before it — it was never a prior close, and the
+      only reason it never produced a wrong day-change is that `dp` is hardcoded
+      to 0. Absent means absent (#139).
+    * `dp` stays 0.0 and is honest: with no live price there is no move to report.
+    """
     if not api_key:
         return None
     try:
@@ -492,13 +510,17 @@ def get_polygon_quote(ticker: str, api_key: str) -> Optional[Dict]:
         if not results:
             return None
         res = results[0]
-        c = float(res['c'])
-        return {
-            'c': c, 'pc': float(res.get('vw', c)),
+        quote = {
+            'c': float(res['c']), 'pc': None,
             'h': float(res['h']), 'l': float(res['l']), 'o': float(res['o']),
             'dp': 0.0,
             'source': 'Polygon (prev close)',
         }
+        bar_ms = res.get('t')
+        if bar_ms:
+            quote['asof_date'] = datetime.fromtimestamp(
+                bar_ms / 1000, ZoneInfo('America/New_York')).date().isoformat()
+        return quote
     except Exception:
         return None
 
@@ -858,12 +880,16 @@ def fetch_us_quotes(tickers: List[str], keys: Dict[str, str]) -> Dict[str, Dict]
         return results
 
     # 7. Polygon (prev-close, last resort)
+    #
+    # Through `_offer` like every other provider. This branch used to call
+    # `_done` directly, which is the whole of #336: a prior-session daily bar
+    # skipped both the freshness and the completeness gate and was recorded as a
+    # healthy, flat, current quote — price, range and all. It still gets used
+    # when nothing else answered; it now arrives at step 8 labelled, so the
+    # range accumulator and the stale-quote guard can both see what it is.
     print(f"  [7] Polygon for: {', '.join(remaining)}")
     for t in list(remaining):
-        q = get_polygon_quote(t, keys.get('POLYGON_API_KEY', ''))
-        if q:
-            _done(t, q)
-            print(f"      ✓ {t}: ${q['c']:.4f} (prev close) [{q['source']}]")
+        _offer(t, get_polygon_quote(t, keys.get('POLYGON_API_KEY', '')))
 
     # 8. fall back to the best quote we had to reject — a price without a range
     #    still beats no price, but it must be labelled so the caller does not

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -577,6 +577,75 @@ class TestDailyBarProviderIsNotComposed:
         assert h["day_low"] != 26.1 and h["day_high"] != 29.9
 
 
+# ── 2026-08-06 (#336): the same disease, one provider further down ──────────
+# Polygon's `/prev` endpoint returns the PRIOR SESSION's daily bar. Step 7 was
+# the only branch calling `_done` instead of `_offer`, so that bar skipped both
+# the freshness and the completeness gate and was recorded as a healthy, flat,
+# current quote — yesterday's close as today's price, yesterday's range as
+# today's range.
+POLYGON_PREV_BAR = {   # verbatim, PLTU, requested 2026-08-05 15:1x ET
+    "ticker": "PLTU", "queryCount": 1, "resultsCount": 1, "adjusted": True,
+    "results": [{"T": "PLTU", "v": 12746526.0, "vw": 41.7637, "o": 36.98,
+                 "c": 44.82, "h": 45.71, "l": 36.265,
+                 "t": 1785873600000, "n": 165741}],
+    "status": "OK", "count": 1,
+}
+
+
+class TestPolygonPrevCloseStatesItsAge:
+    def test_the_bar_reports_its_own_session_and_no_invented_prior_close(
+            self, monkeypatch):
+        monkeypatch.setattr(F.SESSION, "get",
+                            lambda *a, **k: _FakeResp(POLYGON_PREV_BAR))
+        q = F.get_polygon_quote("PLTU", "key")
+        assert q["asof_date"] == "2026-08-04"
+        assert not F._quote_is_fresh(q, "2026-08-05")
+        # `vw` is the prior session's VWAP; it was never a prior close.
+        assert q["pc"] is None
+        assert q["c"] == 44.82
+
+    def test_a_live_quote_beats_it_instead_of_being_skipped(self, monkeypatch):
+        # Every other provider fails, but Finnhub answers: the prior-session bar
+        # must not win, and previously it could not even be compared because
+        # step 7 bypassed the race entirely.
+        monkeypatch.setattr(F, "get_eastmoney_batch", lambda *a, **k: {})
+        for name in ("get_nasdaq_quote", "get_yahoo_v8_quote",
+                     "get_yfinance_quote", "get_alpha_vantage_quote"):
+            monkeypatch.setattr(F, name, lambda *a, **k: None)
+        monkeypatch.setattr(F, "get_finnhub_quote",
+                            lambda t, k: {"c": 43.04, "pc": 44.82, "h": 46.76,
+                                          "l": 42.61, "o": 43.78, "dp": -3.9714,
+                                          "source": "Finnhub"})
+        monkeypatch.setattr(F, "get_polygon_quote",
+                            lambda t, k: {"c": 44.82, "pc": None, "h": 45.71,
+                                          "l": 36.265, "o": 36.98, "dp": 0.0,
+                                          "asof_date": "2026-08-04",
+                                          "source": "Polygon (prev close)"})
+        out = F.fetch_us_quotes(["PLTU"], {"FINNHUB_API_KEY": "x",
+                                           "POLYGON_API_KEY": "k"})
+        assert out["PLTU"]["source"] == "Finnhub"
+        assert out["PLTU"]["c"] == 43.04
+
+    def test_as_the_only_survivor_it_is_used_but_labelled(self, monkeypatch):
+        monkeypatch.setattr(F, "get_eastmoney_batch", lambda *a, **k: {})
+        for name in ("get_nasdaq_quote", "get_finnhub_quote",
+                     "get_yahoo_v8_quote", "get_yfinance_quote",
+                     "get_alpha_vantage_quote"):
+            monkeypatch.setattr(F, name, lambda *a, **k: None)
+        monkeypatch.setattr(F, "get_polygon_quote",
+                            lambda t, k: {"c": 44.82, "pc": None, "h": 45.71,
+                                          "l": 36.265, "o": 36.98, "dp": 0.0,
+                                          "asof_date": "2026-08-04",
+                                          "source": "Polygon (prev close)"})
+        out = F.fetch_us_quotes(["PLTU"], {"POLYGON_API_KEY": "k"})
+        # A price is still better than none — but it must say what it is, which
+        # is what keeps yesterday's 36.265 out of today's range (#332's
+        # accumulator rule keys off exactly this flag).
+        assert out["PLTU"]["c"] == 44.82
+        assert out["PLTU"]["stale_asof"] == "2026-08-04"
+        assert out["PLTU"]["incomplete"] is True
+
+
 # ── the gate that should have caught it ──────────────────────────────────────
 def _mini_portfolio(holding):
     return {


### PR DESCRIPTION
Closes #336.

#333 合完两小时后 PLTU 又坏了一次，走的是**另一个 provider**：

```
PLTU  current_price 44.82  prev_close 44.82  today_change_pct 0.00
      day_low 36.265       data_source "Polygon (prev close) Aug 05, 2026 14:30 ET"
```

同一时刻 Finnhub `43.04 / -3.97%`。账面显示持平，`day_low 36.265` 又是 08-04 那根
日线的低点——和 #332 里 Alpha Vantage 给的是同一个数，因为它们本来就是同一根 bar。

## 根因

`get_polygon_quote` 打的是 `/prev`，**按定义返回上一交易日的日线**。而第 7 跳是
`fetch_us_quotes` 里唯一一个调 `_done()` 而不是 `_offer()` 的分支：

```python
    for t in list(remaining):
        q = get_polygon_quote(t, keys.get('POLYGON_API_KEY', ''))
        if q:
            _done(t, q)          # 新鲜度闸和完整性闸都没跑
```

于是隔夜 bar 以「完整、当日、健康」的身份被记下来：

1. `c` = 昨收 → 盘中当现价，必然 `c == pc` → 涨跌恒 0。而 `dp` 在函数里**硬编码
   `0.0`**，所以 #332 那道 stale-guard ④ 也不会触发（它要求 `|dp| > 0.05`）——
   两个洞正好互补，谁也拦不住谁。
2. `h/l/o` 是昨天的区间，直接进当日区间累积器，当天再也擦不掉。
3. `'pc': float(res.get('vw', c))` —— **拿 VWAP 当昨收**。实测 41.7637 是 08-04 的
   量加权均价，既不是任何一天的收盘。它至今没造成错误涨跌，只是因为 `dp` 被写死成 0。

平时前六家有一个能答就轮不到它。08-05 14:30 ET 那轮前六家全灭（东财整晚 502、
Yahoo/yfinance/AV 都 None），第一次真落到第 7 跳——和 #332 同一类：**兜底路径平时
不走，走的时候一道闸都没有**。

## 改了两处

1. `get_polygon_quote` 报出 bar 自己的日期（`results[0].t`）作为 `asof_date`，并且
   `pc` 返回 `None` 而不是 VWAP（缺失就是缺失，#139 的规矩）。
2. 第 7 跳改走 `_offer()`，和其余六跳同一条路径。它给不出当日区间和真前收，会自然
   落进 `stale`；作为最后兜底使用时带 `stale_asof` + `incomplete`——#332 已经让带
   `stale_asof` 的 quote 不污染当日区间、也不被 guard ④ 重建，两处正好接上。

## 测试

`tests/test_us_quote_staleness.py` +3 条，用本次真实 Polygon payload 原文：

- bar 报出自己的 session、`pc` 不再是 VWAP，且过不了 `_quote_is_fresh`
- 有实时报价时它不再赢下 ticker（以前根本进不了这场比较）
- 作为唯一幸存者时价格照用，但带 `stale_asof` / `incomplete` 标记

变异验证：去掉 `asof_date` → 第 1 条红；`pc` 改回 `vw` → 第 1 条红；第 7 跳改回
`_done` → 第 3 条红。全量 **1623 passed / 4 xfailed**。

## 已止血

03:10 HKT 已在 live workspace 清区间重播种 + Finnhub 重抓：PLTU `43.03 / -3.99% /
区间 42.61–46.76`，并重新发布数据面。
