### PR TITLE
cron health: the scheduled publisher gets a liveness check, which #325 took away (#338)

### DIFF
--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -296,6 +296,71 @@ def heartbeat_coverage(job_name, slots, tz_name, now, ledger):
             'failed': failed, 'pending': pending}
 
 
+# How long the published generation may sit unchanged on a trading day before
+# the scheduled publisher is presumed dead. Deliberately generous: the publisher
+# only pushes when the semantic diff says something changed, so a quiet tick
+# publishing nothing is healthy. This threshold is not "the cadence" (20 min) —
+# it is "nothing has moved in the book for three hours during a session", which
+# on a trading day means the 0,20,40 crontab entry stopped running.
+PUBLISHER_STALE_HOURS = 3
+
+
+def check_scheduled_publisher(now=None, path=None):
+    """Is the every-20-minutes publisher still reaching the data branch?
+
+    #325 moved the generated outputs off `master`, which removed the
+    `dashboard: scheduled publish <ts>` commits — the de-facto liveness signal
+    for the crontab entry that produces them (kcn, 2026-08-06: "以前 schedule
+    publisher 是不是用来监控…现在也看不到"). Nothing replaced it: the publisher
+    writes no heartbeat, appears in no ledger, and does not even write
+    logs/dashboard_build_status.json (that file has three postflight writers and
+    the publisher is none of them). A dead publisher's only symptom was a site
+    quietly frozen on an old generation.
+
+    So ask the published generation itself how old it is. This costs nothing:
+    the workflow already materialises the data branch before running this check,
+    so `assets/data/dashboard.json` here IS the last generation the site serves.
+    Run on a host instead of in CI it answers the weaker local question ("when
+    did this host last build"), which is why it never escalates past a warning.
+    """
+    path = path or (WS / 'assets' / 'data' / 'dashboard.json')
+    now = now or datetime.now(timezone.utc)
+    if not path.exists():
+        return {'state': 'absent', 'detail': 'no published generation to read',
+                'age_hours': None}
+    try:
+        stamp = json.loads(path.read_text()).get('generated_at')
+        published = datetime.fromisoformat(str(stamp).replace('Z', '+00:00'))
+        if published.tzinfo is None:
+            published = published.replace(tzinfo=timezone.utc)
+    except Exception as e:
+        return {'state': 'failed', 'detail': f'generation stamp unreadable: {e}',
+                'age_hours': None}
+    age_hours = round((now - published).total_seconds() / 3600, 1)
+    local = now.astimezone(HKT)
+    # A weekend or a double holiday has no session to publish into, so silence
+    # is correct there and must not be reported as a stalled publisher.
+    # Same local, fail-open import as _market_closed_today: an unavailable
+    # calendar must not turn this into a red, so it falls through to judging.
+    try:
+        import trading_calendar as _tc
+        trading = any(_tc.is_trading_day(m, local.date()) for m in ('hk', 'us'))
+    except Exception:
+        trading = True
+    if not trading:
+        return {'state': 'ok',
+                'detail': f'last generation {age_hours}h old · 非交易日不判',
+                'age_hours': age_hours}
+    if age_hours > PUBLISHER_STALE_HOURS:
+        return {'state': 'stale',
+                'detail': (f'已发布的那一代已 {age_hours}h 未更新 '
+                           f'(> {PUBLISHER_STALE_HOURS}h) — 0,20,40 的 '
+                           f'publish_dashboard.sh 大概率没在跑'),
+                'age_hours': age_hours}
+    return {'state': 'ok', 'detail': f'last generation {age_hours}h old',
+            'age_hours': age_hours}
+
+
 def check_dashboard_build():
     """Read logs/dashboard_build_status.json (written by _harness_common.rebuild_dashboard).
 
@@ -473,6 +538,14 @@ def main():
     elif dash['state'] in ('degraded', 'stale'):
         has_warn = True
 
+    publisher = check_scheduled_publisher(now=now)
+    # 'absent' is reported but never escalated, matching check_dashboard_build:
+    # it means "no generation was fetched to judge", which is not the same claim
+    # as "the publisher is dead". In the workflow the fetch step fails loudly on
+    # its own, so absent cannot hide a real stall there.
+    if publisher['state'] in ('stale', 'failed'):
+        has_warn = True
+
     # Token regressions surface in the daily review, never as a per-cron alert
     # (feedback_no_individual_cron_alerts) and never as a reason to exit non-zero:
     # a job burning 3x its usual tokens is something to look at, not a failure.
@@ -485,6 +558,7 @@ def main():
         'now_hkt': now.astimezone(HKT).strftime('%Y-%m-%d %H:%M HKT'),
         'jobs': report,
         'dashboard_build': dash,
+        'scheduled_publisher': publisher,
         'token_usage': token_reports,
         'has_missing': has_missing,
         'has_warn': has_warn,
@@ -501,6 +575,8 @@ def main():
             print(f"  {icon} {r['name']:25s}  {r['detail']}")
         dash_icon = DASHBOARD_STATE_ICONS[dash['state']]
         print(f"  {dash_icon} {'dashboard build':25s}  {dash['detail']}")
+        pub_icon = DASHBOARD_STATE_ICONS[publisher['state']]
+        print(f"  {pub_icon} {'scheduled publisher':25s}  {publisher['detail']}")
         for line in cron_token_audit.format_lines(token_regressions):
             print(f"  {line}")
         if has_missing:

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -1,6 +1,7 @@
 """Cron health: what counts as evidence that a scheduled job did its work."""
+import json
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -54,3 +55,49 @@ def test_only_todays_finished_runs_count_as_evidence():
     ])
 
     assert cron_health_check.runs_finished_today("job", provider) == 2
+
+
+# ── #338: the publisher's only liveness signal ──────────────────────────────
+# #325 moved the outputs off master, which removed the `dashboard: scheduled
+# publish` commits kcn actually used to see the crontab entry was alive. The
+# published generation's own age is the replacement.
+def _generation(tmp_path, published_at):
+    path = tmp_path / "dashboard.json"
+    path.write_text(json.dumps({"generated_at": published_at.isoformat()}))
+    return path
+
+
+def test_a_frozen_generation_on_a_trading_day_is_reported():
+    # 2026-08-05 is a Wednesday and a session in both markets.
+    now = datetime(2026, 8, 5, 16, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        stale = _generation(Path(d), now - timedelta(hours=4))
+        result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
+    assert result["state"] == "stale"
+    assert result["age_hours"] == 4.0
+
+
+def test_a_quiet_tick_is_not_a_dead_publisher():
+    # The publisher only pushes when the semantic diff changed, so a generation
+    # that is merely an hour old is healthy — flagging it would red the workflow
+    # on every calm session.
+    now = datetime(2026, 8, 5, 16, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        fresh = _generation(Path(d), now - timedelta(hours=1))
+        result = cron_health_check.check_scheduled_publisher(now=now, path=fresh)
+    assert result["state"] == "ok"
+
+
+def test_a_closed_weekend_is_silence_by_design():
+    # 2026-08-09 12:00 HKT is a Sunday: no session to publish into, so an old
+    # generation is correct and must not be reported as a stalled publisher.
+    # (UTC, not HKT — 16:00 UTC on a Sunday is already Monday in Hong Kong.)
+    now = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        stale = _generation(Path(d), now - timedelta(hours=30))
+        result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
+    assert result["state"] == "ok"
+    assert "非交易日" in result["detail"]


### PR DESCRIPTION
Closes #338.

kcn：「以前 schedule publisher 是不是用来监控有一些定时任务有没有成功？现在也看不到。」

## 他说得对，这是 #325 的副作用

#325 之前，`publish_dashboard.sh` 每 20 分钟往 master 打一条
`dashboard: scheduled publish <ts>`。那不是正式监控，但它是实际在用的**存活信号**。
#325 把输出搬到 data-plane 分支之后那条 commit 没了，**没有补等价物**。

查下来这条每天跑 72 次的链路，成功与否**没有任何自动判据**：

- 它不写 heartbeat，`cron-heartbeats.json` 只有 3 个盘中 job
- 它不进 `workflow-outcomes.json`（那是报告类 cron 的）
- 它连 `logs/dashboard_build_status.json` 都不写——那个文件的三个写入者全是
  postflight，publisher 走的是 `publish_dashboard.sh → build_dashboard.py`。
  实测 03:15 HKT 时那个文件的 `checked_at` 停在 02:31 那次盘中 postflight
- `config/cron-schedules.json` 里也没有它（它是 crontab 条目，不是 openclaw cron）

它挂掉的唯一表现，是站点静静冻在某一代上，而没有任何东西在看这件事。

## 修法：问已发布的那一代自己多老

`cron-health.yml` 已经在跑 check 之前 fetch 数据面（#325 加的），所以
`assets/data/dashboard.json` 在那个上下文里**就是站点正在服务的那一代**。直接读它的
`generated_at` 和现在比，超过 **3 小时**就报。

不新增文件、不新增进程、不给 VPS 加任何负载（[[clawock-harness-roi-rule]]）。

**3 小时是刻意放宽的**：publisher 只在语义 diff 有变化时才推，安静 tick 不推是正常的。
这条闸抓的是「publisher 死了」，不是「publisher 这一轮没话说」。非交易日直接不判——
周末没有 session 可发布，沉默是对的。

按 [[feedback_no_individual_cron_alerts]]：不做即时告警，只进工作日 EOD 巡检，
红在 Actions 里。

`absent`（没 fetch 到那一代）**报但不升级**，和 `check_dashboard_build` 的 `absent`
同口径：它说的是「没有东西可判」，不是「publisher 死了」；而在 workflow 里 fetch 那步
自己会先炸，所以 absent 藏不住真故障。

## 测试

`tests/test_cron_health_check.py` +3 条：交易日冻结 4 小时 → stale；1 小时的安静 tick
→ ok；周日冻结 30 小时 → ok 且注明非交易日。

变异验证：去掉超时判断 → 第 1 条红；去掉非交易日豁免 → 第 3 条红；把阈值收紧到
0.5h（即「按 cadence 判」）→ 第 2 条红。全量 **1625 passed / 4 xfailed**。

## 还没做的（#338 里第 2 条，另开）

`assets/data/cron-heartbeats.json` 每次都发布，但 `assets/js` + `index.html` 里
**零引用**——只有 python 脚本读它。要么接到 dashboard 上，要么就别发布。
本 PR 不动它。
