### PR TITLE
insights: accept composite bear_case tickers whose components are all held

### DIFF
--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -1127,6 +1127,31 @@ def _clean_str(v, maxlen):
     return s[:maxlen] if s else None
 
 
+# A bear_case may cover two or three holdings at once (paired thesis on e.g. two
+# leveraged names in the same sector), which the agent writes as `RKLX+SPCH`.
+_COMPOSITE_SEP = re.compile(r'[+/&,]')
+_MAX_COMPOSITE_PARTS = 3
+
+
+def _resolve_insight_ticker(raw, known_tickers):
+    """Resolve a bear_case ticker label against live holdings.
+
+    Accepts a composite label (`A+B`) as long as EVERY component is a real
+    holding — the membership check exists to block names that aren't in the book
+    at all, not to block formatting. Returns the normalised `A+B` label, or None
+    if any component is unknown (→ caller drops the entry, guard unchanged).
+    """
+    if not raw:
+        return None
+    parts = [p.strip() for p in _COMPOSITE_SEP.split(raw)]
+    parts = [p for p in parts if p]
+    if not parts or len(parts) > _MAX_COMPOSITE_PARTS:
+        return None
+    if known_tickers and any(p not in known_tickers for p in parts):
+        return None
+    return '+'.join(parts)
+
+
 def validate_insights(data, known_tickers):
     """Schema + sanity gate for the agent-written daily insights sidecar.
 
@@ -1162,15 +1187,18 @@ def validate_insights(data, known_tickers):
     for c in (data.get('bear_cases') or [])[:5]:
         if not isinstance(c, dict):
             continue
-        tk = _clean_str(c.get('ticker'), 12)
+        # Cap allows a composite label (`A+B`); the real guard is the
+        # per-component holdings check in _resolve_insight_ticker.
+        tk = _clean_str(c.get('ticker'), 40)
         thesis = _clean_str(c.get('thesis'), 220)
         if not tk or not thesis:
             continue
-        if known_tickers and tk not in known_tickers:
+        resolved = _resolve_insight_ticker(tk, known_tickers)
+        if not resolved:
             print(f'  warn: insights dropped bear_case for unknown ticker {tk}', file=sys.stderr)
             continue
         out['bear_cases'].append({
-            'ticker': tk,
+            'ticker': resolved,
             'thesis': thesis,
             'falsifier': _clean_str(c.get('falsifier'), 160) or '',
             'watch': _clean_str(c.get('watch'), 120) or '',

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -1345,3 +1345,33 @@ def test_the_fresh_checkout_population_is_reported_by_its_only_producer():
     report = workflow.split("Report which cards the recovery restored", 1)[1]
     assert "raise SystemExit(0)" in report.split("Commit + push", 1)[0], (
         "a missing payload must end the report, not fail the run")
+
+
+# --- bear_case ticker resolution (#341) ------------------------------------
+#
+# `validate_insights` is the hallucination guard for the LLM-authored insights
+# sidecar: a bear_case on a name that isn't in the book must never reach the
+# public dashboard. On 2026-08-06 that guard also ate a legitimate paired thesis
+# written as `RKLX+SPCH` — both real holdings — so a third of the day's bear
+# cases vanished with no trace on the page. The guard is about membership, not
+# formatting; these pin both halves of that distinction.
+
+def _bear(ticker):
+    return {"bear_cases": [{"ticker": ticker, "thesis": "levered pair unwinds together"}]}
+
+
+def test_composite_bear_case_survives_when_every_component_is_held():
+    out = dashboard.validate_insights(_bear("RKLX+SPCH"), {"RKLX", "SPCH", "00100"})
+    assert [c["ticker"] for c in out["bear_cases"]] == ["RKLX+SPCH"]
+
+
+def test_composite_bear_case_is_dropped_when_any_component_is_unknown():
+    """The guard must not weaken: one fabricated leg poisons the whole entry."""
+    out = dashboard.validate_insights(_bear("RKLX+NVDA"), {"RKLX", "SPCH"})
+    assert out["bear_cases"] == []
+
+
+def test_single_ticker_bear_case_membership_is_unchanged():
+    known = {"RKLX", "SPCH"}
+    assert dashboard.validate_insights(_bear("RKLX"), known)["bear_cases"][0]["ticker"] == "RKLX"
+    assert dashboard.validate_insights(_bear("NVDA"), known)["bear_cases"] == []


### PR DESCRIPTION
Closes #341.

## 问题

`validate_insights()` 把 bear_case 的 ticker 当**整串**去 `known_tickers` 里查。LLM 为「一条同时覆盖两个持仓的配对论点」写的 `RKLX+SPCH`（两个都是真实持仓）整串查不到 → 被幻觉守卫误杀。

2026-08-06 实际后果：三条 bear_case 只上板两条，dashboard 上**没有任何痕迹**说少了一条，只有 `dashboard_build_status.json` 里一行 stderr warn。

守卫的目的是挡「书里根本没有的名字」，不是挡格式。

## 改动

新增 `_resolve_insight_ticker()`：按 `+ / & ,` 拆成分，**每个**成分都是真实持仓才保留（标签规范化成 `A+B`），**任一**成分不认识仍然整条丢弃 + warn。成分数上限 3。

`_clean_str` 的 ticker 长度上限 12 → 40，因为复合串会超 12；真正的守卫是成员检查不是长度。

前端 `dashboard.render.js:2167` 只把 `c.ticker` 当纯标签渲染（不做 ticker → 持仓跳转），复合标签渲染侧零改动。

## 验证

真实数据（2026-08-06 的 `insights-2026-08-06.json` + 当日 12 个持仓）：

```
修改前: bear_cases 2 条 + warn: insights dropped bear_case for unknown ticker RKLX+SPCH
修改后: bear_cases 3 条 (00100 / 07226 / RKLX+SPCH), 无 warn
```

3 条测试，全部做过变异验证（不是装饰品）：

| 变异 | 预期红的测试 | 实测 |
|---|---|---|
| 守卫放松成 `all(p not in known)` | `..._dropped_when_any_component_is_unknown` | ✅ 红 |
| 拒绝一切复合（改回修改前行为） | `..._survives_when_every_component_is_held` | ✅ 红 |

`tests/test_build_dashboard.py` 全绿：69 passed, 1 xfailed。

## 范围外

丢弃行为本身对 dashboard 访客仍然是静默的（只有 build status 里有 warn）。这次只让**合法**的复合活下来，没有改「真幻觉被丢弃时要不要在页面上留痕」——那是另一个决定。
