### PR TITLE
harness: split the catalyst evidence gate into active and passive tiers

### DIFF
--- a/scripts/data/brief_decision_packet.py
+++ b/scripts/data/brief_decision_packet.py
@@ -16,7 +16,13 @@ import hashlib
 import json
 import math
 import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Canonical owner of the active/passive action split; duplicating those sets here
+# would let the evidence gate drift onto the wrong one.
+import decision_v2  # noqa: E402
 
 
 SCHEMA_VERSION = 1
@@ -534,6 +540,40 @@ def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
     return issues
 
 
+def _catalyst_evidence_issues(tag: str, decision: dict, row: dict) -> list[str]:
+    """Evidence check for a decision the model attributed to a catalyst.
+
+    Two tiers, because `actionable_evidence_ids` only ever holds events flagged
+    `actionable_escalation` — the escalation set, not the set of real events:
+
+    * an ACTIVE action must point at an escalated event.  That is the harness
+      rule named by the sibling constraint `active_action_requires_evidence`:
+      you do not trade on a catalyst the harness did not escalate.
+    * a PASSIVE stance only has to point at a real event for this ticker.
+      "I'm watching CRCL because it reported Q2 yesterday" is a legitimate
+      attribution, and requiring escalation there left the model no way to
+      record it — the only ways past the gate were to relabel `driven_by` or to
+      drop `evidence_event_id`, both of which destroy the attribution that
+      `by_driver` win-rate bucketing reads.
+
+    Both tiers still reject an id that matches no event, so a fabricated
+    reference is caught either way.
+    """
+    evidence_id = decision.get("evidence_event_id")
+    action = decision.get("action")
+    if action in decision_v2.ACTIVE_ACTIONS:
+        if evidence_id not in ((row.get("constraints") or {}).get("actionable_evidence_ids") or []):
+            return [f"{tag}: evidence_event_id is outside harness evidence gate"]
+        return []
+    known_ids = {
+        event.get("event_id") for event in (row.get("evidence") or [])
+        if event.get("event_id")
+    }
+    if evidence_id not in known_ids:
+        return [f"{tag}: evidence_event_id does not match any event for this ticker"]
+    return []
+
+
 def validate_plan_constraints(plan: dict, packet: dict) -> list[str]:
     issues = []
     rows = packet.get("tickers") or {}
@@ -551,11 +591,8 @@ def validate_plan_constraints(plan: dict, packet: dict) -> list[str]:
                 f"{tag}: action {action!r} outside harness allowed_actions "
                 f"{constraints.get('allowed_actions') or []}"
             )
-        evidence_id = decision.get("evidence_event_id")
-        if decision.get("driven_by") == "catalyst" and evidence_id not in (
-            constraints.get("actionable_evidence_ids") or []
-        ):
-            issues.append(f"{tag}: evidence_event_id is outside harness evidence gate")
+        if decision.get("driven_by") == "catalyst":
+            issues.extend(_catalyst_evidence_issues(tag, decision, row))
         shares = _number((decision.get("size") or {}).get("shares"), 0)
         max_sell = _number(constraints.get("max_sell_shares"), 0)
         if (

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -304,7 +304,7 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 | **软情绪** (soft) | Reddit 提及数/热度、Google News 标题情绪、散户温度、Trump/Musk 喊话(无落地)、"看好/看空"类口风 | **只能动 confidence ±10pp,不能单独翻 bucket** |
 
 硬性规则:
-- **`context.news_evidence_graph` 存在时，只有 `actionable_escalation=true` 的事件能驱动主动 catalyst 动作**，并把其 `event_id` 原样写入 plan 的 `evidence_event_id`。事件必须是一手/可靠、仍有效、足够新颖、负面证伪且获价量或已校准同行残差确认；任一 blocker 存在就只能 display/watch。
+- **`context.news_evidence_graph` 存在时，只有 `actionable_escalation=true` 的事件能驱动主动 catalyst 动作**，并把其 `event_id` 原样写入 plan 的 `evidence_event_id`。事件必须是一手/可靠、仍有效、足够新颖、负面证伪且获价量或已校准同行残差确认；任一 blocker 存在就只能 display/watch —— 但落成 `watch`/`hold_and_watch` 时**仍然可以**把该事件的 `event_id` 写进 `evidence_event_id` 并保留 `driven_by=catalyst`（被动档只要求事件真实，见 plan.json 字段表）。
 - 同一 novelty cluster 的重复摘要不会增加 conviction；过期事件不能复活。`positive/confirming` 事件一律 hold-only。
 - Tavily 新闻搜索只准处理 `tavily_resolution_queue` 里列出的 event ID 和 query；队列外的日常旧闻/低影响摘要不得消耗 Tavily。未解决不等于可交易，搜索结果仍需下一轮图谱门控。
 - **软情绪单独存在时,bucket 必须维持技术面/基本面给出的那个**;软情绪只允许把该 action 的 confidence 上下微调最多 ±10pp,且要在 rationale 写明"软情绪佐证/背离,confidence ±X"。
@@ -660,7 +660,8 @@ postflight 严格 schema 校验：
 - `action` ∈ {`cut`, `trim_on_rebound`, `hold_and_watch`, `t_only`, `add_only_on_trigger`, `watch`}
 - `condition.type` ∈ {`open`, `price_above`, `price_below`, `index_breakdown`, `event`, `manual`}
 - `driven_by` ∈ {`technical`, `catalyst`, `sentiment`, `influencer`, `macro`, `peer`, `risk_rule`}（每个 decision 必填）
-- `evidence_event_id`：主动且 `driven_by=catalyst` 时必填，必须精确匹配 `context.news_evidence_graph.events` 中同 ticker 且 `actionable_escalation=true` 的事件；其余 decision 填 `null`。
+- `evidence_event_id`：`driven_by=catalyst` 时必填，分两档 —— **主动** call（`cut`/`trim_on_rebound`/`t_only`/`add_only_on_trigger`/`add_on_breakout`）必须精确匹配 `context.news_evidence_graph.events` 中同 ticker 且 `actionable_escalation=true` 的事件（不许拿未升级事件去交易）；**被动** `hold_and_watch`/`watch` 只要求匹配同 ticker 的**真实**事件，不要求 `actionable_escalation=true`（「昨天出了财报所以我盯着」是正当归因）。`driven_by` 不是 `catalyst` 的 decision 填 `null`。
+  - ⚠️ 被动决策若归因 `catalyst` 就**必须**给出真实 `event_id`，不能填 `null` —— 归因得可核。给不出具体事件，就说明它其实不是 catalyst 驱动，改用 `technical`/`risk_rule` 等如实标注。**不要为了过闸而改标 `driven_by`**：这个字段直接决定 `by_driver` 胜率归属（主动和被动都进桶），洗标签就是在污染自己的 edge 统计。
 - `regime` ∈ {`risk_on`, `neutral`, `risk_off`}（每个 decision 必填；按本报告已判定的当前 regime 留痕，迁移旧数据才允许 `unknown`）
 - `confidence` ∈ [0.0, 1.0]
 - `size.shares`（整数，**主动 call（`cut`/`trim_on_rebound`/`t_only`/`add_only_on_trigger`/`add_on_breakout`）必填**；`hold_and_watch`/`watch` 不需要)：股数是这条 call 日后唯一能被折算成钱的凭据。面板上那条金额曲线已撤（见上条铁律），但**重建一套可信对照账本必须有股数，当天没填就永远补不回来**。宁可给保守估数也别留空。填**你真的会动的股数**,不是仓位上限。

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -113,6 +113,13 @@ def _context():
                 "ticker": "00100",
                 "headline": "primary event",
                 "actionable_escalation": True,
+            }, {
+                # Real, reported, but not escalated — the common case. Most
+                # events on a given day look like this one, not like evt_good.
+                "event_id": "evt_quiet",
+                "ticker": "00100",
+                "headline": "quarterly results, no escalation",
+                "actionable_escalation": False,
             }]
         },
         "integrity": {"ok": True, "error_count": 0, "warn_count": 0},
@@ -245,6 +252,46 @@ def test_plan_is_constrained_by_harness_actions_evidence_and_inventory():
     issues = packet_mod.validate_plan_constraints(bad, packet)
     assert any("allowed_actions" in issue for issue in issues)
     assert any("evidence gate" in issue for issue in issues)
+
+
+def _catalyst(action, evidence_id, ticker="00100"):
+    return {"decisions": [{
+        "ticker": ticker,
+        "action": action,
+        "driven_by": "catalyst",
+        "evidence_event_id": evidence_id,
+        "size": {},
+    }]}
+
+
+# --- catalyst evidence gate, active vs passive (#342) -----------------------
+#
+# `actionable_evidence_ids` holds only escalated events, so requiring it of
+# EVERY catalyst-driven decision left a passive stance no way to cite a real but
+# un-escalated event. On 2026-08-06 all three watched names (CRCL/SKHY/SPCX) had
+# 6-7 real events and zero escalated ones, and the only ways past the gate were
+# to relabel `driven_by` or drop the id — both destroying the attribution that
+# `by_driver` bucketing reads.
+
+def test_passive_catalyst_may_cite_a_real_unescalated_event():
+    packet = _compiled()
+    assert packet_mod.validate_plan_constraints(
+        _catalyst("hold_and_watch", "evt_quiet"), packet) == []
+
+
+def test_passive_catalyst_still_rejects_an_event_id_that_matches_nothing():
+    """Relaxing escalation must not relax the hallucination check."""
+    issues = packet_mod.validate_plan_constraints(
+        _catalyst("hold_and_watch", "evt_nonexistent"), _compiled())
+    assert any("does not match any event" in issue for issue in issues)
+
+
+def test_active_catalyst_still_requires_an_escalated_event():
+    """The escalation gate is the point of the active tier — it must not move."""
+    packet = _compiled()
+    issues = packet_mod.validate_plan_constraints(_catalyst("cut", "evt_quiet"), packet)
+    assert any("evidence gate" in issue for issue in issues)
+    assert packet_mod.validate_plan_constraints(_catalyst("cut", "evt_good"), packet) == []
 
 
 def test_pages_prefers_projection_and_keeps_a_backward_fallback():


### PR DESCRIPTION
Closes #342.

## 问题

`validate_plan_constraints()` 对**所有** `driven_by=catalyst` 的决策一律要求引用 `actionable_evidence_ids` 里的 id，而那个列表只收 `actionable_escalation=true` 的事件：

```python
if decision.get("driven_by") == "catalyst" and evidence_id not in (
    constraints.get("actionable_evidence_ids") or []
):
```

于是**被动** `hold_and_watch` 引用一条真实但未升级的事件会被直接拒绝。

2026-08-06 实测三个被盯的票：

| ticker | 匹配事件 | escalated | `actionable_evidence_ids` |
|---|---|---|---|
| CRCL | 6 | 0 | `[]` |
| SKHY | 6 | 0 | `[]` |
| SPCX | 7 | 0 | `[]` |

事件全是真的，只是没有一条被标升级。对这三个 ticker，**任何** catalyst 归因都无条件失败。出路只剩两条，两条都是抹信息：改标 `driven_by`，或删 `evidence_event_id`。当天 agent 两条都做了 —— 三条全洗成 `driven_by=technical` + `evidence_event_id=null`，而散文里写的理由明明是 CRCL 8/5 Q2 财报、SPCX 8/6 解禁。

这不是无害的：`decision_v2.py:1774` 的 `by_driver` 用的是 `reps`（**未**按主动过滤，被动也进桶），所以洗标签直接把被动催化的战绩灌进 `technical` 胜率桶。

而且 `SKILL.md:307` 本来就写的是「只有 `actionable_escalation=true` 的事件能驱动**主动** catalyst 动作」—— **代码比自己的契约更严**。

## 改动

抽出 `_catalyst_evidence_issues()`，分两档：

| 档 | 要求 | 变化 |
|---|---|---|
| `ACTIVE_ACTIONS` | 必须命中 `actionable_evidence_ids`（升级过的事件） | **不变** |
| `PASSIVE_ACTIONS` | 只要求 id 命中该 ticker 的**真实**事件（`row["evidence"]`） | 放宽 |

两档都仍然拒绝匹配不到任何事件的 id，报错文案分开，被动档的失败不会读起来像升级闸。

packet 的 ticker row 本来就带 `"evidence": matching_events`，**schema 零改动**。主动/被动集合从 `decision_v2` 导入（该模块已被 `scripts/data` 下十来个脚本引用），不在这里复制一份以免漂移。

`SKILL.md` 同步：字段表原文是「其余 decision 填 `null`」，只改代码的话模型会继续填 null，而 null 同样命中不了任何事件 —— 闸还是红。所以契约必须跟着走，并明写「不要为了过闸而改标 `driven_by`」。

## 验证

拿 2026-08-06 真实 packet 跑四个场景：

```
被动 + 真实未升级 id   -> PASS          (今天是 fail)
被动 + 伪造 id         -> does not match any event for this ticker
主动 cut + 未升级 id   -> outside harness evidence gate   (回归保护)
主动 cut + 无 id       -> outside harness evidence gate
```

3 条新测试，两条重载荷的都做了变异验证：

| 变异 | 预期红的测试 | 实测 |
|---|---|---|
| 主动档塌进被动档（丢升级闸） | `test_active_catalyst_still_requires_an_escalated_event` + 既有的 `test_plan_is_constrained_by_...` | ✅ 双红 |
| 被动档来者不拒（丢幻觉守卫） | `test_passive_catalyst_still_rejects_an_event_id_that_matches_nothing` | ✅ 红 |

全量本地套件：**1631 passed, 4 xfailed**。`git status` 只有这 3 个文件，无生成产物外溢。

## 范围外

不回填历史 plan.json 里已被抹掉的归因（幂等重算才会纠）。2026-08-06 那三条留着。
