### PR TITLE
brief: give evidence.md a committer, and cover the repo root in the ownership contract

### DIFF
--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -542,6 +542,13 @@ def maybe_commit(status, today, dry_run=False):
     # and `git add` on a gitignored path fails rather than skipping — it would
     # abort this entire commit, which carries portfolio.json, the decision
     # ledger and the whole preflight write set.
+    # `evidence.md` joined 2026-08-06 (#345) as the next instance of exactly the
+    # failure above: preflight rebuilds it every morning via build_evidence.py and
+    # nothing ever staged it, so the public evidence page sat on numbers from
+    # 08-02 (claiming "留痕 38 天" against artifacts saying 42) while live carried a
+    # permanently dirty file for other pushes to trip over. It lives at the repo
+    # root, which is why every directory-scoped `git add` above missed it — the
+    # same gap MEMORY.md/DREAMS.md needed commit_dreaming.sh for.
     add_ok, add_out = _git('add', 'memory/', 'portfolio.json',
                             'memory/decisions.jsonl', 'assets/data/risk.json',
                             'assets/data/lev_regime.json', 'assets/data/benchmark.json',
@@ -561,7 +568,8 @@ def maybe_commit(status, today, dry_run=False):
                             'assets/data/t0_setups_history.jsonl',
                             'assets/data/t0_setup_review.json',
                             'assets/data/brief_projection.json',
-                            'logs/dashboard_build_status.json')
+                            'logs/dashboard_build_status.json',
+                            'evidence.md')
     if not add_ok:
         return False, f'git add failed: {add_out[-200:]}'
 

--- a/tests/test_brief_data_ownership.py
+++ b/tests/test_brief_data_ownership.py
@@ -70,6 +70,46 @@ def test_preflight_writes_are_committed():
         f'workflow took ownership.')
 
 
+def _repo_root_outputs():
+    """Repo-root files written by the scripts preflight shells out to.
+
+    `{NAME} = WS / 'file'` at the top of a script, kept only when that constant is
+    actually written (not merely read) in the same file.
+    """
+    out = {}
+    for script in sorted(set(re.findall(
+            r"scripts' / 'data' / '([a-z_]+\.py)'", PREFLIGHT))):
+        path = ROOT / 'scripts' / 'data' / script
+        if not path.exists():
+            continue
+        source = path.read_text()
+        for const, name in re.findall(
+                r"^([A-Z_]+) = WS / '([^/']+)'$", source, re.M):
+            if re.search(rf"{const}\.write_text\(|_write_\w+\({const}\b", source):
+                out[name] = script
+    return out
+
+
+def test_repo_root_outputs_are_committed_too():
+    """The same contract, for files that do NOT live under assets/data/.
+
+    This is the hole `evidence.md` fell through (#345): every `git add` above is
+    directory-scoped, and the sibling test only discovers `assets/data/` paths, so
+    a repo-root artifact had no owner and nothing failed. build_evidence.py rewrote
+    it each morning for months while the published page served 08-02 numbers and
+    live carried a permanently dirty file. Exactly the MEMORY.md/DREAMS.md gap that
+    needed commit_dreaming.sh — this asserts the root is covered, not just the
+    subdirectory.
+    """
+    staged = _postflight_add_list()
+    unowned = sorted(f'{name} (written by {script})'
+                     for name, script in _repo_root_outputs().items()
+                     if name not in staged)
+    assert not unowned, (
+        f'preflight rebuilds {unowned} at the repo root but postflight never '
+        f'stages them, so origin keeps serving a stale copy and live stays dirty.')
+
+
 def test_gha_synced_files_are_actually_gha_produced():
     """GHA_DATA_FILES is checked out from origin, so a local-only file must not be
     in it — the checkout would silently discard the copy preflight just fetched.


### PR DESCRIPTION
Closes #345.

## 问题

`build_evidence.py` 每天早上被 preflight 调一次重写 `evidence.md`，**但没有任何东西提交它**。全仓 grep 只有它自己的 `OUT = WS / 'evidence.md'`。

后果两条：线上证据页停在 08-02 生成的那版（页面写「留痕 38 天」，产物是 42 天），且 live 每天必脏，去撞别的 push 的 rebase。

## 为什么已有的契约测试没抓到

`tests/test_brief_data_ownership.py` 的存在就是为了防这一族，docstring 里记着它已经抓到过三次（06-05 sidecar / 06-10 risk+lev_regime / 07-16 t0_setups+em_news），并写明「Each fix was a hand-edited git-add list, which is why it kept coming back」。

第四次漏掉的原因很具体：**发现逻辑只匹配 `assets/data/` 路径**

```python
written = set(re.findall(r"WS / 'assets' / 'data' / '([^']+)'", PREFLIGHT))
```

而 `evidence.md` 在仓库根。postflight 里每一个 `git add` 又都是按目录收窄的 —— 于是仓库根成了一块没有任何 owner 的地方。这正是 `MEMORY.md`/`DREAMS.md` 当年需要专门写 `commit_dreaming.sh` 的那个缝。

## 改动

1. `evidence.md` 进 `brief_postflight` 的 `_git('add', ...)`（已确认它 tracked 且非 gitignore —— gitignore 路径会让整个 commit 失败而不是跳过）
2. 契约测试补 `test_repo_root_outputs_are_committed_too`：扫 preflight 通过 subprocess 调的脚本，找 `NAME = WS / 'file'` 形式的仓库根常量，**只保留真被写入的**（`NAME.write_text(` / `_write_*(NAME`），排除只读的（几个脚本的 `PORTFOLIO = WS / 'portfolio.json'` 就是只读，不该因此被要求提交）

实测发现结果恰好是 `{'evidence.md': 'build_evidence.py'}`，没有误报。

## 验证

| 变异 | 结果 |
|---|---|
| 把 `evidence.md` 从 stager 拿掉（= 修复前状态） | ✅ `test_repo_root_outputs_are_committed_too` 红 |

全量套件 **1635 passed, 4 xfailed**。`git status` 只有这 2 个文件。

## 自愈

不需要手工补发：合并后明早 08:00 的简报会把当前这份重算结果一起提交，线上证据页自动追上产物。
