### PR TITLE
news: classify Stock Connect membership changes and give them a direction

### DIFF
--- a/scripts/data/news_evidence_graph.py
+++ b/scripts/data/news_evidence_graph.py
@@ -46,13 +46,13 @@ PRIMARY_SOURCE_TYPES = {
 POSITIVE_WORDS = {
     'beat', 'beats', 'raise', 'raised', 'upgrade', 'upgraded', 'approval',
     'approved', 'contract', 'award', 'buyback', 'record revenue', '获准',
-    '中标', '回购', '上调', '增长', '获批',
+    '中标', '回购', '上调', '增长', '获批', '调入', '纳入',
 }
 NEGATIVE_WORDS = {
     'miss', 'missed', 'probe', 'investigation', 'fraud', 'lawsuit',
     'downgrade', 'downgraded', 'recall', 'dilution', 'offering', 'default',
     'cut guidance', 'restatement', '减持', '调查', '诉讼', '下调', '召回',
-    '亏损', '处罚', '违约',
+    '亏损', '处罚', '违约', '调出', '剔除',
 }
 
 sys.path.insert(0, str(WS / 'scripts' / 'data'))
@@ -186,6 +186,12 @@ def classify_event(title, explicit=None):
         ('product', ('launch', 'release', 'recall', '测试', '发布', '召回')),
         ('analyst_rating', ('upgrade', 'downgrade', 'price target', '覆盖', '评级')),
         ('ownership', ('stake', 'holding', '持股', '减持', '增持')),
+        # Southbound/index membership changes. Deliberately NOT in
+        # HARD_EVENT_TYPES: escalation additionally requires a negative
+        # direction, and widening high_impact here would quietly start
+        # escalating removals — a policy change, not a classification fix.
+        ('index_inclusion', ('港股通', '沪股通', '深股通', '标的名单',
+                             'stock connect', 'index inclusion')),
         ('price_move', ('涨超', '跌幅', 'shares rise', 'shares fall')),
         ('sector_flow', ('sector', '板块', 'etf主力', '资金流入')),
     )

--- a/tests/test_news_evidence_graph.py
+++ b/tests/test_news_evidence_graph.py
@@ -407,3 +407,38 @@ def test_postflight_requires_matching_actionable_event_id(tmp_path):
     path.write_text(json.dumps(missing))
     rejected = brief_postflight.validate_plan_json(path, context)
     assert any('news-evidence-gate' in issue for issue in rejected)
+
+
+def test_stock_connect_membership_gets_a_type_and_a_direction():
+    """港股通 membership changes were classified `other` / `unknown` (#346).
+
+    `unknown` is not a harmless default: `apply_confirmation` derives
+    `expected_sign` from the direction, so an unknown-direction event has
+    `price_aligned is False` no matter how it traded. MiniMax's 2026-08-06
+    inclusion was recorded as "not confirmed" on a day it moved +10.25% — which
+    reads identically to a catalyst the tape rejected, when in truth the tape was
+    never consulted. Escalation is asserted here too: it must stay False, because
+    positive events are hold-only by design (see the sibling escalation test) and
+    the fix must not smuggle in a policy change.
+    """
+    inclusion = '上交所：港股通标的名单调入MINIMAX-W、立讯精密、三环集团'
+    removal = '港股通标的名单调出某某股份'
+    assert graph.classify_event(inclusion) == 'index_inclusion'
+    assert graph.classify_impact(inclusion) == 'positive'
+    assert graph.classify_impact(removal) == 'negative'
+    # Broad words must not fire on an unrelated negative headline.
+    assert graph.classify_impact('某公司纳入调查') == 'conflicting'
+
+    event = {
+        'title': inclusion, 'ticker': '00100', 'reported_ticker': '00100',
+        'event_type': graph.classify_event(inclusion),
+        'impact_direction': graph.classify_impact(inclusion),
+        'source_reliability': 0.62, 'novelty_score': 1.0, 'status': 'active',
+    }
+    portfolio = {'portfolios': {'hk_stocks': {'holdings': [
+        {'ticker': '00100', 'today_change_pct': 10.25,
+         'current_price': 253.8, 'volume': 38060, 'shares': 120}]}}}
+    graph.apply_confirmation(POLICY, [event], portfolio, {}, {})
+    graph.gate_events(POLICY, [event])
+    assert event['confirmation']['price_aligned'] is True
+    assert event['actionable_escalation'] is False


### PR DESCRIPTION
**Part of #346（缺口 2）**，缺口 1（结构化催化日历）另开 PR，所以这条不带 close 关键字。

## 问题

```
classify_event("上交所：港股通标的名单调入MINIMAX-W…")  -> other
classify_impact(同一标题)                                -> unknown
```

8 条 event 规则没有一条覆盖港股通；`POSITIVE_WORDS` 有「上调」，**没有「调入」**。

`unknown` 不是无害默认值：`apply_confirmation` 从方向推 `expected_sign`，方向未知 ⇒ `expected_sign=0` ⇒ **`price_aligned` 恒为 False**，无论盘面怎么走。于是 MiniMax 这条在当天 **+10.25%** 的行情里被记成「未确认」—— 这和「催化被盘面否定了」在数据上完全无法区分，而真相是**方向根本没被评估过**。

## 改动

- `classify_event` 增 `index_inclusion`：`港股通 / 沪股通 / 深股通 / 标的名单 / stock connect / index inclusion`
- `POSITIVE_WORDS` += `调入` `纳入`；`NEGATIVE_WORDS` += `调出` `剔除`

真实事件端到端效果：

| | 修复前 | 修复后 |
|---|---|---|
| event_type | `other` | `index_inclusion` |
| impact_direction | `unknown` | `positive` |
| price_aligned | `False`（结构性不可能为真） | **`True`**（+10.25% 真实确认） |
| confirmed | `False` | `True` |
| **actionable_escalation** | `False` | **`False`（不变）** |
| blockers | 4 条 | 3 条 |

## 刻意没做的事

**`index_inclusion` 没有加进 `HARD_EVENT_TYPES`。** 升级还额外要求方向为负，放宽 `high_impact` 会让「剔除/调出」开始可升级 —— 那是策略变更，不是分类修复。正面事件维持 hold-only，既有的 `test_only_confirmed_negative_primary_event_can_escalate` 已经钉住这条，我没有重复写一条。

## 收敛检查（防止新词误伤）

| 标题 | event | impact |
|---|---|---|
| `…港股通标的名单调入…` | `index_inclusion` | `positive` |
| `港股通标的名单调出某某股份` | `index_inclusion` | `negative` |
| `某公司纳入调查` | `regulatory` | `conflicting` ← 没被误判成利好 |
| `港股异动 \| MINIMAX-W涨超12%` | `price_move` | `unknown` ← 没被新规则抢走 |
| `ABC faces SEC investigation` | `regulatory` | `negative` ← 既有行为不变 |

## 测试

只加了 1 条。变异验证：

| 变异 | 结果 |
|---|---|
| 从 `POSITIVE_WORDS` 拿掉 `调入`（方向退回 unknown） | ✅ 红 |
| 把 `index_inclusion` 加进 `HARD_EVENT_TYPES` | ⚠️ **没红** —— 见下 |

第二个变异**故意不去覆盖**：正面事件的 escalation 本来就被方向闸挡住，加不加 `HARD_EVENT_TYPES` 对它没有区别；真要钉住只会锁死「将来是否允许升级已确认的剔除」这个合理的策略选项。既有 sibling 测试已经覆盖了真正要紧的行为。这里如实记下来，不假装两个变异都被抓到。

全量套件 **1635 passed, 4 xfailed**。
