### PR TITLE
catalysts: give dated company events a structured home instead of prose

### DIFF
--- a/memory/scheduled_catalysts.json
+++ b/memory/scheduled_catalysts.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Company-specific events with a known future date that no API provides: Stock Connect effective dates, lockup expiries, mainnet launches, index rebalance effective dates. Earnings/FOMC/macro are fetched automatically and do NOT belong here.",
+    "maintained": "manual — add an entry when a dated company event is announced; delete it once the date has passed and been reflected in the ledger",
+    "why_this_exists": "Before this file, such dates existed only inside brief prose, so the model re-guessed them every morning. On 2026-08-06 one brief gave three mutually contradictory dates for the same MiniMax Stock Connect event (下周一 / next month / 9月) while using that very date to size a trim.",
+    "date_confidence": {
+      "confirmed": "an official announcement states this exact date",
+      "estimated": "derived from a stated rule (e.g. 'effective the second Monday after review') — usable, but say it is an estimate",
+      "unconfirmed": "the event is real but no date is known yet; date MUST be null. Never fill a guess here."
+    },
+    "consumed_by": "scripts/data/fetch_catalysts.py -> catalysts.json.scheduled_events -> brief context"
+  },
+  "events": [
+    {
+      "ticker": "00100",
+      "name": "MINIMAX-W",
+      "type": "stock_connect_inclusion",
+      "date": null,
+      "date_confidence": "unconfirmed",
+      "detail": "上交所 2026-08-05 公告港股通标的名单调入 00100；调入已宣布，实际生效日尚未从公告原文确认",
+      "source": "上交所公告 2026-08-05（经 em_news 捕获，标题：上交所：港股通标的名单调入MINIMAX-W、立讯精密、三环集团）",
+      "added": "2026-08-06"
+    }
+  ]
+}

--- a/scripts/data/fetch_catalysts.py
+++ b/scripts/data/fetch_catalysts.py
@@ -34,6 +34,9 @@ from instrument_registry import leveraged_symbols
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 OUT_FILE = os.path.join(WS_ROOT, 'assets', 'data', 'catalysts.json')
 API_KEYS_FILE = os.path.join(WS_ROOT, '.api_keys')
+# Dated company events no vendor supplies (Stock Connect effective dates, lockup
+# expiries, mainnet launches). Hand-maintained; see the file's own _meta.
+SCHEDULED_FILE = os.path.join(WS_ROOT, 'memory', 'scheduled_catalysts.json')
 
 UA = 'clawock-catalysts/1.0 (github.com/KCNyu/clawock)'
 HEADERS = {'User-Agent': UA}
@@ -307,6 +310,54 @@ def _highest_impact(catalysts, today_iso):
     return None
 
 
+def scheduled_in_window(window_start, window_end, path=SCHEDULED_FILE):
+    """Hand-maintained company events, filtered to the window.
+
+    An entry whose date is unknown is kept regardless of the window and carries
+    `date: null`. That is the point of the file: the brief must be able to say
+    "生效日未确认" from data instead of inventing a date, which is what produced
+    three contradictory dates for one event on 2026-08-06.
+
+    Returns `(events, error)`. A malformed file must not take the whole catalyst
+    step down — the automatic categories are still worth publishing — but it must
+    not vanish silently either: a JSON typo in a hand-edited file would otherwise
+    drop every scheduled event with nothing anywhere saying so. The error rides
+    out in `catalysts.json.error`, which preflight already surfaces.
+    """
+    try:
+        with open(path, encoding='utf-8') as fh:
+            entries = (json.load(fh) or {}).get('events') or []
+    except FileNotFoundError:
+        return [], None
+    except (OSError, ValueError) as exc:
+        return [], f'{type(exc).__name__}: {exc}'
+    out = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get('ticker'):
+            continue
+        date = entry.get('date')
+        confidence = entry.get('date_confidence') or 'unconfirmed'
+        # A date that is present but outside the window is simply not due yet.
+        if date and not (window_start <= date <= window_end):
+            continue
+        # Guard the one rule the file exists to enforce: no date, no confidence
+        # claim. A stray "confirmed" with a null date would let the brief cite a
+        # certainty that does not exist.
+        if not date:
+            confidence = 'unconfirmed'
+        out.append({
+            'ticker': entry['ticker'],
+            'name': entry.get('name') or entry['ticker'],
+            'type': entry.get('type') or 'other',
+            'date': date,
+            'date_confidence': confidence,
+            'detail': entry.get('detail') or '',
+            'source': entry.get('source') or '',
+        })
+    ordered = sorted(out, key=lambda e: (e['date'] is None, e['date'] or '', e['ticker']))
+    return ordered, None
+
+
 def build_catalysts(days):
     today = datetime.now(timezone(timedelta(hours=8))).strftime('%Y-%m-%d')
     today_dt = datetime.strptime(today, '%Y-%m-%d').date()
@@ -320,6 +371,9 @@ def build_catalysts(days):
 
     fomc = fomc_in_window(today, end_iso)
     macro = macro_in_window(today, end_iso)
+    scheduled, s_error = scheduled_in_window(today, end_iso)
+    if s_error:
+        errors['scheduled_events'] = s_error
 
     catalysts = {
         'earnings':      earnings,
@@ -337,10 +391,13 @@ def build_catalysts(days):
         'earnings':           earnings,
         'fomc':               fomc,
         'macro_events':       macro,
+        'scheduled_events':   scheduled,
         'summary': {
             'earnings_count':           len(earnings),
             'fomc_in_window':           len(fomc),
             'macro_count':              len(macro),
+            'scheduled_count':          len(scheduled),
+            'scheduled_undated':        sum(1 for e in scheduled if not e['date']),
             'highest_impact_within_7d': highest,
         },
     }

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -311,6 +311,10 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 - **只有硬催化能驱动一次 bucket 翻转**(尤其翻成 cut/trim/add)。若你想下主动 call 但手里只有软情绪 → 降级为 `hold_and_watch` + 设触发价观察,别直接动手。
 - influencer(Trump/Musk/Serenity)默认归 **软情绪**;仅当其言论对应**已落地的政策/行政令/具体合同**才升级为硬催化。Serenity 是 KOL 选股(常为微盘/光通信小票),按 [[serenity-skill]] 的证据阶梯属"弱证据线索",只动 confidence、需一手来源(财报/合同/公告)证实后才可加权。
 - 自检:若某 action 的 `driven_by` 是 `sentiment` 或 `influencer` 且 bucket ∈ {cut,trim_on_rebound,add_only_on_trigger} → **这违反铁律,改回 hold_and_watch 或换硬证据**。
+- **前瞻事件的日期只能引用 `context.catalysts`，禁止推测。** 财报/FOMC/宏观在 `earnings`/`fomc`/`macro_events`；公司级预定事件（港股通生效日、解禁日、mainnet 上线、指数调整生效日）在 **`scheduled_events`**（真源 `memory/scheduled_catalysts.json`，手工维护）。
+  - `date_confidence=confirmed` → 可直接写该日期；`estimated` → 写日期但必须标「预计」；**`date` 为 `null`（`unconfirmed`）→ 只能写「生效日未确认」，不准用「下周一」「下个月」「9 月」这类自己推出来的说法**。
+  - `scheduled_events` 里没有的公司级预定事件 → **当作日期未知处理**，同时在 `▎待补` 提示把它加进 `memory/scheduled_catalysts.json`，别在正文里编一个。
+  - 为什么是铁律：2026-08-06 的简报对同一个 MiniMax 港股通事件给出了**三个互相矛盾的日期**（「下周一生效」/「next month」/「9 月生效」），而正文正在拿这个日期决定要不要 trim。没有结构化真源时，模型每天重猜且没有任何东西会红。
 
 #### 🛡️ 消息面证伪不证实(牛市最关键 — REQUIRED)
 

--- a/tests/test_scheduled_catalysts.py
+++ b/tests/test_scheduled_catalysts.py
@@ -1,0 +1,62 @@
+"""The hand-maintained scheduled-catalyst store must not be able to lie quietly.
+
+Company events with a known future date (Stock Connect effective dates, lockup
+expiries, mainnet launches) have no vendor feed, so they live in a file a human
+edits. Before it existed those dates lived only in brief prose, and on
+2026-08-06 one brief gave three contradictory dates for the same MiniMax Stock
+Connect event (下周一 / next month / 9月) while using that date to size a trim.
+
+Both failure modes below are silent by nature — a wrong date reads exactly like
+a right one — which is what earns them a test.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+
+import fetch_catalysts  # noqa: E402
+
+
+def _store(tmp_path, events):
+    path = tmp_path / 'scheduled_catalysts.json'
+    path.write_text(json.dumps({'events': events}), encoding='utf-8')
+    return str(path)
+
+
+def test_an_undated_event_cannot_claim_a_confirmed_date(tmp_path):
+    """`date: null` must force `unconfirmed`, whatever the file says.
+
+    The brief is allowed to print a date only for confirmed/estimated entries, so
+    a stray "confirmed" on a dateless row would license it to state a certainty
+    nobody ever established — the exact failure the store was built to end.
+    """
+    path = _store(tmp_path, [{
+        'ticker': '00100', 'type': 'stock_connect_inclusion',
+        'date': None, 'date_confidence': 'confirmed',
+    }])
+    events, error = fetch_catalysts.scheduled_in_window('2026-08-06', '2026-09-06', path=path)
+    assert error is None
+    assert events[0]['date'] is None
+    assert events[0]['date_confidence'] == 'unconfirmed'
+
+
+def test_a_broken_store_reports_instead_of_emptying_silently(tmp_path):
+    """A JSON typo must surface, not drop every scheduled event without a word."""
+    path = tmp_path / 'broken.json'
+    path.write_text('{ not json', encoding='utf-8')
+    events, error = fetch_catalysts.scheduled_in_window(
+        '2026-08-06', '2026-09-06', path=str(path))
+    assert events == []
+    assert error and 'JSONDecodeError' in error
+
+
+def test_undated_events_survive_the_window_filter(tmp_path):
+    """A dateless event is pending, not expired — the window must not drop it."""
+    path = _store(tmp_path, [
+        {'ticker': 'AAA', 'date': None},
+        {'ticker': 'BBB', 'date': '2027-01-01'},  # far outside the window
+    ])
+    events, _ = fetch_catalysts.scheduled_in_window('2026-08-06', '2026-09-06', path=path)
+    assert [e['ticker'] for e in events] == ['AAA']


### PR DESCRIPTION
Closes #346（缺口 1；缺口 2 = 分类器在 #348）。

## 问题

`catalysts.json` 只有 `earnings` / `fomc` / `macro_events`。公司级、有确定未来日期的事件（港股通生效日、解禁日、mainnet 上线、指数调整生效日）**没有任何结构化归宿** —— grep 全文，`港股通` 和 `00100` 都不在 catalysts 里。

于是这类日期只活在简报散文里，模型每天重新推一遍，且没有任何东西会红。2026-08-06 的实际后果：**同一篇简报对同一个 MiniMax 港股通事件给出三个互相矛盾的日期**

| 行 | 说法 |
|---|---|
| L110 | 「**下周一** 港股通 实际生效前 利好出尽 risk」 |
| L166 | 「（**next month** 实际生效）」 |
| L225 | 「持有等 **9 月** 港股通 生效」 |

「下周一」和「9 月」差一个多月 —— 而 L180 正在拿这个日期做仓位建议（「trim 28 @240 是保守, 改 trim 18 @250+」）。

## 改动

**`memory/scheduled_catalysts.json`**（新，手工维护 —— 没有任何 vendor 提供这类日期）→ `fetch_catalysts.py` 按窗口过滤 → `catalysts.scheduled_events` → 简报 context（preflight 是 `json.loads(cat_out)` 整份透传，新键自动到位）。

放在 `memory/` 是因为它已经被 postflight 的 `git add memory/` 覆盖，和同样手工维护的 `peer-map.json` 一致。

三条设计约束，每条都对应一种「安静地骗人」的方式：

1. **无日期条目不参与窗口过滤** —— 「待定」不是「过期」，窗口不该把它筛掉
2. **`date` 为 null 强制 `date_confidence=unconfirmed`** —— 手写一个 `confirmed` 配 null 日期，就会让简报引用一个从未确立的确定性
3. **坏文件走既有 `error` 通道，不静默清空** —— 手工编辑的文件出个 JSON typo，不该让所有预定事件无声消失（`detect but never silence`）。缺文件不算错误，只有解析失败才算

**SKILL 同步**（否则模型照旧猜）：前瞻日期只能引用 `context.catalysts`；`confirmed` 可直接写、`estimated` 必须标「预计」、**`null` 只能写「生效日未确认」，禁止「下周一/下个月/9 月」这类自推说法**；store 里没有的条目当日期未知处理并提示补录。

## MiniMax 那条

`date: null` / `unconfirmed`。**我没有填一个日期** —— 公告原文里的生效日我没有确认，在这里猜一个就是把本 PR 要修的 bug 重新做一遍。补录时把 `date` 和 `date_confidence` 一起改成 `confirmed` 即可。

## 测试

3 条，两个高载荷的都做了变异验证：

| 变异 | 结果 |
|---|---|
| 去掉「无日期即 unconfirmed」归一化 | ✅ 红 |
| 坏文件静默吞掉（返回 `None` 错误） | ✅ 红 |

全量套件 **1637 passed, 4 xfailed**。

⚠️ 跑 `fetch_catalysts.py` 会重写 `assets/data/catalysts.json`（发布产物），已 `git checkout` 还原，**没有混进本 PR** —— `git status` 只有那 4 个文件。
