### PR TITLE
tools: give the registry its first real consumer, and fix what that exposed

### DIFF
--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -17,6 +17,8 @@ import json
 import sys
 from pathlib import Path
 
+from clawock.tools import ToolError, build_registry
+from clawock.tools import describe as describe_tools
 from clawock.workspace import ENV_VAR, describe, workspace_root
 
 
@@ -90,6 +92,48 @@ def _report(args) -> int:
     return 0 if verdict == "pass" else 1
 
 
+def _tool(args) -> int:
+    """Reach a context tool through the registry instead of a path into scripts/.
+
+    This is what makes the tool layer real (#266). Before it, `clawock.tools` had
+    no caller outside its own tests: the skills reached the same data by running
+    `python3 .../scripts/data/brief_decision_packet.py`, so the registry was an
+    executable design document and the per-query byte budget — the hole #258
+    actually closed — protected a path nobody took, because the callers that read
+    context ARE the skills.
+
+    `--list` prints the contract as JSON, so a non-OpenClaw runner can discover
+    the tools instead of re-deriving them from Chinese prose in a SKILL.md.
+    """
+    root = workspace_root(args.workspace or Path.cwd())
+    registry = build_registry(root)
+    if args.list:
+        print(describe_tools(root, args.dialect))
+        return 0
+    if not args.name:
+        print("a tool name is required (or --list)", file=sys.stderr)
+        return 2
+    params: dict[str, str] = {}
+    for item in args.arg or []:
+        key, sep, value = item.partition("=")
+        if not sep:
+            print(f"--arg must be key=value, got {item!r}", file=sys.stderr)
+            return 2
+        params[key] = value
+    try:
+        print(registry.call(args.name, **params))
+    except (ToolError, ValueError) as exc:
+        # A refusal is the tool working, not the CLI failing: report it on stderr
+        # with a non-zero exit so a caller can tell it apart from real output,
+        # and never print a traceback into the middle of a model turn.
+        # ValueError is in here for one specific reason: the 24 KiB budget raises
+        # it from bounded_payload, so the single most likely refusal on this path
+        # would otherwise be the one thing that crashes instead of refusing.
+        print(f"{args.name}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="clawock", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -107,6 +151,17 @@ def main(argv=None) -> int:
                         help="model prose; reads stdin when omitted")
     report.add_argument("--json", action="store_true")
     report.set_defaults(func=_report)
+
+    tool = sub.add_parser(
+        "tool", help="call a context tool through the registry")
+    tool.add_argument("name", nargs="?", help="tool name, e.g. decision_packet_query")
+    tool.add_argument("--arg", action="append", metavar="KEY=VALUE",
+                      help="tool argument; repeatable")
+    tool.add_argument("--list", action="store_true",
+                      help="print the tool contract as JSON and exit")
+    tool.add_argument("--dialect", choices=("openai", "anthropic"), default="openai")
+    tool.add_argument("--workspace", type=Path, default=None)
+    tool.set_defaults(func=_tool)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/clawock/tools/context_tools.py
+++ b/clawock/tools/context_tools.py
@@ -112,8 +112,17 @@ class DecisionPacketQuery(_PacketTool):
         value = (packet.get("tickers") or {}).get(str(ticker))
         if value is None:
             raise ToolError(f"unknown ticker: {ticker}")
+        # `_meta` carries the generation_id, and a narrowed payload must keep it:
+        # the whole protocol is generation-pinned and postflight validates a report
+        # against the exact generation the model read. The CLI path has always
+        # attached it here; the tool dropped it, so every section query through the
+        # registry was silently un-pinned (found by wiring the first real consumer,
+        # #266 — nothing else would have shown it).
         payload = value if section is None else {
-            "ticker": str(ticker), section: value.get(section)}
+            "_meta": packet.get("_meta"),
+            "ticker": str(ticker),
+            section: value.get(section),
+        }
         # The budget is applied here, not on a print path — that is the bug this
         # layer exists to close: every non-CLI caller used to bypass the cap.
         return packet_module.bounded_payload(payload)

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -55,9 +55,9 @@ python3 /root/.openclaw/workspace/scripts/harness/brief_preflight.py
 ### Step 2: 只读 decision packet summary（唯一常驻输入）
 
 ```bash
-python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
-  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
-  --summary
+PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet_summary \
+  --workspace /root/.openclaw/workspace \
+  --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
 ```
 
 summary 包含 book/concentration、每票 deterministic status、技术/因子可用性、风险计数、allowed actions 与 evidence IDs。它不要求模型加载原始持仓交易流水或整张因子表。
@@ -65,12 +65,15 @@ summary 包含 book/concentration、每票 deterministic status、技术/因子�
 需要分析某票时才查该票；需要单一维度时必须带 `--section`：
 
 ```bash
-python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
-  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
-  --ticker 00100 --section technical
+PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet_query \
+  --workspace /root/.openclaw/workspace \
+  --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
+  --arg ticker=00100 --arg section=technical
 ```
 
 可选 section：`facts|technical|quant|sentiment|evidence|risk|constraints`。一次查询硬上限 24 KiB，并同时校验 manifest hash 与 generation。正常分析禁止 `cat brief-context-{date}.json`，也禁止为了省一次查询而整份读 core/research/market bundle。
+
+> **为什么走 `clawock.cli tool` 而不是直接调 `scripts/data/brief_decision_packet.py`**：工具注册表是这套上下文协议唯一机器可读的定义（`clawock.cli tool --list` 直接吐 JSON schema），而 24 KiB 预算是在注册表里强制的 —— 真正读 context 的调用方就是本 skill，绕过注册表等于绕过预算（#266）。`PYTHONPATH=` 前缀是必需的：`clawock` 尚未 pip 安装，没有它则只在 cwd 恰好是 workspace 时才能跑。输出与旧命令逐 section JSON 等价，含 `_meta.generation_id` 代次钉扎。
 
 ### Step 2.5: 按消费者 lazy-load bundles
 

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -304,6 +304,9 @@ def test_pages_prefers_projection_and_keeps_a_backward_fallback():
     assert "projection.schema_version === 1" in renderer
     assert "projected.length" in renderer
     assert ": holds.map" in renderer
-    assert "--summary" in skill
+    # The summary read moved behind the tool registry (#266); it is the same read,
+    # reached by name instead of by a path into scripts/. --judgment-template has
+    # no tool yet, so it is still a shell-out.
+    assert "decision_packet_summary" in skill
     assert "--judgment-template" in skill
     assert "禁止加入价格、RSI、MA" in skill

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -97,3 +97,70 @@ def test_schemas_render_for_both_dialects():
     assert Fake().to_anthropic_schema()["input_schema"]["required"] == ["a"]
     # Descriptions are what the model reads; leading whitespace is noise.
     assert Fake().to_anthropic_schema()["description"] == "spaced"
+
+
+def test_the_cli_consumer_refuses_an_over_budget_query_instead_of_crashing(
+        tmp_path, monkeypatch, capsys):
+    """The budget must hold for the consumer that actually reads context (#266).
+
+    The sibling test above proves `execute` enforces the cap by raising. That is
+    only half the guarantee once a real caller exists: `bounded_payload` raises
+    ValueError, not ToolError, so a CLI that caught only ToolError would turn the
+    single most likely refusal on this path into a traceback printed into the
+    middle of a model turn — the exact failure the tool layer exists to prevent.
+    """
+    from clawock import cli
+
+    packet_module = type(sys)("brief_decision_packet")
+    packet_module.MAX_QUERY_BYTES = 24 * 1024
+
+    def bounded_payload(value):
+        text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+        if len(text.encode()) > packet_module.MAX_QUERY_BYTES:
+            raise ValueError("decision packet query exceeds")
+        return text
+
+    packet_module.bounded_payload = bounded_payload
+    packet_module.read_packet = lambda path: {
+        "_meta": {"generation_id": "gen"},
+        "tickers": {"00100": {"technical": {"blob": "x" * 40_000}}}}
+    monkeypatch.setattr(context_tools, "_load", lambda ws, mod: packet_module)
+    monkeypatch.setattr(
+        context_tools.DecisionPacketQuery, "check_available",
+        classmethod(lambda cls, ws: True))
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+
+    code = cli.main(["tool", "decision_packet_query", "--workspace", str(tmp_path),
+                     "--arg", f"manifest={manifest}", "--arg", "ticker=00100",
+                     "--arg", "section=technical"])
+
+    captured = capsys.readouterr()
+    assert code == 1, "an over-budget query must fail, not print a giant payload"
+    assert "exceeds" in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out.strip() == ""
+
+
+def test_a_narrowed_query_keeps_the_generation_pin(tmp_path, monkeypatch):
+    """A section query must carry `_meta` (#266).
+
+    The protocol is generation-pinned and postflight validates a report against
+    the generation the model actually read. The CLI path always attached `_meta`
+    here; the tool dropped it, so every narrowed query through the registry was
+    silently un-pinned — invisible until a real consumer compared the two.
+    """
+    packet_module = type(sys)("brief_decision_packet")
+    packet_module.bounded_payload = lambda value: json.dumps(value)
+    packet_module.read_packet = lambda path: {
+        "_meta": {"generation_id": "gen-abc"},
+        "tickers": {"00100": {"technical": {"tag": "trend-off"}}}}
+    monkeypatch.setattr(context_tools, "_load", lambda ws, mod: packet_module)
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+    payload = json.loads(context_tools.DecisionPacketQuery().execute(
+        tmp_path, manifest=str(manifest), ticker="00100", section="technical"))
+
+    assert payload["_meta"]["generation_id"] == "gen-abc"


### PR DESCRIPTION
Closes #266。

## 问题

`clawock/tools/` 在包外**零调用方**（全仓 grep 只剩它自己和 `tests/test_tools_registry.py`）。skills 直接 shell-out 到 `scripts/data/brief_decision_packet.py` 拿同一份数据，于是注册表是「一份碰巧可执行的设计文档」，而 #258 真正修掉的那个 24 KiB 预算洞**保护的是没人走的路** —— 因为真正读 context 的调用方就是 skills。

## 改动

`clawock cli` 加 `tool` 子命令（走注册表），brief skill 的两处 context 读改指向它：

```bash
PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet_query \
  --workspace /root/.openclaw/workspace \
  --arg manifest=.../manifest.json --arg ticker=00100 --arg section=technical
```

`--list` 直接吐 JSON schema，非 OpenClaw runner 不必再从中文散文里反推协议。

`--judgment-template` **保持 shell-out**：它没有对应 tool，而「定义新 tool」是 issue 明确的 non-goal。

## 接上真消费者后立刻暴露的两个缺陷

这两个都是**只有存在调用方才会显形**的：

1. **section 查询丢了 `_meta`** → 每次窄查询在注册表里都**脱离了代次钉扎**。而 CLI 路径一直附着它，postflight 又要拿模型实际读到的 generation 去校验报告。实测旧新每个 section 差恰好 120 字节，就是这个 `_meta`。
2. **`bounded_payload` 抛的是 `ValueError` 不是 `ToolError`** → 只捕 `ToolError` 的 CLI 会把「预算溢出」这个**本路径上最可能发生的拒绝**变成一段 traceback 打进模型 turn 中间 —— 正是工具层存在的意义所要防的事。

## 等价性验证（拿 live 2026-08-06 真 manifest）

| 查询 | 结果 |
|---|---|
| `--summary` | ✓ JSON 等价（13,760B） |
| `--ticker 00100 --section {facts,technical,quant,sentiment,evidence,risk,constraints}` | ✓ 7/7 JSON 等价 |
| `--ticker 00100`（整票） | ✓ JSON 等价 |

唯一字节差是 `print()` 多的一个尾换行。

## 测试

2 条新的，都变异验证过：

| 变异 | 结果 |
|---|---|
| CLI 只捕 `ToolError`（预算溢出变 traceback） | ✅ 红 |
| section 查询丢掉 `_meta`（代次钉扎消失） | ✅ 红 |

改了 1 条既有断言：`test_pages_prefers_projection_and_keeps_a_backward_fallback` 原本钉 `--summary` 字面量，现在钉 `decision_packet_summary` —— 同一次读取，只是改成按名字而不是按 `scripts/` 路径到达。

全量套件 **1641 passed, 4 xfailed**。

## 部署注意

`PYTHONPATH=` 前缀是**必需**的：`clawock` 尚未 pip 安装，`python3 -m clawock.cli` 只在 cwd 恰好是 workspace 时才解析得到（cron agent 的 cwd 确实是 workspace，但 agent 中途 `cd` 过就会断）。已实测：带前缀从 `/tmp` 可跑，不带前缀报 `ModuleNotFoundError`。
