### PR TITLE
coupling: take the watchdogs' session directory from the adapter (10 → 9)

### DIFF
--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -27,8 +27,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data')
 from workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
-OC = Path('/root/.openclaw')
-SESSIONS_DIR = OC / 'agents' / 'main' / 'sessions'
 LOG = WS / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
 # The binary path, the cron CLI call and the cron-state fallback chain moved
@@ -47,7 +45,18 @@ HKT = timezone(timedelta(hours=8))
 # first, and the crontab entry only logs a traceback.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from clawock.providers import openclaw as _openclaw  # noqa: E402
-from clawock.providers.openclaw import OPENCLAW_BIN, cron_cli_json as _adapter_cron_json  # noqa: E402
+from clawock.providers.openclaw import (  # noqa: E402
+    OPENCLAW_BIN, OPENCLAW_HOME, cron_cli_json as _adapter_cron_json,
+)
+
+# Where the runtime keeps its session transcripts. The location is the runtime's,
+# so the adapter owns it (#330 step 1): this module used to hard-code
+# `Path('/root/.openclaw')`, which made it one of the ten sites that know which
+# runtime they are on. Deriving it from the adapter's constant is the fix the
+# ratchet is asking for — not a relocated string, because `clawock/providers/` is
+# the one place where knowing is correct, and it is already this module's source
+# for OPENCLAW_BIN and the cron chain.
+SESSIONS_DIR = OPENCLAW_HOME / 'agents' / 'main' / 'sessions'
 
 
 def log(event):

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -55,8 +55,31 @@ RUNTIME = "openclaw"
 # regressed between the two — the earlier count was measuring the wrong thing,
 # so 14 was the first number here worth quoting. 14 → 13 when the cron-state
 # chain moved into the adapter (#273); 13 → 10 when the two money CLIs and the
-# legacy backfill stopped naming the runtime's workspace absolutely (#290).
-BASELINE = 10
+# legacy backfill stopped naming the runtime's workspace absolutely (#290);
+# 10 → 9 when the watchdogs' session directory came from the adapter's
+# OPENCLAW_HOME instead of a hard-coded path (#330 step 1).
+BASELINE = 9
+
+# The honest floor is 1, not 0 — say it rather than let a future reader assume
+# the remaining count is all debt.
+#
+# `gc_sessions.py` keeps its site by decision (#330). Its OPENCLAW_HOME cleans
+# the runtime's OWN session files: that is running the runtime, not our harness
+# depending on it. Removing the site would mean moving the whole script into
+# clawock/providers/, which is a different argument and probably not worth
+# making — a garbage collector for someone else's files is not part of a
+# portable harness's interface.
+#
+# So the sequence that remains is 9 → 1:
+#   sync_cron_payloads.py (2) + sync_us_cron_dst.py (1) — the only paths that
+#     WRITE OpenClaw's schedule. They need a scheduling capability on the
+#     provider interface, which does not exist yet; that interface is the real
+#     work and the call sites are trivial afterwards.
+#   system_check.py (5) — last, deliberately. It is what proves the earlier
+#     steps did not break anything, so migrating it first would remove the check
+#     while the checked-for change is in flight.
+DELIBERATE_EXCLUSIONS = {"scripts/data/gc_sessions.py": 1}
+HONEST_FLOOR = sum(DELIBERATE_EXCLUSIONS.values())
 
 _SPAWNERS = {"run", "call", "check_call", "check_output", "Popen", "system", "getoutput"}
 
@@ -229,6 +252,16 @@ def test_the_runtime_coupling_count_never_rises():
     assert total >= BASELINE, (
         f"runtime coupling fell to {total} — lower BASELINE to {total} in this "
         "file so the gain is locked in")
+
+    # Keep the documented floor honest. Without this the exclusion note is prose
+    # that can quietly become false — either because the site was fixed and the
+    # note still claims it is deliberate, or because it moved and the note points
+    # at nothing. Both turn "the honest target is 1, not 0" into a lie.
+    for name, count in DELIBERATE_EXCLUSIONS.items():
+        assert len(sites.get(name, [])) == count, (
+            f"{name} is documented as a deliberate exclusion of {count} site(s), "
+            f"but now has {len(sites.get(name, []))}. Update DELIBERATE_EXCLUSIONS "
+            "and the note above it — the floor is part of the claim.")
 
 
 def test_prose_is_not_coupling_and_a_command_is():


### PR DESCRIPTION
**Part of #330（3 步里的第 1 步）**，故意不带 close 关键字 —— 调度能力和 `system_check` 还没做。

## 改动

`_watchdog_common.py` 里硬编码的 `OC = Path('/root/.openclaw')` 去掉，`SESSIONS_DIR` 改从 adapter 的 `OPENCLAW_HOME` 派生。该模块**本来就**从 `clawock/providers/openclaw.py` 导入 `OPENCLAW_BIN` 和 cron 链，home 常量走同一个来源。

**这不是"挪字符串"**（issue 明确点名的反模式）：`clawock/providers/` 正是 ratchet 唯一豁免的目录，因为那里知道运行时是**对的**。判据是 `gc_sessions.py` 自己——它第 29 行 `Path(os.environ.get('OPENCLAW_HOME','/root/.openclaw'))` 被计数，而 30–32 行由 `OPENCLAW_HOME` 派生的三个路径**不计数**。

```
10 → 9，_watchdog_common.py 整个从清单上消失
```

剩余分布：`system_check.py` 5、`sync_cron_payloads.py` 2、`sync_us_cron_dst.py` 1、`gc_sessions.py` 1。

## 为什么单独一个 PR

按 issue 的排序，这一步「touches live delivery, so it wants to be done while attention is on it rather than bundled」。每个 watchdog 和 postflight 都通过 `SESSIONS_DIR` 读会话记录，所以我做了三层验证：

| 检查 | 结果 |
|---|---|
| 路径字符串是否与旧硬编码完全相同 | ✓ `/root/.openclaw/agents/main/sessions` |
| 目录真实存在且有内容 | ✓ 645 个 `.jsonl` |
| 9 个消费者能否 import | ✓ brief/report/intraday × watchdog+postflight、cron_health_check、sync_us_cron_dst、system_check 全通过 |

## 诚实底线（验收项 1）

`gc_sessions.py` 按决定**保留**：它的 `OPENCLAW_HOME` 清的是运行时**自己**的会话文件 —— 那是在运行 runtime，不是我们的 harness 依赖它。要去掉就得把整个脚本搬进 `clawock/providers/`，那是另一个论证，而且大概率不值得做：给别人的文件做垃圾回收不该是可移植 harness 的接口。

所以**诚实目标是 1 不是 0**，剩余序列是 9 → 1。

这一条我没有只写成注释就算数 —— `DELIBERATE_EXCLUSIONS` 被**断言**了。否则那段说明会悄悄变成谎话：要么站点被修了而注释还宣称它是故意保留，要么站点挪了而注释指向空气。

## 测试

没加新测试函数，把断言并进既有的 `test_the_runtime_coupling_count_never_rises`（新定义的常量如果没人读，就正好是我在 #350 刚修掉的「建好没接线」反模式）。

| 变异 | 结果 |
|---|---|
| 把硬编码路径改回去（耦合升回 10） | ✅ 红 |
| 假装 gc_sessions 已修（文档排除项变谎话） | ✅ 红 |

全量套件 **1641 passed, 4 xfailed**。

## 下两步（本 PR 不做）

2. `sync_cron_payloads.py`(2) + `sync_us_cron_dst.py`(1) —— 唯二会**写** OpenClaw 排程的路径，需要 provider 接口上先有调度能力；**接口才是真正的工作量**，调用点改起来是琐事。
3. `system_check.py`(5) —— 最后，故意的。它是证明前两步没弄坏东西的那个东西，先搬它等于在被检查的变更进行中把检查拆了。
