### PR TITLE
coupling: put the schedule writers behind a provider capability (9 → 6)

### DIFF
--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -251,3 +251,95 @@ def read_runs(job_id: str, source: str = "auto") -> CronRead:
                   f"for {job_id}", file=sys.stderr)
             return CronRead(entries, "fossil")
     return CronRead([], "empty")
+
+
+# ── Scheduling ───────────────────────────────────────────────────────────────
+# The capability the two schedule WRITERS need (#330 step 2). Reading is already
+# above; writing was the only part of the cron interface still spelled out as an
+# argv literal inside `scripts/`, which made those two files the only places that
+# had to know this runtime's command line in order to do their job.
+#
+# The split: the patch vocabulary below is ours — what a scheduler is asked to
+# change — and mapping it onto a command line is this adapter's business. A
+# second runtime reimplements the mapping, not the callers.
+
+
+def read_jobs_strict(*, runner=None) -> list[dict]:
+    """Jobs from the CLI, raising if the runtime cannot be read.
+
+    `read_jobs` is fail-soft on purpose: for a watchdog, an unreachable runtime
+    is not the same as an empty schedule. For the paths that WRITE the schedule
+    the opposite is true — an empty read means "every job differs from the
+    contract", which would rewrite the whole table off a failed command. So the
+    writer path gets its own read, and the difference is stated rather than left
+    to whoever calls which.
+    """
+    data = cron_cli_json(["list", "--json"], runner=runner)
+    if not isinstance(data, dict):
+        raise RuntimeError("openclaw cron list failed: no JSON object returned")
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        raise RuntimeError("openclaw cron list failed: response has no job list")
+    return jobs
+
+
+def build_cron_edit_argv(job_id: str, patch: dict, *,
+                         binary: str = OPENCLAW_BIN,
+                         run_timeout_ms: int | None = None) -> list[str]:
+    """One job patch as this runtime's `cron edit` command line.
+
+    Only declared fields are emitted, so an edit never carries a value the caller
+    did not ask to change — that is what keeps a payload sync from clobbering
+    delivery settings it has no opinion about.
+
+    `binary` defaults to the absolute path rather than relying on PATH: the DST
+    sync runs from crontab, where a bare name resolves only because the entry
+    happens to use a login shell.
+    """
+    command = [binary, "cron", "edit", job_id]
+    if "schedule" in patch:
+        schedule = patch["schedule"]
+        if not schedule.get("tz"):
+            # A cron row with no timezone silently follows the host's, which for
+            # a market schedule is the difference between an open and a close.
+            raise ValueError("clearing a cron timezone is not supported safely")
+        command.extend(["--cron", schedule["expr"], "--tz", schedule["tz"], "--exact"])
+    if "enabled" in patch:
+        command.append("--enable" if patch["enabled"] else "--disable")
+    if "model" in patch:
+        command.extend(["--model", patch["model"]])
+    if "fallbacks" in patch:
+        if patch["fallbacks"]:
+            command.extend(["--fallbacks", ",".join(patch["fallbacks"])])
+        else:
+            command.append("--clear-fallbacks")
+    if "thinking" in patch:
+        command.extend(["--thinking", patch["thinking"]])
+    if "toolsAllow" in patch:
+        tools = patch["toolsAllow"]
+        if tools:
+            command.extend(["--tools", ",".join(tools)])
+        else:
+            command.append("--clear-tools")
+    if "timeoutSeconds" in patch:
+        command.extend(["--timeout-seconds", str(patch["timeoutSeconds"])])
+    if "message" in patch:
+        command.extend(["--message", patch["message"]])
+    if "deliveryMode" in patch:
+        mode = patch["deliveryMode"]
+        if mode == "none":
+            command.append("--no-deliver")
+        elif mode == "announce":
+            command.append("--announce")
+        else:
+            raise ValueError(f"unsupported delivery mode {mode!r}")
+    if patch.get("clearTrigger"):
+        command.append("--clear-trigger")
+    if "trigger" in patch:
+        trigger = patch["trigger"]
+        command.extend(["--trigger-script", trigger["scriptPath"]])
+        if trigger["once"]:
+            command.append("--trigger-once")
+    if run_timeout_ms is not None:
+        command.extend(["--timeout", str(run_timeout_ms)])
+    return command

--- a/scripts/data/sync_cron_payloads.py
+++ b/scripts/data/sync_cron_payloads.py
@@ -22,11 +22,24 @@ from workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 sys.path.insert(0, str(WS / "scripts" / "data"))
+# The runtime's cron command line and the strict read both live in the adapter
+# (#330 step 2). This file decides WHAT to change; how that reaches OpenClaw is
+# not its business, and spelling the argv out here was what made it one of the
+# two places outside clawock/providers/ that had to know the runtime.
+#
+# The CHECKOUT root, not WS: `workspace_root` is overridable, so WS can be
+# someone else's data directory with no `clawock` package in it. The import has
+# to resolve against the tree this file ships in.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from cron_contract import (  # noqa: E402
     effective_schedule,
     load_contract,
     render_payload_message,
+)
+from clawock.providers.openclaw import (  # noqa: E402
+    build_cron_edit_argv,
+    read_jobs_strict,
 )
 
 Runner = Callable[..., subprocess.CompletedProcess]
@@ -50,21 +63,15 @@ def _json_object(text: str) -> dict:
     return value
 
 
-def load_live_jobs(runner: Runner = subprocess.run) -> list[dict]:
-    result = runner(
-        ["openclaw", "cron", "list", "--json"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    if result.returncode != 0:
-        detail = (result.stdout + result.stderr).strip()[-500:]
-        raise RuntimeError(f"openclaw cron list failed: {detail}")
-    value = _json_object(result.stdout)
-    jobs = value.get("jobs")
-    if not isinstance(jobs, list):
-        raise ValueError("OpenClaw CLI JSON has no jobs list")
-    return jobs
+def load_live_jobs(runner=None) -> list[dict]:
+    """The live schedule, raising rather than reporting an empty one.
+
+    Strictness is the whole point on this path: an empty read would be diffed
+    against the contract as "every job differs", so a failed command would turn
+    into a full rewrite of the table. The adapter's `read_jobs` is deliberately
+    fail-soft for watchdogs; this uses its strict sibling.
+    """
+    return read_jobs_strict(runner=runner)
 
 
 def _value_summary(value: object) -> object:
@@ -224,56 +231,17 @@ def desired_changes(contract: dict, live_jobs: list[dict],
 
 
 def build_edit_command(change: dict) -> list[str]:
-    patch = change["patch"]
-    command = ["openclaw", "cron", "edit", change["id"]]
-    if "schedule" in patch:
-        schedule = patch["schedule"]
-        if not schedule.get("tz"):
-            raise ValueError(
-                f"{change['name']}: clearing a cron timezone is not supported safely"
-            )
-        command.extend([
-            "--cron", schedule["expr"], "--tz", schedule["tz"], "--exact",
-        ])
-    if "enabled" in patch:
-        command.append("--enable" if patch["enabled"] else "--disable")
-    if "model" in patch:
-        command.extend(["--model", patch["model"]])
-    if "fallbacks" in patch:
-        if patch["fallbacks"]:
-            command.extend(["--fallbacks", ",".join(patch["fallbacks"])])
-        else:
-            command.append("--clear-fallbacks")
-    if "thinking" in patch:
-        command.extend(["--thinking", patch["thinking"]])
-    if "toolsAllow" in patch:
-        tools = patch["toolsAllow"]
-        command.extend(["--tools", ",".join(tools)]) if tools else command.append(
-            "--clear-tools"
-        )
-    if "timeoutSeconds" in patch:
-        command.extend(["--timeout-seconds", str(patch["timeoutSeconds"])])
-    if "message" in patch:
-        command.extend(["--message", patch["message"]])
-    if "deliveryMode" in patch:
-        mode = patch["deliveryMode"]
-        if mode == "none":
-            command.append("--no-deliver")
-        elif mode == "announce":
-            command.append("--announce")
-        else:
-            raise ValueError(
-                f"{change['name']}: unsupported delivery mode {mode!r}"
-            )
-    if patch.get("clearTrigger"):
-        command.append("--clear-trigger")
-    if "trigger" in patch:
-        trigger = patch["trigger"]
-        command.extend(["--trigger-script", trigger["scriptPath"]])
-        if trigger["once"]:
-            command.append("--trigger-once")
-    command.extend(["--timeout", "120000"])
-    return command
+    """This change as a runtime command line.
+
+    The mapping itself lives in `clawock.providers.openclaw`; what stays here is
+    the job name, because the caller's errors are read by a human looking at a
+    contract, not at a job id.
+    """
+    try:
+        return build_cron_edit_argv(
+            change["id"], change["patch"], run_timeout_ms=120000)
+    except ValueError as exc:
+        raise ValueError(f"{change['name']}: {exc}") from exc
 
 
 def apply_changes(changes: list[dict], runner: Runner = subprocess.run,

--- a/scripts/data/sync_us_cron_dst.py
+++ b/scripts/data/sync_us_cron_dst.py
@@ -29,6 +29,13 @@ from cron_contract import (  # noqa: E402
     us_season,
 )
 from _watchdog_common import load_jobs  # noqa: E402
+# The cron command line belongs to the adapter (#330 step 2): this script owns
+# WHEN the US schedule shifts, not how an edit reaches OpenClaw.
+#
+# The CHECKOUT root, not WS: `workspace_root` is overridable, so WS can be a
+# data directory with no `clawock` package in it.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from clawock.providers.openclaw import build_cron_edit_argv  # noqa: E402
 
 def parse_at(value: str | None) -> datetime:
     if not value:
@@ -84,11 +91,11 @@ def apply_openclaw(changes: list[dict]) -> list[str]:
         if not change.get("id"):
             errors.append(f"{change['name']}: missing runtime id")
             continue
-        cmd = [
-            "openclaw", "cron", "edit", change["id"],
-            "--cron", change["to"]["expr"],
-            "--tz", change["to"]["tz"], "--exact",
-        ]
+        try:
+            cmd = build_cron_edit_argv(change["id"], {"schedule": change["to"]})
+        except ValueError as exc:
+            errors.append(f"{change['name']}: {exc}")
+            continue
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=45)
         if result.returncode != 0:
             errors.append(f"{change['name']}: {(result.stdout + result.stderr)[-300:]}")

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -57,8 +57,10 @@ RUNTIME = "openclaw"
 # chain moved into the adapter (#273); 13 → 10 when the two money CLIs and the
 # legacy backfill stopped naming the runtime's workspace absolutely (#290);
 # 10 → 9 when the watchdogs' session directory came from the adapter's
-# OPENCLAW_HOME instead of a hard-coded path (#330 step 1).
-BASELINE = 9
+# OPENCLAW_HOME instead of a hard-coded path (#330 step 1); 9 → 6 when the two
+# schedule writers took their command line from the adapter's scheduling
+# capability instead of spelling out argv (#330 step 2).
+BASELINE = 6
 
 # The honest floor is 1, not 0 — say it rather than let a future reader assume
 # the remaining count is all debt.
@@ -70,14 +72,11 @@ BASELINE = 9
 # making — a garbage collector for someone else's files is not part of a
 # portable harness's interface.
 #
-# So the sequence that remains is 9 → 1:
-#   sync_cron_payloads.py (2) + sync_us_cron_dst.py (1) — the only paths that
-#     WRITE OpenClaw's schedule. They need a scheduling capability on the
-#     provider interface, which does not exist yet; that interface is the real
-#     work and the call sites are trivial afterwards.
+# So the sequence that remains is 6 → 1:
 #   system_check.py (5) — last, deliberately. It is what proves the earlier
 #     steps did not break anything, so migrating it first would remove the check
-#     while the checked-for change is in flight.
+#     while the checked-for change is in flight. With steps 1 and 2 done it is
+#     now the only block left.
 DELIBERATE_EXCLUSIONS = {"scripts/data/gc_sessions.py": 1}
 HONEST_FLOOR = sum(DELIBERATE_EXCLUSIONS.values())
 
@@ -330,16 +329,39 @@ def test_a_multi_source_label_is_not_counted_as_coupling():
         "would reward removing multi-source support")
 
 
-def test_the_cron_writes_are_counted():
-    """The substring classifier missed these while reporting a falling number.
-    They are the only paths in the repository that write OpenClaw's schedule; a
-    metric that cannot see them cannot claim convergence."""
+def test_the_cron_writes_moved_rather_than_vanished():
+    """The schedule writers are the reason this metric exists.
+
+    The substring classifier missed them while reporting a falling number, so
+    the original form of this test pinned them as counted in
+    `sync_cron_payloads` and `sync_us_cron_dst`. They have since moved behind
+    the adapter (#330 step 2), which is the outcome the ratchet is for — but a
+    count can fall for two very different reasons, and "the capability moved"
+    must not be confused with "the sites were deleted and the writes now happen
+    somewhere unaccounted for".
+
+    So: the writers no longer spell out a command line, AND the adapter really
+    does supply one. The classifier's ability to *see* a `cron edit` vector is
+    pinned separately, on synthetic source, by
+    `test_prose_is_not_coupling_and_a_command_is`.
+    """
     sites = coupling_sites()
 
-    assert len(sites.get("scripts/data/sync_cron_payloads.py", [])) >= 2, (
-        "the `cron list` read and the `cron edit` write must both be counted")
-    assert sites.get("scripts/data/sync_us_cron_dst.py"), (
-        "the DST cron rewrite spawns `openclaw cron edit` and must be counted")
+    for writer in ("scripts/data/sync_cron_payloads.py",
+                   "scripts/data/sync_us_cron_dst.py"):
+        assert writer not in sites, (
+            f"{writer} names the runtime again — the schedule writers are "
+            "supposed to reach it through clawock.providers")
+
+    import importlib
+    adapter = importlib.import_module("clawock.providers.openclaw")
+    argv = adapter.build_cron_edit_argv(
+        "job-id", {"schedule": {"expr": "0 8 * * 1-5", "tz": "Asia/Shanghai"}})
+    assert argv[0] == adapter.OPENCLAW_BIN
+    assert argv[1:4] == ["cron", "edit", "job-id"]
+    assert "--exact" in argv, (
+        "a schedule edit must pin the slot exactly; a scheduler stagger is how "
+        "a market open drifts off its bar")
 
 
 def test_the_adapter_is_exempt_because_that_is_what_an_adapter_is_for():

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
+sys.path.insert(0, str(ROOT))
 
 import cron_contract
 import sync_cron_payloads
+from clawock.providers.openclaw import OPENCLAW_BIN
 
 
 JULY = datetime(2026, 7, 30, 0, tzinfo=timezone.utc)
@@ -78,7 +80,8 @@ def test_drift_plan_and_command_patch_only_declared_fields():
         "thinking", "fallbacks", "toolsAllow", "message"
     }
     command = sync_cron_payloads.build_edit_command(change)
-    assert command[:4] == ["openclaw", "cron", "edit", job["id"]]
+    assert command[0] == OPENCLAW_BIN
+    assert command[1:4] == ["cron", "edit", job["id"]]
     assert command[command.index("--thinking") + 1] == "adaptive"
     profile = data["payload_profiles"]["intraday"]
     assert command[command.index("--fallbacks") + 1] == ",".join(
@@ -186,7 +189,11 @@ def test_apply_stops_at_first_failure_and_uses_argv():
     errors = sync_cron_payloads.apply_changes(changes, runner=runner)
     assert len(calls) == 1
     assert isinstance(calls[0][0], list)
-    assert calls[0][0][:4] == ["openclaw", "cron", "edit", "one"]
+    # argv[0] is the absolute binary, not a bare name resolved off PATH (#330
+    # step 2). The DST sync runs from crontab, where the bare form only works
+    # because that entry happens to use a login shell.
+    assert calls[0][0][0] == OPENCLAW_BIN
+    assert calls[0][0][1:4] == ["cron", "edit", "one"]
     assert "first" in errors[0]
     assert "boom" in errors[0]
 


### PR DESCRIPTION
**Part of #330（第 2 步 / 共 3 步）** —— `system_check` 的 5 个站点仍在，故意留到最后，所以不带 close 关键字。

```
9 → 6，两个 sync 脚本整个从耦合清单上消失
剩余：system_check.py 5 + gc_sessions.py 1（后者是已记录的故意排除）
```

## 问题

`sync_cron_payloads` 和 `sync_us_cron_dst` 是**全仓唯二会写 OpenClaw 排程**的路径，而两者都把命令行当 argv 字面量拼在自己文件里。它们本来就已经从一份 reviewed contract 决定「改什么」—— 只有最后一步是运行时特有的，却因此整个文件都得知道运行时。

## 新增的调度能力

| | |
|---|---|
| `read_jobs_strict()` | **失败即抛**的读。`read_jobs` 故意 fail-soft：对 watchdog 来说「读不到运行时」≠「没有任务」。但对写方向恰好相反 —— 空读会被 diff 成「每个 job 都和 contract 不符」，于是一条失败的命令会变成**整张表重写**。 |
| `build_cron_edit_argv()` | 完整 patch 词表 → `cron edit` 命令行。第二个运行时重新实现的是这个映射，不是调用方。 |

调用方保留自己的策略（顺序 apply、首个失败即停、apply 前重查 running 状态）—— 那些不是运行时知识。

## 一个行为变更（值得单独说）

`argv[0]` 从裸 `openclaw` 变成绝对路径 `OPENCLAW_BIN`。

DST 同步是从 **crontab** 跑的，裸名字能解析只是因为那条 entry 恰好用了 `/bin/bash -lc`（登录 shell 加载了 PATH）。已验证该绝对路径存在、可执行、且正是当前 PATH 解析到的同一个文件。两条断言相应更新。

## 改了一条既有测试，附理由

`test_the_cron_writes_are_counted` 原本把「写」钉死在那两个文件里。但**计数下降有两种完全不同的原因**：能力搬走了，或者站点被删掉而写操作跑到了没人记账的地方。所以改成断言「两个写方**不再**命名运行时」**且**「adapter 确实提供了命令行（含 `--exact`）」。

分类器**能不能看见** `cron edit` 这种 argv 的能力，隔壁 `test_prose_is_not_coupling_and_a_command_is` 已经用合成源码钉着，没有丢。

## 一个被测试抓到的真 bug

第一版我为了 import clawock 往 `sys.path` 塞了 `WS`，`test_clawock_importers_do_not_inherit_their_sys_path` 直接红了 —— **`workspace_root` 是可覆盖的**，`WS` 可能是别人的数据目录，里面根本没有 `clawock` 包。改成用 checkout root（`parents[2]`）。这正是 #269 关心的那件事，被现成的闸挡住了。

## 验证

| | |
|---|---|
| `sync_cron_payloads.py`（干跑 live） | `ok · changes=0 errors=0` |
| `sync_us_cron_dst.py`（干跑 live） | `ok · daylight · openclaw=0 watchdog=0` |
| 全量套件 | **1641 passed, 4 xfailed** |

两个干跑都是 0 变更 —— 说明新 argv 路径算出来的计划和旧的一致。

变异验证：

| 变异 | 结果 |
|---|---|
| DST 脚本改回自己拼 argv | ✅ 计数闸 + 搬迁断言 双红 |
| adapter 的 schedule 编辑丢掉 `--exact` | ✅ 搬迁断言 + stagger 测试 双红 |

## 下一步

`system_check.py`(5) —— 最后做。它是证明前两步没弄坏东西的那个东西；本 PR 合并后我会拿它跑一次 live 验证，再动它。
