### PR TITLE
coupling: move system_check behind the providers (6 → 1, the floor)

### DIFF
--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -343,3 +343,30 @@ def build_cron_edit_argv(job_id: str, patch: dict, *,
     if run_timeout_ms is not None:
         command.extend(["--timeout", str(run_timeout_ms)])
     return command
+
+
+# ── Runtime layout and availability ──────────────────────────────────────────
+# Where this runtime keeps the things an operator check needs to look at, and
+# whether it is installed at all (#330 step 3). These were literals in
+# `system_check.py`, which is the last consumer to migrate — deliberately, since
+# it is what proves the earlier steps did not break anything.
+
+# The runtime's own workspace. Not derived from a caller's workspace_root: the
+# semantic index only ever covers the live runtime checkout, so an interactive
+# worktree must judge that one rather than its own copy.
+LIVE_WORKSPACE = OPENCLAW_HOME / "workspace"
+CONFIG_FILE = OPENCLAW_HOME / "openclaw.json"
+MEMORY_INDEX_DB = OPENCLAW_HOME / "agents" / "main" / "agent" / "openclaw-agent.sqlite"
+# The npm/pnpm install, which is a different root from the state home.
+INSTALL_DIR = Path("/root/.local/share/pnpm/global/5/node_modules/openclaw")
+
+
+def is_installed() -> bool:
+    """Whether this runtime is present on this host.
+
+    Callers ask the capability question — "is there a runtime here?" — rather
+    than testing a binary path themselves. A CI runner and a dev clone both
+    answer False, which is what lets an operator check skip cleanly instead of
+    reporting a fault that only means "not this machine".
+    """
+    return Path(OPENCLAW_BIN).exists()

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -20,14 +20,28 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 WS = Path(__file__).resolve().parent.parent
+# Named rather than inlined: this file sits one level below the root, so the
+# usual `parents[2]` would land above it. The name is what says "checkout root"
+# regardless of depth — and it is the checkout, not WS, because `clawock` ships
+# in the tree this file belongs to.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
 
-# Live-box paths for the memory-index check. These are deliberately absolute and
-# not derived from WS: the semantic index only ever covers the live runtime
-# checkout, so an interactive worktree must judge that one, not its own copy.
-# All of them are absent in CI, where the check skips.
-LIVE_WORKSPACE = Path('/root/.openclaw/workspace')
-MEMORY_INDEX_DB = Path('/root/.openclaw/agents/main/agent/openclaw-agent.sqlite')
-OPENCLAW_INSTALL = Path('/root/.local/share/pnpm/global/5/node_modules/openclaw')
+# Live-box paths for the memory-index check. Still deliberately absolute and not
+# derived from WS — the semantic index only ever covers the live runtime
+# checkout, so an interactive worktree must judge that one, not its own copy —
+# but they are the RUNTIME's layout, so the adapter owns them (#330 step 3).
+# This file was the last block of sites that knew which runtime it was on, and
+# it migrates last on purpose: it is what proves the earlier steps did not break
+# anything. All of these are absent in CI, where the checks skip.
+from clawock.providers.openclaw import (  # noqa: E402
+    INSTALL_DIR as OPENCLAW_INSTALL,
+    LIVE_WORKSPACE,
+    MEMORY_INDEX_DB,
+    CONFIG_FILE as OPENCLAW_CONFIG,
+    is_installed as openclaw_is_installed,
+)
+
 MEMORY_INDEX_LOG = LIVE_WORKSPACE / 'logs' / 'memory_index.log'
 # Nightly reindex is 05:10 HKT; 30h lets one run slip into the next daily review
 # rather than firing on the normal gap between two runs.
@@ -358,7 +372,7 @@ def check_no_leaked_secrets(r):
 def check_openclaw_doctor(r):
     """Cheap config-validity check. Full `openclaw doctor` is too slow for hooks,
     so we just re-validate the JSON config can be parsed + has expected shape."""
-    config = Path('/root/.openclaw/openclaw.json')
+    config = OPENCLAW_CONFIG
     if not config.exists():
         r.add('openclaw config', WARNING, 'openclaw.json not found (skipped)')
         return
@@ -435,13 +449,13 @@ def check_cron_paths_exist(r):
     sys.path.insert(0, str(WS / 'scripts' / 'harness'))
     try:
         import _watchdog_common as wc  # type: ignore
-        from _watchdog_common import OPENCLAW_BIN, load_jobs  # type: ignore
+        from _watchdog_common import load_jobs  # type: ignore
         jobs = load_jobs()
     except Exception as e:
         r.add('cron paths', WARNING, f'cron jobs unreadable: {e}')
         return
     if not jobs:
-        if not os.path.exists(OPENCLAW_BIN):
+        if not openclaw_is_installed():
             # CI runner / dev clone without the openclaw install — nothing to check.
             r.add('cron paths', OK, 'skipped (no openclaw CLI on this host)')
         else:

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -59,8 +59,13 @@ RUNTIME = "openclaw"
 # 10 → 9 when the watchdogs' session directory came from the adapter's
 # OPENCLAW_HOME instead of a hard-coded path (#330 step 1); 9 → 6 when the two
 # schedule writers took their command line from the adapter's scheduling
-# capability instead of spelling out argv (#330 step 2).
-BASELINE = 6
+# capability instead of spelling out argv (#330 step 2); 6 → 1 when system_check
+# took the runtime's layout and an is_installed() capability from the adapter
+# (#330 step 3, last on purpose — it is what proves the earlier steps held).
+#
+# 1 is the floor, not a waypoint: see DELIBERATE_EXCLUSIONS below. The ratchet
+# has arrived, and what remains is a decision rather than debt.
+BASELINE = 1
 
 # The honest floor is 1, not 0 — say it rather than let a future reader assume
 # the remaining count is all debt.
@@ -72,11 +77,9 @@ BASELINE = 6
 # making — a garbage collector for someone else's files is not part of a
 # portable harness's interface.
 #
-# So the sequence that remains is 6 → 1:
-#   system_check.py (5) — last, deliberately. It is what proves the earlier
-#     steps did not break anything, so migrating it first would remove the check
-#     while the checked-for change is in flight. With steps 1 and 2 done it is
-#     now the only block left.
+# Nothing remains to migrate. Every other consumer now reaches the runtime
+# through clawock/providers/, which is what makes "it happens to run on OpenClaw"
+# a description of deployment rather than of the code.
 DELIBERATE_EXCLUSIONS = {"scripts/data/gc_sessions.py": 1}
 HONEST_FLOOR = sum(DELIBERATE_EXCLUSIONS.values())
 


### PR DESCRIPTION
Closes #330。第 3 步（最后一步）。

```
6 → 1     ← 诚实底线，不是中间站
```

| 文件 | 之前 | 现在 |
|---|---|---|
| `scripts/system_check.py` | 5 | **0** |
| `scripts/data/gc_sessions.py` | 1 | 1（**故意保留**，已记录并断言） |

## 为什么最后做它

issue 的排序写得很清楚：`system_check` 是**证明前两步没弄坏东西的那个东西**，先搬它等于在被检查的变更进行中把检查拆掉。

前两步合并后我都拿它跑过 live 验证，这次它自己迁移完，再跑一次：

```
clawock system check · 16 ok · 1 warn · 0 critical
  ✓ openclaw config   valid; primary=anthropic/claude-sonnet-5
  ✓ cron paths        11 jobs · 7 referenced scripts present
```

`openclaw config` 和 `cron paths` 正是读了本次搬走的那两样东西的检查。那个 warn 是记忆索引日常漂移，与改动无关。

## 5 个站点怎么处理的

4 个是**运行时的目录布局**（workspace / agent 索引 DB / 安装目录 / 配置文件）—— 那是 adapter 该拥有的，加了 `LIVE_WORKSPACE` `MEMORY_INDEX_DB` `INSTALL_DIR` `CONFIG_FILE`。四个都在 live 上验证过真实存在。

第 5 个是 `os.path.exists(OPENCLAW_BIN)`，但它问的其实是**能力问题**——「这台机器上有没有运行时」。所以变成 `is_installed()`。CI runner 和 dev clone 都会得到 False，这正是让检查**干净跳过**而不是报一个「只代表不是这台机器」的故障所需要的。

## 又被同一个闸抓了一次

`test_clawock_importers_do_not_inherit_their_sys_path` 再次红 —— 这次不是我用错了 `WS`，而是 `system_check.py` 位于 `scripts/` 下**一层**，仓库根是 `parents[1]`，而该测试只认 `parents[2]` 或 `_REPO_ROOT`。

我没有去放宽那个形式列表（那会同时削弱对 `scripts/data/` 下文件的检查——那里 `parents[1]` 是 `scripts/` 不是根），而是用了它已接受的 `_REPO_ROOT` 具名写法。**名字才是「仓库根」的表达，与深度无关。**

## 测试

没加新测试。基线 6 → 1，注释里的序列改成「无剩余待迁移项」。

变异验证：把 config 路径改回硬编码 → 计数闸红。

全量套件 **1641 passed, 4 xfailed**。

## 解耦到此为止的含义

剩下那 1 个是 `gc_sessions.py`：它的 `OPENCLAW_HOME` 清的是运行时**自己**的会话文件 —— 那是在运行 runtime，不是我们的 harness 依赖它。要消掉就得把整个脚本搬进 `clawock/providers/`，那是另一个论证，而且给别人的文件做垃圾回收本就不该是可移植 harness 的接口。

所以「它碰巧跑在 OpenClaw 上」现在描述的是**部署**，不再是代码。
