### PR TITLE
portability: resolve code from the checkout, data from the workspace

### DIFF
--- a/scripts/data/compute_quant_signals.py
+++ b/scripts/data/compute_quant_signals.py
@@ -34,6 +34,11 @@ import requests
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 PORTFOLIO = WS / 'portfolio.json'
 OUT = WS / 'assets' / 'data' / 'quant_signals.json'
@@ -48,7 +53,7 @@ SIGMA_TARGET = 0.25   # vol-target sizing 的组合级目标波动（25% 年化�
 MAX_STALE_DAYS = 7
 RETIRED_RETENTION_DAYS = 7
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from instrument_registry import require as require_instrument  # noqa: E402
 import trading_calendar  # noqa: E402
 

--- a/scripts/data/compute_regime.py
+++ b/scripts/data/compute_regime.py
@@ -74,6 +74,11 @@ import requests
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parent.parent.parent)
 OUT_FILE = WS / 'assets' / 'data' / 'lev_regime.json'
 PORTFOLIO = WS / 'portfolio.json'
@@ -86,7 +91,7 @@ MA_WINDOW = 200      # slower MA = fewer falling-knife re-entries (verified vs 1
 VOL_WINDOW = 20
 VOL_CAP = 0.50       # HSTECH 20d annualised realised-vol ceiling for "vol-ok"
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from instrument_registry import INSTRUMENTS  # noqa: E402
 
 # US 2x single-stock ETF → (underlying ticker, Tencent fqkline symbol). The US dial is

--- a/scripts/data/compute_t0_setups.py
+++ b/scripts/data/compute_t0_setups.py
@@ -27,6 +27,11 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 PORTFOLIO = WS / 'portfolio.json'
 QUANT = WS / 'assets' / 'data' / 'quant_signals.json'
@@ -34,7 +39,7 @@ OUT = WS / 'assets' / 'data' / 't0_setups.json'
 HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 HIST_MAX_LINES = 4000   # 盘中每 30min 一行，封顶约 1 年留痕
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from instrument_registry import INSTRUMENTS  # noqa: E402
 
 try:

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -32,6 +32,11 @@ from zoneinfo import ZoneInfo
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 # The checkout root, so `clawock` is importable regardless of where the WORKSPACE
 # points. WS can be redirected with CLAWOCK_WORKSPACE and is a data directory;
@@ -40,7 +45,7 @@ WS = workspace_root(Path(__file__).resolve().parents[2])
 # resolves only because some other module happened to widen sys.path first is a
 # side effect, not a dependency (#265).
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import cron_token_audit  # noqa: E402
 
 HKT = ZoneInfo('Asia/Hong_Kong')
@@ -216,7 +221,7 @@ def load_runtime_jobs(jobs_file=None):
             jobs.append(resolved)
         return jobs
 
-    sys.path.insert(0, str(WS / 'scripts' / 'harness'))
+    sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'harness'))
     from _watchdog_common import load_jobs
     jobs = load_jobs()
     if not jobs:

--- a/scripts/data/cross_sectional_factor.py
+++ b/scripts/data/cross_sectional_factor.py
@@ -26,6 +26,11 @@ import requests
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 CONFIG = WS / 'config' / 'factor-universe.json'
 OUT = WS / 'assets' / 'data' / 'cross_sectional_factor.json'
@@ -46,7 +51,7 @@ RAW_FACTORS = (
 )
 QUALITY_METHOD_VERSION = 2
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from safe_io import safe_write_json, safe_write_text  # noqa: E402
 
 

--- a/scripts/data/earnings_review.py
+++ b/scripts/data/earnings_review.py
@@ -29,12 +29,17 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 SCHEMA_FILE = WS / "config" / "earnings_review.schema.json"
 ARTIFACT_ROOT = WS / "memory" / "earnings"
 SCHEMA_VERSION = 1
 
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 import research_provenance  # noqa: E402
 
 MARKETS = {"US", "HK"}

--- a/scripts/data/entry_gate.py
+++ b/scripts/data/entry_gate.py
@@ -27,13 +27,18 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 SCHEMA_FILE = WS / "config" / "entry_gate.schema.json"
 VETO_FILE = WS / "config" / "entry-gate-vetoes.json"
 ARTIFACT_ROOT = WS / "memory" / "entry-gates"
 SCHEMA_VERSION = 1
 
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 import instrument_registry  # noqa: E402
 
 MARKETS = {"US", "HK"}

--- a/scripts/data/fetch_em_news.py
+++ b/scripts/data/fetch_em_news.py
@@ -24,13 +24,18 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 PORTFOLIO = WS / 'portfolio.json'
 OUT = WS / 'assets' / 'data' / 'em_news.json'
 UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
 TIMEOUT = 12
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from _em_http import em_get  # noqa: E402  统一请求节流出口
 try:
     from safe_io import safe_write_json

--- a/scripts/data/intraday_delta_gate.py
+++ b/scripts/data/intraday_delta_gate.py
@@ -17,11 +17,16 @@ from zoneinfo import ZoneInfo
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 HKT = ZoneInfo("Asia/Hong_Kong")
 PORTFOLIO = WS / "portfolio.json"
 
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 import cron_heartbeat  # noqa: E402
 import fetch_peers  # noqa: E402
 import trading_calendar  # noqa: E402

--- a/scripts/data/mover_news.py
+++ b/scripts/data/mover_news.py
@@ -42,8 +42,13 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 
 HKT = timezone(timedelta(hours=8))
 MAX_MOVERS = 4

--- a/scripts/data/news_evidence_graph.py
+++ b/scripts/data/news_evidence_graph.py
@@ -21,6 +21,11 @@ from urllib.parse import urlparse
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 POLICY = WS / 'config' / 'news-evidence-policy.json'
 PORTFOLIO = WS / 'portfolio.json'
@@ -55,7 +60,7 @@ NEGATIVE_WORDS = {
     '亏损', '处罚', '违约', '调出', '剔除',
 }
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from safe_io import safe_write_json, safe_write_text  # noqa: E402
 
 

--- a/scripts/data/peer_residual_engine.py
+++ b/scripts/data/peer_residual_engine.py
@@ -21,6 +21,11 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 RULE_CONFIG = WS / 'config' / 'peer-residual-rules.json'
 FACTOR_CONFIG = WS / 'config' / 'factor-universe.json'
@@ -29,7 +34,7 @@ OUT = WS / 'assets' / 'data' / 'peer_residual.json'
 HISTORY = WS / 'assets' / 'data' / 'peer_residual_history.jsonl'
 HORIZONS = (1, 5, 20)
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from cross_sectional_factor import (  # noqa: E402
     _last_index,
     _liquidity,

--- a/scripts/data/preflight_integrity.py
+++ b/scripts/data/preflight_integrity.py
@@ -59,11 +59,16 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 PORTFOLIO = WS / 'portfolio.json'
 OUT = WS / 'assets' / 'data' / 'integrity_report.json'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from instrument_registry import INSTRUMENTS  # noqa: E402
 
 try:

--- a/scripts/data/quant_signal_review.py
+++ b/scripts/data/quant_signal_review.py
@@ -24,11 +24,16 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 HIST = WS / 'assets' / 'data' / 'quant_signals_history.jsonl'
 OUT = WS / 'assets' / 'data' / 'quant_signal_review.json'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 try:
     from safe_io import safe_write_json  # type: ignore
 except Exception:

--- a/scripts/data/recompute_cash.py
+++ b/scripts/data/recompute_cash.py
@@ -16,8 +16,13 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 
 from preflight_integrity import derive_cash  # noqa: E402
 from safe_io import mutate_json  # noqa: E402

--- a/scripts/data/research_surface.py
+++ b/scripts/data/research_surface.py
@@ -27,6 +27,11 @@ from zoneinfo import ZoneInfo
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 THESIS_DIR = WS / "memory" / "theses"
 EARNINGS_DIR = WS / "memory" / "earnings"
@@ -34,7 +39,7 @@ ENTRY_GATE_DIR = WS / "memory" / "entry-gates"
 PORTFOLIO = WS / "portfolio.json"
 CATALYSTS = WS / "assets" / "data" / "catalysts.json"
 
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 import earnings_review  # noqa: E402
 import entry_gate  # noqa: E402
 import thesis_registry  # noqa: E402

--- a/scripts/data/sync_cron_payloads.py
+++ b/scripts/data/sync_cron_payloads.py
@@ -20,8 +20,13 @@ from typing import Callable
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-sys.path.insert(0, str(WS / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 # The runtime's cron command line and the strict read both live in the adapter
 # (#330 step 2). This file decides WHAT to change; how that reaches OpenClaw is
 # not its business, and spelling the argv out here was what made it one of the

--- a/scripts/data/sync_us_cron_dst.py
+++ b/scripts/data/sync_us_cron_dst.py
@@ -16,9 +16,14 @@ from pathlib import Path
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-sys.path.insert(0, str(WS / "scripts" / "data"))
-sys.path.insert(0, str(WS / "scripts" / "harness"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
+sys.path.insert(0, str(_CHECKOUT / "scripts" / "harness"))
 
 from cron_contract import (  # noqa: E402
     effective_schedule,

--- a/scripts/data/t0_setup_review.py
+++ b/scripts/data/t0_setup_review.py
@@ -41,6 +41,11 @@ def wilson_ci(hits, n, z=1.96):
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 OUT = WS / 'assets' / 'data' / 't0_setup_review.json'
@@ -48,7 +53,7 @@ OUT = WS / 'assets' / 'data' / 't0_setup_review.json'
 MIN_N = 20   # 牌面结论可被引用的最小样本量
 HORIZON = 1  # T+1：按「下一个有该标的留痕的交易日」结算
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 try:
     from safe_io import safe_write_json
 except Exception:

--- a/scripts/data/workflow_outcomes.py
+++ b/scripts/data/workflow_outcomes.py
@@ -31,6 +31,11 @@ from zoneinfo import ZoneInfo
 
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 LOCAL_PATH = WS / "memory" / ".tmp" / "workflow-outcomes.json"
 PUBLIC_PATH = WS / "assets" / "data" / "workflow-outcomes.json"
@@ -81,7 +86,7 @@ def slot_for_job(job_name, at=None):
     correct across daylight/standard transitions.
     """
     at = _now(at)
-    sys.path.insert(0, str(WS / "scripts" / "data"))
+    sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
     from cron_contract import effective_schedule, load_contract
 
     expected = next(
@@ -337,7 +342,7 @@ def _match_run(record, entries):
 def reconcile_raw_execution():
     """Overlay raw run status from live SQLite without changing final product."""
     try:
-        sys.path.insert(0, str(WS / "scripts" / "harness"))
+        sys.path.insert(0, str(_CHECKOUT / "scripts" / "harness"))
         import _watchdog_common as common
 
         jobs = common.load_jobs("sqlite")

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -38,8 +38,13 @@ from clawock.validation import (  # noqa: E402,F401
     validate_forbidden_phrases,
 )
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 
 # Single-publisher mutex for all dashboard build outputs (Option 1, 2026-07-04).
 # Shared by the host harness rebuild and publish_dashboard.sh crontab so the two
@@ -395,6 +400,6 @@ def safe_write_text(path, text):
 
     Avoids importing scripts/data/safe_io.py path-juggling in each postflight.
     """
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
     from safe_io import safe_write_text as _swt  # type: ignore
     _swt(str(path), text)

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -26,6 +26,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 LOG = WS / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
@@ -89,10 +94,10 @@ def _record_watchdog_outcome(event):
         if len(parts) != 2:
             return
         market, phase = parts
-        sys.path.insert(0, str(WS / 'scripts' / 'data'))
+        sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
         import workflow_outcomes
         job = workflow_outcomes.job_for(market, phase)
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
     import workflow_outcomes
     action = event.get('action')
     if action == 'ok':

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -36,9 +36,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -46,11 +46,16 @@ from zoneinfo import ZoneInfo
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 TMP_DIR = WS / 'memory' / '.tmp'
 SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 import thesis_registry  # noqa: E402
@@ -1600,7 +1605,7 @@ def main():
     # （遵 feedback_no_individual_cron_alerts 不推送），ERROR 由 build_status 健康卡暴露。
     integrity = {}
     try:
-        sys.path.insert(0, str(WS / 'scripts' / 'data'))
+        sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
         import preflight_integrity as _pi
         integrity = _pi.check()
         if not integrity['ok']:

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -63,10 +63,15 @@ from _watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 TMP = WS / 'memory' / '.tmp'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -46,10 +46,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts' / 'data'))
 from workspace import workspace_root  # noqa: E402
 
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 TMP = WS / 'memory' / '.tmp'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import trading_calendar  # noqa: E402
 import workflow_outcomes  # noqa: E402
 

--- a/scripts/legacy/backfill_t0_history.py
+++ b/scripts/legacy/backfill_t0_history.py
@@ -15,10 +15,15 @@ import sys
 from pathlib import Path
 
 WS = Path(__file__).resolve().parents[2]
+# Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
+# is overridable, so resolving our own modules through WS would read them out of
+# someone else's data directory — or silently pick up whatever happens to be
+# there. Same expression WS is seeded from, kept separate on purpose (#269).
+_CHECKOUT = Path(__file__).resolve().parents[2]
 SNAP_DIR = WS / 'memory' / 'snapshots'
 HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 
-sys.path.insert(0, str(WS / 'scripts' / 'data'))
+sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import compute_t0_setups as t0  # noqa: E402
 
 SNAP_RE = re.compile(r'^\d{4}-\d{2}-\d{2}\.json$')

--- a/tests/test_code_imports_come_from_the_checkout.py
+++ b/tests/test_code_imports_come_from_the_checkout.py
@@ -1,0 +1,83 @@
+"""Code resolves from the checkout; only data resolves from the workspace.
+
+`workspace_root()` is overridable with CLAWOCK_WORKSPACE so the engine can run
+against someone else's book (#246). But a foreign workspace holds market data —
+snapshots, ledgers, plans — not `scripts/data/trading_calendar.py`. A module that
+puts `WS / 'scripts' / 'data'` on sys.path therefore resolves OUR code out of
+THEIR directory: it fails if the directory is absent, and silently imports
+whatever is there if it is not (#269).
+
+The two roles are the same directory on every live run, which is exactly why the
+confusion spread to 28 files without anything breaking. It becomes real the first
+time the override is used — the feature the README sells.
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# `system_check` migrates last, for the same reason it goes last in the
+# decoupling sequence: it is what proves the rest still works.
+MIGRATING_LAST = {"scripts/system_check.py"}
+
+_WS_IMPORT = re.compile(r"sys\.path\.insert\(\s*0\s*,\s*str\(\s*WS\s*/")
+
+
+def test_no_module_resolves_code_through_the_workspace():
+    offenders = []
+    for path in sorted(ROOT.glob("scripts/**/*.py")):
+        rel = path.relative_to(ROOT).as_posix()
+        if rel in MIGRATING_LAST:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if _WS_IMPORT.search(line):
+                offenders.append(f"{rel}:{lineno}")
+    assert not offenders, (
+        "these put the WORKSPACE on sys.path to import our own modules, so a "
+        f"CLAWOCK_WORKSPACE override resolves code out of the data dir: {offenders}")
+
+
+def test_the_two_roots_actually_diverge_under_the_override(tmp_path):
+    """The distinction has to be observable, or the rule above is bookkeeping.
+
+    Deliberately NOT an "import fails without the fix" test. Most of these sites
+    are shadowed: `scripts/data/*` gets its own directory on sys.path just by
+    being executed, and `_harness_common` inserts the correct checkout path at
+    module top before the line that was wrong. So an end-to-end import passes
+    either way, and a test written that way would look like proof while
+    discriminating nothing — the line-level guard above is the one that bites,
+    and it is mutation-verified.
+
+    What is worth pinning end-to-end is that the override is real: workspace_root
+    follows it, the checkout does not, and a script still runs against a book
+    that contains no code at all.
+    """
+    foreign = tmp_path / "someone-elses-book"
+    (foreign / "memory").mkdir(parents=True)
+    (foreign / "assets" / "data").mkdir(parents=True)
+    (foreign / "portfolio.json").write_text('{"portfolios": {}}', encoding="utf-8")
+    assert not (foreign / "scripts").exists(), "the point is that code is absent"
+
+    env = dict(os.environ, CLAWOCK_WORKSPACE=str(foreign))
+    probe = subprocess.run(
+        [sys.executable, "-c",
+         f"import sys; sys.path.insert(0, {str(ROOT / 'scripts' / 'data')!r})\n"
+         "from pathlib import Path\n"
+         "from workspace import workspace_root\n"
+         "print(workspace_root(Path.cwd()))\n"],
+        capture_output=True, text=True, timeout=60, env=env, cwd=str(ROOT),
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.strip() == str(foreign), (
+        "the override is not in effect, so nothing below proves anything")
+
+    ran = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "data" / "mover_news.py"), "--help"],
+        capture_output=True, text=True, timeout=60, env=env, cwd=str(ROOT),
+    )
+    assert ran.returncode == 0, (
+        "a script could not even start against a code-less workspace:\n"
+        f"{ran.stdout}\n{ran.stderr}")


### PR DESCRIPTION
Closes #269。

## 改动

27 个模块把 **workspace** 放上 `sys.path` 去 import **我们自己的代码**。`workspace_root` 是可被 `CLAWOCK_WORKSPACE` 覆盖的（#246 卖的就是这个能力），而别人的 book 里装的是快照、账本、plan —— **不是 `scripts/data/trading_calendar.py`**。覆盖一开，这些 import 要么失败，要么更糟：悄悄捡起那边碰巧存在的 `scripts/data`。

40 个站点 → 全部改从 `_CHECKOUT` 派生（**和 WS 本来就同一个表达式**，只是分了个名字，让两种角色没法再漂回一起）。

`system_check.py` 的 7 个站点**留到下一刀** —— 和它在解耦序列里最后走是同一个理由：它是证明其余部分没坏的那个东西。

两个文件机械替换没匹配上，手改的（脚本没有静默半改，是直接跳过再报出来）：
- `compute_regime.py` 用的是 `.parent.parent.parent` 而不是 `parents[2]`
- `backfill_t0_history.py` 的 `WS` 本来就是 checkout —— 今天无害，但名字仍须区分，否则将来有人把它换成 `workspace_root` 就会**静默**把 import 指到数据目录

## 测试写法：我没有写「不修就会红」的端到端测试，理由如下

写了会好看，但**它什么都证明不了**：

- `scripts/data/*` 被执行时，Python 自动把它自己的目录放上 `sys.path`
- `_harness_common.py:19` 在模块顶部**已经**插了正确的 checkout 路径，早于第 42 行那个错的

我实测过：把 `_harness_common` 的站点变异回 `WS`，在 override 下 import **照样成功**。所以那种端到端测试会「两边都绿」，是装饰品。

真正会咬的是**行级守卫**，而它按 issue 点名的方式做了变异验证：

| 变异 | 结果 |
|---|---|
| 把 `mover_news.py` 一个站点指回 `WS` | ✅ 红（`scripts/data/mover_news.py:51`） |

端到端那条改成钉「**覆盖是真的**」：override 生效时 `workspace_root` 跟着走、checkout 不跟着走，且脚本能在一个**完全没有代码**的 book 上启动。这条能挡住「override 直接把引擎跑挂」这一类真实故障。

## 验证

- 全量套件 **1643 passed, 4 xfailed**
- 27 个改动文件逐个 import 冒烟：全通过
- 真实 override 冒烟：`mover_news.py --help` 在一个只有 `memory/` + `assets/data/` + `portfolio.json` 的合成 book 上 exit 0

## 顺带发现（已单独开 issue，不在本 PR 范围）

同样的混淆在**配置**层还有一份：`instrument_registry.py` 读 `WS / "config" / "instruments.json"`，所以 `brief_preflight.py` 和 `compute_t0_setups.py` 在 override 下会报 `cannot read instrument registry`。

但「仪器目录属于引擎自带还是每个 book 各有一份」是个**判断题**，而 issue 的 non-goals 明确写着不改「任何脚本读什么」，所以我留 issue 不自作主张。
