### PR TITLE
portability: system_check resolves code from the checkout too

### DIFF
--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -129,7 +129,7 @@ def check_portfolio_schema(r):
 
 def check_instrument_registry(r):
     """Canonical metadata must cover every active holding."""
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
         import instrument_registry
         portfolio = json.loads((WS / 'portfolio.json').read_text())
@@ -156,7 +156,7 @@ def check_plan_json_schema(r):
         r.add('plan.json schema', OK, '0 plans yet')
         return
     bad = []
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     import decision_v2
     for p in plans:
         try:
@@ -184,7 +184,7 @@ def check_dashboard_buildable(r):
     try:
         env = dict(os.environ, BUILD_DASHBOARD_OUT=str(out))
         rr = subprocess.run(
-            ['python3', str(WS / 'scripts' / 'data' / 'build_dashboard.py')],
+            ['python3', str(_REPO_ROOT / 'scripts' / 'data' / 'build_dashboard.py')],
             capture_output=True, text=True, timeout=30, cwd=str(WS), env=env,
         )
         if rr.returncode != 0:
@@ -418,7 +418,7 @@ def check_decision_ledger(r):
         r.add('decisions.jsonl', OK, 'no ledger yet (first runs)')
         return
     try:
-        sys.path.insert(0, str(WS / 'scripts' / 'data'))
+        sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
         import decision_v2
         rows = decision_v2.load_decisions(p)
     except Exception as e:
@@ -446,7 +446,7 @@ def check_cron_paths_exist(r):
     only as an explicitly rejected last-resort fossil.
     """
     import re
-    sys.path.insert(0, str(WS / 'scripts' / 'harness'))
+    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'harness'))
     try:
         import _watchdog_common as wc  # type: ignore
         from _watchdog_common import load_jobs  # type: ignore
@@ -471,7 +471,7 @@ def check_cron_paths_exist(r):
         return
 
     try:
-        sys.path.insert(0, str(WS / 'scripts' / 'data'))
+        sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
         from cron_contract import (  # type: ignore
             load_contract, next_us_dst_transition, us_season,
             validate_live_jobs, validate_watchdogs,
@@ -515,7 +515,7 @@ def check_cron_paths_exist(r):
 def check_generated_cron_docs(r):
     """Generated schedule documentation must exactly match the contract."""
     result = subprocess.run(
-        ['python3', str(WS / 'scripts' / 'data' / 'generate_cron_docs.py'), '--check'],
+        ['python3', str(_REPO_ROOT / 'scripts' / 'data' / 'generate_cron_docs.py'), '--check'],
         capture_output=True, text=True, timeout=15, cwd=str(WS),
     )
     if result.returncode == 0:
@@ -533,7 +533,7 @@ def check_trading_calendar_horizon(r):
     holiday into a session. The table cannot be auto-generated (HK dates are
     gazetted, US ones move), so the only safe mechanism is a loud deadline.
     """
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
         import trading_calendar
         coverage = trading_calendar.coverage()
@@ -683,7 +683,7 @@ def check_research_artifacts(r):
     schema broke, is an integrity failure. A due earnings review or an ungated
     position is the human's work queue, so it warns and never blocks a publish.
     """
-    sys.path.insert(0, str(WS / 'scripts' / 'data'))
+    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
         import research_surface
         result = research_surface.check()

--- a/tests/test_code_imports_come_from_the_checkout.py
+++ b/tests/test_code_imports_come_from_the_checkout.py
@@ -19,9 +19,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# `system_check` migrates last, for the same reason it goes last in the
-# decoupling sequence: it is what proves the rest still works.
-MIGRATING_LAST = {"scripts/system_check.py"}
+# Nothing is exempt any more. `system_check` migrated last — for the same reason
+# it goes last in the decoupling sequence, that it is what proves the rest still
+# works — and its own run against the live host is what closed this out.
+MIGRATING_LAST: set[str] = set()
 
 _WS_IMPORT = re.compile(r"sys\.path\.insert\(\s*0\s*,\s*str\(\s*WS\s*/")
 


### PR DESCRIPTION
#269 的收尾（最后 7 个站点）。PR #355 里我按 issue 的排序把 `system_check` 留到最后 —— **和它在解耦序列里最后走是同一个理由：它是证明其余部分没坏的那个东西**，先搬它等于在被检查的变更进行中把检查拆掉。

现在前一刀已经在 live 上跑了一整个盘中（14:35 那档 `ok`），可以收尾了。

## 改动

7 个 `sys.path.insert(0, str(WS / 'scripts' / ...))` → `_REPO_ROOT`。

`_REPO_ROOT` 在 #353 里就已经存在于这个文件（它位于 `scripts/` 下**一层**，通用的 `parents[2]` 会落到 checkout 之上），所以这刀只是把站点从 `WS` 上摘下来。

**契约测试的豁免名单现在是空的**：

```python
MIGRATING_LAST: set[str] = set()
```

全仓零个 `scripts/` 下的模块再通过 workspace 解析我们自己的代码 —— `CLAWOCK_WORKSPACE` 覆盖不可能再从别人的 book 里读出代码。

## 验证

拿迁移后的 `system_check` 打真机：

```
clawock system check · 16 ok · 1 warn · 0 critical
  ✓ instrument registry   12 active holdings mapped
  ✓ cron paths            11 jobs · 7 referenced scripts present
```

这两项**正是通过本次搬动的站点做 import 的**（`instrument_registry`、`_watchdog_common`），所以它们绿就是这刀成立的直接证据。那个 warn 是记忆索引日常漂移，与改动无关。

全量套件 **1643 passed, 4 xfailed**。

变异验证：把任一站点指回 `WS` → 契约测试红。

## 仍未解决（已单独开 issue）

`config/` 也走 workspace 解析（`instrument_registry.py:21`），override 下 `brief_preflight` 会抛 `cannot read instrument registry`。那是「引擎自带 vs 每个 book 各一份」的判断题，不是机械替换，见 **#356**。
