### PR TITLE
ci: brief_preflight --help ran the whole preflight and hung the job

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -227,12 +227,20 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           set -e
-          python3 scripts/harness/report_preflight.py --help > /dev/null
-          python3 scripts/harness/report_postflight.py --help > /dev/null
-          python3 scripts/harness/intraday_preflight.py --help > /dev/null
-          python3 scripts/harness/intraday_postflight.py --help > /dev/null
-          python3 scripts/harness/brief_preflight.py --help > /dev/null 2>&1 || true
-          python3 scripts/harness/brief_postflight.py --help > /dev/null 2>&1 || true
+          # `timeout` is the point of this step as much as the exit code. The two
+          # brief scripts used to be wrapped in `|| true`, which reads like the
+          # case was handled: it is not, because `|| true` catches a non-zero
+          # exit and what actually happened was a HANG. brief_preflight took no
+          # arguments at all, so --help ran the whole preflight — live fetches,
+          # EDGAR, Tavily — and ate the job's entire 10-minute budget, failing an
+          # unrelated PR. A probe must cost nothing, and if it ever stops being
+          # free this fails in seconds instead of taking the job down with it.
+          for cli in report_preflight report_postflight \
+                     intraday_preflight intraday_postflight \
+                     brief_preflight brief_postflight; do
+            timeout 30 python3 "scripts/harness/$cli.py" --help > /dev/null \
+              || { echo "::error::$cli.py --help did not exit 0 within 30s"; exit 1; }
+          done
           echo "OK: all argparse parsers loadable"
 
       - name: Schema-validate portfolio.json

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -27,6 +27,7 @@ Output (stdout): step-by-step progress; final summary with issue count.
 Exit: 0 if no issues, 1 if any data leg failed.
 """
 
+import argparse
 import json
 import math
 import os
@@ -1206,6 +1207,26 @@ def load_influencer_feed(issues):
 
 
 def main():
+    # This script took no arguments at all, so `--help` was not "unsupported" —
+    # it was ignored, and the full preflight ran: live price fetches, SEC EDGAR,
+    # Tavily. A probe meant to cost nothing did a minutes-long real run.
+    #
+    # CI wraps this call in `|| true`, which reads like the case was handled. It
+    # is not: `|| true` catches a non-zero exit, and this never exited non-zero —
+    # it hung. On 2026-08-06 that consumed the validate job's entire 10-minute
+    # budget and failed a PR that had nothing to do with it.
+    #
+    # Parsing argv also restores the contract the repo relies on when an agent
+    # probes a script: `--help` exits 0 having done nothing, and an unknown flag
+    # exits 2 rather than being silently ignored — the latter is what turns
+    # "mistyped argument plus valid input" into a successful-looking no-op.
+    argparse.ArgumentParser(
+        description=(
+            "Deterministic data collection for the daily-deep-brief harness. "
+            "Takes no arguments; the date comes from TODAY or HKT now()."
+        ),
+    ).parse_args()
+
     # Date in HKT (the system's canonical TZ), or honor the TODAY env that the
     # brief-fallback workflow exports — so the context filename here always matches
     # the date the fallback script reads. Naive now() = runner UTC, which mismatched


### PR DESCRIPTION
ci: brief_preflight --help ran the whole preflight and hung the job

brief_preflight.py parsed no arguments at all, so --help was not unsupported —
it was ignored, and the script did its real work: live price fetches, SEC EDGAR,
Tavily. A probe meant to cost nothing took minutes.

The argparse-check step wrapped that call in "|| true", which reads like the
case was handled. It is not. "|| true" catches a non-zero exit, and this never
exited non-zero — it hung. On 2026-08-06 it consumed the validate job's entire
10-minute budget and failed PR #358, which had nothing to do with it. The step
had been passing on timing luck.

Two halves, because either alone leaves the trap armed:

* brief_preflight parses argv. --help exits 0 having done nothing; an unknown
  flag exits 2 rather than being silently ignored, which is what turns
  "mistyped argument plus valid input" into a successful-looking no-op. Every
  caller — the cron payload, the SKILL, brief-fallback — invokes it with no
  arguments, so nothing else changes.
* the CI step runs each CLI under `timeout 30` and drops "|| true". If a probe
  ever stops being free again it fails in seconds with a named error instead of
  taking the job down and pointing at whichever PR happened to be open.

Verified: --help now exits 0 in about a second where it previously ran past 20s;
an unknown flag exits 2; the no-argument path still proceeds into real work.
Full suite 1643 passed.

---

## 发现经过

PR #358 的 `validate` 红了，但我本地 1643 全绿。查下来是 **job 超时 10 分钟**（不是测试失败），孤儿 `python3` 进程被杀。定位到卡在 `argparse-check harness CLIs` 这一步。

关键判断：**这不是 #358 引入的**。我在 master 上直接验证：

```
$ timeout 25 python3 scripts/harness/brief_preflight.py --help
exit=124  ⏱ HANG
```

master 上一样卡。#358 只是让 job 总时长越过了 10 分钟这条线 —— 之前一直是**靠运气过的**。

## 为什么 `|| true` 没兜住

那一步早就写了 `|| true`，看起来像是有人知道这两个脚本不支持 `--help`：

```bash
python3 scripts/harness/brief_preflight.py --help > /dev/null 2>&1 || true
```

但 `|| true` 挡的是**非零退出**，而这里发生的是**挂起**。它一次都没挡住过。

这条属于 memory 里记着的那族铁律：「仓里任何脚本被 agent 探测（`--help`/裸跑）都不该 exit 非 0」——而这个更糟，它不是 exit 非 0，是**真的去干活了**。
