### PR TITLE
portability: clawock starts against a book that is not this repository

### DIFF
--- a/clawock/workspace.py
+++ b/clawock/workspace.py
@@ -24,6 +24,26 @@ ENV_VAR = "CLAWOCK_WORKSPACE"
 REQUIRED = ("portfolio.json", "config/instruments.json")
 
 
+def engine_config(name: str) -> Path:
+    """A config file that ships with the ENGINE rather than with a book (#356).
+
+    `config/` holds two different kinds of thing, and conflating them is what
+    made a foreign workspace unable to start:
+
+    * **schemas** — `instruments.schema.json` and friends describe the FORMAT.
+      Every book uses the identical file, so requiring each one to carry a copy
+      is asking users to vendor our validation rules.
+    * **book data** — `instruments.json`, `factor-universe.json`,
+      `entry-gate-vetoes.json`. These are the user's content and stay in the
+      workspace, where absence means "not configured yet", not "engine broken".
+
+    Schemas resolve here, from the checkout this module ships in. Deliberately
+    NOT workspace-first-with-fallback: a fallback would silently apply this
+    repository's data to someone else's book, which is worse than a clear error.
+    """
+    return Path(__file__).resolve().parents[1] / "config" / name
+
+
 def workspace_root(default: Path | str | None = None) -> Path:
     """The workspace to operate on.
 

--- a/scripts/data/earnings_review.py
+++ b/scripts/data/earnings_review.py
@@ -31,7 +31,7 @@ from pathlib import Path
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.workspace import engine_config, workspace_root  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -39,7 +39,7 @@ from clawock.workspace import workspace_root  # noqa: E402
 # there. Same expression WS is seeded from, kept separate on purpose (#269).
 _CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-SCHEMA_FILE = WS / "config" / "earnings_review.schema.json"
+SCHEMA_FILE = engine_config("earnings_review.schema.json")
 ARTIFACT_ROOT = WS / "memory" / "earnings"
 SCHEMA_VERSION = 1
 

--- a/scripts/data/entry_gate.py
+++ b/scripts/data/entry_gate.py
@@ -29,7 +29,7 @@ from pathlib import Path
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.workspace import engine_config, workspace_root  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -37,7 +37,7 @@ from clawock.workspace import workspace_root  # noqa: E402
 # there. Same expression WS is seeded from, kept separate on purpose (#269).
 _CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
-SCHEMA_FILE = WS / "config" / "entry_gate.schema.json"
+SCHEMA_FILE = engine_config("entry_gate.schema.json")
 VETO_FILE = WS / "config" / "entry-gate-vetoes.json"
 ARTIFACT_ROOT = WS / "memory" / "entry-gates"
 SCHEMA_VERSION = 1
@@ -91,12 +91,24 @@ ARTIFACT_FIELDS = (
 MIRROR_TEST_SENTENCES = 5
 
 
-def load_vetoes(path: Path = VETO_FILE) -> dict:
-    doc = json.loads(path.read_text())
+def load_vetoes(path: Path = VETO_FILE, *, missing_ok: bool = False) -> dict:
+    """The book's standing entry vetoes.
+
+    `missing_ok` splits absence from corruption, same as the instrument registry
+    (#356): a workspace that has declared no vetoes is a normal state for any
+    book but this one, while malformed JSON is corruption and still raises.
+    """
+    if missing_ok and not Path(path).exists():
+        return {}
+    doc = json.loads(Path(path).read_text())
     return {item["id"]: item for item in doc["vetoes"]}
 
 
-VETOES = load_vetoes()
+# Absent vetoes must not stop this module importing — brief_preflight imports it
+# transitively, so raising here killed the whole preflight against a foreign
+# workspace. An empty veto set is not silent: `check` reports any veto a caller
+# names as undefined, which is exactly what an unconfigured book should hear.
+VETOES = load_vetoes(missing_ok=True)
 
 
 def _exact_fields(item, required, prefix, errors) -> bool:

--- a/scripts/data/instrument_registry.py
+++ b/scripts/data/instrument_registry.py
@@ -20,11 +20,11 @@ from typing import Any
 # whose only remaining job was inserting this path as a side effect.
 import sys  # noqa: E402
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.workspace import engine_config, workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 REGISTRY_FILE = WS / "config" / "instruments.json"
-SCHEMA_FILE = WS / "config" / "instruments.schema.json"
+SCHEMA_FILE = engine_config("instruments.schema.json")
 SCHEMA_VERSION = 1
 
 REQUIRED_FIELDS = {
@@ -151,8 +151,20 @@ def validate_registry(doc: Any) -> list[str]:
     return errors
 
 
-def load_registry(path: Path | str = REGISTRY_FILE) -> dict[str, dict]:
+def load_registry(path: Path | str = REGISTRY_FILE,
+                  *, missing_ok: bool = False) -> dict[str, dict]:
+    """The book's instruments.
+
+    `missing_ok` separates two things this used to conflate (#356). An ABSENT
+    registry means the workspace has registered nothing yet — true of any book
+    that is not this one — and must not stop the module from importing, because
+    every host-side gate imports it. A MALFORMED registry is corruption and
+    still raises: degrading there would publish numbers against metadata nobody
+    validated.
+    """
     path = Path(path)
+    if missing_ok and not path.exists():
+        return {}
     try:
         doc = json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
@@ -193,7 +205,16 @@ def validate_active_holdings(
     return errors
 
 
-INSTRUMENTS = load_registry()
+# Import must not depend on this book having a registry. Every host-side safety
+# gate imports this module, so raising here took the whole toolchain down for any
+# workspace but this one — `brief_preflight`, `report_preflight` and
+# `intraday_preflight` all died at import against a foreign book (#356).
+#
+# Absence yields an empty registry, and that is not silent: `validate_active_holdings`
+# then reports every live holding as unregistered, which system_check raises as
+# CRITICAL. A book with holdings and no registry gets a loud, accurate, actionable
+# message instead of a stack trace from an import.
+INSTRUMENTS = load_registry(missing_ok=True)
 
 
 def get(symbol: str) -> dict | None:

--- a/scripts/data/thesis_registry.py
+++ b/scripts/data/thesis_registry.py
@@ -13,10 +13,10 @@ from pathlib import Path
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.workspace import engine_config, workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
-SCHEMA_FILE = WS / "config" / "thesis.schema.json"
+SCHEMA_FILE = engine_config("thesis.schema.json")
 SCHEMA_VERSION = 1
 THESIS_STATES = ("unknown", "broken", "damaged", "weakening", "intact")
 STATE_RANK = {"broken": 0, "damaged": 1, "weakening": 2, "intact": 3}

--- a/tests/test_runs_against_a_foreign_book.py
+++ b/tests/test_runs_against_a_foreign_book.py
@@ -1,0 +1,101 @@
+"""The claim the README makes: point clawock at someone else's book (#356).
+
+`workspace_root()` has been overridable since #246, and #269 stopped every code
+import resolving through the workspace. Neither made this true. `config/` was
+still read from the workspace wholesale, and two modules loaded their config at
+IMPORT time, so a foreign book killed brief/report/intraday preflight before any
+of them reached a single argument.
+
+The split this pins:
+
+* **schemas ship with the engine** — they describe the format, so asking each
+  book to vendor a copy of our validation rules is asking the wrong thing;
+* **book data stays in the workspace, and absence is not corruption** — a
+  workspace that has registered no instruments is every book but this one, while
+  malformed JSON still raises, because degrading there would let numbers be
+  published against metadata nobody validated.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CLIS = ("brief_preflight", "report_preflight", "intraday_preflight",
+        "brief_postflight", "report_postflight", "intraday_postflight")
+
+
+@pytest.fixture
+def foreign_book(tmp_path):
+    """A workspace with data and no config, code, or history — a new user."""
+    book = tmp_path / "someone-elses-book"
+    (book / "memory" / ".tmp").mkdir(parents=True)
+    (book / "assets" / "data").mkdir(parents=True)
+    (book / "portfolio.json").write_text(json.dumps({"portfolios": {
+        "us_stocks": {"currency": "USD", "holdings": []},
+        "hk_stocks": {"currency": "HKD", "holdings": []}}}), encoding="utf-8")
+    assert not (book / "config").exists(), "the point is that config is absent"
+    return book
+
+
+@pytest.mark.parametrize("cli", CLIS)
+def test_every_harness_cli_starts_against_a_foreign_book(cli, foreign_book):
+    """--help is the cheapest proof the module got through import.
+
+    Import is where this failed: both instrument_registry and entry_gate read
+    their config at module scope, so the failure landed before argparse and took
+    every consumer with it.
+    """
+    done = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "harness" / f"{cli}.py"), "--help"],
+        capture_output=True, text=True, timeout=90, cwd=str(ROOT),
+        env=dict(os.environ, CLAWOCK_WORKSPACE=str(foreign_book)),
+    )
+    assert done.returncode == 0, (
+        f"{cli} cannot start against a workspace that is not this repository:\n"
+        f"{done.stdout[-500:]}\n{done.stderr[-1500:]}")
+
+
+def test_an_absent_registry_is_empty_but_a_broken_one_still_raises(tmp_path):
+    sys.path[:0] = [str(ROOT / "scripts" / "data"), str(ROOT)]
+    import instrument_registry as registry
+
+    assert registry.load_registry(tmp_path / "nope.json", missing_ok=True) == {}
+
+    broken = tmp_path / "broken.json"
+    broken.write_text("{ not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="cannot read instrument registry"):
+        registry.load_registry(broken, missing_ok=True)
+
+
+def test_schemas_come_from_the_engine_not_the_book(foreign_book):
+    """A book must not have to carry our validation rules to be validated.
+
+    Asserted in a subprocess WITH the override set, because in this one the
+    workspace is the checkout: `SCHEMA_FILE == engine_config(...)` is vacuously
+    true whenever the two roots coincide, which is every run on the live box.
+    That is the exact confusion this issue exists to end, so a test that can
+    only see it when they already agree proves nothing.
+    """
+    probe = (
+        "import sys; sys.path[:0] = [%r, %r]\n"
+        "import instrument_registry as r\n"
+        "print(r.SCHEMA_FILE)\n"
+        "print(r.REGISTRY_FILE)\n"
+    ) % (str(ROOT / "scripts" / "data"), str(ROOT))
+    done = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=60,
+        cwd=str(ROOT), env=dict(os.environ, CLAWOCK_WORKSPACE=str(foreign_book)))
+    assert done.returncode == 0, done.stderr
+    schema, registry_file = done.stdout.strip().splitlines()
+
+    assert schema.startswith(str(ROOT)), (
+        f"the schema followed the workspace override to {schema}; it describes "
+        "the format and must ship with the engine")
+    assert registry_file.startswith(str(foreign_book)), (
+        f"the registry did NOT follow the override ({registry_file}); the book's "
+        "own instruments must come from the book")


### PR DESCRIPTION
portability: clawock starts against a book that is not this repository

The README sells CLAWOCK_WORKSPACE, #246 made workspace_root overridable and
#269 stopped every code import resolving through the workspace. None of it was
true end to end: pointed at a foreign book, brief_preflight, report_preflight
and intraday_preflight all died, and they died at IMPORT, before reaching a
single argument.

Two causes, and they are different in kind.

config/ held two things under one name. Schemas describe the FORMAT and are
identical for every book, so resolving them from the workspace asked each user
to vendor a copy of our validation rules. They now come from the engine, via
clawock.workspace.engine_config. Deliberately not workspace-first-with-fallback:
a fallback would silently apply this repository's 27 instruments to somebody
else's holdings, which is worse than a clear error.

Book data still comes from the workspace, but absence stopped being fatal.
instrument_registry and entry_gate both loaded config at module scope, so an
unconfigured book took down every consumer that imports them -- which is all of
them. Absence now yields an empty registry and an empty veto set; corruption
still raises, because degrading there would publish numbers against metadata
nobody validated. Empty is not silent either: validate_active_holdings reports
every live holding as unregistered, which system_check raises as CRITICAL, so a
book with holdings and no registry gets an accurate message instead of a
traceback.

Live is unchanged and checked: 27 instruments, 4 vetoes, validate_active_holdings
clean, system_check 16 ok / 1 warn / 0 critical.

The acceptance test runs all six harness CLIs against a workspace holding data
and no config at all. One earlier version of the schema assertion was vacuous --
SCHEMA_FILE == engine_config(...) is trivially true whenever the workspace IS the
checkout, which is every run on this box, and that is precisely the confusion the
issue exists to end. It now asserts in a subprocess with the override set, that
the schema does NOT follow it and the registry does.

Mutation-verified three ways: restore the import-time load and the CLIs fail
again; point the schema back at the workspace and the override test goes red;
let missing_ok swallow parse errors and the corruption test goes red.

Closes #356

---

## 决定性判据：前后对比

**修复前**（拿一个只有 `portfolio.json` + 空 `memory/`、没有 `config/` 的 book）：

```
✗ brief_preflight    exit=1  ValueError: cannot read instrument registry <book>/config/instruments.json
✗ report_preflight   exit=1  同上
✗ intraday_preflight exit=1  同上
```

**修复后**：

```
✓ brief_preflight   ✓ report_preflight   ✓ intraday_preflight
✓ brief_postflight  ✓ report_postflight  ✓ intraday_postflight
```

六条主链全部起得来。

## 我做的两个判断

**1. schema 归引擎，数据归 book，且不做回落。**

`config/` 下混着两类东西。四个 `*.schema.json` 描述**格式**，每个 book 完全一样 —— 让用户自己拷一份我们的校验规则是问的错问题。而 `instruments.json`（27 条全是 kcn 的持仓）、`entry-gate-vetoes.json` 是**用户内容**。

**没有做 workspace-first + checkout 回落**：那会让别人的 book 悄悄套用这个仓库的 27 条 instruments 元数据。比报错更危险。

**2. 「缺失」降级，「损坏」照抛。**

这两件事以前被 `load_registry` 混为一谈。缺失 = 这个 book 还没登记（除了本仓库外的任何 book 都是这个状态）；损坏 = 数据坏了，降级会让数字跑在没人校验过的元数据上。

而且**降级不等于静默**：空登记表会让 `validate_active_holdings` 把每一个活跃持仓报成未登记，`system_check` 直接 CRITICAL。有持仓却没登记的 book 收到的是**准确可操作的信息**，不是一段 import traceback。

## 一个我自己写错又抓回来的测试

第一版 schema 断言是**空真的**：

```python
assert registry.SCHEMA_FILE == engine_config("instruments.schema.json")
```

当 workspace **就是** checkout 时（本机每一次运行都是），两边必然相等 —— 而这正是本 issue 要终结的那个混淆。变异验证时把 schema 改回走 workspace，测试**照样绿**，才暴露出来。

现已改成在**带 override 的子进程**里断言：schema **不**跟着 override 走，registry **跟着**走。

## 变异验证（三条，全部先红后绿）

| 变异 | 结果 |
|---|---|
| 恢复 `INSTRUMENTS` 导入期硬加载 | ✅ 三个 CLI 红 |
| schema 改回走 workspace | ✅ override 测试红 |
| 让 `missing_ok` 把解析错误也吞掉 | ✅ 损坏测试红 |

全量套件 **1654 passed, 4 xfailed**；`system_check` 16 ok / 1 warn / 0 critical，`instrument registry 12 active holdings mapped` 不变。
