### PR TITLE
dashboard: poll the data branch, instead of waiting on a Pages deployment

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -147,6 +147,14 @@ jobs:
           npm install --no-save --silent playwright@1.60.0
           npx playwright install --with-deps chromium
 
+      # The dashboard's four outputs and two sidecars live on the data branch,
+      # not on master (#314), so a checkout does not carry them. The browser
+      # contract loads the real page and would time out waiting for a Hero that
+      # never receives its projection.
+      - name: Fetch the published generation
+        if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
+        run: python3 scripts/build/fetch_data_plane.py
+
       - name: Browser contract — Hero, detail tabs, and chart gestures
         if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
         run: node tests/dashboard_tab_runtime.spec.js

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -203,6 +203,46 @@
   let FULL_DASHBOARD = null;
   let FULL_DASHBOARD_INFLIGHT = null;
 
+  // These six outputs are published to the `data-plane` branch (#314) and only
+  // reach this origin through a Pages deployment. Measured 2026-08-06: the
+  // deployment reports success within seconds but its content becomes visible
+  // ~14 minutes later, and a deployment created while another is still
+  // propagating is dropped outright — so the site lands roughly every other
+  // generation while the publisher writes one every 20 minutes (#367).
+  // Everything after the first paint therefore reads the branch directly, where
+  // the same bytes are readable seconds after the push.
+  //
+  // The first paint deliberately stays on this origin. `overview.json` is the
+  // only fetch on the LCP path, and a second origin's DNS/TCP/TLS handshake
+  // there would be paid by every cold visit — including Lighthouse — to save a
+  // wait that nobody is watching yet. A `preconnect` would not help either: the
+  // first cross-origin request happens 60 s in, far outside the load window.
+  const DATA_PLANE_ORIGIN = "https://raw.githubusercontent.com/KCNyu/clawock/data-plane/";
+  const DATA_PLANE_FILES = new Set([
+    "cron-heartbeats", "dashboard", "decision_audit",
+    "overview", "shadow_portfolio", "workflow-outcomes",
+  ]);
+  // null until the first paint succeeds, and back to null for good if that
+  // origin ever fails us — in which case the page degrades to reading Pages, as
+  // before. The block has to be sticky: re-promoting on the next successful
+  // same-origin poll would make every second poll fail against a broken origin.
+  let LIVE_ORIGIN = null;
+  let LIVE_ORIGIN_BLOCKED = false;
+
+  function _isLiveUrl(url) {
+    return LIVE_ORIGIN != null && url.startsWith(LIVE_ORIGIN);
+  }
+
+  // `bust` is dropped for the live origin on purpose: raw.githubusercontent.com
+  // normalizes query strings out of its cache key (a `?t=` request comes back
+  // `x-cache: HIT` under the unchanged etag), so it would be noise on the wire
+  // and nothing else. `cache: "no-store"` is what actually forces a fresh hop.
+  function _dataUrl(name, bust) {
+    const relative = "assets/data/" + name + ".json";
+    if (LIVE_ORIGIN && DATA_PLANE_FILES.has(name)) return LIVE_ORIGIN + relative;
+    return relative + (bust || "");
+  }
+
   function _generation(value) {
     return value && (value.generation_id || value.generated_at);
   }
@@ -214,15 +254,23 @@
     }
     const fetchGeneration = async retry => {
       const bust = triggeredByUser || retry ? "?t=" + Date.now() : "";
-      const response = await fetch("assets/data/dashboard.json" + bust, {
+      const url = _dataUrl("dashboard", bust);
+      const response = await fetch(url, {
         cache: triggeredByUser || retry ? "no-store" : "no-cache",
       });
       if (!response.ok) throw new Error("dashboard HTTP " + response.status);
       const value = await response.json();
       if (_generation(value) !== generation) {
+        // The live origin caches each file independently for 300 s, so the two
+        // halves of one generation can be minutes apart at the edge. `no-store`
+        // re-hops it. If the pair still does not line up, this generation is
+        // simply not assembled yet — say so in a way the caller can tell apart
+        // from a real failure, and let the next poll pick it up.
         if (!retry) return fetchGeneration(true);
-        throw new Error(
+        const error = new Error(
           `dashboard generation mismatch: wanted ${generation}, got ${_generation(value)}`);
+        error.incompleteGeneration = _isLiveUrl(url);
+        throw error;
       }
       // A slower request for the previous Overview generation must not replace
       // the cache after a newer poll has already become canonical.
@@ -289,9 +337,28 @@
     if (state.ready && !state.stale) return Promise.resolve(false);
 
     const bust = triggeredByUser ? "?t=" + requestStamp : "";
-    state.inFlight = fetch("assets/data/" + k + ".json" + bust, {
-      cache: triggeredByUser ? "no-store" : "no-cache",
-    }).then(async response => response.ok ? await response.json() : null)
+    const init = { cache: triggeredByUser ? "no-store" : "no-cache" };
+    const load = async () => {
+      const url = _dataUrl(k, bust);
+      try {
+        const response = await fetch(url, init);
+        if (response.ok) return await response.json();
+      } catch (error) {
+        if (!_isLiveUrl(url)) return null;
+      }
+      // Sidecars carry no generation to check against, so they cannot ride the
+      // poll's fallback. If the live origin let one down, take the older copy
+      // this origin still serves: a tab rendered a few minutes behind beats an
+      // empty one. Same-origin failures keep the existing null contract.
+      if (!_isLiveUrl(url)) return null;
+      try {
+        const response = await fetch("assets/data/" + k + ".json" + bust, init);
+        return response.ok ? await response.json() : null;
+      } catch (error) {
+        return null;
+      }
+    };
+    state.inFlight = load()
       .catch(() => null)
       .then(value => {
         // Sidecars publish independently from dashboard.json. Revalidate them,
@@ -401,9 +468,7 @@
       // The full cross-tab document is fetched only at the detail consumer boundary.
       // A user-initiated refresh keeps the old cache-buster so it ALWAYS punches
       // through stale intermediary caches (WeChat webview / carrier proxies).
-      const url = triggeredByUser
-        ? "assets/data/overview.json?t=" + Date.now()
-        : "assets/data/overview.json";
+      const url = _dataUrl("overview", triggeredByUser ? "?t=" + Date.now() : "");
       const res = await fetch(url, { cache: triggeredByUser ? "no-store" : "no-cache" });
       if (!res.ok) throw new Error("HTTP " + res.status);
       const json = await res.json();
@@ -473,9 +538,29 @@
         }
       }
       LAST_LOADED_AT = newAt;
+      // The shell is painted and the LCP path is done. Everything from here on
+      // reads the data branch directly, which is ~14 minutes ahead of this
+      // origin during a trading session (#367).
+      if (!LIVE_ORIGIN_BLOCKED) LIVE_ORIGIN = DATA_PLANE_ORIGIN;
     } catch (e) {
+      // A generation whose two halves have not both propagated yet is not a
+      // failure — the next poll gets it. Anything else means we cannot rely on
+      // that origin, so fall back to this one for good. `LIVE_ORIGIN` is set
+      // here only if this cycle actually read from it.
+      if (LIVE_ORIGIN && !e?.incompleteGeneration) {
+        LIVE_ORIGIN_BLOCKED = true;
+        LIVE_ORIGIN = null;
+      }
       console.error("Failed to load Overview projection:", e);
-      document.getElementById("last-updated").textContent = "load failed";
+      // Blanking the age label on a background poll would replace the one honest
+      // statement on screen — how old the rendered generation is — with a string
+      // that says nothing about it. Keep it; a label that visibly stops advancing
+      // is the accurate signal. The first load has nothing to preserve.
+      if (DATA == null) {
+        document.getElementById("last-updated").textContent = "load failed";
+      } else {
+        _updateAgeLabel();
+      }
       if (btn) {
         btn.classList.remove("is-loading");
         btn.removeAttribute("disabled");

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -10,6 +10,11 @@ const { chromium } = require("playwright");
 const ROOT = path.resolve(__dirname, "..");
 const DETAIL_PATH = "/assets/js/dashboard.render.js";
 const TABS = ["drill", "risk", "market", "plan", "reflect"];
+// Everything after the first paint reads the data branch instead of this origin
+// (#367). Every page here stubs it: left unrouted it would put a live call to
+// raw.githubusercontent.com on CI's critical path, and the bytes it would return
+// are the ones already sitting in assets/data.
+const LIVE_DATA_ORIGIN = "https://raw.githubusercontent.com/KCNyu/clawock/data-plane/";
 const MIME = {
   ".css": "text/css; charset=utf-8",
   ".html": "text/html; charset=utf-8",
@@ -35,12 +40,36 @@ function serveWorkspace() {
   });
 }
 
+// Records which data files were served from the live branch, so a test can
+// assert both that the first paint never went there and that a poll always does.
+async function stubLiveOrigin(page, options = {}) {
+  const served = [];
+  await page.route(LIVE_DATA_ORIGIN + "**", async route => {
+    const name = path.basename(new URL(route.request().url()).pathname);
+    served.push(name);
+    if (options.fail) return route.abort("failed");
+    const file = path.resolve(ROOT, "assets/data", name);
+    if (!fs.existsSync(file)) return route.fulfill({ status: 404, body: "not found" });
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "access-control-allow-origin": "*",
+      },
+      body: fs.readFileSync(file, "utf8"),
+    });
+  });
+  return served;
+}
+
 function observe(page) {
   const result = { detailRequests: 0, fullRequests: 0, failures: [], errors: [] };
   page.on("request", request => {
     const pathname = new URL(request.url()).pathname;
     if (pathname === DETAIL_PATH) result.detailRequests += 1;
-    if (pathname === "/assets/data/dashboard.json") result.fullRequests += 1;
+    // Counted on either origin: the point of the assertion is that detail tabs
+    // share one request for the full document, not where it was served from.
+    if (pathname.endsWith("/assets/data/dashboard.json")) result.fullRequests += 1;
   });
   page.on("response", response => {
     const url = new URL(response.url());
@@ -81,6 +110,7 @@ async function dispatchTouch(session, type, points) {
 async function testRuntime(browser, base) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const state = observe(page);
+  await stubLiveOrigin(page);
   await page.goto(base, { waitUntil: "networkidle" });
   await waitForData(page);
   assert.equal(state.detailRequests, 0, "Overview downloaded the detail renderer");
@@ -108,6 +138,7 @@ async function testRuntime(browser, base) {
 
   const deep = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const deepState = observe(deep);
+  await stubLiveOrigin(deep);
   await deep.goto(base + "#reflect", { waitUntil: "domcontentloaded" });
   await waitForTab(deep, "reflect");
   assert.equal(deepState.detailRequests, 1, "deep link did not load one detail bundle");
@@ -117,6 +148,7 @@ async function testRuntime(browser, base) {
 
   const rapid = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const rapidState = observe(rapid);
+  await stubLiveOrigin(rapid);
   await rapid.route(`**${DETAIL_PATH}`, async route => {
     await new Promise(resolve => setTimeout(resolve, 250));
     await route.continue();
@@ -133,6 +165,7 @@ async function testRuntime(browser, base) {
 
   const mismatch = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const mismatchState = observe(mismatch);
+  await stubLiveOrigin(mismatch);
   let fullAttempt = 0;
   await mismatch.route(/\/assets\/data\/dashboard\.json(?:\?.*)?$/, async route => {
     fullAttempt += 1;
@@ -154,12 +187,70 @@ async function testRuntime(browser, base) {
   assert.deepEqual(mismatchState.errors, []);
 }
 
+async function testLiveDataOrigin(browser, base) {
+  // The first paint must stay on this origin. `overview.json` is the only fetch
+  // on the LCP path, so a second origin's handshake there is paid by every cold
+  // visit — Lighthouse included — to save a wait nobody is watching yet.
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const state = observe(page);
+  const served = await stubLiveOrigin(page);
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  assert.deepEqual(served, [], "the first paint reached across origins for its data");
+
+  // Every poll after it must read the branch, which is ~14 minutes ahead of
+  // this origin during a session (#367). A poll that keeps reading Pages is the
+  // regression this whole change exists to prevent.
+  await page.evaluate(() => loadData(false));
+  assert.deepEqual(served, ["overview.json"],
+    "the background poll did not read the data branch");
+
+  // The full document has to follow overview.json across, or the two halves of
+  // one generation come from origins ~14 minutes apart and never line up.
+  await page.click('.tab-btn[data-tab="risk"]');
+  await waitForTab(page, "risk");
+  assert.ok(served.includes("dashboard.json"),
+    "the full document was not read from the data branch");
+  assert.equal(state.fullRequests, 1, "the full document was fetched more than once");
+  assert.deepEqual(state.failures, []);
+  assert.deepEqual(state.errors, []);
+  await page.close();
+
+  // A data branch we cannot reach must cost one attempt, not one per poll, and
+  // must leave a working page behind.
+  const offline = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const offlineState = observe(offline);
+  const attempts = await stubLiveOrigin(offline, { fail: true });
+  await offline.goto(base, { waitUntil: "networkidle" });
+  await waitForData(offline);
+  await offline.evaluate(() => loadData(false));
+  // Asserted here, before the next poll succeeds and repairs the label: the one
+  // honest statement on screen is how old the generation being rendered is, and
+  // a failed background poll must not overwrite it with a string that says
+  // nothing about it.
+  assert.match(await offline.evaluate(() =>
+    document.getElementById("last-updated").textContent), /生成于/,
+    "a failed poll replaced the age of the generation still on screen");
+  // Three polls, not two. The second falls back and succeeds, and it is the
+  // third that catches a fallback which forgets — re-promoting the dead origin
+  // after every recovery makes every other poll fail.
+  await offline.evaluate(() => loadData(false));
+  await offline.evaluate(() => loadData(false));
+  assert.equal(attempts.length, 1,
+    "an unreachable data branch was retried on every poll instead of being dropped");
+  await waitForData(offline);
+  assert.deepEqual(offlineState.failures, []);
+  assert.deepEqual(offlineState.errors, []);
+  await offline.close();
+}
+
 async function testEquityTouch(browser, base) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
   });
   const page = await context.newPage();
   const state = observe(page);
+  await stubLiveOrigin(page);
   await page.goto(base, { waitUntil: "networkidle" });
   await waitForData(page);
   await page.locator(".native-equity-canvas").scrollIntoViewIfNeeded();
@@ -210,6 +301,7 @@ async function main() {
   } : {});
   try {
     await testRuntime(browser, base);
+    await testLiveDataOrigin(browser, base);
     await testEquityTouch(browser, base);
   } finally {
     await browser.close();


### PR DESCRIPTION
Closes #367.

The publish chain is healthy right up to the data branch; the lag is entirely in
the step between "Pages deployment created" and "the CDN serves it". Measured
2026-08-06 (UTC): generation `14:00:03` was pushed, the deployment was created at
14:01:09, `actions/deploy-pages` reported success at 14:01:23 — and the live site
kept serving `13:32:37` until **14:15:32**. The previous transition took the same
~14 minutes, and the deployments created at 13:41:02 and 14:03:32 were never
served at all: the site went straight from `13:32:37` to `14:00:03`.

Against a publisher that writes every 20 minutes, that means roughly every other
generation is dropped. At 14:29 the site was on `14:00:03` while
`raw.githubusercontent.com/.../data-plane/assets/data/overview.json` already
served `14:20:03`, byte-identical to the host's local file.

## What changed

Everything after the first paint reads the six data-branch outputs from the
branch directly. The HTML shell, the JS bundles and the non-data-plane sidecars
are untouched.

**The first paint deliberately stays same-origin.** `overview.json` is the only
fetch on the LCP path, so a second origin's handshake there would be paid by
every cold visit — Lighthouse included — to save a wait nobody is watching yet.
No `preconnect` either: the first cross-origin request happens 60 s in, far
outside the load window, so it would only trip the unused-preconnect audit.
Measured, the two origins are the same weight: 11,062 B gzip vs 10,985 B for
`overview.json`, and the branch sends `max-age=300` against Pages' 600.

Three failure modes are handled explicitly:

- **Per-file skew.** That origin caches each file independently for 300 s, so
  the two halves of one generation can be minutes apart at the edge. A mismatch
  re-hops with `no-store`; if the pair still does not line up, the generation is
  marked incomplete rather than failed and the next poll picks it up. A query
  string is not an option there — verified that `?t=` comes back `x-cache: HIT`
  under an unchanged etag, so it is normalized out of the cache key.
- **Unreachable branch.** The page falls back to this origin permanently. The
  block is sticky on purpose: re-promoting after each recovery would make every
  second poll fail.
- **Failed background poll.** It no longer replaces the age label with
  "load failed". The age of the generation actually on screen is the one honest
  statement available, and a label that visibly stops advancing is the accurate
  signal; the first load, having nothing to preserve, still says "load failed".

## Tests

Four assertions added to the browser contract, each mutation-verified:

| Mutation | Assertion that caught it |
|---|---|
| promote the live origin before the first paint | first paint reached across origins |
| `_dataUrl` always returns the relative path | poll did not read the data branch |
| drop `dashboard` from the data-plane set | full document was not read from the data branch |
| drop the sticky block | unreachable branch retried on every poll |
| always write "load failed" | failed poll replaced the age of the generation |

The offline case needs three polls, not two — the second falls back and
succeeds, and it is the third that catches a fallback which forgets.

Every page in the spec now stubs that origin from the local `assets/data` files;
unrouted, it would have put a live call to raw.githubusercontent.com on CI's
critical path.

## One workflow fix this surfaced

`harness-regression` runs the browser contract without fetching the data branch.
Since #314 those six files are not in a checkout, so the spec would time out
waiting for a Hero that never receives its projection — it just has not run
since the data moved, because no PR has touched `assets/js` in between. Added
the same `fetch_data_plane.py` step the Pages workflow already uses.

Local: 1657 passed, 4 xfailed; browser contract green.

## Not addressed

The ~14 minute Pages propagation is platform-side. This routes around it rather
than trying to fix it — reducing publish frequency was considered and rejected,
since it would still leave every viewer 15+ minutes behind.
