### PR TITLE
dashboard: show actual Au99.99 and London gold breakeven

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1905,9 +1905,9 @@
       grid-column: 1 / -1; min-height: 0;
       display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
       grid-template-areas:
-        "title london"
-        "hero london"
-        "stats london"
+        "title domestic"
+        "hero domestic"
+        "stats domestic"
         "spark london"
         "proj london"
         "asof asof";
@@ -1916,6 +1916,7 @@
     .hero-gold-card > h3 { grid-area: title; }
     #gold-hero { grid-area: hero; min-width: 0; }
     #gold-stats { grid-area: stats; min-width: 0; }
+    #gold-domestic { grid-area: domestic; min-width: 0; }
     #gold-london { grid-area: london; min-width: 0; }
     #gold-spark { grid-area: spark; min-width: 0; }
     #gold-proj { grid-area: proj; min-width: 0; }

--- a/assets/js/dashboard.hero.js
+++ b/assets/js/dashboard.hero.js
@@ -732,6 +732,39 @@
         ${cell('约定投', `${g.installments_est ?? DASH} 笔 ×¥${num(g.daily_amount)}`)}
       </div>`;
 
+    // 国内真基准：000217 跟随上金所国内现货金，这是用户判断回本的主口径。
+    const dg = g.domestic_gold;
+    const goldDomestic = document.getElementById('gold-domestic');
+    if (goldDomestic) {
+      if (!dg || dg.price_cny_g == null) {
+        goldDomestic.innerHTML =
+          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:11px">
+             上金所 Au99.99 暂无有效行情
+           </div>`;
+      } else {
+        const dchg = dg.change_pct;
+        const dcolor = dchg == null ? 'var(--neutral)' : (dchg >= 0 ? 'var(--positive)' : 'var(--negative)');
+        const retained = dg.quote_status === 'retained';
+        goldDomestic.innerHTML =
+          `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
+             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
+             <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
+               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:21px;font-weight:800;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
+               <div><div class="muted" style="font-size:10px">我的回本价</div><div style="font-size:21px;font-weight:800;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+             </div>
+             <div class="muted" style="font-size:11px;margin-top:7px;text-transform:none;letter-spacing:0">
+               距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
+               ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
+               ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
+             </div>
+             <div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+               ${dg.date || ''} 收盘 · 上金所${retained ? ' · ⚠️ 本次抓取失败，沿用上次有效值' : ''}
+             </div>
+           </div>`;
+      }
+    }
+
     // 伦敦金类比口径：折算成克/盎司 + 国际口径现值 + 伦敦金vs你基金归一趋势线
     // （kcn 日常看伦敦金现货趋势/新闻，这块把人民币基金翻译成他熟悉的口径）
     const ld = g.london;
@@ -741,20 +774,25 @@
       else {
         const xchg = ld.xau_change_pct;
         const xcolor = (xchg == null ? 'var(--neutral)' : (xchg >= 0 ? 'var(--positive)' : 'var(--negative)'));
-        const xchgStr = xchg == null ? '' : ` <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
-        // 折算行 + 现价行
+        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
+        const fundBeXau = ld.fund_breakeven_usd_oz != null
+          ? ld.fund_breakeven_usd_oz
+          : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
+        const fundBePct = ld.fund_breakeven_upside_pct != null
+          ? ld.fund_breakeven_upside_pct : g.breakeven_upside_pct;
+        // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">类比伦敦金（国际口径）</div>
-             <div style="display:flex;align-items:baseline;gap:var(--space-3);flex-wrap:wrap;margin-top:3px">
-               <span style="font-size:18px;font-weight:800">≈ ${num(ld.grams_equiv, 1)} 克</span>
-               <span style="font-size:13px;font-weight:700;color:var(--muted,#999)">/ ${num(ld.oz_equiv, 3)} oz</span>
-               ${ld.intl_value_usd != null ? `<span style="font-size:13px">国际现值 <b>$${num(ld.intl_value_usd)}</b></span>` : ''}
+             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
+             <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
+               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:19px;font-weight:800;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
+               <div><div class="muted" style="font-size:10px">按当前汇率回本</div><div style="font-size:19px;font-weight:800;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
              </div>
              <div class="muted" style="font-size:11px;margin-top:5px;text-transform:none;letter-spacing:0">
-               伦敦金现货 <b style="color:var(--text,#eee)">$${num(ld.xau_usd, 2)}</b>/oz${xchgStr}
+               距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
-               · USDCNY ${num(ld.usdcny, 4)}
+               · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
              </div>`;
         const histSource = ld.hist_source || {};
         const histNames = {
@@ -771,14 +809,15 @@
             ℹ️ ${escapeHtml(ld.hist_advisory)}
           </div>`;
         }
-        // DCA 平均成本：同样的钱、同样的定投日子，改买伦敦金现货 → 我的均价是多少（对标基金卡的「平均成本」）
+        // 反事实 DCA 只是模拟对照，默认折叠，不再叫「我的平均成本」。
         const de = ld.dca_equiv;
         if (de && de.avg_cost_usd_oz != null) {
           const beColor = de.breakeven_upside_pct > 0 ? 'var(--negative)' : 'var(--positive)';
           const dColor = de.pnl_pct >= 0 ? 'var(--positive)' : 'var(--negative)';
           html +=
-            `<div style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
-               <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">同额定投伦敦金 · 我的平均成本</div>
+            `<details style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
+               <summary class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
+               <div style="margin-top:6px">
                <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;margin-top:2px">
                  <span style="font-size:17px;font-weight:800">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:11px;font-weight:600;color:var(--muted,#999)">/oz</span></span>
                  <span style="font-size:12px;font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
@@ -800,8 +839,9 @@
               `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
                <table style="width:100%;font-size:12px;border-collapse:collapse">
                  <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
-                 ${lrows}</table>`;
+               ${lrows}</table>`;
           }
+          html += `</div></details>`;
         }
         // 归一对比线：起投=100，伦敦金(USD) vs 你的基金(CNY)
         const cs = (ld.compare_series || []).filter(r => Array.isArray(r) && r[1] != null && r[2] != null);

--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -1816,6 +1816,39 @@
         ${cell('约定投', `${g.installments_est ?? DASH} 笔 ×¥${num(g.daily_amount)}`)}
       </div>`;
 
+    // 国内真基准：000217 跟随上金所国内现货金，这是用户判断回本的主口径。
+    const dg = g.domestic_gold;
+    const goldDomestic = document.getElementById('gold-domestic');
+    if (goldDomestic) {
+      if (!dg || dg.price_cny_g == null) {
+        goldDomestic.innerHTML =
+          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:11px">
+             上金所 Au99.99 暂无有效行情
+           </div>`;
+      } else {
+        const dchg = dg.change_pct;
+        const dcolor = dchg == null ? 'var(--neutral)' : (dchg >= 0 ? 'var(--positive)' : 'var(--negative)');
+        const retained = dg.quote_status === 'retained';
+        goldDomestic.innerHTML =
+          `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
+             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
+             <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
+               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:21px;font-weight:800;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
+               <div><div class="muted" style="font-size:10px">我的回本价</div><div style="font-size:21px;font-weight:800;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+             </div>
+             <div class="muted" style="font-size:11px;margin-top:7px;text-transform:none;letter-spacing:0">
+               距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
+               ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
+               ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
+             </div>
+             <div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+               ${dg.date || ''} 收盘 · 上金所${retained ? ' · ⚠️ 本次抓取失败，沿用上次有效值' : ''}
+             </div>
+           </div>`;
+      }
+    }
+
     // 伦敦金类比口径：折算成克/盎司 + 国际口径现值 + 伦敦金vs你基金归一趋势线
     // （kcn 日常看伦敦金现货趋势/新闻，这块把人民币基金翻译成他熟悉的口径）
     const ld = g.london;
@@ -1825,20 +1858,25 @@
       else {
         const xchg = ld.xau_change_pct;
         const xcolor = (xchg == null ? 'var(--neutral)' : (xchg >= 0 ? 'var(--positive)' : 'var(--negative)'));
-        const xchgStr = xchg == null ? '' : ` <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
-        // 折算行 + 现价行
+        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
+        const fundBeXau = ld.fund_breakeven_usd_oz != null
+          ? ld.fund_breakeven_usd_oz
+          : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
+        const fundBePct = ld.fund_breakeven_upside_pct != null
+          ? ld.fund_breakeven_upside_pct : g.breakeven_upside_pct;
+        // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">类比伦敦金（国际口径）</div>
-             <div style="display:flex;align-items:baseline;gap:var(--space-3);flex-wrap:wrap;margin-top:3px">
-               <span style="font-size:18px;font-weight:800">≈ ${num(ld.grams_equiv, 1)} 克</span>
-               <span style="font-size:13px;font-weight:700;color:var(--muted,#999)">/ ${num(ld.oz_equiv, 3)} oz</span>
-               ${ld.intl_value_usd != null ? `<span style="font-size:13px">国际现值 <b>$${num(ld.intl_value_usd)}</b></span>` : ''}
+             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
+             <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
+               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:19px;font-weight:800;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
+               <div><div class="muted" style="font-size:10px">按当前汇率回本</div><div style="font-size:19px;font-weight:800;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
              </div>
              <div class="muted" style="font-size:11px;margin-top:5px;text-transform:none;letter-spacing:0">
-               伦敦金现货 <b style="color:var(--text,#eee)">$${num(ld.xau_usd, 2)}</b>/oz${xchgStr}
+               距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
-               · USDCNY ${num(ld.usdcny, 4)}
+               · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
              </div>`;
         const histSource = ld.hist_source || {};
         const histNames = {
@@ -1855,14 +1893,15 @@
             ℹ️ ${escapeHtml(ld.hist_advisory)}
           </div>`;
         }
-        // DCA 平均成本：同样的钱、同样的定投日子，改买伦敦金现货 → 我的均价是多少（对标基金卡的「平均成本」）
+        // 反事实 DCA 只是模拟对照，默认折叠，不再叫「我的平均成本」。
         const de = ld.dca_equiv;
         if (de && de.avg_cost_usd_oz != null) {
           const beColor = de.breakeven_upside_pct > 0 ? 'var(--negative)' : 'var(--positive)';
           const dColor = de.pnl_pct >= 0 ? 'var(--positive)' : 'var(--negative)';
           html +=
-            `<div style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
-               <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">同额定投伦敦金 · 我的平均成本</div>
+            `<details style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
+               <summary class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
+               <div style="margin-top:6px">
                <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;margin-top:2px">
                  <span style="font-size:17px;font-weight:800">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:11px;font-weight:600;color:var(--muted,#999)">/oz</span></span>
                  <span style="font-size:12px;font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
@@ -1884,8 +1923,9 @@
               `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
                <table style="width:100%;font-size:12px;border-collapse:collapse">
                  <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
-                 ${lrows}</table>`;
+               ${lrows}</table>`;
           }
+          html += `</div></details>`;
         }
         // 归一对比线：起投=100，伦敦金(USD) vs 你的基金(CNY)
         const cs = (ld.compare_series || []).filter(r => Array.isArray(r) && r[1] != null && r[2] != null);

--- a/index.html
+++ b/index.html
@@ -273,6 +273,7 @@ layout: null
         <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px"></span></h3>
         <div id="gold-hero"></div>
         <div id="gold-stats"></div>
+        <div id="gold-domestic"></div>
         <div id="gold-london"></div>
         <div id="gold-spark"></div>
         <div id="gold-proj"></div>

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -43,7 +43,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `analyze_us_stocks.py` | 美股组合刷新 + RSI | Yahoo v8 chart | ✅ |
 | `analyze_hk_stocks.py` | 港股实时价 + HSI/HSTECH 指数 + 新闻 + 信号 | 腾讯 qt.gtimg.cn | ✅ |
 | `fetch_benchmark_history.py` | SPY / HSI / HSTECH 日线历史(基准叠加) | 腾讯 kline / Yahoo | ✅ |
-| `fetch_gold_dca.py` | 黄金定投 000217 净值 + 定投指标 | 东财 lsjz / fundgz | ✅ |
+| `fetch_gold_dca.py` | 黄金定投 000217 净值 + Au99.99/伦敦金回本映射 | 东财 lsjz / 上金所 / 腾讯 XAU / Frankfurter | ✅ |
 
 ## Layer 2 · 基本面/申报 Fundamentals & Filings
 

--- a/scripts/data/fetch_gold_dca.py
+++ b/scripts/data/fetch_gold_dca.py
@@ -14,8 +14,9 @@
 本脚本【绝不】改这三个基线字段，只：
   1. 拉最新净值 + 近 ~150 交易日历史（api.fund.eastmoney.com/f10/lsjz，稳定渠道）
   2. 拉实时估值（fundgz，净值未出时的当日估算，仅展示用）
-  3. 重算 avg_cost / 现值 / 盈亏 / 回本门槛 / 定投摊薄预测 / 区间高低
-  4. merge-not-overwrite 写回 portfolio.json
+  3. 拉上金所 Au99.99 同日收盘，映射真持仓的国内金/伦敦金回本价
+  4. 重算 avg_cost / 现值 / 盈亏 / 回本门槛 / 定投摊薄预测 / 区间高低
+  5. merge-not-overwrite 写回 portfolio.json
 
 一天刷一次即可，无 LLM、无 API key。延续记忆：
   - openclaw-fetcher-merge-not-overwrite（抓空保留旧值，绝不整文件覆盖真值）
@@ -136,9 +137,64 @@ def fetch_realtime(code):
         return None
 
 
+def _market_number(value):
+    text = str(value or '').strip().replace(',', '').replace('%', '')
+    if text in ('', '-'):
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def fetch_au9999_daily(day):
+    """上金所 Au99.99 每日交易行情，元/克。
+
+    用基金最新净值日查同一交易日，避免周末或净值晚发时把
+    不同日的国内金价与基金净值硬对齐。抓空返回 None，调用方
+    merge-not-overwrite 保留上次有效值。
+    """
+    if not day:
+        return None
+    url = ('https://www.sge.com.cn/sjzx/quotation_daily_new'
+           f'?start_date={day}&end_date={day}')
+    raw = _curl(url, 'https://www.sge.com.cn/')
+    if 'Au99.99' not in raw:
+        return None
+    try:
+        import re
+        rows = re.findall(r'<tr[^>]*>(.*?)</tr>', raw, flags=re.I | re.S)
+        row = next(r for r in rows if re.search(r'>\s*Au99\.99\s*<', r))
+        cells = [re.sub(r'<[^>]+>', '', cell).strip()
+                 for cell in re.findall(r'<td[^>]*>(.*?)</td>', row, flags=re.I | re.S)]
+        # 页面把旧「序号」td 放在 HTML 注释里，宽松 HTML 解析仍可能读到；
+        # 以合约列为锚点，不假设序号是否出现。
+        symbol_idx = cells.index('Au99.99')
+        if symbol_idx < 1 or len(cells) < symbol_idx + 8:
+            return None
+        close = _market_number(cells[symbol_idx + 4])
+        if close is None or close <= 0:
+            return None
+        return {
+            'symbol': 'Au99.99',
+            'price_cny_g': close,
+            'date': cells[symbol_idx - 1],
+            'open_cny_g': _market_number(cells[symbol_idx + 1]),
+            'high_cny_g': _market_number(cells[symbol_idx + 2]),
+            'low_cny_g': _market_number(cells[symbol_idx + 3]),
+            'change_pct': _market_number(cells[symbol_idx + 6]),
+            'weighted_avg_cny_g': _market_number(cells[symbol_idx + 7]),
+            'source': 'sge_quotation_daily_new',
+            'fetched_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+        }
+    except (StopIteration, IndexError, ValueError):
+        return None
+
+
 # ───────────────────────── 伦敦金（XAU）类比口径 ─────────────────────────
 # kcn 日常看的是伦敦金现货趋势 → 把这笔人民币基金折算成「等于多少克/盎司黄金」+
-# 「伦敦金 vs 你的基金」起投归一对比线。三个源（都无 key）：
+# 「伦敦金 vs 你的基金」起投归一对比线。国内真基准另取上金所
+# Au99.99 每日行情。国际口径三个源（都无 key）：
 #   · 现价/涨跌/高低 = 腾讯 hf_XAU（真·伦敦金现货，稳）
 #   · USDCNY        = frankfurter（ECB 日频，带历史）
 #   · 历史日线      = 新浪 GlobalFutures XAU（真·伦敦金现货日线，回溯 2006）；东财 GC00Y 兜底
@@ -418,6 +474,9 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         derived.get('nav_history') or [],
         gold.get('start_date', ''),
     )
+    nav = float(derived.get('nav') or 0)
+    avg_cost = float(derived.get('avg_cost') or 0)
+    breakeven_ratio = (avg_cost / nav) if nav and avg_cost else None
     return {
         'xau_usd': round(xau, 2),
         'xau_change_pct': spot.get('change_pct'),
@@ -429,6 +488,10 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         'oz_equiv': round(oz, 3) if oz else None,
         'grams_equiv': round(grams, 1) if grams else None,
         'intl_value_usd': round(intl_usd, 2) if intl_usd else None,
+        # 真基金持仓的映射回本线：假设 USD/CNY 与内外盘价差不变。
+        # 与下方 dca_equiv（假设每日直接买伦敦金）必须分开。
+        'fund_breakeven_usd_oz': round(xau * breakeven_ratio, 2) if breakeven_ratio else None,
+        'fund_breakeven_upside_pct': derived.get('breakeven_upside_pct'),
         'compare_series': compare,
         'dca_equiv': dca_equiv,
         'hist_source': hist_source or {'name': 'unavailable', 'points': 0},
@@ -447,6 +510,28 @@ def compute_london(derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         'hist_advisory': hist_advisory,
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
     }
+
+
+def compute_domestic_gold(derived, gold, quote):
+    """上金所现价 → 真基金持仓回本价。
+
+    quote 抓空时沿用旧 domestic_gold，但用最新基金成本/净值重算
+    回本映射；这样不会把旧行情冒充新日期，也不会清空最后一个有效值。
+    """
+    reference = quote or gold.get('domestic_gold')
+    if not isinstance(reference, dict):
+        return None
+    price = _market_number(reference.get('price_cny_g'))
+    nav = float(derived.get('nav') or 0)
+    avg_cost = float(derived.get('avg_cost') or 0)
+    if not price or not nav or not avg_cost:
+        return None
+    out = dict(reference)
+    out['price_cny_g'] = round(price, 2)
+    out['breakeven_cny_g'] = round(price * avg_cost / nav, 2)
+    out['breakeven_upside_pct'] = derived.get('breakeven_upside_pct')
+    out['quote_status'] = 'fresh' if quote else 'retained'
+    return out
 
 
 def trading_days_since(history, start):
@@ -472,7 +557,7 @@ def project_dca(units, principal, nav, daily, horizons=(20, 40, 60, 120, 250)):
 
 def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None,
             xau_hist=None, xau_hist_source=None, fx_hist_source=None,
-            hist_advisory=None):
+            hist_advisory=None, domestic_quote=None):
     base_principal = float(gold['principal_invested'])
     base_units = float(gold['units_held'])
     daily = float(gold.get('daily_amount', 200))
@@ -527,6 +612,7 @@ def compute(gold, history, realtime, spot=None, usdcny=None, usdcny_hist=None,
         'nav_history': [[d, round(n, 4)] for d, n, _ in history[-HISTORY_KEEP:]],
         'last_updated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
     }
+    derived['domestic_gold'] = compute_domestic_gold(derived, gold, domestic_quote)
     derived['london'] = compute_london(
         derived, gold, spot, usdcny, usdcny_hist, xau_hist,
         xau_hist_source, fx_hist_source, hist_advisory,
@@ -550,6 +636,12 @@ def main():
         return 1
     if not history:
         print('  warn: 净值历史抓空，沿用 portfolio 里旧 nav（merge-not-overwrite）', file=sys.stderr)
+
+    quote_day = history[-1][0] if history else gold.get('nav_date')
+    domestic_quote = fetch_au9999_daily(quote_day)
+    if not domestic_quote:
+        print(f'  warn: 上金所 Au99.99({quote_day or "unknown"})抓空，沿用上次有效值',
+              file=sys.stderr)
 
     # 伦敦金类比口径（best-effort，抓空各自沿用旧值）
     spot = fetch_london_spot()
@@ -595,7 +687,7 @@ def main():
 
     derived = compute(
         gold, history, realtime, spot, usdcny, usdcny_hist, xau_hist,
-        xau_source, fx_source, history_advisory,
+        xau_source, fx_source, history_advisory, domestic_quote,
     )
 
     # merge：真值字段原样保留，派生字段更新；nav_history 抓空时不清空
@@ -616,11 +708,18 @@ def main():
     if g.get('realtime'):
         rt = g['realtime']
         print(f"  实时估值 {rt['est_nav']} ({rt['est_change_pct']:+.2f}%) @ {rt.get('est_time')}")
+    if g.get('domestic_gold'):
+        dg = g['domestic_gold']
+        print(f"  上金所 Au99.99 ¥{dg['price_cny_g']:,.2f}/克 @ {dg.get('date')} "
+              f"→ 真持仓回本 ¥{dg['breakeven_cny_g']:,.2f}/克 "
+              f"({dg.get('breakeven_upside_pct', 0):+.2f}%, {dg.get('quote_status')})")
     if g.get('london'):
         ld = g['london']
         print(f"  伦敦金 ${ld.get('xau_usd')}/oz ({(ld.get('xau_change_pct') or 0):+.2f}%) "
               f"USDCNY {ld.get('usdcny')} → 折 {ld.get('grams_equiv')} 克 / {ld.get('oz_equiv')} oz "
               f"(国际口径 ${ld.get('intl_value_usd'):,.0f})  对比线 {len(ld.get('compare_series') or [])} 点")
+        print(f"  ↳ 真持仓伦敦金回本 ${ld.get('fund_breakeven_usd_oz'):,.2f}/oz "
+              f"(假设汇率/内外盘价差不变)")
         hs = ld.get('hist_source') or {}
         print(f"  ↳ 历史源 {hs.get('name', 'unknown')} · {hs.get('points', 0)} 点")
         if ld.get('hist_advisory'):

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -79,9 +79,9 @@ def test_gold_dca_uses_the_full_desktop_row_and_an_internal_grid():
     assert "grid-column: 1 / -1" in block
     assert "min-height: 0" in block
     assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in block
-    assert '"title london"' in block
-    assert '"hero london"' in block
-    assert '"stats london"' in block
+    assert '"title domestic"' in block
+    assert '"hero domestic"' in block
+    assert '"stats domestic"' in block
     assert '"spark london"' in block
     assert '"proj london"' in block
     assert '"asof asof"' in block
@@ -89,6 +89,7 @@ def test_gold_dca_uses_the_full_desktop_row_and_an_internal_grid():
         ("title", ".hero-gold-card > h3"),
         ("hero", "#gold-hero"),
         ("stats", "#gold-stats"),
+        ("domestic", "#gold-domestic"),
         ("london", "#gold-london"),
         ("spark", "#gold-spark"),
         ("proj", "#gold-proj"),

--- a/tests/test_gold_dca_history_stability.py
+++ b/tests/test_gold_dca_history_stability.py
@@ -145,7 +145,8 @@ def test_date_bound_keeps_coverage_and_preceding_settlement_window():
 
 def test_london_payload_persists_reference_and_visible_provenance():
     xau = [("2026-07-01", 100.0), ("2026-07-02", 101.0)]
-    derived = {"current_value": 1000.0, "nav_history": [
+    derived = {"current_value": 1000.0, "nav": 3.1, "avg_cost": 3.41,
+               "breakeven_upside_pct": 10.0, "nav_history": [
         ["2026-07-01", 3.0], ["2026-07-02", 3.1],
     ]}
     source = {"name": gold.XAU_PRIMARY_SOURCE, "points": len(xau)}
@@ -171,6 +172,48 @@ def test_london_payload_persists_reference_and_visible_provenance():
     ]
     assert london["hist_advisory"] == "test advisory"
     assert london["dca_equiv"]["oz_held"] > 0
+    assert london["fund_breakeven_usd_oz"] == 112.2
+    assert london["fund_breakeven_upside_pct"] == 10.0
+
+
+def test_sge_au9999_parser_anchors_on_symbol_not_commented_sequence(monkeypatch):
+    html = """
+    <table><tr>
+      <!-- <td>2</td> -->
+      <td>2026-08-07</td><td>Au99.99</td><td>924.71</td>
+      <td>934.00</td><td>918.00</td><td>930.47</td>
+      <td>4.87</td><td>0.53%</td><td>928.37</td><td>5363.04</td>
+    </tr></table>
+    """
+    monkeypatch.setattr(gold, "_curl", lambda *_args, **_kwargs: html)
+
+    quote = gold.fetch_au9999_daily("2026-08-07")
+
+    assert quote["price_cny_g"] == 930.47
+    assert quote["date"] == "2026-08-07"
+    assert quote["high_cny_g"] == 934.0
+    assert quote["low_cny_g"] == 918.0
+    assert quote["change_pct"] == 0.53
+    assert quote["source"] == "sge_quotation_daily_new"
+
+
+def test_domestic_gold_maps_true_holding_breakeven_and_retains_last_quote():
+    derived = {"nav": 3.1312, "avg_cost": 3.3653, "breakeven_upside_pct": 7.48}
+    quote = {
+        "symbol": "Au99.99", "price_cny_g": 930.47, "date": "2026-08-07",
+        "source": "sge_quotation_daily_new",
+    }
+
+    fresh = gold.compute_domestic_gold(derived, {}, quote)
+    retained = gold.compute_domestic_gold(
+        derived, {"domestic_gold": fresh}, quote=None)
+
+    assert fresh["breakeven_cny_g"] == 1000.04
+    assert fresh["breakeven_upside_pct"] == 7.48
+    assert fresh["quote_status"] == "fresh"
+    assert retained["price_cny_g"] == 930.47
+    assert retained["date"] == "2026-08-07"
+    assert retained["quote_status"] == "retained"
 
 
 def test_london_payload_serializes_both_histories_within_bound():
@@ -256,3 +299,7 @@ def test_dashboard_drops_internal_history_but_keeps_provenance_contract():
     assert "历史源 ${escapeHtml(" in renderer
     assert 'role="status"' in renderer
     assert "ld.hist_advisory" in renderer
+    assert "国内基准 · 上金所 Au99.99" in renderer
+    assert "我的回本价" in renderer
+    assert "模拟对照 · 若每个基金交易日直接买伦敦金" in renderer
+    assert "同额定投伦敦金 · 我的平均成本" not in renderer


### PR DESCRIPTION
Closes #371

## Summary

- fetch the official SGE Au99.99 close aligned to the latest fund NAV date and retain the last valid quote on fetch failure
- show current Au99.99 and the holding's mapped CNY/g breakeven as the primary domestic benchmark
- show current London gold and the mapped USD/oz breakeven as a secondary benchmark, with the FX/premium assumption made explicit
- move the counterfactual London-gold DCA comparison behind a collapsed disclosure so it is not confused with the actual holding cost
- rebalance the desktop gold card and preserve a no-overflow mobile layout

## Verification

- 40 targeted pytest checks passed after rebasing onto current master
- Python and both dashboard renderer files pass syntax checks
- mutation check: breaking the CNY/g breakeven formula fails the new holding-mapping test
- real-source dry run: Au99.99 930.47 CNY/g maps to 1000.04 CNY/g; XAU 4341.12 USD/oz maps to 4665.68 USD/oz for the current book snapshot
- Playwright at 390 px: page and viewport widths both 390 px; the simulation disclosure is collapsed by default
- pre-push ledger integrity passed; the identical secret scan completed cleanly in 15.9 seconds after the hook's fixed 10-second timeout
