### PR TITLE
script: defer full-tree secret scanning to GitHub

### DIFF
--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -704,6 +704,9 @@ def check_research_artifacts(r):
 
 def main():
     r = Result()
+    # GitHub Secret Scanning + Push Protection own repository-wide credential
+    # detection. The pre-commit hook still scans staged additions locally; do
+    # not put the old full-tree git-grep back into this latency-sensitive hook.
     checks = [
         check_baseline_files,
         check_scripts_compile,
@@ -712,7 +715,6 @@ def main():
         check_plan_json_schema,
         check_dashboard_buildable,
         check_peer_map_coverage,
-        check_no_leaked_secrets,
         check_openclaw_doctor,
         check_decision_ledger,
         check_cron_paths_exist,

--- a/tests/test_secret_leak_scan.py
+++ b/tests/test_secret_leak_scan.py
@@ -170,14 +170,11 @@ def test_clean_repo_reports_ok(sc, monkeypatch, tmp_path):
     assert _scan(sc, monkeypatch, repo).level == sc.OK
 
 
-def test_this_repo_is_clean(sc):
-    """The live tree must stay clean, and the scan must actually run on it."""
-    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_STRICT)
-    assert failure is None, f"strict scan failed to run: {failure}"
-    assert lines == []
-    lines, failure = sc._grep_tracked(sc.SECRET_PATTERNS_LOOSE)
-    assert failure is None, f"loose scan failed to run: {failure}"
-    assert lines == []
+def test_full_repo_scan_is_not_registered_in_system_check(sc):
+    """GitHub push protection owns full-history scanning; the hook must stay fast."""
+    source = Path(sc.__file__).read_text(encoding="utf-8")
+    checks = source.split("\n    checks = [", 1)[1].split("]", 1)[0]
+    assert "check_no_leaked_secrets" not in checks
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #373

## Summary

- stop registering the full-worktree and HEAD credential grep in the pre-push system check
- rely on the repository's enabled GitHub Secret Scanning and Push Protection for repository-wide detection
- retain the local staged-diff secret check and every ledger, build, cron, and data-integrity gate
- replace the slow live-repository scanner test with a contract that prevents accidental re-registration

## Verification

- GitHub repository security settings report Secret Scanning enabled and Push Protection enabled
- the normal pre-push hook now completes with 16 OK, 0 warnings, and 0 critical failures
- 125 focused system-check and hook tests passed
- scripts/system_check.py compiles and the diff passes whitespace validation
