### PR TITLE
feat: add agent-invoked run envelope

### DIFF
--- a/clawock/__init__.py
+++ b/clawock/__init__.py
@@ -1,4 +1,4 @@
-"""clawock — auditable AI portfolio operation.
+"""clawock — portable decision intelligence for external agents.
 
 This package is the part that is meant to be installable and pointed at any
 workspace. Everything under `scripts/` remains the operator-side implementation

--- a/clawock/__main__.py
+++ b/clawock/__main__.py
@@ -1,0 +1,5 @@
+from clawock.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""`clawock` — a verifiable execution harness for external agent runtimes.
+"""`clawock` — portable decision workflows for external agent runtimes.
 
-Create a portable workspace with ``clawock init``. Existing external agents call
-``clawock run`` to certify inputs and validate/publish their artifacts.
+An agent-native plugin kit backed by a verifiable execution harness. Existing
+external agents call ``clawock run`` to certify inputs and validate/publish their
+artifacts; the model, conversation, memory, skills and tool loop stay external.
 The KCNyu live desk also exposes compatibility phase commands while its instance
 code is migrated.
 """
@@ -285,7 +286,8 @@ def main(argv=None) -> int:
     init.add_argument("workspace", type=Path)
     init.set_defaults(func=_init)
 
-    run = sub.add_parser("run", help="certify and publish an external agent run")
+    run = sub.add_parser(
+        "run", help="certify and publish one external decision-workflow run")
     run_steps = run.add_subparsers(dest="run_command", required=True)
     prepare = run_steps.add_parser("prepare", help="emit certified run input as JSON")
     prepare.add_argument("--workspace", type=Path, default=Path.cwd())

--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -46,6 +46,7 @@ def _run_prepare(args) -> int:
         write_generation({
             str(state): json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
         })
+        state.chmod(0o600)
     except (ValueError, OSError) as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
-"""`clawock` — the entry point a stranger reaches for first.
+"""`clawock` — a verifiable execution harness for external agent runtimes.
 
-Today the only honest thing it can do is answer "could this run against my
-book?", which is precisely the question nobody could previously ask: without
-package metadata or a workspace override, the code only ever operated on the
-tree it lived in.
-
-    clawock doctor                      # this checkout
-    clawock doctor --workspace ~/mybook # someone else's
-    CLAWOCK_WORKSPACE=~/mybook clawock doctor
+Create a portable workspace with ``clawock init``. Existing external agents call
+``clawock run`` to certify inputs and validate/publish their artifacts.
+The KCNyu live desk also exposes compatibility phase commands while its instance
+code is migrated.
 """
 from __future__ import annotations
 
@@ -20,6 +16,103 @@ from pathlib import Path
 from clawock.tools import ToolError, build_registry
 from clawock.tools import describe as describe_tools
 from clawock.workspace import ENV_VAR, describe, workspace_root
+
+
+def _init(args) -> int:
+    from clawock.harness.config import initialize
+
+    try:
+        root = initialize(args.workspace)
+    except (ValueError, OSError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"initialized clawock workspace: {root}")
+    print(f"edit {root / 'clawock.json'} and {root / 'CONTEXT.md'}")
+    return 0
+
+
+def _run_prepare(args) -> int:
+    from clawock.harness import AgentRun
+    from clawock.harness.config import load_request
+    from clawock.publish.store import write_generation
+
+    try:
+        request = load_request(args.workspace)
+        prepared = AgentRun().prepare(request)
+        state = request.workspace / ".clawock" / "work" / prepared.run_id / "request.json"
+        payload = prepared.as_dict()
+        payload["request_file"] = str(state)
+        write_generation({
+            str(state): json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        })
+    except (ValueError, OSError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _run_publish(args) -> int:
+    from clawock.context import assemble_explicit
+    from clawock.harness import AgentRun, PreparedRun
+    from clawock.harness.config import load_request
+    from clawock.publish import FilesystemStore
+
+    try:
+        request = load_request(args.workspace)
+        state_path = args.request.expanduser().resolve()
+        state_root = (request.workspace / ".clawock" / "work").resolve()
+        state_path.relative_to(state_root)
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            raise ValueError("prepared request requires schema_version 1")
+        run_id = payload.get("run_id")
+        generation_id = payload.get("generation_id")
+        if not all(
+            isinstance(value, str) and len(value) == 32
+            and all(char in "0123456789abcdef" for char in value)
+            for value in (run_id, generation_id)
+        ):
+            raise ValueError("prepared request has invalid run/generation IDs")
+        if payload.get("task") != request.task:
+            raise ValueError("workspace task changed after this run was prepared")
+        if payload.get("output_directory") != str(request.output_directory):
+            raise ValueError("workspace output directory changed after this run was prepared")
+        if payload.get("metadata") != dict(request.metadata):
+            raise ValueError("workspace metadata changed after this run was prepared")
+        context = assemble_explicit(request.workspace, request.context_files)
+        supplied_context = payload.get("context")
+        if not isinstance(supplied_context, dict) or (
+            supplied_context.get("certificate") != context.certificate()
+        ):
+            raise ValueError("workspace context changed after this run was prepared")
+
+        artifacts: dict[str, str] = {}
+        for item in args.artifact:
+            name, separator, raw_path = item.partition("=")
+            if not separator:
+                raise ValueError(f"--artifact must be NAME=PATH, got {item!r}")
+            source = Path(raw_path).expanduser()
+            if not source.is_absolute():
+                source = request.workspace / source
+            source = source.resolve()
+            source.relative_to(request.workspace)
+            if name in artifacts:
+                raise ValueError(f"duplicate artifact name: {name}")
+            artifacts[name] = source.read_text(encoding="utf-8")
+
+        prepared = PreparedRun(request, context, run_id, generation_id)
+        receipt = AgentRun().publish(
+            prepared,
+            artifacts,
+            FilesystemStore(request.output_directory / run_id),
+        )
+        result = receipt.as_dict()
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if receipt.status == "published" else 1
 
 
 def _doctor(args) -> int:
@@ -188,7 +281,24 @@ def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="clawock", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    doctor = sub.add_parser("doctor", help="can this workspace run the loop?")
+    init = sub.add_parser("init", help="create a standalone clawock workspace")
+    init.add_argument("workspace", type=Path)
+    init.set_defaults(func=_init)
+
+    run = sub.add_parser("run", help="certify and publish an external agent run")
+    run_steps = run.add_subparsers(dest="run_command", required=True)
+    prepare = run_steps.add_parser("prepare", help="emit certified run input as JSON")
+    prepare.add_argument("--workspace", type=Path, default=Path.cwd())
+    prepare.set_defaults(func=_run_prepare)
+    publish = run_steps.add_parser(
+        "publish", help="validate and publish artifacts produced by the calling agent")
+    publish.add_argument("--workspace", type=Path, default=Path.cwd())
+    publish.add_argument("--request", type=Path, required=True)
+    publish.add_argument("--artifact", action="append", default=[], metavar="NAME=PATH")
+    publish.set_defaults(func=_run_publish)
+
+    doctor = sub.add_parser(
+        "doctor", help="audit portfolio and registry prerequisites")
     doctor.add_argument("--workspace", type=Path, default=None)
     doctor.add_argument("--json", action="store_true")
     doctor.set_defaults(func=_doctor)

--- a/clawock/context.py
+++ b/clawock/context.py
@@ -1,10 +1,10 @@
-"""Portable assembly of the context OpenClaw gives a clawock agent.
+"""Certified context assembly for portable and OpenClaw-backed runs.
 
-OpenClaw cron currently injects five root Markdown files by hard-coded name.  It
-does *not* inject MEMORY/HEARTBEAT/BOOTSTRAP, and its skills catalog is an index,
-not the selected skill body.  Those runtime facts remain unchanged; this module
-makes the same contract available to another runner and turns missing root files
-from a silent quality regression into a named error.
+OpenClaw *isolated cron* currently injects five root Markdown files by hard-coded
+name. It does not inject MEMORY/HEARTBEAT/BOOTSTRAP in that profile, and its
+skills catalog is an index, not the selected skill body. Those facts are not a
+claim about normal interactive chat. ``assemble`` reproduces that compatibility
+profile; ``assemble_explicit`` gives another runtime a neutral file contract.
 
 Skill bodies stay lazy.  Loading every SKILL.md would both waste context and
 change normal chat/tool behaviour, so callers must resolve the selected skills
@@ -12,6 +12,7 @@ explicitly after assembling the bootstrap.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from importlib.resources import files
@@ -23,6 +24,10 @@ class ContextDocument:
     name: str
     path: Path
     text: str
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -36,11 +41,22 @@ class ContextBundle:
         parts += [f"# Skill: {doc.name}\n\n{doc.text.rstrip()}" for doc in self.skills]
         return "\n\n".join(parts) + "\n"
 
+    def certificate(self) -> dict:
+        """Content-addressed identity without a runtime-specific profile name."""
+        return {
+            "chars": len(self.text),
+            "sha256": hashlib.sha256(self.text.encode("utf-8")).hexdigest(),
+            "documents": [
+                {"name": doc.name, "chars": len(doc.text), "sha256": doc.sha256}
+                for doc in (*self.documents, *self.skills)
+            ],
+        }
+
     def manifest(self) -> dict:
         return {
             "bootstrap": [doc.name for doc in self.documents],
             "skills": [doc.name for doc in self.skills],
-            "chars": len(self.text),
+            **self.certificate(),
         }
 
 
@@ -72,6 +88,31 @@ def assemble(workspace, *, skills=()) -> ContextBundle:
         relative = pattern.format(name=name)
         selected.append(_read_required(root / relative, str(name)))
     return ContextBundle(documents, tuple(selected))
+
+
+def assemble_explicit(workspace, documents) -> ContextBundle:
+    """Assemble a runtime-neutral bundle from named workspace documents.
+
+    OpenClaw's five-file bootstrap is one *profile*, not the definition of agent
+    context. A standalone runner needs to say which files form its context
+    without pretending to be OpenClaw or requiring OpenClaw's root filenames.
+    Paths are workspace-relative and may not escape the workspace.
+    """
+    root = Path(workspace).expanduser().resolve()
+    selected = []
+    for raw in dict.fromkeys(str(item) for item in documents):
+        relative = Path(raw)
+        if relative.is_absolute():
+            raise ValueError(f"context path must be workspace-relative: {raw}")
+        path = (root / relative).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"context path escapes workspace: {raw}") from exc
+        selected.append(_read_required(path, relative.as_posix()))
+    if not selected:
+        raise ValueError("at least one context document is required")
+    return ContextBundle(tuple(selected))
 
 
 def audit(workspace) -> dict:

--- a/clawock/harness/__init__.py
+++ b/clawock/harness/__init__.py
@@ -1,10 +1,18 @@
-"""Runtime-neutral harness contracts and the CLI-facing instance adapter.
-
-The package owns lifecycle vocabulary and artifact invariants.  OpenClaw owns
-the conversation/tool loop; the kcn checkout supplies today's heavy pre/post
-flight implementation as an adapter.  No agent loop is reimplemented here.
-"""
-from .model import Artifact, ArtifactSet, RunRequest
+"""Runtime-neutral harness lifecycle plus the live instance compatibility seam."""
+from .agent_run import AgentRun, ArtifactValidator, CoreArtifactValidator, PreparedRun
+from .model import (
+    AgentRunRequest,
+    Artifact,
+    ArtifactSet,
+    RunReceipt,
+    RunRequest,
+    ValidationIssue,
+)
 from .runner import run_phase
 
-__all__ = ["Artifact", "ArtifactSet", "RunRequest", "run_phase"]
+__all__ = [
+    "AgentRun", "AgentRunRequest", "Artifact", "ArtifactSet",
+    "ArtifactValidator", "CoreArtifactValidator", "PreparedRun",
+    "RunReceipt", "RunRequest", "ValidationIssue",
+    "run_phase",
+]

--- a/clawock/harness/agent_run.py
+++ b/clawock/harness/agent_run.py
@@ -1,0 +1,183 @@
+"""The deterministic lifecycle surface called by an external agent runtime."""
+from __future__ import annotations
+
+import json
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+from uuid import uuid4
+
+from clawock.context import ContextBundle, assemble_explicit
+from clawock.harness.model import (
+    AgentRunRequest,
+    Artifact,
+    ArtifactSet,
+    RunReceipt,
+    ValidationIssue,
+)
+from clawock.publish import ArtifactStore
+
+
+MANIFEST_NAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class PreparedRun:
+    """A context-pinned handoff from clawock to the calling external agent."""
+
+    request: AgentRunRequest
+    context: ContextBundle
+    run_id: str
+    generation_id: str
+
+    def __post_init__(self) -> None:
+        for label, value in (("run_id", self.run_id), ("generation_id", self.generation_id)):
+            if not (
+                len(value) == 32
+                and all(character in "0123456789abcdef" for character in value)
+            ):
+                raise ValueError(f"{label} must be a 32-character lowercase hex ID")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "run_id": self.run_id,
+            "generation_id": self.generation_id,
+            "task": self.request.task,
+            "output_directory": str(self.request.output_directory),
+            "context": {
+                "certificate": self.context.certificate(),
+                "documents": [
+                    {"name": document.name, "sha256": document.sha256,
+                     "text": document.text}
+                    for document in self.context.documents
+                ],
+                "skills": [
+                    {"name": skill.name, "sha256": skill.sha256,
+                     "text": skill.text}
+                    for skill in self.context.skills
+                ],
+            },
+            "metadata": dict(self.request.metadata),
+        }
+
+
+class ArtifactValidator(Protocol):
+    name: str
+
+    def validate(self, artifacts: Mapping[str, str]) -> tuple[ValidationIssue, ...]:
+        ...
+
+
+class CoreArtifactValidator:
+    """Reject output that cannot be safely stored as one useful generation."""
+
+    name = "core"
+
+    def validate(self, artifacts: Mapping[str, str]) -> tuple[ValidationIssue, ...]:
+        issues: list[ValidationIssue] = []
+        if not artifacts:
+            issues.append(ValidationIssue(
+                "empty_generation", "external agent supplied no artifacts"))
+        for name, content in artifacts.items():
+            path = Path(name)
+            if (
+                not name
+                or path == Path(".")
+                or path.is_absolute()
+                or ".." in path.parts
+                or path.as_posix() != name
+            ):
+                issues.append(ValidationIssue(
+                    "unsafe_artifact_path",
+                    f"artifact path is not a canonical generation-relative path: {name}",
+                ))
+            if path == Path(MANIFEST_NAME):
+                issues.append(ValidationIssue(
+                    "reserved_artifact_name", f"{MANIFEST_NAME} is owned by clawock"))
+            if not content.strip():
+                issues.append(ValidationIssue(
+                    "empty_artifact", f"artifact is empty: {name}"))
+        return tuple(issues)
+
+
+def _media_type(name: str) -> str:
+    return mimetypes.guess_type(name)[0] or "text/plain"
+
+
+class AgentRun:
+    """Certify and publish an external agent's artifacts without running it.
+
+    OpenClaw, Hermes, Claude Code, Codex or another runtime owns the model,
+    conversation, memory, skills, tools and repair loop. It calls ``prepare``
+    before producing output and ``publish`` after producing or repairing files.
+    """
+
+    def __init__(self, *, validators: tuple[ArtifactValidator, ...] = ()) -> None:
+        self.validators = (CoreArtifactValidator(), *validators)
+
+    def prepare(self, request: AgentRunRequest, *, run_id: str | None = None,
+                generation_id: str | None = None) -> PreparedRun:
+        return PreparedRun(
+            request=request,
+            context=assemble_explicit(request.workspace, request.context_files),
+            run_id=run_id or uuid4().hex,
+            generation_id=generation_id or uuid4().hex,
+        )
+
+    def _issues(self, artifacts: Mapping[str, str]) -> tuple[ValidationIssue, ...]:
+        return tuple(
+            issue
+            for validator in self.validators
+            for issue in validator.validate(artifacts)
+        )
+
+    def publish(self, prepared: PreparedRun, artifacts: Mapping[str, str],
+                store: ArtifactStore) -> RunReceipt:
+        issues = self._issues(artifacts)
+        members = tuple(
+            Artifact(name, Path(name), _media_type(name), prepared.generation_id)
+            for name in artifacts
+        )
+        artifact_set = ArtifactSet(prepared.generation_id, members)
+        artifact_set.validate()
+        if issues:
+            return RunReceipt(
+                run_id=prepared.run_id,
+                generation_id=prepared.generation_id,
+                status="rejected",
+                artifacts=artifact_set,
+                validation_issues=issues,
+            )
+
+        manifest = {
+            "schema_version": 1,
+            "run_id": prepared.run_id,
+            "generation_id": prepared.generation_id,
+            "context": prepared.context.certificate(),
+            "artifacts": [
+                {"name": name, "generation_id": prepared.generation_id}
+                for name in artifacts
+            ],
+            "producer_metadata": dict(prepared.request.metadata),
+        }
+        files: Mapping[str, str] = {
+            **artifacts,
+            MANIFEST_NAME: json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        }
+        published = store.publish(files, label=f"clawock run {prepared.run_id}")
+        final_artifacts = ArtifactSet(prepared.generation_id, (
+            *members,
+            Artifact(MANIFEST_NAME, Path(MANIFEST_NAME),
+                     "application/json", prepared.generation_id),
+        ))
+        final_artifacts.validate()
+        return RunReceipt(
+            run_id=prepared.run_id,
+            generation_id=prepared.generation_id,
+            status="published",
+            artifacts=final_artifacts,
+            publish_receipt=published.receipt,
+            publish_changed=published.changed,
+        )

--- a/clawock/harness/config.py
+++ b/clawock/harness/config.py
@@ -1,0 +1,71 @@
+"""Standalone workspace configuration and initialization."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from clawock.harness.model import AgentRunRequest
+from clawock.publish.store import write_generation
+
+
+CONFIG_NAME = "clawock.json"
+DEFAULT_CONTEXT = "CONTEXT.md"
+
+
+def initialize(workspace: Path | str) -> Path:
+    root = Path(workspace).expanduser().resolve()
+    if root.exists() and any(root.iterdir()):
+        raise ValueError(f"refusing to initialize non-empty directory: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    config = {
+        "schema_version": 1,
+        "task": "Produce a concise answer grounded in the supplied context.",
+        "context": [DEFAULT_CONTEXT],
+        "output_directory": ".clawock/runs",
+    }
+    write_generation({
+        str(root / CONFIG_NAME): json.dumps(config, ensure_ascii=False, indent=2) + "\n",
+        str(root / DEFAULT_CONTEXT): (
+            "# Context\n\n"
+            "Replace this file with the facts and instructions the runtime should use.\n"
+        ),
+    })
+    return root
+
+
+def load_request(workspace: Path | str) -> AgentRunRequest:
+    root = Path(workspace).expanduser().resolve()
+    path = root / CONFIG_NAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"standalone workspace has no {CONFIG_NAME}: {root}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{CONFIG_NAME} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise ValueError(f"{CONFIG_NAME} requires schema_version 1")
+    context = payload.get("context")
+    if not isinstance(context, list) or not all(isinstance(item, str) for item in context):
+        raise ValueError(f"{CONFIG_NAME} context must be a list of paths")
+    output = payload.get("output_directory", ".clawock/runs")
+    if not isinstance(output, str) or not output.strip():
+        raise ValueError(f"{CONFIG_NAME} output_directory must be a relative path")
+    output_path = Path(output)
+    if output_path.is_absolute() or ".." in output_path.parts:
+        raise ValueError(f"{CONFIG_NAME} output_directory must stay inside the workspace")
+    metadata = payload.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{CONFIG_NAME} metadata must be an object")
+    output_resolved = (root / output_path).resolve()
+    try:
+        output_resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{CONFIG_NAME} output_directory resolves outside the workspace") from exc
+    return AgentRunRequest(
+        task=str(payload.get("task", "")),
+        workspace=root,
+        context_files=tuple(context),
+        output_directory=output_resolved,
+        metadata=metadata,
+    )

--- a/clawock/harness/config.py
+++ b/clawock/harness/config.py
@@ -34,6 +34,9 @@ def initialize(workspace: Path | str) -> Path:
             "# Context\n\n"
             "Replace this file with the facts and instructions the runtime should use.\n"
         )
+    local_ignore = root / ".clawock" / ".gitignore"
+    if not local_ignore.exists():
+        writes[str(local_ignore)] = "*\n!.gitignore\n"
     write_generation(writes)
     return root
 

--- a/clawock/harness/config.py
+++ b/clawock/harness/config.py
@@ -14,22 +14,27 @@ DEFAULT_CONTEXT = "CONTEXT.md"
 
 def initialize(workspace: Path | str) -> Path:
     root = Path(workspace).expanduser().resolve()
-    if root.exists() and any(root.iterdir()):
-        raise ValueError(f"refusing to initialize non-empty directory: {root}")
     root.mkdir(parents=True, exist_ok=True)
+    if (root / CONFIG_NAME).exists():
+        raise ValueError(f"refusing to overwrite existing {CONFIG_NAME}: {root}")
     config = {
         "schema_version": 1,
         "task": "Produce a concise answer grounded in the supplied context.",
         "context": [DEFAULT_CONTEXT],
         "output_directory": ".clawock/runs",
     }
-    write_generation({
+    writes = {
         str(root / CONFIG_NAME): json.dumps(config, ensure_ascii=False, indent=2) + "\n",
-        str(root / DEFAULT_CONTEXT): (
+    }
+    # A plugin normally joins an existing agent workspace. Preserve its files
+    # and reuse an existing CONTEXT.md instead of requiring an empty directory
+    # or replacing context that the external runtime already owns.
+    if not (root / DEFAULT_CONTEXT).exists():
+        writes[str(root / DEFAULT_CONTEXT)] = (
             "# Context\n\n"
             "Replace this file with the facts and instructions the runtime should use.\n"
-        ),
-    })
+        )
+    write_generation(writes)
     return root
 
 

--- a/clawock/harness/model.py
+++ b/clawock/harness/model.py
@@ -1,8 +1,10 @@
-"""Small contracts shared by runners, validators and publishers."""
+"""Contracts shared by external callers, validators and publishers."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, Mapping
 
 
 WORKFLOWS = ("brief", "report", "intraday")
@@ -45,3 +47,65 @@ class ArtifactSet:
         if mismatched:
             raise ValueError(
                 "mixed artifact generations: " + ", ".join(mismatched))
+
+
+@dataclass(frozen=True)
+class AgentRunRequest:
+    """The deterministic inputs an external agent asks clawock to certify."""
+
+    task: str
+    workspace: Path
+    context_files: tuple[str, ...]
+    output_directory: Path
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.task.strip():
+            raise ValueError("agent run task is empty")
+        if not self.context_files:
+            raise ValueError("agent run has no context files")
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RunReceipt:
+    run_id: str
+    generation_id: str
+    status: str
+    artifacts: ArtifactSet
+    validation_issues: tuple[ValidationIssue, ...] = ()
+    publish_receipt: str | None = None
+    publish_changed: bool = False
+    created_at: str = field(
+        default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds"))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "run_id": self.run_id,
+            "generation_id": self.generation_id,
+            "status": self.status,
+            "created_at": self.created_at,
+            "artifacts": [
+                {
+                    "name": artifact.name,
+                    "path": str(artifact.path),
+                    "media_type": artifact.media_type,
+                    "generation_id": artifact.generation_id,
+                }
+                for artifact in self.artifacts.artifacts
+            ],
+            "validation_issues": [
+                {"code": issue.code, "message": issue.message}
+                for issue in self.validation_issues
+            ],
+            "publish": {
+                "receipt": self.publish_receipt,
+                "changed": self.publish_changed,
+            },
+        }

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -1,21 +1,25 @@
 # Harness architecture
 
-clawock is an auditable agent harness for portfolio operation, with a
-context-certification layer. It is not an agent orchestration framework: it does
-not implement model routing, a ReAct loop or conversation memory. The external
-agent/runtime remains complete in itself; clawock is the verifiable execution
-envelope around it.
+clawock is an agent-native decision-workflow plugin kit backed by a verifiable
+harness. It packages reusable skills, tool contracts and decision workflows for
+external agents. It is not an agent orchestration framework: it does not
+implement model routing, a ReAct loop or conversation memory. The external
+agent/runtime remains complete in itself.
 
 The runtime is intentionally external. OpenClaw, Hermes, Claude Code, Codex,
 LangGraph or another runner may own the conversation, model and tools; clawock
-wraps that run with certified input, deterministic artifacts, reconciliation,
-validation and publication receipts.
+calls clawock for workflow steps, certified input, deterministic reconciliation,
+validation, outcome evaluation and publication receipts.
+
+A generation is the correlated audit unit emitted by one workflow run, not the
+product itself. The product-level loop is evidence → debate/workflow → decision →
+execution/outcome → bounded, reviewable improvement proposal.
 
 ## Ownership
 
 | Layer | Owns | Current location |
 |---|---|---|
-| Harness core | complete `AgentRun` lifecycle, generation-pinned artifact contract, validation/repair, context assembly, tool schemas | `clawock/` |
+| Plugin/harness core | portable skills/workflows, generation-pinned artifact contract, validation/reconciliation, context assembly, tool schemas, evaluation contracts | `clawock/` + portable skill/workflow packages (in progress) |
 | Instance | portfolio, schedules, selected skills/persona, delivery targets, dashboard skin | root data + `config/` + `skills/` |
 | Runtime adapters | conversations, scheduling, delivery, run history | OpenClaw today; provider interfaces in `clawock/providers/` |
 | Live desk adapter | market refresh, `.tmp` artifact placement, git coordination, publication/watchdogs | `scripts/harness/` |

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -2,14 +2,20 @@
 
 clawock is an auditable agent harness for portfolio operation, with a
 context-certification layer. It is not an agent orchestration framework: it does
-not implement model routing, a ReAct loop or conversation memory. A complete
-agent is **clawock + model + runtime**.
+not implement model routing, a ReAct loop or conversation memory. The external
+agent/runtime remains complete in itself; clawock is the verifiable execution
+envelope around it.
+
+The runtime is intentionally external. OpenClaw, Hermes, Claude Code, Codex,
+LangGraph or another runner may own the conversation, model and tools; clawock
+wraps that run with certified input, deterministic artifacts, reconciliation,
+validation and publication receipts.
 
 ## Ownership
 
 | Layer | Owns | Current location |
 |---|---|---|
-| Harness core | lifecycle vocabulary, generation-pinned artifact contract, validation, context assembly, tool schemas | `clawock/` |
+| Harness core | complete `AgentRun` lifecycle, generation-pinned artifact contract, validation/repair, context assembly, tool schemas | `clawock/` |
 | Instance | portfolio, schedules, selected skills/persona, delivery targets, dashboard skin | root data + `config/` + `skills/` |
 | Runtime adapters | conversations, scheduling, delivery, run history | OpenClaw today; provider interfaces in `clawock/providers/` |
 | Live desk adapter | market refresh, `.tmp` artifact placement, git coordination, publication/watchdogs | `scripts/harness/` |
@@ -17,23 +23,35 @@ agent is **clawock + model + runtime**.
 The public CLI is the stable driver boundary:
 
 ```text
+clawock init <workspace>
+clawock run prepare --workspace <workspace>
+clawock run publish --workspace <workspace> --request <json> --artifact <name=path>
 clawock context audit|assemble
 clawock brief preflight|postflight
 clawock report preflight|postflight
 clawock intraday preflight|postflight
 ```
 
-The workflow commands dispatch in-process; they do not shell out to the old
-scripts. The live implementation remains an instance adapter during the
-strangler migration, which preserves the old Python entry points for GitHub
-workflows and operational rollback.
+`init` and `run` are package-native and work from an installed wheel outside the
+repository. The control direction is external agent → clawock, like an
+agent-native business CLI. `run prepare` emits certified input; the calling agent
+keeps its own model, conversation, memory, skills, tools and repair loop; `run
+publish` validates/reconciles its files and atomically emits generation-pinned
+artifacts plus a receipt. clawock never launches the agent.
+
+The live workflow phase commands dispatch in-process but currently resolve the
+KCNyu implementation from `scripts/harness`. They are a compatibility seam, not
+standalone wheel functionality. The old Python entry points remain available for
+OpenClaw, GitHub workflows and operational rollback until the instance adapter
+cutover is complete.
 
 ## Context contract
 
-OpenClaw 2026.7.1 injects, in order, `AGENTS.md`, `TOOLS.md`, `SOUL.md`,
-`IDENTITY.md`, and `USER.md`. It excludes `MEMORY.md`, `HEARTBEAT.md`, and
-`BOOTSTRAP.md`. `clawock/context_manifest.json` records that exact runtime rule;
-CI fails when an injected file disappears or becomes empty.
+OpenClaw 2026.7.1 isolated cron injects, in order, `AGENTS.md`, `TOOLS.md`,
+`SOUL.md`, `IDENTITY.md`, and `USER.md`. That profile excludes `MEMORY.md`,
+`HEARTBEAT.md`, and `BOOTSTRAP.md`; normal chat, heartbeat and bootstrap have
+different context behavior. `clawock/context_manifest.json` records the isolated
+cron rule, and CI fails when one of those injected files disappears or is empty.
 
 `clawock context assemble` gives another runner the equivalent bootstrap. Skill
 bodies remain lazy: the catalog is only an index, and only an explicitly selected
@@ -43,6 +61,11 @@ silently loading every skill into every run.
 Those five root files must not move while OpenClaw hard-codes their names. The
 manifest owns the portable definition and audit gate; it cannot make an old
 OpenClaw binary consume a different path.
+
+Standalone runs instead list context files in `clawock.json`. Every document and
+the assembled bundle receive SHA-256 certification in the runtime request and
+published manifest. The command protocols are specified in
+[`runtime-protocol.md`](runtime-protocol.md).
 
 ## Artifact contract
 

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -1,13 +1,16 @@
 # External agent invocation protocol
 
-`clawock` is not an agent, model client or agent launcher. It is a deterministic
-CLI/tool surface called by an existing external agent runtime. OpenClaw, Hermes,
+`clawock` is an agent-native decision-workflow plugin kit, not an agent, model
+client or agent launcher. Its deterministic CLI/tool surface is called by an
+existing external agent runtime. OpenClaw, Hermes,
 Claude Code, Codex, LangGraph or another runtime keeps its conversation, memory,
 skills, routing, ReAct and tool loop.
 
 In short: **built for agents, not an agent**. This follows the same agent-native
 CLI principle as Lark CLI at a different layer: Lark exposes business operations
-to an agent, while clawock certifies, validates and publishes a whole generation.
+to an agent, while clawock packages decision workflows and certifies, validates,
+reconciles and evaluates their outputs. A generation is one audit unit, not the
+whole product.
 
 ## Prepare
 

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -27,6 +27,9 @@ clawock run prepare --workspace ./my-workspace
 contains a run ID, generation ID, task, context documents, per-document SHA-256
 hashes and a hash of the assembled context. The external agent reads that input
 using its normal conversation, skills and tools; clawock performs no inference.
+Because the local request contains the full context text, it is written with
+owner-only permissions and `.clawock/work/` is ignored by the workspace-local
+`.clawock/.gitignore`. Published manifests contain hashes, not the context body.
 
 ## Validate and publish
 

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -14,7 +14,9 @@ whole product.
 
 ## Prepare
 
-Initialize a workspace once, then ask clawock to prepare a run:
+Initialize clawock in a new or existing agent workspace, then ask it to prepare a
+run. Initialization preserves every existing project/context file and refuses to
+overwrite an existing `clawock.json`:
 
 ```bash
 clawock init ./my-workspace

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -1,0 +1,50 @@
+# External agent invocation protocol
+
+`clawock` is not an agent, model client or agent launcher. It is a deterministic
+CLI/tool surface called by an existing external agent runtime. OpenClaw, Hermes,
+Claude Code, Codex, LangGraph or another runtime keeps its conversation, memory,
+skills, routing, ReAct and tool loop.
+
+In short: **built for agents, not an agent**. This follows the same agent-native
+CLI principle as Lark CLI at a different layer: Lark exposes business operations
+to an agent, while clawock certifies, validates and publishes a whole generation.
+
+## Prepare
+
+Initialize a workspace once, then ask clawock to prepare a run:
+
+```bash
+clawock init ./my-workspace
+clawock run prepare --workspace ./my-workspace
+```
+
+`prepare` prints JSON and stores the same request beneath `.clawock/work/`. It
+contains a run ID, generation ID, task, context documents, per-document SHA-256
+hashes and a hash of the assembled context. The external agent reads that input
+using its normal conversation, skills and tools; clawock performs no inference.
+
+## Validate and publish
+
+After the external agent writes one or more text artifacts inside the workspace,
+it calls:
+
+```bash
+clawock run publish \
+  --workspace ./my-workspace \
+  --request ./my-workspace/.clawock/work/<run-id>/request.json \
+  --artifact response.md=./response.md
+```
+
+The request is rejected if the configured task or certified context changed
+after preparation. Artifact names must be canonical relative paths inside one
+generation; empty artifacts, traversal and the reserved `manifest.json` name are
+rejected. Rejections are structured JSON for the external agent's own repair
+loop. Nothing is published while validation fails.
+
+On success the configured store receives one write set, including a
+`manifest.json` that pins every artifact and context hash to one generation ID.
+The JSON receipt reports the final location and whether anything changed.
+
+Artifact source paths are restricted to the workspace. The external runtime
+retains responsibility for its own credentials and permissions; clawock neither
+starts it nor receives its provider stderr.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "clawock"
 version = "0.1.0"
-description = "Verifiable execution harness for external agent runtimes"
+description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "clawock"
 version = "0.1.0"
-description = "Auditable agent harness for portfolio operation with context certification"
+description = "Verifiable execution harness for external agent runtimes"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -59,6 +59,17 @@ def test_instance_adapter_receives_workspace_without_leaking_env(monkeypatch, tm
     assert "CLAWOCK_WORKSPACE" not in os.environ
 
 
+def test_init_joins_an_existing_agent_workspace_without_overwriting(tmp_path):
+    context = tmp_path / "CONTEXT.md"
+    context.write_text("runtime-owned context\n")
+    (tmp_path / "AGENTS.md").write_text("runtime-owned instructions\n")
+
+    assert main(["init", str(tmp_path)]) == 0
+    assert context.read_text() == "runtime-owned context\n"
+    assert (tmp_path / "AGENTS.md").read_text() == "runtime-owned instructions\n"
+    assert (tmp_path / "clawock.json").exists()
+
+
 def test_external_agent_can_repair_then_publish_one_certified_generation(tmp_path):
     (tmp_path / "CONTEXT.md").write_text("source fact\n")
     output = tmp_path / "out"

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -1,10 +1,13 @@
 """Small contract tests for the package harness boundary (#365)."""
 import ast
+import json
 import os
 from pathlib import Path
 
 from clawock.cli import main
+from clawock.harness import AgentRun, AgentRunRequest
 from clawock.harness.model import Artifact, ArtifactSet
+from clawock.publish import FilesystemStore
 
 
 def test_cli_dispatches_a_preflight_in_process(monkeypatch):
@@ -54,3 +57,30 @@ def test_instance_adapter_receives_workspace_without_leaking_env(monkeypatch, tm
     assert runner.run_phase("brief", "preflight", workspace=tmp_path) == 0
     assert seen["workspace"] == str(tmp_path.resolve())
     assert "CLAWOCK_WORKSPACE" not in os.environ
+
+
+def test_external_agent_can_repair_then_publish_one_certified_generation(tmp_path):
+    (tmp_path / "CONTEXT.md").write_text("source fact\n")
+    output = tmp_path / "out"
+    harness = AgentRun()
+    prepared = harness.prepare(AgentRunRequest(
+        task="answer from context",
+        workspace=tmp_path,
+        context_files=("CONTEXT.md",),
+        output_directory=output,
+    ))
+
+    rejected = harness.publish(prepared, {"answer.md": ""}, FilesystemStore(output))
+    assert rejected.status == "rejected"
+    assert rejected.validation_issues[0].code == "empty_artifact"
+    assert not output.exists()
+
+    receipt = harness.publish(
+        prepared, {"answer.md": "grounded answer\n"}, FilesystemStore(output))
+    assert receipt.status == "published"
+    assert {item.generation_id for item in receipt.artifacts.artifacts} == {
+        receipt.generation_id}
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert manifest["generation_id"] == receipt.generation_id
+    assert manifest["context"]["documents"][0]["name"] == "CONTEXT.md"
+    assert len(manifest["context"]["documents"][0]["sha256"]) == 64

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -68,6 +68,7 @@ def test_init_joins_an_existing_agent_workspace_without_overwriting(tmp_path):
     assert context.read_text() == "runtime-owned context\n"
     assert (tmp_path / "AGENTS.md").read_text() == "runtime-owned instructions\n"
     assert (tmp_path / "clawock.json").exists()
+    assert (tmp_path / ".clawock/.gitignore").read_text() == "*\n!.gitignore\n"
 
 
 def test_external_agent_can_repair_then_publish_one_certified_generation(tmp_path):

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -24,6 +24,7 @@ source tree can replace it, because the source tree is the thing that lied.
 Mutation check: pin the declaration back to `packages = ["clawock"]` and this
 goes red on the first subpackage.
 """
+import json
 import shutil
 import subprocess
 import sys
@@ -122,3 +123,43 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
         "the run-history provider is importable from the wheel but not callable "
         "there, so it is a provider only where the checkout happens to be:\n"
         + done.stderr[-2000:])
+
+    # Importability still is not the product claim. Drive the complete portable
+    # lifecycle exactly as an external agent does from the installed wheel:
+    # init -> certified prepare -> agent-owned output -> validate/publication.
+    workspace = tmp_path / "book"
+    clean_env = {
+        "PYTHONPATH": str(site), "PATH": "/usr/bin:/bin",
+        "LC_ALL": "C.UTF-8", "PYTHONIOENCODING": "utf-8",
+    }
+    initialized = subprocess.run(
+        [sys.executable, "-m", "clawock", "init", str(workspace)],
+        cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
+    assert initialized.returncode == 0, initialized.stderr
+
+    prepared = subprocess.run(
+        [sys.executable, "-m", "clawock", "run", "prepare",
+         "--workspace", str(workspace)],
+        cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
+    assert prepared.returncode == 0, prepared.stderr
+    request = json.loads(prepared.stdout)
+    assert request["context"]["documents"][0]["sha256"]
+
+    # This write stands in for output produced by OpenClaw, Hermes, Claude Code,
+    # Codex or any other caller. clawock does not start that agent.
+    answer = workspace / "answer.md"
+    answer.write_text(request["context"]["documents"][0]["text"].strip() + "\n")
+    completed = subprocess.run(
+        [sys.executable, "-m", "clawock", "run", "publish",
+         "--workspace", str(workspace), "--request", request["request_file"],
+         "--artifact", "answer.md=answer.md"],
+        cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
+    assert completed.returncode == 0, completed.stderr
+    receipt = json.loads(completed.stdout)
+    assert receipt["status"] == "published"
+    published = Path(receipt["publish"]["receipt"])
+    manifest = json.loads((published / "manifest.json").read_text())
+    assert (published / "answer.md").read_text().startswith("# Context")
+    assert manifest["generation_id"] == receipt["generation_id"]
+    assert {item["generation_id"] for item in receipt["artifacts"]} == {
+        receipt["generation_id"]}


### PR DESCRIPTION
## Summary

- add a package-native `init -> prepare -> publish` lifecycle that works from a non-editable wheel outside the repository
- establish the base envelope for an agent-native decision-workflow plugin kit; a generation is an audit unit, not the product definition
- make the control direction explicit: OpenClaw, Hermes, Claude Code, Codex, or another external agent calls clawock; clawock never launches an agent or calls a model
- certify the selected context and every published generation with correlated SHA-256 and generation IDs
- reject empty/unsafe artifacts without publishing, then allow the external agent's own repair loop to resubmit
- document that OpenClaw's five-file rule is an isolated-cron profile, not the normal chat/memory/skills contract

## Why this slice

This establishes the portable deterministic envelope without moving the live KCNyu/OpenClaw workflow implementation. The legacy `brief`, `report`, and `intraday` phase commands remain compatibility seams backed by `scripts/harness`.

This PR does **not** close #379: it does not publish to PyPI, extract all portable live pre/postflight logic, or prove a real second agent calling the CLI. The earlier reverse-direction `clawock -> codex exec` experiment is intentionally not claimed as product evidence.

## Evidence

- 29 focused package/context/store/wheel contract checks passed
- follow-up isolated wheel and CLI checks: 6 passed
- `python -m clawock --help` and `python -m clawock run --help` expose the agent-invoked boundary
- installed-wheel smoke runs `init -> prepare -> external artifact -> validate/publish` with no source checkout, `scripts`, Git, GitHub, or OpenClaw dependency
- rejected artifacts produce no output directory; successful artifacts and `manifest.json` carry the same generation ID

Refs #378
Refs #379
