### PR TITLE
fix: fail closed on dashboard publish errors

### DIFF
--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -375,8 +375,9 @@ def check_dashboard_build():
 
     Returns a dict with keys: state
     ('ok'|'repaired'|'degraded'|'stale'|'failed'|'absent'), detail, ok,
-    warn_count, repair_count, age_hours. A 'failed' build means dashboard.json is
-    frozen while commits keep flowing — the silent-freeze case this guards against.
+    warn_count, repair_count, age_hours. A failed build or publish means the
+    public generation may be frozen while commits keep flowing — the silent-freeze
+    case this guards against.
     """
     path = WS / 'logs' / 'dashboard_build_status.json'
     if not path.exists():
@@ -394,9 +395,19 @@ def check_dashboard_build():
     except Exception:
         pass
     if not st.get('ok'):
-        return {'state': 'failed', 'detail': f"build FAILED — dashboard.json frozen. tail: {st.get('tail','')[-160:]}",
+        build_ok = st.get('build_ok')
+        publish_ok = st.get('publish_ok')
+        if build_ok is True and publish_ok is False:
+            failure = 'data-plane publish FAILED — public generation may be stale'
+        elif build_ok is False:
+            failure = 'dashboard build FAILED — no generation was produced'
+        else:
+            # Rolling-upgrade compatibility for the old one-bit status file.
+            failure = 'dashboard build/publish FAILED — public generation may be stale'
+        return {'state': 'failed', 'detail': f"{failure}. tail: {st.get('tail','')[-500:]}",
                 'ok': False, 'warn_count': st.get('warn_count', 0),
-                'repair_count': st.get('repair_count', 0), 'age_hours': age_hours}
+                'repair_count': st.get('repair_count', 0), 'age_hours': age_hours,
+                'build_ok': build_ok, 'publish_ok': publish_ok}
     if st.get('warn_count'):
         return {'state': 'degraded', 'detail': f"{st['warn_count']} degraded section(s) on last build",
                 'ok': True, 'warn_count': st['warn_count'],

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -203,8 +203,8 @@ def sync_gha_data_files(ws=None):
         return False, str(e)
 
 
-def _record_dashboard_build(ok, output, ws=None):
-    """Persist the last build_dashboard outcome to logs/dashboard_build_status.json.
+def _record_dashboard_build(build_ok, publish_ok, output, ws=None):
+    """Persist build *and* publication outcomes to the dashboard status file.
 
     Why: report_postflight / brief_postflight call rebuild_dashboard() and discard
     the return value, so a hard crash (returncode!=0) or a silent section
@@ -230,19 +230,32 @@ def _record_dashboard_build(ok, output, ws=None):
         repair_count = sum(
             1 for ln in (output or '').splitlines() if 'repair:' in ln
         )
+        ok = bool(build_ok and publish_ok)
         status = {
             'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-            'ok': bool(ok),
+            'ok': ok,
+            'build_ok': bool(build_ok),
+            # None means publication was not attempted because the build itself
+            # failed. Keeping that distinct from a rejected push makes the next
+            # operator action unambiguous.
+            'publish_ok': None if publish_ok is None else bool(publish_ok),
             'warn_count': warn_count,
             'repair_count': repair_count,
-            'tail': (output or '')[-500:],
+            # Git hooks and remote rules print the useful cause *before* their
+            # generic "failed to push" footer. The old 500-char tail hid it.
+            'tail': (output or '')[-4000:],
         }
         path = ws / DASHBOARD_BUILD_STATUS
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(status, ensure_ascii=False, indent=2))
-        if not ok:
-            print(f'🔴 build_dashboard FAILED — recorded to {DASHBOARD_BUILD_STATUS}; '
-                  f'dashboard.json NOT refreshed. tail: {(output or "")[-200:]}',
+        if not build_ok:
+            print(f'🔴 dashboard build FAILED — recorded to {DASHBOARD_BUILD_STATUS}; '
+                  f'local outputs were not refreshed. tail: {(output or "")[-500:]}',
+                  file=sys.stderr)
+        elif not publish_ok:
+            print(f'🔴 data-plane publish FAILED — recorded to '
+                  f'{DASHBOARD_BUILD_STATUS}; local outputs were rebuilt but the '
+                  f'public generation may be stale. tail: {(output or "")[-500:]}',
                   file=sys.stderr)
         elif warn_count:
             print(f'⚠️  build_dashboard ok but {warn_count} degraded section(s) — '
@@ -264,8 +277,10 @@ def rebuild_dashboard(ws=None):
     Records the outcome via _record_dashboard_build so a failure is observable in
     the daily cron health check even when callers discard the return value.
 
-    Returns (ok, last_300_chars_of_output). Failure is non-fatal — caller
-    should log but not abort the commit pipeline.
+    Returns (ok, diagnostic_output). ``ok`` covers both the local build and the
+    data-plane publication. A publication fault must not prevent report delivery,
+    but callers must surface it as an operational failure so cron retries and
+    health checks cannot turn a frozen public dashboard green.
     """
     ws = ws or WS
     refresh_today_snapshot(ws)
@@ -303,14 +318,17 @@ def rebuild_dashboard(ws=None):
              '--previous', str(previous / 'assets' / 'data' / 'dashboard.json')],
             capture_output=True, text=True, timeout=30, cwd=str(ws),
         )
-        ok = r.returncode == 0
+        build_ok = r.returncode == 0
+        publish_ok = None
         full = r.stdout + r.stderr
-        if ok:
-            full += _publish_generation(ws)
-        _record_dashboard_build(ok, full, ws)
-        return ok, full[-300:]
+        if build_ok:
+            publish_ok, publish_detail = _publish_generation(ws)
+            full += publish_detail
+        ok = bool(build_ok and publish_ok)
+        _record_dashboard_build(build_ok, publish_ok, full, ws)
+        return ok, full[-2000:]
     except Exception as e:
-        _record_dashboard_build(False, str(e), ws)
+        _record_dashboard_build(False, None, str(e), ws)
         return False, str(e)
 
 
@@ -328,10 +346,9 @@ def _publish_generation(ws):
     postflight gets this by construction. A hand-maintained list of callers is
     exactly what missed three postflights in #319 and had to be repaired in #322.
 
-    Non-fatal, and loud. These callers deliver reports; a publishing fault must
-    not take the report's own commit and push down with it. The outcome rides in
-    the build record, so a failure is visible to the daily cron health check
-    rather than only in a log nobody opens.
+    Returns ``(ok, detail)``. These callers deliver reports; a publishing fault
+    must not take report delivery down with it, but it is still a failed
+    postflight and must be visible to cron retry/health surfaces.
 
     Idempotent: the store compares against what the branch actually holds, so an
     interleaved scheduled tick makes this a no-op rather than a conflict — which
@@ -343,14 +360,33 @@ def _publish_generation(ws):
             capture_output=True, text=True, timeout=120, cwd=str(ws),
         )
     except Exception as e:                       # noqa: BLE001 - reported, not raised
-        return f'\n  data-plane publish failed: {e}'
+        return False, f'\n  data-plane publish failed: {e}'
     # A failed git push ends with a generic one-line summary. The hook/remote
     # reason precedes it, so 200 characters erased the only actionable evidence
     # in the 2026-08-08 data-plane freeze (#370).
     tail = (r.stdout + r.stderr).strip()[-2000:]
     if r.returncode != 0:
-        return f'\n  data-plane publish failed: {tail}'
-    return f'\n  {tail}'
+        return False, f'\n  data-plane publish failed: {tail}'
+    return True, f'\n  {tail}'
+
+
+def dashboard_publication_state(ws=None):
+    """Return the last explicit data-plane outcome for postflight wiring.
+
+    Older status files only carried ``ok``; treating an old ``ok=true`` record as
+    published keeps rolling upgrades compatible. New records distinguish a
+    failed local build from a failed public push.
+    """
+    ws = ws or WS
+    try:
+        status = json.loads((ws / DASHBOARD_BUILD_STATUS).read_text())
+    except Exception:
+        return 'unavailable'
+    if status.get('build_ok', status.get('ok')) is not True:
+        return 'rebuild_failed'
+    if status.get('publish_ok', status.get('ok')) is not True:
+        return 'publish_failed'
+    return 'published'
 
 
 def push_with_rebase_retry(remote='origin', branch='master', attempts=3):

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -457,6 +457,7 @@ from clawock.validation import (  # noqa: E402
     check_md_table_column_consistency,
 )
 from _harness_common import (  # noqa: E402
+    dashboard_publication_state,
     git_cmd as _git,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -752,6 +753,10 @@ def main(argv=None):
                          + '\n\n')
 
     commit_ok, commit_msg = maybe_commit(status, today, dry_run=args.dry_run)
+    if status in ('pass', 'warn') and not args.dry_run:
+        data_plane_status = dashboard_publication_state(WS)
+    else:
+        data_plane_status = 'skipped'
 
     # ── WeChat delivery (decoupled from the cron's announce) ──────────────────
     # The cron now runs delivery=none. The announce used to fire at the END of a
@@ -824,6 +829,7 @@ def main(argv=None):
         'wechat_sent':   wechat_sent,
         'commit_ok':     commit_ok,
         'commit_msg':    commit_msg,
+        'data_plane_status': data_plane_status,
         'projection_status': projection_status,
         'projection_issues': projection_issues,
         'readability': readability,
@@ -837,7 +843,11 @@ def main(argv=None):
     workflow_outcomes.record_stage(
         job_name,
         'postflight',
-        'success' if status == 'pass' else ('warning' if status == 'warn' else 'failed'),
+        ('success'
+         if status == 'pass' and data_plane_status in {'published', 'skipped'}
+         else ('warning'
+               if status == 'warn' and data_plane_status in {'published', 'skipped'}
+               else 'failed')),
         slot=slot,
         dry_run=args.dry_run,
         issue_count=len(issues),
@@ -854,6 +864,9 @@ def main(argv=None):
         channel='wechat_or_telegram',
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
+    if (not args.dry_run and status in ('pass', 'warn')
+            and data_plane_status != 'published'):
+        return 2
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)
 
 

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -56,6 +56,7 @@ from clawock.validation import (  # noqa: E402
     validate_forbidden_phrases,
 )
 from _harness_common import (  # noqa: E402
+    dashboard_publication_state,
     git_cmd,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -277,8 +278,7 @@ def publish_data_plane(market):
     """Publish deterministic dashboard outputs, independent of prose quality."""
     try:
         ok, _ = rebuild_dashboard()
-        if not ok:
-            return 'rebuild_failed', False
+        publication_state = dashboard_publication_state(WS)
         # No dashboard outputs here: #314 untracked them, and `git add` on a
         # gitignored path fails rather than skipping, which would abort the
         # snapshot commit too.
@@ -292,7 +292,7 @@ def publish_data_plane(market):
         # git diff --cached --quiet returns 0 when there is NO diff
         clean, _ = git_cmd('diff', '--cached', '--quiet', '--', *paths)
         if clean:
-            return 'current', False
+            return ('current', False) if ok else (publication_state, False)
         msg = (
             f"dashboard: intraday refresh "
             f"({market} {datetime.now().strftime('%H:%M HKT')})"
@@ -301,7 +301,12 @@ def publish_data_plane(market):
         if not committed:
             return 'commit_failed', False
         pushed, _ = push_with_rebase_retry()
-        return ('published', True) if pushed else ('committed_local', False)
+        if not pushed:
+            return 'committed_local', False
+        # The status file must reach master even when the data-plane push failed;
+        # otherwise the off-host health check keeps reading the previous green
+        # record. Report the actual public outcome after that diagnostic commit.
+        return ('published', True) if ok else (publication_state, False)
     except Exception as exc:
         print(f'warn: dashboard auto-publish failed: {exc}', file=sys.stderr)
         return 'publish_failed', False
@@ -490,7 +495,13 @@ def main(argv=None):
         'insights_sidecar': insights_written,
     }
     heartbeat = ctx.get('heartbeat') or {}
-    heartbeat_state = 'completed' if data_plane_ready else 'postflight_failed'
+    publication_ok = data_plane_status in {'published', 'current'}
+    if data_plane_ready and publication_ok:
+        heartbeat_state = 'completed'
+    elif data_plane_ready:
+        heartbeat_state = 'publish_failed'
+    else:
+        heartbeat_state = 'postflight_failed'
     cron_heartbeat.record(
         args.market,
         heartbeat_state,
@@ -505,6 +516,8 @@ def main(argv=None):
         'state': heartbeat_state,
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not publication_ok:
+        return 2
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)
 
 

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -115,6 +115,7 @@ from clawock.validation import (  # noqa: E402
     validate_forbidden_phrases,
 )
 from _harness_common import (  # noqa: E402
+    dashboard_publication_state,
     git_cmd as _git,
     push_with_rebase_retry,
     rebuild_dashboard,
@@ -265,6 +266,7 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
 
 def maybe_commit(status, commit_msg):
     rebuild_ok, _ = rebuild_dashboard()
+    publication_state = dashboard_publication_state(WS)
     suffix = {
         'warn': ' (validation warnings)',
         'fail': ' (data only; prose rejected)',
@@ -287,7 +289,7 @@ def maybe_commit(status, commit_msg):
     commit_paths = add_args[1:]
     ok, out = _git('commit', '-m', f'{commit_msg}{suffix}', '--', *commit_paths)
     if not ok and 'nothing to commit' in out:
-        return True, 'nothing to commit (idempotent)'
+        return True, f'nothing to commit (idempotent; dashboard={publication_state})'
     if not ok:
         return False, out[-200:]
 
@@ -296,18 +298,23 @@ def maybe_commit(status, commit_msg):
     if push_ok:
         if rebuild_ok:
             return True, 'committed + pushed'
-        return True, 'committed + pushed (dashboard rebuild failed)'
-    return True, f'committed (push failed: {push_out[-150:]})'
+        return True, f'committed + pushed (dashboard={publication_state})'
+    return True, (f'committed (push failed: {push_out[-150:]}; '
+                  f'dashboard={publication_state})')
 
 
 def classify_data_plane(commit_ok, commit_msg):
     """Return an explicit publication state independent of prose validation."""
     if not commit_ok:
         return 'failed'
+    if 'dashboard=publish_failed' in commit_msg:
+        return 'publish_failed'
+    if 'dashboard=rebuild_failed' in commit_msg:
+        return 'rebuild_failed'
+    if 'dashboard=unavailable' in commit_msg:
+        return 'unavailable'
     if 'push failed' in commit_msg:
         return 'committed_local'
-    if 'rebuild failed' in commit_msg:
-        return 'published_degraded'
     if 'nothing to commit' in commit_msg:
         return 'current'
     return 'published'
@@ -560,6 +567,8 @@ def main(argv=None):
         deterministic_fallback=(status == 'fail'),
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
+    if data_plane_status not in {'published', 'current'}:
+        return 2
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)
 
 

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -197,6 +197,23 @@ def test_main_delivers_block_plus_prose_on_the_happy_path(run_main, sent):
         assert line in body
 
 
+def test_publish_failure_is_loud_after_report_delivery(
+    run_main, sent, pf, monkeypatch
+):
+    """A delivered report cannot turn a frozen public dashboard green."""
+    monkeypatch.setattr(
+        pf, 'publish_data_plane', lambda market: ('publish_failed', False)
+    )
+
+    rc, out = run_main(PROSE, context_id='abc123def456')
+
+    assert rc == 2
+    assert out['status'] == 'pass'
+    assert out['data_plane_status'] == 'publish_failed'
+    assert out['heartbeat']['state'] == 'publish_failed'
+    assert '▎我的看法' in sent['messages'][0]
+
+
 def test_main_refuses_to_marry_stale_prose_to_fresh_numbers(run_main, sent):
     """The model wrote against a context that has since been regenerated. Ship
     the data block alone rather than a check-in that looks clean and is not."""

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -16,6 +16,7 @@ and two boundaries that must not move:
     previous day's card — showing yesterday's critique as today's.
 """
 import json
+from types import SimpleNamespace
 import sys
 from pathlib import Path
 
@@ -177,7 +178,7 @@ def test_repairs_and_warnings_are_counted_separately(tmp_path):
         '  repair: intraday-insights-2026-07-28.json — repaired JSON (trailing_comma)\n'
     )
 
-    _harness_common._record_dashboard_build(True, output, ws=tmp_path)
+    _harness_common._record_dashboard_build(True, True, output, ws=tmp_path)
 
     status = json.loads((tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text())
     assert status['repair_count'] == 2
@@ -185,11 +186,43 @@ def test_repairs_and_warnings_are_counted_separately(tmp_path):
 
 
 def test_a_clean_build_records_zero_repairs(tmp_path):
-    _harness_common._record_dashboard_build(True, '  wrote dashboard.json\n', ws=tmp_path)
+    _harness_common._record_dashboard_build(
+        True, True, '  wrote dashboard.json\n', ws=tmp_path
+    )
 
     status = json.loads((tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text())
     assert status['repair_count'] == 0
     assert status['warn_count'] == 0
+
+
+def test_rebuild_fails_closed_when_the_publication_push_fails(
+    tmp_path, monkeypatch
+):
+    """Regression for the 2026-08-08 freeze: build green + push red is red."""
+    monkeypatch.setattr(_harness_common, 'refresh_today_snapshot', lambda ws: (True, 'ok'))
+    monkeypatch.setattr(_harness_common, 'sync_gha_data_files', lambda ws: (True, 'ok'))
+    results = iter([
+        SimpleNamespace(returncode=0, stdout='', stderr=''),
+        SimpleNamespace(returncode=0, stdout='wrote dashboard.json\n', stderr=''),
+        SimpleNamespace(
+            returncode=1,
+            stdout='money integrity gate rejected data-plane push\n',
+            stderr='error: failed to push some refs\n',
+        ),
+    ])
+    monkeypatch.setattr(_harness_common.subprocess, 'run', lambda *a, **k: next(results))
+
+    ok, detail = _harness_common.rebuild_dashboard(tmp_path)
+    status = json.loads(
+        (tmp_path / _harness_common.DASHBOARD_BUILD_STATUS).read_text()
+    )
+
+    assert ok is False
+    assert status['ok'] is False
+    assert status['build_ok'] is True
+    assert status['publish_ok'] is False
+    assert 'money integrity gate rejected' in status['tail']
+    assert 'data-plane publish failed' in detail
 
 
 # ── cron_health_check: reported, never escalated ────────────────────────────


### PR DESCRIPTION
Closes #382 (freshness failure-observability slice).

## What changed

- separates local dashboard build success from data-plane publication success
- records `build_ok`, `publish_ok`, overall `ok`, and a diagnostic tail large enough to retain the rejecting gate
- commits the failure record to master even when publication fails, so off-host cron health cannot keep reading an older green state
- keeps WeChat/Telegram delivery independent, while report/brief/intraday postflights exit non-zero on a failed public publication
- records intraday heartbeat as `publish_failed` instead of `completed`
- reports the exact build-vs-publish failure in cron health

## Evidence

- targeted harness/health suite: 92 passed
- money integrity: 0 ERROR / 0 WARN
- mutation check: changing status aggregation back to build-only makes the incident regression test fail

This does not change OpenClaw model, chat, context, memory, skills, delivery, or cron schedules.
