### PR TITLE
feat: ship portable investment decision workflow

### DIFF
--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -23,12 +23,14 @@ def _init(args) -> int:
     from clawock.harness.config import initialize
 
     try:
-        root = initialize(args.workspace)
+        root = initialize(args.workspace, workflow=args.workflow)
     except (ValueError, OSError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
     print(f"initialized clawock workspace: {root}")
     print(f"edit {root / 'clawock.json'} and {root / 'CONTEXT.md'}")
+    if args.workflow:
+        print(f"workflow: {args.workflow}")
     return 0
 
 
@@ -82,6 +84,8 @@ def _run_publish(args) -> int:
             raise ValueError("workspace output directory changed after this run was prepared")
         if payload.get("metadata") != dict(request.metadata):
             raise ValueError("workspace metadata changed after this run was prepared")
+        if payload.get("workflow", {}) != dict(request.workflow):
+            raise ValueError("workspace workflow changed after this run was prepared")
         context = assemble_explicit(request.workspace, request.context_files)
         supplied_context = payload.get("context")
         if not isinstance(supplied_context, dict) or (
@@ -279,12 +283,54 @@ def _context(args) -> int:
     return 0
 
 
+def _workflow(args) -> int:
+    """Discover or install portable Agent Skills shipped by clawock."""
+    from clawock.workflows import install_workflow, list_workflows, load_workflow
+
+    try:
+        if args.workflow_command == "list":
+            payload = [
+                {
+                    "id": pack.workflow_id,
+                    "version": pack.version,
+                    "description": pack.descriptor["description"],
+                    "certificate": pack.certificate,
+                }
+                for pack in list_workflows()
+            ]
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+            return 0
+        if args.workflow_command == "show":
+            print(json.dumps(
+                load_workflow(args.workflow_id).as_dict(),
+                ensure_ascii=False,
+                indent=2,
+            ))
+            return 0
+        root = args.skill_root
+        if root is None:
+            root = args.workspace.expanduser().resolve() / ".agents" / "skills"
+        destination = install_workflow(
+            args.workflow_id, root, force=args.force
+        )
+        print(json.dumps({
+            "workflow": args.workflow_id,
+            "installed": str(destination),
+            "skill": str(destination / "SKILL.md"),
+        }, ensure_ascii=False, indent=2))
+        return 0
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="clawock", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
     init = sub.add_parser("init", help="create a standalone clawock workspace")
     init.add_argument("workspace", type=Path)
+    init.add_argument("--workflow", help="pin a packaged decision workflow")
     init.set_defaults(func=_init)
 
     run = sub.add_parser(
@@ -359,6 +405,22 @@ def main(argv=None) -> int:
     context_assemble.add_argument("--json", action="store_true",
                                   help="print assembly manifest, not prompt text")
     context_assemble.set_defaults(func=_context)
+
+    workflow = sub.add_parser(
+        "workflow", help="discover or install portable decision-workflow skills")
+    workflow_sub = workflow.add_subparsers(dest="workflow_command", required=True)
+    workflow_list = workflow_sub.add_parser("list", help="list packaged workflows")
+    workflow_list.set_defaults(func=_workflow)
+    workflow_show = workflow_sub.add_parser("show", help="print a workflow contract")
+    workflow_show.add_argument("workflow_id")
+    workflow_show.set_defaults(func=_workflow)
+    workflow_install = workflow_sub.add_parser(
+        "install", help="install a workflow as a standard Agent Skill")
+    workflow_install.add_argument("workflow_id")
+    workflow_install.add_argument("--workspace", type=Path, default=Path.cwd())
+    workflow_install.add_argument("--skill-root", type=Path, default=None)
+    workflow_install.add_argument("--force", action="store_true")
+    workflow_install.set_defaults(func=_workflow)
 
     args = parser.parse_args(argv)
     if args.command == "report" and not args.harness_phase and not args.context:

--- a/clawock/harness/agent_run.py
+++ b/clawock/harness/agent_run.py
@@ -60,6 +60,7 @@ class PreparedRun:
                 ],
             },
             "metadata": dict(self.request.metadata),
+            "workflow": dict(self.request.workflow),
         }
 
 
@@ -126,16 +127,27 @@ class AgentRun:
             generation_id=generation_id or uuid4().hex,
         )
 
-    def _issues(self, artifacts: Mapping[str, str]) -> tuple[ValidationIssue, ...]:
+    def _issues(
+        self, prepared: PreparedRun, artifacts: Mapping[str, str]
+    ) -> tuple[ValidationIssue, ...]:
+        workflow_validators: tuple[ArtifactValidator, ...] = ()
+        if prepared.request.workflow:
+            # Lazy to keep the generic harness model independent at import time.
+            # The package API and CLI must enforce the same workflow contract;
+            # requiring every caller to remember to inject these validators would
+            # make the most important gates optional by accident.
+            from clawock.workflows import validators_for
+
+            workflow_validators = validators_for(prepared.request.workflow)
         return tuple(
             issue
-            for validator in self.validators
+            for validator in (*self.validators, *workflow_validators)
             for issue in validator.validate(artifacts)
         )
 
     def publish(self, prepared: PreparedRun, artifacts: Mapping[str, str],
                 store: ArtifactStore) -> RunReceipt:
-        issues = self._issues(artifacts)
+        issues = self._issues(prepared, artifacts)
         members = tuple(
             Artifact(name, Path(name), _media_type(name), prepared.generation_id)
             for name in artifacts
@@ -161,6 +173,7 @@ class AgentRun:
                 for name in artifacts
             ],
             "producer_metadata": dict(prepared.request.metadata),
+            "workflow": dict(prepared.request.workflow),
         }
         files: Mapping[str, str] = {
             **artifacts,

--- a/clawock/harness/config.py
+++ b/clawock/harness/config.py
@@ -12,7 +12,7 @@ CONFIG_NAME = "clawock.json"
 DEFAULT_CONTEXT = "CONTEXT.md"
 
 
-def initialize(workspace: Path | str) -> Path:
+def initialize(workspace: Path | str, *, workflow: str | None = None) -> Path:
     root = Path(workspace).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
     if (root / CONFIG_NAME).exists():
@@ -23,6 +23,12 @@ def initialize(workspace: Path | str) -> Path:
         "context": [DEFAULT_CONTEXT],
         "output_directory": ".clawock/runs",
     }
+    if workflow:
+        from clawock.workflows import load_workflow
+
+        pack = load_workflow(workflow)
+        config["workflow"] = workflow
+        config["task"] = pack.descriptor["task"]
     writes = {
         str(root / CONFIG_NAME): json.dumps(config, ensure_ascii=False, indent=2) + "\n",
     }
@@ -64,6 +70,22 @@ def load_request(workspace: Path | str) -> AgentRunRequest:
     metadata = payload.get("metadata", {})
     if not isinstance(metadata, dict):
         raise ValueError(f"{CONFIG_NAME} metadata must be an object")
+    workflow = payload.get("workflow")
+    workflow_parameters = payload.get("workflow_parameters", {})
+    if workflow is None:
+        if workflow_parameters:
+            raise ValueError(
+                f"{CONFIG_NAME} workflow_parameters require a workflow"
+            )
+        contract = {}
+    elif not isinstance(workflow, str) or not workflow.strip():
+        raise ValueError(f"{CONFIG_NAME} workflow must be a non-empty string")
+    elif not isinstance(workflow_parameters, dict):
+        raise ValueError(f"{CONFIG_NAME} workflow_parameters must be an object")
+    else:
+        from clawock.workflows import workflow_contract
+
+        contract = workflow_contract(workflow, workflow_parameters)
     output_resolved = (root / output_path).resolve()
     try:
         output_resolved.relative_to(root)
@@ -76,4 +98,5 @@ def load_request(workspace: Path | str) -> AgentRunRequest:
         context_files=tuple(context),
         output_directory=output_resolved,
         metadata=metadata,
+        workflow=contract,
     )

--- a/clawock/harness/model.py
+++ b/clawock/harness/model.py
@@ -58,12 +58,26 @@ class AgentRunRequest:
     context_files: tuple[str, ...]
     output_directory: Path
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    workflow: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.task.strip():
             raise ValueError("agent run task is empty")
         if not self.context_files:
             raise ValueError("agent run has no context files")
+        if self.workflow:
+            required = {"id", "version", "certificate", "parameters"}
+            if set(self.workflow) != required:
+                raise ValueError(
+                    "workflow contract must contain exactly " + ", ".join(sorted(required))
+                )
+            if not all(
+                isinstance(self.workflow.get(field), str) and self.workflow[field]
+                for field in ("id", "version", "certificate")
+            ):
+                raise ValueError("workflow id, version and certificate are required")
+            if not isinstance(self.workflow.get("parameters"), Mapping):
+                raise ValueError("workflow parameters must be an object")
 
 
 @dataclass(frozen=True)

--- a/clawock/workflows/__init__.py
+++ b/clawock/workflows/__init__.py
@@ -1,0 +1,19 @@
+"""Portable decision-workflow packs consumed by external agent runtimes."""
+
+from .registry import (
+    WorkflowPack,
+    install_workflow,
+    list_workflows,
+    load_workflow,
+    workflow_contract,
+)
+from .validators import validators_for
+
+__all__ = [
+    "WorkflowPack",
+    "install_workflow",
+    "list_workflows",
+    "load_workflow",
+    "validators_for",
+    "workflow_contract",
+]

--- a/clawock/workflows/packs/__init__.py
+++ b/clawock/workflows/packs/__init__.py
@@ -1,0 +1,1 @@
+"""Package data namespace for portable workflow packs."""

--- a/clawock/workflows/packs/investment-decision/SKILL.md
+++ b/clawock/workflows/packs/investment-decision/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: investment-decision
+description: Produce an evidence-linked investment decision with an explicit bull case, opposing bear case, thesis invalidation conditions, bounded action, and reconciled order/FX amounts. Use when an agent must analyze a security or portfolio action and publish a verifiable decision artifact through clawock.
+---
+
+# Investment decision workflow
+
+Use this workflow inside the current agent runtime. Do not launch another agent
+or model through clawock: the current runtime owns research, conversation,
+memory, skills, tools, repair loops, and permissions.
+
+## Run
+
+1. Run `clawock run prepare --workspace <workspace>` and retain the printed
+   `request_file`, `run_id`, `generation_id`, workflow version, and certified
+   context.
+2. Research with the current runtime's normal tools. Collect traceable evidence
+   observed no later than the decision's `as_of` time.
+3. Write `decision.json` using
+   [the decision contract](references/decision-contract.md) and its linked JSON
+   Schema. Include at least one
+   supporting and one opposing evidence item. The bull and bear cases must cite
+   their evidence rather than merely asserting conclusions.
+4. State thesis invalidation conditions before choosing an action. A high
+   confidence decision must cite primary evidence.
+5. If the action contains an order intent, calculate quote-currency gross amount
+   as quantity times unit price, then calculate base-currency gross amount using
+   the stated FX rate. Do not estimate either total in prose.
+6. Publish with:
+
+   `clawock run publish --workspace <workspace> --request <request_file> --artifact decision.json=<workspace>/decision.json`
+
+7. If publication is rejected, repair only the named artifact issues and retry
+   against the same prepared request. Re-run prepare if its context or workflow
+   certificate changed.
+
+The final receipt is the proof that one workflow version, certified context, and
+artifact generation passed the deterministic gates. It is supporting evidence,
+not a substitute for the decision itself.

--- a/clawock/workflows/packs/investment-decision/agents/openai.yaml
+++ b/clawock/workflows/packs/investment-decision/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Investment Decision"
+  short_description: "Evidence-led investing with debate and reconciliation"
+  default_prompt: "Use $investment-decision to produce and publish an evidence-linked investment decision."

--- a/clawock/workflows/packs/investment-decision/assets/decision.example.json
+++ b/clawock/workflows/packs/investment-decision/assets/decision.example.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "workflow": {
+    "id": "investment-decision",
+    "version": "1.0.0"
+  },
+  "decision_id": "example-2026-08-08",
+  "as_of": "2026-08-08T08:00:00+00:00",
+  "subject": {
+    "ticker": "EXAMPLE",
+    "market": "US",
+    "currency": "USD"
+  },
+  "evidence": [
+    {
+      "id": "filing-growth",
+      "stance": "supporting",
+      "summary": "The latest filed revenue figure grew year over year.",
+      "source": "issuer filing",
+      "source_class": "primary",
+      "observed_at": "2026-08-08T07:30:00+00:00"
+    },
+    {
+      "id": "valuation-risk",
+      "stance": "opposing",
+      "summary": "The current market multiple is above its stated comparison range.",
+      "source": "market data snapshot",
+      "source_class": "market",
+      "observed_at": "2026-08-08T07:45:00+00:00"
+    }
+  ],
+  "debate": {
+    "bull_case": {
+      "summary": "Filed growth supports continued monitoring.",
+      "evidence_ids": [
+        "filing-growth"
+      ]
+    },
+    "bear_case": {
+      "summary": "Valuation leaves insufficient margin of safety for a new entry.",
+      "evidence_ids": [
+        "valuation-risk"
+      ]
+    }
+  },
+  "thesis": {
+    "statement": "Business momentum is constructive, but price does not yet compensate for valuation risk.",
+    "confidence": 0.7,
+    "invalidation_conditions": [
+      "Filed growth reverses",
+      "Valuation falls into the stated entry range"
+    ]
+  },
+  "decision": {
+    "action": "watch",
+    "rationale": "The opposing valuation evidence blocks an entry despite constructive primary evidence.",
+    "evidence_ids": [
+      "filing-growth",
+      "valuation-risk"
+    ],
+    "order": null
+  }
+}

--- a/clawock/workflows/packs/investment-decision/references/decision-contract.md
+++ b/clawock/workflows/packs/investment-decision/references/decision-contract.md
@@ -1,0 +1,58 @@
+# Decision artifact contract
+
+`decision.json` is the single required artifact for workflow version `1.0.0`.
+Unknown or missing fields are rejected so a producer cannot silently invent a
+parallel schema.
+
+The machine-readable shape is `decision.schema.json` in this directory. JSON
+Schema covers structure and primitive types; clawock's Python validator adds the
+cross-reference, provenance, opposing-evidence, action/order and arithmetic
+invariants that JSON Schema cannot express.
+
+## Top-level fields
+
+- `schema_version`: integer `1`.
+- `workflow`: exactly `{"id":"investment-decision","version":"1.0.0"}`.
+- `decision_id`: stable non-empty identifier chosen by the calling runtime.
+- `as_of`: ISO-8601 timestamp with timezone.
+- `subject`: `ticker`, `market`, and quote `currency` strings.
+- `evidence`: traceable evidence rows.
+- `debate`: one bull and one bear case, each linked to evidence IDs.
+- `thesis`: statement, confidence from 0 to 1, and non-empty invalidation conditions.
+- `decision`: bounded action, rationale, evidence links, and optional order intent.
+
+## Evidence
+
+Each row contains exactly:
+
+- `id`: unique non-empty string.
+- `stance`: `supporting`, `opposing`, or `context`.
+- `summary`: the observed fact, not an unsupported conclusion.
+- `source`: a stable locator or source name.
+- `source_class`: `primary`, `secondary`, `market`, or `agent`.
+- `observed_at`: ISO-8601 timestamp with timezone, no later than `as_of`.
+
+The bull case must cite supporting evidence and the bear case must cite opposing
+evidence. Every cited ID must exist. The configured workflow parameters control
+minimum evidence counts and the maximum confidence allowed without a cited
+primary source.
+
+## Decision and order intent
+
+`action` is one of `buy`, `add`, `hold`, `watch`, `trim`, `sell`, `exit`, or
+`abstain`. `hold`, `watch`, and `abstain` carry `order: null`. Other actions
+carry an order with exactly:
+
+- `side`: `buy` or `sell`, consistent with the action.
+- `quantity`, `unit_price`, `gross_amount_quote`.
+- `quote_currency`, `base_currency`.
+- `fx_quote_to_base`, `gross_amount_base`.
+
+All numeric values must be positive and finite. clawock reconciles the two money
+identities to currency cents:
+
+`gross_amount_quote = quantity * unit_price`
+
+`gross_amount_base = gross_amount_quote * fx_quote_to_base`
+
+See `assets/decision.example.json` for a complete hold decision.

--- a/clawock/workflows/packs/investment-decision/references/decision.schema.json
+++ b/clawock/workflows/packs/investment-decision/references/decision.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:clawock:workflow:investment-decision:1.0.0:decision",
+  "title": "clawock investment decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "workflow",
+    "decision_id",
+    "as_of",
+    "subject",
+    "evidence",
+    "debate",
+    "thesis",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {"const": "investment-decision"},
+        "version": {"const": "1.0.0"}
+      }
+    },
+    "decision_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ticker", "market", "currency"],
+      "properties": {
+        "ticker": {"type": "string", "minLength": 1},
+        "market": {"type": "string", "minLength": 1},
+        "currency": {"type": "string", "minLength": 1}
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidence"}
+    },
+    "debate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bull_case", "bear_case"],
+      "properties": {
+        "bull_case": {"$ref": "#/$defs/case"},
+        "bear_case": {"$ref": "#/$defs/case"}
+      }
+    },
+    "thesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statement", "confidence", "invalidation_conditions"],
+      "properties": {
+        "statement": {"type": "string", "minLength": 1},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "invalidation_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "rationale", "evidence_ids", "order"],
+      "properties": {
+        "action": {
+          "enum": ["buy", "add", "hold", "watch", "trim", "sell", "exit", "abstain"]
+        },
+        "rationale": {"type": "string", "minLength": 1},
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "order": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/order"}
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "stance", "summary", "source", "source_class", "observed_at"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "stance": {"enum": ["supporting", "opposing", "context"]},
+        "summary": {"type": "string", "minLength": 1},
+        "source": {"type": "string", "minLength": 1},
+        "source_class": {"enum": ["primary", "secondary", "market", "agent"]},
+        "observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "evidence_ids"],
+      "properties": {
+        "summary": {"type": "string", "minLength": 1},
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "positive-number": {
+      "oneOf": [
+        {"type": "number", "exclusiveMinimum": 0},
+        {"type": "string", "pattern": "^(?:0*[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$"}
+      ]
+    },
+    "order": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "side",
+        "quantity",
+        "unit_price",
+        "quote_currency",
+        "gross_amount_quote",
+        "base_currency",
+        "fx_quote_to_base",
+        "gross_amount_base"
+      ],
+      "properties": {
+        "side": {"enum": ["buy", "sell"]},
+        "quantity": {"$ref": "#/$defs/positive-number"},
+        "unit_price": {"$ref": "#/$defs/positive-number"},
+        "quote_currency": {"type": "string", "minLength": 1},
+        "gross_amount_quote": {"$ref": "#/$defs/positive-number"},
+        "base_currency": {"type": "string", "minLength": 1},
+        "fx_quote_to_base": {"$ref": "#/$defs/positive-number"},
+        "gross_amount_base": {"$ref": "#/$defs/positive-number"}
+      }
+    }
+  }
+}

--- a/clawock/workflows/packs/investment-decision/workflow.json
+++ b/clawock/workflows/packs/investment-decision/workflow.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "id": "investment-decision",
+  "version": "1.0.0",
+  "title": "Investment Decision",
+  "description": "Turn traceable evidence and an explicit opposing case into a bounded investment decision with deterministic order and FX reconciliation.",
+  "task": "Produce decision.json for an evidence-linked investment decision. Include a genuine opposing case, thesis invalidation conditions, a bounded action, and exactly reconciled order and FX amounts when an order is proposed.",
+  "skill": "SKILL.md",
+  "stages": [
+    {
+      "id": "evidence",
+      "owner": "external-runtime",
+      "output": "traceable supporting, opposing, and contextual evidence"
+    },
+    {
+      "id": "debate",
+      "owner": "external-runtime",
+      "output": "bull and bear cases linked to evidence"
+    },
+    {
+      "id": "decision",
+      "owner": "external-runtime",
+      "output": "thesis, invalidation conditions, action, and optional order intent"
+    },
+    {
+      "id": "validate-reconcile-publish",
+      "owner": "clawock",
+      "output": "validation issues or a generation-pinned publication receipt"
+    }
+  ],
+  "artifacts": {
+    "required": [
+      "decision.json"
+    ],
+    "optional": []
+  },
+  "schemas": {
+    "decision.json": "references/decision.schema.json"
+  },
+  "parameters": {
+    "min_supporting_evidence": {
+      "type": "integer",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 5,
+      "description": "Minimum distinct evidence items supporting the thesis."
+    },
+    "min_opposing_evidence": {
+      "type": "integer",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 5,
+      "description": "Minimum distinct evidence items opposing the thesis."
+    },
+    "max_confidence_without_primary_source": {
+      "type": "number",
+      "default": 0.65,
+      "minimum": 0.5,
+      "maximum": 0.85,
+      "description": "Maximum thesis confidence when the decision cites no primary source."
+    }
+  }
+}

--- a/clawock/workflows/registry.py
+++ b/clawock/workflows/registry.py
@@ -1,0 +1,167 @@
+"""Discovery and installation for package-owned workflow/skill packs."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, Mapping
+
+from clawock.publish.store import write_generation
+
+
+PACKS_PACKAGE = "clawock.workflows.packs"
+WORKFLOW_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+@dataclass(frozen=True)
+class WorkflowPack:
+    """One immutable workflow contract shipped inside the installed wheel."""
+
+    descriptor: Mapping[str, Any]
+    resource: Any
+
+    @property
+    def workflow_id(self) -> str:
+        return str(self.descriptor["id"])
+
+    @property
+    def version(self) -> str:
+        return str(self.descriptor["version"])
+
+    @property
+    def certificate(self) -> str:
+        return hashlib.sha256(_canonical(self.descriptor).encode()).hexdigest()
+
+    def contract(self, overrides: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        parameters = {
+            name: spec["default"]
+            for name, spec in self.descriptor.get("parameters", {}).items()
+        }
+        for name, value in (overrides or {}).items():
+            spec = self.descriptor.get("parameters", {}).get(name)
+            if not isinstance(spec, dict):
+                raise ValueError(f"unknown workflow parameter: {name}")
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"workflow parameter {name} must be numeric")
+            if spec.get("type") == "integer" and not isinstance(value, int):
+                raise ValueError(f"workflow parameter {name} must be an integer")
+            if value < spec["minimum"] or value > spec["maximum"]:
+                raise ValueError(
+                    f"workflow parameter {name} must be between "
+                    f"{spec['minimum']} and {spec['maximum']}"
+                )
+            parameters[name] = value
+        return {
+            "id": self.workflow_id,
+            "version": self.version,
+            "certificate": self.certificate,
+            "parameters": parameters,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**dict(self.descriptor), "certificate": self.certificate}
+
+
+def _validate_descriptor(payload: Any, expected_id: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError(f"workflow descriptor is not an object: {expected_id}")
+    required = {
+        "schema_version", "id", "version", "title", "description", "task", "skill",
+        "artifacts", "schemas", "stages", "parameters",
+    }
+    missing = sorted(required - set(payload))
+    if missing:
+        raise ValueError(f"workflow {expected_id} missing fields: {missing}")
+    if payload.get("schema_version") != 1:
+        raise ValueError(f"workflow {expected_id} requires schema_version 1")
+    if payload.get("id") != expected_id or not WORKFLOW_NAME.fullmatch(expected_id):
+        raise ValueError(f"workflow id must match its package directory: {expected_id}")
+    if payload.get("skill") != "SKILL.md":
+        raise ValueError(f"workflow {expected_id} must expose SKILL.md")
+    if not isinstance(payload.get("task"), str) or not payload["task"].strip():
+        raise ValueError(f"workflow {expected_id} has no agent task")
+    required_artifacts = (payload.get("artifacts") or {}).get("required")
+    if not isinstance(required_artifacts, list) or not required_artifacts:
+        raise ValueError(f"workflow {expected_id} has no required artifacts")
+    schemas = payload.get("schemas")
+    if not isinstance(schemas, dict) or set(required_artifacts) - set(schemas):
+        raise ValueError(f"workflow {expected_id} has no schema for every required artifact")
+    for name, spec in payload.get("parameters", {}).items():
+        if not isinstance(spec, dict) or not {
+            "type", "default", "minimum", "maximum", "description"
+        } <= set(spec):
+            raise ValueError(f"workflow {expected_id} parameter is invalid: {name}")
+    return payload
+
+
+def list_workflows() -> tuple[WorkflowPack, ...]:
+    root = files(PACKS_PACKAGE)
+    packs = []
+    for resource in sorted(root.iterdir(), key=lambda item: item.name):
+        descriptor = resource.joinpath("workflow.json")
+        if not resource.is_dir() or not descriptor.is_file():
+            continue
+        payload = json.loads(descriptor.read_text(encoding="utf-8"))
+        packs.append(WorkflowPack(_validate_descriptor(payload, resource.name), resource))
+    return tuple(packs)
+
+
+def load_workflow(workflow_id: str) -> WorkflowPack:
+    for pack in list_workflows():
+        if pack.workflow_id == workflow_id:
+            return pack
+    available = ", ".join(pack.workflow_id for pack in list_workflows()) or "none"
+    raise ValueError(f"unknown workflow {workflow_id!r}; available: {available}")
+
+
+def workflow_contract(
+    workflow_id: str, overrides: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    return load_workflow(workflow_id).contract(overrides)
+
+
+def _resource_files(resource: Any, prefix: str = "") -> dict[str, str]:
+    output: dict[str, str] = {}
+    for child in resource.iterdir():
+        # Package/import debris is not part of the Agent Skill. In an extracted
+        # wheel Python may create __pycache__ beside these resources before the
+        # user installs them; trying to decode that binary as UTF-8 both leaks an
+        # implementation detail and makes installation fail.
+        if child.name == "__pycache__" or child.name == "__init__.py":
+            continue
+        relative = f"{prefix}{child.name}"
+        if child.is_dir():
+            output.update(_resource_files(child, relative + "/"))
+        elif child.is_file():
+            output[relative] = child.read_text(encoding="utf-8")
+    return output
+
+
+def install_workflow(
+    workflow_id: str, skill_root: Path | str, *, force: bool = False
+) -> Path:
+    """Install one pack as a standard Agent Skill without runtime mutation.
+
+    The caller chooses the skill root. ``<workspace>/.agents/skills`` works as a
+    cross-runtime project location and is also discovered by current OpenClaw.
+    Existing skills are never overwritten unless the caller explicitly asks.
+    """
+    pack = load_workflow(workflow_id)
+    destination = Path(skill_root).expanduser().resolve() / workflow_id
+    if destination.exists() and not force:
+        raise ValueError(f"refusing to overwrite existing workflow skill: {destination}")
+    writes = {
+        str(destination / name): content
+        for name, content in _resource_files(pack.resource).items()
+    }
+    write_generation(writes)
+    return destination

--- a/clawock/workflows/registry.py
+++ b/clawock/workflows/registry.py
@@ -39,7 +39,11 @@ class WorkflowPack:
 
     @property
     def certificate(self) -> str:
-        return hashlib.sha256(_canonical(self.descriptor).encode()).hexdigest()
+        members = {
+            name: hashlib.sha256(content.encode()).hexdigest()
+            for name, content in _resource_files(self.resource).items()
+        }
+        return hashlib.sha256(_canonical(members).encode()).hexdigest()
 
     def contract(self, overrides: Mapping[str, Any] | None = None) -> dict[str, Any]:
         parameters = {

--- a/clawock/workflows/validators.py
+++ b/clawock/workflows/validators.py
@@ -1,0 +1,333 @@
+"""Code-enforced invariants for portable decision-workflow artifacts."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Mapping
+
+from clawock.harness.model import ValidationIssue
+
+
+DECISION_ARTIFACT = "decision.json"
+ACTIONS = {"buy", "add", "hold", "watch", "trim", "sell", "exit", "abstain"}
+STANCES = {"supporting", "opposing", "context"}
+SOURCE_CLASSES = {"primary", "secondary", "market", "agent"}
+CENT = Decimal("0.01")
+
+
+def _issue(code: str, message: str) -> ValidationIssue:
+    return ValidationIssue(code, message)
+
+
+def _aware_time(value: Any, field: str, issues: list[ValidationIssue]):
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError
+        return parsed
+    except (TypeError, ValueError):
+        issues.append(_issue("invalid_timestamp", f"{field} must include a timezone"))
+        return None
+
+
+def _decimal(value: Any, field: str, issues: list[ValidationIssue]):
+    try:
+        number = Decimal(str(value))
+        if not number.is_finite() or number <= 0:
+            raise InvalidOperation
+        return number
+    except (InvalidOperation, ValueError):
+        issues.append(_issue("invalid_money", f"{field} must be a positive finite number"))
+        return None
+
+
+def _object_fields(
+    value: Any, required: set[str], field: str, issues: list[ValidationIssue]
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        issues.append(_issue("invalid_shape", f"{field} must be an object"))
+        return {}
+    missing = sorted(required - set(value))
+    extra = sorted(set(value) - required)
+    if missing:
+        issues.append(_issue("missing_fields", f"{field} missing fields: {missing}"))
+    if extra:
+        issues.append(_issue("unknown_fields", f"{field} unknown fields: {extra}"))
+    return value
+
+
+class InvestmentDecisionValidator:
+    """Require adversarial evidence and reconcile every proposed-order amount."""
+
+    name = "investment-decision-v1"
+
+    def __init__(self, contract: Mapping[str, Any]) -> None:
+        self.contract = contract
+        self.parameters = contract.get("parameters", {})
+
+    def validate(self, artifacts: Mapping[str, str]) -> tuple[ValidationIssue, ...]:
+        issues: list[ValidationIssue] = []
+        if DECISION_ARTIFACT not in artifacts:
+            return (_issue(
+                "missing_decision_artifact",
+                f"workflow requires {DECISION_ARTIFACT}",
+            ),)
+        unexpected = sorted(set(artifacts) - {DECISION_ARTIFACT})
+        if unexpected:
+            issues.append(_issue(
+                "unexpected_workflow_artifact",
+                f"workflow does not declare artifacts: {unexpected}",
+            ))
+        try:
+            document = json.loads(artifacts[DECISION_ARTIFACT])
+        except json.JSONDecodeError as exc:
+            return (_issue("invalid_decision_json", f"decision.json is invalid JSON: {exc}"),)
+
+        top = _object_fields(document, {
+            "schema_version", "workflow", "decision_id", "as_of", "subject",
+            "evidence", "debate", "thesis", "decision",
+        }, "decision", issues)
+        if top.get("schema_version") != 1:
+            issues.append(_issue("schema_version", "decision schema_version must be 1"))
+        workflow = _object_fields(
+            top.get("workflow"), {"id", "version"}, "workflow", issues
+        )
+        if workflow.get("id") != self.contract.get("id"):
+            issues.append(_issue("workflow_mismatch", "decision workflow id is not prepared workflow"))
+        if workflow.get("version") != self.contract.get("version"):
+            issues.append(_issue("workflow_mismatch", "decision workflow version is not prepared version"))
+        if not isinstance(top.get("decision_id"), str) or not top.get("decision_id", "").strip():
+            issues.append(_issue("missing_decision_id", "decision_id must be a non-empty string"))
+        as_of = _aware_time(top.get("as_of"), "as_of", issues)
+
+        subject = _object_fields(
+            top.get("subject"), {"ticker", "market", "currency"}, "subject", issues
+        )
+        for field in ("ticker", "market", "currency"):
+            if not isinstance(subject.get(field), str) or not subject.get(field, "").strip():
+                issues.append(_issue("invalid_subject", f"subject.{field} is required"))
+
+        evidence = top.get("evidence")
+        if not isinstance(evidence, list):
+            issues.append(_issue("invalid_evidence", "evidence must be a list"))
+            evidence = []
+        evidence_by_id: dict[str, dict[str, Any]] = {}
+        for index, raw in enumerate(evidence):
+            item = _object_fields(raw, {
+                "id", "stance", "summary", "source", "source_class", "observed_at",
+            }, f"evidence[{index}]", issues)
+            evidence_id = item.get("id")
+            if not isinstance(evidence_id, str) or not evidence_id.strip():
+                issues.append(_issue("invalid_evidence_id", f"evidence[{index}].id is required"))
+            elif evidence_id in evidence_by_id:
+                issues.append(_issue("duplicate_evidence", f"duplicate evidence id: {evidence_id}"))
+            else:
+                evidence_by_id[evidence_id] = item
+            if item.get("stance") not in STANCES:
+                issues.append(_issue("invalid_stance", f"evidence[{index}].stance is invalid"))
+            if item.get("source_class") not in SOURCE_CLASSES:
+                issues.append(_issue("invalid_source_class", f"evidence[{index}].source_class is invalid"))
+            for field in ("summary", "source"):
+                if not isinstance(item.get(field), str) or not item.get(field, "").strip():
+                    issues.append(_issue("incomplete_evidence", f"evidence[{index}].{field} is required"))
+            observed = _aware_time(item.get("observed_at"), f"evidence[{index}].observed_at", issues)
+            if as_of and observed and observed > as_of:
+                issues.append(_issue("future_evidence", f"evidence[{index}] is later than as_of"))
+
+        min_supporting = int(self.parameters.get("min_supporting_evidence", 1))
+        min_opposing = int(self.parameters.get("min_opposing_evidence", 1))
+        supporting = {
+            key for key, item in evidence_by_id.items()
+            if item.get("stance") == "supporting"
+        }
+        opposing = {
+            key for key, item in evidence_by_id.items()
+            if item.get("stance") == "opposing"
+        }
+        if len(supporting) < min_supporting:
+            issues.append(_issue(
+                "insufficient_supporting_evidence",
+                f"requires at least {min_supporting} supporting evidence item(s)",
+            ))
+        if len(opposing) < min_opposing:
+            issues.append(_issue(
+                "insufficient_opposing_evidence",
+                f"requires at least {min_opposing} opposing evidence item(s)",
+            ))
+
+        debate = _object_fields(top.get("debate"), {"bull_case", "bear_case"}, "debate", issues)
+        bull_refs = self._case_refs(debate.get("bull_case"), "bull_case", issues)
+        bear_refs = self._case_refs(debate.get("bear_case"), "bear_case", issues)
+        self._check_refs(bull_refs, set(evidence_by_id), "bull_case", issues)
+        self._check_refs(bear_refs, set(evidence_by_id), "bear_case", issues)
+        if bull_refs and not (set(bull_refs) & supporting):
+            issues.append(_issue("unsupported_bull_case", "bull_case must cite supporting evidence"))
+        if bear_refs and not (set(bear_refs) & opposing):
+            issues.append(_issue("unsupported_bear_case", "bear_case must cite opposing evidence"))
+
+        thesis = _object_fields(
+            top.get("thesis"), {"statement", "confidence", "invalidation_conditions"},
+            "thesis", issues,
+        )
+        if not isinstance(thesis.get("statement"), str) or not thesis.get("statement", "").strip():
+            issues.append(_issue("empty_thesis", "thesis.statement is required"))
+        confidence = thesis.get("confidence")
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+            issues.append(_issue("invalid_confidence", "thesis.confidence must be between 0 and 1"))
+        invalidations = thesis.get("invalidation_conditions")
+        if not isinstance(invalidations, list) or not invalidations or any(
+            not isinstance(item, str) or not item.strip() for item in invalidations
+        ):
+            issues.append(_issue("missing_invalidation", "thesis requires non-empty invalidation conditions"))
+
+        decision = _object_fields(
+            top.get("decision"), {"action", "rationale", "evidence_ids", "order"},
+            "decision", issues,
+        )
+        action = decision.get("action")
+        if action not in ACTIONS:
+            issues.append(_issue("invalid_action", f"decision.action must be one of {sorted(ACTIONS)}"))
+        if not isinstance(decision.get("rationale"), str) or not decision.get("rationale", "").strip():
+            issues.append(_issue("empty_rationale", "decision.rationale is required"))
+        raw_decision_refs = decision.get("evidence_ids")
+        if not isinstance(raw_decision_refs, list) or not raw_decision_refs:
+            issues.append(_issue("unlinked_decision", "decision must cite evidence_ids"))
+            raw_decision_refs = []
+        if any(not isinstance(ref, str) or not ref for ref in raw_decision_refs):
+            issues.append(_issue(
+                "invalid_evidence_reference",
+                "decision evidence_ids must be non-empty strings",
+            ))
+        decision_refs = [
+            ref for ref in raw_decision_refs if isinstance(ref, str) and ref
+        ]
+        if len(decision_refs) != len(set(decision_refs)):
+            issues.append(_issue(
+                "duplicate_evidence_reference",
+                "decision evidence_ids must be unique",
+            ))
+        self._check_refs(decision_refs, set(evidence_by_id), "decision", issues)
+
+        max_without_primary = float(
+            self.parameters.get("max_confidence_without_primary_source", 0.65)
+        )
+        cited = [evidence_by_id.get(ref, {}) for ref in decision_refs]
+        if (
+            isinstance(confidence, (int, float))
+            and not isinstance(confidence, bool)
+            and confidence > max_without_primary
+            and not any(item.get("source_class") == "primary" for item in cited)
+        ):
+            issues.append(_issue(
+                "confidence_without_primary_source",
+                f"confidence above {max_without_primary} requires cited primary evidence",
+            ))
+        self._validate_order(
+            action, decision.get("order"), subject.get("currency"), issues
+        )
+        return tuple(issues)
+
+    @staticmethod
+    def _case_refs(value, name, issues):
+        case = _object_fields(value, {"summary", "evidence_ids"}, name, issues)
+        if not isinstance(case.get("summary"), str) or not case.get("summary", "").strip():
+            issues.append(_issue("empty_debate_case", f"{name}.summary is required"))
+        refs = case.get("evidence_ids")
+        if not isinstance(refs, list) or not refs:
+            issues.append(_issue("unlinked_debate_case", f"{name} must cite evidence_ids"))
+            return []
+        invalid = [ref for ref in refs if not isinstance(ref, str) or not ref]
+        if invalid:
+            issues.append(_issue(
+                "invalid_evidence_reference", f"{name} evidence_ids must be strings"
+            ))
+        valid = [ref for ref in refs if isinstance(ref, str) and ref]
+        if len(valid) != len(set(valid)):
+            issues.append(_issue(
+                "duplicate_evidence_reference", f"{name} evidence_ids must be unique"
+            ))
+        return valid
+
+    @staticmethod
+    def _check_refs(refs, known, name, issues):
+        invalid = sorted({
+            str(ref) for ref in refs
+            if not isinstance(ref, str) or ref not in known
+        })
+        if invalid:
+            issues.append(_issue("missing_evidence_reference", f"{name} references missing evidence: {invalid}"))
+
+    @staticmethod
+    def _validate_order(action, raw, subject_currency, issues):
+        if raw is None:
+            if action in {"buy", "add", "trim", "sell", "exit"}:
+                issues.append(_issue("missing_order", f"action {action} requires an order"))
+            return
+        if action in {"hold", "watch", "abstain"}:
+            issues.append(_issue("unexpected_order", f"action {action} must not carry an order"))
+        order = _object_fields(raw, {
+            "side", "quantity", "unit_price", "quote_currency",
+            "gross_amount_quote", "base_currency", "fx_quote_to_base",
+            "gross_amount_base",
+        }, "decision.order", issues)
+        side = order.get("side")
+        expected_side = "buy" if action in {"buy", "add"} else "sell"
+        if side not in {"buy", "sell"}:
+            issues.append(_issue("invalid_order_side", "decision.order.side must be buy or sell"))
+        elif action in ACTIONS and action not in {"hold", "watch", "abstain"} and side != expected_side:
+            issues.append(_issue("order_action_mismatch", f"action {action} requires order side {expected_side}"))
+        for field in ("quote_currency", "base_currency"):
+            if not isinstance(order.get(field), str) or not order.get(field, "").strip():
+                issues.append(_issue("invalid_currency", f"decision.order.{field} is required"))
+        if (
+            isinstance(subject_currency, str)
+            and isinstance(order.get("quote_currency"), str)
+            and order.get("quote_currency") != subject_currency
+        ):
+            issues.append(_issue(
+                "quote_currency_mismatch",
+                "decision.order.quote_currency must match subject.currency",
+            ))
+        quantity = _decimal(order.get("quantity"), "decision.order.quantity", issues)
+        price = _decimal(order.get("unit_price"), "decision.order.unit_price", issues)
+        gross_quote = _decimal(
+            order.get("gross_amount_quote"), "decision.order.gross_amount_quote", issues
+        )
+        fx = _decimal(order.get("fx_quote_to_base"), "decision.order.fx_quote_to_base", issues)
+        gross_base = _decimal(
+            order.get("gross_amount_base"), "decision.order.gross_amount_base", issues
+        )
+        if quantity and price and gross_quote:
+            expected = (quantity * price).quantize(CENT, rounding=ROUND_HALF_UP)
+            if gross_quote.quantize(CENT, rounding=ROUND_HALF_UP) != expected:
+                issues.append(_issue(
+                    "gross_amount_mismatch",
+                    f"gross_amount_quote must equal quantity * unit_price ({expected})",
+                ))
+        if gross_quote and fx and gross_base:
+            expected = (gross_quote * fx).quantize(CENT, rounding=ROUND_HALF_UP)
+            if gross_base.quantize(CENT, rounding=ROUND_HALF_UP) != expected:
+                issues.append(_issue(
+                    "fx_amount_mismatch",
+                    f"gross_amount_base must equal gross_amount_quote * fx ({expected})",
+                ))
+        if (
+            order.get("quote_currency")
+            and order.get("quote_currency") == order.get("base_currency")
+            and fx is not None
+            and fx != Decimal("1")
+        ):
+            issues.append(_issue(
+                "same_currency_fx_mismatch",
+                "fx_quote_to_base must be 1 when quote and base currency match",
+            ))
+
+
+def validators_for(contract: Mapping[str, Any]):
+    workflow_id = contract.get("id")
+    if not workflow_id:
+        return ()
+    if workflow_id == "investment-decision":
+        return (InvestmentDecisionValidator(contract),)
+    raise ValueError(f"no validators registered for workflow: {workflow_id}")

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -28,6 +28,7 @@ The public CLI is the stable driver boundary:
 
 ```text
 clawock init <workspace>
+clawock workflow list|show|install
 clawock run prepare --workspace <workspace>
 clawock run publish --workspace <workspace> --request <json> --artifact <name=path>
 clawock context audit|assemble
@@ -42,6 +43,23 @@ agent-native business CLI. `run prepare` emits certified input; the calling agen
 keeps its own model, conversation, memory, skills, tools and repair loop; `run
 publish` validates/reconciles its files and atomically emits generation-pinned
 artifacts plus a receipt. clawock never launches the agent.
+
+`clawock workflow install investment-decision --workspace <workspace>` exports
+the package-owned pack to `<workspace>/.agents/skills/investment-decision` as a
+standard Agent Skill (`SKILL.md`, progressive references and assets). Current
+OpenClaw also [discovers project-agent skills](https://docs.openclaw.ai/skills)
+from `.agents/skills`; other
+skills-compatible runtimes can consume the same directory without a fork. The
+installed skill tells the current agent how to call the CLI—it does not delegate
+to a clawock-owned model.
+
+The first shipped workflow pins its ID, semantic version, descriptor certificate
+and bounded parameters into the prepared request. Its deterministic validator
+requires supporting and opposing evidence, linked bull/bear cases, thesis
+invalidation conditions, a bounded action, confidence provenance and exact
+order/FX arithmetic. A prompt cannot waive those gates. Outcome evaluation and
+review/apply/rollback of parameter proposals remain the next #386 slice and are
+not claimed by version 1.0.0.
 
 The live workflow phase commands dispatch in-process but currently resolve the
 KCNyu implementation from `scripts/harness`. They are a compatibility seam, not
@@ -77,3 +95,24 @@ An `ArtifactSet` has one `generation_id`, and every member must carry the same
 ID. This is the runtime-neutral seam after model deliberation: a runner may use
 OpenClaw, a direct API or an interactive coding agent, but validation and publish
 must reject artifacts mixed across generations.
+
+## Workflow pack contract
+
+Package data under `clawock/workflows/packs/<workflow-id>/` owns reusable
+semantics:
+
+```text
+investment-decision/
+├── SKILL.md
+├── workflow.json
+├── agents/openai.yaml
+├── references/decision-contract.md
+├── references/decision.schema.json
+└── assets/decision.example.json
+```
+
+`workflow.json` is the machine-readable discovery and parameter contract;
+`SKILL.md` follows the open [Agent Skills specification](https://agentskills.io/specification)
+and is the runtime-facing procedure; references and assets are loaded
+progressively. Python validators remain package code so neither a runtime nor an
+instance can silently edit financial or provenance invariants by changing prose.

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -53,7 +53,7 @@ skills-compatible runtimes can consume the same directory without a fork. The
 installed skill tells the current agent how to call the CLI—it does not delegate
 to a clawock-owned model.
 
-The first shipped workflow pins its ID, semantic version, descriptor certificate
+The first shipped workflow pins its ID, semantic version, whole-pack certificate
 and bounded parameters into the prepared request. Its deterministic validator
 requires supporting and opposing evidence, linked bull/bear cases, thesis
 invalidation conditions, a bounded action, confidence provenance and exact

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -65,7 +65,7 @@ rejected. Rejections are structured JSON for the external agent's own repair
 loop. Nothing is published while validation fails.
 
 When `clawock.json` pins `investment-decision`, the request and final manifest
-also pin its version, descriptor certificate and effective parameters. The
+also pin its version, whole-pack certificate and effective parameters. The
 required `decision.json` is rejected unless it carries traceable supporting and
 opposing evidence, linked bull/bear cases, thesis invalidation conditions and a
 bounded action. Any order intent is reconciled to currency cents in quote and

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -23,6 +23,21 @@ clawock init ./my-workspace
 clawock run prepare --workspace ./my-workspace
 ```
 
+For the packaged investment workflow, initialize and install its portable skill:
+
+```bash
+clawock init ./my-workspace --workflow investment-decision
+clawock workflow install investment-decision --workspace ./my-workspace
+clawock run prepare --workspace ./my-workspace
+```
+
+The default install target is `.agents/skills/investment-decision`, following the
+open [Agent Skills](https://agentskills.io/specification) directory/`SKILL.md`
+format. Installation refuses to overwrite
+an existing skill unless `--force` is explicit. The runtime discovers and loads
+the skill using its own normal mechanism; clawock does not inject it into a
+conversation.
+
 `prepare` prints JSON and stores the same request beneath `.clawock/work/`. It
 contains a run ID, generation ID, task, context documents, per-document SHA-256
 hashes and a hash of the assembled context. The external agent reads that input
@@ -33,14 +48,14 @@ owner-only permissions and `.clawock/work/` is ignored by the workspace-local
 
 ## Validate and publish
 
-After the external agent writes one or more text artifacts inside the workspace,
-it calls:
+After the external agent writes the workflow artifacts inside the workspace, it
+calls:
 
 ```bash
 clawock run publish \
   --workspace ./my-workspace \
   --request ./my-workspace/.clawock/work/<run-id>/request.json \
-  --artifact response.md=./response.md
+  --artifact decision.json=./decision.json
 ```
 
 The request is rejected if the configured task or certified context changed
@@ -48,6 +63,13 @@ after preparation. Artifact names must be canonical relative paths inside one
 generation; empty artifacts, traversal and the reserved `manifest.json` name are
 rejected. Rejections are structured JSON for the external agent's own repair
 loop. Nothing is published while validation fails.
+
+When `clawock.json` pins `investment-decision`, the request and final manifest
+also pin its version, descriptor certificate and effective parameters. The
+required `decision.json` is rejected unless it carries traceable supporting and
+opposing evidence, linked bull/bear cases, thesis invalidation conditions and a
+bounded action. Any order intent is reconciled to currency cents in quote and
+base currency. The complete schema and example travel with the installed skill.
 
 On success the configured store receives one write set, including a
 `manifest.json` that pins every artifact and context hash to one generation ID.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,12 @@ clawock = "clawock.cli:main"
 include = ["clawock*"]
 
 [tool.setuptools.package-data]
-clawock = ["context_manifest.json"]
+clawock = [
+    "context_manifest.json",
+    "workflows/packs/*/*.json",
+    "workflows/packs/*/*.md",
+    "workflows/packs/*/references/*.md",
+    "workflows/packs/*/references/*.json",
+    "workflows/packs/*/assets/*.json",
+    "workflows/packs/*/agents/*.yaml",
+]

--- a/tests/test_portable_workflow.py
+++ b/tests/test_portable_workflow.py
@@ -1,0 +1,56 @@
+"""High-cost invariants unique to the investment decision workflow."""
+import copy
+import json
+
+from clawock.workflows import load_workflow, validators_for
+
+
+def _example():
+    pack = load_workflow("investment-decision")
+    return json.loads(
+        pack.resource.joinpath("assets/decision.example.json").read_text()
+    )
+
+
+def _codes(document):
+    contract = load_workflow("investment-decision").contract()
+    validator = validators_for(contract)[0]
+    return {
+        issue.code
+        for issue in validator.validate({"decision.json": json.dumps(document)})
+    }
+
+
+def test_an_opposing_case_is_code_enforced_not_prompt_advice():
+    decision = _example()
+    decision["evidence"] = [
+        row for row in decision["evidence"] if row["stance"] != "opposing"
+    ]
+    decision["debate"]["bear_case"]["evidence_ids"] = ["filing-growth"]
+
+    codes = _codes(decision)
+
+    assert "insufficient_opposing_evidence" in codes
+    assert "unsupported_bear_case" in codes
+
+
+def test_order_and_fx_totals_are_reconciled_to_currency_cents():
+    decision = copy.deepcopy(_example())
+    decision["decision"].update({
+        "action": "buy",
+        "order": {
+            "side": "buy",
+            "quantity": "3",
+            "unit_price": "10.25",
+            "quote_currency": "USD",
+            "gross_amount_quote": "30.75",
+            "base_currency": "HKD",
+            "fx_quote_to_base": "7.8",
+            "gross_amount_base": "999.99"
+        },
+    })
+
+    codes = _codes(decision)
+
+    assert "gross_amount_mismatch" not in codes
+    assert "fx_amount_mismatch" in codes

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -132,8 +132,25 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
         "PYTHONPATH": str(site), "PATH": "/usr/bin:/bin",
         "LC_ALL": "C.UTF-8", "PYTHONIOENCODING": "utf-8",
     }
+    discovered = subprocess.run(
+        [sys.executable, "-m", "clawock", "workflow", "list"],
+        cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
+    assert discovered.returncode == 0, discovered.stderr
+    assert {item["id"] for item in json.loads(discovered.stdout)} == {
+        "investment-decision"}
+
+    installed = subprocess.run(
+        [sys.executable, "-m", "clawock", "workflow", "install",
+         "investment-decision", "--workspace", str(workspace)],
+        cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
+    assert installed.returncode == 0, installed.stderr
+    skill = workspace / ".agents/skills/investment-decision"
+    assert (skill / "SKILL.md").read_text().startswith(
+        "---\nname: investment-decision\n")
+
     initialized = subprocess.run(
-        [sys.executable, "-m", "clawock", "init", str(workspace)],
+        [sys.executable, "-m", "clawock", "init", str(workspace),
+         "--workflow", "investment-decision"],
         cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
     assert initialized.returncode == 0, initialized.stderr
 
@@ -144,22 +161,26 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
     assert prepared.returncode == 0, prepared.stderr
     request = json.loads(prepared.stdout)
     assert request["context"]["documents"][0]["sha256"]
+    assert request["workflow"]["id"] == "investment-decision"
+    assert len(request["workflow"]["certificate"]) == 64
 
-    # This write stands in for output produced by OpenClaw, Hermes, Claude Code,
-    # Codex or any other caller. clawock does not start that agent.
-    answer = workspace / "answer.md"
-    answer.write_text(request["context"]["documents"][0]["text"].strip() + "\n")
+    # This copy stands in for decision.json produced by OpenClaw, Hermes, Claude
+    # Code, Codex or another caller. clawock does not start that agent.
+    decision = workspace / "decision.json"
+    decision.write_text((skill / "assets/decision.example.json").read_text())
     completed = subprocess.run(
         [sys.executable, "-m", "clawock", "run", "publish",
          "--workspace", str(workspace), "--request", request["request_file"],
-         "--artifact", "answer.md=answer.md"],
+         "--artifact", "decision.json=decision.json"],
         cwd=tmp_path, env=clean_env, capture_output=True, text=True, timeout=120)
     assert completed.returncode == 0, completed.stderr
     receipt = json.loads(completed.stdout)
     assert receipt["status"] == "published"
     published = Path(receipt["publish"]["receipt"])
     manifest = json.loads((published / "manifest.json").read_text())
-    assert (published / "answer.md").read_text().startswith("# Context")
+    assert json.loads((published / "decision.json").read_text())["decision"][
+        "action"] == "watch"
     assert manifest["generation_id"] == receipt["generation_id"]
+    assert manifest["workflow"] == request["workflow"]
     assert {item["generation_id"] for item in receipt["artifacts"]} == {
         receipt["generation_id"]}


### PR DESCRIPTION
Refs #386 and #379. This is the portable workflow v1 slice; it intentionally does not close either issue.

## Product outcome

Ships the first package-owned investment decision workflow as an installable Agent Skill instead of treating a generic generation envelope as the product.

- `clawock workflow list|show|install` discovers and exports wheel-bundled packs
- the default install target is the cross-runtime `.agents/skills` project root; existing skills are preserved unless `--force` is explicit
- `clawock init --workflow investment-decision` pins a workflow-specific task
- prepared requests and published manifests pin workflow ID, version, descriptor certificate, and effective bounded parameters
- `decision.json` ships with a machine-readable JSON Schema, progressive reference, and example asset
- code requires traceable supporting and opposing evidence, linked bull/bear cases, thesis invalidation, bounded actions, and primary-source provenance for high confidence
- proposed order totals and quote-to-base FX amounts are reconciled deterministically to currency cents
- the external runtime still owns model calls, conversation, memory, tools, skills activation, permissions, and repair loops

## Honest boundary

This PR does not install the skill into the live OpenClaw workspace, migrate cron payloads, claim a second-runtime transcript, or implement outcome-driven proposal review/apply/rollback. Those remain open in #380, #386, and #379.

## Evidence

- Agent Skill quick validation: pass
- package/harness/contract tests: 10 passed
- real non-editable wheel build/install/workflow install/prepare/publish: pass
- JSON Schema Draft 2020-12 and bundled example: valid
- opposing-evidence mutation: regression test fails when the code gate is disabled
- portfolio/money integrity: 0 ERROR / 0 WARN
