### PR TITLE
feat: add bounded workflow improvement loop

### DIFF
--- a/clawock/cli.py
+++ b/clawock/cli.py
@@ -285,7 +285,40 @@ def _context(args) -> int:
 
 def _workflow(args) -> int:
     """Discover or install portable Agent Skills shipped by clawock."""
-    from clawock.workflows import install_workflow, list_workflows, load_workflow
+    from clawock.publish.store import write_generation
+    from clawock.workflows import (
+        apply_proposal,
+        create_proposal,
+        evaluate_files,
+        install_workflow,
+        list_workflows,
+        load_workflow,
+        review_proposal,
+        rollback_change,
+    )
+
+    def emit(payload):
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        output = getattr(args, "output", None)
+        if output is not None:
+            write_generation({str(output.expanduser().resolve()): serialized})
+        print(serialized, end="")
+
+    def changes():
+        parsed = {}
+        for item in args.set:
+            name, separator, raw = item.partition("=")
+            if not separator or not name:
+                raise ValueError(f"--set must be NAME=JSON_VALUE, got {item!r}")
+            if name in parsed:
+                raise ValueError(f"duplicate workflow parameter: {name}")
+            try:
+                parsed[name] = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"--set value for {name} must be a JSON number"
+                ) from exc
+        return parsed
 
     try:
         if args.workflow_command == "list":
@@ -298,14 +331,36 @@ def _workflow(args) -> int:
                 }
                 for pack in list_workflows()
             ]
-            print(json.dumps(payload, ensure_ascii=False, indent=2))
+            emit(payload)
             return 0
         if args.workflow_command == "show":
-            print(json.dumps(
-                load_workflow(args.workflow_id).as_dict(),
-                ensure_ascii=False,
-                indent=2,
+            emit(load_workflow(args.workflow_id).as_dict())
+            return 0
+        if args.workflow_command == "evaluate":
+            emit(evaluate_files(args.workflow_id, args.decision, args.outcome))
+            return 0
+        if args.workflow_command == "propose":
+            emit(create_proposal(
+                args.workspace,
+                args.trigger,
+                changes(),
+                rationale=args.rationale,
+                expected_effect=args.expected_effect,
             ))
+            return 0
+        if args.workflow_command == "review":
+            emit(review_proposal(
+                args.proposal,
+                disposition=args.decision,
+                reviewer=args.reviewer,
+                note=args.note,
+            ))
+            return 0
+        if args.workflow_command == "apply":
+            emit(apply_proposal(args.workspace, args.proposal, args.review))
+            return 0
+        if args.workflow_command == "rollback":
+            emit(rollback_change(args.workspace, args.change_id))
             return 0
         root = args.skill_root
         if root is None:
@@ -313,11 +368,11 @@ def _workflow(args) -> int:
         destination = install_workflow(
             args.workflow_id, root, force=args.force
         )
-        print(json.dumps({
+        emit({
             "workflow": args.workflow_id,
             "installed": str(destination),
             "skill": str(destination / "SKILL.md"),
-        }, ensure_ascii=False, indent=2))
+        })
         return 0
     except (ValueError, OSError, json.JSONDecodeError) as exc:
         print(str(exc), file=sys.stderr)
@@ -421,6 +476,43 @@ def main(argv=None) -> int:
     workflow_install.add_argument("--skill-root", type=Path, default=None)
     workflow_install.add_argument("--force", action="store_true")
     workflow_install.set_defaults(func=_workflow)
+    workflow_evaluate = workflow_sub.add_parser(
+        "evaluate", help="reconcile a decision with observed price and FX evidence")
+    workflow_evaluate.add_argument("workflow_id")
+    workflow_evaluate.add_argument("--decision", type=Path, required=True)
+    workflow_evaluate.add_argument("--outcome", type=Path, required=True)
+    workflow_evaluate.add_argument("--output", type=Path)
+    workflow_evaluate.set_defaults(func=_workflow)
+    workflow_propose = workflow_sub.add_parser(
+        "propose", help="create a bounded parameter proposal from measured evidence")
+    workflow_propose.add_argument("--workspace", type=Path, default=Path.cwd())
+    workflow_propose.add_argument("--trigger", type=Path, required=True)
+    workflow_propose.add_argument("--set", action="append", required=True,
+                                  metavar="NAME=JSON_VALUE")
+    workflow_propose.add_argument("--rationale", required=True)
+    workflow_propose.add_argument("--expected-effect", required=True)
+    workflow_propose.add_argument("--output", type=Path)
+    workflow_propose.set_defaults(func=_workflow)
+    workflow_review = workflow_sub.add_parser(
+        "review", help="accept or reject one exact proposal")
+    workflow_review.add_argument("--proposal", type=Path, required=True)
+    workflow_review.add_argument("--decision", choices=("accepted", "rejected"),
+                                 required=True)
+    workflow_review.add_argument("--reviewer", required=True)
+    workflow_review.add_argument("--note", required=True)
+    workflow_review.add_argument("--output", type=Path)
+    workflow_review.set_defaults(func=_workflow)
+    workflow_apply = workflow_sub.add_parser(
+        "apply", help="apply an accepted proposal and write a rollback record")
+    workflow_apply.add_argument("--workspace", type=Path, default=Path.cwd())
+    workflow_apply.add_argument("--proposal", type=Path, required=True)
+    workflow_apply.add_argument("--review", type=Path, required=True)
+    workflow_apply.set_defaults(func=_workflow)
+    workflow_rollback = workflow_sub.add_parser(
+        "rollback", help="restore the parameters recorded before an applied change")
+    workflow_rollback.add_argument("--workspace", type=Path, default=Path.cwd())
+    workflow_rollback.add_argument("--change-id", required=True)
+    workflow_rollback.set_defaults(func=_workflow)
 
     args = parser.parse_args(argv)
     if args.command == "report" and not args.harness_phase and not args.context:

--- a/clawock/harness/agent_run.py
+++ b/clawock/harness/agent_run.py
@@ -160,6 +160,7 @@ class AgentRun:
                 generation_id=prepared.generation_id,
                 status="rejected",
                 artifacts=artifact_set,
+                workflow=prepared.request.workflow,
                 validation_issues=issues,
             )
 
@@ -191,6 +192,7 @@ class AgentRun:
             generation_id=prepared.generation_id,
             status="published",
             artifacts=final_artifacts,
+            workflow=prepared.request.workflow,
             publish_receipt=published.receipt,
             publish_changed=published.changed,
         )

--- a/clawock/harness/model.py
+++ b/clawock/harness/model.py
@@ -92,6 +92,7 @@ class RunReceipt:
     generation_id: str
     status: str
     artifacts: ArtifactSet
+    workflow: Mapping[str, Any] = field(default_factory=dict)
     validation_issues: tuple[ValidationIssue, ...] = ()
     publish_receipt: str | None = None
     publish_changed: bool = False
@@ -114,6 +115,7 @@ class RunReceipt:
                 }
                 for artifact in self.artifacts.artifacts
             ],
+            "workflow": dict(self.workflow),
             "validation_issues": [
                 {"code": issue.code, "message": issue.message}
                 for issue in self.validation_issues

--- a/clawock/workflows/__init__.py
+++ b/clawock/workflows/__init__.py
@@ -7,13 +7,25 @@ from .registry import (
     load_workflow,
     workflow_contract,
 )
+from .improvements import (
+    apply_proposal,
+    create_proposal,
+    evaluate_files,
+    review_proposal,
+    rollback_change,
+)
 from .validators import validators_for
 
 __all__ = [
     "WorkflowPack",
+    "apply_proposal",
+    "create_proposal",
+    "evaluate_files",
     "install_workflow",
     "list_workflows",
     "load_workflow",
+    "review_proposal",
+    "rollback_change",
     "validators_for",
     "workflow_contract",
 ]

--- a/clawock/workflows/improvements.py
+++ b/clawock/workflows/improvements.py
@@ -1,0 +1,467 @@
+"""Deterministic outcome evaluation and bounded workflow improvement records."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import uuid4
+
+from clawock.harness.config import CONFIG_NAME, load_request
+from clawock.publish.store import write_generation
+
+from .registry import load_workflow
+from .validators import validators_for
+
+
+BPS = Decimal("10000")
+BPS_PRECISION = Decimal("0.01")
+IMPROVEMENT_ROOT = Path(".clawock/improvements")
+DIRECTION = {
+    "buy": Decimal("1"),
+    "add": Decimal("1"),
+    "hold": Decimal("1"),
+    "trim": Decimal("-1"),
+    "sell": Decimal("-1"),
+    "exit": Decimal("-1"),
+    "watch": Decimal("0"),
+    "abstain": Decimal("0"),
+}
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical(value).encode()).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _read_object(path: Path | str, label: str) -> dict[str, Any]:
+    source = Path(path).expanduser().resolve()
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read {label}: {source}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return payload
+
+
+def _aware_time(value: Any, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an ISO 8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed
+
+
+def _positive_decimal(value: Any, field: str) -> Decimal:
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field} must be numeric") from exc
+    if not number.is_finite() or number <= 0:
+        raise ValueError(f"{field} must be a positive finite number")
+    return number
+
+
+def _bps(value: Decimal) -> str:
+    return str(value.quantize(BPS_PRECISION, rounding=ROUND_HALF_UP))
+
+
+def evaluate_investment_outcome(
+    decision: Mapping[str, Any],
+    outcome: Mapping[str, Any],
+    contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Reconcile one observed price/FX outcome against a certified decision."""
+    artifacts = {"decision.json": json.dumps(decision, ensure_ascii=False)}
+    issues = validators_for(contract)[0].validate(artifacts)
+    if issues:
+        summary = "; ".join(f"{issue.code}: {issue.message}" for issue in issues)
+        raise ValueError(f"decision.json failed workflow validation: {summary}")
+
+    required = {
+        "schema_version", "workflow", "decision_id", "observed_at", "evidence"
+    }
+    if set(outcome) != required or outcome.get("schema_version") != 1:
+        raise ValueError(
+            "outcome must contain exactly schema_version, workflow, decision_id, "
+            "observed_at and evidence"
+        )
+    expected_workflow = {
+        "id": contract.get("id"), "version": contract.get("version")
+    }
+    if outcome.get("workflow") != expected_workflow:
+        raise ValueError("outcome workflow does not match the prepared workflow")
+    if outcome.get("decision_id") != decision.get("decision_id"):
+        raise ValueError("outcome decision_id does not match decision.json")
+    observed_at = _aware_time(outcome.get("observed_at"), "outcome.observed_at")
+    decision_as_of = _aware_time(decision.get("as_of"), "decision.as_of")
+    if observed_at <= decision_as_of:
+        raise ValueError("outcome.observed_at must be later than decision.as_of")
+
+    evidence = outcome.get("evidence")
+    evidence_fields = {
+        "source", "source_class", "quote_currency", "entry_price",
+        "outcome_price", "base_currency", "entry_fx_quote_to_base",
+        "outcome_fx_quote_to_base",
+    }
+    if not isinstance(evidence, dict) or set(evidence) != evidence_fields:
+        raise ValueError(
+            "outcome.evidence must contain exactly source, source_class, currencies, "
+            "prices and entry/outcome FX rates"
+        )
+    if evidence.get("source_class") not in {"broker", "exchange", "market_data"}:
+        raise ValueError("outcome.evidence.source_class must be broker, exchange or market_data")
+    if not isinstance(evidence.get("source"), str) or not evidence["source"].strip():
+        raise ValueError("outcome.evidence.source is required")
+    for field in ("quote_currency", "base_currency"):
+        if not isinstance(evidence.get(field), str) or not evidence[field].strip():
+            raise ValueError(f"outcome.evidence.{field} is required")
+    if evidence["quote_currency"] != decision["subject"]["currency"]:
+        raise ValueError("outcome quote_currency must match decision subject currency")
+
+    entry_price = _positive_decimal(evidence["entry_price"], "entry_price")
+    outcome_price = _positive_decimal(evidence["outcome_price"], "outcome_price")
+    entry_fx = _positive_decimal(
+        evidence["entry_fx_quote_to_base"], "entry_fx_quote_to_base"
+    )
+    outcome_fx = _positive_decimal(
+        evidence["outcome_fx_quote_to_base"], "outcome_fx_quote_to_base"
+    )
+    if evidence["quote_currency"] == evidence["base_currency"] and (
+        entry_fx != Decimal("1") or outcome_fx != Decimal("1")
+    ):
+        raise ValueError("same-currency outcome FX rates must both equal 1")
+
+    quote_move = ((outcome_price / entry_price) - 1) * BPS
+    entry_base = entry_price * entry_fx
+    outcome_base = outcome_price * outcome_fx
+    base_move = ((outcome_base / entry_base) - 1) * BPS
+    action = decision["decision"]["action"]
+    direction = DIRECTION[action]
+    return {
+        "schema_version": 1,
+        "kind": "outcome-evaluation",
+        "evaluation_id": uuid4().hex,
+        "created_at": _now(),
+        "workflow": dict(contract),
+        "decision_id": decision["decision_id"],
+        "action": action,
+        "decision_as_of": decision["as_of"],
+        "observed_at": outcome["observed_at"],
+        "outcome_evidence": {
+            "sha256": _sha256(outcome),
+            "source": evidence["source"],
+            "source_class": evidence["source_class"],
+        },
+        "measurements": {
+            "quote_currency": evidence["quote_currency"],
+            "base_currency": evidence["base_currency"],
+            "quote_market_move_bps": _bps(quote_move),
+            "base_market_move_bps": _bps(base_move),
+            "decision_value_bps": _bps(direction * base_move),
+        },
+        "interpretation": (
+            "decision_value_bps is a direction-adjusted market outcome, not "
+            "realized portfolio P&L; watch and abstain score zero"
+        ),
+    }
+
+
+def evaluate_files(
+    workflow_id: str, decision_path: Path | str, outcome_path: Path | str
+) -> dict[str, Any]:
+    if workflow_id != "investment-decision":
+        raise ValueError(f"workflow has no outcome evaluator: {workflow_id}")
+    pack = load_workflow(workflow_id)
+    return evaluate_investment_outcome(
+        _read_object(decision_path, "decision"),
+        _read_object(outcome_path, "outcome"),
+        pack.contract(),
+    )
+
+
+def _parse_trigger(trigger: Mapping[str, Any], contract: Mapping[str, Any]) -> str:
+    if trigger.get("kind") == "outcome-evaluation":
+        if trigger.get("workflow") != dict(contract):
+            raise ValueError("outcome evaluation workflow does not match workspace")
+        return str(trigger.get("evaluation_id") or "")
+    if trigger.get("status") == "rejected" and trigger.get("validation_issues"):
+        if trigger.get("workflow") != dict(contract):
+            raise ValueError("validation receipt workflow does not match workspace")
+        return str(trigger.get("run_id") or "")
+    raise ValueError(
+        "trigger must be an outcome evaluation or a rejected validation receipt"
+    )
+
+
+def create_proposal(
+    workspace: Path | str,
+    trigger_path: Path | str,
+    changes: Mapping[str, Any],
+    *,
+    rationale: str,
+    expected_effect: str,
+) -> dict[str, Any]:
+    """Create a bounded proposal; it cannot apply or review itself."""
+    request = load_request(workspace)
+    if not request.workflow:
+        raise ValueError("workspace has no pinned workflow")
+    if not rationale.strip() or not expected_effect.strip():
+        raise ValueError("proposal rationale and expected effect are required")
+    if not changes:
+        raise ValueError("proposal must change at least one workflow parameter")
+    trigger = _read_object(trigger_path, "proposal trigger")
+    trigger_id = _parse_trigger(trigger, request.workflow)
+    if not trigger_id:
+        raise ValueError("proposal trigger has no stable identifier")
+
+    pack = load_workflow(str(request.workflow["id"]))
+    before = dict(request.workflow["parameters"])
+    after = dict(before)
+    after.update(changes)
+    checked = pack.contract(after)
+    unchanged = [
+        name for name in changes
+        if checked["parameters"].get(name) == before.get(name)
+    ]
+    if unchanged:
+        raise ValueError(f"proposal parameters are unchanged: {sorted(unchanged)}")
+    bounded_changes = {
+        name: {"before": before[name], "after": checked["parameters"][name]}
+        for name in sorted(changes)
+    }
+    return {
+        "schema_version": 1,
+        "kind": "workflow-improvement-proposal",
+        "proposal_id": uuid4().hex,
+        "created_at": _now(),
+        "workflow": dict(request.workflow),
+        "trigger": {
+            "kind": "outcome_evaluation"
+            if trigger.get("kind") == "outcome-evaluation"
+            else "validation_receipt",
+            "id": trigger_id,
+            "sha256": _sha256(trigger),
+        },
+        "changes": bounded_changes,
+        "rationale": rationale.strip(),
+        "expected_effect": expected_effect.strip(),
+    }
+
+
+def review_proposal(
+    proposal_path: Path | str, *, disposition: str, reviewer: str, note: str
+) -> dict[str, Any]:
+    proposal = _read_object(proposal_path, "proposal")
+    _validate_proposal(proposal)
+    if disposition not in {"accepted", "rejected"}:
+        raise ValueError("review disposition must be accepted or rejected")
+    if not reviewer.strip() or not note.strip():
+        raise ValueError("reviewer and review note are required")
+    return {
+        "schema_version": 1,
+        "kind": "workflow-improvement-review",
+        "review_id": uuid4().hex,
+        "created_at": _now(),
+        "proposal_id": proposal["proposal_id"],
+        "proposal_sha256": _sha256(proposal),
+        "disposition": disposition,
+        "reviewer": reviewer.strip(),
+        "note": note.strip(),
+    }
+
+
+def _validate_proposal(proposal: Mapping[str, Any]) -> None:
+    required = {
+        "schema_version", "kind", "proposal_id", "created_at", "workflow",
+        "trigger", "changes", "rationale", "expected_effect",
+    }
+    if set(proposal) != required or proposal.get("schema_version") != 1 or (
+        proposal.get("kind") != "workflow-improvement-proposal"
+    ):
+        raise ValueError("invalid workflow improvement proposal")
+    if not _is_hex(proposal.get("proposal_id"), 32):
+        raise ValueError("proposal has an invalid proposal_id")
+    _aware_time(proposal.get("created_at"), "proposal.created_at")
+    workflow = proposal.get("workflow")
+    if not isinstance(workflow, dict) or set(workflow) != {
+        "id", "version", "certificate", "parameters"
+    } or not _is_hex(workflow.get("certificate"), 64):
+        raise ValueError("proposal has an invalid workflow contract")
+    trigger = proposal.get("trigger")
+    if not isinstance(trigger, dict) or set(trigger) != {"kind", "id", "sha256"} or (
+        trigger.get("kind") not in {"outcome_evaluation", "validation_receipt"}
+    ) or not isinstance(trigger.get("id"), str) or not trigger["id"] or (
+        not _is_hex(trigger.get("sha256"), 64)
+    ):
+        raise ValueError("proposal has an invalid evidence trigger")
+    if any(
+        not isinstance(proposal.get(field), str) or not proposal[field].strip()
+        for field in ("rationale", "expected_effect")
+    ):
+        raise ValueError("proposal rationale and expected effect are required")
+    if not isinstance(proposal.get("changes"), dict) or not proposal["changes"]:
+        raise ValueError("proposal has no parameter changes")
+    for name, change in proposal["changes"].items():
+        if not isinstance(name, str) or not isinstance(change, dict) or (
+            set(change) != {"before", "after"}
+        ):
+            raise ValueError("proposal parameter changes are malformed")
+
+
+def _is_hex(value: Any, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _validate_review(review: Mapping[str, Any], proposal: Mapping[str, Any]) -> None:
+    required = {
+        "schema_version", "kind", "review_id", "created_at", "proposal_id",
+        "proposal_sha256", "disposition", "reviewer", "note",
+    }
+    if set(review) != required or review.get("schema_version") != 1 or (
+        review.get("kind") != "workflow-improvement-review"
+    ):
+        raise ValueError("invalid workflow improvement review")
+    if not _is_hex(review.get("review_id"), 32):
+        raise ValueError("review has an invalid review_id")
+    _aware_time(review.get("created_at"), "review.created_at")
+    if review.get("proposal_id") != proposal["proposal_id"] or (
+        review.get("proposal_sha256") != _sha256(proposal)
+    ):
+        raise ValueError("review does not certify this exact proposal")
+    if review.get("disposition") not in {"accepted", "rejected"}:
+        raise ValueError("review disposition must be accepted or rejected")
+    if any(
+        not isinstance(review.get(field), str) or not review[field].strip()
+        for field in ("reviewer", "note")
+    ):
+        raise ValueError("reviewer and review note are required")
+
+
+def _read_workspace_config(workspace: Path | str) -> tuple[Path, dict[str, Any]]:
+    root = Path(workspace).expanduser().resolve()
+    config_path = root / CONFIG_NAME
+    payload = _read_object(config_path, CONFIG_NAME)
+    return root, payload
+
+
+def _serialize(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+
+
+def _history_with(history_path: Path, event: Mapping[str, Any]) -> str:
+    try:
+        existing = history_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        existing = ""
+    if existing and not existing.endswith("\n"):
+        raise ValueError(f"improvement history is not newline terminated: {history_path}")
+    return existing + _canonical(event) + "\n"
+
+
+def apply_proposal(
+    workspace: Path | str, proposal_path: Path | str, review_path: Path | str
+) -> dict[str, Any]:
+    """Apply an accepted proposal and persist enough state for strict rollback."""
+    proposal = _read_object(proposal_path, "proposal")
+    review = _read_object(review_path, "proposal review")
+    _validate_proposal(proposal)
+    _validate_review(review, proposal)
+    if review.get("disposition") != "accepted":
+        raise ValueError("only an explicitly accepted proposal can be applied")
+
+    root, config = _read_workspace_config(workspace)
+    request = load_request(root)
+    if dict(request.workflow) != proposal.get("workflow"):
+        raise ValueError("workspace workflow changed after proposal creation")
+    before_overrides = config.get("workflow_parameters", {})
+    if not isinstance(before_overrides, dict):
+        raise ValueError(f"{CONFIG_NAME} workflow_parameters must be an object")
+    effective = dict(request.workflow["parameters"])
+    after_overrides = dict(before_overrides)
+    for name, change in proposal["changes"].items():
+        if effective.get(name) != change["before"]:
+            raise ValueError(f"workflow parameter changed since proposal: {name}")
+        after_overrides[name] = change["after"]
+    pack = load_workflow(str(request.workflow["id"]))
+    pack.contract(after_overrides)
+
+    updated = dict(config)
+    updated["workflow_parameters"] = after_overrides
+    change_id = uuid4().hex
+    change = {
+        "schema_version": 1,
+        "kind": "workflow-improvement-change",
+        "change_id": change_id,
+        "created_at": _now(),
+        "proposal_id": proposal["proposal_id"],
+        "proposal_sha256": _sha256(proposal),
+        "review_id": review.get("review_id"),
+        "workflow": dict(request.workflow),
+        "before_overrides": before_overrides,
+        "after_overrides": after_overrides,
+        "status": "applied",
+    }
+    change_path = root / IMPROVEMENT_ROOT / "changes" / f"{change_id}.json"
+    history_path = root / IMPROVEMENT_ROOT / "history.jsonl"
+    write_generation({
+        str(root / CONFIG_NAME): _serialize(updated),
+        str(change_path): _serialize(change),
+        str(history_path): _history_with(history_path, change),
+    })
+    return change
+
+
+def rollback_change(workspace: Path | str, change_id: str) -> dict[str, Any]:
+    root, config = _read_workspace_config(workspace)
+    if not _is_hex(change_id, 32):
+        raise ValueError("change_id must be 32 lowercase hexadecimal characters")
+    change_path = root / IMPROVEMENT_ROOT / "changes" / f"{change_id}.json"
+    change = _read_object(change_path, "improvement change")
+    if change.get("change_id") != change_id or change.get("status") != "applied":
+        raise ValueError("change record is not an applied improvement")
+    current = config.get("workflow_parameters", {})
+    if current != change.get("after_overrides"):
+        raise ValueError("workspace parameters drifted after apply; refusing rollback")
+
+    restored = dict(config)
+    before = change.get("before_overrides")
+    if before:
+        restored["workflow_parameters"] = before
+    else:
+        restored.pop("workflow_parameters", None)
+    event = {
+        "schema_version": 1,
+        "kind": "workflow-improvement-rollback",
+        "rollback_id": uuid4().hex,
+        "created_at": _now(),
+        "change_id": change_id,
+        "workflow": change.get("workflow"),
+        "restored_overrides": before,
+    }
+    history_path = root / IMPROVEMENT_ROOT / "history.jsonl"
+    write_generation({
+        str(root / CONFIG_NAME): _serialize(restored),
+        str(history_path): _history_with(history_path, event),
+    })
+    return event

--- a/clawock/workflows/packs/investment-decision/SKILL.md
+++ b/clawock/workflows/packs/investment-decision/SKILL.md
@@ -37,3 +37,18 @@ memory, skills, tools, repair loops, and permissions.
 The final receipt is the proof that one workflow version, certified context, and
 artifact generation passed the deterministic gates. It is supporting evidence,
 not a substitute for the decision itself.
+
+## Learn from outcomes
+
+After the stated horizon, record broker, exchange, or market-data evidence using
+`assets/outcome.example.json`, then run `clawock workflow evaluate`. The result
+reconciles price and FX before assigning a direction-adjusted basis-point score;
+it is not realized portfolio P&L.
+
+A runtime may use that evaluation or a rejected validation receipt to request a
+bounded parameter proposal with `clawock workflow propose`. The proposal cannot
+apply itself. A named reviewer must explicitly accept or reject the exact hash,
+and accepted changes go through `workflow apply`; `workflow rollback` restores
+the recorded prior parameters. See
+[the decision contract](references/decision-contract.md) for commands and the
+strict no-self-edit boundary.

--- a/clawock/workflows/packs/investment-decision/assets/decision.example.json
+++ b/clawock/workflows/packs/investment-decision/assets/decision.example.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "workflow": {
     "id": "investment-decision",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "decision_id": "example-2026-08-08",
   "as_of": "2026-08-08T08:00:00+00:00",

--- a/clawock/workflows/packs/investment-decision/assets/outcome.example.json
+++ b/clawock/workflows/packs/investment-decision/assets/outcome.example.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "workflow": {
+    "id": "investment-decision",
+    "version": "1.1.0"
+  },
+  "decision_id": "example-2026-08-08",
+  "observed_at": "2026-08-09T08:00:00+00:00",
+  "evidence": {
+    "source": "broker closing-price export",
+    "source_class": "broker",
+    "quote_currency": "USD",
+    "entry_price": "100.00",
+    "outcome_price": "102.00",
+    "base_currency": "HKD",
+    "entry_fx_quote_to_base": "7.80",
+    "outcome_fx_quote_to_base": "7.81"
+  }
+}

--- a/clawock/workflows/packs/investment-decision/references/decision-contract.md
+++ b/clawock/workflows/packs/investment-decision/references/decision-contract.md
@@ -1,6 +1,6 @@
 # Decision artifact contract
 
-`decision.json` is the single required artifact for workflow version `1.0.0`.
+`decision.json` is the single required artifact for workflow version `1.1.0`.
 Unknown or missing fields are rejected so a producer cannot silently invent a
 parallel schema.
 
@@ -12,7 +12,7 @@ invariants that JSON Schema cannot express.
 ## Top-level fields
 
 - `schema_version`: integer `1`.
-- `workflow`: exactly `{"id":"investment-decision","version":"1.0.0"}`.
+- `workflow`: exactly `{"id":"investment-decision","version":"1.1.0"}`.
 - `decision_id`: stable non-empty identifier chosen by the calling runtime.
 - `as_of`: ISO-8601 timestamp with timezone.
 - `subject`: `ticker`, `market`, and quote `currency` strings.
@@ -55,4 +55,56 @@ identities to currency cents:
 
 `gross_amount_base = gross_amount_quote * fx_quote_to_base`
 
-See `assets/decision.example.json` for a complete hold decision.
+See `assets/decision.example.json` for a complete watch decision.
+
+## Outcome evidence and evaluation
+
+Copy `assets/outcome.example.json`, preserve the decision/workflow identifiers,
+and replace the price, FX, timestamp, and source fields with observed evidence.
+Then run:
+
+```bash
+clawock workflow evaluate investment-decision \
+  --decision decision.json --outcome outcome.json --output evaluation.json
+```
+
+The evaluator calculates quote-currency and base-currency market moves in basis
+points. `decision_value_bps` applies +1 to long/hold decisions, -1 to
+trim/sell/exit decisions, and 0 to watch/abstain. This is a reproducible
+directional evaluation, not realized P&L; portfolio cash, fills, fees, taxes and
+position size remain outside this artifact.
+
+## Bounded improvement
+
+An external runtime or human can propose only parameters already bounded by
+`workflow.json`:
+
+```bash
+clawock workflow propose --workspace . --trigger evaluation.json \
+  --set min_opposing_evidence=2 \
+  --rationale "Weak opposing evidence preceded the measured miss." \
+  --expected-effect "Require a second independent opposing source." \
+  --output proposal.json
+
+clawock workflow review --proposal proposal.json --decision accepted \
+  --reviewer analyst@example --note "Evidence supports a bounded trial." \
+  --output review.json
+
+clawock workflow apply --workspace . --proposal proposal.json --review review.json
+clawock workflow rollback --workspace . --change-id <change-id>
+```
+
+The trigger can also be a rejected `clawock run publish` receipt. A proposal
+pins the workflow version/certificate, trigger hash, old/new values and expected
+effect. Apply refuses rejected or mismatched reviews, stale parameters, unknown
+settings and values outside their declared bounds. Rollback refuses to overwrite
+later parameter drift.
+
+This loop never launches a model, edits `SKILL.md`, changes OpenClaw memory/chat
+behavior or accepts its own proposal. Reasoning stays in the external runtime;
+clawock owns the evidence link, deterministic math and reversible adoption
+record.
+
+The bounded parameters change workflow evidence strictness only. They do not
+introduce or tune quantitative factors, catalysts, signals, entry/exit rules or
+portfolio construction; those remain part of the caller's existing strategy.

--- a/clawock/workflows/packs/investment-decision/references/decision.schema.json
+++ b/clawock/workflows/packs/investment-decision/references/decision.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:clawock:workflow:investment-decision:1.0.0:decision",
+  "$id": "urn:clawock:workflow:investment-decision:1.1.0:decision",
   "title": "clawock investment decision",
   "type": "object",
   "additionalProperties": false,
@@ -25,7 +25,7 @@
       "required": ["id", "version"],
       "properties": {
         "id": {"const": "investment-decision"},
-        "version": {"const": "1.0.0"}
+        "version": {"const": "1.1.0"}
       }
     },
     "decision_id": {

--- a/clawock/workflows/packs/investment-decision/references/improvement-proposal.schema.json
+++ b/clawock/workflows/packs/investment-decision/references/improvement-proposal.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:clawock:workflow:investment-decision:1.1.0:improvement-proposal",
+  "title": "clawock bounded workflow improvement proposal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "kind", "proposal_id", "created_at", "workflow",
+    "trigger", "changes", "rationale", "expected_effect"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "kind": {"const": "workflow-improvement-proposal"},
+    "proposal_id": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "certificate", "parameters"],
+      "properties": {
+        "id": {"const": "investment-decision"},
+        "version": {"const": "1.1.0"},
+        "certificate": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "parameters": {"type": "object"}
+      }
+    },
+    "trigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "sha256"],
+      "properties": {
+        "kind": {"enum": ["outcome_evaluation", "validation_receipt"]},
+        "id": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "changes": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["before", "after"],
+        "properties": {
+          "before": {"type": "number"},
+          "after": {"type": "number"}
+        }
+      }
+    },
+    "rationale": {"type": "string", "minLength": 1},
+    "expected_effect": {"type": "string", "minLength": 1}
+  }
+}

--- a/clawock/workflows/packs/investment-decision/references/outcome.schema.json
+++ b/clawock/workflows/packs/investment-decision/references/outcome.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:clawock:workflow:investment-decision:1.1.0:outcome",
+  "title": "clawock investment decision outcome evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "workflow", "decision_id", "observed_at", "evidence"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {"const": "investment-decision"},
+        "version": {"const": "1.1.0"}
+      }
+    },
+    "decision_id": {"type": "string", "minLength": 1},
+    "observed_at": {"type": "string", "format": "date-time"},
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source", "source_class", "quote_currency", "entry_price",
+        "outcome_price", "base_currency", "entry_fx_quote_to_base",
+        "outcome_fx_quote_to_base"
+      ],
+      "properties": {
+        "source": {"type": "string", "minLength": 1},
+        "source_class": {"enum": ["broker", "exchange", "market_data"]},
+        "quote_currency": {"type": "string", "minLength": 1},
+        "entry_price": {"$ref": "#/$defs/positive-number"},
+        "outcome_price": {"$ref": "#/$defs/positive-number"},
+        "base_currency": {"type": "string", "minLength": 1},
+        "entry_fx_quote_to_base": {"$ref": "#/$defs/positive-number"},
+        "outcome_fx_quote_to_base": {"$ref": "#/$defs/positive-number"}
+      }
+    }
+  },
+  "$defs": {
+    "positive-number": {
+      "oneOf": [
+        {"type": "number", "exclusiveMinimum": 0},
+        {"type": "string", "pattern": "^(?:0*[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$"}
+      ]
+    }
+  }
+}

--- a/clawock/workflows/packs/investment-decision/workflow.json
+++ b/clawock/workflows/packs/investment-decision/workflow.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "investment-decision",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "Investment Decision",
   "description": "Turn traceable evidence and an explicit opposing case into a bounded investment decision with deterministic order and FX reconciliation.",
   "task": "Produce decision.json for an evidence-linked investment decision. Include a genuine opposing case, thesis invalidation conditions, a bounded action, and exactly reconciled order and FX amounts when an order is proposed.",
@@ -35,7 +35,19 @@
     "optional": []
   },
   "schemas": {
-    "decision.json": "references/decision.schema.json"
+    "decision.json": "references/decision.schema.json",
+    "outcome.json": "references/outcome.schema.json",
+    "improvement-proposal.json": "references/improvement-proposal.schema.json"
+  },
+  "feedback": {
+    "outcome": "outcome.json",
+    "evaluation": "clawock workflow evaluate",
+    "bounded_parameters": [
+      "min_supporting_evidence",
+      "min_opposing_evidence",
+      "max_confidence_without_primary_source"
+    ],
+    "adoption": ["review", "apply", "rollback"]
   },
   "parameters": {
     "min_supporting_evidence": {

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -57,9 +57,19 @@ The first shipped workflow pins its ID, semantic version, whole-pack certificate
 and bounded parameters into the prepared request. Its deterministic validator
 requires supporting and opposing evidence, linked bull/bear cases, thesis
 invalidation conditions, a bounded action, confidence provenance and exact
-order/FX arithmetic. A prompt cannot waive those gates. Outcome evaluation and
-review/apply/rollback of parameter proposals remain the next #386 slice and are
-not claimed by version 1.0.0.
+order/FX arithmetic. A prompt cannot waive those gates.
+
+Version 1.1 adds the bounded feedback loop without turning clawock into an
+agent. An observed outcome is source-linked and reconciled across price and FX;
+the evaluator reports a direction-adjusted basis-point result with an explicit
+not-realized-P&L caveat. That evaluation, or a rejected validation receipt, can
+anchor a proposal that changes only parameters already bounded by the pack.
+Proposal review certifies an exact hash, apply records before/after overrides,
+and rollback refuses to overwrite later drift. No command launches a model,
+rewrites a skill, or lets a proposal accept itself.
+The shipped parameters govern evidence/provenance strictness only; they do not
+add or tune factors, catalysts, signals, entries, exits or portfolio rules. The
+calling runtime's existing investment strategy remains the decision source.
 
 The live workflow phase commands dispatch in-process but currently resolve the
 KCNyu implementation from `scripts/harness`. They are a compatibility seam, not
@@ -108,7 +118,10 @@ investment-decision/
 ├── agents/openai.yaml
 ├── references/decision-contract.md
 ├── references/decision.schema.json
-└── assets/decision.example.json
+├── references/outcome.schema.json
+├── references/improvement-proposal.schema.json
+├── assets/decision.example.json
+└── assets/outcome.example.json
 ```
 
 `workflow.json` is the machine-readable discovery and parameter contract;

--- a/docs/architecture/runtime-protocol.md
+++ b/docs/architecture/runtime-protocol.md
@@ -75,6 +75,34 @@ On success the configured store receives one write set, including a
 `manifest.json` that pins every artifact and context hash to one generation ID.
 The JSON receipt reports the final location and whether anything changed.
 
+## Evaluate and improve without owning the agent
+
+At the declared horizon, a caller can record observed prices, FX and their
+broker/exchange/market-data source, then reconcile them deterministically:
+
+```bash
+clawock workflow evaluate investment-decision \
+  --decision decision.json --outcome outcome.json --output evaluation.json
+```
+
+The evaluation is evidence for a workflow change, not permission to make one.
+The adoption protocol is deliberately split:
+
+```text
+evaluation or rejected receipt
+          │
+          ▼
+      proposal ──► named accept/reject review ──► apply ──► rollback record
+```
+
+`workflow propose` accepts only pack-declared bounded parameters and pins the
+trigger hash plus the current workflow version/certificate. `workflow apply`
+requires an accepted review of that exact proposal and records the prior
+workspace overrides. `workflow rollback` restores them only if no later
+parameter drift would be overwritten. The external runtime remains responsible
+for reasoning about why a proposal is warranted; clawock supplies the measured
+input, structural limits, adoption record and reversal mechanism.
+
 Artifact source paths are restricted to the workspace. The external runtime
 retains responsibility for its own credentials and permissions; clawock neither
 starts it nor receives its provider stderr.

--- a/tests/test_workflow_improvements.py
+++ b/tests/test_workflow_improvements.py
@@ -1,0 +1,113 @@
+"""High-value evidence, review and rollback invariants for workflow learning."""
+import json
+
+import pytest
+
+from clawock.harness.config import initialize
+from clawock.workflows import (
+    apply_proposal,
+    create_proposal,
+    evaluate_files,
+    load_workflow,
+    review_proposal,
+    rollback_change,
+)
+
+
+def _resource(name):
+    return load_workflow("investment-decision").resource.joinpath(
+        "assets", name
+    ).read_text()
+
+
+def _workspace(tmp_path):
+    root = tmp_path / "workspace"
+    initialize(root, workflow="investment-decision")
+    return root
+
+
+def _evaluation(tmp_path):
+    decision = tmp_path / "decision.json"
+    outcome = tmp_path / "outcome.json"
+    decision.write_text(_resource("decision.example.json"))
+    outcome.write_text(_resource("outcome.example.json"))
+    return evaluate_files("investment-decision", decision, outcome)
+
+
+def _write(path, payload):
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_outcome_reconciles_quote_and_fx_adjusted_base_returns(tmp_path):
+    result = _evaluation(tmp_path)
+
+    assert result["measurements"] == {
+        "quote_currency": "USD",
+        "base_currency": "HKD",
+        "quote_market_move_bps": "200.00",
+        "base_market_move_bps": "213.08",
+        "decision_value_bps": "0.00",
+    }
+    assert "not realized portfolio P&L" in result["interpretation"]
+
+
+def test_rejected_proposal_cannot_mutate_workflow_parameters(tmp_path):
+    workspace = _workspace(tmp_path)
+    trigger = _write(tmp_path / "evaluation.json", _evaluation(tmp_path))
+    proposal = create_proposal(
+        workspace,
+        trigger,
+        {"min_opposing_evidence": 2},
+        rationale="One opposing source was too brittle.",
+        expected_effect="Require independent opposition.",
+    )
+    proposal_path = _write(tmp_path / "proposal.json", proposal)
+    review_path = _write(tmp_path / "review.json", review_proposal(
+        proposal_path,
+        disposition="rejected",
+        reviewer="risk-owner",
+        note="One outcome is insufficient evidence for a policy change.",
+    ))
+    before = (workspace / "clawock.json").read_text()
+
+    with pytest.raises(ValueError, match="explicitly accepted"):
+        apply_proposal(workspace, proposal_path, review_path)
+
+    assert (workspace / "clawock.json").read_text() == before
+    assert not (workspace / ".clawock/improvements/history.jsonl").exists()
+
+
+def test_accepted_parameter_change_restores_exact_config_on_rollback(tmp_path):
+    workspace = _workspace(tmp_path)
+    original = (workspace / "clawock.json").read_text()
+    trigger = _write(tmp_path / "evaluation.json", _evaluation(tmp_path))
+    proposal = create_proposal(
+        workspace,
+        trigger,
+        {"min_opposing_evidence": 2},
+        rationale="Measured evidence supports a bounded stricter trial.",
+        expected_effect="Require two distinct opposing observations.",
+    )
+    proposal_path = _write(tmp_path / "proposal.json", proposal)
+    review_path = _write(tmp_path / "review.json", review_proposal(
+        proposal_path,
+        disposition="accepted",
+        reviewer="risk-owner",
+        note="Accept one reversible parameter-only trial.",
+    ))
+
+    change = apply_proposal(workspace, proposal_path, review_path)
+    updated = json.loads((workspace / "clawock.json").read_text())
+    assert updated["workflow_parameters"] == {"min_opposing_evidence": 2}
+
+    rollback_change(workspace, change["change_id"])
+
+    assert (workspace / "clawock.json").read_text() == original
+    history = [
+        json.loads(line)
+        for line in (workspace / ".clawock/improvements/history.jsonl").read_text().splitlines()
+    ]
+    assert [event["kind"] for event in history] == [
+        "workflow-improvement-change", "workflow-improvement-rollback"
+    ]


### PR DESCRIPTION
## Outcome

Adds the evidence-backed, reviewable and reversible improvement slice of #386
without making clawock an agent or changing the KCNyu investment strategy.

## What changed

- Bumps the portable `investment-decision` workflow to 1.1.0 and ships outcome,
  proposal and example contracts in the Agent Skill pack.
- Reconciles observed entry/outcome prices and both FX rates with Decimal math,
  reporting quote/base moves and a direction-adjusted basis-point result with an
  explicit not-realized-P&L boundary.
- Lets an outcome evaluation or rejected validation receipt anchor a proposal
  that can change only the three existing bounded evidence/provenance parameters.
- Splits adoption into exact-hash accept/reject review, apply with before/after
  record, and drift-safe rollback.
- Carries the workflow contract on rejected run receipts so validation failures
  are usable evidence rather than detached error text.

## Non-goals / safety boundary

- No model invocation, autonomous agent loop, prompt/SKILL self-edit, or
  self-approval.
- No new factor, catalyst, signal, entry/exit rule, portfolio rule, or change to
  the existing KCNyu strategy, OpenClaw context, memory, skill discovery or cron.
- No claim yet of the two-runtime evidence required to close #386.

## Evidence

- 11 targeted package/workflow/wheel tests passed.
- 3 bounded-improvement tests passed after final changes.
- FX mutation changed 213.08 bps to 200.00 bps and the reconciliation test failed
  as intended; mutation was restored.
- Agent Skill quick validation passed.
- Draft 2020-12 schemas and bundled examples validated.
- Money integrity: 0 ERROR / 0 WARN.
- Full required suite is delegated to GitHub Actions.

Refs #386
