### PR TITLE
refactor: configure the external OpenClaw runtime

### DIFF
--- a/clawock/providers/delivery.py
+++ b/clawock/providers/delivery.py
@@ -77,10 +77,10 @@ class OpenClawDelivery:
 
     def __init__(self, binary: str | None = None, account: str | None = None,
                  timeout: int = 60, runner=None) -> None:
-        # Default to the adapter's own constant so callers do not have to know
-        # the path — that knowledge is what this package exists to contain.
-        from clawock.providers.openclaw import OPENCLAW_BIN
-        self.binary = binary or OPENCLAW_BIN
+        # Resolve at construction time so one installed wheel can target a
+        # non-default runtime without importing host constants.
+        from clawock.providers.openclaw import runtime_paths
+        self.binary = binary or runtime_paths().binary
         self.account = account
         self.timeout = timeout
         self._runner = runner or self._run

--- a/clawock/providers/openclaw.py
+++ b/clawock/providers/openclaw.py
@@ -15,11 +15,13 @@ imported it at call time and raised `ModuleNotFoundError` outside the checkout.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
 # pnpm's global bin. Kept as one constant rather than resolved through PATH: the
 # cron environment is not a login shell, and PATH resolution has bitten this
@@ -33,6 +35,68 @@ OPENCLAW_HOME = Path("/root/.openclaw")
 CRON_RUNS_DIR = OPENCLAW_HOME / "cron" / "runs"
 CRON_JOBS_JSON = OPENCLAW_HOME / "cron" / "jobs.json"
 STATE_DB = OPENCLAW_HOME / "state" / "openclaw.sqlite"
+# The npm/pnpm install is a different root from the state home.
+INSTALL_DIR = Path("/root/.local/share/pnpm/global/5/node_modules/openclaw")
+
+
+@dataclass(frozen=True)
+class OpenClawPaths:
+    """One OpenClaw installation, without assuming this host's layout."""
+
+    binary: str
+    home: Path
+    install_dir: Path
+
+    @property
+    def cron_runs_dir(self) -> Path:
+        return self.home / "cron" / "runs"
+
+    @property
+    def cron_jobs_json(self) -> Path:
+        return self.home / "cron" / "jobs.json"
+
+    @property
+    def state_db(self) -> Path:
+        return self.home / "state" / "openclaw.sqlite"
+
+    @property
+    def workspace(self) -> Path:
+        return self.home / "workspace"
+
+    @property
+    def config_file(self) -> Path:
+        return self.home / "openclaw.json"
+
+    @property
+    def memory_index_db(self) -> Path:
+        return self.home / "agents" / "main" / "agent" / "openclaw-agent.sqlite"
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self.home / "agents" / "main" / "sessions"
+
+    @property
+    def supervisor_handoff(self) -> Path:
+        return self.home / "gateway-supervisor-restart-handoff.json"
+
+    @property
+    def workspace_memory_tmp(self) -> Path:
+        return self.workspace / "memory" / ".tmp"
+
+
+def runtime_paths(environ: Mapping[str, str] | None = None) -> OpenClawPaths:
+    """Resolve the selected external OpenClaw runtime.
+
+    `CLAWOCK_OPENCLAW_*` is the package-facing namespace. `OPENCLAW_HOME` stays
+    as a compatibility fallback for existing operator scripts.
+    """
+    env = os.environ if environ is None else environ
+    binary = env.get("CLAWOCK_OPENCLAW_BIN") or OPENCLAW_BIN
+    home_override = env.get("CLAWOCK_OPENCLAW_HOME") or env.get("OPENCLAW_HOME")
+    home = Path(home_override).expanduser() if home_override else OPENCLAW_HOME
+    install_override = env.get("CLAWOCK_OPENCLAW_INSTALL_DIR")
+    install_dir = Path(install_override).expanduser() if install_override else INSTALL_DIR
+    return OpenClawPaths(binary=binary, home=home, install_dir=install_dir)
 
 # `cron list --json` round-trips through the gateway and has been observed at
 # ~42s on a loaded host. A tight timeout trips TimeoutExpired, which callers
@@ -40,7 +104,7 @@ STATE_DB = OPENCLAW_HOME / "state" / "openclaw.sqlite"
 CRON_TIMEOUT_SECONDS = 120
 
 
-def cron_cli_json(cli_args, *, binary: str = OPENCLAW_BIN,
+def cron_cli_json(cli_args, *, binary: str | None = None,
                   timeout: int = CRON_TIMEOUT_SECONDS, runner=None):
     """Run `openclaw cron <args> --json` and parse the object it prints.
 
@@ -51,10 +115,11 @@ def cron_cli_json(cli_args, *, binary: str = OPENCLAW_BIN,
     Leading `Config warnings:` noise is skipped: the CLI prints it before the
     JSON body and it is not an error.
     """
+    selected_binary = binary or runtime_paths().binary
     run = runner or (lambda cmd: subprocess.run(
         cmd, capture_output=True, text=True, timeout=timeout))
     try:
-        done = run([binary, "cron", *cli_args])
+        done = run([selected_binary, "cron", *cli_args])
         # Deliberately NOT gated on returncode: the original helper parsed
         # stdout regardless, and a command that exits non-zero while still
         # printing a valid object was treated as data. Preserving that keeps
@@ -93,9 +158,10 @@ class CronRead:
     source: str
 
 
-def _open_state_db():
+def _open_state_db(paths: OpenClawPaths | None = None):
     """Open the OpenClaw state DB read-only, including its live WAL."""
-    return sqlite3.connect(f"file:{STATE_DB}?mode=ro", uri=True, timeout=5)
+    state_db = (paths or runtime_paths()).state_db
+    return sqlite3.connect(f"file:{state_db}?mode=ro", uri=True, timeout=5)
 
 
 def _sqlite_store_key(conn):
@@ -106,10 +172,10 @@ def _sqlite_store_key(conn):
     return row[0] if row else None
 
 
-def _sqlite_jobs():
+def _sqlite_jobs(paths: OpenClawPaths | None = None):
     """Return live cron jobs from SQLite, or None when the DB/schema is unreadable."""
     try:
-        with _open_state_db() as conn:
+        with _open_state_db(paths) as conn:
             conn.execute("PRAGMA query_only = ON")
             store_key = _sqlite_store_key(conn)
             if store_key is None:
@@ -134,8 +200,9 @@ def _sqlite_jobs():
         return None
 
 
-def _fossil_jobs():
-    for path in (CRON_JOBS_JSON, CRON_JOBS_JSON.with_suffix(".json.migrated")):
+def _fossil_jobs(paths: OpenClawPaths | None = None):
+    jobs_json = (paths or runtime_paths()).cron_jobs_json
+    for path in (jobs_json, jobs_json.with_suffix(".json.migrated")):
         try:
             data = json.loads(path.read_text())
             jobs = data if isinstance(data, list) else data.get("jobs", data.get("items", []))
@@ -149,10 +216,10 @@ def _fossil_jobs():
     return None
 
 
-def _sqlite_runs(job_id):
+def _sqlite_runs(job_id, paths: OpenClawPaths | None = None):
     """Return one job's finished runs oldest→newest, or None if SQLite is unreadable."""
     try:
-        with _open_state_db() as conn:
+        with _open_state_db(paths) as conn:
             conn.execute("PRAGMA query_only = ON")
             store_key = _sqlite_store_key(conn)
             if store_key is None:
@@ -170,9 +237,10 @@ def _sqlite_runs(job_id):
         return None
 
 
-def _fossil_runs(job_id):
+def _fossil_runs(job_id, paths: OpenClawPaths | None = None):
     out = []
-    for cand in (CRON_RUNS_DIR / f"{job_id}.jsonl", CRON_RUNS_DIR / f"{job_id}.jsonl.migrated"):
+    runs_dir = (paths or runtime_paths()).cron_runs_dir
+    for cand in (runs_dir / f"{job_id}.jsonl", runs_dir / f"{job_id}.jsonl.migrated"):
         try:
             if not cand.exists():
                 continue
@@ -197,7 +265,7 @@ def _fossil_runs(job_id):
     return None
 
 
-def read_jobs(source: str = "auto") -> CronRead:
+def read_jobs(source: str = "auto", *, paths: OpenClawPaths | None = None) -> CronRead:
     """Cron jobs from auto|cli|sqlite|fossil.
 
     Auto prefers the public CLI, then the same live SQLite state read-only. The
@@ -207,31 +275,34 @@ def read_jobs(source: str = "auto") -> CronRead:
     if source not in SOURCES:
         raise ValueError(f"unsupported cron source: {source}")
     if source in {"auto", "cli"}:
-        data = cron_cli_json(["list", "--json"])
+        data = (cron_cli_json(["list", "--json"], binary=paths.binary)
+                if paths else cron_cli_json(["list", "--json"]))
         if isinstance(data, dict) and isinstance(data.get("jobs"), list):
             return CronRead(data["jobs"], "cli")
         if source == "cli":
             return CronRead([], "empty")
     if source in {"auto", "sqlite"}:
-        jobs = _sqlite_jobs()
+        jobs = _sqlite_jobs(paths)
         if jobs is not None:
             return CronRead(jobs, "sqlite")
         if source == "sqlite":
             return CronRead([], "empty")
     if source in {"auto", "fossil"}:
-        jobs = _fossil_jobs()
+        jobs = _fossil_jobs(paths)
         if jobs is not None:
             return CronRead(jobs, "fossil")
     return CronRead([], "empty")
 
 
-def read_runs(job_id: str, source: str = "auto") -> CronRead:
+def read_runs(job_id: str, source: str = "auto", *,
+              paths: OpenClawPaths | None = None) -> CronRead:
     """Finished-run records for a job, OLDEST→NEWEST (so callers' [-1] = newest).
     Auto uses CLI → read-only SQLite → migrated JSONL fossil."""
     if source not in SOURCES:
         raise ValueError(f"unsupported cron source: {source}")
     if source in {"auto", "cli"}:
-        data = cron_cli_json(["runs", "--id", job_id])
+        data = (cron_cli_json(["runs", "--id", job_id], binary=paths.binary)
+                if paths else cron_cli_json(["runs", "--id", job_id]))
         if isinstance(data, dict) and isinstance(data.get("entries"), list):
             finished = [e for e in data["entries"] if e.get("action") in (None, "finished")]
             # CLI returns newest-first; reverse to match the old append-order contract.
@@ -239,13 +310,13 @@ def read_runs(job_id: str, source: str = "auto") -> CronRead:
         if source == "cli":
             return CronRead([], "empty")
     if source in {"auto", "sqlite"}:
-        entries = _sqlite_runs(job_id)
+        entries = _sqlite_runs(job_id, paths)
         if entries is not None:
             return CronRead(entries, "sqlite")
         if source == "sqlite":
             return CronRead([], "empty")
     if source in {"auto", "fossil"}:
-        entries = _fossil_runs(job_id)
+        entries = _fossil_runs(job_id, paths)
         if entries is not None:
             print(f"warn: live cron runs unreadable; using STALE migrated JSONL "
                   f"for {job_id}", file=sys.stderr)
@@ -264,7 +335,7 @@ def read_runs(job_id: str, source: str = "auto") -> CronRead:
 # second runtime reimplements the mapping, not the callers.
 
 
-def read_jobs_strict(*, runner=None) -> list[dict]:
+def read_jobs_strict(*, paths: OpenClawPaths | None = None, runner=None) -> list[dict]:
     """Jobs from the CLI, raising if the runtime cannot be read.
 
     `read_jobs` is fail-soft on purpose: for a watchdog, an unreachable runtime
@@ -274,7 +345,8 @@ def read_jobs_strict(*, runner=None) -> list[dict]:
     writer path gets its own read, and the difference is stated rather than left
     to whoever calls which.
     """
-    data = cron_cli_json(["list", "--json"], runner=runner)
+    data = cron_cli_json(
+        ["list", "--json"], binary=paths.binary if paths else None, runner=runner)
     if not isinstance(data, dict):
         raise RuntimeError("openclaw cron list failed: no JSON object returned")
     jobs = data.get("jobs")
@@ -284,7 +356,7 @@ def read_jobs_strict(*, runner=None) -> list[dict]:
 
 
 def build_cron_edit_argv(job_id: str, patch: dict, *,
-                         binary: str = OPENCLAW_BIN,
+                         binary: str | None = None,
                          run_timeout_ms: int | None = None) -> list[str]:
     """One job patch as this runtime's `cron edit` command line.
 
@@ -296,7 +368,7 @@ def build_cron_edit_argv(job_id: str, patch: dict, *,
     sync runs from crontab, where a bare name resolves only because the entry
     happens to use a login shell.
     """
-    command = [binary, "cron", "edit", job_id]
+    command = [binary or runtime_paths().binary, "cron", "edit", job_id]
     if "schedule" in patch:
         schedule = patch["schedule"]
         if not schedule.get("tz"):
@@ -357,11 +429,9 @@ def build_cron_edit_argv(job_id: str, patch: dict, *,
 LIVE_WORKSPACE = OPENCLAW_HOME / "workspace"
 CONFIG_FILE = OPENCLAW_HOME / "openclaw.json"
 MEMORY_INDEX_DB = OPENCLAW_HOME / "agents" / "main" / "agent" / "openclaw-agent.sqlite"
-# The npm/pnpm install, which is a different root from the state home.
-INSTALL_DIR = Path("/root/.local/share/pnpm/global/5/node_modules/openclaw")
 
 
-def is_installed() -> bool:
+def is_installed(paths: OpenClawPaths | None = None) -> bool:
     """Whether this runtime is present on this host.
 
     Callers ask the capability question — "is there a runtime here?" — rather
@@ -369,4 +439,4 @@ def is_installed() -> bool:
     answer False, which is what lets an operator check skip cleanly instead of
     reporting a fault that only means "not this machine".
     """
-    return Path(OPENCLAW_BIN).exists()
+    return Path((paths or runtime_paths()).binary).exists()

--- a/docs/architecture/openclaw-adapter.md
+++ b/docs/architecture/openclaw-adapter.md
@@ -7,6 +7,18 @@ scheduler, and delivery channel. clawock contributes a stable CLI plus portable
 decision workflows, deterministic validation/reconciliation, artifacts and
 receipts.
 
+The adapter resolves a runtime at execution time instead of assuming this
+server's filesystem. Installed packages may set:
+
+- `CLAWOCK_OPENCLAW_BIN` — absolute OpenClaw CLI path;
+- `CLAWOCK_OPENCLAW_HOME` — runtime state home (with `OPENCLAW_HOME` accepted as
+  a compatibility fallback);
+- `CLAWOCK_OPENCLAW_INSTALL_DIR` — npm/pnpm package root for operator checks.
+
+Cron SQLite, fossil history, workspace, session and memory-index paths are
+derived from that selected home. These settings locate an external runtime;
+they do not make clawock launch a model or own an agent loop.
+
 ## Context profiles
 
 The contract was verified against the installed OpenClaw 2026.7.1 source and

--- a/scripts/data/gc_sessions.py
+++ b/scripts/data/gc_sessions.py
@@ -26,10 +26,14 @@ import sys
 import time
 from pathlib import Path
 
-OPENCLAW_HOME = Path(os.environ.get('OPENCLAW_HOME', '/root/.openclaw'))
-SESSIONS_DIR  = OPENCLAW_HOME / 'agents' / 'main' / 'sessions'
-HANDOFF_FILE  = OPENCLAW_HOME / 'gateway-supervisor-restart-handoff.json'
-WORKSPACE_TMP = OPENCLAW_HOME / 'workspace' / 'memory' / '.tmp'
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+from clawock.providers.openclaw import runtime_paths  # noqa: E402
+
+_OPENCLAW_PATHS = runtime_paths()
+SESSIONS_DIR = _OPENCLAW_PATHS.sessions_dir
+HANDOFF_FILE = _OPENCLAW_PATHS.supervisor_handoff
+WORKSPACE_TMP = _OPENCLAW_PATHS.workspace_memory_tmp
 
 KEEP_TRAJECTORY_DAYS = int(os.environ.get('GC_KEEP_TRAJECTORY_DAYS', '7'))
 KEEP_SESSION_DAYS    = int(os.environ.get('GC_KEEP_SESSION_DAYS',    '14'))

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -56,17 +56,17 @@ HKT = timezone(timedelta(hours=8))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from clawock.providers import openclaw as _openclaw  # noqa: E402
 from clawock.providers.openclaw import (  # noqa: E402
-    OPENCLAW_HOME, cron_cli_json as _adapter_cron_json,
+    cron_cli_json as _adapter_cron_json, runtime_paths as _openclaw_paths,
 )
 
 # Where the runtime keeps its session transcripts. The location is the runtime's,
 # so the adapter owns it (#330 step 1): this module used to hard-code
 # `Path('/root/.openclaw')`, which made it one of the ten sites that know which
-# runtime they are on. Deriving it from the adapter's constant is the fix the
-# ratchet is asking for — not a relocated string, because `clawock/providers/` is
-# the one place where knowing is correct, and it is already this module's source
-# for OPENCLAW_HOME and the cron chain.
-SESSIONS_DIR = OPENCLAW_HOME / 'agents' / 'main' / 'sessions'
+# runtime they are on. Deriving it from the adapter's selected runtime is the
+# fix the ratchet is asking for — not a relocated string, because
+# `clawock/providers/` is the one place where knowing is correct and is already
+# this module's source for runtime paths and the cron chain.
+SESSIONS_DIR = _openclaw_paths().sessions_dir
 
 
 def log(event):

--- a/scripts/system_check.py
+++ b/scripts/system_check.py
@@ -35,12 +35,15 @@ sys.path.insert(0, str(_REPO_ROOT))
 # it migrates last on purpose: it is what proves the earlier steps did not break
 # anything. All of these are absent in CI, where the checks skip.
 from clawock.providers.openclaw import (  # noqa: E402
-    INSTALL_DIR as OPENCLAW_INSTALL,
-    LIVE_WORKSPACE,
-    MEMORY_INDEX_DB,
-    CONFIG_FILE as OPENCLAW_CONFIG,
     is_installed as openclaw_is_installed,
+    runtime_paths as openclaw_runtime_paths,
 )
+
+_OPENCLAW_PATHS = openclaw_runtime_paths()
+OPENCLAW_INSTALL = _OPENCLAW_PATHS.install_dir
+LIVE_WORKSPACE = _OPENCLAW_PATHS.workspace
+MEMORY_INDEX_DB = _OPENCLAW_PATHS.memory_index_db
+OPENCLAW_CONFIG = _OPENCLAW_PATHS.config_file
 
 MEMORY_INDEX_LOG = LIVE_WORKSPACE / 'logs' / 'memory_index.log'
 # Nightly reindex is 05:10 HKT; 30h lets one run slip into the next daily review

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -59,11 +59,56 @@ def _make_state_db(path):
             )
 
 
+def test_runtime_paths_derive_one_external_installation():
+    paths = provider.runtime_paths({
+        "CLAWOCK_OPENCLAW_BIN": "/opt/openclaw/bin/openclaw",
+        "CLAWOCK_OPENCLAW_HOME": "/srv/openclaw-state",
+        "CLAWOCK_OPENCLAW_INSTALL_DIR": "/opt/openclaw/package",
+    })
+
+    assert paths.binary == "/opt/openclaw/bin/openclaw"
+    assert paths.state_db == Path("/srv/openclaw-state/state/openclaw.sqlite")
+    assert paths.sessions_dir == Path("/srv/openclaw-state/agents/main/sessions")
+    assert paths.workspace == Path("/srv/openclaw-state/workspace")
+    assert paths.install_dir == Path("/opt/openclaw/package")
+
+
+def test_explicit_runtime_reads_its_own_sqlite(tmp_path):
+    paths = provider.OpenClawPaths(
+        binary="/opt/openclaw/bin/openclaw",
+        home=tmp_path / "external-runtime",
+        install_dir=tmp_path / "package",
+    )
+    paths.state_db.parent.mkdir(parents=True)
+    _make_state_db(paths.state_db)
+
+    jobs = provider.read_jobs("sqlite", paths=paths)
+    runs = provider.read_runs("job-1", "sqlite", paths=paths)
+
+    assert jobs.source == runs.source == "sqlite"
+    assert jobs.entries[0]["name"] == "live job"
+    assert [entry["ts"] for entry in runs.entries] == [100, 200]
+
+
+def test_runtime_binary_override_reaches_read_and_write_commands(monkeypatch):
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_BIN", "/opt/openclaw/bin/openclaw")
+    seen = []
+
+    class Result:
+        stdout = '{"jobs": []}'
+
+    provider.cron_cli_json(
+        ["list", "--json"], runner=lambda cmd: seen.append(cmd) or Result())
+    edit = provider.build_cron_edit_argv("job-1", {"enabled": True})
+
+    assert seen[0][0] == edit[0] == "/opt/openclaw/bin/openclaw"
+
+
 def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
-    db = tmp_path / "openclaw.sqlite"
+    db = tmp_path / "state" / "openclaw.sqlite"
+    db.parent.mkdir()
     _make_state_db(db)
-    monkeypatch.setattr(provider, "STATE_DB", db)
-    monkeypatch.setattr(provider, "CRON_JOBS_JSON", tmp_path / "jobs.json")
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
     monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
     jobs = common.load_jobs()
@@ -75,9 +120,10 @@ def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
 
 
 def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
-    db = tmp_path / "openclaw.sqlite"
+    db = tmp_path / "state" / "openclaw.sqlite"
+    db.parent.mkdir()
     _make_state_db(db)
-    monkeypatch.setattr(provider, "STATE_DB", db)
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
     monkeypatch.setattr(
         provider,
         "cron_cli_json",
@@ -91,10 +137,10 @@ def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
 
 
 def test_fossil_source_is_marked_stale(tmp_path, monkeypatch):
-    monkeypatch.setattr(provider, "STATE_DB", tmp_path / "missing.sqlite")
-    jobs_json = tmp_path / "jobs.json"
+    monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
+    jobs_json = tmp_path / "cron" / "jobs.json"
+    jobs_json.parent.mkdir()
     jobs_json.write_text(json.dumps([{"id": "old", "name": "stale"}]))
-    monkeypatch.setattr(provider, "CRON_JOBS_JSON", jobs_json)
     monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
     assert common.load_jobs() == [{"id": "old", "name": "stale"}]

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -63,24 +63,12 @@ RUNTIME = "openclaw"
 # took the runtime's layout and an is_installed() capability from the adapter
 # (#330 step 3, last on purpose — it is what proves the earlier steps held).
 #
-# 1 is the floor, not a waypoint: see DELIBERATE_EXCLUSIONS below. The ratchet
-# has arrived, and what remains is a decision rather than debt.
-BASELINE = 1
+# 6 → 1 when system_check moved behind the adapter; 1 → 0 when the remaining
+# operator-owned session collector started asking the same adapter for runtime
+# paths. Zero means no code outside the provider knows a host-specific layout.
+BASELINE = 0
 
-# The honest floor is 1, not 0 — say it rather than let a future reader assume
-# the remaining count is all debt.
-#
-# `gc_sessions.py` keeps its site by decision (#330). Its OPENCLAW_HOME cleans
-# the runtime's OWN session files: that is running the runtime, not our harness
-# depending on it. Removing the site would mean moving the whole script into
-# clawock/providers/, which is a different argument and probably not worth
-# making — a garbage collector for someone else's files is not part of a
-# portable harness's interface.
-#
-# Nothing remains to migrate. Every other consumer now reaches the runtime
-# through clawock/providers/, which is what makes "it happens to run on OpenClaw"
-# a description of deployment rather than of the code.
-DELIBERATE_EXCLUSIONS = {"scripts/data/gc_sessions.py": 1}
+DELIBERATE_EXCLUSIONS = {}
 HONEST_FLOOR = sum(DELIBERATE_EXCLUSIONS.values())
 
 _SPAWNERS = {"run", "call", "check_call", "check_output", "Popen", "system", "getoutput"}


### PR DESCRIPTION
## Outcome

Make one installed clawock wheel target an external OpenClaw runtime without
assuming this server's binary, home or pnpm layout.

## Changes

- add a typed OpenClaw runtime path map selected by environment or explicit
  adapter injection;
- derive cron SQLite/fossil history, workspace, sessions, config and memory
  index from the selected runtime home;
- route delivery, watchdog transcripts, system checks and session GC through
  that adapter;
- lower the host-layout coupling ratchet outside providers from 1 to 0;
- document the three package-facing configuration variables.

This is one cutover prerequisite for #380. It does not close the issue: the
isolated OpenClaw canary and full live cron migration remain separate evidence.

## Evidence

- 34 targeted provider/cron tests passed;
- 16 system-check/import-path tests passed;
- configured read-only live SQLite audit returned 11 enabled jobs: 10 market
  jobs plus OpenClaw memory dreaming;
- tracked live cron contract passed with explicit runtime configuration;
- a real wheel installed in a clean venv resolved a non-default OpenClaw binary
  and state home outside the source checkout;
- dry-run session GC resolved the same live runtime paths without deleting;
- diff check and Python compilation passed.

## Safety and product boundary

- no live cron row, payload, schedule, model, fallback, thinking, tool set,
  delivery target or watchdog state was changed;
- no model was invoked and no message was sent;
- no factor, OI input, catalyst, signal, entry/exit or portfolio logic changed;
- clawock still locates an external agent runtime; it does not become an agent
  or model launcher.
