### PR TITLE
fix: avoid WebKit Reflect masonry stalls

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -381,6 +381,19 @@
     .panel.active > .card.lead .sentiment-drill > * {
       break-inside: avoid; margin-bottom: var(--space-2);
     }
+    /* WebKit/Safari can stall while activating Reflect when dynamically sized
+       ECharts canvases live inside this multi-column formatting context. Keep
+       the Chromium masonry everywhere else; only Reflect in WebKit falls back
+       to ordinary block flow. Reset the column-only child hints as well so
+       Safari never has to construct a latent spanning/fragmentation context. */
+    html.is-webkit .panel.active[data-panel="reflect"] {
+      column-count: auto;
+      column-gap: normal;
+    }
+    html.is-webkit .panel.active[data-panel="reflect"] > * {
+      break-inside: auto;
+      column-span: none;
+    }
   }
   .desktop-section-kicker { display: none; }
   /* =========================================================

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -6,6 +6,14 @@
 
   const pager = document.getElementById("pager");
   const DESKTOP_MQ = window.matchMedia("(min-width: 1024px)");
+  // Safari/WebKit can synchronously stall when ECharts canvases are initialized
+  // inside Reflect's desktop multi-column formatting context. Mark WebKit once;
+  // CSS applies a Reflect-only ordinary-flow fallback at the desktop breakpoint.
+  // Chromium keeps the balanced masonry layout, and mobile pager geometry is
+  // untouched because the fallback lives inside the desktop media query.
+  const WEBKIT = /AppleWebKit/i.test(navigator.userAgent || "") &&
+    /Apple/i.test(navigator.vendor || "");
+  document.documentElement.classList.toggle("is-webkit", WEBKIT);
   // The CSS breakpoint is the source of truth; matchMedia avoids a forced style
   // calculation after setActiveButton() has just changed panel classes.
   const pagerLive = () => !!pager && !DESKTOP_MQ.matches;

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -55,6 +55,22 @@ def test_holdings_dividers_do_not_partition_the_masonry_flow():
     ) == 2
 
 
+def test_webkit_reflect_uses_desktop_only_ordinary_flow_fallback():
+    ui = (ROOT / "assets" / "js" / "dashboard.ui.js").read_text()
+    assert "/AppleWebKit/i.test" in ui
+    assert 'classList.toggle("is-webkit", WEBKIT)' in ui
+
+    selector = 'html.is-webkit .panel.active[data-panel="reflect"] {'
+    start = CSS.index(selector)
+    block = enclosing_desktop_block(start)
+    rule = CSS[start:CSS.index("}", start)]
+    assert selector in block
+    assert "column-count: auto" in rule
+    assert 'html.is-webkit .panel.active[data-panel="reflect"] > * {' in block
+    assert "break-inside: auto" in block
+    assert "column-span: none" in block
+
+
 def test_desktop_numeric_and_overview_height_rules_are_scoped_to_desktop():
     honesty = CSS.index(
         ".overview-command > .hero-honesty-card { align-self: start; }"


### PR DESCRIPTION
## Outcome

Prevents Safari/WebKit desktop from stalling while activating Reflect.

- Detects Apple WebKit once in the UI bootstrap.
- Falls back to ordinary block flow only for the Reflect panel inside the desktop breakpoint.
- Resets direct-child fragmentation and spanning hints for that fallback.
- Keeps Chromium two-column masonry unchanged.
- Leaves the mobile scroll-snap pager untouched.

## Evidence

The issue already records the controlled WebKit reproduction and diagnostic CSS override: removing the Reflect multi-column context restores all 9 cards, all 3 canvases, and the full Daily P&L series. This PR makes that exact narrow fallback permanent.

Focused contract check: 7 passed.

Closes #384.