### PR TITLE
feat: export Codex-compatible workflow schemas

### DIFF
--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -312,6 +312,7 @@ def _workflow(args) -> int:
         list_workflows,
         load_workflow,
         review_proposal,
+        render_workflow_schema,
         rollback_change,
     )
 
@@ -353,6 +354,11 @@ def _workflow(args) -> int:
             return 0
         if args.workflow_command == "show":
             emit(load_workflow(args.workflow_id).as_dict())
+            return 0
+        if args.workflow_command == "schema":
+            emit(render_workflow_schema(
+                args.workflow_id, args.artifact, dialect=args.dialect
+            ))
             return 0
         if args.workflow_command == "evaluate":
             emit(evaluate_files(args.workflow_id, args.decision, args.outcome))
@@ -500,6 +506,16 @@ def main(argv=None) -> int:
     workflow_show = workflow_sub.add_parser("show", help="print a workflow contract")
     workflow_show.add_argument("workflow_id")
     workflow_show.set_defaults(func=_workflow)
+    workflow_schema = workflow_sub.add_parser(
+        "schema", help="export an artifact schema for an external runtime")
+    workflow_schema.add_argument("workflow_id")
+    workflow_schema.add_argument("artifact")
+    workflow_schema.add_argument(
+        "--dialect", choices=("canonical", "codex"), default="canonical",
+        help="canonical validation schema or Codex structured-output subset",
+    )
+    workflow_schema.add_argument("--output", type=Path)
+    workflow_schema.set_defaults(func=_workflow)
     workflow_install = workflow_sub.add_parser(
         "install", help="install a workflow as a standard Agent Skill")
     workflow_install.add_argument("workflow_id")

--- a/src/clawock/workflows/__init__.py
+++ b/src/clawock/workflows/__init__.py
@@ -15,9 +15,11 @@ from .improvements import (
     rollback_change,
 )
 from .validators import validators_for
+from .schemas import DIALECTS, render_workflow_schema
 
 __all__ = [
     "WorkflowPack",
+    "DIALECTS",
     "apply_proposal",
     "create_proposal",
     "evaluate_files",
@@ -25,6 +27,7 @@ __all__ = [
     "list_workflows",
     "load_workflow",
     "review_proposal",
+    "render_workflow_schema",
     "rollback_change",
     "validators_for",
     "workflow_contract",

--- a/src/clawock/workflows/schemas.py
+++ b/src/clawock/workflows/schemas.py
@@ -1,0 +1,66 @@
+"""Render workflow artifact schemas for external runtime dialects.
+
+The canonical files stay full JSON Schema and remain the contract clawock uses
+after an agent returns an artifact. Runtime structured-output features commonly
+accept only a subset. A projection can relax generation-time constraints, but it
+must never replace canonical post-generation validation.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .registry import load_workflow
+
+
+DIALECTS = ("canonical", "codex")
+
+# OpenAI Structured Outputs supports only a subset of JSON Schema. These
+# assertions are still enforced by clawock after Codex returns decision.json.
+_CODEX_OMIT = {
+    "$schema",
+    "$id",
+    "uniqueItems",
+    "minLength",
+    "maxLength",
+}
+
+
+def _codex_projection(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_codex_projection(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    projected: dict[str, Any] = {}
+    for key, item in value.items():
+        if key in _CODEX_OMIT:
+            continue
+        if key == "const":
+            projected["enum"] = [_codex_projection(item)]
+            continue
+        if key == "oneOf":
+            projected["anyOf"] = _codex_projection(item)
+            continue
+        projected[key] = _codex_projection(item)
+    return projected
+
+
+def render_workflow_schema(
+    workflow_id: str, artifact: str, *, dialect: str = "canonical"
+) -> dict[str, Any]:
+    """Return one packaged artifact schema without mutating its canonical form."""
+    if dialect not in DIALECTS:
+        raise ValueError(
+            f"unknown schema dialect {dialect!r}; available: {', '.join(DIALECTS)}"
+        )
+    pack = load_workflow(workflow_id)
+    relative = pack.descriptor["schemas"].get(artifact)
+    if not isinstance(relative, str):
+        available = ", ".join(sorted(pack.descriptor["schemas"]))
+        raise ValueError(
+            f"workflow {workflow_id!r} has no schema for {artifact!r}; "
+            f"available: {available}"
+        )
+    schema = json.loads(pack.resource.joinpath(relative).read_text(encoding="utf-8"))
+    return schema if dialect == "canonical" else _codex_projection(schema)

--- a/tests/test_portable_workflow.py
+++ b/tests/test_portable_workflow.py
@@ -2,7 +2,11 @@
 import copy
 import json
 
-from clawock.workflows import load_workflow, validators_for
+from clawock.workflows import (
+    load_workflow,
+    render_workflow_schema,
+    validators_for,
+)
 
 
 def _example():
@@ -54,3 +58,28 @@ def test_order_and_fx_totals_are_reconciled_to_currency_cents():
 
     assert "gross_amount_mismatch" not in codes
     assert "fx_amount_mismatch" in codes
+
+
+def test_codex_schema_is_a_relaxed_projection_not_the_final_validator():
+    canonical = render_workflow_schema(
+        "investment-decision", "decision.json", dialect="canonical"
+    )
+    codex = render_workflow_schema(
+        "investment-decision", "decision.json", dialect="codex"
+    )
+    serialized = json.dumps(codex)
+
+    assert canonical["properties"]["decision"]["properties"][
+        "evidence_ids"
+    ]["uniqueItems"] is True
+    assert "uniqueItems" not in serialized
+    assert "minLength" not in serialized
+    assert "oneOf" not in serialized
+    assert '"const"' not in serialized
+    assert codex["properties"]["schema_version"]["enum"] == [1]
+    assert "anyOf" in codex["properties"]["decision"]["properties"]["order"]
+
+    # Relaxing the model-facing schema must not relax clawock's own gate.
+    invalid = _example()
+    invalid["decision"]["evidence_ids"] = ["filing-growth", "filing-growth"]
+    assert "duplicate_evidence_reference" in _codes(invalid)


### PR DESCRIPTION
## Outcome

Lets an external Codex runtime execute the same packaged investment-decision workflow without making clawock an agent or model launcher.

- Adds `clawock workflow schema <workflow> <artifact> --dialect codex`.
- Projects the canonical JSON Schema into the Structured Outputs subset accepted by Codex.
- Keeps the full canonical schema and deterministic clawock validator as the final authority.
- Does not add a model client, agent loop, prompt router, tool loop, memory system, or provider credential.

OpenAI documents that `codex exec --output-schema` accepts a JSON Schema for the final response, while Structured Outputs supports a subset of JSON Schema:
- https://learn.chatgpt.com/docs/non-interactive-mode
- https://developers.openai.com/api/docs/guides/structured-outputs

## Real second-runtime evidence

External runtime:

- Codex CLI 0.147.0
- model `gpt-5.6-sol`
- provider `openai`
- read-only sandbox
- `--output-schema` generated by this PR
- synthetic `INTEROP` context only; no live portfolio or strategy inputs

Result:

- Codex generated the required evidence-linked `watch` decision.
- Both supporting and opposing evidence were linked.
- No order was proposed because the context supplied no execution authority.
- `clawock run publish` accepted the artifact with 0 validation issues.
- run: `d69129a04a2e437090d4aa3edd9e9a27`
- generation: `b36e11d7ee6948cfb82a3a125501aac1`

## Verification

- Focused workflow and installed-wheel tests: 4 passed.
- Built `clawock-0.1.0-py3-none-any.whl`, installed it into a clean venv, and exported the Codex schema from `/tmp`.
- The canonical schema still rejects duplicate evidence references after the model-facing projection relaxes `uniqueItems`.

Advances the real non-OpenClaw runtime acceptance in #379. No strategy, factor, OI, catalyst, signal, entry/exit, sizing, or portfolio-rule changes.