### PR TITLE
perf: keep dashboard startup responsive

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -67,18 +67,22 @@
       --border-strong: #B9C6D3;
       --text-primary: #101821;
       --text-secondary: #526170;
-      --text-tertiary: #5E6D7D;
-      --accent: #087DD1;
+      --text-tertiary: #596878;
+      --accent: #006EB8;
       --accent-strong: #0567B1;
       --accent-soft: #DCEEFF;
-      --positive: #138B66;
+      --positive: #08734F;
       --negative: #C83D4A;
-      --warning: #A66F08;
+      --warning: #805400;
       --neutral: #66788D;
       --focus: #0078C9;
       --shadow-topbar: 0 8px 24px rgba(18,33,48,.08);
     }
+    /* Preserve the quiet timestamp hierarchy without blending below WCAG AA. */
+    .asof-faded { color: #263848; }
   }
+
+  .asof-faded { opacity: .7; }
 
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
@@ -291,6 +295,11 @@
        Hero can make Chrome reveal the whole pager a frame late under CPU load,
        which is observable as a large CLS even though the inactive pages benefit. */
     .panel.active { content-visibility: visible; }
+    /* Only the current page and its two swipe neighbours need inner layout.
+       Keeping the neighbour boxes warm preserves native swipe preview while
+       explicit hiding prevents the other full dashboard trees from consuming
+       mobile startup style/layout time. */
+    .panel:not(.active):not(.is-near) { content-visibility: hidden; }
     /* visually hidden but kept in the a11y tree so the heading sequence stays h1→h2→h3
        (display:none would drop the h2 → axe/screen-readers see an h1→h3 skip). NOTE: must
        stay IN FLOW — position:absolute here escapes the horizontal scroll-snap pager and
@@ -1051,7 +1060,7 @@
   .drv-chip.drv-technical  { background: rgba(148,163,184,.18); color: var(--muted); }
   .drv-chip.drv-sentiment  { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
   .drv-chip.drv-influencer { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
-  .drv-chip.drv-macro      { background: rgba(96,165,250,.15); color: #60a5fa; }
+  .drv-chip.drv-macro      { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
   .drv-chip.drv-peer       { background: rgba(45,212,191,.15); color: #2dd4bf; }
   @media (max-width: 600px) {
     .drv-chip { font-size: 9px; padding: 1px 5px; margin-left: 4px; }
@@ -1091,7 +1100,7 @@
     border-radius: 5px; margin-right: 8px; vertical-align: middle;
   }
   .bear-lbl.bl-fal   { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
-  .bear-lbl.bl-watch { background: rgba(96,165,250,.15); color: #60a5fa; }
+  .bear-lbl.bl-watch { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
   /* hidden concentration */
   .hc-headline { font-size: 14px; font-weight: 600; line-height: 1.45; margin-bottom: 12px; }
   .hc-bar-row { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }

--- a/assets/js/dashboard.hero.js
+++ b/assets/js/dashboard.hero.js
@@ -324,8 +324,8 @@
   // registry mutable avoids parsing 100KB+ of functions that Overview cannot call.
   const TAB_RENDERERS = {
     hero: [
-      renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderTotals,
-      renderTodayPnl, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
+      renderTotals, renderTodayPnl, renderRiskGuardrail, renderOverviewSummaries,
+      renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
     ],
   };
   let RENDER_VERSION = 0;
@@ -353,6 +353,39 @@
     if (t === "risk" || t === "market") updateFoldPeeks();
   }
 
+  // Overview is the only runtime on the startup path. Its eight independent
+  // projections used to land in one multi-second mobile task; yield between
+  // them so the browser can paint and accept input while preserving the exact
+  // same final DOM. Detail activations stay synchronous after an explicit tab
+  // choice, where one atomic update is preferable to a partially refreshed tab.
+  function renderLandingTab(t, version, done) {
+    if (t !== "hero" || !hasTabRenderer(t)) {
+      renderTab(t, version);
+      done();
+      return;
+    }
+    const renderers = TAB_RENDERERS[t];
+    let index = 0;
+    const step = () => {
+      if (version !== RENDER_VERSION) return;
+      if (currentTab() !== t) {
+        done();
+        return;
+      }
+      renderers[index++]();
+      if (index < renderers.length) {
+        setTimeout(step, 0);
+        return;
+      }
+      _tabRenderVersion.set(t, version);
+      const panel = document.querySelector(`.panel[data-panel="${t}"]`);
+      if (panel) panel.querySelectorAll(".card.is-pending").forEach(card =>
+        card.classList.remove("is-pending"));
+      done();
+    };
+    step();
+  }
+
   function refreshTab(t) {
     if (!DATA || !hasTabRenderer(t) || currentTab() !== t) return;
     TAB_RENDERERS[t].forEach(fn => fn());
@@ -371,10 +404,11 @@
     renderHeader();
     renderStatusBanner();
     syncDeskRail();
-    renderTab(activeTab, version);
-    renderBuildStatus();
-    syncDeskRail();
-    ensureVisibleCharts();
+    renderLandingTab(activeTab, version, () => {
+      renderBuildStatus();
+      syncDeskRail();
+      ensureVisibleCharts();
+    });
   }
 
   function quoteSessionLabel(market) {
@@ -892,11 +926,11 @@
         `<svg viewBox="0 0 ${W} ${H}" width="100%" height="${H}" preserveAspectRatio="none" style="margin-top:4px">
           ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="var(--warning)" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
           <polyline points="${pts}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
-          <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="#60a5fa"/>
+          <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
         <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
-          <span style="color:#60a5fa">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
+          <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
           <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
         </div>`;

--- a/assets/js/dashboard.render.js
+++ b/assets/js/dashboard.render.js
@@ -1976,11 +1976,11 @@
         `<svg viewBox="0 0 ${W} ${H}" width="100%" height="${H}" preserveAspectRatio="none" style="margin-top:4px">
           ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="var(--warning)" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
           <polyline points="${pts}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
-          <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="#60a5fa"/>
+          <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
         <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
-          <span style="color:#60a5fa">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
+          <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
           <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
         </div>`;

--- a/assets/js/dashboard.ui.js
+++ b/assets/js/dashboard.ui.js
@@ -59,8 +59,11 @@
       b.classList.toggle("active", on);
       b.setAttribute("aria-selected", on);
     });
+    const activeIndex = TAB_ORDER.indexOf(t);
     document.querySelectorAll(".panel").forEach(p => {
-      p.classList.toggle("active", p.dataset.panel === t);
+      const panelIndex = TAB_ORDER.indexOf(p.dataset.panel);
+      p.classList.toggle("active", panelIndex === activeIndex);
+      p.classList.toggle("is-near", Math.abs(panelIndex - activeIndex) === 1);
     });
     if (DATA) {
       // Activation is the consumer boundary: mapped sidecars load first, then
@@ -615,6 +618,7 @@
     // Land on the deep-linked tab BEFORE first paint of data (instant, no animation).
     const t0 = tabFromHash();
     if (t0) goToTab(t0, false);
+    else setActiveButton(TAB_ORDER[0]);
     loadData();
     _scheduleAutoRefresh();
   }

--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@ layout: null
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="clawock">
-<!-- Cloudflare Web Analytics (cookieless, no consent banner). Injected after load +
-     idle so its ~350ms of script eval stays off the first-paint critical path; the
-     beacon still fires for every session, so pageview counts are unaffected. -->
+<!-- Cloudflare Web Analytics (cookieless, no consent banner). Keep the third-party
+     evaluator outside the interaction-critical startup window. A delayed pageview
+     still counts an engaged visit without making the live proof feel slower. -->
 <script>
   (function () {
     function loadBeacon() {
@@ -64,10 +64,7 @@ layout: null
       s.setAttribute("data-cf-beacon", '{"token": "704a5341d8c3422a871d6d11d38b25fe"}');
       document.head.appendChild(s);
     }
-    function schedule() {
-      if (window.requestIdleCallback) requestIdleCallback(loadBeacon, { timeout: 3000 });
-      else setTimeout(loadBeacon, 1200);
-    }
+    function schedule() { setTimeout(loadBeacon, 15000); }
     if (document.readyState === "complete") schedule();
     else window.addEventListener("load", schedule, { once: true });
   })();
@@ -284,7 +281,7 @@ layout: null
         <div id="gold-london"></div>
         <div id="gold-spark"></div>
         <div id="gold-proj"></div>
-        <div class="muted" id="gold-asof" style="font-size:10px;margin-top:var(--space-2);opacity:0.7"></div>
+        <div class="muted asof-faded" id="gold-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
       </div>
     </div>
 
@@ -545,14 +542,14 @@ layout: null
       <div id="lev-regime-trigger" style="font-size:11px;margin-top:5px;line-height:1.5"></div>
       <div class="muted" style="font-size:10px;margin:8px 0 3px;opacity:0.8">US · 2x 单股 per-name（趋势off且波动过热才砍）</div>
       <div class="risk-alerts" id="lev-regime-us"></div>
-      <div class="muted" id="lev-regime-asof" style="font-size:10px;margin-top:var(--space-2);opacity:0.7"></div>
+      <div class="muted asof-faded" id="lev-regime-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
     </div>
 
     <div class="card fold-m" id="reentry-card" data-fold-id="reentry" style="display:none">
       <h3>再入场雷达 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">持币等回均线 → 触发即布局</span><span class="peek" id="peek-reentry"></span></h3>
       <div id="reentry-powder" style="margin-bottom:8px"></div>
       <div id="reentry-list"></div>
-      <div class="muted" id="reentry-asof" style="font-size:10px;margin-top:var(--space-2);opacity:0.7"></div>
+      <div class="muted asof-faded" id="reentry-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
     </div>
 
     <div class="card fold-m" id="breakeven-card" data-fold-id="breakeven" style="display:none">

--- a/tests/test_dashboard_tab_lifecycle.py
+++ b/tests/test_dashboard_tab_lifecycle.py
@@ -27,7 +27,8 @@ def test_hidden_tabs_have_no_idle_or_timeout_renderer():
     assert "scheduleDeferredTabs" not in HERO
     assert "requestIdleCallback" not in HERO
     assert "didTimeout" not in HERO
-    assert "renderTab(activeTab, version)" in HERO
+    assert "renderLandingTab(activeTab, version" in HERO
+    assert "if (currentTab() !== t)" in HERO
     assert "currentTab() !== t" in HERO
 
 


### PR DESCRIPTION
## Outcome

Keeps the live proof visually and functionally intact while removing avoidable startup work found in the post-#396 Lighthouse audit.

- yields between the eight independent Overview projections instead of creating one multi-second startup task
- lays out only the active mobile pager page and its two swipe neighbours; native swipe preview remains intact
- delays third-party analytics outside the interaction-critical window
- preserves the quiet/as-of transparency hierarchy while making light-mode semantic colors readable
- replaces two fixed blues with the theme accent so light/dark modes share one accessible token

## Evidence

- browser contract passed: Overview, deep links, rapid tab changes, data-plane fallback, touch chart gestures
- focused dashboard/Pages tests: 28 passed after fetching the published data-plane generation
- lifecycle contract: 4 passed
- local directional Lighthouse (same machine, raw worktree server): mobile performance 51 → 62; desktop 66 → 70; accessibility 96 → 100
- post-merge gate: repeat 3 mobile + 3 desktop samples against the deployed Pages URL and report medians on #383

No investment factors, catalysts, signals, entries/exits, portfolio rules, or financial data are changed.

Refs #383
