### PR TITLE
Cut watchdog crontab over to installed commands

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -90,7 +90,7 @@ context.json 的决策/自进化字段，**必须用上**：
 
 - 编造数据；fallback 链全挂了就明说"数据获取失败"
 - 从 chat / Telegram 触发的 session 不要直接 `git push` — 先问用户。harness postflight 跑完会自动 push（带 rebase+retry），不用 LLM 操心
-- 绕过 `openclaw cron edit` / `sync_us_cron_dst.py` 直接改 cron SQLite/旧 `jobs.json`；contract 改动必须重生成 `docs/operations/cron-schedules.md` 并跑 `ops/system_check.py`
+- 绕过 `openclaw cron edit` / `ops/host/sync_us_cron_dst.py` 直接改 cron SQLite/旧 `jobs.json`；contract 改动必须重生成 `docs/operations/cron-schedules.md` 并跑 `ops/system_check.py`
 - 改 `~/.openclaw/openclaw.json` 不备份（先 `cp -p X X.bak.$(date +%Y%m%d-%H%M)`）— 自动化 LLM 也要遵守
 - 跑 `scripts/legacy/` 下任何脚本当主路径（仅供参考阅读）
 - 在 group chat / WeChat 简报里加 emoji 烟花（标题 1 个 emoji 上限）

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -92,7 +92,7 @@
 - **brief cron Step 4 写紧凑卡，Step 5 postflight 主发**：卡片只含核心结论 + Book + ≤3 动作 + 触发位 + 当日全文链接；LLM 最终回复仅留痕，不调 message 工具。
 - **绝不把 pre-open.md 全文(~14-17KB)糊进微信。** 完整 brief 照常写进 pre-open.md → commit → dashboard/briefs 页看（深度不变，全文不裁）。
 - **教训：2026-05-31** 让 mimo 把完整 brief 作为最终消息吐出 → **复读死循环**（"Now let me output the WeChat message…"复读几十遍被当回复发出，kcn 收到一屏垃圾），2 次实测都犯。**根因=mimo 在长输出上 commit 不下来**，不是 size 也不是措辞；**短卡片 = 物理上不会 loop**（已验证干净投递）。`delivered=true` 对 brief 不可信（同 report stub 坑）。
-- **兜底**：`scripts/harness/brief_watchdog.py`（系统 crontab 08:30 HKT 工作日）读取 postflight delivery marker；Telegram 已成功则不动，marker 缺失/失败才补投 Telegram。它不再重发 WeChat，也不靠截断的 run summary 猜成败。
+- **兜底**：安装命令 `clawock-kcnyu-brief-watchdog`（系统 crontab 08:30 HKT 工作日）读取 postflight delivery marker；Telegram 已成功则不动，marker 缺失/失败才补投 Telegram。它不再重发 WeChat，也不靠截断的 run summary 猜成败。
 - WeChat 通道正常（手动 `openclaw message send` 即时送达）；冷会话静默丢弃见 cold-session 坑（本次不是）。
 - briefs 页 7 列表格在 mobile 横向滚动（`site/_layouts/default.html` @media≤600px：table display:block+overflow-x:auto），不撑破布局。
 

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -8,9 +8,9 @@
       "expr": "20 6 * * *",
       "tz": "Asia/Hong_Kong"
     },
-    "command_contains": [
-      "scripts/data/sync_us_cron_dst.py",
-      "--apply"
+    "command": "/usr/bin/python3 /root/.openclaw/workspace/ops/host/sync_us_cron_dst.py --apply >> /root/.openclaw/workspace/logs/dst-sync.log 2>&1",
+    "legacy_command_contains": [
+      ["scripts/data/sync_us_cron_dst.py", "--apply"]
     ]
   },
   "payload_profiles": {
@@ -185,10 +185,9 @@
           "expr": "10,40 0-2 * * 2-6",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "intraday_watchdog.py",
-          "--job-name \"美股盘中盯盘-overnight\"",
-          "--market us"
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘-overnight\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/intraday_watchdog.py", "--job-name \"美股盘中盯盘-overnight\"", "--market us"]
         ]
       }
     },
@@ -244,10 +243,9 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market us",
-          "--phase close"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase close --job-name \"美股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market us", "--phase close"]
         ]
       }
     },
@@ -268,8 +266,9 @@
           "expr": "30 8 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "brief_watchdog.py >>"
+        "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/brief_watchdog.py >>"]
         ]
       },
       "extra_watchdogs": [
@@ -280,8 +279,9 @@
             "expr": "5 9 * * 1-5",
             "tz": "Asia/Hong_Kong"
           },
-          "command_contains": [
-            "brief_watchdog.py --check-missing"
+          "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog --check-missing >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+          "legacy_command_contains": [
+            ["scripts/harness/brief_watchdog.py --check-missing"]
           ]
         }
       ]
@@ -313,10 +313,9 @@
           "expr": "45 9 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market hk",
-          "--phase open"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase open --job-name \"港股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market hk", "--phase open"]
         ]
       }
     },
@@ -343,10 +342,9 @@
           "expr": "10,40 10-11,14-15 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "intraday_watchdog.py",
-          "--job-name \"盘中盯盘\"",
-          "--market hk"
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"盘中盯盘\" --market hk >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/intraday_watchdog.py", "--job-name \"盘中盯盘\"", "--market hk"]
         ]
       }
     },
@@ -377,10 +375,9 @@
           "expr": "12 12 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market hk",
-          "--phase mid"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase mid --job-name \"港股午盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market hk", "--phase mid"]
         ]
       }
     },
@@ -411,10 +408,9 @@
           "expr": "42 13 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market hk",
-          "--phase pm"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase pm --job-name \"港股午后快报\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market hk", "--phase pm"]
         ]
       }
     },
@@ -445,10 +441,9 @@
           "expr": "15 16 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market hk",
-          "--phase close"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase close --job-name \"港股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market hk", "--phase close"]
         ]
       }
     },
@@ -493,10 +488,9 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command_contains": [
-          "report_watchdog.py",
-          "--market us",
-          "--phase open"
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase open --job-name \"美股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/report_watchdog.py", "--market us", "--phase open"]
         ]
       }
     },
@@ -537,10 +531,9 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command_contains": [
-          "intraday_watchdog.py",
-          "--job-name \"美股盘中盯盘\"",
-          "--market us"
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
+        "legacy_command_contains": [
+          ["scripts/harness/intraday_watchdog.py", "--job-name \"美股盘中盯盘\"", "--market us"]
         ]
       }
     }

--- a/docs/operations/cron-schedules.md
+++ b/docs/operations/cron-schedules.md
@@ -14,7 +14,7 @@ the contract before every push.
 ## DST policy / 夏令时策略
 
 US market jobs remain expressed in HKT because the daemon's ET timezone parser has
-regressed before. `sync_us_cron_dst.py --apply` runs daily at **06:20 HKT**, derives
+regressed before. `ops/host/sync_us_cron_dst.py --apply` runs daily at **06:20 HKT**, derives
 the season from `America/New_York`, and updates both OpenClaw jobs and their system
 watchdogs. The overnight monitor always stops at 02:30 HKT so 03:00 memory dreaming
 keeps an exclusive window; standard time therefore has two fewer US intraday slots.

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -57,7 +57,9 @@ The package now has a standard `src/clawock/` source boundary. The historical
 counts below describe the still-unmoved `scripts/data/` migration inventory;
 they are not a claim that `scripts/` is an acceptable final product home.
 
-Counts: **product 60 · instance 27**.
+Historical classification counts: **product 60 · instance 27**. The two cron
+synchronizers now live in `ops/host/`; the table retains them to preserve the
+decision record while the rest of `scripts/data/` is migrated.
 
 ### Product — the engine
 
@@ -135,11 +137,13 @@ source of truth.
 | Mixed shared implementation | `_harness_common` | Generation/validation helpers are product; this repository's publish and dashboard refresh path is instance |
 | Instance runtime supervision | `_watchdog_common` `brief_watchdog` `report_watchdog` `intraday_watchdog` | Reads runtime sessions/run history, mirrors this deployment's channels and applies this desk's retry policy |
 
-The classification is intentionally not “move all 6,338 lines into the public
-wheel”. Watchdogs stay in the private-instance-shaped adapter; product functions
-cross into `src/clawock/` only after they no longer assume this repository's
-paths. The stable package CLI means payloads do not know the adapter's file
-layout while extraction continues.
+The separate distribution is a migration seam, not evidence that all code in it
+is instance-specific. Reusable investment preflight, validation,
+reconciliation, generation and postflight behavior belongs in `src/clawock/`;
+reusable OpenClaw behavior belongs behind a runtime adapter. Only KCNyu delivery
+targets, live schedules, repository publication and other desk bindings remain
+here. `clawock-kcnyu` is repository-only and must never be published to PyPI or
+pulled in by the portable package.
 
 ## Note on the counts in #331
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -72,7 +72,7 @@ distribution（源码位于 `instances/kcnyu/`）通过标准 Python entry point
 精确的 11-job schedule、EDT/EST 表达式、Mode/harness 和 10 条 watchdog 映射由
 `config/cron-schedules.json` 单源维护，生成的人读表见
 [`docs/operations/cron-schedules.md`](../operations/cron-schedules.md)。
-`sync_us_cron_dst.py --apply` 每日自动对齐美股 live cron + system watchdog；
+`ops/host/sync_us_cron_dst.py --apply` 每日自动对齐美股 live cron + system watchdog；
 `cron_heartbeat.py` 维护 Mode 7 slot ledger，由现有 single publisher 发布。
 
 所有 harness preflight/postflight 的实现都在 `instances/kcnyu/`，统一从安装后的
@@ -88,8 +88,8 @@ Step 2.5 sidecar。schedule、payload、watchdog 或生成文档漂移都会被
 
 **改 cron 配置的安全步骤**（默认只检查，显式 apply；不覆盖投递目标/account/failure alert）：
 ```bash
-python3 scripts/data/sync_cron_payloads.py --json
-python3 scripts/data/sync_cron_payloads.py --apply --json
+python3 ops/host/sync_cron_payloads.py --json
+python3 ops/host/sync_cron_payloads.py --apply --json
 ```
 同步器按精确 job 名/ID 规划最小 patch，发现重复/缺失/额外 job 或目标 job 正在运行时不写，
 逐 job 失败即停，apply 后重新读取验证。升级大版本后仍应先 `openclaw cron list` 数 job 个数

--- a/instances/kcnyu/README.md
+++ b/instances/kcnyu/README.md
@@ -1,7 +1,8 @@
 # clawock-kcnyu
 
-This distribution is the KCNyu live HK + US desk adapter for `clawock`. It is
-not the portable product and is not installed by ordinary `clawock` users.
+This repository-only distribution is the KCNyu live HK + US desk adapter for
+`clawock`. It is not published to PyPI, is not a dependency of `clawock`, and
+is not installed by ordinary `clawock` users.
 
 The adapter owns live market preflight/postflight phases, delivery and watchdog
 behavior. OpenClaw remains the external runtime that owns model calls, chat,
@@ -11,3 +12,9 @@ remain in the configured workspace and are never packaged into either wheel.
 The temporary `scripts/harness/` source wrappers exist only for repository CI
 and old host commands during the cutover. Production OpenClaw calls the stable
 `clawock` CLI, which discovers this adapter through Python entry points.
+
+This remains a migration boundary, not the final product boundary. Reusable
+investment preflight, validation, reconciliation, generation and postflight
+logic moves into `clawock`; reusable OpenClaw integration belongs to a runtime
+adapter. This distribution must shrink to KCNyu-specific configuration and
+bindings such as delivery targets, live schedules and repository publication.

--- a/ops/host/sync_cron_payloads.py
+++ b/ops/host/sync_cron_payloads.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reconcile tracked OpenClaw jobs with the reviewed cron contract.
+"""Reconcile tracked OpenClaw jobs with the reviewed host cron contract.
 
 The default mode is read-only and exits 1 when drift exists. ``--apply`` edits
 only declared fields, one job at a time, and stops at the first failed edit.

--- a/ops/host/sync_us_cron_dst.py
+++ b/ops/host/sync_us_cron_dst.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Keep US OpenClaw jobs and their system watchdogs aligned with New York DST.
+"""Reconcile host watchdog commands and US schedules with the cron contract.
 
 The daemon's America/New_York cron parsing has regressed before, so the runtime
 jobs stay in HKT. This tool derives the correct HKT expressions from the tracked
 seasonal contract and applies them daily at 06:20 HKT, safely before market jobs.
+It also owns the exact system-crontab command for every watchdog, including the
+one-time migration from source-tree compatibility aliases to installed commands.
 """
 from __future__ import annotations
 
@@ -28,7 +30,6 @@ from clawock.workspace import workspace_root  # noqa: E402
 _CHECKOUT = Path(__file__).resolve().parents[2]
 WS = workspace_root(Path(__file__).resolve().parents[2])
 sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
-sys.path.insert(0, str(_CHECKOUT / "scripts" / "harness"))
 
 from cron_contract import (  # noqa: E402
     effective_schedule,
@@ -38,7 +39,6 @@ from cron_contract import (  # noqa: E402
     parse_crontab_lines,
     us_season,
 )
-from _watchdog_common import load_jobs  # noqa: E402
 # The cron command line belongs to the adapter (#330 step 2): this script owns
 # WHEN the US schedule shifts, not how an edit reaches OpenClaw.
 #
@@ -46,7 +46,51 @@ from _watchdog_common import load_jobs  # noqa: E402
 # data directory with no `clawock` package in it.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from clawock.providers.openclaw import build_cron_edit_argv  # noqa: E402
+from clawock.providers.openclaw import (  # noqa: E402
+    build_cron_edit_argv,
+    read_jobs_strict,
+)
+
+
+def load_live_jobs() -> list[dict]:
+    """Read the live scheduler strictly before planning any writes."""
+    return read_jobs_strict()
+
+
+def _find_managed_row(rows: list[dict], spec: dict) -> tuple[dict | None, str]:
+    """Find one canonical row, or one explicitly declared migration source."""
+    canonical = [row for row in rows if row["command"] == spec.get("command")]
+    if len(canonical) == 1:
+        return canonical[0], "canonical"
+    if len(canonical) > 1:
+        return None, "missing"
+    legacy_matchers = spec.get("legacy_command_contains") or []
+    matches = []
+    for tokens in legacy_matchers:
+        row = find_crontab_row(rows, tokens)
+        if row and row["index"] not in {item["index"] for item in matches}:
+            matches.append(row)
+    return (matches[0], "legacy") if len(matches) == 1 else (None, "missing")
+
+
+def _crontab_change(name: str, spec: dict, rows: list[dict], at: datetime,
+                    *, kind: str) -> tuple[dict | None, str | None]:
+    row, matched_by = _find_managed_row(rows, spec)
+    if not row:
+        return None, f"missing or ambiguous {kind} for {name}"
+    desired_expr = effective_schedule(spec, at).get("expr")
+    desired_command = spec.get("command")
+    if row["expr"] == desired_expr and row["command"] == desired_command:
+        return None, None
+    return {
+        "name": name,
+        "kind": kind,
+        "line_index": row["index"],
+        "matched_by": matched_by,
+        "from": {"expr": row["expr"], "command": row["command"]},
+        "to": {"expr": desired_expr, "command": desired_command},
+    }, None
+
 
 def parse_at(value: str | None) -> datetime:
     if not value:
@@ -79,20 +123,28 @@ def desired_changes(contract: dict, live_jobs: list[dict], crontab_text: str,
                         "from": {"expr": current.get("expr"), "tz": current.get("tz")},
                         "to": {"expr": desired.get("expr"), "tz": desired.get("tz")},
                     })
-        watchdog = job.get("watchdog") or {}
-        if not watchdog.get("seasonal_schedules"):
-            continue
-        tokens = watchdog.get("command_contains") or []
-        row = find_crontab_row(cron_rows, tokens)
-        if not row:
-            errors.append(f"missing or ambiguous watchdog for {job['name']}: {tokens}")
-            continue
-        desired_expr = effective_schedule(watchdog, at).get("expr")
-        if row["expr"] != desired_expr:
-            watchdog_changes.append({
-                "name": job["name"], "line_index": row["index"],
-                "from": row["expr"], "to": desired_expr,
-            })
+        watchdogs = [("watchdog", job.get("watchdog"))]
+        watchdogs.extend(
+            (f"extra-watchdog-{index}", watchdog)
+            for index, watchdog in enumerate(job.get("extra_watchdogs") or [], start=1)
+        )
+        for kind, watchdog in watchdogs:
+            if not watchdog:
+                continue
+            change, error = _crontab_change(
+                job["name"], watchdog, cron_rows, at, kind=kind)
+            if error:
+                errors.append(error)
+            elif change:
+                watchdog_changes.append(change)
+
+    sync = contract["dst_sync"]
+    change, error = _crontab_change(
+        "US cron DST sync", sync, cron_rows, at, kind="dst-sync")
+    if error:
+        errors.append(error)
+    elif change:
+        watchdog_changes.append(change)
     return openclaw_changes, watchdog_changes, errors
 
 
@@ -122,7 +174,7 @@ def apply_crontab(text: str, changes: list[dict]) -> list[str]:
         parts = lines[index].split(None, 5)
         if len(parts) < 6:
             return [f"cannot parse crontab line {index + 1}"]
-        lines[index] = f"{change['to']} {parts[5]}"
+        lines[index] = f"{change['to']['expr']} {change['to']['command']}"
     payload = "\n".join(lines) + "\n"
     result = subprocess.run(
         ["crontab", "-"], input=payload, capture_output=True, text=True, timeout=15,
@@ -139,7 +191,7 @@ def main() -> int:
 
     at = parse_at(args.at)
     contract = load_contract()
-    live_jobs = load_jobs()
+    live_jobs = load_live_jobs()
     crontab = subprocess.check_output(["crontab", "-l"], text=True)
     oc_changes, wd_changes, errors = desired_changes(contract, live_jobs, crontab, at)
     applied = False

--- a/scripts/data/cron_contract.py
+++ b/scripts/data/cron_contract.py
@@ -90,15 +90,17 @@ def load_contract(path: str | Path | None = None) -> dict:
         if job.get("payload_profile") not in profiles:
             raise ValueError(f"{job['name']}: unknown payload profile")
         render_payload_message(data, job)
-        watchdog = job.get("watchdog")
-        if watchdog:
+        watchdogs = [job.get("watchdog"), *(job.get("extra_watchdogs") or [])]
+        for watchdog in watchdogs:
+            if not watchdog:
+                continue
             if bool(watchdog.get("schedule")) == bool(watchdog.get("seasonal_schedules")):
                 raise ValueError(f"{job['name']}: watchdog needs exactly one schedule source")
-            if not watchdog.get("command_contains"):
-                raise ValueError(f"{job['name']}: watchdog command matcher missing")
+            if not isinstance(watchdog.get("command"), str) or not watchdog["command"]:
+                raise ValueError(f"{job['name']}: watchdog command missing")
     sync = data.get("dst_sync") or {}
-    if not sync.get("schedule") or not sync.get("command_contains"):
-        raise ValueError("dst_sync schedule and command matcher are required")
+    if not sync.get("schedule") or not isinstance(sync.get("command"), str):
+        raise ValueError("dst_sync schedule and command are required")
     return data
 
 
@@ -348,15 +350,16 @@ def validate_watchdogs(contract: dict, crontab_text: str,
         # 08:30 delivery backstop, and a 09:05 miss detector — 08:30 falls inside the
         # brief's own 08:13-08:49 landing window, so it cannot tell a slow brief from
         # a dead one and a second pass after the window is the only place to judge.
-        # Each entry must still match EXACTLY ONE crontab row, so their
-        # command_contains have to be mutually exclusive, not just present.
+        # Each entry must still match EXACTLY ONE exact crontab command. This is
+        # stricter than the old basename token match, which could accept a
+        # source-tree alias or select both brief watchdog passes.
         for watchdog in [job.get("watchdog")] + list(job.get("extra_watchdogs") or []):
             if not watchdog:
                 continue
-            tokens = watchdog.get("command_contains") or []
-            row = find_crontab_row(rows, tokens)
+            matches = [row for row in rows if row["command"] == watchdog.get("command")]
+            row = matches[0] if len(matches) == 1 else None
             if not row:
-                errors.append(f"{job['name']} watchdog missing or ambiguous: {tokens}")
+                errors.append(f"{job['name']} watchdog command missing or ambiguous")
                 continue
             expected = effective_schedule(watchdog, at).get("expr")
             if row["expr"] != expected:
@@ -365,10 +368,10 @@ def validate_watchdogs(contract: dict, crontab_text: str,
                 )
     sync = contract.get("dst_sync") or {}
     if sync:
-        tokens = sync.get("command_contains") or []
-        row = find_crontab_row(rows, tokens)
+        matches = [row for row in rows if row["command"] == sync.get("command")]
+        row = matches[0] if len(matches) == 1 else None
         if not row:
-            errors.append(f"DST sync cron missing or ambiguous: {tokens}")
+            errors.append("DST sync cron command missing or ambiguous")
         else:
             expected = effective_schedule(sync, at).get("expr")
             if row["expr"] != expected:

--- a/scripts/data/generate_cron_docs.py
+++ b/scripts/data/generate_cron_docs.py
@@ -89,7 +89,7 @@ def render(contract: dict) -> str:
         "## DST policy / 夏令时策略",
         "",
         "US market jobs remain expressed in HKT because the daemon's ET timezone parser has",
-        "regressed before. `sync_us_cron_dst.py --apply` runs daily at **06:20 HKT**, derives",
+        "regressed before. `ops/host/sync_us_cron_dst.py --apply` runs daily at **06:20 HKT**, derives",
         "the season from `America/New_York`, and updates both OpenClaw jobs and their system",
         "watchdogs. The overnight monitor always stops at 02:30 HKT so 03:00 memory dreaming",
         "keeps an exclusive window; standard time therefore has two fewer US intraday slots.",

--- a/skills/openclaw-tune/SKILL.md
+++ b/skills/openclaw-tune/SKILL.md
@@ -215,5 +215,5 @@ End with a structured report:
 ## Inputs / Outputs
 
 - **Reads**: `~/.openclaw/openclaw.json`, live cron state via `openclaw cron list --json`, `config/cron-schedules.json`, workspace canonical MD files, short-term recall state, and disk usage of `~/.openclaw/`
-- **Writes**: trimmed `*.md` workspace files (with bak), cron fields only through `openclaw cron edit` / `sync_us_cron_dst.py` plus the tracked contract and regenerated `docs/operations/cron-schedules.md`, eventual `portfolio.json` if data refresh happens; everything else archived to `/tmp/openclaw-cleanup-<date>/`
+- **Writes**: trimmed `*.md` workspace files (with bak), cron fields only through `openclaw cron edit` / `ops/host/sync_us_cron_dst.py` plus the tracked contract and regenerated `docs/operations/cron-schedules.md`, eventual `portfolio.json` if data refresh happens; everything else archived to `/tmp/openclaw-cleanup-<date>/`
 - **Side effects**: may suggest gateway restart at the end (user-confirmed)

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
+sys.path.insert(0, str(ROOT / 'ops' / 'host'))
 sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 
 import cron_contract
@@ -155,12 +156,11 @@ def _crontab_from_contract(data, at):
             if not watchdog:
                 continue
             expr = cron_contract.effective_schedule(watchdog, at)['expr']
-            tokens = ' '.join(watchdog['command_contains'])
-            rows.append(f'{expr} run-{index} {tokens}')
+            rows.append(f"{expr} {watchdog['command']}")
     sync = data['dst_sync']
     rows.append(
         f"{cron_contract.effective_schedule(sync, at)['expr']} "
-        + ' '.join(sync['command_contains'])
+        + sync['command']
     )
     return '\n'.join(rows) + '\n'
 
@@ -189,6 +189,45 @@ def test_watchdog_contract_and_dst_change_plan_cover_both_schedulers():
     assert {change['name'] for change in watchdogs} == {
         '美股开盘报告', '美股收盘报告', '美股盘中盯盘'
     }
+
+
+def test_legacy_host_rows_are_planned_to_installed_commands():
+    data = contract()
+    july = datetime(2026, 7, 16, 0, tzinfo=timezone.utc)
+    canonical = _crontab_from_contract(data, july)
+    legacy = canonical
+    replacements = {
+        '/root/.local/bin/clawock-kcnyu-brief-watchdog':
+            'python3 scripts/harness/brief_watchdog.py',
+        '/root/.local/bin/clawock-kcnyu-report-watchdog':
+            'python3 scripts/harness/report_watchdog.py',
+        '/root/.local/bin/clawock-kcnyu-intraday-watchdog':
+            'python3 scripts/harness/intraday_watchdog.py',
+        '/usr/bin/python3 /root/.openclaw/workspace/ops/host/sync_us_cron_dst.py':
+            'python3 scripts/data/sync_us_cron_dst.py',
+    }
+    for installed, old in replacements.items():
+        legacy = legacy.replace(installed, old)
+    legacy = legacy.replace(
+        ' >> /root/.openclaw/workspace/logs/watchdog.cron.log',
+        ' >> logs/watchdog.cron.log')
+    legacy = legacy.replace(
+        ' >> /root/.openclaw/workspace/logs/dst-sync.log',
+        ' >> logs/dst-sync.log')
+
+    live = [{
+        'id': f'id-{index}', 'name': job['name'],
+        'schedule': cron_contract.effective_schedule(job, july),
+    } for index, job in enumerate(data['jobs'])]
+    openclaw, host, errors = sync_us_cron_dst.desired_changes(
+        data, live, legacy, july)
+
+    assert errors == []
+    assert openclaw == []
+    assert len([change for change in host if change['kind'] != 'dst-sync']) == 11
+    assert len([change for change in host if change['kind'] == 'dst-sync']) == 1
+    assert all(change['matched_by'] == 'legacy' for change in host)
+    assert all('scripts/harness/' not in change['to']['command'] for change in host)
 
 
 def test_intraday_heartbeat_is_slot_keyed_published_and_health_checked(tmp_path, monkeypatch):

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -228,6 +229,37 @@ def test_legacy_host_rows_are_planned_to_installed_commands():
     assert len([change for change in host if change['kind'] == 'dst-sync']) == 1
     assert all(change['matched_by'] == 'legacy' for change in host)
     assert all('scripts/harness/' not in change['to']['command'] for change in host)
+
+
+def test_crontab_apply_preserves_every_unmanaged_line(monkeypatch):
+    original = (
+        '# managed and unrelated host jobs\n'
+        '30 8 * * 1-5 old-watchdog\n'
+        '0,20,40 * * * * /bin/bash /srv/publisher.sh\n'
+    )
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured['argv'] = argv
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(argv, 0, stdout='', stderr='')
+
+    monkeypatch.setattr(sync_us_cron_dst.subprocess, 'run', fake_run)
+    errors = sync_us_cron_dst.apply_crontab(original, [{
+        'line_index': 1,
+        'to': {
+            'expr': '30 8 * * 1-5',
+            'command': '/root/.local/bin/clawock-kcnyu-brief-watchdog',
+        },
+    }])
+
+    assert errors == []
+    assert captured['argv'] == ['crontab', '-']
+    assert captured['input'] == (
+        '# managed and unrelated host jobs\n'
+        '30 8 * * 1-5 /root/.local/bin/clawock-kcnyu-brief-watchdog\n'
+        '0,20,40 * * * * /bin/bash /srv/publisher.sh\n'
+    )
 
 
 def test_intraday_heartbeat_is_slot_keyed_published_and_health_checked(tmp_path, monkeypatch):

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -340,8 +340,8 @@ def test_the_cron_writes_moved_rather_than_vanished():
     """
     sites = coupling_sites()
 
-    for writer in ("scripts/data/sync_cron_payloads.py",
-                   "scripts/data/sync_us_cron_dst.py"):
+    for writer in ("ops/host/sync_cron_payloads.py",
+                   "ops/host/sync_us_cron_dst.py"):
         assert writer not in sites, (
             f"{writer} names the runtime again — the schedule writers are "
             "supposed to reach it through clawock.providers")

--- a/tests/test_sync_cron_payloads.py
+++ b/tests/test_sync_cron_payloads.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
+sys.path.insert(0, str(ROOT / "ops" / "host"))
 sys.path.insert(0, str(ROOT))
 
 import cron_contract

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -28,6 +28,7 @@ import json
 import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -72,6 +73,16 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
 
     wheels = list(build.glob("clawock-*.whl"))
     assert len(wheels) == 1, f"expected one wheel, got {wheels}"
+
+    # The public product and this repository's live desk are separate install
+    # surfaces. CI installs both to prove the live integration, but publishing
+    # `clawock` must never smuggle the KCNyu adapter in as code or a dependency.
+    with zipfile.ZipFile(wheels[0]) as archive:
+        names = archive.namelist()
+        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        metadata = archive.read(metadata_name).decode()
+    assert not any(name.startswith("clawock_kcnyu/") for name in names)
+    assert "clawock-kcnyu" not in metadata.lower()
 
     site = tmp_path / "site"
     done = subprocess.run(


### PR DESCRIPTION
Closes part of #380 and #381.

## Outcome

- makes `config/cron-schedules.json` own the exact installed command for all 11 system watchdog rows and the DST synchronizer
- moves both OpenClaw schedule synchronizers from the mixed `scripts/data/` bucket to `ops/host/`
- plans the one-time source-alias migration explicitly, while normal validation accepts only the exact installed commands
- reads the live OpenClaw schedule strictly and preserves every unmanaged crontab row
- documents that `clawock-kcnyu` is a repository-only migration seam, not the product boundary or a PyPI dependency
- adds a wheel-content gate proving the public `clawock` artifact contains no KCNyu adapter package or dependency

## Evidence

- 55 targeted tests pass, including the real non-editable wheel build/install test
- read-only live comparison reports zero OpenClaw payload/schedule changes
- read-only host plan reports exactly 11 legacy watchdog rows plus the DST row changing to canonical commands, with no errors
- current season remains EDT/daylight and the next derived transition is 2026-11-01

## Deployment after merge

1. fast-forward live under the normal repository workflow
2. reinstall launchers from `ops/host/install_clawock_launcher.sh`
3. run `ops/host/sync_us_cron_dst.py --apply`
4. prove exact crontab parity, launcher availability, DST idempotency and delivery-disabled watchdog canaries before deleting compatibility aliases
