### PR TITLE
Read cron health through the core provider

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -37,6 +37,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 # anything. All of these are absent in CI, where the checks skip.
 from clawock.providers.openclaw import (  # noqa: E402
     is_installed as openclaw_is_installed,
+    read_jobs as openclaw_read_jobs,
     runtime_paths as openclaw_runtime_paths,
 )
 
@@ -446,16 +447,14 @@ def check_cron_paths_exist(r):
     """Live cron schedules match the tracked contract and payload scripts exist.
 
     6.1 migrated cron storage from cron/jobs.json into state/openclaw.sqlite, so
-    direct file reads silently return nothing. Read via _watchdog_common.load_jobs:
-    CLI first, then the live SQLite DB read-only, with pre-migration files kept
-    only as an explicitly rejected last-resort fossil.
+    direct file reads silently return nothing. Read through the core runtime
+    provider: CLI first, then the live SQLite DB read-only, with pre-migration
+    files kept only as an explicitly rejected last-resort fossil.
     """
     import re
-    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'harness'))
     try:
-        import _watchdog_common as wc  # type: ignore
-        from _watchdog_common import load_jobs  # type: ignore
-        jobs = load_jobs()
+        cron_read = openclaw_read_jobs()
+        jobs = cron_read.entries
     except Exception as e:
         r.add('cron paths', WARNING, f'cron jobs unreadable: {e}')
         return
@@ -466,8 +465,8 @@ def check_cron_paths_exist(r):
         else:
             r.add('cron paths', WARNING, 'openclaw CLI returned 0 cron jobs (storage regression? run doctor --fix)')
         return
-    if getattr(wc, 'LAST_LOAD_SOURCE', None) == 'fossil':
-        # Both live sources were unreadable and load_jobs() served a pre-6.1
+    if cron_read.source == 'fossil':
+        # Both live sources were unreadable and the provider served a pre-6.1
         # fossil that is STALE for model/delivery/message. Refuse validation:
         # passing or failing the payload contract against this view is a lie.
         r.add('cron runtime contract', CRITICAL,
@@ -500,7 +499,10 @@ def check_cron_paths_exist(r):
             if watchdog_errors:
                 r.add('watchdog cron contract', CRITICAL, '; '.join(watchdog_errors[:8]))
             else:
-                n_watchdogs = sum(bool(j.get('watchdog')) for j in contract['jobs'])
+                n_watchdogs = sum(
+                    bool(job.get('watchdog')) + len(job.get('extra_watchdogs') or [])
+                    for job in contract['jobs']
+                )
                 r.add('watchdog cron contract', OK,
                       f'{n_watchdogs} watchdogs + daily DST sync match tracked config')
     except Exception as e:

--- a/tests/test_system_check_cron_provider.py
+++ b/tests/test_system_check_cron_provider.py
@@ -1,0 +1,21 @@
+"""The host health gate must be runnable without the KCNyu distribution.
+
+The installed watchdogs need that repository-only adapter, but `system_check`
+is an operator tool backed by the core OpenClaw provider. Importing the old
+`scripts/harness/_watchdog_common` alias made the live system Python report cron
+state unreadable even though the provider and runtime were healthy.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_system_check_reads_cron_state_only_through_the_core_provider():
+    source = (ROOT / "ops" / "system_check.py").read_text()
+
+    assert "read_jobs as openclaw_read_jobs" in source
+    assert "openclaw_read_jobs()" in source
+    assert "_watchdog_common" not in source
+    assert "scripts' / 'harness" not in source
+    assert "len(job.get('extra_watchdogs') or [])" in source


### PR DESCRIPTION
Closes part of #380 and #381; follow-up to #400.

## Outcome

- removes `ops/system_check.py`'s final import of the `scripts/harness/_watchdog_common` compatibility alias
- reads live cron state through the core `clawock.providers.openclaw` provider, preserving CLI → SQLite → explicitly rejected fossil semantics
- reports the actual 11 watchdog passes, including the brief extra miss-detector
- adds a regression guard that the host health gate has no KCNyu adapter or source-alias dependency

## Evidence

- reproduced live warning after #400: `cron jobs unreadable: No module named 'clawock_kcnyu'`
- after this change, live-backed worktree system check reports 15 OK / 1 unrelated memory-index warning / 0 critical
- cron runtime: 11 jobs, exact schedule+payload match, EDT with next transition 2026-11-01
- watchdog contract: all 11 watchdog passes plus daily DST sync match
- 15 targeted provider/ratchet tests pass
