### PR TITLE
Retire source harness aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ stored here.
 | `docs/`, `tests/` | Product/runbook documentation and invariant checks |
 | root context files, `skills/`, `memory/` | OpenClaw compatibility surface; kept at runtime-required paths |
 | `portfolio.json`, `assets/data/` | Live ledger and generated publication state; never package contents |
-| `scripts/data/`, `scripts/harness/` | Remaining migration surface: instance jobs plus temporary rollback aliases, not portable APIs |
+| `scripts/data/` | Remaining migration surface: repository jobs, not portable APIs |
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -294,7 +294,7 @@ adapter；其它 runner 可以消费同一套 context/tool 契约。live adapter
 | `docs/`、`tests/` | 产品/运维文档与高价值不变量检查 |
 | 根 context 文件、`skills/`、`memory/` | OpenClaw 兼容面；保留在 runtime 要求的位置 |
 | `portfolio.json`、`assets/data/` | live 账本与生成发布状态；永不进入 package |
-| `scripts/data/`、`scripts/harness/` | 仍待迁移的 instance job 与临时回滚别名，不是可移植 API |
+| `scripts/data/` | 仍待迁移的仓库 job，不是可移植 API |
 
 </details>
 

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -8,10 +8,7 @@
       "expr": "20 6 * * *",
       "tz": "Asia/Hong_Kong"
     },
-    "command": "/usr/bin/python3 /root/.openclaw/workspace/ops/host/sync_us_cron_dst.py --apply >> /root/.openclaw/workspace/logs/dst-sync.log 2>&1",
-    "legacy_command_contains": [
-      ["scripts/data/sync_us_cron_dst.py", "--apply"]
-    ]
+    "command": "/usr/bin/python3 /root/.openclaw/workspace/ops/host/sync_us_cron_dst.py --apply >> /root/.openclaw/workspace/logs/dst-sync.log 2>&1"
   },
   "payload_profiles": {
     "report": {
@@ -185,10 +182,7 @@
           "expr": "10,40 0-2 * * 2-6",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘-overnight\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/intraday_watchdog.py", "--job-name \"美股盘中盯盘-overnight\"", "--market us"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘-overnight\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -243,10 +237,7 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase close --job-name \"美股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market us", "--phase close"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase close --job-name \"美股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -266,10 +257,7 @@
           "expr": "30 8 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/brief_watchdog.py >>"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       },
       "extra_watchdogs": [
         {
@@ -279,10 +267,7 @@
             "expr": "5 9 * * 1-5",
             "tz": "Asia/Hong_Kong"
           },
-          "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog --check-missing >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-          "legacy_command_contains": [
-            ["scripts/harness/brief_watchdog.py --check-missing"]
-          ]
+          "command": "/root/.local/bin/clawock-kcnyu-brief-watchdog --check-missing >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
         }
       ]
     },
@@ -313,10 +298,7 @@
           "expr": "45 9 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase open --job-name \"港股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market hk", "--phase open"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase open --job-name \"港股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -342,10 +324,7 @@
           "expr": "10,40 10-11,14-15 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"盘中盯盘\" --market hk >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/intraday_watchdog.py", "--job-name \"盘中盯盘\"", "--market hk"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"盘中盯盘\" --market hk >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -375,10 +354,7 @@
           "expr": "12 12 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase mid --job-name \"港股午盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market hk", "--phase mid"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase mid --job-name \"港股午盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -408,10 +384,7 @@
           "expr": "42 13 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase pm --job-name \"港股午后快报\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market hk", "--phase pm"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase pm --job-name \"港股午后快报\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -441,10 +414,7 @@
           "expr": "15 16 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase close --job-name \"港股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market hk", "--phase close"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market hk --phase close --job-name \"港股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -488,10 +458,7 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase open --job-name \"美股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/report_watchdog.py", "--market us", "--phase open"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-report-watchdog --market us --phase open --job-name \"美股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     },
     {
@@ -531,10 +498,7 @@
             "tz": "Asia/Hong_Kong"
           }
         },
-        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1",
-        "legacy_command_contains": [
-          ["scripts/harness/intraday_watchdog.py", "--job-name \"美股盘中盯盘\"", "--market us"]
-        ]
+        "command": "/root/.local/bin/clawock-kcnyu-intraday-watchdog --job-name \"美股盘中盯盘\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       }
     }
   ]

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -73,9 +73,9 @@ calling runtime's existing investment strategy remains the decision source.
 
 The live workflow phase commands discover KCNyu's separately installed
 `clawock-kcnyu` distribution through standard Python entry points. The portable
-wheel contains neither that implementation nor portfolio data. Temporary
-`scripts/harness/` launchers remain only as rollback aliases while OpenClaw's
-host schedules complete their cutover to the stable `clawock` command.
+wheel contains neither that implementation nor portfolio data. The former
+`scripts/harness/` launchers were removed after OpenClaw phases and host
+watchdogs completed their installed-command cutover.
 
 ## Context contract
 

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -126,9 +126,9 @@ The portable lifecycle vocabulary and generation-pinned `ArtifactSet` live in
 `src/clawock/harness/`; `clawock brief|report|intraday` dispatch phases in-process
 through the `clawock.instance_phases` entry-point group. KCNyu's implementation
 lives in its own `clawock-kcnyu` distribution under `instances/kcnyu/`, so the
-public wheel neither imports nor ships it. Thin `scripts/harness/` aliases remain
-temporarily for rollback; they are not an ownership boundary or a production
-source of truth.
+public wheel neither imports nor ships it. The former `scripts/harness/` aliases
+were retired after every production and test caller moved to installed commands
+or explicit package imports.
 
 | Classification | Modules | Boundary |
 |---|---|---|

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -33,7 +33,7 @@ title: clawock · scripts 详细参考
 确定性活强制脚本化执行；LLM 只做合成；postflight 自验证 + commit。
 生产入口是安装后的 `clawock` CLI；KCNyu 实现由独立的 `clawock-kcnyu`
 distribution（源码位于 `instances/kcnyu/`）通过标准 Python entry points 提供。
-`scripts/harness/` 只保留迁移期回滚别名，不再是实现真源。
+旧的 `scripts/harness/` 回滚别名已在 installed-command 切换验证后删除。
 
 **Daily deep brief**（08:00 HKT cron）
 - **`clawock brief preflight`**：刷 US/HK 价 + FX + portfolio snapshot + HHI 算法 + SEC EDGAR (仅 `is_leveraged_etf=false`) + retrospective vs 上次 plan.json。输出 `memory/.tmp/brief-context-{date}.json`

--- a/instances/kcnyu/README.md
+++ b/instances/kcnyu/README.md
@@ -4,17 +4,15 @@ This repository-only distribution is the KCNyu live HK + US desk adapter for
 `clawock`. It is not published to PyPI, is not a dependency of `clawock`, and
 is not installed by ordinary `clawock` users.
 
-The adapter owns live market preflight/postflight phases, delivery and watchdog
-behavior. OpenClaw remains the external runtime that owns model calls, chat,
-memory, tools and cron scheduling. Portfolio ledgers and generated artifacts
-remain in the configured workspace and are never packaged into either wheel.
+During the migration this distribution still hosts live-market phases, delivery
+and watchdog code. That location is not evidence that the logic is KCNyu-only:
+reusable investment preflight, validation, reconciliation, generation and
+postflight belongs in `clawock`, while reusable OpenClaw integration belongs to
+a runtime adapter. This distribution must shrink to KCNyu-specific configuration
+and bindings such as delivery targets, live schedules and repository publication.
 
-The temporary `scripts/harness/` source wrappers exist only for repository CI
-and old host commands during the cutover. Production OpenClaw calls the stable
-`clawock` CLI, which discovers this adapter through Python entry points.
-
-This remains a migration boundary, not the final product boundary. Reusable
-investment preflight, validation, reconciliation, generation and postflight
-logic moves into `clawock`; reusable OpenClaw integration belongs to a runtime
-adapter. This distribution must shrink to KCNyu-specific configuration and
-bindings such as delivery targets, live schedules and repository publication.
+OpenClaw remains the external runtime that owns model calls, chat, memory, tools
+and cron scheduling. Portfolio ledgers and generated artifacts remain in the
+configured workspace and are never packaged into either wheel. Production phase
+calls use the stable `clawock` CLI and Python entry points; repository source
+wrappers were retired after the installed-command cutover.

--- a/ops/host/install_clawock_launcher.sh
+++ b/ops/host/install_clawock_launcher.sh
@@ -5,7 +5,7 @@
 # product and KCNyu adapter into a dedicated virtualenv. The stable launcher
 # keeps every OpenClaw payload unchanged while entry-point discovery proves the
 # live phase came from the separately installed instance distribution—not from
-# a source-tree `scripts/harness` import.
+# a source-tree import.
 set -euo pipefail
 
 CHECKOUT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"

--- a/ops/host/sync_us_cron_dst.py
+++ b/ops/host/sync_us_cron_dst.py
@@ -5,7 +5,7 @@ The daemon's America/New_York cron parsing has regressed before, so the runtime
 jobs stay in HKT. This tool derives the correct HKT expressions from the tracked
 seasonal contract and applies them daily at 06:20 HKT, safely before market jobs.
 It also owns the exact system-crontab command for every watchdog, including the
-one-time migration from source-tree compatibility aliases to installed commands.
+installed command used after the source-tree alias cutover.
 """
 from __future__ import annotations
 
@@ -33,7 +33,6 @@ sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 
 from cron_contract import (  # noqa: E402
     effective_schedule,
-    find_crontab_row,
     load_contract,
     next_us_dst_transition,
     parse_crontab_lines,
@@ -58,19 +57,11 @@ def load_live_jobs() -> list[dict]:
 
 
 def _find_managed_row(rows: list[dict], spec: dict) -> tuple[dict | None, str]:
-    """Find one canonical row, or one explicitly declared migration source."""
+    """Find exactly one canonical row."""
     canonical = [row for row in rows if row["command"] == spec.get("command")]
     if len(canonical) == 1:
         return canonical[0], "canonical"
-    if len(canonical) > 1:
-        return None, "missing"
-    legacy_matchers = spec.get("legacy_command_contains") or []
-    matches = []
-    for tokens in legacy_matchers:
-        row = find_crontab_row(rows, tokens)
-        if row and row["index"] not in {item["index"] for item in matches}:
-            matches.append(row)
-    return (matches[0], "legacy") if len(matches) == 1 else (None, "missing")
+    return None, "missing"
 
 
 def _crontab_change(name: str, spec: dict, rows: list[dict], at: datetime,

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -35,8 +35,13 @@ SNAPSHOT_FNAME_RE = re.compile(r'^\d{4}-\d{2}-\d{2}\.json$')
 # The checkout root, so `clawock` resolves from the tree this file ships
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
+CHECKOUT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+sys.path.insert(0, str(CHECKOUT_ROOT / "src"))
+# Repository-only dashboard generation still consumes three generic calculations
+# from the transitional KCNyu package. Keep that dependency explicit until those
+# calculations move into core; never recover it through a source-tree alias.
+sys.path.insert(0, str(CHECKOUT_ROOT / "instances" / "kcnyu" / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
 
 WS_ROOT = workspace_root(Path(__file__).resolve().parent.parent.parent)
@@ -387,9 +392,9 @@ def compute_guardrail_outputs(portfolio, risk, lev_regime=None):
     renderer normalized it to ``{}`` and painted a green all-clear.
     """
     try:
-        sys.path.insert(0, str(WS_ROOT / 'scripts' / 'harness'))
-        from brief_preflight import (compute_risk_guardrail, compute_concentration,
-                                     compute_breakeven_math)
+        from clawock_kcnyu.harness.brief_preflight import (
+            compute_breakeven_math, compute_concentration, compute_risk_guardrail,
+        )
         us_book, hk_book = leg_books(portfolio)
         hk_holdings = hk_book['holdings']
         us_holdings = us_book['holdings']
@@ -2954,7 +2959,7 @@ def build_projection(previous_source=None, shadow_previous=None):
             _harness = WS_ROOT / 'scripts' / 'harness'
             if str(_harness) not in sys.path:
                 sys.path.insert(0, str(_harness))
-            from brief_preflight import _classify_regime
+            from clawock_kcnyu.harness.brief_preflight import _classify_regime
             out['regime'] = _classify_regime(_macro)
     except Exception as e:
         print(f'  warn: regime classify failed: {e}', file=sys.stderr)

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -36,6 +36,7 @@ from zoneinfo import ZoneInfo
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock.providers import openclaw  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -227,9 +228,7 @@ def load_runtime_jobs(jobs_file=None):
             jobs.append(resolved)
         return jobs
 
-    sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'harness'))
-    from _watchdog_common import load_jobs
-    jobs = load_jobs()
+    jobs = openclaw.read_jobs().entries
     if not jobs:
         raise RuntimeError('OpenClaw CLI returned no cron jobs; run `openclaw doctor --fix`')
     return jobs

--- a/scripts/data/cron_runs.py
+++ b/scripts/data/cron_runs.py
@@ -21,9 +21,10 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 # Storage-agnostic cron readers (6.1 moved jobs.json/runs/*.jsonl into SQLite —
-# direct file reads silently return nothing). Same layer the watchdogs use.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'harness'))
-import _watchdog_common as watchdog_common  # noqa: E402
+# direct file reads silently return nothing).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
+from clawock.providers import openclaw  # noqa: E402
 
 CRON_DIR = Path.home() / '.openclaw' / 'cron'
 RUNS_DIR = CRON_DIR / 'runs'
@@ -32,12 +33,13 @@ HKT = timezone(timedelta(hours=8))
 
 def load_job_map(backend='auto'):
     try:
+        result = openclaw.read_jobs(backend)
         return {
             j['id']: j.get('name', j['id'][:8])
-            for j in watchdog_common.load_jobs(backend)
-        }
+            for j in result.entries
+        }, result.source
     except Exception:
-        return {}
+        return {}, 'empty'
 
 
 def kind_of(entry):
@@ -47,10 +49,13 @@ def kind_of(entry):
 
 def load_entries(kind_filter, job_id_filter, status_filter, job_map, backend='auto'):
     out = []
+    sources = set()
     for job_id in sorted(job_map):
         if job_id_filter and job_id not in job_id_filter:
             continue
-        for d in watchdog_common.read_runs(job_id, backend):
+        result = openclaw.read_runs(job_id, backend)
+        sources.add(result.source)
+        for d in result.entries:
             if status_filter and d.get('status') != status_filter:
                 continue
             k = kind_of(d)
@@ -60,7 +65,7 @@ def load_entries(kind_filter, job_id_filter, status_filter, job_map, backend='au
             d['_jobId'] = job_id
             out.append(d)
     out.sort(key=lambda x: x.get('ts', 0) or 0, reverse=True)
-    return out
+    return out, sources
 
 
 def fmt_ts(ms):
@@ -106,12 +111,12 @@ def main():
     )
     args = p.parse_args()
 
-    jobs = load_job_map(args.openclaw_backend)
+    jobs, jobs_source = load_job_map(args.openclaw_backend)
     if not jobs:
         print('❌ no live cron jobs visible (OpenClaw CLI/SQLite unavailable)',
               file=sys.stderr)
         return 2
-    if watchdog_common.LAST_LOAD_SOURCE == 'fossil':
+    if jobs_source == 'fossil':
         print('❌ refusing stale pre-6.1 job metadata; use live CLI or SQLite',
               file=sys.stderr)
         return 2
@@ -124,10 +129,11 @@ def main():
                   ', '.join(sorted(jobs.values())), file=sys.stderr)
             return 2
 
-    entries = load_entries(
+    entries, run_sources = load_entries(
         args.kind, job_id_filter, args.status, jobs, args.openclaw_backend
-    )[: args.n]
-    if watchdog_common.LAST_RUNS_SOURCE == 'fossil':
+    )
+    entries = entries[: args.n]
+    if 'fossil' in run_sources:
         print('❌ refusing stale pre-6.1 run history; use live CLI or SQLite',
               file=sys.stderr)
         return 2

--- a/scripts/data/cron_timeline.py
+++ b/scripts/data/cron_timeline.py
@@ -32,6 +32,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock.providers import openclaw  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 WORKFLOWS = WS / '.github' / 'workflows'
@@ -160,10 +161,9 @@ def load_openclaw(backend='auto'):
         # 6.1 moved cron storage into SQLite — read via the storage-agnostic CLI
         # layer (the dead jobs.json silently returned [] and dropped all 11
         # openclaw jobs from the timeline, found 2026-06-10).
-        sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'harness'))
-        import _watchdog_common as watchdog_common
-        jobs = watchdog_common.load_jobs(backend)
-        LAST_OPENCLAW_SOURCE = watchdog_common.LAST_LOAD_SOURCE
+        result = openclaw.read_jobs(backend)
+        jobs = result.entries
+        LAST_OPENCLAW_SOURCE = result.source
     except Exception:
         LAST_OPENCLAW_SOURCE = 'empty'
         return rows

--- a/scripts/data/cron_token_audit.py
+++ b/scripts/data/cron_token_audit.py
@@ -33,7 +33,9 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "harness"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from clawock.providers import openclaw  # noqa: E402
 
 HKT = timezone(timedelta(hours=8))
 # Enough history to have a stable median per provider without reaching back to a
@@ -56,9 +58,7 @@ def _load_runs(job_id, reader=None):
     if reader is not None:
         return reader(job_id) or []
     try:
-        import _watchdog_common as watchdog_common  # noqa: PLC0415
-
-        return watchdog_common.read_runs(job_id, RUN_SOURCE) or []
+        return openclaw.read_runs(job_id, RUN_SOURCE).entries
     except Exception:  # noqa: BLE001 — a health report must not die on the store
         return []
 
@@ -67,9 +67,7 @@ def _load_jobs(reader=None):
     if reader is not None:
         return reader()
     try:
-        import _watchdog_common as watchdog_common  # noqa: PLC0415
-
-        return watchdog_common.load_jobs(RUN_SOURCE) or []
+        return openclaw.read_jobs(RUN_SOURCE).entries
     except Exception:  # noqa: BLE001
         return []
 

--- a/scripts/data/workflow_outcomes.py
+++ b/scripts/data/workflow_outcomes.py
@@ -35,6 +35,7 @@ from zoneinfo import ZoneInfo
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock.providers import openclaw  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -347,11 +348,9 @@ def _match_run(record, entries):
 def reconcile_raw_execution():
     """Overlay raw run status from live SQLite without changing final product."""
     try:
-        sys.path.insert(0, str(_CHECKOUT / "scripts" / "harness"))
-        import _watchdog_common as common
-
-        jobs = common.load_jobs("sqlite")
-        if common.LAST_LOAD_SOURCE != "sqlite" or not jobs:
+        jobs_result = openclaw.read_jobs("sqlite")
+        jobs = jobs_result.entries
+        if jobs_result.source != "sqlite" or not jobs:
             return False
         job_ids = {job.get("name"): job.get("id") for job in jobs}
         ledger = load_ledger()
@@ -362,7 +361,7 @@ def reconcile_raw_execution():
             if not job_id:
                 continue
             if job_id not in run_cache:
-                run_cache[job_id] = common.read_runs(job_id, "sqlite")
+                run_cache[job_id] = openclaw.read_runs(job_id, "sqlite").entries
             matched = _match_run(record, run_cache[job_id])
             if not matched:
                 continue

--- a/scripts/harness/_harness_common.py
+++ b/scripts/harness/_harness_common.py
@@ -1,6 +1,0 @@
-"""Compatibility alias; remove after repository callers use clawock-kcnyu."""
-
-import sys
-from importlib import import_module
-
-sys.modules[__name__] = import_module("clawock_kcnyu.harness._harness_common")

--- a/scripts/harness/_watchdog_common.py
+++ b/scripts/harness/_watchdog_common.py
@@ -1,6 +1,0 @@
-"""Compatibility alias; remove after host watchdogs use clawock-kcnyu."""
-
-import sys
-from importlib import import_module
-
-sys.modules[__name__] = import_module("clawock_kcnyu.harness._watchdog_common")

--- a/scripts/harness/brief_postflight.py
+++ b/scripts/harness/brief_postflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.brief_postflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.brief_postflight")

--- a/scripts/harness/brief_preflight.py
+++ b/scripts/harness/brief_preflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.brief_preflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.brief_preflight")

--- a/scripts/harness/brief_watchdog.py
+++ b/scripts/harness/brief_watchdog.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; host wiring moves to the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.brief_watchdog").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.brief_watchdog")

--- a/scripts/harness/intraday_postflight.py
+++ b/scripts/harness/intraday_postflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.intraday_postflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.intraday_postflight")

--- a/scripts/harness/intraday_preflight.py
+++ b/scripts/harness/intraday_preflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.intraday_preflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.intraday_preflight")

--- a/scripts/harness/intraday_watchdog.py
+++ b/scripts/harness/intraday_watchdog.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; host wiring moves to the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.intraday_watchdog").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.intraday_watchdog")

--- a/scripts/harness/report_postflight.py
+++ b/scripts/harness/report_postflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.report_postflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.report_postflight")

--- a/scripts/harness/report_preflight.py
+++ b/scripts/harness/report_preflight.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; production uses the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.report_preflight").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.report_preflight")

--- a/scripts/harness/report_watchdog.py
+++ b/scripts/harness/report_watchdog.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility CLI; host wiring moves to the installed KCNyu adapter."""
-
-import sys
-from importlib import import_module
-
-if __name__ == "__main__":
-    raise SystemExit(import_module("clawock_kcnyu.harness.report_watchdog").main())
-sys.modules[__name__] = import_module("clawock_kcnyu.harness.report_watchdog")

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -5,12 +5,11 @@ Everything OpenClaw-specific belongs here so the rest of the tree can be counted
 as runtime-agnostic — see `tests/test_runtime_coupling_ratchet.py`, which exempts
 `clawock/providers/` precisely because that is what an adapter is for.
 
-Moved out of `scripts/harness/_watchdog_common.py`, which held the binary path,
-the cron CLI call and the run-history fallback chain, and was therefore the
-largest single consumer that knew which runtime it was on. `_watchdog_common`
-lives in `scripts/harness/`, which is deliberately not in the wheel, so anything
-left there was unreachable from an installation — `OpenClawRuns.list_runs()`
-imported it at call time and raised `ModuleNotFoundError` outside the checkout.
+Moved out of the former `scripts/harness/_watchdog_common.py`, which held the
+binary path, cron CLI call and run-history fallback chain and was therefore the
+largest single consumer that knew which runtime it was on. That source alias was
+never in the wheel, so anything left behind it was unreachable from an install;
+the alias has now been retired.
 """
 from __future__ import annotations
 

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -17,10 +17,9 @@ from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
-import brief_preflight
+from clawock_kcnyu.harness import brief_preflight
 import trading_calendar
 
 

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -10,10 +10,9 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
 
 import brief_context  # noqa: E402
-import brief_postflight  # noqa: E402
+from clawock_kcnyu.harness import brief_postflight  # noqa: E402
 
 
 def _fixture():

--- a/tests/test_brief_fallback_gate.py
+++ b/tests/test_brief_fallback_gate.py
@@ -15,8 +15,7 @@ import textwrap
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
-import brief_postflight
+from clawock_kcnyu.harness import brief_postflight
 
 
 WORKFLOW = ROOT / '.github' / 'workflows' / 'brief-fallback.yml'

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -8,9 +8,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-
-import brief_postflight  # noqa: E402
+from clawock_kcnyu.harness import brief_postflight  # noqa: E402
 
 
 def _authored_decision(**updates):

--- a/tests/test_brief_postflight_sections.py
+++ b/tests/test_brief_postflight_sections.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
-import brief_postflight
+from clawock_kcnyu.harness import brief_postflight
 
 
 CHINESE_LOCALIZED_BRIEF = """\

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -4,8 +4,7 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
-import brief_postflight as postflight  # noqa: E402
+from clawock_kcnyu.harness import brief_postflight as postflight  # noqa: E402
 
 
 def _write_size(path: Path, size: int) -> Path:

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -5,9 +5,7 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-
-import brief_watchdog as watchdog  # noqa: E402
+from clawock_kcnyu.harness import brief_watchdog as watchdog  # noqa: E402
 
 
 TODAY = "2026-07-17"

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -81,7 +81,9 @@ def test_guardrail_compute_exception_is_an_explicit_failure_dict(monkeypatch):
         compute_concentration=lambda _holdings: {},
         compute_breakeven_math=lambda *_args, **_kwargs: {"rows": []},
     )
-    monkeypatch.setitem(sys.modules, "brief_preflight", fake_preflight)
+    monkeypatch.setitem(
+        sys.modules, "clawock_kcnyu.harness.brief_preflight", fake_preflight
+    )
 
     result = dashboard.compute_guardrail_outputs(_portfolio(), risk={})
 

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -10,7 +10,6 @@ from zoneinfo import ZoneInfo
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 sys.path.insert(0, str(ROOT / 'ops' / 'host'))
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 
 import cron_contract
 import cron_heartbeat
@@ -192,43 +191,13 @@ def test_watchdog_contract_and_dst_change_plan_cover_both_schedulers():
     }
 
 
-def test_legacy_host_rows_are_planned_to_installed_commands():
+def test_contract_has_no_retired_host_command_migrations():
     data = contract()
-    july = datetime(2026, 7, 16, 0, tzinfo=timezone.utc)
-    canonical = _crontab_from_contract(data, july)
-    legacy = canonical
-    replacements = {
-        '/root/.local/bin/clawock-kcnyu-brief-watchdog':
-            'python3 scripts/harness/brief_watchdog.py',
-        '/root/.local/bin/clawock-kcnyu-report-watchdog':
-            'python3 scripts/harness/report_watchdog.py',
-        '/root/.local/bin/clawock-kcnyu-intraday-watchdog':
-            'python3 scripts/harness/intraday_watchdog.py',
-        '/usr/bin/python3 /root/.openclaw/workspace/ops/host/sync_us_cron_dst.py':
-            'python3 scripts/data/sync_us_cron_dst.py',
-    }
-    for installed, old in replacements.items():
-        legacy = legacy.replace(installed, old)
-    legacy = legacy.replace(
-        ' >> /root/.openclaw/workspace/logs/watchdog.cron.log',
-        ' >> logs/watchdog.cron.log')
-    legacy = legacy.replace(
-        ' >> /root/.openclaw/workspace/logs/dst-sync.log',
-        ' >> logs/dst-sync.log')
-
-    live = [{
-        'id': f'id-{index}', 'name': job['name'],
-        'schedule': cron_contract.effective_schedule(job, july),
-    } for index, job in enumerate(data['jobs'])]
-    openclaw, host, errors = sync_us_cron_dst.desired_changes(
-        data, live, legacy, july)
-
-    assert errors == []
-    assert openclaw == []
-    assert len([change for change in host if change['kind'] != 'dst-sync']) == 11
-    assert len([change for change in host if change['kind'] == 'dst-sync']) == 1
-    assert all(change['matched_by'] == 'legacy' for change in host)
-    assert all('scripts/harness/' not in change['to']['command'] for change in host)
+    specs = [data['dst_sync']]
+    for job in data['jobs']:
+        specs.extend(job.get('system_watchdogs', []))
+        specs.extend(job.get('extra_system_watchdogs', []))
+    assert all('legacy_command_contains' not in spec for spec in specs)
 
 
 def test_crontab_apply_preserves_every_unmanaged_line(monkeypatch):
@@ -372,7 +341,7 @@ def test_heartbeat_health_graces_the_current_running_slot():
 
 
 def test_intraday_hard_length_limit_is_a_failure():
-    import intraday_postflight
+    from clawock_kcnyu.harness import intraday_postflight
 
     assert intraday_postflight.categorize(
         ['报告长度 3501 字 > 3500 上限']
@@ -409,7 +378,7 @@ def test_intraday_empty_input_is_an_input_error_not_a_content_failure(monkeypatc
     wrong" issues, hiding the real cause (missing plumbing). Empty input must be
     reported as its own class, and must never reach content validation."""
     import io
-    import intraday_postflight
+    from clawock_kcnyu.harness import intraday_postflight
 
     monkeypatch.setattr(sys, 'stdin', io.StringIO(''))
     text, err = intraday_postflight.read_report_text('hk', None)
@@ -426,7 +395,7 @@ def test_intraday_stale_report_file_is_refused(tmp_path):
     report — the failure mode --text-file would otherwise introduce."""
     import os
 
-    import intraday_postflight
+    from clawock_kcnyu.harness import intraday_postflight
 
     report = tmp_path / 'intraday-report-hk.md'
     report.write_text('🇭🇰 港股盯盘 | 07/23 10:03 HKT\n▎我的看法\n' + 'x' * 80)
@@ -452,7 +421,7 @@ def test_intraday_main_stops_on_empty_input_and_blames_the_context_slot(monkeypa
     successful retry marks 10:00 completed."""
     import io
 
-    import intraday_postflight
+    from clawock_kcnyu.harness import intraday_postflight
 
     recorded = {}
     monkeypatch.setattr(sys, 'stdin', io.StringIO(''))

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -6,9 +6,6 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-
-import _watchdog_common as common  # noqa: E402
 from clawock.providers import openclaw as provider  # noqa: E402
 
 
@@ -111,12 +108,12 @@ def test_auto_falls_back_to_live_sqlite_before_fossil(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWOCK_OPENCLAW_HOME", str(tmp_path))
     monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
-    jobs = common.load_jobs()
+    jobs = provider.read_jobs()
 
-    assert common.LAST_LOAD_SOURCE == "sqlite"
-    assert [job["name"] for job in jobs] == ["live job"]
-    assert jobs[0]["payload"]["model"] == "provider/current"
-    assert jobs[0]["state"] == {"lastRunStatus": "ok", "nextRunAtMs": 2000}
+    assert jobs.source == "sqlite"
+    assert [job["name"] for job in jobs.entries] == ["live job"]
+    assert jobs.entries[0]["payload"]["model"] == "provider/current"
+    assert jobs.entries[0]["state"] == {"lastRunStatus": "ok", "nextRunAtMs": 2000}
 
 
 def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
@@ -130,10 +127,10 @@ def test_explicit_sqlite_run_history_is_oldest_first(tmp_path, monkeypatch):
         lambda _args: (_ for _ in ()).throw(AssertionError("CLI must not run")),
     )
 
-    entries = common.read_runs("job-1", source="sqlite")
+    entries = provider.read_runs("job-1", source="sqlite")
 
-    assert common.LAST_RUNS_SOURCE == "sqlite"
-    assert [entry["ts"] for entry in entries] == [100, 200]
+    assert entries.source == "sqlite"
+    assert [entry["ts"] for entry in entries.entries] == [100, 200]
 
 
 def test_fossil_source_is_marked_stale(tmp_path, monkeypatch):
@@ -143,8 +140,9 @@ def test_fossil_source_is_marked_stale(tmp_path, monkeypatch):
     jobs_json.write_text(json.dumps([{"id": "old", "name": "stale"}]))
     monkeypatch.setattr(provider, "cron_cli_json", lambda _args: None)
 
-    assert common.load_jobs() == [{"id": "old", "name": "stale"}]
-    assert common.LAST_LOAD_SOURCE == "fossil"
+    result = provider.read_jobs()
+    assert result.entries == [{"id": "old", "name": "stale"}]
+    assert result.source == "fossil"
 
 
 def test_timeline_returns_nonzero_for_fossil(monkeypatch, capsys):

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -8,9 +8,8 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
 import decision_v2 as dv2
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-from intraday_watchdog import deterministic_fallback as intraday_fallback
-from report_watchdog import deterministic_fallback as report_fallback
+from clawock_kcnyu.harness.intraday_watchdog import deterministic_fallback as intraday_fallback
+from clawock_kcnyu.harness.report_watchdog import deterministic_fallback as report_fallback
 
 
 def decision(day, ticker="AAA", strategy="core_position", action="hold_and_watch",
@@ -695,7 +694,7 @@ class ExecutionCoverageTests(unittest.TestCase):
         wrong field, got the wrong window for every passive row and produced a
         plausible answer that was off by six points.
         """
-        import brief_preflight
+        from clawock_kcnyu.harness import brief_preflight
 
         row = {"plan_date": (date.today() - timedelta(days=10)).isoformat(),
                "ticker": "AAA", "bucket": "cut"}

--- a/tests/test_derivations.py
+++ b/tests/test_derivations.py
@@ -18,7 +18,6 @@ import pytest
 
 WS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(WS, "scripts", "data"))
-sys.path.insert(0, os.path.join(WS, "scripts", "harness"))
 
 import preflight_integrity as pi  # noqa: E402
 import recompute_realized as rr  # noqa: E402

--- a/tests/test_harness_aliases_retired.py
+++ b/tests/test_harness_aliases_retired.py
@@ -1,0 +1,27 @@
+"""The repository source aliases retired after the installed-command cutover."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_source_harness_alias_directory_is_gone():
+    assert list((ROOT / "scripts" / "harness").glob("*.py")) == []
+
+
+def test_runtime_contracts_do_not_reference_source_harness_aliases():
+    paths = [ROOT / "config" / "cron-schedules.json"]
+    paths.extend((ROOT / "scripts" / "data").glob("*"))
+    paths.extend((ROOT / "ops" / "host").glob("*"))
+    offenders = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        if "scripts/harness" in text:
+            offenders.append(path.relative_to(ROOT).as_posix())
+    assert offenders == []

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 WS = Path(__file__).resolve().parents[1]
-sys.path[:0] = [str(WS / "scripts" / "data"), str(WS / "scripts" / "harness")]
+sys.path.insert(0, str(WS / "scripts" / "data"))
 
 import build_dashboard  # noqa: E402
 import compute_quant_signals  # noqa: E402
@@ -16,7 +16,7 @@ import fetch_us_stocks  # noqa: E402
 import instrument_registry  # noqa: E402
 import portfolio_risk_metrics  # noqa: E402
 import preflight_integrity  # noqa: E402
-import brief_preflight  # noqa: E402
+from clawock_kcnyu.harness import brief_preflight  # noqa: E402
 import analyze_hk_stocks  # noqa: E402
 import analyze_us_stocks  # noqa: E402
 
@@ -148,4 +148,3 @@ def test_leveraged_exposure_ignores_closed_positions_with_stale_values():
     assert build_dashboard.compute_leveraged_etf_exposure(
         portfolio, fx_rate=7.84
     ) == live
-

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 HKT = ZoneInfo('Asia/Hong_Kong')
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 
 
 def _ms(at):
@@ -20,7 +19,7 @@ def _run(at, **extra):
 
 
 def test_watchdog_target_owns_the_slot_ten_minutes_earlier():
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     now = datetime(2026, 7, 25, 0, 10, tzinfo=HKT)
     wall, job, slot = watchdog.watchdog_target('us', now)
@@ -42,7 +41,7 @@ def test_hk_watchdog_runs_after_the_observed_long_turn_window():
 
 
 def test_run_for_slot_rejects_the_latest_completed_prior_slot():
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     prior = _run(datetime(2026, 7, 24, 10, 0, tzinfo=HKT))
     expected = _run(datetime(2026, 7, 24, 10, 30, tzinfo=HKT))
@@ -55,7 +54,7 @@ def test_run_for_slot_rejects_the_latest_completed_prior_slot():
 
 
 def test_context_and_delivery_marker_must_match_the_exact_slot(tmp_path):
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     current_slot = '2026-07-24T10:30:00+08:00'
     path = tmp_path / 'context.json'
@@ -74,7 +73,7 @@ def test_context_and_delivery_marker_must_match_the_exact_slot(tmp_path):
 
 
 def test_postflight_delivery_marker_carries_preflight_slot_identity():
-    import intraday_postflight as postflight
+    from clawock_kcnyu.harness import intraday_postflight as postflight
 
     marker = postflight.delivery_marker_payload(
         {
@@ -97,7 +96,7 @@ def test_postflight_delivery_marker_carries_preflight_slot_identity():
 
 def test_main_does_not_assess_a_prior_completed_run(
         tmp_path, monkeypatch):
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     now = datetime(2026, 7, 24, 10, 40, tzinfo=HKT)
     prior = _run(
@@ -134,7 +133,7 @@ def test_main_does_not_assess_a_prior_completed_run(
 
 def test_main_rejects_mismatched_context_and_uses_wall_clock_for_heartbeat(
         tmp_path, monkeypatch):
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     now = datetime(2026, 7, 24, 10, 40, tzinfo=HKT)
     run = _run(datetime(2026, 7, 24, 10, 30, tzinfo=HKT))
@@ -179,7 +178,7 @@ HEADING = '🇭🇰 港股盯盘 | 07/29 10:32 HKT'
 
 def _wire_watchdog(monkeypatch, tmp_path, *, run, now, marker, loop_score=1):
     """Set up main() against a tmp workspace; returns (sends, heartbeats, events)."""
-    import intraday_watchdog as watchdog
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
 
     context_dir = tmp_path / 'memory' / '.tmp'
     context_dir.mkdir(parents=True, exist_ok=True)
@@ -317,7 +316,7 @@ def test_an_absurdly_future_marker_cannot_suppress_the_backstop(
 def test_a_fallback_that_could_not_be_sent_records_a_failure(
         tmp_path, monkeypatch):
     """The one state nobody downstream can infer must leave its own trace."""
-    import intraday_watchdog as watchdog_mod
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog_mod
 
     now = datetime(2026, 7, 29, 10, 40, tzinfo=HKT)
     run = _run(datetime(2026, 7, 29, 10, 30, tzinfo=HKT),

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -24,11 +24,10 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 
 import build_dashboard as dashboard  # noqa: E402
 import cron_health_check  # noqa: E402
-import _harness_common  # noqa: E402
+from clawock_kcnyu.harness import _harness_common  # noqa: E402
 
 
 BROKEN = ('{\n  "behavioral_review": [{"tag": "bias", "text": "chased"}],\n'

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -508,10 +508,7 @@ def test_mover_attribution_has_room_under_the_ceiling():
     why this test existed. #334 lifted the ceiling to 5,000/6,000 and removed the
     pre-write target, so the worst case now clears it with room to spare — the
     remaining risk is the opposite one, a ceiling quietly lowered back onto it."""
-    import sys
-
-    sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-    import report_postflight
+    from clawock_kcnyu.harness import report_postflight
 
     worst_case_measured = 2_898
     assert report_postflight.CHAR_LIMITS["soft"] > worst_case_measured

--- a/tests/test_news_evidence_graph.py
+++ b/tests/test_news_evidence_graph.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from scripts.data import gh_action_news_digest
 from scripts.data import news_evidence_graph as graph
 from scripts.data import validate_sidecars
-from scripts.harness import brief_postflight
+from clawock_kcnyu.harness import brief_postflight
 
 
 POLICY = graph.load_policy()

--- a/tests/test_report_length_ceiling.py
+++ b/tests/test_report_length_ceiling.py
@@ -14,11 +14,10 @@ from pathlib import Path
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
-import _harness_common as common  # noqa: F401
+from clawock_kcnyu.harness import _harness_common as common  # noqa: F401
 from clawock import validation  # noqa: E402
-import intraday_postflight  # noqa: E402
-import report_postflight as postflight  # noqa: E402
+from clawock_kcnyu.harness import intraday_postflight  # noqa: E402
+from clawock_kcnyu.harness import report_postflight as postflight  # noqa: E402
 
 
 def test_every_mode_reads_one_definition_of_the_ceiling():

--- a/tests/test_report_watchdog_retry_parity.py
+++ b/tests/test_report_watchdog_retry_parity.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
-sys.path.insert(0, str(ROOT / 'scripts' / 'harness'))
 
 SENT_AT = datetime(2026, 8, 3, 13, 31, 24)
 NOW_MS = int(datetime(2026, 8, 3, 13, 42).timestamp() * 1000)
@@ -39,7 +38,7 @@ def _marker(context_id, generated_at, **extra):
 
 
 def test_retry_regenerated_context_still_counts_as_delivered():
-    import report_watchdog as watchdog
+    from clawock_kcnyu.harness import report_watchdog as watchdog
 
     # The retry's preflight rebuilt the context 2m35s after the delivered one.
     marker = _marker('af4310c68bbf', datetime(2026, 8, 3, 13, 30, 24))
@@ -54,7 +53,7 @@ def test_retry_regenerated_context_still_counts_as_delivered():
 
 
 def test_stale_body_behind_a_fresh_marker_still_gets_a_backstop():
-    import report_watchdog as watchdog
+    from clawock_kcnyu.harness import report_watchdog as watchdog
 
     # 2026-07-24 shape: the marker was written today, but the report it sent was
     # built from a context two days old. That must remain a miss.
@@ -69,7 +68,7 @@ def test_stale_body_behind_a_fresh_marker_still_gets_a_backstop():
 
 
 def test_context_older_than_the_delivered_one_is_not_a_retry():
-    import report_watchdog as watchdog
+    from clawock_kcnyu.harness import report_watchdog as watchdog
 
     # A retry always regenerates FORWARD. A context materially older than the
     # delivered generation means the watchdog is reading someone else's file,
@@ -85,7 +84,7 @@ def test_context_older_than_the_delivered_one_is_not_a_retry():
 
 def test_postflight_records_the_source_context_timestamp(tmp_path, monkeypatch):
     """Without this field on the marker the window above can never engage."""
-    import report_postflight as postflight
+    from clawock_kcnyu.harness import report_postflight as postflight
 
     monkeypatch.setattr(postflight, 'TMP', tmp_path)
     monkeypatch.setattr(postflight, 'resolve_wechat_target',

--- a/tests/test_risk_discipline.py
+++ b/tests/test_risk_discipline.py
@@ -8,8 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
 import decision_v2  # noqa: E402
 import risk_discipline as discipline  # noqa: E402
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-import brief_postflight  # noqa: E402
+from clawock_kcnyu.harness import brief_postflight  # noqa: E402
 
 
 def _guardrail(kind="hard_stop", ticker="PLTU", leg="US"):

--- a/tests/test_runs_against_a_foreign_book.py
+++ b/tests/test_runs_against_a_foreign_book.py
@@ -25,8 +25,11 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
-CLIS = ("brief_preflight", "report_preflight", "intraday_preflight",
-        "brief_postflight", "report_postflight", "intraday_postflight")
+PHASES = tuple(
+    (mode, phase)
+    for mode in ("brief", "report", "intraday")
+    for phase in ("preflight", "postflight")
+)
 
 
 def _source_install_env(**extra):
@@ -50,22 +53,16 @@ def foreign_book(tmp_path):
     return book
 
 
-@pytest.mark.parametrize("cli", CLIS)
-def test_instance_rollback_aliases_start_against_the_instance_workspace(cli):
-    """The aliases are KCNyu rollback wiring, not the portable product.
-
-    Their implementation now lives in the separately installed instance
-    distribution and may consume this desk's data modules. Public foreign-book
-    portability is exercised through the product CLI below, not by pretending
-    KCNyu's live market/delivery adapter belongs to every user.
-    """
+@pytest.mark.parametrize(("mode", "phase"), PHASES)
+def test_installed_phase_entrypoints_start_against_the_instance_workspace(mode, phase):
+    """Production phase commands resolve the repository-only adapter by entry point."""
     done = subprocess.run(
-        [sys.executable, str(ROOT / "scripts" / "harness" / f"{cli}.py"), "--help"],
+        [sys.executable, "-m", "clawock", mode, phase, "--help"],
         capture_output=True, text=True, timeout=90, cwd=str(ROOT),
         env=_source_install_env(CLAWOCK_WORKSPACE=str(ROOT)),
     )
     assert done.returncode == 0, (
-        f"{cli} cannot start against the KCNyu instance workspace:\n"
+        f"clawock {mode} {phase} cannot start against the KCNyu workspace:\n"
         f"{done.stdout[-500:]}\n{done.stderr[-1500:]}")
 
 

--- a/tests/test_site_deploy.py
+++ b/tests/test_site_deploy.py
@@ -96,7 +96,7 @@ def test_the_dispatch_names_the_event_the_workflow_listens_for(tmp_path):
     subprocess.run([sys.executable, "-c",
                     "import sys; sys.path.insert(0, %r);"
                     "from clawock.publish import GitHubDispatchDeployer as D;"
-                    "D('KCNyu/clawock').request('why')" % str(ROOT)],
+                    "D('KCNyu/clawock').request('why')" % str(ROOT / "src")],
                    env=env, check=True, capture_output=True, text=True)
 
     assert "repos/KCNyu/clawock/dispatches" in log.read_text()

--- a/tests/test_suppression_is_visible.py
+++ b/tests/test_suppression_is_visible.py
@@ -27,7 +27,6 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "harness"))
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
 
 import plan_surface  # noqa: E402

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -207,27 +207,28 @@ def test_reconcile_adds_raw_error_without_changing_final_product(tmp_path, monke
     for stage in ("preflight", "llm", "postflight", "primary_delivery"):
         outcomes.record_stage(job, stage, "success", slot=slot)
 
-    sys.path.insert(0, str(ROOT / "scripts" / "harness"))
-    import _watchdog_common as common
+    from clawock.providers import openclaw
 
     run_at_ms = int(
         outcomes.datetime.fromisoformat(slot).timestamp() * 1000
     )
 
-    def load_jobs(_source):
-        common.LAST_LOAD_SOURCE = "sqlite"
-        return [{"id": "brief-id", "name": job}]
-
-    monkeypatch.setattr(common, "load_jobs", load_jobs)
     monkeypatch.setattr(
-        common,
+        openclaw,
+        "read_jobs",
+        lambda _source: openclaw.CronRead(
+            [{"id": "brief-id", "name": job}], "sqlite"
+        ),
+    )
+    monkeypatch.setattr(
+        openclaw,
         "read_runs",
-        lambda _job_id, _source: [{
-            "runAtMs": run_at_ms,
-            "ts": run_at_ms + 1000,
-            "status": "error",
-            "error": "private provider detail",
-        }],
+        lambda _job_id, _source: openclaw.CronRead([{
+                "runAtMs": run_at_ms,
+                "ts": run_at_ms + 1000,
+                "status": "error",
+                "error": "private provider detail",
+            }], "sqlite"),
     )
 
     assert outcomes.reconcile_raw_execution() is True


### PR DESCRIPTION
## Summary

- retire all 11 `scripts/harness` compatibility aliases after the installed-command cutover
- migrate operational cron readers directly to `clawock.providers.openclaw`
- remove one-time legacy crontab matchers and require exact canonical commands
- make repository tests import the KCNyu package explicitly and pin the retired boundary
- clarify that `clawock-kcnyu` is repository-only migration code, not proof that reusable lifecycle logic is instance-specific

## Verification

- `CLAWOCK_DELIVERY_DISABLED=1 python3 -m pytest -q` — 1693 passed, 10 skipped, 4 xfailed
- `python3 -m json.tool config/cron-schedules.json`
- `git diff --check`
- live read-only `python3 ops/host/sync_us_cron_dst.py --json` — zero OpenClaw changes, zero watchdog changes, zero errors

Part of #381 and the #378 handoff.
