### PR TITLE
Move instrument registry into the product

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -183,6 +183,7 @@ jobs:
         run: |
           python3 -m pytest tests/ -q \
             --cov=scripts \
+            --cov=clawock.instrument_registry \
             --cov-report=term-missing:skip-covered \
             --cov-report=json:coverage-report.json
 
@@ -272,7 +273,7 @@ jobs:
 
       - name: Schema-validate canonical instrument registry
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
-        run: python3 scripts/data/instrument_registry.py
+        run: python3 -m clawock.instrument_registry
 
       - name: Schema-validate memory/*-plan.json
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -54,12 +54,15 @@ classification says where a file belongs, not that it has arrived.
 ## Classification
 
 The package now has a standard `src/clawock/` source boundary. The historical
-counts below describe the still-unmoved `scripts/data/` migration inventory;
-they are not a claim that `scripts/` is an acceptable final product home.
+counts below classify the original `scripts/data/` migration inventory; they are
+not a claim that `scripts/` is an acceptable final product home.
 
 Historical classification counts: **product 60 · instance 27**. The two cron
 synchronizers now live in `ops/host/`; the table retains them to preserve the
-decision record while the rest of `scripts/data/` is migrated.
+decision record while the rest of `scripts/data/` is migrated. The first product
+move is complete: `instrument_registry` now ships as
+`src/clawock/instrument_registry.py`; configured instruments remain workspace
+data and are not bundled in the wheel.
 
 ### Product — the engine
 
@@ -70,7 +73,8 @@ decision record while the rest of `scripts/data/` is migrated.
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` `json_repair` |
-| Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` `bar_checks` `instrument_registry` `trading_calendar` |
+| Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` `bar_checks` `trading_calendar` |
+| Moved into product | `clawock.instrument_registry` | Code and schema ship in the wheel; each user's `config/instruments.json` stays in their workspace |
 | Gates + outputs | `preflight_integrity` `validate_sidecars` `dashboard_outputs` `build_dashboard` `workflow_outcomes` `workflow_health` `coverage_badge` `cron_contract` `cron_heartbeat` |
 
 ### Instance — kcn's desk

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -55,9 +55,9 @@ import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 import brief_context  # noqa: E402
 import brief_decision_packet  # noqa: E402
-from instrument_registry import get as get_instrument  # noqa: E402
-from instrument_registry import compute_lookthrough_exposure  # noqa: E402
-from instrument_registry import one_x_swap_map  # noqa: E402
+from clawock.instrument_registry import get as get_instrument  # noqa: E402
+from clawock.instrument_registry import compute_lookthrough_exposure  # noqa: E402
+from clawock.instrument_registry import one_x_swap_map  # noqa: E402
 
 
 def _run(script, args=None, timeout=120):

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -137,7 +137,7 @@ def check_instrument_registry(r):
     """Canonical metadata must cover every active holding."""
     sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
-        import instrument_registry
+        from clawock import instrument_registry
         portfolio = json.loads((WS / 'portfolio.json').read_text())
         errors = instrument_registry.validate_active_holdings(portfolio)
     except Exception as e:

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -98,7 +98,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `thesis_registry.py` | 持久 thesis schema/validator、证据驱动 drift（红线触发/解除对称要证据）与 decision link 解析 | `memory/theses/*.json` + 本地确定性校验 | ✅ |
 | `earnings_review.py` | 一手财报复盘:来源分级、盈利质量数学、管理层承诺账本、provenance 准出与 thesis 证据交接 | `memory/earnings/*/*.json` + 本地确定性校验 | ✅ |
 | `workflow_health.py` | 排程 GitHub Actions 周度健康:连续失败计数 + **静默停跑**检测(节奏从 workflow 文件里读) | `gh run list` + `.github/workflows/*.yml` | ✅ |
-| `instrument_registry.py` | 工具标的**唯一真源**:杠杆倍数、underlying 看穿(`look_through`/`issuer_for` — 基金→发行人、指数基金→无发行人)、canonical bar manifest | `config/instruments.json` | ✅ |
+| `src/clawock/instrument_registry.py` | 工具标的**唯一真源**:杠杆倍数、underlying 看穿(`look_through`/`issuer_for` — 基金→发行人、指数基金→无发行人)、canonical bar manifest | `config/instruments.json` | ✅ |
 | `entry_gate.py` | 建仓前研究闸:信息分级与投资质量分离、确定性硬否决(行业例外写进配置)、pass/reject/gray 判定与深研路由 | `memory/entry-gates/*.json` + `config/entry-gate-vetoes.json` | ✅ |
 
 ## Layer 8 · 回测/自省 Backtest & Calibration

--- a/scripts/data/analyze_hk_stocks.py
+++ b/scripts/data/analyze_hk_stocks.py
@@ -17,14 +17,18 @@ import json
 import os
 import sys
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
 import bar_checks  # noqa: E402  shared "is this bar believable" contract
 from _em_http import em_get  # noqa: E402
-from instrument_registry import INSTRUMENTS  # noqa: E402
+from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PORTFOLIO_PATH = os.path.join(WS_ROOT, 'portfolio.json')

--- a/scripts/data/analyze_us_stocks.py
+++ b/scripts/data/analyze_us_stocks.py
@@ -15,16 +15,20 @@ Usage:
 
 import json, os, sys
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import requests
 
 # ── imports from sibling script ─────────────────────────────────────────────
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
 from fetch_us_stocks import (
     update_us_portfolio, load_api_keys,
     PORTFOLIO_PATH, SESSION, TIMEOUT
 )
-from instrument_registry import get as get_instrument
+from clawock.instrument_registry import get as get_instrument
 
 ET_TZ  = timezone(timedelta(hours=-4))
 HKT_TZ = timezone(timedelta(hours=8))

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -24,7 +24,6 @@ from zoneinfo import ZoneInfo
 
 import dashboard_outputs
 import decision_v2
-import instrument_registry
 import json_repair
 
 # Strict YYYY-MM-DD.json — rejects baselines/backups/archives that share the
@@ -43,6 +42,7 @@ sys.path.insert(0, str(CHECKOUT_ROOT / "src"))
 # calculations move into core; never recover it through a source-tree alias.
 sys.path.insert(0, str(CHECKOUT_ROOT / "instances" / "kcnyu" / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock import instrument_registry  # noqa: E402
 
 WS_ROOT = workspace_root(Path(__file__).resolve().parent.parent.parent)
 OUT_DIR = WS_ROOT / 'assets' / 'data'

--- a/scripts/data/compute_quant_signals.py
+++ b/scripts/data/compute_quant_signals.py
@@ -59,7 +59,7 @@ MAX_STALE_DAYS = 7
 RETIRED_RETENTION_DAYS = 7
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-from instrument_registry import require as require_instrument  # noqa: E402
+from clawock.instrument_registry import require as require_instrument  # noqa: E402
 import trading_calendar  # noqa: E402
 
 try:

--- a/scripts/data/compute_regime.py
+++ b/scripts/data/compute_regime.py
@@ -97,7 +97,7 @@ VOL_WINDOW = 20
 VOL_CAP = 0.50       # HSTECH 20d annualised realised-vol ceiling for "vol-ok"
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-from instrument_registry import INSTRUMENTS  # noqa: E402
+from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
 
 # US 2x single-stock ETF → (underlying ticker, Tencent fqkline symbol). The US dial is
 # PER-NAME (each ETF tracks one stock) and — verified in backtest_us_leverage.py — must

--- a/scripts/data/compute_t0_setups.py
+++ b/scripts/data/compute_t0_setups.py
@@ -45,7 +45,7 @@ HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 HIST_MAX_LINES = 4000   # 盘中每 30min 一行，封顶约 1 年留痕
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-from instrument_registry import INSTRUMENTS  # noqa: E402
+from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
 
 try:
     from safe_io import safe_write_json

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -48,7 +48,7 @@ CORE_MODULES = (
     'scripts/data/preflight_integrity.py',
     'scripts/data/risk_discipline.py',
     'scripts/data/shadow_portfolio.py',
-    'scripts/data/instrument_registry.py',
+    'src/clawock/instrument_registry.py',
     'scripts/data/recompute_aggregates.py',
     'scripts/data/recompute_realized.py',
     'scripts/data/portfolio_risk_metrics.py',

--- a/scripts/data/entry_gate.py
+++ b/scripts/data/entry_gate.py
@@ -44,7 +44,7 @@ ARTIFACT_ROOT = WS / "memory" / "entry-gates"
 SCHEMA_VERSION = 1
 
 sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
-import instrument_registry  # noqa: E402
+from clawock import instrument_registry  # noqa: E402
 
 MARKETS = {"US", "HK"}
 INSTRUMENT_KINDS = {"company", "leveraged_etf"}

--- a/scripts/data/fetch_catalysts.py
+++ b/scripts/data/fetch_catalysts.py
@@ -28,8 +28,11 @@ from pathlib import Path
 
 import requests
 
-import instrument_registry
-from instrument_registry import leveraged_symbols
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
+from clawock import instrument_registry  # noqa: E402
+from clawock.instrument_registry import leveraged_symbols  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 OUT_FILE = os.path.join(WS_ROOT, 'assets', 'data', 'catalysts.json')

--- a/scripts/data/fetch_daily_bars.py
+++ b/scripts/data/fetch_daily_bars.py
@@ -76,7 +76,7 @@ SCHEMA_VERSION = 1
 # canonical and `em` remains the best-effort cross-audit source. The registry is
 # the one reviewed location for load-bearing .OQ/.N/.AM suffixes, retirement
 # declarations and display names.
-from instrument_registry import canonical_bar_manifest  # noqa: E402
+from clawock.instrument_registry import canonical_bar_manifest  # noqa: E402
 
 MANIFEST: dict[str, dict] = canonical_bar_manifest()
 

--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -29,9 +29,12 @@ from zoneinfo import ZoneInfo
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
 import bar_checks  # noqa: E402  shared "is this bar believable" contract
 from _em_http import em_get  # noqa: E402
-from instrument_registry import INSTRUMENTS  # noqa: E402
+from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
 import trading_calendar  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/scripts/data/gh_action_news_digest.py
+++ b/scripts/data/gh_action_news_digest.py
@@ -22,7 +22,10 @@ from pathlib import Path
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import instrument_registry
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
+from clawock import instrument_registry  # noqa: E402
 from xiaomi_llm import chat
 from fetch_sentiment import fetch_google_news
 

--- a/scripts/data/mover_news.py
+++ b/scripts/data/mover_news.py
@@ -234,7 +234,7 @@ def _market_flashes(names, *, now, window):
 def holding_names(tickers) -> dict:
     """Ticker → display name, for matching a market-wide flash to a holding."""
     try:
-        import instrument_registry  # noqa: PLC0415
+        from clawock import instrument_registry  # noqa: PLC0415
 
         return {
             ticker: (instrument_registry.get(str(ticker)) or {}).get("name")
@@ -287,7 +287,7 @@ def probe_targets(ticker: str, market: str) -> dict:
     earnings calendar and the news digest.
     """
     try:
-        import instrument_registry  # noqa: PLC0415
+        from clawock import instrument_registry  # noqa: PLC0415
 
         resolved = instrument_registry.look_through(ticker)
     except Exception:  # noqa: BLE001 — never break a reporting cron

--- a/scripts/data/portfolio_risk_metrics.py
+++ b/scripts/data/portfolio_risk_metrics.py
@@ -21,14 +21,18 @@ import sys
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import numpy as np
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
 from fetch_fx import get_usdhkd  # noqa: E402
-from instrument_registry import get as get_instrument  # noqa: E402
-from instrument_registry import leverage_map, require as require_instrument  # noqa: E402
+from clawock.instrument_registry import get as get_instrument  # noqa: E402
+from clawock.instrument_registry import leverage_map, require as require_instrument  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PORTFOLIO_FILE = os.path.join(WS_ROOT, 'portfolio.json')

--- a/scripts/data/preflight_integrity.py
+++ b/scripts/data/preflight_integrity.py
@@ -74,7 +74,7 @@ PORTFOLIO = WS / 'portfolio.json'
 OUT = WS / 'assets' / 'data' / 'integrity_report.json'
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-from instrument_registry import INSTRUMENTS  # noqa: E402
+from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
 
 try:
     from safe_io import safe_write_json

--- a/src/clawock/instrument_registry.py
+++ b/src/clawock/instrument_registry.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Canonical instrument metadata shared by dashboard, risk, quant and brief.
 
 The JSON file is deliberately data-only so exchange suffixes, leverage and
@@ -15,13 +14,7 @@ from pathlib import Path
 from typing import Any
 
 
-# The checkout root, so `clawock` resolves from the tree this file ships
-# in. Reached through the scripts/data/workspace shim until #267 step 3,
-# whose only remaining job was inserting this path as a side effect.
-import sys  # noqa: E402
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from clawock.workspace import engine_config, workspace_root  # noqa: E402
+from .workspace import engine_config, workspace_root
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
 REGISTRY_FILE = WS / "config" / "instruments.json"

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -13,12 +13,19 @@ import compute_regime  # noqa: E402
 import compute_t0_setups  # noqa: E402
 import fetch_daily_bars  # noqa: E402
 import fetch_us_stocks  # noqa: E402
-import instrument_registry  # noqa: E402
+from clawock import instrument_registry  # noqa: E402
 import portfolio_risk_metrics  # noqa: E402
 import preflight_integrity  # noqa: E402
 from clawock_kcnyu.harness import brief_preflight  # noqa: E402
 import analyze_hk_stocks  # noqa: E402
 import analyze_us_stocks  # noqa: E402
+
+
+def test_registry_implementation_is_product_not_a_repository_script():
+    assert instrument_registry.__file__ == str(
+        WS / "src" / "clawock" / "instrument_registry.py"
+    )
+    assert not (WS / "scripts" / "data" / "instrument_registry.py").exists()
 
 
 def _portfolio():

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -672,7 +672,7 @@ def test_the_watch_is_opt_in_and_the_daily_brief_opts_in():
 def test_registry_look_through_is_the_single_rule(symbol, kind, issuer, tracks):
     import sys
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
-    import instrument_registry
+    from clawock import instrument_registry
 
     resolved = instrument_registry.look_through(symbol)
     assert (resolved["kind"], resolved["issuer"], resolved["tracks"]) == (kind, issuer, tracks)

--- a/tests/test_runs_against_a_foreign_book.py
+++ b/tests/test_runs_against_a_foreign_book.py
@@ -79,7 +79,7 @@ def test_public_cli_stays_usable_from_a_foreign_book(foreign_book):
 
 def test_an_absent_registry_is_empty_but_a_broken_one_still_raises(tmp_path):
     sys.path[:0] = [str(ROOT / "scripts" / "data"), str(ROOT)]
-    import instrument_registry as registry
+    from clawock import instrument_registry as registry
 
     assert registry.load_registry(tmp_path / "nope.json", missing_ok=True) == {}
 
@@ -100,10 +100,10 @@ def test_schemas_come_from_the_engine_not_the_book(foreign_book):
     """
     probe = (
         "import sys; sys.path[:0] = [%r, %r]\n"
-        "import instrument_registry as r\n"
+        "from clawock import instrument_registry as r\n"
         "print(r.SCHEMA_FILE)\n"
         "print(r.REGISTRY_FILE)\n"
-    ) % (str(ROOT / "scripts" / "data"), str(ROOT))
+    ) % (str(ROOT / "scripts" / "data"), str(ROOT / "src"))
     done = subprocess.run(
         [sys.executable, "-c", probe], capture_output=True, text=True, timeout=60,
         cwd=str(ROOT), env=dict(os.environ, CLAWOCK_WORKSPACE=str(foreign_book)))


### PR DESCRIPTION
## Summary

- move the reusable instrument metadata registry from `scripts/data` into the public `clawock` package
- update every product, instance, operator and test consumer to use `clawock.instrument_registry`
- keep configured instruments in the workspace; the wheel ships the mechanism and schema, not KCNyu's registry data
- add a ratchet proving the old repository-script implementation is gone

## Verification

- `CLAWOCK_DELIVERY_DISABLED=1 python3 -m pytest -q` — 1694 passed, 10 skipped, 4 xfailed
- built-wheel import coverage includes the new module and runs outside the checkout
- foreign-workspace schema/config split tests pass
- `git diff --check`

Part of #381 and #378.
