### PR TITLE
Move trading calendar into clawock

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -187,6 +187,7 @@ jobs:
             --cov=clawock.instrument_registry \
             --cov=clawock.json_repair \
             --cov=clawock.safe_io \
+            --cov=clawock.trading_calendar \
             --cov-report=term-missing:skip-covered \
             --cov-report=json:coverage-report.json
 

--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -1,7 +1,7 @@
 **第一轮强制动作（不能跳过）**：在同一条回复中并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令。`read` 成功前不得进入分析；skills catalog 只有索引，不含 SKILL.md 正文。
 
 **Step 0 — 休市闸（最先执行）**
-分别跑 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py hk` 与 `python3 /root/.openclaw/workspace/scripts/data/trading_calendar.py us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
+分别跑 `/root/.local/bin/clawock calendar hk` 与 `/root/.local/bin/clawock calendar us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
 
 你是 Rick，kcn 的全市场盘前深度分析师。08:00 HKT 工作日，HK 开盘前 90 分钟，US 已收盘 ~4 小时。
 

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -133,8 +133,8 @@
       "message_template": "config/cron-payloads/brief.md",
       "delivery_mode": "none",
       "required_substrings": [
-        "trading_calendar.py hk",
-        "trading_calendar.py us",
+        "/root/.local/bin/clawock calendar hk",
+        "/root/.local/bin/clawock calendar us",
         "skills/daily-deep-brief/SKILL.md",
         "并行调用 `read` 读取 `/root/.openclaw/workspace/skills/daily-deep-brief/SKILL.md` 与下方 Step 0 的两个休市闸命令",
         "skills catalog 只有索引，不含 SKILL.md 正文",
@@ -147,7 +147,8 @@
         "message"
       ],
       "forbidden_substrings": [
-        "唯一投递路径"
+        "唯一投递路径",
+        "trading_calendar.py"
       ]
     },
     "memory": {

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -63,7 +63,8 @@ decision record while the rest of `scripts/data/` is migrated. The first product
 move is complete: `instrument_registry` now ships as
 `src/clawock/instrument_registry.py`; configured instruments remain workspace
 data and are not bundled in the wheel. The dependency-free `bar_checks`,
-`json_repair`, and `safe_io` utilities have also moved into `src/clawock/`.
+`json_repair`, `safe_io`, and `trading_calendar` utilities have also moved into
+`src/clawock/`.
 
 ### Product — the engine
 
@@ -74,8 +75,8 @@ data and are not bundled in the wheel. The dependency-free `bar_checks`,
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` |
-| Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` `trading_calendar` |
-| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.json_repair` `clawock.safe_io` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
+| Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` |
+| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
 | Gates + outputs | `preflight_integrity` `validate_sidecars` `dashboard_outputs` `build_dashboard` `workflow_outcomes` `workflow_health` `coverage_badge` `cron_contract` `cron_heartbeat` |
 
 ### Instance — kcn's desk

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -31,12 +31,12 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
@@ -46,7 +47,6 @@ TMP_DIR = WS / 'memory' / '.tmp'
 SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import trading_calendar  # noqa: E402
 import decision_v2  # noqa: E402
 import thesis_registry  # noqa: E402
 import research_surface  # noqa: E402

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -61,13 +61,13 @@ from ._harness_common import (  # noqa: E402
 from ._watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 
 # A report file older than this is assumed to be a previous slot's leftover. Kept

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
@@ -35,6 +35,7 @@ from datetime import datetime
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 DATA_DIR = WS / 'scripts' / 'data'
@@ -43,7 +44,6 @@ TMP = WS / 'memory' / '.tmp'
 from ._harness_common import compute_context_id
 
 sys.path.insert(0, str(DATA_DIR))
-import trading_calendar  # noqa: E402
 import cron_heartbeat  # noqa: E402
 import peer_scan  # noqa: E402
 import plan_surface  # noqa: E402

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
@@ -42,13 +42,13 @@ from datetime import datetime
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import trading_calendar  # noqa: E402
 import workflow_outcomes  # noqa: E402
 
 # The deterministic report core moved into the installed package so `clawock

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_preflight.py
@@ -51,6 +51,7 @@ from datetime import datetime
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock import trading_calendar
 
 WS = workspace_root(Path.cwd())
 DATA_DIR = WS / 'scripts' / 'data'
@@ -61,7 +62,6 @@ from ._harness_common import (  # noqa: F401 — re-exported for callers/tests
 )
 
 sys.path.insert(0, str(DATA_DIR))
-import trading_calendar  # noqa: E402
 import peer_scan  # noqa: E402
 import plan_surface  # noqa: E402
 import research_surface  # noqa: E402

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -542,7 +542,7 @@ def check_trading_calendar_horizon(r):
     """
     sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
-        import trading_calendar
+        from clawock import trading_calendar
         coverage = trading_calendar.coverage()
     except Exception as e:  # noqa: BLE001
         r.add('trading calendar', CRITICAL, f'cannot read coverage: {e}')

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -2398,7 +2398,7 @@ def compute_build_status(portfolio, data_dir, at=None):
         now = now.astimezone()
     try:
         sys.path.insert(0, str(WS_ROOT / 'scripts' / 'data'))
-        import trading_calendar as _tc
+        from clawock import trading_calendar as _tc
     except Exception:
         _tc = None
     files = []

--- a/scripts/data/build_evidence.py
+++ b/scripts/data/build_evidence.py
@@ -165,7 +165,7 @@ def _sessions_after(start: str, n: int, market: str = 'hk') -> str | None:
     """
     try:
         from datetime import date, timedelta
-        import trading_calendar
+        from clawock import trading_calendar
     except Exception:
         return None
     try:

--- a/scripts/data/compute_quant_signals.py
+++ b/scripts/data/compute_quant_signals.py
@@ -38,6 +38,7 @@ import requests
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock import trading_calendar  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -60,7 +61,6 @@ RETIRED_RETENTION_DAYS = 7
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from clawock.instrument_registry import require as require_instrument  # noqa: E402
-import trading_calendar  # noqa: E402
 
 try:
     from clawock.safe_io import safe_write_json

--- a/scripts/data/compute_t0_setups.py
+++ b/scripts/data/compute_t0_setups.py
@@ -53,7 +53,7 @@ except Exception:
     def safe_write_json(path, data, indent=2):
         Path(path).write_text(json.dumps(data, ensure_ascii=False, indent=indent))
 try:
-    import trading_calendar as tc
+    from clawock import trading_calendar as tc
 except Exception:
     tc = None
 

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -55,7 +55,7 @@ CORE_MODULES = (
     'scripts/data/intraday_delta_gate.py',
     'scripts/data/workflow_outcomes.py',
     'src/clawock/safe_io.py',
-    'scripts/data/trading_calendar.py',
+    'src/clawock/trading_calendar.py',
 )
 
 # Floors sit a couple of points under the measured value: enough headroom that a

--- a/scripts/data/cron_health_check.py
+++ b/scripts/data/cron_health_check.py
@@ -353,7 +353,7 @@ def check_scheduled_publisher(now=None, path=None):
     # Same local, fail-open import as _market_closed_today: an unavailable
     # calendar must not turn this into a red, so it falls through to judging.
     try:
-        import trading_calendar as _tc
+        from clawock import trading_calendar as _tc
         trading = any(_tc.is_trading_day(m, local.date()) for m in ('hk', 'us'))
     except Exception:
         trading = True
@@ -435,7 +435,7 @@ def _market_closed_today(market):
     is correctly skipped by preflight's holiday gate (memory: openclaw-market-holiday-gate),
     so it produces no commit by design. Fail-open (False) if the calendar is unavailable."""
     try:
-        import trading_calendar as _tc
+        from clawock import trading_calendar as _tc
         return not _tc.is_trading_day(market)
     except Exception:
         return False

--- a/scripts/data/decision_v2.py
+++ b/scripts/data/decision_v2.py
@@ -29,16 +29,12 @@ from collections import Counter, defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-# The calendar is the authority on whether a market was open. Never infer that from
-# whether a bar exists — an unfinished session has no bar either.
-import trading_calendar as _cal  # noqa: E402
-
 # The checkout root, so `clawock` resolves from the tree this file ships
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from clawock import trading_calendar as _cal  # noqa: E402
 from clawock.workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])

--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -33,9 +33,9 @@ _CHECKOUT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_CHECKOUT))
 sys.path.insert(0, str(_CHECKOUT / "src"))
 from clawock import bar_checks  # noqa: E402  shared contract
+from clawock import trading_calendar  # noqa: E402
 from _em_http import em_get  # noqa: E402
 from clawock.instrument_registry import INSTRUMENTS  # noqa: E402
-import trading_calendar  # noqa: E402
 
 WS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PORTFOLIO_PATH = os.path.join(WS_ROOT, 'portfolio.json')

--- a/scripts/data/intraday_delta_gate.py
+++ b/scripts/data/intraday_delta_gate.py
@@ -21,6 +21,7 @@ from zoneinfo import ZoneInfo
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock import trading_calendar  # noqa: E402
 
 # Code lives in the checkout; only DATA lives in the workspace. `workspace_root`
 # is overridable, so resolving our own modules through WS would read them out of
@@ -34,7 +35,6 @@ PORTFOLIO = WS / "portfolio.json"
 sys.path.insert(0, str(_CHECKOUT / "scripts" / "data"))
 import cron_heartbeat  # noqa: E402
 import fetch_peers  # noqa: E402
-import trading_calendar  # noqa: E402
 
 
 def _load(path):

--- a/scripts/data/preflight_integrity.py
+++ b/scripts/data/preflight_integrity.py
@@ -83,7 +83,7 @@ except Exception:  # pragma: no cover
         Path(path).write_text(json.dumps(data, ensure_ascii=False, indent=indent))
 
 try:
-    import trading_calendar as tc
+    from clawock import trading_calendar as tc
 except Exception:
     tc = None
 

--- a/scripts/data/shadow_portfolio.py
+++ b/scripts/data/shadow_portfolio.py
@@ -22,15 +22,14 @@ from pathlib import Path
 from typing import Callable
 from zoneinfo import ZoneInfo
 
-import decision_v2
-import trading_calendar
-
 # The checkout root, so `clawock` resolves from the tree this file ships
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 import sys  # noqa: E402
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+import decision_v2  # noqa: E402
+from clawock import trading_calendar  # noqa: E402
 from clawock.workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -150,6 +150,19 @@ def _doctor(args) -> int:
     return 1
 
 
+def _calendar(args) -> int:
+    """Run the package-owned HK/US session guard."""
+    from clawock.trading_calendar import main as calendar_main
+
+    forwarded = [args.market]
+    if args.date:
+        forwarded += ["--date", args.date]
+    if args.session != "full":
+        forwarded += ["--session", args.session]
+    if args.quiet:
+        forwarded.append("--quiet")
+    return calendar_main(forwarded)
+
 
 def _report(args) -> int:
     """Assemble and judge a market report, in-process.
@@ -430,6 +443,15 @@ def main(argv=None) -> int:
     doctor.add_argument("--workspace", type=Path, default=None)
     doctor.add_argument("--json", action="store_true")
     doctor.set_defaults(func=_doctor)
+
+    calendar = sub.add_parser(
+        "calendar", help="check whether an HK or US market session is open")
+    calendar.add_argument("market", choices=("hk", "us"))
+    calendar.add_argument("--date", help="YYYY-MM-DD; defaults to today in market TZ")
+    calendar.add_argument(
+        "--session", choices=("full", "morning", "afternoon"), default="full")
+    calendar.add_argument("--quiet", action="store_true")
+    calendar.set_defaults(func=_calendar)
 
     report = sub.add_parser(
         "report", help="assemble and validate a market report from a context file")

--- a/src/clawock/trading_calendar.py
+++ b/src/clawock/trading_calendar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Trading-calendar guard for HK (HKEX) and US (NYSE/Nasdaq) markets.
 
 Why this exists: every market cron is scheduled `* * 1-5`, which only skips
@@ -31,15 +30,15 @@ Sources (authoritative, re-checked 2026-07-27):
     https://www.hkex.com.hk/-/media/HKEX-Market/Services/Circulars-and-Notices/Participant-and-Members-Circulars/SEHK/2026/MO_DT_133_26_e1.pdf
 
 CLI:
-  python3 trading_calendar.py hk            -> prints OPEN/CLOSED, exit 0/1
-  python3 trading_calendar.py us            -> prints OPEN/CLOSED, exit 0/1
-  python3 trading_calendar.py hk --session afternoon
+  clawock calendar hk                       -> prints OPEN/CLOSED, exit 0/1
+  clawock calendar us                       -> prints OPEN/CLOSED, exit 0/1
+  clawock calendar hk --session afternoon
                                             -> CLOSED on HK half-days too
-  python3 trading_calendar.py us --date 2026-06-19
+  clawock calendar us --date 2026-06-19
                                             -> check a specific date
 
 Exit code: 0 = market open (trading day), 1 = closed. So bash guards read as:
-  python3 trading_calendar.py us || exit 0   # bail on closed
+  clawock calendar us || exit 0              # bail on closed
 """
 from __future__ import annotations
 
@@ -233,7 +232,7 @@ def main(argv: list[str]) -> int:
         # Fail open: don't silently skip a real trading day past the table.
         if not a.quiet:
             print(f"OPEN (warning: {a.market} holiday table only covers "
-                  f"through {LATEST_YEAR}; extend trading_calendar.py)")
+                  f"through {LATEST_YEAR}; extend clawock.trading_calendar)")
         return 0
 
     open_ = is_trading_day(a.market, d, a.session)

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -20,7 +20,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 from clawock_kcnyu.harness import brief_preflight
-import trading_calendar
+from clawock import trading_calendar
 
 
 def test_brief_actually_calls_the_bar_fetcher():

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -390,7 +390,7 @@ def test_hhi_uses_value_weights_and_reports_top_two_concentration():
 
 
 def test_latest_completed_session_skips_holiday_weekend_before_close():
-    import trading_calendar
+    from clawock import trading_calendar
 
     before_close = datetime(
         2026, 7, 6, 15, 0, tzinfo=ZoneInfo("America/New_York")
@@ -408,7 +408,7 @@ def test_latest_completed_session_skips_holiday_weekend_before_close():
 
 
 def test_market_leg_freshness_exposes_one_frozen_holding():
-    import trading_calendar
+    from clawock import trading_calendar
 
     at = datetime(
         2026, 7, 24, 17, 0, tzinfo=ZoneInfo("America/New_York")

--- a/tests/test_code_imports_come_from_the_checkout.py
+++ b/tests/test_code_imports_come_from_the_checkout.py
@@ -2,7 +2,7 @@
 
 `workspace_root()` is overridable with CLAWOCK_WORKSPACE so the engine can run
 against someone else's book (#246). But a foreign workspace holds market data —
-snapshots, ledgers, plans — not `scripts/data/trading_calendar.py`. A module that
+snapshots, ledgers, plans — not package code such as `clawock.trading_calendar`. A module that
 puts `WS / 'scripts' / 'data'` on sys.path therefore resolves OUR code out of
 THEIR directory: it fails if the directory is absent, and silently imports
 whatever is there if it is not (#269).

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -617,6 +617,20 @@ def test_brief_repair_uses_whole_file_write_instead_of_brittle_edit():
     assert '一次已恢复的 `edit` 工具错误仍会把整个 cron 记成 error' in message
 
 
+def test_brief_uses_the_installed_calendar_command():
+    data = contract()
+    profile = data['payload_profiles']['brief']
+    brief = next(job for job in data['jobs'] if job['name'] == '盘前深度简报')
+    message = cron_contract.render_payload_message(data, brief)
+
+    for market in ('hk', 'us'):
+        command = f'/root/.local/bin/clawock calendar {market}'
+        assert command in profile['required_substrings']
+        assert command in message
+    assert 'trading_calendar.py' in profile['forbidden_substrings']
+    assert 'trading_calendar.py' not in message
+
+
 def test_intraday_slots_are_unconditional_again():
     """Every Mode 7 slot runs the turn; no pre-model condition gate.
 

--- a/tests/test_research_surface.py
+++ b/tests/test_research_surface.py
@@ -516,7 +516,7 @@ def test_both_stock_skills_frame_it_as_attribution_not_a_trigger():
 def test_calendar_coverage_is_reported_per_market():
     import sys
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
-    import trading_calendar
+    from clawock import trading_calendar
 
     coverage = trading_calendar.coverage(date(2026, 7, 26))
     assert set(coverage) == {"us", "hk"}

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -1,4 +1,4 @@
-"""Guards for the hand-maintained holiday tables in scripts/data/trading_calendar.py.
+"""Guards for the package-owned hand-maintained holiday tables.
 
 The tables cannot be generated. US observance shifts move dates around the
 weekend, and HK dates come from the gazetted general holidays plus the lunar
@@ -12,6 +12,8 @@ the direction of the failure if it ever lapses again.
 """
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
@@ -19,9 +21,25 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "data"))
 
-import trading_calendar  # noqa: E402
+from clawock import trading_calendar
+
+
+def test_calendar_implementation_and_cli_ship_in_the_product():
+    assert Path(trading_calendar.__file__).relative_to(ROOT).as_posix() == (
+        "src/clawock/trading_calendar.py"
+    )
+    assert not (ROOT / "scripts" / "data" / "trading_calendar.py").exists()
+    result = subprocess.run(
+        [sys.executable, "-m", "clawock", "calendar", "us", "--date", "2026-06-19"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+    )
+    assert result.returncode == 1
+    assert result.stdout.strip() == "CLOSED (US 2026-06-19)"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_us_quote_staleness.py
+++ b/tests/test_us_quote_staleness.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.join(WS, "scripts", "data"))
 
 import fetch_us_stocks as F  # noqa: E402
 import preflight_integrity as pi  # noqa: E402
-import trading_calendar as tc  # noqa: E402
+from clawock import trading_calendar as tc  # noqa: E402
 
 
 # ── 1. the parser must not invent fields the payload does not have ───────────


### PR DESCRIPTION
## Summary

- move the reusable HK/US trading-session calendar from `scripts/data/` into the published `clawock` package
- expose it as the stable `clawock calendar` command and switch the live brief payload away from a repository source path
- update every core, KCNyu adapter, operational, and test consumer to import the package module
- ratchet wheel ownership, cron payload semantics, and coverage accounting

## Why

The market calendar is generic decision-workflow infrastructure. Keeping it under the KCNyu repository script surface made ordinary reuse depend on a private live-desk layout. The package should own the mechanism; the KCNyu adapter should only consume it.

## Verification

- `CLAWOCK_DELIVERY_DISABLED=1 python3 -m pytest tests/ -q` — 1697 passed, 10 skipped, 4 xfailed
- CI-equivalent coverage — total 65.0% (10863/16723), settlement core 78.7% (4082/5188)
- targeted calendar/cron/wheel/harness tests — 270 passed, 1 xfailed

Part of #381.
