### PR TITLE
Package the brief context protocol

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -184,6 +184,8 @@ jobs:
           python3 -m pytest tests/ -q \
             --cov=scripts \
             --cov=clawock.bar_checks \
+            --cov=clawock.brief_context \
+            --cov=clawock.brief_decision_packet \
             --cov=clawock.instrument_registry \
             --cov=clawock.json_repair \
             --cov=clawock.safe_io \

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -64,19 +64,20 @@ move is complete: `instrument_registry` now ships as
 `src/clawock/instrument_registry.py`; configured instruments remain workspace
 data and are not bundled in the wheel. The dependency-free `bar_checks`,
 `json_repair`, `safe_io`, and `trading_calendar` utilities have also moved into
-`src/clawock/`.
+`src/clawock/`. The generation-bound brief context and typed decision packet now
+ship there too; tools never import executable Python from a user's workspace.
 
 ### Product — the engine
 
 | Area | Modules |
 |---|---|
-| Ledger + decision contract | `decision_v2` `brief_decision_packet` `brief_context` `plan_surface` `mark_followed` `audit_resettle` |
+| Ledger + decision contract | `decision_v2` `plan_surface` `mark_followed` `audit_resettle` |
 | Money integrity | `recompute_aggregates` `recompute_cash` `recompute_realized` `snapshot_realized` `shadow_portfolio` |
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` |
 | Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` |
-| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
+| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.brief_context` `clawock.brief_decision_packet` `clawock.decision_contract` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
 | Gates + outputs | `preflight_integrity` `validate_sidecars` `dashboard_outputs` `build_dashboard` `workflow_outcomes` `workflow_health` `coverage_badge` `cron_contract` `cron_heartbeat` |
 
 ### Instance — kcn's desk

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 from clawock import trading_calendar
+from clawock import brief_context, brief_decision_packet
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
@@ -40,8 +41,6 @@ sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
-import brief_context  # noqa: E402
-import brief_decision_packet  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.
 # The canonical keys preserve the existing missing-section issue text.  The aliases

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -40,6 +40,7 @@ from zoneinfo import ZoneInfo
 
 from clawock.workspace import workspace_root
 from clawock import trading_calendar
+from clawock import brief_context, brief_decision_packet
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
@@ -53,8 +54,6 @@ import research_surface  # noqa: E402
 import peer_scan  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
-import brief_context  # noqa: E402
-import brief_decision_packet  # noqa: E402
 from clawock.instrument_registry import get as get_instrument  # noqa: E402
 from clawock.instrument_registry import compute_lookthrough_exposure  # noqa: E402
 from clawock.instrument_registry import one_x_swap_map  # noqa: E402

--- a/scripts/data/decision_v2.py
+++ b/scripts/data/decision_v2.py
@@ -35,6 +35,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock import trading_calendar as _cal  # noqa: E402
+from clawock.decision_contract import (  # noqa: E402
+    ACTIVE_ACTIONS,
+    ADD_ACTIONS,
+    PASSIVE_ACTIONS,
+    SELL_ACTIONS,
+)
 from clawock.workspace import workspace_root  # noqa: E402
 
 WS = workspace_root(Path(__file__).resolve().parents[2])
@@ -61,14 +67,6 @@ STRATEGIES = {
     "core_position", "risk_rebalance", "intraday_t", "event_trade",
     "tactical_entry", "legacy_unknown",
 }
-ACTIVE_ACTIONS = {"cut", "trim_on_rebound", "t_only", "add_only_on_trigger", "add_on_breakout"}
-SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
-# `watch` is a standing stance, not a directional call — it is graded passively
-# (stance_at_open) exactly like hold_and_watch. This is the one place the active/
-# passive split is defined; every surface (dashboard, rick_broadcast) must read it
-# from here so the two can never disagree on what "active" means.
-PASSIVE_ACTIONS = {"hold_and_watch", "watch"}
-ADD_ACTIONS = ACTIVE_ACTIONS - SELL_ACTIONS
 AUDIT_SCHEMA_VERSION = 1
 
 # How long after plan_date an execution verdict is allowed to still be pending.

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -55,7 +55,7 @@ clawock brief preflight
 ### Step 2: 只读 decision packet summary（唯一常驻输入）
 
 ```bash
-PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet_summary \
+/root/.local/bin/clawock tool decision_packet_summary \
   --workspace /root/.openclaw/workspace \
   --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
 ```
@@ -65,7 +65,7 @@ summary 包含 book/concentration、每票 deterministic status、技术/因子�
 需要分析某票时才查该票；需要单一维度时必须带 `--section`：
 
 ```bash
-PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet_query \
+/root/.local/bin/clawock tool decision_packet_query \
   --workspace /root/.openclaw/workspace \
   --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
   --arg ticker=00100 --arg section=technical
@@ -73,7 +73,7 @@ PYTHONPATH=/root/.openclaw/workspace python3 -m clawock.cli tool decision_packet
 
 可选 section：`facts|technical|quant|sentiment|evidence|risk|constraints`。一次查询硬上限 24 KiB，并同时校验 manifest hash 与 generation。正常分析禁止 `cat brief-context-{date}.json`，也禁止为了省一次查询而整份读 core/research/market bundle。
 
-> **为什么走 `clawock.cli tool` 而不是直接调 `scripts/data/brief_decision_packet.py`**：工具注册表是这套上下文协议唯一机器可读的定义（`clawock.cli tool --list` 直接吐 JSON schema），而 24 KiB 预算是在注册表里强制的 —— 真正读 context 的调用方就是本 skill，绕过注册表等于绕过预算（#266）。`PYTHONPATH=` 前缀是必需的：`clawock` 尚未 pip 安装，没有它则只在 cwd 恰好是 workspace 时才能跑。输出与旧命令逐 section JSON 等价，含 `_meta.generation_id` 代次钉扎。
+> **为什么走 `clawock tool`**：工具注册表是这套上下文协议唯一机器可读的定义（`clawock tool --list` 直接吐 JSON schema），而 24 KiB 预算是在注册表里强制的。协议实现随 `clawock` wheel 安装；workspace 只提供本次生成的数据，不再提供可执行 Python 源码。输出含 `_meta.generation_id` 代次钉扎。
 
 ### Step 2.5: 按消费者 lazy-load bundles
 
@@ -81,15 +81,15 @@ bundle 是审计深钻，不是默认模型输入。只有 packet 没有提供�
 
 ```bash
 # 风险情景 / 解套数学使用前
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle risk_detail
+/root/.local/bin/clawock tool context_bundle --workspace /root/.openclaw/workspace --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --arg bundle=risk_detail
 # EDGAR / 同行明细确需原始研究记录时
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle research
+/root/.local/bin/clawock tool context_bundle --workspace /root/.openclaw/workspace --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --arg bundle=research
 # 需要查看事件图完整 provenance 时（action 权限仍以 packet constraints 为准）
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle evidence
+/root/.local/bin/clawock tool context_bundle --workspace /root/.openclaw/workspace --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --arg bundle=evidence
 # 需要市场级而非 per-ticker 的宏观/名人记录时
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle market
+/root/.local/bin/clawock tool context_bundle --workspace /root/.openclaw/workspace --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --arg bundle=market
 # Retrospective / Decision v2 校准段使用前
-python3 /root/.openclaw/workspace/scripts/data/brief_context.py --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --bundle calibration
+/root/.local/bin/clawock tool context_bundle --workspace /root/.openclaw/workspace --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json --arg bundle=calibration
 ```
 
 bundle 路由：
@@ -694,9 +694,9 @@ postflight 严格 schema 校验：
 先生成模板，再只回填观点字段：
 
 ```bash
-python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py \
-  --manifest /root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json \
-  --judgment-template
+/root/.local/bin/clawock tool decision_packet_judgment_template \
+  --workspace /root/.openclaw/workspace \
+  --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
 ```
 
 schema 只允许顶层 `schema_version/context_generation_id/portfolio_assessment/portfolio_counterargument/ticker_judgments`；每票只允许：

--- a/src/clawock/brief_context.py
+++ b/src/clawock/brief_context.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Budgeted, generation-bound context artifacts for the daily deep brief.
 
 The complete preflight context remains the audit record. The model-facing

--- a/src/clawock/brief_decision_packet.py
+++ b/src/clawock/brief_decision_packet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Typed, queryable decision boundary for the daily deep brief.
 
 The expensive producers remain authoritative for prices, technical indicators,
@@ -16,13 +15,9 @@ import hashlib
 import json
 import math
 import os
-import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-# Canonical owner of the active/passive action split; duplicating those sets here
-# would let the evidence gate drift onto the wrong one.
-import decision_v2  # noqa: E402
+from clawock.decision_contract import ACTIVE_ACTIONS
 
 
 SCHEMA_VERSION = 1
@@ -561,7 +556,7 @@ def _catalyst_evidence_issues(tag: str, decision: dict, row: dict) -> list[str]:
     """
     evidence_id = decision.get("evidence_event_id")
     action = decision.get("action")
-    if action in decision_v2.ACTIVE_ACTIONS:
+    if action in ACTIVE_ACTIONS:
         if evidence_id not in ((row.get("constraints") or {}).get("actionable_evidence_ids") or []):
             return [f"{tag}: evidence_event_id is outside harness evidence gate"]
         return []

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -237,7 +237,7 @@ def _tool(args) -> int:
 
     This is what makes the tool layer real (#266). Before it, `clawock.tools` had
     no caller outside its own tests: the skills reached the same data by running
-    `python3 .../scripts/data/brief_decision_packet.py`, so the registry was an
+    a source-checkout script, so the registry was an
     executable design document and the per-query byte budget — the hole #258
     actually closed — protected a path nobody took, because the callers that read
     context ARE the skills.

--- a/src/clawock/decision_contract.py
+++ b/src/clawock/decision_contract.py
@@ -1,0 +1,8 @@
+"""Runtime-neutral vocabulary shared by decision workflow components."""
+
+ACTIVE_ACTIONS = {
+    "cut", "trim_on_rebound", "t_only", "add_only_on_trigger", "add_on_breakout",
+}
+SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
+ADD_ACTIONS = ACTIVE_ACTIONS - SELL_ACTIONS
+PASSIVE_ACTIONS = {"hold_and_watch", "watch"}

--- a/src/clawock/tools/__init__.py
+++ b/src/clawock/tools/__init__.py
@@ -3,8 +3,9 @@
 `skills/daily-deep-brief/SKILL.md` drives a genuinely good lazy-load protocol —
 generation-pinned manifest, typed decision packet, per-section queries, hash
 validation, a hard per-query byte budget. The protocol is not the problem. The
-problem is how the model reaches it: markdown telling it to run
-`python3 /root/.openclaw/workspace/scripts/data/brief_decision_packet.py …`.
+problem was how the model reached it: markdown told it to run a Python file from
+the KCNyu source checkout. The implementation and the tool schema now both ship
+in the wheel.
 
 That makes the skill the only machine-unreadable copy of the interface, forces
 the cron payload to know internal file layout, and leaves any non-OpenClaw

--- a/src/clawock/tools/context_tools.py
+++ b/src/clawock/tools/context_tools.py
@@ -1,45 +1,17 @@
-"""The four capabilities the brief skill already drives, given a schema.
+"""Package-owned context capabilities exposed to external agent runtimes.
 
-Each one delegates to the code that implements it today — `read_packet`,
-`summary_view`, `bounded_payload` in `brief_decision_packet.py`. Nothing here
-reimplements the protocol; it exposes it. That is deliberate: the generation
-pin, the hash check and the per-query byte budget are load-bearing and already
-tested, and a second copy of them would be a second thing to get wrong.
-
-The workspace is passed in rather than resolved from `__file__`, because these
-tools have to work against a foreign workspace — that is the whole point.
+The protocol implementation ships in ``clawock``. The workspace argument points
+only at user artifacts and data; it is never searched for executable Python.
 """
 from __future__ import annotations
 
-import importlib.util
-import json
-import sys
 from pathlib import Path
 
+from clawock import brief_context, brief_decision_packet
 from clawock.tools import BaseTool, ToolError
 
 SECTIONS = ("facts", "technical", "quant", "sentiment", "evidence", "risk",
             "constraints")
-
-
-def _load(workspace, module: str):
-    """Import a workspace's own data module.
-
-    Not a subprocess, and not a copy: these tools read *that workspace's*
-    protocol, so importing that workspace's implementation is the honest
-    resolution. A wheel installed elsewhere still works — it just needs a
-    workspace to point at, exactly like `portfolio.json`.
-    """
-    path = Path(workspace) / "scripts" / "data" / f"{module}.py"
-    if not path.exists():
-        raise ToolError(f"{module}.py not found in workspace {workspace}")
-    data_dir = str(path.parent)
-    if data_dir not in sys.path:
-        sys.path.insert(0, data_dir)
-    spec = importlib.util.spec_from_file_location(module, path)
-    loaded = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(loaded)
-    return loaded
 
 
 def _manifest(workspace, manifest) -> Path:
@@ -51,14 +23,7 @@ def _manifest(workspace, manifest) -> Path:
     return path
 
 
-class _PacketTool(BaseTool):
-    @classmethod
-    def check_available(cls, workspace) -> bool:
-        return (Path(workspace) / "scripts" / "data"
-                / "brief_decision_packet.py").exists()
-
-
-class DecisionPacketSummary(_PacketTool):
+class DecisionPacketSummary(BaseTool):
     name = "decision_packet_summary"
     description = (
         "The brief's resident input: book and concentration, per-ticker "
@@ -78,12 +43,13 @@ class DecisionPacketSummary(_PacketTool):
     }
 
     def execute(self, workspace, *, manifest: str) -> str:
-        packet_module = _load(workspace, "brief_decision_packet")
-        packet = packet_module.read_packet(_manifest(workspace, manifest))
-        return packet_module.bounded_payload(packet_module.summary_view(packet))
+        packet = brief_decision_packet.read_packet(_manifest(workspace, manifest))
+        return brief_decision_packet.bounded_payload(
+            brief_decision_packet.summary_view(packet)
+        )
 
 
-class DecisionPacketQuery(_PacketTool):
+class DecisionPacketQuery(BaseTool):
     name = "decision_packet_query"
     description = (
         "One ticker's slice of the decision packet, optionally narrowed to a "
@@ -107,8 +73,7 @@ class DecisionPacketQuery(_PacketTool):
         if section is not None and section not in SECTIONS:
             raise ToolError(
                 f"unknown section {section!r}; expected one of {', '.join(SECTIONS)}")
-        packet_module = _load(workspace, "brief_decision_packet")
-        packet = packet_module.read_packet(_manifest(workspace, manifest))
+        packet = brief_decision_packet.read_packet(_manifest(workspace, manifest))
         value = (packet.get("tickers") or {}).get(str(ticker))
         if value is None:
             raise ToolError(f"unknown ticker: {ticker}")
@@ -125,7 +90,29 @@ class DecisionPacketQuery(_PacketTool):
         }
         # The budget is applied here, not on a print path — that is the bug this
         # layer exists to close: every non-CLI caller used to bypass the cap.
-        return packet_module.bounded_payload(payload)
+        return brief_decision_packet.bounded_payload(payload)
+
+
+class DecisionPacketJudgmentTemplate(BaseTool):
+    name = "decision_packet_judgment_template"
+    description = (
+        "A generation-pinned template containing only the judgment fields the "
+        "external agent may fill."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "manifest": {"type": "string",
+                         "description": "Path to the generation's manifest.json."},
+        },
+        "required": ["manifest"],
+    }
+
+    def execute(self, workspace, *, manifest: str) -> str:
+        packet = brief_decision_packet.read_packet(_manifest(workspace, manifest))
+        return brief_decision_packet.bounded_payload(
+            brief_decision_packet.judgment_template(packet)
+        )
 
 
 class ContextBundle(BaseTool):
@@ -146,23 +133,8 @@ class ContextBundle(BaseTool):
         "required": ["manifest", "bundle"],
     }
 
-    @classmethod
-    def check_available(cls, workspace) -> bool:
-        return (Path(workspace) / "scripts" / "data" / "brief_context.py").exists()
-
     def execute(self, workspace, *, manifest: str, bundle: str) -> str:
-        path = _manifest(workspace, manifest)
-        entry = ((json.loads(path.read_text(encoding="utf-8")).get("artifacts") or {})
-                 .get(bundle))
-        if not entry:
-            available = sorted(
-                (json.loads(path.read_text(encoding="utf-8")).get("artifacts") or {}))
-            raise ToolError(
-                f"unknown bundle {bundle!r}; manifest lists: {', '.join(available)}")
-        target = Path(entry.get("path") or "")
-        if not target.exists():
-            raise ToolError(f"bundle {bundle!r} is listed but missing: {target}")
-        return target.read_text(encoding="utf-8")
+        return brief_context.read_artifact(_manifest(workspace, manifest), bundle)
 
 
 class ReportContext(BaseTool):
@@ -194,4 +166,10 @@ class ReportContext(BaseTool):
         return path.read_text(encoding="utf-8")
 
 
-TOOLS = (DecisionPacketSummary, DecisionPacketQuery, ContextBundle, ReportContext)
+TOOLS = (
+    DecisionPacketSummary,
+    DecisionPacketQuery,
+    DecisionPacketJudgmentTemplate,
+    ContextBundle,
+    ReportContext,
+)

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -11,8 +11,24 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
 
-import brief_context  # noqa: E402
+from clawock import brief_context
 from clawock_kcnyu.harness import brief_postflight  # noqa: E402
+
+
+def test_context_protocol_implementation_is_owned_by_the_product():
+    from clawock import brief_decision_packet
+
+    assert {
+        Path(module.__file__).relative_to(ROOT).as_posix()
+        for module in (brief_context, brief_decision_packet)
+    } == {
+        "src/clawock/brief_context.py",
+        "src/clawock/brief_decision_packet.py",
+    }
+    assert not any(
+        (ROOT / "scripts" / "data" / name).exists()
+        for name in ("brief_context.py", "brief_decision_packet.py")
+    )
 
 
 def _fixture():

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -9,8 +9,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
 
-import brief_context  # noqa: E402
-import brief_decision_packet as packet_mod  # noqa: E402
+from clawock import brief_context
+from clawock import brief_decision_packet as packet_mod
 
 
 def _context():
@@ -309,9 +309,9 @@ def test_pages_prefers_projection_and_keeps_a_backward_fallback():
     # JavaScript's literal "undefined" in the 综合 column.
     assert "${v.label}" in renderer
     assert "${v.txt}" not in renderer
-    # The summary read moved behind the tool registry (#266); it is the same read,
-    # reached by name instead of by a path into scripts/. --judgment-template has
-    # no tool yet, so it is still a shell-out.
+    # Both reads go through package-owned tool contracts; neither requires a
+    # Python source file in the KCNyu workspace.
     assert "decision_packet_summary" in skill
-    assert "--judgment-template" in skill
+    assert "decision_packet_judgment_template" in skill
+    assert "scripts/data/brief_decision_packet.py" not in skill
     assert "禁止加入价格、RSI、MA" in skill

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -5,7 +5,7 @@
 2. The per-query byte budget bypassed. It used to live only on the CLI print
    path, so every non-CLI caller silently skipped it; that is the bug this layer
    exists to close.
-3. A missing dependency exploding instead of excluding the tool.
+3. A package-owned tool disappearing just because a workspace has no source tree.
 """
 import inspect
 import json
@@ -53,19 +53,17 @@ def test_the_query_budget_is_enforced_through_the_tool(tmp_path, monkeypatch):
     """The cap lived only in the CLI's print path. Any caller using
     read_packet()/summary_view() directly — i.e. every non-CLI consumer —
     bypassed it."""
-    packet_module = type(sys)("brief_decision_packet")
-    packet_module.MAX_QUERY_BYTES = 24 * 1024
-
     def bounded_payload(value):
         text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
-        if len(text.encode()) > packet_module.MAX_QUERY_BYTES:
+        if len(text.encode()) > 24 * 1024:
             raise ValueError("decision packet query exceeds")
         return text
 
-    packet_module.bounded_payload = bounded_payload
-    packet_module.read_packet = lambda path: {
+    monkeypatch.setattr(context_tools.brief_decision_packet,
+                        "bounded_payload", bounded_payload)
+    monkeypatch.setattr(context_tools.brief_decision_packet, "read_packet", lambda path: {
         "tickers": {"00100": {"technical": {"blob": "x" * 40_000}}}}
-    monkeypatch.setattr(context_tools, "_load", lambda ws, mod: packet_module)
+    )
 
     manifest = tmp_path / "manifest.json"
     manifest.write_text("{}")
@@ -76,14 +74,46 @@ def test_the_query_budget_is_enforced_through_the_tool(tmp_path, monkeypatch):
                      section="technical")
 
 
-def test_a_tool_whose_dependency_is_missing_is_excluded_not_raised(tmp_path):
-    """`check_available` is the difference between a shorter tool list and a
-    traceback in the middle of a model turn."""
-    registry = build_registry(tmp_path)          # empty dir: no scripts/, no memory/
+def test_package_tools_exist_without_python_source_in_the_workspace(tmp_path):
+    """A wheel supplies behavior; a user's workspace supplies only artifacts."""
+    registry = build_registry(tmp_path)  # empty dir: no scripts/, no memory/
 
-    assert registry.names() == []
-    with pytest.raises(ToolError, match="unknown tool"):
+    assert registry.names() == [
+        "context_bundle",
+        "decision_packet_judgment_template",
+        "decision_packet_query",
+        "decision_packet_summary",
+    ]
+    with pytest.raises(ToolError, match="manifest not found"):
         registry.call("decision_packet_summary", manifest="x")
+
+
+def test_package_tools_read_a_real_generation_without_workspace_code(tmp_path):
+    source = {"date": "2026-08-08", "quant_signals": {"signal": "verified"}}
+    generation_id = context_tools.brief_context.compute_generation_id(source)
+    packet = {
+        "_meta": {"schema_version": 1, "kind": "brief_decision_packet",
+                  "generation_id": generation_id},
+        "tickers": {"TEST": {}},
+    }
+    _, manifest = context_tools.brief_context.write_run_bundle(
+        source,
+        tmp_path / "brief-context.json",
+        tool_artifacts={"decision_packet": packet},
+    )
+    registry = build_registry(tmp_path)
+
+    bundle = json.loads(registry.call(
+        "context_bundle", manifest=manifest["manifest_path"], bundle="research"
+    ))
+    template = json.loads(registry.call(
+        "decision_packet_judgment_template", manifest=manifest["manifest_path"]
+    ))
+
+    assert bundle["_meta"]["generation_id"] == generation_id
+    assert bundle["quant_signals"] == {"signal": "verified"}
+    assert template["context_generation_id"] == generation_id
+    assert template["ticker_judgments"][0]["ticker"] == "TEST"
 
 
 def test_schemas_render_for_both_dialects():
@@ -111,23 +141,18 @@ def test_the_cli_consumer_refuses_an_over_budget_query_instead_of_crashing(
     """
     from clawock import cli
 
-    packet_module = type(sys)("brief_decision_packet")
-    packet_module.MAX_QUERY_BYTES = 24 * 1024
-
     def bounded_payload(value):
         text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
-        if len(text.encode()) > packet_module.MAX_QUERY_BYTES:
+        if len(text.encode()) > 24 * 1024:
             raise ValueError("decision packet query exceeds")
         return text
 
-    packet_module.bounded_payload = bounded_payload
-    packet_module.read_packet = lambda path: {
+    monkeypatch.setattr(context_tools.brief_decision_packet,
+                        "bounded_payload", bounded_payload)
+    monkeypatch.setattr(context_tools.brief_decision_packet, "read_packet", lambda path: {
         "_meta": {"generation_id": "gen"},
         "tickers": {"00100": {"technical": {"blob": "x" * 40_000}}}}
-    monkeypatch.setattr(context_tools, "_load", lambda ws, mod: packet_module)
-    monkeypatch.setattr(
-        context_tools.DecisionPacketQuery, "check_available",
-        classmethod(lambda cls, ws: True))
+    )
 
     manifest = tmp_path / "manifest.json"
     manifest.write_text("{}")
@@ -151,12 +176,15 @@ def test_a_narrowed_query_keeps_the_generation_pin(tmp_path, monkeypatch):
     here; the tool dropped it, so every narrowed query through the registry was
     silently un-pinned — invisible until a real consumer compared the two.
     """
-    packet_module = type(sys)("brief_decision_packet")
-    packet_module.bounded_payload = lambda value: json.dumps(value)
-    packet_module.read_packet = lambda path: {
+    monkeypatch.setattr(
+        context_tools.brief_decision_packet,
+        "bounded_payload",
+        lambda value: json.dumps(value),
+    )
+    monkeypatch.setattr(context_tools.brief_decision_packet, "read_packet", lambda path: {
         "_meta": {"generation_id": "gen-abc"},
         "tickers": {"00100": {"technical": {"tag": "trend-off"}}}}
-    monkeypatch.setattr(context_tools, "_load", lambda ws, mod: packet_module)
+    )
 
     manifest = tmp_path / "manifest.json"
     manifest.write_text("{}")


### PR DESCRIPTION
## Summary

- move generation-bound brief context and typed decision packet implementations into the published `clawock` package
- remove tool-layer dynamic imports of Python source from the user's workspace
- add a package-owned judgment-template tool and route all daily brief context reads through the installed CLI
- centralize the active/passive decision vocabulary in a runtime-neutral product module
- keep KCNyu preflight/postflight as consumers of the package protocol

## Why

These generation, budget, query, and decision-boundary rules are reusable product behavior. A foreign workspace should contain user data and artifacts, not a private copy of KCNyu's Python source. The previous dynamic loader made the apparently portable tool registry depend on `scripts/data` being present in the workspace.

## Verification

- `CLAWOCK_DELIVERY_DISABLED=1 python3 -m pytest tests/ -q` — 1699 passed, 10 skipped, 4 xfailed
- CI-equivalent coverage — total 65.0% (10862/16718), settlement core 78.7% (4079/5185)
- isolated wheel install in a source-free temporary workspace successfully read a generation bundle and emitted a generation-pinned judgment template
- wheel listing contains `clawock.brief_context`, `clawock.brief_decision_packet`, and `clawock.decision_contract`, with no `scripts/` entries

Part of #379 and #381.
