### PR TITLE
Package the decision ledger engine

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -186,6 +186,7 @@ jobs:
             --cov=clawock.bar_checks \
             --cov=clawock.brief_context \
             --cov=clawock.brief_decision_packet \
+            --cov=clawock.decision_v2 \
             --cov=clawock.instrument_registry \
             --cov=clawock.json_repair \
             --cov=clawock.safe_io \

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -286,9 +286,8 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         run: |
           python3 << 'PY'
-          import json, glob, sys
-          sys.path.insert(0, 'scripts/data')
-          import decision_v2
+          import json, glob
+          from clawock import decision_v2
           for p in sorted(glob.glob('memory/*-plan.json')):
               with open(p) as f: d = json.load(f)
               errors = decision_v2.validate_plan(d, p)
@@ -301,9 +300,8 @@ jobs:
         run: |
           python3 -m unittest discover -s tests -p 'test_decision_v2.py' -v
           python3 << 'PY'
-          import json, glob, sys
-          sys.path.insert(0, 'scripts/data')
-          import decision_v2
+          import json, glob
+          from clawock import decision_v2
           led = decision_v2.load_decisions()
           ids = [d['decision_id'] for d in led]
           dupes = len(ids) - len(set(ids))

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -66,18 +66,20 @@ data and are not bundled in the wheel. The dependency-free `bar_checks`,
 `json_repair`, `safe_io`, and `trading_calendar` utilities have also moved into
 `src/clawock/`. The generation-bound brief context and typed decision packet now
 ship there too; tools never import executable Python from a user's workspace.
+The v2 decision ledger and settlement engine is now `clawock.decision_v2`; its
+default data root is the caller's workspace, never the package installation path.
 
 ### Product — the engine
 
 | Area | Modules |
 |---|---|
-| Ledger + decision contract | `decision_v2` `plan_surface` `mark_followed` `audit_resettle` |
+| Ledger + decision contract | `plan_surface` `mark_followed` `audit_resettle` |
 | Money integrity | `recompute_aggregates` `recompute_cash` `recompute_realized` `snapshot_realized` `shadow_portfolio` |
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` |
 | Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` |
-| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.brief_context` `clawock.brief_decision_packet` `clawock.decision_contract` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
+| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.brief_context` `clawock.brief_decision_packet` `clawock.decision_contract` `clawock.decision_v2` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
 | Gates + outputs | `preflight_integrity` `validate_sidecars` `dashboard_outputs` `build_dashboard` `workflow_outcomes` `workflow_health` `coverage_badge` `cron_contract` `cron_heartbeat` |
 
 ### Instance — kcn's desk

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -32,13 +32,12 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 from clawock import trading_calendar
-from clawock import brief_context, brief_decision_packet
+from clawock import brief_context, brief_decision_packet, decision_v2
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import decision_v2  # noqa: E402
 import workflow_outcomes  # noqa: E402
 import risk_discipline  # noqa: E402
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -40,7 +40,7 @@ from zoneinfo import ZoneInfo
 
 from clawock.workspace import workspace_root
 from clawock import trading_calendar
-from clawock import brief_context, brief_decision_packet
+from clawock import brief_context, brief_decision_packet, decision_v2
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
@@ -48,7 +48,6 @@ TMP_DIR = WS / 'memory' / '.tmp'
 SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 
 sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
-import decision_v2  # noqa: E402
 import thesis_registry  # noqa: E402
 import research_surface  # noqa: E402
 import peer_scan  # noqa: E402

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -163,7 +163,7 @@ def check_plan_json_schema(r):
         return
     bad = []
     sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
-    import decision_v2
+    from clawock import decision_v2
     for p in plans:
         try:
             d = json.loads(open(p).read())
@@ -425,7 +425,7 @@ def check_decision_ledger(r):
         return
     try:
         sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
-        import decision_v2
+        from clawock import decision_v2
         rows = decision_v2.load_decisions(p)
     except Exception as e:
         r.add('decisions.jsonl', CRITICAL, f'parse fail: {e}')

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -112,7 +112,7 @@ clawock 是**美股 + 港股 + 黄金定投**的实盘组合。工具包遵循�
 | `backtest_us_leverage.py` | 美股 2x ETF regime 回测 | 日线模拟 | ✅ |
 | `backtest_combined_regime.py` | 全组合 regime vs buy&hold vs 全 1x（MA/vol 在各代理**原生交易日**上算，不用 union 日历填充值） | 因子代理历史 | ✅ |
 | `validate_regime_dial.py` | 杠杆刻度盘样本外验证：walk-forward + 环形位移置换检验 + 阈值敏感面；建模的是**生产 tier 映射**(1.0/0.5/0.0)而非 2x→cash | 腾讯 kline | ✅ |
-| `decision_v2.py` | strategy episode 结算、coverage、严格前向分层 confidence 校准、方向命中审计 | decisions ledger + canonical bars | ✅ |
+| `src/clawock/decision_v2.py` | 安装包拥有的 strategy episode 结算、coverage、严格前向分层 confidence 校准、方向命中审计 | workspace decisions ledger + canonical bars | ✅ |
 | `risk_discipline.py` | 持久 breach 账本、确认/限时 override、成交证据与同风险增仓冻结 | guardrail + portfolio trades | ✅ |
 | `quant_signal_review.py` · `t0_setup_review.py` | 因子 / 牌面 edge 自检(T+1/T+5 命中率) | 本地留痕 | ✅ |
 | `cross_sectional_factor.py` | 预注册 walk-forward + date×ticker 双向聚类 CI；存活偏差未消除即禁止入决策 | 本地留痕 + 调整后日线 | ✅ |

--- a/scripts/data/audit_resettle.py
+++ b/scripts/data/audit_resettle.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 import argparse
 import copy
 import json
-import os
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import decision_v2 as dv2  # noqa: E402
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from clawock import decision_v2 as dv2  # noqa: E402
 
 
 def snap(decisions: list[dict]) -> dict:

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -23,7 +23,6 @@ from typing import NamedTuple
 from zoneinfo import ZoneInfo
 
 import dashboard_outputs
-import decision_v2
 
 # Strict YYYY-MM-DD.json — rejects baselines/backups/archives that share the
 # snapshots dir (e.g. 2026-05-16-saturday-baseline.json caused duplicate 5-16
@@ -43,6 +42,7 @@ sys.path.insert(0, str(CHECKOUT_ROOT / "instances" / "kcnyu" / "src"))
 from clawock.workspace import workspace_root  # noqa: E402
 from clawock import instrument_registry  # noqa: E402
 from clawock import json_repair  # noqa: E402
+from clawock import decision_v2  # noqa: E402
 
 WS_ROOT = workspace_root(Path(__file__).resolve().parent.parent.parent)
 OUT_DIR = WS_ROOT / 'assets' / 'data'

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -39,7 +39,7 @@ ROOT = workspace_root(Path(__file__).resolve().parents[2])
 # Paths are repo-relative and must all be present in the report — see
 # _core_summary() for why a missing one is an error rather than a skip.
 CORE_MODULES = (
-    'scripts/data/decision_v2.py',
+    'src/clawock/decision_v2.py',
     'scripts/data/entry_gate.py',
     'scripts/data/thesis_registry.py',
     'scripts/data/earnings_review.py',

--- a/scripts/data/gh_action_brief_fallback.py
+++ b/scripts/data/gh_action_brief_fallback.py
@@ -17,8 +17,10 @@ from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from xiaomi_llm import chat
-import decision_v2
+from clawock import decision_v2  # noqa: E402
 
 
 def split_brief_and_plan(out):

--- a/scripts/data/gh_action_weekly_review.py
+++ b/scripts/data/gh_action_weekly_review.py
@@ -17,8 +17,10 @@ from datetime import date, timedelta
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from xiaomi_llm import chat
-import decision_v2
+from clawock import decision_v2  # noqa: E402
 
 
 def _load_json(path, kind, errors):

--- a/scripts/data/mark_followed.py
+++ b/scripts/data/mark_followed.py
@@ -9,8 +9,9 @@ import argparse
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import decision_v2
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from clawock import decision_v2
 
 
 def main():

--- a/scripts/data/rick_broadcast.py
+++ b/scripts/data/rick_broadcast.py
@@ -16,10 +16,14 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CHECKOUT = Path(__file__).resolve().parents[2]
+ROOT = str(_CHECKOUT)
 sys.path.insert(0, os.path.join(ROOT, "scripts", "data"))
-import decision_v2
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+from clawock import decision_v2  # noqa: E402
 QUANT = os.path.join(ROOT, "assets", "data", "quant_signal_review.json")
 T0 = os.path.join(ROOT, "assets", "data", "t0_setup_review.json")
 REPO = "github.com/KCNyu/clawock"

--- a/scripts/data/shadow_portfolio.py
+++ b/scripts/data/shadow_portfolio.py
@@ -28,7 +28,7 @@ from zoneinfo import ZoneInfo
 import sys  # noqa: E402
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-import decision_v2  # noqa: E402
+from clawock import decision_v2  # noqa: E402
 from clawock import trading_calendar  # noqa: E402
 from clawock.workspace import workspace_root  # noqa: E402
 

--- a/src/clawock/decision_v2.py
+++ b/src/clawock/decision_v2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """clawock decision ledger v2.
 
 The legacy scorecard treated every plan row as an independent prediction and
@@ -23,27 +22,23 @@ import os
 import random
 import re
 import statistics
-import sys
 import tempfile
 from collections import Counter, defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
-# The checkout root, so `clawock` resolves from the tree this file ships
-# in. Reached through the scripts/data/workspace shim until #267 step 3,
-# whose only remaining job was inserting this path as a side effect.
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from clawock import trading_calendar as _cal  # noqa: E402
-from clawock.decision_contract import (  # noqa: E402
+from clawock import trading_calendar as _cal
+from clawock.decision_contract import (
     ACTIVE_ACTIONS,
     ADD_ACTIONS,
     PASSIVE_ACTIONS,
     SELL_ACTIONS,
 )
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.workspace import workspace_root
 
-WS = workspace_root(Path(__file__).resolve().parents[2])
+# Installed package code resolves user state from the caller's workspace, never
+# from site-packages or a source checkout path.
+WS = workspace_root(Path.cwd())
 LEDGER = WS / "memory" / "decisions.jsonl"
 SNAP_DIR = WS / "memory" / "snapshots"
 
@@ -457,7 +452,7 @@ def _price(snapshot: dict | None, ticker: str, field: str = "current_price"):
 # (00100 2026-05-18 read 744.5 against a real 827.5, dropping a winner).
 #
 # `memory/bars/` is session-dated, unadjusted, and never contains an unfinished
-# session. See scripts/data/fetch_daily_bars.py for the store's contract.
+# session. The workspace bar writer owns the store's refresh contract.
 # ---------------------------------------------------------------------------
 
 BARS_DIR = WS / "memory" / "bars"

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -123,7 +123,7 @@ def test_retirement_is_declared_never_inferred(tmp_path, monkeypatch):
     `instrument_inactive` and drop out of the denominator with nothing reported. Only
     a declaration in fetch_daily_bars' MANIFEST may say an instrument is retired.
     """
-    import decision_v2
+    from clawock import decision_v2
 
     d = tmp_path / 'memory' / 'bars'
     d.mkdir(parents=True)

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -314,7 +314,7 @@ def test_the_brief_still_gets_the_calibrators_the_dashboard_no_longer_ships():
     import sys
 
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
-    import decision_v2
+    from clawock import decision_v2
 
     metrics = decision_v2.compute_metrics(decision_v2.load_decisions())
     calibration = metrics.get("hierarchical_calibration") or {}
@@ -345,7 +345,7 @@ def test_the_brief_only_ships_calibrator_rows_that_can_move_size():
 
     sys.path.insert(0, str(ROOT / "scripts" / "data"))
     sys.path.insert(0, str(ROOT / "instances" / "kcnyu" / "src"))
-    import decision_v2
+    from clawock import decision_v2
     from clawock_kcnyu.harness import brief_preflight
 
     raw = decision_v2.compute_metrics(decision_v2.load_decisions())

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -7,9 +7,14 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
-import decision_v2 as dv2
+from clawock import decision_v2 as dv2
 from clawock_kcnyu.harness.intraday_watchdog import deterministic_fallback as intraday_fallback
 from clawock_kcnyu.harness.report_watchdog import deterministic_fallback as report_fallback
+
+
+def test_decision_engine_is_owned_by_the_product_package():
+    assert Path(dv2.__file__).relative_to(ROOT).as_posix() == "src/clawock/decision_v2.py"
+    assert not (ROOT / "scripts" / "data" / "decision_v2.py").exists()
 
 
 def decision(day, ticker="AAA", strategy="core_position", action="hold_and_watch",

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -86,6 +86,6 @@ def test_reflect_card_keeps_timing_claims_narrow():
 def test_audit_sidecar_still_covers_all_four_states():
     # The list no longer renders inline, but the published sidecar must still
     # account for every decision across all four states (no cherry-picking).
-    dv = (ROOT / "scripts" / "data" / "decision_v2.py").read_text()
+    dv = (ROOT / "src" / "clawock" / "decision_v2.py").read_text()
     for state in ("settled", "not_triggered", "not_evaluable", "pending"):
         assert state in dv

--- a/tests/test_risk_discipline.py
+++ b/tests/test_risk_discipline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts" / "data"))
-import decision_v2  # noqa: E402
+from clawock import decision_v2
 import risk_discipline as discipline  # noqa: E402
 from clawock_kcnyu.harness import brief_postflight  # noqa: E402
 


### PR DESCRIPTION
## Summary

- move the v2 decision ledger, settlement, calibration, execution matching, and audit engine into the published `clawock` package
- resolve default ledger/snapshot state from the caller's workspace rather than from the package installation or repository path
- update KCNyu harness, dashboard, Actions, operational commands, and tests to consume `clawock.decision_v2`
- ratchet wheel ownership and coverage accounting so the old source path cannot return

## Why

Decision/outcome lineage and deterministic settlement are core product behavior. Leaving the engine in KCNyu's `scripts/data` made the portable workflow depend on a private repository layout even after the packet and context protocol moved into the wheel.

## Verification

- `CLAWOCK_DELIVERY_DISABLED=1 python3 -m pytest tests/ -q` — 1700 passed, 10 skipped, 4 xfailed
- CI-equivalent coverage — total 65.0% (10867/16723), settlement core 78.7% (4076/5182)
- isolated wheel install imported the engine from outside the repository, resolved a temporary caller workspace, and loaded its decision ledger
- wheel listing contains `clawock/decision_v2.py` and no old `scripts/data/decision_v2.py`

Part of #379 and #381.
