### PR TITLE
Make OpenClaw provider defaults portable

### DIFF
--- a/docs/architecture/openclaw-adapter.md
+++ b/docs/architecture/openclaw-adapter.md
@@ -15,6 +15,13 @@ server's filesystem. Installed packages may set:
   a compatibility fallback);
 - `CLAWOCK_OPENCLAW_INSTALL_DIR` — npm/pnpm package root for operator checks.
 
+Without overrides, the adapter resolves `openclaw` from `PATH`, uses
+`~/.openclaw` as the external runtime state home, and discovers common npm/pnpm
+package layouts on a best-effort basis. A service with a deliberately narrow
+`PATH` should set an absolute `CLAWOCK_OPENCLAW_BIN`; an operator check that
+inspects the installed JavaScript should set `CLAWOCK_OPENCLAW_INSTALL_DIR` when
+its package manager layout cannot be discovered.
+
 Cron SQLite, fossil history, workspace, session and memory-index paths are
 derived from that selected home. These settings locate an external runtime;
 they do not make clawock launch a model or own an agent loop.

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -600,6 +600,8 @@ def _memory_index_backlog():
 
 def _memory_index_patch_gaps():
     """Local dist patches openclaw upgrades wipe, both silent at the point of use."""
+    if OPENCLAW_INSTALL is None:
+        return ['openclaw install root unresolved; set CLAWOCK_OPENCLAW_INSTALL_DIR']
     try:
         dist = OPENCLAW_INSTALL.resolve() / 'dist'
     except OSError as e:  # noqa: BLE001

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -22,20 +23,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
-# pnpm's global bin. Kept as one constant rather than resolved through PATH: the
-# cron environment is not a login shell, and PATH resolution has bitten this
-# before.
-OPENCLAW_BIN = "/root/.local/share/pnpm/openclaw"
-
-# Where the runtime keeps its own state. 6.1 migrated cron out of the JSONL
-# files into SQLite; both are still read, newest first, because the fossil is
-# the only thing left when the gateway and the DB are both unreadable.
-OPENCLAW_HOME = Path("/root/.openclaw")
+# Keep this compatibility name for callers that need an argv default, but make
+# its value belong to the current environment rather than to one operator's
+# pnpm installation. Cron services that deliberately run with a restricted PATH
+# should set CLAWOCK_OPENCLAW_BIN to an absolute path.
+OPENCLAW_BIN = shutil.which("openclaw") or "openclaw"
+DEFAULT_OPENCLAW_HOME = Path.home() / ".openclaw"
+# Compatibility aliases remain environment-neutral. New code should accept an
+# OpenClawPaths object or call runtime_paths() so overrides are resolved at use.
+OPENCLAW_HOME = DEFAULT_OPENCLAW_HOME
 CRON_RUNS_DIR = OPENCLAW_HOME / "cron" / "runs"
 CRON_JOBS_JSON = OPENCLAW_HOME / "cron" / "jobs.json"
 STATE_DB = OPENCLAW_HOME / "state" / "openclaw.sqlite"
-# The npm/pnpm install is a different root from the state home.
-INSTALL_DIR = Path("/root/.local/share/pnpm/global/5/node_modules/openclaw")
 
 
 @dataclass(frozen=True)
@@ -44,7 +43,7 @@ class OpenClawPaths:
 
     binary: str
     home: Path
-    install_dir: Path
+    install_dir: Path | None
 
     @property
     def cron_runs_dir(self) -> Path:
@@ -83,6 +82,38 @@ class OpenClawPaths:
         return self.workspace / "memory" / ".tmp"
 
 
+def _discover_install_dir(binary: str, *, search_path: str | None = None) -> Path | None:
+    """Best-effort npm/pnpm package root discovery from a selected CLI.
+
+    The package root is only needed by optional operator checks. Runtime calls
+    need the binary and state home, so an unfamiliar installation layout must
+    not make the provider unusable.
+    """
+    located = (binary if Path(binary).is_absolute()
+               else shutil.which(binary, path=search_path))
+    if not located:
+        return None
+    binary_path = Path(located)
+    try:
+        resolved = binary_path.resolve()
+    except OSError:
+        resolved = binary_path
+
+    # npm commonly symlinks the executable into a package's bin script.
+    for parent in (resolved.parent, *resolved.parents):
+        if parent.name == "openclaw" and parent.parent.name == "node_modules":
+            return parent
+
+    # pnpm's global launcher is a shell wrapper next to global/<n>/node_modules.
+    candidates = sorted(
+        binary_path.parent.glob("global/*/node_modules/openclaw"), reverse=True)
+    return candidates[0] if candidates else None
+
+
+# Legacy import surface, now discovered instead of fixed to one pnpm store.
+INSTALL_DIR = _discover_install_dir(OPENCLAW_BIN)
+
+
 def runtime_paths(environ: Mapping[str, str] | None = None) -> OpenClawPaths:
     """Resolve the selected external OpenClaw runtime.
 
@@ -90,11 +121,15 @@ def runtime_paths(environ: Mapping[str, str] | None = None) -> OpenClawPaths:
     as a compatibility fallback for existing operator scripts.
     """
     env = os.environ if environ is None else environ
-    binary = env.get("CLAWOCK_OPENCLAW_BIN") or OPENCLAW_BIN
+    binary = env.get("CLAWOCK_OPENCLAW_BIN") or shutil.which(
+        "openclaw", path=env.get("PATH")) or "openclaw"
     home_override = env.get("CLAWOCK_OPENCLAW_HOME") or env.get("OPENCLAW_HOME")
-    home = Path(home_override).expanduser() if home_override else OPENCLAW_HOME
+    default_home = (Path(env["HOME"]) / ".openclaw"
+                    if env.get("HOME") else DEFAULT_OPENCLAW_HOME)
+    home = Path(home_override).expanduser() if home_override else default_home
     install_override = env.get("CLAWOCK_OPENCLAW_INSTALL_DIR")
-    install_dir = Path(install_override).expanduser() if install_override else INSTALL_DIR
+    install_dir = (Path(install_override).expanduser() if install_override
+                   else _discover_install_dir(binary, search_path=env.get("PATH")))
     return OpenClawPaths(binary=binary, home=home, install_dir=install_dir)
 
 # `cron list --json` round-trips through the gateway and has been observed at
@@ -422,9 +457,8 @@ def build_cron_edit_argv(job_id: str, patch: dict, *,
 # `system_check.py`, which is the last consumer to migrate — deliberately, since
 # it is what proves the earlier steps did not break anything.
 
-# The runtime's own workspace. Not derived from a caller's workspace_root: the
-# semantic index only ever covers the live runtime checkout, so an interactive
-# worktree must judge that one rather than its own copy.
+# Legacy path imports follow the generic current-user default. Operator code
+# that can target multiple runtimes should use runtime_paths() instead.
 LIVE_WORKSPACE = OPENCLAW_HOME / "workspace"
 CONFIG_FILE = OPENCLAW_HOME / "openclaw.json"
 MEMORY_INDEX_DB = OPENCLAW_HOME / "agents" / "main" / "agent" / "openclaw-agent.sqlite"
@@ -438,4 +472,6 @@ def is_installed(paths: OpenClawPaths | None = None) -> bool:
     answer False, which is what lets an operator check skip cleanly instead of
     reporting a fault that only means "not this machine".
     """
-    return Path((paths or runtime_paths()).binary).exists()
+    binary = (paths or runtime_paths()).binary
+    return (Path(binary).exists() if Path(binary).is_absolute()
+            else shutil.which(binary) is not None)

--- a/tests/test_cron_live_state.py
+++ b/tests/test_cron_live_state.py
@@ -70,6 +70,26 @@ def test_runtime_paths_derive_one_external_installation():
     assert paths.install_dir == Path("/opt/openclaw/package")
 
 
+def test_default_runtime_paths_follow_the_current_user_and_path(tmp_path):
+    home = tmp_path / "user-home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    binary = bin_dir / "openclaw"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    paths = provider.runtime_paths({"HOME": str(home), "PATH": str(bin_dir)})
+
+    assert paths.binary == str(binary)
+    assert paths.home == home / ".openclaw"
+    assert paths.install_dir is None
+
+
+def test_public_provider_has_no_operator_home_literal():
+    source = Path(provider.__file__).read_text()
+    assert "/root/" not in source
+
+
 def test_explicit_runtime_reads_its_own_sqlite(tmp_path):
     paths = provider.OpenClawPaths(
         binary="/opt/openclaw/bin/openclaw",


### PR DESCRIPTION
## Outcome

Remove one-host `/root` and pnpm-store assumptions from the public OpenClaw
provider without changing the live runtime selected on the current host.

## Changes

- resolve the OpenClaw CLI from `CLAWOCK_OPENCLAW_BIN` or `PATH`
- default state storage to the current user's `~/.openclaw`, with the existing
  `CLAWOCK_OPENCLAW_HOME` / `OPENCLAW_HOME` overrides retained
- discover common npm and pnpm package roots instead of shipping one global
  store version in the wheel
- keep the old constant imports as environment-neutral compatibility aliases
- make the optional operator patch check explain how to configure an
  unrecognized package-manager layout
- document defaults and narrow-service environment requirements

## Boundary and live proof

- `src/clawock/providers/openclaw.py` contains no `/root`, KCNyu name, or
  instance path
- current host still resolves the same binary, state home, and OpenClaw package
  directory
- system check remains `15 ok / 1 warn / 0 critical`

## Verification

- 40 focused provider, cron writer, coupling-ratchet, memory-index, system-check,
  and wheel-surface tests passed
- `py_compile` and `git diff --check` passed

Progresses #378 and #381.
