### PR TITLE
Package realized P&L derivations

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -192,9 +192,11 @@ jobs:
             --cov=clawock.instrument_registry \
             --cov=clawock.json_repair \
             --cov=clawock.research_provenance \
+            --cov=clawock.recompute_realized \
             --cov=clawock.risk_discipline \
             --cov=clawock.safe_io \
             --cov=clawock.research_surface \
+            --cov=clawock.snapshot_realized \
             --cov=clawock.thesis_registry \
             --cov=clawock.trading_calendar \
             --cov-report=term-missing:skip-covered \

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -82,7 +82,7 @@ of claim-bearing backtests remain workspace configuration.
 | Area | Modules |
 |---|---|
 | Ledger + decision contract | `plan_surface` `mark_followed` `audit_resettle` |
-| Money integrity | `recompute_aggregates` `recompute_cash` `recompute_realized` `snapshot_realized` `shadow_portfolio` |
+| Money integrity | `recompute_aggregates` `recompute_cash` `clawock realized` `clawock.snapshot_realized` `shadow_portfolio` |
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` |

--- a/scripts/data/analyze_hk_stocks.py
+++ b/scripts/data/analyze_hk_stocks.py
@@ -489,7 +489,7 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
         print("  [dry-run] Not written.\n")
     else:
         from clawock.safe_io import mutate_json
-        from recompute_realized import recompute as recompute_realized
+        from clawock.recompute_realized import recompute as recompute_realized
         recompute_realized(data)
         # 锁内重读、只覆盖自己拥有的 hk_stocks 区 + 顶层 last_updated 戳，保住并发
         # 写者(gold/us)的字段 [cut #2]（last_updated 是顶层键，别随 region-overlay 丢）

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -629,7 +629,7 @@ def load_snapshots():
     point-in-time realized reflected in each snapshot's own holdings and prefer
     it, so the equity curve / drawdown can never be poisoned by a stale aggregate
     even if a future writer regresses. Read-only on the snapshot files."""
-    from snapshot_realized import realized_as_of, snapshot_shares
+    from clawock.snapshot_realized import realized_as_of, snapshot_shares
     ledger = _canonical_ledger()
     legs = _ledger_legs()
     paths = sorted(

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -50,7 +50,7 @@ CORE_MODULES = (
     'scripts/data/shadow_portfolio.py',
     'src/clawock/instrument_registry.py',
     'scripts/data/recompute_aggregates.py',
-    'scripts/data/recompute_realized.py',
+    'src/clawock/recompute_realized.py',
     'scripts/data/portfolio_risk_metrics.py',
     'scripts/data/intraday_delta_gate.py',
     'scripts/data/workflow_outcomes.py',

--- a/scripts/data/fetch_us_stocks.py
+++ b/scripts/data/fetch_us_stocks.py
@@ -1336,7 +1336,7 @@ def update_us_portfolio(
         print("\n  [dry-run] portfolio.json NOT written.\n")
     else:
         from clawock.safe_io import mutate_json
-        from recompute_realized import recompute as recompute_realized
+        from clawock.recompute_realized import recompute as recompute_realized
         recompute_realized(data)
         # 锁内重读、只覆盖自己拥有的 us_stocks 区 + 顶层 last_updated 戳，保住并发
         # 写者(gold/hk)的字段 [cut #2]（last_updated 是顶层键，别随 region-overlay 丢）

--- a/scripts/data/reconcile.sh
+++ b/scripts/data/reconcile.sh
@@ -22,7 +22,7 @@ echo "▸ recompute cash (baseline + trades cashflow + adjustments)…"
 python3 scripts/data/recompute_cash.py $DRY
 
 echo "▸ recompute realized P&L (Σ sell trades)…"
-python3 scripts/data/recompute_realized.py $DRY
+clawock realized $DRY
 
 echo "▸ integrity gate (TCV / cost / pnl / CASH_RECON / COST_BASIS / FX)…"
 python3 scripts/data/preflight_integrity.py

--- a/scripts/legacy/backfill_snapshot_realized.py
+++ b/scripts/legacy/backfill_snapshot_realized.py
@@ -18,20 +18,13 @@ import re
 import sys
 from pathlib import Path
 
-# `safe_io`, `snapshot_realized` and `workspace` all live in scripts/data. This
-# inserted *this* directory instead, so the module has not been importable on
-# its own since it was moved into scripts/legacy — `python3 -c "import
-# backfill_snapshot_realized"` raises ModuleNotFoundError on the first line
-# below. It only ever ran when something else had already put scripts/data on
-# the path.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'data'))
 # The checkout root, so `clawock` resolves from the tree this file ships
 # in. Reached through the scripts/data/workspace shim until #267 step 3,
 # whose only remaining job was inserting this path as a side effect.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from clawock.safe_io import safe_write_json  # noqa: E402
-from snapshot_realized import realized_as_of, snapshot_shares  # noqa: E402
+from clawock.snapshot_realized import realized_as_of, snapshot_shares  # noqa: E402
 from clawock.workspace import workspace_root  # noqa: E402
 
 # The workspace this file sits in, not the operator's. As an absolute live path

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -334,6 +334,8 @@ def _packaged_utility(args) -> int:
         from clawock.earnings_review import main
     elif args.command == "research":
         from clawock.research_surface import main
+    elif args.command == "realized":
+        from clawock.recompute_realized import main
     else:
         from clawock.claim_provenance import main
     return main(args.utility_args)
@@ -446,6 +448,7 @@ def main(argv=None) -> int:
     packaged_utilities = {
         "plan-context", "risk", "dashboard-outputs", "run-card", "provenance",
         "entry-gate", "thesis", "earnings", "research", "claim-provenance",
+        "realized",
     }
     if raw_argv and raw_argv[0] in packaged_utilities:
         return _packaged_utility(argparse.Namespace(
@@ -537,6 +540,7 @@ def main(argv=None) -> int:
         ("earnings", "validate and release primary-source earnings reviews"),
         ("research", "show or check the configured research work queue"),
         ("claim-provenance", "verify backtest claims against run cards"),
+        ("realized", "recompute realized P&L from the trade ledger"),
     ):
         utility = sub.add_parser(name, help=help_text, add_help=False)
         utility.add_argument("utility_args", nargs=argparse.REMAINDER)

--- a/src/clawock/recompute_realized.py
+++ b/src/clawock/recompute_realized.py
@@ -1,46 +1,28 @@
-"""
-recompute_realized.py — single source of truth for portfolio-level realized P&L.
+"""Single source of truth for portfolio-level realized P&L.
 
-Walks `holdings[].trades[]` across both portfolios, sums every entry with a
-`realized_pnl` field, and writes back:
-  portfolios.us_stocks.realized_pnl   (USD)
-  portfolios.us_stocks.realized_note  (deterministic chronological breakdown)
-  portfolios.hk_stocks.realized_pnl   (HKD)
-  portfolios.hk_stocks.realized_note
+Walks `holdings[].trades[]` across every portfolio book, sums every entry with a
+`realized_pnl` field, and writes back each book's `realized_pnl` plus a
+deterministic chronological `realized_note`.
 
-Hooked into fetch_us_stocks.update_us_portfolio() and analyze_hk_stocks
-refresh — runs on every price refresh so the aggregate can never drift away
-from the structured trades[] entries again (the 2026-05-20 SOXL+RKLX bug:
-2dc7786 appended trades[] but forgot to bump the aggregate).
+Designed to run after any price/position refresh so the aggregate cannot drift
+away from the structured trades[] entries.
 
 CLI usage:
-    python3 recompute_realized.py            # rewrite portfolio.json in place
-    python3 recompute_realized.py --dry-run  # print + diff, don't write
+    clawock realized            # rewrite portfolio.json in place
+    clawock realized --dry-run  # print + diff, don't write
 """
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-# The checkout root, so `clawock` resolves from the tree this file ships
-# in. Reached through the scripts/data/workspace shim until #267 step 3,
-# whose only remaining job was inserting this path as a side effect.
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from clawock.safe_io import safe_write_json  # noqa: E402
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock.safe_io import safe_write_json
+from clawock.workspace import workspace_root
 
-# The ledger of whichever workspace this file sits in — the same resolution the
-# other 42 modules use. It was the live absolute path, which made
-# `python3 recompute_realized.py` in a worktree rewrite the operator's real
-# portfolio.json: the library callers pass their own dict, so the constant only
-# ever served the command line, and the command line was pointed at production
-# no matter where it ran from. On the live host this resolves to the same file.
-PORTFOLIO_PATH = os.path.join(workspace_root(Path(__file__).resolve().parents[2]),
-                              'portfolio.json')
+# The CLI operates on the configured workspace. Library callers pass an
+# in-memory ledger and remain independent of filesystem layout.
+PORTFOLIO_PATH = workspace_root(Path.cwd()) / 'portfolio.json'
 
 
 def _aggregate(holdings: List[Dict]) -> Tuple[float, str, List[Dict]]:
@@ -79,9 +61,8 @@ def _aggregate(holdings: List[Dict]) -> Tuple[float, str, List[Dict]]:
 def recompute(data: Dict) -> Dict[str, Dict]:
     """Mutate `data` in place. Return per-region {realized_pnl, realized_note}."""
     out = {}
-    for region in ('us_stocks', 'hk_stocks'):
-        pf = data['portfolios'].get(region)
-        if not pf:
+    for region, pf in (data.get('portfolios') or {}).items():
+        if not isinstance(pf, dict):
             continue
         total, note, sells = _aggregate(pf.get('holdings', []) or [])
         pf['realized_pnl']  = total
@@ -94,11 +75,11 @@ def recompute(data: Dict) -> Dict[str, Dict]:
     return out
 
 
-def main():
+def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument('--dry-run', action='store_true', help='print summary, do not write')
-    ap.add_argument('--path', default=PORTFOLIO_PATH)
-    args = ap.parse_args()
+    ap.add_argument('--path', type=Path, default=PORTFOLIO_PATH)
+    args = ap.parse_args(argv)
 
     with open(args.path, encoding='utf-8') as f:
         data = json.load(f)
@@ -108,8 +89,8 @@ def main():
             'realized_pnl':  data['portfolios'][r].get('realized_pnl'),
             'realized_note': data['portfolios'][r].get('realized_note', ''),
         }
-        for r in ('us_stocks', 'hk_stocks')
-        if r in data['portfolios']
+        for r, portfolio in (data.get('portfolios') or {}).items()
+        if isinstance(portfolio, dict)
     }
 
     after = recompute(data)
@@ -131,7 +112,7 @@ def main():
         print('[dry-run] portfolio.json NOT written.')
         return 0
 
-    safe_write_json(args.path, data)
+    safe_write_json(str(args.path), data)
     print(f'✅ Saved → {args.path}')
     return 0
 

--- a/src/clawock/snapshot_realized.py
+++ b/src/clawock/snapshot_realized.py
@@ -1,35 +1,21 @@
-"""
-snapshot_realized.py — point-in-time realized P&L for a historical snapshot.
+"""Point-in-time realized P&L for a historical snapshot.
 
 `recompute_realized.py` sums *every* trade in portfolio.json — correct for the
 live portfolio, but wrong for a dated snapshot, where realized must reflect only
 the sells that had already settled into that snapshot's holdings. Crediting a
-sell too early inflates equity (phantom high); too late deflates it (phantom
-low — the 2026-05-21 bug, where the SOXL/RKLX sells were debited from holdings
-a day before realized caught up, faking a −$498 drawdown bottom).
+sell too early inflates equity; crediting it too late deflates it.
 
 The canonical portfolio.json `trades[]` ledger is the single source of truth.
 A sell is "reflected" in a snapshot when:
   * sell.date <  snapshot.date                              (settled on a prior day), OR
   * sell.date == snapshot.date AND snapshot_shares <= post_sell_balance
     (same-day tie broken by the snapshot's own share count — handles the
-     08:00 HKT morning snapshot taken before that day's US session).
+     a morning snapshot taken before that day's later market session).
 
 The same-day share check uses the running balance *after* the sell, so a sell is
 only counted once the holding has actually been drawn down to (or below) it. The
 strict date-`<` branch handles later sell→rebuy cycles without false negatives.
 """
-import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-# There was a `PORTFOLIO_PATH` here naming the live ledger absolutely. Nothing
-# in this module read it, and both importers (`build_dashboard`, the legacy
-# backfill) take only the two pure functions below, so it is deleted rather
-# than re-pointed: an unused constant naming production is a loaded gun.
-
-
 def _ledger_sells(holdings):
     """Per-ticker chronological sells, each tagged with its post-sell balance.
 

--- a/tests/test_derivations.py
+++ b/tests/test_derivations.py
@@ -20,7 +20,7 @@ WS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(WS, "scripts", "data"))
 
 import preflight_integrity as pi  # noqa: E402
-import recompute_realized as rr  # noqa: E402
+from clawock import recompute_realized as rr  # noqa: E402
 import recompute_aggregates as ra  # noqa: E402
 import build_dashboard as bd  # noqa: E402
 

--- a/tests/test_workspace_portability.py
+++ b/tests/test_workspace_portability.py
@@ -116,11 +116,11 @@ def test_the_money_clis_target_the_checkout_they_are_in(monkeypatch):
     """
     probe = (
         "import sys; sys.path[:0] = [%r, %r];"
-        "import recompute_realized as rr, snapshot_realized as sr,"
-        " backfill_snapshot_realized as bf;"
+        "from clawock import recompute_realized as rr, snapshot_realized as sr;"
+        " import backfill_snapshot_realized as bf;"
         "print(rr.PORTFOLIO_PATH); print(bf.SNAP_DIR);"
         "print(hasattr(sr, 'PORTFOLIO_PATH'))"
-    ) % (str(ROOT / "scripts" / "data"), str(ROOT / "scripts" / "legacy"))
+    ) % (str(ROOT / "src"), str(ROOT / "scripts" / "legacy"))
     env = {k: v for k, v in os.environ.items() if k != workspace.ENV_VAR}
 
     done = subprocess.run([sys.executable, "-c", probe], cwd=str(ROOT), env=env,


### PR DESCRIPTION
## Outcome

Move realized-P&L derivation and historical snapshot attribution into the
installable package, with one stable CLI for ledger reconciliation.

## Changes

- move `recompute_realized` and `snapshot_realized` from `scripts/data` into
  `src/clawock`
- add `clawock realized [--dry-run] [--path ...]`
- make realized aggregation operate over every declared portfolio book rather
  than embedding only two book keys
- switch US/HK refreshers, dashboard generation, historical backfill, and the
  reconciliation shell to package imports / CLI
- remove repository path bootstrapping and desk incident/ticker history from the
  public modules
- update the product boundary reference and required coverage paths

## Verification

- 103 focused derivation, workspace portability, dashboard, package-surface,
  and wheel tests passed; one existing test xfailed
- live ledger dry-run reports both books unchanged (`2220.56` and `7259.16`)
- public modules contain no KCNyu name, `/root` path, source-directory import,
  or desk ticker examples
- `py_compile` and `git diff --check` passed

Progresses #378 and #381.
