### PR TITLE
Package shadow portfolio simulation

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -200,6 +200,7 @@ jobs:
             --cov=clawock.safe_io \
             --cov=clawock.research_surface \
             --cov=clawock.snapshot_realized \
+            --cov=clawock.shadow_portfolio \
             --cov=clawock.thesis_registry \
             --cov=clawock.trading_calendar \
             --cov-report=term-missing:skip-covered \

--- a/config/portfolio-derivations.json
+++ b/config/portfolio-derivations.json
@@ -6,5 +6,19 @@
   "cash_field_by_book": {
     "us_stocks": "cash_usd",
     "hk_stocks": "cash_hkd"
+  },
+  "shadow_books": {
+    "US": {
+      "portfolio_key": "us_stocks",
+      "currency": "USD",
+      "cash_key": "cash_usd",
+      "market": "us"
+    },
+    "HK": {
+      "portfolio_key": "hk_stocks",
+      "currency": "HKD",
+      "cash_key": "cash_hkd",
+      "market": "hk"
+    }
   }
 }

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -76,9 +76,10 @@ tickers nor artifact paths are compiled into the public package.
 The entry gate, thesis registry, earnings ledger, research queue, and claim
 scanner now ship there as well. KCNyu's research cutover date, cadence and list
 of claim-bearing backtests remain workspace configuration.
-Realized P&L, snapshot attribution, aggregate rebuilding, cash derivation, and
-their shared ledger arithmetic now ship in the package. KCNyu's book names,
-cash-field bindings, and per-book percentage precision remain in
+Realized P&L, snapshot attribution, aggregate rebuilding, cash derivation,
+shadow-book simulation, and their shared ledger arithmetic now ship in the
+package. KCNyu's decision-leg/book mapping, book names, cash-field bindings,
+market calendars, and per-book percentage precision remain in
 `config/portfolio-derivations.json`.
 
 ### Product — the engine
@@ -86,12 +87,12 @@ cash-field bindings, and per-book percentage precision remain in
 | Area | Modules |
 |---|---|
 | Ledger + decision contract | `plan_surface` `mark_followed` `audit_resettle` |
-| Money integrity | `clawock aggregates` `clawock cash` `clawock realized` `clawock.snapshot_realized` `shadow_portfolio` |
+| Money integrity | `clawock aggregates` `clawock cash` `clawock realized` `clawock shadow` `clawock.snapshot_realized` |
 | Risk + governance | `portfolio_risk_metrics` `risk_discipline` `thesis_registry` `entry_gate` `earnings_review` `research_surface` |
 | Quant + research | `compute_quant_signals` `compute_regime` `compute_t0_setups` `t0_setup_review` `quant_signal_review` `cross_sectional_factor` `peer_residual_engine` `peer_scan` `suggest_peers` |
 | Evidence + provenance | `news_evidence_graph` `research_provenance` `claim_provenance` `run_card` `build_evidence` |
 | Market data | `fetch_us_stocks` `fetch_daily_bars` `fetch_fx` `fetch_benchmark_history` `fetch_peers` `fetch_catalysts` `fetch_us_filings` `fetch_fundamentals_em` `fetch_fundflow_em` `fetch_em_news` `fetch_sentiment` `fetch_macro` `mover_news` `known_catalysts` `analyze_hk_stocks` `analyze_us_stocks` `_em_http` `_em_symbols` |
-| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.brief_context` `clawock.brief_decision_packet` `clawock.decision_contract` `clawock.decision_v2` `clawock.plan_surface` `clawock.risk_discipline` `clawock.dashboard_outputs` `clawock.research_provenance` `clawock.run_card` `clawock.entry_gate` `clawock.thesis_registry` `clawock.earnings_review` `clawock.research_surface` `clawock.claim_provenance` `clawock.recompute_realized` `clawock.snapshot_realized` `clawock.portfolio_math` `clawock.recompute_aggregates` `clawock.recompute_cash` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
+| Moved into product | `clawock.instrument_registry` `clawock.bar_checks` `clawock.brief_context` `clawock.brief_decision_packet` `clawock.decision_contract` `clawock.decision_v2` `clawock.plan_surface` `clawock.risk_discipline` `clawock.dashboard_outputs` `clawock.research_provenance` `clawock.run_card` `clawock.entry_gate` `clawock.thesis_registry` `clawock.earnings_review` `clawock.research_surface` `clawock.claim_provenance` `clawock.recompute_realized` `clawock.snapshot_realized` `clawock.portfolio_math` `clawock.recompute_aggregates` `clawock.recompute_cash` `clawock.shadow_portfolio` `clawock.json_repair` `clawock.safe_io` `clawock.trading_calendar` | Code and schemas ship in the wheel; each user's configuration and data stay in their workspace |
 | Gates + outputs | `preflight_integrity` `validate_sidecars` `dashboard_outputs` `build_dashboard` `workflow_outcomes` `workflow_health` `coverage_badge` `cron_contract` `cron_heartbeat` |
 
 ### Instance — kcn's desk
@@ -106,7 +107,7 @@ cash-field bindings, and per-book percentage precision remain in
 | Claims about this book | `backtest_hstech_regime` `backtest_us_leverage` `backtest_combined_regime` `validate_regime_dial` | Validate kcn's dial against kcn's holdings |
 | This site's output contract | `config/dashboard-outputs.json` | Names this desk's generated artifacts, clock fields and linked generation group; the wheel only implements the configured diff algorithm |
 | This desk's research rollout | `config/research-governance.json` `config/claim-provenance.json` | Pins the gate cutover/cadence and the KCNyu backtest claim surfaces without compiling either into the wheel |
-| This desk's ledger bindings | `config/portfolio-derivations.json` | Pins book names, cash fields, and output precision while the wheel owns only the arithmetic |
+| This desk's ledger bindings | `config/portfolio-derivations.json` | Pins decision legs, book names, cash fields, market calendars, and output precision while the wheel owns only the arithmetic |
 
 ### Contested — flagging rather than hiding
 

--- a/scripts/data/build_dashboard.py
+++ b/scripts/data/build_dashboard.py
@@ -431,8 +431,12 @@ def build_shadow_sidecar(portfolio, decisions, previous=None):
     old value at all.
     """
     try:
-        import shadow_portfolio
-        return shadow_portfolio.build_shadow_portfolio(portfolio, decisions)
+        import importlib
+        shadow_portfolio = importlib.import_module('clawock.shadow_portfolio')
+        leg_config = shadow_portfolio.load_leg_config(
+            WS_ROOT / 'config' / 'portfolio-derivations.json')
+        return shadow_portfolio.build_shadow_portfolio(
+            portfolio, decisions, leg_config=leg_config)
     except Exception as e:
         failure = {'computed': False, 'error': str(e)}
         if isinstance(previous, dict):

--- a/scripts/data/coverage_badge.py
+++ b/scripts/data/coverage_badge.py
@@ -47,7 +47,7 @@ CORE_MODULES = (
     'src/clawock/research_surface.py',
     'scripts/data/preflight_integrity.py',
     'src/clawock/risk_discipline.py',
-    'scripts/data/shadow_portfolio.py',
+    'src/clawock/shadow_portfolio.py',
     'src/clawock/instrument_registry.py',
     'src/clawock/recompute_aggregates.py',
     'src/clawock/recompute_realized.py',

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -340,6 +340,8 @@ def _packaged_utility(args) -> int:
         from clawock.recompute_aggregates import main
     elif args.command == "cash":
         from clawock.recompute_cash import main
+    elif args.command == "shadow":
+        from clawock.shadow_portfolio import main
     else:
         from clawock.claim_provenance import main
     return main(args.utility_args)
@@ -453,7 +455,7 @@ def main(argv=None) -> int:
         "plan-context", "risk", "dashboard-outputs", "run-card", "provenance",
         "entry-gate", "thesis", "earnings", "research", "claim-provenance",
         "realized",
-        "aggregates", "cash",
+        "aggregates", "cash", "shadow",
     }
     if raw_argv and raw_argv[0] in packaged_utilities:
         return _packaged_utility(argparse.Namespace(
@@ -548,6 +550,7 @@ def main(argv=None) -> int:
         ("realized", "recompute realized P&L from the trade ledger"),
         ("aggregates", "recompute portfolio values and P&L from leaves"),
         ("cash", "recompute cash from its reconciliation ledger"),
+        ("shadow", "simulate followed decisions against buy and hold"),
     ):
         utility = sub.add_parser(name, help=help_text, add_help=False)
         utility.add_argument("utility_args", nargs=argparse.REMAINDER)

--- a/src/clawock/shadow_portfolio.py
+++ b/src/clawock/shadow_portfolio.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import math
+import argparse
 import os
 import re
 from collections import Counter, defaultdict
@@ -22,28 +23,116 @@ from pathlib import Path
 from typing import Callable
 from zoneinfo import ZoneInfo
 
-# The checkout root, so `clawock` resolves from the tree this file ships
-# in. Reached through the scripts/data/workspace shim until #267 step 3,
-# whose only remaining job was inserting this path as a side effect.
-import sys  # noqa: E402
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
-from clawock import decision_v2  # noqa: E402
-from clawock import trading_calendar  # noqa: E402
-from clawock.workspace import workspace_root  # noqa: E402
+from clawock import decision_v2
+from clawock import trading_calendar
+from clawock.safe_io import safe_write_text
+from clawock.workspace import workspace_root
 
-WS = workspace_root(Path(__file__).resolve().parents[2])
-OUT = WS / "assets" / "data" / "shadow_portfolio.json"
 SCHEMA_VERSION = 1
 ACTIVE_ACTIONS = set(decision_v2.ACTIVE_ACTIONS)
 SELL_ACTIONS = set(decision_v2.SELL_ACTIONS)
 BUY_ACTIONS = set(decision_v2.ADD_ACTIONS)
-LEG_CONFIG = {
-    "US": {"portfolio_key": "us_stocks", "currency": "USD", "cash_key": "cash_usd"},
-    "HK": {"portfolio_key": "hk_stocks", "currency": "HKD", "cash_key": "cash_hkd"},
-}
 EXTERNAL_FLOW_WORDS = ("入金", "deposit", "withdraw", "出金", "transfer")
 CORPORATE_ACTION_WORDS = ("dividend", "股息", "派息", "split", "拆股")
+
+
+def load_leg_config(path: Path | str) -> dict[str, dict[str, str]]:
+    """Load the instance-owned decision-leg to ledger-book mapping."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    configured = payload.get("shadow_books")
+    if not isinstance(configured, dict) or not configured:
+        raise ValueError("portfolio derivation config needs non-empty shadow_books")
+    result = {}
+    required = {"portfolio_key", "currency", "cash_key", "market"}
+    for leg, raw in configured.items():
+        if not isinstance(leg, str) or not leg or not isinstance(raw, dict):
+            raise ValueError("shadow_books entries must map a decision leg to an object")
+        missing = required - raw.keys()
+        if missing:
+            raise ValueError(
+                f"shadow_books.{leg} missing: {', '.join(sorted(missing))}")
+        values = {key: raw[key] for key in required}
+        if any(not isinstance(value, str) or not value.strip()
+               for value in values.values()):
+            raise ValueError(f"shadow_books.{leg} values must be non-empty strings")
+        values["market"] = values["market"].lower()
+        if values["market"] not in trading_calendar.MARKET_TZ:
+            raise ValueError(
+                f"shadow_books.{leg}.market unsupported: {values['market']}")
+        result[leg] = values
+    return result
+
+
+def _leg_cfg(
+    portfolio: dict,
+    leg: str,
+    leg_config: dict[str, dict[str, str]] | None,
+) -> dict[str, str]:
+    """Resolve one leg without compiling an instance's book names into core."""
+    if leg_config is not None:
+        try:
+            configured = leg_config[leg]
+        except KeyError as exc:
+            raise ValueError(f"decision leg {leg!r} has no shadow-book mapping") from exc
+        book = (portfolio.get("portfolios") or {}).get(
+            configured["portfolio_key"])
+        if not isinstance(book, dict):
+            raise ValueError(
+                f"shadow book {configured['portfolio_key']!r} for {leg!r} is missing")
+        ledger_currency = book.get("currency")
+        if ledger_currency and ledger_currency != configured["currency"]:
+            raise ValueError(
+                f"shadow book currency mismatch for {leg!r}: "
+                f"{ledger_currency!r} != {configured['currency']!r}")
+        return configured
+
+    # A portable caller may declare the mapping in its ledger instead of using
+    # the KCNyu instance's sidecar configuration.
+    for portfolio_key, book in (portfolio.get("portfolios") or {}).items():
+        if not isinstance(book, dict) or book.get("decision_leg") != leg:
+            continue
+        currency = book.get("currency")
+        market = book.get("market")
+        cash_key = book.get("cash_key")
+        if not cash_key and isinstance(currency, str) and currency:
+            cash_key = f"cash_{currency.lower()}"
+        if not all(isinstance(value, str) and value for value in (
+                portfolio_key, currency, cash_key, market)):
+            break
+        market = market.lower()
+        if market not in trading_calendar.MARKET_TZ:
+            raise ValueError(f"portfolio market unsupported: {market}")
+        return {
+            "portfolio_key": portfolio_key,
+            "currency": currency,
+            "cash_key": cash_key,
+            "market": market,
+        }
+    raise ValueError(
+        f"decision leg {leg!r} is not declared by the portfolio or configuration")
+
+
+def resolve_leg_config(
+    portfolio: dict,
+    decisions: list[dict],
+    configured: dict[str, dict[str, str]] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Return mappings for every authored decision leg, preserving ledger order."""
+    legs = []
+    for decision in decisions:
+        leg = decision.get("leg")
+        if isinstance(leg, str) and leg and leg not in legs:
+            legs.append(leg)
+    if configured is not None:
+        # Ignore configured books that have no decisions, matching the old
+        # behavior where a leg without an active decision emitted no curve.
+        resolved = {leg: _leg_cfg(portfolio, leg, configured) for leg in legs}
+    else:
+        resolved = {leg: _leg_cfg(portfolio, leg, None) for leg in legs}
+    currencies = [cfg["currency"] for cfg in resolved.values()]
+    if len(currencies) != len(set(currencies)):
+        raise ValueError("shadow-book currencies must be unique output keys")
+    return resolved
 
 
 def _number(value) -> float | None:
@@ -61,8 +150,12 @@ def _shares(value) -> int | None:
     return max(0, int(math.floor(number + 1e-9)))
 
 
-def _holding_map(portfolio: dict, leg: str) -> dict[str, dict]:
-    cfg = LEG_CONFIG[leg]
+def _holding_map(
+    portfolio: dict,
+    leg: str,
+    leg_config: dict[str, dict[str, str]] | None = None,
+) -> dict[str, dict]:
+    cfg = _leg_cfg(portfolio, leg, leg_config)
     holdings = (
         ((portfolio.get("portfolios") or {}).get(cfg["portfolio_key"]) or {})
         .get("holdings") or []
@@ -74,15 +167,24 @@ def _holding_map(portfolio: dict, leg: str) -> dict[str, dict]:
     }
 
 
-def _lot_size(portfolio: dict, leg: str, ticker: str) -> int:
-    raw = (_holding_map(portfolio, leg).get(ticker) or {}).get("lot_size")
+def _lot_size(
+    portfolio: dict,
+    leg: str,
+    ticker: str,
+    leg_config: dict[str, dict[str, str]] | None = None,
+) -> int:
+    raw = (_holding_map(portfolio, leg, leg_config).get(ticker) or {}).get("lot_size")
     lot = _shares(raw)
     return lot if lot and lot > 0 else 1
 
 
-def _trade_rows(portfolio: dict, leg: str) -> list[dict]:
+def _trade_rows(
+    portfolio: dict,
+    leg: str,
+    leg_config: dict[str, dict[str, str]] | None = None,
+) -> list[dict]:
     rows = []
-    for ticker, holding in _holding_map(portfolio, leg).items():
+    for ticker, holding in _holding_map(portfolio, leg, leg_config).items():
         for ordinal, trade in enumerate(holding.get("trades") or []):
             row = dict(trade)
             row["ticker"] = ticker
@@ -91,8 +193,12 @@ def _trade_rows(portfolio: dict, leg: str) -> list[dict]:
     return rows
 
 
-def _cash_adjustments(portfolio: dict, leg: str) -> list[dict]:
-    cfg = LEG_CONFIG[leg]
+def _cash_adjustments(
+    portfolio: dict,
+    leg: str,
+    leg_config: dict[str, dict[str, str]] | None = None,
+) -> list[dict]:
+    cfg = _leg_cfg(portfolio, leg, leg_config)
     book = ((portfolio.get("portfolios") or {}).get(cfg["portfolio_key"]) or {})
     rows = []
     for ordinal, adjustment in enumerate(book.get("cash_adjustments") or []):
@@ -119,14 +225,19 @@ def _cash_adjustments(portfolio: dict, leg: str) -> list[dict]:
     return rows
 
 
-def reconstruct_initial_book(portfolio: dict, leg: str, start_date: str) -> dict:
+def reconstruct_initial_book(
+    portfolio: dict,
+    leg: str,
+    start_date: str,
+    leg_config: dict[str, dict[str, str]] | None = None,
+) -> dict:
     """Reverse the actual ledger from today's state to just before ``start_date``.
 
     Actual post-start trades are used only to recover the seed. They are not
     replayed into either comparison book after the simulation starts.
     """
-    cfg = LEG_CONFIG[leg]
-    holdings = _holding_map(portfolio, leg)
+    cfg = _leg_cfg(portfolio, leg, leg_config)
+    holdings = _holding_map(portfolio, leg, leg_config)
     inventory = {
         ticker: _shares(row.get("shares")) or 0
         for ticker, row in holdings.items()
@@ -137,7 +248,7 @@ def reconstruct_initial_book(portfolio: dict, leg: str, start_date: str) -> dict
     cash = cash or 0.0
 
     reversed_trades = 0
-    for trade in _trade_rows(portfolio, leg):
+    for trade in _trade_rows(portfolio, leg, leg_config):
         if str(trade.get("date") or "") < start_date:
             continue
         ticker = trade["ticker"]
@@ -159,7 +270,7 @@ def reconstruct_initial_book(portfolio: dict, leg: str, start_date: str) -> dict
         reversed_trades += 1
 
     reversed_adjustments = 0
-    for adjustment in _cash_adjustments(portfolio, leg):
+    for adjustment in _cash_adjustments(portfolio, leg, leg_config):
         if adjustment["date"] >= start_date:
             cash -= adjustment["amount"]
             reversed_adjustments += 1
@@ -285,11 +396,12 @@ def _execute_sell(
     decision: dict,
     fill: dict,
     portfolio: dict,
+    leg_config: dict[str, dict[str, str]] | None = None,
 ) -> dict:
     ticker = str(decision.get("ticker") or "")
     inventory = state["inventory"]
     available = inventory.get(ticker, 0)
-    lot = _lot_size(portfolio, decision["leg"], ticker)
+    lot = _lot_size(portfolio, decision["leg"], ticker, leg_config)
     requested = _requested_shares(
         decision, inventory, state["cash"], fill["price"], lot)
     qty = min(requested, available)
@@ -318,10 +430,11 @@ def _execute_buy(
     fill: dict,
     portfolio: dict,
     budget: float | None = None,
+    leg_config: dict[str, dict[str, str]] | None = None,
 ) -> dict:
     ticker = str(decision.get("ticker") or "")
     inventory = state["inventory"]
-    lot = _lot_size(portfolio, decision["leg"], ticker)
+    lot = _lot_size(portfolio, decision["leg"], ticker, leg_config)
     available_cash = state["cash"] if budget is None else min(state["cash"], budget)
     requested = _requested_shares(
         decision, inventory, available_cash, fill["price"], lot)
@@ -351,6 +464,7 @@ def _execute_swap_group(
     rows: list[dict],
     fills: dict[str, dict],
     portfolio: dict,
+    leg_config: dict[str, dict[str, str]] | None = None,
 ) -> list[dict]:
     """Sell first, then spend only that group's proceeds on its buy leg(s)."""
     legs = []
@@ -360,7 +474,8 @@ def _execute_swap_group(
     for decision in sell_rows:
         fill = fills.get(decision.get("decision_id"))
         if fill:
-            legs.append(_execute_sell(state, decision, fill, portfolio))
+            legs.append(_execute_sell(
+                state, decision, fill, portfolio, leg_config=leg_config))
     proceeds = max(0.0, state["cash"] - cash_before)
     remaining = proceeds
     for index, decision in enumerate(buy_rows):
@@ -371,7 +486,9 @@ def _execute_swap_group(
         # available swap pot evenly; they never borrow the pre-existing cash.
         targets_left = len(buy_rows) - index
         budget = remaining if targets_left == 1 else remaining / targets_left
-        leg = _execute_buy(state, decision, fill, portfolio, budget=budget)
+        leg = _execute_buy(
+            state, decision, fill, portfolio, budget=budget,
+            leg_config=leg_config)
         legs.append(leg)
         remaining -= _number(leg.get("notional")) or 0.0
     return legs
@@ -399,7 +516,7 @@ def _mark(
     return (None if missing else round(value, 6), missing)
 
 
-def _market_as_of_date(as_of: str | None, leg: str) -> str | None:
+def _market_as_of_date(as_of: str | None, market: str) -> str | None:
     """Convert a build timestamp to the leg's local market date."""
     if not as_of:
         return None
@@ -407,18 +524,16 @@ def _market_as_of_date(as_of: str | None, leg: str) -> str | None:
         return as_of
     parsed = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
     if parsed.tzinfo is not None:
-        market = leg.lower()
         parsed = parsed.astimezone(ZoneInfo(trading_calendar.MARKET_TZ[market]))
     return parsed.date().isoformat()
 
 
 def _expected_trading_dates(
-    leg: str,
+    market: str,
     start_date: str,
     end_date: str,
 ) -> list[str]:
     """Return every calendar-expected session, independent of bar availability."""
-    market = leg.lower()
     current = date.fromisoformat(start_date)
     end = date.fromisoformat(end_date)
     dates = []
@@ -564,12 +679,15 @@ def simulate_leg(
     bar_loader: Callable[[str, str], dict | None] = decision_v2.bar,
     bar_map_loader: Callable[[str], dict] = decision_v2.load_ticker_bars,
     matched: dict[str, dict] | None = None,
+    leg_config: dict[str, dict[str, str]] | None = None,
 ) -> dict | None:
+    cfg = _leg_cfg(portfolio, leg, leg_config)
     active = _active_triggered(decisions, leg)
     if not active:
         return None
     start_date = start_date or min(_event_session(row) for _, row in active)
-    seed = reconstruct_initial_book(portfolio, leg, start_date)
+    seed = reconstruct_initial_book(
+        portfolio, leg, start_date, leg_config=leg_config)
     followed = {"cash": float(seed["cash"]), "inventory": deepcopy(seed["inventory"])}
     buy_hold = {"cash": float(seed["cash"]), "inventory": deepcopy(seed["inventory"])}
     matched = matched if matched is not None else decision_v2.match_real_executions(
@@ -602,7 +720,8 @@ def simulate_leg(
     }
     end_date = as_of_date or max(
         available_dates | event_dates | {start_date})
-    expected_dates = set(_expected_trading_dates(leg, start_date, end_date))
+    expected_dates = set(_expected_trading_dates(
+        cfg["market"], start_date, end_date))
     # Event sessions remain replayable for backward compatibility with already
     # authored ledgers, but only calendar-expected sessions count toward mark
     # coverage.  Future events beyond the build's as-of date are never replayed.
@@ -612,7 +731,7 @@ def simulate_leg(
 
     adjustments_by_date = defaultdict(list)
     ignored_corporate_actions = []
-    for adjustment in _cash_adjustments(portfolio, leg):
+    for adjustment in _cash_adjustments(portfolio, leg, leg_config):
         if adjustment["date"] < start_date:
             continue
         if adjustment["kind"] == "corporate_action":
@@ -650,7 +769,8 @@ def simulate_leg(
             has_buy = any(row.get("action") in BUY_ACTIONS for row in rows)
             paired_swap = has_sell and has_buy
             if paired_swap:
-                legs = _execute_swap_group(followed, rows, fills, portfolio)
+                legs = _execute_swap_group(
+                    followed, rows, fills, portfolio, leg_config=leg_config)
             else:
                 legs = []
                 for row in rows:
@@ -670,9 +790,13 @@ def simulate_leg(
                         })
                         continue
                     if row.get("action") in SELL_ACTIONS:
-                        legs.append(_execute_sell(followed, row, fill, portfolio))
+                        legs.append(_execute_sell(
+                            followed, row, fill, portfolio,
+                            leg_config=leg_config))
                     else:
-                        legs.append(_execute_buy(followed, row, fill, portfolio))
+                        legs.append(_execute_buy(
+                            followed, row, fill, portfolio,
+                            leg_config=leg_config))
                 if any(
                     swap_pattern.search(
                         " ".join([
@@ -810,7 +934,7 @@ def simulate_leg(
 
     return {
         "leg": leg,
-        "currency": LEG_CONFIG[leg]["currency"],
+        "currency": cfg["currency"],
         "start_date": start_date,
         "end_date": final_point["date"] if final_point else None,
         "initial": seed,
@@ -856,22 +980,25 @@ def build_shadow_portfolio(
     bar_loader: Callable[[str, str], dict | None] = decision_v2.bar,
     bar_map_loader: Callable[[str], dict] = decision_v2.load_ticker_bars,
     matched: dict[str, dict] | None = None,
+    leg_config: dict[str, dict[str, str]] | None = None,
 ) -> dict:
-    """Build the public sidecar. USD and HKD are intentionally never combined."""
+    """Build native-currency curves without adding unlike currencies."""
     as_of = as_of or datetime.now().astimezone().isoformat(timespec="seconds")
     matched = matched if matched is not None else decision_v2.match_real_executions(
         decisions, portfolio)
+    configured = resolve_leg_config(portfolio, decisions, leg_config)
     curves = {}
-    for leg in ("US", "HK"):
+    for leg, cfg in configured.items():
         result = simulate_leg(
             portfolio,
             decisions,
             leg,
             start_date=(start_dates or {}).get(leg),
-            as_of_date=_market_as_of_date(as_of, leg),
+            as_of_date=_market_as_of_date(as_of, cfg["market"]),
             bar_loader=bar_loader,
             bar_map_loader=bar_map_loader,
             matched=matched,
+            leg_config=configured,
         )
         if result:
             curves[result["currency"]] = result
@@ -899,12 +1026,18 @@ def build_shadow_portfolio(
         },
         "fx_policy": {
             "combined_curve": False,
-            "reason": "USD and HKD are separate; no naked cross-currency addition",
+            "reason": (
+                f"native currencies stay separate ({', '.join(curves) or 'none'}); "
+                "no naked cross-currency addition"
+            ),
             "daily_fx_required_for_combination": True,
             "today_fx_for_history_forbidden": True,
         },
         "methodology": {
-            "books": "two independent cash+inventory ledgers with identical reconstructed seeds",
+            "books": (
+                f"{len(configured)} independent cash+inventory ledgers with "
+                "identical reconstruction rules"
+            ),
             "action_scope": "every triggered active decision, including execution.status=not_followed",
             "ordering": "trigger session, then authored created_at, then ledger order",
             "constraints": "sell capped by live inventory; buy capped by live cash; prior legs mutate the next leg",
@@ -948,7 +1081,7 @@ def build_shadow_portfolio(
                 "from prose and remain independent cash-constrained actions."
             ),
             (
-                "USD and HKD stay separate. A combined curve would require point-in-time daily FX, "
+                "Native currencies stay separate. A combined curve would require point-in-time daily FX, "
                 "which this sidecar deliberately does not synthesize."
             ),
         ],
@@ -958,33 +1091,41 @@ def build_shadow_portfolio(
 def write_shadow_portfolio(
     portfolio: dict,
     decisions: list[dict],
-    out_path: Path | str = OUT,
+    out_path: Path | str,
     **kwargs,
 ) -> dict:
     result = build_shadow_portfolio(portfolio, decisions, **kwargs)
     path = Path(out_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        from clawock.safe_io import safe_write_text
-        safe_write_text(
-            str(path), json.dumps(result, ensure_ascii=False, indent=2) + "\n")
-    except ImportError:
-        path.write_text(
-            json.dumps(result, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
+    safe_write_text(
+        str(path), json.dumps(result, ensure_ascii=False, indent=2) + "\n")
     return result
 
 
-def main() -> int:
-    portfolio_path = WS / "portfolio.json"
+def main(argv=None) -> int:
+    workspace = workspace_root(Path.cwd())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", type=Path, default=workspace / "portfolio.json")
+    parser.add_argument(
+        "--config", type=Path,
+        default=workspace / "config" / "portfolio-derivations.json")
+    parser.add_argument(
+        "--decisions", type=Path,
+        default=workspace / "memory" / "decisions.jsonl")
+    parser.add_argument(
+        "--out", type=Path,
+        default=workspace / "assets" / "data" / "shadow_portfolio.json")
+    args = parser.parse_args(argv)
+    portfolio_path = args.path
     if not portfolio_path.exists():
         raise SystemExit("portfolio.json missing")
     portfolio = json.loads(portfolio_path.read_text(encoding="utf-8"))
-    decisions = decision_v2.load_decisions()
+    decisions = decision_v2.load_decisions(args.decisions)
     decision_v2.settle_decisions(decisions)
-    out_path = Path(os.environ.get("SHADOW_PORTFOLIO_OUT") or OUT)
-    result = write_shadow_portfolio(portfolio, decisions, out_path)
+    out_path = Path(os.environ.get("SHADOW_PORTFOLIO_OUT") or args.out)
+    result = write_shadow_portfolio(
+        portfolio, decisions, out_path,
+        leg_config=load_leg_config(args.config))
     points = sum(
         (book.get("mark_coverage") or {}).get("published_points", 0)
         for book in result["curves"].values()

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -105,8 +105,11 @@ def test_shadow_failure_replaces_stale_result_and_success_clears_marker(monkeypa
 
     monkeypatch.setitem(
         sys.modules,
-        "shadow_portfolio",
-        SimpleNamespace(build_shadow_portfolio=explode),
+        "clawock.shadow_portfolio",
+        SimpleNamespace(
+            load_leg_config=lambda _path: {},
+            build_shadow_portfolio=explode,
+        ),
     )
     failed = dashboard.build_shadow_sidecar({}, [], previous)
 
@@ -119,7 +122,7 @@ def test_shadow_failure_replaces_stale_result_and_success_clears_marker(monkeypa
     assert "cumulative_diff" not in failed
     assert all(value is not None for value in failed.values())
 
-    def succeed(_portfolio, _decisions):
+    def succeed(_portfolio, _decisions, **_kwargs):
         return {
             "as_of": "2026-07-17T23:00:00+08:00",
             "curves": {},
@@ -128,8 +131,11 @@ def test_shadow_failure_replaces_stale_result_and_success_clears_marker(monkeypa
 
     monkeypatch.setitem(
         sys.modules,
-        "shadow_portfolio",
-        SimpleNamespace(build_shadow_portfolio=succeed),
+        "clawock.shadow_portfolio",
+        SimpleNamespace(
+            load_leg_config=lambda _path: {},
+            build_shadow_portfolio=succeed,
+        ),
     )
     succeeded = dashboard.build_shadow_sidecar({}, [], failed)
 

--- a/tests/test_shadow_portfolio.py
+++ b/tests/test_shadow_portfolio.py
@@ -1,13 +1,11 @@
-import sys
 from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "scripts" / "data"))
+from clawock import shadow_portfolio as shadow
 
-import shadow_portfolio as shadow
+ROOT = Path(__file__).resolve().parents[1]
 
 
 DAY_1 = "2026-07-01"
@@ -27,10 +25,16 @@ def _portfolio(*, us_cash=0, us_holdings=(), hk_cash=0, hk_holdings=()):
     return {
         "portfolios": {
             "us_stocks": {
+                "decision_leg": "US",
+                "currency": "USD",
+                "market": "us",
                 "cash_usd": us_cash,
                 "holdings": list(us_holdings),
             },
             "hk_stocks": {
+                "decision_leg": "HK",
+                "currency": "HKD",
+                "market": "hk",
                 "cash_hkd": hk_cash,
                 "holdings": list(hk_holdings),
             },
@@ -208,6 +212,95 @@ def test_build_keeps_usd_and_hkd_curves_separate_without_combination():
     assert result["fx_policy"]["combined_curve"] is False
     assert "combined" not in result["curves"]
     assert "combined" not in result["cumulative_diff"]
+
+
+def test_build_uses_instance_mapping_without_compiled_book_names():
+    portfolio = {
+        "portfolios": {
+            "tokyo_growth": {
+                "currency": "JPY",
+                "cash_jpy": 100,
+                "holdings": [_holding("JP1", 1)],
+            },
+            "frankfurt_value": {
+                "currency": "EUR",
+                "cash_eur": 200,
+                "holdings": [_holding("EU1", 1)],
+            },
+        }
+    }
+    decisions = [
+        _decision("jp-sell", "JP1", "cut", 1, leg="TOKYO", price=10),
+        _decision("eu-sell", "EU1", "cut", 1, leg="FRANKFURT", price=20),
+    ]
+    bars = {
+        "JP1": {DAY_1: {"close": 10}},
+        "EU1": {DAY_1: {"close": 20}},
+    }
+    bar_loader, bar_map_loader = _loaders(bars)
+    config = {
+        "TOKYO": {
+            "portfolio_key": "tokyo_growth", "currency": "JPY",
+            "cash_key": "cash_jpy", "market": "us",
+        },
+        "FRANKFURT": {
+            "portfolio_key": "frankfurt_value", "currency": "EUR",
+            "cash_key": "cash_eur", "market": "hk",
+        },
+    }
+
+    result = shadow.build_shadow_portfolio(
+        portfolio,
+        decisions,
+        as_of=DAY_1,
+        bar_loader=bar_loader,
+        bar_map_loader=bar_map_loader,
+        matched={},
+        leg_config=config,
+    )
+
+    assert set(result["curves"]) == {"JPY", "EUR"}
+    assert result["curves"]["JPY"]["leg"] == "TOKYO"
+    assert result["curves"]["EUR"]["leg"] == "FRANKFURT"
+
+
+def test_leg_config_rejects_incomplete_or_unknown_market(tmp_path):
+    path = tmp_path / "portfolio-derivations.json"
+    path.write_text('{"shadow_books":{"X":{"portfolio_key":"book"}}}')
+    with pytest.raises(ValueError, match="missing"):
+        shadow.load_leg_config(path)
+
+    path.write_text(
+        '{"shadow_books":{"X":{"portfolio_key":"book",'
+        '"currency":"EUR","cash_key":"cash_eur","market":"mars"}}}')
+    with pytest.raises(ValueError, match="unsupported"):
+        shadow.load_leg_config(path)
+
+
+def test_configured_book_must_exist_and_match_ledger_currency():
+    portfolio = {
+        "portfolios": {
+            "book": {"currency": "JPY", "cash_jpy": 0, "holdings": []},
+        }
+    }
+    decision = _decision("x", "JP1", "cut", 1, leg="TOKYO")
+    missing = {
+        "TOKYO": {
+            "portfolio_key": "absent", "currency": "JPY",
+            "cash_key": "cash_jpy", "market": "us",
+        }
+    }
+    mismatch = {
+        "TOKYO": {
+            "portfolio_key": "book", "currency": "USD",
+            "cash_key": "cash_jpy", "market": "us",
+        }
+    }
+
+    with pytest.raises(ValueError, match="is missing"):
+        shadow.resolve_leg_config(portfolio, [decision], missing)
+    with pytest.raises(ValueError, match="currency mismatch"):
+        shadow.resolve_leg_config(portfolio, [decision], mismatch)
 
 
 def test_buy_hold_uses_same_seed_and_only_canonical_close_marks():


### PR DESCRIPTION
## Outcome

Move the shadow cash-and-inventory policy simulation into the installable
package without compiling the KCNyu desk's book names or decision-leg mapping
into the public wheel.

## Changes

- move `shadow_portfolio` from `scripts/data` to `src/clawock`
- add the stable `clawock shadow` command with explicit portfolio, decisions,
  config, and output paths
- put KCNyu's US/HK leg-to-book, cash-field, currency, and calendar mapping in
  `config/portfolio-derivations.json`
- make pure callers able to supply their own mapping or declare it in their
  ledger
- reject missing books, currency mismatches, duplicate output currencies, and
  unsupported calendars instead of publishing a misleading curve
- update dashboard generation, coverage ownership, documentation, and tests

## Boundary and behavior proof

- the public module contains no KCNyu name, `/root` path, `scripts/data`
  dependency, or `us_stocks` / `hk_stocks` book key
- a synthetic `tokyo_growth` / `frankfurt_value` ledger produces independent
  JPY and EUR curves from the same package code
- live KCNyu input still produces 111 marked points; every numeric curve and
  attribution value is unchanged
- the only sidecar differences are generic methodology strings replacing the
  hard-coded two-book USD/HKD wording

## Verification

- 96 focused package, wheel, dashboard, and shadow tests passed; one existing
  test xfailed
- the full suite passed under the CI-equivalent `PYTHONPATH=src` environment
- a real dashboard generation wrote all four outputs successfully
- `compileall` and `git diff --check` passed

Progresses #378 and #381.
