### PR TITLE
fix: compute the workflow card before the previous-payload merge

### DIFF
--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -2709,6 +2709,13 @@ def build_projection(previous_source=None, shadow_previous=None):
     # file at all. Without a presence entry the card would publish empty and
     # `--previous` could not restore it — the 2026-06-21 shape. The recovery
     # mechanism exists for exactly this; it just never covered this key.
+    # Computed HERE, next to its presence test, and not 200 lines further down
+    # where it used to be: `merge_previous_payload` runs in between, so the
+    # restored card was overwritten by the empty computed one on exactly the
+    # fresh-checkout build this entry exists to protect. The payload still said
+    # `preserved: ['workflow_outcomes']`, which made the telemetry that decides
+    # whether the merge can be retired report a recovery that never happened.
+    out['workflow_outcomes'] = compute_workflow_outcomes()
     _presence['workflow_outcomes'] = bool(
         (out.get('workflow_outcomes') or {}).get('recent'))
 
@@ -2998,8 +3005,6 @@ def build_projection(previous_source=None, shadow_previous=None):
         # was present" from "the recovery file was not there" (#314).
         if _previous_missing:
             out['build_status']['previous_payload']['missing'] = True
-    out['workflow_outcomes'] = compute_workflow_outcomes()
-
     if brief_ctx_path:
         print(f'  brief-context source: {os.path.basename(brief_ctx_path)}')
 

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -140,6 +140,29 @@ def test_workflow_card_folds_the_published_ledger_into_counts(monkeypatch, tmp_p
     assert "stages" not in card["recent"][0]
 
 
+def test_a_checkout_without_the_ledger_republishes_the_last_workflow_card(
+        monkeypatch, tmp_path):
+    """`--previous` must actually reach the published payload, not just `preserved`.
+
+    brief-fallback builds from a fresh checkout, where the ledger is untracked
+    and absent. The card was computed after the merge ran, so the restored value
+    was overwritten by the empty one while `build_status` still reported the key
+    as preserved — a blank card plus telemetry saying it had been recovered.
+    """
+    (tmp_path / "assets" / "data").mkdir(parents=True)
+    (tmp_path / "memory" / "snapshots").mkdir(parents=True)
+    (tmp_path / "portfolio.json").write_text(json.dumps(_portfolio()))
+    previous = tmp_path / "previous.json"
+    previous.write_text(json.dumps({"workflow_outcomes": {
+        "counts": {"success": 9}, "recent": [{"job": "last good"}]}}))
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+
+    payload = json.loads(dashboard.build_projection(previous_source=previous)["dashboard"])
+
+    assert payload["workflow_outcomes"]["counts"] == {"success": 9}
+    assert "workflow_outcomes" in payload["build_status"]["previous_payload"]["preserved"]
+
+
 def test_shadow_failure_replaces_stale_result_and_success_clears_marker(monkeypatch):
     previous = {
         "as_of": "2026-07-16T23:00:00+08:00",


### PR DESCRIPTION
The workflow card's `--previous` recovery has never worked, and the payload said
it did.

`build_projection` computed `out['workflow_outcomes']` about 200 lines *after*
`merge_previous_payload()` ran. So on a fresh checkout — brief-fallback, where
the ledger is untracked and absent, which is the only case the presence entry
added in #326 exists for — the sequence was:

1. `_presence['workflow_outcomes']` read a key that did not exist yet → `False`
2. the merge restored the last good card and recorded the key in `preserved`
3. the late assignment overwrote it with the empty computed card

The published card was blank and `build_status.previous_payload.preserved`
still listed `workflow_outcomes`. That field is the telemetry #302/#314 left in
place to decide whether the merge can be retired at all, so it was reporting a
recovery that never happened.

Reproduced against a workspace with no `assets/data/workflow-outcomes.json` and
a `--previous` carrying a sentinel card:

```
before  card: {"counts": {}, "recent": []}   preserved: ['workflow_outcomes']
after   card: {"counts": {"success": 9}, …}  preserved: ['workflow_outcomes']
```

Live is unaffected either way — the file is present there, so presence is now
truthfully `True` and the payload reports `preserved: []` instead of a false
positive (verified against the live workspace before opening this).

Fix is the one-line move, with the computation now sitting next to the presence
test it feeds. One regression test, mutation-verified by moving the assignment
back.
