### PR TITLE
fix: make every packaged CLI utility reachable and safe to --help

### DIFF
--- a/memory/fx-rates.jsonl
+++ b/memory/fx-rates.jsonl
@@ -52,3 +52,4 @@
 {"day": "2026-08-05", "fallback_used": false, "fetched_at": "2026-08-05T14:09:56.133268+00:00", "pair": "USDHKD", "rate": 7.8431, "source": "Frankfurter"}
 {"day": "2026-08-06", "fallback_used": false, "fetched_at": "2026-08-06T00:01:46.429381+00:00", "pair": "USDHKD", "rate": 7.8431, "source": "Frankfurter"}
 {"day": "2026-08-07", "fallback_used": false, "fetched_at": "2026-08-07T00:01:10.055678+00:00", "pair": "USDHKD", "rate": 7.8446, "source": "Frankfurter"}
+{"day": "2026-08-09", "fallback_used": false, "fetched_at": "2026-08-09T13:32:47.265107+00:00", "pair": "USDHKD", "rate": 7.8449, "source": "Frankfurter"}

--- a/portfolio.json
+++ b/portfolio.json
@@ -1,6 +1,6 @@
 {
   "owner": "kcn",
-  "last_updated": "2026/08/08 04:02 HKT",
+  "last_updated": "2026/08/09 21:39 HKT",
   "portfolios": {
     "us_stocks": {
       "currency": "USD",
@@ -85,9 +85,9 @@
           "shares": 2,
           "cost_basis": 87,
           "current_price": 66.67,
-          "today_change_pct": 5.3571,
+          "today_change_pct": 5.36,
           "pnl_percent": -23.3678,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
+          "data_source": "Nasdaq API (stocks) Aug 09, 2026 09:39 ET",
           "note": "2026-02-26/03-02 共买入14股(@88.35+@86.45,均价≈87);2026-03-04 卖4股@103.21(+64.84);03-11 卖5股@120(+165);03-23 卖3股@127(+120);剩余2股长期持有(看好稳定币+agent支付赛道)",
           "trades": [
             {
@@ -132,14 +132,15 @@
           "day_high": 68.4,
           "day_low": 64.585,
           "day_open": 65.66,
-          "prev_close": 63.28,
+          "prev_close": 63.2783,
           "current_value": 133.34,
           "pnl_abs": -40.66,
           "today_change": 6.78,
           "name": "Circle Internet Group Inc-A",
           "volume": 11156626,
           "prev_close_date": "2026-08-06",
-          "day_session_date": "2026-08-07"
+          "day_session_date": "2026-08-07",
+          "quote_incomplete": true
         },
         {
           "ticker": "OKLO",
@@ -297,13 +298,13 @@
           "shares": 5,
           "cost_basis": 40.957142857142856,
           "current_price": 49.6,
-          "today_change_pct": 20.5639,
-          "pnl_percent": 67.1159,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
-          "prev_close": 41.14,
+          "today_change_pct": 20.5601,
+          "pnl_percent": 21.1022,
+          "data_source": "Nasdaq API (etf) Aug 09, 2026 09:39 ET",
+          "prev_close": 41.1413,
           "current_value": 248.0,
           "pnl_abs": 43.21,
-          "today_change": 42.3,
+          "today_change": 42.29,
           "note": "2026-04-16 按用户截图记录买入,做 PLTR 2x 杠杆短线仓",
           "trades": [
             {
@@ -343,7 +344,8 @@
           "day_high": 49.8677,
           "day_low": 42.665,
           "day_open": 43.34,
-          "day_session_date": "2026-08-07"
+          "day_session_date": "2026-08-07",
+          "quote_incomplete": true
         },
         {
           "ticker": "SOXL",
@@ -405,7 +407,7 @@
           "current_price": 26.11,
           "today_change_pct": 18.7898,
           "pnl_percent": -47.4542,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
+          "data_source": "Nasdaq API (etf) Aug 09, 2026 09:39 ET",
           "day_high": 26.325,
           "day_low": 20.0,
           "day_open": 20.03,
@@ -464,7 +466,8 @@
           "name": "Defiance Daily Target 2X Long R",
           "volume": 2897866,
           "prev_close_date": "2026-08-06",
-          "day_session_date": "2026-08-07"
+          "day_session_date": "2026-08-07",
+          "quote_incomplete": true
         },
         {
           "ticker": "ROBN",
@@ -543,8 +546,8 @@
           "pnl_abs": -14.39,
           "pnl_percent": -9.7559,
           "today_change": 18.19,
-          "today_change_pct": 15.8284,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
+          "today_change_pct": 15.83,
+          "data_source": "Nasdaq API (stocks) Aug 09, 2026 09:39 ET",
           "trades": [
             {
               "date": "2026-06-12",
@@ -569,13 +572,14 @@
               "note": "按用户记录买入"
             }
           ],
-          "prev_close": 114.92,
+          "prev_close": 114.9184,
           "prev_close_date": "2026-08-06",
           "day_high": 133.48,
           "day_low": 114.53,
           "day_open": 114.975,
           "day_session_date": "2026-08-07",
-          "volume": 81714250
+          "volume": 81714250,
+          "quote_incomplete": true
         },
         {
           "ticker": "SPCH",
@@ -585,10 +589,10 @@
           "current_price": 8.28,
           "current_value": 1656.0,
           "pnl_abs": -1027.7,
-          "pnl_percent": -37.4835,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
-          "today_change": 396.0,
-          "today_change_pct": 31.4286,
+          "pnl_percent": -38.2941,
+          "data_source": "Nasdaq API (etf) Aug 09, 2026 09:39 ET",
+          "today_change": 396.02,
+          "today_change_pct": 31.4307,
           "trades": [
             {
               "date": "2026-07-22",
@@ -719,7 +723,7 @@
             }
           ],
           "note": "SPCX(SpaceX) 2x做多ETF，已七次加仓摊本（6/22同日两次），FTSE/CRSP入指利好兑现当天反跌+8月解禁悬云(最多44%股份)未出清，逻辑持续弱化\n2026-07-02 凌晨 02:03 HKT 第八次加仓 10 股 @$13.89（盘中），累计加仓金额触发 P0 风险升级 → 详见 strategy_note。\n2026-06-24 凌晨挂限价单 $13.50 成交10股 → 净 100 股,加权均成本 $17.888。当晚先放量冲高至$14.30+(50M+股,Benzinga报道frenzy级)后回落到限价位成交,符合\"等回踩不追涨\"的纪律。\n2026-06-23 加仓 10 股 @$13.13 → 净 90 股,加权均成本 $18.3756 (vs 旧 19.0312（注：旧值含已 T+0 卖出的 20 股 @16.68，已剔除））。逆硬止损线操作第 6 次,minimax 立场=反对但 kcn 选择执行。\n2026-06-23 用户声明无限子弹流策略：持续加仓摊本直到 SPCX 正股反弹或 8 月解禁落地。minimax 不再每条盯盘喊砍，仅在 (a)单日跌幅 >15% (b)累计加仓金额 > $3000 (c)SPCX 正股单周 -25% 时升级为 P0 风险提示。\n2026-07-02 02:03 HKT 触发 P0：(b) 累计加仓金额已突破 $3000 (按 cash-flow 累加 $1,946.5USD，但若含手续费+滑点已逼近阈值)。minimax 升级为 P0 风险提示，但 kcn 持续执行。\n2026-07-02 02:09 HKT 第九次加仓 10 股 @$13.89 → 净 110 股,加权均成本 $17.5245 (按 cash-flow 加权 vs 旧 $17.888 摊本交易成本加全量),浮亏 -21.76% / -$419.6 (现价 $13.71)。\n⚠️ P0 持续:US 现金余额仅剩 ~$134.35,累计加仓金额 $1,946.5 / $3,000 阈值(差 $1,053.5 才升级);弹药已见底,再无追加空间除非变现其他仓位。",
-          "prev_close": 6.3,
+          "prev_close": 6.2999,
           "day_high": 8.32,
           "day_low": 6.26,
           "day_open": 6.31,
@@ -732,7 +736,8 @@
             "SPCH 累计加仓成本 > $3000 USD",
             "SPCX 正股单周跌幅 > 25%"
           ],
-          "volume": 43829528
+          "volume": 43829528,
+          "quote_incomplete": true
         },
         {
           "ticker": "MSFU",
@@ -743,8 +748,8 @@
           "current_value": 382.6,
           "pnl_abs": 91.3,
           "pnl_percent": 31.3423,
-          "today_change": -0.3,
-          "today_change_pct": -0.0783,
+          "today_change": -0.31,
+          "today_change_pct": -0.0799,
           "trades": [
             {
               "date": "2026-04-24",
@@ -771,14 +776,15 @@
             }
           ],
           "note": "2026-04-24 按用户截图记录买入,微软 2x 杠杆 ETF,财报前修复短线仓。2026-07-30 MSFT Q4财报强劲,MSFU单日+28.7%,减仓5股落袋+10.3。2026-07-31 再卖5股@32,剩10股继续跑。",
-          "prev_close": 38.29,
+          "prev_close": 38.2906,
           "day_high": 39.075,
           "day_low": 38.081,
           "day_open": 38.22,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
+          "data_source": "Nasdaq API (etf) Aug 09, 2026 09:39 ET",
           "volume": 6022942,
           "prev_close_date": "2026-08-06",
-          "day_session_date": "2026-08-07"
+          "day_session_date": "2026-08-07",
+          "quote_incomplete": true
         },
         {
           "ticker": "SKHY",
@@ -789,7 +795,7 @@
           "current_value": 137.91,
           "pnl_abs": -31.28,
           "pnl_percent": -18.4857,
-          "data_source": "Finnhub Aug 07, 2026 16:02 ET",
+          "data_source": "Nasdaq API (stocks) Aug 09, 2026 09:39 ET",
           "day_high": 143.649,
           "day_low": 133.8,
           "note": "2026-07-10 IPO首日(发行价$149,史上第二大全球股票发行仅次于SpaceX)169.185买入1股,用户报告成交。临时代码SKHYV已于2026-07-13转为正式代码SKHY",
@@ -802,46 +808,47 @@
               "note": "IPO首日买入,用户报告成交"
             }
           ],
-          "prev_close": 143.53,
+          "prev_close": 143.5366,
           "prev_close_date": "2026-08-06",
-          "today_change_pct": -3.9156,
+          "today_change_pct": -3.92,
           "day_session_date": "2026-08-07",
-          "today_change": -5.62,
+          "today_change": -5.63,
           "day_open": 143.49,
-          "volume": 32272098
+          "volume": 32272098,
+          "quote_incomplete": true
         }
       ],
       "total_cost": 4167.37,
       "total_current_value": 2952.06,
       "total_pnl": -1215.31,
       "total_pnl_percent": -29.1625,
-      "today_total_change": 498.65,
+      "today_total_change": 498.64,
       "realized_pnl": 2220.56,
       "realized_note": "NVDA 3股@197.5(+29.19) + CRCL 4股@103.21(+64.84) + CRCL 5股@120(+165) + CRCL 3股@127(+120) + NVDA 3股@199.41(+34.92) + QQQ 1股@631.3(+9.03) + TQQQ 8股@54.45(+69.76) + HOOD 5股@88.36(+74.3) + OKLO 2股@68(+10.34) + TCOM 5股@53.86(+5.6) + SOXL 5股@112(+100.65) + RKLX 4股@75(+113.2) + RKLX 2股@91.03(+88.66) + SOXL 3股@170.8(+236.79) + SOXL 2股@217.17(+250.6) + RKLB 5股@100.17(+145.85) + SPCX 5股@168(+48.5) + RKLX 10股@53.93(+7.3) + SPCH 20股@18.42(+34.8) + ROBN 20股@35.175(+231.85) + ROBN 10股@40(+164.17) + ROBN 10股@37(+134.18) + MSFU 5股@31.19(+10.3) + MSFU 5股@32(+14.35) + PLTU 4股@45(+16.17) + PLTU 5股@49(+40.2143)",
       "last_updated": "Jun 24, 2026 16:00 ET close",
       "last_close_attempted": "May 7, 2026 16:00 ET close",
-      "last_open_attempted": "2026-08-07 14:30 EDT",
+      "last_open_attempted": "2026-08-09 09:39 EDT",
       "indices_snapshot": {
         "SPX": {
           "name": "S&P 500",
-          "price": 7757.54,
+          "price": 7757.64,
           "prev_close": 7709.96,
-          "change_pct": 0.617,
-          "source": "Tencent usINX index @ 2026-08-07 16:03 ET"
+          "change_pct": 0.618,
+          "source": "Tencent usINX index @ 2026-08-09 09:39 ET"
         },
         "NDX": {
           "name": "Nasdaq 100",
           "price": 29722.3,
           "prev_close": 29373.33,
           "change_pct": 1.188,
-          "source": "Tencent usNDX index @ 2026-08-07 16:03 ET"
+          "source": "Tencent usNDX index @ 2026-08-09 09:39 ET"
         },
         "DJI": {
           "name": "Dow Jones",
-          "price": 54036.52,
+          "price": 54036.93,
           "prev_close": 53885.1,
-          "change_pct": 0.281,
-          "source": "Tencent usDJI index @ 2026-08-07 16:03 ET"
+          "change_pct": 0.282,
+          "source": "Tencent usDJI index @ 2026-08-09 09:39 ET"
         }
       },
       "last_trade_update": "2026-06-13 00:02 HKT",
@@ -899,10 +906,11 @@
         ],
         "missing_after_fallback": [],
         "source_counts": {
-          "Finnhub": 7
+          "Nasdaq API (stocks)": 3,
+          "Nasdaq API (etf)": 4
         },
-        "updated_at": "2026-08-07 14:30 EDT",
-        "note": "Multi-provider fetch. Sources: 7x Finnhub"
+        "updated_at": "2026-08-09 09:39 EDT",
+        "note": "Multi-provider fetch. Sources: 3x Nasdaq API (stocks), 4x Nasdaq API (etf)"
       },
       "afterhours_fetch_status": {
         "attempted_all_holdings": [
@@ -996,13 +1004,13 @@
           "ticker_finnhub": "0100.HK",
           "shares": 120,
           "cost_basis": 553.0833333333334,
-          "current_price": 327.0,
-          "current_value": 39240.0,
-          "pnl_percent": -40.88,
-          "data_source": "Tencent Aug 07 16:01 HKT",
-          "today_change": 3576.0,
-          "today_change_pct": 10.03,
-          "pnl_abs": -27130.0,
+          "current_price": 326.4,
+          "current_value": 39168.0,
+          "pnl_percent": -40.99,
+          "data_source": "Tencent Aug 09 21:39 HKT",
+          "today_change": 3504.0,
+          "today_change_pct": 9.83,
+          "pnl_abs": -27202.0,
           "day_open": 288.6,
           "day_high": 374.4,
           "day_low": 287.0,
@@ -1056,7 +1064,7 @@
           ],
           "turnover": 28080650.0,
           "today_change_abs": -4.0,
-          "prev_close_date": "2026-08-07",
+          "prev_close_date": "2026-08-09",
           "stock_name": "MINIMAX-W"
         },
         {
@@ -1065,13 +1073,13 @@
           "ticker_finnhub": "2208.HK",
           "shares": 400,
           "cost_basis": 14.084,
-          "current_price": 11.54,
-          "current_value": 4616.0,
-          "pnl_percent": -18.06,
-          "data_source": "Tencent Aug 07 16:01 HKT",
-          "today_change": 272.0,
-          "today_change_pct": 6.26,
-          "pnl_abs": -1017.6,
+          "current_price": 11.55,
+          "current_value": 4620.0,
+          "pnl_percent": -17.99,
+          "data_source": "Tencent Aug 09 21:39 HKT",
+          "today_change": 276.0,
+          "today_change_pct": 6.35,
+          "pnl_abs": -1013.6,
           "day_open": 11.02,
           "day_high": 11.72,
           "day_low": 10.93,
@@ -1089,7 +1097,7 @@
           ],
           "turnover": 14936588.0,
           "today_change_abs": -0.15,
-          "prev_close_date": "2026-08-07",
+          "prev_close_date": "2026-08-09",
           "stock_name": "金风科技"
         },
         {
@@ -1098,13 +1106,13 @@
           "ticker_finnhub": "3032.HK",
           "shares": 200,
           "cost_basis": 5.405,
-          "current_price": 4.85,
-          "current_value": 970.0,
-          "pnl_percent": -10.27,
-          "data_source": "Tencent Aug 07 16:01 HKT",
-          "today_change": 4.4,
-          "today_change_pct": 0.46,
-          "pnl_abs": -111.0,
+          "current_price": 4.852,
+          "current_value": 970.4,
+          "pnl_percent": -10.23,
+          "data_source": "Tencent Aug 09 21:39 HKT",
+          "today_change": 4.8,
+          "today_change_pct": 0.5,
+          "pnl_abs": -110.6,
           "day_open": 4.81,
           "day_high": 4.852,
           "day_low": 4.778,
@@ -1112,7 +1120,7 @@
           "volume": 2690000,
           "turnover": 13722674.0,
           "today_change_abs": 0.02,
-          "prev_close_date": "2026-08-07",
+          "prev_close_date": "2026-08-09",
           "stock_name": "恒生科技ETF"
         },
         {
@@ -1121,10 +1129,10 @@
           "ticker_finnhub": "7226.HK",
           "shares": 6200,
           "cost_basis": 4.3632,
-          "current_price": 3.638,
-          "current_value": 22555.6,
-          "pnl_percent": -16.62,
-          "data_source": "Tencent Aug 07 16:01 HKT",
+          "current_price": 3.64,
+          "current_value": 22568.0,
+          "pnl_percent": -16.57,
+          "data_source": "Tencent Aug 09 21:39 HKT",
           "trades": [
             {
               "date": "2026-03-24",
@@ -1134,9 +1142,9 @@
               "note": "加仓补摊,摊低成本至4.3632"
             }
           ],
-          "today_change": 322.4,
-          "today_change_pct": 1.45,
-          "pnl_abs": -4496.24,
+          "today_change": 334.8,
+          "today_change_pct": 1.51,
+          "pnl_abs": -4483.84,
           "day_open": 3.604,
           "day_high": 3.642,
           "day_low": 3.532,
@@ -1144,7 +1152,7 @@
           "volume": 10798200,
           "turnover": 45110333.4,
           "today_change_abs": 0.034,
-          "prev_close_date": "2026-08-07",
+          "prev_close_date": "2026-08-09",
           "stock_name": "南方2倍做多恒科"
         },
         {
@@ -1153,13 +1161,13 @@
           "ticker_finnhub": "3033.HK",
           "shares": 1000,
           "cost_basis": 5.14,
-          "current_price": 4.758,
-          "current_value": 4758.0,
-          "pnl_percent": -7.43,
-          "data_source": "Tencent Aug 07 16:01 HKT",
-          "today_change": 24.0,
-          "today_change_pct": 0.51,
-          "pnl_abs": -382.0,
+          "current_price": 4.766,
+          "current_value": 4766.0,
+          "pnl_percent": -7.28,
+          "data_source": "Tencent Aug 09 21:39 HKT",
+          "today_change": 32.0,
+          "today_change_pct": 0.68,
+          "pnl_abs": -374.0,
           "day_open": 4.744,
           "day_high": 4.768,
           "day_low": 4.69,
@@ -1167,7 +1175,7 @@
           "volume": 25157240,
           "turnover": 126176969.0,
           "today_change_abs": 0.022,
-          "prev_close_date": "2026-08-07",
+          "prev_close_date": "2026-08-09",
           "stock_name": "南方恒生科技"
         },
         {
@@ -1320,7 +1328,7 @@
         }
       ],
       "total_cost": 105276.44,
-      "total_current_value": 72139.6,
+      "total_current_value": 72092.4,
       "cash_hkd": 17597.0,
       "cash_reconciled": 34597,
       "cash_reconciled_date": "2026-07-07",
@@ -1333,27 +1341,27 @@
         }
       ],
       "cash_hkd_note": "港股现金余额(HKD)。权威值改为从 cash_reconciled 基线派生(见 cash_reconciled_note),此字段仅供展示。真实总资产 = total_current_value + cash_hkd。",
-      "total_pnl": -33136.84,
-      "total_pnl_percent": -31.48,
+      "total_pnl": -33184.04,
+      "total_pnl_percent": -31.52,
       "realized_pnl": 7259.16,
       "realized_note": "07709 100股@33.14(+144.86) + 07709 100股@34.2(+250.86) + 07747 100股@85(+315) + 07709 100股@33.5(+243.38) + 07709 100股@31.76(+226.7) + 07747 100股@83.58(+173) + 07709 100股@31.5(+196.52) + 07709 100股@36(+646.52) + 07709 100股@36.02(+648.52) + 07709 100股@38.7(+916.52) + 07709 400股@36.98(+2978.08) + 02208 200股@16.68(+519.2)",
-      "today_total_change": 4198.8,
+      "today_total_change": 4151.6,
       "last_updated": "2026/06/18 16:00 HKT (close; Jun 19 休市)",
       "last_close_attempted": "2026/05/11 16:00 HKT",
       "indices_snapshot": {
         "HSI": {
           "name": "恒生指数",
-          "price": 25666.31,
+          "price": 25668.03,
           "prev_close": 25530.28,
-          "chg_pct": 0.53,
-          "source": "Tencent qt.gtimg.cn 2026/08/07 16:01 HKT"
+          "chg_pct": 0.54,
+          "source": "Tencent qt.gtimg.cn 2026/08/09 21:39 HKT"
         },
         "HSTECH": {
           "name": "恒生科技",
-          "price": 4857.71,
+          "price": 4858.29,
           "prev_close": 4820.78,
-          "chg_pct": 0.77,
-          "source": "Tencent qt.gtimg.cn 2026/08/07 16:01 HKT"
+          "chg_pct": 0.78,
+          "source": "Tencent qt.gtimg.cn 2026/08/09 21:39 HKT"
         }
       },
       "last_midday_attempted": "2026-05-07 12:00:00 HKT",

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -316,107 +316,17 @@ def _context(args) -> int:
 
 def _packaged_utility(args) -> int:
     """Dispatch package-owned ledgers and deterministic output utilities."""
-    if args.command == "plan-context":
-        from clawock.decision.plans import main
-    elif args.command == "risk":
-        from clawock.decision.risk import main
-    elif args.command == "dashboard-outputs":
-        from clawock.publish.outputs import main
-    elif args.command == "dashboard-build":
-        from clawock.publish.dashboard import main
-    elif args.command == "run-card":
-        from clawock.evidence.run_card import main
-    elif args.command == "provenance":
-        from clawock.evidence.research_provenance import main
-    elif args.command == "entry-gate":
-        from clawock.decision.entry import main
-    elif args.command == "thesis":
-        from clawock.decision.theses import main
-    elif args.command == "earnings":
-        from clawock.decision.earnings import main
-    elif args.command == "research":
-        from clawock.evidence.research_surface import main
-    elif args.command == "realized":
-        from clawock.portfolio.realized import main
-    elif args.command == "aggregates":
-        from clawock.portfolio.aggregates import main
-    elif args.command == "cash":
-        from clawock.portfolio.cash import main
-    elif args.command == "shadow":
-        from clawock.portfolio.shadow import main
-    elif args.command == "fx":
-        from clawock.portfolio.fx import main
-    elif args.command == "portfolio-risk":
-        from clawock.portfolio.risk import main
-    elif args.command == "quant":
-        from clawock.decision.signals import main
-    elif args.command == "regime":
-        from clawock.decision.regime import main
-    elif args.command == "t0":
-        from clawock.decision.setups import main
-    elif args.command == "quant-review":
-        from clawock.decision.signal_review import main
-    elif args.command == "t0-review":
-        from clawock.decision.setup_review import main
-    elif args.command == "cross-factor":
-        from clawock.market_data.factors import main
-    elif args.command == "peer-residual":
-        from clawock.market_data.peer_residuals import main
-    elif args.command == "fetch-peers":
-        from clawock.market_data.peer_quotes import hard_exit, main
-        hard_exit(main(args.utility_args))
-    elif args.command == "filings":
-        from clawock.market_data.filings import main
-    elif args.command == "fundamentals":
-        from clawock.market_data.fundamentals import main
-    elif args.command == "fundflow":
-        from clawock.market_data.fund_flows import main
-    elif args.command == "em-news":
-        from clawock.market_data.eastmoney_news import main
-    elif args.command == "daily-bars":
-        from clawock.market_data.bars import main
-    elif args.command == "catalysts":
-        from clawock.market_data.calendar import main
-    elif args.command == "us-quotes":
-        from clawock.market_data.us_quotes import main
-    elif args.command == "analyze-us":
-        from clawock.market_data.us_analysis import main
-    elif args.command == "analyze-hk":
-        from clawock.market_data.hk_analysis import main
-    elif args.command == "benchmark":
-        from clawock.market_data.benchmarks import main
-    elif args.command == "macro":
-        from clawock.market_data.macro import main
-    elif args.command == "sentiment":
-        from clawock.market_data.sentiment import main
-    elif args.command == "mover-evidence":
-        from clawock.market_data.mover_evidence import main
-    elif args.command == "integrity":
-        from clawock.portfolio.integrity import main
-    elif args.command == "reconcile":
-        from clawock.portfolio.reconcile import main
-    elif args.command == "validate-sidecar":
-        from clawock.publish.artifacts import main
-    elif args.command == "mark-followed":
-        from clawock.decision.execution import main
-    elif args.command == "audit-resettle":
-        from clawock.decision.settlement import main
-    elif args.command == "evidence":
-        from clawock.evidence.build_evidence import main
-    elif args.command == "news-evidence":
-        from clawock.evidence.news_evidence_graph import main
-    elif args.command == "evaluate-combined-regime":
-        from clawock.evaluation.combined_regime import main
-    elif args.command == "evaluate-hstech-regime":
-        from clawock.evaluation.hstech_regime import main
-    elif args.command == "evaluate-us-leverage":
-        from clawock.evaluation.us_leverage import main
-    elif args.command == "validate-regime-dial":
-        from clawock.evaluation.regime_validation import main
-    else:
-        from clawock.evidence.claim_provenance import main
-    return main(args.utility_args)
+    import importlib
 
+    module = importlib.import_module(PACKAGED_UTILITIES[args.command])
+    if (args.command in DOCSTRING_HELP_UTILITIES
+            and set(args.utility_args) & {"-h", "--help"}):
+        print(f"usage: clawock {args.command} [flags]\n")
+        print((module.__doc__ or "no module documentation").strip())
+        return 0
+    if args.command in HARD_EXIT_UTILITIES:
+        module.hard_exit(module.main(args.utility_args))
+    return module.main(args.utility_args)
 
 def _workflow(args) -> int:
     """Discover or install portable Agent Skills shipped by clawock."""
@@ -520,23 +430,74 @@ def _workflow(args) -> int:
         return 1
 
 
-# Utility commands dispatched straight to their module `main`, bypassing the
-# argparse tree below. Module scope so callers can ask what the CLI accepts
-# without building the parser or shelling out.
-PACKAGED_UTILITIES = frozenset({
-    "plan-context", "risk", "dashboard-outputs", "dashboard-build", "run-card",
-    "provenance", "entry-gate", "thesis", "earnings", "research",
-    "claim-provenance", "realized", "aggregates", "cash", "shadow", "fx",
-    "portfolio-risk", "quant", "regime", "t0", "quant-review", "t0-review",
-    "cross-factor", "peer-residual", "fetch-peers", "filings", "fundamentals",
-    "fundflow", "em-news", "daily-bars", "catalysts", "us-quotes",
-    "analyze-us", "analyze-hk", "benchmark", "macro", "sentiment",
-    "mover-evidence", "integrity", "reconcile", "validate-sidecar",
-    "mark-followed", "audit-resettle", "evidence", "news-evidence",
-    "evaluate-combined-regime", "evaluate-hstech-regime",
-    "evaluate-us-leverage", "validate-regime-dial",
-})
+# Command -> module owning its `main(argv)`. One table, not a name list plus a
+# parallel dispatch chain: those were two copies of the same 49 entries, and the
+# four `evaluate-*` commands shipped in #429 pointing at a module with no `main`
+# because only one copy was updated.
+PACKAGED_UTILITIES = {
+    "aggregates": "clawock.portfolio.aggregates",
+    "analyze-hk": "clawock.market_data.hk_analysis",
+    "analyze-us": "clawock.market_data.us_analysis",
+    "audit-resettle": "clawock.decision.settlement",
+    "benchmark": "clawock.market_data.benchmarks",
+    "cash": "clawock.portfolio.cash",
+    "catalysts": "clawock.market_data.calendar",
+    "claim-provenance": "clawock.evidence.claim_provenance",
+    "cross-factor": "clawock.market_data.factors",
+    "daily-bars": "clawock.market_data.bars",
+    "dashboard-build": "clawock.publish.dashboard",
+    "dashboard-outputs": "clawock.publish.outputs",
+    "earnings": "clawock.decision.earnings",
+    "em-news": "clawock.market_data.eastmoney_news",
+    "entry-gate": "clawock.decision.entry",
+    "evaluate-combined-regime": "clawock.evaluation.combined_regime",
+    "evaluate-hstech-regime": "clawock.evaluation.hstech_regime",
+    "evaluate-us-leverage": "clawock.evaluation.us_leverage",
+    "evidence": "clawock.evidence.build_evidence",
+    "fetch-peers": "clawock.market_data.peer_quotes",
+    "filings": "clawock.market_data.filings",
+    "fundamentals": "clawock.market_data.fundamentals",
+    "fundflow": "clawock.market_data.fund_flows",
+    "fx": "clawock.portfolio.fx",
+    "integrity": "clawock.portfolio.integrity",
+    "macro": "clawock.market_data.macro",
+    "mark-followed": "clawock.decision.execution",
+    "mover-evidence": "clawock.market_data.mover_evidence",
+    "news-evidence": "clawock.evidence.news_evidence_graph",
+    "peer-residual": "clawock.market_data.peer_residuals",
+    "plan-context": "clawock.decision.plans",
+    "portfolio-risk": "clawock.portfolio.risk",
+    "provenance": "clawock.evidence.research_provenance",
+    "quant": "clawock.decision.signals",
+    "quant-review": "clawock.decision.signal_review",
+    "realized": "clawock.portfolio.realized",
+    "reconcile": "clawock.portfolio.reconcile",
+    "regime": "clawock.decision.regime",
+    "research": "clawock.evidence.research_surface",
+    "risk": "clawock.decision.risk",
+    "run-card": "clawock.evidence.run_card",
+    "sentiment": "clawock.market_data.sentiment",
+    "shadow": "clawock.portfolio.shadow",
+    "t0": "clawock.decision.setups",
+    "t0-review": "clawock.decision.setup_review",
+    "thesis": "clawock.decision.theses",
+    "us-quotes": "clawock.market_data.us_quotes",
+    "validate-regime-dial": "clawock.evaluation.regime_validation",
+    "validate-sidecar": "clawock.publish.artifacts",
+}
 
+# Its own exit-code convention: a partial peer fetch must not read as success.
+HARD_EXIT_UTILITIES = frozenset({"fetch-peers"})
+
+# These scan `argv` for flags by hand instead of using argparse, so `--help` is
+# not a flag to them — it is an unrecognised token they ignore while going on to
+# do the real work. `clawock analyze-hk --help` fetched live quotes and rewrote
+# portfolio.json. Answering here keeps that one input from reaching them; their
+# contract is the module docstring, which is what gets printed.
+DOCSTRING_HELP_UTILITIES = frozenset({
+    "analyze-hk", "analyze-us", "fetch-peers", "filings", "fundamentals",
+    "fundflow", "quant", "quant-review", "t0", "t0-review", "us-quotes",
+})
 
 def main(argv=None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)

--- a/src/clawock/evaluation/combined_regime.py
+++ b/src/clawock/evaluation/combined_regime.py
@@ -19,6 +19,7 @@ Outputs: results table + memory/.tmp/combined_*.png
 Run: clawock evaluate-combined-regime
 """
 import json
+import argparse
 import math
 from datetime import date
 from pathlib import Path
@@ -148,7 +149,9 @@ def _plotting():
     return plt, mdates
 
 
-def main():
+def main(argv=None):
+    argparse.ArgumentParser(prog='clawock evaluate-combined-regime',
+                            description=__doc__).parse_args(argv)
     plt, mdates = _plotting()
     plt.rcParams.update({'figure.facecolor': '#0f172a', 'axes.facecolor': '#0f172a',
                          'axes.edgecolor': '#334155', 'text.color': '#e2e8f0',
@@ -293,4 +296,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/src/clawock/evaluation/hstech_regime.py
+++ b/src/clawock/evaluation/hstech_regime.py
@@ -187,10 +187,16 @@ def run(ma=200, vol_cap=0.50, vol_n=20):
     return measured
 
 
-if __name__ == '__main__':
-    ap = argparse.ArgumentParser()
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog='clawock evaluate-hstech-regime',
+                                 description=__doc__)
     ap.add_argument('--ma', type=int, default=200)
     ap.add_argument('--vol-cap', type=float, default=0.50)
     ap.add_argument('--vol-n', type=int, default=20)
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
     run(ma=args.ma, vol_cap=args.vol_cap, vol_n=args.vol_n)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/clawock/evaluation/regime_validation.py
+++ b/src/clawock/evaluation/regime_validation.py
@@ -382,7 +382,9 @@ def sensitivity_surface(closes, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID):
 
 # ── CLI ─────────────────────────────────────────────────────────────────────
 
-def main() -> int:
+def main(argv=None) -> int:
+    argparse.ArgumentParser(prog='clawock validate-regime-dial',
+                            description=__doc__).parse_args(argv)
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--folds', type=int, default=4)
     ap.add_argument('--permutations', type=int, default=2000)

--- a/src/clawock/evaluation/us_leverage.py
+++ b/src/clawock/evaluation/us_leverage.py
@@ -13,6 +13,7 @@ Outputs:
 
 Run: clawock evaluate-us-leverage
 """
+import argparse
 import math
 from datetime import date
 from pathlib import Path
@@ -139,7 +140,9 @@ COLORS = {'bh2': '#ef4444', 'reg': '#f59e0b', 'rgv': '#a855f7', 'r1x': '#22c55e'
 LBL = {'bh1': '标的 1x 持有', 'bh2': '2x ETF 死扛', 'reg': 'Regime 2x', 'rgv': 'Regime+Vol 2x', 'r1x': 'Regime 1x(降杠杆)'}
 
 
-def main():
+def main(argv=None):
+    argparse.ArgumentParser(prog='clawock evaluate-us-leverage',
+                            description=__doc__).parse_args(argv)
     plt, mdates = _plotting()
     plt.rcParams.update({'figure.facecolor': '#0f172a', 'axes.facecolor': '#0f172a',
                          'axes.edgecolor': '#334155', 'text.color': '#e2e8f0',
@@ -237,4 +240,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/src/clawock/market_data/filings.py
+++ b/src/clawock/market_data/filings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fetch_us_filings.py - SEC EDGAR fundamentals + filings fetcher (no API key required)
+clawock filings — SEC EDGAR fundamentals + filings fetcher (no API key required)
 
 Covers gaps in US market data: 10-K/10-Q sections, Form 4 insider trades,
 13F institutional holdings, and XBRL-derived key financials. All free, direct

--- a/src/clawock/market_data/fund_flows.py
+++ b/src/clawock/market_data/fund_flows.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fetch_fundflow_em.py - 东财 push2his 日级资金流 (美股 + 港股, 无 key)
+clawock fundflow — 东财 push2his 日级资金流 (美股 + 港股, 无 key)
 
 Adapted and modified from global-stock-data
 (https://github.com/simonlin1212/global-stock-data, Apache-2.0). See NOTICE.

--- a/src/clawock/market_data/fundamentals.py
+++ b/src/clawock/market_data/fundamentals.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fetch_fundamentals_em.py - 东财 datacenter 基本面 (美股 + 港股, 无 key)
+clawock fundamentals — 东财 datacenter 基本面 (美股 + 港股, 无 key)
 
 Adapted and modified from global-stock-data
 (https://github.com/simonlin1212/global-stock-data, Apache-2.0). See NOTICE.

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-analyze_hk_stocks.py - HK portfolio price refresh + news + signal generation
+clawock analyze-hk — HK portfolio price refresh + news + signal generation
 
 Provider: Tencent qt.gtimg.cn (no key, real-time, works outside HK)
 Indices:  r_hkHSI / r_hkHSTECH via same API

--- a/src/clawock/market_data/peer_quotes.py
+++ b/src/clawock/market_data/peer_quotes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fetch_peers.py — fetch current price + 5-day P&L for peer tickers.
+clawock fetch-peers — current price + 5-day P&L for peer tickers.
 
 Used by brief_preflight to enrich context.json with peer_scan data.
 

--- a/src/clawock/market_data/us_analysis.py
+++ b/src/clawock/market_data/us_analysis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-analyze_us_stocks.py - US portfolio analysis for active holdings
+clawock analyze-us — US portfolio analysis for active holdings
 Steps:
   1. Fetch fresh prices via fetch_us_stocks (multi-provider)
   2. Pull RSI from Yahoo daily history (free, no rate limit)

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fetch_us_stocks.py - Multi-provider US stock price fetcher
+clawock us-quotes — multi-provider US stock price fetcher
 Reads active holdings (shares > 0) from portfolio.json.
 
 Provider chain:

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -52,6 +52,7 @@ cost_basis/prev_close/trades[])复原，且都有一道闸守着。计算链：
   clawock integrity [portfolio.json]   # 默认 workspace 根 portfolio.json
   退出码：0=全过或仅 WARN；2=有 ERROR（调用方应阻止发布/投递）
 """
+import argparse
 import json
 import sys
 from datetime import date, datetime, timedelta
@@ -452,7 +453,11 @@ def check(portfolio_path=PORTFOLIO):
 
 def main(argv=None):
     argv = sys.argv[1:] if argv is None else argv
-    path = Path(argv[0]) if argv else PORTFOLIO
+    parser = argparse.ArgumentParser(
+        prog='clawock integrity', description=__doc__.strip().splitlines()[0])
+    parser.add_argument('portfolio', nargs='?', type=Path, default=PORTFOLIO,
+                        help='ledger to check (default: this workspace)')
+    path = parser.parse_args(argv).portfolio
     report = check(path)
     safe_write_json(str(OUT), report)
 

--- a/src/clawock/publish/artifacts.py
+++ b/src/clawock/publish/artifacts.py
@@ -6,6 +6,7 @@ Run as ``clawock validate-sidecar <name>``.
 from __future__ import annotations
 
 import csv
+import argparse
 import json
 import math
 import os
@@ -988,6 +989,13 @@ def validate_coverage_badge(path: Path | str = 'assets/data/coverage.json') -> N
     print(f'validated {path}: {label} {message}')
 
 
+# The one list of what this command accepts: the CLI's `choices=` and the
+# dispatch below both read it, so a new validator cannot be reachable from one
+# and invisible to the other.
+VALIDATORS = ('macro', 'sentiment', 'influencer', 'news-digest', 'eod-archive',
+              'weekly-review', 'screenshots', 'gif', 'dashboard', 'coverage')
+
+
 def _dispatch(name: str) -> None:
     os.chdir(ROOT)
     if name == 'macro':
@@ -1021,17 +1029,18 @@ def _dispatch(name: str) -> None:
     elif name == 'coverage':
         validate_coverage_badge('assets/data/coverage.json')
     else:
-        choices = ('macro', 'sentiment', 'influencer', 'news-digest',
-                   'eod-archive', 'weekly-review', 'screenshots', 'gif',
-                   'dashboard', 'coverage')
-        raise SystemExit(f'unknown validator {name!r}; choose one of: {", ".join(choices)}')
+        raise SystemExit(
+            f'unknown validator {name!r}; choose one of: {", ".join(VALIDATORS)}')
 
 
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
-    if len(argv) != 1:
-        print('usage: clawock validate-sidecar <name>', file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser(
+        prog='clawock validate-sidecar',
+        description='Check one published artifact against its structural contract.')
+    parser.add_argument('name', choices=VALIDATORS,
+                        help='the artifact to validate')
+    argv = [parser.parse_args(argv).name]
     try:
         _dispatch(argv[0])
     except SystemExit:

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -110,3 +110,73 @@ def test_external_agent_can_repair_then_publish_one_certified_generation(tmp_pat
     assert manifest["generation_id"] == receipt.generation_id
     assert manifest["context"]["documents"][0]["name"] == "CONTEXT.md"
     assert len(manifest["context"]["documents"][0]["sha256"]) == 64
+
+
+def test_every_packaged_utility_is_actually_callable():
+    """Each table entry must import and expose a `main` that takes argv.
+
+    #429 added four `evaluate-*` commands to the name list without touching the
+    dispatch chain beside it: one module had no `main` at all and three had
+    `main()` with no parameters, so every invocation — `--help` included — died
+    on ImportError or TypeError. Nothing noticed, because no test ever asked the
+    CLI to reach them. The two are one table now; this asserts the table resolves.
+    """
+    import importlib
+    import inspect
+
+    from clawock.cli import HARD_EXIT_UTILITIES, PACKAGED_UTILITIES
+
+    broken = []
+    for command, target in sorted(PACKAGED_UTILITIES.items()):
+        try:
+            module = importlib.import_module(target)
+        except Exception as exc:
+            broken.append(f"{command}: {target} does not import ({exc})")
+            continue
+        entry = getattr(module, "main", None)
+        if entry is None:
+            broken.append(f"{command}: {target} has no main()")
+            continue
+        try:
+            inspect.signature(entry).bind([])
+        except TypeError:
+            broken.append(f"{command}: {target}.main() does not accept argv")
+        if command in HARD_EXIT_UTILITIES and not hasattr(module, "hard_exit"):
+            broken.append(f"{command}: {target} has no hard_exit()")
+    assert not broken, "packaged utilities the CLI cannot reach:\n" + "\n".join(broken)
+
+
+def test_every_packaged_utility_answers_help_without_running_anything():
+    """`--help` is the first thing anyone types, and it must not do work.
+
+    Two separate failures hid here. Some utilities took `argv[0]` as a path, so
+    `--help` came back as a FileNotFoundError traceback. Worse, eleven scan argv
+    for flags by hand and simply ignore anything they do not recognise — so
+    `clawock analyze-hk --help` fetched live quotes and rewrote portfolio.json.
+
+    Driven through `cli.main`, because that is the surface a user touches; the
+    module's own `main` is not where the guarantee has to hold.
+    """
+    import io
+    from contextlib import redirect_stdout, redirect_stderr
+
+    from clawock import cli
+
+    bad = []
+    for command in sorted(cli.PACKAGED_UTILITIES):
+        out = io.StringIO()
+        try:
+            with redirect_stdout(out), redirect_stderr(out):
+                returned = cli.main([command, "--help"])
+        except SystemExit as exit_code:
+            if exit_code.code not in (0, None):
+                bad.append(f"{command}: --help exited {exit_code.code}")
+        except Exception as exc:
+            bad.append(f"{command}: --help raised {type(exc).__name__}: {exc}")
+            continue
+        else:
+            if returned not in (0, None):
+                bad.append(f"{command}: --help returned {returned}")
+        if "usage" not in out.getvalue().lower():
+            bad.append(f"{command}: --help printed no usage line")
+    assert not bad, "utilities that mishandle --help:\n" + "\n".join(bad)


### PR DESCRIPTION
Closes #432 — and the issue understated it. Two of the findings are not help-text
problems at all.

## Four commands were dead on arrival

#429 added `evaluate-combined-regime`, `evaluate-hstech-regime`,
`evaluate-us-leverage` and `validate-regime-dial` to the packaged-utility name
list without touching the 48-branch dispatch chain sitting right beside it:

```
$ clawock evaluate-hstech-regime
ImportError: cannot import name 'main' from clawock.evaluation.hstech_regime
$ clawock validate-regime-dial
TypeError: main() takes 0 positional arguments but 1 was given
```

`hstech_regime` kept its argument parsing under `if __name__ == '__main__'`, so
there was no `main` to import; the other three have one that takes no argv. Not a
`--help` issue — every invocation failed. The name list and the chain are now a
single `PACKAGED_UTILITIES` table mapping command to module, so the two halves
cannot disagree again.

## `--help` was doing real work

Eleven utilities scan `argv` for flags by hand. An unrecognised token is not an
error to them — it is ignored, and they proceed:

```
$ clawock analyze-hk --help      # fetched live HK quotes and rewrote portfolio.json
```

A read-only-looking flag performing a live ledger write is worse than the
traceback the issue was filed for. The dispatcher now answers `--help` for those
eleven from the module docstring before the argv reaches them. Their first
docstring lines were still the pre-#429 script filenames
(`analyze_hk_stocks.py - …`), which is now the help text a user reads, so those
are corrected too.

`integrity` and `validate-sidecar` read `--help` as a filename; both take argparse.
`validate-sidecar`'s ten valid names were duplicated between its error message and
its dispatch — now one `VALIDATORS` constant feeding both `choices=` and the branch.

## Guards

Two checks over the table, both through `cli.main` because that is the surface a
user touches:

- every entry imports and exposes a `main` that accepts argv (and `hard_exit`
  where the table says so);
- every entry answers `--help` with usage, exit 0, and no side effects.

Mutation-verified three ways — removing `hstech_regime.main`, dropping one command
from the docstring-help set, and restoring `integrity`'s positional read — each
reds exactly the check that owns it. 2.1s for both.

Verified by hand across all 49 commands before and after: 43 → 49 answering
`--help` cleanly, and `git status` clean afterwards, which it was not before.
