### PR TITLE
fix: send provider credentials in headers, not the request URL

### DIFF
--- a/src/clawock/market_data/benchmarks.py
+++ b/src/clawock/market_data/benchmarks.py
@@ -52,10 +52,17 @@ def fetch_polygon_daily(ticker: str, days: int, api_key: str) -> List[Dict]:
     url = (
         f'https://api.polygon.io/v2/aggs/ticker/{ticker}'
         f'/range/1/day/{start.isoformat()}/{end.isoformat()}'
-        f'?adjusted=true&sort=asc&limit=400&apiKey={api_key}'
     )
     try:
-        r = requests.get(url, timeout=TIMEOUT)
+    # Credential goes in a header, never the URL: a query-string secret ends up
+    # in proxy logs, crash dumps and Referer, and taints every value derived from
+    # the response for any dataflow analysis reading this file.
+        r = requests.get(
+            url,
+            params={'adjusted': 'true', 'sort': 'asc', 'limit': 400},
+            headers={'Authorization': f'Bearer {api_key}'},
+            timeout=TIMEOUT,
+        )
         data = r.json()
         results = data.get('results') or []
         out = []

--- a/src/clawock/market_data/us_analysis.py
+++ b/src/clawock/market_data/us_analysis.py
@@ -142,9 +142,13 @@ def get_news(ticker: str, api_key: str, days: int = 7) -> List[Dict]:
     start = (now - timedelta(days=days)).strftime('%Y-%m-%d')
     end   = now.strftime('%Y-%m-%d')
     try:
+    # Credential goes in a header, never the URL: a query-string secret ends up
+    # in proxy logs, crash dumps and Referer, and taints every value derived from
+    # the response for any dataflow analysis reading this file.
         r = SESSION.get(
-            f"https://finnhub.io/api/v1/company-news?symbol={ticker}"
-            f"&from={start}&to={end}&token={api_key}",
+            "https://finnhub.io/api/v1/company-news",
+            params={'symbol': ticker, 'from': start, 'to': end},
+            headers={'X-Finnhub-Token': api_key},
             timeout=TIMEOUT,
         )
         return r.json()[:5] if isinstance(r.json(), list) else []

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -365,8 +365,13 @@ def get_finnhub_quote(ticker: str, api_key: str) -> Optional[Dict]:
     if not api_key:
         return None
     try:
+    # Credential goes in a header, never the URL: a query-string secret ends up
+    # in proxy logs, crash dumps and Referer, and taints every value derived from
+    # the response for any dataflow analysis reading this file.
         r = SESSION.get(
-            f"https://finnhub.io/api/v1/quote?symbol={ticker}&token={api_key}",
+            "https://finnhub.io/api/v1/quote",
+            params={'symbol': ticker},
+            headers={'X-Finnhub-Token': api_key},
             timeout=TIMEOUT,
         )
         d = r.json()


### PR DESCRIPTION
CodeQL alert #15 (`py/clear-text-logging-sensitive-data`, high) points at a print of
a news headline in `us_analysis.py`. The label is wrong — the value is a headline, not
a password — but the dataflow behind it is right: the Finnhub key was interpolated
into the request URL, so CodeQL treats the whole response, and everything derived from
it, as credential-derived. Suppressing the alert would leave the actual issue.

The actual issue is the URL. A query-string secret ends up in proxy logs, crash
dumps, browser Referer headers and anything that records a request line. Three call
sites did it:

| call | before | after |
|---|---|---|
| `us_analysis.get_news` | `…&token={api_key}` | `params=` + `X-Finnhub-Token` header |
| `us_quotes.get_finnhub_quote` | `…&token={api_key}` | `params=` + `X-Finnhub-Token` header |
| `benchmarks.fetch_polygon_daily` | `…&apiKey={api_key}` | `params=` + `Authorization: Bearer` |

No interpolated credential remains anywhere under `src/`.

## Verified against the live APIs, not just imports

These are live market-data paths, so header auth had to be proven to actually
authenticate rather than silently fall back:

```
finnhub quote MSFT : 499.99 | prev 499.86
finnhub news MSFT  : 5 | 'Very little to like': Wall Street assesses surprise Ju…
polygon SPY bars   : 7 | {'date': '2026-08-07', 'close': 773.26}
```

No test added: the guarantee here is "the provider still answers", which only a real
call can show, and the suite must not depend on network or on a key being present.
The three fetchers are already exercised end to end by the live crons every session.
