### PR TITLE
feat: PyPI-ready metadata and a tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+# Tag-triggered, never automatic on merge: publishing a version to PyPI cannot be
+# undone — the version number is burned even if the release is yanked. The tag is
+# the human decision, and the `pypi` environment lets that decision carry a
+# required reviewer as well.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'index to publish to'
+        required: true
+        default: testpypi
+        type: choice
+        options: [testpypi, pypi]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Build sdist and wheel
+        run: |
+          pip install --quiet build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Tag matches the packaged version
+        # A tag that disagrees with pyproject publishes a version nobody asked
+        # for, under a name that already means something else in the changelog.
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          packaged=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          tagged=${GITHUB_REF_NAME#v}
+          [ "$packaged" = "$tagged" ] || {
+            echo "::error::tag $GITHUB_REF_NAME does not match version $packaged"
+            exit 1
+          }
+
+      - name: Isolated install completes one real run
+        # The acceptance for #379, executed against the artifact about to ship
+        # rather than the source tree: a clean environment, no checkout, no
+        # OpenClaw, no KCNyu workspace. `env -i` is the point — it proves the
+        # package is not reading a variable this runner happens to export.
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/isolated
+          /tmp/isolated/bin/pip install --quiet dist/*.whl
+          mkdir -p /tmp/newuser && cd /tmp/newuser
+          env -i PATH=/usr/bin:/bin HOME=/tmp /tmp/isolated/bin/clawock init book
+          cd book
+          mkdir -p .clawock/work
+          env -i PATH=/usr/bin:/bin HOME=/tmp CLAWOCK_WORKSPACE="$PWD" \
+            /tmp/isolated/bin/clawock run prepare > .clawock/work/request.json
+          echo '{"answer":"smoke"}' > .clawock/work/answer.json
+          env -i PATH=/usr/bin:/bin HOME=/tmp CLAWOCK_WORKSPACE="$PWD" \
+            /tmp/isolated/bin/clawock run publish \
+              --request .clawock/work/request.json \
+              --artifact answer=.clawock/work/answer.json > receipt.json
+          python - <<'PY'
+          import json
+          receipt = json.load(open('receipt.json'))
+          assert receipt['status'] == 'published', receipt
+          assert len(receipt['generation_id']) == 32, receipt
+          names = {artifact['name'] for artifact in receipt['artifacts']}
+          assert {'answer', 'manifest.json'} <= names, names
+          print('isolated run published', receipt['run_id'])
+          PY
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Trusted publishing: PyPI verifies this workflow's OIDC identity, so there is
+    # no long-lived API token in repository secrets to leak or rotate. One-time
+    # setup on the PyPI side is documented in docs/operations/release.md.
+    environment: ${{ inputs.repository || 'pypi' }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build sdist and wheel
         run: |
-          pip install --quiet build twine
+          pip install --quiet -e '.[release]'
           python -m build
           python -m twine check dist/*
 
@@ -57,6 +57,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv /tmp/isolated
+          # Not a dependency list: this installs the artifact under test.
           /tmp/isolated/bin/pip install --quiet dist/*.whl
           mkdir -p /tmp/newuser && cd /tmp/newuser
           env -i PATH=/usr/bin:/bin HOME=/tmp /tmp/isolated/bin/clawock init book

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,0 +1,60 @@
+# Releasing `clawock` to PyPI
+
+Only the runtime-neutral `clawock` distribution is ever published.
+`clawock-kcnyu` is this repository's live-instance adapter: it may be installed
+locally and in CI, but it must never reach an index, be pulled in by the public
+package, or appear in a quickstart an ordinary user follows.
+
+## One-time setup (kcn, on the PyPI side)
+
+Trusted publishing is used instead of an API token, so nothing long-lived sits
+in repository secrets. Configure the publisher at
+<https://pypi.org/manage/account/publishing/> with:
+
+| field | value |
+|---|---|
+| PyPI project name | `clawock` |
+| Owner | `KCNyu` |
+| Repository name | `clawock` |
+| Workflow name | `release.yml` |
+| Environment name | `pypi` |
+
+Repeat on <https://test.pypi.org/manage/account/publishing/> with environment
+name `testpypi` to be able to rehearse.
+
+Then create the two GitHub environments (`Settings → Environments`): `pypi` and
+`testpypi`. Adding yourself as a required reviewer on `pypi` is worth it — the
+release job then waits for an explicit approval, and a version number, once
+published, cannot be reused even after a yank.
+
+## Rehearse on TestPyPI
+
+`Actions → Release → Run workflow`, leaving `repository` at `testpypi`. This runs
+the same build and the same isolated-install check without touching the real
+index.
+
+## Release
+
+```bash
+# version lives in exactly one place
+sed -i 's/^version = .*/version = "0.2.0"/' pyproject.toml
+# ...open a PR, merge it, then tag the merge commit
+git tag v0.2.0 && git push origin v0.2.0
+```
+
+The workflow refuses a tag that disagrees with `pyproject.toml`, because a
+mismatch publishes a version nobody asked for under a name the changelog already
+uses for something else.
+
+## What the release job proves before it publishes
+
+- `twine check` on both the sdist and the wheel.
+- The tag matches the packaged version.
+- A clean virtualenv installs the wheel and completes one real run —
+  `clawock init` → `clawock run prepare` → `clawock run publish` — under
+  `env -i`, with no checkout, no OpenClaw, no KCNyu workspace and no inherited
+  environment, then asserts the receipt carries a 32-character `generation_id`
+  and both the supplied artifact and its manifest.
+
+That last step is the acceptance criterion of #379, executed against the exact
+artifact about to ship rather than against the source tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,29 @@ description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
+authors = [{ name = "Shengyu Li" }]
+keywords = [
+    "agent", "llm", "decision-workflow", "harness", "portfolio", "provenance",
+    "reconciliation", "evidence", "audit", "mcp",
+]
+# Trove classifiers are how PyPI's own search and category filters see this
+# package. Without them it is unlisted everywhere a prospective user would
+# browse, and nothing local ever shows it: `pip install -e .` never renders a
+# project page.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 
 # The one place dependencies are declared. They used to live in nine workflow
 # files as drifting `pip install` lines — `requests` in seven, `requests numpy`
@@ -28,6 +51,13 @@ evaluation = ["numpy>=1.26", "matplotlib>=3.8"]
 imaging = ["Pillow>=10"]
 # Everything the test suite needs to *collect*, not just to pass.
 test = ["pytest>=8", "pytest-cov>=5", "numpy>=1.26", "Pillow>=10"]
+
+[project.urls]
+Homepage = "https://github.com/KCNyu/clawock"
+Documentation = "https://kcnyu.github.io/clawock/"
+Source = "https://github.com/KCNyu/clawock"
+Issues = "https://github.com/KCNyu/clawock/issues"
+Evidence = "https://kcnyu.github.io/clawock/evidence.html"
 
 [project.scripts]
 clawock = "clawock.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ compute = ["numpy>=1.26"]
 evaluation = ["numpy>=1.26", "matplotlib>=3.8"]
 # Screenshot and social-card validation.
 imaging = ["Pillow>=10"]
+# Building and checking a distribution. Here rather than in the release workflow
+# for the same reason as everything else in this table: a version pinned in a
+# workflow line is a second source of truth that drifts unseen.
+release = ["build>=1.2", "twine>=5"]
 # Everything the test suite needs to *collect*, not just to pass.
 test = ["pytest>=8", "pytest-cov>=5", "numpy>=1.26", "Pillow>=10"]
 

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -66,7 +66,14 @@ def _run_publish(args) -> int:
         request = load_request(args.workspace)
         state_path = args.request.expanduser().resolve()
         state_root = (request.workspace / ".clawock" / "work").resolve()
-        state_path.relative_to(state_root)
+        if not state_path.is_relative_to(state_root):
+            # The boundary is deliberate — a request from anywhere else has no
+            # provenance — but `relative_to` reports it as a raw ValueError, and
+            # "'/x/req.json' is not in the subpath of '/x/.clawock/work'" tells a
+            # first-time user nothing about what to do instead.
+            raise ValueError(
+                f"prepared request must live under {state_root}; `clawock run prepare` "
+                f"writes one to {state_root}/<run_id>/request.json — pass that path")
         payload = json.loads(state_path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict) or payload.get("schema_version") != 1:
             raise ValueError("prepared request requires schema_version 1")
@@ -102,7 +109,9 @@ def _run_publish(args) -> int:
             if not source.is_absolute():
                 source = request.workspace / source
             source = source.resolve()
-            source.relative_to(request.workspace)
+            if not source.is_relative_to(request.workspace):
+                raise ValueError(
+                    f"artifact {name!r} is outside the workspace: {source}")
             if name in artifacts:
                 raise ValueError(f"duplicate artifact name: {name}")
             artifacts[name] = source.read_text(encoding="utf-8")
@@ -523,7 +532,10 @@ def main(argv=None) -> int:
     publish = run_steps.add_parser(
         "publish", help="validate and publish artifacts produced by the calling agent")
     publish.add_argument("--workspace", type=Path, default=Path.cwd())
-    publish.add_argument("--request", type=Path, required=True)
+    publish.add_argument(
+        "--request", type=Path, required=True,
+        help="the request `clawock run prepare` wrote to "
+             ".clawock/work/<run_id>/request.json")
     publish.add_argument("--artifact", action="append", default=[], metavar="NAME=PATH")
     publish.set_defaults(func=_run_publish)
 

--- a/tests/test_wheel_contains_the_package.py
+++ b/tests/test_wheel_contains_the_package.py
@@ -199,3 +199,44 @@ def test_every_module_imports_from_a_non_editable_install(tmp_path):
     assert manifest["workflow"] == request["workflow"]
     assert {item["generation_id"] for item in receipt["artifacts"]} == {
         receipt["generation_id"]}
+
+
+def test_the_wheel_carries_the_metadata_pypi_indexes_on(tmp_path):
+    """A package with no classifiers or project URLs is unlisted on PyPI.
+
+    Cheap to lose and invisible locally: `pip install -e .` never renders a
+    project page, so metadata can rot for months while every install works. The
+    build here is the same one the release workflow ships.
+    """
+    import email
+    import tomllib
+
+    source = tmp_path / "src"
+    source.mkdir()
+    shutil.copytree(ROOT / "src" / "clawock", source / "src" / "clawock",
+                    ignore=shutil.ignore_patterns("__pycache__"))
+    for name in BUILD_INPUTS:
+        shutil.copy2(ROOT / name, source / name)
+    build = tmp_path / "wheel"
+    done = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "--no-cache-dir",
+         "-w", str(build), str(source)],
+        capture_output=True, text=True, timeout=300)
+    assert done.returncode == 0, done.stderr[-2000:]
+
+    wheel = next(build.glob("clawock-*.whl"))
+    with zipfile.ZipFile(wheel) as archive:
+        name = next(n for n in archive.namelist() if n.endswith(".dist-info/METADATA"))
+        metadata = email.message_from_bytes(archive.read(name))
+
+    declared = tomllib.load(open(ROOT / "pyproject.toml", "rb"))["project"]
+    assert metadata["Version"] == declared["version"]
+    assert metadata["License-File"] or metadata["License"], "no license in the wheel"
+    assert metadata.get_all("Classifier"), "no trove classifiers — unlisted on PyPI"
+    assert any(c.startswith("License :: ") for c in metadata.get_all("Classifier"))
+    # Every URL PyPI shows in the sidebar has to resolve to something real.
+    urls = dict(
+        entry.split(", ", 1) for entry in (metadata.get_all("Project-URL") or [])
+    )
+    assert {"Homepage", "Source", "Issues"} <= set(urls), urls
+    assert metadata["Description-Content-Type"], "README would render as plain text"

--- a/tests/test_workspace_portability.py
+++ b/tests/test_workspace_portability.py
@@ -30,8 +30,12 @@ def test_no_workflow_reinstates_a_hand_written_package_list():
             stripped = line.split("#", 1)[0]
             if "pip install" not in stripped:
                 continue
-            # Installing the project (optionally with an extra) is the only
-            # accepted form; anything else is a package list growing back.
+            # Installing the project (optionally with an extra) is the accepted
+            # form; anything else is a package list growing back. Installing a
+            # distribution this workflow just built is not a package list — it is
+            # the artifact under test, and naming it is the point.
+            if re.search(r"pip install [^|;]*\bdist/\*", stripped):
+                continue
             if not re.search(r"-e\s+'?\.(\[[a-z,]+\])?'?", stripped):
                 offenders.append(f"{path.name}:{lineno}: {line.strip()}")
 


### PR DESCRIPTION
Toward #379. The acceptance criterion turned out to already pass — I ran it before
writing anything:

```
$ python -m build --wheel
$ python -m venv clean && clean/bin/pip install clawock-0.1.0-py3-none-any.whl
$ cd /tmp/newuser
$ env -i PATH=/usr/bin:/bin HOME=/tmp clean/bin/clawock init mybook
$ env -i … CLAWOCK_WORKSPACE=…/mybook clawock run prepare  > .clawock/work/request.json
$ env -i … clawock run publish --request … --artifact answer=…
{"status": "published", "generation_id": "3b3b66c8…", "artifacts": [answer, manifest.json]}
```

No checkout, no OpenClaw, no KCNyu workspace, `HOME` pointed away from `/root`.
So what is missing is not the lifecycle — it is everything around shipping it.

## Metadata

`pyproject.toml` had no `authors`, no `classifiers`, no `keywords` and no
`[project.urls]`. Trove classifiers are how PyPI's own search and category
filters see a package; without them it is unlisted in every category a
prospective user would browse. This is invisible locally forever, because
`pip install -e .` never renders a project page.

`test_the_wheel_carries_the_metadata_pypi_indexes_on` reads the built wheel's
METADATA and asserts version parity with `pyproject.toml`, a license, trove
classifiers, the three URLs PyPI puts in the sidebar, and a
`Description-Content-Type` (without it the README renders as plain text). It
reuses the build the existing wheel test already does. Mutation-verified by
deleting the classifiers block.

## Release workflow

Tag-triggered (`v*`) plus a manual TestPyPI rehearsal. **Nothing publishes on
merge** — a version number, once on PyPI, is burned even if the release is
yanked, so the tag is the human decision and the `pypi` environment lets that
decision carry a required reviewer. Trusted publishing via OIDC, so there is no
long-lived token in repository secrets.

Before it publishes it runs `twine check`, refuses a tag that disagrees with the
packaged version, and executes the isolated-install run above against the exact
artifact about to ship. One-time PyPI-side setup is in
`docs/operations/release.md`; it needs kcn's account and cannot be done from here.

## One rough edge fixed on the way

`clawock run publish --request req.json` answered:

```
'/x/req.json' is not in the subpath of '/x/.clawock/work'
```

A raw `Path.relative_to` ValueError. The boundary is deliberate — a request from
elsewhere has no provenance — but that message tells a first-time user nothing
about what to do, and `run prepare` prints to stdout, so putting the file in the
current directory is the natural first move. It now names the path `prepare`
actually wrote, and `--help` says so too. Same treatment for the artifact
boundary check.

## Not done here

The actual publish. That is kcn's call and needs the PyPI-side publisher
configured first; #379 stays open until a release exists and `pip install clawock`
from the real index is verified.
