### PR TITLE
feat: trace one dashboard generation from producer to browser

### DIFF
--- a/ops/pages/freshness.py
+++ b/ops/pages/freshness.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Trace one dashboard generation across every layer between producer and browser.
+
+Each layer already had a way to look healthy on its own. The publisher logs a
+successful build, the data branch shows a recent force-update, the Pages workflow
+reports success, and the site returns 200 — and the browser can still be reading
+a generation from yesterday, because "green" at one layer says nothing about
+whether the next one consumed it. Twice now the visible symptom was only that the
+dashboard "did not refresh".
+
+So this asks one question end to end: **which generation is each layer serving,
+and is the distance between them explainable?**
+
+    producer            the workspace that built it   assets/data/dashboard.json
+    data plane          orphan `data-plane` branch    the publisher force-updates
+    Pages deployment    the last successful deploy    what GitHub says it served
+    live                the URL a browser fetches     kcnyu.github.io/...
+
+A lag is not automatically a fault: the host publisher runs every 20 minutes, and
+a Pages deployment reports success roughly 14 minutes before the new content is
+actually served. Both are bounded and expected, so they are reported as
+`behind (within bound)` rather than as failures. Anything beyond that is a real
+stall and exits non-zero, because the whole point is that a frozen dashboard used
+to be indistinguishable from a quiet one.
+
+Read-only: no fetch, no build, no publish.
+
+Run: python3 ops/pages/freshness.py [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+CHECKOUT = Path(__file__).resolve().parents[2]
+PAYLOAD = "assets/data/dashboard.json"
+DATA_PLANE_REF = "origin/data-plane"
+LIVE_URL = f"https://kcnyu.github.io/clawock/{PAYLOAD}"
+
+# How far a layer may trail the newest generation before it is a stall rather
+# than a queue. Measured as reference.generated_at - layer.generated_at, NOT as
+# now - layer.generated_at: the second conflates "this generation is old" with
+# "the pipeline is stuck", and on a quiet night every layer would look stale
+# while being perfectly in sync.
+#
+# The host publisher runs at :00/:20/:40, so the data plane trails by up to one
+# tick plus the build.
+DATA_PLANE_BOUND = timedelta(minutes=25)
+# Then the dispatch, the Pages build, and a CDN propagation that lands roughly
+# 14 minutes after the deployment already reports success. One publisher tick on
+# top, because the deploy is triggered by the tick that produced the generation.
+LIVE_BOUND = timedelta(minutes=45)
+
+
+@dataclass
+class Layer:
+    name: str
+    # "generation" layers serve the payload and are compared by generation id.
+    # The deployment layer serves nothing — it records when GitHub last shipped —
+    # so comparing its commit sha against a generation id would mark it different
+    # every single time and then age it out. It is judged on timing instead.
+    kind: str = "generation"
+    generation: str | None = None
+    generated_at: datetime | None = None
+    detail: str = ""
+    problems: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.generation is not None and not self.problems
+
+
+def _parse(payload: str, name: str) -> Layer:
+    layer = Layer(name)
+    try:
+        data = json.loads(payload)
+    except Exception as exc:
+        layer.problems.append(f"unreadable payload: {exc}")
+        return layer
+    stamp = data.get("generated_at")
+    layer.generation = data.get("generation_id") or stamp
+    try:
+        layer.generated_at = datetime.fromisoformat(str(stamp).replace("Z", "+00:00"))
+    except Exception:
+        layer.problems.append(f"unparseable generated_at: {stamp!r}")
+    return layer
+
+
+def read_producer(workspace: Path) -> Layer:
+    path = workspace / PAYLOAD
+    if not path.is_file():
+        # Expected off the live host: the payloads are not tracked any more, so a
+        # fresh checkout has no producer layer to report. Absence is not a fault.
+        return Layer("producer", detail=f"no local {PAYLOAD} (not the producing host)")
+    layer = _parse(path.read_text(encoding="utf-8"), "producer")
+    layer.detail = str(path)
+    return layer
+
+
+def read_data_plane(checkout: Path) -> Layer:
+    fetch = subprocess.run(["git", "fetch", "--quiet", "origin", "data-plane"],
+                           cwd=checkout, capture_output=True, text=True)
+    show = subprocess.run(["git", "show", f"{DATA_PLANE_REF}:{PAYLOAD}"],
+                          cwd=checkout, capture_output=True, text=True)
+    if show.returncode != 0:
+        layer = Layer("data plane")
+        layer.problems.append(
+            (fetch.stderr or show.stderr or "branch not readable").strip()[:200])
+        return layer
+    layer = _parse(show.stdout, "data plane")
+    layer.detail = DATA_PLANE_REF
+    return layer
+
+
+def read_deployment() -> Layer:
+    """What GitHub says it last deployed, via `gh`. Optional: no token, no layer."""
+    layer = Layer("pages deployment", kind="deployment")
+    done = subprocess.run(
+        ["gh", "api", "repos/KCNyu/clawock/deployments?environment=github-pages&per_page=1",
+         "--jq", ".[0] | {created_at, sha}"],
+        capture_output=True, text=True)
+    if done.returncode != 0:
+        layer.detail = "gh unavailable or unauthenticated — layer skipped"
+        return layer
+    try:
+        info = json.loads(done.stdout or "{}")
+        layer.generated_at = datetime.fromisoformat(
+            info["created_at"].replace("Z", "+00:00"))
+        layer.generation = info.get("sha", "")[:12]
+        layer.detail = f"deployment {layer.generation}"
+    except Exception as exc:
+        layer.problems.append(f"unreadable deployment: {exc}")
+    return layer
+
+
+def read_live(url: str = LIVE_URL) -> Layer:
+    try:
+        import requests
+        response = requests.get(url, timeout=20)
+        response.raise_for_status()
+    except Exception as exc:
+        layer = Layer("live")
+        layer.problems.append(f"{type(exc).__name__}: {exc}")
+        return layer
+    layer = _parse(response.text, "live")
+    layer.detail = url
+    return layer
+
+
+def assess(layers: list[Layer], now: datetime | None = None) -> dict:
+    """Same generation everywhere, or a lag each side can be held to."""
+    now = now or datetime.now(timezone.utc)
+    reference = next((layer for layer in layers
+                      if layer.name == "producer" and layer.ok), None)
+    reference = reference or next((layer for layer in layers if layer.ok), None)
+
+    findings: list[str] = []
+    live = next((layer for layer in layers if layer.name == "live" and layer.ok), None)
+    rows = []
+    for layer in layers:
+        status = "ok"
+        note = layer.detail
+        if layer.problems:
+            status = "unreachable"
+            note = "; ".join(layer.problems)
+            findings.append(f"{layer.name}: {note}")
+        elif layer.generation is None:
+            status = "skipped"
+        elif layer.kind == "deployment":
+            # Consistent means "the generation the browser is being served has
+            # already been deployed". A deployment older than what is live would
+            # mean the site is serving something GitHub never shipped.
+            if live and live.generated_at and layer.generated_at:
+                if layer.generated_at >= live.generated_at:
+                    note = f"shipped {layer.generation} after the live generation"
+                else:
+                    behind = live.generated_at - layer.generated_at
+                    if behind <= LIVE_BOUND:
+                        status = "deploy pending"
+                        note = (f"newest generation is {int(behind.total_seconds() // 60)}m "
+                                f"newer than the last deploy, bound "
+                                f"{int(LIVE_BOUND.total_seconds() // 60)}m")
+                    else:
+                        status = "STALE"
+                        note = (f"last deploy is {int(behind.total_seconds() // 60)}m "
+                                f"older than the live generation")
+                        findings.append(f"{layer.name} is stale: {note}")
+            else:
+                status = "skipped"
+                note = "no live layer to compare against"
+        elif reference and layer.generation != reference.generation:
+            bound = {"data plane": DATA_PLANE_BOUND}.get(layer.name, LIVE_BOUND)
+            behind = (
+                reference.generated_at - layer.generated_at
+                if layer.generated_at and reference.generated_at else None)
+            if behind is not None and behind <= bound:
+                status = "behind (within bound)"
+                note = (f"{int(behind.total_seconds() // 60)}m behind the newest "
+                        f"generation, bound {int(bound.total_seconds() // 60)}m")
+            else:
+                status = "STALE"
+                age = (f"{int(behind.total_seconds() // 60)}m behind"
+                       if behind else "distance unknown")
+                note = f"{age} the newest generation, past the {int(bound.total_seconds() // 60)}m bound"
+                findings.append(f"{layer.name} is stale: {note}")
+        rows.append({
+            "layer": layer.name,
+            "generation": layer.generation,
+            "generated_at": layer.generated_at.isoformat() if layer.generated_at else None,
+            "status": status,
+            "note": note,
+        })
+
+    return {
+        "checked_at": now.isoformat(),
+        "reference": reference.generation if reference else None,
+        "layers": rows,
+        "consistent": all(row["status"] in ("ok", "skipped") for row in rows),
+        "findings": findings,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python3 ops/pages/freshness.py",
+        description="Trace one dashboard generation from producer to browser.")
+    parser.add_argument("--workspace", type=Path, default=Path("/root/.openclaw/workspace"),
+                        help="the producing workspace (default: the live host's)")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    layers = [read_producer(args.workspace), read_data_plane(CHECKOUT),
+              read_deployment(), read_live()]
+    report = assess(layers)
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(f"reference generation: {report['reference']}\n")
+        print(f"{'layer':<18}{'status':<22}{'generated_at':<34}note")
+        print("─" * 110)
+        for row in report["layers"]:
+            print(f"{row['layer']:<18}{row['status']:<22}"
+                  f"{str(row['generated_at'] or '—'):<34}{row['note']}")
+        print()
+        if report["consistent"]:
+            print("✅ every layer is serving the same generation")
+        elif report["findings"]:
+            for finding in report["findings"]:
+                print(f"🔴 {finding}")
+        else:
+            print("🟡 layers differ, all within their documented bounds")
+    return 0 if not report["findings"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_freshness_trace.py
+++ b/tests/test_freshness_trace.py
@@ -1,0 +1,96 @@
+"""The freshness verdict, on synthetic layer readings.
+
+Only `assess()` is tested. The readers talk to git, `gh` and the live site, and a
+test that mocked all three would assert my mocks rather than the pipeline. What
+has to be right is the judgement: a lag that is expected must not read as a
+fault, and a fault must not read as a lag. Both directions cost something real —
+the first trains everyone to ignore the tool, the second is the frozen dashboard
+it exists to catch.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "pages"))
+
+import freshness  # noqa: E402
+
+NOW = datetime(2026, 8, 9, 14, 30, tzinfo=timezone.utc)
+
+
+def _layer(name, minutes_old, *, kind="generation"):
+    at = NOW - timedelta(minutes=minutes_old)
+    return freshness.Layer(name, kind=kind, generation=at.isoformat(), generated_at=at)
+
+
+def _status(report, name):
+    return next(row["status"] for row in report["layers"] if row["layer"] == name)
+
+
+def test_one_generation_everywhere_is_consistent():
+    report = freshness.assess(
+        [_layer("producer", 2), _layer("data plane", 2), _layer("live", 2)], now=NOW)
+    assert report["consistent"] and not report["findings"]
+
+
+def test_a_layer_inside_its_bound_is_a_queue_not_a_fault():
+    """Measured against the newest generation, not against the clock.
+
+    `now - layer.generated_at` looks equivalent and is not: at 03:00, with the
+    market shut and nothing new produced, every layer would be hours "old" while
+    being perfectly in sync — and during the day a healthy live layer reads as
+    stale for the entire propagation window. The first live run of this tool
+    reported exactly that false alarm.
+    """
+    report = freshness.assess(
+        [_layer("producer", 0), _layer("data plane", 5), _layer("live", 20)], now=NOW)
+
+    assert _status(report, "data plane") == "behind (within bound)"
+    assert _status(report, "live") == "behind (within bound)"
+    assert not report["findings"], report["findings"]
+
+    # Same shape, two hours later with nothing new produced: still no alarm.
+    quiet = freshness.assess(
+        [_layer("producer", 120), _layer("data plane", 125), _layer("live", 140)],
+        now=NOW + timedelta(hours=2))
+    assert not quiet["findings"], quiet["findings"]
+
+
+def test_a_layer_past_its_bound_is_a_finding():
+    report = freshness.assess(
+        [_layer("producer", 0), _layer("data plane", 5), _layer("live", 90)], now=NOW)
+
+    assert _status(report, "live") == "STALE"
+    assert report["findings"] and "live" in report["findings"][0]
+    assert not report["consistent"]
+
+
+def test_the_deployment_layer_is_judged_on_timing_not_generation_equality():
+    """It reports a commit sha, which can never equal a generation id.
+
+    Comparing them marked the layer different on every single run, and the age
+    check behind that comparison then declared it stale — a permanent red that
+    says nothing about whether Pages actually shipped the live content.
+    """
+    live = _layer("live", 10)
+    deployed_after = freshness.Layer(
+        "pages deployment", kind="deployment", generation="c2983234b717",
+        generated_at=live.generated_at + timedelta(minutes=1))
+    report = freshness.assess([_layer("producer", 10), live, deployed_after], now=NOW)
+    assert _status(report, "pages deployment") == "ok"
+    assert not report["findings"]
+
+    never_shipped = freshness.Layer(
+        "pages deployment", kind="deployment", generation="0000deadbeef",
+        generated_at=live.generated_at - timedelta(hours=3))
+    stalled = freshness.assess([_layer("producer", 10), live, never_shipped], now=NOW)
+    assert _status(stalled, "pages deployment") == "STALE"
+
+
+def test_an_unreachable_layer_is_a_finding_rather_than_a_silent_pass():
+    broken = freshness.Layer("live")
+    broken.problems.append("ConnectionError: name resolution failed")
+    report = freshness.assess([_layer("producer", 1), broken], now=NOW)
+    assert _status(report, "live") == "unreachable"
+    assert report["findings"]


### PR DESCRIPTION
Toward #382, acceptance line one: *a single diagnostic reports the same generation
or a clearly explained bounded lag at all four freshness layers*.

Every layer already had a way to look healthy alone. The publisher logs a
successful build, the data branch shows a recent force-update, the Pages workflow
reports success, the site returns 200 — and the browser can still be reading
yesterday. Twice the only visible symptom was "the dashboard did not refresh".

```
$ python3 ops/pages/freshness.py
reference generation: 2026-08-09T14:20:04.811658Z

layer             status      generated_at                      note
producer          ok          2026-08-09T14:20:04.811658+00:00  /root/.openclaw/workspace/assets/data/dashboard.json
data plane        ok          2026-08-09T14:20:04.811658+00:00  origin/data-plane
pages deployment  ok          2026-08-09T14:20:55+00:00         shipped c2983234b717 after the live generation
live              ok          2026-08-09T14:20:04.811658+00:00  https://kcnyu.github.io/clawock/assets/data/dashboard.json

✅ every layer is serving the same generation
```

Read-only — no fetch, no build, no publish. `--json` for machine use. Exit 1 only
on a real finding. A missing producer layer (any checkout that is not the live
host) and an unauthenticated `gh` are reported as skipped, not as faults.

## The two judgement calls, both of which I got wrong first

**Lag is measured against the newest generation, not against the clock.** The
first live run reported `live is stale: 40m old` while the pipeline was working
perfectly — the 14:20 deployment had succeeded two minutes earlier and the CDN
had not propagated yet. `now - layer.generated_at` conflates "this generation is
old" with "the pipeline is stuck", and at 03:00 with the market shut it would
call every layer stale while all four are identical. It is
`reference.generated_at - layer.generated_at` now.

**The deployment layer reports a commit sha, which can never equal a generation
id.** Comparing them marked it different on every run and then aged it out to a
permanent red. It is judged on timing instead: has the generation the browser is
being served already been deployed.

Bounds are the observed pipeline, written down: 25m for the data plane (the
publisher runs at :00/:20/:40), 45m for live (dispatch + Pages build + the ~14m
CDN propagation that lands *after* the deployment reports success, plus one
publisher tick).

## Tests

Five, over `assess()` only — the readers talk to git, `gh` and the live site, and
mocking all three would assert my mocks rather than the pipeline. Both false
directions cost something real: crying wolf trains everyone to ignore the tool,
and staying quiet is the frozen dashboard it exists to catch. The two tests that
encode the mistakes above are mutation-verified by restoring each one.
