### PR TITLE
fix: resolve the money checker without PATH, and finish the freshness trace

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -85,14 +85,19 @@ fi
 # INSIDE that script's `git push` — so it inherits exactly the environment that
 # defeated it (a cron job's PATH=/usr/bin:/bin, where the installed console
 # script in ~/.local/bin is invisible). Two gates, one resolver.
+# Resolved relative to this hook, not to $WS: the resolver is tooling that ships
+# with the hook, the way safe_push.sh sources its own siblings. $WS is the book
+# under inspection and may be somebody else's — it is what gets *checked*, not
+# where the checker is found.
 IRC=0
-if [ ! -f "$WS/ops/publish/money_checker.sh" ]; then
+_MONEY_CHECKER="$(dirname "${BASH_SOURCE[0]}")/../ops/publish/money_checker.sh"
+if [ ! -f "$_MONEY_CHECKER" ]; then
   echo "🚫 push blocked — ops/publish/money_checker.sh is missing; the money"
   echo "   checker cannot be resolved. The book was not verified."
   exit 1
 fi
 # shellcheck source=ops/publish/money_checker.sh
-. "$WS/ops/publish/money_checker.sh"
+. "$_MONEY_CHECKER"
 run_money_check "$WS" >/tmp/clawock_integrity.out 2>&1 || IRC=$?
 if [ "$IRC" = 127 ]; then
   echo "🚫 push blocked — clawock is neither on PATH nor importable from"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,13 +79,27 @@ fi
 # reconcile — the "$581 double-count" / "phantom-peak TCV" class of bug. Turning
 # the human "改完必跑 recompute" 铁律 into a structural block: never publish an
 # unreconciled book. WARN (staleness etc.) does NOT block. Override: --no-verify.
+#
+# Finding the checker is shared with ops/publish/safe_push.sh, because a bare
+# `command -v clawock` is not a reliable way to find it and this hook runs
+# INSIDE that script's `git push` — so it inherits exactly the environment that
+# defeated it (a cron job's PATH=/usr/bin:/bin, where the installed console
+# script in ~/.local/bin is invisible). Two gates, one resolver.
 IRC=0
-if ! command -v clawock >/dev/null 2>&1; then
-  echo "🚫 push blocked — clawock CLI is missing; the money checker cannot run"
+if [ ! -f "$WS/ops/publish/money_checker.sh" ]; then
+  echo "🚫 push blocked — ops/publish/money_checker.sh is missing; the money"
+  echo "   checker cannot be resolved. The book was not verified."
+  exit 1
+fi
+# shellcheck source=ops/publish/money_checker.sh
+. "$WS/ops/publish/money_checker.sh"
+run_money_check "$WS" >/tmp/clawock_integrity.out 2>&1 || IRC=$?
+if [ "$IRC" = 127 ]; then
+  echo "🚫 push blocked — clawock is neither on PATH nor importable from"
+  echo "   $WS/src; the money checker cannot run."
   echo "   install the current package before publishing this ledger"
   exit 1
 fi
-CLAWOCK_WORKSPACE="$WS" clawock integrity >/tmp/clawock_integrity.out 2>&1 || IRC=$?
 # Same rule as above: 0 = clean, 2 = ERROR findings, anything else = the checker
 # never reached a verdict and must not be read as a pass.
 if [ "$IRC" != "0" ]; then

--- a/ops/pages/freshness.py
+++ b/ops/pages/freshness.py
@@ -55,6 +55,19 @@ DATA_PLANE_BOUND = timedelta(minutes=25)
 # 14 minutes after the deployment already reports success. One publisher tick on
 # top, because the deploy is triggered by the tick that produced the generation.
 LIVE_BOUND = timedelta(minutes=45)
+# Consistency is not freshness: if the builder stops, every layer keeps agreeing
+# on the same generation and this trace stays green while the dashboard ages.
+#
+# But liveness cannot be read off `generated_at`. The publisher deliberately does
+# not advance the generation when a rebuild is semantically identical — that is
+# the #312 guarantee that a file whose only change is the build clock never gets
+# published — so on a quiet night the timestamp standing still is the correct
+# state, not a stall. My first version of this check called that a stall and
+# cried wolf on the first run.
+#
+# The honest evidence that the builder ran is that it wrote the file. Available
+# only on the producing host; elsewhere the layer is absent and so is the check.
+PRODUCER_BOUND = timedelta(minutes=30)
 
 
 @dataclass
@@ -68,6 +81,10 @@ class Layer:
     generation: str | None = None
     generated_at: datetime | None = None
     detail: str = ""
+    # When the builder last WROTE this layer, as opposed to which generation it
+    # holds. The two answer different questions and only the host can answer this.
+    wrote_at: datetime | None = None
+    build_status: dict | None = None
     problems: list[str] = field(default_factory=list)
 
     @property
@@ -84,6 +101,17 @@ def _parse(payload: str, name: str) -> Layer:
         return layer
     stamp = data.get("generated_at")
     layer.generation = data.get("generation_id") or stamp
+    # The payload carries its own market-session verdict on its inputs. Reading
+    # it here is what makes this a freshness trace rather than a sameness trace,
+    # and it avoids a second copy of the trading-hours table drifting from the
+    # one the builder already uses.
+    status = data.get("build_status")
+    if isinstance(status, dict):
+        layer.build_status = {
+            "healthy": status.get("healthy"),
+            "stale_files": status.get("stale_files") or [],
+            "stale_markets": status.get("stale_markets") or [],
+        }
     try:
         layer.generated_at = datetime.fromisoformat(str(stamp).replace("Z", "+00:00"))
     except Exception:
@@ -99,6 +127,7 @@ def read_producer(workspace: Path) -> Layer:
         return Layer("producer", detail=f"no local {PAYLOAD} (not the producing host)")
     layer = _parse(path.read_text(encoding="utf-8"), "producer")
     layer.detail = str(path)
+    layer.wrote_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
     return layer
 
 
@@ -160,6 +189,15 @@ def assess(layers: list[Layer], now: datetime | None = None) -> dict:
     reference = reference or next((layer for layer in layers if layer.ok), None)
 
     findings: list[str] = []
+    # Has the builder run at all recently? Only the producing host can say.
+    producer = next((layer for layer in layers if layer.name == "producer"), None)
+    if producer and producer.wrote_at:
+        silent = now - producer.wrote_at
+        if silent > PRODUCER_BOUND:
+            findings.append(
+                f"the builder has not written for {int(silent.total_seconds() // 60)}m "
+                f"— it runs every 20m, so the layers agreeing below means production "
+                f"stopped, not that the pipeline is healthy")
     live = next((layer for layer in layers if layer.name == "live" and layer.ok), None)
     rows = []
     for layer in layers:
@@ -216,8 +254,17 @@ def assess(layers: list[Layer], now: datetime | None = None) -> dict:
             "note": note,
         })
 
+    # What the browser is served says about its own inputs, for this session.
+    served = next((layer for layer in layers if layer.name == "live" and layer.build_status),
+                  None) or next((layer for layer in layers if layer.build_status), None)
+    inputs = served.build_status if served else None
+    if inputs and inputs.get("healthy") is False:
+        stale = ", ".join(inputs["stale_files"] + inputs["stale_markets"]) or "unnamed inputs"
+        findings.append(f"the served payload reports stale inputs for this session: {stale}")
+
     return {
         "checked_at": now.isoformat(),
+        "served_inputs": inputs,
         "reference": reference.generation if reference else None,
         "layers": rows,
         "consistent": all(row["status"] in ("ok", "skipped") for row in rows),
@@ -248,7 +295,13 @@ def main(argv=None) -> int:
             print(f"{row['layer']:<18}{row['status']:<22}"
                   f"{str(row['generated_at'] or '—'):<34}{row['note']}")
         print()
-        if report["consistent"]:
+        inputs = report.get("served_inputs")
+        if inputs is not None:
+            verdict = "fresh for this session" if inputs.get("healthy") else "STALE INPUTS"
+            print(f"served payload inputs: {verdict}"
+                  + (f" — {', '.join(inputs['stale_files'] + inputs['stale_markets'])}"
+                     if not inputs.get("healthy") else "") + "\n")
+        if report["consistent"] and not report["findings"]:
             print("✅ every layer is serving the same generation")
         elif report["findings"]:
             for finding in report["findings"]:

--- a/ops/publish/money_checker.sh
+++ b/ops/publish/money_checker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# money_checker.sh — locate and run the package-owned money-conservation check.
+# SOURCE this; do not run it.
+#
+# Why this is a file rather than two `command -v clawock` lines: resolving the
+# checker is not the same as having it on PATH, and both gates learned that the
+# hard way on the same night. The installed console script lives in
+# ~/.local/bin, but a job started from the user crontab runs with
+# PATH=/usr/bin:/bin. So the nightly gold refresh committed portfolio.json,
+# safe_push.sh could not find `clawock`, and the gate fired — correctly, since
+# unverifiable money must not be published, but for the wrong reason. The money
+# commit then sat unpushed on the live checkout, and because the gate re-runs
+# for as long as an unpushed portfolio.json commit exists, it was in front of
+# every later push too.
+#
+# The fallback runs the same package out of the checkout. It is `clawock.cli`
+# either way — never a second implementation of the arithmetic, which would
+# drift from the real one and quietly bless a book the real one rejects — and it
+# names no host path, so a runner, a worktree and a bare cron environment all
+# resolve it the same way.
+#
+# Provides, for the sourcing shell:
+#   money_checker_kind <root>   echoes "installed"|"checkout"; non-zero if neither
+#   run_money_check <root>      runs the check against <root>; 127 if unresolvable
+
+money_checker_kind() {
+  if command -v clawock >/dev/null 2>&1; then
+    echo installed
+    return 0
+  fi
+  if [ -n "$1" ] && PYTHONPATH="$1/src" \
+       python3 -c 'import clawock.cli' >/dev/null 2>&1; then
+    echo checkout
+    return 0
+  fi
+  return 1
+}
+
+run_money_check() {
+  # <root> is the repository/workspace whose book is being published. Passing it
+  # explicitly matters: the point is to verify the book that is about to go out,
+  # not whichever workspace the caller's environment happens to point at.
+  local root="$1" kind
+  kind="$(money_checker_kind "$root")" || return 127
+  if [ "$kind" = installed ]; then
+    env "CLAWOCK_WORKSPACE=$root" clawock integrity
+  else
+    env "CLAWOCK_WORKSPACE=$root" "PYTHONPATH=$root/src" \
+        python3 -m clawock.cli integrity
+  fi
+}

--- a/ops/publish/safe_push.sh
+++ b/ops/publish/safe_push.sh
@@ -20,6 +20,11 @@ BRANCH="${2:-master}"
 # being restated per publisher. It also owns wiping an ephemeral Actions key.
 # shellcheck source=ops/publish/publish_identity.sh
 . "$(dirname "${BASH_SOURCE[0]}")/publish_identity.sh"
+# Locating the money checker is shared with .githooks/pre-push for the same
+# reason: PATH is not a reliable way to find it, and one gate learning that
+# while the other does not is how a book gets published unverified.
+# shellcheck source=ops/publish/money_checker.sh
+. "$(dirname "${BASH_SOURCE[0]}")/money_checker.sh"
 if [ -n "$PUBLISH_REMOTE" ]; then
   REMOTE="$PUBLISH_REMOTE"
 fi
@@ -60,15 +65,17 @@ else
   # Cannot tell what is new; assume the money file is in scope rather than skip.
   PORTFOLIO_TOUCHED="portfolio.json"
 fi
-if [ -n "$PORTFOLIO_TOUCHED" ] && ! command -v clawock >/dev/null 2>&1; then
-  echo "✗ REFUSING TO PUSH — portfolio.json is in this push but the"
-  echo "  package-owned money-conservation checker is unavailable: clawock"
-  echo "  The book cannot be verified from here."
-  exit 4
-fi
 if [ -n "$PORTFOLIO_TOUCHED" ]; then
   echo "▸ portfolio.json is in this push — running money-conservation check…"
-  if ! CLAWOCK_WORKSPACE="${REPO_TOP:-.}" clawock integrity; then
+  RC=0
+  run_money_check "${REPO_TOP:-$PWD}" || RC=$?
+  if [ "$RC" = 127 ]; then
+    echo "✗ REFUSING TO PUSH — portfolio.json is in this push but the"
+    echo "  package-owned money-conservation checker is unavailable: clawock"
+    echo "  It is neither on PATH nor importable from ${REPO_TOP:-$PWD}/src."
+    echo "  The book cannot be verified from here."
+    exit 4
+  elif [ "$RC" != 0 ]; then
     echo "✗ REFUSING TO PUSH — portfolio.json does not reconcile."
     echo "  Cash, positions and P&L must balance before the money file is published."
     echo "  Fix the ledger (see the findings above) and re-commit."

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -483,6 +483,63 @@ def test_latest_completed_session_skips_holiday_weekend_before_close():
     ).isoformat() == "2026-07-06"
 
 
+SESSION_PHASES = [
+    # (market, local hour, phase, the newest session that has conservatively
+    #  finished at that moment). 2026-08-11 is a Tuesday; both markets traded on
+    #  Monday the 10th, so "yesterday" is unambiguous in either timezone.
+    ("hk", 8, "pre-open", "2026-08-10"),
+    ("hk", 12, "mid-session", "2026-08-10"),
+    ("hk", 16, "just after the close", "2026-08-10"),
+    ("hk", 18, "after-hours", "2026-08-11"),
+    ("us", 8, "pre-open", "2026-08-10"),
+    ("us", 12, "mid-session", "2026-08-10"),
+    ("us", 16, "just after the close", "2026-08-10"),
+    ("us", 18, "after-hours", "2026-08-11"),
+]
+
+
+@pytest.mark.parametrize("market, hour, phase, expected", SESSION_PHASES)
+def test_completed_session_is_resolved_per_market_across_the_whole_day(
+        market, hour, phase, expected):
+    """Freshness is judged against the newest *completed* session, so which one
+    that is has to be right at every hour of the day, in each market's own
+    clock.
+
+    The hour after the close is the interesting row and it is deliberate: at
+    16:00 local the session has ended but the quotes that settle it have not
+    necessarily arrived, so the bar stays at yesterday until 17:00. Moving it
+    earlier would mark a leg fresh on today's session before today's prices
+    could possibly be in the book — the failure this whole check exists to
+    catch.
+    """
+    from clawock.market_data import sessions as trading_calendar
+
+    at = datetime(2026, 8, 11, hour, 0,
+                  tzinfo=ZoneInfo(trading_calendar.MARKET_TZ[market]))
+    resolved = dashboard._latest_completed_session(market, trading_calendar, at)
+
+    assert resolved.isoformat() == expected, (
+        f"{market} {phase} ({hour}:00 local) resolved to {resolved}")
+
+
+def test_the_two_markets_disagree_at_the_same_instant():
+    """One clock cannot serve both legs.
+
+    18:00 in Hong Kong is 06:00 in New York on the same date: Hong Kong has
+    finished the 11th while New York has not yet opened it. A single UTC (or
+    host-local) cutoff would give both legs the same answer and silently mark
+    one of them fresh against a session it has no prices for.
+    """
+    from clawock.market_data import sessions as trading_calendar
+
+    instant = datetime(2026, 8, 11, 18, 0, tzinfo=ZoneInfo("Asia/Hong_Kong"))
+
+    hk = dashboard._latest_completed_session("hk", trading_calendar, instant)
+    us = dashboard._latest_completed_session("us", trading_calendar, instant)
+
+    assert (hk.isoformat(), us.isoformat()) == ("2026-08-11", "2026-08-10")
+
+
 def test_market_leg_freshness_exposes_one_frozen_holding():
     from clawock.market_data import sessions as trading_calendar
 

--- a/tests/test_freshness_trace.py
+++ b/tests/test_freshness_trace.py
@@ -94,3 +94,36 @@ def test_an_unreachable_layer_is_a_finding_rather_than_a_silent_pass():
     report = freshness.assess([_layer("producer", 1), broken], now=NOW)
     assert _status(report, "live") == "unreachable"
     assert report["findings"]
+
+
+def test_a_silent_builder_is_a_finding_even_when_every_layer_agrees():
+    """The failure the trace itself can hide: consistent and dead.
+
+    Liveness is read from when the builder last WROTE, never from
+    `generated_at`. The publisher deliberately holds the generation steady when a
+    rebuild is semantically identical (#312), so a timestamp standing still on a
+    quiet night is correct behaviour — the first version of this check called it
+    a stall and cried wolf on its first real run.
+    """
+    producer = _layer("producer", 90)
+    producer.wrote_at = NOW - timedelta(minutes=90)
+    layers = [producer, _layer("data plane", 90), _layer("live", 90)]
+
+    report = freshness.assess(layers, now=NOW)
+    assert report["consistent"], "the layers do agree — that is the trap"
+    assert any("has not written" in f for f in report["findings"]), report["findings"]
+
+    # Same stale generation, but the builder is writing: nothing is wrong.
+    producer.wrote_at = NOW - timedelta(minutes=3)
+    healthy = freshness.assess(layers, now=NOW)
+    assert not healthy["findings"], healthy["findings"]
+
+
+def test_stale_inputs_in_the_served_payload_are_a_finding():
+    """Fresh generation, stale ingredients — the payload already knows."""
+    live = _layer("live", 2)
+    live.build_status = {"healthy": False, "stale_files": ["portfolio.json"],
+                         "stale_markets": ["hk"]}
+    report = freshness.assess([_layer("producer", 2), live], now=NOW)
+    assert report["served_inputs"]["healthy"] is False
+    assert any("stale inputs" in f for f in report["findings"]), report["findings"]

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -240,17 +240,28 @@ def test_data_plane_publisher_preserves_hook_stdout_and_git_stderr():
     ).read_text(), "postflight truncated the hook reason back out of the result"
 
 
+def _safe_push_in(repo):
+    """Copy the publisher and the files it sources next to each other.
+
+    A deployment of safe_push.sh is all of them. Not tolerating an absent one is
+    deliberate: an unreadable identity helper must fail rather than silently
+    push under whatever git happens to be configured with, and an unreadable
+    money checker must fail rather than skip the money gate.
+    """
+    for name in ("safe_push.sh", "publish_identity.sh", "money_checker.sh"):
+        (repo / name).write_text((ROOT / "ops" / "publish" / name).read_text())
+    return repo / "safe_push.sh"
+
+
 def test_safe_push_refuses_the_money_file_when_the_checker_is_missing(tmp_path):
-    """A missing package CLI cannot silently certify a changed money file."""
+    """A missing package CLI cannot silently certify a changed money file.
+
+    The other half of the cron-PATH fix below: nothing on PATH *and* nothing
+    importable from the checkout must still refuse. The fallback exists so a
+    verifiable book gets published, not so the gate becomes a formality.
+    """
     repo = _ledger_repo(tmp_path)
-    script = repo / "safe_push.sh"
-    script.write_text((ROOT / "ops" / "publish" / "safe_push.sh").read_text())
-    # safe_push.sh sources its sibling for identity selection, so a deployment
-    # of it is both files. Not tolerating an absent one is deliberate: an
-    # unreadable identity helper must fail here, not silently push under
-    # whatever git happens to be configured with.
-    (repo / "publish_identity.sh").write_text(
-        (ROOT / "ops" / "publish" / "publish_identity.sh").read_text())
+    script = _safe_push_in(repo)
 
     result = subprocess.run(
         ["/bin/bash", str(script)], cwd=repo, capture_output=True,
@@ -262,12 +273,43 @@ def test_safe_push_refuses_the_money_file_when_the_checker_is_missing(tmp_path):
     assert "checker is unavailable" in result.stdout
 
 
+CRON_ENV = {"PATH": "/usr/bin:/bin", "HOME": "/root", "LANG": "C.UTF-8"}
+"""What a job started from the user crontab actually gets. The installed
+console script lives in ~/.local/bin, which is not on this PATH."""
+
+
+def test_safe_push_finds_the_money_checker_under_a_bare_cron_environment(tmp_path):
+    """The gate must resolve the checker without help from PATH.
+
+    On 2026-08-09 the nightly gold refresh committed portfolio.json and then
+    could not push it: started from the user crontab, `command -v clawock`
+    found nothing, so the gate refused. It was right to refuse an unverifiable
+    book — but the book was verifiable, and the money commit then sat on the
+    live checkout in front of every later push, because the gate re-runs for as
+    long as an unpushed portfolio.json commit exists.
+
+    Asserted behaviourally, in the environment that broke it: reverting to a
+    bare `command -v clawock` makes this red because the run never reaches the
+    check at all.
+    """
+    repo = _ledger_repo(tmp_path)
+    script = _safe_push_in(repo)
+    # The fallback runs the package out of the checkout being pushed.
+    (repo / "src").symlink_to(ROOT / "src")
+
+    result = subprocess.run(["bash", str(script)], cwd=repo, capture_output=True,
+                            text=True, input="", env=CRON_ENV)
+
+    assert "running money-conservation check" in result.stdout, (
+        "the gate never got as far as checking the book:\n" + result.stdout)
+    assert "neither on PATH nor importable" not in result.stdout, (
+        "the checker was reported unavailable although the package is right "
+        "here in the checkout:\n" + result.stdout)
+
+
 def test_safe_push_runs_the_money_check_when_the_money_file_moves(tmp_path):
     repo = _ledger_repo(tmp_path)
-    script = repo / "safe_push.sh"
-    script.write_text((ROOT / "ops" / "publish" / "safe_push.sh").read_text())
-    (repo / "publish_identity.sh").write_text(
-        (ROOT / "ops" / "publish" / "publish_identity.sh").read_text())
+    script = _safe_push_in(repo)
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     marker = tmp_path / "integrity-invoked"


### PR DESCRIPTION
## The bug this starts from

The nightly gold refresh committed `portfolio.json` at 23:50 and then could not push it:

```
2026-08-09T23:50:37+08:00 gold-refresh: 已提交 2dd760c6
✗ REFUSING TO PUSH — portfolio.json is in this push but the
  package-owned money-conservation checker is unavailable: clawock
```

Started from the user crontab, that job runs with `PATH=/usr/bin:/bin`. The installed console script is at `/root/.local/bin/clawock`. So `command -v clawock` found nothing and the gate refused.

The gate was **right** to refuse a book it cannot verify. But this book was verifiable — run by hand, `clawock integrity` reports `0 ERROR / 14 WARN → ✅ 可发布` — and the refusal left the money commit sitting on the live checkout, where it stayed in front of *every later push*, because the gate re-runs for as long as an unpushed `portfolio.json` commit exists. The live checkout was one HK open away from a pile-up.

`.githooks/pre-push:83` had the same line, and it runs **inside** `safe_push.sh`'s own `git push` — so it inherits exactly the environment that defeated the first gate. Fixing one and not the other would have left the failure intact.

## Fix

Resolution moves into `ops/publish/money_checker.sh`, which both gates source (the same shape as `publish_identity.sh`, which exists because two publishers needed one answer):

- prefer the installed command;
- otherwise run the same package out of the checkout being pushed.

The fallback is `clawock.cli` either way — never a second implementation of the arithmetic, which would drift and eventually bless a book the real one rejects — and it names no host path, so a runner, a worktree and a bare cron environment resolve it identically. With neither available it still refuses, unchanged.

Verified under `env -i PATH=/usr/bin:/bin`: `python3 -m clawock.cli integrity` reaches the same verdict the installed command does.

**The stranded commit is already published** (`164cfa3a..2dd760c6`, through `safe_push.sh` from the live checkout, money gate green, `system_check` 15 ok / 1 pre-existing memory-index warn / 0 critical). This PR stops it recurring tonight.

## Freshness trace — the two questions it could not answer (#382)

**Consistency is not freshness.** If the builder stops, every layer keeps agreeing on the same generation and the trace stays green while the dashboard ages. But liveness cannot be read off `generated_at`: the publisher deliberately holds the generation steady when a rebuild is semantically identical (#312), so on a quiet night a still timestamp is *correct*. My first version called that a stall and cried wolf on its first real run. It is now read from when the builder last **wrote** — the only honest evidence, and available only on the producing host, so elsewhere the layer is absent and so is the check.

**A fresh generation can carry stale ingredients.** The payload's own `build_status` already knows; the trace surfaces it rather than keeping a second copy of the trading-hours table that would drift from the one the builder uses.

Real run just now — consistent *and* alive, no false alarm:

```
producer          ok   2026-08-09T16:00:04+00:00   (written 19m ago, bound 30m)
data plane        ok   2026-08-09T16:00:04+00:00
pages deployment  ok   shipped 164cfa3ae67e after the live generation
live              ok   2026-08-09T16:00:04+00:00
served payload inputs: fresh for this session
✅ every layer is serving the same generation
```

## Market-session semantics, pinned (#382 acceptance)

Freshness is judged against the newest *completed* session, so which one that is has to be right at every hour, in each market's own clock. Both legs × pre-open / mid-session / just-after-close / after-hours, plus the instant where 18:00 in Hong Kong and 06:00 in New York **must** give different answers — a single UTC or host-local cutoff passes everything else and fails only that row.

The just-after-close row is deliberate: at 16:00 local the session has ended but the quotes that settle it have not necessarily arrived, so the bar stays at yesterday until 17:00. Moving it earlier marks a leg fresh against a session it cannot have prices for — the exact failure the check exists to catch.

## Mutation verification

Each new test was confirmed to guard something, not to decorate:

| mutation | result |
|---|---|
| `money_checker.sh` back to PATH-only | `test_safe_push_finds_the_money_checker_under_a_bare_cron_environment` red |
| post-close cutoff 17 → 16 | both `just after the close` rows red |
| builder liveness read from `generated_at` | `test_a_silent_builder_is_a_finding_even_when_every_layer_agrees` red |

Merging without a second agent under kcn's 2026-08-10 instruction (「不需要我review和codex介入」); all six required checks must still be green.
