### PR TITLE
fix: decide "which session has finished" once, on the calendar

### DIFF
--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -233,15 +233,7 @@ def _universe():
 
 
 def _latest_completed_session(region, at=None):
-    market = region.lower()
-    now = at or datetime.now(ZoneInfo(trading_calendar.MARKET_TZ[market]))
-    now = now.astimezone(ZoneInfo(trading_calendar.MARKET_TZ[market]))
-    current = now.date() if now.hour >= 17 else now.date() - timedelta(days=1)
-    for _ in range(14):
-        if trading_calendar.is_trading_day(market, current):
-            return current
-        current -= timedelta(days=1)
-    return None
+    return trading_calendar.latest_completed_session(region, at)
 
 
 def _as_date(value):

--- a/src/clawock/market_data/sessions.py
+++ b/src/clawock/market_data/sessions.py
@@ -180,6 +180,41 @@ def is_trading_day(market: str, d: date | None = None, session: str = "full") ->
     return True
 
 
+#: How long after midnight, in market-local time, a session is treated as
+#: finished. Both exchanges close at 16:00 local; the extra hour is for the
+#: settling quotes to arrive, so that "the session ended" never gets read as
+#: "today's prices are in the book" while they are still landing.
+SESSION_SETTLED_HOUR = 17
+
+
+def latest_completed_session(market: str, at: datetime | None = None) -> date | None:
+    """Newest trading session that has conservatively finished in market time.
+
+    The one place this is decided. It used to be decided in three, and the odd
+    one out was load-bearing: `portfolio.integrity` asked `date.today()` — the
+    *host's* date, and counting today as complete — so from midnight until the
+    market actually produced a quote, every holding still carrying the newest
+    real close was flagged stale. For the US leg, whose quotes only arrive
+    around 21:30 Hong Kong time, that was most of every trading day. A staleness
+    warning that fires while nothing is wrong is not a conservative gate; it is
+    the reason a real one goes unread.
+
+    Returns None only if no trading day is found within a fortnight, which means
+    the holiday table is broken rather than that the market is quiet.
+    """
+    market = market.lower()
+    if market not in MARKET_TZ:
+        raise ValueError(f"unknown market {market!r} (use 'hk' or 'us')")
+    tz = ZoneInfo(MARKET_TZ[market])
+    now = at.astimezone(tz) if at else datetime.now(tz)
+    probe = now.date() if now.hour >= SESSION_SETTLED_HOUR else now.date() - timedelta(days=1)
+    for _ in range(14):
+        if is_trading_day(market, probe):
+            return probe
+        probe -= timedelta(days=1)
+    return None
+
+
 def previous_trading_day(market: str, d: date) -> date:
     """Most recent trading day strictly before ``d``."""
     probe = d - timedelta(days=1)

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -97,18 +97,22 @@ RANGE_TOL = 0.005  # current 越界容忍 0.5%（收盘集合竞价/盘后微动
 
 
 def _last_session(market):
-    """上一个（含今天）交易日 ISO 字符串；trading_calendar 不可用时返回 None。"""
+    """最近一个**已收盘**交易日的 ISO 字符串；日历不可用时返回 None。
+
+    以前这里用 `date.today()`（宿主本地日期）并且**把今天算成已完成**，于是从午夜
+    到该市场真正产出报价之间，持有着「最新真实收盘价」的持仓每一只都会被判 stale。
+    美股腿的报价约 21:30 HKT 才到，也就是**每个交易日约 21 小时都在误报**。
+    天天喊狼的闸等于没有闸——真 stale 那次没人会多看一眼。
+
+    现在和面板、决策信号走同一个日历函数：市场本地时区、17:00 之后才认今天。
+    """
     if tc is None:
         return None
-    d = date.today()
-    for _ in range(10):
-        try:
-            if tc.is_trading_day(market, d):
-                return d.isoformat()
-        except Exception:
-            return None
-        d -= timedelta(days=1)
-    return None
+    try:
+        session = tc.latest_completed_session(market)
+    except Exception:
+        return None
+    return session.isoformat() if session else None
 
 
 def _extract_iso(s):

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -2284,15 +2284,13 @@ def _latest_due_fire(schedule, at, calendar=None):
 
 
 def _latest_completed_session(market, calendar, at=None):
-    """Newest trading session that has conservatively finished in market time."""
-    tz = ZoneInfo(calendar.MARKET_TZ[market])
-    now = at.astimezone(tz) if at else datetime.now(tz)
-    current = now.date() if now.hour >= 17 else now.date() - timedelta(days=1)
-    for _ in range(14):
-        if calendar.is_trading_day(market, current):
-            return current
-        current -= timedelta(days=1)
-    return None
+    """Newest trading session that has conservatively finished in market time.
+
+    Thin now: the rule lives on the calendar, which is the only module that
+    knows when a market is open. `calendar` stays a parameter because callers
+    inject it, and it is still what answers the question.
+    """
+    return calendar.latest_completed_session(market, at)
 
 
 def _quote_session(holding, reference):

--- a/tests/test_completed_session_is_decided_once.py
+++ b/tests/test_completed_session_is_decided_once.py
@@ -1,0 +1,131 @@
+"""One answer to "which session has finished", and it must not name today early.
+
+Three modules used to decide this independently. Two agreed — market timezone,
+17:00 local before today counts — and the third, `portfolio.integrity`, asked
+`date.today()` on the *host* and counted today as already complete. So from
+midnight until the market actually produced a quote, every holding still
+carrying the newest real close was reported stale. The US leg's quotes arrive
+around 21:30 Hong Kong time, which made that most of every trading day.
+
+The existing integrity suite could not catch it: its fixture monkeypatches
+`_last_session`, so the one thing that was wrong was stubbed out in every case.
+These tests exercise the real calendar.
+"""
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from clawock.market_data import sessions
+from clawock.portfolio import integrity
+from clawock.publish import dashboard
+from clawock.decision import signals
+
+
+# (market, local wall clock, what has actually finished at that moment).
+# 2026-08-10 is a Monday; both markets last traded Friday the 7th.
+NOT_YET_COMPLETE = [
+    ("us", datetime(2026, 8, 10, 2, 0), "2026-08-07"),
+    ("us", datetime(2026, 8, 10, 9, 35), "2026-08-07"),
+    ("us", datetime(2026, 8, 10, 16, 30), "2026-08-07"),
+    ("hk", datetime(2026, 8, 10, 2, 0), "2026-08-07"),
+    ("hk", datetime(2026, 8, 10, 11, 0), "2026-08-07"),
+    ("hk", datetime(2026, 8, 10, 16, 30), "2026-08-07"),
+    # Only once the settling window has passed does today count.
+    ("us", datetime(2026, 8, 10, 17, 0), "2026-08-10"),
+    ("hk", datetime(2026, 8, 10, 17, 0), "2026-08-10"),
+]
+
+
+@pytest.mark.parametrize("market, wall_clock, expected", NOT_YET_COMPLETE)
+def test_a_session_is_not_complete_until_its_own_market_has_settled(
+        market, wall_clock, expected):
+    at = wall_clock.replace(tzinfo=ZoneInfo(sessions.MARKET_TZ[market]))
+
+    resolved = sessions.latest_completed_session(market, at)
+
+    assert resolved.isoformat() == expected, (
+        f"at {wall_clock:%H:%M} {market.upper()} local, the newest finished "
+        f"session is {expected}, not {resolved}")
+
+
+def test_the_three_call_sites_ask_the_same_calendar():
+    """The drift guard.
+
+    Two of these agreed by being copies of each other, which is exactly how the
+    third was able to be wrong for as long as it was: nothing compared them.
+    Asserted at a real instant so the check keeps meaning something as the
+    calendar moves.
+    """
+    now = datetime.now(timezone.utc)
+
+    from_integrity = integrity._last_session("us")
+    from_dashboard = dashboard._latest_completed_session("us", sessions, now)
+    from_signals = signals._latest_completed_session("us", now)
+
+    assert from_integrity == from_dashboard.isoformat() == from_signals.isoformat(), (
+        f"integrity={from_integrity} dashboard={from_dashboard} "
+        f"signals={from_signals}")
+
+
+def test_integrity_does_not_call_the_newest_available_close_stale(monkeypatch):
+    """The false positive itself, end to end through the real gate.
+
+    A book holding a quote dated the newest *finished* session is as fresh as it
+    is possible to be. Before the fix this was reported stale for most of the
+    day, and a warning that fires while nothing is wrong is the reason the real
+    one goes unread.
+    """
+    newest = sessions.latest_completed_session("us")
+    portfolio = {
+        "portfolios": {
+            "us_stocks": {
+                "currency": "USD",
+                "holdings": [{
+                    "ticker": "EXMPL",
+                    "shares": 10,
+                    "current_price": 100.0,
+                    "data_source": f"provider {newest.isoformat()}",
+                }],
+            }
+        }
+    }
+    monkeypatch.setattr(
+        integrity, "Path",
+        lambda _unused: type("P", (), {"read_text": staticmethod(
+            lambda: __import__("json").dumps(portfolio))})())
+
+    report = integrity.check("ignored")
+    staleness = [f for f in report["findings"] if f["code"] == "STALENESS"]
+
+    assert not staleness, (
+        f"a holding quoted at the newest finished session ({newest}) was "
+        f"reported stale: {staleness}")
+
+
+def test_integrity_still_catches_a_genuinely_old_quote(monkeypatch):
+    """The other half — the gate must still bite when the quote really is old."""
+    newest = sessions.latest_completed_session("us")
+    stale_day = sessions.previous_trading_day("us", newest)
+    portfolio = {
+        "portfolios": {
+            "us_stocks": {
+                "currency": "USD",
+                "holdings": [{
+                    "ticker": "EXMPL",
+                    "shares": 10,
+                    "current_price": 100.0,
+                    "data_source": f"provider {stale_day.isoformat()}",
+                }],
+            }
+        }
+    }
+    monkeypatch.setattr(
+        integrity, "Path",
+        lambda _unused: type("P", (), {"read_text": staticmethod(
+            lambda: __import__("json").dumps(portfolio))})())
+
+    report = integrity.check("ignored")
+
+    assert any(f["code"] == "STALENESS" for f in report["findings"]), (
+        f"a quote from {stale_day}, one session behind {newest}, was accepted")


### PR DESCRIPTION
## Found while reconciling the live book for #382

`clawock integrity` on the live workspace: **0 ERROR / 14 WARN**. Seven of those warnings were false — and false the same way on every trading day.

```
🟡 STALENESS  [us_stocks]  SKHY data_source 日期 2026-08-09 早于上一交易日 2026-08-10
```

At 02:00 HKT on Monday the 10th, neither market has opened. `2026-08-10` is not a completed session in Hong Kong and will not be one in New York for another nineteen hours.

## Three answers to one question

| module | rule |
|---|---|
| `publish/dashboard._latest_completed_session` | market-local TZ, today counts from 17:00 |
| `decision/signals._latest_completed_session` | identical — it is a copy |
| `portfolio/integrity._last_session` | **`date.today()` on the host, today always counts** |

The first two agreed by being the same code, which is exactly how the third could stay wrong without anyone noticing: nothing compared them.

The consequence is not cosmetic. US quotes land around 21:30 HKT, so for roughly twenty-one hours of every trading day the US leg was reported stale while carrying the freshest close that exists. A gate that cries wolf that reliably is the reason a real staleness goes unread — the same argument `_latest_completed_session` was written for on the dashboard side.

## Fix

`latest_completed_session(market, at=None)` moves to `clawock.market_data.sessions`, which is the only module that knows when a market is open, and all three call sites delegate. The 17:00 settle hour becomes a named constant with the reason attached: both exchanges close at 16:00 local, and the extra hour is for settling quotes to arrive, so "the session ended" is never read as "today's prices are in the book" while they are still landing.

Live book, before and after:

```
before: 0 ERROR / 14 WARN
after:  0 ERROR /  7 WARN
```

All seven that disappeared were STALENESS. The seven that remain are STALE_PRICE — a different, genuine condition (quotes missing prev_close and intraday range from every provider).

## Why the existing tests did not catch it

`tests/test_preflight_integrity.py` has a `run_check` fixture that does:

```python
monkeypatch.setattr(pi, "_last_session", lambda _market: last_session)
```

The one thing that was wrong is stubbed out in every case in that file. Same shape as the two CI-caught cases recorded during the data-plane migration: the test and the code it guards share a failure mode.

The new file exercises the real calendar, and pins both halves — the newest available close is not stale, and a quote one session behind still is.

## Mutation verification

| mutation | result |
|---|---|
| `_last_session` back to `date.today()` | agreement test + false-positive test red |
| `SESSION_SETTLED_HOUR` 17 → 0 | six rows of the session-phase table red |

Merging without a second agent under kcn's 2026-08-10 instruction; all six required checks must still be green.