### PR TITLE
fix: the package announces itself, not the runtime driving it

### DIFF
--- a/src/clawock/portfolio/fx.py
+++ b/src/clawock/portfolio/fx.py
@@ -42,7 +42,14 @@ CACHE_TTL_HOURS = 4   # FX moves slowly intraday; refresh 6x/day is enough
 TIMEOUT = 10
 
 SESSION = requests.Session()
-SESSION.headers.update({'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) openclaw-fx/1.0'})
+# The package's outbound identity, not the runtime that happens to be driving
+# it. This said `openclaw-fx/1.0`, so anyone who installed the wheel announced
+# themselves to a third-party FX API as an instance of somebody else's agent
+# runtime. Naming the project matches every other fetcher in the package and is
+# what a rate-limiting operator would need in order to reach us.
+SESSION.headers.update(
+    {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) '
+                   'clawock-fx/1.0 (github.com/KCNyu/clawock)'})
 
 
 def _from_cache(allow_stale: bool = False) -> Optional[Dict]:


### PR DESCRIPTION
Found while auditing the built wheel for #420.

Grepping the installed package for instance and runtime names turns up 17 files. Sixteen are prose — docstrings explaining where code moved from, the OpenClaw adapter naming the runtime it adapts, project URLs in other fetchers' User-Agents. One was not:

```python
SESSION.headers.update({'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) openclaw-fx/1.0'})
```

Anyone who `pip install clawock` and asked it for an FX rate introduced themselves to a third-party API as an instance of somebody else's agent runtime. It is small, but it is the package's outbound identity, and #378 asks for package code that carries no runtime homes.

Now `clawock-fx/1.0 (github.com/KCNyu/clawock)`, matching `clawock-macro-scan` and `clawock-sentiment-scan`, and giving a rate-limiting operator a way to reach the project.

Verified with a real request against a scratch workspace (not the live book): `USDHKD: 7.8449 [Frankfurter]`.

No test. What needs proving here is that the provider still answers, and only a real call shows that; the suite should not depend on the network or on a third party's tolerance for a test-rate request.

The remaining sixteen are recorded on #420 — including one that is a genuine architecture question rather than a slip: whether `clawock.providers.openclaw` belongs in the portable wheel at all, given the terminal architecture draws runtime adapters as a separate box from the public package.

Merging without a second agent under kcn's 2026-08-10 instruction; all six required checks must still be green.