### PR TITLE
fix: system_check must resolve clawock too, and a guard that finds the next one

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -14,6 +14,7 @@ Used by:
 import glob
 import json
 import os
+import shutil
 import subprocess
 import sys
 from datetime import date, datetime, timezone
@@ -43,6 +44,34 @@ from clawock.providers.openclaw import (  # noqa: E402
 )
 
 _OPENCLAW_PATHS = openclaw_runtime_paths()
+
+
+def clawock_argv(*args, env=None):
+    """How to spawn the packaged CLI without depending on the caller's PATH.
+
+    The Python half of what `ops/publish/money_checker.sh` does for the two push
+    gates, and it exists for the same reason they do: a job started from the
+    user crontab runs with PATH=/usr/bin:/bin, and the installed console script
+    lives in ~/.local/bin. A bare `clawock` there is not "the CLI is broken" —
+    it is FileNotFoundError, which this file reports as CRITICAL, which blocks
+    the push. On 2026-08-10 that stranded the 03:20 dreaming commit behind a
+    gate that had nothing to say about it.
+
+    Falls back to the package in this checkout, already on `sys.path` above; a
+    subprocess does not inherit that, so PYTHONPATH is set explicitly. Same rule
+    as the shell resolver: it is `clawock.cli` either way, never a second
+    implementation.
+    """
+    env = dict(os.environ if env is None else env)
+    exe = shutil.which('clawock')
+    if exe:
+        return [exe, *args], env
+    src = str(_REPO_ROOT / 'src')
+    existing = env.get('PYTHONPATH')
+    env['PYTHONPATH'] = f'{src}{os.pathsep}{existing}' if existing else src
+    return [sys.executable, '-m', 'clawock.cli', *args], env
+
+
 OPENCLAW_INSTALL = _OPENCLAW_PATHS.install_dir
 LIVE_WORKSPACE = _OPENCLAW_PATHS.workspace
 MEMORY_INDEX_DB = _OPENCLAW_PATHS.memory_index_db
@@ -228,8 +257,9 @@ def check_dashboard_buildable(r):
     out = Path(tempfile.gettempdir()) / 'system_check_dashboard.json'
     try:
         env = dict(os.environ, BUILD_DASHBOARD_OUT=str(out))
+        argv, env = clawock_argv('dashboard-build', env=env)
         rr = subprocess.run(
-            ['clawock', 'dashboard-build'],
+            argv,
             capture_output=True, text=True, timeout=30, cwd=str(WS), env=env,
         )
         if rr.returncode != 0:

--- a/tests/test_no_bare_clawock_invocation.py
+++ b/tests/test_no_bare_clawock_invocation.py
@@ -1,0 +1,133 @@
+"""Nothing that a cron job can reach may spawn a bare `clawock`.
+
+A job started from the user crontab runs with PATH=/usr/bin:/bin. The installed
+console script lives in ~/.local/bin. So a bare `clawock` is not "the CLI is
+broken" there — it is FileNotFoundError, and every caller turns that into
+something worse than a missing command:
+
+  * `ops/publish/safe_push.sh` refused a verifiable book, stranding the 23:50
+    gold `portfolio.json` commit in front of every later push;
+  * `ops/system_check.py` reported CRITICAL, which blocked the 03:20 dreaming
+    commit through the pre-push hook.
+
+Both were fixed on 2026-08-10, three hours apart, because the first fix was
+written against the two sites I already knew about instead of asking where else
+the shape occurs. This test asks. It discovers call sites rather than listing
+them, so the next one fails here instead of at 03:20 on a live host.
+
+The rule is not "never name clawock" — it is "resolve it before spawning it":
+prefer the installed command, fall back to the package in this checkout.
+"""
+from pathlib import Path
+import ast
+import re
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+# The host-operations surface: what the *user crontab* and the git hooks launch,
+# which is where PATH=/usr/bin:/bin actually applies.
+#
+# `instances/kcnyu/.../harness/` is deliberately out of scope, and not by
+# oversight: it is reached through `clawock brief|report|intraday`, which is what
+# the OpenClaw payloads literally invoke. If that code is running at all, the
+# name already resolved — the runtime's own environment is the proof. Widening
+# this test to cover it would fail 15 working call sites and teach the next
+# reader to delete the test.
+SEARCH_ROOTS = ("ops", ".githooks")
+
+# The shell resolver is the one place allowed to say the bare word, because
+# saying it *is* its job: it probes for the command and falls back when absent.
+# `ops/system_check.py` is deliberately NOT exempt. Exempting the file that had
+# the bug is how the first version of this test passed against the bug it was
+# written for — its Python resolver returns the *resolved absolute path*, so it
+# has no bare literal to hide behind.
+RESOLVERS = {
+    "ops/publish/money_checker.sh",
+}
+
+
+def _python_files():
+    for name in SEARCH_ROOTS:
+        for path in sorted((ROOT / name).rglob("*.py")):
+            if "__pycache__" not in path.parts:
+                yield path
+
+
+def _shell_files():
+    for name in SEARCH_ROOTS:
+        base = ROOT / name
+        for path in sorted(base.rglob("*")):
+            if path.is_file() and (path.suffix == ".sh" or base.name == ".githooks"):
+                yield path
+
+
+def test_no_python_caller_spawns_a_bare_clawock():
+    """An argv vector whose first element is the literal string."""
+    offenders = []
+    for path in _python_files():
+        rel = str(path.relative_to(ROOT))
+        if rel in RESOLVERS:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), rel)
+        except SyntaxError as exc:  # pragma: no cover - would fail elsewhere
+            pytest.fail(f"{rel} does not parse: {exc}")
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            first = node.args[0]
+            if not isinstance(first, (ast.List, ast.Tuple)) or not first.elts:
+                continue
+            head = first.elts[0]
+            if isinstance(head, ast.Constant) and head.value == "clawock":
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "these spawn `clawock` by name, which resolves only when the caller's "
+        "PATH happens to include ~/.local/bin — it does not under cron: "
+        f"{offenders}. Use ops/system_check.py:clawock_argv, or the shell "
+        "resolver ops/publish/money_checker.sh.")
+
+
+# A command word at the start of a line, or right after a pipe / && / ; / $( .
+BARE_CALL = re.compile(r"(?:^|[|;&]|\$\(|\bif\s+|\bthen\s+|!\s*)\s*clawock\s")
+
+
+def test_no_shell_caller_invokes_a_bare_clawock():
+    """Same rule for the shell side, where the first failure happened."""
+    offenders = []
+    for path in _shell_files():
+        rel = str(path.relative_to(ROOT))
+        if rel in RESOLVERS:
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            code = line.split("#", 1)[0]
+            if BARE_CALL.search(code):
+                offenders.append(f"{rel}:{number}  {line.strip()[:70]}")
+
+    assert not offenders, (
+        "these invoke `clawock` as a bare command; under the user crontab's "
+        f"PATH=/usr/bin:/bin it is not found:\n  " + "\n  ".join(offenders))
+
+
+def test_the_resolver_prefers_the_installed_command_but_does_not_need_it(monkeypatch):
+    """The resolver's own contract, both branches.
+
+    Without this the test above is satisfiable by deleting every call site.
+    """
+    import sys
+    sys.path.insert(0, str(ROOT / "ops"))
+    import system_check  # noqa: E402
+
+    monkeypatch.setattr(system_check.shutil, "which", lambda _name: "/usr/bin/clawock")
+    argv, _ = system_check.clawock_argv("doctor")
+    assert argv == ["/usr/bin/clawock", "doctor"], argv
+
+    monkeypatch.setattr(system_check.shutil, "which", lambda _name: None)
+    argv, env = system_check.clawock_argv("doctor")
+    assert argv[1:] == ["-m", "clawock.cli", "doctor"], argv
+    assert str(ROOT / "src") in env["PYTHONPATH"], (
+        "the fallback spawns a subprocess, which does not inherit sys.path — "
+        "without PYTHONPATH it cannot import the package it just chose")


### PR DESCRIPTION
## Found by the failure, not by looking

The live checkout this morning: `## master...origin/master [ahead 1, behind 4]`. The 03:20 dreaming commit had been sitting unpushed for five hours.

```
✗ CRITICAL  dashboard.json build  [Errno 2] No such file or directory: 'clawock'
🚫 1 critical failure(s) — push/commit BLOCKED
🚫 push blocked by clawock system_check (critical failures above)
✗ push failed after 3 retries
```

`ops/host/commit_dreaming.sh` is launched from the user crontab, so `PATH=/usr/bin:/bin`. `ops/system_check.py:232` spawned a bare `clawock dashboard-build`, got `FileNotFoundError`, and reported it as CRITICAL — and the pre-push hook turns any CRITICAL into a blocked push. A gate with nothing to say about dreaming notes stopped them anyway.

Reproduced exactly:

```
$ env -i PATH=/usr/bin:/bin HOME=/root python3 ops/system_check.py
  clawock system check  · 15 ok · 1 warn · 1 critical
  ✗ CRITICAL  dashboard.json build  [Errno 2] No such file or directory: 'clawock'
```

after:

```
  clawock system check  · 16 ok · 1 warn · 0 critical
  ✓ OK  dashboard.json build  134,650 bytes
```

## This is the same bug as #438, and that is the point

#438 fixed `safe_push.sh` and `.githooks/pre-push` this morning. Three hours later the same root cause stranded a different commit through a third site.

The mistake was not missing a file. It was fixing **the two sites I already knew about** and never asking where else the shape occurs. So half of this PR is the resolver and half is discovery.

`clawock_argv()` mirrors `ops/publish/money_checker.sh` on the Python side: prefer the installed command by resolved absolute path, otherwise run `clawock.cli` out of this checkout with `PYTHONPATH` set — a subprocess does not inherit `sys.path`, which is the part that is easy to get wrong.

`tests/test_no_bare_clawock_invocation.py` walks `ops/` and `.githooks/` and asks by shape whether anything spawns the bare name: Python argv vectors via AST, shell command words by position. It **discovers** call sites rather than listing them, so the fourth one fails in CI instead of at 03:20 on the live host.

## Two scoping decisions

**`instances/kcnyu/.../harness/` is out of scope on purpose.** The first draft flagged 15 call sites there. They are not broken: that code is reached through `clawock brief|report|intraday`, which is literally what the OpenClaw cron payloads invoke. If it is running at all, the name already resolved — the runtime's own environment is the proof. Widening the test to cover them would fail 15 working sites and teach the next reader to delete the test.

**`ops/system_check.py` is deliberately NOT exempt.** My first draft put it in the resolver allowlist, and the mutation check then passed *against the very bug this PR fixes* — restoring the bare argv vector stayed green. The Python resolver returns the resolved absolute path precisely so it has no bare literal to hide behind.

## Mutation verification

| mutation | result |
|---|---|
| restore `['clawock', 'dashboard-build']` in system_check | Python check red |
| append `clawock integrity` to safe_push.sh | shell check red |
| `which` returns a path / returns None | both resolver branches asserted |

## One related finding, not fixed here

`instances/kcnyu/src/clawock_kcnyu/gold/update.py:108` spawns a bare `clawock dashboard-build` with `check=False`, so under a bare PATH it fails **silently**. It is a manual reconciliation path — the nightly `ops/host/gold_dca_refresh.sh` calls the launcher by absolute path and is unaffected — but silent is worse than loud. Recorded on #442's sibling rather than widened into this PR an hour before the HK open.

Merging without a second agent under kcn's 2026-08-10 instruction; all six required checks must still be green.