### PR TITLE
fix: the gold reconciliation's refresh failed silently under a bare PATH

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/gold/update.py
+++ b/instances/kcnyu/src/clawock_kcnyu/gold/update.py
@@ -23,6 +23,7 @@
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -35,6 +36,30 @@ from clawock.workspace import workspace_root
 WS_ROOT = str(workspace_root(Path.cwd()))
 
 PORTFOLIO = os.path.join(WS_ROOT, 'portfolio.json')
+
+
+def _console(name):
+    """Locate a console script without trusting the caller's PATH.
+
+    Both of the commands below used to be spawned by bare name with
+    `check=False`, so under the user crontab's PATH=/usr/bin:/bin they raised
+    FileNotFoundError and were swallowed: the refresh silently did not happen
+    and the run still reported success. That is the quiet cousin of the bug
+    that blocked the 03:20 dreaming push, and quiet is worse.
+
+    The console scripts are installed beside the interpreter running this
+    module, so that directory is the reliable answer when PATH has nothing —
+    but only when this really is the environment they were installed into. Run
+    under the system interpreter it resolves to /usr/bin, where nothing lives,
+    so the candidate is checked before it is trusted and the bare name is
+    returned otherwise: an unresolvable command should fail with the message
+    everyone recognises rather than with a path this function invented.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    beside = Path(sys.executable).parent / name
+    return str(beside) if beside.exists() else name
 
 
 def latest_nav(code):
@@ -101,11 +126,11 @@ def main():
 
     if not a.no_refresh:
         print('  刷新净值 + 重建 dashboard…')
-        subprocess.run(['clawock-kcnyu-gold-fetch'], check=False)
+        subprocess.run([_console('clawock-kcnyu-gold-fetch')], check=False)
         # Rebuilt so this host's copy is current; NOT staged. The four outputs
         # left the repository in #314 — the scheduled publisher puts them on the
         # data branch, at most 20 minutes behind this commit.
-        subprocess.run(['clawock', 'dashboard-build'],
+        subprocess.run([_console('clawock'), 'dashboard-build'],
                        check=False, stdout=subprocess.DEVNULL)
 
     if a.publish:


### PR DESCRIPTION
Recorded as a known finding in #443 and cleared here rather than left open.

`instances/kcnyu/src/clawock_kcnyu/gold/update.py` spawned two console scripts by bare name with `check=False`:

```python
subprocess.run(['clawock-kcnyu-gold-fetch'], check=False)
subprocess.run(['clawock', 'dashboard-build'], check=False, stdout=subprocess.DEVNULL)
```

Under the user crontab's `PATH=/usr/bin:/bin` both raise `FileNotFoundError`, and `check=False` swallows it. The reconciliation prints "刷新净值 + 重建 dashboard…" and then success, having done neither.

This is the quiet form of the bug that blocked the 03:20 dreaming push (#443). Loud is better: there the CRITICAL at least stopped something. Here the run reports done.

## Fix

Console scripts install beside the interpreter running the module, so that directory answers when PATH cannot. Verified against the production venv under `env -i PATH=/usr/bin:/bin`:

```
clawock                   -> /root/.local/share/clawock/venv/bin/clawock                   exists=True
clawock-kcnyu-gold-fetch  -> /root/.local/share/clawock/venv/bin/clawock-kcnyu-gold-fetch  exists=True
```

The candidate is checked for existence before it is trusted. My first version was not, and the check caught it: run under the system interpreter it resolved to `/usr/bin/clawock`, which does not exist. Returning the bare name in that case means an unresolvable command still fails with the message everyone recognises, rather than with a path this function invented.

## Scope

The nightly path is unaffected either way — `ops/host/gold_dca_refresh.sh` already calls the launcher by absolute path, which is why the 23:50 job's rebuild has been working. This is the manual `clawock-kcnyu-gold-update` reconciliation path.

Not covered by #443's shape guard, which is deliberately scoped to `ops/` and `.githooks/`: everything else under `instances/` is reached through the OpenClaw payloads, which prove the name resolved by the fact that they ran. This file is the exception — a console script that a person or a host cron can invoke directly — so it is fixed rather than swept into the guard's scope.

Merging without a second agent under kcn's 2026-08-10 instruction; all six required checks must still be green.