### PR TITLE
docs: put installation on the first screen, in both languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**Evidence**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**简体中文**](README.zh.md)
 
+```bash
+pip install "clawock @ git+https://github.com/KCNyu/clawock.git"   # PyPI: #379
+clawock init ./my-decision --workflow investment-decision
+```
+
 <br>
 
 <a href="https://kcnyu.github.io/clawock/">

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,6 +14,11 @@
 
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**证据与反证**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**English**](README.md)
 
+```bash
+pip install "clawock @ git+https://github.com/KCNyu/clawock.git"   # PyPI 待发布：#379
+clawock init ./my-decision --workflow investment-decision
+```
+
 <br>
 
 <a href="https://kcnyu.github.io/clawock/">


### PR DESCRIPTION
Refs #383 (one bounded acceptance item; the editorial/media redesign remains gated on the final live UI).

The first screen told a reader what clawock does and linked the live proof four ways, but not how to install it — that was at line 217, past the information layer, the debate, the scorecard and the test results.

Both commands shown are the ones verified against the built wheel in a clean venv under `env -i` (transcript in the #383 comment), so the first screen promises only what an outside reader actually gets. Git install rather than a bare PyPI name, since the name is not published until #379; the inline pointer says so.

English and Chinese changed identically, preserving the 16/16 heading parity.