### PR TITLE
perf: stop the render-abort guard from forcing a layout per renderer

### DIFF
--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -82,10 +82,26 @@
     }
   }
 
+  // Which page the pager is on, without asking the layout engine.
+  //
+  // Reading scrollLeft/clientWidth is layout-forcing, and the render loop calls
+  // this between renderers — immediately after each one's DOM writes. That
+  // read-after-write interleave forced a synchronous layout once per renderer:
+  // 162ms of the 1,016ms spent in layout on a mobile startup profile (#442),
+  // across two call sites, `renderLandingTab`'s step() and ensureVisibleCharts.
+  //
+  // The scroll handler below already computes this index every animation frame
+  // in order to move `.tab-btn.active`, so the value is maintained regardless.
+  // Caching it there means the geometry is read once per frame by the code whose
+  // job that is, instead of once per renderer by code that only needs to know
+  // whether the user has navigated away. Worst-case staleness is one frame, and
+  // every caller is a guard that tolerates it — aborting a render one renderer
+  // late is the same outcome as aborting it on time.
+  let pagerIndex = 0;
+
   function currentTab() {
     if (pagerLive()) {
-      const i = Math.round(pager.scrollLeft / (pager.clientWidth || 1));
-      return TAB_ORDER[Math.max(0, Math.min(TAB_ORDER.length - 1, i))];
+      return TAB_ORDER[Math.max(0, Math.min(TAB_ORDER.length - 1, pagerIndex))];
     }
     const active = document.querySelector(".tab-btn.active");
     return active ? active.dataset.tab : TAB_ORDER[0];
@@ -96,6 +112,7 @@
   function goToTab(t, smooth = true) {
     if (!TAB_ORDER.includes(t)) return false;
     const idx = TAB_ORDER.indexOf(t);
+    pagerIndex = idx;                          // keep the cache ahead of the scroll
     if (pagerLive()) {
       pager.scrollTo({ left: idx * pager.clientWidth, behavior: smooth ? SCROLL_BEHAVIOR : "auto" });
     }
@@ -122,6 +139,7 @@
       raf = requestAnimationFrame(() => {
         raf = 0;
         const idx = Math.round(pager.scrollLeft / (pager.clientWidth || 1));
+        pagerIndex = Math.max(0, Math.min(TAB_ORDER.length - 1, idx));
         if (idx !== lastIdx) {
           lastIdx = idx;
           const t = TAB_ORDER[Math.max(0, Math.min(TAB_ORDER.length - 1, idx))];

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -294,6 +294,66 @@ async function testEquityTouch(browser, base) {
   await context.close();
 }
 
+// `currentTab()` used to read pager.scrollLeft/clientWidth, which forces layout,
+// and the hero render loop calls it between renderers — right after each one's
+// DOM writes. That interleave cost 162ms of the 1,016ms spent in layout on a
+// mobile startup profile (#442). It now reads an index the scroll handler
+// already maintains every frame.
+//
+// The guard exists to stop a render in flight when the user navigates away, so
+// "it no longer forces layout" is only half of what has to hold: the cache must
+// also still tell the truth about where the pager is.
+async function testTabGuardWithoutForcedLayout(browser, base) {
+  const context = await browser.newContext({
+    viewport: { width: 412, height: 823 }, isMobile: true, hasTouch: true,
+  });
+  const page = await context.newPage();
+  await stubLiveOrigin(page);
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+
+  // 1. A full hero render must not read the pager's geometry at all. Counting on
+  //    the element shadows the prototype getter, so this measures real accesses
+  //    rather than trusting the source.
+  const reads = await page.evaluate(async () => {
+    const pager = document.getElementById("pager");
+    const descriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollLeft");
+    let count = 0;
+    Object.defineProperty(pager, "scrollLeft", {
+      configurable: true,
+      get() { count += 1; return descriptor.get.call(this); },
+    });
+    loadData(false);
+    await new Promise(resolve => setTimeout(resolve, 1500));
+    delete pager.scrollLeft;
+    return count;
+  });
+  assert.equal(reads, 0,
+    `hero render forced ${reads} layout-inducing read(s) of pager.scrollLeft`);
+
+  // 2. The guard must observe a tab change immediately. This is stricter than
+  //    the geometry was: scrollTo is smooth, so scrollLeft kept reporting the
+  //    OLD tab for the length of the animation, and the render it was supposed
+  //    to abort carried on until the scroll caught up.
+  const afterGoTo = await page.evaluate(() => {
+    goToTab("risk");
+    return currentTab();
+  });
+  assert.equal(afterGoTo, "risk", "currentTab() did not follow goToTab synchronously");
+
+  // 3. And it must not drift from a scroll the code did not initiate — a real
+  //    swipe moves scrollLeft with no goToTab call anywhere.
+  await page.evaluate(() => {
+    const pager = document.getElementById("pager");
+    pager.scrollLeft = TAB_ORDER.indexOf("market") * pager.clientWidth;
+    pager.dispatchEvent(new Event("scroll"));
+  });
+  await page.waitForFunction(() => currentTab() === "market", null, { timeout: 4000 })
+    .catch(() => { throw new Error("currentTab() drifted from an uninstrumented scroll"); });
+
+  await context.close();
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -306,6 +366,7 @@ async function main() {
     await testRuntime(browser, base);
     await testLiveDataOrigin(browser, base);
     await testEquityTouch(browser, base);
+    await testTabGuardWithoutForcedLayout(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));


### PR DESCRIPTION
Refs #442.

`currentTab()` read `pager.scrollLeft`/`clientWidth` — layout-forcing — and the hero render loop calls it between renderers, right after each one's DOM writes. That read-after-write interleave forced a synchronous layout once per renderer: **162ms of the 1,016ms** spent in layout on a mobile startup trace, across two call sites (`renderLandingTab`'s `step()` and `ensureVisibleCharts`).

The scroll handler already computes this index every animation frame to move `.tab-btn.active`, so nothing new is tracked. The geometry is now read once per frame by the code whose job that is, rather than once per renderer by code that only needs to know whether the user navigated away.

**It is also more correct than the geometry was.** `scrollTo` is smooth, so `scrollLeft` reported the *old* tab for the length of the animation — a render the guard was supposed to abort ran on until the scroll caught up. `goToTab` now sets the index before starting the scroll.

Worst-case staleness is one frame, and every caller is a guard that tolerates it.

### Tested three ways, because "no longer forces layout" is half the claim

1. a counting getter defined on the element (shadowing the prototype getter, so it measures real accesses) proves a full hero render reads `scrollLeft` **zero** times;
2. `currentTab()` follows `goToTab` **synchronously** — the case the old geometry got wrong;
3. it still follows a scroll the code did not initiate, which is what a real swipe is.

Mutation-verified: restoring the geometry read fails (1) with `hero render forced 1 layout-inducing read(s) of pager.scrollLeft`.

The full browser contract passes locally against the fetched published generation.