### PR TITLE
fix: context parity blamed the model backend for a deliberate runtime rule

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -512,6 +512,68 @@ def check_decision_ledger(r):
         r.add('decisions.jsonl', OK, f'{len(rows)} decisions · {len({x.get("episode_id") for x in rows})} episodes')
 
 
+def check_context_capability(r):
+    """A run that came out with no skills or no tools has to fail somewhere.
+
+    `clawock context audit` answers a different question — it verifies the
+    workspace has the documents and capability roots — so a loss that happens
+    at *assembly* time leaves it green. That is the exact failure #380 exists to
+    prevent, and until this check existed nothing looked at a realized run.
+
+    Warning rather than critical on purpose: a narrowed context is visible in
+    the daily health output, but it says nothing about whether the book
+    reconciles, and this gate blocks pre-push.
+    """
+    from clawock.context.assembly import verify_prompt_report
+
+    store = _OPENCLAW_PATHS.sessions_dir / 'sessions.json'
+    if not store.exists():
+        r.add('context capability', OK, 'no runtime session store (skipped)')
+        return
+    try:
+        sessions = json.loads(store.read_text())
+    except Exception as e:
+        r.add('context capability', WARNING, f'session store unreadable: {e}')
+        return
+
+    newest = {}
+    for key, entry in (sessions or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        report = entry.get('systemPromptReport')
+        if not isinstance(report, dict):
+            continue
+        profile = 'isolated-cron' if ':cron:' in key else 'interactive'
+        try:
+            stamp = int(entry.get('updatedAt') or entry.get('lastInteractionAt') or 0)
+        except (TypeError, ValueError):
+            stamp = 0
+        if stamp >= newest.get(profile, (-1,))[0]:
+            newest[profile] = (stamp, key, report)
+    if not newest:
+        r.add('context capability', OK, 'no prompt report recorded yet')
+        return
+
+    failures, checked = [], []
+    for profile, (_stamp, key, report) in sorted(newest.items()):
+        try:
+            result = verify_prompt_report(report, profile=profile)
+        except ValueError as e:
+            failures.append(f'{profile}: unreadable report ({e})')
+            continue
+        failed = [name for name, ok in result['checks'].items() if ok is False]
+        if failed:
+            failures.append(f'{profile} {key[-24:]}: {", ".join(failed)}')
+        else:
+            seen = result['observed']
+            checked.append(
+                f'{profile} {len(seen["files"])}f/{seen["skills"]}s/{seen["tools"]}t')
+    if failures:
+        r.add('context capability', WARNING, '; '.join(failures))
+    else:
+        r.add('context capability', OK, ' · '.join(checked))
+
+
 def check_cron_paths_exist(r):
     """Live cron schedules match the tracked contract and payload scripts exist.
 
@@ -794,6 +856,7 @@ def main():
         check_peer_map_coverage,
         check_openclaw_doctor,
         check_decision_ledger,
+        check_context_capability,
         check_cron_paths_exist,
         check_generated_cron_docs,
         check_research_artifacts,

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -290,6 +290,7 @@ def _context(args) -> int:
         audit,
         compare_prompt_reports,
         load_prompt_report,
+        verify_prompt_report,
     )
 
     root = workspace_root(getattr(args, "workspace", None) or Path.cwd())
@@ -306,6 +307,13 @@ def _context(args) -> int:
                 load_prompt_report(
                     args.after, session_key=args.after_session_key
                 ),
+                profile=args.profile,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0 if result["ok"] else 1
+        if args.context_command == "verify":
+            result = verify_prompt_report(
+                load_prompt_report(args.report, session_key=args.session_key),
                 profile=args.profile,
             )
             print(json.dumps(result, ensure_ascii=False, indent=2))
@@ -675,6 +683,13 @@ def main(argv=None) -> int:
     context_compare.add_argument("--before-session-key")
     context_compare.add_argument("--after-session-key")
     context_compare.set_defaults(func=_context)
+    context_verify = context_sub.add_parser(
+        "verify",
+        help="check one OpenClaw system-prompt report against its profile")
+    context_verify.add_argument("--profile", required=True)
+    context_verify.add_argument("--report", type=Path, required=True)
+    context_verify.add_argument("--session-key")
+    context_verify.set_defaults(func=_context)
 
     workflow = sub.add_parser(
         "workflow", help="discover or install portable decision-workflow skills")

--- a/src/clawock/context/assembly.py
+++ b/src/clawock/context/assembly.py
@@ -193,6 +193,41 @@ def load_prompt_report(path, *, session_key: str | None = None) -> dict:
     )
 
 
+def skills_delivery(provider: str | None) -> str:
+    """How a model backend receives the skills catalog.
+
+    OpenClaw does not put the catalog in the system prompt for every backend.
+    A CLI backend that owns its own skill loader is handed the same resolved
+    snapshot out of band, so its prompt report shows zero skills while the
+    session still carries all of them.
+    """
+    backends = load_manifest()["backends"]["skills_delivery"]
+    normalized = (provider or "").strip().lower()
+    for mode, providers in backends.items():
+        if mode == "default":
+            continue
+        if normalized in providers:
+            return mode
+    return backends["default"]
+
+
+def session_family(session_key: str | None) -> str | None:
+    """The dialect a session key belongs to, ignoring the job or peer id.
+
+    ``agent:main:cron:<job-uuid>`` is ``cron`` for every job because the
+    projection is job-independent; ``agent:main:openclaw-weixin:direct:<peer>``
+    is ``openclaw-weixin`` because the message tool schema is channel-sensitive.
+    A named one-off session is its own family: two differently named sessions on
+    the same backend were observed with different tool sets.
+    """
+    if not isinstance(session_key, str) or not session_key.strip():
+        return None
+    parts = [part for part in session_key.split(":") if part]
+    if len(parts) < 3 or parts[0] != "agent":
+        return session_key.strip()
+    return parts[2]
+
+
 def _prompt_report_projection(report: Mapping[str, Any]) -> dict:
     injected = report.get("injectedWorkspaceFiles")
     skills = report.get("skills")
@@ -222,11 +257,16 @@ def _prompt_report_projection(report: Mapping[str, Any]) -> dict:
         for item in tool_entries
         if isinstance(item, dict) and isinstance(item.get("name"), str)
     }
+    provider = report.get("provider")
+    provider = provider.strip() if isinstance(provider, str) and provider.strip() else None
     return {
         "files": files,
         "skill_names": skill_names,
         "skills_hash": skills.get("hash"),
         "tool_contracts": tool_contracts,
+        "provider": provider,
+        "skills_delivery": skills_delivery(provider),
+        "family": session_family(report.get("sessionKey")),
     }
 
 
@@ -246,29 +286,94 @@ def compare_prompt_reports(
             and not any(item.get("missing") or item.get("truncated") for item in projected["files"])
         )
 
+    same_backend = baseline["skills_delivery"] == candidate["skills_delivery"]
+    same_family = baseline["family"] == candidate["family"]
+    comparable = same_backend and same_family
     checks = {
         "before_profile": files_ok(baseline),
         "after_profile": files_ok(candidate),
         "workspace_files": baseline["files"] == candidate["files"],
-        "skills_catalog": (
+        "backend_dialect": same_backend,
+        "session_family": same_family,
+        # A capability diff is only attributable to a code change when both
+        # sides speak the same backend and session dialect. Reporting these as
+        # regressions across dialects would blame a deliberate runtime rule.
+        "skills_catalog": None if not comparable else (
             baseline["skill_names"] == candidate["skill_names"]
             and baseline["skills_hash"] == candidate["skills_hash"]
         ),
-        "tool_contracts": baseline["tool_contracts"] == candidate["tool_contracts"],
+        "tool_contracts": None if not comparable else (
+            baseline["tool_contracts"] == candidate["tool_contracts"]
+        ),
+    }
+
+    def side(projected):
+        return {
+            "files": [item["name"] for item in projected["files"]],
+            "skills": len(projected["skill_names"]),
+            "tools": len(projected["tool_contracts"]),
+            "provider": projected["provider"],
+            "skills_delivery": projected["skills_delivery"],
+            "family": projected["family"],
+        }
+
+    return {
+        "runtime_contract": manifest["runtime_contract"],
+        "profile": profile,
+        "comparable": comparable,
+        "unattributable": (
+            [] if comparable else ["skills_catalog", "tool_contracts"]
+        ),
+        "checks": checks,
+        "before": side(baseline),
+        "after": side(candidate),
+        "ok": all(value is True for value in checks.values()),
+    }
+
+
+def verify_prompt_report(report: Mapping[str, Any], *, profile: str) -> dict:
+    """Check one realized session against the profile it claims to be.
+
+    ``compare_prompt_reports`` needs a pair, and ``audit`` only sees the
+    workspace, so a single run that came out with no skills or a narrowed tool
+    set had nowhere to fail. Backend dialect decides what is checkable: a
+    runtime-plugin backend legitimately reports an empty catalog, so that check
+    is reported as unverified rather than passed.
+    """
+    manifest = load_manifest()
+    _, contract = _profile(manifest, profile)
+    projected = _prompt_report_projection(report)
+    expected_files = contract["bootstrap"]
+    delivery = projected["skills_delivery"]
+    checks: dict[str, bool | None] = {
+        "bootstrap_files": (
+            [item["name"] for item in projected["files"]] == expected_files
+        ),
+        "no_missing_document": not any(
+            item.get("missing") for item in projected["files"]
+        ),
+        "no_truncation": not any(
+            item.get("truncated") for item in projected["files"]
+        ),
+        "tools_present": bool(projected["tool_contracts"]),
+        "skills_present": (
+            None if delivery != "system-prompt" else bool(projected["skill_names"])
+        ),
     }
     return {
         "runtime_contract": manifest["runtime_contract"],
         "profile": profile,
+        "provider": projected["provider"],
+        "skills_delivery": delivery,
+        "family": projected["family"],
+        "unverified": [
+            name for name, value in checks.items() if value is None
+        ],
         "checks": checks,
-        "before": {
-            "files": [item["name"] for item in baseline["files"]],
-            "skills": len(baseline["skill_names"]),
-            "tools": len(baseline["tool_contracts"]),
+        "observed": {
+            "files": [item["name"] for item in projected["files"]],
+            "skills": len(projected["skill_names"]),
+            "tools": len(projected["tool_contracts"]),
         },
-        "after": {
-            "files": [item["name"] for item in candidate["files"]],
-            "skills": len(candidate["skill_names"]),
-            "tools": len(candidate["tool_contracts"]),
-        },
-        "ok": all(checks.values()),
+        "ok": all(value for value in checks.values() if value is not None),
     }

--- a/src/clawock/context/manifest.json
+++ b/src/clawock/context/manifest.json
@@ -1,12 +1,13 @@
 {
   "runtime_contract": "openclaw-context-profiles-2026.7.1",
-  "schema_version": 2,
+  "schema_version": 3,
   "verified_against": "OpenClaw 2026.7.1 (2d2ddc4)",
   "source_symbols": [
     "loadWorkspaceBootstrapFiles",
     "filterBootstrapFilesForSession",
     "applyContextModeFilter",
-    "buildSystemPromptReport"
+    "buildSystemPromptReport",
+    "prepareClaudeCliSkillsPlugin"
   ],
   "default_profile": "isolated-cron",
   "profiles": {
@@ -114,6 +115,15 @@
   "tools": {
     "ownership": "OpenClaw assembles schemas and enforces policy",
     "clawock_policy": "never narrow the runtime tool set implicitly"
+  },
+  "backends": {
+    "ownership": "OpenClaw decides how each model backend receives skills and tools",
+    "skills_delivery": {
+      "default": "system-prompt",
+      "runtime-plugin": ["claude-cli"]
+    },
+    "runtime_plugin_note": "A runtime-plugin backend receives the same resolved skill snapshot out of band (claude-cli gets a materialized --plugin-dir plugin) and drops the file/exec tools the CLI already owns. Its prompt report therefore shows an empty skills catalog and a narrower tool set with no capability lost, so those fields cannot be compared against a system-prompt backend.",
+    "channel_family": "the session-key segment after the agent id; jobs and peers inside one family share a tool dialect, and the message tool schema differs between families"
   },
   "memory_search": {
     "default_sources": ["memory"],

--- a/tests/test_context_contract.py
+++ b/tests/test_context_contract.py
@@ -9,6 +9,7 @@ from clawock.context.assembly import (
     compare_prompt_reports,
     load_manifest,
     profile_names,
+    verify_prompt_report,
 )
 
 
@@ -90,6 +91,114 @@ def test_prompt_report_comparison_catches_tool_capability_loss():
     result = compare_prompt_reports(report, narrowed, profile="isolated-cron")
     assert not result["ok"]
     assert not result["checks"]["tool_contracts"]
+
+
+def _report(profile_files, *, skills=("trading",), provider=None,
+            session_key=None, tools=("read", "memory_search")):
+    payload = {
+        "injectedWorkspaceFiles": [
+            {"name": name, "missing": False, "rawChars": 10,
+             "injectedChars": 10, "truncated": False}
+            for name in profile_files
+        ],
+        "skills": {
+            "hash": "skill-hash" if skills else "empty",
+            "entries": [{"name": name} for name in skills],
+        },
+        "tools": {"entries": [
+            {"name": name, "summaryHash": name, "schemaHash": f"{name}-1"}
+            for name in tools
+        ]},
+    }
+    if provider:
+        payload["provider"] = provider
+    if session_key:
+        payload["sessionKey"] = session_key
+    return payload
+
+
+def test_a_backend_that_delegates_skills_is_not_a_capability_regression():
+    """claude-cli receives the catalog as a plugin, so its report shows zero.
+
+    Comparing it against a system-prompt backend used to read as "the agent
+    lost 29 skills and 5 tools", which is a deliberate runtime rule, not a
+    regression. The pair must be rejected as uncomparable instead.
+    """
+    delegated = _report(
+        INTERACTIVE, skills=(), provider="claude-cli",
+        session_key="agent:main:openclaw-weixin:direct:peer@im.wechat",
+        tools=("memory_search",),
+    )
+    in_prompt = _report(
+        INTERACTIVE, provider="minimax", session_key="agent:main:main")
+
+    result = compare_prompt_reports(delegated, in_prompt, profile="interactive")
+
+    assert not result["ok"]
+    assert not result["comparable"]
+    assert not result["checks"]["backend_dialect"]
+    assert not result["checks"]["session_family"]
+    # The capability checks must abstain rather than blame the runtime rule.
+    assert result["checks"]["skills_catalog"] is None
+    assert result["checks"]["tool_contracts"] is None
+    assert result["unattributable"] == ["skills_catalog", "tool_contracts"]
+    assert result["before"]["skills_delivery"] == "runtime-plugin"
+    assert result["after"]["skills_delivery"] == "system-prompt"
+
+
+def test_two_accounts_on_one_backend_stay_comparable():
+    """Live cron alternates `minimax` and `minimax-2` with the same surface.
+
+    A gate keyed on the raw provider string would redden a schedule that is
+    working, so the dialect — not the account — decides comparability.
+    """
+    before = _report(CRON, provider="minimax",
+                     session_key="agent:main:cron:11111111-job-a")
+    after = _report(CRON, provider="minimax-2",
+                    session_key="agent:main:cron:22222222-job-b")
+
+    result = compare_prompt_reports(before, after, profile="isolated-cron")
+
+    assert result["comparable"]
+    assert result["ok"], result["checks"]
+    assert result["before"]["family"] == result["after"]["family"] == "cron"
+
+
+def test_verify_fails_a_session_that_silently_lost_its_skills():
+    """One report had nowhere to fail: audit sees the workspace, compare needs a pair."""
+    healthy = _report(INTERACTIVE, provider="minimax",
+                      session_key="agent:main:main")
+    assert verify_prompt_report(healthy, profile="interactive")["ok"]
+
+    stripped = _report(INTERACTIVE, skills=(), provider="minimax",
+                       session_key="agent:main:main")
+    result = verify_prompt_report(stripped, profile="interactive")
+    assert not result["ok"]
+    assert result["checks"]["skills_present"] is False
+    assert result["unverified"] == []
+
+    # The same empty catalog on a delegating backend is not evidence either way.
+    delegated = _report(INTERACTIVE, skills=(), provider="claude-cli",
+                        session_key="agent:main:openclaw-weixin:direct:peer")
+    delegated_result = verify_prompt_report(delegated, profile="interactive")
+    assert delegated_result["ok"]
+    assert delegated_result["checks"]["skills_present"] is None
+    assert delegated_result["unverified"] == ["skills_present"]
+
+
+def test_verify_fails_a_report_that_does_not_match_the_claimed_profile():
+    cron_run = _report(CRON, provider="minimax",
+                       session_key="agent:main:cron:33333333-job-c")
+    assert verify_prompt_report(cron_run, profile="isolated-cron")["ok"]
+
+    result = verify_prompt_report(cron_run, profile="interactive")
+    assert not result["ok"]
+    assert result["checks"]["bootstrap_files"] is False
+
+    truncated = _report(INTERACTIVE, provider="minimax",
+                        session_key="agent:main:main")
+    truncated["injectedWorkspaceFiles"][0]["truncated"] = True
+    assert not verify_prompt_report(truncated, profile="interactive")["ok"]
 
 
 # Named so the runtime does NOT resurrect them. The docs are only truthful while

--- a/tests/test_system_check_context_capability.py
+++ b/tests/test_system_check_context_capability.py
@@ -1,0 +1,143 @@
+"""The health gate must look at a realized run, not only at the workspace.
+
+`clawock context audit` verifies that the workspace still holds the documents
+and capability roots. It stays green when the loss happens at assembly time —
+the run itself came back with no skills or a narrowed tool set — which is the
+failure #380 exists to prevent. This pins the gate that reads a real report.
+
+Behavioural rather than textual: the check is driven with synthetic session
+stores so that deleting its body, or making it blind to an empty catalog, turns
+these red.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CRON = ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"]
+INTERACTIVE = [*CRON, "HEARTBEAT.md", "MEMORY.md"]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src", ROOT / "instances" / "kcnyu" / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _report(files, *, skills, provider, tools=("read", "memory_search")):
+    return {
+        "provider": provider,
+        "injectedWorkspaceFiles": [
+            {"name": name, "missing": False, "rawChars": 8,
+             "injectedChars": 8, "truncated": False}
+            for name in files
+        ],
+        "skills": {
+            "hash": "h" if skills else "empty",
+            "entries": [{"name": name} for name in skills],
+        },
+        "tools": {"entries": [
+            {"name": name, "summaryHash": name, "schemaHash": f"{name}1"}
+            for name in tools
+        ]},
+    }
+
+
+def _run(system_check, monkeypatch, tmp_path, sessions):
+    store = tmp_path / "sessions"
+    store.mkdir(exist_ok=True)
+    (store / "sessions.json").write_text(json.dumps(sessions), encoding="utf-8")
+
+    class Paths:
+        sessions_dir = store
+
+    monkeypatch.setattr(system_check, "_OPENCLAW_PATHS", Paths)
+    result = system_check.Result()
+    system_check.check_context_capability(result)
+    return result.checks[0]
+
+
+def test_a_healthy_pair_of_live_profiles_passes(system_check, monkeypatch, tmp_path):
+    _, severity, message = _run(system_check, monkeypatch, tmp_path, {
+        "agent:main:main": {
+            "updatedAt": 20,
+            "systemPromptReport": _report(
+                INTERACTIVE, skills=("trading",), provider="minimax"),
+        },
+        "agent:main:cron:job-a": {
+            "updatedAt": 19,
+            "systemPromptReport": _report(
+                CRON, skills=("trading",), provider="minimax"),
+        },
+    })
+    assert severity == system_check.OK, message
+    assert "interactive" in message and "isolated-cron" in message
+
+
+def test_a_run_that_lost_its_skills_is_reported(system_check, monkeypatch, tmp_path):
+    _, severity, message = _run(system_check, monkeypatch, tmp_path, {
+        "agent:main:main": {
+            "updatedAt": 20,
+            "systemPromptReport": _report(
+                INTERACTIVE, skills=(), provider="minimax"),
+        },
+    })
+    # Warning, not critical: this gate blocks pre-push, and a narrowed context
+    # says nothing about whether the book reconciles.
+    assert severity == system_check.WARNING
+    assert "skills_present" in message
+
+
+def test_a_backend_that_delegates_skills_does_not_redden_the_gate(
+        system_check, monkeypatch, tmp_path):
+    """The live WeChat route runs on claude-cli, which gets the catalog as a
+    plugin instead of a prompt block. Failing it would redden a working host
+    every day, which is how a real warning stops being read."""
+    _, severity, _ = _run(system_check, monkeypatch, tmp_path, {
+        "agent:main:openclaw-weixin:direct:peer": {
+            "updatedAt": 20,
+            "systemPromptReport": _report(
+                INTERACTIVE, skills=(), provider="claude-cli"),
+        },
+    })
+    assert severity == system_check.OK
+
+
+def test_only_the_newest_run_of_each_profile_is_judged(
+        system_check, monkeypatch, tmp_path):
+    """Old sessions are history. Judging them would report a loss that has
+    already been fixed, and never clear."""
+    _, severity, _ = _run(system_check, monkeypatch, tmp_path, {
+        "agent:main:cron:old": {
+            "updatedAt": 1,
+            "systemPromptReport": _report(CRON, skills=(), provider="minimax"),
+        },
+        "agent:main:cron:new": {
+            "updatedAt": 2,
+            "systemPromptReport": _report(
+                CRON, skills=("trading",), provider="minimax"),
+        },
+    })
+    assert severity == system_check.OK
+
+
+def test_a_host_without_a_session_store_is_not_a_finding(
+        system_check, monkeypatch, tmp_path):
+    """CI and any clean clone have no runtime beside them."""
+    class Paths:
+        sessions_dir = tmp_path / "absent"
+
+    monkeypatch.setattr(system_check, "_OPENCLAW_PATHS", Paths)
+    result = system_check.Result()
+    system_check.check_context_capability(result)
+    assert result.checks[0][1] == system_check.OK


### PR DESCRIPTION
Parent: #380

## The finding

Every `claude-cli` session in the live session store reports **zero skills and 26
tools**; every other backend reports 27–29 skills and 31–37 tools. It is a clean
split — 6 sessions against 19 — and it is not a capability loss.

`prepareClaudeCliSkillsPlugin` in the installed runtime materializes the same
resolved skill snapshot as a Claude CLI `--plugin-dir` plugin instead of writing a
catalog block into the system prompt, and the tool set drops exactly the tools the
CLI already owns (`read`, `write`, `edit`, `exec`, `apply_patch`, `process`, `pdf`).
The session entries confirm it: the live WeChat session and `agent:main:main` carry
the **same 29-skill snapshot with the same 14,264-byte prompt blob hash**. Only the
delivery route differs.

So the comparator was reporting a deliberate runtime rule as a regression. A
before/after pair that crossed backends came out as "the agent lost 29 skills and 5
tools".

## What changed

**Comparability is decided by dialect, not by the provider string.** Live cron
alternates `minimax` and `minimax-2` across the two accounts with an identical
capability surface, so a gate keyed on the account name would redden a schedule
that is working. It is keyed on the backend's skills-delivery mode plus the session
family (`agent:main:cron:<job>` → `cron` for every job, which keeps the
job-independent cross-job comparison legitimate; `agent:main:openclaw-weixin:…` →
its own family, because the `message` tool schema is channel-sensitive).

When the dialects differ, `skills_catalog` and `tool_contracts` return `null` and
are listed under `unattributable` rather than reported as failures. The pair still
fails — `comparable: false` — it just names the real reason.

**`clawock context verify` is new**, because a single realized session had nowhere
to fail. `context audit` only sees the workspace; `context compare` needs a pair. A
system-prompt session that comes out with no skills is now red. The same empty
catalog on a delegating backend is reported as unverified, not passed — the report
is not evidence either way, and claiming it is would be the silent half of
#380's "silent capability loss must become a visible audit failure".

## Evidence

All 25 live prompt reports run through `verify`, so nothing that works turns red:

```
ok  interactive   claude-cli  runtime-plugin skills=  0 tools= 26 unverified=[skills_present]  ×5
ok  interactive   minimax     system-prompt  skills= 29 tools= 31 unverified=[]   agent:main:main
ok  interactive   openai      system-prompt  skills= 29 tools= 23 unverified=[]   telegram:direct
ok  isolated-cron minimax/-2  system-prompt  skills= 29 tools= 34 unverified=[]   ×11 cron jobs
```

Cross-backend pair, live WeChat (claude-cli) against `agent:main:main` (minimax):

```
"comparable": false,
"unattributable": ["skills_catalog", "tool_contracts"],
"checks": { "backend_dialect": false, "session_family": false,
            "skills_catalog": null, "tool_contracts": null }
```

Four mutations, each turning the new tests red:

| mutation | red test |
|---|---|
| drop `claude-cli` from the delegating list | delegation + verify |
| key comparability on the raw provider string | two-accounts |
| check `skills_present` regardless of delivery | verify |
| stop checking the skills catalog at all | verify |

Full suite: 1,738 passed, 10 skipped, 4 xfailed.

## Correction to earlier evidence on #380

The measurement note from this morning attributed `skills: 0` to turns started by
`openclaw agent`. The correlate is the **provider**, not the launch path — the live
WeChat session was not CLI-started and shows the identical shape. Interactive
before/after pairs must therefore hold the backend fixed as well as the channel,
which is now enforced by the tool instead of remembered by the operator.

## Update: the verifier now has a consumer

A verifier nobody runs would not catch the next silent loss — the same shape as
`clawock.tools` sitting at zero callers in #266. `ops/system_check.py` now judges
the newest run of each profile from the live session store:

```
✓ OK   context capability   interactive 7f/29s/31t · isolated-cron 5f/29s/34t
```

Warning rather than critical, because that gate blocks pre-push and a narrowed
context says nothing about whether the book reconciles. A host with no runtime
beside it (CI, a clean clone) reports OK and skips. Two more mutations — the gate
collecting no failures, and judging every historical session instead of the newest
per profile — each turn the new tests red.
