### PR TITLE
fix: three guards stopped scanning when the directory they scanned was deleted

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/_harness_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_harness_common.py
@@ -16,7 +16,6 @@ from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
-sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 
 # Single-publisher mutex for all dashboard build outputs (Option 1, 2026-07-04).
 # Shared by the host harness rebuild and publish_dashboard.sh crontab so the two
@@ -413,6 +412,5 @@ def safe_write_text(path, text):
 
     Keeps each postflight on the package-owned atomic-write implementation.
     """
-    sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
     from clawock.safe_io import safe_write_text as _swt
     _swt(str(path), text)

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -40,7 +40,6 @@ from clawock.decision import risk as risk_discipline
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 
-sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from clawock_kcnyu.automation import workflow_outcomes  # noqa: E402
 
 # Required concepts and the section labels the brief model may legitimately emit.

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -54,7 +54,6 @@ _CHECKOUT = WS
 TMP_DIR = WS / 'memory' / '.tmp'
 SNAPSHOT_DIR = WS / 'memory' / 'snapshots'
 
-sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from clawock_kcnyu.automation import workflow_outcomes  # noqa: E402
 from clawock.market_data.macro import classify_regime as _classify_regime  # noqa: E402
 from clawock.portfolio.instruments import get as get_instrument  # noqa: E402

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -67,7 +67,6 @@ WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
-sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from clawock_kcnyu.automation import cron_heartbeat  # noqa: E402
 
 # A report file older than this is assumed to be a previous slot's leftover. Kept

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
@@ -48,7 +48,6 @@ WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 
-sys.path.insert(0, str(_CHECKOUT / 'scripts' / 'data'))
 from clawock_kcnyu.automation import workflow_outcomes  # noqa: E402
 
 # The deterministic report core moved into the installed package so `clawock

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -203,7 +203,6 @@ def check_portfolio_schema(r):
 
 def check_instrument_registry(r):
     """Canonical metadata must cover every active holding."""
-    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
         from clawock.portfolio import instruments as instrument_registry
         portfolio = json.loads((WS / 'portfolio.json').read_text())
@@ -230,7 +229,6 @@ def check_plan_json_schema(r):
         r.add('plan.json schema', OK, '0 plans yet')
         return
     bad = []
-    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     from clawock.decision import ledger as decision_v2
     for p in plans:
         try:
@@ -493,7 +491,6 @@ def check_decision_ledger(r):
         r.add('decisions.jsonl', OK, 'no ledger yet (first runs)')
         return
     try:
-        sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
         from clawock.decision import ledger as decision_v2
         rows = decision_v2.load_decisions(p)
     except Exception as e:
@@ -670,7 +667,6 @@ def check_trading_calendar_horizon(r):
     holiday into a session. The table cannot be auto-generated (HK dates are
     gazetted, US ones move), so the only safe mechanism is a loud deadline.
     """
-    sys.path.insert(0, str(_REPO_ROOT / 'scripts' / 'data'))
     try:
         from clawock.market_data import sessions as trading_calendar
         coverage = trading_calendar.coverage()

--- a/tests/test_bar_checks.py
+++ b/tests/test_bar_checks.py
@@ -15,8 +15,6 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-DATA = ROOT / 'scripts' / 'data'
-sys.path.insert(0, str(DATA))
 
 from clawock.market_data import integrity as bar_checks  # noqa: E402
 
@@ -236,9 +234,25 @@ def test_no_script_re_implements_the_degenerate_check_privately():
     # A chained `a == b == c == d` is the shape of a hand-rolled degenerate-range
     # test. Matched through the AST, not the text: the prose in these files
     # legitimately quotes `o == h == l == c` when explaining the bug it caused.
+    # Scanned from where the code lives now. This used to glob `scripts/data`,
+    # which #429 deleted, so it walked zero files and passed for that reason;
+    # and it excluded `bar_checks.py` by name, which is the module that has
+    # since become `clawock.market_data.integrity`. Both halves are now derived
+    # rather than spelled, so a move cannot silently retire the check.
+    canonical = Path(bar_checks.__file__).resolve()
+    modules = [
+        path for root in ('src', 'ops', 'instances')
+        for path in sorted((ROOT / root).rglob('*.py'))
+        if '__pycache__' not in path.parts
+    ]
+    assert len(modules) > 50, f'only {len(modules)} modules scanned — did a root move?'
+    assert canonical in {p.resolve() for p in modules}, (
+        f'{canonical} is outside the scanned roots, so the one implementation '
+        'this test permits is not the one it is looking at')
+
     offenders = []
-    for path in sorted(DATA.glob('*.py')):
-        if path.name == 'bar_checks.py':
+    for path in modules:
+        if path.resolve() == canonical:
             continue
         try:
             tree = ast.parse(path.read_text())
@@ -248,7 +262,7 @@ def test_no_script_re_implements_the_degenerate_check_privately():
             if not isinstance(node, ast.Compare) or len(node.ops) < 3:
                 continue
             if all(isinstance(op, ast.Eq) for op in node.ops):
-                offenders.append(f'{path.name}:{node.lineno}')
+                offenders.append(f'{path.relative_to(ROOT)}:{node.lineno}')
 
     assert not offenders, (
         'private degenerate-range check(s) outside bar_checks.py:\n'

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -16,7 +16,6 @@ from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 from clawock_kcnyu.harness import brief_preflight
 from clawock.market_data import sessions as trading_calendar

--- a/tests/test_brief_data_ownership.py
+++ b/tests/test_brief_data_ownership.py
@@ -19,6 +19,7 @@ nobody can explain.
 Run: python3 -m pytest tests/test_brief_data_ownership.py -q
 """
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -71,44 +72,86 @@ def test_preflight_writes_are_committed():
         f'workflow took ownership.')
 
 
-def _repo_root_outputs():
-    """Repo-root files written by the scripts preflight shells out to.
+def _preflight_utilities():
+    """The packaged commands preflight shells out to, read from its own source."""
+    return sorted(set(re.findall(r"\[\s*'clawock',\s*'([a-z0-9-]+)'", PREFLIGHT)))
 
-    `{NAME} = WS / 'file'` at the top of a script, kept only when that constant is
-    actually written (not merely read) in the same file.
+
+def _utility_outputs():
+    """Every path those utilities write, at any depth, discovered from source.
+
+    This used to look for `scripts/data/<name>.py`, which #429 deleted — so it
+    returned an empty dict and the test below asserted nothing at all. The
+    discovery has to follow the code: preflight now spawns `clawock <command>`,
+    and the CLI's own dispatch table says which module that is.
+
+    A constant counts as an output when it resolves under the workspace and the
+    module writes through it. `evidence.md` — the file #345 was opened for — is
+    `WS / 'site' / 'evidence.md'` today, so the old single-segment pattern would
+    have missed it even if the directory still existed.
     """
+    import importlib
+
+    from clawock.cli import PACKAGED_UTILITIES
+
+    const = re.compile(
+        r"^([A-Z_][A-Z0-9_]*)\s*=\s*([A-Z_][A-Z0-9_]*)((?:\s*/\s*'[^']+')+)\s*$", re.M)
     out = {}
-    for script in sorted(set(re.findall(
-            r"scripts' / 'data' / '([a-z_]+\.py)'", PREFLIGHT))):
-        path = ROOT / 'scripts' / 'data' / script
-        if not path.exists():
+    for command in _preflight_utilities():
+        target = PACKAGED_UTILITIES.get(command)
+        if not target:
             continue
-        source = path.read_text()
-        for const, name in re.findall(
-                r"^([A-Z_]+) = WS / '([^/']+)'$", source, re.M):
-            if re.search(rf"{const}\.write_text\(|_write_\w+\({const}\b", source):
-                out[name] = script
+        source = Path(importlib.import_module(target).__file__).read_text()
+        relative = {'WS': ''}
+        for name, base, tail in const.findall(source):
+            if base in relative:
+                parts = [relative[base], *re.findall(r"'([^']+)'", tail)]
+                relative[name] = '/'.join(part for part in parts if part)
+        for name, rel in relative.items():
+            if name == 'WS' or not rel or '.' not in Path(rel).name:
+                continue
+            written = re.search(
+                rf"\b\w*(?:write|dump)\w*\(\s*(?:str\()?{name}\b"
+                rf"|{name}\.write_text\(|{name}\.open\(", source)
+            if written:
+                out[rel] = command
     return out
 
 
-def test_repo_root_outputs_are_committed_too():
+def test_outputs_outside_assets_data_are_committed_too():
     """The same contract, for files that do NOT live under assets/data/.
 
     This is the hole `evidence.md` fell through (#345): every `git add` above is
     directory-scoped, and the sibling test only discovers `assets/data/` paths, so
-    a repo-root artifact had no owner and nothing failed. build_evidence.py rewrote
-    it each morning for months while the published page served 08-02 numbers and
-    live carried a permanently dirty file. Exactly the MEMORY.md/DREAMS.md gap that
-    needed commit_dreaming.sh — this asserts the root is covered, not just the
-    subdirectory.
+    an artifact outside it had no owner and nothing failed. build_evidence.py
+    rewrote it each morning for months while the published page served 08-02
+    numbers and live carried a permanently dirty file.
+
+    A path is covered by an exact entry or by a staged directory above it; a
+    gitignored path is deliberately not committed, and demanding it would push
+    generated state back into the repository.
     """
     staged = _postflight_add_list()
-    unowned = sorted(f'{name} (written by {script})'
-                     for name, script in _repo_root_outputs().items()
-                     if name not in staged)
+    outputs = _utility_outputs()
+    # Anti-vacuity. Between #429 and now this test discovered nothing and passed
+    # for that reason alone, which is how the guard for #345 stopped guarding.
+    assert len(_preflight_utilities()) >= 10 and len(outputs) >= 8, (
+        f'discovery found {len(_preflight_utilities())} utilities and '
+        f'{len(outputs)} outputs — it has stopped following the code again')
+
+    def covered(path):
+        if path in staged or Path(path).name in GHA_OWNED:
+            return True
+        if any(entry.endswith('/') and path.startswith(entry) for entry in staged):
+            return True
+        return subprocess.run(['git', 'check-ignore', '-q', path],
+                              cwd=str(ROOT)).returncode == 0
+
+    unowned = sorted(f'{name} (written by clawock {command})'
+                     for name, command in outputs.items() if not covered(name))
     assert not unowned, (
-        f'preflight rebuilds {unowned} at the repo root but postflight never '
-        f'stages them, so origin keeps serving a stale copy and live stays dirty.')
+        f'preflight rebuilds {unowned} but postflight never stages them, so '
+        f'origin keeps serving a stale copy and live stays dirty.')
 
 
 def test_gha_synced_files_are_actually_gha_produced():

--- a/tests/test_code_imports_come_from_the_checkout.py
+++ b/tests/test_code_imports_come_from_the_checkout.py
@@ -26,10 +26,28 @@ MIGRATING_LAST: set[str] = set()
 
 _WS_IMPORT = re.compile(r"sys\.path\.insert\(\s*0\s*,\s*str\(\s*WS\s*/")
 
+# Where executable code lives now. This used to be `scripts/**/*.py`, and when
+# #429 deleted that directory the scan quietly became a walk over zero files —
+# the rule below stayed written down while nothing enforced it any more.
+CODE_ROOTS = ("src", "ops", "instances", "tests", ".githooks")
+
+
+def _modules():
+    for root in CODE_ROOTS:
+        for path in sorted((ROOT / root).rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
 
 def test_no_module_resolves_code_through_the_workspace():
+    modules = list(_modules())
+    # Anti-vacuity: this assertion is the reason the check went unnoticed for a
+    # day. A scan that finds nothing passes exactly like a clean tree.
+    assert len(modules) > 50, f"only found {len(modules)} modules — did a root move?"
+
     offenders = []
-    for path in sorted(ROOT.glob("scripts/**/*.py")):
+    for path in modules:
         rel = path.relative_to(ROOT).as_posix()
         if rel in MIGRATING_LAST:
             continue
@@ -39,6 +57,35 @@ def test_no_module_resolves_code_through_the_workspace():
     assert not offenders, (
         "these put the WORKSPACE on sys.path to import our own modules, so a "
         f"CLAWOCK_WORKSPACE override resolves code out of the data dir: {offenders}")
+
+
+_SYS_PATH = re.compile(
+    r"sys\.path\.(?:insert\(\s*0\s*,\s*|append\(\s*)str\(\s*"
+    r"(WS|ROOT|_CHECKOUT|_REPO_ROOT)\s*((?:/\s*['\"][^'\"]+['\"]\s*)+)\)")
+
+
+def test_no_module_puts_a_directory_this_repository_lacks_on_sys_path():
+    """A path entry naming a deleted directory is inert, and that is the problem.
+
+    Python ignores a missing sys.path entry, so ten of these survived #429
+    pointing at `scripts/data` — resolving nothing, costing nothing, and making
+    `scripts/` look alive to whoever greps next. It cost real diagnostic time
+    during #447, where the question was precisely whether that path was gone.
+    """
+    offenders = []
+    for path in _modules():
+        source = path.read_text()
+        for lineno, line in enumerate(source.splitlines(), 1):
+            match = _SYS_PATH.search(line)
+            if not match:
+                continue
+            segments = re.findall(r"['\"]([^'\"]+)['\"]", match.group(2))
+            if not (ROOT.joinpath(*segments)).exists():
+                offenders.append(
+                    f"{path.relative_to(ROOT).as_posix()}:{lineno} → {'/'.join(segments)}")
+    assert not offenders, (
+        "these add a repository path that does not exist, so the import they "
+        f"guard is already resolving from somewhere else: {offenders}")
 
 
 def test_the_two_roots_actually_diverge_under_the_override(tmp_path):
@@ -110,7 +157,7 @@ def test_no_compatibility_shim_re_exports_the_package():
         "each call site, and reviving it would hide the second one again.")
 
     offenders = []
-    for path in sorted(ROOT.glob("scripts/**/*.py")):
+    for path in _modules():
         for lineno, line in enumerate(path.read_text().splitlines(), 1):
             stripped = line.strip()
             if stripped.startswith(("from workspace import", "import workspace")):

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -50,7 +50,7 @@ PROSE = ('▎我的看法\n'
 
 
 def _load(name):
-    for extra in (ROOT / 'scripts' / 'data', ROOT / 'instances' / 'kcnyu' / 'src'):
+    for extra in (ROOT / 'instances' / 'kcnyu' / 'src',):
         if str(extra) not in sys.path:
             sys.path.insert(0, str(extra))
     return importlib.import_module(f'clawock_kcnyu.harness.{name}')

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -7,7 +7,6 @@ from zoneinfo import ZoneInfo
 
 HKT = ZoneInfo('Asia/Hong_Kong')
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 
 def _ms(at):

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts' / 'data'))
 from clawock import json_repair  # noqa: E402
 from clawock.json_repair import AMBIGUOUS, CLEAN, REPAIRED, UNREPAIRABLE  # noqa: E402
 

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 from clawock.publish import dashboard  # noqa: E402
 import cron_health_check  # noqa: E402

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -36,7 +36,7 @@ PROSE = ('▎情绪面\nCRCL 今日 -5.5%，稳定币板块只有它在跌。\n\
 
 
 def _load(name):
-    for extra in (ROOT / 'scripts' / 'data', ROOT / 'instances' / 'kcnyu' / 'src'):
+    for extra in (ROOT / 'instances' / 'kcnyu' / 'src',):
         if str(extra) not in sys.path:
             sys.path.insert(0, str(extra))
     return importlib.import_module(f'clawock_kcnyu.harness.{name}')

--- a/tests/test_report_context_path.py
+++ b/tests/test_report_context_path.py
@@ -32,7 +32,7 @@ HARNESS = ROOT / 'instances' / 'kcnyu' / 'src' / 'clawock_kcnyu' / 'harness'
 
 def _load(name):
     """Import the separately packaged KCNyu adapter."""
-    for extra in (ROOT / 'scripts' / 'data', ROOT / 'instances' / 'kcnyu' / 'src'):
+    for extra in (ROOT / 'instances' / 'kcnyu' / 'src',):
         if str(extra) not in sys.path:
             sys.path.insert(0, str(extra))
     return importlib.import_module(f'clawock_kcnyu.harness.{name}')

--- a/tests/test_report_watchdog_retry_parity.py
+++ b/tests/test_report_watchdog_retry_parity.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 SENT_AT = datetime(2026, 8, 3, 13, 31, 24)
 NOW_MS = int(datetime(2026, 8, 3, 13, 42).timestamp() * 1000)

--- a/tests/test_scheduled_catalysts.py
+++ b/tests/test_scheduled_catalysts.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / 'scripts' / 'data'))
 
 from clawock.market_data import calendar as fetch_catalysts
 


### PR DESCRIPTION
Parent: #420

## What happened

`scripts/` was deleted in #429. Three contract tests were written as walks over
`ROOT.glob("scripts/**/*.py")` or `scripts/data/<name>.py`. They did not break —
they began walking **zero files** and passing for that reason.

| guard | rule it stopped enforcing |
|---|---|
| `test_no_module_resolves_code_through_the_workspace` | #269 — code resolves from the checkout, not from a foreign book |
| `test_no_compatibility_shim_re_exports_the_package` | #267 — the extraction is finished, not paused |
| `test_repo_root_outputs_are_committed_too` | #345 — every file the brief rebuilds has a committer |
| `test_no_script_re_implements_the_degenerate_check_privately` | one definition of "bad bar" |

The third is the expensive one. `evidence.md` was rewritten every morning for
months while the published page served 08-02 numbers, and the guard written to
stop that recurring has not looked at anything since the move. It also matched
only `WS / '<one segment>'`, and the file is `WS / 'site' / 'evidence.md'` today
— so it would have missed its own subject even if the directory still existed.

The fourth had lost both halves the same way: it globbed the deleted directory
*and* excluded `bar_checks.py` by name, which is now
`clawock.market_data.integrity`.

## What changed

Scans follow the code — `src`, `ops`, `instances`, `tests`, `.githooks` — and
the brief-output discovery follows preflight's own `clawock <command>` calls
through the CLI dispatch table:

```
15 utilities discovered, 14 outputs
  assets/data/quant_signals.json           <- clawock quant
  assets/data/t0_setups.json               <- clawock t0
  site/evidence.md                         <- clawock evidence
  .cache/cross_sectional_quality.json      <- clawock cross-factor   (gitignored)
  …
```

Each carries an **anti-vacuity assertion** — a discovery that finds nothing now
fails loudly, since that is the exact way these stopped working. The bar-check
scan derives both the roots and the one permitted implementation from the
imported module rather than spelling either out.

Ten dead `sys.path.insert(..., 'scripts' / 'data')` lines go too. Python ignores
a missing path entry, so they resolved nothing and cost nothing — and made
`scripts/` look alive to whoever greps next, which cost real diagnostic time in
#447 where the question was precisely whether that path was gone. Every import
beside them already came from the installed package. All seven harness modules
and `ops/system_check.py` were smoke-imported after removal; system_check runs
clean on the live host.

New guard, so the same shape cannot come back: **a module may not put a
repository path on sys.path that the repository does not contain.**

## Mutations

| mutation | red test |
|---|---|
| a module resolves code through the workspace again | workspace-import guard |
| a module adds a repository path that does not exist | new sys.path guard |
| postflight stops staging `site/evidence.md` | brief-output ownership |
| discovery stops following the code | brief-output ownership |
| the degenerate-range scan loses its roots | bar-check guard |

Full suite: **1,744 passed**, 10 skipped, 4 xfailed.