### PR TITLE
fix: an ops entry point could not import the package, and its guard was blind

### DIFF
--- a/ops/host/backfill_snapshot_realized.py
+++ b/ops/host/backfill_snapshot_realized.py
@@ -19,9 +19,16 @@ import re
 import sys
 from pathlib import Path
 
-from clawock.safe_io import safe_write_json
-from clawock.portfolio.snapshots import realized_as_of, snapshot_shares
-from clawock.workspace import workspace_root
+# Every other ops entry point does this, and this one is documented above as
+# `python3 ops/host/...`, which is system python — not the venv the package is
+# installed into. Without it the command in the docstring is a ModuleNotFoundError.
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
+
+from clawock.safe_io import safe_write_json  # noqa: E402
+from clawock.portfolio.snapshots import realized_as_of, snapshot_shares  # noqa: E402
+from clawock.workspace import workspace_root  # noqa: E402
 
 # The workspace this file sits in, not the operator's. As an absolute live path
 # it made `--portfolio` default to the real ledger *and* pointed SNAP_DIR at the

--- a/ops/pages/freshness.py
+++ b/ops/pages/freshness.py
@@ -38,6 +38,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(CHECKOUT))
+sys.path.insert(0, str(CHECKOUT / "src"))
+
+from clawock.providers.openclaw import runtime_paths  # noqa: E402
+
 PAYLOAD = "assets/data/dashboard.json"
 DATA_PLANE_REF = "origin/data-plane"
 LIVE_URL = f"https://kcnyu.github.io/clawock/{PAYLOAD}"
@@ -276,8 +281,11 @@ def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         prog="python3 ops/pages/freshness.py",
         description="Trace one dashboard generation from producer to browser.")
-    parser.add_argument("--workspace", type=Path, default=Path("/root/.openclaw/workspace"),
-                        help="the producing workspace (default: the live host's)")
+    # From the adapter, not spelled out: this was the one remaining site outside
+    # `clawock.providers` that knew a host's runtime layout, and the ratchet that
+    # exists to count exactly that could not see it (it scanned `scripts/`).
+    parser.add_argument("--workspace", type=Path, default=runtime_paths().workspace,
+                        help="the producing workspace (default: this runtime's)")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
 

--- a/tests/test_harness_import_independence.py
+++ b/tests/test_harness_import_independence.py
@@ -1,24 +1,25 @@
-"""A module that imports `clawock` must put the checkout on the path itself.
+"""A script run by path must put the checkout on `sys.path` itself.
 
-`clawock` is not installed on the live host. Modules under `scripts/` reach it
-only because something inserted the repository root into `sys.path` first. Two of
-the three live importers did that explicitly; `_watchdog_common` inherited it as a
-side effect of importing the `scripts/data/workspace.py` shim, which inserts the
-root for its own 53 consumers.
+The original subject was `scripts/`, where nothing was installed and the live
+watchdogs reached `clawock` only through a shim's side effect. #429 deleted that
+directory and this scan went with it — it kept globbing `scripts/**/*.py` and
+walking zero files, which passes exactly like a clean tree.
 
-That is a live hazard and a migration blocker at the same time. `_watchdog_common`
-is imported by 15 modules including all three watchdogs, driven by 28 crontab
-entries; if the shim's insert goes away — which is exactly what retiring the shim
-means — every watchdog fails at *import* time. The backstop that exists to notice
-a missing report goes missing first, and the crontab entry logs a traceback into
-watchdog.cron.log.
+The rule did not disappear with the directory; its population moved. `clawock` is
+installed now (#364), but into a venv, and every `ops/` entry point documents
+itself as `python3 ops/<...>.py` — system python, which has no such install. On
+2026-08-10 `ops/host/backfill_snapshot_realized.py` was the one module that had
+lost its two bootstrap lines in the move, so the command printed in its own
+docstring raised ModuleNotFoundError. That is the third time this same file has
+had this defect (it was also broken by the move into `scripts/legacy`, fixed in
+#290), which is why the check is a discovery over the directory rather than a
+list of known entry points.
 
-Why this is a source-shape test and not an "import it in a subprocess" test: CI
-installs the package (`pip install -e '.[test]'`), so the repository root is on
-`sys.path` there no matter what any module does. A runtime import test would pass
-in CI while the live host — the only environment without the install — is the one
-at risk. It would look like coverage and protect nothing. The defect is visible in
-the source, so the test reads the source.
+Why a source-shape test and not "import it in a subprocess": CI installs the
+package, so the import succeeds there no matter what the module does. A runtime
+test would pass in CI while the environment actually at risk — an operator's
+plain `python3` — is the one it cannot see. The defect is visible in the source,
+so the test reads the source.
 
 Mutation check: deleting either insert turns this red, and so does resolving the
 insert from `WS` (the workspace, which CLAWOCK_WORKSPACE may point elsewhere)
@@ -37,7 +38,15 @@ ROOT = Path(__file__).resolve().parents[1]
 # market data, not our package. Naming a form here does not weaken the check —
 # the `"/" in arg` guard below still rejects `_CHECKOUT / 'scripts' / 'data'`,
 # which is a directory below the root and does not make `clawock` importable.
-CHECKOUT_ROOT_FORMS = ("parents[2]", "_REPO_ROOT", "_CHECKOUT")
+# Substrings on purpose: `ROOT` also covers `_REPO_ROOT`, `CHECKOUT` also
+# covers `_CHECKOUT`. Matching the exact private spellings is how a rename
+# turns a live guard into a silent pass.
+CHECKOUT_ROOT_FORMS = ("parents[2]", "ROOT", "CHECKOUT")
+
+# Scripts an operator runs by path. Package modules are imported through an
+# installed distribution and must NOT bootstrap themselves — requiring it there
+# would be the opposite rule.
+ENTRY_POINTS = ROOT / "ops"
 
 
 def _inserts_checkout_root(node: ast.Call, source: str) -> bool:
@@ -58,8 +67,13 @@ def _inserts_checkout_root(node: ast.Call, source: str) -> bool:
 
 
 def test_clawock_importers_do_not_inherit_their_sys_path():
+    scripts = [p for p in sorted(ENTRY_POINTS.rglob("*.py"))
+               if "__pycache__" not in p.parts]
+    # Anti-vacuity: an empty scan is how this stopped working in the first place.
+    assert len(scripts) > 10, f"only {len(scripts)} entry points found — did ops/ move?"
+
     offenders = []
-    for path in sorted(ROOT.glob("scripts/**/*.py")):
+    for path in scripts:
         source = path.read_text()
         if "clawock" not in source:
             continue

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -211,12 +211,24 @@ def _sites_in(tree: ast.AST) -> list[int]:
     return sorted(set(found))
 
 
+# Where code lives. `scripts/**` was half of this list and #429 deleted it, so
+# that half walked zero files; `ops/` and `instances/` — where the deleted code
+# went — were never added, which is how `ops/pages/freshness.py` could default a
+# CLI flag to `/root/.openclaw/workspace` while the ratchet reported zero.
+CODE_ROOTS = ("src/clawock", "ops", "instances")
+
+
+def _modules():
+    for root in CODE_ROOTS:
+        for path in sorted((ROOT / root).rglob("*.py")):
+            if "__pycache__" not in path.parts:
+                yield path
+
+
 def coupling_sites() -> dict[str, list[int]]:
     """Files outside the adapter that invoke OpenClaw or read its state."""
     sites: dict[str, list[int]] = {}
-    for path in sorted(ROOT.glob("scripts/**/*.py")) + sorted(
-        ROOT.glob("src/clawock/**/*.py")
-    ):
+    for path in _modules():
         if ADAPTER in path.parents:
             continue
         try:
@@ -230,6 +242,15 @@ def coupling_sites() -> dict[str, list[int]]:
 
 
 def test_the_runtime_coupling_count_never_rises():
+    # Anti-vacuity: a count of zero is the goal here, so an empty scan and a
+    # decoupled tree produce the same number. That is how half of this scan
+    # could point at a deleted directory unnoticed.
+    modules = list(_modules())
+    assert len(modules) > 50, f"only {len(modules)} modules scanned — did a root move?"
+    assert any(path.name == "system_check.py" for path in modules), (
+        "system_check is the file this ratchet migrated last; if it is outside "
+        "the scan, the scan is not looking where the coupling was")
+
     sites = coupling_sites()
     total = sum(len(lines) for lines in sites.values())
 


### PR DESCRIPTION
Parent: #420

Found by sweeping for the pattern #452 fixed: scans that point at a directory
that no longer exists. Two more, and one of them was hiding a live defect.

## The defect

```
$ python3 ops/host/backfill_snapshot_realized.py --dry-run
ModuleNotFoundError: No module named 'clawock'
```

That is the command printed in the file's own docstring. It is the **one entry
point out of sixteen** that lost its two bootstrap lines when #429 moved it, and
`clawock` is installed into a venv — not into the `python3` an operator types.

Third time for this file: the move into `scripts/legacy` broke it identically and
#290 fixed it identically.

## Why nothing caught it

`test_clawock_importers_do_not_inherit_their_sys_path` scanned
`ROOT.glob("scripts/**/*.py")`. Zero files since #429. Its rule did not expire
with the directory — the population moved to `ops/`, which is what an operator
runs by path now. Package modules stay excluded: they are imported through an
installed distribution, and demanding they bootstrap themselves would be the
opposite rule.

The root-form list also matched exact private spellings (`_CHECKOUT`,
`_REPO_ROOT`) and missed a module that named the same expression `ROOT`. Matching
substrings now — a rename is not a change in meaning.

## The ratchet had the same hole, and it was hiding a site

`coupling_sites()` scanned `scripts/**` (empty) plus `src/clawock/**`. `ops/` and
`instances/` — where the deleted code went — were never added. So this passed:

```python
# ops/pages/freshness.py
parser.add_argument("--workspace", default=Path("/root/.openclaw/workspace"), ...)
```

…while the ratchet reported **zero** and its own note claimed *"Zero means no code
outside the provider knows a host-specific layout."* It came from `runtime_paths()`
after this change, and the ratchet scans `src/clawock`, `ops`, `instances`.

Both guards now carry anti-vacuity assertions. The ratchet's matters most: its
target **is** zero, so an empty scan and a decoupled tree produce the same number.
It also asserts `system_check.py` is inside the scan — that is the file it
migrated last, and the whole claim rests on it.

## Verification

```
$ python3 ops/host/backfill_snapshot_realized.py --dry-run   # exit 0
would change 2/64 snapshot(s).
[dry-run] nothing written.

$ python3 ops/pages/freshness.py --json                      # exit 0
producer ok · data plane ok · pages deployment ok · live ok
```

| mutation | red test |
|---|---|
| the entry point loses its bootstrap again | import independence |
| the hardcoded workspace comes back | coupling ratchet |
| the ratchet loses the `ops` root | coupling ratchet |

Full suite: **1,744 passed**, 10 skipped, 4 xfailed.

**Observation, not addressed here:** the dry-run reports 2 of 64 historical
snapshots whose `realized_pnl` disagrees with the trades ledger. That is a money
question and wants its own issue rather than a repair folded into a path fix.