### PR TITLE
fix: a US fill typed on a Saturday belongs to Friday's session (#454)

### DIFF
--- a/ops/host/backfill_snapshot_realized.py
+++ b/ops/host/backfill_snapshot_realized.py
@@ -64,7 +64,12 @@ def main():
             if not rpf:
                 continue
             shares = snapshot_shares(rpf)
-            new_total, new_note = realized_as_of(ledger_holdings, date, shares)
+            # The market whose calendar dates these fills: without it a US fill
+            # reported at 01:08 HKT on a Saturday reads as belonging to the next
+            # session, and this tool would rewrite a correct snapshot.
+            new_total, new_note = realized_as_of(
+                ledger_holdings, date, shares,
+                market=region[:-len('_stocks')] if region.endswith('_stocks') else region)
             old_total = rpf.get('realized_pnl')
             if old_total is None or abs(float(old_total) - new_total) > 0.005:
                 print(f'{date} {region}: {old_total} -> {new_total}  (Δ {new_total - (old_total or 0):+.2f})')

--- a/src/clawock/portfolio/snapshots.py
+++ b/src/clawock/portfolio/snapshots.py
@@ -16,6 +16,9 @@ The same-day share check uses the running balance *after* the sell, so a sell is
 only counted once the holding has actually been drawn down to (or below) it. The
 strict date-`<` branch handles later sell→rebuy cycles without false negatives.
 """
+from datetime import date as _date
+
+
 def _ledger_sells(holdings):
     """Per-ticker chronological sells, each tagged with its post-sell balance.
 
@@ -50,21 +53,60 @@ def _ledger_sells(holdings):
     return by_ticker
 
 
-def realized_as_of(holdings, snap_date, snap_shares):
+def session_date(market, day):
+    """The trading session a fill belongs to, given the date it was recorded.
+
+    A ledger date is the operator's calendar date. A US session in Hong Kong
+    time runs 21:30 to 04:00, so a fill reported at 01:08 HKT on a Saturday
+    belongs to *Friday's* session and is stamped with Saturday's date. Comparing
+    that raw date against a snapshot named for the session drops the fill from
+    the very session that contains it.
+
+    Only non-session dates move, and only when the calendar covers that year —
+    a real session date, an unknown market, or a year the holiday tables do not
+    reach is returned unchanged rather than guessed at.
+    """
+    if not market or not isinstance(day, str) or len(day) != 10:
+        return day
+    from clawock.market_data.sessions import (
+        MARKET_TZ, covered_years, is_trading_day, previous_trading_day,
+    )
+    if market not in MARKET_TZ:
+        return day
+    try:
+        parsed = _date.fromisoformat(day)
+    except ValueError:
+        return day
+    if parsed.year not in covered_years(market) or is_trading_day(market, parsed):
+        return day
+    return previous_trading_day(market, parsed).isoformat()
+
+
+def realized_as_of(holdings, snap_date, snap_shares, *, market=None):
     """Cumulative realized + chronological note reflected in a snapshot.
 
     holdings    — canonical portfolio.json region holdings (the ledger).
     snap_date   — 'YYYY-MM-DD' of the snapshot.
     snap_shares — {ticker: shares} recorded in that snapshot (0 if absent).
+    market      — calendar to resolve fill dates against ('us'/'hk'). Omitted
+                  means the raw ledger dates are compared, which is only right
+                  for a market whose session cannot cross a date boundary in the
+                  operator's timezone.
     """
     by_ticker = _ledger_sells(holdings)
     reflected = []
     for ticker, sells in by_ticker.items():
         held = snap_shares.get(ticker, 0) or 0
         for s in sells:
-            if s['date'] < snap_date or (
-                s['date'] == snap_date and held <= s['post_bal']
-            ):
+            when = session_date(market, s['date'])
+            # A negative post-sell balance means this holding's trade list is
+            # missing a buy (RKLB records a 5-share sell with no buy beside it),
+            # so the level is offset by a constant nobody can recover. Shares
+            # cannot be negative, so the drawn-down test is read at zero rather
+            # than against an impossible balance — which would otherwise drop a
+            # real, fully-closed sell from the session that contains it.
+            drawn_down = max(s['post_bal'], 0)
+            if when < snap_date or (when == snap_date and held <= drawn_down):
                 reflected.append(s)
 
     reflected.sort(key=lambda x: (x['date'], x['ticker']))

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -645,7 +645,8 @@ def load_snapshots():
                 if not region_pf:
                     continue
                 true_real, _ = realized_as_of(
-                    ledger.get(leg.bucket, []), date, snapshot_shares(region_pf))
+                    ledger.get(leg.bucket, []), date, snapshot_shares(region_pf),
+                    market=leg.key)
                 if abs(true_real - (reals[leg.key] or 0)) > 0.005:
                     reals[leg.key] = true_real
         row = {'date': date, 'file': fname}

--- a/tests/test_snapshot_realized_sessions.py
+++ b/tests/test_snapshot_realized_sessions.py
@@ -1,0 +1,116 @@
+"""A fill belongs to the session it traded in, not to the date it was typed.
+
+`realized_as_of` decides which sells a dated snapshot reflects, and
+`clawock.publish.dashboard.load_snapshots` **overrides** each snapshot's stored
+realized with its answer — so this function, which had no test at all, writes the
+published equity curve.
+
+The defect (#454): a US session runs 21:30–04:00 in Hong Kong time, so a fill
+reported at 01:08 HKT on a Saturday belongs to Friday's session while the ledger
+stamps it with Saturday's date. Comparing that raw date against a snapshot named
+for the session dropped the fill from the very session containing it, and the
+published curve carried two artificial steps because of it:
+
+    2026-06-12  us_realized 1372.88  (snapshot: 1567.23)  understated 194.35
+    2026-08-07  us_realized 2180.35  (snapshot: 2220.56)  understated  40.21
+
+Against the live book, the repair tool went from "would change 2/64 snapshots"
+to 0/64 — the snapshots were right the whole time.
+"""
+import pytest
+
+from clawock.portfolio.snapshots import (
+    realized_as_of,
+    session_date,
+    snapshot_shares,
+)
+
+
+FRIDAY = "2026-06-12"      # a US session
+SATURDAY = "2026-06-13"    # not a session in any market
+
+
+def _holding(ticker, trades):
+    return {"ticker": ticker, "trades": trades}
+
+
+def _closed_position(ticker, sell_date, realized):
+    return _holding(ticker, [
+        {"date": "2026-05-01", "action": "buy", "shares": 5, "price": 80.0},
+        {"date": sell_date, "action": "sell", "shares": 5, "price": 100.0,
+         "realized_pnl": realized},
+    ])
+
+
+def test_a_weekend_stamped_us_fill_belongs_to_the_session_before_it():
+    ledger = [_closed_position("RKLB", SATURDAY, 145.85)]
+    snapshot = {"holdings": [{"ticker": "RKLB", "shares": 0}]}
+
+    total, note = realized_as_of(
+        ledger, FRIDAY, snapshot_shares(snapshot), market="us")
+
+    assert total == 145.85, note
+
+    # Without the calendar the same fill reads as belonging to a later day,
+    # which is what put two artificial steps in the published equity curve.
+    blind, _ = realized_as_of(ledger, FRIDAY, snapshot_shares(snapshot))
+    assert blind == 0
+
+
+def test_a_fill_on_a_real_session_is_not_moved():
+    """Only impossible dates shift. A Thursday fill stays on Thursday, so a
+    snapshot taken before that session still excludes it."""
+    thursday = "2026-06-11"
+    ledger = [_closed_position("RKLB", thursday, 100.0)]
+
+    assert session_date("us", thursday) == thursday
+    held_before, _ = realized_as_of(
+        ledger, "2026-06-10", {"RKLB": 5}, market="us")
+    assert held_before == 0
+
+
+@pytest.mark.parametrize("market, day, expected", [
+    ("us", SATURDAY, FRIDAY),
+    ("us", "2026-08-08", "2026-08-07"),          # the PLTU fill in #454
+    ("hk", SATURDAY, "2026-06-12"),
+    ("us", FRIDAY, FRIDAY),                       # a session date is untouched
+    (None, SATURDAY, SATURDAY),                   # no market claimed, no guess
+    ("jp", SATURDAY, SATURDAY),                   # no calendar for this market
+    ("us", "2021-06-12", "2021-06-12"),           # outside the holiday tables
+    ("us", "not-a-date", "not-a-date"),
+])
+def test_session_date_only_moves_what_it_can_justify(market, day, expected):
+    assert session_date(market, day) == expected
+
+
+def test_an_incomplete_trade_list_still_credits_a_closed_sell():
+    """RKLB records a 5-share sell with no buy beside it, so the running balance
+    goes to -5. The same-day tie-break asks whether the snapshot has been drawn
+    down to the post-sell level; against an impossible balance it can never be,
+    and a real fully-closed sell was dropped. Shares cannot be negative, so the
+    test is read at zero."""
+    ledger = [_holding("RKLB", [
+        {"date": SATURDAY, "action": "sell", "shares": 5, "price": 100.17,
+         "realized_pnl": 145.85},
+    ])]
+
+    total, _ = realized_as_of(ledger, FRIDAY, {"RKLB": 0}, market="us")
+    assert total == 145.85
+
+    # The tie-break still means something: a snapshot that still holds the
+    # position has not been drawn down, so the sell is not yet reflected.
+    still_held, _ = realized_as_of(ledger, FRIDAY, {"RKLB": 5}, market="us")
+    assert still_held == 0
+
+
+def test_the_dashboard_asks_with_a_market():
+    """The curve is only correct if the caller passes one; a build that forgets
+    reverts to the defect without any test here failing."""
+    import inspect
+
+    from clawock.publish import dashboard
+
+    source = inspect.getsource(dashboard.load_snapshots)
+    assert "market=leg.key" in source, (
+        "load_snapshots must resolve fill dates against the leg's calendar, or "
+        "the published equity curve silently returns to raw ledger dates")


### PR DESCRIPTION
Closes #454.

## The defect

A US session runs 21:30–04:00 in Hong Kong time. A fill reported at **01:08 HKT
on a Saturday** traded in *Friday's* session, but the ledger stamps it with
Saturday's date:

```json
{"date": "2026-08-08", "action": "sell", "shares": 5, "price": 49.0,
 "realized_pnl": 40.21, "note": "用户报告成交(微信,01:08 HKT) …"}
```

2026-08-08 is a Saturday; the US market does not trade on a Saturday.
`realized_as_of` compared that raw date against a snapshot named for the session
and dropped the fill from the very session containing it.

## It was already in the published curve

`load_snapshots()` runs the same recomputation on every build and **overrides**
the snapshot's stored realized whenever it diverges — the comment calls this
self-healing, "so the equity curve / drawdown can never be poisoned by a stale
aggregate". What it published:

| date | published | the snapshot | error |
|---|---|---|---|
| 2026-06-12 | `us_realized 1372.88` | 1567.23 | understated **194.35** |
| 2026-08-07 | `us_realized 2180.35` | 2220.56 | understated **40.21** |

and today's US day change read **+0.78%** although no US session has traded since
08-07. The guard against a stale aggregate was the thing producing stale figures.

## The fix

`session_date()` resolves a fill date to the last trading session on or before
it, and only when the calendar can justify it — a real session date, an unknown
market, or a year outside the holiday tables is returned unchanged rather than
guessed at. HK is unaffected in practice: its session cannot cross a date
boundary in HKT.

**Second cause, 06-12 only.** RKLB records a 5-share sell with no buy beside it,
so its running balance reaches `-5` and the same-day tie-break — *has the
snapshot been drawn down to the post-sell level?* — can never be satisfied.
Shares cannot be negative, so that test is read at zero. The ledger gap itself is
reported on the issue; no money data is edited here.

## Verification

Against the live book, the repair tool goes from **2/64 → 0/64** snapshots
needing change. The snapshots were correct all along.

Back-to-back build against `origin/master`, same workspace:

```
.snapshots[22].us_realized: 1372.88 -> 1567.23     (2026-06-12)
.snapshots[22].us_equity:   4017.44 -> 4211.79
.snapshots[62].us_realized: 2180.35 -> 2220.56     (2026-08-07)
.snapshots[62].us_equity:   5132.41 -> 5172.62
.delta.us.today_pct:           0.78 -> 0.0
```

Exactly the two rows, their derived fields, and the day change one of them feeds.
Nothing else moved in either product.

`realized_as_of` had **no test at all**, which is how a function that writes the
published equity curve carried this. Three mutations — dropping the calendar,
dropping the clamp, a build that forgets to pass a market — each turn the new
ones red. Full suite: **1,756 passed**.