### PR TITLE
fix: the delivery backstop could not launch the runtime from cron

### DIFF
--- a/src/clawock/providers/delivery.py
+++ b/src/clawock/providers/delivery.py
@@ -99,8 +99,11 @@ class OpenClawDelivery:
         self._runner = runner or self._run
 
     def _run(self, cmd):
+        # The runtime's own launcher needs `node` on PATH, so a job started from
+        # the user crontab cannot spawn it with the PATH it inherited.
+        from clawock.providers.openclaw import runtime_env
         done = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=self.timeout)
+                              timeout=self.timeout, env=runtime_env())
         return done.returncode, (done.stdout + done.stderr)
 
     def send(self, channel: str, target: str, message: str, *,

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -110,6 +110,77 @@ def _discover_install_dir(binary: str, *, search_path: str | None = None) -> Pat
     return candidates[0] if candidates else None
 
 
+# Where a per-user launcher lives when it is not on the caller's PATH. A job
+# started from the user crontab runs with PATH=/usr/bin:/bin, and none of these
+# are on it — so `shutil.which` answering None does not mean "not installed", it
+# means "not on this PATH". Getting that wrong killed the delivery backstop:
+# 2026-08-10 10:40 and 11:40, two intraday slots failed, the watchdog detected
+# both correctly, and the deterministic fallback reported `openclaw is not
+# installed` instead of sending. Same shape as #438 (the money checker) and #444
+# (the gold refresh); this one was the safety net.
+_LAUNCHER_DIRS = (
+    "~/.local/share/pnpm",      # pnpm global launcher
+    "~/.local/bin",             # the clawock launcher's own directory
+    "/usr/local/bin",
+)
+
+
+def _search_dirs(env: Mapping[str, str]) -> list[Path]:
+    home = env.get("HOME")
+    dirs = []
+    for directory in _LAUNCHER_DIRS:
+        if directory.startswith("~"):
+            if not home:
+                continue
+            dirs.append(Path(home) / directory[2:])
+        else:
+            dirs.append(Path(directory))
+    # nvm keeps node under a per-version directory and puts it on PATH through
+    # a shell profile, which a cron job never sources. Newest version first.
+    if home:
+        dirs.extend(sorted((Path(home) / ".nvm" / "versions" / "node").glob("*/bin"),
+                           reverse=True))
+    return dirs
+
+
+def _resolve_binary(env: Mapping[str, str], name: str = "openclaw") -> str:
+    """The runtime launcher, found without depending on the caller's PATH."""
+    found = shutil.which(name, path=env.get("PATH"))
+    if found:
+        return found
+    for base in _search_dirs(env):
+        candidate = base / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    # Unchanged last resort: the bare name, so a genuinely absent runtime still
+    # reports "not installed" rather than a path that was never there.
+    return name
+
+
+def runtime_env(env: Mapping[str, str] | None = None) -> dict:
+    """Environment for spawning the runtime, with a PATH it can actually run on.
+
+    Resolving the launcher is not enough: the pnpm launcher is a shell script
+    whose last line is `exec node …`, so a bare cron PATH turns
+    `openclaw is not installed` into `exec: node: not found` — a different
+    message for the same undelivered report. Only missing directories that hold
+    a real executable are appended, and the caller's own PATH keeps priority so
+    an operator's choice still wins.
+    """
+    env = os.environ if env is None else env
+    resolved = dict(env)
+    existing = [p for p in (env.get("PATH") or "").split(os.pathsep) if p]
+    for base in _search_dirs(env):
+        entry = str(base)
+        if entry in existing or not base.is_dir():
+            continue
+        if any(item.is_file() and os.access(item, os.X_OK)
+               for item in base.iterdir()):
+            existing.append(entry)
+    resolved["PATH"] = os.pathsep.join(existing)
+    return resolved
+
+
 # Legacy import surface, now discovered instead of fixed to one pnpm store.
 INSTALL_DIR = _discover_install_dir(OPENCLAW_BIN)
 
@@ -121,8 +192,7 @@ def runtime_paths(environ: Mapping[str, str] | None = None) -> OpenClawPaths:
     as a compatibility fallback for existing operator scripts.
     """
     env = os.environ if environ is None else environ
-    binary = env.get("CLAWOCK_OPENCLAW_BIN") or shutil.which(
-        "openclaw", path=env.get("PATH")) or "openclaw"
+    binary = env.get("CLAWOCK_OPENCLAW_BIN") or _resolve_binary(env)
     home_override = env.get("CLAWOCK_OPENCLAW_HOME") or env.get("OPENCLAW_HOME")
     default_home = (Path(env["HOME"]) / ".openclaw"
                     if env.get("HOME") else DEFAULT_OPENCLAW_HOME)
@@ -151,7 +221,7 @@ def cron_cli_json(cli_args, *, binary: str | None = None,
     """
     selected_binary = binary or runtime_paths().binary
     run = runner or (lambda cmd: subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout))
+        cmd, capture_output=True, text=True, timeout=timeout, env=runtime_env()))
     try:
         done = run([selected_binary, "cron", *cli_args])
         # Deliberately NOT gated on returncode: the original helper parsed

--- a/tests/test_runtime_binary_resolution.py
+++ b/tests/test_runtime_binary_resolution.py
@@ -1,0 +1,121 @@
+"""The runtime must be launchable from a job that has a bare PATH.
+
+The delivery backstop is the thing that notices a report never arrived. It runs
+from the user crontab, where `PATH=/usr/bin:/bin`, and on 2026-08-10 it failed
+twice — 10:40 and 11:40, two intraday slots — with `openclaw is not installed`.
+The runtime was installed. `shutil.which` answering None means "not on this
+PATH", and the adapter was reading it as "absent".
+
+Its last successful send was 2026-08-06 23:10, and the first two attempts after
+that both failed, so the migration behind `runtime_paths()` broke it and nothing
+noticed for four days: a backstop only sends when something else already went
+wrong, so its own failure is invisible on every healthy day.
+
+Resolving the launcher is only half. The pnpm launcher is a shell script whose
+last line is `exec node …`, so a bare PATH turns `openclaw is not installed`
+into `exec: node: not found` — same undelivered report, different message.
+
+Third in the family, after #438 (the money checker) and #444 (the gold refresh):
+`command -v X` is not the same question as "is X installed".
+"""
+import os
+import stat
+
+import pytest
+
+from clawock.providers.openclaw import _resolve_binary, runtime_env, runtime_paths
+
+
+CRON_PATH = "/usr/bin:/bin"
+
+
+def _executable(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+@pytest.fixture
+def host(tmp_path):
+    """A home laid out the way this one is: pnpm launcher, nvm node."""
+    home = tmp_path / "home"
+    _executable(home / ".local" / "share" / "pnpm" / "openclaw")
+    _executable(home / ".nvm" / "versions" / "node" / "v22.23.1" / "bin" / "node")
+    return home
+
+
+def test_a_bare_cron_path_still_finds_the_installed_runtime(host):
+    env = {"PATH": CRON_PATH, "HOME": str(host)}
+
+    resolved = _resolve_binary(env)
+
+    assert resolved == str(host / ".local" / "share" / "pnpm" / "openclaw")
+    # The bare name is what produced "is not installed": it reaches subprocess,
+    # raises FileNotFoundError, and the delivery result says the runtime is absent.
+    assert resolved != "openclaw"
+
+
+def test_the_runtime_can_actually_exec_node_from_that_job(host):
+    """Half a fix is a different error message for the same undelivered report."""
+    env = {"PATH": CRON_PATH, "HOME": str(host)}
+
+    path = runtime_env(env)["PATH"].split(os.pathsep)
+
+    assert str(host / ".nvm" / "versions" / "node" / "v22.23.1" / "bin") in path
+    # The caller's own PATH keeps priority — an operator who selected a runtime
+    # must not have this quietly reorder it underneath them.
+    assert path[:2] == CRON_PATH.split(":")
+
+
+def test_a_path_that_already_works_is_left_alone(host):
+    """No reordering, no duplicates, on the healthy path this runs on every day."""
+    own = host / "chosen"
+    _executable(own / "openclaw")
+    env = {"PATH": f"{own}:{CRON_PATH}", "HOME": str(host)}
+
+    assert _resolve_binary(env) == str(own / "openclaw")
+    resolved = runtime_env(env)["PATH"].split(os.pathsep)
+    assert resolved[0] == str(own)
+    assert len(resolved) == len(set(resolved))
+
+
+def test_directories_that_hold_nothing_runnable_are_not_added(tmp_path):
+    """Otherwise PATH grows with entries that only cost stat calls."""
+    home = tmp_path / "empty-home"
+    (home / ".local" / "share" / "pnpm").mkdir(parents=True)
+    (home / ".local" / "share" / "pnpm" / "README").write_text("not executable")
+
+    path = runtime_env({"PATH": CRON_PATH, "HOME": str(home)})["PATH"].split(os.pathsep)
+
+    # Asserted against this directory rather than against the whole PATH: a
+    # system-wide entry such as /usr/local/bin may legitimately exist and hold
+    # executables on the machine running the tests.
+    assert str(home / ".local" / "share" / "pnpm") not in path
+    assert CRON_PATH.split(":") == path[:2]
+
+
+def test_an_absent_runtime_still_reports_itself_absent(tmp_path):
+    """The fallback must not invent a path, or 'not installed' becomes a
+    confusing ENOENT on a file that was never there."""
+    env = {"PATH": CRON_PATH, "HOME": str(tmp_path / "nothing")}
+
+    assert _resolve_binary(env) == "openclaw"
+
+
+def test_an_explicit_override_is_still_obeyed(host):
+    env = {"PATH": CRON_PATH, "HOME": str(host),
+           "CLAWOCK_OPENCLAW_BIN": "/opt/custom/openclaw"}
+
+    assert runtime_paths(env).binary == "/opt/custom/openclaw"
+
+
+def test_the_environment_is_carried_through_not_replaced(host):
+    """Spawning with a rebuilt env must not drop what the runtime needs to
+    authenticate — only PATH is meant to change."""
+    env = {"PATH": CRON_PATH, "HOME": str(host), "OPENCLAW_TOKEN": "keep-me"}
+
+    resolved = runtime_env(env)
+
+    assert resolved["OPENCLAW_TOKEN"] == "keep-me"
+    assert resolved["HOME"] == str(host)


### PR DESCRIPTION
Parent: #380 — "preserve retry, watchdog, delivery idempotency".

Found while gathering this issue's watchdog evidence: the backstop has been
unable to deliver since the adapter migration.

## What happened

The watchdog runs from the user crontab, where `PATH=/usr/bin:/bin`. Today it
detected two failed intraday HK slots correctly and then could not send:

```
2026-08-10T10:40:01  intraday-hk  deterministic-fallback  sent_ok=False  openclaw is not installed
2026-08-10T11:40:02  intraday-hk  deterministic-fallback  sent_ok=False  openclaw is not installed
```

The runtime was installed the whole time. `shutil.which` returning None means
*not on this PATH*, and `runtime_paths()` read it as *absent*, falling back to
the bare name — which reaches `subprocess` and raises `FileNotFoundError`.

## Why it sat for four days

```
last successful backstop send   2026-08-06T23:10:20
next two attempts               2026-08-10  10:40, 11:40   both failed
```

Every send that has succeeded came from an agent turn, which has a full
environment. The only sends attempted from cron are the fallbacks — and a
backstop only sends when something else already went wrong, so on a healthy day
its own failure is invisible. 88 successful backstop sends are in the log before
that line; the migration is what moved binary resolution onto the caller's PATH.

## Half a fix is a different error message

The pnpm launcher is a shell script ending in `exec node …`, and nvm keeps node
under a per-version directory a cron job never has on PATH. Resolving only the
binary turns `openclaw is not installed` into `exec: node: not found` — same
undelivered report. `runtime_env()` appends the launcher and node directories to
the spawn's PATH, only when they exist and hold something executable, and the
caller's PATH keeps priority.

## Verified in the real environment

`env -i PATH=/usr/bin:/bin HOME=/root`, dry-run so nothing was delivered:

```
before   status: failed     detail: openclaw is not installed
after    status: confirmed  detail: {"action":"send","channel":"telegram","dryRun":true,…}
```

| mutation | red test |
|---|---|
| resolution falls back to PATH only | bare-cron-path |
| PATH is not augmented for the spawn | exec-node |
| the rebuilt env drops the caller's variables | environment-carried-through |

Full suite: **1,763 passed**.

Third in this family after #438 (the money checker) and #444 (the gold refresh):
`command -v X` is not the same question as "is X installed". The first two were
found by reading; this one only surfaced because the backstop was asked to work.