### PR TITLE
fix: an intraday retry made the watchdog re-send a report kcn already had

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -382,6 +382,37 @@ def last_report_text(session_id, first_line):
     return found
 
 
+def same_generation_window(marker, ctx_generated_at, *, window_s, backward_s):
+    """Was the delivered report built from THIS slot's data, a regeneration apart?
+
+    The preflight `context_id` is a per-invocation hash, so an openclaw auto-retry
+    (re-runs preflight, then hits postflight's idempotency lock and deliberately
+    does NOT rewrite the marker) guarantees the two ids differ — the one case an
+    id compare exists to survive. Comparing the source contexts' own timestamps
+    separates that from the failure the id compare was added for (2026-07-24
+    美股收盘报告 delivered 07/22 numbers): a retry regenerates minutes later, a
+    genuinely stale body is a whole slot, or a day, behind.
+
+    The window is asymmetric — a retry's context is always the NEWER one, so only
+    a small backward tolerance is allowed for clock and write ordering. Its size
+    belongs to the caller: report phases sit hours apart, Mode 7 slots 30 minutes,
+    and a window at or above the cadence would call the previous slot a retry.
+
+    Shared rather than copied on purpose. Mode 6 was fixed on 2026-08-03 and Mode
+    7 kept paying for the same bug until 2026-08-10 (#458) because the rule lived
+    in one file and the second mode never learned it.
+    """
+    marker_at = marker.get('context_generated_at')
+    if not marker_at or not ctx_generated_at:
+        return False
+    try:
+        delta = (datetime.fromisoformat(ctx_generated_at)
+                 - datetime.fromisoformat(marker_at)).total_seconds()
+    except (TypeError, ValueError):
+        return False
+    return -backward_s <= delta <= window_s
+
+
 def transcript_loop_score(session_id):
     """Max repeat-count of any 50-char window across all assistant text in the
     session transcript. A clean run scores ~1-2; the mimo repeat-loop failure

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -243,6 +243,15 @@ def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out,
     `delivery_state` distinguishes a full report from the fail-closed data block
     (#135): both are real deliveries — the watchdog must not re-send either —
     but only one of them carried the model's prose.
+
+    `context_id` and `context_generated_at` name the preflight invocation this
+    body was built from. Without them the only link back to the delivered report
+    was its first line, which carries the generation minute — so when openclaw
+    auto-retried a run that had already delivered, the retry's preflight rewrote
+    the context, the first lines disagreed, and the watchdog mirrored a report kcn
+    already had (#458, 2026-08-10 HK 10:30 and 11:30). Mode 6's marker has carried
+    both fields since 2026-08-03; Mode 7's context always had them and threw them
+    away here.
     """
     heartbeat = ctx.get('heartbeat') or {}
     return {
@@ -253,6 +262,8 @@ def delivery_marker_payload(ctx, *, ts, sent_ok, tg_ok, first_line, market, out,
         'market': market,
         'job': heartbeat.get('job'),
         'slot': heartbeat.get('slot'),
+        'context_id': ctx.get('context_id'),
+        'context_generated_at': ctx.get('generated_at'),
         'delivery_state': delivery_state,
         'out': (out or '')[-200:],
     }

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_watchdog.py
@@ -69,6 +69,7 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs, KCN_TELEGRAM,
     transcript_loop_score, last_report_text, send_telegram,
+    same_generation_window,
 )
 
 from clawock_kcnyu.automation import cron_heartbeat  # noqa: E402
@@ -77,6 +78,12 @@ LOOP_THRESHOLD = 5         # transcript loop_score ≥ this ⇒ mimo repeat-loop
 MARKER_FRESH_MS = 25 * 60 * 1000  # postflight send-marker older than this ⇒ treat as not-this-slot
 MARKER_FUTURE_SKEW_MS = 5 * 60 * 1000  # marker written just after the watchdog's clock read
 WATCHDOG_DELAY_MINUTES = 10
+# Slots are 30 minutes apart, so this window must stay well under that: at or
+# above the cadence it would read the previous slot's context as a retry of this
+# one. Observed retries regenerate within ~3 minutes (2026-08-10: 10:30:05 →
+# 10:32:57), so 10 gives room without reaching the neighbouring slot.
+REGEN_WINDOW_S = 10 * 60
+REGEN_BACKWARD_S = 60      # tolerance for a context timestamped just before the marker's
 
 
 def deterministic_fallback(raw_block, tag, reason):
@@ -87,12 +94,21 @@ def deterministic_fallback(raw_block, tag, reason):
 
 
 def deliver_fallback(raw_block, tag, reason, args, watchdog_now, flag,
-                     expected_job, expected_slot, run_at, extra=None):
+                     expected_job, expected_slot, run_at, extra=None,
+                     telegram_already_delivered=False):
     """Send the deterministic block and record the outcome — success OR failure.
 
     The failure branch records `watchdog_failed` deliberately: a fallback that
     could not be sent is the one state nobody downstream can infer, so it must
     leave the same kind of trace the mirror path already leaves.
+
+    `telegram_already_delivered` keeps that trace honest about the slot rather
+    than about the backstop. postflight records `telegram_sent=True` when its
+    cosend lands; a backstop that then fails to send has learned nothing about
+    that earlier send, so writing `telegram_sent=False` over it turns a delivered
+    slot into a missing one in the heartbeat (#458). The run still records
+    `watchdog_failed` either way — the failure is not being hidden, only kept
+    from contradicting a confirmed delivery.
     """
     body = deterministic_fallback(raw_block, tag, reason)
     tg_ok, tg_out = send_telegram(KCN_TELEGRAM, body, args.dry_run)
@@ -111,7 +127,8 @@ def deliver_fallback(raw_block, tag, reason, args, watchdog_now, flag,
             cron_heartbeat.record(
                 args.market, 'watchdog_failed', at=watchdog_now,
                 job_name=expected_job, slot=expected_slot,
-                watchdog_state='deterministic_fallback_failed', telegram_sent=False,
+                watchdog_state='deterministic_fallback_failed',
+                telegram_sent=bool(telegram_already_delivered),
             )
     print(json.dumps({'tag': tag, 'deterministic_fallback': tg_ok,
                       'dry_run': args.dry_run}, ensure_ascii=False))
@@ -156,12 +173,39 @@ def context_for_slot(path, job_name, slot):
     return context
 
 
-def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms):
-    """Whether postflight confirmed Telegram delivery for this exact slot."""
+def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms,
+                       ctx_id=None, ctx_generated_at=None):
+    """Whether postflight confirmed Telegram delivery for this exact slot.
+
+    Slot identity comes first and is never traded away: a marker for another
+    job or another slot is not evidence about this one, whatever its ids say.
+
+    Within the slot, identity prefers the preflight `context_id` (exact), then
+    the regeneration window when the ids differ because openclaw retried the run,
+    and only then the legacy first-line compare kept for markers written before
+    those fields existed.
+
+    The first-line compare cannot be the primary judge (#458): the block's first
+    line carries its generation minute, and a retry's preflight regenerates the
+    context while postflight's idempotency lock deliberately leaves the marker
+    alone — so the two disagree by construction on exactly the slots that WERE
+    delivered. On 2026-08-10 that mirrored the HK 10:30 and 11:30 reports back to
+    kcn as "undelivered".
+    """
     if not isinstance(marker, dict) or not marker.get('tg_ok'):
         return False
     if (marker.get('job'), marker.get('slot')) != (job_name, slot):
         return False
+    if marker.get('context_id') and ctx_id:
+        if marker['context_id'] == ctx_id:
+            return True
+        # Ids differ. That is the normal shape of a cron retry, not of a miss.
+        # Markers predating the field fall through to the legacy compare rather
+        # than to a false miss for the length of one deployment.
+        if marker.get('context_generated_at'):
+            return same_generation_window(
+                marker, ctx_generated_at,
+                window_s=REGEN_WINDOW_S, backward_s=REGEN_BACKWARD_S)
     ts = marker.get('ts')
     # Both bounds matter now that the marker is the primary judge: a wildly
     # future-dated ts (clock skew, corrupted or hand-edited marker) would
@@ -237,6 +281,24 @@ def main():
     loop_score, _ = transcript_loop_score(session_id)
     looped = loop_score >= LOOP_THRESHOLD
 
+    marker_path = WS / 'memory' / '.tmp' / f'intraday-sent-{args.market}.json'
+    marker = None
+    if marker_path.exists():
+        try:
+            marker = json.loads(marker_path.read_text())
+        except Exception:
+            marker = None
+    now_ms = int(watchdog_now.timestamp() * 1000)
+    # A confirmed Telegram send for this exact slot, whichever attempt made it.
+    # The evidence gate below can still decline to call the slot covered (stale
+    # generation, failed cosend), and the loop gate deliberately ignores it —
+    # this only records that a send was confirmed, so a backstop that could not
+    # be delivered cannot rewrite that fact into "never delivered" (#458).
+    # Read here rather than at the gate so both gates can carry it.
+    telegram_already_delivered = bool(
+        isinstance(marker, dict) and marker.get('tg_ok')
+        and (marker.get('job'), marker.get('slot')) == (expected_job, expected_slot))
+
     # --- Loop gate: a detected loop always reaches kcn, delivered or not ------
     # A confirmed marker does NOT suppress this. `tg_ok` only proves the send
     # subprocess exited 0 — it never inspects the body. postflight's length cap
@@ -249,7 +311,8 @@ def main():
         deliver_fallback(
             raw_block, tag, '循环', args, watchdog_now, flag,
             expected_job, expected_slot, run_at,
-            extra={'loop_score': loop_score, 'delivered_clean': None})
+            extra={'loop_score': loop_score, 'delivered_clean': None},
+            telegram_already_delivered=telegram_already_delivered)
         return 0
 
     # --- Delivery evidence gate: the postflight marker decides -----------------
@@ -259,18 +322,12 @@ def main():
     # miss. The marker is positive proof — postflight itself recorded tg_ok for
     # this exact job/slot/first_line within the freshness window — and positive
     # proof of delivery outranks any inference drawn from the run record.
-    marker_path = WS / 'memory' / '.tmp' / f'intraday-sent-{args.market}.json'
-    marker = None
-    if marker_path.exists():
-        try:
-            marker = json.loads(marker_path.read_text())
-        except Exception:
-            marker = None
-    now_ms = int(watchdog_now.timestamp() * 1000)
     # TG is covered iff postflight's cosend confirmably delivered this report to
-    # Telegram this exact slot (slot identity, freshness, first line, tg_ok=true).
+    # Telegram this exact slot (slot identity, context generation, tg_ok=true).
     if marker_covers_slot(
-            marker, expected_job, expected_slot, raw_block_first, now_ms):
+            marker, expected_job, expected_slot, raw_block_first, now_ms,
+            ctx_id=context.get('context_id'),
+            ctx_generated_at=context.get('generated_at')):
         cron_heartbeat.record(
             args.market, 'completed', at=watchdog_now,
             job_name=expected_job, slot=expected_slot,
@@ -305,7 +362,8 @@ def main():
         deliver_fallback(
             raw_block, tag, '未完成', args, watchdog_now, flag,
             expected_job, expected_slot, run_at,
-            extra={'loop_score': loop_score, 'delivered_clean': delivered_clean})
+            extra={'loop_score': loop_score, 'delivered_clean': delivered_clean},
+            telegram_already_delivered=telegram_already_delivered)
         return 0
 
     # --- Delivery backstop: Telegram only (no WeChat resend) ------------------

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_watchdog.py
@@ -50,6 +50,7 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs,
     transcript_loop_score, last_report_text, send_telegram, KCN_TELEGRAM,
+    same_generation_window,
 )
 
 LOOP_THRESHOLD = 5                 # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
@@ -66,30 +67,16 @@ def deterministic_fallback(raw_block, tag, reason):
 
 
 def _same_generation_window(marker, ctx_generated_at):
-    """Was the delivered report built from THIS slot's data, a regeneration apart?
+    """This mode's window on the shared rule — see `same_generation_window`.
 
-    `context_id` is a per-preflight-invocation hash, so an openclaw auto-retry
-    (re-runs preflight, then hits postflight's idempotency lock and deliberately
-    does NOT rewrite the marker) guarantees the two ids differ — the one case the
-    id compare exists to survive. Both 2026-08-03 HK false backstops were exactly
-    that: delivered at 13:31 from a 13:30 context, watchdog at 13:42 reading the
-    retry's 13:32:59 context.
-
-    Comparing the source contexts' own timestamps separates that from the failure
-    the id compare was added for (2026-07-24 美股收盘报告 delivered 07/22 numbers):
-    a retry regenerates minutes later, a genuinely stale body is hours or days
-    behind. The window is asymmetric — a retry's context is always the NEWER one,
-    so only a small backward tolerance is allowed for clock/write ordering.
+    Both 2026-08-03 HK false backstops were exactly the retry case: delivered at
+    13:31 from a 13:30 context, watchdog at 13:42 reading the retry's 13:32:59
+    context. Report phases sit hours apart, so a 30-minute window cannot reach
+    the previous phase.
     """
-    marker_at = marker.get('context_generated_at')
-    if not marker_at or not ctx_generated_at:
-        return False
-    try:
-        delta = (datetime.fromisoformat(ctx_generated_at)
-                 - datetime.fromisoformat(marker_at)).total_seconds()
-    except (TypeError, ValueError):
-        return False
-    return -REGEN_BACKWARD_S <= delta <= REGEN_WINDOW_S
+    return same_generation_window(
+        marker, ctx_generated_at,
+        window_s=REGEN_WINDOW_S, backward_s=REGEN_BACKWARD_S)
 
 
 def slot_delivered(marker, ctx_id, raw_block_first, now_ms, ctx_generated_at=None):

--- a/tests/test_intraday_watchdog_retry_parity.py
+++ b/tests/test_intraday_watchdog_retry_parity.py
@@ -1,0 +1,246 @@
+"""intraday_watchdog delivery evidence must survive an openclaw cron retry.
+
+2026-08-10: the HK 10:30 and 11:30 slots were delivered by intraday_postflight
+(WeChat + Telegram cosend, `sent_ok=true` at 10:31:40 and 11:31:37), openclaw
+then auto-retried each run because post-turn summary generation failed, the
+retry's preflight rewrote the context file, and its postflight correctly
+declined to re-send. The watchdog compared the marker's `first_line` — written
+from the block that was actually delivered — against the retry's regenerated
+block, read "never delivered", and fired a deterministic fallback for two
+reports already sitting in kcn's Telegram:
+
+    _1030.json -> '🇭🇰 港股盯盘 | 08/10 10:30 HKT'   delivered, marker
+    _1032.json -> '🇭🇰 港股盯盘 | 08/10 10:33 HKT'   retry, what the gate compared
+
+Only a second bug hid it: the fallback could not send (`openclaw is not
+installed`, the cron-PATH hole fixed by #457), so no duplicate landed. With that
+path working, the same shape delivers the duplicate.
+
+This is the same incident report_watchdog was fixed for on 2026-08-03; see
+tests/test_report_watchdog_retry_parity.py. The port to Mode 7 is what this file
+pins.
+
+The opposite failure must stay caught: a marker whose context belongs to another
+slot, or is a whole generation stale, must still get the backstop. Both
+invariants are pinned here — a fix for either one that breaks the other fails
+this file.
+"""
+import json
+from datetime import datetime
+
+JOB = '盘中盯盘'
+SLOT = '2026-08-10T10:30:00+08:00'
+DELIVERED_LINE = '🇭🇰 港股盯盘 | 08/10 10:30 HKT'
+RETRY_LINE = '🇭🇰 港股盯盘 | 08/10 10:33 HKT'
+DELIVERED_AT = datetime(2026, 8, 10, 10, 30, 5)
+RETRY_AT = datetime(2026, 8, 10, 10, 32, 57)
+NOW_MS = int(datetime(2026, 8, 10, 10, 40).timestamp() * 1000)
+
+
+def _marker(**extra):
+    marker = {
+        'ts': int(datetime(2026, 8, 10, 10, 31, 40).timestamp() * 1000),
+        'tg_ok': True,
+        'first_line': DELIVERED_LINE,
+        'job': JOB,
+        'slot': SLOT,
+        'context_id': '2b44c30f12e5',
+        'context_generated_at': DELIVERED_AT.isoformat(),
+    }
+    marker.update(extra)
+    return marker
+
+
+def test_retry_regenerated_context_still_counts_as_delivered():
+    """The 2026-08-10 10:30 and 11:30 false backstops."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    assert watchdog.marker_covers_slot(
+        _marker(), JOB, SLOT, RETRY_LINE, NOW_MS,
+        ctx_id='c67756a17272', ctx_generated_at=RETRY_AT.isoformat())
+
+
+def test_an_exact_context_id_match_is_delivered():
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    assert watchdog.marker_covers_slot(
+        _marker(), JOB, SLOT, DELIVERED_LINE, NOW_MS,
+        ctx_id='2b44c30f12e5', ctx_generated_at=DELIVERED_AT.isoformat())
+
+
+def test_a_context_a_whole_slot_older_is_not_this_slot():
+    """The failure the id compare exists for: a marker left over from an earlier
+    delivery must not suppress this slot's backstop just because the ids differ
+    and the gate learned to forgive differing ids."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    stale = _marker(
+        context_id='aaaaaaaaaaaa',
+        context_generated_at=datetime(2026, 8, 10, 10, 0, 4).isoformat(),
+    )
+
+    assert not watchdog.marker_covers_slot(
+        stale, JOB, SLOT, RETRY_LINE, NOW_MS,
+        ctx_id='c67756a17272', ctx_generated_at=RETRY_AT.isoformat())
+
+
+def test_a_marker_for_another_slot_is_still_rejected():
+    """Slot identity outranks every id rule: the marker below is fresh, its
+    context was generated seconds before this one, and it is still the wrong
+    slot."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    other = _marker(slot='2026-08-10T11:30:00+08:00')
+
+    assert not watchdog.marker_covers_slot(
+        other, JOB, SLOT, RETRY_LINE, NOW_MS,
+        ctx_id='c67756a17272', ctx_generated_at=RETRY_AT.isoformat())
+
+
+def test_a_failed_telegram_cosend_is_never_delivered():
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    assert not watchdog.marker_covers_slot(
+        _marker(tg_ok=False), JOB, SLOT, DELIVERED_LINE, NOW_MS,
+        ctx_id='2b44c30f12e5', ctx_generated_at=DELIVERED_AT.isoformat())
+
+
+def test_a_marker_predating_the_id_fields_still_uses_the_first_line():
+    """Markers written before this fix carry neither field. They must keep
+    working through the legacy compare rather than turning every slot into a
+    false miss for the length of one deployment."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    legacy = _marker()
+    legacy.pop('context_id')
+    legacy.pop('context_generated_at')
+
+    assert watchdog.marker_covers_slot(
+        legacy, JOB, SLOT, DELIVERED_LINE, NOW_MS,
+        ctx_id='c67756a17272', ctx_generated_at=RETRY_AT.isoformat())
+    assert not watchdog.marker_covers_slot(
+        legacy, JOB, SLOT, RETRY_LINE, NOW_MS,
+        ctx_id='c67756a17272', ctx_generated_at=RETRY_AT.isoformat())
+
+
+def test_postflight_marker_records_the_context_identity_the_gate_needs():
+    """The gate above can only work if postflight writes the two fields. This is
+    the half that was missing: Mode 7's context has carried `context_id` and
+    `generated_at` all along, and the marker threw both away."""
+    from clawock_kcnyu.harness import intraday_postflight as postflight
+
+    marker = postflight.delivery_marker_payload(
+        {
+            'heartbeat': {'job': JOB, 'slot': SLOT},
+            'context_id': '2b44c30f12e5',
+            'generated_at': DELIVERED_AT.isoformat(),
+        },
+        ts=1_000_000,
+        sent_ok=True,
+        tg_ok=True,
+        first_line=DELIVERED_LINE,
+        market='hk',
+        out='ok',
+    )
+
+    assert marker['context_id'] == '2b44c30f12e5'
+    assert marker['context_generated_at'] == DELIVERED_AT.isoformat()
+
+
+def test_the_regeneration_window_is_shared_with_report_watchdog():
+    """Mode 6 was fixed on 2026-08-03 and Mode 7 kept paying for it until today.
+    A second copy of the rule is how that happens again, so the helper must be
+    one object, not two that look alike."""
+    from clawock_kcnyu.harness import _watchdog_common, report_watchdog
+    from clawock_kcnyu.harness import intraday_watchdog
+
+    shared = _watchdog_common.same_generation_window
+    assert intraday_watchdog.same_generation_window is shared
+    assert report_watchdog.same_generation_window is shared
+
+
+def test_the_retry_window_is_tighter_than_the_intraday_cadence():
+    """Slots are 30 minutes apart. A regeneration window at or above that could
+    call the previous slot's context a retry of this one, so the number itself
+    is part of the invariant."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    assert watchdog.REGEN_WINDOW_S < 30 * 60
+
+
+def test_a_delivered_slot_is_not_downgraded_by_a_failed_backstop(tmp_path, monkeypatch):
+    """The second defect in #458: the failure branch recorded telegram_sent=false
+    over postflight's truthful telegram_sent=true, so the heartbeat claimed a
+    delivered slot was undelivered."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    recorded = []
+    monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
+                        lambda *a, **kw: recorded.append((a, kw)))
+    monkeypatch.setattr(watchdog, 'send_telegram', lambda *a, **kw: (False, 'boom'))
+
+    class Args:
+        market = 'hk'
+        dry_run = False
+
+    watchdog.deliver_fallback(
+        'block', 'intraday-hk', '未完成', Args(), datetime(2026, 8, 10, 10, 40),
+        tmp_path / 'flag', JOB, SLOT, 1_000_000,
+        telegram_already_delivered=True)
+
+    assert recorded, 'a failed fallback must still leave a trace'
+    _, kwargs = recorded[-1]
+    assert kwargs['telegram_sent'] is True, (
+        'postflight delivered this slot; a failed backstop must not rewrite that')
+
+
+def test_a_never_delivered_slot_still_records_the_failure(tmp_path, monkeypatch):
+    """The other side of the same branch: when nothing was delivered, a failed
+    fallback must keep saying so."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    recorded = []
+    monkeypatch.setattr(watchdog.cron_heartbeat, 'record',
+                        lambda *a, **kw: recorded.append((a, kw)))
+    monkeypatch.setattr(watchdog, 'send_telegram', lambda *a, **kw: (False, 'boom'))
+
+    class Args:
+        market = 'hk'
+        dry_run = False
+
+    watchdog.deliver_fallback(
+        'block', 'intraday-hk', '未完成', Args(), datetime(2026, 8, 10, 10, 40),
+        tmp_path / 'flag', JOB, SLOT, 1_000_000)
+
+    _, kwargs = recorded[-1]
+    assert kwargs['telegram_sent'] is False
+    assert kwargs['watchdog_state'] == 'deterministic_fallback_failed'
+
+
+def test_the_context_file_this_incident_produced_still_reads_as_delivered():
+    """A last guard against a fix that only satisfies hand-built fixtures: the
+    two artifacts below are verbatim from the 2026-08-10 incident."""
+    from clawock_kcnyu.harness import intraday_watchdog as watchdog
+
+    delivered = json.loads(json.dumps({
+        'context_id': '2b44c30f12e5',
+        'generated_at': '2026-08-10T10:30:05',
+        'raw_wechat_block': DELIVERED_LINE + '\n...',
+    }))
+    retried = json.loads(json.dumps({
+        'context_id': 'c67756a17272',
+        'generated_at': '2026-08-10T10:32:57',
+        'raw_wechat_block': RETRY_LINE + '\n...',
+    }))
+
+    marker = _marker(
+        context_id=delivered['context_id'],
+        context_generated_at=delivered['generated_at'],
+        first_line=delivered['raw_wechat_block'].splitlines()[0],
+    )
+
+    assert watchdog.marker_covers_slot(
+        marker, JOB, SLOT,
+        retried['raw_wechat_block'].splitlines()[0], NOW_MS,
+        ctx_id=retried['context_id'],
+        ctx_generated_at=retried['generated_at'])


### PR DESCRIPTION
Closes #458.

## The bug

Today's HK 10:30 and 11:30 slots were delivered by `intraday_postflight`
(WeChat + a Telegram cosend returning `sent_ok=true` at 10:31:40 / 11:31:37) and
the watchdog fired a deterministic fallback for both anyway.

openclaw auto-retries an intraday run whose post-turn summary generation fails —
7 of today's 8 HK slots retried. The retry's preflight rewrites the context file
while its postflight correctly hits the idempotency lock and deliberately does
**not** rewrite the delivery marker. `marker_covers_slot` then compared the
marker's `first_line` (from the block actually delivered) against the retry's
regenerated block. That first line carries its generation minute, so the two
disagree by construction on exactly the slots that *were* delivered:

```
intraday-context-hk-2026-08-10_1030.json -> '🇭🇰 港股盯盘 | 08/10 10:30 HKT'   delivered, marker
intraday-context-hk-2026-08-10_1032.json -> '🇭🇰 港股盯盘 | 08/10 10:33 HKT'   retry, what the gate compared
```

The slots that stayed green are the ones whose first attempt errored *before*
reaching postflight, so the retry itself sent and wrote a marker matching its own
context — which is why this is intermittent rather than constant.

Only a second bug hid it: the fallback could not send at all (`openclaw is not
installed`, the cron-PATH hole fixed by #457), so no duplicate reached kcn. With
that path working, the same shape delivers the duplicate.

## The fix

`report_watchdog` was fixed for the identical incident on 2026-08-03 by matching
on the preflight `context_id` and forgiving a regenerated context. Mode 7 never
got the port, although its context has carried `context_id` and `generated_at`
all along — the marker discarded both.

- `intraday_postflight`'s marker now records `context_id` + `context_generated_at`.
- `marker_covers_slot` prefers an exact id, falls back to a regeneration window,
  and keeps the legacy first-line compare for markers predating the fields.
  Slot identity still outranks every id rule.
- The window helper moved to `_watchdog_common` and is shared with
  `report_watchdog` rather than copied — one mode learning a rule the other does
  not is how this recurred. Its size stays per-mode: report phases sit hours
  apart, intraday slots 30 minutes, so Mode 7 uses 10 and a test pins it below
  the cadence.
- The failed-fallback branch no longer records `telegram_sent=false` over
  postflight's truthful `telegram_sent=true`. The run still records
  `watchdog_failed`; the failure is not hidden, only kept from contradicting a
  confirmed delivery.

## Verification

`tests/test_intraday_watchdog_retry_parity.py` — 12 tests, all red before the
change (11 fail, and the 12th only passes because it asserts a constant that did
not exist).

Both directions are mutation-verified:

- Loosening the gate to `return True` once ids differ makes
  `test_a_context_a_whole_slot_older_is_not_this_slot` fail — the fix cannot be
  satisfied by simply forgiving mismatches.
- The last test replays the two verbatim 2026-08-10 artifacts rather than
  hand-built fixtures.

Local: 1748 passed. The 4 failures and 23 errors in the full run reproduce
identically on unmodified `origin/master` in the same worktree (they need a built
dashboard and an installed CLI the bare worktree does not have), so they are not
from this change.
