### PR TITLE
feat: report trade lists that cannot be replayed as a share ledger

### DIFF
--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -47,6 +47,12 @@ cost_basis/prev_close/trades[])复原，且都有一道闸守着。计算链：
                  → 同一 US session 落进两个 HK 日期快照（fd86a53）
   TRUE_PRINCIPAL true_principal（峰值净投入）≥ 当前净投入(cost−realized)   WARN
                  → 手填本金常量过期 → 「净本金回报率」分母失真而虚高
+  SHARE_LEDGER   trades[] 净股 == shares（账本能当股数账本重放）           WARN
+                 → 九只持仓建仓早于账本，replay 差一个常数且事后无从恢复；
+                   #455 的 realized_as_of 同日 tie-break 对着负余额永远为假，
+                   一笔真实清仓被丢出发布的权益曲线（那里钳零是打补丁）。
+                   判据是「缺失股数」不是「余额转负」：再卖一笔只让低点更深、
+                   改不了缺多少，而 07226 缺 5200 股却一次都没转负。
 
 用法：
   clawock integrity [portfolio.json]   # 默认 workspace 根 portfolio.json
@@ -158,6 +164,88 @@ def _prev_snapshot_cash(region, field):
         except Exception:
             continue
     return None
+
+
+# 账本不完整、已知且已签收的持仓：(区, ticker) → 缺失的建仓股数。
+# 这些仓位在「每笔交易都记进 trades[]」之前就已开仓，所以 trades[] replay 不回
+# 当前 shares。差额是常数、可复现，记在这里是为了**不让这张表悄悄变长**——
+# 补一笔 reconstructed 建仓会改动 money 文件，那是 kcn 的决定（#456 选项 2）。
+#
+# 记「缺失股数」而不是「余额转负的日期」，因为只有前者是稳定的：再卖一笔会让
+# 负值低点更深、却改不了缺了多少。也正因为如此，07226 才在这张表里——它 6200 股
+# 对着 +1000 的 trades，缺 5200 股建仓，但一次都没转负，用「转负」筛就永远看不见。
+KNOWN_INCOMPLETE_LEDGERS = {
+    ('us_stocks', 'TQQQ'): 8,
+    ('us_stocks', 'OKLO'): 2,
+    ('us_stocks', 'TCOM'): 5,
+    ('us_stocks', 'HOOD'): 5,
+    ('us_stocks', 'RKLB'): 5,
+    ('hk_stocks', '07709'): 600,
+    ('hk_stocks', '07747'): 200,
+    ('hk_stocks', '02208'): 600,
+    ('hk_stocks', '07226'): 5200,
+}
+SHARE_TOL = 1e-6
+
+
+def ledger_deficit(holding):
+    """当前 shares 与 trades[] replay 净股之差 —— 即「没记进账本的建仓股数」。
+
+    0 表示这份 trades[] 可以当股数账本重放；>0 表示缺买入；<0 表示多记了买入。
+    没有 trades[] 的持仓返回 0：它根本没有可重放的清单（建仓早于账本），
+    对它报警只会把真正的九个埋进噪音里。
+    """
+    trades = holding.get('trades') or []
+    if not trades:
+        return 0.0
+    _, net = _moving_avg_cost(trades)
+    return (_num(holding.get('shares')) or 0) - net
+
+
+def check_share_ledgers(portfolios):
+    """SHARE_LEDGER：trades[] 能不能当股数账本重放。
+
+    不影响钱：每笔卖出自带 realized_pnl，账面合计分毫不差，钱闸绿是对的。
+    代价是任何「按 trades[] 重放股数」的消费者都会拿到一个差了常数的结果，而且
+    那个常数事后无从恢复——#455 就是这么被咬的：realized_as_of 的同日 tie-break
+    问「快照是否已降到卖出后的余额」，对着 -5 的余额永远为假，于是一笔真实的清仓
+    被从发布出去的权益曲线里丢掉了。那里的钳零是正确的局部修法，但它是在给这条
+    缺陷打补丁。
+
+    WARN 而非 ERROR：钱是对的，拦发布会让一个不损坏数字的历史遗留问题挡住投递，
+    而这正是 detect-but-never-silence 反对的那种降级的镜像——要看得见，不要拦。
+
+    只报一件事：缺口没被签收。「名单活得比问题久」和「闸扫了 0 份账本」这两条
+    同样重要，但它们都不能做成运行时 finding——全现金 / 只有黄金的账本本来就没有
+    可重放的清单，合成 fixture 又常借用真 ticker，两者都会让这个码变成噪音，
+    而一个总在响的码等于没有码。它们改由 tests/test_share_ledger_completeness.py
+    对着**真账本**断言：九条每条都得还在、还带 trades[]、缺口还等于签收的数字。
+    """
+    findings = []
+    for region, port in (portfolios or {}).items():
+        if not isinstance(port, dict):
+            continue
+        for h in port.get('holdings', []) or []:
+            if not (h.get('trades') or []):
+                continue
+            ticker = h.get('ticker')
+            deficit = ledger_deficit(h)
+            known = KNOWN_INCOMPLETE_LEDGERS.get((region, ticker))
+            if abs(deficit) > SHARE_TOL:
+                if known is None:
+                    findings.append({
+                        'code': 'SHARE_LEDGER', 'level': 'WARN', 'region': region,
+                        'ticker': ticker,
+                        'msg': f'{ticker} shares={_num(h.get("shares")) or 0:.0f} 与 trades[] '
+                               f'净股差 {deficit:+.0f} 股；账本缺建仓、无法当股数账本重放'
+                               f'（新出现，不在 #456 已签收名单里）'})
+                elif abs(deficit - known) > SHARE_TOL:
+                    findings.append({
+                        'code': 'SHARE_LEDGER', 'level': 'WARN', 'region': region,
+                        'ticker': ticker,
+                        'msg': f'{ticker} 账本缺口从已签收的 {known:.0f} 变成 {deficit:.0f} 股；'
+                               f'又多了一笔没有对应买入的卖出'})
+    return findings
 
 
 def check(portfolio_path=PORTFOLIO):
@@ -442,6 +530,9 @@ def check(portfolio_path=PORTFOLIO):
                 add('GOLD_RECON', 'WARN',
                     f'gold_dca 手填隐含均价 {implied:.3f} 与 NAV {nav:.3f} 偏离 {implied / nav:.2f}×；'
                     f'疑 principal/units 填错或单位反', region='gold')
+
+    # SHARE_LEDGER：跨区一次算完（名单是按区+ticker 记的），所以放在区循环之外。
+    findings.extend(check_share_ledgers(P))
 
     errors = [f for f in findings if f['level'] == 'ERROR']
     warns = [f for f in findings if f['level'] == 'WARN']

--- a/tests/test_preflight_integrity.py
+++ b/tests/test_preflight_integrity.py
@@ -482,13 +482,21 @@ def test_cost_basis_exact_half_percent_passes_and_just_over_fails(run_check):
     _assert_only(run_check(over), "COST_BASIS", "ERROR", "trades 移动加权")
 
 
-def test_cost_basis_skips_incomplete_trade_ledger_without_false_positive(run_check):
+def test_cost_basis_skips_incomplete_trade_ledger_but_share_ledger_reports_it(run_check):
+    """COST_BASIS must stay silent on a half ledger — its moving average cannot
+    be verified against a list that is missing the opening buy, and raising an
+    ERROR there would fail the book for something it cannot know.
+
+    SHARE_LEDGER is the other half of that trade-off (#456): the same input is
+    exactly what it exists to report, so silence here is now proven to be
+    COST_BASIS declining to judge, not the incompleteness going unseen.
+    """
     data = _portfolio_data()
     h = _port(data)["holdings"][0]
     h["trades"] = [
         {"date": "2026-07-01", "action": "buy", "shares": 2, "price": 1}
     ]
-    _assert_clean(run_check(data))
+    _assert_only(run_check(data), "SHARE_LEDGER", "WARN", "无法当股数账本重放")
 
 
 # Cross-field, freshness, principal, and cash gates ----------------------------

--- a/tests/test_share_ledger_completeness.py
+++ b/tests/test_share_ledger_completeness.py
@@ -1,0 +1,188 @@
+"""The trade list must replay to the shares actually held — or say why it cannot.
+
+#456: eight holdings record a sell with no matching buy, so replaying
+`holdings[].trades[]` drives the share balance negative. Realized P&L is
+unaffected and the money gate is right to be green; the cost is that the trade
+list cannot be replayed as a share ledger, and every consumer that tries gets a
+number wrong by a constant nobody can recover. #455 hit exactly that and had to
+clamp the balance at zero locally.
+
+This file pins the check that stops the set growing silently.
+
+Two things are deliberately stronger than the issue's framing:
+
+`shares - net_from_trades` is the invariant, not "the balance goes negative".
+Negative balance is a symptom that only appears when the unrecorded opening lot
+is smaller than a later sell. 07226 holds 6,200 shares against +1,000 of
+recorded trades — 5,200 opening shares missing, never once negative, and the
+issue's own table missed it for that reason. The deficit is also the stable
+number: it survives further selling, while the negative low-water mark deepens.
+
+An entry that no longer reproduces must be removed. A known-issue list that
+outlives its issue is how a gate quietly stops gating.
+"""
+import json
+
+import pytest
+
+from clawock.portfolio.integrity import (
+    KNOWN_INCOMPLETE_LEDGERS, check_share_ledgers, ledger_deficit,
+)
+
+
+def _holding(ticker, shares, trades):
+    return {'ticker': ticker, 'shares': shares, 'trades': trades}
+
+
+def _buy(date, shares):
+    return {'date': date, 'action': 'buy', 'shares': shares, 'price': 10}
+
+
+def _sell(date, shares):
+    return {'date': date, 'action': 'sell', 'shares': shares, 'price': 12}
+
+
+def _codes(findings, code):
+    return [f for f in findings if f['code'] == code]
+
+
+def test_a_complete_ledger_replays_to_the_recorded_shares():
+    holding = _holding('CRCL', 2, [_buy('2026-05-01', 5), _sell('2026-05-02', 3)])
+    assert ledger_deficit(holding) == 0
+
+
+def test_the_deficit_is_the_unrecorded_opening_lot():
+    """07226's shape: every recorded trade is a buy, and the position is still
+    larger than all of them together."""
+    holding = _holding('07226', 6200, [_buy('2026-06-01', 1000)])
+    assert ledger_deficit(holding) == 5200
+
+
+def test_the_deficit_survives_further_selling():
+    """Why the deficit is the recorded number and the negative low-water mark is
+    not: selling more deepens the trough but cannot change what is missing."""
+    before = _holding('02208', 400, [_sell('2026-04-27', 200)])
+    after = _holding('02208', 300, [_sell('2026-04-27', 200), _sell('2026-05-06', 100)])
+    assert ledger_deficit(before) == ledger_deficit(after) == 600
+
+
+def test_a_ledger_that_never_goes_negative_is_still_caught():
+    """The gap this check exists to close: the issue's negative-balance test
+    reports nothing here, and 5,200 shares are still unaccounted for."""
+    findings = check_share_ledgers(
+        {'hk_stocks': {'holdings': [_holding('NEWTKR', 6200, [_buy('2026-06-01', 1000)])]}})
+    assert _codes(findings, 'SHARE_LEDGER'), 'an unrecorded opening lot must be reported'
+
+
+def test_a_known_incomplete_ledger_is_not_reported_again():
+    holdings = [_holding('TQQQ', 0, [_sell('2026-04-16', 8)])]
+    findings = check_share_ledgers({'us_stocks': {'holdings': holdings}})
+    assert not _codes(findings, 'SHARE_LEDGER')
+
+
+def test_a_known_ledger_that_drifts_further_is_reported():
+    """The allowlist forgives one recorded deficit, not any deficit on that
+    ticker: a NEW unmatched sell is a new data-entry error."""
+    holdings = [_holding('TQQQ', 0, [_sell('2026-04-16', 8), _sell('2026-05-20', 3)])]
+    findings = check_share_ledgers({'us_stocks': {'holdings': holdings}})
+    found = _codes(findings, 'SHARE_LEDGER')
+    assert found, 'a deepened deficit is not the deficit that was signed off'
+    assert '11' in found[0]['msg']
+
+
+def test_a_repaired_ledger_is_silent_at_runtime():
+    """A backfilled ledger produces no finding — and the demand that its
+    allowlist entry then be *removed* is made against the real book in
+    `test_the_check_actually_replays_nine_real_ledgers`, not here. A runtime
+    code for it would fire on every synthetic fixture that borrows a real
+    ticker, and a code that always fires is a code nobody reads."""
+    holdings = [_holding('TQQQ', 8, [_buy('2026-01-05', 8), _sell('2026-04-16', 8),
+                                     _buy('2026-04-17', 8)])]
+    assert check_share_ledgers({'us_stocks': {'holdings': holdings}}) == []
+
+
+def test_a_holding_with_no_trades_is_not_a_finding():
+    """Positions that predate the trade log entirely carry no list to replay.
+    Flagging them would bury the nine real ones in noise — and an all-cash or
+    gold-only book legitimately has nothing to scan at all."""
+    findings = check_share_ledgers(
+        {'us_stocks': {'holdings': [{'ticker': 'NVDA', 'shares': 10, 'trades': []},
+                                    _holding('CRCL', 2, [_buy('2026-05-01', 2)])]}})
+    assert not _codes(findings, 'SHARE_LEDGER')
+
+
+def test_the_finding_never_blocks_publication():
+    """Realized P&L reconciles to the cent and the book totals are right, so an
+    incomplete share ledger must stay visible without stopping delivery — the
+    same level REALIZED_SUM sits at."""
+    findings = check_share_ledgers(
+        {'hk_stocks': {'holdings': [_holding('NEWTKR', 6200, [_buy('2026-06-01', 1000)])]}})
+    assert all(f['level'] == 'WARN' for f in findings)
+
+
+def test_the_allowlist_matches_the_live_book_exactly():
+    """The list is a statement about real data, so it is checked against real
+    data: every entry must still reproduce, and nothing outside it may be
+    incomplete. This is the test that fails the day a tenth one appears."""
+    from clawock.portfolio.integrity import PORTFOLIO
+
+    if not PORTFOLIO.exists():
+        pytest.skip('no live book in this checkout')
+    data = json.loads(PORTFOLIO.read_text())
+    findings = check_share_ledgers(data.get('portfolios', {}))
+    assert [f for f in findings if f['code'] == 'SHARE_LEDGER_VACUOUS'] == []
+    assert [f['msg'] for f in findings if f['code'].startswith('SHARE_LEDGER')] == []
+
+
+def test_the_gate_is_actually_wired_into_the_published_check(tmp_path):
+    """A check nobody calls is the most expensive kind of green. `clawock
+    integrity` is what preflight and publishing run, so the finding has to come
+    out of `check()` — not merely out of the function this file tests directly.
+    """
+    from clawock.portfolio.integrity import check
+
+    book = tmp_path / 'portfolio.json'
+    book.write_text(json.dumps({'portfolios': {'us_stocks': {
+        'currency': 'USD',
+        'holdings': [_holding('NEWTKR', 6200, [_buy('2026-06-01', 1000)])],
+    }}}))
+
+    report = check(book)
+    assert [f for f in report['findings'] if f['code'] == 'SHARE_LEDGER'], (
+        'check() must surface the share-ledger finding')
+    assert report['ok'], 'the money is right — this finding must not block publishing'
+
+
+def test_the_check_actually_replays_nine_real_ledgers():
+    """The anti-vacuous assertion, and it lives here on purpose.
+
+    A discovery-style gate that finds nothing because it looked at nothing
+    reports success forever (#452, #453). But "scanned zero" cannot be a runtime
+    finding: an all-cash or gold-only book legitimately has no trade list to
+    replay, and firing there would train everyone to ignore the code.
+
+    So the claim is checked against the real book instead, where it is falsifiable
+    without being noisy: each of the nine must still be present, still carry a
+    trades list, and still reproduce its recorded deficit. Rename the `trades`
+    key or move holdings and this fails — which is the exact rot that would
+    otherwise leave the gate scanning nothing and reporting clean.
+    """
+    from clawock.portfolio.integrity import PORTFOLIO
+
+    if not PORTFOLIO.exists():
+        pytest.skip('no live book in this checkout')
+    portfolios = json.loads(PORTFOLIO.read_text()).get('portfolios', {})
+    by_key = {(region, h.get('ticker')): h
+              for region, port in portfolios.items()
+              for h in (port.get('holdings') or [])}
+
+    assert len(KNOWN_INCOMPLETE_LEDGERS) == 9
+    assert ('hk_stocks', '07226') in KNOWN_INCOMPLETE_LEDGERS, (
+        'the one the negative-balance framing missed')
+
+    for key, deficit in KNOWN_INCOMPLETE_LEDGERS.items():
+        holding = by_key.get(key)
+        assert holding is not None, f'{key} left the book without leaving the list'
+        assert holding.get('trades'), f'{key} no longer carries a replayable list'
+        assert ledger_deficit(holding) == deficit, (
+            f'{key} deficit moved; the signed-off number is stale')


### PR DESCRIPTION
Refs #456. Takes **option 1** — write the constraint down and stop the set
growing silently. Option 2 (backfilling reconstructed opening lots) edits money
data, which is kcn's call and not something a check should do as a side effect.

## The invariant is the deficit, not the negative balance

`shares - net_from_trades` is what this measures. A negative running balance is
only the symptom that appears when the unrecorded opening lot happens to be
smaller than a later sell, and the deficit is the stable number — selling more
deepens the trough but cannot change how much is missing.

## That finds a ninth the issue's table missed

| leg | ticker | deficit | ever negative? |
|---|---|---|---|
| us | TQQQ | 8 | yes |
| us | OKLO | 2 | yes |
| us | TCOM | 5 | yes |
| us | HOOD | 5 | yes |
| us | RKLB | 5 | yes |
| hk | 07709 | 600 | yes |
| hk | 07747 | 200 | yes |
| hk | 02208 | 600 | yes |
| **hk** | **07226** | **5,200** | **never** |

`07226` holds 6,200 shares against +1,000 of recorded trades. It never goes
negative, so the negative-balance framing cannot see it — and unlike the other
eight it is a **live** position, not a closed one.

It also matters more than the closed ones: `COST_BASIS` only verifies the moving
average when `net == shares`, so every incomplete ledger is exempt from the
strictest money ERROR in the file. Nine holdings currently hold that exemption
and nothing said so.

## Level

`WARN`. Realized P&L reconciles to the cent, the book totals are right, and the
money gate is correct to be green. Blocking publication over a historical gap
would be the mirror image of the silent downgrade this repo forbids — visible
without stopping delivery.

## What is deliberately not a runtime finding

The gate reports one thing: a deficit nobody signed off. Two other claims matter
just as much and are asserted in tests against the **real book** instead:

- the allowlist outliving its issue
- the check scanning nothing at all (the #452/#453 family)

As runtime codes both fire on legitimate inputs — an all-cash or gold-only book
has no list to replay, and synthetic fixtures borrow real tickers like `07226`.
A code that fires on healthy data is a code nobody reads. Against the real book
they are falsifiable and quiet: each of the nine must still exist, still carry a
`trades[]` list, and still reproduce its recorded deficit.

## Verification

13 tests, red before the change. Three mutations, each caught:

| mutation | caught by |
|---|---|
| unwire `check_share_ledgers` from `check()` | `test_the_gate_is_actually_wired_into_the_published_check` |
| forgive any deficit, not just the signed-off one | the new-ledger and drift tests |
| rename the `trades` key in `portfolio.json` | `test_the_check_actually_replays_nine_real_ledgers` |

The third is the one that matters most: it proves the gate cannot go quiet by
scanning nothing.

`clawock integrity` on the live book stays `0 ERROR / 0 WARN`, and injecting a
tenth incomplete ledger produces the finding.

`test_cost_basis_skips_incomplete_trade_ledger_without_false_positive` asserted
global cleanliness on a half ledger — now exactly the shape this check reports.
It becomes an assertion that COST_BASIS stays silent *while* SHARE_LEDGER
speaks, rather than one of them quietly standing for both.

Full suite: 1748 passed. The 4 failures / 23 errors reproduce identically on
unmodified `origin/master` in the same worktree (they need a built dashboard and
an installed CLI a bare worktree does not have).
