### PR TITLE
feat: make the isolated-install proof a file a reader can run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,33 +52,12 @@ jobs:
       - name: Isolated install completes one real run
         # The acceptance for #379, executed against the artifact about to ship
         # rather than the source tree: a clean environment, no checkout, no
-        # OpenClaw, no KCNyu workspace. `env -i` is the point — it proves the
-        # package is not reading a variable this runner happens to export.
-        run: |
-          set -euo pipefail
-          python -m venv /tmp/isolated
-          # Not a dependency list: this installs the artifact under test.
-          /tmp/isolated/bin/pip install --quiet dist/*.whl
-          mkdir -p /tmp/newuser && cd /tmp/newuser
-          env -i PATH=/usr/bin:/bin HOME=/tmp /tmp/isolated/bin/clawock init book
-          cd book
-          mkdir -p .clawock/work
-          env -i PATH=/usr/bin:/bin HOME=/tmp CLAWOCK_WORKSPACE="$PWD" \
-            /tmp/isolated/bin/clawock run prepare > .clawock/work/request.json
-          echo '{"answer":"smoke"}' > .clawock/work/answer.json
-          env -i PATH=/usr/bin:/bin HOME=/tmp CLAWOCK_WORKSPACE="$PWD" \
-            /tmp/isolated/bin/clawock run publish \
-              --request .clawock/work/request.json \
-              --artifact answer=.clawock/work/answer.json > receipt.json
-          python - <<'PY'
-          import json
-          receipt = json.load(open('receipt.json'))
-          assert receipt['status'] == 'published', receipt
-          assert len(receipt['generation_id']) == 32, receipt
-          names = {artifact['name'] for artifact in receipt['artifacts']}
-          assert {'answer', 'manifest.json'} <= names, names
-          print('isolated run published', receipt['run_id'])
-          PY
+        # OpenClaw, no KCNyu workspace.
+        #
+        # The steps live in examples/minimal-run/run.sh rather than here so that
+        # what CI proves and what a reader can run are one file. Inline, this was
+        # a proof only GitHub could execute.
+        run: examples/minimal-run/run.sh dist/*.whl
 
       - uses: actions/upload-artifact@v5
         with:

--- a/config/root-allowlist.json
+++ b/config/root-allowlist.json
@@ -23,6 +23,7 @@
     "assets": {"owner": "generated instance state", "consumer": "publisher and Pages data plane"},
     "config": {"owner": "workspace and repository contracts", "consumer": "package, instance, CI and operations"},
     "docs": {"owner": "product and operator documentation", "consumer": "GitHub and Pages staging"},
+    "examples": {"owner": "runnable proofs that the published package works without this checkout", "consumer": ".github/workflows/release.yml"},
     "instances": {"owner": "KCNyu instance distribution", "consumer": "clawock-kcnyu install"},
     "logs": {"owner": "generated operator state", "consumer": "live host checks and cron"},
     "memory": {"owner": "runtime compatibility and instance state", "consumer": "OpenClaw memory and published briefs"},

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# Examples
+
+Runnable proofs that `clawock` works as an installed package rather than as this
+checkout. Each one is executed by CI, so an example that stops working fails a
+required check instead of quietly rotting into documentation.
+
+| example | what it proves |
+|---|---|
+| [`minimal-run/`](minimal-run/) | a clean virtualenv installs the wheel and finishes one complete run — `init` → `run prepare` → `run publish` — with no checkout, no Git, no OpenClaw and an emptied environment |
+
+## Why they are files and not workflow steps
+
+The claim these support is that someone else can use the package. A check that
+only exists inside `release.yml` cannot be run by that someone, so it proves the
+package works for GitHub and nothing more. `release.yml` calls
+`examples/minimal-run/run.sh`; there is one copy, and it is the copy a reader
+can execute.

--- a/examples/minimal-run/run.sh
+++ b/examples/minimal-run/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# One complete clawock run, from an installed wheel, with nothing else present.
+#
+# This is the acceptance check for #379 and the last box of #420, and it is a
+# file rather than a workflow step on purpose: the claim is "a stranger can
+# install the package and finish a run without this repository", and a snippet
+# buried in release.yml is not something a stranger can execute. `release.yml`
+# invokes this script, so what CI proves and what a reader can run are the same
+# thing rather than two copies that drift.
+#
+# `env -i` is the whole point. It clears the environment for every clawock call,
+# so a pass cannot come from a variable this machine happens to export — the
+# failure mode that makes "works on my box" survive all the way to a user.
+#
+# Usage:
+#   examples/minimal-run/run.sh                 # install clawock from PyPI
+#   examples/minimal-run/run.sh dist/*.whl      # install the artifact under test
+set -euo pipefail
+
+wheel="${1:-}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "==> installing into a clean virtualenv"
+python3 -m venv "$workdir/venv"
+if [ -n "$wheel" ]; then
+  "$workdir/venv/bin/pip" install --quiet "$wheel"
+else
+  "$workdir/venv/bin/pip" install --quiet clawock
+fi
+clawock="$workdir/venv/bin/clawock"
+
+# HOME is redirected too: a run must not read the caller's dotfiles, and this is
+# also what lets the script work on a machine that has a real clawock workspace.
+iso() { env -i PATH=/usr/bin:/bin HOME="$workdir/home" "$@"; }
+mkdir -p "$workdir/home" "$workdir/newuser"
+cd "$workdir/newuser"
+
+echo "==> clawock init"
+iso "$clawock" init book
+cd book
+mkdir -p .clawock/work
+
+echo "==> clawock run prepare"
+iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run prepare > .clawock/work/request.json
+
+# Stands in for the agent's answer. A real runtime writes its model output here;
+# the package's job is to certify and publish whatever it is handed, so a literal
+# is enough to exercise every gate this example is about.
+echo '{"answer":"smoke"}' > .clawock/work/answer.json
+
+echo "==> clawock run publish"
+iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run publish \
+  --request .clawock/work/request.json \
+  --artifact answer=.clawock/work/answer.json > receipt.json
+
+echo "==> checking the receipt"
+"$workdir/venv/bin/python" - <<'PY'
+import json
+receipt = json.load(open('receipt.json'))
+assert receipt['status'] == 'published', receipt
+assert len(receipt['generation_id']) == 32, receipt
+names = {artifact['name'] for artifact in receipt['artifacts']}
+assert {'answer', 'manifest.json'} <= names, names
+print('isolated run published', receipt['run_id'])
+PY

--- a/tests/test_examples_are_executed.py
+++ b/tests/test_examples_are_executed.py
@@ -1,0 +1,89 @@
+"""An example nobody runs is documentation that lies on a schedule.
+
+`examples/minimal-run/run.sh` is the acceptance check for #379 and the last
+unchecked box of #420: a clean environment installs the wheel and finishes one
+complete run with no checkout, no Git and no OpenClaw. It used to live inline in
+`release.yml`, which proved the package worked for GitHub and for nobody else —
+a reader could not execute it.
+
+Moving it into a file only helps if the file is the one CI runs. These tests pin
+that: the workflow must invoke the script, and the script must not quietly grow
+a dependency on the checkout it exists to prove is unnecessary.
+"""
+import os
+import re
+import stat
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / 'examples' / 'minimal-run' / 'run.sh'
+RELEASE = ROOT / '.github' / 'workflows' / 'release.yml'
+
+
+def test_the_example_exists_and_is_executable():
+    assert EXAMPLE.exists(), 'the blueprint lists examples/; this is the first one'
+    mode = EXAMPLE.stat().st_mode
+    assert mode & stat.S_IXUSR, 'a proof a reader cannot run is not a proof'
+
+
+def test_the_release_workflow_runs_the_example_rather_than_its_own_copy():
+    """The drift this whole change exists to prevent: CI running one copy while
+    the file a reader runs slowly stops working."""
+    workflow = RELEASE.read_text()
+    assert 'examples/minimal-run/run.sh' in workflow, (
+        'release.yml must invoke the example, not reimplement it')
+
+    # And it must not have kept the inline version alongside it.
+    isolated = workflow.split('Isolated install completes one real run', 1)[1]
+    isolated = isolated.split('- uses:', 1)[0]
+    assert 'clawock init' not in isolated, (
+        'the inline copy is back; there must be exactly one set of steps')
+
+
+def test_the_example_clears_the_environment_for_every_call():
+    """`env -i` is the substance of the claim. Without it a pass can come from a
+    variable the runner happens to export, which is exactly how "works on my
+    box" survives to a user."""
+    script = EXAMPLE.read_text()
+    assert 'env -i' in script
+    assert re.search(r'HOME="?\$\{?workdir', script), (
+        'HOME must be redirected too, or the run reads the caller dotfiles')
+
+
+def test_the_example_does_not_reach_back_into_the_repository():
+    """It proves the package works *without* this checkout, so referring to the
+    source tree would make the proof circular."""
+    script = EXAMPLE.read_text()
+    for forbidden in ('src/clawock', 'instances/', 'PYTHONPATH', 'pip install -e',
+                      'git clone', '/root/'):
+        assert forbidden not in script, f'{forbidden!r} makes the proof circular'
+
+
+def test_the_example_installs_from_the_index_when_given_no_artifact():
+    """The default path is what a stranger runs after #379 lands. CI passes the
+    wheel under test instead, and both have to keep working."""
+    script = EXAMPLE.read_text()
+    assert 'pip" install --quiet clawock' in script or \
+           'pip install --quiet clawock' in script, (
+        'the no-argument path must install the published package')
+
+
+def test_every_example_directory_is_listed_in_the_readme():
+    """Keeps the index honest as examples are added — the same discovery rule the
+    root allowlist applies one level up."""
+    listed = (ROOT / 'examples' / 'README.md').read_text()
+    present = sorted(p.name for p in (ROOT / 'examples').iterdir() if p.is_dir())
+    assert present, 'no example directories found — this test would pass on an empty tree'
+    for name in present:
+        assert f'{name}/' in listed, f'examples/{name} is not in examples/README.md'
+
+
+def test_examples_has_an_owner_in_the_root_allowlist():
+    """`ops/system_check.py` raises a CRITICAL for any unexplained top-level
+    path, so a new directory must arrive with its owner or it breaks the live
+    health check."""
+    import json
+
+    entries = json.loads((ROOT / 'config' / 'root-allowlist.json').read_text())['entries']
+    assert 'examples' in entries, 'a new root path must declare an owner'
+    assert entries['examples']['owner'] and entries['examples']['consumer']


### PR DESCRIPTION
Refs #420, #379. Closes the one real gap the [#420 acceptance audit](https://github.com/KCNyu/clawock/issues/420#issuecomment-5239405797) turned up.

## The gap

The terminal blueprint lists `examples/` — "source-free minimal and runtime
integration proofs" — and the tree had none. The proof it describes *did* exist
and *did* run, inline in `release.yml`.

That is not the same thing. The claim being supported is **a stranger can
install clawock and finish a run without this repository**. A snippet buried in
a workflow proves the package works for GitHub Actions and for nobody else,
because nobody else can execute it.

## The change

The steps move to `examples/minimal-run/run.sh`; `release.yml` becomes:

```yaml
run: examples/minimal-run/run.sh dist/*.whl
```

One copy, and it is the copy a reader can run. With no argument the script
installs from the index — the path a stranger takes once #379 lands — while CI
passes the wheel under test.

`env -i` survives the move and is the substance of the thing: the environment is
cleared for every `clawock` call, so a pass cannot come from a variable the
runner happens to export. `HOME` is redirected too, which is also what lets the
script run on a machine that already has a real clawock workspace — verified
here, on exactly such a box:

```
==> clawock init
==> clawock run prepare
==> clawock run publish
==> checking the receipt
isolated run published ce997581d9d54cd88aff694aec4b2d9d
```

## Keeping it from rotting

An example nobody runs is documentation that lies on a schedule.
`tests/test_examples_are_executed.py` (7 tests) pins:

- `release.yml` invokes the script **and** has not kept an inline copy beside it
  — re-inlining the old steps fails this test, verified by mutation
- the script keeps `env -i` and the redirected `HOME`
- the script never reaches back into the checkout it exists to prove unnecessary
  (`src/clawock`, `PYTHONPATH`, `pip install -e`, `git clone`, `/root/`)
- the no-argument path installs the published package
- every example directory appears in `examples/README.md`, with an assertion
  that fails rather than passes when the directory list is empty

## One thing that would have broken the live health check

A new top-level path needs an owner: `ops/system_check.py::check_root_allowlist`
raises a **CRITICAL** for any unexplained root entry. `examples` is registered in
`config/root-allowlist.json`, and the check still reports every tracked path
owned — 34 now instead of 33.

## Verification

Full suite 1767 passed. The 4 failures / 23 errors reproduce identically on
unmodified `origin/master` in the same worktree; I diffed the
`test_pages_deployment_contract` failure specifically, since adding a root
directory could plausibly have changed what Pages stages — same error, same
cause, unrelated.
