### PR TITLE
fix: reconstruct the nine opening lots that predate the ledger

### DIFF
--- a/portfolio.json
+++ b/portfolio.json
@@ -69,6 +69,19 @@
           "volume": 5773156,
           "trades": [
             {
+              "date": "2026-06-12",
+              "action": "buy",
+              "shares": 5,
+              "price": 71.0,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
+            {
               "date": "2026-06-13",
               "action": "sell",
               "shares": 5,
@@ -159,6 +172,19 @@
           "name": "Oklo Inc-A",
           "trades": [
             {
+              "date": "2026-04-21",
+              "action": "buy",
+              "shares": 2,
+              "price": 62.83,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
+            {
               "date": "2026-04-22",
               "action": "sell",
               "shares": 2,
@@ -223,6 +249,19 @@
           "name": "携程",
           "trades": [
             {
+              "date": "2026-04-21",
+              "action": "buy",
+              "shares": 5,
+              "price": 52.74,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
+            {
               "date": "2026-04-22",
               "action": "sell",
               "shares": 5,
@@ -250,6 +289,19 @@
           "pnl_abs": 0.0,
           "today_change": 0.0,
           "trades": [
+            {
+              "date": "2026-04-15",
+              "action": "buy",
+              "shares": 8,
+              "price": 45.73,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
             {
               "date": "2026-04-16",
               "action": "sell",
@@ -280,6 +332,19 @@
           "today_change": 0.0,
           "name": "Robinhood Markets Inc-A",
           "trades": [
+            {
+              "date": "2026-04-21",
+              "action": "buy",
+              "shares": 5,
+              "price": 73.5,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
             {
               "date": "2026-04-22",
               "action": "sell",
@@ -1080,6 +1145,19 @@
           "volume": 889000,
           "trades": [
             {
+              "date": "2026-04-26",
+              "action": "buy",
+              "shares": 600,
+              "price": 14.084,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
+            {
               "date": "2026-04-27",
               "action": "sell",
               "shares": 200,
@@ -1127,6 +1205,18 @@
           "pnl_percent": -14.19,
           "data_source": "Tencent Aug 10 16:00 HKT",
           "trades": [
+            {
+              "date": "2026-03-23",
+              "action": "buy",
+              "shares": 5200,
+              "price": 4.4973,
+              "reconstructed": true,
+              "derived_from": [
+                "cost_basis"
+              ],
+              "corroborated": false,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
             {
               "date": "2026-03-24",
               "action": "buy",
@@ -1178,6 +1268,19 @@
           "cost_basis": 29.5347875,
           "note": "已清仓 - 历史 sells 保留用于 realized_pnl 汇总(trades 来自 5bb41ea^)",
           "trades": [
+            {
+              "date": "2026-03-10",
+              "action": "buy",
+              "shares": 600,
+              "price": 32.0401,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,9 个约束最大残差 0.0114;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
             {
               "date": "2026-03-11",
               "action": "buy",
@@ -1301,6 +1404,19 @@
           "cost_basis": 81.85,
           "note": "已清仓 - 历史 sells 保留用于 realized_pnl 汇总(trades 来自 5bb41ea^)",
           "trades": [
+            {
+              "date": "2026-03-17",
+              "action": "buy",
+              "shares": 200,
+              "price": 81.85,
+              "reconstructed": true,
+              "derived_from": [
+                "realized_pnl",
+                "cost_basis"
+              ],
+              "corroborated": true,
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+            },
             {
               "date": "2026-03-18",
               "action": "sell",

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -167,24 +167,20 @@ def _prev_snapshot_cash(region, field):
 
 
 # 账本不完整、已知且已签收的持仓：(区, ticker) → 缺失的建仓股数。
-# 这些仓位在「每笔交易都记进 trades[]」之前就已开仓，所以 trades[] replay 不回
-# 当前 shares。差额是常数、可复现，记在这里是为了**不让这张表悄悄变长**——
-# 补一笔 reconstructed 建仓会改动 money 文件，那是 kcn 的决定（#456 选项 2）。
 #
-# 记「缺失股数」而不是「余额转负的日期」，因为只有前者是稳定的：再卖一笔会让
-# 负值低点更深、却改不了缺了多少。也正因为如此，07226 才在这张表里——它 6200 股
-# 对着 +1000 的 trades，缺 5200 股建仓，但一次都没转负，用「转负」筛就永远看不见。
-KNOWN_INCOMPLETE_LEDGERS = {
-    ('us_stocks', 'TQQQ'): 8,
-    ('us_stocks', 'OKLO'): 2,
-    ('us_stocks', 'TCOM'): 5,
-    ('us_stocks', 'HOOD'): 5,
-    ('us_stocks', 'RKLB'): 5,
-    ('hk_stocks', '07709'): 600,
-    ('hk_stocks', '07747'): 200,
-    ('hk_stocks', '02208'): 600,
-    ('hk_stocks', '07226'): 5200,
-}
+# **现在是空的，而且这是这张表的成功状态，不是它失效了。** 九只(#456)在 2026-08-10
+# 补上了 reconstructed 建仓分录：kcn 在 clawock 之前就持有它们，所以缺的不是漏记，
+# 是账本本身从半路开始。补完九只全部 replay 归零，名单随之清空。
+#
+# 留着这个机制而不是删掉：它现在守的是「不许再出现第十只」。空表让这道闸变得
+# 什么都扫不出来，所以反空转的责任全部压在
+# tests/test_share_ledger_completeness.py 对真账本的断言上——那里要求扫到的账本
+# 数量不为零、且每一份都能重放。表空了以后，那个断言才是唯一还在证明这道闸活着的
+# 东西，删了它这道闸就会永远报绿。
+#
+# 判据仍然记「缺失股数」而不是「余额转负的日期」：只有前者稳定，再卖一笔会让负值
+# 低点更深却改不了缺多少。当初 07226 缺 5200 股却一次都没转负，用「转负」筛就看不见。
+KNOWN_INCOMPLETE_LEDGERS = {}
 SHARE_TOL = 1e-6
 
 
@@ -385,8 +381,19 @@ def check(portfolio_path=PORTFOLIO):
 
             # COST_BASIS：仅当 trades 账本完整(净股==当前 shares)时才校验，
             # 半账本(只记近期 T+0、缺建仓买入)净股对不上 → cost_basis 是手填的、跳过
+            #
+            # 重建建仓分录(#456)让九只的净股重新对上，于是这道闸开始校验它们。
+            # 对其中八只这是真校验：开仓价是从**每笔卖出自己记的 realized_pnl**
+            # 反解的，与 cost_basis 相互独立，两者吻合才有那个价。
+            # 07226 一笔卖出都没有，开仓价只能从 cost_basis 本身反解 —— 再拿这道闸
+            # 去校验 cost_basis 就是循环论证，会把一次诚实的「无法校验」变成一次
+            # 自己构造出来的「已核对」，比原来的跳过更坏。
+            # 所以判据不是「有没有重建分录」，而是「那笔重建有没有独立佐证」。
             trades = h.get('trades') or []
-            if trades and cost is not None and sh:
+            uncorroborated = any(
+                tr.get('reconstructed') and not tr.get('corroborated')
+                for tr in trades)
+            if trades and cost is not None and sh and not uncorroborated:
                 mavg, net = _moving_avg_cost(trades)
                 if mavg is not None and abs(net - sh) < 1e-6 and cost > 0:
                     if abs(mavg - cost) / cost > 0.005:   # 偏离 >0.5%

--- a/tests/test_share_ledger_completeness.py
+++ b/tests/test_share_ledger_completeness.py
@@ -30,6 +30,52 @@ from clawock.portfolio.integrity import (
 )
 
 
+def _replay_residuals(rest, quantity, price, cost_basis):
+    """How badly an opening lot of (quantity @ price) contradicts what IS recorded.
+
+    Deliberately a second implementation rather than a call into the package: it
+    re-derives the stored price from the rest of the ledger, so a bug in the
+    production moving-average would have to be reproduced here identically to
+    hide. Same reason the money gate recomputes rather than trusts.
+    """
+    order = [{'date': '0000-00-00', 'action': 'buy',
+              'shares': quantity, 'price': price}]
+    order += sorted(rest, key=lambda t: t.get('date', ''))
+    shares = 0.0
+    cost = 0.0
+    errors = []
+    for trade in order:
+        qty = float(trade.get('shares') or 0)
+        px = float(trade.get('price') or 0)
+        if trade.get('action') == 'buy':
+            shares += qty
+            cost += qty * px
+            continue
+        average = cost / shares if shares else 0.0
+        if trade.get('realized_pnl') is not None:
+            errors.append(qty * (px - average) - float(trade['realized_pnl']))
+        cost -= qty * average
+        shares -= qty
+    final = cost / shares if shares else None
+    if final is not None and cost_basis:
+        errors.append(final - cost_basis)
+    return errors
+
+
+def _solve_opening_price(rest, quantity, cost_basis, shares_now):
+    low, high = 0.0, 500.0
+    def total(price):
+        return sum(e * e for e in _replay_residuals(rest, quantity, price, cost_basis))
+    for _ in range(400):
+        left = low + (high - low) / 3
+        right = high - (high - low) / 3
+        if total(left) < total(right):
+            high = right
+        else:
+            low = left
+    return (low + high) / 2
+
+
 def _holding(ticker, shares, trades):
     return {'ticker': ticker, 'shares': shares, 'trades': trades}
 
@@ -74,16 +120,26 @@ def test_a_ledger_that_never_goes_negative_is_still_caught():
     assert _codes(findings, 'SHARE_LEDGER'), 'an unrecorded opening lot must be reported'
 
 
-def test_a_known_incomplete_ledger_is_not_reported_again():
-    holdings = [_holding('TQQQ', 0, [_sell('2026-04-16', 8)])]
+def test_a_signed_off_deficit_is_not_reported_again(monkeypatch):
+    """The suppression mechanism, exercised against a patched list rather than
+    the live one — which is empty now that #456 was fixed by backfill instead of
+    by exemption. Testing it through real data would make this test pass or fail
+    on today's book instead of on the behaviour."""
+    monkeypatch.setattr(
+        'clawock.portfolio.integrity.KNOWN_INCOMPLETE_LEDGERS',
+        {('us_stocks', 'ZZZZ'): 8})
+    holdings = [_holding('ZZZZ', 0, [_sell('2026-04-16', 8)])]
     findings = check_share_ledgers({'us_stocks': {'holdings': holdings}})
     assert not _codes(findings, 'SHARE_LEDGER')
 
 
-def test_a_known_ledger_that_drifts_further_is_reported():
-    """The allowlist forgives one recorded deficit, not any deficit on that
-    ticker: a NEW unmatched sell is a new data-entry error."""
-    holdings = [_holding('TQQQ', 0, [_sell('2026-04-16', 8), _sell('2026-05-20', 3)])]
+def test_a_signed_off_ledger_that_drifts_further_is_reported(monkeypatch):
+    """The list forgives one recorded deficit, not any deficit on that ticker:
+    a NEW unmatched sell is a new data-entry error."""
+    monkeypatch.setattr(
+        'clawock.portfolio.integrity.KNOWN_INCOMPLETE_LEDGERS',
+        {('us_stocks', 'ZZZZ'): 8})
+    holdings = [_holding('ZZZZ', 0, [_sell('2026-04-16', 8), _sell('2026-05-20', 3)])]
     findings = check_share_ledgers({'us_stocks': {'holdings': holdings}})
     found = _codes(findings, 'SHARE_LEDGER')
     assert found, 'a deepened deficit is not the deficit that was signed off'
@@ -91,11 +147,7 @@ def test_a_known_ledger_that_drifts_further_is_reported():
 
 
 def test_a_repaired_ledger_is_silent_at_runtime():
-    """A backfilled ledger produces no finding — and the demand that its
-    allowlist entry then be *removed* is made against the real book in
-    `test_the_check_actually_replays_nine_real_ledgers`, not here. A runtime
-    code for it would fire on every synthetic fixture that borrows a real
-    ticker, and a code that always fires is a code nobody reads."""
+    """What the nine look like now: replays clean, says nothing."""
     holdings = [_holding('TQQQ', 8, [_buy('2026-01-05', 8), _sell('2026-04-16', 8),
                                      _buy('2026-04-17', 8)])]
     assert check_share_ledgers({'us_stocks': {'holdings': holdings}}) == []
@@ -153,36 +205,130 @@ def test_the_gate_is_actually_wired_into_the_published_check(tmp_path):
     assert report['ok'], 'the money is right — this finding must not block publishing'
 
 
-def test_the_check_actually_replays_nine_real_ledgers():
-    """The anti-vacuous assertion, and it lives here on purpose.
+def test_the_check_actually_replays_the_real_book():
+    """The anti-vacuous assertion, and with the allowlist empty it is now the
+    ONLY thing proving this gate is still alive.
 
     A discovery-style gate that finds nothing because it looked at nothing
-    reports success forever (#452, #453). But "scanned zero" cannot be a runtime
-    finding: an all-cash or gold-only book legitimately has no trade list to
-    replay, and firing there would train everyone to ignore the code.
+    reports success forever (#452, #453). "Scanned zero" cannot be a runtime
+    finding — an all-cash or gold-only book legitimately has no trade list to
+    replay — so the claim is made here, against the real book.
 
-    So the claim is checked against the real book instead, where it is falsifiable
-    without being noisy: each of the nine must still be present, still carry a
-    trades list, and still reproduce its recorded deficit. Rename the `trades`
-    key or move holdings and this fails — which is the exact rot that would
-    otherwise leave the gate scanning nothing and reporting clean.
+    Delete this test and the gate reports clean for the rest of time.
     """
     from clawock.portfolio.integrity import PORTFOLIO
 
     if not PORTFOLIO.exists():
         pytest.skip('no live book in this checkout')
     portfolios = json.loads(PORTFOLIO.read_text()).get('portfolios', {})
-    by_key = {(region, h.get('ticker')): h
-              for region, port in portfolios.items()
-              for h in (port.get('holdings') or [])}
+    scanned = [h for port in portfolios.values()
+               for h in (port.get('holdings') or []) if h.get('trades')]
 
-    assert len(KNOWN_INCOMPLETE_LEDGERS) == 9
-    assert ('hk_stocks', '07226') in KNOWN_INCOMPLETE_LEDGERS, (
-        'the one the negative-balance framing missed')
+    assert len(scanned) >= 15, (
+        f'only {len(scanned)} ledgers carry trades[] — the gate is scanning almost '
+        'nothing, which is how it goes quiet without going red')
+    assert not check_share_ledgers(portfolios), 'the live book must replay clean'
+    for holding in scanned:
+        assert ledger_deficit(holding) == 0, holding.get('ticker')
 
-    for key, deficit in KNOWN_INCOMPLETE_LEDGERS.items():
-        holding = by_key.get(key)
-        assert holding is not None, f'{key} left the book without leaving the list'
-        assert holding.get('trades'), f'{key} no longer carries a replayable list'
-        assert ledger_deficit(holding) == deficit, (
-            f'{key} deficit moved; the signed-off number is stale')
+
+def test_the_allowlist_is_empty_and_that_is_the_success_state():
+    """#456 closed by backfill, not by exemption. A non-empty list means a tenth
+    incomplete ledger appeared and someone signed it off instead of fixing it —
+    which is a decision that should be visible in a diff."""
+    assert KNOWN_INCOMPLETE_LEDGERS == {}
+
+
+def test_every_reconstructed_lot_is_re_derivable_from_the_rest_of_the_ledger():
+    """The reconstructed opening lots are the one place in the book where a
+    number was computed rather than recorded, so the computation is re-run here
+    on every CI run instead of being trusted because a commit message said so.
+
+    For each lot: drop it, solve for the opening price that reproduces every
+    OTHER recorded number in that holding — each sell's own realized_pnl, and
+    the holding's cost_basis — and require the stored price back. A hand-edited
+    price, or a later trade that contradicts it, fails this.
+    """
+    from clawock.portfolio.integrity import PORTFOLIO
+
+    if not PORTFOLIO.exists():
+        pytest.skip('no live book in this checkout')
+    portfolios = json.loads(PORTFOLIO.read_text()).get('portfolios', {})
+
+    checked = 0
+    for port in portfolios.values():
+        for holding in port.get('holdings') or []:
+            trades = holding.get('trades') or []
+            lots = [t for t in trades if t.get('reconstructed')]
+            if not lots:
+                continue
+            assert len(lots) == 1, 'one opening lot per holding'
+            lot = lots[0]
+            rest = [t for t in trades if not t.get('reconstructed')]
+            solved = _solve_opening_price(
+                rest, float(lot['shares']), float(holding.get('cost_basis') or 0),
+                float(holding.get('shares') or 0))
+            assert abs(solved - float(lot['price'])) < 0.01, (
+                f"{holding.get('ticker')}: stored {lot['price']}, "
+                f"re-derived {solved:.4f}")
+            checked += 1
+
+    assert checked == 9, f'expected 9 reconstructed lots, found {checked}'
+
+
+def test_a_lot_pinned_only_by_cost_basis_is_not_marked_corroborated():
+    """07226 has no sells, so its opening price comes from cost_basis alone and
+    checking cost_basis against it would be circular. The flag that keeps
+    COST_BASIS honest has to actually be set on that holding and not on the
+    others."""
+    from clawock.portfolio.integrity import PORTFOLIO
+
+    if not PORTFOLIO.exists():
+        pytest.skip('no live book in this checkout')
+    portfolios = json.loads(PORTFOLIO.read_text()).get('portfolios', {})
+    flags = {}
+    for port in portfolios.values():
+        for holding in port.get('holdings') or []:
+            for t in holding.get('trades') or []:
+                if t.get('reconstructed'):
+                    flags[holding['ticker']] = t.get('corroborated')
+
+    assert flags.get('07226') is False, (
+        'the one lot with no independent source must not claim corroboration')
+    assert all(v is True for k, v in flags.items() if k != '07226'), flags
+
+
+def test_cost_basis_declines_to_judge_an_uncorroborated_reconstruction():
+    """The gate must skip exactly the circular case — and must NOT skip a
+    holding whose reconstruction was pinned by independent realized_pnl."""
+    from clawock.portfolio.integrity import check
+
+    def book(corroborated, cost_basis):
+        return {'portfolios': {'hk_stocks': {
+            'currency': 'HKD',
+            'holdings': [{
+                'ticker': 'X', 'shares': 200, 'cost_basis': cost_basis,
+                'trades': [
+                    {'date': '2026-01-01', 'action': 'buy', 'shares': 200,
+                     'price': 10.0, 'reconstructed': True,
+                     'corroborated': corroborated},
+                ],
+            }],
+        }}}
+
+    import tempfile
+    from pathlib import Path as _P
+
+    def findings(corroborated, cost_basis):
+        with tempfile.TemporaryDirectory() as d:
+            p = _P(d) / 'portfolio.json'
+            p.write_text(json.dumps(book(corroborated, cost_basis)))
+            return [f['code'] for f in check(p)['findings']]
+
+    # cost_basis wildly disagrees with the replay (10.0)
+    assert 'COST_BASIS' in findings(True, 99.0), (
+        'a corroborated reconstruction must still be checked'
+    )
+    assert 'COST_BASIS' not in findings(False, 99.0), (
+        'an uncorroborated reconstruction must not be judged against itself'
+    )


### PR DESCRIPTION
Closes #456. kcn's call on option 2, after establishing that the repair is
derived rather than invented.

## These were never an error

kcn held these positions before clawock existed. The missing opening buy is not
a lapse — the ledger honestly starts mid-story. That reframing is what makes a
backfill legitimate rather than a cover-up.

## Almost nothing is invented

Every sell carries its own `realized_pnl`, which pins the average cost at the
moment of that sell. The opening price is therefore **determined** by numbers
already in the book:

| ticker | shares | price | independent constraints | worst residual |
|---|---|---|---|---|
| TQQQ | 8 | 45.7300 | 1 | 0.0000 |
| OKLO | 2 | 62.8300 | 1 | 0.0000 |
| TCOM | 5 | 52.7400 | 1 | 0.0000 |
| HOOD | 5 | 73.5000 | 1 | 0.0000 |
| RKLB | 5 | 71.0000 | 1 | 0.0000 |
| 02208 | 600 | 14.0840 | 2 | 0.0000 |
| 07747 | 200 | 81.8500 | 2 | 0.0000 |
| **07709** | 600 | **32.0401** | **9** | 0.0114 |
| 07226 | 5200 | 4.4973 | 1 ⚠️ | 0.0000 |

**07709 is the proof**: nine independent equations, one unknown, all reproduced.
Its solved price also regenerates `29.5552` — the mid-history average kcn typed
into a note on 2026-03-31, which took no part in the fit.

Only the **date** is chosen, and it is provably inert: one day before that
holding's first recorded trade, so it sorts first (the moving average depends on
order, not the calendar) and lands before both cash reconciliation baselines
(`us 2026-06-19`, `hk 2026-07-07`), so it cannot enter the cash window.

## Nothing published moved

| check | result |
|---|---|
| every per-holding and per-region derived number | **0 differences** across 23 holdings |
| trade cash flow after each reconciliation baseline | identical (`-281.64` / `-17000.00`) |
| `realized_as_of` recomputed across all 64 snapshots | **0 changed** |
| `clawock integrity` | 0 ERROR / 0 WARN |

The #455 clamp (`max(post_bal, 0)`) becomes a no-op rather than a load-bearing
workaround.

## The one that needed care

`07226` has no sells, so its opening price could only come from `cost_basis` —
and letting `COST_BASIS` then verify `cost_basis` is circular. It would convert
an honest "cannot verify" into a fabricated "checked", which is **worse than the
skip it replaces**.

So the lots record whether they were independently corroborated, and
`COST_BASIS` declines to judge a holding whose reconstruction was not. The
judgement is "does this reconstruction have an independent source", not "is
there a reconstruction".

Everywhere else the gate got **strictly stronger** — it now covers nine holdings
that were silently exempt. Demonstrated by breaking each `cost_basis` by 50%:

```
02208 →  🔴 COST_BASIS  cost_basis=21.1260 ≠ trades 移动加权=14.0840
07226 →  (no COST_BASIS finding — correctly declines)
```

## The allowlist is empty, and that is the success state

`KNOWN_INCOMPLETE_LEDGERS = {}` because #456 was closed by repair, not by
exemption. But an empty list means the gate can no longer prove itself from its
own contents, so the anti-vacuous assertion is now the *only* thing keeping it
alive: the live book must present **at least 15 replayable ledgers, all
reconciling**. Deleting that test makes the gate report clean forever, and the
docstring says so.

## The reconstruction re-derives itself on every CI run

Rather than trusting a commit message, each lot is dropped, its price re-solved
from the rest of that holding's ledger, and the stored value required back —
using a deliberately separate implementation, so a bug in the production moving
average would have to be reproduced identically to hide.

Mutation-verified:

| mutation | caught by |
|---|---|
| hand-edit 07709's price `32.0401 → 32.50` | `test_every_reconstructed_lot_is_re_derivable_from_the_rest_of_the_ledger` |
| mark 07226 `corroborated: true` | `test_a_lot_pinned_only_by_cost_basis_is_not_marked_corroborated` |

Full suite 1771 passed; the 4 failures / 23 errors reproduce identically on
unmodified `origin/master` in the same worktree.
