### PR TITLE
fix: date the reconstructed lots before the whole ledger, not their own holding

### DIFF
--- a/portfolio.json
+++ b/portfolio.json
@@ -69,7 +69,7 @@
           "volume": 5773156,
           "trades": [
             {
-              "date": "2026-06-12",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 5,
               "price": 71.0,
@@ -79,7 +79,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-06-13",
@@ -172,7 +172,7 @@
           "name": "Oklo Inc-A",
           "trades": [
             {
-              "date": "2026-04-21",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 2,
               "price": 62.83,
@@ -182,7 +182,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-04-22",
@@ -249,7 +249,7 @@
           "name": "携程",
           "trades": [
             {
-              "date": "2026-04-21",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 5,
               "price": 52.74,
@@ -259,7 +259,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-04-22",
@@ -290,7 +290,7 @@
           "today_change": 0.0,
           "trades": [
             {
-              "date": "2026-04-15",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 8,
               "price": 45.73,
@@ -300,7 +300,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-04-16",
@@ -333,7 +333,7 @@
           "name": "Robinhood Markets Inc-A",
           "trades": [
             {
-              "date": "2026-04-21",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 5,
               "price": 73.5,
@@ -343,7 +343,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-04-22",
@@ -1145,7 +1145,7 @@
           "volume": 889000,
           "trades": [
             {
-              "date": "2026-04-26",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 600,
               "price": 14.084,
@@ -1155,7 +1155,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-04-27",
@@ -1206,7 +1206,7 @@
           "data_source": "Tencent Aug 10 16:00 HKT",
           "trades": [
             {
-              "date": "2026-03-23",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 5200,
               "price": 4.4973,
@@ -1215,7 +1215,7 @@
                 "cost_basis"
               ],
               "corroborated": false,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由cost_basis反解,1 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-03-24",
@@ -1269,7 +1269,7 @@
           "note": "已清仓 - 历史 sells 保留用于 realized_pnl 汇总(trades 来自 5bb41ea^)",
           "trades": [
             {
-              "date": "2026-03-10",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 600,
               "price": 32.0401,
@@ -1279,7 +1279,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,9 个约束最大残差 0.0114;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,9 个约束最大残差 0.0114;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-03-11",
@@ -1405,7 +1405,7 @@
           "note": "已清仓 - 历史 sells 保留用于 realized_pnl 汇总(trades 来自 5bb41ea^)",
           "trades": [
             {
-              "date": "2026-03-17",
+              "date": "2025-12-23",
               "action": "buy",
               "shares": 200,
               "price": 81.85,
@@ -1415,7 +1415,7 @@
                 "cost_basis"
               ],
               "corroborated": true,
-              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于首笔已记成交,不进现金对账窗口。"
+              "note": "建仓早于本账本(clawock 之前已持有)。股数=shares−已记净股;单价由realized_pnl/cost_basis反解,2 个约束最大残差 0.0000;日期为排序占位,早于**全账本**首笔已记成交(2025-12-24),因此不进现金对账窗口,也不会被任何以某个起始日回滚账本的消费者(shadow 种子重建)当成模拟期内的交易。"
             },
             {
               "date": "2026-03-18",

--- a/tests/test_share_ledger_completeness.py
+++ b/tests/test_share_ledger_completeness.py
@@ -276,6 +276,40 @@ def test_every_reconstructed_lot_is_re_derivable_from_the_rest_of_the_ledger():
     assert checked == 9, f'expected 9 reconstructed lots, found {checked}'
 
 
+def test_reconstructed_lots_precede_every_recorded_trade_in_the_whole_book():
+    """The date is the one field that was chosen rather than derived, and it is
+    only harmless while it sits before the entire ledger — not merely before its
+    own holding's first trade.
+
+    That distinction is not theoretical. The first backfill dated each lot one
+    day before *its own* first recorded trade, which put RKLB's at 2026-06-12 —
+    after the shadow portfolio's 2026-05-18 start. `reconstruct_initial_book`
+    reverses every trade on or after the start date to recover the seed, so it
+    read that lot as a purchase made during the simulation and removed 5 real
+    shares from the starting book, moving published seed cash by $355.
+
+    kcn held those shares before clawock existed. Any consumer that rewinds the
+    book to a date is entitled to assume a pre-ledger position was already held,
+    so the lots belong before every recorded trade there is.
+    """
+    from clawock.portfolio.integrity import PORTFOLIO
+
+    if not PORTFOLIO.exists():
+        pytest.skip('no live book in this checkout')
+    portfolios = json.loads(PORTFOLIO.read_text()).get('portfolios', {})
+    trades = [t for port in portfolios.values()
+              for h in (port.get('holdings') or [])
+              for t in (h.get('trades') or [])]
+
+    recorded = [t['date'] for t in trades if not t.get('reconstructed')]
+    reconstructed = [t['date'] for t in trades if t.get('reconstructed')]
+    assert recorded and reconstructed, 'this test must have both kinds to compare'
+    assert max(reconstructed) < min(recorded), (
+        f'a reconstructed lot is dated {max(reconstructed)}, on or after the '
+        f'earliest recorded trade {min(recorded)}; any consumer that rewinds the '
+        'book to a start date will treat it as an in-period purchase')
+
+
 def test_a_lot_pinned_only_by_cost_basis_is_not_marked_corroborated():
     """07226 has no sells, so its opening price comes from cost_basis alone and
     checking cost_basis against it would be circular. The flag that keeps


### PR DESCRIPTION
Refs #456. Fixes a defect I introduced in #462 — caught by auditing the
downstream consumers of `trades[]` after the merge rather than before it.

## What went wrong

#462 dated each reconstructed opening lot one day before **that holding's**
first recorded trade, and claimed the date was inert. It is not.

RKLB's first recorded trade is 2026-06-13, so its lot landed on **2026-06-12 —
after the shadow portfolio's 2026-05-18 start**.

`reconstruct_initial_book` recovers the simulation seed by reversing every trade
on or after the start date. It read that lot as a purchase made *during* the
simulation and removed 5 real shares from the starting book:

| | before #462 (correct) | after #462 (wrong) |
|---|---|---|
| USD seed cash | 135.195 | 490.195 |
| USD seed inventory | includes `RKLB: 5` | RKLB dropped |

kcn held those shares before clawock existed — on 2026-05-18 they were really
there. The pre-#462 value was right and #462 moved it.

## Why the reasoning was wrong for all nine, not just RKLB

"Before its own first trade" only bounds that one holding. Consumers rewind the
**whole book** to a single shared date, so a lot is only safely invisible if it
precedes every recorded trade there is. The eight others happened to be early
enough; that was luck, not design.

The earliest recorded trade anywhere in the book is 2025-12-24, so every
reconstructed lot now sits at **2025-12-23**.

## Verified after the change

| check | result |
|---|---|
| shadow seed, both legs | **identical to pre-backfill values** |
| ledgers replay to `shares` | all 21 |
| reconstructed averages vs `cost_basis` | 02208 `14.0840`, 07226 `4.3632` |
| `realized_as_of` across 64 snapshots | 0 changed |
| cash flow after both reconciliation baselines | unchanged |
| `clawock integrity` | 0 ERROR / 0 WARN |

## Pinned rather than argued

`test_reconstructed_lots_precede_every_recorded_trade_in_the_whole_book` asserts
the invariant directly. Restoring RKLB's old 2026-06-12 date fails it —
mutation-verified.

The docstring records the incident, because the failure mode is not obvious from
the data: the book looks fine, every total reconciles, and only a consumer that
rewinds to a start date can tell.
