### PR TITLE
docs: install from PyPI, because it is now on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**Evidence**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**简体中文**](README.zh.md)
 
 ```bash
-pip install "clawock @ git+https://github.com/KCNyu/clawock.git"   # PyPI: #379
+pip install clawock
 clawock init ./my-decision --workflow investment-decision
 ```
 
@@ -221,13 +221,13 @@ Hong Kong times run on HKT; US session times follow ET and their cron expression
 
 ## Run it on your own book
 
-The package lifecycle is no longer welded to this account's directory. Until
-the trusted-publishing release in [#379](https://github.com/KCNyu/clawock/issues/379)
-lands, install the current pre-release from GitHub rather than assuming the PyPI
-name is live:
+The package lifecycle is no longer welded to this account's directory. It is
+published to PyPI through GitHub trusted publishing — no API token, and the
+release job proves a clean environment can install the exact artifact and finish
+a run before it uploads:
 
 ```bash
-python -m pip install "clawock @ git+https://github.com/KCNyu/clawock.git"
+python -m pip install clawock
 clawock workflow install investment-decision --workspace ./my-decision
 clawock init ./my-decision --workflow investment-decision
 clawock run prepare --workspace ./my-decision

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**证据与反证**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**English**](README.md)
 
 ```bash
-pip install "clawock @ git+https://github.com/KCNyu/clawock.git"   # PyPI 待发布：#379
+pip install clawock
 clawock init ./my-decision --workflow investment-decision
 ```
 
@@ -216,12 +216,12 @@ package 架构。
 
 ## 在你自己的账本上跑
 
-package lifecycle 已经不再焊死在这个账户目录上。在
-[#379](https://github.com/KCNyu/clawock/issues/379) 完成 trusted publishing 前，
-请从 GitHub 安装当前 pre-release，不假装 PyPI 名称已经上线：
+package lifecycle 已经不再焊死在这个账户目录上。它通过 GitHub trusted publishing
+发布到 PyPI —— 没有 API token，且发布任务会先证明一个干净环境能装上这个 artifact
+并跑完一次完整运行，然后才上传：
 
 ```bash
-python -m pip install "clawock @ git+https://github.com/KCNyu/clawock.git"
+python -m pip install clawock
 clawock workflow install investment-decision --workspace ./my-decision
 clawock init ./my-decision --workflow investment-decision
 clawock run prepare --workspace ./my-decision


### PR DESCRIPTION
v0.1.0 is published (#379), so the first command on the first screen was the one command that went stale the moment the release landed. Both READMEs still taught a `git+https` install and cited the issue as the reason.

Verified against the real index rather than assumed — `examples/minimal-run/run.sh` with no argument installs from PyPI into a clean virtualenv under `env -i`:

```
==> clawock init
==> clawock run prepare
==> clawock run publish
==> checking the receipt
isolated run published a9efba14f90a41748d98b6db102e3877
```

And the rejection half, from the same published package:

```json
{ "status": "rejected",
  "validation_issues": [{"code": "missing_decision_artifact",
                         "message": "workflow requires decision.json"}],
  "publish": {"receipt": null, "changed": false} }
```

exit 1, named reason, nothing published. That is both halves of #420's last acceptance box, executed against PyPI.

Refs #379, #383