### PR TITLE
docs: take the install block out of the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**Evidence**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**简体中文**](README.zh.md)
 
-```bash
-pip install clawock
-clawock init ./my-decision --workflow investment-decision
-```
-
 <br>
 
 <a href="https://kcnyu.github.io/clawock/">
@@ -43,6 +38,9 @@ runtime owns the model call, conversation, memory, planning, tools, permissions,
 and credentials. clawock installs the reusable workflow that certifies evidence,
 forces an opposing case, validates money and FX, links outcomes, and keeps every
 improvement proposal reviewable and reversible.
+
+It installs from PyPI — `pip install clawock` — and
+[runs on your own book](#run-it-on-your-own-book) without this repository.
 
 This repository is also the first continuously running proof: a disciplined,
 self-grading AI investing experiment on a real Hong Kong + US portfolio — not a

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,11 +14,6 @@
 
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**证据与反证**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**English**](README.md)
 
-```bash
-pip install clawock
-clawock init ./my-decision --workflow investment-decision
-```
-
 <br>
 
 <a href="https://kcnyu.github.io/clawock/">
@@ -41,6 +36,9 @@ clawock 是一套**面向 Agent 的投资决策 workflow plugin kit，加上一�
 harness**。OpenClaw、Hermes、Claude Code、Codex 或其它外部 runtime 负责模型
 调用、对话、记忆、规划、工具、权限和凭证；clawock 安装可复用 workflow，负责
 认证证据、强制反方、校验资金和汇率、连接结果，并让每个改进提案可审、可回滚。
+
+它发布在 PyPI 上 —— `pip install clawock` —— 而且
+[在你自己的账本上跑](#在你自己的账本上跑)不需要这个仓库。
 
 这个仓库也是第一套持续运行的证明：一个真实港股 + 美股组合上的纪律化、公开、
 自评式 AI 投资实验 —— 不是一夜暴富的机器人，也不是跟单服务。


### PR DESCRIPTION
kcn: "install 不一定要放到 readme 开头 太奇怪了" — agreed, it read as an interruption.

The hero runs logo → tagline → badges → links → image. A fenced ```bash block sat between the links and the image, so the first thing a reader met was a command for something they had not been told about yet.

Install now sits one line into **What this is**, immediately after the sentence defining the package:

> It installs from PyPI — `pip install clawock` — and [runs on your own book](#run-it-on-your-own-book) without this repository.

Still on the first screen, which is what #449 was for, without the hero stopping to be a terminal. The full quickstart stays where it belongs, in *Run it on your own book*, so there is one copy of the real command sequence rather than two.

Both READMEs; in-page anchors verified against the actual headings in each language.

Refs #383