### PR TITLE
fix: the bare context audit only checked one of six profiles

### DIFF
--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -87,9 +87,11 @@ have their own rules. `src/clawock/context/manifest.json` records each profile, 
 lazy skill/memory capability roots, conversation-history ownership and the rule
 that clawock never narrows OpenClaw's tools implicitly.
 
-`clawock context audit --profile <name>` fails visibly when an injected file is
-missing/empty or when moving `skills/`, `MEMORY.md` or `memory/` would silently
-remove catalog/search capability. This is broader than comparing prompt text:
+`clawock context audit` fails visibly when an injected file is missing/empty or
+when moving `skills/`, `MEMORY.md` or `memory/` would silently remove
+catalog/search capability. With no `--profile` it audits every profile and fails
+if any one of them does — a file that only the interactive profile requires is
+not covered by auditing isolated-cron alone. This is broader than comparing prompt text:
 the skills catalog contains metadata rather than skill bodies, memory search can
 remain available where `MEMORY.md` is not injected, and session history belongs
 to the runtime rather than the bootstrap bundle.

--- a/docs/architecture/openclaw-adapter.md
+++ b/docs/architecture/openclaw-adapter.md
@@ -52,9 +52,11 @@ five-file cron bundle into normal chat.
 Audit the live workspace without invoking a model:
 
 ```bash
+# every profile; non-zero if any of them is missing a required file
+clawock context audit --workspace /path/to/workspace
+
+# or one profile at a time
 clawock context audit --workspace /path/to/workspace --profile interactive
-clawock context audit --workspace /path/to/workspace --profile isolated-cron
-clawock context audit --workspace /path/to/workspace --profile heartbeat-full
 ```
 
 ## OpenClaw cron is a separate runtime contract

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -288,6 +288,7 @@ def _context(args) -> int:
     from clawock.context.assembly import (
         assemble,
         audit,
+        audit_all,
         compare_prompt_reports,
         load_prompt_report,
         verify_prompt_report,
@@ -296,7 +297,10 @@ def _context(args) -> int:
     root = workspace_root(getattr(args, "workspace", None) or Path.cwd())
     try:
         if args.context_command == "audit":
-            result = audit(root, profile=args.profile)
+            # No --profile means every profile, not the manifest default: the
+            # obvious invocation has to be the safe one (#380).
+            result = (audit(root, profile=args.profile) if args.profile
+                      else audit_all(root))
             print(json.dumps(result, ensure_ascii=False, indent=2))
             return 0 if result["ok"] else 1
         if args.context_command == "compare":
@@ -659,11 +663,15 @@ def main(argv=None) -> int:
         "context", help="audit or assemble the agent context contract")
     context_sub = context.add_subparsers(dest="context_command", required=True)
     context_audit = context_sub.add_parser(
-        "audit", help="verify one OpenClaw context profile and capability roots")
+        "audit", help="verify the OpenClaw context profiles and capability roots")
     context_audit.add_argument("--workspace", type=Path, default=None)
     context_audit.add_argument(
-        "--profile", default="isolated-cron",
-        help="interactive, isolated-cron, heartbeat-full/light, bootstrap-pending or subagent",
+        # No default on purpose. It used to be "isolated-cron", so the bare
+        # command silently audited the five-file profile and reported ok while a
+        # file only the seven-file interactive profile requires was missing (#380).
+        "--profile", default=None,
+        help="audit one profile instead of all: interactive, isolated-cron, "
+             "heartbeat-full/light, bootstrap-pending or subagent",
     )
     context_audit.set_defaults(func=_context)
     context_assemble = context_sub.add_parser(

--- a/src/clawock/context/assembly.py
+++ b/src/clawock/context/assembly.py
@@ -133,6 +133,38 @@ def assemble_explicit(workspace, documents) -> ContextBundle:
     return ContextBundle(tuple(selected))
 
 
+def audit_all(workspace) -> dict:
+    """Audit every context profile, and pass only if all of them pass.
+
+    `audit()` answers for one profile, which made the obvious command the unsafe
+    one: with no `--profile` it resolved to the manifest default — isolated-cron,
+    five bootstrap files — so emptying `MEMORY.md`, which only the seven-file
+    interactive profile requires, produced `ok: true` and exit 0. A required
+    context file could be gone with the audit that exists to notice it reporting
+    green (#380).
+
+    Auditing one profile is still the right operation when you mean one profile.
+    Defaulting to one profile was the bug.
+    """
+    root = Path(workspace).expanduser().resolve()
+    names = list(load_manifest()["profiles"])
+    profiles = {name: audit(root, profile=name) for name in names}
+    return {
+        "profiles": profiles,
+        "audited": names,
+        # A rollup so a caller does not have to walk every profile to find the
+        # one that failed; each entry names the profile it came from.
+        "missing": sorted(
+            f"{name}:{item}" for name, r in profiles.items() for item in r["missing"]),
+        "empty": sorted(
+            f"{name}:{item}" for name, r in profiles.items() for item in r["empty"]),
+        "missing_capabilities": sorted(
+            f"{name}:{item}"
+            for name, r in profiles.items() for item in r["missing_capabilities"]),
+        "ok": all(r["ok"] for r in profiles.values()),
+    }
+
+
 def audit(workspace, *, profile: str | None = None) -> dict:
     """Audit one OpenClaw context profile and its lazy capability roots."""
     root = Path(workspace).expanduser().resolve()

--- a/tests/test_context_audit_covers_every_profile.py
+++ b/tests/test_context_audit_covers_every_profile.py
@@ -1,0 +1,152 @@
+"""`clawock context audit` with no --profile must cover every profile.
+
+#380's acceptance: "Removing or renaming a required context file becomes a
+visible audit failure instead of a silent capability loss."
+
+It did not, for the command anyone would actually run. With no `--profile` the
+audit resolved to the manifest default — `isolated-cron`, five bootstrap files —
+so emptying `MEMORY.md`, which only the seven-file `interactive` profile
+requires, produced `ok: true` and exit 0. Measured on a copy of the live
+workspace:
+
+    context audit                      → ok=True   exit 0   empty=[]
+    context audit --profile interactive → ok=False  exit 1   empty=['MEMORY.md']
+
+Auditing one profile is still right when you mean one profile. Defaulting to one
+was the bug: the obvious command has to be the safe one.
+"""
+import json
+
+import pytest
+
+from clawock.context.assembly import audit, audit_all, load_manifest
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A workspace carrying every file every profile requires."""
+    manifest = load_manifest()
+    for contract in manifest["profiles"].values():
+        for name in contract["bootstrap"]:
+            path = tmp_path / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f'content of {name}\n')
+        for relative in contract.get("capability_paths", []):
+            # MEMORY.md is both a bootstrap document and a capability root, so
+            # this must not try to turn an existing file into a directory.
+            target = tmp_path / relative
+            if not target.exists():
+                target.mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_a_complete_workspace_passes(workspace):
+    assert audit_all(workspace)["ok"] is True
+
+
+def test_every_profile_is_audited(workspace):
+    result = audit_all(workspace)
+    assert set(result["audited"]) == set(load_manifest()["profiles"])
+    assert len(result["audited"]) > 1, (
+        'with one profile this whole distinction is vacuous — if the manifest '
+        'ever collapses to a single profile, this test should be reconsidered '
+        'rather than silently passing'
+    )
+
+
+def _only_in_non_default_profile(manifest):
+    """A bootstrap file some profile requires and the default profile does not."""
+    default = manifest["profiles"][manifest["default_profile"]]["bootstrap"]
+    for name, contract in manifest["profiles"].items():
+        if name == manifest["default_profile"]:
+            continue
+        for item in contract["bootstrap"]:
+            if item not in default:
+                return name, item
+    return None, None
+
+
+def test_emptying_a_file_the_default_profile_ignores_still_fails(workspace):
+    """The exact 2026-08-10 hole, expressed against the manifest rather than
+    against MEMORY.md by name — so it keeps testing the property if the profiles
+    are ever reorganised."""
+    manifest = load_manifest()
+    profile, name = _only_in_non_default_profile(manifest)
+    assert name, 'no profile requires a file the default one does not — nothing to test'
+
+    (workspace / name).write_text('   \n')
+
+    assert audit(workspace)["ok"] is True, (
+        'precondition: the default profile genuinely does not care about this file'
+    )
+    result = audit_all(workspace)
+    assert result["ok"] is False
+    assert f'{profile}:{name}' in result["empty"]
+
+
+def test_removing_such_a_file_also_fails(workspace):
+    manifest = load_manifest()
+    profile, name = _only_in_non_default_profile(manifest)
+    (workspace / name).unlink()
+
+    result = audit_all(workspace)
+    assert result["ok"] is False
+    assert f'{profile}:{name}' in result["missing"]
+
+
+def test_the_rollup_names_the_profile_each_finding_came_from(workspace):
+    """A bare filename in a multi-profile rollup sends the reader looking in the
+    wrong contract."""
+    manifest = load_manifest()
+    profile, name = _only_in_non_default_profile(manifest)
+    (workspace / name).unlink()
+
+    for item in audit_all(workspace)["missing"]:
+        assert ':' in item, item
+    assert audit_all(workspace)["profiles"][profile]["ok"] is False
+
+
+def test_single_profile_audit_keeps_its_shape(workspace):
+    """`--profile X` is unchanged — it is still the right operation when you
+    mean one profile, and its JSON is what the adapter docs show."""
+    result = audit(workspace, profile=load_manifest()["default_profile"])
+    assert result["profile"] == load_manifest()["default_profile"]
+    assert "bootstrap" in result and "profiles" not in result
+
+
+def test_the_bare_command_audits_every_profile(workspace, capsys):
+    """Through the real argument parser, not a hand-built namespace.
+
+    The first version of this fix passed its unit tests and changed nothing:
+    `--profile` carried `default="isolated-cron"`, so `args.profile` was never
+    None and the all-profiles branch was unreachable. A test that constructs
+    Args itself cannot see that — it tests the handler while the bug lives in
+    the parser.
+    """
+    from clawock import cli
+
+    manifest = load_manifest()
+    _profile, name = _only_in_non_default_profile(manifest)
+    (workspace / name).unlink()
+
+    code = cli.main(['context', 'audit', '--workspace', str(workspace)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 1, 'the exit code is what a cron or a human actually reads'
+    assert payload["ok"] is False
+    assert set(payload["audited"]) == set(manifest["profiles"])
+
+
+def test_naming_one_profile_still_audits_only_that_one(workspace, capsys):
+    from clawock import cli
+
+    manifest = load_manifest()
+    _profile, name = _only_in_non_default_profile(manifest)
+    (workspace / name).unlink()
+
+    code = cli.main(['context', 'audit', '--workspace', str(workspace),
+                     '--profile', manifest["default_profile"]])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 0, 'the default profile genuinely does not require that file'
+    assert payload["profile"] == manifest["default_profile"]


### PR DESCRIPTION
Refs #380.

## The hole

#380's acceptance is that removing or renaming a required context file becomes a **visible audit failure instead of a silent capability loss**. It was not — for the command anyone would actually run.

`--profile` carried `default="isolated-cron"`, so a bare `clawock context audit` checked the five-file cron profile and nothing else. Measured on a copy of the live workspace:

| | ok | exit | finding |
|---|---|---|---|
| `context audit` | ✅ True | 0 | — |
| `context audit --profile interactive` | ❌ False | 1 | `empty=['MEMORY.md']` |

`MEMORY.md` was **empty** and the audit said fine. `HEARTBEAT.md` — required by four of the six profiles — could be deleted with the same green result.

## The fix

No `--profile` now audits **all six** and fails if any one does, each finding tagged with its profile:

```
missing = ['bootstrap-pending:HEARTBEAT.md', 'heartbeat-full:HEARTBEAT.md',
           'heartbeat-light:HEARTBEAT.md', 'interactive:HEARTBEAT.md']
```

Naming a profile keeps the old single-profile output, which is what `docs/architecture/openclaw-adapter.md` shows. Auditing one profile was never wrong; defaulting to one was.

## A note on how this nearly shipped broken

My first version passed its own tests and **changed nothing**. The test constructed an argparse namespace by hand with `profile=None`, so it exercised the handler while the bug lived in the parser default. Only running the real command against a copy of the live workspace caught it.

The test now goes through `cli.main()` with a real argv — the only version that fails against the unfixed parser.

## Verification

Live workspace audits clean across all six profiles (`exit 0`, `missing/empty/missing_capabilities` all empty). 8 tests. Full suite 1786 passed; the 4 failures / 23 errors reproduce identically on unmodified `origin/master` in the same worktree.