### PR TITLE
release: v0.1.1 — fix the PyPI project page, and stop restating the version

### DIFF
--- a/instances/kcnyu/pyproject.toml
+++ b/instances/kcnyu/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock-kcnyu"
-version = "0.1.0"
+version = "0.1.1"
 description = "KCNyu live-desk adapter for the clawock decision-workflow harness"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/instances/kcnyu/src/clawock_kcnyu/__init__.py
+++ b/instances/kcnyu/src/clawock_kcnyu/__init__.py
@@ -1,4 +1,14 @@
 """KCNyu instance adapter for the runtime-neutral clawock package."""
+from importlib.metadata import PackageNotFoundError, version as _installed_version
 
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+
+# Read from the installed distribution rather than restated here. This was a
+# literal until 2026-08-10, which made it a second source of truth that nothing
+# compared against pyproject — so the first version bump after it was written
+# would have shipped a package reporting the previous version, silently and
+# correctly-looking. Found by bumping to 0.1.1.
+try:
+    __version__ = _installed_version("clawock-kcnyu")
+except PackageNotFoundError:  # running from a source tree, never installed
+    __version__ = "0.0.0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.0"
+version = "0.1.1"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_versions_agree.py
+++ b/tests/test_versions_agree.py
@@ -1,0 +1,76 @@
+"""One version number, declared in one place.
+
+`clawock_kcnyu.__version__` was a literal `"0.1.0"` that nothing compared
+against `instances/kcnyu/pyproject.toml`. A second source of truth for a number
+that only ever changes at release time is a drift that waits: the first bump
+after it was written would ship a package reporting the previous version, and
+nothing would have said so. Found by bumping to 0.1.1 — the literal stayed
+behind.
+
+The public `clawock` package deliberately exposes no `__version__`; consumers
+read `importlib.metadata`, which cannot disagree with what was installed.
+"""
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _declared(pyproject: Path) -> str:
+    return tomllib.loads(pyproject.read_text())["project"]["version"]
+
+
+def test_the_two_distributions_ship_the_same_version():
+    """They are released together from one tag, so a disagreement means one of
+    them was bumped and the other forgotten."""
+    public = _declared(ROOT / 'pyproject.toml')
+    instance = _declared(ROOT / 'instances' / 'kcnyu' / 'pyproject.toml')
+    assert public == instance, (
+        f'clawock {public} but clawock-kcnyu {instance}; one bump was missed'
+    )
+
+
+def test_the_instance_version_is_not_restated_in_source():
+    """The specific shape of the old bug: a literal that a bump does not reach."""
+    source = (ROOT / 'instances' / 'kcnyu' / 'src' / 'clawock_kcnyu'
+              / '__init__.py').read_text()
+    declared = _declared(ROOT / 'instances' / 'kcnyu' / 'pyproject.toml')
+    assert f'"{declared}"' not in source, (
+        'the version is restated in __init__.py; read it from the installed '
+        'distribution instead so a bump cannot leave it behind'
+    )
+    assert 'importlib.metadata' in source
+
+
+def test_the_installed_module_reports_the_declared_version():
+    """And when it IS installed, the two must actually agree — the assertion
+    above only proves the literal is gone, not that the replacement works."""
+    try:
+        import clawock_kcnyu
+    except ImportError:
+        pytest.skip('clawock-kcnyu is not importable in this environment')
+    if clawock_kcnyu.__version__ == '0.0.0+unknown':
+        pytest.skip('running from a source tree, not an installed distribution')
+    assert clawock_kcnyu.__version__ == _declared(
+        ROOT / 'instances' / 'kcnyu' / 'pyproject.toml')
+
+
+def test_the_dependency_pin_still_admits_the_current_version():
+    """`clawock-kcnyu` depends on a range of `clawock`. A bump that leaves the
+    range behind installs the wrong pair without failing anything."""
+    data = tomllib.loads((ROOT / 'instances' / 'kcnyu' / 'pyproject.toml').read_text())
+    pins = [d for d in data['project'].get('dependencies', []) if d.startswith('clawock')]
+    assert pins, 'the instance must depend on the public package'
+
+    public = _declared(ROOT / 'pyproject.toml')
+    major_minor = '.'.join(public.split('.')[:2])
+    for pin in pins:
+        lower = pin.split('>=', 1)[1].split(',')[0] if '>=' in pin else None
+        upper = pin.split('<', 1)[1] if '<' in pin else None
+        if lower:
+            assert tuple(int(p) for p in lower.split('.')) <= tuple(
+                int(p) for p in public.split('.')), f'{pin} excludes {public}'
+        if upper:
+            assert major_minor < upper.rstrip(), f'{pin} excludes {public}'


### PR DESCRIPTION
v0.1.0's published description **cannot be edited**, so the six broken images fixed in #468 only reach https://pypi.org/project/clawock/ through a release. That is the entire user-facing content of this version.

## Bumping surfaced a second defect

`clawock_kcnyu.__version__` was the literal `"0.1.0"`, and **nothing compared it** to `instances/kcnyu/pyproject.toml`. This bump would have shipped a package reporting the previous version — silently, and looking entirely correct. A second source of truth for a number that only changes at release time is a drift that waits for the first release.

It now reads `importlib.metadata`, which cannot disagree with what was installed.

## What the new tests pin

`tests/test_versions_agree.py` — three things a release can quietly break:

| invariant | mutation that catches it |
|---|---|
| both distributions carry the same version | bump only `pyproject.toml` → fails |
| the instance version is not restated in source | write the literal back → fails |
| the instance's `clawock>=…,<…` range still admits the public version | — |

The public `clawock` package deliberately exposes no `__version__`; consumers read `importlib.metadata`, which cannot drift.

## After merge

I tag `v0.1.1`, watch the release workflow, and verify from the index that the published description carries absolute image URLs and that `examples/minimal-run/run.sh` still completes a run from PyPI.

Full suite 1798 passed; the 4 failures / 23 errors reproduce identically on unmodified `origin/master`.