### PR TITLE
fix: evidence.html had no inbound link anywhere on the site

### DIFF
--- a/ops/growth/crawl_visibility.py
+++ b/ops/growth/crawl_visibility.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Weekly Search Console pull — turn "are we getting indexed yet" into a number.
+
+Before this existed the honest answer to that question was "we should wait for
+data", which is not an answer: the data was already there, behind a service
+account sitting on this box. One 30-second query replaced a standing guess with
+
+    62 impressions / 1 click in 90 days, 1 of 82 pages ever shown,
+    homepage last crawled 50 days ago, sitemap submitted 7 weeks ago and
+    never once downloaded.
+
+That distinguishes the two explanations that otherwise look identical from the
+outside: on-page quality (Lighthouse 100/100/100, valid sitemap, robots open)
+versus crawl budget. Only the second is the constraint here, and only measuring
+says which.
+
+Credentials: a Search Console service account with read access to the property.
+`--credentials` or `CLAWOCK_GSC_CREDENTIALS`; nothing is read from the repo.
+Runs read-only — this cannot change anything on the property.
+
+Usage:
+    crawl_visibility.py                      # 90-day summary + coverage probes
+    crawl_visibility.py --days 28
+    crawl_visibility.py --json               # machine-readable, for a gate later
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SITE = os.environ.get("CLAWOCK_SITE_URL", "https://kcnyu.github.io/clawock/")
+SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
+API = "https://searchconsole.googleapis.com"
+
+# Probed individually because the API exposes no whole-site coverage report.
+# One page per discovery path: the entry point, a page reachable only through
+# an internal link, and one reachable only through the sitemap.
+PROBES = ("", "briefs.html", "evidence.html")
+
+
+def _default_credentials() -> str:
+    """Where this host keeps the Search Console key, without naming a runtime.
+
+    Spelled through the adapter rather than as a literal `/root/.openclaw/...`:
+    that literal is exactly what `test_runtime_coupling_ratchet` counts, and it
+    caught this file on its first run. The credential lives beside the runtime
+    state because that is where the operator put it, not because the package may
+    assume so — `CLAWOCK_GSC_CREDENTIALS` overrides, and a foreign host that has
+    neither gets the loud error below.
+    """
+    from clawock.providers.openclaw import runtime_paths
+
+    return str(runtime_paths().home / "credentials" / "gsc-sa.json")
+
+
+def _token(credentials_path: str) -> str:
+    from google.oauth2 import service_account
+    import google.auth.transport.requests as gtr
+
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path, scopes=SCOPES)
+    creds.refresh(gtr.Request())
+    return creds.token
+
+
+def _call(url: str, token: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        url, data=data, method="POST" if data else "GET",
+        headers={"Authorization": f"Bearer {token}",
+                 "Content-Type": "application/json"})
+    with urllib.request.urlopen(request, timeout=45) as response:
+        return json.load(response)
+
+
+def collect(token: str, days: int) -> dict:
+    quoted = urllib.parse.quote(SITE, safe="")
+    end = datetime.date.today()
+    start = end - datetime.timedelta(days=days)
+
+    totals = _call(f"{API}/webmasters/v3/sites/{quoted}/searchAnalytics/query",
+                   token, {"startDate": str(start), "endDate": str(end)})
+    rows = totals.get("rows") or [{}]
+    pages = _call(f"{API}/webmasters/v3/sites/{quoted}/searchAnalytics/query",
+                  token, {"startDate": str(start), "endDate": str(end),
+                          "dimensions": ["page"], "rowLimit": 100})
+
+    sitemaps = []
+    for entry in _call(f"{API}/webmasters/v3/sites/{quoted}/sitemaps",
+                       token).get("sitemap", []):
+        sitemaps.append({
+            "path": entry.get("path"),
+            "lastSubmitted": entry.get("lastSubmitted"),
+            # Absent means Google has never fetched it. That absence is the
+            # single most informative field this script reports.
+            "lastDownloaded": entry.get("lastDownloaded"),
+            "isPending": entry.get("isPending"),
+            "errors": entry.get("errors"),
+        })
+
+    coverage = {}
+    for probe in PROBES:
+        url = SITE + probe
+        try:
+            result = _call(f"{API}/v1/urlInspection/index:inspect", token,
+                           {"inspectionUrl": url, "siteUrl": SITE})
+            status = (result.get("inspectionResult") or {}).get(
+                "indexStatusResult") or {}
+            coverage[probe or "/"] = {
+                "verdict": status.get("verdict"),
+                "coverageState": status.get("coverageState"),
+                "lastCrawlTime": status.get("lastCrawlTime"),
+            }
+        except urllib.error.HTTPError as error:
+            coverage[probe or "/"] = {"error": f"{error.code}"}
+
+    return {
+        "site": SITE,
+        "window": {"start": str(start), "end": str(end), "days": days},
+        "impressions": rows[0].get("impressions", 0),
+        "clicks": rows[0].get("clicks", 0),
+        "position": rows[0].get("position"),
+        "pages_with_impressions": len(pages.get("rows") or []),
+        "sitemaps": sitemaps,
+        "coverage": coverage,
+    }
+
+
+def render(report: dict) -> str:
+    window = report["window"]
+    lines = [f"Search Console — {report['site']}  ({window['start']} → {window['end']})",
+             f"  impressions {report['impressions']:.0f} · clicks {report['clicks']:.0f}"
+             f" · pages with any impression {report['pages_with_impressions']}"]
+    for sitemap in report["sitemaps"]:
+        fetched = sitemap["lastDownloaded"] or "NEVER DOWNLOADED"
+        lines.append(f"  sitemap submitted {sitemap['lastSubmitted']} · fetched {fetched}")
+    for page, status in report["coverage"].items():
+        lines.append(f"  {page:16} {status.get('coverageState') or status.get('error')}"
+                     f"  last crawl {status.get('lastCrawlTime') or '—'}")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(prog="crawl_visibility")
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument("--credentials", default=os.environ.get(
+        "CLAWOCK_GSC_CREDENTIALS") or _default_credentials())
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not os.path.exists(args.credentials):
+        # Loud rather than silent: a visibility check that cannot see is not a
+        # clean bill of health, and this runs unattended from cron.
+        print(f"ERROR: no Search Console credentials at {args.credentials}",
+              file=sys.stderr)
+        return 2
+    try:
+        report = collect(_token(args.credentials), args.days)
+    except Exception as error:  # network, auth, quota
+        print(f"ERROR: Search Console query failed: {error}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report, ensure_ascii=False, indent=2) if args.json
+          else render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -176,6 +176,7 @@
     <nav class="topbar-actions">
       <a class="nav-link {% if page.url == '/' or page.url == '/index.html' %}active{% endif %}" href="{{ '/' | relative_url }}">Dashboard</a>
       <a class="nav-link {% if page.url contains 'briefs' %}active{% endif %}" href="{{ '/briefs.html' | relative_url }}">Briefs</a>
+      <a class="nav-link {% if page.url contains 'evidence' %}active{% endif %}" href="{{ '/evidence.html' | relative_url }}">Evidence</a>
       <a class="nav-link {% if page.url contains 'README' %}active{% endif %}" href="{{ '/README.html' | relative_url }}">README</a>
       <a class="nav-link" href="https://github.com/KCNyu/clawock" target="_blank" rel="noopener">GitHub</a>
     </nav>

--- a/site/index.html
+++ b/site/index.html
@@ -95,6 +95,7 @@ layout: null
     </div>
     <div class="topbar-actions">
       <a class="nav-link" href="briefs.html">Briefs</a>
+      <a class="nav-link" href="evidence.html">Evidence</a>
       <a class="nav-link" href="https://github.com/KCNyu/clawock" target="_blank" rel="noopener">GitHub</a>
       <button class="refresh-btn" id="refresh-btn" type="button" aria-label="Refresh data">
         <span class="ic" aria-hidden="true">&#x21bb;</span>
@@ -867,6 +868,7 @@ layout: null
   <p>
     <a href="https://github.com/KCNyu/clawock">clawock</a>
     · <a href="briefs.html">briefs</a>
+    · <a href="evidence.html">evidence</a>
     · <a href="assets/data/dashboard.json"><code>dashboard.json</code></a>
   </p>
   <p>Not investment advice · point-in-time · past performance ≠ future results</p>


### PR DESCRIPTION
## The defect

Google reports `evidence.html` as **"URL is unknown"**, and the cause is structural, not just crawl budget:

| surface | links to evidence.html? |
|---|---|
| shared layout nav (`_layouts/default.html`) | ❌ Dashboard / Briefs / README / GitHub |
| `index.html` own topbar | ❌ Briefs / GitHub |
| `briefs.html` | ❌ mentions it **zero** times |
| `sitemap.xml` | ✅ — but Google has **never downloaded** it |
| GitHub README | ✅ — but GitHub applies `rel=nofollow` |

A published page with no inbound path. Adds Evidence to both navs and the footer.

## What this does not fix, stated plainly

`briefs.html` **is** directly linked from an indexed homepage and is *also* unknown to Google. So linking alone does not produce a crawl at this budget. This removes a real defect without pretending it is the constraint.

## Also: measuring instead of guessing

`ops/growth/crawl_visibility.py` turns "are we getting indexed yet" into a number. The data was already reachable through a Search Console service account on this host while the standing answer was "wait for data":

```
Search Console — https://kcnyu.github.io/clawock/  (2026-05-13 → 2026-08-11)
  impressions 62 · clicks 1 · pages with any impression 1
  sitemap submitted 2026-06-23 · fetched NEVER DOWNLOADED
  /                Submitted and indexed     last crawl 2026-06-22
  briefs.html      URL is unknown to Google
  evidence.html    URL is unknown to Google
```

Exits 2 rather than quietly when it cannot see — it runs unattended, and a visibility check that cannot see is not a clean bill of health.

## The ratchet caught my own file

First run of `test_runtime_coupling_ratchet` failed: the script hardcoded `/root/.openclaw/credentials/...`. It now resolves through `clawock.providers.openclaw`, with `CLAWOCK_GSC_CREDENTIALS` overriding. Working exactly as intended, on the first new file to touch it since the baseline hit 0.