### PR TITLE
fix: the watchdog judged a slot that was still running

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_watchdog.py
@@ -173,6 +173,43 @@ def context_for_slot(path, job_name, slot):
     return context
 
 
+
+def attempt_still_running(context, last_run):
+    """Is a newer attempt in flight than the newest FINISHED run for this slot?
+
+    openclaw writes a run record only with `action: "finished"`, so an attempt
+    that is currently executing is invisible to `run_for_slot` — it returns the
+    newest *completed* run, which after a few retries can be an `error` from an
+    attempt that has already been superseded.
+
+    The preflight context is the signal that is already on disk. It is written
+    at the start of an attempt, so a context generated AFTER the newest finished
+    run ended means another attempt began after that run and has not finished.
+
+    2026-08-11 00:00 US is the case this exists for: attempts at 00:00, 00:01:55
+    and 00:03:30 all errored, the fourth started 00:07:14 and ran 275s, and the
+    watchdog judged at 00:10:44 on attempt 3's error. It sent the deterministic
+    fallback one second before postflight delivered the real report.
+
+    Deferring is safe in one direction only, and it is the right direction: a
+    genuinely dead slot writes no newer context, so a real miss still gets its
+    backstop. Sending for work that then succeeds is a duplicate, which is what
+    this whole gate ordering exists to prevent.
+    """
+    generated_at = (context or {}).get('generated_at')
+    finished_ms = (last_run or {}).get('ts')
+    if not generated_at or not isinstance(finished_ms, (int, float)):
+        return False
+    try:
+        started = datetime.fromisoformat(generated_at)
+    except (TypeError, ValueError):
+        return False
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=HKT)
+    finished = datetime.fromtimestamp(finished_ms / 1000, HKT)
+    return started > finished
+
+
 def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms,
                        ctx_id=None, ctx_generated_at=None):
     """Whether postflight confirmed Telegram delivery for this exact slot.
@@ -276,6 +313,16 @@ def main():
              'expected_job': expected_job, 'expected_slot': expected_slot,
              'run_at': run_at})
         return 0
+    # --- In-flight gate: never judge a slot that has not finished -----------
+    if attempt_still_running(context, last):
+        log({'tag': tag, 'action': 'defer',
+             'reason': 'a newer attempt is still running — preflight context '
+                       'postdates the newest finished run',
+             'expected_job': expected_job, 'expected_slot': expected_slot,
+             'context_generated_at': context.get('generated_at'),
+             'last_finished_ms': last.get('ts')})
+        return 0
+
     raw_block = (context.get('raw_wechat_block') or '').strip()
     raw_block_first = raw_block.splitlines()[0] if raw_block else None
     loop_score, _ = transcript_loop_score(session_id)

--- a/tests/test_intraday_watchdog_inflight.py
+++ b/tests/test_intraday_watchdog_inflight.py
@@ -1,0 +1,108 @@
+"""The watchdog must not judge a slot that has not finished running.
+
+2026-08-11 00:00 US overnight. The slot burned three failed attempts before the
+successful one started, so the work was still in flight when the watchdog ran:
+
+    00:00:00  attempt 1  error   (86s)
+    00:01:55  attempt 2  error   (34s)
+    00:03:30  attempt 3  error  (104s)  → finished 00:05:14
+    00:07:14  attempt 4  ok     (275s)  → finished 00:11:48
+    00:10:44  watchdog sends the deterministic fallback ("未完成")
+    00:10:45  postflight delivers the real report
+
+kcn received both, one second apart.
+
+openclaw writes a run record only with `action: "finished"`, so a running
+attempt is invisible and `run_for_slot` returns the newest *completed* one —
+attempt 3's error. The preflight context is the signal that was already on disk:
+it is written when an attempt starts, so a context generated after the newest
+finished run ended means a later attempt began and has not finished.
+
+This is not the #458/#459 failure. That was marker/context identity on retries;
+this is judging a slot that is still running.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+HKT = timezone(timedelta(hours=8))
+
+
+def _ms(hour, minute, second=0):
+    return int(datetime(2026, 8, 11, hour, minute, second,
+                        tzinfo=HKT).timestamp() * 1000)
+
+
+def test_the_2026_08_11_timeline_is_deferred():
+    """Verbatim from the incident: attempt 3 finished 00:05:14, attempt 4's
+    preflight ran 00:07:27, watchdog at 00:10:44."""
+    from clawock_kcnyu.harness.intraday_watchdog import attempt_still_running
+
+    assert attempt_still_running(
+        {'generated_at': '2026-08-11T00:07:27'},
+        {'ts': _ms(0, 5, 14)})
+
+
+def test_a_context_older_than_the_finished_run_is_not_in_flight():
+    """The healthy shape: the run wrote its own context, then finished."""
+    from clawock_kcnyu.harness.intraday_watchdog import attempt_still_running
+
+    assert not attempt_still_running(
+        {'generated_at': '2026-08-11T00:07:27'},
+        {'ts': _ms(0, 11, 48)})
+
+
+def test_a_dead_slot_is_not_deferred():
+    """The direction that must not break. A slot whose run errored and where
+    nothing started afterwards writes no newer context, so the backstop still
+    fires — deferring unconditionally would silence every real miss."""
+    from clawock_kcnyu.harness.intraday_watchdog import attempt_still_running
+
+    assert not attempt_still_running(
+        {'generated_at': '2026-08-11T00:00:13'},
+        {'ts': _ms(0, 5, 14)})
+
+
+@pytest.mark.parametrize('context, run', [
+    ({}, {'ts': _ms(0, 5)}),
+    ({'generated_at': None}, {'ts': _ms(0, 5)}),
+    ({'generated_at': 'not-a-date'}, {'ts': _ms(0, 5)}),
+    ({'generated_at': '2026-08-11T00:07:27'}, {}),
+    ({'generated_at': '2026-08-11T00:07:27'}, {'ts': None}),
+    (None, None),
+])
+def test_missing_or_broken_inputs_do_not_defer(context, run):
+    """Unreadable inputs must fall through to the existing gates rather than
+    silently suppressing the backstop — an unknown state is not evidence that
+    something is running."""
+    from clawock_kcnyu.harness.intraday_watchdog import attempt_still_running
+
+    assert not attempt_still_running(context, run)
+
+
+def test_a_naive_timestamp_is_read_as_local_not_utc():
+    """Preflight writes `generated_at` without an offset. Reading it as UTC
+    would shift it 8 hours and make every context look older than its run,
+    disabling this gate entirely and silently."""
+    from clawock_kcnyu.harness.intraday_watchdog import attempt_still_running
+
+    # 00:07:27 HKT is 16:07 UTC the previous day; if parsed as UTC it would sort
+    # before a run that finished at 00:05:14 HKT and the gate would not fire.
+    assert attempt_still_running(
+        {'generated_at': '2026-08-11T00:07:27'},
+        {'ts': _ms(0, 5, 14)})
+
+
+def test_the_gate_runs_before_the_slot_is_judged():
+    """Placement is the substance: it has to sit above the loop, marker and
+    generation gates, because each of those can send."""
+    import inspect
+
+    from clawock_kcnyu.harness import intraday_watchdog
+
+    source = inspect.getsource(intraday_watchdog.main)
+    defer = source.index('attempt_still_running(context, last)')
+    for later in ("if looped:", "marker_covers_slot(", "delivered_clean"):
+        assert defer < source.index(later), (
+            f'the in-flight check must precede {later!r}, or the slot can still '
+            'be judged while it is running')


### PR DESCRIPTION
Closes #471. Found reviewing the overnight US session — the first full night after today's watchdog work.

## What kcn received

The deterministic fallback and the real report, **one second apart**:

```
00:00:00  attempt 1  error  (86s)
00:01:55  attempt 2  error  (34s)
00:03:30  attempt 3  error (104s)  → finished 00:05:14
00:07:14  attempt 4  ok    (275s)  → finished 00:11:48
00:10:44  watchdog → deterministic-fallback, fail_kind "未完成"
00:10:45  postflight → telegram-cosend, the real report
```

## Why

openclaw writes a run record only with `action: "finished"`, so an attempt that is **currently running is invisible**. `run_for_slot` returns the newest *completed* run — here attempt 3's `error` — while attempt 4 was mid-run. `WATCHDOG_DELAY_MINUTES = 10` assumes a slot resolves within ten minutes of its schedule; three retries pushed this one to 11m48s.

This is **not** #458/#459. That was marker/context identity on retries. This is judging a slot that had not finished.

## The signal was already on disk

The preflight context is written when an attempt *starts*:

```
_0000  generated_at 00:00:13
_0003  generated_at 00:03:39
_0007  generated_at 00:07:27   ← attempt 4
```

At 00:10:44 the newest finished run had ended at **00:05:14** while the latest context was generated at **00:07:27**. A preflight newer than the newest finished run means a later attempt started and has not finished.

## Direction of safety

Deferring is safe one way only, and it is the right way. A genuinely dead slot writes no newer context, so a real miss still gets its backstop. Sending a fallback for work that then succeeds is a duplicate — the exact thing the gate ordering exists to prevent.

## Verification

11 tests, including the incident replayed verbatim. Mutations, both caught:

| mutation | result |
|---|---|
| defer unconditionally | dead-slot and broken-input tests fail |
| parse the naive `generated_at` as UTC | silently disables the gate → two tests fail |

One test pins **placement** — the check must precede the loop, marker and generation gates, since each can send.

Full suite 1809 passed; the 4 failures / 23 errors reproduce identically on unmodified `origin/master`.