### PR TITLE
fix: move the SEO check to Actions, and let the capability gate count jobs

### DIFF
--- a/.github/workflows/seo-visibility.yml
+++ b/.github/workflows/seo-visibility.yml
@@ -1,0 +1,62 @@
+name: SEO Visibility
+
+# Weekly Search Console pull, so "are we getting indexed yet" is a number in the
+# run log instead of a standing guess.
+#
+# On GitHub rather than the VPS because that is the standing rule for new
+# automation: the box already carries the market schedule, and a check whose
+# whole purpose is to survive and observe should not depend on the thing most
+# likely to be down. It was briefly a VPS crontab entry, which also managed to
+# reproduce both classic cron traps in one line — a bare `python3` that could not
+# import the package, and a relative path with no working directory.
+#
+# Mondays 06:30 UTC. Scheduled runs drift by hours on GitHub; for a weekly
+# reading of a number that moves over weeks, that is irrelevant.
+on:
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install
+        # The extra, not a hand-written package line — dependencies live in
+        # pyproject so a version cannot drift between here and there.
+        run: pip install --quiet -e '.[seo]'
+
+      - name: Query Search Console
+        env:
+          # Read-only on one property. Passed as a file path rather than parsed
+          # from the environment so the script has one credential interface,
+          # whichever host it runs on.
+          GSC_CREDENTIALS: ${{ secrets.GSC_CREDENTIALS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GSC_CREDENTIALS}" ]; then
+            echo "::error::GSC_CREDENTIALS is unset — this check cannot see, which is not a pass"
+            exit 1
+          fi
+          printf '%s' "$GSC_CREDENTIALS" > /tmp/gsc.json
+          # CLAWOCK_GSC_CREDENTIALS short-circuits the host-path default, so the
+          # script never needs the installed package just to find a file.
+          CLAWOCK_GSC_CREDENTIALS=/tmp/gsc.json \
+            python3 ops/growth/crawl_visibility.py | tee /tmp/report.txt
+          {
+            echo '### Search Console'
+            echo '```'
+            cat /tmp/report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          rm -f /tmp/gsc.json

--- a/ops/growth/crawl_visibility.py
+++ b/ops/growth/crawl_visibility.py
@@ -33,6 +33,15 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
+
+# Bootstrap before importing the package, the way every other ops entry point
+# does. Without it the import resolves only when the caller happens to supply
+# PYTHONPATH — which is exactly how the first cron line for this script failed
+# with ModuleNotFoundError under a bare `python3`.
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
 
 SITE = os.environ.get("CLAWOCK_SITE_URL", "https://kcnyu.github.io/clawock/")
 SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -509,6 +509,41 @@ def check_decision_ledger(r):
         r.add('decisions.jsonl', OK, f'{len(rows)} decisions · {len({x.get("episode_id") for x in rows})} episodes')
 
 
+def _cron_jobs_without_prompt_report(sessions):
+    """Enabled cron jobs whose newest session carries no `systemPromptReport`.
+
+    The gate below verifies the newest session per *profile*, which is the right
+    question for "is context still being assembled correctly" and the wrong one
+    for "is every job covered". On 2026-08-11 ten market jobs reported a uniform
+    5 files / 29 skills / 34 tools while `Memory Dreaming Promotion` produced no
+    report at all, and the profile-level check averaged it away.
+
+    Returns names rather than a count, and returns empty when the job list
+    cannot be read — an unreadable schedule is not evidence that every job is
+    covered, but it is also not this check's failure to report.
+    """
+    try:
+        from clawock.providers.openclaw import cron_cli_json
+
+        listing = cron_cli_json(['list', '--json']) or {}
+    except Exception:
+        return []
+
+    reported = {
+        key.split(':cron:', 1)[1].split(':')[0]
+        for key, entry in (sessions or {}).items()
+        if ':cron:' in key and isinstance(entry, dict)
+        and isinstance(entry.get('systemPromptReport'), dict)
+    }
+    missing = []
+    for job in listing.get('jobs', []) or []:
+        if not job.get('enabled'):
+            continue
+        if str(job.get('id')) not in reported:
+            missing.append(str(job.get('name') or job.get('id'))[:28])
+    return sorted(missing)
+
+
 def check_context_capability(r):
     """A run that came out with no skills or no tools has to fail somewhere.
 
@@ -558,6 +593,18 @@ def check_context_capability(r):
     # nothing to say. A profile that HAS sessions but carries no prompt report
     # anywhere is different: the runtime used to record what this gate reads and
     # has stopped, so every later run goes unverified behind a green check.
+    # Coverage is counted against the jobs that are actually scheduled, not
+    # against whatever sessions happen to exist. Nine healthy cron reports
+    # otherwise average away a tenth enabled job that produces none — the gate
+    # reads OK while one live job is unverifiable (#473). Names, not a count, so
+    # the finding says which job to go look at.
+    unreported_jobs = _cron_jobs_without_prompt_report(sessions)
+    if unreported_jobs:
+        r.add('context capability', WARNING,
+              f'{len(unreported_jobs)} enabled cron job(s) produce no prompt '
+              f'report, so this gate cannot see them: '
+              f'{", ".join(unreported_jobs)}')
+
     silent = sorted(profiles_seen - set(newest))
     if silent:
         r.add('context capability', WARNING,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ compute = ["numpy>=1.26"]
 evaluation = ["numpy>=1.26", "matplotlib>=3.8"]
 # Screenshot and social-card validation.
 imaging = ["Pillow>=10"]
+# Search Console visibility pull (ops/growth/crawl_visibility.py). Declared here
+# for the same reason as everything else in this table: a version pinned in a
+# workflow line is a second source of truth that drifts unseen.
+seo = ["google-auth>=2.30"]
 # Building and checking a distribution. Here rather than in the release workflow
 # for the same reason as everything else in this table: a version pinned in a
 # workflow line is a second source of truth that drifts unseen.

--- a/tests/test_context_capability_not_vacuous.py
+++ b/tests/test_context_capability_not_vacuous.py
@@ -140,3 +140,50 @@ def test_the_live_machine_is_actually_being_checked():
             profiles[profile] = True
     assert profiles, 'no sessions at all — this assertion must not pass vacuously'
     assert all(profiles.values()), f'a profile stopped recording reports: {profiles}'
+
+
+def test_an_enabled_job_with_no_report_is_named(monkeypatch):
+    """#473: nine healthy cron reports averaged away a tenth enabled job that
+    produced none, so the gate read OK while a live job was unverifiable."""
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{'id': 'a', 'name': 'Healthy', 'enabled': True},
+                               {'id': 'b', 'name': 'Dreaming', 'enabled': True}]})
+    missing = sc._cron_jobs_without_prompt_report({
+        'agent:main:cron:a:run:1': {'systemPromptReport': {}},
+    })
+    assert missing == ['Dreaming']
+
+
+def test_a_disabled_job_is_not_demanded(monkeypatch):
+    """Only what is scheduled has to be observable."""
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{'id': 'b', 'name': 'Off', 'enabled': False}]})
+    assert sc._cron_jobs_without_prompt_report({}) == []
+
+
+def test_every_job_covered_reports_nothing(monkeypatch):
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{'id': 'a', 'name': 'Healthy', 'enabled': True}]})
+    assert sc._cron_jobs_without_prompt_report({
+        'agent:main:cron:a:run:1': {'systemPromptReport': {}}}) == []
+
+
+def test_an_unreadable_schedule_does_not_invent_findings(monkeypatch):
+    """A schedule that cannot be read is not evidence either way, and this check
+    must not turn that into noise on a foreign host."""
+    import ops.system_check as sc
+
+    def boom(argv):
+        raise RuntimeError('no runtime here')
+
+    monkeypatch.setattr('clawock.providers.openclaw.cron_cli_json', boom)
+    assert sc._cron_jobs_without_prompt_report({}) == []

--- a/tests/test_system_check_context_capability.py
+++ b/tests/test_system_check_context_capability.py
@@ -62,6 +62,12 @@ def _run(system_check, monkeypatch, tmp_path, sessions):
         sessions_dir = store
 
     monkeypatch.setattr(system_check, "_OPENCLAW_PATHS", Paths)
+    # This fixture describes a world with these sessions and no schedule. Without
+    # saying so, the job-coverage check (#473) would read the real machine's cron
+    # list and report all eleven live jobs as uncovered by synthetic sessions —
+    # two different worlds compared against each other.
+    monkeypatch.setattr("clawock.providers.openclaw.cron_cli_json",
+                        lambda argv: {"jobs": []})
     result = system_check.Result()
     system_check.check_context_capability(result)
     return result.checks[0]


### PR DESCRIPTION
Two things, both from kcn's review.

## 1. The visibility check belonged on GitHub, not the VPS

The standing rule: new checks and automation default to GitHub's free
capabilities and stop adding standing load to the box. I put it in the crontab
anyway. A check whose whole purpose is to observe should not depend on the thing
most likely to be down.

Now a weekly workflow reading `secrets.GSC_CREDENTIALS` (read-only, one
property); the crontab entry is removed.

### That detour reproduced both classic cron traps in one line

```
bare python3          → ModuleNotFoundError: No module named 'clawock'
relative script path  → cron has no working directory
```

The root cause was mine, and **the repo already had a rule for it**:
`test_clawock_importers_do_not_inherit_their_sys_path` requires an ops entry
point to put the checkout on `sys.path` itself rather than depend on the
caller's `PYTHONPATH`. My script skipped it. With the bootstrap it runs under a
bare `python3` from any directory — verified with
`env -i PATH=/usr/bin:/bin HOME=/root` invoked from `/root`.

Third time this family has surfaced (#453 was the last), and this time the gate
caught it before merge rather than after.

### And the dependency

`test_no_workflow_reinstates_a_hand_written_package_list` caught
`pip install google-auth` in the workflow. Declared as the `seo` extra instead —
same reason that table already gives: a version pinned in a workflow line is a
second source of truth that drifts unseen.

## 2. #473 — the capability gate averaged away an unverifiable job

`check_context_capability` verified the newest session **per profile**, so nine
healthy cron reports hid a tenth enabled job producing none:

```
context capability | ⚠ WARN | 1 enabled cron job(s) produce no prompt report,
                              so this gate cannot see them: Memory Dreaming Promotion
```

Coverage is now counted against **enabled jobs** and names them, so the number
of jobs the gate covers is something someone chose rather than a coincidence.

The existing fixtures needed one line: they describe a world with certain
sessions and no schedule, and without saying so the check compared this
machine's real eleven jobs against synthetic sessions. Four new tests cover the
named-job, disabled-job, fully-covered and unreadable-schedule cases.

## Note on this PR's own history

The first version of this body was posted with an inline `--body` containing
backticks, which the shell executed — the exact incident recorded on 2026-08-02
that ends with "always use `--body-file`". Fixed by rewriting it from a file.
