### PR TITLE
fix: clawock --version failed, and the published package had no changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+What changed between the versions of the `clawock` distribution on PyPI.
+
+Only the public package is released, so only changes a package consumer can
+observe are listed here. The live KCNyu desk changes many times a day and its
+record is the commit history, the dashboard and the evidence page — not this
+file. `clawock-kcnyu` is never published; it appears below only where a release
+step touched it.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The newest heading here has to match the version in `pyproject.toml` — CI fails
+otherwise, so a release cannot ship an entry that was never written.
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.1.1] — 2026-08-10
+
+### Fixed
+
+- The PyPI project page rendered six broken images, including the logo and the
+  hero card — the first two things a visitor saw. `pyproject.toml` ships
+  `README.md` verbatim as `long_description`, and PyPI has no repository to
+  resolve a relative path against. Every asset and document reference in the
+  README is now absolute. An already-published version cannot be re-rendered, so
+  this needed a new release rather than a fix in place. ([#468])
+- The instance package restated its version as a literal, so the 0.1.1 build
+  would have announced 0.1.0. It reads `importlib.metadata` now, and the two
+  distributions' versions are checked against each other. ([#469])
+
+## [0.1.0] — 2026-08-10
+
+First release. `pip install clawock` gets the runtime-neutral decision-workflow
+package: the lifecycle CLI (`clawock init` → `run prepare` → `run publish`),
+packaged workflows installable as Agent Skills, the context/tool contracts,
+generation-pinned artifact publication with receipts, and the deterministic
+portfolio, market-data, decision and evidence domains.
+
+Published through GitHub trusted publishing, with no API token. Before it
+uploads, the release job installs the exact artifact into a clean virtualenv
+under `env -i` — no checkout, no runtime, no workspace, no inherited
+environment — and completes one full run. ([#436], [#379])
+
+[#379]: https://github.com/KCNyu/clawock/issues/379
+[#436]: https://github.com/KCNyu/clawock/pull/436
+[#468]: https://github.com/KCNyu/clawock/pull/468
+[#469]: https://github.com/KCNyu/clawock/pull/469
+[Unreleased]: https://github.com/KCNyu/clawock/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/KCNyu/clawock/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/KCNyu/clawock/releases/tag/v0.1.0

--- a/config/root-allowlist.json
+++ b/config/root-allowlist.json
@@ -6,6 +6,7 @@
     ".gitignore": {"owner": "repository configuration", "consumer": "git"},
     "AGENTS.md": {"owner": "runtime compatibility", "consumer": "OpenClaw and coding agents"},
     "BOOTSTRAP.md": {"owner": "runtime compatibility", "consumer": "OpenClaw bootstrap"},
+    "CHANGELOG.md": {"owner": "public package release notes", "consumer": "PyPI project links and GitHub"},
     "CLAUDE.md": {"owner": "runtime compatibility", "consumer": "Claude Code entry context"},
     "DREAMS.md": {"owner": "runtime compatibility", "consumer": "OpenClaw dreaming promotion"},
     "HEARTBEAT.md": {"owner": "runtime compatibility", "consumer": "OpenClaw heartbeat"},

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -38,6 +38,7 @@ index.
 ```bash
 # version lives in exactly one place
 sed -i 's/^version = .*/version = "0.2.0"/' pyproject.toml
+# then write the CHANGELOG.md entry for that version, in the same PR
 # ...open a PR, merge it, then tag the merge commit
 git tag v0.2.0 && git push origin v0.2.0
 ```
@@ -45,6 +46,12 @@ git tag v0.2.0 && git push origin v0.2.0
 The workflow refuses a tag that disagrees with `pyproject.toml`, because a
 mismatch publishes a version nobody asked for under a name the changelog already
 uses for something else.
+
+`tests/test_versions_agree.py` refuses a bump whose `CHANGELOG.md` entry is
+missing, which is why the entry belongs in the same PR as the bump. Writing it
+afterwards means the artifact is already on PyPI describing itself as something
+nobody wrote down, and a published version cannot be replaced — only superseded,
+which is what 0.1.1 cost.
 
 ## What the release job proves before it publishes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ Homepage = "https://github.com/KCNyu/clawock"
 Documentation = "https://kcnyu.github.io/clawock/"
 Source = "https://github.com/KCNyu/clawock"
 Issues = "https://github.com/KCNyu/clawock/issues"
+# PyPI renders project URLs as the sidebar of the project page, and a
+# `Changelog` key is the one downstream tooling looks for by name when it wants
+# to show a user what a pending upgrade contains. Without it, "what changed
+# between 0.1.0 and 0.1.1" had no answer anywhere a package consumer could see.
+Changelog = "https://github.com/KCNyu/clawock/blob/master/CHANGELOG.md"
 Evidence = "https://kcnyu.github.io/clawock/evidence.html"
 
 [project.scripts]

--- a/src/clawock/__init__.py
+++ b/src/clawock/__init__.py
@@ -2,8 +2,9 @@
 
 This package is the runtime-neutral product that can be installed and pointed at
 any workspace. Cohesive product areas live in domain subpackages such as
-``clawock.evidence`` and ``clawock.portfolio``; remaining code under ``scripts``
-is instance or repository operations, never an alternate product namespace.
+``clawock.evidence`` and ``clawock.portfolio``; instance and repository
+operations live in ``instances/`` and ``ops/``, never an alternate product
+namespace inside this package.
 """
 
 from clawock.workspace import ENV_VAR, describe, missing_pieces, workspace_root

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -520,6 +520,22 @@ DOCSTRING_HELP_UTILITIES = frozenset({
     "fundflow", "quant", "quant-review", "t0", "t0-review", "us-quotes",
 })
 
+
+def _installed_version() -> str:
+    """What pip actually put on this machine, or a sentinel saying it did not.
+
+    A source tree that was never installed has no distribution metadata, and
+    inventing a number for it would be the drift this indirection exists to
+    avoid — so it says so instead.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("clawock")
+    except PackageNotFoundError:
+        return "0+unknown (running from an uninstalled source tree)"
+
+
 def main(argv=None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv and raw_argv[0] in PACKAGED_UTILITIES:
@@ -528,6 +544,18 @@ def main(argv=None) -> int:
         ))
 
     parser = argparse.ArgumentParser(prog="clawock", description=__doc__)
+    # The first command anyone runs after `pip install`, and until now the one
+    # command that failed: argparse rejected `--version` as an unknown argument
+    # and answered with exit 2 plus the whole 50-subcommand usage block. Someone
+    # checking which artifact pip gave them got a wall of text and a failure.
+    #
+    # Read from installed distribution metadata rather than a literal, for the
+    # reason `tests/test_versions_agree.py` records: a restated number survives
+    # the bump that was supposed to change it, and the stale copy is the one the
+    # user is shown. `clawock.__version__` stays absent on purpose — that file
+    # explains why — so this reads the distribution directly.
+    parser.add_argument(
+        "--version", action="version", version=f"clawock {_installed_version()}")
     sub = parser.add_subparsers(dest="command", required=True)
 
     init = sub.add_parser("init", help="create a standalone clawock workspace")

--- a/tests/test_readme_parity.py
+++ b/tests/test_readme_parity.py
@@ -134,6 +134,52 @@ def test_per_run_context_layers_documented_in_both_languages():
         )
 
 
+def test_the_information_layer_table_adds_up_in_both_languages():
+    """The one structural number in the README that nothing was checking.
+
+    Everything else with a count behind it is pinned — the per-run block counts
+    read the preflights' own context dicts, the section and asset lists are
+    compared across languages. The information-layer table was prose: a headline
+    ("N fetch and compute modules across M layers") sitting above a table whose
+    rows carry the per-layer counts, in two languages, with nothing tying the
+    four numbers together. Editing one row and forgetting the headline is a
+    silent, plausible edit, and so is fixing it in one language only.
+
+    What this does NOT prove, stated so nobody reads more into a green: it does
+    not verify the modules exist or that the taxonomy still matches the package.
+    That mapping has no artifact behind it — the layers were drawn when these
+    were files under `scripts/data/`, which #429 deleted — so a test claiming to
+    check it would be encoding a guess as truth. This checks the four numbers
+    agree; grounding the taxonomy is separate work.
+    """
+    seen = {}
+    for md, name, pattern in (
+        (EN, "README.md", r"\*\*(\d+) fetch and compute modules across (\d+) layers\*\*"),
+        (ZH, "README.zh.md", r"\*\*(\d+) 层、(\d+) 个抓取与计算模块\*\*"),
+    ):
+        headline = re.search(pattern, md)
+        assert headline, f"{name}: the information-layer headline changed shape"
+        # ZH states layers first, EN states modules first.
+        modules, layers = (headline.group(1), headline.group(2))
+        if name.endswith("zh.md"):
+            layers, modules = modules, layers
+
+        rows = [ln for ln in md.splitlines() if re.match(r"^\| \d+ · ", ln)]
+        assert len(rows) == int(layers), (
+            f"{name}: headline says {layers} layers, table has {len(rows)} rows")
+
+        per_layer = [int(ln.split("|")[2].strip()) for ln in rows]
+        assert sum(per_layer) == int(modules), (
+            f"{name}: rows sum to {sum(per_layer)}, headline says {modules}")
+
+        seen[name] = per_layer
+
+    # The rows must also be the same rows in both languages, or the two READMEs
+    # describe different systems while each stays internally self-consistent.
+    assert seen["README.md"] == seen["README.zh.md"], (
+        f"layer counts differ between languages: {seen}")
+
+
 def test_explicit_h2_sequences():
     # Lock both languages' section order (and their 1:1 correspondence by position),
     # not just the count — so a section can't be added/reordered in one language only.

--- a/tests/test_version_flag.py
+++ b/tests/test_version_flag.py
@@ -1,0 +1,82 @@
+"""`clawock --version` has to answer, and answer with the installed artifact.
+
+Until 2026-08-11 it was the only documented-looking invocation that failed.
+`--version` was never declared, so argparse treated it as an unknown argument
+and replied with exit 2 and the entire 50-subcommand usage block. That is the
+first thing a reader does after `pip install clawock` — the README's own
+quickstart opens with the install line — so the package's first impression was
+a failure and a wall of text.
+
+Two properties, because fixing only the first is how the old
+`clawock_kcnyu.__version__ = "0.1.0"` literal got shipped reporting the previous
+release (`tests/test_versions_agree.py`):
+
+1. the flag exists and exits 0;
+2. what it prints is read from distribution metadata, not restated in source.
+
+The public package deliberately exposes no `clawock.__version__` — that choice
+and its reasoning live in `test_versions_agree.py`, and this file does not
+reverse it. The CLI reads the distribution directly instead.
+"""
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "clawock.cli", *args],
+        capture_output=True, text=True, cwd=ROOT,
+        env={"PATH": "/usr/bin:/bin", "PYTHONPATH": str(ROOT / "src")},
+    )
+
+
+def test_the_version_flag_exits_zero_and_names_the_program():
+    done = _run("--version")
+    # The regression was exit 2 with usage on stderr; assert the exit code and
+    # the shape, since argparse's failure also contains the word "clawock".
+    assert done.returncode == 0, (
+        f"`clawock --version` exited {done.returncode}: {done.stderr[:400]}")
+    assert re.fullmatch(r"clawock \S+.*", done.stdout.strip()), done.stdout
+    assert "usage:" not in done.stdout
+
+
+def test_the_reported_version_is_the_installed_one():
+    """The half that catches a literal: it must agree with what pip recorded.
+
+    Skipped rather than faked when the package is not installed — in that state
+    there is no truth to compare against, and asserting the checkout's declared
+    number instead would pass for exactly the code this test rejects.
+    """
+    try:
+        from importlib.metadata import version
+        installed = version("clawock")
+    except Exception:
+        pytest.skip("clawock is not installed in this environment")
+
+    assert _run("--version").stdout.strip() == f"clawock {installed}"
+
+
+def test_the_version_is_not_restated_anywhere_in_the_package():
+    """Mutation guard. `--version` reading a hard-coded string would satisfy
+    both tests above on the day it was written and be wrong at the next bump —
+    which is precisely how the instance package shipped 0.1.1 announcing 0.1.0.
+    """
+    declared = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+    offenders = [
+        path.relative_to(ROOT).as_posix()
+        for path in sorted((ROOT / "src" / "clawock").rglob("*.py"))
+        if f'"{declared}"' in path.read_text() or f"'{declared}'" in path.read_text()
+    ]
+    assert not offenders, (
+        f"version {declared} is restated in {offenders}; read it from the "
+        "installed distribution so a bump cannot leave a copy behind"
+    )
+    # Anti-vacuity: the scan above passes just as well if it walks nothing.
+    assert len(list((ROOT / "src" / "clawock").rglob("*.py"))) > 50

--- a/tests/test_versions_agree.py
+++ b/tests/test_versions_agree.py
@@ -8,8 +8,14 @@ nothing would have said so. Found by bumping to 0.1.1 — the literal stayed
 behind.
 
 The public `clawock` package deliberately exposes no `__version__`; consumers
-read `importlib.metadata`, which cannot disagree with what was installed.
+read `importlib.metadata`, which cannot disagree with what was installed. The
+CLI's `--version` reads the same place (`tests/test_version_flag.py`).
+
+The changelog checks live here for the same reason: a version number and the
+description of what it contains are one release decision, and separating them is
+how a package ends up on PyPI announcing a version nobody wrote an entry for.
 """
+import re
 import tomllib
 from pathlib import Path
 
@@ -55,6 +61,50 @@ def test_the_installed_module_reports_the_declared_version():
         pytest.skip('running from a source tree, not an installed distribution')
     assert clawock_kcnyu.__version__ == _declared(
         ROOT / 'instances' / 'kcnyu' / 'pyproject.toml')
+
+
+def _changelog_versions() -> list[str]:
+    """Released versions, newest first. `[Unreleased]` is not one."""
+    headings = re.findall(r'^## \[([^\]]+)\]', (ROOT / 'CHANGELOG.md').read_text(),
+                          re.MULTILINE)
+    return [h for h in headings if h.lower() != 'unreleased']
+
+
+def test_the_changelog_describes_the_version_being_shipped():
+    """A changelog nobody is required to update is a changelog that stops at the
+    release someone last remembered.
+
+    `docs/operations/release.md` already tells the releaser that a mismatched
+    tag "publishes a version nobody asked for under a name the changelog already
+    uses for something else" — written before there was a changelog to use. This
+    is the check that sentence assumed: the newest entry has to be the version
+    in `pyproject.toml`, so the entry gets written in the same PR as the bump
+    rather than after the artifact is already on PyPI and unchangeable.
+    """
+    released = _changelog_versions()
+    assert released, 'CHANGELOG.md lists no released version'
+    declared = _declared(ROOT / 'pyproject.toml')
+    assert released[0] == declared, (
+        f'pyproject ships {declared} but the newest CHANGELOG entry is '
+        f'{released[0]}; write the entry in the PR that bumps the version'
+    )
+
+
+def test_the_changelog_lists_each_version_once_newest_first():
+    """Order and uniqueness are the two things a reader assumes without checking,
+    which is what makes a silent duplicate or an out-of-order insert expensive."""
+    released = _changelog_versions()
+    assert len(released) == len(set(released)), f'duplicate entries: {released}'
+    keys = [tuple(int(part) for part in v.split('.')) for v in released]
+    assert keys == sorted(keys, reverse=True), f'not newest-first: {released}'
+
+
+def test_the_changelog_is_reachable_from_the_package_metadata():
+    """The file only does its job if PyPI links to it; a changelog nobody can
+    find from the project page is a file in a repository."""
+    urls = tomllib.loads((ROOT / 'pyproject.toml').read_text())['project']['urls']
+    assert 'Changelog' in urls, 'declare a Changelog URL so PyPI renders the link'
+    assert urls['Changelog'].endswith('/CHANGELOG.md')
 
 
 def test_the_dependency_pin_still_admits_the_current_version():


### PR DESCRIPTION
Found while reviewing the promotion surface end to end, the way a stranger meets
it: `pip install clawock` from PyPI into a clean venv, then the README quickstart
verbatim under `env -i`. The quickstart works. Two things around it do not.

## 1. `clawock --version` was the one documented-looking command that failed

```
$ clawock --version
usage: clawock [-h]
               {init,run,doctor,calendar,report,brief,intraday,tool,plan-context,
                risk,dashboard-outputs,dashboard-build,run-card,provenance,...}
               ...
$ echo $?
2
```

`--version` was never declared, so argparse treated it as an unknown argument and
answered with exit 2 and the whole 50-subcommand usage block. That is the first
thing anyone runs after an install to confirm which artifact pip actually gave
them — and since v0.1.0 shipped a README whose relative images were broken
(#468), "which version am I on" is not a hypothetical question here.

It reads `importlib.metadata`, not a literal, for the reason
`tests/test_versions_agree.py` already records: a restated number survives the
bump that was supposed to change it, and the stale copy is the one the user is
shown — exactly how `clawock_kcnyu` nearly shipped 0.1.1 announcing 0.1.0.

`clawock.__version__` stays absent. That is a deliberate choice with its
reasoning written down, and nothing here justifies reversing it; the CLI reads
the distribution directly instead.

An uninstalled source tree has no metadata and says so
(`0+unknown (running from an uninstalled source tree)`) rather than inventing a
number, which would be the drift the indirection exists to avoid.

## 2. The package is on PyPI with no changelog

0.1.0 and 0.1.1 were published on the same day, the second one specifically to
replace a project page that rendered six broken images. A consumer had no way to
learn that — no `CHANGELOG.md`, and no `Changelog` key in `[project.urls]`, which
is the one PyPI renders in the sidebar and the one downstream tooling looks for
by name when it wants to show what a pending upgrade contains.

`docs/operations/release.md` was already written as if a changelog existed — it
warns that a mismatched tag "publishes a version nobody asked for under a name
the changelog already uses for something else."

Added in Keep a Changelog format, scoped to what a *package consumer* can
observe. The live desk changes many times a day and its record is the dashboard,
the evidence page and the commit history; putting that in a package changelog
would bury the two entries that matter.

Three checks keep it from becoming the file nobody updates:

- the newest entry must be the version in `pyproject.toml`, so the entry is
  written in the PR that bumps the version rather than after the artifact is on
  PyPI and unchangeable;
- entries are unique and newest-first;
- the `Changelog` URL is declared — a changelog nobody can reach from the
  project page is a file in a repository.

Mutation-verified: bumping `pyproject.toml` to 0.2.0 without an entry turns the
first one red.

## 3. The one README number nothing was checking

Every other structural count in the README is pinned — the per-run block counts
read the preflights' own context dicts, sections and assets are compared across
languages. The information-layer table was prose: a headline ("26 fetch and
compute modules across 8 layers") above a table carrying the per-layer counts, in
two languages, with nothing tying the four numbers together. Editing one row and
forgetting the headline is a plausible silent edit; so is fixing it in one
language only.

The new test says explicitly what it does **not** prove: it does not verify the
modules exist or that the taxonomy still matches the package. That mapping has no
artifact behind it — the layers were drawn when these were files under
`scripts/data/`, which #429 deleted — so a test claiming to check it would be
encoding a guess as truth. Grounding the taxonomy is separate work; this checks
the four numbers agree. Mutation-verified in three directions: a changed EN row,
a changed ZH headline, and a ZH row edited without its EN counterpart.

## Also

`src/clawock/__init__.py` — the package's own front door, shipped verbatim to
PyPI — still described repository operations as living "under `scripts`", a
directory #429 deleted. Corrected to `instances/` and `ops/`.

`CHANGELOG.md` is registered in `config/root-allowlist.json` with an owner and a
consumer, as the root contract requires.

## Verification

- `clawock --version` → `clawock 0.1.1`, exit 0, from a clean venv holding the
  published 0.1.1 wheel.
- The published wheel re-checked while here: 228 files, zero `instances/`,
  `ops/` or `site/` leakage, `clawock_kcnyu` not importable.
- Full suite green locally with both distributions importable (the sidecar
  failures in a bare shell are `python3 -m clawock.publish.dashboard` with no
  install, not a regression — CI installs both editable).

Closes #475. The half this deliberately does not attempt — whether the layer
taxonomy still describes the package — is #476.
