### PR TITLE
fix(brief): size the fallback budget for MiniMax and verify the run it dispatches

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/automation/brief_fallback.py
+++ b/instances/kcnyu/src/clawock_kcnyu/automation/brief_fallback.py
@@ -19,6 +19,13 @@ from pathlib import Path
 from clawock_kcnyu.automation.llm import chat
 from clawock.decision import ledger as decision_v2
 
+# Output budget for the single-turn brief. Thinking is enabled, and _call_provider
+# takes its reasoning budget out of this same allowance, so the usable prose budget is
+# BRIEF_MAX_TOKENS minus up to 16000. Sized against the real artifact: briefs run ~33KB
+# (~20K tokens) plus the trailing plan.json block, so this leaves roughly 4x headroom
+# and stays well under MiniMax M3's 131072 cap. See the call site for why 32000 failed.
+BRIEF_MAX_TOKENS = 96000
+
 
 def split_brief_and_plan(out):
     """(markdown, plan_json_str) from the model output.
@@ -270,10 +277,20 @@ def main():
         f"格式: 1) 完整 brief markdown (按 SKILL); 2) 末尾 ```json``` plan.json. 直接出 brief, 不要客套."
     )
 
-    # Use full mimo-v2.5-pro cap (32K) + thinking enabled for brief depth.
+    # BRIEF_MAX_TOKENS, not 32000: that old number was mimo-v2.5-pro's cap, left behind
+    # when MiniMax M3 became primary on 2026-06-16 (M3 maxOutput is 131072, and chat()
+    # now clamps per provider, so a budget above mimo's cap no longer breaks the Xiaomi
+    # fallback). 32000 was not merely conservative, it was fatal: chat() leaves thinking
+    # enabled, so _call_provider spends min(max_tokens-1024, 16000) of the SAME output
+    # budget on reasoning — half of it — leaving ~16K for prose. The brief runs ~33KB.
+    # On 2026-08-11 that produced `102644 in / 32000 out (stop=max_tokens)`: the markdown
+    # was truncated mid-body, the trailing ```json``` plan block was never emitted, and
+    # validation correctly refused to write anything. Net effect: the only automatic
+    # recovery path could not physically emit a complete brief.
     # timeout=900: the full-context brief prefills ~116KB and thinks before emitting
     # ~20K tokens; the 180s default timed out 3x on 2026-07-16 and killed the run.
-    out = chat(system=system, user=user, max_tokens=32000, temperature=0.6, timeout=900)
+    out = chat(system=system, user=user, max_tokens=BRIEF_MAX_TOKENS,
+               temperature=0.6, timeout=900)
 
     # Split markdown + plan.json (see split_brief_and_plan for the tolerance rules).
     md_part, json_part = split_brief_and_plan(out)

--- a/instances/kcnyu/src/clawock_kcnyu/automation/llm.py
+++ b/instances/kcnyu/src/clawock_kcnyu/automation/llm.py
@@ -53,6 +53,7 @@ DEFAULT_MODEL = 'mimo-v2.5-pro'
 MINIMAX_BASE = 'https://api.minimaxi.com/anthropic'
 MINIMAX_MODEL = 'MiniMax-M3'
 MINIMAX_MAX_TOKENS = 131072  # M3 maxOutput
+XIAOMI_MAX_TOKENS = 32000  # mimo-v2.5-pro maxOutput — far below M3's
 ANTHROPIC_VERSION = '2023-06-01'
 TIMEOUT = 180  # 3 min per call
 MAX_RETRIES = 3
@@ -236,7 +237,8 @@ def chat(system: str = '', user: str = '', messages: list = None,
     if fallback and xiaomi_key:
         try:
             return _call_provider('xiaomi', base_url, xiaomi_key, model, messages,
-                                  max_tokens, temperature, json_response, thinking,
+                                  min(max_tokens, XIAOMI_MAX_TOKENS),
+                                  temperature, json_response, thinking,
                                   timeout)
         except Exception as e:
             errors.append(f'xiaomi[{e}]')

--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -19,6 +19,7 @@ session transcript. transcript_loop_score detects that directly and cleanly
 import json
 import subprocess
 import sys
+import time
 from collections import Counter
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -288,6 +289,118 @@ def dispatch_brief_fallback(dry_run=False):
         return r.returncode == 0, (r.stdout + r.stderr)[-400:]
     except Exception as e:
         return False, str(e)[:300]
+
+
+BRIEF_FALLBACK_WORKFLOW = 'brief-fallback.yml'
+# 09:05 dispatch + this budget must finish before 10:00 HKT, after which
+# brief-fallback.yml refuses to build a pre-open brief anyway. Observed runtime is
+# ~5-8 min (2026-08-11: 8m01s), so 15 min covers a slow run without risking the
+# hard cutoff, and a timeout here is reported as 'pending', never as success.
+BRIEF_FALLBACK_POLL_BUDGET_S = 15 * 60
+BRIEF_FALLBACK_POLL_INTERVAL_S = 30
+
+
+def _parse_iso(value):
+    """Timezone-aware datetime from an ISO-8601 string, or None.
+
+    Both offset forms have to normalise to the same instant: the dispatch timestamp is
+    written in HKT (`...T09:05:04+08:00`) while GitHub reports `createdAt` in UTC
+    (`...T01:05:04Z`). Comparing those as strings ranks the UTC one earlier and drops
+    the very run we just dispatched, which would make every outcome 'unknown'."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def _gh_json(args, timeout=60):
+    """Run a `gh` command expecting JSON on stdout. Returns parsed JSON or None."""
+    try:
+        r = subprocess.run(['gh'] + args, capture_output=True, text=True,
+                           timeout=timeout, cwd=str(WS))
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except Exception:
+        return None
+
+
+def await_brief_fallback_outcome(since_iso, dry_run=False,
+                                 budget_s=BRIEF_FALLBACK_POLL_BUDGET_S,
+                                 interval_s=BRIEF_FALLBACK_POLL_INTERVAL_S,
+                                 sleep=time.sleep, now=None):
+    """Block until the dispatched brief-fallback run finishes. Returns (state, detail).
+
+    state is one of 'success' | 'failure' | 'pending' | 'unknown'.
+
+    Why this exists (2026-08-11): `dispatch_brief_fallback` returns the exit status of
+    `gh workflow run`, i.e. "the dispatch was accepted" — and the 09:05 alert used that
+    to tell kcn "✅ 已 dispatch ... 约 5-10 分钟落盘并 push". That day the dispatch was
+    accepted and the run failed 8 minutes later (the model hit max_tokens, so plan.json
+    never validated and nothing was written). Both the on-box 08:00 path and the only
+    automatic recovery path were dead, and the last signal kcn received was a green
+    check. Detecting a miss and then reporting a fabricated success is worse than not
+    detecting it, so the miss alert now reports what the run actually did.
+
+    Never returns 'success' on a timeout or on any lookup failure: an unverified run is
+    'pending'/'unknown', which the alert renders as "outcome unverified", not as done."""
+    now = now or (lambda: datetime.now(HKT))
+    if dry_run:
+        return 'pending', '(dry-run) outcome polling skipped'
+
+    deadline = now().timestamp() + budget_s
+    # A dispatch we cannot date cannot be used to reject stale runs, so fall back to
+    # "any run" rather than silently discarding every candidate.
+    since = _parse_iso(since_iso)
+    run = None
+    while True:
+        runs = _gh_json(['run', 'list', '--workflow', BRIEF_FALLBACK_WORKFLOW,
+                         '--event', 'workflow_dispatch', '--limit', '5',
+                         '--json', 'databaseId,status,conclusion,url,createdAt'])
+        if runs:
+            # Only consider runs created at/after our dispatch, so a stale earlier
+            # run can never be mistaken for this one's outcome. Compared as instants:
+            # the two sides arrive in different timezones (see _parse_iso).
+            dated = [(r, _parse_iso(r.get('createdAt'))) for r in runs]
+            fresh = [(r, t) for r, t in dated
+                     if t is not None and (since is None or t >= since)]
+            if fresh:
+                run = max(fresh, key=lambda rt: rt[1])[0]
+        if run and run.get('status') == 'completed':
+            conclusion = run.get('conclusion') or 'unknown'
+            url = run.get('url') or ''
+            if conclusion == 'success':
+                return 'success', url
+            return 'failure', f'{conclusion} {url} {_gh_run_failure_detail(run)}'.strip()
+        if now().timestamp() + interval_s > deadline:
+            if run:
+                return 'pending', (f'still {run.get("status") or "unknown"} after '
+                                   f'{budget_s // 60}min: {run.get("url") or ""}')
+            return 'unknown', f'no workflow_dispatch run found within {budget_s // 60}min'
+        sleep(interval_s)
+
+
+def _gh_run_failure_detail(run, max_len=300):
+    """Best-effort one-line reason a fallback run failed; '' when unavailable."""
+    run_id = run.get('databaseId')
+    if not run_id:
+        return ''
+    try:
+        r = subprocess.run(['gh', 'run', 'view', str(run_id), '--log-failed'],
+                           capture_output=True, text=True, timeout=120, cwd=str(WS))
+    except Exception:
+        return ''
+    if r.returncode != 0:
+        return ''
+    # Keep the last real output lines; the failing step's error is at the tail.
+    lines = [ln.split('\t')[-1].strip() for ln in r.stdout.splitlines() if ln.strip()]
+    lines = [ln for ln in lines if not ln.startswith('##[group]')]
+    return ' / '.join(lines[-3:])[:max_len]
 
 
 def cosend_telegram(message, tag, dry_run=False):

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -50,7 +50,7 @@ from pathlib import Path
 
 from ._watchdog_common import (
     WS, HKT, log, build_brief_card, send_telegram, KCN_TELEGRAM,
-    dispatch_brief_fallback,
+    dispatch_brief_fallback, await_brief_fallback_outcome,
 )
 
 MARKER_FRESH_MS = 30 * 60 * 1000  # postflight send-marker older than this ⇒ not this slot
@@ -182,7 +182,7 @@ def alert_brief_missing(today, dry_run, issues=None):
     alert = (
         f'🔴 盘前深度简报产物不完整 — {today}\n\n'
         f'09:05 检查结果：\n{issue_text}\n\n'
-        + ('✅ 已自动 dispatch off-host 兜底 (brief-fallback.yml)，约 5-10 分钟落盘并 push。\n'
+        + ('🔄 已 dispatch off-host 兜底 (brief-fallback.yml)，正在等待运行结果，稍后另发一条。\n'
            if dispatched else
            '⚠️ 自动 dispatch 兜底失败，需要手动：gh workflow run brief-fallback.yml\n'
            '（10:00 HKT 前有效，之后 workflow 会判定过期跳过）\n')
@@ -213,11 +213,56 @@ def alert_brief_missing(today, dry_run, issues=None):
     if tg_ok and not dry_run:
         flag.parent.mkdir(parents=True, exist_ok=True)
         flag.write_text(datetime.now(HKT).isoformat())
+
+    # The miss alert above is deliberately sent before the run finishes, so kcn learns
+    # at 09:05 that 08:00 missed. Only now do we find out whether the recovery actually
+    # worked — reporting that is the whole point (2026-08-11: dispatch accepted, run
+    # failed 8min later, and the last thing kcn heard was a green check).
+    outcome, outcome_detail = 'not-dispatched', ''
+    if dispatched:
+        outcome, outcome_detail = await_brief_fallback_outcome(
+            state.get('dispatch_attempted_at') or datetime.now(HKT).isoformat(),
+            dry_run)
+        state['fallback_outcome'] = outcome
+        state['fallback_outcome_detail'] = outcome_detail
+        if not dry_run:
+            write_missing_state(today, state)
+        follow_up = _fallback_outcome_message(today, outcome, outcome_detail)
+        try:
+            follow_ok, follow_out = send_telegram(KCN_TELEGRAM, follow_up, dry_run)
+        except Exception as e:
+            follow_ok, follow_out = False, f'{type(e).__name__}: {e}'[:300]
+        log({'tag': 'brief', 'action': 'fallback-outcome', 'dry_run': dry_run,
+             'outcome': outcome, 'detail': outcome_detail,
+             'sent_ok': follow_ok, 'target': KCN_TELEGRAM, 'out': follow_out})
+
     print(json.dumps({'tag': 'brief', 'reason': 'brief artifacts incomplete',
                       'issues': issues,
                       'dispatched_fallback': dispatched, 'alerted_telegram': tg_ok,
+                      'fallback_outcome': outcome,
                       'dry_run': dry_run}, ensure_ascii=False))
     return 0
+
+
+def _fallback_outcome_message(today, outcome, detail):
+    """Telegram follow-up naming what the off-host fallback actually did.
+
+    Only 'success' claims the brief exists, and it says so because the run concluded
+    success — every other state is reported as unresolved with the manual next step."""
+    if outcome == 'success':
+        return (f'✅ off-host 兜底已完成 — {today}\n\n'
+                f'{detail}\n\n'
+                f'pre-open.md + plan.json 已由 workflow 生成并 push。')
+    if outcome == 'failure':
+        return (f'🔴 off-host 兜底失败 — {today}\n\n'
+                f'{detail}\n\n'
+                f'今天两条路径都没产出简报，没有自动补救了。\n'
+                f'手动：gh run rerun <id> 或 gh workflow run brief-fallback.yml'
+                f'（10:00 HKT 前有效）')
+    return (f'⚠️ off-host 兜底结果未确认 — {today}\n\n'
+            f'{detail}\n\n'
+            f'注意：这不代表成功。请查 '
+            f'gh run list --workflow=brief-fallback.yml')
 
 
 def main():

--- a/tests/test_brief_fallback_outcome.py
+++ b/tests/test_brief_fallback_outcome.py
@@ -1,0 +1,188 @@
+"""await_brief_fallback_outcome must never report an unverified run as success.
+
+The 2026-08-11 outage was not a missing check — it was a check that reported the
+dispatch call's exit status and called that recovery. Every test here pins the
+direction of the failure: when in doubt, not success.
+"""
+from datetime import datetime, timedelta, timezone
+
+from clawock_kcnyu.harness import _watchdog_common as common
+
+
+SINCE = "2026-08-11T01:05:00Z"
+HKT = timezone(timedelta(hours=8))
+
+
+class FakeClock:
+    """Virtual time, so a 15-minute poll budget costs no wall clock in CI."""
+
+    def __init__(self):
+        self._t = datetime(2026, 8, 11, 9, 5, tzinfo=HKT)
+        self.slept = []
+
+    def now(self):
+        return self._t
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self._t += timedelta(seconds=seconds)
+
+
+def _fake_gh(monkeypatch, pages):
+    """Serve one `gh run list` JSON payload per poll, in order."""
+    calls = {"n": 0}
+
+    def gh_json(args, timeout=60):
+        assert args[:2] == ["run", "list"]
+        page = pages[min(calls["n"], len(pages) - 1)]
+        calls["n"] += 1
+        return page
+
+    monkeypatch.setattr(common, "_gh_json", gh_json)
+    return calls
+
+
+def test_completed_success_is_reported_as_success(monkeypatch):
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 1, "status": "completed", "conclusion": "success",
+        "url": "https://gh/run/1", "createdAt": "2026-08-11T01:05:04Z",
+    }]])
+
+    clock = FakeClock()
+    assert common.await_brief_fallback_outcome(
+        SINCE, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now
+    ) == ("success", "https://gh/run/1")
+
+
+def test_completed_failure_is_reported_as_failure_with_the_reason(monkeypatch):
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 2, "status": "completed", "conclusion": "failure",
+        "url": "https://gh/run/2", "createdAt": "2026-08-11T01:05:04Z",
+    }]])
+    monkeypatch.setattr(common, "_gh_run_failure_detail",
+                        lambda _run, **_kw: "plan.json v2 validation failed")
+
+    clock = FakeClock()
+    state, detail = common.await_brief_fallback_outcome(
+        SINCE, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+    assert state == "failure"
+    assert "plan.json v2 validation failed" in detail
+
+
+def test_a_run_that_never_completes_is_pending_not_success(monkeypatch):
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 3, "status": "in_progress", "conclusion": None,
+        "url": "https://gh/run/3", "createdAt": "2026-08-11T01:05:04Z",
+    }]])
+    clock = FakeClock()
+
+    state, detail = common.await_brief_fallback_outcome(
+        SINCE, budget_s=900, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "pending"
+    assert "https://gh/run/3" in detail
+    assert clock.slept, "should have polled rather than returning immediately"
+    assert sum(clock.slept) <= 900, "must not poll past its own budget"
+
+
+def test_a_run_created_before_our_dispatch_is_never_adopted(monkeypatch):
+    """A stale green run from a previous day must not stand in for today's."""
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 4, "status": "completed", "conclusion": "success",
+        "url": "https://gh/run/old", "createdAt": "2026-08-10T02:38:41Z",
+    }]])
+
+    clock = FakeClock()
+    state, detail = common.await_brief_fallback_outcome(
+        SINCE, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "unknown"
+    assert "https://gh/run/old" not in detail
+
+
+def test_gh_lookup_failure_is_unknown_not_success(monkeypatch):
+    _fake_gh(monkeypatch, [None])
+    clock = FakeClock()
+
+    state, _detail = common.await_brief_fallback_outcome(
+        SINCE, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "unknown"
+
+
+def test_a_queued_run_that_later_completes_is_picked_up(monkeypatch):
+    _fake_gh(monkeypatch, [
+        [{"databaseId": 5, "status": "queued", "conclusion": None,
+          "url": "https://gh/run/5", "createdAt": "2026-08-11T01:05:04Z"}],
+        [{"databaseId": 5, "status": "completed", "conclusion": "success",
+          "url": "https://gh/run/5", "createdAt": "2026-08-11T01:05:04Z"}],
+    ])
+
+    clock = FakeClock()
+    state, _detail = common.await_brief_fallback_outcome(
+        SINCE, budget_s=600, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "success"
+    assert clock.slept == [30], "should poll once, then see the completed run"
+
+
+def test_dry_run_does_not_poll_and_does_not_claim_success(monkeypatch):
+    def explode(*_a, **_kw):
+        raise AssertionError("dry-run must not shell out to gh")
+
+    monkeypatch.setattr(common, "_gh_json", explode)
+
+    state, _detail = common.await_brief_fallback_outcome(SINCE, dry_run=True)
+    assert state == "pending"
+
+
+# The dispatch timestamp is written in HKT; GitHub reports createdAt in UTC. These
+# describe the same instant 4 seconds apart, and a naive string compare ranks the
+# UTC one first — which would discard the run we just fired, every single day.
+HKT_DISPATCH = "2026-08-11T09:05:00.367448+08:00"
+UTC_CREATED = "2026-08-11T01:05:04Z"
+
+
+def test_the_run_we_just_dispatched_is_matched_across_timezone_forms(monkeypatch):
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 9, "status": "completed", "conclusion": "failure",
+        "url": "https://gh/run/9", "createdAt": UTC_CREATED,
+    }]])
+    monkeypatch.setattr(common, "_gh_run_failure_detail", lambda _run, **_kw: "boom")
+    clock = FakeClock()
+
+    # Bounded clock on purpose: if the match regresses, this must fail in a
+    # millisecond rather than spin out the real 15-minute poll budget.
+    state, _detail = common.await_brief_fallback_outcome(
+        HKT_DISPATCH, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "failure", (
+        "a UTC createdAt must not sort before an HKT dispatch of the same instant"
+    )
+
+
+def test_a_genuinely_earlier_run_is_still_rejected_across_timezone_forms(monkeypatch):
+    """The timezone fix must not weaken the stale-run guard it sits inside."""
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 10, "status": "completed", "conclusion": "success",
+        "url": "https://gh/run/old", "createdAt": "2026-08-10T02:38:41Z",
+    }]])
+    clock = FakeClock()
+
+    state, _detail = common.await_brief_fallback_outcome(
+        HKT_DISPATCH, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "unknown"
+
+
+def test_an_undated_run_is_never_adopted(monkeypatch):
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 11, "status": "completed", "conclusion": "success",
+        "url": "https://gh/run/undated", "createdAt": None,
+    }]])
+    clock = FakeClock()
+
+    state, _detail = common.await_brief_fallback_outcome(
+        HKT_DISPATCH, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
+
+    assert state == "unknown"

--- a/tests/test_brief_fallback_token_budget.py
+++ b/tests/test_brief_fallback_token_budget.py
@@ -1,0 +1,80 @@
+"""The brief's output budget must fit the brief that is actually published.
+
+2026-08-11: the call site asked for max_tokens=32000 — mimo-v2.5-pro's cap, left
+behind when MiniMax M3 became primary. Thinking takes its reserve out of the same
+allowance, so only ~16K remained for prose against a ~33KB brief. The run ended
+`stop=max_tokens` with the trailing plan.json block never emitted.
+"""
+import json
+
+from clawock_kcnyu.automation import brief_fallback, llm
+
+
+# The largest published pre-open.md observed to date, in bytes. Mostly CJK, which
+# is ~1 token per 3-byte character, so this is a deliberately generous token proxy.
+OBSERVED_BRIEF_BYTES = 33005
+THINKING_RESERVE = 16000  # _call_provider's cap on budget_tokens
+
+
+def _thinking_reserve(max_tokens):
+    return max(1024, min(max_tokens - 1024, THINKING_RESERVE))
+
+
+def test_prose_budget_survives_the_thinking_reserve_at_the_observed_brief_size():
+    prose_budget = brief_fallback.BRIEF_MAX_TOKENS - _thinking_reserve(
+        brief_fallback.BRIEF_MAX_TOKENS)
+
+    assert prose_budget > OBSERVED_BRIEF_BYTES, (
+        "output budget minus the thinking reserve must exceed the real brief size; "
+        "this is the exact arithmetic that failed on 2026-08-11"
+    )
+
+
+def test_the_old_32000_budget_would_still_fail_this_check():
+    """Pins the direction: the guard must reject the value that broke production."""
+    prose_budget = 32000 - _thinking_reserve(32000)
+
+    assert prose_budget < OBSERVED_BRIEF_BYTES
+
+
+def test_budget_stays_within_minimax_capacity():
+    assert brief_fallback.BRIEF_MAX_TOKENS <= llm.MINIMAX_MAX_TOKENS
+
+
+def _capture_provider_calls(monkeypatch):
+    seen = []
+
+    def fake_call(label, base_url, api_key, model, messages, max_tokens, *args, **kw):
+        seen.append({"label": label, "max_tokens": max_tokens})
+        raise RuntimeError("forced fallback")
+
+    monkeypatch.setattr(llm, "_call_provider", fake_call)
+    return seen
+
+
+def test_each_provider_is_clamped_to_its_own_cap(monkeypatch):
+    """Raising the caller's budget must not hand mimo a value it cannot serve."""
+    seen = _capture_provider_calls(monkeypatch)
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm")
+    monkeypatch.setenv("XIAOMI_API_KEY", "xm")
+
+    try:
+        llm.chat(user="hi", max_tokens=brief_fallback.BRIEF_MAX_TOKENS)
+    except RuntimeError:
+        pass
+
+    by_label = {c["label"]: c["max_tokens"] for c in seen}
+    assert by_label["minimax"] == brief_fallback.BRIEF_MAX_TOKENS
+    assert by_label["xiaomi"] == llm.XIAOMI_MAX_TOKENS
+    assert llm.XIAOMI_MAX_TOKENS < brief_fallback.BRIEF_MAX_TOKENS
+
+
+def test_brief_fallback_asks_for_the_module_budget_not_a_literal(monkeypatch):
+    """The regression was a hardcoded number at the call site; keep it out."""
+    source = (brief_fallback.__file__)
+    with open(source) as fh:
+        body = fh.read()
+
+    call = body.split("out = chat(", 1)[1].split(")", 1)[0]
+    assert "BRIEF_MAX_TOKENS" in call
+    assert "32000" not in call

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -11,6 +11,16 @@ from clawock_kcnyu.harness import brief_watchdog as watchdog  # noqa: E402
 TODAY = "2026-07-17"
 
 
+def _stub_outcome(monkeypatch, outcome="success", detail="https://example/run/1"):
+    """Neutralise the post-dispatch poll. Tests that care assert on it explicitly.
+
+    Without this the alert path would shell out to `gh` from the test suite."""
+    monkeypatch.setattr(
+        watchdog, "await_brief_fallback_outcome",
+        lambda _since, _dry_run: (outcome, detail),
+    )
+
+
 def _write_brief(ws):
     path = ws / "memory" / f"{TODAY}-pre-open.md"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -61,11 +71,13 @@ def test_missing_alert_dispatches_only_once_after_success(tmp_path, monkeypatch)
     monkeypatch.setattr(watchdog, "dispatch_brief_fallback", dispatch)
     monkeypatch.setattr(watchdog, "send_telegram", send)
     monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch)
 
     issues = ["plan_missing"]
     assert watchdog.alert_brief_missing(TODAY, False, issues) == 0
     assert watchdog.alert_brief_missing(TODAY, False, issues) == 0
-    assert calls == {"dispatch": 1, "send": 1}
+    # 2 sends on the first pass: the 09:05 miss alert, then the outcome follow-up.
+    assert calls == {"dispatch": 1, "send": 2}
 
 
 def test_dispatch_state_is_persisted_before_notification_and_timeout_is_retried(
@@ -90,10 +102,11 @@ def test_dispatch_state_is_persisted_before_notification_and_timeout_is_retried(
     monkeypatch.setattr(watchdog, "dispatch_brief_fallback", dispatch)
     monkeypatch.setattr(watchdog, "send_telegram", send)
     monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch)
 
     assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
     state = json.loads(watchdog.missing_state_path(TODAY).read_text())
-    assert calls == {"dispatch": 1, "send": 2}
+    assert calls == {"dispatch": 1, "send": 3}
     assert state["notification_attempts"] == 2
     assert state["notification_succeeded"] is True
     assert "telegram delivered" in state["notification_out"]
@@ -114,9 +127,10 @@ def test_failed_notification_can_retry_later_without_redispatch(tmp_path, monkey
     monkeypatch.setattr(watchdog, "dispatch_brief_fallback", dispatch)
     monkeypatch.setattr(watchdog, "send_telegram", send_fails)
     monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch)
 
     assert watchdog.alert_brief_missing(TODAY, False, ["plan_missing"]) == 0
-    assert calls == {"dispatch": 1, "send": 2}
+    assert calls == {"dispatch": 1, "send": 3}
     state = json.loads(watchdog.missing_state_path(TODAY).read_text())
     assert state["fallback_dispatch_succeeded"] is True
     assert state["notification_succeeded"] is False
@@ -126,7 +140,7 @@ def test_failed_notification_can_retry_later_without_redispatch(tmp_path, monkey
         lambda *_args: calls.__setitem__("send", calls["send"] + 1) or (True, "ok"),
     )
     assert watchdog.alert_brief_missing(TODAY, False, ["plan_missing"]) == 0
-    assert calls == {"dispatch": 1, "send": 3}
+    assert calls == {"dispatch": 1, "send": 5}
     state = json.loads(watchdog.missing_state_path(TODAY).read_text())
     assert state["notification_attempts"] == 3
     assert state["notification_succeeded"] is True
@@ -141,6 +155,7 @@ def test_dry_run_does_not_poison_recovery_state_or_dedupe(tmp_path, monkeypatch)
         watchdog, "send_telegram", lambda *_args: (True, "dry telegram")
     )
     monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch, "pending", "(dry-run) outcome polling skipped")
 
     assert watchdog.alert_brief_missing(TODAY, True, ["brief_missing"]) == 0
     assert not watchdog.missing_state_path(TODAY).exists()
@@ -169,9 +184,83 @@ def test_corrupt_state_suppresses_duplicate_dispatch_but_still_notifies(
         lambda *_args: calls.__setitem__("send", calls["send"] + 1) or (True, "ok"),
     )
     monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch)
 
+    # dispatched is False here, so there is no run to poll and no follow-up.
     assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
     assert calls == {"dispatch": 0, "send": 1}
     state = json.loads(path.read_text())
     assert state["fallback_dispatch_attempted"] is True
     assert "state_error" in state
+
+
+def _run_alert_capturing_messages(monkeypatch, tmp_path, outcome, detail):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    messages = []
+    monkeypatch.setattr(
+        watchdog, "dispatch_brief_fallback", lambda _dry_run: (True, "queued")
+    )
+    monkeypatch.setattr(
+        watchdog, "send_telegram",
+        lambda _target, message, _dry_run: (messages.append(message), (True, "ok"))[1],
+    )
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    _stub_outcome(monkeypatch, outcome, detail)
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+    return messages
+
+
+def test_a_failed_fallback_run_is_reported_as_failed_not_as_dispatched_ok(
+    tmp_path, monkeypatch
+):
+    """2026-08-11 regression: dispatch succeeded, the run failed 8 min later, and the
+    only thing kcn was told was a green check. The follow-up must name the failure."""
+    messages = _run_alert_capturing_messages(
+        monkeypatch, tmp_path, "failure",
+        "failure https://gh/run/1 plan.json v2 validation failed",
+    )
+
+    assert len(messages) == 2
+    first, follow_up = messages
+    # The 09:05 alert may say a dispatch happened, but must not claim it will land.
+    assert "落盘并 push" not in first
+    assert "🔴 off-host 兜底失败" in follow_up
+    assert "plan.json v2 validation failed" in follow_up
+    assert "✅" not in follow_up
+
+
+def test_unfinished_fallback_run_is_reported_as_unverified_never_as_success(
+    tmp_path, monkeypatch
+):
+    messages = _run_alert_capturing_messages(
+        monkeypatch, tmp_path, "pending", "still in_progress after 15min: https://gh/2"
+    )
+
+    follow_up = messages[-1]
+    assert "未确认" in follow_up
+    assert "这不代表成功" in follow_up
+    assert "✅" not in follow_up
+
+
+def test_successful_fallback_run_is_the_only_case_that_claims_the_brief_exists(
+    tmp_path, monkeypatch
+):
+    messages = _run_alert_capturing_messages(
+        monkeypatch, tmp_path, "success", "https://gh/run/3"
+    )
+
+    follow_up = messages[-1]
+    assert follow_up.startswith("✅ off-host 兜底已完成")
+    assert "https://gh/run/3" in follow_up
+
+
+def test_outcome_is_persisted_so_a_later_pass_can_see_what_happened(
+    tmp_path, monkeypatch
+):
+    _run_alert_capturing_messages(
+        monkeypatch, tmp_path, "failure", "failure https://gh/run/4"
+    )
+
+    state = json.loads(watchdog.missing_state_path(TODAY).read_text())
+    assert state["fallback_outcome"] == "failure"
+    assert "https://gh/run/4" in state["fallback_outcome_detail"]


### PR DESCRIPTION
Closes #480.

2026-08-11 两条路径都没产出简报。本机 08:00 那条是 MiniMax 30s 响应头 deadline + 同源 fallback 链
（需要动 provider 链，未在本 PR 范围内）。这个 PR 修 off-host 兜底这条。

## 1. `max_tokens=32000` 卡的是小米的上限

调用点的注释直说了它的来历：

    # Use full mimo-v2.5-pro cap (32K) + thinking enabled for brief depth.
    out = chat(..., max_tokens=32000, ...)

2026-06-16 主力换成 MiniMax M3 之后这行没跟着改。`llm.py` 里其实早就知道真实上限
（`MINIMAX_MAX_TOKENS = 131072`），但 `chat()` 里的 `min(max_tokens, MINIMAX_MAX_TOKENS)`
永远不触发——真正卡住的是调用点写死的 32000。

而且这不只是"保守"，是致命：`chat()` 默认 `thinking_disabled=False`，`_call_provider` 于是从
**同一份输出预算**里切走 `min(max_tokens - 1024, 16000) = 16000` 给推理，正文只剩约 16000。
简报本身跑到 33KB。当天报文：

    minimax: 102644 in / 32000 out (stop=max_tokens)
    plan.json v2 validation failed: decisions must be a non-empty list

正文被腰斩，末尾的 ```json``` plan block 根本没输出，校验按 2026-07-16 定的"先校验后落盘"
拒绝写入（这个行为本身是对的）。结果是唯一的自动补救路径**在物理上不可能**产出完整简报。

**改法**：`chat()` 改成按 provider 各自钳位（新增 `XIAOMI_MAX_TOKENS`），这样抬高调用方预算
不会把一个 mimo 服务不了的值递给它；调用点改用 `BRIEF_MAX_TOKENS = 96000`。

**实测**（打真实端点，不是只看文档）：

    max_tokens=96000 → HTTP 200, out=47136, stop_reason=end_turn, 599s

47136 远超 32000 且自然收尾，说明这个预算是真被兑现的，不是"接受了但不兑现"。
官方 API reference 只给 M3 context window 1,000,000 并注明 max token 指输入+输出总和，
没有单列输出上限；96000 在 `MINIMAX_MAX_TOKENS` 和实测之下都安全。

## 2. dispatch 之后没有人看结局

`dispatch_brief_fallback` 返回的是 `gh workflow run` 的 exit status，也就是
**「dispatch 这个动作被接受了」**。09:05 的告警却把它渲染成：

    ✅ 已自动 dispatch off-host 兜底 (brief-fallback.yml)，约 5-10 分钟落盘并 push。

当天 dispatch 确实被接受，run 8 分钟后 failure。整条链已经死透，而 kcn 收到的最后一个信号
是绿勾。检测到了 miss 然后报一个编造的成功，比不检测更糟。

**改法**：新增 `await_brief_fallback_outcome()`，轮询被 dispatch 的那次 run 到结束，
再补发一条说明它**实际**做了什么。只有 concluded success 才声称简报存在；超时或查不到
一律报「未确认」并明说「这不代表成功」。

一个自己 review 时抓到的坑，已修并有测试钉死：dispatch 时间戳写的是 HKT
（`...T09:05:04+08:00`），GitHub 的 `createdAt` 是 UTC（`...T01:05:04Z`）——
按字符串比会把刚 dispatch 的那次 run 判成"早于 dispatch"而滤掉，poller 将天天返回 unknown。
现在按时刻比较。

**没有新增 crontab 行**，所以 `cron_contract` 的 `command_contains: ['brief_watchdog.py']`
唯一性闸不受影响（那个闸是对的，不放松）。

## 测试

新增 17 条，全部做了变异验证（不是装饰性的）：

| 变异 | 结果 |
|---|---|
| `BRIEF_MAX_TOKENS` 退回 32000 | 2 条失败 |
| 超时当成 `success` | 1 条失败 |
| 去掉 xiaomi 钳位 | 1 条失败 |
| 时区比较退回字符串 | 1 条失败（0.48s，不是挂住） |

轮询测试注入假时钟，15 分钟预算不烧墙钟。

worktree 全套：**327 passed, 1 failed**。唯一的红是
`tests/test_context_contract.py::test_every_command_the_injected_context_names_exists`，
把本 PR 改动 stash 掉后在 `origin/master` 上**一模一样地失败** ⇒ 与本 PR 无关，
本地 `python -m clawock --help` 解析到的不是这个 worktree 的包。以 CI 为准。
