### PR TITLE
fix: harden intraday evidence provenance

### DIFF
--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -24,8 +24,9 @@ clawock intraday preflight --market {{market}}
 **Step 2.5 - 状态横幅 sidecar（dashboard 顶部横幅 + Movers 归因，别跳过）**
 写 `memory/.tmp/intraday-insights-{今天YYYY-MM-DD}.json`（完整规范见 `skills/_shared/intraday-status-sidecar.md`）：
 ```json
-{"generated_at": "<ISO8601 UTC>", "status_banner": "≤50字：regime+今日盈亏主来源+最该盯的一件事", "movers": {"代码": "≤40字归因+操作含义"}}
+{"status_banner": "≤50字：regime+今日盈亏主来源+最该盯的一件事", "movers": {"代码": "≤40字归因+操作含义"}}
 ```
+- 模型只写 `status_banner` / `movers`；`generated_at` 由 postflight harness 写入真实 UTC，禁止自行生成时间。
 - `movers` 覆盖 context 里 anomalies/today_movers 的每个票；杠杆 ETF 点明"杠杆放大"
 - 只用 context 真实数字，不确定催化就写"无明确个股催化，纯 beta"，不编造
 - 只输出文本，绝不写任何 key；写完再走 Step 3

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -39,7 +39,7 @@ the existing single publisher exposes without introducing another git writer.
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from clawock.harness.validation import (
@@ -62,6 +62,7 @@ from ._watchdog_common import resolve_wechat_target, send_wechat, cosend_telegra
 
 from clawock.workspace import workspace_root
 from clawock.market_data import sessions as trading_calendar
+from clawock.safe_io import safe_write_json
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
@@ -139,6 +140,32 @@ def input_error(market, err):
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 2
+
+
+def normalize_intraday_insights(path, generated_at=None):
+    """Replace model metadata with the current harness generation timestamp.
+
+    The model owns narrative only. Malformed/missing sidecars are dashboard
+    degradation, never a reason to suppress the deterministic market report.
+    """
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text())
+        if not isinstance(payload, dict):
+            raise ValueError('top-level JSON must be an object')
+        canonical = {
+            'generated_at': generated_at or datetime.now(timezone.utc).isoformat(
+                timespec='seconds').replace('+00:00', 'Z'),
+            'status_banner': payload.get('status_banner'),
+            'movers': payload.get('movers'),
+        }
+        safe_write_json(str(path), canonical)
+        return True
+    except Exception as exc:
+        print(f'warn: {path.name} 解析/规范化失败 — dashboard status_banner 将忽略: '
+              f'{exc}', file=sys.stderr)
+        return False
 
 
 def assemble_message(ctx, prose):
@@ -374,10 +401,15 @@ def main(argv=None):
     # dropped Step 2.5 and nothing noticed for 6 days. A missing narrative
     # sidecar must never block/clutter the report (kcn: no per-cron alerts),
     # but it should leave a visible trace in the cron run log + result JSON.
-    insights_path = TMP / f'intraday-insights-{datetime.now().strftime("%Y-%m-%d")}.json'
-    insights_written = insights_path.exists()
+    sidecar_date = ctx.get('date')
+    try:
+        datetime.strptime(str(sidecar_date), '%Y-%m-%d')
+    except (TypeError, ValueError):
+        sidecar_date = datetime.now().strftime('%Y-%m-%d')
+    insights_path = TMP / f'intraday-insights-{sidecar_date}.json'
+    insights_written = normalize_intraday_insights(insights_path)
     if not insights_written:
-        print(f'warn: {insights_path.name} 未写 — dashboard status_banner 将过期隐藏 '
+        print(f'warn: {insights_path.name} 缺失或不可用 — dashboard status_banner 将过期隐藏 '
               f'(SKILL Mode 7 Step 2.5 / cron payload Step 2.5)', file=sys.stderr)
 
     # The banner counts and lists ESCALATING issues only; advisory findings get

--- a/skills/_shared/intraday-status-sidecar.md
+++ b/skills/_shared/intraday-status-sidecar.md
@@ -8,11 +8,12 @@
 写 `memory/.tmp/intraday-insights-{YYYY-MM-DD}.json`：
 ```json
 {
-  "generated_at": "{ISO8601, UTC}",
   "status_banner": "一句话 ≤50字：regime + 今日盈亏主来源 + 最该盯的一件事（盯盘提醒口吻）",
   "movers": {"代码": "一行归因 ≤40字：催化 / 板块beta / 纯杠杆放大噪音 + 操作含义(追/不追/观望)"}
 }
 ```
+- **模型只写 `status_banner` / `movers` 文本**；`generated_at` 由 postflight harness
+  以当前真实 UTC 写入，禁止模型生成或猜测基础设施时间。
 - `movers` 覆盖 context 里 `anomalies` / today_movers 的**每个**票；**杠杆 ETF 要点明"杠杆放大"、区分标的真涨还是纯 beta**（本市场杠杆 ticker 见调用方 Step 2.5）。
 - **催化优先引 `context.mover_news`**：该票有 `signal=interrupt` 的条目就用它的标题要点 + `age_minutes` 写归因；`halts` 命中先写停牌；`no_recent_filing` / `index_fund_no_issuer` / `degraded` 各自照实说（分别是「无一手公告」「指数基金无发行人」「催化源未取到」）。
 - **只用 context.json 的真实数字**；不确定催化就写"无明确个股催化，纯 beta"，**不编造财报/新闻**。

--- a/src/clawock/harness/validation.py
+++ b/src/clawock/harness/validation.py
@@ -88,6 +88,24 @@ _CURRENCY_CLAIM = re.compile(
 # Checked against 23 real sent reports: that one character was every false
 # positive. `~` is what the observed defect ("+0.3~-0.4%") actually used.
 _RANGE = re.compile(rf'({_NUM})\s*(?:~|～|—|–|到|至)\s*({_NUM})\s*%')
+_UNIT_NUM = r'[+-]?\d[\d,]*(?:\.\d+)?'
+_UNIT_CLAIMS = {
+    'percent': re.compile(rf'({_UNIT_NUM})\s*[%％]'),
+    'pp': re.compile(rf'({_UNIT_NUM})\s*(?:pp\b|个百分点|百分点)', re.IGNORECASE),
+    'multiple': re.compile(rf'({_UNIT_NUM})\s*(?:[xX×](?![A-Za-z])|倍)'),
+    'sigma': re.compile(rf'({_UNIT_NUM})\s*(?:σ|sigma\b)', re.IGNORECASE),
+}
+_UNIT_LABELS = {'percent': '%', 'pp': 'pp', 'multiple': 'x', 'sigma': 'σ'}
+_UNIT_KEY_HINTS = {
+    'percent': re.compile(r'(?:^|_)(?:pct|percent|percentage)(?:_|$)'),
+    'pp': re.compile(r'(?:^|_)(?:pp|percentage_points?)(?:_|$)'),
+    'multiple': re.compile(r'(?:^|_)(?:multiple|multiplier|leverage|leverage_ratio)(?:_|$)'),
+    'sigma': re.compile(r'(?:^|_)(?:sigma|z_?score\d*)(?:_|$)'),
+}
+# A hypothetical percentage is not a claim about current evidence. Keep the
+# long-standing low-noise boundary: "若再跌 2%" may be scenario prose, while an
+# asserted "今日 -2%" must quote the context.
+_HYPOTHETICAL = re.compile(r'(?:若|如果|假如|一旦|假设|情景|scenario|\bif\b)', re.IGNORECASE)
 MAX_NUMERIC_SAMPLES = 4
 # Only book-scale currency figures are checked. US price talk is conventionally
 # written with the symbol — "跌破 $65，下一支撑 $60" is a level, not a claim about
@@ -139,8 +157,49 @@ def _context_numbers(ctx):
     return seen
 
 
+def _context_unit_numbers(ctx):
+    """Numbers with the market unit the context actually attaches to them.
+
+    A flat number set lets an unrelated ``2.3%`` authorize an invented
+    ``2.3x``. Strings carry their units explicitly; numeric JSON fields carry a
+    unit only when their key names it (``move_pct``, ``gap_pp``, ``zscore20``).
+    """
+    seen = {unit: set() for unit in _UNIT_CLAIMS}
+
+    def add(unit, value):
+        number = _as_number(value)
+        if number is not None:
+            seen[unit].add(round(abs(number), 4))
+
+    def walk(node, key=''):
+        if isinstance(node, dict):
+            for child_key, value in node.items():
+                walk(value, str(child_key).lower())
+        elif isinstance(node, (list, tuple)):
+            for value in node:
+                walk(value, key)
+        elif isinstance(node, bool):
+            return
+        elif isinstance(node, (int, float)):
+            for unit, hint in _UNIT_KEY_HINTS.items():
+                if hint.search(key):
+                    add(unit, node)
+        elif isinstance(node, str):
+            for unit, pattern in _UNIT_CLAIMS.items():
+                for raw in pattern.findall(node):
+                    add(unit, raw)
+
+    walk(ctx)
+    return seen
+
+
+def _is_hypothetical_percent(text, start):
+    clause_start = max(text.rfind(mark, 0, start) for mark in '\n。！？；;') + 1
+    return bool(_HYPOTHETICAL.search(text[max(clause_start, start - 16):start]))
+
+
 def check_numeric_claims(text, ctx):
-    """Flag share/currency magnitudes the context never states, and impossible
+    """Flag unit-bearing magnitudes the context never states, and impossible
     percentage ranges.
 
     Returns at most ONE issue on purpose. Every postflight turns a small number of
@@ -150,6 +209,7 @@ def check_numeric_claims(text, ctx):
     strictly worse failure. One aggregated line keeps the gate advisory.
     """
     known = _context_numbers(ctx)
+    known_by_unit = _context_unit_numbers(ctx)
     unverified = []
 
     def check(value, label):
@@ -165,6 +225,18 @@ def check_numeric_claims(text, ctx):
         amount = _as_number(raw, magnitude)
         if amount is not None and abs(amount) >= MIN_CHECKED_AMOUNT:
             check(amount, f'{raw}{magnitude or ""}')
+
+    for unit, pattern in _UNIT_CLAIMS.items():
+        for match in pattern.finditer(text):
+            if unit == 'percent' and _is_hypothetical_percent(text, match.start()):
+                continue
+            raw = match.group(1)
+            value = _as_number(raw)
+            if value is None or round(abs(value), 4) in known_by_unit[unit]:
+                continue
+            label = f'{raw}{_UNIT_LABELS[unit]}'
+            if label not in unverified:
+                unverified.append(label)
 
     impossible = [
         f'{lo}~{hi}%' for lo, hi in _RANGE.findall(text)

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -194,6 +194,46 @@ def test_main_delivers_block_plus_prose_on_the_happy_path(run_main, sent):
         assert line in body
 
 
+def test_main_replaces_model_authored_future_sidecar_time(
+    run_main, sent, tmp_path
+):
+    """The 2026-08-11 trajectory wrote local 10:02 with a UTC offset (+8h).
+    Postflight must persist the prose but never that model-authored clock."""
+    path = tmp_path / 'intraday-insights-2026-08-11.json'
+    future = '2026-08-11T10:02:00+00:00'
+    path.write_text(json.dumps({
+        'generated_at': future,
+        'status_banner': 'low 12% 区间底，先观察',
+        'movers': {'02208': '无明确个股催化，观望'},
+        'model_metadata': 'must not survive',
+    }, ensure_ascii=False))
+
+    rc, out = run_main(
+        PROSE, context_id='abc123def456',
+        ctx=_ctx(date='2026-08-11', generated_at='2026-08-11T10:01:59'),
+    )
+
+    persisted = json.loads(path.read_text())
+    assert rc == 0 and out['insights_sidecar'] is True
+    assert persisted['generated_at'] != future
+    assert persisted['generated_at'].endswith('Z')
+    assert set(persisted) == {'generated_at', 'status_banner', 'movers'}
+    assert persisted['status_banner'] == 'low 12% 区间底，先观察'
+    assert '▎我的看法' in sent['messages'][0]
+
+
+def test_malformed_sidecar_never_suppresses_delivery(run_main, sent, tmp_path):
+    path = tmp_path / 'intraday-insights-2026-08-11.json'
+    path.write_text('{"status_banner":')
+
+    rc, out = run_main(
+        PROSE, context_id='abc123def456', ctx=_ctx(date='2026-08-11'))
+
+    assert rc == 0 and out['status'] == 'pass'
+    assert out['insights_sidecar'] is False
+    assert '▎我的看法' in sent['messages'][0]
+
+
 def test_publish_failure_is_loud_after_report_delivery(
     run_main, sent, pf, monkeypatch
 ):

--- a/tests/test_numeric_claims.py
+++ b/tests/test_numeric_claims.py
@@ -12,6 +12,7 @@ kind of green.
 """
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -19,7 +20,7 @@ import pytest
 
 
 WS = Path(__file__).resolve().parents[1]
-HARNESS = str(WS / "scripts" / "harness")
+INSTANCE_SRC = str(WS / "instances" / "kcnyu" / "src")
 
 # The 09:30 港股开盘报告 context, reduced to the fields prose quotes from.
 CTX = {
@@ -37,8 +38,8 @@ CTX = {
 
 @pytest.fixture(scope="module")
 def hc():
-    if HARNESS not in sys.path:
-        sys.path.insert(0, HARNESS)
+    if INSTANCE_SRC not in sys.path:
+        sys.path.insert(0, INSTANCE_SRC)
     return pytest.importorskip("clawock.harness.validation")
 
 
@@ -81,8 +82,9 @@ def test_prices_without_a_unit_are_not_policed(hc):
     assert hc.check_numeric_claims("07226 若跌破 4.00 支撑位考虑减仓。", CTX) == []
 
 
-def test_a_well_formed_range_is_not_flagged(hc):
-    assert hc.check_numeric_claims("同业今日在 0.2~0.5% 之间。", CTX) == []
+def test_a_well_formed_range_still_requires_context_provenance(hc):
+    issue = hc.check_numeric_claims("同业今日在 0.2~0.5% 之间。", CTX)
+    assert issue and "context 里没有的数字" in issue[0]
 
 
 def test_gate_emits_at_most_one_issue(hc):
@@ -106,9 +108,9 @@ def test_gate_cannot_turn_a_delivered_report_into_a_blocked_one(hc, module_name)
     `fail` — not delivered — while the same two without it were `warn`. An
     advisory line must never be able to cost kcn a report.
     """
-    if HARNESS not in sys.path:
-        sys.path.insert(0, HARNESS)
-    post = pytest.importorskip(module_name)
+    if INSTANCE_SRC not in sys.path:
+        sys.path.insert(0, INSTANCE_SRC)
+    post = importlib.import_module(f'clawock_kcnyu.harness.{module_name}')
     gate = _gate_issue(hc)
     soft = "报告长度 3200 字 > 3000 软上限 (warn)"
     thin = '"▎我的看法" 段仅 40 字，太敷衍'
@@ -119,9 +121,9 @@ def test_gate_cannot_turn_a_delivered_report_into_a_blocked_one(hc, module_name)
 
 
 def test_advisory_never_masks_a_real_failure(hc):
-    if HARNESS not in sys.path:
-        sys.path.insert(0, HARNESS)
-    post = pytest.importorskip("intraday_postflight")
+    if INSTANCE_SRC not in sys.path:
+        sys.path.insert(0, INSTANCE_SRC)
+    post = importlib.import_module('clawock_kcnyu.harness.intraday_postflight')
     # A critical issue must still fail with the advisory line alongside it.
     assert post.categorize(['缺段标记 "▎我的看法"', _gate_issue(hc)]) == "fail"
     # And a genuine over-budget pile must still fail.
@@ -144,9 +146,9 @@ def test_known_blind_spot_a_real_number_on_the_wrong_subject(hc):
 
 @pytest.mark.parametrize("module_name", ["report_postflight", "intraday_postflight"])
 def test_both_postflights_run_the_gate(module_name):
-    if HARNESS not in sys.path:
-        sys.path.insert(0, HARNESS)
-    module = pytest.importorskip(module_name)
+    if INSTANCE_SRC not in sys.path:
+        sys.path.insert(0, INSTANCE_SRC)
+    module = importlib.import_module(f'clawock_kcnyu.harness.{module_name}')
     prose = (
         "🇭🇰 港股盯盘 | 07/27 09:33 HKT\n▎我的看法\n"
         "恒指 25,031、恒科 4,654，07226 现价 3.34 是纪律 swap 标的，今日不追高；"
@@ -187,11 +189,35 @@ def test_a_numeric_ticker_followed_by_a_negative_percent_is_not_a_range(hc):
     07226 to 3.5 and was every single false positive the gate produced. The
     observed real defect used `~` ("+0.3~-0.4%"), which still trips.
     """
-    assert hc.check_numeric_claims("07226 -3.5% 领跌，03032 -2.0%。", CTX) == []
-    assert hc.check_numeric_claims("恒科 -2.04% → 2x 的 07226 放大到 -3.9%。", CTX) == []
+    ctx = dict(CTX, exact_unit_literals=["-3.5%", "-2.0%", "-2.04%", "2x", "-3.9%"])
+    assert hc.check_numeric_claims("07226 -3.5% 领跌，03032 -2.0%。", ctx) == []
+    assert hc.check_numeric_claims("恒科 -2.04% → 2x 的 07226 放大到 -3.9%。", ctx) == []
     assert hc.check_numeric_claims("两支 ETF 同步 +0.3~-0.4%。", CTX)
 
 
 def test_a_backwards_range_is_still_caught(hc):
     assert hc.check_numeric_claims("波动在 5~1% 之间。", CTX)
-    assert hc.check_numeric_claims("波动在 1~5% 之间。", CTX) == []
+    assert hc.check_numeric_claims("波动在 1~5% 之间。", CTX)
+
+
+def test_market_units_require_unit_specific_context_provenance(hc):
+    ctx = {
+        "move_pct": -1.44,
+        "divergence_signal": "gap +9.0pp",
+        "instrument": "2x HSTECH",
+        "rationale": "z+2.1σ EXTREME",
+        # Same digits under another unit must not authorize a calculated multiple.
+        "peer_pct": 2.3,
+    }
+    exact = "07226 -1.44%，跑输同业 9pp；产品 2× 杠杆，信号 2.1σ。"
+    assert hc.check_numeric_claims(exact, ctx) == []
+
+    issue = hc.check_numeric_claims("07226 -1.44%，杠杆放大约 2.3x。", ctx)
+    assert len(issue) == 1
+    assert "2.3x" in issue[0] and hc.ADVISORY_MARK in issue[0]
+
+
+def test_absent_market_units_stay_one_advisory(hc):
+    issue = hc.check_numeric_claims("今日 +8.8%，背离 7pp，放大 3x，偏离 4σ。", CTX)
+    assert len(issue) == 1
+    assert all(label in issue[0] for label in ("+8.8%", "7pp", "3x", "4σ"))


### PR DESCRIPTION
## What changed

- normalize the intraday insights sidecar before dashboard publication, retaining only model-owned narrative and stamping a harness-owned UTC `generated_at`
- keep missing or malformed sidecars warn-only so deterministic report delivery continues
- extend the shared numeric provenance advisory to `%`, `pp`, `x`/`×`, and `σ`, with unit-specific context matching
- update the shared skill and canonical cron payload so the model is no longer instructed to author infrastructure time
- repair the numeric contract tests' stale import path so both real postflight integrations execute instead of skipping

## Evidence

- replaying trajectory `993d3509-08fb-43be-834a-91f13087f5b7` now produces exactly one advisory: `2.3x`; all context-backed percentage and pp claims pass
- the +8h model timestamp is overwritten with UTC before `publish_data_plane()` runs
- malformed sidecar JSON still delivers the report and records `insights_sidecar=false`

## Verification

- `pytest -q tests/test_numeric_claims.py tests/test_intraday_prose_assembly.py tests/test_sync_cron_payloads.py tests/test_cron_contracts.py` — 73 passed
- mutation checks: replacing unit-specific matching with the flat number set fails the `2.3x` regression; trusting the model timestamp fails the future-time regression
- required remote checks must pass before merge

Closes #482
Closes #483
