### PR TITLE
feat: publish GitHub releases after PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,3 +84,35 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: ${{ inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
+
+  github-release:
+    # A GitHub Release is a public claim that the version exists. Create it only
+    # for a real version tag, and only after PyPI accepted that exact artifact.
+    # TestPyPI workflow_dispatch runs have a branch ref and deliberately skip it.
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Render the public-package changelog section
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          python3 ops/publish/release_notes.py "$version" --output /tmp/release-notes.md
+
+      - name: Publish GitHub Release with the verified distributions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --verify-tag \
+            --title "clawock $GITHUB_REF_NAME" \
+            --notes-file /tmp/release-notes.md

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -47,6 +47,11 @@ The workflow refuses a tag that disagrees with `pyproject.toml`, because a
 mismatch publishes a version nobody asked for under a name the changelog already
 uses for something else.
 
+After real PyPI publication succeeds, the same workflow creates the matching
+GitHub Release, attaches the verified sdist/wheel and renders only that version's
+`CHANGELOG.md` section plus its versioned PyPI link. TestPyPI dispatches do not
+create a public GitHub Release, and a failed PyPI upload cannot leave one behind.
+
 `tests/test_versions_agree.py` refuses a bump whose `CHANGELOG.md` entry is
 missing, which is why the entry belongs in the same PR as the bump. Writing it
 afterwards means the artifact is already on PyPI describing itself as something
@@ -57,6 +62,8 @@ which is what 0.1.1 cost.
 
 - `twine check` on both the sdist and the wheel.
 - The tag matches the packaged version.
+- The matching changelog section exists exactly once and becomes the GitHub
+  Release notes; the built sdist/wheel are attached only after PyPI succeeds.
 - A clean virtualenv installs the wheel and completes one real run —
   `clawock init` → `clawock run prepare` → `clawock run publish` — under
   `env -i`, with no checkout, no OpenClaw, no KCNyu workspace and no inherited

--- a/ops/publish/release_notes.py
+++ b/ops/publish/release_notes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Render one public package release from the matching CHANGELOG section.
+
+The repository contains high-frequency private-instance/runtime commits that do
+not ship in the ``clawock`` distribution. GitHub's generated release notes would
+therefore describe the wrong product. ``CHANGELOG.md`` is the existing public
+package boundary; this tool makes the GitHub Release use that same boundary.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def changelog_section(text: str, version: str) -> str:
+    heading = re.compile(
+        rf"^## \[{re.escape(version)}\](?:\s+[—-]\s+.*)?$", re.MULTILINE)
+    matches = list(heading.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(
+            f"CHANGELOG must contain exactly one [{version}] heading; "
+            f"found {len(matches)}")
+    start = matches[0].end()
+    remainder = text[start:]
+    boundaries = [match.start() for pattern in (r"^##\s+", r"^\[[^\]]+\]:")
+                  if (match := re.search(pattern, remainder, re.MULTILINE))]
+    end = start + min(boundaries) if boundaries else len(text)
+    body = text[start:end].strip()
+    if not body:
+        raise ValueError(f"CHANGELOG [{version}] section is empty")
+
+    # Keep reference-style issue/PR links working, but do not drag every other
+    # version's comparison/release URL into this version's notes.
+    definitions = dict(re.findall(
+        r"^\[([^\]]+)\]:\s*(\S+)\s*$", text, re.MULTILINE))
+    used = dict.fromkeys(re.findall(r"\[([^\]]+)\](?!\()", body))
+    refs = [f"[{label}]: {definitions[label]}" for label in used
+            if label in definitions]
+    return body + (("\n\n" + "\n".join(refs)) if refs else "")
+
+
+def release_notes(text: str, version: str) -> str:
+    pypi = f"https://pypi.org/project/clawock/{version}/"
+    return (
+        f"Install from [PyPI]({pypi}):\n\n"
+        f"```console\npython -m pip install clawock=={version}\n```\n\n"
+        f"{changelog_section(text, version)}\n"
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        notes = release_notes(args.changelog.read_text(encoding="utf-8"), args.version)
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: cannot render GitHub release notes: {exc}", file=sys.stderr)
+        return 2
+    if args.output:
+        args.output.write_text(notes, encoding="utf-8")
+    else:
+        print(notes, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_release_contract.py
+++ b/tests/test_github_release_contract.py
@@ -1,0 +1,46 @@
+"""A PyPI version must leave a matching, honest first-party release page."""
+from pathlib import Path
+
+import pytest
+
+from ops.publish.release_notes import changelog_section, release_notes
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_release_notes_use_only_the_matching_public_changelog_section():
+    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    notes = release_notes(text, "0.1.1")
+
+    assert "https://pypi.org/project/clawock/0.1.1/" in notes
+    assert "python -m pip install clawock==0.1.1" in notes
+    assert "six broken images" in notes
+    assert "https://github.com/KCNyu/clawock/pull/468" in notes
+    assert "First release" not in notes
+    assert "[Unreleased]" not in notes
+    assert "compare/v0.1.1...HEAD" not in notes
+
+
+@pytest.mark.parametrize("text", [
+    "## [Unreleased]\nNothing yet.\n",
+    "## [1.2.3]\none\n\n## [1.2.3]\ntwo\n",
+    "## [1.2.3] — 2026-08-11\n\n## [1.2.2]\nolder\n",
+])
+def test_missing_ambiguous_or_empty_changelog_sections_fail(text):
+    with pytest.raises(ValueError):
+        changelog_section(text, "1.2.3")
+
+
+def test_github_release_is_downstream_of_real_pypi_and_attaches_artifacts():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_job = workflow.split("\n  github-release:\n", 1)[1]
+
+    assert "needs: publish" in release_job
+    assert "if: startsWith(github.ref, 'refs/tags/v')" in release_job
+    assert "contents: write" in release_job
+    assert "ops/publish/release_notes.py" in release_job
+    assert "actions/download-artifact" in release_job
+    assert 'gh release create "$GITHUB_REF_NAME" dist/*' in release_job
+    assert workflow.count("contents: write") == 1


### PR DESCRIPTION
## What changed

- create a GitHub Release only after a tag-triggered real-PyPI publication succeeds
- attach the exact sdist/wheel produced and verified by the release build
- render release notes from the matching public-package `CHANGELOG.md` section, with a versioned PyPI install link
- keep `contents: write` scoped to the downstream GitHub Release job; TestPyPI/branch dispatches skip it
- document the release contract and add focused workflow/extractor tests

## Why this is the SEO/GEO action

Search Console still reports one page with impressions and a sitemap Google has never downloaded. More onsite metadata has no distribution path. PyPI now has 0.1.0/0.1.1, but GitHub has zero Releases and the changelog's 0.1.0 release link is empty. Version-specific GitHub Release pages are crawlable first-party references with canonical artifacts and package-only narrative.

## Verification

- `pytest -q tests/test_github_release_contract.py tests/test_versions_agree.py tests/test_examples_are_executed.py tests/test_pr_publish_gate_contract.py` — 30 passed, 1 existing optional skip
- rendered 0.1.0 and 0.1.1 notes locally; each contains only its own changelog body and referenced issue/PR links
- required remote checks must pass before merge

After merge, backfill releases for the existing v0.1.0/v0.1.1 tags from the files PyPI serves, verifying each SHA256 against PyPI JSON before upload.

Closes #486
