### PR TITLE
Fix capability false positives after provider failures

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -518,6 +518,12 @@ def _cron_jobs_without_prompt_report(sessions):
     5 files / 29 skills / 34 tools while `Memory Dreaming Promotion` produced no
     report at all, and the profile-level check averaged it away.
 
+    A per-job session entry is replaced when a run starts, before the runtime
+    attaches its prompt report. It also stays report-less when the provider
+    fails before responding. Both states are explicit in the authoritative cron
+    listing; neither is evidence of capability loss. Successful jobs, jobs with
+    no history, and jobs with an unknown outcome still have to be named.
+
     Returns names rather than a count, and returns empty when the job list
     cannot be read — an unreadable schedule is not evidence that every job is
     covered, but it is also not this check's failure to report.
@@ -539,8 +545,18 @@ def _cron_jobs_without_prompt_report(sessions):
     for job in listing.get('jobs', []) or []:
         if not job.get('enabled'):
             continue
-        if str(job.get('id')) not in reported:
-            missing.append(str(job.get('name') or job.get('id'))[:28])
+        if str(job.get('id')) in reported:
+            continue
+        state = job.get('state') if isinstance(job.get('state'), dict) else {}
+        if job.get('status') == 'running' or state.get('runningAtMs') is not None:
+            continue
+        last_status = str(
+            state.get('lastStatus') or state.get('lastRunStatus') or '').lower()
+        if last_status in {
+                'error', 'failed', 'failure', 'timeout', 'timed_out',
+                'cancelled', 'canceled', 'skipped'}:
+            continue
+        missing.append(str(job.get('name') or job.get('id'))[:28])
     return sorted(missing)
 
 

--- a/tests/test_context_capability_not_vacuous.py
+++ b/tests/test_context_capability_not_vacuous.py
@@ -157,6 +157,55 @@ def test_an_enabled_job_with_no_report_is_named(monkeypatch):
     assert missing == ['Dreaming']
 
 
+def test_a_provider_failed_run_is_not_mislabeled_as_capability_loss(monkeypatch):
+    """#490: a response-header timeout replaces the job session with an entry
+    that has no report. The scheduler already says the run failed; blaming
+    context assembly as well makes the capability warning cry wolf."""
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{
+            'id': 'a', 'name': 'Provider timeout', 'enabled': True,
+            'state': {'lastStatus': 'error'},
+        }]})
+    assert sc._cron_jobs_without_prompt_report({
+        'agent:main:cron:a': {'updatedAt': 20},
+    }) == []
+
+
+def test_a_successful_job_without_a_report_is_still_named(monkeypatch):
+    """A successful run had a chance to assemble context. No report after that
+    remains the capability gap this gate exists to expose."""
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{
+            'id': 'a', 'name': 'Dreaming', 'enabled': True,
+            'state': {'lastStatus': 'ok'},
+        }]})
+    assert sc._cron_jobs_without_prompt_report({
+        'agent:main:cron:a': {'updatedAt': 20},
+    }) == ['Dreaming']
+
+
+def test_a_running_job_waits_for_its_report(monkeypatch):
+    """The runtime replaces the per-job session at run start and attaches the
+    report later. That bounded in-flight window is not evidence of loss."""
+    import ops.system_check as sc
+
+    monkeypatch.setattr(
+        'clawock.providers.openclaw.cron_cli_json',
+        lambda argv: {'jobs': [{
+            'id': 'a', 'name': 'In flight', 'enabled': True,
+            'state': {'runningAtMs': 1786429918631, 'lastStatus': 'error'},
+        }]})
+    assert sc._cron_jobs_without_prompt_report({
+        'agent:main:cron:a': {'updatedAt': 20},
+    }) == []
+
+
 def test_a_disabled_job_is_not_demanded(monkeypatch):
     """Only what is scheduled has to be observable."""
     import ops.system_check as sc


### PR DESCRIPTION
Closes #490.

## What changed

- Treat an in-flight cron session as pending rather than as evidence that agent
  context disappeared.
- Treat an explicitly failed/cancelled/skipped latest scheduler outcome as an
  explained absence of `systemPromptReport`.
- Keep successful, unknown and no-history jobs fail-visible, so the per-job gate
  from #473 does not become vacuous.

The check uses the `state` included in the same authoritative `cron list`
response it already reads. It adds no per-job CLI calls and does not infer an
outcome from timestamps.

## Evidence

At 14:31 HKT the live gate named three jobs. `盘中盯盘` had a MiniMax
response-header timeout and no report, then retried successfully at 14:35 and
immediately gained a report. `盘前深度简报` had the same provider timeout but no
later run today, so the old gate would mislabel it until tomorrow.

With this branch against the same live runtime, `ops/system_check.py` names only
the known successful/no-report job:

```
1 enabled cron job(s) produce no prompt report ... Memory Dreaming Promotion
```

## Verification

- `pytest -q tests/test_context_capability_not_vacuous.py tests/test_system_check_context_capability.py` — 18 passed
- `python3 ops/system_check.py` — 0 critical; capability warning reduced to the one real unknown
- `git diff --check`
