### PR TITLE
Re-run the brief on-host when its only scheduled attempt already failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ otherwise, so a release cannot ship an entry that was never written.
 
 ## [Unreleased]
 
+### Added
+
+- `clawock.providers.openclaw.run_cron_job(job_id)` asks the runtime to run a scheduled job now, reporting `(ok, output)` like the rest of the adapter instead of raising. It exists because the runtime's transient retry is budgeted by a `consecutiveErrors` counter that only resets on success, so a job scheduled once a day loses its retry after three bad days and needs recovery driven from outside the scheduler (#493).
+
 ### Changed
 
 - The command catalog the README links moved to `docs/reference/commands.md` — named after the deleted `scripts/` directory before — and its inventory is now generated from the installed-command registries instead of being hand-maintained, so it lists every command the two distributions install (#489). The old path stays as a pointer because published releases link it.

--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -264,6 +264,71 @@ def send_telegram(target, message, dry_run):
     return result.status != 'failed', result.detail
 
 
+BRIEF_CONTRACT_MODE = 'daily-deep-brief'
+# The runtime marks a run failed with these; anything else (including a missing
+# status) is not evidence that the attempt is over.
+FAILED_RUN_STATUSES = {'error', 'failed', 'failure', 'timeout', 'timed_out',
+                       'cancelled', 'canceled'}
+
+
+def brief_cron_job():
+    """The live cron job for the daily deep brief, or None if it cannot be read.
+
+    Identified through `config/cron-schedules.json` — the contract already names
+    exactly one `daily-deep-brief` job — rather than by a string typed here, so
+    renaming the job in the contract cannot leave a watchdog looking for a job
+    that no longer exists.
+    """
+    try:
+        from clawock_kcnyu.schedule import load_contract
+
+        names = {job.get('name') for job in load_contract().get('jobs', [])
+                 if job.get('mode') == BRIEF_CONTRACT_MODE}
+    except Exception:
+        return None
+    if not names:
+        return None
+    listing = _cron_cli_json(['list', '--json'])
+    if not isinstance(listing, dict):
+        return None
+    for job in listing.get('jobs') or []:
+        if job.get('name') in names:
+            return job
+    return None
+
+
+def cron_run_ended_in_failure(job, today, now=None):
+    """Did this job's latest run already end in failure, today?
+
+    Three answers, not two. `None` means no evidence — an unreadable job, a job
+    still running, or one whose last run was another day — and a watchdog must
+    not act on it, because absence of a report is what #490 showed gets
+    misread as a failure.
+    """
+    if not isinstance(job, dict):
+        return None
+    state = job.get('state') if isinstance(job.get('state'), dict) else {}
+    if job.get('status') == 'running' or state.get('runningAtMs') is not None:
+        return None
+    last_status = str(state.get('lastStatus') or state.get('lastRunStatus') or '').lower()
+    last_run_at = state.get('lastRunAtMs')
+    if not isinstance(last_run_at, (int, float)):
+        return None
+    ran_on = datetime.fromtimestamp(last_run_at / 1000, HKT).strftime('%Y-%m-%d')
+    if ran_on != today:
+        return None
+    if last_status in FAILED_RUN_STATUSES:
+        return True
+    return False if last_status else None
+
+
+def rerun_cron_job(job_id, dry_run=False):
+    """Queue one more run of an on-host cron job. Returns (ok, tail)."""
+    if dry_run:
+        return True, f'(dry-run) openclaw cron run {job_id}'
+    return _openclaw.run_cron_job(job_id)
+
+
 def dispatch_brief_fallback(dry_run=False):
     """Fire .github/workflows/brief-fallback.yml on demand. Returns (ok, tail_of_output).
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -30,6 +30,12 @@ land?", and it runs at 08:30 — INSIDE the brief's observed landing window (08:
 one, so that mode cannot judge a total miss and must stay quiet about it.
 
   (default)        08:30 — delivery backstop: mirror the card to Telegram if unconfirmed.
+                   With no brief on disk it also asks the scheduler whether the 08:00
+                   run is still going: if that run already ended in error it re-runs the
+                   on-host job once (#493), because the runtime's own transient retry —
+                   the thing that rescues every other job from the provider's first-call
+                   timeouts — is budgeted by a `consecutiveErrors` counter this job can
+                   no longer reset. A run still in flight is still left alone.
   --check-missing  09:05 — miss detector: the landing window has closed, so no brief now
                    means no brief today. Alerts AND fires the off-host GHA fallback.
 
@@ -51,6 +57,7 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, build_brief_card, send_telegram, KCN_TELEGRAM,
     dispatch_brief_fallback, await_brief_fallback_outcome,
+    brief_cron_job, cron_run_ended_in_failure, rerun_cron_job,
 )
 
 MARKER_FRESH_MS = 30 * 60 * 1000  # postflight send-marker older than this ⇒ not this slot
@@ -85,6 +92,60 @@ def inspect_brief_artifacts(today):
             or not all(isinstance(row, dict) and row.get('action') for row in actions)):
         issues.append('plan_invalid')
     return issues
+
+
+def rerun_flag_path(today):
+    return WS / 'memory' / '.tmp' / f'watchdog-brief-rerun-{today}.done'
+
+
+def retrigger_or_wait(today, dry_run):
+    """08:30 with no brief on disk: wait, or run the on-host job once more.
+
+    The landing window (08:13-08:49 observed) is why this pass stays quiet about
+    a missing brief — at 08:30 late and lost look the same *from the artifact*.
+    They do not look the same from the scheduler, which already knows whether
+    the 08:00 run is still going. #490 drew that line for the capability gate;
+    the recovery path needs it too.
+
+    Why re-run here rather than leave it to 09:05's off-host fallback: the
+    runtime's own transient retry is what rescues every other job from the
+    provider's first-call timeouts, and the brief cannot get it — the budget is
+    `consecutiveErrors > 3`, and that counter only resets on a success a
+    once-a-day job never reaches while it is failing (#493). A brief run takes
+    9-19 minutes, so one started at 08:30 still lands before the 09:05 miss
+    detector, which keeps its alert and its off-host dispatch either way.
+
+    Deliberately narrow: only a run that has already ended in failure *today*
+    triggers this. A running job, a job that has not run today, and an
+    unreadable schedule all keep the old silence, because none of them is
+    evidence that the attempt is over.
+    """
+    tag = 'brief'
+    job = brief_cron_job()
+    failed = cron_run_ended_in_failure(job, today)
+    if not failed:
+        log({'tag': tag, 'action': 'skip',
+             'reason': 'no pre-open.md yet (inside 08:13-08:49 landing window; '
+                       '09:05 --check-missing pass judges the miss)',
+             'run_evidence': 'none' if failed is None else 'last run ok'})
+        return 0
+
+    flag = rerun_flag_path(today)
+    if flag.exists():
+        log({'tag': tag, 'action': 'skip',
+             'reason': 'on-host re-run already fired today (dedupe flag present)'})
+        return 0
+
+    ok, out = rerun_cron_job(job.get('id'), dry_run)
+    if ok and not dry_run:
+        flag.parent.mkdir(parents=True, exist_ok=True)
+        flag.write_text(datetime.now(HKT).isoformat())
+    log({'tag': tag, 'action': 'rerun-onhost', 'dry_run': dry_run, 'queued_ok': ok,
+         'job_id': job.get('id'), 'job_name': job.get('name'),
+         'reason': 'the 08:00 run already ended in error; the runtime will not '
+                   'retry it (consecutiveErrors past its budget)',
+         'out': out})
+    return 0
 
 
 def missing_state_path(today):
@@ -286,11 +347,9 @@ def main():
     # No brief on disk. There is no card to mirror either way — what differs is whether
     # we can yet call it a miss. At 08:30 we are inside the landing window (08:13-08:49
     # observed) so silence is correct; at 09:05 the window has closed, so it is a miss.
+    # Unless the scheduler already says the run is over: then nothing is landing.
     if not (WS / 'memory' / f'{today}-pre-open.md').exists():
-        log({'tag': tag, 'action': 'skip',
-             'reason': 'no pre-open.md yet (inside 08:13-08:49 landing window; '
-                       '09:05 --check-missing pass judges the miss)'})
-        return 0
+        return retrigger_or_wait(today, args.dry_run)
 
     # Trust the postflight send-marker, not the poisoned run-record `delivered`.
     marker_path = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -237,6 +237,31 @@ def cron_cli_json(cli_args, *, binary: str | None = None,
         return None
 
 
+def run_cron_job(job_id, *, binary: str | None = None,
+                 timeout: int = CRON_TIMEOUT_SECONDS, runner=None):
+    """Ask the runtime to run a cron job now. Returns (ok, output tail).
+
+    The runtime queues the run and returns; it is not waited on, because the
+    callers are watchdogs that must not hold a crontab slot for the length of an
+    agent turn.
+
+    This exists because the runtime's own transient retry is budgeted by
+    `consecutiveErrors`, which only resets on success and is not per slot: a job
+    that gets one attempt a day loses its retry after three bad days and keeps
+    it lost (#493). Recovery for such a job has to be driven from outside the
+    scheduler's own accounting.
+    """
+    selected_binary = binary or runtime_paths().binary
+    run = runner or (lambda cmd: subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout, env=runtime_env()))
+    try:
+        done = run([selected_binary, "cron", "run", str(job_id)])
+        tail = ((done.stdout or "") + (done.stderr or ""))[-400:]
+        return done.returncode == 0, tail
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"[:300]
+
+
 # ── Cron state ───────────────────────────────────────────────────────────────
 # Moved verbatim from `_watchdog_common`, with one shape change: which source
 # answered is returned instead of being left in a module global. A watchdog that

--- a/tests/test_brief_watchdog_onhost_retrigger.py
+++ b/tests/test_brief_watchdog_onhost_retrigger.py
@@ -1,0 +1,144 @@
+"""The 08:30 pass may re-run the brief, but only on evidence the run is over.
+
+On 2026-08-11 there was no brief at all. The 08:00 run died on a MiniMax
+response-header timeout — the same first-call timeout that hit nine other jobs
+that morning, all of which the runtime retried minutes later and all of which
+then succeeded. The brief did not get that retry: the runtime stops retrying at
+`consecutiveErrors > 3`, and that counter only resets on a success, which a job
+with one attempt a day never reaches while it is failing. It stood at 8 (#493).
+
+Meanwhile the 08:30 watchdog logged `skip`, reasoning from the absence of a file
+that the brief might still be landing — 29 minutes after the run it was waiting
+for had ended in error.
+
+So the pass now asks the scheduler. What it must not do is guess: a running job,
+a job that has not run today, and an unreadable schedule are all silence, for
+the reason #490 spelled out — a report that is missing is not a report that
+failed.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+from clawock_kcnyu.harness import brief_watchdog as watchdog  # noqa: E402
+from clawock_kcnyu.harness import _watchdog_common as common  # noqa: E402
+
+HKT = timezone(timedelta(hours=8))
+TODAY = "2026-08-11"
+JOB_ID = "db3df0d0-7622-4b75-81ce-86d510eeef33"
+
+
+def _at(clock):
+    """Epoch ms for an HKT wall clock on TODAY."""
+    return int(datetime.strptime(f"{TODAY} {clock}", "%Y-%m-%d %H:%M")
+               .replace(tzinfo=HKT).timestamp() * 1000)
+
+
+def _job(**state):
+    return {"id": JOB_ID, "name": "盘前深度简报", "enabled": True, "state": state}
+
+
+def _watch(monkeypatch, tmp_path, job, spy):
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "log", lambda event: spy.setdefault("logs", []).append(event))
+    monkeypatch.setattr(watchdog, "brief_cron_job", lambda: job)
+    monkeypatch.setattr(
+        watchdog, "rerun_cron_job",
+        lambda job_id, dry_run=False: (spy.setdefault("reruns", []).append(job_id), (True, "queued"))[1])
+
+
+def _actions(spy):
+    return [event.get("action") for event in spy.get("logs", [])]
+
+
+def test_a_run_that_already_failed_today_is_re_run_once(tmp_path, monkeypatch):
+    spy = {}
+    _watch(monkeypatch, tmp_path, _job(lastStatus="error", lastRunAtMs=_at("08:01"),
+                                       consecutiveErrors=8), spy)
+
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=False) == 0
+    assert spy["reruns"] == [JOB_ID]
+    assert _actions(spy) == ["rerun-onhost"]
+
+    # Second pass, same day: the flag it wrote is the whole point.
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=False) == 0
+    assert spy["reruns"] == [JOB_ID]
+    assert _actions(spy)[-1] == "skip"
+
+
+def test_a_run_still_in_flight_is_left_alone(tmp_path, monkeypatch):
+    """The landing window the old skip was right about."""
+    spy = {}
+    _watch(monkeypatch, tmp_path, _job(runningAtMs=_at("08:00"), lastStatus="error",
+                                       lastRunAtMs=_at("08:01")), spy)
+
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=False) == 0
+    assert spy.get("reruns") is None
+    assert _actions(spy) == ["skip"]
+
+
+def test_a_schedule_that_cannot_be_read_is_not_evidence_of_failure(tmp_path, monkeypatch):
+    spy = {}
+    _watch(monkeypatch, tmp_path, None, spy)
+
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=False) == 0
+    assert spy.get("reruns") is None
+    assert _actions(spy) == ["skip"]
+
+
+def test_yesterdays_failure_does_not_re_run_todays_job(tmp_path, monkeypatch):
+    """Otherwise every morning would open with a re-run of a job that has not
+    had its scheduled attempt yet."""
+    spy = {}
+    yesterday = _at("08:01") - 24 * 3600 * 1000
+    _watch(monkeypatch, tmp_path, _job(lastStatus="error", lastRunAtMs=yesterday), spy)
+
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=False) == 0
+    assert spy.get("reruns") is None
+
+
+def test_dry_run_queues_nothing_and_writes_no_flag(tmp_path, monkeypatch):
+    spy = {}
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "log", lambda event: spy.setdefault("logs", []).append(event))
+    monkeypatch.setattr(watchdog, "brief_cron_job",
+                        lambda: _job(lastStatus="error", lastRunAtMs=_at("08:01")))
+
+    assert watchdog.retrigger_or_wait(TODAY, dry_run=True) == 0
+    assert not watchdog.rerun_flag_path(TODAY).exists()
+    assert _actions(spy) == ["rerun-onhost"]
+
+
+def test_the_evidence_reader_answers_three_ways():
+    """`None` is not `False`: one means no evidence, the other means the run is
+    fine. Collapsing them is how a provider outage got read as context loss."""
+    assert common.cron_run_ended_in_failure(
+        _job(lastStatus="error", lastRunAtMs=_at("08:01")), TODAY) is True
+    assert common.cron_run_ended_in_failure(
+        _job(lastStatus="ok", lastRunAtMs=_at("08:01")), TODAY) is False
+    assert common.cron_run_ended_in_failure(
+        _job(lastRunAtMs=_at("08:01")), TODAY) is None
+    assert common.cron_run_ended_in_failure(_job(), TODAY) is None
+    assert common.cron_run_ended_in_failure(None, TODAY) is None
+
+
+def test_the_brief_job_is_found_through_the_contract_not_a_typed_name(monkeypatch):
+    """A name typed in the watchdog would keep matching nothing after a rename."""
+    contract = json.loads((ROOT / "config" / "cron-schedules.json").read_text())
+    brief = [job for job in contract["jobs"]
+             if job.get("mode") == common.BRIEF_CONTRACT_MODE]
+    assert len(brief) == 1, "the contract no longer names exactly one brief job"
+
+    monkeypatch.setattr(common, "_cron_cli_json", lambda _argv: {
+        "jobs": [{"id": "other", "name": "港股收盘报告"},
+                 {"id": JOB_ID, "name": brief[0]["name"]}]})
+
+    assert common.brief_cron_job()["id"] == JOB_ID
+
+
+def test_no_live_job_matches_the_contract_name(monkeypatch):
+    monkeypatch.setattr(common, "_cron_cli_json", lambda _argv: {"jobs": [
+        {"id": "other", "name": "港股收盘报告"}]})
+
+    assert common.brief_cron_job() is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -157,3 +157,33 @@ def test_delivery_rewire_preserves_the_ok_contract_callers_depend_on():
         result = OpenClawDelivery(
             runner=lambda cmd, c=code: (c, '{"ok":1}')).send("wechat", "kcn", "hi")
         assert (result.status != "failed") is expected_ok, result
+
+
+def test_running_a_cron_job_reports_instead_of_raising():
+    """`run_cron_job` is a watchdog's recovery lever, so it answers `(ok, tail)`
+    like every other adapter call: a scheduler that is down must read as "not
+    queued", never as an exception inside a crontab entry (#493)."""
+    from types import SimpleNamespace
+
+    from clawock.providers.openclaw import run_cron_job
+
+    calls = []
+
+    def queued(cmd):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="queued run 42", stderr="")
+
+    ok, tail = run_cron_job("job-1", binary="/opt/openclaw", runner=queued)
+    assert ok and "queued run 42" in tail
+    assert calls == [["/opt/openclaw", "cron", "run", "job-1"]]
+
+    ok, tail = run_cron_job(
+        "job-1", runner=lambda _cmd: SimpleNamespace(
+            returncode=1, stdout="", stderr="gateway unreachable"))
+    assert not ok and "gateway unreachable" in tail
+
+    def explode(_cmd):
+        raise TimeoutError("no gateway")
+
+    ok, tail = run_cron_job("job-1", runner=explode)
+    assert not ok and "TimeoutError" in tail


### PR DESCRIPTION
Closes #493.

## What changed

- `brief_watchdog`'s 08:30 pass no longer decides from the absence of a file
  alone. With no `pre-open.md` it reads the same `cron list --json` it already
  uses and asks whether the 08:00 run is over:
  - **ended in error today** → one on-host re-run, logged as `rerun-onhost`,
    with a per-day dedupe flag;
  - **still running** → the old `skip`, which the landing window is right about;
  - **no evidence** (unreadable schedule, no run today, no status) → `skip`.
- `clawock.providers.openclaw.run_cron_job(job_id)` — the adapter call behind
  it, reporting `(ok, tail)` instead of raising, like the rest of the provider.
- The brief job is resolved through `config/cron-schedules.json` (the one
  `daily-deep-brief` entry), not by a job name typed into the watchdog.
- 09:05 `--check-missing` is untouched: it still alerts and still dispatches the
  off-host fallback, which has its own "did openclaw already write it" guard.

## Why

2026-08-11 produced no brief. The 08:00 run failed on a MiniMax
response-header timeout; nine other jobs hit the identical error that morning
(09:31, 10:01, 10:32, 11:01, 11:31, 12:02, 14:01, 15:01, 16:02) and every one
of them was retried by the runtime minutes later and succeeded. The brief was
never retried.

```
resolveTransientCronRetryDecision:
  if (consecutiveErrors > retryConfig.maxAttempts)   // DEFAULT_MAX_TRANSIENT_RETRIES = 3
    return { retryable: false, reason: "max retries exhausted" };
```

`consecutiveErrors` resets only on success and is not per slot. A 30-minute job
fails, retries, succeeds and resets several times an hour. A once-a-day job
that fails its single attempt never reaches the success that would reset it —
so after three bad days its retry is gone for as long as it keeps failing. The
brief's counter is **8**; it has opened with this same timeout on 08-04, 08-06,
08-07, 08-10 and 08-11.

That left the off-host fallback as the only recovery. It ran at 09:05 and
failed too (`102644 in / 32000 out (stop=max_tokens)`, the budget defect #481
fixed later the same morning), so nothing was delivered.

## Verification

- `pytest -q tests/test_brief_watchdog_onhost_retrigger.py tests/test_brief_watchdog.py tests/test_providers.py` — 33 passed
- `pytest -k "watchdog or ratchet or cron or provider or brief or import_independence"` — 312 passed
- Against the **live runtime state**, the new path resolves the real job
  (`db3df0d0…` / 盘前深度简报, `lastStatus=error`, `consecutiveErrors=8`) and
  decides `rerun-onhost` — i.e. it would have fired at 08:30 today. Verified in
  dry-run; no run was queued.

## Deliberately not done

Backfilling today's brief. A pre-open brief written at 20:00 HKT is not a
pre-open brief, and publishing one would put a stale artifact in the record.
