### PR TITLE
Name the configured retry budget, not the runtime default

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -110,8 +110,9 @@ def retrigger_or_wait(today, dry_run):
     Why re-run here rather than leave it to 09:05's off-host fallback: the
     runtime's own transient retry is what rescues every other job from the
     provider's first-call timeouts, and the brief cannot get it — the budget is
-    `consecutiveErrors > 3`, and that counter only resets on a success a
-    once-a-day job never reaches while it is failing (#493). A brief run takes
+    `consecutiveErrors > cron.retry.maxAttempts` (5 on this host), and that
+    counter only resets on a success a once-a-day job never reaches while it is
+    failing (#493). A brief run takes
     9-19 minutes, so one started at 08:30 still lands before the 09:05 miss
     detector, which keeps its alert and its off-host dispatch either way.
 

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -247,8 +247,9 @@ def run_cron_job(job_id, *, binary: str | None = None,
 
     This exists because the runtime's own transient retry is budgeted by
     `consecutiveErrors`, which only resets on success and is not per slot: a job
-    that gets one attempt a day loses its retry after three bad days and keeps
-    it lost (#493). Recovery for such a job has to be driven from outside the
+    that gets one attempt a day loses its retry after `cron.retry.maxAttempts`
+    bad days (5 on the live host, 3 by runtime default) and keeps it lost
+    (#493). Recovery for such a job has to be driven from outside the
     scheduler's own accounting.
     """
     selected_binary = binary or runtime_paths().binary

--- a/tests/test_brief_watchdog_onhost_retrigger.py
+++ b/tests/test_brief_watchdog_onhost_retrigger.py
@@ -4,8 +4,9 @@ On 2026-08-11 there was no brief at all. The 08:00 run died on a MiniMax
 response-header timeout — the same first-call timeout that hit nine other jobs
 that morning, all of which the runtime retried minutes later and all of which
 then succeeded. The brief did not get that retry: the runtime stops retrying at
-`consecutiveErrors > 3`, and that counter only resets on a success, which a job
-with one attempt a day never reaches while it is failing. It stood at 8 (#493).
+`consecutiveErrors > cron.retry.maxAttempts` — 5 in this host's config, 3 by
+runtime default — and that counter only resets on a success, which a job with
+one attempt a day never reaches while it is failing. It stood at 8 (#493).
 
 Meanwhile the 08:30 watchdog logged `skip`, reasoning from the absence of a file
 that the brief might still be landing — 29 minutes after the run it was waiting


### PR DESCRIPTION
Follow-up to #494 / #493.

Those comments say the runtime stops retrying at `consecutiveErrors > 3`. Three
is `DEFAULT_MAX_TRANSIENT_RETRIES`, the runtime's default — this host overrides
it in `openclaw.json`:

```json
"cron": { "retry": { "maxAttempts": 5,
                     "backoffMs": [30000, 60000, 120000, 300000, 300000] } }
```

so the threshold actually in force is 5.

The diagnosis and the fix are unchanged: the brief's `consecutiveErrors` was 7
before the 2026-08-11 run and is 8 now, exhausted against either number, and the
counter still only resets on a success a once-a-day job cannot reach while it is
failing. What changes is the explanation a future reader inherits, which should
name the configured knob rather than a constant that is overridden here.

Comment-only; no behaviour change.
