### PR TITLE
fix: refresh feedback label broke the topbar apart on phones

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -4,15 +4,16 @@ on:
   push:
     branches: [master]
     paths:
-      - 'scripts/**'
       - 'src/**'
       - 'instances/**'
       - 'ops/**'
       - 'pyproject.toml'
       - 'tests/**'
-      - 'assets/css/**'
-      - 'assets/js/**'
-      - 'index.html'
+      # The dashboard moved under site/ in #399; these globs kept the
+      # pre-move paths and stopped matching anything.
+      - 'site/assets/css/**'
+      - 'site/assets/js/**'
+      - 'site/index.html'
       - 'portfolio.json'
       - 'memory/**-plan.json'
       # Research artifacts are validated by the suite below, so a
@@ -124,14 +125,14 @@ jobs:
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
-              scripts/*|src/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*)
+              src/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*)
                 code=true
                 break
                 ;;
             esac
           done <<< "$changed"
           ui=false
-          if grep -Eq '^(assets/(css|js)/|index\.html$|tests/dashboard_tab_runtime\.spec\.js$)' <<< "$changed"; then
+          if grep -Eq '^(site/assets/(css|js)/|site/index\.html$|tests/dashboard_tab_runtime\.spec\.js$)' <<< "$changed"; then
             ui=true
             code=true
           fi

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -177,8 +177,12 @@
        feedback onto the icon so it does not disappear with the text. */
     .refresh-btn { padding: 0; justify-content: center; }
     .refresh-btn .lbl { display: none; }
-    .refresh-btn.ok-flash .ic, .refresh-btn.fresh-flash .ic { font-size: 0; }
-    .refresh-btn.ok-flash .ic::after,
+    /* Only the "a new generation landed" outcome becomes a check — that is the
+       one whose label carries one ("已更新 ✓" vs "已是最新"). "Nothing new"
+       keeps the ↻ and says so with the green rim. Two outcomes have to differ
+       by shape; if they differed only by border colour, colour would be the
+       sole carrier of the difference. */
+    .refresh-btn.fresh-flash .ic { font-size: 0; }
     .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: 15px; }
   }
   .topbar-actions { display: inline-flex; align-items: center; gap: 8px; }

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -139,6 +139,9 @@
   }
   .brand h1 {
     margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.01em;
+    /* `.brand` may shrink (min-width: 0), and an un-clipped h1 then paints on
+       top of the nav links instead of getting narrower. Truncate instead. */
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .brand .updated {
     font-size: 11px; color: var(--text-dim);
@@ -155,6 +158,11 @@
     font-size: 14px; cursor: pointer;
     display: inline-flex; align-items: center; gap: 4px;
     transition: background 0.15s, color 0.15s, border-color 0.3s;
+    /* The click-feedback labels are CJK, which — unlike "Refresh" — has a break
+       opportunity between every character. Without these two the button is a
+       shrinkable flex item and "已是最新" stacks one glyph per line, turning the
+       pill into an 82px-tall column. */
+    flex: 0 0 auto; white-space: nowrap;
   }
   .refresh-btn:active { background: var(--card-2); }
   .refresh-btn.is-loading .ic { animation: spin 0.8s linear infinite; }
@@ -162,6 +170,17 @@
   .refresh-btn.fresh-flash { border-color: var(--accent); color: var(--accent); }
   .refresh-btn[disabled] { opacity: 0.6; cursor: not-allowed; }
   @keyframes spin { to { transform: rotate(360deg); } }
+  @media (max-width: 560px) {
+    /* Three nav links plus a labelled button overflow the row, and the overflow
+       lands on the brand. The label is the compressible part: collapse to the
+       icon-only 36px target `min-width` already sizes for, and move the click
+       feedback onto the icon so it does not disappear with the text. */
+    .refresh-btn { padding: 0; justify-content: center; }
+    .refresh-btn .lbl { display: none; }
+    .refresh-btn.ok-flash .ic, .refresh-btn.fresh-flash .ic { font-size: 0; }
+    .refresh-btn.ok-flash .ic::after,
+    .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: 15px; }
+  }
   .topbar-actions { display: inline-flex; align-items: center; gap: 8px; }
   .nav-link {
     color: var(--text-dim); text-decoration: none; font-size: 13px;
@@ -170,6 +189,12 @@
   .nav-link:hover { color: var(--text); background: var(--card-2); }
   @media (max-width: 480px) {
     .nav-link { padding: var(--space-2); font-size: 12px; }
+  }
+  @media (max-width: 400px) {
+    /* Last few pixels at 360–390: tighten the row rather than let the brand
+       hit its ellipsis. Nav-link padding stays put — it is the tap target. */
+    .topbar-actions { gap: 4px; }
+    .brand h1 { font-size: 18px; }
   }
 
   .tabs {

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -418,6 +418,33 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
     "desktop refresh button lost its text label");
   await desktop.close();
 
+  // Hiding the label costs the phone layout the one thing the label carried:
+  // that "已更新 ✓" and "已是最新" are different answers. Whatever replaces it
+  // has to keep them apart by shape, not by border colour alone.
+  const feedback = await browser.newPage({ viewport: { width: 390, height: 800 } });
+  await stubLiveOrigin(feedback);
+  await feedback.goto(base, { waitUntil: "networkidle" });
+  await waitForData(feedback);
+  const marks = await feedback.evaluate(() => {
+    const btn = document.getElementById("refresh-btn");
+    const ic = btn.querySelector(".ic");
+    const visibleMark = state => {
+      btn.classList.remove("ok-flash", "fresh-flash");
+      if (state) btn.classList.add(state);
+      // A zeroed font size means the element's own text is gone and whatever
+      // ::after draws is what the user actually sees.
+      return getComputedStyle(ic).fontSize === "0px"
+        ? getComputedStyle(ic, "::after").content
+        : ic.textContent;
+    };
+    return { idle: visibleMark(null), ok: visibleMark("ok-flash"), fresh: visibleMark("fresh-flash") };
+  });
+  assert(marks.ok !== marks.fresh,
+    `both refresh outcomes draw the same mark (${marks.ok}) below 560px`);
+  assert(marks.fresh !== marks.idle,
+    "a new generation left the refresh icon unchanged below 560px");
+  await feedback.close();
+
   // Hiding the label below 560px means today's two strings can no longer be
   // squeezed hard enough to break — which would leave the button's own
   // single-line guarantee untested until someone widens that breakpoint or adds

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -354,6 +354,89 @@ async function testTabGuardWithoutForcedLayout(browser, base) {
   await context.close();
 }
 
+// The refresh button swaps its label to a CJK string ("已是最新" / "已更新 ✓") for
+// 1.8s after a click. CJK has a line-break opportunity between every character,
+// so a shrinkable flex item breaks it one glyph per line: the 36px pill became
+// an 82px-tall column, and the topbar it overflowed painted the brand on top of
+// the nav links. Both states are geometry, so measure them rather than grep the
+// stylesheet for the properties that happen to fix them today.
+async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
+  // 360px is the narrowest width the wordmark is promised in full. 320px is
+  // past that: there the brand may reach its ellipsis, but it still may not be
+  // painted over the links — an un-clipped h1 in a shrunk flex item overlaps
+  // them instead of getting narrower.
+  const phones = [{ width: 320, mayTruncate: true }, { width: 360 },
+                  { width: 390 }, { width: 412 }];
+  for (const { width, mayTruncate } of phones) {
+    const context = await browser.newContext({
+      viewport: { width, height: 800 }, isMobile: true, hasTouch: true,
+    });
+    const page = await context.newPage();
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+
+    const idleHeight = (await page.locator("#refresh-btn").boundingBox()).height;
+    await page.click("#refresh-btn");
+    await page.waitForFunction(
+      () => document.querySelector("#refresh-btn .lbl").textContent !== "Refresh",
+      null, { timeout: 5000 },
+    ).catch(() => { throw new Error(`refresh at ${width}px never reported back`); });
+
+    const box = await page.evaluate(() => {
+      const rect = el => el.getBoundingClientRect();
+      const btn = document.getElementById("refresh-btn");
+      const h1 = document.querySelector(".brand h1");
+      const link = document.querySelector(".topbar-actions .nav-link");
+      const row = document.querySelector(".topbar-row");
+      return {
+        label: btn.querySelector(".lbl").textContent,
+        height: rect(btn).height,
+        gap: rect(link).left - rect(h1).right,
+        clipped: h1.scrollWidth > h1.clientWidth + 0.5,
+        overflow: row.scrollWidth - row.clientWidth,
+      };
+    });
+    assert(box.label !== "Refresh", `label did not swap at ${width}px`);
+    assert(box.height <= idleHeight + 1,
+      `refresh button grew to ${box.height}px showing "${box.label}" at ${width}px`);
+    assert(box.gap >= 0,
+      `brand overlaps the nav links by ${-box.gap}px at ${width}px`);
+    assert(mayTruncate || !box.clipped, `brand wordmark is truncated at ${width}px`);
+    assert(box.overflow <= 0, `topbar row overflows by ${box.overflow}px at ${width}px`);
+    await context.close();
+  }
+
+  // The narrow layout drops the label to keep the row inside its width. That
+  // must stay a narrow-viewport concession: on a desktop the button keeps its
+  // text, and the feedback is the text.
+  const desktop = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  await stubLiveOrigin(desktop);
+  await desktop.goto(base, { waitUntil: "networkidle" });
+  await waitForData(desktop);
+  assert(await desktop.locator("#refresh-btn .lbl").isVisible(),
+    "desktop refresh button lost its text label");
+  await desktop.close();
+
+  // Hiding the label below 560px means today's two strings can no longer be
+  // squeezed hard enough to break — which would leave the button's own
+  // single-line guarantee untested until someone widens that breakpoint or adds
+  // a fourth nav link. Feed it a label long enough to put the row over budget:
+  // the button may become wide, it may not become tall.
+  const stress = await browser.newPage({ viewport: { width: 600, height: 900 } });
+  await stubLiveOrigin(stress);
+  await stress.goto(base, { waitUntil: "networkidle" });
+  await waitForData(stress);
+  const grew = await stress.evaluate(() => {
+    const btn = document.getElementById("refresh-btn");
+    const before = btn.getBoundingClientRect().height;
+    btn.querySelector(".lbl").textContent = "已是最新的一份生成数据";
+    return btn.getBoundingClientRect().height - before;
+  });
+  assert(grew <= 1, `refresh button wrapped its label onto ${grew}px of extra lines`);
+  await stress.close();
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -367,6 +450,7 @@ async function main() {
     await testLiveDataOrigin(browser, base);
     await testEquityTouch(browser, base);
     await testTabGuardWithoutForcedLayout(browser, base);
+    await testTopbarFitsWhenRefreshLabelSwaps(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_harness_regression_paths.py
+++ b/tests/test_harness_regression_paths.py
@@ -7,6 +7,8 @@ later (thesis and earnings schemas, evidence policies, peer rules) silently fell
 outside the gate — a config-only PR reported green in seconds without running the
 tests that read that config. These assertions keep the directory-wide form.
 """
+import subprocess
+from fnmatch import fnmatch
 from pathlib import Path
 
 from workflow_contract_helpers import case_patterns, push_paths
@@ -40,8 +42,27 @@ def test_every_shipped_config_file_matches_the_gate():
     assert all(name.startswith("config/") for name in CONFIG_FILES)
 
 
-def test_scripts_and_tests_stay_gated():
-    for pattern in ("scripts/*", "tests/*"):
+def test_code_and_tests_stay_gated():
+    # `scripts/` was retired in #429; its code lives under src/, ops/ and
+    # instances/, which carry their own entries here.
+    assert not (ROOT / "scripts").exists()
+    for pattern in ("src/*", "tests/*"):
         assert pattern in case_patterns(WORKFLOW_PATH)
-    for pattern in ("scripts/**", "tests/**"):
+    for pattern in ("src/**", "ops/**", "instances/**", "tests/**"):
         assert pattern in push_paths(WORKFLOW_PATH)
+
+
+def test_no_push_path_matches_nothing_in_the_checkout():
+    # A path that matches no file is not a gate. #399 moved the dashboard under
+    # `site/` and left `assets/css/**`, `assets/js/**` and `index.html` behind:
+    # they kept passing review because they read correctly, while every
+    # stylesheet and script edit stopped triggering the workflow at all.
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert tracked, "empty checkout would make this assertion vacuous"
+    dead = [
+        pattern for pattern in push_paths(WORKFLOW_PATH)
+        if not any(fnmatch(name, pattern.replace("**", "*")) for name in tracked)
+    ]
+    assert dead == [], f"path filter matches no tracked file: {dead}"


### PR DESCRIPTION
Closes #496.

## The defect

Tapping Refresh on a phone turned the button into an 82px-tall column of
stacked characters. The confirmation label is CJK ("已是最新" / "已更新 ✓"),
CJK breaks between every character, and `.refresh-btn` was a shrinkable flex
item with no `white-space` rule — so the same squeeze that merely overflowed
the unbreakable word "Refresh" stacked the four glyphs vertically.

The squeeze itself predates the tap. #470 added a third topbar nav link, and at
390px the row needs 402px of content in 358px. The brand `h1` sits in a
`min-width: 0` flex box with no `overflow` rule, so on **every load** at 390px
it was already painting 32.4px on top of "Briefs".

## The fix

| change | scope |
|---|---|
| `flex: 0 0 auto; white-space: nowrap` | no label, in any language, breaks the button's line |
| icon-only refresh button | <=560px — the label is the compressible part, and `min-width: 36px` already sized for exactly this |
| feedback moves onto the icon (`↻` -> `✓`) | <=560px — hiding the text must not silently delete the confirmation |
| `gap: 4px`, 18px wordmark | <=400px — 360-390px keeps the full wordmark instead of falling back to its ellipsis |
| `h1` truncates | all widths — a too-narrow row must shorten the wordmark, never paint it over the links |

Geometry after, at every width measured (negative overlap = clearance):

| viewport | button | overlap | wordmark |
|---|---|---|---|
| 320 | 36 x 36 | -12.0 | truncated (accepted) |
| 360 | 36 x 36 | -13.8 | whole |
| 390 | 36 x 36 | -43.8 | whole |
| 412 | 36 x 36 | -64.1 | whole |
| 480 | 36 x 36 | -114.1 | whole |
| 540 | 36 x 36 | -138.4 | whole |
| 600 | 99.5 x 36 | -134.8 | whole |
| 768 / 1280 | 99.5 x 36 | wide | whole |

320px is the one width that still gives something up: the wordmark reaches its
ellipsis there. That is a deliberate stop — buying it back needs the nav links'
tap targets, and a tap target is worth more than two glyphs of the wordmark on
a device generation that is essentially gone.

## Why this shipped: the browser contract has not run since 2026-08-08

`validate` runs the Chromium contract only when a path filter says the UI
changed, and that filter still named `assets/css/**`, `assets/js/**` and
`index.html`. #399 moved all three under `site/`. Since then the `ui` flag has
been false for every UI pull request, and a master push touching only a
stylesheet did not start the workflow at all. Both the push filter and the
`Detect code changes` regex now name the real paths.

`scripts/**` / `scripts/*` are removed in the same pass — #429 retired that
directory and its code moved to src/, ops/ and instances/, each gated on its
own. `test_no_push_path_matches_nothing_in_the_checkout` keeps the class from
returning: a path filter matching no tracked file reads fine in review and
gates nothing.

## The test

Rendered, not grepped. The two existing CSS tests assert substrings in the
stylesheet; neither has a notion of a box that is 82px tall. The new case loads
the real page at 320/360/390/412, clicks the real button, waits for the real
label swap, and asserts the geometry: height unchanged, no overlap, wordmark
whole from 360px, no row overflow.

Against `master`'s stylesheet it fails with the reported symptom:

```
AssertionError: refresh button grew to 82px showing "已是最新" at 320px
```

Each of the four CSS rules was then reverted individually:

| reverted | suite says |
|---|---|
| `flex`/`nowrap` pair | `refresh button wrapped its label onto 26px of extra lines` |
| `.lbl { display: none }` | `brand wordmark is truncated at 360px` |
| `h1` ellipsis | `brand overlaps the nav links by 26.2px at 320px` |
| 400px tightening | `brand wordmark is truncated at 360px` |

The `flex`/`nowrap` pair is the one that needed care. Hiding the label below
560px means the two real strings can no longer be squeezed hard enough to
break, so a phone-width test can no longer falsify it — it would have been an
assertion that passes whether or not the property is there. The stress case at
600px feeds the button a label long enough to put the row over budget and
asserts it may grow wide but not tall.

## Verification

- `node tests/dashboard_tab_runtime.spec.js` — green here on Chromium, red on master's CSS.
- `pytest` on the workflow-reading suites (`test_harness_regression_paths`, `test_workflow_health`, `test_cron_contracts`, `test_pr_publish_gate_contract`, `test_dashboard_desktop_layout_contract`, `test_dashboard_contrast`, `test_dashboard_artifact_gate_contract`, `test_pages_deployment_contract`, `test_research_surface`, `test_coverage_badge`, `test_workspace_portability`) — 199 passed.
- `test_dashboard_payload_size` errors identically with and without this branch checked out: this worktree has no `clawock` install. CI does.
