### PR TITLE
fix: the header walked out of the content column past 1600px

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -225,10 +225,25 @@
 
   /* Desktop tab bar — a real underline nav, not the mobile edge-fade scroller. */
   @media (min-width: 1024px) {
+    /* The header is full-bleed — its background, shadow and rule span the
+       viewport — but what it holds belongs to the same column as the cards.
+       `main` is `max-width: 1600px` centred with 28px of padding, so past
+       1600px the header kept walking outward while the content stopped: at
+       1920px the wordmark sat 172px left of the first card and Refresh 144px
+       past its right edge. Move the inline padding off the full-bleed element
+       and onto the two rows, so they resolve to main's own content box. */
+    .topbar { padding-inline: 0; }
+    .topbar-row, .tabs {
+      max-width: 1600px; margin-inline: auto; padding-inline: 28px;
+    }
     .tabs {
       gap: 2px; margin-top: 14px; overflow: visible;
       -webkit-mask-image: none; mask-image: none;
-      border-bottom: 1px solid var(--border);
+      /* No rule of its own: it sat 1px above the header's own full-bleed
+         border, which was invisible while both spanned the viewport. Once the
+         strip is column-width, the doubled pixel shows as a step at the column
+         edge. The header's border is the rule; the active indicator lands on
+         it either way. */
     }
     .tab-btn {
       padding: 10px 18px; min-height: 40px; font-size: 13.5px; font-weight: 550;

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -464,6 +464,50 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
   await stress.close();
 }
 
+// The header is full-bleed by design — background, shadow and rule cross the
+// whole viewport — but everything it holds belongs to the same column as the
+// cards. `main` stops at 1600px; the header's padding did not, so past that
+// width the wordmark and the tab strip kept walking outward while the content
+// stood still (172px of drift at 1920, 492px at 2560).
+async function testHeaderSharesTheContentColumn(browser, base) {
+  for (const width of [1280, 1920, 2560]) {
+    const page = await browser.newPage({ viewport: { width, height: 900 } });
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    const m = await page.evaluate(() => {
+      const box = el => el.getBoundingClientRect();
+      const main = document.querySelector("main");
+      const style = getComputedStyle(main);
+      const tabs = document.querySelector(".tabs");
+      const topbar = document.querySelector(".topbar");
+      const tabsRule = parseFloat(getComputedStyle(tabs).borderBottomWidth) || 0;
+      return {
+        columnLeft: box(main).left + parseFloat(style.paddingLeft),
+        columnRight: box(main).right - parseFloat(style.paddingRight),
+        brandLeft: box(document.querySelector(".brand-mark")).left,
+        tabLeft: box(document.querySelector(".tab-btn")).left,
+        refreshRight: box(document.getElementById("refresh-btn")).right,
+        // A rule that stops at the column edge, one pixel above the header's
+        // own full-bleed rule, draws a visible step where they part company.
+        doubledRule: tabsRule > 0 &&
+          box(topbar).bottom - box(tabs).bottom <= 2 &&
+          box(tabs).width < box(topbar).width,
+      };
+    });
+    const off = (a, b) => Math.abs(a - b);
+    assert(off(m.brandLeft, m.columnLeft) <= 1,
+      `wordmark is ${off(m.brandLeft, m.columnLeft)}px off the content column at ${width}px`);
+    assert(off(m.tabLeft, m.columnLeft) <= 1,
+      `tab strip is ${off(m.tabLeft, m.columnLeft)}px off the content column at ${width}px`);
+    assert(off(m.refreshRight, m.columnRight) <= 1,
+      `refresh button is ${off(m.refreshRight, m.columnRight)}px off the column's right edge at ${width}px`);
+    assert(!m.doubledRule,
+      `a column-width rule sits on the header's full-bleed rule at ${width}px`);
+    await page.close();
+  }
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -478,6 +522,7 @@ async function main() {
     await testEquityTouch(browser, base);
     await testTabGuardWithoutForcedLayout(browser, base);
     await testTopbarFitsWhenRefreshLabelSwaps(browser, base);
+    await testHeaderSharesTheContentColumn(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));


### PR DESCRIPTION
Stacked on #497 — base it there or merge #497 first; the diff below is the last
commit only (`9c62572`).

## The defect

kcn: "现在那块导航栏乱七八糟的". On a wide monitor the header is not attached to
anything. `main` is `max-width: 1600px` centred with 28px of padding; the
header padded itself 16px against the viewport. Below 1600px the two nearly
agree, so it never showed. Above it the content column stops growing and the
header does not:

| viewport | wordmark vs first card | Refresh vs column right edge |
|---|---|---|
| 1280 | 12px left | — (main is not capped yet) |
| 1920 | **172px left** | **144px past** |
| 2560 | **492px left** | **464px past** |

Measured on the published site, so this is what the page does today, not what
the stylesheet suggests.

## The fix

The header stays full-bleed: background, shadow and rule still cross the
viewport. Only the inline padding moves off `.topbar` and onto `.topbar-row`
and `.tabs`, which then resolve to main's own content box. After:

| viewport | wordmark | tab strip | Refresh right |
|---|---|---|---|
| 1024 / 1280 / 1440 / 1920 / 2560 | 0px off | 0px off | 0px off |

`.tabs` also loses its own bottom border at >=1024px. It had been sitting 1px
above the header's full-bleed rule — invisible while both spanned the viewport,
a visible step at the column edge once the strip is column-width. Sampling
across the rule at 1920px, x=60 / 600 / 1850 now all read row y=123,
rgb(216,224,232) — one continuous line.

**Desktop only.** The entire change is inside `@media (min-width: 1024px)`,
which the mobile pager never enters, and the phone cases in the same spec are
untouched and still green.

## The test

`testHeaderSharesTheContentColumn` renders 1280 / 1920 / 2560 and asserts the
wordmark, the first tab and the button's right edge each land on main's own
content box, plus that no column-width rule sits within 2px of the header's
full-bleed one. Both halves were mutation-verified:

| reverted | suite says |
|---|---|
| the container rule | `wordmark is 12px off the content column at 1280px` |
| the `.tabs` border | `a column-width rule sits on the header's full-bleed rule at 1920px` |

## Verification

- `node tests/dashboard_tab_runtime.spec.js` — green, including every case from #497.
- `pytest tests/test_dashboard_desktop_layout_contract.py tests/test_dashboard_contrast.py tests/test_harness_regression_paths.py` — 14 passed.
