### PR TITLE
fix: the site-wide nav pointed every page at a 404

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -177,7 +177,6 @@
       <a class="nav-link {% if page.url == '/' or page.url == '/index.html' %}active{% endif %}" href="{{ '/' | relative_url }}">Dashboard</a>
       <a class="nav-link {% if page.url contains 'briefs' %}active{% endif %}" href="{{ '/briefs.html' | relative_url }}">Briefs</a>
       <a class="nav-link {% if page.url contains 'evidence' %}active{% endif %}" href="{{ '/evidence.html' | relative_url }}">Evidence</a>
-      <a class="nav-link {% if page.url contains 'README' %}active{% endif %}" href="{{ '/README.html' | relative_url }}">README</a>
       <a class="nav-link" href="https://github.com/KCNyu/clawock" target="_blank" rel="noopener">GitHub</a>
     </nav>
   </div>

--- a/site/briefs.md
+++ b/site/briefs.md
@@ -75,5 +75,5 @@ Self-learning loop 用，给次日 retrospective 算 trigger / P&L / confidence 
 
 ## 📚 Reference
 
-- [README](README.html) — 项目总览 + 架构 + cron map
+- [README](https://github.com/KCNyu/clawock#readme) — 项目总览 + 架构 + cron map
 - [Dashboard](./) — 实时持仓 + 集中度 + retrospective

--- a/tests/test_site_internal_links.py
+++ b/tests/test_site_internal_links.py
@@ -1,0 +1,114 @@
+"""Every internal link on the site must resolve to something the build emits.
+
+The site-wide nav carried a `README` entry pointing at `/README.html`. That URL
+worked while the repository root *was* the Jekyll source root: `README.md` sat
+in the tree and Jekyll rendered it. #399 moved the site under `site/` and had
+`ops/pages/stage_site.py` assemble the source tree instead, and the root README
+is not part of it — so since 2026-08-08 every page on the site advertised a
+404, in its header, to every visitor and every crawler. Nothing noticed,
+because no check ever asked whether a link had a destination.
+
+Crawl budget is this site's binding constraint, which makes a dead link in the
+site-wide nav worse than a missing one: it is spent on a URL that cannot exist.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+
+# Some published URLs are not files in this checkout: the dashboard's own JSON
+# lives on the data branch (#314) and is joined in during staging. What makes
+# them real is the declaration, so that is what this reads — a link to an
+# undeclared artifact is exactly the thing worth failing on.
+PUBLIC = json.loads((ROOT / "config" / "pages-public.json").read_text())
+PUBLISHED = set(PUBLIC["browser_data"]) | set(PUBLIC["required_pages"])
+
+HREF = re.compile(r'href="([^"]+)"')
+MARKDOWN_LINK = re.compile(r'(?<!!)\[[^\]]*\]\(([^)\s]+)')
+# {{ '/briefs.html' | relative_url }} — a quoted literal. `{{ f.url | ... }}`
+# is a loop variable with no static destination, so it is not one of these.
+RELATIVE_URL = re.compile(r"^\{\{\s*'([^']+)'\s*\|\s*relative_url\s*\}\}$")
+
+EXTERNAL = ("http://", "https://", "//", "mailto:", "data:")
+
+
+def pages() -> list[Path]:
+    return sorted(
+        path for path in SITE.rglob("*")
+        if path.suffix in {".html", ".md"} and path.is_file()
+    )
+
+
+def targets(text: str) -> list[str]:
+    return HREF.findall(text) + MARKDOWN_LINK.findall(text)
+
+
+def internal_links() -> list[tuple[Path, str]]:
+    found = []
+    for page in pages():
+        for raw in targets(page.read_text(encoding="utf-8")):
+            link = raw.strip()
+            match = RELATIVE_URL.match(link)
+            if match:
+                link = match.group(1)
+            if link.startswith(EXTERNAL) or link.startswith("#") or not link:
+                continue
+            if "{{" in link or "{%" in link:
+                continue  # a Liquid variable; its destination is not static
+            found.append((page, link.split("?")[0].split("#")[0]))
+    return found
+
+
+def resolves(link: str) -> bool:
+    relative = link.lstrip("/")
+    if relative in {"", "./"}:
+        return (SITE / "index.html").exists()
+    if relative in PUBLISHED:
+        return True
+    candidate = SITE / relative
+    if candidate.is_file():
+        return True
+    if relative.endswith("/"):
+        return any((candidate / f"index{s}").exists() for s in (".html", ".md"))
+    if relative.endswith(".html"):
+        # Jekyll emits page.html from page.md — but only for a *page*, and what
+        # makes a markdown file a page is front matter. `optional_front_matter`
+        # is deliberately off in _config.yml, so a file without it is copied as
+        # a static file and no .html is ever produced. `site/README.md` is one:
+        # it exists, which is why linking to /README.html looked safe, and
+        # /README.html has never resolved.
+        source = candidate.with_suffix(".md")
+        return source.exists() and source.read_text(encoding="utf-8").startswith("---")
+    return False
+
+
+def test_no_page_links_to_a_destination_the_build_will_not_emit():
+    links = internal_links()
+    # Without this the check would pass loudest exactly when the extraction
+    # broke and it stopped seeing any link at all.
+    assert len(links) >= 8, f"only found {len(links)} internal links to check"
+    assert any(link.endswith("briefs.html") for _, link in links)
+    assert any(link.endswith("evidence.html") for _, link in links)
+
+    dead = sorted({
+        f"{page.relative_to(ROOT)} -> {link}"
+        for page, link in links if not resolves(link)
+    })
+    assert dead == [], "internal links with no destination: " + "; ".join(dead)
+
+
+def test_the_shared_nav_does_not_advertise_a_page_the_site_does_not_have():
+    # The nav is on every page, so one dead entry there is one dead link per
+    # page — the shape that made this cost three days of crawls unnoticed.
+    layout = (SITE / "_layouts" / "default.html").read_text(encoding="utf-8")
+    nav = layout[layout.index('<nav class="topbar-actions">'):]
+    nav = nav[:nav.index("</nav>")]
+    for raw in HREF.findall(nav):
+        match = RELATIVE_URL.match(raw.strip())
+        if not match:
+            continue
+        assert resolves(match.group(1)), f"shared nav links to missing {match.group(1)}"


### PR DESCRIPTION
## The defect

Every page on the site carried a `README` entry in its shared nav pointing at
`/README.html`. That URL is a 404, and so is `/README.md`:

```
https://kcnyu.github.io/clawock/README.html   404
https://kcnyu.github.io/clawock/README.md     404
```

It worked while the repository root *was* the Jekyll source root — `README.md`
sat in the tree and Jekyll rendered it. #399 (2026-08-08) moved the site under
`site/` and had `ops/pages/stage_site.py` assemble the source instead. The root
README is not part of that tree. `site/README.md` is a different document — it
documents the directory — and has no front matter, so with
`optional_front_matter` deliberately off it is copied as a static file and no
`README.html` is ever produced.

This is the third thing #399 left pointing at the old layout, after the
browser contract's path filter (#496) and the header's own padding (#498).

## Why remove rather than repair

`GitHub` sits next to it in the same nav and lands on the repository page whose
body **is** that README — canonical, bilingual, always current. Staging a copy
would put a second rendering on a second URL competing with the repository for
the same queries, on a site whose binding constraint is crawl budget: 82 URLs,
one indexed, a sitemap Google has never downloaded. A dead entry in a shared
nav is worse than no entry — it is one dead link per page, spending that budget
on a URL that cannot exist.

The Briefs page's own reference now points at the repository README instead.

## The gate

Every internal link must resolve to something the build emits. A target counts
if it is a file under `site/`, a markdown page **with front matter** (what makes
Jekyll render it), or an entry in `config/pages-public.json` — whose contents
`ops/pages/prepare_pages_artifact.py` already refuses to publish without, which
is what makes a declaration load-bearing rather than a second opinion.

| mutation | suite says |
|---|---|
| restore the nav entry | `no destination: site/_layouts/default.html -> /README.html; site/briefs.md -> README.html` — and the nav-specific assertion fires too |
| link an undeclared `assets/data/*.json` | `no destination: site/index.html -> assets/data/not_declared.json` |

The extraction carries its own anti-vacuity assertion: it must find at least 8
internal links and must see `briefs.html` and `evidence.html` among them, so a
regex that silently stops matching cannot pass as a clean sweep.

Note the shape of the near-miss. The obvious rule — "`X.html` resolves if
`X.md` exists" — passes on this exact defect, because `site/README.md` does
exist. Front matter is what separates a page from a static file, and that is
what the site was already telling us.

## Verification

- `pytest tests/test_site_internal_links.py tests/test_pages_deployment_contract.py tests/test_site_deploy.py` — 20 passed.
- The two `test_pages_deployment_contract` cases need `assets/data/` present; they fail identically on an unfetched checkout with or without this branch.
