### PR TITLE
feat: turn existing signals into information alpha overlay

### DIFF
--- a/config/news-evidence-policy.json
+++ b/config/news-evidence-policy.json
@@ -6,6 +6,29 @@
   "price_confirmation_abs_pct": 2.0,
   "volume_confirmation_ratio": 1.5,
   "peer_residual_sigma": 1.5,
+  "information_overlay": {
+    "registered_at": "2026-08-13",
+    "minimum_history_dates": 24,
+    "minimum_cross_section_tickers": 8,
+    "freshness_half_life_hours": 36,
+    "maximum_event_age_hours": 168,
+    "positive_rank_upsize_threshold": 0.75,
+    "negative_rank_downsize_threshold": 0.25,
+    "sizing": {
+      "factor_top_score": 0.25,
+      "factor_bottom_score": -0.25,
+      "factor_top_multiplier": 1.15,
+      "factor_bottom_multiplier": 0.75,
+      "peer_leader_multiplier": 1.15,
+      "peer_mean_reversion_multiplier": 1.1,
+      "peer_laggard_multiplier": 0.6,
+      "information_positive_multiplier": 1.2,
+      "information_negative_multiplier": 0.6,
+      "minimum_combined_multiplier": 0.5,
+      "maximum_combined_multiplier": 1.5
+    },
+    "discipline": "Continuous information ranks may only resize an already-approved technical tranche after prospective activation; they never create add authority."
+  },
   "novelty_lookback_days": 30,
   "expiry_days": {
     "filing_10k": 30,

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -206,7 +206,8 @@ class _InMemoryPlanPath:
         return str(self._path)
 
 
-def normalize_plan_json(path, ledger_path=None, *, write=True, return_plan=False):
+def normalize_plan_json(path, ledger_path=None, *, decision_packet=None,
+                        write=True, return_plan=False):
     """Fill only machine-owned v2 fields before validation.
 
     ``normalize_authored_plan`` also canonicalizes legacy/default values.  Never
@@ -245,6 +246,10 @@ def normalize_plan_json(path, ledger_path=None, *, write=True, return_plan=False
             authored,
             ledger_path or (WS / 'memory' / 'decisions.jsonl'),
         )
+        if decision_packet:
+            normalized = brief_decision_packet.bind_plan_provenance(
+                normalized, decision_packet
+            )
         if write and normalized != authored:
             path.write_text(
                 json.dumps(normalized, ensure_ascii=False, indent=2) + '\n'
@@ -676,6 +681,7 @@ def main(argv=None):
     issues += readability_issues(readability)
     normalization_issues, normalized_plan = normalize_plan_json(
         plan_path,
+        decision_packet=decision_packet,
         write=not args.dry_run,
         return_plan=True,
     )

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -1808,6 +1808,7 @@ def main(argv=None):
                     for event in current_events[:40]
                 ],
                 'actionable_events': graph.get('actionable_events') or [],
+                'information_overlay': graph.get('information_overlay') or {},
                 'tavily_resolution_queue': (
                     graph.get('tavily_resolution_queue') or []
                 ),

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -44,7 +44,7 @@ SNAP_DIR = WS / "memory" / "snapshots"
 
 SCHEMA_VERSION = 2
 # Bumped when the meaning of an evaluation changes, so a stale row is identifiable.
-EVAL_SCHEMA_VERSION = 3
+EVAL_SCHEMA_VERSION = 4
 # Snapshots and plan_dates are both named on the HK calendar day; comparing them
 # against a UTC "today" slips a day for the eight hours after HK midnight.
 HKT = timezone(timedelta(hours=8))
@@ -183,6 +183,9 @@ def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) ->
         # Additive contract marker: pre-2026-08 plans remain valid/readable, while
         # every newly normalized plan is subject to the technical trace rules.
         "technical_trace_version": 1,
+        # Written by postflight from the generation-pinned decision packet.
+        # A model-authored value is replaced before validation and ledger upsert.
+        "signal_provenance": action.get("signal_provenance"),
         "simulated_entry_price": _float(action.get("simulated_entry_price")),
         "horizon_sessions": int(action.get("horizon_sessions") or 1),
         "override": action.get("override") or {
@@ -701,8 +704,10 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
         # Wipe derived fields so a stale value can never survive a rule change.
         for k in ("triggered", "trigger_session", "execution_price", "capital", "status",
                   "outcome", "underlying_return_t1_pct", "benefit_t1_pct", "benefit_t5_pct",
+                  "benefit_t20_pct",
                   "fill_reason", "fill_assumed", "fill_model", "session_reason",
                   "not_evaluable_reason", "mark_t1_session", "mark_t5_session",
+                  "mark_t20_session",
                   "evaluation_mode", "reference_price", "reference_reason",
                   "condition_role", "pending_reason", "mark_horizon",
                   "evaluation_schema_version"):
@@ -772,9 +777,9 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
                        "not_evaluable_reason": fill_reason})
         else:
             entry = fill
-            marks = next_sessions(leg, sess, 5)
-            b1 = b5 = u1 = None
-            m1 = m5 = None
+            marks = next_sessions(leg, sess, 20)
+            b1 = b5 = b20 = u1 = None
+            m1 = m5 = m20 = None
             reason = None
             if marks:
                 m1 = marks[0]
@@ -797,14 +802,21 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
                 nb5 = bar(ticker, m5)
                 if nb5 is not None and m5 < today:
                     _, b5 = _benefit(d.get("action"), entry, nb5["close"])
+            if len(marks) >= 20:
+                m20 = marks[19]
+                nb20 = bar(ticker, m20)
+                if nb20 is not None and m20 < today:
+                    _, b20 = _benefit(d.get("action"), entry, nb20["close"])
             ev.update({
                 "status": "settled" if b1 is not None else "pending",
                 "outcome": _outcome(b1),
                 "underlying_return_t1_pct": u1,
                 "benefit_t1_pct": b1,
                 "benefit_t5_pct": b5,
+                "benefit_t20_pct": b20,
                 "mark_t1_session": m1 if b1 is not None else None,
                 "mark_t5_session": m5 if b5 is not None else None,
+                "mark_t20_session": m20 if b20 is not None else None,
                 "mark_horizon": "open_of_session_to_close_of_next_session",
             })
             if b1 is None and reason:
@@ -1755,6 +1767,94 @@ def compute_metrics(decisions: list[dict], window_days: int = 30) -> dict:
                     }))}
 
     coverage_active = _coverage([d for d in in_window if d.get("action") in ACTIVE_ACTIONS])
+
+    def _prospective_overlay_metrics(rows: list[dict]) -> dict:
+        """Forward attribution from immutable, decision-time signal snapshots.
+
+        This is intentionally per decision rather than episode elected/averaged:
+        every tactical tranche has its own packet, multiplier and forward path.
+        Date-cluster intervals keep a busy news day from pretending to be many
+        independent samples. Empty cohorts are evidence of warm-up, not success.
+        """
+        eligible = [
+            row for row in rows
+            if row.get("strategy_id") == "tactical_entry"
+            and row.get("action") in ADD_ACTIONS
+            and isinstance(row.get("signal_provenance"), dict)
+            and (row.get("signal_provenance") or {}).get("schema_version") == 1
+        ]
+
+        def cohort(row):
+            sizing = ((row.get("signal_provenance") or {}).get("sizing") or {})
+            contributors = sizing.get("contributors") or []
+            if contributors:
+                return "setup_plus_information"
+            if sizing.get("sizing_active"):
+                return "overlay_active_neutral"
+            return "setup_only"
+
+        def bucket(group: list[dict], key: str) -> dict:
+            values = [
+                _float((row.get("evaluation") or {}).get(key))
+                for row in group
+            ]
+            values = [value for value in values if value is not None]
+            return {
+                "n_decisions": len(group),
+                "n_settled": len(values),
+                "n_dates": len({
+                    row.get("plan_date") for row in group
+                    if _float((row.get("evaluation") or {}).get(key)) is not None
+                }),
+                "win_rate": (
+                    round(sum(value > 0 for value in values) / len(values), 4)
+                    if values else None
+                ),
+                "avg_benefit_pct": (
+                    round(statistics.fmean(values), 4) if values else None
+                ),
+                "cluster_ci95": _cluster_ci(
+                    group,
+                    lambda row: _float((row.get("evaluation") or {}).get(key)),
+                ),
+            }
+
+        by_cohort = defaultdict(list)
+        by_contributor = defaultdict(list)
+        for row in eligible:
+            by_cohort[cohort(row)].append(row)
+            sizing = ((row.get("signal_provenance") or {}).get("sizing") or {})
+            for contributor in sizing.get("contributors") or []:
+                by_contributor[str(contributor)].append(row)
+        horizons = {}
+        for horizon, key in (
+            ("t1", "benefit_t1_pct"),
+            ("t5", "benefit_t5_pct"),
+            ("t20", "benefit_t20_pct"),
+        ):
+            horizons[horizon] = {
+                "cohorts": {
+                    name: bucket(by_cohort.get(name, []), key)
+                    for name in (
+                        "setup_only", "overlay_active_neutral",
+                        "setup_plus_information",
+                    )
+                },
+                "contributors": {
+                    name: bucket(group, key)
+                    for name, group in sorted(by_contributor.items())
+                },
+            }
+        return {
+            "status": "collecting" if eligible else "warming_up",
+            "n_eligible_decisions": len(eligible),
+            "method": (
+                "prospective tactical-entry decisions only; immutable packet-time "
+                "snapshots; date-cluster CI; no retrospective reconstruction"
+            ),
+            "horizons": horizons,
+        }
+
     return {
         "schema_version": SCHEMA_VERSION,
         "method": "episode-level; triggered-only; date-cluster bootstrap; capital-weighted where size exists",
@@ -1794,6 +1894,7 @@ def compute_metrics(decisions: list[dict], window_days: int = 30) -> dict:
         "by_technical_setup": _breakdown(
             reps, lambda r: r.get("technical_setup_id"), "benefit_t1_pct"
         ),
+        "information_overlay": _prospective_overlay_metrics(in_window),
         "execution": dict(execution),
         "active_overrides": len(overrides),
     }

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -11,6 +11,7 @@ a compact contract:
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import math
@@ -183,6 +184,7 @@ def _thesis_view(context: dict, ticker: str) -> dict:
 
 def _execution_view(holding: dict, leg: str, capital: float, cash: float,
                     technical: dict, thesis: dict, leveraged: bool,
+                    overlay: dict | None = None,
                     open_add: bool = False) -> dict:
     price = _number(holding.get("current_price"), 4)
     shares = int(_number(holding.get("shares"), 0) or 0)
@@ -211,7 +213,7 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         / (1 - target_fraction),
     )
     max_value = min(max(cash, 0.0), room_value)
-    max_add_shares = (
+    position_room_shares = (
         int(max_value // (price * lot)) * lot
         if price and lot else 0
     )
@@ -221,23 +223,26 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         if row.get("tranche_pct_of_position")
     ]
     tranche_pct = min(setup_pcts) if setup_pcts else 0.05
-    desired = max(1, int(shares * tranche_pct))
+    overlay = overlay or {}
+    sizing_multiplier = float(overlay.get("sizing_multiplier") or 1.0)
+    desired = max(1, int(shares * tranche_pct * sizing_multiplier))
     suggested = (
         max(lot, (desired // lot) * lot) if lot else 0
     )
-    suggested = min(suggested, max_add_shares)
+    suggested = min(suggested, position_room_shares)
+    max_tranche_shares = suggested
 
     thesis_state = thesis.get("state") or "unknown"
     if thesis_state in {"broken", "damaged", "weakening"}:
         thesis_gate = "blocked"
-        max_add_shares = suggested = 0
+        max_tranche_shares = suggested = 0
     elif thesis_state == "intact":
         thesis_gate = "intact"
     else:
         # No canonical thesis is not treated as intact. It may gather one small
         # prospective sample, but cannot pyramid multiple tranches.
         thesis_gate = "exploration_only"
-        max_add_shares = min(max_add_shares, suggested)
+        max_tranche_shares = min(max_tranche_shares, suggested)
 
     blockers = []
     if leveraged:
@@ -250,7 +255,7 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         blockers.append("no_approved_setup")
     if not price:
         blockers.append("price_missing")
-    if max_add_shares <= 0:
+    if max_tranche_shares <= 0:
         blockers.append("no_cash_or_target_room")
     return {
         "order_unit": "board_lot" if leg == "HK" else "integer_share",
@@ -258,10 +263,19 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         "fractional_shares_supported": False,
         "min_tranche_shares": lot,
         "suggested_tranche_shares": suggested,
-        "max_add_shares": max_add_shares,
-        "max_add_value": round(max_add_shares * price, 2) if price else 0,
+        "max_tranche_shares": max_tranche_shares,
+        # max_add_* is the authority for this decision, while position_room_*
+        # only records the wider concentration/cash envelope.  Conflating the
+        # two lets an authored plan spend every future tranche at once.
+        "max_add_shares": max_tranche_shares,
+        "position_room_shares": position_room_shares,
+        "max_add_value": round(max_tranche_shares * price, 2) if price else 0,
+        "position_room_value": (
+            round(position_room_shares * price, 2) if price else 0
+        ),
         "target_max_pct": target_max_pct,
         "thesis_gate": thesis_gate,
+        "information_overlay": overlay,
         "blockers": sorted(set(blockers)),
     }
 
@@ -289,7 +303,75 @@ def _peer_view(row: dict) -> dict:
         "residual_20d": _number(row.get("residual_blend_20d"), 4),
         "leadership_persistence": row.get("leadership_persistence"),
         "laggard_persistence": row.get("laggard_persistence"),
+        "usable_rules": list(row.get("usable_rules") or []),
         "usable_for_decisions": bool(row.get("usable_for_decisions")),
+    }
+
+
+def _information_view(graph: dict, ticker: str, source_ticker: str) -> dict:
+    overlay = graph.get("information_overlay") or {}
+    rows = overlay.get("tickers") or {}
+    row = rows.get(source_ticker) or rows.get(ticker) or {}
+    return {
+        "as_of": row.get("as_of") or overlay.get("as_of"),
+        "source_ticker": source_ticker,
+        "status": row.get("status") or overlay.get("status") or "missing",
+        "signed_score": _number(row.get("signed_score"), 6),
+        "cross_section_rank": _number(row.get("cross_section_rank"), 4),
+        "own_surprise_z": _number(row.get("own_surprise_z"), 4),
+        "event_count": int(row.get("event_count") or 0),
+        "sizing_tilt": row.get("sizing_tilt") or "inactive",
+        "usable_for_decisions": bool(
+            overlay.get("usable_for_decisions")
+            and row.get("usable_for_decisions")
+        ),
+        "activation_blockers": list(
+            ((overlay.get("activation") or {}).get("blockers") or [])
+        ),
+    }
+
+
+def _information_sizing_overlay(info: dict, factor: dict, peer: dict,
+                                policy: dict) -> dict:
+    multiplier = 1.0
+    contributors = []
+    if factor.get("usable_for_decisions"):
+        score = factor.get("composite_score")
+        if score is not None and score >= policy.get("factor_top_score", 0.25):
+            multiplier *= policy.get("factor_top_multiplier", 1.15)
+            contributors.append("factor_top")
+        elif score is not None and score <= policy.get("factor_bottom_score", -0.25):
+            multiplier *= policy.get("factor_bottom_multiplier", 0.75)
+            contributors.append("factor_bottom")
+    if peer.get("usable_for_decisions"):
+        rules = set(peer.get("usable_rules") or [])
+        if "laggard_avoidance" in rules:
+            multiplier *= policy.get("peer_laggard_multiplier", 0.6)
+            contributors.append("peer_laggard")
+        elif "leader_continuation" in rules:
+            multiplier *= policy.get("peer_leader_multiplier", 1.15)
+            contributors.append("peer_leader")
+        elif "mean_reversion" in rules:
+            multiplier *= policy.get("peer_mean_reversion_multiplier", 1.1)
+            contributors.append("peer_mean_reversion")
+    if info.get("usable_for_decisions"):
+        if info.get("sizing_tilt") == "positive":
+            multiplier *= policy.get("information_positive_multiplier", 1.2)
+            contributors.append("information_positive_surprise")
+        elif info.get("sizing_tilt") == "negative":
+            multiplier *= policy.get("information_negative_multiplier", 0.6)
+            contributors.append("information_negative_or_low_rank")
+    active = any(
+        row.get("usable_for_decisions") for row in (info, factor, peer)
+    )
+    return {
+        "sizing_active": active,
+        "sizing_multiplier": round(min(
+            policy.get("maximum_combined_multiplier", 1.5),
+            max(policy.get("minimum_combined_multiplier", 0.5), multiplier),
+        ), 4),
+        "contributors": contributors,
+        "discipline": "resizes an approved technical tranche; never creates add authority",
     }
 
 
@@ -445,6 +527,7 @@ def _constraints(shares: int, risks: list[dict], actionable_ids: list[str],
         "actionable_evidence_ids": actionable_ids,
         "technical_setup_ids": setup_ids,
         "max_add_shares": execution.get("max_add_shares", 0),
+        "position_room_shares": execution.get("position_room_shares", 0),
         "max_add_value": execution.get("max_add_value", 0),
         "target_max_pct": execution.get("target_max_pct"),
         "min_tranche_shares": execution.get("min_tranche_shares"),
@@ -461,6 +544,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
     peer_rows = (context.get("peer_residual") or {}).get("held") or {}
     sentiment_rows = (context.get("sentiment") or {}).get("tickers") or []
     events = (context.get("news_evidence_graph") or {}).get("events") or []
+    evidence_graph = context.get("news_evidence_graph") or {}
     proxies = _proxy_map(context)
     holdings = list(_active_holdings(context))
     active = {str(holding.get("ticker")) for _, holding in holdings}
@@ -524,9 +608,26 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
         shares = int(_number(holding.get("shares"), 0) or 0)
         ticker_risks = risks.get(ticker) or []
         thesis = _thesis_view(context, ticker)
+        factor_view = _factor_view(
+            cross_rows.get(source_ticker) or cross_rows.get(ticker)
+        )
+        peer_view = _peer_view(
+            peer_rows.get(source_ticker) or peer_rows.get(ticker)
+        )
+        information_view = _information_view(
+            evidence_graph, ticker, source_ticker
+        )
+        sizing_policy = (
+            (evidence_graph.get("information_overlay") or {})
+            .get("sizing_policy") or {}
+        )
+        sizing_overlay = _information_sizing_overlay(
+            information_view, factor_view, peer_view, sizing_policy
+        )
         leveraged = is_leveraged_holding(holding)
         execution = _execution_view(
             holding, leg, invested[leg], cash[leg], technical, thesis, leveraged,
+            overlay=sizing_overlay,
             open_add=open_add_gate_error or ticker in open_adds,
         )
         tickers[ticker] = {
@@ -547,8 +648,8 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             "thesis": thesis,
             "execution": execution,
             "quant": {
-                "factor": _factor_view(cross_rows.get(source_ticker) or cross_rows.get(ticker)),
-                "peer_residual": _peer_view(peer_rows.get(source_ticker) or peer_rows.get(ticker)),
+                "factor": factor_view,
+                "peer_residual": peer_view,
                 "activation": {
                     "factor": bool(
                         ((context.get("cross_sectional_factor") or {}).get("activation") or {})
@@ -561,6 +662,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 },
             },
             "sentiment": _sentiment_view(sentiment_rows, ticker, source_ticker),
+            "information": information_view,
             "evidence": matching_events,
             "risk": ticker_risks,
             "status": _status(technical, ticker_risks),
@@ -616,6 +718,48 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
     if size > MAX_PACKET_BYTES:
         raise ValueError(f"decision packet exceeds {MAX_PACKET_BYTES} bytes: {size}")
     return packet
+
+
+def _decision_provenance(packet: dict, ticker: str) -> dict | None:
+    """Machine-owned point-in-time signal state for one ledger decision."""
+    row = (packet.get("tickers") or {}).get(str(ticker))
+    if not row:
+        return None
+    execution = row.get("execution") or {}
+    quant = row.get("quant") or {}
+    return {
+        "schema_version": 1,
+        "context_generation_id": (packet.get("_meta") or {}).get("generation_id"),
+        "observed_at": packet.get("generated_at"),
+        "information": copy.deepcopy(row.get("information") or {}),
+        "factor": copy.deepcopy(quant.get("factor") or {}),
+        "peer_residual": copy.deepcopy(quant.get("peer_residual") or {}),
+        "sizing": copy.deepcopy(execution.get("information_overlay") or {}),
+        "authority": {
+            "max_add_shares": (row.get("constraints") or {}).get("max_add_shares"),
+            "position_room_shares": (
+                row.get("constraints") or {}
+            ).get("position_room_shares"),
+            "lot_size": (row.get("constraints") or {}).get("lot_size"),
+        },
+    }
+
+
+def bind_plan_provenance(plan: dict, packet: dict) -> dict:
+    """Replace any model-supplied signal claims with packet-owned snapshots.
+
+    The packet is hash-bound to the preflight generation.  Persisting this copy
+    is what makes later T+1/T+5/T+20 attribution use the facts visible at the
+    decision, rather than today's revised news/factor files.
+    """
+    bound = copy.deepcopy(plan)
+    for decision in bound.get("decisions") or []:
+        provenance = _decision_provenance(packet, decision.get("ticker"))
+        if provenance is not None:
+            decision["signal_provenance"] = provenance
+        else:
+            decision.pop("signal_provenance", None)
+    return bound
 
 
 def summary_view(packet: dict) -> dict:
@@ -803,15 +947,15 @@ def validate_plan_constraints(plan: dict, packet: dict) -> list[str]:
             lot = _number(constraints.get("lot_size"), 0)
             if shares is None or shares <= 0:
                 issues.append(f"{tag}: add requires positive integer size.shares")
-            elif shares > max_add:
-                issues.append(
-                    f"{tag}: size.shares {shares:g} exceeds max_add_shares {max_add:g}"
-                )
             elif int(shares) != shares:
                 issues.append(f"{tag}: fractional shares are not supported")
             elif lot and int(shares) % int(lot) != 0:
                 issues.append(
                     f"{tag}: size.shares {shares:g} is not a board-lot multiple of {lot:g}"
+                )
+            elif shares > max_add:
+                issues.append(
+                    f"{tag}: size.shares {shares:g} exceeds max_add_shares {max_add:g}"
                 )
 
             condition = decision.get("condition") or {}

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -13,7 +13,9 @@ Writes:
 import argparse
 import hashlib
 import json
+import math
 import re
+import statistics
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -27,6 +29,7 @@ FACTOR_CONFIG = WS / 'config' / 'factor-universe.json'
 EM_NEWS = WS / 'assets' / 'data' / 'em_news.json'
 US_NEWS = WS / 'assets' / 'data' / 'us_news_digest.json'
 SENTIMENT = WS / 'assets' / 'data' / 'sentiment.json'
+INFLUENCER = WS / 'assets' / 'data' / 'influencer_feed.json'
 CATALYSTS = WS / 'assets' / 'data' / 'catalysts.json'
 PEER_RESIDUAL = WS / 'assets' / 'data' / 'peer_residual.json'
 CROSS_FACTOR = WS / 'assets' / 'data' / 'cross_sectional_factor.json'
@@ -75,7 +78,7 @@ def load_policy(path=POLICY):
     return policy
 
 
-def normalize_timestamp(value, fallback=None):
+def normalize_timestamp(value, fallback=None, naive_timezone=timezone.utc):
     """Return UTC ISO timestamp plus input precision."""
     if isinstance(value, (int, float)) and value > 0:
         return {
@@ -91,7 +94,7 @@ def normalize_timestamp(value, fallback=None):
             parsed = datetime.fromisoformat(candidate)
             precision = 'date' if len(text) == 10 else 'minute'
             if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
+                parsed = parsed.replace(tzinfo=naive_timezone)
             return {'iso': parsed.astimezone(timezone.utc).isoformat(),
                     'precision': precision}
         except ValueError:
@@ -99,12 +102,19 @@ def normalize_timestamp(value, fallback=None):
         for fmt in ('%Y/%m/%d %H:%M', '%Y-%m-%d %H:%M',
                     '%a, %d %b %Y %H:%M:%S %Z'):
             try:
-                parsed = datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
-                return {'iso': parsed.isoformat(), 'precision': 'minute'}
+                parsed = datetime.strptime(text, fmt).replace(
+                    tzinfo=naive_timezone
+                )
+                return {
+                    'iso': parsed.astimezone(timezone.utc).isoformat(),
+                    'precision': 'minute',
+                }
             except ValueError:
                 continue
     if fallback:
-        return normalize_timestamp(fallback)
+        return normalize_timestamp(
+            fallback, naive_timezone=naive_timezone
+        )
     return {'iso': None, 'precision': 'unknown'}
 
 
@@ -248,7 +258,17 @@ def source_type(origin='', source='', url='', title=''):
 def make_event(policy, *, ticker, title, published_at, origin,
                source='', url='', event_type=None, event_time=None,
                reported_ticker=None, metadata=None):
-    published = normalize_timestamp(published_at)
+    # Eastmoney emits timezone-naive China timestamps. Treating those as UTC
+    # moves the evidence eight hours into the future and corrupts both cutoff
+    # and decay. Other current producers either include an offset/RFC zone or
+    # use UTC; keep their existing interpretation.
+    source_timezone = (
+        timezone(timedelta(hours=8))
+        if str(origin or '').startswith('eastmoney') else timezone.utc
+    )
+    published = normalize_timestamp(
+        published_at, naive_timezone=source_timezone
+    )
     event_ts = normalize_timestamp(event_time) if event_time else published
     kind = classify_event(title, event_type)
     src_type = source_type(origin, source, url, title)
@@ -384,6 +404,48 @@ def collect_sentiment_news_events(policy, underlying):
                     source=item.get('source') or 'Google News',
                     url=item.get('url') or '',
                 ))
+    return events
+
+
+def collect_influencer_events(policy, underlying):
+    """Import named-ticker statements; sector inference never becomes a node.
+
+    The influencer producer explicitly separates direct ticker extraction from
+    broad sector matches. Only the former is attributable enough for an alpha
+    feature. `relevance` and stance are preserved as metadata, while the source
+    tier keeps secondary Musk coverage weak and direct Trump/Substack URLs
+    auditable rather than promoting every mention to primary evidence.
+    """
+    payload = _load(INFLUENCER)
+    events = []
+    seen = set()
+    for item in payload.get('items') or []:
+        title = item.get('text') or item.get('summary_cn')
+        for reported in item.get('tickers') or []:
+            ticker = underlying.get(reported, reported)
+            key = (ticker, title, item.get('published'))
+            if not ticker or key in seen:
+                continue
+            seen.add(key)
+            events.append(make_event(
+                policy,
+                ticker=ticker,
+                reported_ticker=reported,
+                title=title,
+                published_at=(
+                    item.get('published') or payload.get('generated_at')
+                ),
+                origin=item.get('origin') or 'llm_digest_legacy',
+                source=item.get('source') or item.get('author') or '',
+                url=item.get('url') or '',
+                metadata={
+                    'channel': 'influencer_feed',
+                    'author': item.get('author'),
+                    'stance': item.get('stance'),
+                    'relevance': item.get('relevance'),
+                    'direct_ticker_only': True,
+                },
+            ))
     return events
 
 
@@ -834,6 +896,202 @@ def gate_events(policy, events):
     return events
 
 
+def _event_information_component(event, now, overlay_policy):
+    """Signed, decayed information magnitude; polarity alone is never enough."""
+    published = (event.get('publication_time') or {}).get('iso')
+    try:
+        observed = datetime.fromisoformat(published)
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=timezone.utc)
+        # The snapshot is point-in-time. A timestamp after its cutoff is not
+        # "maximally fresh"; it is unavailable information and must be absent.
+        if observed > now:
+            return None
+        age_hours = (now - observed).total_seconds() / 3600
+    except Exception:
+        return None
+    if age_hours > overlay_policy['maximum_event_age_hours']:
+        return None
+    direction = {'positive': 1, 'negative': -1}.get(
+        event.get('impact_direction'), 0
+    )
+    if not direction or event.get('ticker') == 'MARKET':
+        return None
+    novelty = float(event.get('novelty_score') or 0)
+    reliability = float(event.get('source_reliability') or 0)
+    sources = max(1, int(event.get('corroborating_source_count') or 1))
+    corroboration = min(1.0, 0.5 + 0.25 * (sources - 1))
+    freshness = math.exp(
+        -math.log(2) * age_hours
+        / float(overlay_policy['freshness_half_life_hours'])
+    )
+    confirmation = event.get('confirmation') or {}
+    # An aligned move is evidence the event is real but also that part of it has
+    # already reached price. Preserve the signal while reducing unpriced room.
+    price_nonreaction = 0.6 if confirmation.get('price_aligned') else 1.0
+    magnitude = novelty * reliability * corroboration * freshness * price_nonreaction
+    return {
+        'event_id': event.get('event_id'),
+        'published_at': published,
+        'direction': direction,
+        'novelty': round(novelty, 4),
+        'reliability': round(reliability, 4),
+        'corroborating_sources': sources,
+        'freshness': round(freshness, 4),
+        'price_nonreaction': price_nonreaction,
+        'signed_score': round(direction * magnitude, 6),
+    }
+
+
+def _history_information_rows(history, overlay_policy):
+    rows = []
+    for snapshot in history:
+        as_of = str(snapshot.get('as_of') or '')[:10]
+        by_ticker = {}
+        for event in snapshot.get('events') or []:
+            score = event.get('information_signed_score')
+            ticker = str(event.get('ticker') or '')
+            if ticker and isinstance(score, (int, float)):
+                by_ticker[ticker] = by_ticker.get(ticker, 0.0) + float(score)
+        for ticker, score in by_ticker.items():
+            rows.append({'as_of': as_of, 'ticker': ticker, 'score': score})
+    return rows
+
+
+def _history_information_dates(history):
+    """Registered point-in-time snapshots, including days with zero signal."""
+    return sorted({
+        str(snapshot.get('as_of') or '')[:10]
+        for snapshot in history
+        if snapshot.get('information_overlay_schema_version') == 1
+        and snapshot.get('as_of')
+    })
+
+
+def build_information_overlay(policy, events, history, now):
+    """Ticker surprise and cross-sectional rank from already-collected evidence."""
+    overlay_policy = policy['information_overlay']
+    components = {}
+    covered_tickers = set()
+    for event in events:
+        ticker = str(event.get('ticker') or '')
+        published = (event.get('publication_time') or {}).get('iso')
+        try:
+            observable = datetime.fromisoformat(published)
+            if observable.tzinfo is None:
+                observable = observable.replace(tzinfo=timezone.utc)
+        except Exception:
+            observable = None
+        if ticker and ticker != 'MARKET' and observable and observable <= now:
+            covered_tickers.add(ticker)
+        component = _event_information_component(event, now, overlay_policy)
+        if component is None:
+            continue
+        event['information_signed_score'] = component['signed_score']
+        components.setdefault(ticker, []).append(component)
+
+    historical = _history_information_rows(history, overlay_policy)
+    history_dates = _history_information_dates(history)
+    # Cross-sectional coverage is the names the current source snapshots can
+    # observe, not only names whose headline classifier emitted a direction.
+    # A covered name with no qualifying event is a real zero signal. Dropping
+    # those names makes activation depend on how excitable today's headlines
+    # are and can leave a well-covered universe permanently warming up.
+    eligible_tickers = sorted(covered_tickers)
+    activation_checks = {
+        'history_dates': {
+            'actual': len(history_dates),
+            'required': overlay_policy['minimum_history_dates'],
+            'pass': len(history_dates) >= overlay_policy['minimum_history_dates'],
+        },
+        'cross_section_tickers': {
+            'actual': len(eligible_tickers),
+            'required': overlay_policy['minimum_cross_section_tickers'],
+            'pass': len(eligible_tickers) >= overlay_policy['minimum_cross_section_tickers'],
+        },
+    }
+    active = all(check['pass'] for check in activation_checks.values())
+
+    raw = {
+        ticker: sum(row['signed_score'] for row in components.get(ticker, []))
+        for ticker in eligible_tickers
+    }
+    # Mid-rank ties. Ticker spelling must never decide which equal-score name
+    # lands above an activation threshold.
+    ranks = {}
+    ordered_scores = sorted(raw.values())
+    for ticker, score in raw.items():
+        positions = [
+            index for index, value in enumerate(ordered_scores)
+            if value == score
+        ]
+        ranks[ticker] = (
+            statistics.fmean(index + 0.5 for index in positions)
+            / len(ordered_scores)
+        )
+    ticker_rows = {}
+    for ticker in eligible_tickers:
+        by_day = {
+            row['as_of']: row['score']
+            for row in historical if row['ticker'] == ticker
+        }
+        # No qualifying event on a registered day is a real zero observation,
+        # not missing data. Event-day-only baselines overstate normal intensity.
+        own = [by_day.get(day, 0.0) for day in history_dates]
+        mean = statistics.fmean(own) if own else None
+        stdev = statistics.pstdev(own) if len(own) >= 2 else None
+        surprise = (
+            (raw[ticker] - mean) / stdev
+            if mean is not None and stdev and stdev > 0 else None
+        )
+        ticker_rows[ticker] = {
+            'ticker': ticker,
+            'as_of': now.isoformat(),
+            'signed_score': round(raw[ticker], 6),
+            'cross_section_rank': round(ranks[ticker], 4),
+            'own_history_dates': len(history_dates),
+            'own_surprise_z': round(surprise, 4) if surprise is not None else None,
+            'event_count': len(components.get(ticker, [])),
+            'sizing_tilt': (
+                'positive'
+                if (active
+                    and ranks[ticker] >= overlay_policy['positive_rank_upsize_threshold']
+                    and raw[ticker] > 0)
+                else 'negative'
+                if (active and (
+                    ranks[ticker] <= overlay_policy['negative_rank_downsize_threshold']
+                    or raw[ticker] < 0
+                ))
+                else 'neutral' if active else 'inactive'
+            ),
+            'event_components': sorted(
+                components.get(ticker, []),
+                key=lambda row: row['published_at'], reverse=True
+            )[:8],
+            'status': 'active' if active else 'warming_up',
+            'usable_for_decisions': active,
+        }
+    return {
+        'schema_version': 1,
+        'as_of': now.isoformat(),
+        'registered_at': overlay_policy['registered_at'],
+        'status': 'active' if active else 'warming_up',
+        'usable_for_decisions': active,
+        'activation': {
+            'checks': activation_checks,
+            'blockers': [name for name, check in activation_checks.items()
+                         if not check['pass']],
+            'discipline': overlay_policy['discipline'],
+        },
+        'sizing_thresholds': {
+            'positive_rank': overlay_policy['positive_rank_upsize_threshold'],
+            'negative_rank': overlay_policy['negative_rank_downsize_threshold'],
+        },
+        'sizing_policy': overlay_policy['sizing'],
+        'tickers': ticker_rows,
+    }
+
+
 def tavily_queue(policy, events):
     queue = []
     for event in events:
@@ -902,6 +1160,7 @@ def update_history(as_of, events):
     ]
     snapshots.append({
         'as_of': as_of,
+        'information_overlay_schema_version': 1,
         'events': [
             {
                 'event_id': event['event_id'],
@@ -917,6 +1176,7 @@ def update_history(as_of, events):
                 'published_at': event['publication_time'].get('iso'),
                 'status': event['status'],
                 'actionable_escalation': event['actionable_escalation'],
+                'information_signed_score': event.get('information_signed_score'),
             }
             for event in events
         ],
@@ -955,6 +1215,7 @@ def main(argv=None):
         *collect_em_events(policy, underlying),
         *collect_us_news_events(policy, underlying),
         *collect_sentiment_news_events(policy, underlying),
+        *collect_influencer_events(policy, underlying),
         *collect_catalyst_events(policy, underlying),
     ]
     events = deduplicate_events(events)
@@ -968,6 +1229,9 @@ def main(argv=None):
         _load(CROSS_FACTOR),
     )
     events = gate_events(policy, events)
+    information_overlay = build_information_overlay(
+        policy, events, history, now
+    )
     queue = tavily_queue(policy, events)
     update_history(now.date().isoformat(), events)
     out = {
@@ -975,6 +1239,7 @@ def main(argv=None):
         'generated_at': now.isoformat(),
         'as_of': now.date().isoformat(),
         'events': events,
+        'information_overlay': information_overlay,
         'actionable_events': [
             event['event_id'] for event in events
             if event['actionable_escalation']
@@ -986,6 +1251,7 @@ def main(argv=None):
             'eastmoney': 'loaded' if EM_NEWS.exists() else 'missing',
             'us_news_digest': 'loaded' if US_NEWS.exists() else 'missing',
             'sentiment_news': 'loaded' if SENTIMENT.exists() else 'missing',
+            'influencer_feed': 'loaded' if INFLUENCER.exists() else 'missing',
             'catalysts': 'loaded' if CATALYSTS.exists() else 'missing',
             'peer_residual': 'loaded' if PEER_RESIDUAL.exists() else 'missing',
         },
@@ -1000,6 +1266,7 @@ def main(argv=None):
             'actionable_escalations': sum(
                 event['actionable_escalation'] for event in events
             ),
+            'information_overlay_status': information_overlay['status'],
             'tavily_resolution_queue': len(queue),
         },
         'policy': {

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -436,12 +436,62 @@ def test_add_room_solves_the_post_trade_60_percent_boundary():
     execution = packet["tickers"]["00100"]["execution"]
 
     # (500 + 250) / (1_000 + 250) == 60%; cash is only an affordability cap.
-    assert execution["max_add_shares"] == 40  # one more 20-share lot would exceed 60%
-    assert (500 + execution["max_add_value"]) / (
-        1_000 + execution["max_add_value"]
+    # Concentration room and one-tranche authority are distinct. The setup only
+    # authorizes 10% of the existing 100 shares = one 20-share board lot.
+    assert execution["position_room_shares"] == 40
+    assert execution["max_add_shares"] == 20
+    assert execution["max_tranche_shares"] == 20
+    assert (500 + execution["position_room_value"]) / (
+        1_000 + execution["position_room_value"]
     ) < 0.60
-    next_lot_value = execution["max_add_value"] + 20 * 5
+    next_lot_value = execution["position_room_value"] + 20 * 5
     assert (500 + next_lot_value) / (1_000 + next_lot_value) > 0.60
+
+
+def test_inactive_and_active_information_only_resize_existing_authority():
+    context = _context()
+    base = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )["tickers"]["00100"]
+    assert base["execution"]["information_overlay"]["sizing_multiplier"] == 1
+
+    context["news_evidence_graph"]["information_overlay"] = {
+        "as_of": "2026-07-28T08:00:00+08:00",
+        "status": "active", "usable_for_decisions": True,
+        "activation": {"blockers": []},
+        "tickers": {"00100": {
+            "status": "active", "usable_for_decisions": True,
+            "signed_score": 0.4, "cross_section_rank": 0.9,
+            "sizing_tilt": "positive", "event_count": 2,
+        }},
+    }
+    active = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )["tickers"]["00100"]
+    assert active["execution"]["information_overlay"]["sizing_multiplier"] == 1.2
+    assert active["constraints"]["max_add_shares"] <= active["constraints"]["position_room_shares"]
+
+    # Removing the setup removes action authority even though information stays high.
+    context["quant_signals"]["rows"]["00100"]["technical_setups"] = []
+    no_setup = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )["tickers"]["00100"]
+    assert "add_only_on_trigger" not in no_setup["constraints"]["allowed_actions"]
+
+
+def test_plan_provenance_is_replaced_from_generation_bound_packet():
+    packet = _compiled()
+    plan = {"decisions": [{
+        "ticker": "00100",
+        "signal_provenance": {"information": {"signed_score": 999}},
+    }]}
+
+    bound = packet_mod.bind_plan_provenance(plan, packet)
+
+    provenance = bound["decisions"][0]["signal_provenance"]
+    assert provenance["context_generation_id"] == packet["_meta"]["generation_id"]
+    assert provenance["information"] == packet["tickers"]["00100"]["information"]
+    assert provenance["information"].get("signed_score") != 999
 
 
 def _catalyst(action, evidence_id, ticker="00100"):

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -57,6 +57,32 @@ def test_machine_owned_fields_are_normalized_before_validation(tmp_path):
     assert brief_postflight.validate_plan_json(path) == []
 
 
+def test_packet_provenance_overwrites_authored_claim(tmp_path):
+    path = _write_authored_plan(tmp_path, _authored_decision(
+        signal_provenance={"information": {"signed_score": 999}},
+    ))
+    packet = {
+        "_meta": {"generation_id": "gen-real"},
+        "generated_at": "2026-07-30T08:00:00+08:00",
+        "tickers": {"AAA": {
+            "information": {"signed_score": -0.2},
+            "quant": {"factor": {}, "peer_residual": {}},
+            "execution": {"information_overlay": {
+                "sizing_multiplier": 0.6,
+                "contributors": ["information_negative_or_low_rank"],
+            }},
+            "constraints": {"max_add_shares": 0, "position_room_shares": 0},
+        }},
+    }
+
+    assert brief_postflight.normalize_plan_json(
+        path, tmp_path / "decisions.jsonl", decision_packet=packet
+    ) == []
+    provenance = json.loads(path.read_text())["decisions"][0]["signal_provenance"]
+    assert provenance["context_generation_id"] == "gen-real"
+    assert provenance["information"]["signed_score"] == -0.2
+
+
 def test_semantic_authoring_error_is_not_rewritten_into_a_valid_default(tmp_path):
     path = _write_authored_plan(
         tmp_path,

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -83,6 +83,40 @@ def test_metrics_attribute_settled_technical_adds_to_the_named_setup():
     assert metrics["by_technical_setup"]["trend_pullback"]["avg_benefit_pct"] == 2.5
 
 
+def test_metrics_attribute_packet_time_overlay_at_three_horizons():
+    base = decision(
+        "2026-07-01", strategy="tactical_entry",
+        action="add_only_on_trigger", benefit=1.0,
+    )
+    base["technical_setup_id"] = "trend_pullback"
+    base["signal_provenance"] = {
+        "schema_version": 1,
+        "sizing": {"sizing_active": False, "contributors": []},
+    }
+    base["evaluation"]["benefit_t20_pct"] = 3.0
+    informed = copy.deepcopy(base)
+    informed["decision_id"] = "dec-informed"
+    informed["episode_id"] = "ep-informed"
+    informed["ticker"] = "BBB"
+    informed["signal_provenance"]["sizing"] = {
+        "sizing_active": True,
+        "sizing_multiplier": 1.2,
+        "contributors": ["information_positive_surprise"],
+    }
+    informed["evaluation"].update(
+        benefit_t1_pct=2.0, benefit_t5_pct=4.0, benefit_t20_pct=8.0,
+    )
+
+    overlay = dv2.compute_metrics(
+        [base, informed], window_days=365
+    )["information_overlay"]
+
+    assert overlay["n_eligible_decisions"] == 2
+    assert overlay["horizons"]["t1"]["cohorts"]["setup_only"]["n_settled"] == 1
+    assert overlay["horizons"]["t5"]["cohorts"]["setup_plus_information"]["avg_benefit_pct"] == 4.0
+    assert overlay["horizons"]["t20"]["contributors"]["information_positive_surprise"]["avg_benefit_pct"] == 8.0
+
+
 def decision(day, ticker="AAA", strategy="core_position", action="hold_and_watch",
              benefit=1.0, triggered=True, capital=100.0):
     d = dv2.legacy_action_to_decision({

--- a/tests/test_news_evidence_graph.py
+++ b/tests/test_news_evidence_graph.py
@@ -65,6 +65,83 @@ def test_normalize_timestamp_and_event_id_include_event_time():
     assert first['event_id'] != second['event_id']
 
 
+def test_eastmoney_naive_timestamp_is_hkt_and_future_event_is_excluded():
+    event = graph.make_event(
+        POLICY, ticker='00100', title='获批新合同',
+        published_at='2026-07-26 08:00', origin='eastmoney-search',
+    )
+    event['novelty_score'] = 1.0
+    # 08:00 HKT is midnight UTC, so it is already observable at 00:30 UTC.
+    component = graph._event_information_component(
+        event, datetime(2026, 7, 26, 0, 30, tzinfo=timezone.utc),
+        POLICY['information_overlay'],
+    )
+    assert event['publication_time']['iso'] == '2026-07-26T00:00:00+00:00'
+    assert component is not None
+
+    event['publication_time']['iso'] = '2026-07-26T01:00:00+00:00'
+    assert graph._event_information_component(
+        event, datetime(2026, 7, 26, 0, 30, tzinfo=timezone.utc),
+        POLICY['information_overlay'],
+    ) is None
+
+
+def test_information_history_counts_registered_zero_signal_days():
+    history = [{
+        'as_of': f'2026-07-{day:02d}',
+        'information_overlay_schema_version': 1,
+        'events': ([{'ticker': 'ABC', 'information_signed_score': 1.0}]
+                   if day == 1 else []),
+    } for day in range(1, 4)]
+    event = _event(title='ABC receives approval and raises guidance')
+    event.update(novelty_score=1.0, corroborating_source_count=1)
+    overlay = graph.build_information_overlay(POLICY, [event], history, NOW)
+
+    assert overlay['activation']['checks']['history_dates']['actual'] == 3
+    assert overlay['tickers']['ABC']['own_history_dates'] == 3
+
+
+def test_information_cross_section_uses_midrank_for_ties():
+    first = _event(
+        title='ABC receives approval', ticker='ABC',
+        published_at=NOW.isoformat(),
+    )
+    second = _event(
+        title='XYZ receives approval', ticker='XYZ',
+        published_at=NOW.isoformat(),
+    )
+    for event in (first, second):
+        event.update(novelty_score=1.0, corroborating_source_count=1)
+
+    overlay = graph.build_information_overlay(
+        POLICY, [first, second], [], NOW
+    )
+
+    assert overlay['tickers']['ABC']['cross_section_rank'] == 0.5
+    assert overlay['tickers']['XYZ']['cross_section_rank'] == 0.5
+
+
+def test_covered_name_without_direction_is_a_zero_not_missing():
+    directed = _event(
+        title='ABC receives approval', ticker='ABC',
+        published_at=NOW.isoformat(),
+    )
+    directed.update(novelty_score=1.0, corroborating_source_count=1)
+    neutral = _event(
+        title='XYZ publishes a general corporate update', ticker='XYZ',
+        published_at=NOW.isoformat(),
+    )
+    neutral.update(novelty_score=1.0, corroborating_source_count=1)
+
+    overlay = graph.build_information_overlay(
+        POLICY, [directed, neutral], [], NOW
+    )
+
+    assert overlay['activation']['checks']['cross_section_tickers']['actual'] == 2
+    assert overlay['tickers']['XYZ']['signed_score'] == 0
+    assert overlay['tickers']['XYZ']['event_count'] == 0
+
+
 def test_source_type_rejects_sec_domain_substring_spoofing():
     assert graph.source_type(
         origin='gnews-rss',
@@ -91,6 +168,34 @@ def test_deduplicate_prefers_primary_source_and_keeps_corroboration():
     assert result[0]['source_type'] == 'sec_filing'
     assert result[0]['duplicate_event_ids'] == [weak['event_id']]
     assert result[0]['corroborating_source_count'] == 2
+
+
+def test_influencer_import_uses_direct_tickers_not_sector_inference(
+    tmp_path, monkeypatch
+):
+    feed = tmp_path / 'influencer_feed.json'
+    feed.write_text(json.dumps({
+        'generated_at': NOW.isoformat(),
+        'items': [{
+            'author': 'Musk',
+            'text': 'Tesla contract award expands capacity',
+            'published': NOW.isoformat(),
+            'origin': 'gnews-rss',
+            'source': 'Reuters',
+            'url': 'https://reuters.com/example',
+            'tickers': ['TSLA'],
+            'sector_holdings': ['PLTU'],
+            'stance': 'endorse',
+            'relevance': 80,
+        }],
+    }))
+    monkeypatch.setattr(graph, 'INFLUENCER', feed)
+
+    events = graph.collect_influencer_events(POLICY, {})
+
+    assert [event['ticker'] for event in events] == ['TSLA']
+    assert events[0]['metadata']['channel'] == 'influencer_feed'
+    assert events[0]['metadata']['direct_ticker_only'] is True
 
 
 def test_deduplicate_collapses_paraphrased_event_summaries():


### PR DESCRIPTION
## Outcome

Turns existing evidence, sentiment-news, influencer, factor and peer-residual artifacts into a prospective information overlay instead of leaving them as decorative prose.

## Mechanism

- scores deduplicated ticker events as signed `novelty × reliability × corroboration × freshness × price non-reaction`
- imports direct-ticker influencer statements while excluding sector inference from alpha
- enforces point-in-time timestamps, HKT handling for Eastmoney, future-event exclusion, zero-signal history days and tie-safe cross-sectional mid-ranks
- stays `warming_up` until 24 registered history dates and 8 current cross-section tickers exist
- lets only already-activated factor/peer/information signals resize an already-approved technical tranche, bounded to `[0.5, 1.5]`
- separates one-tranche authority from remaining concentration room; risk, thesis, leveraged-product, cash and board-lot gates remain final
- overwrites model-supplied provenance with the generation-bound packet snapshot and persists information/factor/peer/sizing contributors in the decision ledger
- reports prospective setup-only vs setup+information outcomes at T+1/T+5/T+20 without reconstructing old signals from newer data

## Evidence

- focused strategy/decision suite: 122 passed
- compileall passed
- `git diff --check` passed
- live sidecar smoke: 111 events; overlay correctly `warming_up`; influencer source loaded

Tests are the regression backstop; no alpha efficacy is claimed before prospective samples settle.

Closes #502
