### PR TITLE
feat: add quant and information add campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Every trading day the system pulls fresh prices, FX, volatility, earnings and ma
 
 ## The information layer
 
-Reading the market is most of what the LLM does, so the widest part of the system is data collection. The repository catalogs **39 fetch and compute modules across 8 layers**, with **bilingual Hong Kong + US coverage** — live quotes, SEC + Eastmoney filings, capital flow, earnings calendars, macro (VIX / DXY / 10Y), Reddit and news sentiment, and market-moving social feeds. Each brief consumes the subset relevant to that market and session. Collection stays broad; the decision layer stays constrained.
+Reading the market is most of what the LLM does, so the widest part of the system is data collection. The repository catalogs **40 fetch and compute modules across 8 layers**, with **bilingual Hong Kong + US coverage** — live quotes, SEC + Eastmoney filings, capital flow, earnings calendars, macro (VIX / DXY / 10Y), Reddit and news sentiment, and market-moving social feeds. Each brief consumes the subset relevant to that market and session. Collection stays broad; the decision layer stays constrained.
 
 | Layer | Modules | Primary sources |
 |---|:---:|---|
@@ -89,7 +89,7 @@ Reading the market is most of what the LLM does, so the widest part of the syste
 | 5 · Macro & sentiment | 3 | Yahoo · Reddit · CNN · social feeds |
 | 6 · Quant & risk | 8 | deterministic math over price history |
 | 7 · Book & FX integrity | 6 | Frankfurter · the reconciliation ledger · local invariants |
-| 8 · Backtest & calibration | 6 | local snapshots + canonical bars |
+| 8 · Backtest & calibration | 7 | local snapshots + canonical bars |
 
 The fetch layer degrades gracefully: every live Eastmoney call routes through **one throttled gateway**, critical paths (quotes, FX) use **multi-source fallback**, and an empty fetch **keeps the prior value** instead of overwriting a good series with a blank. Public sources include Tencent, stooq, yfinance, Frankfurter, SEC EDGAR, Finnhub, Nasdaq, Eastmoney, Polygon, Alpha Vantage, Reddit, and Google News — full command and provider catalog in [the command reference](https://github.com/KCNyu/clawock/blob/master/docs/reference/commands.md), whose inventory is generated from the same registries this table is checked against. Which module sits in which layer is itself an artifact — [`config/information-layers.json`](https://github.com/KCNyu/clawock/blob/master/config/information-layers.json), where every packaged command is either in a layer or listed with the reason it is not collection — and CI checks the table above against it, so a module that moves cannot leave its count standing.
 
@@ -123,6 +123,14 @@ Analysis resolves into explicit, gated strategy decisions — and one stock can 
 
 - **Several strategies, graded separately.** `core_position`, `risk_rebalance`, `intraday_t`, `event_trade`, and `tactical_entry` can coexist on the same name, because a long-term thesis and an intraday trade can legitimately disagree. Each is graded in its own episode.
 - **Attribution-first.** Every decision is tagged by its dominant driver, and that driver's edge is measured *dynamically* from the record — no hit rate is hard-coded into the logic.
+
+### Low-frequency add campaigns
+
+Adds use a stateful interaction rather than treating a moving average as alpha. Within each market, the factor rank and curated-peer residual form one `price_relative` evidence family. Point-in-time news contributes a separate family through reliable positive surprise or source-weighted attention that has accelerated against the same name's own earlier snapshots. An add needs both families; negative information or peer-laggard evidence blocks it. Separate enter/exit ranks give an open campaign hysteresis, so a small rank wobble cannot churn permission off and on.
+
+Authority, sizing and execution stay separate. A warming policy may collect one 2.5% exploration tranche per ticker and policy version; that is not validated authority and cannot be used on daily-reset leveraged products. One indivisible broker unit is allowed only while it remains inside the 3% market-book exploration cap, so an expensive board lot cannot masquerade as a small sample. Validated campaigns may approach their target in several tranches. The price setup only schedules an authorized tranche for the next five local sessions: next-session execution, invalidation first, gap-aware fills, separate HK/US ranks, calendars and lot rules.
+
+Every held name remains visible as `eligible`, `waiting_timing`, `risk_blocked`, `already_at_target`, `constraint_blocked`, or `insufficient_evidence`. Thus zero orders can be a legitimate result, but a bare `add=0` is not. `clawock evaluate-add-alpha` compares setup-only, price-relative, information and interaction variants at T+1/T+5/T+20; current-universe and legacy-news replay is labeled diagnostic and survivorship-limited, never promoted into validated alpha.
 - **Falsify, don't confirm.** In a risk-on tape the default is HOLD. A bullish story doesn't trigger a buy until it clears a disconfirming check and an "is this already priced in?" test on the last few days' move.
 - **Regime over timing.** Leverage isn't timed; a 200-day-trend × volatility dial sets the cap. The backtested lesson: the edge was in *de-leveraging in the wrong regime*, not in calling tops.
 
@@ -194,8 +202,9 @@ That path is covered by a large unit-test suite — it's what keeps the system s
 | **Concentration per leg** | `HHI = Σ wᵢ²` per book: `<0.15` ✅ · `0.15–0.25` 🟡 · `0.25–0.40` 🟠 · `>0.40` 🔴. Never blended across currencies. |
 | **Leverage judged by regime** | A 200-day-trend × volatility dial caps the leverage-ETF sleeve (×1 / ×0.5 / ×0); daily-reset 2×/3× products skip fundamentals entirely. |
 | **Return on peak principal** | Return % uses peak net deposits from the cash-flow ledger, not `cost − realized` — a realized win must not fake a higher return. |
-| **News needs an evidence graph** | Filings, issuer/exchange news, calendars, and headlines are deduplicated into expiring event IDs. Only a reliable, novel, negative event with price/volume or validated peer confirmation can drive a discretionary action; positive and repeated news stays watch-only. |
-| **Unproven signals are shown, never obeyed** | A quant factor layer runs in code but is barred from influencing a decision until it clears a minimum sample and proves a hit rate. |
+| **News needs an evidence graph** | Filings, issuer/exchange news, calendars, and headlines are deduplicated into expiring event IDs. A reliable, novel, negative event with price/volume or validated peer confirmation may drive defensive action. Positive surprise or accelerating attention can only join price-relative evidence in a capped add exploration; it cannot trade alone. |
+| **Unproven signals get an exploration boundary** | A quant factor cannot claim validated authority until it clears prospective activation. While warming up, a pre-registered interaction can collect one capped tranche per ticker/policy; the ledger keeps that evidence grade distinct. |
+| **Add authority needs quant × information** | Factor and peer residual count as one price-relative family, not two votes. A second point-in-time news surprise/attention family must agree before an exploration or validated tranche exists; technical prices only time that already-authorized capital. |
 | **Published research numbers need two sources** | Long-form numbers carry a provenance manifest: exact Decimal arithmetic, two independent sources per figure, and a tolerance cap the manifest cannot raise for itself. A single-sourced or disagreeing figure blocks release of the artifact that quotes it. |
 | **A thesis moves only on new evidence** | Assumptions, red lines and valuation anchors live in versioned JSON. A dimension may change only with evidence observed after the last check; a price move can reprice valuation but cannot touch business, moat or management; triggering *and* clearing a red line both need evidence. A missing baseline stays `unknown` instead of being reconstructed from prose. |
 | **Earnings quality is computed, not asserted** | Cash conversion, working-capital gaps, dilution, SBC share and guidance outcomes are derived in code from at least four comparable periods. A basis or currency switch mid-history is an error, a missing input reads `unavailable` with a reason, and footnote claims require a primary issuer document. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,7 +73,7 @@ package 架构。
 
 ## 信息层
 
-读市场是 LLM 干的大部分活,所以整套系统最宽的一环是数据收集。仓库编录了 **8 层、39 个抓取与计算模块**,**港股与美股双语覆盖** —— 实时报价、SEC + 东财申报、资金流、财报日历、宏观(VIX / DXY / 10Y)、Reddit 与新闻情绪,以及能撬动行情的社交 feed。每份简报只取与该市场、该 session 相关的子集。信息收集保持宽,决策层保持窄。
+读市场是 LLM 干的大部分活,所以整套系统最宽的一环是数据收集。仓库编录了 **8 层、40 个抓取与计算模块**,**港股与美股双语覆盖** —— 实时报价、SEC + 东财申报、资金流、财报日历、宏观(VIX / DXY / 10Y)、Reddit 与新闻情绪,以及能撬动行情的社交 feed。每份简报只取与该市场、该 session 相关的子集。信息收集保持宽,决策层保持窄。
 
 | 层 | 模块 | 主要来源 |
 |---|:---:|---|
@@ -84,7 +84,7 @@ package 架构。
 | 5 · 宏观/情绪 | 3 | Yahoo · Reddit · CNN · 社交 feed |
 | 6 · 量化与风险 | 8 | 对价格历史做确定性计算 |
 | 7 · 账本/汇率校验 | 6 | Frankfurter · 对账账本 · 本地不变量 |
-| 8 · 回测/自省 | 6 | 本地快照 + 基准行情 |
+| 8 · 回测/自省 | 7 | 本地快照 + 基准行情 |
 
 抓取层优雅降级:所有现役东财调用统一走**一个节流网关**,关键路径(报价、汇率)用**多源兜底**,而一次抓空会**保留旧值**,不会用空白覆盖一条好序列。公开来源包括腾讯、stooq、yfinance、Frankfurter、SEC EDGAR、Finnhub、Nasdaq、东财、Polygon、Alpha Vantage、Reddit 与 Google News —— 完整命令、provider 与产物目录见[命令参考](docs/reference/commands.md),它的清单和上面这张表核对的是同两份 registry,由生成器产出。哪个模块属于哪一层本身也是一份产物 —— [`config/information-layers.json`](config/information-layers.json),每条打包命令要么进某一层,要么带着「为什么它不算收集」的理由列在排除表里 —— 上面那张表由 CI 对着它核,模块搬了家,数字不会还留在原地。
 
@@ -118,6 +118,14 @@ package 架构。
 
 - **多条策略,分别打分。** `core_position`、`risk_rebalance`、`intraday_t`、`event_trade`、`tactical_entry` 可以在同一只标的上并存,因为长线论点和日内交易本就可能合理地分歧。每条在自己的 episode 里打分。
 - **归因优先。** 每条决策按其主导驱动打标签,而那个驱动的 edge 是从记录里*动态*测出来的 —— 逻辑里不硬编码任何命中率。
+
+### 低频加仓 campaign
+
+加仓使用有状态的交互信号，不把均线包装成 alpha。港美分别排名：截面因子和同行残差合并为一个 `price_relative` 证据族；时点新闻通过可靠的正向 surprise，或相对同一只票自身历史突然加速的 source-weighted attention，形成另一个证据族。两族必须同时成立，负面信息或同行 laggard 证据优先阻断。进入和退出使用不同 rank 阈值，为已开启 campaign 提供滞回，避免一次小幅排名抖动反复开关权限。
+
+权限、仓位和执行三层分开。warming policy 每只票、每个 policy version 只允许采一批 2.5% exploration；它不等于 validated，也不能用于每日重置杠杆产品。不可分割的最小交易单位只有在仍低于该市场账 3% exploration 硬上限时才能补成一股/一手，昂贵 board lot 不能伪装成小样本。validated campaign 才能分多批向目标靠近。技术价位只负责把已经授权的一批安排在未来五个本地交易日：最早下一 session、先判失效、跳空按开盘、港美分别使用日历和交易单位。
+
+每个持仓都会显示 `eligible`、`waiting_timing`、`risk_blocked`、`already_at_target`、`constraint_blocked` 或 `insufficient_evidence`。所以零订单可以是正常结果，但不能再只给一个裸的 `add=0`。`clawock evaluate-add-alpha` 分别比较 setup-only、price-relative、information 和 interaction 的 T+1/T+5/T+20；当前 universe 与旧新闻快照的 replay 只标 diagnostic / survivorship-limited，绝不冒充 validated alpha。
 - **证伪,不证实。** 风偏向上的行情里默认 HOLD。一个看多的故事在跨过一道证伪检查、以及一道「这是不是已经被 price in 了?」的近几日涨幅测试之前,不会触发买入。
 - **regime 高于择时。** 杠杆不做择时;200 日趋势 × 波动率的拨盘给它封顶。回测的教训是:edge 在*于错误 regime 里降杠杆*,不在抄顶。
 
@@ -189,8 +197,9 @@ package 架构。
 | **集中度按腿计算** | 每本账 `HHI = Σ wᵢ²`:`<0.15` ✅ · `0.15–0.25` 🟡 · `0.25–0.40` 🟠 · `>0.40` 🔴。绝不跨币种混算。 |
 | **杠杆按 regime 拨挡** | 200 日趋势 × 波动率的拨盘给杠杆 ETF 仓位封顶(×1 / ×0.5 / ×0);每日重置的 2×/3× 产品完全跳过基本面。 |
 | **回报基于峰值本金** | 回报率用现金流账本里的峰值净投入,而不是 `成本 − 已实现` —— 一笔已实现盈利不该伪造出更高的回报。 |
-| **软情绪不能翻转交易** | 一条推文或一种情绪只能微调置信度数字;只有硬的、带日期的催化剂才能改动作。风偏向上的行情里默认 HOLD。 |
-| **未验证的信号只展示、绝不遵从** | 一层量化因子跑在代码里,但在它跨过最小样本量并证明命中率之前,被禁止影响任何决策。 |
+| **软情绪不能单独翻转交易** | 一条推文或单一情绪只能微调置信度；source-weighted attention 只有同时满足自身历史加速和 price-relative 强度时，才可进入有上限的 exploration。硬的、带日期的负面催化仍可直接触发防守动作。 |
+| **未验证信号只能进入 exploration 边界** | 量化因子在通过前瞻激活前不能声称 validated；warming-up 阶段只有预注册交互可以按 ticker/policy 采一批有上限的样本，账本单独标注证据等级。 |
+| **加仓必须有量化 × 信息交互** | 因子和同行残差只算一个 price-relative family，不得冒充两票；还要有独立的时点新闻 surprise/attention family 才产生 exploration 或 validated tranche，技术价位只安排已经授权的资金。 |
 | **对外研究里的数字必须两源** | 长文里的数字带 provenance manifest:精确 Decimal 运算、每个数字两个独立来源、tolerance 上限不能由 manifest 自己抬高。单源或两源不一致的数字,直接卡住引用它的产物准出。 |
 | **thesis 只在有新证据时变** | 假设、红线、估值锚都落在带版本的 JSON 里。某个维度要变,必须有上次检查之后观察到的证据;价格波动只能改估值,动不了生意 / 护城河 / 管理层;红线的触发**和**解除都要证据。没有基线就诚实记 `unknown`,不靠文案补造历史。 |
 | **盈利质量由代码算,不靠断言** | 现金转化、营运资本缺口、摊薄、SBC 占比、指引结果都由代码从至少四个可比期算出。中途换会计基准或币种直接判错,缺输入就写 `unavailable` 并给原因,脚注类结论必须有一手发行人文件。 |

--- a/config/add-alpha-policy.json
+++ b/config/add-alpha-policy.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 2,
+  "registered_at": "2026-08-13",
+  "minimum_evidence_families": 2,
+  "minimum_information_score": 0.08,
+  "minimum_attention_acceleration": 1.25,
+  "minimum_attention_source_types": 1,
+  "attention_score_prior": 0.10,
+  "minimum_event_novelty": 0.5,
+  "minimum_event_reliability": 0.5,
+  "minimum_price_nonreaction": 0.6,
+  "confirmation_window_sessions": 5,
+  "exploration_enabled": true,
+  "exploration_max_tranches": 1,
+  "exploration_tranche_pct": 0.025,
+  "exploration_max_book_pct": 0.03,
+  "validated_max_tranches": 2,
+  "validated_tranche_pct": 0.075,
+  "markets": {
+    "HK": {
+      "enter_market_percentile": 0.70,
+      "exit_market_percentile": 0.50,
+      "minimum_attention_rank": 0.65,
+      "minimum_factor_coverage_pct": 80.0,
+      "minimum_sector_universe_size": 4,
+      "minimum_peer_count": 3
+    },
+    "US": {
+      "enter_market_percentile": 0.75,
+      "exit_market_percentile": 0.55,
+      "minimum_attention_rank": 0.75,
+      "minimum_factor_coverage_pct": 80.0,
+      "minimum_sector_universe_size": 4,
+      "minimum_peer_count": 3
+    }
+  },
+  "discipline": "Factor and peer residual share one price-relative family. An add also requires point-in-time information surprise or own-history attention acceleration, then a future-session price confirmation. Exploration is one 2.5% tranche per ticker and policy version, never a validated claim, and daily-reset leveraged products require validated evidence."
+}

--- a/config/information-layers.json
+++ b/config/information-layers.json
@@ -263,6 +263,10 @@
         {
           "command": "audit-resettle",
           "note": "dry-run bar-based re-settle that reports every verdict it would change"
+        },
+        {
+          "command": "evaluate-add-alpha",
+          "note": "point-in-time diagnostic replay of price-relative and information interaction adds"
         }
       ]
     }

--- a/config/news-evidence-policy.json
+++ b/config/news-evidence-policy.json
@@ -12,6 +12,7 @@
     "minimum_cross_section_tickers": 8,
     "freshness_half_life_hours": 36,
     "maximum_event_age_hours": 168,
+    "attention_score_prior": 0.1,
     "positive_rank_upsize_threshold": 0.75,
     "negative_rank_downsize_threshold": 0.25,
     "sizing": {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,7 +25,7 @@ title: clawock · command reference
 
 ## Installed commands / 已安装命令
 
-**61 commands** are installed: 49 from `clawock` and 12 from `clawock-kcnyu`. 39 of them collect or compute information and appear under the layer they feed; the remaining 22 publish, gate, record or schedule, and are listed with the reason they are not collection.
+**62 commands** are installed: 50 from `clawock` and 12 from `clawock-kcnyu`. 40 of them collect or compute information and appear under the layer they feed; the remaining 22 publish, gate, record or schedule, and are listed with the reason they are not collection.
 
 本节由生成器从两份 registry 与 `config/information-layers.json` 推导，不手写；新增或删除一条命令，这张表自己会变。
 
@@ -123,6 +123,7 @@ Sources: local snapshots + canonical bars
 | `clawock validate-regime-dial` | `clawock.evaluation.regime_validation` | out-of-sample and circular-shift null for the dial's timing |
 | `clawock shadow` | `clawock.portfolio.shadow` | replays triggered calls against buy-and-hold to measure simulated timing alpha |
 | `clawock audit-resettle` | `clawock.decision.settlement` | dry-run bar-based re-settle that reports every verdict it would change |
+| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of low-frequency price-relative × information adds; reuses production authority and fill rules |
 
 ### Not information collection / 不属于信息收集
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -123,7 +123,7 @@ Sources: local snapshots + canonical bars
 | `clawock validate-regime-dial` | `clawock.evaluation.regime_validation` | out-of-sample and circular-shift null for the dial's timing |
 | `clawock shadow` | `clawock.portfolio.shadow` | replays triggered calls against buy-and-hold to measure simulated timing alpha |
 | `clawock audit-resettle` | `clawock.decision.settlement` | dry-run bar-based re-settle that reports every verdict it would change |
-| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of low-frequency price-relative × information adds; reuses production authority and fill rules |
+| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of price-relative and information interaction adds |
 
 ### Not information collection / 不属于信息收集
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_preflight.py
@@ -96,13 +96,12 @@ def _run_clawock(command, args=None, timeout=120):
 
 
 def _technical_setup_usage():
-    """Count only broker-observed technical add tranches."""
+    """Count every broker-observed setup tranche, regardless of alpha driver."""
     usage = {}
     for row in decision_v2.load_decisions():
         setup_id = row.get('technical_setup_id')
         campaign_id = row.get('technical_campaign_id')
         if (row.get('action') not in decision_v2.ADD_ACTIONS
-                or row.get('driven_by') != 'technical'
                 or not setup_id or not campaign_id
                 or (row.get('execution') or {}).get('status') != 'followed'):
             continue
@@ -765,7 +764,13 @@ def _detect_followed(row, min_window_days=None):
         # One definition, in decision_v2: _exec_rate needs the identical rule to
         # separate "not verifiable yet" from "never will be", and a second copy
         # here would drift without anything failing.
-        min_window_days = decision_v2.verification_window_days(bucket)
+        condition = row.get('condition') or {}
+        min_window_days = decision_v2.verification_window_days(
+            bucket,
+            plan_date=plan_date,
+            leg=row.get('leg'),
+            valid_for_sessions=condition.get('valid_for_sessions'),
+        )
 
     # Day BEFORE plan_date (last commit before plan was created)
     try:
@@ -903,8 +908,11 @@ def compute_decision_metrics():
             continue
         if (d.get('evaluation') or {}).get('triggered') is not True:
             continue
-        legacy_view = {'plan_date': d.get('plan_date'), 'ticker': d.get('ticker'),
-                       'bucket': d.get('action')}
+        legacy_view = {
+            'plan_date': d.get('plan_date'), 'ticker': d.get('ticker'),
+            'bucket': d.get('action'), 'leg': d.get('leg'),
+            'condition': d.get('condition') or {},
+        }
         verdict = _detect_followed(legacy_view)
         if verdict in ('true', 'false'):
             d['execution'] = {'status': 'followed' if verdict == 'true' else 'not_followed',
@@ -1577,8 +1585,13 @@ def main(argv=None):
                 for h in book.get('holdings', [])
                 if h.get('shares', 0) > 0
             }
+            signal_names = {
+                str((get_instrument(ticker) or {}).get('signal_symbol') or '')
+                for ticker in held
+            }
             held_rows = {
-                ticker: row for ticker, row in rankings.items() if ticker in held
+                ticker: row for ticker, row in rankings.items()
+                if ticker in held or ticker in signal_names
             }
             leaders = sorted(
                 rankings.items(),
@@ -1628,6 +1641,10 @@ def main(argv=None):
                 for h in book.get('holdings', [])
                 if h.get('shares', 0) > 0
             }
+            signal_names = {
+                str((get_instrument(ticker) or {}).get('signal_symbol') or '')
+                for ticker in held
+            }
             peer_residual_ctx = {
                 'as_of': peer_residual.get('as_of'),
                 'taxonomy': peer_residual.get('taxonomy'),
@@ -1635,7 +1652,7 @@ def main(argv=None):
                 'rule_activation': peer_residual.get('rule_activation'),
                 'held': {
                     ticker: row for ticker, row in peer_live.items()
-                    if ticker in held
+                    if ticker in held or ticker in signal_names
                 },
             }
             active_peer_rules = [

--- a/memory/backtests/add_alpha_walkforward-20260812-3774163f.json
+++ b/memory/backtests/add_alpha_walkforward-20260812-3774163f.json
@@ -1,0 +1,692 @@
+{
+  "schema_version": 1,
+  "run_id": "add_alpha_walkforward-20260812-3774163f",
+  "backtest": "add_alpha_walkforward",
+  "generated_at": "2026-08-12T19:33:49+00:00",
+  "git_commit": "2d0a0451",
+  "reproduction_key": "sha256:3774163f77eb4d81",
+  "params": {
+    "horizons": [
+      1,
+      5,
+      20
+    ],
+    "entry": "production alpha_confirmation; next session; invalidation first; gap aware",
+    "confirmation_window_sessions": 5,
+    "variants": [
+      "setup_only",
+      "price_relative",
+      "information",
+      "interaction"
+    ],
+    "policy_version": 2,
+    "parameter_fit": "none; pre-registered thresholds"
+  },
+  "inputs": [
+    {
+      "symbol": "cross_sectional_factor_history.jsonl",
+      "source": "registered factor snapshots",
+      "bars": 11,
+      "first_session": "2026-07-24",
+      "last_session": "2026-08-07",
+      "digest": "sha256:8a8a0013b5fc7f71"
+    },
+    {
+      "symbol": "peer_residual_history.jsonl",
+      "source": "registered peer-residual snapshots",
+      "bars": 11,
+      "first_session": "2026-07-24",
+      "last_session": "2026-08-07",
+      "digest": "sha256:cffb94cd57e2e130"
+    },
+    {
+      "symbol": "news_evidence_history.jsonl",
+      "source": "point-in-time news evidence snapshots",
+      "bars": 12,
+      "first_session": "2026-07-26",
+      "last_session": "2026-08-10",
+      "digest": "sha256:f281214092f8a147"
+    },
+    {
+      "symbol": "00100",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 144,
+      "first_session": "2026-01-09",
+      "last_session": "2026-08-12",
+      "digest": "sha256:a9e168e3f7a80958"
+    },
+    {
+      "symbol": "02513",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 145,
+      "first_session": "2026-01-08",
+      "last_session": "2026-08-12",
+      "digest": "sha256:f450ea8c10398ee6"
+    },
+    {
+      "symbol": "01384",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 193,
+      "first_session": "2025-10-28",
+      "last_session": "2026-08-12",
+      "digest": "sha256:763c48ca4c591ce0"
+    },
+    {
+      "symbol": "09678",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 276,
+      "first_session": "2025-06-30",
+      "last_session": "2026-08-12",
+      "digest": "sha256:9a85a73a5dec6433"
+    },
+    {
+      "symbol": "06682",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:f0b3b8df7e70b932"
+    },
+    {
+      "symbol": "00020",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:29ed1a0b37edd8f5"
+    },
+    {
+      "symbol": "02208",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:e9469a5387f58884"
+    },
+    {
+      "symbol": "00916",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:a4ebdd6731b5646e"
+    },
+    {
+      "symbol": "01798",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:4dbfb8ddd6c5a80e"
+    },
+    {
+      "symbol": "00956",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:5a702cd7226da616"
+    },
+    {
+      "symbol": "01072",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:957e7bb7a0c90873"
+    },
+    {
+      "symbol": "03032",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:ecd80869a58c6706"
+    },
+    {
+      "symbol": "03033",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-25",
+      "last_session": "2026-08-12",
+      "digest": "sha256:68cd6cf112bc2158"
+    },
+    {
+      "symbol": "RKLB",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:0799a0922455bcef"
+    },
+    {
+      "symbol": "ASTS",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:0c227293ec5bf7ef"
+    },
+    {
+      "symbol": "BKSY",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:ae09c938c440a44b"
+    },
+    {
+      "symbol": "IRDM",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:95a7eaf3de58182f"
+    },
+    {
+      "symbol": "LMT",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:7a07f2340a882551"
+    },
+    {
+      "symbol": "SPCX",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 42,
+      "first_session": "2026-06-12",
+      "last_session": "2026-08-12",
+      "digest": "sha256:5356484533ea298a"
+    },
+    {
+      "symbol": "CRCL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 298,
+      "first_session": "2025-06-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:ae05940093532775"
+    },
+    {
+      "symbol": "COIN",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:db5cd15cda4b9106"
+    },
+    {
+      "symbol": "HOOD",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:286b69177e8f5e02"
+    },
+    {
+      "symbol": "PYPL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:299ddfb7682ec6d4"
+    },
+    {
+      "symbol": "XYZ",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:3bce2221d86ccc00"
+    },
+    {
+      "symbol": "PLTR",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:ee328fb1baec53a0"
+    },
+    {
+      "symbol": "SNOW",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:1d562fb69d38609c"
+    },
+    {
+      "symbol": "DDOG",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:266633399255e0a4"
+    },
+    {
+      "symbol": "NET",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:0884ae028d3ff6b1"
+    },
+    {
+      "symbol": "MSFT",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:e4bad6a61e250caf"
+    },
+    {
+      "symbol": "GOOGL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:811b57a0853e216c"
+    },
+    {
+      "symbol": "AAPL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:27fbe0900e37e7da"
+    },
+    {
+      "symbol": "META",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:395361326935af14"
+    },
+    {
+      "symbol": "ORCL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:bb49f516e437120c"
+    },
+    {
+      "symbol": "SKHY",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 24,
+      "first_session": "2026-07-10",
+      "last_session": "2026-08-12",
+      "digest": "sha256:58dcd8cc5bf5080d"
+    },
+    {
+      "symbol": "MU",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:479c5a671244921a"
+    },
+    {
+      "symbol": "WDC",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:3ebb2ee023c07c22"
+    },
+    {
+      "symbol": "STX",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:a06c54b7391eb3f9"
+    },
+    {
+      "symbol": "NVDA",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-05",
+      "last_session": "2026-08-12",
+      "digest": "sha256:73857503353893a3"
+    }
+  ],
+  "code": [
+    {
+      "file": "add_alpha_walkforward.py",
+      "digest": "sha256:97393ba9dbdf7923"
+    },
+    {
+      "file": "add_alpha.py",
+      "digest": "sha256:fc196042266437f3"
+    }
+  ],
+  "metrics": {
+    "us": {
+      "setup_only": {
+        "t1": {
+          "n": 122,
+          "n_dates": 11,
+          "n_tickers": 21,
+          "mean_return": 0.011925,
+          "hit_rate": 0.5902,
+          "mean_excess_vs_same_date_setup": -0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 73,
+          "n_dates": 8,
+          "n_tickers": 20,
+          "mean_return": 0.037162,
+          "hit_rate": 0.7123,
+          "mean_excess_vs_same_date_setup": 0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "price_relative": {
+        "t1": {
+          "n": 49,
+          "n_dates": 11,
+          "n_tickers": 8,
+          "mean_return": 0.004939,
+          "hit_rate": 0.6327,
+          "mean_excess_vs_same_date_setup": -0.009594,
+          "excess_date_cluster_ci95": [
+            -0.019951,
+            -0.000633
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 31,
+          "n_dates": 8,
+          "n_tickers": 8,
+          "mean_return": 0.000604,
+          "hit_rate": 0.6129,
+          "mean_excess_vs_same_date_setup": -0.033908,
+          "excess_date_cluster_ci95": [
+            -0.047996,
+            -0.016486
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "information": {
+        "t1": {
+          "n": 13,
+          "n_dates": 8,
+          "n_tickers": 4,
+          "mean_return": 0.02752,
+          "hit_rate": 0.8462,
+          "mean_excess_vs_same_date_setup": 0.012834,
+          "excess_date_cluster_ci95": [
+            -0.00178,
+            0.027362
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 8,
+          "n_dates": 5,
+          "n_tickers": 3,
+          "mean_return": 0.093961,
+          "hit_rate": 0.875,
+          "mean_excess_vs_same_date_setup": 0.0561,
+          "excess_date_cluster_ci95": [
+            0.027025,
+            0.101587
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "interaction": {
+        "t1": {
+          "n": 4,
+          "n_dates": 4,
+          "n_tickers": 1,
+          "mean_return": 0.031052,
+          "hit_rate": 1.0,
+          "mean_excess_vs_same_date_setup": 0.013244,
+          "excess_date_cluster_ci95": [
+            -0.021929,
+            0.055877
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 3,
+          "n_dates": 3,
+          "n_tickers": 1,
+          "mean_return": 0.055589,
+          "hit_rate": 0.6667,
+          "mean_excess_vs_same_date_setup": 0.014946,
+          "excess_date_cluster_ci95": [
+            -0.016921,
+            0.077716
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      }
+    },
+    "hk": {
+      "setup_only": {
+        "t1": {
+          "n": 69,
+          "n_dates": 11,
+          "n_tickers": 12,
+          "mean_return": 0.005009,
+          "hit_rate": 0.5072,
+          "mean_excess_vs_same_date_setup": 0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 48,
+          "n_dates": 8,
+          "n_tickers": 11,
+          "mean_return": 0.030075,
+          "hit_rate": 0.4792,
+          "mean_excess_vs_same_date_setup": -0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "price_relative": {
+        "t1": {
+          "n": 23,
+          "n_dates": 11,
+          "n_tickers": 7,
+          "mean_return": -0.004846,
+          "hit_rate": 0.3913,
+          "mean_excess_vs_same_date_setup": -0.006961,
+          "excess_date_cluster_ci95": [
+            -0.014335,
+            0.000754
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 16,
+          "n_dates": 8,
+          "n_tickers": 4,
+          "mean_return": -0.026716,
+          "hit_rate": 0.25,
+          "mean_excess_vs_same_date_setup": -0.065006,
+          "excess_date_cluster_ci95": [
+            -0.081778,
+            -0.047327
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "information": {
+        "t1": {
+          "n": 13,
+          "n_dates": 9,
+          "n_tickers": 4,
+          "mean_return": 0.014106,
+          "hit_rate": 0.6154,
+          "mean_excess_vs_same_date_setup": 0.008654,
+          "excess_date_cluster_ci95": [
+            -0.002739,
+            0.024894
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 9,
+          "n_dates": 6,
+          "n_tickers": 4,
+          "mean_return": 0.080826,
+          "hit_rate": 0.5556,
+          "mean_excess_vs_same_date_setup": 0.048854,
+          "excess_date_cluster_ci95": [
+            -0.029014,
+            0.151229
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "interaction": {
+        "t1": {
+          "n": 2,
+          "n_dates": 2,
+          "n_tickers": 2,
+          "mean_return": 0.017743,
+          "hit_rate": 0.5,
+          "mean_excess_vs_same_date_setup": 0.039444,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      }
+    },
+    "coverage": {
+      "factor_dates": 11,
+      "information_dates": 12,
+      "overlap_dates": 10,
+      "authority_classifications": {
+        "none": 186,
+        "exploration": 6,
+        "validated": 0
+      },
+      "information_grade": "retrospective_point_in_time_replay_only",
+      "factor_grade": "retrospective_current_universe_survivorship_limited",
+      "prospective_information_dates": 0,
+      "parameter_fit": "none_pre_registered_policy",
+      "claim": "diagnostic_not_validated_alpha"
+    }
+  },
+  "notes": [
+    "US and HK are ranked and evaluated separately.",
+    "Production classify_authority and confirmation primitives are reused directly.",
+    "Current-universe factor history is survivorship-limited and cannot validate authority.",
+    "Legacy information replay seeds diagnostics only; prospective activation remains warming_up.",
+    "Same-day entry/invalidation ambiguity is invalidated, never assumed filled."
+  ],
+  "data_boundary": "derived metrics and source names only; no raw vendor bars"
+}

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -56,7 +56,12 @@ clawock brief preflight
 
 当 packet 某票出现 `technical.setups` 并考虑加仓时，先读
 [`references/technical-playbooks.md`](references/technical-playbooks.md)。只允许使用该
-reference 的三种 staged setup；具体触发、失效、手数和上限仍以本次 packet 为准。
+reference 的三种技术 staged setup，或 packet 编译出的 `alpha_confirmation`；
+具体触发、失效、手数和上限仍以本次 packet 为准。`alpha_confirmation` 不是
+第四种技术 alpha：量化横截面/同业残差负责 price-relative 选名，新闻 surprise
+或 attention acceleration 提供独立的 point-in-time information family，技术价位
+只安排未来 1–5 个本地交易日的执行。Bull/Bear 可反证、否决或降档，不能凭措辞
+创造 authority、提高 tier 或改股数。
 
 ```bash
 /root/.local/bin/clawock tool decision_packet_summary \
@@ -676,7 +681,7 @@ postflight 严格 schema 校验：
 - `regime` ∈ {`risk_on`, `neutral`, `risk_off`}（每个 decision 必填；按本报告已判定的当前 regime 留痕，迁移旧数据才允许 `unknown`）
 - `confidence` ∈ [0.0, 1.0]
 - `size.shares`（整数，**主动 call（`cut`/`trim_on_rebound`/`t_only`/`add_only_on_trigger`/`add_on_breakout`）必填**；`hold_and_watch`/`watch` 不需要)：股数是这条 call 日后唯一能被折算成钱的凭据。面板上那条金额曲线已撤（见上条铁律），但**重建一套可信对照账本必须有股数，当天没填就永远补不回来**。宁可给保守估数也别留空。填**你真的会动的股数**,不是仓位上限。
-- 技术 add 还必须逐字填写 packet setup 的 `technical_setup_id`、`technical_campaign_id`、`invalidation_price` 与 `tranche_number=next_tranche_number`。港股 `size.shares` 必须为 `lot_size` 的整手倍数；美股当前只支持整数股。已有 open add 或 `remaining_tranches=0` 时不得重复开单。
+- 所有 add 都必须逐字填写 packet setup 的 `technical_setup_id`、`technical_campaign_id`、`invalidation_price`、`condition.valid_for_sessions` 与 `tranche_number=next_tranche_number`。`alpha_confirmation` 的 `driven_by` 应按真正主导证据写 `peer`/`catalyst`/`sentiment`，不能因为技术只负责 timing 就洗成 `technical`。exploration 只是 0.25 target tranche 的前瞻采样，不是 validated；每日重置杠杆产品不能走 exploration。港股 `size.shares` 必须为 `lot_size` 的整手倍数；美股当前只支持整数股。已有 open add 或 `remaining_tranches=0` 时不得重复开单。
 - `contested` ∈ {`true`, `false`}（每个 decision 必填）：Tier 2 的 Bull 与 Bear 是否真的在该策略上分歧。
 - `thesis_invalidation`（string，主动 cut/trim/add 必填；hold 选填）：**借鉴 UZI-Skill 的 thesis-tracking**——这个仓位的论点**会被什么具体催化推翻**？把 catalyst-gate(cut #1)落地成「论点+失效条件」：你只在这个**失效催化真的发生**时动手，而不是技术面波动。例：「crypto rev 环比转正则停止减仓」。这逼着每个主动 call 绑定一个可被证伪的硬催化，而非"看着toppy"。
 - `thesis_id` 必须沿用 `context.thesis_registry.theses.<ticker>.thesis_id`（resolved 时）；registry 为 `unknown` 时保留已有 decision ID，不得新造一个“看起来像历史”的 canonical thesis。`context.retrospective.decisions[].thesis_ref` 是只读解析结果。

--- a/skills/daily-deep-brief/references/technical-playbooks.md
+++ b/skills/daily-deep-brief/references/technical-playbooks.md
@@ -13,11 +13,19 @@
 
 仓库活跃不代表算法是新发明；以上日期只证明实现仍在维护。趋势、突破、RSI、ATR 本身是经典机制。
 
-## 三种允许的 setup
+## 三种技术 setup + 一种 alpha 执行确认
 
 1. `trend_pullback`：多头趋势成立，当日触及并收复 MA20，收阳且高于前收。第一次加一小批，失效线为 MA50/ATR/吊灯线中更严格的有效线；最多两批。
 2. `confirmed_breakout`：收盘突破此前 20 日高，1 个月动量为正且吊灯止损未破。第一次只加小批；跌回 MA20/吊灯线即失效；最多两批。
 3. `oversold_reclaim`：前一日 RSI≤35 且 20 日 z≤−1，次日收复前一日高点。它是唯一允许降低均价的 setup，只加一批 5%，跌破此前 5 日低点失效。
+
+`alpha_confirmation` 只能由 packet 生成，模型不能自己创建。它先要求两个独立
+family：factor/peer residual 合并为 `price_relative`，新闻方向 surprise 或相对自身
+历史的 attention acceleration 为 `point_in_time_information`；随后技术层只在未来
+1–5 个本地交易日等突破确认，跳空按开盘成交，同日同时触发 entry 与 invalidation
+按失效处理。warming-up exploration 每 ticker/policy 只采一批 2.5%；不足一股/一手
+时，只有该最小单位仍低于市场账 3% 硬上限才可补成一单位，否则输出零。validated
+才能多批，杠杆 ETF 不允许 exploration。
 
 `亏损`、`比成本低`、`今天翻红`、`利好新闻`都不是 setup。不得把它们单独包装成摊低成本。
 

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -474,6 +474,7 @@ PACKAGED_UTILITIES = {
     "evaluate-combined-regime": "clawock.evaluation.combined_regime",
     "evaluate-hstech-regime": "clawock.evaluation.hstech_regime",
     "evaluate-us-leverage": "clawock.evaluation.us_leverage",
+    "evaluate-add-alpha": "clawock.evaluation.add_alpha_walkforward",
     "evidence": "clawock.evidence.build_evidence",
     "fetch-peers": "clawock.market_data.peer_quotes",
     "filings": "clawock.market_data.filings",
@@ -681,6 +682,7 @@ def main(argv=None) -> int:
         ("evaluate-combined-regime", "backtest the combined configured regime dial"),
         ("evaluate-hstech-regime", "backtest the HSTECH leverage regime"),
         ("evaluate-us-leverage", "backtest US single-stock leverage regimes"),
+        ("evaluate-add-alpha", "walk-forward evaluate add factor and information interactions"),
         ("validate-regime-dial", "walk-forward validate the production regime dial"),
     ):
         utility = sub.add_parser(name, help=help_text, add_help=False)

--- a/src/clawock/decision/add_alpha.py
+++ b/src/clawock/decision/add_alpha.py
@@ -1,0 +1,294 @@
+"""Low-frequency add campaigns from price-relative and information features.
+
+The implementation borrows Qlib's useful boundary — signal selection, target
+position and order timing are separate — without importing its China-centric
+backtester.  It is intentionally not an HFT strategy:
+
+* ranks are produced once per completed HK or US session;
+* factor and peer residuals share one price-relative evidence family;
+* point-in-time news attention/surprise is a separate family;
+* a small exploration campaign may collect one prospective fill while a
+  pre-registered interaction warms up;
+* technical prices only schedule that authorised tranche.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+POLICY_VERSION = 2
+
+
+def _number(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def confirmation_levels(technical: dict) -> dict | None:
+    """Return the production entry/invalidation pair for an alpha campaign.
+
+    This is deliberately a public pure function: the live packet, replay and
+    ledger must not each invent a slightly different five-day confirmation.
+    The caller supplies only values known at the signal-session close.
+    """
+    close = _number(technical.get("close"))
+    prior_high = _number(technical.get("prior_5d_high"))
+    prior_low = _number(technical.get("prior_5d_low"))
+    chandelier = _number(technical.get("chandelier_stop"))
+    ma20 = _number(technical.get("ma20"))
+    if close is None or prior_high is None:
+        return None
+    entry = max(close, prior_high)
+    invalidation_candidates = [
+        value for value in (prior_low, chandelier, ma20)
+        if value is not None and 0 < value < entry
+    ]
+    if not invalidation_candidates:
+        return None
+    return {
+        "entry_price": round(entry, 4),
+        "invalidation_price": round(max(invalidation_candidates), 4),
+    }
+
+
+def confirmation_bar_outcome(
+    bar: dict, *, entry_price: float, invalidation_price: float
+) -> dict:
+    """Evaluate one future OHLC bar, with risk-line ambiguity fail-closed."""
+    low = _number(bar.get("low"))
+    high = _number(bar.get("high"))
+    open_ = _number(bar.get("open"))
+    if low is None or high is None or open_ is None:
+        return {"state": "not_evaluable", "reason": "ohlc_missing"}
+    if low <= invalidation_price:
+        return {"state": "invalidated", "reason": "invalidation_traded"}
+    if high < entry_price:
+        return {"state": "waiting", "reason": "entry_not_traded"}
+    return {
+        "state": "filled",
+        "price": max(open_, entry_price),
+        "reason": "gap_through" if open_ >= entry_price else "intraday_cross",
+    }
+
+
+def _market_policy(policy: dict, market: str) -> dict:
+    markets = policy.get("markets") or {}
+    return markets.get(str(market).upper()) or {}
+
+
+def _factor_support(
+    factor: dict, market_policy: dict, *, continuing: bool = False
+) -> tuple[bool, list[str]]:
+    rank = _number(factor.get("market_percentile"))
+    coverage = _number(factor.get("coverage_pct"))
+    sector_size = int(factor.get("sector_universe_size") or 0)
+    reasons = []
+    threshold = market_policy[
+        "exit_market_percentile" if continuing else "enter_market_percentile"
+    ]
+    if rank is not None and rank >= threshold:
+        reasons.append(
+            "market_rank_hysteresis" if continuing else "market_top_rank"
+        )
+    if coverage is not None and coverage >= market_policy["minimum_factor_coverage_pct"]:
+        reasons.append("factor_coverage_sufficient")
+    if sector_size >= market_policy["minimum_sector_universe_size"]:
+        reasons.append("industry_comparison_sufficient")
+    return len(reasons) == 3, reasons
+
+
+def _peer_support(peer: dict, market_policy: dict) -> tuple[bool, list[str], list[str]]:
+    triggered = set(peer.get("triggered_rules") or peer.get("usable_rules") or [])
+    negatives = sorted(triggered & {"laggard_avoidance"})
+    positives = sorted(triggered & {"leader_continuation", "mean_reversion"})
+    peer_count = int(peer.get("available_peer_count") or 0)
+    return (
+        bool(positives)
+        and not negatives
+        and peer_count >= market_policy["minimum_peer_count"],
+        positives,
+        negatives,
+    )
+
+
+def _information_support(
+    info: dict, policy: dict, market_policy: dict
+) -> tuple[bool, list[str], list[str]]:
+    signed = _number(info.get("signed_score"))
+    attention_rank = _number(info.get("attention_rank"))
+    attention_acceleration = _number(info.get("attention_acceleration"))
+    attention_source_types = int(info.get("attention_source_type_count") or 0)
+    components = info.get("event_components") or []
+    positive_events = [
+        str(row.get("event_id"))
+        for row in components
+        if _number(row.get("direction")) == 1
+        and (_number(row.get("novelty")) or 0) >= policy["minimum_event_novelty"]
+        and (_number(row.get("reliability")) or 0) >= policy["minimum_event_reliability"]
+        and (_number(row.get("price_nonreaction")) or 0) >= policy["minimum_price_nonreaction"]
+        and row.get("event_id")
+    ]
+    modes = []
+    if signed is not None and signed >= policy["minimum_information_score"] and positive_events:
+        modes.append("positive_surprise")
+    # Attention is deliberately unsigned. It only becomes informative when
+    # price-relative evidence independently says this is a leader, never alone.
+    attention_events = [
+        str(row.get("event_id"))
+        for row in (info.get("attention_components") or [])
+        if row.get("event_id")
+    ]
+    if (
+        attention_rank is not None
+        and attention_rank >= market_policy["minimum_attention_rank"]
+        and attention_acceleration is not None
+        and attention_acceleration >= policy["minimum_attention_acceleration"]
+        and attention_source_types >= policy["minimum_attention_source_types"]
+        and int(info.get("attention_event_count") or 0) > 0
+    ):
+        modes.append("attention_acceleration")
+    return bool(modes), modes, sorted(set(positive_events + attention_events))
+
+
+def classify_authority(
+    factor: dict,
+    peer: dict,
+    information: dict,
+    *,
+    leveraged: bool,
+    policy: dict,
+    market: str,
+    continuing: bool = False,
+) -> dict:
+    """Return a stateful-campaign eligibility tier and auditable blockers."""
+    market_policy = _market_policy(policy, market)
+    factor_ok, factor_reasons = _factor_support(
+        factor, market_policy, continuing=continuing
+    )
+    peer_ok, peer_reasons, peer_negatives = _peer_support(peer, market_policy)
+    info_ok, info_modes, event_ids = _information_support(
+        information, policy, market_policy
+    )
+
+    price_relative_ok = factor_ok or peer_ok
+    families = [
+        name for name, passed in (
+            ("price_relative", price_relative_ok),
+            ("point_in_time_information", info_ok),
+        ) if passed
+    ]
+    sources = [
+        name for name, passed in (
+            ("factor", factor_ok),
+            ("peer_residual", peer_ok),
+            ("information", info_ok),
+        ) if passed
+    ]
+    blockers = []
+    signed = _number(information.get("signed_score"))
+    if peer_negatives:
+        blockers.append("peer_laggard_avoidance")
+    if (
+        signed is not None
+        and signed <= -float(policy["minimum_information_score"])
+    ):
+        blockers.append("negative_information")
+    if len(families) < policy["minimum_evidence_families"]:
+        blockers.append("independent_evidence_families")
+    validated_price = bool(
+        (factor_ok and factor.get("usable_for_decisions"))
+        or (peer_ok and peer.get("usable_for_decisions"))
+    )
+    validated_info = bool(info_ok and information.get("usable_for_decisions"))
+    validated = validated_price and validated_info
+    if leveraged and not validated:
+        blockers.append("leveraged_requires_validated_evidence")
+    if not blockers and validated:
+        tier = "validated"
+    elif not blockers and policy.get("exploration_enabled"):
+        tier = "exploration"
+    else:
+        tier = "none"
+    return {
+        "schema_version": 2,
+        "policy_version": POLICY_VERSION,
+        "tier": tier,
+        "market": str(market).upper(),
+        "continuing_campaign": bool(continuing),
+        "sources": sources,
+        "evidence_families": families,
+        "factor_reasons": factor_reasons,
+        "peer_rules": peer_reasons,
+        "information_modes": info_modes,
+        "information_event_ids": event_ids,
+        "blockers": sorted(set(blockers)),
+        "discipline": (
+            "one price-relative family plus point-in-time information authorise "
+            "capital; technical confirmation only schedules the tranche"
+        ),
+    }
+
+
+def confirmation_setup(
+    technical: dict,
+    authority: dict,
+    policy: dict,
+    *,
+    ticker: str,
+) -> dict | None:
+    """Build a multi-session, gap-aware execution intent for one campaign."""
+    if authority.get("tier") not in {"exploration", "validated"}:
+        return None
+    if not technical.get("usable") or technical.get("stop_state") != "intact":
+        return None
+    signal_date = str(technical.get("as_of") or "")[:10]
+    if not signal_date:
+        return None
+    levels = confirmation_levels(technical)
+    if levels is None:
+        return None
+    tier = authority["tier"]
+    policy_hash = hashlib.sha256(
+        json.dumps(policy, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:8]
+    market = authority["market"]
+    if tier == "exploration":
+        # Exploration buys evidence; it is not a recurring trading rule. One
+        # fill per ticker/policy version prevents a fresh daily snapshot from
+        # silently resetting the cap and pyramiding an unvalidated idea.
+        campaign_id = f"{market}:{ticker}:explore:p{POLICY_VERSION}:{policy_hash}"
+    else:
+        # Daily headlines and attention events churn. They are provenance for
+        # the decision, not campaign identity: including their IDs silently
+        # resets the tranche cap every morning. A new campaign requires an
+        # explicit policy version, not a new syndication headline.
+        campaign_id = f"{market}:{ticker}:validated:p{POLICY_VERSION}:{policy_hash}"
+    return {
+        "setup_id": "alpha_confirmation",
+        "campaign_id": campaign_id,
+        "label": "低频交互加仓确认",
+        "entry_type": "price_above",
+        "entry_price": levels["entry_price"],
+        "invalidation_price": levels["invalidation_price"],
+        "max_tranches": (
+            policy["validated_max_tranches"]
+            if tier == "validated" else policy["exploration_max_tranches"]
+        ),
+        "tranche_pct_of_position": (
+            policy["validated_tranche_pct"]
+            if tier == "validated" else policy["exploration_tranche_pct"]
+        ),
+        "authority_tier": tier,
+        "target_tranche_level": 0.25 if tier == "exploration" else 1.0,
+        "authority_sources": list(authority.get("sources") or []),
+        "evidence_families": list(authority.get("evidence_families") or []),
+        "signal_date": signal_date,
+        "valid_for_sessions": int(policy["confirmation_window_sessions"]),
+        "detail": (
+            "relative-price plus point-in-time information selected the name; "
+            "the next 1–5 local sessions use a gap-aware price confirmation"
+        ),
+    }

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -44,7 +44,7 @@ SNAP_DIR = WS / "memory" / "snapshots"
 
 SCHEMA_VERSION = 2
 # Bumped when the meaning of an evaluation changes, so a stale row is identifiable.
-EVAL_SCHEMA_VERSION = 4
+EVAL_SCHEMA_VERSION = 5
 # Snapshots and plan_dates are both named on the HK calendar day; comparing them
 # against a UTC "today" slips a day for the eight hours after HK midnight.
 HKT = timezone(timedelta(hours=8))
@@ -75,9 +75,41 @@ AUDIT_SCHEMA_VERSION = 1
 SAME_DAY_STANCES = {"hold_and_watch", "watch", "t_only"}
 
 
-def verification_window_days(action: str | None) -> int:
-    """Days after plan_date before an unresolved execution is permanent."""
-    return 1 if (action or "").lower() in SAME_DAY_STANCES else 2
+def verification_window_days(
+    action: str | None, *, plan_date: str | None = None,
+    leg: str | None = None, valid_for_sessions: int | None = None,
+) -> int:
+    """Calendar span before an unresolved execution is permanent.
+
+    Multi-session adds are converted from their own leg's trading calendar.
+    The fallback remains deliberately conservative for legacy callers that do
+    not carry a leg/condition yet.
+    """
+    action = (action or "").lower()
+    if action in SAME_DAY_STANCES:
+        return 1
+    if action in ADD_ACTIONS:
+        if plan_date and leg and valid_for_sessions:
+            try:
+                market_leg = leg.upper()
+                start = plan_date
+                if not is_session(market_leg, start):
+                    starts = next_sessions(market_leg, start, 1)
+                    start = starts[0] if starts else start
+                remaining = max(0, min(9, int(valid_for_sessions) - 1))
+                sessions = next_sessions(market_leg, start, remaining) if remaining else []
+                end = sessions[-1] if sessions else start
+                if end:
+                    return max(
+                        1,
+                        (date.fromisoformat(end)
+                         - date.fromisoformat(plan_date)).days,
+                    )
+            except (TypeError, ValueError):
+                pass
+        # Legacy add rows did not persist the session window or leg.
+        return 9
+    return 2
 
 # Confidence is calibrated prospectively over strategy episodes, never by fitting
 # and scoring the same row. Sparse leaves borrow pseudo-observations from their
@@ -165,6 +197,9 @@ def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) ->
             "type": condition_type,
             "price": condition_price,
             "description": authored_condition.get("description") or action.get("trigger_condition") or "",
+            "valid_for_sessions": _int(
+                authored_condition.get("valid_for_sessions")
+            ) or 1,
         },
         "size": {
             "shares": _int(authored_size.get("shares")) if authored_size else _int(action.get("size_shares")),
@@ -270,6 +305,9 @@ def validate_decision(d: dict) -> list[str]:
         errors.append(f"bad condition.type {condition.get('type')!r}")
     if condition.get("type") in ("price_above", "price_below") and _float(condition.get("price")) is None:
         errors.append("price condition requires condition.price")
+    valid_for_sessions = _int(condition.get("valid_for_sessions")) or 1
+    if not 1 <= valid_for_sessions <= 10:
+        errors.append("condition.valid_for_sessions must be in [1,10]")
     conf = _float(d.get("confidence"))
     if conf is None or not 0 <= conf <= 1:
         errors.append("confidence must be in [0,1]")
@@ -287,16 +325,16 @@ def validate_decision(d: dict) -> list[str]:
         errors.append("technical_trace_version must be 1 when present")
     if setup_id is not None and (not isinstance(setup_id, str) or not setup_id):
         errors.append("technical_setup_id must be null or non-empty text")
-    if (trace_version == 1 and d.get("action") in ADD_ACTIONS
-            and d.get("driven_by") == "technical"):
+    if trace_version == 1 and d.get("action") in ADD_ACTIONS:
+        prefix = "technical add" if d.get("driven_by") == "technical" else "add"
         if not setup_id:
-            errors.append("technical add requires technical_setup_id")
+            errors.append(f"{prefix} requires technical_setup_id")
         if not isinstance(campaign_id, str) or not campaign_id:
-            errors.append("technical add requires technical_campaign_id")
+            errors.append(f"{prefix} requires technical_campaign_id")
         if _float(d.get("invalidation_price")) is None:
-            errors.append("technical add requires invalidation_price")
+            errors.append(f"{prefix} requires invalidation_price")
         if (_int(d.get("tranche_number")) or 0) < 1:
-            errors.append("technical add requires tranche_number >= 1")
+            errors.append(f"{prefix} requires tranche_number >= 1")
     if d.get("regime", "unknown") not in REGIMES:
         errors.append(f"bad regime {d.get('regime')!r}")
     override = d.get("override") or {}
@@ -722,26 +760,75 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
                 changed += 1
             continue
 
-        day_bar = bar(ticker, sess)
-        if day_bar is None:
+        condition = d.get("condition") or {}
+        window = max(1, min(10, _int(condition.get("valid_for_sessions")) or 1))
+        candidate_sessions = [sess]
+        if window > 1:
+            candidate_sessions += next_sessions(leg, sess, window - 1)
+        evaluated = []
+        fired = fill = fill_reason = None
+        trigger_session = None
+        pending_session = None
+        missing_session = None
+        invalidated_session = None
+        invalidation = _float(d.get("invalidation_price"))
+        for candidate in candidate_sessions:
+            day_bar = bar(ticker, candidate)
+            if day_bar is None:
+                if candidate >= today or candidate > (last_closed_session(leg) or ""):
+                    pending_session = candidate
+                    break
+                missing_session = candidate
+                break
+            evaluated.append(candidate)
+            # An authorised add is cancelled as soon as its risk line trades.
+            # We intentionally treat an ambiguous same-day low-below/high-above
+            # bar as invalidated: daily OHLC cannot prove the trigger happened
+            # first, and optimism here would be lookahead by assumption.
+            if (
+                d.get("action") in ADD_ACTIONS
+                and invalidation is not None
+                and day_bar["low"] <= invalidation
+            ):
+                invalidated_session = candidate
+                fired, fill, fill_reason = False, None, "invalidation_traded"
+                break
+            fired, fill, fill_reason = condition_execution(d, day_bar)
+            if fired is True or fired is None:
+                trigger_session = candidate if fired is True else None
+                break
+        if missing_session is not None:
+            inactive = ticker_retired(ticker)
+            ev.update({
+                "triggered": None,
+                "status": "not_evaluable",
+                "outcome": "unknown",
+                "not_evaluable_reason": (
+                    "instrument_inactive" if inactive else "bar_missing"
+                ),
+                "trigger_session": missing_session,
+            })
+            if json.dumps(ev, sort_keys=True) != before:
+                changed += 1
+            continue
+        if not evaluated and pending_session:
             # The market WAS open (the calendar said so) but we have no bar. Either
             # the session has not closed yet — which is pending, not unevaluable —
             # or this instrument genuinely did not trade (not yet listed, halted, or
             # retired — an instrument declared `retired` in fetch_daily_bars' MANIFEST).
             last = last_closed_session(leg) or ""
-            if sess > last:
+            if pending_session > last:
                 ev.update({"triggered": None, "status": "pending", "outcome": "pending",
-                           "pending_reason": "session_not_final", "trigger_session": sess})
+                           "pending_reason": "session_not_final", "trigger_session": pending_session})
             else:
                 inactive = ticker_retired(ticker)
                 ev.update({"triggered": None, "status": "not_evaluable", "outcome": "unknown",
                            "not_evaluable_reason": "instrument_inactive" if inactive else "bar_missing",
-                           "trigger_session": sess})
+                           "trigger_session": pending_session})
             if json.dumps(ev, sort_keys=True) != before:
                 changed += 1
             continue
 
-        fired, fill, fill_reason = condition_execution(d, day_bar)
         shares = _int((d.get("size") or {}).get("shares"))
         passive = d.get("action") in PASSIVE_ACTIONS
         ev["evaluation_schema_version"] = EVAL_SCHEMA_VERSION
@@ -751,7 +838,7 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
             # stay absent so a stance can never be counted as a fill.
             ev.update({
                 "triggered": True,
-                "trigger_session": sess,
+                "trigger_session": trigger_session or sess,
                 "evaluation_mode": "passive_stance",
                 "reference_price": fill,
                 "reference_reason": "first_tradable_price_after_publication",
@@ -761,7 +848,7 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
         else:
             ev.update({
                 "triggered": fired,
-                "trigger_session": sess if fired else None,
+                "trigger_session": trigger_session if fired else None,
                 "evaluation_mode": "active_fill",
                 "condition_role": "entry",
                 "execution_price": fill,
@@ -771,13 +858,27 @@ def settle_decisions(decisions: list[dict], now_date: str | None = None) -> int:
                 "fill_model": "daily_ohlc_gap_aware_v1" if fired else None,
             })
         if fired is False:
-            ev.update({"status": "not_triggered", "outcome": "not_triggered"})
+            if invalidated_session:
+                ev.update({
+                    "status": "not_triggered", "outcome": "not_triggered",
+                    "not_evaluable_reason": "campaign_invalidated",
+                    "trigger_session": invalidated_session,
+                })
+            elif pending_session and len(evaluated) < window:
+                ev.update({
+                    "status": "pending", "outcome": "pending",
+                    "pending_reason": "confirmation_window_open",
+                    "trigger_session": pending_session,
+                })
+            else:
+                ev.update({"status": "not_triggered", "outcome": "not_triggered"})
         elif fired is None:
             ev.update({"status": "not_evaluable", "outcome": "unknown",
                        "not_evaluable_reason": fill_reason})
         else:
             entry = fill
-            marks = next_sessions(leg, sess, 20)
+            fill_session = trigger_session or sess
+            marks = next_sessions(leg, fill_session, 20)
             b1 = b5 = b20 = u1 = None
             m1 = m5 = m20 = None
             reason = None
@@ -1345,7 +1446,14 @@ def _exec_rate(rows: list[dict], today: date | None = None) -> dict:
             # Counting it as pending would let an unparseable row hide forever
             # in the bucket that means "wait and it will resolve".
             continue
-        if planned + timedelta(days=verification_window_days(row.get("action"))) > today:
+        condition = row.get("condition") or {}
+        window_days = verification_window_days(
+            row.get("action"),
+            plan_date=row.get("plan_date"),
+            leg=row.get("leg"),
+            valid_for_sessions=_int(condition.get("valid_for_sessions")),
+        )
+        if planned + timedelta(days=window_days) > today:
             pending += 1
     return {
         "n": len(rows),

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -19,7 +19,9 @@ import os
 from pathlib import Path
 
 from clawock.decision.actions import ACTIVE_ACTIONS
-from clawock.portfolio.instruments import is_leveraged_holding
+from clawock.decision import add_alpha
+from clawock.portfolio.instruments import get as instrument_metadata, is_leveraged_holding
+from clawock.workspace import workspace_root
 
 
 SCHEMA_VERSION = 1
@@ -27,6 +29,7 @@ JUDGMENT_SCHEMA_VERSION = 1
 PAGES_SCHEMA_VERSION = 1
 MAX_PACKET_BYTES = 96 * 1024
 MAX_QUERY_BYTES = 24 * 1024
+ADD_ALPHA_POLICY = workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
 TEXT_LIMITS = {
     "portfolio_assessment": 800,
@@ -82,6 +85,23 @@ def _proxy_map(context: dict) -> dict[str, str]:
         for row in names
         if row.get("etf") and row.get("underlying")
     }
+    # The instrument registry is the production authority for both books;
+    # lev_regime.names is only a risk-dial subset and used to omit HK proxies.
+    for _, holding in _active_holdings(context):
+        ticker = str(holding.get("ticker") or "")
+        meta = instrument_metadata(ticker) or {}
+        available = (context.get("quant_signals") or {}).get("rows") or {}
+        signal = next(
+            (
+                str(candidate) for candidate in (
+                    meta.get("signal_symbol"), meta.get("one_x_substitute")
+                )
+                if candidate and str(candidate) in available
+            ),
+            None,
+        )
+        if signal:
+            out[ticker] = str(signal)
     for ticker, row in ((context.get("quant_signals") or {}).get("rows") or {}).items():
         note = str(row.get("note") or "")
         marker = " 的标的"
@@ -133,6 +153,16 @@ def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
                 "tranche_pct_of_position": _number(
                     setup.get("tranche_pct_of_position"), 4
                 ),
+                "valid_for_sessions": int(
+                    setup.get("valid_for_sessions") or 1
+                ),
+                "signal_date": setup.get("signal_date"),
+                "authority_tier": setup.get("authority_tier"),
+                "target_tranche_level": _number(
+                    setup.get("target_tranche_level"), 2
+                ),
+                "authority_sources": list(setup.get("authority_sources") or []),
+                "evidence_families": list(setup.get("evidence_families") or []),
                 "detail": str(setup.get("detail") or "")[:300],
             })
     return {
@@ -150,6 +180,11 @@ def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
         "mom_3m_pct": _number(row.get("mom_3m"), 1),
         "vol20_annualized": _number(row.get("vol20_annualized"), 4),
         "atr14_pct": _number(row.get("atr14_pct"), 2),
+        "close": _number(row.get("close"), 4),
+        "ma20": _number(row.get("ma20"), 4),
+        "prior_5d_high": _number(row.get("prior_5d_high"), 4),
+        "prior_5d_low": _number(row.get("prior_5d_low"), 4),
+        "chandelier_stop": _number(row.get("chandelier_stop"), 4),
         "stop_distance_pct": stop_distance,
         "stop_state": (
             "breached" if stop_distance is not None and stop_distance < 0
@@ -184,6 +219,8 @@ def _thesis_view(context: dict, ticker: str) -> dict:
 
 def _execution_view(holding: dict, leg: str, capital: float, cash: float,
                     technical: dict, thesis: dict, leveraged: bool,
+                    authority_tier: str = "none",
+                    exploration_max_book_pct: float = 0.03,
                     overlay: dict | None = None,
                     open_add: bool = False) -> dict:
     price = _number(holding.get("current_price"), 4)
@@ -225,10 +262,23 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
     tranche_pct = min(setup_pcts) if setup_pcts else 0.05
     overlay = overlay or {}
     sizing_multiplier = float(overlay.get("sizing_multiplier") or 1.0)
-    desired = max(1, int(shares * tranche_pct * sizing_multiplier))
-    suggested = (
-        max(lot, (desired // lot) * lot) if lot else 0
-    )
+    desired = int(shares * tranche_pct * sizing_multiplier)
+    rounded = ((desired // lot) * lot if lot else 0)
+    if authority_tier == "exploration":
+        unit_value = price * lot if price and lot else None
+        exploration_budget = max(0.0, capital * exploration_max_book_pct)
+        # 2.5% is the target step; the 3% market-book cap is the hard execution
+        # envelope. One indivisible broker unit may bridge that small gap, but
+        # an expensive HK board lot may not masquerade as a tiny experiment.
+        suggested = (
+            rounded if rounded > 0
+            else lot if unit_value and unit_value <= exploration_budget
+            else 0
+        )
+    else:
+        # Existing validated/basic campaigns retain one market unit as their
+        # minimum executable size, subject to cash and concentration room.
+        suggested = max(lot, rounded) if lot else 0
     suggested = min(suggested, position_room_shares)
     max_tranche_shares = suggested
 
@@ -245,8 +295,8 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         max_tranche_shares = min(max_tranche_shares, suggested)
 
     blockers = []
-    if leveraged:
-        blockers.append("leveraged_daily_reset")
+    if leveraged and authority_tier != "validated":
+        blockers.append("leveraged_requires_validated_evidence")
     if open_add:
         blockers.append("open_add_order")
     if leg == "HK" and lot is None:
@@ -256,7 +306,11 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
     if not price:
         blockers.append("price_missing")
     if max_tranche_shares <= 0:
-        blockers.append("no_cash_or_target_room")
+        blockers.append(
+            "tranche_below_market_unit"
+            if position_room_shares > 0 and desired < (lot or 1)
+            else "no_cash_or_target_room"
+        )
     return {
         "order_unit": "board_lot" if leg == "HK" else "integer_share",
         "lot_size": lot,
@@ -270,6 +324,9 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
         "max_add_shares": max_tranche_shares,
         "position_room_shares": position_room_shares,
         "max_add_value": round(max_tranche_shares * price, 2) if price else 0,
+        "exploration_budget_value": round(
+            max(0.0, capital * exploration_max_book_pct), 2
+        ),
         "position_room_value": (
             round(position_room_shares * price, 2) if price else 0
         ),
@@ -286,9 +343,14 @@ def _factor_view(row: dict) -> dict:
         "as_of": row.get("feature_as_of"),
         "sector": row.get("sector"),
         "composite_score": _number(row.get("composite_score"), 4),
+        "market_percentile": _number(row.get("market_percentile"), 4),
+        "sector_universe_size": int(row.get("sector_universe_size") or 0),
         "coverage_pct": _number(row.get("factor_coverage_pct"), 1),
         "relative_strength": _number(row.get("relative_strength"), 4),
         "breadth": _number(row.get("breadth"), 4),
+        "membership_history_complete": bool(
+            row.get("membership_history_complete")
+        ),
         "usable_for_decisions": bool(row.get("usable_for_decisions")),
     }
 
@@ -303,6 +365,8 @@ def _peer_view(row: dict) -> dict:
         "residual_20d": _number(row.get("residual_blend_20d"), 4),
         "leadership_persistence": row.get("leadership_persistence"),
         "laggard_persistence": row.get("laggard_persistence"),
+        "available_peer_count": int(row.get("available_peer_count") or 0),
+        "triggered_rules": list(row.get("triggered_rules") or []),
         "usable_rules": list(row.get("usable_rules") or []),
         "usable_for_decisions": bool(row.get("usable_for_decisions")),
     }
@@ -320,6 +384,19 @@ def _information_view(graph: dict, ticker: str, source_ticker: str) -> dict:
         "cross_section_rank": _number(row.get("cross_section_rank"), 4),
         "own_surprise_z": _number(row.get("own_surprise_z"), 4),
         "event_count": int(row.get("event_count") or 0),
+        "event_components": copy.deepcopy(row.get("event_components") or []),
+        "attention_score": _number(row.get("attention_score"), 6),
+        "attention_rank": _number(row.get("attention_rank"), 4),
+        "attention_event_count": int(row.get("attention_event_count") or 0),
+        "attention_acceleration": _number(
+            row.get("attention_acceleration"), 4
+        ),
+        "attention_source_type_count": int(
+            row.get("attention_source_type_count") or 0
+        ),
+        "attention_components": copy.deepcopy(
+            row.get("attention_components") or []
+        ),
         "sizing_tilt": row.get("sizing_tilt") or "inactive",
         "usable_for_decisions": bool(
             overlay.get("usable_for_decisions")
@@ -329,6 +406,13 @@ def _information_view(graph: dict, ticker: str, source_ticker: str) -> dict:
             ((overlay.get("activation") or {}).get("blockers") or [])
         ),
     }
+
+
+def _add_alpha_policy(context: dict) -> dict:
+    supplied = context.get("add_alpha_policy")
+    if isinstance(supplied, dict) and supplied:
+        return copy.deepcopy(supplied)
+    return json.loads(ADD_ALPHA_POLICY.read_text(encoding="utf-8"))
 
 
 def _information_sizing_overlay(info: dict, factor: dict, peer: dict,
@@ -540,11 +624,21 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
     if not generation_id:
         raise ValueError("decision packet requires context generation_id")
     quant_rows = (context.get("quant_signals") or {}).get("rows") or {}
-    cross_rows = (context.get("cross_sectional_factor") or {}).get("held_rankings") or {}
-    peer_rows = (context.get("peer_residual") or {}).get("held") or {}
+    cross_payload = context.get("cross_sectional_factor") or {}
+    peer_payload = context.get("peer_residual") or {}
+    # ``held_rankings``/``held`` were early fixture names. Production has
+    # always published ``live_rankings``/``live``. Keeping the aliases is useful
+    # for older external runtimes, but the real producer contract comes first.
+    cross_rows = (
+        cross_payload.get("live_rankings")
+        or cross_payload.get("held_rankings")
+        or {}
+    )
+    peer_rows = peer_payload.get("live") or peer_payload.get("held") or {}
     sentiment_rows = (context.get("sentiment") or {}).get("tickers") or []
     events = (context.get("news_evidence_graph") or {}).get("events") or []
     evidence_graph = context.get("news_evidence_graph") or {}
+    add_policy = _add_alpha_policy(context)
     proxies = _proxy_map(context)
     holdings = list(_active_holdings(context))
     active = {str(holding.get("ticker")) for _, holding in holdings}
@@ -625,8 +719,41 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             information_view, factor_view, peer_view, sizing_policy
         )
         leveraged = is_leveraged_holding(holding)
+        ticker_usage = setup_usage.get(ticker) or {}
+        continuing_alpha = any(
+            ":validated:" in str(campaign) and int(used or 0) > 0
+            for campaign, used in ticker_usage.items()
+        )
+        alpha_authority = add_alpha.classify_authority(
+            factor_view,
+            peer_view,
+            information_view,
+            leveraged=leveraged,
+            policy=add_policy,
+            market=leg,
+            continuing=continuing_alpha,
+        )
+        if alpha_authority.get("tier") == "exploration":
+            # A current-universe backfill can discover an interaction worth
+            # collecting, but never upgrade itself into validated authority.
+            alpha_authority["limitations"] = [
+                "prospective_collection_only",
+                "current_universe_survivorship_limit",
+            ]
+        alpha_setup = add_alpha.confirmation_setup(
+            technical, alpha_authority, add_policy, ticker=ticker
+        )
+        if alpha_setup is not None:
+            technical["setups"].append(alpha_setup)
+            technical = _apply_setup_usage(
+                technical, ticker_usage
+            )
         execution = _execution_view(
             holding, leg, invested[leg], cash[leg], technical, thesis, leveraged,
+            authority_tier=alpha_authority.get("tier") or "none",
+            exploration_max_book_pct=float(
+                add_policy.get("exploration_max_book_pct") or 0.03
+            ),
             overlay=sizing_overlay,
             open_add=open_add_gate_error or ticker in open_adds,
         )
@@ -650,6 +777,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             "quant": {
                 "factor": factor_view,
                 "peer_residual": peer_view,
+                "add_authority": alpha_authority,
                 "activation": {
                     "factor": bool(
                         ((context.get("cross_sectional_factor") or {}).get("activation") or {})
@@ -670,6 +798,54 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 shares, ticker_risks, actionable_ids, technical, execution
             ),
         }
+
+    tier_counts = {"validated": 0, "exploration": 0, "none": 0}
+    blocker_counts = {}
+    candidates = []
+    for ticker, row in tickers.items():
+        authority = ((row.get("quant") or {}).get("add_authority") or {})
+        tier = authority.get("tier") or "none"
+        tier_counts[tier] = tier_counts.get(tier, 0) + 1
+        for blocker in authority.get("blockers") or []:
+            blocker_counts[blocker] = blocker_counts.get(blocker, 0) + 1
+        setup = next(
+            (
+                item for item in (row.get("technical") or {}).get("setups") or []
+                if item.get("setup_id") == "alpha_confirmation"
+            ),
+            None,
+        )
+        constraints = row.get("constraints") or {}
+        execution = row.get("execution") or {}
+        allowed = "add_only_on_trigger" in (constraints.get("allowed_actions") or [])
+        if tier == "none":
+            state = "insufficient_evidence"
+        elif setup is None:
+            state = "waiting_timing"
+        elif setup.get("remaining_tranches") == 0:
+            state = "already_at_target"
+        elif execution.get("blockers") or row.get("risk"):
+            state = "risk_blocked"
+        elif allowed:
+            state = "eligible"
+        else:
+            state = "constraint_blocked"
+        candidates.append({
+            "ticker": ticker,
+            "leg": row.get("leg"),
+            "state": state,
+            "tier": tier,
+            "target_tranche_level": (
+                0.25 if tier == "exploration" else 1.0 if tier == "validated" else 0.0
+            ),
+            "sources": list(authority.get("sources") or []),
+            "authority_blockers": list(authority.get("blockers") or []),
+            "entry_price": (setup or {}).get("entry_price"),
+            "invalidation_price": (setup or {}).get("invalidation_price"),
+            "max_add_shares": constraints.get("max_add_shares"),
+            "allowed": allowed,
+            "execution_blockers": list(execution.get("blockers") or []),
+        })
 
     packet = {
         "_meta": {
@@ -713,6 +889,31 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 "evidence IDs", "risk", "status", "constraints",
             ],
         },
+        "add_alpha_policy": {
+            key: add_policy.get(key)
+            for key in (
+                "schema_version", "registered_at", "minimum_evidence_families",
+                "confirmation_window_sessions", "exploration_max_tranches",
+                "exploration_tranche_pct", "validated_max_tranches",
+                "exploration_max_book_pct",
+                "validated_tranche_pct", "markets", "discipline",
+            )
+        },
+        "add_alpha_diagnostics": {
+            "held_names": len(tickers),
+            "tier_counts": tier_counts,
+            "candidate_count": len(candidates),
+            "authority_candidate_count": sum(
+                row["tier"] in {"exploration", "validated"} for row in candidates
+            ),
+            "allowed_candidate_count": sum(bool(row["allowed"]) for row in candidates),
+            "candidate_rate": round(sum(
+                row["tier"] in {"exploration", "validated"} for row in candidates
+            ) / len(tickers), 4) if tickers else 0,
+            "blocker_counts": dict(sorted(blocker_counts.items())),
+            "candidates": candidates,
+            "zero_output_visible": True,
+        },
     }
     size = len(_compact(packet).encode("utf-8"))
     if size > MAX_PACKET_BYTES:
@@ -734,6 +935,7 @@ def _decision_provenance(packet: dict, ticker: str) -> dict | None:
         "information": copy.deepcopy(row.get("information") or {}),
         "factor": copy.deepcopy(quant.get("factor") or {}),
         "peer_residual": copy.deepcopy(quant.get("peer_residual") or {}),
+        "add_authority": copy.deepcopy(quant.get("add_authority") or {}),
         "sizing": copy.deepcopy(execution.get("information_overlay") or {}),
         "authority": {
             "max_add_shares": (row.get("constraints") or {}).get("max_add_shares"),
@@ -741,6 +943,7 @@ def _decision_provenance(packet: dict, ticker: str) -> dict | None:
                 row.get("constraints") or {}
             ).get("position_room_shares"),
             "lot_size": (row.get("constraints") or {}).get("lot_size"),
+            "tier": ((quant.get("add_authority") or {}).get("tier")),
         },
     }
 
@@ -980,6 +1183,12 @@ def validate_plan_constraints(plan: dict, packet: dict) -> list[str]:
             if not approved:
                 issues.append(
                     f"{tag}: add condition does not match an approved technical setup"
+                )
+            elif int(condition.get("valid_for_sessions") or 1) != int(
+                approved[0].get("valid_for_sessions") or 1
+            ):
+                issues.append(
+                    f"{tag}: add condition validity does not match approved setup"
                 )
     return issues
 

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -164,6 +164,8 @@ def compute_signals(bars):
         'ma200': round(ma200, 3) if ma200 else None,
         'prior_20d_high': round(prior_20d_high, 3) if prior_20d_high else None,
         'prior_20d_low': round(prior_20d_low, 3) if prior_20d_low else None,
+        'prior_5d_high': round(prior_5d_high, 3) if prior_5d_high else None,
+        'prior_5d_low': round(prior_5d_low, 3) if prior_5d_low else None,
         'dist_ma200_pct': round((c / ma200 - 1) * 100, 1) if ma200 else None,
         'golden_cross': (ma50 > ma200) if (ma50 and ma200) else None,
         'trend_on': trend_on if ma200 else None,

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -1,0 +1,496 @@
+"""Point-in-time replay of low-frequency price-relative × information adds.
+
+The command name is retained for CLI compatibility.  The report is explicit
+about evidence grade: parameters are pre-registered rather than fitted, and
+the current curated factor universe creates survivorship-limited diagnostics.
+Prospective activation still requires newly collected sessions.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import random
+import statistics
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from clawock.decision import add_alpha, signals
+from clawock.evidence import news_evidence_graph, run_card
+from clawock.market_data import factors
+from clawock.workspace import workspace_root
+
+
+WS = workspace_root(Path.cwd())
+FACTOR_CONFIG = WS / "config" / "factor-universe.json"
+ALPHA_POLICY = WS / "config" / "add-alpha-policy.json"
+NEWS_POLICY = WS / "config" / "news-evidence-policy.json"
+FACTOR_HISTORY = WS / "assets" / "data" / "cross_sectional_factor_history.jsonl"
+PEER_HISTORY = WS / "assets" / "data" / "peer_residual_history.jsonl"
+NEWS_HISTORY = WS / "assets" / "data" / "news_evidence_history.jsonl"
+HORIZONS = (1, 5, 20)
+VARIANTS = ("setup_only", "price_relative", "information", "interaction")
+
+
+def _json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _jsonl(path):
+    rows = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return sorted(rows, key=lambda row: str(row.get("as_of") or ""))
+
+
+def _digest(path):
+    return "sha256:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()[:16]
+
+
+def _number(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _market(ticker, config_by_ticker):
+    return str((config_by_ticker.get(ticker) or {}).get("region") or "").lower()
+
+
+def _midrank(values, value):
+    if value is None or not values:
+        return None
+    ordered = sorted(values)
+    positions = [index for index, item in enumerate(ordered) if item == value]
+    return statistics.fmean(positions) / max(1, len(ordered) - 1)
+
+
+def _technical_at(bars, signal_date):
+    known = [row for row in bars if row.get("date") <= signal_date]
+    if not known or known[-1].get("date") != signal_date:
+        return None
+    row = signals.compute_signals(known)
+    if not row:
+        return None
+    return {
+        "close": row.get("close"),
+        "prior_5d_high": row.get("prior_5d_high"),
+        "prior_5d_low": row.get("prior_5d_low"),
+        "chandelier_stop": row.get("chandelier_stop"),
+        "ma20": row.get("ma20"),
+    }
+
+
+def _confirmation_fill(bars, signal_date, window=5):
+    technical = _technical_at(bars, signal_date)
+    levels = add_alpha.confirmation_levels(technical or {})
+    if not levels:
+        return None
+    after = [row for row in bars if row.get("date") > signal_date][:window]
+    for row in after:
+        outcome = add_alpha.confirmation_bar_outcome(
+            row,
+            entry_price=levels["entry_price"],
+            invalidation_price=levels["invalidation_price"],
+        )
+        if outcome["state"] in {"invalidated", "not_evaluable"}:
+            return None
+        if outcome["state"] == "filled":
+            return {
+                "session": row["date"],
+                "price": outcome["price"],
+                "fill_reason": outcome["reason"],
+                **levels,
+            }
+    return None
+
+
+def _forward_return(bars, entry_session, entry_price, horizon):
+    index = next(
+        (i for i, row in enumerate(bars) if row.get("date") == entry_session), None
+    )
+    if index is None or index + horizon >= len(bars) or not entry_price:
+        return None
+    return bars[index + horizon]["close"] / entry_price - 1
+
+
+def _cluster_ci(rows, field, samples=1000):
+    by_date = defaultdict(list)
+    for row in rows:
+        value = _number(row.get(field))
+        if value is not None:
+            by_date[row["date"]].append(value)
+    dates = sorted(by_date)
+    if len(dates) < 3:
+        return None
+    rnd = random.Random(20260813)
+    draws = []
+    for _ in range(samples):
+        chosen = [rnd.choice(dates) for _ in dates]
+        values = [value for day in chosen for value in by_date[day]]
+        draws.append(statistics.fmean(values))
+    draws.sort()
+    return [
+        round(draws[int(0.025 * (len(draws) - 1))], 6),
+        round(draws[int(0.975 * (len(draws) - 1))], 6),
+    ]
+
+
+def _summary(rows):
+    values = [row["return"] for row in rows]
+    excess = [row["excess_vs_setup"] for row in rows if row.get("excess_vs_setup") is not None]
+    return {
+        "n": len(rows),
+        "n_dates": len({row["date"] for row in rows}),
+        "n_tickers": len({row["ticker"] for row in rows}),
+        "mean_return": round(statistics.fmean(values), 6) if values else None,
+        "hit_rate": round(sum(value > 0 for value in values) / len(values), 4)
+        if values else None,
+        "mean_excess_vs_same_date_setup": (
+            round(statistics.fmean(excess), 6) if excess else None
+        ),
+        "excess_date_cluster_ci95": _cluster_ci(rows, "excess_vs_setup"),
+        "status": (
+            "diagnostic"
+            if len({row["date"] for row in rows}) >= 8 and len(rows) >= 20
+            else "collecting"
+        ),
+    }
+
+
+def _snapshot_cutoff(snapshot):
+    raw = snapshot.get("observed_at") or f'{str(snapshot.get("as_of") or "")[:10]}T23:59:59+00:00'
+    try:
+        cutoff = datetime.fromisoformat(str(raw))
+        return cutoff if cutoff.tzinfo else cutoff.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _attention_snapshot(snapshot, overlay_policy):
+    cutoff = _snapshot_cutoff(snapshot)
+    scores = defaultdict(float)
+    signed = defaultdict(float)
+    source_types = defaultdict(set)
+    positive_components = defaultdict(list)
+    attention_components = defaultdict(list)
+    if cutoff is None:
+        return {}
+    for event in snapshot.get("events") or []:
+        ticker = str(event.get("ticker") or "")
+        if not ticker or ticker == "MARKET":
+            continue
+        payload = {
+            "event_id": event.get("event_id"),
+            "ticker": ticker,
+            "impact_direction": event.get("impact_direction"),
+            "publication_time": {"iso": event.get("published_at")},
+            "novelty_score": event.get("novelty_score"),
+            "source_reliability": event.get("source_reliability"),
+            "source_type": event.get("source_type"),
+            "corroborating_source_count": 1,
+            "confirmation": {},
+        }
+        attention = news_evidence_graph._event_attention_component(
+            payload, cutoff, overlay_policy
+        )
+        if attention:
+            scores[ticker] += attention["attention_value"]
+            source_types[ticker].add(attention["source_type"])
+            attention_components[ticker].append(attention)
+        signed_value = _number(event.get("information_signed_score"))
+        if signed_value is not None:
+            signed[ticker] += signed_value
+            if signed_value > 0:
+                positive_components[ticker].append({
+                    "event_id": event.get("event_id"),
+                    "direction": 1,
+                    "novelty": _number(event.get("novelty_score")) or 0,
+                    "reliability": _number(event.get("source_reliability")) or 0,
+                    "price_nonreaction": 1.0,
+                })
+    return {
+        "attention": dict(scores),
+        "signed": dict(signed),
+        "source_types": {ticker: len(values) for ticker, values in source_types.items()},
+        "positive_components": dict(positive_components),
+        "attention_components": dict(attention_components),
+    }
+
+
+def _news_by_date(history, overlay_policy, config_by_ticker, prior=0.1):
+    """Rebuild every attention feature using earlier snapshots only."""
+    out = {}
+    prior_scores = defaultdict(list)
+    for snapshot in history:
+        day = str(snapshot.get("as_of") or "")[:10]
+        current = _attention_snapshot(snapshot, overlay_policy)
+        if not day:
+            continue
+        tickers = set(config_by_ticker) | set(current.get("attention") or {})
+        ranks = {}
+        for market in ("hk", "us"):
+            names = [ticker for ticker in tickers if _market(ticker, config_by_ticker) == market]
+            values = [(current.get("attention") or {}).get(ticker, 0.0) for ticker in names]
+            for ticker in names:
+                ranks[ticker] = _midrank(
+                    values, (current.get("attention") or {}).get(ticker, 0.0)
+                )
+        rows = {}
+        for ticker in tickers:
+            score = (current.get("attention") or {}).get(ticker, 0.0)
+            baseline = statistics.fmean(prior_scores[ticker]) if prior_scores[ticker] else 0.0
+            rows[ticker] = {
+                "signed_score": (current.get("signed") or {}).get(ticker, 0.0),
+                "event_components": (current.get("positive_components") or {}).get(ticker, []),
+                "attention_score": score,
+                "attention_rank": ranks.get(ticker),
+                "attention_acceleration": (score + prior) / (baseline + prior),
+                "attention_source_type_count": (current.get("source_types") or {}).get(ticker, 0),
+                "attention_event_count": len(
+                    (current.get("attention_components") or {}).get(ticker, [])
+                ),
+                "attention_components": (current.get("attention_components") or {}).get(ticker, []),
+                "usable_for_decisions": False,
+            }
+        out[day] = {
+            "rows": rows,
+            "backfill": bool(snapshot.get("information_overlay_backfill")),
+        }
+        for ticker in tickers:
+            prior_scores[ticker].append((current.get("attention") or {}).get(ticker, 0.0))
+    return out
+
+
+def _factor_rows(snapshot, config_by_ticker):
+    rows = snapshot.get("rows") or {}
+    by_market = defaultdict(list)
+    for ticker, row in rows.items():
+        score = _number(row.get("composite_score"))
+        if score is not None:
+            by_market[_market(ticker, config_by_ticker)].append(score)
+    sector_sizes = defaultdict(int)
+    for spec in config_by_ticker.values():
+        sector_sizes[(spec["region"], spec["sector"])] += 1
+    out = {}
+    for ticker, row in rows.items():
+        spec = config_by_ticker.get(ticker) or {}
+        score = _number(row.get("composite_score"))
+        out[ticker] = {
+            "market_percentile": (
+                _number(row.get("market_percentile"))
+                if row.get("market_percentile") is not None
+                else _midrank(by_market[_market(ticker, config_by_ticker)], score)
+            ),
+            "coverage_pct": _number(row.get("factor_coverage_pct")) or 0,
+            "sector_universe_size": int(
+                row.get("sector_universe_size")
+                or sector_sizes[(spec.get("region"), spec.get("sector"))]
+            ),
+            "usable_for_decisions": False,
+        }
+    return out
+
+
+def evaluate(config, policy, news_policy, fetched, factor_history, peer_history, news_history):
+    specs = {row["ticker"]: row for row in config["symbols"]}
+    # Legacy snapshots already froze every raw fact at their daily cutoff.
+    # Reconstruct the newly registered deterministic components in memory; do
+    # not require a generated-history rewrite for a reproducible evaluation.
+    news_history = news_evidence_graph._backfill_information_components(
+        news_policy,
+        copy.deepcopy(news_history),
+        datetime(2026, 8, 13, tzinfo=timezone.utc),
+    )
+    news = _news_by_date(
+        news_history,
+        news_policy["information_overlay"],
+        specs,
+        prior=float(policy.get("attention_score_prior") or 0.1),
+    )
+    peers = {
+        str(snapshot.get("as_of") or "")[:10]: snapshot.get("rows") or {}
+        for snapshot in peer_history
+    }
+    observations = {
+        market: {variant: {horizon: [] for horizon in HORIZONS} for variant in VARIANTS}
+        for market in ("us", "hk")
+    }
+    coverage = {"factor_dates": 0, "information_dates": len(news), "overlap_dates": 0}
+    authority_counts = {"none": 0, "exploration": 0, "validated": 0}
+    for snapshot in factor_history:
+        snapshot_date = str(snapshot.get("as_of") or "")[:10]
+        if not snapshot_date:
+            continue
+        coverage["factor_dates"] += 1
+        if snapshot_date in news:
+            coverage["overlap_dates"] += 1
+        ranked = _factor_rows(snapshot, specs)
+        for ticker, factor_row in ranked.items():
+            spec = specs.get(ticker)
+            bars = (fetched.get(ticker) or {}).get("bars") or []
+            signal_date = str(
+                ((snapshot.get("rows") or {}).get(ticker) or {}).get("feature_as_of")
+                or snapshot_date
+            )[:10]
+            if not spec or not bars:
+                continue
+            fill = _confirmation_fill(
+                bars, signal_date, int(policy["confirmation_window_sessions"])
+            )
+            if not fill:
+                continue
+            peer_row = (peers.get(signal_date) or peers.get(snapshot_date) or {}).get(ticker) or {}
+            peer_view = {
+                "triggered_rules": peer_row.get("triggered_rules") or [],
+                "available_peer_count": int(peer_row.get("available_peer_count") or 0),
+                "usable_for_decisions": False,
+            }
+            info = ((news.get(signal_date) or news.get(snapshot_date) or {}).get("rows") or {}).get(ticker) or {}
+            authority = add_alpha.classify_authority(
+                factor_row,
+                peer_view,
+                info,
+                leveraged=False,
+                policy=policy,
+                market=spec["region"],
+            )
+            authority_counts[authority["tier"]] += 1
+            factor_ok = add_alpha._factor_support(
+                factor_row, policy["markets"][spec["region"].upper()]
+            )[0]
+            peer_ok = add_alpha._peer_support(
+                peer_view, policy["markets"][spec["region"].upper()]
+            )[0]
+            information_ok = add_alpha._information_support(
+                info, policy, policy["markets"][spec["region"].upper()]
+            )[0]
+            selected = {
+                "setup_only": True,
+                "price_relative": factor_ok or peer_ok,
+                "information": information_ok,
+                "interaction": authority["tier"] in {"exploration", "validated"},
+            }
+            for horizon in HORIZONS:
+                value = _forward_return(
+                    bars, fill["session"], fill["price"], horizon
+                )
+                if value is None:
+                    continue
+                for variant, include in selected.items():
+                    if include:
+                        observations[spec["region"]][variant][horizon].append({
+                            "date": signal_date,
+                            "ticker": ticker,
+                            "return": value,
+                            "fill_reason": fill["fill_reason"],
+                        })
+    for market in observations.values():
+        for horizon in HORIZONS:
+            baseline_by_date = defaultdict(list)
+            for row in market["setup_only"][horizon]:
+                baseline_by_date[row["date"]].append(row["return"])
+            baseline = {
+                day: statistics.fmean(values) for day, values in baseline_by_date.items()
+            }
+            for variant in VARIANTS:
+                for row in market[variant][horizon]:
+                    row["excess_vs_setup"] = (
+                        row["return"] - baseline[row["date"]]
+                        if row["date"] in baseline else None
+                    )
+    metrics = {
+        market: {
+            variant: {
+                f"t{horizon}": _summary(rows)
+                for horizon, rows in horizons.items()
+            }
+            for variant, horizons in variants.items()
+        }
+        for market, variants in observations.items()
+    }
+    metrics["coverage"] = {
+        **coverage,
+        "authority_classifications": authority_counts,
+        "information_grade": "retrospective_point_in_time_replay_only",
+        "factor_grade": "retrospective_current_universe_survivorship_limited",
+        "prospective_information_dates": sum(
+            not row["backfill"] for row in news.values()
+        ),
+        "parameter_fit": "none_pre_registered_policy",
+        "claim": "diagnostic_not_validated_alpha",
+    }
+    return metrics
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-card", action="store_true")
+    args = parser.parse_args(argv)
+    config = _json(FACTOR_CONFIG)
+    policy = _json(ALPHA_POLICY)
+    news_policy = _json(NEWS_POLICY)
+    fetched = factors.fetch_universe(config)
+    histories = (_jsonl(FACTOR_HISTORY), _jsonl(PEER_HISTORY), _jsonl(NEWS_HISTORY))
+    metrics = evaluate(config, policy, news_policy, fetched, *histories)
+    card_path = None
+    if not args.no_card:
+        inputs = []
+        for path, source in (
+            (FACTOR_HISTORY, "registered factor snapshots"),
+            (PEER_HISTORY, "registered peer-residual snapshots"),
+            (NEWS_HISTORY, "point-in-time news evidence snapshots"),
+        ):
+            rows = _jsonl(path)
+            inputs.append({
+                "symbol": path.name,
+                "source": source,
+                "bars": len(rows),
+                "first_session": str((rows[0] if rows else {}).get("as_of")),
+                "last_session": str((rows[-1] if rows else {}).get("as_of")),
+                "digest": _digest(path),
+            })
+        for spec in config["symbols"]:
+            bars = (fetched.get(spec["ticker"]) or {}).get("bars") or []
+            if bars:
+                inputs.append({
+                    "symbol": spec["ticker"],
+                    "source": "Tencent qfq daily OHLC",
+                    "bars": len(bars),
+                    "first_session": bars[0]["date"],
+                    "last_session": bars[-1]["date"],
+                    "digest": run_card.series_digest(bars),
+                })
+        card_path = run_card.record(
+            "add_alpha_walkforward",
+            params={
+                "horizons": list(HORIZONS),
+                "entry": "production alpha_confirmation; next session; invalidation first; gap aware",
+                "confirmation_window_sessions": policy["confirmation_window_sessions"],
+                "variants": list(VARIANTS),
+                "policy_version": add_alpha.POLICY_VERSION,
+                "parameter_fit": "none; pre-registered thresholds",
+            },
+            inputs=inputs,
+            metrics=metrics,
+            code_files=[Path(__file__), Path(add_alpha.__file__)],
+            notes=[
+                "US and HK are ranked and evaluated separately.",
+                "Production classify_authority and confirmation primitives are reused directly.",
+                "Current-universe factor history is survivorship-limited and cannot validate authority.",
+                "Legacy information replay seeds diagnostics only; prospective activation remains warming_up.",
+                "Same-day entry/invalidation ambiguity is invalidated, never assumed filled.",
+            ],
+        )
+    print(json.dumps({"metrics": metrics, "run_card": str(card_path) if card_path else None}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -943,6 +943,52 @@ def _event_information_component(event, now, overlay_policy):
     }
 
 
+def _event_attention_component(event, now, overlay_policy):
+    """Unsigned, source-weighted attention available at the snapshot cutoff.
+
+    Most collected headlines cannot be assigned a trustworthy buy/sell polarity
+    from a title.  Treating those rows as zero discarded the very attention
+    information the producers had collected; asking an LLM to invent polarity
+    would be worse.  Attention is therefore a separate feature: it can support
+    an interaction with relative-price strength, but can never authorise an add
+    by itself.
+    """
+    published = (event.get('publication_time') or {}).get('iso')
+    try:
+        observed = datetime.fromisoformat(published)
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=timezone.utc)
+        if observed > now:
+            return None
+        age_hours = (now - observed).total_seconds() / 3600
+    except Exception:
+        return None
+    if age_hours > overlay_policy['maximum_event_age_hours']:
+        return None
+    if event.get('ticker') == 'MARKET':
+        return None
+    novelty = float(event.get('novelty_score') or 0)
+    reliability = float(event.get('source_reliability') or 0)
+    sources = max(1, int(event.get('corroborating_source_count') or 1))
+    corroboration = min(1.0, 0.5 + 0.25 * (sources - 1))
+    freshness = math.exp(
+        -math.log(2) * age_hours
+        / float(overlay_policy['freshness_half_life_hours'])
+    )
+    value = novelty * reliability * corroboration * freshness
+    return {
+        'event_id': event.get('event_id'),
+        'published_at': published,
+        'novelty': round(novelty, 4),
+        'reliability': round(reliability, 4),
+        'corroborating_sources': sources,
+        'freshness': round(freshness, 4),
+        'attention_value': round(value, 6),
+        'channel': (event.get('metadata') or {}).get('channel') or 'news',
+        'source_type': event.get('source_type') or 'unknown',
+    }
+
+
 def _history_information_rows(history, overlay_policy):
     rows = []
     for snapshot in history:
@@ -958,12 +1004,61 @@ def _history_information_rows(history, overlay_policy):
     return rows
 
 
-def _history_information_dates(history):
+def _history_attention_rows(history, overlay_policy):
+    """Daily own-name attention baselines from facts frozen in each snapshot."""
+    rows = []
+    for snapshot in history:
+        as_of = str(snapshot.get('as_of') or '')[:10]
+        if not as_of:
+            continue
+        scores = {}
+        for event in snapshot.get('events') or []:
+            try:
+                cutoff = datetime.fromisoformat(
+                    str(snapshot.get('observed_at')
+                        or f'{as_of}T23:59:59+00:00')
+                )
+                if cutoff.tzinfo is None:
+                    cutoff = cutoff.replace(tzinfo=timezone.utc)
+            except (TypeError, ValueError):
+                continue
+            component = _event_attention_component({
+                'event_id': event.get('event_id'),
+                'ticker': event.get('ticker'),
+                'publication_time': {'iso': event.get('published_at')},
+                'novelty_score': event.get('novelty_score'),
+                'source_reliability': event.get('source_reliability'),
+                'source_type': event.get('source_type'),
+                'corroborating_source_count': 1,
+            }, cutoff, overlay_policy)
+            if component is not None:
+                ticker = str(event.get('ticker') or '')
+                scores[ticker] = scores.get(ticker, 0.0) + component['attention_value']
+        for ticker, score in scores.items():
+            rows.append({'as_of': as_of, 'ticker': ticker, 'score': score})
+    return rows
+
+
+def _history_information_dates(
+    history, *, activation_only=False, registered_at=None
+):
     """Registered point-in-time snapshots, including days with zero signal."""
     return sorted({
         str(snapshot.get('as_of') or '')[:10]
         for snapshot in history
         if snapshot.get('information_overlay_schema_version') == 1
+        and (
+            not activation_only
+            or not registered_at
+            or str(snapshot.get('as_of') or '')[:10] >= registered_at
+        )
+        and (
+            not activation_only
+            or not snapshot.get('information_overlay_backfill')
+            or (snapshot.get('information_overlay_backfill') or {}).get(
+                'activation_eligible'
+            ) is True
+        )
         and snapshot.get('as_of')
     })
 
@@ -972,6 +1067,7 @@ def build_information_overlay(policy, events, history, now):
     """Ticker surprise and cross-sectional rank from already-collected evidence."""
     overlay_policy = policy['information_overlay']
     components = {}
+    attention_components = {}
     covered_tickers = set()
     for event in events:
         ticker = str(event.get('ticker') or '')
@@ -985,13 +1081,22 @@ def build_information_overlay(policy, events, history, now):
         if ticker and ticker != 'MARKET' and observable and observable <= now:
             covered_tickers.add(ticker)
         component = _event_information_component(event, now, overlay_policy)
+        attention = _event_attention_component(event, now, overlay_policy)
+        if attention is not None:
+            attention_components.setdefault(ticker, []).append(attention)
         if component is None:
             continue
         event['information_signed_score'] = component['signed_score']
         components.setdefault(ticker, []).append(component)
 
     historical = _history_information_rows(history, overlay_policy)
+    historical_attention = _history_attention_rows(history, overlay_policy)
     history_dates = _history_information_dates(history)
+    activation_dates = _history_information_dates(
+        history,
+        activation_only=True,
+        registered_at=overlay_policy['registered_at'],
+    )
     # Cross-sectional coverage is the names the current source snapshots can
     # observe, not only names whose headline classifier emitted a direction.
     # A covered name with no qualifying event is a real zero signal. Dropping
@@ -1000,9 +1105,9 @@ def build_information_overlay(policy, events, history, now):
     eligible_tickers = sorted(covered_tickers)
     activation_checks = {
         'history_dates': {
-            'actual': len(history_dates),
+            'actual': len(activation_dates),
             'required': overlay_policy['minimum_history_dates'],
-            'pass': len(history_dates) >= overlay_policy['minimum_history_dates'],
+            'pass': len(activation_dates) >= overlay_policy['minimum_history_dates'],
         },
         'cross_section_tickers': {
             'actual': len(eligible_tickers),
@@ -1014,6 +1119,13 @@ def build_information_overlay(policy, events, history, now):
 
     raw = {
         ticker: sum(row['signed_score'] for row in components.get(ticker, []))
+        for ticker in eligible_tickers
+    }
+    attention_raw = {
+        ticker: sum(
+            row['attention_value']
+            for row in attention_components.get(ticker, [])
+        )
         for ticker in eligible_tickers
     }
     # Mid-rank ties. Ticker spelling must never decide which equal-score name
@@ -1029,6 +1141,24 @@ def build_information_overlay(policy, events, history, now):
             statistics.fmean(index + 0.5 for index in positions)
             / len(ordered_scores)
         )
+    attention_ranks = {}
+    for region_tickers in (
+        [ticker for ticker in eligible_tickers if ticker.isdigit()],
+        [ticker for ticker in eligible_tickers if not ticker.isdigit()],
+    ):
+        ordered_attention = sorted(
+            attention_raw[ticker] for ticker in region_tickers
+        )
+        for ticker in region_tickers:
+            score = attention_raw[ticker]
+            positions = [
+                index for index, value in enumerate(ordered_attention)
+                if value == score
+            ]
+            attention_ranks[ticker] = (
+                statistics.fmean(index + 0.5 for index in positions)
+                / len(ordered_attention)
+            )
     ticker_rows = {}
     for ticker in eligible_tickers:
         by_day = {
@@ -1038,6 +1168,24 @@ def build_information_overlay(policy, events, history, now):
         # No qualifying event on a registered day is a real zero observation,
         # not missing data. Event-day-only baselines overstate normal intensity.
         own = [by_day.get(day, 0.0) for day in history_dates]
+        attention_by_day = {
+            row['as_of']: row['score']
+            for row in historical_attention if row['ticker'] == ticker
+        }
+        own_attention = [attention_by_day.get(day, 0.0) for day in history_dates]
+        attention_baseline = (
+            statistics.fmean(own_attention) if own_attention else 0.0
+        )
+        attention_prior = float(overlay_policy.get('attention_score_prior', 0.1))
+        attention_acceleration = (
+            (attention_raw[ticker] + attention_prior)
+            / (attention_baseline + attention_prior)
+        )
+        source_types = {
+            row.get('source_type')
+            for row in attention_components.get(ticker, [])
+            if row.get('source_type')
+        }
         mean = statistics.fmean(own) if own else None
         stdev = statistics.pstdev(own) if len(own) >= 2 else None
         surprise = (
@@ -1050,8 +1198,20 @@ def build_information_overlay(policy, events, history, now):
             'signed_score': round(raw[ticker], 6),
             'cross_section_rank': round(ranks[ticker], 4),
             'own_history_dates': len(history_dates),
+            'prospective_history_dates': len(activation_dates),
             'own_surprise_z': round(surprise, 4) if surprise is not None else None,
             'event_count': len(components.get(ticker, [])),
+            'attention_score': round(attention_raw[ticker], 6),
+            'attention_rank': round(attention_ranks[ticker], 4),
+            'attention_rank_scope': 'HK' if ticker.isdigit() else 'US',
+            'attention_event_count': len(attention_components.get(ticker, [])),
+            'attention_baseline': round(attention_baseline, 6),
+            'attention_acceleration': round(attention_acceleration, 4),
+            'attention_source_type_count': len(source_types),
+            'attention_components': sorted(
+                attention_components.get(ticker, []),
+                key=lambda row: row['published_at'], reverse=True
+            )[:8],
             'sizing_tilt': (
                 'positive'
                 if (active
@@ -1153,13 +1313,14 @@ def build_graph(events):
     return {'nodes': nodes, 'edges': edges}
 
 
-def update_history(as_of, events):
+def update_history(as_of, events, prior=None):
     snapshots = [
-        row for row in _load_history()
+        row for row in (_load_history() if prior is None else prior)
         if str(row.get('as_of') or '')[:10] != as_of
     ]
     snapshots.append({
         'as_of': as_of,
+        'observed_at': datetime.now(timezone.utc).isoformat(),
         'information_overlay_schema_version': 1,
         'events': [
             {
@@ -1173,6 +1334,8 @@ def update_history(as_of, events):
                 'title': event['title'],
                 'source_type': event['source_type'],
                 'source_reliability': event['source_reliability'],
+                'novelty_score': event.get('novelty_score'),
+                'impact_direction': event.get('impact_direction'),
                 'published_at': event['publication_time'].get('iso'),
                 'status': event['status'],
                 'actionable_escalation': event['actionable_escalation'],
@@ -1187,6 +1350,74 @@ def update_history(as_of, events):
         '\n'.join(json.dumps(row, ensure_ascii=False, separators=(',', ':'))
                   for row in snapshots) + '\n',
     )
+    return snapshots
+
+
+def _backfill_information_components(policy, snapshots, cutoff):
+    """Score legacy snapshots with only facts persisted at their cutoff.
+
+    #503 introduced the continuous overlay after these point-in-time event
+    snapshots already existed.  Replaying the deterministic formula is not a
+    current-news backfill: every input below (published_at, novelty, source and
+    confirmation-independent price nonreaction) was frozen in that day's row.
+    We mark it explicitly so it can seed baselines but never masquerade as a
+    pre-registered live activation date.
+    """
+    overlay_policy = policy['information_overlay']
+    seen = []
+    for snapshot in sorted(snapshots, key=lambda row: row.get('as_of') or ''):
+        as_of = str(snapshot.get('as_of') or '')[:10]
+        if not as_of:
+            continue
+        try:
+            observed_at = datetime.fromisoformat(f'{as_of}T23:59:59+00:00')
+        except ValueError:
+            continue
+        for event in snapshot.get('events') or []:
+            prior = [
+                row for row in seen
+                if row.get('ticker') == event.get('ticker')
+                and (
+                    row.get('event_id') == event.get('event_id')
+                    or row.get('novelty_cluster') == event.get('novelty_cluster')
+                    or row.get('novelty_cluster') in (
+                        event.get('duplicate_novelty_clusters') or []
+                    )
+                )
+            ]
+            novelty = event.get('novelty_score')
+            if novelty is None:
+                novelty = 0.0 if prior else 1.0
+                # This is a deterministic replay from the exact cluster IDs
+                # frozen at the old cutoff. Persist it so unsigned attention
+                # history is comparable instead of treating all legacy days as
+                # zero merely because the field did not exist yet.
+                event['novelty_score'] = novelty
+            direction = event.get('impact_direction') or classify_impact(
+                event.get('title')
+            )
+            if event.get('information_signed_score') is None:
+                component = _event_information_component({
+                    'event_id': event.get('event_id'),
+                    'ticker': event.get('ticker'),
+                    'impact_direction': direction,
+                    'publication_time': {'iso': event.get('published_at')},
+                    'novelty_score': novelty,
+                    'source_reliability': event.get('source_reliability'),
+                    'corroborating_source_count': 1,
+                    'confirmation': {},
+                }, observed_at, overlay_policy)
+                if component is not None:
+                    event['information_signed_score'] = component['signed_score']
+            seen.append(event)
+        snapshot['information_overlay_schema_version'] = 1
+        snapshot.setdefault('observed_at', observed_at.isoformat())
+        if as_of < overlay_policy['registered_at']:
+            snapshot['information_overlay_backfill'] = {
+                'method': 'deterministic_point_in_time_replay_v1',
+                'created_at': cutoff.isoformat(),
+                'activation_eligible': False,
+            }
     return snapshots
 
 
@@ -1207,6 +1438,7 @@ def main(argv=None):
         row for row in _load_history()
         if str(row.get('as_of') or '')[:10] != now.date().isoformat()
     ]
+    history = _backfill_information_components(policy, history, now)
     sec, sec_status = collect_sec_events(
         policy, portfolio, underlying, enabled=not args.no_sec
     )
@@ -1233,7 +1465,7 @@ def main(argv=None):
         policy, events, history, now
     )
     queue = tavily_queue(policy, events)
-    update_history(now.date().isoformat(), events)
+    update_history(now.date().isoformat(), events, prior=history)
     out = {
         'schema_version': 1,
         'generated_at': now.isoformat(),

--- a/src/clawock/market_data/factors.py
+++ b/src/clawock/market_data/factors.py
@@ -84,10 +84,14 @@ def parse_bars(payload, symbol):
     out = []
     for row in rows:
         try:
+            open_ = float(row[1])
             close = float(row[2])
+            high = float(row[3])
+            low = float(row[4])
             volume = float(row[5]) if len(row) > 5 and row[5] not in ('', None) else None
-            if close > 0:
-                out.append({'date': str(row[0])[:10], 'close': close,
+            if min(open_, close, high, low) > 0:
+                out.append({'date': str(row[0])[:10], 'open': open_,
+                            'close': close, 'high': high, 'low': low,
                             'volume': volume})
         except (TypeError, ValueError, IndexError):
             continue
@@ -373,6 +377,12 @@ def _centered_ranks(values):
     return ranks
 
 
+def _percentile_ranks(values):
+    """Average-tie ranks on [0, 1], independent within each market."""
+    centered = _centered_ranks(values)
+    return {ticker: value + 0.5 for ticker, value in centered.items()}
+
+
 def rank_snapshot(config, fetched, as_of, quality=None, region=None):
     quality = quality or {}
     specs = [row for row in config['symbols']
@@ -490,6 +500,23 @@ def rank_snapshot(config, fetched, as_of, quality=None, region=None):
         for field in ('mom_1m', 'mom_3m', 'mom_6m', *RAW_FACTORS):
             if isinstance(row.get(field), float):
                 row[field] = round(row[field], 6)
+
+    # Portfolio construction consumes a rank, not an arbitrary score cutoff.
+    # Keep US and HK separate: the two markets do not share a session, peer
+    # distribution, liquidity scale, or investible universe.  A sector with
+    # only two near-identical ETFs is also made explicit so it cannot create a
+    # spurious extreme rank merely because one of the pair is slightly ahead.
+    for region in sorted({row['region'] for row in raw.values()}):
+        values = {
+            ticker: row['composite_score']
+            for ticker, row in raw.items()
+            if row['region'] == region
+            and isinstance(row.get('composite_score'), (int, float))
+        }
+        for ticker, percentile in _percentile_ranks(values).items():
+            raw[ticker]['market_percentile'] = round(percentile, 4)
+    for ticker, row in raw.items():
+        row['sector_universe_size'] = len(by_sector.get(row['sector']) or [])
     return raw
 
 
@@ -792,6 +819,8 @@ def _history_snapshot(as_of, rows, registered_at):
                 'feature_as_of': row['feature_as_of'],
                 'close': row['close'],
                 'composite_score': row['composite_score'],
+                'market_percentile': row.get('market_percentile'),
+                'sector_universe_size': row.get('sector_universe_size'),
                 'factor_coverage_pct': row['factor_coverage_pct'],
             }
             for ticker, row in rows.items()

--- a/tests/test_add_alpha.py
+++ b/tests/test_add_alpha.py
@@ -1,0 +1,178 @@
+"""Contracts for low-frequency factor × information add authority."""
+
+import copy
+import json
+from pathlib import Path
+
+from clawock.decision import add_alpha
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = json.loads(
+    (ROOT / "config" / "add-alpha-policy.json").read_text(encoding="utf-8")
+)
+
+
+def _factor(**overrides):
+    row = {
+        "market_percentile": 0.9, "coverage_pct": 95,
+        "sector_universe_size": 5, "usable_for_decisions": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def _peer(**overrides):
+    row = {
+        "triggered_rules": ["leader_continuation"],
+        "available_peer_count": 4, "usable_for_decisions": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def _information(**overrides):
+    row = {
+        "signed_score": 0.12, "attention_rank": 0.9,
+        "attention_acceleration": 2.0, "attention_source_type_count": 2,
+        "attention_event_count": 2,
+        "attention_components": [{"event_id": "attention-1"}],
+        "event_components": [{
+            "event_id": "positive-1", "direction": 1, "novelty": 1,
+            "reliability": 0.9, "price_nonreaction": 1,
+        }],
+        "usable_for_decisions": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_factor_and_peer_are_one_family_not_fake_independent_sources():
+    authority = add_alpha.classify_authority(
+        _factor(), _peer(),
+        _information(
+            signed_score=0, attention_rank=0.5,
+            attention_acceleration=1, attention_event_count=0,
+            attention_components=[], event_components=[],
+        ),
+        leveraged=False, policy=POLICY, market="US",
+    )
+
+    assert authority["sources"] == ["factor", "peer_residual"]
+    assert authority["evidence_families"] == ["price_relative"]
+    assert authority["tier"] == "none"
+    assert "independent_evidence_families" in authority["blockers"]
+
+
+def test_attention_acceleration_unlocks_one_nonleveraged_exploration_campaign():
+    authority = add_alpha.classify_authority(
+        _factor(), _peer(), _information(),
+        leveraged=False, policy=POLICY, market="US",
+    )
+    technical = {
+        "usable": True, "stop_state": "intact", "as_of": "2026-08-13",
+        "close": 10, "prior_5d_high": 10.2, "prior_5d_low": 9,
+        "ma20": 9.5, "chandelier_stop": 8.5,
+    }
+    next_day = copy.deepcopy(technical)
+    next_day["as_of"] = "2026-08-14"
+
+    first = add_alpha.confirmation_setup(
+        technical, authority, POLICY, ticker="ABC"
+    )
+    second = add_alpha.confirmation_setup(
+        next_day, authority, POLICY, ticker="ABC"
+    )
+
+    assert authority["tier"] == "exploration"
+    assert authority["evidence_families"] == [
+        "price_relative", "point_in_time_information",
+    ]
+    assert first["campaign_id"] == second["campaign_id"]
+    assert first["max_tranches"] == 1
+    assert first["target_tranche_level"] == 0.25
+
+
+def test_validated_campaign_does_not_reset_when_daily_event_ids_change():
+    authority = add_alpha.classify_authority(
+        _factor(usable_for_decisions=True), _peer(),
+        _information(usable_for_decisions=True),
+        leveraged=False, policy=POLICY, market="US",
+    )
+    technical = {
+        "usable": True, "stop_state": "intact", "as_of": "2026-08-13",
+        "close": 10, "prior_5d_high": 10.2, "prior_5d_low": 9,
+        "ma20": 9.5, "chandelier_stop": 8.5,
+    }
+    first = add_alpha.confirmation_setup(
+        technical, authority, POLICY, ticker="ABC"
+    )
+    authority["information_event_ids"] = ["tomorrows-headline"]
+    second = add_alpha.confirmation_setup(
+        technical, authority, POLICY, ticker="ABC"
+    )
+
+    assert authority["tier"] == "validated"
+    assert first["campaign_id"] == second["campaign_id"]
+
+
+def test_factor_rank_has_enter_exit_hysteresis_for_an_open_campaign():
+    factor = _factor(market_percentile=0.6)
+    fresh = add_alpha.classify_authority(
+        factor, _peer(triggered_rules=[]), _information(), leveraged=False,
+        policy=POLICY, market="US",
+    )
+    continuing = add_alpha.classify_authority(
+        factor, _peer(triggered_rules=[]), _information(), leveraged=False,
+        policy=POLICY, market="US", continuing=True,
+    )
+
+    assert fresh["tier"] == "none"
+    assert continuing["tier"] == "exploration"
+    assert "market_rank_hysteresis" in continuing["factor_reasons"]
+
+
+def test_confirmation_primitives_are_gap_aware_and_invalidation_first():
+    levels = add_alpha.confirmation_levels({
+        "close": 10, "prior_5d_high": 10.2, "prior_5d_low": 9,
+        "ma20": 9.5, "chandelier_stop": 8.5,
+    })
+    assert levels == {"entry_price": 10.2, "invalidation_price": 9.5}
+    assert add_alpha.confirmation_bar_outcome(
+        {"open": 10.8, "high": 11, "low": 10.4}, **levels
+    ) == {"state": "filled", "price": 10.8, "reason": "gap_through"}
+    assert add_alpha.confirmation_bar_outcome(
+        {"open": 10, "high": 10.5, "low": 9.4}, **levels
+    )["state"] == "invalidated"
+
+
+def test_leveraged_exploration_is_forbidden_but_validated_is_distinct():
+    exploratory = add_alpha.classify_authority(
+        _factor(), _peer(), _information(),
+        leveraged=True, policy=POLICY, market="US",
+    )
+    validated = add_alpha.classify_authority(
+        _factor(usable_for_decisions=True), _peer(),
+        _information(usable_for_decisions=True),
+        leveraged=True, policy=POLICY, market="US",
+    )
+
+    assert exploratory["tier"] == "none"
+    assert "leveraged_requires_validated_evidence" in exploratory["blockers"]
+    assert validated["tier"] == "validated"
+
+
+def test_tiny_negative_news_noise_does_not_veto_but_material_negative_does():
+    tiny = add_alpha.classify_authority(
+        _factor(), _peer(), _information(signed_score=-0.001),
+        leveraged=False, policy=POLICY, market="US",
+    )
+    material = add_alpha.classify_authority(
+        _factor(), _peer(), _information(signed_score=-0.2),
+        leveraged=False, policy=POLICY, market="US",
+    )
+
+    assert tiny["tier"] == "exploration"
+    assert "negative_information" not in tiny["blockers"]
+    assert material["tier"] == "none"
+    assert "negative_information" in material["blockers"]

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+import copy
 from pathlib import Path
 
 
@@ -186,10 +187,83 @@ def test_compiler_owns_proxy_join_risk_status_and_action_bounds():
     assert hk["constraints"]["min_tranche_shares"] == 20
     assert hk["constraints"]["max_add_shares"] % 20 == 0
     assert "add_only_on_trigger" in hk["constraints"]["allowed_actions"]
+    assert hk["quant"]["add_authority"]["tier"] == "none"
     assert len(packet_mod._compact(packet).encode()) < packet_mod.MAX_PACKET_BYTES
     assert len(
         json.dumps(packet_mod.summary_view(packet), ensure_ascii=False).encode()
     ) < packet_mod.MAX_QUERY_BYTES
+
+
+def test_production_factor_and_peer_keys_reach_add_authority():
+    context = _context()
+    context["cross_sectional_factor"] = {
+        "activation": {"usable_for_decisions": False},
+        "live_rankings": {"00100": {
+            "feature_as_of": "2026-07-28", "market_percentile": 0.9,
+            "sector_universe_size": 6, "factor_coverage_pct": 95,
+            "usable_for_decisions": False,
+        }},
+    }
+    context["peer_residual"] = {
+        "rule_activation": {},
+        "live": {"00100": {
+            "feature_as_of": "2026-07-28",
+            "triggered_rules": ["leader_continuation"],
+            "available_peer_count": 5, "usable_for_decisions": False,
+        }},
+    }
+    context["news_evidence_graph"]["information_overlay"] = {
+        "as_of": "2026-07-28T08:00:00+08:00",
+        "status": "warming_up", "usable_for_decisions": False,
+        "activation": {"blockers": ["history_dates"]},
+        "tickers": {"00100": {
+            "status": "warming_up", "usable_for_decisions": False,
+            "signed_score": 0.12, "attention_rank": 0.9,
+            "attention_acceleration": 2.0, "attention_event_count": 1,
+            "attention_source_type_count": 1,
+            "attention_components": [{"event_id": "attention-1"}],
+            "event_components": [{
+                "event_id": "positive-1", "direction": 1,
+                "novelty": 1, "reliability": 0.9,
+                "price_nonreaction": 1,
+            }],
+        }},
+    }
+    context["quant_signals"]["rows"]["00100"].update(
+        close=11, ma20=10, prior_5d_high=11.2, prior_5d_low=9.5,
+        chandelier_stop=9.8,
+    )
+
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    row = packet["tickers"]["00100"]
+
+    assert row["quant"]["add_authority"]["tier"] == "exploration"
+    assert row["quant"]["add_authority"]["evidence_families"] == [
+        "price_relative", "point_in_time_information",
+    ]
+    assert any(
+        setup["setup_id"] == "alpha_confirmation"
+        for setup in row["technical"]["setups"]
+    )
+    # This 20-share lot is 10% of the tiny fixture book, above the separate 3%
+    # hard exploration envelope, so it may not masquerade as a 2.5% sample.
+    assert row["execution"]["max_add_shares"] == 0
+    assert "tranche_below_market_unit" in row["execution"]["blockers"]
+
+
+def test_one_us_share_can_collect_exploration_inside_the_hard_book_cap():
+    execution = packet_mod._execution_view(
+        {"shares": 2, "current_price": 100, "current_value": 200},
+        "US", 10_000, 1_000,
+        {"setups": [{"tranche_pct_of_position": 0.025}]},
+        {"state": "unknown"}, False,
+        authority_tier="exploration", exploration_max_book_pct=0.03,
+    )
+
+    assert execution["max_add_shares"] == 1
+    assert execution["max_add_value"] == 100
 
 
 def test_packet_is_deterministic_and_manifest_hash_bound(tmp_path):
@@ -339,7 +413,9 @@ def test_unknown_registry_leveraged_name_is_blocked_without_a_risk_breach():
         context, brief_context.compute_generation_id(context)
     )
 
-    assert "leveraged_daily_reset" in packet["tickers"]["LEVX"]["execution"]["blockers"]
+    assert "leveraged_requires_validated_evidence" in (
+        packet["tickers"]["LEVX"]["execution"]["blockers"]
+    )
     assert not any(
         action.startswith("add_")
         for action in packet["tickers"]["LEVX"]["constraints"]["allowed_actions"]

--- a/tests/test_cross_sectional_factor.py
+++ b/tests/test_cross_sectional_factor.py
@@ -113,6 +113,28 @@ def test_rank_snapshot_is_centered_within_sector_not_across_sector_beta():
             ]
             assert sum(ranks) == pytest.approx(0.0)
 
+    percentiles = sorted(row["market_percentile"] for row in rows.values())
+    assert percentiles == pytest.approx([0.0, 0.2, 0.4, 0.6, 0.8, 1.0])
+    assert {row["sector_universe_size"] for row in rows.values()} == {3}
+
+
+def test_market_percentiles_are_isolated_between_hk_and_us():
+    config = _small_config()
+    config["symbols"][-1]["region"] = "hk"
+    fetched = {
+        spec["ticker"]: {"bars": _bars(0.001 * (index + 1))}
+        for index, spec in enumerate(config["symbols"])
+    }
+    as_of = fetched["A1"]["bars"][-1]["date"]
+
+    rows = factor.rank_snapshot(config, fetched, as_of)
+
+    assert rows["B3"]["market_percentile"] == 0.5
+    assert sorted(
+        row["market_percentile"] for row in rows.values()
+        if row["region"] == "us"
+    ) == pytest.approx([0.0, 0.25, 0.625, 0.625, 1.0])
+
 
 def test_two_way_cluster_ci_requires_both_date_and_ticker_clusters():
     one_date = [

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -808,6 +808,18 @@ class ExecutionCoverageTests(unittest.TestCase):
             with mock.patch.object(dv2, "verification_window_days", return_value=3650):
                 self.assertEqual(brief_preflight._detect_followed(row), "unknown")
 
+    def test_add_verification_counts_the_own_legs_sessions_across_a_long_holiday(self):
+        # HK LNY: the five-session campaign starting 2026-02-13 ends on 02-24,
+        # not at the old fixed nine-calendar-day cutoff on 02-22.
+        # old fixed nine-calendar-day cutoff on 02-22.
+        self.assertEqual(
+            dv2.verification_window_days(
+                "add_only_on_trigger", plan_date="2026-02-13", leg="HK",
+                valid_for_sessions=5,
+            ),
+            11,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_news_evidence_graph.py
+++ b/tests/test_news_evidence_graph.py
@@ -88,14 +88,17 @@ def test_eastmoney_naive_timestamp_is_hkt_and_future_event_is_excluded():
 
 def test_information_history_counts_registered_zero_signal_days():
     history = [{
-        'as_of': f'2026-07-{day:02d}',
+        'as_of': f'2026-08-{day:02d}',
         'information_overlay_schema_version': 1,
+        'information_overlay_backfill': {'activation_eligible': True},
         'events': ([{'ticker': 'ABC', 'information_signed_score': 1.0}]
                    if day == 1 else []),
     } for day in range(1, 4)]
     event = _event(title='ABC receives approval and raises guidance')
     event.update(novelty_score=1.0, corroborating_source_count=1)
-    overlay = graph.build_information_overlay(POLICY, [event], history, NOW)
+    policy = deepcopy(POLICY)
+    policy['information_overlay']['registered_at'] = '2026-07-01'
+    overlay = graph.build_information_overlay(policy, [event], history, NOW)
 
     assert overlay['activation']['checks']['history_dates']['actual'] == 3
     assert overlay['tickers']['ABC']['own_history_dates'] == 3
@@ -140,6 +143,38 @@ def test_covered_name_without_direction_is_a_zero_not_missing():
     assert overlay['activation']['checks']['cross_section_tickers']['actual'] == 2
     assert overlay['tickers']['XYZ']['signed_score'] == 0
     assert overlay['tickers']['XYZ']['event_count'] == 0
+
+
+def test_attention_requires_own_history_acceleration_not_just_headline_count():
+    old = _event(
+        title='ABC general corporate update', ticker='ABC',
+        published_at='2026-07-25T08:00:00+00:00',
+    )
+    old.update(novelty_score=1.0, corroborating_source_count=1)
+    history = [{
+        'as_of': '2026-07-25',
+        'observed_at': old['publication_time']['iso'],
+        'information_overlay_schema_version': 1,
+        'events': [{
+            'event_id': old['event_id'], 'ticker': 'ABC',
+            'published_at': old['publication_time']['iso'],
+            'novelty_score': 1.0, 'source_reliability': 0.99,
+            'source_type': 'sec_filing',
+        }],
+    }]
+    current = _event(
+        title='ABC another corporate update', ticker='ABC',
+        published_at=NOW.isoformat(),
+    )
+    current.update(novelty_score=1.0, corroborating_source_count=1)
+
+    overlay = graph.build_information_overlay(POLICY, [current], history, NOW)
+    row = overlay['tickers']['ABC']
+
+    assert row['attention_event_count'] == 1
+    assert row['attention_source_type_count'] == 1
+    assert row['attention_baseline'] > 0
+    assert 0.9 < row['attention_acceleration'] < 1.25
 
 
 def test_source_type_rejects_sec_domain_substring_spoofing():


### PR DESCRIPTION
Closes #504.

## Outcome

- fixes the production factor/peer field mismatch that left real evidence empty at the decision boundary
- adds a low-frequency add authority with two independent evidence families: price-relative factor/peer evidence and point-in-time information surprise/attention acceleration
- separates authority, target tranche and future-session technical execution; includes gap-aware fills, invalidation-first handling, HK/US ranks and market-unit caps
- makes every held name's zero output observable through candidate states and blockers
- adds a production-parity point-in-time evaluator and an explicitly diagnostic, survivorship-limited run card
- wires alpha confirmation into the brief skill, command taxonomy/reference, and both READMEs
- preserves the earlier SPCH cumulative-cost P0 retirement already present in branch history

## Evidence

- 189 targeted strategy, ledger, packet, CLI, context and README checks pass after rebasing onto current master
- replay classified six historical exploration authorities, so the policy is not structurally locked at zero
- interaction samples remain labelled collecting; no retrospective result is promoted to validated authority
- run card: `memory/backtests/add_alpha_walkforward-20260812-3774163f.json`

## Research boundary

The implementation borrows signal-to-target-to-order separation and hysteresis from current Qlib, TradingAgents and AgenticTrading mechanisms without importing a high-frequency or China-market execution stack. LLM judgment may structure events, argue bull/bear cases and veto/downsize; code owns ranks, authority, sizing, market units, fills and outcome attribution.
