### PR TITLE
ops: raise the MiniMax response-header deadline to 60s and verify its value

### DIFF
--- a/ops/host/reapply_openclaw_patches.sh
+++ b/ops/host/reapply_openclaw_patches.sh
@@ -39,17 +39,24 @@ if [[ ! -d "$DIST" ]]; then
   exit 1
 fi
 
+# The last entry verifies the deadline VALUE, not just the patch generation.
+# The MiniMax header deadline separates two measured latency populations and
+# the success population drifts right as injected context grows (issue #506),
+# so a stale patch script that still writes the old number must not pass merely
+# because its marker looks current.
 PATCH_MARKERS=(
   "threads: 1, batchSize: 512"
   "const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 60000;"
   "clawock-minimax-m3-priority"
-  "clawock-minimax-response-header-timeout-v2"
+  "clawock-minimax-response-header-timeout-v3"
+  "MiniMax response-header timeout after 60000ms"
 )
 PATCH_LABELS=(
   "single-thread local embeddings"
   "60s memory_search deadline"
   "MiniMax-M3 priority admission"
-  "MiniMax 30s response-header deadline"
+  "MiniMax 60s response-header deadline"
+  "MiniMax response-header deadline value"
 )
 
 declare -a syntax_targets=()

--- a/tests/test_openclaw_upgrade_skill_contract.py
+++ b/tests/test_openclaw_upgrade_skill_contract.py
@@ -19,7 +19,8 @@ PATCH_MARKERS = (
     "threads: 1, batchSize: 512",
     "const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 60000;",
     "clawock-minimax-m3-priority",
-    "clawock-minimax-response-header-timeout-v2",
+    "clawock-minimax-response-header-timeout-v3",
+    "MiniMax response-header timeout after 60000ms",
 )
 
 


### PR DESCRIPTION
Refs #506.

## 做了什么

把 MiniMax response-header 死线从 **30s 抬到 60s**，并让 wrapper 校验**这个数值本身**而不只是补丁代次 marker。

补丁本体在 `/root/tools/openclaw/current/patch-minimax-response-header-timeout.sh`（仓外，已同步改好并重跑，dist 现在是 `-v3` + `60000ms` + `6e4`，`node --check` 通过、重跑幂等）。本 PR 是仓内那两处跟着走的引用。

## 为什么是 60s

那道死线**不是常数，是一条分隔两个实测分布的标定线**：

- 2026-07-29/30 标定时：91 次成功请求 header 延迟最大 **18.362s**；6 次 overloaded 429 最小 **101.530s**。30s 落在空档里，当时是对的。
- header 延迟就是 prefill 成本，**会随注入 context 增长右移**。2026-08-13 本机实测：

| 请求体 | TTFB |
|---|---|
| 244 KB | 4.07s |
| 489 KB | 7.51s |
| 978 KB | 24.0s（冷前缀缓存 27.7s）|

11 个 cron job 里盘前简报 context 最大，所以**只有它越线**：08:00 和 08:30 两跑都精确卡在 `30000ms` 被 abort，其余 10 个当天全绿。

60s 距 429 群下沿 101.5s 仍有充分余量，补丁存在的目的（挡那种挂 100–143s 才回 429 的请求）完全保留。

## 为什么还要校验数值

`reapply_openclaw_patches.sh` 原本只 grep 代次 marker。**一个还在写旧数字的过期补丁脚本，marker 看起来是新的就能蒙混过关** —— 这和上面那个缺陷是同一类：把标定当常数。所以新增第 5 条 marker 直接断言 bundle 里的 `MiniMax response-header timeout after 60000ms`。

补丁脚本另加了 `--measure` 模式（opt-in，会真打 API）：按几档体积量当前 TTFB，逼近死线 70% 就非零退出并明说「这就是 #506 的成因」。

## 验证

- `bash ops/host/reapply_openclaw_patches.sh --check-only` 对活 dist 五条 marker 全过；
- `tests/test_openclaw_upgrade_skill_contract.py` 4 passed；
- **变异验证**（[[feedback-tests-are-a-backstop-not-a-kpi]]）：把 wrapper 里的 60000ms 改回 30000ms → `test_wrapper_owns_all_current_patches_in_stable_order` 立刻红；改回即绿。断言不是装饰性的。

## 不在本 PR 范围

**没有动 fallback 链。** `openclaw-fallback-chain-health` 里 kcn 08-06 已结案「我就一个 minimax」：`minimax` 与 `minimax-2` 是同一把 key 同一个 endpoint，加跳/换序都是白工，唯一解是另一个 provider 账号（采购决定）。当时定的重开判据第 ① 条是「**重试也开始失败**」—— 今天 08:00 与 08:30 双双失败正好命中，所以 #506 成立；但正确的杠杆是抬这条死线，不是再去动那条链。

**没有补发今天的简报**：20:00 写一份 pre-open 不是 pre-open。
