### PR TITLE
fix: weight attention acceleration symmetrically on both sides

### DIFF
--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -201,7 +201,13 @@ def _attention_snapshot(snapshot, overlay_policy):
             payload, cutoff, overlay_policy
         )
         if attention:
-            scores[ticker] += attention["attention_value"]
+            # The comparable value, not attention_value: this score is the
+            # numerator of an acceleration ratio whose baseline is rebuilt
+            # from the same corroboration-less snapshots. Identical today
+            # because the payload above pins one source, but reading the
+            # weighted field would silently reintroduce the asymmetry the
+            # moment replay learns real corroboration counts.
+            scores[ticker] += attention["baseline_comparable_value"]
             source_types[ticker].add(attention["source_type"])
             attention_components[ticker].append(attention)
         signed_value = _number(event.get("information_signed_score"))

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -943,6 +943,15 @@ def _event_information_component(event, now, overlay_policy):
     }
 
 
+def _corroboration_weight(sources):
+    """Source-count weight, with one source as the reproducible floor.
+
+    Kept as one function so the live path and the baseline-comparable path
+    cannot drift apart into two slightly different weightings.
+    """
+    return min(1.0, 0.5 + 0.25 * (max(1, int(sources or 1)) - 1))
+
+
 def _event_attention_component(event, now, overlay_policy):
     """Unsigned, source-weighted attention available at the snapshot cutoff.
 
@@ -970,12 +979,19 @@ def _event_attention_component(event, now, overlay_policy):
     novelty = float(event.get('novelty_score') or 0)
     reliability = float(event.get('source_reliability') or 0)
     sources = max(1, int(event.get('corroborating_source_count') or 1))
-    corroboration = min(1.0, 0.5 + 0.25 * (sources - 1))
+    corroboration = _corroboration_weight(sources)
     freshness = math.exp(
         -math.log(2) * age_hours
         / float(overlay_policy['freshness_half_life_hours'])
     )
     value = novelty * reliability * corroboration * freshness
+    # ``update_history`` does not persist ``corroborating_source_count``, so a
+    # historical baseline can only ever be rebuilt at the one-source floor.
+    # Acceleration therefore compares floor-weighted against floor-weighted;
+    # scoring the live side at full corroboration against that baseline moved
+    # the ratio in one direction only. Full weight still drives the
+    # cross-sectional attention score and its rank, where both sides are live.
+    comparable = novelty * reliability * _corroboration_weight(1) * freshness
     return {
         'event_id': event.get('event_id'),
         'published_at': published,
@@ -984,6 +1000,7 @@ def _event_attention_component(event, now, overlay_policy):
         'corroborating_sources': sources,
         'freshness': round(freshness, 4),
         'attention_value': round(value, 6),
+        'baseline_comparable_value': round(comparable, 6),
         'channel': (event.get('metadata') or {}).get('channel') or 'news',
         'source_type': event.get('source_type') or 'unknown',
     }
@@ -1033,7 +1050,10 @@ def _history_attention_rows(history, overlay_policy):
             }, cutoff, overlay_policy)
             if component is not None:
                 ticker = str(event.get('ticker') or '')
-                scores[ticker] = scores.get(ticker, 0.0) + component['attention_value']
+                scores[ticker] = (
+                    scores.get(ticker, 0.0)
+                    + component['baseline_comparable_value']
+                )
         for ticker, score in scores.items():
             rows.append({'as_of': as_of, 'ticker': ticker, 'score': score})
     return rows
@@ -1128,6 +1148,15 @@ def build_information_overlay(policy, events, history, now):
         )
         for ticker in eligible_tickers
     }
+    # The numerator of the acceleration ratio. Deliberately not attention_raw:
+    # the denominator is rebuilt from snapshots that cannot carry corroboration.
+    attention_comparable = {
+        ticker: sum(
+            row['baseline_comparable_value']
+            for row in attention_components.get(ticker, [])
+        )
+        for ticker in eligible_tickers
+    }
     # Mid-rank ties. Ticker spelling must never decide which equal-score name
     # lands above an activation threshold.
     ranks = {}
@@ -1178,7 +1207,7 @@ def build_information_overlay(policy, events, history, now):
         )
         attention_prior = float(overlay_policy.get('attention_score_prior', 0.1))
         attention_acceleration = (
-            (attention_raw[ticker] + attention_prior)
+            (attention_comparable[ticker] + attention_prior)
             / (attention_baseline + attention_prior)
         )
         source_types = {
@@ -1202,6 +1231,7 @@ def build_information_overlay(policy, events, history, now):
             'own_surprise_z': round(surprise, 4) if surprise is not None else None,
             'event_count': len(components.get(ticker, [])),
             'attention_score': round(attention_raw[ticker], 6),
+            'attention_comparable_score': round(attention_comparable[ticker], 6),
             'attention_rank': round(attention_ranks[ticker], 4),
             'attention_rank_scope': 'HK' if ticker.isdigit() else 'US',
             'attention_event_count': len(attention_components.get(ticker, [])),

--- a/tests/test_news_evidence_graph.py
+++ b/tests/test_news_evidence_graph.py
@@ -177,6 +177,54 @@ def test_attention_requires_own_history_acceleration_not_just_headline_count():
     assert 0.9 < row['attention_acceleration'] < 1.25
 
 
+def test_attention_acceleration_weights_live_and_baseline_identically():
+    """Corroboration must reach the rank but never the acceleration gate.
+
+    ``update_history`` does not persist ``corroborating_source_count``, so a
+    historical baseline can only ever be rebuilt at the one-source floor.
+    Scoring the live side at full corroboration against that floor moved
+    acceleration in one direction only — upward, always — on the gate that
+    authorises capital.
+    """
+    old = _event(
+        title='ABC general corporate update', ticker='ABC',
+        published_at='2026-07-25T08:00:00+00:00',
+    )
+    old.update(novelty_score=1.0, corroborating_source_count=1)
+    history = [{
+        'as_of': '2026-07-25',
+        'observed_at': old['publication_time']['iso'],
+        'information_overlay_schema_version': 1,
+        'events': [{
+            'event_id': old['event_id'], 'ticker': 'ABC',
+            'published_at': old['publication_time']['iso'],
+            'novelty_score': 1.0, 'source_reliability': 0.99,
+            'source_type': 'sec_filing',
+        }],
+    }]
+
+    def row_for(sources):
+        current = _event(
+            title='ABC another corporate update', ticker='ABC',
+            published_at=NOW.isoformat(),
+        )
+        current.update(novelty_score=1.0, corroborating_source_count=sources)
+        overlay = graph.build_information_overlay(
+            POLICY, [current], history, NOW
+        )
+        return overlay['tickers']['ABC']
+
+    single = row_for(1)
+    corroborated = row_for(3)
+
+    # Corroboration is real information and still separates the two names in
+    # the cross-sectional attention score that feeds attention_rank.
+    assert corroborated['attention_score'] > single['attention_score']
+    # But it must not move a ratio whose denominator cannot see it.
+    assert (corroborated['attention_acceleration']
+            == single['attention_acceleration'])
+
+
 def test_source_type_rejects_sec_domain_substring_spoofing():
     assert graph.source_type(
         origin='gnews-rss',


### PR DESCRIPTION
Closes #507.

## 缺陷

`attention_acceleration = (live + prior) / (baseline + prior)`，撞的是 `minimum_attention_acceleration: 1.25` 这道**授权动用资金**的闸。

分子（live）按事件真实来源数加权：`corroboration = min(1.0, 0.5 + 0.25 * (sources - 1))` ∈ [0.5, 1.0]。
分母（baseline）从历史快照重建，而 `update_history()` 落盘的 event 投影里**从来没有** `corroborating_source_count` 这个字段 ⇒ 只能按一源下限 **0.5** 重建。

同一条事件今天以最高 1.0 的权重进分子，明天进历史后只以 0.5 的权重进分母。**偏差永远只朝一个方向：往上。**

## 量级不小

不是「四舍五入级」的偏差。fixture 实测：**一条 3-source 事件把 acceleration 从 1.00 抬到 1.83** —— 真实注意力毫无变化，纯靠 corroboration 就越过了 1.25 的闸。

（今天生产数据 84 条事件里只有 2 条 `count>1`，所以历史影响面窄；但任何一条这样的事件落在某个 ticker 上，那个 ticker 的闸就被它单独顶开。）

## 修法

采用 issue 里的方案 2（零迁移成本、立刻对称）：新增 `baseline_comparable_value`（corroboration 固定取一源下限），acceleration 两侧都用它。

**完整 corroboration 依然驱动 `attention_score` / `attention_rank`** —— 那是截面排序，两边都是 live 数据，加权是诚实的。丢掉 corroboration 才是丢信息。

`_corroboration_weight()` 抽成单一函数，避免 live 路径和 comparable 路径日后各自漂移成两套权重。

另外把 `add_alpha_walkforward.py` 里那处 `attention["attention_value"]` 也改成读 comparable：它给 payload 钉死 `corroborating_source_count: 1`，所以**今天数值完全相同**，但它同样是一个 acceleration 比值的分子，继续读加权字段等于把这个陷阱原样留在原地。

## 验证

- **先红后绿**（[[feedback-tests-are-a-backstop-not-a-kpi]]）：新测试在修之前是红的，报 `assert 1.8319 == 1.0`；修完绿。
- **两侧断言**（[[feedback-codex-two-sided-invariant-briefs.md]]）：既断言 corroboration **仍然**拉开 `attention_score`（否则「修复」可能是把 corroboration 整个删掉），又断言它**不再**移动 acceleration。单改一头会让另一头红。
- `tests/test_news_evidence_graph.py` 24 passed、`test_add_alpha.py` + 上述共 31 passed、`test_brief_decision_packet.py` / `test_decision_v2.py` / `test_cross_sectional_factor.py` 共 95 passed。

## Review 说明

按 clawock 约定 Claude 作者的 PR 应由 Codex 交叉 review。**Codex 配额已耗尽（提示恢复时间 Aug 18）**，命中 2026-08-03 kcn 那条对称例外：由 Claude 自己完成最终 diff/CI/merge-state 审计后合并。未跳过任何必需检查，也未用共享 KCNyu 身份伪造独立 review。
