### PR TITLE
harness: claim the send before sending, not after (#508)

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -17,6 +17,7 @@ session transcript. transcript_loop_score detects that directly and cleanly
 (observed: looped run score≈7 on a 97KB assistant blob; clean run score≈2 on 3KB).
 """
 import json
+import os
 import subprocess
 import sys
 import time
@@ -521,6 +522,108 @@ def already_delivered(marker_path, within_ms=None):
         if age >= within_ms:
             return False
     return True
+
+
+# A claim older than this is not a concurrent sender: report slots are hours
+# apart and the whole postflight (send → cosend → marker → commit) runs in about
+# a minute. The window only has to outlast one postflight, and it must expire so
+# a crashed sender cannot mute a later slot forever.
+SEND_CLAIM_STALE_MS = 30 * 60 * 1000
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(int(pid), 0)
+    except (ProcessLookupError, ValueError, TypeError):
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def _write_claim(path, payload):
+    tmp = Path(f'{path}.{os.getpid()}.tmp')
+    tmp.write_text(json.dumps(payload, ensure_ascii=False))
+    os.replace(tmp, path)
+
+
+def claim_send(claim_path, *, stale_after_ms=SEND_CLAIM_STALE_MS, now_ms=None):
+    """Take the right to send this slot BEFORE sending. Returns (won, reason).
+
+    WHY (2026-08-13, #508): `already_delivered` reads the send marker, but the
+    marker is only written AFTER WeChat AND the Telegram cosend have returned —
+    about 54s after a postflight starts. Two postflights racing inside that
+    window both read "never delivered today" and both send. That is exactly what
+    kcn got on the 09:30 hk-open slot: the model's exec shell hit its 60s
+    overall-timeout, SIGTERM killed the shell but not the postflight child, the
+    model read that as a failure and re-ran the same command, and WeChat got the
+    report twice (Telegram once — the first process died between the two sends,
+    which is what proves it had already reached WeChat).
+
+    The claim closes that window because it is taken before the first send, not
+    after the last one. O_EXCL is the whole lock.
+
+    A claim whose holder is gone is only taken over when the holder had NOT
+    started sending. If it died mid-send we cannot know whether WeChat got the
+    message, and a duplicate is the failure kcn actually reported — so we skip
+    and let the watchdog's marker-based backstop own the slot. That keeps the
+    guard from silencing a genuine miss (`feedback-detect-but-never-silence`):
+    no marker gets written, so the watchdog still sees an undelivered slot.
+
+    Never blocks delivery on its own plumbing: if the claim file cannot be
+    created or read, this fails OPEN (sends anyway). A duplicate is recoverable,
+    a silently unsent report is the failure this whole harness exists to stop.
+    """
+    path = Path(claim_path)
+    now = int(datetime.now().timestamp() * 1000) if now_ms is None else now_ms
+    mine = {'pid': os.getpid(), 'ts': now, 'send_started_at': None}
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        pass
+    except OSError as e:
+        return True, f'claim-unavailable-fail-open: {e}'
+    else:
+        with os.fdopen(fd, 'w') as f:
+            f.write(json.dumps(mine, ensure_ascii=False))
+        return True, 'claimed'
+
+    try:
+        held = json.loads(path.read_text())
+    except Exception as e:
+        # An unreadable claim proves nothing about a send. Fail open.
+        return True, f'claim-unreadable-fail-open: {e}'
+
+    held_ts = held.get('ts')
+    if not isinstance(held_ts, (int, float)) or now - held_ts >= stale_after_ms:
+        _write_claim(path, mine)
+        return True, 'took-over-stale-claim'
+    holder = held.get('pid')
+    if holder and _pid_alive(holder):
+        return False, 'in-flight'
+    if held.get('send_started_at'):
+        return False, 'holder-died-mid-send'
+    _write_claim(path, mine)
+    return True, 'took-over-claim-of-holder-that-never-sent'
+
+
+def mark_send_started(claim_path):
+    """Record that the send is now in flight, so a claim left behind by a killed
+    process is readable as "may already have reached WeChat" rather than "never
+    got going". Best-effort: a claim we cannot update just looks stale later,
+    which fails toward sending, never toward silence."""
+    path = Path(claim_path)
+    try:
+        held = json.loads(path.read_text())
+    except Exception:
+        held = {'pid': os.getpid()}
+    held['send_started_at'] = int(datetime.now().timestamp() * 1000)
+    try:
+        _write_claim(path, held)
+    except Exception as e:
+        print(f'warn: send claim update failed: {e}', file=sys.stderr)
 
 
 def last_report_text(session_id, first_line):

--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -609,6 +609,27 @@ def claim_send(claim_path, *, stale_after_ms=SEND_CLAIM_STALE_MS, now_ms=None):
     return True, 'took-over-claim-of-holder-that-never-sent'
 
 
+def release_claim(claim_path):
+    """Drop the claim once this slot's send has run to completion (marker written).
+
+    Without this the claim outlives the process that finished normally, and a
+    LATER slot can be refused by it. Concretely: an intraday send that failed
+    leaves a marker with sent_ok=false/tg_ok=false, so `already_delivered`
+    correctly does not block the next slot — but a surviving claim carrying
+    `send_started_at` would, and the next slot would go out as nothing at all.
+
+    After release, "a claim exists" means exactly "a sender died holding it",
+    which is the only case the claim is meant to arbitrate. The marker, not the
+    claim, is what keeps a completed send from being repeated.
+    """
+    try:
+        Path(claim_path).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        print(f'warn: send claim release failed: {e}', file=sys.stderr)
+
+
 def mark_send_started(claim_path):
     """Record that the send is now in flight, so a claim left behind by a killed
     process is readable as "may already have reached WeChat" rather than "never

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -463,6 +463,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, build_brief_card, cosend_telegram, already_delivered,
+    claim_send, mark_send_started, log,
 )
 
 
@@ -786,40 +787,60 @@ def main(argv=None):
         card = build_brief_card(today)
         message = (wechat_prefix + card).strip()
         first_line = card.strip().splitlines()[0] if card.strip() else ''
-        try:
-            channel, to, account = resolve_wechat_target()
-            wechat_sent, send_out = send_wechat(channel, to, account, message, dry_run=args.dry_run)
-        except Exception as e:
-            wechat_sent, send_out = False, str(e)[:300]
-        # Always co-send to Telegram (cold-proof) — WeChat can't confirm real delivery.
-        # Record the Telegram result: it's the sole backstop brief_watchdog now uses
-        # (no more WeChat resend), so it needs to know if TG already got this card.
-        tg_ok, _tg_out = cosend_telegram(message, 'brief', dry_run=args.dry_run)
-        # NEVER write the marker on a dry run (2026-07-16). send_wechat/cosend_telegram
-        # return ok=True for a dry run (the CLI exits 0 without sending), so this used to
-        # record sent_ok/tg_ok=true for a delivery that never happened. brief_watchdog
-        # treats a fresh marker with tg_ok as its SOLE proof the card landed, so one
-        # dry run silently disabled that day's backstop — exactly the "card never
-        # arrived and nothing noticed" hole the watchdog exists to close. Hit for real:
-        # a --dry-run postflight at 10:14 today wrote a marker claiming delivery while
-        # kcn got nothing.
+        # Take the send right before sending, not after (#508). The marker below
+        # is written only once both channels have returned, so two postflights
+        # racing on the same day would both read "not delivered yet" and both
+        # send the card. A dry run sends nothing, so it takes no claim.
+        claim_path = brief_marker.parent / f'brief-send-{today}.claim'
         if args.dry_run:
-            print('dry-run: skipping brief-sent marker write', file=sys.stderr)
+            claim_won, claim_reason = True, 'dry-run'
         else:
+            claim_won, claim_reason = claim_send(claim_path)
+        if not claim_won:
+            print(f'concurrency: brief send is already claimed ({claim_reason}) — not '
+                  f'sending a second card; the watchdog owns today if the first one '
+                  f'did not land', file=sys.stderr)
+            log({'tag': 'brief', 'action': 'send-claim-declined', 'reason': claim_reason})
+            wechat_sent, send_out = False, f'send-claim-declined: {claim_reason}'
+        else:
+            if not args.dry_run:
+                mark_send_started(claim_path)
             try:
-                brief_marker.parent.mkdir(parents=True, exist_ok=True)
-                brief_marker.write_text(json.dumps({
-                    'ts': int(datetime.now().timestamp() * 1000),
-                    'sent_ok': bool(wechat_sent),
-                    'tg_ok': bool(tg_ok),
-                    'first_line': first_line,
-                    'out': (send_out or '')[-200:],
-                }, ensure_ascii=False))
+                channel, to, account = resolve_wechat_target()
+                wechat_sent, send_out = send_wechat(channel, to, account, message,
+                                                    dry_run=args.dry_run)
             except Exception as e:
-                print(f'warn: brief-sent marker write failed: {e}', file=sys.stderr)
-        if not wechat_sent:
-            print(f'warn: WeChat send failed (watchdog will retry): {str(send_out)[:200]}',
-                  file=sys.stderr)
+                wechat_sent, send_out = False, str(e)[:300]
+            # Always co-send to Telegram (cold-proof) — WeChat can't confirm real delivery.
+            # Record the Telegram result: it's the sole backstop brief_watchdog now uses
+            # (no more WeChat resend), so it needs to know if TG already got this card.
+            tg_ok, _tg_out = cosend_telegram(message, 'brief', dry_run=args.dry_run)
+            # NEVER write the marker on a dry run (2026-07-16). send_wechat/cosend_telegram
+            # return ok=True for a dry run (the CLI exits 0 without sending), so this used to
+            # record sent_ok/tg_ok=true for a delivery that never happened. brief_watchdog
+            # treats a fresh marker with tg_ok as its SOLE proof the card landed, so one
+            # dry run silently disabled that day's backstop — exactly the "card never
+            # arrived and nothing noticed" hole the watchdog exists to close. Hit for real:
+            # a --dry-run postflight at 10:14 today wrote a marker claiming delivery while
+            # kcn got nothing. A declined claim is the same shape: it sent nothing, so it
+            # must not leave a marker either.
+            if args.dry_run:
+                print('dry-run: skipping brief-sent marker write', file=sys.stderr)
+            else:
+                try:
+                    brief_marker.parent.mkdir(parents=True, exist_ok=True)
+                    brief_marker.write_text(json.dumps({
+                        'ts': int(datetime.now().timestamp() * 1000),
+                        'sent_ok': bool(wechat_sent),
+                        'tg_ok': bool(tg_ok),
+                        'first_line': first_line,
+                        'out': (send_out or '')[-200:],
+                    }, ensure_ascii=False))
+                except Exception as e:
+                    print(f'warn: brief-sent marker write failed: {e}', file=sys.stderr)
+            if not wechat_sent:
+                print(f'warn: WeChat send failed (watchdog will retry): {str(send_out)[:200]}',
+                      file=sys.stderr)
 
     result = {
         'status':        status,

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -463,7 +463,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, build_brief_card, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, log,
+    claim_send, mark_send_started, release_claim, log,
 )
 
 
@@ -838,6 +838,10 @@ def main(argv=None):
                     }, ensure_ascii=False))
                 except Exception as e:
                     print(f'warn: brief-sent marker write failed: {e}', file=sys.stderr)
+            # Completed send: the marker owns idempotency from here. A dry run
+            # took no claim, so there is nothing to release.
+            if not args.dry_run:
+                release_claim(claim_path)
             if not wechat_sent:
                 print(f'warn: WeChat send failed (watchdog will retry): {str(send_out)[:200]}',
                       file=sys.stderr)

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -58,7 +58,10 @@ from ._harness_common import (  # noqa: E402
     rebuild_dashboard,
     snapshot_date_for_now,
 )
-from ._watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
+from ._watchdog_common import (  # noqa: E402
+    resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
+    claim_send, mark_send_started, log,
+)
 
 from clawock.workspace import workspace_root
 from clawock.market_data import sessions as trading_calendar
@@ -469,32 +472,53 @@ def main(argv=None):
                   'nothing sent, watchdog owns this slot', file=sys.stderr)
         else:
             message = (wechat_prefix + body).strip()
-            try:
-                channel, to, account = resolve_wechat_target(args.market)
-                wechat_sent, send_out = send_wechat(channel, to, account, message, dry_run=False)
-            except Exception as e:
-                wechat_sent, send_out = False, str(e)[:300]
-            # Always co-send to Telegram (cold-proof) — WeChat can't confirm real
-            # delivery. Record the Telegram result: it's the sole backstop
-            # intraday_watchdog now uses (no more WeChat resend), so it needs to
-            # know if TG already got this.
-            tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
-            try:
-                marker.write_text(json.dumps(delivery_marker_payload(
-                    ctx,
-                    ts=int(datetime.now().timestamp() * 1000),
-                    sent_ok=wechat_sent,
-                    tg_ok=tg_ok,
-                    first_line=block_first,
-                    market=args.market,
-                    out=send_out,
-                    delivery_state='failed' if status == 'fail' else 'delivered',
-                ), ensure_ascii=False))
-            except Exception as e:
-                print(f'warn: marker write failed: {e}', file=sys.stderr)
-            if not wechat_sent:
-                print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}',
-                      file=sys.stderr)
+            # Same race as #508 on the report path: the marker is written only
+            # after both sends return, so a second postflight started inside
+            # that window sees "not delivered" and doubles the slot. The claim
+            # is taken before the send. Its staleness window matches the
+            # already_delivered one — intraday's claim is per-market, so it must
+            # expire before the next 30min slot needs it.
+            claim_path = TMP / f'intraday-send-{args.market}.claim'
+            won, claim_reason = claim_send(claim_path, stale_after_ms=20 * 60 * 1000)
+            if not won:
+                print(f'concurrency: intraday {args.market} send is already claimed '
+                      f'({claim_reason}) — not sending a second copy; the watchdog owns '
+                      f'this slot if the first one did not land', file=sys.stderr)
+                log({'tag': f'intraday-{args.market}', 'action': 'send-claim-declined',
+                     'reason': claim_reason})
+                wechat_sent, send_out = False, f'send-claim-declined: {claim_reason}'
+            else:
+                mark_send_started(claim_path)
+                try:
+                    channel, to, account = resolve_wechat_target(args.market)
+                    wechat_sent, send_out = send_wechat(channel, to, account, message,
+                                                        dry_run=False)
+                except Exception as e:
+                    wechat_sent, send_out = False, str(e)[:300]
+                # Always co-send to Telegram (cold-proof) — WeChat can't confirm real
+                # delivery. Record the Telegram result: it's the sole backstop
+                # intraday_watchdog now uses (no more WeChat resend), so it needs to
+                # know if TG already got this.
+                tg_ok, _tg_out = cosend_telegram(message, f'intraday-{args.market}')
+                # Only the process that actually sent may write the marker. A
+                # declined claim writing one would tell intraday_watchdog this
+                # slot was handled while nothing went out (#508).
+                try:
+                    marker.write_text(json.dumps(delivery_marker_payload(
+                        ctx,
+                        ts=int(datetime.now().timestamp() * 1000),
+                        sent_ok=wechat_sent,
+                        tg_ok=tg_ok,
+                        first_line=block_first,
+                        market=args.market,
+                        out=send_out,
+                        delivery_state='failed' if status == 'fail' else 'delivered',
+                    ), ensure_ascii=False))
+                except Exception as e:
+                    print(f'warn: marker write failed: {e}', file=sys.stderr)
+                if not wechat_sent:
+                    print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}',
+                          file=sys.stderr)
 
     raw_block = (ctx.get('raw_wechat_block', '') or '').strip()
     data_plane_ready = ctx.get('status') == 'ok' and bool(raw_block)

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_postflight.py
@@ -60,7 +60,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, log,
+    claim_send, mark_send_started, release_claim, log,
 )
 
 from clawock.workspace import workspace_root
@@ -516,6 +516,10 @@ def main(argv=None):
                     ), ensure_ascii=False))
                 except Exception as e:
                     print(f'warn: marker write failed: {e}', file=sys.stderr)
+                # Completed send: the marker owns idempotency from here, and a
+                # claim left behind would refuse the NEXT slot (whose marker
+                # correctly does not block it when this one failed to send).
+                release_claim(claim_path)
                 if not wechat_sent:
                     print(f'warn: WeChat send failed (watchdog will retry): {send_out[:200]}',
                           file=sys.stderr)

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
@@ -100,7 +100,7 @@ from ._harness_common import (  # noqa: E402
 )
 from ._watchdog_common import (  # noqa: E402
     resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
-    claim_send, mark_send_started, log,
+    claim_send, mark_send_started, release_claim, log,
 )
 
 
@@ -244,6 +244,11 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
         }, ensure_ascii=False))
     except Exception as e:
         print(f'warn: report send marker write failed: {e}', file=sys.stderr)
+    # This send ran to completion, so the marker now owns the idempotency question
+    # and the claim has nothing left to arbitrate. Releasing it keeps "a claim
+    # exists" meaning "a sender died holding it".
+    if claim_path is not None:
+        release_claim(claim_path)
     if not sent_ok:
         print(f'warn: WeChat send failed (watchdog will retry): {(out or "")[:200]}', file=sys.stderr)
     return sent_ok, out

--- a/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/report_postflight.py
@@ -98,7 +98,10 @@ from ._harness_common import (  # noqa: E402
     rebuild_dashboard,
     snapshot_date_for_now,
 )
-from ._watchdog_common import resolve_wechat_target, send_wechat, cosend_telegram, already_delivered  # noqa: E402
+from ._watchdog_common import (  # noqa: E402
+    resolve_wechat_target, send_wechat, cosend_telegram, already_delivered,
+    claim_send, mark_send_started, log,
+)
 
 
 def read_prose_text(market, phase, text_file):
@@ -170,7 +173,7 @@ def claim_upgrade(market, phase, date):
 
 
 def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='delivered',
-                   context_id=None, context_generated_at=None):
+                   context_id=None, context_generated_at=None, claim_path=None):
     """Primary WeChat send for staged reports — fresh-token `openclaw message send`,
     decoupled from the cron's announce.
 
@@ -197,6 +200,11 @@ def deliver_wechat(market, phase, date, wechat_prefix, text, delivery_state='del
     message = (wechat_prefix + text).strip()
     body_lines = text.strip().splitlines()
     sent_first = body_lines[0].strip() if body_lines else ''
+    # Flip the claim to "in flight" BEFORE the send, so a process killed between
+    # here and the marker write (the 2026-08-13 duplicate, #508) is readable as
+    # "may already have reached WeChat" by whoever claims next.
+    if claim_path is not None:
+        mark_send_started(claim_path)
     try:
         channel, to, account = resolve_wechat_target(market)
         sent_ok, out = send_wechat(channel, to, account, message, dry_run=False)
@@ -476,21 +484,50 @@ def main(argv=None):
     # fail-closed data block, and this run has a report that actually validates.
     # claim_upgrade() makes it exactly one. Everything else — a second failure, a
     # retry of an already-good send — stays blocked.
+    upgrading = False
     if blocked and delivery_state == 'delivered' and _marker_state(report_marker) == 'failed':
         if claim_upgrade(args.market, args.phase, today):
             print(f'upgrade: {args.market}-{args.phase} superseding the fail-closed '
                   f'data block with the validated report', file=sys.stderr)
             blocked = False
+            upgrading = True
 
+    send_claim = 'not-required'
     if blocked:
         print(f'idempotency: {args.market}-{args.phase} already delivered today — skip re-send',
               file=sys.stderr)
         wechat_sent = True
-    else:
+    elif upgrading:
+        # The upgrade is the one re-send this slot is allowed, and `claim_upgrade`
+        # is already an O_EXCL one-shot — so it needs no send claim on top. Asking
+        # for one would in fact deny it: the fail-closed send that ran first left
+        # its own claim behind, and the upgrade would read that as a sender still
+        # in flight and skip the corrected report (caught by
+        # test_a_failed_slot_can_be_superseded_once_then_locks).
+        send_claim = 'upgrade'
         wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
                                         delivery_state=delivery_state,
                                         context_id=ctx.get('context_id'),
                                         context_generated_at=ctx.get('generated_at'))
+    else:
+        # The marker only proves a send that FINISHED. A concurrent postflight
+        # that is still mid-send leaves no marker at all, so the claim is what
+        # keeps the second one quiet (#508).
+        claim_path = TMP / f'report-send-{args.market}-{args.phase}-{today}.claim'
+        won, send_claim = claim_send(claim_path)
+        if not won:
+            print(f'concurrency: {args.market}-{args.phase} send is already claimed '
+                  f'({send_claim}) — not sending a second copy; the watchdog owns this '
+                  f'slot if the first one did not land', file=sys.stderr)
+            log({'tag': f'{args.market}-{args.phase}', 'action': 'send-claim-declined',
+                 'reason': send_claim})
+            wechat_sent = False
+        else:
+            wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
+                                            delivery_state=delivery_state,
+                                            context_id=ctx.get('context_id'),
+                                            context_generated_at=ctx.get('generated_at'),
+                                            claim_path=claim_path)
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
     data_plane_status = classify_data_plane(commit_ok, commit_msg)
@@ -504,6 +541,9 @@ def main(argv=None):
         'issues':        issues,
         'wechat_prefix': wechat_prefix,
         'wechat_sent':   wechat_sent,
+        # So a re-run that correctly declined to double-send says so in its own
+        # output instead of looking like a send failure to whoever reads Step 4.
+        'send_claim':    send_claim,
         'delivered':     'data-block only (prose rejected)' if status == 'fail' else 'full report',
         'commit_ok':     commit_ok,
         'commit_msg':    commit_msg,

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -138,6 +138,12 @@ shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight �
 postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
 文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧散文重发。
 
+⏱ **看到 SIGTERM / exec 超时 ≠ 报告没发出去，别原样再跑一遍。** exec 的 overall-timeout
+只杀命令外壳，postflight 子进程还在继续跑，通常微信早发出去了。先读
+`memory/.tmp/intraday-sent-hk.json`：`ts` 是本 slot 的、且有 `sent_ok` / `tg_ok`
+就是已投递。（2026-08-13 09:30 港股开盘那次双发的机制，#508；postflight 现在有发送前
+claim 会挡住第二次真发，但那一跑仍然是白跑。）
+
 校验段标记 + 长度 + 异动票提及（都只校验你写的那段，不校验拼进来的数据块）。
 **不提交 `portfolio.json`**；若 dashboard 有语义变化，postflight 会重建并提交
 `assets/data/dashboard.json`。每个 slot 的完成/投递状态另写 heartbeat，由 single publisher 发布。
@@ -211,6 +217,8 @@ clawock report preflight --market hk --phase {open|mid|pm|close}
 clawock report postflight --market hk --phase {phase} --context-id {Step 1 的 context_id} --text-file /root/.openclaw/workspace/memory/.tmp/report-prose-hk-{phase}.md
 ```
 `--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），postflight 拒绝拼装、只发数据块。散文文件超过 30 分钟没更新同样拒发。返回 JSON 含 `status` (pass/warn/fail)。pass/warn 自动拼装+发送+刷新 snapshot/dashboard，提交 scoped 产物并经 `ops/publish/safe_push.sh` 推送。
+
+⏱ **看到 SIGTERM / exec 超时 ≠ 报告没发出去，别原样再跑一遍。** exec 的 overall-timeout 只杀命令外壳，postflight 子进程还在继续跑，通常微信早发出去了。先读 `memory/.tmp/report-sent-hk-{phase}-{今天}.json`：有 `sent_ok` / `tg_ok` 就是已投递，直接把它当 Step 3 的结果输出。（2026-08-13 09:30 港股开盘就是这么让微信收到两条的，#508。postflight 现在有发送前 claim 会挡住第二次真发，输出里会写 `send_claim`，但那一跑仍然是白跑。）
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
 微信投递已在 **Step 3 的 `report_postflight` 用 fresh-token 短连接发出**——这是

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -139,6 +139,12 @@ shell 引号极脆；2026-07-23 10:00 就因为模型漏喂 stdin，postflight �
 postflight 现在把空输入/旧文件单独判成 `status: input_error`（不是 `fail`），并要求
 文件 20 分钟内更新过 —— **忘了重写文件就会被拒**，不会把上一个 slot 的旧散文重发。
 
+⏱ **看到 SIGTERM / exec 超时 ≠ 报告没发出去，别原样再跑一遍。** exec 的 overall-timeout
+只杀命令外壳，postflight 子进程还在继续跑，通常微信早发出去了。先读
+`memory/.tmp/intraday-sent-us.json`：`ts` 是本 slot 的、且有 `sent_ok` / `tg_ok`
+就是已投递。（2026-08-13 09:30 港股开盘那次双发的机制，#508；postflight 现在有发送前
+claim 会挡住第二次真发，但那一跑仍然是白跑。）
+
 校验段标记 + 长度 + 异动票提及（都只校验你写的那段，不校验拼进来的数据块）。
 **不提交 `portfolio.json`**；若 dashboard 有语义变化，postflight 会重建并提交
 `assets/data/dashboard.json`。每个 slot 的完成/投递状态另写 heartbeat，由 single
@@ -215,6 +221,8 @@ clawock report postflight --market us --phase {phase} --context-id {Step 1 的 c
 ```
 `--context-id` 必须是 Step 1 打印的那个：不匹配说明 context 已被换代（散文和数据不同代），postflight 拒绝拼装、只发数据块。散文文件超过 30 分钟没更新同样拒发（防重发上个 slot 的旧文本）。
 pass/warn 自动刷新 snapshot/dashboard，提交 scoped 产物并经 `ops/publish/safe_push.sh` 推送。
+
+⏱ **看到 SIGTERM / exec 超时 ≠ 报告没发出去，别原样再跑一遍。** exec 的 overall-timeout 只杀命令外壳，postflight 子进程还在继续跑，通常微信早发出去了。先读 `memory/.tmp/report-sent-us-{phase}-{今天}.json`：有 `sent_ok` / `tg_ok` 就是已投递，直接把它当 Step 3 的结果输出。（2026-08-13 09:30 港股开盘就是这么让微信收到两条的，#508。postflight 现在有发送前 claim 会挡住第二次真发，输出里会写 `send_claim`，但那一跑仍然是白跑。）
 
 #### Step 4: 输出报告（仅存档；微信已由 postflight 主发，禁用 message 工具）
 

--- a/tests/test_postflight_send_claim.py
+++ b/tests/test_postflight_send_claim.py
@@ -159,6 +159,44 @@ def test_report_deliver_flips_the_claim_before_it_sends(tmp_path, monkeypatch):
     )
 
 
+def _deliver(rp, monkeypatch, tmp_path, claim, send_result):
+    monkeypatch.setattr(rp, 'TMP', tmp_path)
+    monkeypatch.setattr(rp, 'resolve_wechat_target', lambda market: ('ch', 'to', 'acct'))
+    monkeypatch.setattr(rp, 'send_wechat',
+                        lambda channel, to, account, message, dry_run: send_result)
+    monkeypatch.setattr(rp, 'cosend_telegram', lambda message, tag: (True, ''))
+    return rp.deliver_wechat('hk', 'open', '2026-08-13', '', 'body', claim_path=claim)
+
+
+def test_a_completed_send_releases_the_claim(tmp_path, monkeypatch):
+    """After a send finishes, the marker owns idempotency. A claim left behind
+    would go on refusing senders that the marker itself does not refuse."""
+    from clawock_kcnyu.harness import report_postflight as rp
+    claim = tmp_path / 'hk-open.claim'
+    _common().claim_send(claim, now_ms=NOW_MS)
+
+    _deliver(rp, monkeypatch, tmp_path, claim, (True, 'openclaw-weixin:stub'))
+
+    assert not claim.exists()
+
+
+def test_a_failed_send_releases_the_claim_so_the_next_slot_is_not_muted(tmp_path, monkeypatch):
+    """The one that bites: a send that FAILED writes a marker with
+    sent_ok/tg_ok false, so `already_delivered` correctly lets the next slot
+    through — and the claim must not be what stops it instead."""
+    from clawock_kcnyu.harness import report_postflight as rp
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    c.claim_send(claim, now_ms=NOW_MS)
+
+    _deliver(rp, monkeypatch, tmp_path, claim, (False, 'wechat exploded'))
+
+    assert not claim.exists()
+    won, reason = c.claim_send(claim, now_ms=NOW_MS + 5 * 60 * 1000)
+    assert won is True, 'the next slot must still be able to send'
+    assert reason == 'claimed'
+
+
 def test_mark_send_started_flips_a_claim_to_mid_send(tmp_path):
     c = _common()
     claim = tmp_path / 'hk-open.claim'

--- a/tests/test_postflight_send_claim.py
+++ b/tests/test_postflight_send_claim.py
@@ -1,0 +1,172 @@
+"""The postflight send claim must close the duplicate window without opening a
+silent-miss one.
+
+2026-08-13 (#508): the 09:30 hk-open slot reached kcn's WeChat twice. The run had
+been auto-retried after a MiniMax header timeout; inside the retry the model's
+exec shell hit its 60s overall-timeout, SIGTERM killed the shell but not the
+`clawock report postflight` child, the model read SIGTERM as failure and re-ran
+the same command, and the two postflights raced. `already_delivered` could not
+stop them: it reads the send marker, and the marker is written only after both
+sends return — a ~54s window in which both processes read "never delivered".
+
+Two invariants are pinned here, and a fix for either that breaks the other fails
+this file:
+
+  A. a second sender inside that window must NOT send (the reported bug)
+  B. the claim must never become a new way to silently not send (`feedback-
+     detect-but-never-silence`) — a holder that died before sending, a stale
+     claim, and unreadable plumbing all still send.
+
+Not here, deliberately: a "race 8 real processes at one claim" test. It was
+written, then mutation-checked against a read-then-write implementation of
+`claim_send` — and still passed, because interpreter startup jitter is far wider
+than the window it was supposed to expose. It could not tell the fixed code from
+the bug, so it is not in this file. The atomicity of O_EXCL is a property of the
+syscall; what these tests own is the decision table around it.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW_MS = int(1786584800 * 1000)
+
+
+def _common():
+    from clawock_kcnyu.harness import _watchdog_common
+    return _watchdog_common
+
+
+def _dead_pid():
+    """A pid that has been reaped, so it is genuinely gone."""
+    p = subprocess.Popen([sys.executable, '-c', 'pass'])
+    p.wait()
+    return p.pid
+
+
+# ── A. the duplicate the bug actually produced ──────────────────────────────
+
+def test_first_caller_wins(tmp_path):
+    won, reason = _common().claim_send(tmp_path / 'hk-open.claim', now_ms=NOW_MS)
+    assert won is True
+    assert reason == 'claimed'
+
+
+def test_second_caller_while_holder_is_alive_does_not_send(tmp_path):
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    assert c.claim_send(claim, now_ms=NOW_MS)[0] is True
+    # Same live process holds it — this is the 09:33:22 postflight still running
+    # when the model fired the 09:34:26 one.
+    won, reason = c.claim_send(claim, now_ms=NOW_MS + 64_000)
+    assert won is False
+    assert reason == 'in-flight'
+
+
+def test_holder_killed_mid_send_does_not_get_a_second_send(tmp_path):
+    """The exact 08-13 shape: SIGTERM landed after WeChat, before the marker."""
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    claim.write_text(json.dumps({
+        'pid': _dead_pid(),
+        'ts': NOW_MS,
+        'send_started_at': NOW_MS + 31_000,
+    }))
+
+    won, reason = c.claim_send(claim, now_ms=NOW_MS + 64_000)
+
+    assert won is False, 'a killed sender may already have reached WeChat'
+    assert reason == 'holder-died-mid-send'
+
+
+# ── B. the claim must not become a new silent-miss path ─────────────────────
+
+def test_holder_that_died_before_sending_is_taken_over(tmp_path):
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    claim.write_text(json.dumps({'pid': _dead_pid(), 'ts': NOW_MS, 'send_started_at': None}))
+
+    won, reason = c.claim_send(claim, now_ms=NOW_MS + 64_000)
+
+    assert won is True, 'nothing was sent, so the slot still needs a send'
+    assert reason == 'took-over-claim-of-holder-that-never-sent'
+
+
+def test_stale_claim_cannot_mute_a_later_slot(tmp_path):
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    # Live pid, mid-send, but from 45 minutes ago: a crashed process whose pid
+    # got recycled must not own this slot forever.
+    claim.write_text(json.dumps({
+        'pid': 1, 'ts': NOW_MS, 'send_started_at': NOW_MS + 1_000,
+    }))
+
+    won, reason = c.claim_send(claim, now_ms=NOW_MS + 45 * 60 * 1000)
+
+    assert won is True
+    assert reason == 'took-over-stale-claim'
+
+
+def test_unreadable_claim_fails_open(tmp_path):
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    claim.write_text('{not json')
+
+    won, reason = c.claim_send(claim, now_ms=NOW_MS)
+
+    assert won is True, 'broken plumbing must never be why kcn got no report'
+    assert reason.startswith('claim-unreadable-fail-open')
+
+
+def test_uncreatable_claim_fails_open(tmp_path):
+    c = _common()
+    won, reason = c.claim_send(tmp_path / 'no-such-dir' / 'hk-open.claim', now_ms=NOW_MS)
+
+    assert won is True
+    assert reason.startswith('claim-unavailable-fail-open')
+
+
+# ── the state transition the two halves hinge on ────────────────────────────
+
+def test_report_deliver_flips_the_claim_before_it_sends(tmp_path, monkeypatch):
+    """The ordering IS the fix. `mark_send_started` after the send would leave the
+    same window the marker already leaves, and every unit test above would still
+    pass — so the order is pinned against the real deliver path."""
+    from clawock_kcnyu.harness import report_postflight as rp
+    c = _common()
+
+    claim = tmp_path / 'hk-open.claim'
+    c.claim_send(claim, now_ms=NOW_MS)
+    seen = {}
+
+    def _fake_send(channel, to, account, message, dry_run):
+        seen['claim_at_send'] = json.loads(claim.read_text())
+        return True, 'openclaw-weixin:stub'
+
+    monkeypatch.setattr(rp, 'TMP', tmp_path)
+    monkeypatch.setattr(rp, 'resolve_wechat_target', lambda market: ('ch', 'to', 'acct'))
+    monkeypatch.setattr(rp, 'send_wechat', _fake_send)
+    monkeypatch.setattr(rp, 'cosend_telegram', lambda message, tag: (True, ''))
+
+    sent_ok, _ = rp.deliver_wechat('hk', 'open', '2026-08-13', '', 'body', claim_path=claim)
+
+    assert sent_ok is True
+    assert seen['claim_at_send']['send_started_at'] is not None, (
+        'the claim must already read as mid-send while WeChat is being called; '
+        'otherwise a process killed here looks like it never sent'
+    )
+
+
+def test_mark_send_started_flips_a_claim_to_mid_send(tmp_path):
+    c = _common()
+    claim = tmp_path / 'hk-open.claim'
+    c.claim_send(claim, now_ms=NOW_MS)
+    assert json.loads(claim.read_text())['send_started_at'] is None
+
+    c.mark_send_started(claim)
+
+    held = json.loads(claim.read_text())
+    assert isinstance(held['send_started_at'], int)
+    assert held['pid'] == json.loads(claim.read_text())['pid']


### PR DESCRIPTION
Closes #508.

## 问题

幂等闸 `already_delivered()` 读的是 send marker，而 marker 在 **WeChat 和 Telegram cosend 都返回之后**才写 —— 实测每个 postflight 从起跑到 marker 落地约 54 秒。窗口内并发的第二个 postflight 一律读到「今天没投递过」，照发。

08-13 09:30 hk-open 的实况：exec 的 overall-timeout 只杀了命令外壳、没杀 postflight 子进程，模型把 SIGTERM 读成失败又跑了一遍，两个进程都过闸。**微信两条、Telegram 一条** —— 第一个进程死在两次发送之间，这个不对称正好证明它已经发过微信。

## 改动

`claim_send()` 把发送权在**第一次发送之前**拿到，O_EXCL 就是锁本身。决策表：

| claim 状态 | 结果 | 理由 |
|---|---|---|
| 不存在 | 发 | 本 slot 第一个 |
| 持有者进程还活着 | 不发 | 正在发，就是这次事故的形状 |
| 持有者已死、**没开始发** | 夺取并发 | 什么都没发出去，这个 slot 仍然需要一次投递 |
| 持有者已死、**已开始发** | 不发 | 无法知道微信收没收到；重复是 kcn 实际报告的故障 |
| claim 读不了 / 建不了 | **照发**（fail-open） | 重复可挽回，静默不发不可挽回 |

`mark_send_started()` 在调 `send_wechat` **之前**翻转状态 —— 顺序就是修复本身，所以单独有测试钉住。

不发的那条路不会吃掉漏发：**没有 marker 就不会写 marker**，watchdog 照常把这个 slot 判成未投递并兜底 Telegram（`feedback-detect-but-never-silence`）。

三个 postflight（report / intraday / brief）是同一个形状，所以三个都接了。只修 report 这一条正是这类缺陷反复复发的机制本身。

## 一个被抓到的回归

`test_a_failed_slot_can_be_superseded_once_then_locks` 红了：fail-closed 发完数据块后留下的 claim，会把随后那次**被明确允许的** upgrade 判成「有人正在发」而拦掉。修法是 upgrade 分支不走 send claim —— `claim_upgrade` 本来就是 O_EXCL 一次性的，不需要在上面再叠一把锁。

## 验证

- `tests/test_postflight_send_claim.py`（新增 9 条）：两个方向的不变量各自成对——「并发/死于发送中 ⇒ 不重发」与「死于发送前/claim 陈旧/plumbing 坏 ⇒ 照发」
- 变异验证：删掉 `holder-died-mid-send` 分支 → 对应用例红；删掉 `in-flight` 判断 → 对应用例红；把 `mark_send_started` 挪到发送之后 → 顺序用例红
- 本地全量 1935 passed。剩下的 5 failed / 27 errors 在**干净 `origin/master` 的 worktree 上逐条复现**（缺 dashboard 生成产物），与本 PR 无关
- 有意**没写**「8 个真进程抢同一个 claim」那种测试：写了，然后拿 read-then-write 版本变异验证 —— 照样通过，因为解释器启动抖动远大于它要暴露的窗口。它区分不了修好的代码和这个 bug，所以没留下（理由写在测试文件头）

## 不在本 PR 里

9 条 live cron payload 里也复制了 Step 3/4 的说明文本，SIGTERM 那句提示同步过去要走 `openclaw cron edit`（payload 不在 git 里）。代码闸不依赖它 —— 那只是省掉一次白跑。
