### PR TITLE
harness: read the fallback outcome from the run the dispatch named (#512)

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -18,6 +18,7 @@ session transcript. transcript_loop_score detects that directly and cleanly
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -382,24 +383,45 @@ def _parse_iso(value):
 
 
 def _gh_json(args, timeout=60):
-    """Run a `gh` command expecting JSON on stdout. Returns parsed JSON or None."""
+    """Run a `gh` command expecting JSON on stdout. Returns (parsed, error).
+
+    `error` is None only on success. Keeping it separate matters here: a lookup
+    that FAILED and a lookup that found nothing used to collapse into the same
+    `None`, so a broken `gh` reported itself as "no run found" — the same shape
+    of lie this function's only consumer exists to stop telling.
+    """
     try:
         r = subprocess.run(['gh'] + args, capture_output=True, text=True,
                            timeout=timeout, cwd=str(WS))
-    except Exception:
-        return None
+    except Exception as e:
+        return None, f'gh {args[0]} failed: {str(e)[:120]}'
     if r.returncode != 0:
-        return None
+        return None, f'gh {args[0]} exited {r.returncode}: {(r.stderr or "").strip()[:120]}'
     try:
-        return json.loads(r.stdout)
-    except Exception:
-        return None
+        return json.loads(r.stdout), None
+    except Exception as e:
+        return None, f'gh {args[0]} returned unparseable JSON: {str(e)[:120]}'
+
+
+_RUN_URL_RE = re.compile(r'/actions/runs/(\d+)')
+
+
+def run_id_from_dispatch_out(dispatch_out):
+    """The run id `gh workflow run` already printed, or None.
+
+    `dispatch_brief_fallback` returns the run's URL. Reading the id out of it
+    beats re-discovering the run by timestamp, which is what #512 was: the
+    dispatch stamp carries microseconds, GitHub truncates `createdAt` to the
+    second, and the run we had just dispatched always sorted as "older than the
+    dispatch" and got discarded."""
+    m = _RUN_URL_RE.search(str(dispatch_out or ''))
+    return m.group(1) if m else None
 
 
 def await_brief_fallback_outcome(since_iso, dry_run=False,
                                  budget_s=BRIEF_FALLBACK_POLL_BUDGET_S,
                                  interval_s=BRIEF_FALLBACK_POLL_INTERVAL_S,
-                                 sleep=time.sleep, now=None):
+                                 sleep=time.sleep, now=None, dispatch_out=None):
     """Block until the dispatched brief-fallback run finishes. Returns (state, detail).
 
     state is one of 'success' | 'failure' | 'pending' | 'unknown'.
@@ -420,23 +442,42 @@ def await_brief_fallback_outcome(since_iso, dry_run=False,
         return 'pending', '(dry-run) outcome polling skipped'
 
     deadline = now().timestamp() + budget_s
+    # Preferred: the dispatch already told us WHICH run this is, so no time-window
+    # heuristic is needed at all (#512). It also removes the "two dispatches in the
+    # same minute" ambiguity the search path never handled.
+    run_id = run_id_from_dispatch_out(dispatch_out)
     # A dispatch we cannot date cannot be used to reject stale runs, so fall back to
     # "any run" rather than silently discarding every candidate.
     since = _parse_iso(since_iso)
+    if since is not None:
+        # GitHub reports createdAt truncated to the second while the dispatch stamp
+        # carries microseconds, and `gh workflow run` only returns once the run
+        # exists — so the run we just dispatched lands in the SAME second and used
+        # to compare as strictly older, discarding the only candidate that could
+        # ever match (#512: two consecutive days recorded 'unknown' for runs that
+        # had actually FAILED). Truncating our side too compares like with like.
+        since = since.replace(microsecond=0)
     run = None
+    lookup_error = None
     while True:
-        runs = _gh_json(['run', 'list', '--workflow', BRIEF_FALLBACK_WORKFLOW,
-                         '--event', 'workflow_dispatch', '--limit', '5',
-                         '--json', 'databaseId,status,conclusion,url,createdAt'])
-        if runs:
-            # Only consider runs created at/after our dispatch, so a stale earlier
-            # run can never be mistaken for this one's outcome. Compared as instants:
-            # the two sides arrive in different timezones (see _parse_iso).
-            dated = [(r, _parse_iso(r.get('createdAt'))) for r in runs]
-            fresh = [(r, t) for r, t in dated
-                     if t is not None and (since is None or t >= since)]
-            if fresh:
-                run = max(fresh, key=lambda rt: rt[1])[0]
+        if run_id:
+            run, lookup_error = _gh_json(
+                ['run', 'view', run_id,
+                 '--json', 'databaseId,status,conclusion,url,createdAt'])
+        else:
+            runs, lookup_error = _gh_json(
+                ['run', 'list', '--workflow', BRIEF_FALLBACK_WORKFLOW,
+                 '--event', 'workflow_dispatch', '--limit', '5',
+                 '--json', 'databaseId,status,conclusion,url,createdAt'])
+            if runs:
+                # Only consider runs created at/after our dispatch, so a stale earlier
+                # run can never be mistaken for this one's outcome. Compared as instants:
+                # the two sides arrive in different timezones (see _parse_iso).
+                dated = [(r, _parse_iso(r.get('createdAt'))) for r in runs]
+                fresh = [(r, t) for r, t in dated
+                         if t is not None and (since is None or t >= since)]
+                if fresh:
+                    run = max(fresh, key=lambda rt: rt[1])[0]
         if run and run.get('status') == 'completed':
             conclusion = run.get('conclusion') or 'unknown'
             url = run.get('url') or ''
@@ -447,7 +488,13 @@ def await_brief_fallback_outcome(since_iso, dry_run=False,
             if run:
                 return 'pending', (f'still {run.get("status") or "unknown"} after '
                                    f'{budget_s // 60}min: {run.get("url") or ""}')
-            return 'unknown', f'no workflow_dispatch run found within {budget_s // 60}min'
+            # "we could not look" and "there is nothing to find" are different
+            # facts, and the alert should not present the first as the second.
+            if lookup_error:
+                return 'unknown', (f'run lookup kept failing for '
+                                   f'{budget_s // 60}min: {lookup_error}')
+            scope = f'run {run_id}' if run_id else 'workflow_dispatch run'
+            return 'unknown', f'no {scope} found within {budget_s // 60}min'
         sleep(interval_s)
 
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -284,7 +284,7 @@ def alert_brief_missing(today, dry_run, issues=None):
     if dispatched:
         outcome, outcome_detail = await_brief_fallback_outcome(
             state.get('dispatch_attempted_at') or datetime.now(HKT).isoformat(),
-            dry_run)
+            dry_run, dispatch_out=state.get('dispatch_out'))
         state['fallback_outcome'] = outcome
         state['fallback_outcome_detail'] = outcome_detail
         if not dry_run:

--- a/tests/test_brief_fallback_outcome.py
+++ b/tests/test_brief_fallback_outcome.py
@@ -275,8 +275,10 @@ def test_run_id_is_read_out_of_the_dispatch_output():
 def test_a_failing_lookup_is_not_reported_as_no_run_found(monkeypatch):
     """"we could not look" and "there is nothing to find" are different facts.
     Collapsing them is how a dead recovery path reads as a quiet one."""
+    # No hostname in the fixture: CodeQL reads `"host" in text` as an attempted
+    # (and incomplete) URL check, even in an assertion about an error string.
     monkeypatch.setattr(common, "_gh_json", lambda args, timeout=60: (
-        None, "gh run exited 1: could not connect to api.github.com"))
+        None, "gh run exited 1: could not reach the API endpoint"))
     clock = _Aug13Clock()
 
     state, detail = common.await_brief_fallback_outcome(
@@ -285,4 +287,6 @@ def test_a_failing_lookup_is_not_reported_as_no_run_found(monkeypatch):
 
     assert state == "unknown"
     assert "lookup kept failing" in detail
-    assert "api.github.com" in detail
+    assert "could not reach the API endpoint" in detail, (
+        "the reason gh failed must survive into what kcn is told"
+    )

--- a/tests/test_brief_fallback_outcome.py
+++ b/tests/test_brief_fallback_outcome.py
@@ -3,6 +3,17 @@
 The 2026-08-11 outage was not a missing check — it was a check that reported the
 dispatch call's exit status and called that recovery. Every test here pins the
 direction of the failure: when in doubt, not success.
+
+#512 then found that the check had never once reported a real outcome anyway:
+`since` carried microseconds (datetime.now) while GitHub truncates `createdAt`
+to the second, and `gh workflow run` only returns once the run exists — so the
+run we had just dispatched landed in the SAME second and always compared as
+strictly older than the dispatch that created it. Two consecutive days recorded
+`unknown` for runs that had actually FAILED.
+
+That is the second defect of this family. The first was timezone-shaped (HKT vs
+Z), and its tests are below. Both stay pinned: a fix for either that reopens the
+other is not a fix.
 """
 from datetime import datetime, timedelta, timezone
 
@@ -29,14 +40,17 @@ class FakeClock:
 
 
 def _fake_gh(monkeypatch, pages):
-    """Serve one `gh run list` JSON payload per poll, in order."""
+    """Serve one `gh run list` JSON payload per poll, in order.
+
+    `_gh_json` returns (data, error) since #512, so that a lookup which FAILED
+    stops being indistinguishable from one that found nothing."""
     calls = {"n": 0}
 
     def gh_json(args, timeout=60):
         assert args[:2] == ["run", "list"]
         page = pages[min(calls["n"], len(pages) - 1)]
         calls["n"] += 1
-        return page
+        return (page, None) if page is not None else (None, "gh run exited 1")
 
     monkeypatch.setattr(common, "_gh_json", gh_json)
     return calls
@@ -186,3 +200,89 @@ def test_an_undated_run_is_never_adopted(monkeypatch):
         HKT_DISPATCH, budget_s=60, interval_s=30, sleep=clock.sleep, now=clock.now)
 
     assert state == "unknown"
+
+
+# ── #512: the dispatch second, and the run the dispatch already named ────────
+
+# The real 2026-08-13 pair. The run is stamped 0.402503s BEFORE the dispatch that
+# created it, purely because GitHub truncates createdAt to the second.
+SAME_SECOND_DISPATCH = "2026-08-13T09:05:05.402503+08:00"
+SAME_SECOND_CREATED = "2026-08-13T01:05:05Z"
+RUN_URL = "https://github.com/KCNyu/clawock/actions/runs/31656565034"
+
+
+class _Aug13Clock(FakeClock):
+    def __init__(self):
+        super().__init__()
+        self._t = datetime(2026, 8, 13, 9, 5, tzinfo=HKT)
+
+
+def test_a_run_created_within_the_dispatch_second_is_not_discarded(monkeypatch):
+    """The whole of #512: sub-second `since` vs whole-second `createdAt`.
+
+    Both real occurrences were recorded as `unknown` while the run had FAILED —
+    the run existed, the URL was in hand, and the window threw it away."""
+    _fake_gh(monkeypatch, [[{
+        "databaseId": 31656565034, "status": "completed", "conclusion": "failure",
+        "url": RUN_URL, "createdAt": SAME_SECOND_CREATED,
+    }]])
+    monkeypatch.setattr(common, "_gh_run_failure_detail", lambda _run, **_kw: "boom")
+    clock = _Aug13Clock()
+
+    state, detail = common.await_brief_fallback_outcome(
+        SAME_SECOND_DISPATCH, budget_s=60, interval_s=30,
+        sleep=clock.sleep, now=clock.now)
+
+    assert state == "failure", (
+        "a createdAt truncated into the dispatch's own second is this run, "
+        "not a stale one"
+    )
+    assert RUN_URL in detail
+
+
+def test_the_dispatched_run_is_read_by_id_when_the_url_is_known(monkeypatch):
+    """Better than any window: the dispatch already said which run this is."""
+    seen = {}
+
+    def gh_json(args, timeout=60):
+        seen["args"] = args
+        return {"databaseId": 31656565034, "status": "completed",
+                "conclusion": "failure", "url": RUN_URL,
+                "createdAt": SAME_SECOND_CREATED}, None
+
+    monkeypatch.setattr(common, "_gh_json", gh_json)
+    monkeypatch.setattr(common, "_gh_run_failure_detail", lambda _run, **_kw: "boom")
+    clock = _Aug13Clock()
+
+    state, _detail = common.await_brief_fallback_outcome(
+        SAME_SECOND_DISPATCH, budget_s=60, interval_s=30,
+        sleep=clock.sleep, now=clock.now, dispatch_out=RUN_URL + "\n")
+
+    assert state == "failure"
+    assert seen["args"][:3] == ["run", "view", "31656565034"], (
+        "with the run id in hand the outcome must be read from that run rather "
+        "than rediscovered by timestamp"
+    )
+
+
+def test_run_id_is_read_out_of_the_dispatch_output():
+    assert common.run_id_from_dispatch_out(RUN_URL + "\n") == "31656565034"
+    assert common.run_id_from_dispatch_out(
+        "(prior dispatch attempt; outcome unavailable)") is None
+    assert common.run_id_from_dispatch_out(None) is None
+
+
+def test_a_failing_lookup_is_not_reported_as_no_run_found(monkeypatch):
+    """"we could not look" and "there is nothing to find" are different facts.
+    Collapsing them is how a dead recovery path reads as a quiet one."""
+    monkeypatch.setattr(common, "_gh_json", lambda args, timeout=60: (
+        None, "gh run exited 1: could not connect to api.github.com"))
+    clock = _Aug13Clock()
+
+    state, detail = common.await_brief_fallback_outcome(
+        SAME_SECOND_DISPATCH, budget_s=60, interval_s=30,
+        sleep=clock.sleep, now=clock.now, dispatch_out=RUN_URL + "\n")
+
+    assert state == "unknown"
+    assert "lookup kept failing" in detail
+    assert "api.github.com" in detail

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -17,7 +17,7 @@ def _stub_outcome(monkeypatch, outcome="success", detail="https://example/run/1"
     Without this the alert path would shell out to `gh` from the test suite."""
     monkeypatch.setattr(
         watchdog, "await_brief_fallback_outcome",
-        lambda _since, _dry_run: (outcome, detail),
+        lambda _since, _dry_run, **_kw: (outcome, detail),
     )
 
 
@@ -208,6 +208,33 @@ def _run_alert_capturing_messages(monkeypatch, tmp_path, outcome, detail):
     _stub_outcome(monkeypatch, outcome, detail)
     assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
     return messages
+
+
+def test_the_dispatched_run_url_is_handed_to_the_outcome_poll(tmp_path, monkeypatch):
+    """#512's fix is only real if the wiring carries it.
+
+    `await_brief_fallback_outcome` can read the outcome straight from the run the
+    dispatch named, but only if this caller passes that URL down. The stub in
+    `_stub_outcome` accepts any kwargs, so nothing else in this file would notice
+    the argument being dropped — and a dropped argument silently returns the whole
+    path to the timestamp heuristic that #512 is about.
+    """
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    run_url = "https://github.com/KCNyu/clawock/actions/runs/31656565034\n"
+    seen = {}
+    monkeypatch.setattr(
+        watchdog, "dispatch_brief_fallback", lambda _dry_run: (True, run_url)
+    )
+    monkeypatch.setattr(watchdog, "send_telegram", lambda *_args: (True, "ok"))
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    monkeypatch.setattr(
+        watchdog, "await_brief_fallback_outcome",
+        lambda _since, _dry_run, **kw: (seen.update(kw), ("success", run_url))[1],
+    )
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert seen.get("dispatch_out") == run_url
 
 
 def test_a_failed_fallback_run_is_reported_as_failed_not_as_dispatched_ok(


### PR DESCRIPTION
Closes #512.

## 问题

`await_brief_fallback_outcome` 用 `t >= since` 挑候选 run：

- `since` = dispatch 时间戳，`datetime.now(HKT).isoformat()`，**带微秒**
- `t` = GitHub 的 `createdAt`，**截断到整秒**

`gh workflow run` 要等 run 建好才返回，所以 run 必然落在 dispatch 的**同一秒**里，整秒截断一减就永远「早于 dispatch」，唯一可能匹配的候选每一轮都被丢掉，直到 15 分钟预算耗尽 → `unknown`。

| 日期 | dispatch_attempted_at（UTC） | run createdAt | `t >= since` | 记录 | 真实 |
|---|---|---|---|---|---|
| 08-12 | `01:05:03.959414Z` | `01:05:03Z` | False | unknown | **failure** |
| 08-13 | `01:05:05.402503Z` | `01:05:05Z` | False | unknown | **failure** |

⇒ 这个函数自 PR #481 上线以来**在生产里一次都没报出过真实结论**，而它盖住的两次都是 failure。#481 要修的正是「把 dispatch 被接受渲染成绿勾」，结果换成了一个恒定的 `unknown`。

这是同族**第二个**缺陷：第一个是时区形状的（HKT `+08:00` vs UTC `Z` 按字符串比），已修，`_parse_iso` 的 docstring 还留着警告。

## 改动

1. **主路径不再猜**：`dispatch_brief_fallback` 本来就返回 run 的 URL，从里面抠 run id，直接 `gh run view <id>`。时间窗启发式整个不参与，「同一分钟两次 dispatch」的歧义也一起没了。
2. **回退路径**（dispatch 没打出 URL）仍走搜索，但两边都截断到整秒再比。
3. `_gh_json` 拆开「查询失败」与「查不到」：原来都返回 `None`，于是 gh 本身挂掉会自称「没有 run」——正是这个函数存在的目的所要制止的那类谎报。

## 验证

- `tests/test_brief_fallback_outcome.py`：原有 10 条**全部保留**（适配 `_gh_json` 新的 `(data, error)` 返回），新增 4 条盯 #512。两个缺口——时区版与亚秒版——现在各自有测试，改一个不能放开另一个
- 变异验证：去掉 `since` 截断 / 忽略 `dispatch_out` / 合并 lookup 失败与空结果，三处各自转红
- **接线单独有测试**：`test_brief_watchdog.py` 里的 stub 接受任意 kwargs，所以调用点漏传 `dispatch_out` 不会被那边任何一条测试发现，而漏传就等于整条路径退回到出问题的时间窗启发式。补了一条专门盯这个，去掉调用点的参数即转红

## 说明

那个 run（`31656565034`）本身失败的原因是 `plan.json v2 validation failed: decisions must be a non-empty list`（`stop=end_turn`，不是预算腰斩，是正文没产出合法 decisions block）。**那是另一件事，不在本 PR 范围** —— 本 PR 只让真实结论能被报出来。
