### PR TITLE
brief watchdog: 把耗尽的重试预算写进 09:05 告警 (#506)

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -331,6 +331,16 @@ def rerun_cron_job(job_id, dry_run=False):
     return _openclaw.run_cron_job(job_id)
 
 
+def cron_retry_budget(job):
+    """Has this job run out of runtime retries? See providers.openclaw."""
+    return _openclaw.cron_retry_budget(job)
+
+
+# Raising `cron.retry.maxAttempts` past this is rejected by the runtime's config
+# schema, so it bounds what the operator can do about an exhausted budget.
+CRON_MAX_ALLOWED_ATTEMPTS = _openclaw.RUNTIME_MAX_ALLOWED_ATTEMPTS
+
+
 def dispatch_brief_fallback(dry_run=False):
     """Fire .github/workflows/brief-fallback.yml on demand. Returns (ok, tail_of_output).
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -273,21 +273,24 @@ FAILED_RUN_STATUSES = {'error', 'failed', 'failure', 'timeout', 'timed_out',
                        'cancelled', 'canceled'}
 
 
-def brief_cron_job():
-    """The live cron job for the daily deep brief, or None if it cannot be read.
+def _brief_job_names():
+    """Names the contract gives the daily deep brief, or an empty set.
 
-    Identified through `config/cron-schedules.json` — the contract already names
-    exactly one `daily-deep-brief` job — rather than by a string typed here, so
-    renaming the job in the contract cannot leave a watchdog looking for a job
-    that no longer exists.
+    The contract already names exactly one `daily-deep-brief` job, so renaming
+    it there cannot leave a watchdog looking for a job that no longer exists.
     """
     try:
         from clawock_kcnyu.schedule import load_contract
 
-        names = {job.get('name') for job in load_contract().get('jobs', [])
-                 if job.get('mode') == BRIEF_CONTRACT_MODE}
+        return {job.get('name') for job in load_contract().get('jobs', [])
+                if job.get('mode') == BRIEF_CONTRACT_MODE}
     except Exception:
-        return None
+        return set()
+
+
+def brief_cron_job():
+    """The live cron job for the daily deep brief, or None if it cannot be read."""
+    names = _brief_job_names()
     if not names:
         return None
     listing = _cron_cli_json(['list', '--json'])
@@ -295,6 +298,25 @@ def brief_cron_job():
         return None
     for job in listing.get('jobs') or []:
         if job.get('name') in names:
+            return job
+    return None
+
+
+def brief_cron_job_state():
+    """Same job, read straight from the runtime's state DB instead of the CLI.
+
+    The CLI round-trips through the gateway, which on a bad morning is a
+    component that may be hung — and its 120s subprocess timeout would then be
+    120s of a caller holding still. SQLite is a local read-only file open with
+    its own 5s timeout, it is authoritative for exactly the runtime state this
+    is wanted for (`consecutiveErrors`), and it answers whether or not the
+    gateway is alive.
+    """
+    names = _brief_job_names()
+    if not names:
+        return None
+    for job in _openclaw.read_jobs('sqlite').entries:
+        if isinstance(job, dict) and job.get('name') in names:
             return job
     return None
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -218,11 +218,20 @@ def retry_budget_note():
     Silent unless the budget is *provably* exhausted: an unreadable job or a
     healthy budget both leave the alert exactly as it was, because a miss has
     other causes and a guess here would send kcn after the wrong one.
+
+    Reading the budget means a `cron list` round trip through the gateway, which
+    is exactly the component a bad morning may have taken down. Nothing it can
+    do may cost the alert: an exception here would swallow the one notification
+    that reaches a human. It also runs after the off-host dispatch, so a slow
+    gateway cannot push that past brief-fallback.yml's 10:00 HKT cutoff.
     """
-    job = brief_cron_job()
-    if not isinstance(job, dict):
+    try:
+        job = brief_cron_job()
+        if not isinstance(job, dict):
+            return ''
+        budget = cron_retry_budget(job)
+    except Exception:
         return ''
-    budget = cron_retry_budget(job)
     if not budget.exhausted:
         return ''
     remedy = (

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -144,14 +144,20 @@ def retrigger_or_wait(today, dry_run):
     if ok and not dry_run:
         flag.parent.mkdir(parents=True, exist_ok=True)
         flag.write_text(datetime.now(HKT).isoformat())
+    # The re-run fires on the run being over, not on the budget — but what the
+    # log may *claim* about the budget is only what was read. The old wording
+    # asserted "the runtime will not retry it" unconditionally, which was the
+    # 08-13 case and not the general one: a job whose budget is intact will be
+    # retried by the scheduler, and one whose state is unreadable is not
+    # evidence of either (#506).
+    verdict = ('exhausted — this re-run is one more single attempt'
+               if budget.exhausted else
+               'intact — the scheduler may also retry on its own'
+               if budget.exhausted is False else
+               'unknown — job state unreadable')
     log({'tag': tag, 'action': 'rerun-onhost', 'dry_run': dry_run, 'queued_ok': ok,
          'job_id': job.get('id'), 'job_name': job.get('name'),
-         'reason': 'the 08:00 run already ended in error; the runtime will not '
-                   'retry it (consecutiveErrors past its budget)',
-         # This re-run is one more single attempt: it inherits the same exhausted
-         # budget, so it dies to the same first-call timeout the runtime retries
-         # away for every other job. Recording the numbers here is what lets the
-         # 09:05 pass say so instead of blaming the provider again (#506).
+         'reason': f'the 08:00 run already ended in error; retry budget {verdict}',
          'retry_budget': budget.describe(), 'retry_budget_exhausted': budget.exhausted,
          'out': out})
     return 0
@@ -236,10 +242,11 @@ def retry_budget_note():
     if not budget.exhausted:
         return ''
     remedy = (
-        # `>` is the scheduler's rule, so the cap has to *reach* the counter,
-        # not pass it. Saying "raise past 10" would name 11, which the runtime's
-        # schema rejects — advice that cannot be carried out.
-        f'把 openclaw.json 的 cron.retry.maxAttempts 设为 ≥ {budget.consecutive_errors}'
+        # The scheduler increments the counter before comparing, so the next
+        # failure is judged at counter + 1 and a cap equal to the stored counter
+        # buys nothing. `cap_needed` is that arithmetic; naming the value keeps
+        # the advice from being one short.
+        f'把 openclaw.json 的 cron.retry.maxAttempts 设为 ≥ {budget.cap_needed}'
         if budget.raisable else
         f'配置上限只到 {CRON_MAX_ALLOWED_ATTEMPTS}，抬 maxAttempts 已经救不回来 —— '
         f'只能重置计数（停 gateway → state/openclaw.sqlite 的 cron_jobs '

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -57,7 +57,8 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, build_brief_card, send_telegram, KCN_TELEGRAM,
     dispatch_brief_fallback, await_brief_fallback_outcome,
-    brief_cron_job, cron_run_ended_in_failure, rerun_cron_job,
+    brief_cron_job, cron_run_ended_in_failure, rerun_cron_job, cron_retry_budget,
+    CRON_MAX_ALLOWED_ATTEMPTS,
 )
 
 MARKER_FRESH_MS = 30 * 60 * 1000  # postflight send-marker older than this ⇒ not this slot
@@ -137,6 +138,7 @@ def retrigger_or_wait(today, dry_run):
              'reason': 'on-host re-run already fired today (dedupe flag present)'})
         return 0
 
+    budget = cron_retry_budget(job)
     ok, out = rerun_cron_job(job.get('id'), dry_run)
     if ok and not dry_run:
         flag.parent.mkdir(parents=True, exist_ok=True)
@@ -145,6 +147,11 @@ def retrigger_or_wait(today, dry_run):
          'job_id': job.get('id'), 'job_name': job.get('name'),
          'reason': 'the 08:00 run already ended in error; the runtime will not '
                    'retry it (consecutiveErrors past its budget)',
+         # This re-run is one more single attempt: it inherits the same exhausted
+         # budget, so it dies to the same first-call timeout the runtime retries
+         # away for every other job. Recording the numbers here is what lets the
+         # 09:05 pass say so instead of blaming the provider again (#506).
+         'retry_budget': budget.describe(), 'retry_budget_exhausted': budget.exhausted,
          'out': out})
     return 0
 
@@ -196,6 +203,40 @@ def write_missing_state(today, state):
     tmp.replace(path)
 
 
+def retry_budget_note():
+    """Name an exhausted retry budget in the 09:05 alert, or say nothing.
+
+    Every automatic recovery this watchdog owns is one more single attempt, and
+    an exhausted budget is what makes single attempts lose: the runtime stops
+    retrying at `consecutiveErrors > cron.retry.maxAttempts`, and that counter
+    only clears on a success the job cannot reach while it is failing. On
+    2026-08-13 that state was three days old and invisible — the alert pointed
+    at `sar -q` and the provider, both of which were healthy (#506). Only a
+    counter reset gets the job out, and nothing on the box does it by itself, so
+    this line is addressed to the one reader who can.
+
+    Silent unless the budget is *provably* exhausted: an unreadable job or a
+    healthy budget both leave the alert exactly as it was, because a miss has
+    other causes and a guess here would send kcn after the wrong one.
+    """
+    job = brief_cron_job()
+    if not isinstance(job, dict):
+        return ''
+    budget = cron_retry_budget(job)
+    if not budget.exhausted:
+        return ''
+    remedy = (
+        f'把 openclaw.json 的 cron.retry.maxAttempts 抬过 {budget.consecutive_errors}'
+        if budget.raisable else
+        f'配置上限只到 {CRON_MAX_ALLOWED_ATTEMPTS}，抬 maxAttempts 已经救不回来 —— '
+        f'只能重置计数（停 gateway → state/openclaw.sqlite 的 cron_jobs '
+        f'consecutive_errors 与 state_json 一起归零 → 起 gateway）'
+    )
+    return (f'⛔ 这个 job 的 runtime 重试预算已耗尽：{budget.describe()}\n'
+            f'    ⇒ 它每天只有一次机会、失败即止；别的 job 撞同一堵墙靠重试活下来。\n'
+            f'    ⇒ {remedy}\n\n')
+
+
 def alert_brief_missing(today, dry_run, issues=None):
     """09:05 HKT: landing artifacts are incomplete ⇒ page kcn + self-heal.
 
@@ -244,6 +285,7 @@ def alert_brief_missing(today, dry_run, issues=None):
     alert = (
         f'🔴 盘前深度简报产物不完整 — {today}\n\n'
         f'09:05 检查结果：\n{issue_text}\n\n'
+        + retry_budget_note()
         + ('🔄 已 dispatch off-host 兜底 (brief-fallback.yml)，正在等待运行结果，稍后另发一条。\n'
            if dispatched else
            '⚠️ 自动 dispatch 兜底失败，需要手动：gh workflow run brief-fallback.yml\n'

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -57,7 +57,8 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, build_brief_card, send_telegram, KCN_TELEGRAM,
     dispatch_brief_fallback, await_brief_fallback_outcome,
-    brief_cron_job, cron_run_ended_in_failure, rerun_cron_job, cron_retry_budget,
+    brief_cron_job, brief_cron_job_state, cron_run_ended_in_failure,
+    rerun_cron_job, cron_retry_budget,
     CRON_MAX_ALLOWED_ATTEMPTS,
 )
 
@@ -226,7 +227,7 @@ def retry_budget_note():
     gateway cannot push that past brief-fallback.yml's 10:00 HKT cutoff.
     """
     try:
-        job = brief_cron_job()
+        job = brief_cron_job_state()
         if not isinstance(job, dict):
             return ''
         budget = cron_retry_budget(job)
@@ -235,14 +236,20 @@ def retry_budget_note():
     if not budget.exhausted:
         return ''
     remedy = (
-        f'把 openclaw.json 的 cron.retry.maxAttempts 抬过 {budget.consecutive_errors}'
+        # `>` is the scheduler's rule, so the cap has to *reach* the counter,
+        # not pass it. Saying "raise past 10" would name 11, which the runtime's
+        # schema rejects — advice that cannot be carried out.
+        f'把 openclaw.json 的 cron.retry.maxAttempts 设为 ≥ {budget.consecutive_errors}'
         if budget.raisable else
         f'配置上限只到 {CRON_MAX_ALLOWED_ATTEMPTS}，抬 maxAttempts 已经救不回来 —— '
         f'只能重置计数（停 gateway → state/openclaw.sqlite 的 cron_jobs '
         f'consecutive_errors 与 state_json 一起归零 → 起 gateway）'
     )
+    # Only the two things this reading proves: the numbers, and that the
+    # scheduler will not retry at them. Why today's run failed, and whether
+    # anything else failed with it, are not visible from here.
     return (f'⛔ 这个 job 的 runtime 重试预算已耗尽：{budget.describe()}\n'
-            f'    ⇒ 它每天只有一次机会、失败即止；别的 job 撞同一堵墙靠重试活下来。\n'
+            f'    ⇒ 调度器不会再自动重试它；每次 run 只剩一次尝试。\n'
             f'    ⇒ {remedy}\n\n')
 
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_watchdog.py
@@ -154,7 +154,9 @@ def retrigger_or_wait(today, dry_run):
                if budget.exhausted else
                'intact — the scheduler may also retry on its own'
                if budget.exhausted is False else
-               'unknown — job state unreadable')
+               # Either side of the comparison can be the missing one; naming
+               # only the job would send a reader to the wrong file.
+               'unknown — counter or cap unreadable')
     log({'tag': tag, 'action': 'rerun-onhost', 'dry_run': dry_run, 'queued_ok': ok,
          'job_id': job.get('id'), 'job_name': job.get('name'),
          'reason': f'the 08:00 run already ended in error; retry budget {verdict}',

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -263,6 +263,71 @@ def run_cron_job(job_id, *, binary: str | None = None,
         return False, f"{type(exc).__name__}: {exc}"[:300]
 
 
+# The runtime's own default when `cron.retry.maxAttempts` is unset
+# (DEFAULT_MAX_TRANSIENT_RETRIES in the scheduler bundle).
+RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES = 3
+# The runtime's config schema rejects a larger value, so a job already past this
+# many consecutive failures cannot be rescued by raising the cap at all.
+RUNTIME_MAX_ALLOWED_ATTEMPTS = 10
+
+
+@dataclass(frozen=True)
+class CronRetryBudget:
+    """Whether the runtime will still retry a job after a transient error.
+
+    The scheduler's rule is `consecutiveErrors > cron.retry.maxAttempts ⇒ no
+    retry`, and `consecutiveErrors` counts *runs*, not attempts within a run: it
+    only resets on a success. For a once-a-day job that makes the budget a
+    countdown of bad days, and once it runs out the job is in a ring — it needs
+    a retry to succeed, and a success to get its retry back. Nothing in the
+    runtime reports that state, which is why 2026-08-13's brief died looking
+    exactly like a provider timeout (#506).
+
+    `exhausted` is None when the job state cannot be read; absence of evidence is
+    not evidence of a healthy budget, and callers must not report either way.
+    """
+
+    consecutive_errors: int | None
+    max_attempts: int
+    exhausted: bool | None
+
+    @property
+    def raisable(self) -> bool:
+        """Can raising the configured cap alone restore this job's retries?"""
+        return (self.consecutive_errors is not None
+                and self.consecutive_errors <= RUNTIME_MAX_ALLOWED_ATTEMPTS)
+
+    def describe(self) -> str:
+        if self.exhausted is None:
+            return "retry budget unknown (job state unreadable)"
+        return (f"consecutiveErrors={self.consecutive_errors} "
+                f"{'>' if self.exhausted else '<='} maxAttempts={self.max_attempts}")
+
+
+def cron_max_attempts(*, paths: OpenClawPaths | None = None) -> int:
+    """`cron.retry.maxAttempts` from the live runtime config, or its default."""
+    config_file = (paths or runtime_paths()).config_file
+    try:
+        config = json.loads(config_file.read_text())
+        value = ((config.get("cron") or {}).get("retry") or {}).get("maxAttempts")
+    except Exception:
+        return RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
+    return value
+
+
+def cron_retry_budget(job, *, paths: OpenClawPaths | None = None,
+                      max_attempts: int | None = None) -> CronRetryBudget:
+    """Read one job's remaining transient-retry budget from its live state."""
+    cap = cron_max_attempts(paths=paths) if max_attempts is None else max_attempts
+    state = job.get("state") if isinstance(job, dict) else None
+    errors = state.get("consecutiveErrors") if isinstance(state, dict) else None
+    if isinstance(errors, bool) or not isinstance(errors, int) or errors < 0:
+        return CronRetryBudget(None, cap, None)
+    return CronRetryBudget(errors, cap, errors > cap)
+
+
 # ── Cron state ───────────────────────────────────────────────────────────────
 # Moved verbatim from `_watchdog_common`, with one shape change: which source
 # answered is returned instead of being left in a module global. A watchdog that

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -283,48 +283,78 @@ class CronRetryBudget:
     runtime reports that state, which is why 2026-08-13's brief died looking
     exactly like a provider timeout (#506).
 
-    `exhausted` is None when the job state cannot be read; absence of evidence is
-    not evidence of a healthy budget, and callers must not report either way.
+    `exhausted` is None whenever either side of the comparison is unreadable —
+    the counter or the cap. Absence of evidence is not evidence of a healthy
+    budget, and it is not evidence of an exhausted one either: a caller that
+    fills in a plausible cap can accuse a job whose real cap is higher.
     """
 
     consecutive_errors: int | None
-    max_attempts: int
+    max_attempts: int | None
     exhausted: bool | None
 
     @property
     def raisable(self) -> bool:
-        """Can raising the configured cap alone restore this job's retries?"""
+        """Can raising the configured cap alone restore this job's retries?
+
+        The scheduler retries while `consecutiveErrors <= maxAttempts`, so the
+        cap has to reach the counter — not exceed it — and the runtime's schema
+        refuses to store more than RUNTIME_MAX_ALLOWED_ATTEMPTS.
+        """
         return (self.consecutive_errors is not None
                 and self.consecutive_errors <= RUNTIME_MAX_ALLOWED_ATTEMPTS)
 
     def describe(self) -> str:
         if self.exhausted is None:
-            return "retry budget unknown (job state unreadable)"
+            return "retry budget unknown (counter or cap unreadable)"
         return (f"consecutiveErrors={self.consecutive_errors} "
                 f"{'>' if self.exhausted else '<='} maxAttempts={self.max_attempts}")
 
 
-def cron_max_attempts(*, paths: OpenClawPaths | None = None) -> int:
-    """`cron.retry.maxAttempts` from the live runtime config, or its default."""
+def _valid_attempts(value) -> int | None:
+    """A usable `maxAttempts`, or None when the runtime could not be running it."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0 or value > RUNTIME_MAX_ALLOWED_ATTEMPTS:
+        # The runtime's config schema rejects these outright, so a file holding
+        # one is not the configuration the live scheduler loaded.
+        return None
+    return value
+
+
+def cron_max_attempts(*, paths: OpenClawPaths | None = None) -> int | None:
+    """`cron.retry.maxAttempts` from the live runtime config.
+
+    None means the config could not be read — a missing file, a permission
+    error, corrupt JSON, or a value the runtime would have refused to start on.
+    That is not the same as a config that parses and simply omits the field,
+    which is the documented case for the runtime's own default: a caller that
+    treats the two alike will compare a real counter against an invented cap.
+    """
     config_file = (paths or runtime_paths()).config_file
     try:
         config = json.loads(config_file.read_text())
-        value = ((config.get("cron") or {}).get("retry") or {}).get("maxAttempts")
+        retry = (config.get("cron") or {}).get("retry") or {}
     except Exception:
+        return None
+    if not isinstance(retry, dict):
+        return None
+    if "maxAttempts" not in retry:
         return RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        return RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
-    return value
+    return _valid_attempts(retry["maxAttempts"])
 
 
 def cron_retry_budget(job, *, paths: OpenClawPaths | None = None,
                       max_attempts: int | None = None) -> CronRetryBudget:
     """Read one job's remaining transient-retry budget from its live state."""
-    cap = cron_max_attempts(paths=paths) if max_attempts is None else max_attempts
+    cap = (cron_max_attempts(paths=paths) if max_attempts is None
+           else _valid_attempts(max_attempts))
     state = job.get("state") if isinstance(job, dict) else None
     errors = state.get("consecutiveErrors") if isinstance(state, dict) else None
     if isinstance(errors, bool) or not isinstance(errors, int) or errors < 0:
-        return CronRetryBudget(None, cap, None)
+        errors = None
+    if errors is None or cap is None:
+        return CronRetryBudget(errors, cap, None)
     return CronRetryBudget(errors, cap, errors > cap)
 
 

--- a/src/clawock/providers/openclaw.py
+++ b/src/clawock/providers/openclaw.py
@@ -294,15 +294,29 @@ class CronRetryBudget:
     exhausted: bool | None
 
     @property
+    def cap_needed(self) -> int | None:
+        """The smallest `maxAttempts` that would let the *next* failure retry.
+
+        The scheduler increments `consecutiveErrors` on a failed run and only
+        then compares it, so the stored counter is what the failure that just
+        happened was judged against — and the next one will be judged at
+        counter + 1. A cap merely equal to the stored counter therefore buys
+        nothing: the next failure steps past it in the same instant.
+        """
+        if self.consecutive_errors is None:
+            return None
+        return self.consecutive_errors + 1
+
+    @property
     def raisable(self) -> bool:
         """Can raising the configured cap alone restore this job's retries?
 
-        The scheduler retries while `consecutiveErrors <= maxAttempts`, so the
-        cap has to reach the counter — not exceed it — and the runtime's schema
-        refuses to store more than RUNTIME_MAX_ALLOWED_ATTEMPTS.
+        Only while the cap it would take is one the runtime's schema will
+        actually store — at a stored counter of 10 the needed cap is 11, which
+        is rejected, so the counter itself has to be reset.
         """
-        return (self.consecutive_errors is not None
-                and self.consecutive_errors <= RUNTIME_MAX_ALLOWED_ATTEMPTS)
+        return (self.cap_needed is not None
+                and self.cap_needed <= RUNTIME_MAX_ALLOWED_ATTEMPTS)
 
     def describe(self) -> str:
         if self.exhausted is None:
@@ -334,14 +348,20 @@ def cron_max_attempts(*, paths: OpenClawPaths | None = None) -> int | None:
     config_file = (paths or runtime_paths()).config_file
     try:
         config = json.loads(config_file.read_text())
-        retry = (config.get("cron") or {}).get("retry") or {}
     except Exception:
         return None
-    if not isinstance(retry, dict):
+    # `cron: null` and `retry: []` are not "the field is absent" — they are
+    # shapes the runtime's schema rejects, so they say nothing about the cap the
+    # live scheduler is running. Only a well-formed section may fall back.
+    for key in ("cron", "retry"):
+        if not isinstance(config, dict):
+            return None
+        config = config.get(key, {})
+    if not isinstance(config, dict):
         return None
-    if "maxAttempts" not in retry:
+    if "maxAttempts" not in config:
         return RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
-    return _valid_attempts(retry["maxAttempts"])
+    return _valid_attempts(config["maxAttempts"])
 
 
 def cron_retry_budget(job, *, paths: OpenClawPaths | None = None,

--- a/tests/test_brief_watchdog.py
+++ b/tests/test_brief_watchdog.py
@@ -3,12 +3,26 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 from clawock_kcnyu.harness import brief_watchdog as watchdog  # noqa: E402
 
 
 TODAY = "2026-07-17"
+
+
+@pytest.fixture(autouse=True)
+def _no_live_scheduler(monkeypatch):
+    """The 09:05 alert asks the scheduler for the job's retry budget (#506).
+
+    Unstubbed that is a real `openclaw cron list --json` round trip — 3s per
+    test against whatever the live gateway happens to hold, or a timeout on a
+    host where the binary exists and the gateway does not. The budget line has
+    its own suite; here the scheduler is simply absent, which is the case that
+    must leave every assertion below unchanged.
+    """
+    monkeypatch.setattr(watchdog, "brief_cron_job", lambda: None)
 
 
 def _stub_outcome(monkeypatch, outcome="success", detail="https://example/run/1"):

--- a/tests/test_brief_watchdog_retry_budget.py
+++ b/tests/test_brief_watchdog_retry_budget.py
@@ -1,0 +1,166 @@
+"""An exhausted retry budget has to be named, because only kcn can clear it.
+
+2026-08-13: no brief. The 08:00 run died on a MiniMax first-call timeout, the
+08:30 re-run died on the same one, and the 09:05 alert told kcn to go look at
+`sar -q` and the provider — both of which were healthy. Every other job that
+morning hit the identical timeout and lived, because the runtime retried them
+minutes later. The brief could not be retried: `consecutiveErrors` stood at 12
+against `cron.retry.maxAttempts`, it only clears on a success, and a job with
+one attempt a day cannot reach one while it is failing (#506, the recurrence of
+#493).
+
+That state is invisible from everything the watchdog reported, and it is not
+self-healing, so the alert now carries the numbers and the way out. It stays
+silent when the budget is healthy or unreadable: a missing brief has other
+causes, and pointing at this one when it is not the cause is how the last
+three diagnoses went wrong.
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+from clawock.providers import openclaw as provider  # noqa: E402
+from clawock_kcnyu.harness import brief_watchdog as watchdog  # noqa: E402
+
+TODAY = "2026-08-13"
+
+
+def _job(**state):
+    return {"id": "db3df0d0", "name": "盘前深度简报", "state": state}
+
+
+def _paths(tmp_path, config=None):
+    if config is not None:
+        (tmp_path / "openclaw.json").write_text(json.dumps(config))
+    return provider.OpenClawPaths(binary="openclaw", home=tmp_path, install_dir=None)
+
+
+# ── the reader ───────────────────────────────────────────────────────────────
+
+def test_budget_is_exhausted_only_past_the_configured_cap(tmp_path):
+    paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
+
+    assert provider.cron_retry_budget(_job(consecutiveErrors=6), paths=paths).exhausted is True
+    # The runtime's own rule is `>`, not `>=`: at exactly the cap one retry is left.
+    assert provider.cron_retry_budget(_job(consecutiveErrors=5), paths=paths).exhausted is False
+    assert provider.cron_retry_budget(_job(consecutiveErrors=0), paths=paths).exhausted is False
+
+
+def test_an_unreadable_counter_is_unknown_not_healthy(tmp_path):
+    paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
+
+    for job in (_job(), _job(consecutiveErrors=None), _job(consecutiveErrors="12"),
+                _job(consecutiveErrors=-1), {"id": "x"}, None):
+        budget = provider.cron_retry_budget(job, paths=paths)
+        assert budget.exhausted is None, job
+        assert budget.consecutive_errors is None, job
+
+
+def test_a_missing_or_invalid_cap_falls_back_to_the_runtime_default(tmp_path):
+    default = provider.RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
+
+    assert provider.cron_max_attempts(paths=_paths(tmp_path, {})) == default
+    assert provider.cron_max_attempts(paths=_paths(tmp_path, {"cron": {"retry": {}}})) == default
+    assert provider.cron_max_attempts(
+        paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": "5"}}})) == default
+    # No config file at all — an installation this process cannot read.
+    assert provider.cron_max_attempts(paths=_paths(tmp_path / "absent")) == default
+    assert provider.cron_max_attempts(
+        paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": 7}}})) == 7
+
+
+def test_a_counter_past_the_schema_ceiling_cannot_be_fixed_by_raising_the_cap(tmp_path):
+    """The runtime rejects maxAttempts > 10, so 12 bad days needs a reset."""
+    paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
+
+    assert provider.cron_retry_budget(_job(consecutiveErrors=8), paths=paths).raisable is True
+    assert provider.cron_retry_budget(_job(consecutiveErrors=12), paths=paths).raisable is False
+
+
+# ── the alert ────────────────────────────────────────────────────────────────
+
+def _alert_text(monkeypatch, tmp_path, job):
+    """Run the 09:05 alert with a stubbed job and return what Telegram got."""
+    sent = []
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "brief_cron_job", lambda: job)
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda _dry: (True, "ok"))
+    monkeypatch.setattr(watchdog, "send_telegram",
+                        lambda _to, message, _dry: (sent.append(message), (True, "ok"))[1])
+    monkeypatch.setattr(watchdog, "await_brief_fallback_outcome",
+                        lambda _since, _dry, **_kw: ("success", "https://example/run/1"))
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing", "plan_missing"]) == 0
+    return sent[0]
+
+
+def test_the_alert_names_the_exhausted_budget_and_the_only_way_out(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(watchdog, "cron_retry_budget",
+                        lambda _job: provider.CronRetryBudget(12, 5, True))
+
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=12))
+
+    assert "12" in text and "5" in text
+    # 12 is past the schema ceiling, so the alert must not send kcn to raise the
+    # cap — that config edit is rejected by the runtime.
+    assert "maxAttempts 已经救不回来" in text
+    assert "consecutive_errors" in text
+
+
+def test_a_budget_below_the_ceiling_is_told_it_can_be_raised(monkeypatch, tmp_path):
+    monkeypatch.setattr(watchdog, "cron_retry_budget",
+                        lambda _job: provider.CronRetryBudget(6, 5, True))
+
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=6))
+
+    assert "cron.retry.maxAttempts" in text and "6" in text
+    assert "已经救不回来" not in text
+
+
+def test_a_healthy_budget_leaves_the_alert_exactly_as_it_was(monkeypatch, tmp_path):
+    monkeypatch.setattr(watchdog, "cron_retry_budget",
+                        lambda _job: provider.CronRetryBudget(1, 5, False))
+
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=1))
+
+    assert "重试预算" not in text
+    assert "盘前深度简报产物不完整" in text
+
+
+def test_an_unreadable_job_says_nothing_about_the_budget(monkeypatch, tmp_path):
+    text = _alert_text(monkeypatch, tmp_path, None)
+
+    assert "重试预算" not in text
+
+
+def test_an_unknown_budget_says_nothing_about_the_budget(monkeypatch, tmp_path):
+    monkeypatch.setattr(watchdog, "cron_retry_budget",
+                        lambda _job: provider.CronRetryBudget(None, 5, None))
+
+    text = _alert_text(monkeypatch, tmp_path, _job())
+
+    assert "重试预算" not in text
+
+
+# ── the 08:30 re-run ─────────────────────────────────────────────────────────
+
+def test_the_0830_rerun_records_the_budget_it_is_running_against(
+        monkeypatch, tmp_path):
+    """The re-run is one more single attempt; the log has to show that."""
+    logged = []
+    job = _job(lastStatus="error", lastRunAtMs=None, consecutiveErrors=12)
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "brief_cron_job", lambda: job)
+    monkeypatch.setattr(watchdog, "cron_run_ended_in_failure", lambda _job, _today: True)
+    monkeypatch.setattr(watchdog, "cron_retry_budget",
+                        lambda _job: provider.CronRetryBudget(12, 5, True))
+    monkeypatch.setattr(watchdog, "rerun_cron_job", lambda _id, _dry: (True, "queued"))
+    monkeypatch.setattr(watchdog, "log", logged.append)
+
+    assert watchdog.retrigger_or_wait(TODAY, False) == 0
+
+    rerun = [event for event in logged if event.get("action") == "rerun-onhost"]
+    assert len(rerun) == 1
+    assert rerun[0]["retry_budget_exhausted"] is True
+    assert "12" in rerun[0]["retry_budget"] and "5" in rerun[0]["retry_budget"]

--- a/tests/test_brief_watchdog_retry_budget.py
+++ b/tests/test_brief_watchdog_retry_budget.py
@@ -134,6 +134,32 @@ def test_an_unreadable_job_says_nothing_about_the_budget(monkeypatch, tmp_path):
     assert "重试预算" not in text
 
 
+def test_a_broken_budget_lookup_never_costs_the_alert(monkeypatch, tmp_path):
+    """Reading the budget goes through the gateway — the thing that may be down.
+
+    This alert is the last notification that reaches a human on a morning with
+    no brief. Losing it to an exception raised while collecting an extra line
+    about *why* would be strictly worse than sending the line-less alert.
+    """
+    def explode():
+        raise RuntimeError("gateway unreachable")
+
+    monkeypatch.setattr(watchdog, "brief_cron_job", explode)
+    sent = []
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda _dry: (True, "ok"))
+    monkeypatch.setattr(watchdog, "send_telegram",
+                        lambda _to, message, _dry: (sent.append(message), (True, "ok"))[1])
+    monkeypatch.setattr(watchdog, "await_brief_fallback_outcome",
+                        lambda _since, _dry, **_kw: ("success", "https://example/run/1"))
+    monkeypatch.setattr(watchdog, "log", lambda _event: None)
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert sent and "盘前深度简报产物不完整" in sent[0]
+    assert "重试预算" not in sent[0]
+
+
 def test_an_unknown_budget_says_nothing_about_the_budget(monkeypatch, tmp_path):
     monkeypatch.setattr(watchdog, "cron_retry_budget",
                         lambda _job: provider.CronRetryBudget(None, 5, None))

--- a/tests/test_brief_watchdog_retry_budget.py
+++ b/tests/test_brief_watchdog_retry_budget.py
@@ -56,34 +56,78 @@ def test_an_unreadable_counter_is_unknown_not_healthy(tmp_path):
         assert budget.consecutive_errors is None, job
 
 
-def test_a_missing_or_invalid_cap_falls_back_to_the_runtime_default(tmp_path):
+def test_a_config_that_parses_without_the_field_uses_the_runtime_default(tmp_path):
+    """This is the one case the runtime itself documents a default for."""
     default = provider.RUNTIME_DEFAULT_MAX_TRANSIENT_RETRIES
 
     assert provider.cron_max_attempts(paths=_paths(tmp_path, {})) == default
     assert provider.cron_max_attempts(paths=_paths(tmp_path, {"cron": {"retry": {}}})) == default
     assert provider.cron_max_attempts(
-        paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": "5"}}})) == default
-    # No config file at all — an installation this process cannot read.
-    assert provider.cron_max_attempts(paths=_paths(tmp_path / "absent")) == default
-    assert provider.cron_max_attempts(
         paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": 7}}})) == 7
 
 
+def test_an_unreadable_cap_is_unknown_and_never_a_default(tmp_path):
+    """Inventing a cap invents accusations: real cap 10, counter 6, verdict wrong.
+
+    A file that cannot be read tells us nothing about what the live scheduler
+    loaded, so it must not be answered with a number that happens to be
+    plausible. Only a config that parses and omits the field has a documented
+    default.
+    """
+    # No config file at all — an installation this process cannot read.
+    assert provider.cron_max_attempts(paths=_paths(tmp_path / "absent")) is None
+    for value in ("5", True, -1, None, 11, 20):
+        assert provider.cron_max_attempts(
+            paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": value}}})) is None, value
+    corrupt = tmp_path / "corrupt"
+    corrupt.mkdir()
+    (corrupt / "openclaw.json").write_text("{not json")
+    assert provider.cron_max_attempts(
+        paths=provider.OpenClawPaths(binary="openclaw", home=corrupt, install_dir=None)) is None
+
+
+def test_an_unknown_cap_makes_the_verdict_unknown_not_exhausted(tmp_path):
+    budget = provider.cron_retry_budget(_job(consecutiveErrors=6),
+                                        paths=_paths(tmp_path / "absent"))
+
+    assert budget.exhausted is None
+    assert budget.consecutive_errors == 6 and budget.max_attempts is None
+
+
 def test_a_counter_past_the_schema_ceiling_cannot_be_fixed_by_raising_the_cap(tmp_path):
-    """The runtime rejects maxAttempts > 10, so 12 bad days needs a reset."""
+    """The runtime rejects maxAttempts > 10, so 12 bad days needs a reset.
+
+    10 itself is still raisable: the rule is `errors > cap`, so a cap of exactly
+    10 leaves a counter of 10 one retry.
+    """
     paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
 
     assert provider.cron_retry_budget(_job(consecutiveErrors=8), paths=paths).raisable is True
+    assert provider.cron_retry_budget(_job(consecutiveErrors=10), paths=paths).raisable is True
+    assert provider.cron_retry_budget(_job(consecutiveErrors=11), paths=paths).raisable is False
     assert provider.cron_retry_budget(_job(consecutiveErrors=12), paths=paths).raisable is False
 
 
 # ── the alert ────────────────────────────────────────────────────────────────
 
-def _alert_text(monkeypatch, tmp_path, job):
-    """Run the 09:05 alert with a stubbed job and return what Telegram got."""
+_RUNS = [0]
+
+
+def _alert_text(monkeypatch, tmp_path, job, budget=None):
+    """Run the 09:05 alert with a stubbed job and return what Telegram got.
+
+    Each call gets its own workspace: the alert writes a dedupe flag and
+    recovery state, and a second call sharing them would return early without
+    sending anything at all.
+    """
     sent = []
-    monkeypatch.setattr(watchdog, "WS", tmp_path)
-    monkeypatch.setattr(watchdog, "brief_cron_job", lambda: job)
+    _RUNS[0] += 1
+    ws = tmp_path / f"ws{_RUNS[0]}"
+    ws.mkdir()
+    monkeypatch.setattr(watchdog, "WS", ws)
+    monkeypatch.setattr(watchdog, "brief_cron_job_state", lambda: job)
+    if budget is not None:
+        monkeypatch.setattr(watchdog, "cron_retry_budget", lambda _job: budget)
     monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda _dry: (True, "ok"))
     monkeypatch.setattr(watchdog, "send_telegram",
                         lambda _to, message, _dry: (sent.append(message), (True, "ok"))[1])
@@ -94,44 +138,78 @@ def _alert_text(monkeypatch, tmp_path, job):
     return sent[0]
 
 
+def _baseline(monkeypatch, tmp_path):
+    """The alert as it reads when the budget contributes nothing."""
+    return _alert_text(monkeypatch, tmp_path, None)
+
+
 def test_the_alert_names_the_exhausted_budget_and_the_only_way_out(
         monkeypatch, tmp_path):
-    monkeypatch.setattr(watchdog, "cron_retry_budget",
-                        lambda _job: provider.CronRetryBudget(12, 5, True))
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=12),
+                       provider.CronRetryBudget(12, 5, True))
 
-    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=12))
-
-    assert "12" in text and "5" in text
+    # Both numbers, in the one form that cannot be satisfied by the "09:05" and
+    # the date already in the message.
+    assert "consecutiveErrors=12 > maxAttempts=5" in text
     # 12 is past the schema ceiling, so the alert must not send kcn to raise the
     # cap — that config edit is rejected by the runtime.
     assert "maxAttempts 已经救不回来" in text
     assert "consecutive_errors" in text
+    assert "cron.retry.maxAttempts 设为" not in text
 
 
-def test_a_budget_below_the_ceiling_is_told_it_can_be_raised(monkeypatch, tmp_path):
-    monkeypatch.setattr(watchdog, "cron_retry_budget",
-                        lambda _job: provider.CronRetryBudget(6, 5, True))
+def test_a_budget_below_the_ceiling_is_told_which_value_to_set(monkeypatch, tmp_path):
+    """`errors > cap` ⇒ the cap has to reach the counter, not pass it.
 
-    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=6))
+    Told to "raise past 6" an operator sets 7, which is fine; told to raise past
+    10 they would set 11, which the runtime's schema rejects outright. Naming
+    the value removes the trap.
+    """
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=10),
+                       provider.CronRetryBudget(10, 5, True))
 
-    assert "cron.retry.maxAttempts" in text and "6" in text
+    assert "cron.retry.maxAttempts 设为 ≥ 10" in text
     assert "已经救不回来" not in text
 
 
-def test_a_healthy_budget_leaves_the_alert_exactly_as_it_was(monkeypatch, tmp_path):
-    monkeypatch.setattr(watchdog, "cron_retry_budget",
-                        lambda _job: provider.CronRetryBudget(1, 5, False))
+def test_the_alert_claims_only_what_the_counter_proves(monkeypatch, tmp_path):
+    """No causal story: this reading does not know why today's run failed.
 
-    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=1))
+    The first draft said "one chance a day" (the day had two on-host runs) and
+    "the other jobs survived the same wall" (nothing here observed the other
+    jobs). Both were true on 08-13 and neither was evidence from this reading.
+    """
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=12),
+                       provider.CronRetryBudget(12, 5, True))
 
-    assert "重试预算" not in text
-    assert "盘前深度简报产物不完整" in text
+    assert "每天只有一次机会" not in text
+    assert "别的 job" not in text
+    assert "调度器不会再自动重试" in text
+
+
+def test_a_healthy_budget_leaves_the_alert_byte_identical(monkeypatch, tmp_path):
+    baseline = _baseline(monkeypatch, tmp_path)
+
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=1),
+                       provider.CronRetryBudget(1, 5, False))
+
+    assert text == baseline
+
+
+def test_an_unknown_verdict_leaves_the_alert_byte_identical(monkeypatch, tmp_path):
+    """Counter or cap unreadable — the two ways to know nothing."""
+    baseline = _baseline(monkeypatch, tmp_path)
+
+    for budget in (provider.CronRetryBudget(None, 5, None),
+                   provider.CronRetryBudget(6, None, None)):
+        assert _alert_text(monkeypatch, tmp_path, _job(), budget) == baseline
 
 
 def test_an_unreadable_job_says_nothing_about_the_budget(monkeypatch, tmp_path):
     text = _alert_text(monkeypatch, tmp_path, None)
 
     assert "重试预算" not in text
+    assert "盘前深度简报产物不完整" in text
 
 
 def test_a_broken_budget_lookup_never_costs_the_alert(monkeypatch, tmp_path):
@@ -144,7 +222,7 @@ def test_a_broken_budget_lookup_never_costs_the_alert(monkeypatch, tmp_path):
     def explode():
         raise RuntimeError("gateway unreachable")
 
-    monkeypatch.setattr(watchdog, "brief_cron_job", explode)
+    monkeypatch.setattr(watchdog, "brief_cron_job_state", explode)
     sent = []
     monkeypatch.setattr(watchdog, "WS", tmp_path)
     monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda _dry: (True, "ok"))
@@ -158,15 +236,6 @@ def test_a_broken_budget_lookup_never_costs_the_alert(monkeypatch, tmp_path):
 
     assert sent and "盘前深度简报产物不完整" in sent[0]
     assert "重试预算" not in sent[0]
-
-
-def test_an_unknown_budget_says_nothing_about_the_budget(monkeypatch, tmp_path):
-    monkeypatch.setattr(watchdog, "cron_retry_budget",
-                        lambda _job: provider.CronRetryBudget(None, 5, None))
-
-    text = _alert_text(monkeypatch, tmp_path, _job())
-
-    assert "重试预算" not in text
 
 
 # ── the 08:30 re-run ─────────────────────────────────────────────────────────

--- a/tests/test_brief_watchdog_retry_budget.py
+++ b/tests/test_brief_watchdog_retry_budget.py
@@ -79,6 +79,11 @@ def test_an_unreadable_cap_is_unknown_and_never_a_default(tmp_path):
     for value in ("5", True, -1, None, 11, 20):
         assert provider.cron_max_attempts(
             paths=_paths(tmp_path, {"cron": {"retry": {"maxAttempts": value}}})) is None, value
+    # Shapes the schema rejects are not "the field is absent" either.
+    for config in ({"cron": None}, {"cron": []}, {"cron": {"retry": None}},
+                   {"cron": {"retry": []}}, []):
+        assert provider.cron_max_attempts(
+            paths=_paths(tmp_path, config)) is None, config
     corrupt = tmp_path / "corrupt"
     corrupt.mkdir()
     (corrupt / "openclaw.json").write_text("{not json")
@@ -94,17 +99,30 @@ def test_an_unknown_cap_makes_the_verdict_unknown_not_exhausted(tmp_path):
     assert budget.consecutive_errors == 6 and budget.max_attempts is None
 
 
-def test_a_counter_past_the_schema_ceiling_cannot_be_fixed_by_raising_the_cap(tmp_path):
-    """The runtime rejects maxAttempts > 10, so 12 bad days needs a reset.
+def test_the_cap_that_would_help_is_one_past_the_stored_counter(tmp_path):
+    """`applyJobResult` increments the counter and *then* compares it.
 
-    10 itself is still raisable: the rule is `errors > cap`, so a cap of exactly
-    10 leaves a counter of 10 one retry.
+    So the stored counter is what the failure that just happened was judged
+    against, and the next failure is judged at counter + 1. A cap merely equal
+    to the stored counter is spent in the same instant it is granted.
+    """
+    paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
+
+    assert provider.cron_retry_budget(_job(consecutiveErrors=6), paths=paths).cap_needed == 7
+    assert provider.cron_retry_budget(_job(), paths=paths).cap_needed is None
+
+
+def test_a_counter_past_the_schema_ceiling_cannot_be_fixed_by_raising_the_cap(tmp_path):
+    """The runtime rejects maxAttempts > 10, so the cure runs out at 9.
+
+    At a stored counter of 9 the needed cap is 10, which the schema still
+    stores. At 10 it is 11, which it does not — from there only a reset works.
     """
     paths = _paths(tmp_path, {"cron": {"retry": {"maxAttempts": 5}}})
 
     assert provider.cron_retry_budget(_job(consecutiveErrors=8), paths=paths).raisable is True
-    assert provider.cron_retry_budget(_job(consecutiveErrors=10), paths=paths).raisable is True
-    assert provider.cron_retry_budget(_job(consecutiveErrors=11), paths=paths).raisable is False
+    assert provider.cron_retry_budget(_job(consecutiveErrors=9), paths=paths).raisable is True
+    assert provider.cron_retry_budget(_job(consecutiveErrors=10), paths=paths).raisable is False
     assert provider.cron_retry_budget(_job(consecutiveErrors=12), paths=paths).raisable is False
 
 
@@ -159,17 +177,27 @@ def test_the_alert_names_the_exhausted_budget_and_the_only_way_out(
 
 
 def test_a_budget_below_the_ceiling_is_told_which_value_to_set(monkeypatch, tmp_path):
-    """`errors > cap` ⇒ the cap has to reach the counter, not pass it.
+    """The named value must clear the *next* failure, not the last one.
 
-    Told to "raise past 6" an operator sets 7, which is fine; told to raise past
-    10 they would set 11, which the runtime's schema rejects outright. Naming
-    the value removes the trap.
+    The scheduler increments before comparing, so a counter of 9 needs a cap of
+    10; advising 9 would leave the very next failure unretried, which is the
+    same non-fix wearing a different number.
     """
-    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=10),
-                       provider.CronRetryBudget(10, 5, True))
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=9),
+                       provider.CronRetryBudget(9, 5, True))
 
     assert "cron.retry.maxAttempts 设为 ≥ 10" in text
     assert "已经救不回来" not in text
+
+
+def test_a_counter_at_the_ceiling_is_sent_to_reset_not_to_the_config(
+        monkeypatch, tmp_path):
+    """Counter 10 needs cap 11, which the runtime refuses to store."""
+    text = _alert_text(monkeypatch, tmp_path, _job(consecutiveErrors=10),
+                       provider.CronRetryBudget(10, 5, True))
+
+    assert "maxAttempts 已经救不回来" in text
+    assert "cron.retry.maxAttempts 设为" not in text
 
 
 def test_the_alert_claims_only_what_the_counter_proves(monkeypatch, tmp_path):
@@ -258,4 +286,33 @@ def test_the_0830_rerun_records_the_budget_it_is_running_against(
     rerun = [event for event in logged if event.get("action") == "rerun-onhost"]
     assert len(rerun) == 1
     assert rerun[0]["retry_budget_exhausted"] is True
-    assert "12" in rerun[0]["retry_budget"] and "5" in rerun[0]["retry_budget"]
+    assert rerun[0]["retry_budget"] == "consecutiveErrors=12 > maxAttempts=5"
+    assert "exhausted" in rerun[0]["reason"]
+
+
+def test_the_0830_rerun_does_not_claim_a_verdict_it_did_not_read(
+        monkeypatch, tmp_path):
+    """The re-run fires on the run being over, not on the budget.
+
+    The reason line used to assert "the runtime will not retry it" for every
+    re-run. That was 08-13's case, not the general one: an intact budget means
+    the scheduler may retry too, and an unreadable one means neither is known.
+    """
+    for budget, expected in ((provider.CronRetryBudget(1, 5, False), "intact"),
+                             (provider.CronRetryBudget(None, 5, None), "unknown")):
+        logged = []
+        ws = tmp_path / f"ws-{expected}"
+        ws.mkdir()
+        monkeypatch.setattr(watchdog, "WS", ws)
+        monkeypatch.setattr(watchdog, "brief_cron_job", lambda: _job())
+        monkeypatch.setattr(watchdog, "cron_run_ended_in_failure", lambda _job, _today: True)
+        monkeypatch.setattr(watchdog, "cron_retry_budget", lambda _job: budget)
+        monkeypatch.setattr(watchdog, "rerun_cron_job", lambda _id, _dry: (True, "queued"))
+        monkeypatch.setattr(watchdog, "log", logged.append)
+
+        assert watchdog.retrigger_or_wait(TODAY, False) == 0
+
+        rerun = [e for e in logged if e.get("action") == "rerun-onhost"]
+        assert len(rerun) == 1, expected
+        assert expected in rerun[0]["reason"], (expected, rerun[0]["reason"])
+        assert "the runtime will not retry it" not in rerun[0]["reason"]


### PR DESCRIPTION
Closes the open half of #506.

## 状态：runtime 侧已现场修复，本 PR 修的是「它当时看不见」

**现场（已做，不在本 PR 里）**：`盘前深度简报` 的 `consecutive_errors` 已从 12 归零（停 gateway → 改 `state/openclaw.sqlite` 的 `cron_jobs.consecutive_errors` + `state_json.consecutiveErrors` → 起 gateway，sqlite 已备份），`cron.retry.maxAttempts` 5 → 10。明早 08:00 这个 job 重新拿到和其余 10 个 job 一样的重试预算。

**issue 里列的候选 ①「把 maxAttempts 抬到 >12」是做不到的**：runtime 的 config schema 直接拒绝，`Too big: expected number to be <=10`，gateway 拒绝启动。12 > 10 ⇒ 抬阈值这条路对当时的状态根本不通，只能重置计数。这一条已经编码进本 PR 的 `raisable`。

## 本 PR

那个环（没有重试就不成功、不成功就清不掉计数）本身是不可自愈的，而当时**没有任何一处报告它**：08:30 重跑撞同一堵墙，09:05 告警让 kcn 去看 `sar -q` 和 provider —— 两者当天都是健康的，这正是当天先误判成 context 体积、再误判成 vendor 的原因。

- `providers.openclaw.cron_retry_budget()`：拿 `consecutiveErrors` 比活配置的 `cron.retry.maxAttempts`（未配置时用 runtime 默认 3）。状态读不到时返回 `exhausted=None` —— 读不到不等于健康。
- 09:05 告警多一行，写明数字和唯一出路，并区分两种出路（低于 schema 上限 10 → 抬 cap 即可；已经超过 → 只能重置计数）。
- 08:30 重跑把它跑在什么预算下记进日志：那一跑是**又一次单次尝试**，不是重试。

**预算健康或读不到时，告警一个字不变** —— 简报缺失有别的死法（本 issue 之前已经有三种互不通用的根因），指错一次的代价就是当天白查。

## 测试

`tests/test_brief_watchdog_retry_budget.py`（10 条）覆盖：`>` 而非 `>=` 的边界、非法/缺失计数判 unknown、cap 缺失或非法回落 runtime 默认、超过 schema 上限时 `raisable=False`、告警在四种状态下的文案（耗尽且可抬 / 耗尽不可抬 / 健康 / 读不到）、08:30 日志带预算。

变异验证（三处都能变红）：`errors > cap` → `>=`；`retry_budget_note` 恒返回空串；`raisable` 去掉上限判断。

顺带：告警路径现在会问调度器，所以既有 09:05 套件加了 autouse stub —— 不 stub 的话每条测试要真打一次 `openclaw cron list --json`（实测 3.2s/次，且读的是活 gateway 的状态）。该文件 35 条从 32.7s 降到 0.3s。

## 没做

- **没查「为什么 gateway 路径每档首次必超时」**。60s 死线兑现了（`elapsedMs=60018`）却照样超时，说明这不是慢 prefill；直连同一 endpoint 的暖请求 1.2–27s 从没停过。这是能根治的方向，但它是另一条线，`#506` 里已单列。
- 没动 60s 死线补丁（不回滚，理由见 issue）。
