### PR TITLE
dashboard: publish add campaign evidence and current holdings

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The model submits decisions; it can never write or amend its own evaluation. Tha
 
 <p align="center"><img src="https://raw.githubusercontent.com/KCNyu/clawock/refs/heads/master/site/assets/shadow-backtest.png" alt="cumulative episode win rate against a 50% directional-hit line" width="760"></p>
 
-<sub>Cumulative episode win rate against a 50% directional-hit line — how often the direction was right, not what it earned. The buy-and-hold comparison is the shadow portfolio (in the details below and on Reflect); this is a different question. Refreshed weekly by GitHub Actions; live figures live on the <a href="https://kcnyu.github.io/clawock/">Reflect tab</a>.</sub>
+<sub>Cumulative episode win rate against a 50% directional-hit line — how often the direction was right, not what it earned. The buy-and-hold comparison is the Shadow Portfolio under Holdings; this is a different question. Refreshed weekly by GitHub Actions; live figures are on the <a href="https://kcnyu.github.io/clawock/#drill">Holdings tab</a>.</sub>
 
 <details>
 <summary><b>How the grading handles the hard cases</b></summary>

--- a/README.zh.md
+++ b/README.zh.md
@@ -152,7 +152,7 @@ package 架构。
 
 <p align="center"><img src="site/assets/shadow-backtest.png" alt="累计 episode 胜率对 50% 方向命中基线" width="760"></p>
 
-<sub>累计 episode 胜率对 50% 方向命中基线 —— 衡量的是方向对了多少次,不是赚了多少。买入持有的对比是影子组合(在下方 details 和 Reflect 里),那是另一个问题。由 GitHub Actions 每周刷新;实时数字见<a href="https://kcnyu.github.io/clawock/">诚实(Reflect)标签页</a>。</sub>
+<sub>累计 episode 胜率对 50% 方向命中基线 —— 衡量的是方向对了多少次,不是赚了多少。买入持有的对比是持仓(Holdings)里的 Shadow Portfolio,那是另一个问题。由 GitHub Actions 每周刷新;实时数字见<a href="https://kcnyu.github.io/clawock/#drill">持仓(Holdings)标签页</a>。</sub>
 
 <details>
 <summary><b>打分怎么处理那些难缠的边界情况</b></summary>

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1089,6 +1089,54 @@
   .outcome.loss { background: color-mix(in srgb, var(--negative) 15%, transparent); color: var(--negative); }
   .outcome.pending { background: rgba(107,118,145,.15); color: var(--gray); }
   .outcome.flat { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
+  /* Add campaign — one deterministic public projection, split by market. */
+  .campaign-summary, .campaign-coverage {
+    color: var(--text-dim); font: 11px/1.55 var(--mono);
+    padding: 8px 0;
+  }
+  .add-campaign-legs, .campaign-market-grid {
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+  .add-campaign-leg, .campaign-market {
+    min-width: 0; border: 1px solid var(--border); border-radius: var(--radius-sm);
+    background: var(--card-2); overflow: hidden;
+  }
+  .add-campaign-leg h4, .campaign-market h4 {
+    margin: 0; padding: 9px 11px; border-bottom: 1px solid var(--border);
+    color: var(--text-dim); font: 700 11px var(--mono); letter-spacing: .04em;
+  }
+  .add-campaign-row { padding: 10px 11px; border-bottom: 1px dashed var(--border); }
+  .add-campaign-row:last-child { border-bottom: 0; }
+  .add-campaign-row > div:first-child,
+  .add-campaign-row > div:nth-child(2) { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
+  .campaign-tier, .campaign-state, .campaign-blockers span {
+    display: inline-flex; padding: 2px 6px; border-radius: 999px;
+    font: 600 10px var(--mono); background: rgba(107,118,145,.14); color: var(--text-dim);
+  }
+  .campaign-state.state-eligible { color: var(--positive); background: color-mix(in srgb, var(--positive) 14%, transparent); }
+  .campaign-state.state-risk_blocked, .campaign-state.state-constraint_blocked { color: var(--negative); background: color-mix(in srgb, var(--negative) 12%, transparent); }
+  .campaign-state.state-waiting_timing { color: var(--warning); background: color-mix(in srgb, var(--warning) 12%, transparent); }
+  .campaign-families, .campaign-detail { color: var(--text-dim); font-size: 11px; line-height: 1.5; }
+  .campaign-detail { margin-top: 5px; font-family: var(--mono); }
+  .campaign-blockers { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+  .campaign-blockers b { color: var(--text-faint); font: 600 9px/20px var(--mono); text-transform: uppercase; }
+  .campaign-evidence-head {
+    display: flex; justify-content: space-between; gap: 8px; flex-wrap: wrap;
+    margin-top: var(--space-4); padding: 10px 0 8px; border-top: 1px solid var(--border);
+    color: var(--text-dim); font-size: 11px;
+  }
+  .campaign-evidence-head b { color: var(--text); }
+  .campaign-horizon {
+    display: flex; justify-content: space-between; gap: 8px;
+    padding: 8px 10px; border-bottom: 1px dashed var(--border); font-size: 11px;
+  }
+  .campaign-horizon:last-child { border-bottom: 0; }
+  .campaign-horizon b { font-family: var(--mono); color: var(--text); }
+  .campaign-horizon span { color: var(--text-dim); text-align: right; }
+  @media (max-width: 680px) {
+    .add-campaign-legs, .campaign-market-grid { grid-template-columns: 1fr; }
+  }
   /* Bucket historical win-rate badge (from calibration.per_bucket) */
   .bucket-wr {
     display: inline-block; margin-left: 8px; padding: 2px 8px;

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -338,7 +338,7 @@
       renderTodayPnl, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
     ],
     drill: [
-      renderDecisionMatrix, renderHoldings, renderExtremes, renderMovers,
+      renderDecisionMatrix, renderAddCampaign, renderHoldings, renderExtremes, renderMovers,
       renderAnomalies, render8dHeatmap, renderTodayRange, renderShadowPortfolioCard,
     ],
     risk: [
@@ -1226,8 +1226,12 @@
       ? (projection.tickers || [])
       : [];
     const H = safe(DATA, "holdings") || {};
-    const holds = [...(H.us || []), ...(H.hk || [])].filter(h => h && h.is_active);
-    if (!projected.length && !holds.length) { card.style.display = 'none'; return; }
+    // dashboard.holdings is the current ledger projection. The brief sidecar
+    // publishes independently and may be days older, so it may enrich a ticker
+    // but must never own membership in a card labelled current holdings.
+    const holds = [...(H.us || []), ...(H.hk || [])].filter(h =>
+      h && h.is_active !== false && (h.shares ?? 0) > 0);
+    if (!holds.length) { card.style.display = 'none'; return; }
     card.style.display = '';
     const qrows = ((safe(DATA, "quant_signals") || {}).rows) || {};
     // 杠杆 ETF→底层标的映射（量化按标的算，ETF 本身无 quant 行）。
@@ -1267,8 +1271,12 @@
       if (q.tag || q.rsi14 != null) return { rank: 3, label: '趋势off·观望', state: 'neutral' };
       return { rank: 5, label: '—', state: 'neutral' };
     };
-    const enriched = projected.length
-      ? projected.map(row => {
+    const projectedByTicker = new Map(projected.map(row => [row.ticker, row]));
+    let usedProjection = false;
+    const enriched = holds.map(h => {
+        const row = projectedByTicker.get(h.ticker);
+        if (row) {
+          usedProjection = true;
           const q = row.technical || {};
           const proxy = q.is_proxy ? q.source_ticker : '';
           if (proxy) usedProxy = true;
@@ -1278,29 +1286,27 @@
             col: riskAction.kind === 'stop' ? 'var(--negative)' : 'var(--warning)',
             kind: riskAction.kind,
           } : null;
-          const live = holds.find(h => h.ticker === row.ticker) || {};
           return {
             h: {
-              ticker: row.ticker,
+              ticker: h.ticker,
               // Projection owns analysis; current marks remain live intraday.
-              today_change_pct: live.today_change_pct ?? (row.facts || {}).today_change_pct,
-              pnl_percent: live.pnl_percent ?? (row.facts || {}).pnl_pct,
+              today_change_pct: h.today_change_pct ?? (row.facts || {}).today_change_pct,
+              pnl_percent: h.pnl_percent ?? (row.facts || {}).pnl_pct,
             },
             q,
             a,
             proxy,
             v: row.status || verdict(q, a),
           };
-        })
-      : holds.map(h => {
-          const usable = r => r && (!r.status || r.status === 'fresh');
-          const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
-          const proxy = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : '';
-          if (proxy) usedProxy = true;
-          const q = direct || (proxy ? qrows[proxy] : {}) || {};
-          const a = action[h.ticker];
-          return { h, q, a, proxy, v: verdict(q, a) };
-        });
+        }
+        const usable = r => r && (!r.status || r.status === 'fresh');
+        const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
+        const proxy = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : '';
+        if (proxy) usedProxy = true;
+        const q = direct || (proxy ? qrows[proxy] : {}) || {};
+        const a = action[h.ticker];
+        return { h, q, a, proxy, v: verdict(q, a) };
+      });
     // 排序：需要动作的优先(rank 升序)，同级浮亏深的在前 → 最该看的在最上面
     enriched.sort((x, y) => (x.v.rank - y.v.rank) || ((x.h.pnl_percent ?? 0) - (y.h.pnl_percent ?? 0)));
     document.getElementById('decision-matrix-tbody').innerHTML = enriched.map(({ h, q, a, proxy, v }) => {
@@ -1319,8 +1325,88 @@
     document.getElementById('decision-matrix-note').textContent =
       '综合：止损/减仓=硬闸规则(必动)，观望/趋势ON=技术状态(非买卖建议)。按需动作优先排序。'
       + '52w位置：绿=近一年低位(便宜)、红=高位(追高警惕)。'
-      + (projected.length ? '数据由 harness projection 编译，页面不重算规则。' : '兼容模式：等待 projection。')
+      + (usedProjection ? '匹配行由 harness projection 编译；当前持仓成员以最新账本为准。' : '兼容模式：等待 projection。')
       + (usedProxy ? '▵=杠杆ETF量化列取底层标的。' : '');
+  }
+
+  function renderAddCampaign() {
+    const card = document.getElementById("add-campaign-card");
+    const body = document.getElementById("add-campaign-body");
+    const evidence = document.getElementById("add-campaign-evidence");
+    const status = document.getElementById("add-campaign-status");
+    if (!card || !body || !evidence || !status) return;
+    const campaign = safe(DATA, "brief_projection", "add_campaign");
+    if (!campaign) {
+      status.textContent = "projection missing";
+      status.className = "badge muted";
+      body.innerHTML = '<div class="empty-state">当前公开 projection 还没有 campaign 字段；不是零信号。</div>';
+      evidence.innerHTML = "";
+      return;
+    }
+    if (campaign.status !== "current") {
+      status.textContent = "pre-policy packet";
+      status.className = "badge muted";
+      body.innerHTML = `<div class="revision-note"><b>尚无当前生产 receipt。</b> 这份 brief packet 早于新 campaign 上线，不能据此声称所有持仓都被拒绝。packet ${escapeHtml(campaign.packet_generated_at || "—")}</div>`;
+    } else {
+      const d = campaign.diagnostics || {};
+      const tiers = d.tier_counts || {};
+      status.textContent = `collecting · authority ${d.authority_candidate_count || 0}/${d.held_names || 0}`;
+      status.className = "badge muted";
+      const stateLabel = {
+        eligible: "可执行", waiting_timing: "等技术位", risk_blocked: "风险拦截",
+        already_at_target: "tranche 已满", constraint_blocked: "约束拦截",
+        insufficient_evidence: "证据不足",
+      };
+      const blockerLabel = {
+        independent_evidence_families: "缺独立证据族",
+        leveraged_requires_validated_evidence: "杠杆需 validated",
+        negative_information: "负面信息",
+        peer_laggard_avoidance: "同行落后",
+        no_cash_or_target_room: "现金/目标空间不足",
+        tranche_below_market_unit: "低于交易单位",
+        open_add_order: "已有未结加仓",
+        no_approved_setup: "无授权 setup",
+      };
+      const rows = (campaign.candidates || []).slice().sort((a, b) =>
+        String(a.leg || "").localeCompare(String(b.leg || "")) ||
+        String(a.ticker || "").localeCompare(String(b.ticker || "")));
+      const legBlock = leg => {
+        const inLeg = rows.filter(row => row.leg === leg);
+        return `<section class="add-campaign-leg"><h4>${leg} · ${inLeg.length} holdings</h4>` +
+          (inLeg.length ? inLeg.map(row => {
+            const authorityBlockers = row.authority_blockers || [];
+            const executionBlockers = row.execution_blockers || [];
+            const families = (row.evidence_families || []).join(" + ") || "—";
+            const sources = (row.sources || []).join(" + ") || "—";
+            const prices = row.entry_price == null ? "未授权入场位" :
+              `entry ${row.entry_price} · invalid ${row.invalidation_price ?? "—"}`;
+            return `<div class="add-campaign-row">
+              <div><b class="ticker">${escapeHtml(row.ticker || "—")}</b><span class="campaign-tier">${escapeHtml(row.tier || "none")}</span></div>
+              <div><span class="campaign-state state-${escapeHtml(row.state || "unknown")}">${escapeHtml(stateLabel[row.state] || row.state || "unknown")}</span><span class="campaign-families">families ${escapeHtml(families)} · sources ${escapeHtml(sources)}</span></div>
+              <div class="campaign-detail">${escapeHtml(prices)} · tranche ${row.target_tranche_level ?? 0} · max shares ${row.max_add_shares ?? 0}</div>
+              <div class="campaign-blockers"><b>authority</b>${authorityBlockers.length ? authorityBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}<b>execution</b>${executionBlockers.length ? executionBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}</div>
+            </div>`;
+          }).join("") : '<div class="empty-state">No held names.</div>') + `</section>`;
+      };
+      body.innerHTML = `<div class="campaign-summary">packet ${escapeHtml(campaign.packet_generated_at || "—")} · generation ${escapeHtml(campaign.context_generation_id || "—")} · validated ${tiers.validated || 0} · exploration ${tiers.exploration || 0} · none ${tiers.none || 0}</div><div class="add-campaign-legs">${legBlock("US")}${legBlock("HK")}</div>`;
+    }
+
+    const run = campaign.run_card;
+    if (!run) {
+      evidence.innerHTML = '<div class="revision-note"><b>独立 run card 未发布。</b> 当前只显示生产候选状态，不显示回测结论。</div>';
+      return;
+    }
+    const coverage = run.coverage || {};
+    const horizon = (market, key) => {
+      const row = safe(run, "markets", market, key) || {};
+      if (!row.n) return `<div class="campaign-horizon"><b>${key.toUpperCase()}</b><span>collecting · n=0</span></div>`;
+      const ret = row.mean_return == null ? "—" : `${row.mean_return >= 0 ? "+" : ""}${(row.mean_return * 100).toFixed(2)}%`;
+      const hit = row.hit_rate == null ? "—" : `${(row.hit_rate * 100).toFixed(1)}%`;
+      return `<div class="campaign-horizon"><b>${key.toUpperCase()}</b><span>n=${row.n} · mean ${ret} · hit ${hit}</span></div>`;
+    };
+    const market = key => `<section class="campaign-market"><h4>${key.toUpperCase()} interaction</h4>${horizon(key, "t1")}${horizon(key, "t5")}${horizon(key, "t20")}</section>`;
+    const auth = coverage.authority_classifications || {};
+    evidence.innerHTML = `<div class="campaign-evidence-head"><b>Independent run card · ${escapeHtml(run.run_id || "—")}</b><span>diagnostic / collecting，不是 validated alpha</span></div><div class="campaign-market-grid">${market("us")}${market("hk")}</div><div class="campaign-coverage">factor ${coverage.factor_dates ?? "—"} dates · information ${coverage.information_dates ?? "—"} · overlap ${coverage.overlap_dates ?? "—"} · prospective ${coverage.prospective_information_dates ?? "—"} · authority none ${auth.none ?? 0} / explore ${auth.exploration ?? 0} / validated ${auth.validated ?? 0}</div>`;
   }
 
   function renderHoldings() {
@@ -2558,6 +2644,9 @@
     if (!container) return;
     const buckets = ["cut", "trim_on_rebound", "add_only_on_trigger", "add_on_breakout", "hold_and_watch", "watch", "t_only"];
     const perBucket = calib.by_action || {};
+    const bucketLabel = b => b === "add_only_on_trigger"
+      ? "add_only_on_trigger · legacy/mixed"
+      : b;
 
     const rows = buckets
       .map(b => ({ name: b, cal: perBucket[b] }))
@@ -2575,7 +2664,7 @@
         const followTxt = r.cal.avg_benefit_pct != null ? ` · avg ${r.cal.avg_benefit_pct >= 0 ? "+" : ""}${r.cal.avg_benefit_pct.toFixed(2)}%` : "";
         return `
           <div class="bucket-row">
-            <div class="name">${r.name}</div>
+            <div class="name">${bucketLabel(r.name)}</div>
             <div class="bar-wrap">
               <div class="bar-fill ${wCls}${lowN}" style="width:${wr == null ? 0 : wr}%"></div>
             </div>

--- a/site/evidence.md
+++ b/site/evidence.md
@@ -57,6 +57,24 @@ description: 我们测了什么、什么没通过。全部数字从产物读取�
 
 > **这不是一条没通过的检验，是还没到期。** 前瞻收益要 21 个交易日才算得出来，注册后的快照一条都还没满窗，所以计数必然是 0（最早可测 2026-08-24，按当前节奏最早 2026-09-24 才可能激活）。这一层只用 `registered_at` 之后记录的快照，回溯结果永远不能激活它——代价就是必须等，而等待和失败是两件事。
 
+## 低频加仓交互（新 campaign）
+
+**判定：⚪ 尚不可判** · 样本：factor 11 日 × information 12 日 · 来源：run card `add_alpha_walkforward-20260812-3774163f`
+
+| | |
+|---|---|
+| `US T1 interaction` | n=4 · mean 3.11% · hit 100.0% · collecting |
+| `US T5 interaction` | n=3 · mean 5.56% · hit 66.7% · collecting |
+| `US T20 interaction` | collecting · n=0（不显示为 0%） |
+| `HK T1 interaction` | n=2 · mean 1.77% · hit 50.0% · collecting |
+| `HK T5 interaction` | collecting · n=0（不显示为 0%） |
+| `HK T20 interaction` | collecting · n=0（不显示为 0%） |
+| 覆盖日期 | factor 11 · information 12 · overlap 10 |
+| 前瞻信息日期 | 0 |
+| authority 分类 | none 186 · exploration 6 · validated 0 |
+
+> 价格相对强弱与点时信息必须共同出现；技术位只安排已经获准的 tranche。当前 run card 是 current-universe / legacy-news replay，且前瞻信息日期仍为 0，所以只用于收集与诊断，**不是 validated alpha**。旧账本里的 `add_only_on_trigger` 是 mixed/legacy 样本，不计作这套 campaign 的成绩。
+
 ---
 
-<sub>由 `clawock evidence` 生成于 2026-08-08T00:31:42+08:00。数字全部读自产物；改动结论请改产物，不要改这一页。</sub>
+<sub>由 `clawock evidence` 生成于 2026-08-13T16:01:09+08:00。数字全部读自产物；改动结论请改产物，不要改这一页。</sub>

--- a/site/index.html
+++ b/site/index.html
@@ -307,6 +307,18 @@ layout: null
       <div class="muted" id="decision-matrix-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
     </div>
 
+    <div class="card desktop-wide" id="add-campaign-card">
+      <div class="card-head">
+        <div>
+          <div class="overview-card-kicker">Quant × information · low frequency</div>
+          <h3>Add Campaign <span class="badge muted" id="add-campaign-status">—</span></h3>
+        </div>
+      </div>
+      <p class="chart-hint">先由价格相对强弱 + 点时信息共同授权资金，再等技术价位安排 tranche。这里是新 campaign 的独立状态与样本；Reflect 的旧 <code>add_only_on_trigger</code> 桶不是它的战绩。</p>
+      <div id="add-campaign-body"><div class="empty-state">等待今日 brief projection。</div></div>
+      <div id="add-campaign-evidence"></div>
+    </div>
+
     <div class="card desktop-wide" id="holdings-card">
       <h3>Holdings <span class="muted" id="holdings-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
       <div class="table-wrap">

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -839,6 +839,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 0.25 if tier == "exploration" else 1.0 if tier == "validated" else 0.0
             ),
             "sources": list(authority.get("sources") or []),
+            "evidence_families": list(authority.get("evidence_families") or []),
             "authority_blockers": list(authority.get("blockers") or []),
             "entry_price": (setup or {}).get("entry_price"),
             "invalidation_price": (setup or {}).get("invalidation_price"),
@@ -1197,6 +1198,7 @@ def compile_pages_projection(
     packet: dict,
     overlay: dict | None = None,
     overlay_issues: list[str] | None = None,
+    add_alpha_run_card: dict | None = None,
 ) -> dict:
     overlay_issues = list(overlay_issues or [])
     valid_overlay = overlay if overlay and not overlay_issues else {}
@@ -1261,6 +1263,22 @@ def compile_pages_projection(
             row.get("ticker") or "",
         )
     )
+    diagnostics = packet.get("add_alpha_diagnostics")
+    campaign_status = "current" if isinstance(diagnostics, dict) else "pre_policy_packet"
+    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    candidates = []
+    for candidate in diagnostics.get("candidates") or []:
+        candidates.append({
+            key: candidate.get(key)
+            for key in (
+                "ticker", "leg", "state", "tier", "target_tranche_level",
+                "sources", "evidence_families", "authority_blockers",
+                "execution_blockers", "entry_price", "invalidation_price",
+                "max_add_shares", "allowed",
+            )
+        })
+    candidates.sort(key=lambda row: (row.get("leg") or "", row.get("ticker") or ""))
+
     return {
         "schema_version": PAGES_SCHEMA_VERSION,
         "generated_at": packet.get("generated_at"),
@@ -1277,6 +1295,81 @@ def compile_pages_projection(
             "counterargument": valid_overlay.get("portfolio_counterargument"),
         } if valid_overlay else None,
         "tickers": rows,
+        "add_campaign": {
+            "status": campaign_status,
+            "packet_generated_at": packet.get("generated_at"),
+            "context_generation_id": (packet.get("_meta") or {}).get("generation_id"),
+            "policy": {
+                key: (packet.get("add_alpha_policy") or {}).get(key)
+                for key in (
+                    "schema_version", "registered_at", "minimum_evidence_families",
+                    "confirmation_window_sessions", "exploration_max_tranches",
+                    "exploration_tranche_pct", "validated_max_tranches",
+                    "validated_tranche_pct", "exploration_max_book_pct",
+                )
+            } if campaign_status == "current" else None,
+            "diagnostics": {
+                key: diagnostics.get(key)
+                for key in (
+                    "held_names", "tier_counts", "candidate_count",
+                    "authority_candidate_count", "allowed_candidate_count",
+                    "candidate_rate", "blocker_counts", "zero_output_visible",
+                )
+            } if campaign_status == "current" else None,
+            "candidates": candidates,
+            "run_card": _compact_add_alpha_run_card(add_alpha_run_card),
+        },
+    }
+
+
+def _latest_add_alpha_run_card() -> dict | None:
+    cards = sorted(
+        (workspace_root(Path.cwd()) / "memory" / "backtests").glob(
+            "add_alpha_walkforward-*.json"
+        )
+    )
+    if not cards:
+        return None
+    try:
+        return json.loads(cards[-1].read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _compact_add_alpha_run_card(card: dict | None) -> dict | None:
+    """Project the latest evaluator receipt without publishing vendor inputs."""
+    if not isinstance(card, dict):
+        return None
+    metrics = card.get("metrics") or {}
+    coverage = metrics.get("coverage") or {}
+    market_metrics = {}
+    for market in ("us", "hk"):
+        interaction = (metrics.get(market) or {}).get("interaction") or {}
+        market_metrics[market] = {
+            horizon: {
+                key: (interaction.get(horizon) or {}).get(key)
+                for key in (
+                    "n", "n_dates", "n_tickers", "mean_return", "hit_rate",
+                    "mean_excess_vs_same_date_setup", "status",
+                )
+            }
+            for horizon in ("t1", "t5", "t20")
+        }
+    return {
+        "run_id": card.get("run_id"),
+        "generated_at": card.get("generated_at"),
+        "reproduction_key": card.get("reproduction_key"),
+        "policy_version": (card.get("params") or {}).get("policy_version"),
+        "parameter_fit": (card.get("params") or {}).get("parameter_fit"),
+        "markets": market_metrics,
+        "coverage": {
+            key: coverage.get(key)
+            for key in (
+                "factor_dates", "information_dates", "overlap_dates",
+                "prospective_information_dates", "authority_classifications",
+                "information_grade", "factor_grade", "claim",
+            )
+        },
     }
 
 
@@ -1295,7 +1388,9 @@ def write_pages_projection(
         except Exception as exc:
             issues = [f"judgment overlay parse failed: {exc}"]
             overlay = {}
-    projection = compile_pages_projection(packet, overlay, issues)
+    projection = compile_pages_projection(
+        packet, overlay, issues, add_alpha_run_card=_latest_add_alpha_run_card()
+    )
     _atomic_write(output_path, projection)
     return projection, issues
 

--- a/src/clawock/evidence/build_evidence.py
+++ b/src/clawock/evidence/build_evidence.py
@@ -257,6 +257,51 @@ def cross_sectional_section() -> dict | None:
     }
 
 
+def add_alpha_section() -> dict | None:
+    """The new add interaction, kept separate from legacy add decisions."""
+    card = _latest_card('add_alpha_walkforward')
+    if not card:
+        return None
+    metrics = card.get('metrics') or {}
+    coverage = metrics.get('coverage') or {}
+    rows = []
+    for market in ('us', 'hk'):
+        interaction = ((metrics.get(market) or {}).get('interaction') or {})
+        for horizon in ('t1', 't5', 't20'):
+            stat = interaction.get(horizon) or {}
+            n = int(stat.get('n') or 0)
+            if not n:
+                value = 'collecting · n=0（不显示为 0%）'
+            else:
+                value = (f"n={n} · mean {_pct(stat.get('mean_return'), 2)} · "
+                         f"hit {_pct(stat.get('hit_rate'), 1)} · "
+                         f"{stat.get('status') or 'collecting'}")
+            rows.append((f'`{market.upper()} {horizon.upper()} interaction`', value))
+    authority = coverage.get('authority_classifications') or {}
+    rows += [
+        ('覆盖日期',
+         f"factor {coverage.get('factor_dates')} · information "
+         f"{coverage.get('information_dates')} · overlap {coverage.get('overlap_dates')}"),
+        ('前瞻信息日期', str(coverage.get('prospective_information_dates'))),
+        ('authority 分类',
+         f"none {authority.get('none', 0)} · exploration "
+         f"{authority.get('exploration', 0)} · validated {authority.get('validated', 0)}"),
+    ]
+    return {
+        'title': '低频加仓交互（新 campaign）',
+        'verdict': VERDICT['undecided'],
+        'rows': rows,
+        'reading': (
+            "价格相对强弱与点时信息必须共同出现；技术位只安排已经获准的 tranche。"
+            "当前 run card 是 current-universe / legacy-news replay，且前瞻信息日期仍为 0，"
+            "所以只用于收集与诊断，**不是 validated alpha**。旧账本里的 "
+            "`add_only_on_trigger` 是 mixed/legacy 样本，不计作这套 campaign 的成绩。"),
+        'source': f"run card `{card.get('run_id')}`",
+        'sample': f"factor {coverage.get('factor_dates')} 日 × information "
+                  f"{coverage.get('information_dates')} 日",
+    }
+
+
 def render(sections: list[dict], generated_at: str) -> str:
     lines = [
         '---',
@@ -289,7 +334,8 @@ def render(sections: list[dict], generated_at: str) -> str:
 
 
 def build() -> str:
-    builders = (dial_section, factor_section, cross_sectional_section)
+    builders = (dial_section, factor_section, cross_sectional_section,
+                add_alpha_section)
     sections = [section for section in (build() for build in builders) if section]
     audit = _load(DATA / 'decision_audit.json') or {}
     return render(sections, audit.get('as_of') or 'unknown')

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -190,6 +190,86 @@ async function testRuntime(browser, base) {
   assert.deepEqual(mismatchState.errors, []);
 }
 
+async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const state = observe(page);
+  await stubLiveOrigin(page);
+  await page.route(/\/assets\/data\/brief_projection\.json(?:\?.*)?$/, async route => {
+    const payload = JSON.parse(fs.readFileSync(
+      path.resolve(ROOT, "assets/data/brief_projection.json"), "utf8"));
+    const dashboard = JSON.parse(fs.readFileSync(
+      path.resolve(ROOT, "assets/data/dashboard.json"), "utf8"));
+    const active = [...(dashboard.holdings?.us || []), ...(dashboard.holdings?.hk || [])]
+      .filter(row => row && row.is_active !== false && (row.shares ?? 0) > 0);
+    assert(active.length > 1, "fixture needs current holdings");
+    // Remove a genuinely active name and add a zero-share name. The old
+    // implementation rendered the sidecar verbatim, so it both retained
+    // CLOSED and silently dropped the active name.
+    payload.tickers = (payload.tickers || [])
+      .filter(row => row.ticker !== active[0].ticker)
+      .concat([{
+        ticker: "CLOSED", leg: "US", facts: {}, technical: {}, risk: {},
+        status: { rank: 5, label: "stale", state: "neutral" },
+      }]);
+    payload.add_campaign = {
+      status: "current", packet_generated_at: "2026-08-13T08:00:00+08:00",
+      diagnostics: { held_names: active.length, authority_candidate_count: 0,
+        tier_counts: { validated: 0, exploration: 0, none: active.length } },
+      candidates: [
+        { ticker: active[0].ticker, leg: "US", state: "insufficient_evidence",
+          tier: "none", evidence_families: [], authority_blockers:
+          ["independent_evidence_families"], execution_blockers: [],
+          target_tranche_level: 0, max_add_shares: 0 },
+        { ticker: active[1].ticker, leg: "HK", state: "waiting_timing",
+          tier: "exploration", evidence_families:
+          ["price_relative", "point_in_time_information"],
+          sources: ["factor", "information"], authority_blockers: [],
+          execution_blockers: [], target_tranche_level: 0.25, max_add_shares: 1 },
+      ],
+      run_card: { run_id: "add_alpha_walkforward-fixture", coverage: {
+        factor_dates: 11, information_dates: 12, overlap_dates: 10,
+        prospective_information_dates: 0,
+        authority_classifications: { none: 186, exploration: 6, validated: 0 },
+      }, markets: {
+        us: { t1: { n: 4, mean_return: .03, hit_rate: 1 },
+          t5: { n: 0, status: "collecting" }, t20: { n: 0, status: "collecting" } },
+        hk: { t1: { n: 2, mean_return: .01, hit_rate: .5 },
+          t5: { n: 0, status: "collecting" }, t20: { n: 0, status: "collecting" } },
+      }},
+    };
+    await route.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify(payload) });
+  });
+  await page.goto(base + "#drill", { waitUntil: "domcontentloaded" });
+  await waitForTab(page, "drill");
+
+  const membership = await page.evaluate(() => {
+    const active = [...(DATA.holdings?.us || []), ...(DATA.holdings?.hk || [])]
+      .filter(row => row && row.is_active !== false && (row.shares ?? 0) > 0)
+      .map(row => row.ticker).sort();
+    const rendered = [...document.querySelectorAll("#decision-matrix-tbody tr td:first-child strong")]
+      .map(cell => cell.textContent.trim()).sort();
+    return { active, rendered };
+  });
+  assert.deepEqual(membership.rendered, membership.active,
+    "stale brief projection still owns current-holdings membership");
+  assert(!membership.rendered.includes("CLOSED"), "sold-out projection row survived");
+  assert.match(await page.locator("#add-campaign-card").innerText(), /US ·|HK ·/,
+    "campaign did not keep markets separate");
+  assert.match(await page.locator("#add-campaign-card").innerText(), /collecting · n=0/,
+    "zero sample was rendered as performance instead of collecting");
+
+  await page.click('.tab-btn[data-tab="reflect"]');
+  await waitForTab(page, "reflect");
+  const legacy = page.locator("#plan-bucket-bars .name", {
+    hasText: "add_only_on_trigger",
+  });
+  if (await legacy.count()) assert.match(await legacy.first().innerText(), /legacy\/mixed/);
+  assert.deepEqual(state.failures, []);
+  assert.deepEqual(state.errors, []);
+  await page.close();
+}
+
 async function testLiveDataOrigin(browser, base) {
   // The first paint must stay on this origin. `overview.json` is the only fetch
   // on the LCP path, so a second origin's handshake there is paid by every cold
@@ -518,6 +598,7 @@ async function main() {
   } : {});
   try {
     await testRuntime(browser, base);
+    await testCurrentHoldingsOwnDecisionMatrixMembership(browser, base);
     await testLiveDataOrigin(browser, base);
     await testEquityTouch(browser, base);
     await testTabGuardWithoutForcedLayout(browser, base);

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -327,6 +327,90 @@ def test_invalid_overlay_cannot_corrupt_deterministic_pages_rows(tmp_path):
     assert json.loads(output_path.read_text()) == projection
 
 
+def test_pages_projection_exposes_add_campaign_without_raw_run_card_inputs():
+    context = _context()
+    context["cross_sectional_factor"] = {
+        "activation": {"usable_for_decisions": False},
+        "live_rankings": {"00100": {
+            "feature_as_of": "2026-07-28", "market_percentile": 0.9,
+            "sector_universe_size": 6, "factor_coverage_pct": 95,
+            "usable_for_decisions": False,
+        }},
+    }
+    context["news_evidence_graph"]["information_overlay"] = {
+        "as_of": "2026-07-28T08:00:00+08:00", "status": "warming_up",
+        "usable_for_decisions": False, "activation": {"blockers": []},
+        "tickers": {"00100": {
+            "status": "warming_up", "usable_for_decisions": False,
+            "signed_score": 0.2, "event_components": [{
+                "event_id": "positive-1", "direction": 1, "novelty": 1,
+                "reliability": 0.9, "price_nonreaction": 1,
+            }],
+        }},
+    }
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    card = {
+        "run_id": "add_alpha_walkforward-fixture", "generated_at": "now",
+        "reproduction_key": "sha256:fixture", "inputs": [{"raw": "vendor"}],
+        "params": {"policy_version": 2, "parameter_fit": "none"},
+        "metrics": {
+            "us": {"interaction": {
+                "t1": {"n": 4, "n_dates": 4, "n_tickers": 1,
+                       "mean_return": 0.03, "hit_rate": 1, "status": "collecting"},
+                "t5": {"n": 0, "status": "collecting"},
+                "t20": {"n": 0, "status": "collecting"},
+            }},
+            "hk": {"interaction": {
+                horizon: {"n": 0, "status": "collecting"}
+                for horizon in ("t1", "t5", "t20")
+            }},
+            "coverage": {
+                "factor_dates": 11, "information_dates": 12,
+                "overlap_dates": 10, "prospective_information_dates": 0,
+                "authority_classifications": {"none": 186, "exploration": 6,
+                                               "validated": 0},
+                "claim": "diagnostic_not_validated_alpha",
+            },
+        },
+    }
+
+    projection = packet_mod.compile_pages_projection(
+        packet, add_alpha_run_card=card
+    )
+    campaign = projection["add_campaign"]
+    assert campaign["status"] == "current"
+    assert campaign["diagnostics"]["held_names"] == 3
+    assert [row["ticker"] for row in campaign["candidates"]] == [
+        "00100", "HK2", "LEVX",
+    ]
+    hk = next(row for row in campaign["candidates"] if row["ticker"] == "00100")
+    assert "price_relative" in hk["evidence_families"]
+    assert set(hk) >= {
+        "state", "tier", "sources", "evidence_families",
+        "authority_blockers", "execution_blockers", "entry_price",
+        "invalidation_price", "target_tranche_level", "max_add_shares",
+    }
+    run_card = campaign["run_card"]
+    assert run_card["markets"]["us"]["t1"]["n"] == 4
+    assert run_card["markets"]["hk"]["t20"]["status"] == "collecting"
+    assert run_card["coverage"]["prospective_information_dates"] == 0
+    assert "inputs" not in run_card
+
+
+def test_pages_projection_names_a_packet_that_predates_add_policy():
+    packet = _compiled()
+    packet.pop("add_alpha_diagnostics")
+    packet.pop("add_alpha_policy")
+
+    campaign = packet_mod.compile_pages_projection(packet)["add_campaign"]
+
+    assert campaign["status"] == "pre_policy_packet"
+    assert campaign["diagnostics"] is None
+    assert campaign["candidates"] == []
+
+
 def test_plan_is_constrained_by_harness_actions_evidence_and_inventory():
     packet = _compiled()
     good = {
@@ -618,8 +702,10 @@ def test_pages_prefers_projection_and_keeps_a_backward_fallback():
     assert 'brief_projection: "drill"' in ui
     assert 'safe(DATA, "brief_projection")' in renderer
     assert "projection.schema_version === 1" in renderer
-    assert "projected.length" in renderer
-    assert ": holds.map" in renderer
+    assert "const projectedByTicker = new Map" in renderer
+    assert "const enriched = holds.map" in renderer
+    assert "projectedByTicker.get(h.ticker)" in renderer
+    assert "(h.shares ?? 0) > 0" in renderer
     # The compiled status schema is {rank, label, state}; keep the Pages
     # consumer on the same key so a populated projection cannot print
     # JavaScript's literal "undefined" in the 综合 column.

--- a/tests/test_build_evidence.py
+++ b/tests/test_build_evidence.py
@@ -91,6 +91,42 @@ def test_regenerating_the_page_is_idempotent():
     assert ev.build() == ev.build()
 
 
+def test_add_campaign_is_separate_and_zero_samples_stay_collecting(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(ev, "CARDS", tmp_path)
+    (tmp_path / "add_alpha_walkforward-20260812-fixture.json").write_text(
+        json.dumps({
+            "run_id": "add_alpha_walkforward-20260812-fixture",
+            "metrics": {
+                "us": {"interaction": {
+                    "t1": {"n": 4, "mean_return": .031, "hit_rate": 1,
+                           "status": "collecting"},
+                    "t5": {"n": 0, "status": "collecting"},
+                    "t20": {"n": 0, "status": "collecting"},
+                }},
+                "hk": {"interaction": {
+                    horizon: {"n": 0, "status": "collecting"}
+                    for horizon in ("t1", "t5", "t20")
+                }},
+                "coverage": {"factor_dates": 11, "information_dates": 12,
+                             "overlap_dates": 10,
+                             "prospective_information_dates": 0,
+                             "authority_classifications": {
+                                 "none": 186, "exploration": 6, "validated": 0,
+                             }},
+            },
+        })
+    )
+
+    section = ev.add_alpha_section()
+
+    assert section["verdict"] == ev.VERDICT["undecided"]
+    assert "不是 validated alpha" in section["reading"]
+    assert "mixed/legacy" in section["reading"]
+    assert any("collecting · n=0" in value for _, value in section["rows"])
+    assert not any("0.0%" in value for _, value in section["rows"] if "n=0" in value)
+
+
 def test_not_yet_elapsed_is_neither_a_pass_nor_a_failure(tmp_path, monkeypatch):
     """A prospective criterion at zero while its forward window has not elapsed
     is waiting, not failing. Rendering the two the same is the exact conflation


### PR DESCRIPTION
Closes #517.
Closes #518.

## Outcome

- publishes the existing daily `add_alpha_diagnostics` through the bounded
  `brief_projection.json` instead of exposing the raw decision packet
- adds a Holdings → Add Campaign card with separate US/HK ticker states,
  authority tiers, evidence families/sources, authority vs execution blockers,
  tranche/entry/invalidation, packet timestamp and generation
- projects only the latest run card's derived interaction metrics and coverage;
  raw vendor inputs stay repository-only
- renders zero samples as `collecting · n=0` and labels the independent receipt
  diagnostic/not validated alpha
- adds the same run-card evidence to the generated Evidence page
- labels Reflect's generic `add_only_on_trigger` bucket `legacy/mixed`
- corrects both README Shadow Portfolio links to Holdings
- makes latest positive-share dashboard holdings own the decision-matrix row
  set; a stale brief may enrich a matching ticker but cannot retain sold-out
  names or omit a newly opened holding

No portfolio/trade history is deleted. Closed positions remain in the ledger
and historical evaluation; they leave only the current-holdings surface.

## Verification

- `192 passed` across README parity, sidecar validation/ownership, decision
  packet/projection, Evidence, desktop layout, tab lifecycle and Pages contracts
- `node tests/dashboard_tab_runtime.spec.js` passed twice in Chromium
- rendered mutation fixture adds a fake `CLOSED` projection row and removes a
  real active row: the matrix still exactly equals current active holdings
- rendered fixture verifies market-separated campaign output and that empty
  horizons show collecting rather than 0% performance
- `node --check site/assets/js/dashboard.render.js`
- `git diff --check`

## Production boundary

The most recent real brief packet predates the campaign merge. The new surface
therefore says `pre-policy packet` until the next postflight writes a real
current receipt; it does not relabel that old packet as zero authority.

