### PR TITLE
brief: fail when Pages projection stays stale

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -508,7 +508,7 @@ def log_decisions(today):
     print(f'  decisions.jsonl: +{inserted}, updated {updated}, settled {settled} ({len(ledger)} total)')
 
 
-def write_publish_gate(status, today):
+def write_publish_gate(status, today, *, reason=None):
     """Machine-readable publish gate the off-host fallback workflow reads before it
     commits. The fallback runs on a fresh GH-Action checkout where a broad
     `git add … && commit && push` is its own committer and cannot see maybe_commit's
@@ -518,6 +518,8 @@ def write_publish_gate(status, today):
     do-not-publish, so only an explicit publish_ok=true releases a commit."""
     gate = {'today': today, 'status': status, 'publish_ok': status != 'fail',
             'written_at': datetime.now().isoformat()}
+    if reason:
+        gate['reason'] = reason
     p = WS / 'logs' / 'brief_postflight_status.json'
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(gate, ensure_ascii=False) + '\n')
@@ -714,10 +716,12 @@ def main(argv=None):
         issue_count=len(issues),
         readability=readability,
     )
-    # Emit the cross-process publish gate BEFORE anything else can raise, so the
-    # off-host workflow's committer has an explicit verdict (and a crash leaves no
-    # file → fail-closed).
-    write_publish_gate(status, today)
+    # Emit a CLOSED cross-process gate before anything else can raise.  A valid
+    # brief is not yet a publishable generation: the deterministic Pages
+    # projection below is part of that generation too.  Releasing pass/warn here
+    # let a projection exception preserve yesterday's sidecar while the fallback
+    # workflow committed everything else and reported green (#520).
+    write_publish_gate('fail', today, reason='pending_pages_projection')
 
     # Pages consumes a versioned projection, not the model's raw files.  Missing
     # or invalid prose is isolated: deterministic technical/risk rows still
@@ -740,6 +744,22 @@ def main(argv=None):
             projection_issues = [str(exc)]
             print(f'warn: brief Pages projection failed: {exc}', file=sys.stderr)
 
+    projection_ready = (
+        args.dry_run
+        or status == 'fail'
+        or projection_status in {'valid', 'missing', 'invalid'}
+    )
+    publication_status = status if projection_ready else 'fail'
+    # This is the only release of the off-host committer.  Judgment validity is
+    # deliberately not required: missing/invalid prose still writes a complete
+    # deterministic projection.  A writer exception or absent decision packet is
+    # different — no current generation was produced.
+    write_publish_gate(
+        publication_status,
+        today,
+        reason=None if projection_ready else 'pages_projection_failed',
+    )
+
     if status == 'pass':
         wechat_prefix = ''
     elif status == 'warn':
@@ -753,8 +773,11 @@ def main(argv=None):
                          + ('\n- ...' if len(issues) > 5 else '')
                          + '\n\n')
 
-    commit_ok, commit_msg = maybe_commit(status, today, dry_run=args.dry_run)
-    if status in ('pass', 'warn') and not args.dry_run:
+    commit_ok, commit_msg = maybe_commit(
+        publication_status, today, dry_run=args.dry_run
+    )
+    if (status in ('pass', 'warn') and projection_ready
+            and not args.dry_run):
         data_plane_status = dashboard_publication_state(WS)
     else:
         data_plane_status = 'skipped'
@@ -857,6 +880,7 @@ def main(argv=None):
         'data_plane_status': data_plane_status,
         'projection_status': projection_status,
         'projection_issues': projection_issues,
+        'publication_ready': projection_ready,
         'readability': readability,
         'files_checked': {
             'pre_open_md':  str(md_path),
@@ -869,9 +893,11 @@ def main(argv=None):
         job_name,
         'postflight',
         ('success'
-         if status == 'pass' and data_plane_status in {'published', 'skipped'}
+         if (status == 'pass' and projection_ready
+             and data_plane_status in {'published', 'skipped'})
          else ('warning'
-               if status == 'warn' and data_plane_status in {'published', 'skipped'}
+               if (status == 'warn' and projection_ready
+                   and data_plane_status in {'published', 'skipped'})
                else 'failed')),
         slot=slot,
         dry_run=args.dry_run,
@@ -890,7 +916,7 @@ def main(argv=None):
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if (not args.dry_run and status in ('pass', 'warn')
-            and data_plane_status != 'published'):
+            and (not projection_ready or data_plane_status != 'published')):
         return 2
     return 0 if status == 'pass' else (1 if status == 'warn' else 2)
 

--- a/tests/test_brief_projection_publication_gate.py
+++ b/tests/test_brief_projection_publication_gate.py
@@ -1,0 +1,119 @@
+"""A green brief may not publish while its Pages projection stays stale."""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+
+from clawock_kcnyu.harness import brief_postflight as postflight
+
+
+def _run_postflight(tmp_path, monkeypatch, capsys, *, projection_error=None):
+    today = datetime.now().strftime('%Y-%m-%d')
+    context_path = tmp_path / 'memory' / '.tmp' / f'brief-context-{today}.json'
+    context_path.parent.mkdir(parents=True)
+    context_path.write_text(json.dumps({'generation_id': 'generation-fixture'}))
+
+    stages = []
+    commits = []
+    monkeypatch.setattr(postflight, 'WS', tmp_path)
+    monkeypatch.setattr(
+        postflight.trading_calendar, 'closed_reason', lambda _market: None
+    )
+    monkeypatch.setattr(
+        postflight.workflow_outcomes, 'slot_for_job', lambda _job: 'slot'
+    )
+    monkeypatch.setattr(
+        postflight.workflow_outcomes,
+        'record_stage',
+        lambda job, stage, state, **fields: stages.append(
+            (job, stage, state, fields)
+        ),
+    )
+    monkeypatch.setattr(
+        postflight.brief_context, 'validate_run_bundle', lambda *_args: []
+    )
+    monkeypatch.setattr(
+        postflight.brief_decision_packet,
+        'read_packet',
+        lambda _manifest: {'_meta': {'generation_id': 'generation-fixture'}},
+    )
+    monkeypatch.setattr(postflight, 'validate_markdown', lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        postflight, 'readability_issues', lambda _readability: []
+    )
+    monkeypatch.setattr(
+        postflight,
+        'normalize_plan_json',
+        lambda *_a, **_k: ([], {'decisions': []}),
+    )
+    monkeypatch.setattr(postflight, 'validate_plan_json', lambda *_a, **_k: [])
+    monkeypatch.setattr(postflight, 'already_delivered', lambda _path: True)
+
+    def maybe_commit(status, _today, dry_run=False):
+        commits.append((status, dry_run))
+        return ((True, 'committed + pushed') if status != 'fail'
+                else (False, 'skipped (status=fail)'))
+
+    monkeypatch.setattr(postflight, 'maybe_commit', maybe_commit)
+    monkeypatch.setattr(
+        postflight, 'dashboard_publication_state', lambda _ws: 'published'
+    )
+
+    if projection_error:
+        def write_projection(*_args):
+            raise RuntimeError(projection_error)
+    else:
+        def write_projection(_packet, _judgment, output):
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text('{}')
+            return {'judgment_status': 'missing'}, []
+    monkeypatch.setattr(
+        postflight.brief_decision_packet,
+        'write_pages_projection',
+        write_projection,
+    )
+    monkeypatch.setattr(sys, 'argv', ['brief_postflight.py'])
+
+    code = postflight.main()
+    result = json.loads(capsys.readouterr().out)
+    gate = json.loads(
+        (tmp_path / 'logs' / 'brief_postflight_status.json').read_text()
+    )
+    return code, result, gate, commits, stages
+
+
+def test_projection_failure_keeps_publish_gate_closed_and_fails_stage(
+    tmp_path, monkeypatch, capsys
+):
+    code, result, gate, commits, stages = _run_postflight(
+        tmp_path, monkeypatch, capsys, projection_error='disk full'
+    )
+
+    assert code == 2
+    assert result['status'] == 'pass'
+    assert result['projection_status'] == 'failed'
+    assert result['projection_issues'] == ['disk full']
+    assert result['publication_ready'] is False
+    assert commits == [('fail', False)]
+    assert gate['publish_ok'] is False
+    assert gate['reason'] == 'pages_projection_failed'
+    assert next(state for _, stage, state, _ in stages
+                if stage == 'postflight') == 'failed'
+
+
+def test_written_deterministic_projection_releases_existing_publish_route(
+    tmp_path, monkeypatch, capsys
+):
+    code, result, gate, commits, stages = _run_postflight(
+        tmp_path, monkeypatch, capsys
+    )
+
+    assert code == 0
+    assert result['projection_status'] == 'missing'
+    assert result['publication_ready'] is True
+    assert commits == [('pass', False)]
+    assert gate['publish_ok'] is True
+    assert 'reason' not in gate
+    assert next(state for _, stage, state, _ in stages
+                if stage == 'postflight') == 'success'


### PR DESCRIPTION
Closes #520.

## Outcome

- changes the off-host publish gate to start closed while the deterministic
  Pages projection is still pending
- releases the gate only after `brief_projection.json` has been written for
  the current decision packet
- keeps missing/invalid judgment overlays publishable because the deterministic
  rows are still complete
- turns a projection writer exception or absent current packet into
  `publication_ready=false`, a failed postflight outcome, no commit, and exit 2
- keeps the prior valid projection intact instead of replacing it with a partial
  generation

## Behavioral proof

The new regression runs the real postflight control flow with a forced
projection writer failure. It asserts all five externally relevant facts:

- original brief validation remains `status=pass`
- projection status and exception remain explicit in JSON
- the cross-process fallback gate stays closed
- `maybe_commit` receives `status=fail`
- workflow outcome is failed and process exits 2

The paired success test verifies a deterministic projection with a missing
optional judgment overlay still follows the existing pass/commit route.

## Verification

- 75 relevant tests passed
- Python compile check passed
- `git diff --check` passed
