### PR TITLE
feat: surface early trend add candidates

### DIFF
--- a/config/add-alpha-policy.json
+++ b/config/add-alpha-policy.json
@@ -14,6 +14,8 @@
   "exploration_max_tranches": 1,
   "exploration_tranche_pct": 0.025,
   "exploration_max_book_pct": 0.03,
+  "early_peer_dispersion_multiple": 1.5,
+  "early_no_chase_zscore": 2.0,
   "validated_max_tranches": 2,
   "validated_tranche_pct": 0.075,
   "markets": {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -123,7 +123,7 @@ Sources: local snapshots + canonical bars
 | `clawock validate-regime-dial` | `clawock.evaluation.regime_validation` | out-of-sample and circular-shift null for the dial's timing |
 | `clawock shadow` | `clawock.portfolio.shadow` | replays triggered calls against buy-and-hold to measure simulated timing alpha |
 | `clawock audit-resettle` | `clawock.decision.settlement` | dry-run bar-based re-settle that reports every verdict it would change |
-| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of price-relative and information interaction adds |
+| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of mature interaction adds plus underlying-deduplicated short-history breakout candidates (T+1/T+5) |
 
 ### Not information collection / 不属于信息收集
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -123,7 +123,7 @@ Sources: local snapshots + canonical bars
 | `clawock validate-regime-dial` | `clawock.evaluation.regime_validation` | out-of-sample and circular-shift null for the dial's timing |
 | `clawock shadow` | `clawock.portfolio.shadow` | replays triggered calls against buy-and-hold to measure simulated timing alpha |
 | `clawock audit-resettle` | `clawock.decision.settlement` | dry-run bar-based re-settle that reports every verdict it would change |
-| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of mature interaction adds plus underlying-deduplicated short-history breakout candidates (T+1/T+5) |
+| `clawock evaluate-add-alpha` | `clawock.evaluation.add_alpha_walkforward` | point-in-time diagnostic replay of price-relative and information interaction adds |
 
 ### Not information collection / 不属于信息收集
 

--- a/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/_watchdog_common.py
@@ -176,24 +176,148 @@ KCN_TELEGRAM = '2033937852'
 # Public full-brief link (rendered from memory/{date}-pre-open.md by GH Pages).
 BRIEF_URL_TMPL = 'https://kcnyu.github.io/clawock/memory/{date}-pre-open.html'
 
+_EARLY_SECTION_HEADER = '▎提前布局候选'
+_EARLY_BLOCKER_LABELS = {
+    'needs_primary_evidence': '缺一手披露',
+    'needs_information_confirmation': '缺独立消息确认',
+    'overheated_wait_rebreak': '过热，等回踩再突破',
+    'leveraged_requires_validated_evidence': '杠杆代理仅观察',
+    'no_20d_breakout': '未突破20日高',
+    'no_short_peer_leadership': '短期同业领先不足',
+}
+_EARLY_STATE_LABELS = {
+    'exploration_ready': '可小仓试探',
+    'wait_pullback_rebreak': '候选·等回踩再突破',
+    'wait_information': '候选·等消息确认',
+    'candidate_only': '候选·仅观察',
+}
 
-def build_brief_card(today):
+
+def _brief_decision_packet(today):
+    manifest = (WS / 'memory' / '.tmp' / f'brief-context-{today}' / 'manifest.json')
+    if not manifest.exists():
+        return None
+    try:
+        from clawock.decision import packet as decision_packet
+        return decision_packet.read_packet(manifest)
+    except Exception:
+        return None
+
+
+def _early_candidate_section(packet):
+    """Compact, harness-owned candidate truth, deduplicated by underlying."""
+    if not isinstance(packet, dict):
+        return ''
+    diagnostics = packet.get('add_alpha_diagnostics') or {}
+    candidates = diagnostics.get('candidates') or []
+    observed = [
+        row for row in candidates
+        if (row.get('early_trend') or {}).get('observed')
+        or row.get('tier') in {'exploration', 'validated'}
+    ]
+    by_source = {}
+    for row in observed:
+        source = str(row.get('source_ticker') or row.get('ticker') or '?')
+        current = by_source.get(source)
+        # Prefer the directly held underlying over a leveraged/proxy row.
+        if current is None or (current.get('is_proxy') and not row.get('is_proxy')):
+            by_source[source] = row
+    idea_count = len(by_source)
+    exploration_count = len({
+        str(row.get('source_ticker') or row.get('ticker') or '?')
+        for row in observed
+        if (row.get('early_trend') or {}).get('exploration_ready')
+    })
+    allowed_count = sum(bool(row.get('allowed')) for row in candidates)
+    lines = [
+        _EARLY_SECTION_HEADER,
+        f'提示 {idea_count} 个底层机会 · 可小仓试探 {exploration_count} · 当前可加仓 {allowed_count}',
+    ]
+    ranked = sorted(
+        by_source.items(),
+        key=lambda item: (
+            0 if (item[1].get('early_trend') or {}).get('exploration_ready') else 1,
+            item[0],
+        ),
+    )[:2]
+    for source, row in ranked:
+        early = row.get('early_trend') or {}
+        state = _EARLY_STATE_LABELS.get(
+            early.get('state'), early.get('state') or row.get('state') or '候选'
+        )
+        proxies = sorted({
+            str(candidate.get('ticker')) for candidate in observed
+            if str(candidate.get('source_ticker') or candidate.get('ticker')) == source
+            and candidate.get('is_proxy')
+        })
+        name = source + (f"（{','.join(proxies)} 映射）" if proxies else '')
+        blockers = [
+            _EARLY_BLOCKER_LABELS.get(blocker, blocker)
+            for blocker in early.get('blockers') or []
+            if blocker in _EARLY_BLOCKER_LABELS
+        ][:2]
+        suffix = f"；{'、'.join(blockers)}" if blockers else ''
+        lines.append(f'- {name}: {state}{suffix}')
+    if not ranked:
+        lines.append('- 暂无确定性提前提示；不是“模型没写”，而是价格/同业条件未同时成立')
+    return '\n'.join(lines)
+
+
+def _inject_early_candidate_section(card, packet):
+    section = _early_candidate_section(packet)
+    if not section:
+        return card
+    lines = card.splitlines()
+    start = next(
+        (index for index, line in enumerate(lines)
+         if line.strip() == _EARLY_SECTION_HEADER),
+        None,
+    )
+    if start is not None:
+        end = start + 1
+        while end < len(lines):
+            stripped = lines[end].strip()
+            if stripped.startswith('▎') or stripped.startswith('📈'):
+                break
+            end += 1
+        lines[start:end] = section.splitlines() + ['']
+        return '\n'.join(lines).strip()
+    insert = next(
+        (index for index, line in enumerate(lines)
+         if line.strip().startswith('📈')),
+        len(lines),
+    )
+    prefix = lines[:insert]
+    suffix = lines[insert:]
+    if prefix and prefix[-1].strip():
+        prefix.append('')
+    prefix.extend(section.splitlines())
+    if suffix:
+        prefix.append('')
+    return '\n'.join(prefix + suffix).strip()
+
+
+def build_brief_card(today, decision_packet=None):
     """The WeChat card for the 08:00 盘前深度简报 — single source of truth shared by
     brief_postflight (primary send) and brief_watchdog (backstop).
 
     Preference order:
       1. LLM-written card at memory/.tmp/brief-card-{date}.txt — the rich TL;DR
-         (核心结论 narrative) the model composes in the SKILL's Step 5. Sent verbatim.
+         (核心结论 narrative) the model composes in the SKILL's Step 5.
       2. Deterministic fallback from memory/{date}-plan.json (book + ≤4 decisions +
          full-brief link) if the model didn't write the card file — never silent.
+
+    In both paths the harness inserts/replaces the deterministic early-candidate
+    section from the generation-bound packet. Model omission cannot hide it.
     """
     url = BRIEF_URL_TMPL.format(date=today)
+    decision_packet = decision_packet or _brief_decision_packet(today)
     card_file = WS / 'memory' / '.tmp' / f'brief-card-{today}.txt'
     try:
         if card_file.exists():
             txt = card_file.read_text().strip()
             if txt:
-                return txt
+                return _inject_early_candidate_section(txt, decision_packet)
     except Exception:
         pass  # fall through to deterministic build
     lines = [f'📊 盘前深度简报｜{today} 08:00 HKT']
@@ -216,7 +340,7 @@ def build_brief_card(today):
     except Exception:
         pass  # link-only fallback
     lines += ['', f'📈 完整报告：{url}']
-    return '\n'.join(lines)
+    return _inject_early_candidate_section('\n'.join(lines), decision_packet)
 
 
 def resolve_wechat_target(market=None):

--- a/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/brief_postflight.py
@@ -807,7 +807,7 @@ def main(argv=None):
         except Exception:
             pass
     elif status in ('pass', 'warn'):
-        card = build_brief_card(today)
+        card = build_brief_card(today, decision_packet=decision_packet)
         message = (wechat_prefix + card).strip()
         first_line = card.strip().splitlines()[0] if card.strip() else ''
         # Take the send right before sending, not after (#508). The marker below

--- a/memory/backtests/add_alpha_walkforward-20260813-3a918d77.json
+++ b/memory/backtests/add_alpha_walkforward-20260813-3a918d77.json
@@ -1,0 +1,852 @@
+{
+  "schema_version": 1,
+  "run_id": "add_alpha_walkforward-20260813-3a918d77",
+  "backtest": "add_alpha_walkforward",
+  "generated_at": "2026-08-13T14:21:11+00:00",
+  "git_commit": "5c8bdce8",
+  "reproduction_key": "sha256:3a918d77d204699a",
+  "params": {
+    "horizons": [
+      1,
+      5,
+      20
+    ],
+    "entry": "production alpha_confirmation; next session; invalidation first; gap aware",
+    "confirmation_window_sessions": 5,
+    "variants": [
+      "setup_only",
+      "price_relative",
+      "information",
+      "interaction"
+    ],
+    "early_variants": [
+      "observed",
+      "information_confirmed",
+      "exploration_ready"
+    ],
+    "policy_version": 2,
+    "parameter_fit": "none; pre-registered thresholds"
+  },
+  "inputs": [
+    {
+      "symbol": "cross_sectional_factor_history.jsonl",
+      "source": "registered factor snapshots",
+      "bars": 14,
+      "first_session": "2026-07-24",
+      "last_session": "2026-08-13",
+      "digest": "sha256:e18ee56962f65502"
+    },
+    {
+      "symbol": "peer_residual_history.jsonl",
+      "source": "registered peer-residual snapshots",
+      "bars": 14,
+      "first_session": "2026-07-24",
+      "last_session": "2026-08-13",
+      "digest": "sha256:276944722f4d206b"
+    },
+    {
+      "symbol": "news_evidence_history.jsonl",
+      "source": "point-in-time news evidence snapshots",
+      "bars": 14,
+      "first_session": "2026-07-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:c9a73c79f8d6d201"
+    },
+    {
+      "symbol": "00100",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 145,
+      "first_session": "2026-01-09",
+      "last_session": "2026-08-13",
+      "digest": "sha256:77280508ed148d71"
+    },
+    {
+      "symbol": "02513",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 146,
+      "first_session": "2026-01-08",
+      "last_session": "2026-08-13",
+      "digest": "sha256:ba78af2e3d853d22"
+    },
+    {
+      "symbol": "01384",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 194,
+      "first_session": "2025-10-28",
+      "last_session": "2026-08-13",
+      "digest": "sha256:92ddb50d9e360c50"
+    },
+    {
+      "symbol": "09678",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 277,
+      "first_session": "2025-06-30",
+      "last_session": "2026-08-13",
+      "digest": "sha256:5756f58b66b4e9a6"
+    },
+    {
+      "symbol": "06682",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:d23c7e79432c9bbd"
+    },
+    {
+      "symbol": "00020",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:e05aa573cf0fd7a6"
+    },
+    {
+      "symbol": "02208",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:c90e15548754bf11"
+    },
+    {
+      "symbol": "00916",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:ee7531db0747fb1a"
+    },
+    {
+      "symbol": "01798",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:51421dfe476d8488"
+    },
+    {
+      "symbol": "00956",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:287a309c6c7cae83"
+    },
+    {
+      "symbol": "01072",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:674d0bd4aa15f78b"
+    },
+    {
+      "symbol": "03032",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:ea31ee1636d7c07c"
+    },
+    {
+      "symbol": "03033",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 420,
+      "first_session": "2024-11-26",
+      "last_session": "2026-08-13",
+      "digest": "sha256:745e09da5d69c15c"
+    },
+    {
+      "symbol": "RKLB",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:c5f32f99ffb96231"
+    },
+    {
+      "symbol": "ASTS",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a47d4cff7b7dd837"
+    },
+    {
+      "symbol": "BKSY",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:3b116cecd026324a"
+    },
+    {
+      "symbol": "IRDM",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:deb90c876df79f03"
+    },
+    {
+      "symbol": "LMT",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:c46dccb946812dfd"
+    },
+    {
+      "symbol": "SPCX",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 43,
+      "first_session": "2026-06-12",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a9e0c70646de9a91"
+    },
+    {
+      "symbol": "CRCL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 299,
+      "first_session": "2025-06-05",
+      "last_session": "2026-08-13",
+      "digest": "sha256:e85d7391a637344e"
+    },
+    {
+      "symbol": "COIN",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:ff4be92ec788f6a1"
+    },
+    {
+      "symbol": "HOOD",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:df217fb51b180c45"
+    },
+    {
+      "symbol": "PYPL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a43acc11b7c55c24"
+    },
+    {
+      "symbol": "XYZ",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:4199949e383cb077"
+    },
+    {
+      "symbol": "PLTR",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a045aa9028b0c3cb"
+    },
+    {
+      "symbol": "SNOW",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:4e53e3ecfa597075"
+    },
+    {
+      "symbol": "DDOG",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:069492da4aa674ee"
+    },
+    {
+      "symbol": "NET",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:c4a8fd4e5badb71d"
+    },
+    {
+      "symbol": "MSFT",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:0e48c7e7cd22dd8a"
+    },
+    {
+      "symbol": "GOOGL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:d2eb155bed8e5231"
+    },
+    {
+      "symbol": "AAPL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:78a4d289e9444215"
+    },
+    {
+      "symbol": "META",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:7cf5a64a067bcc5b"
+    },
+    {
+      "symbol": "ORCL",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a163403bbbb34e42"
+    },
+    {
+      "symbol": "SKHY",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 25,
+      "first_session": "2026-07-10",
+      "last_session": "2026-08-13",
+      "digest": "sha256:e96f476792296b36"
+    },
+    {
+      "symbol": "MU",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:f28c056788110657"
+    },
+    {
+      "symbol": "WDC",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:0e63e69cccff2d65"
+    },
+    {
+      "symbol": "STX",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:e6c93159b5637df5"
+    },
+    {
+      "symbol": "NVDA",
+      "source": "Tencent qfq daily OHLC",
+      "bars": 421,
+      "first_session": "2024-12-06",
+      "last_session": "2026-08-13",
+      "digest": "sha256:a441a8c1c70e6093"
+    }
+  ],
+  "code": [
+    {
+      "file": "add_alpha_walkforward.py",
+      "digest": "sha256:d02acb8d6f56e065"
+    },
+    {
+      "file": "add_alpha.py",
+      "digest": "sha256:fc196042266437f3"
+    },
+    {
+      "file": "early_trend.py",
+      "digest": "sha256:cffd27223c1a71ef"
+    }
+  ],
+  "metrics": {
+    "us": {
+      "setup_only": {
+        "t1": {
+          "n": 134,
+          "n_dates": 12,
+          "n_tickers": 21,
+          "mean_return": 0.011768,
+          "hit_rate": 0.5821,
+          "mean_excess_vs_same_date_setup": -0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 84,
+          "n_dates": 9,
+          "n_tickers": 20,
+          "mean_return": 0.037762,
+          "hit_rate": 0.7619,
+          "mean_excess_vs_same_date_setup": 0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "price_relative": {
+        "t1": {
+          "n": 51,
+          "n_dates": 12,
+          "n_tickers": 8,
+          "mean_return": 0.004549,
+          "hit_rate": 0.6078,
+          "mean_excess_vs_same_date_setup": -0.009858,
+          "excess_date_cluster_ci95": [
+            -0.019412,
+            -0.001208
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 37,
+          "n_dates": 9,
+          "n_tickers": 8,
+          "mean_return": 0.002896,
+          "hit_rate": 0.7027,
+          "mean_excess_vs_same_date_setup": -0.033508,
+          "excess_date_cluster_ci95": [
+            -0.045806,
+            -0.019439
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "information": {
+        "t1": {
+          "n": 15,
+          "n_dates": 9,
+          "n_tickers": 5,
+          "mean_return": 0.029605,
+          "hit_rate": 0.8667,
+          "mean_excess_vs_same_date_setup": 0.015326,
+          "excess_date_cluster_ci95": [
+            0.00124,
+            0.027445
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 9,
+          "n_dates": 6,
+          "n_tickers": 3,
+          "mean_return": 0.083284,
+          "hit_rate": 0.8889,
+          "mean_excess_vs_same_date_setup": 0.044706,
+          "excess_date_cluster_ci95": [
+            0.005849,
+            0.084999
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "interaction": {
+        "t1": {
+          "n": 4,
+          "n_dates": 4,
+          "n_tickers": 1,
+          "mean_return": 0.031052,
+          "hit_rate": 1.0,
+          "mean_excess_vs_same_date_setup": 0.013244,
+          "excess_date_cluster_ci95": [
+            -0.021929,
+            0.055877
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 4,
+          "n_dates": 4,
+          "n_tickers": 1,
+          "mean_return": 0.041296,
+          "hit_rate": 0.75,
+          "mean_excess_vs_same_date_setup": -0.002233,
+          "excess_date_cluster_ci95": [
+            -0.04664,
+            0.05479
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      }
+    },
+    "hk": {
+      "setup_only": {
+        "t1": {
+          "n": 71,
+          "n_dates": 12,
+          "n_tickers": 12,
+          "mean_return": 0.003334,
+          "hit_rate": 0.493,
+          "mean_excess_vs_same_date_setup": 0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 54,
+          "n_dates": 9,
+          "n_tickers": 12,
+          "mean_return": 0.034444,
+          "hit_rate": 0.463,
+          "mean_excess_vs_same_date_setup": 0.0,
+          "excess_date_cluster_ci95": [
+            -0.0,
+            0.0
+          ],
+          "status": "diagnostic"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "price_relative": {
+        "t1": {
+          "n": 23,
+          "n_dates": 11,
+          "n_tickers": 7,
+          "mean_return": -0.004846,
+          "hit_rate": 0.3913,
+          "mean_excess_vs_same_date_setup": -0.006961,
+          "excess_date_cluster_ci95": [
+            -0.014335,
+            0.000754
+          ],
+          "status": "diagnostic"
+        },
+        "t5": {
+          "n": 18,
+          "n_dates": 9,
+          "n_tickers": 5,
+          "mean_return": -0.029271,
+          "hit_rate": 0.2222,
+          "mean_excess_vs_same_date_setup": -0.071017,
+          "excess_date_cluster_ci95": [
+            -0.088914,
+            -0.053324
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "information": {
+        "t1": {
+          "n": 13,
+          "n_dates": 9,
+          "n_tickers": 4,
+          "mean_return": 0.014106,
+          "hit_rate": 0.6154,
+          "mean_excess_vs_same_date_setup": 0.008654,
+          "excess_date_cluster_ci95": [
+            -0.002739,
+            0.024894
+          ],
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 10,
+          "n_dates": 7,
+          "n_tickers": 4,
+          "mean_return": 0.071718,
+          "hit_rate": 0.5,
+          "mean_excess_vs_same_date_setup": 0.036004,
+          "excess_date_cluster_ci95": [
+            -0.037736,
+            0.128427
+          ],
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      },
+      "interaction": {
+        "t1": {
+          "n": 2,
+          "n_dates": 2,
+          "n_tickers": 2,
+          "mean_return": 0.017743,
+          "hit_rate": 0.5,
+          "mean_excess_vs_same_date_setup": 0.039444,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        },
+        "t5": {
+          "n": 1,
+          "n_dates": 1,
+          "n_tickers": 1,
+          "mean_return": -0.010252,
+          "hit_rate": 0.0,
+          "mean_excess_vs_same_date_setup": -0.079643,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        },
+        "t20": {
+          "n": 0,
+          "n_dates": 0,
+          "n_tickers": 0,
+          "mean_return": null,
+          "hit_rate": null,
+          "mean_excess_vs_same_date_setup": null,
+          "excess_date_cluster_ci95": null,
+          "status": "collecting"
+        }
+      }
+    },
+    "early_trend": {
+      "us": {
+        "observed": {
+          "t1": {
+            "n": 8,
+            "n_dates": 7,
+            "n_tickers": 3,
+            "mean_return": 0.005129,
+            "hit_rate": 0.5,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 5,
+            "n_dates": 4,
+            "n_tickers": 2,
+            "mean_return": 0.063911,
+            "hit_rate": 1.0,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        },
+        "information_confirmed": {
+          "t1": {
+            "n": 4,
+            "n_dates": 3,
+            "n_tickers": 2,
+            "mean_return": 0.010668,
+            "hit_rate": 0.5,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 4,
+            "n_dates": 3,
+            "n_tickers": 2,
+            "mean_return": 0.070451,
+            "hit_rate": 1.0,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        },
+        "exploration_ready": {
+          "t1": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        }
+      },
+      "hk": {
+        "observed": {
+          "t1": {
+            "n": 2,
+            "n_dates": 1,
+            "n_tickers": 2,
+            "mean_return": -0.023876,
+            "hit_rate": 0.0,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        },
+        "information_confirmed": {
+          "t1": {
+            "n": 1,
+            "n_dates": 1,
+            "n_tickers": 1,
+            "mean_return": -0.012255,
+            "hit_rate": 0.0,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        },
+        "exploration_ready": {
+          "t1": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          },
+          "t5": {
+            "n": 0,
+            "n_dates": 0,
+            "n_tickers": 0,
+            "mean_return": null,
+            "hit_rate": null,
+            "mean_excess_vs_same_date_setup": null,
+            "excess_date_cluster_ci95": null,
+            "status": "collecting"
+          }
+        }
+      }
+    },
+    "coverage": {
+      "factor_dates": 14,
+      "information_dates": 14,
+      "overlap_dates": 12,
+      "authority_classifications": {
+        "none": 217,
+        "exploration": 7,
+        "validated": 0
+      },
+      "information_grade": "retrospective_point_in_time_replay_only",
+      "factor_grade": "retrospective_current_universe_survivorship_limited",
+      "prospective_information_dates": 1,
+      "parameter_fit": "none_pre_registered_policy",
+      "claim": "diagnostic_not_validated_alpha",
+      "early_trend": {
+        "eligible_signal_dates": 139,
+        "peer_metrics_evaluated": 139,
+        "observed_candidates": 11,
+        "information_confirmed": 6,
+        "exploration_ready": 0,
+        "missing_taxonomy": 0,
+        "entry": "signal_session_close_for_measurement_only",
+        "lookahead": "features_recomputed_at_each_snapshot_date; future closes used only for outcomes",
+        "history_limit": "registered histories currently cover about 14 dates"
+      }
+    }
+  },
+  "notes": [
+    "US and HK are ranked and evaluated separately.",
+    "Production classify_authority and confirmation primitives are reused directly.",
+    "Current-universe factor history is survivorship-limited and cannot validate authority.",
+    "Legacy information replay seeds diagnostics only; prospective activation remains warming_up.",
+    "Same-day entry/invalidation ambiguity is invalidated, never assumed filled.",
+    "Early candidates are one row per underlying and use signal-date-close features with T+1/T+5 future closes only as outcomes.",
+    "The early history is small; every result remains collecting/diagnostic, never validated alpha."
+  ],
+  "data_boundary": "derived metrics and source names only; no raw vendor bars"
+}

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1350,12 +1350,15 @@
     } else {
       const d = campaign.diagnostics || {};
       const tiers = d.tier_counts || {};
-      status.textContent = `collecting · authority ${d.authority_candidate_count || 0}/${d.held_names || 0}`;
+      status.textContent = `ideas ${d.observed_idea_count ?? d.observed_candidate_count ?? 0} · authority ${d.authority_candidate_count || 0}/${d.held_names || 0}`;
       status.className = "badge muted";
       const stateLabel = {
         eligible: "可执行", waiting_timing: "等技术位", risk_blocked: "风险拦截",
         already_at_target: "tranche 已满", constraint_blocked: "约束拦截",
         insufficient_evidence: "证据不足",
+        wait_pullback_rebreak: "候选·等回踩再突破",
+        wait_information: "候选·等信息确认",
+        candidate_only: "候选·仅观察",
       };
       const blockerLabel = {
         independent_evidence_families: "缺独立证据族",
@@ -1366,6 +1369,11 @@
         tranche_below_market_unit: "低于交易单位",
         open_add_order: "已有未结加仓",
         no_approved_setup: "无授权 setup",
+        no_20d_breakout: "未突破20日高",
+        no_short_peer_leadership: "短期同行领先不足",
+        needs_information_confirmation: "等信息确认",
+        needs_primary_evidence: "缺一手证据",
+        overheated_wait_rebreak: "过热·等回踩再突破",
       };
       const rows = (campaign.candidates || []).slice().sort((a, b) =>
         String(a.leg || "").localeCompare(String(b.leg || "")) ||
@@ -1380,15 +1388,19 @@
             const sources = (row.sources || []).join(" + ") || "—";
             const prices = row.entry_price == null ? "未授权入场位" :
               `entry ${row.entry_price} · invalid ${row.invalidation_price ?? "—"}`;
+            const early = row.early_trend || {};
+            const earlyMetrics = early.metrics || {};
+            const earlyLine = early.observed ? `<div class="campaign-detail"><b>early hint</b> ${escapeHtml((early.price_modes || []).join(" + ") || "—")} · info ${escapeHtml((early.information_modes || []).join(" + ") || "待确认")} · 5d residual ${earlyMetrics.residual_5d ?? "—"} · attention accel ${earlyMetrics.attention_acceleration ?? "—"}</div>` : "";
             return `<div class="add-campaign-row">
-              <div><b class="ticker">${escapeHtml(row.ticker || "—")}</b><span class="campaign-tier">${escapeHtml(row.tier || "none")}</span></div>
+              <div><b class="ticker">${escapeHtml(row.ticker || "—")}</b>${row.is_proxy ? `<span class="campaign-tier">via ${escapeHtml(row.source_ticker || "underlying")}</span>` : ""}<span class="campaign-tier">${escapeHtml(row.tier || "none")}</span></div>
               <div><span class="campaign-state state-${escapeHtml(row.state || "unknown")}">${escapeHtml(stateLabel[row.state] || row.state || "unknown")}</span><span class="campaign-families">families ${escapeHtml(families)} · sources ${escapeHtml(sources)}</span></div>
               <div class="campaign-detail">${escapeHtml(prices)} · tranche ${row.target_tranche_level ?? 0} · max shares ${row.max_add_shares ?? 0}</div>
+              ${earlyLine}
               <div class="campaign-blockers"><b>authority</b>${authorityBlockers.length ? authorityBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}<b>execution</b>${executionBlockers.length ? executionBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}</div>
             </div>`;
           }).join("") : '<div class="empty-state">No held names.</div>') + `</section>`;
       };
-      body.innerHTML = `<div class="campaign-summary">packet ${escapeHtml(campaign.packet_generated_at || "—")} · generation ${escapeHtml(campaign.context_generation_id || "—")} · validated ${tiers.validated || 0} · exploration ${tiers.exploration || 0} · none ${tiers.none || 0}</div><div class="add-campaign-legs">${legBlock("US")}${legBlock("HK")}</div>`;
+      body.innerHTML = `<div class="campaign-summary">packet ${escapeHtml(campaign.packet_generated_at || "—")} · generation ${escapeHtml(campaign.context_generation_id || "—")} · early ideas ${d.observed_idea_count ?? d.observed_candidate_count ?? 0} · early exploration ideas ${d.early_exploration_ready_idea_count ?? d.early_exploration_ready_count ?? 0} · mature validated ${tiers.validated || 0} / exploration ${tiers.exploration || 0}</div><div class="add-campaign-legs">${legBlock("US")}${legBlock("HK")}</div>`;
     }
 
     const run = campaign.run_card;
@@ -1406,7 +1418,14 @@
     };
     const market = key => `<section class="campaign-market"><h4>${key.toUpperCase()} interaction</h4>${horizon(key, "t1")}${horizon(key, "t5")}${horizon(key, "t20")}</section>`;
     const auth = coverage.authority_classifications || {};
-    evidence.innerHTML = `<div class="campaign-evidence-head"><b>Independent run card · ${escapeHtml(run.run_id || "—")}</b><span>diagnostic / collecting，不是 validated alpha</span></div><div class="campaign-market-grid">${market("us")}${market("hk")}</div><div class="campaign-coverage">factor ${coverage.factor_dates ?? "—"} dates · information ${coverage.information_dates ?? "—"} · overlap ${coverage.overlap_dates ?? "—"} · prospective ${coverage.prospective_information_dates ?? "—"} · authority none ${auth.none ?? 0} / explore ${auth.exploration ?? 0} / validated ${auth.validated ?? 0}</div>`;
+    const earlyHorizon = (marketKey, horizonKey) => {
+      const row = safe(run, "early_trend", marketKey, "observed", horizonKey) || {};
+      const ret = row.mean_return == null ? "—" : `${row.mean_return >= 0 ? "+" : ""}${(row.mean_return * 100).toFixed(2)}%`;
+      const hit = row.hit_rate == null ? "—" : `${(row.hit_rate * 100).toFixed(1)}%`;
+      return `${horizonKey.toUpperCase()} n=${row.n ?? 0} · mean ${ret} · hit ${hit}`;
+    };
+    const earlyCoverage = coverage.early_trend || {};
+    evidence.innerHTML = `<div class="campaign-evidence-head"><b>Independent run card · ${escapeHtml(run.run_id || "—")}</b><span>diagnostic / collecting，不是 validated alpha</span></div><div class="campaign-market-grid">${market("us")}${market("hk")}</div><div class="campaign-coverage"><b>early candidate replay</b> · US ${earlyHorizon("us", "t1")} / ${earlyHorizon("us", "t5")} · HK ${earlyHorizon("hk", "t1")} / ${earlyHorizon("hk", "t5")} · observed ${earlyCoverage.observed_candidates ?? 0}, information-confirmed ${earlyCoverage.information_confirmed ?? 0}, exploration-ready ${earlyCoverage.exploration_ready ?? 0}</div><div class="campaign-coverage">factor ${coverage.factor_dates ?? "—"} dates · information ${coverage.information_dates ?? "—"} · overlap ${coverage.overlap_dates ?? "—"} · prospective ${coverage.prospective_information_dates ?? "—"} · authority none ${auth.none ?? 0} / explore ${auth.exploration ?? 0} / validated ${auth.validated ?? 0}</div>`;
   }
 
   function renderHoldings() {

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -63,6 +63,12 @@ reference 的三种技术 staged setup，或 packet 编译出的 `alpha_confirma
 只安排未来 1–5 个本地交易日的执行。Bull/Bear 可反证、否决或降档，不能凭措辞
 创造 authority、提高 tier 或改股数。
 
+`quant.early_trend.observed=true` 是 harness 已发现的提前布局候选：必须让 Bull 写最强的
+可证伪提前布局论点，让 Bear 写 priced-in/拥挤/来源质量反驳，Judge 再给
+`candidate|wait|reject`。Judge 只能把 deterministic candidate 保留、等待或否决；不得把
+`observed=false` 的票辩成 candidate。优先核对 `primary_event_ids`；只有新闻转载时必须把
+`needs_primary_evidence` 原样保留，不能冒充一手催化。
+
 ```bash
 /root/.local/bin/clawock tool decision_packet_summary \
   --workspace /root/.openclaw/workspace \
@@ -716,9 +722,12 @@ schema 只允许顶层 `schema_version/context_generation_id/portfolio_assessmen
   "ticker": "00100",
   "verdict": "bullish|neutral|bearish|mixed",
   "confidence": 0.62,
+  "disposition": "candidate|wait|reject",
   "assessment": "你的评价",
   "counterargument": "最强反方",
-  "rationale": "为何在冲突信号中这样判断"
+  "rationale": "为何在冲突信号中这样判断",
+  "falsifier": "什么事实会推翻当前候选/等待判断",
+  "next_evidence": "下一步要找的一手披露或价格确认"
 }
 ```
 
@@ -776,6 +785,9 @@ USD${total} ({pct}%) | HK leg {hk}HKD | US leg {us}USD
 
 ▎触发位（≤2 条最近的）
 {watch_levels 关键 1-2 条}
+
+▎提前布局候选
+{从 packet.add_alpha_diagnostics 逐字汇总 early hints / exploration / allowed 数量；列最多2票的 candidate|wait 及主要 blocker。allowed=0 也必须显示，禁止把候选隐藏成“无信号”}
 
 📈 完整深度报告（Tier1/2/3 辩论 + 板块全景 + 复盘 + 唱反调）：
 https://kcnyu.github.io/clawock/memory/{date}-pre-open.html

--- a/src/clawock/decision/early_trend.py
+++ b/src/clawock/decision/early_trend.py
@@ -1,0 +1,175 @@
+"""Short-history early-trend candidates, separate from mature add authority.
+
+The lane is intentionally an observation before it is an order.  It catches a
+20-session breakout that is also exceptional relative to listed peers, even
+when a newly listed name has no MA200.  Price and peer residual are one
+price-relative family; information remains independent.  Only a non-leveraged,
+non-overheated name with both families receives a tiny exploration setup.
+"""
+from __future__ import annotations
+
+
+PRIMARY_SOURCE_TYPES = {
+    "sec_filing", "exchange_announcement", "issuer_announcement",
+    "official_macro_schedule",
+}
+POSITIVE_DIRECTIONS = {1, "1", "positive"}
+
+
+def _number(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def classify(technical: dict, peer: dict, information: dict, events: list[dict],
+             *, leveraged: bool, policy: dict, market: str) -> dict:
+    """Return a visible candidate state without pretending it is validated."""
+    close = _number(technical.get("close"))
+    prior_high = _number(technical.get("prior_20d_high"))
+    residual = _number(peer.get("residual_5d"))
+    dispersion = _number(peer.get("dispersion_5d"))
+    peers = int(peer.get("available_peer_count") or 0)
+    market_policy = (policy.get("markets") or {}).get(str(market).upper()) or {}
+    multiple = _number(policy.get("early_peer_dispersion_multiple")) or 1.5
+    breakout = close is not None and prior_high is not None and close > prior_high
+    residual_multiple = (
+        residual / dispersion
+        if residual is not None and dispersion not in (None, 0) else None
+    )
+    residual_leader = bool(
+        residual is not None and residual > 0
+        and residual_multiple is not None and residual_multiple >= multiple
+        and peers >= int(market_policy.get("minimum_peer_count") or 3)
+    )
+    price_candidate = bool(technical.get("usable") and breakout and residual_leader)
+
+    primary_ids = sorted({
+        str(event.get("event_id")) for event in events
+        if event.get("event_id")
+        and event.get("source_type") in PRIMARY_SOURCE_TYPES
+        and event.get("direction") in POSITIVE_DIRECTIONS
+    })
+    attention_rank = _number(information.get("attention_rank"))
+    acceleration = _number(information.get("attention_acceleration"))
+    source_types = int(information.get("attention_source_type_count") or 0)
+    attention_ok = bool(
+        attention_rank is not None
+        and attention_rank >= float(market_policy.get("minimum_attention_rank") or 1)
+        and acceleration is not None
+        and acceleration >= float(policy.get("minimum_attention_acceleration") or 1)
+        and source_types >= int(policy.get("minimum_attention_source_types") or 1)
+        and int(information.get("attention_event_count") or 0) > 0
+    )
+    information_modes = []
+    if primary_ids:
+        information_modes.append("primary_positive_event")
+    if attention_ok:
+        information_modes.append("attention_acceleration")
+    information_ok = bool(information_modes)
+    zscore = _number(technical.get("zscore20"))
+    overheated = zscore is not None and zscore >= float(
+        policy.get("early_no_chase_zscore") or 2.0
+    )
+
+    blockers = []
+    if not breakout:
+        blockers.append("no_20d_breakout")
+    if not residual_leader:
+        blockers.append("no_short_peer_leadership")
+    if not information_ok:
+        blockers.append("needs_information_confirmation")
+    if not primary_ids:
+        blockers.append("needs_primary_evidence")
+    if overheated:
+        blockers.append("overheated_wait_rebreak")
+    if leveraged:
+        blockers.append("leveraged_requires_validated_evidence")
+
+    if not price_candidate:
+        state = "not_candidate"
+    elif overheated:
+        state = "wait_pullback_rebreak"
+    elif not information_ok:
+        state = "wait_information"
+    elif leveraged:
+        state = "candidate_only"
+    else:
+        state = "exploration_ready"
+    return {
+        "schema_version": 1,
+        "state": state,
+        "observed": price_candidate,
+        "exploration_ready": state == "exploration_ready",
+        "market": str(market).upper(),
+        "price_modes": [
+            name for name, passed in (
+                ("20d_breakout", breakout),
+                ("short_peer_residual", residual_leader),
+            ) if passed
+        ],
+        "information_modes": information_modes,
+        "evidence_families": [
+            name for name, passed in (
+                ("price_relative", price_candidate),
+                ("point_in_time_information", information_ok),
+            ) if passed
+        ],
+        "primary_event_ids": primary_ids,
+        "metrics": {
+            "close": close,
+            "prior_20d_high": prior_high,
+            "residual_5d": residual,
+            "peer_dispersion_5d": dispersion,
+            "residual_dispersion_multiple": (
+                round(residual_multiple, 4) if residual_multiple is not None else None
+            ),
+            "attention_rank": attention_rank,
+            "attention_acceleration": acceleration,
+            "zscore20": zscore,
+        },
+        "blockers": sorted(set(blockers)),
+        "discipline": (
+            "short-history candidate; price/peer are one family, primary or "
+            "attention information is independent, and z>=2 waits for a rebreak"
+        ),
+    }
+
+
+def exploration_setup(technical: dict, candidate: dict, policy: dict,
+                      *, ticker: str) -> dict | None:
+    """Create one future-session rebreak intent, never a market-chase order."""
+    if not candidate.get("exploration_ready"):
+        return None
+    close = _number(technical.get("close"))
+    prior_high = _number(technical.get("prior_20d_high"))
+    invalidation = max(
+        value for value in (
+            _number(technical.get("ma20")),
+            _number(technical.get("chandelier_stop")),
+            _number(technical.get("prior_5d_low")),
+        ) if value is not None and value > 0
+    )
+    entry = max(close or 0, prior_high or 0)
+    if not entry or invalidation >= entry:
+        return None
+    return {
+        "setup_id": "early_trend_confirmation",
+        "campaign_id": f"{candidate['market']}:{ticker}:early:p1",
+        "label": "早期趋势确认",
+        "entry_type": "price_above",
+        "entry_price": round(entry, 4),
+        "invalidation_price": round(invalidation, 4),
+        "max_tranches": 1,
+        "tranche_pct_of_position": float(
+            policy.get("exploration_tranche_pct") or 0.025
+        ),
+        "valid_for_sessions": int(policy.get("confirmation_window_sessions") or 5),
+        "signal_date": technical.get("as_of"),
+        "authority_tier": "exploration",
+        "target_tranche_level": 0.25,
+        "authority_sources": ["early_trend", "information"],
+        "evidence_families": ["price_relative", "point_in_time_information"],
+        "detail": "次新/短历史早期趋势候选；未来时段再突破才执行，跌破失效位取消",
+    }

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -19,24 +19,27 @@ import os
 from pathlib import Path
 
 from clawock.decision.actions import ACTIVE_ACTIONS
-from clawock.decision import add_alpha
+from clawock.decision import add_alpha, early_trend
 from clawock.portfolio.instruments import get as instrument_metadata, is_leveraged_holding
 from clawock.workspace import workspace_root
 
 
 SCHEMA_VERSION = 1
-JUDGMENT_SCHEMA_VERSION = 1
+JUDGMENT_SCHEMA_VERSION = 2
 PAGES_SCHEMA_VERSION = 1
 MAX_PACKET_BYTES = 96 * 1024
 MAX_QUERY_BYTES = 24 * 1024
 ADD_ALPHA_POLICY = workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
+DISPOSITIONS = {"candidate", "wait", "reject"}
 TEXT_LIMITS = {
     "portfolio_assessment": 800,
     "portfolio_counterargument": 800,
     "assessment": 500,
     "counterargument": 500,
     "rationale": 500,
+    "falsifier": 300,
+    "next_evidence": 300,
 }
 
 
@@ -130,7 +133,7 @@ def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
     fresh = row.get("status") in (None, "fresh")
     trend = (
         "on" if row.get("trend_on") is True
-        else "off" if row.get("trend_on") is False or row.get("tag")
+        else "off" if row.get("trend_on") is False
         else "unknown"
     )
     stop_distance = _number(row.get("stop_distance_pct"), 1)
@@ -165,12 +168,15 @@ def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
                 "evidence_families": list(setup.get("evidence_families") or []),
                 "detail": str(setup.get("detail") or "")[:300],
             })
+    tag = row.get("tag")
+    if trend == "unknown" and isinstance(tag, str):
+        tag = tag.replace("趋势OFF", "趋势未知")
     return {
         "source_ticker": source_ticker,
         "is_proxy": bool(proxy),
         "status": row.get("status") or ("available" if row else "unavailable"),
         "as_of": row.get("row_as_of"),
-        "tag": row.get("tag"),
+        "tag": tag,
         "trend": trend,
         "rsi14": _number(row.get("rsi14"), 1),
         "rsi_state": _rsi_state(row.get("rsi14")),
@@ -184,6 +190,9 @@ def _technical(row: dict, source_ticker: str, proxy: bool) -> dict:
         "ma20": _number(row.get("ma20"), 4),
         "prior_5d_high": _number(row.get("prior_5d_high"), 4),
         "prior_5d_low": _number(row.get("prior_5d_low"), 4),
+        "prior_20d_high": _number(row.get("prior_20d_high"), 4),
+        "prior_20d_low": _number(row.get("prior_20d_low"), 4),
+        "zscore20": _number(row.get("zscore20"), 2),
         "chandelier_stop": _number(row.get("chandelier_stop"), 4),
         "stop_distance_pct": stop_distance,
         "stop_state": (
@@ -363,6 +372,7 @@ def _peer_view(row: dict) -> dict:
         "residual_1d": _number(row.get("residual_blend_1d"), 4),
         "residual_5d": _number(row.get("residual_blend_5d"), 4),
         "residual_20d": _number(row.get("residual_blend_20d"), 4),
+        "dispersion_5d": _number(row.get("peer_dispersion_5d"), 4),
         "leadership_persistence": row.get("leadership_persistence"),
         "laggard_persistence": row.get("laggard_persistence"),
         "available_peer_count": int(row.get("available_peer_count") or 0),
@@ -482,7 +492,7 @@ def _sentiment_view(rows: list[dict], ticker: str, source_ticker: str) -> dict:
 
 
 def _event_view(event: dict) -> dict:
-    return {
+    view = {
         key: event.get(key)
         for key in (
             "event_id",
@@ -496,9 +506,14 @@ def _event_view(event: dict) -> dict:
             "confidence_tier",
             "actionable_escalation",
             "actionable_reasons",
+            "source_type", "primary_source", "direction",
         )
         if event.get(key) not in (None, "", [])
     }
+    direction = event.get("direction", event.get("impact_direction"))
+    if direction not in (None, "", []):
+        view["direction"] = direction
+    return view
 
 
 def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
@@ -564,6 +579,8 @@ def _status(technical: dict, risks: list[dict]) -> dict:
         return {"rank": 4, "label": "趋势ON", "state": "positive"}
     if technical.get("rsi_state") == "oversold":
         return {"rank": 2, "label": "超卖·观望", "state": "elevated"}
+    if technical.get("usable") and technical.get("trend") == "unknown":
+        return {"rank": 3, "label": "趋势未知·短历史", "state": "neutral"}
     if technical.get("usable"):
         return {"rank": 3, "label": "趋势off·观望", "state": "neutral"}
     return {"rank": 5, "label": "数据不足", "state": "neutral"}
@@ -740,6 +757,19 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 "prospective_collection_only",
                 "current_universe_survivorship_limit",
             ]
+        early_candidate = early_trend.classify(
+            technical, peer_view, information_view, matching_events,
+            leveraged=leveraged, policy=add_policy, market=leg,
+        )
+        early_setup = early_trend.exploration_setup(
+            technical, early_candidate, add_policy, ticker=ticker,
+        )
+        # The early lane can grant one exploration intent without changing the
+        # mature factor×information authority classification.  Downstream risk,
+        # cash, lot and open-order gates remain identical.
+        execution_tier = alpha_authority.get("tier") or "none"
+        if early_setup is not None and execution_tier == "none":
+            execution_tier = "exploration"
         alpha_setup = add_alpha.confirmation_setup(
             technical, alpha_authority, add_policy, ticker=ticker
         )
@@ -748,9 +778,12 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             technical = _apply_setup_usage(
                 technical, ticker_usage
             )
+        if early_setup is not None:
+            technical["setups"].append(early_setup)
+            technical = _apply_setup_usage(technical, ticker_usage)
         execution = _execution_view(
             holding, leg, invested[leg], cash[leg], technical, thesis, leveraged,
-            authority_tier=alpha_authority.get("tier") or "none",
+            authority_tier=execution_tier,
             exploration_max_book_pct=float(
                 add_policy.get("exploration_max_book_pct") or 0.03
             ),
@@ -778,6 +811,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 "factor": factor_view,
                 "peer_residual": peer_view,
                 "add_authority": alpha_authority,
+                "early_trend": early_candidate,
                 "activation": {
                     "factor": bool(
                         ((context.get("cross_sectional_factor") or {}).get("activation") or {})
@@ -804,6 +838,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
     candidates = []
     for ticker, row in tickers.items():
         authority = ((row.get("quant") or {}).get("add_authority") or {})
+        early = ((row.get("quant") or {}).get("early_trend") or {})
         tier = authority.get("tier") or "none"
         tier_counts[tier] = tier_counts.get(tier, 0) + 1
         for blocker in authority.get("blockers") or []:
@@ -815,14 +850,25 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             ),
             None,
         )
+        early_setup = next(
+            (
+                item for item in (row.get("technical") or {}).get("setups") or []
+                if item.get("setup_id") == "early_trend_confirmation"
+            ),
+            None,
+        )
+        active_setup = setup or early_setup
         constraints = row.get("constraints") or {}
         execution = row.get("execution") or {}
         allowed = "add_only_on_trigger" in (constraints.get("allowed_actions") or [])
-        if tier == "none":
+        early_ready = bool(early.get("exploration_ready"))
+        if tier == "none" and early.get("observed"):
+            state = early.get("state") or "candidate_only"
+        elif tier == "none":
             state = "insufficient_evidence"
-        elif setup is None:
+        elif active_setup is None:
             state = "waiting_timing"
-        elif setup.get("remaining_tranches") == 0:
+        elif active_setup.get("remaining_tranches") == 0:
             state = "already_at_target"
         elif execution.get("blockers") or row.get("risk"):
             state = "risk_blocked"
@@ -833,19 +879,29 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
         candidates.append({
             "ticker": ticker,
             "leg": row.get("leg"),
+            "source_ticker": (row.get("technical") or {}).get("source_ticker") or ticker,
+            "is_proxy": bool((row.get("technical") or {}).get("is_proxy")),
             "state": state,
             "tier": tier,
             "target_tranche_level": (
-                0.25 if tier == "exploration" else 1.0 if tier == "validated" else 0.0
+                0.25 if tier == "exploration" or early_ready
+                else 1.0 if tier == "validated" else 0.0
             ),
-            "sources": list(authority.get("sources") or []),
-            "evidence_families": list(authority.get("evidence_families") or []),
+            "sources": sorted(set(
+                list(authority.get("sources") or [])
+                + (["early_trend", "information"] if early_ready else [])
+            )),
+            "evidence_families": sorted(set(
+                list(authority.get("evidence_families") or [])
+                + (list(early.get("evidence_families") or []) if early_ready else [])
+            )),
             "authority_blockers": list(authority.get("blockers") or []),
-            "entry_price": (setup or {}).get("entry_price"),
-            "invalidation_price": (setup or {}).get("invalidation_price"),
+            "entry_price": (active_setup or {}).get("entry_price"),
+            "invalidation_price": (active_setup or {}).get("invalidation_price"),
             "max_add_shares": constraints.get("max_add_shares"),
             "allowed": allowed,
             "execution_blockers": list(execution.get("blockers") or []),
+            "early_trend": early,
         })
 
     packet = {
@@ -882,8 +938,10 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
         "judgment_contract": {
             "schema_version": JUDGMENT_SCHEMA_VERSION,
             "verdicts": sorted(VERDICTS),
+            "dispositions": sorted(DISPOSITIONS),
             "model_owned_fields": [
-                "verdict", "confidence", "assessment", "counterargument", "rationale",
+                "verdict", "confidence", "disposition", "assessment",
+                "counterargument", "rationale", "falsifier", "next_evidence",
             ],
             "harness_owned_fields": [
                 "facts", "technical", "quant", "sentiment collection",
@@ -896,7 +954,8 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 "schema_version", "registered_at", "minimum_evidence_families",
                 "confirmation_window_sessions", "exploration_max_tranches",
                 "exploration_tranche_pct", "validated_max_tranches",
-                "exploration_max_book_pct",
+                "exploration_max_book_pct", "early_peer_dispersion_multiple",
+                "early_no_chase_zscore",
                 "validated_tranche_pct", "markets", "discipline",
             )
         },
@@ -908,6 +967,31 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
                 row["tier"] in {"exploration", "validated"} for row in candidates
             ),
             "allowed_candidate_count": sum(bool(row["allowed"]) for row in candidates),
+            "observed_candidate_count": sum(
+                bool((row.get("early_trend") or {}).get("observed"))
+                or row["tier"] in {"exploration", "validated"}
+                for row in candidates
+            ),
+            "observed_idea_count": len({
+                row.get("source_ticker") or row["ticker"]
+                for row in candidates
+                if bool((row.get("early_trend") or {}).get("observed"))
+                or row["tier"] in {"exploration", "validated"}
+            }),
+            "observed_candidate_rate": round(sum(
+                bool((row.get("early_trend") or {}).get("observed"))
+                or row["tier"] in {"exploration", "validated"}
+                for row in candidates
+            ) / len(tickers), 4) if tickers else 0,
+            "early_exploration_ready_count": sum(
+                bool((row.get("early_trend") or {}).get("exploration_ready"))
+                for row in candidates
+            ),
+            "early_exploration_ready_idea_count": len({
+                row.get("source_ticker") or row["ticker"]
+                for row in candidates
+                if bool((row.get("early_trend") or {}).get("exploration_ready"))
+            }),
             "candidate_rate": round(sum(
                 row["tier"] in {"exploration", "validated"} for row in candidates
             ) / len(tickers), 4) if tickers else 0,
@@ -937,6 +1021,7 @@ def _decision_provenance(packet: dict, ticker: str) -> dict | None:
         "factor": copy.deepcopy(quant.get("factor") or {}),
         "peer_residual": copy.deepcopy(quant.get("peer_residual") or {}),
         "add_authority": copy.deepcopy(quant.get("add_authority") or {}),
+        "early_trend": copy.deepcopy(quant.get("early_trend") or {}),
         "sizing": copy.deepcopy(execution.get("information_overlay") or {}),
         "authority": {
             "max_add_shares": (row.get("constraints") or {}).get("max_add_shares"),
@@ -991,6 +1076,7 @@ def summary_view(packet: dict) -> dict:
                     "peer": ((row.get("quant") or {}).get("peer_residual") or {})
                     .get("usable_for_decisions"),
                 },
+                "early_trend": ((row.get("quant") or {}).get("early_trend") or {}),
                 "risk_count": len(row.get("risk") or []),
                 "constraints": row.get("constraints"),
             }
@@ -1012,9 +1098,12 @@ def judgment_template(packet: dict) -> dict:
                 "ticker": ticker,
                 "verdict": "neutral",
                 "confidence": 0.5,
+                "disposition": "wait",
                 "assessment": "",
                 "counterargument": "",
                 "rationale": "",
+                "falsifier": "",
+                "next_evidence": "",
             }
             for ticker in packet.get("tickers", {})
         ],
@@ -1028,8 +1117,8 @@ def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
         "portfolio_counterargument", "ticker_judgments",
     }
     row_allowed = {
-        "ticker", "verdict", "confidence", "assessment",
-        "counterargument", "rationale",
+        "ticker", "verdict", "confidence", "disposition", "assessment",
+        "counterargument", "rationale", "falsifier", "next_evidence",
     }
     if not isinstance(overlay, dict):
         return ["judgment overlay must be an object"]
@@ -1070,10 +1159,27 @@ def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
         seen.add(ticker)
         if row.get("verdict") not in VERDICTS:
             issues.append(f"{label} invalid verdict {row.get('verdict')!r}")
+        disposition = row.get("disposition")
+        if disposition not in DISPOSITIONS:
+            issues.append(f"{label} invalid disposition {disposition!r}")
+        deterministic = (packet.get("tickers") or {}).get(ticker) or {}
+        authority = ((deterministic.get("quant") or {}).get("add_authority") or {})
+        early = ((deterministic.get("quant") or {}).get("early_trend") or {})
+        can_be_candidate = bool(
+            authority.get("tier") in {"exploration", "validated"}
+            or early.get("observed")
+        )
+        if disposition == "candidate" and not can_be_candidate:
+            issues.append(
+                f"{label} disposition candidate cannot upgrade a deterministic non-candidate"
+            )
         confidence = _number(row.get("confidence"))
         if confidence is None or not 0 <= confidence <= 1:
             issues.append(f"{label} confidence must be in [0,1]")
-        for field in ("assessment", "counterargument", "rationale"):
+        for field in (
+            "assessment", "counterargument", "rationale", "falsifier",
+            "next_evidence",
+        ):
             value = row.get(field)
             if not isinstance(value, str) or not value.strip():
                 issues.append(f"{label} {field} must be non-empty text")
@@ -1211,6 +1317,18 @@ def compile_pages_projection(
         risks = row.get("risk") or []
         hard = any(item.get("kind") == "hard_stop" for item in risks)
         direct = any(item.get("scope") == "ticker" for item in risks)
+        judgment = judgments.get(ticker)
+        authority = ((row.get("quant") or {}).get("add_authority") or {})
+        early = ((row.get("quant") or {}).get("early_trend") or {})
+        deterministic_candidate = bool(
+            authority.get("tier") in {"exploration", "validated"}
+            or early.get("observed")
+        )
+        effective_disposition = (
+            judgment.get("disposition") if judgment and deterministic_candidate
+            else "reject" if judgment and judgment.get("disposition") == "reject"
+            else "wait"
+        )
         rows.append({
             "ticker": ticker,
             "name": row.get("name"),
@@ -1254,7 +1372,12 @@ def compile_pages_projection(
                 ],
             },
             "status": row.get("status"),
-            "judgment": judgments.get(ticker),
+            "judgment": judgment,
+            "candidate_disposition": {
+                "deterministic_candidate": deterministic_candidate,
+                "effective": effective_disposition,
+                "discipline": "judgment may downgrade or reject; it cannot create authority",
+            },
         })
     rows.sort(
         key=lambda row: (
@@ -1271,10 +1394,12 @@ def compile_pages_projection(
         candidates.append({
             key: candidate.get(key)
             for key in (
-                "ticker", "leg", "state", "tier", "target_tranche_level",
+                "ticker", "leg", "source_ticker", "is_proxy", "state", "tier",
+                "target_tranche_level",
                 "sources", "evidence_families", "authority_blockers",
                 "execution_blockers", "entry_price", "invalidation_price",
                 "max_add_shares", "allowed",
+                "early_trend",
             )
         })
     candidates.sort(key=lambda row: (row.get("leg") or "", row.get("ticker") or ""))
@@ -1313,7 +1438,10 @@ def compile_pages_projection(
                 for key in (
                     "held_names", "tier_counts", "candidate_count",
                     "authority_candidate_count", "allowed_candidate_count",
-                    "candidate_rate", "blocker_counts", "zero_output_visible",
+                    "observed_candidate_count", "observed_candidate_rate",
+                    "observed_idea_count", "early_exploration_ready_count",
+                    "early_exploration_ready_idea_count", "candidate_rate",
+                    "blocker_counts", "zero_output_visible",
                 )
             } if campaign_status == "current" else None,
             "candidates": candidates,
@@ -1343,6 +1471,7 @@ def _compact_add_alpha_run_card(card: dict | None) -> dict | None:
     metrics = card.get("metrics") or {}
     coverage = metrics.get("coverage") or {}
     market_metrics = {}
+    early_metrics = {}
     for market in ("us", "hk"):
         interaction = (metrics.get(market) or {}).get("interaction") or {}
         market_metrics[market] = {
@@ -1355,6 +1484,20 @@ def _compact_add_alpha_run_card(card: dict | None) -> dict | None:
             }
             for horizon in ("t1", "t5", "t20")
         }
+        early = (metrics.get("early_trend") or {}).get(market) or {}
+        early_metrics[market] = {
+            state: {
+                horizon: {
+                    key: ((early.get(state) or {}).get(horizon) or {}).get(key)
+                    for key in (
+                        "n", "n_dates", "n_tickers", "mean_return",
+                        "hit_rate", "status",
+                    )
+                }
+                for horizon in ("t1", "t5")
+            }
+            for state in ("observed", "information_confirmed", "exploration_ready")
+        }
     return {
         "run_id": card.get("run_id"),
         "generated_at": card.get("generated_at"),
@@ -1362,6 +1505,7 @@ def _compact_add_alpha_run_card(card: dict | None) -> dict | None:
         "policy_version": (card.get("params") or {}).get("policy_version"),
         "parameter_fit": (card.get("params") or {}).get("parameter_fit"),
         "markets": market_metrics,
+        "early_trend": early_metrics,
         "coverage": {
             key: coverage.get(key)
             for key in (
@@ -1369,7 +1513,7 @@ def _compact_add_alpha_run_card(card: dict | None) -> dict | None:
                 "prospective_information_dates", "authority_classifications",
                 "information_grade", "factor_grade", "claim",
             )
-        },
+        } | {"early_trend": coverage.get("early_trend")},
     }
 
 

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -17,9 +17,9 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from clawock.decision import add_alpha, signals
+from clawock.decision import add_alpha, early_trend, signals
 from clawock.evidence import news_evidence_graph, run_card
-from clawock.market_data import factors
+from clawock.market_data import factors, peer_residuals
 from clawock.workspace import workspace_root
 
 
@@ -30,6 +30,7 @@ NEWS_POLICY = WS / "config" / "news-evidence-policy.json"
 FACTOR_HISTORY = WS / "assets" / "data" / "cross_sectional_factor_history.jsonl"
 PEER_HISTORY = WS / "assets" / "data" / "peer_residual_history.jsonl"
 NEWS_HISTORY = WS / "assets" / "data" / "news_evidence_history.jsonl"
+PEER_MAP = WS / "memory" / "peer-map.json"
 HORIZONS = (1, 5, 20)
 VARIANTS = ("setup_only", "price_relative", "information", "interaction")
 
@@ -82,8 +83,12 @@ def _technical_at(bars, signal_date):
         "close": row.get("close"),
         "prior_5d_high": row.get("prior_5d_high"),
         "prior_5d_low": row.get("prior_5d_low"),
+        "prior_20d_high": row.get("prior_20d_high"),
         "chandelier_stop": row.get("chandelier_stop"),
         "ma20": row.get("ma20"),
+        "zscore20": row.get("zscore20"),
+        "usable": True,
+        "as_of": signal_date,
     }
 
 
@@ -118,6 +123,30 @@ def _forward_return(bars, entry_session, entry_price, horizon):
     if index is None or index + horizon >= len(bars) or not entry_price:
         return None
     return bars[index + horizon]["close"] / entry_price - 1
+
+
+def _close_forward_return(bars, signal_date, horizon):
+    """Signal after session close; first measurable horizon is a later close."""
+    index = next(
+        (i for i, row in enumerate(bars) if row.get("date") == signal_date), None
+    )
+    if index is None or index + horizon >= len(bars):
+        return None
+    entry = _number(bars[index].get("close"))
+    future = _number(bars[index + horizon].get("close"))
+    return future / entry - 1 if entry and future is not None else None
+
+
+def _events_at(snapshot, ticker):
+    return [
+        {
+            "event_id": event.get("event_id"),
+            "source_type": event.get("source_type"),
+            "direction": event.get("impact_direction"),
+        }
+        for event in snapshot.get("events") or []
+        if str(event.get("ticker") or "") == ticker
+    ]
 
 
 def _cluster_ci(rows, field, samples=1000):
@@ -320,6 +349,18 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
         specs,
         prior=float(policy.get("attention_score_prior") or 0.1),
     )
+    news_snapshots = {
+        str(snapshot.get("as_of") or "")[:10]: snapshot
+        for snapshot in news_history
+    }
+    taxonomy, _ = peer_residuals.build_taxonomy(config, _json(PEER_MAP))
+    canonical_taxonomy = {
+        row["signal_ticker"]: row
+        for _, row in peer_residuals._canonical_taxonomy_items(taxonomy)
+    }
+    peer_weight_cap = float(
+        _json(peer_residuals.RULE_CONFIG)["basket_weight_cap"]
+    )
     peers = {
         str(snapshot.get("as_of") or "")[:10]: snapshot.get("rows") or {}
         for snapshot in peer_history
@@ -330,6 +371,22 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
     }
     coverage = {"factor_dates": 0, "information_dates": len(news), "overlap_dates": 0}
     authority_counts = {"none": 0, "exploration": 0, "validated": 0}
+    early_observations = {
+        market: {
+            state: {horizon: [] for horizon in (1, 5)}
+            for state in ("observed", "information_confirmed", "exploration_ready")
+        }
+        for market in ("us", "hk")
+    }
+    early_coverage = {
+        "eligible_signal_dates": 0,
+        "peer_metrics_evaluated": 0,
+        "observed_candidates": 0,
+        "information_confirmed": 0,
+        "exploration_ready": 0,
+        "missing_taxonomy": 0,
+    }
+    seen_early = set()
     for snapshot in factor_history:
         snapshot_date = str(snapshot.get("as_of") or "")[:10]
         if not snapshot_date:
@@ -397,6 +454,67 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
                             "return": value,
                             "fill_reason": fill["fill_reason"],
                         })
+        # Early lane is evaluated independently of the mature setup/fill lane.
+        # One row per economic exposure (never both SPCX and SPCH), using only
+        # bars and information snapshots available at the signal-date close.
+        for ticker, taxonomy_row in canonical_taxonomy.items():
+            spec = specs.get(ticker)
+            bars = (fetched.get(ticker) or {}).get("bars") or []
+            if not spec or not bars:
+                continue
+            signal_date = str(
+                ((snapshot.get("rows") or {}).get(ticker) or {}).get("feature_as_of")
+                or snapshot_date
+            )[:10]
+            observation_key = (ticker, signal_date)
+            if observation_key in seen_early:
+                continue
+            seen_early.add(observation_key)
+            technical = _technical_at(bars, signal_date)
+            if not technical:
+                continue
+            early_coverage["eligible_signal_dates"] += 1
+            peer_metrics = peer_residuals.metrics_at(
+                taxonomy_row, fetched, signal_date,
+                peer_weight_cap,
+            )
+            if not peer_metrics:
+                continue
+            early_coverage["peer_metrics_evaluated"] += 1
+            peer_view = {
+                "residual_5d": peer_metrics.get("residual_blend_5d"),
+                "dispersion_5d": peer_metrics.get("peer_dispersion_5d"),
+                "available_peer_count": peer_metrics.get("available_peer_count"),
+            }
+            info = ((news.get(signal_date) or {}).get("rows") or {}).get(ticker) or {}
+            candidate = early_trend.classify(
+                technical, peer_view, info,
+                _events_at(news_snapshots.get(signal_date) or {}, ticker),
+                leveraged=False, policy=policy, market=spec["region"],
+            )
+            if not candidate["observed"]:
+                continue
+            early_coverage["observed_candidates"] += 1
+            info_confirmed = "point_in_time_information" in candidate["evidence_families"]
+            early_coverage["information_confirmed"] += int(info_confirmed)
+            early_coverage["exploration_ready"] += int(candidate["exploration_ready"])
+            states = ["observed"]
+            if info_confirmed:
+                states.append("information_confirmed")
+            if candidate["exploration_ready"]:
+                states.append("exploration_ready")
+            for horizon in (1, 5):
+                value = _close_forward_return(bars, signal_date, horizon)
+                if value is None:
+                    continue
+                for state in states:
+                    early_observations[spec["region"]][state][horizon].append({
+                        "date": signal_date,
+                        "ticker": ticker,
+                        "return": value,
+                        "state": candidate["state"],
+                        "has_primary": bool(candidate["primary_event_ids"]),
+                    })
     for market in observations.values():
         for horizon in HORIZONS:
             baseline_by_date = defaultdict(list)
@@ -421,6 +539,16 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
         }
         for market, variants in observations.items()
     }
+    metrics["early_trend"] = {
+        market: {
+            state: {
+                f"t{horizon}": _summary(rows)
+                for horizon, rows in horizons.items()
+            }
+            for state, horizons in states.items()
+        }
+        for market, states in early_observations.items()
+    }
     metrics["coverage"] = {
         **coverage,
         "authority_classifications": authority_counts,
@@ -431,6 +559,12 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
         ),
         "parameter_fit": "none_pre_registered_policy",
         "claim": "diagnostic_not_validated_alpha",
+        "early_trend": {
+            **early_coverage,
+            "entry": "signal_session_close_for_measurement_only",
+            "lookahead": "features_recomputed_at_each_snapshot_date; future closes used only for outcomes",
+            "history_limit": "registered histories currently cover about 14 dates",
+        },
     }
     return metrics
 
@@ -442,7 +576,11 @@ def main(argv=None):
     config = _json(FACTOR_CONFIG)
     policy = _json(ALPHA_POLICY)
     news_policy = _json(NEWS_POLICY)
-    fetched = factors.fetch_universe(config)
+    # The early residual needs every curated peer, including names outside the
+    # factor universe. Fetch the expanded taxonomy once; factor snapshots still
+    # determine which economic exposures enter the replay.
+    _, fetch_config = peer_residuals.build_taxonomy(config, _json(PEER_MAP))
+    fetched = factors.fetch_universe(fetch_config)
     histories = (_jsonl(FACTOR_HISTORY), _jsonl(PEER_HISTORY), _jsonl(NEWS_HISTORY))
     metrics = evaluate(config, policy, news_policy, fetched, *histories)
     card_path = None
@@ -480,18 +618,21 @@ def main(argv=None):
                 "entry": "production alpha_confirmation; next session; invalidation first; gap aware",
                 "confirmation_window_sessions": policy["confirmation_window_sessions"],
                 "variants": list(VARIANTS),
+                "early_variants": ["observed", "information_confirmed", "exploration_ready"],
                 "policy_version": add_alpha.POLICY_VERSION,
                 "parameter_fit": "none; pre-registered thresholds",
             },
             inputs=inputs,
             metrics=metrics,
-            code_files=[Path(__file__), Path(add_alpha.__file__)],
+            code_files=[Path(__file__), Path(add_alpha.__file__), Path(early_trend.__file__)],
             notes=[
                 "US and HK are ranked and evaluated separately.",
                 "Production classify_authority and confirmation primitives are reused directly.",
                 "Current-universe factor history is survivorship-limited and cannot validate authority.",
                 "Legacy information replay seeds diagnostics only; prospective activation remains warming_up.",
                 "Same-day entry/invalidation ambiguity is invalidated, never assumed filled.",
+                "Early candidates are one row per underlying and use signal-date-close features with T+1/T+5 future closes only as outcomes.",
+                "The early history is small; every result remains collecting/diagnostic, never validated alpha.",
             ],
         )
     print(json.dumps({"metrics": metrics, "run_card": str(card_path) if card_path else None}, ensure_ascii=False, indent=2))

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -214,6 +214,8 @@ async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
     payload.add_campaign = {
       status: "current", packet_generated_at: "2026-08-13T08:00:00+08:00",
       diagnostics: { held_names: active.length, authority_candidate_count: 0,
+        observed_candidate_count: 2, observed_idea_count: 1,
+        early_exploration_ready_count: 0, early_exploration_ready_idea_count: 0,
         tier_counts: { validated: 0, exploration: 0, none: active.length } },
       candidates: [
         { ticker: active[0].ticker, leg: "US", state: "insufficient_evidence",
@@ -221,6 +223,7 @@ async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
           ["independent_evidence_families"], execution_blockers: [],
           target_tranche_level: 0, max_add_shares: 0 },
         { ticker: active[1].ticker, leg: "HK", state: "waiting_timing",
+          source_ticker: active[1].ticker, is_proxy: false,
           tier: "exploration", evidence_families:
           ["price_relative", "point_in_time_information"],
           sources: ["factor", "information"], authority_blockers: [],
@@ -230,11 +233,18 @@ async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
         factor_dates: 11, information_dates: 12, overlap_dates: 10,
         prospective_information_dates: 0,
         authority_classifications: { none: 186, exploration: 6, validated: 0 },
+        early_trend: { observed_candidates: 2, information_confirmed: 1,
+          exploration_ready: 0 },
       }, markets: {
         us: { t1: { n: 4, mean_return: .03, hit_rate: 1 },
           t5: { n: 0, status: "collecting" }, t20: { n: 0, status: "collecting" } },
         hk: { t1: { n: 2, mean_return: .01, hit_rate: .5 },
           t5: { n: 0, status: "collecting" }, t20: { n: 0, status: "collecting" } },
+      }, early_trend: {
+        us: { observed: { t1: { n: 1, mean_return: .02, hit_rate: 1 },
+          t5: { n: 1, mean_return: .05, hit_rate: 1 } } },
+        hk: { observed: { t1: { n: 1, mean_return: -.01, hit_rate: 0 },
+          t5: { n: 0, status: "collecting" } } },
       }},
     };
     await route.fulfill({ status: 200, contentType: "application/json",
@@ -258,6 +268,10 @@ async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
     "campaign did not keep markets separate");
   assert.match(await page.locator("#add-campaign-card").innerText(), /collecting · n=0/,
     "zero sample was rendered as performance instead of collecting");
+  assert.match(await page.locator("#add-campaign-card").innerText(), /early candidate replay/,
+    "early candidate evidence stayed hidden from the rendered campaign");
+  assert.match(await page.locator("#add-campaign-card").innerText(), /early ideas 1/,
+    "underlying-deduplicated early idea count was not rendered");
 
   await page.click('.tab-btn[data-tab="reflect"]');
   await waitForTab(page, "reflect");

--- a/tests/test_add_alpha_walkforward_early.py
+++ b/tests/test_add_alpha_walkforward_early.py
@@ -1,0 +1,75 @@
+"""No-lookahead contracts for the early-candidate diagnostic replay."""
+from clawock.evaluation import add_alpha_walkforward as replay
+
+
+def test_early_replay_uses_signal_close_then_future_closes_only(monkeypatch):
+    bars = []
+    for day in range(1, 36):
+        close = 10.0 if day < 30 else 11.0 + (day - 30) * .1
+        bars.append({
+            "date": f"2026-07-{day:02d}",
+            "open": close, "high": close, "low": close, "close": close,
+        })
+    signal_date = bars[29]["date"]
+    config = {
+        "symbols": [{"ticker": "ABC", "region": "us", "sector": "test"}],
+        "leveraged_proxies": [],
+    }
+    policy = {
+        "minimum_attention_acceleration": 1.25,
+        "minimum_attention_source_types": 1,
+        "early_peer_dispersion_multiple": 1.5,
+        "early_no_chase_zscore": 99,
+        "confirmation_window_sessions": 5,
+        "minimum_evidence_families": 2,
+        "minimum_information_score": .08,
+        "minimum_event_novelty": .5,
+        "minimum_event_reliability": .5,
+        "minimum_price_nonreaction": .6,
+        "markets": {"US": {
+            "minimum_attention_rank": .75, "minimum_peer_count": 3,
+            "minimum_factor_coverage_pct": 80, "minimum_sector_universe_size": 4,
+            "enter_market_percentile": .75, "exit_market_percentile": .55,
+        }},
+    }
+    news_policy = {"information_overlay": {}}
+    factor_history = [{
+        "as_of": signal_date,
+        "rows": {"ABC": {"feature_as_of": signal_date, "composite_score": .5}},
+    }]
+
+    monkeypatch.setattr(
+        replay.peer_residuals, "build_taxonomy",
+        lambda _config, _peers: ({"ABC": {"signal_ticker": "ABC"}}, _config),
+    )
+    monkeypatch.setattr(
+        replay.peer_residuals, "_canonical_taxonomy_items",
+        lambda taxonomy: list(taxonomy.items()),
+    )
+    monkeypatch.setattr(
+        replay.peer_residuals, "metrics_at",
+        lambda *_args: {
+            "residual_blend_5d": .2, "peer_dispersion_5d": .05,
+            "available_peer_count": 4,
+        },
+    )
+    monkeypatch.setattr(
+        replay, "_json",
+        lambda path: {"basket_weight_cap": .4}
+        if str(path).endswith("peer-residual-rules.json") else {},
+    )
+
+    metrics = replay.evaluate(
+        config, policy, news_policy, {"ABC": {"bars": bars}},
+        factor_history, [], [],
+    )
+
+    t1 = metrics["early_trend"]["us"]["observed"]["t1"]
+    t5 = metrics["early_trend"]["us"]["observed"]["t5"]
+    assert t1["n"] == 1 and t5["n"] == 1
+    assert t1["mean_return"] == round(bars[30]["close"] / bars[29]["close"] - 1, 6)
+    assert t5["mean_return"] == round(bars[34]["close"] / bars[29]["close"] - 1, 6)
+    assert metrics["early_trend"]["us"]["information_confirmed"]["t1"]["n"] == 0
+    assert metrics["coverage"]["early_trend"]["lookahead"].startswith(
+        "features_recomputed_at_each_snapshot_date"
+    )

--- a/tests/test_brief_candidate_card.py
+++ b/tests/test_brief_candidate_card.py
@@ -1,0 +1,73 @@
+"""The compact brief cannot hide deterministic early-positioning hints."""
+import json
+
+from clawock_kcnyu.harness import _watchdog_common as common
+
+
+TODAY = "2026-08-13"
+
+
+def _packet():
+    return {
+        "add_alpha_diagnostics": {
+            "candidates": [{
+                "ticker": "00100", "source_ticker": "00100", "is_proxy": False,
+                "tier": "none", "allowed": False,
+                "early_trend": {
+                    "observed": True, "exploration_ready": False,
+                    "state": "wait_pullback_rebreak",
+                    "blockers": ["needs_primary_evidence", "overheated_wait_rebreak"],
+                },
+            }, {
+                "ticker": "SPCX", "source_ticker": "SPCX", "is_proxy": False,
+                "tier": "none", "allowed": False,
+                "early_trend": {
+                    "observed": True, "exploration_ready": False,
+                    "state": "wait_information",
+                    "blockers": ["needs_information_confirmation", "needs_primary_evidence"],
+                },
+            }, {
+                "ticker": "SPCH", "source_ticker": "SPCX", "is_proxy": True,
+                "tier": "none", "allowed": False,
+                "early_trend": {
+                    "observed": True, "exploration_ready": False,
+                    "state": "candidate_only",
+                    "blockers": ["leveraged_requires_validated_evidence"],
+                },
+            }],
+        },
+    }
+
+
+def test_rich_card_gets_a_deterministic_deduplicated_candidate_section(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(common, "WS", tmp_path)
+    card = tmp_path / "memory" / ".tmp" / f"brief-card-{TODAY}.txt"
+    card.parent.mkdir(parents=True)
+    card.write_text(
+        "📊 盘前深度简报\n\n▎提前布局候选\n模型遗漏的旧文字\n\n📈 完整报告：link",
+        encoding="utf-8",
+    )
+
+    result = common.build_brief_card(TODAY, decision_packet=_packet())
+
+    assert result.count("▎提前布局候选") == 1
+    assert "提示 2 个底层机会 · 可小仓试探 0 · 当前可加仓 0" in result
+    assert "SPCX（SPCH 映射）" in result
+    assert "模型遗漏的旧文字" not in result
+    assert "缺一手披露" in result
+
+
+def test_plan_fallback_also_reports_zero_candidate_truth(tmp_path, monkeypatch):
+    monkeypatch.setattr(common, "WS", tmp_path)
+    plan = tmp_path / "memory" / f"{TODAY}-plan.json"
+    plan.parent.mkdir(parents=True)
+    plan.write_text(json.dumps({"decisions": []}), encoding="utf-8")
+    packet = {"add_alpha_diagnostics": {"candidates": []}}
+
+    result = common.build_brief_card(TODAY, decision_packet=packet)
+
+    assert "提示 0 个底层机会 · 可小仓试探 0 · 当前可加仓 0" in result
+    assert "不是“模型没写”" in result
+    assert result.index("▎提前布局候选") < result.index("📈 完整报告")

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -163,6 +163,8 @@ def _valid_overlay(packet):
         row["assessment"] = "结构化信号支持当前判断。"
         row["counterargument"] = "短线可能反向波动。"
         row["rationale"] = "在趋势和风险约束冲突时优先风险。"
+        row["falsifier"] = "突破失效或一手证据转负。"
+        row["next_evidence"] = "下一时段价格确认与发行人披露。"
     return overlay
 
 
@@ -307,6 +309,59 @@ def test_judgment_schema_allows_opinions_but_rejects_market_fields():
     )
 
 
+def test_judgment_can_downgrade_but_cannot_invent_a_candidate():
+    packet = _compiled()
+    overlay = _valid_overlay(packet)
+    lev = next(row for row in overlay["ticker_judgments"] if row["ticker"] == "LEVX")
+    lev["disposition"] = "candidate"
+
+    issues = packet_mod.validate_judgment_overlay(packet, overlay)
+
+    assert any("cannot upgrade" in issue for issue in issues)
+
+
+def test_judgment_rejects_a_deterministic_candidate_without_removing_the_hint():
+    context = _context()
+    context["quant_signals"]["rows"]["00100"].update({
+        "trend_on": None, "close": 11, "prior_20d_high": 10, "zscore20": 1,
+    })
+    context["peer_residual"]["held"]["00100"] = {
+        "feature_as_of": "2026-07-28", "residual_blend_5d": .2,
+        "peer_dispersion_5d": .05, "available_peer_count": 4,
+    }
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    overlay = _valid_overlay(packet)
+    hk = next(row for row in overlay["ticker_judgments"] if row["ticker"] == "00100")
+    hk["disposition"] = "reject"
+
+    assert packet_mod.validate_judgment_overlay(packet, overlay) == []
+    projection = packet_mod.compile_pages_projection(packet, overlay)
+    row = next(row for row in projection["tickers"] if row["ticker"] == "00100")
+    candidate = next(
+        row for row in projection["add_campaign"]["candidates"]
+        if row["ticker"] == "00100"
+    )
+    assert row["candidate_disposition"]["effective"] == "reject"
+    assert candidate["early_trend"]["observed"] is True
+
+
+def test_short_history_is_unknown_not_trend_off():
+    context = _context()
+    context["quant_signals"]["rows"]["00100"].update({
+        "trend_on": None, "tag": "趋势OFF · z+2.1σ极端",
+    })
+
+    row = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )["tickers"]["00100"]
+
+    assert row["technical"]["trend"] == "unknown"
+    assert "趋势未知" in row["technical"]["tag"]
+    assert row["status"]["label"] == "趋势未知·短历史"
+
+
 def test_invalid_overlay_cannot_corrupt_deterministic_pages_rows(tmp_path):
     packet = _compiled()
     overlay = _valid_overlay(packet)
@@ -372,6 +427,20 @@ def test_pages_projection_exposes_add_campaign_without_raw_run_card_inputs():
                 "authority_classifications": {"none": 186, "exploration": 6,
                                                "validated": 0},
                 "claim": "diagnostic_not_validated_alpha",
+                "early_trend": {"observed_candidates": 5},
+            },
+            "early_trend": {
+                "us": {"observed": {
+                    "t1": {"n": 3, "mean_return": .02, "hit_rate": .67,
+                           "status": "collecting"},
+                    "t5": {"n": 2, "mean_return": .04, "hit_rate": 1,
+                           "status": "collecting"},
+                }},
+                "hk": {"observed": {
+                    "t1": {"n": 1, "mean_return": -.01, "hit_rate": 0,
+                           "status": "collecting"},
+                    "t5": {"n": 0, "status": "collecting"},
+                }},
             },
         },
     }
@@ -388,7 +457,7 @@ def test_pages_projection_exposes_add_campaign_without_raw_run_card_inputs():
     hk = next(row for row in campaign["candidates"] if row["ticker"] == "00100")
     assert "price_relative" in hk["evidence_families"]
     assert set(hk) >= {
-        "state", "tier", "sources", "evidence_families",
+        "state", "tier", "source_ticker", "is_proxy", "sources", "evidence_families",
         "authority_blockers", "execution_blockers", "entry_price",
         "invalidation_price", "target_tranche_level", "max_add_shares",
     }
@@ -396,7 +465,62 @@ def test_pages_projection_exposes_add_campaign_without_raw_run_card_inputs():
     assert run_card["markets"]["us"]["t1"]["n"] == 4
     assert run_card["markets"]["hk"]["t20"]["status"] == "collecting"
     assert run_card["coverage"]["prospective_information_dates"] == 0
+    assert run_card["coverage"]["early_trend"]["observed_candidates"] == 5
+    assert run_card["early_trend"]["us"]["observed"]["t1"]["n"] == 3
     assert "inputs" not in run_card
+
+
+def test_candidate_diagnostics_deduplicate_proxy_and_underlying_as_one_idea():
+    context = _context()
+    context["portfolio"]["portfolios"]["us_stocks"]["holdings"].append({
+        "ticker": "BASE", "name": "Underlying", "shares": 10,
+        "cost_basis": 10, "current_price": 11, "current_value": 110,
+    })
+    for ticker in ("BASE",):
+        context["quant_signals"]["rows"][ticker] = {
+            "status": "fresh", "row_as_of": "2026-07-28", "trend_on": None,
+            "close": 11, "prior_20d_high": 10, "zscore20": 2.1,
+        }
+    context["peer_residual"]["held"]["BASE"] = {
+        "feature_as_of": "2026-07-28", "residual_blend_5d": .2,
+        "peer_dispersion_5d": .05, "available_peer_count": 4,
+    }
+
+    diagnostics = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )["add_alpha_diagnostics"]
+
+    assert diagnostics["observed_candidate_count"] == 2
+    assert diagnostics["observed_idea_count"] == 1
+
+
+def test_early_exploration_reports_its_real_tranche_and_evidence_families():
+    context = _context()
+    context["quant_signals"]["rows"]["00100"].update({
+        "trend_on": None, "close": 11, "prior_20d_high": 10,
+        "prior_5d_low": 9.5, "ma20": 10, "zscore20": 1,
+    })
+    context["peer_residual"]["held"]["00100"] = {
+        "feature_as_of": "2026-07-28", "residual_blend_5d": .2,
+        "peer_dispersion_5d": .05, "available_peer_count": 4,
+    }
+    context["news_evidence_graph"]["events"][0].update({
+        "source_type": "issuer_announcement", "impact_direction": "positive",
+    })
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    row = next(
+        row for row in packet["add_alpha_diagnostics"]["candidates"]
+        if row["ticker"] == "00100"
+    )
+
+    assert row["state"] == "exploration_ready"
+    assert row["target_tranche_level"] == .25
+    assert row["evidence_families"] == [
+        "point_in_time_information", "price_relative",
+    ]
+    assert row["entry_price"] == 11
 
 
 def test_pages_projection_names_a_packet_that_predates_add_policy():
@@ -652,6 +776,9 @@ def test_plan_provenance_is_replaced_from_generation_bound_packet():
     assert provenance["context_generation_id"] == packet["_meta"]["generation_id"]
     assert provenance["information"] == packet["tickers"]["00100"]["information"]
     assert provenance["information"].get("signed_score") != 999
+    assert provenance["early_trend"] == (
+        packet["tickers"]["00100"]["quant"]["early_trend"]
+    )
 
 
 def _catalyst(action, evidence_id, ticker="00100"):

--- a/tests/test_early_trend.py
+++ b/tests/test_early_trend.py
@@ -1,0 +1,92 @@
+"""Behavior contracts for the short-history candidate lane."""
+from clawock.decision import early_trend
+
+
+POLICY = {
+    "minimum_attention_acceleration": 1.25,
+    "minimum_attention_source_types": 1,
+    "early_peer_dispersion_multiple": 1.5,
+    "early_no_chase_zscore": 2.0,
+    "exploration_tranche_pct": 0.025,
+    "confirmation_window_sessions": 5,
+    "markets": {
+        "HK": {"minimum_attention_rank": .65, "minimum_peer_count": 3},
+        "US": {"minimum_attention_rank": .75, "minimum_peer_count": 3},
+    },
+}
+
+
+def test_short_history_breakout_is_visible_but_overheated_never_chases():
+    candidate = early_trend.classify(
+        {"usable": True, "close": 376.8, "prior_20d_high": 374.4,
+         "zscore20": 2.14},
+        {"residual_5d": .2133, "dispersion_5d": .1063,
+         "available_peer_count": 5},
+        {"attention_rank": .875, "attention_acceleration": 2.3669,
+         "attention_source_type_count": 2, "attention_event_count": 9},
+        [], leveraged=False, policy=POLICY, market="HK",
+    )
+
+    assert candidate["observed"] is True
+    assert candidate["state"] == "wait_pullback_rebreak"
+    assert candidate["information_modes"] == ["attention_acceleration"]
+    assert "needs_primary_evidence" in candidate["blockers"]
+    assert early_trend.exploration_setup({}, candidate, POLICY, ticker="00100") is None
+
+
+def test_primary_event_can_promote_a_cool_nonleveraged_candidate_to_exploration():
+    technical = {
+        "usable": True, "as_of": "2026-08-13", "close": 10.5,
+        "prior_20d_high": 10, "prior_5d_low": 9, "ma20": 9.5,
+        "chandelier_stop": 8.8, "zscore20": 1.2,
+    }
+    candidate = early_trend.classify(
+        technical,
+        {"residual_5d": .12, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {},
+        [{"event_id": "sec-1", "source_type": "sec_filing", "direction": 1}],
+        leveraged=False, policy=POLICY, market="US",
+    )
+    setup = early_trend.exploration_setup(
+        technical, candidate, POLICY, ticker="ABC"
+    )
+
+    assert candidate["state"] == "exploration_ready"
+    assert candidate["primary_event_ids"] == ["sec-1"]
+    assert setup["setup_id"] == "early_trend_confirmation"
+    assert setup["tranche_pct_of_position"] == .025
+
+
+def test_primary_source_precedes_syndication_and_accepts_numeric_direction():
+    candidate = early_trend.classify(
+        {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},
+        {"residual_5d": .2, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {},
+        [
+            {"event_id": "wire", "source_type": "finnhub_syndication",
+             "direction": "positive"},
+            {"event_id": "filing", "source_type": "issuer_announcement",
+             "direction": "1"},
+        ],
+        leveraged=False, policy=POLICY, market="US",
+    )
+
+    assert candidate["primary_event_ids"] == ["filing"]
+    assert candidate["information_modes"] == ["primary_positive_event"]
+    assert "needs_primary_evidence" not in candidate["blockers"]
+
+
+def test_leveraged_candidate_never_gets_unvalidated_exploration():
+    candidate = early_trend.classify(
+        {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},
+        {"residual_5d": .2, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {"attention_rank": .9, "attention_acceleration": 2,
+         "attention_source_type_count": 2, "attention_event_count": 2},
+        [], leveraged=True, policy=POLICY, market="US",
+    )
+    assert candidate["observed"] is True
+    assert candidate["exploration_ready"] is False
+    assert "leveraged_requires_validated_evidence" in candidate["blockers"]


### PR DESCRIPTION
Closes #522.

## Outcome

Visible trends in short-history names no longer disappear behind the MA200 gate. The brief now separates an auditable early hint, one bounded exploration tranche, and mature validated add authority.

## Mechanism

- Requires a prior-20-session breakout and 5-session peer leadership of at least 1.5 peer dispersions.
- Treats breakout and peer residual as one price-relative evidence family.
- Requires independent point-in-time information for exploration: positive primary evidence or registered attention acceleration.
- Keeps `needs_primary_evidence` when only syndicated evidence exists.
- Blocks market chasing at `zscore20 >= 2`; the state becomes pullback/rebreak wait.
- Keeps leveraged daily-reset products out of unvalidated exploration.
- Makes Bull/Bear/Judge consequential through bounded `candidate|wait|reject`, falsifier and next evidence, while preserving deterministic authority ownership.
- Injects a deterministic candidate summary into the compact card and deduplicates proxy/underlying ideas.

## Production replay

The frozen 2026-08-13 packet now shows two underlying ideas: `00100` and `SPCX` (`SPCH` is explicitly a leveraged proxy), both in wait-for-rebreak state. Current allowed adds remain zero.

## Evaluation

Receipt: `memory/backtests/add_alpha_walkforward-20260813-3a918d77.json`.

- US candidate T+1: n=8, mean +0.51%, hit 50%; T+5: n=5, mean +6.39%, hit 100%.
- HK candidate T+1: n=2, mean -2.39%, hit 0%; no T+5 sample.
- About 14 registered dates only; all results remain `collecting`, not validated alpha.

## Verification

- Focused behavioral suite: 98 passed.
- JavaScript syntax checks passed.
- `git diff --check` passed.
