### PR TITLE
refactor: make active information a core strategy

### DIFF
--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -20,9 +20,15 @@ execution/outcome → bounded, reviewable improvement proposal.
 | Layer | Owns | Current location |
 |---|---|---|
 | Plugin/harness core | portable skills/workflows, generation-pinned artifact contract, validation/reconciliation, context assembly, tool schemas, evaluation contracts | `src/clawock/` + portable skill/workflow packages (in progress) |
-| Instance | portfolio, schedules, selected skills/persona, delivery targets, dashboard skin | root data + `config/` + `skills/` |
+| Instance | portfolio data, schedules, deployment overrides, selected skills/persona, delivery targets, dashboard skin | root data + `config/` + `skills/` |
 | Runtime adapters | conversations, scheduling, delivery, run history | OpenClaw today; provider interfaces in `src/clawock/providers/` |
 | Live desk adapter | market refresh, `.tmp` artifact placement, git coordination, publication/watchdogs | separately installable `instances/kcnyu/` distribution |
+
+Reusable investment strategies remain product code under `src/clawock/decision/`,
+even when the first consumer is the live KCNyu desk. The live adapter binds those
+strategies into phases and delivery; it is not a second strategy package. The
+full provider → strategy → instance ownership rule is documented in
+[`product-vs-instance.md`](../reference/product-vs-instance.md#evidence-strategy-and-instance-rule).
 
 The public CLI is the stable driver boundary:
 

--- a/docs/reference/product-vs-instance.md
+++ b/docs/reference/product-vs-instance.md
@@ -21,6 +21,40 @@ needs the behavior unchanged.
 File size, language and test coverage do not decide ownership. Stable commands
 are APIs; historical Python or shell paths are not.
 
+## Evidence, strategy and instance rule
+
+Investment strategy is a product capability, not an instance implementation.
+Use this dependency direction for every new signal or strategy:
+
+```text
+market_data provider DTO -> decision strategy -> instance phase/render/delivery
+```
+
+- A provider fetches and normalizes attributable evidence and reports source
+  degradation. It does not read a portfolio, choose an action, inspect reaction
+  thresholds, size exposure, persist strategy state or alert a user.
+- A strategy under `src/clawock/decision/` owns the reusable algorithm: portfolio
+  scope, instrument look-through, signal state, risk/exploration contract and
+  its bounded state. It accepts a generic workspace/book and explicit policy;
+  it does not know KCNyu, OpenClaw, a delivery target or prose layout.
+- An instance is a thin binding for phase wiring, deployment-only overrides,
+  presentation and delivery. Do not move an algorithm into `instances/` merely
+  because one live desk consumes it first.
+- Consumers depend on public DTO/functions, never another feature's private
+  constants, config rule IDs or module globals. For example, an information-first
+  strategy must consume a primary-disclosure DTO rather than the internal
+  `interrupt` classification of mover attribution.
+- Resolve workspace paths when the phase is called. Import-time paths and default
+  arguments derived from them bind a long-lived process to whichever workspace
+  imported the module first.
+- Skills explain how to consume the structured result. They must not redefine
+  thresholds, sizing or state transitions already owned by Python policy.
+
+The placement test is therefore not “does this mention a portfolio?” A portable
+strategy is expected to operate on a caller's portfolio. The test is “would a
+different clawock user need this algorithm unchanged?” If yes, it belongs in
+the product; only the live deployment binding belongs in the instance.
+
 ## Canonical owners
 
 | Path | Owner |

--- a/instances/kcnyu/README.md
+++ b/instances/kcnyu/README.md
@@ -6,10 +6,12 @@ is not installed by ordinary `clawock` users.
 
 During the migration this distribution still hosts live-market phases, delivery
 and watchdog code. That location is not evidence that the logic is KCNyu-only:
-reusable investment preflight, validation, reconciliation, generation and
-postflight belongs in `clawock`, while reusable OpenClaw integration belongs to
-a runtime adapter. This distribution must shrink to KCNyu-specific configuration
-and bindings such as delivery targets, live schedules and repository publication.
+reusable investment providers and strategies — including portfolio scope,
+look-through, signal state and sizing contracts — belong in `clawock`, while
+reusable OpenClaw integration belongs to a runtime adapter. This distribution
+must shrink to KCNyu-specific configuration and bindings such as phase wiring,
+delivery targets, live schedules and repository publication. It must not become
+a second strategy package.
 
 OpenClaw remains the external runtime that owns model calls, chat, memory, tools
 and cron scheduling. Portfolio ledgers and generated artifacts remain in the

--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
@@ -41,6 +41,7 @@ from clawock.decision import signals as quant_signals
 from clawock.evidence import research_surface
 from clawock.cli import PACKAGED_UTILITIES
 from clawock.market_data import known_catalysts, mover_evidence as mover_news, peer_scan
+from clawock.decision import active_information
 
 WS = workspace_root(Path.cwd())
 TMP = WS / 'memory' / '.tmp'
@@ -48,7 +49,6 @@ TMP = WS / 'memory' / '.tmp'
 from ._harness_common import compute_context_id
 
 from clawock_kcnyu.automation import cron_heartbeat  # noqa: E402
-from clawock_kcnyu import active_information  # noqa: E402
 
 
 # `scripts/data` was deleted in #429 and the analysis moved into the package in
@@ -406,7 +406,7 @@ def main(argv=None):
     # anomaly.  This is the active counterpart to mover_news below, which still
     # answers the separate question "what explains an already-large move?".
     try:
-        active_information_ctx = active_information.scan_workspace(args.market)
+        active_information_ctx = active_information.scan_workspace(WS, args.market)
     except Exception as exc:  # noqa: BLE001 — a filing source must not red a slot
         active_information_ctx = {
             'schema_version': 1, 'market': args.market, 'candidates': [],

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -87,7 +87,7 @@ In this order:
 clawock intraday preflight --market hk
 ```
 跑 `clawock analyze-hk --wechat --md-table` + 抽信号 + 异动，输出 `memory/.tmp/intraday-context-hk-latest.json`，并把**同一份 JSON** 打到 stdout（含 `context_id` —— Step 3 要原样回传）。
-- `active_information_candidates` — **不等价格先异动**，每个 slot 主动扫持仓运营公司的一手港交所公告；基金/指数不伪装成发行人，杠杆底层按发行人去重。`candidate` 是正向明确披露且日内尚未充分反应，`wait` 是方向未提取/股价已反应/价格缺失，`reject` 是不利披露下拒绝加仓；三者都不是下单授权。港股未验证探索最多显示 portfolio 中已核过的 **一手 board lot**，缺 lot 就只留候选，绝不假定 1 股是一手。
+- `active_information_candidates` — 框架已完成一手披露扫描、底层去重、`candidate|wait|reject` 与探索上限计算；这里只消费结构化结果，不在 skill 里重算阈值、方向或股数。三态都不是下单授权。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 - `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
   - `known_catalysts` 是当天 08:00 brief 已核过、且只按本轮异动票裁剪的结构化催化。它回答「此前已知什么」，`mover_news` 回答「这个分钟窗口新发生什么」；两者不能混为一谈，也不因此扩大新闻窗口。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -89,7 +89,7 @@ dreaming 留独占窗口，所以 EST 季比 EDT 季少两个 slot。
 clawock intraday preflight --market us
 ```
 输出 `memory/.tmp/intraday-context-us-latest.json`，并把**同一份 JSON** 打到 stdout（含 `context_id` —— Step 3 要原样回传）。关键字段：`should_alert` + `alert_reasons`，另有 `peer_scan`（本腿持仓的板块+同业涨跌，已排序）和 `plan_context`（08:00 简报为本腿定下、尚未成交的决策）。
-- `active_information_candidates` — **不等价格先异动**，每个 slot 主动扫持仓公司与杠杆持仓底层发行人的一手披露，并按发行人去重。`candidate` 是正向明确披露且日内尚未充分反应，`wait` 是方向未提取/股价已反应/价格缺失，`reject` 是不利披露下拒绝加仓；三者都不是下单授权。美股未验证探索最多显示底层 **1 股** hint，杠杆日重置产品不做未验证探索。
+- `active_information_candidates` — 框架已完成一手披露扫描、底层去重、`candidate|wait|reject` 与探索上限计算；这里只消费结构化结果，不在 skill 里重算阈值、方向或股数。三态都不是下单授权。
 - `mover_thesis` — **只对本轮异动票**的 thesis 只读快照：`state`、`triggered`/`watch` 红线（含 severity 与 required_action）、下次 review trigger；最新一次 entry gate 判 `reject` 也会标出来。没有基线就是 `unknown`，不许靠记忆补。**这是归因语境不是催化剂**：红线解释「这个跌为什么要紧、当初说好要怎么做」，但能不能动手仍由 catalyst-gate 决定（软消息/情绪不构成主动操作依据）。
 - `mover_news` — **只对本轮异动票**、有限预算抓回来的「刚发生了什么」：`tier=primary` 是交易所/监管一手文件（港股=港交所公告，美股=SEC filing，带 `age_minutes`），`tier=supporting` 是券商研报/媒体/7×24 快讯。**只有 primary 才可能构成硬催化**（仍要过 catalyst-gate）；supporting 只能当色彩，不能作为主动操作依据。
   - `known_catalysts` 是当天 08:00 brief 已核过、且只按本轮异动票裁剪的结构化催化。它回答「此前已知什么」，`mover_news` 回答「这个分钟窗口新发生什么」；两者不能混为一谈，也不因此扩大新闻窗口。

--- a/src/clawock/decision/active_information.py
+++ b/src/clawock/decision/active_information.py
@@ -1,44 +1,91 @@
-"""KCNyu information-first intraday candidates from primary disclosures.
+"""Reusable information-first strategy for primary disclosures.
 
-This is instance policy, not portable clawock core: it knows the KCNyu live book,
-the one-lot/one-share exploration preference and the held proxy universe.  Core
-provides bounded disclosure evidence and instrument primitives; this adapter
-chooses what to scan and how to surface a candidate.
+The strategy accepts a generic portfolio, instrument registry, explicit policy
+and workspace.  It owns discovery scope, signal state, exploration sizing and
+event deduplication; it does not know a live instance, runtime, delivery target
+or prose renderer.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from clawock.market_data import mover_evidence, peer_quotes
-from clawock.portfolio import instruments
+from clawock.decision import information_signals
+from clawock.market_data import peer_quotes, primary_disclosures
+from clawock.portfolio import instruments as default_instruments
 from clawock.safe_io import safe_write_json
-from clawock.workspace import workspace_root
 
 
-WS = workspace_root(Path.cwd())
-PORTFOLIO = WS / "portfolio.json"
-SEEN_DIR = WS / "memory" / ".tmp"
-MAX_ACTIVE_ISSUERS = 4
-HOT_REACTION_PCT = 3.0
-CONTRADICTED_REACTION_PCT = -2.0
-POSITIVE_TERMS = (
-    "盈喜", "盈利预喜", "正面盈利", "上调指引", "提高指引", "raise guidance",
-    "raised guidance", "record revenue", "beats expectations", "股份回购",
-    "购回股份", "buyback", "repurchase", "中标", "获得订单", "contract award",
-    "awarded contract", "获批", "获得批准", "approved", "regulatory approval",
+@dataclass(frozen=True)
+class ActiveInformationPolicy:
+    max_active_issuers: int
+    window_minutes: int
+    budget_s: float
+    hk_exploration_lots: int
+    us_exploration_shares: int
+    signal: information_signals.InformationPolicy
+
+
+DEFAULT_POLICY = ActiveInformationPolicy(
+    max_active_issuers=4,
+    window_minutes=240,
+    budget_s=20,
+    hk_exploration_lots=1,
+    us_exploration_shares=1,
+    signal=information_signals.InformationPolicy(
+        positive_markers=(
+            "盈喜", "盈利预喜", "正面盈利", "上调指引", "提高指引", "raise guidance",
+            "raised guidance", "record revenue", "beats expectations", "股份回购",
+            "购回股份", "buyback", "repurchase", "中标", "获得订单", "contract award",
+            "awarded contract", "获批", "获得批准", "approved", "regulatory approval",
+        ),
+        negative_markers=(
+            "盈利警告", "盈警", "下调指引", "cut guidance", "lowered guidance",
+            "配售", "供股", "发行新股", "可转换债券", "先旧后新", "offering",
+            "prospectus supplement", "at-the-market", "424b", "s-1", "s-3",
+            "late filing", "nt 10-",
+            "loss of customer", "default", "recall", "调查", "诉讼",
+        ),
+        eligible_markers=(
+            "8-k", "6-k", "10-q", "10-k", "20-f", "annual report", "quarterly report",
+            "results of operations", "sc 13d", "sc to", "425", "defm14a", "merger",
+            "内幕消息", "须予公布的交易",
+            "非常重大", "收购", "要约", "合并", "出售股权", "重大资产", "业绩公告",
+            "中期业绩", "年度业绩", "季度业绩", "未经审核", "停牌", "短暂停止买卖",
+            "复牌", "恢复买卖",
+        ),
+        ignored_markers=(
+            "翌日披露报表", "月报表", "证券变动月报表", "下一营业日披露报表",
+            "法律意见书", "律师事务所关于", "form 3", "form 4", "form 5",
+            "statement of changes in beneficial ownership", "schedule 13g",
+            "notice of proposed sale",
+        ),
+        categories=(
+            ("dilution", ("配售", "供股", "发行新股", "可转换债券", "先旧后新",
+                          "offering", "prospectus supplement", "at-the-market", "424b",
+                          "s-1", "s-3")),
+            ("filing_delay", ("late filing", "nt 10-")),
+            ("profit_revision", ("盈利警告", "盈警", "盈喜", "盈利预喜", "上调指引",
+                                 "raise guidance", "raised guidance")),
+            ("capital_return", ("股份回购", "购回股份", "buyback", "repurchase")),
+            ("ownership", ("13d",)),
+            ("results", ("10-q", "10-k", "20-f", "annual report", "quarterly report",
+                         "results of operations", "业绩公告", "中期业绩", "年度业绩", "季度业绩")),
+            ("corporate_action", ("merger", "sc to", "425", "defm14a", "收购", "要约",
+                                  "合并", "出售股权", "重大资产")),
+            ("inside_information", ("内幕消息", "须予公布的交易", "非常重大")),
+            ("trading_status", ("停牌", "短暂停止买卖", "复牌", "恢复买卖")),
+        ),
+        hot_reaction_pct=3.0,
+        contradicted_reaction_pct=-2.0,
+    ),
 )
-NEGATIVE_TERMS = (
-    "盈利警告", "盈警", "下调指引", "cut guidance", "lowered guidance",
-    "配售", "供股", "发行新股", "可转换债券", "先旧后新", "offering",
-    "prospectus supplement", "at-the-market", "late filing", "nt 10-",
-    "loss of customer", "default", "recall", "调查", "诉讼",
-)
 
 
-def _load_portfolio(path=PORTFOLIO):
+def _load_portfolio(path):
     try:
         doc = json.loads(Path(path).read_text())
         return doc if isinstance(doc, dict) else {}
@@ -46,7 +93,7 @@ def _load_portfolio(path=PORTFOLIO):
         return {}
 
 
-def active_issuer_scope(portfolio: dict, market: str) -> list[dict]:
+def active_issuer_scope(portfolio: dict, market: str, *, registry) -> list[dict]:
     """Deduplicated reporting issuers behind active holdings for one market."""
     leg = "hk_stocks" if market == "hk" else "us_stocks"
     holdings = ((portfolio.get("portfolios") or {}).get(leg) or {}).get("holdings") or []
@@ -55,7 +102,7 @@ def active_issuer_scope(portfolio: dict, market: str) -> list[dict]:
         if not isinstance(holding, dict) or (holding.get("shares") or 0) <= 0:
             continue
         ticker = str(holding.get("ticker") or "")
-        target = instruments.look_through(ticker)
+        target = default_instruments.look_through(ticker, registry=registry)
         issuer = target.get("issuer")
         if not issuer:
             continue
@@ -64,7 +111,7 @@ def active_issuer_scope(portfolio: dict, market: str) -> list[dict]:
             "proxy_holdings": [], "leveraged_only": True, "board_lot": None,
         })
         row["holdings"].append(ticker)
-        leveraged = instruments.is_leveraged_holding(holding)
+        leveraged = default_instruments.is_leveraged_holding(holding, registry=registry)
         if ticker == issuer:
             row["direct_holdings"].append(ticker)
             if not leveraged:
@@ -85,86 +132,29 @@ def _event_id(issuer: str, item: dict) -> str:
     if item.get("accession"):
         return f"sec:{item['accession']}"
     raw = "|".join(str(value or "") for value in (
-        issuer, item.get("published_at"), item.get("url"), item.get("raw_title") or item.get("title")
+        issuer, item.get("published_at"), item.get("source_url"), item.get("title")
     ))
     return "primary:" + hashlib.sha256(raw.encode()).hexdigest()[:20]
 
 
-def extract_expectation(item: dict) -> dict:
-    """Classify only language attributable to the primary item itself."""
-    title = str(item.get("raw_title") or item.get("title") or "")
-    folded = title.casefold()
-    negative = next((term for term in NEGATIVE_TERMS if term.casefold() in folded), None)
-    positive = next((term for term in POSITIVE_TERMS if term.casefold() in folded), None)
-    rule = str(item.get("triage_rule") or "")
-    if negative:
-        direction = "negative"
-        marker = negative
-    elif positive:
-        direction = "positive"
-        marker = positive
-    elif rule in {"us-offering", "us-late-filing", "hk-equity-raise", "hk-profit-alert"}:
-        # hk-profit-alert combines 盈喜 and 盈警, so only explicit terms above may
-        # resolve it.  The other three rule ids are directionally unambiguous.
-        if rule == "hk-profit-alert":
-            direction, marker = "unknown", None
-        else:
-            direction, marker = "negative", rule
-    else:
-        direction, marker = "unknown", None
-    category = {
-        "us-offering": "dilution", "hk-equity-raise": "dilution",
-        "us-late-filing": "filing_delay", "hk-profit-alert": "profit_revision",
-        "hk-buyback-programme": "capital_return", "us-13d-activist": "ownership",
-        "us-8k": "material_event", "us-periodic": "results",
-        "hk-results": "results", "hk-mna": "corporate_action",
-        "us-mna": "corporate_action", "hk-inside-information": "inside_information",
-    }.get(rule, "material_disclosure")
-    return {
-        "direction": direction,
-        "category": category,
-        "detail": title,
-        "explicit_marker": marker,
-        "detail_status": "explicit" if direction != "unknown" else "needs_detail_extraction",
-    }
-
-
-def _disposition(direction: str, reaction, *, leveraged_only=False) -> tuple[str, list[str]]:
-    blockers = ["candidate_is_not_order_authority"]
-    if direction == "negative":
-        return "reject", blockers + ["adverse_primary_disclosure"]
-    if direction != "positive":
-        return "wait", blockers + ["needs_detail_extraction"]
-    if not isinstance(reaction, (int, float)):
-        # Do not erase the event merely because price coverage failed.  It stays a
-        # candidate hint, but exploration remains blocked below.
-        blockers.append("price_reaction_unavailable")
-        if leveraged_only:
-            blockers.append("leveraged_holding_cannot_take_unvalidated_exploration")
-        return "candidate", blockers
-    if reaction >= HOT_REACTION_PCT:
-        return "wait", blockers + ["price_already_reacted"]
-    if reaction <= CONTRADICTED_REACTION_PCT:
-        return "wait", blockers + ["tape_contradicts_positive_event"]
-    if leveraged_only:
-        blockers.append("leveraged_holding_cannot_take_unvalidated_exploration")
-    return "candidate", blockers
-
-
-def _exploration_hint(scope: dict, market: str, disposition: str, reaction) -> dict | None:
-    if disposition != "candidate" or not isinstance(reaction, (int, float)):
+def _exploration_hint(scope: dict, market: str, disposition: str, reaction,
+                      *, registry, policy) -> dict | None:
+    if (disposition != "candidate" or not isinstance(reaction, (int, float))
+            or scope.get("leveraged_only")):
         return None
     issuer = scope["issuer"]
-    meta = instruments.get(issuer) or {}
+    meta = default_instruments.get(issuer, registry=registry) or {}
     if float(meta.get("leverage_multiple") or 1) > 1:
         return None
     if market == "hk":
         lot = scope.get("board_lot")
         if not isinstance(lot, int) or lot <= 0:
             return None
-        shares, unit = lot, "one_board_lot"
+        shares = lot * int(policy.hk_exploration_lots)
+        unit = "one_board_lot" if policy.hk_exploration_lots == 1 else "board_lots"
     else:
-        shares, unit = 1, "one_share"
+        shares = int(policy.us_exploration_shares)
+        unit = "one_share" if shares == 1 else "shares"
     return {
         "ticker": issuer, "shares": shares, "unit": unit,
         "status": "unvalidated_exploration_hint",
@@ -173,15 +163,21 @@ def _exploration_hint(scope: dict, market: str, disposition: str, reaction) -> d
     }
 
 
-def scan(portfolio: dict | None, *, market: str, now=None, http=None,
-         quote_fetcher=peer_quotes.fetch_all) -> dict:
+def scan(portfolio: dict | None, *, market: str, policy=DEFAULT_POLICY, now=None, http=None,
+         quote_fetcher=peer_quotes.fetch_all, disclosure_probe=primary_disclosures.probe,
+         registry) -> dict:
     """Scan the bounded live issuer set before any price-anomaly filter."""
     now = now or datetime.now(timezone.utc)
-    scope = active_issuer_scope(portfolio or {}, market)
-    chased, skipped = scope[:MAX_ACTIVE_ISSUERS], scope[MAX_ACTIVE_ISSUERS:]
+    scope = active_issuer_scope(
+        portfolio or {}, market, registry=registry,
+    )
+    chased = scope[:policy.max_active_issuers]
+    skipped = scope[policy.max_active_issuers:]
     issuers = [row["issuer"] for row in chased]
-    evidence = mover_evidence.probe(
-        issuers, market=market, now=now, http=http, primary_only=True,
+    evidence = disclosure_probe(
+        issuers, market=market, now=now, http=http,
+        window_minutes=policy.window_minutes, budget_s=policy.budget_s,
+        max_issuers=policy.max_active_issuers,
     ) if issuers else {}
     try:
         quotes = quote_fetcher(
@@ -195,22 +191,24 @@ def scan(portfolio: dict | None, *, market: str, now=None, http=None,
     status_by_issuer = {}
     for target in chased:
         issuer = target["issuer"]
-        entry = ((evidence.get("tickers") or {}).get(issuer) or {})
+        entry = ((evidence.get("issuers") or {}).get(issuer) or {})
         status_by_issuer[issuer] = entry.get("status") or "not_checked"
         quote = quotes.get(issuer) or {}
         reaction = quote.get("pct_1d") if not quote.get("stale_quote") else None
-        primary_interrupts = [
-            item for item in (entry.get("items") or [])
-            if item.get("tier") == mover_evidence.PRIMARY
-            and item.get("signal") == mover_evidence.INTERRUPT
-        ]
-        for item in primary_interrupts:
-            expectation = extract_expectation(item)
-            disposition, blockers = _disposition(
-                expectation["direction"], reaction,
-                leveraged_only=bool(target.get("leveraged_only")),
+        for item in (entry.get("events") or []):
+            if item.get("evidence_tier") != "primary":
+                continue
+            signal = information_signals.evaluate(item, reaction, policy.signal)
+            if signal is None:
+                continue
+            disposition = signal["disposition"]
+            blockers = list(signal["blockers"])
+            if target.get("leveraged_only"):
+                blockers.append("leveraged_holding_cannot_take_unvalidated_exploration")
+            hint = _exploration_hint(
+                target, market, disposition, reaction,
+                registry=registry, policy=policy,
             )
-            hint = _exploration_hint(target, market, disposition, reaction)
             if disposition == "candidate" and hint is None:
                 if market == "hk":
                     blockers.append("verified_board_lot_unavailable")
@@ -219,7 +217,7 @@ def scan(portfolio: dict | None, *, market: str, now=None, http=None,
             published = item.get("published_at")
             try:
                 expires = datetime.fromisoformat(str(published).replace("Z", "+00:00")) + timedelta(
-                    minutes=mover_evidence.WINDOW_MINUTES
+                    minutes=policy.window_minutes
                 )
                 expires_at = expires.isoformat()
             except (TypeError, ValueError):
@@ -230,30 +228,16 @@ def scan(portfolio: dict | None, *, market: str, now=None, http=None,
                 "held_via": target["holdings"],
                 "published_at": published,
                 "expires_at": expires_at,
-                "source_url": item.get("url"),
+                "source_url": item.get("source_url"),
                 "source_class": item.get("source_class"),
                 "source_quality": "primary",
-                **expectation,
+                **{key: value for key, value in signal.items()
+                   if key not in {"disposition", "blockers"}},
                 "session_reaction_pct": reaction,
                 "reaction_source": quote.get("source"),
                 "disposition": disposition,
                 "blockers": sorted(set(blockers)),
                 "exploration_hint": hint,
-                "falsifier": (
-                    "price rejects the disclosure or a later primary filing reverses the detail"
-                    if expectation["direction"] == "positive" else
-                    "a later primary filing resolves or reverses the adverse/unknown detail"
-                ),
-                "next_evidence": (
-                    "independent support plus non-overheated price confirmation"
-                    if expectation["detail_status"] == "explicit" else
-                    "extract the attributable filing detail before any directional action"
-                ),
-                "judge_contract": {
-                    "allowed": ["candidate", "wait", "reject"],
-                    "may_upgrade": False,
-                    "precomputed": disposition,
-                },
             })
     rows.sort(key=lambda row: (row.get("published_at") or "", row["issuer"]), reverse=True)
     return {
@@ -277,9 +261,16 @@ def scan(portfolio: dict | None, *, market: str, now=None, http=None,
     }
 
 
-def scan_workspace(market: str, **kwargs) -> dict:
-    result = scan(_load_portfolio(), market=market, **kwargs)
-    path = SEEN_DIR / f"active-information-seen-{market}.json"
+def scan_workspace(workspace, market: str, *, policy=DEFAULT_POLICY, **kwargs) -> dict:
+    workspace = Path(workspace)
+    registry = default_instruments.load_registry(
+        workspace / "config" / "instruments.json", missing_ok=True,
+    )
+    result = scan(
+        _load_portfolio(workspace / "portfolio.json"), market=market,
+        policy=policy, registry=registry, **kwargs,
+    )
+    path = workspace / "memory" / ".tmp" / f"active-information-seen-{market}.json"
     try:
         seen_doc = json.loads(path.read_text()) if path.exists() else {}
         seen = seen_doc.get("events") if isinstance(seen_doc, dict) else {}

--- a/src/clawock/decision/information_signals.py
+++ b/src/clawock/decision/information_signals.py
@@ -1,0 +1,98 @@
+"""Pure signal mechanics for point-in-time primary disclosures.
+
+The caller supplies both evidence and policy.  This module performs no fetch,
+workspace read, portfolio discovery, sizing, persistence, delivery or alerting.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class InformationPolicy:
+    positive_markers: tuple[str, ...]
+    negative_markers: tuple[str, ...]
+    eligible_markers: tuple[str, ...]
+    ignored_markers: tuple[str, ...]
+    categories: tuple[tuple[str, tuple[str, ...]], ...]
+    hot_reaction_pct: float
+    contradicted_reaction_pct: float
+
+
+def _first_marker(text: str, markers: Iterable[str]) -> str | None:
+    folded = text.casefold()
+    return next((marker for marker in markers if marker.casefold() in folded), None)
+
+
+def evaluate(event: Mapping, reaction_pct, policy: InformationPolicy) -> dict | None:
+    """Map one normalized event and a reaction into a bounded signal.
+
+    ``None`` means the caller's policy says the event is not strategy-relevant;
+    it does not mean the provider found no disclosure.
+    """
+    detail = str(event.get("title") or "")
+    ignored = _first_marker(detail, policy.ignored_markers)
+    positive = _first_marker(detail, policy.positive_markers)
+    negative = _first_marker(detail, policy.negative_markers)
+    eligible = positive or negative or _first_marker(detail, policy.eligible_markers)
+    if ignored or not eligible:
+        return None
+
+    if negative:
+        direction, explicit_marker = "negative", negative
+    elif positive:
+        direction, explicit_marker = "positive", positive
+    else:
+        direction, explicit_marker = "unknown", eligible
+
+    category = "material_disclosure"
+    for name, markers in policy.categories:
+        if _first_marker(detail, markers):
+            category = name
+            break
+
+    blockers = ["candidate_is_not_order_authority"]
+    if direction == "negative":
+        disposition = "reject"
+        blockers.append("adverse_primary_disclosure")
+    elif direction != "positive":
+        disposition = "wait"
+        blockers.append("needs_detail_extraction")
+    elif not isinstance(reaction_pct, (int, float)):
+        disposition = "candidate"
+        blockers.append("price_reaction_unavailable")
+    elif reaction_pct >= policy.hot_reaction_pct:
+        disposition = "wait"
+        blockers.append("price_already_reacted")
+    elif reaction_pct <= policy.contradicted_reaction_pct:
+        disposition = "wait"
+        blockers.append("tape_contradicts_positive_event")
+    else:
+        disposition = "candidate"
+
+    detail_status = "explicit" if direction != "unknown" else "needs_detail_extraction"
+    return {
+        "direction": direction,
+        "category": category,
+        "detail": detail,
+        "explicit_marker": explicit_marker,
+        "detail_status": detail_status,
+        "disposition": disposition,
+        "blockers": blockers,
+        "falsifier": (
+            "price rejects the disclosure or a later primary filing reverses the detail"
+            if direction == "positive" else
+            "a later primary filing resolves or reverses the adverse/unknown detail"
+        ),
+        "next_evidence": (
+            "independent support plus non-overheated price confirmation"
+            if detail_status == "explicit" else
+            "extract the attributable filing detail before any directional action"
+        ),
+        "judge_contract": {
+            "allowed": ["candidate", "wait", "reject"],
+            "may_upgrade": False,
+            "precomputed": disposition,
+        },
+    }

--- a/src/clawock/market_data/mover_evidence.py
+++ b/src/clawock/market_data/mover_evidence.py
@@ -40,6 +40,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from clawock.workspace import workspace_root  # noqa: E402
+from clawock.market_data import primary_disclosures
 
 WS = workspace_root(Path.cwd())
 
@@ -61,10 +62,8 @@ PER_REQUEST_TIMEOUT_S = 5
 TOTAL_BUDGET_S = 20
 UA = "Mozilla/5.0 (clawock intraday catalyst probe)"
 TENCENT_NEWS = "https://web.ifzq.gtimg.cn/appstock/news/info/search"
-SEC_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
-# Tencent type=0 is the exchange/regulator filing feed (HKEX announcements for HK,
-# SEC forms for US), timestamped to the second. type=1 is broker research and media.
-TENCENT_FILINGS_TYPE = 0
+# Tencent type=1 is broker research and media. Primary exchange/regulator
+# collection lives behind primary_disclosures instead of this consumer.
 TENCENT_NEWS_TYPE = 1
 PRIMARY = "primary"
 SUPPORTING = "supporting"
@@ -107,22 +106,9 @@ def _parse_tencent_time(value):
         return None
 
 
-def _parse_sec_time(value):
-    try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
-    except (TypeError, ValueError):
-        return None
-
-
 def tencent_symbol(ticker: str, market: str) -> str | None:
     """Map a workspace ticker onto the Tencent symbol space."""
-    ticker = str(ticker or "").strip()
-    if not ticker:
-        return None
-    if market == "hk":
-        digits = ticker.split(".")[0].zfill(5)
-        return f"hk{digits}" if digits.isdigit() else None
-    return f"us{ticker.upper()}"
+    return primary_disclosures.tencent_symbol(ticker, market)
 
 
 def _tencent_items(symbol, feed_type, tier, source_class, *, now, window, http):
@@ -151,56 +137,28 @@ def _tencent_items(symbol, feed_type, tier, source_class, *, now, window, http):
 
 
 def _sec_items(ticker, *, now, window, http):
-    from clawock.market_data import filings as fetch_us_filings  # noqa: PLC0415
-
-    cik = fetch_us_filings.lookup_cik(ticker)
-    if not cik:
-        return [], f"no CIK for {ticker}"
-    # lookup_cik already returns the `CIK##########` form; prepending our own
-    # prefix produced `CIKCIK…` and a silent 404 on every US mover.
-    digits = re.sub(r"\D", "", str(cik))
-    payload = http(
-        SEC_SUBMISSIONS.format(cik=digits.zfill(10)),
-        headers={"User-Agent": fetch_us_filings._load_user_agent()},
+    events, note = primary_disclosures.fetch_sec(
+        ticker, now=now, window_minutes=window, http=http,
     )
-    recent = ((payload or {}).get("filings") or {}).get("recent") or {}
-    forms = recent.get("form") or []
-    accepted = recent.get("acceptanceDateTime") or []
-    docs = recent.get("primaryDocDescription") or []
-    accessions = recent.get("accessionNumber") or []
-    primary_docs = recent.get("primaryDocument") or []
-    filing_items = recent.get("items") or []
-    items = []
-    for index, form in enumerate(forms):
-        when = _parse_sec_time(accepted[index] if index < len(accepted) else None)
-        if when is None:
-            continue
-        age = _age_minutes(when, now)
-        if age < 0 or age > window:
-            continue
-        description = docs[index] if index < len(docs) else ""
-        accession = accessions[index] if index < len(accessions) else ""
-        primary_doc = primary_docs[index] if index < len(primary_docs) else ""
-        filed_items_text = filing_items[index] if index < len(filing_items) else ""
-        archive_url = None
-        if accession and primary_doc:
-            archive_url = (
-                "https://www.sec.gov/Archives/edgar/data/"
-                f"{int(digits)}/{str(accession).replace('-', '')}/{primary_doc}"
-            )
-        items.append({
-            "published_at": when.isoformat(),
-            "age_minutes": age,
-            "title": _truncate(f"{form} {description}".strip()),
-            "raw_title": f"{form} {description}".strip(),
-            "tier": PRIMARY,
-            "source_class": "sec_filing",
-            "url": archive_url,
-            "accession": accession or None,
-            "form": str(form or "") or None,
-            "filing_items": str(filed_items_text or "") or None,
-        })
-    return items, None
+    return [_as_mover_item(event) for event in events], note
+
+
+def _as_mover_item(event):
+    title = str(event.get("title") or "")
+    return {
+        **event,
+        "title": _truncate(title),
+        "raw_title": title,
+        "tier": PRIMARY,
+        "url": event.get("source_url"),
+    }
+
+
+def _exchange_items(symbol, *, now, window, http):
+    events, note = primary_disclosures.fetch_exchange(
+        symbol, now=now, window_minutes=window, http=http,
+    )
+    return [_as_mover_item(event) for event in events], note
 
 
 def _market_flashes(names, *, now, window):
@@ -361,8 +319,7 @@ def halts(symbols, *, now, window, http_text=None) -> dict:
 
 
 def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
-          budget_s=TOTAL_BUDGET_S, http=None, http_text=None, clock=None,
-          primary_only=False) -> dict:
+          budget_s=TOTAL_BUDGET_S, http=None, http_text=None, clock=None) -> dict:
     """Catalyst evidence for the flagged tickers. Never raises."""
     tickers = [str(t) for t in (movers or []) if t]
     if not tickers:
@@ -394,17 +351,14 @@ def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
         calls = (
             ("sec", (lambda t=issuer: _sec_items(t, now=now, window=window_minutes, http=http))
              if market == "us" else None),
-            ("filings", (lambda s=symbol: (_tencent_items(
-                s, TENCENT_FILINGS_TYPE, PRIMARY, "exchange_filing",
-                now=now, window=window_minutes, http=http), None)) if symbol else None),
+            ("filings", (lambda s=symbol: _exchange_items(
+                s, now=now, window=window_minutes, http=http)) if symbol else None),
             ("research", (lambda s=symbol: (_tencent_items(
                 s, TENCENT_NEWS_TYPE, SUPPORTING, "broker_or_media",
                 now=now, window=window_minutes, http=http), None)) if symbol else None),
         )
         for label, call in calls:
             if call is None:
-                continue
-            if primary_only and label == "research":
                 continue
             if (label == "filings" and market == "us"
                     and any(row["source_class"] == "sec_filing" for row in entry["items"])):
@@ -457,12 +411,9 @@ def probe(movers, *, market, now=None, window_minutes=WINDOW_MINUTES,
         entry["target"] = target
         results[ticker] = entry
 
-    if primary_only:
-        flashes, flash_note = [], None
-    else:
-        flashes, flash_note = _market_flashes(
-            [name for name in names.values() if name], now=now, window=window_minutes
-        )
+    flashes, flash_note = _market_flashes(
+        [name for name in names.values() if name], now=now, window=window_minutes
+    )
     halt_symbols = []
     if market == "us":
         # A halt is a low-probability event for large caps, so this is not worth a

--- a/src/clawock/market_data/primary_disclosures.py
+++ b/src/clawock/market_data/primary_disclosures.py
@@ -1,0 +1,214 @@
+"""Runtime-neutral collection of attributable primary disclosures.
+
+This module owns source access and normalization only.  It does not resolve a
+portfolio, classify an event as a trading candidate, inspect price reaction,
+size exposure, persist cursors or alert a user.  Those are downstream policy
+and instance concerns.
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+
+HKT = timezone(timedelta(hours=8))
+PER_REQUEST_TIMEOUT_S = 5
+SEC_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
+TENCENT_NEWS = "https://web.ifzq.gtimg.cn/appstock/news/info/search"
+TENCENT_FILINGS_TYPE = 0
+UA = "Mozilla/5.0 (clawock primary disclosure provider)"
+
+
+def _http_json(url: str, *, headers=None, timeout=PER_REQUEST_TIMEOUT_S):
+    request = urllib.request.Request(
+        url, headers={"User-Agent": UA, "Referer": "https://gu.qq.com/", **(headers or {})}
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8", "ignore"))
+
+
+def _age_minutes(when: datetime, now: datetime) -> int:
+    return int((now - when).total_seconds() // 60)
+
+
+def _parse_tencent_time(value):
+    try:
+        return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(tzinfo=HKT)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_sec_time(value):
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def tencent_symbol(issuer: str, market: str) -> str | None:
+    issuer = str(issuer or "").strip()
+    if not issuer:
+        return None
+    if market == "hk":
+        digits = issuer.split(".")[0].zfill(5)
+        return f"hk{digits}" if digits.isdigit() else None
+    return f"us{issuer.upper()}"
+
+
+def fetch_exchange(symbol, *, now, window_minutes, http=None):
+    """Fetch normalized exchange/regulator announcements for one issuer."""
+    http = http or _http_json
+    payload = http(
+        f"{TENCENT_NEWS}?{urllib.parse.urlencode({'symbol': symbol, 'n': 8, 'page': 1, 'type': TENCENT_FILINGS_TYPE})}"
+    )
+    rows = ((payload or {}).get("data") or {}).get("data") or []
+    items = []
+    for row in rows:
+        when = _parse_tencent_time(row.get("time"))
+        if when is None:
+            continue
+        age = _age_minutes(when, now)
+        if age < 0 or age > window_minutes:
+            continue
+        title = re.sub(r"\s+", " ", str(row.get("title") or "")).strip()
+        items.append({
+            "published_at": when.isoformat(),
+            "age_minutes": age,
+            "title": title,
+            "source_class": "exchange_filing",
+            "evidence_tier": "primary",
+            "source_url": row.get("url") or None,
+            "accession": None,
+            "form": None,
+            "filing_items": None,
+        })
+    return items, None
+
+
+def fetch_sec(issuer, *, now, window_minutes, http=None):
+    """Fetch normalized SEC submissions for one reporting issuer."""
+    from clawock.market_data import filings as fetch_us_filings  # noqa: PLC0415
+
+    http = http or _http_json
+    cik = fetch_us_filings.lookup_cik(issuer)
+    if not cik:
+        return [], f"no CIK for {issuer}"
+    digits = re.sub(r"\D", "", str(cik))
+    payload = http(
+        SEC_SUBMISSIONS.format(cik=digits.zfill(10)),
+        headers={"User-Agent": fetch_us_filings._load_user_agent()},
+    )
+    recent = ((payload or {}).get("filings") or {}).get("recent") or {}
+    forms = recent.get("form") or []
+    accepted = recent.get("acceptanceDateTime") or []
+    docs = recent.get("primaryDocDescription") or []
+    accessions = recent.get("accessionNumber") or []
+    primary_docs = recent.get("primaryDocument") or []
+    filing_items = recent.get("items") or []
+    items = []
+    for index, form in enumerate(forms):
+        when = _parse_sec_time(accepted[index] if index < len(accepted) else None)
+        if when is None:
+            continue
+        age = _age_minutes(when, now)
+        if age < 0 or age > window_minutes:
+            continue
+        description = docs[index] if index < len(docs) else ""
+        accession = accessions[index] if index < len(accessions) else ""
+        primary_doc = primary_docs[index] if index < len(primary_docs) else ""
+        filed_items_text = filing_items[index] if index < len(filing_items) else ""
+        archive_url = None
+        if accession and primary_doc:
+            archive_url = (
+                "https://www.sec.gov/Archives/edgar/data/"
+                f"{int(digits)}/{str(accession).replace('-', '')}/{primary_doc}"
+            )
+        items.append({
+            "published_at": when.isoformat(),
+            "age_minutes": age,
+            "title": re.sub(r"\s+", " ", f"{form} {description}").strip(),
+            "source_class": "sec_filing",
+            "evidence_tier": "primary",
+            "source_url": archive_url,
+            "accession": accession or None,
+            "form": str(form or "") or None,
+            "filing_items": str(filed_items_text or "") or None,
+        })
+    return items, None
+
+
+def probe(issuers, *, market: str, now=None, window_minutes: int,
+          budget_s: float, max_issuers: int, http=None, clock=None) -> dict:
+    """Return normalized primary disclosures and honest source status.
+
+    Every bound is supplied by the caller.  A provider must not smuggle one
+    strategy's cadence, scope or freshness assumptions into another consumer.
+    """
+    issuer_list = list(dict.fromkeys(str(value) for value in (issuers or []) if value))
+    now = now or datetime.now(timezone.utc)
+    http = http or _http_json
+    clock = clock or time.monotonic
+    started = clock()
+    chased, skipped = issuer_list[:max_issuers], issuer_list[max_issuers:]
+    results = {}
+
+    for issuer in chased:
+        entry = {
+            "status": "no_recent_disclosure", "events": [], "notes": [],
+            "degraded_sources": [],
+        }
+        symbol = tencent_symbol(issuer, market)
+        calls = (
+            ("sec", (lambda t=issuer: fetch_sec(
+                t, now=now, window_minutes=window_minutes, http=http
+            )) if market == "us" else None),
+            ("exchange", (lambda s=symbol: fetch_exchange(
+                s, now=now, window_minutes=window_minutes, http=http
+            )) if symbol else None),
+        )
+        for label, call in calls:
+            if call is None:
+                continue
+            if (label == "exchange"
+                    and any(row["source_class"] == "sec_filing" for row in entry["events"])):
+                continue
+            if clock() - started > budget_s:
+                entry["notes"].append(f"{label}: skipped, time budget spent")
+                entry["status"] = "degraded"
+                entry["degraded_sources"].append(label)
+                break
+            try:
+                items, note = call()
+            except Exception as exc:  # noqa: BLE001 - evidence collection fails soft
+                entry["notes"].append(f"{label}: {type(exc).__name__}")
+                entry["status"] = "degraded"
+                entry["degraded_sources"].append(label)
+                continue
+            if note:
+                entry["notes"].append(f"{label}: {note}")
+                # A failed ticker-to-CIK lookup is not evidence of no filing.
+                if label == "sec":
+                    entry["status"] = "degraded"
+                    entry["degraded_sources"].append(label)
+            entry["events"].extend(items)
+        entry["events"].sort(key=lambda row: row.get("published_at") or "", reverse=True)
+        entry["degraded_sources"] = sorted(set(entry["degraded_sources"]))
+        if entry["events"] and not entry["degraded_sources"]:
+            entry["status"] = "found"
+        elif entry["status"] != "degraded":
+            entry["status"] = "no_recent_disclosure"
+        results[issuer] = entry
+
+    payload = {
+        "as_of": now.isoformat(),
+        "window_minutes": window_minutes,
+        "elapsed_s": round(clock() - started, 2),
+        "issuers": results,
+    }
+    if skipped:
+        payload["not_chased"] = skipped
+    return payload

--- a/src/clawock/portfolio/instruments.py
+++ b/src/clawock/portfolio/instruments.py
@@ -211,8 +211,8 @@ def validate_active_holdings(
 INSTRUMENTS = load_registry(missing_ok=True)
 
 
-def get(symbol: str) -> dict | None:
-    return INSTRUMENTS.get(symbol)
+def get(symbol: str, *, registry: dict[str, dict] | None = None) -> dict | None:
+    return (INSTRUMENTS if registry is None else registry).get(symbol)
 
 
 def require(symbol: str) -> dict:
@@ -233,7 +233,9 @@ _LEVERAGED_NAME_MARKERS = (
 )
 
 
-def is_leveraged_holding(holding: dict) -> bool:
+def is_leveraged_holding(
+    holding: dict, *, registry: dict[str, dict] | None = None
+) -> bool:
     """Classify a live holding conservatively when registry coverage lags.
 
     Registered metadata remains authoritative. The explicit holding flag and
@@ -243,7 +245,7 @@ def is_leveraged_holding(holding: dict) -> bool:
     if holding.get("is_leveraged_etf") is True:
         return True
     symbol = str(holding.get("ticker") or "")
-    meta = get(symbol)
+    meta = get(symbol, registry=registry)
     if meta is not None:
         return float(meta.get("leverage_multiple") or 1) > 1
     name = str(holding.get("name") or holding.get("stock_name") or "").casefold()
@@ -253,7 +255,10 @@ def is_leveraged_holding(holding: dict) -> bool:
     )
 
 
-def look_through(symbol: str, *, max_hops: int = 3) -> dict:
+def look_through(
+    symbol: str, *, max_hops: int = 3,
+    registry: dict[str, dict] | None = None,
+) -> dict:
     """Resolve a holding to the issuer whose news, filings and earnings move it.
 
     A 2x single-stock ETF publishes nothing of its own: PLTU is moved by PLTR,
@@ -274,7 +279,7 @@ def look_through(symbol: str, *, max_hops: int = 3) -> dict:
     if not current:
         return {"kind": "index_fund", "issuer": None, "tracks": None, "chain": chain}
     for _ in range(max_hops):
-        meta = get(current) or {}
+        meta = get(current, registry=registry) or {}
         underlying = meta.get("underlying")
         if not underlying or underlying in chain:
             break
@@ -282,7 +287,7 @@ def look_through(symbol: str, *, max_hops: int = 3) -> dict:
         current = str(underlying)
     if not chain:
         return {"kind": "issuer", "issuer": str(symbol), "tracks": None, "chain": chain}
-    final = get(current)
+    final = get(current, registry=registry)
     no_issuer = (
         final is None                       # a label like NASDAQ_100, not a security
         or final.get("venue") == "INDEX"    # an index

--- a/tests/test_active_information.py
+++ b/tests/test_active_information.py
@@ -1,11 +1,15 @@
 """High-cost invariants for the information-first intraday lane."""
 from datetime import datetime, timezone
+from pathlib import Path
 
-from clawock_kcnyu import active_information as ai
+from clawock.decision import active_information as ai
+from clawock.portfolio import instruments
 from clawock_kcnyu.harness import intraday_preflight
 
 
 NOW = datetime(2026, 8, 13, 6, 0, tzinfo=timezone.utc)
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = instruments.load_registry(ROOT / "config" / "instruments.json")
 
 
 def portfolio(hk=None, us=None):
@@ -20,8 +24,8 @@ def portfolio(hk=None, us=None):
 def probe_with(item, status="found"):
     def probe(issuers, **_kwargs):
         return {
-            "tickers": {
-                issuer: {"status": status, "items": [dict(item)] if item else []}
+            "issuers": {
+                issuer: {"status": status, "events": [dict(item)] if item else []}
                 for issuer in issuers
             }
         }
@@ -31,24 +35,20 @@ def probe_with(item, status="found"):
 POSITIVE = {
     "published_at": "2026-08-13T05:45:00+00:00",
     "title": "正面盈利预告及股份回购计划",
-    "raw_title": "正面盈利预告及股份回购计划",
-    "tier": "primary",
+    "source_url": "https://example.test/announcement",
     "source_class": "exchange_filing",
-    "signal": "interrupt",
-    "triage_rule": "hk-profit-alert",
-    "url": "https://example.test/announcement",
+    "evidence_tier": "primary",
 }
 
 
 def test_positive_primary_event_becomes_one_board_lot_candidate_before_a_large_move(monkeypatch):
-    monkeypatch.setattr(ai.mover_evidence, "probe", probe_with(POSITIVE))
     book = portfolio(hk=[
         {"ticker": "00100", "shares": 120, "lot_size": 20},
     ])
 
     result = ai.scan(
-        book, market="hk", now=NOW,
-        quote_fetcher=lambda *_args, **_kwargs: {
+        book, market="hk", now=NOW, registry=REGISTRY,
+        disclosure_probe=probe_with(POSITIVE), quote_fetcher=lambda *_args, **_kwargs: {
             "00100": {"price": 400, "pct_1d": 0.8, "source": "tencent"}
         },
     )
@@ -69,18 +69,16 @@ def test_proxy_and_underlying_are_one_issuer_and_hot_tape_is_wait(monkeypatch):
         "title": "Raised guidance after record revenue",
         "raw_title": "Raised guidance after record revenue",
         "source_class": "sec_filing",
-        "triage_rule": "us-8k",
         "accession": "0001-26-000001",
     }
-    monkeypatch.setattr(ai.mover_evidence, "probe", probe_with(us_item))
     book = portfolio(us=[
         {"ticker": "SPCX", "shares": 1},
         {"ticker": "SPCH", "shares": 240},
     ])
 
     result = ai.scan(
-        book, market="us", now=NOW,
-        quote_fetcher=lambda *_args, **_kwargs: {
+        book, market="us", now=NOW, registry=REGISTRY,
+        disclosure_probe=probe_with(us_item), quote_fetcher=lambda *_args, **_kwargs: {
             "SPCX": {"price": 150, "pct_1d": 5.2, "source": "tencent"}
         },
     )
@@ -96,14 +94,13 @@ def test_proxy_and_underlying_are_one_issuer_and_hot_tape_is_wait(monkeypatch):
 def test_supporting_item_cannot_create_a_candidate(monkeypatch):
     supporting = {
         **POSITIVE,
-        "tier": "supporting",
+        "evidence_tier": "supporting",
         "source_class": "broker_or_media",
     }
-    monkeypatch.setattr(ai.mover_evidence, "probe", probe_with(supporting))
-
     result = ai.scan(
         portfolio(us=[{"ticker": "CRCL", "shares": 2}]),
-        market="us", now=NOW,
+        market="us", now=NOW, registry=REGISTRY,
+        disclosure_probe=probe_with(supporting),
         quote_fetcher=lambda *_args, **_kwargs: {
             "CRCL": {"price": 75, "pct_1d": 0.2, "source": "tencent"}
         },

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -99,3 +99,56 @@ def test_the_entry_point_is_inside_the_package():
     assert module.split(".")[0] == PKG.name, (
         f"entry point {module} is not inside the package directory {PKG.name}")
     assert (PKG / "__init__.py").exists(), "clawock must be a real package"
+
+
+def test_information_strategy_has_one_product_owner():
+    """Keep provider → strategy → instance as an executable ownership rule.
+
+    This is intentionally one structural backstop, not a test per implementation
+    detail.  The expensive regression is putting the algorithm back in the live
+    adapter or coupling it to mover attribution's private protocol.
+    """
+    strategy = PKG / "decision" / "active_information.py"
+    instance_copy = (
+        ROOT / "instances" / "kcnyu" / "src" / "clawock_kcnyu"
+        / "active_information.py"
+    )
+    phase = (
+        ROOT / "instances" / "kcnyu" / "src" / "clawock_kcnyu"
+        / "harness" / "intraday_preflight.py"
+    )
+
+    assert strategy.is_file(), "the reusable information strategy belongs in clawock"
+    assert not instance_copy.exists(), "instances are bindings, not a second strategy package"
+
+    tree = ast.parse(strategy.read_text())
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.update(f"{node.module}.{alias.name}" for alias in node.names)
+    assert not any(name.startswith("clawock_kcnyu") for name in imports)
+    assert "clawock.market_data.mover_evidence" not in imports
+    assert "clawock.market_data.primary_disclosures" in imports, (
+        "the strategy should consume the public primary-disclosure provider")
+    private_contracts = {"triage_rule", "WINDOW_MINUTES", "INTERRUPT", "PRIMARY"}
+    referenced = {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    } | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    } | {
+        node.value for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert not (private_contracts & referenced), (
+        "strategy depends on mover attribution's private protocol: "
+        f"{sorted(private_contracts & referenced)}")
+
+    phase_imports = {
+        node.module
+        for node in ast.walk(ast.parse(phase.read_text()))
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "clawock.decision" in phase_imports, (
+        "the instance phase must bind the product strategy, not reimplement it")


### PR DESCRIPTION
## Outcome

Makes information-first discovery a reusable clawock strategy instead of a
KCNyu-instance implementation, and turns the ownership rule into an executable
architecture boundary.

```text
primary-disclosure provider DTO
        -> information signal + active strategy
        -> KCNyu phase/render/alert binding
```

### Product ownership

- Adds `clawock.market_data.primary_disclosures`, which only fetches and
  normalizes attributable SEC/exchange evidence and honest degraded source
  state.
- Moves the full active-information algorithm into
  `clawock.decision.active_information`: portfolio scope, issuer/proxy
  look-through, event evaluation, reaction state, candidate/wait/reject,
  exploration sizing and the seen-event cursor.
- Adds a pure `clawock.decision.information_signals` policy function. Policy is
  explicit and typed; providers carry no strategy defaults.
- Extends instrument helpers to accept an explicit workspace registry so a
  long-lived process is not bound to whichever workspace imported the module.

### Instance boundary

- Deletes `clawock_kcnyu.active_information`.
- The KCNyu intraday phase now only calls the product strategy with the current
  workspace, renders the returned contract and integrates it into alerting.
- The HK/US skills consume the structured result instead of restating thresholds
  or sizing policy.

### Decoupling from mover attribution

- Both mover attribution and proactive discovery consume the same public
  primary-disclosure provider DTO.
- The active strategy no longer imports `mover_evidence`, reads its
  `PRIMARY`/`INTERRUPT`/`WINDOW_MINUTES` constants or branches on filing-triage
  rule IDs.
- `mover_evidence.primary_only` is removed; it was an active-strategy mode hidden
  inside a reactive feature.

### Rule for future strategies

`docs/reference/product-vs-instance.md` now states the provider → strategy →
instance ownership test. One AST boundary check prevents the expensive
regression: a second instance strategy implementation or dependency on mover
attribution's private protocol. This is intentionally one architecture guard,
not test-count expansion.

## Verification

- `git diff --check`
- Python compile for the changed modules
- 89 targeted checks passed: active-information behavior, mover attribution,
  instance CLI/import boundary, instrument registry, package surface and a real
  non-editable wheel import.
- Full suite remains delegated to required GitHub CI.

Closes #526
