### PR TITLE
fix: add free US filing mirror fallback

### DIFF
--- a/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
+++ b/instances/kcnyu/src/clawock_kcnyu/harness/intraday_preflight.py
@@ -237,7 +237,8 @@ def append_active_information_section(block, active):
     """Make information-first candidates visible without relying on model prose."""
     rows = (active or {}).get('candidates') or []
     degraded = (active or {}).get('degraded_issuers') or []
-    if not rows and not degraded:
+    partial = (active or {}).get('partially_degraded_issuers') or []
+    if not rows and not degraded and not partial:
         return block
     lines = ['', '🛰️ 主动一级信息（候选≠下单）']
     label = {'candidate': '候选', 'wait': '等待', 'reject': '拒绝加仓'}
@@ -258,6 +259,10 @@ def append_active_information_section(block, active):
         lines.append(f'  …另有 {len(rows) - 4} 条')
     if degraded:
         lines.append(f"  ⚠️ 一级源降级：{','.join(degraded)}（不是无消息）")
+    if partial:
+        lines.append(
+            f"  △ SEC直连降级、镜像已检查：{','.join(partial)}"
+        )
     return block + '\n' + '\n'.join(lines)
 
 

--- a/src/clawock/decision/active_information.py
+++ b/src/clawock/decision/active_information.py
@@ -189,10 +189,16 @@ def scan(portfolio: dict | None, *, market: str, policy=DEFAULT_POLICY, now=None
 
     rows = []
     status_by_issuer = {}
+    source_health_by_issuer = {}
     for target in chased:
         issuer = target["issuer"]
         entry = ((evidence.get("issuers") or {}).get(issuer) or {})
         status_by_issuer[issuer] = entry.get("status") or "not_checked"
+        source_health_by_issuer[issuer] = {
+            "healthy_sources": list(entry.get("healthy_sources") or []),
+            "degraded_sources": list(entry.get("degraded_sources") or []),
+            "partial_degradation": bool(entry.get("partial_degradation")),
+        }
         quote = quotes.get(issuer) or {}
         reaction = quote.get("pct_1d") if not quote.get("stale_quote") else None
         for item in (entry.get("events") or []):
@@ -203,6 +209,10 @@ def scan(portfolio: dict | None, *, market: str, policy=DEFAULT_POLICY, now=None
                 continue
             disposition = signal["disposition"]
             blockers = list(signal["blockers"])
+            if item.get("time_precision") == "date":
+                blockers.append("filing_time_unavailable")
+                if disposition == "candidate":
+                    disposition = "wait"
             if target.get("leveraged_only"):
                 blockers.append("leveraged_holding_cannot_take_unvalidated_exploration")
             hint = _exploration_hint(
@@ -227,6 +237,10 @@ def scan(portfolio: dict | None, *, market: str, policy=DEFAULT_POLICY, now=None
                 "issuer": issuer,
                 "held_via": target["holdings"],
                 "published_at": published,
+                "filed_date": item.get("filed_date"),
+                "observed_at": item.get("observed_at"),
+                "time_precision": item.get("time_precision"),
+                "freshness_status": item.get("freshness_status"),
                 "expires_at": expires_at,
                 "source_url": item.get("source_url"),
                 "source_class": item.get("source_class"),
@@ -247,12 +261,17 @@ def scan(portfolio: dict | None, *, market: str, policy=DEFAULT_POLICY, now=None
         "scope": chased,
         "skipped_scope": [row["issuer"] for row in skipped],
         "issuer_status": status_by_issuer,
+        "issuer_source_health": source_health_by_issuer,
         "candidates": rows,
         "candidate_count": sum(row["disposition"] == "candidate" for row in rows),
         "wait_count": sum(row["disposition"] == "wait" for row in rows),
         "reject_count": sum(row["disposition"] == "reject" for row in rows),
         "degraded_issuers": sorted(
             issuer for issuer, status in status_by_issuer.items() if status == "degraded"
+        ),
+        "partially_degraded_issuers": sorted(
+            issuer for issuer, health in source_health_by_issuer.items()
+            if health["partial_degradation"]
         ),
         "discipline": (
             "primary disclosure first; session reaction is a timing check; candidate visibility "

--- a/src/clawock/market_data/primary_disclosures.py
+++ b/src/clawock/market_data/primary_disclosures.py
@@ -13,6 +13,7 @@ import time
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 
 HKT = timezone(timedelta(hours=8))
@@ -20,6 +21,7 @@ PER_REQUEST_TIMEOUT_S = 5
 SEC_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
 TENCENT_NEWS = "https://web.ifzq.gtimg.cn/appstock/news/info/search"
 TENCENT_FILINGS_TYPE = 0
+NASDAQ_FILINGS = "https://api.nasdaq.com/api/company/{issuer}/sec-filings"
 UA = "Mozilla/5.0 (clawock primary disclosure provider)"
 
 
@@ -141,6 +143,53 @@ def fetch_sec(issuer, *, now, window_minutes, http=None):
     return items, None
 
 
+def fetch_nasdaq_filings(issuer, *, now, window_minutes, http=None):
+    """Fetch Nasdaq's free SEC-filing mirror when SEC direct is unavailable.
+
+    Nasdaq exposes the filing date but not the SEC acceptance timestamp.  Same
+    US-session-date rows are therefore useful primary documents, while their
+    exact freshness remains explicitly unverified downstream.
+    """
+    http = http or _http_json
+    payload = http(
+        NASDAQ_FILINGS.format(issuer=urllib.parse.quote(str(issuer).upper()))
+        + "?limit=10"
+    )
+    rows = ((payload or {}).get("data") or {}).get("rows") or []
+    session_date = now.astimezone(ZoneInfo("America/New_York")).date()
+    items = []
+    for row in rows:
+        try:
+            filed_date = datetime.strptime(str(row.get("filed")), "%m/%d/%Y").date()
+        except (TypeError, ValueError):
+            continue
+        # A date-only mirror cannot honestly prove a rolling intraday window.
+        # Keep only today's US filing date; callers must retain the precision
+        # blocker before treating it as an exploration trigger.
+        if filed_date != session_date:
+            continue
+        links = row.get("view") if isinstance(row.get("view"), dict) else {}
+        source_url = links.get("htmlLink") or links.get("docLink") or None
+        form = re.sub(r"\s+", " ", str(row.get("formType") or "")).strip()
+        company = re.sub(r"\s+", " ", str(row.get("companyName") or "")).strip()
+        items.append({
+            "published_at": None,
+            "filed_date": filed_date.isoformat(),
+            "observed_at": now.isoformat(),
+            "time_precision": "date",
+            "freshness_status": "same_session_date_time_unavailable",
+            "age_minutes": None,
+            "title": re.sub(r"\s+", " ", f"{form} {company}").strip(),
+            "source_class": "sec_filing_mirror",
+            "evidence_tier": "primary",
+            "source_url": source_url,
+            "accession": None,
+            "form": form or None,
+            "filing_items": None,
+        })
+    return items, None
+
+
 def probe(issuers, *, market: str, now=None, window_minutes: int,
           budget_s: float, max_issuers: int, http=None, clock=None) -> dict:
     """Return normalized primary disclosures and honest source status.
@@ -159,11 +208,14 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
     for issuer in chased:
         entry = {
             "status": "no_recent_disclosure", "events": [], "notes": [],
-            "degraded_sources": [],
+            "degraded_sources": [], "healthy_sources": [],
         }
         symbol = tencent_symbol(issuer, market)
         calls = (
             ("sec", (lambda t=issuer: fetch_sec(
+                t, now=now, window_minutes=window_minutes, http=http
+            )) if market == "us" else None),
+            ("nasdaq_filing_mirror", (lambda t=issuer: fetch_nasdaq_filings(
                 t, now=now, window_minutes=window_minutes, http=http
             )) if market == "us" else None),
             ("exchange", (lambda s=symbol: fetch_exchange(
@@ -173,8 +225,12 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
         for label, call in calls:
             if call is None:
                 continue
-            if (label == "exchange"
+            if (label in {"nasdaq_filing_mirror", "exchange"}
                     and any(row["source_class"] == "sec_filing" for row in entry["events"])):
+                continue
+            if (label == "exchange"
+                    and any(row["source_class"] == "sec_filing_mirror"
+                            for row in entry["events"])):
                 continue
             if clock() - started > budget_s:
                 entry["notes"].append(f"{label}: skipped, time budget spent")
@@ -195,12 +251,20 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
                     entry["status"] = "degraded"
                     entry["degraded_sources"].append(label)
             entry["events"].extend(items)
+            if not (label == "sec" and note):
+                entry["healthy_sources"].append(label)
         entry["events"].sort(key=lambda row: row.get("published_at") or "", reverse=True)
         entry["degraded_sources"] = sorted(set(entry["degraded_sources"]))
-        if entry["events"] and not entry["degraded_sources"]:
+        entry["healthy_sources"] = sorted(set(entry["healthy_sources"]))
+        entry["partial_degradation"] = bool(
+            entry["degraded_sources"] and entry["healthy_sources"]
+        )
+        if entry["events"]:
             entry["status"] = "found"
-        elif entry["status"] != "degraded":
+        elif entry["healthy_sources"]:
             entry["status"] = "no_recent_disclosure"
+        else:
+            entry["status"] = "degraded"
         results[issuer] = entry
 
     payload = {

--- a/tests/test_active_information.py
+++ b/tests/test_active_information.py
@@ -1,6 +1,7 @@
 """High-cost invariants for the information-first intraday lane."""
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from clawock.decision import active_information as ai
 from clawock.market_data import primary_disclosures
@@ -126,9 +127,10 @@ def test_sec_403_falls_back_to_healthy_nasdaq_primary_mirror(monkeypatch):
     )
 
     def http(url, **_kwargs):
-        if "data.sec.gov" in url:
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
             raise RuntimeError("SEC 403")
-        if "api.nasdaq.com" in url:
+        if host == "api.nasdaq.com":
             return {"data": {"rows": [{
                 "companyName": "Circle Internet Group Inc.",
                 "formType": "8-K", "filed": "08/13/2026",

--- a/tests/test_active_information.py
+++ b/tests/test_active_information.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from clawock.decision import active_information as ai
+from clawock.market_data import primary_disclosures
 from clawock.portfolio import instruments
 from clawock_kcnyu.harness import intraday_preflight
 
@@ -117,3 +118,57 @@ def test_primary_candidate_wakes_the_intraday_alert_without_a_price_anomaly():
 
     assert alert is True
     assert reasons == ["主动一级信息: 00100"]
+
+
+def test_sec_403_falls_back_to_healthy_nasdaq_primary_mirror(monkeypatch):
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _ticker: "CIK0001876042"
+    )
+
+    def http(url, **_kwargs):
+        if "data.sec.gov" in url:
+            raise RuntimeError("SEC 403")
+        if "api.nasdaq.com" in url:
+            return {"data": {"rows": [{
+                "companyName": "Circle Internet Group Inc.",
+                "formType": "8-K", "filed": "08/13/2026",
+                "view": {"htmlLink": "https://mirror.test/crcl-8k"},
+            }]}}
+        raise AssertionError(url)
+
+    result = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http,
+    )["issuers"]["CRCL"]
+
+    assert result["status"] == "found"
+    assert result["partial_degradation"] is True
+    assert result["degraded_sources"] == ["sec"]
+    assert result["healthy_sources"] == ["nasdaq_filing_mirror"]
+    assert result["events"][0]["source_class"] == "sec_filing_mirror"
+    assert result["events"][0]["time_precision"] == "date"
+
+
+def test_date_only_primary_mirror_event_waits_instead_of_unlocking_exploration():
+    mirror_item = {
+        **POSITIVE,
+        "published_at": None,
+        "filed_date": "2026-08-13",
+        "observed_at": NOW.isoformat(),
+        "time_precision": "date",
+        "freshness_status": "same_session_date_time_unavailable",
+        "title": "8-K Raised guidance after record revenue",
+        "source_class": "sec_filing_mirror",
+    }
+    result = ai.scan(
+        portfolio(us=[{"ticker": "CRCL", "shares": 2}]),
+        market="us", now=NOW, registry=REGISTRY,
+        disclosure_probe=probe_with(mirror_item), quote_fetcher=lambda *_args, **_kwargs: {
+            "CRCL": {"price": 75, "pct_1d": 0.2, "source": "tencent"}
+        },
+    )
+
+    row = result["candidates"][0]
+    assert row["disposition"] == "wait"
+    assert row["exploration_hint"] is None
+    assert "filing_time_unavailable" in row["blockers"]


### PR DESCRIPTION
Closes #528.

## What changed

- adds Nasdaq's free SEC-filings mirror behind the runtime-neutral primary-disclosure provider
- records healthy/degraded sources separately and exposes partial degradation to the strategy and thin KCNyu renderer
- treats date-only mirror filings as primary documents with uncertain intraday timing: they can surface `wait`/`reject`, but cannot unlock an exploration tranche without exact filing time
- keeps SEC direct first and Tencent exchange mirror available; no Tavily credits are spent in the 30-minute baseline path

## Evidence

Live read-only probes from the production host:

- SEC submissions and ticker endpoints: HTTP 403
- Nasdaq filing endpoint: healthy for CRCL/RKLB/SKHY/SPCX; returned current rows including SKHY 6-K and RKLB filings
- Tencent filing mirror: healthy but empty for the latest four-hour window

Targeted local validation: `68 passed` (`tests/test_active_information.py` + `tests/test_mover_news.py`). Full suite remains CI-owned.
