### PR TITLE
fix: recognize range position as percent context

### DIFF
--- a/src/clawock/harness/validation.py
+++ b/src/clawock/harness/validation.py
@@ -97,7 +97,10 @@ _UNIT_CLAIMS = {
 }
 _UNIT_LABELS = {'percent': '%', 'pp': 'pp', 'multiple': 'x', 'sigma': 'σ'}
 _UNIT_KEY_HINTS = {
-    'percent': re.compile(r'(?:^|_)(?:pct|percent|percentage)(?:_|$)'),
+    # ``range_pos`` is the T+0 strategy's 0–100 intraday range percentile.
+    # It is rendered and discussed with ``%`` even though its established JSON
+    # key predates the otherwise-consistent ``*_pct`` naming convention.
+    'percent': re.compile(r'(?:^|_)(?:pct|percent|percentage|range_pos)(?:_|$)'),
     'pp': re.compile(r'(?:^|_)(?:pp|percentage_points?)(?:_|$)'),
     'multiple': re.compile(r'(?:^|_)(?:multiple|multiplier|leverage|leverage_ratio)(?:_|$)'),
     'sigma': re.compile(r'(?:^|_)(?:sigma|z_?score\d*)(?:_|$)'),

--- a/tests/test_numeric_claims.py
+++ b/tests/test_numeric_claims.py
@@ -217,6 +217,15 @@ def test_market_units_require_unit_specific_context_provenance(hc):
     assert "2.3x" in issue[0] and hc.ADVISORY_MARK in issue[0]
 
 
+def test_range_pos_is_percent_specific_context(hc):
+    ctx = {"t0_setups": {"rows": {"SKHY": {"range_pos": 86.5}}}}
+
+    assert hc.check_numeric_claims("SKHY range_pos 86.5%，追高低质。", ctx) == []
+    issue = hc.check_numeric_claims("SKHY range_pos 86.6%，追高低质。", ctx)
+    assert len(issue) == 1
+    assert "86.6%" in issue[0] and hc.ADVISORY_MARK in issue[0]
+
+
 def test_absent_market_units_stay_one_advisory(hc):
     issue = hc.check_numeric_claims("今日 +8.8%，背离 7pp，放大 3x，偏离 4σ。", CTX)
     assert len(issue) == 1


### PR DESCRIPTION
## Summary

- recognize the established `range_pos` field as percent-bearing context
- keep unit-specific numeric provenance strict for percent claims
- add one behavior-level regression covering the valid quote and an absent value

## Verification

- `PYTHONPATH=src:instances/kcnyu/src pytest -q tests/test_numeric_claims.py`
- replayed the frozen 2026-08-13 12:00 ET prose/context: no advisory
- changed the quote to an absent `86.6%`: advisory remains

Closes #530
