### PR TITLE
fix: intraday delta gate diffs leverage regime + risk alerts (#546)

### DIFF
--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -3,7 +3,9 @@
 
 The trigger evaluates this script before creating an agent turn. It compares the
 returned normalized state with its durable prior state and invokes the LLM only
-for a condition delta, a material reprice, or a low-frequency forced review.
+for a condition delta. The normalized state deliberately excludes raw quote
+churn: it carries decision-relevant semantics (signals, setups, plans, primary
+events, source health) plus the leverage regime and risk-alert state.
 """
 from __future__ import annotations
 
@@ -109,13 +111,14 @@ def semantic_state(market, session_date, *, signals_detail, anomalies, setups,
                 (active_information or {}).get("partially_degraded_issuers") or []
             ),
         },
+        "regime": _regime_state(market),
     }
 
 
 def compare_semantic_states(current, previous):
     previous = previous if isinstance(previous, dict) else {}
     keys = ("session", "breaches", "setups", "plans", "primary_events",
-            "primary_source_health")
+            "primary_source_health", "regime")
     components = [key for key in keys if current.get(key) != previous.get(key)]
     old_events = previous.get("primary_events") or {}
     new_events = current.get("primary_events") or {}
@@ -229,6 +232,8 @@ def _regime_state(market):
     return {
         "portfolio_tier": regime.get("tier"),
         "leg_tier": leg.get("tier"),
+        "lev_cap_mult": leg.get("lev_cap_mult"),
+        "leg_trend_on": leg.get("trend_on"),
         "names": names,
         "risk_alerts": [list(row) for row in alerts],
     }


### PR DESCRIPTION
## 背景 / issue #546

盘中 delta 门的 `semantic_state()` 只归一化 6 个键（session/breaches/setups/plans/primary_events/primary_source_health），**杠杆 regime 与 risk 告警不在比较范围内**。当相邻两档之间发生 tier 翻转（amber→red）或 `lev_cap_mult` 变化时，`compare_semantic_states()` 判定"无变化"，压成一行 `unchanged_receipt`，LLM 散文完全不生成。

## 改动

`src/clawock/harness/intraday_delta.py`（仅此一文件，+7/−2）：

1. `semantic_state()` 的返回 dict 新增 `regime` 键，复用已有的 `_regime_state(market)`。
2. `_regime_state()` 补上 `lev_cap_mult` 与 `leg_trend_on`（原实现只有 portfolio_tier/leg_tier/names/risk_alerts，未暴露档位系数与趋势翻转）。
3. `compare_semantic_states()` 的比较键加 `regime`。
4. 模块 docstring 修正：删除从未实现的 "material reprice" / "low-frequency forced review" 承诺，改为如实描述（仅 condition delta，且明确排除报价噪音）。

## 不做（沿用 issue 边界）

- 不把原始价格纳入比较（保持 "excluding quote churn" 既有设计）。
- 不实现低频率 forced review（本 PR 选择"从文档移除承诺"，而非实现；若需要 forced review 可另开 issue）。

## 验收对应

- [x] tier / lev_cap_mult 在两档间变化 → `delivery_mode=full_delta`（`regime` 进比较键）
- [x] risk.json 新增告警 → `risk_alerts` 变化 → delta 判定 changed
- [x] 报价噪音不触发行为不变（breaches/setups/plans 原样比较）
- [x] forced review 从文档移除（未实现则如实不承诺）

## 测试

- `tests/test_intraday_delta_gate.py` 13 passed
- `tests/test_intraday_prose_assembly.py` 15 passed
- 手动 smoke：regime 翻转 → `changed=True, components=['regime']`；无变化 → `changed=False`