### PR TITLE
feat: short-history (<30 bar) names reach the early-trend lane (#542)

### DIFF
--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -265,6 +265,79 @@ def compute_signals(bars):
     return sig
 
 
+def compute_short_history_signals(bars):
+    """Reduced technical view for 20–29-bar names (early-trend lane only).
+
+    Newly listed names cannot compute MA200, so the mature `compute_signals`
+    30-bar gate answers None and the early-trend lane — built exactly for these
+    short-history targets — never sees them. This view computes the fields that
+    exist from 20 bars up (close, MA20, prior-20d/5d range, RSI14, zscore20,
+    ATR/chandelier) and leaves the mature factors (MA50/MA200/vol20/momentum)
+    None, so a short name can never masquerade as a mature factor row. It
+    answers None below 20 bars, where even the short view is not computable.
+    """
+    closes = [b['close'] for b in bars]
+    if len(closes) < 20:
+        return None
+    c = closes[-1]
+    ma20 = _ma(closes, 20)
+    prior_20d_high = max(b['high'] for b in bars[-21:-1]) if len(bars) >= 21 else None
+    prior_20d_low = min(b['low'] for b in bars[-21:-1]) if len(bars) >= 21 else None
+    prior_5d_high = max(b['high'] for b in bars[-6:-1]) if len(bars) >= 6 else None
+    prior_5d_low = min(b['low'] for b in bars[-6:-1]) if len(bars) >= 6 else None
+    prev_close = closes[-2] if len(closes) >= 2 else None
+    z = None
+    if ma20 and len(closes) >= 20:
+        sd = math.sqrt(sum((x - ma20) ** 2 for x in closes[-20:]) / 20)
+        z = round((c - ma20) / sd, 2) if sd else None
+    atr = _atr14(bars)
+    chandelier = stop_dist = None
+    if atr and len(bars) >= 22:
+        hi22 = max(b['high'] for b in bars[-22:])
+        chandelier = hi22 - 3 * atr
+        stop_dist = round((c / chandelier - 1) * 100, 1) if chandelier > 0 else None
+    sig = {
+        'close': c,
+        'prev_close': prev_close,
+        'ma20': round(ma20, 3) if ma20 else None,
+        'ma50': None,
+        'ma200': None,
+        'prior_20d_high': round(prior_20d_high, 3) if prior_20d_high else None,
+        'prior_20d_low': round(prior_20d_low, 3) if prior_20d_low else None,
+        'prior_5d_high': round(prior_5d_high, 3) if prior_5d_high else None,
+        'prior_5d_low': round(prior_5d_low, 3) if prior_5d_low else None,
+        'dist_ma200_pct': None,
+        'golden_cross': None,
+        'trend_on': None,
+        'mom_1m': None,
+        'mom_3m': None,
+        'mom_6m': None,
+        'mom_12_1': None,
+        'rsi14': _rsi14(closes),
+        'zscore20': z,
+        'vol20_annualized': None,
+        'atr14_pct': round(atr / c * 100, 2) if atr else None,
+        'chandelier_stop': round(chandelier, 3) if chandelier else None,
+        'stop_distance_pct': stop_dist,
+        'vol_target_weight': None,
+        'pct_52w_range': None,
+        'bars': len(closes),
+    }
+    sig['technical_setups'] = []
+    tags = ['短历史']
+    if sig['rsi14'] is not None:
+        if sig['rsi14'] >= 70:
+            tags.append(f"RSI超买{sig['rsi14']}")
+        elif sig['rsi14'] <= 30:
+            tags.append(f"RSI超卖{sig['rsi14']}")
+    if z is not None and abs(z) >= 2:
+        tags.append(f'z{z:+.1f}σ极端')
+    if stop_dist is not None and stop_dist < 0:
+        tags.append('已破吊灯止损')
+    sig['tag'] = ' · '.join(tags)
+    return sig
+
+
 def _universe_details():
     """活跃持仓 → 去重后的 signal rows，保留每行覆盖的真实持仓。
 
@@ -380,6 +453,10 @@ def refresh_rows(previous, universe, *, run_date=None, previous_as_of=None,
                     and _as_date(bar.get('date')) <= expected)
             ]
         sig = compute_signals(bars) if bars else None
+        if sig is None:
+            # A short-history name cannot reach the 30-bar mature gate, but the
+            # early-trend lane needs its 20-bar-computable technical view.
+            sig = compute_short_history_signals(bars)
         if sig is not None:
             row_as_of = _as_date(bars[-1].get('date'))
             age_days = (run_date - row_as_of).days if row_as_of else None
@@ -475,16 +552,17 @@ def provisional_setups(universe=None, *, region=None, fetch=None):
         label = detail.get('label')
         try:
             bars = fetcher(detail['code'], 400)
-            sig = compute_signals(bars)
+            sig = compute_signals(bars) or compute_short_history_signals(bars)
         except Exception as exc:  # noqa: BLE001 — one bad symbol must not blank the rest
             errors.append({'label': label, 'error': f'{type(exc).__name__}: {exc}'[:200]})
             continue
         if sig is None:
-            # `fetch_bars` returns [] on a failed request rather than raising,
-            # and `compute_signals` answers None below 30 bars — so the ordinary
-            # production failure arrives as a value, not an exception, and an
-            # unguarded `.get` here would escape the loop and take every row
-            # already collected with it.
+            # `fetch_bars` returns [] on a failed request rather than raising.
+            # `compute_signals` answers None below 30 bars and the short-history
+            # fallback answers None below 20 — so the ordinary production
+            # failure arrives as a value, not an exception, and an unguarded
+            # `.get` here would escape the loop and take every row already
+            # collected with it.
             errors.append({'label': label,
                            'error': f'no_bars' if not bars else f'insufficient_bars({len(bars)})'})
             continue

--- a/tests/test_intraday_provisional_setups.py
+++ b/tests/test_intraday_provisional_setups.py
@@ -311,12 +311,23 @@ def test_an_empty_bar_list_is_reported_not_raised():
     assert out['errors'] == [{'label': '02208', 'error': 'no_bars'}]
 
 
-def test_too_few_bars_is_reported_with_the_count():
-    short = _flat(29, 10.0)
+def test_short_history_name_is_evaluated_not_reported_as_insufficient():
+    """20–29 bars now route through the short-history view (#542).
 
-    out = S.provisional_setups(_universe(), fetch=lambda code, cnt: short)
+    A sub-30-bar name used to be reported `insufficient_bars(N)` and stay
+    invisible to the early-trend lane. It is now evaluated with the
+    20-bar-computable technical view; a flat series yields no setup and no error.
+    """
+    out = S.provisional_setups(_universe(), fetch=lambda code, cnt: _flat(25, 10.0))
 
-    assert out['errors'] == [{'label': '02208', 'error': 'insufficient_bars(29)'}]
+    assert out == {'rows': [], 'confirmed_at_close': False}
+
+
+def test_below_twenty_bars_is_still_reported_with_the_count():
+    """Below 20 bars even the short-history view is not computable."""
+    out = S.provisional_setups(_universe(), fetch=lambda code, cnt: _flat(15, 10.0))
+
+    assert out['errors'] == [{'label': '02208', 'error': 'insufficient_bars(15)'}]
 
 
 def test_an_empty_feed_for_one_symbol_keeps_the_rows_already_collected():


### PR DESCRIPTION
## 背景 / issue #542

`compute_signals` 的 `len(closes) < 30 → None` 硬门槛把次新名字（如 SKHY 25 bars）整个挡在量化层外：`quant_signals.json` 里 status=missing、close/ma20/zscore20 全空，early_trend 因此判 `not_candidate` + 全 null technical。**为次新建的 early_trend lane，被次新自己过不去的门槛挡住**——不是阈值过紧，是短历史路径的 technical 输入不匹配它要服务的对象。

## 改动

`src/clawock/decision/signals.py`（+1 函数 +2 调用点）+ 测试：

1. 新增 `compute_short_history_signals(bars)`：20–29 bar 的名字照常算 close / MA20 / prior-20d/5d 区间 / RSI14 / zscore20 / ATR / 吊灯止损；MA50/MA200/vol20/动量等成熟因子标 None。`technical_setups=[]`（三条经典 setup 都需要 trend_on，短历史名字本就无法满足）。<20 bar 返回 None。
2. `refresh_rows` 在 `compute_signals` 返回 None 时回落 `compute_short_history_signals` → SKHY 之类名字在 `quant_signals.json` 变成 fresh 短历史行，`packet.py` 的 `_technical` 得到 `usable=True`，early_trend.classify 拿到 close/prior_20d_high/zscore20，得以出现 `observed` 或明确 blockers。
3. `provisional_setups` 同样回落 → 盘中不再对 SKHY 报 `insufficient_bars(25)`，而是如实给出无 setup。

## 不做（沿用 issue 边界）

- 不降低 `compute_signals` 全局 30-bar 门槛（成熟因子 MA200/vol20 仍只在 ≥30 bar 产出）。
- 不把任何名字特判进 lane。
- 阈值/规则本身不改。

## 验收对应

- [x] SKHY(25 bars) 在 decision_packet 的 early_trend 出现 observed/明确 blockers（technical 不再全 null）
- [x] 盘中 provisional_setups 不再报 `insufficient_bars(25)`
- [x] 成熟名字(bars≥30)输出逐字节一致（compute_signals 逻辑未动）

## 测试

- 定向：test_intraday_provisional_setups / test_quant_row_freshness / test_quant_technical_setups / test_early_trend / test_add_alpha_walkforward_early / test_brief_decision_packet 全绿
- 全量：2060 passed；4 个失败均为环境预存（openclaw 二进制路径 / dashboard payload 重建 / cron coupling），与本次改动无关