### PR TITLE
test: policy key parity + intraday preflight direct tests (#553 #554)

### DIFF
--- a/tests/test_intraday_preflight.py
+++ b/tests/test_intraday_preflight.py
@@ -1,0 +1,96 @@
+"""Intraday preflight helpers: alert rule, fail-soft setup collection, receipt (#554).
+
+Mode 7 runs 8 HK + 10 US slots per trading day. The alert rule decides whether
+a slot wakes kcn, `collect_provisional_setups` must never red a cron when the
+quote feed fails, and the unchanged receipt is the common-case push — its
+wording is the only thing most slots ever say.
+"""
+import pytest
+
+from clawock.harness import intraday_preflight as P
+
+
+# ── decide_alert: what wakes kcn ────────────────────────────────────────────
+
+def test_anomaly_alone_wakes():
+    should, reasons = P.decide_alert(
+        {"alert": 0, "watch": 0, "stop": 0, "trim": 0},
+        [{"ticker": "00100", "move_pct": -5.1}],
+    )
+    assert should is True
+    assert any("异动" in r for r in reasons)
+
+
+def test_two_signals_without_anomaly_wake():
+    should, _ = P.decide_alert(
+        {"alert": 0, "watch": 2, "stop": 0, "trim": 0}, [],
+    )
+    assert should is True
+
+
+def test_stop_or_alert_alone_wakes():
+    assert P.decide_alert(
+        {"alert": 0, "watch": 0, "stop": 1, "trim": 0}, [])[0] is True
+    assert P.decide_alert(
+        {"alert": 1, "watch": 0, "stop": 0, "trim": 0}, [])[0] is True
+
+
+def test_single_watch_does_not_wake():
+    should, reasons = P.decide_alert(
+        {"alert": 0, "watch": 1, "stop": 0, "trim": 0}, [],
+    )
+    assert should is False
+    assert reasons == []
+
+
+# ── collect_provisional_setups: fail-soft by value ─────────────────────────
+
+def test_setup_collection_passes_through(monkeypatch):
+    expected = {"rows": [{"label": "CRCL", "setup_id": "x"}],
+                "confirmed_at_close": False}
+    monkeypatch.setattr(
+        P.quant_signals, "provisional_setups", lambda **kwargs: expected)
+
+    assert P.collect_provisional_setups("us") == expected
+
+
+def test_setup_collection_never_reds_the_cron(monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("quote feed down")
+
+    monkeypatch.setattr(P.quant_signals, "provisional_setups", boom)
+
+    out = P.collect_provisional_setups("hk")
+    assert out["rows"] == []
+    assert out["confirmed_at_close"] is False
+    assert out["errors"] and out["errors"][0]["error"].startswith("RuntimeError")
+
+
+# ── render_unchanged_receipt: the common-case wording ──────────────────────
+
+def test_receipt_states_no_conditions_and_refresh_counts():
+    block = "🇭🇰 港股盯盘 | 08/14 15:30 HKT\n| 00100 | 120 | ..."
+    text = P.render_unchanged_receipt("hk", block, {
+        "refreshed": 3, "active": 4, "unrefreshed": [],
+    }, {"collection": {"cache_hit": False}})
+
+    assert text.startswith("🇭🇰 港股盯盘 | 08/14 15:30 HKT")
+    assert "本轮无新的加仓/减仓条件" in text
+    assert "3/4" in text
+
+
+def test_receipt_names_unrefreshed_and_degraded_sources():
+    text = P.render_unchanged_receipt("us", "🇺🇸 美股盯盘", {
+        "refreshed": 2, "active": 4, "unrefreshed": ["SPCH"],
+    }, {"collection": {}, "degraded_issuers": ["BAD"], "partial": []})
+
+    assert "未证实本轮刷新：SPCH" in text
+    assert "一级源降级：BAD" in text
+
+
+def test_receipt_uses_cache_source_when_collection_was_cached():
+    text = P.render_unchanged_receipt("hk", "🇭🇰 港股盯盘", {
+        "refreshed": 1, "active": 1, "unrefreshed": [],
+    }, {"collection": {"cache_hit": True}})
+
+    assert "一级信息缓存复核" in text

--- a/tests/test_policy_key_parity.py
+++ b/tests/test_policy_key_parity.py
@@ -1,0 +1,71 @@
+"""Policy config keys vs code references must not drift (#553).
+
+`packet.py` reads add-authorization policy from `config/add-alpha-policy.json`
+and sizing-overlay policy from `config/news-evidence-policy.json` (via the
+`information_overlay.sizing_policy` the evidence graph publishes). Every
+`policy.get(key, default)` call that names a literal key is a configuration
+contract: if the key is missing from its config, the code silently falls back
+to a hardcoded default and editing the config does nothing. This parity test
+is the trip-wire for that drift (same idea as `test_readme_parity`).
+"""
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKET = ROOT / "src" / "clawock" / "decision" / "packet.py"
+
+
+def _flat_keys(mapping, prefix=""):
+    out = set()
+    for key, value in mapping.items():
+        if isinstance(value, dict):
+            out |= _flat_keys(value, f"{prefix}{key}.")
+        else:
+            out.add(f"{prefix}{key}")
+    return out
+
+
+def _literal_policy_keys(function_name):
+    """Literal `policy.get("key", ...)` keys inside a named function."""
+    source = PACKET.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != function_name:
+            continue
+        segment = ast.get_source_segment(source, node) or ""
+        return set(re.findall(r'policy\.get\("([a-z_0-9]+)"', segment))
+    return set()
+
+
+def test_add_alpha_policy_keys_all_present_in_config():
+    """Every literal add_policy.get key must exist in add-alpha-policy.json."""
+    source = PACKET.read_text(encoding="utf-8")
+    used = set(re.findall(r'add_policy\.get\("([a-z_0-9]+)"', source))
+    assert used, "no add_policy.get literal keys found — test fixture drift"
+    config = json.loads((ROOT / "config" / "add-alpha-policy.json").read_text())
+    present = _flat_keys(config)
+    missing = used - present
+    assert not missing, (
+        "packet.py add_policy keys missing from config/add-alpha-policy.json: "
+        f"{sorted(missing)} — editing the config cannot change them"
+    )
+
+
+def test_sizing_policy_keys_all_present_in_news_evidence_config():
+    """Every literal sizing policy.get key must exist in the sizing section."""
+    used = _literal_policy_keys("_information_sizing_overlay")
+    assert used, "no sizing policy.get literal keys found — test fixture drift"
+    config = json.loads(
+        (ROOT / "config" / "news-evidence-policy.json").read_text()
+    )
+    sizing = (config.get("information_overlay") or {}).get("sizing") or {}
+    present = _flat_keys(sizing)
+    missing = used - present
+    assert not missing, (
+        "packet.py sizing_policy keys missing from news-evidence-policy.json "
+        f"'sizing' section: {sorted(missing)} — editing the config cannot change them"
+    )


### PR DESCRIPTION
## 背景

- **#553**:sizing 覆盖层配置勘误后,真正的问题是"两份 policy 文件职责边界无对账测试"——`policy.get(key, default)` 引用的 key 若在对应 config 缺失会静默走默认值(改配置不生效)。
- **#554**:`intraday_preflight.py` 无直接测试——盘中 8+10 slot/天的核心路径,decide_alert / collect_provisional_setups fail-soft / render_unchanged_receipt 全是行为契约,靠人工。

## 改动(纯新增测试,零逻辑改动)

1. `tests/test_policy_key_parity.py`:
   - `add_policy.get("...")` 字面量 key ⊆ `config/add-alpha-policy.json`(扁平 key)
   - `_information_sizing_overlay` 内 `policy.get("...")` 字面量 key ⊆ `config/news-evidence-policy.json` 的 `information_overlay.sizing` 段
   - 防漂移思路与 `test_readme_parity` 一致:未来加 key 忘配 config 会当场红。

2. `tests/test_intraday_preflight.py`:
   - `decide_alert`:anomaly 单独唤醒 / ≥2 信号 / STOP/ALERT 单独唤醒 / 单个 WATCH 不唤醒
   - `collect_provisional_setups`:正常透传 + feed 挂掉返回 errors 不红 cron
   - `render_unchanged_receipt`:无变化文案 / 刷新计数 / unrefreshed 点名 / 一级源降级 / 缓存来源标注

## 测试

- 新增 11 passed;相关回归 87 passed(含 readme_parity / decision packet / intraday 全系)。