### PR TITLE
feat: plan_context stops carrying user-overridden risk_rule cuts (#552)

### DIFF
--- a/src/clawock/decision/plans.py
+++ b/src/clawock/decision/plans.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock.decision import risk as risk_ledger
 
 WS = workspace_root(Path.cwd())
 MEMORY = WS / "memory"
@@ -90,6 +91,28 @@ def _is_open(row):
     return execution == OPEN_EXECUTION and evaluation == "pending"
 
 
+def _overridden_risk_tickers(ledger_path=None):
+    """Tickers whose risk_rule discipline the user has explicitly overridden.
+
+    `clawock risk override <breach_id>` marks a breach record as overridden
+    (status=overridden, override.status=active, TTL-bound). A user who keeps
+    adding to SPCH while the system daily re-hangs a "SPCH cut" risk_rule order
+    is not going to execute it — repeating it every slot is the #552 churn. This
+    returns the tickers with an active override so `open_decisions_context` can
+    stop carrying their risk_rule cuts while every other gate stays untouched.
+    """
+    try:
+        ledger = risk_ledger.load_ledger(
+            Path(ledger_path) if ledger_path else risk_ledger.LEDGER)
+    except Exception:  # noqa: BLE001 — a broken breach ledger must not red a report cron
+        return set()
+    overridden = set()
+    for row in ledger.get("records") or []:
+        if risk_ledger.override_is_active(row) and row.get("ticker"):
+            overridden.add(str(row["ticker"]))
+    return overridden
+
+
 def _entry(row):
     size = row.get("size") or {}
     condition = row.get("condition") or {}
@@ -152,9 +175,26 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
         rows = [row for row in _load_ledger(ledger_path) if _is_open(row)]
         if leg:
             rows = [row for row in rows if str(row.get("leg", "")).upper() == leg.upper()]
+        # User-overridden risk discipline is not carried over (#552): the breach
+        # ledger's active override already says the user knows and keeps the
+        # position, so re-hanging the same risk_rule cut every slot is churn, not
+        # discipline. Other decisions on the same ticker stay untouched.
+        overridden_tickers = _overridden_risk_tickers(
+            ledger_path=memory / "risk_breaches.json")
+        dropped = []
+        if overridden_tickers:
+            def _is_overridden_cut(row):
+                return (str(row.get("ticker") or "") in overridden_tickers
+                        and row.get("driven_by") == "risk_rule"
+                        and row.get("action") in ("cut", "trim_on_rebound"))
+            dropped = [str(row.get("ticker")) for row in rows if _is_overridden_cut(row)]
+            rows = [row for row in rows if not _is_overridden_cut(row)]
         if not rows:
-            return ({"open_add_tickers": [], "open_add_gate_error": open_add_gate_error}
-                    if open_add_gate_error else {})
+            if open_add_gate_error:
+                return {"open_add_tickers": [], "open_add_gate_error": open_add_gate_error}
+            if dropped:
+                return {"open_add_tickers": [], "overridden_by_user": sorted(set(dropped))}
+            return {}
 
         # Today's plan first, then the oldest carried-over orders: a swap hanging
         # since Friday is more urgent than one written this morning, but the
@@ -176,6 +216,8 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
             # Unlike `open`, this safety projection is never truncated.
             "open_add_tickers": open_add_tickers,
         }
+        if dropped:
+            context["overridden_by_user"] = sorted(set(dropped))
         if open_add_gate_error:
             context["open_add_gate_error"] = open_add_gate_error
         if len(rows) > MAX_DECISIONS:

--- a/tests/test_plans_override.py
+++ b/tests/test_plans_override.py
@@ -1,0 +1,99 @@
+"""User risk overrides stop the daily re-hang of the same cut (#552).
+
+`clawock risk override <breach_id>` marks a breach as user-overridden. A user
+who keeps adding to SPCH while the system re-hangs "SPCH cut 200" every slot is
+not going to execute it — the plan context should stop carrying that risk_rule
+cut while every other decision stays untouched.
+"""
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from clawock.decision import plans
+
+
+def _stamp_future(days=7):
+    return (datetime.now(ZoneInfo("Asia/Hong_Kong")) + timedelta(days=days)
+            ).isoformat()
+
+
+def _write_ledger(path, rows):
+    path.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n")
+
+
+def _open_row(ticker, action, driven_by="risk_rule"):
+    return {
+        "decision_id": f"dec-{ticker}-{action}",
+        "plan_date": "2026-08-13",
+        "ticker": ticker,
+        "leg": "HK",
+        "action": action,
+        "driven_by": driven_by,
+        "size": {"shares": 100},
+        "condition": {"type": "open"},
+        "execution": {"status": "unknown"},
+        "evaluation": {"status": "pending"},
+        "confidence": 0.8,
+    }
+
+
+def _write_breaches(path, rows):
+    path.write_text(json.dumps({
+        "schema_version": 1, "updated_at": "x", "records": rows,
+    }))
+
+
+def test_overridden_risk_tickers_reads_active_overrides(tmp_path):
+    breaches = tmp_path / "risk_breaches.json"
+    _write_breaches(breaches, [
+        {"ticker": "SPCH", "status": "overridden", "override": {
+            "status": "active", "reason": "无限子弹流",
+            "created_at": "x", "expires_at": _stamp_future()}},
+        {"ticker": "RKLX", "status": "open", "override": {}},
+        {"ticker": "MSFU", "status": "overridden", "override": {
+            "status": "active", "reason": "x", "expires_at": "2020-01-01T00:00:00"}},
+    ])
+
+    assert plans._overridden_risk_tickers(ledger_path=breaches) == {"SPCH"}
+
+
+def test_open_decisions_context_drops_overridden_risk_cuts(tmp_path):
+    ledger = tmp_path / "decisions.jsonl"
+    _write_ledger(ledger, [
+        _open_row("SPCH", "cut", "risk_rule"),
+        _open_row("CRCL", "cut", "thesis"),
+        _open_row("SPCH", "hold_and_watch", "technical"),
+    ])
+    breaches = tmp_path / "risk_breaches.json"
+    _write_breaches(breaches, [
+        {"ticker": "SPCH", "status": "overridden", "override": {
+            "status": "active", "reason": "无限子弹流",
+            "created_at": "x", "expires_at": _stamp_future()}},
+    ])
+
+    ctx = plans.open_decisions_context(
+        leg="HK", today="2026-08-14", ledger=ledger, memory_dir=tmp_path,
+    )
+
+    assert ctx["overridden_by_user"] == ["SPCH"]
+    open_rows = {row["decision_id"] for row in ctx["open"]}
+    assert "dec-SPCH-cut" not in open_rows          # risk_rule cut dropped
+    assert "dec-CRCL-cut" in open_rows              # thesis cut kept
+    assert "dec-SPCH-hold_and_watch" in open_rows   # non-risk decision kept
+
+
+def test_no_override_means_no_change(tmp_path):
+    ledger = tmp_path / "decisions.jsonl"
+    _write_ledger(ledger, [_open_row("SPCH", "cut", "risk_rule")])
+    breaches = tmp_path / "risk_breaches.json"
+    _write_breaches(breaches, [
+        {"ticker": "SPCH", "status": "open", "override": {}},
+    ])
+
+    ctx = plans.open_decisions_context(
+        leg="HK", today="2026-08-14", ledger=ledger, memory_dir=tmp_path,
+    )
+
+    assert "overridden_by_user" not in ctx
+    assert "dec-SPCH-cut" in {row["decision_id"] for row in ctx["open"]}


### PR DESCRIPTION
## 背景 / issue #552

用户实际行为(SPCH 无限子弹流 21 笔买入 / 00100 加仓)与系统纪律输出长期对立:系统每天把 "SPCH cut 200" 当 carried_over 重挂,用户从不执行(执行率 6%)。两边互相不理解,每天重复喊话。

## 改动

`src/clawock/decision/plans.py`(+`tests/test_plans_override.py`):

1. `_overridden_risk_tickers(ledger_path)`:读 `memory/risk_breaches.json`,返回存在 **active override**(`clawock risk override <breach_id>`,status=overridden + TTL 未过期)的 ticker 集合。fail-soft(账本坏不红 cron)。
2. `open_decisions_context` 过滤:被 override 的 ticker 的 **risk_rule driven 的 cut/trim_on_rebound** 不再进入 plan_context(不再每天 carried_over);同 ticker 的其它决策(thesis cut / hold)保留;未 override 名字行为不变。
3. context 新增 `overridden_by_user` 列表,LLM 散文可说明"SPCH 纪律单已由用户 override,不再重复提示"。

**注意**:breach override 机制(`clawock risk override`)本来就存在,本次只补了 plan_context 的联动。SPCH/00100 是否 override 是用户决策——**本 PR 不替用户回填**,用户想停喊话就跑 `clawock risk override <breach_id> --reason "无限子弹流" --ttl-hours 720`。

## 验收

- [x] override 后 plan_context 不再含该 ticker 的 risk_rule cut(测试断言)
- [x] 同 ticker 非 risk_rule 决策保留;未 override 名字不变(测试断言)
- [x] 无 override 时行为与现状一致(测试断言)
- [x] breach 账本缺失/损坏时 fail-soft,不红 report/intraday cron

## 不做

- 不改硬止损规则本身(override 是用户显式授权,不是规则松动)
- 不替用户回填 SPCH/00100 的 override(用户决策)