### PR TITLE
feat: brief watchdog gets a second on-host rerun at 09:05 before off-host fallback (#550)

### DIFF
--- a/src/clawock/harness/brief_watchdog.py
+++ b/src/clawock/harness/brief_watchdog.py
@@ -65,6 +65,7 @@ from ._watchdog_common import (
 MARKER_FRESH_MS = 30 * 60 * 1000  # postflight send-marker older than this ⇒ not this slot
 MISSING_STATE_VERSION = 1
 NOTIFICATION_ATTEMPTS_PER_RUN = 2
+MAX_ONHOST_RERUNS = 2  # 08:30 first re-run; 09:05 second chance before off-host fallback (#550)
 
 
 def inspect_brief_artifacts(today):
@@ -98,6 +99,61 @@ def inspect_brief_artifacts(today):
 
 def rerun_flag_path(today):
     return WS / 'memory' / '.tmp' / f'watchdog-brief-rerun-{today}.done'
+
+
+def _rerun_count(today):
+    """How many on-host re-runs fired today (flag file now holds a counter)."""
+    try:
+        return int(rerun_flag_path(today).read_text().strip() or 0)
+    except (OSError, ValueError):
+        return 0
+
+
+def _mark_rerun(today):
+    path = rerun_flag_path(today)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(_rerun_count(today) + 1))
+
+
+def _rerun_once(today, dry_run, attempt):
+    """Queue one on-host re-run, deduped to MAX_ONHOST_RERUNS per day (#550).
+
+    The 08:30 pass fires attempt 1; if its re-run itself failed (2026-08-12),
+    the 09:05 miss detector fires attempt 2 before dispatching the off-host
+    fallback — a local re-run is cheaper than a vendor fallback and lands well
+    before the 10:00 HKT cutoff. Returns True when a re-run was queued.
+    """
+    if _rerun_count(today) >= MAX_ONHOST_RERUNS:
+        return False
+    job = brief_cron_job()
+    if not isinstance(job, dict) or not job.get('id'):
+        # The 09:05 alert is the core invariant; an unreadable schedule must
+        # never block it — fall back to the off-host path without a re-run.
+        return False
+    ok, out = rerun_cron_job(job.get('id'), dry_run)
+    if ok and not dry_run:
+        _mark_rerun(today)
+    budget = cron_retry_budget(job)
+    # The re-run fires on the run being over, not on the budget — but what the
+    # log may *claim* about the budget is only what was read. The old wording
+    # asserted "the runtime will not retry it" unconditionally, which was the
+    # 08-13 case and not the general one: a job whose budget is intact will be
+    # retried by the scheduler, and one whose state is unreadable is not
+    # evidence of either (#506).
+    verdict = ('exhausted — this re-run is one more single attempt'
+               if budget.exhausted else
+               'intact — the scheduler may also retry on its own'
+               if budget.exhausted is False else
+               # Either side of the comparison can be the missing one; naming
+               # only the job would send a reader to the wrong file.
+               'unknown — counter or cap unreadable')
+    log({'tag': 'brief', 'action': 'rerun-onhost', 'attempt': attempt,
+         'dry_run': dry_run, 'queued_ok': ok,
+         'job_id': job.get('id'), 'job_name': job.get('name'),
+         'reason': f'the 08:00 run already ended in error; retry budget {verdict}',
+         'retry_budget': budget.describe(), 'retry_budget_exhausted': budget.exhausted,
+         'out': out})
+    return ok
 
 
 def retrigger_or_wait(today, dry_run):
@@ -139,29 +195,7 @@ def retrigger_or_wait(today, dry_run):
              'reason': 'on-host re-run already fired today (dedupe flag present)'})
         return 0
 
-    budget = cron_retry_budget(job)
-    ok, out = rerun_cron_job(job.get('id'), dry_run)
-    if ok and not dry_run:
-        flag.parent.mkdir(parents=True, exist_ok=True)
-        flag.write_text(datetime.now(HKT).isoformat())
-    # The re-run fires on the run being over, not on the budget — but what the
-    # log may *claim* about the budget is only what was read. The old wording
-    # asserted "the runtime will not retry it" unconditionally, which was the
-    # 08-13 case and not the general one: a job whose budget is intact will be
-    # retried by the scheduler, and one whose state is unreadable is not
-    # evidence of either (#506).
-    verdict = ('exhausted — this re-run is one more single attempt'
-               if budget.exhausted else
-               'intact — the scheduler may also retry on its own'
-               if budget.exhausted is False else
-               # Either side of the comparison can be the missing one; naming
-               # only the job would send a reader to the wrong file.
-               'unknown — counter or cap unreadable')
-    log({'tag': tag, 'action': 'rerun-onhost', 'dry_run': dry_run, 'queued_ok': ok,
-         'job_id': job.get('id'), 'job_name': job.get('name'),
-         'reason': f'the 08:00 run already ended in error; retry budget {verdict}',
-         'retry_budget': budget.describe(), 'retry_budget_exhausted': budget.exhausted,
-         'out': out})
+    _rerun_once(today, dry_run, attempt=1)
     return 0
 
 
@@ -286,6 +320,11 @@ def alert_brief_missing(today, dry_run, issues=None):
 
     state['issues'] = list(issues)
     if not state.get('fallback_dispatch_attempted'):
+        # Second on-host chance before the off-host fallback (#550): the 08:30
+        # re-run can itself fail (2026-08-12), and a local re-run is cheaper
+        # than a vendor fallback and lands well before the 10:00 HKT cutoff.
+        if _rerun_count(today) < MAX_ONHOST_RERUNS:
+            _rerun_once(today, dry_run, attempt=2)
         dispatched, out = dispatch_brief_fallback(dry_run)
         state.update({
             'fallback_dispatch_attempted': True,

--- a/tests/test_brief_watchdog_second_rerun.py
+++ b/tests/test_brief_watchdog_second_rerun.py
@@ -1,0 +1,76 @@
+"""The 09:05 pass gets a second on-host re-run before the off-host fallback (#550).
+
+2026-08-11/12 showed the failure chain: the 08:00 run died, the 08:30 re-run
+queued but ITS run also failed, and by 09:05 there was no brief — the only
+recovery left was the vendor fallback. A second on-host re-run at 09:05 is
+cheaper than the fallback and lands well before the 10:00 HKT cutoff.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+from clawock.harness import brief_watchdog as watchdog  # noqa: E402
+
+HKT = timezone(timedelta(hours=8))
+TODAY = "2026-08-12"
+JOB_ID = "db3df0d0-7622-4b75-81ce-86d510eeef33"
+
+
+def _job(**state):
+    return {"id": JOB_ID, "name": "盘前深度简报", "enabled": True, "state": state}
+
+
+def _watch(monkeypatch, tmp_path, job=None):
+    spy = {}
+    monkeypatch.setattr(watchdog, "WS", tmp_path)
+    monkeypatch.setattr(watchdog, "log", lambda event: spy.setdefault("logs", []).append(event))
+    if job is not None:
+        monkeypatch.setattr(watchdog, "brief_cron_job", lambda: job)
+        monkeypatch.setattr(
+            watchdog, "rerun_cron_job",
+            lambda job_id, dry_run=False: (spy.setdefault("reruns", []).append(job_id), (True, "queued"))[1])
+    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda dry_run=False: (True, "dispatched"))
+    monkeypatch.setattr(watchdog, "send_telegram", lambda *a, **k: (True, "sent"))
+    monkeypatch.setattr(watchdog, "write_missing_state", lambda *a, **k: None)
+    monkeypatch.setattr(watchdog, "brief_cron_job_state", lambda: {})
+    monkeypatch.setattr(watchdog, "await_brief_fallback_outcome", lambda *a, **k: (True, "ok"))
+    return spy
+
+
+def test_miss_detector_fires_second_rerun_before_fallback(monkeypatch, tmp_path):
+    """08:30 already re-ran once (flag count=1): 09:05 queues attempt 2."""
+    spy = _watch(monkeypatch, tmp_path, job=_job(lastStatus="error", consecutiveErrors=8))
+    flag = watchdog.rerun_flag_path(TODAY)
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text("1")
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    attempts = [e.get("attempt") for e in spy["logs"] if e.get("action") == "rerun-onhost"]
+    assert attempts == [2]
+    assert len(spy["reruns"]) == 1
+    # the dedupe counter advanced
+    assert watchdog._rerun_count(TODAY) == 2
+
+
+def test_miss_detector_stops_after_two_reruns(monkeypatch, tmp_path):
+    """Both on-host chances used: no third re-run, fallback still dispatched."""
+    spy = _watch(monkeypatch, tmp_path, job=_job(lastStatus="error", consecutiveErrors=8))
+    flag = watchdog.rerun_flag_path(TODAY)
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text("2")
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert spy.get("reruns") or [] == []
+    assert watchdog._rerun_count(TODAY) == 2
+
+
+def test_miss_detector_without_schedule_still_alerts(monkeypatch, tmp_path):
+    """Unreadable schedule must not block the alert: fallback + notification only."""
+    spy = _watch(monkeypatch, tmp_path, job=None)  # brief_cron_job returns None
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert spy.get("reruns") or [] == []


### PR DESCRIPTION
## 背景 / issue #550

08-11/08-12 早报连续缺失、08-13 晚 13.5h:08:00 run error → 08:30 watchdog rerun 一次 → **rerun 的 run 自己也失败(08-12)就没有第二次机会** → 只剩远端 vendor fallback(还经常 outcome unknown)。本地 rerun 比 vendor fallback 便宜,且 9-19 分钟就能落地,远早于 10:00 HKT cutoff。

## 改动

`src/clawock/harness/brief_watchdog.py`:

1. rerun dedupe flag 从"存在即 dedupe"升级为**计数文件**(`_rerun_count` / `_mark_rerun`),`MAX_ONHOST_RERUNS = 2`。
2. 抽出 `_rerun_once(today, dry_run, attempt)`:排队一次 rerun + 计数 + 预算判定日志(原 retrigger_or_wait 的逻辑,行为不变,log 新增 `attempt` 字段)。
3. `retrigger_or_wait`(08:30):attempt=1(原行为)。
4. **`alert_brief_missing`(09:05):dispatch off-host fallback 之前,若今天 rerun 次数 < 2,先 attempt=2 再 rerun 一次**——08:30 那次失败时,09:05 有第二次本地机会,之后才 fallback。
5. 防御:schedule 不可读(job 拿不到)时跳过 rerun、直接 fallback——09:05 告警是核心不变量,绝不能被 rerun 阻塞。

## 验收

- [x] 08:30 已 rerun 一次(count=1)且 09:05 仍缺 → attempt=2 触发,然后才 dispatch fallback(测试)
- [x] 两次机会用完(count=2)→ 不再 rerun,fallback 照常(测试)
- [x] schedule 不可读 → 不 rerun、告警不阻塞(测试)
- [x] 既有 watchdog 行为不变(08:30 单次 rerun + dedupe,test_brief_watchdog 13 + onhost_retrigger 8 全过)

## 不做

- 不修 openclaw runtime 的 consecutiveErrors 预算(外部,告警里的 retry_budget_note 已提示手动处理)
- 不引入新的 cron 时间点

## 测试

- 新增 `tests/test_brief_watchdog_second_rerun.py` 3 项;相关回归 24 passed(本地 test_brief_watchdog_retry_budget.py 单独跑在本机间歇挂起,属既有环境问题——该测试覆盖 `_watchdog_common` provider,本 PR 未触碰;以 CI 全量为准)