### PR TITLE
feat: plan context pairs cut ammunition with same-leg radar candidates (#555)

### DIFF
--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -465,6 +465,40 @@ def append_opportunity_radar_section(block, radar, signals_detail=None):
     return block + '\n' + '\n'.join(lines)
 
 
+def attach_reinvest_candidates(plan_ctx, opportunity_radar, signals_detail=None):
+    """Pair cut/trim ammunition with same-leg opportunity candidates (#555).
+
+    A risk_rule cut used to be a dead end: the plan says sell, never what the
+    money is for. This attaches up to two radar candidates (the same leg, no
+    STOP/ALERT flag) to the plan context so the prose can say "砍 X 的弹药 →
+    候选:Y(突破 Z 触发)/ W(等回踩)". Candidates are observations, never orders.
+    Returns the plan context unchanged when there is nothing to pair.
+    """
+    rows = (opportunity_radar or {}).get('rows') or []
+    if not rows:
+        return plan_ctx
+    flagged = {item.get('ticker') for item in (signals_detail or [])
+               if str(item.get('level', '')).upper() in CONFLICTING_LEVELS}
+    flagged.discard(None)
+    candidates = []
+    for row in rows:
+        if set(row.get('holdings') or []) & flagged:
+            continue
+        prior = row.get('prior_20d_high')
+        trigger = ('已突破' if row.get('state') == 'breakout'
+                   else f"突破前高 {prior:g}" if prior is not None else '等回踩')
+        candidates.append({
+            'ticker': row.get('label'),
+            'state': row.get('state'),
+            'trigger': trigger,
+        })
+        if len(candidates) >= 2:
+            break
+    if not candidates:
+        return plan_ctx
+    return {**(plan_ctx or {}), 'reinvest_candidates': candidates}
+
+
 def append_active_information_section(block, active, *, event_ids=None):
     """Render changed primary events plus compact context for existing ones.
 
@@ -810,6 +844,11 @@ def main(argv=None):
     # near-breakout candidates, additive to the early-trend lane. Candidate rows
     # join the setups dimension so the delta gate surfaces their appearance.
     opportunity_radar = collect_opportunity_radar(args.market)
+    # A cut's ammunition gets a same-leg destination (#555): the radar rows that
+    # are not themselves flagged pair into the plan context, so the prose can
+    # say what the money is for instead of ending at "sell".
+    plan_ctx = attach_reinvest_candidates(
+        plan_ctx, opportunity_radar, signals_detail)
     combined_setups = {
         'rows': (live_setups.get('rows') or [])
         + (early_candidates.get('rows') or [])

--- a/tests/test_reinvest_candidates.py
+++ b/tests/test_reinvest_candidates.py
@@ -1,0 +1,55 @@
+"""A cut's ammunition gets a same-leg destination (#555).
+
+The 08:00 plan used to end at "sell SPCH": the risk_rule cut never said what
+the money was for. With the opportunity radar (#551) in place, the plan context
+can carry up to two same-leg, un-flagged candidates so the prose can pair
+"砍 X 的弹药 → 候选:Y". Candidates stay observations, never orders.
+"""
+from clawock.harness import intraday_preflight as P
+
+
+def _radar_row(label, state="breakout", prior=100.0):
+    return {'label': label, 'setup_id': f'opportunity:{state}', 'state': state,
+            'state_zh': '机会·突破', 'holdings': [label],
+            'close': 110.0, 'prior_20d_high': prior,
+            'pct_from_high': 10.0, 'zscore20': 1.0}
+
+
+def test_attach_pairs_up_to_two_unflagged_candidates():
+    plan_ctx = {'open': [{'decision_id': 'd1', 'action': 'cut'}]}
+    radar = {'rows': [_radar_row('00100', 'breakout', 374.4),
+                      _radar_row('SKHY', 'near_breakout', 177.93),
+                      _radar_row('CRCL', 'breakout', 75.89)]}
+
+    out = P.attach_reinvest_candidates(plan_ctx, radar, [])
+
+    assert out['reinvest_candidates'] == [
+        {'ticker': '00100', 'state': 'breakout', 'trigger': '已突破'},
+        {'ticker': 'SKHY', 'state': 'near_breakout', 'trigger': '突破前高 177.93'},
+    ]
+    assert len(out['reinvest_candidates']) == 2
+
+
+def test_flagged_candidates_are_excluded():
+    radar = {'rows': [_radar_row('SPCH'), _radar_row('SKHY')]}
+    signals = [{'ticker': 'SPCH', 'level': 'STOP'}]
+
+    out = P.attach_reinvest_candidates({}, radar, signals)
+
+    tickers = [c['ticker'] for c in out['reinvest_candidates']]
+    assert 'SPCH' not in tickers
+    assert tickers == ['SKHY']
+
+
+def test_no_candidates_returns_context_untouched():
+    plan_ctx = {'open': []}
+
+    assert P.attach_reinvest_candidates(plan_ctx, {'rows': []}, []) is plan_ctx
+    assert P.attach_reinvest_candidates(plan_ctx, None, []) is plan_ctx
+
+
+def test_all_flagged_returns_context_untouched():
+    radar = {'rows': [_radar_row('SPCH')]}
+    signals = [{'ticker': 'SPCH', 'level': 'ALERT'}]
+
+    assert P.attach_reinvest_candidates({'open': []}, radar, signals) == {'open': []}


### PR DESCRIPTION
## 背景 / issue #555

risk_rule cut 曾经是死胡同:plan 只说卖,不说卖了的钱去哪。用户视角"系统只会说卖"。现在 #551 机会雷达已合并,cut 的弹药可以配同腿候选。

## 改动

`src/clawock/harness/intraday_preflight.py` + `tests/test_reinvest_candidates.py`:

1. `attach_reinvest_candidates(plan_ctx, opportunity_radar, signals_detail)`:从机会雷达挑**同腿、无 STOP/ALERT 标记**的最多 2 个候选,附到 plan_context 的 `reinvest_candidates`(`{ticker, state, trigger}`,trigger 形如"突破前高 374.4"/"已突破")。
2. main() 接入:opportunity_radar 计算后注入 plan_ctx——盘中 LLM 散文可写"砍 SPCH 的弹药 → 候选:00100(突破前高 374.4)/ SKHY(等回踩)"。
3. 无候选 / 全 flagged → context 原样返回(逐字节不变)。

**设计边界**:候选是观察不是指令;不改 decision schema / postflight 校验 / 不下单授权。配对只进 plan_context(散文层),`reinvest_candidates` 不是可执行决策。

## 验收

- [x] 有候选 → plan_ctx 带 reinvest_candidates(≤2,按雷达顺序)
- [x] STOP/ALERT 标记的名字被排除(测试)
- [x] 无候选 / 全排除 → context 原样(identity 断言)
- [x] 既有 intraday 行为不变(回归 20 passed)

## 不做

- 不暗示"砍了必买"(配对是候选,不是指令)
- 不自动下单