### PR TITLE
perf: mtime-keyed JSON read cache; wire into signals universe + intraday delta (#557)

### DIFF
--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -34,7 +34,7 @@ import requests
 
 from clawock.market_data import sessions as trading_calendar
 from clawock.portfolio.instruments import require as require_instrument
-from clawock.safe_io import safe_write_json
+from clawock.safe_io import safe_write_json, load_json_cached
 from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
@@ -344,7 +344,7 @@ def _universe_details():
     杠杆产品使用 registry 的 signal_symbol 折到标的/1x proxy；venue 后缀
     同样从 registry 读取，绝不再默认猜成 Nasdaq。
     """
-    port = json.loads(PORTFOLIO.read_text())
+    port = load_json_cached(PORTFOLIO)
     by_code = {}
     for book in (port.get('portfolios') or {}).values():
         if not isinstance(book, dict):

--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -21,7 +21,7 @@ from clawock.workspace import workspace_root
 from clawock.market_data import sessions as trading_calendar
 from clawock.market_data import peer_quotes as fetch_peers
 from clawock.automation import cron_heartbeat
-from clawock.safe_io import safe_write_json
+from clawock.safe_io import safe_write_json, load_json_cached
 
 WS = workspace_root(Path.cwd())
 HKT = ZoneInfo("Asia/Hong_Kong")
@@ -143,7 +143,7 @@ def market_session_date(market, at):
 
 def _load(path):
     try:
-        value = json.loads(Path(path).read_text())
+        value = load_json_cached(path)
         return value if isinstance(value, dict) else {}
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}

--- a/src/clawock/safe_io.py
+++ b/src/clawock/safe_io.py
@@ -202,3 +202,34 @@ if __name__ == '__main__':
         final = json.load(open(ctr))
         assert len(final) == 20, f'lost updates: only {len(final)}/20 keys survived'
         print('mutate_json concurrency (20 writers, no lost updates): OK')
+
+
+# Process-local JSON read cache, keyed by file mtime (#557). Same mtime ⇒ the
+# same bytes, so a cached hit is always current: a producer that atomically
+# replaces a file (every `safe_write_json` caller) bumps mtime and the next
+# read re-parses. No TTL, no staleness window.
+_JSON_READ_CACHE: dict[str, tuple[float, object]] = {}
+
+
+def load_json_cached(path: str | os.PathLike) -> object:
+    """Read + parse JSON once per mtime within this process.
+
+    Portfolio.json alone is read by 39 modules; a single preflight re-parses it
+    several times. Callers that re-read the same file in one process should
+    route through here. Raises FileNotFoundError / JSONDecodeError exactly like
+    a plain read — only the parse count changes.
+    """
+    path = os.path.abspath(os.fspath(path))
+    mtime = os.path.getmtime(path)
+    cached = _JSON_READ_CACHE.get(path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+    with open(path, encoding='utf-8') as f:
+        value = json.load(f)
+    _JSON_READ_CACHE[path] = (mtime, value)
+    return value
+
+
+def clear_json_cache() -> None:
+    """Drop every cached entry (tests; a long-lived process after a mass move)."""
+    _JSON_READ_CACHE.clear()

--- a/tests/test_safe_io_json_cache.py
+++ b/tests/test_safe_io_json_cache.py
@@ -1,0 +1,68 @@
+"""Process-local JSON read cache keyed by file mtime (#557).
+
+Same mtime ⇒ same bytes, so a cached hit is always current and a producer that
+atomically replaces the file bumps mtime and the next read re-parses. The
+contract: parse count drops, freshness never does.
+"""
+import json
+import os
+
+from clawock.safe_io import load_json_cached, clear_json_cache
+
+
+def _write(path, payload):
+    path.write_text(json.dumps(payload))
+
+
+def test_second_read_with_same_mtime_skips_parse(monkeypatch, tmp_path):
+    p = tmp_path / "x.json"
+    _write(p, {"a": 1})
+    calls = {"n": 0}
+    real_load = json.load
+
+    def spy(f):
+        calls["n"] += 1
+        return real_load(f)
+
+    monkeypatch.setattr("clawock.safe_io.json.load", spy)
+
+    assert load_json_cached(p) == {"a": 1}
+    assert load_json_cached(p) == {"a": 1}
+    assert calls["n"] == 1
+
+
+def test_mtime_change_reparses(tmp_path):
+    p = tmp_path / "x.json"
+    _write(p, {"a": 1})
+    os.utime(p, (1_000_000_000, 1_000_000_000))
+    assert load_json_cached(p) == {"a": 1}
+
+    _write(p, {"a": 2})
+    os.utime(p, (2_000_000_000, 2_000_000_000))
+    assert load_json_cached(p) == {"a": 2}
+
+
+def test_clear_cache_forces_reparse(monkeypatch, tmp_path):
+    p = tmp_path / "x.json"
+    _write(p, {"a": 1})
+    calls = {"n": 0}
+    real_load = json.load
+
+    def spy(f):
+        calls["n"] += 1
+        return real_load(f)
+
+    monkeypatch.setattr("clawock.safe_io.json.load", spy)
+    load_json_cached(p)
+    clear_json_cache()
+    load_json_cached(p)
+    assert calls["n"] == 2
+
+
+def test_missing_file_raises_like_a_plain_read(tmp_path):
+    try:
+        load_json_cached(tmp_path / "nope.json")
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("expected FileNotFoundError")


### PR DESCRIPTION
## 背景 / issue #557

portfolio.json 被 39 个模块读取,一个 preflight 内重复解析多次(dashboard.py 24 处引用)。目标是进程内缓存 + mtime 失效:文件没变就复用,变了必重读——**不引入任何 staleness 窗口**。

## 改动

1. `src/clawock/safe_io.py`:`load_json_cached(path)` + `clear_json_cache()`。
   - 缓存键 = 绝对路径,mtime 相等即命中(原子替换写方都会 bump mtime)。
   - 缺失文件/坏 JSON 与裸读行为一致(raise),异常路径不缓存。
   - 纯进程内,无跨进程共享。
2. 接入两个高频调用点(证明模式 + 实际收益):
   - `signals._universe_details`(每盘中 slot 被 provisional_setups / early_trend / opportunity_radar 调 3 次,每次全量解析 portfolio.json 93KB)
   - `intraday_delta._load`(每 slot 读 lev_regime.json / risk.json)
3. `tests/test_safe_io_json_cache.py` 4 项:同 mtime 不重解析(monkeypatch json.load 计数)/ mtime 变化重读 / clear 强制重读 / 缺失文件 raise。

## 验收

- [x] 同 mtime 第二次读不解析(测试断言 parse 计数 = 1)
- [x] mtime 变化立即读到新值(测试)
- [x] 异常路径(缺失文件)行为与裸读一致(测试)
- [x] 既有 signals / intraday_delta 行为不变(回归 55 passed)

## 不做

- 不接 dashboard/artifacts 的 34 处(收益最大但改动面大,留后续;conftest 产物守卫已兜底)
- 不引入跨进程缓存/常驻服务

## 说明

dashboard/artifacts 的接入已写进 #557 issue 后续步骤;本次先把基础设施 + 两个高频点落地,验证模式后其余按需接入。