### PR TITLE
feat: SEO/GEO 资产 —— llms.txt + FAQ 页 + LLM 爬虫放行

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -1,0 +1,105 @@
+---
+layout: default
+title: clawock FAQ
+description: Answers to the questions new users ask about clawock — an open-source, agent-native investment decision workflow with a public self-graded scorecard on a real HK + US account.
+---
+
+# FAQ
+
+## What is clawock?
+
+clawock is an open-source, **agent-native investment decision-workflow engine**
+with a verifiable harness. It is not a trading bot and not a copy-trading
+service: an external agent runtime (Claude Code, Codex, OpenClaw, DeepSeek
+Harness, or your own) owns the model and tools, while clawock owns the decision
+contract — certified evidence, a mandatory opposing case, deterministic money
+and FX reconciliation, and a public scorecard.
+
+It is also the first continuously running proof: a real Hong Kong + US
+brokerage account has run it for 90+ days, with every judgment settled by
+Python and published — losses included.
+
+## Is this an AI trading bot that makes money?
+
+No, and it says so itself. The live account return is **−15.95%** and active
+recommendations have **not beaten buy-and-hold**. Directional hit rates (53%
+active, n=73) carry 95% confidence intervals that straddle 50% — statistically
+not an edge yet. The project's claim is not "makes money", it is "**can't be
+fooled**": the model proposes, Python settles, and the model can never grade
+itself. Use it as a measurable, auditable baseline — not as a get-rich signal.
+
+## Why would I install it if it doesn't beat buy-and-hold?
+
+Three things it delivers today:
+
+1. A daily 08:00 brief with a chain of evidence, delivered to WeChat;
+2. An audit framework where every decision can be recomputed and checked
+   (`clawock audit-resettle`, `clawock reconcile`, `clawock integrity`);
+3. An honest baseline — any future strategy or agent can be compared against
+   90+ days of live, publicly settled records.
+
+It does not promise "earn"; it promises "every call has a paper trail".
+
+## How is the scorecard different from other AI trading projects?
+
+- **The model can't grade itself.** LLMs propose trades; Python settles them
+  from canonical vendor bars on each market's own calendar.
+- **No cherry-picking.** The raw ledger (`memory/decisions.jsonl`, 640+
+  records) is public; "if a number doesn't reproduce, we lose."
+- **One thesis counts once.** Repeated restatements collapse into one episode,
+  so holding a position for five mornings doesn't manufacture five samples.
+- **Human-in-the-loop is disclosed.** Follow-through decisions belong to the
+  account owner; every followed/not-followed entry carries a source. Until the
+  follow-rule set is published for audit, account return is labeled
+  human-in-the-loop performance, not model performance.
+
+## Which agent frameworks does it work with?
+
+Any harness that can read a file and write `decision.json`: Claude Code,
+Codex, OpenClaw, DeepSeek Harness, or a plain CLI. The contract is files and a
+CLI — swap harnesses and the workflow does not move. See
+[examples/harness-agnostic](https://github.com/KCNyu/clawock/tree/master/examples/harness-agnostic)
+for the same run driven from five harnesses.
+
+## Does it work with DeepSeek Harness?
+
+Yes. A skill package is published on npm as `clawock-dsh`; install it with
+`dsh plugin --profile web add clawock-dsh`. The agent then follows the same
+prepare → `decision.json` → publish loop, with the model call staying entirely
+in your runtime.
+
+## How do I install it?
+
+```bash
+python -m pip install clawock
+clawock workflow install investment-decision --workspace ./my-decision
+clawock init ./my-decision --workflow investment-decision
+clawock run prepare --workspace ./my-decision
+```
+
+Or hand the repository URL to your agent and let it run
+`bash examples/minimal-run/run.sh` first — a no-model, no-network proof of one
+complete decision loop. Model costs ride on your own API key; clawock itself is
+free and open source (MIT).
+
+## Where does the data come from?
+
+41 fetch and compute modules across 8 layers: Tencent, Yahoo, Eastmoney,
+Polygon, SEC EDGAR, HKEX, Finnhub, Frankfurter, Reddit, Google News and more —
+bilingual HK + US coverage, with multi-source fallback on critical paths. The
+influencer radar scans Trump (Truth Social primary feed) and Musk (news
+aggregation) every 48 hours, links statements to your holdings, and records
+misses as well as hits.
+
+## Why is it open source? What's the catch?
+
+The system was already running — this is the author's own real account, with
+the author's own money. Open-sourcing is how the ledger and the workflow are
+kept honest. There is no paid tier, no advisory group, no copy-trading
+subscription; whether you install it has no effect on the author's income.
+
+## Is this investment advice?
+
+No. The repository contains real trading positions and is a personal record
+and portable workspace — not investment advice, not a recommendation, and not
+a copy-trading system. Every number may be stale by the time you read it.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,59 @@
+# clawock
+
+> AI argues. Code settles. Even the losses stay on the page.
+
+clawock is an agent-native, harness-agnostic investment decision-workflow
+engine. An external agent runtime (Claude Code, Codex, OpenClaw, DeepSeek
+Harness, or your own) owns the model, conversation, memory and tools; clawock
+owns the decision contract: certified evidence, a mandatory opposing case,
+deterministic money and FX reconciliation, and a public scorecard the model can
+never grade itself.
+
+A real Hong Kong + US account has run it for 90+ days: 177 judgments settled by
+Python, live account return −15.95%, every loss on the page, every number
+reproducible from `clawock audit-resettle`.
+
+## Key pages
+
+- [GitHub repository](https://github.com/KCNyu/clawock): source, issues, PRs
+- [Live dashboard](https://kcnyu.github.io/clawock/): positions, risk, self-graded scorecard
+- [Daily briefs](https://kcnyu.github.io/clawock/briefs.html): published morning reads (bilingual)
+- [Evidence & refutation](https://kcnyu.github.io/clawock/evidence.html): what was tested and what failed
+- [FAQ](https://kcnyu.github.io/clawock/faq.html): questions new users ask
+- [简体中文 README](https://github.com/KCNyu/clawock/blob/master/README.zh.md)
+
+## Install
+
+```bash
+python -m pip install clawock
+clawock workflow install investment-decision --workspace ./my-decision
+clawock init ./my-decision --workflow investment-decision
+clawock run prepare --workspace ./my-decision
+```
+
+Or throw the repository URL at any agent and let it follow the three-step
+skill flow (prepare → write `decision.json` → publish). A no-model end-to-end
+proof runs with `bash examples/minimal-run/run.sh`.
+
+## For DeepSeek Harness users
+
+An official-style skill package is available: `dsh plugin --profile web add clawock-dsh`
+(published to npm as `clawock-dsh`). The same decision contract works from a
+pure CLI, an OpenClaw skill, a Claude Code instruction, a Codex AGENTS.md, or a
+DSH agent — see [examples/harness-agnostic](https://github.com/KCNyu/clawock/tree/master/examples/harness-agnostic).
+
+## What makes it different
+
+- The model can never grade itself: LLMs propose, Python settles.
+- One thesis counts once; repeated restatements collapse into one episode.
+- Factors need out-of-sample validation before they influence decisions.
+- The ledger must reconcile before anything is published.
+- Every number on the README reproduces from `clawock audit-resettle` — if it
+  doesn't match, the project loses.
+
+## Honesty policy
+
+The live scorecard keeps every eligible result, losses included, including the
+fact that active recommendations have not beaten buy-and-hold. This repository
+is a personal record and portable workspace — not investment advice, not a
+copy-trading service.

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -2,3 +2,11 @@ User-agent: *
 Allow: /
 
 Sitemap: https://kcnyu.github.io/clawock/sitemap.xml
+
+# LLM crawlers
+User-agent: GPTBot
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: PerplexityBot
+Allow: /


### PR DESCRIPTION
fixes #576。\n\n- site/llms.txt:LLM 爬虫标准入口(llmstxt.org 规范),让生成式引擎结构化理解 clawock(定位/安装/DSH 插件/差异化/诚实政策)\n- site/faq.md:FAQ 页打真实查询词(open source AI trading agent / AI investment decision framework / DeepSeek Harness / 为什么开源等),jekyll-seo-tag 自动出 title/description/canonical\n- site/robots.txt:放行 GPTBot/ClaudeBot/PerplexityBot\n\n品牌词 clawock 目前精确搜索零结果;llms.txt+FAQ 是 LLM 检索的基础设施,配合后续外链/发帖补语料。