### PR TITLE
memory: 撤回 WhaleHub 提交(非官方),记录官方渠道口径

### DIFF
--- a/memory/2026-08-15.md
+++ b/memory/2026-08-15.md
@@ -53,9 +53,10 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 | #577 | SEO/GEO:site/llms.txt + site/faq.md + robots 放行 GPTBot/ClaudeBot/PerplexityBot | #576(close) |
 | #578 | 推广文案 ops/growth/posts/README.md(X/知乎/小红书) | — |
 
-### 外部提交
-- **WhaleHub**(vvlife/whalehub-dsh)**PR #9**:registry/plugins.json 加 clawock-dsh 条目(npm 源,等维护者合并)
-- **YELEBAI/dsh-plugin-marketplace**:自动扫描 `topic:dsh-plugin`(已加)+ npm 源自动核验——**npm publish 成功后自动收录,无需手动提交**
+### 外部渠道(官方口径)
+- **WhaleHub(vvlife/whalehub-dsh)**:第三方社区市场,**非官方——已撤回 PR #9 并清理 fork**。原则:只走官方渠道(DeepSeek Harness 官方/npm),不主动登记第三方市场
+- **YELEBAI/dsh-plugin-marketplace**:同样是第三方,但**无需手动提交**(自动扫描 `topic:dsh-plugin` + npm 核验),topic 已加属 GitHub 官方功能,保留无害
+- **npm registry**:官方分发渠道,唯一待办(kcn 凭据)
 
 ### ⚠️ 仓库规则(重要)
 GitHub 仓库保护规则:master **必须走 PR**(Changes must be made through a pull request + 6 required checks)。任何直推(含 memory/运行时数据)都被拒。以后所有提交:分支 → PR → CI 绿 → squash merge。


### PR DESCRIPTION
WhaleHub 为第三方社区市场,按 kcn 指示撤回 PR #9 并清理 fork;记录原则:只走官方渠道(npm/官方文档),YELEBAI 为自动扫描无需手动提交故保留。