### PR TITLE
ci: npm publish workflow(clawock-dsh)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+name: npm-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.0). Leave empty to use dsh-plugin/package.json."
+        required: false
+
+permissions:
+  id-token: write   # OIDC: npm trusted publishing (no token needed when configured)
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Bump version (optional)
+        if: ${{ github.event.inputs.version != '' }}
+        working-directory: dsh-plugin
+        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+
+      - name: Verify package contents
+        working-directory: dsh-plugin
+        run: |
+          npm pack --dry-run
+          test -f package.json
+          test -f skills/investment-decision/SKILL.md
+
+      - name: Publish to npm
+        working-directory: dsh-plugin
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
手动触发(workflow_dispatch)发布 dsh-plugin 到 npm。\n\n- 优先 OIDC trusted publishing(--provenance,需 npmjs 侧绑定 KCNyu/clawock 仓库)\n- 若配置了 NPM_TOKEN secret 则自动使用\n- 发布前 npm pack 验证包内容\n\n触发:Actions → npm-publish → Run workflow。首次需在 npmjs.com 配置 trusted publishing 或添加 NPM_TOKEN secret(二选一)。