### PR TITLE
memory: 补充 workflow 合并(#581/#582)与 npm publish 触发路径

### DIFF
--- a/memory/2026-08-15.md
+++ b/memory/2026-08-15.md
@@ -52,6 +52,8 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 | #575 | memory 本文件(仓库规则要求 master 走 PR) | — |
 | #577 | SEO/GEO:site/llms.txt + site/faq.md + robots 放行 GPTBot/ClaudeBot/PerplexityBot | #576(close) |
 | #578 | 推广文案 ops/growth/posts/README.md(X/知乎/小红书) | — |
+| #581 | npm-publish workflow(clawock-dsh,dispatch+provenance) | — |
+| #582 | README 刷新合并为一个 workflow(screenshot-refresh 扩展:截图+metrics 单 commit 直推,删 readme-metrics.yml) | — |
 
 ### 外部渠道(官方口径)
 - **WhaleHub(vvlife/whalehub-dsh)**:第三方社区市场,**非官方——已撤回 PR #9 并清理 fork**。原则:只走官方渠道(DeepSeek Harness 官方/npm),不主动登记第三方市场
@@ -62,7 +64,8 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 GitHub 仓库保护规则:master **必须走 PR**(Changes must be made through a pull request + 6 required checks)。任何直推(含 memory/运行时数据)都被拒。以后所有提交:分支 → PR → CI 绿 → squash merge。
 
 ### 遗留(未完成)
-1. **npm publish clawock-dsh**(唯一阻塞:无 npm 凭据;kcn 执行 `cd dsh-plugin && npm publish` 即触发 YELEBAI 自动收录 + README 安装命令生效)
+1. **npm publish clawock-dsh**:workflow #581 已就绪(Actions → npm-publish → Run workflow)。两条路径:①npmjs.com 配置 trusted publishing 绑定 KCNyu/clawock(推荐,OIDC 无需 token);②或添加 NPM_TOKEN secret。触发后 YELEBAI 自动收录 + README 安装命令生效
+2. 外部仓库提交原则:**必须经 kcn 同意**(WhaleHub PR #9 已撤回,教训已记)
 2. 推广发布(X/知乎/小红书文案已就绪,需 kcn 账号执行)
 3. 每日简报标题关键词化(属 runtime 生成内容)
 4. dashboard.gif 压缩(7.6MB)


### PR DESCRIPTION
补充:README 刷新合并单 workflow(#582)、npm-publish workflow(#581)及触发方式(trusted publishing 或 NPM_TOKEN)、外部提交须经同意原则。