### PR TITLE
memory: clawock-dsh npm 发布完成

### DIFF
--- a/memory/2026-08-15.md
+++ b/memory/2026-08-15.md
@@ -70,3 +70,10 @@ GitHub 仓库保护规则:master **必须走 PR**(Changes must be made through a
 3. 每日简报标题关键词化(属 runtime 生成内容)
 4. dashboard.gif 压缩(7.6MB)
 5. Discussions 未开
+
+## npm 发布完成 + release 联动(kcn 提供 token)
+- **clawock-dsh@0.1.0 已发布 npm**(2026-08-15)。回写:tag `dsh-plugin-v0.1.0` + GitHub Release(避免 v* 格式 tag,防止触发 release.yml PyPI 流程)
+- NPM_TOKEN 已入 GitHub secrets;release.yml 新增 npm job(v* tag 发版时 clawock-dsh 版本同步主版本自动发布,#586)
+- README(zh/en)已去"发布后"措辞,加 DSH + npm badge(#586)
+- 本地 token 配置:.clawhub/npmcfg/.npmrc(gitignored;/root 只读,用 NPM_CONFIG_USERCONFIG 指向);发布命令已验证
+- YELEBAI 市场自动收录中(topic: dsh-plugin)


### PR DESCRIPTION
clawock-dsh@0.1.0 已发布 npm(2026-08-15),tag dsh-plugin-v0.1.0 + GitHub Release 回写;token 配置存放位置与发布命令记录。