### PR TITLE
feat: release 联动 npm + README badge 更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,33 @@ jobs:
         with:
           repository-url: ${{ inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
 
+  npm:
+    # The DSH skill package rides the same version train as the Python package:
+    # a v* tag publishes clawock to PyPI and clawock-dsh to npm together.
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') && inputs.repository != 'testpypi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+
+      - name: Sync dsh-plugin version to the release version
+        working-directory: dsh-plugin
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          npm version "$version" --no-git-tag-version
+
+      - name: Publish clawock-dsh to npm
+        working-directory: dsh-plugin
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     # A GitHub Release is a public claim that the version exists. Create it only
     # for a real version tag, and only after PyPI accepted that exact artifact.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 [![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](https://github.com/KCNyu/clawock/blob/master/LICENSE)
+[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-ready-8257D0?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTggMkM0LjcgMiAyIDQuNyAyIDhzMi43IDYgNiA2IDYtMi43IDYtNi0yLjctNi02LTZ6bTAgMTBhNCA0IDAgMSAxIDAtOCA0IDQgMCAwIDEgMCA4eiIvPjwvc3ZnPg==)](https://github.com/deepseek-ai/deepseek-harness)
+[![npm](https://img.shields.io/npm/v/clawock-dsh?style=flat-square&labelColor=252b35&color=cb0000)](https://www.npmjs.com/package/clawock-dsh)
 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**Evidence**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**简体中文**](https://github.com/KCNyu/clawock/blob/master/README.zh.md)
 
@@ -253,7 +255,7 @@ correlated generation receipt. The packaged example can smoke the lifecycle
 without a model (`bash examples/minimal-run/run.sh`), and
 [`examples/harness-agnostic/`](https://github.com/KCNyu/clawock/blob/master/examples/harness-agnostic/README.md) shows the
 same run driven from a pure CLI, an OpenClaw skill, a Claude Code instruction, a Codex AGENTS.md,
-and a DeepSeek Harness agent — the harness never touches the contract.
+and a DeepSeek Harness agent — the harness never touches the contract. DSH users have a ready skill package on npm: `dsh plugin --profile web add clawock-dsh`.
 
 For the KCNyu compatibility surface, `clawock doctor`, `clawock context audit`,
 and `CLAWOCK_WORKSPACE` still inspect or point at an operational book. They name

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,6 +14,7 @@
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 [![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-ready-8257D0?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTggMkM0LjcgMiAyIDQuNyAyIDhzMi43IDYgNiA2IDYtMi43IDYtNi0yLjctNi02LTZ6bTAgMTBhNCA0IDAgMSAxIDAtOCA0IDQgMCAwIDEgMCA4eiIvPjwvc3ZnPg==)](https://github.com/deepseek-ai/deepseek-harness)
+[![npm](https://img.shields.io/npm/v/clawock-dsh?style=flat-square&labelColor=252b35&color=cb0000)](https://www.npmjs.com/package/clawock-dsh)
 
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**证据与反证**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**English**](README.md)
 
@@ -222,7 +223,7 @@ initialized clawock workspace: .../book
 isolated run published 9c07e83a19b046b089f443829eb9a06e
 ```
 
-跑完你就拿到了第一张被 Python 校验过的决策回执。换 harness?[`examples/harness-agnostic`](examples/harness-agnostic/README.md) 五种跑法同一条契约;DSH 用户还有现成 skill 包(发布后 `dsh plugin --profile web add clawock-dsh`)。
+跑完你就拿到了第一张被 Python 校验过的决策回执。换 harness?[`examples/harness-agnostic`](examples/harness-agnostic/README.md) 五种跑法同一条契约;DSH 用户还有现成 skill 包(`dsh plugin --profile web add clawock-dsh`,已发布 npm)。
 
 **装完你得到三件事:** ① 每天 08:00 微信一份带证据链的深度简报,盘中每 30 分钟轻量盯盘(可关);② 一套所有决策可复算、可查账的审计框架;③ 一个诚实的基线——以后任何策略、任何 Agent,都能拿它跟 90 天实盘记录对比。它现在不能承诺「赚」,能承诺的是「每一笔都有据可查」。模型费用走你自己的 API key,clawock 本身免费开源。
 


### PR DESCRIPTION
- release.yml 新增 npm job:v* tag 发版时,clawock-dsh 版本同步主版本并发布 npm(用 NPM_TOKEN secret,已配置)\n- README(zh/en):去掉'发布后'措辞(clawock-dsh 已发布),新增 DeepSeek Harness + npm 版本 badge\n- en 补 DSH 安装句:dsh plugin --profile web add clawock-dsh\n- npm-publish.yml(手动)保留用于单独补发