### PR TITLE
release: v0.1.3(harness-agnostic 契约 + clawock-dsh npm 包)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The newest heading here has to match the version in `pyproject.toml` — CI fails
 otherwise, so a release cannot ship an entry that was never written.
 
+## [0.1.3] — 2026-08-15
+
+### Added
+
+- **Harness-agnostic decision contract.** The workflow is files + CLI, so the
+  same decision run works from a pure CLI, an OpenClaw skill, a Claude Code
+  instruction, a Codex `AGENTS.md`, or a DeepSeek Harness agent — see
+  `examples/harness-agnostic/` (each runnable, executed by `release.yml`).
+- **`clawock-dsh` skill package on npm.** DSH users install one command:
+  `dsh plugin --profile web add clawock-dsh`. A pure `dsh.skills` package (no
+  Node code) that walks the agent through prepare → `decision.json` → publish.
+- **README rewritten around the live record.** First-line hook (90 days live,
+  −15.95%, every loss on the page), four-line scorecard reconciliation
+  (ledger / directional hit / shadow portfolio / real account), reproducible
+  auditing (`clawock audit-resettle`), and the influencer radar (Trump /
+  Musk) now documented in both languages. Live numbers are maintained by
+  `ops/growth/refresh_readme_metrics.py` placeholders, refreshed weekly by CI.
+- `ops/publish/publish_dsh_plugin.sh` — single entry point for publishing the
+  npm side of a release, shared by `release.yml` and manual bumps.
+
+### Changed
+
+- README.zh.md and README.md now share a locked 12-section structure (CI
+  parity tests); the information-layer tables are checked against
+  `config/information-layers.json` and the per-run block counts against the
+  preflights themselves.
+
 ## [Unreleased]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 [![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](https://github.com/KCNyu/clawock/blob/master/LICENSE)
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-ready-8257D0?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTggMkM0LjcgMiAyIDQuNyAyIDhzMi43IDYgNiA2IDYtMi43IDYtNi0yLjctNi02LTZ6bTAgMTBhNCA0IDAgMSAxIDAtOCA0IDQgMCAwIDEgMCA4eiIvPjwvc3ZnPg==)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm](https://img.shields.io/npm/v/clawock-dsh?style=flat-square&labelColor=252b35&color=cb0000)](https://www.npmjs.com/package/clawock-dsh)
 
 [**Live dashboard**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**Daily briefs**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**Evidence**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**简体中文**](https://github.com/KCNyu/clawock/blob/master/README.zh.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,8 +13,6 @@
 [![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek%20Harness-ready-8257D0?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTggMkM0LjcgMiAyIDQuNyAyIDhzMi43IDYgNiA2IDYtMi43IDYtNi0yLjctNi02LTZ6bTAgMTBhNCA0IDAgMSAxIDAtOCA0IDQgMCAwIDEgMCA4eiIvPjwvc3ZnPg==)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm](https://img.shields.io/npm/v/clawock-dsh?style=flat-square&labelColor=252b35&color=cb0000)](https://www.npmjs.com/package/clawock-dsh)
 
 [**实时仪表盘**](https://kcnyu.github.io/clawock/) &nbsp;·&nbsp; [**每日简报**](https://kcnyu.github.io/clawock/briefs.html) &nbsp;·&nbsp; [**证据与反证**](https://kcnyu.github.io/clawock/evidence.html) &nbsp;·&nbsp; [**English**](README.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.2"
+version = "0.1.3"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
版本 0.1.2 → 0.1.3。合并后打 tag v0.1.3 触发 release.yml:PyPI + npm(clawock-dsh@0.1.3)+ 一个 GitHub Release。

0.1.3 内容:
- harness-agnostic 决策契约:同一套 prepare → decision.json → publish 流程,纯 CLI / OpenClaw skill / Claude Code 指令 / Codex AGENTS.md / DeepSeek Harness 五种 harness 通用(examples/harness-agnostic,release.yml 逐一验证)
- clawock-dsh npm 包:DSH 用户一条命令安装(dsh plugin --profile web add clawock-dsh)
- README 重写:实盘记录为主线(90 天 / −15.95% / 可复算审计),数字由 CI 每周自动刷新
- badge 区整理:移除自制 DeepSeek Harness ready 与 npm 子包 badge,保留核心状态 badge

详见 CHANGELOG。