### PR TITLE
test: 恒真断言修复 + delta gate 封闭化 + safe_io 缓存边界(#607 #611 #623)

### DIFF
--- a/src/clawock/safe_io.py
+++ b/src/clawock/safe_io.py
@@ -21,6 +21,7 @@ import math
 import os
 import sys
 import tempfile
+from typing import Any
 
 
 @contextlib.contextmanager
@@ -172,6 +173,54 @@ def safe_write_text(path: str, text: str) -> None:
         raise
 
 
+# Process-local JSON read cache, keyed by file mtime (#557), bounded LRU.
+# Same mtime + an atomic writer (every `safe_write_json`/`safe_write_text`
+# caller) ⇒ same bytes, so a cached hit is current for those producers: the
+# atomic replace bumps mtime and the next read re-parses. The guarantee does
+# NOT extend to in-place writers that restore mtime or coarse-mtime
+# filesystems (FAT / NFS / SMB) — see load_json_cached's docstring.
+_JSON_READ_CACHE: dict[str, tuple[float, Any]] = {}
+_MAX_JSON_CACHE_ENTRIES = 256
+
+
+def load_json_cached(path: str | os.PathLike) -> Any:
+    """Read + parse JSON once per mtime within this process.
+
+    Portfolio.json alone is read by dozens of modules; a single preflight
+    re-parses it several times. Callers that re-read the same file in one
+    process should route through here. Raises FileNotFoundError /
+    JSONDecodeError exactly like a plain read — only the parse count changes.
+
+    Contract boundaries (do not extend them silently):
+    - READ-ONLY return: the same mutable object is handed to every caller for
+      the same mtime, so an in-place mutation would poison later reads. Mutate
+      a copy if you must write.
+    - Freshness is guaranteed for atomic writers only. A producer that writes
+      in place without bumping mtime (or restores it), or a filesystem with
+      coarse mtime granularity, can hand back stale bytes — the price of the
+      parse-count win.
+    - Bounded: the oldest entry is evicted past _MAX_JSON_CACHE_ENTRIES;
+      eviction costs one re-parse, nothing else.
+    """
+    path = os.path.abspath(os.fspath(path))
+    mtime = os.path.getmtime(path)
+    cached = _JSON_READ_CACHE.get(path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+    with open(path, encoding='utf-8') as f:
+        value = json.load(f)
+    _JSON_READ_CACHE[path] = (mtime, value)
+    if len(_JSON_READ_CACHE) > _MAX_JSON_CACHE_ENTRIES:
+        # dict preserves insertion order: the first key is the oldest entry.
+        _JSON_READ_CACHE.pop(next(iter(_JSON_READ_CACHE)))
+    return value
+
+
+def clear_json_cache() -> None:
+    """Drop every cached entry (tests; a long-lived process after a mass move)."""
+    _JSON_READ_CACHE.clear()
+
+
 if __name__ == '__main__':
     # Self-test
     import tempfile as _tf
@@ -202,34 +251,3 @@ if __name__ == '__main__':
         final = json.load(open(ctr))
         assert len(final) == 20, f'lost updates: only {len(final)}/20 keys survived'
         print('mutate_json concurrency (20 writers, no lost updates): OK')
-
-
-# Process-local JSON read cache, keyed by file mtime (#557). Same mtime ⇒ the
-# same bytes, so a cached hit is always current: a producer that atomically
-# replaces a file (every `safe_write_json` caller) bumps mtime and the next
-# read re-parses. No TTL, no staleness window.
-_JSON_READ_CACHE: dict[str, tuple[float, object]] = {}
-
-
-def load_json_cached(path: str | os.PathLike) -> object:
-    """Read + parse JSON once per mtime within this process.
-
-    Portfolio.json alone is read by 39 modules; a single preflight re-parses it
-    several times. Callers that re-read the same file in one process should
-    route through here. Raises FileNotFoundError / JSONDecodeError exactly like
-    a plain read — only the parse count changes.
-    """
-    path = os.path.abspath(os.fspath(path))
-    mtime = os.path.getmtime(path)
-    cached = _JSON_READ_CACHE.get(path)
-    if cached is not None and cached[0] == mtime:
-        return cached[1]
-    with open(path, encoding='utf-8') as f:
-        value = json.load(f)
-    _JSON_READ_CACHE[path] = (mtime, value)
-    return value
-
-
-def clear_json_cache() -> None:
-    """Drop every cached entry (tests; a long-lived process after a mass move)."""
-    _JSON_READ_CACHE.clear()

--- a/tests/test_brief_watchdog_second_rerun.py
+++ b/tests/test_brief_watchdog_second_rerun.py
@@ -63,7 +63,7 @@ def test_miss_detector_stops_after_two_reruns(monkeypatch, tmp_path):
 
     assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
 
-    assert spy.get("reruns") or [] == []
+    assert spy.get("reruns") is None
     assert watchdog._rerun_count(TODAY) == 2
 
 
@@ -73,4 +73,4 @@ def test_miss_detector_without_schedule_still_alerts(monkeypatch, tmp_path):
 
     assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
 
-    assert spy.get("reruns") or [] == []
+    assert spy.get("reruns") is None

--- a/tests/test_intraday_delta_gate.py
+++ b/tests/test_intraday_delta_gate.py
@@ -216,6 +216,15 @@ def _wire_preflight(monkeypatch, tmp_path):
     monkeypatch.setattr(preflight, "collect_provisional_setups", lambda _m: setups)
     monkeypatch.setattr(
         preflight, "collect_early_trend_candidates", lambda _m: {"rows": []})
+    # #611: the radar and reinvest collectors run the real universe + Tencent
+    # fetches when left unpatched, so the suite depended on the live market
+    # (radar empty today, full_delta tomorrow) and the network. Both are pure
+    # producers here: empty radar rows, identity pass-through for the plan ctx.
+    monkeypatch.setattr(
+        preflight, "collect_opportunity_radar", lambda _m: {"rows": []})
+    monkeypatch.setattr(
+        preflight, "attach_reinvest_candidates",
+        lambda ctx, radar, signals_detail=None: ctx)
     monkeypatch.setattr(preflight, "quote_coverage", lambda *_a, **_k: {
         "refreshed": 1, "active": 1, "unrefreshed": [],
     })

--- a/tests/test_safe_io_json_cache.py
+++ b/tests/test_safe_io_json_cache.py
@@ -1,13 +1,20 @@
 """Process-local JSON read cache keyed by file mtime (#557).
 
-Same mtime ⇒ same bytes, so a cached hit is always current and a producer that
-atomically replaces the file bumps mtime and the next read re-parses. The
-contract: parse count drops, freshness never does.
+Same mtime + an atomic writer ⇒ same bytes, so a cached hit is current for
+producers that replace the file (bumping mtime). The contract: parse count
+drops, freshness never does — for atomic writers. In-place writers that
+restore mtime and coarse-mtime filesystems are out of contract (documented
+failure mode, pinned by a test below so it cannot silently become a promise).
+
+The cache is bounded (LRU-style eviction past _MAX_JSON_CACHE_ENTRIES) and the
+returned object is shared across callers — read-only contract.
 """
 import json
 import os
 
-from clawock.safe_io import load_json_cached, clear_json_cache
+from clawock.safe_io import (
+    load_json_cached, clear_json_cache, _MAX_JSON_CACHE_ENTRIES,
+)
 
 
 def _write(path, payload):
@@ -66,3 +73,83 @@ def test_missing_file_raises_like_a_plain_read(tmp_path):
         pass
     else:
         raise AssertionError("expected FileNotFoundError")
+
+
+def test_cache_is_bounded_and_evicts_oldest(monkeypatch, tmp_path):
+    """#623: the cache must not grow without bound; eviction only costs a
+    re-parse. A pure-LRU reading of the dict: the first inserted entry is the
+    first evicted once the cap is exceeded."""
+    files = []
+    for i in range(_MAX_JSON_CACHE_ENTRIES + 10):
+        p = tmp_path / f"f{i}.json"
+        _write(p, {"i": i})
+        files.append(p)
+    calls = {"n": 0}
+    real_load = json.load
+
+    def spy(f):
+        calls["n"] += 1
+        return real_load(f)
+
+    monkeypatch.setattr("clawock.safe_io.json.load", spy)
+
+    for p in files:
+        load_json_cached(p)
+    assert calls["n"] == len(files)
+
+    # The ten oldest entries were evicted: re-reading them parses again.
+    for i in range(10):
+        load_json_cached(files[i])
+    assert calls["n"] == len(files) + 10
+
+    # A recently inserted entry is still cached.
+    load_json_cached(files[-1])
+    assert calls["n"] == len(files) + 10
+
+
+def test_json_decode_error_is_not_cached(monkeypatch, tmp_path):
+    """A failed parse must not poison the cache: fix the file (mtime bumps),
+    and the next read succeeds."""
+    p = tmp_path / "broken.json"
+    p.write_text("{not json")
+    try:
+        load_json_cached(p)
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("expected JSONDecodeError")
+
+    _write(p, {"ok": 1})
+    assert load_json_cached(p) == {"ok": 1}
+
+
+def test_returned_object_is_shared_read_only_contract(monkeypatch, tmp_path):
+    """#623: the same mutable object is returned on cache hits — callers must
+    treat it as read-only. Pinned so a future deep-copy refactor is deliberate
+    (it would also give up most of the parse-count win)."""
+    p = tmp_path / "shared.json"
+    _write(p, {"a": [1]})
+    first = load_json_cached(p)
+    second = load_json_cached(p)
+    assert first is second
+
+
+def test_same_mtime_different_bytes_returns_stale(monkeypatch, tmp_path):
+    """Documented failure mode, pinned as behavior: an in-place writer that
+    restores the mtime hands the cache an unchanged key, so the stale object is
+    returned. This is why the docstring limits the freshness promise to atomic
+    writers — the test exists to keep that limitation visible."""
+    p = tmp_path / "inplace.json"
+    _write(p, {"v": 1})
+    os.utime(p, (1_000_000_000, 1_000_000_000))
+    assert load_json_cached(p) == {"v": 1}
+
+    # In-place rewrite that restores the exact same mtime.
+    with open(p, "w") as f:
+        f.write('{"v": 2}')
+    os.utime(p, (1_000_000_000, 1_000_000_000))
+
+    assert load_json_cached(p) == {"v": 1}, (
+        "in-place writer with restored mtime is out of contract; a cached hit "
+        "may be stale — switch the producer to safe_write_json to opt in to "
+        "freshness")


### PR DESCRIPTION
## 测试修复组（#607 #611 #623）

| Issue | 改动 |
|---|---|
| #607(1) | `test_brief_watchdog_second_rerun.py` 两处恒真断言 `assert spy.get("reruns") or [] == []`（优先级 bug，恒为 True）→ 与同簇旧文件一致的 `assert spy.get("reruns") is None` |
| #611 | `test_intraday_delta_gate.py` 的 `_wire_preflight` 补 patch `collect_opportunity_radar`（空 rows）与 `attach_reinvest_candidates`（恒等）——此前真跑 radar 会读真实持仓 + 打 Tencent 真 HTTP，13 个测试 8.5s、结果随行情漂移（radar 某天非空即翻 full_delta 失败）。现在完全封闭 |
| #623 | `safe_io.load_json_cached`：docstring 收回「Same mtime ⇒ same bytes」过度承诺（限定原子写者，列出失效条件：就地写恢复 mtime / FAT·NFS·SMB 粗粒度 mtime）；返回对象明确**只读契约**（共享同一对象）；缓存**有界**（>256 淘汰最旧，dict 插入序即 LRU）；补 4 个测试：淘汰边界、JSONDecodeError 不污染缓存、共享对象身份钉死、同 mtime 不同内容失效模式钉死。顺带 #620(6) 的 safe_io 部分：函数移到 `__main__` 之前、注解 `-> Any` |

## 验证

- 32 passed（safe_io 缓存 9 项 + delta gate 13 项 + watchdog 两文件）
- delta gate 测试不再依赖网络/行情
