### PR TITLE
fix: 短历史闸按上市日期收紧 + lane fail-soft 粒度 + 单槽 bars 缓存(#608 #612 #613 #625)

### DIFF
--- a/config/factor-universe.json
+++ b/config/factor-universe.json
@@ -31,6 +31,7 @@
   "symbols": [
     {"ticker": "00100", "region": "hk", "sector": "hk_ai_models"},
     {"ticker": "02513", "region": "hk", "sector": "hk_ai_models"},
+    {"ticker": "03317", "region": "hk", "sector": "hk_ai_models"},
     {"ticker": "01384", "region": "hk", "sector": "hk_ai_models"},
     {"ticker": "09678", "region": "hk", "sector": "hk_ai_models"},
     {"ticker": "06682", "region": "hk", "sector": "hk_ai_models"},

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -338,11 +338,43 @@ def compute_short_history_signals(bars):
     return sig
 
 
-def _universe_details():
+# A name with ≥30 sessions since listing can reach the mature 30-bar gate; the
+# short-history fallback is for names that genuinely cannot. 45 calendar days
+# ≈ 30 trading sessions, with slack for holidays.
+SHORT_HISTORY_MAX_AGE_DAYS = 45
+
+
+def is_short_history_candidate(detail, run_date):
+    """Genuinely-new-listing gate for the 20–29-bar fallback (#608).
+
+    The short-history view must not rescue a mature name whose feed returned
+    only 20–29 bars (a partial feed): that would bypass the deliberate 30-bar
+    data-quality gate with half a signal set. Only names whose registry
+    `listing_date` is present and recent (≤ SHORT_HISTORY_MAX_AGE_DAYS) are
+    candidates; an absent or unparseable listing_date means "not known to be
+    new", and the strict gate stands.
+    """
+    ld = (detail or {}).get('listing_date')
+    if not ld:
+        return False
+    try:
+        listing = datetime.fromisoformat(ld).date()
+    except (ValueError, TypeError):
+        return False
+    return (run_date - listing).days <= SHORT_HISTORY_MAX_AGE_DAYS
+
+
+def universe_details(errors=None):
     """活跃持仓 → 去重后的 signal rows，保留每行覆盖的真实持仓。
 
     杠杆产品使用 registry 的 signal_symbol 折到标的/1x proxy；venue 后缀
     同样从 registry 读取，绝不再默认猜成 Nasdaq。
+
+    Per-holding tolerance (#612): one registry gap (unknown ticker, missing
+    canonical Tencent symbol) must not blank the whole universe — the bad
+    holding is skipped and reported via `errors` (when provided), mirroring
+    the per-row fail-soft doctrine of #136. Rows carry the registry
+    `listing_date` so short-history gating (#608) works for every consumer.
     """
     port = load_json_cached(PORTFOLIO)
     by_code = {}
@@ -353,25 +385,40 @@ def _universe_details():
             if h.get('shares', 0) <= 0:
                 continue
             t = h.get('ticker')
-            meta = require_instrument(t)
-            signal_symbol = meta.get('signal_symbol') or t
-            signal_meta = require_instrument(signal_symbol)
-            label = signal_symbol
-            code = signal_meta.get('tencent_symbol')
-            note = f'{t} 的标的/1x proxy' if signal_symbol != t else ''
-            if not code:
-                raise ValueError(f'{signal_symbol} has no canonical Tencent symbol')
+            try:
+                meta = require_instrument(t)
+                signal_symbol = meta.get('signal_symbol') or t
+                signal_meta = require_instrument(signal_symbol)
+                label = signal_symbol
+                code = signal_meta.get('tencent_symbol')
+                note = f'{t} 的标的/1x proxy' if signal_symbol != t else ''
+                if not code:
+                    raise ValueError(
+                        f'{signal_symbol} has no canonical Tencent symbol')
+            except Exception as exc:  # noqa: BLE001 — one bad holding must not blank the rest
+                if errors is not None:
+                    errors.append({
+                        'label': t,
+                        'error': f'{type(exc).__name__}: {exc}'[:200],
+                    })
+                continue
             row = by_code.setdefault(code, {
                 'label': label,
                 'code': code,
                 'note': note,
                 'region': signal_meta['region'],
                 'source_holdings': [],
+                'listing_date': signal_meta.get('listing_date'),
             })
             row['source_holdings'].append(t)
             if note and not row['note']:
                 row['note'] = note
     return list(by_code.values())
+
+
+def _universe_details():
+    """Deprecated alias for out-of-tree callers; use `universe_details`."""
+    return universe_details()
 
 
 def _universe():
@@ -453,9 +500,11 @@ def refresh_rows(previous, universe, *, run_date=None, previous_as_of=None,
                     and _as_date(bar.get('date')) <= expected)
             ]
         sig = compute_signals(bars) if bars else None
-        if sig is None:
-            # A short-history name cannot reach the 30-bar mature gate, but the
-            # early-trend lane needs its 20-bar-computable technical view.
+        if sig is None and is_short_history_candidate(detail, run_date):
+            # A genuinely-new name cannot reach the 30-bar mature gate, but the
+            # early-trend lane needs its 20-bar-computable technical view. The
+            # listing-date gate keeps a partial-feed mature name on the strict
+            # gate (#608).
             sig = compute_short_history_signals(bars)
         if sig is not None:
             row_as_of = _as_date(bars[-1].get('date'))
@@ -552,7 +601,9 @@ def provisional_setups(universe=None, *, region=None, fetch=None):
         label = detail.get('label')
         try:
             bars = fetcher(detail['code'], 400)
-            sig = compute_signals(bars) or compute_short_history_signals(bars)
+            sig = compute_signals(bars)
+            if sig is None and is_short_history_candidate(detail, date.today()):
+                sig = compute_short_history_signals(bars)
         except Exception as exc:  # noqa: BLE001 — one bad symbol must not blank the rest
             errors.append({'label': label, 'error': f'{type(exc).__name__}: {exc}'[:200]})
             continue

--- a/src/clawock/decision/watch_list.py
+++ b/src/clawock/decision/watch_list.py
@@ -10,6 +10,7 @@ brief preflight 每天对这些名字做一次价格面扫描:突破 / 接近突
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 
 from clawock.workspace import workspace_root
@@ -42,7 +43,6 @@ def collect() -> dict:
     pct_from_high / ret_5d / state(breakout | near_breakout | strong).
     """
     rows = []
-    short_history = getattr(quant_signals, "compute_short_history_signals", None)
     for ticker in watch_tickers():
         meta = get_instrument(ticker) or {}
         code = meta.get("tencent_symbol")
@@ -51,8 +51,11 @@ def collect() -> dict:
         try:
             bars = quant_signals.fetch_bars(code, 400)
             sig = quant_signals.compute_signals(bars)
-            if sig is None and short_history is not None:
-                sig = short_history(bars)
+            if sig is None and quant_signals.is_short_history_candidate(
+                    meta, date.today()):
+                # Only a genuinely-new name may use the 20-bar short view; a
+                # partial-feed mature name stays on the 30-bar gate (#608).
+                sig = quant_signals.compute_short_history_signals(bars)
         except Exception:  # noqa: BLE001 — one dead feed must not blank the rest
             continue
         if not sig:

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -55,6 +55,21 @@ from clawock.automation import cron_heartbeat  # noqa: E402
 from clawock.harness import intraday_delta  # noqa: E402
 
 
+# Process-local bars cache for one preflight slot (#613): the provisional,
+# early-trend and radar collectors each fetch the same code, and a 10-name
+# portfolio was paying 3x fetches per slot (~540 requests/day). Cleared at the
+# start of every main() run so a slot never reads the previous slot's bars.
+_BARS_CACHE: dict[tuple[str, int], list] = {}
+
+
+def _fetch_bars_cached(code, cnt=400):
+    """fetch_bars memoised for the lifetime of one preflight slot."""
+    key = (code, cnt)
+    if key not in _BARS_CACHE:
+        _BARS_CACHE[key] = quant_signals.fetch_bars(code, cnt)
+    return _BARS_CACHE[key]
+
+
 # `scripts/data` was deleted in #429 and the analysis moved into the package in
 # #421, which added `clawock analyze-hk` / `analyze-us` but left these two callers
 # pointing at the old path. Both preflights then failed on every run while still
@@ -170,7 +185,7 @@ def collect_provisional_setups(market):
     """
     try:
         return quant_signals.provisional_setups(
-            region='HK' if market == 'hk' else 'US')
+            region='HK' if market == 'hk' else 'US', fetch=_fetch_bars_cached)
     except Exception as exc:  # noqa: BLE001 — a quote feed must never red the cron
         return {'rows': [], 'confirmed_at_close': False,
                 'errors': [{'label': None,
@@ -246,10 +261,17 @@ EARLY_STATE_LABELS = {
 
 
 def _load_json(path):
+    """Read a JSON asset as a dict, never raising.
+
+    #612: a file that parses to a non-dict (e.g. a list) used to escape the
+    try/except below and AttributeError the whole preflight at `.get`. A
+    non-dict shape is treated as absent, matching the missing-file case.
+    """
     try:
-        return json.loads(Path(path).read_text())
+        value = json.loads(Path(path).read_text())
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
+    return value if isinstance(value, dict) else {}
 
 
 def collect_early_trend_candidates(market):
@@ -263,11 +285,14 @@ def collect_early_trend_candidates(market):
     answering returns no candidates, never a red cron.
     """
     region = 'HK' if market == 'hk' else 'US'
+    errors = []
     try:
-        universe = [d for d in quant_signals._universe_details()
+        universe = [d for d in quant_signals.universe_details(errors=errors)
                     if d.get('region') == region]
-    except Exception:  # noqa: BLE001
-        return {'rows': []}
+    except Exception as exc:  # noqa: BLE001 — last resort; universe_details is per-holding tolerant
+        return {'rows': [],
+                'errors': [{'label': None,
+                            'error': f'{type(exc).__name__}: {exc}'[:200]}]}
     peer_rows = (_load_json(WS / 'assets' / 'data' / 'peer_residual.json')
                  .get('live') or {})
     graph = _load_json(WS / 'assets' / 'data' / 'news_evidence_graph.json')
@@ -279,17 +304,17 @@ def collect_early_trend_candidates(market):
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         policy = {}
     rows = []
+    run_date = datetime.now(ZoneInfo('Asia/Hong_Kong')).date()
     for detail in universe:
         label = detail.get('label')
         try:
-            bars = quant_signals.fetch_bars(detail['code'], 400)
-            # `compute_short_history_signals` (#542) may not be present yet;
-            # degrade to the mature gate rather than hard-depending on it.
-            short_history = getattr(
-                quant_signals, 'compute_short_history_signals', None)
+            bars = _fetch_bars_cached(detail['code'], 400)
             sig = quant_signals.compute_signals(bars)
-            if sig is None and short_history is not None:
-                sig = short_history(bars)
+            if sig is None and quant_signals.is_short_history_candidate(
+                    detail, run_date):
+                # Only a genuinely-new name may use the 20-bar short view; a
+                # partial-feed mature name stays on the 30-bar gate (#608).
+                sig = quant_signals.compute_short_history_signals(bars)
         except Exception:  # noqa: BLE001
             continue
         if not sig:
@@ -345,7 +370,12 @@ def collect_early_trend_candidates(market):
             'prior_20d_high': sig.get('prior_20d_high'),
             'blockers': candidate.get('blockers') or [],
         })
-    return {'rows': rows}
+    result = {'rows': rows}
+    if errors:
+        # Data gaps must be said, not swallowed (#612): a registry gap that
+        # used to blank the whole lane now lands here for the context JSON.
+        result['errors'] = errors
+    return result
 
 
 def append_early_trend_section(block, candidates, signals_detail=None):
@@ -382,24 +412,31 @@ def collect_opportunity_radar(market):
     """机会雷达:突破/等回踩/接近突破的价格面候选观察(#551)。
 
     与 early_trend 的区别:这是纯价格面,不要求 peer/information 确认——
-    回答"机会在哪",不下单授权(候选≠下单)。数据全部来自 technical 视图,
-    零新抓取。fail-soft:任何名字取不到 bars 就跳过,不红 cron。
+    回答"机会在哪",不下单授权(候选≠下单)。数据来自 technical 视图,
+    与本槽其他 collector 共享同一趟 bars 抓取(#613,非"零抓取")。
+    fail-soft:任何名字取不到 bars 就跳过,registry 缺口进 errors,不红 cron。
     """
     region = 'HK' if market == 'hk' else 'US'
+    errors = []
     try:
-        universe = [d for d in quant_signals._universe_details()
+        universe = [d for d in quant_signals.universe_details(errors=errors)
                     if d.get('region') == region]
-    except Exception:  # noqa: BLE001
-        return {'rows': []}
-    short_history = getattr(quant_signals, 'compute_short_history_signals', None)
+    except Exception as exc:  # noqa: BLE001 — last resort; universe_details is per-holding tolerant
+        return {'rows': [],
+                'errors': [{'label': None,
+                            'error': f'{type(exc).__name__}: {exc}'[:200]}]}
     rows = []
+    run_date = datetime.now(ZoneInfo('Asia/Hong_Kong')).date()
     for detail in universe:
         label = detail.get('label')
         try:
-            bars = quant_signals.fetch_bars(detail['code'], 400)
+            bars = _fetch_bars_cached(detail['code'], 400)
             sig = quant_signals.compute_signals(bars)
-            if sig is None and short_history is not None:
-                sig = short_history(bars)
+            if sig is None and quant_signals.is_short_history_candidate(
+                    detail, run_date):
+                # Only a genuinely-new name may use the 20-bar short view; a
+                # partial-feed mature name stays on the 30-bar gate (#608).
+                sig = quant_signals.compute_short_history_signals(bars)
         except Exception:  # noqa: BLE001
             continue
         if not sig:
@@ -430,7 +467,10 @@ def collect_opportunity_radar(market):
             'zscore20': z,
         })
     rows.sort(key=lambda row: row['pct_from_high'], reverse=True)
-    return {'rows': rows}
+    result = {'rows': rows}
+    if errors:
+        result['errors'] = errors
+    return result
 
 
 def append_opportunity_radar_section(block, radar, signals_detail=None):
@@ -721,6 +761,10 @@ def main(argv=None):
     now = datetime.now(ZoneInfo('Asia/Hong_Kong'))
     stamp = now.strftime('%Y-%m-%d_%H%M')
     heartbeat = cron_heartbeat.record(args.market, 'started')
+
+    # One fetch per code per slot: the three collectors share this slot's bars
+    # through _fetch_bars_cached (#613).
+    _BARS_CACHE.clear()
 
     # Holiday/weekend gate (before fetch): closed market → no stale price write,
     # emit a market_closed sentinel (no alert), exit 0.

--- a/tests/test_factor_universe_parity.py
+++ b/tests/test_factor_universe_parity.py
@@ -1,0 +1,32 @@
+"""factor-universe.json must cover every AI-factor instrument (#625).
+
+The cross-factor ranking consumes factor-universe.json; a registered AI name
+missing from its sector group is a silent blind spot in the ranking. This
+parity test makes the two registries drift-locked: any instruments.json entry
+with factor=CHINA_AI must be a member of the hk_ai_models group.
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name):
+    return json.loads((ROOT / 'config' / name).read_text(encoding='utf-8'))
+
+
+def test_every_china_ai_instrument_is_in_hk_ai_models_group():
+    instruments = _load('instruments.json')['instruments']
+    universe = _load('factor-universe.json')
+
+    members = {s['ticker'] for s in universe['symbols']
+               if s.get('sector') == 'hk_ai_models'}
+    ai = {code for code, meta in instruments.items()
+          if meta.get('factor') == 'CHINA_AI' and meta.get('region') == 'HK'}
+
+    missing = ai - members
+    assert not missing, (
+        f'CHINA_AI 标的缺 factor-universe hk_ai_models 组: {sorted(missing)}')
+
+    # The #556 pair is registered; 03317 迅策 was the concrete gap (#625).
+    assert {'00100', '02513', '03317'} <= members

--- a/tests/test_intraday_bars_cache.py
+++ b/tests/test_intraday_bars_cache.py
@@ -1,0 +1,43 @@
+"""Per-slot bars cache (#613): the three collectors must share one fetch.
+
+Before #613 each collector fetched the same code independently (3x per slot,
+~540 requests/day for a 10-name book). The cache is scoped to one preflight
+slot: main() clears it, and distinct codes still fetch separately.
+"""
+from clawock.harness import intraday_preflight as P
+
+
+def test_fetch_bars_cached_fetches_once_per_code(monkeypatch):
+    calls = {'n': 0}
+
+    def fake_fetch(code, cnt=400):
+        calls['n'] += 1
+        return [{'date': '2026-08-14', 'close': 10, 'high': 11, 'low': 9}]
+
+    monkeypatch.setattr(P.quant_signals, 'fetch_bars', fake_fetch)
+    P._BARS_CACHE.clear()
+
+    first = P._fetch_bars_cached('x', 400)
+    second = P._fetch_bars_cached('x', 400)
+    assert first is second
+    assert calls['n'] == 1
+
+    P._fetch_bars_cached('y', 400)
+    assert calls['n'] == 2  # a distinct code fetches its own bars
+
+
+def test_cache_scope_is_one_slot(monkeypatch):
+    """Clearing the cache (what main() does at slot start) forces a refetch."""
+    calls = {'n': 0}
+
+    def fake_fetch(code, cnt=400):
+        calls['n'] += 1
+        return []
+
+    monkeypatch.setattr(P.quant_signals, 'fetch_bars', fake_fetch)
+    P._BARS_CACHE.clear()
+
+    P._fetch_bars_cached('x', 400)
+    P._BARS_CACHE.clear()
+    P._fetch_bars_cached('x', 400)
+    assert calls['n'] == 2

--- a/tests/test_intraday_early_trend.py
+++ b/tests/test_intraday_early_trend.py
@@ -27,9 +27,10 @@ def _wire(tmp_path, monkeypatch, *, residual=0.09, dispersion=0.03, peers=5,
         json.dumps({'information_overlay': {'tickers': {}}, 'events': []}))
     (tmp_path / 'config' / 'add-alpha-policy.json').write_text(json.dumps({}))
     monkeypatch.setattr(
-        P.quant_signals, '_universe_details',
-        lambda: [{'label': 'CRCL', 'code': 'hkCRCL', 'region': region,
-                  'source_holdings': ['CRCL']}],
+        P.quant_signals, 'universe_details',
+        lambda errors=None: [{'label': 'CRCL', 'code': 'hkCRCL',
+                              'region': region,
+                              'source_holdings': ['CRCL']}],
     )
     monkeypatch.setattr(P.quant_signals, 'fetch_bars', lambda code, cnt: [])
     monkeypatch.setattr(P.quant_signals, 'compute_signals', lambda bars: {
@@ -64,11 +65,14 @@ def test_collect_fails_soft_when_universe_is_unavailable(monkeypatch, tmp_path):
     """A broken portfolio/registry must return no candidates, not red the cron."""
     monkeypatch.setattr(P, 'WS', tmp_path)
 
-    def boom():
+    def boom(**kwargs):
         raise ValueError('no tencent symbol')
-    monkeypatch.setattr(P.quant_signals, '_universe_details', boom)
+    monkeypatch.setattr(P.quant_signals, 'universe_details', boom)
 
-    assert P.collect_early_trend_candidates('hk') == {'rows': []}
+    out = P.collect_early_trend_candidates('hk')
+    assert out['rows'] == []
+    assert out['errors'] == [{'label': None,
+                              'error': 'ValueError: no tencent symbol'}]
 
 
 def test_append_early_trend_section_is_additive():

--- a/tests/test_intraday_opportunity_radar.py
+++ b/tests/test_intraday_opportunity_radar.py
@@ -16,7 +16,8 @@ def _wire(tmp_path, monkeypatch, sig_rows):
          'source_holdings': [label]}
         for label in sig_rows
     ]
-    monkeypatch.setattr(P.quant_signals, '_universe_details', lambda: universe)
+    monkeypatch.setattr(P.quant_signals, 'universe_details',
+                        lambda errors=None: universe)
     monkeypatch.setattr(P.quant_signals, 'fetch_bars', lambda code, cnt: [])
 
     def compute(bars, _row=iter(sig_rows.items())):
@@ -59,11 +60,14 @@ def test_radar_classifies_breakout_wait_and_near(tmp_path, monkeypatch):
 def test_radar_fails_soft_when_universe_breaks(monkeypatch, tmp_path):
     monkeypatch.setattr(P, 'WS', tmp_path)
 
-    def boom():
+    def boom(**kwargs):
         raise ValueError('no tencent symbol')
-    monkeypatch.setattr(P.quant_signals, '_universe_details', boom)
+    monkeypatch.setattr(P.quant_signals, 'universe_details', boom)
 
-    assert P.collect_opportunity_radar('us') == {'rows': []}
+    out = P.collect_opportunity_radar('us')
+    assert out['rows'] == []
+    assert out['errors'] == [{'label': None,
+                              'error': 'ValueError: no tencent symbol'}]
 
 
 def test_radar_section_is_additive():

--- a/tests/test_intraday_provisional_setups.py
+++ b/tests/test_intraday_provisional_setups.py
@@ -312,13 +312,18 @@ def test_an_empty_bar_list_is_reported_not_raised():
 
 
 def test_short_history_name_is_evaluated_not_reported_as_insufficient():
-    """20–29 bars now route through the short-history view (#542).
+    """20–29 bars route through the short-history view for genuinely-new
+    listings (#542 + #608 gate).
 
     A sub-30-bar name used to be reported `insufficient_bars(N)` and stay
-    invisible to the early-trend lane. It is now evaluated with the
-    20-bar-computable technical view; a flat series yields no setup and no error.
+    invisible to the early-trend lane. With a recent listing_date it is now
+    evaluated with the 20-bar-computable technical view; a flat series yields
+    no setup and no error. A mature name without a listing_date stays on the
+    strict 30-bar gate (#608) and is covered in test_short_history_signals.
     """
-    out = S.provisional_setups(_universe(), fetch=lambda code, cnt: _flat(25, 10.0))
+    universe = [{'label': 'SKHY', 'code': 'hkSKHY', 'region': 'US',
+                 'source_holdings': ['SKHY'], 'listing_date': '2026-07-10'}]
+    out = S.provisional_setups(universe, fetch=lambda code, cnt: _flat(25, 10.0))
 
     assert out == {'rows': [], 'confirmed_at_close': False}
 

--- a/tests/test_short_history_signals.py
+++ b/tests/test_short_history_signals.py
@@ -1,0 +1,106 @@
+"""Short-history (20–29 bar) view boundaries and the listing-date gate (#608).
+
+The mature 30-bar gate is a deliberate data-quality threshold. The short view
+exists only for genuinely-new listings — a partial-feed mature name must stay
+on the strict gate, or it enters the universe with half a signal set.
+"""
+import json
+from datetime import date, timedelta
+
+from clawock.decision import signals
+
+
+def _bars(n, start='2026-07-10'):
+    """n synthetic daily bars (calendar-day steps; fine for these computations)."""
+    rows = []
+    d = date.fromisoformat(start)
+    for i in range(n):
+        dt = d + timedelta(days=i)
+        rows.append({
+            'date': dt.isoformat(),
+            'open': 10.0,
+            'high': 11.0 + (i % 2) * 0.1,
+            'low': 9.0 - (i % 2) * 0.1,
+            'close': 10.0 + (i % 5) * 0.2,
+        })
+    return rows
+
+
+def test_short_view_boundaries():
+    """19 bars is not computable; 20/21/29 are; mature factors stay None."""
+    assert signals.compute_short_history_signals(_bars(19)) is None
+    for n in (20, 21, 29):
+        sig = signals.compute_short_history_signals(_bars(n))
+        assert sig is not None, f'{n} bars should compute the short view'
+        assert sig.get('close') is not None
+    sig = signals.compute_short_history_signals(_bars(25))
+    # A short name can never masquerade as a mature factor row.
+    assert sig.get('ma50') is None
+    assert sig.get('ma200') is None
+    assert sig.get('vol20') is None
+
+
+def test_candidate_gate_uses_registry_listing_date():
+    run = date(2026, 8, 14)
+    # SKHY listed 2026-07-10 → 35 days: genuinely short.
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-07-10'}, run) is True
+    # One day ago — still short.
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-08-13'}, run) is True
+    # Listed more than the window ago: the 30-bar gate should have been reachable.
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-05-01'}, run) is False
+    # Absent / unparseable listing_date means "not known to be new".
+    assert signals.is_short_history_candidate({}, run) is False
+    assert signals.is_short_history_candidate(
+        {'listing_date': 'not-a-date'}, run) is False
+    assert signals.is_short_history_candidate(None, run) is False
+
+
+def test_provisional_setups_fallback_only_for_new_listings(monkeypatch):
+    """A 25-bar mature name (or one without a listing date) must NOT get the
+    short view — it surfaces as insufficient_bars instead (#608)."""
+    new_detail = {'label': 'SKHY', 'code': 'x', 'region': 'US',
+                  'listing_date': '2026-07-10'}
+    mature = {'label': 'NVDA', 'code': 'y', 'region': 'US',
+              'listing_date': '1999-01-22'}
+    no_date = {'label': 'ZZZ', 'code': 'z', 'region': 'US'}
+    bars25 = _bars(25)
+
+    monkeypatch.setattr(signals, 'compute_signals', lambda bars: None)
+    monkeypatch.setattr(
+        signals, 'compute_short_history_signals',
+        lambda bars: {'close': 10.0, 'technical_setups': [
+            {'setup_id': 'ma20_reclaim', 'label': 'SKHY', 'close': 10.0}]})
+
+    out = signals.provisional_setups(
+        universe=[new_detail, mature, no_date], region='US',
+        fetch=lambda code, cnt: bars25)
+
+    labels = [r.get('label') for r in out.get('rows')]
+    assert labels == ['SKHY'], labels
+    errs = {e.get('label') for e in out.get('errors')}
+    assert {'NVDA', 'ZZZ'} <= errs, errs
+
+
+def test_universe_details_tolerates_one_bad_holding(monkeypatch, tmp_path):
+    """#612: a registry gap must not blank the whole universe; it lands in
+    errors and the row carries the listing_date for the short-history gate."""
+    port = {'portfolios': {'us_stocks': {'holdings': [
+        {'ticker': 'NVDA', 'shares': 10},
+        {'ticker': 'NOT_A_TICKER', 'shares': 5},
+        {'ticker': 'SKHY', 'shares': 3},
+    ]}}}
+    pf = tmp_path / 'portfolio.json'
+    pf.write_text(json.dumps(port))
+    monkeypatch.setattr(signals, 'PORTFOLIO', pf)
+
+    errors = []
+    rows = signals.universe_details(errors=errors)
+
+    labels = {r['label'] for r in rows}
+    assert 'NVDA' in labels and 'SKHY' in labels
+    assert len(errors) == 1 and errors[0]['label'] == 'NOT_A_TICKER'
+    skhy = next(r for r in rows if r['label'] == 'SKHY')
+    assert skhy.get('listing_date') == '2026-07-10'


### PR DESCRIPTION
## signals/universe 数据质量组（#608 #612 #613 #625）

| Issue | 改动 |
|---|---|
| #608 | 短历史兜底收紧：`compute_short_history_signals` 只对 **registry `listing_date` 存在且 ≤45 天**（≈30 交易日）的新上市名称生效；`refresh_rows`/`provisional_setups`/盘中两 lane/watch_list 全部走 `is_short_history_candidate` 闸。partial-feed 的成熟标的回到严格的 30-bar 闸（`insufficient_bars` 上报，不再以「短历史」身份进 universe）。universe 行携带 listing_date。已实测：智谱 02513（147 bars）/迅策 03317（153 bars）远超 30-bar，闸不误伤 |
| #612 | `universe_details(errors=...)` 逐持仓容错：一个 registry 缺口（未知 ticker / 缺 Tencent symbol）进 `errors` 上报，不再清空整条 universe（此前一条坏持仓让 early-trend + radar 两条 lane 静默变空）；两条 lane 返回 `errors` 字段（数据缺口必说）；`_load_json` 加 isinstance 守卫——非 dict 文件不再 AttributeError 红整个 preflight |
| #613 | 盘中三 collector（provisional/early-trend/radar）共用进程内 bars 缓存 `_fetch_bars_cached`，`main()` 每槽清空 → 每名字每槽 3x 抓取降为 1x（10 名持仓约 540 次/天 → 180 次/天）；radar docstring 更正「零新抓取」的虚假声称 |
| #625 | factor-universe `hk_ai_models` 补 **03317 迅策**；新增 CHINA_AI 全覆盖 parity 测试（instruments.json 与 factor-universe.json 漂移锁） |

## 测试

- 新增 `test_short_history_signals.py`（19/20/21/29 bar 边界、闸判定、provisional 集成、universe 逐行容错）、`test_factor_universe_parity.py`、`test_intraday_bars_cache.py`
- 更新 early-trend/radar/provisional 测试以匹配新签名与 errors 语义
- 本地全量：2088 passed（3 个失败均为本机环境特有的 OPENCLAW_BIN 解析差异，CI 不受影响）

## 数据缺口声明

02513/03317 的 `listing_date` 为 null（registry 未登记），但它们已有 140+ 根 bar，`compute_signals` 正常工作，不受收紧影响；未来如再注册新上市标的，须登记 listing_date 才能获得短历史视图。
