### PR TITLE
fix: 盘中 harness 五连修(#603 #605 #606 #609 #610)

### DIFF
--- a/src/clawock/decision/plans.py
+++ b/src/clawock/decision/plans.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 from clawock.decision import risk as risk_ledger
+from clawock.decision import ledger as decision_v2
 
 WS = workspace_root(Path.cwd())
 MEMORY = WS / "memory"
@@ -153,6 +154,38 @@ def _plan_extras(plan_date, memory_dir):
     return _trim(override, EXEC_MODE_CHARS) or None
 
 
+def _settle_override_backlog(dropped_rows, ledger_path):
+    """Batch-settle risk_rule cuts hidden by an active user override (#609).
+
+    #552 only filtered the read side: the ledger kept accumulating a daily
+    "SPCH cut" as `unknown` forever, and the moment the override TTL expired
+    the whole backlog re-entered the open queue and could crowd out the day's
+    fresh decisions. Settling writes `execution.status=overridden_by_user` in
+    the same pass that hides the rows — the ledger stays append-consistent,
+    the unknown bucket stops growing, and expired overrides have nothing left
+    to flood back. Idempotent: settled rows are no longer open, so later calls
+    find nothing to settle.
+    """
+    settled_ids = {row.get("decision_id") for row in dropped_rows
+                   if row.get("decision_id")}
+    if not settled_ids:
+        return
+    full = decision_v2.load_decisions(ledger_path)
+    changed = 0
+    for row in full:
+        if row.get("decision_id") not in settled_ids:
+            continue
+        execution = dict(row.get("execution") or {})
+        if execution.get("status") != OPEN_EXECUTION:
+            continue
+        execution["status"] = "overridden_by_user"
+        execution["source"] = "risk_override"
+        row["execution"] = execution
+        changed += 1
+    if changed:
+        decision_v2.write_decisions(full, ledger_path)
+
+
 def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None):
     """Open decisions the report/intraday prose has to reconcile against.
 
@@ -187,8 +220,13 @@ def open_decisions_context(*, leg=None, today=None, ledger=None, memory_dir=None
                 return (str(row.get("ticker") or "") in overridden_tickers
                         and row.get("driven_by") == "risk_rule"
                         and row.get("action") in ("cut", "trim_on_rebound"))
-            dropped = [str(row.get("ticker")) for row in rows if _is_overridden_cut(row)]
+            dropped_rows = [row for row in rows if _is_overridden_cut(row)]
+            dropped = sorted({str(row.get("ticker"))
+                              for row in dropped_rows})
             rows = [row for row in rows if not _is_overridden_cut(row)]
+            if dropped_rows:
+                # #609: settle, not just hide — see _settle_override_backlog.
+                _settle_override_backlog(dropped_rows, ledger_path)
         if not rows:
             if open_add_gate_error:
                 return {"open_add_tickers": [], "open_add_gate_error": open_add_gate_error}

--- a/src/clawock/harness/brief_watchdog.py
+++ b/src/clawock/harness/brief_watchdog.py
@@ -319,13 +319,29 @@ def alert_brief_missing(today, dry_run, issues=None):
         return 0
 
     state['issues'] = list(issues)
+    rerun_queued = False
     if not state.get('fallback_dispatch_attempted'):
         # Second on-host chance before the off-host fallback (#550): the 08:30
         # re-run can itself fail (2026-08-12), and a local re-run is cheaper
         # than a vendor fallback and lands well before the 10:00 HKT cutoff.
-        if _rerun_count(today) < MAX_ONHOST_RERUNS:
-            _rerun_once(today, dry_run, attempt=2)
-        dispatched, out = dispatch_brief_fallback(dry_run)
+        # #606: gate the chance on evidence, not just the counter — only a run
+        # that already ended in failure today is proof the attempt is over
+        # (three-way rule as the 08:30 pass); a healthy run or an unreadable
+        # schedule must not stack another queue entry. The counter only caps
+        # the number of chances.
+        failed = cron_run_ended_in_failure(brief_cron_job(), today)
+        if failed and _rerun_count(today) < MAX_ONHOST_RERUNS:
+            rerun_queued = _rerun_once(today, dry_run, attempt=2)
+        if rerun_queued:
+            # #606: the queued local re-run writes the same brief artifacts the
+            # GHA fallback would; dispatching both made two LLMs race on the
+            # same files with per-environment delivery markers → duplicate
+            # WeChat/TG risk (#508 pattern). Skip the fallback while the local
+            # chance is in flight; the alert below names both paths and the
+            # manual dispatch stays available before the 10:00 HKT cutoff.
+            dispatched, out = False, 'local rerun queued; off-host fallback skipped'
+        else:
+            dispatched, out = dispatch_brief_fallback(dry_run)
         state.update({
             'fallback_dispatch_attempted': True,
             'fallback_dispatch_succeeded': bool(dispatched),
@@ -346,14 +362,22 @@ def alert_brief_missing(today, dry_run, issues=None):
         'plan_invalid': f'plan 无效：memory/{today}-plan.json 无法解析或没有非空动作数组',
     }
     issue_text = '\n'.join(f'- {labels[x]}' for x in issues)
+    if rerun_queued:
+        recovery_note = (
+            '🔄 已排队本地重跑(attempt 2)，off-host 兜底已跳过（防双写）。'
+            '若重跑未落地，10:00 HKT 前可手动：gh workflow run brief-fallback.yml\n')
+    elif dispatched:
+        recovery_note = (
+            '🔄 已 dispatch off-host 兜底 (brief-fallback.yml)，正在等待运行结果，稍后另发一条。\n')
+    else:
+        recovery_note = (
+            '⚠️ 自动 dispatch 兜底失败，需要手动：gh workflow run brief-fallback.yml\n'
+            '（10:00 HKT 前有效，之后 workflow 会判定过期跳过）\n')
     alert = (
         f'🔴 盘前深度简报产物不完整 — {today}\n\n'
         f'09:05 检查结果：\n{issue_text}\n\n'
         + retry_budget_note()
-        + ('🔄 已 dispatch off-host 兜底 (brief-fallback.yml)，正在等待运行结果，稍后另发一条。\n'
-           if dispatched else
-           '⚠️ 自动 dispatch 兜底失败，需要手动：gh workflow run brief-fallback.yml\n'
-           '（10:00 HKT 前有效，之后 workflow 会判定过期跳过）\n')
+        + recovery_note
         + f'\n查因：openclaw cron runs --id $(openclaw cron list | grep 盘前深度简报) '
           f'/ sar -q 看 08:00 起的 blocked'
     )
@@ -375,6 +399,7 @@ def alert_brief_missing(today, dry_run, issues=None):
 
     log({'tag': 'brief', 'action': 'alert-brief-missing', 'dry_run': dry_run,
          'issues': issues,
+         'rerun_queued': rerun_queued,
          'dispatched_fallback': dispatched, 'dispatch_out': out,
          'sent_ok': tg_ok, 'target': KCN_TELEGRAM, 'out': tg_out,
          'recovery_state': state})

--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -80,8 +80,22 @@ def semantic_state(market, session_date, *, signals_detail, anomalies, setups,
                 "level": move_level,
                 "direction": "up" if move > 0 else "down",
             })
+    # #610: the price-surface lanes encode their live sub-state in setup_id
+    # (opportunity:{breakout|wait_rebreak|near_breakout},
+    # early_trend:{state}) and those sub-states flip on raw quote churn around
+    # a threshold (close vs prior, zscore20 vs 2.0) — exactly the churn this
+    # gate exists to exclude. Compare the lane identity, not the churny
+    # sub-state; a row appearing or disappearing still counts as a delta.
+    def _stable_setup_id(setup_id):
+        if setup_id and ':' in str(setup_id):
+            prefix = str(setup_id).split(':', 1)[0]
+            if prefix in ('opportunity', 'early_trend'):
+                return prefix
+        return setup_id
+
     setup_rows = [{
-        "label": row.get("label"), "setup_id": row.get("setup_id"),
+        "label": row.get("label"),
+        "setup_id": _stable_setup_id(row.get("setup_id")),
         "holdings": sorted(row.get("holdings") or []),
     } for row in ((setups or {}).get("rows") or [])]
     plan_rows = [{

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -342,11 +342,20 @@ def collect_early_trend_candidates(market):
             'attention_event_count': irow.get('attention_event_count'),
         }
         holdings = list(detail.get('source_holdings') or [label])
-        matching = [
-            event for event in events
-            if str(event.get('ticker') or event.get('reported_ticker') or '')
-            in set(holdings) | {label}
-        ]
+        # #603: the daily path bridges `direction` from `impact_direction`
+        # (packet._event_view); the raw event dicts only carry impact_direction,
+        # so the intraday lane handed classify() a payload where primary_ids was
+        # always empty. Normalise exactly like the daily path before matching.
+        matching = []
+        for event in events:
+            if str(event.get('ticker') or event.get('reported_ticker') or '') \
+                    not in set(holdings) | {label}:
+                continue
+            view = dict(event)
+            direction = event.get('direction', event.get('impact_direction'))
+            if direction not in (None, '', []):
+                view['direction'] = direction
+            matching.append(view)
         leveraged = any(
             is_leveraged_holding({'ticker': ticker}) for ticker in holdings
         )
@@ -516,6 +525,12 @@ def attach_reinvest_candidates(plan_ctx, opportunity_radar, signals_detail=None)
     """
     rows = (opportunity_radar or {}).get('rows') or []
     if not rows:
+        return plan_ctx
+    # #605: only an open cut/trim decision has ammunition to pair. A clean day
+    # must return the context unchanged — otherwise the model sees an
+    # "ammunition" field with nothing to cut and can invent a cut for the money.
+    if not any(str(row.get('action')) in ('cut', 'trim_on_rebound')
+               for row in ((plan_ctx or {}).get('open') or [])):
         return plan_ctx
     flagged = {item.get('ticker') for item in (signals_detail or [])
                if str(item.get('level', '')).upper() in CONFLICTING_LEVELS}

--- a/tests/test_brief_watchdog_second_rerun.py
+++ b/tests/test_brief_watchdog_second_rerun.py
@@ -30,7 +30,9 @@ def _watch(monkeypatch, tmp_path, job=None):
         monkeypatch.setattr(
             watchdog, "rerun_cron_job",
             lambda job_id, dry_run=False: (spy.setdefault("reruns", []).append(job_id), (True, "queued"))[1])
-    monkeypatch.setattr(watchdog, "dispatch_brief_fallback", lambda dry_run=False: (True, "dispatched"))
+    monkeypatch.setattr(
+        watchdog, "dispatch_brief_fallback",
+        lambda dry_run=False: (spy.setdefault("fallbacks", []).append(1), (True, "dispatched"))[1])
     monkeypatch.setattr(watchdog, "send_telegram", lambda *a, **k: (True, "sent"))
     monkeypatch.setattr(watchdog, "write_missing_state", lambda *a, **k: None)
     monkeypatch.setattr(watchdog, "brief_cron_job_state", lambda: {})
@@ -40,7 +42,10 @@ def _watch(monkeypatch, tmp_path, job=None):
 
 def test_miss_detector_fires_second_rerun_before_fallback(monkeypatch, tmp_path):
     """08:30 already re-ran once (flag count=1): 09:05 queues attempt 2."""
-    spy = _watch(monkeypatch, tmp_path, job=_job(lastStatus="error", consecutiveErrors=8))
+    ran_at = int(datetime(2026, 8, 12, 8, 5, tzinfo=HKT).timestamp() * 1000)
+    spy = _watch(monkeypatch, tmp_path,
+                 job=_job(lastStatus="error", consecutiveErrors=8,
+                          lastRunAtMs=ran_at))
     flag = watchdog.rerun_flag_path(TODAY)
     flag.parent.mkdir(parents=True, exist_ok=True)
     flag.write_text("1")
@@ -52,6 +57,34 @@ def test_miss_detector_fires_second_rerun_before_fallback(monkeypatch, tmp_path)
     assert len(spy["reruns"]) == 1
     # the dedupe counter advanced
     assert watchdog._rerun_count(TODAY) == 2
+    # #606: a queued local re-run must suppress the off-host fallback — two
+    # writers on the same artifacts caused the #508 double-delivery pattern.
+    assert spy.get("fallbacks") is None
+    assert spy["logs"][-1]["rerun_queued"] is True
+
+
+def test_miss_detector_with_healthy_run_skips_rerun_and_dispatches_fallback(monkeypatch, tmp_path):
+    """#606: the 09:05 chance is evidence-gated. A run that ended OK today is
+    not a failed attempt — no extra queue entry, fallback goes straight out."""
+    ran_at = int(datetime(2026, 8, 12, 8, 5, tzinfo=HKT).timestamp() * 1000)
+    spy = _watch(monkeypatch, tmp_path,
+                 job=_job(lastStatus="ok", lastRunAtMs=ran_at))
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert spy.get("reruns") is None
+    assert spy.get("fallbacks") == [1]
+
+
+def test_miss_detector_with_no_run_evidence_dispatches_fallback(monkeypatch, tmp_path):
+    """#606: a job still running (or unreadable) is no evidence the attempt is
+    over — no rerun, fallback dispatched (the alert invariant is the core)."""
+    spy = _watch(monkeypatch, tmp_path, job=_job(status="running", runningAtMs=1))
+
+    assert watchdog.alert_brief_missing(TODAY, False, ["brief_missing"]) == 0
+
+    assert spy.get("reruns") is None
+    assert spy.get("fallbacks") == [1]
 
 
 def test_miss_detector_stops_after_two_reruns(monkeypatch, tmp_path):

--- a/tests/test_intraday_delta_gate.py
+++ b/tests/test_intraday_delta_gate.py
@@ -295,3 +295,38 @@ def test_preflight_main_selects_full_delta_for_risk_change(monkeypatch, tmp_path
 
     assert ctx["delivery_mode"] == "full_delta"
     assert ctx["semantic_delta"]["components"] == ["breaches"]
+
+
+def test_setup_sub_state_churn_is_not_a_delta():
+    """#610: opportunity/early_trend sub-states flip on raw quote churn around
+    a threshold (close vs prior, zscore20 vs 2.0). The gate compares the lane
+    identity, not the churny sub-state; row appearance/disappearance still
+    counts, and non-lane setup ids keep their full identity."""
+    base = dict(market="hk", session_date="2026-08-14",
+                signals_detail=[], anomalies=[], plans={"open": []},
+                active_information={})
+    row = {"label": "00100", "holdings": ["00100"]}
+
+    s_breakout = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id": "opportunity:breakout"}]})
+    s_wait = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id": "opportunity:wait_rebreak"}]})
+    s_early = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id": "early_trend:wait_information"}]})
+    s_early_ready = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id": "early_trend:exploration_ready"}]})
+
+    assert s_breakout["setups"] == s_wait["setups"]
+    assert s_early["setups"] == s_early_ready["setups"]
+    assert gate.compare_semantic_states(s_breakout, s_wait)["changed"] is False
+
+    # appearance/disappearance is a real delta
+    s_none = gate.semantic_state(**base, setups={"rows": []})
+    assert s_none["setups"] != s_breakout["setups"]
+    assert "setups" in gate.compare_semantic_states(s_breakout, s_none)["components"]
+
+    # non-lane setup ids keep their full identity (e.g. provisional entry rules)
+    s_conf = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id": "confirmed_breakout"}]})
+    assert s_conf["setups"][0]["setup_id"] == "confirmed_breakout"
+    assert gate.compare_semantic_states(s_breakout, s_conf)["changed"] is True

--- a/tests/test_intraday_early_trend.py
+++ b/tests/test_intraday_early_trend.py
@@ -90,3 +90,33 @@ def test_append_early_trend_section_is_additive():
     assert '🕯️ 早期趋势候选' in rendered
     assert '候选·等回踩再突破' in rendered
     assert '现价 10 / 前高 9' in rendered
+
+
+def test_impact_direction_events_reach_classify_as_primary_evidence(monkeypatch, tmp_path):
+    """#603: the intraday lane must bridge impact_direction → direction like
+    the daily path (packet._event_view). The raw graph events only carry
+    impact_direction, so without the bridge primary_ids is always empty and the
+    candidate degrades to wait_information — the daily run sees it as
+    exploration_ready on the same payload."""
+    _wire(tmp_path, monkeypatch, zscore=1.0)
+    events_path = tmp_path / 'assets' / 'data' / 'news_evidence_graph.json'
+    events_path.write_text(json.dumps({
+        'information_overlay': {'tickers': {}},
+        'events': [{'event_id': 'e1', 'ticker': 'CRCL',
+                    'source_type': 'sec_filing',
+                    'impact_direction': 'positive'}],
+    }))
+
+    out = P.collect_early_trend_candidates('hk')
+
+    assert out['rows'][0]['state'] == 'exploration_ready'
+
+
+def test_lane_without_primary_evidence_stays_wait_information(monkeypatch, tmp_path):
+    """Control: the same technical setup with no primary event stays
+    wait_information — the #603 bridge is what unlocks exploration_ready."""
+    _wire(tmp_path, monkeypatch, zscore=1.0)
+
+    out = P.collect_early_trend_candidates('hk')
+
+    assert out['rows'][0]['state'] == 'wait_information'

--- a/tests/test_plans_override.py
+++ b/tests/test_plans_override.py
@@ -97,3 +97,73 @@ def test_no_override_means_no_change(tmp_path):
 
     assert "overridden_by_user" not in ctx
     assert "dec-SPCH-cut" in {row["decision_id"] for row in ctx["open"]}
+
+
+def _active_override(breaches_path):
+    _write_breaches(breaches_path, [
+        {"ticker": "SPCH", "status": "overridden", "override": {
+            "status": "active", "reason": "无限子弹流",
+            "created_at": "x", "expires_at": _stamp_future()}},
+    ])
+
+
+def _ledger_rows(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_override_settles_the_backlog_in_the_ledger(tmp_path):
+    """#609: the read-side filter (#552) also settles — an overridden cut the
+    user will not execute must not stay `unknown` forever, or the ledger
+    accumulates one cut per morning and the unknown bucket grows without end."""
+    ledger = tmp_path / "decisions.jsonl"
+    _write_ledger(ledger, [
+        _open_row("SPCH", "cut", "risk_rule"),
+        _open_row("SPCH", "trim_on_rebound", "risk_rule"),
+        _open_row("SPCH", "hold_and_watch", "technical"),
+        _open_row("CRCL", "cut", "thesis"),
+    ])
+    breaches = tmp_path / "risk_breaches.json"
+    _active_override(breaches)
+
+    ctx = plans.open_decisions_context(
+        leg="HK", today="2026-08-14", ledger=ledger, memory_dir=tmp_path)
+    assert ctx["overridden_by_user"] == ["SPCH"]
+
+    by_id = {r["decision_id"]: r for r in _ledger_rows(ledger)}
+    assert by_id["dec-SPCH-cut"]["execution"]["status"] == "overridden_by_user"
+    assert by_id["dec-SPCH-cut"]["execution"]["source"] == "risk_override"
+    assert by_id["dec-SPCH-trim_on_rebound"]["execution"]["status"] == "overridden_by_user"
+    # non-risk rows stay untouched
+    assert by_id["dec-SPCH-hold_and_watch"]["execution"]["status"] == "unknown"
+    assert by_id["dec-CRCL-cut"]["execution"]["status"] == "unknown"
+
+
+def test_settled_rows_do_not_flood_back_after_override_expiry(tmp_path):
+    """#609 TTL: once settled, an expired override has nothing to re-queue —
+    the accumulated cut backlog cannot crowd out fresh decisions."""
+    ledger = tmp_path / "decisions.jsonl"
+    _write_ledger(ledger, [
+        _open_row("SPCH", "cut", "risk_rule"),
+        _open_row("CRCL", "cut", "thesis"),
+    ])
+    breaches = tmp_path / "risk_breaches.json"
+    _active_override(breaches)
+
+    # First pass: override active → dropped and settled.
+    plans.open_decisions_context(
+        leg="HK", today="2026-08-14", ledger=ledger, memory_dir=tmp_path)
+
+    # Override TTL expires.
+    _write_breaches(breaches, [
+        {"ticker": "SPCH", "status": "overridden", "override": {
+            "status": "expired", "reason": "无限子弹流",
+            "created_at": "x", "expires_at": "2026-08-10T00:00:00"}},
+    ])
+
+    ctx = plans.open_decisions_context(
+        leg="HK", today="2026-08-15", ledger=ledger, memory_dir=tmp_path)
+
+    open_ids = {row["decision_id"] for row in ctx["open"]}
+    assert "dec-SPCH-cut" not in open_ids  # settled earlier, no flood-back
+    assert "dec-CRCL-cut" in open_ids      # the day's real open decision
+    assert "overridden_by_user" not in ctx

--- a/tests/test_reinvest_candidates.py
+++ b/tests/test_reinvest_candidates.py
@@ -34,11 +34,26 @@ def test_flagged_candidates_are_excluded():
     radar = {'rows': [_radar_row('SPCH'), _radar_row('SKHY')]}
     signals = [{'ticker': 'SPCH', 'level': 'STOP'}]
 
-    out = P.attach_reinvest_candidates({}, radar, signals)
+    out = P.attach_reinvest_candidates(
+        {'open': [{'decision_id': 'd1', 'action': 'cut'}]}, radar, signals)
 
     tickers = [c['ticker'] for c in out['reinvest_candidates']]
     assert 'SPCH' not in tickers
     assert tickers == ['SKHY']
+
+
+def test_clean_day_without_cut_returns_context_untouched():
+    """#605: no open cut/trim decision → no ammunition to pair. Attaching
+    candidates on a clean day would invite the model to invent a cut for the
+    money (the pre-#605 test pinned the ungated behavior as correct)."""
+    radar = {'rows': [_radar_row('00100', 'breakout', 374.4),
+                      _radar_row('SKHY', 'near_breakout', 177.93)]}
+
+    plan_ctx = {'open': [{'decision_id': 'd1', 'action': 'hold_and_watch'}]}
+    assert P.attach_reinvest_candidates(plan_ctx, radar, []) is plan_ctx
+
+    empty = {'open': []}
+    assert P.attach_reinvest_candidates(empty, radar, []) is empty
 
 
 def test_no_candidates_returns_context_untouched():


### PR DESCRIPTION
## 盘中 harness 组（#603 #605 #606 #609 #610）

| Issue | 改动 |
|---|---|
| #603 | 盘中 early-trend lane 补齐 daily 路径的 `impact_direction → direction` 桥接（对照 `packet._event_view`）：news_evidence_graph.json 79/79 条事件只有 impact_direction，classify 的 `primary_ids` 恒空 → 盘中系统性退化 `wait_information`。补双向测试（有 primary 证据 → `exploration_ready`；无 → `wait_information`） |
| #605 | `attach_reinvest_candidates` 加闸：仅当 `plan_ctx.open[]` 真有 cut/trim 决策才挂 `reinvest_candidates`——干净的一天不再出现「弹药」字段，杜绝模型虚构砍单（旧测试还把未加闸行为钉成正确，已翻转）。SKILL 文档补齐两个新 context 可选键 |
| #606 | brief watchdog 09:05 恢复路径分流：本地 rerun **排队成功即跳过 off-host fallback**（两个 LLM 并发写同一批 artifact + 跨环境 delivery markers = 双写/重复推送，#508 形态）；rerun 门槛从纯计数改为**证据**（`cron_run_ended_in_failure` 三态判定，与 08:30 pass 同一规则）；告警文案与日志同时报告两条恢复路径 |
| #609 | #552 只做读侧过滤的窟窿：`open_decisions_context` 隐藏 overridden risk_rule cut 的同时**批量结案**（`execution.status=overridden_by_user`）——unknown 桶停止逐日增长；override TTL 过期后积压行不再回流挤掉当日决策（`MAX_DECISIONS=12`）。补结案 + 过期回流测试 |
| #610 | 语义 delta gate 对 `opportunity:` / `early_trend:` 子状态做前缀归一：价格在 prior / z=2 边界震荡不再每 slot 翻 full_delta；行出现/消失仍算 delta；非 lane 的 setup_id（如 `confirmed_breakout`）保持原样。补边界震荡测试 |

## 验证

- 全量套件 2096 passed（3 个失败为本机环境特有的 OPENCLAW_BIN 解析差异，CI 不受影响）
- 每个 issue 都有正反测试

## 权衡声明（#606）

rerun 排队后跳过 fallback 意味着：若本地重跑也失败，当日不再自动走 off-host——09:05 告警会明确告诉 kcn「本地重跑已排队、兜底已跳过、10:00 HKT 前可手动 dispatch」，这是 issue 建议的取舍（防双写优先）。
