### PR TITLE
feat+refactor: watch_list 打通 LLM 边界 + 阈值收敛 config + 风格统一(#602 #620 #621)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -86,6 +86,33 @@ fi
 # ──────────────────────────────────────────────────────────────────────────
 
 # ──────────────────────────────────────────────────────────────────────────
+# 3.5 watch-list.json ↔ instruments.json cross-validation (#602/#621)
+#    The watch list is maintained by hand alongside instruments.json; a typo
+#    used to be a permanent silent no-scan. Any change to either file re-checks
+#    the pair.
+# ──────────────────────────────────────────────────────────────────────────
+if echo "$STAGED" | grep -qE '^(config/watch-list\.json|config/instruments\.json)$'; then
+  echo "  ▸ validating watch-list.json ↔ instruments.json…"
+  python3 - <<'PY' || exit 1
+import json, sys
+try:
+    wl = json.load(open('config/watch-list.json'))
+    inst = json.load(open('config/instruments.json'))['instruments']
+except Exception as e:
+    print(f'    ✗ config parse error: {e}', file=sys.stderr)
+    sys.exit(1)
+missing = [t for t in (wl.get('tickers') or []) if t not in inst]
+if missing:
+    print(f'    ✗ watch-list tickers missing from instruments.json: {missing}',
+          file=sys.stderr)
+    print('    → 先在 instruments.json 注册(含 tencent_symbol)再加观察池',
+          file=sys.stderr)
+    sys.exit(1)
+print('    ✓ watch-list.json ↔ instruments.json OK')
+PY
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
 # 4. No staged secrets (paranoid scan)
 # ──────────────────────────────────────────────────────────────────────────
 SECRETS_HIT=$(git diff --cached -U0 -- ':!*.md' ':!.gitignore' \

--- a/config/add-alpha-policy.json
+++ b/config/add-alpha-policy.json
@@ -5,6 +5,7 @@
   "minimum_information_score": 0.08,
   "minimum_attention_acceleration": 1.25,
   "minimum_attention_source_types": 1,
+  "opportunity_near_pct": 5.0,
   "attention_score_prior": 0.10,
   "minimum_event_novelty": 0.5,
   "minimum_event_reliability": 0.5,

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -112,8 +112,10 @@ bundle 路由：
 - `risk_detail`: `breakeven_math`, `risk_metrics`
 - `research`: `quant_signals`, `cross_sectional_factor`, `peer_residual`, `t0_setups`, `us_fundamentals`, `peer_scan` 及对应 review
 - `evidence`: `catalysts`, `news_evidence_graph`
-- `market`: `macro`, `sentiment`, `influencer`, `em_news`
+- `market`: `macro`, `sentiment`, `influencer`, `em_news`, `watch_list`
 - `calibration`: `retrospective`, `decision_metrics`, `reflections`
+
+`market.watch_list`（#556）：非持仓 AI 观察池（智谱 02513 / 迅策 03317 等）的**价格面观察**——仅当突破/接近突破/5d 大涨时才有行。写「新机会」节时读取它，但**观察池名字绝不产生 add 授权、绝不进决策**（不进 plan / `_constraints`）。
 
 manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 core；只有下面明确要求消费该字段时才读。任一 bundle 的 `_meta.generation_id` 与 manifest 不同，立即停止，不得把不同 preflight run 的事实拼在一起。
 

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -182,6 +182,7 @@ clawock report preflight --market hk --phase {open|mid|pm|close}
 - 股数/比例**照抄 `shares`/`pct`，不许换算也不许心算**；`carried_over>0` 时点一句「{n} 条昨日挂单仍未成交」。
 - `plan_context` 为 `{}` 说明今天本腿没有未完成决策，按正常写，不要编一个计划出来。
 - `plan_context` 里带 `error` 字段说明**计划没读出来，不是今天没有计划**（issue #136）。此时必须在 ▎操作建议 开头写一行「今日计划未取到（{error}），以下建议未与 08:00 简报对账」，并且**不许**顺势断言「今天没有未完成决策」。
+- 可选键（#605/#609）：`overridden_by_user` = 用户已 override 的 risk_rule 砍单（已隐藏并结案，**不要再提「该砍未砍」**）；`reinvest_candidates` = 砍/trim 的弹药去向候选（仅当 `open[]` 真有 cut/trim 时出现；是观察不是授权，配对话术照抄候选 ticker 与 trigger，不许虚构「砍 X 的弹药」当 `open[]` 里没有 X）。
 
 🔢 **数字铁律（postflight 会查，见 `check_numeric_claims`）**：散文里出现的每个金额/股数**必须是 context 里已有的数字**，照抄不换算。
 - **禁止重述持仓股数、持仓市值、浮盈金额** —— 这些 postflight 已经拼在消息开头了，重述一遍只会多一次说错的机会（2026-07-27 就把 6200 股的仓位写成 1000 股）。**例外且仅此一个**：`plan_context.open[].shares` 是「这一单要动多少股」，照抄它是被要求的；被禁的是「这只票我持有多少股」。两者不是一回事——07226 持仓 6200 股、当日 swap 单 1000 股，同一天同一只票。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -185,6 +185,7 @@ clawock report preflight --market us --phase {open|close}
 - 股数/比例**照抄 `shares`/`pct`，不许换算也不许心算**；`carried_over>0` 时点一句「{n} 条昨日挂单仍未成交」。
 - `plan_context` 为 `{}` 说明今天本腿没有未完成决策，按正常写，不要编一个计划出来。
 - `plan_context` 里带 `error` 字段说明**计划没读出来，不是今天没有计划**（issue #136）。此时必须在 ▎操作建议 开头写一行「今日计划未取到（{error}），以下建议未与 08:00 简报对账」，并且**不许**顺势断言「今天没有未完成决策」。
+- 可选键（#605/#609）：`overridden_by_user` = 用户已 override 的 risk_rule 砍单（已隐藏并结案，**不要再提「该砍未砍」**）；`reinvest_candidates` = 砍/trim 的弹药去向候选（仅当 `open[]` 真有 cut/trim 时出现；是观察不是授权，配对话术照抄候选 ticker 与 trigger，不许虚构「砍 X 的弹药」当 `open[]` 里没有 X）。
 
 🔢 **数字铁律（postflight 会查，见 `check_numeric_claims`）**：散文里出现的每个金额/股数**必须是 context 里已有的数字**，照抄不换算。
 - **禁止重述持仓股数、持仓市值、浮盈金额** —— 这些 postflight 已经拼在消息开头了，重述一遍只会多一次说错的机会（2026-07-27 就把 6200 股的仓位写成 1000 股）。**例外且仅此一个**：`plan_context.open[].shares` 是「这一单要动多少股」，照抄它是被要求的；被禁的是「这只票我持有多少股」。两者不是一回事——07226 持仓 6200 股、当日 swap 单 1000 股，同一天同一只票。

--- a/src/clawock/context/brief.py
+++ b/src/clawock/context/brief.py
@@ -65,6 +65,7 @@ BUNDLE_FIELDS = {
         "sentiment",
         "influencer",
         "em_news",
+        "watch_list",
     ),
     "calibration": (
         "retrospective",

--- a/src/clawock/decision/plans.py
+++ b/src/clawock/decision/plans.py
@@ -24,9 +24,9 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from clawock.workspace import workspace_root
-from clawock.decision import risk as risk_ledger
 from clawock.decision import ledger as decision_v2
+from clawock.decision import risk as risk_ledger
+from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
 MEMORY = WS / "memory"

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -34,7 +34,7 @@ import requests
 
 from clawock.market_data import sessions as trading_calendar
 from clawock.portfolio.instruments import require as require_instrument
-from clawock.safe_io import safe_write_json, load_json_cached
+from clawock.safe_io import load_json_cached, safe_write_json
 from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
@@ -416,16 +416,11 @@ def universe_details(errors=None):
     return list(by_code.values())
 
 
-def _universe_details():
-    """Deprecated alias for out-of-tree callers; use `universe_details`."""
-    return universe_details()
-
-
 def _universe():
     """Compatibility view used by registry tests and small callers."""
     return [
         (row['label'], row['code'], row['note'])
-        for row in _universe_details()
+        for row in universe_details()
     ]
 
 
@@ -595,7 +590,7 @@ def provisional_setups(universe=None, *, region=None, fetch=None):
     """
     rows, errors = [], []
     fetcher = fetch or fetch_bars
-    for detail in (universe if universe is not None else _universe_details()):
+    for detail in (universe if universe is not None else universe_details()):
         if region and detail.get('region') != region:
             continue
         label = detail.get('label')
@@ -644,7 +639,7 @@ def main(argv=None):
             prev = json.loads(OUT.read_text())
         except Exception:
             prev = {}
-    universe = _universe_details()
+    universe = universe_details()
     rows = refresh_rows(
         prev.get('rows') or {},
         universe,

--- a/src/clawock/decision/watch_list.py
+++ b/src/clawock/decision/watch_list.py
@@ -13,22 +13,38 @@ import json
 from datetime import date
 from pathlib import Path
 
-from clawock.workspace import workspace_root
 from clawock.decision import signals as quant_signals
+from clawock.market_data import sessions as trading_calendar
 from clawock.portfolio.instruments import get as get_instrument
+from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
-WATCH_LIST = WS / "config" / "watch-list.json"
-
-# 出现门槛:距 20 日高 ≤5%、或 5d 收益 ≥8%(次新无前高数据时只看 5d)
+# 出现门槛:距 20 日高 ≤5%、或 5d 收益 ≥8%(次新无前高数据时只看 5d)。
+# NEAR_HIGH_PCT 的单一真源在 add-alpha-policy.json 的 `opportunity_near_pct`
+# (#621)——radar 与 watch list 同读一个值,改配置两边同时生效。
 NEAR_HIGH_PCT = 5.0
 STRONG_5D_PCT = 8.0
+
+
+def _watch_list_path() -> Path:
+    """Config path, resolved at call time (#620: import must not depend on cwd)."""
+    return workspace_root(Path.cwd()) / "config" / "watch-list.json"
+
+
+def _policy_near_pct() -> float:
+    """`opportunity_near_pct` from add-alpha-policy.json, default NEAR_HIGH_PCT."""
+    try:
+        policy = json.loads(
+            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            .read_text(encoding="utf-8"))
+        return float(policy.get("opportunity_near_pct") or NEAR_HIGH_PCT)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+        return NEAR_HIGH_PCT
 
 
 def watch_tickers() -> list[str]:
     """Registered watch-list tickers (fail-soft: a broken config is empty)."""
     try:
-        doc = json.loads(WATCH_LIST.read_text())
+        doc = json.loads(_watch_list_path().read_text())
         return [str(t) for t in (doc.get("tickers") or []) if t]
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return []
@@ -37,26 +53,44 @@ def watch_tickers() -> list[str]:
 def collect() -> dict:
     """Scan watch-list names on completed bars; never raises, never authorizes.
 
-    Returns ``{"rows": [...]}`` where a row is present only when the name is
-    breaking out, within NEAR_HIGH_PCT of its 20d high, or up ≥STRONG_5D_PCT
-    over 5 sessions. Each row: ticker / name / close / prior_20d_high /
-    pct_from_high / ret_5d / state(breakout | near_breakout | strong).
+    Returns ``{"rows": [...], "errors": [...]}`` where a row is present only
+    when the name is breaking out, within near-high % of its 20d high, or up
+    ≥STRONG_5D_PCT over 5 sessions. A watch-list ticker missing from
+    instruments.json (or without a canonical Tencent symbol) is reported in
+    `errors` — a typo must not be a permanent silent no-scan (#602).
     """
-    rows = []
+    rows, errors = [], []
+    near_pct = _policy_near_pct()
     for ticker in watch_tickers():
         meta = get_instrument(ticker) or {}
         code = meta.get("tencent_symbol")
         if not code:
+            errors.append({'ticker': ticker,
+                           'error': 'missing instruments.json entry or Tencent symbol'})
             continue
         try:
             bars = quant_signals.fetch_bars(code, 400)
+            # "On completed bars" is a real filter, not a docstring promise
+            # (#621): an intraday re-run must not read the still-open bar as a
+            # completed daily candle.
+            region = meta.get('region')
+            expected = (trading_calendar.latest_completed_session(region)
+                        if region else None)
+            if expected:
+                bars = [
+                    bar for bar in bars
+                    if bar.get('date') is not None
+                    and date.fromisoformat(str(bar['date'])[:10]) <= expected
+                ]
             sig = quant_signals.compute_signals(bars)
             if sig is None and quant_signals.is_short_history_candidate(
                     meta, date.today()):
                 # Only a genuinely-new name may use the 20-bar short view; a
                 # partial-feed mature name stays on the 30-bar gate (#608).
                 sig = quant_signals.compute_short_history_signals(bars)
-        except Exception:  # noqa: BLE001 — one dead feed must not blank the rest
+        except Exception as exc:  # noqa: BLE001 — one dead feed must not blank the rest
+            errors.append({'ticker': ticker,
+                           'error': f'{type(exc).__name__}: {exc}'[:200]})
             continue
         if not sig:
             continue
@@ -69,7 +103,7 @@ def collect() -> dict:
         ret_5d = (closes[-1] / closes[-6] - 1) * 100 if len(closes) >= 6 else None
         if prior is not None and close > prior:
             state = "breakout"
-        elif pct_from_high is not None and pct_from_high >= -NEAR_HIGH_PCT:
+        elif pct_from_high is not None and pct_from_high >= -near_pct:
             state = "near_breakout"
         elif ret_5d is not None and ret_5d >= STRONG_5D_PCT:
             state = "strong"
@@ -89,7 +123,10 @@ def collect() -> dict:
         row["state"] != "breakout",
         -(row["ret_5d"] or 0),
     ))
-    return {"rows": rows}
+    result = {"rows": rows}
+    if errors:
+        result["errors"] = errors
+    return result
 
 
 def main(argv=None) -> int:

--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -21,7 +21,7 @@ from clawock.workspace import workspace_root
 from clawock.market_data import sessions as trading_calendar
 from clawock.market_data import peer_quotes as fetch_peers
 from clawock.automation import cron_heartbeat
-from clawock.safe_io import safe_write_json, load_json_cached
+from clawock.safe_io import load_json_cached, safe_write_json
 
 WS = workspace_root(Path.cwd())
 HKT = ZoneInfo("Asia/Hong_Kong")

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -299,9 +299,8 @@ def collect_early_trend_candidates(market):
     info_rows = ((graph.get('information_overlay') or {}).get('tickers') or {})
     events = (graph or {}).get('events') or []
     try:
-        policy = json.loads(
-            (WS / 'config' / 'add-alpha-policy.json').read_text(encoding='utf-8'))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        policy = _load_json(WS / 'config' / 'add-alpha-policy.json')
+    except Exception:  # noqa: BLE001
         policy = {}
     rows = []
     run_date = datetime.now(ZoneInfo('Asia/Hong_Kong')).date()
@@ -436,6 +435,16 @@ def collect_opportunity_radar(market):
                             'error': f'{type(exc).__name__}: {exc}'[:200]}]}
     rows = []
     run_date = datetime.now(ZoneInfo('Asia/Hong_Kong')).date()
+    # #621: thresholds come from add-alpha-policy.json like every other lane
+    # (early_no_chase_zscore / opportunity_near_pct), so radar and early-trend
+    # cannot drift apart when the config changes.
+    try:
+        radar_policy = _load_json(WS / 'config' / 'add-alpha-policy.json')
+        near_pct = float(radar_policy.get("opportunity_near_pct")
+                         or OPPORTUNITY_NEAR_PCT)
+        no_chase_z = float(radar_policy.get("early_no_chase_zscore") or 2.0)
+    except (TypeError, ValueError):
+        near_pct, no_chase_z = OPPORTUNITY_NEAR_PCT, 2.0
     for detail in universe:
         label = detail.get('label')
         try:
@@ -456,11 +465,11 @@ def collect_opportunity_radar(market):
         if close is None or prior is None or prior <= 0:
             continue
         pct_from_high = (close / prior - 1) * 100
-        if close > prior and (z is None or z < 2):
+        if close > prior and (z is None or z < no_chase_z):
             state, state_zh = 'breakout', '机会·突破'
         elif close > prior:
             state, state_zh = 'wait_rebreak', '机会·等回踩'
-        elif close >= prior * (1 - OPPORTUNITY_NEAR_PCT / 100):
+        elif close >= prior * (1 - near_pct / 100):
             state, state_zh = 'near_breakout', '机会·接近'
         else:
             continue

--- a/tests/test_brief_context_bundle.py
+++ b/tests/test_brief_context_bundle.py
@@ -178,3 +178,11 @@ def test_tampered_bundle_is_detected(tmp_path):
         tmp_path / "brief.json", Path(manifest["manifest_path"])
     )
     assert any("hash 不匹配" in issue for issue in issues)
+
+
+def test_watch_list_is_a_market_bundle_field_not_extras():
+    """#602: the AI watch list must ride the market bundle so the brief LLM
+    can read it on demand — if it ever slips back to `extras`, the feature is
+    silently silenced (a field nothing prints is a detector that has been
+    silenced, #515)."""
+    assert "watch_list" in brief_context.BUNDLE_FIELDS["market"]

--- a/tests/test_policy_key_parity.py
+++ b/tests/test_policy_key_parity.py
@@ -69,3 +69,33 @@ def test_sizing_policy_keys_all_present_in_news_evidence_config():
         "packet.py sizing_policy keys missing from news-evidence-policy.json "
         f"'sizing' section: {sorted(missing)} — editing the config cannot change them"
     )
+
+
+def test_early_trend_and_radar_policy_keys_all_present_in_config():
+    """#621: parity coverage extends beyond packet.py to the intraday lanes —
+    early_trend.classify and the opportunity radar are the direct consumers of
+    minimum_peer_count / minimum_attention_rank / early_no_chase_zscore /
+    opportunity_near_pct. A key missing from the config silently falls back to
+    a hardcoded default and editing the config does nothing."""
+    sources = {
+        "early_trend.py": (ROOT / "src" / "clawock" / "decision" / "early_trend.py"),
+        "intraday_preflight.py": (ROOT / "src" / "clawock" / "harness" / "intraday_preflight.py"),
+    }
+    used = set()
+    for name, path in sources.items():
+        keys = set(re.findall(
+            r'policy\.get\("([a-z_0-9]+)"', path.read_text(encoding="utf-8")))
+        assert keys, f"no policy.get literal keys in {name} — fixture drift"
+        used |= keys
+    config = json.loads((ROOT / "config" / "add-alpha-policy.json").read_text())
+    present = _flat_keys(config)
+    # Keys read off a per-market sub-policy (minimum_peer_count etc.) live
+    # nested under markets.* — flatten those too (the dict key itself counts).
+    present.add("markets")
+    for market, sub in (config.get("markets") or {}).items():
+        present |= _flat_keys(sub)
+    missing = used - present
+    assert not missing, (
+        "early_trend/intraday_preflight policy keys missing from "
+        f"add-alpha-policy.json: {sorted(missing)} — editing the config cannot "
+        "change them")

--- a/tests/test_quant_package_boundary.py
+++ b/tests/test_quant_package_boundary.py
@@ -39,7 +39,7 @@ def test_quant_and_regime_discover_holdings_without_kcnyu_book_keys(
     monkeypatch.setattr(quant, "PORTFOLIO", portfolio)
     monkeypatch.setattr(regime, "PORTFOLIO", portfolio)
 
-    rows = quant._universe_details()
+    rows = quant.universe_details()
 
     assert {row["label"] for row in rows} == {"RKLB", "SPCX"}
     assert regime._held_us_lev_etfs() == ["RKLX", "SPCH"]

--- a/tests/test_watch_list.py
+++ b/tests/test_watch_list.py
@@ -10,7 +10,8 @@ from clawock.decision import watch_list as W
 
 def _wire(tmp_path, monkeypatch, sig_rows):
     watch_path = tmp_path / "config" / "watch-list.json"
-    monkeypatch.setattr(W, "WATCH_LIST", watch_path)
+    monkeypatch.setattr(W, "_watch_list_path", lambda: watch_path)
+    monkeypatch.setattr(W, "_policy_near_pct", lambda: 5.0)
     watch_path.parent.mkdir(parents=True)
     watch_path.write_text(json.dumps({"tickers": list(sig_rows)}))
     metas = {
@@ -57,7 +58,8 @@ def test_collect_omits_quiet_names(tmp_path, monkeypatch):
 
 
 def test_collect_fails_soft_on_missing_config(tmp_path, monkeypatch):
-    monkeypatch.setattr(W, "WATCH_LIST", tmp_path / "config" / "watch-list.json")
+    monkeypatch.setattr(W, "_watch_list_path",
+                        lambda: tmp_path / "config" / "watch-list.json")
 
     assert W.watch_tickers() == []
     assert W.collect() == {"rows": []}
@@ -75,3 +77,52 @@ def test_strong_5d_appears_when_no_prior_high(tmp_path, monkeypatch):
 
     assert out["rows"][0]["state"] == "strong"
     assert out["rows"][0]["ret_5d"] >= 8.0
+
+
+def test_missing_instruments_entry_is_reported_not_silent(tmp_path, monkeypatch):
+    """#602: a watch-list ticker absent from instruments.json must land in
+    `errors` — a typo is not a permanent silent no-scan."""
+    watch_path = tmp_path / "config" / "watch-list.json"
+    monkeypatch.setattr(W, "_watch_list_path", lambda: watch_path)
+    monkeypatch.setattr(W, "_policy_near_pct", lambda: 5.0)
+    watch_path.parent.mkdir(parents=True)
+    watch_path.write_text(json.dumps({"tickers": ["02513", "TYP0"]}))
+    monkeypatch.setattr(
+        W, "get_instrument",
+        lambda t: {"name": "智谱", "tencent_symbol": "hk02513"}
+        if t == "02513" else {})
+    monkeypatch.setattr(W.quant_signals, "fetch_bars", lambda code, cnt: [])
+    monkeypatch.setattr(W.quant_signals, "compute_signals", lambda bars: None)
+
+    out = W.collect()
+
+    assert any(e["ticker"] == "TYP0" for e in out.get("errors", []))
+    assert [r["ticker"] for r in out["rows"]] == []
+
+
+def test_completed_bars_filter_drops_the_open_bar(tmp_path, monkeypatch):
+    """#621: "on completed bars" is enforced — a still-open bar (dated after
+    the latest completed session) must not reach the signal computation."""
+    watch_path = tmp_path / "config" / "watch-list.json"
+    monkeypatch.setattr(W, "_watch_list_path", lambda: watch_path)
+    monkeypatch.setattr(W, "_policy_near_pct", lambda: 5.0)
+    watch_path.parent.mkdir(parents=True)
+    watch_path.write_text(json.dumps({"tickers": ["02513"]}))
+    monkeypatch.setattr(
+        W, "get_instrument",
+        lambda t: {"name": "智谱", "tencent_symbol": "hk02513", "region": "HK"})
+    monkeypatch.setattr(
+        W.quant_signals, "fetch_bars",
+        lambda code, cnt: [{"date": "2020-01-02", "close": 10.0},
+                           {"date": "2099-01-01", "close": 11.0}])
+    seen = {}
+
+    def spy_compute(bars):
+        seen["dates"] = sorted(b.get("date") for b in bars)
+        return None
+
+    monkeypatch.setattr(W.quant_signals, "compute_signals", spy_compute)
+
+    W.collect()
+
+    assert seen["dates"] == ["2020-01-02"], seen


### PR DESCRIPTION
## watch-list/风格组（#602 #620 #621）

| Issue | 改动 |
|---|---|
| #602 | watch_list 数据打通 LLM 边界：挂进 `market` bundle（此前落 `extras` 被 SKILL 隔离，功能空转）；SKILL 补读取指令 + 「观察池绝不产生 add 授权」红线；缺 instruments 条目的 ticker 进 `errors` 字段（拼错=可见，不再永久静默）；pre-commit 新增 watch-list↔instruments 交叉校验（漏注册直接提交失败）；bundle 回归测试钉死 `watch_list ∈ market` |
| #620 | 风格统一：`universe_details` 公开化（删 `_universe_details` 别名，内部调用全改）；watch_list 路径解析移入函数（import 不再依赖 cwd）；JSON 读取统一走 `load_json_cached` 包装的 `_load_json`（early-trend/radar 的 add-alpha-policy 手写第三套 try/except 删除）；signals/intraday_delta/plans/watch_list import 顺序修正 |
| #621 | 阈值收敛：radar 的 `OPPORTUNITY_NEAR_PCT` 与 watch_list 的 `NEAR_HIGH_PCT` 统一读 `add-alpha-policy.json` 新增的 `opportunity_near_pct`（单一真源）；radar 硬编码 `z < 2` 改读 `early_no_chase_zscore`；watch_list 落实 docstring 声称的「completed bars」过滤（未收盘 bar 不再当完整日 K）；policy parity 测试扩展到 early_trend.py + intraday_preflight.py（含 markets.* 嵌套 key）；补 watch_list 缺 instruments / completed-bars 测试 |

## 验证

- 33 项定向测试通过；全量套件运行中（CI 为准）
- pre-commit 校验用手工验证（staged 一个假 ticker 应失败）

## 数据缺口声明

`opportunity_near_pct` 是新增配置键（默认 5.0），与旧行为一致；改它时 radar 与 watch_list 同步生效。
