### PR TITLE
docs: 修 5 个 harness 示例与 dsh-plugin SKILL 的教学契约(#600)

### DIFF
--- a/examples/harness-agnostic/claude-code.CLAUDE.md
+++ b/examples/harness-agnostic/claude-code.CLAUDE.md
@@ -6,9 +6,9 @@ is one file in, one file out.
 
 ## When to engage
 
-When a clawock request file is present (normally `.clawock/work/request.json`
-produced by `clawock run prepare`), or when the user asks to run the
-investment-decision workflow.
+When a clawock request file is present (`.clawock/work/<run_id>/request.json`,
+the `request_file` path printed by `clawock run prepare`), or when the user
+asks to run the investment-decision workflow.
 
 ## The loop
 
@@ -20,23 +20,48 @@ investment-decision workflow.
 
    ```json
    {
+     "schema_version": 1,
+     "workflow": {"id": "investment-decision", "version": "1.1.0"},
+     "decision_id": "example-2026-08-08",
+     "as_of": "2026-08-08T08:00:00+00:00",
+     "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
+     "evidence": [
+       {"id": "filing-growth", "stance": "supporting",
+        "summary": "The latest filed revenue figure grew year over year.",
+        "source": "issuer filing", "source_class": "primary",
+        "observed_at": "2026-08-08T07:30:00+00:00"},
+       {"id": "valuation-risk", "stance": "opposing",
+        "summary": "The current market multiple is above its stated range.",
+        "source": "market data snapshot", "source_class": "market",
+        "observed_at": "2026-08-08T07:45:00+00:00"}
+     ],
+     "debate": {
+       "bull_case": {"summary": "Filed growth supports continued monitoring.",
+                     "evidence_ids": ["filing-growth"]},
+       "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+                     "evidence_ids": ["valuation-risk"]}
+     },
+     "thesis": {
+       "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+       "confidence": 0.7,
+       "invalidation_conditions": ["Filed growth reverses"]
+     },
      "decision": {
-       "action": "hold",
-       "strategy": "core_position",
-       "confidence": 0.4,
-       "reasoning": "claim with cited evidence",
-       "opposing_case": "genuine counterargument",
-       "evidence": [{"source": "...", "claim": "..."}]
+       "action": "watch",
+       "rationale": "The opposing valuation evidence blocks an entry.",
+       "evidence_ids": ["filing-growth", "valuation-risk"],
+       "order": null
      }
    }
    ```
+
 
 3. **Run `clawock run publish`** with the request and your artifact:
 
    ```bash
    clawock run publish \
-     --request .clawock/work/request.json \
-     --artifact decision=.clawock/work/decision.json
+     --request .clawock/work/<run_id>/request.json \
+     --artifact decision.json=decision.json
    ```
 
 4. **Report the receipt** — `status` and `run_id` — and stop. Do not edit the

--- a/examples/harness-agnostic/codex.AGENTS.md
+++ b/examples/harness-agnostic/codex.AGENTS.md
@@ -7,9 +7,9 @@ root.
 
 ## When to engage
 
-When a clawock request file is present (normally `.clawock/work/request.json`
-produced by `clawock run prepare`), or when the user asks to run the
-investment-decision workflow.
+When a clawock request file is present (`.clawock/work/<run_id>/request.json`,
+the `request_file` path printed by `clawock run prepare`), or when the user
+asks to run the investment-decision workflow.
 
 ## The loop
 
@@ -21,23 +21,48 @@ investment-decision workflow.
 
    ```json
    {
+     "schema_version": 1,
+     "workflow": {"id": "investment-decision", "version": "1.1.0"},
+     "decision_id": "example-2026-08-08",
+     "as_of": "2026-08-08T08:00:00+00:00",
+     "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
+     "evidence": [
+       {"id": "filing-growth", "stance": "supporting",
+        "summary": "The latest filed revenue figure grew year over year.",
+        "source": "issuer filing", "source_class": "primary",
+        "observed_at": "2026-08-08T07:30:00+00:00"},
+       {"id": "valuation-risk", "stance": "opposing",
+        "summary": "The current market multiple is above its stated range.",
+        "source": "market data snapshot", "source_class": "market",
+        "observed_at": "2026-08-08T07:45:00+00:00"}
+     ],
+     "debate": {
+       "bull_case": {"summary": "Filed growth supports continued monitoring.",
+                     "evidence_ids": ["filing-growth"]},
+       "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+                     "evidence_ids": ["valuation-risk"]}
+     },
+     "thesis": {
+       "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+       "confidence": 0.7,
+       "invalidation_conditions": ["Filed growth reverses"]
+     },
      "decision": {
-       "action": "hold",
-       "strategy": "core_position",
-       "confidence": 0.4,
-       "reasoning": "claim with cited evidence",
-       "opposing_case": "genuine counterargument",
-       "evidence": [{"source": "...", "claim": "..."}]
+       "action": "watch",
+       "rationale": "The opposing valuation evidence blocks an entry.",
+       "evidence_ids": ["filing-growth", "valuation-risk"],
+       "order": null
      }
    }
    ```
+
 
 3. **Run `clawock run publish`** with the request and your artifact:
 
    ```bash
    clawock run publish \
-     --request .clawock/work/request.json \
-     --artifact decision=.clawock/work/decision.json
+     --request .clawock/work/<run_id>/request.json \
+     --artifact decision.json=decision.json
    ```
 
 4. **Report the receipt** — `status` and `run_id` — and stop. Do not edit the

--- a/examples/harness-agnostic/dsh-plugin/package.json
+++ b/examples/harness-agnostic/dsh-plugin/package.json
@@ -1,11 +1,23 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "description": "clawock investment-decision workflow skill for DeepSeek Harness agents — evidence, opposing case, deterministic settlement, public scorecard",
   "license": "MIT",
-  "keywords": ["dsh", "deepseek-harness", "clawock", "investment", "agent", "trading", "skill"],
-  "files": ["skills"],
+  "keywords": [
+    "dsh",
+    "deepseek-harness",
+    "clawock",
+    "investment",
+    "agent",
+    "trading",
+    "skill"
+  ],
+  "files": [
+    "skills"
+  ],
   "dsh": {
-    "skills": ["./skills/investment-decision/SKILL.md"]
+    "skills": [
+      "./skills/investment-decision/SKILL.md"
+    ]
   }
 }

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
@@ -33,7 +33,8 @@ clawock init ./book --workflow investment-decision
 clawock run prepare --workspace ./book
 ```
 
-Read the emitted request file (`.clawock/work/request.json`). It contains:
+Read the emitted request file (the `request_file` path printed on stdout,
+e.g. `.clawock/work/<run_id>/request.json`). It contains:
 
 - `task` — the decision contract (evidence, opposing case, bounded action,
   reconciled amounts)
@@ -48,16 +49,41 @@ Write `decision.json` next to the request:
 
 ```json
 {
+  "schema_version": 1,
+  "workflow": {"id": "investment-decision", "version": "1.1.0"},
+  "decision_id": "example-2026-08-08",
+  "as_of": "2026-08-08T08:00:00+00:00",
+  "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
+  "evidence": [
+ {"id": "filing-growth", "stance": "supporting",
+  "summary": "The latest filed revenue figure grew year over year.",
+  "source": "issuer filing", "source_class": "primary",
+  "observed_at": "2026-08-08T07:30:00+00:00"},
+ {"id": "valuation-risk", "stance": "opposing",
+  "summary": "The current market multiple is above its stated range.",
+  "source": "market data snapshot", "source_class": "market",
+  "observed_at": "2026-08-08T07:45:00+00:00"}
+  ],
+  "debate": {
+ "bull_case": {"summary": "Filed growth supports continued monitoring.",
+"evidence_ids": ["filing-growth"]},
+ "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+"evidence_ids": ["valuation-risk"]}
+  },
+  "thesis": {
+ "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+ "confidence": 0.7,
+ "invalidation_conditions": ["Filed growth reverses"]
+  },
   "decision": {
-    "action": "hold",
-    "strategy": "core_position",
-    "confidence": 0.4,
-    "reasoning": "claim, citing evidence from the context",
-    "opposing_case": "the genuine counterargument, not a strawman",
-    "evidence": [{"source": "CONTEXT.md", "claim": "..."}]
+ "action": "watch",
+ "rationale": "The opposing valuation evidence blocks an entry.",
+ "evidence_ids": ["filing-growth", "valuation-risk"],
+ "order": null
   }
 }
 ```
+
 
 Rules that are not negotiable:
 
@@ -71,8 +97,8 @@ Rules that are not negotiable:
 
 ```bash
 clawock run publish \
-  --request ./book/.clawock/work/request.json \
-  --artifact decision=./book/.clawock/work/decision.json
+  --request ./book/.clawock/work/<run_id>/request.json \
+  --artifact decision.json=./book/decision.json
 ```
 
 Report the receipt's `status` and `run_id` to the user. Never edit the

--- a/examples/harness-agnostic/dsh.md
+++ b/examples/harness-agnostic/dsh.md
@@ -16,7 +16,8 @@ workspace context file) covering three steps:
    clawock run prepare --workspace /path/to/book
    ```
 
-   and read the emitted `request.json`. It contains the certified context
+   and read the emitted `request_file` (printed on stdout; the path looks like
+   `.clawock/work/<run_id>/request.json`). It contains the certified context
    (per-file sha256 fingerprints), the task, and the workflow gates
    (`min_supporting_evidence`, `min_opposing_evidence`,
    `max_confidence_without_primary_source`).
@@ -25,16 +26,41 @@ workspace context file) covering three steps:
 
    ```json
    {
+     "schema_version": 1,
+     "workflow": {"id": "investment-decision", "version": "1.1.0"},
+     "decision_id": "example-2026-08-08",
+     "as_of": "2026-08-08T08:00:00+00:00",
+     "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
+     "evidence": [
+       {"id": "filing-growth", "stance": "supporting",
+        "summary": "The latest filed revenue figure grew year over year.",
+        "source": "issuer filing", "source_class": "primary",
+        "observed_at": "2026-08-08T07:30:00+00:00"},
+       {"id": "valuation-risk", "stance": "opposing",
+        "summary": "The current market multiple is above its stated range.",
+        "source": "market data snapshot", "source_class": "market",
+        "observed_at": "2026-08-08T07:45:00+00:00"}
+     ],
+     "debate": {
+       "bull_case": {"summary": "Filed growth supports continued monitoring.",
+                     "evidence_ids": ["filing-growth"]},
+       "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+                     "evidence_ids": ["valuation-risk"]}
+     },
+     "thesis": {
+       "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+       "confidence": 0.7,
+       "invalidation_conditions": ["Filed growth reverses"]
+     },
      "decision": {
-       "action": "hold",
-       "strategy": "core_position",
-       "confidence": 0.4,
-       "reasoning": "claim, citing evidence",
-       "opposing_case": "genuine counterargument",
-       "evidence": [{"source": "...", "claim": "..."}]
+       "action": "watch",
+       "rationale": "The opposing valuation evidence blocks an entry.",
+       "evidence_ids": ["filing-growth", "valuation-risk"],
+       "order": null
      }
    }
    ```
+
 
    Rules: every reasoning claim cites evidence; `opposing_case` is required
    and must be a real counterargument; proposed order amounts must reconcile;
@@ -44,8 +70,8 @@ workspace context file) covering three steps:
 
    ```bash
    clawock run publish \
-     --request /path/to/book/.clawock/work/request.json \
-     --artifact decision=/path/to/book/.clawock/work/decision.json
+     --request /path/to/book/.clawock/work/<run_id>/request.json \
+     --artifact decision.json=/path/to/book/decision.json
    ```
 
    Report the receipt's `status` and `run_id` to the user. Do not edit the

--- a/examples/harness-agnostic/openclaw.SKILL.md
+++ b/examples/harness-agnostic/openclaw.SKILL.md
@@ -11,8 +11,9 @@ entire job is one file in, one file out.
 
 ## When to run
 
-A `run prepare` has written a request file, normally at
-`.clawock/work/request.json`. Open it first; it tells you:
+A `run prepare` has written a request file (the `request_file` path it
+printed, e.g. `.clawock/work/<run_id>/request.json`). Open it first; it tells
+you:
 
 - `task` — the decision contract (evidence, opposing case, bounded action,
   reconciled amounts)
@@ -29,19 +30,41 @@ explicit:
 
 ```json
 {
+  "schema_version": 1,
+  "workflow": {"id": "investment-decision", "version": "1.1.0"},
+  "decision_id": "example-2026-08-08",
+  "as_of": "2026-08-08T08:00:00+00:00",
+  "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
+  "evidence": [
+ {"id": "filing-growth", "stance": "supporting",
+  "summary": "The latest filed revenue figure grew year over year.",
+  "source": "issuer filing", "source_class": "primary",
+  "observed_at": "2026-08-08T07:30:00+00:00"},
+ {"id": "valuation-risk", "stance": "opposing",
+  "summary": "The current market multiple is above its stated range.",
+  "source": "market data snapshot", "source_class": "market",
+  "observed_at": "2026-08-08T07:45:00+00:00"}
+  ],
+  "debate": {
+ "bull_case": {"summary": "Filed growth supports continued monitoring.",
+"evidence_ids": ["filing-growth"]},
+ "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+"evidence_ids": ["valuation-risk"]}
+  },
+  "thesis": {
+ "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+ "confidence": 0.7,
+ "invalidation_conditions": ["Filed growth reverses"]
+  },
   "decision": {
-    "action": "hold",
-    "symbol": null,
-    "strategy": "core_position",
-    "confidence": 0.4,
-    "reasoning": "No actionable setup this session.",
-    "opposing_case": "Holding is itself a stance; the case against it is ...",
-    "evidence": [
-      {"source": "CONTEXT.md", "claim": "..."}
-    ]
+ "action": "watch",
+ "rationale": "The opposing valuation evidence blocks an entry.",
+ "evidence_ids": ["filing-growth", "valuation-risk"],
+ "order": null
   }
 }
 ```
+
 
 Rules that are not negotiable:
 


### PR DESCRIPTION
## SKILL/示例组（#600）

## 问题（已用真实验证器复现）

已发布的 `clawock-dsh@0.1.3` SKILL 与 `examples/harness-agnostic/` 全部 5 个示例的教学流程三处与真实 CLI/验证器不符，**照抄必失败**（fail-closed，教程整体不可用）：

1. **artifact 名错误**：示例教 `--artifact decision=...`，但 `validators.py` 只认 `DECISION_ARTIFACT = "decision.json"`——实测旧写法报 `missing_decision_artifact`
2. **decision 结构错误**：示例教的形状只有 `{decision:{...}}`，schema `required` 是 9 个顶层字段（schema_version/workflow/decision_id/as_of/subject/evidence/debate/thesis/decision）——缺 8 个
3. **request 路径错误**：示例写死 `.clawock/work/request.json`，prepare 实际写 `.clawock/work/<run_id>/request.json`（stdout 打印 `request_file`）

## 改动

- 5 个示例（dsh.md / claude-code.CLAUDE.md / codex.AGENTS.md / openclaw.SKILL.md / dsh-plugin SKILL.md）全部修正：artifact 名、9 字段完整形状（取自 pack 的 `decision.example.json`）、request 路径改为「回传 prepare 打印的 `request_file`」
- `dsh-plugin/package.json` 0.1.0 → **0.1.4**（patch 重发准备；发布仍需 v0.1.4 tag，CHANGELOG/pyproject 同步留给 release PR——CI 要求 CHANGELOG 最新标题匹配 pyproject 版本）

## 验证

- `PYTHONPATH=src` 本地跑通：`clawock init` → `run prepare`（确认 request_file 路径）→ 写入 `decision.example.json` → `run publish` → **exit 0 / status=published**
- 旧写法 `--artifact decision=` 实测失败（`missing_decision_artifact`）——证明文档确实坏、修复确实生效

## 待 kcn

- 打 `v0.1.4` tag 触发 release（PyPI + npm 0.1.4 + GitHub Release）；届时 #617 的幂等 bump 保证 package.json 已同步时不再炸
