### PR TITLE
fix: 报告 watchdog 显式告警 holder-died-mid-send 的 WeChat 缺口(#544)

### DIFF
--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -119,6 +119,23 @@ def slot_delivered(marker, ctx_id, raw_block_first, now_ms, ctx_generated_at=Non
     return same_line, 'legacy-first-line'
 
 
+def wechat_gap_reason(claim):
+    """#544: name a holder-died-mid-send WeChat gap explicitly.
+
+    A sender killed between the WeChat send and the Telegram cosend leaves a
+    claim with `send_started_at` set and no completion marker — the one case
+    where "WeChat delivery unconfirmed" is a fact, not a guess. The Telegram
+    backstop must say that out loud instead of reading like a normal mirror.
+    Returns (reason, banner) or None when the claim does not show the gap.
+    """
+    if isinstance(claim, dict) and claim.get('send_started_at'):
+        return ('holder-died-mid-send',
+                '⚠️ 该槽位 WeChat 送达未被确认：postflight 发送进程在发送中途死亡'
+                '（claim 带 send_started_at、无完成 marker）。'
+                '仅 Telegram 兜底一份，请留意微信是否已收到。\n\n')
+    return None
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--market', choices=['hk', 'us'], required=True)
@@ -241,7 +258,22 @@ def main():
     reason = ('postflight marker missing' if not marker
               else 'postflight cosend failed' if not marker.get('tg_ok')
               else 'marker stale/mismatch')
-    tg_banner = f'📨 自动补发（{reason}，Telegram 兜底一份）\n\n'
+    # #544: with no marker, a claim whose holder died mid-send is the explicit
+    # "WeChat delivery unconfirmed" case — say it instead of silently mirroring.
+    claim_path = WS / 'memory' / '.tmp' / \
+        f'report-send-{args.market}-{args.phase}-{today}.claim'
+    claim = None
+    try:
+        if claim_path.exists():
+            claim = json.loads(claim_path.read_text())
+    except Exception:
+        claim = None
+    gap = wechat_gap_reason(claim) if not marker else None
+    if gap:
+        reason = gap[0]
+        tg_banner = gap[1]
+    else:
+        tg_banner = f'📨 自动补发（{reason}，Telegram 兜底一份）\n\n'
     tg_ok, tg_out = send_telegram(KCN_TELEGRAM, tg_banner + report.strip(), args.dry_run)
     log({'tag': tag, 'action': 'mirror-telegram', 'dry_run': args.dry_run, 'sent_ok': tg_ok,
          'job_id': job_id, 'reason': reason, 'loop_score': loop_score,

--- a/tests/test_report_watchdog_retry_parity.py
+++ b/tests/test_report_watchdog_retry_parity.py
@@ -100,3 +100,31 @@ def test_postflight_records_the_source_context_timestamp(tmp_path, monkeypatch):
     marker = json.loads((tmp_path / 'report-sent-hk-pm-2026-08-03.json').read_text())
     assert marker['context_generated_at'] == '2026-08-03T13:30:24.100000'
     assert marker['context_id'] == 'af4310c68bbf'
+
+
+def test_holder_died_mid_send_is_named_explicitly():
+    """#544: a claim left by a sender killed mid-send (send_started_at set, no
+    completion marker) must produce an explicit 'WeChat 送达未被确认' alert —
+    the acceptance is that kcn is told, not that the Telegram mirror silently
+    reads like a normal message."""
+    from clawock.harness import report_watchdog as watchdog
+
+    gap = watchdog.wechat_gap_reason(
+        {'pid': 872161, 'ts': 1786685531697, 'send_started_at': 1786685531697})
+
+    assert gap is not None
+    reason, banner = gap
+    assert reason == 'holder-died-mid-send'
+    assert 'WeChat 送达未被确认' in banner
+    assert 'Telegram 兜底' in banner
+
+
+def test_claim_without_send_start_is_not_a_gap():
+    """A claim whose holder never started sending is not 'mid-send' — the slot
+    stays a normal missing-marker mirror."""
+    from clawock.harness import report_watchdog as watchdog
+
+    assert watchdog.wechat_gap_reason(
+        {'pid': 872161, 'ts': 1786685531697, 'send_started_at': None}) is None
+    assert watchdog.wechat_gap_reason(None) is None
+    assert watchdog.wechat_gap_reason({}) is None


### PR DESCRIPTION
## 报告投递缺口（#544）

## 问题（2026-08-14 港股午后 13:30 槽位实测）

postflight 的 claim holder（pid 872161）在 `deliver_wechat` 发送中途死亡：claim 存在（`send_started_at` 已置位）但 `report-sent-hk-pm-*.json` 完成 marker 不存在。watchdog 只把数据块镜像到 Telegram——用户收到一条看起来普通的补发消息，**不知道微信大概率没收到**。同类 "Exec failed → 无 marker → 静默缺失" 已在 08-10×2 / 08-11 / 08-14 复发。

## 改动

`report_watchdog.py`：marker 缺失时检查 claim——`send_started_at` 已置位 = 发送中途死亡，Telegram 兜底横幅改为**显式告警**：

> ⚠️ 该槽位 WeChat 送达未被确认：postflight 发送进程在发送中途死亡（claim 带 send_started_at、无完成 marker）。仅 Telegram 兜底一份，请留意微信是否已收到。

- 不重发微信（尊重 2026-07-09 决策，撞双发）
- 健康槽位零变化（有 marker 时照旧由 marker 判定；claim 无 `send_started_at` 不算 gap）
- SKILL 侧约束已在 #558 落地（daily-deep-brief SKILL 铁律：postflight 之后禁止读 `.tmp` marker/claim 确认送达，违例形态正是本 issue 的触发层）

## 验证

- 新增测试：holder-died-mid-send → 显式告警文案；无 send_started_at / 无 claim → 普通 mirror
- 既有 4 个 retry-parity 测试保持通过（不破坏 #508 双发防护语义）
