### PR TITLE
feat: cron 模型链追加 OpenCode Go deepseek-v4-flash 兜底

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -17,11 +17,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/report.md",
@@ -65,11 +67,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
@@ -126,11 +130,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3"
+        "minimax-2/MiniMax-M3",
+        "opencode-go/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/brief.md",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -532,30 +532,33 @@ def test_strategy_cron_provider_order_is_fixed_policy():
     } == {
         'report': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
+                'opencode-go/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],
         },
         'intraday': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
+                'opencode-go/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],
         },
         'brief': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
+                'opencode-go/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],


### PR DESCRIPTION
## 变更

cron 市场任务的模型兜底链追加 **OpenCode Go 套餐**（`opencode-go/deepseek-v4-flash`）：

- `config/cron-schedules.json`：3 个 payload profile（report / intraday / brief）的 `fallbacks` 从 `[minimax-2/MiniMax-M3]` 扩展为 `[minimax-2/MiniMax-M3, opencode-go/deepseek-v4-flash]`；`model_candidates` 同步追加（保持 rotation 为 candidates 固定前缀的契约约束）。
- `tests/test_cron_contracts.py`：`test_strategy_cron_provider_order_is_fixed_policy` 固定策略预期随契约更新（这是有意的策略变更：MiniMax 双条目重试后由 OpenCode Go 套餐兜底，套餐按量走 `https://opencode.ai/zen/go/v1`）。

## 运行时同步

live cron 任务（sqlite）已通过 `openclaw cron edit --fallbacks` 同步为同一链，本 PR 只落契约与测试。

## 验证

- `tests/test_cron_contracts.py` 31 个测试全部通过（含更新后的固定策略测试）
- `tests/test_sync_cron_payloads.py` 2 个失败为预存在的本机环境问题（OPENCLAW_BIN 解析为 pnpm 绝对路径），在干净 origin/master 上同样失败，与本次改动无关
