### PR TITLE
docs: harness 示例契约自洽 + clawock-dsh 接线修正与体验升级(#646)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ required check instead of quietly rotting into documentation.
 |---|---|
 | [`minimal-run/`](minimal-run/) | a clean virtualenv installs the wheel and finishes one complete run — `init` → `run prepare` → `run publish` — with no checkout, no Git, no OpenClaw and an emptied environment |
 | [`harness-agnostic/`](harness-agnostic/) | one decision run driven from five harnesses — pure CLI, OpenClaw skill, Claude Code instruction, Codex AGENTS.md, DeepSeek Harness agent — with the same files-and-CLI contract throughout |
-| [`profiles/`](profiles/) | a second desk can select markets, workflows, resources, policy, presentation and delivery declaratively, without a Python instance package |
+| [`profiles/`](profiles/) | a second desk can select markets, workflows, resources, policy, presentation and delivery declaratively, without a Python instance package. Note: this is the harness *profile* surface (e.g. the `intraday` desk workflow) — distinct from the portable decision-workflow contract in `harness-agnostic/`, which is pinned per workspace with `--workflow investment-decision` |
 
 ## Why they are files and not workflow steps
 

--- a/examples/harness-agnostic/README.md
+++ b/examples/harness-agnostic/README.md
@@ -21,6 +21,38 @@ request, writes a decision, and lets Python validate. Swap OpenClaw for
 Codex, or Codex for DeepSeek Harness, tomorrow and `decision.json` looks the
 same.
 
+## From zero to a published decision
+
+Every harness file below assumes a prepared workspace already exists. One
+time per workspace, create it with the workflow pinned — that flag is what
+turns `decision.json` into the enforced contract (without it, publish checks
+nothing workflow-specific):
+
+```bash
+python -m pip install clawock
+clawock init book --workflow investment-decision
+```
+
+Then each run is three steps: `clawock run prepare --workspace book`, write
+`decision.json` at the **workspace root** (artifact paths are resolved
+against the workspace root, not the request directory — `decision.json=decision.json`
+means `<workspace>/decision.json`; the shape is in any harness file below),
+and
+
+```bash
+clawock run publish \
+  --workspace book \
+  --request book/.clawock/work/<run_id>/request.json \
+  --artifact decision.json=book/decision.json
+```
+
+`run_id` is printed by `run prepare` (the `request_file` path). The full
+contract — including money/FX reconciliation and reported failure repair —
+is described in the package's installed skill
+(`clawock workflow install investment-decision --workspace book`, then read
+`book/.agents/skills/investment-decision/references/decision-contract.md`)
+and enforced by `clawock run publish` itself.
+
 ## Running the pure-CLI proof
 
 ```bash
@@ -28,4 +60,6 @@ bash examples/harness-agnostic/run.sh
 ```
 
 Same isolation discipline as `minimal-run`: clean virtualenv, emptied
-environment, no checkout, no Git, no model.
+environment, no checkout, no Git, no model. The pure-CLI script intentionally
+publishes a stand-in `answer` artifact without a pinned workflow — it proves
+the loop, not the contract; the five harness files above prove the contract.

--- a/examples/harness-agnostic/README.md
+++ b/examples/harness-agnostic/README.md
@@ -10,7 +10,7 @@ clawock run prepare ──► request.json ──► [your agent, any harness] �
 
 | harness | how the agent participates | file |
 |---|---|---|
-| None (pure CLI) | a literal stands in for the agent; proves the whole loop with no model | [`run.sh`](run.sh) |
+| None (pure CLI) | a literal stands in for the agent; proves the whole loop with no model and no pinned workflow | [`run.sh`](run.sh) |
 | OpenClaw | a SKILL.md tells the agent to read `request.json` and write `decision.json` | [`openclaw.SKILL.md`](openclaw.SKILL.md) |
 | Claude Code | a CLAUDE.md instruction block, loaded per workspace | [`claude-code.CLAUDE.md`](claude-code.CLAUDE.md) |
 | Codex | an AGENTS.md instruction block, auto-loaded from the workspace root | [`codex.AGENTS.md`](codex.AGENTS.md) |
@@ -46,9 +46,19 @@ clawock run publish \
   --artifact decision.json=book/decision.json
 ```
 
-`run_id` is printed by `run prepare` (the `request_file` path). The full
-contract — including money/FX reconciliation and reported failure repair —
-is described in the package's installed skill
+`run_id` is printed by `run prepare` (the `request_file` path). The default
+gates are `min_supporting_evidence: 1`, `min_opposing_evidence: 1`,
+`max_confidence_without_primary_source: 0.65`; introspect the exact artifact
+shape any time with `clawock workflow schema investment-decision decision.json`.
+
+**If publish rejects**, the receipt lists `validation_issues` with `code` and
+`message` — repair only the named issue and retry against the **same**
+prepared request; re-run `prepare` only if the context or workflow
+certificate changed. The only artifact allowed when the workflow is pinned is
+`decision.json`.
+
+The full contract — including money/FX reconciliation and reported failure
+repair — is described in the package's installed skill
 (`clawock workflow install investment-decision --workspace book`, then read
 `book/.agents/skills/investment-decision/references/decision-contract.md`)
 and enforced by `clawock run publish` itself.

--- a/examples/harness-agnostic/claude-code.CLAUDE.md
+++ b/examples/harness-agnostic/claude-code.CLAUDE.md
@@ -8,7 +8,9 @@ is one file in, one file out.
 
 When a clawock request file is present (`.clawock/work/<run_id>/request.json`,
 the `request_file` path printed by `clawock run prepare`), or when the user
-asks to run the investment-decision workflow.
+asks to run the investment-decision workflow. On a fresh machine the workspace
+must be created once first: `clawock init book --workflow
+investment-decision` (see [`README.md`](README.md) — "From zero").
 
 ## The loop
 
@@ -16,7 +18,8 @@ asks to run the investment-decision workflow.
    (with sha256 fingerprints), the `task`, and `workflow.parameters`
    (evidence and opposing-case minimums, confidence cap without a primary
    source).
-2. **Write `decision.json`** next to the request. Minimal shape:
+2. **Write `decision.json`** at the workspace root (artifact paths resolve
+   against the workspace root, not the request directory). Minimal shape:
 
    ```json
    {
@@ -68,9 +71,15 @@ asks to run the investment-decision workflow.
    receipt, do not re-grade the decision, do not "improve" the artifact after
    publish; Python settles.
 
-## Non-negotiables
+## Non-negotiables (enforced by `clawock run publish`)
 
-- Every claim in `reasoning` cites an item in `evidence`.
-- `opposing_case` must be a real counterargument; publish fails without one.
-- Order amounts must reconcile; never invent prices, FX or sizes.
-- Confidence above the workflow cap requires a primary source in `evidence`.
+- `debate.bull_case` and `debate.bear_case` are both required; the bear case
+  must be a genuine counterargument and must cite opposing-stance evidence —
+  publish fails without it.
+- Every `evidence` row needs `stance`, `source_class` and an `observed_at` no
+  later than `as_of`.
+- All `evidence_ids` references must exist; conclusions in
+  `thesis.statement` and `decision.rationale` should be backed by cited
+  evidence.
+- Order amounts must reconcile to the cent; never invent prices, FX or sizes.
+- Confidence above the workflow cap requires a cited primary source.

--- a/examples/harness-agnostic/claude-code.CLAUDE.md
+++ b/examples/harness-agnostic/claude-code.CLAUDE.md
@@ -73,9 +73,10 @@ investment-decision` (see [`README.md`](README.md) — "From zero").
 
 ## Non-negotiables (enforced by `clawock run publish`)
 
-- `debate.bull_case` and `debate.bear_case` are both required; the bear case
-  must be a genuine counterargument and must cite opposing-stance evidence —
-  publish fails without it.
+- `debate.bull_case` and `debate.bear_case` are both required and each cites
+  its evidence; the bear case must cite opposing-stance evidence — publish
+  fails without it. Python checks that linkage, not sincerity: make the bear
+  case a genuine counterargument — that honesty is yours.
 - Every `evidence` row needs `stance`, `source_class` and an `observed_at` no
   later than `as_of`.
 - All `evidence_ids` references must exist; conclusions in

--- a/examples/harness-agnostic/codex.AGENTS.md
+++ b/examples/harness-agnostic/codex.AGENTS.md
@@ -9,7 +9,9 @@ root.
 
 When a clawock request file is present (`.clawock/work/<run_id>/request.json`,
 the `request_file` path printed by `clawock run prepare`), or when the user
-asks to run the investment-decision workflow.
+asks to run the investment-decision workflow. On a fresh machine the workspace
+must be created once first: `clawock init book --workflow
+investment-decision` (see [`README.md`](README.md) — "From zero").
 
 ## The loop
 
@@ -17,7 +19,8 @@ asks to run the investment-decision workflow.
    (with per-file sha256 fingerprints), the `task`, and `workflow.parameters`
    (evidence and opposing-case minimums, confidence cap without a primary
    source).
-2. **Write `decision.json`** next to the request. Minimal shape:
+2. **Write `decision.json`** at the workspace root (artifact paths resolve
+   against the workspace root, not the request directory). Minimal shape:
 
    ```json
    {
@@ -69,12 +72,18 @@ asks to run the investment-decision workflow.
    receipt, do not re-grade the decision, do not "improve" the artifact after
    publish; Python settles.
 
-## Non-negotiables
+## Non-negotiables (enforced by `clawock run publish`)
 
-- Every claim in `reasoning` cites an item in `evidence`.
-- `opposing_case` must be a real counterargument; publish fails without one.
-- Order amounts must reconcile; never invent prices, FX or sizes.
-- Confidence above the workflow cap requires a primary source in `evidence`.
+- `debate.bull_case` and `debate.bear_case` are both required; the bear case
+  must be a genuine counterargument and must cite opposing-stance evidence —
+  publish fails without it.
+- Every `evidence` row needs `stance`, `source_class` and an `observed_at` no
+  later than `as_of`.
+- All `evidence_ids` references must exist; conclusions in
+  `thesis.statement` and `decision.rationale` should be backed by cited
+  evidence.
+- Order amounts must reconcile to the cent; never invent prices, FX or sizes.
+- Confidence above the workflow cap requires a cited primary source.
 
 ## Why this file exists
 

--- a/examples/harness-agnostic/codex.AGENTS.md
+++ b/examples/harness-agnostic/codex.AGENTS.md
@@ -74,9 +74,10 @@ investment-decision` (see [`README.md`](README.md) — "From zero").
 
 ## Non-negotiables (enforced by `clawock run publish`)
 
-- `debate.bull_case` and `debate.bear_case` are both required; the bear case
-  must be a genuine counterargument and must cite opposing-stance evidence —
-  publish fails without it.
+- `debate.bull_case` and `debate.bear_case` are both required and each cites
+  its evidence; the bear case must cite opposing-stance evidence — publish
+  fails without it. Python checks that linkage, not sincerity: make the bear
+  case a genuine counterargument — that honesty is yours.
 - Every `evidence` row needs `stance`, `source_class` and an `observed_at` no
   later than `as_of`.
 - All `evidence_ids` references must exist; conclusions in

--- a/examples/harness-agnostic/dsh-plugin/README.md
+++ b/examples/harness-agnostic/dsh-plugin/README.md
@@ -1,16 +1,35 @@
 # clawock-dsh
 
-clawock 的 DeepSeek Harness 插件:一个纯 skill 包,把 investment-decision
+clawock 的 DeepSeek Harness 插件:一个 skill 包,把 investment-decision
 决策工作流注入 DSH agent。零 Node 代码——clawock 是 Python CLI,skill
-只负责告诉 agent 怎么走「读请求 → 写决策 → Python 校验」三步。
+只负责告诉 agent 怎么走「读请求 → 研究 + 正反辩论 → 写决策 → Python
+校验结算」四步。
 
-## 安装
+## 安装(rc.6 及以后验证过的接线)
 
 ```bash
 dsh plugin --profile web add clawock-dsh
 ```
 
-已发布 npm(`clawock-dsh`)。装完重启 web profile,skill 即生效。
+这一步把包装进 profile(pnpm 安装到
+`~/.dsh/profiles/web/node_modules/`),但 **DSH rc.6 的 skill 发现只扫
+项目根与用户根,不扫 node_modules** —— 所以还需要一步把 skill 放到可发现
+的位置(任选其一):
+
+```bash
+# 用户级(推荐,任何 workspace 都生效)
+cp -r ~/.dsh/profiles/web/node_modules/clawock-dsh/skills/investment-decision ~/.dsh/skills/
+
+# 或项目级(openclaw/clawock 也认的标准 Agent Skill 根)
+cp -r ~/.dsh/profiles/web/node_modules/clawock-dsh/skills/investment-decision <project>/.agents/skills/
+```
+
+然后重启 web profile,skill 即出现在 agent 的 skill 目录里。
+
+> 更省事的路:clawock 本身就把同一个 skill 装进标准 Agent Skill 根
+> (`clawock workflow install investment-decision --workspace <project>` →
+> `<project>/.agents/skills/`),DSH 同样会扫到这个位置。npm 插件是另一条
+> 分发通道,并预留未来的 UI 贡献位。
 
 ## 前提
 
@@ -22,10 +41,30 @@ python -m pip install clawock
 
 ## 装了之后
 
-agent 在需要做投资决策时自动使用本 skill:跑 `clawock run prepare` 读
-request、写 `decision.json`(带证据、带反方)、`clawock run publish` 校验并
-出回执。模型永远不能给自己打分——价格、风控、账本、战绩全部由 Python
-独立结算。
+用户说「分析一下 X / 做个投资决策」时,agent 自动走:
+
+1. `clawock run prepare` → 读带指纹认证的 request(`context` + 三道闸:
+   支持证据下限 / 反对证据下限 / 无一手来源的置信度上限);
+2. 用 DSH 自带的工具研究,并**主动收集反方论据**(发布时 Python 强制
+   至少一条 opposing 证据,熊方必须是真反驳,不是稻草人);
+3. 写 `decision.json`(bull/bear 辩论 + thesis + 有界 action);
+4. `clawock run publish` → 出回执,agent 给你一张「决策卡」(bull / bear /
+   thesis / confidence / action / run_id)。
+
+模型永远不能给自己打分——价格、风控、账本、战绩全部由 Python 独立结算。
+
+## 快速上手对话
+
+```
+你:安装好之后,帮我分析一下 0700.HK 能不能加点仓
+agent:准备请求…(clawock run prepare)
+      ┌─ 我会先收集双方证据再下结论 ─┐
+      ├ Bull  业绩文件确认增长(primary)  ├
+      ├ Bear  估值高于五年区间(market)   ├
+      └ 输出 + Python 校验 + 出回执 ┘
+      Subject 0700 (HK/HKD)  ·  Action add ·  confidence 0.7 …
+      Receipt published · run_id <id> · 证书已钉住
+```
 
 ## 为什么是 skill 而不是工具
 
@@ -34,6 +73,14 @@ clawock 的契约是文件 + CLI,DSH 的 bash 工具已经能执行全部命令;
 harness-agnostic 定位的一部分——同一份契约,OpenClaw skill / Claude Code
 指令 / Codex AGENTS.md / DSH skill 各有一个壳,内容同构
 ([../README.md](../README.md))。
+
+## 校验安装成功
+
+重启后在会话里问「你现在带哪些 skill?」应能看到 `investment-decision`;
+或直接让 agent 执行 `clawock run prepare`,看它是否打印 `request_file`。
+如果 skill 没出现,检查上一步的 `cp` 目标是否在
+`~/.dsh/skills/` 或 `<project>/.agents/skills/`(DSH 只扫这两个根,
+不扫 node_modules)。
 
 ## 发布(脚本)
 

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
@@ -1,14 +1,22 @@
 ---
 name: investment-decision
-description: Use this skill when the user wants to run a clawock investment decision — a request file is present or the workspace has clawock installed.
+description: Run a clawock investment decision — read the prepared request, research with the host's own tools, write decision.json with evidence and an explicit bull/bear debate, and let Python validate and settle. Use when the user asks for an investment decision or a clawock run request is present.
 ---
 
 # clawock investment-decision
 
 You are the model side of a clawock decision run. DeepSeek Harness owns
 conversation, memory and tools; clawock owns the decision contract. Your job
-is one file in, one file out: read a request, write a decision, let Python
-validate it. The model can never grade itself.
+is one file in, one file out: read a request, research, write a decision, let
+Python validate it. The model can never grade itself.
+
+```
+prepare ──► request.json ──► you: research + write decision.json ──► publish ──► receipt
+(certified │                       (collect evidence,                │       (Python settles:
+ context + │                        run the bull/bear debate,          │        evidence counts, debate
+ gates)    │                        pick a bounded action)             │        links, money/FX to the cent)
+           └───────────────────────────────────────────────────────────┘
+```
 
 ## Prerequisites
 
@@ -18,12 +26,18 @@ validate it. The model can never grade itself.
 python -m pip install clawock
 ```
 
-If a workspace is not initialized yet:
+If a workspace is not initialized yet, create it **with the workflow pinned** —
+that flag is what turns `decision.json` into the enforced contract:
 
 ```bash
-clawock workflow install investment-decision --workspace ./book
 clawock init ./book --workflow investment-decision
+clawock workflow install investment-decision --workspace ./book
 ```
+
+The second command copies the readable contract (including
+`references/decision-contract.md` and the JSON Schema) into
+`./book/.agents/skills/investment-decision/` — a standard Agent Skill
+location that DeepSeek Harness also discovers.
 
 ## The loop
 
@@ -38,14 +52,31 @@ e.g. `.clawock/work/<run_id>/request.json`). It contains:
 
 - `task` — the decision contract (evidence, opposing case, bounded action,
   reconciled amounts)
-- `context.documents` — the certified context with per-file sha256
-  fingerprints
+- `context.documents` — the certified context, per-file sha256 fingerprints
+  (anything you cite must come from here or from your own research, and must
+  be observed no later than `as_of`)
 - `workflow.parameters` — gates: `min_supporting_evidence`,
   `min_opposing_evidence`, `max_confidence_without_primary_source`
 
-### 2. Decide
+### 2. Research, then debate, then decide
 
-Write `decision.json` next to the request:
+Research with the host's normal tools (web search, file reads, the live
+dashboard at <https://kcnyu.github.io/clawock/> as `source_class: market`
+evidence). Collect **both** sides on purpose — the workflow has an opposing
+minimum, and `publish` refuses a decision whose bear case is a strawman:
+
+1. Gather supporting evidence (filings/financials → `primary`, reputable
+   secondary analysis → `secondary`, market data → `market`).
+2. Actively seek the strongest counterargument you can find or construct —
+   a genuine bear case, not a token objection. Record it as `opposing`
+   evidence.
+3. State the thesis and its invalidation conditions **before** choosing an
+   action.
+4. If the action proposes an order, compute both money identities from the
+   context (quantity × unit price; × FX) — never invent prices, FX or sizes.
+
+Write `decision.json` at the workspace root — artifact paths are resolved
+against the workspace root, not the request directory:
 
 ```json
 {
@@ -55,65 +86,109 @@ Write `decision.json` next to the request:
   "as_of": "2026-08-08T08:00:00+00:00",
   "subject": {"ticker": "EXAMPLE", "market": "US", "currency": "USD"},
   "evidence": [
- {"id": "filing-growth", "stance": "supporting",
-  "summary": "The latest filed revenue figure grew year over year.",
-  "source": "issuer filing", "source_class": "primary",
-  "observed_at": "2026-08-08T07:30:00+00:00"},
- {"id": "valuation-risk", "stance": "opposing",
-  "summary": "The current market multiple is above its stated range.",
-  "source": "market data snapshot", "source_class": "market",
-  "observed_at": "2026-08-08T07:45:00+00:00"}
+    {"id": "filing-growth", "stance": "supporting",
+     "summary": "The latest filed revenue figure grew year over year.",
+     "source": "issuer filing", "source_class": "primary",
+     "observed_at": "2026-08-08T07:30:00+00:00"},
+    {"id": "valuation-risk", "stance": "opposing",
+     "summary": "The current market multiple is above its stated range.",
+     "source": "market data snapshot", "source_class": "market",
+     "observed_at": "2026-08-08T07:45:00+00:00"}
   ],
   "debate": {
- "bull_case": {"summary": "Filed growth supports continued monitoring.",
-"evidence_ids": ["filing-growth"]},
- "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
-"evidence_ids": ["valuation-risk"]}
+    "bull_case": {"summary": "Filed growth supports continued monitoring.",
+                  "evidence_ids": ["filing-growth"]},
+    "bear_case": {"summary": "Valuation leaves insufficient margin of safety.",
+                  "evidence_ids": ["valuation-risk"]}
   },
   "thesis": {
- "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
- "confidence": 0.7,
- "invalidation_conditions": ["Filed growth reverses"]
+    "statement": "Momentum is constructive, but price does not compensate for valuation risk.",
+    "confidence": 0.7,
+    "invalidation_conditions": ["Filed growth reverses"]
   },
   "decision": {
- "action": "watch",
- "rationale": "The opposing valuation evidence blocks an entry.",
- "evidence_ids": ["filing-growth", "valuation-risk"],
- "order": null
+    "action": "watch",
+    "rationale": "The opposing valuation evidence blocks an entry.",
+    "evidence_ids": ["filing-growth", "valuation-risk"],
+    "order": null
   }
 }
 ```
 
+Rules that are enforced by `clawock run publish`, not by this file:
 
-Rules that are not negotiable:
-
-1. Every claim in `reasoning` cites an item in `evidence`.
-2. `opposing_case` is required; publish fails without it.
-3. Proposed order amounts must reconcile — never invent prices, FX or sizes.
-4. Confidence above `max_confidence_without_primary_source` needs a primary
-   source in `evidence`.
+1. `debate.bull_case` and `debate.bear_case` are both required; the bear case
+   must be a genuine counterargument and must cite opposing-stance evidence —
+   publish refuses without it.
+2. Every `evidence` row needs a `stance` (`supporting` | `opposing` |
+   `context`), a `source_class` (`primary` | `secondary` | `market` |
+   `agent`) and an `observed_at` no later than `as_of`.
+3. All `evidence_ids` references must exist (decision and both debate cases);
+   conclusions in `thesis.statement` and `decision.rationale` should be
+   backed by cited evidence.
+4. If you propose an order, the currency amounts must reconcile to the cent;
+   let the numbers come out of the context, never invent them.
+5. Confidence above `max_confidence_without_primary_source` requires a cited
+   primary source.
 
 ### 3. Publish and report
 
 ```bash
 clawock run publish \
+  --workspace ./book \
   --request ./book/.clawock/work/<run_id>/request.json \
   --artifact decision.json=./book/decision.json
 ```
 
-Report the receipt's `status` and `run_id` to the user. Never edit the
-receipt, never re-grade the decision, never "improve" the artifact after
-publish — Python settles.
+Report the receipt's `status` and `run_id`, and if `status` is `published`,
+show the user a compact decision card:
 
-## What clawock does on its side
+```
+Subject      EXAMPLE (US/USD)          decision_id example-2026-08-08
+Bull         Filed growth supports continued monitoring.        [1 citing]
+Bear         Valuation leaves insufficient margin of safety.    [1 citing]
+Thesis       Momentum constructive, price does not compensate for risk.
+Confidence   0.70  ·  Action watch  ·  Invalidation: filed growth reverses
+Receipt      published  ·  run_id <run_id>  ·  certificate pinned
+```
 
-- Certifies the context (fingerprints) before you read it
-- Validates evidence, opposing case and money/FX reconciliation at publish
-- Emits a generation receipt binding your decision to the certified context
+Never edit the receipt, never re-grade the decision, never "improve" the
+artifact after publish — Python settles.
+
+## If publish rejects
+
+The receipt lists `validation_issues` with `code` + `message`. Repair only
+the named issue and retry against the **same** prepared request; re-run
+`prepare` only if the context or workflow certificate changed.
+
+| typical `code` | meaning | fix |
+|---|---|---|
+| `unknown_fields` / `missing_fields` | a field name is wrong or extra | align with the JSON example above; no `reasoning`, no `opposing_case` |
+| `insufficient_supporting_evidence` / `insufficient_opposing_evidence` | gate minimums not met | add more evidence rows with that `stance` |
+| `unsupported_bear_case` / `unsupported_bull_case` | debate case cites the wrong stance | point `bear_case` at `opposing` rows, `bull_case` at `supporting` rows |
+| `missing_evidence_reference` | `evidence_ids` names an unknown row | only cite `id`s that exist in `evidence` |
+| `gross_amount_mismatch` / `fx_amount_mismatch` | order arithmetic wrong | recompute `quantity × unit_price` and `× fx_quote_to_base` to the cent |
+| `confidence_without_primary_source` | confidence above the cap, no primary cited | add a `primary` row and cite it in `decision.evidence_ids` |
+| `future_evidence` | `observed_at` after `as_of` | backdate or fix timestamps |
+
+## Where things land
+
+| path | contents |
+|---|---|
+| `<workspace>/decision.json` | your artifact (read by publish) |
+| `<workspace>/.clawock/work/<run_id>/request.json` | the certified request |
+| `<workspace>/.clawock/runs/<run_id>/` | receipt + manifest (the settlement record) |
+
+## Learn from outcomes
+
+After the stated horizon, record price/FX outcome evidence and run
+`clawock workflow evaluate investment-decision --decision ... --outcome ...`.
+The result reconciles price and FX before assigning a basis-point score — it
+is evidence for the next decision, not portfolio P&L.
 
 ## Learn more
 
-The live proof runs on a real HK + US desk: <https://kcnyu.github.io/clawock/>
+Live proof on a real HK + US desk: <https://kcnyu.github.io/clawock/>
 The same contract from other harnesses (OpenClaw skill, Claude Code
 instruction, Codex AGENTS.md, pure CLI):
 <https://github.com/KCNyu/clawock/tree/master/examples/harness-agnostic>

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
@@ -117,9 +117,11 @@ against the workspace root, not the request directory:
 
 Rules that are enforced by `clawock run publish`, not by this file:
 
-1. `debate.bull_case` and `debate.bear_case` are both required; the bear case
-   must be a genuine counterargument and must cite opposing-stance evidence —
-   publish refuses without it.
+1. `debate.bull_case` and `debate.bear_case` are both required and each cites
+   evidence; the bear case must cite opposing-stance evidence — publish
+   refuses without it. Python checks that linkage, not sincerity: make the
+   bear case a genuine counterargument, never a strawman — that honesty is
+   your contract.
 2. Every `evidence` row needs a `stance` (`supporting` | `opposing` |
    `context`), a `source_class` (`primary` | `secondary` | `market` |
    `agent`) and an `observed_at` no later than `as_of`.

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/SKILL.md
@@ -133,6 +133,12 @@ Rules that are enforced by `clawock run publish`, not by this file:
 5. Confidence above `max_confidence_without_primary_source` requires a cited
    primary source.
 
+The sibling files next to this SKILL.md carry the full contract:
+`references/decision-contract.md` (with `assets/order.example.json`, an
+order-carrying decision whose two money identities reconcile). Introspect
+the exact artifact shape any time: `clawock workflow schema
+investment-decision decision.json`.
+
 ### 3. Publish and report
 
 ```bash
@@ -156,6 +162,21 @@ Receipt      published  ·  run_id <run_id>  ·  certificate pinned
 
 Never edit the receipt, never re-grade the decision, never "improve" the
 artifact after publish — Python settles.
+
+## Before publish: self-check
+
+Run this checklist before invoking `publish` — Python re-checks all of it
+anyway, but a clean first pass beats a rejected receipt:
+
+- both `debate.bull_case` and `debate.bear_case` present, each citing
+  existing `evidence_ids`, the bear case citing `opposing` rows
+- every cited `evidence_id` exists; no duplicates
+- every evidence row has `stance`, `source`, `source_class`, and
+  `observed_at` no later than `as_of`
+- one `primary` row is cited whenever `confidence` exceeds the cap
+- an order (if any) satisfies `gross_amount_quote = quantity × unit_price`
+  and `gross_amount_base = gross_amount_quote × fx_quote_to_base`, to the
+  cent
 
 ## If publish rejects
 

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/assets/order.example.json
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/assets/order.example.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "workflow": {
+    "id": "investment-decision",
+    "version": "1.1.0"
+  },
+  "decision_id": "order-example-2026-08-08",
+  "as_of": "2026-08-08T08:00:00+00:00",
+  "subject": {
+    "ticker": "0700",
+    "market": "HK",
+    "currency": "HKD"
+  },
+  "evidence": [
+    {
+      "id": "filing-growth",
+      "stance": "supporting",
+      "summary": "The latest filed revenue figure grew year over year.",
+      "source": "issuer filing",
+      "source_class": "primary",
+      "observed_at": "2026-08-08T07:30:00+00:00"
+    },
+    {
+      "id": "sell-side-target",
+      "stance": "supporting",
+      "summary": "A broker's HK$450 target exceeds the entry level.",
+      "source": "broker research note",
+      "source_class": "secondary",
+      "observed_at": "2026-08-08T07:35:00+00:00"
+    },
+    {
+      "id": "valuation-risk",
+      "stance": "opposing",
+      "summary": "The trailing multiple is above the five-year range.",
+      "source": "market data snapshot",
+      "source_class": "market",
+      "observed_at": "2026-08-08T07:45:00+00:00"
+    }
+  ],
+  "debate": {
+    "bull_case": {
+      "summary": "Filed growth and a broker target support a funded entry.",
+      "evidence_ids": [
+        "filing-growth",
+        "sell-side-target"
+      ]
+    },
+    "bear_case": {
+      "summary": "The valuation leaves limited margin of safety at the entry price.",
+      "evidence_ids": [
+        "valuation-risk"
+      ]
+    }
+  },
+  "thesis": {
+    "statement": "Filing-confirmed growth plus a small size makes the valuation risk acceptable; invalidation conditions bound the downside.",
+    "confidence": 0.7,
+    "invalidation_conditions": [
+      "Next filing misses revenue",
+      "Close below the invalidation level"
+    ]
+  },
+  "decision": {
+    "action": "add",
+    "rationale": "Primary evidence supports growth; the small add and invalidation conditions bound the valuation risk.",
+    "evidence_ids": [
+      "filing-growth",
+      "valuation-risk"
+    ],
+    "order": {
+      "side": "buy",
+      "quantity": "200",
+      "unit_price": "310.00",
+      "quote_currency": "HKD",
+      "gross_amount_quote": "62000.00",
+      "base_currency": "HKD",
+      "fx_quote_to_base": "1",
+      "gross_amount_base": "62000.00"
+    }
+  }
+}

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/references/decision-contract.md
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/references/decision-contract.md
@@ -1,0 +1,112 @@
+# Decision artifact contract
+
+`decision.json` is the single required artifact for workflow version `1.1.0`.
+Unknown or missing fields are rejected so a producer cannot silently invent a
+parallel schema.
+
+The machine-readable shape is `decision.schema.json` in this directory. JSON
+Schema covers structure and primitive types; clawock's Python validator adds the
+cross-reference, provenance, opposing-evidence, action/order and arithmetic
+invariants that JSON Schema cannot express.
+
+## Top-level fields
+
+- `schema_version`: integer `1`.
+- `workflow`: exactly `{"id":"investment-decision","version":"1.1.0"}`.
+- `decision_id`: stable non-empty identifier chosen by the calling runtime.
+- `as_of`: ISO-8601 timestamp with timezone.
+- `subject`: `ticker`, `market`, and quote `currency` strings.
+- `evidence`: traceable evidence rows.
+- `debate`: one bull and one bear case, each linked to evidence IDs.
+- `thesis`: statement, confidence from 0 to 1, and non-empty invalidation conditions.
+- `decision`: bounded action, rationale, evidence links, and optional order intent.
+
+## Evidence
+
+Each row contains exactly:
+
+- `id`: unique non-empty string.
+- `stance`: `supporting`, `opposing`, or `context`.
+- `summary`: the observed fact, not an unsupported conclusion.
+- `source`: a stable locator or source name.
+- `source_class`: `primary`, `secondary`, `market`, or `agent`.
+- `observed_at`: ISO-8601 timestamp with timezone, no later than `as_of`.
+
+The bull case must cite supporting evidence and the bear case must cite opposing
+evidence. Every cited ID must exist. The configured workflow parameters control
+minimum evidence counts and the maximum confidence allowed without a cited
+primary source.
+
+## Decision and order intent
+
+`action` is one of `buy`, `add`, `hold`, `watch`, `trim`, `sell`, `exit`, or
+`abstain`. `hold`, `watch`, and `abstain` carry `order: null`. Other actions
+carry an order with exactly:
+
+- `side`: `buy` or `sell`, consistent with the action.
+- `quantity`, `unit_price`, `gross_amount_quote`.
+- `quote_currency`, `base_currency`.
+- `fx_quote_to_base`, `gross_amount_base`.
+
+All numeric values must be positive and finite. clawock reconciles the two money
+identities to currency cents:
+
+`gross_amount_quote = quantity * unit_price`
+
+`gross_amount_base = gross_amount_quote * fx_quote_to_base`
+
+See `assets/decision.example.json` for a complete watch decision, and
+`assets/order.example.json` for an order-carrying decision with both money
+identities reconciled.
+
+## Outcome evidence and evaluation
+
+Copy `assets/outcome.example.json`, preserve the decision/workflow identifiers,
+and replace the price, FX, timestamp, and source fields with observed evidence.
+Then run:
+
+```bash
+clawock workflow evaluate investment-decision \
+  --decision decision.json --outcome outcome.json --output evaluation.json
+```
+
+The evaluator calculates quote-currency and base-currency market moves in basis
+points. `decision_value_bps` applies +1 to long/hold decisions, -1 to
+trim/sell/exit decisions, and 0 to watch/abstain. This is a reproducible
+directional evaluation, not realized P&L; portfolio cash, fills, fees, taxes and
+position size remain outside this artifact.
+
+## Bounded improvement
+
+An external runtime or human can propose only parameters already bounded by
+`workflow.json`:
+
+```bash
+clawock workflow propose --workspace . --trigger evaluation.json \
+  --set min_opposing_evidence=2 \
+  --rationale "Weak opposing evidence preceded the measured miss." \
+  --expected-effect "Require a second independent opposing source." \
+  --output proposal.json
+
+clawock workflow review --proposal proposal.json --decision accepted \
+  --reviewer analyst@example --note "Evidence supports a bounded trial." \
+  --output review.json
+
+clawock workflow apply --workspace . --proposal proposal.json --review review.json
+clawock workflow rollback --workspace . --change-id <change-id>
+```
+
+The trigger can also be a rejected `clawock run publish` receipt. A proposal
+pins the workflow version/certificate, trigger hash, old/new values and expected
+effect. Apply refuses rejected or mismatched reviews, stale parameters, unknown
+settings and values outside their declared bounds. Rollback refuses to overwrite
+later parameter drift.
+
+This loop never launches a model, edits `SKILL.md`, changes OpenClaw memory/chat
+behavior or accepts its own proposal. Reasoning stays in the external runtime;
+clawock owns the evidence link, deterministic math and reversible adoption
+record.
+
+The bounded parameters change workflow evidence strictness only. They do not
+introduce or tune quantitative factors, catalysts, signals, entry/exit rules or
+portfolio construction; those remain part of the caller's existing strategy.

--- a/examples/harness-agnostic/dsh-plugin/skills/investment-decision/references/decision.schema.json
+++ b/examples/harness-agnostic/dsh-plugin/skills/investment-decision/references/decision.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:clawock:workflow:investment-decision:1.1.0:decision",
+  "title": "clawock investment decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "workflow",
+    "decision_id",
+    "as_of",
+    "subject",
+    "evidence",
+    "debate",
+    "thesis",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {"const": "investment-decision"},
+        "version": {"const": "1.1.0"}
+      }
+    },
+    "decision_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ticker", "market", "currency"],
+      "properties": {
+        "ticker": {"type": "string", "minLength": 1},
+        "market": {"type": "string", "minLength": 1},
+        "currency": {"type": "string", "minLength": 1}
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidence"}
+    },
+    "debate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bull_case", "bear_case"],
+      "properties": {
+        "bull_case": {"$ref": "#/$defs/case"},
+        "bear_case": {"$ref": "#/$defs/case"}
+      }
+    },
+    "thesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statement", "confidence", "invalidation_conditions"],
+      "properties": {
+        "statement": {"type": "string", "minLength": 1},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "invalidation_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "rationale", "evidence_ids", "order"],
+      "properties": {
+        "action": {
+          "enum": ["buy", "add", "hold", "watch", "trim", "sell", "exit", "abstain"]
+        },
+        "rationale": {"type": "string", "minLength": 1},
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "order": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/order"}
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "stance", "summary", "source", "source_class", "observed_at"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "stance": {"enum": ["supporting", "opposing", "context"]},
+        "summary": {"type": "string", "minLength": 1},
+        "source": {"type": "string", "minLength": 1},
+        "source_class": {"enum": ["primary", "secondary", "market", "agent"]},
+        "observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "evidence_ids"],
+      "properties": {
+        "summary": {"type": "string", "minLength": 1},
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "positive-number": {
+      "oneOf": [
+        {"type": "number", "exclusiveMinimum": 0},
+        {"type": "string", "pattern": "^(?:0*[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$"}
+      ]
+    },
+    "order": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "side",
+        "quantity",
+        "unit_price",
+        "quote_currency",
+        "gross_amount_quote",
+        "base_currency",
+        "fx_quote_to_base",
+        "gross_amount_base"
+      ],
+      "properties": {
+        "side": {"enum": ["buy", "sell"]},
+        "quantity": {"$ref": "#/$defs/positive-number"},
+        "unit_price": {"$ref": "#/$defs/positive-number"},
+        "quote_currency": {"type": "string", "minLength": 1},
+        "gross_amount_quote": {"$ref": "#/$defs/positive-number"},
+        "base_currency": {"type": "string", "minLength": 1},
+        "fx_quote_to_base": {"$ref": "#/$defs/positive-number"},
+        "gross_amount_base": {"$ref": "#/$defs/positive-number"}
+      }
+    }
+  }
+}

--- a/examples/harness-agnostic/dsh.md
+++ b/examples/harness-agnostic/dsh.md
@@ -72,9 +72,10 @@ clawock init book --workflow investment-decision
 
 
    Rules (enforced by `clawock run publish`, not by this file):
-   - `debate.bull_case` and `debate.bear_case` are both required; the bear
-     case must be a genuine counterargument and cite opposing-stance
-     evidence — publish refuses a decision without it.
+   - `debate.bull_case` and `debate.bear_case` are both required and each cites
+     evidence; the bear case must cite opposing-stance evidence — publish
+     refuses without it. Python checks that linkage, not sincerity: make the
+     bear case a genuine counterargument — that honesty is the model's.
    - Every `evidence` row needs `stance`, `source_class` and an `observed_at`
      no later than `as_of`.
    - All `evidence_ids` references must exist (decision and both debate

--- a/examples/harness-agnostic/dsh.md
+++ b/examples/harness-agnostic/dsh.md
@@ -8,7 +8,14 @@ the same as the pure-CLI example.
 ## What the agent needs to know
 
 Give the DSH agent a workspace instruction (e.g. in its system prompt or a
-workspace context file) covering three steps:
+workspace context file) covering three steps. On a fresh machine the
+workspace must be created once first — see [`README.md`](README.md) ("From
+zero to a published decision"); the short version is:
+
+```bash
+python -m pip install clawock
+clawock init book --workflow investment-decision
+```
 
 1. **Prepare.** When asked to run an investment decision, execute:
 
@@ -22,7 +29,9 @@ workspace context file) covering three steps:
    (`min_supporting_evidence`, `min_opposing_evidence`,
    `max_confidence_without_primary_source`).
 
-2. **Decide.** Write `decision.json` next to the request. Shape:
+2. **Decide.** Write `decision.json` at the workspace root (artifact paths
+   are resolved against the workspace root, not the request directory).
+   Shape:
 
    ```json
    {
@@ -62,14 +71,23 @@ workspace context file) covering three steps:
    ```
 
 
-   Rules: every reasoning claim cites evidence; `opposing_case` is required
-   and must be a real counterargument; proposed order amounts must reconcile;
-   confidence above the cap needs a primary source.
+   Rules (enforced by `clawock run publish`, not by this file):
+   - `debate.bull_case` and `debate.bear_case` are both required; the bear
+     case must be a genuine counterargument and cite opposing-stance
+     evidence — publish refuses a decision without it.
+   - Every `evidence` row needs `stance`, `source_class` and an `observed_at`
+     no later than `as_of`.
+   - All `evidence_ids` references must exist (decision and both debate
+     cases); conclusions in `thesis.statement` and `decision.rationale`
+     should be backed by cited evidence.
+   - Order amounts must reconcile to the cent. Confidence above
+     `max_confidence_without_primary_source` needs a cited primary source.
 
 3. **Publish and report.**
 
    ```bash
    clawock run publish \
+     --workspace /path/to/book \
      --request /path/to/book/.clawock/work/<run_id>/request.json \
      --artifact decision.json=/path/to/book/decision.json
    ```

--- a/examples/harness-agnostic/openclaw.SKILL.md
+++ b/examples/harness-agnostic/openclaw.SKILL.md
@@ -13,7 +13,9 @@ entire job is one file in, one file out.
 
 A `run prepare` has written a request file (the `request_file` path it
 printed, e.g. `.clawock/work/<run_id>/request.json`). Open it first; it tells
-you:
+you. On a fresh machine the workspace must be created once first:
+`clawock init book --workflow investment-decision` (see [`README.md`](README.md)
+— "From zero").
 
 - `task` — the decision contract (evidence, opposing case, bounded action,
   reconciled amounts)
@@ -24,9 +26,10 @@ you:
 
 ## What to produce
 
-Write `decision.json` in the same directory. The schema is the package's
-`investment-decision` workflow; when in doubt, keep the fields minimal and
-explicit:
+Write `decision.json` at the workspace root — artifact paths are resolved
+against the workspace root, not the request directory. The schema is the
+package's `investment-decision` workflow; when in doubt, keep the fields
+minimal and explicit:
 
 ```json
 {
@@ -66,15 +69,21 @@ explicit:
 ```
 
 
-Rules that are not negotiable:
+Rules that are enforced by `clawock run publish`, not by this file:
 
-1. Every claim in `reasoning` cites an item in `evidence`.
-2. `opposing_case` is required and must be a genuine counterargument, not a
-   strawman — the contract refuses to publish without it.
-3. If you propose an order, the currency amounts must reconcile; let the
-   numbers come out of the context, never invent them.
-4. Confidence above `max_confidence_without_primary_source` requires a
-   primary source in `evidence`.
+1. `debate.bull_case` and `debate.bear_case` are both required; the bear case
+   must be a genuine counterargument and must cite opposing-stance evidence —
+   publish refuses without it.
+2. Every `evidence` row needs a `stance` (`supporting` | `opposing` |
+   `context`), a `source_class` (`primary` | `secondary` | `market` |
+   `agent`) and an `observed_at` no later than `as_of`.
+3. All `evidence_ids` references must exist (decision and both debate cases);
+   conclusions in `thesis.statement` and `decision.rationale` should be
+   backed by cited evidence.
+4. If you propose an order, the currency amounts must reconcile to the cent;
+   let the numbers come out of the context, never invent them.
+5. Confidence above `max_confidence_without_primary_source` requires a cited
+   primary source.
 
 ## After writing
 

--- a/examples/harness-agnostic/openclaw.SKILL.md
+++ b/examples/harness-agnostic/openclaw.SKILL.md
@@ -71,9 +71,11 @@ minimal and explicit:
 
 Rules that are enforced by `clawock run publish`, not by this file:
 
-1. `debate.bull_case` and `debate.bear_case` are both required; the bear case
-   must be a genuine counterargument and must cite opposing-stance evidence —
-   publish refuses without it.
+1. `debate.bull_case` and `debate.bear_case` are both required and each cites
+   evidence; the bear case must cite opposing-stance evidence — publish
+   refuses without it. Python checks that linkage, not sincerity: make the
+   bear case a genuine counterargument, never a strawman — that honesty is
+   the model's contract.
 2. Every `evidence` row needs a `stance` (`supporting` | `opposing` |
    `context`), a `source_class` (`primary` | `secondary` | `market` |
    `agent`) and an `observed_at` no later than `as_of`.

--- a/examples/harness-agnostic/run.sh
+++ b/examples/harness-agnostic/run.sh
@@ -32,18 +32,25 @@ cd book
 mkdir -p .clawock/work
 
 echo "==> clawock run prepare"
-iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run prepare > .clawock/work/request.json
+# cwd is enough: clawock finds the workspace from the current directory.
+# --workspace/CLAWOCK_WORKSPACE only matter when running from elsewhere.
+iso "$clawock" run prepare > .clawock/work/request.json
 
 # This is the entire harness surface. In the other examples in this directory,
 # an OpenClaw skill, a Claude Code instruction or a DeepSeek Harness agent does
-# exactly this one step: write decision.json from request.json. Nothing else in
-# the loop belongs to the harness.
-echo '{"answer":"smoke"}' > .clawock/work/decision.json
+# exactly this one step: read request.json and write decision.json. Nothing
+# else in the loop belongs to the harness.
+#
+# No workflow is pinned here (init without --workflow), so publish checks only
+# the base loop and a literal "answer" artifact is enough. A pinned workflow
+# (init --workflow investment-decision) instead refuses to publish a non-
+# decision.json artifact — see the five harness files in this directory.
+echo '{"answer":"smoke"}' > .clawock/work/answer.json
 
 echo "==> clawock run publish"
-iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run publish \
+iso "$clawock" run publish \
   --request .clawock/work/request.json \
-  --artifact answer=.clawock/work/decision.json > receipt.json
+  --artifact answer=.clawock/work/answer.json > receipt.json
 
 echo "==> checking the receipt"
 "$workdir/venv/bin/python" - <<'PY'

--- a/examples/minimal-run/run.sh
+++ b/examples/minimal-run/run.sh
@@ -42,7 +42,9 @@ cd book
 mkdir -p .clawock/work
 
 echo "==> clawock run prepare"
-iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run prepare > .clawock/work/request.json
+# cwd is enough: clawock finds the workspace from the current directory.
+# --workspace/CLAWOCK_WORKSPACE only matter when running from elsewhere.
+iso "$clawock" run prepare > .clawock/work/request.json
 
 # Stands in for the agent's answer. A real runtime writes its model output here;
 # the package's job is to certify and publish whatever it is handed, so a literal
@@ -50,7 +52,7 @@ iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run prepare > .clawock/work/request.
 echo '{"answer":"smoke"}' > .clawock/work/answer.json
 
 echo "==> clawock run publish"
-iso env CLAWOCK_WORKSPACE="$PWD" "$clawock" run publish \
+iso "$clawock" run publish \
   --request .clawock/work/request.json \
   --artifact answer=.clawock/work/answer.json > receipt.json
 

--- a/src/clawock/workflows/packs/investment-decision/assets/order.example.json
+++ b/src/clawock/workflows/packs/investment-decision/assets/order.example.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "workflow": {
+    "id": "investment-decision",
+    "version": "1.1.0"
+  },
+  "decision_id": "order-example-2026-08-08",
+  "as_of": "2026-08-08T08:00:00+00:00",
+  "subject": {
+    "ticker": "0700",
+    "market": "HK",
+    "currency": "HKD"
+  },
+  "evidence": [
+    {
+      "id": "filing-growth",
+      "stance": "supporting",
+      "summary": "The latest filed revenue figure grew year over year.",
+      "source": "issuer filing",
+      "source_class": "primary",
+      "observed_at": "2026-08-08T07:30:00+00:00"
+    },
+    {
+      "id": "sell-side-target",
+      "stance": "supporting",
+      "summary": "A broker's HK$450 target exceeds the entry level.",
+      "source": "broker research note",
+      "source_class": "secondary",
+      "observed_at": "2026-08-08T07:35:00+00:00"
+    },
+    {
+      "id": "valuation-risk",
+      "stance": "opposing",
+      "summary": "The trailing multiple is above the five-year range.",
+      "source": "market data snapshot",
+      "source_class": "market",
+      "observed_at": "2026-08-08T07:45:00+00:00"
+    }
+  ],
+  "debate": {
+    "bull_case": {
+      "summary": "Filed growth and a broker target support a funded entry.",
+      "evidence_ids": [
+        "filing-growth",
+        "sell-side-target"
+      ]
+    },
+    "bear_case": {
+      "summary": "The valuation leaves limited margin of safety at the entry price.",
+      "evidence_ids": [
+        "valuation-risk"
+      ]
+    }
+  },
+  "thesis": {
+    "statement": "Filing-confirmed growth plus a small size makes the valuation risk acceptable; invalidation conditions bound the downside.",
+    "confidence": 0.7,
+    "invalidation_conditions": [
+      "Next filing misses revenue",
+      "Close below the invalidation level"
+    ]
+  },
+  "decision": {
+    "action": "add",
+    "rationale": "Primary evidence supports growth; the small add and invalidation conditions bound the valuation risk.",
+    "evidence_ids": [
+      "filing-growth",
+      "valuation-risk"
+    ],
+    "order": {
+      "side": "buy",
+      "quantity": "200",
+      "unit_price": "310.00",
+      "quote_currency": "HKD",
+      "gross_amount_quote": "62000.00",
+      "base_currency": "HKD",
+      "fx_quote_to_base": "1",
+      "gross_amount_base": "62000.00"
+    }
+  }
+}

--- a/src/clawock/workflows/packs/investment-decision/references/decision-contract.md
+++ b/src/clawock/workflows/packs/investment-decision/references/decision-contract.md
@@ -55,7 +55,9 @@ identities to currency cents:
 
 `gross_amount_base = gross_amount_quote * fx_quote_to_base`
 
-See `assets/decision.example.json` for a complete watch decision.
+See `assets/decision.example.json` for a complete watch decision, and
+`assets/order.example.json` for an order-carrying decision with both money
+identities reconciled.
 
 ## Outcome evidence and evaluation
 


### PR DESCRIPTION
## 背景

对抗 review(本会话 + 3 个 subagent 交叉)发现 `examples/harness-agnostic/` 整组教学文件**不能自洽**:
JSON 示例全部通过真实 validator,规则散文却在教 validator 拒绝的字段,照散文写必被 `publish` 以 `unknown_fields` 拒绝(#646 只修了一半)。另有初始化断路、工件路径矛盾、dsh 插件接线失效等问题。

## 改动

### 教学契约自洽(5 个 harness 文件 + README + run.sh)

- 散文规则全部改为与 `validators.py` / `decision-contract.md` 一致:删 `reasoning` / `opposing_case`,改 `debate.bull_case` + `debate.bear_case`(熊方须引用 opposing 证据)、`stance`/`source_class`/`observed_at ≤ as_of`、evidence_ids 交叉引用、金额对账到分、置信度上限需"被引用的"一手源
- 统一的「From zero」建库路径:`clawock init <book> --workflow investment-decision` 是把 `decision.json` 变成强制契约的开关,此前 5 个示例都没交代(复现会直接断在 prepare)
- 「写在 request 旁边」实测与 publish 相对路径解析(workspace 根)矛盾,统一为 workspace 根并写入 README
- `dsh.md` publish 补 `--workspace`(异地 cwd 实测失败)
- 两个 run.sh 的 `CLAWOCK_WORKSPACE` 实测为装饰性(cwd 发现已足够),移除并注明;`harness-agnostic/run.sh` 假产物由 `decision.json` 改名 `answer.json` 并以注释解释与教学契约的分工
- 新增 `src/.../assets/order.example.json`:带 order + 两条金额恒等(quantity×price、×FX)对账的完整示例——仓库此前**没有任何** order 示例(S2 复现走查点名缺口)

### clawock-dsh 插件(接线修正 + 体验升级)

- **接线实证**:DSH rc.6 的 skill 发现只扫 `<project>/.dsh/skills`、`<project>/.agents/skills`、`~/.dsh/skills` 等根,不扫 node_modules;`dsh.skills` manifest 字段在整个 rc.6 树里**无消费者** → 原 README「装完重启即生效」不成立。README 改为真实接线(装后 `cp` 到 `~/.dsh/skills/` 或项目 `.agents/skills/`,后者与 `clawock workflow install` 的目标重合),并加安装校验步骤
- SKILL.md 体验升级:流程图、研究阶段「主动收集反方论据」、发布后向用户输出**决策卡**(bull/bear/thesis/confidence/action/run_id)、`publish` 拒绝时的修复表(issue code 与 validators.py 逐条对齐)、文件落盘表、`workflow evaluate` 收尾

## 验证

- 5 个教学文件内嵌 JSON + 新 order 示例 → 全部通过真实 `InvestmentDecisionValidator`(0 issues)
- init → prepare → 写教学示例 → publish 全链路源码端到端实测(published, 含乱加 `reasoning`/`opposing_case` 的拒绝实测)
- artifact 相对路径解析到 workspace 根的行为实测确认
- `bash -n` 两个 run.sh 通过;`tests/test_portable_workflow.py` 3 passed

## 遗留(未动,需 kcn 决定)

- **Decision Studio web 面板**(P2):DSH 支持 client plugin(`conversation.view` tab,trajectory 是现成范式),可做「请求上下文 + 决策卡 + 回执横幅」的可视化;需要 npm 包从纯 skill 变成 bundle + client,且要有 DSH dev server 才能目验,本会话没做,留给下一轮
- #646 关闭待本 PR 合入后由 kcn 关