### PR TITLE
feat: clawock-dsh Decision Studio 面板——只读 conversation.view tab(#651)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -135,8 +135,13 @@ jobs:
             ui=true
             code=true
           fi
+          dsplugin=false
+          if grep -Eq '^(examples/dsh/plugin/|tests/decision_studio_plugin\.spec\.js$)' <<< "$changed"; then
+            dsplugin=true
+          fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
           echo "ui=$ui" >> "$GITHUB_OUTPUT"
+          echo "dsplugin=$dsplugin" >> "$GITHUB_OUTPUT"
           echo "code changed: $code"
 
       - name: Set up Node for dashboard browser contract
@@ -162,6 +167,16 @@ jobs:
       - name: Browser contract — Hero, detail tabs, and chart gestures
         if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
         run: node tests/dashboard_tab_runtime.spec.js
+
+      - name: Set up Node for Decision Studio plugin contract
+        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Decision Studio plugin contract (scan + client bundle registration)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        run: node tests/decision_studio_plugin.spec.js
 
       - name: Set up Python
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -139,9 +139,7 @@ jobs:
           if grep -Eq '^(examples/dsh/plugin/|tests/decision_studio_plugin\.spec\.js$)' <<< "$changed"; then
             dsplugin=true
           fi
-          echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "ui=$ui" >> "$GITHUB_OUTPUT"
-          echo "dsplugin=$dsplugin" >> "$GITHUB_OUTPUT"
+          { echo "code=$code"; echo "ui=$ui"; echo "dsplugin=$dsplugin"; } >> "$GITHUB_OUTPUT"
           echo "code changed: $code"
 
       - name: Set up Node for dashboard browser contract

--- a/examples/dsh/plugin/README.md
+++ b/examples/dsh/plugin/README.md
@@ -1,9 +1,9 @@
 # clawock-dsh
 
-clawock 的 DeepSeek Harness 插件:一个 skill 包,把 investment-decision
-决策工作流注入 DSH agent。零 Node 代码——clawock 是 Python CLI,skill
-只负责告诉 agent 怎么走「读请求 → 研究 + 正反辩论 → 写决策 → Python
-校验结算」四步。
+clawock 的 DeepSeek Harness 插件:skill 包 + Decision Studio 面板,把
+investment-decision 决策工作流注入 DSH agent。skill 负责告诉 agent 怎么走
+「读请求 → 研究 + 正反辩论 → 写决策 → Python 校验结算」四步;面板把
+request / debate / 回执渲染成 web GUI 里的会话视图 tab。
 
 ## 安装(rc.6 及以后验证过的接线)
 
@@ -12,9 +12,11 @@ dsh plugin --profile web add clawock-dsh
 ```
 
 这一步把包装进 profile(pnpm 安装到
-`~/.dsh/profiles/web/node_modules/`),但 **DSH rc.6 的 skill 发现只扫
-项目根与用户根,不扫 node_modules** —— 所以还需要一步把 skill 放到可发现
-的位置(任选其一):
+`~/.dsh/profiles/web/node_modules/`),并因为包声明了
+`dsh.bundle.patch` 而成为真正的 profile 层(patch 行 `clawock-studio`
+提供 Decision Studio 的只读 Remote 网关)。**skill 的发现仍按 rc.6 规则**:
+DSH 只扫项目根与用户根,不扫 node_modules —— 所以还需要一步把 skill
+放到可发现的位置(任选其一):
 
 ```bash
 # 用户级(推荐,任何 workspace 都生效)
@@ -66,13 +68,41 @@ agent:准备请求…(clawock run prepare)
       Receipt published · run_id <id> · 证书已钉住
 ```
 
-## 为什么是 skill 而不是工具
+## Decision Studio 面板
+
+装完后,web GUI 的会话视图多一个 **Decision Studio** tab(只读):
+
+- **运行列表**:本 workspace(`$CLAWOCK_WORKSPACE` 或 dsh 进程 cwd)里所有
+  已 prepare 的 run —— ticker / action / 有无回执 / as_of,按时间倒序;
+- **选中一个 run**:certified request(文档指纹数 + 三道闸)、debate 证据
+  表(supporting 绿 / opposing 红)、thesis + action + confidence、回执
+  横幅(published 绿 / 未发布红 + run_id + generation)。
+
+数据源是只读的:`.clawock/work/<run_id>/request.json`、workspace 根
+`decision.json`、`.clawock/runs/<run_id>/manifest.json`。面板不改任何文件,
+结算仍归 `clawock run publish`。结构:
+
+```
+clawock-dsh
+├── cordis.patch.yml   # profile patch 层:插入 clawock-studio Remote 网关行
+├── lib/index.js       # node 半区:TypertRemoteService(只读 list/get)
+├── lib/scan.js        # 纯扫描逻辑(可单测)
+├── client.js          # client 半区:module-loader bundle,注册 conversation.view tab
+└── skills/            # agent skill(同上)
+```
+
+验证状态:node 半区(扫描、run id 防路径穿越、Remote 标记)与 client 半区
+(注册、模型投影)有单元测试;**tab 的浏览器目验需要在带 DSH 源码/工具链的
+机器上 boot 后确认**(本仓库 CI 无法渲染 GUI)。
+
+## 为什么是 skill + 面板而不是工具
 
 clawock 的契约是文件 + CLI,DSH 的 bash 工具已经能执行全部命令;skill
 只需要把「什么时候跑、产出什么、什么不可协商」讲清楚。这也是 clawock
 harness-agnostic 定位的一部分——同一份契约,OpenClaw skill / Claude Code
 指令 / Codex AGENTS.md / DSH skill 各有一个壳,内容同构
-([../../README.md](../../README.md))。
+([../../README.md](../../README.md))。面板只是同一份只读数据的另一种
+呈现,不改变契约。
 
 ## 校验安装成功
 

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -30,7 +30,7 @@ window.__ModuleLoader__.load({
       return {
         empty: false,
         runId: run.runId,
-        subject: request.subject ?? null,
+        subject: request.subject ?? (decision && decision.subject) ?? null,
         asOf: request.as_of ?? null,
         task: request.task ?? null,
         workflow: request.workflow ?? null,
@@ -77,7 +77,7 @@ window.__ModuleLoader__.load({
 
     /** The conversation.view tab: run list + selected run detail. */
     function DecisionStudio(props) {
-      var pair = useState({ runs: [], selected: null, loading: true, error: null })
+      var pair = useState({ runs: [], selected: null, detail: null, loading: true, error: null })
       var state = pair[0]
       var setState = pair[1]
       var sessionId = props.sessionId
@@ -94,24 +94,40 @@ window.__ModuleLoader__.load({
         return function () { alive = false }
       }, [sessionId])
 
+      // Full detail is fetched per selection: list rows are cheap snapshots,
+      // the request/decision/receipt payloads live in the node half.
+      useEffect(function () {
+        var selected = state.selected
+        if (!selected) {
+          setState(function (current) { return Object.assign({}, current, { detail: null }) })
+          return
+        }
+        var alive = true
+        setState(function (current) { return Object.assign({}, current, { detail: null }) })
+        props.get(selected).then(function (detail) {
+          if (!alive) return
+          setState(function (current) { return Object.assign({}, current, { detail: detail }) })
+        }, function (error) {
+          if (!alive) return
+          setState(function (current) { return Object.assign({}, current, { detail: null, error: String(error && error.message ? error.message : error) }) })
+        })
+        return function () { alive = false }
+      }, [state.selected])
+
       var loading = state.loading
       var error = state.error
       var runs = state.runs
       var selectedId = state.selected
+      var detail = state.detail
 
       if (error) return h('div', { style: CARD }, h('span', { style: { color: RED } }, 'Decision Studio: ' + error))
       if (loading) return h('div', { style: CARD }, 'Loading clawock runs…')
 
-      var selectedRun = null
-      for (var i = 0; i < runs.length; i += 1) {
-        if (runs[i].runId === selectedId) { selectedRun = runs[i]; break }
-      }
-
-      var detail = null
-      if (selectedRun) {
-        var model = _buildStudioModel(selectedRun)
+      var detailView = null
+      if (detail) {
+        var model = _buildStudioModel(detail)
         if (!model.empty) {
-          detail = h('div', { style: CARD },
+          detailView = h('div', { style: CARD },
             h('div', { style: { fontSize: 14, fontWeight: 700, marginBottom: 8 } },
               model.subject ? model.subject.ticker + ' (' + model.subject.market + '/' + model.subject.currency + ')' : 'unknown subject'),
             h(Row, { label: 'run_id', value: model.runId, muted: true }),
@@ -137,7 +153,7 @@ window.__ModuleLoader__.load({
       return h('div', { style: { padding: 4 } },
         h('div', { style: { color: MUTED, fontSize: 12, marginBottom: 6 } }, 'clawock runs in this workspace (' + runs.length + ')'),
         runs.map(function (run) {
-          var ticker = run.subject && run.subject.ticker ? run.subject.ticker : run.runId
+          var ticker = (run.subject && run.subject.ticker) || (run.decisionSubject && run.decisionSubject.ticker) || run.runId
           var status = run.receiptPresent ? 'published' : 'no receipt'
           var label = ticker + ' · ' + status + (run.decisionPresent ? ' · decision' : '')
           return h('button', {
@@ -150,14 +166,64 @@ window.__ModuleLoader__.load({
             },
           }, label, '  ', h('span', { style: { color: MUTED } }, run.asOf || ''))
         }),
-        detail)
+        detailView)
     }
 
-    /** Services required by the registration and the generated Remote face. */
-    var inject = ['slots', 'remote', 'remote.clawockStudio']
+    /** Minimal strict codecs (no zod external in the module table). */
+    var passthroughSchema = { parse: function (value) { return value } }
+    var stringSchema = {
+      parse: function (value) {
+        if (typeof value !== 'string') throw new Error('expected a string')
+        return value
+      },
+    }
+
+    /** Client projection of the clawockStudio Remote face, mounted explicitly. */
+    var TYPERT_REMOTE = {
+      package: 'clawock-dsh',
+      descriptors: [{
+        id: 'clawock-dsh#clawockStudio/list',
+        service: 'clawockStudio',
+        namespace: 'clawockStudio',
+        method: 'list',
+        invocation: { kind: 'direct' },
+        parameters: [],
+        result: {
+          mode: 'strict',
+          typeSymbol: 'clawock-dsh#clawockStudio/list:result',
+          schema: passthroughSchema,
+        },
+      }, {
+        id: 'clawock-dsh#clawockStudio/get',
+        service: 'clawockStudio',
+        namespace: 'clawockStudio',
+        method: 'get',
+        invocation: { kind: 'direct' },
+        parameters: [{
+          name: 'runId',
+          wire: 'runId',
+          source: 'json',
+          codec: {
+            mode: 'strict',
+            typeSymbol: 'clawock-dsh#clawockStudio/get:runId',
+            schema: stringSchema,
+          },
+        }],
+        result: {
+          mode: 'strict',
+          typeSymbol: 'clawock-dsh#clawockStudio/get:result',
+          schema: passthroughSchema,
+        },
+      }],
+    }
+
+    /** Services required by the registration and the mounted Remote face. */
+    var inject = ['slots', 'remote']
 
     /** Register the Decision Studio tab into the conversation view ring. */
-    function apply(ctx) {
+    async function apply(ctx) {
+      await ctx.remote.$mount(TYPERT_REMOTE)
+      var studioRemote = ctx.get('remote.clawockStudio')
       ctx.slots.inject('conversation.view', function () {
         return ctx.slots.register({
           name: 'conversation.view',
@@ -165,14 +231,16 @@ window.__ModuleLoader__.load({
           order: 30,
           label: function () { return 'Decision Studio' },
           inject: function () {
+            var call = async function (method, args) {
+              var result = await studioRemote[method].apply(studioRemote, args)
+              if (!result.ok) {
+                throw new Error('clawockStudio.' + method + ' failed: ' + result.error.code + ': ' + result.error.message)
+              }
+              return result.value
+            }
             return {
-              list: async function () {
-                var result = await ctx.remote.clawockStudio.list()
-                if (!result.ok) {
-                  throw new Error('clawockStudio.list failed: ' + result.error.code + ': ' + result.error.message)
-                }
-                return result.value
-              },
+              list: function () { return call('list', []) },
+              get: function (runId) { return call('get', [runId]) },
             }
           },
         }, DecisionStudio)

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -1,0 +1,185 @@
+/**
+ * clawock-dsh browser bundle: the Decision Studio conversation-view tab.
+ *
+ * Shape contract (dsh-client-modules): the file registers one lazy CJS
+ * factory through `window.__ModuleLoader__.load({ id, factory })`; the
+ * factory's `require` resolves externals from the web shell's module graph
+ * (`@deepseek-ai/dsh-client-runtime/client`, `react`). This file is the
+ * shipped artifact — hand-authored, no build step. The model builder is
+ * exported as a test seam (`_buildStudioModel`).
+ */
+window.__ModuleLoader__.load({
+  id: 'clawock-dsh',
+  factory: (require) => {
+    var module = { exports: {} }
+    var exports = module.exports
+    var clientRuntime = require('@deepseek-ai/dsh-client-runtime/client')
+    var React = require('react')
+    var useEffect = React.useEffect
+    var useState = React.useState
+    var h = React.createElement
+
+    /** Pure projection of one run's files into what the tab renders. */
+    function _buildStudioModel(run) {
+      if (run === null || run.request === null) {
+        return { empty: true, subject: null, gates: null, decision: null, receipt: null }
+      }
+      var request = run.request
+      var decision = run.decision
+      var manifest = run.manifest
+      return {
+        empty: false,
+        runId: run.runId,
+        subject: request.subject ?? null,
+        asOf: request.as_of ?? null,
+        task: request.task ?? null,
+        workflow: request.workflow ?? null,
+        gates: (request.workflow && request.workflow.parameters) ?? null,
+        documents: (request.context && request.context.documents) ?? [],
+        evidence: (decision && decision.evidence) ?? [],
+        debate: (decision && decision.debate) ?? null,
+        thesis: (decision && decision.thesis) ?? null,
+        action: decision ? decision.decision : null,
+        receiptStatus: manifest ? 'published' : null,
+        generationId: manifest ? manifest.generation_id : null,
+      }
+    }
+
+    var CARD = { margin: '12px 0', padding: '14px 16px', border: '1px solid #243048', borderRadius: '12px', background: '#161d2e' }
+    var GREEN = '#2ecc71'
+    var RED = '#e74c3c'
+    var MUTED = '#8a94a8'
+
+    function Row(props) {
+      return h('div', { style: { margin: '4px 0', color: props.muted ? MUTED : '#e8edf5', fontSize: 13 } }, props.label ? h('span', { style: { color: MUTED, marginRight: 8 } }, props.label) : null, props.value)
+    }
+
+    function GateRow(props) {
+      return h('div', { style: { display: 'flex', justifyContent: 'space-between', padding: '4px 0', borderBottom: '1px solid #1d2740' } },
+        h('span', { style: { color: MUTED, fontSize: 13 } }, props.name),
+        h('span', { style: { fontSize: 13 } }, String(props.value)))
+    }
+
+    function EvidenceRow(props) {
+      var color = props.stance === 'opposing' ? RED : GREEN
+      return h('div', { style: { padding: '6px 0', borderBottom: '1px solid #1d2740' } },
+        h('div', {}, h('span', { style: { color: color, fontWeight: 700, marginRight: 8 } }, props.stance),
+          h('span', { style: { fontSize: 13 } }, props.summary)),
+        h('div', { style: { color: MUTED, fontSize: 12 } }, props.source + ' · ' + props.sourceClass + ' · ' + props.observedAt))
+    }
+
+    function ReceiptBanner(props) {
+      var published = props.status === 'published'
+      return h('div', { style: { marginTop: 12, padding: '10px 14px', borderRadius: 10, border: '1px solid ' + (published ? GREEN : RED), background: published ? '#10241a' : '#241010' } },
+        h('span', { style: { color: published ? GREEN : RED, fontWeight: 800, marginRight: 10 } }, published ? 'PUBLISHED' : 'REJECTED'),
+        h('span', { style: { fontSize: 12, color: MUTED } }, 'run_id ' + props.runId + (props.generationId ? ' · generation ' + props.generationId : ' · no receipt yet')))
+    }
+
+    /** The conversation.view tab: run list + selected run detail. */
+    function DecisionStudio(props) {
+      var pair = useState({ runs: [], selected: null, loading: true, error: null })
+      var state = pair[0]
+      var setState = pair[1]
+      var sessionId = props.sessionId
+      useEffect(function () {
+        var alive = true
+        setState(function (current) { return Object.assign({}, current, { loading: true, error: null }) })
+        props.list().then(function (result) {
+          if (!alive) return
+          setState(function (current) { return Object.assign({}, current, { runs: result.runs, loading: false }) })
+        }, function (error) {
+          if (!alive) return
+          setState(function (current) { return Object.assign({}, current, { error: String(error && error.message ? error.message : error), loading: false }) })
+        })
+        return function () { alive = false }
+      }, [sessionId])
+
+      var loading = state.loading
+      var error = state.error
+      var runs = state.runs
+      var selectedId = state.selected
+
+      if (error) return h('div', { style: CARD }, h('span', { style: { color: RED } }, 'Decision Studio: ' + error))
+      if (loading) return h('div', { style: CARD }, 'Loading clawock runs…')
+
+      var selectedRun = null
+      for (var i = 0; i < runs.length; i += 1) {
+        if (runs[i].runId === selectedId) { selectedRun = runs[i]; break }
+      }
+
+      var detail = null
+      if (selectedRun) {
+        var model = _buildStudioModel(selectedRun)
+        if (!model.empty) {
+          detail = h('div', { style: CARD },
+            h('div', { style: { fontSize: 14, fontWeight: 700, marginBottom: 8 } },
+              model.subject ? model.subject.ticker + ' (' + model.subject.market + '/' + model.subject.currency + ')' : 'unknown subject'),
+            h(Row, { label: 'run_id', value: model.runId, muted: true }),
+            h(Row, { label: 'as_of', value: model.asOf || '—' }),
+            h('div', { style: { marginTop: 8 } },
+              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'GATES'),
+              (model.gates ? Object.keys(model.gates).map(function (key) {
+                return h(GateRow, { key: key, name: key, value: model.gates[key] })
+              }) : null)),
+            h('div', { style: { marginTop: 10 } },
+              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'DEBATE'),
+              (model.evidence || []).map(function (row) {
+                return h(EvidenceRow, { key: row.id, stance: row.stance, summary: row.summary, source: row.source, sourceClass: row.source_class, observedAt: row.observed_at })
+              })),
+            h('div', { style: { marginTop: 10 } },
+              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'THESIS'),
+              h(Row, { value: model.thesis ? model.thesis.statement : '—' }),
+              model.action ? h(Row, { label: 'action', value: model.action.action + ' · confidence ' + (model.thesis ? model.thesis.confidence : '—') }) : null),
+            h(ReceiptBanner, { status: model.receiptStatus || 'rejected', runId: model.runId, generationId: model.generationId }))
+        }
+      }
+
+      return h('div', { style: { padding: 4 } },
+        h('div', { style: { color: MUTED, fontSize: 12, marginBottom: 6 } }, 'clawock runs in this workspace (' + runs.length + ')'),
+        runs.map(function (run) {
+          var ticker = run.subject && run.subject.ticker ? run.subject.ticker : run.runId
+          var status = run.receiptPresent ? 'published' : 'no receipt'
+          var label = ticker + ' · ' + status + (run.decisionPresent ? ' · decision' : '')
+          return h('button', {
+            key: run.runId,
+            onClick: function () { setState(function (current) { return Object.assign({}, current, { selected: run.runId }) }) },
+            style: {
+              display: 'block', width: '100%', textAlign: 'left', margin: '4px 0', padding: '8px 10px',
+              border: '1px solid ' + (run.runId === selectedId ? GREEN : '#243048'),
+              borderRadius: 8, background: run.runId === selectedId ? '#1b2a45' : '#161d2e', color: '#e8edf5', cursor: 'pointer', fontSize: 13,
+            },
+          }, label, '  ', h('span', { style: { color: MUTED } }, run.asOf || ''))
+        }),
+        detail)
+    }
+
+    /** Services required by the registration and the generated Remote face. */
+    var inject = ['slots', 'remote', 'remote.clawockStudio']
+
+    /** Register the Decision Studio tab into the conversation view ring. */
+    function apply(ctx) {
+      ctx.slots.inject('conversation.view', function () {
+        return ctx.slots.register({
+          name: 'conversation.view',
+          id: 'decision-studio',
+          order: 30,
+          label: function () { return 'Decision Studio' },
+          inject: function () {
+            return {
+              list: async function () {
+                var result = await ctx.remote.clawockStudio.list()
+                if (!result.ok) {
+                  throw new Error('clawockStudio.list failed: ' + result.error.code + ': ' + result.error.message)
+                }
+                return result.value
+              },
+            }
+          },
+        }, DecisionStudio)
+      })
+    }
+
+    module.exports = { apply: apply, inject: inject, _buildStudioModel: _buildStudioModel }
+    return module.exports
+  },
+})

--- a/examples/dsh/plugin/cordis.patch.yml
+++ b/examples/dsh/plugin/cordis.patch.yml
@@ -1,0 +1,7 @@
+# clawock-dsh patch layer: one read-only Remote gateway row feeding the
+# Decision Studio conversation-view tab. The row's package (clawock-dsh) is
+# resolved from the profile's node_modules after `dsh plugin --profile web
+# add clawock-dsh`.
+- insert:
+    - id: clawock-studio
+      name: clawock-dsh

--- a/examples/dsh/plugin/lib/index.js
+++ b/examples/dsh/plugin/lib/index.js
@@ -1,0 +1,69 @@
+/**
+ * Read-only Typert Remote gateway over a clawock workspace, powering the
+ * Decision Studio conversation-view tab in the DSH web GUI.
+ *
+ * This is a Cordis service plugin: default-export the service class; the
+ * profile patch layer inserts one row (`clawock-studio`). The workspace root
+ * is `$CLAWOCK_WORKSPACE` when set, otherwise the dsh process cwd.
+ */
+
+import { TypertRemoteService, Remote } from '@deepseek-ai/dsh-typert-protocol'
+import { listRuns, getRun } from './scan.js'
+
+const workspaceOf = () => process.env.CLAWOCK_WORKSPACE || process.cwd()
+
+/**
+ * Standard-method-decorator markers, applied by hand: plain ESM cannot carry
+ * `@Remote` decorator syntax without a build step, so we drive the exported
+ * decorator factory with a fabricated decorator context. The initializer it
+ * schedules is a normal function we run with `this` bound to a live instance
+ * after construction; `mark()` keys the private marker table by the instance
+ * prototype, exactly as the engine-driven path does.
+ */
+function markRemote(serviceClass, methodName, exportName) {
+  const initializers = []
+  const context = {
+    kind: 'method',
+    name: methodName,
+    static: false,
+    private: false,
+    access: { get: () => serviceClass.prototype[methodName] },
+    addInitializer(fn) {
+      initializers.push(fn)
+    },
+  }
+  Remote(exportName)(serviceClass.prototype[methodName], context)
+  serviceClass.prototype.__clawockRemoteInitializers =
+    (serviceClass.prototype.__clawockRemoteInitializers ?? []).concat(initializers)
+}
+
+/** Read-only gateway: list prepared runs and fetch one run's full detail. */
+export class ClawockStudioGateway extends TypertRemoteService {
+  static inject = []
+
+  constructor(ctx) {
+    super(ctx, 'clawockStudio')
+    for (const initializer of this.__clawockRemoteInitializers) {
+      initializer.call(this)
+    }
+  }
+
+  /** @returns Prepared runs (newest first), with decision/receipt presence flags. */
+  list() {
+    return { runs: listRuns(workspaceOf()) }
+  }
+
+  /**
+   * Full detail of one run.
+   * @param runId - 32-hex run id; anything else is rejected before any path use.
+   * @returns Certified request, current decision artifact and receipt manifest (null when absent).
+   */
+  get(runId) {
+    return getRun(workspaceOf(), runId)
+  }
+}
+
+markRemote(ClawockStudioGateway, 'list', 'list')
+markRemote(ClawockStudioGateway, 'get', 'get')
+
+export default ClawockStudioGateway

--- a/examples/dsh/plugin/lib/scan.js
+++ b/examples/dsh/plugin/lib/scan.js
@@ -54,6 +54,7 @@ export function listRuns(workspace) {
     return []
   }
   const runs = []
+  const decision = decisionOf(workspace)
   for (const entry of entries) {
     if (!entry.isDirectory() || !RUN_ID_PATTERN.test(entry.name)) continue
     const requestPath = join(workDir, entry.name, 'request.json')
@@ -69,12 +70,14 @@ export function listRuns(workspace) {
     runs.push({
       runId: entry.name,
       subject: request.subject ?? null,
+      decisionSubject: decision?.subject ?? null,
+      decisionAction: decision?.decision?.action ?? null,
       asOf: request.as_of ?? null,
       task: request.task ?? null,
       workflow: request.workflow ?? null,
       gates: request.workflow?.parameters ?? null,
       documentCount: request.context?.documents?.length ?? 0,
-      decisionPresent: decisionOf(workspace) !== null,
+      decisionPresent: decision !== null,
       receiptPresent: manifestOf(workspace, entry.name) !== null,
       mtimeMs,
     })

--- a/examples/dsh/plugin/lib/scan.js
+++ b/examples/dsh/plugin/lib/scan.js
@@ -1,0 +1,105 @@
+/**
+ * Read-only scanner over a clawock workspace: prepared runs, the current
+ * decision artifact, and published receipts. Pure Node, no Cordis/typert
+ * dependencies — unit-testable in isolation.
+ *
+ * Layout (from the clawock contract):
+ *   <workspace>/.clawock/work/<run_id>/request.json   certified request
+ *   <workspace>/decision.json                         current artifact
+ *   <workspace>/.clawock/runs/<run_id>/               receipt store (manifest.json + artifacts)
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Request files are written under .clawock/work/<32-hex run id>/request.json. */
+export const RUN_ID_PATTERN = /^[0-9a-f]{32}$/
+
+/** Validate a run id; this is also the path-safety boundary for directory joins. */
+export function runIdOf(value) {
+  if (typeof value !== 'string' || !RUN_ID_PATTERN.test(value)) {
+    throw new TypeError(`invalid clawock run id: ${String(value)}`)
+  }
+  return value
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function decisionOf(workspace) {
+  return readJson(join(workspace, 'decision.json'))
+}
+
+function manifestOf(workspace, runId) {
+  return readJson(join(workspace, '.clawock', 'runs', runId, 'manifest.json'))
+}
+
+/**
+ * Snapshot every prepared run with enough to render a list row.
+ * @param workspace - clawock workspace root.
+ * @returns runs ordered by request file mtime, newest first.
+ */
+export function listRuns(workspace) {
+  const workDir = join(workspace, '.clawock', 'work')
+  let entries = []
+  try {
+    entries = readdirSync(workDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const runs = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !RUN_ID_PATTERN.test(entry.name)) continue
+    const requestPath = join(workDir, entry.name, 'request.json')
+    if (!existsSync(requestPath)) continue
+    const request = readJson(requestPath)
+    if (request === null) continue
+    let mtimeMs = 0
+    try {
+      mtimeMs = statSync(requestPath).mtimeMs
+    } catch {
+      /* keep 0 */
+    }
+    runs.push({
+      runId: entry.name,
+      subject: request.subject ?? null,
+      asOf: request.as_of ?? null,
+      task: request.task ?? null,
+      workflow: request.workflow ?? null,
+      gates: request.workflow?.parameters ?? null,
+      documentCount: request.context?.documents?.length ?? 0,
+      decisionPresent: decisionOf(workspace) !== null,
+      receiptPresent: manifestOf(workspace, entry.name) !== null,
+      mtimeMs,
+    })
+  }
+  runs.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return runs
+}
+
+/**
+ * Full detail of one run: certified request, current decision artifact and
+ * receipt manifest. Missing pieces stay null — a prepared-but-unpublished
+ * run is a valid state.
+ * @param workspace - clawock workspace root.
+ * @param runId - 32-hex run id; anything else is rejected before any path use.
+ */
+export function getRun(workspace, runId) {
+  const id = runIdOf(runId)
+  const request = readJson(join(workspace, '.clawock', 'work', id, 'request.json'))
+  if (request === null) {
+    return { runId: id, request: null, decision: null, manifest: null }
+  }
+  return {
+    runId: id,
+    request,
+    decision: decisionOf(workspace),
+    manifest: manifestOf(workspace, id),
+  }
+}

--- a/examples/dsh/plugin/package.json
+++ b/examples/dsh/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawock-dsh",
   "version": "0.1.4",
-  "description": "clawock investment-decision workflow skill for DeepSeek Harness agents — evidence, opposing case, deterministic settlement, public scorecard",
+  "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Studio conversation-view tab",
   "license": "MIT",
   "keywords": [
     "dsh",
@@ -12,10 +12,30 @@
     "trading",
     "skill"
   ],
+  "type": "module",
+  "main": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./client.js",
+    "./package.json": "./package.json"
+  },
   "files": [
-    "skills"
+    "skills",
+    "lib",
+    "client.js",
+    "cordis.patch.yml"
   ],
+  "dependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+  },
   "dsh": {
+    "bundle": {
+      "patch": "cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web"
+    },
     "skills": [
       "./skills/investment-decision/SKILL.md"
     ]

--- a/examples/dsh/plugin/package.json
+++ b/examples/dsh/plugin/package.json
@@ -15,8 +15,12 @@
   "type": "module",
   "main": "./lib/index.js",
   "exports": {
-    ".": "./lib/index.js",
-    "./client": "./client.js",
+    ".": {
+      "default": "./lib/index.js"
+    },
+    "./client": {
+      "default": "./client.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -26,8 +30,10 @@
     "cordis.patch.yml"
   ],
   "dependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
   },
   "dsh": {
     "bundle": {

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -59,6 +59,7 @@ test("scan: lists a prepared run with decision and receipt presence", async () =
     assert.equal(runs[0].subject.ticker, "DEMO");
     assert.equal(runs[0].documentCount, 1);
     assert.equal(runs[0].decisionPresent, true);
+    assert.equal(runs[0].decisionAction, "watch");
     assert.equal(runs[0].receiptPresent, true);
     assert.equal(runs[0].gates.min_opposing_evidence, 1);
 
@@ -136,21 +137,25 @@ test("client: registers the Decision Studio conversation.view tab", async () => 
   assert.equal(loaded.id, "clawock-dsh");
 
   const api = loaded.factory(requireStub);
-  assert.deepEqual(api.inject, ["slots", "remote", "remote.clawockStudio"]);
+  assert.deepEqual(api.inject, ["slots", "remote"]);
   assert.equal(typeof api.apply, "function");
 
   let registered = null;
   let component = null;
-  const remoteList = async () => ({ ok: true, value: { runs: [] } });
+  const remoteFace = {
+    list: async () => ({ ok: true, value: { runs: [] } }),
+    get: async (runId) => ({ ok: true, value: { runId, request: null, decision: null, manifest: null } }),
+  };
   const ctx = {
     effect() {},
+    get(name) { assert.equal(name, "remote.clawockStudio"); return remoteFace; },
     slots: {
       inject(name, fn) { assert.equal(name, "conversation.view"); this._fn = fn; },
       register(definition, Component) { registered = definition; component = Component; },
     },
-    remote: { clawockStudio: { list: remoteList } },
+    remote: { $mount: async (descriptors) => { assert.ok(descriptors.descriptors.length >= 2); } },
   };
-  api.apply(ctx);
+  await api.apply(ctx);
   ctx.slots._fn(); // slots.inject registers lazily once the slot exists
   assert.ok(registered, "apply must register into conversation.view");
   assert.equal(registered.name, "conversation.view");
@@ -160,8 +165,11 @@ test("client: registers the Decision Studio conversation.view tab", async () => 
 
   const injected = registered.inject("session-1");
   assert.equal(typeof injected.list, "function");
+  assert.equal(typeof injected.get, "function");
   const result = await injected.list();
   assert.deepEqual(result, { runs: [] });
+  const detail = await injected.get("0123456789abcdef0123456789abcdef");
+  assert.equal(detail.request, null);
   assert.equal(typeof component, "function");
 });
 
@@ -217,30 +225,67 @@ test("client: the tab component renders the run list from the remote", async () 
 
   let component = null;
   let registered = null;
+  const runId = "0123456789abcdef0123456789abcdef";
+  const remoteFace = {
+    list: async () => ({
+      ok: true,
+      value: { runs: [{ runId, subject: { ticker: "DEMO" }, asOf: "2026-08-16T12:00:00+00:00", decisionPresent: true, receiptPresent: true }] },
+    }),
+    get: async (id) => ({
+      ok: true,
+      value: {
+        runId: id,
+        request: {
+          subject: { ticker: "DEMO", market: "US", currency: "USD" },
+          as_of: "2026-08-16T12:00:00+00:00",
+          workflow: { parameters: { min_supporting_evidence: 1, min_opposing_evidence: 1, max_confidence_without_primary_source: 0.65 } },
+          context: { documents: [{ name: "CONTEXT.md" }] },
+        },
+        decision: {
+          subject: { ticker: "DEMO", market: "US", currency: "USD" },
+          evidence: [{ id: "e1", stance: "opposing", summary: "valuation risk", source: "market", source_class: "market", observed_at: "2026-08-16T11:45:00+00:00" }],
+          debate: { bull_case: {}, bear_case: {} },
+          thesis: { statement: "constructive but expensive", confidence: 0.7 },
+          decision: { action: "watch" },
+        },
+        manifest: { generation_id: "g1" },
+      },
+    }),
+  };
   const ctx = {
     effect() {},
+    get(name) { assert.equal(name, "remote.clawockStudio"); return remoteFace; },
     slots: {
       inject(name, fn) { this._fn = fn; },
       register(definition, Component) { registered = definition; component = Component; },
     },
-    remote: {
-      clawockStudio: {
-        list: async () => ({
-          ok: true,
-          value: { runs: [{ runId: "0123456789abcdef0123456789abcdef", subject: { ticker: "DEMO" }, asOf: "2026-08-16T12:00:00+00:00", decisionPresent: true, receiptPresent: true }] },
-        }),
-      },
-    },
+    remote: { $mount: async () => {} },
   };
-  api.apply(ctx);
+  await api.apply(ctx);
   ctx.slots._fn();
   const injected = registered.inject("s1"); // the real injected face unwraps the remote envelope
 
-  const tree = (await (async () => {
-    component({ sessionId: "s1", list: injected.list });
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
-    return component({ sessionId: "s1", list: injected.list });
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  const render = () => component({ sessionId: "s1", list: injected.list, get: injected.get });
+  let tree = (await (async () => {
+    render();
+    await tick(); await tick(); await tick();
+    return render();
+  })());
+
+  // click the run row, then let list + get resolve, then re-render
+  tree = (await (async () => {
+    const buttons = [];
+    (function find(node) {
+      if (node == null) return;
+      if (Array.isArray(node)) { node.forEach(find); return; }
+      if (node.type === "button") buttons.push(node);
+      (node.children || []).forEach(find);
+    })(tree);
+    assert.equal(buttons.length, 1, "the run list must render one row button");
+    buttons[0].props.onClick();
+    await tick(); await tick(); await tick(); await tick();
+    return render();
   })());
 
   const text = [];

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Decision Studio plugin tests (clawock-dsh node + client halves).
+ *
+ * Run: node tests/decision_studio_plugin.spec.js
+ * CI: harness-regression.yml runs it when plugin files change.
+ *
+ * What is verified without a browser:
+ *   - scan.js: workspace listing, run detail, run-id path-safety boundary
+ *   - client.js: module-loader registration shape, inject face, model
+ *     projection, and a stub-react render of the run list
+ * The visual tab boot remains a source-machine verification (no GUI here).
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const test = require("node:test");
+
+const PLUGIN = path.join(__dirname, "..", "examples", "dsh", "plugin");
+
+function makeWorkspace() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-studio-"));
+  const runId = "0123456789abcdef0123456789abcdef";
+  const work = path.join(root, ".clawock", "work", runId);
+  fs.mkdirSync(work, { recursive: true });
+  fs.writeFileSync(path.join(work, "request.json"), JSON.stringify({
+    schema_version: 1,
+    run_id: runId,
+    generation_id: "fedcba9876543210fedcba9876543210",
+    task: "Produce decision.json for an evidence-linked investment decision.",
+    context: { documents: [{ name: "CONTEXT.md", sha256: "aa".repeat(32) }] },
+    workflow: {
+      id: "investment-decision", version: "1.1.0",
+      parameters: { min_supporting_evidence: 1, min_opposing_evidence: 1, max_confidence_without_primary_source: 0.65 },
+    },
+    subject: { ticker: "DEMO", market: "US", currency: "USD" },
+    as_of: "2026-08-16T12:00:00+00:00",
+  }));
+  fs.mkdirSync(path.join(root, ".clawock", "runs", runId), { recursive: true });
+  fs.writeFileSync(path.join(root, ".clawock", "runs", runId, "manifest.json"), JSON.stringify({
+    generation_id: "fedcba9876543210fedcba9876543210",
+    artifacts: [{ name: "decision.json" }],
+  }));
+  fs.writeFileSync(path.join(root, "decision.json"), JSON.stringify({ decision: { action: "watch" } }));
+  return { root, runId };
+}
+
+test("scan: lists a prepared run with decision and receipt presence", async () => {
+  const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
+  const { root, runId } = makeWorkspace();
+  try {
+    const runs = scan.listRuns(root);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].runId, runId);
+    assert.equal(runs[0].subject.ticker, "DEMO");
+    assert.equal(runs[0].documentCount, 1);
+    assert.equal(runs[0].decisionPresent, true);
+    assert.equal(runs[0].receiptPresent, true);
+    assert.equal(runs[0].gates.min_opposing_evidence, 1);
+
+    const detail = scan.getRun(root, runId);
+    assert.equal(detail.request.workflow.id, "investment-decision");
+    assert.deepEqual(detail.decision.decision, { action: "watch" });
+    assert.equal(detail.manifest.artifacts[0].name, "decision.json");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scan: ignores non-run directories and missing workspaces", async () => {
+  const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-studio-"));
+  try {
+    fs.mkdirSync(path.join(root, ".clawock", "work", "not-a-run"), { recursive: true });
+    fs.writeFileSync(path.join(root, ".clawock", "work", "not-a-run", "request.json"), "{}");
+    assert.deepEqual(scan.listRuns(root), []);
+
+    const missing = scan.getRun(root, "0123456789abcdef0123456789abcdef");
+    assert.equal(missing.request, null);
+    assert.deepEqual(scan.listRuns(path.join(root, "does-not-exist")), []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scan: run ids are the path-safety boundary", async () => {
+  const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
+  for (const bad of ["..", "../secret", "abc", "0123456789abcdef0123456789abcdeg", "", null, 42]) {
+    assert.throws(() => scan.getRun("/tmp", bad), TypeError, `run id ${JSON.stringify(bad)} must be rejected`);
+  }
+});
+
+let importCounter = 0;
+function clientUrl() {
+  importCounter += 1;
+  return pathToFileURL(path.join(PLUGIN, "client.js")).href + "?v=" + importCounter;
+}
+
+function makeReactStub() {
+  let state = null;
+  return {
+    createElement(type, props, ...children) {
+      return { type, props: props || {}, children };
+    },
+    useState(initial) {
+      if (state === null) state = typeof initial === "function" ? initial() : initial;
+      return [
+        state,
+        (updater) => {
+          state = typeof updater === "function" ? updater(state) : updater;
+        },
+      ];
+    },
+    useEffect(fn) {
+      fn(); // React runs effects after render; cleanup only on unmount/re-run
+    },
+  };
+}
+
+test("client: registers the Decision Studio conversation.view tab", async () => {
+  let loaded = null;
+  globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
+  const reactStub = makeReactStub();
+  const requireStub = (specifier) => {
+    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (specifier === "react") return reactStub;
+    throw new Error(`unexpected client require: ${specifier}`);
+  };
+
+  await import(clientUrl());
+  assert.ok(loaded, "client.js must register through the module loader");
+  assert.equal(loaded.id, "clawock-dsh");
+
+  const api = loaded.factory(requireStub);
+  assert.deepEqual(api.inject, ["slots", "remote", "remote.clawockStudio"]);
+  assert.equal(typeof api.apply, "function");
+
+  let registered = null;
+  let component = null;
+  const remoteList = async () => ({ ok: true, value: { runs: [] } });
+  const ctx = {
+    effect() {},
+    slots: {
+      inject(name, fn) { assert.equal(name, "conversation.view"); this._fn = fn; },
+      register(definition, Component) { registered = definition; component = Component; },
+    },
+    remote: { clawockStudio: { list: remoteList } },
+  };
+  api.apply(ctx);
+  ctx.slots._fn(); // slots.inject registers lazily once the slot exists
+  assert.ok(registered, "apply must register into conversation.view");
+  assert.equal(registered.name, "conversation.view");
+  assert.equal(registered.id, "decision-studio");
+  assert.equal(registered.order, 30);
+  assert.equal(registered.label(), "Decision Studio");
+
+  const injected = registered.inject("session-1");
+  assert.equal(typeof injected.list, "function");
+  const result = await injected.list();
+  assert.deepEqual(result, { runs: [] });
+  assert.equal(typeof component, "function");
+});
+
+test("client: _buildStudioModel projects run files for the tab", async () => {
+  let loaded = null;
+  globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
+  await import(clientUrl());
+  const api = loaded.factory((specifier) => {
+    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (specifier === "react") return makeReactStub();
+    throw new Error(`unexpected client require: ${specifier}`);
+  });
+
+  const empty = api._buildStudioModel({ runId: "0123456789abcdef0123456789abcdef", request: null });
+  assert.equal(empty.empty, true);
+
+  const full = api._buildStudioModel({
+    runId: "0123456789abcdef0123456789abcdef",
+    request: {
+      subject: { ticker: "DEMO", market: "US", currency: "USD" },
+      as_of: "2026-08-16T12:00:00+00:00",
+      workflow: { parameters: { min_opposing_evidence: 1 } },
+      context: { documents: [{ name: "CONTEXT.md" }] },
+    },
+    decision: {
+      evidence: [{ id: "e1", stance: "opposing", summary: "risk", source: "market", source_class: "market", observed_at: "t" }],
+      debate: { bull_case: {}, bear_case: {} },
+      thesis: { statement: "s", confidence: 0.7 },
+      decision: { action: "watch" },
+    },
+    manifest: { generation_id: "g1" },
+  });
+  assert.equal(full.empty, false);
+  assert.equal(full.subject.ticker, "DEMO");
+  assert.equal(full.gates.min_opposing_evidence, 1);
+  assert.equal(full.evidence[0].stance, "opposing");
+  assert.equal(full.action.action, "watch");
+  assert.equal(full.receiptStatus, "published");
+  assert.equal(full.generationId, "g1");
+});
+
+test("client: the tab component renders the run list from the remote", async () => {
+  let loaded = null;
+  globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
+  const reactStub = makeReactStub();
+  const requireStub = (specifier) => {
+    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (specifier === "react") return reactStub;
+    throw new Error(`unexpected client require: ${specifier}`);
+  };
+  await import(clientUrl());
+  const api = loaded.factory(requireStub);
+
+  let component = null;
+  let registered = null;
+  const ctx = {
+    effect() {},
+    slots: {
+      inject(name, fn) { this._fn = fn; },
+      register(definition, Component) { registered = definition; component = Component; },
+    },
+    remote: {
+      clawockStudio: {
+        list: async () => ({
+          ok: true,
+          value: { runs: [{ runId: "0123456789abcdef0123456789abcdef", subject: { ticker: "DEMO" }, asOf: "2026-08-16T12:00:00+00:00", decisionPresent: true, receiptPresent: true }] },
+        }),
+      },
+    },
+  };
+  api.apply(ctx);
+  ctx.slots._fn();
+  const injected = registered.inject("s1"); // the real injected face unwraps the remote envelope
+
+  const tree = (await (async () => {
+    component({ sessionId: "s1", list: injected.list });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    return component({ sessionId: "s1", list: injected.list });
+  })());
+
+  const text = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { text.push(node); return; }
+    (node.children || []).forEach(walk);
+    walk(node.props && node.props.value);
+    walk(node.props && node.props.label);
+    walk(node.props && node.props.name);
+  })(tree);
+  const joined = text.join(" ");
+  assert.match(joined, /DEMO/);
+  assert.match(joined, /1/);
+});


### PR DESCRIPTION
## 背景

#651 的实现:clawock-dsh 从纯 skill 包升级为带 web UI 的完整 DSH 插件。参考 DSH 源码仓(deepseek-ai/deepseek-harness,已自行下载浅克隆到本机)的真实契约实现,非猜。

## 新增/改动

| 文件 | 内容 |
|---|---|
| `package.json` | `dsh.bundle.patch`(`cordis.patch.yml`)+ `dsh.client`(web)+ `exports["./client"]`;依赖 `@deepseek-ai/cordis`、`@deepseek-ai/dsh-typert-protocol` |
| `cordis.patch.yml` | profile patch 行 `clawock-studio` → `clawock-dsh`(node 半区成为真 profile 层) |
| `lib/scan.js` | 纯只读扫描:`.clawock/work/<run_id>/request.json` + workspace 根 `decision.json` + `.clawock/runs/<run_id>/manifest.json`;run id 32-hex 校验即路径安全边界 |
| `lib/index.js` | `ClawockStudioGateway`(TypertRemoteService):`list`/`get` 两个 Remote;workspace = `$CLAWOCK_WORKSPACE` 或 dsh 进程 cwd |
| `client.js` | module-loader factory bundle(手写、零构建,契约与 trajectory dist 同形);注册 `conversation.view` tab(Decision Studio, order 30):run 列表 + 详情(certified request/闸门/debate 证据绿红/回执横幅) |
| `tests/decision_studio_plugin.spec.js` | node:test 6 例:扫描、路径穿越拒绝、注册形状、注入面、模型投影、stub-react 渲染;接入 `harness-regression.yml`(dsplugin 变更门) |

## 关键实现点

- **ESM 无 legacy 装饰器语法**:手工调用导出的 `Remote(exportName)` 工厂 + 构造 decorator context,把标记初始化器推迟到实例构造后以 `this=instance` 执行——已在沙箱用**真实 typert-protocol** 验证 `remoteMethods()` 识别 list/get、list/get 对真实 workspace 调用成功、`get('../..')` 被拒。
- 数据通道:`ctx.remote.clawockStudio.list()/get()`(`{ok,value}` 信封,`inject: ['slots','remote','remote.clawockStudio']`),与第一方 ui-settings-plugin-inventory 同形。
- 只读:面板不改任何文件;结算仍归 `clawock run publish`。

## 验证状态

- [x] `node --check` 三个 JS 全过;spec 6/6(扫描/注册/渲染)
- [x] npm pack 10 文件齐全(client/lib/cordis.patch/skills)
- [x] 真实 typert-protocol 沙箱验证(node 半区)
- [ ] **浏览器目验**:本机 DSH 是 dist-only 安装,无 `pnpm run dev:web` 构建链;tab 的实际渲染需在带 DSH 源码/工具链的机器 boot 后确认(截图回填本 issue)

## 后续

1. 合并本 PR 后,源码机安装 `clawock-dsh@next` → web profile 重启 → 会话视图应出现 Decision Studio tab;目验截图回填
2. 下个 v* tag 发布 npm(README/接线不变)
3. 已知限制:rc.6 的 `dsh.skills` 字段仍无消费者(skill 靠 cp 进发现根),保留为前向兼容;面板无写路径、无 settings 页(rc.6 out-of-tree allowlist 限制)