### PR TITLE
fix: 盘中 delta 闸保留 early_trend:exploration_ready 身份,解锁跳变按 delta 投递(#645)

### DIFF
--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -82,14 +82,24 @@ def semantic_state(market, session_date, *, signals_detail, anomalies, setups,
             })
     # #610: the price-surface lanes encode their live sub-state in setup_id
     # (opportunity:{breakout|wait_rebreak|near_breakout},
-    # early_trend:{state}) and those sub-states flip on raw quote churn around
-    # a threshold (close vs prior, zscore20 vs 2.0) — exactly the churn this
-    # gate exists to exclude. Compare the lane identity, not the churny
+    # early_trend:{state}) and most of those sub-states flip on raw quote churn
+    # around a threshold (close vs prior, zscore20 vs 2.0) — exactly the churn
+    # this gate exists to exclude. Compare the lane identity, not the churny
     # sub-state; a row appearing or disappearing still counts as a delta.
+    #
+    # #645: one sub-state is NOT quote churn — early_trend:exploration_ready is
+    # driven by primary_ids / the information layer (#603), and the
+    # wait_information→exploration_ready flip unlocks a 2.5% exploration
+    # tranche. That decision-relevant jump must stay a delta: keep the
+    # exploration_ready identity, collapse only the churny sub-states.
     def _stable_setup_id(setup_id):
         if setup_id and ':' in str(setup_id):
-            prefix = str(setup_id).split(':', 1)[0]
-            if prefix in ('opportunity', 'early_trend'):
+            prefix, _, sub = str(setup_id).partition(':')
+            if prefix == 'opportunity':
+                return prefix
+            if prefix == 'early_trend':
+                if sub == 'exploration_ready':
+                    return setup_id
                 return prefix
         return setup_id
 

--- a/tests/test_intraday_delta_gate.py
+++ b/tests/test_intraday_delta_gate.py
@@ -301,7 +301,11 @@ def test_setup_sub_state_churn_is_not_a_delta():
     """#610: opportunity/early_trend sub-states flip on raw quote churn around
     a threshold (close vs prior, zscore20 vs 2.0). The gate compares the lane
     identity, not the churny sub-state; row appearance/disappearance still
-    counts, and non-lane setup ids keep their full identity."""
+    counts, and non-lane setup ids keep their full identity.
+
+    #645: early_trend:exploration_ready is NOT quote churn — it is driven by
+    primary_ids / the information layer, and its unlock jump must stay a delta.
+    Only the churny sub-states collapse to the lane identity."""
     base = dict(market="hk", session_date="2026-08-14",
                 signals_detail=[], anomalies=[], plans={"open": []},
                 active_information={})
@@ -313,12 +317,26 @@ def test_setup_sub_state_churn_is_not_a_delta():
         **base, setups={"rows": [{**row, "setup_id": "opportunity:wait_rebreak"}]})
     s_early = gate.semantic_state(
         **base, setups={"rows": [{**row, "setup_id": "early_trend:wait_information"}]})
+    s_early_pullback = gate.semantic_state(
+        **base, setups={"rows": [{**row, "setup_id":
+                                  "early_trend:wait_pullback_rebreak"}]})
     s_early_ready = gate.semantic_state(
-        **base, setups={"rows": [{**row, "setup_id": "early_trend:exploration_ready"}]})
+        **base, setups={"rows": [{**row, "setup_id":
+                                  "early_trend:exploration_ready"}]})
 
+    # quote-churn sub-states within a lane collapse to the lane identity
     assert s_breakout["setups"] == s_wait["setups"]
-    assert s_early["setups"] == s_early_ready["setups"]
+    assert s_early["setups"] == s_early_pullback["setups"]
     assert gate.compare_semantic_states(s_breakout, s_wait)["changed"] is False
+    assert gate.compare_semantic_states(
+        s_early, s_early_pullback)["changed"] is False
+
+    # #645: the wait_information→exploration_ready unlock (and its loss) is a
+    # decision-relevant delta, not churn to be folded away.
+    assert s_early["setups"] != s_early_ready["setups"]
+    assert gate.compare_semantic_states(s_early, s_early_ready)["changed"] is True
+    assert gate.compare_semantic_states(
+        s_early_ready, s_early_pullback)["changed"] is True
 
     # appearance/disappearance is a real delta
     s_none = gate.semantic_state(**base, setups={"rows": []})


### PR DESCRIPTION
## 修什么

#645:盘中 delta 闸 #610 把 `early_trend:{state}` 全部折叠成 lane 身份,
`wait_information→exploration_ready` 解锁跳变被归并为非 delta → 解锁
2.5% exploration 只发短回执。但 exploration_ready 由 primary_ids /
信息层驱动(#603 修通的盘中 primary_ids),不是 close/zscore 价格 churn。

## 改法

- `intraday_delta.py:_stable_setup_id`:`opportunity:*` 与除
  `exploration_ready` 外的 `early_trend:*` 仍折叠到 lane 身份(quote-churn
  子状态);`early_trend:exploration_ready` 保留完整身份。
- 翻转测试 `test_setup_sub_state_churn_is_not_a_delta` 里被钉死的
  `s_early == s_early_ready` 断言,补双向断言:解锁与丢失解锁都是 delta;
  同时补 `wait_information vs wait_pullback_rebreak` 仍折叠的 quote-churn 断言。

## 验证

- 本地 `tests/test_intraday_delta_gate.py` 14 passed。
- 语义:exploration_ready 解锁/丢失现在按 full_delta 投递,与 #603
  (盘中 primary_ids 通)自洽;纯 zscore/close churn 仍不触发 delta。
