### PR TITLE
refactor: 配置阈值收敛(strong_5d_pct / short_history_max_age_days)+ X or DEFAULT 反模式修复(#640/#643/#649)

### DIFF
--- a/config/add-alpha-policy.json
+++ b/config/add-alpha-policy.json
@@ -17,6 +17,9 @@
   "exploration_max_book_pct": 0.03,
   "early_peer_dispersion_multiple": 1.5,
   "early_no_chase_zscore": 2.0,
+  "strong_5d_pct": 8.0,
+  "short_history_max_age_days": 45,
+  "short_history_max_age_days_rationale": "45 日历天 ≈ 30 交易日,含节假日余量(#608)",
   "validated_max_tranches": 2,
   "validated_tranche_pct": 0.075,
   "markets": {

--- a/src/clawock/decision/early_trend.py
+++ b/src/clawock/decision/early_trend.py
@@ -69,8 +69,11 @@ def classify(technical: dict, peer: dict, information: dict, events: list[dict],
         information_modes.append("attention_acceleration")
     information_ok = bool(information_modes)
     zscore = _number(technical.get("zscore20"))
+    # #649: explicit None check, never `X or DEFAULT` — a config value of 0
+    # (z≥0 永不追高,最保守) must not be swallowed into the 2.0 default.
+    raw_no_chase = policy.get("early_no_chase_zscore")
     overheated = zscore is not None and zscore >= float(
-        policy.get("early_no_chase_zscore") or 2.0
+        raw_no_chase if raw_no_chase is not None else 2.0
     )
 
     blockers = []

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -340,8 +340,30 @@ def compute_short_history_signals(bars):
 
 # A name with ≥30 sessions since listing can reach the mature 30-bar gate; the
 # short-history fallback is for names that genuinely cannot. 45 calendar days
-# ≈ 30 trading sessions, with slack for holidays.
+# ≈ 30 trading sessions, with slack for holidays. The value is policy, not a
+# code constant: the single source of truth is add-alpha-policy.json's
+# `short_history_max_age_days` (#643), read at call time; this module constant
+# is only the fallback when the config is missing.
 SHORT_HISTORY_MAX_AGE_DAYS = 45
+
+
+def _policy_short_history_max_age_days() -> int:
+    """`short_history_max_age_days` from add-alpha-policy.json, default 45.
+
+    Resolved at call time so a config edit applies without a code change; a
+    missing/broken config falls back to the 45-calendar-day default (#643).
+    """
+    try:
+        policy = json.loads(
+            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            .read_text(encoding="utf-8"))
+        raw = policy.get("short_history_max_age_days")
+        if raw is not None:
+            return int(raw)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError,
+            TypeError):
+        pass
+    return SHORT_HISTORY_MAX_AGE_DAYS
 
 
 def is_short_history_candidate(detail, run_date):
@@ -350,9 +372,9 @@ def is_short_history_candidate(detail, run_date):
     The short-history view must not rescue a mature name whose feed returned
     only 20–29 bars (a partial feed): that would bypass the deliberate 30-bar
     data-quality gate with half a signal set. Only names whose registry
-    `listing_date` is present and recent (≤ SHORT_HISTORY_MAX_AGE_DAYS) are
-    candidates; an absent or unparseable listing_date means "not known to be
-    new", and the strict gate stands.
+    `listing_date` is present and recent (≤ the configured window, default
+    SHORT_HISTORY_MAX_AGE_DAYS) are candidates; an absent or unparseable
+    listing_date means "not known to be new", and the strict gate stands.
     """
     ld = (detail or {}).get('listing_date')
     if not ld:
@@ -361,7 +383,7 @@ def is_short_history_candidate(detail, run_date):
         listing = datetime.fromisoformat(ld).date()
     except (ValueError, TypeError):
         return False
-    return (run_date - listing).days <= SHORT_HISTORY_MAX_AGE_DAYS
+    return (run_date - listing).days <= _policy_short_history_max_age_days()
 
 
 def universe_details(errors=None):

--- a/src/clawock/decision/watch_list.py
+++ b/src/clawock/decision/watch_list.py
@@ -20,7 +20,9 @@ from clawock.workspace import workspace_root
 
 # 出现门槛:距 20 日高 ≤5%、或 5d 收益 ≥8%(次新无前高数据时只看 5d)。
 # NEAR_HIGH_PCT 的单一真源在 add-alpha-policy.json 的 `opportunity_near_pct`
-# (#621)——radar 与 watch list 同读一个值,改配置两边同时生效。
+# (#621)——radar 与 watch list 同读一个值,改配置两边同时生效;
+# STRONG_5D_PCT 的单一真源在 `strong_5d_pct`(#640)。下面两个常量只是
+# 配置缺失时的 fallback 默认值。
 NEAR_HIGH_PCT = 5.0
 STRONG_5D_PCT = 8.0
 
@@ -31,14 +33,36 @@ def _watch_list_path() -> Path:
 
 
 def _policy_near_pct() -> float:
-    """`opportunity_near_pct` from add-alpha-policy.json, default NEAR_HIGH_PCT."""
+    """`opportunity_near_pct` from add-alpha-policy.json, default NEAR_HIGH_PCT.
+
+    Explicit None check, never `X or DEFAULT` (#649): a config value of 0 is a
+    legal threshold ("只有真突破算机会") and must not be swallowed into the
+    default. The literal key keeps the policy-key parity trip-wire alive.
+    """
     try:
         policy = json.loads(
             (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
             .read_text(encoding="utf-8"))
-        return float(policy.get("opportunity_near_pct") or NEAR_HIGH_PCT)
+        raw = policy.get("opportunity_near_pct")
+        if raw is not None:
+            return float(raw)
     except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
-        return NEAR_HIGH_PCT
+        pass
+    return NEAR_HIGH_PCT
+
+
+def _policy_strong_5d_pct() -> float:
+    """`strong_5d_pct` from add-alpha-policy.json, default STRONG_5D_PCT (#640)."""
+    try:
+        policy = json.loads(
+            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            .read_text(encoding="utf-8"))
+        raw = policy.get("strong_5d_pct")
+        if raw is not None:
+            return float(raw)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+        pass
+    return STRONG_5D_PCT
 
 
 def watch_tickers() -> list[str]:
@@ -61,6 +85,7 @@ def collect() -> dict:
     """
     rows, errors = [], []
     near_pct = _policy_near_pct()
+    strong_5d_pct = _policy_strong_5d_pct()
     for ticker in watch_tickers():
         meta = get_instrument(ticker) or {}
         code = meta.get("tencent_symbol")
@@ -105,7 +130,7 @@ def collect() -> dict:
             state = "breakout"
         elif pct_from_high is not None and pct_from_high >= -near_pct:
             state = "near_breakout"
-        elif ret_5d is not None and ret_5d >= STRONG_5D_PCT:
+        elif ret_5d is not None and ret_5d >= strong_5d_pct:
             state = "strong"
         else:
             continue

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -440,9 +440,13 @@ def collect_opportunity_radar(market):
     # cannot drift apart when the config changes.
     try:
         radar_policy = _load_json(WS / 'config' / 'add-alpha-policy.json')
-        near_pct = float(radar_policy.get("opportunity_near_pct")
-                         or OPPORTUNITY_NEAR_PCT)
-        no_chase_z = float(radar_policy.get("early_no_chase_zscore") or 2.0)
+        # #649: explicit None checks, never `X or DEFAULT` — a config value of
+        # 0 (e.g. `early_no_chase_zscore: 0` = z≥0 永不追高) is legal and must
+        # not be swallowed into the default.
+        raw_near = radar_policy.get("opportunity_near_pct")
+        raw_z = radar_policy.get("early_no_chase_zscore")
+        near_pct = float(raw_near) if raw_near is not None else OPPORTUNITY_NEAR_PCT
+        no_chase_z = float(raw_z) if raw_z is not None else 2.0
     except (TypeError, ValueError):
         near_pct, no_chase_z = OPPORTUNITY_NEAR_PCT, 2.0
     for detail in universe:

--- a/tests/test_intraday_opportunity_radar.py
+++ b/tests/test_intraday_opportunity_radar.py
@@ -5,6 +5,8 @@ adds a price-surface view — breakthrough / wait-rebreak / near-breakout — so
 00100 that breaks its 20d high at 11:00 is visible at 11:30 instead of the next
 morning. Radar rows are observations, never entry authorization.
 """
+import json
+
 from clawock.harness import intraday_preflight as P
 
 
@@ -68,6 +70,38 @@ def test_radar_fails_soft_when_universe_breaks(monkeypatch, tmp_path):
     assert out['rows'] == []
     assert out['errors'] == [{'label': None,
                               'error': 'ValueError: no tencent symbol'}]
+
+
+def test_radar_no_chase_z_zero_is_respected_not_swallowed(tmp_path, monkeypatch):
+    """#649: `early_no_chase_zscore: 0` ("z≥0 永不追高") is legal config;
+    `X or DEFAULT` would swallow it into 2.0 and misclassify as breakout."""
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"early_no_chase_zscore": 0}))
+    _wire(tmp_path, monkeypatch, {
+        'BO': {'close': 110.0, 'prior_20d_high': 100.0, 'zscore20': 0.5},
+    })
+
+    out = P.collect_opportunity_radar('hk')
+
+    # z=0.5 ≥ 0 → 追高被禁 → wait_rebreak,不是 breakout。
+    assert out['rows'][0]['state'] == 'wait_rebreak'
+
+
+def test_radar_near_pct_zero_means_near_breakout_never_matches(
+        tmp_path, monkeypatch):
+    """#649: `opportunity_near_pct: 0` ("只有真突破算机会") — a 1% dip below
+    the high is no longer 'near'."""
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"opportunity_near_pct": 0}))
+    _wire(tmp_path, monkeypatch, {
+        'NEAR': {'close': 99.0, 'prior_20d_high': 100.0, 'zscore20': 0.5},
+    })
+
+    out = P.collect_opportunity_radar('hk')
+
+    assert out['rows'] == []
 
 
 def test_radar_section_is_additive():

--- a/tests/test_policy_key_parity.py
+++ b/tests/test_policy_key_parity.py
@@ -80,6 +80,10 @@ def test_early_trend_and_radar_policy_keys_all_present_in_config():
     sources = {
         "early_trend.py": (ROOT / "src" / "clawock" / "decision" / "early_trend.py"),
         "intraday_preflight.py": (ROOT / "src" / "clawock" / "harness" / "intraday_preflight.py"),
+        # #640/#643: the watch-list 5d gate and the short-history window are
+        # config consumers too — their keys must exist or edits do nothing.
+        "watch_list.py": (ROOT / "src" / "clawock" / "decision" / "watch_list.py"),
+        "signals.py": (ROOT / "src" / "clawock" / "decision" / "signals.py"),
     }
     used = set()
     for name, path in sources.items():
@@ -96,6 +100,6 @@ def test_early_trend_and_radar_policy_keys_all_present_in_config():
         present |= _flat_keys(sub)
     missing = used - present
     assert not missing, (
-        "early_trend/intraday_preflight policy keys missing from "
-        f"add-alpha-policy.json: {sorted(missing)} — editing the config cannot "
-        "change them")
+        "early_trend/intraday_preflight/watch_list/signals policy keys missing "
+        f"from add-alpha-policy.json: {sorted(missing)} — editing the config "
+        "cannot change them")

--- a/tests/test_short_history_signals.py
+++ b/tests/test_short_history_signals.py
@@ -58,6 +58,38 @@ def test_candidate_gate_uses_registry_listing_date():
     assert signals.is_short_history_candidate(None, run) is False
 
 
+def test_short_history_window_boundary_is_inclusive_at_45_days():
+    """#643: 45 calendar days is the exact boundary — exactly-45 is a
+    candidate (inclusive ≤), 46 is not. Pins the `<=` vs `<` edge."""
+    run = date(2026, 8, 14)
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-06-30'}, run) is True
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-06-29'}, run) is False
+
+
+def test_short_history_window_is_config_driven(tmp_path, monkeypatch):
+    """#643: the window comes from add-alpha-policy.json's
+    `short_history_max_age_days` — editing the config moves the gate without a
+    code change (45→90 doubling and back must both take effect)."""
+    run = date(2026, 8, 14)
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.parent.mkdir(parents=True)
+    monkeypatch.setattr(signals, "workspace_root", lambda default=None: tmp_path)
+
+    # 60 days old: outside the default 45, inside a configured 90.
+    cfg.write_text(json.dumps({"short_history_max_age_days": 90}))
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-06-15'}, run) is True
+    # 100 days old: candidate under 180, not under the default 45.
+    cfg.write_text(json.dumps({"short_history_max_age_days": 180}))
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-05-06'}, run) is True
+    cfg.write_text(json.dumps({"short_history_max_age_days": 45}))
+    assert signals.is_short_history_candidate(
+        {'listing_date': '2026-05-06'}, run) is False
+
+
 def test_provisional_setups_fallback_only_for_new_listings(monkeypatch):
     """A 25-bar mature name (or one without a listing date) must NOT get the
     short view — it surfaces as insufficient_bars instead (#608)."""

--- a/tests/test_watch_list.py
+++ b/tests/test_watch_list.py
@@ -79,6 +79,45 @@ def test_strong_5d_appears_when_no_prior_high(tmp_path, monkeypatch):
     assert out["rows"][0]["ret_5d"] >= 8.0
 
 
+def test_policy_near_pct_respects_explicit_zero(tmp_path, monkeypatch):
+    """#649: `opportunity_near_pct: 0` ("只有真突破算机会") is legal config;
+    `X or DEFAULT` would silently swallow it into 5.0."""
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"opportunity_near_pct": 0}))
+    monkeypatch.setattr(W, "workspace_root", lambda default=None: tmp_path)
+
+    assert W._policy_near_pct() == 0.0
+
+
+def test_policy_strong_5d_pct_comes_from_config(tmp_path, monkeypatch):
+    """#640: `strong_5d_pct` lives in add-alpha-policy.json — editing the
+    config moves the 5d gate without a code change."""
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"strong_5d_pct": 20.0}))
+    monkeypatch.setattr(W, "workspace_root", lambda default=None: tmp_path)
+
+    assert W._policy_strong_5d_pct() == 20.0
+
+
+def test_strong_state_follows_config_threshold(tmp_path, monkeypatch):
+    """#640: collect() uses the configured 5d gate — an 18.75% 5d gain is
+    'strong' under the 8.0 default but quiet under a 20.0 config."""
+    _wire(tmp_path, monkeypatch, {"03317": {"close": 95.0, "prior_20d_high": None}})
+    cfg = tmp_path / "config" / "add-alpha-policy.json"
+    cfg.write_text(json.dumps({"strong_5d_pct": 20.0}))
+    monkeypatch.setattr(W, "workspace_root", lambda default=None: tmp_path)
+    monkeypatch.setattr(
+        W.quant_signals, "fetch_bars",
+        lambda code, cnt: [{"close": 80.0} for _ in range(5)] +
+                          [{"close": 95.0}] * 5,
+    )
+
+    # ret_5d = (95/80 − 1)*100 = 18.75 < 20 → no row under the raised gate.
+    assert W.collect() == {"rows": []}
+
+
 def test_missing_instruments_entry_is_reported_not_silent(tmp_path, monkeypatch):
     """#602: a watch-list ticker absent from instruments.json must land in
     `errors` — a typo is not a permanent silent no-scan."""


### PR DESCRIPTION
## 修什么

- **#640**:`watch_list.py:25 STRONG_5D_PCT = 8.0` 仍是 module-level 常量,
  #621 同族阈值(opportunity_near_pct / early_no_chase_zscore)已走 config。
- **#643**:`signals.py SHORT_HISTORY_MAX_AGE_DAYS = 45` hardcoded,短历史闸
  边界(45±1、翻倍)无测试钉住。
- **#649**:三处(实为四处)`X or DEFAULT` 反模式——配置写 0
  (`opportunity_near_pct:0` / `early_no_chase_zscore:0`)被静默吞成缺省。
  memory `clawock-core-math-test-coverage.md` 明确列为反模式。

## 改法

- `add-alpha-policy.json` 新增 `strong_5d_pct: 8.0`、
  `short_history_max_age_days: 45` + `short_history_max_age_days_rationale`。
- `watch_list.py`:`_policy_strong_5d_pct()` 与 `_policy_near_pct()` 镜像对称;
  `signals.py`:`_policy_short_history_max_age_days()`(调用时解析,fallback 45)。
- 四处读取全部改显式 None 判定(含 review 补充的第 4 处 early_trend.py:73)。
- `test_policy_key_parity.py` 覆盖扩展到 watch_list.py/signals.py——新键
  缺配置即红,旧键删除也即红。
- 测试:watch_list 的 near_pct=0 尊重 / strong 阈值 config 驱动;
  radar 的 no_chase_z=0(→wait_rebreak)与 near_pct=0(→不出行);
  短历史闸 45 天含/46 天不含边界 + 45→90→180→45 config 驱动(变异验证:
  改回 `or` 或把 45 写死,对应测试都红)。

## 验证

本地 44 passed(测试前需 `unset CLAWOCK_WORKSPACE`——本机该变量指向
demo book 会污染 workspace_root 解析)。
