### PR TITLE
config: instruments.json 补齐 12 只 listing_date + validator/pre-commit 入闸(#647)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -86,15 +86,17 @@ fi
 # ──────────────────────────────────────────────────────────────────────────
 
 # ──────────────────────────────────────────────────────────────────────────
-# 3.5 watch-list.json ↔ instruments.json cross-validation (#602/#621)
+# 3.5 watch-list.json ↔ instruments.json cross-validation (#602/#621/#647)
 #    The watch list is maintained by hand alongside instruments.json; a typo
 #    used to be a permanent silent no-scan. Any change to either file re-checks
-#    the pair.
+#    the pair. #647: every instrument must also carry a listing_date — the
+#    short-history gate (#608) depends on it and fails closed + silent when it
+#    is null, so a new registry entry without one must not be committable.
 # ──────────────────────────────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE '^(config/watch-list\.json|config/instruments\.json)$'; then
   echo "  ▸ validating watch-list.json ↔ instruments.json…"
   python3 - <<'PY' || exit 1
-import json, sys
+import json, re, sys
 try:
     wl = json.load(open('config/watch-list.json'))
     inst = json.load(open('config/instruments.json'))['instruments']
@@ -106,6 +108,15 @@ if missing:
     print(f'    ✗ watch-list tickers missing from instruments.json: {missing}',
           file=sys.stderr)
     print('    → 先在 instruments.json 注册(含 tencent_symbol)再加观察池',
+          file=sys.stderr)
+    sys.exit(1)
+no_date = [s for s, m in inst.items()
+           if not isinstance(m.get('listing_date'), str)
+           or not re.fullmatch(r'\d{4}-\d{2}-\d{2}', m['listing_date'])]
+if no_date:
+    print(f'    ✗ instruments missing a YYYY-MM-DD listing_date: {no_date}',
+          file=sys.stderr)
+    print('    → 短历史闸(#608)依赖该字段,null 会静默 fail-closed',
           file=sys.stderr)
     sys.exit(1)
 print('    ✓ watch-list.json ↔ instruments.json OK')

--- a/config/instruments.json
+++ b/config/instruments.json
@@ -19,7 +19,7 @@
       "underlying": null,
       "one_x_substitute": null,
       "signal_symbol": "00100",
-      "listing_date": null,
+      "listing_date": "2026-01-09",
       "peer_bucket": "hk-ai-models",
       "retired": false
     },
@@ -63,7 +63,7 @@
       "underlying": "HSTECH",
       "one_x_substitute": null,
       "signal_symbol": "03032",
-      "listing_date": null,
+      "listing_date": "2020-09-04",
       "peer_bucket": "hk-hstech-etf",
       "retired": false
     },
@@ -85,7 +85,7 @@
       "underlying": "HSTECH",
       "one_x_substitute": null,
       "signal_symbol": "03033",
-      "listing_date": null,
+      "listing_date": "2020-08-28",
       "peer_bucket": "hk-hstech-etf",
       "retired": false
     },
@@ -108,7 +108,7 @@
       "underlying": "HSTECH",
       "one_x_substitute": "03033",
       "signal_symbol": "HSTECH",
-      "listing_date": null,
+      "listing_date": "2020-12-10",
       "peer_bucket": "hk-hstech-etf",
       "retired": false
     },
@@ -130,7 +130,7 @@
       "underlying": "SKHY",
       "one_x_substitute": "SKHY",
       "signal_symbol": "SKHY",
-      "listing_date": null,
+      "listing_date": "2025-10-16",
       "peer_bucket": "semiconductor-memory",
       "retired": false
     },
@@ -152,7 +152,7 @@
       "underlying": "005930.KS",
       "one_x_substitute": null,
       "signal_symbol": null,
-      "listing_date": null,
+      "listing_date": "2025-05-28",
       "peer_bucket": "semiconductor-memory",
       "retired": false
     },
@@ -241,7 +241,7 @@
       "underlying": "MSFT",
       "one_x_substitute": "MSFT",
       "signal_symbol": "MSFT",
-      "listing_date": null,
+      "listing_date": "2022-09-07",
       "peer_bucket": "us-megacap-tech",
       "retired": false
     },
@@ -330,7 +330,7 @@
       "underlying": "PLTR",
       "one_x_substitute": "PLTR",
       "signal_symbol": "PLTR",
-      "listing_date": null,
+      "listing_date": "2024-12-11",
       "peer_bucket": "us-ai-software",
       "retired": false
     },
@@ -397,7 +397,7 @@
       "underlying": "RKLB",
       "one_x_substitute": "RKLB",
       "signal_symbol": "RKLB",
-      "listing_date": null,
+      "listing_date": "2025-03-13",
       "peer_bucket": "us-commercial-space",
       "retired": false
     },
@@ -420,7 +420,7 @@
       "underlying": "HOOD",
       "one_x_substitute": "HOOD",
       "signal_symbol": "HOOD",
-      "listing_date": null,
+      "listing_date": "2025-01-31",
       "peer_bucket": "us-fintech",
       "retired": false
     },
@@ -619,7 +619,7 @@
       "underlying": null,
       "one_x_substitute": null,
       "signal_symbol": "02513",
-      "listing_date": null,
+      "listing_date": "2026-01-08",
       "peer_bucket": "hk-ai-models",
       "retired": false
     },
@@ -641,7 +641,7 @@
       "underlying": null,
       "one_x_substitute": null,
       "signal_symbol": "03317",
-      "listing_date": null,
+      "listing_date": "2025-12-30",
       "peer_bucket": "hk-ai-models",
       "retired": false
     }

--- a/src/clawock/portfolio/instruments.py
+++ b/src/clawock/portfolio/instruments.py
@@ -112,10 +112,11 @@ def validate_registry(doc: Any) -> list[str]:
         if not isinstance(leverage, (int, float)) or isinstance(leverage, bool) or leverage < 1:
             errors.append(f"{where}.leverage_multiple must be a number >= 1")
         listing_date = meta.get("listing_date")
-        if listing_date is not None and (
-            not isinstance(listing_date, str) or not _DATE_RE.fullmatch(listing_date)
-        ):
-            errors.append(f"{where}.listing_date must be YYYY-MM-DD or null")
+        # #647: the short-history gate (#608) depends on this field being
+        # present and recent — a null listing_date makes it fail closed and
+        # silent. It is registry data hygiene now, not an optional field.
+        if not isinstance(listing_date, str) or not _DATE_RE.fullmatch(listing_date):
+            errors.append(f"{where}.listing_date must be YYYY-MM-DD (non-null)")
         if not isinstance(meta.get("retired"), bool):
             errors.append(f"{where}.retired must be boolean")
         for field in ("name", "venue", "sector", "factor", "peer_bucket"):

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -60,6 +60,21 @@ def test_invalid_one_x_substitute_factor_is_rejected():
     )
 
 
+def test_null_listing_date_is_rejected():
+    """#647: a registry entry without a listing_date fails validation — the
+    short-history gate (#608) depends on it and a null makes it fail closed
+    and silent. Registry hygiene is a validator contract now, not a comment."""
+    doc = {
+        "schema_version": 1,
+        "instruments": copy.deepcopy(instrument_registry.INSTRUMENTS),
+    }
+    doc["instruments"]["NVDA"]["listing_date"] = None
+    errors = instrument_registry.validate_registry(doc)
+    assert any(
+        "NVDA.listing_date" in error for error in errors
+    )
+
+
 def test_all_consumer_maps_derive_the_missing_audit_symbols_from_registry():
     assert portfolio_risk_metrics.LEVERAGED["SPCH"] == 2
     assert brief_preflight.LEV_1X_SWAP["RKLX"] == "RKLB"


### PR DESCRIPTION
## 修什么

#647:instruments.json 12/29 缺 listing_date(含观察池 02513/03317),
短历史闸(#608)的数据前提无人维护——fail-closed 但静默,下一个真次新股
会无声丢 lane。validate_registry 允许 null;pre-commit 3.5 只查 ticker 存在。

## 改法

- **数据回填**:12 只 listing_date = 腾讯日K 首根 bar 日期(与信号管线
  同一数据源,可复算),补齐后全部为成熟票,短历史闸按真实窗口评估:

  | ticker | listing_date | ticker | listing_date |
  |---|---|---|---|
  | 00100 MINIMAX-W | 2026-01-09 | 03032 恒生科技ETF | 2020-09-04 |
  | 03033 南方恒生科技 | 2020-08-28 | 07226 XL二南方恒科 | 2020-12-10 |
  | 07709 XL二南方海力士 | 2025-10-16 | 07747 XL二南三星 | 2025-05-28 |
  | MSFU | 2022-09-07 | PLTU | 2024-12-11 |
  | RKLX | 2025-03-13 | ROBN | 2025-01-31 |
  | 02513 智谱 | 2026-01-08 | 03317 迅策科技 | 2025-12-30 |

- **入闸**:`validate_registry` 要求 listing_date 非空 YYYY-MM-DD,null 即红
  (CI validate 跑 test_instrument_registry);pre-commit 3.5 同规则,
  缺日期的 registry 条目不可提交。
- 回归测试:`test_null_listing_date_is_rejected`。

## 验证

本地 58 passed(pre-commit 3.5 钩子在真实 config 上通过、null 日期被拒)。
