### PR TITLE
docs: README.zh.md 公开战绩散文去冻结数字,与 CW_M 模板对齐(#648)

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -121,9 +121,9 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 
 翻译成人话:**每 10 次主动判断,对 5 次半——跟抛硬币差不多,连作者都承认。** 所以它只敢吹「不骗你」,不敢吹「赚多少」。
 
-方向命中率 ≠ 赚到钱:真实账户收益 −15.95%,收益对比买入持有仍然落后;影子组合(模拟,非实盘)的对比在[持仓页](https://kcnyu.github.io/clawock/#drill)如实展示。[**原始账本在此:640 条全部公开,欢迎查账。**](https://github.com/KCNyu/clawock/blob/master/memory/decisions.jsonl)
+方向命中率 ≠ 赚到钱:真实账户收益自公开以来为负(数字见下方「四条线」表,由脚本刷新),收益对比买入持有仍然落后;影子组合(模拟,非实盘)的对比在[持仓页](https://kcnyu.github.io/clawock/#drill)如实展示。[**原始账本全部公开,欢迎查账。**](https://github.com/KCNyu/clawock/blob/master/memory/decisions.jsonl)
 
-**查账不是读文档,战绩可以复算:** `clawock audit-resettle` 重新结算整本决策账(默认不写入)、`clawock reconcile` 复算全部组合派生、`clawock integrity` 校验资金与行情不变量。判定规则(什么是 win / loss、怎么归组、怎么处理缺数据)全部在代码里版本化,**对不上算我们输**——README 上每个数字,都能从命令跑出来。四个口径互不换算:别拿 53% 去算账户收益,也别拿 640 当已结算数。
+**查账不是读文档,战绩可以复算:** `clawock audit-resettle` 重新结算整本决策账(默认不写入)、`clawock reconcile` 复算全部组合派生、`clawock integrity` 校验资金与行情不变量。判定规则(什么是 win / loss、怎么归组、怎么处理缺数据)全部在代码里版本化,**对不上算我们输**——README 上每个数字,都能从命令跑出来。四个口径互不换算:别拿方向命中率去算账户收益,也别拿账本行数当已结算数。
 
 **四条线,各算各的:**
 

--- a/tests/test_readme_parity.py
+++ b/tests/test_readme_parity.py
@@ -219,6 +219,13 @@ def test_no_live_numbers_in_evergreen_copy():
         r"win rate of \d", r"\d+%\s*win", r"n\s*=\s*\d",   # sample sizes / rates
         r"[-+]?\$\d[\d,]*\s*(?:profit|loss|P&L|pnl)",       # money results
         r"胜率\s*\d", r"样本\s*\d", r"n\s*=\s*\d+\s*条",
+        # #648: 公开战绩 prose must not re-freeze live results the CW_M
+        # placeholders own — the refresh script only rewrites placeholders, so
+        # a hard-coded twin on the same page silently drifts (the −15.95%/640
+        # twin already did once; this guard pins the phrasings that carry one).
+        r"真实账户收益\s*[−-]?\d",   # prose P&L, not the bracketed template
+        r"账本在此:\s*\d+",          # frozen ledger row count in prose
+        r"别拿\s*\d+",               # frozen figure in a rule-of-thumb sentence
     ]
     for md, name in ((EN, "README.md"), (ZH, "README.zh.md")):
         for pat in banned:


### PR DESCRIPTION
## 修什么

#648:README.zh.md:124 散文冻结「真实账户收益 −15.95%」「原始账本在此:
640 条」——无 CW_M 模板,refresh_readme_metrics.py 只重写占位符,同页
132/133 行模板副本一刷新就与散文漂移(#568 引入,同型已复发过一次)。

## 改法

- 散文去冻结:「真实账户收益自公开以来为负(数字见下方「四条线」表,
  由脚本刷新)」「原始账本全部公开,欢迎查账」「别拿账本行数当已结算数」。
- `test_no_live_numbers_in_evergreen_copy` 补三条防复发 pattern:
  `真实账户收益\s*[−-]?\d` / `账本在此:\s*\d+` / `别拿\s*\d+`——
  模板占位符形态(收益 **<!-- CW_M:... -->−15.95%)不受影响。

## 验证

本地 test_readme_parity.py + test_readme_renders_off_github.py 21 passed。
