### PR TITLE
fix: load_json_cached 返回独立副本 + _load_json 非 dict 守卫补回归测试(#642/#644)

### DIFF
--- a/src/clawock/safe_io.py
+++ b/src/clawock/safe_io.py
@@ -15,6 +15,7 @@ these tokens on the read side; this module closes the same hole on the write
 side.
 """
 import contextlib
+import copy
 import fcntl
 import json
 import math
@@ -192,9 +193,12 @@ def load_json_cached(path: str | os.PathLike) -> Any:
     JSONDecodeError exactly like a plain read — only the parse count changes.
 
     Contract boundaries (do not extend them silently):
-    - READ-ONLY return: the same mutable object is handed to every caller for
-      the same mtime, so an in-place mutation would poison later reads. Mutate
-      a copy if you must write.
+    - INDEPENDENT COPY return (#642): every caller receives a deep copy of the
+      cached parse, never the shared instance — an in-place mutation (a
+      `.setdefault()` / `.update()` / `list.append()`) can no longer poison
+      another caller's read. The parse-count win is preserved: copying is far
+      cheaper than re-parsing, and portfolio.json is read only a handful of
+      times per process.
     - Freshness is guaranteed for atomic writers only. A producer that writes
       in place without bumping mtime (or restores it), or a filesystem with
       coarse mtime granularity, can hand back stale bytes — the price of the
@@ -206,14 +210,14 @@ def load_json_cached(path: str | os.PathLike) -> Any:
     mtime = os.path.getmtime(path)
     cached = _JSON_READ_CACHE.get(path)
     if cached is not None and cached[0] == mtime:
-        return cached[1]
+        return copy.deepcopy(cached[1])
     with open(path, encoding='utf-8') as f:
         value = json.load(f)
     _JSON_READ_CACHE[path] = (mtime, value)
     if len(_JSON_READ_CACHE) > _MAX_JSON_CACHE_ENTRIES:
         # dict preserves insertion order: the first key is the oldest entry.
         _JSON_READ_CACHE.pop(next(iter(_JSON_READ_CACHE)))
-    return value
+    return copy.deepcopy(value)
 
 
 def clear_json_cache() -> None:

--- a/tests/test_intraday_preflight.py
+++ b/tests/test_intraday_preflight.py
@@ -94,3 +94,28 @@ def test_receipt_uses_cache_source_when_collection_was_cached():
     }, {"collection": {"cache_hit": True}})
 
     assert "一级信息缓存复核" in text
+
+
+# ── _load_json: the #612 non-dict guard, pinned (#644) ─────────────────────
+
+def test_load_json_returns_empty_for_non_dict_payload(tmp_path):
+    """#644: a file that parses to a non-dict (e.g. a list) is treated as
+    absent — the #612 guard must stay pinned by a test, or a refactor that
+    drops the `isinstance(value, dict)` check silently reds the whole
+    preflight the next time a list-shaped file appears."""
+    path = tmp_path / "config" / "add-alpha-policy.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("[]")
+
+    assert P._load_json(path) == {}
+
+
+def test_load_json_returns_empty_for_missing_file(tmp_path):
+    assert P._load_json(tmp_path / "nope.json") == {}
+
+
+def test_load_json_returns_dict_as_is(tmp_path):
+    path = tmp_path / "ok.json"
+    path.write_text('{"a": 1}')
+
+    assert P._load_json(path) == {"a": 1}

--- a/tests/test_safe_io_json_cache.py
+++ b/tests/test_safe_io_json_cache.py
@@ -6,8 +6,9 @@ drops, freshness never does — for atomic writers. In-place writers that
 restore mtime and coarse-mtime filesystems are out of contract (documented
 failure mode, pinned by a test below so it cannot silently become a promise).
 
-The cache is bounded (LRU-style eviction past _MAX_JSON_CACHE_ENTRIES) and the
-returned object is shared across callers — read-only contract.
+The cache is bounded (LRU-style eviction past _MAX_JSON_CACHE_ENTRIES) and,
+since #642, every caller receives an independent deep copy — mutating the
+returned object can never poison the next reader.
 """
 import json
 import os
@@ -123,15 +124,19 @@ def test_json_decode_error_is_not_cached(monkeypatch, tmp_path):
     assert load_json_cached(p) == {"ok": 1}
 
 
-def test_returned_object_is_shared_read_only_contract(monkeypatch, tmp_path):
-    """#623: the same mutable object is returned on cache hits — callers must
-    treat it as read-only. Pinned so a future deep-copy refactor is deliberate
-    (it would also give up most of the parse-count win)."""
+def test_returned_object_is_an_independent_copy(monkeypatch, tmp_path):
+    """#642: cache hits hand out independent deep copies — a caller's in-place
+    mutation (top-level key, nested list append) must not poison the next
+    reader. The old shared-mutable contract let one `.update()` corrupt every
+    downstream read of portfolio.json across modules."""
     p = tmp_path / "shared.json"
     _write(p, {"a": [1]})
     first = load_json_cached(p)
+    first["b"] = 2
+    first["a"].append(9)
     second = load_json_cached(p)
-    assert first is second
+    assert first is not second
+    assert second == {"a": [1]}  # mutation invisible to the next caller
 
 
 def test_same_mtime_different_bytes_returns_stale(monkeypatch, tmp_path):


### PR DESCRIPTION
## 修什么

- **#642**:`load_json_cached` 缓存命中返回同一 process-global mutable 对象
  (docstring 只标 "READ-ONLY",零 runtime 强制)。portfolio.json 现被
  signals.py 与 intraday_delta.py 共用,任一 caller 一次 `.setdefault()` /
  `.update()` / `list.append()` 就污染所有下游读;未来必然有第三个 caller。
- **#644**:`intraday_preflight._load_json` 的 #612 非 dict 守卫(曾救整条
  preflight)没有任何回归测试,重构合并分支时静默回退无人发现。

## 改法

- `safe_io.load_json_cached`:每次返回 `copy.deepcopy(cached)`——parse-count
  收益保留(拷贝远便宜于解析,portfolio.json 一天没几次读),共享可变隐患
  消除;docstring 的 "READ-ONLY return" 契约改为 "INDEPENDENT COPY"。
- 测试翻转:`test_returned_object_is_shared_read_only_contract`(钉 `first is
  second`)→ `test_returned_object_is_an_independent_copy`:顶层 key 赋值 +
  嵌套 list append 后,下一次读取不可见 mutation。
- `_load_json` 补三条回归测试:非 dict 形状(如 `[]`)→ `{}`、缺文件 → `{}`、
  dict 原样返回。

## 验证

本地 test_safe_io_json_cache / test_intraday_preflight / delta gate /
early_trend / radar / short-history 47 passed;全量套件后台运行中。
