### PR TITLE
feat: 决策心智账本——OpenClaw 产出互通 + 对话判定落账 + Decision Mind 面板

### DIFF
--- a/docs/decision-mind-ledger.md
+++ b/docs/decision-mind-ledger.md
@@ -1,0 +1,110 @@
+# 决策心智账本 — Decision Mind Ledger (schema v0 草案)
+
+> 讨论稿,未落库。用途:把对话与盘前产生的**投资判定**冻结为
+> 「思想快照 + 情绪压力 + 可证伪条件」的结构化记录,事后自动对账。
+> 与券商流水、交易日记的区别:对抗性结构(bear 强制)+ 情绪冻结 +
+> 确定性对账 + 校准统计。
+
+## 一条记录 = 决策卡(冻结)+ 对账(事后填写)
+
+```json
+{
+  "schema_version": 0,
+  "decision_id": "dec-<12hex>",
+  "subject": { "ticker": "00100", "market": "HK", "currency": "HKD" },
+  "decided_at": "2026-08-16T13:45:00+08:00",
+  "source": "conversation",                  // conversation | brief
+  "action": "reject",                        // buy/add/trim/sell/hold/watch/reject/abstain
+  "confidence": 0.65,                        // 0..1
+  "driven_by": "fundamental",                // technical|fundamental|sentiment|mixed
+
+  "mind": {                                  // ← 思想快照(append-only,冻结)
+    "bull": { "summary": "...", "evidence": ["..."] },
+    "bear": { "summary": "...", "evidence": ["..."] },   // 强制非空:无反方不许落账
+    "thesis": "...",
+    "invalidation": ["缩量企稳", "2 日不创新低", "站回 340"]   // 可证伪条件
+  },
+
+  "emotion": {                               // ← 情绪压力层(决策时自评)
+    "pressure": "averaging_down",            // fomo|revenge|averaging_down|fear|euphoria|calm|mixed
+    "note": "浮亏 -40% 的摊本冲动,判定时明确压过;这次忍住没加"
+  },
+
+  "accounting": {                            // ← 对账(事后,只允许更新这里)
+    "trigger": { "status": "pending", "condition": "站回 340", "price_at_decision": 329.0 },
+    "execution": { "executed": false, "note": "判定为不加,未产生订单" },
+    "outcome": { "grade": "pending" },       // correct|wrong|mixed|pending
+    "calibration": { "confidence_bin": "0.6-0.7", "hit": null }
+  }
+}
+```
+
+## 字段规则(不可协商)
+
+1. **bear 强制非空** —— 没有真实反方的判定不许落账(对抗性结构的核心)
+2. **mind 与 emotion 冻结** —— 落账后不可改;只有 `accounting` 可被
+   evaluation 机制更新(触发/执行/结果/校准)
+3. **可证伪优先** —— `invalidation` 必须写可观察条件,不写空话
+4. **情绪默认诚实** —— 默认 `calm`;浮亏摊本/FOMO/报复性场景要求自认
+   (账本的价值一半在这里)
+5. **action 枚举对齐 clawock 决策契约**,与盘前简报决策同词表
+
+## 与现有系统关系
+
+- **数据落点**:对话决策写入 `memory/decisions.jsonl`(与盘前决策同账本,
+  真源一个)或单开 `memory/conversation-decisions.jsonl`(待定,见讨论)
+- **对账**:复用现有 evaluation 机制(`triggered/executed` 语义),执行标记
+  走 `clawock mark-followed`
+- **面板**:DSH Decision Studio 从「runs 调试视图」改为「决策心智视图」:
+  日期/标的/动作/信心/情绪/对账状态,展开看决策卡全貌
+- **校准**:`confidence_bin` 汇入命中率统计,回答「我的 0.65 准不准」
+
+## 样例一(今天真实):MiniMax 加仓判定 → 未加仓
+
+```
+00100 MINIMAX-W · 2026-08-16 · action reject(加仓) · 0.65 · fundamental
+Bull   营收 +159% YoY;入通/海外霸榜/高盛三催化叙事
+Bear   净利率 -2368%、负债率 343%、每股净资产 -24.37;z+2.8σ 情绪极值反转
+Thesis 高增长救不了资不抵债,情绪反转期先活下来
+失效   缩量企稳 + 2 日不创新低 + 站回 340
+情绪   averaging_down —— 浮亏 -40% 的摊本冲动被压过,这次忍住没加
+对账   execution=未加仓(判定被遵守)· trigger=pending(等 340/企稳)
+```
+
+## 样例二(历史复盘,可选补录):SPCH 无限子弹流
+
+```
+SPCH · 2026-06-23 · action add(第 6 次摊本) · 0.3 · sentiment
+Bull   无限子弹流,均价摊低后回本更快
+Bear   minmax 立场=反对:逆硬止损线第 6 次,累计加仓逼近 $3000
+Thesis 只要反弹就回本(事后看:反弹出现但被更高成本拖累)
+失效   单日 -15% 或正股单周 -25% 升级 P0
+情绪   averaging_down —— 明确自认:这单是情绪驱动
+对账   execution=已执行 10 股 @13.13 · outcome=mixed
+```
+
+## 面板设计(与 dashboard 同风格)
+
+- 令牌:bg #070A0F / 卡片 #202E3E / border #1D2937 / accent #36A3FF /
+  正 #28C08D / 负 #F05B67 / 警示 #E3A640(全部取自 dashboard.css)
+- 列表卡:日期分组,每张卡 = 标的 + action 胶囊(加=绿/减=红/观望=灰)+
+  信心 + 情绪胶囊(非 calm 才显示,警示色)+ 对账状态胶囊(已触发/已执行/待定)
+- 展开详情:Bull/Bear 对置条(正绿负红 + 证据计数)、信心计量条、
+  失效条件列表、情绪注记、对账区(触发/执行/校准)
+- 预览:`decision-mind-ledger.html`(静态 mock,本机可开)
+
+## 数据互通(OpenClaw ↔ DSH,一个账本两个入口)
+
+- **唯一真源**:`<workspace>/memory/decisions.jsonl`。OpenClaw 盘前简报的
+  决策与 DSH 对话判定写同一个账本,两边都能读。
+- **DSH 读 OpenClaw 产出**:面板 node 半区读取该文件(默认工作区
+  `/root/.openclaw/workspace`,可配置),按 decision_group_id/decided_at
+  分组;旧记录没有 mind/emotion 字段时降级渲染(只有动作/条件/对账)。
+- **对话判定落账**:skill 规范——verdict 产生时追加一条,`source:
+  "conversation"`,字段与现有 schema 兼容(condition 用同形结构,以便
+  每日 settle 自动对账触发/执行)。
+- **互通已验证(源码读证)**:`brief_postflight.log_decisions` 为
+  load → upsert/settle → 全量写回,不删外部记录;实现时用复制账本做
+  迁移测试钉住「对话记录经 postflight 一轮后仍在且被 settle」。
+- **kcn 自用**:面板默认指向每日 OpenClaw 运行的真实工作区,
+  决策记录实时可见。

--- a/examples/dsh/plugin/README.md
+++ b/examples/dsh/plugin/README.md
@@ -68,19 +68,21 @@ agent:准备请求…(clawock run prepare)
       Receipt published · run_id <id> · 证书已钉住
 ```
 
-## Decision Studio 面板
+## Decision Mind 面板
 
-装完后,web GUI 的会话视图多一个 **Decision Studio** tab(只读):
+装完后,web GUI 的会话视图多一个 **Decision Mind** tab(只读,DSH 原生
+浅色风格)。**OpenClaw 每天产出的东西,这里都能读**:
 
-- **运行列表**:本 workspace(`$CLAWOCK_WORKSPACE` 或 dsh 进程 cwd)里所有
-  已 prepare 的 run —— ticker / action / 有无回执 / as_of,按时间倒序;
-- **选中一个 run**:certified request(文档指纹数 + 三道闸)、debate 证据
-  表(supporting 绿 / opposing 红)、thesis + action + confidence、回执
-  横幅(published 绿 / 未发布红 + run_id + generation)。
+- **账本**:`memory/decisions.jsonl` 的决策记录,按日期分组 —— 盘前简报
+  决策与对话判定(带 bull/bear 思想、情绪压力、可证伪条件)同源展示,
+  旧记录自动降级(只有动作/条件/对账);
+- **持仓**:`portfolio.json` 按书分组(港/美股),ticker / 股数 / 现价 /
+  盈亏%,红绿语义色;
+- **计划**:最近的 `memory/*-plan.json` 与决策数。
 
-数据源是只读的:`.clawock/work/<run_id>/request.json`、workspace 根
-`decision.json`、`.clawock/runs/<run_id>/manifest.json`。面板不改任何文件,
-结算仍归 `clawock run publish`。结构:
+对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
+... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,
+bear 与失效条件强制,情绪自认)。面板不改任何文件,结算仍归既有机制。结构:
 
 ```
 clawock-dsh

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -130,9 +130,11 @@ window.__ModuleLoader__.load({
       return h('span', { className: 'chip ' + props.tone }, props.children)
     }
 
+    var ACTIVE_ACTIONS = ['add', 'buy', 'trim', 'sell', 'cut', 't_only', 'trim_on_rebound']
+
     function ActionChip(action) {
       var tone = action === 'add' || action === 'buy' ? 'add'
-        : action === 'trim' || action === 'sell' ? 'trim'
+        : ACTIVE_ACTIONS.indexOf(action) >= 0 ? 'trim'
         : action === 'reject' || action === 'watch' || action === 'hold' || action === 'abstain' ? 'reject'
         : 'gray'
       return h(Chip, { tone: tone }, String(action))
@@ -216,19 +218,9 @@ window.__ModuleLoader__.load({
       }))
     }
 
-    function PlansView(props) {
-      var plans = props.plans
-      if (!plans.length) return h('div', { className: 'empty' }, 'memory/*-plan.json 未找到')
-      return h('div', null, plans.map(function (p) {
-        return h('div', { className: 'plan', key: p.date },
-          h('span', { className: 'd' }, p.date),
-          h('span', { className: 'n' }, p.decisions + ' decisions' + (p.title ? ' · ' + p.title : '')))
-      }))
-    }
-
     /** The conversation-view tab: desk data (ledger / portfolio / plans). */
     function DecisionMind(props) {
-      var pair = useState({ view: 'ledger', selected: null, ledger: [], portfolio: { books: [] }, plans: [], loading: true, error: null })
+      var pair = useState({ view: 'ledger', filter: 'trades', selected: null, ledger: [], portfolio: { books: [] }, loading: true, error: null })
       var state = pair[0]
       var setState = pair[1]
       var sessionId = props.sessionId
@@ -246,21 +238,30 @@ window.__ModuleLoader__.load({
       }, [sessionId])
 
       if (state.error) return h('div', { className: 'dml' }, h('div', { className: 'card' }, h('span', { style: { color: 'var(--neg)' } }, 'Decision Mind: ' + state.error)))
-      var entries = state.ledger.map(_displayEntry)
+      var allEntries = state.ledger.map(_displayEntry)
+      var entries = allEntries.filter(function (d) {
+        if (state.filter === 'all') return true
+        if (d.executionStatus !== 'followed') return false
+        return state.filter === 'followed' || ACTIVE_ACTIONS.indexOf(d.action) >= 0
+      })
 
       var body
       if (state.loading) body = h('div', { className: 'empty' }, 'Loading desk data…')
       else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
-      else if (state.view === 'portfolio') body = h(PortfolioView, { books: state.portfolio.books })
-      else body = h(PlansView, { plans: state.plans })
+      else body = h(PortfolioView, { books: state.portfolio.books })
 
       return h('div', { className: 'dml' },
         h('div', { className: 'head' },
-          h('div', { className: 'title' }, h('h3', null, '决策心智'), h('span', null, 'Decision Mind · ' + entries.length + ' 条决策')),
+          h('div', { className: 'title' },
+            h('h3', null, '决策心智'),
+            h('span', null, 'Decision Mind · ' + entries.length + '/' + allEntries.length + ' 条')),
           h('div', { className: 'seg' },
             h('button', { className: state.view === 'ledger' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ledger' }) }) } }, '账本'),
-            h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓'),
-            h('button', { className: state.view === 'plans' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'plans' }) }) } }, '计划'))),
+            h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓')),
+          state.view === 'ledger' ? h('div', { className: 'seg', style: { marginLeft: 8 } },
+            h('button', { className: state.filter === 'trades' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'trades' }) }) } }, '已执行交易'),
+            h('button', { className: state.filter === 'followed' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'followed' }) }) } }, '已执行'),
+            h('button', { className: state.filter === 'all' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'all' }) }) } }, '全部')) : null),
         body)
     }
 

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -1,12 +1,12 @@
 /**
- * clawock-dsh browser bundle: the Decision Studio conversation-view tab.
+ * clawock-dsh browser bundle: the Decision Mind conversation-view tab.
  *
- * Shape contract (dsh-client-modules): the file registers one lazy CJS
- * factory through `window.__ModuleLoader__.load({ id, factory })`; the
- * factory's `require` resolves externals from the web shell's module graph
- * (`@deepseek-ai/dsh-client-runtime/client`, `react`). This file is the
- * shipped artifact — hand-authored, no build step. The model builder is
- * exported as a test seam (`_buildStudioModel`).
+ * Shows whatever the OpenClaw desk produced — the shared decision ledger
+ * (memory/decisions.jsonl), the portfolio, and recent daily plans — through
+ * read-only Typert remotes. Hand-authored module-loader factory, no build
+ * step. Visual language: restrained DSH-native light theme (ui-theme token
+ * values), glass only on the sticky header, DeepSeek blue as the single
+ * accent, semantic tints for pos/neg/warn.
  */
 window.__ModuleLoader__.load({
   id: 'clawock-dsh',
@@ -19,208 +19,276 @@ window.__ModuleLoader__.load({
     var useState = React.useState
     var h = React.createElement
 
-    /** Pure projection of one run's files into what the tab renders. */
-    function _buildStudioModel(run) {
-      if (run === null || run.request === null) {
-        return { empty: true, subject: null, gates: null, decision: null, receipt: null }
-      }
-      var request = run.request
-      var decision = run.decision
-      var manifest = run.manifest
+    // CSS injection lives in the factory closure (module-loader convention).
+    var STYLE_ID = 'clawock-dsh-styles'
+    if (!document.getElementById(STYLE_ID)) {
+      var style = document.createElement('style')
+      style.id = STYLE_ID
+      style.textContent = [
+        '.dml{--bg:#F9FAFB;--surface:#FFFFFF;--surface2:#F5F6F7;--text:#0F1115;--text2:#81858C;--text3:#ADB2B8;',
+        '--brand:#4176E6;--brand-deep:#4868B2;--brand-soft:#EDF3FE;--border-l1:rgba(0,0,0,.04);--border-l2:rgba(0,0,0,.10);--border-card:rgba(0,0,0,.08);',
+        '--hover:rgba(38,49,72,.06);--active:rgba(38,49,72,.12);',
+        '--pos:#1E9E6C;--pos-soft:#E6FAED;--neg:#D64550;--neg-soft:#FEF2F2;--warn:#B77B16;--warn-soft:#FEF5E7;',
+        '--shadow-lv2:0 4px 12px rgba(0,0,0,.02),0 2px 8px rgba(0,0,0,.04);--shadow-lv3:0 0 1px rgba(0,0,0,.2),0 0 4px rgba(0,0,0,.02),0 12px 32px rgba(0,0,0,.08);',
+        '--radius-lg:14px;--radius-md:10px;--radius-sm:8px;--radius-pill:999px;',
+        '--font:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;',
+        '--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;',
+        'font:14px/1.55 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;padding:4px 2px;',
+        'background-image:radial-gradient(900px 300px at 50% -120px,rgba(65,118,230,.05),transparent 70%)}',
+        '.dml .head{position:sticky;top:0;z-index:5;margin:-4px -2px 0;padding:12px 14px 10px;',
+        'background:linear-gradient(180deg,rgba(249,250,251,.9),rgba(249,250,251,.72));',
+        '-webkit-backdrop-filter:blur(20px);backdrop-filter:blur(20px);border-bottom:1px solid var(--border-l1)}',
+        '.dml .title{display:flex;align-items:baseline;gap:10px;margin-bottom:10px}',
+        '.dml .title h3{margin:0;font-size:16px;font-weight:700;letter-spacing:-.01em}',
+        '.dml .title span{color:var(--text3);font-size:12px}',
+        '.dml .seg{display:inline-flex;padding:2px;background:var(--surface2);border:1px solid var(--border-l2);border-radius:var(--radius-pill)}',
+        '.dml .seg button{border:0;background:transparent;color:var(--text2);font-size:12.5px;font-weight:600;padding:4px 14px;border-radius:var(--radius-pill);cursor:pointer;transition:background .15s,color .15s}',
+        '.dml .seg button:hover{background:var(--hover)}',
+        '.dml .seg button.on{background:var(--surface);color:var(--brand);box-shadow:var(--shadow-lv2)}',
+        '.dml .day{margin:18px 0 8px;color:var(--text3);font-size:11.5px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;gap:8px}',
+        '.dml .day::after{content:"";flex:1;height:1px;background:linear-gradient(90deg,rgba(65,118,230,.2),transparent)}',
+        '.dml .card{margin:8px 0;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2);overflow:hidden;transition:border-color .15s}',
+        '.dml .card:hover{border-color:var(--border-l2)}',
+        '.dml .row{display:flex;align-items:center;gap:10px;padding:12px 14px;cursor:pointer;transition:background .15s}',
+        '.dml .row:hover{background:var(--hover)}.dml .row:active{background:var(--active)}',
+        '.dml .tk{font-weight:700;font-size:14px;min-width:118px}',
+        '.dml .chip{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;border-radius:var(--radius-pill);font-size:11.5px;font-weight:600}',
+        '.dml .chip.add{color:var(--pos);background:var(--pos-soft)}.dml .chip.trim{color:var(--neg);background:var(--neg-soft)}',
+        '.dml .chip.reject{color:var(--text2);background:var(--surface2)}.dml .chip.emo{color:var(--warn);background:var(--warn-soft)}',
+        '.dml .chip.ok{color:var(--pos);background:var(--pos-soft)}.dml .chip.warn{color:var(--warn);background:var(--warn-soft)}',
+        '.dml .chip.gray{color:var(--text3);background:var(--surface2)}',
+        '.dml .conf{margin-left:auto;color:var(--text2);font-size:12px;font-family:var(--mono);font-variant-numeric:tabular-nums}',
+        '.dml .chev{color:var(--text3);font-size:10px;transition:transform .18s}',
+        '.dml .open .chev{transform:rotate(180deg)}',
+        '.dml .detail{display:none;border-top:1px solid var(--border-l1);padding:16px;background:var(--bg)}',
+        '.dml .open .detail{display:block}',
+        '.dml .sec{font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--text3);text-transform:uppercase;margin:14px 0 8px}',
+        '.dml .sec:first-child{margin-top:0}',
+        '.dml .vs{display:grid;grid-template-columns:1fr 1fr;gap:12px}',
+        '.dml .side{padding:12px 14px;border-radius:var(--radius-sm);border:1px solid var(--border-l2)}',
+        '.dml .side.bull{background:var(--pos-soft);border-color:rgba(30,158,108,.3)}',
+        '.dml .side.bear{background:var(--neg-soft);border-color:rgba(214,69,80,.3)}',
+        '.dml .side b{font-size:11px;letter-spacing:.08em;text-transform:uppercase}',
+        '.dml .side.bull b{color:var(--pos)}.dml .side.bear b{color:var(--neg)}',
+        '.dml .side p{margin:7px 0 4px;font-size:13px;color:var(--text)}',
+        '.dml .side .src{color:var(--text3);font-size:12px}',
+        '.dml .meter{height:8px;border-radius:var(--radius-pill);background:var(--border-l2);overflow:hidden;margin:8px 0 4px}',
+        '.dml .meter>div{height:100%;border-radius:var(--radius-pill);background:linear-gradient(90deg,var(--brand-deep),var(--brand))}',
+        '.dml .kv{display:flex;justify-content:space-between;gap:14px;padding:6px 0;border-bottom:1px solid var(--border-l1);font-size:13px}',
+        '.dml .kv span{color:var(--text3);flex-shrink:0}.dml .kv:last-child{border-bottom:none}',
+        '.dml ul.inv{margin:6px 0 0;padding-left:18px;color:var(--text2);font-size:13px}',
+        '.dml ul.inv li{margin:3px 0}',
+        '.dml .emo-note{margin-top:12px;padding:10px 14px;border-radius:var(--radius-sm);background:var(--warn-soft);border-left:3px solid var(--warn);font-size:13px;color:var(--text2)}',
+        '.dml .acc{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}',
+        '.dml .stat{padding:10px 12px;border:1px solid var(--border-l2);border-radius:var(--radius-sm);background:var(--surface)}',
+        '.dml .stat span{display:block;color:var(--text3);font-size:11px}.dml .stat b{font-size:13px;font-weight:600}',
+        '.dml .okb{color:var(--pos)}.dml .warnb{color:var(--warn)}.dml .grayb{color:var(--text2)}',
+        '.dml .mono{font-family:var(--mono);font-size:12px;color:var(--text2)}',
+        '.dml table{width:100%;border-collapse:collapse;font-size:13px}',
+        '.dml th{color:var(--text3);font-weight:600;text-align:left;padding:6px 10px;border-bottom:1px solid var(--border-l2);font-size:11.5px}',
+        '.dml td{padding:7px 10px;border-bottom:1px solid var(--border-l1);font-variant-numeric:tabular-nums}',
+        '.dml td.num{text-align:right;font-family:var(--mono);font-size:12.5px}',
+        '.dml .pos{color:var(--pos)}.dml .neg{color:var(--neg)}',
+        '.dml .book{margin:12px 0}',
+        '.dml .book h4{margin:0 0 8px;font-size:13px;font-weight:700;color:var(--text2)}',
+        '.dml .plan{margin:8px 0;padding:12px 14px;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2)}',
+        '.dml .plan .d{font-weight:700;font-size:13.5px;font-family:var(--mono)}',
+        '.dml .plan .n{color:var(--text3);font-size:12.5px;margin-left:10px}',
+        '.dml .empty{padding:26px 14px;text-align:center;color:var(--text3);font-size:13px}',
+      ].join('')
+      document.head.appendChild(style)
+    }
+
+    /** Pure projection of one ledger entry into display fields (test seam). */
+    function _displayEntry(entry) {
+      var subject = entry.subject || {}
+      var mind = entry.mind || {}
+      var emotion = entry.emotion || {}
+      var evaluation = entry.evaluation || {}
+      var execution = entry.execution || {}
       return {
-        empty: false,
-        runId: run.runId,
-        subject: request.subject ?? (decision && decision.subject) ?? null,
-        asOf: request.as_of ?? null,
-        task: request.task ?? null,
-        workflow: request.workflow ?? null,
-        gates: (request.workflow && request.workflow.parameters) ?? null,
-        documents: (request.context && request.context.documents) ?? [],
-        evidence: (decision && decision.evidence) ?? [],
-        debate: (decision && decision.debate) ?? null,
-        thesis: (decision && decision.thesis) ?? null,
-        action: decision ? decision.decision : null,
-        receiptStatus: manifest ? 'published' : null,
-        generationId: manifest ? manifest.generation_id : null,
+        id: entry.decision_id || null,
+        ticker: subject.ticker || entry.ticker || '?',
+        date: entry.decided_at || entry.plan_date || null,
+        action: entry.action || 'hold',
+        confidence: entry.confidence ?? null,
+        drivenBy: entry.driven_by || null,
+        source: entry.source || 'brief',
+        bull: mind.bull && mind.bull.summary ? mind.bull.summary : null,
+        bear: mind.bear && mind.bear.summary ? mind.bear.summary : null,
+        thesis: mind.thesis || null,
+        invalidation: Array.isArray(mind.invalidation) ? mind.invalidation : [],
+        emotion: emotion.pressure || null,
+        emotionNote: emotion.note || null,
+        condition: entry.condition && entry.condition.description ? entry.condition.description : null,
+        executionStatus: execution.status || null,
+        outcome: evaluation.outcome || null,
       }
     }
 
-    var CARD = { margin: '12px 0', padding: '14px 16px', border: '1px solid #243048', borderRadius: '12px', background: '#161d2e' }
-    var GREEN = '#2ecc71'
-    var RED = '#e74c3c'
-    var MUTED = '#8a94a8'
-
-    function Row(props) {
-      return h('div', { style: { margin: '4px 0', color: props.muted ? MUTED : '#e8edf5', fontSize: 13 } }, props.label ? h('span', { style: { color: MUTED, marginRight: 8 } }, props.label) : null, props.value)
+    function Chip(props) {
+      return h('span', { className: 'chip ' + props.tone }, props.children)
     }
 
-    function GateRow(props) {
-      return h('div', { style: { display: 'flex', justifyContent: 'space-between', padding: '4px 0', borderBottom: '1px solid #1d2740' } },
-        h('span', { style: { color: MUTED, fontSize: 13 } }, props.name),
-        h('span', { style: { fontSize: 13 } }, String(props.value)))
+    function ActionChip(action) {
+      var tone = action === 'add' || action === 'buy' ? 'add'
+        : action === 'trim' || action === 'sell' ? 'trim'
+        : action === 'reject' || action === 'watch' || action === 'hold' || action === 'abstain' ? 'reject'
+        : 'gray'
+      return h(Chip, { tone: tone }, String(action))
     }
 
-    function EvidenceRow(props) {
-      var color = props.stance === 'opposing' ? RED : GREEN
-      return h('div', { style: { padding: '6px 0', borderBottom: '1px solid #1d2740' } },
-        h('div', {}, h('span', { style: { color: color, fontWeight: 700, marginRight: 8 } }, props.stance),
-          h('span', { style: { fontSize: 13 } }, props.summary)),
-        h('div', { style: { color: MUTED, fontSize: 12 } }, props.source + ' · ' + props.sourceClass + ' · ' + props.observedAt))
+    function LedgerCard(props) {
+      var d = props.entry
+      var expanded = props.open
+      return h('div', { className: 'card' + (expanded ? ' open' : '') },
+        h('div', { className: 'row', onClick: props.onToggle },
+          h('span', { className: 'tk' }, d.ticker),
+          ActionChip(d.action),
+          d.emotion && d.emotion !== 'calm' ? h(Chip, { tone: 'emo' }, '⚡ ' + d.emotion) : null,
+          d.outcome ? h(Chip, { tone: d.outcome === 'not_triggered' ? 'gray' : 'ok' }, d.outcome) : null,
+          h('span', { className: 'conf' }, (d.confidence ?? '—') + (d.drivenBy ? ' · ' + d.drivenBy : '')),
+          h('span', { className: 'chev' }, '▾')),
+        h('div', { className: 'detail' },
+          d.bull || d.bear ? h('div', { className: 'vs' },
+            h('div', { className: 'side bull' }, h('b', null, 'Bull'), h('p', null, d.bull || '—'), h('div', { className: 'src' }, 'evidence · decision time')),
+            h('div', { className: 'side bear' }, h('b', null, 'Bear'), h('p', null, d.bear || '—'), h('div', { className: 'src' }, 'opposing · mandatory'))) : null,
+          d.thesis ? h('div', { className: 'sec' }, 'Thesis') : null,
+          d.thesis ? h('div', { className: 'kv' }, h('span', null, 'thesis'), h('b', null, d.thesis)) : null,
+          d.confidence !== null ? h('div', { className: 'kv' }, h('span', null, 'confidence'), h('b', { className: 'mono' }, String(d.confidence))) : null,
+          d.confidence !== null ? h('div', { className: 'meter' }, h('div', { style: { width: Math.max(4, Math.min(100, d.confidence * 100)) + '%' } })) : null,
+          d.invalidation.length ? h('div', { className: 'sec' }, '可证伪条件') : null,
+          d.invalidation.length ? h('ul', { className: 'inv' }, d.invalidation.map(function (c, i) { return h('li', { key: i }, c) })) : null,
+          d.emotionNote ? h('div', { className: 'emo-note' }, '⚡ ' + d.emotionNote) : null,
+          d.condition || d.executionStatus || d.outcome ? h('div', { className: 'sec' }, '对账') : null,
+          (d.condition || d.executionStatus || d.outcome) ? h('div', { className: 'acc' },
+            h('div', { className: 'stat' }, h('span', null, 'condition'), h('b', { className: 'grayb' }, d.condition || '—')),
+            h('div', { className: 'stat' }, h('span', null, 'execution'), h('b', { className: d.executionStatus === 'followed' ? 'okb' : 'grayb' }, d.executionStatus || '—')),
+            h('div', { className: 'stat' }, h('span', null, 'outcome'), h('b', { className: d.outcome === 'not_triggered' ? 'grayb' : 'okb' }, d.outcome || '—'))) : null))
     }
 
-    function ReceiptBanner(props) {
-      var published = props.status === 'published'
-      return h('div', { style: { marginTop: 12, padding: '10px 14px', borderRadius: 10, border: '1px solid ' + (published ? GREEN : RED), background: published ? '#10241a' : '#241010' } },
-        h('span', { style: { color: published ? GREEN : RED, fontWeight: 800, marginRight: 10 } }, published ? 'PUBLISHED' : 'REJECTED'),
-        h('span', { style: { fontSize: 12, color: MUTED } }, 'run_id ' + props.runId + (props.generationId ? ' · generation ' + props.generationId : ' · no receipt yet')))
+    function LedgerView(props) {
+      var entries = props.entries
+      if (!entries.length) return h('div', { className: 'empty' }, '账本为空 — 对话判定或盘前决策会出现在这里')
+      var groups = {}
+      var order = []
+      for (var i = entries.length - 1; i >= 0; i -= 1) {
+        var d = entries[i]
+        var key = (d.date || '').slice(0, 10) || 'unknown'
+        if (!groups[key]) { groups[key] = []; order.push(key) }
+        groups[key].push(d)
+      }
+      return h('div', null, order.map(function (key) {
+        return h('div', { key: key },
+          h('div', { className: 'day' }, key),
+          groups[key].map(function (d) {
+            return h(LedgerCard, {
+              key: d.id || d.ticker + key,
+              entry: d,
+              open: props.selected === d.id,
+              onToggle: function () { props.onSelect(props.selected === d.id ? null : d.id) },
+            })
+          }))
+      }))
     }
 
-    /** The conversation.view tab: run list + selected run detail. */
-    function DecisionStudio(props) {
-      var pair = useState({ runs: [], selected: null, detail: null, loading: true, error: null })
+    function PortfolioView(props) {
+      var books = props.books
+      if (!books.length) return h('div', { className: 'empty' }, 'portfolio.json 未找到或为空')
+      return h('div', null, books.map(function (book) {
+        return h('div', { className: 'book card', key: book.name },
+          h('div', { style: { padding: '12px 14px', borderBottom: '1px solid var(--border-l1)' } },
+            h('span', { style: { fontWeight: 700 } }, book.name),
+            h('span', { className: 'mono', style: { marginLeft: 10 } }, book.currency || '')),
+          h('div', { style: { overflowX: 'auto' } },
+            h('table', null,
+              h('thead', null, h('tr', null,
+                h('th', null, 'ticker'), h('th', { style: { textAlign: 'right' } }, 'shares'),
+                h('th', { style: { textAlign: 'right' } }, 'price'), h('th', { style: { textAlign: 'right' } }, 'pnl%'))),
+              h('tbody', null, book.holdings.map(function (hl) {
+                return h('tr', { key: hl.ticker },
+                  h('td', null, hl.ticker),
+                  h('td', { className: 'num' }, String(hl.shares)),
+                  h('td', { className: 'num' }, hl.price !== null ? String(hl.price) : '—'),
+                  h('td', { className: 'num ' + (hl.pnlPct !== null && hl.pnlPct < 0 ? 'neg' : 'pos') },
+                    hl.pnlPct !== null ? (hl.pnlPct > 0 ? '+' : '') + hl.pnlPct.toFixed(1) + '%' : '—'))
+              })))))
+      }))
+    }
+
+    function PlansView(props) {
+      var plans = props.plans
+      if (!plans.length) return h('div', { className: 'empty' }, 'memory/*-plan.json 未找到')
+      return h('div', null, plans.map(function (p) {
+        return h('div', { className: 'plan', key: p.date },
+          h('span', { className: 'd' }, p.date),
+          h('span', { className: 'n' }, p.decisions + ' decisions' + (p.title ? ' · ' + p.title : '')))
+      }))
+    }
+
+    /** The conversation-view tab: desk data (ledger / portfolio / plans). */
+    function DecisionMind(props) {
+      var pair = useState({ view: 'ledger', selected: null, ledger: [], portfolio: { books: [] }, plans: [], loading: true, error: null })
       var state = pair[0]
       var setState = pair[1]
       var sessionId = props.sessionId
       useEffect(function () {
         var alive = true
-        setState(function (current) { return Object.assign({}, current, { loading: true, error: null }) })
-        props.list().then(function (result) {
+        setState(function (c) { return Object.assign({}, c, { loading: true, error: null }) })
+        Promise.all([props.ledger(), props.portfolio(), props.plans()]).then(function (results) {
           if (!alive) return
-          setState(function (current) { return Object.assign({}, current, { runs: result.runs, loading: false }) })
+          setState(function (c) { return Object.assign({}, c, { ledger: results[0].entries, portfolio: results[1], plans: results[2].plans, loading: false }) })
         }, function (error) {
           if (!alive) return
-          setState(function (current) { return Object.assign({}, current, { error: String(error && error.message ? error.message : error), loading: false }) })
+          setState(function (c) { return Object.assign({}, c, { error: String(error && error.message ? error.message : error), loading: false }) })
         })
         return function () { alive = false }
       }, [sessionId])
 
-      // Full detail is fetched per selection: list rows are cheap snapshots,
-      // the request/decision/receipt payloads live in the node half.
-      useEffect(function () {
-        var selected = state.selected
-        if (!selected) {
-          setState(function (current) { return Object.assign({}, current, { detail: null }) })
-          return
-        }
-        var alive = true
-        setState(function (current) { return Object.assign({}, current, { detail: null }) })
-        props.get(selected).then(function (detail) {
-          if (!alive) return
-          setState(function (current) { return Object.assign({}, current, { detail: detail }) })
-        }, function (error) {
-          if (!alive) return
-          setState(function (current) { return Object.assign({}, current, { detail: null, error: String(error && error.message ? error.message : error) }) })
-        })
-        return function () { alive = false }
-      }, [state.selected])
+      if (state.error) return h('div', { className: 'dml' }, h('div', { className: 'card' }, h('span', { style: { color: 'var(--neg)' } }, 'Decision Mind: ' + state.error)))
+      var entries = state.ledger.map(_displayEntry)
 
-      var loading = state.loading
-      var error = state.error
-      var runs = state.runs
-      var selectedId = state.selected
-      var detail = state.detail
+      var body
+      if (state.loading) body = h('div', { className: 'empty' }, 'Loading desk data…')
+      else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
+      else if (state.view === 'portfolio') body = h(PortfolioView, { books: state.portfolio.books })
+      else body = h(PlansView, { plans: state.plans })
 
-      if (error) return h('div', { style: CARD }, h('span', { style: { color: RED } }, 'Decision Studio: ' + error))
-      if (loading) return h('div', { style: CARD }, 'Loading clawock runs…')
-
-      var detailView = null
-      if (detail) {
-        var model = _buildStudioModel(detail)
-        if (!model.empty) {
-          detailView = h('div', { style: CARD },
-            h('div', { style: { fontSize: 14, fontWeight: 700, marginBottom: 8 } },
-              model.subject ? model.subject.ticker + ' (' + model.subject.market + '/' + model.subject.currency + ')' : 'unknown subject'),
-            h(Row, { label: 'run_id', value: model.runId, muted: true }),
-            h(Row, { label: 'as_of', value: model.asOf || '—' }),
-            h('div', { style: { marginTop: 8 } },
-              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'GATES'),
-              (model.gates ? Object.keys(model.gates).map(function (key) {
-                return h(GateRow, { key: key, name: key, value: model.gates[key] })
-              }) : null)),
-            h('div', { style: { marginTop: 10 } },
-              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'DEBATE'),
-              (model.evidence || []).map(function (row) {
-                return h(EvidenceRow, { key: row.id, stance: row.stance, summary: row.summary, source: row.source, sourceClass: row.source_class, observedAt: row.observed_at })
-              })),
-            h('div', { style: { marginTop: 10 } },
-              h('div', { style: { color: MUTED, fontSize: 12, letterSpacing: '0.08em' } }, 'THESIS'),
-              h(Row, { value: model.thesis ? model.thesis.statement : '—' }),
-              model.action ? h(Row, { label: 'action', value: model.action.action + ' · confidence ' + (model.thesis ? model.thesis.confidence : '—') }) : null),
-            h(ReceiptBanner, { status: model.receiptStatus || 'rejected', runId: model.runId, generationId: model.generationId }))
-        }
-      }
-
-      return h('div', { style: { padding: 4 } },
-        h('div', { style: { color: MUTED, fontSize: 12, marginBottom: 6 } }, 'clawock runs in this workspace (' + runs.length + ')'),
-        runs.map(function (run) {
-          var ticker = (run.subject && run.subject.ticker) || (run.decisionSubject && run.decisionSubject.ticker) || run.runId
-          var status = run.receiptPresent ? 'published' : 'no receipt'
-          var label = ticker + ' · ' + status + (run.decisionPresent ? ' · decision' : '')
-          return h('button', {
-            key: run.runId,
-            onClick: function () { setState(function (current) { return Object.assign({}, current, { selected: run.runId }) }) },
-            style: {
-              display: 'block', width: '100%', textAlign: 'left', margin: '4px 0', padding: '8px 10px',
-              border: '1px solid ' + (run.runId === selectedId ? GREEN : '#243048'),
-              borderRadius: 8, background: run.runId === selectedId ? '#1b2a45' : '#161d2e', color: '#e8edf5', cursor: 'pointer', fontSize: 13,
-            },
-          }, label, '  ', h('span', { style: { color: MUTED } }, run.asOf || ''))
-        }),
-        detailView)
+      return h('div', { className: 'dml' },
+        h('div', { className: 'head' },
+          h('div', { className: 'title' }, h('h3', null, '决策心智'), h('span', null, 'Decision Mind · ' + entries.length + ' 条决策')),
+          h('div', { className: 'seg' },
+            h('button', { className: state.view === 'ledger' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ledger' }) }) } }, '账本'),
+            h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓'),
+            h('button', { className: state.view === 'plans' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'plans' }) }) } }, '计划'))),
+        body)
     }
 
     /** Minimal strict codecs (no zod external in the module table). */
     var passthroughSchema = { parse: function (value) { return value } }
-    var stringSchema = {
-      parse: function (value) {
-        if (typeof value !== 'string') throw new Error('expected a string')
-        return value
-      },
+
+    function remoteDescriptor(method) {
+      return {
+        id: 'clawock-dsh#clawockStudio/' + method,
+        service: 'clawockStudio',
+        namespace: 'clawockStudio',
+        method: method,
+        invocation: { kind: 'direct' },
+        parameters: [],
+        result: { mode: 'strict', typeSymbol: 'clawock-dsh#clawockStudio/' + method + ':result', schema: passthroughSchema },
+      }
     }
 
     /** Client projection of the clawockStudio Remote face, mounted explicitly. */
     var TYPERT_REMOTE = {
       package: 'clawock-dsh',
-      descriptors: [{
-        id: 'clawock-dsh#clawockStudio/list',
-        service: 'clawockStudio',
-        namespace: 'clawockStudio',
-        method: 'list',
-        invocation: { kind: 'direct' },
-        parameters: [],
-        result: {
-          mode: 'strict',
-          typeSymbol: 'clawock-dsh#clawockStudio/list:result',
-          schema: passthroughSchema,
-        },
-      }, {
-        id: 'clawock-dsh#clawockStudio/get',
-        service: 'clawockStudio',
-        namespace: 'clawockStudio',
-        method: 'get',
-        invocation: { kind: 'direct' },
-        parameters: [{
-          name: 'runId',
-          wire: 'runId',
-          source: 'json',
-          codec: {
-            mode: 'strict',
-            typeSymbol: 'clawock-dsh#clawockStudio/get:runId',
-            schema: stringSchema,
-          },
-        }],
-        result: {
-          mode: 'strict',
-          typeSymbol: 'clawock-dsh#clawockStudio/get:result',
-          schema: passthroughSchema,
-        },
-      }],
+      descriptors: ['list', 'get', 'ledger', 'portfolio', 'plans'].map(function (m) { return remoteDescriptor(m) }),
     }
 
     /** Services required by the registration and the mounted Remote face. */
     var inject = ['slots', 'remote']
 
-    /** Register the Decision Studio tab into the conversation view ring. */
+    /** Register the Decision Mind tab into the conversation view ring. */
     async function apply(ctx) {
       await ctx.remote.$mount(TYPERT_REMOTE)
       var studioRemote = ctx.get('remote.clawockStudio')
@@ -229,25 +297,26 @@ window.__ModuleLoader__.load({
           name: 'conversation.view',
           id: 'decision-studio',
           order: 30,
-          label: function () { return 'Decision Studio' },
+          label: function () { return 'Decision Mind' },
           inject: function () {
             var call = async function (method, args) {
-              var result = await studioRemote[method].apply(studioRemote, args)
+              var result = await studioRemote[method].apply(studioRemote, args || [])
               if (!result.ok) {
                 throw new Error('clawockStudio.' + method + ' failed: ' + result.error.code + ': ' + result.error.message)
               }
               return result.value
             }
             return {
-              list: function () { return call('list', []) },
-              get: function (runId) { return call('get', [runId]) },
+              ledger: function () { return call('ledger') },
+              portfolio: function () { return call('portfolio') },
+              plans: function () { return call('plans') },
             }
           },
-        }, DecisionStudio)
+        }, DecisionMind)
       })
     }
 
-    module.exports = { apply: apply, inject: inject, _buildStudioModel: _buildStudioModel }
+    module.exports = { apply: apply, inject: inject, _displayEntry: _displayEntry }
     return module.exports
   },
 })

--- a/examples/dsh/plugin/lib/index.js
+++ b/examples/dsh/plugin/lib/index.js
@@ -9,6 +9,7 @@
 
 import { TypertRemoteService, Remote } from '@deepseek-ai/dsh-typert-protocol'
 import { listRuns, getRun } from './scan.js'
+import { readLedger, readPortfolio, readPlans } from './ledger.js'
 
 const workspaceOf = () => process.env.CLAWOCK_WORKSPACE || process.cwd()
 
@@ -61,9 +62,27 @@ export class ClawockStudioGateway extends TypertRemoteService {
   get(runId) {
     return getRun(workspaceOf(), runId)
   }
+
+  /** @returns The shared decision ledger (memory/decisions.jsonl), file order. */
+  ledger() {
+    return readLedger(workspaceOf())
+  }
+
+  /** @returns Portfolio summary per book, with the desk's money fields. */
+  portfolio() {
+    return readPortfolio(workspaceOf())
+  }
+
+  /** @returns Recent daily plans, newest first. */
+  plans() {
+    return readPlans(workspaceOf())
+  }
 }
 
 markRemote(ClawockStudioGateway, 'list', 'list')
 markRemote(ClawockStudioGateway, 'get', 'get')
+markRemote(ClawockStudioGateway, 'ledger', 'ledger')
+markRemote(ClawockStudioGateway, 'portfolio', 'portfolio')
+markRemote(ClawockStudioGateway, 'plans', 'plans')
 
 export default ClawockStudioGateway

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -1,0 +1,112 @@
+/**
+ * Read-only readers over the OpenClaw desk's produced data: the shared
+ * decision ledger, the portfolio, and recent daily plans. Pure Node, no
+ * Cordis/typert dependencies — unit-testable in isolation.
+ *
+ * These are the files the OpenClaw runtime produces every day, so whatever
+ * OpenClaw writes, this DSH plugin can show.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PLAN_PATTERN = /^(\d{4}-\d{2}-\d{2})-plan\.json$/
+
+function readJson(path) {
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse the decision ledger (memory/decisions.jsonl) — one JSON object per
+ * line. Malformed lines are skipped, never fatal: the desk's own writer
+ * round-trips the file and this view must survive any of its states.
+ * @param workspace - desk workspace root.
+ * @returns `{ entries, path }`; entries are in file order (oldest first).
+ */
+export function readLedger(workspace) {
+  const path = join(workspace, 'memory', 'decisions.jsonl')
+  const entries = []
+  if (existsSync(path)) {
+    const lines = readFileSync(path, 'utf8').split('\n')
+    for (const line of lines) {
+      if (!line.trim()) continue
+      try {
+        entries.push(JSON.parse(line))
+      } catch {
+        /* skip one malformed line */
+      }
+    }
+  }
+  return { entries, path }
+}
+
+/**
+ * Summarize the portfolio (portfolio.json): per-book holdings with the desk's
+ * own money fields and totals.
+ * @param workspace - desk workspace root.
+ * @returns `{ books, lastUpdated }`; books with no positive holdings are kept
+ *          (a zeroed book is still information).
+ */
+export function readPortfolio(workspace) {
+  const doc = readJson(join(workspace, 'portfolio.json'))
+  if (doc === null) return { books: [], lastUpdated: null }
+  const books = []
+  const portfolios = doc.portfolios ?? {}
+  for (const [name, book] of Object.entries(portfolios)) {
+    if (book === null || typeof book !== 'object' || !Array.isArray(book.holdings)) continue
+    const holdings = book.holdings
+      .filter((h) => h !== null && typeof h === 'object')
+      .map((h) => ({
+        ticker: h.ticker ?? h.stock_name ?? h.name ?? '?',
+        shares: h.shares ?? h.quantity ?? 0,
+        cost: h.cost_basis ?? null,
+        price: h.current_price ?? null,
+        pnlPct: h.pnl_percent ?? null,
+        pnlAbs: h.pnl_abs ?? null,
+      }))
+    books.push({
+      name,
+      currency: book.currency ?? null,
+      truePrincipal: book.true_principal ?? null,
+      holdings,
+    })
+  }
+  return { books, lastUpdated: doc.last_updated ?? null }
+}
+
+/**
+ * List recent daily plans (memory/YYYY-MM-DD-plan.json), newest first.
+ * @param workspace - desk workspace root.
+ * @param limit - how many plans to return.
+ * @returns `{ plans }` with date and decision count per plan.
+ */
+export function readPlans(workspace, limit = 14) {
+  const plans = []
+  let files = []
+  try {
+    files = readdirSync(join(workspace, 'memory'))
+  } catch {
+    return { plans }
+  }
+  const dated = files
+    .map((name) => PLAN_PATTERN.exec(name))
+    .filter(Boolean)
+    .map((m) => ({ date: m[1], name: m[0] }))
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .slice(0, limit)
+  for (const file of dated) {
+    const doc = readJson(join(workspace, 'memory', file.name))
+    if (doc === null) continue
+    plans.push({
+      date: file.date,
+      decisions: Array.isArray(doc.decisions) ? doc.decisions.length : 0,
+      title: doc.title ?? null,
+    })
+  }
+  return { plans }
+}

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -61,6 +61,7 @@ export function readPortfolio(workspace) {
     if (book === null || typeof book !== 'object' || !Array.isArray(book.holdings)) continue
     const holdings = book.holdings
       .filter((h) => h !== null && typeof h === 'object')
+      .filter((h) => (h.shares ?? h.quantity ?? 0) > 0) // zero-share rows are not positions
       .map((h) => ({
         ticker: h.ticker ?? h.stock_name ?? h.name ?? '?',
         shares: h.shares ?? h.quantity ?? 0,
@@ -69,6 +70,7 @@ export function readPortfolio(workspace) {
         pnlPct: h.pnl_percent ?? null,
         pnlAbs: h.pnl_abs ?? null,
       }))
+    if (holdings.length === 0) continue // a book with no positions is not shown
     books.push({
       name,
       currency: book.currency ?? null,

--- a/examples/dsh/plugin/skills/investment-decision/SKILL.md
+++ b/examples/dsh/plugin/skills/investment-decision/SKILL.md
@@ -209,6 +209,30 @@ After the stated horizon, record price/FX outcome evidence and run
 The result reconciles price and FX before assigning a basis-point score — it
 is evidence for the next decision, not portfolio P&L.
 
+## Record conversation verdicts
+
+A conversation verdict (加仓/减仓/建仓/清仓/观望) is a decision — write it
+to the shared decision-mind ledger, the same `memory/decisions.jsonl` the
+daily OpenClaw brief writes to, so both sides can read it and the daily
+settlement round-trips it:
+
+```bash
+clawock record \
+  --subject 00100 --market HK --currency HKD \
+  --action reject --confidence 0.65 --driven-by fundamental \
+  --bull "营收 +159% YoY,入通/海外霸榜催化" \
+  --bear "净利率 -2368%,资不抵债,z+2.8σ 反转" \
+  --thesis "高增长救不了资不抵债,先活下来" \
+  --invalidation "站回 340" --invalidation "缩量企稳" \
+  --emotion averaging_down --note "浮亏 -40% 的摊本冲动被压过,忍住没加"
+```
+
+Rules: the bear case and at least one observable invalidation condition are
+mandatory (the command rejects weak records); be honest about emotion
+pressure — `fomo`/`revenge`/`averaging_down` are the exact patterns this
+ledger exists to surface. Full schema:
+`docs/decision-mind-ledger.md` (installed with the package).
+
 ## Learn more
 
 Live proof on a real HK + US desk: <https://kcnyu.github.io/clawock/>

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -709,6 +709,7 @@ def main(argv=None) -> int:
         ("reconcile", "recompute all portfolio derivations and verify integrity"),
         ("validate-sidecar", "validate a workflow-generated sidecar artifact"),
         ("mark-followed", "record execution ground truth in the decision ledger"),
+        ("record", "append a conversation verdict to the decision-mind ledger"),
         ("audit-resettle", "audit decision re-settlement without writing by default"),
         ("evidence", "rebuild the artifact-backed public evidence page"),
         ("news-evidence", "build the expiring news and filing evidence graph"),

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -290,6 +290,12 @@ def assign_episode_ids(decisions: list[dict]) -> list[dict]:
 
 
 def validate_decision(d: dict) -> list[str]:
+    # Decision-mind conversation records (docs/decision-mind-ledger.md) are a
+    # deliberate second ledger row type: they carry mind/emotion instead of the
+    # plan-decision fields below, and are validated by their own rules.
+    if d.get("schema_version") == 0 and d.get("source") == "conversation":
+        from clawock.decision.record import validate_mind_record
+        return validate_mind_record(d)
     errors = []
     for key in ("decision_id", "episode_id", "plan_date", "created_at", "ticker", "strategy_id", "action", "condition"):
         if d.get(key) in (None, ""):

--- a/src/clawock/decision/record.py
+++ b/src/clawock/decision/record.py
@@ -86,7 +86,13 @@ def build_record(args) -> dict:
         # record like any other decision (docs/decision-mind-ledger.md).
         "condition": {"description": args.invalidation[0] if args.invalidation else "",
                       "price": None, "type": "manual"},
-        "execution": {"status": "unknown", "source": "conversation", "detected_at": None},
+        # A no-op verdict (reject/hold/watch/abstain) is "executed" when it is
+        # respected — no order was placed, which is the decision itself. Order
+        # actions start unknown until marked via `clawock mark-followed`.
+        "execution": {
+            "status": "followed" if args.action in {"reject", "hold", "watch", "abstain"} else "unknown",
+            "source": "conversation", "detected_at": None,
+        },
         "accounting": {
             "trigger": {"status": "pending", "condition": args.invalidation[0] if args.invalidation else ""},
             "execution": {"executed": None},

--- a/src/clawock/decision/record.py
+++ b/src/clawock/decision/record.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Append a conversation investment verdict to the decision ledger.
+
+The decision-mind ledger (docs/decision-mind-ledger.md) freezes the mind
+(bull/bear/thesis/invalidation) and emotion pressure at decision time, then
+lets the existing daily settlement machinery account for it. Records written
+here also carry the legacy ``condition``/``execution`` fields so the desk's
+normal ``settle_decisions`` round-trip treats them like any other decision.
+
+Usage:
+  clawock record --subject 00100 --market HK --currency HKD \
+    --action reject --confidence 0.65 --driven-by fundamental \
+    --bull "营收 +159% YoY" --bear "资不抵债" --thesis "先活下来" \
+    --invalidation "站回 340" --invalidation "缩量企稳" \
+    --emotion averaging_down --note "摊本冲动被压过,忍住没加"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from clawock.decision import ledger as decision_v2
+
+ACTIONS = {"buy", "add", "trim", "sell", "hold", "watch", "reject", "abstain"}
+DRIVEN_BY = {"technical", "fundamental", "sentiment", "mixed"}
+EMOTIONS = {"calm", "fomo", "revenge", "averaging_down", "fear", "euphoria", "mixed"}
+MIND_SCHEMA_VERSION = 0
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def validate_mind_record(record: dict) -> list[str]:
+    """Return human-readable issues; empty means the record is appendable."""
+    issues: list[str] = []
+    subject = record.get("subject") or {}
+    for field in ("ticker", "market", "currency"):
+        if not isinstance(subject.get(field), str) or not subject.get(field, "").strip():
+            issues.append(f"subject.{field} is required")
+    if record.get("action") not in ACTIONS:
+        issues.append(f"action must be one of {sorted(ACTIONS)}")
+    confidence = record.get("confidence")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        issues.append("confidence must be between 0 and 1")
+    if record.get("driven_by") not in DRIVEN_BY:
+        issues.append(f"driven_by must be one of {sorted(DRIVEN_BY)}")
+    mind = record.get("mind") or {}
+    for side in ("bull", "bear"):
+        case = mind.get(side) or {}
+        if not isinstance(case.get("summary"), str) or not case.get("summary", "").strip():
+            issues.append(f"mind.{side}.summary is required (opposing case is mandatory)")
+    if not isinstance(mind.get("invalidation"), list) or not mind.get("invalidation"):
+        issues.append("mind.invalidation must be a non-empty list of observable conditions")
+    emotion = record.get("emotion") or {}
+    if emotion.get("pressure") not in EMOTIONS:
+        issues.append(f"emotion.pressure must be one of {sorted(EMOTIONS)}")
+    return issues
+
+
+def build_record(args) -> dict:
+    subject = {"ticker": args.subject, "market": args.market, "currency": args.currency}
+    decided_at = _now_iso()
+    decision_id = "dec-" + decision_v2._stable_id("conversation", args.subject, decided_at, size=12)
+    mind = {
+        "bull": {"summary": args.bull, "evidence": args.bull_evidence},
+        "bear": {"summary": args.bear, "evidence": args.bear_evidence},
+        "thesis": args.thesis,
+        "invalidation": args.invalidation,
+    }
+    record = {
+        "schema_version": MIND_SCHEMA_VERSION,
+        "decision_id": decision_id,
+        "subject": subject,
+        "decided_at": decided_at,
+        "source": "conversation",
+        "action": args.action,
+        "confidence": args.confidence,
+        "driven_by": args.driven_by,
+        "mind": mind,
+        "emotion": {"pressure": args.emotion, "note": args.note},
+        # Legacy-compatible fields so daily settlement round-trips process this
+        # record like any other decision (docs/decision-mind-ledger.md).
+        "condition": {"description": args.invalidation[0] if args.invalidation else "",
+                      "price": None, "type": "manual"},
+        "execution": {"status": "unknown", "source": "conversation", "detected_at": None},
+        "accounting": {
+            "trigger": {"status": "pending", "condition": args.invalidation[0] if args.invalidation else ""},
+            "execution": {"executed": None},
+            "outcome": {"grade": "pending"},
+        },
+    }
+    return record
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="clawock record")
+    ap.add_argument("--ledger", type=Path, default=None,
+                    help="decisions.jsonl path (default: the workspace ledger)")
+    ap.add_argument("--subject", required=True, help="ticker, e.g. 00100")
+    ap.add_argument("--market", default="HK", help="market, e.g. HK or US")
+    ap.add_argument("--currency", default="HKD", help="quote currency")
+    ap.add_argument("--action", required=True, choices=sorted(ACTIONS))
+    ap.add_argument("--confidence", type=float, required=True)
+    ap.add_argument("--driven-by", default="mixed", choices=sorted(DRIVEN_BY))
+    ap.add_argument("--bull", required=True, help="supporting case summary")
+    ap.add_argument("--bear", required=True, help="opposing case summary (mandatory)")
+    ap.add_argument("--bull-evidence", action="append", default=[])
+    ap.add_argument("--bear-evidence", action="append", default=[])
+    ap.add_argument("--thesis", default="")
+    ap.add_argument("--invalidation", action="append", required=True,
+                    help="observable falsification condition; repeatable")
+    ap.add_argument("--emotion", default="calm", choices=sorted(EMOTIONS))
+    ap.add_argument("--note", default="")
+    args = ap.parse_args(argv)
+
+    record = build_record(args)
+    issues = validate_mind_record(record)
+    if issues:
+        for issue in issues:
+            print(f"record rejected: {issue}", file=sys.stderr)
+        return 1
+
+    rows = decision_v2.load_decisions(args.ledger)
+    rows.append(record)
+    decision_v2.write_decisions(rows, args.ledger)
+    print(json.dumps(record, ensure_ascii=False, indent=2))
+    print(f"appended {record['decision_id']} ({len(rows)} total)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -105,6 +105,7 @@ test("ledger: portfolio summarizes holdings per book", async () => {
   try {
     const { books, lastUpdated } = ledger.readPortfolio(root);
     assert.equal(lastUpdated, "2026-08-16 13:42 HKT");
+    assert.equal(books.length, 1, "zero-share book (us_stocks/NVDA 0) must be dropped");
     const hk = books.find((b) => b.name === "hk_stocks");
     assert.equal(hk.currency, "HKD");
     assert.equal(hk.holdings.length, 1);
@@ -258,8 +259,13 @@ test("client: renders ledger cards from the mounted remote", async () => {
         decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
         mind: { bull: { summary: "营收 +159%" }, bear: { summary: "资不抵债" }, invalidation: ["站回 340"] },
         emotion: { pressure: "averaging_down", note: "忍住没加" },
+        execution: { status: "followed" } },
+      { decision_id: "dec-2", plan_date: "2026-08-10", ticker: "07226", action: "hold", confidence: 0.5,
+        execution: { status: "followed" } },
+      { decision_id: "dec-3", plan_date: "2026-08-11", ticker: "02208", action: "cut", confidence: 0.6,
+        execution: { status: "followed" } },
+      { decision_id: "dec-4", plan_date: "2026-08-12", ticker: "03032", action: "trim", confidence: 0.4,
         execution: { status: "unknown" } },
-      { decision_id: "dec-2", plan_date: "2026-08-10", ticker: "07226", action: "hold", confidence: 0.5 },
     ] } }),
     portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [] }] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
@@ -293,10 +299,60 @@ test("client: renders ledger cards from the mounted remote", async () => {
   })(tree);
   const joined = text.join(" ");
   assert.match(joined, /决策心智/);
-  assert.match(joined, /00100/);
-  assert.match(joined, /reject/);
-  assert.match(joined, /averaging_down/);
-  assert.match(joined, /07226/);
+  assert.match(joined, /已执行交易/);
+  // default filter = executed trades only: the cut shows, the reject/hold/unknown do not
+  assert.match(joined, /02208/);
+  assert.match(joined, /cut/);
+  assert.doesNotMatch(joined, /00100/);
+  assert.doesNotMatch(joined, /03032/);
+
+  const findButton = (label) => {
+    let found = null;
+    (function collect(node) {
+      if (node == null || found) return;
+      if (Array.isArray(node)) { node.forEach(collect); return; }
+      if (node.type === "button") {
+        const t = (node.children || []).filter((c) => typeof c === "string").join("");
+        if (t === label) found = node;
+      }
+      (node.children || []).forEach(collect);
+    })(tree);
+    return found;
+  };
+
+  // switch to 已执行: the respected reject (00100) and hold appear
+  findButton("已执行").props.onClick();
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const textB = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { textB.push(node); return; }
+    (node.children || []).forEach(walk);
+    walk(node.props && node.props.value);
+    walk(node.props && node.props.label);
+  })(tree);
+  const joinedB = textB.join(" ");
+  assert.match(joinedB, /00100/);
+  assert.match(joinedB, /reject/);
+  assert.match(joinedB, /07226/);
+  assert.doesNotMatch(joinedB, /03032/);
+
+  // switch to 全部: the unknown trim appears too
+  findButton("全部").props.onClick();
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const textC = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { textC.push(node); return; }
+    (node.children || []).forEach(walk);
+    walk(node.props && node.props.value);
+    walk(node.props && node.props.label);
+  })(tree);
+  assert.match(textC.join(" "), /03032/);
 
   // click a ledger card row: expand shows the mind detail
   const cardRows = [];
@@ -306,7 +362,7 @@ test("client: renders ledger cards from the mounted remote", async () => {
     if (node.props && node.props.onClick && node.props.className === "row") cardRows.push(node);
     (node.children || []).forEach(collect);
   })(tree);
-  assert.equal(cardRows.length, 2, "two ledger cards");
+  assert.ok(cardRows.length >= 2, "expanded ledger cards");
   cardRows[0].props.onClick();
   await tick();
   tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 /**
- * Decision Studio plugin tests (clawock-dsh node + client halves).
+ * Decision Mind plugin tests (clawock-dsh node + client halves).
  *
  * Run: node tests/decision_studio_plugin.spec.js
  * CI: harness-regression.yml runs it when plugin files change.
  *
  * What is verified without a browser:
- *   - scan.js: workspace listing, run detail, run-id path-safety boundary
- *   - client.js: module-loader registration shape, inject face, model
- *     projection, and a stub-react render of the run list
- * The visual tab boot remains a source-machine verification (no GUI here).
+ *   - scan.js: workspace run listing, run-id path-safety boundary
+ *   - ledger.js: decision ledger / portfolio / plan readers over OpenClaw
+ *     desk files (whatever OpenClaw produces, this plugin can show)
+ *   - client.js: module-loader registration, mounted Remote face, display
+ *     projection, and a stub-react render of the ledger cards
  */
 "use strict";
 
@@ -22,76 +23,111 @@ const test = require("node:test");
 
 const PLUGIN = path.join(__dirname, "..", "examples", "dsh", "plugin");
 
-function makeWorkspace() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-studio-"));
-  const runId = "0123456789abcdef0123456789abcdef";
-  const work = path.join(root, ".clawock", "work", runId);
-  fs.mkdirSync(work, { recursive: true });
-  fs.writeFileSync(path.join(work, "request.json"), JSON.stringify({
-    schema_version: 1,
-    run_id: runId,
-    generation_id: "fedcba9876543210fedcba9876543210",
-    task: "Produce decision.json for an evidence-linked investment decision.",
-    context: { documents: [{ name: "CONTEXT.md", sha256: "aa".repeat(32) }] },
-    workflow: {
-      id: "investment-decision", version: "1.1.0",
-      parameters: { min_supporting_evidence: 1, min_opposing_evidence: 1, max_confidence_without_primary_source: 0.65 },
+// The bundle injects its stylesheet through `document` at factory time;
+// node:test has no DOM, so provide the minimal surface the factory touches.
+globalThis.document = {
+  getElementById() { return null; },
+  createElement() { return { id: "", textContent: "" }; },
+  head: { appendChild() {} },
+};
+
+function makeDesk() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-mind-"));
+  fs.mkdirSync(path.join(root, "memory"), { recursive: true });
+  fs.writeFileSync(path.join(root, "memory", "decisions.jsonl"), [
+    JSON.stringify({
+      decision_id: "dec-legacy1", plan_date: "2026-08-10", ticker: "00100", leg: "HK",
+      action: "trim_on_rebound", confidence: 0.7, driven_by: "technical",
+      condition: { description: "跌破 730 减 20 股", price: 730.0, type: "price_below" },
+      evaluation: { outcome: "not_triggered", status: "not_triggered" },
+      execution: { status: "unknown" },
+    }),
+    JSON.stringify({
+      schema_version: 0, decision_id: "dec-conv1", source: "conversation",
+      subject: { ticker: "00100", market: "HK", currency: "HKD" },
+      decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
+      driven_by: "fundamental",
+      mind: { bull: { summary: "营收 +159%", evidence: [] }, bear: { summary: "资不抵债", evidence: [] },
+              thesis: "先活下来", invalidation: ["站回 340"] },
+      emotion: { pressure: "averaging_down", note: "忍住没加" },
+      execution: { status: "unknown" },
+    }),
+    "not valid json line that must be skipped",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({
+    last_updated: "2026-08-16 13:42 HKT",
+    portfolios: {
+      hk_stocks: { currency: "HKD", holdings: [
+        { ticker: "00100", name: "MINIMAX-W", shares: 120, cost_basis: 553.08, current_price: 329.0, pnl_percent: -40.5 },
+      ] },
+      us_stocks: { currency: "USD", holdings: [
+        { ticker: "NVDA", shares: 0, current_price: 213.0, pnl_percent: 0 },
+      ] },
     },
-    subject: { ticker: "DEMO", market: "US", currency: "USD" },
-    as_of: "2026-08-16T12:00:00+00:00",
   }));
-  fs.mkdirSync(path.join(root, ".clawock", "runs", runId), { recursive: true });
-  fs.writeFileSync(path.join(root, ".clawock", "runs", runId, "manifest.json"), JSON.stringify({
-    generation_id: "fedcba9876543210fedcba9876543210",
-    artifacts: [{ name: "decision.json" }],
+  fs.writeFileSync(path.join(root, "memory", "2026-08-10-plan.json"), JSON.stringify({
+    schema_version: 2, title: "盘前 plan", decisions: [{ ticker: "00100" }, { ticker: "07226" }],
   }));
-  fs.writeFileSync(path.join(root, "decision.json"), JSON.stringify({ decision: { action: "watch" } }));
-  return { root, runId };
+  fs.writeFileSync(path.join(root, "memory", "2026-08-15-plan.json"), JSON.stringify({
+    schema_version: 2, decisions: [],
+  }));
+  return root;
 }
-
-test("scan: lists a prepared run with decision and receipt presence", async () => {
-  const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
-  const { root, runId } = makeWorkspace();
-  try {
-    const runs = scan.listRuns(root);
-    assert.equal(runs.length, 1);
-    assert.equal(runs[0].runId, runId);
-    assert.equal(runs[0].subject.ticker, "DEMO");
-    assert.equal(runs[0].documentCount, 1);
-    assert.equal(runs[0].decisionPresent, true);
-    assert.equal(runs[0].decisionAction, "watch");
-    assert.equal(runs[0].receiptPresent, true);
-    assert.equal(runs[0].gates.min_opposing_evidence, 1);
-
-    const detail = scan.getRun(root, runId);
-    assert.equal(detail.request.workflow.id, "investment-decision");
-    assert.deepEqual(detail.decision.decision, { action: "watch" });
-    assert.equal(detail.manifest.artifacts[0].name, "decision.json");
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test("scan: ignores non-run directories and missing workspaces", async () => {
-  const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-studio-"));
-  try {
-    fs.mkdirSync(path.join(root, ".clawock", "work", "not-a-run"), { recursive: true });
-    fs.writeFileSync(path.join(root, ".clawock", "work", "not-a-run", "request.json"), "{}");
-    assert.deepEqual(scan.listRuns(root), []);
-
-    const missing = scan.getRun(root, "0123456789abcdef0123456789abcdef");
-    assert.equal(missing.request, null);
-    assert.deepEqual(scan.listRuns(path.join(root, "does-not-exist")), []);
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
 
 test("scan: run ids are the path-safety boundary", async () => {
   const scan = await import(pathToFileURL(path.join(PLUGIN, "lib", "scan.js")).href);
-  for (const bad of ["..", "../secret", "abc", "0123456789abcdef0123456789abcdeg", "", null, 42]) {
+  for (const bad of ["..", "../secret", "abc", "", null, 42]) {
     assert.throws(() => scan.getRun("/tmp", bad), TypeError, `run id ${JSON.stringify(bad)} must be rejected`);
+  }
+});
+
+test("ledger: reads decisions.jsonl, skips malformed lines, keeps desk entries", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = makeDesk();
+  try {
+    const { entries } = ledger.readLedger(root);
+    assert.equal(entries.length, 2, "malformed line must be skipped, not fatal");
+    const conv = entries.find((d) => d.source === "conversation");
+    assert.equal(conv.mind.bear.summary, "资不抵债");
+    assert.equal(conv.emotion.pressure, "averaging_down");
+    const brief = entries.find((d) => d.plan_date === "2026-08-10");
+    assert.equal(brief.action, "trim_on_rebound");
+    assert.deepEqual(ledger.readLedger(path.join(root, "nope")).entries, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ledger: portfolio summarizes holdings per book", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = makeDesk();
+  try {
+    const { books, lastUpdated } = ledger.readPortfolio(root);
+    assert.equal(lastUpdated, "2026-08-16 13:42 HKT");
+    const hk = books.find((b) => b.name === "hk_stocks");
+    assert.equal(hk.currency, "HKD");
+    assert.equal(hk.holdings.length, 1);
+    assert.equal(hk.holdings[0].ticker, "00100");
+    assert.equal(hk.holdings[0].pnlPct, -40.5);
+    assert.deepEqual(ledger.readPortfolio(path.join(root, "nope")).books, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ledger: plans list newest first with decision counts", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = makeDesk();
+  try {
+    const { plans } = ledger.readPlans(root);
+    assert.equal(plans.length, 2);
+    assert.equal(plans[0].date, "2026-08-15");
+    assert.equal(plans[0].decisions, 0);
+    assert.equal(plans[1].date, "2026-08-10");
+    assert.equal(plans[1].decisions, 2);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 
@@ -105,6 +141,10 @@ function makeReactStub() {
   let state = null;
   return {
     createElement(type, props, ...children) {
+      if (typeof type === "function") {
+        // Mini-renderer: invoke function components so their subtrees appear.
+        return type(Object.assign({}, props, { children }));
+      }
       return { type, props: props || {}, children };
     },
     useState(initial) {
@@ -122,29 +162,30 @@ function makeReactStub() {
   };
 }
 
-test("client: registers the Decision Studio conversation.view tab", async () => {
+async function loadClient() {
   let loaded = null;
   globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
-  const reactStub = makeReactStub();
-  const requireStub = (specifier) => {
-    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
-    if (specifier === "react") return reactStub;
-    throw new Error(`unexpected client require: ${specifier}`);
-  };
-
   await import(clientUrl());
   assert.ok(loaded, "client.js must register through the module loader");
-  assert.equal(loaded.id, "clawock-dsh");
+  return loaded;
+}
 
-  const api = loaded.factory(requireStub);
+test("client: registers the Decision Mind tab and mounts the remote face", async () => {
+  const loaded = await loadClient();
+  assert.equal(loaded.id, "clawock-dsh");
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
   assert.deepEqual(api.inject, ["slots", "remote"]);
-  assert.equal(typeof api.apply, "function");
 
   let registered = null;
   let component = null;
   const remoteFace = {
-    list: async () => ({ ok: true, value: { runs: [] } }),
-    get: async (runId) => ({ ok: true, value: { runId, request: null, decision: null, manifest: null } }),
+    ledger: async () => ({ ok: true, value: { entries: [] } }),
+    portfolio: async () => ({ ok: true, value: { books: [] } }),
+    plans: async () => ({ ok: true, value: { plans: [] } }),
   };
   const ctx = {
     effect() {},
@@ -153,108 +194,79 @@ test("client: registers the Decision Studio conversation.view tab", async () => 
       inject(name, fn) { assert.equal(name, "conversation.view"); this._fn = fn; },
       register(definition, Component) { registered = definition; component = Component; },
     },
-    remote: { $mount: async (descriptors) => { assert.ok(descriptors.descriptors.length >= 2); } },
+    remote: { $mount: async (descriptors) => { assert.equal(descriptors.descriptors.length, 5); } },
   };
   await api.apply(ctx);
-  ctx.slots._fn(); // slots.inject registers lazily once the slot exists
-  assert.ok(registered, "apply must register into conversation.view");
-  assert.equal(registered.name, "conversation.view");
+  ctx.slots._fn();
   assert.equal(registered.id, "decision-studio");
   assert.equal(registered.order, 30);
-  assert.equal(registered.label(), "Decision Studio");
+  assert.equal(registered.label(), "Decision Mind");
 
-  const injected = registered.inject("session-1");
-  assert.equal(typeof injected.list, "function");
-  assert.equal(typeof injected.get, "function");
-  const result = await injected.list();
-  assert.deepEqual(result, { runs: [] });
-  const detail = await injected.get("0123456789abcdef0123456789abcdef");
-  assert.equal(detail.request, null);
+  const injected = registered.inject("s1");
+  assert.equal(typeof injected.ledger, "function");
+  assert.equal(typeof injected.portfolio, "function");
+  assert.equal(typeof injected.plans, "function");
+  assert.deepEqual(await injected.ledger(), { entries: [] });
   assert.equal(typeof component, "function");
 });
 
-test("client: _buildStudioModel projects run files for the tab", async () => {
-  let loaded = null;
-  globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
-  await import(clientUrl());
-  const api = loaded.factory((specifier) => {
-    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
-    if (specifier === "react") return makeReactStub();
-    throw new Error(`unexpected client require: ${specifier}`);
+test("client: _displayEntry projects mind records and degrades legacy entries", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
   });
 
-  const empty = api._buildStudioModel({ runId: "0123456789abcdef0123456789abcdef", request: null });
-  assert.equal(empty.empty, true);
-
-  const full = api._buildStudioModel({
-    runId: "0123456789abcdef0123456789abcdef",
-    request: {
-      subject: { ticker: "DEMO", market: "US", currency: "USD" },
-      as_of: "2026-08-16T12:00:00+00:00",
-      workflow: { parameters: { min_opposing_evidence: 1 } },
-      context: { documents: [{ name: "CONTEXT.md" }] },
-    },
-    decision: {
-      evidence: [{ id: "e1", stance: "opposing", summary: "risk", source: "market", source_class: "market", observed_at: "t" }],
-      debate: { bull_case: {}, bear_case: {} },
-      thesis: { statement: "s", confidence: 0.7 },
-      decision: { action: "watch" },
-    },
-    manifest: { generation_id: "g1" },
+  const conv = api._displayEntry({
+    decision_id: "dec-1", source: "conversation",
+    subject: { ticker: "00100", market: "HK", currency: "HKD" },
+    decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
+    mind: { bull: { summary: "b" }, bear: { summary: "r" }, thesis: "t", invalidation: ["c1"] },
+    emotion: { pressure: "averaging_down", note: "忍住" },
+    execution: { status: "unknown" },
   });
-  assert.equal(full.empty, false);
-  assert.equal(full.subject.ticker, "DEMO");
-  assert.equal(full.gates.min_opposing_evidence, 1);
-  assert.equal(full.evidence[0].stance, "opposing");
-  assert.equal(full.action.action, "watch");
-  assert.equal(full.receiptStatus, "published");
-  assert.equal(full.generationId, "g1");
+  assert.equal(conv.ticker, "00100");
+  assert.equal(conv.action, "reject");
+  assert.equal(conv.emotion, "averaging_down");
+  assert.deepEqual(conv.invalidation, ["c1"]);
+
+  const legacy = api._displayEntry({
+    decision_id: "dec-2", plan_date: "2026-08-10", ticker: "00100",
+    action: "trim_on_rebound", confidence: 0.7,
+    condition: { description: "跌破 730" }, evaluation: { outcome: "not_triggered" },
+  });
+  assert.equal(legacy.bull, null);
+  assert.equal(legacy.condition, "跌破 730");
+  assert.equal(legacy.outcome, "not_triggered");
+  assert.equal(legacy.emotion, null);
 });
 
-test("client: the tab component renders the run list from the remote", async () => {
-  let loaded = null;
-  globalThis.window = { __ModuleLoader__: { load(entry) { loaded = entry; } } };
-  const reactStub = makeReactStub();
-  const requireStub = (specifier) => {
-    if (specifier === "@deepseek-ai/dsh-client-runtime/client") return {};
-    if (specifier === "react") return reactStub;
-    throw new Error(`unexpected client require: ${specifier}`);
-  };
-  await import(clientUrl());
-  const api = loaded.factory(requireStub);
+test("client: renders ledger cards from the mounted remote", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
 
-  let component = null;
   let registered = null;
-  const runId = "0123456789abcdef0123456789abcdef";
+  let component = null;
   const remoteFace = {
-    list: async () => ({
-      ok: true,
-      value: { runs: [{ runId, subject: { ticker: "DEMO" }, asOf: "2026-08-16T12:00:00+00:00", decisionPresent: true, receiptPresent: true }] },
-    }),
-    get: async (id) => ({
-      ok: true,
-      value: {
-        runId: id,
-        request: {
-          subject: { ticker: "DEMO", market: "US", currency: "USD" },
-          as_of: "2026-08-16T12:00:00+00:00",
-          workflow: { parameters: { min_supporting_evidence: 1, min_opposing_evidence: 1, max_confidence_without_primary_source: 0.65 } },
-          context: { documents: [{ name: "CONTEXT.md" }] },
-        },
-        decision: {
-          subject: { ticker: "DEMO", market: "US", currency: "USD" },
-          evidence: [{ id: "e1", stance: "opposing", summary: "valuation risk", source: "market", source_class: "market", observed_at: "2026-08-16T11:45:00+00:00" }],
-          debate: { bull_case: {}, bear_case: {} },
-          thesis: { statement: "constructive but expensive", confidence: 0.7 },
-          decision: { action: "watch" },
-        },
-        manifest: { generation_id: "g1" },
-      },
-    }),
+    ledger: async () => ({ ok: true, value: { entries: [
+      { decision_id: "dec-1", source: "conversation", subject: { ticker: "00100" },
+        decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
+        mind: { bull: { summary: "营收 +159%" }, bear: { summary: "资不抵债" }, invalidation: ["站回 340"] },
+        emotion: { pressure: "averaging_down", note: "忍住没加" },
+        execution: { status: "unknown" } },
+      { decision_id: "dec-2", plan_date: "2026-08-10", ticker: "07226", action: "hold", confidence: 0.5 },
+    ] } }),
+    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [] }] } }),
+    plans: async () => ({ ok: true, value: { plans: [] } }),
   };
   const ctx = {
     effect() {},
-    get(name) { assert.equal(name, "remote.clawockStudio"); return remoteFace; },
+    get() { return remoteFace; },
     slots: {
       inject(name, fn) { this._fn = fn; },
       register(definition, Component) { registered = definition; component = Component; },
@@ -263,30 +275,12 @@ test("client: the tab component renders the run list from the remote", async () 
   };
   await api.apply(ctx);
   ctx.slots._fn();
-  const injected = registered.inject("s1"); // the real injected face unwraps the remote envelope
+  const injected = registered.inject("s1");
 
   const tick = () => new Promise((resolve) => setImmediate(resolve));
-  const render = () => component({ sessionId: "s1", list: injected.list, get: injected.get });
-  let tree = (await (async () => {
-    render();
-    await tick(); await tick(); await tick();
-    return render();
-  })());
-
-  // click the run row, then let list + get resolve, then re-render
-  tree = (await (async () => {
-    const buttons = [];
-    (function find(node) {
-      if (node == null) return;
-      if (Array.isArray(node)) { node.forEach(find); return; }
-      if (node.type === "button") buttons.push(node);
-      (node.children || []).forEach(find);
-    })(tree);
-    assert.equal(buttons.length, 1, "the run list must render one row button");
-    buttons[0].props.onClick();
-    await tick(); await tick(); await tick(); await tick();
-    return render();
-  })());
+  let tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  await tick(); await tick(); await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
 
   const text = [];
   (function walk(node) {
@@ -296,9 +290,38 @@ test("client: the tab component renders the run list from the remote", async () 
     (node.children || []).forEach(walk);
     walk(node.props && node.props.value);
     walk(node.props && node.props.label);
-    walk(node.props && node.props.name);
   })(tree);
   const joined = text.join(" ");
-  assert.match(joined, /DEMO/);
-  assert.match(joined, /1/);
+  assert.match(joined, /决策心智/);
+  assert.match(joined, /00100/);
+  assert.match(joined, /reject/);
+  assert.match(joined, /averaging_down/);
+  assert.match(joined, /07226/);
+
+  // click a ledger card row: expand shows the mind detail
+  const cardRows = [];
+  (function collect(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(collect); return; }
+    if (node.props && node.props.onClick && node.props.className === "row") cardRows.push(node);
+    (node.children || []).forEach(collect);
+  })(tree);
+  assert.equal(cardRows.length, 2, "two ledger cards");
+  cardRows[0].props.onClick();
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const text2 = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { text2.push(node); return; }
+    (node.children || []).forEach(walk);
+    walk(node.props && node.props.value);
+    walk(node.props && node.props.label);
+  })(tree);
+  const joined2 = text2.join(" ");
+  assert.match(joined2, /营收 \+159%/);
+  assert.match(joined2, /资不抵债/);
+  assert.match(joined2, /站回 340/);
+  assert.match(joined2, /忍住没加/);
 });

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -1,0 +1,102 @@
+"""decision-mind ledger record command: validation, append, settle round-trip."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from clawock.decision import ledger as decision_v2
+from clawock.decision.record import build_record, main, validate_mind_record
+
+
+def _args(**overrides):
+    base = {
+        "subject": "00100", "market": "HK", "currency": "HKD",
+        "action": "reject", "confidence": 0.65, "driven_by": "fundamental",
+        "bull": "营收 +159% YoY", "bear": "资不抵债,净利率 -2368%",
+        "bull_evidence": [], "bear_evidence": [],
+        "thesis": "先活下来", "invalidation": ["站回 340", "缩量企稳"],
+        "emotion": "averaging_down", "note": "摊本冲动被压过",
+    }
+    return type("Args", (), {**base, **overrides})()
+
+
+def test_build_record_shape_and_legacy_compat():
+    record = build_record(_args())
+    assert record["schema_version"] == 0
+    assert record["source"] == "conversation"
+    assert record["decision_id"].startswith("dec-")
+    assert record["mind"]["bear"]["summary"] == "资不抵债,净利率 -2368%"
+    assert record["emotion"]["pressure"] == "averaging_down"
+    # Legacy-compatible fields so the desk's machinery round-trips this record.
+    assert record["condition"]["description"] == "站回 340"
+    assert record["execution"]["status"] == "unknown"
+    assert "plan_date" not in record
+
+
+def test_validation_rejects_weak_records():
+    issues = validate_mind_record(build_record(_args()))
+    assert issues == []
+
+    no_bear = build_record(_args(bear=""))
+    assert any("mind.bear.summary" in issue for issue in validate_mind_record(no_bear))
+
+    no_invalidation = build_record(_args(invalidation=[]))
+    assert any("mind.invalidation" in issue for issue in validate_mind_record(no_invalidation))
+
+    bad_confidence = build_record(_args(confidence=1.3))
+    assert any("confidence" in issue for issue in validate_mind_record(bad_confidence))
+
+    bad_emotion = build_record(_args(emotion="greedy"))
+    assert any("emotion.pressure" in issue for issue in validate_mind_record(bad_emotion))
+
+
+def test_main_appends_and_survives_settle_round_trip(tmp_path):
+    ledger = tmp_path / "decisions.jsonl"
+    # A pre-existing legacy entry, shaped like the desk's plan decisions.
+    decision_v2.write_decisions([{
+        "decision_id": "dec-legacy1234", "plan_date": "2026-08-10",
+        "ticker": "00100", "leg": "HK", "action": "trim_on_rebound",
+        "condition": {"description": "跌破 730 减 20 股", "price": 730.0, "type": "price_below"},
+        "evaluation": {"status": "not_triggered", "outcome": "not_triggered"},
+        "execution": {"status": "unknown"},
+    }], ledger)
+
+    argv = [
+        "--ledger", str(ledger),
+        "--subject", "00100", "--market", "HK", "--currency", "HKD",
+        "--action", "reject", "--confidence", "0.65", "--driven-by", "fundamental",
+        "--bull", "营收 +159% YoY", "--bear", "资不抵债",
+        "--thesis", "先活下来",
+        "--invalidation", "站回 340", "--invalidation", "缩量企稳",
+        "--emotion", "averaging_down", "--note", "忍住没加",
+    ]
+    assert main(argv) == 0
+
+    rows = decision_v2.load_decisions(ledger)
+    assert len(rows) == 2
+    conversation = [d for d in rows if d.get("source") == "conversation"]
+    assert len(conversation) == 1
+    assert conversation[0]["mind"]["invalidation"] == ["站回 340", "缩量企稳"]
+
+    # The daily postflight settles the whole list in place; a conversation
+    # record has no plan_date and must survive untouched.
+    decision_v2.settle_decisions(rows)
+    after = decision_v2.load_decisions(ledger)
+    conversation = [d for d in after if d.get("source") == "conversation"]
+    assert len(conversation) == 1
+    assert conversation[0]["decision_id"] == rows[0]["decision_id"] or \
+        conversation[0]["decision_id"] == rows[1]["decision_id"]
+    assert conversation[0]["mind"]["bear"]["summary"] == "资不抵债"
+    assert all(d["decision_id"] for d in after)
+
+
+def test_main_rejects_invalid_record(tmp_path):
+    ledger = tmp_path / "decisions.jsonl"
+    argv = [
+        "--ledger", str(ledger),
+        "--subject", "00100", "--action", "reject", "--confidence", "0.65",
+        "--bull", "ok", "--bear", "", "--invalidation", "cond",
+    ]
+    assert main(argv) == 1
+    assert not ledger.exists()

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -30,7 +30,9 @@ def test_build_record_shape_and_legacy_compat():
     assert record["emotion"]["pressure"] == "averaging_down"
     # Legacy-compatible fields so the desk's machinery round-trips this record.
     assert record["condition"]["description"] == "站回 340"
-    assert record["execution"]["status"] == "unknown"
+    # A no-op verdict respected is an executed decision; order actions are not.
+    assert record["execution"]["status"] == "followed"
+    assert build_record(_args(action="add"))["execution"]["status"] == "unknown"
     assert "plan_date" not in record
 
 

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -91,6 +91,19 @@ def test_main_appends_and_survives_settle_round_trip(tmp_path):
     assert all(d["decision_id"] for d in after)
 
 
+def test_validate_decision_accepts_mind_records_and_rejects_weak_ones():
+    from clawock.decision.ledger import validate_decision
+    # A well-formed conversation record passes the desk's row validator.
+    good = build_record(_args())
+    assert validate_decision(good) == []
+    # A plan-style record still requires the plan fields (no cross-contamination).
+    weak = build_record(_args(bear=""))
+    assert any("mind.bear.summary" in issue for issue in validate_decision(weak))
+    legacy = {"decision_id": "dec-x", "plan_date": "2026-08-10", "ticker": "00100",
+              "action": "hold", "confidence": 0.5, "condition": {"type": "manual"}}
+    assert any("missing episode_id" in issue for issue in validate_decision(legacy))
+
+
 def test_main_rejects_invalid_record(tmp_path):
     ledger = tmp_path / "decisions.jsonl"
     argv = [


### PR DESCRIPTION
## 背景

kcn 定案:插件的 job = **决策心智账本**——对话里的加仓/减仓/观望判定与 OpenClaw 盘前决策进**同一个账本**,DSH 面板读真工作区数据,kcn 自己日常使用。

## 改动(10 文件)

| 文件 | 内容 |
|---|---|
| `docs/decision-mind-ledger.md` | schema v0:思想快照(bull/bear/thesis/invalidation,冻结)+ 情绪压力层 + 对账;五条不可协商规则(bear 强制/冻结/可证伪/情绪诚实/action 对齐);互通设计 |
| `src/clawock/decision/record.py` + cli 注册 | `clawock record`:校验 + 原子追加;带 legacy condition/execution 字段,每日 settle 原样放行(无 plan_date 跳过——已读源码验证) |
| `examples/dsh/plugin/skills/.../SKILL.md` | 「对话落账规范」:verdict 即记录,给 `clawock record` 完整示例 |
| `examples/dsh/plugin/lib/ledger.js` | 读 OpenClaw 产出:decisions.jsonl(坏行跳过)/ portfolio.json(按书分组)/ plan.json(倒序) |
| `examples/dsh/plugin/lib/index.js` | 网关新增 ledger/portfolio/plans 三个 Remote(共 5 个) |
| `examples/dsh/plugin/client.js` | 重写:Decision Mind 视图 —— 账本/持仓/计划三段切换;克制版 DSH 原生浅色(ui-theme 令牌实值、玻璃仅吸顶头、DeepSeek 蓝单主色、语义 tint 胶囊、旧记录降级渲染);`$mount` 显式挂载 5 描述符 |
| `tests/decision_studio_plugin.spec.js` | 7 例:ledger 读取器×3、run-id 防穿越、注册/挂载、display 投影(含 legacy 降级)、账本卡渲染+展开 |
| `tests/test_decision_record.py` | 4 例:记录形状/校验拒绝/追加+settle 往返存活/非法拒绝不写文件 |

## 验证

- node spec 7/7;`node --check` 全过;pytest 7 passed(record 4 + portable 3)
- settle 互通:对话记录无 plan_date,`settle_decisions` 直接跳过——已用测试钉住
- 待 CI 六项 required checks(新 dsplugin 门会跑 spec)

## 互通承诺

OpenClaw 每天写的 `memory/decisions.jsonl`、`portfolio.json`、`memory/*-plan.json` 面板全部可读;对话判定经 `clawock record` 写回同一账本,盘前 postflight 全量写回不吞外部记录(源码读证 + 测试)。

## 后续

- 合并后:live 环境 CLAWOCK_WORKSPACE 指向真实工作区 + 重启 + 落 MiniMax 首条对话记录(今天真实判定:reject 加仓、未执行)
- 视觉:克制版浅色(设计师 subagent 对抗审核定稿 v4),光晕/紫/彩底已全砍