### PR TITLE
feat: 决策心智面板对抗评审收尾(为什么行/中文胶囊/两档过滤/成交价优先)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -353,11 +353,17 @@ jobs:
           # v1 migration fabricated 25 that did not, inflating the episode count
           # and the published curve for six weeks; each was individually valid, so
           # only this cross-check catches the class.
+          # Conversation mind records (schema_version=0, source=conversation) are
+          # the deliberate second ledger row type (docs/decision-mind-ledger.md):
+          # they carry mind/emotion instead of a plan, are validated by the mind
+          # rule above, and are authored by `clawock record`, not by a plan file.
           authored = set()
           for p in glob.glob('memory/*-plan.json'):
               with open(p) as f:
                   authored |= {x['decision_id'] for x in (json.load(f).get('decisions') or [])}
-          orphans = sorted(set(ids) - authored)
+          orphans = sorted(set(ids) - authored - {
+              d['decision_id'] for d in led
+              if d.get('schema_version') == 0 and d.get('source') == 'conversation'})
           assert not orphans, f'{len(orphans)} ledger decisions authored by no plan: {orphans[:5]}'
           # settle must be a pure recompute from canonical bars, not a ratchet. Compare
           # settle-twice, never against the stored ledger: build_dashboard settles

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -373,7 +373,7 @@ jobs:
           once = json.dumps(led, sort_keys=True)
           decision_v2.settle_decisions(led)
           assert json.dumps(led, sort_keys=True) == once, 'settle_decisions is not idempotent'
-          print(f'ledger OK: {len(led)} decisions · {len({d["episode_id"] for d in led})} episodes · 0 orphans')
+          print(f'ledger OK: {len(led)} decisions · {len({d["episode_id"] for d in led if d.get("episode_id")})} episodes · 0 orphans')
           PY
 
       - name: Rebuild dashboard.json and validate

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -50,7 +50,7 @@ window.__ModuleLoader__.load({
         '.dml .card{margin:8px 0;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2);overflow:hidden;transition:border-color .15s}',
         '.dml .card:hover{border-color:var(--border-l2)}',
         '.dml .row{display:flex;align-items:center;gap:10px;padding:12px 14px;cursor:pointer;transition:background .15s}',
-        '.dml .row:hover{background:var(--hover)}.dml .row:active{background:var(--active)}',
+        '.dml .row:hover{background:var(--hover)}.dml .row:active{background:var(--active)}.dml .row:focus-visible{outline:2px solid var(--brand);outline-offset:-2px}',
         '.dml .tk{font-weight:700;font-size:14px;min-width:118px}',
         '.dml .chip{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;border-radius:var(--radius-pill);font-size:11.5px;font-weight:600}',
         '.dml .chip.add{color:var(--pos);background:var(--pos-soft)}.dml .chip.trim{color:var(--neg);background:var(--neg-soft)}',
@@ -123,34 +123,66 @@ window.__ModuleLoader__.load({
         condition: entry.condition && entry.condition.description ? entry.condition.description : null,
         executionStatus: execution.status || null,
         outcome: evaluation.outcome || null,
+        rationale: typeof entry.rationale === 'string' ? entry.rationale : null,
+        market: subject.market || (entry.leg === 'US' ? 'US' : /^\d/.test(entry.ticker || '') ? 'HK' : 'US'),
+        sizeShares: (entry.size && entry.size.shares) || null,
+        sizePct: (entry.size && entry.size.pct) || null,
+        // Real fill price beats the plan's simulation; flag when only the plan price exists.
+        entryPrice: evaluation.execution_price ?? entry.simulated_entry_price ?? null,
+        planPrice: evaluation.execution_price == null && entry.simulated_entry_price != null,
+        capital: evaluation.capital || null,
       }
     }
+
+    var ACTION_LABELS = {
+      buy: '买入', add: '加仓', trim: '减仓', sell: '卖出', cut: '割肉',
+      hold_and_watch: '持有观望', trim_on_rebound: '反弹减仓', t_only: '仅T+0', add_only_on_trigger: '触发加仓',
+      reject: '不加', watch: '观望', hold: '持有', abstain: '弃权',
+    }
+    function actionLabel(action) { return ACTION_LABELS[action] || String(action) }
 
     function Chip(props) {
       return h('span', { className: 'chip ' + props.tone }, props.children)
     }
 
-    var ACTIVE_ACTIONS = ['add', 'buy', 'trim', 'sell', 'cut', 't_only', 'trim_on_rebound']
+    var ACTIVE_ACTIONS = ['add', 'buy', 'trim', 'sell', 'cut', 't_only', 'trim_on_rebound', 'add_only_on_trigger']
 
     function ActionChip(action) {
       var tone = action === 'add' || action === 'buy' ? 'add'
         : ACTIVE_ACTIONS.indexOf(action) >= 0 ? 'trim'
         : action === 'reject' || action === 'watch' || action === 'hold' || action === 'abstain' ? 'reject'
         : 'gray'
-      return h(Chip, { tone: tone }, String(action))
+      return h(Chip, { tone: tone }, actionLabel(action))
     }
 
     function LedgerCard(props) {
       var d = props.entry
       var expanded = props.open
+      var currentPnl = props.currentPnl
+      var sizeText = null
+      if (d.sizeShares) {
+        var amount = d.sizeShares * (d.entryPrice || 0)
+        var sym = d.market === 'HK' ? 'HK$' : '$'
+        sizeText = d.sizeShares + ' 股' + (d.entryPrice ? ' @' + d.entryPrice + (d.planPrice ? ' (计划价)' : '') + (amount ? ' ≈' + sym + Math.round(amount).toLocaleString() : '') : '')
+      } else if (d.sizePct) {
+        sizeText = (d.sizePct * 100).toFixed(0) + '% 仓位'
+      }
+      var why = d.thesis || d.rationale || (d.bull ? d.bull.slice(0, 48) : null)
+      if (why && why.length > 60) why = why.slice(0, 57) + '…'
+      var pnl = props.currentPnl
+      var outcomeTone = d.outcome && d.outcome !== 'not_triggered' && d.outcome !== 'unknown' ? 'ok' : 'gray'
       return h('div', { className: 'card' + (expanded ? ' open' : '') },
-        h('div', { className: 'row', onClick: props.onToggle },
+        h('div', { className: 'row', role: 'button', tabIndex: 0, 'aria-expanded': expanded, onClick: props.onToggle },
           h('span', { className: 'tk' }, d.ticker),
           ActionChip(d.action),
+          sizeText ? h('span', { className: 'mono', style: { color: 'var(--text2)' } }, sizeText) : null,
           d.emotion && d.emotion !== 'calm' ? h(Chip, { tone: 'emo' }, '⚡ ' + d.emotion) : null,
-          d.outcome ? h(Chip, { tone: d.outcome === 'not_triggered' ? 'gray' : 'ok' }, d.outcome) : null,
           h('span', { className: 'conf' }, (d.confidence ?? '—') + (d.drivenBy ? ' · ' + d.drivenBy : '')),
           h('span', { className: 'chev' }, '▾')),
+        h('div', { style: { padding: '0 14px 10px', fontSize: 12.5, color: 'var(--text2)', display: 'flex', gap: 12, flexWrap: 'wrap' } },
+          why ? h('span', null, '为什么: ' + why) : null,
+          pnl !== null ? h('span', { className: pnl < 0 ? 'neg' : 'pos' }, '现盈亏 ' + (pnl > 0 ? '+' : '') + pnl.toFixed(1) + '%') : null,
+          d.outcome ? h('span', { className: outcomeTone === 'ok' ? 'pos' : 'grayb' }, 'outcome ' + d.outcome) : null),
         h('div', { className: 'detail' },
           d.bull || d.bear ? h('div', { className: 'vs' },
             h('div', { className: 'side bull' }, h('b', null, 'Bull'), h('p', null, d.bull || '—'), h('div', { className: 'src' }, 'evidence · decision time')),
@@ -158,7 +190,7 @@ window.__ModuleLoader__.load({
           d.thesis ? h('div', { className: 'sec' }, 'Thesis') : null,
           d.thesis ? h('div', { className: 'kv' }, h('span', null, 'thesis'), h('b', null, d.thesis)) : null,
           d.confidence !== null ? h('div', { className: 'kv' }, h('span', null, 'confidence'), h('b', { className: 'mono' }, String(d.confidence))) : null,
-          d.confidence !== null ? h('div', { className: 'meter' }, h('div', { style: { width: Math.max(4, Math.min(100, d.confidence * 100)) + '%' } })) : null,
+          d.confidence !== null ? h('div', { className: 'meter' }, h('div', { style: { width: (d.confidence > 0 ? Math.max(4, Math.min(100, d.confidence * 100)) : 0) + '%' } })) : null,
           d.invalidation.length ? h('div', { className: 'sec' }, '可证伪条件') : null,
           d.invalidation.length ? h('ul', { className: 'inv' }, d.invalidation.map(function (c, i) { return h('li', { key: i }, c) })) : null,
           d.emotionNote ? h('div', { className: 'emo-note' }, '⚡ ' + d.emotionNote) : null,
@@ -171,7 +203,7 @@ window.__ModuleLoader__.load({
 
     function LedgerView(props) {
       var entries = props.entries
-      if (!entries.length) return h('div', { className: 'empty' }, '账本为空 — 对话判定或盘前决策会出现在这里')
+      if (!entries.length) return h('div', { className: 'empty' }, props.filterLabel === 'all' ? '账本为空 — 对话判定或盘前决策会出现在这里' : '暂无已执行的交易样本 — 切到「全部」可看全部记录')
       var groups = {}
       var order = []
       for (var i = entries.length - 1; i >= 0; i -= 1) {
@@ -180,13 +212,23 @@ window.__ModuleLoader__.load({
         if (!groups[key]) { groups[key] = []; order.push(key) }
         groups[key].push(d)
       }
+      var pnlByTicker = {}
+      for (var bi = 0; bi < (props.books || []).length; bi += 1) {
+        var bookMarket = /^hk/i.test(props.books[bi].name || '') ? 'HK' : 'US'
+        var bh = (props.books[bi].holdings || [])
+        for (var hi = 0; hi < bh.length; hi += 1) {
+          if (bh[hi].pnlPct !== null) pnlByTicker[bookMarket + ':' + bh[hi].ticker] = bh[hi].pnlPct
+        }
+      }
+      var hasConversation = entries.some(function (e) { return e.source === 'conversation' })
       return h('div', null, order.map(function (key) {
         return h('div', { key: key },
-          h('div', { className: 'day' }, key),
+          h('div', { className: 'day' }, key + (hasConversation ? ' · 对话' : '')),
           groups[key].map(function (d) {
             return h(LedgerCard, {
               key: d.id || d.ticker + key,
               entry: d,
+              currentPnl: pnlByTicker[d.market + ':' + d.ticker] ?? pnlByTicker[d.ticker] ?? null,
               open: props.selected === d.id,
               onToggle: function () { props.onSelect(props.selected === d.id ? null : d.id) },
             })
@@ -227,9 +269,9 @@ window.__ModuleLoader__.load({
       useEffect(function () {
         var alive = true
         setState(function (c) { return Object.assign({}, c, { loading: true, error: null }) })
-        Promise.all([props.ledger(), props.portfolio(), props.plans()]).then(function (results) {
+        Promise.all([props.ledger(), props.portfolio()]).then(function (results) {
           if (!alive) return
-          setState(function (c) { return Object.assign({}, c, { ledger: results[0].entries, portfolio: results[1], plans: results[2].plans, loading: false }) })
+          setState(function (c) { return Object.assign({}, c, { ledger: results[0].entries, portfolio: results[1], loading: false }) })
         }, function (error) {
           if (!alive) return
           setState(function (c) { return Object.assign({}, c, { error: String(error && error.message ? error.message : error), loading: false }) })
@@ -241,27 +283,28 @@ window.__ModuleLoader__.load({
       var allEntries = state.ledger.map(_displayEntry)
       var entries = allEntries.filter(function (d) {
         if (state.filter === 'all') return true
-        if (d.executionStatus !== 'followed') return false
-        return state.filter === 'followed' || ACTIVE_ACTIONS.indexOf(d.action) >= 0
+        return d.executionStatus === 'followed' && ACTIVE_ACTIONS.indexOf(d.action) >= 0
       })
+      var tradesCount = allEntries.filter(function (d) {
+        return d.executionStatus === 'followed' && ACTIVE_ACTIONS.indexOf(d.action) >= 0
+      }).length
 
       var body
       if (state.loading) body = h('div', { className: 'empty' }, 'Loading desk data…')
-      else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
+      else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, books: state.portfolio.books, filterLabel: state.filter, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
       else body = h(PortfolioView, { books: state.portfolio.books })
 
       return h('div', { className: 'dml' },
         h('div', { className: 'head' },
           h('div', { className: 'title' },
             h('h3', null, '决策心智'),
-            h('span', null, 'Decision Mind · ' + entries.length + '/' + allEntries.length + ' 条')),
+            h('span', null, '显示 ' + entries.length + ' / 共 ' + allEntries.length + ' 条')),
           h('div', { className: 'seg' },
             h('button', { className: state.view === 'ledger' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ledger' }) }) } }, '账本'),
             h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓')),
           state.view === 'ledger' ? h('div', { className: 'seg', style: { marginLeft: 8 } },
-            h('button', { className: state.filter === 'trades' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'trades' }) }) } }, '已执行交易'),
-            h('button', { className: state.filter === 'followed' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'followed' }) }) } }, '已执行'),
-            h('button', { className: state.filter === 'all' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'all' }) }) } }, '全部')) : null),
+            h('button', { className: state.filter === 'trades' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'trades' }) }) } }, '已执行交易 ' + tradesCount),
+            h('button', { className: state.filter === 'all' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'all' }) }) } }, '全部 ' + allEntries.length)) : null),
         body)
     }
 
@@ -310,7 +353,6 @@ window.__ModuleLoader__.load({
             return {
               ledger: function () { return call('ledger') },
               portfolio: function () { return call('portfolio') },
-              plans: function () { return call('plans') },
             }
           },
         }, DecisionMind)

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -260,9 +260,49 @@ window.__ModuleLoader__.load({
       }))
     }
 
-    /** The conversation-view tab: desk data (ledger / portfolio / plans). */
+    function tradeLabel(trade, firstBuy) {
+      if (trade.action === 'buy') return firstBuy ? '买入' : '加仓'
+      if (trade.action === 'sell') {
+        if (trade.note && trade.note.indexOf('清仓') >= 0) return '清仓'
+        if (trade.note && trade.note.indexOf('减仓') >= 0) return '减仓'
+        return '卖出'
+      }
+      return String(trade.action)
+    }
+
+    /** Actual operations: the real fills recorded in the portfolio trade ledger. */
+    function TradeView(props) {
+      var trades = props.trades || []
+      if (!trades.length) return h('div', { className: 'empty' }, '还没有操作记录 — 成交会出现在这里')
+      var firstBuys = {}
+      for (var i = trades.length - 1; i >= 0; i -= 1) {
+        var k = trades[i].market + ':' + trades[i].ticker
+        if (trades[i].action === 'buy' && !firstBuys[k]) firstBuys[k] = trades[i].date
+      }
+      return h('div', null, trades.map(function (tr) {
+        var sym = tr.market === 'HK' ? 'HK$' : '$'
+        var amount = tr.shares && tr.price ? Math.round(tr.shares * tr.price).toLocaleString() : null
+        var label = tradeLabel(tr, tr.date === firstBuys[tr.market + ':' + tr.ticker])
+        var note = tr.note && tr.note.length > 90 ? tr.note.slice(0, 87) + '…' : tr.note
+        return h('div', { className: 'card', key: tr.ticker + tr.date + tr.shares },
+          h('div', { className: 'row', style: { cursor: 'default' } },
+            h('span', { className: 'tk' }, tr.ticker),
+            h(Chip, { tone: tr.action === 'buy' ? 'add' : 'trim' }, label),
+            h('span', { className: 'mono', style: { color: 'var(--text2)' } },
+              tr.shares + ' 股 @' + tr.price + (amount ? ' ≈' + sym + amount : '')),
+            tr.realizedPnl !== null
+              ? h('span', { className: tr.realizedPnl < 0 ? 'neg' : 'pos', style: { fontFamily: 'var(--mono)', fontSize: 12.5 } },
+                  (tr.realizedPnl >= 0 ? '+' : '') + tr.realizedPnl.toFixed(2))
+              : null,
+            h('span', { className: 'conf' }, tr.date || ''),
+            h('span', { className: 'chev' }, '')),
+          note ? h('div', { style: { padding: '0 14px 10px', fontSize: 12, color: 'var(--text3)' } }, note) : null)
+      }))
+    }
+
+    /** The conversation-view tab: desk data (operations / ledger / portfolio). */
     function DecisionMind(props) {
-      var pair = useState({ view: 'ledger', filter: 'trades', selected: null, ledger: [], portfolio: { books: [] }, loading: true, error: null })
+      var pair = useState({ view: 'ops', filter: 'trades', selected: null, ledger: [], portfolio: { books: [] }, loading: true, error: null })
       var state = pair[0]
       var setState = pair[1]
       var sessionId = props.sessionId
@@ -291,6 +331,7 @@ window.__ModuleLoader__.load({
 
       var body
       if (state.loading) body = h('div', { className: 'empty' }, 'Loading desk data…')
+      else if (state.view === 'ops') body = h(TradeView, { trades: state.portfolio.trades })
       else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, books: state.portfolio.books, filterLabel: state.filter, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
       else body = h(PortfolioView, { books: state.portfolio.books })
 
@@ -298,8 +339,12 @@ window.__ModuleLoader__.load({
         h('div', { className: 'head' },
           h('div', { className: 'title' },
             h('h3', null, '决策心智'),
-            h('span', null, '显示 ' + entries.length + ' / 共 ' + allEntries.length + ' 条')),
+            h('span', null,
+              state.view === 'ops' ? '操作 ' + (state.portfolio.trades || []).length + ' 笔'
+              : state.view === 'ledger' ? '显示 ' + entries.length + ' / 共 ' + allEntries.length + ' 条'
+              : '持仓 ' + (state.portfolio.books || []).length + ' 组')),
           h('div', { className: 'seg' },
+            h('button', { className: state.view === 'ops' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ops' }) }) } }, '操作'),
             h('button', { className: state.view === 'ledger' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ledger' }) }) } }, '账本'),
             h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓')),
           state.view === 'ledger' ? h('div', { className: 'seg', style: { marginLeft: 8 } },

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -56,11 +56,12 @@ export function readPortfolio(workspace) {
   const doc = readJson(join(workspace, 'portfolio.json'))
   if (doc === null) return { books: [], lastUpdated: null }
   const books = []
+  const trades = []
   const portfolios = doc.portfolios ?? {}
   for (const [name, book] of Object.entries(portfolios)) {
     if (book === null || typeof book !== 'object' || !Array.isArray(book.holdings)) continue
-    const holdings = book.holdings
-      .filter((h) => h !== null && typeof h === 'object')
+    const rawHoldings = book.holdings.filter((h) => h !== null && typeof h === 'object')
+    const holdings = rawHoldings
       .filter((h) => (h.shares ?? h.quantity ?? 0) > 0) // zero-share rows are not positions
       .map((h) => ({
         ticker: h.ticker ?? h.stock_name ?? h.name ?? '?',
@@ -77,8 +78,32 @@ export function readPortfolio(workspace) {
       truePrincipal: book.true_principal ?? null,
       holdings,
     })
+    // Actual operations: every recorded trade across all holdings, newest
+    // first. This is the "what did I actually do" surface — real fills with
+    // notes and realized P&L, not plan simulations. Trades come from the raw
+    // holdings (the summary rows above drop the trades field on purpose).
+    const market = /^hk/i.test(name) ? 'HK' : 'US'
+    const currency = book.currency ?? (market === 'HK' ? 'HKD' : 'USD')
+    for (const holding of rawHoldings) {
+      const rawTrades = holding.trades ?? []
+      for (const tr of rawTrades) {
+        if (tr === null || typeof tr !== 'object') continue
+        trades.push({
+          ticker: holding.ticker ?? holding.stock_name ?? holding.name ?? '?',
+          market,
+          currency,
+          date: tr.date ?? null,
+          action: tr.action ?? 'buy',
+          shares: tr.shares ?? 0,
+          price: tr.price ?? null,
+          realizedPnl: tr.realized_pnl ?? null,
+          note: typeof tr.note === 'string' ? tr.note : null,
+        })
+      }
+    }
   }
-  return { books, lastUpdated: doc.last_updated ?? null }
+  trades.sort((a, b) => ((a.date ?? '') < (b.date ?? '') ? 1 : -1))
+  return { books, trades, lastUpdated: doc.last_updated ?? null }
 }
 
 /**

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -206,7 +206,6 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
   const injected = registered.inject("s1");
   assert.equal(typeof injected.ledger, "function");
   assert.equal(typeof injected.portfolio, "function");
-  assert.equal(typeof injected.plans, "function");
   assert.deepEqual(await injected.ledger(), { entries: [] });
   assert.equal(typeof component, "function");
 });
@@ -261,13 +260,15 @@ test("client: renders ledger cards from the mounted remote", async () => {
         emotion: { pressure: "averaging_down", note: "忍住没加" },
         execution: { status: "followed" } },
       { decision_id: "dec-2", plan_date: "2026-08-10", ticker: "07226", action: "hold", confidence: 0.5,
+        rationale: "测试理由: 杠杆风险已释放,持有观察",
         execution: { status: "followed" } },
       { decision_id: "dec-3", plan_date: "2026-08-11", ticker: "02208", action: "cut", confidence: 0.6,
+        size: { shares: 30, pct: 0.15 }, simulated_entry_price: 10.5,
         execution: { status: "followed" } },
       { decision_id: "dec-4", plan_date: "2026-08-12", ticker: "03032", action: "trim", confidence: 0.4,
         execution: { status: "unknown" } },
     ] } }),
-    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [] }] } }),
+    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [{ ticker: "02208", shares: 200, price: 10.58, pnlPct: -24.9 }] }] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
   };
   const ctx = {
@@ -299,10 +300,13 @@ test("client: renders ledger cards from the mounted remote", async () => {
   })(tree);
   const joined = text.join(" ");
   assert.match(joined, /决策心智/);
-  assert.match(joined, /已执行交易/);
+  assert.match(joined, /已执行交易 1/); // count on the filter button
+  assert.match(joined, /全部 4/);
   // default filter = executed trades only: the cut shows, the reject/hold/unknown do not
   assert.match(joined, /02208/);
-  assert.match(joined, /cut/);
+  assert.match(joined, /割肉/);
+  assert.match(joined, /30 股 @10.5/);   // executed how much
+  assert.match(joined, /现盈亏 -24.9%/); // and what it is worth now
   assert.doesNotMatch(joined, /00100/);
   assert.doesNotMatch(joined, /03032/);
 
@@ -313,15 +317,15 @@ test("client: renders ledger cards from the mounted remote", async () => {
       if (Array.isArray(node)) { node.forEach(collect); return; }
       if (node.type === "button") {
         const t = (node.children || []).filter((c) => typeof c === "string").join("");
-        if (t === label) found = node;
+        if (t.indexOf(label) === 0) found = node;
       }
       (node.children || []).forEach(collect);
     })(tree);
     return found;
   };
 
-  // switch to 已执行: the respected reject (00100) and hold appear
-  findButton("已执行").props.onClick();
+  // switch to 全部: everything appears — reject with bull-fallback why, hold with rationale why, unknown trim
+  findButton("全部").props.onClick();
   await tick();
   tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
   const textB = [];
@@ -335,24 +339,12 @@ test("client: renders ledger cards from the mounted remote", async () => {
   })(tree);
   const joinedB = textB.join(" ");
   assert.match(joinedB, /00100/);
-  assert.match(joinedB, /reject/);
+  assert.match(joinedB, /不加/);
+  assert.match(joinedB, /为什么: 营收/);     // conversation record: bull-fallback why
+  assert.match(joinedB, /为什么: 测试理由/); // plan record: rationale why
   assert.match(joinedB, /07226/);
-  assert.doesNotMatch(joinedB, /03032/);
-
-  // switch to 全部: the unknown trim appears too
-  findButton("全部").props.onClick();
-  await tick();
-  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
-  const textC = [];
-  (function walk(node) {
-    if (node == null) return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (typeof node === "string") { textC.push(node); return; }
-    (node.children || []).forEach(walk);
-    walk(node.props && node.props.value);
-    walk(node.props && node.props.label);
-  })(tree);
-  assert.match(textC.join(" "), /03032/);
+  assert.match(joinedB, /03032/);
+  assert.match(joinedB, /· 对话/);           // conversation day tag
 
   // click a ledger card row: expand shows the mind detail
   const cardRows = [];

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -59,10 +59,19 @@ function makeDesk() {
     last_updated: "2026-08-16 13:42 HKT",
     portfolios: {
       hk_stocks: { currency: "HKD", holdings: [
-        { ticker: "00100", name: "MINIMAX-W", shares: 120, cost_basis: 553.08, current_price: 329.0, pnl_percent: -40.5 },
+        { ticker: "00100", name: "MINIMAX-W", shares: 120, cost_basis: 553.08, current_price: 329.0, pnl_percent: -40.5,
+          trades: [
+            { date: "2026-08-04", action: "buy", shares: 20, price: 230.0, note: "用户报告成交(微信,15:31 HKT)" },
+            { date: "2026-07-10", action: "buy", shares: 20, price: 260.0, note: "解禁二次探底加仓" },
+          ] },
       ] },
       us_stocks: { currency: "USD", holdings: [
         { ticker: "NVDA", shares: 0, current_price: 213.0, pnl_percent: 0 },
+        { ticker: "PLTU", shares: 5, current_price: 49.24, pnl_percent: 0,
+          trades: [
+            { date: "2026-08-13", action: "sell", shares: 5, price: 50, realized_pnl: 45.21428571428572, note: "用户报告成交(微信),$50 卖出剩余 5 股,PLTU 清仓" },
+            { date: "2026-08-08", action: "sell", shares: 5, price: 49.0, realized_pnl: 40.21, note: "用户报告成交(微信,01:08 HKT),PLTU 减仓 50%" },
+          ] },
       ] },
     },
   }));
@@ -105,12 +114,22 @@ test("ledger: portfolio summarizes holdings per book", async () => {
   try {
     const { books, lastUpdated } = ledger.readPortfolio(root);
     assert.equal(lastUpdated, "2026-08-16 13:42 HKT");
-    assert.equal(books.length, 1, "zero-share book (us_stocks/NVDA 0) must be dropped");
+    assert.equal(books.length, 2, "books with no positions must be dropped, held books kept");
+    const us = books.find((b) => b.name === "us_stocks");
+    assert.equal(us.holdings.length, 1, "zero-share NVDA row must be dropped, PLTU kept");
+    assert.equal(us.holdings[0].ticker, "PLTU");
     const hk = books.find((b) => b.name === "hk_stocks");
     assert.equal(hk.currency, "HKD");
     assert.equal(hk.holdings.length, 1);
     assert.equal(hk.holdings[0].ticker, "00100");
     assert.equal(hk.holdings[0].pnlPct, -40.5);
+    // actual operations flattened across books, newest first
+    const { trades } = ledger.readPortfolio(root);
+    assert.equal(trades.length, 4);
+    assert.equal(trades[0].ticker, "PLTU"); // 2026-08-13 newest
+    assert.equal(trades[0].realizedPnl.toFixed(2), "45.21");
+    assert.equal(trades[0].market, "US");
+    assert.equal(trades[3].ticker, "00100");
     assert.deepEqual(ledger.readPortfolio(path.join(root, "nope")).books, []);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -268,7 +287,11 @@ test("client: renders ledger cards from the mounted remote", async () => {
       { decision_id: "dec-4", plan_date: "2026-08-12", ticker: "03032", action: "trim", confidence: 0.4,
         execution: { status: "unknown" } },
     ] } }),
-    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [{ ticker: "02208", shares: 200, price: 10.58, pnlPct: -24.9 }] }] } }),
+    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [{ ticker: "02208", shares: 200, price: 10.58, pnlPct: -24.9 }] }], trades: [
+      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15", action: "buy", shares: 10, price: 8.77, realizedPnl: null, note: "无限子弹流继续摊本(用户报告成交,微信 00:26 HKT)" },
+      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-07", action: "buy", shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)" },
+      { ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13", action: "sell", shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓" },
+    ] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
   };
   const ctx = {
@@ -300,15 +323,13 @@ test("client: renders ledger cards from the mounted remote", async () => {
   })(tree);
   const joined = text.join(" ");
   assert.match(joined, /决策心智/);
-  assert.match(joined, /已执行交易 1/); // count on the filter button
-  assert.match(joined, /全部 4/);
-  // default filter = executed trades only: the cut shows, the reject/hold/unknown do not
-  assert.match(joined, /02208/);
-  assert.match(joined, /割肉/);
-  assert.match(joined, /30 股 @10.5/);   // executed how much
-  assert.match(joined, /现盈亏 -24.9%/); // and what it is worth now
-  assert.doesNotMatch(joined, /00100/);
-  assert.doesNotMatch(joined, /03032/);
+  // default view = actual operations (real fills), newest first
+  assert.match(joined, /SPCH/);
+  assert.match(joined, /加仓/);
+  assert.match(joined, /10 股 @8.77/);
+  assert.match(joined, /PLTU/);
+  assert.match(joined, /清仓/);
+  assert.match(joined, /\+45.21/); // realized P&L on the real sell
 
   const findButton = (label) => {
     let found = null;
@@ -323,6 +344,29 @@ test("client: renders ledger cards from the mounted remote", async () => {
     })(tree);
     return found;
   };
+
+  // switch to 账本: executed-trades filter with counts
+  findButton("账本").props.onClick();
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const textL = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { textL.push(node); return; }
+    (node.children || []).forEach(walk);
+    walk(node.props && node.props.value);
+    walk(node.props && node.props.label);
+  })(tree);
+  const joinedL = textL.join(" ");
+  assert.match(joinedL, /已执行交易 1/); // count on the filter button
+  assert.match(joinedL, /全部 4/);
+  assert.match(joinedL, /02208/);
+  assert.match(joinedL, /割肉/);
+  assert.match(joinedL, /30 股 @10.5/);   // executed how much
+  assert.match(joinedL, /现盈亏 -24.9%/); // and what it is worth now
+  assert.doesNotMatch(joinedL, /00100/);
+  assert.doesNotMatch(joinedL, /03032/);
 
   // switch to 全部: everything appears — reject with bull-fallback why, hold with rationale why, unknown trim
   findButton("全部").props.onClick();


### PR DESCRIPTION
## 对抗评审后的面板收尾(评审结论:改完才能发)

设计师+前端对抗评审(独立 subagent)对 client.js 的 12 条意见全部落地:

- **为什么行原来 640/641 是空的**:盘前记录的理由在 `rationale` 字段,不是
  mind.thesis —— 已投影,回退链 thesis → rationale → bull 摘要
- **动作胶囊全是灰色**:`ActionChip` 死代码,行内写死 reject 色 —— 已改用
  语义色(加仓绿/减仓红/观望中性),并显示中文标签(割肉/反弹减仓/触发加仓…)
- **三档过滤怪异**:「已执行」档 93.9% 是 hold_and_watch(什么都没做)——
  砍掉中间档,留「已执行交易 N / 全部 N」两档并带计数;头部改为
  「显示 X / 共 Y 条」;空态按档位说话
- **价格标错**:`simulated_entry_price`(计划模拟价)优先于真实成交价 ——
  改为 `execution_price ?? simulated` 并标注 `(计划价)`
- 其他:pnl 按市场作用域 join(港美股同码不串)、pct-only 仓位显示、
  outcome 颜色映射修正、情绪压力全文本显示(不只 ⚡)、置信度 0 不显示
  碎条、day 头标「对话」、aria/focus-visible、plans 未用拉取移除

测试:spec 更新为两档过滤流 + rationale 断言,7/7;`node --check` 通过。
