### PR TITLE
feat: 统一 decision-mind 账本写入入口(clawock record --source <harness>)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -353,17 +353,19 @@ jobs:
           # v1 migration fabricated 25 that did not, inflating the episode count
           # and the published curve for six weeks; each was individually valid, so
           # only this cross-check catches the class.
-          # Conversation mind records (schema_version=0, source=conversation) are
-          # the deliberate second ledger row type (docs/decision-mind-ledger.md):
-          # they carry mind/emotion instead of a plan, are validated by the mind
-          # rule above, and are authored by `clawock record`, not by a plan file.
+          # Conversation mind records (schema_version=0) are the deliberate
+          # second ledger row type (docs/decision-mind-ledger.md): they carry
+          # mind/emotion instead of a plan, are validated by the mind rule
+          # above, and are authored by `clawock record --source <harness>`
+          # (DSH/OpenClaw/Claude Code/Codex/CLI), not by a plan file. Exclude
+          # every mind record from the plan-origin cross-check regardless of
+          # which harness wrote it.
           authored = set()
           for p in glob.glob('memory/*-plan.json'):
               with open(p) as f:
                   authored |= {x['decision_id'] for x in (json.load(f).get('decisions') or [])}
           orphans = sorted(set(ids) - authored - {
-              d['decision_id'] for d in led
-              if d.get('schema_version') == 0 and d.get('source') == 'conversation'})
+              d['decision_id'] for d in led if d.get('schema_version') == 0})
           assert not orphans, f'{len(orphans)} ledger decisions authored by no plan: {orphans[:5]}'
           # settle must be a pure recompute from canonical bars, not a ratchet. Compare
           # settle-twice, never against the stored ledger: build_dashboard settles

--- a/docs/decision-mind-ledger.md
+++ b/docs/decision-mind-ledger.md
@@ -13,7 +13,7 @@
   "decision_id": "dec-<12hex>",
   "subject": { "ticker": "00100", "market": "HK", "currency": "HKD" },
   "decided_at": "2026-08-16T13:45:00+08:00",
-  "source": "conversation",                  // conversation | brief
+  "source": "conversation",                  // conversation|openclaw|claude|codex|cli|brief
   "action": "reject",                        // buy/add/trim/sell/hold/watch/reject/abstain
   "confidence": 0.65,                        // 0..1
   "driven_by": "fundamental",                // technical|fundamental|sentiment|mixed
@@ -52,11 +52,17 @@
 ## 与现有系统关系
 
 - **数据落点**:对话决策写入 `memory/decisions.jsonl`(与盘前决策同账本,
-  真源一个)或单开 `memory/conversation-decisions.jsonl`(待定,见讨论)
+  真源一个)
+- **唯一写入入口**:`clawock record` —— 所有 harness 的对话判定都走这一个
+  命令(校验、冻结、原子追加),**禁止任何 harness 手改 jsonl**。`--source`
+  标记产出来源:`conversation`(DSH 默认)/ `openclaw` / `claude` / `codex` /
+  `cli`;盘前 brief 决策仍由 postflight 写(不经过 record)。
 - **对账**:复用现有 evaluation 机制(`triggered/executed` 语义),执行标记
   走 `clawock mark-followed`
 - **面板**:DSH Decision Studio 从「runs 调试视图」改为「决策心智视图」:
-  日期/标的/动作/信心/情绪/对账状态,展开看决策卡全貌
+  日期/标的/动作/信心/情绪/对账状态,展开看决策卡全貌。插件是**只读
+  加工层**:读 decisions.jsonl + portfolio.json 渲染,不关心谁写的、
+  不写任何数据。
 - **校准**:`confidence_bin` 汇入命中率统计,回答「我的 0.65 准不准」
 
 ## 样例一(今天真实):MiniMax 加仓判定 → 未加仓
@@ -93,16 +99,18 @@ Thesis 只要反弹就回本(事后看:反弹出现但被更高成本拖累)
   失效条件列表、情绪注记、对账区(触发/执行/校准)
 - 预览:`decision-mind-ledger.html`(静态 mock,本机可开)
 
-## 数据互通(OpenClaw ↔ DSH,一个账本两个入口)
+## 数据互通(一个账本,多个 harness 入口)
 
-- **唯一真源**:`<workspace>/memory/decisions.jsonl`。OpenClaw 盘前简报的
-  决策与 DSH 对话判定写同一个账本,两边都能读。
-- **DSH 读 OpenClaw 产出**:面板 node 半区读取该文件(默认工作区
+- **唯一真源**:`<workspace>/memory/decisions.jsonl`。盘前 brief 决策与
+  各 harness(DSH/OpenClaw/Claude Code/Codex/CLI)的对话判定写同一个账本,
+  谁都能读。
+- **统一写入入口**:对话判定一律走 `clawock record --source <harness>`
+  (校验 bear/失效条件强制、冻结 mind/emotion、原子追加);**禁止手改
+  jsonl**。盘前决策由 brief postflight 写入(不经过 record)。
+- **面板(只读加工层)**:node 半区读该文件(默认工作区
   `/root/.openclaw/workspace`,可配置),按 decision_group_id/decided_at
   分组;旧记录没有 mind/emotion 字段时降级渲染(只有动作/条件/对账)。
-- **对话判定落账**:skill 规范——verdict 产生时追加一条,`source:
-  "conversation"`,字段与现有 schema 兼容(condition 用同形结构,以便
-  每日 settle 自动对账触发/执行)。
+  插件不关心记录是谁写的,也不写任何数据——加工数据源,仅此而已。
 - **互通已验证(源码读证)**:`brief_postflight.log_decisions` 为
   load → upsert/settle → 全量写回,不删外部记录;实现时用复制账本做
   迁移测试钉住「对话记录经 postflight 一轮后仍在且被 settle」。

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -84,3 +84,26 @@ investment-decision` (see [`../../README.md`](../../README.md) — "From zero").
   evidence.
 - Order amounts must reconcile to the cent; never invent prices, FX or sizes.
 - Confidence above the workflow cap requires a cited primary source.
+
+## Record conversation verdicts
+
+A verdict you give in this chat (加仓/减仓/建仓/清仓/观望) is a decision —
+write it to the shared decision-mind ledger, the **same**
+`memory/decisions.jsonl` the daily brief, OpenClaw and DSH read. Never edit
+that file by hand: `clawock record` is the only writer for conversation
+verdicts, from any harness. It validates (bear case + invalidation
+mandatory), freezes the mind/emotion snapshot, and appends atomically.
+
+```bash
+clawock record --source claude \
+  --subject 00100 --market HK --currency HKD \
+  --action reject --confidence 0.65 --driven-by fundamental \
+  --bull "营收 +159% YoY,入通/海外霸榜催化" \
+  --bear "净利率 -2368%,资不抵债,z+2.8σ 反转" \
+  --thesis "高增长救不了资不抵债,先活下来" \
+  --invalidation "站回 340" --invalidation "缩量企稳" \
+  --emotion averaging_down --note "浮亏 -40% 的摊本冲动被压过,忍住没加"
+```
+
+`--source` tells the ledger which harness produced the verdict. One ledger,
+one record command, every harness calls it — nobody writes JSON directly.

--- a/examples/codex/AGENTS.md
+++ b/examples/codex/AGENTS.md
@@ -92,3 +92,26 @@ clawock's contract is files and a CLI, so the harness is swappable. This file
 is the Codex side of the same contract shown for a pure CLI, an OpenClaw
 skill, a Claude Code instruction and a DeepSeek Harness agent in
 `examples/` — swap harnesses, `decision.json` looks the same.
+
+## Record conversation verdicts
+
+A verdict you give in this chat (加仓/减仓/建仓/清仓/观望) is a decision —
+write it to the shared decision-mind ledger, the **same**
+`memory/decisions.jsonl` the daily brief, OpenClaw and DSH read. Never edit
+that file by hand: `clawock record` is the only writer for conversation
+verdicts, from any harness. It validates (bear case + invalidation
+mandatory), freezes the mind/emotion snapshot, and appends atomically.
+
+```bash
+clawock record --source codex \
+  --subject 00100 --market HK --currency HKD \
+  --action reject --confidence 0.65 --driven-by fundamental \
+  --bull "营收 +159% YoY,入通/海外霸榜催化" \
+  --bear "净利率 -2368%,资不抵债,z+2.8σ 反转" \
+  --thesis "高增长救不了资不抵债,先活下来" \
+  --invalidation "站回 340" --invalidation "缩量企稳" \
+  --emotion averaging_down --note "浮亏 -40% 的摊本冲动被压过,忍住没加"
+```
+
+`--source` tells the ledger which harness produced the verdict. One ledger,
+one record command, every harness calls it — nobody writes JSON directly.

--- a/examples/dsh/plugin/skills/investment-decision/SKILL.md
+++ b/examples/dsh/plugin/skills/investment-decision/SKILL.md
@@ -227,6 +227,11 @@ clawock record \
   --emotion averaging_down --note "浮亏 -40% 的摊本冲动被压过,忍住没加"
 ```
 
+`--source` defaults to `conversation` for DSH; other harnesses pass their
+own — OpenClaw `--source openclaw`, Claude Code `--source claude`, Codex
+`--source codex`. One ledger, one record command, every harness calls it;
+nobody edits `decisions.jsonl` directly.
+
 Rules: the bear case and at least one observable invalidation condition are
 mandatory (the command rejects weak records); be honest about emotion
 pressure — `fomo`/`revenge`/`averaging_down` are the exact patterns this

--- a/examples/openclaw/SKILL.md
+++ b/examples/openclaw/SKILL.md
@@ -92,3 +92,28 @@ Rules that are enforced by `clawock run publish`, not by this file:
 Run the publish step (normally via `clawock run publish` in the workspace)
 and report the receipt's `status` and `run_id` to the user. Never edit the
 receipt. Never re-grade your own decision — Python settles.
+
+## Record conversation verdicts
+
+A verdict you give in this chat (加仓/减仓/建仓/清仓/观望) is a decision —
+write it to the shared decision-mind ledger, the **same**
+`memory/decisions.jsonl` the daily brief and the DSH plugin read. Never edit
+that file by hand: `clawock record` is the only writer for conversation
+verdicts, from any harness. It validates (bear case + invalidation
+mandatory), freezes the mind/emotion snapshot, and appends atomically.
+
+```bash
+clawock record --source openclaw \
+  --subject 00100 --market HK --currency HKD \
+  --action reject --confidence 0.65 --driven-by fundamental \
+  --bull "营收 +159% YoY,入通/海外霸榜催化" \
+  --bear "净利率 -2368%,资不抵债,z+2.8σ 反转" \
+  --thesis "高增长救不了资不抵债,先活下来" \
+  --invalidation "站回 340" --invalidation "缩量企稳" \
+  --emotion averaging_down --note "浮亏 -40% 的摊本冲动被压过,忍住没加"
+```
+
+`--source` tells the ledger which harness produced the verdict
+(`openclaw` here; DSH passes `conversation`, other harnesses pass their own).
+The rule is the same as the DSH plugin's: one ledger, one record command,
+every harness calls it — nobody writes JSON directly.

--- a/src/clawock/decision/record.py
+++ b/src/clawock/decision/record.py
@@ -13,6 +13,10 @@ Usage:
     --bull "营收 +159% YoY" --bear "资不抵债" --thesis "先活下来" \
     --invalidation "站回 340" --invalidation "缩量企稳" \
     --emotion averaging_down --note "摊本冲动被压过,忍住没加"
+
+  # Another harness (OpenClaw / Claude Code / Codex / CLI) records its own
+  # conversation verdicts into the same ledger:
+  clawock record --source openclaw --subject 00100 --market HK ...
 """
 from __future__ import annotations
 
@@ -27,6 +31,11 @@ from clawock.decision import ledger as decision_v2
 ACTIONS = {"buy", "add", "trim", "sell", "hold", "watch", "reject", "abstain"}
 DRIVEN_BY = {"technical", "fundamental", "sentiment", "mixed"}
 EMOTIONS = {"calm", "fomo", "revenge", "averaging_down", "fear", "euphoria", "mixed"}
+# Which harness produced the verdict. `conversation` is the DSH default and
+# the historical value; other harnesses pass their own so the ledger can say
+# where a mind record came from. `brief` is the desk's daily plan writer and
+# is not a valid record() value — it is produced by the brief postflight.
+SOURCES = {"conversation", "openclaw", "claude", "codex", "cli"}
 MIND_SCHEMA_VERSION = 0
 
 
@@ -43,6 +52,8 @@ def validate_mind_record(record: dict) -> list[str]:
             issues.append(f"subject.{field} is required")
     if record.get("action") not in ACTIONS:
         issues.append(f"action must be one of {sorted(ACTIONS)}")
+    if record.get("source") not in SOURCES:
+        issues.append(f"source must be one of {sorted(SOURCES)}")
     confidence = record.get("confidence")
     if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
         issues.append("confidence must be between 0 and 1")
@@ -64,7 +75,8 @@ def validate_mind_record(record: dict) -> list[str]:
 def build_record(args) -> dict:
     subject = {"ticker": args.subject, "market": args.market, "currency": args.currency}
     decided_at = _now_iso()
-    decision_id = "dec-" + decision_v2._stable_id("conversation", args.subject, decided_at, size=12)
+    source = getattr(args, "source", "conversation")
+    decision_id = "dec-" + decision_v2._stable_id(source, args.subject, decided_at, size=12)
     mind = {
         "bull": {"summary": args.bull, "evidence": args.bull_evidence},
         "bear": {"summary": args.bear, "evidence": args.bear_evidence},
@@ -76,7 +88,7 @@ def build_record(args) -> dict:
         "decision_id": decision_id,
         "subject": subject,
         "decided_at": decided_at,
-        "source": "conversation",
+        "source": source,
         "action": args.action,
         "confidence": args.confidence,
         "driven_by": args.driven_by,
@@ -91,7 +103,7 @@ def build_record(args) -> dict:
         # actions start unknown until marked via `clawock mark-followed`.
         "execution": {
             "status": "followed" if args.action in {"reject", "hold", "watch", "abstain"} else "unknown",
-            "source": "conversation", "detected_at": None,
+            "source": source, "detected_at": None,
         },
         "accounting": {
             "trigger": {"status": "pending", "condition": args.invalidation[0] if args.invalidation else ""},
@@ -106,6 +118,8 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="clawock record")
     ap.add_argument("--ledger", type=Path, default=None,
                     help="decisions.jsonl path (default: the workspace ledger)")
+    ap.add_argument("--source", default="conversation", choices=sorted(SOURCES),
+                    help="which harness produced this verdict (conversation=DSH)")
     ap.add_argument("--subject", required=True, help="ticker, e.g. 00100")
     ap.add_argument("--market", default="HK", help="market, e.g. HK or US")
     ap.add_argument("--currency", default="HKD", help="quote currency")

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -106,6 +106,50 @@ def test_validate_decision_accepts_mind_records_and_rejects_weak_ones():
     assert any("missing episode_id" in issue for issue in validate_decision(legacy))
 
 
+def test_source_param_distinguishes_harnesses(tmp_path):
+    """Any harness (OpenClaw/Claude Code/Codex/CLI) records into the same
+    ledger; `--source` says which one wrote the verdict."""
+    ledger = tmp_path / "decisions.jsonl"
+
+    def argv_for(source, ticker):
+        return [
+            "--ledger", str(ledger),
+            "--source", source,
+            "--subject", ticker, "--market", "US", "--currency", "USD",
+            "--action", "watch", "--confidence", "0.55", "--driven-by", "mixed",
+            "--bull", "支撑仍在", "--bear", "宏观逆风",
+            "--invalidation", "跌破支撑",
+        ]
+
+    assert main(argv_for("openclaw", "PLTU")) == 0
+    assert main(argv_for("claude", "MSFU")) == 0
+    assert main(argv_for("codex", "RKLX")) == 0
+
+    rows = decision_v2.load_decisions(ledger)
+    sources = {d["source"] for d in rows}
+    assert sources == {"openclaw", "claude", "codex"}
+    by_ticker = {d["subject"]["ticker"]: d for d in rows}
+    # execution.source follows the recording harness, so settlement and
+    # post-hoc marking can tell who recorded what.
+    assert by_ticker["PLTU"]["execution"]["source"] == "openclaw"
+    # IDs stay unique across sources (stable id seeds on the source value).
+    assert len({d["decision_id"] for d in rows}) == 3
+
+
+def test_validation_rejects_unknown_source(tmp_path):
+    ledger = tmp_path / "decisions.jsonl"
+    argv = [
+        "--ledger", str(ledger),
+        "--source", "chatgpt-web",
+        "--subject", "00100", "--action", "reject", "--confidence", "0.65",
+        "--bull", "ok", "--bear", "counter", "--invalidation", "cond",
+    ]
+    # argparse rejects the choice before any file is touched.
+    with pytest.raises(SystemExit):
+        main(argv)
+    assert not ledger.exists()
+
+
 def test_main_rejects_invalid_record(tmp_path):
     ledger = tmp_path / "decisions.jsonl"
     argv = [


### PR DESCRIPTION
## 做什么

落实「一个账本一个入口」:决策心智账本 `memory/decisions.jsonl` 是唯一真源,**`clawock record` 是唯一对话判定写入命令**。各 harness(OpenClaw / Claude Code / Codex / 纯 CLI / DSH)通过 `--source` 标记产出来源后落账,禁止任何 harness 手改 jsonl;插件保持纯只读加工层(读 decisions.jsonl + portfolio.json 渲染,不写数据)。

## 改动

- `src/clawock/decision/record.py`:`--source` 枚举 `{conversation(默认,DSH)/openclaw/claude/codex/cli}`,写入 `source` + `execution.source`,`decision_id` 用 source 作稳定前缀(openclaw 记录 → `dec-openclaw-…`);`validate_mind_record` 强制枚举
- `.github/workflows/harness-regression.yml`:audit 的 orphan 检查从「放行 source=conversation」改为「放行全部 schema_version=0 心智记录」——新 harness 来源的白名单不用每次加,且心智记录本就不出自 plan 文件
- 教学示例:OpenClaw skill / Claude Code CLAUDE.md / Codex AGENTS.md 补 **Record conversation verdicts** 段(先例 + `--source` 用法);DSH skill 标注 `--source` 默认值;`docs/decision-mind-ledger.md` 数据互通节重写为多 harness 入口
- 测试:+2(不同 harness 写同一账本可区分、未知 source 被拒)

## 验收

1. `clawock record --source openclaw --subject X …` 落账,`source=openclaw`、`execution.source=openclaw`、id 前缀 `dec-openclaw-`
2. `--source bing`(未知)被 argparse 拒绝,账本不被触碰
3. 全量 ledger audit(schema_version=0 全部放行)本地通过:641 条 · 0 orphans
4. OpenClaw/Claude Code/Codex 三方 skill 均已教「verdict → clawock record --source <harness>」

## 背景

kcn 要求:OpenClaw 聊天的决策最终也要进同一个视图;插件只是加工数据源。之前 OpenClaw 聊天判定没有落账路径(只有盘前 brief 和 DSH 的 conversation 各 1 个来源),本 PR 把入口统一,后续 OpenClaw 聊天接线直接用 `--source openclaw` 即可。
