### PR TITLE
feat: dashboard 新增「决策轨迹」卡片(真实成交×决策账本×T+1)

### DIFF
--- a/examples/dsh/plugin/README.md
+++ b/examples/dsh/plugin/README.md
@@ -70,15 +70,27 @@ agent:准备请求…(clawock run prepare)
 
 ## Decision Mind 面板
 
-装完后,web GUI 的会话视图多一个 **Decision Mind** tab(只读,DSH 原生
-浅色风格)。**OpenClaw 每天产出的东西,这里都能读**:
+装完后,web GUI 的会话视图多一个 **Decision Mind** tab(只读)。它只做
+一件事:**每一笔真实成交,都是一条可以点开的决策轨迹**。
 
-- **账本**:`memory/decisions.jsonl` 的决策记录,按日期分组 —— 盘前简报
-  决策与对话判定(带 bull/bear 思想、情绪压力、可证伪条件)同源展示,
-  旧记录自动降级(只有动作/条件/对账);
-- **持仓**:`portfolio.json` 按书分组(港/美股),ticker / 股数 / 现价 /
-  盈亏%,红绿语义色;
-- **计划**:最近的 `memory/*-plan.json` 与决策数。
+- **主轴是真实成交**(portfolio.json trades[]),不是计划流水。每行 =
+  标的 + 动作 + 数量@价 + **盈亏焦点数字**,副行是 **T+1 判定**
+  (快照收盘价对比成交价:卖飞/卖对)+ 日期。
+- **点开一条轨迹**:GitHub 式纵向时间线 —— 当时计划(动作/信心/驱动 +
+  条件/计划股数/计划价)→ 执行(是否遵守)→ T+1 结果 → 盈亏(已实现
+  或持仓现值)。为什么(rationale)/情绪压力(非 calm 才显示)/备注
+  用语义色左边框分层。
+- **没有决策的成交显式标注**「无关联决策记录」—— 不假装有判断。
+  SPCH 那种「计划 cut 却持续买入摊本」的纪律偏差,一条轨迹看得明明白白。
+- **抬头统计**:已实现盈亏(USD/HKD 分别计、折算 USD 等值,绝不混加)、
+  T+1 卖飞/卖对计数、决策挂接率;过滤:全部 / 无决策 / 卖出复盘 /
+  挂接决策。
+
+对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
+... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,
+bear 与失效条件强制,情绪自认)。面板不改任何文件,结算仍归既有机制。
+同一个「决策轨迹」数据契约也渲染在公开 dashboard 的 Reflect 面板
+(`build_decision_traces`)——插件与网页同一份加工逻辑。结构:
 
 对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
 ... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,

--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -1,12 +1,18 @@
 /**
  * clawock-dsh browser bundle: the Decision Mind conversation-view tab.
  *
- * Shows whatever the OpenClaw desk produced — the shared decision ledger
- * (memory/decisions.jsonl), the portfolio, and recent daily plans — through
- * read-only Typert remotes. Hand-authored module-loader factory, no build
- * step. Visual language: restrained DSH-native light theme (ui-theme token
- * values), glass only on the sticky header, DeepSeek blue as the single
- * accent, semantic tints for pos/neg/warn.
+ * One organic view — the decision trace: real fills as the spine, the shared
+ * decision ledger (memory/decisions.jsonl) soft-paired (±3 days) as the "why"
+ * layer, and snapshot closes as the T+1 verdict. This replaced the old
+ * three-tab layout (ops/ledger/portfolio): the ledger was "useless" as a
+ * parallel tab because it showed plan rows without their fills; the trace
+ * view is the synthesis — every fill carries its plan, its execution and its
+ * result, and fills without a decision say so explicitly.
+ *
+ * Visual language: modern SaaS on DSH tokens — white cards on a light gray
+ * canvas, the P&L figure as the 16.5px/700 focal number, T+1 verdict chips,
+ * GitHub-style vertical timeline in the expandable detail. Read-only Typert
+ * remotes; hand-authored module-loader factory, no build step.
  */
 window.__ModuleLoader__.load({
   id: 'clawock-dsh',
@@ -25,332 +31,319 @@ window.__ModuleLoader__.load({
       var style = document.createElement('style')
       style.id = STYLE_ID
       style.textContent = [
-        '.dml{--bg:#F9FAFB;--surface:#FFFFFF;--surface2:#F5F6F7;--text:#0F1115;--text2:#81858C;--text3:#ADB2B8;',
-        '--brand:#4176E6;--brand-deep:#4868B2;--brand-soft:#EDF3FE;--border-l1:rgba(0,0,0,.04);--border-l2:rgba(0,0,0,.10);--border-card:rgba(0,0,0,.08);',
-        '--hover:rgba(38,49,72,.06);--active:rgba(38,49,72,.12);',
-        '--pos:#1E9E6C;--pos-soft:#E6FAED;--neg:#D64550;--neg-soft:#FEF2F2;--warn:#B77B16;--warn-soft:#FEF5E7;',
-        '--shadow-lv2:0 4px 12px rgba(0,0,0,.02),0 2px 8px rgba(0,0,0,.04);--shadow-lv3:0 0 1px rgba(0,0,0,.2),0 0 4px rgba(0,0,0,.02),0 12px 32px rgba(0,0,0,.08);',
-        '--radius-lg:14px;--radius-md:10px;--radius-sm:8px;--radius-pill:999px;',
+        '.dmt{--bg:#F7F8FA;--surface:#FFFFFF;--text:#15171B;--text2:#61666B;--text3:#81858C;--cap:#ADB2B8;',
+        '--brand:#4176E6;--brand-soft:#EDF3FE;--ok:#1B8644;--ok-soft:#E6FAED;--bad:#C01313;--bad-soft:#FDEBEE;--warn:#AA6924;',
+        '--border:rgba(17,24,39,.06);--border2:rgba(17,24,39,.10);',
+        '--hover:rgba(17,24,39,.05);--shadow-sm:0 1px 2px rgba(16,24,40,.04);--shadow-md:0 4px 16px rgba(16,24,40,.08);',
+        '--radius:12px;--radius-sm:8px;',
         '--font:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;',
         '--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;',
-        'font:14px/1.55 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;padding:4px 2px;',
-        'background-image:radial-gradient(900px 300px at 50% -120px,rgba(65,118,230,.05),transparent 70%)}',
-        '.dml .head{position:sticky;top:0;z-index:5;margin:-4px -2px 0;padding:12px 14px 10px;',
-        'background:linear-gradient(180deg,rgba(249,250,251,.9),rgba(249,250,251,.72));',
-        '-webkit-backdrop-filter:blur(20px);backdrop-filter:blur(20px);border-bottom:1px solid var(--border-l1)}',
-        '.dml .title{display:flex;align-items:baseline;gap:10px;margin-bottom:10px}',
-        '.dml .title h3{margin:0;font-size:16px;font-weight:700;letter-spacing:-.01em}',
-        '.dml .title span{color:var(--text3);font-size:12px}',
-        '.dml .seg{display:inline-flex;padding:2px;background:var(--surface2);border:1px solid var(--border-l2);border-radius:var(--radius-pill)}',
-        '.dml .seg button{border:0;background:transparent;color:var(--text2);font-size:12.5px;font-weight:600;padding:4px 14px;border-radius:var(--radius-pill);cursor:pointer;transition:background .15s,color .15s}',
-        '.dml .seg button:hover{background:var(--hover)}',
-        '.dml .seg button.on{background:var(--surface);color:var(--brand);box-shadow:var(--shadow-lv2)}',
-        '.dml .day{margin:18px 0 8px;color:var(--text3);font-size:11.5px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;gap:8px}',
-        '.dml .day::after{content:"";flex:1;height:1px;background:linear-gradient(90deg,rgba(65,118,230,.2),transparent)}',
-        '.dml .card{margin:8px 0;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2);overflow:hidden;transition:border-color .15s}',
-        '.dml .card:hover{border-color:var(--border-l2)}',
-        '.dml .row{display:flex;align-items:center;gap:10px;padding:12px 14px;cursor:pointer;transition:background .15s}',
-        '.dml .row:hover{background:var(--hover)}.dml .row:active{background:var(--active)}.dml .row:focus-visible{outline:2px solid var(--brand);outline-offset:-2px}',
-        '.dml .tk{font-weight:700;font-size:14px;min-width:118px}',
-        '.dml .chip{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;border-radius:var(--radius-pill);font-size:11.5px;font-weight:600}',
-        '.dml .chip.add{color:var(--pos);background:var(--pos-soft)}.dml .chip.trim{color:var(--neg);background:var(--neg-soft)}',
-        '.dml .chip.reject{color:var(--text2);background:var(--surface2)}.dml .chip.emo{color:var(--warn);background:var(--warn-soft)}',
-        '.dml .chip.ok{color:var(--pos);background:var(--pos-soft)}.dml .chip.warn{color:var(--warn);background:var(--warn-soft)}',
-        '.dml .chip.gray{color:var(--text3);background:var(--surface2)}',
-        '.dml .conf{margin-left:auto;color:var(--text2);font-size:12px;font-family:var(--mono);font-variant-numeric:tabular-nums}',
-        '.dml .chev{color:var(--text3);font-size:10px;transition:transform .18s}',
-        '.dml .open .chev{transform:rotate(180deg)}',
-        '.dml .detail{display:none;border-top:1px solid var(--border-l1);padding:16px;background:var(--bg)}',
-        '.dml .open .detail{display:block}',
-        '.dml .sec{font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--text3);text-transform:uppercase;margin:14px 0 8px}',
-        '.dml .sec:first-child{margin-top:0}',
-        '.dml .vs{display:grid;grid-template-columns:1fr 1fr;gap:12px}',
-        '.dml .side{padding:12px 14px;border-radius:var(--radius-sm);border:1px solid var(--border-l2)}',
-        '.dml .side.bull{background:var(--pos-soft);border-color:rgba(30,158,108,.3)}',
-        '.dml .side.bear{background:var(--neg-soft);border-color:rgba(214,69,80,.3)}',
-        '.dml .side b{font-size:11px;letter-spacing:.08em;text-transform:uppercase}',
-        '.dml .side.bull b{color:var(--pos)}.dml .side.bear b{color:var(--neg)}',
-        '.dml .side p{margin:7px 0 4px;font-size:13px;color:var(--text)}',
-        '.dml .side .src{color:var(--text3);font-size:12px}',
-        '.dml .meter{height:8px;border-radius:var(--radius-pill);background:var(--border-l2);overflow:hidden;margin:8px 0 4px}',
-        '.dml .meter>div{height:100%;border-radius:var(--radius-pill);background:linear-gradient(90deg,var(--brand-deep),var(--brand))}',
-        '.dml .kv{display:flex;justify-content:space-between;gap:14px;padding:6px 0;border-bottom:1px solid var(--border-l1);font-size:13px}',
-        '.dml .kv span{color:var(--text3);flex-shrink:0}.dml .kv:last-child{border-bottom:none}',
-        '.dml ul.inv{margin:6px 0 0;padding-left:18px;color:var(--text2);font-size:13px}',
-        '.dml ul.inv li{margin:3px 0}',
-        '.dml .emo-note{margin-top:12px;padding:10px 14px;border-radius:var(--radius-sm);background:var(--warn-soft);border-left:3px solid var(--warn);font-size:13px;color:var(--text2)}',
-        '.dml .acc{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}',
-        '.dml .stat{padding:10px 12px;border:1px solid var(--border-l2);border-radius:var(--radius-sm);background:var(--surface)}',
-        '.dml .stat span{display:block;color:var(--text3);font-size:11px}.dml .stat b{font-size:13px;font-weight:600}',
-        '.dml .okb{color:var(--pos)}.dml .warnb{color:var(--warn)}.dml .grayb{color:var(--text2)}',
-        '.dml .mono{font-family:var(--mono);font-size:12px;color:var(--text2)}',
-        '.dml table{width:100%;border-collapse:collapse;font-size:13px}',
-        '.dml th{color:var(--text3);font-weight:600;text-align:left;padding:6px 10px;border-bottom:1px solid var(--border-l2);font-size:11.5px}',
-        '.dml td{padding:7px 10px;border-bottom:1px solid var(--border-l1);font-variant-numeric:tabular-nums}',
-        '.dml td.num{text-align:right;font-family:var(--mono);font-size:12.5px}',
-        '.dml .pos{color:var(--pos)}.dml .neg{color:var(--neg)}',
-        '.dml .book{margin:12px 0}',
-        '.dml .book h4{margin:0 0 8px;font-size:13px;font-weight:700;color:var(--text2)}',
-        '.dml .plan{margin:8px 0;padding:12px 14px;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2)}',
-        '.dml .plan .d{font-weight:700;font-size:13.5px;font-family:var(--mono)}',
-        '.dml .plan .n{color:var(--text3);font-size:12.5px;margin-left:10px}',
-        '.dml .empty{padding:26px 14px;text-align:center;color:var(--text3);font-size:13px}',
+        'font:13px/1.45 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;min-height:100%}',
+        '.dmt .top{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.92);-webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);padding:10px 16px 8px}',
+        '.dmt .tt{display:flex;align-items:center;gap:8px;font:700 17px/1.3 var(--font);letter-spacing:-.01em}',
+        '.dmt .tt::before{content:"";width:9px;height:9px;border-radius:3px;background:var(--brand)}',
+        '.dmt .ts{font:400 11.5px/1.3 var(--font);color:var(--cap);margin-top:2px}',
+        '.dmt .stats{display:flex;align-items:flex-end;gap:0;margin-top:8px;flex-wrap:wrap}',
+        '.dmt .sg{display:flex;flex-direction:column;gap:2px;padding:0 14px}',
+        '.dmt .sg+.sg{border-left:1px solid rgba(0,0,0,.08)}',
+        '.dmt .sl{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.03em;white-space:nowrap}',
+        '.dmt .sv{font:650 14px/1.3 var(--font);color:var(--text);font-variant-numeric:tabular-nums;white-space:nowrap}',
+        '.dmt .sv.focus{font:700 16px/1.3 var(--font)}',
+        '.dmt .sv.up{color:var(--ok)}.dmt .sv.down{color:var(--bad)}',
+        '.dmt .rate{font:400 10.5px/1.3 var(--font);color:var(--cap);margin-left:auto;align-self:center}',
+        '.dmt .filters{display:flex;gap:2px;margin-top:8px;flex-wrap:wrap}',
+        '.dmt .ft{border:0;background:transparent;color:var(--text3);font:600 12px/1.4 var(--font);padding:5px 11px;border-radius:8px;cursor:pointer;transition:background .12s,color .12s}',
+        '.dmt .ft:hover{background:var(--hover)}',
+        '.dmt .ft.on{color:var(--text);background:rgba(17,24,39,.06)}',
+        '.dmt .list{max-width:760px;margin:0 auto;padding:10px 16px 32px}',
+        '.dmt .day{margin:16px 0 2px;display:flex;align-items:center;gap:8px;font:650 13px/1.3 var(--font);color:var(--text)}',
+        '.dmt .day .n{color:var(--cap);font:400 10.5px/1.3 var(--mono);margin-left:auto}',
+        '.dmt .day::after{content:"";flex:1;height:1px;background:var(--border);margin-left:6px}',
+        '.dmt .cell{width:100%;margin:7px 0;border-radius:12px;border:1px solid var(--border);background:var(--surface);cursor:pointer;box-shadow:var(--shadow-sm);transition:box-shadow .15s,border-color .15s}',
+        '.dmt .cell:hover{border-color:var(--border2);box-shadow:var(--shadow-md)}',
+        '.dmt .cell.open{border-color:var(--brand);box-shadow:0 0 0 3px rgba(65,118,230,.12)}',
+        '.dmt .main{display:flex;align-items:center;gap:12px;padding:13px 14px 6px}',
+        '.dmt .dotm{flex:none;width:6px;height:6px;border-radius:50%;background:var(--cap);margin-right:2px}',
+        '.dmt .cell.hasdec .dotm{background:var(--brand)}',
+        '.dmt .tk{flex:0 1 auto;min-width:0;font:650 14.5px/1.4 var(--font);letter-spacing:-.01em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+        '.dmt .mkt{font:700 9.5px/1 var(--font);margin-left:3px;vertical-align:2px;color:var(--brand)}',
+        '.dmt .mkt.hk{color:var(--text3)}',
+        '.dmt .tag{flex:none;display:inline-flex;align-items:center;height:20px;padding:0 7px;border-radius:6px;border:1px solid rgba(0,0,0,.05);background:rgba(0,0,0,.03);font:600 11.5px/1 var(--font);color:var(--text2);letter-spacing:.02em}',
+        '.dmt .qty{flex:0 1 auto;min-width:0;text-align:right;font:500 12.5px/1.4 var(--mono);color:var(--text2);font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
+        '.dmt .sp{flex:1 1 auto;min-width:8px}',
+        '.dmt .pnl{flex:none;min-width:92px;text-align:right;font:700 16.5px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em}',
+        '.dmt .pnl.up{color:var(--ok)}.dmt .pnl.down{color:var(--bad)}.dmt .pnl.na{color:var(--cap);font-weight:500;font-size:13px}',
+        '.dmt .sub{display:flex;align-items:center;gap:10px;padding:3px 14px 11px;font:400 11px/1.4 var(--font);color:var(--cap)}',
+        '.dmt .t1{flex:none;display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:5px;font:600 10.5px/1 var(--font);white-space:nowrap;font-variant-numeric:tabular-nums}',
+        '.dmt .t1.up{color:var(--ok);background:var(--ok-soft);border:1px solid rgba(27,132,68,.18)}',
+        '.dmt .t1.down{color:var(--bad);background:var(--bad-soft);border:1px solid rgba(192,19,19,.18)}',
+        '.dmt .t1.flat{color:var(--text2);background:rgba(0,0,0,.03)}',
+        '.dmt .sub .date{flex:none;font-variant-numeric:tabular-nums}',
+        '.dmt .chev{margin-left:auto;flex:none;color:var(--cap);font-size:10px;transition:transform .15s}',
+        '.dmt .cell.open .chev{transform:rotate(180deg)}',
+        '.dmt .detail{display:grid;grid-template-rows:0fr;opacity:0;border-top:1px solid rgba(0,0,0,.04);transition:grid-template-rows .24s cubic-bezier(.22,1,.36,1),opacity .15s ease;overflow:hidden}',
+        '.dmt .cell.open .detail{grid-template-rows:1fr;opacity:1}',
+        '.dmt .dinner{overflow:hidden;min-height:0;padding:12px 16px 14px}',
+        '.dmt .trhead{display:flex;align-items:center;gap:6px;font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.05em;margin-bottom:8px}',
+        '.dmt .trhead::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--brand)}',
+        '.dmt .trace{position:relative;padding-left:22px}',
+        '.dmt .trace::before{content:"";position:absolute;left:5px;top:12px;bottom:10px;width:2px;background:rgba(0,0,0,.08)}',
+        '.dmt .tnode{position:relative;padding:2px 0 14px}',
+        '.dmt .tnode:last-child{padding-bottom:2px}',
+        '.dmt .tnode::before{content:"";position:absolute;left:-22px;top:5px;width:10px;height:10px;border-radius:50%;background:#fff;border:2px solid var(--cap);box-sizing:border-box}',
+        '.dmt .tnode.dec::before{border-color:var(--brand)}',
+        '.dmt .tnode.follow::before{border-color:var(--ok)}.dmt .tnode.skip::before{border-color:var(--warn)}',
+        '.dmt .tnode.win::before{border-color:var(--ok)}.dmt .tnode.loss::before{border-color:var(--bad)}',
+        '.dmt .tnode .tw{font:400 10px/1.4 var(--mono);color:var(--cap);margin-bottom:1px}',
+        '.dmt .tnode .n{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.04em;margin-bottom:2px}',
+        '.dmt .tnode .v{font:600 13px/1.4 var(--font)}',
+        '.dmt .tnode.win .v{color:var(--ok)}.dmt .tnode.loss .v{color:var(--bad)}',
+        '.dmt .tnode.follow .v{color:var(--ok)}.dmt .tnode.skip .v{color:var(--warn)}',
+        '.dmt .pchips{display:flex;flex-wrap:wrap;gap:6px;margin:4px 0 8px}',
+        '.dmt .pc{font:400 11px/1.4 var(--font);padding:2px 8px;border-radius:6px;background:rgba(0,0,0,.03);border:1px solid var(--border);color:var(--text2)}',
+        '.dmt .tnote{margin:7px 0;padding:3px 0 3px 10px;border-left:3px solid rgba(0,0,0,.12);font:400 11.5px/1.6 var(--font);color:var(--text2);white-space:pre-wrap;overflow-wrap:anywhere}',
+        '.dmt .tnote.why{border-left-color:var(--brand)}',
+        '.dmt .tnote.emo{border-left-color:var(--warn)}',
+        '.dmt .tnote .k{color:var(--cap);font:600 10.5px/1.4 var(--font)}',
+        '.dmt .tmiss{padding:7px 10px;border:1px dashed var(--border2);border-radius:6px;font:400 11.5px/1.5 var(--font);color:var(--cap);margin-top:8px}',
+        '.dmt .empty{padding:48px 20px;text-align:center;color:var(--cap);font:400 13px/1.5 var(--font)}',
+        '@media (max-width:520px){',
+        '.dmt .main{gap:8px;padding:12px 12px 6px}',
+        '.dmt .tk{font-size:13.5px}',
+        '.dmt .qty{font-size:11px;text-align:left}',
+        '.dmt .pnl{min-width:84px;font-size:14.5px}',
+        '.dmt .sub{gap:8px;padding:3px 12px 10px}',
+        '.dmt .sg{padding:0 11px}',
+        '.dmt .sv{font-size:13px}.dmt .sv.focus{font-size:14.5px}',
+        '}',
+        '@media (prefers-reduced-motion:reduce){',
+        '.dmt *{transition:none!important;animation:none!important}',
+        '}',
       ].join('')
       document.head.appendChild(style)
     }
 
-    /** Pure projection of one ledger entry into display fields (test seam). */
-    function _displayEntry(entry) {
-      var subject = entry.subject || {}
-      var mind = entry.mind || {}
-      var emotion = entry.emotion || {}
-      var evaluation = entry.evaluation || {}
-      var execution = entry.execution || {}
+    var ACT = { buy:'买入', add:'加仓', trim:'减仓', sell:'卖出', cut:'割肉', hold:'持有',
+      hold_and_watch:'持有', trim_on_rebound:'反弹减仓', t_only:'仅T+0',
+      add_only_on_trigger:'触发加仓', reject:'不加', watch:'观望', abstain:'弃权' }
+    var DRV = { technical:'技术面', fundamental:'基本面', sentiment:'情绪面', mixed:'混合', risk_rule:'风控规则' }
+    var EXE = { followed:['已遵守','follow'], not_followed:['未执行','skip'], unknown:['未知',''] }
+    var EMO = { fomo:'追高冲动', revenge:'报复性', averaging_down:'摊薄冲动', fear:'恐慌',
+      euphoria:'亢奋', calm:'平静', mixed:'混合' }
+
+    function esc(s) { return String(s == null ? '' : s).replace(/</g, '&lt;') }
+
+    function fmtMoney(v) {
+      if (v == null || !isFinite(v)) return '—'
+      return (v > 0 ? '+' : '') + Number(v).toLocaleString(undefined, { maximumFractionDigits: 0 })
+    }
+
+    function fmtPct(v, digits) {
+      if (v == null || !isFinite(v)) return '—'
+      return (v > 0 ? '+' : '') + Number(v).toFixed(digits || 1) + '%'
+    }
+
+    /** Display projection of one trace (test seam). */
+    function _displayEntry(trace) {
+      var d = trace.decision || null
       return {
-        id: entry.decision_id || null,
-        ticker: subject.ticker || entry.ticker || '?',
-        date: entry.decided_at || entry.plan_date || null,
-        action: entry.action || 'hold',
-        confidence: entry.confidence ?? null,
-        drivenBy: entry.driven_by || null,
-        source: entry.source || 'brief',
-        bull: mind.bull && mind.bull.summary ? mind.bull.summary : null,
-        bear: mind.bear && mind.bear.summary ? mind.bear.summary : null,
-        thesis: mind.thesis || null,
-        invalidation: Array.isArray(mind.invalidation) ? mind.invalidation : [],
-        emotion: emotion.pressure || null,
-        emotionNote: emotion.note || null,
-        condition: entry.condition && entry.condition.description ? entry.condition.description : null,
-        executionStatus: execution.status || null,
-        outcome: evaluation.outcome || null,
-        rationale: typeof entry.rationale === 'string' ? entry.rationale : null,
-        market: subject.market || (entry.leg === 'US' ? 'US' : /^\d/.test(entry.ticker || '') ? 'HK' : 'US'),
-        sizeShares: (entry.size && entry.size.shares) || null,
-        sizePct: (entry.size && entry.size.pct) || null,
-        // Real fill price beats the plan's simulation; flag when only the plan price exists.
-        entryPrice: evaluation.execution_price ?? entry.simulated_entry_price ?? null,
-        planPrice: evaluation.execution_price == null && entry.simulated_entry_price != null,
-        capital: evaluation.capital || null,
+        ticker: trace.ticker || '?',
+        market: trace.market || 'US',
+        currency: trace.currency || 'USD',
+        date: trace.date || null,
+        action: trace.action || 'hold',
+        shares: trace.shares || 0,
+        price: trace.price ?? null,
+        realizedPnl: trace.realizedPnl ?? null,
+        note: trace.note || null,
+        t1: trace.t1 || null,
+        holdPnl: trace.holdPnl ?? null,
+        decision: d,
       }
     }
 
-    var ACTION_LABELS = {
-      buy: '买入', add: '加仓', trim: '减仓', sell: '卖出', cut: '割肉',
-      hold_and_watch: '持有观望', trim_on_rebound: '反弹减仓', t_only: '仅T+0', add_only_on_trigger: '触发加仓',
-      reject: '不加', watch: '观望', hold: '持有', abstain: '弃权',
-    }
-    function actionLabel(action) { return ACTION_LABELS[action] || String(action) }
+    function Chip(props) { return h('span', { className: 'tag' }, props.children) }
 
-    function Chip(props) {
-      return h('span', { className: 'chip ' + props.tone }, props.children)
-    }
-
-    var ACTIVE_ACTIONS = ['add', 'buy', 'trim', 'sell', 'cut', 't_only', 'trim_on_rebound', 'add_only_on_trigger']
-
-    function ActionChip(action) {
-      var tone = action === 'add' || action === 'buy' ? 'add'
-        : ACTIVE_ACTIONS.indexOf(action) >= 0 ? 'trim'
-        : action === 'reject' || action === 'watch' || action === 'hold' || action === 'abstain' ? 'reject'
-        : 'gray'
-      return h(Chip, { tone: tone }, actionLabel(action))
-    }
-
-    function LedgerCard(props) {
-      var d = props.entry
-      var expanded = props.open
-      var currentPnl = props.currentPnl
-      var sizeText = null
-      if (d.sizeShares) {
-        var amount = d.sizeShares * (d.entryPrice || 0)
-        var sym = d.market === 'HK' ? 'HK$' : '$'
-        sizeText = d.sizeShares + ' 股' + (d.entryPrice ? ' @' + d.entryPrice + (d.planPrice ? ' (计划价)' : '') + (amount ? ' ≈' + sym + Math.round(amount).toLocaleString() : '') : '')
-      } else if (d.sizePct) {
-        sizeText = (d.sizePct * 100).toFixed(0) + '% 仓位'
+    function TraceDetail(props) {
+      var t = props.trace
+      var d = t.decision
+      var sym = t.currency === 'HKD' ? 'HK$' : '$'
+      if (!d) {
+        var t1miss = t.t1 ? h('div', { className: 'tnode ' + (t.t1.delta >= 0 ? 'loss' : 'win') },
+          h('div', { className: 'n' }, 'T+1 结果'),
+          h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%')) : null
+        return h('div', null,
+          h('div', { className: 'trhead' }, '决策轨迹 · 无关联记录'),
+          h('div', { className: 'trace' },
+            h('div', { className: 'tnode dec' },
+              h('div', { className: 'n' }, '决策'),
+              h('div', { className: 'v', style: { color: 'var(--cap)' } }, '无关联记录')),
+            h('div', { className: 'tnode follow' },
+              h('div', { className: 'n' }, '执行'),
+              h('div', { className: 'v' }, (ACT[t.action] || t.action) + ' ' + t.shares + '股 @' + t.price + ' ' + sym)),
+            t1miss),
+          t.note ? h('div', { className: 'tnote' }, esc(t.note)) : null,
+          h('div', { className: 'tmiss' }, '此笔无关联决策记录 — 事实保留,判断缺失显式标出'))
       }
-      var why = d.thesis || d.rationale || (d.bull ? d.bull.slice(0, 48) : null)
-      if (why && why.length > 60) why = why.slice(0, 57) + '…'
-      var pnl = props.currentPnl
-      var outcomeTone = d.outcome && d.outcome !== 'not_triggered' && d.outcome !== 'unknown' ? 'ok' : 'gray'
-      return h('div', { className: 'card' + (expanded ? ' open' : '') },
-        h('div', { className: 'row', role: 'button', tabIndex: 0, 'aria-expanded': expanded, onClick: props.onToggle },
-          h('span', { className: 'tk' }, d.ticker),
-          ActionChip(d.action),
-          sizeText ? h('span', { className: 'mono', style: { color: 'var(--text2)' } }, sizeText) : null,
-          d.emotion && d.emotion !== 'calm' ? h(Chip, { tone: 'emo' }, '⚡ ' + d.emotion) : null,
-          h('span', { className: 'conf' }, (d.confidence ?? '—') + (d.drivenBy ? ' · ' + d.drivenBy : '')),
+      var exe = EXE[d.execution] || ['未知', '']
+      var decV = (ACT[d.action] || d.action) + (d.confidence != null ? ' ' + Math.round(d.confidence * 100) + '%' : '') +
+        (d.drivenBy ? ' · ' + (DRV[d.drivenBy] || d.drivenBy) : '')
+      var why = d.rationale || d.bull || ''
+      var emo = d.emotion && d.emotion !== 'calm' ? (EMO[d.emotion] || d.emotion) : null
+      var chips = []
+      if (d.condition) chips.push(h('span', { className: 'pc', key: 'c' }, '条件: ' + d.condition))
+      if (d.sizeShares) chips.push(h('span', { className: 'pc', key: 's' }, '计划 ' + d.sizeShares + ' 股'))
+      if (d.plannedPrice) chips.push(h('span', { className: 'pc', key: 'p' }, '计划价 ' + d.plannedPrice))
+      var t1node = t.t1 ? h('div', { className: 'tnode ' + (t.t1.delta >= 0 ? 'loss' : 'win') },
+        h('div', { className: 'tw' }, t.t1.date),
+        h('div', { className: 'n' }, 'T+1 结果'),
+        h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' · ' + t.t1.verdict : ''))) : null
+      var rv, rc
+      if (t.realizedPnl != null) { rv = (t.realizedPnl >= 0 ? '+' : '') + Number(t.realizedPnl).toFixed(2) + ' ' + sym; rc = t.realizedPnl >= 0 ? 'win' : 'loss' }
+      else if (t.holdPnl != null) { rv = fmtPct(t.holdPnl, 1); rc = t.holdPnl >= 0 ? 'win' : 'loss' }
+      else { rv = '—'; rc = '' }
+      return h('div', null,
+        h('div', { className: 'trhead' }, '决策轨迹 · ' + (d.planDate || '')),
+        h('div', { className: 'trace' },
+          h('div', { className: 'tnode dec' },
+            h('div', { className: 'tw' }, d.planDate || ''),
+            h('div', { className: 'n' }, '计划'),
+            h('div', { className: 'v' }, decV)),
+          h('div', { className: 'tnode ' + (exe[1] || '') },
+            h('div', { className: 'tw' }, t.date || ''),
+            h('div', { className: 'n' }, '执行'),
+            h('div', { className: 'v' }, exe[0] + (exe[1] === 'skip' ? ' — 实际动了手' : ''))),
+          t1node,
+          h('div', { className: 'tnode ' + rc },
+            h('div', { className: 'n' }, '盈亏'),
+            h('div', { className: 'v' }, rv))),
+        chips.length ? h('div', { className: 'pchips' }, chips) : null,
+        why ? h('div', { className: 'tnote why' }, h('span', { className: 'k' }, '为什么 '), esc(why)) : null,
+        emo ? h('div', { className: 'tnote emo' }, h('span', { className: 'k' }, '情绪 '), '⚡ ' + emo) : null,
+        t.note ? h('div', { className: 'tnote' }, h('span', { className: 'k' }, '备注 '), esc(t.note)) : null)
+    }
+
+    function TraceCell(props) {
+      var t = props.trace
+      var open = props.open
+      var sym = t.currency === 'HKD' ? 'HK$' : '$'
+      var qty = t.shares + ' @' + t.price
+      var pnl
+      if (t.realizedPnl != null) pnl = h('span', { className: 'pnl ' + (t.realizedPnl >= 0 ? 'up' : 'down') },
+        (t.realizedPnl >= 0 ? '+' : '') + Number(t.realizedPnl).toFixed(2) + ' ' + sym)
+      else if (t.holdPnl != null) pnl = h('span', { className: 'pnl ' + (t.holdPnl >= 0 ? 'up' : 'down') }, fmtPct(t.holdPnl, 1))
+      else pnl = h('span', { className: 'pnl na' }, '—')
+      var t1tag = null
+      if (t.t1) {
+        var tc = t.t1.delta >= 0 ? 'down' : (t.t1.delta < -1 ? 'up' : 'flat')
+        var tlabel = 'T+1 ' + (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' ' + t.t1.verdict : '')
+        t1tag = h('span', { className: 't1 ' + tc }, tlabel)
+      } else if (t.action === 'sell') {
+        t1tag = h('span', { className: 't1 flat' }, 'T+1 —')
+      }
+      return h('div', { className: 'cell' + (t.decision ? ' hasdec' : '') + (open ? ' open' : ''), role: 'button', tabIndex: 0, 'aria-expanded': open, onClick: props.onToggle, onKeyDown: props.onKeyDown },
+        h('div', { className: 'main' },
+          h('span', { className: 'dotm' }),
+          h('span', { className: 'tk' }, t.ticker, h('span', { className: 'mkt' + (t.market === 'HK' ? ' hk' : '') }, t.market === 'HK' ? '港' : '美')),
+          h(Chip, null, ACT[t.action] || t.action),
+          h('span', { className: 'qty' }, qty),
+          h('span', { className: 'sp' }),
+          pnl),
+        h('div', { className: 'sub' },
+          t1tag,
+          h('span', { className: 'date' }, (t.date || '').slice(5)),
           h('span', { className: 'chev' }, '▾')),
-        h('div', { style: { padding: '0 14px 10px', fontSize: 12.5, color: 'var(--text2)', display: 'flex', gap: 12, flexWrap: 'wrap' } },
-          why ? h('span', null, '为什么: ' + why) : null,
-          pnl !== null ? h('span', { className: pnl < 0 ? 'neg' : 'pos' }, '现盈亏 ' + (pnl > 0 ? '+' : '') + pnl.toFixed(1) + '%') : null,
-          d.outcome ? h('span', { className: outcomeTone === 'ok' ? 'pos' : 'grayb' }, 'outcome ' + d.outcome) : null),
         h('div', { className: 'detail' },
-          d.bull || d.bear ? h('div', { className: 'vs' },
-            h('div', { className: 'side bull' }, h('b', null, 'Bull'), h('p', null, d.bull || '—'), h('div', { className: 'src' }, 'evidence · decision time')),
-            h('div', { className: 'side bear' }, h('b', null, 'Bear'), h('p', null, d.bear || '—'), h('div', { className: 'src' }, 'opposing · mandatory'))) : null,
-          d.thesis ? h('div', { className: 'sec' }, 'Thesis') : null,
-          d.thesis ? h('div', { className: 'kv' }, h('span', null, 'thesis'), h('b', null, d.thesis)) : null,
-          d.confidence !== null ? h('div', { className: 'kv' }, h('span', null, 'confidence'), h('b', { className: 'mono' }, String(d.confidence))) : null,
-          d.confidence !== null ? h('div', { className: 'meter' }, h('div', { style: { width: (d.confidence > 0 ? Math.max(4, Math.min(100, d.confidence * 100)) : 0) + '%' } })) : null,
-          d.invalidation.length ? h('div', { className: 'sec' }, '可证伪条件') : null,
-          d.invalidation.length ? h('ul', { className: 'inv' }, d.invalidation.map(function (c, i) { return h('li', { key: i }, c) })) : null,
-          d.emotionNote ? h('div', { className: 'emo-note' }, '⚡ ' + d.emotionNote) : null,
-          d.condition || d.executionStatus || d.outcome ? h('div', { className: 'sec' }, '对账') : null,
-          (d.condition || d.executionStatus || d.outcome) ? h('div', { className: 'acc' },
-            h('div', { className: 'stat' }, h('span', null, 'condition'), h('b', { className: 'grayb' }, d.condition || '—')),
-            h('div', { className: 'stat' }, h('span', null, 'execution'), h('b', { className: d.executionStatus === 'followed' ? 'okb' : 'grayb' }, d.executionStatus || '—')),
-            h('div', { className: 'stat' }, h('span', null, 'outcome'), h('b', { className: d.outcome === 'not_triggered' ? 'grayb' : 'okb' }, d.outcome || '—'))) : null))
+          h('div', { className: 'dinner' }, h(TraceDetail, { trace: t }))))
     }
 
-    function LedgerView(props) {
-      var entries = props.entries
-      if (!entries.length) return h('div', { className: 'empty' }, props.filterLabel === 'all' ? '账本为空 — 对话判定或盘前决策会出现在这里' : '暂无已执行的交易样本 — 切到「全部」可看全部记录')
-      var groups = {}
-      var order = []
-      for (var i = entries.length - 1; i >= 0; i -= 1) {
-        var d = entries[i]
-        var key = (d.date || '').slice(0, 10) || 'unknown'
-        if (!groups[key]) { groups[key] = []; order.push(key) }
-        groups[key].push(d)
-      }
-      var pnlByTicker = {}
-      for (var bi = 0; bi < (props.books || []).length; bi += 1) {
-        var bookMarket = /^hk/i.test(props.books[bi].name || '') ? 'HK' : 'US'
-        var bh = (props.books[bi].holdings || [])
-        for (var hi = 0; hi < bh.length; hi += 1) {
-          if (bh[hi].pnlPct !== null) pnlByTicker[bookMarket + ':' + bh[hi].ticker] = bh[hi].pnlPct
-        }
-      }
-      var hasConversation = entries.some(function (e) { return e.source === 'conversation' })
-      return h('div', null, order.map(function (key) {
-        return h('div', { key: key },
-          h('div', { className: 'day' }, key + (hasConversation ? ' · 对话' : '')),
-          groups[key].map(function (d) {
-            return h(LedgerCard, {
-              key: d.id || d.ticker + key,
-              entry: d,
-              currentPnl: pnlByTicker[d.market + ':' + d.ticker] ?? pnlByTicker[d.ticker] ?? null,
-              open: props.selected === d.id,
-              onToggle: function () { props.onSelect(props.selected === d.id ? null : d.id) },
-            })
-          }))
-      }))
-    }
-
-    function PortfolioView(props) {
-      var books = props.books
-      if (!books.length) return h('div', { className: 'empty' }, 'portfolio.json 未找到或为空')
-      return h('div', null, books.map(function (book) {
-        return h('div', { className: 'book card', key: book.name },
-          h('div', { style: { padding: '12px 14px', borderBottom: '1px solid var(--border-l1)' } },
-            h('span', { style: { fontWeight: 700 } }, book.name),
-            h('span', { className: 'mono', style: { marginLeft: 10 } }, book.currency || '')),
-          h('div', { style: { overflowX: 'auto' } },
-            h('table', null,
-              h('thead', null, h('tr', null,
-                h('th', null, 'ticker'), h('th', { style: { textAlign: 'right' } }, 'shares'),
-                h('th', { style: { textAlign: 'right' } }, 'price'), h('th', { style: { textAlign: 'right' } }, 'pnl%'))),
-              h('tbody', null, book.holdings.map(function (hl) {
-                return h('tr', { key: hl.ticker },
-                  h('td', null, hl.ticker),
-                  h('td', { className: 'num' }, String(hl.shares)),
-                  h('td', { className: 'num' }, hl.price !== null ? String(hl.price) : '—'),
-                  h('td', { className: 'num ' + (hl.pnlPct !== null && hl.pnlPct < 0 ? 'neg' : 'pos') },
-                    hl.pnlPct !== null ? (hl.pnlPct > 0 ? '+' : '') + hl.pnlPct.toFixed(1) + '%' : '—'))
-              })))))
-      }))
-    }
-
-    function tradeLabel(trade, firstBuy) {
-      if (trade.action === 'buy') return firstBuy ? '买入' : '加仓'
-      if (trade.action === 'sell') {
-        if (trade.note && trade.note.indexOf('清仓') >= 0) return '清仓'
-        if (trade.note && trade.note.indexOf('减仓') >= 0) return '减仓'
-        return '卖出'
-      }
-      return String(trade.action)
-    }
-
-    /** Actual operations: the real fills recorded in the portfolio trade ledger. */
-    function TradeView(props) {
-      var trades = props.trades || []
-      if (!trades.length) return h('div', { className: 'empty' }, '还没有操作记录 — 成交会出现在这里')
-      var firstBuys = {}
-      for (var i = trades.length - 1; i >= 0; i -= 1) {
-        var k = trades[i].market + ':' + trades[i].ticker
-        if (trades[i].action === 'buy' && !firstBuys[k]) firstBuys[k] = trades[i].date
-      }
-      return h('div', null, trades.map(function (tr) {
-        var sym = tr.market === 'HK' ? 'HK$' : '$'
-        var amount = tr.shares && tr.price ? Math.round(tr.shares * tr.price).toLocaleString() : null
-        var label = tradeLabel(tr, tr.date === firstBuys[tr.market + ':' + tr.ticker])
-        var note = tr.note && tr.note.length > 90 ? tr.note.slice(0, 87) + '…' : tr.note
-        return h('div', { className: 'card', key: tr.ticker + tr.date + tr.shares },
-          h('div', { className: 'row', style: { cursor: 'default' } },
-            h('span', { className: 'tk' }, tr.ticker),
-            h(Chip, { tone: tr.action === 'buy' ? 'add' : 'trim' }, label),
-            h('span', { className: 'mono', style: { color: 'var(--text2)' } },
-              tr.shares + ' 股 @' + tr.price + (amount ? ' ≈' + sym + amount : '')),
-            tr.realizedPnl !== null
-              ? h('span', { className: tr.realizedPnl < 0 ? 'neg' : 'pos', style: { fontFamily: 'var(--mono)', fontSize: 12.5 } },
-                  (tr.realizedPnl >= 0 ? '+' : '') + tr.realizedPnl.toFixed(2))
-              : null,
-            h('span', { className: 'conf' }, tr.date || ''),
-            h('span', { className: 'chev' }, '')),
-          note ? h('div', { style: { padding: '0 14px 10px', fontSize: 12, color: 'var(--text3)' } }, note) : null)
-      }))
-    }
-
-    /** The conversation-view tab: desk data (operations / ledger / portfolio). */
+    /** The single organic view: decision trace timeline. */
     function DecisionMind(props) {
-      var pair = useState({ view: 'ops', filter: 'trades', selected: null, ledger: [], portfolio: { books: [] }, loading: true, error: null })
+      var pair = useState({ filter: 'all', open: null, traces: [], rate: null, loading: true, error: null })
       var state = pair[0]
       var setState = pair[1]
-      var sessionId = props.sessionId
       useEffect(function () {
         var alive = true
         setState(function (c) { return Object.assign({}, c, { loading: true, error: null }) })
-        Promise.all([props.ledger(), props.portfolio()]).then(function (results) {
+        props.traces().then(function (result) {
           if (!alive) return
-          setState(function (c) { return Object.assign({}, c, { ledger: results[0].entries, portfolio: results[1], loading: false }) })
+          setState(function (c) { return Object.assign({}, c, { traces: result.trades, rate: result.rate, loading: false }) })
         }, function (error) {
           if (!alive) return
           setState(function (c) { return Object.assign({}, c, { error: String(error && error.message ? error.message : error), loading: false }) })
         })
         return function () { alive = false }
-      }, [sessionId])
+      }, [props.sessionId])
 
-      if (state.error) return h('div', { className: 'dml' }, h('div', { className: 'card' }, h('span', { style: { color: 'var(--neg)' } }, 'Decision Mind: ' + state.error)))
-      var allEntries = state.ledger.map(_displayEntry)
-      var entries = allEntries.filter(function (d) {
-        if (state.filter === 'all') return true
-        return d.executionStatus === 'followed' && ACTIVE_ACTIONS.indexOf(d.action) >= 0
-      })
-      var tradesCount = allEntries.filter(function (d) {
-        return d.executionStatus === 'followed' && ACTIVE_ACTIONS.indexOf(d.action) >= 0
-      }).length
+      if (state.error) return h('div', { className: 'dmt' }, h('div', { className: 'empty' }, 'Decision Mind: ' + state.error))
+      if (state.loading) return h('div', { className: 'dmt' }, h('div', { className: 'empty' }, '正在加载决策与持仓…'))
+
+      var traces = state.traces.map(_displayEntry)
+      var filtered = traces.slice()
+      if (state.filter === 'miss') filtered = filtered.filter(function (t) { return !t.decision })
+      if (state.filter === 'sold') filtered = filtered.filter(function (t) { return t.action === 'sell' })
+      if (state.filter === 'dec') filtered = filtered.filter(function (t) { return t.decision })
+
+      var usd = traces.filter(function (t) { return t.realizedPnl != null && t.currency === 'USD' }).reduce(function (s, t) { return s + t.realizedPnl }, 0)
+      var hkd = traces.filter(function (t) { return t.realizedPnl != null && t.currency === 'HKD' }).reduce(function (s, t) { return s + t.realizedPnl }, 0)
+      var fx = state.rate
+      var totalUsd = usd + (fx ? hkd / fx : 0)
+      var fw = traces.filter(function (t) { return t.t1 && t.t1.verdict === '卖飞' }).length
+      var ok = traces.filter(function (t) { return t.t1 && t.t1.verdict === '卖对' }).length
+      var matched = traces.filter(function (t) { return t.decision }).length
+
+      var groups = {}
+      filtered.forEach(function (t) { var k = (t.date || '').slice(0, 10); (groups[k] = groups[k] || []).push(t) })
+      var dates = Object.keys(groups).sort().reverse()
+
+      var todayIso = (function () { var n = new Date(); return n.getFullYear() + '-' + String(n.getMonth() + 1).padStart(2, '0') + '-' + String(n.getDate()).padStart(2, '0') })()
+      function rel(iso) {
+        if (iso === todayIso) return '今天'
+        var y = function (d) { return new Date(d + 'T00:00:00') }
+        var diff = Math.round((y(todayIso) - y(iso)) / 86400000)
+        if (diff === 1) return '昨天'
+        if (diff >= 2 && diff <= 7) return diff + '天前'
+        return parseInt(iso.slice(5, 7)) + '月' + parseInt(iso.slice(8, 10)) + '日'
+      }
 
       var body
-      if (state.loading) body = h('div', { className: 'empty' }, 'Loading desk data…')
-      else if (state.view === 'ops') body = h(TradeView, { trades: state.portfolio.trades })
-      else if (state.view === 'ledger') body = h(LedgerView, { entries: entries, books: state.portfolio.books, filterLabel: state.filter, selected: state.selected, onSelect: function (id) { setState(function (c) { return Object.assign({}, c, { selected: id }) }) } })
-      else body = h(PortfolioView, { books: state.portfolio.books })
+      if (!filtered.length) body = h('div', { className: 'empty' }, '没有符合条件的成交')
+      else body = h('div', null, dates.map(function (date) {
+        return h('div', { key: date },
+          h('div', { className: 'day' }, rel(date), h('span', null, date), h('span', { className: 'n' }, groups[date].length)),
+          groups[date].map(function (t) {
+            var key = t.ticker + t.date + t.shares
+            return h(TraceCell, {
+              key: key,
+              trace: t,
+              open: state.open === key,
+              onToggle: function () { setState(function (c) { return Object.assign({}, c, { open: c.open === key ? null : key }) }) },
+              onKeyDown: function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setState(function (c) { return Object.assign({}, c, { open: c.open === key ? null : key }) }) } },
+            })
+          }))
+      }))
 
-      return h('div', { className: 'dml' },
-        h('div', { className: 'head' },
-          h('div', { className: 'title' },
-            h('h3', null, '决策心智'),
-            h('span', null,
-              state.view === 'ops' ? '操作 ' + (state.portfolio.trades || []).length + ' 笔'
-              : state.view === 'ledger' ? '显示 ' + entries.length + ' / 共 ' + allEntries.length + ' 条'
-              : '持仓 ' + (state.portfolio.books || []).length + ' 组')),
-          h('div', { className: 'seg' },
-            h('button', { className: state.view === 'ops' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ops' }) }) } }, '操作'),
-            h('button', { className: state.view === 'ledger' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'ledger' }) }) } }, '账本'),
-            h('button', { className: state.view === 'portfolio' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { view: 'portfolio' }) }) } }, '持仓')),
-          state.view === 'ledger' ? h('div', { className: 'seg', style: { marginLeft: 8 } },
-            h('button', { className: state.filter === 'trades' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'trades' }) }) } }, '已执行交易 ' + tradesCount),
-            h('button', { className: state.filter === 'all' ? 'on' : '', onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: 'all' }) }) } }, '全部 ' + allEntries.length)) : null),
-        body)
+      var stats = h('div', { className: 'stats' },
+        h('div', { className: 'sg' }, h('span', { className: 'sl' }, '已实现 (USD 等值)'),
+          h('span', { className: 'sv focus ' + (totalUsd >= 0 ? 'up' : 'down') }, (totalUsd >= 0 ? '+' : '') + fmtMoney(totalUsd))),
+        h('div', { className: 'sg' }, h('span', { className: 'sl' }, 'T+1 卖飞/卖对'),
+          h('span', { className: 'sv' }, h('span', { className: 'down' }, fw), ' / ', h('span', { className: 'up' }, ok))),
+        h('div', { className: 'sg' }, h('span', { className: 'sl' }, '决策挂接'), h('span', { className: 'sv' }, matched + '/' + traces.length)),
+        fx ? h('span', { className: 'rate' }, traces.length + ' 笔成交 · @' + fx) : h('span', { className: 'rate' }, traces.length + ' 笔成交'))
+
+      var filters = h('div', { className: 'filters' },
+        ['all', 'miss', 'sold', 'dec'].map(function (f) {
+          var label = { all: '全部', miss: '无决策', sold: '卖出复盘', dec: '挂接决策' }[f]
+          return h('button', { key: f, className: 'ft' + (state.filter === f ? ' on' : ''), onClick: function () { setState(function (c) { return Object.assign({}, c, { filter: f }) }) } }, label)
+        }))
+
+      return h('div', { className: 'dmt' },
+        h('div', { className: 'top' },
+          h('div', { className: 'tt' }, '决策轨迹'),
+          h('div', { className: 'ts' }, '真实成交 × 决策账本 × T+1 结果'),
+          stats,
+          filters),
+        h('div', { className: 'list' }, body))
     }
 
     /** Minimal strict codecs (no zod external in the module table). */
@@ -371,7 +364,7 @@ window.__ModuleLoader__.load({
     /** Client projection of the clawockStudio Remote face, mounted explicitly. */
     var TYPERT_REMOTE = {
       package: 'clawock-dsh',
-      descriptors: ['list', 'get', 'ledger', 'portfolio', 'plans'].map(function (m) { return remoteDescriptor(m) }),
+      descriptors: ['list', 'get', 'ledger', 'portfolio', 'plans', 'traces'].map(function (m) { return remoteDescriptor(m) }),
     }
 
     /** Services required by the registration and the mounted Remote face. */
@@ -396,6 +389,7 @@ window.__ModuleLoader__.load({
               return result.value
             }
             return {
+              traces: function () { return call('traces') },
               ledger: function () { return call('ledger') },
               portfolio: function () { return call('portfolio') },
             }

--- a/examples/dsh/plugin/lib/index.js
+++ b/examples/dsh/plugin/lib/index.js
@@ -9,7 +9,7 @@
 
 import { TypertRemoteService, Remote } from '@deepseek-ai/dsh-typert-protocol'
 import { listRuns, getRun } from './scan.js'
-import { readLedger, readPortfolio, readPlans } from './ledger.js'
+import { readLedger, readPortfolio, readPlans, readTraces } from './ledger.js'
 
 const workspaceOf = () => process.env.CLAWOCK_WORKSPACE || process.cwd()
 
@@ -77,6 +77,16 @@ export class ClawockStudioGateway extends TypertRemoteService {
   plans() {
     return readPlans(workspaceOf())
   }
+
+  /**
+   * The decision-trace view: real fills as the spine with soft-paired
+   * decisions (±3 days) and T+1 verdicts. This is the plugin's single
+   * organic view — the dashboard card renders the same contract.
+   * @returns `{ trades, rate, rateSource, lastUpdated }`.
+   */
+  traces() {
+    return readTraces(workspaceOf())
+  }
 }
 
 markRemote(ClawockStudioGateway, 'list', 'list')
@@ -84,5 +94,6 @@ markRemote(ClawockStudioGateway, 'get', 'get')
 markRemote(ClawockStudioGateway, 'ledger', 'ledger')
 markRemote(ClawockStudioGateway, 'portfolio', 'portfolio')
 markRemote(ClawockStudioGateway, 'plans', 'plans')
+markRemote(ClawockStudioGateway, 'traces', 'traces')
 
 export default ClawockStudioGateway

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -137,3 +137,159 @@ export function readPlans(workspace, limit = 14) {
   }
   return { plans }
 }
+
+/* ------------------------------------------------------------------ */
+/* Decision trace view: the organic "one view" — real fills as the     */
+/* spine, decision ledger soft-paired (±3 days) as the "why" layer,    */
+/* snapshot closes (memory/snapshots/*.json) for T+1 verdicts.         */
+/* ------------------------------------------------------------------ */
+
+const SNAPSHOT_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/
+
+/** Day number for window arithmetic (no Date TZ pitfalls for ISO dates). */
+function dayNum(iso) {
+  if (typeof iso !== 'string') return null
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  if (!m) return null
+  return Number(m[1]) * 400 + Number(m[2]) * 32 + Number(m[3])
+}
+
+/**
+ * Price lookup per ticker across daily snapshots: { ticker: { date: price } }.
+ * Snapshots carry `current_price` per holding; the newest day with a price
+ * after a trade date is its T+1 close.
+ */
+function readSnapshotPrices(workspace) {
+  const byTicker = {}
+  let files = []
+  try {
+    files = readdirSync(join(workspace, 'memory', 'snapshots'))
+  } catch {
+    return byTicker
+  }
+  for (const name of files) {
+    const m = SNAPSHOT_PATTERN.exec(name)
+    if (!m) continue
+    const doc = readJson(join(workspace, 'memory', 'snapshots', name))
+    if (doc === null) continue
+    const portfolios = doc.portfolios ?? {}
+    for (const book of Object.values(portfolios)) {
+      if (book === null || typeof book !== 'object') continue
+      const holdings = Array.isArray(book.holdings) ? book.holdings : []
+      for (const h of holdings) {
+        if (h === null || typeof h !== 'object') continue
+        const ticker = h.ticker
+        const price = h.current_price
+        if (typeof ticker === 'string' && typeof price === 'number') {
+          byTicker[ticker] ??= {}
+          byTicker[ticker][m[1]] = price
+        }
+      }
+    }
+  }
+  return byTicker
+}
+
+/** First close at least `n` trading days after `date` for `ticker`. */
+function futureClose(byTicker, ticker, date, n) {
+  const days = byTicker[ticker]
+  if (!days) return null
+  const base = dayNum(date)
+  if (base === null) return null
+  const later = Object.keys(days).filter((d) => dayNum(d) > base).sort()
+  const hit = later[n - 1]
+  if (hit === undefined) return null
+  return { date: hit, price: days[hit] }
+}
+
+/**
+ * One real fill, enriched for the trace view: the soft-paired decision
+ * (same ticker within ±3 days) and the T+1 close verdict.
+ */
+function enrichTrade(trade, byTicker, decByKey, books) {
+  const out = { ...trade }
+  // T+1 verdict: sell verdicts read "卖飞/卖对", buys read "涨/跌".
+  const t1 = futureClose(byTicker, trade.ticker, trade.date, 1)
+  if (t1 !== null && trade.price) {
+    const delta = ((t1.price - trade.price) / trade.price) * 100
+    out.t1 = {
+      date: t1.date,
+      price: Math.round(t1.price * 100) / 100,
+      delta: Math.round(delta * 100) / 100,
+      verdict: trade.action === 'sell' ? (delta > 1 ? '卖飞' : delta < -1 ? '卖对' : '持平') : (delta > 0 ? '涨' : '跌'),
+    }
+  }
+  // Soft-pair the decision ledger: same ticker, plan date within ±3 days.
+  const key = (tk) => Object.keys(decByKey).filter((k) => k.startsWith(tk + ':'))
+  let best = null
+  let bestDiff = 99
+  for (const k of key(trade.ticker)) {
+    const dt = k.slice(trade.ticker.length + 1)
+    const diff = Math.abs(dayNum(dt) - dayNum(trade.date))
+    if (diff <= 3 && diff < bestDiff) {
+      const rows = decByKey[k]
+      best = rows[rows.length - 1]
+      bestDiff = diff
+    }
+  }
+  if (best) {
+    const subject = best.subject ?? {}
+    const mind = best.mind ?? {}
+    const emotion = best.emotion ?? {}
+    const size = best.size ?? {}
+    const evaluation = best.evaluation ?? {}
+    out.decision = {
+      planDate: best.plan_date ?? (best.decided_at ?? '').slice(0, 10) ?? null,
+      action: best.action ?? null,
+      confidence: best.confidence ?? null,
+      drivenBy: best.driven_by ?? null,
+      rationale: typeof best.rationale === 'string' ? best.rationale : null,
+      thesis: mind.thesis ?? null,
+      invalidation: Array.isArray(mind.invalidation) ? mind.invalidation : [],
+      bull: (mind.bull ?? {}).summary ?? null,
+      bear: (mind.bear ?? {}).summary ?? null,
+      emotion: emotion.pressure ?? null,
+      emotionNote: emotion.note ?? null,
+      execution: (best.execution ?? {}).status ?? null,
+      condition: (best.condition ?? {}).description ?? null,
+      sizeShares: size.shares ?? null,
+      sizePct: size.pct ?? null,
+      plannedPrice: evaluation.execution_price ?? best.simulated_entry_price ?? null,
+      source: best.source ?? 'brief',
+    }
+  }
+  // Current position P&L (live data) for still-held tickers.
+  const held = books.find((b) => b.holdings.some((h) => h.ticker === trade.ticker))
+  const row = held?.holdings.find((h) => h.ticker === trade.ticker)
+  if (row) out.holdPnl = row.pnlPct
+  return out
+}
+
+/**
+ * The decision trace data: every real fill as a trace node with its
+ * soft-paired decision and T+1 verdict, newest first. This is the organic
+ * view the plugin shows — one list, one spine (real fills), decisions as
+ * the "why" layer, no parallel tabs.
+ * @param workspace - desk workspace root.
+ * @returns `{ trades, rate, rateSource, lastUpdated }` — `trades` is the
+ *          enriched fill list; `rate` is the USD/HKD FX rate when the desk
+ *          published one in portfolio.json market_context (else null).
+ */
+export function readTraces(workspace) {
+  const { books, trades, lastUpdated } = readPortfolio(workspace)
+  const byTicker = readSnapshotPrices(workspace)
+  const decByKey = {}
+  const { entries } = readLedger(workspace)
+  for (const e of entries) {
+    const tk = e.ticker ?? (e.subject ?? {}).ticker
+    const dt = e.plan_date ?? (e.decided_at ?? '').slice(0, 10)
+    if (typeof tk !== 'string' || typeof dt !== 'string' || !dt) continue
+    decByKey[tk + ':' + dt] ??= []
+    decByKey[tk + ':' + dt].push(e)
+  }
+  const enriched = trades.map((t) => enrichTrade(t, byTicker, decByKey, books))
+  const doc = readJson(join(workspace, 'portfolio.json'))
+  const marketContext = doc?.market_context ?? {}
+  const rate = typeof marketContext.usdhk_rate === 'number' ? marketContext.usdhk_rate : null
+  return { trades: enriched, rate, rateSource: marketContext.usdhk_source ?? null, lastUpdated }
+}

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2162,3 +2162,53 @@
     .bucket-row .stat { grid-column: 2; grid-row: 1; }
     .catalyst-row { grid-template-columns: 64px minmax(64px, auto) minmax(0, 1fr); }
   }
+
+/* =========================================================
+   Decision traces — real fills as the spine with soft-paired
+   decisions and T+1 verdicts (public mirror of the DSH plugin)
+   ========================================================= */
+#decision-traces-card { font-size: 13px; }
+#trace-stats b { font-variant-numeric: tabular-nums; }
+.tr-row { border: 1px solid var(--border); border-radius: 10px; background: var(--surface); margin: 6px 0; overflow: hidden; }
+.tr-row summary { display: flex; align-items: center; gap: 10px; padding: 10px 14px; cursor: pointer; list-style: none; }
+.tr-row summary::-webkit-details-marker { display: none; }
+.tr-row summary:hover { background: var(--hover-bg, rgba(0,0,0,0.03)); }
+.tr-row[open] { border-color: var(--accent); }
+.tr-row[open] summary::after { transform: rotate(180deg); }
+.tr-row summary::after { content: '▾'; color: var(--text-dim); font-size: 10px; margin-left: auto; transition: transform 0.15s; }
+.tr-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--border-strong, var(--text-dim)); flex: none; }
+.tr-dot.has { background: var(--accent); }
+.tr-tk { font-weight: 700; font-size: 13.5px; }
+.tr-act { font-size: 11.5px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
+.tr-act.pos { color: var(--pos); background: color-mix(in srgb, var(--pos) 12%, transparent); }
+.tr-act.neg { color: var(--neg); background: color-mix(in srgb, var(--neg) 12%, transparent); }
+.tr-act.muted { color: var(--text-dim); background: var(--bg-soft, rgba(0,0,0,0.04)); }
+.tr-qty { color: var(--text-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+.tr-spacer { flex: 1; }
+.tr-t1 { font-size: 11px; font-weight: 700; padding: 2px 7px; border-radius: 5px; white-space: nowrap; }
+.tr-t1.pos { color: var(--pos); background: color-mix(in srgb, var(--pos) 10%, transparent); }
+.tr-t1.neg { color: var(--neg); background: color-mix(in srgb, var(--neg) 10%, transparent); }
+.tr-pnl { font-weight: 700; font-size: 15px; font-variant-numeric: tabular-nums; min-width: 88px; text-align: right; }
+.tr-pnl.pos { color: var(--pos); } .tr-pnl.neg { color: var(--neg); }
+.tr-body { padding: 4px 14px 12px; border-top: 1px solid var(--border); background: var(--surface-soft, rgba(0,0,0,0.015)); }
+.trace-line { position: relative; padding-left: 20px; margin: 8px 0 4px; }
+.trace-line::before { content: ''; position: absolute; left: 5px; top: 8px; bottom: 8px; width: 2px; background: var(--border); }
+.tr-node { position: relative; padding: 3px 0 10px; }
+.tr-node::before { content: ''; position: absolute; left: -20px; top: 7px; width: 9px; height: 9px; border-radius: 50%; background: var(--surface); border: 2px solid var(--text-dim); }
+.tr-node.dec::before { border-color: var(--accent); }
+.tr-node.ok::before { border-color: var(--pos); }
+.tr-node.skip::before { border-color: var(--accent-strong); }
+.tr-node.pos::before { border-color: var(--pos); }
+.tr-node.neg::before { border-color: var(--neg); }
+.tr-n { font-size: 10.5px; font-weight: 700; letter-spacing: 0.05em; color: var(--text-dim); text-transform: uppercase; }
+.tr-v { font-size: 12.5px; font-weight: 600; margin-top: 2px; }
+.tr-v.pos { color: var(--pos); } .tr-v.neg { color: var(--neg); } .tr-v.ok { color: var(--pos); } .tr-v.skip { color: var(--accent-strong); }
+.tr-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0 8px; }
+.tr-chip { font-size: 11px; padding: 2px 8px; border-radius: 6px; background: var(--bg-soft, rgba(0,0,0,0.04)); border: 1px solid var(--border); color: var(--text-dim); }
+.tr-note { margin: 6px 0; padding: 3px 0 3px 10px; border-left: 3px solid var(--border); font-size: 12px; color: var(--text-secondary); line-height: 1.6; white-space: pre-wrap; overflow-wrap: anywhere; }
+.tr-note.why { border-left-color: var(--accent); }
+.tr-note.emo { border-left-color: var(--accent-strong); }
+.tr-miss { margin: 8px 0; padding: 7px 10px; border: 1px dashed var(--border); border-radius: 6px; font-size: 11.5px; color: var(--text-dim); }
+.trace-day { margin-bottom: 14px; }
+.trace-day-h { font-size: 11px; font-weight: 700; color: var(--text-dim); letter-spacing: 0.05em; margin: 10px 0 6px; display: flex; align-items: center; gap: 6px; }
+.trace-day-h::after { content: ''; flex: 1; height: 1px; background: var(--border); }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -356,7 +356,7 @@
     reflect: [
       renderBehavioralReview, renderDecisionAudit, renderCalibBadge,
       renderPlanReview, renderCalibByTrigger, renderCalibByDriver,
-      renderReflectKpi, renderDelta,
+      renderDecisionTraces, renderReflectKpi, renderDelta,
     ],
   };
   let RENDER_VERSION = 0;
@@ -2756,6 +2756,114 @@
             ${fmtPnl(a.benefit_t1_pct)}
           </div>
         </div>`;
+    }).join("");
+  }
+
+  // =========================================================
+  // Decision traces: real fills as the spine, soft-paired decisions
+  // as the "why", T+1 closes as the result. Same contract as the DSH
+  // plugin view — this card is the public mirror.
+  // =========================================================
+  function renderDecisionTraces() {
+    const wrap = document.getElementById("trace-list");
+    if (!wrap) return;
+    const card = wrap.closest(".card");
+    const list = safe(DATA, "decision_traces") || [];
+    if (!list.length) { if (card) card.style.display = "none"; return; }
+    if (card) card.style.display = "";
+    const ACT = {buy:"买入",add:"加仓",trim:"减仓",sell:"卖出",cut:"割肉",hold:"持有",hold_and_watch:"持有",trim_on_rebound:"反弹减仓",t_only:"仅T+0",add_only_on_trigger:"触发加仓",reject:"不加",watch:"观望",abstain:"弃权"};
+    const DRV = {technical:"技术面",fundamental:"基本面",sentiment:"情绪面",mixed:"混合",risk_rule:"风控规则"};
+    const EXE = {followed:["已遵守","ok"],not_followed:["未执行","skip"],unknown:["未知","na"]};
+    const EMO = {fomo:"追高冲动",revenge:"报复性",averaging_down:"摊薄冲动",fear:"恐慌",euphoria:"亢奋",calm:"平静",mixed:"混合"};
+    const esc = escapeHtml;
+
+    // Stats row: USD-eq realized + T+1 verdict counts + match rate.
+    const usd = list.filter(t => t.realizedPnl != null && t.currency === "USD").reduce((s,t) => s + t.realizedPnl, 0);
+    const hkd = list.filter(t => t.realizedPnl != null && t.currency === "HKD").reduce((s,t) => s + t.realizedPnl, 0);
+    const fx = safe(DATA, "fx", "usdhkd");
+    const totalUsd = usd + (fx ? hkd / fx : 0);
+    const fw = list.filter(t => t.t1 && t.t1.verdict === "卖飞").length;
+    const ok = list.filter(t => t.t1 && t.t1.verdict === "卖对").length;
+    const matched = list.filter(t => t.decision).length;
+    const statsEl = document.getElementById("trace-stats");
+    if (statsEl) {
+      statsEl.innerHTML =
+        `<span>已实现 <b class="${totalUsd >= 0 ? "pos" : "neg"}">${fmtMoney(totalUsd, "USD")}</b> <span class="muted">USD等值</span></span>` +
+        `<span class="muted">(US ${fmtMoney(usd, "USD")} + HK ${fmtMoney(hkd, "HKD")})</span>` +
+        `<span>T+1 <b class="neg">${fw}</b>卖飞 / <b class="pos">${ok}</b>卖对</span>` +
+        `<span>挂接 <b>${matched}</b>/${list.length}</span>` +
+        (fx ? `<span class="muted">@${fx}</span>` : "");
+    }
+
+    // Group by date, newest first; each fill is an expandable trace row.
+    const groups = {};
+    list.forEach(t => { const k = (t.date || "").slice(0,10); (groups[k] = groups[k] || []).push(t); });
+    const dates = Object.keys(groups).sort().reverse();
+
+    function traceHTML(t) {
+      const d = t.decision;
+      const sym = t.currency === "HKD" ? "HK$" : "$";
+      if (!d) {
+        let t1 = "";
+        if (t.t1) t1 = `<div class="tr-node ${t.t1.delta >= 0 ? "neg" : "pos"}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}</div></div>`;
+        return `<div class="trace-line">
+          <div class="tr-node dec"><div class="tr-n">决策</div><div class="tr-v muted">无关联记录</div></div>
+          <div class="tr-node ok"><div class="tr-n">执行</div><div class="tr-v">${esc(ACT[t.action] || t.action)} ${t.shares}股 @${t.price} ${sym}</div></div>
+          ${t1}
+        </div>${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}
+        <div class="tr-miss">此笔无关联决策记录 — 事实保留,判断缺失显式标出</div>`;
+      }
+      const exe = EXE[d.execution] || ["未知","na"];
+      const decV = `${ACT[d.action] || d.action}${d.confidence != null ? " " + Math.round(d.confidence*100) + "%" : ""} <span class="muted">${DRV[d.drivenBy] || d.drivenBy || ""}</span>`;
+      const why = d.rationale || d.bull || "";
+      const emo = d.emotion && d.emotion !== "calm" ? (EMO[d.emotion] || d.emotion) : null;
+      let chips = "";
+      if (d.condition) chips += `<span class="tr-chip">条件: ${esc(d.condition)}</span>`;
+      if (d.sizeShares) chips += `<span class="tr-chip">计划 ${d.sizeShares} 股</span>`;
+      if (d.plannedPrice) chips += `<span class="tr-chip">计划价 ${d.plannedPrice}</span>`;
+      let t1 = "";
+      if (t.t1) t1 = `<div class="tr-node ${t.t1.delta >= 0 ? "neg" : "pos"}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}${t.action === "sell" ? " · " + t.t1.verdict : ""}</div></div>`;
+      let rv, rc;
+      if (t.realizedPnl != null) { rv = (t.realizedPnl >= 0 ? "+" : "") + Number(t.realizedPnl).toFixed(2) + " " + sym; rc = t.realizedPnl >= 0 ? "pos" : "neg"; }
+      else if (t.holdPnl != null) { rv = fmtPct(t.holdPnl, 1); rc = t.holdPnl >= 0 ? "pos" : "neg"; }
+      else { rv = DASH; rc = "na"; }
+      return `<div class="trace-line">
+        <div class="tr-node dec"><div class="tr-n">计划 · ${esc(d.planDate || "")}</div><div class="tr-v">${decV}</div></div>
+        <div class="tr-node ${exe[1]}"><div class="tr-n">执行</div><div class="tr-v">${exe[0]}${exe[1] === "skip" ? " — 实际动了手" : ""}</div></div>
+        ${t1}
+        <div class="tr-node ${rc}"><div class="tr-n">盈亏</div><div class="tr-v">${rv}</div></div>
+      </div>
+      ${chips ? `<div class="tr-chips">${chips}</div>` : ""}
+      ${why ? `<div class="tr-note why">${esc(why)}</div>` : ""}
+      ${emo ? `<div class="tr-note emo">⚡ ${esc(emo)}</div>` : ""}
+      ${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}`;
+    }
+
+    wrap.innerHTML = dates.map(date => {
+      const rows = groups[date];
+      return `<div class="trace-day"><div class="trace-day-h">${esc(date)} <span class="muted">${rows.length}</span></div>
+        ${rows.map(t => {
+          const tone = t.action === "buy" || t.action === "add" ? "pos" : (t.action === "sell" || t.action === "cut" || t.action === "trim" ? "neg" : "muted");
+          const pnl = t.realizedPnl != null
+            ? `<span class="tr-pnl ${t.realizedPnl >= 0 ? "pos" : "neg"}">${t.realizedPnl >= 0 ? "+" : ""}${Number(t.realizedPnl).toFixed(2)} ${t.currency === "HKD" ? "HK$" : "$"}</span>`
+            : (t.holdPnl != null ? `<span class="tr-pnl ${t.holdPnl >= 0 ? "pos" : "neg"}">${fmtPct(t.holdPnl, 1)}</span>` : "");
+          const t1tag = t.t1
+            ? `<span class="tr-t1 ${t.t1.delta >= 0 ? "neg" : "pos"}">T+1 ${fmtPct(t.t1.delta, 1)} ${t.t1.verdict}</span>`
+            : "";
+          return `<details class="tr-row">
+            <summary>
+              <span class="tr-dot ${t.decision ? "has" : ""}"></span>
+              <span class="tr-tk">${esc(t.ticker)}</span>
+              <span class="tr-act ${tone}">${esc(ACT[t.action] || t.action)}</span>
+              <span class="tr-qty">${t.shares} @${t.price}</span>
+              <span class="tr-spacer"></span>
+              ${t1tag}
+              ${pnl}
+            </summary>
+            <div class="tr-body">${traceHTML(t)}</div>
+          </details>`;
+        }).join("")}
+      </div>`;
     }).join("");
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -780,6 +780,15 @@ layout: null
       <div id="chart-ai-winrate" class="chart-box" style="height:210px;min-height:210px"></div>
     </div>
 
+    <div class="sect-divider">决策轨迹 · 真实成交 vs 当时计划</div>
+
+    <div class="card" id="decision-traces-card">
+      <h3>决策轨迹 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">真实成交为轴 · 软配对决策(±3日)为「为什么」 · T+1 收盘判卖飞/卖对</span></h3>
+      <p class="chart-hint">每一笔成交是一条可点开的轨迹：当时计划(动作/信心/条件)、执行(是否遵守)、T+1 结果、已实现盈亏。无关联决策的成交显式标注——不假装有判断。币种分别计(HKD/USD 不混加)。</p>
+      <div id="trace-stats" style="display:flex;gap:24px;flex-wrap:wrap;margin:8px 0 12px;font-size:12px"></div>
+      <div id="trace-list"></div>
+    </div>
+
     <div class="sect-divider">净值表现 · portfolio</div>
 
     <div class="card">

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -671,7 +671,7 @@ def _snapshot_close_index(workspace=None):
     return index
 
 
-def build_decision_traces(limit=60, workspace=None):
+def build_decision_traces(limit=40, workspace=None):
     """The decision-trace view data: every real fill as a trace node with its
     soft-paired decision (±3 days, same ticker) and T+1 close verdict.
 
@@ -764,7 +764,9 @@ def build_decision_traces(limit=60, workspace=None):
                         'action': best.get('action'),
                         'confidence': best.get('confidence'),
                         'drivenBy': best.get('driven_by'),
-                        'rationale': best.get('rationale') if isinstance(best.get('rationale'), str) else None,
+                        'rationale': (best.get('rationale')[:140] + '…')
+                        if isinstance(best.get('rationale'), str) and len(best.get('rationale')) > 140
+                        else (best.get('rationale') if isinstance(best.get('rationale'), str) else None),
                         'thesis': mind.get('thesis'),
                         'invalidation': mind.get('invalidation') if isinstance(mind.get('invalidation'), list) else [],
                         'bull': (mind.get('bull') or {}).get('summary'),
@@ -2984,7 +2986,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     # Decision trace view: real fills as the spine with soft-paired decisions
     # and T+1 verdicts. Same contract the DSH plugin renders; the dashboard
     # card is the public mirror. Pure read of portfolio.json + ledger + snaps.
-    out['decision_traces'] = build_decision_traces(limit=60)
+    out['decision_traces'] = build_decision_traces(limit=40)
     out['debate_metrics'] = compute_debate_metrics()
     out['plan_timeline'] = compute_plan_timeline(plans, limit=15)
     out['weight_confidence'] = compute_weight_confidence(portfolio)

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -619,6 +619,172 @@ def _canonical_ledger():
     return _LEDGER_CACHE
 
 
+def _day_num(iso):
+    """Day number for window arithmetic; None for unparsable values."""
+    if not isinstance(iso, str):
+        return None
+    m = re.match(r'^(\d{4})-(\d{2})-(\d{2})', iso)
+    if not m:
+        return None
+    return int(m[1]) * 400 + int(m[2]) * 32 + int(m[3])
+
+
+def _future_close(prices_by_ticker, ticker, date_iso, n=1):
+    """First snapshot close at least n trading days after date_iso, or None."""
+    days = prices_by_ticker.get(ticker)
+    if not days:
+        return None
+    base = _day_num(date_iso)
+    if base is None:
+        return None
+    later = sorted(d for d in days if _day_num(d) > base)
+    if len(later) < n:
+        return None
+    return later[n - 1], days[later[n - 1]]
+
+
+def _snapshot_close_index(workspace=None):
+    """{ticker: {date: current_price}} from memory/snapshots/*.json (all files,
+    not just the embedded window — T+1 verdicts need older closes too)."""
+    index = {}
+    ws = workspace or WS_ROOT
+    paths = sorted(glob.glob(str(ws / 'memory' / 'snapshots' / '*.json')))
+    for p in paths:
+        name = os.path.basename(p)
+        if not SNAPSHOT_FNAME_RE.match(name):
+            continue
+        d = load_json(p)
+        if not d:
+            continue
+        date_key = name.split('.')[0].split('-')
+        date_key = '-'.join(date_key[:3]) if len(date_key) >= 3 else name
+        for book in (d.get('portfolios') or {}).values():
+            if not isinstance(book, dict):
+                continue
+            for h in (book.get('holdings') or []):
+                if not isinstance(h, dict):
+                    continue
+                tk = h.get('ticker')
+                price = h.get('current_price')
+                if isinstance(tk, str) and isinstance(price, (int, float)):
+                    index.setdefault(tk, {})[date_key] = price
+    return index
+
+
+def build_decision_traces(limit=60, workspace=None):
+    """The decision-trace view data: every real fill as a trace node with its
+    soft-paired decision (±3 days, same ticker) and T+1 close verdict.
+
+    This is the organic "one view" the DSH plugin and this dashboard card both
+    render: the spine is real fills (portfolio.json trades[]), the "why" layer
+    is the decision ledger, the result is the T+1 close (snapshot prices).
+    Pure read — never mutates portfolio.json or the ledger.
+    @param workspace - desk root; defaults to the module WS_ROOT (used by the
+                       real build). Tests pass a synthetic temp dir.
+    @returns list of trace dicts, newest first, capped at `limit`.
+    """
+    ws = workspace or WS_ROOT
+    # Prices first (needed for T+1 verdicts).
+    prices = _snapshot_close_index(ws)
+    # Decision ledger by ticker+date (last row wins on same-key collisions).
+    decisions = decision_v2.load_decisions(ws / 'memory' / 'decisions.jsonl')
+    dec_by_key = {}
+    for e in decisions:
+        tk = e.get('ticker') or (e.get('subject') or {}).get('ticker')
+        dt = e.get('plan_date') or (e.get('decided_at') or '')[:10]
+        if isinstance(tk, str) and isinstance(dt, str) and dt:
+            dec_by_key[tk + ':' + dt] = e
+    # Portfolio doc (single read, used for holdings/trades/positions).
+    pf_doc = load_json(str(ws / 'portfolio.json')) or {}
+    # Current-position P&L lookup for still-held tickers.
+    held_pnl = {}
+    for book in (pf_doc.get('portfolios') or {}).values():
+        if not isinstance(book, dict):
+            continue
+        for h in (book.get('holdings') or []):
+            if not isinstance(h, dict):
+                continue
+            if (h.get('shares') or h.get('quantity') or 0) > 0 and h.get('pnl_percent') is not None:
+                held_pnl[h.get('ticker')] = h.get('pnl_percent')
+    # Flatten all trades with market/currency context.
+    traces = []
+    for leg in resolve_legs(pf_doc):
+        for h in (pf_doc.get('portfolios') or {}).get(leg.bucket, {}).get('holdings', []):
+            if not isinstance(h, dict):
+                continue
+            ticker = h.get('ticker')
+            for tr in (h.get('trades') or []):
+                if not isinstance(tr, dict) or not isinstance(tr.get('date'), str):
+                    continue
+                t = {
+                    'ticker': ticker,
+                    'market': leg.key,
+                    'currency': leg.currency,
+                    'date': tr.get('date'),
+                    'action': tr.get('action') or 'buy',
+                    'shares': tr.get('shares') or 0,
+                    'price': tr.get('price'),
+                    'realizedPnl': tr.get('realized_pnl'),
+                    'note': tr.get('note') if isinstance(tr.get('note'), str) else None,
+                    't1': None,
+                    'decision': None,
+                    'holdPnl': None,
+                }
+                # T+1 verdict.
+                fc = _future_close(prices, ticker, t['date'], 1)
+                if fc and t.get('price'):
+                    delta = (fc[1] - t['price']) / t['price'] * 100
+                    t['t1'] = {
+                        'date': fc[0],
+                        'price': round(fc[1], 2),
+                        'delta': round(delta, 2),
+                        'verdict': ('卖飞' if delta > 1 else '卖对' if delta < -1 else '持平')
+                        if t['action'] == 'sell' else ('涨' if delta > 0 else '跌'),
+                    }
+                # Soft-pair the decision ledger (±3 days).
+                base = _day_num(t['date'])
+                best = None
+                best_diff = 99
+                prefix = (ticker or '') + ':'
+                for key, e in dec_by_key.items():
+                    if not key.startswith(prefix):
+                        continue
+                    diff = abs(_day_num(key[len(prefix):]) - base)
+                    if diff <= 3 and diff < best_diff:
+                        best = e
+                        best_diff = diff
+                if best:
+                    subject = best.get('subject') or {}
+                    mind = best.get('mind') or {}
+                    emotion = best.get('emotion') or {}
+                    size = best.get('size') or {}
+                    evaluation = best.get('evaluation') or {}
+                    t['decision'] = {
+                        'planDate': best.get('plan_date') or (best.get('decided_at') or '')[:10],
+                        'action': best.get('action'),
+                        'confidence': best.get('confidence'),
+                        'drivenBy': best.get('driven_by'),
+                        'rationale': best.get('rationale') if isinstance(best.get('rationale'), str) else None,
+                        'thesis': mind.get('thesis'),
+                        'invalidation': mind.get('invalidation') if isinstance(mind.get('invalidation'), list) else [],
+                        'bull': (mind.get('bull') or {}).get('summary'),
+                        'bear': (mind.get('bear') or {}).get('summary'),
+                        'emotion': emotion.get('pressure'),
+                        'emotionNote': emotion.get('note'),
+                        'execution': (best.get('execution') or {}).get('status'),
+                        'condition': (best.get('condition') or {}).get('description'),
+                        'sizeShares': size.get('shares'),
+                        'sizePct': size.get('pct'),
+                        'plannedPrice': evaluation.get('execution_price') or best.get('simulated_entry_price'),
+                        'source': best.get('source') or 'brief',
+                    }
+                if ticker in held_pnl:
+                    t['holdPnl'] = held_pnl[ticker]
+                traces.append(t)
+    traces.sort(key=lambda t: (t.get('date') or ''), reverse=True)
+    return traces[:limit]
+
+
 def load_snapshots():
     """Returns recent-N snapshot summaries (NOT full holdings). Capped at MAX_SNAPSHOTS_EMBEDDED.
 
@@ -2815,6 +2981,10 @@ def build_projection(previous_source=None, shadow_previous=None):
     # function stays for the rebuild (see the official-bars task) — the field goes.
     out['decision_delta'] = decision_v2.decision_delta(_decisions)
     out['recent_decisions'] = decision_v2.recent_decisions(_decisions, limit=20)
+    # Decision trace view: real fills as the spine with soft-paired decisions
+    # and T+1 verdicts. Same contract the DSH plugin renders; the dashboard
+    # card is the public mirror. Pure read of portfolio.json + ledger + snaps.
+    out['decision_traces'] = build_decision_traces(limit=60)
     out['debate_metrics'] = compute_debate_metrics()
     out['plan_timeline'] = compute_plan_timeline(plans, limit=15)
     out['weight_confidence'] = compute_weight_confidence(portfolio)

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -206,6 +206,7 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
     ledger: async () => ({ ok: true, value: { entries: [] } }),
     portfolio: async () => ({ ok: true, value: { books: [] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
+    traces: async () => ({ ok: true, value: { trades: [], rate: null } }),
   };
   const ctx = {
     effect() {},
@@ -214,7 +215,7 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
       inject(name, fn) { assert.equal(name, "conversation.view"); this._fn = fn; },
       register(definition, Component) { registered = definition; component = Component; },
     },
-    remote: { $mount: async (descriptors) => { assert.equal(descriptors.descriptors.length, 5); } },
+    remote: { $mount: async (descriptors) => { assert.equal(descriptors.descriptors.length, 6); } },
   };
   await api.apply(ctx);
   ctx.slots._fn();
@@ -223,13 +224,13 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
   assert.equal(registered.label(), "Decision Mind");
 
   const injected = registered.inject("s1");
+  assert.equal(typeof injected.traces, "function");
   assert.equal(typeof injected.ledger, "function");
-  assert.equal(typeof injected.portfolio, "function");
-  assert.deepEqual(await injected.ledger(), { entries: [] });
+  assert.deepEqual(await injected.traces(), { trades: [], rate: null });
   assert.equal(typeof component, "function");
 });
 
-test("client: _displayEntry projects mind records and degrades legacy entries", async () => {
+test("client: _displayEntry projects a trace with its decision and T+1", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
     if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
@@ -237,31 +238,30 @@ test("client: _displayEntry projects mind records and degrades legacy entries", 
     throw new Error(`unexpected require: ${s}`);
   });
 
-  const conv = api._displayEntry({
-    decision_id: "dec-1", source: "conversation",
-    subject: { ticker: "00100", market: "HK", currency: "HKD" },
-    decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
-    mind: { bull: { summary: "b" }, bear: { summary: "r" }, thesis: "t", invalidation: ["c1"] },
-    emotion: { pressure: "averaging_down", note: "忍住" },
-    execution: { status: "unknown" },
+  const withDec = api._displayEntry({
+    ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13",
+    action: "sell", shares: 5, price: 50, realizedPnl: 45.21, note: "清仓",
+    t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对" },
+    decision: { planDate: "2026-08-10", action: "trim_on_rebound", confidence: 0.6,
+      drivenBy: "technical", rationale: "浮盈保护", execution: "followed",
+      condition: "反弹至 50 减仓" },
   });
-  assert.equal(conv.ticker, "00100");
-  assert.equal(conv.action, "reject");
-  assert.equal(conv.emotion, "averaging_down");
-  assert.deepEqual(conv.invalidation, ["c1"]);
+  assert.equal(withDec.ticker, "PLTU");
+  assert.equal(withDec.realizedPnl, 45.21);
+  assert.equal(withDec.t1.verdict, "卖对");
+  assert.equal(withDec.decision.action, "trim_on_rebound");
 
-  const legacy = api._displayEntry({
-    decision_id: "dec-2", plan_date: "2026-08-10", ticker: "00100",
-    action: "trim_on_rebound", confidence: 0.7,
-    condition: { description: "跌破 730" }, evaluation: { outcome: "not_triggered" },
+  const bare = api._displayEntry({
+    ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15",
+    action: "buy", shares: 10, price: 8.77, realizedPnl: null,
   });
-  assert.equal(legacy.bull, null);
-  assert.equal(legacy.condition, "跌破 730");
-  assert.equal(legacy.outcome, "not_triggered");
-  assert.equal(legacy.emotion, null);
+  assert.equal(bare.ticker, "SPCH");
+  assert.equal(bare.decision, null);
+  assert.equal(bare.t1, null);
+  assert.equal(bare.realizedPnl, null);
 });
 
-test("client: renders ledger cards from the mounted remote", async () => {
+test("client: renders the single decision-trace view from the mounted remote", async () => {
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
     if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
@@ -272,26 +272,25 @@ test("client: renders ledger cards from the mounted remote", async () => {
   let registered = null;
   let component = null;
   const remoteFace = {
-    ledger: async () => ({ ok: true, value: { entries: [
-      { decision_id: "dec-1", source: "conversation", subject: { ticker: "00100" },
-        decided_at: "2026-08-16T13:45:00+08:00", action: "reject", confidence: 0.65,
-        mind: { bull: { summary: "营收 +159%" }, bear: { summary: "资不抵债" }, invalidation: ["站回 340"] },
-        emotion: { pressure: "averaging_down", note: "忍住没加" },
-        execution: { status: "followed" } },
-      { decision_id: "dec-2", plan_date: "2026-08-10", ticker: "07226", action: "hold", confidence: 0.5,
-        rationale: "测试理由: 杠杆风险已释放,持有观察",
-        execution: { status: "followed" } },
-      { decision_id: "dec-3", plan_date: "2026-08-11", ticker: "02208", action: "cut", confidence: 0.6,
-        size: { shares: 30, pct: 0.15 }, simulated_entry_price: 10.5,
-        execution: { status: "followed" } },
-      { decision_id: "dec-4", plan_date: "2026-08-12", ticker: "03032", action: "trim", confidence: 0.4,
-        execution: { status: "unknown" } },
-    ] } }),
-    portfolio: async () => ({ ok: true, value: { books: [{ name: "hk_stocks", currency: "HKD", holdings: [{ ticker: "02208", shares: 200, price: 10.58, pnlPct: -24.9 }] }], trades: [
-      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15", action: "buy", shares: 10, price: 8.77, realizedPnl: null, note: "无限子弹流继续摊本(用户报告成交,微信 00:26 HKT)" },
-      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-07", action: "buy", shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)" },
-      { ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13", action: "sell", shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓" },
-    ] } }),
+    traces: async () => ({ ok: true, value: { trades: [
+      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15", action: "buy",
+        shares: 10, price: 8.77, realizedPnl: null, note: "无限子弹流继续摊本(微信 00:26 HKT)",
+        t1: null, holdPnl: -28.0,
+        decision: { planDate: "2026-08-14", action: "cut", confidence: 0.82,
+          drivenBy: "risk_rule", rationale: "超限硬止损", execution: "unknown",
+          sizeShares: 200, plannedPrice: 9.21 } },
+      { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-07", action: "buy",
+        shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)",
+        t1: { date: "2026-08-10", price: 5.6, delta: -4.76, verdict: "跌" } },
+      { ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13", action: "sell",
+        shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓",
+        t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对" },
+        decision: { planDate: "2026-08-10", action: "trim_on_rebound", confidence: 0.6,
+          drivenBy: "technical", rationale: "浮盈保护", execution: "followed",
+          condition: "反弹至 50 减仓" } },
+    ], rate: 7.8473 } }),
+    ledger: async () => ({ ok: true, value: { entries: [] } }),
+    portfolio: async () => ({ ok: true, value: { books: [] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
   };
   const ctx = {
@@ -308,29 +307,37 @@ test("client: renders ledger cards from the mounted remote", async () => {
   const injected = registered.inject("s1");
 
   const tick = () => new Promise((resolve) => setImmediate(resolve));
-  let tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  let tree = component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
   await tick(); await tick(); await tick();
-  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  tree = component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
 
-  const text = [];
-  (function walk(node) {
-    if (node == null) return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (typeof node === "string") { text.push(node); return; }
-    (node.children || []).forEach(walk);
-    walk(node.props && node.props.value);
-    walk(node.props && node.props.label);
-  })(tree);
-  const joined = text.join(" ");
-  assert.match(joined, /决策心智/);
-  // default view = actual operations (real fills), newest first
+  const collectText = () => {
+    const text = [];
+    (function walk(node) {
+      if (node == null) return;
+      if (Array.isArray(node)) { node.forEach(walk); return; }
+      if (typeof node === "string") { text.push(node); return; }
+      (node.children || []).forEach(walk);
+      walk(node.props && node.props.value);
+      walk(node.props && node.props.label);
+    })(tree);
+    return text.join(" ");
+  };
+
+  // Single view: title + stats + all fills as trace rows.
+  const joined = collectText();
+  assert.match(joined, /决策轨迹/);
+  assert.match(joined, /已实现 \(USD 等值\)/);
+  assert.match(joined, /T\+1 卖飞\/卖对/);
   assert.match(joined, /SPCH/);
-  assert.match(joined, /加仓/);
-  assert.match(joined, /10 股 @8.77/);
+  assert.match(joined, /买入/);
+  assert.match(joined, /10 @8.77/);
   assert.match(joined, /PLTU/);
-  assert.match(joined, /清仓/);
-  assert.match(joined, /\+45.21/); // realized P&L on the real sell
+  assert.match(joined, /卖出/);
+  assert.match(joined, /\+45.21/);       // realized P&L on the real sell
+  assert.match(joined, /卖对/);           // T+1 verdict chip
 
+  // Filter: 无决策 keeps only SPCH fills without a decision.
   const findButton = (label) => {
     let found = null;
     (function collect(node) {
@@ -344,76 +351,31 @@ test("client: renders ledger cards from the mounted remote", async () => {
     })(tree);
     return found;
   };
-
-  // switch to 账本: executed-trades filter with counts
-  findButton("账本").props.onClick();
+  findButton("无决策").props.onClick();
   await tick();
-  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
-  const textL = [];
-  (function walk(node) {
-    if (node == null) return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (typeof node === "string") { textL.push(node); return; }
-    (node.children || []).forEach(walk);
-    walk(node.props && node.props.value);
-    walk(node.props && node.props.label);
-  })(tree);
-  const joinedL = textL.join(" ");
-  assert.match(joinedL, /已执行交易 1/); // count on the filter button
-  assert.match(joinedL, /全部 4/);
-  assert.match(joinedL, /02208/);
-  assert.match(joinedL, /割肉/);
-  assert.match(joinedL, /30 股 @10.5/);   // executed how much
-  assert.match(joinedL, /现盈亏 -24.9%/); // and what it is worth now
-  assert.doesNotMatch(joinedL, /00100/);
-  assert.doesNotMatch(joinedL, /03032/);
+  tree = component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
+  const joinedMiss = collectText();
+  assert.match(joinedMiss, /SPCH/);
+  assert.doesNotMatch(joinedMiss, /PLTU/); // PLTU has a decision → filtered out
 
-  // switch to 全部: everything appears — reject with bull-fallback why, hold with rationale why, unknown trim
+  // Expand a row: the trace detail shows plan → execution → P&L.
   findButton("全部").props.onClick();
   await tick();
-  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
-  const textB = [];
-  (function walk(node) {
-    if (node == null) return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (typeof node === "string") { textB.push(node); return; }
-    (node.children || []).forEach(walk);
-    walk(node.props && node.props.value);
-    walk(node.props && node.props.label);
-  })(tree);
-  const joinedB = textB.join(" ");
-  assert.match(joinedB, /00100/);
-  assert.match(joinedB, /不加/);
-  assert.match(joinedB, /为什么: 营收/);     // conversation record: bull-fallback why
-  assert.match(joinedB, /为什么: 测试理由/); // plan record: rationale why
-  assert.match(joinedB, /07226/);
-  assert.match(joinedB, /03032/);
-  assert.match(joinedB, /· 对话/);           // conversation day tag
-
-  // click a ledger card row: expand shows the mind detail
-  const cardRows = [];
+  tree = component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
+  const cell = [];
   (function collect(node) {
     if (node == null) return;
     if (Array.isArray(node)) { node.forEach(collect); return; }
-    if (node.props && node.props.onClick && node.props.className === "row") cardRows.push(node);
+    if (node.props && node.props.onClick && String(node.props.className || "").indexOf("cell") === 0) cell.push(node);
     (node.children || []).forEach(collect);
   })(tree);
-  assert.ok(cardRows.length >= 2, "expanded ledger cards");
-  cardRows[0].props.onClick();
+  assert.ok(cell.length >= 2, "trace rows present");
+  cell[0].props.onClick();
   await tick();
-  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
-  const text2 = [];
-  (function walk(node) {
-    if (node == null) return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (typeof node === "string") { text2.push(node); return; }
-    (node.children || []).forEach(walk);
-    walk(node.props && node.props.value);
-    walk(node.props && node.props.label);
-  })(tree);
-  const joined2 = text2.join(" ");
-  assert.match(joined2, /营收 \+159%/);
-  assert.match(joined2, /资不抵债/);
-  assert.match(joined2, /站回 340/);
-  assert.match(joined2, /忍住没加/);
+  tree = component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
+  const joined2 = collectText();
+  assert.match(joined2, /决策轨迹 · /);   // expand header
+  assert.match(joined2, /割肉/);           // plan action
+  assert.match(joined2, /执行/);
+  assert.match(joined2, /盈亏/);
 });

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -1,0 +1,144 @@
+"""Behavioral tests for build_decision_traces — the dashboard card mirror of
+the DSH plugin's decision-trace view.
+
+Synthetic workspace under a temp dir; WS_ROOT is monkeypatched so no real desk
+data, snapshots or network are touched. Verifies the trace contract: real fills
+as the spine, soft-paired decisions (±3 days, same ticker) as the "why" layer,
+T+1 close verdicts, and no cross-currency mixing in the realized figures.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from clawock.publish import dashboard
+
+
+@pytest.fixture()
+def ws(tmp_path, monkeypatch):
+    """A minimal desk: portfolio.json + decisions.jsonl + two snapshots."""
+    (tmp_path / "memory" / "snapshots").mkdir(parents=True)
+    portfolio = {
+        "portfolios": {
+            "us_stocks": {"currency": "USD", "holdings": [
+                {"ticker": "PLTU", "shares": 5, "current_price": 49.24,
+                 "pnl_percent": -1.5, "trades": [
+                     {"date": "2026-08-13", "action": "sell", "shares": 5,
+                      "price": 50.0, "realized_pnl": 45.21,
+                      "note": "PLTU 清仓"},
+                     {"date": "2026-08-08", "action": "buy", "shares": 5,
+                      "price": 45.0, "note": "建仓"},
+                 ]},
+                {"ticker": "SPCH", "shares": 10, "current_price": 8.77,
+                 "pnl_percent": -28.0, "trades": [
+                     {"date": "2026-08-15", "action": "buy", "shares": 10,
+                      "price": 8.77, "note": "无限子弹流摊本"},
+                 ]},
+            ]},
+            "hk_stocks": {"currency": "HKD", "holdings": [
+                {"ticker": "00100", "shares": 120, "current_price": 329.0,
+                 "pnl_percent": -40.5, "trades": [
+                     {"date": "2026-08-04", "action": "buy", "shares": 20,
+                      "price": 230.0, "note": "微信成交"},
+                 ]},
+            ]},
+        },
+    }
+    (tmp_path / "portfolio.json").write_text(json.dumps(portfolio), encoding="utf-8")
+    decisions = [
+        # PLTU: plan on 08-10 (within ±3 of the 08-13 sell) — soft pair.
+        {"decision_id": "dec-pltu1", "plan_date": "2026-08-10", "ticker": "PLTU",
+         "action": "trim_on_rebound", "confidence": 0.6, "driven_by": "technical",
+         "rationale": "浮盈保护", "size": {"shares": 5},
+         "execution": {"status": "followed"},
+         "condition": {"description": "反弹至 50 减仓"}},
+        # SPCH: plan on 08-14, trade on 08-15 — direction conflict.
+        {"decision_id": "dec-spch1", "plan_date": "2026-08-14", "ticker": "SPCH",
+         "action": "cut", "confidence": 0.82, "driven_by": "risk_rule",
+         "rationale": "超限硬止损", "size": {"shares": 200, "pct": 0.8},
+         "evaluation": {"execution_price": 9.21},
+         "execution": {"status": "unknown"}},
+        # Conversation mind record (schema_version=0) with full mind fields.
+        {"schema_version": 0, "decision_id": "dec-00100a", "ticker": "00100",
+         "decided_at": "2026-08-04T13:45:00+08:00", "action": "reject",
+         "confidence": 0.65, "driven_by": "fundamental", "source": "conversation",
+         "subject": {"ticker": "00100", "market": "HK", "currency": "HKD"},
+         "mind": {"bull": {"summary": "营收 +159%"}, "bear": {"summary": "资不抵债"},
+                  "thesis": "先活下来", "invalidation": ["站回 340"]},
+         "emotion": {"pressure": "averaging_down", "note": "忍住没加"},
+         "execution": {"status": "followed"}},
+    ]
+    (tmp_path / "memory" / "decisions.jsonl").write_text(
+        "".join(json.dumps(d, ensure_ascii=False) + "\n" for d in decisions),
+        encoding="utf-8")
+    # Snapshots: 08-14 (T+1 for the 08-13 sell) and 08-15.
+    for day, prices in [("2026-08-14", {"PLTU": 49.24, "SPCH": 9.0, "00100": 330.0}),
+                        ("2026-08-15", {"PLTU": 49.0, "SPCH": 9.1, "00100": 329.0})]:
+        snap = {"portfolios": {"us_stocks": {"holdings": [
+            {"ticker": k, "current_price": v} for k, v in prices.items()]}}}
+        (tmp_path / "memory" / "snapshots" / f"{day}.json").write_text(
+            json.dumps(snap), encoding="utf-8")
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    return tmp_path
+
+
+def test_traces_spine_is_real_fills_newest_first(ws):
+    traces = dashboard.build_decision_traces()
+    assert len(traces) == 4
+    dates = [t["date"] for t in traces]
+    assert dates == sorted(dates, reverse=True), "newest first"
+
+
+def test_soft_pair_attaches_decision_within_window(ws):
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["decision"] is not None
+    assert pltu["decision"]["action"] == "trim_on_rebound"
+    assert pltu["decision"]["planDate"] == "2026-08-10"
+    assert pltu["decision"]["condition"] == "反弹至 50 减仓"
+    assert pltu["decision"]["sizeShares"] == 5
+    assert pltu["decision"]["execution"] == "followed"
+
+
+def test_t1_verdict_on_sell(ws):
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    # T+1 close 49.24 vs sell 50.0 → -1.52% → 卖对.
+    assert pltu["t1"] is not None
+    assert pltu["t1"]["verdict"] == "卖对"
+    assert pltu["t1"]["delta"] < 0
+
+
+def test_direction_conflict_is_visible(ws):
+    """SPCH planned cut on 08-14 but bought on 08-15: the trace must carry
+    both sides — this is the product's core signal."""
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    assert spch["decision"]["action"] == "cut"
+    assert spch["action"] == "buy"
+    assert spch["decision"]["plannedPrice"] == 9.21
+
+
+def test_conversation_mind_record_pairs_with_its_trade(ws):
+    traces = dashboard.build_decision_traces()
+    hk = next(t for t in traces if t["ticker"] == "00100")
+    assert hk["currency"] == "HKD"
+    assert hk["decision"]["action"] == "reject"
+    assert hk["decision"]["source"] == "conversation"
+    assert hk["decision"]["thesis"] == "先活下来"
+    assert hk["decision"]["emotion"] == "averaging_down"
+    assert hk["decision"]["bull"] == "营收 +159%"
+
+
+def test_no_t1_when_snapshot_missing(ws):
+    """The 08-15 SPCH buy has no close after it → t1 stays absent, not fake."""
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    assert spch["t1"] is None
+
+
+def test_hold_pnl_attached_for_still_held_tickers(ws):
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    assert spch["holdPnl"] == -28.0

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -138,6 +138,16 @@ def test_no_t1_when_snapshot_missing(ws):
     assert spch["t1"] is None
 
 
+def test_rationale_truncated_to_payload_budget(ws):
+    """Full rationales blew the 200KB dashboard cap (209KB in CI); the trace
+    contract truncates them at 140 chars so the payload stays publishable."""
+    traces = dashboard.build_decision_traces()
+    for t in traces:
+        r = (t.get("decision") or {}).get("rationale")
+        if r:
+            assert len(r) <= 141, f"rationale too long: {len(r)}"
+
+
 def test_hold_pnl_attached_for_still_held_tickers(ws):
     traces = dashboard.build_decision_traces()
     spch = next(t for t in traces if t["ticker"] == "SPCH")


### PR DESCRIPTION
## 做什么

Reflect 复盘面板新增「决策轨迹」卡片——**真实成交为轴、软配对决策为「为什么」、T+1 收盘判卖飞/卖对**。与 DSH 插件同一份数据契约,这是公开的复盘镜像。

## 改动

- `src/clawock/publish/dashboard.py`:`build_decision_traces(limit, workspace)`——portfolio.json trades[] + decisions.jsonl(±3 日软配对)+ 快照收盘价(T+1)聚合;`build_projection` 输出 `decision_traces`(60 条,payload +0.18MB);纯读不写
- `site/index.html`:reflect panel 加卡片(标题/说明/统计条/列表)
- `site/assets/js/dashboard.render.js`:`renderDecisionTraces` 注册进 reflect;两段式行(ticker+动作+数量@价+盈亏 / T+1 徽标),details 展开纵向轨迹(计划/执行/T+1/盈亏 + 计划 chips + 为什么/情绪/备注),币种分开(HKD/USD 不混加),无决策成交显式标注
- `site/assets/css/dashboard.css`:轨迹行/时间线节点/徽标/note 语义色样式
- `tests/test_decision_traces.py`:7 例(软配对窗口/方向冲突可见/T+1 卖对/conversation mind 记录/无快照无 T+1/持仓盈亏挂接/新→旧排序)

## 验收

1. `build_projection` 产出 `decision_traces` 60 条(实测)
2. Playwright 端到端:reflect tab 渲染 60 行、展开轨迹完整(计划 割肉 82% 风控规则 → 执行 → T+1 → 盈亏 -28.0% + 计划 chips + rationale)、零 JS 错误
3. `clawock dashboard-build` 后 dashboard.json 带 decision_traces

## 为什么

kcn:「这个(决策轨迹)也可以做一个子模块在 dashboard 里面」。SPCH「37 条计划 cut vs 22 笔摊本」的方向冲突、T+1 卖飞/卖对判定,从「两个 tab 各说各话」变成「一笔成交一条轨迹」——复盘面板缺的最后一块。
