### PR TITLE
fix: validate_decision 按 schema_version==0 路由全部 mind 记录,不再要求 source=conversation (#664)

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -290,10 +290,12 @@ def assign_episode_ids(decisions: list[dict]) -> list[dict]:
 
 
 def validate_decision(d: dict) -> list[str]:
-    # Decision-mind conversation records (docs/decision-mind-ledger.md) are a
-    # deliberate second ledger row type: they carry mind/emotion instead of the
+    # Decision-mind records (docs/decision-mind-ledger.md) are a deliberate
+    # second ledger row type: they carry mind/emotion instead of the
     # plan-decision fields below, and are validated by their own rules.
-    if d.get("schema_version") == 0 and d.get("source") == "conversation":
+    # schema_version 0 is exclusively the mind ledger; every record.SOURCES
+    # harness (conversation/openclaw/claude/codex/cli) writes this row type.
+    if d.get("schema_version") == 0:
         from clawock.decision.record import validate_mind_record
         return validate_mind_record(d)
     errors = []

--- a/tests/test_decision_record.py
+++ b/tests/test_decision_record.py
@@ -106,6 +106,20 @@ def test_validate_decision_accepts_mind_records_and_rejects_weak_ones():
     assert any("missing episode_id" in issue for issue in validate_decision(legacy))
 
 
+def test_validate_decision_accepts_every_source_v0_mind_record():
+    """#664: every harness in record.SOURCES writes a valid v0 mind record, and
+    the desk's row validator must route each one to the mind rules — not the
+    v2 plan rules that demand episode_id/plan_date."""
+    from clawock.decision.ledger import validate_decision
+    from clawock.decision import record as decision_record
+    for source in sorted(decision_record.SOURCES):
+        rec = build_record(_args(source=source))
+        assert rec["source"] == source
+        assert rec["schema_version"] == 0
+        assert validate_decision(rec) == [], \
+            f"v0 mind record from {source!r} failed the desk validator"
+
+
 def test_source_param_distinguishes_harnesses(tmp_path):
     """Any harness (OpenClaw/Claude Code/Codex/CLI) records into the same
     ledger; `--source` says which one wrote the verdict."""


### PR DESCRIPTION
修复 #664:`src/clawock/decision/ledger.py` 的 `validate_decision` 此前只在 `schema_version == 0 and source == "conversation"` 时把记录路由到 decision-mind 校验器;任何 harness 按 #662 的 `--source openclaw|claude|codex|cli` 落账的 v0 记录都会掉进 v2 plan 校验器,报约 9 个错(missing episode_id/plan_date/created_at/ticker/strategy_id、schema_version must be 2 …),使 pre-push system_check 判 CRITICAL——与 #662 自己的 README 和教学文件(教各 harness 传自己 source)自相矛盾。

## 变更

- `ledger.py`:`schema_version == 0` 单独路由 mind 校验,不再要求 `source == "conversation"`(v0 行类型只属于 decision-mind 账本,`validate_mind_record` 仍强制 `source in SOURCES`)。
- 新增回归测试 `test_validate_decision_accepts_every_source_v0_mind_record`:对 `record.SOURCES` 的每个枚举(conversation/openclaw/claude/codex/cli)构造合法 v0 mind 记录,断言 `validate_decision(record) == []`。

## 先红后绿

- 修复前(未改 ledger.py 跑新测试):FAILED,`AssertionError: v0 mind record from 'claude' failed the desk validator`,9 个错、首个为 `missing episode_id`——与 issue 实测一致。
- 修复后:`pytest tests/test_decision_record.py -x -q` → 8 passed;`pytest tests/test_decision_v2.py tests/test_decision_record.py -x -q` → 66 passed。
