### PR TITLE
refactor: 收敛剩余 8 处 X or DEFAULT 配置读取(0 值合法不再被吞) (#666)

### DIFF
--- a/src/clawock/decision/early_trend.py
+++ b/src/clawock/decision/early_trend.py
@@ -33,6 +33,24 @@ def classify(technical: dict, peer: dict, information: dict, events: list[dict],
     peers = int(peer.get("available_peer_count") or 0)
     market_policy = (policy.get("markets") or {}).get(str(market).upper()) or {}
     multiple = _number(policy.get("early_peer_dispersion_multiple")) or 1.5
+    # #666: explicit None checks, never `X or DEFAULT` — a config value of 0
+    # (e.g. `minimum_peer_count: 0` = 不设同行样本下限) is legal and must not
+    # be swallowed into the default.
+    raw_min_peers = market_policy.get("minimum_peer_count")
+    min_peers = int(raw_min_peers) if raw_min_peers is not None else 3
+    raw_min_attention_rank = market_policy.get("minimum_attention_rank")
+    min_attention_rank = (
+        float(raw_min_attention_rank) if raw_min_attention_rank is not None
+        else 1.0
+    )
+    raw_min_acceleration = policy.get("minimum_attention_acceleration")
+    min_acceleration = (
+        float(raw_min_acceleration) if raw_min_acceleration is not None else 1.0
+    )
+    raw_min_source_types = policy.get("minimum_attention_source_types")
+    min_source_types = (
+        int(raw_min_source_types) if raw_min_source_types is not None else 1
+    )
     breakout = close is not None and prior_high is not None and close > prior_high
     residual_multiple = (
         residual / dispersion
@@ -41,7 +59,7 @@ def classify(technical: dict, peer: dict, information: dict, events: list[dict],
     residual_leader = bool(
         residual is not None and residual > 0
         and residual_multiple is not None and residual_multiple >= multiple
-        and peers >= int(market_policy.get("minimum_peer_count") or 3)
+        and peers >= min_peers
     )
     price_candidate = bool(technical.get("usable") and breakout and residual_leader)
 
@@ -56,10 +74,10 @@ def classify(technical: dict, peer: dict, information: dict, events: list[dict],
     source_types = int(information.get("attention_source_type_count") or 0)
     attention_ok = bool(
         attention_rank is not None
-        and attention_rank >= float(market_policy.get("minimum_attention_rank") or 1)
+        and attention_rank >= min_attention_rank
         and acceleration is not None
-        and acceleration >= float(policy.get("minimum_attention_acceleration") or 1)
-        and source_types >= int(policy.get("minimum_attention_source_types") or 1)
+        and acceleration >= min_acceleration
+        and source_types >= min_source_types
         and int(information.get("attention_event_count") or 0) > 0
     )
     information_modes = []
@@ -157,6 +175,11 @@ def exploration_setup(technical: dict, candidate: dict, policy: dict,
     entry = max(close or 0, prior_high or 0)
     if not entry or invalidation >= entry:
         return None
+    # #666: explicit None checks, never `X or DEFAULT` — a config value of 0
+    # (e.g. `exploration_tranche_pct: 0` = 禁用探索档) is legal and must not
+    # be swallowed into the default.
+    raw_tranche_pct = policy.get("exploration_tranche_pct")
+    raw_confirmation_sessions = policy.get("confirmation_window_sessions")
     return {
         "setup_id": "early_trend_confirmation",
         "campaign_id": f"{candidate['market']}:{ticker}:early:p1",
@@ -165,10 +188,13 @@ def exploration_setup(technical: dict, candidate: dict, policy: dict,
         "entry_price": round(entry, 4),
         "invalidation_price": round(invalidation, 4),
         "max_tranches": 1,
-        "tranche_pct_of_position": float(
-            policy.get("exploration_tranche_pct") or 0.025
+        "tranche_pct_of_position": (
+            float(raw_tranche_pct) if raw_tranche_pct is not None else 0.025
         ),
-        "valid_for_sessions": int(policy.get("confirmation_window_sessions") or 5),
+        "valid_for_sessions": (
+            int(raw_confirmation_sessions)
+            if raw_confirmation_sessions is not None else 5
+        ),
         "signal_date": technical.get("as_of"),
         "authority_tier": "exploration",
         "target_tranche_level": 0.25,

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -781,11 +781,16 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
         if early_setup is not None:
             technical["setups"].append(early_setup)
             technical = _apply_setup_usage(technical, ticker_usage)
+        raw_exploration_book = add_policy.get("exploration_max_book_pct")
         execution = _execution_view(
             holding, leg, invested[leg], cash[leg], technical, thesis, leveraged,
             authority_tier=execution_tier,
-            exploration_max_book_pct=float(
-                add_policy.get("exploration_max_book_pct") or 0.03
+            # #666: explicit None check, never `X or DEFAULT` — a config value
+            # of 0 (`exploration_max_book_pct: 0` = 封死探索敞口) is legal and
+            # must not be swallowed into the 0.03 default.
+            exploration_max_book_pct=(
+                float(raw_exploration_book)
+                if raw_exploration_book is not None else 0.03
             ),
             overlay=sizing_overlay,
             open_add=open_add_gate_error or ticker in open_adds,

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -343,11 +343,15 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
         copy.deepcopy(news_history),
         datetime(2026, 8, 13, tzinfo=timezone.utc),
     )
+    # #666: explicit None check, never `X or DEFAULT` — a config value of 0
+    # (`attention_score_prior: 0`) is legal and must not be swallowed into
+    # the 0.1 default.
+    raw_attention_prior = policy.get("attention_score_prior")
     news = _news_by_date(
         news_history,
         news_policy["information_overlay"],
         specs,
-        prior=float(policy.get("attention_score_prior") or 0.1),
+        prior=float(raw_attention_prior) if raw_attention_prior is not None else 0.1,
     )
     news_snapshots = {
         str(snapshot.get("as_of") or "")[:10]: snapshot

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -196,7 +196,9 @@ def test_compiler_owns_proxy_join_risk_status_and_action_bounds():
     ) < packet_mod.MAX_QUERY_BYTES
 
 
-def test_production_factor_and_peer_keys_reach_add_authority():
+def _exploration_context():
+    """Context where 00100 reaches `exploration` authority through the
+    factor/peer/information payloads (used by the #666 zero-value contract)."""
     context = _context()
     context["cross_sectional_factor"] = {
         "activation": {"usable_for_decisions": False},
@@ -235,6 +237,11 @@ def test_production_factor_and_peer_keys_reach_add_authority():
         close=11, ma20=10, prior_5d_high=11.2, prior_5d_low=9.5,
         chandelier_stop=9.8,
     )
+    return context
+
+
+def test_production_factor_and_peer_keys_reach_add_authority():
+    context = _exploration_context()
 
     packet = packet_mod.compile_packet(
         context, brief_context.compute_generation_id(context)
@@ -253,6 +260,24 @@ def test_production_factor_and_peer_keys_reach_add_authority():
     # hard exploration envelope, so it may not masquerade as a 2.5% sample.
     assert row["execution"]["max_add_shares"] == 0
     assert "tranche_below_market_unit" in row["execution"]["blockers"]
+
+
+def test_exploration_max_book_pct_zero_means_zero_exploration_budget():
+    """#666: `exploration_max_book_pct: 0` (0 = 封死探索敞口) is legal config;
+    `X or DEFAULT` would silently swallow it into 0.03."""
+    context = _exploration_context()
+    add_policy = json.loads(
+        (ROOT / "config" / "add-alpha-policy.json").read_text(encoding="utf-8"))
+    add_policy["exploration_max_book_pct"] = 0
+    context["add_alpha_policy"] = add_policy
+
+    packet = packet_mod.compile_packet(
+        context, brief_context.compute_generation_id(context)
+    )
+    execution = packet["tickers"]["00100"]["execution"]
+
+    assert execution["exploration_budget_value"] == 0.0
+    assert execution["max_add_value"] == 0
 
 
 def test_one_us_share_can_collect_exploration_inside_the_hard_book_cap():

--- a/tests/test_early_trend.py
+++ b/tests/test_early_trend.py
@@ -58,6 +58,30 @@ def test_primary_event_can_promote_a_cool_nonleveraged_candidate_to_exploration(
     assert setup["tranche_pct_of_position"] == .025
 
 
+def test_exploration_tranche_pct_zero_is_not_swallowed_into_default():
+    """#666: `exploration_tranche_pct: 0` (0 = 禁用探索档) is legal config;
+    `X or DEFAULT` would silently swallow it into 0.025."""
+    technical = {
+        "usable": True, "as_of": "2026-08-13", "close": 10.5,
+        "prior_20d_high": 10, "prior_5d_low": 9, "ma20": 9.5,
+        "chandelier_stop": 8.8, "zscore20": 1.2,
+    }
+    candidate = early_trend.classify(
+        technical,
+        {"residual_5d": .12, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {},
+        [{"event_id": "sec-1", "source_type": "sec_filing", "direction": 1}],
+        leveraged=False, policy=POLICY, market="US",
+    )
+    policy = dict(POLICY, exploration_tranche_pct=0)
+    setup = early_trend.exploration_setup(
+        technical, candidate, policy, ticker="ABC"
+    )
+
+    assert setup["tranche_pct_of_position"] == 0.0
+
+
 def test_primary_source_precedes_syndication_and_accepts_numeric_direction():
     candidate = early_trend.classify(
         {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},


### PR DESCRIPTION
修复 #666: `X or DEFAULT` 配置读取中 0 是合法值却被吞成默认值的最后 8 处。

8 处全部改为显式 None 判定(镜像 #649/#656 的 _policy_near_pct / no_chase_z 写法),
policy.get("key") 字面量保留,test_policy_key_parity 的字面量正则防线不受影响:

- src/clawock/decision/early_trend.py:44 minimum_peer_count(0 = 不设同行样本下限)
- early_trend.py:59 minimum_attention_rank
- early_trend.py:61 minimum_attention_acceleration
- early_trend.py:62 minimum_attention_source_types
- early_trend.py:169 exploration_tranche_pct(0 = 禁用探索档)
- early_trend.py:171 confirmation_window_sessions
- src/clawock/decision/packet.py:788 exploration_max_book_pct(0 = 封死探索敞口)
- src/clawock/evaluation/add_alpha_walkforward.py:350 attention_score_prior

新增 0 值 config 测试(与 #656 的 near_pct 0 值测试同族,放同处):

- tests/test_early_trend.py::test_exploration_tranche_pct_zero_is_not_swallowed_into_default
  — exploration_tranche_pct=0 时 tranche_pct_of_position 必须是 0.0 而非 0.025
- tests/test_brief_decision_packet.py::test_exploration_max_book_pct_zero_means_zero_exploration_budget
  — exploration_max_book_pct=0 时 exploration_budget_value 必须是 0.0 而非 0.03 档

两个新测试均做过变异验证:把修复改回 `or` 后测试变红,恢复修复后变绿。

验证:
unset CLAWOCK_WORKSPACE CLAWOCK_PROFILE;
python3 -m pytest tests/test_policy_key_parity.py tests/test_early_trend.py
  tests/test_brief_decision_packet.py tests/test_add_alpha_walkforward_early.py
  38 passed
