### PR TITLE
fix: 清理 #592 遗留的 crontab/indexnow 死引用 + 宿主 crontab 反空转闸 (#663 #672)

### DIFF
--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -14,7 +14,6 @@
   ],
   "required_pages": [
     "index.html",
-    "4fb2df1611ed42e5b67fd6171a237acb.txt",
     "google7be5b41525cebe9d.html",
     "briefs.html",
     "evidence.html",
@@ -32,7 +31,6 @@
   ],
   "artifact_include": [
     "index.html",
-    "4fb2df1611ed42e5b67fd6171a237acb.txt",
     "google7be5b41525cebe9d.html",
     "briefs.html",
     "evidence.html",

--- a/ops/host/cron_timeline.py
+++ b/ops/host/cron_timeline.py
@@ -244,10 +244,6 @@ def load_crontab():
             name = 'sync_us_dst'
         elif 'gold_dca_refresh' in cmd:
             name = 'gold_dca_refresh'
-        elif 'rick_broadcast_nostr' in cmd:
-            name = 'nostr_broadcast'
-        elif 'indexnow_submit' in cmd:
-            name = 'indexnow_submit'
         elif re.search(r'(^|/)git\b', cmd) and re.search(r'\bgc\b', cmd):
             name = 'git gc'
         else:

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -75,6 +75,10 @@ OPENCLAW_INSTALL = _OPENCLAW_PATHS.install_dir
 LIVE_WORKSPACE = _OPENCLAW_PATHS.workspace
 MEMORY_INDEX_DB = _OPENCLAW_PATHS.memory_index_db
 OPENCLAW_CONFIG = _OPENCLAW_PATHS.config_file
+# Derived, never spelled out: an absolute host path in this file is exactly the
+# runtime coupling the ratchet bans, and the host tools directory belongs to
+# whoever runs the check, not to this repository.
+HOST_TOOLS_DIR = Path.home() / 'tools'
 
 MEMORY_INDEX_LOG = LIVE_WORKSPACE / 'logs' / 'memory_index.log'
 # Nightly reindex is 05:10 HKT; 30h lets one run slip into the next daily review
@@ -349,7 +353,7 @@ SECRET_PATTERNS_STRICT = (
     r'|\bxox[baprs]-[A-Za-z0-9-]{10,}'              # Slack token
     r'|\btvly-[A-Za-z0-9_-]{20,}'                   # Tavily search key
     # Nostr nsec (bech32: fixed prefix, fixed length, no b/i/o/1 in the charset).
-    # nostr_publish.js signs with this — a leak lets anyone post as Rick.
+    # An nsec is the account's signing key — a leak lets anyone post as its owner.
     r'|\bnsec1[02-9ac-hj-np-z]{58}\b'
 )
 
@@ -725,6 +729,72 @@ def check_cron_paths_exist(r):
         r.add('cron paths', OK, f'{len(jobs)} jobs · {len(refs)} referenced scripts present')
 
 
+def _host_crontab_target_audit(crontab_text):
+    """(rows, missing) — absolute host crontab command paths that do not exist.
+
+    A cron line whose script was deleted still fires on schedule and fails only
+    inside cron's own mail, which nobody reads — the #592 cleanup deleted
+    `indexnow_submit.py` and `rick_broadcast_nostr.sh` while the host crontab
+    kept scheduling them (#663). Every absolute path in the command part that
+    sits under the live workspace or the host tools directory must therefore
+    resolve, or the line is a silent no-op.
+
+    Both roots are derived, not spelled out: the workspace comes from the
+    provider adapter and the tools directory from the operator's home, so this
+    file stays free of the host-path coupling the ratchet bans. Tokens are read
+    until the first shell operator (`>`, `|`, `;`): a redirect target like
+    `>> logs/watchdog.cron.log` is created by cron, so a not-yet-written log is
+    not a missing file.
+    """
+    import re
+    import shlex
+
+    from clawock.scheduling import parse_crontab_lines
+
+    missing = []
+    rows = parse_crontab_lines(crontab_text)
+    for row in rows:
+        for token in shlex.split(row['command']):
+            if '=' in token:  # env assignment prefixing the command (PATH=…)
+                continue
+            if re.search(r'[>|;]', token):
+                break
+            if not token.startswith('/'):
+                continue
+            target = Path(token)
+            if not any(target.is_relative_to(root)
+                       for root in (LIVE_WORKSPACE, HOST_TOOLS_DIR)):
+                continue
+            if not os.path.exists(target):
+                missing.append(token)
+    return rows, missing
+
+
+def check_host_crontab_targets(r):
+    """Host crontab lines must not point at files that no longer exist.
+
+    Skip-safe by design: CI runners and fresh hosts have no crontab, and an
+    unreadable or empty one is not a finding. The check exists because deleting
+    an ops script without touching the host crontab turns the scheduled line
+    into a silent no-op that no repository-side gate can see (#663).
+    """
+    try:
+        out = subprocess.run(
+            ['crontab', '-l'], capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return  # no crontab on this host — nothing to check
+    if out.returncode != 0 or not out.stdout.strip():
+        return
+    rows, missing = _host_crontab_target_audit(out.stdout)
+    if missing:
+        for path in missing:
+            r.add('host crontab targets', CRITICAL,
+                  f'crontab points at missing file: {path}')
+    else:
+        r.add('host crontab targets', OK, f'{len(rows)} lines · no missing targets')
+
+
 def check_generated_cron_docs(r):
     """Generated schedule documentation must exactly match the contract."""
     result = subprocess.run(
@@ -933,6 +1003,7 @@ def main():
         check_decision_ledger,
         check_context_capability,
         check_cron_paths_exist,
+        check_host_crontab_targets,
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,

--- a/site/4fb2df1611ed42e5b67fd6171a237acb.txt
+++ b/site/4fb2df1611ed42e5b67fd6171a237acb.txt
@@ -1,1 +1,0 @@
-4fb2df1611ed42e5b67fd6171a237acb

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -12,7 +12,6 @@ CONTRACT = json.loads((ROOT / "config/pages-public.json").read_text())
 WORKFLOW = (ROOT / ".github/workflows/pages.yml").read_text()
 UI = (ROOT / "site/assets/js/dashboard.ui.js").read_text()
 INDEX = (ROOT / "site/index.html").read_text()
-INDEXNOW_KEY = "4fb2df1611ed42e5b67fd6171a237acb.txt"
 GOOGLE_VERIFICATION = "google7be5b41525cebe9d.html"
 
 
@@ -46,13 +45,6 @@ def test_linked_web_manifest_is_required_and_triggers_deploy():
 
     assert manifest in CONTRACT["required_pages"]
     assert manifest in CONTRACT["artifact_include"]
-    assert WORKFLOW.count("'site/**'") == 2
-
-
-def test_indexnow_key_is_required_public_and_triggers_deploy():
-    assert (ROOT / "site" / INDEXNOW_KEY).read_text().strip() == INDEXNOW_KEY.removesuffix(".txt")
-    assert INDEXNOW_KEY in CONTRACT["required_pages"]
-    assert INDEXNOW_KEY in CONTRACT["artifact_include"]
     assert WORKFLOW.count("'site/**'") == 2
 
 
@@ -153,7 +145,7 @@ def test_builder_stages_only_public_consumers(tmp_path):
     (site / "index.html").write_text("ok")
     for path in (
         "briefs.html", "evidence.html", "robots.txt", "manifest.webmanifest",
-        INDEXNOW_KEY, GOOGLE_VERIFICATION,
+        GOOGLE_VERIFICATION,
     ):
         (site / path).write_text("ok")
     (site / "sitemap.xml").write_text(
@@ -196,7 +188,6 @@ def test_builder_stages_only_public_consumers(tmp_path):
         if node.tag.rsplit("}", 1)[-1] == "loc"
     ]
     assert sitemap_locs == ["https://kcnyu.github.io/clawock/"]
-    assert (output / INDEXNOW_KEY).is_file()
     assert (output / GOOGLE_VERIFICATION).is_file()
     assert (output / "assets/data/dashboard.json").is_file()
     assert (output / "assets/data/overview.json").is_file()

--- a/tests/test_system_check_host_crontab.py
+++ b/tests/test_system_check_host_crontab.py
@@ -1,0 +1,141 @@
+"""The health gate must catch a host crontab line pointing at a deleted file.
+
+The #592 cleanup deleted `ops/growth/indexnow_submit.py` and the Nostr
+broadcast script while the host crontab kept scheduling them, so both kept
+"running" as silent no-ops that no repository-side gate could see (#663). This
+pins the host-crontab anti-no-op check: a crontab command whose absolute path
+under the live workspace (or the host tools directory) no longer exists is a
+CRITICAL, and a missing or empty crontab is no finding at all — CI runners
+have no crontab and must not redden over it.
+
+Behavioural, not textual: the check is driven with a fake `crontab -l` so that
+deleting its body, or making it blind to an empty crontab, turns these red.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def host_roots(system_check, monkeypatch, tmp_path):
+    """Point the gate's derived roots at scratch paths so the test never judges
+    this machine's real workspace or tools directory."""
+    workspace = tmp_path / "workspace"
+    tools = tmp_path / "tools"
+    workspace.mkdir()
+    tools.mkdir()
+    monkeypatch.setattr(system_check, "LIVE_WORKSPACE", workspace)
+    monkeypatch.setattr(system_check, "HOST_TOOLS_DIR", tools)
+    return workspace, tools
+
+
+def _run(system_check, monkeypatch, stdout="", returncode=0):
+    def fake_crontab(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            ["crontab", "-l"], returncode, stdout, "")
+
+    monkeypatch.setattr(subprocess, "run", fake_crontab)
+    result = system_check.Result()
+    system_check.check_host_crontab_targets(result)
+    return result.checks
+
+
+def test_a_workspace_script_behind_python3_that_vanished_is_critical(
+        system_check, monkeypatch, host_roots):
+    workspace, _ = host_roots
+    dead = workspace / "ops" / "growth" / "indexnow_submit.py"
+    checks = _run(system_check, monkeypatch, stdout=(
+        f"0 12 * * * /usr/bin/python3 {dead} >> {workspace}/logs/indexnow.log 2>&1\n"
+    ))
+
+    assert checks == [
+        ("host crontab targets", system_check.CRITICAL,
+         f"crontab points at missing file: {dead}"),
+    ]
+
+
+def test_a_tools_script_that_vanished_is_critical(
+        system_check, monkeypatch, host_roots):
+    _, tools = host_roots
+    dead = tools / "clawock-autoloop" / "run.sh"
+    checks = _run(system_check, monkeypatch, stdout=f"0 23 * * * {dead}\n")
+
+    assert checks == [
+        ("host crontab targets", system_check.CRITICAL,
+         f"crontab points at missing file: {dead}"),
+    ]
+
+
+def test_existing_scripts_keep_the_gate_green(
+        system_check, monkeypatch, host_roots):
+    workspace, _ = host_roots
+    live = workspace / "ops" / "host" / "sync_us_cron_dst.py"
+    live.parent.mkdir(parents=True)
+    live.write_text("")
+    checks = _run(system_check, monkeypatch, stdout=(
+        f"0 8 * * * /usr/bin/python3 {live} --apply >> "
+        f"{workspace}/logs/dst-sync.log 2>&1\n"
+    ))
+
+    assert checks == [("host crontab targets", system_check.OK,
+                       "1 lines · no missing targets")]
+
+
+def test_a_redirect_target_is_not_judged_as_a_missing_file(
+        system_check, monkeypatch, host_roots):
+    workspace, _ = host_roots
+    live = workspace / "ops" / "host" / "sync_us_cron_dst.py"
+    live.parent.mkdir(parents=True)
+    live.write_text("")
+    checks = _run(system_check, monkeypatch, stdout=(
+        f"0 8 * * * /usr/bin/python3 {live} >> {workspace}/logs/never-written.log 2>&1\n"
+    ))
+
+    assert checks[0][1] == system_check.OK
+
+
+def test_an_empty_crontab_is_not_a_finding(system_check, monkeypatch, host_roots):
+    assert _run(system_check, monkeypatch, stdout="") == []
+
+
+def test_an_unreadable_crontab_is_not_a_finding(
+        system_check, monkeypatch, host_roots):
+    assert _run(system_check, monkeypatch, stdout="", returncode=1) == []
+
+
+def test_a_host_without_the_crontab_binary_is_not_a_finding(
+        system_check, monkeypatch, host_roots):
+    def no_crontab(*args, **kwargs):
+        raise FileNotFoundError("no crontab on this host")
+
+    monkeypatch.setattr(subprocess, "run", no_crontab)
+    result = system_check.Result()
+    system_check.check_host_crontab_targets(result)
+    assert result.checks == []
+
+
+def test_absolute_paths_outside_the_host_roots_are_not_judged(
+        system_check, monkeypatch, host_roots):
+    checks = _run(system_check, monkeypatch, stdout=(
+        "0 9 * * * /usr/bin/python3 /opt/missing_thing.py\n"))
+
+    assert checks == [("host crontab targets", system_check.OK,
+                       "1 lines · no missing targets")]


### PR DESCRIPTION
## 范围

修复 #663 与 #672：清理 #592 删除 `ops/growth/indexnow_submit.py` 与
`rick_broadcast_nostr.sh` 之后留下的死引用，并补一道防止同类问题再发的闸。

## 变更

1. **cron_timeline 死分支(#663)** — `ops/host/cron_timeline.py` 删除
   `rick_broadcast_nostr` / `indexnow_submit` 两个已无对应脚本的解析分支。
2. **宿主 crontab 反空转闸(#663)** — `ops/system_check.py` 新增
   `check_host_crontab_targets`：解析 `crontab -l`，凡是命令里位于 live
   workspace 或宿主 tools 目录下的绝对路径在磁盘上不存在，即报 CRITICAL
   （`crontab points at missing file: <path>`）。skip-safe：CI/无 crontab
   的主机上失败或为空时静默跳过，不产生任何告警。两条根路径均从 provider
   适配器与 `Path.home()` 派生，不写死宿主路径（不触耦合棘轮）。配套行为
   测试 `tests/test_system_check_host_crontab.py`。
3. **IndexNow 死特性(#672)** — 删除 `site/4fb2df1611ed42e5b67fd6171a237acb.txt`，
   从 `config/pages-public.json` 的 `required_pages` 与 `artifact_include`
   移除，`tests/test_pages_deployment_contract.py` 移除 `INDEXNOW_KEY` 常量、
   对应测试与两处 staging 断言。
4. **注释修正** — `ops/system_check.py` nsec 扫描注释不再点名已删除的
   `nostr_publish.js`（扫描本身保留）。

## 宿主 crontab

指向两个已删脚本的宿主 crontab 行已由操作者手工移除（本 PR 不含仓库外
变更）。本 PR 的闸就是保证这一类问题今后不会再静默复发：再删 ops 脚本而
漏清宿主 crontab，`system_check` 会直接 CRITICAL 挡 push，而不是像这次
一样实跑失败才发现。
