### PR TITLE
docs: decision-mind-ledger.md 按实况重写(schema/枚举/三视图/已实现边界) (#673)

### DIFF
--- a/docs/decision-mind-ledger.md
+++ b/docs/decision-mind-ledger.md
@@ -1,118 +1,168 @@
-# 决策心智账本 — Decision Mind Ledger (schema v0 草案)
+# 决策心智账本 — Decision Mind Ledger (schema v0)
 
-> 讨论稿,未落库。用途:把对话与盘前产生的**投资判定**冻结为
-> 「思想快照 + 情绪压力 + 可证伪条件」的结构化记录,事后自动对账。
-> 与券商流水、交易日记的区别:对抗性结构(bear 强制)+ 情绪冻结 +
-> 确定性对账 + 校准统计。
+> 已落地(PR #661/#662),不是草案:对话与盘前产生的**投资判定**冻结为
+> 「思想快照 + 情绪压力 + 可证伪条件」的结构化记录,与盘前计划行同写
+> `memory/decisions.jsonl`。本文件按实况重写,依据:
+> `src/clawock/decision/record.py`(唯一写入方)、
+> `src/clawock/decision/ledger.py`(校验路由与结算)、
+> `examples/dsh/plugin/client.js` + `lib/*.js`(DSH 面板)、
+> `examples/openclaw/SKILL.md`、`examples/claude-code/CLAUDE.md`、
+> `examples/codex/AGENTS.md`(各 harness 的调用约定)。
 
-## 一条记录 = 决策卡(冻结)+ 对账(事后填写)
+## 一条记录 = 决策卡(冻结,可通过 validate_mind_record)
+
+下例与 `build_record`(record.py)的实际输出同形,可通过
+`validate_mind_record`(record.py)校验:
 
 ```json
 {
   "schema_version": 0,
-  "decision_id": "dec-<12hex>",
+  "decision_id": "dec-conversation-43970cf6d9ff",
   "subject": { "ticker": "00100", "market": "HK", "currency": "HKD" },
-  "decided_at": "2026-08-16T13:45:00+08:00",
-  "source": "conversation",                  // conversation|openclaw|claude|codex|cli|brief
-  "action": "reject",                        // buy/add/trim/sell/hold/watch/reject/abstain
-  "confidence": 0.65,                        // 0..1
-  "driven_by": "fundamental",                // technical|fundamental|sentiment|mixed
-
-  "mind": {                                  // ← 思想快照(append-only,冻结)
-    "bull": { "summary": "...", "evidence": ["..."] },
-    "bear": { "summary": "...", "evidence": ["..."] },   // 强制非空:无反方不许落账
-    "thesis": "...",
-    "invalidation": ["缩量企稳", "2 日不创新低", "站回 340"]   // 可证伪条件
+  "decided_at": "2026-08-16T14:30:50+08:00",
+  "source": "conversation",
+  "action": "reject",
+  "confidence": 0.65,
+  "driven_by": "fundamental",
+  "mind": {
+    "bull": { "summary": "营收 +159% YoY,入通/海外霸榜/高盛三催化叙事仍在", "evidence": [] },
+    "bear": { "summary": "净利率 -2368%、负债率 343%、每股净资产 -24.37;z+2.8σ 情绪极值反转", "evidence": [] },
+    "thesis": "高增长救不了资不抵债,情绪反转期先活下来",
+    "invalidation": ["缩量企稳(量能低于前日50%)", "连续2日不创新低", "站回 HK40"]
   },
-
-  "emotion": {                               // ← 情绪压力层(决策时自评)
-    "pressure": "averaging_down",            // fomo|revenge|averaging_down|fear|euphoria|calm|mixed
-    "note": "浮亏 -40% 的摊本冲动,判定时明确压过;这次忍住没加"
-  },
-
-  "accounting": {                            // ← 对账(事后,只允许更新这里)
-    "trigger": { "status": "pending", "condition": "站回 340", "price_at_decision": 329.0 },
-    "execution": { "executed": false, "note": "判定为不加,未产生订单" },
-    "outcome": { "grade": "pending" },       // correct|wrong|mixed|pending
-    "calibration": { "confidence_bin": "0.6-0.7", "hit": null }
+  "emotion": { "pressure": "averaging_down", "note": "浮亏 -40% 的摊本冲动被明确压过——忍住没加" },
+  "condition": { "description": "缩量企稳(量能低于前日50%)", "price": null, "type": "manual" },
+  "execution": { "status": "followed", "source": "conversation", "detected_at": null },
+  "accounting": {
+    "trigger": { "status": "pending", "condition": "缩量企稳(量能低于前日50%)" },
+    "execution": { "executed": null },
+    "outcome": { "grade": "pending" }
   }
 }
 ```
 
-## 字段规则(不可协商)
+字段说明(全部由 `build_record` 生成,record.py):
 
-1. **bear 强制非空** —— 没有真实反方的判定不许落账(对抗性结构的核心)
-2. **mind 与 emotion 冻结** —— 落账后不可改;只有 `accounting` 可被
-   evaluation 机制更新(触发/执行/结果/校准)
-3. **可证伪优先** —— `invalidation` 必须写可观察条件,不写空话
-4. **情绪默认诚实** —— 默认 `calm`;浮亏摊本/FOMO/报复性场景要求自认
-   (账本的价值一半在这里)
-5. **action 枚举对齐 clawock 决策契约**,与盘前简报决策同词表
+| 字段 | 含义 |
+|---|---|
+| `schema_version` | 恒为 0(`MIND_SCHEMA_VERSION`),与 v2 计划行区分 |
+| `decision_id` | `dec-<source>-<12hex>`,由 `_stable_id` 稳定生成 |
+| `subject` | `ticker`/`market`/`currency` 三个必填非空字符串 |
+| `decided_at` | 写入时的本地时间,ISO 带秒 |
+| `source` | 产出 harness,见下方枚举 |
+| `action` / `confidence` / `driven_by` | 判定、信心(0..1 数值)、驱动,见下方枚举对照 |
+| `mind` | 思想快照:`bull`/`bear` 各含 `summary` + `evidence`,另有 `thesis` 与 `invalidation` 列表 |
+| `emotion` | 情绪压力自评:`pressure`(枚举)+ `note` |
+| `condition` | 兼容字段:`description` 取 `invalidation[0]`,`price=null`,`type="manual"` |
+| `execution` | 无操作动作(`reject/hold/watch/abstain`)落账即 `followed`;下单动作(`buy/add/trim/sell`)初始 `unknown`,待 `clawock mark-followed <decision_id> [--no]` 标记(execution.py) |
+| `accounting` | 落账时一次性写入:`trigger.status="pending"`、`execution.executed=null`、`outcome.grade="pending"`。**目前没有任何代码读取或更新这一块**,见「已实现 / 未实现」 |
 
-## 与现有系统关系
+## 校验规则(validate_mind_record)
 
-- **数据落点**:对话决策写入 `memory/decisions.jsonl`(与盘前决策同账本,
-  真源一个)
-- **唯一写入入口**:`clawock record` —— 所有 harness 的对话判定都走这一个
-  命令(校验、冻结、原子追加),**禁止任何 harness 手改 jsonl**。`--source`
-  标记产出来源:`conversation`(DSH 默认)/ `openclaw` / `claude` / `codex` /
-  `cli`;盘前 brief 决策仍由 postflight 写(不经过 record)。
-- **对账**:复用现有 evaluation 机制(`triggered/executed` 语义),执行标记
-  走 `clawock mark-followed`
-- **面板**:DSH Decision Studio 从「runs 调试视图」改为「决策心智视图」:
-  日期/标的/动作/信心/情绪/对账状态,展开看决策卡全貌。插件是**只读
-  加工层**:读 decisions.jsonl + portfolio.json 渲染,不关心谁写的、
-  不写任何数据。
-- **校准**:`confidence_bin` 汇入命中率统计,回答「我的 0.65 准不准」
+不满足任一条即 `record rejected`,不落账(record.py):
 
-## 样例一(今天真实):MiniMax 加仓判定 → 未加仓
+1. `subject.ticker/market/currency` 非空字符串
+2. `action` ∈ 下方 record 词表
+3. `source` ∈ 下方 SOURCES
+4. `confidence` 为数值(非 bool)且在 [0, 1]
+5. `driven_by` ∈ 下方 record 词表
+6. `mind.bull.summary` 与 `mind.bear.summary` 必须非空 —— **反方强制**,没有真实 bear 不许落账
+7. `mind.invalidation` 非空列表(可观察条件)
+8. `emotion.pressure` ∈ 下方 record 词表
+
+`mind` 与 `emotion` 落账后没有任何更新路径,即冻结;只有
+`execution.status` 会经 `mark-followed` 变化。
+
+## 枚举对照:record(v0 心智记录)与 plan(v2 计划行)是两套词表
+
+| 字段 | `clawock record` 心智记录(record.py) | 盘前计划行(ledger.py) |
+|---|---|---|
+| `action` | `buy, add, trim, sell, hold, watch, reject, abstain` | `cut, trim_on_rebound, hold_and_watch, t_only, add_only_on_trigger, add_on_breakout, watch` |
+| `driven_by` | `technical, fundamental, sentiment, mixed` | `technical, catalyst, sentiment, influencer, macro, peer, risk_rule` |
+| `emotion.pressure` | `calm, fomo, revenge, averaging_down, fear, euphoria, mixed` | 计划行没有 `emotion` 字段 |
+| `source` | `conversation, openclaw, claude, codex, cli` | 计划行没有 `source` 字段 |
+
+注意:两套 `action` 词表只有 `watch` 重叠,此前文档声称的「与盘前简报决策
+同词表」不成立,勿再沿用。
+
+## 写入与校验路径
+
+- **唯一写入入口**:`clawock record --source <harness> ...`(record.py)。
+  校验不过打 `record rejected: <原因>` 并退出;通过后
+  `load_decisions → append → write_decisions`(临时文件 + `os.replace`
+  原子落盘)。任何 harness 禁止手改 jsonl。
+- **`--source` 合法值**:`conversation`(DSH 默认)/`openclaw`/`claude`/
+  `codex`/`cli`(record.py 的 `SOURCES`)。`brief` **不是**合法值,传了会被
+  `choices` 拒绝;盘前 brief 决策是 schema v2 计划行,由 brief postflight
+  写入,不经过 `record`。
+- **harness 约定**:`examples/openclaw/SKILL.md`、
+  `examples/claude-code/CLAUDE.md`、`examples/codex/AGENTS.md` 各自示范
+  `clawock record --source openclaw|claude|codex` 同一条命令 —— 一个账本、
+  一个命令、每个 harness 都调它。
+- **校验路由**(ledger.py `validate_decision`):`schema_version == 0` **且**
+  `source == "conversation"` 的行路由到 `validate_mind_record`;v2 计划行
+  走原校验器。两个条件缺一不可——当前其它 `source` 的 v0 行不会走
+  mind 校验,而是落入 v2 校验器。
+- **落点**:`<workspace>/memory/decisions.jsonl`,v0 心智记录与 v2 计划行
+  共存于同一文件(ledger.py `LEDGER`)。
+
+## 面板:DSH Decision Mind(只读,三视图)
+
+注册为 DSH 对话视图环里的 "Decision Mind" 标签页(`conversation.view`
+slot,id=`decision-studio`,client.js)。三个分段视图:
+
+- **操作**:`portfolio.json` 里每笔真实成交(`trades`)——买入/加仓/卖出/
+  清仓/减仓标签、股数@价格、金额、已实现盈亏、备注。这是「实际做了什么」
+  的表面,不是计划模拟。
+- **账本**:`decisions.jsonl` 逐条记录,按日期分组;两个过滤:已执行交易
+  (`execution.status == followed` 且 active action)/ 全部;展开看
+  Bull/Bear 对置条、thesis、信心、可证伪条件、情绪注记、对账区。
+- **持仓**:按 book 分组表格(ticker/shares/price/pnl%),含币种与 principal。
+
+实现要点:
+
+- **只读**:浏览器端通过 Typert remote 服务 `clawockStudio` 调
+  `list/get/ledger/portfolio/plans`(client.js;lib/index.js 为 gateway,
+  lib/ledger.js 为纯读 `decisions.jsonl`(坏行跳过)/`portfolio.json`/
+  `memory/*-plan.json`)。插件不写任何数据,只做加工展示。
+- **工作区**:`$CLAWOCK_WORKSPACE` 环境变量,缺省为 dsh 进程 cwd
+  (lib/index.js `workspaceOf()`)。没有硬编码绝对路径。
+- **视觉**:DSH 原生**浅色**主题(ui-theme 令牌值),单一强调色 DeepSeek
+  蓝 `#4176E6`,正/负/警示语义色,仅吸顶 header 用玻璃效果(client.js
+  头部注释与 CSS)。
+- 仓库中**不存在** `decision-mind-ledger.html`,也没有暗色主题令牌。
+
+## 已实现 / 未实现
+
+**已实现**:
+
+- `clawock record` 全链路:校验、冻结、原子追加;schema v0 心智记录已
+  真实写入 `memory/decisions.jsonl`(如 `dec-conversation-*` 行)
+- `mind`/`emotion` 落账后无更新路径(冻结);bear 反方与 invalidation 强制
+- 执行标记:无操作动作落账即 `followed`;下单动作经
+  `clawock mark-followed` 标记(execution.py 按 decision_id 定位)
+- DSH 三视图只读面板;openclaw/claude-code/codex 三个 harness 文档统一
+  走 `clawock record --source <harness>`
+
+**未实现(如实声明)**:
+
+- **自动对账没有实现**。`settle_decisions`(ledger.py)只结算带
+  `plan_date`/`evaluation` 的 v2 计划行;v0 心智记录没有这两个字段,在
+  该函数开头就被跳过。`accounting` 块由 record.py 写入后没有任何代码
+  读取或更新它——`outcome.grade` 永远停在 `pending`,不存在
+  `correct|wrong|mixed` 的判定。旧文档「事后自动对账」的承诺不成立。
+- **校准未实现**:`build_record` 不写 `confidence_bin`,也没有任何统计
+  代码读取它;「我的 0.65 准不准」暂无答案。
+- 心智记录不参与 v2 的 episode/T+1 计分。
+
+## 样例(真实落库记录,memory/decisions.jsonl)
 
 ```
-00100 MINIMAX-W · 2026-08-16 · action reject(加仓) · 0.65 · fundamental
-Bull   营收 +159% YoY;入通/海外霸榜/高盛三催化叙事
+00100 MINIMAX-W · 2026-08-16 · action reject · 0.65 · fundamental
+Bull   营收 +159% YoY,入通/海外霸榜/高盛三催化叙事仍在
 Bear   净利率 -2368%、负债率 343%、每股净资产 -24.37;z+2.8σ 情绪极值反转
 Thesis 高增长救不了资不抵债,情绪反转期先活下来
-失效   缩量企稳 + 2 日不创新低 + 站回 340
-情绪   averaging_down —— 浮亏 -40% 的摊本冲动被压过,这次忍住没加
-对账   execution=未加仓(判定被遵守)· trigger=pending(等 340/企稳)
+失效   缩量企稳(量能低于前日50%) + 连续2日不创新低 + 站回 HK40
+情绪   averaging_down —— 浮亏 -40% 的摊本冲动被明确压过——忍住没加
+执行   followed(无操作判定被遵守)· accounting.outcome.grade=pending(无自动对账)
 ```
-
-## 样例二(历史复盘,可选补录):SPCH 无限子弹流
-
-```
-SPCH · 2026-06-23 · action add(第 6 次摊本) · 0.3 · sentiment
-Bull   无限子弹流,均价摊低后回本更快
-Bear   minmax 立场=反对:逆硬止损线第 6 次,累计加仓逼近 $3000
-Thesis 只要反弹就回本(事后看:反弹出现但被更高成本拖累)
-失效   单日 -15% 或正股单周 -25% 升级 P0
-情绪   averaging_down —— 明确自认:这单是情绪驱动
-对账   execution=已执行 10 股 @13.13 · outcome=mixed
-```
-
-## 面板设计(与 dashboard 同风格)
-
-- 令牌:bg #070A0F / 卡片 #202E3E / border #1D2937 / accent #36A3FF /
-  正 #28C08D / 负 #F05B67 / 警示 #E3A640(全部取自 dashboard.css)
-- 列表卡:日期分组,每张卡 = 标的 + action 胶囊(加=绿/减=红/观望=灰)+
-  信心 + 情绪胶囊(非 calm 才显示,警示色)+ 对账状态胶囊(已触发/已执行/待定)
-- 展开详情:Bull/Bear 对置条(正绿负红 + 证据计数)、信心计量条、
-  失效条件列表、情绪注记、对账区(触发/执行/校准)
-- 预览:`decision-mind-ledger.html`(静态 mock,本机可开)
-
-## 数据互通(一个账本,多个 harness 入口)
-
-- **唯一真源**:`<workspace>/memory/decisions.jsonl`。盘前 brief 决策与
-  各 harness(DSH/OpenClaw/Claude Code/Codex/CLI)的对话判定写同一个账本,
-  谁都能读。
-- **统一写入入口**:对话判定一律走 `clawock record --source <harness>`
-  (校验 bear/失效条件强制、冻结 mind/emotion、原子追加);**禁止手改
-  jsonl**。盘前决策由 brief postflight 写入(不经过 record)。
-- **面板(只读加工层)**:node 半区读该文件(默认工作区
-  `/root/.openclaw/workspace`,可配置),按 decision_group_id/decided_at
-  分组;旧记录没有 mind/emotion 字段时降级渲染(只有动作/条件/对账)。
-  插件不关心记录是谁写的,也不写任何数据——加工数据源,仅此而已。
-- **互通已验证(源码读证)**:`brief_postflight.log_decisions` 为
-  load → upsert/settle → 全量写回,不删外部记录;实现时用复制账本做
-  迁移测试钉住「对话记录经 postflight 一轮后仍在且被 settle」。
-- **kcn 自用**:面板默认指向每日 OpenClaw 运行的真实工作区,
-  决策记录实时可见。


### PR DESCRIPTION
#673 的修复:docs/decision-mind-ledger.md 按实况全面重写。

实况来源(均已读源码核对):

- `src/clawock/decision/record.py` —— 唯一写入方:v0 schema 样例与 `build_record` 输出同形,已验证可通过 `validate_mind_record`(issues=[]);SOURCES 不含 `brief`(choices 会拒);action/driven_by/emotion 三套枚举照抄
- `src/clawock/decision/ledger.py` —— `validate_decision` 仅在 `schema_version==0 且 source=="conversation"` 时路由到 mind 校验;`settle_decisions` 跳过无 `plan_date` 的 v0 行 ⇒ 自动对账未实现、`accounting.outcome.grade` 恒为 pending,如实写入「未实现」边界
- `examples/dsh/plugin/client.js` + `lib/*.js` —— 面板实为三视图(操作/账本/持仓)、浅色主题、Typert remote `clawockStudio` 只读;仓库不存在 decision-mind-ledger.html
- `examples/{openclaw,claude-code,codex}` —— 各 harness 统一 `clawock record --source <harness>`

主要修正:

1. 标题去掉「草案」,标注已落地(#661/#662)
2. v0 schema 示例可往返 validate_mind_record(含兼容字段 condition/execution 与 accounting 块)
3. 新增 record(v0) vs plan(v2) 两套 action/driven_by 词表对照表(旧文档「同词表」说法不成立)
4. 删除 brief 为合法 source、confidence_bin 校准、correct|wrong|mixed 自动对账等未实现承诺
5. 面板改述为三视图 + 浅色主题,删除暗色令牌与 decision-mind-ledger.html、/root/ 硬编码路径
6. 显式「已实现 / 未实现」边界

仅改一个文档文件。
