### PR TITLE
fix: 决策面板 outcome=loss 不再渲染绿色 + 移动端溢出止血 (#665 #674)

### DIFF
--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -82,19 +82,25 @@ window.__ModuleLoader__.load({
         '.dml .acc{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}',
         '.dml .stat{padding:10px 12px;border:1px solid var(--border-l2);border-radius:var(--radius-sm);background:var(--surface)}',
         '.dml .stat span{display:block;color:var(--text3);font-size:11px}.dml .stat b{font-size:13px;font-weight:600}',
-        '.dml .okb{color:var(--pos)}.dml .warnb{color:var(--warn)}.dml .grayb{color:var(--text2)}',
+        '.dml .okb{color:var(--pos)}.dml .negb{color:var(--neg)}.dml .warnb{color:var(--warn)}.dml .grayb{color:var(--text2)}',
         '.dml .mono{font-family:var(--mono);font-size:12px;color:var(--text2)}',
         '.dml table{width:100%;border-collapse:collapse;font-size:13px}',
         '.dml th{color:var(--text3);font-weight:600;text-align:left;padding:6px 10px;border-bottom:1px solid var(--border-l2);font-size:11.5px}',
         '.dml td{padding:7px 10px;border-bottom:1px solid var(--border-l1);font-variant-numeric:tabular-nums}',
         '.dml td.num{text-align:right;font-family:var(--mono);font-size:12.5px}',
-        '.dml .pos{color:var(--pos)}.dml .neg{color:var(--neg)}',
+        '.dml .pos{color:var(--pos)}.dml .neg{color:var(--neg)}.dml .row .pnl{font-size:12.5px}',
         '.dml .book{margin:12px 0}',
         '.dml .book h4{margin:0 0 8px;font-size:13px;font-weight:700;color:var(--text2)}',
         '.dml .plan{margin:8px 0;padding:12px 14px;border:1px solid var(--border-card);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-lv2)}',
         '.dml .plan .d{font-weight:700;font-size:13.5px;font-family:var(--mono)}',
         '.dml .plan .n{color:var(--text3);font-size:12.5px;margin-left:10px}',
         '.dml .empty{padding:26px 14px;text-align:center;color:var(--text3);font-size:13px}',
+        '@media (max-width:390px){',
+        '.dml .row{flex-wrap:wrap;min-height:44px}',
+        '.dml .pnl{flex-basis:100%;font-size:17px}',
+        '.dml .row .pnl{font-size:17px}',
+        '.dml .conf{flex-basis:100%;margin-left:0}',
+        '}',
       ].join('')
       document.head.appendChild(style)
     }
@@ -141,6 +147,13 @@ window.__ModuleLoader__.load({
     }
     function actionLabel(action) { return ACTION_LABELS[action] || String(action) }
 
+    /** Explicit outcome → tone map: only win is positive; loss/flat are negative. */
+    function outcomeTone(outcome) {
+      if (outcome === 'win') return 'ok'
+      if (outcome === 'loss' || outcome === 'flat') return 'neg'
+      return 'gray' // not_triggered | unknown | pending | missing
+    }
+
     function Chip(props) {
       return h('span', { className: 'chip ' + props.tone }, props.children)
     }
@@ -170,7 +183,7 @@ window.__ModuleLoader__.load({
       var why = d.thesis || d.rationale || (d.bull ? d.bull.slice(0, 48) : null)
       if (why && why.length > 60) why = why.slice(0, 57) + '…'
       var pnl = props.currentPnl
-      var outcomeTone = d.outcome && d.outcome !== 'not_triggered' && d.outcome !== 'unknown' ? 'ok' : 'gray'
+      var tone = outcomeTone(d.outcome)
       return h('div', { className: 'card' + (expanded ? ' open' : '') },
         h('div', { className: 'row', role: 'button', tabIndex: 0, 'aria-expanded': expanded, onClick: props.onToggle },
           h('span', { className: 'tk' }, d.ticker),
@@ -181,8 +194,8 @@ window.__ModuleLoader__.load({
           h('span', { className: 'chev' }, '▾')),
         h('div', { style: { padding: '0 14px 10px', fontSize: 12.5, color: 'var(--text2)', display: 'flex', gap: 12, flexWrap: 'wrap' } },
           why ? h('span', null, '为什么: ' + why) : null,
-          pnl !== null ? h('span', { className: pnl < 0 ? 'neg' : 'pos' }, '现盈亏 ' + (pnl > 0 ? '+' : '') + pnl.toFixed(1) + '%') : null,
-          d.outcome ? h('span', { className: outcomeTone === 'ok' ? 'pos' : 'grayb' }, 'outcome ' + d.outcome) : null),
+          pnl !== null ? h('span', { className: 'pnl ' + (pnl < 0 ? 'neg' : 'pos') }, '现盈亏 ' + (pnl > 0 ? '+' : '') + pnl.toFixed(1) + '%') : null,
+          d.outcome ? h('span', { className: tone === 'ok' ? 'pos' : tone === 'neg' ? 'neg' : 'grayb' }, 'outcome ' + d.outcome) : null),
         h('div', { className: 'detail' },
           d.bull || d.bear ? h('div', { className: 'vs' },
             h('div', { className: 'side bull' }, h('b', null, 'Bull'), h('p', null, d.bull || '—'), h('div', { className: 'src' }, 'evidence · decision time')),
@@ -198,7 +211,7 @@ window.__ModuleLoader__.load({
           (d.condition || d.executionStatus || d.outcome) ? h('div', { className: 'acc' },
             h('div', { className: 'stat' }, h('span', null, 'condition'), h('b', { className: 'grayb' }, d.condition || '—')),
             h('div', { className: 'stat' }, h('span', null, 'execution'), h('b', { className: d.executionStatus === 'followed' ? 'okb' : 'grayb' }, d.executionStatus || '—')),
-            h('div', { className: 'stat' }, h('span', null, 'outcome'), h('b', { className: d.outcome === 'not_triggered' ? 'grayb' : 'okb' }, d.outcome || '—'))) : null))
+            h('div', { className: 'stat' }, h('span', null, 'outcome'), h('b', { className: tone === 'ok' ? 'okb' : tone === 'neg' ? 'negb' : 'grayb' }, d.outcome || '—'))) : null))
     }
 
     function LedgerView(props) {
@@ -291,7 +304,7 @@ window.__ModuleLoader__.load({
             h('span', { className: 'mono', style: { color: 'var(--text2)' } },
               tr.shares + ' 股 @' + tr.price + (amount ? ' ≈' + sym + amount : '')),
             tr.realizedPnl !== null
-              ? h('span', { className: tr.realizedPnl < 0 ? 'neg' : 'pos', style: { fontFamily: 'var(--mono)', fontSize: 12.5 } },
+              ? h('span', { className: 'pnl ' + (tr.realizedPnl < 0 ? 'neg' : 'pos'), style: { fontFamily: 'var(--mono)' } },
                   (tr.realizedPnl >= 0 ? '+' : '') + tr.realizedPnl.toFixed(2))
               : null,
             h('span', { className: 'conf' }, tr.date || ''),

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -417,3 +417,119 @@ test("client: renders ledger cards from the mounted remote", async () => {
   assert.match(joined2, /站回 340/);
   assert.match(joined2, /忍住没加/);
 });
+
+test("client: loss/flat outcomes render the neg tone, never green (#665)", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
+
+  let registered = null;
+  let component = null;
+  const remoteFace = {
+    ledger: async () => ({ ok: true, value: { entries: [
+      { decision_id: "dec-loss1", source: "conversation", subject: { ticker: "09988", market: "HK" },
+        decided_at: "2026-08-15T10:00:00+08:00", action: "buy", confidence: 0.55,
+        execution: { status: "followed" }, evaluation: { outcome: "loss" } },
+      { decision_id: "dec-flat1", plan_date: "2026-08-14", ticker: "00700", action: "trim", confidence: 0.5,
+        execution: { status: "unknown" }, evaluation: { outcome: "flat" } },
+      { decision_id: "dec-nt1", plan_date: "2026-08-13", ticker: "09618", action: "trim", confidence: 0.5,
+        execution: { status: "unknown" }, evaluation: { outcome: "not_triggered" } },
+    ] } }),
+    portfolio: async () => ({ ok: true, value: { books: [], trades: [] } }),
+    plans: async () => ({ ok: true, value: { plans: [] } }),
+  };
+  const ctx = {
+    effect() {},
+    get() { return remoteFace; },
+    slots: {
+      inject(name, fn) { this._fn = fn; },
+      register(definition, Component) { registered = definition; component = Component; },
+    },
+    remote: { $mount: async () => {} },
+  };
+  await api.apply(ctx);
+  ctx.slots._fn();
+  const injected = registered.inject("s1");
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  let tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  await tick(); await tick(); await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+
+  const clickLabel = (label) => {
+    let found = null;
+    (function collect(node) {
+      if (node == null || found) return;
+      if (Array.isArray(node)) { node.forEach(collect); return; }
+      if (node.type === "button") {
+        const t = (node.children || []).filter((c) => typeof c === "string").join("");
+        if (t.indexOf(label) === 0) found = node;
+      }
+      (node.children || []).forEach(collect);
+    })(tree);
+    found.props.onClick();
+  };
+  const outcomeSpansIn = (node) => {
+    const spans = [];
+    (function collect(n) {
+      if (n == null) return;
+      if (Array.isArray(n)) { n.forEach(collect); return; }
+      if (n.props && typeof n.props.className === "string") {
+        const t = (n.children || []).filter((c) => typeof c === "string").join("");
+        if (t.indexOf("outcome") >= 0) spans.push({ cls: n.props.className, text: t });
+      }
+      (n.children || []).forEach(collect);
+    })(node);
+    return spans;
+  };
+
+  // executed-trades filter: the followed loss entry is the only card
+  clickLabel("账本");
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const loss = outcomeSpansIn(tree).find((s) => s.text.indexOf("loss") >= 0);
+  assert.ok(loss, "loss outcome must render in the ledger sub-row");
+  assert.match(loss.cls, /\bneg\b/, "loss must use the neg tone");
+  assert.doesNotMatch(loss.cls, /\bpos\b/, "loss must never render green");
+
+  // expanded card: the outcome stat must agree (negb, not okb)
+  const rows = [];
+  (function collect(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(collect); return; }
+    if (node.props && node.props.onClick && node.props.className === "row") rows.push(node);
+    (node.children || []).forEach(collect);
+  })(tree);
+  assert.ok(rows.length >= 1, "ledger card row must render");
+  rows[0].props.onClick();
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const outcomeStats = [];
+  (function collect(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(collect); return; }
+    if (node.type === "b" && node.props && typeof node.props.className === "string") {
+      const t = (node.children || []).filter((c) => typeof c === "string").join("");
+      outcomeStats.push({ cls: node.props.className, text: t });
+    }
+    (node.children || []).forEach(collect);
+  })(tree);
+  const lossStat = outcomeStats.find((s) => s.text === "loss");
+  assert.ok(lossStat, "loss stat must render when the card is expanded");
+  assert.equal(lossStat.cls, "negb", "loss stat must use negb, not okb");
+
+  // 全部: flat shares neg, not_triggered stays gray
+  clickLabel("全部");
+  await tick();
+  tree = component({ sessionId: "s1", ledger: injected.ledger, portfolio: injected.portfolio, plans: injected.plans });
+  const allSpans = outcomeSpansIn(tree);
+  const flat = allSpans.find((s) => s.text.indexOf("flat") >= 0);
+  assert.ok(flat, "flat outcome must render");
+  assert.match(flat.cls, /\bneg\b/, "flat must share the neg tone");
+  assert.doesNotMatch(flat.cls, /\bpos\b/);
+  const nt = allSpans.find((s) => s.text.indexOf("not_triggered") >= 0);
+  assert.ok(nt, "not_triggered outcome must render");
+  assert.match(nt.cls, /\bgrayb\b/, "not_triggered must stay gray");
+});


### PR DESCRIPTION
## #665 · outcome=loss 不再渲染绿色

`examples/dsh/plugin/client.js` 之前把「非 not_triggered / unknown 的 outcome」一律当成 ok 色：
- 副行 span：`outcomeTone === 'ok' ? 'pos' : 'grayb'` → loss/flat/pending 全绿
- 对账 stat：`d.outcome === 'not_triggered' ? 'grayb' : 'okb'` → loss/flat 也是绿色

改为显式映射 `outcomeTone()`：

| outcome | 副行 span | 对账 stat |
|---|---|---|
| `win` | `pos` | `okb` |
| `loss` / `flat` | `neg` | `negb`（新增 `.dml .negb{color:var(--neg)}`） |
| `not_triggered` / `unknown` / `pending` / 缺失 | `grayb` | `grayb` |

新增 spec：`client: loss/flat outcomes render the neg tone, never green (#665)`，fixture 含 loss（followed+buy）、flat、not_triggered 三条，断言 loss/flat 渲染 `neg` 类且不含 `pos`，展开后 stat 为 `negb`，not_triggered 保持 `grayb`。
回归验证：对新断言，旧映射下测试失败（`loss must use the neg tone` / `loss stat must use negb, not okb`），新映射下通过。

## #674 · 移动端溢出止血（≤390px）

新增 `@media (max-width:390px)` 块（沿用 inline-CSS-string 风格）：
- `.dml .row{flex-wrap:wrap;min-height:44px}` — action row 换行，tap 目标 ≥40px
- `.dml .pnl{flex-basis:100%;font-size:17px}` + `.dml .row .pnl{font-size:17px}` — 盈亏独占一行且字号 ≥17px（ops 行内样式 fontSize 移到基础规则 `.dml .row .pnl{font-size:12.5px}`，桌面视觉不变，小屏可被覆盖）
- `.dml .conf{flex-basis:100%;margin-left:0}` — 日期/置信度可换行，不再被截断

## 测试

```
$ node --check examples/dsh/plugin/client.js   # OK
$ node tests/decision_studio_plugin.spec.js
# tests 8
# pass 8
# fail 0
```

新断言对旧映射回归（红→绿）：`# pass 7 / # fail 1`（仅新测试失败）。
