### PR TITLE
docs: release.md 补充 npm/dsh 发布路径与三处版本契约 (#675)

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -57,6 +57,55 @@ afterwards means the artifact is already on PyPI describing itself as something
 nobody wrote down, and a published version cannot be replaced — only superseded,
 which is what 0.1.1 cost.
 
+## The npm side: `clawock-dsh` (DSH skill package)
+
+The DSH skill package rides the same version train as the Python package.
+`ops/publish/publish_dsh_plugin.sh` is the single entry point for every npm
+publication path — release.yml and a human both go through it:
+
+```bash
+# Publish whatever version examples/dsh/plugin/package.json declares
+NPM_TOKEN=... ops/publish/publish_dsh_plugin.sh
+
+# Standalone npm bump (no GitHub Release, no PyPI): the version is explicit
+NPM_TOKEN=... ops/publish/publish_dsh_plugin.sh 0.2.1
+```
+
+`NPM_TOKEN` is the npm registry auth token and the only environment input the
+script needs (a userconfig with registry auth works too). Before touching the
+registry it runs `npm pack --dry-run` and verifies the package and its
+`skills/investment-decision/SKILL.md` both exist.
+
+On a `v*` tag the workflow's `npm` job calls the same script with the tag
+version (`"${GITHUB_REF_NAME#v}"`), so PyPI and npm publish together; the GitHub
+Release is created only after both publishers accepted (`needs: [publish, npm]`).
+PR pushes and TestPyPI dispatches never touch npm.
+
+## One version, three places
+
+A release version is declared in `pyproject.toml`, and two other places must
+not disagree with it:
+
+- `pyproject.toml` — what PyPI publishes; the workflow refuses a tag that
+  disagrees with it
+- `examples/dsh/plugin/package.json` — what npm publishes; the publish script
+  bumps it to the version it is given
+- `CHANGELOG.md` top entry — what the version claims to contain
+
+`tests/test_versions_agree.py` enforces the contract in CI: the newest changelog
+entry must be the `pyproject.toml` version, entries must be unique and
+newest-first, and the changelog must be reachable from the package metadata. A
+bump that updates `pyproject.toml` alone meets a red `validate` before any tag
+can be cut.
+
+## The bump is idempotent
+
+`npm version <same>` exits non-zero (#617), so both publish paths compare
+first: when `package.json` already sits at the target version — a re-run after
+a partial failure, for instance — the bump is skipped with no error and the
+flow proceeds straight to publish. Running the standalone command twice is
+safe.
+
 ## What the release job proves before it publishes
 
 - `twine check` on both the sdist and the wheel.


### PR DESCRIPTION
## 背景

#586/#590/#628 加了 npm/dsh 发布路径，但 `docs/operations/release.md` 仍是零 npm 内容（#675）。

## 变更

`docs/operations/release.md` 新增三节：

- **npm 侧发布路径**：`ops/publish/publish_dsh_plugin.sh` 是唯一入口；release.yml 打 `v*` tag 时 `npm` job 带 tag 版本调用它（PyPI 与 npm 同发，GitHub Release 需两者都成功后创建），人工 standalone bump 用显式版本参数；需 `NPM_TOKEN`
- **三处版本一致性**：`pyproject.toml` / `examples/dsh/plugin/package.json` / `CHANGELOG.md` 顶部条目，CI 由 `tests/test_versions_agree.py` 把关（最新 changelog 条目必须等于 pyproject 版本、唯一且新在前）
- **幂等 bump**：#617 之后两条路径都先比较，`package.json` 已同步则跳过 bump、不报错，直接进入发布；standalone 命令跑两次安全

仅文档改动，无代码变更。
