### PR TITLE
fix: T+1 结果颜色按动作方向映射——买入涨为 win/绿、卖出涨为 loss/红(卖飞) (#665)

### DIFF
--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -133,6 +133,23 @@ window.__ModuleLoader__.load({
 
     function esc(s) { return String(s == null ? '' : s).replace(/</g, '&lt;') }
 
+    /** T+1 tone is action-aware: a rising price is good for the buyer and bad
+     *  for the seller (卖飞). One sign rule for both would color buy gains red
+     *  and buy losses green. */
+    function t1Tone(action, delta) {
+      var up = delta >= 0
+      var sell = action === 'sell' || action === 'cut' || action === 'trim' || action === 'trim_on_rebound'
+      if (sell) return up ? 'loss' : 'win'
+      return up ? 'win' : 'loss'
+    }
+    function t1ChipTone(action, delta) {
+      if (delta > -1 && delta < 1) return 'flat'
+      var up = delta >= 1
+      var sell = action === 'sell' || action === 'cut' || action === 'trim' || action === 'trim_on_rebound'
+      if (sell) return up ? 'down' : 'up'
+      return up ? 'up' : 'down'
+    }
+
     function fmtMoney(v) {
       if (v == null || !isFinite(v)) return '—'
       return (v > 0 ? '+' : '') + Number(v).toLocaleString(undefined, { maximumFractionDigits: 0 })
@@ -169,7 +186,7 @@ window.__ModuleLoader__.load({
       var d = t.decision
       var sym = t.currency === 'HKD' ? 'HK$' : '$'
       if (!d) {
-        var t1miss = t.t1 ? h('div', { className: 'tnode ' + (t.t1.delta >= 0 ? 'loss' : 'win') },
+        var t1miss = t.t1 ? h('div', { className: 'tnode ' + t1Tone(t.action, t.t1.delta) },
           h('div', { className: 'n' }, 'T+1 结果'),
           h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%')) : null
         return h('div', null,
@@ -194,7 +211,7 @@ window.__ModuleLoader__.load({
       if (d.condition) chips.push(h('span', { className: 'pc', key: 'c' }, '条件: ' + d.condition))
       if (d.sizeShares) chips.push(h('span', { className: 'pc', key: 's' }, '计划 ' + d.sizeShares + ' 股'))
       if (d.plannedPrice) chips.push(h('span', { className: 'pc', key: 'p' }, '计划价 ' + d.plannedPrice))
-      var t1node = t.t1 ? h('div', { className: 'tnode ' + (t.t1.delta >= 0 ? 'loss' : 'win') },
+      var t1node = t.t1 ? h('div', { className: 'tnode ' + t1Tone(t.action, t.t1.delta) },
         h('div', { className: 'tw' }, t.t1.date),
         h('div', { className: 'n' }, 'T+1 结果'),
         h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' · ' + t.t1.verdict : ''))) : null
@@ -235,7 +252,7 @@ window.__ModuleLoader__.load({
       else pnl = h('span', { className: 'pnl na' }, '—')
       var t1tag = null
       if (t.t1) {
-        var tc = t.t1.delta >= 0 ? 'down' : (t.t1.delta < -1 ? 'up' : 'flat')
+        var tc = t1ChipTone(t.action, t.t1.delta)
         var tlabel = 'T+1 ' + (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' ' + t.t1.verdict : '')
         t1tag = h('span', { className: 't1 ' + tc }, tlabel)
       } else if (t.action === 'sell') {
@@ -398,7 +415,7 @@ window.__ModuleLoader__.load({
       })
     }
 
-    module.exports = { apply: apply, inject: inject, _displayEntry: _displayEntry }
+    module.exports = { apply: apply, inject: inject, _displayEntry: _displayEntry, t1Tone: t1Tone, t1ChipTone: t1ChipTone }
     return module.exports
   },
 })

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2777,6 +2777,15 @@
     const EMO = {fomo:"追高冲动",revenge:"报复性",averaging_down:"摊薄冲动",fear:"恐慌",euphoria:"亢奋",calm:"平静",mixed:"混合"};
     const esc = escapeHtml;
 
+    // T+1 tone is action-aware: a rising price is good for the buyer, bad for
+    // the seller (卖飞). One sign rule for both would color buy gains red.
+    const t1Cls = (t) => {
+      const up = t.t1.delta >= 0;
+      const sell = t.action === "sell" || t.action === "cut" || t.action === "trim" || t.action === "trim_on_rebound";
+      if (sell) return up ? "neg" : "pos";
+      return up ? "pos" : "neg";
+    };
+
     // Stats row: USD-eq realized + T+1 verdict counts + match rate.
     const usd = list.filter(t => t.realizedPnl != null && t.currency === "USD").reduce((s,t) => s + t.realizedPnl, 0);
     const hkd = list.filter(t => t.realizedPnl != null && t.currency === "HKD").reduce((s,t) => s + t.realizedPnl, 0);
@@ -2805,7 +2814,7 @@
       const sym = t.currency === "HKD" ? "HK$" : "$";
       if (!d) {
         let t1 = "";
-        if (t.t1) t1 = `<div class="tr-node ${t.t1.delta >= 0 ? "neg" : "pos"}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}</div></div>`;
+        if (t.t1) t1 = `<div class="tr-node ${t1Cls(t)}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}</div></div>`;
         return `<div class="trace-line">
           <div class="tr-node dec"><div class="tr-n">决策</div><div class="tr-v muted">无关联记录</div></div>
           <div class="tr-node ok"><div class="tr-n">执行</div><div class="tr-v">${esc(ACT[t.action] || t.action)} ${t.shares}股 @${t.price} ${sym}</div></div>
@@ -2822,7 +2831,7 @@
       if (d.sizeShares) chips += `<span class="tr-chip">计划 ${d.sizeShares} 股</span>`;
       if (d.plannedPrice) chips += `<span class="tr-chip">计划价 ${d.plannedPrice}</span>`;
       let t1 = "";
-      if (t.t1) t1 = `<div class="tr-node ${t.t1.delta >= 0 ? "neg" : "pos"}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}${t.action === "sell" ? " · " + t.t1.verdict : ""}</div></div>`;
+      if (t.t1) t1 = `<div class="tr-node ${t1Cls(t)}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}${t.action === "sell" ? " · " + t.t1.verdict : ""}</div></div>`;
       let rv, rc;
       if (t.realizedPnl != null) { rv = (t.realizedPnl >= 0 ? "+" : "") + Number(t.realizedPnl).toFixed(2) + " " + sym; rc = t.realizedPnl >= 0 ? "pos" : "neg"; }
       else if (t.holdPnl != null) { rv = fmtPct(t.holdPnl, 1); rc = t.holdPnl >= 0 ? "pos" : "neg"; }
@@ -2848,7 +2857,7 @@
             ? `<span class="tr-pnl ${t.realizedPnl >= 0 ? "pos" : "neg"}">${t.realizedPnl >= 0 ? "+" : ""}${Number(t.realizedPnl).toFixed(2)} ${t.currency === "HKD" ? "HK$" : "$"}</span>`
             : (t.holdPnl != null ? `<span class="tr-pnl ${t.holdPnl >= 0 ? "pos" : "neg"}">${fmtPct(t.holdPnl, 1)}</span>` : "");
           const t1tag = t.t1
-            ? `<span class="tr-t1 ${t.t1.delta >= 0 ? "neg" : "pos"}">T+1 ${fmtPct(t.t1.delta, 1)} ${t.t1.verdict}</span>`
+            ? `<span class="tr-t1 ${t1Cls(t)}">T+1 ${fmtPct(t.t1.delta, 1)} ${t.t1.verdict}</span>`
             : "";
           return `<details class="tr-row">
             <summary>

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -379,3 +379,31 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined2, /执行/);
   assert.match(joined2, /盈亏/);
 });
+
+test("client: T+1 tone is action-aware — buy gains are win, sell misses are loss (#665)", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
+  const t1Tone = api.t1Tone;
+  assert.ok(t1Tone, "t1Tone exported for the spec");
+  // buy: price up = win (green), price down = loss (red)
+  assert.equal(t1Tone("buy", 5.0), "win");
+  assert.equal(t1Tone("buy", -4.76), "loss");
+  assert.equal(t1Tone("add", 0.5), "win");
+  // sell family: price up after selling = 卖飞 (loss), down = 卖对 (win)
+  assert.equal(t1Tone("sell", 5.0), "loss");
+  assert.equal(t1Tone("sell", -1.52), "win");
+  assert.equal(t1Tone("cut", 2.0), "loss");
+  assert.equal(t1Tone("trim_on_rebound", -2.0), "win");
+  // chip tone: |delta|<1 is flat; direction flips with action
+  assert.equal(api.t1ChipTone("buy", 0.3), "flat");
+  assert.equal(api.t1ChipTone("sell", 0.3), "flat");
+  assert.equal(api.t1ChipTone("buy", 4.0), "up");
+  assert.equal(api.t1ChipTone("buy", -4.0), "down");
+  assert.equal(api.t1ChipTone("sell", 4.0), "down");
+  assert.equal(api.t1ChipTone("sell", -4.0), "up");
+});
+


### PR DESCRIPTION
#676(决策轨迹卡片,并行会话)重写 client.js 时把旧 LedgerView 的 outcome 展示换成了 T+1 节点,但引进了同一族新 bug:`t.t1.delta >= 0 ? 'loss' : 'win'` 用卖出的语义套所有动作——买入后涨 5% 显示红 loss、买入后跌显示绿 win(sell 语义才正确)。dashboard.render.js 的 tr-node/tr-t1 同型。

## 改动

- client.js:新增 t1Tone/t1ChipTone,动作感知(buy/add → 涨=win/up;sell/cut/trim 族 → 涨=loss/down);三处调用点替换
- dashboard.render.js:t1Cls 助手,三处 tr-node/tr-t1 类名替换
- spec 新增 8 向断言 + 变异验证(把 helper 改回旧 sell-only 规则 → 新测试红)

## 验证

- node tests/decision_studio_plugin.spec.js 8/8
- 变异回退 → 7/8(新测试红),已恢复
