### PR TITLE
docs: memory/2026-08-15.md 补充 clawock-dsh 0.1.4 发布记录 (#641)

### DIFF
--- a/memory/2026-08-15.md
+++ b/memory/2026-08-15.md
@@ -10,7 +10,7 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 1. **README.zh.md 全面重写**(328 行 → ~300 行):第一行宣言(90 天/实盘 −15.95%/ledger 链接/`clawock audit-resettle` 复算/"模型不能给自己打分——全网第一个把 AI 战绩交给代码结算的投研台")、12 个标准 H2 结构(parity CI 锁定)、装起来(甩给 AI 三步+手动+demo 输出)、公开战绩(177 表+人话翻译+四条线对账表)、为什么可信、LLM 决策(大白话版+信息流图+影响者雷达)、许可(为什么开源:作者真实账户,不收费无荐股群)
 2. **README.md(en)**:harness-agnostic 定位同步;PyPI 渲染规则修复(相对链接→绝对 URL);补 information-flow.svg(资产 parity)
 3. **examples/harness-agnostic/**(5 文件):纯 CLI/OpenClaw skill/Claude Code 指令/Codex AGENTS.md/DSH 五种跑法;run.sh 已注册 release.yml
-4. **dsh-plugin/**(clawock-dsh npm 包):package.json(dsh.skills)+ SKILL.md + README;npm pack 验证通过,**clawock-dsh@0.1.0 已于 08-15 23:36 HKT 发布,0.1.3 随 release 流程发布(见 #591)**
+4. **dsh-plugin/**(clawock-dsh npm 包):package.json(dsh.skills)+ SKILL.md + README;npm pack 验证通过,**clawock-dsh@0.1.0 已于 08-15 23:36 HKT 发布,0.1.3 随 release 流程发布(见 #591);08-16 已随 v0.1.4 release 发布 0.1.4**
 5. **数字自动刷新**:ops/growth/refresh_readme_metrics.py(从 ledger+data-plane 重算全部指标,替换 `<!-- CW_M:* -->` 占位符,写 readme_metrics.json)+ .github/workflows/readme-metrics.yml(每周一 01:15 UTC)
 6. **site/assets/information-flow.svg** 新增
 7. 其他:DSH badge、topics 优化(trading/deepseek-harness/dsh-plugin/quantitative-finance/self-hosted 等,按热度×唯一性重选)
@@ -29,7 +29,7 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 - #560-564 全部 close(PR #568 处理;CLI 瘦身 #560 保留为产品方向)
 
 ### 遗留事项(下一步)
-1. ~~**npm publish clawock-dsh**~~ ✅ **已完成**:clawock-dsh@0.1.0 于 08-15 23:36 HKT 发布、0.1.3 随 v0.1.3 release(16:08Z)发布;README 的 `dsh plugin --profile web add clawock-dsh` 已生效。注:此前记的 `.clawhub/local-memory.md` 不存在(gitignored 文件从未落盘),凭据/状态请以 npm registry 为准
+1. ~~**npm publish clawock-dsh**~~ ✅ **已完成**:clawock-dsh@0.1.0 于 08-15 23:36 HKT 发布、0.1.3 随 v0.1.3 release(16:08Z)发布、0.1.4 随 v0.1.4 release(08-16)发布;README 的 `dsh plugin --profile web add clawock-dsh` 已生效。注:此前记的 `.clawhub/local-memory.md` 不存在(gitignored 文件从未落盘),凭据/状态请以 npm registry 为准
 2. **SEO/GEO(#564 的落地内容)**:llms.txt、FAQ 页(打真实搜索词)、每日中文简报关键词化+hub 页——尚未做,需新 issue→PR
 3. **推广文案**:X 版(英文,含 ready-to-post tweet 草稿在 .x-review.md 曾生成)+ 知乎版(蹭 DSH 热点:8/13 DeepSeek Harness 开源一夜 5 万星,clawock harness-agnostic + dsh skill 包)
 4. 影子组合"bring your own decisions"(clawock settle my_trades.csv)产品化建议——X 英文博主提出,可开 issue
@@ -58,13 +58,13 @@ kcn 要求以第三方 critical 视角 review clawock(README zh/seo/geo/为什�
 ### 外部渠道(官方口径)
 - **WhaleHub(vvlife/whalehub-dsh)**:第三方社区市场,**非官方——已撤回 PR #9 并清理 fork**。原则:只走官方渠道(DeepSeek Harness 官方/npm),不主动登记第三方市场
 - **YELEBAI/dsh-plugin-marketplace**:同样是第三方,但**无需手动提交**(自动扫描 `topic:dsh-plugin` + npm 核验),topic 已加属 GitHub 官方功能,保留无害
-- **npm registry**:官方分发渠道,**已发布 clawock-dsh@0.1.0(23:36 HKT)/0.1.3(16:08Z)**,YELEBAI 已可自动收录
+- **npm registry**:官方分发渠道,**已发布 clawock-dsh@0.1.0(23:36 HKT)/0.1.3(16:08Z)/0.1.4(08-16 v0.1.4)**,YELEBAI 已可自动收录
 
 ### ⚠️ 仓库规则(重要)
 GitHub 仓库保护规则:master **必须走 PR**(Changes must be made through a pull request + 6 required checks)。**交互式 agent 的代码改动任何直推都被拒**(含 memory 类提交);唯一例外是**自动化发布路径**:DeployKey(运行时市场数据/dashboard/README 刷新等生成物)按 workflow 白名单直推 master,github-actions bot 的 dashboard/portfolio 刷新持续走此路径。`a5be119d`(08-15 20:17 "memory: 8月零加仓诊断")无关联 PR,属 admin/DeployKey 路径之外的特例,已记录待 kcn 确认。live checkout 必须留在 master(08-15 曾误留 feature 分支,已恢复)。以后交互式提交:worktree → 分支 → PR → CI 绿 → squash merge。
 
 ### 遗留(未完成)
-1. ~~**npm publish clawock-dsh**~~ ✅ 已完成(0.1.0/0.1.3);发布后 YELEBAI 自动收录 + README 安装命令已生效
+1. ~~**npm publish clawock-dsh**~~ ✅ 已完成(0.1.0/0.1.3/0.1.4);发布后 YELEBAI 自动收录 + README 安装命令已生效
 2. 外部仓库提交原则:**必须经 kcn 同意**(WhaleHub PR #9 已撤回,教训已记)
 2. 推广发布(X/知乎/小红书文案已就绪,需 kcn 账号执行)
 3. 每日简报标题关键词化(属 runtime 生成内容)


### PR DESCRIPTION
#641:memory/2026-08-15.md 四处写 clawock-dsh 发布到 0.1.3 为止,补上 08-16 随 v0.1.4 release 发布的 0.1.4(不重写历史,追加最新版本)。
