### PR TITLE
feat: 恢复 Nostr/Rick 自动战绩播报通道(脚本+测试+cron_timeline 解析) (#671)

### DIFF
--- a/ops/growth/nostr_publish.js
+++ b/ops/growth/nostr_publish.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/*
+ * nostr_publish.js — publish a public kind-1 note to Nostr relays.
+ *
+ * openclaw's bundled Nostr channel is NIP-04 DM-only, so for public
+ * broadcasting (Rick's scorecard posts) we sign + publish directly with
+ * nostr-tools (already vendored by the @openclaw/nostr plugin).
+ *
+ *   NOSTR_PRIVATE_KEY=<nsec|hex> node nostr_publish.js  <<< "post text"
+ *   echo "..." | node ops/growth/nostr_publish.js --dry-run
+ *
+ * Prints the author npub, event id, and an njump.me permalink.
+ */
+const fs = require("fs");
+const path = require("path");
+const { createRequire } = require("module");
+
+// --- locate nostr-tools inside the installed openclaw nostr plugin ---------
+function findNostrTools() {
+  if (process.env.NOSTR_TOOLS_PATH) return process.env.NOSTR_TOOLS_PATH;
+  const base = "/root/.openclaw/npm/projects";
+  let dirs = [];
+  try {
+    dirs = fs.readdirSync(base).filter((d) => d.startsWith("openclaw-nostr-"));
+  } catch (_) { /* ignore */ }
+  for (const d of dirs) {
+    const p = path.join(base, d, "node_modules/@openclaw/nostr/node_modules/nostr-tools");
+    if (fs.existsSync(p)) return p;
+  }
+  return "nostr-tools"; // last resort: hope it's on NODE_PATH
+}
+const nt = createRequire(findNostrTools() + "/")("nostr-tools");
+const { finalizeEvent, getPublicKey, SimplePool, nip19 } = nt;
+
+const RELAYS = (process.env.NOSTR_RELAYS ||
+  "wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net,wss://relay.nostr.band"
+).split(",").map((s) => s.trim()).filter(Boolean);
+
+function parseKey(raw) {
+  raw = (raw || "").trim();
+  if (!raw) throw new Error("NOSTR_PRIVATE_KEY is empty");
+  if (raw.startsWith("nsec")) {
+    const { type, data } = nip19.decode(raw);
+    if (type !== "nsec") throw new Error("not an nsec key");
+    return data; // Uint8Array
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) return Uint8Array.from(Buffer.from(raw, "hex"));
+  throw new Error("key must be nsec... or 64-char hex");
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const text = fs.readFileSync(0, "utf8").trim(); // stdin
+  if (!text) throw new Error("empty post (nothing on stdin)");
+
+  const sk = parseKey(process.env.NOSTR_PRIVATE_KEY);
+  const pk = getPublicKey(sk);
+  const npub = nip19.npubEncode(pk);
+
+  const evt = finalizeEvent(
+    { kind: 1, created_at: Math.floor(Date.now() / 1000), tags: [], content: text },
+    sk
+  );
+
+  console.error(`author : ${npub}`);
+  console.error(`event  : ${evt.id}`);
+  console.error(`chars  : ${text.length}`);
+  if (dryRun) {
+    console.error("DRY RUN — not published.");
+    console.log(JSON.stringify(evt, null, 2));
+    return;
+  }
+
+  const pool = new SimplePool();
+  const results = await Promise.allSettled(pool.publish(RELAYS, evt));
+  const ok = results.filter((r) => r.status === "fulfilled").length;
+  console.error(`published to ${ok}/${RELAYS.length} relays`);
+  console.error(`view   : https://njump.me/${nip19.neventEncode({ id: evt.id, relays: RELAYS.slice(0, 2) })}`);
+  try { pool.close(RELAYS); } catch (_) { /* ignore */ }
+  if (ok === 0) process.exit(1);
+}
+
+main().catch((e) => { console.error("ERROR:", e.message); process.exit(1); });

--- a/ops/growth/rick_broadcast.py
+++ b/ops/growth/rick_broadcast.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""rick_broadcast.py — turn the self-grading scorecard into a Rick-voiced post.
+
+Reads the honest v2 decision ledger plus the quant/T+0 review sidecars
+and emits a short, ready-to-post update in Rick's voice. Delivery is a separate
+concern: this only prints text (and optional --json) to stdout, so you can pipe
+it to X / Nostr / a copy-paste, manually or from a cron.
+
+Usage:
+    python3 ops/growth/rick_broadcast.py            # both languages
+    python3 ops/growth/rick_broadcast.py --lang en  # english only
+    python3 ops/growth/rick_broadcast.py --json     # machine-readable
+"""
+from __future__ import annotations
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_CHECKOUT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CHECKOUT))
+sys.path.insert(0, str(_CHECKOUT / "src"))
+from clawock.decision import ledger as decision_v2  # noqa: E402
+QUANT = _CHECKOUT / "assets" / "data" / "quant_signal_review.json"
+T0 = _CHECKOUT / "assets" / "data" / "t0_setup_review.json"
+REPO = "github.com/KCNyu/clawock"
+DASH = "kcnyu.github.io/clawock"   # live dashboard — the clickable landing (has the card + links back to the repo)
+
+# The model's *active* directional calls vs. just sitting on a position. Read the
+# split from decision_v2 so the broadcast and the dashboard can never disagree on
+# what "active" means — `watch` is a standing stance and belongs with the passives.
+ACTIVE = decision_v2.ACTIVE_ACTIONS
+PASSIVE = decision_v2.PASSIVE_ACTIONS
+
+
+def _rate(rows):
+    """win-rate over settled (win/loss) rows; returns (pct:int|None, n:int)."""
+    settled = [r for r in rows if r["outcome"] in ("win", "loss")]
+    if not settled:
+        return None, 0
+    wins = sum(1 for r in settled if r["outcome"] == "win")
+    return round(100 * wins / len(settled)), len(settled)
+
+
+def scorecard():
+    rows = decision_v2.episode_representatives(decision_v2.load_decisions(), "t1")
+    def pct(group):
+        return (round(100 * sum((r.get("evaluation") or {}).get("outcome") == "win" for r in group) / len(group)), len(group)) if group else (None, 0)
+    active_rows = [r for r in rows if r.get("action") in ACTIVE]
+    active_pct, active_n = pct(active_rows)
+    hold_pct, hold_n = pct([r for r in rows if r.get("action") in PASSIVE])
+    hi_pct, hi_n = pct([r for r in active_rows if float(r.get("confidence") or 0) >= 0.75])
+
+    out = {
+        "active_hit": active_pct, "active_n": active_n,
+        "hold_hit": hold_pct, "hold_n": hold_n,
+        "high_conf_hit": hi_pct, "high_conf_n": hi_n,
+        "total_settled": len(rows),
+    }
+
+    # T+0 setup grades (usable ones only) — the "card read" honesty
+    try:
+        t0 = json.load(open(T0))
+        out["t0"] = {
+            k: {"label": g["label"], "hit": round(100 * g["hit_rate"]), "n": g["n"]}
+            for k, g in t0.get("grades", {}).items()
+            if g.get("usable") and g.get("hit_rate") is not None
+        }
+        out["t0_days"] = t0.get("days_logged")
+    except (OSError, ValueError):
+        out["t0"] = {}
+
+    # quant factors: how many have earned the right to speak (usable=True)
+    try:
+        q = json.load(open(QUANT))
+        facs = q.get("factors", {})
+        out["quant_usable"] = sum(1 for f in facs.values() if f.get("usable"))
+        out["quant_total"] = len(facs)
+    except (OSError, ValueError):
+        out["quant_usable"], out["quant_total"] = 0, 0
+    return out
+
+
+def render_en(s):
+    lines = ["📈 Rick's recommendation report card — directional hit rates, graded by Python:", ""]
+    if s["active_hit"] is not None:
+        lines.append(f"• active calls: {s['active_hit']}% (n={s['active_n']})")
+    if s["hold_hit"] is not None:
+        lines.append(f"• just holding: {s['hold_hit']}% (n={s['hold_n']})")
+    if s["high_conf_hit"] is not None:
+        lines.append(f"• high-conviction active calls: {s['high_conf_hit']}% (n={s['high_conf_n']})")
+    # Active calls and passive holds are different claim types over different sample
+    # pools (decision_v2.compute_metrics treats them as separate), so ranking one
+    # against the other is not a valid read — publish both, rank neither. "Python
+    # keeps the scorecard" only means the model does not grade itself.
+    verdict = ("active calls and passive holds are different bets on different samples — "
+               "I publish both and rank neither. Python keeps the scorecard, I don't get to grade myself.")
+    lines += ["", verdict, "", f"See it live 👉 {DASH}", f"⭐ open source 👉 {REPO}"]
+    return "\n".join(lines)
+
+
+def render_zh(s):
+    lines = ["📈 Rick 的建议成绩单 —— Python 统计判断方向命中率:", ""]
+    if s["active_hit"] is not None:
+        lines.append(f"• 主动操作(cut/trim/加仓):命中 {s['active_hit']}%(n={s['active_n']})")
+    if s["hold_hit"] is not None:
+        lines.append(f"• 只是躺着 hold:{s['hold_hit']}%(n={s['hold_n']})")
+    if s["high_conf_hit"] is not None:
+        lines.append(f"• 高信心主动判断:{s['high_conf_hit']}%(n={s['high_conf_n']})")
+    # 主动操作与被动持有是两类不同的赌注、不同的样本池,不做高下排名(见
+    # decision_v2.compute_metrics 把两者当不同 claim)。
+    verdict = ("主动操作和被动持有是两类不同的赌注、不同的样本 —— 两个数都摆出来,不做高下排名。"
+               "战绩表是 Python 另算的,我评不了自己。")
+    lines += ["", verdict, "", f"实时看板 👉 {DASH}", f"⭐ 开源 👉 {REPO}"]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lang", choices=["en", "zh", "both"], default="both")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+    s = scorecard()
+    if args.json:
+        print(json.dumps({"scorecard": s,
+                          "en": render_en(s), "zh": render_zh(s)},
+                         ensure_ascii=False, indent=2))
+        return
+    if args.lang in ("en", "both"):
+        print(render_en(s))
+    if args.lang == "both":
+        print("\n" + "─" * 40 + "\n")
+    if args.lang in ("zh", "both"):
+        print(render_zh(s))
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/growth/rick_broadcast_nostr.sh
+++ b/ops/growth/rick_broadcast_nostr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Autonomous Nostr broadcast: Rick's self-grading scorecard → public kind-1 note.
+# Zero-touch — no account, no API key beyond the local Nostr secret.
+# Key lives OUTSIDE the repo (never committed); only the env var is passed in.
+set -euo pipefail
+
+cd /root/.openclaw/workspace
+
+# cron runs with a minimal PATH that lacks nvm's node bin → `node: command not found`.
+# Detect the newest installed nvm node and prepend it (survives node version bumps).
+if ! command -v node >/dev/null 2>&1; then
+  NODE_BIN="$(find /root/.nvm/versions/node -mindepth 2 -maxdepth 2 \
+    -type d -name bin -print 2>/dev/null | sort -V | tail -1)"
+  [[ -n "$NODE_BIN" ]] && export PATH="$NODE_BIN:$PATH"
+fi
+
+KEYFILE=/root/.openclaw/nostr-rick.key
+
+if [[ ! -r "$KEYFILE" ]]; then
+  echo "$(date -Is) ERROR: Nostr key not readable at $KEYFILE" >&2
+  exit 1
+fi
+NOSTR_PRIVATE_KEY="$(cat "$KEYFILE")"
+export NOSTR_PRIVATE_KEY
+
+# Generate the post from live data, then sign + publish to public relays.
+python3 ops/growth/rick_broadcast.py --lang en | node ops/growth/nostr_publish.js

--- a/ops/host/cron_timeline.py
+++ b/ops/host/cron_timeline.py
@@ -244,6 +244,8 @@ def load_crontab():
             name = 'sync_us_dst'
         elif 'gold_dca_refresh' in cmd:
             name = 'gold_dca_refresh'
+        elif 'rick_broadcast_nostr' in cmd:
+            name = 'nostr_broadcast'
         elif re.search(r'(^|/)git\b', cmd) and re.search(r'\bgc\b', cmd):
             name = 'git gc'
         else:

--- a/tests/test_rick_broadcast.py
+++ b/tests/test_rick_broadcast.py
@@ -1,0 +1,75 @@
+"""The autonomous public broadcast must not rank active calls against passive holds.
+
+rick_broadcast is sent straight to public Nostr relays. active calls and passive
+stances are different claim types over different sample pools (decision_v2.compute_metrics
+treats them separately), so declaring one "better" is an invalid read. Both renderers
+used to flip their verdict on active_hit >= hold_hit; these tests pin that the copy
+states non-comparability and never ranks, in either ordering.
+
+Run: python3 -m pytest tests/test_rick_broadcast.py -q
+"""
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'ops' / 'growth'))
+import rick_broadcast
+
+FORBIDDEN = ['less often', 'earned its keep', '还不如', '没拖后腿', 'this week', '这周']
+
+
+def _card(active_hit, hold_hit):
+    return {'active_hit': active_hit, 'active_n': 10, 'hold_hit': hold_hit, 'hold_n': 10,
+            'high_conf_hit': 50, 'high_conf_n': 4, 'total_settled': 20}
+
+
+def test_broadcast_never_ranks_active_vs_passive_in_either_ordering():
+    for active_hit, hold_hit in ((20, 80), (80, 20)):
+        s = _card(active_hit, hold_hit)
+        for render, non_comparability in (
+            (rick_broadcast.render_en, 'rank neither'),
+            (rick_broadcast.render_zh, '不做高下排名'),
+        ):
+            out = render(s)
+            # both rates still shown
+            assert f'{active_hit}%' in out and f'{hold_hit}%' in out, out
+            # the non-comparability statement is present
+            assert non_comparability in out, out
+            # and no ranking / windowed-time phrase survives
+            for bad in FORBIDDEN:
+                assert bad not in out, f'forbidden phrase {bad!r} in output:\n{out}'
+
+
+def test_broadcast_is_explicitly_recommendation_only_and_python_graded():
+    s = _card(40, 60)
+    en = rick_broadcast.render_en(s)
+    zh = rick_broadcast.render_zh(s)
+
+    assert 'recommendation report card' in en
+    assert 'directional hit rates, graded by Python' in en
+    assert 'grading itself' not in en
+    assert 'real money' not in en
+
+    assert '建议成绩单' in zh
+    assert 'Python 统计判断方向命中率' in zh
+    assert '给自己打分' not in zh
+    assert '真金白银' not in zh
+
+
+def test_high_confidence_rate_is_active_only_and_renders_its_sample_size():
+    representatives = [
+        {'action': 'cut', 'confidence': 0.80, 'evaluation': {'outcome': 'win'}},
+        {'action': 'cut', 'confidence': 0.60, 'evaluation': {'outcome': 'loss'}},
+        {'action': 'hold_and_watch', 'confidence': 0.90,
+         'evaluation': {'outcome': 'loss'}},
+    ]
+    with mock.patch.object(rick_broadcast.decision_v2, 'load_decisions', return_value=[]), \
+         mock.patch.object(rick_broadcast.decision_v2, 'episode_representatives',
+                           return_value=representatives):
+        s = rick_broadcast.scorecard()
+
+    assert s['high_conf_hit'] == 100
+    assert s['high_conf_n'] == 1
+    assert 'high-conviction active calls: 100% (n=1)' in rick_broadcast.render_en(s)
+    assert '高信心主动判断:100%(n=1)' in rick_broadcast.render_zh(s)

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -434,6 +434,10 @@ HOST_OWNED_SHELL = {
     "ops/host/reapply_openclaw_patches.sh": (
         2, "patches the runtime's own pnpm install after an upgrade: the "
            "install directory and the patch root are the subject of the script"),
+    "ops/growth/rick_broadcast_nostr.sh": (
+        2, "host cron wrapper that reads the Nostr key from this machine's "
+           "runtime dir and posts from the live checkout — the broadcast has "
+           "no meaning off this host"),
 }
 
 def _shell_files():


### PR DESCRIPTION
#671 裁定为恢复(唯一零注册全自动公开发帖渠道,带来可爬外链;X/HN 仍人肉)。

## 变更

- 恢复 ops/growth/{rick_broadcast.py, rick_broadcast_nostr.sh, nostr_publish.js}(#592 删除前的原样内容,import 与 ledger ACTIVE/PASSIVE 断言实测通过)
- 恢复 tests/test_rick_broadcast.py(3 例,实测通过)
- 恢复 ops/host/cron_timeline.py 的 nostr_broadcast 解析分支(#679 删的)
- 宿主侧:合并后由操作员恢复 crontab 23:00 行;key 文件 /root/.openclaw/nostr-rick.key 仍在(0600)

## 验证

- pytest 3/3(rick_broadcast)+ 21/21(host crontab 闸+pages 契约)
