### PR TITLE
release: v0.1.5 — clawock-dsh 插件 T+1 颜色修复 + 决策轨迹卡片

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The newest heading here has to match the version in `pyproject.toml` — CI fails
 otherwise, so a release cannot ship an entry that was never written.
 
+## [0.1.5] — 2026-08-16
+
+### Fixed
+
+- **The `clawock-dsh` DSH plugin's T+1 result color was inverted for sell
+  actions.** It applied one sign rule to every action, so a rising price after
+  a *sell* (a loss for the seller — 卖飞) rendered green, and a falling price
+  after a *buy* rendered green too. The color is now action-aware: rising is
+  good (green) for a buyer, bad (red) for a seller, and vice versa. ([#665])
+
+### Added
+
+- **`clawock record --source <harness>`** is now the single write path for the
+  decision-mind ledger (`memory/decisions.jsonl`); every harness (OpenClaw,
+  Claude, Codex, DSH, CLI) tags its own conversational judgments through it
+  instead of hand-writing JSONL, and `validate_decision` accepts the resulting
+  schema-version-0 records from any of them. ([#661], [#662])
+- **The DSH plugin's Decision Studio tab is now a single "决策轨迹" (decision
+  trace) timeline** built from real trade fills, not a separate, disconnected
+  ledger view: each row pairs an actual execution with its T+1 result chip and
+  expands into the plan → execution → outcome sequence. It renders only the
+  most recent activity by default, with a "show all" control for the rest.
+  ([#676], [#684])
+
 ## [0.1.4] — 2026-08-16
 
 ### Fixed
@@ -166,7 +190,13 @@ environment — and completes one full run. ([#436], [#379])
 [#485]: https://github.com/KCNyu/clawock/pull/485
 [#477]: https://github.com/KCNyu/clawock/issues/477
 [#478]: https://github.com/KCNyu/clawock/issues/478
-[Unreleased]: https://github.com/KCNyu/clawock/compare/v0.1.2...HEAD
+[#661]: https://github.com/KCNyu/clawock/pull/661
+[#662]: https://github.com/KCNyu/clawock/pull/662
+[#665]: https://github.com/KCNyu/clawock/issues/665
+[#676]: https://github.com/KCNyu/clawock/pull/676
+[#684]: https://github.com/KCNyu/clawock/pull/684
+[Unreleased]: https://github.com/KCNyu/clawock/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/KCNyu/clawock/compare/v0.1.4...v0.1.5
 [0.1.2]: https://github.com/KCNyu/clawock/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/KCNyu/clawock/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/KCNyu/clawock/releases/tag/v0.1.0

--- a/examples/dsh/plugin/package.json
+++ b/examples/dsh/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Studio conversation-view tab",
   "license": "MIT",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.4"
+version = "0.1.5"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
npm 上的 `clawock-dsh@0.1.4`(08-15 17:38 UTC 发布)落后 master 一天以上:
#661/#662(record --source 统一写入)、#665/#685(T+1 结果颜色按动作方向修复,
之前 sell 涨=红卖飞被渲染成绿)、#676/#684(决策轨迹卡片重写+默认折叠)全部
只在仓库里,从未随一次 tag 发布过。本机 dsh 服务装的也是这份旧 0.1.4(已经
用本地文件同步 + `systemctl restart dsh` 临时救过,curl 验证过 served 的
client.js 现在含 t1Tone/决策轨迹,但那只是这台机器,公开 npm 包仍是旧的)。

## 变更

- `pyproject.toml` + `examples/dsh/plugin/package.json`: 0.1.4 → 0.1.5
- `CHANGELOG.md`:0.1.5 条目(Fixed: T+1 颜色反转;Added: record --source
  统一入口 + 决策轨迹卡片)+ 补齐 #661/#662/#665/#676/#684 链接引用 +
  修正 [Unreleased]/[0.1.5] compare 链接

## 验证

`pytest tests/test_versions_agree.py`:3/3 绿

## 合并后还差一步(需要 kcn 手动做)

这个 PR 只是版本号+CHANGELOG 的准备,`docs/operations/release.md` 设计成
必须由人工打 tag 触发(PyPI environment 要求人工 approve,发布是不可逆动作,
我不应该也不能代为完成这一步):

```
git tag v0.1.5 && git push origin v0.1.5
```

推送后 release.yml 会等 PyPI environment approve,然后把 PyPI(`clawock`)
和 npm(`clawock-dsh`)一起发布 0.1.5。