### PR TITLE
docs: README 视觉/定位改版 + 版本徽章 + 情绪数据诚实修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@
 
 ### AI argues. Code settles. The losses stay on the page.
 
-Install the decision intelligence behind this live Hong Kong + US desk into any agent, in any harness — OpenClaw, Claude Code, Codex, DeepSeek Harness, or your own runner. Evidence, opposition, deterministic reconciliation, and outcome-linked improvement; the harness around the model is yours to pick and yours to change.
+A real Hong Kong + US brokerage account, run day after day by agents that have
+to argue their case — and graded by code the model never gets to touch. Every
+call is published, wins and losses alike, because a system that only shows you
+the wins is marketing, not evidence. Install the same decision workflow into
+your own agent, in any harness — OpenClaw, Claude Code, Codex, DeepSeek
+Harness, or one you write yourself.
 
+[![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
+[![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
@@ -32,26 +39,31 @@ Install the decision intelligence behind this live Hong Kong + US desk into any 
 
 ## What this is
 
-clawock is an **agent-native, harness-agnostic investment decision-workflow
-plugin kit with a verifiable harness**. OpenClaw, Hermes, Claude Code, Codex,
-DeepSeek Harness, or another external runtime owns the model call,
-conversation, memory, planning, tools, permissions, and credentials. clawock
-installs the reusable workflow that certifies evidence, forces an opposing
-case, validates money and FX, links outcomes, and keeps every improvement
-proposal reviewable and reversible. Swap harnesses and the decision contract
-does not move: the loop is files and a CLI — see
+This repository is a live account before it is a package. A multi-agent desk
+debates the evidence on a real brokerage account with separate Hong Kong and
+US books and proposes trades; execution stays with the account owner. The
+product is the record that comes out of that: real positions, an accumulating
+decision history, and a public scorecard the model does not get a vote on —
+not a get-rich bot, and not a copy-trading service.
+
+**clawock is the reusable half of that desk, pulled out of one live account
+instead of designed in the abstract: an agent-native, harness-agnostic
+investment decision-workflow plugin with a verifiable harness.** OpenClaw,
+Claude Code, Codex, DeepSeek Harness, or another external runtime keeps the
+model call, conversation, memory, planning, tools, permissions, and
+credentials — clawock installs the workflow that certifies evidence, forces an
+opposing case, validates money and FX, links outcomes back to the decision
+that caused them, and keeps every improvement proposal reviewable and
+reversible. Swap harnesses and the decision contract does not move: the loop
+is files and a CLI — see
 [`examples/`](https://github.com/KCNyu/clawock/blob/master/examples/README.md) for the
 same run driven from a pure CLI, an OpenClaw skill, a Claude Code instruction, a Codex AGENTS.md,
 and a DeepSeek Harness agent.
 
 It installs from PyPI — `pip install clawock` — and
-[runs on your own book](#run-it-on-your-own-book) without this repository.
-
-This repository is also the first continuously running proof: a disciplined,
-self-grading AI investing experiment on a real Hong Kong + US portfolio — not a
-get-rich bot, and not a copy-trading service.
-
-A multi-agent desk monitors a real brokerage account with separate Hong Kong and US books, debates the evidence, and proposes trades; execution stays with the account owner. The product is the live record: real positions, an accumulating decision history, and a public scorecard. The model proposes; Python owns the prices, the risk limits, the ledger, the settlement, and the grading.
+[runs on your own book](#run-it-on-your-own-book) without this repository. The
+model proposes; Python owns the prices, the risk limits, the ledger, the
+settlement, and the grading.
 
 ### What makes it different
 
@@ -268,12 +280,12 @@ The **Decision Mind** tab is one organic view, not three tabs: the spine is
 your real fills (`portfolio.json` trades), each row carries the soft-paired
 decision (±3 days from `decisions.jsonl`) as the "why", and the T+1 snapshot
 close decides 卖飞/卖对 on sells. Click a fill and the trace unfolds — plan →
-execution → T+1 → P&L — with the rationale, emotion pressure and notes in
-semantic colors. Fills with no decision say so explicitly; nothing is
-pretended. Currency is never mixed: USD and HKD figures are kept apart and
-only ever combined through the desk's published FX rate. The same trace data
-powers the public dashboard's Reflect card, so the plugin and the website
-render one contract:
+execution → T+1 → P&L — with the rationale and note in semantic colors, plus
+an emotion-pressure field on the (currently few) records that logged one.
+Fills with no decision say so explicitly; nothing is pretended. Currency is
+never mixed: USD and HKD figures are kept apart and only ever combined through
+the desk's published FX rate. The same trace data powers the public
+dashboard's Reflect card, so the plugin and the website render one contract:
 
 <p align="center"><img src="https://raw.githubusercontent.com/KCNyu/clawock/refs/heads/master/site/assets/dsh-decision-mind.png" alt="Decision Mind plugin — decision traces: real fills with soft-paired decisions and T+1 verdicts, expandable to a plan → execution → result timeline" width="860"></p>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,8 @@
 
 8 层 41 模块信息流 · 多 Agent 辩论 · Python 确定性结算,打包成 `pip install clawock`,装进任何 Agent(Claude Code / Codex / OpenClaw / DeepSeek Harness)。不跟单、不代下单。
 
+[![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
+[![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
 [![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
@@ -234,9 +236,10 @@ dsh plugin --profile web add clawock-dsh
 **Decision Mind** tab 只有一个视图:主轴是真实成交(`portfolio.json` trades),
 每行挂接软配对的决策(±3 天,来自 `decisions.jsonl`)作为「当时为什么」,
 卖出单用 T+1 快照收盘价判定卖飞/卖对。点开一条成交,展开成
-**计划 → 执行 → T+1 → 盈亏** 的纵向时间线,为什么(rationale)/情绪压力/
-备注用语义色左边框分层。没有决策的成交显式标注「无关联决策记录」——
-不假装有判断。币种绝不混加:USD/HKD 分开,只经桌面发布的汇率折算。
+**计划 → 执行 → T+1 → 盈亏** 的纵向时间线,为什么(rationale)和备注用语义色
+左边框分层;情绪压力字段也在,但目前只有极少数记录填过,不是每条都有。
+没有决策的成交显式标注「无关联决策记录」——不假装有判断。
+币种绝不混加:USD/HKD 分开,只经桌面发布的汇率折算。
 同一份轨迹数据也渲染在公开 dashboard 的 Reflect 卡片——插件和网页
 同一个数据契约:
 


### PR DESCRIPTION
kcn 反馈 README 现在"视觉/排版"和"定位/卖点表述"不够,截图对比 GitHub 实际
渲染(Playwright)后做的改版。

## 变更

- **开场重排**:英文原来先讲「Install the decision intelligence...」这种
  抽象产品话术,后面才讲这是真账户在跑;改成先给最硬的钩子(真实港美股账户、
  AI 必须自己辩论、代码结算、赢亏都公开),再讲可复用的技术机制。中文版
  本来就是这个顺序(90天/−15.95%/「模型不能给自己打分」),这次让英文追上
  同等力度
- **「What this is」去重排**:原文技术描述和"real desk"描述分两段说、顺序
  颠倒且部分重复;合并成一条更紧的叙事
- **顶部加 PyPI + npm 版本徽章**(EN/ZH 同步):今晚正好撞上 npm 包停在旧
  版本一整天没人发现(#690 已修);加徽章后这类滞后下次直接在 README 上
  可见,不用等人工排查
- **诚实修正**(EN/ZH 同步):DSH 插件段落写「情绪压力/notes」像是常态字段,
  实测 `decisions.jsonl` 里带 mind/emotion 的只有 **1/641(0.16%)**,改成
  如实描述「字段在,但目前只有极少数记录填过」

## 验证

`tests/test_readme_parity.py` 等 26 项通过;全量 `pytest`:2153 passed /
5 skipped / 4 xfailed,无新增失败。