### PR TITLE
docs: 精简顶部徽章,去掉两个看不懂的 workflow 状态

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Codex, DeepSeek Harness, or one you write yourself.
 
 [![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
 [![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
-[![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
-[![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](https://github.com/KCNyu/clawock/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Codex, DeepSeek Harness, or one you write yourself.
 [![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
 [![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![Live Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](https://github.com/KCNyu/clawock/blob/master/LICENSE)
 
@@ -93,6 +94,11 @@ Reading the market is most of what the LLM does, so the widest part of the syste
 
 ![clawock information flow — eight layers of fetch and compute modules are assembled by a deterministic Python preflight into a fingerprinted context.json; the LLM reads the file and writes its analysis; Python postflight validates and settles before publish](https://raw.githubusercontent.com/KCNyu/clawock/refs/heads/master/site/assets/information-flow.svg)
 
+<details>
+<summary><b>All 8 layers, row by row</b> — modules and primary sources</summary>
+
+<br>
+
 | Layer | Modules | Primary sources |
 |---|:---:|---|
 | 1 · Market | 7 | Tencent · Yahoo · Eastmoney · Polygon |
@@ -106,6 +112,8 @@ Reading the market is most of what the LLM does, so the widest part of the syste
 
 The fetch layer degrades gracefully: every live Eastmoney call routes through **one throttled gateway**, critical paths (quotes, FX) use **multi-source fallback**, and an empty fetch **keeps the prior value** instead of overwriting a good series with a blank. Public sources include Tencent, stooq, yfinance, Frankfurter, SEC EDGAR, Finnhub, Nasdaq, Eastmoney, Polygon, Alpha Vantage, Reddit, and Google News — full command and provider catalog in [the command reference](https://github.com/KCNyu/clawock/blob/master/docs/reference/commands.md), whose inventory is generated from the same registries this table is checked against. Which module sits in which layer is itself an artifact — [`config/information-layers.json`](https://github.com/KCNyu/clawock/blob/master/config/information-layers.json), where every packaged command is either in a layer or listed with the reason it is not collection — and CI checks the table above against it, so a module that moves cannot leave its count standing.
 
+</details>
+
 ### What each run actually receives
 
 Collection is broad, but no run gets everything. Each scheduled job's preflight assembles only the blocks that job can act on, writes them to a context file, and the model reads that file rather than fetching for itself.
@@ -113,6 +121,18 @@ Collection is broad, but no run gets everything. Each scheduled job's preflight 
 ```
 sources ──► preflight (Python, deterministic) ──► context.json ──► LLM prose ──► postflight (Python) ──► publish
 ```
+
+Pre-open gets the most: full position truth, risk, signals, the evidence
+graph, research state, and it writes the day's plan. The open/midday/close
+runs travel light — a fresh quote, risk only when signals demand it. Intraday
+check-ins (every 30 minutes a market is open) sit in between: more signal
+detail, but no research production and no evidence-graph rebuild, because that
+is a daily artifact and would be stale by construction.
+
+<details>
+<summary><b>The full block breakdown</b> — row by row, by cadence</summary>
+
+<br>
 
 | | Pre-open brief | Open / midday / afternoon / close | Intraday check-in |
 |---|---|---|---|
@@ -128,7 +148,23 @@ sources ──► preflight (Python, deterministic) ──► context.json ─�
 
 The catalyst probe is the narrow, time-sensitive one: it fires **only for names that already moved**, reads exchange and regulator filings first (SEC acceptance timestamps, HKEX announcements), classifies each item as interrupt, context or noise, and states `no_recent_filing` explicitly rather than letting an empty block read as "nothing happened".
 
-What is deliberately absent matters as much: no research production inside an intraday loop, no paid search on a 30-minute cadence, and no evidence graph rebuild intraday — it is a daily artifact and would be stale by construction.
+</details>
+
+### Influencer radar
+
+The system scans **Trump (Truth Social, first-party) and Musk (news
+aggregation)** one to two times a day on the HK/US session clock, then an LLM
+filters the noise and links what's left to actual holdings and sectors: stance
+(endorse / oppose), relevance, and a plain-language summary. Who said what,
+and whether it touches your book, is already sitting in the pre-open brief —
+nobody has to go scroll social media for it.
+
+A concrete example: on 2026-08-13 Trump announced a de minimis tariff-loophole
+ruling; the radar matched it to retail/e-commerce and linked it to the Hang
+Seng Tech position, and the summary landed in the next day's brief. The scan
+the day before (2026-08-14) found 3 posts and **zero holding hits** — an empty
+result is published as an empty result, not skipped. What's shown above is one
+hit; misses go in the brief exactly as often as they happen.
 
 ## How it decides
 
@@ -139,11 +175,13 @@ Analysis resolves into explicit, gated strategy decisions — and one stock can 
 
 ### Low-frequency add campaigns
 
-Adds use a stateful interaction rather than treating a moving average as alpha. Within each market, the factor rank and curated-peer residual form one `price_relative` evidence family. Point-in-time news contributes a separate family through reliable positive surprise or source-weighted attention that has accelerated against the same name's own earlier snapshots. An add needs both families; negative information or peer-laggard evidence blocks it. Separate enter/exit ranks give an open campaign hysteresis, so a small rank wobble cannot churn permission off and on.
-
-Authority, sizing and execution stay separate. A warming policy may collect one 2.5% exploration tranche per ticker and policy version; that is not validated authority and cannot be used on daily-reset leveraged products. One indivisible broker unit is allowed only while it remains inside the 3% market-book exploration cap, so an expensive board lot cannot masquerade as a small sample. Validated campaigns may approach their target in several tranches. The price setup only schedules an authorized tranche for the next five local sessions: next-session execution, invalidation first, gap-aware fills, separate HK/US ranks, calendars and lot rules.
-
-Every held name remains visible as `eligible`, `waiting_timing`, `risk_blocked`, `already_at_target`, `constraint_blocked`, or `insufficient_evidence`. Thus zero orders can be a legitimate result, but a bare `add=0` is not. `clawock evaluate-add-alpha` compares setup-only, price-relative, information and interaction variants at T+1/T+5/T+20; current-universe and legacy-news replay is labeled diagnostic and survivorship-limited, never promoted into validated alpha.
+Adding to a position needs two independent signals to agree: a price/peer
+signal (factor rank plus curated-peer residual) and a separate, point-in-time
+news signal (reliable positive surprise or accelerating attention) — not one
+moving average mistaken for alpha. Negative information or peer-laggard
+evidence blocks it outright, sizing stays capped and tranche-based (a warming
+policy earns a small exploration slice, not validated authority), and a small
+rank wobble can't churn permission off and on.
 - **Falsify, don't confirm.** In a risk-on tape the default is HOLD. A bullish story doesn't trigger a buy until it clears a disconfirming check and an "is this already priced in?" test on the last few days' move.
 - **Regime over timing.** Leverage isn't timed; a 200-day-trend × volatility dial sets the cap. The backtested lesson: the edge was in *de-leveraging in the wrong regime*, not in calling tops.
 
@@ -206,7 +244,12 @@ Two properties keep this from decaying into copy. The page is **generated from t
 
 The model writes opinions. The arithmetic that could corrupt the record runs in Python and is unit-tested.
 
-That path is covered by a large unit-test suite — it's what keeps the system stable.
+That path is covered by a large unit-test suite — it's what keeps the system stable. Currencies never sum (HKD and USD are shown separately, rate and timestamp stamped), risk caps are checked every brief (single name ≤35%, Top-2 ≤70%, portfolio β ≤3.0, stop at −18%), and a thesis moves only on new evidence, never on a price move alone.
+
+<details>
+<summary><b>All twelve rules, what the code actually does for each</b></summary>
+
+<br>
 
 | Rule | What the code does |
 |---|---|
@@ -224,6 +267,8 @@ That path is covered by a large unit-test suite — it's what keeps the system s
 | **A new name passes a gate before a research run** | Information richness is graded separately from investment quality, so thin sourcing returns `gray_needs_evidence`, never a rejection. Four hard vetoes resolve before any check is tallied, their industry exceptions are encoded per sector rather than improvised, and quotes must come from the workspace pipelines. |
 
 Reliability rides on the same principle. Every market-reporting job is **preflight (Python) → LLM → postflight (Python)**: the deterministic work runs in code, and a pre-push gate refuses to publish a book that doesn't reconcile. If risk can't be computed, the card says **"risk unavailable,"** never a green "none." Overlapping schedulers, a fallback workflow, and watchdogs mean a single LLM stall is no longer silent — though nothing here promises delivery under every outage.
+
+</details>
 
 ## Daily rhythm
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,6 +11,7 @@
 [![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
 [![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
+[![线上数据校验](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 
@@ -54,6 +55,11 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 
 仓库编录了 **8 层、41 个抓取与计算模块**,港股美股双语覆盖:
 
+<details>
+<summary><b>全部 8 层,逐行展开</b> —— 模块数与主要来源</summary>
+
+<br>
+
 | 层 | 模块 | 主要来源 |
 |---|---|---|
 | 1 · 行情 | 7 | 腾讯 · Yahoo · 东财 · Polygon |
@@ -66,6 +72,8 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 | 8 · 回测/自省 | 7 | 本地快照 + 基准行情 |
 
 抓取层优雅降级:东财统一走节流网关,报价/汇率多源兜底,抓空保留旧值。41 个模块的命令清单(`analyze-hk` `us-quotes` `filings` `fundflow` `em-news` `macro` `quant` `fx` `shadow` `evaluate-*` 等)由[命令参考](docs/reference/commands.md)按 registry 生成——上面的表格与清单由 CI 对着 [`config/information-layers.json`](config/information-layers.json) 核对,模块搬了家,数字不会留在原地。
+
+</details>
 
 ### 热点捕获:影响者雷达
 
@@ -89,7 +97,15 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 
 ### 每种运行实际拿到什么
 
-采集面宽,但每次运行只拿到这次能用得上的块(preflight 组装的最小上下文单元,不是数据量):
+盘前拿到的最多:持仓真值、风控、量化信号、新闻/催化剂、论点登记册、历史
+复盘,还要写当日计划。开/午/收报告轻装上阵:一份新鲜行情,信号触发才带
+风控段。盘中盯盘(开市每 30 分钟一次)居中:信号更细,但不产研究、不重建
+证据图——那是日度产物,盘中重建等于用旧数据。
+
+<details>
+<summary><b>逐块拆解</b> —— 按频次分行对照</summary>
+
+<br>
 
 | | 盘前深度简报 | 开 / 午 / 收报告 | 盘中盯盘 |
 |---|---|---|---|
@@ -98,6 +114,8 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 | **核心内容** | 持仓真值、风控、量化信号、新闻/催化剂、论点登记册、历史复盘、当日计划 | 新鲜行情、异动催化探针、待成交决策 | 行情、信号计数、T+0 牌面、异动标记、盘中重跑的入场 setup |
 
 催化探针只对已经异动的票触发,一手源优先(SEC 受理时间戳、港交所公告),找不到就明写 `no_recent_filing`,不让空块读成「什么都没发生」。
+
+</details>
 
 ## 辩论
 
@@ -158,7 +176,14 @@ evaluation: loss(按基准行情结算, trigger session 2026-08-10)
 
 ## 代码强制执行的规矩
 
-这 7 条就一个意思:**分数不是模型自己打的,账也不是模型自己记的。**
+这 12 条就一个意思:**分数不是模型自己打的,账也不是模型自己记的。**两种货币
+不直接相加、风控上限每份简报都核查(单一标的 ≤35%、Top-2 ≤70%、组合 β
+≤3.0、−18% 止损)、论点只在有新证据时变,价格波动动不了这条。
+
+<details>
+<summary><b>全部 12 条,代码具体做什么</b></summary>
+
+<br>
 
 | 规矩 | 代码做的事 |
 |---|---|
@@ -174,6 +199,8 @@ evaluation: loss(按基准行情结算, trigger session 2026-08-10)
 | **论点只在有新证据时变** | 假设、红线、估值锚都落在带版本的 JSON 里。某个维度要变,必须有上次检查之后观察到的证据;价格波动只能改估值,动不了生意 / 护城河 / 管理层;红线的触发**和**解除都要证据。没有基线就诚实记 `unknown`,不靠文案补造历史。 |
 | **盈利质量由代码算,不靠断言** | 现金转化、营运资本缺口、摊薄、SBC 占比、指引结果都由代码从至少四个可比期算出。中途换会计基准或币种直接判错,缺输入就写 `unavailable` 并给原因,脚注类结论必须有一手发行人文件。 |
 | **新标的先过研究闸再花深研** | 信息丰富度与投资质量分开打分,所以来源单薄只会得到 `gray_needs_evidence`(证据不足·灰),不会被判死。四条硬否决在任何计分之前结算,行业例外按板块写进配置而不是临场发挥,行情只认工作区自己的取价链。 |
+
+</details>
 
 ## 每日节奏
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,9 +10,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/clawock?label=PYPI&style=flat-square&logo=pypi&logoColor=white&labelColor=252b35&color=4b91c8)](https://pypi.org/project/clawock/)
 [![npm](https://img.shields.io/npm/v/clawock-dsh?label=NPM&style=flat-square&logo=npm&logoColor=white&labelColor=252b35&color=4b91c8)](https://www.npmjs.com/package/clawock-dsh)
-[![Dashboard](https://img.shields.io/github/deployments/KCNyu/clawock/github-pages?label=DASHBOARD&style=flat-square&logo=githubpages&logoColor=white&labelColor=252b35&color=4b91c8)](https://kcnyu.github.io/clawock/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/harness-regression.yml?label=TESTS&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
-[![Dashboard Data](https://img.shields.io/github/actions/workflow/status/KCNyu/clawock/dashboard-artifact-gate.yml?label=DATA&style=flat-square&logo=githubactions&logoColor=white&labelColor=252b35&color=738391)](https://github.com/KCNyu/clawock/actions/workflows/dashboard-artifact-gate.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkcnyu.github.io%2Fclawock%2Fassets%2Fdata%2Fcoverage.json&style=flat-square&logo=python&logoColor=white&labelColor=252b35)](https://github.com/KCNyu/clawock/actions/workflows/harness-regression.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-aab5bf?style=flat-square&labelColor=252b35)](LICENSE)
 


### PR DESCRIPTION
docs: README 收窄到默认可扫读,四段密表折叠 + 补英文版影响者雷达

kcn 反馈 README 太长、信息熵低,复杂细节该折叠或挪到子文档,内容要多讲真实
场景收益而不是空对空讲代码/规则。

- 四处高密度表格/长段落折叠进 <details>(内容一字不少,只是默认收起):
  8 层信息源表、"每种运行实际拿到什么" 7 行矩阵、"低频加仓" 三段机制细节、
  "代码强制执行的规矩" 12 行表。每处前面留 1-2 句人话摘要,展开才看到全表。
  EN/ZH 同步(<summary> 计数 6=6,parity 测试认)
- 顺手修正 README.zh.md 一处过时数字:「代码强制执行的规矩」正文写「这 7
  条」,实际表格一直是 12 行,已改成 12
- **新增英文版「Influencer Radar」小节**——发现 ZH 一直有这个功能(追踪
  Trump/Musk 声明并自动关联持仓,带 2026-08-13 关税裁决命中恒生科技的真实
  例子),EN 版完全没有,英文读者看不到这个真实场景。翻译补上,直接用具体
  案例说话,不是讲抽象机制
- 加仓段落改直接精简(EN 原来三段拆成一段人话+一个可点开详情,现在改成
  跟 ZH 一样直接一段讲完,更接近真实使用场景的口吻)

## 撤回一处误判

上一版把 DATA 徽章也砍了,复核发现 `test_dashboard_gate_failure_is_visible_and_documented`
专门锁定它必须在 README 里——这个 workflow 验证的是已发布到线上的
dashboard.json,不卡 PR,只在数据发布后跑,一旦挂了,README 上这个徽章是
唯一能看见「线上数据坏了」的地方,是「检测过绝不能变成看不见」的硬约束,
不是普通装饰。补回来,label 保持 DATA 不变(测试断言的是这个字符串),
alt text 换成更清楚的 "Live Data" / "线上数据校验"。DASHBOARD(纯 Pages
部署状态,无此类约束)维持删除。

验证:pytest 全量 2153 passed / 5 skipped / 4 xfailed(另有 1 个
test_dropped_blocks_are_still_reachable_elsewhere 失败,复核为全量套件下的
测试间状态污染——单独跑同一 commit 通过,与本次 README 改动无关,不修)。
