### PR TITLE
docs: 四张架构图改窄栏布局(手机可读)+ 修一处失效的粗体语法

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ The fetch layer degrades gracefully: every live Eastmoney call routes through **
 Collection is broad, but no run gets everything. Each scheduled job's preflight assembles only the blocks that job can act on, writes them to a context file, and the model reads that file rather than fetching for itself.
 
 ```
-sources ──► preflight (Python, deterministic) ──► context.json ──► LLM prose ──► postflight (Python) ──► publish
+sources
+  ──► preflight (Python, deterministic)
+  ──► context.json
+  ──► LLM prose
+  ──► postflight (Python)
+  ──► publish
 ```
 
 Pre-open gets the most: full position truth, risk, signals, the evidence

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 ### AI 争辩。代码结算。连亏损都摆在明面上。
 
-它跑了 **<!-- CW_M:days -->90<!-- /CW_M:days --> 天,实盘收益 **<!-- CW_M:return_pct -->−15.95%<!-- /CW_M:return_pct -->**——每一笔亏损都摊开在页面上([原始决策记录](https://github.com/KCNyu/clawock/blob/master/memory/decisions.jsonl)),账目都能从命令复算(`clawock audit-resettle` 结算决策账、`clawock reconcile` 复算组合派生)。**模型不能给自己打分**——在我们已知范围内,第一个把 AI 战绩交给代码结算的投研台。AI 建议满天飞,谁为结果负责?代码负责。
+它跑了 **<!-- CW_M:days -->90<!-- /CW_M:days --> 天**,实盘收益 **<!-- CW_M:return_pct -->−15.95%<!-- /CW_M:return_pct -->**——每一笔亏损都摊开在页面上([原始决策记录](https://github.com/KCNyu/clawock/blob/master/memory/decisions.jsonl)),账目都能从命令复算(`clawock audit-resettle` 结算决策账、`clawock reconcile` 复算组合派生)。**模型不能给自己打分**——在我们已知范围内,第一个把 AI 战绩交给代码结算的投研台。AI 建议满天飞,谁为结果负责?代码负责。
 
 8 层 41 模块信息流 · 多 Agent 辩论 · Python 确定性结算,打包成 `pip install clawock`,装进任何 Agent(Claude Code / Codex / OpenClaw / DeepSeek Harness)。不跟单、不代下单。
 
@@ -48,7 +48,12 @@ clawock 是一套真实港美股账户上运行的 AI 投研系统,解决一个�
 ![clawock 信息流 —— 8 层 41 个模块经 Python preflight 按需组装成带指纹的 context.json;LLM 只读文件写分析;postflight 校验结算后发布](site/assets/information-flow.svg)
 
 ```
-数据源 ──► preflight(Python,确定性)──► context.json(带指纹)──► LLM 读文件写分析 ──► postflight(Python 校验)──► 发布
+数据源
+  ──► preflight(Python,确定性)
+  ──► context.json(带指纹)
+  ──► LLM 读文件写分析
+  ──► postflight(Python 校验)
+  ──► 发布
 ```
 
 ## 信息层

--- a/site/assets/architecture.svg
+++ b/site/assets/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="560" viewBox="0 0 900 560" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1510" viewBox="0 0 640 1510" role="img" aria-labelledby="title desc">
   <title id="title">KCNyu live investment instance built with clawock contracts</title>
   <desc id="desc">This is the KCNyu deployment, not the reusable clawock product architecture. Python assembles one immutable evidence pack. OpenClaw agent lenses argue bull versus bear, risk voices stress every call, and a judge writes a proposed strategy. Deterministic code validates the decision contract and publishes the brief, ledger, and dashboard. Canonical market bars settle every call, grading feeds a public scorecard, and the scorecard feeds the next brief.</desc>
   <defs>
@@ -21,144 +21,143 @@
     <style>
       .sans{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
       .ink{fill:#151a21}.muted{fill:#61707e}.blue{fill:#4b83ad}.green{fill:#138b66}.warm{fill:#b8524a}
-      .kicker{font:700 10px "SFMono-Regular",Consolas,monospace;letter-spacing:1.3px}
-      .title{font:800 26px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.6px}
+      .kicker{font:700 12px "SFMono-Regular",Consolas,monospace;letter-spacing:1px}
+      .title{font:800 25px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.5px}
       .stage{font:800 20px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.4px}
-      .body{font:500 12.5px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .label{font:750 12px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .micro{font:600 10.5px "SFMono-Regular",Consolas,monospace}
+      .body{font:500 14px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .label{font:750 14px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .micro{font:600 12.5px "SFMono-Regular",Consolas,monospace}
       .card{fill:#fff;stroke:#dde4eb;stroke-width:1.2}
       .chip{fill:#f2f5f8;stroke:#dde4eb;stroke-width:1}
       .wire{fill:none;stroke:#8593a1;stroke-width:1.8;marker-end:url(#arrow)}
     </style>
   </defs>
 
-  <rect width="900" height="560" fill="url(#page)"/>
+  <rect width="640" height="1510" fill="url(#page)"/>
 
-  <!-- Header -->
   <g class="sans">
-    <g transform="translate(24 18) scale(.34)">
+    <g transform="translate(26 20) scale(.34)">
       <path d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" fill="#10141a"/>
       <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" fill="url(#brand-bull)"/>
     </g>
-    <text x="52" y="36" font-size="20" font-weight="800" class="ink">clawock</text>
-    <text x="876" y="34" text-anchor="end" class="kicker blue">KCNyu LIVE INSTANCE · HK + US</text>
-    <text x="24" y="74" class="title ink">How this deployment turns a claim into a public record</text>
-    <text x="24" y="95" class="body muted">OpenClaw argues the call. clawock contracts settle the outcome — this loop is instance-owned.</text>
-  </g>
-
-  <!-- Loop connectors (clockwise ring) -->
-  <g class="sans">
-    <path d="M288 197H314" class="wire"/>
-    <path d="M582 197H608" class="wire"/>
-    <path d="M744 282V370" class="wire"/>
-    <path d="M612 437H586" class="wire"/>
-    <path d="M318 437H292" class="wire"/>
-    <path d="M156 372V284" class="wire"/>
-
-    <!-- publish token on the right connector -->
-    <g transform="translate(744 327)">
-      <rect x="-52" y="-13" width="104" height="26" rx="13" fill="#26323d"/>
-      <text x="0" y="4" text-anchor="middle" class="kicker" fill="#eaf2f8">PUBLISH</text>
-    </g>
-    <!-- return token on the left connector -->
-    <g transform="translate(156 328)">
-      <rect x="-56" y="-13" width="112" height="26" rx="13" fill="#fff" stroke="#cbd9e4"/>
-      <text x="0" y="4" text-anchor="middle" class="kicker blue">&#8634; NEXT BRIEF</text>
-    </g>
+    <text x="54" y="38" font-size="21" font-weight="800" class="ink">clawock</text>
+    <text x="26" y="66" class="kicker blue">KCNYU LIVE INSTANCE · HK + US</text>
+    <text x="26" y="98" class="title ink">How this deployment turns</text>
+    <text x="26" y="126" class="title ink">a claim into a public record</text>
+    <text x="26" y="152" class="body muted">OpenClaw argues the call. clawock contracts settle</text>
+    <text x="26" y="171" class="body muted">the outcome — this loop is instance-owned.</text>
   </g>
 
   <!-- 01 Evidence pack -->
-  <g transform="translate(24 112)" class="sans">
-    <rect class="card" width="264" height="170" rx="15"/>
-    <rect width="5" height="170" rx="2.5" fill="#6d9fc5"/>
-    <text x="20" y="30" class="kicker blue">01 · PYTHON</text>
-    <text x="20" y="60" class="stage ink">Evidence pack</text>
-    <text x="20" y="80" class="body muted">One reconciled, immutable input.</text>
-    <path d="M20 94H244" stroke="#e6ecf1"/>
-    <g transform="translate(20 108)">
-      <rect width="106" height="26" rx="8" class="chip"/>
-      <text x="53" y="17" text-anchor="middle" class="label ink">Book</text>
-      <rect x="118" width="106" height="26" rx="8" class="chip"/>
-      <text x="171" y="17" text-anchor="middle" class="label ink">Market</text>
-      <rect y="34" width="106" height="26" rx="8" class="chip"/>
-      <text x="53" y="51" text-anchor="middle" class="label ink">Risk</text>
-      <rect x="118" y="34" width="106" height="26" rx="8" class="chip"/>
-      <text x="171" y="51" text-anchor="middle" class="label ink">Events</text>
+  <g transform="translate(26 196)" class="sans">
+    <rect class="card" width="588" height="184" rx="15"/>
+    <rect width="5" height="184" rx="2.5" fill="#6d9fc5"/>
+    <text x="24" y="32" class="kicker blue">01 · PYTHON</text>
+    <text x="24" y="62" class="stage ink">Evidence pack</text>
+    <text x="24" y="84" class="body muted">One reconciled, immutable input.</text>
+    <path d="M24 98H564" stroke="#e6ecf1"/>
+    <g transform="translate(24 112)">
+      <rect width="264" height="30" rx="8" class="chip"/>
+      <text x="132" y="20" text-anchor="middle" class="label ink">Book</text>
+      <rect x="276" width="264" height="30" rx="8" class="chip"/>
+      <text x="408" y="20" text-anchor="middle" class="label ink">Market</text>
+      <rect y="38" width="264" height="30" rx="8" class="chip"/>
+      <text x="132" y="58" text-anchor="middle" class="label ink">Risk</text>
+      <rect x="276" y="38" width="264" height="30" rx="8" class="chip"/>
+      <text x="408" y="58" text-anchor="middle" class="label ink">Events</text>
     </g>
   </g>
 
+  <path d="M320 380V416" class="wire"/>
+
   <!-- 02 Decision room -->
-  <g transform="translate(318 112)" class="sans">
-    <rect width="264" height="170" rx="15" fill="url(#core)" stroke="#cbd8e2" stroke-width="1.2"/>
-    <rect width="5" height="170" rx="2.5" fill="#7aa7c8"/>
-    <text x="20" y="30" class="kicker blue">02 · MULTI-AGENT LLM</text>
-    <text x="20" y="60" class="stage ink">Decision room</text>
-    <text x="20" y="80" class="body muted">Independent lenses argue bull vs bear;</text>
-    <text x="20" y="96" class="body muted">three risk voices stress every call.</text>
-    <rect x="20" y="108" width="98" height="30" rx="8" fill="#e8f6f1" stroke="#c9e7dc"/>
-    <text x="69" y="128" text-anchor="middle" class="label green">BULL</text>
-    <text x="132" y="128" text-anchor="middle" class="kicker blue">VS</text>
-    <rect x="146" y="108" width="98" height="30" rx="8" fill="#fff0ef" stroke="#f0d1cf"/>
-    <text x="195" y="128" text-anchor="middle" class="label warm">BEAR</text>
-    <rect x="20" y="146" width="224" height="30" rx="9" fill="#26323d"/>
-    <text x="34" y="165" class="kicker" fill="#c8d9e6">JUDGE</text>
-    <text x="80" y="165" fill="#eef4f8" font-size="8.5" font-family="'SFMono-Regular',Consolas,monospace">action · trigger · confidence</text>
+  <g transform="translate(26 420)" class="sans">
+    <rect width="588" height="212" rx="15" fill="url(#core)" stroke="#cbd8e2" stroke-width="1.2"/>
+    <rect width="5" height="212" rx="2.5" fill="#7aa7c8"/>
+    <text x="24" y="32" class="kicker blue">02 · MULTI-AGENT LLM</text>
+    <text x="24" y="62" class="stage ink">Decision room</text>
+    <text x="24" y="84" class="body muted">Independent lenses argue bull vs bear;</text>
+    <text x="24" y="102" class="body muted">three risk voices stress every call.</text>
+    <rect x="24" y="116" width="216" height="34" rx="9" fill="#e8f6f1" stroke="#c9e7dc"/>
+    <text x="132" y="138" text-anchor="middle" class="label green">BULL</text>
+    <text x="270" y="138" text-anchor="middle" class="kicker blue">VS</text>
+    <rect x="300" y="116" width="264" height="34" rx="9" fill="#fff0ef" stroke="#f0d1cf"/>
+    <text x="432" y="138" text-anchor="middle" class="label warm">BEAR</text>
+    <rect x="24" y="160" width="540" height="34" rx="9" fill="#26323d"/>
+    <text x="40" y="182" class="kicker" fill="#c8d9e6">JUDGE</text>
+    <text x="106" y="182" fill="#eef4f8" class="micro">action · trigger · confidence</text>
   </g>
+
+  <path d="M320 632V668" class="wire"/>
 
   <!-- 03 Decision contract -->
-  <g transform="translate(612 112)" class="sans">
-    <rect class="card" width="264" height="170" rx="15"/>
-    <rect width="5" height="170" rx="2.5" fill="#6d9fc5"/>
-    <text x="20" y="30" class="kicker blue">03 · PYTHON CODE GATE</text>
-    <text x="20" y="60" class="stage ink">Decision contract</text>
-    <text x="20" y="80" class="body muted">Only valid records get published.</text>
-    <path d="M20 94H244" stroke="#e6ecf1"/>
+  <g transform="translate(26 672)" class="sans">
+    <rect class="card" width="588" height="188" rx="15"/>
+    <rect width="5" height="188" rx="2.5" fill="#6d9fc5"/>
+    <text x="24" y="32" class="kicker blue">03 · PYTHON CODE GATE</text>
+    <text x="24" y="62" class="stage ink">Decision contract</text>
+    <text x="24" y="84" class="body muted">Only valid records get published.</text>
+    <path d="M24 98H564" stroke="#e6ecf1"/>
 
-    <circle cx="31" cy="116" r="11" fill="#e9eef2"/>
-    <path d="M26 116l3 3 6-7" fill="none" stroke="#4b83ad" stroke-width="1.8"/>
-    <text x="51" y="120" class="label ink">Required fields validated</text>
+    <circle cx="36" cy="122" r="12" fill="#e9eef2"/>
+    <path d="M30 122l4 4 7-8" fill="none" stroke="#4b83ad" stroke-width="2"/>
+    <text x="58" y="127" class="label ink">Required fields validated</text>
 
-    <circle cx="31" cy="146" r="11" fill="#f5e6dd"/>
-    <path d="M31 139v8M31 151v1" stroke="#b95f3a" stroke-width="1.8"/>
-    <text x="51" y="150" class="label ink">Hard-limit actions enforced</text>
-    <text x="20" y="162" class="micro muted">&#8594; brief · ledger · dashboard</text>
+    <circle cx="36" cy="156" r="12" fill="#f5e6dd"/>
+    <path d="M36 148v9M36 161v1.2" stroke="#b95f3a" stroke-width="2"/>
+    <text x="58" y="161" class="label ink">Hard-limit actions enforced</text>
+    <text x="24" y="178" class="micro muted">&#8594; brief · ledger · dashboard</text>
   </g>
 
-  <!-- Settlement loop (bottom row, flows right to left) -->
-  <!-- Public scorecard -->
-  <g transform="translate(24 374)" class="sans">
-    <rect class="card" width="264" height="126" rx="15"/>
-    <circle cx="34" cy="40" r="15" fill="#e9eef2"/>
-    <path d="M27 45l4-5 4 3 7-9" fill="none" stroke="#5d7487" stroke-width="1.7"/>
-    <text x="60" y="36" class="kicker blue">PUBLIC SCORECARD</text>
-    <text x="60" y="55" class="body muted">outcomes + coverage</text>
-    <path d="M20 78H244" stroke="#e6ecf1"/>
-    <text x="20" y="102" class="body ink">Every call graded in the open,</text>
-    <text x="20" y="118" class="label ink">win rate · Brier · timing edge</text>
-  </g>
-
-  <!-- Settle + grade -->
-  <g transform="translate(318 374)" class="sans">
-    <rect class="card" width="264" height="126" rx="15"/>
-    <circle cx="34" cy="40" r="15" fill="#e9eef2"/>
-    <path d="M27 40h14M34 33v14" stroke="#5d7487" stroke-width="1.6"/>
-    <text x="60" y="36" class="kicker blue">SETTLE + GRADE</text>
-    <text x="60" y="55" class="body muted">episodes · timing · calibration</text>
-    <path d="M20 78H244" stroke="#e6ecf1"/>
-    <text x="20" y="102" class="body ink">Each episode scored on the</text>
-    <text x="20" y="118" class="label ink">move that actually happened</text>
+  <path d="M320 860V896" class="wire"/>
+  <g transform="translate(224 868)" class="sans">
+    <rect width="192" height="28" rx="14" fill="#26323d"/>
+    <text x="96" y="18.5" text-anchor="middle" class="kicker" fill="#eaf2f8">PUBLISH</text>
   </g>
 
   <!-- Canonical bars -->
-  <g transform="translate(612 374)" class="sans">
-    <rect class="card" width="264" height="126" rx="15"/>
-    <circle cx="34" cy="40" r="15" fill="#e9eef2"/>
-    <path d="M27 47l4-6 3 4 3-8 4 5" fill="none" stroke="#5d7487" stroke-width="1.6"/>
-    <text x="60" y="36" class="kicker blue">CANONICAL BARS</text>
-    <text x="60" y="55" class="body muted">session-dated market truth</text>
-    <path d="M20 78H244" stroke="#e6ecf1"/>
-    <text x="20" y="102" class="body ink">One settled price series,</text>
-    <text x="20" y="118" class="label ink">no post-hoc adjustment</text>
+  <g transform="translate(26 926)" class="sans">
+    <rect class="card" width="588" height="142" rx="15"/>
+    <circle cx="40" cy="46" r="16" fill="#e9eef2"/>
+    <path d="M32 55l5-7 4 5 4-10 5 6" fill="none" stroke="#5d7487" stroke-width="1.7"/>
+    <text x="70" y="42" class="kicker blue">CANONICAL BARS</text>
+    <text x="70" y="62" class="body muted">session-dated market truth</text>
+    <path d="M24 88H564" stroke="#e6ecf1"/>
+    <text x="24" y="112" class="body ink">One settled price series,</text>
+    <text x="24" y="130" class="label ink">no post-hoc adjustment</text>
+  </g>
+
+  <path d="M320 1068V1104" class="wire"/>
+
+  <!-- Settle + grade -->
+  <g transform="translate(26 1108)" class="sans">
+    <rect class="card" width="588" height="142" rx="15"/>
+    <circle cx="40" cy="46" r="16" fill="#e9eef2"/>
+    <path d="M32 46h16M40 38v16" stroke="#5d7487" stroke-width="1.7"/>
+    <text x="70" y="42" class="kicker blue">SETTLE + GRADE</text>
+    <text x="70" y="62" class="body muted">episodes · timing · calibration</text>
+    <path d="M24 88H564" stroke="#e6ecf1"/>
+    <text x="24" y="112" class="body ink">Each episode scored on the</text>
+    <text x="24" y="130" class="label ink">move that actually happened</text>
+  </g>
+
+  <path d="M320 1250V1286" class="wire"/>
+
+  <!-- Public scorecard -->
+  <g transform="translate(26 1290)" class="sans">
+    <rect class="card" width="588" height="142" rx="15"/>
+    <circle cx="40" cy="46" r="16" fill="#e9eef2"/>
+    <path d="M31 52l5-6 4 4 8-11" fill="none" stroke="#5d7487" stroke-width="1.7"/>
+    <text x="70" y="42" class="kicker blue">PUBLIC SCORECARD</text>
+    <text x="70" y="62" class="body muted">outcomes + coverage</text>
+    <path d="M24 88H564" stroke="#e6ecf1"/>
+    <text x="24" y="112" class="body ink">Every call graded in the open,</text>
+    <text x="24" y="130" class="label ink">win rate · Brier · timing edge</text>
+  </g>
+
+  <path d="M320 1432V1454" class="wire"/>
+  <g transform="translate(178 1458)" class="sans">
+    <rect width="284" height="30" rx="15" fill="#fff" stroke="#cbd9e4"/>
+    <text x="142" y="20" text-anchor="middle" class="kicker blue">&#8634; FEEDS THE NEXT BRIEF</text>
   </g>
 </svg>

--- a/site/assets/debate-flow.svg
+++ b/site/assets/debate-flow.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="440" viewBox="0 0 1000 440" role="img" aria-labelledby="dtitle ddesc">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1110" viewBox="0 0 640 1110" role="img" aria-labelledby="dtitle ddesc">
   <title id="dtitle">Inside the clawock multi-agent debate</title>
-  <desc id="ddesc">A left-to-right pipeline. One shared evidence pack feeds four analyst lenses that merge into a single table. Two researchers are asked to argue opposing bull and bear cases and to record where they disagree, so unanimous agreement reads as a flag. Three risk voices then stress every call and a judge names the strategy frame driving each decision, resolving the argument into plan.json — which enters the next session's grading pipeline, where code, not the model, settles the score.</desc>
+  <desc id="ddesc">A pipeline. One shared evidence pack feeds four analyst lenses that merge into a single table. Two researchers are asked to argue opposing bull and bear cases and to record where they disagree, so unanimous agreement reads as a flag. Three risk voices then stress every call and a judge names the strategy frame driving each decision, resolving the argument into plan.json — which enters the next session's grading pipeline, where code, not the model, settles the score.</desc>
   <defs>
     <linearGradient id="dpage" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#fcfcfd"/>
@@ -17,103 +17,95 @@
     <style>
       .sans{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
       .ink{fill:#151a21}.muted{fill:#61707e}.blue{fill:#4b83ad}.green{fill:#138b66}.warm{fill:#b8524a}
-      .kicker{font:700 10px "SFMono-Regular",Consolas,monospace;letter-spacing:1.1px}
-      .title{font:800 24px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.5px}
-      .stage{font:750 13px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .body{font:500 12px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .label{font:750 13px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .micro{font:600 10.5px "SFMono-Regular",Consolas,monospace}
+      .kicker{font:700 12px "SFMono-Regular",Consolas,monospace;letter-spacing:1px}
+      .title{font:800 25px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.5px}
+      .body{font:500 14px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .label{font:750 15px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .micro{font:600 12.5px "SFMono-Regular",Consolas,monospace}
       .card{fill:#fff;stroke:#dde4eb;stroke-width:1.2}
       .chip{fill:#f2f5f8;stroke:#dde4eb;stroke-width:1}
       .wire{fill:none;stroke:#8593a1;stroke-width:1.8;marker-end:url(#darrow)}
     </style>
   </defs>
 
-  <rect width="1000" height="440" fill="url(#dpage)"/>
+  <rect width="640" height="1110" fill="url(#dpage)"/>
 
-  <!-- Header -->
   <g class="sans">
-    <g transform="translate(24 20) scale(.32)">
+    <g transform="translate(26 20) scale(.34)">
       <path d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" fill="#10141a"/>
       <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" fill="url(#dbull)"/>
     </g>
-    <text x="50" y="36" font-size="19" font-weight="800" class="ink">clawock</text>
-    <text x="976" y="34" text-anchor="end" class="kicker blue">THE DEBATE · HK + US</text>
-    <text x="24" y="76" class="title ink">Inside the multi-agent debate</text>
-    <text x="24" y="97" class="body muted">Disagreement is required. The resolution is attributed.</text>
-  </g>
-
-  <!-- Stage kickers -->
-  <g class="sans">
-    <text x="115" y="132" text-anchor="middle" class="kicker muted">SHARED INPUT</text>
-    <text x="358" y="132" text-anchor="middle" class="kicker muted">TIER 1 · ANALYST LENSES</text>
-    <text x="616" y="132" text-anchor="middle" class="kicker muted">TIER 2 · RESEARCHERS</text>
-    <text x="866" y="132" text-anchor="middle" class="kicker muted">TIER 3 · RISK + JUDGE</text>
-  </g>
-
-  <!-- Connectors between stages -->
-  <g>
-    <path d="M202 250H244" class="wire"/>
-    <path d="M472 250H510" class="wire"/>
-    <path d="M722 250H760" class="wire"/>
+    <text x="54" y="38" font-size="21" font-weight="800" class="ink">clawock</text>
+    <text x="26" y="66" class="kicker blue">THE DEBATE · HK + US</text>
+    <text x="26" y="98" class="title ink">Inside the multi-agent debate</text>
+    <text x="26" y="122" class="body muted">Disagreement is required. The resolution is attributed.</text>
   </g>
 
   <!-- Stage 1 · Evidence -->
   <g class="sans">
-    <rect x="30" y="150" width="172" height="200" rx="10" class="card"/>
-    <text x="116" y="238" text-anchor="middle" class="label ink">context.json</text>
-    <text x="116" y="260" text-anchor="middle" class="body muted">one immutable</text>
-    <text x="116" y="276" text-anchor="middle" class="body muted">evidence pack</text>
-    <text x="116" y="300" text-anchor="middle" class="micro blue">every claim cites it</text>
+    <text x="26" y="158" class="kicker muted">SHARED INPUT</text>
+    <rect x="26" y="168" width="588" height="72" rx="10" class="card"/>
+    <text x="46" y="198" class="label ink">context.json — one immutable evidence pack</text>
+    <text x="46" y="222" class="micro blue">every claim below has to cite it</text>
   </g>
 
-  <!-- Stage 2 · Analyst lenses (4 chips) -->
+  <path d="M320 240V266" class="wire"/>
+
+  <!-- Stage 2 · Analyst lenses -->
   <g class="sans">
-    <rect x="246" y="150" width="226" height="200" rx="10" class="card"/>
-    <rect x="262" y="166" width="194" height="30" rx="6" class="chip"/>
-    <text x="359" y="185" text-anchor="middle" class="body ink">Fundamental</text>
-    <rect x="262" y="202" width="194" height="30" rx="6" class="chip"/>
-    <text x="359" y="221" text-anchor="middle" class="body ink">Technical</text>
-    <rect x="262" y="238" width="194" height="30" rx="6" class="chip"/>
-    <text x="359" y="257" text-anchor="middle" class="body ink">Sentiment</text>
-    <rect x="262" y="274" width="194" height="30" rx="6" class="chip"/>
-    <text x="359" y="293" text-anchor="middle" class="body ink">Sector rotation</text>
-    <text x="359" y="330" text-anchor="middle" class="micro muted">same context → one table</text>
+    <text x="26" y="288" class="kicker muted">TIER 1 · ANALYST LENSES</text>
+    <rect x="26" y="298" width="588" height="130" rx="10" class="card"/>
+    <rect x="42" y="314" width="264" height="32" rx="7" class="chip"/>
+    <text x="174" y="335" text-anchor="middle" class="body ink">Fundamental</text>
+    <rect x="314" y="314" width="264" height="32" rx="7" class="chip"/>
+    <text x="446" y="335" text-anchor="middle" class="body ink">Technical</text>
+    <rect x="42" y="354" width="264" height="32" rx="7" class="chip"/>
+    <text x="174" y="375" text-anchor="middle" class="body ink">Sentiment</text>
+    <rect x="314" y="354" width="264" height="32" rx="7" class="chip"/>
+    <text x="446" y="375" text-anchor="middle" class="body ink">Sector rotation</text>
+    <text x="310" y="412" text-anchor="middle" class="micro muted">same context → one merged table</text>
   </g>
+
+  <path d="M320 428V454" class="wire"/>
 
   <!-- Stage 3 · Bull vs Bear -->
   <g class="sans">
-    <rect x="512" y="150" width="208" height="200" rx="10" class="card"/>
-    <rect x="528" y="168" width="176" height="46" rx="8" fill="#eef5fb" stroke="#bcd6ea" stroke-width="1"/>
-    <text x="616" y="190" text-anchor="middle" class="label blue">Bull case</text>
-    <text x="616" y="206" text-anchor="middle" class="micro muted">hold / add</text>
-    <text x="616" y="250" text-anchor="middle" class="kicker warm">OPPOSING  CASE</text>
-    <text x="616" y="266" text-anchor="middle" class="micro muted">protocol · unanimity flagged</text>
-    <rect x="528" y="286" width="176" height="46" rx="8" fill="#fbeeed" stroke="#eccfcb" stroke-width="1"/>
-    <text x="616" y="308" text-anchor="middle" class="label warm">Bear case</text>
-    <text x="616" y="324" text-anchor="middle" class="micro muted">trim / cut</text>
+    <text x="26" y="476" class="kicker muted">TIER 2 · RESEARCHERS</text>
+    <rect x="26" y="486" width="588" height="180" rx="10" class="card"/>
+    <rect x="42" y="502" width="556" height="52" rx="9" fill="#eef5fb" stroke="#bcd6ea" stroke-width="1"/>
+    <text x="320" y="530" text-anchor="middle" class="label blue">Bull case — hold / add</text>
+    <text x="320" y="580" text-anchor="middle" class="kicker warm">OPPOSING CASE REQUIRED</text>
+    <text x="320" y="600" text-anchor="middle" class="micro muted">unanimous agreement gets flagged, not trusted</text>
+    <rect x="42" y="612" width="556" height="52" rx="9" fill="#fbeeed" stroke="#eccfcb" stroke-width="1"/>
+    <text x="320" y="640" text-anchor="middle" class="label warm">Bear case — trim / cut</text>
   </g>
+
+  <path d="M320 666V692" class="wire"/>
 
   <!-- Stage 4 · Risk voices + Judge -->
   <g class="sans">
-    <rect x="762" y="150" width="214" height="200" rx="10" class="card"/>
-    <rect x="776" y="166" width="61" height="28" rx="6" class="chip"/>
-    <text x="806" y="184" text-anchor="middle" class="micro ink">Aggr.</text>
-    <rect x="839" y="166" width="61" height="28" rx="6" class="chip"/>
-    <text x="869" y="184" text-anchor="middle" class="micro ink">Cons.</text>
-    <rect x="902" y="166" width="60" height="28" rx="6" class="chip"/>
-    <text x="932" y="184" text-anchor="middle" class="micro ink">Neut.</text>
-    <rect x="776" y="206" width="186" height="58" rx="8" fill="#eef2f6" stroke="#d3dde6" stroke-width="1.2"/>
-    <text x="869" y="230" text-anchor="middle" class="label ink">Judge</text>
-    <text x="869" y="250" text-anchor="middle" class="micro muted">names the strategy frame</text>
-    <path d="M869 264V286" class="wire"/>
-    <rect x="806" y="288" width="126" height="34" rx="7" fill="#0f1620"/>
-    <text x="869" y="310" text-anchor="middle" class="micro" fill="#eef5fb">plan.json</text>
+    <text x="26" y="714" class="kicker muted">TIER 3 · RISK + JUDGE</text>
+    <rect x="26" y="724" width="588" height="234" rx="10" class="card"/>
+    <rect x="42" y="740" width="176" height="34" rx="7" class="chip"/>
+    <text x="130" y="762" text-anchor="middle" class="body ink">Aggressive</text>
+    <rect x="226" y="740" width="176" height="34" rx="7" class="chip"/>
+    <text x="314" y="762" text-anchor="middle" class="body ink">Conservative</text>
+    <rect x="410" y="740" width="188" height="34" rx="7" class="chip"/>
+    <text x="504" y="762" text-anchor="middle" class="body ink">Neutral</text>
+    <rect x="42" y="790" width="556" height="76" rx="9" fill="#eef2f6" stroke="#d3dde6" stroke-width="1.2"/>
+    <text x="320" y="822" text-anchor="middle" class="label ink">Judge</text>
+    <text x="320" y="846" text-anchor="middle" class="micro muted">names the strategy frame driving the call</text>
+    <path d="M320 866V888" class="wire"/>
+    <rect x="230" y="892" width="180" height="42" rx="8" fill="#0f1620"/>
+    <text x="320" y="918" text-anchor="middle" class="micro" fill="#eef5fb">plan.json</text>
   </g>
+
+  <path d="M320 958V984" class="wire"/>
 
   <!-- Footer: into the grading loop -->
   <g class="sans">
-    <path d="M869 350V378H150" class="wire"/>
-    <text x="150" y="404" class="body muted">→ enters the next session's grading pipeline — where <tspan class="ink" font-weight="750">code, not the model,</tspan> settles the score.</text>
+    <rect x="26" y="994" width="588" height="106" rx="12" fill="#0f1620"/>
+    <text x="46" y="1032" fill="#dbe6ee" class="body">enters the next session's grading pipeline —</text>
+    <text x="46" y="1060" fill="#ffffff" font-weight="750" class="body">code, not the model, settles the score.</text>
   </g>
 </svg>

--- a/site/assets/information-flow.svg
+++ b/site/assets/information-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="480" viewBox="0 0 960 480" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1075" viewBox="0 0 640 1075" role="img" aria-labelledby="title desc">
   <title id="title">clawock information flow — 8 layers, 40 modules, one certified context</title>
   <desc id="desc">Eight information layers with 40 fetch and compute modules feed a deterministic Python preflight, which assembles only the blocks that run can act on into a fingerprinted context.json. The LLM reads that file and writes its analysis; Python postflight validates and settles; the result is published.</desc>
   <defs>
@@ -14,14 +14,14 @@
       .sans{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
       .mono{font-family:"SFMono-Regular",Consolas,monospace}
       .ink{fill:#151a21}.muted{fill:#61707e}.blue{fill:#407ba7}
-      .kicker{font:700 10px "SFMono-Regular",Consolas,monospace;letter-spacing:1.3px}
+      .kicker{font:700 12px "SFMono-Regular",Consolas,monospace;letter-spacing:1px}
       .title{font:800 24px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.5px}
-      .sub{font:500 12.5px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .layer{font:750 12px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .layerno{font:700 10px "SFMono-Regular",Consolas,monospace}
-      .count{font:600 9.5px "SFMono-Regular",Consolas,monospace}
-      .flow{font:650 12.5px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .flowsub{font:500 10px "SFMono-Regular",Consolas,monospace}
+      .sub{font:500 14px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .layer{font:750 15px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .layerno{font:700 12px "SFMono-Regular",Consolas,monospace}
+      .count{font:600 12.5px "SFMono-Regular",Consolas,monospace}
+      .flow{font:650 15px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .flowsub{font:500 12.5px "SFMono-Regular",Consolas,monospace}
       .shell{fill:#fff;stroke:#d8e1e8;stroke-width:1.2}
       .card{fill:#fff;stroke:#d4dfe7;stroke-width:1.1}
       .hl{fill:#eef5fa;stroke:#9fc3dd;stroke-width:1.3}
@@ -29,84 +29,85 @@
     </style>
   </defs>
 
-  <rect width="960" height="480" fill="url(#page)"/>
+  <rect width="640" height="1075" fill="url(#page)"/>
 
   <g class="sans">
-    <text x="26" y="30" class="kicker blue">INFORMATION FLOW</text>
-    <text x="26" y="58" class="title ink">8 层 · 40 个模块,汇成一份带指纹的上下文</text>
-    <text x="26" y="78" class="sub muted">每次运行只组装该场次能用的块 —— 模型读文件,不自己抓数据</text>
+    <text x="26" y="34" class="kicker blue">INFORMATION FLOW</text>
+    <text x="26" y="66" class="title ink">8 layers · 40 modules, one</text>
+    <text x="26" y="92" class="title ink">certified context</text>
+    <text x="26" y="116" class="sub muted">Each run assembles only what that session can</text>
+    <text x="26" y="136" class="sub muted">use — the model reads a file, never fetches.</text>
 
     <!-- eight layer cards, two columns x four rows -->
     <g>
-      <rect x="26" y="96" width="180" height="62" rx="8" class="card"/>
-      <text x="38" y="118" class="layerno blue">L1 · 行情</text>
-      <text x="38" y="136" class="layer ink">7 模块</text>
-      <text x="38" y="150" class="count muted">腾讯 · Yahoo · 东财 · Polygon</text>
+      <rect x="26" y="158" width="280" height="80" rx="10" class="card"/>
+      <text x="42" y="184" class="layerno blue">L1 · MARKET</text>
+      <text x="42" y="206" class="layer ink">7 modules</text>
+      <text x="42" y="224" class="count muted">Tencent · Yahoo · Eastmoney</text>
 
-      <rect x="216" y="96" width="180" height="62" rx="8" class="card"/>
-      <text x="228" y="118" class="layerno blue">L2 · 基本面/申报</text>
-      <text x="228" y="136" class="layer ink">3 模块</text>
-      <text x="228" y="150" class="count muted">SEC EDGAR · 东财 · 港交所</text>
+      <rect x="334" y="158" width="280" height="80" rx="10" class="card"/>
+      <text x="350" y="184" class="layerno blue">L2 · FUNDAMENTALS</text>
+      <text x="350" y="206" class="layer ink">3 modules</text>
+      <text x="350" y="224" class="count muted">SEC EDGAR · Eastmoney · HKEX</text>
 
-      <rect x="26" y="172" width="180" height="62" rx="8" class="card"/>
-      <text x="38" y="194" class="layerno blue">L3 · 资金面</text>
-      <text x="38" y="212" class="layer ink">1 模块</text>
-      <text x="38" y="226" class="count muted">东财资金流</text>
+      <rect x="26" y="248" width="280" height="80" rx="10" class="card"/>
+      <text x="42" y="274" class="layerno blue">L3 · CAPITAL FLOW</text>
+      <text x="42" y="296" class="layer ink">1 module</text>
+      <text x="42" y="314" class="count muted">Eastmoney push2his</text>
 
-      <rect x="216" y="172" width="180" height="62" rx="8" class="card"/>
-      <text x="228" y="194" class="layerno blue">L4 · 消息面与催化剂</text>
-      <text x="228" y="212" class="layer ink">5 模块 · 双语</text>
-      <text x="228" y="226" class="count muted">东财 · Finnhub · Google News</text>
+      <rect x="334" y="248" width="280" height="80" rx="10" class="card"/>
+      <text x="350" y="274" class="layerno blue">L4 · NEWS · BILINGUAL</text>
+      <text x="350" y="296" class="layer ink">5 modules</text>
+      <text x="350" y="314" class="count muted">Eastmoney · Finnhub · Google</text>
 
-      <rect x="26" y="248" width="180" height="62" rx="8" class="card"/>
-      <text x="38" y="270" class="layerno blue">L5 · 宏观/情绪</text>
-      <text x="38" y="288" class="layer ink">3 模块</text>
-      <text x="38" y="302" class="count muted">Yahoo · Reddit · CNN</text>
+      <rect x="26" y="338" width="280" height="80" rx="10" class="card"/>
+      <text x="42" y="364" class="layerno blue">L5 · MACRO/SENTIMENT</text>
+      <text x="42" y="386" class="layer ink">3 modules</text>
+      <text x="42" y="404" class="count muted">Yahoo · Reddit · CNN</text>
 
-      <rect x="216" y="248" width="180" height="62" rx="8" class="card"/>
-      <text x="228" y="270" class="layerno blue">L6 · 量化与风险</text>
-      <text x="228" y="288" class="layer ink">8 模块</text>
-      <text x="228" y="302" class="count muted">价格历史上的确定性计算</text>
+      <rect x="334" y="338" width="280" height="80" rx="10" class="card"/>
+      <text x="350" y="364" class="layerno blue">L6 · QUANT &amp; RISK</text>
+      <text x="350" y="386" class="layer ink">9 modules</text>
+      <text x="350" y="404" class="count muted">deterministic price math</text>
 
-      <rect x="26" y="324" width="180" height="62" rx="8" class="card"/>
-      <text x="38" y="346" class="layerno blue">L7 · 账本/汇率校验</text>
-      <text x="38" y="364" class="layer ink">6 模块</text>
-      <text x="38" y="378" class="count muted">Frankfurter · 对账账本</text>
+      <rect x="26" y="428" width="280" height="80" rx="10" class="card"/>
+      <text x="42" y="454" class="layerno blue">L7 · BOOK &amp; FX</text>
+      <text x="42" y="476" class="layer ink">6 modules</text>
+      <text x="42" y="494" class="count muted">Frankfurter · recon ledger</text>
 
-      <rect x="216" y="324" width="180" height="62" rx="8" class="card"/>
-      <text x="228" y="346" class="layerno blue">L8 · 回测/自省</text>
-      <text x="228" y="364" class="layer ink">7 模块</text>
-      <text x="228" y="378" class="count muted">本地快照 + 基准行情</text>
+      <rect x="334" y="428" width="280" height="80" rx="10" class="card"/>
+      <text x="350" y="454" class="layerno blue">L8 · BACKTEST</text>
+      <text x="350" y="476" class="layer ink">7 modules</text>
+      <text x="350" y="494" class="count muted">local snapshots + bars</text>
     </g>
 
-    <!-- gather arrow -->
-    <path d="M470 260 L500 260" class="wire"/>
-    <text x="470" y="250" class="count muted">按需组装</text>
+    <path d="M320 530V560" class="wire"/>
+    <text x="26" y="552" class="count muted">assembled on demand</text>
 
-    <!-- right pipeline -->
+    <!-- pipeline -->
     <g>
-      <rect x="508" y="96" width="220" height="56" rx="8" class="hl"/>
-      <text x="520" y="122" class="flow ink">preflight(Python,确定性)</text>
-      <text x="520" y="138" class="flowsub muted">只取本场次能用的块</text>
-      <path d="M618 152 L618 174" class="wire"/>
+      <rect x="26" y="568" width="588" height="70" rx="10" class="hl"/>
+      <text x="46" y="598" class="flow ink">preflight (Python, deterministic)</text>
+      <text x="46" y="620" class="flowsub muted">takes only the blocks this run can use</text>
+      <path d="M320 638V666" class="wire"/>
 
-      <rect x="508" y="176" width="220" height="56" rx="8" class="card"/>
-      <text x="520" y="202" class="flow ink">context.json(带指纹)</text>
-      <text x="520" y="218" class="flowsub muted">sha256 逐文件认证</text>
-      <path d="M618 232 L618 254" class="wire"/>
+      <rect x="26" y="674" width="588" height="70" rx="10" class="card"/>
+      <text x="46" y="704" class="flow ink">context.json (fingerprinted)</text>
+      <text x="46" y="726" class="flowsub muted">sha256 per document</text>
+      <path d="M320 744V772" class="wire"/>
 
-      <rect x="508" y="256" width="220" height="56" rx="8" class="card"/>
-      <text x="520" y="282" class="flow ink">LLM 读文件 · 写分析</text>
-      <text x="520" y="298" class="flowsub muted">证据 + 反方,不能自己抓数</text>
-      <path d="M618 312 L618 334" class="wire"/>
+      <rect x="26" y="780" width="588" height="70" rx="10" class="card"/>
+      <text x="46" y="810" class="flow ink">LLM reads the file · writes analysis</text>
+      <text x="46" y="832" class="flowsub muted">evidence + opposing case, never fetches data</text>
+      <path d="M320 850V878" class="wire"/>
 
-      <rect x="508" y="336" width="220" height="56" rx="8" class="card"/>
-      <text x="520" y="362" class="flow ink">postflight(Python 校验)</text>
-      <text x="520" y="378" class="flowsub muted">结算、打分、资金守恒</text>
-      <path d="M618 392 L618 414" class="wire"/>
+      <rect x="26" y="886" width="588" height="70" rx="10" class="card"/>
+      <text x="46" y="916" class="flow ink">postflight (Python validates)</text>
+      <text x="46" y="938" class="flowsub muted">settles, scores, checks money conservation</text>
+      <path d="M320 956V984" class="wire"/>
 
-      <rect x="508" y="416" width="220" height="48" rx="8" class="card"/>
-      <text x="520" y="446" class="flow ink">发布:简报 / 仪表盘 / 战绩</text>
+      <rect x="26" y="992" width="588" height="60" rx="10" class="card"/>
+      <text x="46" y="1028" class="flow ink">publish: brief / dashboard / scorecard</text>
     </g>
   </g>
 </svg>

--- a/site/assets/product-architecture.svg
+++ b/site/assets/product-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="680" viewBox="0 0 960 680" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1010" viewBox="0 0 640 1010" role="img" aria-labelledby="title desc">
   <title id="title">clawock product architecture</title>
   <desc id="desc">External agent runtimes own the model, conversation, memory, planning, tools, permissions and credentials. They install a standard skill and call the clawock CLI using JSON. The clawock package owns portable decision workflows, certified inputs, artifact contracts, deterministic money and foreign-exchange reconciliation, outcome evaluation, receipts, and bounded proposal review and rollback. User instances own strategy, evidence, ledgers, schedules, delivery and user interfaces.</desc>
   <defs>
@@ -22,116 +22,116 @@
       .sans{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif}
       .mono{font-family:"SFMono-Regular",Consolas,monospace}
       .ink{fill:#151a21}.muted{fill:#61707e}.blue{fill:#407ba7}
-      .kicker{font:700 10px "SFMono-Regular",Consolas,monospace;letter-spacing:1.3px}
-      .title{font:800 27px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.7px}
-      .section{font:800 19px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.35px}
-      .body{font:500 12.5px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .label{font:750 12px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
-      .micro{font:600 10.5px "SFMono-Regular",Consolas,monospace}
+      .kicker{font:700 12px "SFMono-Regular",Consolas,monospace;letter-spacing:1px}
+      .title{font:800 26px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.6px}
+      .section{font:800 19px Inter,-apple-system,"Segoe UI",Arial,sans-serif;letter-spacing:-.3px}
+      .body{font:500 14px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .label{font:750 15px Inter,-apple-system,"Segoe UI",Arial,sans-serif}
+      .micro{font:600 12.5px "SFMono-Regular",Consolas,monospace}
       .shell{fill:#fff;stroke:#d8e1e8;stroke-width:1.2}
       .card{fill:#fff;stroke:#d4dfe7;stroke-width:1.1}
       .wire{fill:none;stroke:#718392;stroke-width:1.8;marker-end:url(#arrow)}
     </style>
   </defs>
 
-  <rect width="960" height="680" fill="url(#page)"/>
+  <rect width="640" height="1010" fill="url(#page)"/>
 
   <g class="sans">
-    <g transform="translate(26 18) scale(.34)">
+    <g transform="translate(26 20) scale(.34)">
       <path d="M8 13C22 9 40 16 55 28C42 24 28 25 17 32C12 27 9 21 8 13Z" fill="#10141a"/>
       <path d="M56 51C42 55 24 48 9 36C22 40 36 39 47 32C52 37 55 43 56 51Z" fill="url(#brand-bull)"/>
     </g>
-    <text x="54" y="36" font-size="20" font-weight="800" class="ink">clawock</text>
-    <text x="934" y="34" text-anchor="end" class="kicker blue">PRODUCT ARCHITECTURE · RUNTIME NEUTRAL</text>
-    <text x="26" y="76" class="title ink">Decision intelligence between the agent and the instance</text>
-    <text x="26" y="98" class="body muted">The runtime thinks and acts. clawock makes the decision workflow portable, reconciled, and reviewable.</text>
+    <text x="54" y="38" font-size="21" font-weight="800" class="ink">clawock</text>
+    <text x="26" y="66" class="kicker blue">PRODUCT ARCHITECTURE · RUNTIME NEUTRAL</text>
+    <text x="26" y="98" class="title ink">Decision intelligence between</text>
+    <text x="26" y="126" class="title ink">the agent and the instance</text>
+    <text x="26" y="152" class="body muted">The runtime thinks and acts. clawock makes the</text>
+    <text x="26" y="171" class="body muted">decision workflow portable, reconciled, reviewable.</text>
   </g>
 
-  <g transform="translate(26 122)" class="sans">
-    <rect width="908" height="112" rx="16" class="shell"/>
-    <rect width="6" height="112" rx="3" fill="#27323c"/>
-    <text x="24" y="29" class="kicker blue">OWNED BY THE EXTERNAL RUNTIME</text>
-    <text x="24" y="60" class="section ink">OpenClaw · Hermes · Claude Code · Codex · other agents</text>
-    <text x="24" y="84" class="body muted">model call · conversation · memory · planning / ReAct · tools · permissions · credentials</text>
-    <rect x="736" y="27" width="144" height="56" rx="12" fill="#f2f5f7" stroke="#d8e1e8"/>
-    <text x="808" y="51" text-anchor="middle" class="kicker blue">THE AGENT</text>
-    <text x="808" y="70" text-anchor="middle" class="label ink">reads · reasons · writes</text>
+  <g transform="translate(26 196)" class="sans">
+    <rect width="588" height="128" rx="16" class="shell"/>
+    <rect width="6" height="128" rx="3" fill="#27323c"/>
+    <text x="24" y="30" class="kicker blue">OWNED BY THE EXTERNAL RUNTIME</text>
+    <text x="24" y="58" class="section ink">OpenClaw · Claude Code · Codex ·</text>
+    <text x="24" y="80" class="section ink">DeepSeek Harness · other agents</text>
+    <text x="24" y="106" class="body muted">model call · conversation · memory · tools</text>
+    <rect x="424" y="20" width="140" height="34" rx="10" fill="#f2f5f7" stroke="#d8e1e8"/>
+    <text x="494" y="41" text-anchor="middle" class="kicker blue">READS · REASONS · WRITES</text>
   </g>
 
-  <path d="M480 234V272" class="wire"/>
-  <g transform="translate(342 242)" class="sans">
-    <rect width="276" height="26" rx="13" fill="#26323d"/>
-    <text x="138" y="17" text-anchor="middle" class="kicker" fill="#eaf2f8">INSTALL SKILL · CALL CLI + JSON</text>
+  <path d="M320 324V360" class="wire"/>
+  <g transform="translate(172 332)" class="sans">
+    <rect width="296" height="28" rx="14" fill="#26323d"/>
+    <text x="148" y="18.5" text-anchor="middle" class="kicker" fill="#eaf2f8">INSTALL SKILL · CALL CLI + JSON</text>
   </g>
 
-  <g transform="translate(26 276)" class="sans">
-    <rect width="908" height="244" rx="18" fill="url(#product)" stroke="#bfcfdb" stroke-width="1.4"/>
-    <rect width="6" height="244" rx="3" fill="#4b8ab8"/>
-    <text x="24" y="30" class="kicker blue">OWNED BY THE CLAWOCK PACKAGE · src/clawock/</text>
-    <text x="24" y="61" class="section ink">Portable decision-workflow plugin + verifiable harness</text>
+  <g transform="translate(26 364)" class="sans">
+    <rect width="588" height="484" rx="18" fill="url(#product)" stroke="#bfcfdb" stroke-width="1.4"/>
+    <rect width="6" height="484" rx="3" fill="#4b8ab8"/>
+    <text x="24" y="31" class="kicker blue">OWNED BY THE CLAWOCK PACKAGE · src/clawock/</text>
+    <text x="24" y="62" class="section ink">Portable decision-workflow plugin</text>
+    <text x="24" y="86" class="section ink">+ verifiable harness</text>
 
-    <g transform="translate(24 83)">
-      <rect width="156" height="120" rx="13" class="card"/>
+    <g transform="translate(24 108)">
+      <rect width="270" height="120" rx="13" class="card"/>
       <text x="16" y="26" class="kicker blue">01 · WORKFLOW</text>
-      <text x="16" y="51" class="label ink">Evidence + opposition</text>
-      <text x="16" y="70" class="body muted">thesis · invalidation</text>
-      <text x="16" y="89" class="body muted">bounded decision</text>
-      <text x="16" y="108" class="micro muted">SKILL.md + schemas</text>
+      <text x="16" y="52" class="label ink">Evidence + opposition</text>
+      <text x="16" y="73" class="body muted">thesis · invalidation</text>
+      <text x="16" y="92" class="body muted">bounded decision</text>
+      <text x="16" y="112" class="micro muted">SKILL.md + schemas</text>
     </g>
-
-    <path d="M180 143H196" class="wire"/>
-    <g transform="translate(196 83)">
-      <rect width="156" height="120" rx="13" class="card"/>
+    <g transform="translate(294 108)">
+      <rect width="270" height="120" rx="13" class="card"/>
       <text x="16" y="26" class="kicker blue">02 · CERTIFY</text>
-      <text x="16" y="51" class="label ink">Pinned input</text>
-      <text x="16" y="70" class="body muted">context hashes</text>
-      <text x="16" y="89" class="body muted">workflow version</text>
-      <text x="16" y="108" class="micro muted">run prepare</text>
+      <text x="16" y="52" class="label ink">Pinned input</text>
+      <text x="16" y="73" class="body muted">context hashes</text>
+      <text x="16" y="92" class="body muted">workflow version</text>
+      <text x="16" y="112" class="micro muted">run prepare</text>
     </g>
 
-    <path d="M352 143H368" class="wire"/>
-    <g transform="translate(368 83)">
-      <rect width="172" height="120" rx="13" class="card"/>
+    <g transform="translate(24 242)">
+      <rect width="270" height="120" rx="13" class="card"/>
       <text x="16" y="26" class="kicker blue">03 · RECONCILE</text>
-      <text x="16" y="51" class="label ink">Deterministic truth</text>
-      <text x="16" y="70" class="body muted">order · cash · FX · P&amp;L</text>
-      <text x="16" y="89" class="body muted">artifact validation</text>
-      <text x="16" y="108" class="micro muted">run publish</text>
+      <text x="16" y="52" class="label ink">Deterministic truth</text>
+      <text x="16" y="73" class="body muted">order · cash · FX</text>
+      <text x="16" y="92" class="body muted">artifact validation</text>
+      <text x="16" y="112" class="micro muted">run publish</text>
     </g>
-
-    <path d="M540 143H556" class="wire"/>
-    <g transform="translate(556 83)">
-      <rect width="146" height="120" rx="13" class="card"/>
+    <g transform="translate(294 242)">
+      <rect width="270" height="120" rx="13" class="card"/>
       <text x="16" y="26" class="kicker blue">04 · EVALUATE</text>
-      <text x="16" y="51" class="label ink">Observed outcome</text>
-      <text x="16" y="70" class="body muted">decision lineage</text>
-      <text x="16" y="89" class="body muted">generation receipt</text>
-      <text x="16" y="108" class="micro muted">workflow evaluate</text>
+      <text x="16" y="52" class="label ink">Observed outcome</text>
+      <text x="16" y="73" class="body muted">decision lineage</text>
+      <text x="16" y="92" class="body muted">generation receipt</text>
+      <text x="16" y="112" class="micro muted">workflow evaluate</text>
     </g>
 
-    <path d="M702 143H718" class="wire"/>
-    <g transform="translate(718 83)">
-      <rect width="142" height="120" rx="13" class="card"/>
+    <g transform="translate(24 376)">
+      <rect width="540" height="84" rx="13" class="card"/>
       <text x="16" y="26" class="kicker blue">05 · IMPROVE</text>
-      <text x="16" y="51" class="label ink">Bounded proposal</text>
-      <text x="16" y="70" class="body muted">review exact diff</text>
-      <text x="16" y="89" class="body muted">apply · rollback</text>
-      <text x="16" y="108" class="micro muted">never silent</text>
+      <text x="16" y="52" class="label ink">Bounded proposal</text>
+      <text x="16" y="72" class="body muted">review exact diff · apply · rollback · never silent</text>
     </g>
+
+    <path d="M159 228V242" class="wire"/>
+    <path d="M429 228V242" class="wire"/>
   </g>
 
-  <path d="M480 520V558" class="wire"/>
-  <g transform="translate(385 528)" class="sans">
-    <rect width="190" height="26" rx="13" fill="#fff" stroke="#c8d6e0"/>
-    <text x="95" y="17" text-anchor="middle" class="kicker blue">ADAPTER-OWNED I/O</text>
+  <path d="M320 848V884" class="wire"/>
+  <g transform="translate(225 856)" class="sans">
+    <rect width="190" height="28" rx="14" fill="#fff" stroke="#c8d6e0"/>
+    <text x="95" y="18.5" text-anchor="middle" class="kicker blue">ADAPTER-OWNED I/O</text>
   </g>
 
-  <g transform="translate(26 562)" class="sans">
-    <rect width="908" height="90" rx="16" class="shell"/>
-    <rect width="6" height="90" rx="3" fill="#9a7b65"/>
-    <text x="24" y="29" class="kicker blue">OWNED BY THE USER INSTANCE</text>
-    <text x="24" y="58" class="section ink">Strategy · evidence · ledger · schedules · delivery · UI</text>
-    <text x="906" y="30" text-anchor="end" class="micro muted">not included in the wheel</text>
-    <text x="906" y="58" text-anchor="end" class="body muted">KCNyu is one live proof, not the product</text>
+  <g transform="translate(26 888)" class="sans">
+    <rect width="588" height="106" rx="16" class="shell"/>
+    <rect width="6" height="106" rx="3" fill="#9a7b65"/>
+    <text x="24" y="30" class="kicker blue">OWNED BY THE USER INSTANCE</text>
+    <text x="24" y="59" class="section ink">Strategy · evidence · ledger ·</text>
+    <text x="24" y="81" class="section ink">schedules · delivery · UI</text>
+    <text x="564" y="30" text-anchor="end" class="micro muted">not in the wheel</text>
+    <text x="564" y="52" text-anchor="end" class="body muted">KCNyu is one live proof,</text>
+    <text x="564" y="71" text-anchor="end" class="body muted">not the product</text>
   </g>
 </svg>


### PR DESCRIPTION
docs: 四张架构图改窄栏布局(手机可读)+ 修一处失效的粗体语法

kcn 反馈让把 SVG 图都好好画一遍——实测发现真问题:所有 4 张图(product-
architecture / architecture / information-flow / debate-flow)画布宽度都在
900-1000px,GitHub 渲染 README 图片是按容器宽度铺满(不管原图多宽),手机
容器只有 ~350-390px,导致图内文字被压缩到 3-5px,基本看不清。截图实测过
(见会话记录),不是猜的。

## 改法

四张图画布收窄到 640,原来横向铺开的多列布局(product-architecture 的 5 个
横排步骤卡片、architecture 的左右三列环形布局、debate-flow 的四段横向管道)
全部改成纵向单列堆叠,字号同步调大(kicker 10→12px,body 12.5→14px,label
12→15px)。画布变窄+字号变大双重作用下,同一个手机容器宽度下渲染出来的
文字明显更大更清楚。内容/信息量没删减,只是换了排布方向。

验证方法:写了个 Playwright 脚本把每张图分别按「桌面容器 800px」「手机
容器 350px」两种宽度渲染截图比对,四张图逐张过了一遍,修了两处真实
排版 bug(product-architecture 里一段文字顶到卡片边框外、"05·IMPROVE"卡片
和下方"ADAPTER-OWNED I/O"胶囊高度算错导致重叠)。

## 顺手修的 markdown 语法 bug

kcn 发现的:README.zh.md 开头"它跑了 **90 天"里的 `**` 因为没有闭合符号,
GitHub 直接把星号当纯文本显示出来,不是加粗——补上缺的收尾 `**`。

同时把 EN/ZH 两处一行式的 pipeline 代码块(`sources ──► preflight ──► ...`)
从单行改成竖排箭头列表,手机上这种单行长代码块要横向滚动才能看全,现在
换行后每一步独立成行,不用横滑。

## 验证

pytest 全量 2153 passed / 5 skipped / 4 xfailed,readme/brand-assets 相关
测试单独跑也全绿(这几张图没有精确字节数/尺寸断言,改动安全)。
