### PR TITLE
fix(dsh-plugin): Decision Mind header stat no longer doubles the sign

### DIFF
--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -342,7 +342,7 @@ window.__ModuleLoader__.load({
 
       var stats = h('div', { className: 'stats' },
         h('div', { className: 'sg' }, h('span', { className: 'sl' }, '已实现 (USD 等值)'),
-          h('span', { className: 'sv focus ' + (totalUsd >= 0 ? 'up' : 'down') }, (totalUsd >= 0 ? '+' : '') + fmtMoney(totalUsd))),
+          h('span', { className: 'sv focus ' + (totalUsd >= 0 ? 'up' : 'down') }, fmtMoney(totalUsd))),
         h('div', { className: 'sg' }, h('span', { className: 'sl' }, 'T+1 卖飞/卖对'),
           h('span', { className: 'sv' }, h('span', { className: 'down' }, fw), ' / ', h('span', { className: 'up' }, ok))),
         h('div', { className: 'sg' }, h('span', { className: 'sl' }, '决策挂接'), h('span', { className: 'sv' }, matched + '/' + traces.length)),

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -336,6 +336,7 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined, /卖出/);
   assert.match(joined, /\+45.21/);       // realized P&L on the real sell
   assert.match(joined, /卖对/);           // T+1 verdict chip
+  assert.doesNotMatch(joined, /\+\+/);   // header stat must not double-prepend the sign
 
   // Filter: 无决策 keeps only SPCH fills without a decision.
   const findButton = (label) => {


### PR DESCRIPTION
Fixes #698.

## Problem

Decision Mind tab header stat "已实现 (USD 等值)" rendered `++2,348` for
positive totals instead of `+2,348`.

## Root cause

`examples/dsh/plugin/client.js` prepended `'+'` at the call site *and* passed
the value through `fmtMoney()`, which already adds `'+'` for positive
numbers. Only one call site exists.

## Fix

Drop the redundant outer prefix, rely on `fmtMoney`'s own sign handling.
Added a regression assertion (`doesNotMatch(joined, /\+\+/)`) to the existing
render test in `tests/decision_studio_plugin.spec.js`.

## Verification

```
node --test tests/decision_studio_plugin.spec.js
# 8 pass, 0 fail
```

Found while screenshotting the live Decision Mind tab in DSH for an
unrelated purpose (social post) — not from a report.
