### PR TITLE
feat(dsh-plugin): Decision Mind 列表默认折叠最近 3 组 + 展开内容懒渲染

### DIFF
--- a/examples/dsh/plugin/client.js
+++ b/examples/dsh/plugin/client.js
@@ -117,6 +117,8 @@ window.__ModuleLoader__.load({
         '.dmt .tnote .k{color:var(--cap);font:600 10.5px/1.4 var(--font)}',
         '.dmt .tmiss{padding:7px 10px;border:1px dashed var(--border2);border-radius:6px;font:400 11.5px/1.5 var(--font);color:var(--cap);margin-top:8px}',
         '.dmt .empty{padding:48px 20px;text-align:center;color:var(--cap);font:400 13px/1.5 var(--font)}',
+        '.dmt .trace-more{display:block;width:calc(100% - 32px);margin:10px 16px;padding:9px 12px;border:1px dashed var(--border2);border-radius:10px;background:var(--surface);color:var(--text2);font:600 12px/1.4 var(--font);cursor:pointer;transition:background .12s,border-color .12s,color .12s}',
+        '.dmt .trace-more:hover{background:var(--hover);border-color:var(--brand);color:var(--text)}',
         '@media (max-width:520px){',
         '.dmt .main{gap:8px;padding:12px 12px 6px}',
         '.dmt .tk{font-size:13.5px}',
@@ -281,12 +283,12 @@ window.__ModuleLoader__.load({
           h('span', { className: 'date' }, (t.date || '').slice(5)),
           h('span', { className: 'chev' }, '▾')),
         h('div', { className: 'detail' },
-          h('div', { className: 'dinner' }, h(TraceDetail, { trace: t }))))
+          h('div', { className: 'dinner' }, open ? h(TraceDetail, { trace: t }) : null)))
     }
 
     /** The single organic view: decision trace timeline. */
     function DecisionMind(props) {
-      var pair = useState({ filter: 'all', open: null, traces: [], rate: null, loading: true, error: null })
+      var pair = useState({ filter: 'all', open: null, traces: [], rate: null, loading: true, error: null, showAll: false })
       var state = pair[0]
       var setState = pair[1]
       useEffect(function () {
@@ -333,9 +335,16 @@ window.__ModuleLoader__.load({
         return parseInt(iso.slice(5, 7)) + '月' + parseInt(iso.slice(8, 10)) + '日'
       }
 
-      var body
-      if (!filtered.length) body = h('div', { className: 'empty' }, '没有符合条件的成交')
-      else body = h('div', null, dates.map(function (date) {
+      // Default fold: render only the newest TRACE_FOLD_GROUPS date groups.
+      // 100 fills as one wall of cells is not scannable and janks the first
+      // paint when the tab mounts — the first screen is the recent story,
+      // the rest behind an explicit "show all" (same contract as the
+      // dashboard trace card). Stats above stay computed over ALL fills.
+      var TRACE_FOLD_GROUPS = 3
+      var visibleDates = state.showAll ? dates : dates.slice(0, TRACE_FOLD_GROUPS)
+      var hiddenCount = filtered.length - visibleDates.reduce(function (sum, d) { return sum + groups[d].length }, 0)
+
+      function renderDate(date) {
         return h('div', { key: date },
           h('div', { className: 'day' }, rel(date), h('span', null, date), h('span', { className: 'n' }, groups[date].length)),
           groups[date].map(function (t) {
@@ -348,7 +357,20 @@ window.__ModuleLoader__.load({
               onKeyDown: function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setState(function (c) { return Object.assign({}, c, { open: c.open === key ? null : key }) }) } },
             })
           }))
-      }))
+      }
+
+      var moreBtn = (hiddenCount > 0 || state.showAll)
+        ? h('button', { key: 'more', className: 'trace-more', onClick: function () { setState(function (c) { return Object.assign({}, c, { showAll: !c.showAll }) }) } },
+            state.showAll ? '收起,只显示最近 ' + TRACE_FOLD_GROUPS + ' 组' : '显示全部 ' + hiddenCount + ' 笔更早成交')
+        : null
+
+      var body
+      if (!filtered.length) body = h('div', { className: 'empty' }, '没有符合条件的成交')
+      else {
+        var kids = visibleDates.map(renderDate)
+        if (moreBtn) kids.push(moreBtn)
+        body = h('div', null, kids)
+      }
 
       var stats = h('div', { className: 'stats' },
         h('div', { className: 'sg' }, h('span', { className: 'sl' }, '已实现 (USD 等值)'),

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -408,3 +408,94 @@ test("client: T+1 tone is action-aware — buy gains are win, sell misses are lo
   assert.equal(api.t1ChipTone("sell", -4.0), "up");
 });
 
+test("client: trace list folds to the newest 3 date groups, show-all reveals the rest", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return {};
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
+
+  // 5 distinct date groups → default renders the newest 3 (AAA/BBB/CCC),
+  // DDD/EEE stay behind the "show all" toggle. This is the anti-jank fold:
+  // the first paint must not be a 100-cell wall.
+  const mk = (ticker, date) => ({ ticker, market: "US", currency: "USD", date, action: "buy", shares: 1, price: 10, realizedPnl: null });
+  const trades = [
+    mk("AAA", "2026-08-15"),
+    mk("BBB", "2026-08-14"),
+    mk("CCC", "2026-08-13"),
+    mk("DDD", "2026-08-10"),
+    mk("EEE", "2026-08-05"),
+  ];
+
+  let registered = null;
+  let component = null;
+  const remoteFace = {
+    traces: async () => ({ ok: true, value: { trades, rate: null } }),
+    ledger: async () => ({ ok: true, value: { entries: [] } }),
+    portfolio: async () => ({ ok: true, value: { books: [] } }),
+    plans: async () => ({ ok: true, value: { plans: [] } }),
+  };
+  const ctx = {
+    effect() {},
+    get() { return remoteFace; },
+    slots: { inject(n, fn) { this._fn = fn; }, register(definition, Component) { registered = definition; component = Component; } },
+    remote: { $mount: async () => {} },
+  };
+  await api.apply(ctx);
+  ctx.slots._fn();
+  const injected = registered.inject("s1");
+
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  const render = () => component({ sessionId: "s1", traces: injected.traces, ledger: injected.ledger, portfolio: injected.portfolio });
+  let tree = render();
+  await tick(); await tick(); await tick();
+  tree = render();
+
+  const collectText = () => {
+    const text = [];
+    (function walk(node) {
+      if (node == null) return;
+      if (Array.isArray(node)) { node.forEach(walk); return; }
+      if (typeof node === "string") { text.push(node); return; }
+      (node.children || []).forEach(walk);
+      walk(node.props && node.props.value);
+      walk(node.props && node.props.label);
+    })(tree);
+    return text.join(" ");
+  };
+  const findButton = (label) => {
+    let found = null;
+    (function collect(node) {
+      if (node == null || found) return;
+      if (Array.isArray(node)) { node.forEach(collect); return; }
+      if (node.type === "button") {
+        const t = (node.children || []).filter((c) => typeof c === "string").join("");
+        if (t.indexOf(label) === 0) found = node;
+      }
+      (node.children || []).forEach(collect);
+    })(tree);
+    return found;
+  };
+
+  // Folded default: newest 3 groups only, older fills not in the DOM.
+  const joined = collectText();
+  assert.match(joined, /AAA/);
+  assert.match(joined, /BBB/);
+  assert.match(joined, /CCC/);
+  assert.doesNotMatch(joined, /DDD/);
+  assert.doesNotMatch(joined, /EEE/);
+
+  // The toggle advertises exactly what's hidden, then reveals it.
+  const more = findButton("显示全部");
+  assert.ok(more, "fold toggle must be present when fills exceed the default");
+  assert.match(joined, /显示全部 2 笔/);
+  more.props.onClick();
+  await tick();
+  tree = render();
+  const joinedAll = collectText();
+  assert.match(joinedAll, /DDD/);
+  assert.match(joinedAll, /EEE/);
+  assert.match(joinedAll, /收起/);
+});
+


### PR DESCRIPTION
## 问题

切到 Decision Mind tab 会卡:100 笔成交每笔都渲染成一个完整的可展开 cell,而且
**折叠态也照样构建了 detail 时间线子树**(只是 CSS `grid-template-rows:0fr` 藏起来)。
所以初始 DOM 里同时存在 100 个 cell × 每个 cell 的完整 plan→执行→T+1→盈亏子树。

## 改法(两处)

1. **默认折叠**:只渲染最近 3 个交易日组,底部「显示全部 N 笔更早成交」↔「收起」按钮
   切换。与 dashboard 决策轨迹卡 #684 同口径(插件和网页是同一份数据契约)。
   顶部统计卡(已实现盈亏 / T+1 / 决策挂接)仍基于**全部**成交计算,折叠不影响数字。
2. **展开内容懒渲染**:`TraceCell` 的 `detail` 只在 `open` 时构建 `TraceDetail`,
   折叠态不再渲染展开子树——这是真正的懒加载,砍掉每笔 cell 里最重的那部分 DOM。

trajectory 切过去不卡是因为它数据量小(单条),没有可比性;DSH 不给我们控制 tab
挂载/缓存的 API,能做的就是把初始渲染量压下来。

## 测试

- 新增 spec:5 个日期组,默认只渲染最新 3 组(更早 2 笔不在 DOM),点「显示全部」后
  露出其余并出现「收起」。
- `node tests/decision_studio_plugin.spec.js` 9/9 通过。