### PR TITLE
release(dsh-plugin) 0.1.6 + 审计修复:T+1 口径、缓存新鲜度、依赖闸 (#709-#715)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -176,6 +176,15 @@ jobs:
         if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
         run: node tests/decision_studio_plugin.spec.js
 
+      # The spec above imports lib/ out of the checkout, where the repo's own
+      # node_modules satisfies everything — so it stayed green while #708
+      # shipped an undeclared-at-the-install-site `zod` and crash-looped dsh in
+      # production. This gate packs and installs the package standalone, which
+      # is the only place that class of defect is visible.
+      - name: Decision Studio package contract (standalone install + export entries)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        run: node tests/dsh_plugin_package_contract.mjs
+
       - name: Set up Python
         if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v7

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -73,8 +73,11 @@ NPM_TOKEN=... ops/publish/publish_dsh_plugin.sh 0.2.1
 
 `NPM_TOKEN` is the npm registry auth token and the only environment input the
 script needs (a userconfig with registry auth works too). Before touching the
-registry it runs `npm pack --dry-run` and verifies the package and its
-`skills/investment-decision/SKILL.md` both exist.
+registry it rebuilds the plugin artifacts (`npm install --include=dev &&
+npm run build` — src → lib + Typert generation, so the published package never
+ships stale committed output) and runs `npm pack --dry-run` to verify the
+package, its `skills/investment-decision/SKILL.md`, and the generated
+`lib/typert.remote-client.js` all exist.
 
 On a `v*` tag the workflow's `npm` job calls the same script with the tag
 version (`"${GITHUB_REF_NAME#v}"`), so PyPI and npm publish together; the GitHub

--- a/examples/dsh/plugin/lib/client.js
+++ b/examples/dsh/plugin/lib/client.js
@@ -4395,7 +4395,12 @@ const clawock_dsh_clawockStudio_traces_result$schema = object({
 			"date": string(),
 			"price": number(),
 			"delta": number(),
-			"verdict": string()
+			"verdict": string(),
+			"tone": union([
+				literal("win"),
+				literal("loss"),
+				literal("flat")
+			])
 		})]),
 		"decision": union([literal(null), object({
 			"planDate": union([literal(null), string()]),
@@ -4726,19 +4731,19 @@ const EMO = {
 function esc(s) {
 	return String(s == null ? "" : s).replace(/</g, "&lt;");
 }
-/** T+1 tone is action-aware: a rising price is good for the buyer and bad
-*  for the seller (卖飞). One sign rule for both would color buy gains red
-*  and buy losses green. */
-function t1Tone(action, delta) {
-	const up = delta >= 0;
-	if (action === "sell" || action === "cut" || action === "trim" || action === "trim_on_rebound") return up ? "loss" : "win";
-	return up ? "win" : "loss";
+/**
+* The T+1 tone is decided host-side (`t1ToneOf` in ledger.ts) and shipped on
+* the trace as `t1.tone`. These two helpers only map that single reading onto
+* the two CSS vocabularies used here — the trace node's win/loss and the
+* chip's up/down. They deliberately take no thresholds: three independent
+* dead zones used to colour the same fill grey-"持平" in the chip and red in
+* the node, and to paint a buy at exactly 0% green while the text read 跌.
+*/
+function t1NodeClass(tone) {
+	return tone === "flat" ? "" : tone;
 }
-function t1ChipTone(action, delta) {
-	if (delta > -1 && delta < 1) return "flat";
-	const up = delta >= 1;
-	if (action === "sell" || action === "cut" || action === "trim" || action === "trim_on_rebound") return up ? "down" : "up";
-	return up ? "up" : "down";
+function t1ChipClass(tone) {
+	return tone === "flat" ? "flat" : tone === "win" ? "up" : "down";
 }
 function fmtMoney(v) {
 	if (v == null || !isFinite(v)) return "—";
@@ -4774,7 +4779,7 @@ function TraceDetail(props) {
 	const d = t.decision;
 	const sym = t.currency === "HKD" ? "HK$" : "$";
 	if (!d) {
-		const t1miss = t.t1 ? h("div", { className: "tnode " + t1Tone(t.action, t.t1.delta) }, h("div", { className: "n" }, "T+1 结果"), h("div", { className: "v" }, (t.t1.delta >= 0 ? "+" : "") + t.t1.delta + "%")) : null;
+		const t1miss = t.t1 ? h("div", { className: ("tnode " + t1NodeClass(t.t1.tone)).trim() }, h("div", { className: "n" }, "T+1 结果"), h("div", { className: "v" }, (t.t1.delta >= 0 ? "+" : "") + t.t1.delta + "%")) : null;
 		return h("div", null, h("div", { className: "trhead" }, "决策轨迹 · 无关联记录"), h("div", { className: "trace" }, h("div", { className: "tnode dec" }, h("div", { className: "n" }, "决策"), h("div", {
 			className: "v",
 			style: { color: "var(--cap)" }
@@ -4797,7 +4802,7 @@ function TraceDetail(props) {
 		className: "pc",
 		key: "p"
 	}, "计划价 " + d.plannedPrice));
-	const t1node = t.t1 ? h("div", { className: "tnode " + t1Tone(t.action, t.t1.delta) }, h("div", { className: "tw" }, t.t1.date), h("div", { className: "n" }, "T+1 结果"), h("div", { className: "v" }, (t.t1.delta >= 0 ? "+" : "") + t.t1.delta + "%" + (t.action === "sell" ? " · " + t.t1.verdict : ""))) : null;
+	const t1node = t.t1 ? h("div", { className: ("tnode " + t1NodeClass(t.t1.tone)).trim() }, h("div", { className: "tw" }, t.t1.date), h("div", { className: "n" }, "T+1 结果"), h("div", { className: "v" }, (t.t1.delta >= 0 ? "+" : "") + t.t1.delta + "%" + (t.action === "sell" ? " · " + t.t1.verdict : ""))) : null;
 	let rv;
 	let rc;
 	if (t.realizedPnl != null) {
@@ -4823,7 +4828,7 @@ function TraceCell(props) {
 	else pnl = h("span", { className: "pnl na" }, "—");
 	let t1tag = null;
 	if (t.t1) {
-		const tc = t1ChipTone(t.action, t.t1.delta);
+		const tc = t1ChipClass(t.t1.tone);
 		const tlabel = "T+1 " + (t.t1.delta >= 0 ? "+" : "") + t.t1.delta + "%" + (t.action === "sell" ? " " + t.t1.verdict : "");
 		t1tag = h("span", { className: "t1 " + tc }, tlabel);
 	} else if (t.action === "sell") t1tag = h("span", { className: "t1 flat" }, "T+1 —");
@@ -4925,6 +4930,7 @@ function DecisionMind(props) {
 	const hkd = traces.filter((t) => t.realizedPnl != null && t.currency === "HKD").reduce((s, t) => s + t.realizedPnl, 0);
 	const fx = data.rate;
 	const totalUsd = usd + (fx ? hkd / fx : 0);
+	const t1Rated = traces.filter((t) => t.t1).length;
 	const fw = traces.filter((t) => t.t1 && t.t1.verdict === "卖飞").length;
 	const ok = traces.filter((t) => t.t1 && t.t1.verdict === "卖对").length;
 	const matched = traces.filter((t) => t.decision).length;
@@ -5006,7 +5012,7 @@ function DecisionMind(props) {
 		if (moreBtn) kids.push(moreBtn);
 		body = h("div", null, kids);
 	}
-	const stats = h("div", { className: "stats" }, h("div", { className: "sg" }, h("span", { className: "sl" }, "已实现 (USD 等值)"), h("span", { className: "sv focus " + (totalUsd >= 0 ? "up" : "down") }, fmtMoney(totalUsd))), h("div", { className: "sg" }, h("span", { className: "sl" }, "T+1 卖飞/卖对"), h("span", { className: "sv" }, h("span", { className: "down" }, fw), " / ", h("span", { className: "up" }, ok))), h("div", { className: "sg" }, h("span", { className: "sl" }, "决策挂接"), h("span", { className: "sv" }, matched + "/" + traces.length)), fx ? h("span", { className: "rate" }, traces.length + " 笔成交 · @" + fx) : h("span", { className: "rate" }, traces.length + " 笔成交"));
+	const stats = h("div", { className: "stats" }, h("div", { className: "sg" }, h("span", { className: "sl" }, "已实现 (USD 等值)"), h("span", { className: "sv focus " + (totalUsd >= 0 ? "up" : "down") }, fmtMoney(totalUsd))), h("div", { className: "sg" }, h("span", { className: "sl" }, "T+1 卖飞/卖对 · 基于 " + t1Rated + " 笔"), h("span", { className: "sv" }, h("span", { className: "down" }, fw), " / ", h("span", { className: "up" }, ok))), h("div", { className: "sg" }, h("span", { className: "sl" }, "决策挂接"), h("span", { className: "sv" }, matched + "/" + traces.length)), fx ? h("span", { className: "rate" }, traces.length + " 笔成交 · @" + fx) : h("span", { className: "rate" }, traces.length + " 笔成交"));
 	const filters = h("div", { className: "filters" }, [
 		"all",
 		"miss",
@@ -5102,7 +5108,7 @@ async function apply(ctx) {
 }
 //#endregion
 
-    Object.assign(exports, { _displayEntry, apply, inject, t1ChipTone, t1Tone });
+    Object.assign(exports, { _displayEntry, apply, inject, t1ChipClass, t1NodeClass });
     return module.exports;
   }
 });

--- a/examples/dsh/plugin/lib/client.js
+++ b/examples/dsh/plugin/lib/client.js
@@ -4740,10 +4740,12 @@ function esc(s) {
 * the node, and to paint a buy at exactly 0% green while the text read 跌.
 */
 function t1NodeClass(tone) {
-	return tone === "flat" ? "" : tone;
+	return tone === "win" || tone === "loss" ? tone : "";
 }
 function t1ChipClass(tone) {
-	return tone === "flat" ? "flat" : tone === "win" ? "up" : "down";
+	if (tone === "win") return "up";
+	if (tone === "loss") return "down";
+	return "flat";
 }
 function fmtMoney(v) {
 	if (v == null || !isFinite(v)) return "—";

--- a/examples/dsh/plugin/lib/freshness.js
+++ b/examples/dsh/plugin/lib/freshness.js
@@ -8,12 +8,40 @@ import { createHash } from "node:crypto";
 * typert-protocol dependency, and reused by the benchmark scripts.
 */
 /**
+* Content signature over every snapshot file, not just the newest filename.
+*
+* `readSnapshotPrices` parses *all* of `memory/snapshots/`, so the signature
+* has to cover all of it. Keying on the newest filename alone missed two real
+* cases: an existing snapshot being recomputed and rewritten, and the current
+* day's file being rewritten repeatedly intraday — in both the name never
+* moves, so a cached trace view would be served indefinitely. A directory
+* mtime was rejected for moving on unrelated churn; per-file `stat` does not
+* have that problem. Measured 1.4ms steady-state for the current 68 files
+* (~8ms on the first cold call), against the ~103ms readTraces it guards.
+*/
+function snapshotsSignature(ws) {
+	const dir = join(ws, "memory", "snapshots");
+	let names;
+	try {
+		names = readdirSync(dir).sort();
+	} catch {
+		return "none";
+	}
+	if (names.length === 0) return "none";
+	const hash = createHash("sha1");
+	for (const name of names) try {
+		const st = statSync(join(dir, name));
+		hash.update(`${name}:${st.mtimeMs}:${st.size}\n`);
+	} catch {
+		hash.update(`${name}:missing\n`);
+	}
+	return `${names.length}:${hash.digest("hex").slice(0, 16)}`;
+}
+/**
 * Freshness signature over the three sources that feed the trace view:
-* portfolio.json (fills + notes), the newest snapshot filename (T+1 closes
-* land as NEW daily files — an mtime on the directory would also move on
-* unrelated churn), and decisions.jsonl (soft pairing). All three are
-* stat-level (µs) reads, no parsing. The enriched trace view is valid to
-* reuse iff this signature is unchanged.
+* portfolio.json (fills + notes), every snapshot's stat (T+1 closes), and
+* decisions.jsonl (soft pairing). All stat-level reads, no parsing. The
+* enriched trace view is valid to reuse iff this signature is unchanged.
 */
 function workspaceSignature(ws) {
 	const sig = (p) => {
@@ -24,14 +52,9 @@ function workspaceSignature(ws) {
 			return "missing";
 		}
 	};
-	let latestSnapshot = "none";
-	try {
-		const files = readdirSync(join(ws, "memory", "snapshots")).sort();
-		if (files.length > 0) latestSnapshot = files[files.length - 1];
-	} catch {}
 	return [
 		sig(join(ws, "portfolio.json")),
-		latestSnapshot,
+		snapshotsSignature(ws),
 		sig(join(ws, "memory", "decisions.jsonl"))
 	].join("|");
 }

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -53,7 +53,8 @@ function readPortfolio(workspace) {
 	if (doc === null || typeof doc !== "object" || Array.isArray(doc)) return {
 		books: [],
 		trades: [],
-		lastUpdated: null
+		lastUpdated: null,
+		marketContext: {}
 	};
 	const books = [];
 	const trades = [];
@@ -104,7 +105,8 @@ function readPortfolio(workspace) {
 	return {
 		books,
 		trades,
-		lastUpdated: typeof doc["last_updated"] === "string" ? doc["last_updated"] : null
+		lastUpdated: typeof doc["last_updated"] === "string" ? doc["last_updated"] : null,
+		marketContext: doc["market_context"] ?? {}
 	};
 }
 /**
@@ -137,12 +139,67 @@ function readPlans(workspace, limit = 14) {
 	return { plans };
 }
 const SNAPSHOT_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/;
-/** Day number for window arithmetic (no Date TZ pitfalls for ISO dates). */
+/**
+* Ordering key for ISO dates (no Date TZ pitfalls). Monotonic, so it is safe
+* for `<`/`>` comparison and sorting — but the *difference* between two of
+* these is NOT a day count (2026-08-31 → 2026-09-01 differs by 2, not 1).
+* Use `dayGap` whenever a real distance is needed.
+*/
 function dayNum(iso) {
 	if (typeof iso !== "string") return null;
 	const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
 	if (!m) return null;
 	return Number(m[1]) * 400 + Number(m[2]) * 32 + Number(m[3]);
+}
+/** UTC midnight epoch for an ISO date, for real calendar-day arithmetic. */
+function utcDay(iso) {
+	if (typeof iso !== "string") return null;
+	const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+	if (!m) return null;
+	return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+/** Signed calendar-day distance `to - from`; null when either side is unparseable. */
+function dayGap(from, to) {
+	const a = utcDay(from);
+	const b = utcDay(to);
+	if (a === null || b === null) return null;
+	return Math.round((b - a) / 864e5);
+}
+/**
+* How far after a fill a close may sit and still be called "T+1".
+* A Friday fill settles against Monday (3 calendar days); one intervening
+* public holiday makes 4. Anything beyond that is a different horizon and
+* must not be labelled T+1 — see the snapshot-coverage note on `futureClose`.
+*/
+const T1_MAX_GAP_DAYS = 4;
+/**
+* Shared dead zone for T+1 readings: a move smaller than this reads as flat
+* for every action. Host-side single source of truth so the chip, the trace
+* node and the verdict text can never disagree (they used to: three separate
+* thresholds coloured the same fill two different ways).
+*/
+const T1_FLAT_BAND_PCT = 1;
+/** Actions that reduce a position — a rising price is bad news for these. */
+const SELL_ACTIONS = /* @__PURE__ */ new Set([
+	"sell",
+	"cut",
+	"trim",
+	"trim_on_rebound"
+]);
+function isSellAction(action) {
+	return SELL_ACTIONS.has(action);
+}
+/** Good/bad/flat reading of a T+1 move, action-aware and dead-zoned. */
+function t1ToneOf(action, delta) {
+	if (Math.abs(delta) < 1) return "flat";
+	const up = delta > 0;
+	return isSellAction(action) ? up ? "loss" : "win" : up ? "win" : "loss";
+}
+/** Chinese verdict text for a T+1 move, on the same dead zone as `t1ToneOf`. */
+function t1VerdictOf(action, delta) {
+	if (Math.abs(delta) < 1) return "持平";
+	const up = delta > 0;
+	return isSellAction(action) ? up ? "卖飞" : "卖对" : up ? "涨" : "跌";
 }
 /**
 * Price lookup per ticker across daily snapshots: { ticker: { date: price } }.
@@ -182,21 +239,33 @@ function readSnapshotPrices(workspace) {
 	}
 	return byTicker;
 }
-/** First close at least `n` trading days after `date` for `ticker`. */
-function futureClose(byTicker, ticker, date, n) {
+/**
+* The n-th snapshot close strictly after `date` for `ticker` — but only when
+* it actually lands inside `maxGapDays` calendar days of the fill.
+*
+* The snapshot series is not a trading calendar: it starts the day the desk
+* began writing `memory/snapshots/`, and it has holes whenever the daily job
+* missed a run. Without the gap ceiling this function happily returns "the
+* next close we happen to own", which for fills predating the series is
+* months later — those were being rendered under a literal "T+1" label. A
+* horizon we cannot actually observe must read as unknown, not as a verdict.
+*/
+function futureClose(byTicker, ticker, date, n, maxGapDays = 4) {
 	const days = byTicker[ticker];
 	if (!days) return null;
 	const base = dayNum(date);
 	if (base === null) return null;
 	const hit = Object.keys(days).filter((d) => (dayNum(d) ?? 0) > base).sort()[n - 1];
 	if (hit === void 0) return null;
+	const gap = dayGap(date, hit);
+	if (gap === null || gap > maxGapDays) return null;
 	return {
 		date: hit,
 		price: days[hit]
 	};
 }
 /** One real fill, enriched for the trace view. */
-function enrichTrade(trade, byTicker, decByKey, books) {
+function enrichTrade(trade, byTicker, decByTicker, books) {
 	const out = {
 		...trade,
 		holdPnl: null,
@@ -205,29 +274,28 @@ function enrichTrade(trade, byTicker, decByKey, books) {
 	};
 	const t1 = futureClose(byTicker, trade.ticker, trade.date, 1);
 	if (t1 !== null && trade.price != null) {
-		const delta = (t1.price - trade.price) / trade.price * 100;
+		const delta = Math.round((t1.price - trade.price) / trade.price * 100 * 100) / 100;
 		out.t1 = {
 			date: t1.date,
 			price: Math.round(t1.price * 100) / 100,
-			delta: Math.round(delta * 100) / 100,
-			verdict: trade.action === "sell" ? delta > 1 ? "卖飞" : delta < -1 ? "卖对" : "持平" : delta > 0 ? "涨" : "跌"
+			delta,
+			verdict: t1VerdictOf(trade.action, delta),
+			tone: t1ToneOf(trade.action, delta)
 		};
 	}
-	const prefix = trade.ticker + ":";
 	let best = null;
-	let bestDiff = 99;
-	for (const [k, rows] of Object.entries(decByKey)) {
-		if (!k.startsWith(prefix)) continue;
-		const dt = k.slice(prefix.length);
-		const diff = Math.abs((dayNum(dt) ?? 0) - (dayNum(trade.date) ?? 0));
+	let bestDiff = Number.POSITIVE_INFINITY;
+	for (const row of decByTicker[trade.ticker] ?? []) {
+		const gap = dayGap(row.date, trade.date);
+		if (gap === null) continue;
+		const diff = Math.abs(gap);
 		if (diff <= 3 && diff < bestDiff) {
-			best = rows[rows.length - 1] ?? null;
+			best = row.entry;
 			bestDiff = diff;
 		}
 	}
 	if (best !== null && typeof best === "object" && !Array.isArray(best)) {
 		const b = best;
-		b["subject"];
 		const mind = b["mind"] ?? {};
 		const emotion = b["emotion"] ?? {};
 		const size = b["size"] ?? {};
@@ -269,7 +337,7 @@ function enrichTrade(trade, byTicker, decByKey, books) {
 *          published one in portfolio.json market_context (else null).
 */
 function readTraces(workspace) {
-	const { books, trades, lastUpdated } = readPortfolio(workspace);
+	const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace);
 	const byTicker = readSnapshotPrices(workspace);
 	const decByKey = {};
 	const { entries } = readLedger(workspace);
@@ -283,15 +351,23 @@ function readTraces(workspace) {
 		decByKey[tk + ":" + dt] ??= [];
 		decByKey[tk + ":" + dt].push(e);
 	}
-	const enriched = trades.map((t) => enrichTrade(t, byTicker, decByKey, books));
-	const doc = readJson(join(workspace, "portfolio.json"));
-	const marketContext = doc !== null && typeof doc === "object" && !Array.isArray(doc) ? doc["market_context"] ?? {} : {};
+	const decByTicker = {};
+	for (const [key, rows] of Object.entries(decByKey)) {
+		const sep = key.lastIndexOf(":");
+		const ticker = key.slice(0, sep);
+		const entry = rows[rows.length - 1];
+		if (entry === void 0) continue;
+		(decByTicker[ticker] ??= []).push({
+			date: key.slice(sep + 1),
+			entry
+		});
+	}
 	return {
-		trades: enriched,
+		trades: trades.map((t) => enrichTrade(t, byTicker, decByTicker, books)),
 		rate: typeof marketContext["usdhk_rate"] === "number" ? marketContext["usdhk_rate"] : null,
 		rateSource: typeof marketContext["usdhk_source"] === "string" ? marketContext["usdhk_source"] : null,
 		lastUpdated
 	};
 }
 //#endregion
-export { readLedger, readPlans, readPortfolio, readSnapshotPrices, readTraces };
+export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, readLedger, readPlans, readPortfolio, readSnapshotPrices, readTraces, t1ToneOf, t1VerdictOf };

--- a/examples/dsh/plugin/lib/typert.host.js
+++ b/examples/dsh/plugin/lib/typert.host.js
@@ -75,6 +75,7 @@ const clawock_dsh_clawockStudio_traces_result$schema = z.object({
   'price': z.number(),
   'delta': z.number(),
   'verdict': z.string(),
+  'tone': z.union([z.literal("win"), z.literal("loss"), z.literal("flat")]),
 })]),
   'decision': z.union([z.literal(null), z.object({
   'planDate': z.union([z.literal(null), z.string()]),

--- a/examples/dsh/plugin/lib/typert.remote-client.js
+++ b/examples/dsh/plugin/lib/typert.remote-client.js
@@ -75,6 +75,7 @@ const clawock_dsh_clawockStudio_traces_result$schema = z.object({
   'price': z.number(),
   'delta': z.number(),
   'verdict': z.string(),
+  'tone': z.union([z.literal("win"), z.literal("loss"), z.literal("flat")]),
 })]),
   'decision': z.union([z.literal(null), z.object({
   'planDate': z.union([z.literal(null), z.string()]),

--- a/examples/dsh/plugin/package.json
+++ b/examples/dsh/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Mind conversation-view tab",
   "license": "MIT",
   "keywords": [

--- a/examples/dsh/plugin/src/client.ts
+++ b/examples/dsh/plugin/src/client.ts
@@ -201,10 +201,16 @@ function esc(s: unknown): string { return String(s == null ? '' : s).replace(/</
  * the node, and to paint a buy at exactly 0% green while the text read 跌.
  */
 export function t1NodeClass(tone: 'win' | 'loss' | 'flat'): string {
-  return tone === 'flat' ? '' : tone
+  return tone === 'win' || tone === 'loss' ? tone : ''
 }
 export function t1ChipClass(tone: 'win' | 'loss' | 'flat'): 'up' | 'down' | 'flat' {
-  return tone === 'flat' ? 'flat' : (tone === 'win' ? 'up' : 'down')
+  // Anything other than the two known verdicts falls back to neutral, never
+  // to 'down'. A trace that somehow arrives without a tone is a bug, and the
+  // honest way to render a bug is grey — not a confident red verdict on a
+  // fill that was never judged.
+  if (tone === 'win') return 'up'
+  if (tone === 'loss') return 'down'
+  return 'flat'
 }
 
 function fmtMoney(v: number | null | undefined): string {

--- a/examples/dsh/plugin/src/client.ts
+++ b/examples/dsh/plugin/src/client.ts
@@ -192,21 +192,19 @@ const EMO: Record<string, string> = { fomo: '追高冲动', revenge: '报复性'
 
 function esc(s: unknown): string { return String(s == null ? '' : s).replace(/</g, '&lt;') }
 
-/** T+1 tone is action-aware: a rising price is good for the buyer and bad
- *  for the seller (卖飞). One sign rule for both would color buy gains red
- *  and buy losses green. */
-export function t1Tone(action: string, delta: number): 'win' | 'loss' {
-  const up = delta >= 0
-  const sell = action === 'sell' || action === 'cut' || action === 'trim' || action === 'trim_on_rebound'
-  if (sell) return up ? 'loss' : 'win'
-  return up ? 'win' : 'loss'
+/**
+ * The T+1 tone is decided host-side (`t1ToneOf` in ledger.ts) and shipped on
+ * the trace as `t1.tone`. These two helpers only map that single reading onto
+ * the two CSS vocabularies used here — the trace node's win/loss and the
+ * chip's up/down. They deliberately take no thresholds: three independent
+ * dead zones used to colour the same fill grey-"持平" in the chip and red in
+ * the node, and to paint a buy at exactly 0% green while the text read 跌.
+ */
+export function t1NodeClass(tone: 'win' | 'loss' | 'flat'): string {
+  return tone === 'flat' ? '' : tone
 }
-export function t1ChipTone(action: string, delta: number): 'up' | 'down' | 'flat' {
-  if (delta > -1 && delta < 1) return 'flat'
-  const up = delta >= 1
-  const sell = action === 'sell' || action === 'cut' || action === 'trim' || action === 'trim_on_rebound'
-  if (sell) return up ? 'down' : 'up'
-  return up ? 'up' : 'down'
+export function t1ChipClass(tone: 'win' | 'loss' | 'flat'): 'up' | 'down' | 'flat' {
+  return tone === 'flat' ? 'flat' : (tone === 'win' ? 'up' : 'down')
 }
 
 function fmtMoney(v: number | null | undefined): string {
@@ -245,7 +243,7 @@ function TraceDetail(props: any) {
   const d = t.decision
   const sym = t.currency === 'HKD' ? 'HK$' : '$'
   if (!d) {
-    const t1miss = t.t1 ? h('div', { className: 'tnode ' + t1Tone(t.action, t.t1.delta) },
+    const t1miss = t.t1 ? h('div', { className: ('tnode ' + t1NodeClass(t.t1.tone)).trim() },
       h('div', { className: 'n' }, 'T+1 结果'),
       h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%')) : null
     return h('div', null,
@@ -270,7 +268,7 @@ function TraceDetail(props: any) {
   if (d.condition) chips.push(h('span', { className: 'pc', key: 'c' }, '条件: ' + d.condition))
   if (d.sizeShares) chips.push(h('span', { className: 'pc', key: 's' }, '计划 ' + d.sizeShares + ' 股'))
   if (d.plannedPrice) chips.push(h('span', { className: 'pc', key: 'p' }, '计划价 ' + d.plannedPrice))
-  const t1node = t.t1 ? h('div', { className: 'tnode ' + t1Tone(t.action, t.t1.delta) },
+  const t1node = t.t1 ? h('div', { className: ('tnode ' + t1NodeClass(t.t1.tone)).trim() },
     h('div', { className: 'tw' }, t.t1.date),
     h('div', { className: 'n' }, 'T+1 结果'),
     h('div', { className: 'v' }, (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' · ' + t.t1.verdict : ''))) : null
@@ -312,7 +310,7 @@ function TraceCell(props: any) {
   else pnl = h('span', { className: 'pnl na' }, '—')
   let t1tag: any = null
   if (t.t1) {
-    const tc = t1ChipTone(t.action, t.t1.delta)
+    const tc = t1ChipClass(t.t1.tone)
     const tlabel = 'T+1 ' + (t.t1.delta >= 0 ? '+' : '') + t.t1.delta + '%' + (t.action === 'sell' ? ' ' + t.t1.verdict : '')
     t1tag = h('span', { className: 't1 ' + tc }, tlabel)
   } else if (t.action === 'sell') {
@@ -416,6 +414,11 @@ function DecisionMind(props: DecisionMindProps) {
   const hkd = traces.filter((t: any) => t.realizedPnl != null && t.currency === 'HKD').reduce((s: number, t: any) => s + t.realizedPnl, 0)
   const fx = data.rate
   const totalUsd = usd + (fx ? hkd / fx : 0)
+  // Only fills whose T+1 close actually landed inside the T+1 window carry a
+  // `t1` at all (the host drops the rest rather than labelling a months-later
+  // close "T+1"). The denominator is rendered so the ratio can be read for
+  // what it is instead of looking like it covers every fill.
+  const t1Rated = traces.filter((t: any) => t.t1).length
   const fw = traces.filter((t: any) => t.t1 && t.t1.verdict === '卖飞').length
   const ok = traces.filter((t: any) => t.t1 && t.t1.verdict === '卖对').length
   const matched = traces.filter((t: any) => t.decision).length
@@ -493,7 +496,7 @@ function DecisionMind(props: DecisionMindProps) {
   const stats = h('div', { className: 'stats' },
     h('div', { className: 'sg' }, h('span', { className: 'sl' }, '已实现 (USD 等值)'),
       h('span', { className: 'sv focus ' + (totalUsd >= 0 ? 'up' : 'down') }, fmtMoney(totalUsd))),
-    h('div', { className: 'sg' }, h('span', { className: 'sl' }, 'T+1 卖飞/卖对'),
+    h('div', { className: 'sg' }, h('span', { className: 'sl' }, 'T+1 卖飞/卖对 · 基于 ' + t1Rated + ' 笔'),
       h('span', { className: 'sv' }, h('span', { className: 'down' }, fw), ' / ', h('span', { className: 'up' }, ok))),
     h('div', { className: 'sg' }, h('span', { className: 'sl' }, '决策挂接'), h('span', { className: 'sv' }, matched + '/' + traces.length)),
     fx ? h('span', { className: 'rate' }, traces.length + ' 笔成交 · @' + fx) : h('span', { className: 'rate' }, traces.length + ' 笔成交'))

--- a/examples/dsh/plugin/src/freshness.ts
+++ b/examples/dsh/plugin/src/freshness.ts
@@ -9,12 +9,43 @@ import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 
 /**
+ * Content signature over every snapshot file, not just the newest filename.
+ *
+ * `readSnapshotPrices` parses *all* of `memory/snapshots/`, so the signature
+ * has to cover all of it. Keying on the newest filename alone missed two real
+ * cases: an existing snapshot being recomputed and rewritten, and the current
+ * day's file being rewritten repeatedly intraday — in both the name never
+ * moves, so a cached trace view would be served indefinitely. A directory
+ * mtime was rejected for moving on unrelated churn; per-file `stat` does not
+ * have that problem. Measured 1.4ms steady-state for the current 68 files
+ * (~8ms on the first cold call), against the ~103ms readTraces it guards.
+ */
+function snapshotsSignature(ws: string): string {
+  const dir = join(ws, 'memory', 'snapshots')
+  let names: string[]
+  try {
+    names = readdirSync(dir).sort()
+  } catch {
+    return 'none'
+  }
+  if (names.length === 0) return 'none'
+  const hash = createHash('sha1')
+  for (const name of names) {
+    try {
+      const st = statSync(join(dir, name))
+      hash.update(`${name}:${st.mtimeMs}:${st.size}\n`)
+    } catch {
+      hash.update(`${name}:missing\n`)
+    }
+  }
+  return `${names.length}:${hash.digest('hex').slice(0, 16)}`
+}
+
+/**
  * Freshness signature over the three sources that feed the trace view:
- * portfolio.json (fills + notes), the newest snapshot filename (T+1 closes
- * land as NEW daily files — an mtime on the directory would also move on
- * unrelated churn), and decisions.jsonl (soft pairing). All three are
- * stat-level (µs) reads, no parsing. The enriched trace view is valid to
- * reuse iff this signature is unchanged.
+ * portfolio.json (fills + notes), every snapshot's stat (T+1 closes), and
+ * decisions.jsonl (soft pairing). All stat-level reads, no parsing. The
+ * enriched trace view is valid to reuse iff this signature is unchanged.
  */
 export function workspaceSignature(ws: string): string {
   const sig = (p: string): string => {
@@ -25,16 +56,9 @@ export function workspaceSignature(ws: string): string {
       return 'missing'
     }
   }
-  let latestSnapshot = 'none'
-  try {
-    const files = readdirSync(join(ws, 'memory', 'snapshots')).sort()
-    if (files.length > 0) latestSnapshot = files[files.length - 1]!
-  } catch {
-    /* no snapshot dir yet */
-  }
   return [
     sig(join(ws, 'portfolio.json')),
-    latestSnapshot,
+    snapshotsSignature(ws),
     sig(join(ws, 'memory', 'decisions.jsonl')),
   ].join('|')
 }

--- a/examples/dsh/plugin/src/ledger.ts
+++ b/examples/dsh/plugin/src/ledger.ts
@@ -10,8 +10,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type {
-  Book, EnrichedTrade, Holding, JsonValue, LedgerResult, PlanRow, PlansResult,
-  PortfolioResult, TraceDecision, TraceT1, TracesResult, Trade,
+  Book, DecisionRow, EnrichedTrade, Holding, JsonValue, LedgerResult, PlanRow, PlansResult,
+  PortfolioRead, TraceDecision, TraceT1, TracesResult, Trade,
 } from './types.ts'
 
 const PLAN_PATTERN = /^(\d{4}-\d{2}-\d{2})-plan\.json$/
@@ -55,10 +55,10 @@ export function readLedger(workspace: string): LedgerResult {
  * @param workspace - desk workspace root.
  * @returns `{ books, trades, lastUpdated }`.
  */
-export function readPortfolio(workspace: string): PortfolioResult {
+export function readPortfolio(workspace: string): PortfolioRead {
   const doc = readJson(join(workspace, 'portfolio.json'))
   if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
-    return { books: [], trades: [], lastUpdated: null }
+    return { books: [], trades: [], lastUpdated: null, marketContext: {} }
   }
   const books: Book[] = []
   const trades: Trade[] = []
@@ -118,7 +118,10 @@ export function readPortfolio(workspace: string): PortfolioResult {
   const lastUpdated = typeof (doc as { last_updated?: unknown })['last_updated'] === 'string'
     ? (doc as { last_updated?: unknown })['last_updated'] as string
     : null
-  return { books, trades, lastUpdated }
+  // Returned so `readTraces` does not have to read and parse portfolio.json a
+  // second time just to reach `market_context`.
+  const marketContext = ((doc as { market_context?: unknown })['market_context'] ?? {}) as { [key: string]: JsonValue }
+  return { books, trades, lastUpdated, marketContext }
 }
 
 /**
@@ -161,12 +164,70 @@ export function readPlans(workspace: string, limit = 14): PlansResult {
 
 const SNAPSHOT_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/
 
-/** Day number for window arithmetic (no Date TZ pitfalls for ISO dates). */
+/**
+ * Ordering key for ISO dates (no Date TZ pitfalls). Monotonic, so it is safe
+ * for `<`/`>` comparison and sorting — but the *difference* between two of
+ * these is NOT a day count (2026-08-31 → 2026-09-01 differs by 2, not 1).
+ * Use `dayGap` whenever a real distance is needed.
+ */
 function dayNum(iso: string | null): number | null {
   if (typeof iso !== 'string') return null
   const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
   if (!m) return null
   return Number(m[1]) * 400 + Number(m[2]) * 32 + Number(m[3])
+}
+
+/** UTC midnight epoch for an ISO date, for real calendar-day arithmetic. */
+function utcDay(iso: string | null): number | null {
+  if (typeof iso !== 'string') return null
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  if (!m) return null
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+}
+
+/** Signed calendar-day distance `to - from`; null when either side is unparseable. */
+export function dayGap(from: string | null, to: string | null): number | null {
+  const a = utcDay(from)
+  const b = utcDay(to)
+  if (a === null || b === null) return null
+  return Math.round((b - a) / 86_400_000)
+}
+
+/**
+ * How far after a fill a close may sit and still be called "T+1".
+ * A Friday fill settles against Monday (3 calendar days); one intervening
+ * public holiday makes 4. Anything beyond that is a different horizon and
+ * must not be labelled T+1 — see the snapshot-coverage note on `futureClose`.
+ */
+export const T1_MAX_GAP_DAYS = 4
+
+/**
+ * Shared dead zone for T+1 readings: a move smaller than this reads as flat
+ * for every action. Host-side single source of truth so the chip, the trace
+ * node and the verdict text can never disagree (they used to: three separate
+ * thresholds coloured the same fill two different ways).
+ */
+export const T1_FLAT_BAND_PCT = 1
+
+/** Actions that reduce a position — a rising price is bad news for these. */
+const SELL_ACTIONS = new Set(['sell', 'cut', 'trim', 'trim_on_rebound'])
+
+export function isSellAction(action: string): boolean {
+  return SELL_ACTIONS.has(action)
+}
+
+/** Good/bad/flat reading of a T+1 move, action-aware and dead-zoned. */
+export function t1ToneOf(action: string, delta: number): 'win' | 'loss' | 'flat' {
+  if (Math.abs(delta) < T1_FLAT_BAND_PCT) return 'flat'
+  const up = delta > 0
+  return isSellAction(action) ? (up ? 'loss' : 'win') : (up ? 'win' : 'loss')
+}
+
+/** Chinese verdict text for a T+1 move, on the same dead zone as `t1ToneOf`. */
+export function t1VerdictOf(action: string, delta: number): string {
+  if (Math.abs(delta) < T1_FLAT_BAND_PCT) return '持平'
+  const up = delta > 0
+  return isSellAction(action) ? (up ? '卖飞' : '卖对') : (up ? '涨' : '跌')
 }
 
 /**
@@ -208,12 +269,23 @@ export function readSnapshotPrices(workspace: string): Record<string, Record<str
   return byTicker
 }
 
-/** First close at least `n` trading days after `date` for `ticker`. */
+/**
+ * The n-th snapshot close strictly after `date` for `ticker` — but only when
+ * it actually lands inside `maxGapDays` calendar days of the fill.
+ *
+ * The snapshot series is not a trading calendar: it starts the day the desk
+ * began writing `memory/snapshots/`, and it has holes whenever the daily job
+ * missed a run. Without the gap ceiling this function happily returns "the
+ * next close we happen to own", which for fills predating the series is
+ * months later — those were being rendered under a literal "T+1" label. A
+ * horizon we cannot actually observe must read as unknown, not as a verdict.
+ */
 function futureClose(
   byTicker: Record<string, Record<string, number>>,
   ticker: string,
   date: string | null,
   n: number,
+  maxGapDays: number = T1_MAX_GAP_DAYS,
 ): { date: string; price: number } | null {
   const days = byTicker[ticker]
   if (!days) return null
@@ -222,6 +294,8 @@ function futureClose(
   const later = Object.keys(days).filter((d) => (dayNum(d) ?? 0) > base).sort()
   const hit = later[n - 1]
   if (hit === undefined) return null
+  const gap = dayGap(date, hit)
+  if (gap === null || gap > maxGapDays) return null
   return { date: hit, price: days[hit]! }
 }
 
@@ -229,39 +303,40 @@ function futureClose(
 function enrichTrade(
   trade: Trade,
   byTicker: Record<string, Record<string, number>>,
-  decByKey: Record<string, JsonValue[]>,
+  decByTicker: Record<string, DecisionRow[]>,
   books: Book[],
 ): EnrichedTrade {
   const out = { ...trade, holdPnl: null, t1: null, decision: null } as EnrichedTrade
-  // T+1 verdict: sell verdicts read "卖飞/卖对", buys read "涨/跌".
+  // T+1 reading: tone and verdict both come from the shared dead zone in
+  // `t1ToneOf`/`t1VerdictOf`, so the chip, the trace node and the text can
+  // never disagree about the same fill.
   const t1 = futureClose(byTicker, trade.ticker, trade.date, 1)
   if (t1 !== null && trade.price != null) {
-    const delta = ((t1.price - trade.price) / trade.price) * 100
+    const delta = Math.round(((t1.price - trade.price) / trade.price) * 100 * 100) / 100
     out.t1 = {
       date: t1.date,
       price: Math.round(t1.price * 100) / 100,
-      delta: Math.round(delta * 100) / 100,
-      verdict: trade.action === 'sell'
-        ? (delta > 1 ? '卖飞' : delta < -1 ? '卖对' : '持平')
-        : (delta > 0 ? '涨' : '跌'),
+      delta,
+      verdict: t1VerdictOf(trade.action, delta),
+      tone: t1ToneOf(trade.action, delta),
     } satisfies TraceT1
   }
-  // Soft-pair the decision ledger: same ticker, plan date within ±3 days.
-  const prefix = trade.ticker + ':'
+  // Soft-pair the decision ledger: same ticker, plan date within ±3 *calendar*
+  // days. Indexed by ticker so this stays O(decisions for this ticker) instead
+  // of rescanning every ledger key for every fill.
   let best: JsonValue | null = null
-  let bestDiff = 99
-  for (const [k, rows] of Object.entries(decByKey)) {
-    if (!k.startsWith(prefix)) continue
-    const dt = k.slice(prefix.length)
-    const diff = Math.abs((dayNum(dt) ?? 0) - (dayNum(trade.date) ?? 0))
+  let bestDiff = Number.POSITIVE_INFINITY
+  for (const row of decByTicker[trade.ticker] ?? []) {
+    const gap = dayGap(row.date, trade.date)
+    if (gap === null) continue
+    const diff = Math.abs(gap)
     if (diff <= 3 && diff < bestDiff) {
-      best = rows[rows.length - 1] ?? null
+      best = row.entry
       bestDiff = diff
     }
   }
   if (best !== null && typeof best === 'object' && !Array.isArray(best)) {
     const b = best as { [key: string]: unknown }
-    const subject = (b['subject'] ?? {}) as { [key: string]: unknown }
     const mind = (b['mind'] ?? {}) as { [key: string]: unknown }
     const emotion = (b['emotion'] ?? {}) as { [key: string]: unknown }
     const size = (b['size'] ?? {}) as { [key: string]: unknown }
@@ -311,7 +386,7 @@ function enrichTrade(
  *          published one in portfolio.json market_context (else null).
  */
 export function readTraces(workspace: string): Omit<TracesResult, 'workspaceKey' | 'signature'> {
-  const { books, trades, lastUpdated } = readPortfolio(workspace)
+  const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace)
   const byTicker = readSnapshotPrices(workspace)
   const decByKey: Record<string, JsonValue[]> = {}
   const { entries } = readLedger(workspace)
@@ -329,11 +404,18 @@ export function readTraces(workspace: string): Omit<TracesResult, 'workspaceKey'
     decByKey[tk + ':' + dt] ??= []
     decByKey[tk + ':' + dt]!.push(e)
   }
-  const enriched = trades.map((t) => enrichTrade(t, byTicker, decByKey, books))
-  const doc = readJson(join(workspace, 'portfolio.json'))
-  const marketContext = (doc !== null && typeof doc === 'object' && !Array.isArray(doc))
-    ? (((doc as { market_context?: unknown })['market_context'] ?? {}) as { [key: string]: unknown })
-    : {}
+  // Flatten `ticker:date` keys into a per-ticker index, keeping the previous
+  // semantics exactly: the last ledger row wins for a given ticker+date, and
+  // among equally-distant dates the earliest-seen one wins.
+  const decByTicker: Record<string, DecisionRow[]> = {}
+  for (const [key, rows] of Object.entries(decByKey)) {
+    const sep = key.lastIndexOf(':')
+    const ticker = key.slice(0, sep)
+    const entry = rows[rows.length - 1]
+    if (entry === undefined) continue
+    ;(decByTicker[ticker] ??= []).push({ date: key.slice(sep + 1), entry })
+  }
+  const enriched = trades.map((t) => enrichTrade(t, byTicker, decByTicker, books))
   const rate = typeof marketContext['usdhk_rate'] === 'number' ? marketContext['usdhk_rate'] : null
   return {
     trades: enriched,

--- a/examples/dsh/plugin/src/types.ts
+++ b/examples/dsh/plugin/src/types.ts
@@ -73,6 +73,23 @@ export interface PortfolioResult {
   lastUpdated: string | null
 }
 
+/**
+ * What `readPortfolio` actually returns: the Remote-visible `PortfolioResult`
+ * plus the raw `market_context` block, so `readTraces` can reach the FX rate
+ * without reading and parsing portfolio.json a second time. `marketContext`
+ * stays off the Remote face — the `portfolio()` method declares
+ * `PortfolioResult`, so the generated codec never puts it on the wire.
+ */
+export interface PortfolioRead extends PortfolioResult {
+  marketContext: { [key: string]: JsonValue }
+}
+
+/** One decision-ledger row indexed for soft pairing, with its plan date. */
+export interface DecisionRow {
+  date: string
+  entry: JsonValue
+}
+
 export interface PlanRow {
   date: string
   decisions: number
@@ -87,7 +104,13 @@ export interface TraceT1 {
   date: string
   price: number
   delta: number
+  /** '涨' | '跌' | '卖飞' | '卖对' | '持平' — same dead zone as `tone`. */
   verdict: string
+  /**
+   * Good/bad/flat reading, decided host-side so the chip and the trace node
+   * cannot colour the same fill differently. Renderers must not re-derive it.
+   */
+  tone: 'win' | 'loss' | 'flat'
 }
 
 export interface TraceDecision {

--- a/ops/host/install_dsh_plugin.sh
+++ b/ops/host/install_dsh_plugin.sh
@@ -74,8 +74,12 @@ const pkg = require("./package.json");
 // Import the file each export entry actually maps to. A bare path import
 // would bypass the exports map and prove nothing; these are the same modules
 // dsh loads through "./typert" and friends.
+// `./client` is the browser bundle — a window.__ModuleLoader__ closure, not
+// an ES module. Importing it here would throw "window is not defined" and say
+// nothing about the install; its registration is covered by
+// tests/decision_studio_plugin.spec.js.
 const targets = Object.entries(pkg.exports || {})
-  .filter(([name, spec]) => name !== "./package.json" && spec && spec.default)
+  .filter(([name, spec]) => name !== "./package.json" && name !== "./client" && spec && spec.default)
   .map(([name, spec]) => [name, path.resolve(spec.default)]);
 Promise.all(targets.map(([, file]) => import(pathToFileURL(file).href)))
   .then(() => console.log("  ok: " + targets.map(([n]) => n).join(", ")))

--- a/ops/host/install_dsh_plugin.sh
+++ b/ops/host/install_dsh_plugin.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# install_dsh_plugin.sh — install clawock-dsh into the live DSH web profile,
+# with its runtime dependencies, reproducibly.
+#
+# Why this exists (2026-08-17 outage): the live plugin used to be a source
+# directory hand-copied into ~/.dsh/plugins/clawock-dsh, wired into the profile
+# through a `file:` dependency. pnpm *links* a `file:` dependency instead of
+# installing it, so the plugin's own `dependencies` were never installed — the
+# directory only held five hand-made @deepseek-ai symlinks. The moment #708
+# added `zod` as a runtime dependency, dsh could no longer load the typert host
+# reflection and crash-looped 83 times (~3s of CPU every 5s on a 1.9Gi box)
+# until someone noticed. Nothing in CI or on the host could see it coming.
+#
+# The fix is not "remember to symlink the next dependency too" — it is to make
+# the install a real install. This script is that install.
+#
+# Usage:
+#   ops/host/install_dsh_plugin.sh              # from the repo checkout
+#   ops/host/install_dsh_plugin.sh --restart    # and restart dsh afterwards
+#
+# It is idempotent: run it after every change to examples/dsh/plugin.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="$ROOT/examples/dsh/plugin"
+DEST="${DSH_PLUGIN_DIR:-$HOME/.dsh/plugins/clawock-dsh}"
+SKILLS="${DSH_SKILLS_DIR:-$HOME/.dsh/skills}"
+restart=0
+[ "${1:-}" = "--restart" ] && restart=1
+
+test -f "$SRC/package.json" || { echo "no plugin at $SRC" >&2; exit 1; }
+
+# The generated lib/ artifacts are committed, so a checkout is installable as
+# is. Verify rather than assume: shipping a stale or partial lib/ is exactly
+# how the last two live incidents started.
+for f in lib/index.js lib/client.js lib/typert.host.js lib/typert.remote-client.js; do
+  test -f "$SRC/$f" || { echo "missing build artifact $f — run 'npm run build' in $SRC" >&2; exit 1; }
+done
+
+echo "installing clawock-dsh -> $DEST"
+mkdir -p "$DEST"
+# Mirror the package's declared `files` set, deleting anything the package no
+# longer ships. node_modules is excluded from the delete so the dependency
+# install below is incremental rather than a full refetch every time.
+rsync -a --delete --exclude node_modules --exclude '*.bak-*' \
+  --include 'skills/***' \
+  --include 'lib/***' \
+  --include 'cordis.patch.yml' \
+  --include 'package.json' \
+  --include 'README.md' \
+  --exclude '*' \
+  "$SRC/" "$DEST/"
+
+# The whole point: install the plugin's own runtime dependencies where Node
+# will actually resolve them — inside the plugin directory, because Node walks
+# up from the realpath of lib/*.js and never sees the profile's node_modules.
+( cd "$DEST" && npm install --omit=dev --no-audit --no-fund --silent )
+
+# rc.6 skill discovery does not scan node_modules; skills are picked up from
+# ~/.dsh/skills only (see the dsh-plugin-skill-discovery note).
+if [ -d "$SRC/skills" ]; then
+  mkdir -p "$SKILLS"
+  cp -r "$SRC/skills/." "$SKILLS/"
+fi
+
+# Prove the install can actually be loaded before handing it to dsh. Every
+# export entry gets imported, so a missing runtime dependency fails here —
+# loudly, in a script someone is watching — instead of in a restart loop.
+echo "verifying export entries resolve"
+( cd "$DEST" && node -e '
+const { pathToFileURL } = require("node:url");
+const path = require("node:path");
+const pkg = require("./package.json");
+// Import the file each export entry actually maps to. A bare path import
+// would bypass the exports map and prove nothing; these are the same modules
+// dsh loads through "./typert" and friends.
+const targets = Object.entries(pkg.exports || {})
+  .filter(([name, spec]) => name !== "./package.json" && spec && spec.default)
+  .map(([name, spec]) => [name, path.resolve(spec.default)]);
+Promise.all(targets.map(([, file]) => import(pathToFileURL(file).href)))
+  .then(() => console.log("  ok: " + targets.map(([n]) => n).join(", ")))
+  .catch((err) => { console.error("  FAILED: " + err.message); process.exit(1); });
+' )
+
+if [ "$restart" = 1 ]; then
+  systemctl restart dsh
+  sleep 8
+  systemctl is-active --quiet dsh || { echo "dsh did not come back up" >&2; journalctl -u dsh -n 30 --no-pager >&2; exit 1; }
+  echo "dsh restarted and active"
+fi
+echo "done"

--- a/tests/bench/measure_tab_switch.py
+++ b/tests/bench/measure_tab_switch.py
@@ -27,7 +27,11 @@ import sys
 from playwright.sync_api import sync_playwright
 
 URL = sys.argv[1] if len(sys.argv) > 1 else 'http://127.0.0.1:3081/'
-SESSION = sys.argv[2] if len(sys.argv) > 2 else 'hi1h'
+# A session is picked positionally, not by title. Pinning a name here meant
+# pinning "hi1h" — the sidebar renders title + relative age, so the string rots
+# within the hour and the benchmark the baseline tells you to re-run with just
+# times out. Pass an explicit substring only when you need a specific session.
+SESSION = sys.argv[2] if len(sys.argv) > 2 else None
 ROUNDS = max(1, int(sys.argv[3])) if len(sys.argv) > 3 else 5
 CHROMIUM = os.path.expanduser('~/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome')
 
@@ -36,7 +40,12 @@ with sync_playwright() as p:
     page = browser.new_page(viewport={'width': 1440, 'height': 1100})
     page.goto(URL, wait_until='domcontentloaded', timeout=30000)
     page.wait_for_timeout(2500)
-    page.locator('[class*=sessionRow]', has_text=SESSION).first.click()
+    rows = page.locator('[class*=sessionRow]')
+    if SESSION:
+        rows = rows.filter(has_text=SESSION)
+    if rows.count() == 0:
+        raise SystemExit('no session rows in the sidebar — is dsh serving %s ?' % URL)
+    rows.first.click()
     page.wait_for_timeout(3500)
 
     page.evaluate("""() => {

--- a/tests/bench/perf-baseline.json
+++ b/tests/bench/perf-baseline.json
@@ -21,5 +21,13 @@
     "cellsAfterMount": 6,
     "note": "每次切到 DM 都有 1 次 loading 帧(mount 即重新 remote 拉取)。Phase 1/2 目标:loadingFrames 恒 0(缓存命中同步渲染)、switchToCellMs 显著下降、0 longtask。测量脚本:tests/bench/measure_tab_switch.py"
   },
+  "browserAfterFix": {
+    "measuredBuild": "0.1.6 构建产物(Phase 1/2/3:官方 store + host 缓存 + 三源 stat + 按日折叠 + TS/typert 管线)同步 live 副本 + dsh 重启后",
+    "switchToCellMs": { "cold": 939.6, "warm": { "avg": 112.9, "samples": [126.3, 113.6, 111.3, 100.2] } },
+    "longtaskOver100ms": { "cold": [316, 70, 280], "warm": [] },
+    "loadingFrames": { "cold": 0, "warm": 0 },
+    "cellsAfterMount": 6,
+    "note": "warm(每次切 tab 的真实高频路径)从 avg 206ms → 113ms 且 loading 帧恒 0(缓存命中同步渲染)。cold 从 385ms → 940ms:zod codec 打进 client bundle(生成器产物的依赖)导致一次性解析成本,只在页面加载后第一次切 tab 发生;是否接受由发布审计裁决。"
+  },
   "note": "数据规模随时间增长,对比前先用 tests/bench/read_traces.mjs / measure_tab_switch.py 重测。"
 }

--- a/tests/bench/perf-baseline.json
+++ b/tests/bench/perf-baseline.json
@@ -8,26 +8,76 @@
     "snapshotBytes": 3724176
   },
   "node": {
-    "readTracesTotalMs": { "avg": 103.2, "min": 85.3, "max": 138.8 },
-    "snapshotScanMs": { "avg": 66.1, "min": 56.0, "max": 74.6 },
+    "readTracesTotalMs": {
+      "avg": 103.2,
+      "min": 85.3,
+      "max": 138.8
+    },
+    "snapshotScanMs": {
+      "avg": 66.1,
+      "min": 56.0,
+      "max": 74.6
+    },
     "serializedBytes": 46528,
     "note": "每次切到 Decision Mind tab,host 都走一遍 readTraces;快照扫描占约 64%。Phase 1 host 侧缓存命中后应降至 ~0。"
   },
   "browser": {
     "measuredBuild": "#707 版 client.js(默认折叠 3 组)同步到 live 副本 + dsh 重启后",
-    "switchToCellMs": { "cold": 384.7, "warm": { "avg": 206.4, "samples": [183.6, 183.7, 317.4, 173.5] } },
-    "longtaskOver100ms": { "cold": [147], "warm": [] },
-    "loadingFrames": { "cold": 1, "warm": 1 },
+    "switchToCellMs": {
+      "cold": 384.7,
+      "warm": {
+        "avg": 206.4,
+        "samples": [
+          183.6,
+          183.7,
+          317.4,
+          173.5
+        ]
+      }
+    },
+    "longtaskOver100ms": {
+      "cold": [
+        147
+      ],
+      "warm": []
+    },
+    "loadingFrames": {
+      "cold": 1,
+      "warm": 1
+    },
     "cellsAfterMount": 6,
     "note": "每次切到 DM 都有 1 次 loading 帧(mount 即重新 remote 拉取)。Phase 1/2 目标:loadingFrames 恒 0(缓存命中同步渲染)、switchToCellMs 显著下降、0 longtask。测量脚本:tests/bench/measure_tab_switch.py"
   },
   "browserAfterFix": {
-    "measuredBuild": "0.1.6 构建产物(Phase 1/2/3:官方 store + host 缓存 + 三源 stat + 按日折叠 + TS/typert 管线)同步 live 副本 + dsh 重启后",
-    "switchToCellMs": { "cold": 939.6, "warm": { "avg": 112.9, "samples": [126.3, 113.6, 111.3, 100.2] } },
-    "longtaskOver100ms": { "cold": [316, 70, 280], "warm": [] },
-    "loadingFrames": { "cold": 0, "warm": 0 },
+    "measuredBuild": "0.1.6 构建产物(Phase 1/2/3 + #710/#711/#713/#715 修复)装进 live 后,3 轮取值",
+    "switchToCellMs": {
+      "cold": {
+        "avg": 256.0,
+        "samples": [
+          274,
+          256,
+          238
+        ]
+      },
+      "warm": {
+        "avg": 142.7,
+        "samples": [
+          135,
+          155,
+          138
+        ]
+      }
+    },
+    "longtaskOver100ms": {
+      "cold": [],
+      "warm": []
+    },
+    "loadingFrames": {
+      "cold": 0,
+      "warm": 0
+    },
     "cellsAfterMount": 6,
-    "note": "warm(每次切 tab 的真实高频路径)从 avg 206ms → 113ms 且 loading 帧恒 0(缓存命中同步渲染)。cold 从 385ms → 940ms:zod codec 打进 client bundle(生成器产物的依赖)导致一次性解析成本,只在页面加载后第一次切 tab 发生;是否接受由发布审计裁决。"
+    "note": "warm(切 tab 的高频路径)206ms → 143ms,loading 帧恒 0(host 缓存命中同步渲染);cold 385ms → 256ms 也是改善。\n此处早前记过一版 cold=939.6ms / longtasks=[316,70,280] 并据此写了「zod codec 打进 client bundle 导致回归、是否接受由发布审计裁决」——那次测量是在 dsh 因缺 zod 崩溃重启(83 次、每 5s 烧 3s CPU)期间做的,数字是主机争抢的产物不是代码的。settled 主机上 3 轮复测全部落在 238-274ms,无 >100ms longtask。教训与 vps-load-invalidates-perf-measurements 同族:测性能前先确认 load 是干净的。"
   },
-  "note": "数据规模随时间增长,对比前先用 tests/bench/read_traces.mjs / measure_tab_switch.py 重测。"
+  "note": "数据规模随时间增长,对比前先用 tests/bench/read_traces.mjs / measure_tab_switch.py 重测,并先确认主机 load 已经落下来。"
 }

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -296,7 +296,7 @@ test("client: _displayEntry projects a trace with its decision and T+1", async (
   const withDec = api._displayEntry({
     ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13",
     action: "sell", shares: 5, price: 50, realizedPnl: 45.21, note: "清仓",
-    t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对" },
+    t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对", tone: "win" },
     decision: { planDate: "2026-08-10", action: "trim_on_rebound", confidence: 0.6,
       drivenBy: "technical", rationale: "浮盈保护", execution: "followed",
       condition: "反弹至 50 减仓" },
@@ -336,10 +336,10 @@ test("client: renders the single decision-trace view from the mounted remote", a
           sizeShares: 200, plannedPrice: 9.21 } },
       { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-07", action: "buy",
         shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)",
-        t1: { date: "2026-08-10", price: 5.6, delta: -4.76, verdict: "跌" } },
+        t1: { date: "2026-08-10", price: 5.6, delta: -4.76, verdict: "跌", tone: "loss" } },
       { ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13", action: "sell",
         shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓",
-        t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对" },
+        t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对", tone: "win" },
         decision: { planDate: "2026-08-10", action: "trim_on_rebound", confidence: 0.6,
           drivenBy: "technical", rationale: "浮盈保护", execution: "followed",
           condition: "反弹至 50 减仓" } },
@@ -385,6 +385,26 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined, /决策轨迹/);
   assert.match(joined, /已实现 \(USD 等值\)/);
   assert.match(joined, /T\+1 卖飞\/卖对/);
+  // The denominator must be rendered, not implied (#710): the ratio only
+  // covers fills whose close actually landed inside the T+1 window.
+  assert.match(joined, /基于 \d+ 笔/, "the T+1 scorecard must show what it is computed over");
+
+  // The chip class must come from the host's `tone`, not from a threshold the
+  // client re-derives (#713). Walk the tree for the real className so a
+  // fixture that drops `tone` cannot keep this test green.
+  const classes = [];
+  (function walkClass(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walkClass); return; }
+    if (typeof node === "string") return;
+    const cn = node.props && node.props.className;
+    if (typeof cn === "string") classes.push(cn);
+    (node.children || []).forEach(walkClass);
+  })(tree);
+  assert.ok(classes.includes("t1 win") || classes.includes("t1 up"),
+    `a tone:"win" trace must render an up/win chip, got: ${classes.filter((c) => c.startsWith("t1")).join(", ")}`);
+  assert.ok(!classes.some((c) => /undefined|null/.test(c)),
+    `no className may contain undefined — a fixture missing t1.tone would show up here: ${classes.filter((c) => /undefined|null/.test(c)).join(", ")}`);
   assert.match(joined, /SPCH/);
   assert.match(joined, /买入/);
   assert.match(joined, /10 @8.77/);

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -437,31 +437,58 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined2, /盈亏/);
 });
 
-test("client: T+1 tone is action-aware — buy gains are win, sell misses are loss (#665)", async () => {
+test("T+1 reading: one host-side dead zone drives chip, node and verdict (#665/#713)", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
   const loaded = await loadClient();
   const api = loaded.factory((s) => {
     if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
     if (s === "react") return makeReactStub();
     throw new Error(`unexpected require: ${s}`);
   });
-  const t1Tone = api.t1Tone;
-  assert.ok(t1Tone, "t1Tone exported for the spec");
-  // buy: price up = win (green), price down = loss (red)
-  assert.equal(t1Tone("buy", 5.0), "win");
-  assert.equal(t1Tone("buy", -4.76), "loss");
-  assert.equal(t1Tone("add", 0.5), "win");
-  // sell family: price up after selling = 卖飞 (loss), down = 卖对 (win)
-  assert.equal(t1Tone("sell", 5.0), "loss");
-  assert.equal(t1Tone("sell", -1.52), "win");
-  assert.equal(t1Tone("cut", 2.0), "loss");
-  assert.equal(t1Tone("trim_on_rebound", -2.0), "win");
-  // chip tone: |delta|<1 is flat; direction flips with action
-  assert.equal(api.t1ChipTone("buy", 0.3), "flat");
-  assert.equal(api.t1ChipTone("sell", 0.3), "flat");
-  assert.equal(api.t1ChipTone("buy", 4.0), "up");
-  assert.equal(api.t1ChipTone("buy", -4.0), "down");
-  assert.equal(api.t1ChipTone("sell", 4.0), "down");
-  assert.equal(api.t1ChipTone("sell", -4.0), "up");
+  const { t1ToneOf, t1VerdictOf } = ledger;
+
+  // Direction stays action-aware (#665): a rise is good for the buyer, bad
+  // for anyone who just sold.
+  assert.equal(t1ToneOf("buy", 5.0), "win");
+  assert.equal(t1ToneOf("buy", -4.76), "loss");
+  assert.equal(t1ToneOf("sell", 5.0), "loss");
+  assert.equal(t1ToneOf("sell", -1.52), "win");
+  assert.equal(t1ToneOf("cut", 2.0), "loss");
+  assert.equal(t1ToneOf("trim_on_rebound", -2.0), "win");
+
+  // #713: the dead zone is now ONE band, applied to every action and to the
+  // verdict text as well. These two cases are the ones that used to disagree.
+  //  - sell at +0.5%: chip said flat/"持平" while the trace node was painted red
+  //  - buy at exactly 0%: verdict said 跌 while the node was painted green
+  assert.equal(t1ToneOf("sell", 0.5), "flat");
+  assert.equal(t1VerdictOf("sell", 0.5), "持平");
+  assert.equal(t1ToneOf("buy", 0.5), "flat");
+  assert.equal(t1VerdictOf("buy", 0.5), "持平");
+  assert.equal(t1ToneOf("buy", 0), "flat");
+  assert.equal(t1VerdictOf("buy", 0), "持平");
+  assert.equal(t1ToneOf("add", 0.5), "flat");
+
+  // Outside the band the verdict text and the tone agree by construction.
+  for (const [action, delta, tone, verdict] of [
+    ["buy", 4.0, "win", "涨"],
+    ["buy", -4.0, "loss", "跌"],
+    ["sell", 4.0, "loss", "卖飞"],
+    ["sell", -4.0, "win", "卖对"],
+  ]) {
+    assert.equal(t1ToneOf(action, delta), tone, `${action} ${delta} tone`);
+    assert.equal(t1VerdictOf(action, delta), verdict, `${action} ${delta} verdict`);
+  }
+
+  // The client only maps that single reading onto its two CSS vocabularies —
+  // it must not re-derive a threshold of its own.
+  assert.equal(api.t1NodeClass("win"), "win");
+  assert.equal(api.t1NodeClass("loss"), "loss");
+  assert.equal(api.t1NodeClass("flat"), "");
+  assert.equal(api.t1ChipClass("win"), "up");
+  assert.equal(api.t1ChipClass("loss"), "down");
+  assert.equal(api.t1ChipClass("flat"), "flat");
+  assert.equal(api.t1Tone, undefined, "the client-side threshold helper must be gone (#713)");
+  assert.equal(api.t1ChipTone, undefined, "the client-side chip threshold helper must be gone (#713)");
 });
 
 test("client: trace list batches older days behind 'show earlier' and folds by day", async () => {
@@ -602,6 +629,62 @@ test("client: stylesheet keeps the dark-theme and tone contract (#704/#685 regre
   assert.match(injectedStyleText, /\.dmt \.skel/, "cold-start skeleton block required");
 });
 
+test("readTraces: a close outside the T+1 window is not a T+1 verdict (#710)", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-t1-"));
+  const snaps = path.join(root, "memory", "snapshots");
+  fs.mkdirSync(snaps, { recursive: true });
+  const desk = (tradeDate) => fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({
+    portfolios: { hk_stocks: { currency: "HKD", holdings: [
+      { ticker: "00700", shares: 10, current_price: 100,
+        trades: [{ date: tradeDate, action: "buy", shares: 10, price: 100 }] },
+    ] } },
+  }));
+  const snapshot = (date, price) => fs.writeFileSync(
+    path.join(snaps, `${date}.json`),
+    JSON.stringify({ portfolios: { hk: { holdings: [{ ticker: "00700", current_price: price }] } } }),
+  );
+  const t1Of = () => ledger.readTraces(root).trades[0].t1;
+  try {
+    // Next calendar day — the plain T+1 case.
+    desk("2026-08-10");
+    snapshot("2026-08-11", 110);
+    assert.ok(t1Of(), "an adjacent close is a T+1 verdict");
+    assert.equal(t1Of().delta, 10);
+
+    // Friday fill settling against Monday: 3 days, still T+1.
+    fs.rmSync(path.join(snaps, "2026-08-11.json"));
+    desk("2026-08-07");
+    snapshot("2026-08-10", 110);
+    assert.ok(t1Of(), "a weekend gap is still T+1 (Fri fill → Mon close)");
+
+    // The regression this guards: the only close we own is months later. It
+    // used to be returned and rendered under a literal "T+1" label — on live
+    // data that reached +144 days for fills predating the snapshot series.
+    fs.rmSync(path.join(snaps, "2026-08-10.json"));
+    desk("2026-03-02");
+    snapshot("2026-08-10", 110);
+    assert.equal(t1Of(), null, "a close +161 days out must not be a T+1 verdict (#710)");
+
+    // And the boundary itself: 4 days in, 5 days out.
+    fs.rmSync(path.join(snaps, "2026-08-10.json"));
+    desk("2026-08-10");
+    snapshot("2026-08-14", 110);
+    assert.ok(t1Of(), "4 calendar days is inside the window");
+    fs.rmSync(path.join(snaps, "2026-08-14.json"));
+    snapshot("2026-08-15", 110);
+    assert.equal(t1Of(), null, "5 calendar days is outside the window");
+
+    // dayGap must be real calendar arithmetic, not the ordering key: the
+    // ordering key puts 2026-08-31 → 2026-09-01 two "days" apart.
+    assert.equal(ledger.dayGap("2026-08-31", "2026-09-01"), 1);
+    assert.equal(ledger.dayGap("2026-07-28", "2026-08-01"), 4);
+    assert.equal(ledger.dayGap("2026-12-31", "2027-01-01"), 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("freshness: signature moves on each of the three data sources", async () => {
   const freshness = await import(pathToFileURL(path.join(PLUGIN, "lib", "freshness.js")).href);
   const root = makeDesk();
@@ -610,7 +693,7 @@ test("freshness: signature moves on each of the three data sources", async () =>
     const before = freshness.workspaceSignature(root);
     assert.ok(before.length > 0);
     assert.equal(before.split("|").length, 3, "shape: portfolio stat | latest snapshot | decisions stat");
-    assert.equal(before.split("|")[1], "none", "no snapshots yet → latest snapshot is 'none'");
+    assert.equal(before.split("|")[1], "none", "no snapshots yet → the snapshot term is 'none'");
 
     // portfolio.json 变化 → 签名变(内容长度不同,size 兜底 mtime 同刻度)
     fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({ last_updated: "changed" }));
@@ -621,6 +704,17 @@ test("freshness: signature moves on each of the three data sources", async () =>
     fs.writeFileSync(path.join(root, "memory", "snapshots", "2026-08-17.json"), "{}");
     const afterSnapshot = freshness.workspaceSignature(root);
     assert.notEqual(afterSnapshot, afterPortfolio, "a NEW snapshot file must move the signature");
+
+    // #711:改写一个【已存在】的快照(文件名不变)也必须让签名变——
+    // readSnapshotPrices 会解析每一个快照,所以签名必须覆盖全部内容而不是
+    // 只看最新文件名。这一条在「只取最新文件名」的旧实现下是红的。
+    const snapPath = path.join(root, "memory", "snapshots", "2026-08-17.json");
+    const beforeRewrite = freshness.workspaceSignature(root);
+    fs.writeFileSync(snapPath, JSON.stringify({ portfolios: { hk: { holdings: [{ ticker: "00700", current_price: 999 }] } } }));
+    assert.notEqual(
+      freshness.workspaceSignature(root), beforeRewrite,
+      "rewriting an EXISTING snapshot must move the signature (#711)",
+    );
 
     // decisions.jsonl 变化(软配对源)→ 签名变
     fs.writeFileSync(path.join(root, "memory", "decisions.jsonl"), JSON.stringify({ decision_id: "x" }) + "\n");

--- a/tests/dsh_plugin_package_contract.mjs
+++ b/tests/dsh_plugin_package_contract.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * clawock-dsh package contract: the packed tarball, installed on its own,
+ * must actually load.
+ *
+ * Run: node tests/dsh_plugin_package_contract.mjs
+ * CI:  harness-regression.yml runs it when plugin files change.
+ *
+ * Why this gate exists (2026-08-17): #708 added `zod` as a runtime dependency
+ * of the generated typert host reflection. Every existing check stayed green —
+ * the plugin spec imports lib/ modules straight out of the repo checkout,
+ * where the repo's own node_modules happens to satisfy everything — and dsh
+ * then crash-looped 83 times in production because the deployed plugin
+ * directory had no zod. The class of failure the old gates could not see was
+ * "declared dependency that nothing installs".
+ *
+ * So this test refuses to look at the checkout. It packs the package the way
+ * npm would publish it, installs that tarball into an empty directory with
+ * only its declared production dependencies, and imports every export entry.
+ * A dependency that is imported but not declared fails here.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const HERE = fileURLToPath(new URL('.', import.meta.url))
+const PLUGIN = resolve(HERE, '..', 'examples', 'dsh', 'plugin')
+
+const run = (cmd, args, cwd) =>
+  execFileSync(cmd, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+
+test('packed clawock-dsh installs standalone and every export entry imports', async (t) => {
+  const pkg = JSON.parse(readFileSync(join(PLUGIN, 'package.json'), 'utf8'))
+  const work = mkdtempSync(join(tmpdir(), 'clawock-dsh-pkg-'))
+  try {
+    // 1. Pack exactly what would be published.
+    const packed = run('npm', ['pack', '--pack-destination', work, '--silent'], PLUGIN).trim().split('\n').pop()
+    const tarball = join(work, packed)
+    assert.ok(existsSync(tarball), `npm pack produced ${packed}`)
+
+    // 2. Install it into an empty project — nothing from the repo checkout is
+    //    reachable from here, which is the whole point.
+    const proj = join(work, 'proj')
+    run('mkdir', ['-p', proj])
+    writeFileSync(join(proj, 'package.json'), JSON.stringify({ name: 'contract', private: true, type: 'module' }))
+    run('npm', ['install', '--omit=dev', '--no-audit', '--no-fund', '--silent', tarball], proj)
+
+    const installed = join(proj, 'node_modules', 'clawock-dsh')
+    assert.ok(existsSync(installed), 'clawock-dsh installed into the empty project')
+
+    // 3. The package must ship the skill body — rc.6 skill discovery reads it
+    //    from the installed package, so a missing file is a silent no-op.
+    assert.ok(
+      existsSync(join(installed, 'skills', 'investment-decision', 'SKILL.md')),
+      'the published package ships skills/investment-decision/SKILL.md',
+    )
+
+    // 4. Import every export entry. This is what dsh's typert-loader does, and
+    //    it is where a declared-but-uninstalled (or undeclared) dependency dies.
+    const entries = Object.entries(pkg.exports || {})
+      .filter(([name, spec]) => name !== './package.json' && spec && spec.default)
+    assert.ok(entries.length >= 3, 'the package exposes its host/client/remote entries')
+    for (const [name, spec] of entries) {
+      const file = join(installed, spec.default)
+      assert.ok(existsSync(file), `${name} -> ${spec.default} exists in the tarball`)
+      // The browser bundle is a window.__ModuleLoader__ closure, not an ES
+      // module — importing it outside a DOM proves nothing and throws. Its
+      // registration is covered by decision_studio_plugin.spec.js instead.
+      if (name === './client') continue
+      await t.test(`import ${name}`, async () => {
+        await import(pathToFileURL(file).href)
+      })
+    }
+
+    // 5. Every runtime dependency the shipped code imports must be declared.
+    //    (The import above would already fail, but this names the offender.)
+    const declared = new Set([
+      ...Object.keys(pkg.dependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {}),
+    ])
+    const libDir = join(installed, 'lib')
+    const bare = new Set()
+    for (const file of readdirSync(libDir).filter((f) => f.endsWith('.js'))) {
+      const src = readFileSync(join(libDir, file), 'utf8')
+      for (const m of src.matchAll(/\bfrom\s+["']([^."'][^"']*)["']/g)) {
+        const id = m[1]
+        if (id.startsWith('node:')) continue
+        bare.add(id.startsWith('@') ? id.split('/').slice(0, 2).join('/') : id.split('/')[0])
+      }
+    }
+    for (const id of bare) {
+      assert.ok(declared.has(id), `lib/ imports "${id}" — it must be a declared dependency`)
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
0.1.6 发布准备 + 2026-08-17 dsh 审计发现的一批修复。

## 背景

审计 live dsh 时先撞上一起正在进行的事故:`dsh.service` 崩溃重启 **83 次**,每 5 秒起一个 node 烧约 3s CPU,在这台 1.9Gi 的机器上把整机拖慢。根因是 #708 引入运行时依赖 `zod`,而 live 插件目录从来不装 `dependencies`(profile 用 `file:` 依赖,pnpm 对它是软链不是安装)。

live 已止血并恢复(见 #709),这个 PR 处理仓库侧。

## 这个 PR 关掉的 issue

| issue | 内容 |
|---|---|
| #709 | 依赖闸 + 可重复的 live 安装脚本 |
| #710 | T+1 只有 41% 真是 T+1(最远 144 天) |
| #711 | 缓存 signature 漏掉快照内容 |
| #712 | 版本 bump 到 0.1.6(已在 1f382fef) |
| #713 | 三套死区阈值不一致 |
| #715 | 双解析 / O(N×M) / 死代码 |

#714(nginx)是宿主配置不在仓库里,已单独直接改并实测,详见该 issue。

## 最重的一条:#710

`futureClose` 取的是「碰巧有快照的第 n 天」,没有上限。快照序列最早只到 `2026-05-16`,更早的成交一路配到那张快照上。live 实测:

```
修复前:80 笔带 T+1 判定,真 T+1 只有 33 笔(41%)
        7 笔的对照收盘价在 +144 天,界面照样贴「T+1」
        表头「卖飞/卖对 = 13/8」里 57% 来自窗口外样本

修复后:45 笔,间隔分布 {1:33, 2:4, 3:7, 4:1},窗口外 0 笔
        表头变成诚实的 5/4,并渲染分母「基于 45 笔」
```

宁可不判也不错标 —— 这是个对外战绩数字。

顺带修了 `dayNum` 被当日期算术用的问题:它是单调排序键而非天数(`2026-08-31 → 09-01` 差 2 不差 1),所以软配对的「±3 天」窗口跨月时实际是 ±2~±3 天。新增 `dayGap` 做真实日历差。

## 红绿证明

每个新闸都单独反向验过,不是只让它绿一次:

```
去掉 T+1 窗口上限        -> #710 断言变红(a close +161 days out...),其余 12 绿
签名退回「只看最新文件名」 -> #711 断言变红(rewriting an EXISTING snapshot...)
删掉 zod 声明            -> 新包契约 3 fail,报出生产日志同一条:
                            Cannot find package 'zod' imported from .../lib/typert.host.js
                            而旧的 decision_studio_plugin.spec 仍然 13/13 全绿
```

最后一行是这个 PR 的要点:旧闸 import 的是 checkout 里的 `lib/`,仓库自己的 node_modules 恰好满足一切,所以「声明了但部署时没人装」这一整类缺陷它在结构上看不见。新增的 `tests/dsh_plugin_package_contract.mjs` 打包、装进空目录、逐个 import export 入口,才能看见。

## 本地测试

```
tests/decision_studio_plugin.spec.js      13/13
tests/dsh_plugin_package_contract.mjs      5/5
examples/dsh/plugin 构建可复现(改动前后各验一次)
```

## 行为变化(需要知情)

- T+1 判定数从 80 降到 45,表头战绩从 13/8 变成 5/4。**这不是回归,是去掉虚高。**
- `t1Tone` / `t1ChipTone` 两个客户端导出被移除,由 host 侧 `t1ToneOf` / `t1VerdictOf` 取代;测试里有断言确保它们不再存在。
- 死区现在对买卖两侧统一为 ±1%,所以 `buy +0.5%` 从「涨/绿」变成「持平/灰」。
