### PR TITLE
fix: T+1 改用官方 bar 收盘价 + bars 补齐至 2025-12 + README 指标修复 (#717 #718)

### DIFF
--- a/examples/dsh/plugin/build.mjs
+++ b/examples/dsh/plugin/build.mjs
@@ -28,7 +28,18 @@ async function writeJson(file, value) {
 }
 
 async function wrapWebClient(file) {
-  const source = (await readFile(file, 'utf8')).replace(/[ \t]+$/gm, '')
+  let source = (await readFile(file, 'utf8')).replace(/[ \t]+$/gm, '')
+  // The bundler stamps each `//#region` with the module's path *as resolved on
+  // this machine*, so building the same source in a different directory
+  // produced a different committed artifact (17 lines of pure path churn when
+  // the same commit was built from another worktree). The generated lib/ is
+  // committed and reviewed, so it has to be a function of the source alone —
+  // otherwise "does lib/ match a build of src/?" is unanswerable. Normalize
+  // the path to the package-relative one it should have been.
+  source = source.replace(
+    /^(\/\/#(?:end)?region )(.*?)(node_modules\/.*)$/gm,
+    (_, tag, _abs, rest) => `${tag}${rest}`,
+  )
   const match = source.match(/export \{ ([^}]+) \};\n?$/)
   if (!match) throw new Error('client bundle must end with named exports')
   const exports = match[1]

--- a/examples/dsh/plugin/lib/client.js
+++ b/examples/dsh/plugin/lib/client.js
@@ -6,7 +6,7 @@ window.__ModuleLoader__.load({
     Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const React = require("react");
 const clientRuntime = require("@deepseek-ai/dsh-client-runtime/client");
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/core.js
+//#region node_modules/zod/v4/core/core.js
 var _a$1;
 function $constructor(name, initializer, params) {
 	function init(inst, def) {
@@ -65,7 +65,7 @@ function config(newConfig) {
 	return globalConfig;
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/util.js
+//#region node_modules/zod/v4/core/util.js
 function getEnumValues(entries) {
 	const numericValues = Object.values(entries).filter((v) => typeof v === "number");
 	return Object.entries(entries).filter(([k, _]) => numericValues.indexOf(+k) === -1).map(([_, v]) => v);
@@ -379,7 +379,7 @@ function issue(...args) {
 	return { ...iss };
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/errors.js
+//#region node_modules/zod/v4/core/errors.js
 const initializer$1 = (inst, def) => {
 	inst.name = "$ZodError";
 	Object.defineProperty(inst, "_zod", {
@@ -439,7 +439,7 @@ function formatError(error, mapper = (issue) => issue.message) {
 	return fieldErrors;
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/parse.js
+//#region node_modules/zod/v4/core/parse.js
 const _parse = (_Err) => (schema, value, _ctx, _params) => {
 	const ctx = _ctx ? {
 		..._ctx,
@@ -553,7 +553,7 @@ const _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
 	return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/regexes.js
+//#region node_modules/zod/v4/core/regexes.js
 /**
 * @deprecated CUID v1 is deprecated by its authors due to information leakage
 * (timestamps embedded in the id). Use {@link cuid2} instead.
@@ -617,7 +617,7 @@ const boolean$1 = /^(?:true|false)$/i;
 const lowercase = /^[^A-Z]*$/;
 const uppercase = /^[^a-z]*$/;
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/checks.js
+//#region node_modules/zod/v4/core/checks.js
 const $ZodCheck = /*@__PURE__*/ $constructor("$ZodCheck", (inst, def) => {
 	var _a;
 	inst._zod ?? (inst._zod = {});
@@ -979,7 +979,7 @@ const $ZodCheckOverwrite = /*@__PURE__*/ $constructor("$ZodCheckOverwrite", (ins
 	};
 });
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/doc.js
+//#region node_modules/zod/v4/core/doc.js
 var Doc = class {
 	constructor(args = []) {
 		this.content = [];
@@ -1010,14 +1010,14 @@ var Doc = class {
 	}
 };
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/versions.js
+//#region node_modules/zod/v4/core/versions.js
 const version = {
 	major: 4,
 	minor: 4,
 	patch: 3
 };
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/schemas.js
+//#region node_modules/zod/v4/core/schemas.js
 const $ZodType = /*@__PURE__*/ $constructor("$ZodType", (inst, def) => {
 	var _a;
 	inst ?? (inst = {});
@@ -2262,7 +2262,7 @@ function handleRefineResult(result, payload, input, inst) {
 	}
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/registries.js
+//#region node_modules/zod/v4/core/registries.js
 var _a;
 var $ZodRegistry = class {
 	constructor() {
@@ -2309,7 +2309,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 const globalRegistry = globalThis.__zod_globalRegistry;
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/api.js
+//#region node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class, params) {
 	return new Class({
@@ -2814,7 +2814,7 @@ function _check(fn, params) {
 	return ch;
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/to-json-schema.js
+//#region node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
 	let target = params?.target ?? "draft-2020-12";
 	if (target === "draft-4") target = "draft-04";
@@ -3109,7 +3109,7 @@ const createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params)
 	return finalize(ctx, schema);
 };
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/core/json-schema-processors.js
+//#region node_modules/zod/v4/core/json-schema-processors.js
 const formatMap = {
 	guid: "uuid",
 	url: "uri",
@@ -3380,7 +3380,7 @@ const lazyProcessor = (schema, ctx, _json, params) => {
 	seen.ref = innerType;
 };
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/classic/iso.js
+//#region node_modules/zod/v4/classic/iso.js
 const ZodISODateTime = /*@__PURE__*/ $constructor("ZodISODateTime", (inst, def) => {
 	$ZodISODateTime.init(inst, def);
 	ZodStringFormat.init(inst, def);
@@ -3410,7 +3410,7 @@ function duration(params) {
 	return /* @__PURE__ */ _isoDuration(ZodISODuration, params);
 }
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/classic/errors.js
+//#region node_modules/zod/v4/classic/errors.js
 const initializer = (inst, issues) => {
 	$ZodError.init(inst, issues);
 	inst.name = "ZodError";
@@ -3432,7 +3432,7 @@ const initializer = (inst, issues) => {
 };
 const ZodRealError = /*@__PURE__*/ $constructor("ZodError", initializer, { Parent: Error });
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/classic/parse.js
+//#region node_modules/zod/v4/classic/parse.js
 const parse = /* @__PURE__ */ _parse(ZodRealError);
 const parseAsync = /* @__PURE__ */ _parseAsync(ZodRealError);
 const safeParse = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -3446,7 +3446,7 @@ const safeDecode = /* @__PURE__ */ _safeDecode(ZodRealError);
 const safeEncodeAsync = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 const safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 //#endregion
-//#region ../../root/worktrees/clawock-dm-perf/examples/dsh/plugin/node_modules/zod/v4/classic/schemas.js
+//#region node_modules/zod/v4/classic/schemas.js
 const _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
 	const proto = Object.getPrototypeOf(inst);

--- a/examples/dsh/plugin/lib/freshness.js
+++ b/examples/dsh/plugin/lib/freshness.js
@@ -8,19 +8,20 @@ import { createHash } from "node:crypto";
 * typert-protocol dependency, and reused by the benchmark scripts.
 */
 /**
-* Content signature over every snapshot file, not just the newest filename.
+* Content signature over the canonical bar files.
 *
-* `readSnapshotPrices` parses *all* of `memory/snapshots/`, so the signature
-* has to cover all of it. Keying on the newest filename alone missed two real
-* cases: an existing snapshot being recomputed and rewritten, and the current
-* day's file being rewritten repeatedly intraday — in both the name never
-* moves, so a cached trace view would be served indefinitely. A directory
-* mtime was rejected for moving on unrelated churn; per-file `stat` does not
-* have that problem. Measured 1.4ms steady-state for the current 68 files
-* (~8ms on the first cold call), against the ~103ms readTraces it guards.
+* `readBarCloses` reads `memory/bars/<ticker>.json`, so the signature has to
+* cover those. Two rewrite paths matter and neither moves a filename: the
+* daily writer appends the newly closed session to every ticker's file, and a
+* `--repair` run revises a stored bar in place. Keying on anything but the
+* files' own stat would serve a cached trace view straight through both.
+*
+* (Before the store moved to bars this hashed `memory/snapshots/`; the earlier
+* version keyed on the newest snapshot *filename* alone, which missed every
+* in-place rewrite — see #711.)
 */
-function snapshotsSignature(ws) {
-	const dir = join(ws, "memory", "snapshots");
+function barsSignature(ws) {
+	const dir = join(ws, "memory", "bars");
 	let names;
 	try {
 		names = readdirSync(dir).sort();
@@ -39,8 +40,9 @@ function snapshotsSignature(ws) {
 }
 /**
 * Freshness signature over the three sources that feed the trace view:
-* portfolio.json (fills + notes), every snapshot's stat (T+1 closes), and
-* decisions.jsonl (soft pairing). All stat-level reads, no parsing. The
+* portfolio.json (fills + notes), every canonical bar file's stat (T+1
+* closes), and decisions.jsonl (soft pairing). All stat-level reads, no
+* parsing. The
 * enriched trace view is valid to reuse iff this signature is unchanged.
 */
 function workspaceSignature(ws) {
@@ -54,7 +56,7 @@ function workspaceSignature(ws) {
 	};
 	return [
 		sig(join(ws, "portfolio.json")),
-		snapshotsSignature(ws),
+		barsSignature(ws),
 		sig(join(ws, "memory", "decisions.jsonl"))
 	].join("|");
 }

--- a/examples/dsh/plugin/lib/ledger.js
+++ b/examples/dsh/plugin/lib/ledger.js
@@ -138,7 +138,10 @@ function readPlans(workspace, limit = 14) {
 	}
 	return { plans };
 }
-const SNAPSHOT_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/;
+/** A bar file is `memory/bars/<ticker>.json`; the ticker is a path component. */
+const TICKER_PATTERN = /^[A-Za-z0-9.\-]{1,15}$/;
+/** Bar keys are exchange session dates. */
+const SESSION_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 /**
 * Ordering key for ISO dates (no Date TZ pitfalls). Monotonic, so it is safe
 * for `<`/`>` comparison and sorting — but the *difference* between two of
@@ -202,40 +205,45 @@ function t1VerdictOf(action, delta) {
 	return isSellAction(action) ? up ? "卖飞" : "卖对" : up ? "涨" : "跌";
 }
 /**
-* Price lookup per ticker across daily snapshots: { ticker: { date: price } }.
-* Snapshots carry `current_price` per holding; the newest day with a price
-* after a trade date is its T+1 close.
+* Session close per ticker from the canonical bar store: { ticker: { date: close } }.
+*
+* Reads `memory/bars/<ticker>.json`, the same store the Python settlement path
+* uses — deliberately NOT `memory/snapshots/*.json`.
+*
+* A snapshot is a *portfolio* file whose `current_price` carries the vintage of
+* whichever cron happened to write it. `src/clawock/market_data/bars.py`
+* measured it on 00100 across 15 snapshots: the previous close 7 times, that
+* day's close 3 times, an intraday print 5 times. Worse, the field is carried
+* forward once a position is closed — NVDA sat at a frozen 213 for five
+* straight sessions while its real closes ran 222.32 / 220.61 / 223.47 /
+* 219.51 / 215.33. Settlement migrated off snapshots for exactly this reason;
+* this view stayed behind and marked 82% of its T+1 deltas against a price the
+* rest of the system had already disowned, flipping 10 verdicts outright.
+*
+* Bars are session-dated, unadjusted, and never contain an unfinished session,
+* so a close read here is the same number the ledger settles against. Only the
+* tickers actually traded are read, which is also why this is cheaper than the
+* full snapshot scan it replaces.
+*
+* @param workspace - desk workspace root.
+* @param tickers - the tickers to load; anything else on disk is not read.
 */
-function readSnapshotPrices(workspace) {
+function readBarCloses(workspace, tickers) {
 	const byTicker = {};
-	let files = [];
-	try {
-		files = readdirSync(join(workspace, "memory", "snapshots"));
-	} catch {
-		return byTicker;
-	}
-	for (const name of files) {
-		const m = SNAPSHOT_PATTERN.exec(name);
-		if (!m) continue;
-		const doc = readJson(join(workspace, "memory", "snapshots", name));
+	for (const ticker of new Set(tickers)) {
+		if (!TICKER_PATTERN.test(ticker)) continue;
+		const doc = readJson(join(workspace, "memory", "bars", `${ticker}.json`));
 		if (doc === null || typeof doc !== "object" || Array.isArray(doc)) continue;
-		const portfolios = doc["portfolios"];
-		if (portfolios === null || typeof portfolios !== "object" || Array.isArray(portfolios)) continue;
-		for (const book of Object.values(portfolios)) {
-			if (book === null || typeof book !== "object" || Array.isArray(book)) continue;
-			const holdings = book["holdings"];
-			if (!Array.isArray(holdings)) continue;
-			for (const h of holdings) {
-				if (h === null || typeof h !== "object") continue;
-				const hObj = h;
-				const ticker = hObj["ticker"];
-				const price = hObj["current_price"];
-				if (typeof ticker === "string" && typeof price === "number") {
-					byTicker[ticker] ??= {};
-					byTicker[ticker][m[1]] = price;
-				}
-			}
+		const bars = doc["bars"];
+		if (bars === null || typeof bars !== "object" || Array.isArray(bars)) continue;
+		const closes = {};
+		for (const [date, bar] of Object.entries(bars)) {
+			if (!SESSION_DATE_PATTERN.test(date)) continue;
+			if (bar === null || typeof bar !== "object" || Array.isArray(bar)) continue;
+			const close = bar["close"];
+			if (typeof close === "number" && isFinite(close)) closes[date] = close;
 		}
+		if (Object.keys(closes).length > 0) byTicker[ticker] = closes;
 	}
 	return byTicker;
 }
@@ -338,7 +346,7 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 */
 function readTraces(workspace) {
 	const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace);
-	const byTicker = readSnapshotPrices(workspace);
+	const byTicker = readBarCloses(workspace, trades.map((t) => t.ticker));
 	const decByKey = {};
 	const { entries } = readLedger(workspace);
 	for (const e of entries) {
@@ -370,4 +378,4 @@ function readTraces(workspace) {
 	};
 }
 //#endregion
-export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, readLedger, readPlans, readPortfolio, readSnapshotPrices, readTraces, t1ToneOf, t1VerdictOf };
+export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, readBarCloses, readLedger, readPlans, readPortfolio, readTraces, t1ToneOf, t1VerdictOf };

--- a/examples/dsh/plugin/package-lock.json
+++ b/examples/dsh/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawock-dsh",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",

--- a/examples/dsh/plugin/src/freshness.ts
+++ b/examples/dsh/plugin/src/freshness.ts
@@ -9,19 +9,20 @@ import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 
 /**
- * Content signature over every snapshot file, not just the newest filename.
+ * Content signature over the canonical bar files.
  *
- * `readSnapshotPrices` parses *all* of `memory/snapshots/`, so the signature
- * has to cover all of it. Keying on the newest filename alone missed two real
- * cases: an existing snapshot being recomputed and rewritten, and the current
- * day's file being rewritten repeatedly intraday — in both the name never
- * moves, so a cached trace view would be served indefinitely. A directory
- * mtime was rejected for moving on unrelated churn; per-file `stat` does not
- * have that problem. Measured 1.4ms steady-state for the current 68 files
- * (~8ms on the first cold call), against the ~103ms readTraces it guards.
+ * `readBarCloses` reads `memory/bars/<ticker>.json`, so the signature has to
+ * cover those. Two rewrite paths matter and neither moves a filename: the
+ * daily writer appends the newly closed session to every ticker's file, and a
+ * `--repair` run revises a stored bar in place. Keying on anything but the
+ * files' own stat would serve a cached trace view straight through both.
+ *
+ * (Before the store moved to bars this hashed `memory/snapshots/`; the earlier
+ * version keyed on the newest snapshot *filename* alone, which missed every
+ * in-place rewrite — see #711.)
  */
-function snapshotsSignature(ws: string): string {
-  const dir = join(ws, 'memory', 'snapshots')
+function barsSignature(ws: string): string {
+  const dir = join(ws, 'memory', 'bars')
   let names: string[]
   try {
     names = readdirSync(dir).sort()
@@ -43,8 +44,9 @@ function snapshotsSignature(ws: string): string {
 
 /**
  * Freshness signature over the three sources that feed the trace view:
- * portfolio.json (fills + notes), every snapshot's stat (T+1 closes), and
- * decisions.jsonl (soft pairing). All stat-level reads, no parsing. The
+ * portfolio.json (fills + notes), every canonical bar file's stat (T+1
+ * closes), and decisions.jsonl (soft pairing). All stat-level reads, no
+ * parsing. The
  * enriched trace view is valid to reuse iff this signature is unchanged.
  */
 export function workspaceSignature(ws: string): string {
@@ -58,7 +60,7 @@ export function workspaceSignature(ws: string): string {
   }
   return [
     sig(join(ws, 'portfolio.json')),
-    snapshotsSignature(ws),
+    barsSignature(ws),
     sig(join(ws, 'memory', 'decisions.jsonl')),
   ].join('|')
 }

--- a/examples/dsh/plugin/src/ledger.ts
+++ b/examples/dsh/plugin/src/ledger.ts
@@ -159,10 +159,14 @@ export function readPlans(workspace: string, limit = 14): PlansResult {
 /* ------------------------------------------------------------------ */
 /* Decision trace view: the organic "one view" — real fills as the     */
 /* spine, decision ledger soft-paired (±3 days) as the "why" layer,    */
-/* snapshot closes (memory/snapshots/*.json) for T+1 verdicts.         */
+/* canonical session closes (memory/bars/<ticker>.json) for T+1.       */
 /* ------------------------------------------------------------------ */
 
-const SNAPSHOT_PATTERN = /^(\d{4}-\d{2}-\d{2})\.json$/
+/** A bar file is `memory/bars/<ticker>.json`; the ticker is a path component. */
+const TICKER_PATTERN = /^[A-Za-z0-9.\-]{1,15}$/
+
+/** Bar keys are exchange session dates. */
+const SESSION_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
 /**
  * Ordering key for ISO dates (no Date TZ pitfalls). Monotonic, so it is safe
@@ -231,40 +235,47 @@ export function t1VerdictOf(action: string, delta: number): string {
 }
 
 /**
- * Price lookup per ticker across daily snapshots: { ticker: { date: price } }.
- * Snapshots carry `current_price` per holding; the newest day with a price
- * after a trade date is its T+1 close.
+ * Session close per ticker from the canonical bar store: { ticker: { date: close } }.
+ *
+ * Reads `memory/bars/<ticker>.json`, the same store the Python settlement path
+ * uses — deliberately NOT `memory/snapshots/*.json`.
+ *
+ * A snapshot is a *portfolio* file whose `current_price` carries the vintage of
+ * whichever cron happened to write it. `src/clawock/market_data/bars.py`
+ * measured it on 00100 across 15 snapshots: the previous close 7 times, that
+ * day's close 3 times, an intraday print 5 times. Worse, the field is carried
+ * forward once a position is closed — NVDA sat at a frozen 213 for five
+ * straight sessions while its real closes ran 222.32 / 220.61 / 223.47 /
+ * 219.51 / 215.33. Settlement migrated off snapshots for exactly this reason;
+ * this view stayed behind and marked 82% of its T+1 deltas against a price the
+ * rest of the system had already disowned, flipping 10 verdicts outright.
+ *
+ * Bars are session-dated, unadjusted, and never contain an unfinished session,
+ * so a close read here is the same number the ledger settles against. Only the
+ * tickers actually traded are read, which is also why this is cheaper than the
+ * full snapshot scan it replaces.
+ *
+ * @param workspace - desk workspace root.
+ * @param tickers - the tickers to load; anything else on disk is not read.
  */
-export function readSnapshotPrices(workspace: string): Record<string, Record<string, number>> {
+export function readBarCloses(workspace: string, tickers: Iterable<string>): Record<string, Record<string, number>> {
   const byTicker: Record<string, Record<string, number>> = {}
-  let files: string[] = []
-  try {
-    files = readdirSync(join(workspace, 'memory', 'snapshots'))
-  } catch {
-    return byTicker
-  }
-  for (const name of files) {
-    const m = SNAPSHOT_PATTERN.exec(name)
-    if (!m) continue
-    const doc = readJson(join(workspace, 'memory', 'snapshots', name))
+  for (const ticker of new Set(tickers)) {
+    // The ticker is a path component here, so it has to be constrained before
+    // the join — the same boundary `runIdOf` draws in scan.ts.
+    if (!TICKER_PATTERN.test(ticker)) continue
+    const doc = readJson(join(workspace, 'memory', 'bars', `${ticker}.json`))
     if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) continue
-    const portfolios = (doc as { portfolios?: unknown })['portfolios']
-    if (portfolios === null || typeof portfolios !== 'object' || Array.isArray(portfolios)) continue
-    for (const book of Object.values(portfolios as Record<string, unknown>)) {
-      if (book === null || typeof book !== 'object' || Array.isArray(book)) continue
-      const holdings = (book as { holdings?: unknown })['holdings']
-      if (!Array.isArray(holdings)) continue
-      for (const h of holdings) {
-        if (h === null || typeof h !== 'object') continue
-        const hObj = h as { ticker?: unknown; current_price?: unknown }
-        const ticker = hObj['ticker']
-        const price = hObj['current_price']
-        if (typeof ticker === 'string' && typeof price === 'number') {
-          byTicker[ticker] ??= {}
-          byTicker[ticker]![m[1]!] = price
-        }
-      }
+    const bars = (doc as { bars?: unknown })['bars']
+    if (bars === null || typeof bars !== 'object' || Array.isArray(bars)) continue
+    const closes: Record<string, number> = {}
+    for (const [date, bar] of Object.entries(bars as Record<string, unknown>)) {
+      if (!SESSION_DATE_PATTERN.test(date)) continue
+      if (bar === null || typeof bar !== 'object' || Array.isArray(bar)) continue
+      const close = (bar as { close?: unknown })['close']
+      if (typeof close === 'number' && isFinite(close)) closes[date] = close
     }
+    if (Object.keys(closes).length > 0) byTicker[ticker] = closes
   }
   return byTicker
 }
@@ -387,7 +398,7 @@ function enrichTrade(
  */
 export function readTraces(workspace: string): Omit<TracesResult, 'workspaceKey' | 'signature'> {
   const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace)
-  const byTicker = readSnapshotPrices(workspace)
+  const byTicker = readBarCloses(workspace, trades.map((t) => t.ticker))
   const decByKey: Record<string, JsonValue[]> = {}
   const { entries } = readLedger(workspace)
   for (const e of entries) {

--- a/memory/bars/00100.json
+++ b/memory/bars/00100.json
@@ -7,6 +7,672 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2026-01-09": {
+   "open": 235.4,
+   "high": 351.8,
+   "low": 220.0,
+   "close": 345.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-12": {
+   "open": 378.8,
+   "high": 479.0,
+   "low": 352.2,
+   "close": 398.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-13": {
+   "open": 425.0,
+   "high": 429.2,
+   "low": 353.0,
+   "close": 365.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-14": {
+   "open": 375.0,
+   "high": 391.6,
+   "low": 333.4,
+   "close": 366.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-15": {
+   "open": 351.8,
+   "high": 377.4,
+   "low": 344.0,
+   "close": 358.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-16": {
+   "open": 365.0,
+   "high": 440.0,
+   "low": 351.0,
+   "close": 438.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-19": {
+   "open": 415.2,
+   "high": 423.0,
+   "low": 375.4,
+   "close": 378.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-20": {
+   "open": 390.0,
+   "high": 398.0,
+   "low": 371.0,
+   "close": 390.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-21": {
+   "open": 388.4,
+   "high": 422.8,
+   "low": 381.0,
+   "close": 404.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-22": {
+   "open": 410.0,
+   "high": 416.0,
+   "low": 392.0,
+   "close": 395.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-23": {
+   "open": 400.6,
+   "high": 405.0,
+   "low": 375.0,
+   "close": 376.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-26": {
+   "open": 378.0,
+   "high": 392.0,
+   "low": 361.0,
+   "close": 386.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-27": {
+   "open": 407.8,
+   "high": 499.0,
+   "low": 404.0,
+   "close": 488.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-28": {
+   "open": 494.0,
+   "high": 500.0,
+   "low": 462.2,
+   "close": 488.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-29": {
+   "open": 498.8,
+   "high": 590.0,
+   "low": 482.6,
+   "close": 500.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-30": {
+   "open": 515.0,
+   "high": 547.0,
+   "low": 463.8,
+   "close": 473.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-02": {
+   "open": 489.0,
+   "high": 548.5,
+   "low": 476.0,
+   "close": 523.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-03": {
+   "open": 525.0,
+   "high": 599.5,
+   "low": 524.0,
+   "close": 581.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-04": {
+   "open": 555.0,
+   "high": 571.0,
+   "low": 520.5,
+   "close": 532.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-05": {
+   "open": 508.0,
+   "high": 524.0,
+   "low": 471.8,
+   "close": 486.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-06": {
+   "open": 448.0,
+   "high": 494.0,
+   "low": 446.2,
+   "close": 461.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-09": {
+   "open": 480.0,
+   "high": 530.0,
+   "low": 465.0,
+   "close": 515.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-10": {
+   "open": 520.0,
+   "high": 570.0,
+   "low": 520.0,
+   "close": 539.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-11": {
+   "open": 552.5,
+   "high": 555.0,
+   "low": 501.0,
+   "close": 513.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-12": {
+   "open": 542.0,
+   "high": 636.5,
+   "low": 527.5,
+   "close": 588.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-13": {
+   "open": 600.0,
+   "high": 688.0,
+   "low": 580.5,
+   "close": 680.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-16": {
+   "open": 700.0,
+   "high": 886.0,
+   "low": 692.0,
+   "close": 847.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-20": {
+   "open": 893.0,
+   "high": 980.0,
+   "low": 809.0,
+   "close": 970.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-23": {
+   "open": 873.0,
+   "high": 937.0,
+   "low": 820.0,
+   "close": 840.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-24": {
+   "open": 860.0,
+   "high": 928.0,
+   "low": 835.0,
+   "close": 880.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-25": {
+   "open": 841.0,
+   "high": 862.5,
+   "low": 710.0,
+   "close": 753.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-26": {
+   "open": 779.0,
+   "high": 818.0,
+   "low": 755.0,
+   "close": 788.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-27": {
+   "open": 777.0,
+   "high": 777.5,
+   "low": 665.0,
+   "close": 763.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-02": {
+   "open": 703.5,
+   "high": 799.0,
+   "low": 701.0,
+   "close": 752.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-03": {
+   "open": 827.5,
+   "high": 908.0,
+   "low": 784.0,
+   "close": 821.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-04": {
+   "open": 827.5,
+   "high": 883.5,
+   "low": 711.5,
+   "close": 735.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-05": {
+   "open": 792.0,
+   "high": 832.0,
+   "low": 749.5,
+   "close": 800.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-06": {
+   "open": 785.0,
+   "high": 848.0,
+   "low": 778.0,
+   "close": 805.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-09": {
+   "open": 800.0,
+   "high": 1000.0,
+   "low": 786.0,
+   "close": 997.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-10": {
+   "open": 1046.0,
+   "high": 1286.0,
+   "low": 1026.0,
+   "close": 1220.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-11": {
+   "open": 1180.0,
+   "high": 1320.0,
+   "low": 1101.0,
+   "close": 1141.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-12": {
+   "open": 1160.0,
+   "high": 1221.0,
+   "low": 1072.0,
+   "close": 1084.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-13": {
+   "open": 1100.0,
+   "high": 1124.0,
+   "low": 992.0,
+   "close": 1010.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-16": {
+   "open": 1028.0,
+   "high": 1072.0,
+   "low": 968.0,
+   "close": 1027.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-17": {
+   "open": 1058.0,
+   "high": 1100.0,
+   "low": 1030.0,
+   "close": 1033.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-18": {
+   "open": 1080.0,
+   "high": 1330.0,
+   "low": 1070.0,
+   "close": 1238.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-19": {
+   "open": 1176.0,
+   "high": 1236.0,
+   "low": 1051.0,
+   "close": 1066.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-20": {
+   "open": 1115.0,
+   "high": 1127.0,
+   "low": 998.0,
+   "close": 1009.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-23": {
+   "open": 995.0,
+   "high": 1048.0,
+   "low": 900.0,
+   "close": 916.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-24": {
+   "open": 964.5,
+   "high": 1032.0,
+   "low": 933.5,
+   "close": 1030.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-25": {
+   "open": 1060.0,
+   "high": 1098.0,
+   "low": 1000.0,
+   "close": 1079.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-26": {
+   "open": 1100.0,
+   "high": 1117.0,
+   "low": 979.0,
+   "close": 986.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-27": {
+   "open": 985.0,
+   "high": 990.0,
+   "low": 920.0,
+   "close": 990.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-30": {
+   "open": 949.0,
+   "high": 1048.0,
+   "low": 920.0,
+   "close": 1014.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-31": {
+   "open": 990.0,
+   "high": 1040.0,
+   "low": 920.0,
+   "close": 929.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-01": {
+   "open": 1020.0,
+   "high": 1104.0,
+   "low": 990.0,
+   "close": 1060.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-02": {
+   "open": 1021.0,
+   "high": 1030.0,
+   "low": 940.0,
+   "close": 949.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-08": {
+   "open": 1030.0,
+   "high": 1059.0,
+   "low": 972.0,
+   "close": 999.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-09": {
+   "open": 1000.0,
+   "high": 1097.0,
+   "low": 981.0,
+   "close": 998.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-10": {
+   "open": 1022.0,
+   "high": 1045.0,
+   "low": 985.0,
+   "close": 998.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-13": {
+   "open": 1028.0,
+   "high": 1030.0,
+   "low": 944.0,
+   "close": 960.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-14": {
+   "open": 970.0,
+   "high": 1008.0,
+   "low": 944.0,
+   "close": 951.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-15": {
+   "open": 951.0,
+   "high": 978.0,
+   "low": 815.0,
+   "close": 847.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-16": {
+   "open": 815.5,
+   "high": 918.0,
+   "low": 815.5,
+   "close": 900.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-17": {
+   "open": 900.5,
+   "high": 903.0,
+   "low": 840.0,
+   "close": 859.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-20": {
+   "open": 890.0,
+   "high": 920.0,
+   "low": 858.0,
+   "close": 911.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-21": {
+   "open": 912.0,
+   "high": 916.0,
+   "low": 870.0,
+   "close": 898.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-22": {
+   "open": 880.0,
+   "high": 957.0,
+   "low": 876.0,
+   "close": 928.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-23": {
+   "open": 931.0,
+   "high": 943.0,
+   "low": 850.0,
+   "close": 858.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-24": {
+   "open": 880.0,
+   "high": 880.0,
+   "low": 750.0,
+   "close": 777.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-27": {
+   "open": 755.0,
+   "high": 770.0,
+   "low": 660.0,
+   "close": 750.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-28": {
+   "open": 762.0,
+   "high": 775.0,
+   "low": 706.0,
+   "close": 723.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-29": {
+   "open": 723.5,
+   "high": 748.0,
+   "low": 706.5,
+   "close": 708.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-30": {
+   "open": 685.0,
+   "high": 723.0,
+   "low": 685.0,
+   "close": 713.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
   "2026-05-04": {
    "open": 749.0,
    "high": 809.5,
@@ -645,6 +1311,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 390.0,
+   "high": 395.0,
+   "low": 318.0,
+   "close": 329.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/02208.json
+++ b/memory/bars/02208.json
@@ -7,6 +7,906 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 12.5,
+   "high": 12.54,
+   "low": 11.94,
+   "close": 12.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-02": {
+   "open": 12.1,
+   "high": 12.46,
+   "low": 11.87,
+   "close": 12.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-03": {
+   "open": 12.26,
+   "high": 12.68,
+   "low": 11.5,
+   "close": 12.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-04": {
+   "open": 12.2,
+   "high": 12.43,
+   "low": 11.91,
+   "close": 12.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-05": {
+   "open": 12.29,
+   "high": 13.28,
+   "low": 12.22,
+   "close": 13.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-08": {
+   "open": 13.19,
+   "high": 13.38,
+   "low": 13.06,
+   "close": 13.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-09": {
+   "open": 13.2,
+   "high": 13.34,
+   "low": 12.66,
+   "close": 12.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-10": {
+   "open": 12.6,
+   "high": 12.8,
+   "low": 12.42,
+   "close": 12.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-11": {
+   "open": 12.66,
+   "high": 13.62,
+   "low": 12.66,
+   "close": 13.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-12": {
+   "open": 13.45,
+   "high": 13.63,
+   "low": 12.81,
+   "close": 13.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-15": {
+   "open": 13.68,
+   "high": 14.44,
+   "low": 13.45,
+   "close": 13.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-16": {
+   "open": 13.94,
+   "high": 14.08,
+   "low": 13.05,
+   "close": 13.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-17": {
+   "open": 13.37,
+   "high": 13.5,
+   "low": 13.01,
+   "close": 13.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-18": {
+   "open": 13.24,
+   "high": 13.85,
+   "low": 12.82,
+   "close": 13.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-19": {
+   "open": 13.23,
+   "high": 13.55,
+   "low": 13.0,
+   "close": 13.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-22": {
+   "open": 13.33,
+   "high": 13.88,
+   "low": 13.33,
+   "close": 13.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-23": {
+   "open": 13.96,
+   "high": 14.75,
+   "low": 13.45,
+   "close": 13.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-24": {
+   "open": 13.47,
+   "high": 13.86,
+   "low": 13.0,
+   "close": 13.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-29": {
+   "open": 15.0,
+   "high": 15.71,
+   "low": 14.07,
+   "close": 15.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-30": {
+   "open": 15.19,
+   "high": 15.35,
+   "low": 13.5,
+   "close": 13.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-31": {
+   "open": 13.55,
+   "high": 13.93,
+   "low": 13.37,
+   "close": 13.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-02": {
+   "open": 14.0,
+   "high": 16.28,
+   "low": 13.86,
+   "close": 16.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-05": {
+   "open": 15.49,
+   "high": 16.4,
+   "low": 14.59,
+   "close": 14.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-06": {
+   "open": 15.19,
+   "high": 16.09,
+   "low": 14.3,
+   "close": 15.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-07": {
+   "open": 15.74,
+   "high": 16.3,
+   "low": 14.86,
+   "close": 15.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-08": {
+   "open": 15.7,
+   "high": 16.48,
+   "low": 15.18,
+   "close": 16.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-09": {
+   "open": 16.8,
+   "high": 18.49,
+   "low": 16.6,
+   "close": 16.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-12": {
+   "open": 17.4,
+   "high": 17.65,
+   "low": 16.64,
+   "close": 17.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-13": {
+   "open": 17.2,
+   "high": 17.2,
+   "low": 15.0,
+   "close": 15.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-14": {
+   "open": 15.79,
+   "high": 15.98,
+   "low": 14.84,
+   "close": 14.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-15": {
+   "open": 14.52,
+   "high": 14.85,
+   "low": 13.92,
+   "close": 14.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-16": {
+   "open": 14.39,
+   "high": 14.89,
+   "low": 14.12,
+   "close": 14.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-19": {
+   "open": 14.7,
+   "high": 15.29,
+   "low": 14.2,
+   "close": 15.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-20": {
+   "open": 15.08,
+   "high": 15.15,
+   "low": 14.43,
+   "close": 14.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-21": {
+   "open": 14.32,
+   "high": 14.84,
+   "low": 14.31,
+   "close": 14.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-22": {
+   "open": 14.55,
+   "high": 15.54,
+   "low": 14.54,
+   "close": 15.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-23": {
+   "open": 15.98,
+   "high": 17.17,
+   "low": 15.71,
+   "close": 16.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-26": {
+   "open": 17.0,
+   "high": 17.1,
+   "low": 15.66,
+   "close": 15.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-27": {
+   "open": 15.57,
+   "high": 16.12,
+   "low": 15.47,
+   "close": 15.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-28": {
+   "open": 15.96,
+   "high": 15.97,
+   "low": 15.31,
+   "close": 15.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-29": {
+   "open": 15.5,
+   "high": 15.89,
+   "low": 15.0,
+   "close": 15.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-30": {
+   "open": 15.22,
+   "high": 15.37,
+   "low": 14.44,
+   "close": 14.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-02": {
+   "open": 14.49,
+   "high": 14.77,
+   "low": 13.92,
+   "close": 14.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-03": {
+   "open": 14.3,
+   "high": 14.9,
+   "low": 14.0,
+   "close": 14.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-04": {
+   "open": 14.6,
+   "high": 14.88,
+   "low": 13.59,
+   "close": 13.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-05": {
+   "open": 13.53,
+   "high": 13.54,
+   "low": 12.91,
+   "close": 13.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-06": {
+   "open": 13.1,
+   "high": 13.51,
+   "low": 12.92,
+   "close": 13.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-09": {
+   "open": 13.56,
+   "high": 14.35,
+   "low": 13.42,
+   "close": 14.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-10": {
+   "open": 14.12,
+   "high": 14.16,
+   "low": 13.6,
+   "close": 13.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-11": {
+   "open": 13.73,
+   "high": 13.95,
+   "low": 13.54,
+   "close": 13.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-12": {
+   "open": 13.5,
+   "high": 13.86,
+   "low": 13.5,
+   "close": 13.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-13": {
+   "open": 13.68,
+   "high": 13.75,
+   "low": 13.35,
+   "close": 13.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-16": {
+   "open": 13.6,
+   "high": 13.7,
+   "low": 13.36,
+   "close": 13.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-20": {
+   "open": 13.7,
+   "high": 13.91,
+   "low": 13.41,
+   "close": 13.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-23": {
+   "open": 14.1,
+   "high": 14.8,
+   "low": 14.04,
+   "close": 14.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-24": {
+   "open": 14.16,
+   "high": 14.55,
+   "low": 13.98,
+   "close": 14.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-25": {
+   "open": 14.89,
+   "high": 14.98,
+   "low": 14.5,
+   "close": 14.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-26": {
+   "open": 14.76,
+   "high": 15.88,
+   "low": 14.47,
+   "close": 15.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-27": {
+   "open": 15.56,
+   "high": 15.8,
+   "low": 15.31,
+   "close": 15.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-02": {
+   "open": 15.48,
+   "high": 15.78,
+   "low": 14.65,
+   "close": 14.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-03": {
+   "open": 14.76,
+   "high": 14.89,
+   "low": 13.27,
+   "close": 13.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-04": {
+   "open": 13.17,
+   "high": 14.22,
+   "low": 13.17,
+   "close": 13.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-05": {
+   "open": 13.98,
+   "high": 14.4,
+   "low": 13.73,
+   "close": 14.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-06": {
+   "open": 14.29,
+   "high": 14.78,
+   "low": 13.91,
+   "close": 14.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-09": {
+   "open": 14.11,
+   "high": 14.65,
+   "low": 13.64,
+   "close": 14.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-10": {
+   "open": 14.79,
+   "high": 14.98,
+   "low": 14.43,
+   "close": 14.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-11": {
+   "open": 14.61,
+   "high": 15.7,
+   "low": 14.51,
+   "close": 15.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-12": {
+   "open": 15.22,
+   "high": 16.65,
+   "low": 15.03,
+   "close": 16.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-13": {
+   "open": 16.29,
+   "high": 17.16,
+   "low": 16.12,
+   "close": 16.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-16": {
+   "open": 16.8,
+   "high": 17.7,
+   "low": 16.08,
+   "close": 16.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-17": {
+   "open": 16.4,
+   "high": 16.5,
+   "low": 15.23,
+   "close": 15.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-18": {
+   "open": 15.36,
+   "high": 17.1,
+   "low": 15.13,
+   "close": 16.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-19": {
+   "open": 16.21,
+   "high": 16.54,
+   "low": 15.44,
+   "close": 15.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-20": {
+   "open": 15.81,
+   "high": 16.39,
+   "low": 15.38,
+   "close": 15.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-23": {
+   "open": 15.25,
+   "high": 15.31,
+   "low": 14.52,
+   "close": 14.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-24": {
+   "open": 15.32,
+   "high": 15.42,
+   "low": 14.54,
+   "close": 14.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-25": {
+   "open": 15.32,
+   "high": 15.9,
+   "low": 15.12,
+   "close": 15.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-26": {
+   "open": 15.67,
+   "high": 15.85,
+   "low": 14.7,
+   "close": 14.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-27": {
+   "open": 14.7,
+   "high": 14.76,
+   "low": 13.84,
+   "close": 13.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-30": {
+   "open": 14.33,
+   "high": 15.33,
+   "low": 14.06,
+   "close": 14.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-31": {
+   "open": 15.0,
+   "high": 15.43,
+   "low": 14.22,
+   "close": 14.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-01": {
+   "open": 14.76,
+   "high": 14.76,
+   "low": 13.8,
+   "close": 14.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-02": {
+   "open": 14.26,
+   "high": 14.39,
+   "low": 13.5,
+   "close": 13.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-08": {
+   "open": 13.85,
+   "high": 14.44,
+   "low": 13.85,
+   "close": 14.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-09": {
+   "open": 14.31,
+   "high": 14.31,
+   "low": 13.6,
+   "close": 14.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-10": {
+   "open": 14.28,
+   "high": 14.6,
+   "low": 13.9,
+   "close": 14.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-13": {
+   "open": 13.9,
+   "high": 14.13,
+   "low": 13.75,
+   "close": 14.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-14": {
+   "open": 14.17,
+   "high": 15.36,
+   "low": 14.0,
+   "close": 15.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-15": {
+   "open": 15.4,
+   "high": 15.61,
+   "low": 14.89,
+   "close": 14.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-16": {
+   "open": 15.2,
+   "high": 15.4,
+   "low": 14.93,
+   "close": 15.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-17": {
+   "open": 15.3,
+   "high": 15.75,
+   "low": 15.18,
+   "close": 15.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-20": {
+   "open": 15.7,
+   "high": 17.18,
+   "low": 15.15,
+   "close": 16.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-21": {
+   "open": 16.82,
+   "high": 17.08,
+   "low": 16.4,
+   "close": 16.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-22": {
+   "open": 16.45,
+   "high": 16.54,
+   "low": 15.82,
+   "close": 16.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-23": {
+   "open": 16.36,
+   "high": 16.46,
+   "low": 15.45,
+   "close": 15.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-24": {
+   "open": 15.82,
+   "high": 16.28,
+   "low": 15.4,
+   "close": 15.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-27": {
+   "open": 16.6,
+   "high": 17.45,
+   "low": 16.4,
+   "close": 16.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-28": {
+   "open": 16.99,
+   "high": 17.19,
+   "low": 15.9,
+   "close": 16.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-29": {
+   "open": 15.8,
+   "high": 16.68,
+   "low": 15.8,
+   "close": 16.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-30": {
+   "open": 16.77,
+   "high": 17.78,
+   "low": 16.62,
+   "close": 17.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
   "2026-05-04": {
    "open": 17.4,
    "high": 18.3,
@@ -645,6 +1545,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 10.58,
+   "high": 10.62,
+   "low": 10.36,
+   "close": 10.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/02513.json
+++ b/memory/bars/02513.json
@@ -1,0 +1,1335 @@
+{
+ "schema_version": 1,
+ "ticker": "02513",
+ "leg": "HK",
+ "tencent": "hk02513",
+ "em_audit_secid": "116.02513",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2026-01-08": {
+   "open": 120.0,
+   "high": 135.0,
+   "low": 116.1,
+   "close": 131.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-09": {
+   "open": 137.2,
+   "high": 165.0,
+   "low": 137.2,
+   "close": 158.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-12": {
+   "open": 182.3,
+   "high": 258.0,
+   "low": 165.1,
+   "close": 208.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-13": {
+   "open": 220.4,
+   "high": 225.2,
+   "low": 176.0,
+   "close": 181.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-14": {
+   "open": 194.7,
+   "high": 222.6,
+   "low": 189.0,
+   "close": 216.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-15": {
+   "open": 212.0,
+   "high": 243.0,
+   "low": 206.0,
+   "close": 241.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-16": {
+   "open": 233.8,
+   "high": 263.0,
+   "low": 228.0,
+   "close": 250.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-19": {
+   "open": 245.0,
+   "high": 250.0,
+   "low": 220.2,
+   "close": 224.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-20": {
+   "open": 232.0,
+   "high": 232.2,
+   "low": 197.5,
+   "close": 207.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-21": {
+   "open": 208.0,
+   "high": 217.0,
+   "low": 200.0,
+   "close": 204.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-22": {
+   "open": 209.6,
+   "high": 209.6,
+   "low": 196.1,
+   "close": 202.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-23": {
+   "open": 205.0,
+   "high": 205.0,
+   "low": 190.7,
+   "close": 192.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-26": {
+   "open": 192.0,
+   "high": 224.2,
+   "low": 185.0,
+   "close": 217.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-27": {
+   "open": 223.0,
+   "high": 244.6,
+   "low": 214.0,
+   "close": 233.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-28": {
+   "open": 233.2,
+   "high": 233.2,
+   "low": 221.0,
+   "close": 228.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-29": {
+   "open": 230.6,
+   "high": 252.0,
+   "low": 224.0,
+   "close": 227.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-30": {
+   "open": 228.0,
+   "high": 234.8,
+   "low": 216.6,
+   "close": 226.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-02": {
+   "open": 226.2,
+   "high": 246.6,
+   "low": 219.0,
+   "close": 224.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-03": {
+   "open": 230.0,
+   "high": 253.0,
+   "low": 229.8,
+   "close": 243.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-04": {
+   "open": 235.0,
+   "high": 237.0,
+   "low": 222.2,
+   "close": 227.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-05": {
+   "open": 222.6,
+   "high": 231.0,
+   "low": 210.6,
+   "close": 216.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-06": {
+   "open": 207.0,
+   "high": 208.6,
+   "low": 198.0,
+   "close": 203.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-09": {
+   "open": 214.0,
+   "high": 287.8,
+   "low": 214.0,
+   "close": 276.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-10": {
+   "open": 278.0,
+   "high": 344.0,
+   "low": 277.4,
+   "close": 317.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-11": {
+   "open": 333.0,
+   "high": 354.0,
+   "low": 306.8,
+   "close": 312.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-12": {
+   "open": 339.8,
+   "high": 443.0,
+   "low": 318.8,
+   "close": 402.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-13": {
+   "open": 422.0,
+   "high": 496.0,
+   "low": 408.0,
+   "close": 485.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-16": {
+   "open": 522.0,
+   "high": 540.0,
+   "low": 460.0,
+   "close": 508.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-20": {
+   "open": 534.0,
+   "high": 725.0,
+   "low": 532.5,
+   "close": 725.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-23": {
+   "open": 625.0,
+   "high": 672.5,
+   "low": 540.0,
+   "close": 560.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-24": {
+   "open": 575.5,
+   "high": 698.0,
+   "low": 525.0,
+   "close": 628.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-25": {
+   "open": 591.0,
+   "high": 666.0,
+   "low": 555.5,
+   "close": 560.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-26": {
+   "open": 580.5,
+   "high": 600.0,
+   "low": 553.0,
+   "close": 556.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-27": {
+   "open": 540.0,
+   "high": 592.0,
+   "low": 482.0,
+   "close": 575.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-02": {
+   "open": 550.5,
+   "high": 610.0,
+   "low": 544.0,
+   "close": 550.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-03": {
+   "open": 568.0,
+   "high": 625.0,
+   "low": 526.5,
+   "close": 528.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-04": {
+   "open": 534.0,
+   "high": 578.0,
+   "low": 500.0,
+   "close": 510.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-05": {
+   "open": 526.0,
+   "high": 551.5,
+   "low": 497.0,
+   "close": 520.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-06": {
+   "open": 509.0,
+   "high": 553.5,
+   "low": 505.0,
+   "close": 532.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-09": {
+   "open": 513.0,
+   "high": 583.0,
+   "low": 481.2,
+   "close": 575.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-10": {
+   "open": 648.0,
+   "high": 697.0,
+   "low": 587.0,
+   "close": 649.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-11": {
+   "open": 629.0,
+   "high": 708.0,
+   "low": 600.0,
+   "close": 609.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-12": {
+   "open": 625.0,
+   "high": 633.5,
+   "low": 545.5,
+   "close": 555.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-13": {
+   "open": 551.5,
+   "high": 582.0,
+   "low": 519.0,
+   "close": 530.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-16": {
+   "open": 545.0,
+   "high": 615.0,
+   "low": 543.5,
+   "close": 605.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-17": {
+   "open": 609.0,
+   "high": 639.5,
+   "low": 593.5,
+   "close": 621.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-18": {
+   "open": 625.0,
+   "high": 765.0,
+   "low": 624.0,
+   "close": 742.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-19": {
+   "open": 710.0,
+   "high": 738.0,
+   "low": 646.0,
+   "close": 659.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-20": {
+   "open": 683.0,
+   "high": 690.0,
+   "low": 615.0,
+   "close": 630.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-23": {
+   "open": 600.0,
+   "high": 633.5,
+   "low": 571.0,
+   "close": 590.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-24": {
+   "open": 618.0,
+   "high": 655.0,
+   "low": 595.0,
+   "close": 655.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-25": {
+   "open": 685.0,
+   "high": 760.0,
+   "low": 663.0,
+   "close": 760.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-26": {
+   "open": 780.0,
+   "high": 790.0,
+   "low": 683.0,
+   "close": 684.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-27": {
+   "open": 684.0,
+   "high": 696.0,
+   "low": 641.5,
+   "close": 668.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-30": {
+   "open": 650.5,
+   "high": 750.0,
+   "low": 642.5,
+   "close": 733.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-31": {
+   "open": 720.0,
+   "high": 755.0,
+   "low": 672.0,
+   "close": 693.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-01": {
+   "open": 797.5,
+   "high": 938.0,
+   "low": 797.5,
+   "close": 915.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-02": {
+   "open": 891.5,
+   "high": 900.0,
+   "low": 764.0,
+   "close": 779.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-08": {
+   "open": 895.0,
+   "high": 925.0,
+   "low": 837.0,
+   "close": 868.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-09": {
+   "open": 897.5,
+   "high": 999.0,
+   "low": 862.0,
+   "close": 929.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-10": {
+   "open": 958.0,
+   "high": 970.0,
+   "low": 918.0,
+   "close": 936.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-13": {
+   "open": 945.0,
+   "high": 1005.0,
+   "low": 922.0,
+   "close": 957.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-14": {
+   "open": 980.0,
+   "high": 1010.0,
+   "low": 937.0,
+   "close": 948.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-15": {
+   "open": 976.0,
+   "high": 982.0,
+   "low": 825.0,
+   "close": 867.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-16": {
+   "open": 853.0,
+   "high": 919.0,
+   "low": 839.0,
+   "close": 883.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-17": {
+   "open": 880.0,
+   "high": 911.0,
+   "low": 860.0,
+   "close": 891.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-20": {
+   "open": 896.0,
+   "high": 1030.0,
+   "low": 895.0,
+   "close": 975.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-21": {
+   "open": 976.5,
+   "high": 979.5,
+   "low": 895.0,
+   "close": 950.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-22": {
+   "open": 937.5,
+   "high": 1029.0,
+   "low": 927.5,
+   "close": 986.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-23": {
+   "open": 1010.0,
+   "high": 1078.0,
+   "low": 984.5,
+   "close": 1028.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-24": {
+   "open": 1031.0,
+   "high": 1076.0,
+   "low": 896.0,
+   "close": 935.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-27": {
+   "open": 916.0,
+   "high": 934.5,
+   "low": 872.0,
+   "close": 914.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-28": {
+   "open": 920.0,
+   "high": 920.0,
+   "low": 788.0,
+   "close": 800.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-29": {
+   "open": 805.0,
+   "high": 855.0,
+   "low": 797.0,
+   "close": 816.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-30": {
+   "open": 840.0,
+   "high": 891.0,
+   "low": 798.0,
+   "close": 868.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-04": {
+   "open": 881.0,
+   "high": 967.0,
+   "low": 880.0,
+   "close": 957.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-05": {
+   "open": 955.5,
+   "high": 963.0,
+   "low": 915.0,
+   "close": 919.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-06": {
+   "open": 930.0,
+   "high": 939.0,
+   "low": 885.0,
+   "close": 928.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-07": {
+   "open": 942.0,
+   "high": 975.0,
+   "low": 910.5,
+   "close": 975.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-08": {
+   "open": 950.0,
+   "high": 970.0,
+   "low": 912.0,
+   "close": 923.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-11": {
+   "open": 933.0,
+   "high": 960.0,
+   "low": 885.0,
+   "close": 899.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-12": {
+   "open": 918.0,
+   "high": 918.0,
+   "low": 831.0,
+   "close": 840.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-13": {
+   "open": 831.0,
+   "high": 1168.0,
+   "low": 831.0,
+   "close": 1150.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-14": {
+   "open": 1135.0,
+   "high": 1229.0,
+   "low": 1070.0,
+   "close": 1090.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-15": {
+   "open": 1100.0,
+   "high": 1125.0,
+   "low": 1030.0,
+   "close": 1040.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-18": {
+   "open": 1049.0,
+   "high": 1160.0,
+   "low": 1012.0,
+   "close": 1137.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-19": {
+   "open": 1118.0,
+   "high": 1137.0,
+   "low": 975.0,
+   "close": 1030.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-20": {
+   "open": 1028.0,
+   "high": 1058.0,
+   "low": 976.0,
+   "close": 1058.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-21": {
+   "open": 1141.0,
+   "high": 1149.0,
+   "low": 988.0,
+   "close": 1010.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-22": {
+   "open": 1016.0,
+   "high": 1341.0,
+   "low": 1016.0,
+   "close": 1282.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-26": {
+   "open": 1308.0,
+   "high": 1459.0,
+   "low": 1214.0,
+   "close": 1345.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-27": {
+   "open": 1400.0,
+   "high": 1468.0,
+   "low": 1367.0,
+   "close": 1425.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-28": {
+   "open": 1440.0,
+   "high": 1657.0,
+   "low": 1399.0,
+   "close": 1618.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-29": {
+   "open": 1650.0,
+   "high": 1993.0,
+   "low": 1500.0,
+   "close": 1595.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-01": {
+   "open": 1511.0,
+   "high": 1612.0,
+   "low": 1394.0,
+   "close": 1466.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-02": {
+   "open": 1460.0,
+   "high": 1522.0,
+   "low": 1363.0,
+   "close": 1412.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-03": {
+   "open": 1427.0,
+   "high": 1567.0,
+   "low": 1420.0,
+   "close": 1462.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-04": {
+   "open": 1425.0,
+   "high": 1458.0,
+   "low": 1380.0,
+   "close": 1426.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-05": {
+   "open": 1426.0,
+   "high": 1440.0,
+   "low": 1260.0,
+   "close": 1297.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-08": {
+   "open": 1250.0,
+   "high": 1479.0,
+   "low": 1156.0,
+   "close": 1314.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-09": {
+   "open": 1250.0,
+   "high": 1300.0,
+   "low": 1136.0,
+   "close": 1136.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-10": {
+   "open": 1136.0,
+   "high": 1152.0,
+   "low": 1011.0,
+   "close": 1048.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-11": {
+   "open": 1032.0,
+   "high": 1130.0,
+   "low": 1021.0,
+   "close": 1061.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-12": {
+   "open": 1138.0,
+   "high": 1200.0,
+   "low": 1031.0,
+   "close": 1097.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-15": {
+   "open": 1261.0,
+   "high": 1620.0,
+   "low": 1261.0,
+   "close": 1457.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-16": {
+   "open": 1467.0,
+   "high": 1650.0,
+   "low": 1450.0,
+   "close": 1474.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-17": {
+   "open": 1474.0,
+   "high": 1739.0,
+   "low": 1375.0,
+   "close": 1660.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-18": {
+   "open": 1721.0,
+   "high": 2094.0,
+   "low": 1721.0,
+   "close": 2094.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-22": {
+   "open": 2100.0,
+   "high": 2980.0,
+   "low": 2100.0,
+   "close": 2410.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-23": {
+   "open": 2420.0,
+   "high": 2422.0,
+   "low": 1980.0,
+   "close": 2170.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-24": {
+   "open": 2186.0,
+   "high": 2520.0,
+   "low": 2040.0,
+   "close": 2174.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-25": {
+   "open": 2326.0,
+   "high": 2418.0,
+   "low": 2180.0,
+   "close": 2350.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-26": {
+   "open": 2334.0,
+   "high": 2360.0,
+   "low": 1933.0,
+   "close": 2046.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-29": {
+   "open": 2040.0,
+   "high": 2108.0,
+   "low": 1928.0,
+   "close": 1961.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-30": {
+   "open": 1988.0,
+   "high": 2198.0,
+   "low": 1933.0,
+   "close": 2104.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-02": {
+   "open": 2160.0,
+   "high": 2160.0,
+   "low": 1711.0,
+   "close": 1754.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-03": {
+   "open": 1750.0,
+   "high": 2076.0,
+   "low": 1700.0,
+   "close": 1793.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-06": {
+   "open": 1735.0,
+   "high": 1822.0,
+   "low": 1503.0,
+   "close": 1530.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-07": {
+   "open": 1530.0,
+   "high": 1707.0,
+   "low": 1489.0,
+   "close": 1610.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-08": {
+   "open": 1563.0,
+   "high": 1918.0,
+   "low": 1450.0,
+   "close": 1825.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-09": {
+   "open": 1879.0,
+   "high": 2222.0,
+   "low": 1803.0,
+   "close": 2032.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-10": {
+   "open": 1850.0,
+   "high": 1999.0,
+   "low": 1597.0,
+   "close": 1640.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-13": {
+   "open": 1720.0,
+   "high": 1836.0,
+   "low": 1604.0,
+   "close": 1645.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-14": {
+   "open": 1660.0,
+   "high": 1708.0,
+   "low": 1473.0,
+   "close": 1600.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-15": {
+   "open": 1700.0,
+   "high": 1867.0,
+   "low": 1535.0,
+   "close": 1707.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-16": {
+   "open": 1583.0,
+   "high": 1764.0,
+   "low": 1530.0,
+   "close": 1548.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-17": {
+   "open": 1360.0,
+   "high": 1434.0,
+   "low": 1085.0,
+   "close": 1107.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-20": {
+   "open": 1110.0,
+   "high": 1140.0,
+   "low": 878.0,
+   "close": 890.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-21": {
+   "open": 930.0,
+   "high": 1262.0,
+   "low": 927.5,
+   "close": 1219.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-22": {
+   "open": 1300.0,
+   "high": 1300.0,
+   "low": 1096.0,
+   "close": 1175.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-23": {
+   "open": 1210.0,
+   "high": 1250.0,
+   "low": 1094.0,
+   "close": 1171.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-24": {
+   "open": 1148.0,
+   "high": 1290.0,
+   "low": 1113.0,
+   "close": 1237.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-27": {
+   "open": 1253.0,
+   "high": 1345.0,
+   "low": 1206.0,
+   "close": 1281.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-28": {
+   "open": 1210.0,
+   "high": 1218.0,
+   "low": 1003.0,
+   "close": 1042.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-29": {
+   "open": 1064.0,
+   "high": 1103.0,
+   "low": 985.0,
+   "close": 1033.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-30": {
+   "open": 1048.0,
+   "high": 1048.0,
+   "low": 840.0,
+   "close": 862.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-31": {
+   "open": 991.0,
+   "high": 1125.0,
+   "low": 934.0,
+   "close": 987.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-03": {
+   "open": 940.0,
+   "high": 953.5,
+   "low": 851.0,
+   "close": 940.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-04": {
+   "open": 940.0,
+   "high": 1061.0,
+   "low": 940.0,
+   "close": 1010.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-05": {
+   "open": 1050.0,
+   "high": 1110.0,
+   "low": 1018.0,
+   "close": 1041.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-06": {
+   "open": 1010.0,
+   "high": 1145.0,
+   "low": 996.5,
+   "close": 1087.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-07": {
+   "open": 1120.0,
+   "high": 1300.0,
+   "low": 1108.0,
+   "close": 1246.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-10": {
+   "open": 1292.0,
+   "high": 1327.0,
+   "low": 1184.0,
+   "close": 1252.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-11": {
+   "open": 1290.0,
+   "high": 1298.0,
+   "low": 1172.0,
+   "close": 1192.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-12": {
+   "open": 1208.0,
+   "high": 1285.0,
+   "low": 1190.0,
+   "close": 1208.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-13": {
+   "open": 1230.0,
+   "high": 1324.0,
+   "low": 1225.0,
+   "close": 1317.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-14": {
+   "open": 1356.0,
+   "high": 1435.0,
+   "low": 1199.0,
+   "close": 1270.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  }
+ }
+}

--- a/memory/bars/03032.json
+++ b/memory/bars/03032.json
@@ -7,6 +7,906 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 5.59,
+   "high": 5.645,
+   "low": 5.57,
+   "close": 5.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-02": {
+   "open": 5.635,
+   "high": 5.665,
+   "low": 5.57,
+   "close": 5.605,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-03": {
+   "open": 5.605,
+   "high": 5.605,
+   "low": 5.5,
+   "close": 5.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-04": {
+   "open": 5.515,
+   "high": 5.625,
+   "low": 5.48,
+   "close": 5.595,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-05": {
+   "open": 5.595,
+   "high": 5.67,
+   "low": 5.535,
+   "close": 5.645,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-08": {
+   "open": 5.65,
+   "high": 5.69,
+   "low": 5.625,
+   "close": 5.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-09": {
+   "open": 5.64,
+   "high": 5.645,
+   "low": 5.52,
+   "close": 5.525,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-10": {
+   "open": 5.515,
+   "high": 5.565,
+   "low": 5.48,
+   "close": 5.555,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-11": {
+   "open": 5.575,
+   "high": 5.6,
+   "low": 5.495,
+   "close": 5.515,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-12": {
+   "open": 5.55,
+   "high": 5.625,
+   "low": 5.53,
+   "close": 5.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-15": {
+   "open": 5.575,
+   "high": 5.575,
+   "low": 5.475,
+   "close": 5.485,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-16": {
+   "open": 5.465,
+   "high": 5.465,
+   "low": 5.33,
+   "close": 5.375,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-17": {
+   "open": 5.375,
+   "high": 5.455,
+   "low": 5.36,
+   "close": 5.435,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-18": {
+   "open": 5.41,
+   "high": 5.41,
+   "low": 5.345,
+   "close": 5.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-19": {
+   "open": 5.425,
+   "high": 5.49,
+   "low": 5.41,
+   "close": 5.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-22": {
+   "open": 5.49,
+   "high": 5.535,
+   "low": 5.46,
+   "close": 5.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-23": {
+   "open": 5.505,
+   "high": 5.505,
+   "low": 5.445,
+   "close": 5.465,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-24": {
+   "open": 5.465,
+   "high": 5.505,
+   "low": 5.46,
+   "close": 5.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-29": {
+   "open": 5.515,
+   "high": 5.6,
+   "low": 5.46,
+   "close": 5.465,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-30": {
+   "open": 5.47,
+   "high": 5.58,
+   "low": 5.47,
+   "close": 5.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-31": {
+   "open": 5.55,
+   "high": 5.55,
+   "low": 5.465,
+   "close": 5.485,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-02": {
+   "open": 5.515,
+   "high": 5.73,
+   "low": 5.51,
+   "close": 5.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-05": {
+   "open": 5.72,
+   "high": 5.76,
+   "low": 5.675,
+   "close": 5.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-06": {
+   "open": 5.72,
+   "high": 5.855,
+   "low": 5.72,
+   "close": 5.795,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-07": {
+   "open": 5.795,
+   "high": 5.795,
+   "low": 5.665,
+   "close": 5.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-08": {
+   "open": 5.7,
+   "high": 5.7,
+   "low": 5.595,
+   "close": 5.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-09": {
+   "open": 5.685,
+   "high": 5.715,
+   "low": 5.64,
+   "close": 5.655,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-12": {
+   "open": 5.68,
+   "high": 5.84,
+   "low": 5.67,
+   "close": 5.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-13": {
+   "open": 5.935,
+   "high": 5.975,
+   "low": 5.805,
+   "close": 5.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-14": {
+   "open": 5.855,
+   "high": 5.945,
+   "low": 5.81,
+   "close": 5.865,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-15": {
+   "open": 5.865,
+   "high": 5.88,
+   "low": 5.76,
+   "close": 5.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-16": {
+   "open": 5.85,
+   "high": 5.87,
+   "low": 5.77,
+   "close": 5.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-19": {
+   "open": 5.765,
+   "high": 5.775,
+   "low": 5.715,
+   "close": 5.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-20": {
+   "open": 5.72,
+   "high": 5.74,
+   "low": 5.64,
+   "close": 5.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-21": {
+   "open": 5.61,
+   "high": 5.76,
+   "low": 5.61,
+   "close": 5.725,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-22": {
+   "open": 5.74,
+   "high": 5.775,
+   "low": 5.685,
+   "close": 5.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-23": {
+   "open": 5.795,
+   "high": 5.795,
+   "low": 5.73,
+   "close": 5.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-26": {
+   "open": 5.78,
+   "high": 5.78,
+   "low": 5.66,
+   "close": 5.695,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-27": {
+   "open": 5.695,
+   "high": 5.745,
+   "low": 5.655,
+   "close": 5.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-28": {
+   "open": 5.73,
+   "high": 5.875,
+   "low": 5.73,
+   "close": 5.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-29": {
+   "open": 5.84,
+   "high": 5.87,
+   "low": 5.78,
+   "close": 5.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-30": {
+   "open": 5.805,
+   "high": 5.805,
+   "low": 5.69,
+   "close": 5.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-02": {
+   "open": 5.66,
+   "high": 5.66,
+   "low": 5.445,
+   "close": 5.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-03": {
+   "open": 5.52,
+   "high": 5.555,
+   "low": 5.315,
+   "close": 5.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-04": {
+   "open": 5.395,
+   "high": 5.41,
+   "low": 5.3,
+   "close": 5.345,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-05": {
+   "open": 5.28,
+   "high": 5.39,
+   "low": 5.2,
+   "close": 5.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-06": {
+   "open": 5.255,
+   "high": 5.37,
+   "low": 5.25,
+   "close": 5.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-09": {
+   "open": 5.42,
+   "high": 5.435,
+   "low": 5.365,
+   "close": 5.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-10": {
+   "open": 5.41,
+   "high": 5.495,
+   "low": 5.41,
+   "close": 5.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-11": {
+   "open": 5.44,
+   "high": 5.495,
+   "low": 5.425,
+   "close": 5.465,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-12": {
+   "open": 5.45,
+   "high": 5.45,
+   "low": 5.37,
+   "close": 5.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-13": {
+   "open": 5.305,
+   "high": 5.355,
+   "low": 5.29,
+   "close": 5.335,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-16": {
+   "open": 5.355,
+   "high": 5.355,
+   "low": 5.225,
+   "close": 5.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-20": {
+   "open": 5.33,
+   "high": 5.335,
+   "low": 5.185,
+   "close": 5.185,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-23": {
+   "open": 5.265,
+   "high": 5.395,
+   "low": 5.265,
+   "close": 5.355,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-24": {
+   "open": 5.32,
+   "high": 5.32,
+   "low": 5.21,
+   "close": 5.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-25": {
+   "open": 5.305,
+   "high": 5.305,
+   "low": 5.22,
+   "close": 5.225,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-26": {
+   "open": 5.23,
+   "high": 5.25,
+   "low": 5.085,
+   "close": 5.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-27": {
+   "open": 5.09,
+   "high": 5.155,
+   "low": 5.075,
+   "close": 5.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-02": {
+   "open": 5.025,
+   "high": 5.06,
+   "low": 4.94,
+   "close": 4.966,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-03": {
+   "open": 4.992,
+   "high": 4.998,
+   "low": 4.832,
+   "close": 4.844,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-04": {
+   "open": 4.8,
+   "high": 4.854,
+   "low": 4.722,
+   "close": 4.806,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-05": {
+   "open": 4.908,
+   "high": 4.908,
+   "low": 4.744,
+   "close": 4.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-06": {
+   "open": 4.77,
+   "high": 4.95,
+   "low": 4.766,
+   "close": 4.924,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-09": {
+   "open": 4.752,
+   "high": 4.918,
+   "low": 4.724,
+   "close": 4.912,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-10": {
+   "open": 4.998,
+   "high": 5.035,
+   "low": 4.934,
+   "close": 5.035,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-11": {
+   "open": 5.065,
+   "high": 5.1,
+   "low": 5.01,
+   "close": 5.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-12": {
+   "open": 5.015,
+   "high": 5.06,
+   "low": 4.942,
+   "close": 5.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-13": {
+   "open": 4.992,
+   "high": 5.02,
+   "low": 4.934,
+   "close": 4.958,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-16": {
+   "open": 4.958,
+   "high": 5.105,
+   "low": 4.912,
+   "close": 5.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-17": {
+   "open": 5.12,
+   "high": 5.21,
+   "low": 5.065,
+   "close": 5.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-18": {
+   "open": 5.095,
+   "high": 5.11,
+   "low": 5.03,
+   "close": 5.085,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-19": {
+   "open": 4.998,
+   "high": 5.04,
+   "low": 4.954,
+   "close": 4.962,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-20": {
+   "open": 4.954,
+   "high": 4.974,
+   "low": 4.812,
+   "close": 4.854,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-23": {
+   "open": 4.77,
+   "high": 4.78,
+   "low": 4.638,
+   "close": 4.686,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-24": {
+   "open": 4.788,
+   "high": 4.818,
+   "low": 4.67,
+   "close": 4.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-25": {
+   "open": 4.852,
+   "high": 4.924,
+   "low": 4.78,
+   "close": 4.892,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-26": {
+   "open": 4.868,
+   "high": 4.888,
+   "low": 4.72,
+   "close": 4.722,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-27": {
+   "open": 4.718,
+   "high": 4.812,
+   "low": 4.698,
+   "close": 4.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-30": {
+   "open": 4.658,
+   "high": 4.702,
+   "low": 4.596,
+   "close": 4.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-31": {
+   "open": 4.67,
+   "high": 4.718,
+   "low": 4.6,
+   "close": 4.624,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-01": {
+   "open": 4.75,
+   "high": 4.764,
+   "low": 4.684,
+   "close": 4.728,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-02": {
+   "open": 4.706,
+   "high": 4.716,
+   "low": 4.608,
+   "close": 4.646,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-08": {
+   "open": 4.792,
+   "high": 4.916,
+   "low": 4.792,
+   "close": 4.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-09": {
+   "open": 4.906,
+   "high": 4.906,
+   "low": 4.79,
+   "close": 4.812,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-10": {
+   "open": 4.836,
+   "high": 4.918,
+   "low": 4.824,
+   "close": 4.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-13": {
+   "open": 4.808,
+   "high": 4.824,
+   "low": 4.776,
+   "close": 4.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-14": {
+   "open": 4.85,
+   "high": 4.882,
+   "low": 4.788,
+   "close": 4.836,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-15": {
+   "open": 4.934,
+   "high": 4.956,
+   "low": 4.89,
+   "close": 4.894,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-16": {
+   "open": 4.95,
+   "high": 5.08,
+   "low": 4.95,
+   "close": 5.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-17": {
+   "open": 5.05,
+   "high": 5.055,
+   "low": 4.98,
+   "close": 5.025,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-20": {
+   "open": 5.025,
+   "high": 5.085,
+   "low": 5.005,
+   "close": 5.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-21": {
+   "open": 5.055,
+   "high": 5.065,
+   "low": 4.998,
+   "close": 5.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-22": {
+   "open": 4.994,
+   "high": 4.994,
+   "low": 4.92,
+   "close": 4.952,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-23": {
+   "open": 4.952,
+   "high": 4.952,
+   "low": 4.83,
+   "close": 4.848,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-24": {
+   "open": 4.826,
+   "high": 4.894,
+   "low": 4.76,
+   "close": 4.888,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-27": {
+   "open": 4.888,
+   "high": 4.954,
+   "low": 4.88,
+   "close": 4.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-28": {
+   "open": 4.922,
+   "high": 4.922,
+   "low": 4.796,
+   "close": 4.812,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-29": {
+   "open": 4.864,
+   "high": 4.902,
+   "low": 4.838,
+   "close": 4.892,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-30": {
+   "open": 4.872,
+   "high": 4.876,
+   "low": 4.806,
+   "close": 4.866,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
   "2026-05-04": {
    "open": 4.866,
    "high": 5.035,
@@ -645,6 +1545,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 4.79,
+   "high": 4.79,
+   "low": 4.694,
+   "close": 4.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/03033.json
+++ b/memory/bars/03033.json
@@ -7,6 +7,906 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 5.5,
+   "high": 5.555,
+   "low": 5.475,
+   "close": 5.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-02": {
+   "open": 5.57,
+   "high": 5.575,
+   "low": 5.48,
+   "close": 5.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-03": {
+   "open": 5.52,
+   "high": 5.52,
+   "low": 5.41,
+   "close": 5.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-04": {
+   "open": 5.435,
+   "high": 5.54,
+   "low": 5.395,
+   "close": 5.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-05": {
+   "open": 5.47,
+   "high": 5.58,
+   "low": 5.44,
+   "close": 5.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-08": {
+   "open": 5.56,
+   "high": 5.595,
+   "low": 5.535,
+   "close": 5.545,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-09": {
+   "open": 5.55,
+   "high": 5.55,
+   "low": 5.425,
+   "close": 5.445,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-10": {
+   "open": 5.435,
+   "high": 5.475,
+   "low": 5.39,
+   "close": 5.455,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-11": {
+   "open": 5.49,
+   "high": 5.515,
+   "low": 5.405,
+   "close": 5.425,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-12": {
+   "open": 5.435,
+   "high": 5.535,
+   "low": 5.435,
+   "close": 5.515,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-15": {
+   "open": 5.46,
+   "high": 5.47,
+   "low": 5.38,
+   "close": 5.385,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-16": {
+   "open": 5.36,
+   "high": 5.37,
+   "low": 5.24,
+   "close": 5.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-17": {
+   "open": 5.3,
+   "high": 5.37,
+   "low": 5.275,
+   "close": 5.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-18": {
+   "open": 5.3,
+   "high": 5.325,
+   "low": 5.255,
+   "close": 5.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-19": {
+   "open": 5.32,
+   "high": 5.395,
+   "low": 5.32,
+   "close": 5.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-22": {
+   "open": 5.395,
+   "high": 5.44,
+   "low": 5.385,
+   "close": 5.415,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-23": {
+   "open": 5.415,
+   "high": 5.415,
+   "low": 5.355,
+   "close": 5.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-24": {
+   "open": 5.375,
+   "high": 5.415,
+   "low": 5.37,
+   "close": 5.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-29": {
+   "open": 5.415,
+   "high": 5.505,
+   "low": 5.365,
+   "close": 5.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-30": {
+   "open": 5.385,
+   "high": 5.49,
+   "low": 5.385,
+   "close": 5.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2025-12-31": {
+   "open": 5.455,
+   "high": 5.465,
+   "low": 5.375,
+   "close": 5.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-02": {
+   "open": 5.435,
+   "high": 5.64,
+   "low": 5.42,
+   "close": 5.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-05": {
+   "open": 5.635,
+   "high": 5.665,
+   "low": 5.585,
+   "close": 5.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-06": {
+   "open": 5.665,
+   "high": 5.755,
+   "low": 5.66,
+   "close": 5.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-07": {
+   "open": 5.685,
+   "high": 5.695,
+   "low": 5.57,
+   "close": 5.625,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-08": {
+   "open": 5.6,
+   "high": 5.6,
+   "low": 5.5,
+   "close": 5.555,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-09": {
+   "open": 5.58,
+   "high": 5.62,
+   "low": 5.545,
+   "close": 5.565,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-12": {
+   "open": 5.615,
+   "high": 5.745,
+   "low": 5.575,
+   "close": 5.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-13": {
+   "open": 5.85,
+   "high": 5.88,
+   "low": 5.71,
+   "close": 5.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-14": {
+   "open": 5.76,
+   "high": 5.845,
+   "low": 5.71,
+   "close": 5.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-15": {
+   "open": 5.755,
+   "high": 5.78,
+   "low": 5.665,
+   "close": 5.705,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-16": {
+   "open": 5.75,
+   "high": 5.775,
+   "low": 5.67,
+   "close": 5.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-19": {
+   "open": 5.65,
+   "high": 5.685,
+   "low": 5.62,
+   "close": 5.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-20": {
+   "open": 5.63,
+   "high": 5.645,
+   "low": 5.545,
+   "close": 5.565,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-21": {
+   "open": 5.53,
+   "high": 5.665,
+   "low": 5.525,
+   "close": 5.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-22": {
+   "open": 5.66,
+   "high": 5.685,
+   "low": 5.59,
+   "close": 5.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-23": {
+   "open": 5.69,
+   "high": 5.695,
+   "low": 5.635,
+   "close": 5.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-26": {
+   "open": 5.675,
+   "high": 5.675,
+   "low": 5.565,
+   "close": 5.605,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-27": {
+   "open": 5.615,
+   "high": 5.65,
+   "low": 5.56,
+   "close": 5.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-28": {
+   "open": 5.655,
+   "high": 5.775,
+   "low": 5.65,
+   "close": 5.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-29": {
+   "open": 5.735,
+   "high": 5.77,
+   "low": 5.68,
+   "close": 5.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-01-30": {
+   "open": 5.665,
+   "high": 5.68,
+   "low": 5.595,
+   "close": 5.605,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-02": {
+   "open": 5.53,
+   "high": 5.53,
+   "low": 5.355,
+   "close": 5.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-03": {
+   "open": 5.45,
+   "high": 5.465,
+   "low": 5.225,
+   "close": 5.345,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-04": {
+   "open": 5.34,
+   "high": 5.34,
+   "low": 5.205,
+   "close": 5.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-05": {
+   "open": 5.18,
+   "high": 5.305,
+   "low": 5.15,
+   "close": 5.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-06": {
+   "open": 5.17,
+   "high": 5.285,
+   "low": 5.165,
+   "close": 5.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-09": {
+   "open": 5.335,
+   "high": 5.34,
+   "low": 5.275,
+   "close": 5.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-10": {
+   "open": 5.34,
+   "high": 5.405,
+   "low": 5.32,
+   "close": 5.325,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-11": {
+   "open": 5.35,
+   "high": 5.405,
+   "low": 5.335,
+   "close": 5.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-12": {
+   "open": 5.365,
+   "high": 5.365,
+   "low": 5.28,
+   "close": 5.295,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-13": {
+   "open": 5.21,
+   "high": 5.265,
+   "low": 5.2,
+   "close": 5.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-16": {
+   "open": 5.23,
+   "high": 5.26,
+   "low": 5.14,
+   "close": 5.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-20": {
+   "open": 5.21,
+   "high": 5.245,
+   "low": 5.1,
+   "close": 5.105,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-23": {
+   "open": 5.155,
+   "high": 5.305,
+   "low": 5.155,
+   "close": 5.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-24": {
+   "open": 5.22,
+   "high": 5.22,
+   "low": 5.125,
+   "close": 5.145,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-25": {
+   "open": 5.19,
+   "high": 5.205,
+   "low": 5.13,
+   "close": 5.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-26": {
+   "open": 5.16,
+   "high": 5.165,
+   "low": 4.994,
+   "close": 5.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-02-27": {
+   "open": 5.0,
+   "high": 5.07,
+   "low": 4.986,
+   "close": 5.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-02": {
+   "open": 4.946,
+   "high": 4.974,
+   "low": 4.856,
+   "close": 4.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-03": {
+   "open": 4.9,
+   "high": 4.92,
+   "low": 4.752,
+   "close": 4.762,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-04": {
+   "open": 4.71,
+   "high": 4.772,
+   "low": 4.644,
+   "close": 4.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-05": {
+   "open": 4.796,
+   "high": 4.804,
+   "low": 4.66,
+   "close": 4.692,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-06": {
+   "open": 4.706,
+   "high": 4.866,
+   "low": 4.688,
+   "close": 4.836,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-09": {
+   "open": 4.648,
+   "high": 4.838,
+   "low": 4.634,
+   "close": 4.822,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-10": {
+   "open": 4.92,
+   "high": 4.948,
+   "low": 4.848,
+   "close": 4.946,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-11": {
+   "open": 4.996,
+   "high": 5.01,
+   "low": 4.926,
+   "close": 4.936,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-12": {
+   "open": 4.92,
+   "high": 4.972,
+   "low": 4.86,
+   "close": 4.924,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-13": {
+   "open": 4.894,
+   "high": 4.938,
+   "low": 4.852,
+   "close": 4.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-16": {
+   "open": 4.886,
+   "high": 5.02,
+   "low": 4.828,
+   "close": 4.998,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-17": {
+   "open": 5.025,
+   "high": 5.12,
+   "low": 4.98,
+   "close": 4.998,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-18": {
+   "open": 5.015,
+   "high": 5.025,
+   "low": 4.942,
+   "close": 5.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-19": {
+   "open": 4.9,
+   "high": 4.96,
+   "low": 4.866,
+   "close": 4.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-20": {
+   "open": 4.84,
+   "high": 4.89,
+   "low": 4.728,
+   "close": 4.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-23": {
+   "open": 4.682,
+   "high": 4.704,
+   "low": 4.558,
+   "close": 4.606,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-24": {
+   "open": 4.662,
+   "high": 4.73,
+   "low": 4.588,
+   "close": 4.718,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-25": {
+   "open": 4.77,
+   "high": 4.842,
+   "low": 4.69,
+   "close": 4.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-26": {
+   "open": 4.784,
+   "high": 4.788,
+   "low": 4.636,
+   "close": 4.656,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-27": {
+   "open": 4.624,
+   "high": 4.73,
+   "low": 4.618,
+   "close": 4.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-30": {
+   "open": 4.546,
+   "high": 4.62,
+   "low": 4.514,
+   "close": 4.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-03-31": {
+   "open": 4.598,
+   "high": 4.636,
+   "low": 4.52,
+   "close": 4.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-01": {
+   "open": 4.668,
+   "high": 4.682,
+   "low": 4.602,
+   "close": 4.646,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-02": {
+   "open": 4.624,
+   "high": 4.634,
+   "low": 4.526,
+   "close": 4.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-08": {
+   "open": 4.742,
+   "high": 4.832,
+   "low": 4.71,
+   "close": 4.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-09": {
+   "open": 4.77,
+   "high": 4.786,
+   "low": 4.706,
+   "close": 4.714,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-10": {
+   "open": 4.748,
+   "high": 4.834,
+   "low": 4.736,
+   "close": 4.758,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-13": {
+   "open": 4.724,
+   "high": 4.742,
+   "low": 4.692,
+   "close": 4.724,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-14": {
+   "open": 4.77,
+   "high": 4.798,
+   "low": 4.702,
+   "close": 4.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-15": {
+   "open": 4.858,
+   "high": 4.872,
+   "low": 4.802,
+   "close": 4.814,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-16": {
+   "open": 4.874,
+   "high": 4.994,
+   "low": 4.872,
+   "close": 4.994,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-17": {
+   "open": 4.948,
+   "high": 4.966,
+   "low": 4.894,
+   "close": 4.936,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-20": {
+   "open": 4.952,
+   "high": 4.996,
+   "low": 4.918,
+   "close": 4.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-21": {
+   "open": 4.978,
+   "high": 4.98,
+   "low": 4.912,
+   "close": 4.956,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-22": {
+   "open": 4.898,
+   "high": 4.902,
+   "low": 4.836,
+   "close": 4.858,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-23": {
+   "open": 4.854,
+   "high": 4.858,
+   "low": 4.744,
+   "close": 4.758,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-24": {
+   "open": 4.73,
+   "high": 4.808,
+   "low": 4.674,
+   "close": 4.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-27": {
+   "open": 4.814,
+   "high": 4.868,
+   "low": 4.794,
+   "close": 4.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-28": {
+   "open": 4.824,
+   "high": 4.828,
+   "low": 4.71,
+   "close": 4.726,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-29": {
+   "open": 4.784,
+   "high": 4.816,
+   "low": 4.756,
+   "close": 4.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
+  "2026-04-30": {
+   "open": 4.78,
+   "high": 4.792,
+   "low": 4.72,
+   "close": 4.776,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
+  },
   "2026-05-04": {
    "open": 4.844,
    "high": 4.95,
@@ -645,6 +1545,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 4.686,
+   "high": 4.688,
+   "low": 4.608,
+   "close": 4.616,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:46+08:00"
   }
  },
  "retired": false

--- a/memory/bars/03317.json
+++ b/memory/bars/03317.json
@@ -1,0 +1,1389 @@
+{
+ "schema_version": 1,
+ "ticker": "03317",
+ "leg": "HK",
+ "tencent": "hk03317",
+ "em_audit_secid": "116.03317",
+ "adjustment": "raw",
+ "source": "tencent",
+ "retired": false,
+ "bars": {
+  "2025-12-30": {
+   "open": 48.02,
+   "high": 48.84,
+   "low": 38.02,
+   "close": 48.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-31": {
+   "open": 48.5,
+   "high": 50.5,
+   "low": 46.26,
+   "close": 50.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-02": {
+   "open": 50.4,
+   "high": 50.4,
+   "low": 47.42,
+   "close": 48.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-05": {
+   "open": 48.68,
+   "high": 50.0,
+   "low": 48.0,
+   "close": 48.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-06": {
+   "open": 48.12,
+   "high": 48.6,
+   "low": 47.68,
+   "close": 48.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-07": {
+   "open": 48.12,
+   "high": 49.44,
+   "low": 46.5,
+   "close": 48.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-08": {
+   "open": 48.74,
+   "high": 48.74,
+   "low": 47.34,
+   "close": 47.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-09": {
+   "open": 48.0,
+   "high": 48.8,
+   "low": 47.52,
+   "close": 48.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-12": {
+   "open": 48.4,
+   "high": 56.75,
+   "low": 47.34,
+   "close": 53.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-13": {
+   "open": 53.0,
+   "high": 65.0,
+   "low": 53.0,
+   "close": 62.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-14": {
+   "open": 62.5,
+   "high": 68.0,
+   "low": 58.4,
+   "close": 62.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-15": {
+   "open": 63.0,
+   "high": 65.3,
+   "low": 60.0,
+   "close": 61.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-16": {
+   "open": 61.8,
+   "high": 72.0,
+   "low": 61.4,
+   "close": 67.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-19": {
+   "open": 67.0,
+   "high": 72.05,
+   "low": 64.65,
+   "close": 68.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-20": {
+   "open": 69.0,
+   "high": 70.0,
+   "low": 59.85,
+   "close": 60.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-21": {
+   "open": 60.3,
+   "high": 62.8,
+   "low": 59.65,
+   "close": 60.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-22": {
+   "open": 60.95,
+   "high": 60.95,
+   "low": 57.25,
+   "close": 58.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-23": {
+   "open": 58.0,
+   "high": 59.75,
+   "low": 55.85,
+   "close": 56.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-26": {
+   "open": 56.8,
+   "high": 56.8,
+   "low": 53.9,
+   "close": 55.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-27": {
+   "open": 55.15,
+   "high": 62.0,
+   "low": 53.05,
+   "close": 60.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-28": {
+   "open": 60.45,
+   "high": 60.5,
+   "low": 57.5,
+   "close": 57.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-29": {
+   "open": 57.55,
+   "high": 60.75,
+   "low": 56.6,
+   "close": 59.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-30": {
+   "open": 59.4,
+   "high": 59.4,
+   "low": 51.45,
+   "close": 53.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-02": {
+   "open": 53.8,
+   "high": 53.8,
+   "low": 49.6,
+   "close": 52.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-03": {
+   "open": 53.0,
+   "high": 54.6,
+   "low": 51.2,
+   "close": 54.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-04": {
+   "open": 54.25,
+   "high": 54.4,
+   "low": 52.3,
+   "close": 53.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-05": {
+   "open": 53.95,
+   "high": 53.95,
+   "low": 50.45,
+   "close": 52.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-06": {
+   "open": 52.0,
+   "high": 54.0,
+   "low": 50.85,
+   "close": 52.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-09": {
+   "open": 55.0,
+   "high": 61.8,
+   "low": 54.3,
+   "close": 60.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-10": {
+   "open": 60.55,
+   "high": 78.0,
+   "low": 60.55,
+   "close": 70.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-11": {
+   "open": 70.0,
+   "high": 74.0,
+   "low": 63.0,
+   "close": 69.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-12": {
+   "open": 70.0,
+   "high": 75.35,
+   "low": 63.05,
+   "close": 69.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-13": {
+   "open": 65.6,
+   "high": 74.9,
+   "low": 65.0,
+   "close": 71.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-16": {
+   "open": 75.2,
+   "high": 78.0,
+   "low": 67.25,
+   "close": 70.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-20": {
+   "open": 72.0,
+   "high": 81.2,
+   "low": 70.8,
+   "close": 79.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-23": {
+   "open": 86.7,
+   "high": 95.5,
+   "low": 82.05,
+   "close": 90.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-24": {
+   "open": 89.0,
+   "high": 92.8,
+   "low": 83.05,
+   "close": 90.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-25": {
+   "open": 87.5,
+   "high": 90.0,
+   "low": 85.15,
+   "close": 86.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-26": {
+   "open": 86.85,
+   "high": 88.5,
+   "low": 82.2,
+   "close": 82.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-27": {
+   "open": 82.2,
+   "high": 94.55,
+   "low": 82.2,
+   "close": 91.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-02": {
+   "open": 89.0,
+   "high": 89.95,
+   "low": 78.05,
+   "close": 78.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-03": {
+   "open": 79.95,
+   "high": 85.0,
+   "low": 76.6,
+   "close": 77.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-04": {
+   "open": 77.45,
+   "high": 79.9,
+   "low": 71.9,
+   "close": 73.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-05": {
+   "open": 75.0,
+   "high": 78.0,
+   "low": 70.1,
+   "close": 70.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-06": {
+   "open": 70.65,
+   "high": 76.85,
+   "low": 70.0,
+   "close": 76.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-09": {
+   "open": 87.1,
+   "high": 130.3,
+   "low": 76.0,
+   "close": 115.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-10": {
+   "open": 132.0,
+   "high": 165.0,
+   "low": 116.2,
+   "close": 153.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-11": {
+   "open": 145.0,
+   "high": 170.5,
+   "low": 134.6,
+   "close": 141.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-12": {
+   "open": 145.0,
+   "high": 152.9,
+   "low": 132.5,
+   "close": 141.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-13": {
+   "open": 142.0,
+   "high": 144.9,
+   "low": 112.1,
+   "close": 113.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-16": {
+   "open": 115.0,
+   "high": 120.8,
+   "low": 106.3,
+   "close": 109.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-17": {
+   "open": 112.0,
+   "high": 150.5,
+   "low": 106.6,
+   "close": 150.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-18": {
+   "open": 150.0,
+   "high": 166.6,
+   "low": 135.5,
+   "close": 149.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-19": {
+   "open": 140.0,
+   "high": 160.7,
+   "low": 140.0,
+   "close": 144.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-20": {
+   "open": 152.0,
+   "high": 153.0,
+   "low": 139.2,
+   "close": 147.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-23": {
+   "open": 142.9,
+   "high": 151.2,
+   "low": 133.8,
+   "close": 136.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-24": {
+   "open": 141.2,
+   "high": 143.8,
+   "low": 127.0,
+   "close": 137.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-25": {
+   "open": 143.0,
+   "high": 159.2,
+   "low": 141.9,
+   "close": 156.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-26": {
+   "open": 160.0,
+   "high": 161.9,
+   "low": 146.0,
+   "close": 151.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-27": {
+   "open": 150.0,
+   "high": 197.0,
+   "low": 144.0,
+   "close": 188.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-30": {
+   "open": 186.9,
+   "high": 217.0,
+   "low": 174.1,
+   "close": 204.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-31": {
+   "open": 207.4,
+   "high": 222.2,
+   "low": 194.6,
+   "close": 199.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-01": {
+   "open": 217.0,
+   "high": 221.8,
+   "low": 193.0,
+   "close": 203.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-02": {
+   "open": 201.6,
+   "high": 210.8,
+   "low": 195.0,
+   "close": 198.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-08": {
+   "open": 209.0,
+   "high": 249.0,
+   "low": 209.0,
+   "close": 232.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-09": {
+   "open": 232.0,
+   "high": 289.4,
+   "low": 227.6,
+   "close": 288.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-10": {
+   "open": 296.8,
+   "high": 324.0,
+   "low": 286.0,
+   "close": 310.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-13": {
+   "open": 317.2,
+   "high": 382.8,
+   "low": 312.8,
+   "close": 358.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-14": {
+   "open": 372.2,
+   "high": 377.8,
+   "low": 330.0,
+   "close": 341.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-15": {
+   "open": 351.0,
+   "high": 352.0,
+   "low": 303.6,
+   "close": 312.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-16": {
+   "open": 314.0,
+   "high": 353.8,
+   "low": 306.0,
+   "close": 344.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-17": {
+   "open": 349.0,
+   "high": 349.0,
+   "low": 323.2,
+   "close": 325.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-20": {
+   "open": 329.0,
+   "high": 342.0,
+   "low": 315.0,
+   "close": 322.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-21": {
+   "open": 321.0,
+   "high": 331.0,
+   "low": 309.8,
+   "close": 329.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-22": {
+   "open": 331.6,
+   "high": 358.6,
+   "low": 322.8,
+   "close": 342.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-23": {
+   "open": 345.2,
+   "high": 368.0,
+   "low": 333.2,
+   "close": 341.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-24": {
+   "open": 338.4,
+   "high": 341.4,
+   "low": 279.4,
+   "close": 287.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-27": {
+   "open": 300.0,
+   "high": 317.0,
+   "low": 283.0,
+   "close": 305.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-28": {
+   "open": 311.0,
+   "high": 311.0,
+   "low": 256.8,
+   "close": 260.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-29": {
+   "open": 260.0,
+   "high": 272.0,
+   "low": 253.2,
+   "close": 264.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-30": {
+   "open": 270.0,
+   "high": 272.6,
+   "low": 248.8,
+   "close": 252.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-04": {
+   "open": 258.6,
+   "high": 280.0,
+   "low": 255.8,
+   "close": 276.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-05": {
+   "open": 274.0,
+   "high": 274.0,
+   "low": 258.0,
+   "close": 260.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-06": {
+   "open": 263.6,
+   "high": 265.6,
+   "low": 239.2,
+   "close": 244.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-07": {
+   "open": 246.8,
+   "high": 261.6,
+   "low": 228.8,
+   "close": 261.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-08": {
+   "open": 271.0,
+   "high": 280.0,
+   "low": 247.2,
+   "close": 250.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-11": {
+   "open": 255.0,
+   "high": 262.4,
+   "low": 237.8,
+   "close": 246.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-12": {
+   "open": 246.4,
+   "high": 248.0,
+   "low": 225.2,
+   "close": 228.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-13": {
+   "open": 227.8,
+   "high": 289.0,
+   "low": 227.6,
+   "close": 283.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-14": {
+   "open": 286.2,
+   "high": 307.0,
+   "low": 269.6,
+   "close": 279.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-15": {
+   "open": 287.2,
+   "high": 303.6,
+   "low": 260.0,
+   "close": 270.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-18": {
+   "open": 274.6,
+   "high": 290.0,
+   "low": 264.4,
+   "close": 277.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-19": {
+   "open": 277.0,
+   "high": 277.0,
+   "low": 245.6,
+   "close": 250.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-20": {
+   "open": 249.6,
+   "high": 252.8,
+   "low": 234.4,
+   "close": 240.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-21": {
+   "open": 245.2,
+   "high": 253.8,
+   "low": 225.2,
+   "close": 226.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-22": {
+   "open": 231.0,
+   "high": 264.0,
+   "low": 226.4,
+   "close": 241.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-26": {
+   "open": 250.0,
+   "high": 260.0,
+   "low": 230.0,
+   "close": 247.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-27": {
+   "open": 248.0,
+   "high": 257.0,
+   "low": 241.4,
+   "close": 244.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-28": {
+   "open": 249.6,
+   "high": 254.6,
+   "low": 235.4,
+   "close": 243.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-05-29": {
+   "open": 250.0,
+   "high": 254.8,
+   "low": 226.0,
+   "close": 227.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-01": {
+   "open": 231.0,
+   "high": 232.0,
+   "low": 195.2,
+   "close": 197.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-02": {
+   "open": 194.0,
+   "high": 195.8,
+   "low": 184.0,
+   "close": 185.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-03": {
+   "open": 190.0,
+   "high": 199.7,
+   "low": 176.0,
+   "close": 180.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-04": {
+   "open": 180.0,
+   "high": 193.0,
+   "low": 175.6,
+   "close": 188.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-05": {
+   "open": 185.8,
+   "high": 188.0,
+   "low": 163.2,
+   "close": 166.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-08": {
+   "open": 155.0,
+   "high": 174.7,
+   "low": 152.0,
+   "close": 165.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-09": {
+   "open": 165.0,
+   "high": 168.4,
+   "low": 155.0,
+   "close": 157.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-10": {
+   "open": 157.5,
+   "high": 161.9,
+   "low": 147.7,
+   "close": 157.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-11": {
+   "open": 150.1,
+   "high": 160.3,
+   "low": 148.9,
+   "close": 153.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-12": {
+   "open": 158.9,
+   "high": 164.0,
+   "low": 144.0,
+   "close": 147.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-15": {
+   "open": 151.6,
+   "high": 167.3,
+   "low": 149.7,
+   "close": 151.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-16": {
+   "open": 153.3,
+   "high": 153.3,
+   "low": 139.6,
+   "close": 140.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-17": {
+   "open": 139.0,
+   "high": 144.0,
+   "low": 134.1,
+   "close": 136.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-18": {
+   "open": 136.0,
+   "high": 139.1,
+   "low": 130.0,
+   "close": 134.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-22": {
+   "open": 138.9,
+   "high": 143.5,
+   "low": 127.8,
+   "close": 130.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-23": {
+   "open": 130.1,
+   "high": 130.2,
+   "low": 122.3,
+   "close": 124.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-24": {
+   "open": 124.0,
+   "high": 131.9,
+   "low": 116.8,
+   "close": 116.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-25": {
+   "open": 118.6,
+   "high": 118.6,
+   "low": 109.5,
+   "close": 110.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-26": {
+   "open": 109.7,
+   "high": 109.7,
+   "low": 101.4,
+   "close": 103.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-29": {
+   "open": 108.0,
+   "high": 131.4,
+   "low": 108.0,
+   "close": 119.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-06-30": {
+   "open": 118.0,
+   "high": 125.3,
+   "low": 102.2,
+   "close": 121.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-02": {
+   "open": 130.0,
+   "high": 143.1,
+   "low": 123.0,
+   "close": 123.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-03": {
+   "open": 113.1,
+   "high": 126.7,
+   "low": 106.6,
+   "close": 117.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-06": {
+   "open": 120.8,
+   "high": 134.9,
+   "low": 111.7,
+   "close": 113.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-07": {
+   "open": 111.6,
+   "high": 123.0,
+   "low": 108.5,
+   "close": 108.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-08": {
+   "open": 109.3,
+   "high": 115.5,
+   "low": 105.3,
+   "close": 109.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-09": {
+   "open": 110.2,
+   "high": 115.0,
+   "low": 103.0,
+   "close": 106.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-10": {
+   "open": 106.6,
+   "high": 106.6,
+   "low": 88.35,
+   "close": 89.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-13": {
+   "open": 89.45,
+   "high": 90.7,
+   "low": 82.35,
+   "close": 83.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-14": {
+   "open": 86.0,
+   "high": 92.65,
+   "low": 81.15,
+   "close": 90.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-15": {
+   "open": 92.0,
+   "high": 96.75,
+   "low": 89.0,
+   "close": 94.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-16": {
+   "open": 95.4,
+   "high": 107.7,
+   "low": 92.15,
+   "close": 99.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-17": {
+   "open": 100.0,
+   "high": 104.1,
+   "low": 88.5,
+   "close": 91.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-20": {
+   "open": 94.0,
+   "high": 110.8,
+   "low": 93.5,
+   "close": 107.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-21": {
+   "open": 110.8,
+   "high": 132.8,
+   "low": 105.5,
+   "close": 126.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-22": {
+   "open": 130.0,
+   "high": 131.1,
+   "low": 120.5,
+   "close": 123.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-23": {
+   "open": 126.9,
+   "high": 140.2,
+   "low": 121.1,
+   "close": 140.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-24": {
+   "open": 140.5,
+   "high": 147.2,
+   "low": 119.2,
+   "close": 122.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-27": {
+   "open": 125.0,
+   "high": 129.8,
+   "low": 116.6,
+   "close": 121.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-28": {
+   "open": 116.7,
+   "high": 122.4,
+   "low": 106.2,
+   "close": 108.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-29": {
+   "open": 105.2,
+   "high": 110.5,
+   "low": 97.5,
+   "close": 103.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-30": {
+   "open": 104.5,
+   "high": 108.0,
+   "low": 95.4,
+   "close": 97.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-07-31": {
+   "open": 108.0,
+   "high": 109.7,
+   "low": 99.15,
+   "close": 103.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-03": {
+   "open": 119.0,
+   "high": 130.7,
+   "low": 113.5,
+   "close": 117.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-04": {
+   "open": 123.0,
+   "high": 143.6,
+   "low": 121.5,
+   "close": 138.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-05": {
+   "open": 140.5,
+   "high": 149.5,
+   "low": 134.8,
+   "close": 136.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-06": {
+   "open": 134.0,
+   "high": 138.7,
+   "low": 127.4,
+   "close": 129.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-07": {
+   "open": 131.3,
+   "high": 140.5,
+   "low": 128.0,
+   "close": 131.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-10": {
+   "open": 138.0,
+   "high": 143.3,
+   "low": 133.0,
+   "close": 142.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-11": {
+   "open": 142.0,
+   "high": 142.0,
+   "low": 133.3,
+   "close": 133.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-12": {
+   "open": 134.5,
+   "high": 137.7,
+   "low": 130.3,
+   "close": 135.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-13": {
+   "open": 136.0,
+   "high": 139.6,
+   "low": 130.3,
+   "close": 130.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-08-14": {
+   "open": 132.8,
+   "high": 142.8,
+   "low": 130.9,
+   "close": 138.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  }
+ }
+}

--- a/memory/bars/07226.json
+++ b/memory/bars/07226.json
@@ -7,6 +7,906 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 5.36,
+   "high": 5.465,
+   "low": 5.305,
+   "close": 5.405,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-02": {
+   "open": 5.48,
+   "high": 5.51,
+   "low": 5.33,
+   "close": 5.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-03": {
+   "open": 5.33,
+   "high": 5.34,
+   "low": 5.185,
+   "close": 5.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-04": {
+   "open": 5.235,
+   "high": 5.42,
+   "low": 5.15,
+   "close": 5.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-05": {
+   "open": 5.31,
+   "high": 5.5,
+   "low": 5.235,
+   "close": 5.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-08": {
+   "open": 5.45,
+   "high": 5.53,
+   "low": 5.415,
+   "close": 5.435,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-09": {
+   "open": 5.46,
+   "high": 5.46,
+   "low": 5.215,
+   "close": 5.225,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-10": {
+   "open": 5.23,
+   "high": 5.295,
+   "low": 5.135,
+   "close": 5.275,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-11": {
+   "open": 5.335,
+   "high": 5.365,
+   "low": 5.16,
+   "close": 5.185,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-12": {
+   "open": 5.305,
+   "high": 5.4,
+   "low": 5.225,
+   "close": 5.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-15": {
+   "open": 5.26,
+   "high": 5.28,
+   "low": 5.105,
+   "close": 5.125,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-16": {
+   "open": 5.06,
+   "high": 5.09,
+   "low": 4.846,
+   "close": 4.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-17": {
+   "open": 4.94,
+   "high": 5.08,
+   "low": 4.904,
+   "close": 5.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-18": {
+   "open": 4.936,
+   "high": 4.99,
+   "low": 4.864,
+   "close": 4.958,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-19": {
+   "open": 5.04,
+   "high": 5.125,
+   "low": 4.986,
+   "close": 5.065,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-22": {
+   "open": 5.12,
+   "high": 5.205,
+   "low": 5.1,
+   "close": 5.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-23": {
+   "open": 5.165,
+   "high": 5.165,
+   "low": 5.04,
+   "close": 5.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-24": {
+   "open": 5.07,
+   "high": 5.145,
+   "low": 5.07,
+   "close": 5.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-29": {
+   "open": 5.095,
+   "high": 5.32,
+   "low": 5.055,
+   "close": 5.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-30": {
+   "open": 5.085,
+   "high": 5.275,
+   "low": 5.085,
+   "close": 5.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-31": {
+   "open": 5.205,
+   "high": 5.23,
+   "low": 5.065,
+   "close": 5.105,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-02": {
+   "open": 5.155,
+   "high": 5.56,
+   "low": 5.14,
+   "close": 5.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-05": {
+   "open": 5.555,
+   "high": 5.615,
+   "low": 5.455,
+   "close": 5.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-06": {
+   "open": 5.62,
+   "high": 5.795,
+   "low": 5.62,
+   "close": 5.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-07": {
+   "open": 5.65,
+   "high": 5.675,
+   "low": 5.435,
+   "close": 5.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-08": {
+   "open": 5.48,
+   "high": 5.48,
+   "low": 5.3,
+   "close": 5.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-09": {
+   "open": 5.46,
+   "high": 5.535,
+   "low": 5.385,
+   "close": 5.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-12": {
+   "open": 5.515,
+   "high": 5.765,
+   "low": 5.445,
+   "close": 5.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-13": {
+   "open": 5.96,
+   "high": 6.03,
+   "low": 5.695,
+   "close": 5.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-14": {
+   "open": 5.8,
+   "high": 5.965,
+   "low": 5.7,
+   "close": 5.815,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-15": {
+   "open": 5.79,
+   "high": 5.835,
+   "low": 5.605,
+   "close": 5.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-16": {
+   "open": 5.78,
+   "high": 5.81,
+   "low": 5.615,
+   "close": 5.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-19": {
+   "open": 5.575,
+   "high": 5.635,
+   "low": 5.515,
+   "close": 5.525,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-20": {
+   "open": 5.51,
+   "high": 5.56,
+   "low": 5.365,
+   "close": 5.395,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-21": {
+   "open": 5.34,
+   "high": 5.595,
+   "low": 5.325,
+   "close": 5.515,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-22": {
+   "open": 5.6,
+   "high": 5.625,
+   "low": 5.45,
+   "close": 5.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-23": {
+   "open": 5.645,
+   "high": 5.65,
+   "low": 5.53,
+   "close": 5.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-26": {
+   "open": 5.59,
+   "high": 5.59,
+   "low": 5.39,
+   "close": 5.455,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-27": {
+   "open": 5.47,
+   "high": 5.55,
+   "low": 5.375,
+   "close": 5.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-28": {
+   "open": 5.555,
+   "high": 5.795,
+   "low": 5.55,
+   "close": 5.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-29": {
+   "open": 5.7,
+   "high": 5.78,
+   "low": 5.605,
+   "close": 5.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-30": {
+   "open": 5.57,
+   "high": 5.6,
+   "low": 5.43,
+   "close": 5.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-02": {
+   "open": 5.33,
+   "high": 5.33,
+   "low": 4.962,
+   "close": 5.095,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-03": {
+   "open": 5.155,
+   "high": 5.17,
+   "low": 4.724,
+   "close": 4.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-04": {
+   "open": 4.858,
+   "high": 4.898,
+   "low": 4.692,
+   "close": 4.764,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-05": {
+   "open": 4.634,
+   "high": 4.862,
+   "low": 4.596,
+   "close": 4.822,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-06": {
+   "open": 4.616,
+   "high": 4.82,
+   "low": 4.602,
+   "close": 4.728,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-09": {
+   "open": 4.91,
+   "high": 4.924,
+   "low": 4.812,
+   "close": 4.844,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-10": {
+   "open": 4.916,
+   "high": 5.035,
+   "low": 4.894,
+   "close": 4.898,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-11": {
+   "open": 4.93,
+   "high": 5.035,
+   "low": 4.91,
+   "close": 4.978,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-12": {
+   "open": 4.948,
+   "high": 4.95,
+   "low": 4.804,
+   "close": 4.828,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-13": {
+   "open": 4.68,
+   "high": 4.778,
+   "low": 4.652,
+   "close": 4.734,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-16": {
+   "open": 4.702,
+   "high": 4.75,
+   "low": 4.544,
+   "close": 4.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-20": {
+   "open": 4.678,
+   "high": 4.726,
+   "low": 4.476,
+   "close": 4.478,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-23": {
+   "open": 4.612,
+   "high": 4.822,
+   "low": 4.612,
+   "close": 4.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-24": {
+   "open": 4.674,
+   "high": 4.674,
+   "low": 4.492,
+   "close": 4.552,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-25": {
+   "open": 4.62,
+   "high": 4.646,
+   "low": 4.516,
+   "close": 4.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-26": {
+   "open": 4.58,
+   "high": 4.58,
+   "low": 4.27,
+   "close": 4.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-27": {
+   "open": 4.278,
+   "high": 4.396,
+   "low": 4.254,
+   "close": 4.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-02": {
+   "open": 4.184,
+   "high": 4.234,
+   "low": 4.028,
+   "close": 4.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-03": {
+   "open": 4.106,
+   "high": 4.128,
+   "low": 3.852,
+   "close": 3.864,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-04": {
+   "open": 3.772,
+   "high": 3.882,
+   "low": 3.672,
+   "close": 3.798,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-05": {
+   "open": 3.916,
+   "high": 3.93,
+   "low": 3.704,
+   "close": 3.754,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-06": {
+   "open": 3.772,
+   "high": 4.03,
+   "low": 3.742,
+   "close": 3.978,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-09": {
+   "open": 3.644,
+   "high": 3.976,
+   "low": 3.644,
+   "close": 3.954,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-10": {
+   "open": 4.12,
+   "high": 4.164,
+   "low": 3.998,
+   "close": 4.158,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-11": {
+   "open": 4.23,
+   "high": 4.268,
+   "low": 4.126,
+   "close": 4.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-12": {
+   "open": 4.108,
+   "high": 4.204,
+   "low": 4.01,
+   "close": 4.116,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-13": {
+   "open": 4.086,
+   "high": 4.14,
+   "low": 3.998,
+   "close": 4.014,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-16": {
+   "open": 4.04,
+   "high": 4.268,
+   "low": 3.958,
+   "close": 4.234,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-17": {
+   "open": 4.29,
+   "high": 4.446,
+   "low": 4.21,
+   "close": 4.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-18": {
+   "open": 4.27,
+   "high": 4.288,
+   "low": 4.15,
+   "close": 4.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-19": {
+   "open": 4.032,
+   "high": 4.174,
+   "low": 4.018,
+   "close": 4.042,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-20": {
+   "open": 3.978,
+   "high": 4.058,
+   "low": 3.794,
+   "close": 3.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-23": {
+   "open": 3.708,
+   "high": 3.748,
+   "low": 3.51,
+   "close": 3.588,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-24": {
+   "open": 3.682,
+   "high": 3.786,
+   "low": 3.566,
+   "close": 3.768,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-25": {
+   "open": 3.856,
+   "high": 3.956,
+   "low": 3.728,
+   "close": 3.912,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-26": {
+   "open": 3.852,
+   "high": 3.87,
+   "low": 3.624,
+   "close": 3.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-27": {
+   "open": 3.624,
+   "high": 3.77,
+   "low": 3.59,
+   "close": 3.682,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-30": {
+   "open": 3.494,
+   "high": 3.598,
+   "low": 3.43,
+   "close": 3.542,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-31": {
+   "open": 3.548,
+   "high": 3.618,
+   "low": 3.442,
+   "close": 3.478,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-01": {
+   "open": 3.664,
+   "high": 3.686,
+   "low": 3.566,
+   "close": 3.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-02": {
+   "open": 3.598,
+   "high": 3.61,
+   "low": 3.446,
+   "close": 3.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-08": {
+   "open": 3.782,
+   "high": 3.912,
+   "low": 3.726,
+   "close": 3.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-09": {
+   "open": 3.814,
+   "high": 3.838,
+   "low": 3.708,
+   "close": 3.724,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-10": {
+   "open": 3.768,
+   "high": 3.91,
+   "low": 3.764,
+   "close": 3.786,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-13": {
+   "open": 3.73,
+   "high": 3.764,
+   "low": 3.686,
+   "close": 3.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-14": {
+   "open": 3.83,
+   "high": 3.854,
+   "low": 3.706,
+   "close": 3.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-15": {
+   "open": 3.95,
+   "high": 3.97,
+   "low": 3.864,
+   "close": 3.874,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-16": {
+   "open": 3.976,
+   "high": 4.166,
+   "low": 3.972,
+   "close": 4.164,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-17": {
+   "open": 4.086,
+   "high": 4.122,
+   "low": 4.006,
+   "close": 4.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-20": {
+   "open": 4.1,
+   "high": 4.172,
+   "low": 4.042,
+   "close": 4.102,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-21": {
+   "open": 4.15,
+   "high": 4.15,
+   "low": 4.032,
+   "close": 4.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-22": {
+   "open": 4.014,
+   "high": 4.014,
+   "low": 3.91,
+   "close": 3.944,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-23": {
+   "open": 3.95,
+   "high": 3.95,
+   "low": 3.76,
+   "close": 3.778,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-24": {
+   "open": 3.72,
+   "high": 3.854,
+   "low": 3.65,
+   "close": 3.836,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-27": {
+   "open": 3.868,
+   "high": 3.946,
+   "low": 3.828,
+   "close": 3.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-28": {
+   "open": 3.874,
+   "high": 3.884,
+   "low": 3.694,
+   "close": 3.714,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-29": {
+   "open": 3.79,
+   "high": 3.86,
+   "low": 3.756,
+   "close": 3.842,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-30": {
+   "open": 3.8,
+   "high": 3.82,
+   "low": 3.71,
+   "close": 3.792,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
   "2026-05-04": {
    "open": 3.908,
    "high": 4.066,
@@ -645,6 +1545,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 3.514,
+   "high": 3.518,
+   "low": 3.4,
+   "close": 3.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
   }
  },
  "retired": false

--- a/memory/bars/07709.json
+++ b/memory/bars/07709.json
@@ -8,6 +8,906 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 11.13,
+   "high": 11.69,
+   "low": 11.06,
+   "close": 11.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-02": {
+   "open": 12.14,
+   "high": 12.31,
+   "low": 11.97,
+   "close": 12.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-03": {
+   "open": 12.23,
+   "high": 12.28,
+   "low": 11.94,
+   "close": 12.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-04": {
+   "open": 11.27,
+   "high": 11.6,
+   "low": 11.12,
+   "close": 11.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-05": {
+   "open": 11.49,
+   "high": 11.7,
+   "low": 11.12,
+   "close": 11.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-08": {
+   "open": 11.56,
+   "high": 13.15,
+   "low": 11.41,
+   "close": 12.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-09": {
+   "open": 12.77,
+   "high": 12.77,
+   "low": 12.43,
+   "close": 12.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-10": {
+   "open": 13.14,
+   "high": 13.56,
+   "low": 13.05,
+   "close": 13.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-11": {
+   "open": 13.52,
+   "high": 13.52,
+   "low": 12.32,
+   "close": 12.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-12": {
+   "open": 12.88,
+   "high": 13.07,
+   "low": 12.45,
+   "close": 12.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-15": {
+   "open": 12.03,
+   "high": 12.3,
+   "low": 11.73,
+   "close": 11.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-16": {
+   "open": 11.6,
+   "high": 11.6,
+   "low": 10.8,
+   "close": 10.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-17": {
+   "open": 11.18,
+   "high": 11.8,
+   "low": 10.95,
+   "close": 11.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-18": {
+   "open": 11.8,
+   "high": 12.12,
+   "low": 11.68,
+   "close": 11.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-19": {
+   "open": 12.2,
+   "high": 12.43,
+   "low": 11.6,
+   "close": 11.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-22": {
+   "open": 12.6,
+   "high": 13.13,
+   "low": 12.6,
+   "close": 12.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-23": {
+   "open": 13.33,
+   "high": 13.4,
+   "low": 13.0,
+   "close": 13.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-24": {
+   "open": 13.35,
+   "high": 13.49,
+   "low": 13.3,
+   "close": 13.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-29": {
+   "open": 15.32,
+   "high": 15.67,
+   "low": 14.83,
+   "close": 15.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-30": {
+   "open": 16.5,
+   "high": 16.58,
+   "low": 15.86,
+   "close": 16.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-31": {
+   "open": 16.3,
+   "high": 16.3,
+   "low": 15.9,
+   "close": 16.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-02": {
+   "open": 16.15,
+   "high": 17.62,
+   "low": 16.15,
+   "close": 17.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-05": {
+   "open": 18.0,
+   "high": 18.64,
+   "low": 18.0,
+   "close": 18.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-06": {
+   "open": 17.75,
+   "high": 19.99,
+   "low": 17.55,
+   "close": 19.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-07": {
+   "open": 21.38,
+   "high": 21.8,
+   "low": 20.22,
+   "close": 20.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-08": {
+   "open": 23.0,
+   "high": 23.34,
+   "low": 21.22,
+   "close": 21.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-09": {
+   "open": 20.22,
+   "high": 21.5,
+   "low": 20.22,
+   "close": 20.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-12": {
+   "open": 21.64,
+   "high": 21.76,
+   "low": 20.26,
+   "close": 21.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-13": {
+   "open": 21.0,
+   "high": 21.0,
+   "low": 19.8,
+   "close": 20.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-14": {
+   "open": 20.7,
+   "high": 20.9,
+   "low": 19.9,
+   "close": 20.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-15": {
+   "open": 20.6,
+   "high": 21.66,
+   "low": 20.04,
+   "close": 21.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-16": {
+   "open": 21.8,
+   "high": 22.0,
+   "low": 21.12,
+   "close": 21.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-19": {
+   "open": 21.56,
+   "high": 22.5,
+   "low": 21.56,
+   "close": 21.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-20": {
+   "open": 20.58,
+   "high": 21.56,
+   "low": 20.44,
+   "close": 20.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-21": {
+   "open": 21.12,
+   "high": 21.38,
+   "low": 20.1,
+   "close": 20.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-22": {
+   "open": 21.7,
+   "high": 22.08,
+   "low": 21.1,
+   "close": 21.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-23": {
+   "open": 21.24,
+   "high": 22.5,
+   "low": 20.68,
+   "close": 21.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-26": {
+   "open": 20.9,
+   "high": 21.22,
+   "low": 20.14,
+   "close": 20.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-27": {
+   "open": 21.78,
+   "high": 23.94,
+   "low": 21.68,
+   "close": 23.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-28": {
+   "open": 25.78,
+   "high": 28.4,
+   "low": 24.9,
+   "close": 28.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-29": {
+   "open": 25.2,
+   "high": 28.14,
+   "low": 25.18,
+   "close": 27.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-30": {
+   "open": 31.06,
+   "high": 31.64,
+   "low": 29.44,
+   "close": 29.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-02": {
+   "open": 28.34,
+   "high": 28.42,
+   "low": 24.3,
+   "close": 25.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-03": {
+   "open": 29.06,
+   "high": 30.16,
+   "low": 28.2,
+   "close": 29.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-04": {
+   "open": 28.46,
+   "high": 29.6,
+   "low": 28.46,
+   "close": 29.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-05": {
+   "open": 27.1,
+   "high": 27.5,
+   "low": 25.0,
+   "close": 25.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-06": {
+   "open": 23.46,
+   "high": 25.86,
+   "low": 22.82,
+   "close": 25.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-09": {
+   "open": 27.92,
+   "high": 28.2,
+   "low": 27.14,
+   "close": 27.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-10": {
+   "open": 28.06,
+   "high": 28.36,
+   "low": 27.28,
+   "close": 27.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-11": {
+   "open": 26.8,
+   "high": 27.0,
+   "low": 26.1,
+   "close": 26.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-12": {
+   "open": 27.94,
+   "high": 29.28,
+   "low": 27.28,
+   "close": 28.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-13": {
+   "open": 27.6,
+   "high": 28.68,
+   "low": 27.12,
+   "close": 27.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-16": {
+   "open": 27.6,
+   "high": 28.64,
+   "low": 27.02,
+   "close": 28.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-20": {
+   "open": 28.2,
+   "high": 32.0,
+   "low": 27.9,
+   "close": 31.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-23": {
+   "open": 33.12,
+   "high": 33.12,
+   "low": 31.04,
+   "close": 32.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-24": {
+   "open": 33.62,
+   "high": 35.64,
+   "low": 33.62,
+   "close": 35.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-25": {
+   "open": 36.62,
+   "high": 37.76,
+   "low": 35.9,
+   "close": 37.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-26": {
+   "open": 37.74,
+   "high": 43.06,
+   "low": 36.88,
+   "close": 42.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-27": {
+   "open": 38.78,
+   "high": 42.0,
+   "low": 38.32,
+   "close": 39.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-02": {
+   "open": 37.7,
+   "high": 39.52,
+   "low": 36.5,
+   "close": 36.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-03": {
+   "open": 36.8,
+   "high": 37.12,
+   "low": 28.42,
+   "close": 31.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-04": {
+   "open": 28.26,
+   "high": 29.68,
+   "low": 24.32,
+   "close": 25.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-05": {
+   "open": 28.84,
+   "high": 31.76,
+   "low": 28.84,
+   "close": 29.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-06": {
+   "open": 26.8,
+   "high": 28.92,
+   "low": 26.42,
+   "close": 28.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-09": {
+   "open": 24.2,
+   "high": 24.56,
+   "low": 17.0,
+   "close": 23.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-10": {
+   "open": 27.22,
+   "high": 29.2,
+   "low": 26.94,
+   "close": 28.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-11": {
+   "open": 30.0,
+   "high": 31.24,
+   "low": 28.4,
+   "close": 28.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-12": {
+   "open": 28.78,
+   "high": 29.54,
+   "low": 27.44,
+   "close": 28.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-13": {
+   "open": 26.8,
+   "high": 27.74,
+   "low": 26.22,
+   "close": 26.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-16": {
+   "open": 28.4,
+   "high": 30.58,
+   "low": 27.62,
+   "close": 29.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-17": {
+   "open": 31.64,
+   "high": 32.18,
+   "low": 29.6,
+   "close": 30.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-18": {
+   "open": 32.66,
+   "high": 35.82,
+   "low": 32.18,
+   "close": 35.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-19": {
+   "open": 32.5,
+   "high": 34.68,
+   "low": 31.96,
+   "close": 32.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-20": {
+   "open": 32.56,
+   "high": 33.32,
+   "low": 31.48,
+   "close": 31.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-23": {
+   "open": 28.12,
+   "high": 28.94,
+   "low": 26.66,
+   "close": 27.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-24": {
+   "open": 28.56,
+   "high": 31.06,
+   "low": 27.64,
+   "close": 30.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-25": {
+   "open": 33.54,
+   "high": 33.86,
+   "low": 30.54,
+   "close": 31.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-26": {
+   "open": 28.52,
+   "high": 28.72,
+   "low": 26.8,
+   "close": 27.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-27": {
+   "open": 25.0,
+   "high": 27.14,
+   "low": 24.58,
+   "close": 26.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-30": {
+   "open": 23.18,
+   "high": 24.18,
+   "low": 23.1,
+   "close": 23.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-31": {
+   "open": 20.78,
+   "high": 22.46,
+   "low": 19.84,
+   "close": 20.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-01": {
+   "open": 23.36,
+   "high": 24.84,
+   "low": 23.22,
+   "close": 24.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-02": {
+   "open": 23.2,
+   "high": 23.2,
+   "low": 20.1,
+   "close": 21.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-08": {
+   "open": 24.42,
+   "high": 32.26,
+   "low": 24.42,
+   "close": 31.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-09": {
+   "open": 29.5,
+   "high": 30.0,
+   "low": 28.4,
+   "close": 28.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-10": {
+   "open": 31.14,
+   "high": 31.58,
+   "low": 30.04,
+   "close": 30.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-13": {
+   "open": 30.7,
+   "high": 31.46,
+   "low": 30.3,
+   "close": 31.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-14": {
+   "open": 35.76,
+   "high": 36.32,
+   "low": 34.74,
+   "close": 35.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-15": {
+   "open": 39.4,
+   "high": 39.42,
+   "low": 36.8,
+   "close": 36.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-16": {
+   "open": 38.48,
+   "high": 38.94,
+   "low": 37.54,
+   "close": 38.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-17": {
+   "open": 37.78,
+   "high": 37.94,
+   "low": 36.1,
+   "close": 37.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-20": {
+   "open": 38.72,
+   "high": 39.6,
+   "low": 38.66,
+   "close": 39.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-21": {
+   "open": 42.62,
+   "high": 43.14,
+   "low": 41.44,
+   "close": 42.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-22": {
+   "open": 41.82,
+   "high": 43.22,
+   "low": 40.74,
+   "close": 43.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-23": {
+   "open": 43.36,
+   "high": 44.0,
+   "low": 39.84,
+   "close": 42.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-24": {
+   "open": 42.46,
+   "high": 43.12,
+   "low": 40.9,
+   "close": 42.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-27": {
+   "open": 46.6,
+   "high": 49.0,
+   "low": 46.6,
+   "close": 47.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-28": {
+   "open": 49.82,
+   "high": 50.1,
+   "low": 47.06,
+   "close": 47.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-29": {
+   "open": 48.0,
+   "high": 48.4,
+   "low": 46.88,
+   "close": 47.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-30": {
+   "open": 48.52,
+   "high": 48.98,
+   "low": 46.6,
+   "close": 47.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
   "2026-05-04": {
    "open": 52.76,
    "high": 59.2,
@@ -646,6 +1546,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:06+08:00"
+  },
+  "2026-08-14": {
+   "open": 36.88,
+   "high": 37.56,
+   "low": 36.08,
+   "close": 36.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
   }
  }
 }

--- a/memory/bars/07747.json
+++ b/memory/bars/07747.json
@@ -8,6 +8,906 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 24.7,
+   "high": 24.7,
+   "low": 23.54,
+   "close": 23.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-02": {
+   "open": 24.8,
+   "high": 25.2,
+   "low": 24.6,
+   "close": 25.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-03": {
+   "open": 25.5,
+   "high": 26.38,
+   "low": 25.5,
+   "close": 25.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-04": {
+   "open": 25.92,
+   "high": 26.04,
+   "low": 25.06,
+   "close": 25.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-05": {
+   "open": 26.64,
+   "high": 27.5,
+   "low": 26.64,
+   "close": 27.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-08": {
+   "open": 27.8,
+   "high": 28.6,
+   "low": 27.52,
+   "close": 28.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-09": {
+   "open": 28.14,
+   "high": 28.14,
+   "low": 27.04,
+   "close": 27.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-10": {
+   "open": 27.4,
+   "high": 27.86,
+   "low": 26.22,
+   "close": 27.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-11": {
+   "open": 28.0,
+   "high": 28.2,
+   "low": 26.8,
+   "close": 27.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-12": {
+   "open": 27.5,
+   "high": 27.68,
+   "low": 26.86,
+   "close": 27.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-15": {
+   "open": 27.0,
+   "high": 27.0,
+   "low": 25.52,
+   "close": 25.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-16": {
+   "open": 25.68,
+   "high": 25.68,
+   "low": 24.4,
+   "close": 24.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-17": {
+   "open": 24.5,
+   "high": 26.96,
+   "low": 24.5,
+   "close": 26.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-18": {
+   "open": 26.3,
+   "high": 27.08,
+   "low": 25.76,
+   "close": 27.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-19": {
+   "open": 27.04,
+   "high": 27.18,
+   "low": 26.24,
+   "close": 26.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-22": {
+   "open": 27.7,
+   "high": 28.4,
+   "low": 27.7,
+   "close": 28.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-23": {
+   "open": 28.8,
+   "high": 29.24,
+   "low": 28.58,
+   "close": 28.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-24": {
+   "open": 28.98,
+   "high": 28.98,
+   "low": 28.7,
+   "close": 28.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-29": {
+   "open": 32.94,
+   "high": 33.2,
+   "low": 32.28,
+   "close": 32.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-30": {
+   "open": 34.0,
+   "high": 34.06,
+   "low": 33.16,
+   "close": 33.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-31": {
+   "open": 33.44,
+   "high": 33.58,
+   "low": 33.18,
+   "close": 33.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-02": {
+   "open": 34.76,
+   "high": 38.14,
+   "low": 34.76,
+   "close": 38.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-05": {
+   "open": 41.18,
+   "high": 44.24,
+   "low": 41.18,
+   "close": 44.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-06": {
+   "open": 41.22,
+   "high": 44.7,
+   "low": 41.18,
+   "close": 44.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-07": {
+   "open": 46.36,
+   "high": 46.78,
+   "low": 43.74,
+   "close": 45.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-08": {
+   "open": 46.0,
+   "high": 47.18,
+   "low": 43.96,
+   "close": 44.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-09": {
+   "open": 42.3,
+   "high": 45.16,
+   "low": 42.26,
+   "close": 44.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-12": {
+   "open": 45.08,
+   "high": 45.38,
+   "low": 42.62,
+   "close": 43.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-13": {
+   "open": 44.02,
+   "high": 44.02,
+   "low": 42.56,
+   "close": 43.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-14": {
+   "open": 43.92,
+   "high": 44.78,
+   "low": 43.5,
+   "close": 44.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-15": {
+   "open": 45.0,
+   "high": 47.56,
+   "low": 44.3,
+   "close": 47.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-16": {
+   "open": 50.04,
+   "high": 51.28,
+   "low": 49.46,
+   "close": 51.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-19": {
+   "open": 50.9,
+   "high": 51.42,
+   "low": 49.8,
+   "close": 50.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-20": {
+   "open": 48.0,
+   "high": 49.58,
+   "low": 47.2,
+   "close": 47.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-21": {
+   "open": 50.42,
+   "high": 50.76,
+   "low": 48.34,
+   "close": 50.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-22": {
+   "open": 53.9,
+   "high": 54.92,
+   "low": 51.42,
+   "close": 53.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-23": {
+   "open": 54.08,
+   "high": 54.6,
+   "low": 50.7,
+   "close": 52.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-26": {
+   "open": 52.88,
+   "high": 53.16,
+   "low": 51.8,
+   "close": 52.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-27": {
+   "open": 53.24,
+   "high": 58.06,
+   "low": 53.14,
+   "close": 57.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-28": {
+   "open": 60.0,
+   "high": 62.64,
+   "low": 57.82,
+   "close": 62.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-29": {
+   "open": 56.56,
+   "high": 59.68,
+   "low": 56.56,
+   "close": 58.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-30": {
+   "open": 61.9,
+   "high": 62.22,
+   "low": 58.04,
+   "close": 58.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-02": {
+   "open": 56.18,
+   "high": 56.2,
+   "low": 49.74,
+   "close": 51.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-03": {
+   "open": 58.0,
+   "high": 62.66,
+   "low": 56.38,
+   "close": 61.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-04": {
+   "open": 59.6,
+   "high": 63.7,
+   "low": 59.6,
+   "close": 63.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-05": {
+   "open": 60.14,
+   "high": 60.14,
+   "low": 55.4,
+   "close": 57.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-06": {
+   "open": 51.9,
+   "high": 56.6,
+   "low": 51.32,
+   "close": 55.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-09": {
+   "open": 60.96,
+   "high": 61.84,
+   "low": 60.0,
+   "close": 60.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-10": {
+   "open": 61.38,
+   "high": 61.48,
+   "low": 60.28,
+   "close": 60.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-11": {
+   "open": 60.38,
+   "high": 62.36,
+   "low": 59.92,
+   "close": 61.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-12": {
+   "open": 66.76,
+   "high": 71.0,
+   "low": 66.52,
+   "close": 70.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-13": {
+   "open": 71.4,
+   "high": 74.12,
+   "low": 70.3,
+   "close": 72.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-16": {
+   "open": 72.24,
+   "high": 75.78,
+   "low": 71.28,
+   "close": 75.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-20": {
+   "open": 79.2,
+   "high": 79.78,
+   "low": 77.5,
+   "close": 79.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-23": {
+   "open": 82.54,
+   "high": 83.04,
+   "low": 78.82,
+   "close": 81.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-24": {
+   "open": 82.56,
+   "high": 88.38,
+   "low": 82.56,
+   "close": 88.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-25": {
+   "open": 89.1,
+   "high": 92.58,
+   "low": 89.1,
+   "close": 91.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-26": {
+   "open": 99.5,
+   "high": 106.15,
+   "low": 97.22,
+   "close": 106.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-27": {
+   "open": 99.5,
+   "high": 107.55,
+   "low": 97.04,
+   "close": 104.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-02": {
+   "open": 100.35,
+   "high": 103.75,
+   "low": 97.2,
+   "close": 97.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-03": {
+   "open": 96.96,
+   "high": 97.02,
+   "low": 79.94,
+   "close": 82.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-04": {
+   "open": 77.8,
+   "high": 77.8,
+   "low": 61.0,
+   "close": 67.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-05": {
+   "open": 77.04,
+   "high": 81.48,
+   "low": 73.52,
+   "close": 76.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-06": {
+   "open": 69.64,
+   "high": 74.38,
+   "low": 68.22,
+   "close": 72.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-09": {
+   "open": 61.64,
+   "high": 64.08,
+   "low": 57.0,
+   "close": 63.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-10": {
+   "open": 72.84,
+   "high": 74.72,
+   "low": 69.18,
+   "close": 72.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-11": {
+   "open": 75.04,
+   "high": 76.7,
+   "low": 71.32,
+   "close": 72.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-12": {
+   "open": 71.64,
+   "high": 72.4,
+   "low": 69.9,
+   "close": 72.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-13": {
+   "open": 68.48,
+   "high": 70.18,
+   "low": 67.64,
+   "close": 68.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-16": {
+   "open": 69.78,
+   "high": 73.12,
+   "low": 68.22,
+   "close": 73.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-17": {
+   "open": 77.64,
+   "high": 78.68,
+   "low": 74.26,
+   "close": 74.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-18": {
+   "open": 84.56,
+   "high": 87.88,
+   "low": 83.34,
+   "close": 86.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-19": {
+   "open": 80.68,
+   "high": 84.26,
+   "low": 79.62,
+   "close": 80.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-20": {
+   "open": 80.64,
+   "high": 81.88,
+   "low": 78.5,
+   "close": 79.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-23": {
+   "open": 71.04,
+   "high": 72.5,
+   "low": 67.6,
+   "close": 67.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-24": {
+   "open": 69.0,
+   "high": 74.08,
+   "low": 68.24,
+   "close": 73.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-25": {
+   "open": 76.0,
+   "high": 76.48,
+   "low": 70.5,
+   "close": 71.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-26": {
+   "open": 66.4,
+   "high": 66.6,
+   "low": 63.18,
+   "close": 64.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-27": {
+   "open": 59.5,
+   "high": 65.2,
+   "low": 58.64,
+   "close": 63.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-30": {
+   "open": 59.0,
+   "high": 61.88,
+   "low": 58.62,
+   "close": 61.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-31": {
+   "open": 56.96,
+   "high": 60.3,
+   "low": 54.12,
+   "close": 55.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-01": {
+   "open": 63.3,
+   "high": 70.96,
+   "low": 63.3,
+   "close": 69.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-02": {
+   "open": 69.42,
+   "high": 69.42,
+   "low": 59.44,
+   "close": 62.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-08": {
+   "open": 72.1,
+   "high": 87.0,
+   "low": 72.1,
+   "close": 84.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-09": {
+   "open": 79.62,
+   "high": 80.12,
+   "low": 77.9,
+   "close": 79.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-10": {
+   "open": 83.7,
+   "high": 84.36,
+   "low": 80.16,
+   "close": 80.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-13": {
+   "open": 78.4,
+   "high": 78.44,
+   "low": 75.9,
+   "close": 77.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-14": {
+   "open": 82.32,
+   "high": 83.7,
+   "low": 80.5,
+   "close": 81.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-15": {
+   "open": 87.68,
+   "high": 87.7,
+   "low": 82.76,
+   "close": 83.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-16": {
+   "open": 85.18,
+   "high": 90.0,
+   "low": 85.18,
+   "close": 89.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-17": {
+   "open": 88.48,
+   "high": 89.96,
+   "low": 87.2,
+   "close": 88.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-20": {
+   "open": 88.52,
+   "high": 90.48,
+   "low": 86.68,
+   "close": 87.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-21": {
+   "open": 90.0,
+   "high": 90.78,
+   "low": 88.16,
+   "close": 90.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-22": {
+   "open": 89.98,
+   "high": 89.98,
+   "low": 87.54,
+   "close": 89.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-23": {
+   "open": 97.88,
+   "high": 98.26,
+   "low": 87.72,
+   "close": 92.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-24": {
+   "open": 90.8,
+   "high": 91.62,
+   "low": 88.2,
+   "close": 90.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-27": {
+   "open": 93.6,
+   "high": 95.92,
+   "low": 92.32,
+   "close": 93.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-28": {
+   "open": 95.14,
+   "high": 95.56,
+   "low": 91.3,
+   "close": 91.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-29": {
+   "open": 90.36,
+   "high": 96.9,
+   "low": 89.6,
+   "close": 94.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-30": {
+   "open": 96.64,
+   "high": 96.64,
+   "low": 90.68,
+   "close": 92.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
   "2026-05-04": {
    "open": 96.2,
    "high": 102.85,
@@ -646,6 +1546,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-13T21:34:07+08:00"
+  },
+  "2026-08-14": {
+   "open": 81.54,
+   "high": 85.58,
+   "low": 80.6,
+   "close": 85.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
   }
  }
 }

--- a/memory/bars/CRCL.json
+++ b/memory/bars/CRCL.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 77.49,
+   "high": 79.84,
+   "low": 75.23,
+   "close": 75.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-02": {
+   "open": 78.4,
+   "high": 80.73,
+   "low": 77.18,
+   "close": 77.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-03": {
+   "open": 78.39,
+   "high": 86.59,
+   "low": 75.97,
+   "close": 86.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-04": {
+   "open": 83.98,
+   "high": 88.27,
+   "low": 83.2,
+   "close": 87.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-05": {
+   "open": 86.09,
+   "high": 86.66,
+   "low": 83.14,
+   "close": 85.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-08": {
+   "open": 86.95,
+   "high": 87.41,
+   "low": 81.34,
+   "close": 83.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-09": {
+   "open": 83.23,
+   "high": 89.98,
+   "low": 81.76,
+   "close": 88.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-10": {
+   "open": 87.34,
+   "high": 89.55,
+   "low": 85.05,
+   "close": 88.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-11": {
+   "open": 85.85,
+   "high": 89.26,
+   "low": 83.33,
+   "close": 88.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-12": {
+   "open": 89.53,
+   "high": 91.3,
+   "low": 82.03,
+   "close": 83.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-15": {
+   "open": 83.85,
+   "high": 84.18,
+   "low": 74.73,
+   "close": 75.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-16": {
+   "open": 77.86,
+   "high": 83.5,
+   "low": 77.33,
+   "close": 83.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-17": {
+   "open": 82.88,
+   "high": 85.74,
+   "low": 79.08,
+   "close": 79.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-18": {
+   "open": 82.74,
+   "high": 84.47,
+   "low": 80.08,
+   "close": 80.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-19": {
+   "open": 82.44,
+   "high": 86.3,
+   "low": 82.43,
+   "close": 86.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-22": {
+   "open": 87.74,
+   "high": 91.2,
+   "low": 86.43,
+   "close": 87.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-23": {
+   "open": 84.8,
+   "high": 85.57,
+   "low": 81.02,
+   "close": 82.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-24": {
+   "open": 82.72,
+   "high": 83.05,
+   "low": 79.86,
+   "close": 82.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-26": {
+   "open": 82.39,
+   "high": 82.5,
+   "low": 79.71,
+   "close": 81.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-29": {
+   "open": 79.25,
+   "high": 83.04,
+   "low": 79.12,
+   "close": 80.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-30": {
+   "open": 80.18,
+   "high": 82.89,
+   "low": 79.65,
+   "close": 79.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-31": {
+   "open": 79.96,
+   "high": 80.39,
+   "low": 78.77,
+   "close": 79.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-02": {
+   "open": 80.84,
+   "high": 84.58,
+   "low": 79.62,
+   "close": 83.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-05": {
+   "open": 84.58,
+   "high": 88.06,
+   "low": 84.1,
+   "close": 84.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-06": {
+   "open": 86.0,
+   "high": 86.2,
+   "low": 81.95,
+   "close": 84.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-07": {
+   "open": 83.19,
+   "high": 83.6,
+   "low": 80.53,
+   "close": 80.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-08": {
+   "open": 79.9,
+   "high": 82.72,
+   "low": 78.85,
+   "close": 81.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-09": {
+   "open": 82.2,
+   "high": 84.33,
+   "low": 79.45,
+   "close": 82.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-12": {
+   "open": 81.14,
+   "high": 83.12,
+   "low": 79.85,
+   "close": 82.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-13": {
+   "open": 83.24,
+   "high": 84.28,
+   "low": 80.29,
+   "close": 83.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-14": {
+   "open": 84.99,
+   "high": 88.46,
+   "low": 81.75,
+   "close": 84.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-15": {
+   "open": 83.47,
+   "high": 83.79,
+   "low": 76.11,
+   "close": 76.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-16": {
+   "open": 76.74,
+   "high": 80.02,
+   "low": 75.58,
+   "close": 78.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-20": {
+   "open": 75.7,
+   "high": 77.47,
+   "low": 72.62,
+   "close": 72.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-21": {
+   "open": 72.9,
+   "high": 74.59,
+   "low": 70.42,
+   "close": 72.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-22": {
+   "open": 73.55,
+   "high": 73.81,
+   "low": 70.76,
+   "close": 71.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-23": {
+   "open": 70.86,
+   "high": 72.55,
+   "low": 69.88,
+   "close": 71.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-26": {
+   "open": 70.01,
+   "high": 72.43,
+   "low": 69.85,
+   "close": 70.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-27": {
+   "open": 70.38,
+   "high": 70.54,
+   "low": 67.5,
+   "close": 69.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-28": {
+   "open": 72.86,
+   "high": 77.0,
+   "low": 71.91,
+   "close": 72.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-29": {
+   "open": 70.31,
+   "high": 70.6,
+   "low": 65.75,
+   "close": 67.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-30": {
+   "open": 66.6,
+   "high": 66.91,
+   "low": 61.88,
+   "close": 63.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-02": {
+   "open": 61.5,
+   "high": 61.87,
+   "low": 58.41,
+   "close": 58.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-03": {
+   "open": 60.17,
+   "high": 60.17,
+   "low": 53.76,
+   "close": 56.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-04": {
+   "open": 56.19,
+   "high": 56.29,
+   "low": 51.52,
+   "close": 55.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-05": {
+   "open": 53.63,
+   "high": 54.48,
+   "low": 49.9,
+   "close": 50.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-06": {
+   "open": 53.81,
+   "high": 57.8,
+   "low": 53.62,
+   "close": 57.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-09": {
+   "open": 56.33,
+   "high": 60.88,
+   "low": 55.76,
+   "close": 60.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-10": {
+   "open": 58.54,
+   "high": 62.0,
+   "low": 58.3,
+   "close": 59.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-11": {
+   "open": 59.11,
+   "high": 59.17,
+   "low": 55.89,
+   "close": 57.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-12": {
+   "open": 58.75,
+   "high": 58.75,
+   "low": 55.31,
+   "close": 56.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-13": {
+   "open": 58.44,
+   "high": 62.2,
+   "low": 57.23,
+   "close": 60.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-17": {
+   "open": 59.27,
+   "high": 62.9,
+   "low": 57.02,
+   "close": 61.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-18": {
+   "open": 62.13,
+   "high": 64.7,
+   "low": 61.2,
+   "close": 63.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-19": {
+   "open": 62.27,
+   "high": 62.85,
+   "low": 59.8,
+   "close": 61.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-20": {
+   "open": 62.25,
+   "high": 65.5,
+   "low": 61.5,
+   "close": 63.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-23": {
+   "open": 62.1,
+   "high": 63.13,
+   "low": 59.83,
+   "close": 61.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-24": {
+   "open": 60.39,
+   "high": 62.95,
+   "low": 59.46,
+   "close": 61.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-25": {
+   "open": 73.77,
+   "high": 83.35,
+   "low": 71.19,
+   "close": 83.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-26": {
+   "open": 81.57,
+   "high": 90.6,
+   "low": 81.23,
+   "close": 87.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-27": {
+   "open": 83.62,
+   "high": 84.98,
+   "low": 80.97,
+   "close": 83.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-02": {
+   "open": 80.8,
+   "high": 96.61,
+   "low": 80.23,
+   "close": 96.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-03": {
+   "open": 91.5,
+   "high": 104.3,
+   "low": 91.13,
+   "close": 99.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-04": {
+   "open": 102.8,
+   "high": 106.35,
+   "low": 101.4,
+   "close": 105.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-05": {
+   "open": 105.27,
+   "high": 110.12,
+   "low": 103.3,
+   "close": 105.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-06": {
+   "open": 102.82,
+   "high": 106.29,
+   "low": 100.07,
+   "close": 101.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-09": {
+   "open": 105.21,
+   "high": 112.66,
+   "low": 104.9,
+   "close": 111.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-10": {
+   "open": 113.44,
+   "high": 121.8,
+   "low": 112.8,
+   "close": 118.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-11": {
+   "open": 119.8,
+   "high": 123.4,
+   "low": 111.72,
+   "close": 112.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-12": {
+   "open": 113.05,
+   "high": 117.78,
+   "low": 112.15,
+   "close": 114.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-13": {
+   "open": 118.34,
+   "high": 119.3,
+   "low": 113.16,
+   "close": 115.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-16": {
+   "open": 120.15,
+   "high": 126.5,
+   "low": 119.77,
+   "close": 125.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-17": {
+   "open": 124.01,
+   "high": 136.65,
+   "low": 122.74,
+   "close": 132.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-18": {
+   "open": 131.49,
+   "high": 135.49,
+   "low": 128.0,
+   "close": 132.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-19": {
+   "open": 126.33,
+   "high": 129.74,
+   "low": 121.41,
+   "close": 128.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-20": {
+   "open": 127.98,
+   "high": 132.38,
+   "low": 122.91,
+   "close": 126.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-23": {
+   "open": 124.15,
+   "high": 127.48,
+   "low": 121.32,
+   "close": 126.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-24": {
+   "open": 126.35,
+   "high": 127.08,
+   "low": 98.31,
+   "close": 101.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-25": {
+   "open": 106.77,
+   "high": 110.25,
+   "low": 101.6,
+   "close": 103.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-26": {
+   "open": 101.91,
+   "high": 103.55,
+   "low": 97.31,
+   "close": 98.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-27": {
+   "open": 97.74,
+   "high": 97.78,
+   "low": 90.85,
+   "close": 93.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-30": {
+   "open": 96.26,
+   "high": 96.5,
+   "low": 88.27,
+   "close": 89.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-31": {
+   "open": 91.25,
+   "high": 97.8,
+   "low": 89.4,
+   "close": 95.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-01": {
+   "open": 98.42,
+   "high": 99.46,
+   "low": 90.26,
+   "close": 90.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-02": {
+   "open": 87.45,
+   "high": 90.39,
+   "low": 84.27,
+   "close": 90.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-06": {
+   "open": 93.09,
+   "high": 94.7,
+   "low": 91.02,
+   "close": 92.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-07": {
+   "open": 90.97,
+   "high": 95.28,
+   "low": 88.0,
+   "close": 94.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-08": {
+   "open": 101.29,
+   "high": 101.82,
+   "low": 93.0,
+   "close": 94.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-09": {
+   "open": 93.06,
+   "high": 93.95,
+   "low": 84.6,
+   "close": 85.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-10": {
+   "open": 88.05,
+   "high": 90.33,
+   "low": 84.91,
+   "close": 88.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-13": {
+   "open": 86.34,
+   "high": 98.68,
+   "low": 86.27,
+   "close": 98.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-14": {
+   "open": 102.26,
+   "high": 110.51,
+   "low": 101.41,
+   "close": 105.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-15": {
+   "open": 107.58,
+   "high": 108.7,
+   "low": 102.93,
+   "close": 105.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-16": {
+   "open": 107.0,
+   "high": 108.04,
+   "low": 101.7,
+   "close": 107.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-17": {
+   "open": 110.37,
+   "high": 111.2,
+   "low": 102.7,
+   "close": 105.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-20": {
+   "open": 102.48,
+   "high": 106.5,
+   "low": 98.5,
+   "close": 106.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-21": {
+   "open": 104.73,
+   "high": 105.1,
+   "low": 95.79,
+   "close": 96.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-22": {
+   "open": 99.95,
+   "high": 105.79,
+   "low": 99.38,
+   "close": 104.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-23": {
+   "open": 101.22,
+   "high": 103.65,
+   "low": 97.9,
+   "close": 100.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-24": {
+   "open": 102.27,
+   "high": 103.0,
+   "low": 97.56,
+   "close": 99.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-27": {
+   "open": 98.56,
+   "high": 98.8,
+   "low": 94.29,
+   "close": 95.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-28": {
+   "open": 92.5,
+   "high": 95.39,
+   "low": 92.26,
+   "close": 94.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-29": {
+   "open": 93.55,
+   "high": 96.27,
+   "low": 90.19,
+   "close": 95.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-30": {
+   "open": 95.29,
+   "high": 95.29,
+   "low": 89.9,
+   "close": 90.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
   "2026-05-01": {
    "open": 92.77,
    "high": 100.01,
@@ -654,6 +1590,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:28+08:00"
+  },
+  "2026-08-14": {
+   "open": 74.46,
+   "high": 74.62,
+   "low": 71.2,
+   "close": 71.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
   }
  },
  "retired": false

--- a/memory/bars/HOOD.json
+++ b/memory/bars/HOOD.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 123.45,
+   "high": 125.29,
+   "low": 118.86,
+   "close": 123.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-02": {
+   "open": 125.25,
+   "high": 129.18,
+   "low": 124.51,
+   "close": 125.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-03": {
+   "open": 126.1,
+   "high": 134.34,
+   "low": 124.4,
+   "close": 133.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-04": {
+   "open": 133.21,
+   "high": 137.36,
+   "low": 132.77,
+   "close": 137.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-05": {
+   "open": 135.06,
+   "high": 135.24,
+   "low": 129.96,
+   "close": 131.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-08": {
+   "open": 134.1,
+   "high": 138.09,
+   "low": 132.0,
+   "close": 136.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-09": {
+   "open": 134.5,
+   "high": 139.75,
+   "low": 133.57,
+   "close": 135.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-10": {
+   "open": 135.26,
+   "high": 137.46,
+   "low": 133.43,
+   "close": 135.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-11": {
+   "open": 131.78,
+   "high": 131.78,
+   "low": 122.53,
+   "close": 123.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-12": {
+   "open": 125.34,
+   "high": 125.65,
+   "low": 117.84,
+   "close": 119.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-15": {
+   "open": 120.4,
+   "high": 120.66,
+   "low": 114.1,
+   "close": 115.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-16": {
+   "open": 116.7,
+   "high": 120.7,
+   "low": 115.76,
+   "close": 119.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-17": {
+   "open": 120.97,
+   "high": 124.7,
+   "low": 115.59,
+   "close": 115.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-18": {
+   "open": 121.87,
+   "high": 124.25,
+   "low": 117.05,
+   "close": 117.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-19": {
+   "open": 119.47,
+   "high": 122.96,
+   "low": 118.2,
+   "close": 121.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-22": {
+   "open": 123.51,
+   "high": 124.55,
+   "low": 121.07,
+   "close": 122.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-23": {
+   "open": 120.3,
+   "high": 121.15,
+   "low": 116.75,
+   "close": 120.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-24": {
+   "open": 119.96,
+   "high": 120.67,
+   "low": 118.6,
+   "close": 120.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-26": {
+   "open": 120.71,
+   "high": 121.03,
+   "low": 117.7,
+   "close": 118.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-29": {
+   "open": 116.89,
+   "high": 118.95,
+   "low": 116.02,
+   "close": 117.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-30": {
+   "open": 117.63,
+   "high": 118.64,
+   "low": 115.18,
+   "close": 115.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2025-12-31": {
+   "open": 114.84,
+   "high": 115.65,
+   "low": 112.85,
+   "close": 113.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-02": {
+   "open": 115.48,
+   "high": 116.03,
+   "low": 110.41,
+   "close": 115.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-05": {
+   "open": 117.92,
+   "high": 123.42,
+   "low": 117.55,
+   "close": 123.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-06": {
+   "open": 124.16,
+   "high": 124.35,
+   "low": 118.05,
+   "close": 121.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-07": {
+   "open": 120.05,
+   "high": 120.1,
+   "low": 116.55,
+   "close": 116.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-08": {
+   "open": 115.75,
+   "high": 117.32,
+   "low": 113.87,
+   "close": 115.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-09": {
+   "open": 116.98,
+   "high": 118.23,
+   "low": 114.88,
+   "close": 115.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-12": {
+   "open": 114.51,
+   "high": 119.62,
+   "low": 114.46,
+   "close": 117.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-13": {
+   "open": 117.4,
+   "high": 120.43,
+   "low": 116.0,
+   "close": 120.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-14": {
+   "open": 120.29,
+   "high": 120.88,
+   "low": 116.61,
+   "close": 119.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-15": {
+   "open": 119.61,
+   "high": 119.88,
+   "low": 110.13,
+   "close": 110.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-16": {
+   "open": 111.05,
+   "high": 111.25,
+   "low": 106.88,
+   "close": 108.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-20": {
+   "open": 105.0,
+   "high": 108.35,
+   "low": 104.45,
+   "close": 105.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-21": {
+   "open": 105.73,
+   "high": 108.5,
+   "low": 104.95,
+   "close": 105.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-22": {
+   "open": 107.48,
+   "high": 108.08,
+   "low": 105.1,
+   "close": 106.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-23": {
+   "open": 106.9,
+   "high": 111.46,
+   "low": 106.5,
+   "close": 106.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-26": {
+   "open": 106.26,
+   "high": 108.49,
+   "low": 104.83,
+   "close": 107.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-27": {
+   "open": 107.7,
+   "high": 109.05,
+   "low": 104.66,
+   "close": 105.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-28": {
+   "open": 105.29,
+   "high": 107.25,
+   "low": 103.0,
+   "close": 103.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-29": {
+   "open": 103.82,
+   "high": 103.82,
+   "low": 99.2,
+   "close": 101.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-01-30": {
+   "open": 102.74,
+   "high": 104.3,
+   "low": 98.37,
+   "close": 99.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-02": {
+   "open": 95.88,
+   "high": 95.89,
+   "low": 88.67,
+   "close": 89.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-03": {
+   "open": 90.1,
+   "high": 90.35,
+   "low": 84.93,
+   "close": 87.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-04": {
+   "open": 84.77,
+   "high": 85.3,
+   "low": 77.62,
+   "close": 80.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-05": {
+   "open": 77.67,
+   "high": 79.41,
+   "low": 71.87,
+   "close": 72.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-06": {
+   "open": 77.86,
+   "high": 84.3,
+   "low": 77.12,
+   "close": 82.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-09": {
+   "open": 84.88,
+   "high": 88.6,
+   "low": 82.83,
+   "close": 86.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-10": {
+   "open": 85.32,
+   "high": 88.22,
+   "low": 85.21,
+   "close": 85.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-11": {
+   "open": 77.88,
+   "high": 79.9,
+   "low": 74.25,
+   "close": 77.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-12": {
+   "open": 78.87,
+   "high": 79.0,
+   "low": 70.43,
+   "close": 71.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-13": {
+   "open": 72.47,
+   "high": 77.08,
+   "low": 71.52,
+   "close": 75.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-17": {
+   "open": 74.34,
+   "high": 76.72,
+   "low": 72.87,
+   "close": 75.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-18": {
+   "open": 74.79,
+   "high": 78.27,
+   "low": 74.06,
+   "close": 75.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-19": {
+   "open": 74.39,
+   "high": 76.14,
+   "low": 73.53,
+   "close": 75.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-20": {
+   "open": 75.2,
+   "high": 78.08,
+   "low": 75.13,
+   "close": 76.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-23": {
+   "open": 74.6,
+   "high": 74.95,
+   "low": 71.42,
+   "close": 71.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-24": {
+   "open": 70.91,
+   "high": 73.88,
+   "low": 69.22,
+   "close": 73.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-25": {
+   "open": 76.91,
+   "high": 78.11,
+   "low": 74.64,
+   "close": 77.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-26": {
+   "open": 76.93,
+   "high": 79.57,
+   "low": 76.45,
+   "close": 79.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-02-27": {
+   "open": 76.8,
+   "high": 77.79,
+   "low": 74.82,
+   "close": 75.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-02": {
+   "open": 73.49,
+   "high": 79.54,
+   "low": 73.0,
+   "close": 78.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-03": {
+   "open": 74.04,
+   "high": 77.4,
+   "low": 72.25,
+   "close": 76.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-04": {
+   "open": 79.6,
+   "high": 83.85,
+   "low": 79.58,
+   "close": 82.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-05": {
+   "open": 82.12,
+   "high": 84.75,
+   "low": 78.55,
+   "close": 80.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-06": {
+   "open": 77.91,
+   "high": 79.0,
+   "low": 76.38,
+   "close": 77.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-09": {
+   "open": 75.92,
+   "high": 79.65,
+   "low": 75.55,
+   "close": 79.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-10": {
+   "open": 80.21,
+   "high": 80.75,
+   "low": 77.66,
+   "close": 78.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-11": {
+   "open": 78.11,
+   "high": 79.77,
+   "low": 76.74,
+   "close": 78.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-12": {
+   "open": 77.34,
+   "high": 77.82,
+   "low": 75.07,
+   "close": 76.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-13": {
+   "open": 76.75,
+   "high": 77.63,
+   "low": 72.8,
+   "close": 73.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-16": {
+   "open": 75.1,
+   "high": 75.81,
+   "low": 74.11,
+   "close": 75.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-17": {
+   "open": 75.4,
+   "high": 77.7,
+   "low": 75.39,
+   "close": 77.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-18": {
+   "open": 76.13,
+   "high": 77.25,
+   "low": 74.83,
+   "close": 74.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-19": {
+   "open": 72.28,
+   "high": 75.16,
+   "low": 71.7,
+   "close": 74.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-20": {
+   "open": 73.1,
+   "high": 73.41,
+   "low": 69.9,
+   "close": 70.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-23": {
+   "open": 71.85,
+   "high": 73.6,
+   "low": 70.92,
+   "close": 72.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-24": {
+   "open": 71.51,
+   "high": 71.84,
+   "low": 68.58,
+   "close": 69.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-25": {
+   "open": 71.83,
+   "high": 74.59,
+   "low": 71.75,
+   "close": 72.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-26": {
+   "open": 71.15,
+   "high": 73.24,
+   "low": 69.7,
+   "close": 70.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-27": {
+   "open": 68.54,
+   "high": 68.89,
+   "low": 65.87,
+   "close": 66.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-30": {
+   "open": 66.86,
+   "high": 67.89,
+   "low": 63.52,
+   "close": 65.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-03-31": {
+   "open": 65.82,
+   "high": 69.41,
+   "low": 65.18,
+   "close": 69.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-01": {
+   "open": 71.13,
+   "high": 71.55,
+   "low": 69.14,
+   "close": 70.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-02": {
+   "open": 67.2,
+   "high": 70.15,
+   "low": 65.57,
+   "close": 68.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-06": {
+   "open": 69.31,
+   "high": 70.82,
+   "low": 68.71,
+   "close": 69.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-07": {
+   "open": 68.3,
+   "high": 69.66,
+   "low": 66.62,
+   "close": 69.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-08": {
+   "open": 76.8,
+   "high": 77.87,
+   "low": 71.31,
+   "close": 71.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-09": {
+   "open": 71.59,
+   "high": 72.46,
+   "low": 68.78,
+   "close": 70.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-10": {
+   "open": 70.11,
+   "high": 70.87,
+   "low": 68.28,
+   "close": 69.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-13": {
+   "open": 68.21,
+   "high": 71.7,
+   "low": 67.8,
+   "close": 71.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-14": {
+   "open": 75.13,
+   "high": 79.28,
+   "low": 75.05,
+   "close": 79.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-15": {
+   "open": 83.55,
+   "high": 87.55,
+   "low": 81.5,
+   "close": 87.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-16": {
+   "open": 89.19,
+   "high": 89.38,
+   "low": 83.87,
+   "close": 86.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-17": {
+   "open": 90.06,
+   "high": 93.32,
+   "low": 89.57,
+   "close": 90.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-20": {
+   "open": 89.7,
+   "high": 92.38,
+   "low": 88.21,
+   "close": 91.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-21": {
+   "open": 91.08,
+   "high": 91.45,
+   "low": 86.19,
+   "close": 86.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-22": {
+   "open": 89.35,
+   "high": 90.14,
+   "low": 87.48,
+   "close": 88.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-23": {
+   "open": 86.7,
+   "high": 87.61,
+   "low": 81.75,
+   "close": 83.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-24": {
+   "open": 84.9,
+   "high": 85.06,
+   "low": 82.82,
+   "close": 84.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-27": {
+   "open": 84.28,
+   "high": 85.7,
+   "low": 83.12,
+   "close": 83.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-28": {
+   "open": 81.46,
+   "high": 83.14,
+   "low": 80.82,
+   "close": 82.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-29": {
+   "open": 72.3,
+   "high": 73.59,
+   "low": 69.93,
+   "close": 71.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
+  "2026-04-30": {
+   "open": 71.18,
+   "high": 73.87,
+   "low": 70.76,
+   "close": 72.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
+  },
   "2026-05-01": {
    "open": 73.78,
    "high": 75.28,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:28+08:00"
+  },
+  "2026-08-14": {
+   "open": 98.0,
+   "high": 98.42,
+   "low": 95.44,
+   "close": 95.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:47+08:00"
   }
  }
 }

--- a/memory/bars/MSFT.json
+++ b/memory/bars/MSFT.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 488.44,
+   "high": 489.86,
+   "low": 484.65,
+   "close": 486.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-02": {
+   "open": 486.72,
+   "high": 493.5,
+   "low": 486.32,
+   "close": 490.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-03": {
+   "open": 476.32,
+   "high": 484.24,
+   "low": 475.2,
+   "close": 477.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-04": {
+   "open": 479.76,
+   "high": 481.32,
+   "low": 476.49,
+   "close": 480.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-05": {
+   "open": 482.52,
+   "high": 483.4,
+   "low": 478.88,
+   "close": 483.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-08": {
+   "open": 484.89,
+   "high": 492.3,
+   "low": 484.38,
+   "close": 491.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-09": {
+   "open": 489.1,
+   "high": 492.12,
+   "low": 488.5,
+   "close": 492.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-10": {
+   "open": 484.03,
+   "high": 484.25,
+   "low": 475.08,
+   "close": 478.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-11": {
+   "open": 476.63,
+   "high": 486.03,
+   "low": 475.86,
+   "close": 483.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-12": {
+   "open": 479.82,
+   "high": 482.45,
+   "low": 476.34,
+   "close": 478.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-15": {
+   "open": 480.1,
+   "high": 480.72,
+   "low": 472.52,
+   "close": 474.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-16": {
+   "open": 471.91,
+   "high": 477.89,
+   "low": 470.88,
+   "close": 476.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-17": {
+   "open": 476.91,
+   "high": 480.0,
+   "low": 475.0,
+   "close": 476.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-18": {
+   "open": 478.19,
+   "high": 489.6,
+   "low": 477.89,
+   "close": 483.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-19": {
+   "open": 487.36,
+   "high": 487.85,
+   "low": 482.49,
+   "close": 485.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-22": {
+   "open": 486.12,
+   "high": 488.73,
+   "low": 482.69,
+   "close": 484.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-23": {
+   "open": 484.98,
+   "high": 487.83,
+   "low": 484.74,
+   "close": 486.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-24": {
+   "open": 485.68,
+   "high": 489.16,
+   "low": 484.83,
+   "close": 488.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-26": {
+   "open": 486.71,
+   "high": 488.12,
+   "low": 485.96,
+   "close": 487.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-29": {
+   "open": 484.86,
+   "high": 488.35,
+   "low": 484.18,
+   "close": 487.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-30": {
+   "open": 485.93,
+   "high": 489.68,
+   "low": 485.5,
+   "close": 487.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-31": {
+   "open": 487.84,
+   "high": 488.14,
+   "low": 483.3,
+   "close": 483.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-02": {
+   "open": 484.39,
+   "high": 484.66,
+   "low": 470.16,
+   "close": 472.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-05": {
+   "open": 474.06,
+   "high": 476.07,
+   "low": 469.5,
+   "close": 472.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-06": {
+   "open": 473.8,
+   "high": 478.74,
+   "low": 469.75,
+   "close": 478.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-07": {
+   "open": 479.76,
+   "high": 489.7,
+   "low": 477.95,
+   "close": 483.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-08": {
+   "open": 481.24,
+   "high": 482.66,
+   "low": 475.86,
+   "close": 478.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-09": {
+   "open": 474.06,
+   "high": 479.82,
+   "low": 472.2,
+   "close": 479.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-12": {
+   "open": 476.67,
+   "high": 480.99,
+   "low": 475.68,
+   "close": 477.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-13": {
+   "open": 474.68,
+   "high": 475.78,
+   "low": 465.95,
+   "close": 470.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-14": {
+   "open": 466.46,
+   "high": 468.2,
+   "low": 457.17,
+   "close": 459.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-15": {
+   "open": 464.12,
+   "high": 464.25,
+   "low": 455.9,
+   "close": 456.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-16": {
+   "open": 457.83,
+   "high": 463.19,
+   "low": 456.48,
+   "close": 459.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-20": {
+   "open": 451.22,
+   "high": 456.8,
+   "low": 449.28,
+   "close": 454.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-21": {
+   "open": 452.6,
+   "high": 452.69,
+   "low": 438.68,
+   "close": 444.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-22": {
+   "open": 447.62,
+   "high": 452.84,
+   "low": 444.7,
+   "close": 451.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-23": {
+   "open": 451.87,
+   "high": 471.1,
+   "low": 450.53,
+   "close": 465.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-26": {
+   "open": 465.31,
+   "high": 474.25,
+   "low": 462.0,
+   "close": 470.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-27": {
+   "open": 473.7,
+   "high": 482.87,
+   "low": 473.16,
+   "close": 480.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-28": {
+   "open": 483.21,
+   "high": 483.74,
+   "low": 478.0,
+   "close": 481.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-29": {
+   "open": 439.99,
+   "high": 442.5,
+   "low": 421.02,
+   "close": 433.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-30": {
+   "open": 439.17,
+   "high": 439.6,
+   "low": 426.45,
+   "close": 430.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-02": {
+   "open": 430.24,
+   "high": 430.74,
+   "low": 422.25,
+   "close": 423.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-03": {
+   "open": 422.01,
+   "high": 422.05,
+   "low": 408.56,
+   "close": 411.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-04": {
+   "open": 411.0,
+   "high": 419.8,
+   "low": 409.24,
+   "close": 414.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-05": {
+   "open": 407.44,
+   "high": 408.3,
+   "low": 392.32,
+   "close": 393.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-06": {
+   "open": 399.17,
+   "high": 401.79,
+   "low": 392.92,
+   "close": 401.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-09": {
+   "open": 404.85,
+   "high": 414.89,
+   "low": 400.87,
+   "close": 413.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-10": {
+   "open": 419.62,
+   "high": 423.68,
+   "low": 412.7,
+   "close": 413.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-11": {
+   "open": 416.18,
+   "high": 416.46,
+   "low": 401.01,
+   "close": 404.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-12": {
+   "open": 405.0,
+   "high": 406.2,
+   "low": 398.01,
+   "close": 401.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-13": {
+   "open": 404.45,
+   "high": 405.54,
+   "low": 398.05,
+   "close": 401.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-17": {
+   "open": 399.22,
+   "high": 400.52,
+   "low": 394.53,
+   "close": 396.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-18": {
+   "open": 398.13,
+   "high": 402.56,
+   "low": 396.32,
+   "close": 399.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-19": {
+   "open": 400.69,
+   "high": 404.43,
+   "low": 396.67,
+   "close": 398.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-20": {
+   "open": 396.11,
+   "high": 400.12,
+   "low": 395.16,
+   "close": 397.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-23": {
+   "open": 395.0,
+   "high": 395.36,
+   "low": 383.1,
+   "close": 384.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-24": {
+   "open": 384.14,
+   "high": 389.36,
+   "low": 381.71,
+   "close": 389.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-25": {
+   "open": 390.53,
+   "high": 401.47,
+   "low": 390.16,
+   "close": 400.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-26": {
+   "open": 404.71,
+   "high": 407.49,
+   "low": 398.74,
+   "close": 401.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-27": {
+   "open": 390.88,
+   "high": 396.82,
+   "low": 389.88,
+   "close": 392.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-02": {
+   "open": 392.86,
+   "high": 401.19,
+   "low": 390.63,
+   "close": 398.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-03": {
+   "open": 393.14,
+   "high": 406.7,
+   "low": 392.67,
+   "close": 403.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-04": {
+   "open": 401.27,
+   "high": 411.03,
+   "low": 400.31,
+   "close": 405.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-05": {
+   "open": 404.42,
+   "high": 411.61,
+   "low": 404.4,
+   "close": 410.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-06": {
+   "open": 409.2,
+   "high": 413.05,
+   "low": 408.51,
+   "close": 408.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-09": {
+   "open": 404.92,
+   "high": 410.21,
+   "low": 403.5,
+   "close": 409.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-10": {
+   "open": 410.03,
+   "high": 410.2,
+   "low": 402.93,
+   "close": 405.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-11": {
+   "open": 405.57,
+   "high": 409.01,
+   "low": 401.59,
+   "close": 404.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-12": {
+   "open": 404.63,
+   "high": 406.12,
+   "low": 401.71,
+   "close": 401.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-13": {
+   "open": 401.0,
+   "high": 404.8,
+   "low": 394.25,
+   "close": 395.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-16": {
+   "open": 398.07,
+   "high": 400.63,
+   "low": 394.79,
+   "close": 399.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-17": {
+   "open": 400.27,
+   "high": 404.4,
+   "low": 397.75,
+   "close": 399.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-18": {
+   "open": 397.13,
+   "high": 398.0,
+   "low": 391.0,
+   "close": 391.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-19": {
+   "open": 390.1,
+   "high": 392.49,
+   "low": 387.06,
+   "close": 389.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-20": {
+   "open": 386.79,
+   "high": 387.0,
+   "low": 380.12,
+   "close": 381.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-23": {
+   "open": 383.9,
+   "high": 387.21,
+   "low": 381.68,
+   "close": 383.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-24": {
+   "open": 382.36,
+   "high": 382.47,
+   "low": 371.85,
+   "close": 372.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-25": {
+   "open": 376.92,
+   "high": 377.06,
+   "low": 369.63,
+   "close": 371.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-26": {
+   "open": 370.82,
+   "high": 374.72,
+   "low": 365.19,
+   "close": 365.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-27": {
+   "open": 361.9,
+   "high": 362.45,
+   "low": 356.51,
+   "close": 356.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-30": {
+   "open": 361.9,
+   "high": 365.36,
+   "low": 356.28,
+   "close": 358.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-31": {
+   "open": 364.55,
+   "high": 372.9,
+   "low": 363.07,
+   "close": 370.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-01": {
+   "open": 373.49,
+   "high": 373.99,
+   "low": 368.2,
+   "close": 369.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-02": {
+   "open": 367.21,
+   "high": 373.64,
+   "low": 364.15,
+   "close": 373.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-06": {
+   "open": 373.49,
+   "high": 373.73,
+   "low": 369.5,
+   "close": 372.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-07": {
+   "open": 370.34,
+   "high": 372.45,
+   "low": 366.56,
+   "close": 372.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-08": {
+   "open": 384.98,
+   "high": 385.0,
+   "low": 371.41,
+   "close": 374.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-09": {
+   "open": 372.5,
+   "high": 373.5,
+   "low": 367.05,
+   "close": 373.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-10": {
+   "open": 372.98,
+   "high": 375.64,
+   "low": 370.03,
+   "close": 370.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-13": {
+   "open": 373.61,
+   "high": 384.54,
+   "low": 371.02,
+   "close": 384.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-14": {
+   "open": 387.92,
+   "high": 394.69,
+   "low": 386.52,
+   "close": 393.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-15": {
+   "open": 398.0,
+   "high": 414.37,
+   "low": 396.73,
+   "close": 411.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-16": {
+   "open": 419.86,
+   "high": 420.82,
+   "low": 412.14,
+   "close": 420.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-17": {
+   "open": 424.82,
+   "high": 431.58,
+   "low": 420.69,
+   "close": 422.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-20": {
+   "open": 421.15,
+   "high": 423.33,
+   "low": 416.3,
+   "close": 418.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-21": {
+   "open": 420.24,
+   "high": 427.18,
+   "low": 417.2,
+   "close": 424.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-22": {
+   "open": 426.19,
+   "high": 433.7,
+   "low": 423.67,
+   "close": 432.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-23": {
+   "open": 419.89,
+   "high": 423.66,
+   "low": 411.41,
+   "close": 415.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-24": {
+   "open": 416.97,
+   "high": 424.95,
+   "low": 415.8,
+   "close": 424.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-27": {
+   "open": 422.38,
+   "high": 427.11,
+   "low": 417.07,
+   "close": 424.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-28": {
+   "open": 424.57,
+   "high": 429.92,
+   "low": 421.9,
+   "close": 429.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-29": {
+   "open": 424.58,
+   "high": 426.82,
+   "low": 420.29,
+   "close": 424.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-30": {
+   "open": 410.81,
+   "high": 414.42,
+   "low": 398.01,
+   "close": 407.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
   "2026-05-01": {
    "open": 412.8,
    "high": 417.11,
@@ -654,6 +1590,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:29+08:00"
+  },
+  "2026-08-14": {
+   "open": 496.36,
+   "high": 500.01,
+   "low": 493.92,
+   "close": 495.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/MSFU.json
+++ b/memory/bars/MSFU.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 45.39,
+   "high": 45.7,
+   "low": 44.73,
+   "close": 45.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-02": {
+   "open": 45.08,
+   "high": 46.34,
+   "low": 45.06,
+   "close": 45.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-03": {
+   "open": 43.1,
+   "high": 44.64,
+   "low": 42.95,
+   "close": 43.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-04": {
+   "open": 43.71,
+   "high": 44.04,
+   "low": 43.2,
+   "close": 43.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-05": {
+   "open": 44.11,
+   "high": 44.4,
+   "low": 43.58,
+   "close": 44.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-08": {
+   "open": 44.62,
+   "high": 46.01,
+   "low": 44.62,
+   "close": 45.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-09": {
+   "open": 45.46,
+   "high": 45.96,
+   "low": 45.32,
+   "close": 45.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-10": {
+   "open": 42.19,
+   "high": 42.19,
+   "low": 40.5,
+   "close": 41.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-11": {
+   "open": 40.67,
+   "high": 42.4,
+   "low": 40.67,
+   "close": 42.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-12": {
+   "open": 41.34,
+   "high": 41.75,
+   "low": 40.7,
+   "close": 41.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-15": {
+   "open": 41.34,
+   "high": 41.34,
+   "low": 40.05,
+   "close": 40.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-16": {
+   "open": 39.89,
+   "high": 40.91,
+   "low": 39.72,
+   "close": 40.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-17": {
+   "open": 40.75,
+   "high": 41.25,
+   "low": 40.49,
+   "close": 40.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-18": {
+   "open": 41.09,
+   "high": 42.91,
+   "low": 40.96,
+   "close": 41.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-19": {
+   "open": 42.49,
+   "high": 42.59,
+   "low": 41.68,
+   "close": 42.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-22": {
+   "open": 42.31,
+   "high": 42.71,
+   "low": 41.69,
+   "close": 42.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-23": {
+   "open": 41.79,
+   "high": 42.25,
+   "low": 41.79,
+   "close": 42.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-24": {
+   "open": 41.96,
+   "high": 42.51,
+   "low": 41.76,
+   "close": 42.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-26": {
+   "open": 42.1,
+   "high": 42.28,
+   "low": 41.92,
+   "close": 42.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-29": {
+   "open": 41.72,
+   "high": 42.3,
+   "low": 41.63,
+   "close": 42.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-30": {
+   "open": 41.84,
+   "high": 42.53,
+   "low": 41.84,
+   "close": 42.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-31": {
+   "open": 42.13,
+   "high": 42.21,
+   "low": 41.41,
+   "close": 41.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-02": {
+   "open": 41.61,
+   "high": 41.61,
+   "low": 39.14,
+   "close": 39.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-05": {
+   "open": 39.75,
+   "high": 40.1,
+   "low": 39.04,
+   "close": 39.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-06": {
+   "open": 39.7,
+   "high": 40.54,
+   "low": 39.08,
+   "close": 40.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-07": {
+   "open": 40.76,
+   "high": 42.38,
+   "low": 40.42,
+   "close": 41.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-08": {
+   "open": 41.03,
+   "high": 41.16,
+   "low": 40.06,
+   "close": 40.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-09": {
+   "open": 39.77,
+   "high": 40.67,
+   "low": 39.41,
+   "close": 40.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-12": {
+   "open": 40.14,
+   "high": 40.85,
+   "low": 40.01,
+   "close": 40.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-13": {
+   "open": 39.83,
+   "high": 39.96,
+   "low": 38.34,
+   "close": 39.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-14": {
+   "open": 38.43,
+   "high": 38.7,
+   "low": 36.88,
+   "close": 37.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-15": {
+   "open": 37.93,
+   "high": 38.0,
+   "low": 36.67,
+   "close": 36.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-16": {
+   "open": 36.91,
+   "high": 37.78,
+   "low": 36.74,
+   "close": 37.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-20": {
+   "open": 35.9,
+   "high": 36.74,
+   "low": 35.53,
+   "close": 36.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-21": {
+   "open": 36.04,
+   "high": 36.06,
+   "low": 33.85,
+   "close": 34.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-22": {
+   "open": 35.33,
+   "high": 36.05,
+   "low": 34.82,
+   "close": 35.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-23": {
+   "open": 35.89,
+   "high": 38.92,
+   "low": 35.73,
+   "close": 38.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-26": {
+   "open": 38.01,
+   "high": 39.44,
+   "low": 37.47,
+   "close": 38.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-27": {
+   "open": 39.35,
+   "high": 40.85,
+   "low": 39.34,
+   "close": 40.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-28": {
+   "open": 40.95,
+   "high": 40.96,
+   "low": 40.06,
+   "close": 40.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-29": {
+   "open": 33.6,
+   "high": 34.01,
+   "low": 30.43,
+   "close": 32.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-30": {
+   "open": 33.32,
+   "high": 33.38,
+   "low": 31.45,
+   "close": 32.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-02": {
+   "open": 32.0,
+   "high": 32.05,
+   "low": 30.81,
+   "close": 30.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-03": {
+   "open": 30.78,
+   "high": 30.78,
+   "low": 28.81,
+   "close": 29.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-04": {
+   "open": 29.1,
+   "high": 30.25,
+   "low": 28.91,
+   "close": 29.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-05": {
+   "open": 28.68,
+   "high": 28.76,
+   "low": 26.5,
+   "close": 26.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-06": {
+   "open": 27.41,
+   "high": 27.75,
+   "low": 26.56,
+   "close": 27.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-09": {
+   "open": 28.15,
+   "high": 29.54,
+   "low": 27.63,
+   "close": 29.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-10": {
+   "open": 30.17,
+   "high": 30.79,
+   "low": 29.24,
+   "close": 29.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-11": {
+   "open": 29.74,
+   "high": 29.77,
+   "low": 27.57,
+   "close": 28.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-12": {
+   "open": 28.12,
+   "high": 28.28,
+   "low": 27.15,
+   "close": 27.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-13": {
+   "open": 27.87,
+   "high": 28.15,
+   "low": 27.14,
+   "close": 27.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-17": {
+   "open": 27.29,
+   "high": 27.45,
+   "low": 26.63,
+   "close": 26.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-18": {
+   "open": 27.13,
+   "high": 27.73,
+   "low": 26.9,
+   "close": 27.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-19": {
+   "open": 27.6,
+   "high": 28.09,
+   "low": 27.06,
+   "close": 27.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-20": {
+   "open": 26.98,
+   "high": 27.49,
+   "low": 26.81,
+   "close": 27.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-23": {
+   "open": 26.82,
+   "high": 26.82,
+   "low": 25.17,
+   "close": 25.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-24": {
+   "open": 25.29,
+   "high": 25.98,
+   "low": 24.98,
+   "close": 25.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-25": {
+   "open": 26.12,
+   "high": 27.55,
+   "low": 26.1,
+   "close": 27.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-26": {
+   "open": 28.01,
+   "high": 28.41,
+   "low": 27.23,
+   "close": 27.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-27": {
+   "open": 26.05,
+   "high": 26.93,
+   "low": 25.98,
+   "close": 26.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-02": {
+   "open": 26.25,
+   "high": 27.5,
+   "low": 26.08,
+   "close": 27.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-03": {
+   "open": 26.38,
+   "high": 28.24,
+   "low": 26.34,
+   "close": 27.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-04": {
+   "open": 27.49,
+   "high": 28.85,
+   "low": 27.4,
+   "close": 28.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-05": {
+   "open": 27.94,
+   "high": 28.92,
+   "low": 27.91,
+   "close": 28.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-06": {
+   "open": 28.53,
+   "high": 29.1,
+   "low": 28.46,
+   "close": 28.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-09": {
+   "open": 27.87,
+   "high": 28.68,
+   "low": 27.75,
+   "close": 28.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-10": {
+   "open": 28.65,
+   "high": 28.67,
+   "low": 27.67,
+   "close": 28.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-11": {
+   "open": 28.1,
+   "high": 28.5,
+   "low": 27.48,
+   "close": 27.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-12": {
+   "open": 27.89,
+   "high": 28.08,
+   "low": 27.49,
+   "close": 27.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-13": {
+   "open": 27.32,
+   "high": 27.89,
+   "low": 26.48,
+   "close": 26.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-16": {
+   "open": 26.98,
+   "high": 27.31,
+   "low": 26.52,
+   "close": 27.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-17": {
+   "open": 27.23,
+   "high": 27.8,
+   "low": 26.91,
+   "close": 27.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-18": {
+   "open": 26.82,
+   "high": 26.93,
+   "low": 25.98,
+   "close": 26.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-19": {
+   "open": 25.87,
+   "high": 26.17,
+   "low": 25.46,
+   "close": 25.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-20": {
+   "open": 25.4,
+   "high": 25.44,
+   "low": 24.53,
+   "close": 24.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-23": {
+   "open": 25.07,
+   "high": 25.43,
+   "low": 24.72,
+   "close": 24.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-24": {
+   "open": 24.68,
+   "high": 24.68,
+   "low": 23.31,
+   "close": 23.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-25": {
+   "open": 23.9,
+   "high": 23.94,
+   "low": 23.03,
+   "close": 23.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-26": {
+   "open": 23.17,
+   "high": 23.65,
+   "low": 22.47,
+   "close": 22.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-27": {
+   "open": 22.04,
+   "high": 22.1,
+   "low": 21.38,
+   "close": 21.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-30": {
+   "open": 21.99,
+   "high": 22.43,
+   "low": 21.35,
+   "close": 21.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-31": {
+   "open": 22.38,
+   "high": 23.33,
+   "low": 22.17,
+   "close": 23.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-01": {
+   "open": 23.4,
+   "high": 23.42,
+   "low": 22.77,
+   "close": 22.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-02": {
+   "open": 22.62,
+   "high": 23.4,
+   "low": 22.24,
+   "close": 23.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-06": {
+   "open": 23.37,
+   "high": 23.41,
+   "low": 22.89,
+   "close": 23.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-07": {
+   "open": 23.0,
+   "high": 23.25,
+   "low": 22.53,
+   "close": 23.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-08": {
+   "open": 24.76,
+   "high": 24.81,
+   "low": 23.13,
+   "close": 23.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-09": {
+   "open": 23.27,
+   "high": 23.36,
+   "low": 22.57,
+   "close": 23.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-10": {
+   "open": 23.27,
+   "high": 23.61,
+   "low": 22.92,
+   "close": 23.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-13": {
+   "open": 23.36,
+   "high": 24.72,
+   "low": 23.05,
+   "close": 24.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-14": {
+   "open": 25.13,
+   "high": 26.01,
+   "low": 24.97,
+   "close": 25.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-15": {
+   "open": 26.43,
+   "high": 28.59,
+   "low": 26.29,
+   "close": 28.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-16": {
+   "open": 29.33,
+   "high": 29.5,
+   "low": 28.3,
+   "close": 29.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-17": {
+   "open": 30.05,
+   "high": 30.97,
+   "low": 29.46,
+   "close": 29.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-20": {
+   "open": 29.53,
+   "high": 29.8,
+   "low": 28.82,
+   "close": 29.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-21": {
+   "open": 29.3,
+   "high": 30.33,
+   "low": 28.94,
+   "close": 29.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-22": {
+   "open": 30.2,
+   "high": 31.22,
+   "low": 29.85,
+   "close": 31.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-23": {
+   "open": 29.23,
+   "high": 29.76,
+   "low": 28.04,
+   "close": 28.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-24": {
+   "open": 28.8,
+   "high": 29.89,
+   "low": 28.65,
+   "close": 29.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-27": {
+   "open": 29.54,
+   "high": 30.2,
+   "low": 28.82,
+   "close": 29.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-28": {
+   "open": 29.84,
+   "high": 30.59,
+   "low": 29.47,
+   "close": 30.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-29": {
+   "open": 29.79,
+   "high": 30.15,
+   "low": 29.23,
+   "close": 29.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-30": {
+   "open": 27.87,
+   "high": 28.39,
+   "low": 26.12,
+   "close": 27.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
   "2026-05-01": {
    "open": 28.1,
    "high": 28.7,
@@ -662,6 +1598,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:29+08:00"
+  },
+  "2026-08-14": {
+   "open": 37.58,
+   "high": 38.19,
+   "low": 37.27,
+   "close": 37.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/NVDA.json
+++ b/memory/bars/NVDA.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 174.76,
+   "high": 180.3,
+   "low": 173.68,
+   "close": 179.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-02": {
+   "open": 181.76,
+   "high": 185.66,
+   "low": 180.0,
+   "close": 181.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-03": {
+   "open": 181.08,
+   "high": 182.45,
+   "low": 179.11,
+   "close": 179.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-04": {
+   "open": 181.62,
+   "high": 184.52,
+   "low": 179.96,
+   "close": 183.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-05": {
+   "open": 183.89,
+   "high": 184.66,
+   "low": 180.91,
+   "close": 182.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-08": {
+   "open": 182.64,
+   "high": 188.0,
+   "low": 182.4,
+   "close": 185.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-09": {
+   "open": 185.56,
+   "high": 185.72,
+   "low": 183.32,
+   "close": 184.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-10": {
+   "open": 184.97,
+   "high": 185.48,
+   "low": 182.04,
+   "close": 183.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-11": {
+   "open": 180.28,
+   "high": 181.32,
+   "low": 176.62,
+   "close": 180.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-12": {
+   "open": 181.11,
+   "high": 182.82,
+   "low": 174.62,
+   "close": 175.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-15": {
+   "open": 177.94,
+   "high": 178.42,
+   "low": 175.03,
+   "close": 176.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-16": {
+   "open": 176.26,
+   "high": 178.49,
+   "low": 174.9,
+   "close": 177.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-17": {
+   "open": 176.1,
+   "high": 176.13,
+   "low": 170.31,
+   "close": 170.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-18": {
+   "open": 174.53,
+   "high": 176.15,
+   "low": 171.82,
+   "close": 174.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-19": {
+   "open": 176.67,
+   "high": 181.45,
+   "low": 176.34,
+   "close": 180.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-22": {
+   "open": 183.92,
+   "high": 184.16,
+   "low": 182.35,
+   "close": 183.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-23": {
+   "open": 182.97,
+   "high": 189.33,
+   "low": 182.9,
+   "close": 189.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-24": {
+   "open": 187.94,
+   "high": 188.91,
+   "low": 186.59,
+   "close": 188.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-26": {
+   "open": 189.92,
+   "high": 192.69,
+   "low": 188.0,
+   "close": 190.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-29": {
+   "open": 187.71,
+   "high": 188.76,
+   "low": 185.91,
+   "close": 188.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-30": {
+   "open": 188.24,
+   "high": 188.99,
+   "low": 186.93,
+   "close": 187.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-31": {
+   "open": 189.57,
+   "high": 190.56,
+   "low": 186.49,
+   "close": 186.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-02": {
+   "open": 189.84,
+   "high": 192.93,
+   "low": 188.26,
+   "close": 188.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-05": {
+   "open": 191.76,
+   "high": 193.63,
+   "low": 186.15,
+   "close": 188.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-06": {
+   "open": 190.52,
+   "high": 192.17,
+   "low": 186.82,
+   "close": 187.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-07": {
+   "open": 188.57,
+   "high": 191.37,
+   "low": 186.56,
+   "close": 189.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-08": {
+   "open": 189.11,
+   "high": 189.55,
+   "low": 183.71,
+   "close": 185.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-09": {
+   "open": 185.08,
+   "high": 186.34,
+   "low": 183.67,
+   "close": 184.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-12": {
+   "open": 183.22,
+   "high": 187.12,
+   "low": 183.02,
+   "close": 184.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-13": {
+   "open": 185.0,
+   "high": 188.11,
+   "low": 183.4,
+   "close": 185.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-14": {
+   "open": 184.32,
+   "high": 184.46,
+   "low": 180.8,
+   "close": 183.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-15": {
+   "open": 186.5,
+   "high": 189.7,
+   "low": 186.33,
+   "close": 187.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-16": {
+   "open": 189.08,
+   "high": 190.44,
+   "low": 186.08,
+   "close": 186.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-20": {
+   "open": 181.9,
+   "high": 182.38,
+   "low": 177.61,
+   "close": 178.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-21": {
+   "open": 179.05,
+   "high": 185.38,
+   "low": 178.4,
+   "close": 183.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-22": {
+   "open": 184.75,
+   "high": 186.17,
+   "low": 183.93,
+   "close": 184.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-23": {
+   "open": 187.5,
+   "high": 189.6,
+   "low": 186.82,
+   "close": 187.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-26": {
+   "open": 187.16,
+   "high": 189.12,
+   "low": 185.99,
+   "close": 186.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-27": {
+   "open": 187.24,
+   "high": 190.0,
+   "low": 185.7,
+   "close": 188.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-28": {
+   "open": 191.27,
+   "high": 192.35,
+   "low": 189.84,
+   "close": 191.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-29": {
+   "open": 191.34,
+   "high": 193.48,
+   "low": 186.06,
+   "close": 192.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-30": {
+   "open": 191.21,
+   "high": 194.49,
+   "low": 189.47,
+   "close": 191.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-02": {
+   "open": 187.2,
+   "high": 190.3,
+   "low": 184.88,
+   "close": 185.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-03": {
+   "open": 186.24,
+   "high": 186.27,
+   "low": 176.23,
+   "close": 180.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-04": {
+   "open": 179.46,
+   "high": 179.58,
+   "low": 171.91,
+   "close": 174.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-05": {
+   "open": 174.93,
+   "high": 176.82,
+   "low": 171.03,
+   "close": 171.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-06": {
+   "open": 176.69,
+   "high": 187.0,
+   "low": 174.6,
+   "close": 185.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-09": {
+   "open": 184.26,
+   "high": 193.66,
+   "low": 183.95,
+   "close": 190.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-10": {
+   "open": 191.38,
+   "high": 192.48,
+   "low": 188.12,
+   "close": 188.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-11": {
+   "open": 192.45,
+   "high": 193.26,
+   "low": 188.77,
+   "close": 190.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-12": {
+   "open": 193.03,
+   "high": 193.61,
+   "low": 186.51,
+   "close": 186.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-13": {
+   "open": 187.48,
+   "high": 187.5,
+   "low": 181.59,
+   "close": 182.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-17": {
+   "open": 181.75,
+   "high": 187.15,
+   "low": 179.18,
+   "close": 184.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-18": {
+   "open": 188.75,
+   "high": 190.37,
+   "low": 186.76,
+   "close": 187.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-19": {
+   "open": 187.06,
+   "high": 188.43,
+   "low": 185.66,
+   "close": 187.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-20": {
+   "open": 186.57,
+   "high": 190.33,
+   "low": 185.94,
+   "close": 189.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-23": {
+   "open": 191.4,
+   "high": 193.95,
+   "low": 189.58,
+   "close": 191.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-24": {
+   "open": 191.49,
+   "high": 193.77,
+   "low": 187.4,
+   "close": 192.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-25": {
+   "open": 194.45,
+   "high": 197.63,
+   "low": 193.79,
+   "close": 195.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-26": {
+   "open": 194.27,
+   "high": 194.29,
+   "low": 184.32,
+   "close": 184.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-27": {
+   "open": 181.25,
+   "high": 182.59,
+   "low": 176.38,
+   "close": 177.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-02": {
+   "open": 175.01,
+   "high": 183.46,
+   "low": 174.64,
+   "close": 182.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-03": {
+   "open": 178.49,
+   "high": 180.9,
+   "low": 176.92,
+   "close": 180.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-04": {
+   "open": 180.44,
+   "high": 184.7,
+   "low": 180.06,
+   "close": 183.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-05": {
+   "open": 181.17,
+   "high": 184.06,
+   "low": 177.88,
+   "close": 183.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-06": {
+   "open": 179.84,
+   "high": 182.76,
+   "low": 176.82,
+   "close": 177.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-09": {
+   "open": 176.83,
+   "high": 182.91,
+   "low": 175.56,
+   "close": 182.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-10": {
+   "open": 182.4,
+   "high": 186.44,
+   "low": 182.01,
+   "close": 184.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-11": {
+   "open": 185.91,
+   "high": 187.62,
+   "low": 184.45,
+   "close": 186.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-12": {
+   "open": 184.05,
+   "high": 184.94,
+   "low": 181.75,
+   "close": 183.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-13": {
+   "open": 184.92,
+   "high": 186.09,
+   "low": 179.94,
+   "close": 180.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-16": {
+   "open": 182.97,
+   "high": 188.88,
+   "low": 181.41,
+   "close": 183.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-17": {
+   "open": 185.06,
+   "high": 185.4,
+   "low": 181.68,
+   "close": 181.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-18": {
+   "open": 182.48,
+   "high": 183.38,
+   "low": 180.33,
+   "close": 180.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-19": {
+   "open": 178.01,
+   "high": 179.98,
+   "low": 175.79,
+   "close": 178.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-20": {
+   "open": 178.0,
+   "high": 178.26,
+   "low": 171.72,
+   "close": 172.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-23": {
+   "open": 177.26,
+   "high": 178.37,
+   "low": 174.76,
+   "close": 175.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-24": {
+   "open": 174.83,
+   "high": 176.22,
+   "low": 173.98,
+   "close": 175.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-25": {
+   "open": 177.1,
+   "high": 181.22,
+   "low": 176.85,
+   "close": 178.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-26": {
+   "open": 176.07,
+   "high": 176.51,
+   "low": 171.14,
+   "close": 171.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-27": {
+   "open": 170.0,
+   "high": 170.97,
+   "low": 167.01,
+   "close": 167.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-30": {
+   "open": 168.78,
+   "high": 169.45,
+   "low": 164.27,
+   "close": 165.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-31": {
+   "open": 166.97,
+   "high": 174.62,
+   "low": 166.96,
+   "close": 174.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-01": {
+   "open": 176.0,
+   "high": 177.37,
+   "low": 174.75,
+   "close": 175.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-02": {
+   "open": 172.18,
+   "high": 177.49,
+   "low": 171.37,
+   "close": 177.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-06": {
+   "open": 177.16,
+   "high": 177.79,
+   "low": 175.76,
+   "close": 177.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-07": {
+   "open": 175.73,
+   "high": 178.23,
+   "low": 173.66,
+   "close": 178.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-08": {
+   "open": 184.5,
+   "high": 185.26,
+   "low": 180.3,
+   "close": 182.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-09": {
+   "open": 181.84,
+   "high": 184.08,
+   "low": 180.62,
+   "close": 183.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-10": {
+   "open": 184.31,
+   "high": 190.0,
+   "low": 184.3,
+   "close": 188.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-13": {
+   "open": 186.03,
+   "high": 189.66,
+   "low": 185.74,
+   "close": 189.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-14": {
+   "open": 190.84,
+   "high": 196.51,
+   "low": 190.77,
+   "close": 196.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-15": {
+   "open": 196.54,
+   "high": 200.4,
+   "low": 195.74,
+   "close": 198.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-16": {
+   "open": 197.43,
+   "high": 199.85,
+   "low": 195.81,
+   "close": 198.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-17": {
+   "open": 199.9,
+   "high": 201.7,
+   "low": 199.27,
+   "close": 201.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-20": {
+   "open": 199.98,
+   "high": 202.17,
+   "low": 197.84,
+   "close": 202.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-21": {
+   "open": 202.13,
+   "high": 202.75,
+   "low": 199.0,
+   "close": 199.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-22": {
+   "open": 200.99,
+   "high": 202.5,
+   "low": 199.0,
+   "close": 202.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-23": {
+   "open": 202.46,
+   "high": 203.83,
+   "low": 197.22,
+   "close": 199.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-24": {
+   "open": 199.96,
+   "high": 210.95,
+   "low": 199.81,
+   "close": 208.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-27": {
+   "open": 209.65,
+   "high": 216.83,
+   "low": 207.38,
+   "close": 216.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-28": {
+   "open": 209.49,
+   "high": 214.73,
+   "low": 208.2,
+   "close": 213.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-29": {
+   "open": 212.7,
+   "high": 212.72,
+   "low": 207.58,
+   "close": 209.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-30": {
+   "open": 209.93,
+   "high": 210.3,
+   "low": 198.7,
+   "close": 199.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
   "2026-05-01": {
    "open": 201.28,
    "high": 203.0,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:29+08:00"
+  },
+  "2026-08-14": {
+   "open": 226.77,
+   "high": 227.49,
+   "low": 224.5,
+   "close": 225.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
   }
  }
 }

--- a/memory/bars/OKLO.json
+++ b/memory/bars/OKLO.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 88.54,
+   "high": 90.6,
+   "low": 85.5,
+   "close": 87.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-02": {
+   "open": 88.98,
+   "high": 96.5,
+   "low": 88.6,
+   "close": 91.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-03": {
+   "open": 90.99,
+   "high": 97.0,
+   "low": 89.01,
+   "close": 96.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-04": {
+   "open": 96.98,
+   "high": 114.29,
+   "low": 94.61,
+   "close": 111.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-05": {
+   "open": 105.99,
+   "high": 107.59,
+   "low": 100.51,
+   "close": 104.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-08": {
+   "open": 108.14,
+   "high": 109.17,
+   "low": 100.6,
+   "close": 104.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-09": {
+   "open": 103.61,
+   "high": 107.55,
+   "low": 101.92,
+   "close": 103.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-10": {
+   "open": 102.9,
+   "high": 104.57,
+   "low": 98.32,
+   "close": 100.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-11": {
+   "open": 98.49,
+   "high": 103.42,
+   "low": 94.41,
+   "close": 103.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-12": {
+   "open": 102.71,
+   "high": 103.14,
+   "low": 87.34,
+   "close": 87.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-15": {
+   "open": 89.35,
+   "high": 89.6,
+   "low": 82.0,
+   "close": 82.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-16": {
+   "open": 80.75,
+   "high": 84.24,
+   "low": 78.67,
+   "close": 83.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-17": {
+   "open": 84.29,
+   "high": 85.58,
+   "low": 75.0,
+   "close": 75.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-18": {
+   "open": 80.51,
+   "high": 81.0,
+   "low": 76.07,
+   "close": 77.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-19": {
+   "open": 78.7,
+   "high": 85.26,
+   "low": 78.53,
+   "close": 83.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-22": {
+   "open": 85.78,
+   "high": 85.83,
+   "low": 80.14,
+   "close": 83.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-23": {
+   "open": 81.81,
+   "high": 84.95,
+   "low": 80.79,
+   "close": 81.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-24": {
+   "open": 80.49,
+   "high": 81.31,
+   "low": 78.64,
+   "close": 81.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-26": {
+   "open": 80.03,
+   "high": 80.35,
+   "low": 76.16,
+   "close": 76.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-29": {
+   "open": 74.8,
+   "high": 78.48,
+   "low": 73.76,
+   "close": 74.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-30": {
+   "open": 74.31,
+   "high": 74.65,
+   "low": 71.6,
+   "close": 71.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-31": {
+   "open": 71.42,
+   "high": 72.32,
+   "low": 70.86,
+   "close": 71.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-02": {
+   "open": 73.99,
+   "high": 77.92,
+   "low": 72.13,
+   "close": 77.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-05": {
+   "open": 81.65,
+   "high": 90.85,
+   "low": 80.4,
+   "close": 89.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-06": {
+   "open": 93.0,
+   "high": 96.95,
+   "low": 88.73,
+   "close": 95.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-07": {
+   "open": 93.6,
+   "high": 100.69,
+   "low": 92.81,
+   "close": 97.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-08": {
+   "open": 96.71,
+   "high": 100.19,
+   "low": 93.42,
+   "close": 97.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-09": {
+   "open": 114.35,
+   "high": 115.72,
+   "low": 104.03,
+   "close": 105.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-12": {
+   "open": 103.33,
+   "high": 105.9,
+   "low": 100.37,
+   "close": 102.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-13": {
+   "open": 105.75,
+   "high": 107.6,
+   "low": 96.6,
+   "close": 97.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-14": {
+   "open": 94.77,
+   "high": 97.08,
+   "low": 91.5,
+   "close": 95.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-15": {
+   "open": 97.8,
+   "high": 99.29,
+   "low": 91.38,
+   "close": 91.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-16": {
+   "open": 92.1,
+   "high": 96.7,
+   "low": 89.3,
+   "close": 94.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-20": {
+   "open": 90.84,
+   "high": 97.0,
+   "low": 88.93,
+   "close": 89.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-21": {
+   "open": 96.39,
+   "high": 100.2,
+   "low": 86.02,
+   "close": 90.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-22": {
+   "open": 92.46,
+   "high": 93.6,
+   "low": 89.88,
+   "close": 90.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-23": {
+   "open": 91.39,
+   "high": 91.39,
+   "low": 86.17,
+   "close": 87.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-26": {
+   "open": 86.18,
+   "high": 86.81,
+   "low": 81.13,
+   "close": 82.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-27": {
+   "open": 82.81,
+   "high": 86.85,
+   "low": 81.21,
+   "close": 85.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-28": {
+   "open": 86.73,
+   "high": 95.1,
+   "low": 85.6,
+   "close": 94.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-29": {
+   "open": 93.95,
+   "high": 93.95,
+   "low": 83.5,
+   "close": 86.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-30": {
+   "open": 85.15,
+   "high": 88.68,
+   "low": 78.91,
+   "close": 79.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-02": {
+   "open": 78.25,
+   "high": 78.38,
+   "low": 73.29,
+   "close": 73.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-03": {
+   "open": 75.48,
+   "high": 79.18,
+   "low": 74.03,
+   "close": 78.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-04": {
+   "open": 77.2,
+   "high": 77.26,
+   "low": 64.0,
+   "close": 68.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-05": {
+   "open": 66.5,
+   "high": 67.38,
+   "low": 61.68,
+   "close": 62.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-06": {
+   "open": 64.98,
+   "high": 72.18,
+   "low": 64.31,
+   "close": 71.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-09": {
+   "open": 69.31,
+   "high": 75.5,
+   "low": 68.64,
+   "close": 75.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-10": {
+   "open": 74.48,
+   "high": 76.37,
+   "low": 69.13,
+   "close": 69.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-11": {
+   "open": 71.44,
+   "high": 71.5,
+   "low": 64.89,
+   "close": 66.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-12": {
+   "open": 67.17,
+   "high": 67.71,
+   "low": 63.62,
+   "close": 63.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-13": {
+   "open": 64.42,
+   "high": 68.19,
+   "low": 62.56,
+   "close": 65.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-17": {
+   "open": 64.6,
+   "high": 69.59,
+   "low": 62.84,
+   "close": 67.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-18": {
+   "open": 67.38,
+   "high": 70.15,
+   "low": 65.8,
+   "close": 67.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-19": {
+   "open": 66.23,
+   "high": 68.36,
+   "low": 64.34,
+   "close": 67.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-20": {
+   "open": 66.66,
+   "high": 67.77,
+   "low": 62.68,
+   "close": 63.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-23": {
+   "open": 61.6,
+   "high": 63.34,
+   "low": 60.89,
+   "close": 63.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-24": {
+   "open": 61.71,
+   "high": 65.3,
+   "low": 60.12,
+   "close": 65.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-25": {
+   "open": 66.41,
+   "high": 67.67,
+   "low": 64.76,
+   "close": 66.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-26": {
+   "open": 65.84,
+   "high": 69.95,
+   "low": 64.6,
+   "close": 69.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-27": {
+   "open": 65.72,
+   "high": 66.08,
+   "low": 62.07,
+   "close": 62.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-02": {
+   "open": 60.12,
+   "high": 64.9,
+   "low": 60.0,
+   "close": 64.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-03": {
+   "open": 61.93,
+   "high": 64.52,
+   "low": 60.04,
+   "close": 63.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-04": {
+   "open": 63.8,
+   "high": 66.18,
+   "low": 63.3,
+   "close": 65.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-05": {
+   "open": 64.4,
+   "high": 64.62,
+   "low": 59.07,
+   "close": 62.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-06": {
+   "open": 60.31,
+   "high": 62.8,
+   "low": 58.19,
+   "close": 58.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-09": {
+   "open": 57.11,
+   "high": 62.06,
+   "low": 56.47,
+   "close": 61.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-10": {
+   "open": 61.91,
+   "high": 63.45,
+   "low": 61.26,
+   "close": 61.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-11": {
+   "open": 61.8,
+   "high": 64.1,
+   "low": 61.11,
+   "close": 62.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-12": {
+   "open": 61.74,
+   "high": 63.2,
+   "low": 59.51,
+   "close": 59.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-13": {
+   "open": 61.06,
+   "high": 61.73,
+   "low": 57.95,
+   "close": 58.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-16": {
+   "open": 59.84,
+   "high": 60.36,
+   "low": 57.83,
+   "close": 59.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-17": {
+   "open": 64.96,
+   "high": 65.97,
+   "low": 59.24,
+   "close": 60.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-18": {
+   "open": 60.19,
+   "high": 61.75,
+   "low": 56.68,
+   "close": 56.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-19": {
+   "open": 55.64,
+   "high": 56.69,
+   "low": 53.5,
+   "close": 54.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-20": {
+   "open": 54.57,
+   "high": 57.32,
+   "low": 52.75,
+   "close": 53.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-23": {
+   "open": 54.6,
+   "high": 57.21,
+   "low": 54.02,
+   "close": 56.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-24": {
+   "open": 55.46,
+   "high": 56.08,
+   "low": 53.33,
+   "close": 54.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-25": {
+   "open": 56.46,
+   "high": 57.65,
+   "low": 54.43,
+   "close": 55.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-26": {
+   "open": 53.61,
+   "high": 54.88,
+   "low": 51.1,
+   "close": 51.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-27": {
+   "open": 51.52,
+   "high": 52.64,
+   "low": 50.15,
+   "close": 50.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-30": {
+   "open": 50.94,
+   "high": 51.97,
+   "low": 44.88,
+   "close": 45.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-31": {
+   "open": 46.02,
+   "high": 50.0,
+   "low": 45.6,
+   "close": 49.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-01": {
+   "open": 51.08,
+   "high": 51.85,
+   "low": 47.92,
+   "close": 48.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-02": {
+   "open": 45.95,
+   "high": 49.05,
+   "low": 45.36,
+   "close": 48.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-06": {
+   "open": 48.1,
+   "high": 49.85,
+   "low": 47.98,
+   "close": 48.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-07": {
+   "open": 47.4,
+   "high": 47.94,
+   "low": 44.91,
+   "close": 46.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-08": {
+   "open": 50.52,
+   "high": 51.38,
+   "low": 48.0,
+   "close": 50.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-09": {
+   "open": 49.53,
+   "high": 50.36,
+   "low": 47.4,
+   "close": 47.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-10": {
+   "open": 48.86,
+   "high": 52.15,
+   "low": 48.55,
+   "close": 50.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-13": {
+   "open": 49.0,
+   "high": 53.96,
+   "low": 48.1,
+   "close": 53.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-14": {
+   "open": 59.09,
+   "high": 61.61,
+   "low": 56.22,
+   "close": 58.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-15": {
+   "open": 62.53,
+   "high": 66.62,
+   "low": 61.11,
+   "close": 63.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-16": {
+   "open": 67.61,
+   "high": 68.76,
+   "low": 60.81,
+   "close": 64.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-17": {
+   "open": 66.06,
+   "high": 74.21,
+   "low": 64.95,
+   "close": 66.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-20": {
+   "open": 65.53,
+   "high": 68.3,
+   "low": 63.75,
+   "close": 68.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-21": {
+   "open": 68.41,
+   "high": 69.0,
+   "low": 62.22,
+   "close": 62.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-22": {
+   "open": 65.19,
+   "high": 72.63,
+   "low": 64.75,
+   "close": 72.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-23": {
+   "open": 77.73,
+   "high": 80.64,
+   "low": 73.66,
+   "close": 76.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-24": {
+   "open": 81.29,
+   "high": 81.5,
+   "low": 70.88,
+   "close": 71.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-27": {
+   "open": 71.0,
+   "high": 76.2,
+   "low": 70.3,
+   "close": 75.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-28": {
+   "open": 71.51,
+   "high": 72.87,
+   "low": 68.79,
+   "close": 69.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-29": {
+   "open": 70.54,
+   "high": 70.6,
+   "low": 63.2,
+   "close": 64.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-30": {
+   "open": 65.54,
+   "high": 72.84,
+   "low": 65.26,
+   "close": 72.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
   "2026-05-01": {
    "open": 71.68,
    "high": 71.68,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:29+08:00"
+  },
+  "2026-08-14": {
+   "open": 46.51,
+   "high": 47.26,
+   "low": 44.32,
+   "close": 44.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
   }
  }
 }

--- a/memory/bars/PLTR.json
+++ b/memory/bars/PLTR.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 165.0,
+   "high": 169.1,
+   "low": 163.12,
+   "close": 167.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-02": {
+   "open": 169.59,
+   "high": 175.75,
+   "low": 169.59,
+   "close": 170.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-03": {
+   "open": 170.14,
+   "high": 177.91,
+   "low": 168.83,
+   "close": 176.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-04": {
+   "open": 176.37,
+   "high": 178.44,
+   "low": 174.43,
+   "close": 177.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-05": {
+   "open": 178.23,
+   "high": 182.15,
+   "low": 177.16,
+   "close": 181.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-08": {
+   "open": 182.21,
+   "high": 183.88,
+   "low": 179.54,
+   "close": 181.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-09": {
+   "open": 180.97,
+   "high": 182.85,
+   "low": 180.38,
+   "close": 181.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-10": {
+   "open": 184.95,
+   "high": 190.39,
+   "low": 182.75,
+   "close": 187.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-11": {
+   "open": 184.8,
+   "high": 188.05,
+   "low": 180.21,
+   "close": 187.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-12": {
+   "open": 185.81,
+   "high": 186.53,
+   "low": 177.67,
+   "close": 183.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-15": {
+   "open": 185.08,
+   "high": 187.78,
+   "low": 180.03,
+   "close": 183.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-16": {
+   "open": 181.66,
+   "high": 188.5,
+   "low": 181.14,
+   "close": 187.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-17": {
+   "open": 187.72,
+   "high": 187.75,
+   "low": 176.5,
+   "close": 177.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-18": {
+   "open": 181.51,
+   "high": 187.33,
+   "low": 181.51,
+   "close": 185.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-19": {
+   "open": 186.74,
+   "high": 195.0,
+   "low": 186.73,
+   "close": 193.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-22": {
+   "open": 195.04,
+   "high": 198.88,
+   "low": 192.43,
+   "close": 193.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-23": {
+   "open": 192.83,
+   "high": 195.37,
+   "low": 191.74,
+   "close": 194.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-24": {
+   "open": 193.16,
+   "high": 195.17,
+   "low": 192.83,
+   "close": 194.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-26": {
+   "open": 195.02,
+   "high": 196.35,
+   "low": 188.62,
+   "close": 188.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-29": {
+   "open": 186.85,
+   "high": 187.2,
+   "low": 183.64,
+   "close": 184.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-30": {
+   "open": 184.35,
+   "high": 184.73,
+   "low": 180.7,
+   "close": 180.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2025-12-31": {
+   "open": 181.13,
+   "high": 181.53,
+   "low": 177.25,
+   "close": 177.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-02": {
+   "open": 181.3,
+   "high": 181.35,
+   "low": 166.35,
+   "close": 167.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-05": {
+   "open": 174.88,
+   "high": 175.82,
+   "low": 171.79,
+   "close": 174.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-06": {
+   "open": 175.76,
+   "high": 180.19,
+   "low": 174.77,
+   "close": 179.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-07": {
+   "open": 179.8,
+   "high": 187.28,
+   "low": 177.66,
+   "close": 181.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-08": {
+   "open": 185.62,
+   "high": 185.66,
+   "low": 174.37,
+   "close": 176.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-09": {
+   "open": 177.02,
+   "high": 178.72,
+   "low": 174.75,
+   "close": 177.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-12": {
+   "open": 177.69,
+   "high": 182.5,
+   "low": 176.34,
+   "close": 179.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-13": {
+   "open": 178.88,
+   "high": 181.1,
+   "low": 176.14,
+   "close": 178.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-14": {
+   "open": 178.13,
+   "high": 181.6,
+   "low": 173.95,
+   "close": 178.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-15": {
+   "open": 178.71,
+   "high": 180.6,
+   "low": 176.53,
+   "close": 177.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-16": {
+   "open": 179.36,
+   "high": 182.43,
+   "low": 170.01,
+   "close": 170.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-20": {
+   "open": 167.63,
+   "high": 171.97,
+   "low": 166.24,
+   "close": 168.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-21": {
+   "open": 168.4,
+   "high": 169.49,
+   "low": 161.11,
+   "close": 165.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-22": {
+   "open": 168.93,
+   "high": 169.0,
+   "low": 164.95,
+   "close": 165.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-23": {
+   "open": 167.27,
+   "high": 172.0,
+   "low": 166.3,
+   "close": 169.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-26": {
+   "open": 168.21,
+   "high": 170.59,
+   "low": 167.33,
+   "close": 167.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-27": {
+   "open": 167.48,
+   "high": 169.44,
+   "low": 164.69,
+   "close": 165.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-28": {
+   "open": 164.4,
+   "high": 165.05,
+   "low": 157.24,
+   "close": 157.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-29": {
+   "open": 157.63,
+   "high": 157.63,
+   "low": 147.12,
+   "close": 151.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-01-30": {
+   "open": 150.05,
+   "high": 151.0,
+   "low": 145.14,
+   "close": 146.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-02": {
+   "open": 150.94,
+   "high": 151.4,
+   "low": 146.65,
+   "close": 147.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-03": {
+   "open": 165.05,
+   "high": 165.08,
+   "low": 153.12,
+   "close": 157.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-04": {
+   "open": 155.41,
+   "high": 155.85,
+   "low": 135.68,
+   "close": 139.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-05": {
+   "open": 136.82,
+   "high": 137.98,
+   "low": 128.32,
+   "close": 130.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-06": {
+   "open": 135.33,
+   "high": 137.69,
+   "low": 132.35,
+   "close": 135.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-09": {
+   "open": 136.58,
+   "high": 145.87,
+   "low": 134.78,
+   "close": 142.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-10": {
+   "open": 144.97,
+   "high": 145.56,
+   "low": 137.77,
+   "close": 139.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-11": {
+   "open": 139.03,
+   "high": 139.25,
+   "low": 132.95,
+   "close": 135.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-12": {
+   "open": 135.36,
+   "high": 135.89,
+   "low": 126.56,
+   "close": 129.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-13": {
+   "open": 127.9,
+   "high": 133.56,
+   "low": 126.23,
+   "close": 131.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-17": {
+   "open": 128.9,
+   "high": 134.32,
+   "low": 127.29,
+   "close": 133.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-18": {
+   "open": 135.89,
+   "high": 140.96,
+   "low": 134.87,
+   "close": 135.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-19": {
+   "open": 132.31,
+   "high": 136.16,
+   "low": 131.01,
+   "close": 134.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-20": {
+   "open": 132.37,
+   "high": 136.21,
+   "low": 131.17,
+   "close": 135.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-23": {
+   "open": 132.04,
+   "high": 132.04,
+   "low": 127.39,
+   "close": 130.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-24": {
+   "open": 129.01,
+   "high": 130.24,
+   "low": 126.37,
+   "close": 128.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-25": {
+   "open": 130.61,
+   "high": 136.09,
+   "low": 129.18,
+   "close": 134.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-26": {
+   "open": 133.85,
+   "high": 137.51,
+   "low": 132.63,
+   "close": 135.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-02-27": {
+   "open": 134.07,
+   "high": 138.1,
+   "low": 133.98,
+   "close": 137.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-02": {
+   "open": 140.78,
+   "high": 147.14,
+   "low": 140.52,
+   "close": 145.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-03": {
+   "open": 142.1,
+   "high": 147.5,
+   "low": 138.2,
+   "close": 147.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-04": {
+   "open": 148.43,
+   "high": 154.52,
+   "low": 148.06,
+   "close": 153.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-05": {
+   "open": 152.94,
+   "high": 156.38,
+   "low": 149.61,
+   "close": 152.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-06": {
+   "open": 150.44,
+   "high": 161.45,
+   "low": 150.29,
+   "close": 157.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-09": {
+   "open": 155.69,
+   "high": 158.44,
+   "low": 152.97,
+   "close": 156.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-10": {
+   "open": 155.99,
+   "high": 156.66,
+   "low": 150.14,
+   "close": 151.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-11": {
+   "open": 151.38,
+   "high": 153.17,
+   "low": 149.33,
+   "close": 151.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-12": {
+   "open": 153.01,
+   "high": 155.88,
+   "low": 150.98,
+   "close": 153.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-13": {
+   "open": 153.3,
+   "high": 154.56,
+   "low": 148.58,
+   "close": 150.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-16": {
+   "open": 152.45,
+   "high": 153.86,
+   "low": 151.17,
+   "close": 152.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-17": {
+   "open": 152.41,
+   "high": 156.75,
+   "low": 152.12,
+   "close": 155.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-18": {
+   "open": 154.95,
+   "high": 156.69,
+   "low": 152.61,
+   "close": 152.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-19": {
+   "open": 153.1,
+   "high": 156.15,
+   "low": 150.5,
+   "close": 155.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-20": {
+   "open": 155.2,
+   "high": 156.65,
+   "low": 149.09,
+   "close": 150.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-23": {
+   "open": 153.24,
+   "high": 161.08,
+   "low": 153.24,
+   "close": 160.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-24": {
+   "open": 160.07,
+   "high": 162.4,
+   "low": 151.64,
+   "close": 154.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-25": {
+   "open": 157.42,
+   "high": 160.27,
+   "low": 154.86,
+   "close": 154.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-26": {
+   "open": 153.06,
+   "high": 153.12,
+   "low": 147.25,
+   "close": 147.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-27": {
+   "open": 145.88,
+   "high": 145.96,
+   "low": 141.56,
+   "close": 143.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-30": {
+   "open": 143.27,
+   "high": 144.12,
+   "low": 136.3,
+   "close": 137.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-03-31": {
+   "open": 140.02,
+   "high": 147.86,
+   "low": 138.97,
+   "close": 146.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-01": {
+   "open": 147.0,
+   "high": 148.3,
+   "low": 144.47,
+   "close": 146.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-02": {
+   "open": 143.49,
+   "high": 148.51,
+   "low": 137.99,
+   "close": 148.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-06": {
+   "open": 148.36,
+   "high": 150.61,
+   "low": 146.63,
+   "close": 147.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-07": {
+   "open": 146.88,
+   "high": 150.27,
+   "low": 144.45,
+   "close": 150.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-08": {
+   "open": 154.77,
+   "high": 156.28,
+   "low": 139.17,
+   "close": 140.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-09": {
+   "open": 139.4,
+   "high": 139.54,
+   "low": 128.47,
+   "close": 130.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-10": {
+   "open": 128.48,
+   "high": 129.2,
+   "low": 122.68,
+   "close": 128.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-13": {
+   "open": 130.23,
+   "high": 134.42,
+   "low": 129.15,
+   "close": 132.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-14": {
+   "open": 134.43,
+   "high": 138.07,
+   "low": 134.0,
+   "close": 135.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-15": {
+   "open": 136.79,
+   "high": 142.58,
+   "low": 134.93,
+   "close": 142.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-16": {
+   "open": 144.29,
+   "high": 145.55,
+   "low": 139.53,
+   "close": 142.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-17": {
+   "open": 145.32,
+   "high": 148.28,
+   "low": 143.3,
+   "close": 146.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-20": {
+   "open": 145.0,
+   "high": 147.2,
+   "low": 143.83,
+   "close": 145.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-21": {
+   "open": 146.81,
+   "high": 149.87,
+   "low": 144.0,
+   "close": 145.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-22": {
+   "open": 148.36,
+   "high": 152.68,
+   "low": 147.41,
+   "close": 152.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-23": {
+   "open": 149.7,
+   "high": 150.29,
+   "low": 139.92,
+   "close": 141.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-24": {
+   "open": 142.96,
+   "high": 143.33,
+   "low": 138.93,
+   "close": 143.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-27": {
+   "open": 141.25,
+   "high": 145.07,
+   "low": 141.01,
+   "close": 143.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-28": {
+   "open": 142.3,
+   "high": 143.85,
+   "low": 140.42,
+   "close": 141.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-29": {
+   "open": 139.76,
+   "high": 139.76,
+   "low": 134.68,
+   "close": 137.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
+  "2026-04-30": {
+   "open": 138.48,
+   "high": 140.2,
+   "low": 136.65,
+   "close": 139.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
+  },
   "2026-05-01": {
    "open": 143.25,
    "high": 146.44,
@@ -662,6 +1598,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:29+08:00"
+  },
+  "2026-08-14": {
+   "open": 179.48,
+   "high": 180.18,
+   "low": 173.8,
+   "close": 174.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:48+08:00"
   }
  },
  "retired": false

--- a/memory/bars/PLTU.json
+++ b/memory/bars/PLTU.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 77.08,
+   "high": 81.32,
+   "low": 75.79,
+   "close": 79.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-02": {
+   "open": 81.99,
+   "high": 87.6,
+   "low": 81.99,
+   "close": 82.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-03": {
+   "open": 82.05,
+   "high": 88.25,
+   "low": 81.11,
+   "close": 88.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-04": {
+   "open": 88.34,
+   "high": 90.32,
+   "low": 86.31,
+   "close": 89.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-05": {
+   "open": 89.93,
+   "high": 94.01,
+   "low": 89.08,
+   "close": 93.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-08": {
+   "open": 94.03,
+   "high": 95.73,
+   "low": 91.38,
+   "close": 93.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-09": {
+   "open": 93.0,
+   "high": 94.68,
+   "low": 92.25,
+   "close": 93.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-10": {
+   "open": 80.99,
+   "high": 86.63,
+   "low": 78.87,
+   "close": 84.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-11": {
+   "open": 81.16,
+   "high": 84.16,
+   "low": 77.24,
+   "close": 83.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-12": {
+   "open": 82.02,
+   "high": 82.09,
+   "low": 75.0,
+   "close": 80.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-15": {
+   "open": 81.5,
+   "high": 83.71,
+   "low": 79.75,
+   "close": 79.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-16": {
+   "open": 78.33,
+   "high": 84.5,
+   "low": 78.02,
+   "close": 83.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-17": {
+   "open": 83.72,
+   "high": 83.72,
+   "low": 74.04,
+   "close": 74.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-18": {
+   "open": 78.04,
+   "high": 82.75,
+   "low": 78.0,
+   "close": 81.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-19": {
+   "open": 82.38,
+   "high": 89.5,
+   "low": 82.38,
+   "close": 88.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-22": {
+   "open": 89.51,
+   "high": 93.01,
+   "low": 87.3,
+   "close": 88.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-23": {
+   "open": 87.0,
+   "high": 89.2,
+   "low": 85.98,
+   "close": 88.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-24": {
+   "open": 87.3,
+   "high": 89.0,
+   "low": 86.94,
+   "close": 88.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-26": {
+   "open": 89.0,
+   "high": 90.0,
+   "low": 82.96,
+   "close": 83.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-29": {
+   "open": 81.48,
+   "high": 81.66,
+   "low": 78.57,
+   "close": 79.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-30": {
+   "open": 79.07,
+   "high": 79.5,
+   "low": 76.06,
+   "close": 76.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-31": {
+   "open": 76.37,
+   "high": 76.71,
+   "low": 73.15,
+   "close": 73.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-02": {
+   "open": 76.56,
+   "high": 76.56,
+   "low": 64.1,
+   "close": 65.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-05": {
+   "open": 70.76,
+   "high": 71.46,
+   "low": 68.38,
+   "close": 70.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-06": {
+   "open": 71.45,
+   "high": 74.96,
+   "low": 70.67,
+   "close": 74.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-07": {
+   "open": 74.62,
+   "high": 80.84,
+   "low": 72.9,
+   "close": 76.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-08": {
+   "open": 79.3,
+   "high": 79.5,
+   "low": 70.12,
+   "close": 72.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-09": {
+   "open": 72.18,
+   "high": 73.59,
+   "low": 70.41,
+   "close": 72.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-12": {
+   "open": 72.82,
+   "high": 76.67,
+   "low": 71.71,
+   "close": 74.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-13": {
+   "open": 73.25,
+   "high": 75.52,
+   "low": 71.44,
+   "close": 73.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-14": {
+   "open": 73.17,
+   "high": 75.87,
+   "low": 69.66,
+   "close": 73.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-15": {
+   "open": 73.81,
+   "high": 75.02,
+   "low": 71.75,
+   "close": 72.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-16": {
+   "open": 73.57,
+   "high": 76.34,
+   "low": 66.34,
+   "close": 67.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-20": {
+   "open": 64.34,
+   "high": 67.83,
+   "low": 63.38,
+   "close": 65.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-21": {
+   "open": 65.1,
+   "high": 65.86,
+   "low": 59.45,
+   "close": 62.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-22": {
+   "open": 65.06,
+   "high": 65.16,
+   "low": 62.42,
+   "close": 63.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-23": {
+   "open": 64.4,
+   "high": 67.6,
+   "low": 63.4,
+   "close": 65.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-26": {
+   "open": 65.07,
+   "high": 66.5,
+   "low": 64.12,
+   "close": 64.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-27": {
+   "open": 64.15,
+   "high": 65.61,
+   "low": 62.02,
+   "close": 62.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-28": {
+   "open": 61.75,
+   "high": 62.17,
+   "low": 56.43,
+   "close": 56.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-29": {
+   "open": 56.6,
+   "high": 56.6,
+   "low": 49.11,
+   "close": 52.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-30": {
+   "open": 51.29,
+   "high": 51.85,
+   "low": 47.85,
+   "close": 48.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-02": {
+   "open": 51.62,
+   "high": 51.94,
+   "low": 48.85,
+   "close": 49.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-03": {
+   "open": 61.0,
+   "high": 61.1,
+   "low": 53.19,
+   "close": 56.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-04": {
+   "open": 54.53,
+   "high": 54.66,
+   "low": 40.45,
+   "close": 43.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-05": {
+   "open": 41.63,
+   "high": 42.13,
+   "low": 36.26,
+   "close": 37.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-06": {
+   "open": 40.38,
+   "high": 41.66,
+   "low": 38.68,
+   "close": 40.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-09": {
+   "open": 41.04,
+   "high": 46.62,
+   "low": 39.93,
+   "close": 44.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-10": {
+   "open": 46.2,
+   "high": 46.48,
+   "low": 41.59,
+   "close": 42.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-11": {
+   "open": 42.38,
+   "high": 42.52,
+   "low": 38.64,
+   "close": 40.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-12": {
+   "open": 40.05,
+   "high": 40.4,
+   "low": 34.9,
+   "close": 36.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-13": {
+   "open": 35.94,
+   "high": 38.84,
+   "low": 34.74,
+   "close": 37.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-17": {
+   "open": 36.18,
+   "high": 39.28,
+   "low": 35.28,
+   "close": 38.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-18": {
+   "open": 40.14,
+   "high": 43.13,
+   "low": 39.6,
+   "close": 39.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-19": {
+   "open": 38.1,
+   "high": 40.34,
+   "low": 37.31,
+   "close": 39.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-20": {
+   "open": 38.07,
+   "high": 40.3,
+   "low": 37.4,
+   "close": 39.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-23": {
+   "open": 37.86,
+   "high": 37.86,
+   "low": 35.16,
+   "close": 37.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-24": {
+   "open": 36.12,
+   "high": 36.74,
+   "low": 34.66,
+   "close": 36.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-25": {
+   "open": 36.92,
+   "high": 40.04,
+   "low": 36.2,
+   "close": 38.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-26": {
+   "open": 38.85,
+   "high": 40.9,
+   "low": 38.06,
+   "close": 39.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-27": {
+   "open": 38.91,
+   "high": 41.21,
+   "low": 38.82,
+   "close": 40.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-02": {
+   "open": 42.79,
+   "high": 46.59,
+   "low": 42.71,
+   "close": 45.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-03": {
+   "open": 43.41,
+   "high": 46.83,
+   "low": 41.06,
+   "close": 46.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-04": {
+   "open": 47.36,
+   "high": 51.27,
+   "low": 47.2,
+   "close": 50.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-05": {
+   "open": 50.13,
+   "high": 52.54,
+   "low": 48.06,
+   "close": 50.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-06": {
+   "open": 48.62,
+   "high": 55.77,
+   "low": 48.5,
+   "close": 52.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-09": {
+   "open": 51.9,
+   "high": 53.74,
+   "low": 50.16,
+   "close": 52.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-10": {
+   "open": 52.22,
+   "high": 52.5,
+   "low": 48.25,
+   "close": 48.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-11": {
+   "open": 49.18,
+   "high": 50.2,
+   "low": 47.74,
+   "close": 49.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-12": {
+   "open": 50.19,
+   "high": 51.97,
+   "low": 48.8,
+   "close": 50.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-13": {
+   "open": 50.05,
+   "high": 51.05,
+   "low": 47.16,
+   "close": 48.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-16": {
+   "open": 49.68,
+   "high": 50.56,
+   "low": 48.86,
+   "close": 49.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-17": {
+   "open": 49.54,
+   "high": 52.45,
+   "low": 49.49,
+   "close": 51.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-18": {
+   "open": 51.19,
+   "high": 52.4,
+   "low": 49.7,
+   "close": 49.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-19": {
+   "open": 50.0,
+   "high": 51.97,
+   "low": 48.34,
+   "close": 51.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-20": {
+   "open": 51.21,
+   "high": 52.23,
+   "low": 47.33,
+   "close": 48.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-23": {
+   "open": 50.15,
+   "high": 54.96,
+   "low": 50.0,
+   "close": 54.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-24": {
+   "open": 53.9,
+   "high": 55.42,
+   "low": 48.3,
+   "close": 50.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-25": {
+   "open": 52.0,
+   "high": 53.84,
+   "low": 50.38,
+   "close": 50.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-26": {
+   "open": 49.09,
+   "high": 49.17,
+   "low": 45.41,
+   "close": 45.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-27": {
+   "open": 44.28,
+   "high": 44.46,
+   "low": 41.93,
+   "close": 42.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-30": {
+   "open": 43.08,
+   "high": 43.32,
+   "low": 38.77,
+   "close": 39.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-31": {
+   "open": 40.92,
+   "high": 45.35,
+   "low": 40.28,
+   "close": 44.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-01": {
+   "open": 44.81,
+   "high": 45.68,
+   "low": 43.36,
+   "close": 44.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-02": {
+   "open": 42.54,
+   "high": 45.74,
+   "low": 40.95,
+   "close": 45.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-06": {
+   "open": 45.59,
+   "high": 47.0,
+   "low": 44.59,
+   "close": 45.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-07": {
+   "open": 44.7,
+   "high": 46.78,
+   "low": 43.25,
+   "close": 46.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-08": {
+   "open": 49.7,
+   "high": 50.51,
+   "low": 39.89,
+   "close": 40.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-09": {
+   "open": 40.1,
+   "high": 40.1,
+   "low": 33.76,
+   "close": 34.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-10": {
+   "open": 33.79,
+   "high": 34.18,
+   "low": 30.71,
+   "close": 33.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-13": {
+   "open": 34.7,
+   "high": 36.89,
+   "low": 34.14,
+   "close": 35.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-14": {
+   "open": 36.83,
+   "high": 38.86,
+   "low": 36.7,
+   "close": 37.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-15": {
+   "open": 38.26,
+   "high": 41.37,
+   "low": 37.18,
+   "close": 41.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-16": {
+   "open": 42.44,
+   "high": 42.64,
+   "low": 39.63,
+   "close": 41.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-17": {
+   "open": 42.94,
+   "high": 44.67,
+   "low": 41.78,
+   "close": 43.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-20": {
+   "open": 42.7,
+   "high": 44.05,
+   "low": 42.05,
+   "close": 43.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-21": {
+   "open": 43.84,
+   "high": 45.62,
+   "low": 42.13,
+   "close": 43.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-22": {
+   "open": 44.75,
+   "high": 47.25,
+   "low": 44.15,
+   "close": 47.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-23": {
+   "open": 45.26,
+   "high": 45.78,
+   "low": 39.38,
+   "close": 40.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-24": {
+   "open": 41.2,
+   "high": 41.41,
+   "low": 38.84,
+   "close": 41.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-27": {
+   "open": 40.11,
+   "high": 42.33,
+   "low": 40.01,
+   "close": 41.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-28": {
+   "open": 40.56,
+   "high": 41.56,
+   "low": 39.68,
+   "close": 40.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-29": {
+   "open": 39.2,
+   "high": 39.25,
+   "low": 36.4,
+   "close": 38.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-30": {
+   "open": 38.31,
+   "high": 39.48,
+   "low": 37.52,
+   "close": 38.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
   "2026-05-01": {
    "open": 41.18,
    "high": 42.93,
@@ -670,6 +1606,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:30+08:00"
+  },
+  "2026-08-14": {
+   "open": 53.68,
+   "high": 54.2,
+   "low": 50.45,
+   "close": 50.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/QQQ.json
+++ b/memory/bars/QQQ.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 613.63,
+   "high": 619.44,
+   "low": 612.52,
+   "close": 617.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-02": {
+   "open": 619.46,
+   "high": 623.75,
+   "low": 617.59,
+   "close": 622.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-03": {
+   "open": 619.62,
+   "high": 624.22,
+   "low": 618.03,
+   "close": 623.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-04": {
+   "open": 624.93,
+   "high": 624.94,
+   "low": 619.54,
+   "close": 622.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-05": {
+   "open": 624.38,
+   "high": 628.92,
+   "low": 623.71,
+   "close": 625.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-08": {
+   "open": 627.21,
+   "high": 628.84,
+   "low": 621.69,
+   "close": 624.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-09": {
+   "open": 623.01,
+   "high": 625.87,
+   "low": 621.0,
+   "close": 625.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-10": {
+   "open": 623.85,
+   "high": 629.21,
+   "low": 620.99,
+   "close": 627.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-11": {
+   "open": 623.82,
+   "high": 625.78,
+   "low": 617.72,
+   "close": 625.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-12": {
+   "open": 622.08,
+   "high": 623.54,
+   "low": 611.36,
+   "close": 613.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-15": {
+   "open": 618.37,
+   "high": 618.42,
+   "low": 609.32,
+   "close": 610.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-16": {
+   "open": 608.26,
+   "high": 613.51,
+   "low": 606.91,
+   "close": 611.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-17": {
+   "open": 613.06,
+   "high": 613.65,
+   "low": 600.28,
+   "close": 600.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-18": {
+   "open": 609.8,
+   "high": 612.93,
+   "low": 606.92,
+   "close": 609.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-19": {
+   "open": 611.95,
+   "high": 617.62,
+   "low": 611.87,
+   "close": 617.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-22": {
+   "open": 621.35,
+   "high": 621.65,
+   "low": 617.77,
+   "close": 619.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-23": {
+   "open": 618.2,
+   "high": 622.41,
+   "low": 617.78,
+   "close": 622.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-24": {
+   "open": 621.99,
+   "high": 624.28,
+   "low": 621.72,
+   "close": 623.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-26": {
+   "open": 624.66,
+   "high": 625.52,
+   "low": 623.14,
+   "close": 623.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-29": {
+   "open": 620.1,
+   "high": 622.78,
+   "low": 618.73,
+   "close": 620.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-30": {
+   "open": 619.84,
+   "high": 622.18,
+   "low": 619.22,
+   "close": 619.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-31": {
+   "open": 619.65,
+   "high": 619.96,
+   "low": 614.05,
+   "close": 614.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-02": {
+   "open": 620.06,
+   "high": 622.85,
+   "low": 610.15,
+   "close": 613.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-05": {
+   "open": 619.32,
+   "high": 620.81,
+   "low": 616.72,
+   "close": 617.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-06": {
+   "open": 619.23,
+   "high": 624.02,
+   "low": 618.54,
+   "close": 623.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-07": {
+   "open": 623.04,
+   "high": 627.94,
+   "low": 622.56,
+   "close": 624.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-08": {
+   "open": 623.03,
+   "high": 623.42,
+   "low": 617.8,
+   "close": 620.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-09": {
+   "open": 621.41,
+   "high": 627.89,
+   "low": 619.06,
+   "close": 626.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-12": {
+   "open": 622.31,
+   "high": 628.85,
+   "low": 622.26,
+   "close": 627.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-13": {
+   "open": 627.27,
+   "high": 629.47,
+   "low": 623.7,
+   "close": 626.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-14": {
+   "open": 622.24,
+   "high": 623.45,
+   "low": 614.56,
+   "close": 619.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-15": {
+   "open": 626.6,
+   "high": 630.0,
+   "low": 620.75,
+   "close": 621.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-16": {
+   "open": 625.5,
+   "high": 626.08,
+   "low": 618.88,
+   "close": 621.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-20": {
+   "open": 610.53,
+   "high": 615.06,
+   "low": 607.05,
+   "close": 608.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-21": {
+   "open": 609.47,
+   "high": 620.42,
+   "low": 607.86,
+   "close": 616.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-22": {
+   "open": 622.35,
+   "high": 622.46,
+   "low": 617.78,
+   "close": 620.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-23": {
+   "open": 619.73,
+   "high": 625.4,
+   "low": 618.65,
+   "close": 622.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-26": {
+   "open": 623.21,
+   "high": 627.61,
+   "low": 622.12,
+   "close": 625.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-27": {
+   "open": 628.91,
+   "high": 632.04,
+   "low": 627.34,
+   "close": 631.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-28": {
+   "open": 635.46,
+   "high": 636.6,
+   "low": 631.81,
+   "close": 633.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-29": {
+   "open": 632.65,
+   "high": 633.67,
+   "low": 618.27,
+   "close": 629.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-30": {
+   "open": 625.71,
+   "high": 628.26,
+   "low": 619.3,
+   "close": 621.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-02": {
+   "open": 618.7,
+   "high": 628.49,
+   "low": 618.66,
+   "close": 626.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-03": {
+   "open": 628.3,
+   "high": 629.98,
+   "low": 610.96,
+   "close": 616.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-04": {
+   "open": 615.02,
+   "high": 615.1,
+   "low": 600.47,
+   "close": 605.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-05": {
+   "open": 600.21,
+   "high": 604.81,
+   "low": 594.76,
+   "close": 597.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-06": {
+   "open": 600.19,
+   "high": 611.41,
+   "low": 598.77,
+   "close": 609.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-09": {
+   "open": 607.54,
+   "high": 616.46,
+   "low": 605.07,
+   "close": 614.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-10": {
+   "open": 615.31,
+   "high": 617.02,
+   "low": 611.01,
+   "close": 611.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-11": {
+   "open": 616.38,
+   "high": 617.52,
+   "low": 607.69,
+   "close": 613.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-12": {
+   "open": 614.71,
+   "high": 615.81,
+   "low": 599.57,
+   "close": 600.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-13": {
+   "open": 600.43,
+   "high": 606.48,
+   "low": 596.42,
+   "close": 601.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-17": {
+   "open": 598.38,
+   "high": 603.95,
+   "low": 593.34,
+   "close": 601.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-18": {
+   "open": 602.11,
+   "high": 609.77,
+   "low": 600.72,
+   "close": 605.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-19": {
+   "open": 602.81,
+   "high": 605.82,
+   "low": 600.75,
+   "close": 603.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-20": {
+   "open": 600.12,
+   "high": 610.35,
+   "low": 599.23,
+   "close": 608.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-23": {
+   "open": 606.61,
+   "high": 608.01,
+   "low": 599.05,
+   "close": 601.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-24": {
+   "open": 602.4,
+   "high": 608.99,
+   "low": 599.73,
+   "close": 607.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-25": {
+   "open": 611.07,
+   "high": 616.83,
+   "low": 611.0,
+   "close": 616.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-26": {
+   "open": 615.59,
+   "high": 615.59,
+   "low": 603.98,
+   "close": 609.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-27": {
+   "open": 602.98,
+   "high": 608.32,
+   "low": 602.19,
+   "close": 607.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-02": {
+   "open": 598.86,
+   "high": 609.92,
+   "low": 597.99,
+   "close": 608.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-03": {
+   "open": 596.33,
+   "high": 603.96,
+   "low": 591.87,
+   "close": 601.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-04": {
+   "open": 604.16,
+   "high": 612.88,
+   "low": 603.43,
+   "close": 610.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-05": {
+   "open": 607.4,
+   "high": 612.76,
+   "low": 602.26,
+   "close": 608.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-06": {
+   "open": 600.31,
+   "high": 606.0,
+   "low": 598.33,
+   "close": 599.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-09": {
+   "open": 594.23,
+   "high": 609.27,
+   "low": 591.33,
+   "close": 607.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-10": {
+   "open": 607.78,
+   "high": 613.29,
+   "low": 605.42,
+   "close": 607.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-11": {
+   "open": 608.95,
+   "high": 612.43,
+   "low": 605.03,
+   "close": 607.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-12": {
+   "open": 602.76,
+   "high": 604.14,
+   "low": 597.05,
+   "close": 597.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-13": {
+   "open": 599.73,
+   "high": 603.6,
+   "low": 592.57,
+   "close": 593.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-16": {
+   "open": 600.04,
+   "high": 603.86,
+   "low": 599.11,
+   "close": 600.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-17": {
+   "open": 603.14,
+   "high": 605.9,
+   "low": 601.87,
+   "close": 603.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-18": {
+   "open": 601.49,
+   "high": 603.16,
+   "low": 594.56,
+   "close": 594.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-19": {
+   "open": 589.51,
+   "high": 595.8,
+   "low": 587.08,
+   "close": 593.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-20": {
+   "open": 591.06,
+   "high": 591.17,
+   "low": 578.54,
+   "close": 582.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-23": {
+   "open": 590.52,
+   "high": 595.08,
+   "low": 585.96,
+   "close": 588.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-24": {
+   "open": 584.81,
+   "high": 587.93,
+   "low": 581.93,
+   "close": 583.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-25": {
+   "open": 589.14,
+   "high": 591.37,
+   "low": 585.69,
+   "close": 587.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-26": {
+   "open": 582.6,
+   "high": 584.63,
+   "low": 573.43,
+   "close": 573.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-27": {
+   "open": 570.81,
+   "high": 571.02,
+   "low": 561.57,
+   "close": 562.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-30": {
+   "open": 567.38,
+   "high": 568.05,
+   "low": 555.6,
+   "close": 558.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-31": {
+   "open": 564.29,
+   "high": 578.64,
+   "low": 564.21,
+   "close": 577.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-01": {
+   "open": 581.48,
+   "high": 587.74,
+   "low": 580.42,
+   "close": 584.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-02": {
+   "open": 573.97,
+   "high": 586.05,
+   "low": 571.92,
+   "close": 584.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-06": {
+   "open": 586.23,
+   "high": 590.61,
+   "low": 584.69,
+   "close": 588.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-07": {
+   "open": 585.64,
+   "high": 588.98,
+   "low": 578.4,
+   "close": 588.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-08": {
+   "open": 608.71,
+   "high": 609.9,
+   "low": 602.12,
+   "close": 606.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-09": {
+   "open": 605.93,
+   "high": 610.5,
+   "low": 603.03,
+   "close": 610.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-10": {
+   "open": 611.84,
+   "high": 613.67,
+   "low": 609.58,
+   "close": 611.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-13": {
+   "open": 609.48,
+   "high": 626.74,
+   "low": 608.11,
+   "close": 617.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-14": {
+   "open": 620.22,
+   "high": 628.6,
+   "low": 620.1,
+   "close": 628.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-15": {
+   "open": 629.08,
+   "high": 637.83,
+   "low": 628.2,
+   "close": 637.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-16": {
+   "open": 639.21,
+   "high": 642.18,
+   "low": 635.26,
+   "close": 640.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-17": {
+   "open": 645.59,
+   "high": 650.0,
+   "low": 644.07,
+   "close": 648.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-20": {
+   "open": 648.04,
+   "high": 648.76,
+   "low": 642.52,
+   "close": 646.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-21": {
+   "open": 648.41,
+   "high": 650.2,
+   "low": 642.21,
+   "close": 644.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-22": {
+   "open": 650.15,
+   "high": 655.33,
+   "low": 648.52,
+   "close": 655.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-23": {
+   "open": 653.55,
+   "high": 656.92,
+   "low": 645.52,
+   "close": 651.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-24": {
+   "open": 658.51,
+   "high": 664.51,
+   "low": 656.53,
+   "close": 663.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-27": {
+   "open": 663.4,
+   "high": 664.43,
+   "low": 660.69,
+   "close": 664.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-28": {
+   "open": 657.41,
+   "high": 659.64,
+   "low": 653.81,
+   "close": 657.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-29": {
+   "open": 658.63,
+   "high": 661.72,
+   "low": 656.59,
+   "close": 661.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-30": {
+   "open": 665.35,
+   "high": 668.9,
+   "low": 657.56,
+   "close": 667.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
   "2026-05-01": {
    "open": 669.16,
    "high": 675.97,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:30+08:00"
+  },
+  "2026-08-14": {
+   "open": 733.41,
+   "high": 734.39,
+   "low": 728.32,
+   "close": 731.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
   }
  }
 }

--- a/memory/bars/RKLB.json
+++ b/memory/bars/RKLB.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 41.15,
+   "high": 41.3,
+   "low": 39.98,
+   "close": 40.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-02": {
+   "open": 40.56,
+   "high": 42.99,
+   "low": 40.42,
+   "close": 41.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-03": {
+   "open": 41.9,
+   "high": 44.74,
+   "low": 41.5,
+   "close": 44.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-04": {
+   "open": 45.65,
+   "high": 49.68,
+   "low": 44.82,
+   "close": 49.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-05": {
+   "open": 48.88,
+   "high": 49.7,
+   "low": 47.7,
+   "close": 49.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-08": {
+   "open": 50.08,
+   "high": 52.37,
+   "low": 49.22,
+   "close": 51.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-09": {
+   "open": 51.23,
+   "high": 53.75,
+   "low": 50.34,
+   "close": 53.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-10": {
+   "open": 53.44,
+   "high": 58.83,
+   "low": 52.25,
+   "close": 57.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-11": {
+   "open": 57.51,
+   "high": 64.15,
+   "low": 56.85,
+   "close": 63.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-12": {
+   "open": 62.5,
+   "high": 65.18,
+   "low": 59.8,
+   "close": 61.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-15": {
+   "open": 63.05,
+   "high": 64.56,
+   "low": 55.08,
+   "close": 55.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-16": {
+   "open": 54.19,
+   "high": 56.73,
+   "low": 52.68,
+   "close": 55.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-17": {
+   "open": 56.1,
+   "high": 56.91,
+   "low": 53.09,
+   "close": 53.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-18": {
+   "open": 56.2,
+   "high": 60.25,
+   "low": 56.03,
+   "close": 59.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-19": {
+   "open": 61.12,
+   "high": 70.56,
+   "low": 60.75,
+   "close": 70.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-22": {
+   "open": 72.94,
+   "high": 78.45,
+   "low": 72.75,
+   "close": 77.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-23": {
+   "open": 73.81,
+   "high": 79.18,
+   "low": 73.29,
+   "close": 77.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-24": {
+   "open": 78.04,
+   "high": 79.83,
+   "low": 74.8,
+   "close": 77.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-26": {
+   "open": 76.68,
+   "high": 76.99,
+   "low": 70.39,
+   "close": 70.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-29": {
+   "open": 69.5,
+   "high": 72.74,
+   "low": 69.32,
+   "close": 70.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-30": {
+   "open": 73.03,
+   "high": 74.69,
+   "low": 70.44,
+   "close": 70.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-31": {
+   "open": 71.5,
+   "high": 73.2,
+   "low": 69.13,
+   "close": 69.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-02": {
+   "open": 70.63,
+   "high": 76.24,
+   "low": 66.85,
+   "close": 75.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-05": {
+   "open": 74.62,
+   "high": 78.25,
+   "low": 71.31,
+   "close": 78.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-06": {
+   "open": 77.76,
+   "high": 86.25,
+   "low": 74.05,
+   "close": 86.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-07": {
+   "open": 84.1,
+   "high": 85.96,
+   "low": 81.85,
+   "close": 84.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-08": {
+   "open": 85.5,
+   "high": 89.87,
+   "low": 82.26,
+   "close": 83.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-09": {
+   "open": 84.53,
+   "high": 88.43,
+   "low": 82.45,
+   "close": 84.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-12": {
+   "open": 84.98,
+   "high": 88.84,
+   "low": 83.42,
+   "close": 87.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-13": {
+   "open": 89.14,
+   "high": 89.73,
+   "low": 85.65,
+   "close": 86.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-14": {
+   "open": 86.35,
+   "high": 92.19,
+   "low": 84.5,
+   "close": 91.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-15": {
+   "open": 89.27,
+   "high": 92.46,
+   "low": 86.65,
+   "close": 90.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-16": {
+   "open": 92.53,
+   "high": 99.58,
+   "low": 92.4,
+   "close": 96.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-20": {
+   "open": 93.7,
+   "high": 98.27,
+   "low": 88.3,
+   "close": 89.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-21": {
+   "open": 90.02,
+   "high": 91.25,
+   "low": 82.71,
+   "close": 87.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-22": {
+   "open": 86.38,
+   "high": 89.4,
+   "low": 81.35,
+   "close": 87.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-23": {
+   "open": 89.06,
+   "high": 94.45,
+   "low": 86.12,
+   "close": 88.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-26": {
+   "open": 86.75,
+   "high": 87.16,
+   "low": 80.01,
+   "close": 80.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-27": {
+   "open": 82.89,
+   "high": 87.0,
+   "low": 82.0,
+   "close": 87.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-28": {
+   "open": 87.22,
+   "high": 89.8,
+   "low": 86.03,
+   "close": 88.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-29": {
+   "open": 87.94,
+   "high": 89.0,
+   "low": 83.0,
+   "close": 85.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-30": {
+   "open": 85.0,
+   "high": 89.32,
+   "low": 78.02,
+   "close": 80.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-02": {
+   "open": 79.16,
+   "high": 80.7,
+   "low": 73.88,
+   "close": 74.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-03": {
+   "open": 78.6,
+   "high": 81.32,
+   "low": 75.77,
+   "close": 81.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-04": {
+   "open": 81.35,
+   "high": 81.35,
+   "low": 68.56,
+   "close": 73.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-05": {
+   "open": 69.98,
+   "high": 72.99,
+   "low": 65.2,
+   "close": 66.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-06": {
+   "open": 69.0,
+   "high": 72.66,
+   "low": 67.0,
+   "close": 72.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-09": {
+   "open": 72.03,
+   "high": 76.8,
+   "low": 70.75,
+   "close": 75.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-10": {
+   "open": 74.6,
+   "high": 75.86,
+   "low": 71.55,
+   "close": 72.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-11": {
+   "open": 73.13,
+   "high": 73.4,
+   "low": 67.02,
+   "close": 69.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-12": {
+   "open": 67.53,
+   "high": 68.45,
+   "low": 63.87,
+   "close": 66.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-13": {
+   "open": 66.7,
+   "high": 69.6,
+   "low": 65.5,
+   "close": 67.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-17": {
+   "open": 66.08,
+   "high": 70.99,
+   "low": 65.0,
+   "close": 69.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-18": {
+   "open": 71.0,
+   "high": 75.77,
+   "low": 69.99,
+   "close": 74.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-19": {
+   "open": 72.9,
+   "high": 77.11,
+   "low": 72.35,
+   "close": 76.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-20": {
+   "open": 75.48,
+   "high": 78.2,
+   "low": 69.4,
+   "close": 70.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-23": {
+   "open": 68.76,
+   "high": 71.25,
+   "low": 68.5,
+   "close": 70.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-24": {
+   "open": 68.88,
+   "high": 70.06,
+   "low": 66.6,
+   "close": 69.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-25": {
+   "open": 71.1,
+   "high": 71.85,
+   "low": 68.88,
+   "close": 70.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-26": {
+   "open": 70.05,
+   "high": 72.74,
+   "low": 68.81,
+   "close": 72.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-27": {
+   "open": 67.59,
+   "high": 69.59,
+   "low": 64.1,
+   "close": 69.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-02": {
+   "open": 66.68,
+   "high": 72.1,
+   "low": 66.45,
+   "close": 70.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-03": {
+   "open": 68.86,
+   "high": 73.25,
+   "low": 66.19,
+   "close": 70.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-04": {
+   "open": 70.81,
+   "high": 74.1,
+   "low": 69.47,
+   "close": 71.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-05": {
+   "open": 70.92,
+   "high": 72.31,
+   "low": 67.34,
+   "close": 70.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-06": {
+   "open": 68.14,
+   "high": 75.11,
+   "low": 68.14,
+   "close": 70.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-09": {
+   "open": 69.39,
+   "high": 72.13,
+   "low": 67.82,
+   "close": 71.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-10": {
+   "open": 70.34,
+   "high": 72.94,
+   "low": 68.62,
+   "close": 68.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-11": {
+   "open": 68.8,
+   "high": 73.3,
+   "low": 68.33,
+   "close": 71.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-12": {
+   "open": 71.95,
+   "high": 72.6,
+   "low": 68.28,
+   "close": 68.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-13": {
+   "open": 69.15,
+   "high": 71.31,
+   "low": 67.44,
+   "close": 68.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-16": {
+   "open": 69.33,
+   "high": 72.38,
+   "low": 68.67,
+   "close": 71.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-17": {
+   "open": 71.48,
+   "high": 78.67,
+   "low": 71.27,
+   "close": 78.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-18": {
+   "open": 76.04,
+   "high": 76.88,
+   "low": 69.4,
+   "close": 69.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-19": {
+   "open": 68.82,
+   "high": 72.73,
+   "low": 68.0,
+   "close": 71.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-20": {
+   "open": 72.0,
+   "high": 73.98,
+   "low": 66.39,
+   "close": 67.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-23": {
+   "open": 68.09,
+   "high": 69.45,
+   "low": 66.05,
+   "close": 68.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-24": {
+   "open": 67.0,
+   "high": 68.6,
+   "low": 64.46,
+   "close": 66.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-25": {
+   "open": 68.94,
+   "high": 75.06,
+   "low": 68.94,
+   "close": 72.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-26": {
+   "open": 71.2,
+   "high": 72.09,
+   "low": 65.59,
+   "close": 65.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-27": {
+   "open": 66.01,
+   "high": 66.1,
+   "low": 60.35,
+   "close": 60.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-30": {
+   "open": 61.45,
+   "high": 61.64,
+   "low": 56.13,
+   "close": 57.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-31": {
+   "open": 61.71,
+   "high": 64.58,
+   "low": 59.03,
+   "close": 64.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-01": {
+   "open": 65.5,
+   "high": 68.67,
+   "low": 65.3,
+   "close": 65.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-02": {
+   "open": 62.23,
+   "high": 69.39,
+   "low": 61.86,
+   "close": 67.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-06": {
+   "open": 67.73,
+   "high": 70.32,
+   "low": 66.6,
+   "close": 67.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-07": {
+   "open": 67.12,
+   "high": 68.3,
+   "low": 63.96,
+   "close": 66.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-08": {
+   "open": 72.0,
+   "high": 73.67,
+   "low": 67.81,
+   "close": 69.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-09": {
+   "open": 69.06,
+   "high": 69.79,
+   "low": 66.55,
+   "close": 66.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-10": {
+   "open": 67.7,
+   "high": 70.06,
+   "low": 66.34,
+   "close": 68.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-13": {
+   "open": 67.05,
+   "high": 71.55,
+   "low": 66.59,
+   "close": 70.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-14": {
+   "open": 73.56,
+   "high": 74.75,
+   "low": 70.48,
+   "close": 72.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-15": {
+   "open": 73.59,
+   "high": 74.59,
+   "low": 69.6,
+   "close": 73.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-16": {
+   "open": 76.97,
+   "high": 83.49,
+   "low": 76.9,
+   "close": 82.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-17": {
+   "open": 84.08,
+   "high": 86.99,
+   "low": 83.6,
+   "close": 84.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-20": {
+   "open": 84.85,
+   "high": 90.35,
+   "low": 84.6,
+   "close": 89.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-21": {
+   "open": 90.33,
+   "high": 91.95,
+   "low": 85.75,
+   "close": 86.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-22": {
+   "open": 90.47,
+   "high": 93.1,
+   "low": 87.76,
+   "close": 90.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-23": {
+   "open": 89.85,
+   "high": 90.3,
+   "low": 81.57,
+   "close": 84.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-24": {
+   "open": 86.34,
+   "high": 86.41,
+   "low": 79.08,
+   "close": 79.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-27": {
+   "open": 79.69,
+   "high": 82.48,
+   "low": 77.05,
+   "close": 82.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-28": {
+   "open": 80.08,
+   "high": 81.78,
+   "low": 77.6,
+   "close": 78.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-29": {
+   "open": 77.86,
+   "high": 78.01,
+   "low": 73.99,
+   "close": 77.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-30": {
+   "open": 77.55,
+   "high": 83.59,
+   "low": 77.47,
+   "close": 82.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
   "2026-05-01": {
    "open": 83.53,
    "high": 83.79,
@@ -654,6 +1590,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:30+08:00"
+  },
+  "2026-08-14": {
+   "open": 79.59,
+   "high": 82.48,
+   "low": 78.51,
+   "close": 80.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/RKLX.json
+++ b/memory/bars/RKLX.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 53.37,
+   "high": 53.97,
+   "low": 50.4,
+   "close": 51.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-02": {
+   "open": 52.06,
+   "high": 58.08,
+   "low": 51.65,
+   "close": 55.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-03": {
+   "open": 55.52,
+   "high": 62.86,
+   "low": 54.5,
+   "close": 62.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-04": {
+   "open": 65.11,
+   "high": 76.48,
+   "low": 63.22,
+   "close": 75.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-05": {
+   "open": 74.02,
+   "high": 76.45,
+   "low": 70.5,
+   "close": 74.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-08": {
+   "open": 77.83,
+   "high": 84.67,
+   "low": 75.21,
+   "close": 82.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-09": {
+   "open": 27.02,
+   "high": 29.7,
+   "low": 26.08,
+   "close": 29.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-10": {
+   "open": 29.48,
+   "high": 35.23,
+   "low": 28.1,
+   "close": 33.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-11": {
+   "open": 33.8,
+   "high": 41.46,
+   "low": 33.01,
+   "close": 40.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-12": {
+   "open": 39.51,
+   "high": 42.93,
+   "low": 35.93,
+   "close": 38.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-15": {
+   "open": 40.12,
+   "high": 42.0,
+   "low": 30.17,
+   "close": 30.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-16": {
+   "open": 29.17,
+   "high": 32.0,
+   "low": 27.54,
+   "close": 30.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-17": {
+   "open": 31.49,
+   "high": 32.06,
+   "low": 28.0,
+   "close": 28.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-18": {
+   "open": 31.42,
+   "high": 35.6,
+   "low": 31.15,
+   "close": 35.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-19": {
+   "open": 36.84,
+   "high": 47.8,
+   "low": 36.42,
+   "close": 47.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-22": {
+   "open": 50.93,
+   "high": 58.5,
+   "low": 50.76,
+   "close": 57.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-23": {
+   "open": 51.89,
+   "high": 59.58,
+   "low": 50.86,
+   "close": 56.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-24": {
+   "open": 57.94,
+   "high": 60.49,
+   "low": 53.17,
+   "close": 56.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-26": {
+   "open": 55.6,
+   "high": 56.05,
+   "low": 46.63,
+   "close": 46.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-29": {
+   "open": 45.34,
+   "high": 49.68,
+   "low": 45.18,
+   "close": 46.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-30": {
+   "open": 44.29,
+   "high": 46.27,
+   "low": 40.69,
+   "close": 40.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-31": {
+   "open": 42.15,
+   "high": 43.74,
+   "low": 39.14,
+   "close": 39.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-02": {
+   "open": 41.02,
+   "high": 46.98,
+   "low": 36.47,
+   "close": 46.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-05": {
+   "open": 45.16,
+   "high": 49.74,
+   "low": 41.12,
+   "close": 49.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-06": {
+   "open": 49.0,
+   "high": 59.68,
+   "low": 44.34,
+   "close": 59.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-07": {
+   "open": 56.89,
+   "high": 59.38,
+   "low": 53.56,
+   "close": 56.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-08": {
+   "open": 58.3,
+   "high": 64.49,
+   "low": 54.21,
+   "close": 55.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-09": {
+   "open": 57.36,
+   "high": 62.28,
+   "low": 54.55,
+   "close": 57.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-12": {
+   "open": 57.63,
+   "high": 62.92,
+   "low": 55.66,
+   "close": 61.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-13": {
+   "open": 63.25,
+   "high": 64.24,
+   "low": 58.6,
+   "close": 59.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-14": {
+   "open": 59.3,
+   "high": 67.52,
+   "low": 56.87,
+   "close": 66.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-15": {
+   "open": 63.95,
+   "high": 67.91,
+   "low": 59.56,
+   "close": 65.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-16": {
+   "open": 67.8,
+   "high": 78.0,
+   "low": 67.8,
+   "close": 73.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-20": {
+   "open": 69.37,
+   "high": 76.14,
+   "low": 61.1,
+   "close": 62.45,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-21": {
+   "open": 63.7,
+   "high": 65.25,
+   "low": 53.32,
+   "close": 60.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-22": {
+   "open": 58.66,
+   "high": 62.6,
+   "low": 51.6,
+   "close": 60.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-23": {
+   "open": 62.14,
+   "high": 69.3,
+   "low": 58.01,
+   "close": 61.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-26": {
+   "open": 58.6,
+   "high": 59.18,
+   "low": 49.52,
+   "close": 50.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-27": {
+   "open": 52.95,
+   "high": 58.1,
+   "low": 51.91,
+   "close": 58.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-28": {
+   "open": 58.49,
+   "high": 61.94,
+   "low": 56.8,
+   "close": 60.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-29": {
+   "open": 59.18,
+   "high": 60.55,
+   "low": 52.8,
+   "close": 56.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-30": {
+   "open": 55.05,
+   "high": 60.95,
+   "low": 46.22,
+   "close": 48.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-02": {
+   "open": 47.44,
+   "high": 49.34,
+   "low": 41.28,
+   "close": 41.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-03": {
+   "open": 46.56,
+   "high": 49.55,
+   "low": 43.35,
+   "close": 49.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-04": {
+   "open": 49.47,
+   "high": 49.47,
+   "low": 34.0,
+   "close": 39.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-05": {
+   "open": 36.19,
+   "high": 39.31,
+   "low": 31.04,
+   "close": 32.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-06": {
+   "open": 34.55,
+   "high": 38.2,
+   "low": 32.71,
+   "close": 37.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-09": {
+   "open": 37.85,
+   "high": 42.54,
+   "low": 36.21,
+   "close": 41.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-10": {
+   "open": 40.09,
+   "high": 41.16,
+   "low": 36.83,
+   "close": 37.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-11": {
+   "open": 38.66,
+   "high": 38.66,
+   "low": 32.14,
+   "close": 34.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-12": {
+   "open": 32.74,
+   "high": 33.62,
+   "low": 29.06,
+   "close": 31.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-13": {
+   "open": 31.83,
+   "high": 34.46,
+   "low": 30.64,
+   "close": 32.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-17": {
+   "open": 31.12,
+   "high": 35.75,
+   "low": 30.06,
+   "close": 34.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-18": {
+   "open": 35.72,
+   "high": 40.59,
+   "low": 34.93,
+   "close": 39.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-19": {
+   "open": 37.47,
+   "high": 42.05,
+   "low": 37.01,
+   "close": 41.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-20": {
+   "open": 40.28,
+   "high": 43.17,
+   "low": 33.72,
+   "close": 35.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-23": {
+   "open": 33.07,
+   "high": 35.56,
+   "low": 32.81,
+   "close": 34.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-24": {
+   "open": 33.21,
+   "high": 34.33,
+   "low": 31.05,
+   "close": 34.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-25": {
+   "open": 35.32,
+   "high": 36.0,
+   "low": 33.25,
+   "close": 34.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-26": {
+   "open": 34.0,
+   "high": 36.9,
+   "low": 33.09,
+   "close": 36.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-27": {
+   "open": 31.67,
+   "high": 33.64,
+   "low": 28.18,
+   "close": 33.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-02": {
+   "open": 30.69,
+   "high": 35.95,
+   "low": 30.53,
+   "close": 34.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-03": {
+   "open": 32.88,
+   "high": 37.11,
+   "low": 30.14,
+   "close": 33.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-04": {
+   "open": 34.72,
+   "high": 37.86,
+   "low": 33.46,
+   "close": 35.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-05": {
+   "open": 34.81,
+   "high": 36.14,
+   "low": 31.21,
+   "close": 33.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-06": {
+   "open": 31.94,
+   "high": 38.66,
+   "low": 31.94,
+   "close": 33.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-09": {
+   "open": 32.89,
+   "high": 35.71,
+   "low": 31.61,
+   "close": 35.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-10": {
+   "open": 34.02,
+   "high": 36.51,
+   "low": 32.36,
+   "close": 32.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-11": {
+   "open": 32.7,
+   "high": 36.68,
+   "low": 32.08,
+   "close": 35.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-12": {
+   "open": 35.18,
+   "high": 36.0,
+   "low": 31.85,
+   "close": 31.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-13": {
+   "open": 32.64,
+   "high": 34.52,
+   "low": 30.97,
+   "close": 31.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-16": {
+   "open": 32.66,
+   "high": 35.5,
+   "low": 32.08,
+   "close": 34.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-17": {
+   "open": 34.78,
+   "high": 41.62,
+   "low": 34.5,
+   "close": 41.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-18": {
+   "open": 38.82,
+   "high": 39.6,
+   "low": 31.83,
+   "close": 31.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-19": {
+   "open": 31.29,
+   "high": 34.8,
+   "low": 30.5,
+   "close": 34.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-20": {
+   "open": 34.08,
+   "high": 35.96,
+   "low": 28.8,
+   "close": 29.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-23": {
+   "open": 30.24,
+   "high": 31.5,
+   "low": 28.52,
+   "close": 30.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-24": {
+   "open": 29.25,
+   "high": 30.75,
+   "low": 27.12,
+   "close": 28.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-25": {
+   "open": 30.99,
+   "high": 36.2,
+   "low": 30.99,
+   "close": 34.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-26": {
+   "open": 32.45,
+   "high": 33.62,
+   "low": 27.5,
+   "close": 27.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-27": {
+   "open": 27.85,
+   "high": 27.88,
+   "low": 23.03,
+   "close": 23.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-30": {
+   "open": 23.79,
+   "high": 24.0,
+   "low": 19.8,
+   "close": 20.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-31": {
+   "open": 23.72,
+   "high": 25.89,
+   "low": 21.9,
+   "close": 25.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-01": {
+   "open": 26.64,
+   "high": 29.16,
+   "low": 26.48,
+   "close": 26.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-02": {
+   "open": 23.78,
+   "high": 29.72,
+   "low": 23.7,
+   "close": 28.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-06": {
+   "open": 28.39,
+   "high": 30.52,
+   "low": 27.43,
+   "close": 28.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-07": {
+   "open": 27.77,
+   "high": 28.7,
+   "low": 25.24,
+   "close": 27.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-08": {
+   "open": 31.77,
+   "high": 33.12,
+   "low": 28.38,
+   "close": 29.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-09": {
+   "open": 29.45,
+   "high": 29.95,
+   "low": 27.2,
+   "close": 27.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-10": {
+   "open": 28.01,
+   "high": 30.0,
+   "low": 26.96,
+   "close": 28.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-13": {
+   "open": 27.53,
+   "high": 31.25,
+   "low": 27.16,
+   "close": 30.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-14": {
+   "open": 33.05,
+   "high": 34.09,
+   "low": 30.33,
+   "close": 31.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-15": {
+   "open": 33.11,
+   "high": 33.9,
+   "low": 29.54,
+   "close": 33.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-16": {
+   "open": 35.99,
+   "high": 41.87,
+   "low": 35.99,
+   "close": 41.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-17": {
+   "open": 42.54,
+   "high": 45.35,
+   "low": 41.99,
+   "close": 43.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-20": {
+   "open": 43.19,
+   "high": 48.86,
+   "low": 43.07,
+   "close": 47.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-21": {
+   "open": 48.6,
+   "high": 50.5,
+   "low": 43.86,
+   "close": 44.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-22": {
+   "open": 48.8,
+   "high": 51.4,
+   "low": 45.85,
+   "close": 48.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-23": {
+   "open": 48.0,
+   "high": 48.55,
+   "low": 39.21,
+   "close": 42.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-24": {
+   "open": 44.0,
+   "high": 44.0,
+   "low": 36.82,
+   "close": 37.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-27": {
+   "open": 37.25,
+   "high": 40.0,
+   "low": 34.9,
+   "close": 39.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-28": {
+   "open": 37.55,
+   "high": 39.3,
+   "low": 35.3,
+   "close": 36.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-29": {
+   "open": 35.67,
+   "high": 35.67,
+   "low": 32.0,
+   "close": 34.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-30": {
+   "open": 35.2,
+   "high": 40.6,
+   "low": 35.05,
+   "close": 39.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
   "2026-05-01": {
    "open": 40.47,
    "high": 40.81,
@@ -662,6 +1598,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:30+08:00"
+  },
+  "2026-08-14": {
+   "open": 23.87,
+   "high": 25.65,
+   "low": 23.27,
+   "close": 24.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/ROBN.json
+++ b/memory/bars/ROBN.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 69.96,
+   "high": 72.38,
+   "low": 64.81,
+   "close": 70.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-02": {
+   "open": 72.48,
+   "high": 76.66,
+   "low": 71.3,
+   "close": 73.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-03": {
+   "open": 73.38,
+   "high": 82.65,
+   "low": 71.25,
+   "close": 81.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-04": {
+   "open": 81.53,
+   "high": 86.22,
+   "low": 80.7,
+   "close": 85.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-05": {
+   "open": 83.61,
+   "high": 83.61,
+   "low": 77.03,
+   "close": 79.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-08": {
+   "open": 81.85,
+   "high": 86.9,
+   "low": 79.61,
+   "close": 84.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-09": {
+   "open": 82.05,
+   "high": 88.97,
+   "low": 81.2,
+   "close": 83.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-10": {
+   "open": 82.92,
+   "high": 86.0,
+   "low": 81.15,
+   "close": 83.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-11": {
+   "open": 79.17,
+   "high": 79.21,
+   "low": 67.6,
+   "close": 68.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-12": {
+   "open": 70.69,
+   "high": 70.9,
+   "low": 62.37,
+   "close": 64.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-15": {
+   "open": 65.12,
+   "high": 65.25,
+   "low": 58.36,
+   "close": 59.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-16": {
+   "open": 60.56,
+   "high": 65.14,
+   "low": 60.02,
+   "close": 63.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-17": {
+   "open": 65.75,
+   "high": 69.4,
+   "low": 59.86,
+   "close": 60.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-18": {
+   "open": 66.26,
+   "high": 68.5,
+   "low": 61.13,
+   "close": 61.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-19": {
+   "open": 63.79,
+   "high": 67.27,
+   "low": 62.35,
+   "close": 65.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-22": {
+   "open": 68.01,
+   "high": 68.89,
+   "low": 65.22,
+   "close": 66.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-23": {
+   "open": 64.54,
+   "high": 65.18,
+   "low": 60.5,
+   "close": 64.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-24": {
+   "open": 61.57,
+   "high": 62.21,
+   "low": 60.2,
+   "close": 62.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-26": {
+   "open": 62.2,
+   "high": 62.47,
+   "low": 59.1,
+   "close": 59.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-29": {
+   "open": 58.12,
+   "high": 60.21,
+   "low": 57.4,
+   "close": 58.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-30": {
+   "open": 58.68,
+   "high": 59.92,
+   "low": 56.46,
+   "close": 56.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2025-12-31": {
+   "open": 56.01,
+   "high": 56.69,
+   "low": 54.14,
+   "close": 54.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-02": {
+   "open": 56.72,
+   "high": 57.12,
+   "low": 51.73,
+   "close": 56.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-05": {
+   "open": 58.96,
+   "high": 64.26,
+   "low": 58.69,
+   "close": 64.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-06": {
+   "open": 65.24,
+   "high": 65.24,
+   "low": 58.75,
+   "close": 62.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-07": {
+   "open": 60.71,
+   "high": 60.71,
+   "low": 57.27,
+   "close": 57.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-08": {
+   "open": 56.48,
+   "high": 58.03,
+   "low": 54.62,
+   "close": 56.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-09": {
+   "open": 57.39,
+   "high": 58.69,
+   "low": 55.54,
+   "close": 55.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-12": {
+   "open": 55.24,
+   "high": 60.0,
+   "low": 55.0,
+   "close": 58.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-13": {
+   "open": 57.89,
+   "high": 60.87,
+   "low": 56.58,
+   "close": 60.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-14": {
+   "open": 60.67,
+   "high": 61.25,
+   "low": 57.1,
+   "close": 60.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-15": {
+   "open": 60.01,
+   "high": 60.16,
+   "low": 50.55,
+   "close": 50.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-16": {
+   "open": 51.64,
+   "high": 51.64,
+   "low": 47.52,
+   "close": 49.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-20": {
+   "open": 45.66,
+   "high": 48.79,
+   "low": 45.36,
+   "close": 46.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-21": {
+   "open": 46.15,
+   "high": 48.8,
+   "low": 45.72,
+   "close": 46.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-22": {
+   "open": 47.86,
+   "high": 48.27,
+   "low": 45.85,
+   "close": 46.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-23": {
+   "open": 47.32,
+   "high": 50.42,
+   "low": 47.03,
+   "close": 47.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-26": {
+   "open": 46.82,
+   "high": 48.66,
+   "low": 45.52,
+   "close": 47.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-27": {
+   "open": 47.87,
+   "high": 49.16,
+   "low": 45.35,
+   "close": 45.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-28": {
+   "open": 45.94,
+   "high": 47.5,
+   "low": 43.95,
+   "close": 44.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-29": {
+   "open": 44.46,
+   "high": 44.46,
+   "low": 40.67,
+   "close": 42.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-01-30": {
+   "open": 43.31,
+   "high": 44.83,
+   "low": 39.89,
+   "close": 40.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-02": {
+   "open": 37.64,
+   "high": 37.79,
+   "low": 31.91,
+   "close": 32.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-03": {
+   "open": 33.0,
+   "high": 33.07,
+   "low": 29.24,
+   "close": 30.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-04": {
+   "open": 29.19,
+   "high": 29.48,
+   "low": 24.12,
+   "close": 26.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-05": {
+   "open": 24.13,
+   "high": 25.4,
+   "low": 20.54,
+   "close": 21.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-06": {
+   "open": 23.91,
+   "high": 27.76,
+   "low": 23.59,
+   "close": 26.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-09": {
+   "open": 28.24,
+   "high": 30.65,
+   "low": 26.89,
+   "close": 29.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-10": {
+   "open": 28.36,
+   "high": 30.41,
+   "low": 28.36,
+   "close": 28.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-11": {
+   "open": 23.58,
+   "high": 24.74,
+   "low": 21.04,
+   "close": 23.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-12": {
+   "open": 23.97,
+   "high": 24.02,
+   "low": 18.95,
+   "close": 19.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-13": {
+   "open": 20.19,
+   "high": 22.58,
+   "low": 19.53,
+   "close": 21.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-17": {
+   "open": 20.96,
+   "high": 22.38,
+   "low": 20.21,
+   "close": 21.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-18": {
+   "open": 21.31,
+   "high": 23.28,
+   "low": 20.85,
+   "close": 21.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-19": {
+   "open": 20.92,
+   "high": 22.04,
+   "low": 20.66,
+   "close": 21.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-20": {
+   "open": 21.48,
+   "high": 23.1,
+   "low": 21.46,
+   "close": 22.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-23": {
+   "open": 21.15,
+   "high": 21.29,
+   "low": 19.25,
+   "close": 19.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-24": {
+   "open": 19.04,
+   "high": 20.58,
+   "low": 18.09,
+   "close": 20.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-25": {
+   "open": 22.24,
+   "high": 22.94,
+   "low": 21.04,
+   "close": 22.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-26": {
+   "open": 22.33,
+   "high": 23.77,
+   "low": 22.0,
+   "close": 23.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-02-27": {
+   "open": 21.94,
+   "high": 22.69,
+   "low": 20.96,
+   "close": 21.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-02": {
+   "open": 20.11,
+   "high": 23.63,
+   "low": 19.93,
+   "close": 23.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-03": {
+   "open": 20.42,
+   "high": 22.36,
+   "low": 19.4,
+   "close": 21.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-04": {
+   "open": 23.58,
+   "high": 26.0,
+   "low": 23.55,
+   "close": 25.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-05": {
+   "open": 25.06,
+   "high": 26.59,
+   "low": 22.82,
+   "close": 24.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-06": {
+   "open": 22.36,
+   "high": 23.03,
+   "low": 21.52,
+   "close": 21.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-09": {
+   "open": 21.18,
+   "high": 23.39,
+   "low": 21.15,
+   "close": 23.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-10": {
+   "open": 23.78,
+   "high": 23.97,
+   "low": 22.25,
+   "close": 22.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-11": {
+   "open": 22.44,
+   "high": 23.43,
+   "low": 21.68,
+   "close": 22.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-12": {
+   "open": 22.09,
+   "high": 22.3,
+   "low": 20.75,
+   "close": 21.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-13": {
+   "open": 21.7,
+   "high": 22.03,
+   "low": 19.44,
+   "close": 19.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-16": {
+   "open": 20.63,
+   "high": 21.05,
+   "low": 20.16,
+   "close": 20.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-17": {
+   "open": 20.86,
+   "high": 22.09,
+   "low": 20.86,
+   "close": 21.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-18": {
+   "open": 21.25,
+   "high": 21.82,
+   "low": 20.46,
+   "close": 20.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-19": {
+   "open": 19.0,
+   "high": 20.61,
+   "low": 18.75,
+   "close": 20.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-20": {
+   "open": 19.57,
+   "high": 19.62,
+   "low": 17.81,
+   "close": 18.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-23": {
+   "open": 18.62,
+   "high": 19.65,
+   "low": 18.32,
+   "close": 19.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-24": {
+   "open": 18.67,
+   "high": 18.76,
+   "low": 17.05,
+   "close": 17.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-25": {
+   "open": 18.64,
+   "high": 20.04,
+   "low": 18.64,
+   "close": 19.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-26": {
+   "open": 18.28,
+   "high": 19.39,
+   "low": 17.54,
+   "close": 17.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-27": {
+   "open": 16.98,
+   "high": 16.98,
+   "low": 15.6,
+   "close": 15.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-30": {
+   "open": 15.98,
+   "high": 16.52,
+   "low": 14.49,
+   "close": 15.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-03-31": {
+   "open": 15.55,
+   "high": 17.24,
+   "low": 15.23,
+   "close": 17.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-01": {
+   "open": 18.07,
+   "high": 18.21,
+   "low": 17.07,
+   "close": 17.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-02": {
+   "open": 15.97,
+   "high": 17.51,
+   "low": 15.26,
+   "close": 16.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-06": {
+   "open": 17.15,
+   "high": 17.85,
+   "low": 16.87,
+   "close": 17.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-07": {
+   "open": 16.64,
+   "high": 17.27,
+   "low": 15.8,
+   "close": 17.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-08": {
+   "open": 20.86,
+   "high": 21.35,
+   "low": 18.09,
+   "close": 18.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-09": {
+   "open": 18.14,
+   "high": 18.67,
+   "low": 16.78,
+   "close": 17.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-10": {
+   "open": 17.47,
+   "high": 17.8,
+   "low": 16.52,
+   "close": 16.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-13": {
+   "open": 16.43,
+   "high": 18.2,
+   "low": 16.32,
+   "close": 18.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-14": {
+   "open": 19.93,
+   "high": 22.03,
+   "low": 19.92,
+   "close": 21.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-15": {
+   "open": 24.61,
+   "high": 26.62,
+   "low": 23.36,
+   "close": 26.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-16": {
+   "open": 27.75,
+   "high": 27.75,
+   "low": 24.42,
+   "close": 26.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-17": {
+   "open": 28.11,
+   "high": 30.15,
+   "low": 27.8,
+   "close": 28.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-20": {
+   "open": 27.71,
+   "high": 29.51,
+   "low": 26.95,
+   "close": 28.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-21": {
+   "open": 28.75,
+   "high": 28.99,
+   "low": 25.6,
+   "close": 25.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-22": {
+   "open": 27.46,
+   "high": 27.93,
+   "low": 26.38,
+   "close": 26.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-23": {
+   "open": 25.81,
+   "high": 26.37,
+   "low": 22.87,
+   "close": 23.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-24": {
+   "open": 24.68,
+   "high": 24.75,
+   "low": 23.52,
+   "close": 24.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-27": {
+   "open": 24.37,
+   "high": 25.17,
+   "low": 23.65,
+   "close": 24.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-28": {
+   "open": 22.64,
+   "high": 23.63,
+   "low": 22.31,
+   "close": 23.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-29": {
+   "open": 17.61,
+   "high": 18.27,
+   "low": 16.25,
+   "close": 16.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
+  "2026-04-30": {
+   "open": 16.86,
+   "high": 18.2,
+   "low": 16.73,
+   "close": 17.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
+  },
   "2026-05-01": {
    "open": 18.19,
    "high": 18.87,
@@ -654,6 +1590,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:30+08:00"
+  },
+  "2026-08-14": {
+   "open": 26.72,
+   "high": 27.07,
+   "low": 25.46,
+   "close": 25.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:49+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SKHY.json
+++ b/memory/bars/SKHY.json
@@ -231,6 +231,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:31+08:00"
+  },
+  "2026-08-14": {
+   "open": 169.32,
+   "high": 171.58,
+   "low": 163.76,
+   "close": 166.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SOXL.json
+++ b/memory/bars/SOXL.json
@@ -7,6 +7,942 @@
  "adjustment": "raw",
  "source": "tencent",
  "bars": {
+  "2025-12-01": {
+   "open": 39.58,
+   "high": 42.36,
+   "low": 39.46,
+   "close": 41.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-02": {
+   "open": 42.79,
+   "high": 44.61,
+   "low": 42.03,
+   "close": 43.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-03": {
+   "open": 44.45,
+   "high": 46.68,
+   "low": 43.15,
+   "close": 46.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-04": {
+   "open": 45.89,
+   "high": 46.1,
+   "low": 44.44,
+   "close": 45.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-05": {
+   "open": 46.47,
+   "high": 48.05,
+   "low": 46.3,
+   "close": 46.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-08": {
+   "open": 47.56,
+   "high": 48.6,
+   "low": 46.7,
+   "close": 47.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-09": {
+   "open": 47.04,
+   "high": 48.05,
+   "low": 46.47,
+   "close": 47.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-10": {
+   "open": 47.65,
+   "high": 50.09,
+   "low": 47.01,
+   "close": 49.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-11": {
+   "open": 48.01,
+   "high": 48.9,
+   "low": 44.66,
+   "close": 48.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-12": {
+   "open": 46.92,
+   "high": 47.38,
+   "low": 41.06,
+   "close": 41.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-15": {
+   "open": 43.11,
+   "high": 43.42,
+   "low": 40.8,
+   "close": 41.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-16": {
+   "open": 40.75,
+   "high": 41.66,
+   "low": 39.24,
+   "close": 40.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-17": {
+   "open": 41.0,
+   "high": 41.32,
+   "low": 35.7,
+   "close": 36.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-18": {
+   "open": 39.97,
+   "high": 40.42,
+   "low": 38.11,
+   "close": 38.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-19": {
+   "open": 39.6,
+   "high": 42.36,
+   "low": 39.5,
+   "close": 41.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-22": {
+   "open": 44.45,
+   "high": 44.56,
+   "low": 42.73,
+   "close": 43.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-23": {
+   "open": 42.62,
+   "high": 43.8,
+   "low": 42.22,
+   "close": 43.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-24": {
+   "open": 43.72,
+   "high": 44.36,
+   "low": 43.59,
+   "close": 44.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-26": {
+   "open": 44.75,
+   "high": 44.79,
+   "low": 43.81,
+   "close": 44.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-29": {
+   "open": 42.98,
+   "high": 44.33,
+   "low": 42.35,
+   "close": 43.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-30": {
+   "open": 44.15,
+   "high": 44.75,
+   "low": 43.57,
+   "close": 43.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-31": {
+   "open": 43.89,
+   "high": 44.15,
+   "low": 42.01,
+   "close": 42.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-02": {
+   "open": 45.13,
+   "high": 48.09,
+   "low": 45.08,
+   "close": 47.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-05": {
+   "open": 50.35,
+   "high": 51.22,
+   "low": 48.63,
+   "close": 49.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-06": {
+   "open": 51.11,
+   "high": 54.3,
+   "low": 51.07,
+   "close": 54.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-07": {
+   "open": 52.2,
+   "high": 52.74,
+   "low": 50.84,
+   "close": 52.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-08": {
+   "open": 51.8,
+   "high": 51.81,
+   "low": 48.13,
+   "close": 49.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-09": {
+   "open": 51.09,
+   "high": 54.76,
+   "low": 50.31,
+   "close": 53.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-12": {
+   "open": 52.39,
+   "high": 55.15,
+   "low": 52.35,
+   "close": 54.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-13": {
+   "open": 55.69,
+   "high": 57.63,
+   "low": 55.43,
+   "close": 56.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-14": {
+   "open": 54.89,
+   "high": 55.44,
+   "low": 53.0,
+   "close": 55.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-15": {
+   "open": 60.96,
+   "high": 61.67,
+   "low": 58.01,
+   "close": 58.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-16": {
+   "open": 61.19,
+   "high": 62.19,
+   "low": 59.5,
+   "close": 60.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-20": {
+   "open": 57.34,
+   "high": 61.05,
+   "low": 57.22,
+   "close": 57.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-21": {
+   "open": 60.24,
+   "high": 65.11,
+   "low": 59.46,
+   "close": 63.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-22": {
+   "open": 66.9,
+   "high": 66.96,
+   "low": 63.04,
+   "close": 63.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-23": {
+   "open": 62.48,
+   "high": 63.36,
+   "low": 60.15,
+   "close": 61.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-26": {
+   "open": 60.75,
+   "high": 61.96,
+   "low": 59.6,
+   "close": 60.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-27": {
+   "open": 63.31,
+   "high": 65.99,
+   "low": 62.54,
+   "close": 64.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-28": {
+   "open": 69.0,
+   "high": 70.93,
+   "low": 67.98,
+   "close": 70.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-29": {
+   "open": 70.4,
+   "high": 71.98,
+   "low": 62.65,
+   "close": 70.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-30": {
+   "open": 67.12,
+   "high": 69.86,
+   "low": 60.29,
+   "close": 61.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-02": {
+   "open": 59.46,
+   "high": 66.94,
+   "low": 59.1,
+   "close": 65.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-03": {
+   "open": 66.81,
+   "high": 67.62,
+   "low": 57.02,
+   "close": 61.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-04": {
+   "open": 59.44,
+   "high": 61.03,
+   "low": 49.33,
+   "close": 53.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-05": {
+   "open": 51.31,
+   "high": 55.49,
+   "low": 50.01,
+   "close": 53.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-06": {
+   "open": 56.4,
+   "high": 62.25,
+   "low": 55.67,
+   "close": 61.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-09": {
+   "open": 59.99,
+   "high": 65.05,
+   "low": 59.29,
+   "close": 64.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-10": {
+   "open": 64.67,
+   "high": 65.21,
+   "low": 61.42,
+   "close": 63.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-11": {
+   "open": 67.21,
+   "high": 69.1,
+   "low": 63.23,
+   "close": 68.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-12": {
+   "open": 69.67,
+   "high": 70.86,
+   "low": 62.77,
+   "close": 63.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-13": {
+   "open": 63.93,
+   "high": 66.25,
+   "low": 61.43,
+   "close": 64.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-17": {
+   "open": 62.02,
+   "high": 65.96,
+   "low": 59.56,
+   "close": 64.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-18": {
+   "open": 65.26,
+   "high": 68.45,
+   "low": 64.07,
+   "close": 66.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-19": {
+   "open": 64.33,
+   "high": 65.51,
+   "low": 62.96,
+   "close": 65.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-20": {
+   "open": 63.76,
+   "high": 68.22,
+   "low": 63.58,
+   "close": 67.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-23": {
+   "open": 65.85,
+   "high": 67.65,
+   "low": 63.47,
+   "close": 65.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-24": {
+   "open": 68.11,
+   "high": 70.0,
+   "low": 66.35,
+   "close": 68.53,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-25": {
+   "open": 70.89,
+   "high": 72.36,
+   "low": 70.48,
+   "close": 71.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-26": {
+   "open": 71.03,
+   "high": 71.11,
+   "low": 61.63,
+   "close": 65.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-27": {
+   "open": 61.51,
+   "high": 63.76,
+   "low": 60.66,
+   "close": 62.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-02": {
+   "open": 58.11,
+   "high": 62.82,
+   "low": 58.05,
+   "close": 62.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-03": {
+   "open": 55.12,
+   "high": 55.86,
+   "low": 51.36,
+   "close": 53.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-04": {
+   "open": 55.96,
+   "high": 57.72,
+   "low": 54.38,
+   "close": 56.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-05": {
+   "open": 55.32,
+   "high": 57.69,
+   "low": 51.13,
+   "close": 54.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-06": {
+   "open": 50.09,
+   "high": 53.36,
+   "low": 46.8,
+   "close": 47.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-09": {
+   "open": 45.51,
+   "high": 53.78,
+   "low": 44.53,
+   "close": 53.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-10": {
+   "open": 53.36,
+   "high": 57.78,
+   "low": 53.36,
+   "close": 54.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-11": {
+   "open": 55.5,
+   "high": 57.74,
+   "low": 55.35,
+   "close": 56.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-12": {
+   "open": 53.53,
+   "high": 53.88,
+   "low": 49.53,
+   "close": 50.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-13": {
+   "open": 51.88,
+   "high": 53.96,
+   "low": 50.04,
+   "close": 50.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-16": {
+   "open": 54.06,
+   "high": 55.68,
+   "low": 53.01,
+   "close": 53.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-17": {
+   "open": 55.1,
+   "high": 55.4,
+   "low": 53.3,
+   "close": 54.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-18": {
+   "open": 55.03,
+   "high": 56.48,
+   "low": 54.0,
+   "close": 54.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-19": {
+   "open": 49.53,
+   "high": 56.11,
+   "low": 48.5,
+   "close": 54.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-20": {
+   "open": 54.69,
+   "high": 55.36,
+   "low": 49.0,
+   "close": 51.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-23": {
+   "open": 54.63,
+   "high": 56.81,
+   "low": 52.28,
+   "close": 53.03,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-24": {
+   "open": 51.54,
+   "high": 56.09,
+   "low": 51.54,
+   "close": 54.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-25": {
+   "open": 56.64,
+   "high": 58.25,
+   "low": 55.59,
+   "close": 57.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-26": {
+   "open": 54.19,
+   "high": 54.44,
+   "low": 48.87,
+   "close": 48.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-27": {
+   "open": 48.04,
+   "high": 49.38,
+   "low": 45.96,
+   "close": 46.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-30": {
+   "open": 47.86,
+   "high": 48.29,
+   "low": 39.52,
+   "close": 40.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-31": {
+   "open": 42.88,
+   "high": 48.18,
+   "low": 42.61,
+   "close": 47.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-01": {
+   "open": 50.04,
+   "high": 54.09,
+   "low": 49.62,
+   "close": 52.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-02": {
+   "open": 46.06,
+   "high": 53.07,
+   "low": 46.05,
+   "close": 52.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-06": {
+   "open": 53.75,
+   "high": 55.6,
+   "low": 52.88,
+   "close": 54.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-07": {
+   "open": 54.32,
+   "high": 56.6,
+   "low": 52.13,
+   "close": 56.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-08": {
+   "open": 66.33,
+   "high": 67.98,
+   "low": 63.56,
+   "close": 67.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-09": {
+   "open": 68.12,
+   "high": 72.28,
+   "low": 68.12,
+   "close": 71.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-10": {
+   "open": 74.3,
+   "high": 78.3,
+   "low": 74.3,
+   "close": 76.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-13": {
+   "open": 75.59,
+   "high": 80.74,
+   "low": 75.25,
+   "close": 80.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-14": {
+   "open": 83.27,
+   "high": 85.57,
+   "low": 80.71,
+   "close": 85.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-15": {
+   "open": 84.66,
+   "high": 85.98,
+   "low": 79.76,
+   "close": 85.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-16": {
+   "open": 85.01,
+   "high": 89.39,
+   "low": 83.31,
+   "close": 88.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-17": {
+   "open": 93.2,
+   "high": 94.75,
+   "low": 90.66,
+   "close": 94.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-20": {
+   "open": 95.97,
+   "high": 96.93,
+   "low": 92.03,
+   "close": 95.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-21": {
+   "open": 97.97,
+   "high": 99.95,
+   "low": 95.32,
+   "close": 98.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-22": {
+   "open": 102.94,
+   "high": 106.09,
+   "low": 99.6,
+   "close": 105.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-23": {
+   "open": 108.62,
+   "high": 116.77,
+   "low": 107.46,
+   "close": 112.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-24": {
+   "open": 125.21,
+   "high": 130.12,
+   "low": 120.24,
+   "close": 128.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-27": {
+   "open": 128.33,
+   "high": 129.59,
+   "low": 117.79,
+   "close": 123.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-28": {
+   "open": 108.75,
+   "high": 115.62,
+   "low": 103.99,
+   "close": 109.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-29": {
+   "open": 114.76,
+   "high": 118.32,
+   "low": 112.3,
+   "close": 117.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-30": {
+   "open": 122.81,
+   "high": 127.45,
+   "low": 117.5,
+   "close": 126.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
   "2026-05-01": {
    "open": 124.39,
    "high": 131.38,
@@ -654,6 +1590,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:31+08:00"
+  },
+  "2026-08-14": {
+   "open": 143.79,
+   "high": 146.65,
+   "low": 138.9,
+   "close": 144.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SOXX.json
+++ b/memory/bars/SOXX.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 292.87,
+   "high": 299.42,
+   "low": 292.53,
+   "close": 296.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-02": {
+   "open": 300.45,
+   "high": 304.84,
+   "low": 298.69,
+   "close": 302.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-03": {
+   "open": 304.5,
+   "high": 309.57,
+   "low": 301.47,
+   "close": 309.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-04": {
+   "open": 307.84,
+   "high": 308.27,
+   "low": 304.59,
+   "close": 306.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-05": {
+   "open": 309.3,
+   "high": 312.83,
+   "low": 308.93,
+   "close": 309.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-08": {
+   "open": 311.93,
+   "high": 314.08,
+   "low": 309.87,
+   "close": 312.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-09": {
+   "open": 310.78,
+   "high": 312.85,
+   "low": 309.44,
+   "close": 312.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-10": {
+   "open": 312.01,
+   "high": 317.35,
+   "low": 310.56,
+   "close": 316.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-11": {
+   "open": 312.8,
+   "high": 314.78,
+   "low": 305.79,
+   "close": 314.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-12": {
+   "open": 310.8,
+   "high": 311.6,
+   "low": 297.96,
+   "close": 299.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-15": {
+   "open": 302.6,
+   "high": 303.5,
+   "low": 297.23,
+   "close": 298.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-16": {
+   "open": 296.71,
+   "high": 298.92,
+   "low": 293.08,
+   "close": 296.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-17": {
+   "open": 297.32,
+   "high": 298.18,
+   "low": 284.43,
+   "close": 285.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-18": {
+   "open": 295.72,
+   "high": 296.96,
+   "low": 290.84,
+   "close": 292.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-19": {
+   "open": 294.67,
+   "high": 301.69,
+   "low": 294.5,
+   "close": 299.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-22": {
+   "open": 306.73,
+   "high": 306.94,
+   "low": 302.55,
+   "close": 303.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-23": {
+   "open": 302.21,
+   "high": 305.12,
+   "low": 301.37,
+   "close": 304.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-24": {
+   "open": 305.0,
+   "high": 306.5,
+   "low": 304.71,
+   "close": 306.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-26": {
+   "open": 307.4,
+   "high": 307.54,
+   "low": 305.29,
+   "close": 306.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-29": {
+   "open": 303.37,
+   "high": 306.46,
+   "low": 301.89,
+   "close": 305.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-30": {
+   "open": 306.08,
+   "high": 307.48,
+   "low": 304.7,
+   "close": 304.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2025-12-31": {
+   "open": 305.64,
+   "high": 306.12,
+   "low": 301.11,
+   "close": 301.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-02": {
+   "open": 308.56,
+   "high": 315.81,
+   "low": 308.56,
+   "close": 313.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-05": {
+   "open": 320.7,
+   "high": 322.64,
+   "low": 316.88,
+   "close": 318.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-06": {
+   "open": 322.07,
+   "high": 329.15,
+   "low": 322.0,
+   "close": 328.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-07": {
+   "open": 325.05,
+   "high": 325.95,
+   "low": 322.11,
+   "close": 324.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-08": {
+   "open": 324.19,
+   "high": 324.19,
+   "low": 316.4,
+   "close": 319.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-09": {
+   "open": 322.8,
+   "high": 330.67,
+   "low": 321.11,
+   "close": 328.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-12": {
+   "open": 325.7,
+   "high": 331.38,
+   "low": 325.53,
+   "close": 330.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-13": {
+   "open": 332.85,
+   "high": 336.42,
+   "low": 331.89,
+   "close": 333.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-14": {
+   "open": 331.03,
+   "high": 331.99,
+   "low": 327.18,
+   "close": 331.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-15": {
+   "open": 343.1,
+   "high": 344.55,
+   "low": 337.22,
+   "close": 337.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-16": {
+   "open": 343.51,
+   "high": 345.41,
+   "low": 340.22,
+   "close": 342.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-20": {
+   "open": 336.2,
+   "high": 343.19,
+   "low": 335.96,
+   "close": 337.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-21": {
+   "open": 341.84,
+   "high": 351.33,
+   "low": 340.3,
+   "close": 348.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-22": {
+   "open": 354.36,
+   "high": 354.6,
+   "low": 347.37,
+   "close": 348.67,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-23": {
+   "open": 346.39,
+   "high": 348.03,
+   "low": 342.17,
+   "close": 344.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-26": {
+   "open": 343.29,
+   "high": 345.5,
+   "low": 341.13,
+   "close": 343.07,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-27": {
+   "open": 348.16,
+   "high": 353.2,
+   "low": 346.65,
+   "close": 351.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-28": {
+   "open": 358.53,
+   "high": 362.04,
+   "low": 356.72,
+   "close": 360.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-29": {
+   "open": 361.18,
+   "high": 363.8,
+   "low": 347.72,
+   "close": 361.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-01-30": {
+   "open": 356.0,
+   "high": 360.19,
+   "low": 343.71,
+   "close": 346.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-02": {
+   "open": 342.37,
+   "high": 356.11,
+   "low": 341.9,
+   "close": 352.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-03": {
+   "open": 355.91,
+   "high": 357.12,
+   "low": 338.09,
+   "close": 345.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-04": {
+   "open": 342.18,
+   "high": 345.39,
+   "low": 323.33,
+   "close": 330.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-05": {
+   "open": 326.54,
+   "high": 335.47,
+   "low": 324.04,
+   "close": 330.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-06": {
+   "open": 337.4,
+   "high": 349.56,
+   "low": 335.87,
+   "close": 348.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-09": {
+   "open": 344.84,
+   "high": 354.74,
+   "low": 343.88,
+   "close": 352.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-10": {
+   "open": 353.52,
+   "high": 355.04,
+   "low": 348.12,
+   "close": 351.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-11": {
+   "open": 358.82,
+   "high": 362.28,
+   "low": 351.4,
+   "close": 360.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-12": {
+   "open": 363.46,
+   "high": 365.38,
+   "low": 351.05,
+   "close": 351.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-13": {
+   "open": 352.8,
+   "high": 357.61,
+   "low": 348.68,
+   "close": 354.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-17": {
+   "open": 349.81,
+   "high": 357.1,
+   "low": 345.32,
+   "close": 354.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-18": {
+   "open": 355.82,
+   "high": 361.67,
+   "low": 353.6,
+   "close": 357.92,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-19": {
+   "open": 354.18,
+   "high": 356.32,
+   "low": 351.77,
+   "close": 355.84,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-20": {
+   "open": 353.59,
+   "high": 361.33,
+   "low": 352.8,
+   "close": 359.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-23": {
+   "open": 357.57,
+   "high": 360.38,
+   "low": 352.85,
+   "close": 356.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-24": {
+   "open": 361.6,
+   "high": 364.74,
+   "low": 358.04,
+   "close": 362.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-25": {
+   "open": 366.2,
+   "high": 368.82,
+   "low": 365.51,
+   "close": 368.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-26": {
+   "open": 366.38,
+   "high": 366.48,
+   "low": 350.41,
+   "close": 356.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-02-27": {
+   "open": 349.6,
+   "high": 354.03,
+   "low": 348.34,
+   "close": 352.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-02": {
+   "open": 343.79,
+   "high": 352.33,
+   "low": 343.34,
+   "close": 352.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-03": {
+   "open": 338.09,
+   "high": 339.31,
+   "low": 330.89,
+   "close": 334.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-04": {
+   "open": 339.96,
+   "high": 343.81,
+   "low": 336.79,
+   "close": 341.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-05": {
+   "open": 338.9,
+   "high": 343.72,
+   "low": 330.57,
+   "close": 337.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-06": {
+   "open": 328.4,
+   "high": 335.04,
+   "low": 321.49,
+   "close": 323.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-09": {
+   "open": 318.31,
+   "high": 337.17,
+   "low": 316.22,
+   "close": 336.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-10": {
+   "open": 336.31,
+   "high": 345.56,
+   "low": 336.31,
+   "close": 338.81,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-11": {
+   "open": 340.5,
+   "high": 345.4,
+   "low": 340.45,
+   "close": 342.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-12": {
+   "open": 337.34,
+   "high": 337.55,
+   "low": 328.64,
+   "close": 330.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-13": {
+   "open": 333.88,
+   "high": 338.4,
+   "low": 329.79,
+   "close": 331.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-16": {
+   "open": 338.89,
+   "high": 342.04,
+   "low": 336.32,
+   "close": 337.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-17": {
+   "open": 340.56,
+   "high": 341.16,
+   "low": 336.79,
+   "close": 340.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-18": {
+   "open": 340.53,
+   "high": 343.44,
+   "low": 338.29,
+   "close": 338.29,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-19": {
+   "open": 328.76,
+   "high": 342.77,
+   "low": 326.76,
+   "close": 340.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-20": {
+   "open": 339.71,
+   "high": 341.25,
+   "low": 327.94,
+   "close": 332.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-23": {
+   "open": 340.12,
+   "high": 344.93,
+   "low": 335.12,
+   "close": 336.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-24": {
+   "open": 333.79,
+   "high": 343.22,
+   "low": 333.62,
+   "close": 341.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-25": {
+   "open": 344.17,
+   "high": 347.68,
+   "low": 342.14,
+   "close": 345.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-26": {
+   "open": 339.45,
+   "high": 339.89,
+   "low": 328.52,
+   "close": 328.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-27": {
+   "open": 326.84,
+   "high": 329.95,
+   "low": 322.16,
+   "close": 323.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-30": {
+   "open": 326.75,
+   "high": 327.63,
+   "low": 307.26,
+   "close": 309.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-03-31": {
+   "open": 315.6,
+   "high": 329.18,
+   "low": 314.88,
+   "close": 328.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-01": {
+   "open": 333.49,
+   "high": 342.65,
+   "low": 332.35,
+   "close": 338.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-02": {
+   "open": 325.11,
+   "high": 340.39,
+   "low": 325.03,
+   "close": 339.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-06": {
+   "open": 341.52,
+   "high": 345.77,
+   "low": 339.92,
+   "close": 344.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-07": {
+   "open": 343.04,
+   "high": 347.94,
+   "low": 338.47,
+   "close": 347.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-08": {
+   "open": 367.89,
+   "high": 371.15,
+   "low": 362.13,
+   "close": 370.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-09": {
+   "open": 371.3,
+   "high": 378.95,
+   "low": 371.3,
+   "close": 378.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-10": {
+   "open": 382.67,
+   "high": 389.6,
+   "low": 382.67,
+   "close": 386.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-13": {
+   "open": 384.88,
+   "high": 393.57,
+   "low": 384.37,
+   "close": 393.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-14": {
+   "open": 397.84,
+   "high": 401.44,
+   "low": 393.51,
+   "close": 401.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-15": {
+   "open": 400.31,
+   "high": 402.09,
+   "low": 392.39,
+   "close": 401.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-16": {
+   "open": 400.6,
+   "high": 407.48,
+   "low": 397.99,
+   "close": 405.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-17": {
+   "open": 413.38,
+   "high": 415.73,
+   "low": 409.58,
+   "close": 415.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-20": {
+   "open": 417.43,
+   "high": 418.86,
+   "low": 411.79,
+   "close": 417.55,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-21": {
+   "open": 420.4,
+   "high": 423.35,
+   "low": 416.67,
+   "close": 420.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-22": {
+   "open": 427.26,
+   "high": 432.16,
+   "low": 422.82,
+   "close": 431.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-23": {
+   "open": 435.34,
+   "high": 446.64,
+   "low": 434.04,
+   "close": 441.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-24": {
+   "open": 457.59,
+   "high": 463.87,
+   "low": 450.97,
+   "close": 461.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-27": {
+   "open": 461.75,
+   "high": 463.0,
+   "low": 448.93,
+   "close": 455.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-28": {
+   "open": 437.63,
+   "high": 446.14,
+   "low": 431.74,
+   "close": 438.71,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-29": {
+   "open": 445.26,
+   "high": 450.37,
+   "low": 442.41,
+   "close": 449.99,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
+  "2026-04-30": {
+   "open": 455.7,
+   "high": 462.14,
+   "low": 449.34,
+   "close": 461.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
+  },
   "2026-05-01": {
    "open": 458.47,
    "high": 466.91,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:31+08:00"
+  },
+  "2026-08-14": {
+   "open": 549.58,
+   "high": 552.89,
+   "low": 542.93,
+   "close": 550.42,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
   }
  }
 }

--- a/memory/bars/SPCH.json
+++ b/memory/bars/SPCH.json
@@ -384,6 +384,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:31+08:00"
+  },
+  "2026-08-14": {
+   "open": 9.43,
+   "high": 9.55,
+   "low": 8.45,
+   "close": 9.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/SPCX.json
+++ b/memory/bars/SPCX.json
@@ -393,6 +393,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:31+08:00"
+  },
+  "2026-08-14": {
+   "open": 142.9,
+   "high": 144.02,
+   "low": 135.5,
+   "close": 140.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:50+08:00"
   }
  },
  "retired": false

--- a/memory/bars/TCOM.json
+++ b/memory/bars/TCOM.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 69.85,
+   "high": 70.55,
+   "low": 69.5,
+   "close": 70.28,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-02": {
+   "open": 70.0,
+   "high": 70.45,
+   "low": 69.8,
+   "close": 70.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-03": {
+   "open": 68.85,
+   "high": 70.77,
+   "low": 68.83,
+   "close": 70.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-04": {
+   "open": 71.36,
+   "high": 71.99,
+   "low": 70.98,
+   "close": 71.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-05": {
+   "open": 70.99,
+   "high": 72.08,
+   "low": 70.62,
+   "close": 71.75,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-08": {
+   "open": 70.59,
+   "high": 70.69,
+   "low": 69.74,
+   "close": 70.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-09": {
+   "open": 69.46,
+   "high": 70.2,
+   "low": 69.18,
+   "close": 70.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-10": {
+   "open": 70.2,
+   "high": 70.99,
+   "low": 70.13,
+   "close": 70.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-11": {
+   "open": 70.08,
+   "high": 70.47,
+   "low": 69.86,
+   "close": 70.13,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-12": {
+   "open": 70.56,
+   "high": 70.97,
+   "low": 70.11,
+   "close": 70.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-15": {
+   "open": 71.0,
+   "high": 72.07,
+   "low": 70.72,
+   "close": 71.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-16": {
+   "open": 71.01,
+   "high": 71.39,
+   "low": 70.67,
+   "close": 70.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-17": {
+   "open": 72.0,
+   "high": 73.2,
+   "low": 71.69,
+   "close": 71.85,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-18": {
+   "open": 71.91,
+   "high": 72.29,
+   "low": 71.24,
+   "close": 71.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-19": {
+   "open": 71.77,
+   "high": 72.88,
+   "low": 71.29,
+   "close": 72.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-22": {
+   "open": 73.5,
+   "high": 74.3,
+   "low": 73.41,
+   "close": 73.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-23": {
+   "open": 73.39,
+   "high": 73.46,
+   "low": 72.3,
+   "close": 72.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-24": {
+   "open": 72.48,
+   "high": 72.96,
+   "low": 72.17,
+   "close": 72.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-26": {
+   "open": 72.31,
+   "high": 72.53,
+   "low": 72.15,
+   "close": 72.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-29": {
+   "open": 72.17,
+   "high": 72.65,
+   "low": 72.05,
+   "close": 72.61,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-30": {
+   "open": 73.0,
+   "high": 73.48,
+   "low": 72.32,
+   "close": 72.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-31": {
+   "open": 71.61,
+   "high": 72.13,
+   "low": 71.5,
+   "close": 71.91,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-02": {
+   "open": 74.1,
+   "high": 74.8,
+   "low": 73.92,
+   "close": 74.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-05": {
+   "open": 74.11,
+   "high": 75.76,
+   "low": 73.81,
+   "close": 75.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-06": {
+   "open": 77.06,
+   "high": 77.61,
+   "low": 76.06,
+   "close": 76.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-07": {
+   "open": 76.49,
+   "high": 76.82,
+   "low": 75.75,
+   "close": 76.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-08": {
+   "open": 76.65,
+   "high": 77.65,
+   "low": 76.65,
+   "close": 76.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-09": {
+   "open": 76.75,
+   "high": 76.81,
+   "low": 75.52,
+   "close": 75.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-12": {
+   "open": 77.41,
+   "high": 78.99,
+   "low": 77.34,
+   "close": 78.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-13": {
+   "open": 78.12,
+   "high": 78.47,
+   "low": 75.44,
+   "close": 75.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-14": {
+   "open": 63.03,
+   "high": 65.0,
+   "low": 61.33,
+   "close": 62.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-15": {
+   "open": 60.98,
+   "high": 62.29,
+   "low": 60.71,
+   "close": 61.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-16": {
+   "open": 60.48,
+   "high": 62.92,
+   "low": 60.2,
+   "close": 61.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-20": {
+   "open": 61.32,
+   "high": 61.96,
+   "low": 60.14,
+   "close": 60.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-21": {
+   "open": 62.47,
+   "high": 62.96,
+   "low": 61.83,
+   "close": 62.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-22": {
+   "open": 61.95,
+   "high": 62.6,
+   "low": 61.64,
+   "close": 62.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-23": {
+   "open": 62.13,
+   "high": 63.17,
+   "low": 62.13,
+   "close": 62.88,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-26": {
+   "open": 62.76,
+   "high": 63.99,
+   "low": 62.76,
+   "close": 63.97,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-27": {
+   "open": 64.11,
+   "high": 64.24,
+   "low": 62.4,
+   "close": 62.44,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-28": {
+   "open": 62.72,
+   "high": 63.13,
+   "low": 62.11,
+   "close": 62.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-29": {
+   "open": 61.95,
+   "high": 62.54,
+   "low": 61.35,
+   "close": 62.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-30": {
+   "open": 61.92,
+   "high": 61.99,
+   "low": 60.72,
+   "close": 61.37,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-02": {
+   "open": 60.98,
+   "high": 62.04,
+   "low": 60.91,
+   "close": 62.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-03": {
+   "open": 61.73,
+   "high": 62.01,
+   "low": 60.2,
+   "close": 60.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-04": {
+   "open": 58.53,
+   "high": 58.64,
+   "low": 57.06,
+   "close": 57.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-05": {
+   "open": 57.29,
+   "high": 58.17,
+   "low": 56.95,
+   "close": 57.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-06": {
+   "open": 57.6,
+   "high": 59.51,
+   "low": 57.6,
+   "close": 59.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-09": {
+   "open": 58.4,
+   "high": 59.04,
+   "low": 58.1,
+   "close": 58.58,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-10": {
+   "open": 57.49,
+   "high": 57.94,
+   "low": 57.23,
+   "close": 57.5,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-11": {
+   "open": 57.37,
+   "high": 57.97,
+   "low": 56.52,
+   "close": 57.94,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-12": {
+   "open": 56.0,
+   "high": 56.05,
+   "low": 54.33,
+   "close": 54.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-13": {
+   "open": 53.52,
+   "high": 54.48,
+   "low": 53.3,
+   "close": 54.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-17": {
+   "open": 54.01,
+   "high": 56.45,
+   "low": 53.69,
+   "close": 56.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-18": {
+   "open": 56.3,
+   "high": 56.64,
+   "low": 55.98,
+   "close": 56.63,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-19": {
+   "open": 56.24,
+   "high": 56.44,
+   "low": 55.19,
+   "close": 55.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-20": {
+   "open": 53.53,
+   "high": 54.65,
+   "low": 53.15,
+   "close": 54.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-23": {
+   "open": 54.24,
+   "high": 54.27,
+   "low": 52.7,
+   "close": 52.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-24": {
+   "open": 52.81,
+   "high": 54.06,
+   "low": 52.33,
+   "close": 53.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-25": {
+   "open": 53.67,
+   "high": 53.86,
+   "low": 52.59,
+   "close": 53.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-26": {
+   "open": 52.18,
+   "high": 52.82,
+   "low": 51.56,
+   "close": 52.27,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-27": {
+   "open": 52.13,
+   "high": 53.0,
+   "low": 52.11,
+   "close": 52.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-02": {
+   "open": 51.0,
+   "high": 51.74,
+   "low": 50.7,
+   "close": 51.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-03": {
+   "open": 50.45,
+   "high": 52.09,
+   "low": 49.48,
+   "close": 51.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-04": {
+   "open": 51.55,
+   "high": 51.56,
+   "low": 50.18,
+   "close": 50.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-05": {
+   "open": 50.47,
+   "high": 52.02,
+   "low": 50.12,
+   "close": 51.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-06": {
+   "open": 52.92,
+   "high": 54.24,
+   "low": 52.68,
+   "close": 54.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-09": {
+   "open": 52.76,
+   "high": 53.76,
+   "low": 51.85,
+   "close": 53.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-10": {
+   "open": 53.88,
+   "high": 54.01,
+   "low": 52.76,
+   "close": 53.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-11": {
+   "open": 53.21,
+   "high": 53.21,
+   "low": 51.91,
+   "close": 52.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-12": {
+   "open": 52.16,
+   "high": 52.34,
+   "low": 51.9,
+   "close": 51.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-13": {
+   "open": 51.82,
+   "high": 52.26,
+   "low": 51.58,
+   "close": 51.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-16": {
+   "open": 52.36,
+   "high": 52.88,
+   "low": 52.2,
+   "close": 52.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-17": {
+   "open": 52.9,
+   "high": 52.91,
+   "low": 52.22,
+   "close": 52.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-18": {
+   "open": 52.05,
+   "high": 52.63,
+   "low": 51.89,
+   "close": 51.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-19": {
+   "open": 50.99,
+   "high": 51.92,
+   "low": 50.7,
+   "close": 51.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-20": {
+   "open": 51.61,
+   "high": 51.71,
+   "low": 51.04,
+   "close": 51.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-23": {
+   "open": 50.78,
+   "high": 51.97,
+   "low": 50.7,
+   "close": 51.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-24": {
+   "open": 50.78,
+   "high": 51.35,
+   "low": 50.5,
+   "close": 51.18,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-25": {
+   "open": 51.64,
+   "high": 51.64,
+   "low": 50.92,
+   "close": 51.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-26": {
+   "open": 50.08,
+   "high": 50.85,
+   "low": 49.94,
+   "close": 50.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-27": {
+   "open": 49.94,
+   "high": 50.25,
+   "low": 48.48,
+   "close": 48.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-30": {
+   "open": 48.69,
+   "high": 49.51,
+   "low": 48.69,
+   "close": 49.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-31": {
+   "open": 48.76,
+   "high": 49.82,
+   "low": 48.52,
+   "close": 49.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-01": {
+   "open": 50.25,
+   "high": 50.46,
+   "low": 49.23,
+   "close": 49.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-02": {
+   "open": 49.49,
+   "high": 50.81,
+   "low": 49.48,
+   "close": 50.48,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-06": {
+   "open": 50.01,
+   "high": 50.74,
+   "low": 49.94,
+   "close": 50.09,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-07": {
+   "open": 50.09,
+   "high": 50.25,
+   "low": 49.62,
+   "close": 50.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-08": {
+   "open": 52.0,
+   "high": 52.91,
+   "low": 51.73,
+   "close": 51.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-09": {
+   "open": 51.38,
+   "high": 51.5,
+   "low": 50.56,
+   "close": 51.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-10": {
+   "open": 51.51,
+   "high": 51.8,
+   "low": 51.17,
+   "close": 51.32,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-13": {
+   "open": 50.81,
+   "high": 51.82,
+   "low": 50.73,
+   "close": 51.77,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-14": {
+   "open": 51.21,
+   "high": 52.67,
+   "low": 51.2,
+   "close": 52.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-15": {
+   "open": 52.94,
+   "high": 54.38,
+   "low": 52.94,
+   "close": 54.12,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-16": {
+   "open": 55.03,
+   "high": 55.25,
+   "low": 54.4,
+   "close": 54.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-17": {
+   "open": 55.58,
+   "high": 55.7,
+   "low": 55.06,
+   "close": 55.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-20": {
+   "open": 54.1,
+   "high": 55.04,
+   "low": 53.95,
+   "close": 55.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-21": {
+   "open": 54.97,
+   "high": 55.14,
+   "low": 54.43,
+   "close": 54.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-22": {
+   "open": 54.18,
+   "high": 54.34,
+   "low": 53.55,
+   "close": 53.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-23": {
+   "open": 53.14,
+   "high": 53.16,
+   "low": 52.31,
+   "close": 52.95,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-24": {
+   "open": 53.14,
+   "high": 53.14,
+   "low": 52.69,
+   "close": 53.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-27": {
+   "open": 52.55,
+   "high": 53.27,
+   "low": 52.11,
+   "close": 53.2,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-28": {
+   "open": 52.76,
+   "high": 53.23,
+   "low": 52.33,
+   "close": 52.34,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-29": {
+   "open": 52.79,
+   "high": 53.08,
+   "low": 52.19,
+   "close": 52.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-30": {
+   "open": 53.87,
+   "high": 54.42,
+   "low": 53.33,
+   "close": 54.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
   "2026-05-01": {
    "open": 54.46,
    "high": 54.46,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:32+08:00"
+  },
+  "2026-08-14": {
+   "open": 44.89,
+   "high": 45.06,
+   "low": 44.61,
+   "close": 44.98,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
   }
  }
 }

--- a/memory/bars/TQQQ.json
+++ b/memory/bars/TQQQ.json
@@ -8,6 +8,942 @@
  "source": "tencent",
  "retired": false,
  "bars": {
+  "2025-12-01": {
+   "open": 53.11,
+   "high": 54.65,
+   "low": 52.82,
+   "close": 54.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-02": {
+   "open": 54.63,
+   "high": 55.76,
+   "low": 54.14,
+   "close": 55.3,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-03": {
+   "open": 54.66,
+   "high": 55.88,
+   "low": 54.23,
+   "close": 55.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-04": {
+   "open": 56.04,
+   "high": 56.05,
+   "low": 54.61,
+   "close": 55.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-05": {
+   "open": 55.86,
+   "high": 57.08,
+   "low": 55.68,
+   "close": 56.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-08": {
+   "open": 56.57,
+   "high": 57.04,
+   "low": 55.12,
+   "close": 55.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-09": {
+   "open": 55.45,
+   "high": 56.22,
+   "low": 55.09,
+   "close": 56.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-10": {
+   "open": 55.65,
+   "high": 57.09,
+   "low": 54.89,
+   "close": 56.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-11": {
+   "open": 55.63,
+   "high": 56.16,
+   "low": 53.98,
+   "close": 56.11,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-12": {
+   "open": 55.11,
+   "high": 55.52,
+   "low": 52.23,
+   "close": 52.82,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-15": {
+   "open": 54.06,
+   "high": 54.06,
+   "low": 51.72,
+   "close": 52.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-16": {
+   "open": 51.43,
+   "high": 52.77,
+   "low": 51.1,
+   "close": 52.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-17": {
+   "open": 52.65,
+   "high": 52.8,
+   "low": 49.37,
+   "close": 49.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-18": {
+   "open": 51.67,
+   "high": 52.46,
+   "low": 50.98,
+   "close": 51.51,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-19": {
+   "open": 52.2,
+   "high": 53.64,
+   "low": 52.19,
+   "close": 53.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-22": {
+   "open": 54.81,
+   "high": 54.89,
+   "low": 53.88,
+   "close": 54.25,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-23": {
+   "open": 53.97,
+   "high": 55.07,
+   "low": 53.86,
+   "close": 55.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-24": {
+   "open": 54.87,
+   "high": 55.45,
+   "low": 54.78,
+   "close": 55.36,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-26": {
+   "open": 55.52,
+   "high": 55.75,
+   "low": 55.11,
+   "close": 55.31,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-29": {
+   "open": 54.29,
+   "high": 54.99,
+   "low": 53.92,
+   "close": 54.49,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-30": {
+   "open": 54.2,
+   "high": 54.82,
+   "low": 54.04,
+   "close": 54.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2025-12-31": {
+   "open": 54.13,
+   "high": 54.2,
+   "low": 52.64,
+   "close": 52.72,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-02": {
+   "open": 54.17,
+   "high": 54.88,
+   "low": 51.61,
+   "close": 52.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-05": {
+   "open": 53.95,
+   "high": 54.33,
+   "low": 53.29,
+   "close": 53.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-06": {
+   "open": 53.92,
+   "high": 55.17,
+   "low": 53.74,
+   "close": 55.01,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-07": {
+   "open": 54.89,
+   "high": 56.19,
+   "low": 54.77,
+   "close": 55.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-08": {
+   "open": 54.87,
+   "high": 54.98,
+   "low": 53.5,
+   "close": 54.19,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-09": {
+   "open": 54.39,
+   "high": 56.1,
+   "low": 53.79,
+   "close": 55.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-12": {
+   "open": 54.6,
+   "high": 56.34,
+   "low": 54.58,
+   "close": 55.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-13": {
+   "open": 55.91,
+   "high": 56.5,
+   "low": 54.96,
+   "close": 55.6,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-14": {
+   "open": 54.55,
+   "high": 54.88,
+   "low": 52.5,
+   "close": 53.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-15": {
+   "open": 55.65,
+   "high": 55.83,
+   "low": 54.13,
+   "close": 54.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-16": {
+   "open": 55.32,
+   "high": 55.46,
+   "low": 53.58,
+   "close": 54.14,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-20": {
+   "open": 51.39,
+   "high": 52.56,
+   "low": 50.48,
+   "close": 50.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-21": {
+   "open": 51.07,
+   "high": 53.8,
+   "low": 50.67,
+   "close": 52.73,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-22": {
+   "open": 54.32,
+   "high": 54.33,
+   "low": 53.15,
+   "close": 53.9,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-23": {
+   "open": 53.59,
+   "high": 55.07,
+   "low": 53.32,
+   "close": 54.38,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-26": {
+   "open": 54.47,
+   "high": 55.63,
+   "low": 54.21,
+   "close": 55.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-27": {
+   "open": 55.98,
+   "high": 56.8,
+   "low": 55.56,
+   "close": 56.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-28": {
+   "open": 57.7,
+   "high": 58.01,
+   "low": 56.73,
+   "close": 57.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-29": {
+   "open": 56.95,
+   "high": 57.21,
+   "low": 53.06,
+   "close": 56.04,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-01-30": {
+   "open": 55.02,
+   "high": 55.71,
+   "low": 53.32,
+   "close": 54.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-02": {
+   "open": 53.16,
+   "high": 55.71,
+   "low": 53.15,
+   "close": 55.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-03": {
+   "open": 55.64,
+   "high": 55.76,
+   "low": 51.08,
+   "close": 52.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-04": {
+   "open": 52.14,
+   "high": 52.15,
+   "low": 48.43,
+   "close": 49.76,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-05": {
+   "open": 48.39,
+   "high": 49.53,
+   "low": 47.06,
+   "close": 47.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-06": {
+   "open": 48.34,
+   "high": 51.01,
+   "low": 48.0,
+   "close": 50.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-09": {
+   "open": 50.06,
+   "high": 52.27,
+   "low": 49.44,
+   "close": 51.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-10": {
+   "open": 51.97,
+   "high": 52.4,
+   "low": 50.89,
+   "close": 51.02,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-11": {
+   "open": 52.21,
+   "high": 52.5,
+   "low": 50.04,
+   "close": 51.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-12": {
+   "open": 51.8,
+   "high": 52.07,
+   "low": 47.99,
+   "close": 48.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-13": {
+   "open": 48.15,
+   "high": 49.59,
+   "low": 47.18,
+   "close": 48.47,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-17": {
+   "open": 47.64,
+   "high": 48.98,
+   "low": 46.42,
+   "close": 48.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-18": {
+   "open": 48.53,
+   "high": 50.36,
+   "low": 48.2,
+   "close": 49.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-19": {
+   "open": 48.67,
+   "high": 49.4,
+   "low": 48.16,
+   "close": 48.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-20": {
+   "open": 47.96,
+   "high": 50.45,
+   "low": 47.76,
+   "close": 50.06,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-23": {
+   "open": 49.53,
+   "high": 49.88,
+   "low": 47.66,
+   "close": 48.24,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-24": {
+   "open": 48.45,
+   "high": 50.04,
+   "low": 47.82,
+   "close": 49.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-25": {
+   "open": 50.55,
+   "high": 51.96,
+   "low": 50.53,
+   "close": 51.87,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-26": {
+   "open": 51.63,
+   "high": 51.64,
+   "low": 48.71,
+   "close": 50.05,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-02-27": {
+   "open": 48.45,
+   "high": 49.77,
+   "low": 48.26,
+   "close": 49.52,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-02": {
+   "open": 47.46,
+   "high": 50.15,
+   "low": 47.23,
+   "close": 49.7,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-03": {
+   "open": 46.81,
+   "high": 48.67,
+   "low": 45.72,
+   "close": 48.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-04": {
+   "open": 48.69,
+   "high": 50.79,
+   "low": 48.52,
+   "close": 50.26,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-05": {
+   "open": 49.44,
+   "high": 50.76,
+   "low": 48.17,
+   "close": 49.8,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-06": {
+   "open": 47.66,
+   "high": 49.05,
+   "low": 47.18,
+   "close": 47.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-09": {
+   "open": 46.19,
+   "high": 49.77,
+   "low": 45.5,
+   "close": 49.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-10": {
+   "open": 49.41,
+   "high": 50.74,
+   "low": 48.83,
+   "close": 49.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-11": {
+   "open": 49.68,
+   "high": 50.52,
+   "low": 48.73,
+   "close": 49.35,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-12": {
+   "open": 48.15,
+   "high": 48.49,
+   "low": 46.75,
+   "close": 46.83,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-13": {
+   "open": 47.35,
+   "high": 48.25,
+   "low": 45.67,
+   "close": 45.93,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-16": {
+   "open": 47.37,
+   "high": 48.27,
+   "low": 47.18,
+   "close": 47.46,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-17": {
+   "open": 48.12,
+   "high": 48.76,
+   "low": 47.81,
+   "close": 48.16,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-18": {
+   "open": 47.72,
+   "high": 48.11,
+   "low": 46.05,
+   "close": 46.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-19": {
+   "open": 44.87,
+   "high": 46.32,
+   "low": 44.3,
+   "close": 45.69,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-20": {
+   "open": 45.18,
+   "high": 45.21,
+   "low": 42.3,
+   "close": 43.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-23": {
+   "open": 45.11,
+   "high": 46.15,
+   "low": 44.13,
+   "close": 44.57,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-24": {
+   "open": 43.84,
+   "high": 44.55,
+   "low": 43.19,
+   "close": 43.62,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-25": {
+   "open": 44.7,
+   "high": 45.22,
+   "low": 43.95,
+   "close": 44.39,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-26": {
+   "open": 43.23,
+   "high": 43.68,
+   "low": 41.15,
+   "close": 41.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-27": {
+   "open": 40.56,
+   "high": 40.59,
+   "low": 38.56,
+   "close": 38.78,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-30": {
+   "open": 39.75,
+   "high": 39.91,
+   "low": 37.32,
+   "close": 37.89,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-03-31": {
+   "open": 39.09,
+   "high": 42.0,
+   "low": 39.07,
+   "close": 41.68,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-01": {
+   "open": 42.63,
+   "high": 43.98,
+   "low": 42.41,
+   "close": 43.23,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-02": {
+   "open": 40.88,
+   "high": 43.55,
+   "low": 40.44,
+   "close": 43.33,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-06": {
+   "open": 43.6,
+   "high": 44.59,
+   "low": 43.27,
+   "close": 44.1,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-07": {
+   "open": 43.45,
+   "high": 44.21,
+   "low": 41.84,
+   "close": 44.15,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-08": {
+   "open": 48.64,
+   "high": 48.92,
+   "low": 47.15,
+   "close": 48.0,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-09": {
+   "open": 48.02,
+   "high": 49.09,
+   "low": 47.31,
+   "close": 48.96,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-10": {
+   "open": 49.36,
+   "high": 49.81,
+   "low": 48.82,
+   "close": 49.17,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-13": {
+   "open": 48.78,
+   "high": 50.74,
+   "low": 48.46,
+   "close": 50.66,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-14": {
+   "open": 51.39,
+   "high": 53.43,
+   "low": 51.38,
+   "close": 53.41,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-15": {
+   "open": 53.57,
+   "high": 55.74,
+   "low": 53.33,
+   "close": 55.65,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-16": {
+   "open": 56.13,
+   "high": 56.92,
+   "low": 55.1,
+   "close": 56.43,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-17": {
+   "open": 57.78,
+   "high": 58.94,
+   "low": 57.37,
+   "close": 58.59,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-20": {
+   "open": 58.4,
+   "high": 58.58,
+   "low": 56.91,
+   "close": 58.08,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-21": {
+   "open": 58.48,
+   "high": 58.97,
+   "low": 56.82,
+   "close": 57.4,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-22": {
+   "open": 58.93,
+   "high": 60.3,
+   "low": 58.49,
+   "close": 60.21,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-23": {
+   "open": 59.8,
+   "high": 60.73,
+   "low": 57.59,
+   "close": 59.22,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-24": {
+   "open": 61.08,
+   "high": 62.74,
+   "low": 60.56,
+   "close": 62.56,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-27": {
+   "open": 62.41,
+   "high": 62.7,
+   "low": 61.64,
+   "close": 62.64,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-28": {
+   "open": 60.72,
+   "high": 61.33,
+   "low": 59.68,
+   "close": 60.74,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-29": {
+   "open": 61.0,
+   "high": 61.87,
+   "low": 60.45,
+   "close": 61.86,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
+  "2026-04-30": {
+   "open": 62.89,
+   "high": 63.8,
+   "low": 60.7,
+   "close": 63.54,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
+  },
   "2026-05-01": {
    "open": 63.89,
    "high": 65.84,
@@ -655,6 +1591,15 @@
    "source": "tencent",
    "adjustment": "raw",
    "fetched_at": "2026-08-14T08:03:32+08:00"
+  },
+  "2026-08-14": {
+   "open": 77.57,
+   "high": 77.85,
+   "low": 75.94,
+   "close": 76.79,
+   "source": "tencent",
+   "adjustment": "raw",
+   "fetched_at": "2026-08-17T09:11:51+08:00"
   }
  }
 }

--- a/ops/growth/refresh_readme_metrics.py
+++ b/ops/growth/refresh_readme_metrics.py
@@ -38,6 +38,26 @@ def _ci(pct: float, n: int) -> str:
     return f"{round(lo)}%–{round(hi)}%"
 
 
+def _earliest_stamp(rows) -> str:
+    """The oldest decision timestamp in the ledger, across both row shapes.
+
+    `memory/decisions.jsonl` holds two kinds of row. Plan-authored rows carry
+    `created_at`. Decision Mind's conversation rows (`schema_version: 0`,
+    `source: "conversation"`) carry `decided_at` and no `created_at` — so the
+    original `min(r["created_at"] for r in rows)` raised `KeyError` the first
+    night one of those landed (2026-08-16), and the nightly README refresh has
+    failed on every run since. Every other reader in the tree already reaches
+    for this field through `.get`; this was the one bare subscript.
+
+    Rows with neither stamp are skipped rather than fatal: a new row shape
+    should degrade this metric, not take down the workflow.
+    """
+    stamps = [s for s in ((r.get("created_at") or r.get("decided_at") or "") for r in rows) if s]
+    if not stamps:
+        raise ValueError("no decision row carries created_at or decided_at")
+    return min(stamps)
+
+
 def _pct(group) -> tuple:
     if not group:
         return None, 0
@@ -68,7 +88,7 @@ def _refresh() -> int:
     hold_pct, hold_n = _pct(passive)
     hi_pct, hi_n = _pct(hi)
 
-    first_day = min(r["created_at"] for r in rows)
+    first_day = _earliest_stamp(rows)
     days = (datetime.now(datetime.fromisoformat(first_day).tzinfo)
             - datetime.fromisoformat(first_day)).days
 

--- a/src/clawock/market_data/bars.py
+++ b/src/clawock/market_data/bars.py
@@ -62,7 +62,13 @@ WS = workspace_root(Path.cwd())
 BARS_DIR = WS / "memory" / "bars"
 HKT = ZoneInfo("Asia/Hong_Kong")
 ET = ZoneInfo("America/New_York")
-START_DATE = "2026-05-01"          # decisions start 2026-05-17; a margin gives T-n context
+# Decisions start 2026-05-17, so settlement alone would only need a margin before
+# that. The floor is earlier because the Decision Mind trace view settles *fills*,
+# and the fill log in portfolio.json goes back to 2025-12-23 — with the old
+# 2026-05-01 floor, 51 of 100 fills had no canonical close to mark against and the
+# panel fell back to snapshot `current_price`, the very field this store exists to
+# replace. One month of margin below the oldest fill gives those a T-n context too.
+START_DATE = "2025-12-01"
 SCHEMA_VERSION = 1
 
 # Pinned identities now come from config/instruments.json. `tencent` remains

--- a/tests/bench/perf-baseline.json
+++ b/tests/bench/perf-baseline.json
@@ -4,22 +4,24 @@
   "workspace": "/root/.openclaw/workspace",
   "data": {
     "trades": 100,
-    "snapshotFiles": 69,
-    "snapshotBytes": 3724176
+    "barFiles": 28,
+    "barBytes": 839537,
+    "tickersRead": 21,
+    "note": "#717 之前这里是 snapshotFiles:69 / snapshotBytes:3724176 —— 价格源换成 memory/bars 后,只读实际成交过的 21 个 ticker,不再全量解析 68 个组合快照。"
   },
   "node": {
     "readTracesTotalMs": {
-      "avg": 103.2,
-      "min": 85.3,
-      "max": 138.8
+      "avg": 49.9,
+      "min": 31.5,
+      "max": 85.0
     },
-    "snapshotScanMs": {
-      "avg": 66.1,
-      "min": 56.0,
-      "max": 74.6
+    "barCloseReadMs": {
+      "avg": 10.0,
+      "min": 5.8,
+      "max": 27.6
     },
-    "serializedBytes": 46528,
-    "note": "每次切到 Decision Mind tab,host 都走一遍 readTraces;快照扫描占约 64%。Phase 1 host 侧缓存命中后应降至 ~0。"
+    "serializedBytes": 49659,
+    "note": "#717 换价格源后:readTraces 103.2ms → 49.9ms,价格读取 66.1ms(快照全扫)→ 10.0ms(按 ticker 读 bar)。缓存命中仍是 µs。"
   },
   "browser": {
     "measuredBuild": "#707 版 client.js(默认折叠 3 组)同步到 live 副本 + dsh 重启后",

--- a/tests/bench/read_traces.mjs
+++ b/tests/bench/read_traces.mjs
@@ -6,18 +6,21 @@
  *   node tests/bench/read_traces.mjs [workspace] [runs]
  *
  * 默认 workspace 取 $CLAWOCK_WORKSPACE 或 cwd,默认 5 次。输出 JSON 指标:
- * 总耗时 / 快照扫描耗时(独立测 readSnapshotPrices)/ 快照文件数、字节数 /
+ * 总耗时 / 收盘价读取耗时(独立测 readBarCloses)/ bar 文件数、字节数 /
  * 结果序列化字节数。基线对比文件见同目录 perf-baseline.json。
  *
  * 这是「归因闸」(plan #702 v2 Phase 0.5)的 node 侧脚本:每次切到 Decision
- * Mind tab,host 都走一遍 readTraces;快照扫描是其中最大的可重复成本。
- * Phase 1 加 host 侧缓存后,本脚本承担「命中路径不再重扫」的回归断言。
+ * Mind tab,host 都走一遍 readTraces。Phase 1 加了 host 侧缓存,本脚本承担
+ * 「命中路径不再重扫」的回归断言。
+ *
+ * #717 之后价格源从 memory/snapshots/(全量解析 68 个组合快照)换成
+ * memory/bars/<ticker>.json(只读实际成交过的 ticker),所以这里量的也换了。
  */
 import { performance } from 'node:perf_hooks'
 import { readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { readTraces, readSnapshotPrices } from '../../examples/dsh/plugin/lib/ledger.js'
+import { readTraces, readPortfolio, readBarCloses } from '../../examples/dsh/plugin/lib/ledger.js'
 
 const workspace = process.argv[2] || process.env.CLAWOCK_WORKSPACE || process.cwd()
 const runs = Math.max(1, Number(process.argv[3] || 5))
@@ -38,38 +41,41 @@ function stats(list) {
   }
 }
 
-// 快照目录静态规模(不解析内容)
-const snapDir = join(workspace, 'memory', 'snapshots')
-let snapFiles = 0
-let snapBytes = 0
+// bar 目录静态规模(不解析内容)
+const barDir = join(workspace, 'memory', 'bars')
+let barFiles = 0
+let barBytes = 0
 try {
-  for (const f of readdirSync(snapDir)) {
-    snapFiles += 1
-    snapBytes += statSync(join(snapDir, f)).size
+  for (const f of readdirSync(barDir)) {
+    barFiles += 1
+    barBytes += statSync(join(barDir, f)).size
   }
 } catch {
-  /* 无快照目录 = 0 */
+  /* 无 bars 目录 = 0 */
 }
+
+// 实际会被读到的 ticker 集合 —— readBarCloses 只读这些,不是整个目录
+const tradedTickers = readPortfolio(workspace).trades.map((t) => t.ticker)
 
 // 预热(避开首次文件系统缓存冷启动)
 readTraces(workspace)
-readSnapshotPrices(workspace)
+readBarCloses(workspace, tradedTickers)
 
 const totalMs = []
-const snapshotMs = []
+const closesMs = []
 let serializedBytes = 0
 for (let i = 0; i < runs; i++) {
   const t = time(() => readTraces(workspace))
   totalMs.push(t.ms)
   serializedBytes = JSON.stringify(t.value).length
-  snapshotMs.push(time(() => readSnapshotPrices(workspace)).ms)
+  closesMs.push(time(() => readBarCloses(workspace, tradedTickers)).ms)
 }
 
 console.log(JSON.stringify({
   workspace,
   runs,
-  snapshots: { files: snapFiles, bytes: snapBytes },
+  bars: { files: barFiles, bytes: barBytes, tickersRead: new Set(tradedTickers).size },
   readTracesTotalMs: stats(totalMs),
-  snapshotScanMs: stats(snapshotMs),
+  barCloseReadMs: stats(closesMs),
   serializedBytes,
 }, null, 2))

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -652,47 +652,54 @@ test("client: stylesheet keeps the dark-theme and tone contract (#704/#685 regre
 test("readTraces: a close outside the T+1 window is not a T+1 verdict (#710)", async () => {
   const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-t1-"));
-  const snaps = path.join(root, "memory", "snapshots");
-  fs.mkdirSync(snaps, { recursive: true });
+  const bars = path.join(root, "memory", "bars");
+  fs.mkdirSync(bars, { recursive: true });
   const desk = (tradeDate) => fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({
     portfolios: { hk_stocks: { currency: "HKD", holdings: [
       { ticker: "00700", shares: 10, current_price: 100,
         trades: [{ date: tradeDate, action: "buy", shares: 10, price: 100 }] },
     ] } },
   }));
-  const snapshot = (date, price) => fs.writeFileSync(
-    path.join(snaps, `${date}.json`),
-    JSON.stringify({ portfolios: { hk: { holdings: [{ ticker: "00700", current_price: price }] } } }),
-  );
+  // Closes come from the canonical bar store, not from portfolio snapshots
+  // (#717): one file per ticker, keyed by exchange session.
+  const closes = {};
+  const close = (date, price) => {
+    closes[date] = { open: price, high: price, low: price, close: price };
+    fs.writeFileSync(path.join(bars, "00700.json"), JSON.stringify({ bars: closes }));
+  };
+  const dropClose = (date) => {
+    delete closes[date];
+    fs.writeFileSync(path.join(bars, "00700.json"), JSON.stringify({ bars: closes }));
+  };
   const t1Of = () => ledger.readTraces(root).trades[0].t1;
   try {
     // Next calendar day — the plain T+1 case.
     desk("2026-08-10");
-    snapshot("2026-08-11", 110);
+    close("2026-08-11", 110);
     assert.ok(t1Of(), "an adjacent close is a T+1 verdict");
     assert.equal(t1Of().delta, 10);
 
     // Friday fill settling against Monday: 3 days, still T+1.
-    fs.rmSync(path.join(snaps, "2026-08-11.json"));
+    dropClose("2026-08-11");
     desk("2026-08-07");
-    snapshot("2026-08-10", 110);
+    close("2026-08-10", 110);
     assert.ok(t1Of(), "a weekend gap is still T+1 (Fri fill → Mon close)");
 
     // The regression this guards: the only close we own is months later. It
     // used to be returned and rendered under a literal "T+1" label — on live
     // data that reached +144 days for fills predating the snapshot series.
-    fs.rmSync(path.join(snaps, "2026-08-10.json"));
+    dropClose("2026-08-10");
     desk("2026-03-02");
-    snapshot("2026-08-10", 110);
+    close("2026-08-10", 110);
     assert.equal(t1Of(), null, "a close +161 days out must not be a T+1 verdict (#710)");
 
     // And the boundary itself: 4 days in, 5 days out.
-    fs.rmSync(path.join(snaps, "2026-08-10.json"));
+    dropClose("2026-08-10");
     desk("2026-08-10");
-    snapshot("2026-08-14", 110);
+    close("2026-08-14", 110);
     assert.ok(t1Of(), "4 calendar days is inside the window");
-    fs.rmSync(path.join(snaps, "2026-08-14.json"));
-    snapshot("2026-08-15", 110);
+    dropClose("2026-08-14");
+    close("2026-08-15", 110);
     assert.equal(t1Of(), null, "5 calendar days is outside the window");
 
     // dayGap must be real calendar arithmetic, not the ordering key: the
@@ -705,41 +712,93 @@ test("readTraces: a close outside the T+1 window is not a T+1 verdict (#710)", a
   }
 });
 
+test("readBarCloses: T+1 marks against the canonical bar store, never snapshots (#717)", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-bars-"));
+  fs.mkdirSync(path.join(root, "memory", "bars"), { recursive: true });
+  fs.mkdirSync(path.join(root, "memory", "snapshots"), { recursive: true });
+  try {
+    fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({
+      portfolios: { us_stocks: { currency: "USD", holdings: [
+        { ticker: "NVDA", shares: 10, current_price: 213,
+          trades: [{ date: "2026-08-10", action: "buy", shares: 10, price: 200 }] },
+      ] } },
+    }));
+    // The snapshot says one thing (a stale carried-forward 213 — the real
+    // shape of the bug: NVDA sat frozen at 213 for five sessions), the
+    // canonical bar says another. The view must read the bar.
+    fs.writeFileSync(path.join(root, "memory", "snapshots", "2026-08-11.json"), JSON.stringify({
+      portfolios: { us: { holdings: [{ ticker: "NVDA", current_price: 213 }] } },
+    }));
+    fs.writeFileSync(path.join(root, "memory", "bars", "NVDA.json"), JSON.stringify({
+      bars: { "2026-08-11": { open: 219, high: 226, low: 218, close: 220.61 } },
+    }));
+
+    const t1 = ledger.readTraces(root).trades[0].t1;
+    assert.ok(t1, "a bar close inside the window is a T+1 verdict");
+    assert.equal(t1.price, 220.61, "the T+1 price is the canonical bar close, not the snapshot quote");
+    assert.equal(t1.delta, 10.31, "delta is marked against the bar close");
+
+    // Only `close` counts — high/low get revised by the provider and are not
+    // what a T+1 mark settles against (all 19 conflicts seen on the 2026-08-17
+    // backfill were high/low, zero were close).
+    fs.writeFileSync(path.join(root, "memory", "bars", "NVDA.json"), JSON.stringify({
+      bars: { "2026-08-11": { open: 219, high: 999, low: 1, close: 220.61 } },
+    }));
+    assert.equal(ledger.readTraces(root).trades[0].t1.delta, 10.31, "a high/low revision must not move the T+1 mark");
+
+    // No bar file for the ticker = no verdict. It must not fall back to the
+    // snapshot that is sitting right there.
+    fs.rmSync(path.join(root, "memory", "bars", "NVDA.json"));
+    assert.equal(ledger.readTraces(root).trades[0].t1, null,
+      "without a canonical bar there is no T+1 — never a snapshot fallback");
+
+    // The ticker is a path component; it must be constrained before the join.
+    const escaped = ledger.readBarCloses(root, ["../../../etc/passwd", "NVDA"]);
+    assert.deepEqual(Object.keys(escaped), [], "a traversal-shaped ticker reads nothing");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("freshness: signature moves on each of the three data sources", async () => {
   const freshness = await import(pathToFileURL(path.join(PLUGIN, "lib", "freshness.js")).href);
   const root = makeDesk();
-  fs.mkdirSync(path.join(root, "memory", "snapshots"), { recursive: true });
+  const barsDir = path.join(root, "memory", "bars");
+  fs.mkdirSync(barsDir, { recursive: true });
   try {
     const before = freshness.workspaceSignature(root);
     assert.ok(before.length > 0);
-    assert.equal(before.split("|").length, 3, "shape: portfolio stat | latest snapshot | decisions stat");
-    assert.equal(before.split("|")[1], "none", "no snapshots yet → the snapshot term is 'none'");
+    assert.equal(before.split("|").length, 3, "shape: portfolio stat | bars digest | decisions stat");
+    assert.equal(before.split("|")[1], "none", "no bar files yet → the bars term is 'none'");
 
     // portfolio.json 变化 → 签名变(内容长度不同,size 兜底 mtime 同刻度)
     fs.writeFileSync(path.join(root, "portfolio.json"), JSON.stringify({ last_updated: "changed" }));
     const afterPortfolio = freshness.workspaceSignature(root);
     assert.notEqual(afterPortfolio, before, "portfolio.json change must move the signature");
 
-    // 新快照落盘(T+1 数据源)→ 签名变——这就是 mtime-only 方案管不住的分支
-    fs.writeFileSync(path.join(root, "memory", "snapshots", "2026-08-17.json"), "{}");
-    const afterSnapshot = freshness.workspaceSignature(root);
-    assert.notEqual(afterSnapshot, afterPortfolio, "a NEW snapshot file must move the signature");
+    // 新 ticker 的 bar 文件落盘(T+1 数据源)→ 签名变
+    const barPath = path.join(barsDir, "00700.json");
+    fs.writeFileSync(barPath, JSON.stringify({ bars: { "2026-08-14": { close: 100 } } }));
+    const afterBars = freshness.workspaceSignature(root);
+    assert.notEqual(afterBars, afterPortfolio, "a NEW bar file must move the signature");
 
-    // #711:改写一个【已存在】的快照(文件名不变)也必须让签名变——
-    // readSnapshotPrices 会解析每一个快照,所以签名必须覆盖全部内容而不是
-    // 只看最新文件名。这一条在「只取最新文件名」的旧实现下是红的。
-    const snapPath = path.join(root, "memory", "snapshots", "2026-08-17.json");
+    // #711:改写一个【已存在】的 bar 文件(文件名不变)也必须让签名变。
+    // 这是两条真实路径:每日写入把新收盘的 session 追加进每个 ticker 的文件,
+    // `--repair` 就地修订一根旧 bar。任何只看文件名的签名都会漏掉这两种。
     const beforeRewrite = freshness.workspaceSignature(root);
-    fs.writeFileSync(snapPath, JSON.stringify({ portfolios: { hk: { holdings: [{ ticker: "00700", current_price: 999 }] } } }));
+    fs.writeFileSync(barPath, JSON.stringify({
+      bars: { "2026-08-14": { close: 100 }, "2026-08-17": { close: 111 } },
+    }));
     assert.notEqual(
       freshness.workspaceSignature(root), beforeRewrite,
-      "rewriting an EXISTING snapshot must move the signature (#711)",
+      "appending a session to an EXISTING bar file must move the signature (#711)",
     );
 
     // decisions.jsonl 变化(软配对源)→ 签名变
+    const beforeLedger = freshness.workspaceSignature(root);
     fs.writeFileSync(path.join(root, "memory", "decisions.jsonl"), JSON.stringify({ decision_id: "x" }) + "\n");
-    const afterLedger = freshness.workspaceSignature(root);
-    assert.notEqual(afterLedger, afterSnapshot, "decisions.jsonl change must move the signature");
+    assert.notEqual(freshness.workspaceSignature(root), beforeLedger, "decisions.jsonl change must move the signature");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/test_screenshot_refresh_workflow_contract.py
+++ b/tests/test_screenshot_refresh_workflow_contract.py
@@ -63,3 +63,46 @@ def test_gif_is_validated_only_on_manual_dispatch_before_publish():
     validator_block = _step_block(validate)
     assert "if: github.event_name == 'workflow_dispatch'" in validator_block
     assert_validator_step(WORKFLOW, validate, 'gif')
+
+
+def _refresh_module():
+    """Load ops/growth/refresh_readme_metrics.py without installing it."""
+    import importlib.util
+    from pathlib import Path
+    path = Path(__file__).resolve().parents[1] / 'ops' / 'growth' / 'refresh_readme_metrics.py'
+    spec = importlib.util.spec_from_file_location('refresh_readme_metrics', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_earliest_stamp_accepts_decision_mind_conversation_rows():
+    """A conversation row carries `decided_at`, never `created_at` (#718).
+
+    `memory/decisions.jsonl` holds two row shapes. Decision Mind writes
+    `schema_version: 0, source: "conversation"` rows stamped with `decided_at`.
+    The metrics refresh used a bare `r["created_at"]`, so the first such row
+    (2026-08-16) turned the nightly README workflow red with `KeyError` and
+    kept it red. Reverting to a bare subscript must fail this test.
+    """
+    earliest = _refresh_module()._earliest_stamp
+    plan_row = {'created_at': '2026-05-17T08:00:00+08:00'}
+    conversation_row = {
+        'schema_version': 0, 'source': 'conversation',
+        'decided_at': '2026-08-16T14:30:50+08:00',
+    }
+
+    # The shape that broke it, alone and mixed in.
+    assert earliest([conversation_row]) == '2026-08-16T14:30:50+08:00'
+    assert earliest([plan_row, conversation_row]) == '2026-05-17T08:00:00+08:00'
+    assert earliest([conversation_row, plan_row]) == '2026-05-17T08:00:00+08:00'
+
+    # A future row shape with neither stamp degrades the metric, never the run.
+    assert earliest([{'decision_id': 'x'}, plan_row]) == '2026-05-17T08:00:00+08:00'
+
+
+def test_earliest_stamp_is_explicit_when_no_row_has_a_stamp():
+    """An empty result must raise, not return '' for datetime.fromisoformat."""
+    import pytest
+    with pytest.raises(ValueError):
+        _refresh_module()._earliest_stamp([{'decision_id': 'x'}])


### PR DESCRIPTION
接 #716 的续作。两条独立的线,都是审计里发现的:T+1 的**价格源**(#717,kcn 定调「先补 bars 覆盖再切」),和 README workflow 每晚必红(#718)。

## #717 — T+1 marked against a price the system itself disowned

#710 修的是 T+1 的横轴(时间窗)。纵轴一直是错的。

面板读 `memory/snapshots/*.json` 的 `current_price`。`bars.py` 自己的注释量过这个字段:00100 的 15 次里 **7 次是前收、3 次是当日收盘、5 次是盘中价**;清仓后还会被结转——NVDA 连续 5 个 session 冻在 213,真实收盘是 222.32 / 220.61 / 223.47 / 219.51 / 215.33。

Python 结算侧早就为此迁到 `memory/bars/`,这个视图没跟上。实测 **82% 对不上官方收盘,10 个结论直接翻转**:

```
SPCH 2026-06-15 sell: 面板  0%    -> 官方 +24.59%   大卖飞被显示成持平
SPCH 2026-07-13 buy : 面板 +2.6%  -> 官方  -4.9%    亏损被显示成绿色
ROBN 2026-07-08 sell: 面板 +0.41% -> 官方    +6%
```

### 先补覆盖

`START_DATE` 2026-05-01 → **2025-12-01**。旧下限只够 decision ledger(始于 2026-05-17),但这个视图结算的是**成交**,而成交最早到 2025-12-23 —— 100 笔里 51 笔根本没有官方收盘可对。

backfill:**2664 根新增、0 根修改**(merge 不可变,纯追加)。

### 再切换

`readSnapshotPrices` → `readBarCloses(workspace, tickers)`:按 ticker 读文件,不再全量解析 68 个组合快照。ticker 是路径组件,过 `TICKER_PATTERN` 才 join(同 `scan.ts` 的 `runIdOf` 边界)。

### 结果

| | 切换前 | 切换后 |
|---|---|---|
| T+1 判定 | 45 / 100 | **99 / 100** |
| 间隔分布 | {1:33, 2:4, 3:7, 4:1} | {1:**79**, 2:5, 3:12, 4:3} |
| 卖飞/卖对 | 5 / 4 | **19 / 19** |
| 价格核对 | — | **99/99 等于 bar close** |
| `readTraces` | 103.2ms | **49.9ms** |
| 价格读取 | 66.1ms(全扫快照) | **10.0ms** |

补覆盖之后,「少而准 vs 多而错」的取舍消失了 —— 样本反而更多,而且准,还更快。

`freshness` 的 signature 跟着从 snapshots 换成 bars:两条真实的原地重写路径(每日追加新 session、`--repair` 修订旧 bar)都不移动文件名,#711 的判据同样适用。

### backfill 的 19 个冲突

全部只动 `high`/`low`,**close 零差异**,因此不影响 T+1。按模块契约未自动覆盖(需 `--repair` 且要给理由)。它们影响的是 `price_above`/`price_below` 触发判定,属于另一条线,留待单独判定 —— 我没有替它做决定。

## #718 — README Refresh 每晚必红

```
refresh_readme_metrics: error: KeyError: 'created_at'
```

`refresh_readme_metrics.py:71` 用了 `min(r["created_at"] for r in rows)` 裸下标。Decision Mind 的对话行(`schema_version: 0` / `source: conversation`)带的是 `decided_at`,没有 `created_at`。641 行里正好 1 行(08-16 那条)触发,此后每晚必红,README 的截图和数字都停在 08-16 之前。

仓库里其他读这个字段的地方**全部**用 `.get(...)`,只有这一处是裸下标。

教训:账本加新行类型不只是「写入方 + 校验方两处」(memory 里的既有结论),还有**第三类 —— 下游读账本的消费者**。

## 构建可复现性(顺带修的)

`lib/client.js` 把绝对构建路径写进了 `//#region` 注释,换个目录构建就产生不同的提交产物(同一 commit 换 worktree 构建出 17 行纯路径 churn)。committed `lib/` 是要被 review 的,它必须只是 src 的函数,否则「lib/ 是否等于 src 的构建」这个问题无法回答。已在 `build.mjs` 归一化。

**实证**:把源码复制到一个完全无关的目录重新构建,6 个产物逐字节相同。

`package-lock.json` 的 version 补到 0.1.6(#716 的 bump 漏了锁文件)。

## 红绿

每条都反向验过:

```
退回读快照       -> #717 断言红:the T+1 price is the canonical bar close, not the snapshot quote
去掉 T+1 窗口    -> #710 断言红:a close +161 days out must not be a T+1 verdict
签名只看文件名    -> #711 断言红:appending a session to an EXISTING bar file must move the signature
退回裸下标       -> #718 断言红:KeyError: 'created_at'
```

新增的 #717 测试还钉住两件事:high/low 被修订时 T+1 不能动(`close` 才算数),以及没有 bar 文件时**必须**返回 null 而不是回落到旁边那个快照。

## 测试

```
decision_studio_plugin.spec.js              14/14
dsh_plugin_package_contract.mjs              5/5
test_screenshot_refresh_workflow_contract.py 5/5
构建可复现(跨目录逐字节相同)
```

## 数据改动

`memory/bars/` +21276 行 / **-0 行**,2 个新 ticker 文件。纯追加,没有删改任何既有 bar。
