### PR TITLE
P0 hotfix: assign_episode_ids 跳过 mind 账本行,别再把已生成的简报扔掉 (#720)

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -268,6 +268,18 @@ def assign_episode_ids(decisions: list[dict]) -> list[dict]:
     ordered = sorted(enumerate(decisions), key=lambda x: (x[1].get("plan_date", ""), x[0]))
     state: dict[tuple[str, str, str], dict] = {}
     for _, d in ordered:
+        # Mind-ledger rows (schema_version 0) are the deliberate second row type
+        # `validate_decision` routes away below: they carry mind/emotion instead
+        # of the plan-decision fields, so they have no plan_date and no episode
+        # semantics — a reaffirmation window over conversation records is not a
+        # thing. `normalize_authored_plan` feeds the *whole* ledger through here,
+        # so the first such row (2026-08-16) made `d["plan_date"]` raise KeyError
+        # and took down every brief-fallback run: the LLM produced the brief
+        # (103932 in / 22991 out) and then the write-back threw it away.
+        # The sort key above already tolerates the missing field; this line was
+        # the one that did not.
+        if d.get("schema_version") == 0 or not d.get("plan_date"):
+            continue
         key = (d.get("ticker", ""), d.get("strategy_id", "legacy_unknown"), d.get("action"))
         cur_date = datetime.strptime(d["plan_date"], "%Y-%m-%d").date()
         if d.get("episode_id"):

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -854,3 +854,44 @@ class EmptyCalibrationPopulation(unittest.TestCase):
         unsettled["evaluation"] = {}
 
         self.assertIsNone(dv2.compute_metrics([unsettled])["brier"])
+
+
+def test_assign_episode_ids_skips_mind_ledger_rows():
+    """Mind rows carry no plan_date and must not reach the episode keying (#720).
+
+    `memory/decisions.jsonl` holds two row types. Decision Mind writes
+    `schema_version: 0` rows with mind/emotion instead of the plan-decision
+    fields — `validate_decision` already routes them to their own validator.
+    `assign_episode_ids` did not: it subscripted `d["plan_date"]` directly, and
+    `normalize_authored_plan` feeds it the *whole* ledger. The first mind row
+    (2026-08-16) therefore made every brief-fallback run die *after* the LLM
+    had already produced the brief, throwing the result away.
+
+    Reverting to the bare subscript must fail this test.
+    """
+    from clawock.decision.ledger import assign_episode_ids
+
+    mind = {
+        "schema_version": 0, "source": "conversation",
+        "decision_id": "dec-conversation-x",
+        "decided_at": "2026-08-16T14:30:50+08:00",
+        "subject": {"ticker": "00100"},
+    }
+    plan_a = {"decision_id": "d1", "plan_date": "2026-08-10", "ticker": "00100",
+              "strategy_id": "core", "action": "hold"}
+    plan_b = {"decision_id": "d2", "plan_date": "2026-08-12", "ticker": "00100",
+              "strategy_id": "core", "action": "hold"}
+
+    out = assign_episode_ids([plan_a, mind, plan_b])
+
+    # It must not raise, the mind row must stay untouched, and the plan rows
+    # must still group exactly as they did before the mind row existed.
+    assert "episode_id" not in mind, "a mind row has no episode semantics"
+    assert plan_a["episode_id"], "plan rows still get an episode id"
+    assert plan_a["episode_id"] == plan_b["episode_id"], "a 2-day gap is one episode"
+    assert out is not None
+
+    # A plan row missing plan_date degrades (no episode) rather than crashing.
+    broken = {"decision_id": "d3", "ticker": "00100", "strategy_id": "core", "action": "hold"}
+    assign_episode_ids([broken])
+    assert "episode_id" not in broken


### PR DESCRIPTION
**P0 热修**:`brief-fallback` 在这个 bug 存在期间**永远不可能成功** —— 每次只是白烧一次完整 LLM 调用然后崩掉。

## 今天怎么暴露的

盘前深度简报 08:03 / 08:33 / 09:11 三次全败(provider 瞬时故障)。09:27 触发 GHA 兜底,日志:

```
minimax: 103932 in / 22991 out (stop=end_turn)     <- 简报已经写出来了
  File ".../src/clawock/automation/brief_fallback.py", line 322, in main
  File ".../src/clawock/decision/ledger.py", line 423, in normalize_authored_plan
  File ".../src/clawock/decision/ledger.py", line 272, in assign_episode_ids
KeyError: 'plan_date'
```

**LLM 成功了,22991 个 output token 的简报生成完毕,然后写回账本时崩掉,整篇被丢弃。**

## 根因(和 #718 同族)

`memory/decisions.jsonl` 有两种行。Decision Mind 的 `schema_version: 0` 行带 mind/emotion,**没有 `plan_date`** —— 就在同一个文件里,`validate_decision` 明确写着这一点并专门路由走:

> Decision-mind records are a deliberate second ledger row type: they carry mind/emotion instead of the plan-decision fields below

`assign_episode_ids` 没跟上。而且它**自己内部就自相矛盾**:

```python
ordered = sorted(..., key=lambda x: (x[1].get("plan_date", ""), x[0]))   # 268 行:容错
...
cur_date = datetime.strptime(d["plan_date"], "%Y-%m-%d").date()          # 272 行:裸下标
```

`normalize_authored_plan` 把**整个账本**(`load_decisions()` 全量)喂进来,所以 08-16 第一条对话记录落盘后必崩。

## 修法

mind 行本来就没有 episode 语义 —— 对话记录之间不存在「重申窗口」这回事。跳过是**正确语义**,不是绕过。plan 行缺 `plan_date` 时同样跳过而非崩溃(#718 里同样的降级取向:新行形状应该降级指标,不该拖垮流程)。

## 实证

641 行全量跑通:

```
mind 行 1 个  -> episode_id 0 个   ✓
plan 行 640 个 -> episode_id 640 个
既有归组零变化:199 个 episode 与修复前逐条一致 ✓
```

**红绿**:退回裸下标 → `KeyError: 'plan_date'`,测试变红;`tests/test_decision_v2.py` 59 passed。

## 这是第三处了

#718 是 `refresh_readme_metrics.py`,这是 `assign_episode_ids`。memory 里对「账本加新行类型」的既有结论是「改写入方 + 校验方两处」—— 这两次证明**下游读账本的消费者是第三类**,而且当时没人扫过。合并后我会把剩下的裸下标扫一遍。
