### PR TITLE
fix(cron_runs): 以投递回执为准,别把已投递的报告显示成失败 (#721)

### DIFF
--- a/ops/host/cron_runs.py
+++ b/ops/host/cron_runs.py
@@ -83,12 +83,64 @@ def fmt_dur(ms):
     return f'{s/60:4.1f}m'
 
 
-def status_glyph(status):
+# A job's on-disk delivery receipt, by job name. `report_postflight` writes
+# `report-sent-<market>-<phase>-<date>.json` and the brief writes
+# `brief-sent-<date>.json`; both carry `sent_ok`. The crontab passes
+# --market/--phase per job, so this is the same pairing, written down once.
+RECEIPT_BY_JOB = {
+    '港股开盘报告': 'report-sent-hk-open-{date}.json',
+    '港股午盘报告': 'report-sent-hk-mid-{date}.json',
+    '港股午后快报': 'report-sent-hk-pm-{date}.json',
+    '港股收盘报告': 'report-sent-hk-close-{date}.json',
+    '美股开盘报告': 'report-sent-us-open-{date}.json',
+    '美股收盘报告': 'report-sent-us-close-{date}.json',
+    '盘前深度简报': 'brief-sent-{date}.json',
+}
+# The live desk workspace, whose memory/.tmp holds the receipts. Resolved from
+# the environment rather than from this file's location: run out of an
+# interactive worktree, `parents[2]` is the worktree and every receipt lookup
+# silently misses — the exact "looks fine, proves nothing" failure this whole
+# function exists to remove.
+import os  # noqa: E402
+WS = Path(os.environ.get('CLAWOCK_WORKSPACE') or (Path.home() / '.openclaw' / 'workspace'))
+TMP = WS / 'memory' / '.tmp'
+
+
+def delivered_receipt(job_name, ts_ms):
+    """The delivery receipt for this job on this run's date, when it exists.
+
+    A run status of `error` does not mean the desk produced nothing: openclaw
+    records `FallbackSummaryError` when its own *run-summary* LLM call fails,
+    which happens after the report has already been written and delivered.
+    On 2026-08-17 that painted 港股开盘报告 red twice while the receipt on disk
+    said `sent_ok: true, delivery_state: delivered` at 09:32:13 — kcn had the
+    report in WeChat. The receipt is the fact; the run status is an inference.
+    """
+    pattern = RECEIPT_BY_JOB.get((job_name or '').strip())
+    if not pattern or not ts_ms:
+        return None
+    date = datetime.fromtimestamp(ts_ms / 1000).strftime('%Y-%m-%d')
+    path = TMP / pattern.format(date=date)
+    try:
+        doc = json.loads(path.read_text())
+    except Exception:
+        return None
+    return doc if doc.get('sent_ok') else None
+
+
+def status_glyph(status, receipt=None):
+    # An `error` that nevertheless delivered is a summary-only failure: show it
+    # as a warning, never as a red that is indistinguishable from "no report".
+    if status == 'error' and receipt is not None:
+        return '⚠️'
     return {'ok': '✅', 'error': '🔴', 'warn': '⚠️'}.get(status, '❓')
 
 
-def summarize(entry, full=False):
+def summarize(entry, full=False, receipt=None):
     if entry.get('status') == 'error':
+        if receipt is not None:
+            note = ('已投递 %s · 仅运行摘要失败 — ' % receipt.get('delivery_state', 'delivered'))
+            return (note + (entry.get('error') or 'unknown'))[: None if full else 80]
         return ('ERR: ' + (entry.get('error') or 'unknown'))[: None if full else 80]
     s = entry.get('summary') or ''
     s = s.replace('\n', ' ⏎ ')
@@ -171,16 +223,22 @@ def main():
                 break
             out.append(ch); vw += w
         name_pad = ''.join(out) + ' ' * (14 - vw)
+        # The on-disk receipt outranks the run record: openclaw reports
+        # `delivered=None / not-requested` on a run whose summary call failed,
+        # even when postflight already delivered the report (2026-08-17).
+        receipt = delivered_receipt(jobs.get(e['_jobId'], ''), e.get('ts'))
         deliv = '—'
-        if e.get('delivered') is True:
+        if receipt is not None:
+            deliv = '✓rcpt'
+        elif e.get('delivered') is True:
             deliv = '✓   '
         elif e.get('delivered') is False:
             deliv = '✗   '
         elif e.get('deliveryStatus'):
             deliv = (e['deliveryStatus'][:4]).ljust(4)
-        print(f"{fmt_ts(e.get('ts')):<11}  {name_pad}  {status_glyph(e.get('status'))}  "
+        print(f"{fmt_ts(e.get('ts')):<11}  {name_pad}  {status_glyph(e.get('status'), receipt)}  "
               f"{e['_kind'][:4]:<4}  {fmt_dur(e.get('durationMs')):>5}  {deliv:<5}  "
-              f"{summarize(e, args.full)}")
+              f"{summarize(e, args.full, receipt)}")
     return 0
 
 

--- a/tests/test_cron_runs_delivery_truth.py
+++ b/tests/test_cron_runs_delivery_truth.py
@@ -9,7 +9,6 @@ the tool said it had failed twice.
 """
 import importlib.util
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -17,9 +16,16 @@ import pytest
 MODULE = Path(__file__).resolve().parents[1] / 'ops' / 'host' / 'cron_runs.py'
 
 
-def _load(workspace):
-    """Import cron_runs.py bound to a throwaway workspace."""
-    os.environ['CLAWOCK_WORKSPACE'] = str(workspace)
+def _load(monkeypatch, workspace):
+    """Import cron_runs.py bound to a throwaway workspace.
+
+    `monkeypatch` (not `os.environ[...] = ...`) because CLAWOCK_WORKSPACE is
+    read by the whole tree: leaking it out of this module points every later
+    test in the same pytest process at a tmp dir. That is not hypothetical —
+    the first version of this file did exactly that and turned 19 dashboard /
+    sidecar tests red on CI while passing in isolation.
+    """
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(workspace))
     spec = importlib.util.spec_from_file_location('cron_runs_under_test', MODULE)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -38,8 +44,8 @@ def _receipt(desk, name, **fields):
     (desk / 'memory' / '.tmp' / name).write_text(json.dumps(doc))
 
 
-def test_delivered_report_with_failed_summary_is_not_a_red(desk):
-    mod = _load(desk)
+def test_delivered_report_with_failed_summary_is_not_a_red(monkeypatch, desk):
+    mod = _load(monkeypatch, desk)
     _receipt(desk, 'report-sent-hk-open-2026-08-17.json')
     entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
 
@@ -49,8 +55,8 @@ def test_delivered_report_with_failed_summary_is_not_a_red(desk):
     assert '已投递' in mod.summarize(entry, receipt=receipt)
 
 
-def test_a_genuinely_undelivered_run_stays_red(desk):
-    mod = _load(desk)
+def test_a_genuinely_undelivered_run_stays_red(monkeypatch, desk):
+    mod = _load(monkeypatch, desk)
     # No receipt written: this is the real failure shape (盘前深度简报, 2026-08-17).
     entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
 
@@ -60,24 +66,24 @@ def test_a_genuinely_undelivered_run_stays_red(desk):
     assert mod.summarize(entry, receipt=receipt).startswith('ERR:')
 
 
-def test_a_receipt_that_did_not_send_is_not_treated_as_delivered(desk):
-    mod = _load(desk)
+def test_a_receipt_that_did_not_send_is_not_treated_as_delivered(monkeypatch, desk):
+    mod = _load(monkeypatch, desk)
     _receipt(desk, 'report-sent-hk-open-2026-08-17.json', sent_ok=False, delivery_state='failed')
 
     assert mod.delivered_receipt('港股开盘报告', 1786930333675) is None
     assert mod.status_glyph('error', None) == '🔴'
 
 
-def test_receipts_are_read_from_the_live_workspace_not_the_checkout(desk):
+def test_receipts_are_read_from_the_live_workspace_not_the_checkout(monkeypatch, desk):
     """Run out of an interactive worktree, a location-derived path finds nothing."""
-    mod = _load(desk)
+    mod = _load(monkeypatch, desk)
     assert mod.WS == desk, 'CLAWOCK_WORKSPACE decides where receipts are read from'
     assert mod.TMP == desk / 'memory' / '.tmp'
 
 
-def test_every_delivering_job_has_a_receipt_pattern(desk):
+def test_every_delivering_job_has_a_receipt_pattern(monkeypatch, desk):
     """A job that delivers but is missing from the map silently stays red."""
-    mod = _load(desk)
+    mod = _load(monkeypatch, desk)
     for job in ('港股开盘报告', '港股午盘报告', '港股午后快报', '港股收盘报告',
                 '美股开盘报告', '美股收盘报告', '盘前深度简报'):
         assert job in mod.RECEIPT_BY_JOB, f'{job} delivers — it needs a receipt pattern'

--- a/tests/test_cron_runs_delivery_truth.py
+++ b/tests/test_cron_runs_delivery_truth.py
@@ -1,0 +1,83 @@
+"""cron_runs.py must report what was delivered, not what the run record guessed.
+
+2026-08-17: openclaw records `FallbackSummaryError` when its own *run-summary*
+LLM call fails — which happens after postflight has already written and
+delivered the report. `cron_runs.py` printed those runs as 🔴, identical to a
+run that produced nothing, while the receipt on disk said
+`sent_ok: true, delivery_state: delivered`. The report was in kcn's WeChat and
+the tool said it had failed twice.
+"""
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+MODULE = Path(__file__).resolve().parents[1] / 'ops' / 'host' / 'cron_runs.py'
+
+
+def _load(workspace):
+    """Import cron_runs.py bound to a throwaway workspace."""
+    os.environ['CLAWOCK_WORKSPACE'] = str(workspace)
+    spec = importlib.util.spec_from_file_location('cron_runs_under_test', MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def desk(tmp_path):
+    (tmp_path / 'memory' / '.tmp').mkdir(parents=True)
+    return tmp_path
+
+
+def _receipt(desk, name, **fields):
+    doc = {'ts': 1786930333675, 'sent_ok': True, 'delivery_state': 'delivered'}
+    doc.update(fields)
+    (desk / 'memory' / '.tmp' / name).write_text(json.dumps(doc))
+
+
+def test_delivered_report_with_failed_summary_is_not_a_red(desk):
+    mod = _load(desk)
+    _receipt(desk, 'report-sent-hk-open-2026-08-17.json')
+    entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
+
+    receipt = mod.delivered_receipt('港股开盘报告', 1786930333675)
+    assert receipt is not None, 'the receipt for this job/date must be found'
+    assert mod.status_glyph('error', receipt) == '⚠️', 'a delivered report is not a red'
+    assert '已投递' in mod.summarize(entry, receipt=receipt)
+
+
+def test_a_genuinely_undelivered_run_stays_red(desk):
+    mod = _load(desk)
+    # No receipt written: this is the real failure shape (盘前深度简报, 2026-08-17).
+    entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
+
+    receipt = mod.delivered_receipt('盘前深度简报', 1786930333675)
+    assert receipt is None
+    assert mod.status_glyph('error', receipt) == '🔴', 'no receipt means no delivery — stay red'
+    assert mod.summarize(entry, receipt=receipt).startswith('ERR:')
+
+
+def test_a_receipt_that_did_not_send_is_not_treated_as_delivered(desk):
+    mod = _load(desk)
+    _receipt(desk, 'report-sent-hk-open-2026-08-17.json', sent_ok=False, delivery_state='failed')
+
+    assert mod.delivered_receipt('港股开盘报告', 1786930333675) is None
+    assert mod.status_glyph('error', None) == '🔴'
+
+
+def test_receipts_are_read_from_the_live_workspace_not_the_checkout(desk):
+    """Run out of an interactive worktree, a location-derived path finds nothing."""
+    mod = _load(desk)
+    assert mod.WS == desk, 'CLAWOCK_WORKSPACE decides where receipts are read from'
+    assert mod.TMP == desk / 'memory' / '.tmp'
+
+
+def test_every_delivering_job_has_a_receipt_pattern(desk):
+    """A job that delivers but is missing from the map silently stays red."""
+    mod = _load(desk)
+    for job in ('港股开盘报告', '港股午盘报告', '港股午后快报', '港股收盘报告',
+                '美股开盘报告', '美股收盘报告', '盘前深度简报'):
+        assert job in mod.RECEIPT_BY_JOB, f'{job} delivers — it needs a receipt pattern'


### PR DESCRIPTION
关闭 #721。

## 问题

2026-08-17 上午 `cron_runs.py` 显示 5 条 🔴,**其中 2 条是假红**。港股开盘报告实际完全成功:

```
09:30:17  report-context-hk-open-2026-08-17.json
09:31     report-prose-hk-open.md              (真分析内容)
09:32:13  report-sent-hk-open-2026-08-17.json  {"sent_ok": true, "delivery_state": "delivered"}
```

kcn 09:31 在微信收到了完整报告 —— 而工具告诉我它失败了两次。**我今天就是照着这个红下了反的结论。**

## 根因

答案就在错误类名里:`FallbackSummary**Error**`。它来自 openclaw 给这次运行**生成摘要**的 LLM 调用,不是干活那次。活干完、投递完之后,只要事后写摘要的调用挂掉,整条 run 就记成 `error`。

而且 openclaw **自己的判定是对的**:

```
openclaw cron list:
  港股开盘报告   11m ago   status=ok          ← 正确
  盘前深度简报   45m ago   status=error(15x)  ← 正确
```

是 `cron_runs.py` 把 `cron_run_logs` 里每条 run 的 error 平铺了出来,没有采纳 job 级判定。

## 修法

以**磁盘上的投递回执**为准:该档存在 `report-sent-<market>-<phase>-<date>.json` / `brief-sent-<date>.json` 且 `sent_ok=true` → 显示 `⚠️` + `✓rcpt` + 「已投递 · 仅运行摘要失败」;没有回执的仍然是 🔴。

**回执是事实,run status 是推断。**

## live 实测

```
08-17 09:48  港股开盘报告  ✅  ✓rcpt  港股开盘报告已投递 ✅ ...
08-17 09:37  港股开盘报告  ⚠️  ✓rcpt  已投递 delivered · 仅运行摘要失败 — FallbackSummaryError...
08-17 09:34  港股开盘报告  ⚠️  ✓rcpt  已投递 delivered · 仅运行摘要失败 — FallbackSummaryError...
08-17 09:11  盘前深度简报  🔴  not-   ERR: FallbackSummaryError...     <- 真红
08-17 08:33  盘前深度简报  🔴  not-   ERR: FallbackSummaryError...     <- 真红
08-17 08:03  盘前深度简报  🔴  not-   ERR: FallbackSummaryError...     <- 真红
```

原本无法区分的两类,现在一眼能分。

## 一个自己给自己挖的坑,已填

`WS` 最初写成 `Path(__file__).resolve().parents[2]`。在交互 worktree 里跑时那是 worktree 而不是 live workspace,**每次回执查找都会静默落空**,测试照样绿 —— 正是这个函数要消灭的那种「看着没事、什么也没证明」的失败。改为从 `CLAWOCK_WORKSPACE` 解析,并专门加了一条断言钉住。

## 红绿

去掉回执判定 → `test_delivered_report_with_failed_summary_is_not_a_red` 变红;5 passed。
