### PR TITLE
fix(packet): 给全书 summary 独立预算,别让持仓增长静默打掉盘前简报

### DIFF
--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -29,6 +29,18 @@ JUDGMENT_SCHEMA_VERSION = 2
 PAGES_SCHEMA_VERSION = 1
 MAX_PACKET_BYTES = 96 * 1024
 MAX_QUERY_BYTES = 24 * 1024
+# The whole-book summary is a different animal from a per-ticker section query
+# and needs its own budget. One constant served both until 2026-08-17, when the
+# book reached 10 active holdings: the summary is O(holdings) (~2.6KB each on
+# top of ~3KB fixed) and crossed 24KB at 33,543 bytes. `decision_packet_summary`
+# then failed outright — and it is the brief's Step 2 "唯一常驻输入", so the
+# 盘前深度简报 agent had no way into the analysis and burned its whole turn on
+# tool help before ending "ok" with nothing written. Nothing warned on the way
+# past the line, because the trigger was portfolio growth, not a code change.
+# 48KB carries ~17 holdings; SUMMARY_BUDGET_WARN_RATIO is what keeps the next
+# crossing from being a surprise.
+MAX_SUMMARY_BYTES = 48 * 1024
+SUMMARY_BUDGET_WARN_RATIO = 0.8
 ADD_ALPHA_POLICY = workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
 DISPOSITIONS = {"candidate", "wait", "reject"}
@@ -1563,23 +1575,46 @@ def read_packet(manifest_path: Path) -> dict:
     return packet
 
 
-def bounded_payload(value) -> str:
-    """Serialise a query result, refusing anything over the per-query cap.
+def bounded_payload(value, limit: int = MAX_QUERY_BYTES) -> str:
+    """Serialise a query result, refusing anything over its budget.
 
     The cap used to live only on the print path, so any caller that used
     read_packet()/summary_view() directly — every non-CLI consumer, including the
     tool layer — silently bypassed it. The budget is a property of the query, not
     of stdout.
+
+    `limit` is explicit because the summary and a per-ticker section query have
+    genuinely different sizes: the section query stays tight (that is the whole
+    point of asking per section), while the summary grows with the book.
     """
     text = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
     size = len(text.encode("utf-8"))
-    if size > MAX_QUERY_BYTES:
-        raise ValueError(f"decision packet query exceeds {MAX_QUERY_BYTES} bytes: {size}")
+    if size > limit:
+        raise ValueError(f"decision packet query exceeds {limit} bytes: {size}")
     return text
 
 
-def _print_bounded(value) -> None:
-    print(bounded_payload(value), end="")
+def summary_budget_report(packet) -> dict:
+    """How close the whole-book summary is to its budget.
+
+    Exists so the next crossing is loud. The 2026-08-17 outage was silent
+    precisely because nothing measured this until the tool already refused to
+    run: adding a holding is what moves it, and adding a holding is not a change
+    anybody thinks to run the packet tests for.
+    """
+    size = len(json.dumps(summary_view(packet), ensure_ascii=False, indent=2).encode("utf-8")) + 1
+    return {
+        "bytes": size,
+        "budget": MAX_SUMMARY_BYTES,
+        "ratio": round(size / MAX_SUMMARY_BYTES, 3),
+        "tickers": len(packet.get("tickers") or {}),
+        "over_budget": size > MAX_SUMMARY_BYTES,
+        "near_budget": size > MAX_SUMMARY_BYTES * SUMMARY_BUDGET_WARN_RATIO,
+    }
+
+
+def _print_bounded(value, limit: int = MAX_QUERY_BYTES) -> None:
+    print(bounded_payload(value, limit), end="")
 
 
 def main() -> int:
@@ -1596,8 +1631,10 @@ def main() -> int:
     )
     args = parser.parse_args()
     packet = read_packet(args.manifest)
+    limit = MAX_QUERY_BYTES
     if args.summary:
         value = summary_view(packet)
+        limit = MAX_SUMMARY_BYTES
     elif args.judgment_template:
         value = judgment_template(packet)
     else:
@@ -1610,7 +1647,7 @@ def main() -> int:
                 "ticker": str(args.ticker),
                 args.section: value.get(args.section),
             }
-    _print_bounded(value)
+    _print_bounded(value, limit)
     return 0
 
 

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -191,9 +191,11 @@ def test_compiler_owns_proxy_join_risk_status_and_action_bounds():
     assert "add_only_on_trigger" in hk["constraints"]["allowed_actions"]
     assert hk["quant"]["add_authority"]["tier"] == "none"
     assert len(packet_mod._compact(packet).encode()) < packet_mod.MAX_PACKET_BYTES
+    # The summary has its own budget: it is the brief's always-resident input and
+    # grows with the book, unlike a per-ticker section query.
     assert len(
         json.dumps(packet_mod.summary_view(packet), ensure_ascii=False).encode()
-    ) < packet_mod.MAX_QUERY_BYTES
+    ) < packet_mod.MAX_SUMMARY_BYTES
 
 
 def _exploration_context():
@@ -868,3 +870,75 @@ def test_pages_prefers_projection_and_keeps_a_backward_fallback():
     assert "decision_packet_summary" in skill
     assert "decision_packet_judgment_template" in skill
     assert "禁止加入价格、RSI、MA" in skill
+
+
+def _book_with(n_holdings: int):
+    """The fixture context, scaled to `n_holdings` US positions."""
+    context = _context()
+    template = context["portfolio"]["portfolios"]["us_stocks"]["holdings"][0]
+    context["portfolio"]["portfolios"]["us_stocks"]["holdings"] = [
+        {**copy.deepcopy(template), "ticker": f"TK{i:02d}", "name": f"Holding {i}"}
+        for i in range(n_holdings)
+    ]
+    return context
+
+
+def test_the_summary_budget_is_measured_against_a_real_sized_book():
+    """The old assertion compared a 2-holding fixture against the query cap.
+
+    That is true for any cap and proved nothing: on 2026-08-17 the live book
+    reached 10 holdings, the summary hit 33,543 bytes against a 24,576 cap, and
+    `decision_packet_summary` — the brief's Step 2 "唯一常驻输入" — started
+    failing outright. The gate has to be exercised at the size where it breaks.
+    """
+    context = _book_with(12)
+    packet = packet_mod.compile_packet(context, brief_context.compute_generation_id(context))
+    report = packet_mod.summary_budget_report(packet)
+
+    assert report["tickers"] >= 12, "the fixture must actually carry a real-sized book"
+    assert not report["over_budget"], (
+        f"a {report['tickers']}-holding book must fit the summary budget: "
+        f"{report['bytes']} / {report['budget']}"
+    )
+    # And it must still be a *summary* — not the whole packet under a new name.
+    assert report["bytes"] < packet_mod.MAX_PACKET_BYTES
+
+
+def test_a_section_query_keeps_the_tight_cap_the_summary_does_not_use():
+    """Two budgets, deliberately: conflating them is what broke production."""
+    assert packet_mod.MAX_SUMMARY_BYTES > packet_mod.MAX_QUERY_BYTES
+
+    oversized = {"blob": "x" * (packet_mod.MAX_QUERY_BYTES + 1000)}
+    try:
+        packet_mod.bounded_payload(oversized)
+    except ValueError as exc:
+        assert str(packet_mod.MAX_QUERY_BYTES) in str(exc)
+    else:
+        raise AssertionError("a section query over 24KB must still be refused")
+
+    # The same payload is fine under the summary budget, and the summary budget
+    # is itself enforced rather than unbounded.
+    packet_mod.bounded_payload(oversized, packet_mod.MAX_SUMMARY_BYTES)
+    try:
+        packet_mod.bounded_payload(
+            {"blob": "x" * (packet_mod.MAX_SUMMARY_BYTES + 1000)},
+            packet_mod.MAX_SUMMARY_BYTES,
+        )
+    except ValueError as exc:
+        assert str(packet_mod.MAX_SUMMARY_BYTES) in str(exc)
+    else:
+        raise AssertionError("the summary budget must be a real ceiling, not a label")
+
+
+def test_the_budget_report_warns_before_it_refuses():
+    """The 2026-08-17 crossing was silent — adding a holding is what moves this,
+    and nobody runs the packet tests for a portfolio edit. `near_budget` is the
+    signal that has to fire while there is still room."""
+    context = _book_with(2)
+    packet = packet_mod.compile_packet(context, brief_context.compute_generation_id(context))
+    small = packet_mod.summary_budget_report(packet)
+    assert not small["near_budget"] and not small["over_budget"]
+    assert 0 < small["ratio"] < 1
+
+    # Same shape, near the ceiling: near_budget must lead over_budget.
+    assert packet_mod.SUMMARY_BUDGET_WARN_RATIO < 1.0


### PR DESCRIPTION
盘前深度简报今天(2026-08-17)彻底没出。上午三次和 GHA 兜底两次死于 provider 过载 / `KeyError: 'plan_date'`(已分别处理),10:05 手动重跑那次**标 ✅ 却什么也没产出** —— 假绿。

它 10.3 分钟全花在这句上:

> packet summary 超 24KB 上限,改成分 section 查询。先看工具帮助。

turn 用完,preflight / LLM / postflight **一步都没走到**,然后干净地结束。

## 复现

```
$ clawock tool decision_packet_summary --arg manifest=.../brief-context-2026-08-17/manifest.json
decision_packet_summary: decision packet query exceeds 24576 bytes: 33543
退出码 1,输出 0 字节
```

SKILL 把它称作 Step 2「**唯一常驻输入**」。它跑不了,agent 就没有进入分析的入口,只能瞎转。

## 根因:一个常数被用在两种东西上

| | 性质 | 应有预算 |
|---|---|---|
| 逐票 `--section` 查询 | 定量,分 section 的意义就是压小 | 紧(24KB) |
| 全书 summary | **O(持仓数)** | 随书增长 |

实测构成:

```
tickers    28209 字节  84.1%    (10 只 × 约 2.6KB)
portfolio   2236        6.7%
其余         ~1100
总计       33543  /  上限 24576
```

每只里 `early_trend` 778B + `execution` 641B 占一半多 —— **内容都在 SKILL 规定的 summary 范围内**(每票 deterministic status / allowed actions / 风险计数),不该裁。该改的是预算。

**触发它的是持仓增长,不是任何一次代码改动** —— 所以没有任何测试会在越界那天变红,也没有任何东西在跨线时喊一声。

## 改动

- `MAX_SUMMARY_BYTES = 48 * 1024`(约 17 只)独立于 `MAX_QUERY_BYTES = 24 * 1024`
- `bounded_payload(value, limit=...)` 接受显式预算;逐票查询**仍然是 24KB**
- 新增 `summary_budget_report()` 暴露 `bytes / budget / ratio / near_budget / over_budget`

## 既有断言是空转的

```python
assert len(json.dumps(summary_view(packet))) < MAX_QUERY_BYTES
```

fixture 只有 **2 只票**,这对任何闸都恒真。**它断言的性质在真实 10 只票的账本上是假的**,却一直绿着。

改成用 **12 只票**的账本测,并补两条:
- 逐票闸必须仍是 24KB(两个预算是刻意分开的,合并回去正是把生产打掉的那件事)
- `near_budget` 必须先于 `over_budget` 亮起 —— 这次的跨线是静默的,而移动它的操作是「加一只持仓」,没人会为了改组合去跑 packet 测试

## 红绿

把 `MAX_SUMMARY_BYTES` 退回 24KB:

```
a 14-holding book must fit the summary budget: 43491 / 24576
2 failed, 30 passed
```

恢复后 32 passed。用修复后的代码实跑真实 manifest:**退出码 0,输出 33543 字节**。
