### PR TITLE
fix(tools): summary 工具也要用 summary 预算 —— #723 只修了 CLI 那一半

### DIFF
--- a/src/clawock/tools/context_tools.py
+++ b/src/clawock/tools/context_tools.py
@@ -45,8 +45,14 @@ class DecisionPacketSummary(BaseTool):
 
     def execute(self, workspace, *, manifest: str) -> str:
         packet = brief_decision_packet.read_packet(_manifest(workspace, manifest))
+        # The summary budget, not the per-query one. #723 raised the ceiling but
+        # only on packet.py's own CLI path; this tool is what the brief agent
+        # actually calls, and it kept the 24KB default — so the fix was live in
+        # the source and still dead in production, which is the exact shape the
+        # inert-fix rule exists for. The test below pins this call site.
         return brief_decision_packet.bounded_payload(
-            brief_decision_packet.summary_view(packet)
+            brief_decision_packet.summary_view(packet),
+            brief_decision_packet.MAX_SUMMARY_BYTES,
         )
 
 

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -192,3 +192,51 @@ def test_a_narrowed_query_keeps_the_generation_pin(tmp_path, monkeypatch):
         tmp_path, manifest=str(manifest), ticker="00100", section="technical"))
 
     assert payload["_meta"]["generation_id"] == "gen-abc"
+
+
+def test_the_summary_tool_uses_the_summary_budget_not_the_query_budget(tmp_path, monkeypatch):
+    """The brief agent calls this tool, not packet.py's CLI.
+
+    #723 gave the whole-book summary its own 48KB budget, but only on the CLI
+    path in packet.py. `DecisionPacketSummary.execute` kept `bounded_payload`'s
+    24KB default, so the live `clawock tool decision_packet_summary` still died
+    with `exceeds 24576 bytes: 33543` on a merged fix — right in source, dead in
+    production. This pins the call site that actually matters.
+    """
+    seen = {}
+
+    def bounded_payload(value, limit=context_tools.brief_decision_packet.MAX_QUERY_BYTES):
+        seen["limit"] = limit
+        return json.dumps(value, ensure_ascii=False)
+
+    monkeypatch.setattr(context_tools.brief_decision_packet, "bounded_payload", bounded_payload)
+    monkeypatch.setattr(context_tools.brief_decision_packet, "read_packet", lambda path: {"tickers": {}})
+    monkeypatch.setattr(context_tools.brief_decision_packet, "summary_view", lambda packet: {"ok": True})
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+    context_tools.DecisionPacketSummary().execute(tmp_path, manifest=str(manifest))
+
+    assert seen["limit"] == context_tools.brief_decision_packet.MAX_SUMMARY_BYTES, (
+        "the summary must be serialised against MAX_SUMMARY_BYTES; the per-query "
+        "default is what took the 盘前简报 down on 2026-08-17"
+    )
+
+
+def test_a_real_sized_summary_survives_the_tool_layer(tmp_path, monkeypatch):
+    """End-to-end through the tool, at the size that actually broke: a summary
+    over the 24KB query cap must come back rather than raise."""
+    big = {"tickers": [{"ticker": f"TK{i:02d}", "blob": "x" * 2_600} for i in range(11)]}
+
+    monkeypatch.setattr(context_tools.brief_decision_packet, "read_packet", lambda path: {"tickers": {}})
+    monkeypatch.setattr(context_tools.brief_decision_packet, "summary_view", lambda packet: big)
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+
+    out = context_tools.DecisionPacketSummary().execute(tmp_path, manifest=str(manifest))
+    size = len(out.encode())
+    assert size > context_tools.brief_decision_packet.MAX_QUERY_BYTES, (
+        "the fixture has to be past the old cap or this proves nothing"
+    )
+    assert size < context_tools.brief_decision_packet.MAX_SUMMARY_BYTES


### PR DESCRIPTION
#723 只修了一半。合并后在 live 实测:

```
$ clawock tool decision_packet_summary ...
decision_packet_summary: decision packet query exceeds 24576 bytes: 33543
退出码 1
```

源码里 `MAX_SUMMARY_BYTES` 出现 6 次,**生产里照样死**。

## 为什么

#723 改的是 `packet.py` 自己的 CLI(`--summary`)路径。而**盘前简报 agent 调的是 `clawock tool decision_packet_summary`** —— 它走 `tools/context_tools.py` 的 `DecisionPacketSummary.execute`,那里 `bounded_payload` 仍然用 24KB 默认值。

「源码里对、生产里死」,正是 `clawock-inert-fixes` 那条规则存在的原因 —— 我自己在同一天犯了一次,而且是在修另一个同类问题的过程中。

## 改动

`DecisionPacketSummary.execute` 显式传 `MAX_SUMMARY_BYTES`。逐票查询那两处(`DecisionPacketQuery`)保持 24KB **不动** —— 两个预算刻意分开。

## 测试钉的是工具层,不是 CLI

这是关键:#723 的测试全部走 `packet.py`,所以它们在 live 挂掉时依然全绿。新增两条直接打 `DecisionPacketSummary.execute`:

1. 断言 summary 必须用 `MAX_SUMMARY_BYTES` 序列化(记录实际传入的 limit)
2. 走完整工具路径喂一个 11 只票、越过旧 24KB 闸的 summary,要求它**返回**而不是抛 —— 并断言 fixture 确实越过了旧闸,否则「这条测试什么也没证明」

## 红绿

把 `execute` 退回默认闸(**就是合并 #723 之后 live 的真实状态**):

```
2 failed, 7 passed
  the summary must be serialised against MAX_SUMMARY_BYTES; the per-query default is what took the 盘前简报 down
```

恢复后 9 passed。
