### PR TITLE
fix(cron_runs): 回执要匹配到那次运行 —— #722 把假红换成了假绿

### DIFF
--- a/ops/host/cron_runs.py
+++ b/ops/host/cron_runs.py
@@ -106,8 +106,14 @@ WS = Path(os.environ.get('CLAWOCK_WORKSPACE') or (Path.home() / '.openclaw' / 'w
 TMP = WS / 'memory' / '.tmp'
 
 
-def delivered_receipt(job_name, ts_ms):
-    """The delivery receipt for this job on this run's date, when it exists.
+# How far outside a run's own window a receipt may still belong to it. The
+# receipt is written by postflight inside the run, so this only absorbs clock
+# jitter between the run record and the file mtime.
+RECEIPT_MATCH_SLACK_MS = 90 * 1000
+
+
+def delivered_receipt(job_name, ts_ms, duration_ms=None):
+    """The delivery receipt produced *by this run*, when there is one.
 
     A run status of `error` does not mean the desk produced nothing: openclaw
     records `FallbackSummaryError` when its own *run-summary* LLM call fails,
@@ -115,6 +121,17 @@ def delivered_receipt(job_name, ts_ms):
     On 2026-08-17 that painted 港股开盘报告 red twice while the receipt on disk
     said `sent_ok: true, delivery_state: delivered` at 09:32:13 — kcn had the
     report in WeChat. The receipt is the fact; the run status is an inference.
+
+    The receipt must be matched to the *run*, not merely to the date. Matching
+    on job+date alone turned the fix into its own mirror image: once the brief
+    finally delivered at 10:39, the three genuinely-dead 08:03 / 08:33 / 09:11
+    runs — and the 10:15 run that produced nothing at all — all started showing
+    "已投递", because a receipt existed somewhere on that date. Trading a false
+    red for a false green is not a fix.
+
+    A run's window is [ts - duration, ts]; `ts` is when the run was recorded,
+    which is its end. Only a receipt stamped inside that window (plus a little
+    slack) was produced by it.
     """
     pattern = RECEIPT_BY_JOB.get((job_name or '').strip())
     if not pattern or not ts_ms:
@@ -125,7 +142,15 @@ def delivered_receipt(job_name, ts_ms):
         doc = json.loads(path.read_text())
     except Exception:
         return None
-    return doc if doc.get('sent_ok') else None
+    if not doc.get('sent_ok'):
+        return None
+    receipt_ts = doc.get('ts')
+    if not isinstance(receipt_ts, (int, float)):
+        return None
+    started = ts_ms - (duration_ms or 0)
+    if not (started - RECEIPT_MATCH_SLACK_MS <= receipt_ts <= ts_ms + RECEIPT_MATCH_SLACK_MS):
+        return None
+    return doc
 
 
 def status_glyph(status, receipt=None):
@@ -226,7 +251,7 @@ def main():
         # The on-disk receipt outranks the run record: openclaw reports
         # `delivered=None / not-requested` on a run whose summary call failed,
         # even when postflight already delivered the report (2026-08-17).
-        receipt = delivered_receipt(jobs.get(e['_jobId'], ''), e.get('ts'))
+        receipt = delivered_receipt(jobs.get(e['_jobId'], ''), e.get('ts'), e.get('durationMs'))
         deliv = '—'
         if receipt is not None:
             deliv = '✓rcpt'

--- a/tests/test_cron_runs_delivery_truth.py
+++ b/tests/test_cron_runs_delivery_truth.py
@@ -38,6 +38,10 @@ def desk(tmp_path):
     return tmp_path
 
 
+RUN_TS = 1786930333675 + 30_000       # run recorded 30s after the receipt
+RUN_DURATION = 5 * 60 * 1000          # 5-minute run, so the receipt is inside it
+
+
 def _receipt(desk, name, **fields):
     doc = {'ts': 1786930333675, 'sent_ok': True, 'delivery_state': 'delivered'}
     doc.update(fields)
@@ -49,7 +53,7 @@ def test_delivered_report_with_failed_summary_is_not_a_red(monkeypatch, desk):
     _receipt(desk, 'report-sent-hk-open-2026-08-17.json')
     entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
 
-    receipt = mod.delivered_receipt('港股开盘报告', 1786930333675)
+    receipt = mod.delivered_receipt('港股开盘报告', RUN_TS, RUN_DURATION)
     assert receipt is not None, 'the receipt for this job/date must be found'
     assert mod.status_glyph('error', receipt) == '⚠️', 'a delivered report is not a red'
     assert '已投递' in mod.summarize(entry, receipt=receipt)
@@ -60,7 +64,7 @@ def test_a_genuinely_undelivered_run_stays_red(monkeypatch, desk):
     # No receipt written: this is the real failure shape (盘前深度简报, 2026-08-17).
     entry = {'status': 'error', 'error': 'FallbackSummaryError: All models failed (3): ...'}
 
-    receipt = mod.delivered_receipt('盘前深度简报', 1786930333675)
+    receipt = mod.delivered_receipt('盘前深度简报', RUN_TS, RUN_DURATION)
     assert receipt is None
     assert mod.status_glyph('error', receipt) == '🔴', 'no receipt means no delivery — stay red'
     assert mod.summarize(entry, receipt=receipt).startswith('ERR:')
@@ -70,7 +74,7 @@ def test_a_receipt_that_did_not_send_is_not_treated_as_delivered(monkeypatch, de
     mod = _load(monkeypatch, desk)
     _receipt(desk, 'report-sent-hk-open-2026-08-17.json', sent_ok=False, delivery_state='failed')
 
-    assert mod.delivered_receipt('港股开盘报告', 1786930333675) is None
+    assert mod.delivered_receipt('港股开盘报告', RUN_TS, RUN_DURATION) is None
     assert mod.status_glyph('error', None) == '🔴'
 
 
@@ -87,3 +91,40 @@ def test_every_delivering_job_has_a_receipt_pattern(monkeypatch, desk):
     for job in ('港股开盘报告', '港股午盘报告', '港股午后快报', '港股收盘报告',
                 '美股开盘报告', '美股收盘报告', '盘前深度简报'):
         assert job in mod.RECEIPT_BY_JOB, f'{job} delivers — it needs a receipt pattern'
+
+
+def test_a_receipt_from_a_later_run_does_not_vindicate_an_earlier_failure(desk, monkeypatch):
+    """Matching on job+date alone turns the fix into its own mirror image.
+
+    On 2026-08-17 the brief failed at 08:03 / 08:33 / 09:11, produced nothing at
+    10:15, and only delivered at 10:39. Keyed on the date, that single receipt
+    made all four earlier runs display 已投递 — a false green traded for the
+    false red this module exists to remove. The receipt has to belong to the run
+    that is being rendered.
+    """
+    mod = _load(monkeypatch, desk)
+    delivered_at = 1786930333675
+    _receipt(desk, 'brief-sent-2026-08-17.json', ts=delivered_at)
+
+    # The run that actually delivered: the receipt falls inside its window.
+    assert mod.delivered_receipt('盘前深度简报', delivered_at + 20_000, 8 * 60 * 1000) is not None
+
+    # Runs that ended hours before it. Same job, same date, no delivery.
+    for hours_before in (1, 2, 3):
+        earlier_end = delivered_at - hours_before * 3600 * 1000
+        assert mod.delivered_receipt('盘前深度简报', earlier_end, 6 * 60 * 1000) is None, (
+            f'a run ending {hours_before}h before the delivery did not deliver'
+        )
+
+    # And a run that started after it (a retry the idempotency gate blocked)
+    # also did not deliver — it only regenerated the prose.
+    later_end = delivered_at + 20 * 60 * 1000
+    assert mod.delivered_receipt('盘前深度简报', later_end, 3 * 60 * 1000) is None
+
+
+def test_a_run_without_a_duration_still_matches_its_own_receipt(desk, monkeypatch):
+    """durationMs is not always present; a receipt at the run timestamp must
+    still be attributed rather than silently dropped."""
+    mod = _load(monkeypatch, desk)
+    _receipt(desk, 'report-sent-hk-open-2026-08-17.json', ts=1786930333675)
+    assert mod.delivered_receipt('港股开盘报告', 1786930333675, None) is not None


### PR DESCRIPTION
#722 的缺陷,今天上午的真实输出暴露的。

## 问题

`delivered_receipt` 按 **job 名 + 日期**找回执。于是:

```
08:03 盘前深度简报  ⚠️ ✓rcpt 已投递 delivered   <- 没投递
08:33 盘前深度简报  ⚠️ ✓rcpt 已投递 delivered   <- 没投递
09:11 盘前深度简报  ⚠️ ✓rcpt 已投递 delivered   <- 没投递
10:15 盘前深度简报  ✅ ✓rcpt 已投递 delivered   <- 跑满 10.3 分钟零产出
```

简报直到 **10:39:44** 才真的投出去。那一份回执一落盘,当天**所有更早的失败运行**都被倒贴成「已投递」。

**把假红换成假绿,不算修好。** 这正是 #721 要消灭的那个毛病的镜像,而我在修它的时候造了出来。

## 改动

按运行窗口匹配:run 的 `ts` 是结束时刻,窗口 `[ts - durationMs, ts]` 加 90s 容差(吸收 run 记录与文件 mtime 之间的抖动),只有落在窗口内的回执才是这次运行产出的。

## 修复后,同一批真实数据

```
08:03 / 08:33 / 09:11  盘前深度简报  🔴 not-    确实没投递
10:15                  盘前深度简报  ✅ not-    openclaw 自报 ok,但无回执 —— 不再谎称已投递
10:39                  盘前深度简报  ⚠️ ✓rcpt   真的投了
09:34                  港股开盘报告  ⚠️ ✓rcpt   窗口含 09:32:13 回执
09:37                  港股开盘报告  🔴 not-    重试,被幂等闸挡下,确实没投
```

09:37 那条尤其说明问题:报告确实已经在 kcn 手上了,但**那次运行**没有投递任何东西 —— 现在表里说的就是这个事实,不多不少。

## 红绿

退回「只按 job+日期」(**就是合并 #722 之后 live 的真实状态**):

```
1 failed, 6 passed
  a run ending 1h before the delivery did not deliver
```

新测试还覆盖了「晚于投递的重试运行也不算投递」和「durationMs 缺失时仍能匹配自己的回执」。
