### PR TITLE
feat(intraday): 加 always_full 开关,暂时每档都发全量

### DIFF
--- a/config/intraday-delivery.json
+++ b/config/intraday-delivery.json
@@ -1,0 +1,6 @@
+{
+  "always_full": true,
+  "note": "2026-08-17 kcn: 暂时每档都发全量,不要 unchanged_receipt 短回执。改回 false(或删掉本文件)即恢复 #532/#533 的语义去重闸。",
+  "set_at": "2026-08-17",
+  "set_by": "kcn"
+}

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -692,6 +692,30 @@ def quote_coverage(_block, market, portfolio_path=None, *, now=None,
     }
 
 
+def always_full_intraday() -> bool:
+    """Whether every open-market slot should send the full block.
+
+    The semantic-delta gate (#532/#533) sends a compact receipt when nothing
+    material moved, which is the right default: it keeps every slot visible
+    without repeating an unchanged report. kcn asked on 2026-08-17 to see the
+    full block on every slot for a while instead.
+
+    A config toggle rather than deleting the gate, because the contract behind
+    it is deliberate — "semantic deduplication must never become a skip/no-send
+    gate" — and this is meant to be temporary. Absence of the file, an
+    unreadable file, or a missing key all mean the gate stays on: a runtime
+    switch must fail back to the reviewed behaviour, not to whatever a typo
+    happens to produce.
+
+    `config/intraday-delivery.json`:  {"always_full": true}
+    """
+    try:
+        doc = json.loads((WS / 'config' / 'intraday-delivery.json').read_text())
+    except Exception:
+        return False
+    return doc.get('always_full') is True
+
+
 def render_unchanged_receipt(market, block, coverage, active):
     first = ((block or '').strip().splitlines() or [
         '🇭🇰 港股盯盘' if market == 'hk' else '🇺🇸 美股盯盘'
@@ -942,7 +966,11 @@ def main(argv=None):
     prior_doc = intraday_delta.load_delivered_state(WS, args.market)
     prior_state = prior_doc.get('state') if isinstance(prior_doc, dict) else {}
     semantic_delta = intraday_delta.compare_semantic_states(semantic_state, prior_state)
-    unchanged = bool(prior_state) and not semantic_delta['changed']
+    # The delta is still computed and still stored when the gate is off: the
+    # delivered-state cursor has to keep advancing, or flipping the toggle back
+    # would compare against a months-old state and send one bogus full slot.
+    always_full = always_full_intraday()
+    unchanged = bool(prior_state) and not semantic_delta['changed'] and not always_full
     if unchanged:
         raw_block = render_unchanged_receipt(
             args.market, stdout.strip(), coverage, active_information_ctx,
@@ -971,6 +999,10 @@ def main(argv=None):
         'generated_at':     now.isoformat(timespec='seconds'),
         'raw_wechat_block': raw_block,
         'delivery_mode': delivery_mode,
+        # Auditable: a full block on a slot the delta called unchanged is the
+        # toggle at work, not the delta misfiring.
+        'always_full': always_full,
+        'semantic_unchanged': bool(prior_state) and not semantic_delta['changed'],
         'semantic_state': semantic_state,
         'semantic_delta': semantic_delta,
         'quote_coverage': coverage,

--- a/tests/test_intraday_always_full_toggle.py
+++ b/tests/test_intraday_always_full_toggle.py
@@ -1,0 +1,68 @@
+"""The intraday delta gate must be switchable without being deleted.
+
+#532/#533 established the contract: every open-market slot stays visible, an
+unchanged slot sends a compact receipt instead of repeating the full block, and
+"semantic deduplication must never become a skip/no-send gate". kcn asked on
+2026-08-17 to see the full block on every slot for a while. That is a toggle,
+not a reason to remove the gate — so these tests pin both directions.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src'))
+
+from clawock.harness import intraday_preflight
+
+
+def _module(monkeypatch, workspace):
+    """Point the module's workspace at a scratch dir.
+
+    Deliberately not a module reload: import validates the instrument registry,
+    so a reload would make these tests about registry fixtures instead of about
+    the toggle.
+    """
+    monkeypatch.setattr(intraday_preflight, 'WS', workspace)
+    return intraday_preflight
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    (tmp_path / 'config').mkdir()
+    return tmp_path
+
+
+def test_no_config_file_leaves_the_gate_on(monkeypatch, workspace):
+    """The reviewed default must survive an absent toggle."""
+    assert _module(monkeypatch, workspace).always_full_intraday() is False
+
+
+def test_the_toggle_turns_every_slot_into_a_full_block(monkeypatch, workspace):
+    (workspace / 'config' / 'intraday-delivery.json').write_text(
+        json.dumps({'always_full': True}))
+    assert _module(monkeypatch, workspace).always_full_intraday() is True
+
+
+def test_a_broken_or_ambiguous_toggle_falls_back_to_the_gate(monkeypatch, workspace):
+    """A runtime switch must fail back to the reviewed behaviour.
+
+    Not to whatever a typo produces: "true", 1 and a truncated file all mean
+    "somebody meant something and it did not parse", and the safe reading of
+    that is the default the contract was written for.
+    """
+    path = workspace / 'config' / 'intraday-delivery.json'
+    for content in ('{not json', '{}', json.dumps({'always_full': 'true'}),
+                    json.dumps({'always_full': 1}), json.dumps({'always_full': False})):
+        path.write_text(content)
+        assert _module(monkeypatch, workspace).always_full_intraday() is False, content
+
+
+def test_the_live_workspace_toggle_is_currently_on():
+    """The repo ships the toggle enabled (2026-08-17). If someone turns it back
+    off, this test is the reminder to update the note and the memory entry."""
+    doc = json.loads((ROOT / 'config' / 'intraday-delivery.json').read_text())
+    assert doc['always_full'] is True
+    assert doc.get('note'), 'a temporary override has to say why and how to undo it'


### PR DESCRIPTION
kcn:「把那个盘中拦截去掉暂时 我还是想都看到」。

## 做成开关,不是删掉

#532/#533 的语义去重闸背后是一条明确写下的契约:

> Every scheduled open-market slot remains visible. **Semantic deduplication must never become a skip/no-send gate.**
> A changed slot sends the full block plus model judgement. An unchanged slot sends a deterministic compact receipt.

它是刻意设计的,而这次是**暂时**的 —— 所以加开关。

```json
// config/intraday-delivery.json
{"always_full": true}
```

打开后每个开市档都发全量 block,不再出短回执。改成 `false` 或删掉文件即恢复。

## fail back 到评审过的行为

文件不存在 / 读不了 / 键缺失 / 值是 `"true"` 或 `1` 而不是布尔 `true` —— **一律回落到原闸**。运行时开关必须 fail back 到评审过的行为,而不是回落到某个笔误恰好产生的行为。测试把这五种情况都钉住了。

## delta 照常计算

关键一点:开关打开时 delta **仍然计算和存储**。delivered-state 游标必须继续前进,否则关回去那天会拿几个月前的状态做比较,白发一档全量。

结果里留两个字段便于事后分辨:

- `always_full` —— 开关状态
- `semantic_unchanged` —— delta 的真实判定

这样看到一档全量时能分清「是开关造成的」还是「delta 真的变了」。

## 红绿

去掉开关(闸恢复无条件生效)→ `1 failed`。盘中相关测试 19 passed。

行为实证:

```
always_full=False -> unchanged=True  -> 发送 短回执
always_full=True  -> unchanged=False -> 发送 全量
```

## 还有一条测试是给未来的自己看的

`test_the_live_workspace_toggle_is_currently_on` 断言仓库里这份配置当前是开着的,且必须带 `note`。谁把它关回去,这条测试就是提醒 —— 顺手更新说明和 memory,别让一个「暂时」的开关无声无息变成永久状态。
