### PR TITLE
release: 0.1.6 发布准备(pyproject + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,65 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The newest heading here has to match the version in `pyproject.toml` — CI fails
 otherwise, so a release cannot ship an entry that was never written.
 
+## [0.1.6] — 2026-08-17
+
+### Fixed
+
+- **The `clawock-dsh` plugin marked T+1 against a price the rest of the system
+  had already disowned.** It read `current_price` out of the portfolio
+  snapshots, a field whose vintage follows whichever job wrote it — measured
+  across 15 snapshots on one ticker it was the previous close 7 times, that
+  day's close 3 times and an intraday print 5 times, and it is carried forward
+  once a position closes (one ticker sat frozen at 213 for five sessions while
+  its real closes ran 222.32 / 220.61 / 223.47 / 219.51 / 215.33). Settlement
+  moved to the canonical `memory/bars/` store for exactly this reason; the
+  panel had not followed. On the live book 82% of T+1 deltas disagreed with the
+  canonical close and 10 verdicts inverted outright. T+1 now reads
+  `memory/bars/<ticker>.json`, and a fill with no canonical bar shows no
+  verdict rather than falling back. ([#717], [#719])
+- **"T+1" was not T+1 for most fills.** The close was whichever snapshot
+  happened to come next, with no ceiling, so fills predating the snapshot
+  series were marked against a close up to 144 days later — still labelled
+  T+1. A close is now only a T+1 verdict when it lands within four calendar
+  days (a Friday fill settles against Monday; one holiday makes four), and the
+  scorecard renders the denominator it is computed over. ([#710], [#716])
+- **One dead zone, applied everywhere.** The verdict text, the trace node and
+  the result chip each carried their own threshold, so a sell at +0.5% rendered
+  a grey "持平" chip next to a red node, and a buy at exactly 0% was painted
+  green while the text read 跌. The reading is now decided once, host-side, and
+  the client only maps it to CSS. ([#713], [#716])
+- **`decision_packet_summary` refused to run once the book reached ten
+  holdings.** The whole-book summary and a single-ticker section query shared
+  one 24KB budget, but the summary is O(holdings) — it crossed the line at
+  33,543 bytes and exited non-zero. It is the brief's resident input, so the
+  brief had no way into its own analysis. The summary now has its own budget
+  and reports how close it is to it. ([#723], [#724])
+- **A conversation-source ledger row could take down anything that read the
+  ledger.** Rows written by the decision-mind path carry `decided_at` and no
+  `created_at` / `plan_date`; two readers subscripted those keys directly, so
+  the first such row made episode assignment raise `KeyError` — discarding an
+  already-generated brief — and turned the README metrics refresh red every
+  night. Both readers now route mind rows the way the validator already did.
+  ([#718], [#720])
+- **The canonical bar store started only at 2026-05-01**, so fills older than
+  that had no close to settle against. It now starts 2025-12-01, a month before
+  the oldest recorded fill. ([#719])
+
+### Added
+
+- **`ops/host/install_dsh_plugin.sh`** installs the DSH plugin with its runtime
+  dependencies and verifies every export entry imports before handing it to the
+  harness. The previous path linked the source directory into the profile
+  without ever installing its dependencies, so the first plugin release to
+  declare one could not load at all. ([#709], [#716])
+- **A packaged-install contract test** (`tests/dsh_plugin_package_contract.mjs`)
+  packs `clawock-dsh`, installs the tarball into an empty project and imports
+  each export entry, which is the only place a declared-but-never-installed
+  dependency is visible. ([#709], [#716])
+- **`config/intraday-delivery.json`** switches intraday delivery between the
+  semantic-delta receipts and a full block on every slot. Absent, unreadable or
+  ambiguous configuration keeps the reviewed default. ([#726])
+
 ## [0.1.5] — 2026-08-16
 
 ### Fixed
@@ -200,3 +259,14 @@ environment — and completes one full run. ([#436], [#379])
 [0.1.2]: https://github.com/KCNyu/clawock/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/KCNyu/clawock/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/KCNyu/clawock/releases/tag/v0.1.0
+[#709]: https://github.com/KCNyu/clawock/issues/709
+[#710]: https://github.com/KCNyu/clawock/issues/710
+[#713]: https://github.com/KCNyu/clawock/issues/713
+[#716]: https://github.com/KCNyu/clawock/pull/716
+[#717]: https://github.com/KCNyu/clawock/issues/717
+[#718]: https://github.com/KCNyu/clawock/issues/718
+[#719]: https://github.com/KCNyu/clawock/pull/719
+[#720]: https://github.com/KCNyu/clawock/pull/720
+[#723]: https://github.com/KCNyu/clawock/pull/723
+[#724]: https://github.com/KCNyu/clawock/pull/724
+[#726]: https://github.com/KCNyu/clawock/pull/726

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.5"
+version = "0.1.6"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
0.1.6 发布准备。走完整 release(PyPI + npm + GitHub Release),kcn 选的 B。

## 两个硬闸

`release.yml` 会在两处拒绝不一致的发布,所以这个 PR 必须先合:

1. **「Tag matches the packaged version」** —— tag 版本 ≠ `pyproject.toml` 版本就报错退出。`pyproject` 从 `0.1.5` bump 到 `0.1.6`。
2. **CHANGELOG 最新标题必须等于 `pyproject` 版本** —— 文件自己写着「CI fails otherwise, so a release cannot ship an entry that was never written」。补 `## [0.1.6] — 2026-08-17`。

## 版本现状

| | 之前 | 现在 |
|---|---|---|
| `pyproject.toml` / PyPI | 0.1.5 / 0.1.5 | **0.1.6** / 待发 |
| `examples/dsh/plugin/package.json` / npm | 0.1.6 / **0.1.5** | 0.1.6 / 待发 |

npm 侧的 package.json 早在 #716 就 bump 过但没发,所以 npm 上仍是 0.1.5 —— 这次一起发出去,#712 的遗留才算真正闭合。

## CHANGELOG 只写消费者能观察到的

按文件自己的规则(「Only the public package is released, so only changes a package consumer can observe are listed here」),写了 6 条 Fixed + 3 条 Added,每条都带上让人能判断严重性的实测数字,而不是「修了 T+1」这种。

## 实证

```
ops/publish/release_notes.py 0.1.6  -> 渲染通过,4385 字节
pytest -k "changelog or release or version"  -> 21 passed, 1 skipped
```

## 合并后

打 `v0.1.6` tag → `release.yml` 依次跑:构建 sdist/wheel → tag/版本一致性校验 → 隔离安装跑一次真实 run → harness-free 契约 → 发 PyPI → 发 npm → 建 GitHub Release(**只有 PyPI 接受了那个 artifact 之后才建 Release**)。
