### PR TITLE
release: 0.1.7 发布准备 —— 把 clawock-dsh 真正发到 npm (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,58 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The newest heading here has to match the version in `pyproject.toml` — CI fails
 otherwise, so a release cannot ship an entry that was never written.
 
+## [0.1.7] — 2026-08-17
+
+The Python package's code is identical to 0.1.6. This version exists because the
+two distributions ride one version train and the npm half of 0.1.6 never
+shipped: `clawock-dsh` is the release.
+
+### Fixed
+
+- **`clawock-dsh` on npm was a different build than its version number
+  claimed, and 0.1.6 never got there at all.** npm's `latest` was 0.1.5, whose
+  tarball is the pre-#708 layout — `client.js` at the root, no
+  `lib/typert.*`, no `./typert` or `./remote` export, no `zod` dependency —
+  so `dsh plugin add clawock-dsh` installed a plugin that registers and then
+  shows no data. Both 0.1.6 publish attempts died inside npm itself
+  (`Exit handler never called!`): the plugin's `package-lock.json` had been
+  regenerated on a machine behind a mirror registry, so all 169 `resolved`
+  URLs pointed at a host the GitHub runner cannot reach and every fetch
+  stalled through npm's retry ladder. The lockfile is back on
+  registry.npmjs.org, the publish job pins the npm that does the publishing
+  and records which registry it used, and — because "publish exited 0" was
+  never evidence — it now downloads the registry copy back and asserts
+  file-for-file, export-for-export and dependency-for-dependency that it is
+  what was packed. ([#732], [#728])
+
+### Changed
+
+- **The DSH plugin follows the official Harness client rules instead of a
+  reverse-engineered shape.** Styles ship as CSS Modules whose
+  `<style data-plugin="clawock-dsh">` tag the module loader owns and removes on
+  unload, so nothing touches `document` while the bundle is loading; the UI
+  store is a `createDecisionMindStore()` factory called inside `apply` rather
+  than a module-level singleton shared across plugin reloads; the trace cache
+  lives in the plugin instance and reaches the view through its props; the
+  scroll container comes from an element ref instead of a global selector; and
+  the browser bundle carries no business `any` — it consumes the same wire
+  types the host declares. The generated Typert reflection is now emitted by
+  the official generator running in place over the real source tree (the
+  package moved to `examples/dsh/packages/clawock-dsh` because rc.6 discovers
+  packages only under a workspace root's `packages/`), the build is
+  reproducible, and CI rebuilds `lib/` on every plugin change and fails if the
+  committed artifacts differ. ([#729], [#730], [#731])
+- **Installing the plugin from a checkout goes through the official
+  installer.** `ops/host/install_dsh_plugin.sh` packs the package and hands the
+  tarball to `dsh plugin --profile web add`, which installs it the way a
+  registry package is installed and reconciles the profile's bundle rows
+  itself. It no longer hand-copies a source directory and hand-edits the
+  profile manifest — a directory spec is only *linked*, which is how a plugin
+  dependency went uninstalled and crash-looped dsh in the first place. The
+  tarball's file name carries a content hash, because pnpm keys a `file:`
+  tarball by path and would otherwise serve the previous build from its store
+  while every step reported success. ([#731])
+
 ## [0.1.6] — 2026-08-17
 
 ### Fixed
@@ -254,7 +306,9 @@ environment — and completes one full run. ([#436], [#379])
 [#665]: https://github.com/KCNyu/clawock/issues/665
 [#676]: https://github.com/KCNyu/clawock/pull/676
 [#684]: https://github.com/KCNyu/clawock/pull/684
-[Unreleased]: https://github.com/KCNyu/clawock/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/KCNyu/clawock/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/KCNyu/clawock/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/KCNyu/clawock/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/KCNyu/clawock/compare/v0.1.4...v0.1.5
 [0.1.2]: https://github.com/KCNyu/clawock/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/KCNyu/clawock/compare/v0.1.0...v0.1.1
@@ -270,3 +324,9 @@ environment — and completes one full run. ([#436], [#379])
 [#723]: https://github.com/KCNyu/clawock/pull/723
 [#724]: https://github.com/KCNyu/clawock/pull/724
 [#726]: https://github.com/KCNyu/clawock/pull/726
+[#728]: https://github.com/KCNyu/clawock/pull/728
+[#729]: https://github.com/KCNyu/clawock/issues/729
+[#730]: https://github.com/KCNyu/clawock/issues/730
+[#731]: https://github.com/KCNyu/clawock/issues/731
+[#732]: https://github.com/KCNyu/clawock/issues/732
+[#733]: https://github.com/KCNyu/clawock/pull/733

--- a/examples/dsh/packages/clawock-dsh/package-lock.json
+++ b/examples/dsh/packages/clawock-dsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawock-dsh",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",

--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Mind conversation-view tab",
   "license": "MIT",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.6"
+version = "0.1.7"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Refs #732(发布后由 release run 的实证收口)。

0.1.6 现在是半发布:PyPI 有 0.1.6,npm 的 `latest` 还是 0.1.5,而那份 0.1.5
的 tarball 是 #708 之前的布局(顶层 client.js、无 `lib/typert.*`、无 zod)。
两次 0.1.6 的 npm publish 都死在 npm 自己的 `Exit handler never called!`,
根因(#728 已修)是插件 lockfile 在装了镜像 registry 的机器上生成过。

所以**不复用 0.1.6 号发 npm** —— 那就是 #712「一个版本号两份代码」的复现。
发 0.1.7,两个分发同一条版本列车:

- `pyproject.toml` 0.1.6 → 0.1.7(Python 侧代码与 0.1.6 **完全相同**,
  `git diff v0.1.6..master -- src/` 为空;CHANGELOG 里明说这一版是为插件发的);
- `examples/dsh/packages/clawock-dsh/package.json` → 0.1.7;
- CHANGELOG 补 `[0.1.7]` 段(顺带补上一直缺的 `[0.1.6]` compare 链接,
  并把 `[Unreleased]` 从 v0.1.5 挪到 v0.1.7)。

合并后打 `v0.1.7` tag 走全量 release:PyPI → npm → GitHub Release。npm 那步
现在发完会把 registry 上那份下载回来逐文件核对(#728),所以「发出去了」和
「发出去的是这份代码」是两条独立证据。
