### PR TITLE
docs(changelog): 更正 0.1.7 条目 —— 0.1.6 其实已经发到 npm 了

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,27 +15,29 @@ otherwise, so a release cannot ship an entry that was never written.
 
 ## [0.1.7] — 2026-08-17
 
-The Python package's code is identical to 0.1.6. This version exists because the
-two distributions ride one version train and the npm half of 0.1.6 never
-shipped: `clawock-dsh` is the release.
+The Python package's code is identical to 0.1.6. This version exists to ship the
+plugin: `clawock-dsh` is the release.
 
 ### Fixed
 
 - **`clawock-dsh` on npm was a different build than its version number
-  claimed, and 0.1.6 never got there at all.** npm's `latest` was 0.1.5, whose
+  claimed.** npm's `latest` was 0.1.5 for a day, whose
   tarball is the pre-#708 layout — `client.js` at the root, no
   `lib/typert.*`, no `./typert` or `./remote` export, no `zod` dependency —
   so `dsh plugin add clawock-dsh` installed a plugin that registers and then
-  shows no data. Both 0.1.6 publish attempts died inside npm itself
-  (`Exit handler never called!`): the plugin's `package-lock.json` had been
+  shows no data. The two tag-triggered 0.1.6 publishes died inside
+  npm itself (`Exit handler never called!`): the plugin's `package-lock.json` had been
   regenerated on a machine behind a mirror registry, so all 169 `resolved`
   URLs pointed at a host the GitHub runner cannot reach and every fetch
   stalled through npm's retry ladder. The lockfile is back on
-  registry.npmjs.org, the publish job pins the npm that does the publishing
-  and records which registry it used, and — because "publish exited 0" was
-  never evidence — it now downloads the registry copy back and asserts
-  file-for-file, export-for-export and dependency-for-dependency that it is
-  what was packed. ([#732], [#728])
+  registry.npmjs.org and the publish job pins the npm that does the publishing
+  and records which registry it used; with those in place a manual npm-only run
+  did land 0.1.6 on 2026-08-17 at 06:16Z, so the registry was already correct
+  before this version. What 0.1.7 adds is the part that makes that claim
+  checkable rather than assumed: because "publish exited 0" was never evidence,
+  publishing now downloads the registry copy back and asserts file-for-file,
+  export-for-export and dependency-for-dependency that it is what was packed.
+  ([#732], [#728])
 
 ### Changed
 


### PR DESCRIPTION
自纠。合并 #734 时我在 CHANGELOG / PR 正文 / #732 的结案评论里都写了「0.1.6
从没到过 npm」,这是错的。

事实:#728 把锁文件和 npm 版本钉好之后,一次 `npm_only` 手工 dispatch
([run 32000904670](https://github.com/KCNyu/clawock/actions/runs/32000904670),
branch ref)在 **2026-08-17 06:16:33Z 成功发布了 0.1.6**(18 个文件,含 zod)。
我当时只看了 `npm view clawock-dsh` 的当前 `dist-tags`,没查 `time['0.1.6']`,
就沿用了 issue #732 里「两次 publish 均崩」的旧结论 —— 那两次(tag 触发)确实崩了,
但不是全部尝试。

所以 0.1.7 的实际价值不是「终于发出去了」,而是:

- 插件按 DSH 官方写法标准化(#729/#730/#731)这一半不变;
- npm 这一半从「发出去了」升级成「**发出去的是不是这份代码**有机检断言」——
  发完把 registry 那份拉回来逐文件/逐导出/逐依赖核对。

改动:CHANGELOG 的 `[0.1.7]` 段按事实重写(不删条目,改叙述),并同步改了
GitHub Release v0.1.7 的正文。#732 也补了更正评论。
