### PR TITLE
fix(dashboard): 决策轨迹卡 —— 手机端裁剪、T+1 数据源、统计口径、文案表意 (#736 #737 #738 #739 #740)

### DIFF
--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -105,8 +105,11 @@ agent:准备请求…(clawock run prepare)
 对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
 ... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,
 bear 与失效条件强制,情绪自认)。面板不改任何文件,结算仍归既有机制。
-同一个「决策轨迹」数据契约也渲染在公开 dashboard 的 Reflect 面板
-(`build_decision_traces`)——插件与网页同一份加工逻辑。结构:
+同一个「决策轨迹」**数据契约**也渲染在公开 dashboard 的 Reflect 面板
+(`build_decision_traces`)——但那是**另一套实现**:插件是运行期读 workspace 的
+TypeScript(`src/ledger.ts::readTraces`),网页是构建期算好塞进 `dashboard.json`
+的 Python。两边不共享代码,曾经因此漂移到判词都不一致(#739/#740),
+现在由 `tests/test_decision_trace_parity.py` 钉住共用的规则常量与判词表。结构:
 
 对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
 ... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2212,3 +2212,39 @@
 .trace-day { margin-bottom: 14px; }
 .trace-day-h { font-size: 11px; font-weight: 700; color: var(--text-dim); letter-spacing: 0.05em; margin: 10px 0 6px; display: flex; align-items: center; gap: 6px; }
 .trace-day-h::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+.tr-pnl-k { font-size: 10px; font-weight: 600; color: var(--text-dim); margin-right: 3px; }
+.tr-align { font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 5px; white-space: nowrap; }
+.tr-align.skip { color: var(--accent-strong); background: color-mix(in srgb, var(--accent-strong) 12%, transparent); }
+.tr-align.ok { color: var(--pos); background: color-mix(in srgb, var(--pos) 12%, transparent); }
+.tr-align.na { color: var(--text-dim); background: var(--bg-soft, rgba(0,0,0,0.04)); }
+#trace-stats { display: flex; flex-wrap: wrap; gap: 6px 24px; margin: 8px 0 12px; font-size: 12px; line-height: 1.5; }
+
+/* The summary row is a nowrap flex line whose min-content is ~367px — wider
+   than any phone — and .tr-row clips instead of scrolling, so below ~420px the
+   P&L number and the disclosure arrow were simply cut off the row (#736).
+   Explicit two-row grid: identity + focus number on line 1, the supporting
+   numbers on line 2. Every child gets a cell, so nothing can be pushed out. */
+@media (max-width: 520px) {
+  .tr-row summary {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+    column-gap: 8px; row-gap: 3px;
+    padding: 11px 12px;
+  }
+  .tr-row summary .tr-dot { grid-area: 1 / 1; }
+  .tr-row summary .tr-tk { grid-area: 1 / 2; }
+  .tr-row summary .tr-act { grid-area: 1 / 3; justify-self: start; }
+  .tr-row summary .tr-pnl { grid-area: 1 / 4; min-width: 0; font-size: 14.5px; white-space: nowrap; }
+  .tr-row summary .tr-qty { grid-area: 2 / 2 / 3 / 4; }
+  .tr-row summary .tr-t1 { grid-area: 2 / 4 / 3 / 6; justify-self: end; }
+  .tr-row summary .tr-spacer { display: none; }
+  /* The arrow used to share row 1 with the P&L through margin-left:auto, which
+     is what pushed it off the row entirely. Its own column keeps it visible —
+     a row nobody can see is expandable is a row nobody expands. */
+  .tr-row summary::after { grid-area: 1 / 5; margin: 0; align-self: center; }
+  .tr-body { padding: 4px 12px 12px; }
+  .trace-line { padding-left: 18px; }
+  .tr-node::before { left: -18px; }
+  #trace-stats { gap: 4px 14px; }
+  #trace-stats > span { flex: 1 1 100%; }
+}

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2761,8 +2761,17 @@
 
   // =========================================================
   // Decision traces: real fills as the spine, soft-paired decisions
-  // as the "why", T+1 closes as the result. Same contract as the DSH
-  // plugin view — this card is the public mirror.
+  // as the "why", T+1 canonical closes as the result. The DSH plugin renders
+  // the same contract from its own implementation; parity is enforced by
+  // fixture, not by shared code (#739).
+  //
+  // Wording rules this card learned the hard way (#737/#738):
+  //  - every count carries its denominator, and window sums are labelled as
+  //    the window, never as the ledger;
+  //  - the ledger's execution.status grades the *plan*, so it is shown as
+  //    「账本自评」 and never as this fill's execution;
+  //  - 本笔已实现 (per-fill, money) and 该持仓浮动 (position-level, percent) are
+  //    different quantities and never share a label.
   // =========================================================
   function renderDecisionTraces() {
     const wrap = document.getElementById("trace-list");
@@ -2777,31 +2786,49 @@
     const EMO = {fomo:"追高冲动",revenge:"报复性",averaging_down:"摊薄冲动",fear:"恐慌",euphoria:"亢奋",calm:"平静",mixed:"混合"};
     const esc = escapeHtml;
 
-    // T+1 tone is action-aware: a rising price is good for the buyer, bad for
-    // the seller (卖飞). One sign rule for both would color buy gains red.
-    const t1Cls = (t) => {
-      const up = t.t1.delta >= 0;
-      const sell = t.action === "sell" || t.action === "cut" || t.action === "trim" || t.action === "trim_on_rebound";
-      if (sell) return up ? "neg" : "pos";
-      return up ? "pos" : "neg";
-    };
+    // T+1 tone ships with the data so this chip cannot colour a move the words
+    // call 持平: the ±1% dead zone lives once, in build_decision_traces. `tone`
+    // is absent only on a payload built before #739.
+    const TONE = {win: "pos", loss: "neg", flat: "na"};
+    const t1Cls = (t) => TONE[t.t1.tone] || "na";
 
-    // Stats row: USD-eq realized + T+1 verdict counts + match rate.
-    const usd = list.filter(t => t.realizedPnl != null && t.currency === "USD").reduce((s,t) => s + t.realizedPnl, 0);
-    const hkd = list.filter(t => t.realizedPnl != null && t.currency === "HKD").reduce((s,t) => s + t.realizedPnl, 0);
-    const fx = safe(DATA, "fx", "usdhkd");
-    const totalUsd = usd + (fx ? hkd / fx : 0);
-    const fw = list.filter(t => t.t1 && t.t1.verdict === "卖飞").length;
-    const ok = list.filter(t => t.t1 && t.t1.verdict === "卖对").length;
-    const matched = list.filter(t => t.decision).length;
+    // Stats. Every number is scoped and carries its denominator: this card
+    // renders a window (the newest `limit` fills), and summing that window into
+    // an unqualified 已实现 total is how it came to print $926.3 while the
+    // ledger held US $2,347.68 + HK$7,259.16 (#737).
+    const sc = safe(DATA, "decision_trace_scope") || {};
+    const shown = sc.fillsShown || list.length;
+    const total = sc.fillsTotal || shown;
+    const realShown = sc.realizedShown || {};
+    const realAll = sc.realizedAll || {};
+    // USD first, then the rest — the desk reports in USD-eq, and the two legs
+    // are listed side by side rather than summed (HKD + USD is not a number).
+    const money = (by) => {
+      const keys = Object.keys(by).sort((a, b) => (a === "USD" ? -1 : b === "USD" ? 1 : a < b ? -1 : 1));
+      return keys.length
+        ? keys.map(c => `<b class="${by[c] >= 0 ? "pos" : "neg"}">${fmtMoney(by[c], c)}</b>`).join(" + ")
+        : `<b>${DASH}</b>`;
+    };
+    const verdicts = (label, tally) => {
+      const keys = Object.keys(tally || {});
+      if (!keys.length) return "";
+      const n = keys.reduce((s, k) => s + tally[k], 0);
+      return `${label} <b>${n}</b>: ` + keys.sort().map(k =>
+        `<b class="${k === "卖对" || k === "涨" ? "pos" : k === "持平" ? "na" : "neg"}">${tally[k]}</b>${k}`).join(" / ");
+    };
     const statsEl = document.getElementById("trace-stats");
     if (statsEl) {
+      const v = sc.t1Verdicts || {};
+      const align = sc.alignment || {};
+      const t1line = [verdicts("卖出", v.reduce), verdicts("买入", v.add)].filter(Boolean).join(" · ");
       statsEl.innerHTML =
-        `<span>已实现 <b class="${totalUsd >= 0 ? "pos" : "neg"}">${fmtMoney(totalUsd, "USD")}</b> <span class="muted">USD等值</span></span>` +
-        `<span class="muted">(US ${fmtMoney(usd, "USD")} + HK ${fmtMoney(hkd, "HKD")})</span>` +
-        `<span>T+1 <b class="neg">${fw}</b>卖飞 / <b class="pos">${ok}</b>卖对</span>` +
-        `<span>挂接 <b>${matched}</b>/${list.length}</span>` +
-        (fx ? `<span class="muted">@${fx}</span>` : "");
+        `<span>本卡显示 <b>最近 ${shown}</b> 笔成交 <span class="muted">/ 全部 ${total} 笔</span></span>` +
+        `<span>其中 <b>${sc.closedShown != null ? sc.closedShown : DASH}</b> 笔已平仓,已实现 ${money(realShown)} ` +
+        `<span class="muted">(全期 ${money(realAll)},不只这 ${shown} 笔)</span></span>` +
+        (t1line ? `<span>T+1 ${t1line}</span>` : "") +
+        `<span>有当日计划 <b>${sc.pairedShown != null ? sc.pairedShown : DASH}</b>/${shown}` +
+        (align.opposite ? `,其中 <b class="neg">${align.opposite}</b> 笔与计划反向` : "") +
+        ` <span class="muted">· 带心智/情绪 ${sc.emotionShown != null ? sc.emotionShown : DASH}/${shown}</span></span>`;
     }
 
     // Group by date, newest first; each fill is an expandable trace row.
@@ -2809,42 +2836,82 @@
     list.forEach(t => { const k = (t.date || "").slice(0,10); (groups[k] = groups[k] || []).push(t); });
     const dates = Object.keys(groups).sort().reverse();
 
+    // The fill itself, in words — the one node that is never inferred.
+    function fillNode(t) {
+      const sym = t.currency === "HKD" ? "HK$" : "$";
+      return `${esc(ACT[t.action] || t.action)} ${t.shares} 股 @ ${sym}${t.price}`;
+    }
+
+    // What actually happened to the money on this row. Two different
+    // quantities, so two different labels: a closed fill has its own realized
+    // amount; an open one only has the whole position's floating percent, which
+    // is not this fill's result and must not be labelled as if it were.
+    function pnlNode(t) {
+      const sym = t.currency === "HKD" ? "HK$" : "$";
+      if (t.realizedPnl != null) {
+        const v = (t.realizedPnl >= 0 ? "+" : "") + Number(t.realizedPnl).toFixed(2) + " " + sym;
+        return {n: "本笔已实现", v, c: t.realizedPnl >= 0 ? "pos" : "neg"};
+      }
+      if (t.holdPnl != null) {
+        return {n: `该持仓当前浮动 <span class="muted">(${esc(t.ticker)} 全仓,非本笔)</span>`,
+                v: fmtPct(t.holdPnl, 1), c: t.holdPnl >= 0 ? "pos" : "neg"};
+      }
+      return {n: "本笔盈亏", v: DASH + " <span class=\"muted\">未平仓</span>", c: "na"};
+    }
+
     function traceHTML(t) {
       const d = t.decision;
-      const sym = t.currency === "HKD" ? "HK$" : "$";
-      if (!d) {
-        let t1 = "";
-        if (t.t1) t1 = `<div class="tr-node ${t1Cls(t)}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}</div></div>`;
-        return `<div class="trace-line">
-          <div class="tr-node dec"><div class="tr-n">决策</div><div class="tr-v muted">无关联记录</div></div>
-          <div class="tr-node ok"><div class="tr-n">执行</div><div class="tr-v">${esc(ACT[t.action] || t.action)} ${t.shares}股 @${t.price} ${sym}</div></div>
-          ${t1}
-        </div>${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}
-        <div class="tr-miss">此笔无关联决策记录 — 事实保留,判断缺失显式标出</div>`;
+      const pnl = pnlNode(t);
+      const pnlHTML = `<div class="tr-node ${pnl.c}"><div class="tr-n">${pnl.n}</div><div class="tr-v">${pnl.v}</div></div>`;
+      let t1 = "";
+      if (t.t1) {
+        t1 = `<div class="tr-node ${t1Cls(t)}"><div class="tr-n">T+1 收盘 · ${esc(t.t1.date)}</div>` +
+          `<div class="tr-v">${fmtPct(t.t1.delta, 1)} · ${esc(t.t1.verdict)}</div></div>`;
+      } else {
+        t1 = `<div class="tr-node na"><div class="tr-n">T+1 收盘</div>` +
+          `<div class="tr-v muted">${DASH} 官方行情里还没有 4 天内的下一根收盘</div></div>`;
       }
-      const exe = EXE[d.execution] || ["未知","na"];
-      const decV = `${ACT[d.action] || d.action}${d.confidence != null ? " " + Math.round(d.confidence*100) + "%" : ""} <span class="muted">${DRV[d.drivenBy] || d.drivenBy || ""}</span>`;
+      if (!d) {
+        return `<div class="trace-line">
+          <div class="tr-node na"><div class="tr-n">当时的计划</div><div class="tr-v muted">这一天没有该标的的计划记录</div></div>
+          <div class="tr-node dec"><div class="tr-n">真实成交</div><div class="tr-v">${fillNode(t)}</div></div>
+          ${t1}
+          ${pnlHTML}
+        </div>${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}
+        <div class="tr-miss">这笔成交在决策账本里找不到前后 3 天的同标的计划:成交是真的,当时的判断没有留下记录。</div>`;
+      }
+      // The plan-vs-fill relation, stated instead of left to be inferred: 22 of
+      // 40 published rows were outright reversals of their own plan and the card
+      // said nothing about it.
+      const ALIGN = {
+        same: ["与计划同向", "ok"],
+        opposite: ["与计划反向", "skip"],
+        other: ["计划未指向买卖", "na"],
+      };
+      const al = ALIGN[d.alignment] || null;
+      const decV = `${esc(ACT[d.action] || d.action)}` +
+        (d.sizeShares ? ` ${d.sizeShares} 股` : "") +
+        (d.plannedPrice ? ` @ ${d.plannedPrice}` : "") +
+        (d.confidence != null ? ` <span class="muted">信心 ${Math.round(d.confidence*100)}%</span>` : "") +
+        (DRV[d.drivenBy] || d.drivenBy ? ` <span class="muted">· ${esc(DRV[d.drivenBy] || d.drivenBy)}</span>` : "");
       const why = d.rationale || d.bull || "";
       const emo = d.emotion && d.emotion !== "calm" ? (EMO[d.emotion] || d.emotion) : null;
       let chips = "";
-      if (d.condition) chips += `<span class="tr-chip">条件: ${esc(d.condition)}</span>`;
-      if (d.sizeShares) chips += `<span class="tr-chip">计划 ${d.sizeShares} 股</span>`;
-      if (d.plannedPrice) chips += `<span class="tr-chip">计划价 ${d.plannedPrice}</span>`;
-      let t1 = "";
-      if (t.t1) t1 = `<div class="tr-node ${t1Cls(t)}"><div class="tr-n">T+1 结果</div><div class="tr-v">${fmtPct(t.t1.delta, 1)}${t.action === "sell" ? " · " + t.t1.verdict : ""}</div></div>`;
-      let rv, rc;
-      if (t.realizedPnl != null) { rv = (t.realizedPnl >= 0 ? "+" : "") + Number(t.realizedPnl).toFixed(2) + " " + sym; rc = t.realizedPnl >= 0 ? "pos" : "neg"; }
-      else if (t.holdPnl != null) { rv = fmtPct(t.holdPnl, 1); rc = t.holdPnl >= 0 ? "pos" : "neg"; }
-      else { rv = DASH; rc = "na"; }
+      if (d.condition) chips += `<span class="tr-chip">触发条件: ${esc(d.condition)}</span>`;
+      // The ledger's execution.status is the plan's own self-report. It answers
+      // "was this plan followed", not "did this fill happen" — the row is a
+      // completed fill either way, so 「未执行」 as a top-level verdict on it read
+      // as a contradiction. It stays, demoted and labelled for what it is.
+      if (d.execution) chips += `<span class="tr-chip">账本自评: ${esc((EXE[d.execution] || [d.execution])[0])}</span>`;
       return `<div class="trace-line">
-        <div class="tr-node dec"><div class="tr-n">计划 · ${esc(d.planDate || "")}</div><div class="tr-v">${decV}</div></div>
-        <div class="tr-node ${exe[1]}"><div class="tr-n">执行</div><div class="tr-v">${exe[0]}${exe[1] === "skip" ? " — 实际动了手" : ""}</div></div>
+        <div class="tr-node dec"><div class="tr-n">当时的计划 · ${esc(d.planDate || "")}</div><div class="tr-v">${decV}</div></div>
+        <div class="tr-node ${al ? al[1] : "dec"}"><div class="tr-n">真实成交</div><div class="tr-v">${fillNode(t)}${al ? ` <span class="tr-align ${al[1]}">${al[0]}</span>` : ""}</div></div>
         ${t1}
-        <div class="tr-node ${rc}"><div class="tr-n">盈亏</div><div class="tr-v">${rv}</div></div>
+        ${pnlHTML}
       </div>
       ${chips ? `<div class="tr-chips">${chips}</div>` : ""}
       ${why ? `<div class="tr-note why">${esc(why)}</div>` : ""}
-      ${emo ? `<div class="tr-note emo">⚡ ${esc(emo)}</div>` : ""}
+      ${emo ? `<div class="tr-note emo">⚡ 当时情绪:${esc(emo)}${d.emotionNote ? " — " + esc(d.emotionNote) : ""}</div>` : ""}
       ${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}`;
     }
 
@@ -2860,15 +2927,18 @@
         return `<div class="trace-day"><div class="trace-day-h">${esc(date)} <span class="muted">${rows.length}</span></div>
           ${rows.map(t => {
             const tone = t.action === "buy" || t.action === "add" ? "pos" : (t.action === "sell" || t.action === "cut" || t.action === "trim" ? "neg" : "muted");
+            // Collapsed row: a realized amount belongs to this fill, a floating
+            // percent belongs to the whole position. The 持仓 prefix is what
+            // keeps the second one from reading as "this trade lost 28%".
             const pnl = t.realizedPnl != null
               ? `<span class="tr-pnl ${t.realizedPnl >= 0 ? "pos" : "neg"}">${t.realizedPnl >= 0 ? "+" : ""}${Number(t.realizedPnl).toFixed(2)} ${t.currency === "HKD" ? "HK$" : "$"}</span>`
-              : (t.holdPnl != null ? `<span class="tr-pnl ${t.holdPnl >= 0 ? "pos" : "neg"}">${fmtPct(t.holdPnl, 1)}</span>` : "");
+              : (t.holdPnl != null ? `<span class="tr-pnl ${t.holdPnl >= 0 ? "pos" : "neg"}"><span class="tr-pnl-k">持仓</span>${fmtPct(t.holdPnl, 1)}</span>` : "");
             const t1tag = t.t1
               ? `<span class="tr-t1 ${t1Cls(t)}">T+1 ${fmtPct(t.t1.delta, 1)} ${t.t1.verdict}</span>`
               : "";
             return `<details class="tr-row">
               <summary>
-                <span class="tr-dot ${t.decision ? "has" : ""}"></span>
+                <span class="tr-dot ${t.decision ? "has" : ""}" title="${t.decision ? "有当日计划记录" : "无当日计划记录"}"></span>
                 <span class="tr-tk">${esc(t.ticker)}</span>
                 <span class="tr-act ${tone}">${esc(ACT[t.action] || t.action)}</span>
                 <span class="tr-qty">${t.shares} @${t.price}</span>

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2809,18 +2809,24 @@
         ? keys.map(c => `<b class="${by[c] >= 0 ? "pos" : "neg"}">${fmtMoney(by[c], c)}</b>`).join(" + ")
         : `<b>${DASH}</b>`;
     };
-    const verdicts = (label, tally) => {
+    // `judged` is how many of that side's fills carry a T+1 verdict; `total` is
+    // how many the window holds. Printing only `judged` would move the
+    // denominator without saying so, which is #737 in miniature.
+    const verdicts = (label, tally, total) => {
       const keys = Object.keys(tally || {});
       if (!keys.length) return "";
-      const n = keys.reduce((s, k) => s + tally[k], 0);
-      return `${label} <b>${n}</b>: ` + keys.sort().map(k =>
+      const judged = keys.reduce((s, k) => s + tally[k], 0);
+      const denom = total != null && total !== judged ? `<b>${judged}</b>/${total}` : `<b>${judged}</b>`;
+      return `${label} ${denom}: ` + keys.sort().map(k =>
         `<b class="${k === "卖对" || k === "涨" ? "pos" : k === "持平" ? "na" : "neg"}">${tally[k]}</b>${k}`).join(" / ");
     };
     const statsEl = document.getElementById("trace-stats");
     if (statsEl) {
       const v = sc.t1Verdicts || {};
       const align = sc.alignment || {};
-      const t1line = [verdicts("卖出", v.reduce), verdicts("买入", v.add)].filter(Boolean).join(" · ");
+      const sides = sc.t1Sides || {};
+      const t1line = [verdicts("卖出", v.reduce, sides.reduce), verdicts("买入", v.add, sides.add)]
+        .filter(Boolean).join(" · ");
       statsEl.innerHTML =
         `<span>本卡显示 <b>最近 ${shown}</b> 笔成交 <span class="muted">/ 全部 ${total} 笔</span></span>` +
         `<span>其中 <b>${sc.closedShown != null ? sc.closedShown : DASH}</b> 笔已平仓,已实现 ${money(realShown)} ` +
@@ -2836,10 +2842,12 @@
     list.forEach(t => { const k = (t.date || "").slice(0,10); (groups[k] = groups[k] || []).push(t); });
     const dates = Object.keys(groups).sort().reverse();
 
-    // The fill itself, in words — the one node that is never inferred.
+    // The fill itself, in words — the one node that is never inferred. shares
+    // and price come straight from portfolio.json, which the payload does not
+    // coerce, so they are escaped like any other untrusted string.
     function fillNode(t) {
       const sym = t.currency === "HKD" ? "HK$" : "$";
-      return `${esc(ACT[t.action] || t.action)} ${t.shares} 股 @ ${sym}${t.price}`;
+      return `${esc(ACT[t.action] || t.action)} ${esc(String(t.shares))} 股 @ ${sym}${esc(String(t.price))}`;
     }
 
     // What actually happened to the money on this row. Two different
@@ -2941,7 +2949,7 @@
                 <span class="tr-dot ${t.decision ? "has" : ""}" title="${t.decision ? "有当日计划记录" : "无当日计划记录"}"></span>
                 <span class="tr-tk">${esc(t.ticker)}</span>
                 <span class="tr-act ${tone}">${esc(ACT[t.action] || t.action)}</span>
-                <span class="tr-qty">${t.shares} @${t.price}</span>
+                <span class="tr-qty">${esc(String(t.shares))} @${esc(String(t.price))}</span>
                 <span class="tr-spacer"></span>
                 ${t1tag}
                 ${pnl}

--- a/site/index.html
+++ b/site/index.html
@@ -783,9 +783,9 @@ layout: null
     <div class="sect-divider">决策轨迹 · 真实成交 vs 当时计划</div>
 
     <div class="card" id="decision-traces-card">
-      <h3>决策轨迹 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">真实成交为轴 · 软配对决策(±3日)为「为什么」 · T+1 收盘判卖飞/卖对</span></h3>
-      <p class="chart-hint">每一笔成交是一条可点开的轨迹：当时计划(动作/信心/条件)、执行(是否遵守)、T+1 结果、已实现盈亏。无关联决策的成交显式标注——不假装有判断。币种分别计(HKD/USD 不混加)。</p>
-      <div id="trace-stats" style="display:flex;gap:24px;flex-wrap:wrap;margin:8px 0 12px;font-size:12px"></div>
+      <h3>决策轨迹 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">一笔真实成交 + 那几天写下的计划 + 官方收盘给的结果</span></h3>
+      <p class="chart-hint">点开一笔成交看四件事：<b>当时的计划</b>（同标的前后 3 天内的账本记录，没有就写明没有）、<b>真实成交</b>（并标出它与计划同向还是反向）、<b>T+1 收盘</b>（官方逐日行情，间隔超过 4 天的下一根不算 T+1）、<b>钱</b>（已平仓看本笔已实现金额，未平仓只有该持仓整体浮动 —— 两者不共用标签）。卡内统计只覆盖显示的这些成交，全期口径单独标注；港币美元分开计。</p>
+      <div id="trace-stats"></div>
       <div id="trace-list"></div>
     </div>
 

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -24,6 +24,8 @@ from zoneinfo import ZoneInfo
 # snapshots dir (e.g. 2026-05-16-saturday-baseline.json caused duplicate 5-16
 # rows in the equity curve before this filter was added).
 SNAPSHOT_FNAME_RE = re.compile(r'^\d{4}-\d{2}-\d{2}\.json$')
+# A session key inside a canonical bar document (memory/bars/<ticker>.json).
+SESSION_DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
 from clawock.workspace import workspace_root
 from clawock.portfolio import instruments as instrument_registry
@@ -620,72 +622,133 @@ def _canonical_ledger():
 
 
 def _day_num(iso):
-    """Day number for window arithmetic; None for unparsable values."""
+    """Calendar day ordinal for window arithmetic; None for unparsable values.
+
+    Must be a real day count, not a y*400+m*32+d packing: the packed form
+    silently shortens every window that crosses a month (by 32 − days-in-month)
+    and makes a year boundary unreachable — 2026-12-31 → 2027-01-01 packs to a
+    distance of 18, so a January fill could never pair with a late-December
+    plan. The DSH plugin's `dayGap` is calendar-correct; this is the same rule.
+    """
     if not isinstance(iso, str):
         return None
     m = re.match(r'^(\d{4})-(\d{2})-(\d{2})', iso)
     if not m:
         return None
-    return int(m[1]) * 400 + int(m[2]) * 32 + int(m[3])
+    try:
+        return date(int(m[1]), int(m[2]), int(m[3])).toordinal()
+    except ValueError:
+        return None
 
 
-def _future_close(prices_by_ticker, ticker, date_iso, n=1):
-    """First snapshot close at least n trading days after date_iso, or None."""
+# How far after a fill a close may sit and still be called T+1. A Friday fill
+# settles against Monday (3 calendar days); one intervening public holiday makes
+# 4. Beyond that it is a different horizon and must not wear the T+1 label.
+# Mirrors T1_MAX_GAP_DAYS in the DSH plugin (examples/dsh/.../src/ledger.ts).
+T1_MAX_GAP_DAYS = 4
+# Moves smaller than this read as noise, not as a verdict. Mirrors the plugin's
+# T1_FLAT_BAND_PCT. Tone and verdict share it so the coloured chip and the words
+# can never disagree about the same fill.
+T1_FLAT_BAND_PCT = 1
+# Actions that reduce a position — for these a rising close is bad news.
+T1_SELL_ACTIONS = ('sell', 'cut', 'trim', 'trim_on_rebound')
+
+
+def _t1_tone(action, delta):
+    """'win' | 'loss' | 'flat' reading of a T+1 move, action-aware, dead-zoned."""
+    if abs(delta) < T1_FLAT_BAND_PCT:
+        return 'flat'
+    up = delta > 0
+    if action in T1_SELL_ACTIONS:
+        return 'loss' if up else 'win'
+    return 'win' if up else 'loss'
+
+
+def _t1_verdict(action, delta):
+    """Verdict text for a T+1 move, on the same dead zone as `_t1_tone`."""
+    if abs(delta) < T1_FLAT_BAND_PCT:
+        return '持平'
+    up = delta > 0
+    if action in T1_SELL_ACTIONS:
+        return '卖飞' if up else '卖对'
+    return '涨' if up else '跌'
+
+
+def _future_close(prices_by_ticker, ticker, date_iso, n=1, max_gap_days=T1_MAX_GAP_DAYS):
+    """The n-th canonical close strictly after date_iso, or None.
+
+    The gap ceiling is load-bearing: the bar store has holes (holidays, a
+    retired ticker, a fill that predates coverage), so "the next close we
+    happen to own" can be months later. Without the ceiling those were being
+    rendered under a literal T+1 label.
+    """
     days = prices_by_ticker.get(ticker)
     if not days:
         return None
     base = _day_num(date_iso)
     if base is None:
         return None
-    later = sorted(d for d in days if _day_num(d) > base)
+    later = sorted(d for d in days if (_day_num(d) or 0) > base)
     if len(later) < n:
         return None
-    return later[n - 1], days[later[n - 1]]
+    hit = later[n - 1]
+    if (_day_num(hit) - base) > max_gap_days:
+        return None
+    return hit, days[hit]
 
 
-def _snapshot_close_index(workspace=None):
-    """{ticker: {date: current_price}} from memory/snapshots/*.json (all files,
-    not just the embedded window — T+1 verdicts need older closes too)."""
+def _bar_close_index(workspace=None, tickers=None):
+    """{ticker: {date: close}} from the canonical bar store memory/bars/*.json.
+
+    Deliberately NOT memory/snapshots/*.json. A snapshot is a *portfolio* file
+    whose `current_price` carries the vintage of whichever cron wrote it —
+    measured on 00100 across 15 snapshots it was the previous close 7 times,
+    that day's close 3 times and an intraday print 5 times — and the field is
+    carried forward after a position closes. Settlement migrated off snapshots
+    for exactly this reason; this view read them until #740, where 9 of the 40
+    published T+1 verdicts turned out to be wrong (SPCH 2026-06-18 showed
+    −10.64% against a real −40.33%). `bars.py` START_DATE was lowered to
+    2025-12-01 specifically so this view could mark fills against real closes.
+    """
     index = {}
     ws = workspace or WS_ROOT
-    paths = sorted(glob.glob(str(ws / 'memory' / 'snapshots' / '*.json')))
-    for p in paths:
-        name = os.path.basename(p)
-        if not SNAPSHOT_FNAME_RE.match(name):
+    wanted = None if tickers is None else {t for t in tickers if isinstance(t, str)}
+    for p in sorted(glob.glob(str(ws / 'memory' / 'bars' / '*.json'))):
+        ticker = os.path.basename(p)[:-len('.json')]
+        if wanted is not None and ticker not in wanted:
             continue
         d = load_json(p)
-        if not d:
+        if not isinstance(d, dict):
             continue
-        date_key = name.split('.')[0].split('-')
-        date_key = '-'.join(date_key[:3]) if len(date_key) >= 3 else name
-        for book in (d.get('portfolios') or {}).values():
-            if not isinstance(book, dict):
+        closes = {}
+        for day, bar in (d.get('bars') or {}).items():
+            if not isinstance(day, str) or not SESSION_DATE_RE.match(day):
                 continue
-            for h in (book.get('holdings') or []):
-                if not isinstance(h, dict):
-                    continue
-                tk = h.get('ticker')
-                price = h.get('current_price')
-                if isinstance(tk, str) and isinstance(price, (int, float)):
-                    index.setdefault(tk, {})[date_key] = price
+            close = bar.get('close') if isinstance(bar, dict) else None
+            if isinstance(close, (int, float)) and math.isfinite(close):
+                closes[day] = close
+        if closes:
+            index[ticker] = closes
     return index
 
 
 def build_decision_traces(limit=40, workspace=None):
     """The decision-trace view data: every real fill as a trace node with its
-    soft-paired decision (±3 days, same ticker) and T+1 close verdict.
+    soft-paired decision (±3 calendar days, same ticker) and T+1 close verdict.
 
     This is the organic "one view" the DSH plugin and this dashboard card both
     render: the spine is real fills (portfolio.json trades[]), the "why" layer
-    is the decision ledger, the result is the T+1 close (snapshot prices).
+    is the decision ledger, the result is the T+1 canonical close.
     Pure read — never mutates portfolio.json or the ledger.
     @param workspace - desk root; defaults to the module WS_ROOT (used by the
                        real build). Tests pass a synthetic temp dir.
-    @returns list of trace dicts, newest first, capped at `limit`.
+    @returns list of trace dicts, newest first, capped at `limit`. The card's
+             own totals must come from `build_decision_trace_scope`, never from
+             summing this window (#737).
     """
     ws = workspace or WS_ROOT
-    # Prices first (needed for T+1 verdicts).
-    prices = _snapshot_close_index(ws)
+    # Prices first (needed for T+1 verdicts). Canonical bars, never snapshots.
+    prices = _bar_close_index(ws)
     # Decision ledger by ticker+date (last row wins on same-key collisions).
     decisions = decision_v2.load_decisions(ws / 'memory' / 'decisions.jsonl')
     dec_by_key = {}
@@ -730,18 +793,19 @@ def build_decision_traces(limit=40, workspace=None):
                     'decision': None,
                     'holdPnl': None,
                 }
-                # T+1 verdict.
+                # T+1 verdict. `tone` ships with the verdict so the rendered
+                # chip cannot colour a move the words call 持平 (#739).
                 fc = _future_close(prices, ticker, t['date'], 1)
                 if fc and t.get('price'):
-                    delta = (fc[1] - t['price']) / t['price'] * 100
+                    delta = round((fc[1] - t['price']) / t['price'] * 100, 2)
                     t['t1'] = {
                         'date': fc[0],
                         'price': round(fc[1], 2),
-                        'delta': round(delta, 2),
-                        'verdict': ('卖飞' if delta > 1 else '卖对' if delta < -1 else '持平')
-                        if t['action'] == 'sell' else ('涨' if delta > 0 else '跌'),
+                        'delta': delta,
+                        'verdict': _t1_verdict(t['action'], delta),
+                        'tone': _t1_tone(t['action'], delta),
                     }
-                # Soft-pair the decision ledger (±3 days).
+                # Soft-pair the decision ledger (±3 calendar days).
                 base = _day_num(t['date'])
                 best = None
                 best_diff = 99
@@ -749,7 +813,10 @@ def build_decision_traces(limit=40, workspace=None):
                 for key, e in dec_by_key.items():
                     if not key.startswith(prefix):
                         continue
-                    diff = abs(_day_num(key[len(prefix):]) - base)
+                    plan_day = _day_num(key[len(prefix):])
+                    if plan_day is None or base is None:
+                        continue
+                    diff = abs(plan_day - base)
                     if diff <= 3 and diff < best_diff:
                         best = e
                         best_diff = diff
@@ -764,9 +831,7 @@ def build_decision_traces(limit=40, workspace=None):
                         'action': best.get('action'),
                         'confidence': best.get('confidence'),
                         'drivenBy': best.get('driven_by'),
-                        'rationale': (best.get('rationale')[:140] + '…')
-                        if isinstance(best.get('rationale'), str) and len(best.get('rationale')) > 140
-                        else (best.get('rationale') if isinstance(best.get('rationale'), str) else None),
+                        'rationale': _readable_rationale(best.get('rationale')),
                         'thesis': mind.get('thesis'),
                         'invalidation': mind.get('invalidation') if isinstance(mind.get('invalidation'), list) else [],
                         'bull': (mind.get('bull') or {}).get('summary'),
@@ -779,12 +844,124 @@ def build_decision_traces(limit=40, workspace=None):
                         'sizePct': size.get('pct'),
                         'plannedPrice': evaluation.get('execution_price') or best.get('simulated_entry_price'),
                         'source': best.get('source') or 'brief',
+                        # How the plan's direction relates to the fill that
+                        # actually happened. The ledger's own execution.status
+                        # is a plan self-report and answers a different
+                        # question, so it must not be rendered as if it graded
+                        # this fill (#738).
+                        'alignment': _plan_fill_alignment(best.get('action'), t['action']),
                     }
                 if ticker in held_pnl:
                     t['holdPnl'] = held_pnl[ticker]
                 traces.append(t)
     traces.sort(key=lambda t: (t.get('date') or ''), reverse=True)
     return traces[:limit]
+
+
+def _readable_rationale(text, cap=140):
+    """A rationale fit for a public card: internal breach ids stripped, then
+    truncated to the payload budget.
+
+    Raw rationales leak the risk engine's internals — "硬止损 -27.23% ≤ -18%
+    (breach risk-95ac7f6cd591 30d)" — into the one field a reader looks at to
+    understand *why*. The hash says nothing to anyone outside the process, and
+    it was eating the 140-char budget the real sentence needed (#738).
+    Truncation stays because the full text blew the 200KB dashboard cap.
+    """
+    if not isinstance(text, str):
+        return None
+    cleaned = re.sub(r'\s*\((?:breach\s+)?risk-[0-9a-f]{6,}(?:\s+\d+d)?\)', '', text)
+    cleaned = re.sub(r'[ \t]{2,}', ' ', cleaned).strip()
+    if not cleaned:
+        return None
+    return (cleaned[:cap] + '…') if len(cleaned) > cap else cleaned
+
+
+# Fill actions grouped by what they do to a position, so a plan can be compared
+# with the fill that followed it.
+_ADD_SIDE = ('buy', 'add')
+_REDUCE_SIDE = ('sell', 'cut', 'trim', 'trim_on_rebound')
+
+
+def _plan_fill_alignment(plan_action, fill_action):
+    """'same' | 'opposite' | 'other' — the plan's direction vs the fill's.
+
+    Not cosmetic: 39 of the 40 published traces had a plan action that differed
+    from the fill, and the card said nothing about it. "Plan said cut, I bought"
+    is the single most informative thing on this panel, so it ships as data
+    instead of being left for the reader to infer from two adjacent lines.
+    """
+    if not isinstance(plan_action, str) or not isinstance(fill_action, str):
+        return None
+    if plan_action == fill_action:
+        return 'same'
+    plan_side = 'add' if plan_action in _ADD_SIDE else 'reduce' if plan_action in _REDUCE_SIDE else None
+    fill_side = 'add' if fill_action in _ADD_SIDE else 'reduce' if fill_action in _REDUCE_SIDE else None
+    if plan_side is None or fill_side is None:
+        return 'other'
+    return 'same' if plan_side == fill_side else 'opposite'
+
+
+def build_decision_trace_scope(traces, workspace=None, limit=40):
+    """What the trace card is allowed to claim about itself.
+
+    The card used to sum its own 40-row window and print the result as an
+    unqualified 已实现 total: $926.3 against a real US $2,347.68 + HK$7,259.16,
+    and a flat "HK HK$0" while HK realized was HK$7,259.16 (#737). The window is
+    a window; the totals have to come from the whole fill ledger and be labelled
+    as such.
+    @param traces - the (already capped) trace list the card will render.
+    @returns dict of counts/totals, all with their denominators.
+    """
+    ws = workspace or WS_ROOT
+    pf_doc = load_json(str(ws / 'portfolio.json')) or {}
+    all_fills = 0
+    realized_all = {}
+    for leg in resolve_legs(pf_doc):
+        for h in (pf_doc.get('portfolios') or {}).get(leg.bucket, {}).get('holdings', []):
+            if not isinstance(h, dict):
+                continue
+            for tr in (h.get('trades') or []):
+                if not isinstance(tr, dict) or not isinstance(tr.get('date'), str):
+                    continue
+                all_fills += 1
+                if isinstance(tr.get('realized_pnl'), (int, float)):
+                    realized_all[leg.currency] = realized_all.get(leg.currency, 0) + tr['realized_pnl']
+    shown = list(traces or [])
+    realized_shown = {}
+    closed_shown = 0
+    for t in shown:
+        if isinstance(t.get('realizedPnl'), (int, float)):
+            closed_shown += 1
+            cur = t.get('currency')
+            realized_shown[cur] = realized_shown.get(cur, 0) + t['realizedPnl']
+    verdicts = {}
+    for t in shown:
+        v = (t.get('t1') or {}).get('verdict')
+        if v:
+            side = 'reduce' if t.get('action') in _REDUCE_SIDE else 'add'
+            verdicts.setdefault(side, {})
+            verdicts[side][v] = verdicts[side].get(v, 0) + 1
+    return {
+        'fillsTotal': all_fills,
+        'fillsShown': len(shown),
+        'limit': limit,
+        'closedShown': closed_shown,
+        'realizedAll': {k: round(v, 2) for k, v in realized_all.items()},
+        'realizedShown': {k: round(v, 2) for k, v in realized_shown.items()},
+        'pairedShown': sum(1 for t in shown if t.get('decision')),
+        'alignment': {
+            key: sum(1 for t in shown if (t.get('decision') or {}).get('alignment') == key)
+            for key in ('same', 'opposite', 'other')
+        },
+        # The mind/emotion layer the card advertises: 0 of 40 traces carried an
+        # emotion in production. Shipping the coverage number keeps the gap
+        # visible instead of silently rendering nothing (#738).
+        'emotionShown': sum(1 for t in shown if (t.get('decision') or {}).get('emotion')),
+        'mindShown': sum(1 for t in shown if (t.get('decision') or {}).get('thesis')),
+        't1Verdicts': verdicts,
+        't1Shown': sum(1 for t in shown if t.get('t1')),
+    }
 
 
 def load_snapshots():
@@ -2984,9 +3161,15 @@ def build_projection(previous_source=None, shadow_previous=None):
     out['decision_delta'] = decision_v2.decision_delta(_decisions)
     out['recent_decisions'] = decision_v2.recent_decisions(_decisions, limit=20)
     # Decision trace view: real fills as the spine with soft-paired decisions
-    # and T+1 verdicts. Same contract the DSH plugin renders; the dashboard
-    # card is the public mirror. Pure read of portfolio.json + ledger + snaps.
-    out['decision_traces'] = build_decision_traces(limit=40)
+    # and T+1 verdicts against canonical bars. The DSH plugin renders the same
+    # *contract* from its own TypeScript implementation — the two are not shared
+    # code, so the parity fixture in tests/test_decision_traces.py is what keeps
+    # them honest (#739). Pure read of portfolio.json + ledger + bars.
+    _traces = build_decision_traces(limit=40)
+    out['decision_traces'] = _traces
+    # The card's own totals. Never let it sum its 40-row window and print that
+    # as the ledger total (#737).
+    out['decision_trace_scope'] = build_decision_trace_scope(_traces, limit=40)
     out['debate_metrics'] = compute_debate_metrics()
     out['plan_timeline'] = compute_plan_timeline(plans, limit=15)
     out['weight_confidence'] = compute_weight_confidence(portfolio)

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -720,8 +720,15 @@ def _bar_close_index(workspace=None, tickers=None):
         d = load_json(p)
         if not isinstance(d, dict):
             continue
+        # `bars` must be a mapping. A list here (a hand-edited or
+        # half-migrated doc) would raise on .items() and take the whole
+        # dashboard build down with it — the plugin's reader type-guards for
+        # the same reason.
+        raw_bars = d.get('bars')
+        if not isinstance(raw_bars, dict):
+            continue
         closes = {}
-        for day, bar in (d.get('bars') or {}).items():
+        for day, bar in raw_bars.items():
             if not isinstance(day, str) or not SESSION_DATE_RE.match(day):
                 continue
             close = bar.get('close') if isinstance(bar, dict) else None
@@ -840,9 +847,15 @@ def build_decision_traces(limit=40, workspace=None):
                         'emotionNote': emotion.get('note'),
                         'execution': (best.get('execution') or {}).get('status'),
                         'condition': (best.get('condition') or {}).get('description'),
-                        'sizeShares': size.get('shares'),
-                        'sizePct': size.get('pct'),
-                        'plannedPrice': evaluation.get('execution_price') or best.get('simulated_entry_price'),
+                        # Coerced, because the renderer interpolates these into
+                        # HTML without escaping (they are numbers by contract).
+                        # A hand-written ledger row carrying a string here would
+                        # otherwise reach the page verbatim. The plugin's reader
+                        # runs them through Number() for the same reason.
+                        'sizeShares': _as_number(size.get('shares')),
+                        'sizePct': _as_number(size.get('pct')),
+                        'plannedPrice': _as_number(
+                            evaluation.get('execution_price') or best.get('simulated_entry_price')),
                         'source': best.get('source') or 'brief',
                         # How the plan's direction relates to the fill that
                         # actually happened. The ledger's own execution.status
@@ -856,6 +869,19 @@ def build_decision_traces(limit=40, workspace=None):
                 traces.append(t)
     traces.sort(key=lambda t: (t.get('date') or ''), reverse=True)
     return traces[:limit]
+
+
+def _as_number(value):
+    """`value` as a finite number, else None. Bools are not numbers here."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value if math.isfinite(value) else None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _readable_rationale(text, cap=140):
@@ -935,11 +961,17 @@ def build_decision_trace_scope(traces, workspace=None, limit=40):
             closed_shown += 1
             cur = t.get('currency')
             realized_shown[cur] = realized_shown.get(cur, 0) + t['realizedPnl']
+    # T+1 verdicts per side, plus how many fills that side actually has. A fill
+    # with no canonical close inside the window carries no verdict, so counting
+    # only the judged ones would quietly shrink the denominator — the same move
+    # #737 is about, one scale down (27 judged buys out of 28 in the window).
     verdicts = {}
+    sides = {}
     for t in shown:
+        side = 'reduce' if t.get('action') in _REDUCE_SIDE else 'add'
+        sides[side] = sides.get(side, 0) + 1
         v = (t.get('t1') or {}).get('verdict')
         if v:
-            side = 'reduce' if t.get('action') in _REDUCE_SIDE else 'add'
             verdicts.setdefault(side, {})
             verdicts[side][v] = verdicts[side].get(v, 0) + 1
     return {
@@ -960,6 +992,7 @@ def build_decision_trace_scope(traces, workspace=None, limit=40):
         'emotionShown': sum(1 for t in shown if (t.get('decision') or {}).get('emotion')),
         'mindShown': sum(1 for t in shown if (t.get('decision') or {}).get('thesis')),
         't1Verdicts': verdicts,
+        't1Sides': sides,
         't1Shown': sum(1 for t in shown if t.get('t1')),
     }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -602,6 +602,53 @@ async function testHeaderSharesTheContentColumn(browser, base) {
   }
 }
 
+// #736: the decision-trace summary row is a nowrap flex line whose min-content
+// is ~367px — wider than any phone — and .tr-row clips instead of scrolling, so
+// on a 390px iPhone the P&L number lost its last characters and at 320px it sat
+// entirely outside the row, together with the disclosure arrow. Measured, not
+// eyeballed: scrollWidth vs clientWidth on the summary, plus every child's right
+// edge against the row's.
+async function testTraceRowsFitPhoneWidths(browser, base) {
+  for (const width of [320, 360, 390, 414]) {
+    const page = await browser.newPage({ viewport: { width, height: 780 } });
+    await stubLiveOrigin(page);
+    await page.goto(base + "#reflect", { waitUntil: "domcontentloaded" });
+    await waitForTab(page, "reflect");
+    const m = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll("#trace-list .tr-row")];
+      if (!rows.length) return {rows: 0};
+      const overflow = [];
+      const outside = [];
+      for (const row of rows) {
+        const summary = row.querySelector("summary");
+        if (summary.scrollWidth > summary.clientWidth + 1) {
+          overflow.push(`${row.querySelector(".tr-tk")?.textContent}: ${summary.scrollWidth} > ${summary.clientWidth}`);
+        }
+        const right = row.getBoundingClientRect().right;
+        for (const child of summary.children) {
+          const box = child.getBoundingClientRect();
+          if (box.width > 0 && box.right > right + 1) {
+            outside.push(`${child.className} (${Math.round(box.right)} > ${Math.round(right)})`);
+          }
+        }
+      }
+      // The card exists at all only when the payload carries traces.
+      const card = document.getElementById("decision-traces-card");
+      return {rows: rows.length, overflow, outside, docWidth: document.documentElement.scrollWidth,
+              cardHidden: card ? card.style.display === "none" : true};
+    });
+    if (m.rows === 0) {
+      assert(m.cardHidden !== false, "the trace card is showing with no rows in it");
+      await page.close();
+      continue;
+    }
+    assert.deepEqual(m.overflow, [], `clipped trace summary rows at ${width}px`);
+    assert.deepEqual(m.outside, [], `trace summary children outside their row at ${width}px`);
+    assert(m.docWidth <= width, `the page scrolls horizontally at ${width}px (${m.docWidth})`);
+    await page.close();
+  }
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -618,6 +665,7 @@ async function main() {
     await testTabGuardWithoutForcedLayout(browser, base);
     await testTopbarFitsWhenRefreshLabelSwaps(browser, base);
     await testHeaderSharesTheContentColumn(browser, base);
+    await testTraceRowsFitPhoneWidths(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_decision_trace_parity.py
+++ b/tests/test_decision_trace_parity.py
@@ -1,0 +1,110 @@
+"""The decision-trace contract exists twice and is not shared code.
+
+`src/clawock/publish/dashboard.py::build_decision_traces` (Python, build time,
+published in dashboard.json) and `examples/dsh/packages/clawock-dsh/src/
+ledger.ts::readTraces` (TypeScript, read at runtime from the desk workspace)
+render the same view from the same desk files. Both call themselves "the same
+contract" in their own comments, and by 2026-08-17 they had drifted anyway:
+
+  - the plugin moved T+1 onto the canonical bar store; the dashboard was still
+    marking against snapshot `current_price` and got 9 of 40 verdicts wrong
+    (#740);
+  - the plugin shared one ±1% dead zone between the chip colour and the verdict
+    word; the dashboard coloured on `delta >= 0`, so three live rows showed a
+    red chip labelled 持平 (#739);
+  - the plugin capped the T+1 gap at 4 calendar days; the dashboard had no
+    ceiling at all;
+  - the plugin used real calendar arithmetic for the ±3-day pairing window; the
+    dashboard packed dates as y*400+m*32+d.
+
+This module pins the load-bearing rule constants and vocabulary on both sides so
+the next divergence fails a required check instead of shipping. Scope is honest:
+it reads the TypeScript source rather than executing it, so it catches a changed
+constant, threshold, action set or verdict word — not a behavioural rewrite. The
+end-to-end behaviour of each side is covered by its own suite
+(tests/test_decision_traces.py, tests/decision_studio_plugin.spec.js).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from clawock.publish import dashboard
+
+PLUGIN_LEDGER = (Path(__file__).resolve().parents[1] / "examples" / "dsh"
+                 / "packages" / "clawock-dsh" / "src" / "ledger.ts")
+
+
+@pytest.fixture(scope="module")
+def plugin_source():
+    assert PLUGIN_LEDGER.exists(), f"plugin ledger source missing: {PLUGIN_LEDGER}"
+    return PLUGIN_LEDGER.read_text(encoding="utf-8")
+
+
+def _const(source, name):
+    m = re.search(r'export const ' + re.escape(name) + r'\s*=\s*(-?\d+(?:\.\d+)?)', source)
+    assert m, f"{name} not found in {PLUGIN_LEDGER.name}"
+    return float(m[1])
+
+
+def test_t1_gap_ceiling_matches(plugin_source):
+    assert dashboard.T1_MAX_GAP_DAYS == _const(plugin_source, "T1_MAX_GAP_DAYS")
+
+
+def test_t1_flat_band_matches(plugin_source):
+    assert dashboard.T1_FLAT_BAND_PCT == _const(plugin_source, "T1_FLAT_BAND_PCT")
+
+
+def test_reducing_action_set_matches(plugin_source):
+    m = re.search(r"const SELL_ACTIONS = new Set\(\[([^\]]*)\]\)", plugin_source)
+    assert m, "SELL_ACTIONS not found in the plugin ledger"
+    plugin_actions = set(re.findall(r"'([^']+)'", m[1]))
+    assert plugin_actions == set(dashboard.T1_SELL_ACTIONS), (
+        "the two sides disagree about which actions reduce a position, so the "
+        "same fill would be coloured win on one and loss on the other")
+
+
+def test_verdict_vocabulary_matches(plugin_source):
+    """Same five words, same conditions — a fill may not be 卖飞 in the plugin
+    and 涨 on the dashboard."""
+    m = re.search(r"export function t1VerdictOf\(.*?\n\}", plugin_source, re.S)
+    assert m, "t1VerdictOf not found in the plugin ledger"
+    plugin_words = set(re.findall(r"'([^']+)'", m[0]))
+    ours = {dashboard._t1_verdict(a, d)
+            for a in ("buy", "sell") for d in (-5, -0.5, 0.5, 5)}
+    assert plugin_words == ours == {"卖飞", "卖对", "持平", "涨", "跌"}
+
+
+def test_pairing_window_matches(plugin_source):
+    """Both sides soft-pair on ±3 days of the fill."""
+    m = re.search(r"if \(diff <= (\d+) && diff < bestDiff\)", plugin_source)
+    assert m, "the plugin's pairing window is no longer recognisable"
+    plugin_window = int(m[1])
+    src = Path(dashboard.__file__).read_text(encoding="utf-8")
+    ours = re.search(r"if diff <= (\d+) and diff < best_diff:", src)
+    assert ours, "the dashboard's pairing window is no longer recognisable"
+    assert plugin_window == int(ours[1]) == 3
+
+
+def test_both_sides_read_the_canonical_bar_store(plugin_source):
+    """#740's root cause in one assertion: whichever side reaches for
+    memory/snapshots/ to settle a T+1 is the broken one."""
+    assert "memory" in plugin_source and "'bars'" in plugin_source
+    src = Path(dashboard.__file__).read_text(encoding="utf-8")
+    builder = src[src.index("def build_decision_traces("):src.index("def _readable_rationale(")]
+    assert "_bar_close_index" in builder
+    # The quoted path component, so prose about snapshots stays allowed while
+    # any attempt to build a memory/snapshots path here fails.
+    assert "'snapshots'" not in builder and '"snapshots"' not in builder, (
+        "build_decision_traces must not settle T+1 against snapshot prices")
+    assert "_snapshot_close_index" not in builder
+
+
+def test_verdict_and_tone_agree_on_every_side_of_the_dead_zone():
+    """The invariant that failed live: a move the words call 持平 must not be
+    coloured, and a coloured move must not be called 持平."""
+    for action in ("buy", "add", "sell", "cut", "trim", "trim_on_rebound"):
+        for delta in (-9, -1.0001, -1, -0.999, 0, 0.999, 1, 1.0001, 9):
+            verdict = dashboard._t1_verdict(action, delta)
+            tone = dashboard._t1_tone(action, delta)
+            assert (verdict == "持平") == (tone == "flat"), (action, delta, verdict, tone)

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -2,9 +2,16 @@
 the DSH plugin's decision-trace view.
 
 Synthetic workspace under a temp dir; WS_ROOT is monkeypatched so no real desk
-data, snapshots or network are touched. Verifies the trace contract: real fills
-as the spine, soft-paired decisions (±3 days, same ticker) as the "why" layer,
-T+1 close verdicts, and no cross-currency mixing in the realized figures.
+data, bars or network are touched. Verifies the trace contract: real fills as
+the spine, soft-paired decisions (±3 calendar days, same ticker) as the "why"
+layer, T+1 verdicts against canonical bars, and no cross-currency mixing in the
+realized figures.
+
+The fixture writes `memory/snapshots/` prices that DISAGREE with
+`memory/bars/` on purpose. That disagreement is the anti-inert assertion for
+#740: if this view ever slides back onto snapshot `current_price`, the deltas
+move and `test_t1_marks_against_canonical_bars_not_snapshots` goes red instead
+of the regression shipping quietly.
 """
 import json
 import os
@@ -72,9 +79,24 @@ def ws(tmp_path, monkeypatch):
     (tmp_path / "memory" / "decisions.jsonl").write_text(
         "".join(json.dumps(d, ensure_ascii=False) + "\n" for d in decisions),
         encoding="utf-8")
-    # Snapshots: 08-14 (T+1 for the 08-13 sell) and 08-15.
-    for day, prices in [("2026-08-14", {"PLTU": 49.24, "SPCH": 9.0, "00100": 330.0}),
-                        ("2026-08-15", {"PLTU": 49.0, "SPCH": 9.1, "00100": 329.0})]:
+    # Canonical bars — the price source this view settles against.
+    bars = {
+        "PLTU": {"2026-08-14": 49.24, "2026-08-15": 49.0},
+        # 08-05 is the T+1 close for the 08-04 HK fill; 00100 keeps trading.
+        "00100": {"2026-08-05": 230.0, "2026-08-14": 330.0, "2026-08-15": 329.0},
+        # SPCH deliberately has NO close after its 2026-08-15 fill.
+        "SPCH": {"2026-08-13": 8.5},
+    }
+    (tmp_path / "memory" / "bars").mkdir(parents=True)
+    for ticker, closes in bars.items():
+        (tmp_path / "memory" / "bars" / f"{ticker}.json").write_text(json.dumps({
+            "schema_version": 1, "ticker": ticker,
+            "bars": {d: {"open": c, "high": c, "low": c, "close": c} for d, c in closes.items()},
+        }), encoding="utf-8")
+    # Snapshots with contradicting prices. Nothing may read these (#740) — they
+    # exist so a silent regression back onto snapshot current_price is visible.
+    for day, prices in [("2026-08-14", {"PLTU": 60.0, "SPCH": 20.0, "00100": 500.0}),
+                        ("2026-08-15", {"PLTU": 61.0, "SPCH": 21.0, "00100": 501.0})]:
         snap = {"portfolios": {"us_stocks": {"holdings": [
             {"ticker": k, "current_price": v} for k, v in prices.items()]}}}
         (tmp_path / "memory" / "snapshots" / f"{day}.json").write_text(
@@ -131,7 +153,7 @@ def test_conversation_mind_record_pairs_with_its_trade(ws):
     assert hk["decision"]["bull"] == "营收 +159%"
 
 
-def test_no_t1_when_snapshot_missing(ws):
+def test_no_t1_when_canonical_close_missing(ws):
     """The 08-15 SPCH buy has no close after it → t1 stays absent, not fake."""
     traces = dashboard.build_decision_traces()
     spch = next(t for t in traces if t["ticker"] == "SPCH")
@@ -152,3 +174,148 @@ def test_hold_pnl_attached_for_still_held_tickers(ws):
     traces = dashboard.build_decision_traces()
     spch = next(t for t in traces if t["ticker"] == "SPCH")
     assert spch["holdPnl"] == -28.0
+
+
+def test_t1_marks_against_canonical_bars_not_snapshots(ws):
+    """#740: this view settled T+1 against snapshot `current_price`, the field
+    settlement had already disowned — 9 of 40 published verdicts were wrong.
+
+    The fixture's snapshots say PLTU closed at 60.0 on 08-14; the canonical bar
+    says 49.24. Marking the 50.0 sell against the snapshot would read +20%
+    (卖飞); against the bar it is -1.52% (卖对). Asserting the *number* is what
+    makes this gate non-inert: it fails if the source ever slides back.
+    """
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["t1"]["price"] == 49.24, "T+1 price must come from memory/bars"
+    assert pltu["t1"]["delta"] == -1.52
+    assert pltu["t1"]["verdict"] == "卖对"
+
+
+def test_t1_refuses_a_close_beyond_the_gap_ceiling(ws, tmp_path):
+    """A close far after the fill is a different horizon and must not wear the
+    T+1 label. Mirrors the plugin's T1_MAX_GAP_DAYS = 4."""
+    bars = tmp_path / "memory" / "bars" / "PLTU.json"
+    doc = json.loads(bars.read_text())
+    # Only close left for the 08-13 sell is 11 days later.
+    doc["bars"] = {"2026-08-24": {"open": 60.0, "high": 60.0, "low": 60.0, "close": 60.0}}
+    bars.write_text(json.dumps(doc), encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["t1"] is None, "an 11-day-later close is not T+1"
+
+
+def test_t1_accepts_a_weekend_gap(ws, tmp_path):
+    """Friday fill settling against Monday is 3 calendar days — still T+1."""
+    bars = tmp_path / "memory" / "bars" / "PLTU.json"
+    doc = json.loads(bars.read_text())
+    doc["bars"] = {"2026-08-16": {"open": 55.0, "high": 55.0, "low": 55.0, "close": 55.0}}
+    bars.write_text(json.dumps(doc), encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["t1"] is not None and pltu["t1"]["date"] == "2026-08-16"
+
+
+def test_t1_tone_and_verdict_share_one_dead_zone(ws):
+    """#739: the card coloured the chip on `delta >= 0` while the words used a
+    ±1% dead zone, so a sell at +0.5% rendered a red chip labelled 持平 — three
+    such rows were live. Tone ships with the verdict from one rule."""
+    assert dashboard._t1_verdict("sell", 0.5) == "持平"
+    assert dashboard._t1_tone("sell", 0.5) == "flat", "a 持平 move may not be coloured"
+    assert dashboard._t1_verdict("sell", 2.0) == "卖飞"
+    assert dashboard._t1_tone("sell", 2.0) == "loss"
+    assert dashboard._t1_verdict("buy", 2.0) == "涨"
+    assert dashboard._t1_tone("buy", 2.0) == "win"
+    # A reducing action other than plain "sell" follows the sell rule too: the
+    # old renderer only special-cased `sell` and coloured cut/trim gains green.
+    for reducing in ("cut", "trim", "trim_on_rebound"):
+        assert dashboard._t1_tone(reducing, 3.0) == "loss", reducing
+        assert dashboard._t1_verdict(reducing, 3.0) == "卖飞", reducing
+
+
+def test_pairing_window_is_calendar_days_across_a_year_boundary():
+    """#739: the window used y*400+m*32+d, which puts 2026-12-31 and
+    2027-01-01 eighteen "days" apart — a January fill could never pair with a
+    late-December plan, and every cross-month window was quietly short."""
+    assert dashboard._day_num("2027-01-01") - dashboard._day_num("2026-12-31") == 1
+    assert dashboard._day_num("2026-08-01") - dashboard._day_num("2026-07-29") == 3
+    assert dashboard._day_num("2026-03-01") - dashboard._day_num("2026-02-27") == 2
+    assert dashboard._day_num("not-a-date") is None
+    assert dashboard._day_num("2026-02-30") is None, "an impossible date is not a day"
+
+
+def test_year_boundary_plan_pairs_with_january_fill(tmp_path, monkeypatch):
+    """The same defect, end to end: a 12-31 plan and a 01-02 fill are 2 days
+    apart and must soft-pair."""
+    (tmp_path / "memory").mkdir()
+    (tmp_path / "portfolio.json").write_text(json.dumps({"portfolios": {"us_stocks": {
+        "currency": "USD", "holdings": [{"ticker": "NVDA", "shares": 1, "trades": [
+            {"date": "2027-01-02", "action": "buy", "shares": 1, "price": 100.0}]}]}}}),
+        encoding="utf-8")
+    (tmp_path / "memory" / "decisions.jsonl").write_text(json.dumps({
+        "decision_id": "dec-y", "plan_date": "2026-12-31", "ticker": "NVDA",
+        "action": "buy", "confidence": 0.7, "driven_by": "technical"},
+        ensure_ascii=False) + "\n", encoding="utf-8")
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    traces = dashboard.build_decision_traces()
+    assert traces[0]["decision"] is not None, "12-31 plan must pair with a 01-02 fill"
+    assert traces[0]["decision"]["planDate"] == "2026-12-31"
+
+
+def test_rationale_strips_internal_breach_ids(ws, tmp_path):
+    """#738: the public card printed "(breach risk-66a236e9b7e1 30d)" — an
+    internal hash that means nothing to a reader and ate the 140-char budget."""
+    line = json.loads((tmp_path / "memory" / "decisions.jsonl").read_text().splitlines()[1])
+    line["rationale"] = ("76.69% single_name超限 mandatory cap 35% "
+                         "(breach risk-66a236e9b7e1 30d) + 硬止损 -27.23% ≤ -18% "
+                         "(breach risk-95ac7f6cd591 30d) 一次性 cut 200 shares")
+    lines = (tmp_path / "memory" / "decisions.jsonl").read_text().splitlines()
+    lines[1] = json.dumps(line, ensure_ascii=False)
+    (tmp_path / "memory" / "decisions.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    rationale = spch["decision"]["rationale"]
+    assert "risk-" not in rationale and "breach" not in rationale
+    assert "一次性 cut 200 shares" in rationale, "the real sentence must survive"
+
+
+def test_alignment_states_the_plan_vs_fill_relation(ws):
+    """#738: 39 of 40 published rows had a plan action that differed from the
+    fill and the card said nothing. The relation ships as data."""
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    assert spch["decision"]["alignment"] == "opposite", "planned cut, actually bought"
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["decision"]["alignment"] == "same", "planned trim, actually sold"
+    hk = next(t for t in traces if t["ticker"] == "00100")
+    assert hk["decision"]["alignment"] == "other", "a reject plan points at neither side"
+
+
+def test_scope_totals_come_from_the_whole_ledger_not_the_window(ws):
+    """#737: the card summed its own window and printed the result as an
+    unqualified 已实现 total — $926.3 while the ledger held US $2,347.68 +
+    HK$7,259.16, and a flat "HK HK$0" while HK realized was HK$7,259.16."""
+    traces = dashboard.build_decision_traces(limit=2)
+    scope = dashboard.build_decision_trace_scope(traces, limit=2)
+    assert scope["fillsShown"] == 2
+    assert scope["fillsTotal"] == 4, "the denominator is the whole fill ledger"
+    # The window (newest 2 fills) holds no closed HK fill; the ledger holds the
+    # HKD leg either way, so a reader can never mistake the window for the total.
+    assert scope["realizedShown"] == {"USD": 45.21}
+    assert scope["realizedAll"] == {"USD": 45.21}
+    assert scope["closedShown"] == 1
+
+
+def test_scope_keeps_currencies_apart_and_counts_carry_denominators(ws):
+    traces = dashboard.build_decision_traces()
+    scope = dashboard.build_decision_trace_scope(traces)
+    assert scope["fillsShown"] == scope["fillsTotal"] == 4
+    assert scope["pairedShown"] == 4, "all four fills fall inside a plan window"
+    # The 08-08 PLTU buy also lands in the 08-10 trim plan's window, so it
+    # counts as a reversal too: planned to reduce, actually added.
+    assert scope["alignment"] == {"same": 1, "opposite": 2, "other": 1}
+    # Mind/emotion coverage is published even when it is bad news: production
+    # ran 0/40 while the card advertised an emotion layer (#738).
+    assert scope["emotionShown"] == 1 and scope["mindShown"] == 1
+    assert set(scope["t1Verdicts"]) <= {"reduce", "add"}
+    assert sum(scope["t1Verdicts"]["reduce"].values()) == 1

--- a/tests/test_decision_traces.py
+++ b/tests/test_decision_traces.py
@@ -319,3 +319,63 @@ def test_scope_keeps_currencies_apart_and_counts_carry_denominators(ws):
     assert scope["emotionShown"] == 1 and scope["mindShown"] == 1
     assert set(scope["t1Verdicts"]) <= {"reduce", "add"}
     assert sum(scope["t1Verdicts"]["reduce"].values()) == 1
+
+
+def test_malformed_bar_document_cannot_take_the_build_down(ws, tmp_path):
+    """`bars` as a list (a hand-edited or half-migrated doc) used to raise
+    AttributeError on .items() and fail the whole dashboard build."""
+    (tmp_path / "memory" / "bars" / "PLTU.json").write_text(
+        json.dumps({"bars": [{"date": "2026-08-14", "close": 49.24}]}), encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["t1"] is None, "an unreadable bar doc yields no verdict, not a crash"
+
+
+def test_bar_closes_reject_non_finite_and_non_numeric(ws, tmp_path):
+    (tmp_path / "memory" / "bars" / "PLTU.json").write_text(json.dumps({"bars": {
+        "2026-08-14": {"close": "49.24"},          # string
+        "2026-08-15": {"close": None},             # null
+        "2026-08-16": {"open": 1.0},               # no close at all
+        "not-a-date": {"close": 50.0},             # not a session key
+    }}), encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    pltu = next(t for t in traces if t["ticker"] == "PLTU" and t["date"] == "2026-08-13")
+    assert pltu["t1"] is None
+
+
+def test_scope_publishes_the_side_totals_behind_the_verdict_counts(ws, tmp_path):
+    """A fill with no canonical close carries no verdict. Counting only the
+    judged ones would move the denominator silently — #737 one scale down."""
+    traces = dashboard.build_decision_traces()
+    scope = dashboard.build_decision_trace_scope(traces)
+    # 3 buys in the window, only 1 judged: SPCH's 08-15 buy has no later close
+    # at all, and PLTU's 08-08 buy is 6 days from the next one — past the T+1
+    # ceiling. The card must show 1/3, not a bare 1.
+    assert scope["t1Sides"]["add"] == 3
+    assert sum(scope["t1Verdicts"]["add"].values()) == 1
+    assert scope["t1Sides"]["reduce"] == 1
+
+
+def test_numeric_decision_fields_are_coerced(ws, tmp_path):
+    """These are interpolated into HTML unescaped by contract, so a string in
+    the ledger must not reach the page verbatim."""
+    lines = (tmp_path / "memory" / "decisions.jsonl").read_text().splitlines()
+    row = json.loads(lines[1])
+    row["size"] = {"shares": "200<script>", "pct": "0.8"}
+    row["evaluation"] = {"execution_price": "9.21"}
+    lines[1] = json.dumps(row, ensure_ascii=False)
+    (tmp_path / "memory" / "decisions.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    traces = dashboard.build_decision_traces()
+    spch = next(t for t in traces if t["ticker"] == "SPCH")
+    assert spch["decision"]["sizeShares"] is None, "unparsable shares must not pass through"
+    assert spch["decision"]["sizePct"] == 0.8
+    assert spch["decision"]["plannedPrice"] == 9.21
+
+
+def test_rationale_keeps_text_that_only_looks_like_a_breach_id(ws, tmp_path):
+    """The strip must not over-reach into ordinary prose."""
+    assert dashboard._readable_rationale("risk-off 情绪 (breach risk-abc123def456 30d)") == "risk-off 情绪"
+    assert dashboard._readable_rationale("(risk-taking 有上限)") == "(risk-taking 有上限)"
+    assert dashboard._readable_rationale("(breach risk-abc123def456 30d)") is None
+    assert dashboard._readable_rationale(None) is None
+    assert dashboard._readable_rationale(12) is None

--- a/tests/test_validate_sidecars.py
+++ b/tests/test_validate_sidecars.py
@@ -21,8 +21,23 @@ EOD_FIELDS = (
 
 
 def write_json(path: Path, payload) -> Path:
+    """Re-serialize a payload the way the publisher does.
+
+    `json.dumps` defaults — `ensure_ascii=True` plus `", "`/`": "` separators —
+    inflated this desk's payload by 16% (27,916 bytes on 2026-08-17), because
+    every Chinese character became a 6-byte `\\uXXXX` escape. The dashboard size
+    cap is checked against the file on disk, so the gate was measuring that
+    inflated copy: it fired at an effective ~172KB while the published payload
+    was 174,658 bytes and 25KB clear of its 200,000-byte cap. The mismatch went
+    unnoticed until the payload grew enough for the escape penalty alone to
+    cross the line, at which point nine tests in this module went red on data
+    commits nobody had touched. Match `serialize_dashboard_payload` so the
+    number the gate measures is the number that ships — in both directions: an
+    over-cap payload must still be able to red this suite.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload), encoding='utf-8')
+    path.write_text(json.dumps(payload, ensure_ascii=False, separators=(',', ':')),
+                    encoding='utf-8')
     return path
 
 


### PR DESCRIPTION
修 Reflect 面板「决策轨迹」卡的五个缺陷。起因是 kcn 报「mobile 展示不完全收缩」+「那一块描述看不太懂」,
查的过程里又挖出两个更硬的(#740 数据源、#739 漂移)。

Closes #736, #737, #738, #739, #740.

## #740 T+1 判定读的是已被弃用的 snapshot current_price(最严重)

`_snapshot_close_index()` 读 `memory/snapshots/*.json` 的 `current_price` —— 结算路径早就弃用了这个字段。
两处仓库内记录本来就指着这件事:插件 `readBarCloses()` 的注释(00100 实测 15 个快照里 7 次前收 /
3 次当日收 / 5 次盘中价,清仓后 carry forward,NVDA 冻在 213 五个交易日),以及
`bars.py:64-71` —— `START_DATE` 当初就是**为这张卡**下调到 2025-12-01 的。插件迁过去了,这条 Python 路留在原地。

按官方逐日行情重算当前 40 行:**9 行判词直接翻转**,28 行 delta 偏差 >0.5pt。

| ticker | 成交日 | snapshot(线上) | canonical bars |
|---|---|---|---|
| SPCH | 06-18 buy | −10.64% | **−40.33%** |
| SPCH | 06-19 buy | −9.01% | **−26.75%** |
| SPCH | 06-15 sell | 0.00% 持平 | **+24.59% 卖飞** |
| RKLB | 06-13 sell | 0.00% 持平 | **+9.06% 卖飞** |
| SPCH | 07-13 buy | +2.60% 涨 | **−4.90% 跌** |
| PLTU | 08-13 sell | −1.52% 卖对 | **+1.12% 卖飞** |

改成读 `memory/bars/<ticker>.json` 的 `bars[date].close`(新 `_bar_close_index`,ticker 过路径白名单)。

**反空转断言**:`tests/test_decision_traces.py` 的 fixture 现在故意让 `memory/snapshots/` 与
`memory/bars/` 的价格**互相矛盾**(snapshot 说 PLTU 60.0,bar 说 49.24),测试断言取到的是 49.24 /
delta −1.52 / 卖对。把 `_bar_close_index` 换回 snapshot 索引跑一遍,测试确实变红(`assert 60.0 == 49.24`)——
不是靠注释保证的。

## #739 两套手写实现已经漂移

kcn 问「是公用逻辑吗和 plugin 的」——**不是**。dashboard 是构建期 Python(`build_decision_traces`,
产物进 `dashboard.json`),插件是运行期 TypeScript(`src/ledger.ts::readTraces`);渲染、CSS、行结构也各一套。
两边注释互称 "same contract",但没有任何测试约束过。实测四处漂移:

1. **T+1 色调 vs 判词打架(线上 3 行)**:`t1Cls()` 用无死区的 `delta >= 0`,判词用 ±1% 死区 →
   卖出且 0~1% 时**红色 chip 上写着「持平」**。插件早已把两者收敛到 `t1ToneOf`/`t1VerdictOf`。
   现在 `tone` 由 Python 随 `verdict` 一起下发,前端只读不算。
2. **缺最大间隔上限**:插件有 `T1_MAX_GAP_DAYS = 4`,这边没有 —— 停牌/清仓后重现的 ticker 会被贴上「T+1」。已补齐。
3. **`_day_num` 不是真日历**:`y*400+m*32+d` 让跨月窗口偷偷变短(7月 +1、2月 +4),
   跨年 `2026-12-31 → 2027-01-01` 算出 **18 天**,January 的成交永远配不上 12 月底的计划。改真日历序数。
   (当前 100 笔上两种算法差异 0 条 —— 潜伏,跨年必炸。)
4. **只特判了 `sell`**:`cut`/`trim`/`trim_on_rebound` 走了买入的着色规则。

新增 `tests/test_decision_trace_parity.py`:钉住两边共用的 `T1_MAX_GAP_DAYS`、`T1_FLAT_BAND_PCT`、
减仓动作集、五个判词、±3 窗口,以及「谁去读 snapshots 谁就是错的那一边」。
**范围说明(诚实)**:它读 TypeScript 源文本、不执行它 —— 能抓常量/阈值/动作集/判词表被改单边,
抓不到行为级重写。改了常数验证过会红。同时改掉插件 README 里「插件与网页同一份加工逻辑」这句不实描述。

## #737 统计行把 40 笔窗口合计当成总账

线上写的是 `已实现 $926.3 USD等值 (US $926.3 + HK HK$0)`。真实全期 **US$2,347.68 + HK$7,259.16** ——
卡上的数只有 28%,而 `HK HK$0` 的读法是假的(40 笔窗口里恰好没有港股平仓)。
`T+1 4卖飞/4卖对` 也丢掉了第三桶(4持平)和全部 28 笔买入(18跌/10涨);`挂接 39/40` 是内部词。

新增 `build_decision_trace_scope()` 下发带分母的范围口径,抬头改成:

```
本卡显示 最近 40 笔成交 / 全部 100 笔
其中 12 笔已平仓,已实现 $926.3 (全期 $2,348 + HK$7,259,不只这 40 笔)
T+1 卖出 12: 4卖对 / 8卖飞 · 买入 27: 8涨 / 19跌
有当日计划 39/40,其中 22 笔与计划反向 · 带心智/情绪 0/40
```

## #738 文案表错意(kcn 的「看不太懂」)

不是文案粗糙,是标签指错了对象:

- **「执行:未执行 — 实际动了手」贴在一笔已成交的交易上**。`execution.status` 是**那条计划的自评**,
  不是这笔成交的执行结果(8 条 `followed` 里计划动作照样和成交动作不同)。降级为「账本自评」小标签,
  原位置换成**「真实成交」+ 与计划同向/反向**的显式判定(新增 `alignment` 字段;真实数据 **22/40 反向**,
  典型是「风控让割肉 200 股、实际买入 10 股」—— 这张卡最有信息量的一件事,此前一个字都没说)。
- **「盈亏」一个标签装两种东西**:12 行是本笔已实现金额,30 行是**整个持仓的浮动百分比**。
  拆成「本笔已实现」/「该持仓当前浮动(SPCH 全仓,非本笔)」;折叠行的百分比加「持仓」前缀。
- **rationale 吐内部 id**:`(breach risk-66a236e9b7e1 30d)` 清掉(同时把 140 字预算让给真正的句子)。
- **情绪层 0/40**:覆盖率进统计行,而不是只在文案里承诺一个线上不存在的东西。
- 抬头/hint 全部改人话(「软配对决策(±3日)为『为什么』」这类黑话下架)。

## #736 手机端裁剪

`summary` 是 nowrap flex,7 个子元素 + gap + padding 让 **min-content 恒为 367px**(与 viewport 无关),
而 `.tr-row { overflow: hidden }` 是裁而不滚。实测:

| viewport | scrollWidth vs 可用宽 | `.tr-pnl` 右边界 vs 行右边界 |
|---|---|---|
| 390 | 367 vs 322(溢出 45px) | 386 vs 357 → 尾部被切,显示成 `-28` |
| 320 | 367 vs 252(溢出 115px) | 386 vs 287 → **整个数字在行外**,展开箭头一并消失 |

≤520px 改成显式两行 grid(每个子元素各占一格,箭头独占一列):第一行 dot+ticker+动作+盈亏+箭头,
第二行 数量 + T+1 chip。修复后 320/360/390 全部 `scrollWidth == clientWidth`、无子元素越界、页面不横向滚动;
桌面(768/1280)行结构不变。

`tests/dashboard_tab_runtime.spec.js` 新增 320/360/390/414 的浏览器断言(summary 溢出 + 每个子元素右边界 +
文档不横向滚动)。把 media query 断点改成 0px 验证过会红。

## 验证

- `pytest tests/ -q` → **2199 passed, 5 skipped, 4 xfailed**(worktree 内跑,`CLAWOCK_WORKSPACE` 已 unset)
- `node tests/dashboard_tab_runtime.spec.js` → 全绿(含新增手机断言),跑的是本地真实构建产物
- payload:`+1,707` bytes,构建后 174,655 / 200,000 上限
- 两个新闸都做过反向验证(见上),不是空转

---

## 附带修掉一个挡路的 pre-existing 红:#743

第一次跑 CI,`validate` 红在 `202,592 bytes exceeds the 200,000-byte full dashboard cap`,
带着 9 个跟大小毫无关系的测试(对账/代次/现金口径)。查下来**不是本 PR 造成的**:
把所有代码改动撤掉、只留 `origin/master` @ `0f5b8d9a`(纯数据提交)也一样红,`200,584 bytes`。

根因是这个闸量错了对象:`validate_dashboard` 读磁盘文件大小,而
`tests/test_validate_sidecars.py::write_json` 用 `json.dumps(payload)` 默认参数重写 payload
—— `ensure_ascii=True` 把每个汉字写成 6 字节 `\uXXXX`,这份满是中文的 payload 被虚增
**27,916 字节(+16.0%)**:发布口径 **174,658**,测试口径 **202,574**。
也就是说这个闸的实际阈值是 **~172KB 而不是 200KB**,今天的数据刚好涨过那条虚线。
master 一路绿是因为跑单测的 step 只在 `pull_request` 上跑,push 到 master 不跑。

已附带修掉(`write_json` 按 `serialize_dashboard_payload` 的口径序列化),两个方向都验过:
121/121 绿;塞 60KB 真实 UTF-8 内容(不靠转义放大)后断言照样触发
`234,670 bytes exceeds the 200,000-byte full dashboard cap` —— 不是把闸关掉。

本 PR 自己的 payload 增量:`+1,707` bytes(174,658 / 200,000,余量 25KB)。
