### PR TITLE
fix(dsh-plugin): 决策轨迹插件侧文案表意与外溢对齐 —— 执行/盈亏/挂接口径、alignment 平权 (#741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,14 +329,18 @@ dsh plugin --profile web add clawock-dsh
 
 The **Decision Mind** tab is one view, not three tabs: the spine is your real
 fills (`portfolio.json` trades), each row carries the soft-paired decision
-(±3 days from `decisions.jsonl`) as the "why", and the T+1 snapshot close
-decides 卖飞/卖对 on sells. Click a fill and the trace unfolds — plan →
-execution → T+1 → P&L — with the rationale and note in semantic colors, plus
-an emotion-pressure field on the small number of records that logged one so
-far. Fills with no decision say so explicitly, instead of making one up.
-Currency is never mixed: USD and HKD stay apart and only combine through the
-desk's published FX rate. The same trace data powers the public dashboard's
-Reflect card, so the plugin and the website render one contract:
+(±3 days from `decisions.jsonl`) as the "why", and the T+1 verdict comes from
+the canonical `memory/bars/` close inside the T+1 window (never a snapshot
+price) — 卖飞/卖对 on reduces, 涨/跌 on adds, 持平 in the dead zone. Click a
+fill and the trace unfolds — plan → real fill (stated 与计划同向/反向, with
+`execution.status` preserved only as the plan's own 账本自评 label) → T+1 →
+P&L (本笔已实现 and 该持仓当前浮动 never share one label) — with the
+rationale and note in semantic colors, plus an emotion-pressure field on the
+small number of records that logged one so far. Fills with no plan say so
+explicitly, instead of making one up. Currency is never mixed: USD and HKD
+stay apart and only combine through the desk's published FX rate. The same
+trace data powers the public dashboard's Reflect card, but the two sides are
+separate implementations pinned together by `tests/test_decision_trace_parity.py`:
 
 <p align="center"><img src="https://raw.githubusercontent.com/KCNyu/clawock/refs/heads/master/site/assets/dsh-decision-mind.png" alt="Decision Mind plugin — decision traces: real fills with soft-paired decisions and T+1 verdicts, expandable to a plan → execution → result timeline" width="860"></p>
 

--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -90,17 +90,22 @@ agent:准备请求…(clawock run prepare)
 一件事:**每一笔真实成交,都是一条可以点开的决策轨迹**。
 
 - **主轴是真实成交**(portfolio.json trades[]),不是计划流水。每行 =
-  标的 + 动作 + 数量@价 + **盈亏焦点数字**,副行是 **T+1 判定**
-  (快照收盘价对比成交价:卖飞/卖对)+ 日期。
-- **点开一条轨迹**:GitHub 式纵向时间线 —— 当时计划(动作/信心/驱动 +
-  条件/计划股数/计划价)→ 执行(是否遵守)→ T+1 结果 → 盈亏(已实现
-  或持仓现值)。为什么(rationale)/情绪压力(非 calm 才显示)/备注
-  用语义色左边框分层。
-- **没有决策的成交显式标注**「无关联决策记录」—— 不假装有判断。
-  SPCH 那种「计划 cut 却持续买入摊本」的纪律偏差,一条轨迹看得明明白白。
+  标的 + 动作 + 数量@价 + **盈亏焦点数字**,副行是 **T+1 判定**(官方
+  逐日行情的 T+1 收盘对比成交价,`memory/bars/`,绝不读快照
+  `current_price`;未判出显式写「T+1 未判」,不假装没这回事)+ 日期。
+- **点开一条轨迹**:GitHub 式纵向时间线 —— 当时的计划(动作/股数@计划价/
+  信心/驱动)→ **真实成交**(与计划同向/反向,`execution.status` 只是计划
+  自己的「账本自评」小标签,不冒充这笔成交的执行结果)→ T+1 收盘 →
+  **本笔已实现** / **该持仓当前浮动(非本笔)**,两个量永不共用一个
+  「盈亏」标签。为什么(rationale,内部 breach id 已剥)/情绪压力(非 calm
+  才显示)/备注用语义色左边框分层。
+- **没有当日计划的成交显式标注**—— 不假装有判断:真实数据里过半成交
+  找不到前后 3 天的同标的计划,这本身就是信息。SPCH 那种「计划 cut 却
+  持续买入摊本」的纪律偏差,一条轨迹看得明明白白。
 - **抬头统计**:已实现盈亏(USD/HKD 分别计、折算 USD 等值,绝不混加)、
-  T+1 卖飞/卖对计数、决策挂接率;过滤:全部 / 无决策 / 卖出复盘 /
-  挂接决策。
+  T+1 卖飞/卖对(判出 X/Y 笔卖出,分母是卖出侧而非全部成交)、
+  有当日计划 m/n(反向 N 笔);过滤:全部 / 无当日计划 / 卖出复盘 /
+  有当日计划。
 
 对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
 ... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,
@@ -110,10 +115,6 @@ bear 与失效条件强制,情绪自认)。面板不改任何文件,结算仍归
 TypeScript(`src/ledger.ts::readTraces`),网页是构建期算好塞进 `dashboard.json`
 的 Python。两边不共享代码,曾经因此漂移到判词都不一致(#739/#740),
 现在由 `tests/test_decision_trace_parity.py` 钉住共用的规则常量与判词表。结构:
-
-对话判定落账:`clawock record --subject ... --action ... --bull ... --bear
-... --invalidation ... --emotion ...`(schema 见 `docs/decision-mind-ledger.md`,
-bear 与失效条件强制,情绪自认)。面板不改任何文件,结算仍归既有机制。结构:
 
 ```
 clawock-dsh
@@ -187,7 +188,7 @@ harness-agnostic 定位的一部分——同一份契约,OpenClaw skill / Claude
    ```
 3. 侧栏点进一个真实 session,等加载完,点顶部 `Decision Mind` tab。**tab 栏
    和 DSH 顶栏必须留在截图里**——那正是「这是插件 tab、不是独立页」的证据。
-4. 展开一笔有完整决策轨迹(计划→执行→T+1→盈亏)的真实成交:
+4. 展开一笔有完整决策轨迹(计划→真实成交→T+1→盈亏)的真实成交:
    ```python
    cell = page.locator('[data-cell=trace]', has_text='TICKER').first
    cell.scroll_into_view_if_needed(); cell.click()

--- a/examples/dsh/packages/clawock-dsh/lib/client.js
+++ b/examples/dsh/packages/clawock-dsh/lib/client.js
@@ -4557,7 +4557,7 @@ const TYPERT_REMOTE = {
 };
 //#endregion
 //#region \0dsh-css:src/styles.module.css.mjs
-const css = ".SPgITW_dmt{--bg:#f7f8fa;--surface:#fff;--text:#15171b;--text2:#61666b;--text3:#81858c;--cap:#adb2b8;--brand:#4176e6;--brand-soft:#edf3fe;--ok:#1b8644;--ok-soft:#e6faed;--bad:#c01313;--bad-soft:#fdebee;--warn:#aa6924;--border:#1118270f;--border2:#1118271a;--hover:#1118270d;--shadow-sm:0 1px 2px #1018280a;--shadow-md:0 4px 16px #10182814;--veil:#ffffffeb;--tint-soft:#00000008;--tint-border:#0000000d;--tint-mid:#00000014;--tint-strong:#0000001f;--brand-glow:#4176e61f;--t1-up-border:#1b84442e;--t1-down-border:#c013132e;--radius:12px;--radius-sm:8px;--font:-apple-system,BlinkMacSystemFont,\"Segoe UI\",\"PingFang SC\",\"Hiragino Sans GB\",\"Microsoft YaHei\",sans-serif;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font:13px/1.45 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;min-height:100%}body[data-ds-dark-theme] .SPgITW_dmt{--bg:#0f1115;--surface:#1b1b1c;--text:#ededee;--text2:#a7abb2;--text3:#7d8189;--cap:#5b5f66;--brand:#6c97f2;--brand-soft:#1e2a44;--ok:#3fcb74;--ok-soft:#153824;--bad:#f2554f;--bad-soft:#3b1516;--warn:#e0a752;--border:#ffffff14;--border2:#ffffff24;--hover:#ffffff12;--shadow-sm:0 1px 2px #0000004d;--shadow-md:0 4px 16px #0006;--veil:#141518d9;--tint-soft:#ffffff0f;--tint-border:#ffffff14;--tint-mid:#ffffff1f;--tint-strong:#ffffff2e;--brand-glow:#6c97f238;--t1-up-border:#3fcb7459;--t1-down-border:#f2554f59}.SPgITW_dmt .SPgITW_top{z-index:20;background:var(--veil);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);padding:10px 16px 8px;position:sticky;top:0}.SPgITW_dmt .SPgITW_tt{font:700 17px/1.3 var(--font);letter-spacing:-.01em;align-items:center;gap:8px;display:flex}.SPgITW_dmt .SPgITW_tt:before{content:\"\";background:var(--brand);border-radius:3px;width:9px;height:9px}.SPgITW_dmt .SPgITW_ts{font:400 11.5px/1.3 var(--font);color:var(--cap);margin-top:2px}.SPgITW_dmt .SPgITW_stats{flex-wrap:wrap;align-items:flex-end;gap:0;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_sg{flex-direction:column;gap:2px;padding:0 14px;display:flex}.SPgITW_dmt .SPgITW_sg+.SPgITW_sg{border-left:1px solid #00000014}.SPgITW_dmt .SPgITW_sl{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.03em;white-space:nowrap}.SPgITW_dmt .SPgITW_sv{font:650 14px/1.3 var(--font);color:var(--text);font-variant-numeric:tabular-nums;white-space:nowrap}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font:700 16px/1.3 var(--font)}.SPgITW_dmt .SPgITW_sv.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_sv.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_rate{font:400 10.5px/1.3 var(--font);color:var(--cap);align-self:center;margin-left:auto}.SPgITW_dmt .SPgITW_filters{flex-wrap:wrap;gap:2px;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_ft{color:var(--text3);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border:0;border-radius:8px;padding:5px 11px;transition:background .12s,color .12s}.SPgITW_dmt .SPgITW_ft:hover{background:var(--hover)}.SPgITW_dmt .SPgITW_ft.SPgITW_on{color:var(--text);background:#1118270f}.SPgITW_dmt .SPgITW_list{max-width:760px;margin:0 auto;padding:10px 16px 32px}.SPgITW_dmt .SPgITW_day{font:650 13px/1.3 var(--font);color:var(--text);align-items:center;gap:8px;margin:16px 0 2px;display:flex}.SPgITW_dmt .SPgITW_day .SPgITW_n{color:var(--cap);font:400 10.5px/1.3 var(--mono);margin-left:auto}.SPgITW_dmt .SPgITW_day:after{content:\"\";background:var(--border);flex:1;height:1px;margin-left:6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold{cursor:pointer;border-radius:8px;margin-left:-6px;padding:2px 6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold:hover{background:var(--hover)}.SPgITW_dmt .SPgITW_day.SPgITW_fold .SPgITW_chev{text-align:center;flex:none;width:14px;margin-left:0}.SPgITW_dmt .SPgITW_cell{border:1px solid var(--border);background:var(--surface);cursor:pointer;width:100%;box-shadow:var(--shadow-sm);border-radius:12px;margin:7px 0;transition:box-shadow .15s,border-color .15s}.SPgITW_dmt .SPgITW_cell:hover{border-color:var(--border2);box-shadow:var(--shadow-md)}.SPgITW_dmt .SPgITW_cell.SPgITW_open{border-color:var(--brand);box-shadow:0 0 0 3px #4176e61f}.SPgITW_dmt .SPgITW_main{align-items:center;gap:12px;padding:13px 14px 6px;display:flex}.SPgITW_dmt .SPgITW_dotm{background:var(--cap);border-radius:50%;flex:none;width:6px;height:6px;margin-right:2px}.SPgITW_dmt .SPgITW_cell.SPgITW_hasdec .SPgITW_dotm{background:var(--brand)}.SPgITW_dmt .SPgITW_tk{min-width:0;font:650 14.5px/1.4 var(--font);letter-spacing:-.01em;text-overflow:ellipsis;white-space:nowrap;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_mkt{font:700 9.5px/1 var(--font);vertical-align:2px;color:var(--brand);margin-left:3px}.SPgITW_dmt .SPgITW_mkt.SPgITW_hk{color:var(--text3)}.SPgITW_dmt .SPgITW_tag{border:1px solid var(--tint-border);background:var(--tint-soft);height:20px;font:600 11.5px/1 var(--font);color:var(--text2);letter-spacing:.02em;border-radius:6px;flex:none;align-items:center;padding:0 7px;display:inline-flex}.SPgITW_dmt .SPgITW_qty{text-align:right;min-width:0;font:500 12.5px/1.4 var(--mono);color:var(--text2);font-variant-numeric:tabular-nums;white-space:nowrap;text-overflow:ellipsis;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_sp{flex:auto;min-width:8px}.SPgITW_dmt .SPgITW_pnl{text-align:right;min-width:92px;font:700 16.5px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;flex:none}.SPgITW_dmt .SPgITW_pnl.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_pnl.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_pnl.SPgITW_na{color:var(--cap);font-size:13px;font-weight:500}.SPgITW_dmt .SPgITW_sub{font:400 11px/1.4 var(--font);color:var(--cap);align-items:center;gap:10px;padding:3px 14px 11px;display:flex}.SPgITW_dmt .SPgITW_t1{height:18px;font:600 10.5px/1 var(--font);white-space:nowrap;font-variant-numeric:tabular-nums;border-radius:5px;flex:none;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_t1.SPgITW_up{color:var(--ok);background:var(--ok-soft);border:1px solid var(--t1-up-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_down{color:var(--bad);background:var(--bad-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_flat{color:var(--text2);background:var(--tint-soft)}.SPgITW_dmt .SPgITW_sub .SPgITW_date{font-variant-numeric:tabular-nums;flex:none}.SPgITW_dmt .SPgITW_chev{color:var(--cap);flex:none;margin-left:auto;font-size:10px;transition:transform .15s}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_chev{transform:rotate(180deg)}.SPgITW_dmt .SPgITW_detail{opacity:0;border-top:1px solid var(--tint-border);grid-template-rows:0fr;transition:grid-template-rows .24s cubic-bezier(.22,1,.36,1),opacity .15s;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{opacity:1;grid-template-rows:1fr}.SPgITW_dmt .SPgITW_dinner{min-height:0;padding:12px 16px 14px;overflow:hidden}.SPgITW_dmt .SPgITW_trhead{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.05em;align-items:center;gap:6px;margin-bottom:8px;display:flex}.SPgITW_dmt .SPgITW_trhead:before{content:\"\";background:var(--brand);border-radius:50%;width:6px;height:6px}.SPgITW_dmt .SPgITW_trace{padding-left:22px;position:relative}.SPgITW_dmt .SPgITW_trace:before{content:\"\";background:var(--tint-mid);width:2px;position:absolute;top:12px;bottom:10px;left:5px}.SPgITW_dmt .SPgITW_tnode{padding:2px 0 14px;position:relative}.SPgITW_dmt .SPgITW_tnode:last-child{padding-bottom:2px}.SPgITW_dmt .SPgITW_tnode:before{content:\"\";background:var(--surface);border:2px solid var(--cap);box-sizing:border-box;border-radius:50%;width:10px;height:10px;position:absolute;top:5px;left:-22px}.SPgITW_dmt .SPgITW_tnode.SPgITW_dec:before{border-color:var(--brand)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip:before{border-color:var(--warn)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss:before{border-color:var(--bad)}.SPgITW_dmt .SPgITW_tnode .SPgITW_tw{font:400 10px/1.4 var(--mono);color:var(--cap);margin-bottom:1px}.SPgITW_dmt .SPgITW_tnode .SPgITW_n{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.04em;margin-bottom:2px}.SPgITW_dmt .SPgITW_tnode .SPgITW_v{font:600 13px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss .SPgITW_v{color:var(--bad)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip .SPgITW_v{color:var(--warn)}.SPgITW_dmt .SPgITW_pchips{flex-wrap:wrap;gap:6px;margin:4px 0 8px;display:flex}.SPgITW_dmt .SPgITW_pc{font:400 11px/1.4 var(--font);background:var(--tint-soft);border:1px solid var(--border);color:var(--text2);border-radius:6px;padding:2px 8px}.SPgITW_dmt .SPgITW_tnote{border-left:3px solid var(--tint-strong);font:400 11.5px/1.6 var(--font);color:var(--text2);white-space:pre-wrap;overflow-wrap:anywhere;margin:7px 0;padding:3px 0 3px 10px}.SPgITW_dmt .SPgITW_tnote.SPgITW_why{border-left-color:var(--brand)}.SPgITW_dmt .SPgITW_tnote.SPgITW_emo{border-left-color:var(--warn)}.SPgITW_dmt .SPgITW_tnote .SPgITW_k{color:var(--cap);font:600 10.5px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tmiss{border:1px dashed var(--border2);font:400 11.5px/1.5 var(--font);color:var(--cap);border-radius:6px;margin-top:8px;padding:7px 10px}.SPgITW_dmt .SPgITW_empty{text-align:center;color:var(--cap);font:400 13px/1.5 var(--font);padding:48px 20px}.SPgITW_dmt .SPgITW_trace-more{border:1px dashed var(--border2);background:var(--surface);width:calc(100% - 32px);color:var(--text2);font:600 12px/1.4 var(--font);cursor:pointer;border-radius:10px;margin:10px 16px;padding:9px 12px;transition:background .12s,border-color .12s,color .12s;display:block}.SPgITW_dmt .SPgITW_trace-more:hover{background:var(--hover);border-color:var(--brand);color:var(--text)}.SPgITW_dmt .SPgITW_skel{border:1px solid var(--border);background:var(--surface);border-radius:12px;align-items:center;gap:12px;margin:7px 0;padding:13px 16px;display:flex}.SPgITW_dmt .SPgITW_skel-dot{background:var(--tint-strong);border-radius:50%;flex:none;width:6px;height:6px}.SPgITW_dmt .SPgITW_skel-bar{background:var(--tint-mid);border-radius:5px;height:10px}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w40{width:40%}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w20{width:20%}@media (width<=520px){.SPgITW_dmt .SPgITW_main{gap:8px;padding:12px 12px 6px}.SPgITW_dmt .SPgITW_tk{font-size:13.5px}.SPgITW_dmt .SPgITW_qty{text-align:left;font-size:11px}.SPgITW_dmt .SPgITW_pnl{min-width:84px;font-size:14.5px}.SPgITW_dmt .SPgITW_sub{gap:8px;padding:3px 12px 10px}.SPgITW_dmt .SPgITW_sg{padding:0 11px}.SPgITW_dmt .SPgITW_sv{font-size:13px}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font-size:14.5px}}@media (prefers-reduced-motion:reduce){.SPgITW_dmt *{transition:none!important;animation:none!important}}";
+const css = ".SPgITW_dmt{--bg:#f7f8fa;--surface:#fff;--text:#15171b;--text2:#61666b;--text3:#81858c;--cap:#adb2b8;--brand:#4176e6;--brand-soft:#edf3fe;--ok:#1b8644;--ok-soft:#e6faed;--bad:#c01313;--bad-soft:#fdebee;--warn:#aa6924;--border:#1118270f;--border2:#1118271a;--hover:#1118270d;--shadow-sm:0 1px 2px #1018280a;--shadow-md:0 4px 16px #10182814;--veil:#ffffffeb;--tint-soft:#00000008;--tint-border:#0000000d;--tint-mid:#00000014;--tint-strong:#0000001f;--brand-glow:#4176e61f;--t1-up-border:#1b84442e;--t1-down-border:#c013132e;--radius:12px;--radius-sm:8px;--font:-apple-system,BlinkMacSystemFont,\"Segoe UI\",\"PingFang SC\",\"Hiragino Sans GB\",\"Microsoft YaHei\",sans-serif;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font:13px/1.45 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;min-height:100%}body[data-ds-dark-theme] .SPgITW_dmt{--bg:#0f1115;--surface:#1b1b1c;--text:#ededee;--text2:#a7abb2;--text3:#7d8189;--cap:#5b5f66;--brand:#6c97f2;--brand-soft:#1e2a44;--ok:#3fcb74;--ok-soft:#153824;--bad:#f2554f;--bad-soft:#3b1516;--warn:#e0a752;--border:#ffffff14;--border2:#ffffff24;--hover:#ffffff12;--shadow-sm:0 1px 2px #0000004d;--shadow-md:0 4px 16px #0006;--veil:#141518d9;--tint-soft:#ffffff0f;--tint-border:#ffffff14;--tint-mid:#ffffff1f;--tint-strong:#ffffff2e;--brand-glow:#6c97f238;--t1-up-border:#3fcb7459;--t1-down-border:#f2554f59}.SPgITW_dmt .SPgITW_top{z-index:20;background:var(--veil);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);padding:10px 16px 8px;position:sticky;top:0}.SPgITW_dmt .SPgITW_tt{font:700 17px/1.3 var(--font);letter-spacing:-.01em;align-items:center;gap:8px;display:flex}.SPgITW_dmt .SPgITW_tt:before{content:\"\";background:var(--brand);border-radius:3px;width:9px;height:9px}.SPgITW_dmt .SPgITW_ts{font:400 11.5px/1.3 var(--font);color:var(--cap);margin-top:2px}.SPgITW_dmt .SPgITW_stats{flex-wrap:wrap;align-items:flex-end;gap:0;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_sg{flex-direction:column;gap:2px;padding:0 14px;display:flex}.SPgITW_dmt .SPgITW_sg+.SPgITW_sg{border-left:1px solid #00000014}.SPgITW_dmt .SPgITW_sl{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.03em;white-space:nowrap}.SPgITW_dmt .SPgITW_sv{font:650 14px/1.3 var(--font);color:var(--text);font-variant-numeric:tabular-nums;white-space:nowrap}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font:700 16px/1.3 var(--font)}.SPgITW_dmt .SPgITW_sv.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_sv.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_rate{font:400 10.5px/1.3 var(--font);color:var(--cap);align-self:center;margin-left:auto}.SPgITW_dmt .SPgITW_filters{flex-wrap:wrap;gap:2px;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_ft{color:var(--text3);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border:0;border-radius:8px;padding:5px 11px;transition:background .12s,color .12s}.SPgITW_dmt .SPgITW_ft:hover{background:var(--hover)}.SPgITW_dmt .SPgITW_ft.SPgITW_on{color:var(--text);background:#1118270f}.SPgITW_dmt .SPgITW_list{max-width:760px;margin:0 auto;padding:10px 16px 32px}.SPgITW_dmt .SPgITW_day{font:650 13px/1.3 var(--font);color:var(--text);align-items:center;gap:8px;margin:16px 0 2px;display:flex}.SPgITW_dmt .SPgITW_day .SPgITW_n{color:var(--cap);font:400 10.5px/1.3 var(--mono);margin-left:auto}.SPgITW_dmt .SPgITW_day:after{content:\"\";background:var(--border);flex:1;height:1px;margin-left:6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold{cursor:pointer;border-radius:8px;margin-left:-6px;padding:2px 6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold:hover{background:var(--hover)}.SPgITW_dmt .SPgITW_day.SPgITW_fold .SPgITW_chev{text-align:center;flex:none;width:14px;margin-left:0}.SPgITW_dmt .SPgITW_cell{border:1px solid var(--border);background:var(--surface);cursor:pointer;width:100%;box-shadow:var(--shadow-sm);border-radius:12px;margin:7px 0;transition:box-shadow .15s,border-color .15s}.SPgITW_dmt .SPgITW_cell:hover{border-color:var(--border2);box-shadow:var(--shadow-md)}.SPgITW_dmt .SPgITW_cell.SPgITW_open{border-color:var(--brand);box-shadow:0 0 0 3px #4176e61f}.SPgITW_dmt .SPgITW_main{align-items:center;gap:12px;padding:13px 14px 6px;display:flex}.SPgITW_dmt .SPgITW_dotm{background:var(--cap);border-radius:50%;flex:none;width:6px;height:6px;margin-right:2px}.SPgITW_dmt .SPgITW_cell.SPgITW_hasdec .SPgITW_dotm{background:var(--brand)}.SPgITW_dmt .SPgITW_tk{min-width:0;font:650 14.5px/1.4 var(--font);letter-spacing:-.01em;text-overflow:ellipsis;white-space:nowrap;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_mkt{font:700 9.5px/1 var(--font);vertical-align:2px;color:var(--brand);margin-left:3px}.SPgITW_dmt .SPgITW_mkt.SPgITW_hk{color:var(--text3)}.SPgITW_dmt .SPgITW_tag{border:1px solid var(--tint-border);background:var(--tint-soft);height:20px;font:600 11.5px/1 var(--font);color:var(--text2);letter-spacing:.02em;border-radius:6px;flex:none;align-items:center;padding:0 7px;display:inline-flex}.SPgITW_dmt .SPgITW_qty{text-align:right;min-width:0;font:500 12.5px/1.4 var(--mono);color:var(--text2);font-variant-numeric:tabular-nums;white-space:nowrap;text-overflow:ellipsis;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_sp{flex:auto;min-width:8px}.SPgITW_dmt .SPgITW_pnl{text-align:right;min-width:92px;font:700 16.5px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;flex:none}.SPgITW_dmt .SPgITW_pnl.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_pnl.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_pnl.SPgITW_na{color:var(--cap);font-size:13px;font-weight:500}.SPgITW_dmt .SPgITW_pnlk{font:600 10.5px/1.2 var(--font);color:var(--cap);letter-spacing:0;margin-right:3px}.SPgITW_dmt .SPgITW_sub{font:400 11px/1.4 var(--font);color:var(--cap);align-items:center;gap:10px;padding:3px 14px 11px;display:flex}.SPgITW_dmt .SPgITW_t1{height:18px;font:600 10.5px/1 var(--font);white-space:nowrap;font-variant-numeric:tabular-nums;border-radius:5px;flex:none;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_t1.SPgITW_up{color:var(--ok);background:var(--ok-soft);border:1px solid var(--t1-up-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_down{color:var(--bad);background:var(--bad-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_flat{color:var(--text2);background:var(--tint-soft)}.SPgITW_dmt .SPgITW_sub .SPgITW_date{font-variant-numeric:tabular-nums;flex:none}.SPgITW_dmt .SPgITW_chev{color:var(--cap);flex:none;margin-left:auto;font-size:10px;transition:transform .15s}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_chev{transform:rotate(180deg)}.SPgITW_dmt .SPgITW_detail{opacity:0;border-top:1px solid var(--tint-border);grid-template-rows:0fr;transition:grid-template-rows .24s cubic-bezier(.22,1,.36,1),opacity .15s;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{opacity:1;grid-template-rows:1fr}.SPgITW_dmt .SPgITW_dinner{min-height:0;padding:12px 16px 14px;overflow:hidden}.SPgITW_dmt .SPgITW_trhead{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.05em;align-items:center;gap:6px;margin-bottom:8px;display:flex}.SPgITW_dmt .SPgITW_trhead:before{content:\"\";background:var(--brand);border-radius:50%;width:6px;height:6px}.SPgITW_dmt .SPgITW_trace{padding-left:22px;position:relative}.SPgITW_dmt .SPgITW_trace:before{content:\"\";background:var(--tint-mid);width:2px;position:absolute;top:12px;bottom:10px;left:5px}.SPgITW_dmt .SPgITW_tnode{padding:2px 0 14px;position:relative}.SPgITW_dmt .SPgITW_tnode:last-child{padding-bottom:2px}.SPgITW_dmt .SPgITW_tnode:before{content:\"\";background:var(--surface);border:2px solid var(--cap);box-sizing:border-box;border-radius:50%;width:10px;height:10px;position:absolute;top:5px;left:-22px}.SPgITW_dmt .SPgITW_tnode.SPgITW_dec:before{border-color:var(--brand)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip:before{border-color:var(--warn)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss:before{border-color:var(--bad)}.SPgITW_dmt .SPgITW_tnode .SPgITW_tw{font:400 10px/1.4 var(--mono);color:var(--cap);margin-bottom:1px}.SPgITW_dmt .SPgITW_tnode .SPgITW_n{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.04em;margin-bottom:2px}.SPgITW_dmt .SPgITW_tnode .SPgITW_v{font:600 13px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss .SPgITW_v{color:var(--bad)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip .SPgITW_v{color:var(--warn)}.SPgITW_dmt .SPgITW_pchips{flex-wrap:wrap;gap:6px;margin:4px 0 8px;display:flex}.SPgITW_dmt .SPgITW_pc{font:400 11px/1.4 var(--font);background:var(--tint-soft);border:1px solid var(--border);color:var(--text2);border-radius:6px;padding:2px 8px}.SPgITW_dmt .SPgITW_tnote{border-left:3px solid var(--tint-strong);font:400 11.5px/1.6 var(--font);color:var(--text2);white-space:pre-wrap;overflow-wrap:anywhere;margin:7px 0;padding:3px 0 3px 10px}.SPgITW_dmt .SPgITW_tnote.SPgITW_why{border-left-color:var(--brand)}.SPgITW_dmt .SPgITW_tnote.SPgITW_emo{border-left-color:var(--warn)}.SPgITW_dmt .SPgITW_tnote .SPgITW_k{color:var(--cap);font:600 10.5px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tmiss{border:1px dashed var(--border2);font:400 11.5px/1.5 var(--font);color:var(--cap);border-radius:6px;margin-top:8px;padding:7px 10px}.SPgITW_dmt .SPgITW_empty{text-align:center;color:var(--cap);font:400 13px/1.5 var(--font);padding:48px 20px}.SPgITW_dmt .SPgITW_trace-more{border:1px dashed var(--border2);background:var(--surface);width:calc(100% - 32px);color:var(--text2);font:600 12px/1.4 var(--font);cursor:pointer;border-radius:10px;margin:10px 16px;padding:9px 12px;transition:background .12s,border-color .12s,color .12s;display:block}.SPgITW_dmt .SPgITW_trace-more:hover{background:var(--hover);border-color:var(--brand);color:var(--text)}.SPgITW_dmt .SPgITW_skel{border:1px solid var(--border);background:var(--surface);border-radius:12px;align-items:center;gap:12px;margin:7px 0;padding:13px 16px;display:flex}.SPgITW_dmt .SPgITW_skel-dot{background:var(--tint-strong);border-radius:50%;flex:none;width:6px;height:6px}.SPgITW_dmt .SPgITW_skel-bar{background:var(--tint-mid);border-radius:5px;height:10px}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w40{width:40%}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w20{width:20%}@media (width<=520px){.SPgITW_dmt .SPgITW_main{gap:8px;padding:12px 12px 6px}.SPgITW_dmt .SPgITW_tk{font-size:13.5px}.SPgITW_dmt .SPgITW_qty{text-align:left;font-size:11px}.SPgITW_dmt .SPgITW_pnl{min-width:84px;font-size:14.5px}.SPgITW_dmt .SPgITW_sub{gap:8px;padding:3px 12px 10px}.SPgITW_dmt .SPgITW_sg{padding:0 11px}.SPgITW_dmt .SPgITW_sv{font-size:13px}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font-size:14.5px}}@media (prefers-reduced-motion:reduce){.SPgITW_dmt *{transition:none!important;animation:none!important}}";
 const tagId = "clawock-dsh/styles.module.css";
 if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
 	const tag = document.createElement("style");
@@ -4599,6 +4599,7 @@ var styles_module_css_default = {
 	"pc": "SPgITW_pc",
 	"pchips": "SPgITW_pchips",
 	"pnl": "SPgITW_pnl",
+	"pnlk": "SPgITW_pnlk",
 	"qty": "SPgITW_qty",
 	"rate": "SPgITW_rate",
 	"sg": "SPgITW_sg",
@@ -4638,8 +4639,9 @@ var styles_module_css_default = {
 *
 * One organic view — the decision trace: real fills as the spine, the shared
 * decision ledger (memory/decisions.jsonl) soft-paired (±3 days) as the "why"
-* layer, and snapshot closes as the T+1 verdict. Fills without a decision say
-* so explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
+* layer, and canonical bar closes (memory/bars/, never snapshot current_price
+* — see readBarCloses) as the T+1 verdict. Fills without a decision say so
+* explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
 * figure as the focal number and a GitHub-style vertical timeline in the
 * expandable detail.
 *
@@ -4726,10 +4728,26 @@ const DRV = {
 	mixed: "混合",
 	risk_rule: "风控规则"
 };
+/**
+* The ledger's `execution.status`, in words.
+*
+* This grades the PLAN — "was this plan followed" — and it is not a statement
+* about the fill on the row, which happened either way. Rendering 「未执行」 as
+* that row's 执行 verdict read as a flat contradiction on a completed buy, and
+* on live data 8 rows said 已遵守 while the plan's action still differed from
+* the fill's. So it renders as 账本自评 and never as the fill's own status; the
+* plan-vs-fill relation is `decision.alignment` below.
+*/
 const EXE = {
-	followed: ["已遵守", "follow"],
-	not_followed: ["未执行", "skip"],
-	unknown: ["未知", ""]
+	followed: "遵守了计划",
+	not_followed: "没按计划",
+	unknown: "未标注"
+};
+/** The plan-vs-fill relation, stated instead of left to be inferred. */
+const ALIGN = {
+	same: ["与计划同向", "follow"],
+	opposite: ["与计划反向", "skip"],
+	other: ["计划未指向买卖", ""]
 };
 const EMO = {
 	fomo: "追高冲动",
@@ -4742,9 +4760,9 @@ const EMO = {
 };
 const FILTER_LABEL = {
 	all: "全部",
-	miss: "无决策",
+	miss: "无当日计划",
 	sold: "卖出复盘",
-	dec: "挂接决策"
+	dec: "有当日计划"
 };
 function esc(value) {
 	return String(value === null || value === void 0 ? "" : value).replace(/</g, "&lt;");
@@ -4787,7 +4805,8 @@ function _displayEntry(trace) {
 		note: trace.note ?? null,
 		t1: trace.t1 ?? null,
 		holdPnl: trace.holdPnl ?? null,
-		decision: trace.decision ?? null
+		decision: trace.decision ?? null,
+		side: trace.side === "reduce" || trace.side === "add" ? trace.side : null
 	};
 }
 function Chip(props) {
@@ -4797,64 +4816,65 @@ function TraceDetail(props) {
 	const trace = props.trace;
 	const decision = trace.decision;
 	const sym = trace.currency === "HKD" ? "HK$" : "$";
+	const fillText = (ACT[trace.action] ?? trace.action) + " " + trace.shares + " 股 @ " + sym + trace.price;
 	if (decision === null) {
-		const t1miss = trace.t1 === null ? null : h("div", { className: cx("tnode", t1NodeClass(trace.t1.tone)) }, h("div", { className: cx("n") }, "T+1 结果"), h("div", { className: cx("v") }, (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "%"));
-		return h("div", null, h("div", { className: cx("trhead") }, "决策轨迹 · 无关联记录"), h("div", { className: cx("trace") }, h("div", { className: cx("tnode", "dec") }, h("div", { className: cx("n") }, "决策"), h("div", {
+		const t1miss = trace.t1 === null ? null : h("div", { className: cx("tnode", t1NodeClass(trace.t1.tone)) }, h("div", { className: cx("tw") }, trace.t1.date), h("div", { className: cx("n") }, "T+1 收盘"), h("div", { className: cx("v") }, (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "% · " + trace.t1.verdict));
+		return h("div", null, h("div", { className: cx("trhead") }, "决策轨迹 · 无当日计划"), h("div", { className: cx("trace") }, h("div", { className: cx("tnode", "dec") }, h("div", { className: cx("n") }, "当时的计划"), h("div", {
 			className: cx("v"),
 			style: { color: "var(--cap)" }
-		}, "无关联记录")), h("div", { className: cx("tnode", "follow") }, h("div", { className: cx("n") }, "执行"), h("div", { className: cx("v") }, (ACT[trace.action] ?? trace.action) + " " + trace.shares + "股 @" + trace.price + " " + sym)), t1miss), trace.note === null ? null : h("div", { className: cx("tnote") }, esc(trace.note)), h("div", { className: cx("tmiss") }, "此笔无关联决策记录 — 事实保留,判断缺失显式标出"));
+		}, "这一天没有该标的的计划记录")), h("div", { className: cx("tnode", "follow") }, h("div", { className: cx("tw") }, trace.date ?? ""), h("div", { className: cx("n") }, "真实成交"), h("div", { className: cx("v") }, fillText)), t1miss), trace.note === null ? null : h("div", { className: cx("tnote") }, esc(trace.note)), h("div", { className: cx("tmiss") }, "这笔成交在决策账本里找不到前后 3 天的同标的计划:成交是真的,当时的判断没有留下记录。"));
 	}
-	const [exeLabel, exeTone] = EXE[decision.execution ?? "unknown"] ?? EXE["unknown"];
-	const planned = (ACT[decision.action ?? ""] ?? decision.action ?? "") + (decision.confidence === null ? "" : " " + Math.round(decision.confidence * 100) + "%") + (decision.drivenBy === null ? "" : " · " + (DRV[decision.drivenBy] ?? decision.drivenBy));
+	const [alignLabel, alignTone] = ALIGN[decision.alignment ?? ""] ?? ["", ""];
+	const planned = (ACT[decision.action ?? ""] ?? decision.action ?? "") + (decision.sizeShares === null ? "" : " " + decision.sizeShares + " 股") + (decision.plannedPrice === null ? "" : " @ " + decision.plannedPrice) + (decision.confidence === null ? "" : " · 信心 " + Math.round(decision.confidence * 100) + "%") + (decision.drivenBy === null ? "" : " · " + (DRV[decision.drivenBy] ?? decision.drivenBy));
 	const why = decision.rationale ?? decision.bull ?? "";
 	const emotion = decision.emotion !== null && decision.emotion !== "calm" ? EMO[decision.emotion] ?? decision.emotion : null;
 	const chips = [];
 	if (decision.condition !== null) chips.push(h("span", {
 		className: cx("pc"),
 		key: "c"
-	}, "条件: " + decision.condition));
-	if (decision.sizeShares !== null) chips.push(h("span", {
+	}, "触发条件: " + decision.condition));
+	if (decision.execution !== null) chips.push(h("span", {
 		className: cx("pc"),
-		key: "s"
-	}, "计划 " + decision.sizeShares + " 股"));
-	if (decision.plannedPrice !== null) chips.push(h("span", {
-		className: cx("pc"),
-		key: "p"
-	}, "计划价 " + decision.plannedPrice));
-	const t1node = trace.t1 === null ? null : h("div", { className: cx("tnode", t1NodeClass(trace.t1.tone)) }, h("div", { className: cx("tw") }, trace.t1.date), h("div", { className: cx("n") }, "T+1 结果"), h("div", { className: cx("v") }, (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "%" + (trace.action === "sell" ? " · " + trace.t1.verdict : "")));
+		key: "e"
+	}, "账本自评: " + (EXE[decision.execution] ?? decision.execution)));
+	const t1node = trace.t1 === null ? null : h("div", { className: cx("tnode", t1NodeClass(trace.t1.tone)) }, h("div", { className: cx("tw") }, trace.t1.date), h("div", { className: cx("n") }, "T+1 收盘"), h("div", { className: cx("v") }, (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "% · " + trace.t1.verdict));
 	let pnlText;
 	let pnlTone;
+	let pnlLabel;
 	if (trace.realizedPnl !== null) {
 		pnlText = (trace.realizedPnl >= 0 ? "+" : "") + trace.realizedPnl.toFixed(2) + " " + sym;
 		pnlTone = trace.realizedPnl >= 0 ? "win" : "loss";
+		pnlLabel = "本笔已实现";
 	} else if (trace.holdPnl !== null) {
 		pnlText = fmtPct(trace.holdPnl);
 		pnlTone = trace.holdPnl >= 0 ? "win" : "loss";
+		pnlLabel = "该持仓当前浮动 (" + trace.ticker + " 全仓,非本笔)";
 	} else {
-		pnlText = "—";
+		pnlText = "— 未平仓";
 		pnlTone = "";
+		pnlLabel = "本笔盈亏";
 	}
-	return h("div", null, h("div", { className: cx("trhead") }, "决策轨迹 · " + (decision.planDate ?? "")), h("div", { className: cx("trace") }, h("div", { className: cx("tnode", "dec") }, h("div", { className: cx("tw") }, decision.planDate ?? ""), h("div", { className: cx("n") }, "计划"), h("div", { className: cx("v") }, planned)), h("div", { className: cx("tnode", exeTone) }, h("div", { className: cx("tw") }, trace.date ?? ""), h("div", { className: cx("n") }, "执行"), h("div", { className: cx("v") }, exeLabel + (exeTone === "skip" ? " — 实际动了手" : ""))), t1node, h("div", { className: cx("tnode", pnlTone) }, h("div", { className: cx("n") }, "盈亏"), h("div", { className: cx("v") }, pnlText))), chips.length === 0 ? null : h("div", { className: cx("pchips") }, chips), why === "" ? null : h("div", { className: cx("tnote", "why") }, h("span", { className: cx("k") }, "为什么 "), esc(why)), emotion === null ? null : h("div", { className: cx("tnote", "emo") }, h("span", { className: cx("k") }, "情绪 "), "⚡ " + emotion), trace.note === null ? null : h("div", { className: cx("tnote") }, h("span", { className: cx("k") }, "备注 "), esc(trace.note)));
+	return h("div", null, h("div", { className: cx("trhead") }, "决策轨迹 · " + (decision.planDate ?? "")), h("div", { className: cx("trace") }, h("div", { className: cx("tnode", "dec") }, h("div", { className: cx("tw") }, decision.planDate ?? ""), h("div", { className: cx("n") }, "当时的计划"), h("div", { className: cx("v") }, planned)), h("div", { className: cx("tnode", alignTone) }, h("div", { className: cx("tw") }, trace.date ?? ""), h("div", { className: cx("n") }, "真实成交"), h("div", { className: cx("v") }, fillText, alignLabel === "" ? null : h("span", { className: cx("pc", alignTone) }, alignLabel))), t1node, h("div", { className: cx("tnode", pnlTone) }, h("div", { className: cx("n") }, pnlLabel), h("div", { className: cx("v") }, pnlText))), chips.length === 0 ? null : h("div", { className: cx("pchips") }, chips), why === "" ? null : h("div", { className: cx("tnote", "why") }, h("span", { className: cx("k") }, "为什么 "), esc(why)), emotion === null ? null : h("div", { className: cx("tnote", "emo") }, h("span", { className: cx("k") }, "情绪 "), "⚡ " + emotion), trace.note === null ? null : h("div", { className: cx("tnote") }, h("span", { className: cx("k") }, "备注 "), esc(trace.note)));
 }
 function TraceCell(props) {
 	const trace = props.trace;
 	const sym = trace.currency === "HKD" ? "HK$" : "$";
 	let pnl;
 	if (trace.realizedPnl !== null) pnl = h("span", { className: cx("pnl", trace.realizedPnl >= 0 ? "up" : "down") }, (trace.realizedPnl >= 0 ? "+" : "") + trace.realizedPnl.toFixed(2) + " " + sym);
-	else if (trace.holdPnl !== null) pnl = h("span", { className: cx("pnl", trace.holdPnl >= 0 ? "up" : "down") }, fmtPct(trace.holdPnl));
+	else if (trace.holdPnl !== null) pnl = h("span", { className: cx("pnl", trace.holdPnl >= 0 ? "up" : "down") }, h("span", { className: cx("pnlk") }, "持仓"), fmtPct(trace.holdPnl));
 	else pnl = h("span", { className: cx("pnl", "na") }, "—");
-	let t1tag = null;
+	let t1tag;
 	if (trace.t1 !== null) {
 		const tone = t1ChipClass(trace.t1.tone);
-		const label = "T+1 " + (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "%" + (trace.action === "sell" ? " " + trace.t1.verdict : "");
+		const label = "T+1 " + (trace.t1.delta >= 0 ? "+" : "") + trace.t1.delta + "% " + trace.t1.verdict;
 		t1tag = h("span", {
 			className: cx("t1", tone),
 			"data-tone": tone
 		}, label);
-	} else if (trace.action === "sell") t1tag = h("span", {
+	} else t1tag = h("span", {
 		className: cx("t1", "flat"),
 		"data-tone": "flat"
-	}, "T+1 —");
+	}, "T+1 未判");
 	return h("div", {
 		className: cx("cell", trace.decision !== null && "hasdec", props.open && "open"),
 		"data-cell": "trace",
@@ -4959,19 +4979,22 @@ function DecisionMind(props) {
 	if (data.loading) return h("div", {
 		className: cx("dmt"),
 		ref: rootRef
-	}, h("div", { className: cx("top") }, h("div", { className: cx("tt") }, "决策轨迹"), h("div", { className: cx("ts") }, "真实成交 × 决策账本 × T+1 结果")), h("div", { className: cx("list") }, h(SkeletonRow, { key: "sk1" }), h(SkeletonRow, { key: "sk2" }), h(SkeletonRow, { key: "sk3" })));
+	}, h("div", { className: cx("top") }, h("div", { className: cx("tt") }, "决策轨迹"), h("div", { className: cx("ts") }, "一笔真实成交 + 当时写下的计划 + 官方收盘给的结果")), h("div", { className: cx("list") }, h(SkeletonRow, { key: "sk1" }), h(SkeletonRow, { key: "sk2" }), h(SkeletonRow, { key: "sk3" })));
 	const traces = data.trades.map(_displayEntry);
 	let filtered = traces;
 	if (filter === "miss") filtered = traces.filter((trace) => trace.decision === null);
-	if (filter === "sold") filtered = traces.filter((trace) => trace.action === "sell");
+	if (filter === "sold") filtered = traces.filter((trace) => trace.side === "reduce");
 	if (filter === "dec") filtered = traces.filter((trace) => trace.decision !== null);
 	const sumRealized = (currency) => traces.filter((trace) => trace.realizedPnl !== null && trace.currency === currency).reduce((sum, trace) => sum + (trace.realizedPnl ?? 0), 0);
 	const rate = data.rate;
 	const totalUsd = sumRealized("USD") + (rate === null ? 0 : sumRealized("HKD") / rate);
-	const t1Rated = traces.filter((trace) => trace.t1 !== null).length;
-	const soldEarly = traces.filter((trace) => trace.t1?.verdict === "卖飞").length;
-	const soldRight = traces.filter((trace) => trace.t1?.verdict === "卖对").length;
+	const sells = traces.filter((trace) => trace.side === "reduce");
+	const sideless = traces.filter((trace) => trace.side === null).length;
+	const sellsRated = sells.filter((trace) => trace.t1 !== null).length;
+	const soldEarly = sells.filter((trace) => trace.t1?.verdict === "卖飞").length;
+	const soldRight = sells.filter((trace) => trace.t1?.verdict === "卖对").length;
 	const matched = traces.filter((trace) => trace.decision !== null).length;
+	const reversed = traces.filter((trace) => trace.decision?.alignment === "opposite").length;
 	const groups = {};
 	for (const trace of filtered) {
 		const day = (trace.date ?? "").slice(0, 10);
@@ -5039,7 +5062,7 @@ function DecisionMind(props) {
 		if (moreButton !== null) kids.push(moreButton);
 		body = h("div", null, kids);
 	}
-	const stats = h("div", { className: cx("stats") }, h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "已实现 (USD 等值)"), h("span", { className: cx("sv", "focus", totalUsd >= 0 ? "up" : "down") }, fmtMoney(totalUsd))), h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "T+1 卖飞/卖对 · 基于 " + t1Rated + " 笔"), h("span", { className: cx("sv") }, h("span", { className: cx("down") }, soldEarly), " / ", h("span", { className: cx("up") }, soldRight))), h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "决策挂接"), h("span", { className: cx("sv") }, matched + "/" + traces.length)), h("span", { className: cx("rate") }, traces.length + " 笔成交" + (rate === null ? "" : " · @" + rate)));
+	const stats = h("div", { className: cx("stats") }, h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "已实现 (USD 等值)"), h("span", { className: cx("sv", "focus", totalUsd >= 0 ? "up" : "down") }, fmtMoney(totalUsd))), h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "T+1 卖飞/卖对 · 判出 " + sellsRated + "/" + sells.length + " 笔卖出" + (sideless === 0 ? "" : " · " + sideless + " 笔无侧向")), h("span", { className: cx("sv") }, h("span", { className: cx("down") }, soldEarly), " / ", h("span", { className: cx("up") }, soldRight))), h("div", { className: cx("sg") }, h("span", { className: cx("sl") }, "有当日计划" + (reversed === 0 ? "" : " · 反向 " + reversed)), h("span", { className: cx("sv") }, matched + "/" + traces.length)), h("span", { className: cx("rate") }, traces.length + " 笔成交" + (rate === null ? "" : " · @" + rate)));
 	const filters = h("div", { className: cx("filters") }, [
 		"all",
 		"miss",
@@ -5055,7 +5078,7 @@ function DecisionMind(props) {
 	return h("div", {
 		className: cx("dmt"),
 		ref: rootRef
-	}, h("div", { className: cx("top") }, h("div", { className: cx("tt") }, "决策轨迹"), h("div", { className: cx("ts") }, "真实成交 × 决策账本 × T+1 结果" + (data.stale ? " · 更新失败,显示此前快照" : "")), stats, filters), h("div", { className: cx("list") }, body));
+	}, h("div", { className: cx("top") }, h("div", { className: cx("tt") }, "决策轨迹"), h("div", { className: cx("ts") }, "一笔真实成交 + 当时写下的计划 + 官方收盘给的结果" + (data.stale ? " · 更新失败,显示此前快照" : "")), stats, filters), h("div", { className: cx("list") }, body));
 }
 /** Services required by the registration and the mounted Remote face. */
 const inject = ["slots", "remote"];

--- a/examples/dsh/packages/clawock-dsh/lib/ledger.js
+++ b/examples/dsh/packages/clawock-dsh/lib/ledger.js
@@ -192,6 +192,38 @@ const SELL_ACTIONS = /* @__PURE__ */ new Set([
 function isSellAction(action) {
 	return SELL_ACTIONS.has(action);
 }
+/** Actions that add to a position. */
+const ADD_ACTIONS = /* @__PURE__ */ new Set(["buy", "add"]);
+/**
+* 'same' | 'opposite' | 'other' — the plan's direction against the fill's.
+*
+* Mirrors `_plan_fill_alignment` in src/clawock/publish/dashboard.py; the two
+* implementations are pinned together by tests/test_decision_trace_parity.py.
+*/
+function planFillAlignment(planAction, fillAction) {
+	if (typeof planAction !== "string" || typeof fillAction !== "string") return null;
+	if (planAction === fillAction) return "same";
+	const sideOf = (action) => ADD_ACTIONS.has(action) ? "add" : SELL_ACTIONS.has(action) ? "reduce" : null;
+	const planSide = sideOf(planAction);
+	const fillSide = sideOf(fillAction);
+	if (planSide === null || fillSide === null) return "other";
+	return planSide === fillSide ? "same" : "opposite";
+}
+/**
+* A rationale fit for a reader: the risk engine's internal breach ids stripped.
+*
+* The raw field carries things like "硬止损 -27.23% ≤ -18% (breach
+* risk-95ac7f6cd591 30d)" — the hash says nothing to anyone outside the
+* process, and it is sitting in the one field a reader opens to understand
+* *why*. Mirrors `_readable_rationale` in dashboard.py, minus the 140-char
+* truncation: that exists to fit a published payload cap, which this panel
+* (reading the workspace at runtime) does not have.
+*/
+function readableRationale(text) {
+	if (typeof text !== "string") return null;
+	const cleaned = text.replace(/\s*\((?:breach\s+)?risk-[0-9a-f]{6,}(?:\s+\d+d)?\)/g, "").replace(/[ \t]{2,}/g, " ").trim();
+	return cleaned === "" ? null : cleaned;
+}
 /** Good/bad/flat reading of a T+1 move, action-aware and dead-zoned. */
 function t1ToneOf(action, delta) {
 	if (Math.abs(delta) < 1) return "flat";
@@ -278,7 +310,8 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 		...trade,
 		holdPnl: null,
 		t1: null,
-		decision: null
+		decision: null,
+		side: isSellAction(trade.action) ? "reduce" : ADD_ACTIONS.has(trade.action) ? "add" : null
 	};
 	const t1 = futureClose(byTicker, trade.ticker, trade.date, 1);
 	if (t1 !== null && trade.price != null) {
@@ -317,7 +350,7 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 			action: typeof b["action"] === "string" ? b["action"] : null,
 			confidence: b["confidence"] == null ? null : Number(b["confidence"]),
 			drivenBy: typeof b["driven_by"] === "string" ? b["driven_by"] : null,
-			rationale: typeof b["rationale"] === "string" ? b["rationale"] : null,
+			rationale: readableRationale(typeof b["rationale"] === "string" ? b["rationale"] : null),
 			bull: typeof bull["summary"] === "string" ? bull["summary"] : null,
 			bear: typeof bear["summary"] === "string" ? bear["summary"] : null,
 			emotion: typeof emotion["pressure"] === "string" ? emotion["pressure"] : null,
@@ -327,7 +360,8 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 			sizeShares: size["shares"] == null ? null : Number(size["shares"]),
 			sizePct: size["pct"] == null ? null : Number(size["pct"]),
 			plannedPrice: evaluation["execution_price"] != null ? Number(evaluation["execution_price"]) : b["simulated_entry_price"] != null ? Number(b["simulated_entry_price"]) : null,
-			source: typeof b["source"] === "string" ? b["source"] : "brief"
+			source: typeof b["source"] === "string" ? b["source"] : "brief",
+			alignment: planFillAlignment(typeof b["action"] === "string" ? b["action"] : null, trade.action)
 		};
 	}
 	const row = books.find((bk) => bk.holdings.some((h) => h.ticker === trade.ticker))?.holdings.find((h) => h.ticker === trade.ticker);
@@ -378,4 +412,4 @@ function readTraces(workspace) {
 	};
 }
 //#endregion
-export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, readBarCloses, readLedger, readPlans, readPortfolio, readTraces, t1ToneOf, t1VerdictOf };
+export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, planFillAlignment, readBarCloses, readLedger, readPlans, readPortfolio, readTraces, readableRationale, t1ToneOf, t1VerdictOf };

--- a/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
@@ -3,8 +3,9 @@
  *
  * One organic view — the decision trace: real fills as the spine, the shared
  * decision ledger (memory/decisions.jsonl) soft-paired (±3 days) as the "why"
- * layer, and snapshot closes as the T+1 verdict. Fills without a decision say
- * so explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
+ * layer, and canonical bar closes (memory/bars/, never snapshot current_price
+ * — see readBarCloses) as the T+1 verdict. Fills without a decision say so
+ * explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
  * figure as the focal number and a GitHub-style vertical timeline in the
  * expandable detail.
  *
@@ -105,6 +106,16 @@ export interface DisplayEntry {
     t1: TraceT1 | null;
     holdPnl: number | null;
     decision: TraceDecision | null;
+    /**
+     * 'add' | 'reduce' decided host-side (see EnrichedTrade.side), or null when
+     * the payload carried no side at all.
+     *
+     * Nullable on purpose. Defaulting an unknown side to 'add' silently files
+     * every sell under buys and the sell scorecard then reads a confident
+     * "判出 0/0 笔卖出" — wrong, not degraded. Null keeps those fills out of both
+     * sides and makes the header say how many it could not place.
+     */
+    side: 'add' | 'reduce' | null;
 }
 /** Display projection of one trace (test seam). */
 export declare function _displayEntry(trace: EnrichedTrade): DisplayEntry;

--- a/examples/dsh/packages/clawock-dsh/lib/types/ledger.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/ledger.d.ts
@@ -45,6 +45,24 @@ export declare const T1_MAX_GAP_DAYS = 4;
  */
 export declare const T1_FLAT_BAND_PCT = 1;
 export declare function isSellAction(action: string): boolean;
+/**
+ * 'same' | 'opposite' | 'other' — the plan's direction against the fill's.
+ *
+ * Mirrors `_plan_fill_alignment` in src/clawock/publish/dashboard.py; the two
+ * implementations are pinned together by tests/test_decision_trace_parity.py.
+ */
+export declare function planFillAlignment(planAction: string | null | undefined, fillAction: string | null | undefined): 'same' | 'opposite' | 'other' | null;
+/**
+ * A rationale fit for a reader: the risk engine's internal breach ids stripped.
+ *
+ * The raw field carries things like "硬止损 -27.23% ≤ -18% (breach
+ * risk-95ac7f6cd591 30d)" — the hash says nothing to anyone outside the
+ * process, and it is sitting in the one field a reader opens to understand
+ * *why*. Mirrors `_readable_rationale` in dashboard.py, minus the 140-char
+ * truncation: that exists to fit a published payload cap, which this panel
+ * (reading the workspace at runtime) does not have.
+ */
+export declare function readableRationale(text: string | null | undefined): string | null;
 /** Good/bad/flat reading of a T+1 move, action-aware and dead-zoned. */
 export declare function t1ToneOf(action: string, delta: number): 'win' | 'loss' | 'flat';
 /** Chinese verdict text for a T+1 move, on the same dead zone as `t1ToneOf`. */

--- a/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
@@ -118,11 +118,33 @@ export interface TraceDecision {
     sizePct: number | null;
     plannedPrice: number | null;
     source: string | null;
+    /**
+     * How the plan's direction relates to the fill that actually happened.
+     * 'same' | 'opposite' | 'other' (the plan pointed at neither side), or null
+     * when either action is missing.
+     *
+     * Load-bearing, not decorative: on live data 22 of 40 traces were outright
+     * reversals of their own plan, and the panel showed nothing about it — the
+     * reader had to infer "risk said cut, I bought" from two adjacent lines.
+     * `execution.status` does NOT answer this: it is the plan's own self-report
+     * and stays available separately as 账本自评.
+     */
+    alignment: 'same' | 'opposite' | 'other' | null;
 }
 export interface EnrichedTrade extends Trade {
     holdPnl: number | null;
     t1: TraceT1 | null;
     decision: TraceDecision | null;
+    /**
+     * What this fill did to the position, decided host-side by `isSellAction`.
+     *
+     * Shipped so the browser half never keeps its own copy of the action set: the
+     * client used to test `action === 'sell'`, which silently dropped the verdict
+     * for cut / trim / trim_on_rebound, and a second copy of that set is how the
+     * two implementations drifted in #739. Null means the action is in neither
+     * bucket — the fill is kept out of both sides rather than guessed into one.
+     */
+    side: 'add' | 'reduce' | null;
 }
 export interface TracesResult {
     workspaceKey: string;

--- a/examples/dsh/packages/clawock-dsh/src/client.ts
+++ b/examples/dsh/packages/clawock-dsh/src/client.ts
@@ -3,8 +3,9 @@
  *
  * One organic view — the decision trace: real fills as the spine, the shared
  * decision ledger (memory/decisions.jsonl) soft-paired (±3 days) as the "why"
- * layer, and snapshot closes as the T+1 verdict. Fills without a decision say
- * so explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
+ * layer, and canonical bar closes (memory/bars/, never snapshot current_price
+ * — see readBarCloses) as the T+1 verdict. Fills without a decision say so
+ * explicitly. Visual language: modern SaaS on DSH tokens, with the P&L
  * figure as the focal number and a GitHub-style vertical timeline in the
  * expandable detail.
  *
@@ -142,15 +143,31 @@ const ACT: Record<string, string> = {
 const DRV: Record<string, string> = {
   technical: '技术面', fundamental: '基本面', sentiment: '情绪面', mixed: '混合', risk_rule: '风控规则',
 }
-const EXE: Record<string, [label: string, tone: string]> = {
-  followed: ['已遵守', 'follow'], not_followed: ['未执行', 'skip'], unknown: ['未知', ''],
+/**
+ * The ledger's `execution.status`, in words.
+ *
+ * This grades the PLAN — "was this plan followed" — and it is not a statement
+ * about the fill on the row, which happened either way. Rendering 「未执行」 as
+ * that row's 执行 verdict read as a flat contradiction on a completed buy, and
+ * on live data 8 rows said 已遵守 while the plan's action still differed from
+ * the fill's. So it renders as 账本自评 and never as the fill's own status; the
+ * plan-vs-fill relation is `decision.alignment` below.
+ */
+const EXE: Record<string, string> = {
+  followed: '遵守了计划', not_followed: '没按计划', unknown: '未标注',
+}
+/** The plan-vs-fill relation, stated instead of left to be inferred. */
+const ALIGN: Record<string, [label: string, tone: string]> = {
+  same: ['与计划同向', 'follow'],
+  opposite: ['与计划反向', 'skip'],
+  other: ['计划未指向买卖', ''],
 }
 const EMO: Record<string, string> = {
   fomo: '追高冲动', revenge: '报复性', averaging_down: '摊薄冲动', fear: '恐慌',
   euphoria: '亢奋', calm: '平静', mixed: '混合',
 }
 const FILTER_LABEL: Record<TraceFilter, string> = {
-  all: '全部', miss: '无决策', sold: '卖出复盘', dec: '挂接决策',
+  all: '全部', miss: '无当日计划', sold: '卖出复盘', dec: '有当日计划',
 }
 
 function esc(value: unknown): string {
@@ -202,6 +219,16 @@ export interface DisplayEntry {
   t1: TraceT1 | null
   holdPnl: number | null
   decision: TraceDecision | null
+  /**
+   * 'add' | 'reduce' decided host-side (see EnrichedTrade.side), or null when
+   * the payload carried no side at all.
+   *
+   * Nullable on purpose. Defaulting an unknown side to 'add' silently files
+   * every sell under buys and the sell scorecard then reads a confident
+   * "判出 0/0 笔卖出" — wrong, not degraded. Null keeps those fills out of both
+   * sides and makes the header say how many it could not place.
+   */
+  side: 'add' | 'reduce' | null
 }
 
 /** Display projection of one trace (test seam). */
@@ -219,6 +246,10 @@ export function _displayEntry(trace: EnrichedTrade): DisplayEntry {
     t1: trace.t1 ?? null,
     holdPnl: trace.holdPnl ?? null,
     decision: trace.decision ?? null,
+    // Passed through, never recomputed and never defaulted: the browser must
+    // not own a second copy of the action set (#739), and an absent side is
+    // reported as absent rather than guessed.
+    side: trace.side === 'reduce' || trace.side === 'add' ? trace.side : null,
   }
 }
 
@@ -230,66 +261,82 @@ function TraceDetail(props: { trace: DisplayEntry }): React.ReactElement {
   const trace = props.trace
   const decision = trace.decision
   const sym = trace.currency === 'HKD' ? 'HK$' : '$'
+  // The fill itself, in words — the one node on this row that is never inferred.
+  const fillText = (ACT[trace.action] ?? trace.action) + ' ' + trace.shares + ' 股 @ ' + sym + trace.price
   if (decision === null) {
     const t1miss = trace.t1 === null ? null : h('div', { className: cx('tnode', t1NodeClass(trace.t1.tone)) },
-      h('div', { className: cx('n') }, 'T+1 结果'),
-      h('div', { className: cx('v') }, (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '%'))
+      h('div', { className: cx('tw') }, trace.t1.date),
+      h('div', { className: cx('n') }, 'T+1 收盘'),
+      h('div', { className: cx('v') }, (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '% · ' + trace.t1.verdict))
     return h('div', null,
-      h('div', { className: cx('trhead') }, '决策轨迹 · 无关联记录'),
+      h('div', { className: cx('trhead') }, '决策轨迹 · 无当日计划'),
       h('div', { className: cx('trace') },
         h('div', { className: cx('tnode', 'dec') },
-          h('div', { className: cx('n') }, '决策'),
-          h('div', { className: cx('v'), style: { color: 'var(--cap)' } }, '无关联记录')),
+          h('div', { className: cx('n') }, '当时的计划'),
+          h('div', { className: cx('v'), style: { color: 'var(--cap)' } }, '这一天没有该标的的计划记录')),
         h('div', { className: cx('tnode', 'follow') },
-          h('div', { className: cx('n') }, '执行'),
-          h('div', { className: cx('v') }, (ACT[trace.action] ?? trace.action) + ' ' + trace.shares + '股 @' + trace.price + ' ' + sym)),
+          h('div', { className: cx('tw') }, trace.date ?? ''),
+          h('div', { className: cx('n') }, '真实成交'),
+          h('div', { className: cx('v') }, fillText)),
         t1miss),
       trace.note === null ? null : h('div', { className: cx('tnote') }, esc(trace.note)),
-      h('div', { className: cx('tmiss') }, '此笔无关联决策记录 — 事实保留,判断缺失显式标出'))
+      h('div', { className: cx('tmiss') },
+        '这笔成交在决策账本里找不到前后 3 天的同标的计划:成交是真的,当时的判断没有留下记录。'))
   }
-  const [exeLabel, exeTone] = EXE[decision.execution ?? 'unknown'] ?? EXE['unknown']!
+  const [alignLabel, alignTone] = ALIGN[decision.alignment ?? ''] ?? ['', '']
   const planned = (ACT[decision.action ?? ''] ?? decision.action ?? '')
-    + (decision.confidence === null ? '' : ' ' + Math.round(decision.confidence * 100) + '%')
+    + (decision.sizeShares === null ? '' : ' ' + decision.sizeShares + ' 股')
+    + (decision.plannedPrice === null ? '' : ' @ ' + decision.plannedPrice)
+    + (decision.confidence === null ? '' : ' · 信心 ' + Math.round(decision.confidence * 100) + '%')
     + (decision.drivenBy === null ? '' : ' · ' + (DRV[decision.drivenBy] ?? decision.drivenBy))
   const why = decision.rationale ?? decision.bull ?? ''
   const emotion = decision.emotion !== null && decision.emotion !== 'calm'
     ? (EMO[decision.emotion] ?? decision.emotion)
     : null
   const chips: React.ReactElement[] = []
-  if (decision.condition !== null) chips.push(h('span', { className: cx('pc'), key: 'c' }, '条件: ' + decision.condition))
-  if (decision.sizeShares !== null) chips.push(h('span', { className: cx('pc'), key: 's' }, '计划 ' + decision.sizeShares + ' 股'))
-  if (decision.plannedPrice !== null) chips.push(h('span', { className: cx('pc'), key: 'p' }, '计划价 ' + decision.plannedPrice))
+  if (decision.condition !== null) chips.push(h('span', { className: cx('pc'), key: 'c' }, '触发条件: ' + decision.condition))
+  if (decision.execution !== null) {
+    chips.push(h('span', { className: cx('pc'), key: 'e' },
+      '账本自评: ' + (EXE[decision.execution] ?? decision.execution)))
+  }
   const t1node = trace.t1 === null ? null : h('div', { className: cx('tnode', t1NodeClass(trace.t1.tone)) },
     h('div', { className: cx('tw') }, trace.t1.date),
-    h('div', { className: cx('n') }, 'T+1 结果'),
+    h('div', { className: cx('n') }, 'T+1 收盘'),
     h('div', { className: cx('v') },
-      (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '%' + (trace.action === 'sell' ? ' · ' + trace.t1.verdict : '')))
+      (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '% · ' + trace.t1.verdict))
+  // 本笔已实现 and 该持仓浮动 are different quantities — one belongs to this
+  // fill, the other to the whole position — so they never share a label.
   let pnlText: string
   let pnlTone: string
+  let pnlLabel: string
   if (trace.realizedPnl !== null) {
     pnlText = (trace.realizedPnl >= 0 ? '+' : '') + trace.realizedPnl.toFixed(2) + ' ' + sym
     pnlTone = trace.realizedPnl >= 0 ? 'win' : 'loss'
+    pnlLabel = '本笔已实现'
   } else if (trace.holdPnl !== null) {
     pnlText = fmtPct(trace.holdPnl)
     pnlTone = trace.holdPnl >= 0 ? 'win' : 'loss'
+    pnlLabel = '该持仓当前浮动 (' + trace.ticker + ' 全仓,非本笔)'
   } else {
-    pnlText = '—'
+    pnlText = '— 未平仓'
     pnlTone = ''
+    pnlLabel = '本笔盈亏'
   }
   return h('div', null,
     h('div', { className: cx('trhead') }, '决策轨迹 · ' + (decision.planDate ?? '')),
     h('div', { className: cx('trace') },
       h('div', { className: cx('tnode', 'dec') },
         h('div', { className: cx('tw') }, decision.planDate ?? ''),
-        h('div', { className: cx('n') }, '计划'),
+        h('div', { className: cx('n') }, '当时的计划'),
         h('div', { className: cx('v') }, planned)),
-      h('div', { className: cx('tnode', exeTone) },
+      h('div', { className: cx('tnode', alignTone) },
         h('div', { className: cx('tw') }, trace.date ?? ''),
-        h('div', { className: cx('n') }, '执行'),
-        h('div', { className: cx('v') }, exeLabel + (exeTone === 'skip' ? ' — 实际动了手' : ''))),
+        h('div', { className: cx('n') }, '真实成交'),
+        h('div', { className: cx('v') }, fillText,
+          alignLabel === '' ? null : h('span', { className: cx('pc', alignTone) }, alignLabel))),
       t1node,
       h('div', { className: cx('tnode', pnlTone) },
-        h('div', { className: cx('n') }, '盈亏'),
+        h('div', { className: cx('n') }, pnlLabel),
         h('div', { className: cx('v') }, pnlText))),
     chips.length === 0 ? null : h('div', { className: cx('pchips') }, chips),
     why === '' ? null : h('div', { className: cx('tnote', 'why') }, h('span', { className: cx('k') }, '为什么 '), esc(why)),
@@ -312,21 +359,31 @@ function TraceCell(props: TraceCellProps): React.ReactElement {
     pnl = h('span', { className: cx('pnl', trace.realizedPnl >= 0 ? 'up' : 'down') },
       (trace.realizedPnl >= 0 ? '+' : '') + trace.realizedPnl.toFixed(2) + ' ' + sym)
   } else if (trace.holdPnl !== null) {
-    pnl = h('span', { className: cx('pnl', trace.holdPnl >= 0 ? 'up' : 'down') }, fmtPct(trace.holdPnl))
+    // A floating percent belongs to the whole position, not to this fill. The
+    // 持仓 prefix is what stops it reading as "this trade lost 28%".
+    pnl = h('span', { className: cx('pnl', trace.holdPnl >= 0 ? 'up' : 'down') },
+      h('span', { className: cx('pnlk') }, '持仓'), fmtPct(trace.holdPnl))
   } else {
     pnl = h('span', { className: cx('pnl', 'na') }, '—')
   }
-  let t1tag: React.ReactElement | null = null
+  let t1tag: React.ReactElement
   if (trace.t1 !== null) {
     const tone = t1ChipClass(trace.t1.tone)
-    const label = 'T+1 ' + (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '%'
-      + (trace.action === 'sell' ? ' ' + trace.t1.verdict : '')
+    // The verdict word already carries the side (卖飞/卖对/持平 for a reducing
+    // fill, 涨/跌 for an adding one), so it is always shown. Gating it on
+    // `action === 'sell'` used to drop it for cut/trim/trim_on_rebound and
+    // forced the client to keep its own copy of the action set — the kind of
+    // duplicate that drifted apart in #739.
+    const label = 'T+1 ' + (trace.t1.delta >= 0 ? '+' : '') + trace.t1.delta + '% ' + trace.t1.verdict
     // data-tone carries the host's reading into the DOM: it is what the
     // regression spec reads, so hashed class names cannot hide a chip that
     // stopped following `t1.tone` (#713).
     t1tag = h('span', { className: cx('t1', tone), 'data-tone': tone }, label)
-  } else if (trace.action === 'sell') {
-    t1tag = h('span', { className: cx('t1', 'flat'), 'data-tone': 'flat' }, 'T+1 —')
+  } else {
+    // Said out loud for every unjudged fill, not just sells: no canonical close
+    // inside the T+1 window means there is no verdict, and silence there reads
+    // like the fill was fine.
+    t1tag = h('span', { className: cx('t1', 'flat'), 'data-tone': 'flat' }, 'T+1 未判')
   }
   return h('div', {
     className: cx('cell', trace.decision !== null && 'hasdec', props.open && 'open'),
@@ -444,7 +501,7 @@ export function DecisionMind(props: DecisionMindProps): React.ReactElement {
     return h('div', { className: cx('dmt'), ref: rootRef },
       h('div', { className: cx('top') },
         h('div', { className: cx('tt') }, '决策轨迹'),
-        h('div', { className: cx('ts') }, '真实成交 × 决策账本 × T+1 结果')),
+        h('div', { className: cx('ts') }, '一笔真实成交 + 当时写下的计划 + 官方收盘给的结果')),
       h('div', { className: cx('list') },
         h(SkeletonRow, { key: 'sk1' }),
         h(SkeletonRow, { key: 'sk2' }),
@@ -454,7 +511,10 @@ export function DecisionMind(props: DecisionMindProps): React.ReactElement {
   const traces = data.trades.map(_displayEntry)
   let filtered = traces
   if (filter === 'miss') filtered = traces.filter((trace) => trace.decision === null)
-  if (filter === 'sold') filtered = traces.filter((trace) => trace.action === 'sell')
+  // The sell filter follows the host-computed `side`, not a client-side copy of
+  // the action set: `action === 'sell'` silently missed cut/trim/trim_on_rebound
+  // and is exactly the duplicate that drifted in #739.
+  if (filter === 'sold') filtered = traces.filter((trace) => trace.side === 'reduce')
   if (filter === 'dec') filtered = traces.filter((trace) => trace.decision !== null)
 
   const sumRealized = (currency: string): number => traces
@@ -466,10 +526,16 @@ export function DecisionMind(props: DecisionMindProps): React.ReactElement {
   // `t1` at all (the host drops the rest rather than labelling a months-later
   // close "T+1"). The denominator is rendered so the ratio can be read for
   // what it is instead of looking like it covers every fill.
-  const t1Rated = traces.filter((trace) => trace.t1 !== null).length
-  const soldEarly = traces.filter((trace) => trace.t1?.verdict === '卖飞').length
-  const soldRight = traces.filter((trace) => trace.t1?.verdict === '卖对').length
+  // Every count carries the denominator it is actually a fraction of. The old
+  // label read "T+1 卖飞/卖对 · 基于 39 笔" while only sell-side verdicts were
+  // shown and those 39 counted buys as well.
+  const sells = traces.filter((trace) => trace.side === 'reduce')
+  const sideless = traces.filter((trace) => trace.side === null).length
+  const sellsRated = sells.filter((trace) => trace.t1 !== null).length
+  const soldEarly = sells.filter((trace) => trace.t1?.verdict === '卖飞').length
+  const soldRight = sells.filter((trace) => trace.t1?.verdict === '卖对').length
   const matched = traces.filter((trace) => trace.decision !== null).length
+  const reversed = traces.filter((trace) => trace.decision?.alignment === 'opposite').length
 
   const groups: Record<string, DisplayEntry[]> = {}
   for (const trace of filtered) {
@@ -549,11 +615,12 @@ export function DecisionMind(props: DecisionMindProps): React.ReactElement {
       h('span', { className: cx('sl') }, '已实现 (USD 等值)'),
       h('span', { className: cx('sv', 'focus', totalUsd >= 0 ? 'up' : 'down') }, fmtMoney(totalUsd))),
     h('div', { className: cx('sg') },
-      h('span', { className: cx('sl') }, 'T+1 卖飞/卖对 · 基于 ' + t1Rated + ' 笔'),
+      h('span', { className: cx('sl') }, 'T+1 卖飞/卖对 · 判出 ' + sellsRated + '/' + sells.length
+        + ' 笔卖出' + (sideless === 0 ? '' : ' · ' + sideless + ' 笔无侧向')),
       h('span', { className: cx('sv') },
         h('span', { className: cx('down') }, soldEarly), ' / ', h('span', { className: cx('up') }, soldRight))),
     h('div', { className: cx('sg') },
-      h('span', { className: cx('sl') }, '决策挂接'),
+      h('span', { className: cx('sl') }, '有当日计划' + (reversed === 0 ? '' : ' · 反向 ' + reversed)),
       h('span', { className: cx('sv') }, matched + '/' + traces.length)),
     h('span', { className: cx('rate') },
       traces.length + ' 笔成交' + (rate === null ? '' : ' · @' + rate)))
@@ -568,7 +635,7 @@ export function DecisionMind(props: DecisionMindProps): React.ReactElement {
   return h('div', { className: cx('dmt'), ref: rootRef },
     h('div', { className: cx('top') },
       h('div', { className: cx('tt') }, '决策轨迹'),
-      h('div', { className: cx('ts') }, '真实成交 × 决策账本 × T+1 结果' + (data.stale ? ' · 更新失败,显示此前快照' : '')),
+      h('div', { className: cx('ts') }, '一笔真实成交 + 当时写下的计划 + 官方收盘给的结果' + (data.stale ? ' · 更新失败,显示此前快照' : '')),
       stats,
       filters),
     h('div', { className: cx('list') }, body))

--- a/examples/dsh/packages/clawock-dsh/src/ledger.ts
+++ b/examples/dsh/packages/clawock-dsh/src/ledger.ts
@@ -220,6 +220,48 @@ export function isSellAction(action: string): boolean {
   return SELL_ACTIONS.has(action)
 }
 
+/** Actions that add to a position. */
+const ADD_ACTIONS = new Set(['buy', 'add'])
+
+/**
+ * 'same' | 'opposite' | 'other' — the plan's direction against the fill's.
+ *
+ * Mirrors `_plan_fill_alignment` in src/clawock/publish/dashboard.py; the two
+ * implementations are pinned together by tests/test_decision_trace_parity.py.
+ */
+export function planFillAlignment(
+  planAction: string | null | undefined,
+  fillAction: string | null | undefined,
+): 'same' | 'opposite' | 'other' | null {
+  if (typeof planAction !== 'string' || typeof fillAction !== 'string') return null
+  if (planAction === fillAction) return 'same'
+  const sideOf = (action: string): 'add' | 'reduce' | null =>
+    ADD_ACTIONS.has(action) ? 'add' : (SELL_ACTIONS.has(action) ? 'reduce' : null)
+  const planSide = sideOf(planAction)
+  const fillSide = sideOf(fillAction)
+  if (planSide === null || fillSide === null) return 'other'
+  return planSide === fillSide ? 'same' : 'opposite'
+}
+
+/**
+ * A rationale fit for a reader: the risk engine's internal breach ids stripped.
+ *
+ * The raw field carries things like "硬止损 -27.23% ≤ -18% (breach
+ * risk-95ac7f6cd591 30d)" — the hash says nothing to anyone outside the
+ * process, and it is sitting in the one field a reader opens to understand
+ * *why*. Mirrors `_readable_rationale` in dashboard.py, minus the 140-char
+ * truncation: that exists to fit a published payload cap, which this panel
+ * (reading the workspace at runtime) does not have.
+ */
+export function readableRationale(text: string | null | undefined): string | null {
+  if (typeof text !== 'string') return null
+  const cleaned = text
+    .replace(/\s*\((?:breach\s+)?risk-[0-9a-f]{6,}(?:\s+\d+d)?\)/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim()
+  return cleaned === '' ? null : cleaned
+}
+
 /** Good/bad/flat reading of a T+1 move, action-aware and dead-zoned. */
 export function t1ToneOf(action: string, delta: number): 'win' | 'loss' | 'flat' {
   if (Math.abs(delta) < T1_FLAT_BAND_PCT) return 'flat'
@@ -317,7 +359,14 @@ function enrichTrade(
   decByTicker: Record<string, DecisionRow[]>,
   books: Book[],
 ): EnrichedTrade {
-  const out = { ...trade, holdPnl: null, t1: null, decision: null } as EnrichedTrade
+  const out = {
+    ...trade, holdPnl: null, t1: null, decision: null,
+    // Unknown actions stay null, never defaulted to 'add': the client treats a
+    // null side as "could not place this fill" and keeps it out of both the
+    // sell scorecard and the add bucket. Filling it with 'add' would silently
+    // file every unclassified action under buys.
+    side: isSellAction(trade.action) ? 'reduce' : (ADD_ACTIONS.has(trade.action) ? 'add' : null),
+  } as EnrichedTrade
   // T+1 reading: tone and verdict both come from the shared dead zone in
   // `t1ToneOf`/`t1VerdictOf`, so the chip, the trace node and the text can
   // never disagree about the same fill.
@@ -364,7 +413,7 @@ function enrichTrade(
       action: typeof b['action'] === 'string' ? b['action'] : null,
       confidence: b['confidence'] == null ? null : Number(b['confidence']),
       drivenBy: typeof b['driven_by'] === 'string' ? b['driven_by'] : null,
-      rationale: typeof b['rationale'] === 'string' ? b['rationale'] : null,
+      rationale: readableRationale(typeof b['rationale'] === 'string' ? b['rationale'] : null),
       bull: typeof bull['summary'] === 'string' ? bull['summary'] : null,
       bear: typeof bear['summary'] === 'string' ? bear['summary'] : null,
       emotion: typeof emotion['pressure'] === 'string' ? emotion['pressure'] : null,
@@ -376,6 +425,8 @@ function enrichTrade(
       plannedPrice: evaluation['execution_price'] != null ? Number(evaluation['execution_price'])
         : (b['simulated_entry_price'] != null ? Number(b['simulated_entry_price']) : null),
       source: typeof b['source'] === 'string' ? b['source'] : 'brief',
+      alignment: planFillAlignment(
+        typeof b['action'] === 'string' ? b['action'] : null, trade.action),
     }
     out.decision = decision
   }

--- a/examples/dsh/packages/clawock-dsh/src/styles.module.css
+++ b/examples/dsh/packages/clawock-dsh/src/styles.module.css
@@ -297,6 +297,14 @@ body[data-ds-dark-theme] .dmt {
   font-weight:500;
   font-size:13px
 }
+/* Marks the focus number as the position's floating percent rather than this
+   fill's realized amount — two different quantities in one slot. */
+.dmt .pnlk {
+  font:600 10.5px/1.2 var(--font);
+  color:var(--cap);
+  margin-right:3px;
+  letter-spacing:0
+}
 .dmt .sub {
   display:flex;
   align-items:center;

--- a/examples/dsh/packages/clawock-dsh/src/types.ts
+++ b/examples/dsh/packages/clawock-dsh/src/types.ts
@@ -129,12 +129,34 @@ export interface TraceDecision {
   sizePct: number | null
   plannedPrice: number | null
   source: string | null
+  /**
+   * How the plan's direction relates to the fill that actually happened.
+   * 'same' | 'opposite' | 'other' (the plan pointed at neither side), or null
+   * when either action is missing.
+   *
+   * Load-bearing, not decorative: on live data 22 of 40 traces were outright
+   * reversals of their own plan, and the panel showed nothing about it — the
+   * reader had to infer "risk said cut, I bought" from two adjacent lines.
+   * `execution.status` does NOT answer this: it is the plan's own self-report
+   * and stays available separately as 账本自评.
+   */
+  alignment: 'same' | 'opposite' | 'other' | null
 }
 
 export interface EnrichedTrade extends Trade {
   holdPnl: number | null
   t1: TraceT1 | null
   decision: TraceDecision | null
+  /**
+   * What this fill did to the position, decided host-side by `isSellAction`.
+   *
+   * Shipped so the browser half never keeps its own copy of the action set: the
+   * client used to test `action === 'sell'`, which silently dropped the verdict
+   * for cut / trim / trim_on_rebound, and a second copy of that set is how the
+   * two implementations drifted in #739. Null means the action is in neither
+   * bucket — the fill is kept out of both sides rather than guessed into one.
+   */
+  side: 'add' | 'reduce' | null
 }
 
 export interface TracesResult {

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -349,19 +349,23 @@ test("client: renders the single decision-trace view from the mounted remote", a
     traces: async () => ({ ok: true, value: { workspaceKey: "ws1", signature: "sig1", trades: [
       { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15", action: "buy",
         shares: 10, price: 8.77, realizedPnl: null, note: "无限子弹流继续摊本(微信 00:26 HKT)",
-        t1: null, holdPnl: -28.0,
+        t1: null, holdPnl: -28.0, side: "add",
         decision: { planDate: "2026-08-14", action: "cut", confidence: 0.82,
           drivenBy: "risk_rule", rationale: "超限硬止损", execution: "unknown",
-          sizeShares: 200, plannedPrice: 9.21 } },
+          sizeShares: 200, plannedPrice: 9.21,
+          // Host-computed: the plan says cut (reduce), the fill buys (add).
+          alignment: "opposite" } },
       { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-07", action: "buy",
-        shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)",
+        shares: 20, price: 5.88, realizedPnl: null, note: "用户报告成交(01:34 HKT)", side: "add",
         t1: { date: "2026-08-10", price: 5.6, delta: -4.76, verdict: "跌", tone: "loss" } },
       { ticker: "PLTU", market: "US", currency: "USD", date: "2026-08-13", action: "sell",
-        shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓",
+        shares: 5, price: 50, realizedPnl: 45.21428571428572, note: "PLTU 清仓", side: "reduce",
         t1: { date: "2026-08-14", price: 49.24, delta: -1.52, verdict: "卖对", tone: "win" },
         decision: { planDate: "2026-08-10", action: "trim_on_rebound", confidence: 0.6,
           drivenBy: "technical", rationale: "浮盈保护", execution: "followed",
-          condition: "反弹至 50 减仓" } },
+          condition: "反弹至 50 减仓",
+          // Host-computed: trim_on_rebound and sell are both reduces.
+          alignment: "same" } },
     ], rate: 7.8473 } }),
     ledger: async () => ({ ok: true, value: { entries: [] } }),
     portfolio: async () => ({ ok: true, value: { books: [] } }),
@@ -404,9 +408,13 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined, /决策轨迹/);
   assert.match(joined, /已实现 \(USD 等值\)/);
   assert.match(joined, /T\+1 卖飞\/卖对/);
-  // The denominator must be rendered, not implied (#710): the ratio only
-  // covers fills whose close actually landed inside the T+1 window.
-  assert.match(joined, /基于 \d+ 笔/, "the T+1 scorecard must show what it is computed over");
+  // The denominator must be rendered, not implied (#710), and it must be the
+  // denominator the ratio is actually a fraction of (#741): the label used to
+  // read "基于 39 笔" while showing only sell-side verdicts, counting buys in.
+  assert.match(joined, /判出 \d+\/\d+ 笔卖出/,
+    "the T+1 scorecard must show what it is computed over, per side");
+  assert.doesNotMatch(joined, /判出 0\/0 笔卖出/,
+    "a fixture with a sell in it must not report zero sells");
 
   // The chip tone must come from the host's `tone`, not from a threshold the
   // client re-derives (#713). It rides `data-tone` rather than a class name:
@@ -441,7 +449,7 @@ test("client: renders the single decision-trace view from the mounted remote", a
   assert.match(joined, /卖对/);           // T+1 verdict chip
   assert.doesNotMatch(joined, /\+\+/);   // header stat must not double-prepend the sign
 
-  // Filter: 无决策 keeps only SPCH fills without a decision.
+  // Filter: 无当日计划 keeps only SPCH fills without a decision.
   const findButton = (label) => {
     let found = null;
     (function collect(node) {
@@ -455,7 +463,7 @@ test("client: renders the single decision-trace view from the mounted remote", a
     })(tree);
     return found;
   };
-  findButton("无决策").props.onClick();
+  findButton("无当日计划").props.onClick();
   await tick();
   tree = component({ sessionId: "s1", cachedTraces: injected.cachedTraces, fetchTraces: injected.fetchTraces, useStore: store.useStore, actions: store.actions });
   const joinedMiss = collectText();
@@ -478,10 +486,23 @@ test("client: renders the single decision-trace view from the mounted remote", a
   await tick();
   tree = component({ sessionId: "s1", cachedTraces: injected.cachedTraces, fetchTraces: injected.fetchTraces, useStore: store.useStore, actions: store.actions });
   const joined2 = collectText();
-  assert.match(joined2, /决策轨迹 · /);   // expand header
-  assert.match(joined2, /割肉/);           // plan action
-  assert.match(joined2, /执行/);
-  assert.match(joined2, /盈亏/);
+  assert.match(joined2, /决策轨迹 · /);       // expand header
+  assert.match(joined2, /割肉/);               // plan action
+  assert.match(joined2, /当时的计划/);
+  assert.match(joined2, /真实成交/);
+  // #741: the row is a completed fill, so the ledger's own execution.status may
+  // not be rendered as that fill's 执行 verdict — "未执行" on a real buy read as
+  // a contradiction. It survives as the plan's self-report, labelled as such.
+  assert.match(joined2, /账本自评/);
+  assert.doesNotMatch(joined2, /(^|[^自])执行\s/, "execution.status must not head a node on this row");
+  // #741: the plan-vs-fill relation is stated, not left to be inferred. The
+  // fixture plans 割肉 and buys — a reversal.
+  assert.match(joined2, /与计划反向/);
+  // #741: per-fill realized money and position-level floating percent are
+  // different quantities and never share the 盈亏 label. This row is unclosed,
+  // so it shows the position's figure, marked as the position's.
+  assert.match(joined2, /该持仓当前浮动/);
+  assert.doesNotMatch(joined2, /盈亏\s*[-+\d]/, "a bare 盈亏 label may not carry either figure");
 });
 
 test("T+1 reading: one host-side dead zone drives chip, node and verdict (#665/#713)", async () => {

--- a/tests/test_decision_trace_parity.py
+++ b/tests/test_decision_trace_parity.py
@@ -108,3 +108,71 @@ def test_verdict_and_tone_agree_on_every_side_of_the_dead_zone():
             verdict = dashboard._t1_verdict(action, delta)
             tone = dashboard._t1_tone(action, delta)
             assert (verdict == "持平") == (tone == "flat"), (action, delta, verdict, tone)
+
+
+def _action_sets(plugin_source):
+    """(add, reduce) action buckets as written in the plugin ledger, reduced to
+    what planFillAlignment actually reads — not what the docs say it reads."""
+    m_add = re.search(r"const ADD_ACTIONS = new Set\(\[([^\]]*)\]\)", plugin_source)
+    m_reduce = re.search(r"const SELL_ACTIONS = new Set\(\[([^\]]*)\]\)", plugin_source)
+    assert m_add, "ADD_ACTIONS not found in the plugin ledger"
+    assert m_reduce, "SELL_ACTIONS not found in the plugin ledger"
+    return (set(re.findall(r"'([^']+)'", m_add[1])),
+            set(re.findall(r"'([^']+)'", m_reduce[1])))
+
+
+def test_aligning_action_sets_match(plugin_source):
+    """The plan-vs-fill 'same/opposite' classification groups actions into the
+    same add/reduce buckets on both sides (#741). If they ever disagree, the
+    plugin would print 与计划同向 where the dashboard prints 与计划反向 for the
+    same pair of actions."""
+    plugin_add, plugin_reduce = _action_sets(plugin_source)
+    assert plugin_add == set(dashboard._ADD_SIDE), (
+        "the two sides disagree about which actions add to a position")
+    assert plugin_reduce == set(dashboard._REDUCE_SIDE), (
+        "the two sides disagree about which actions reduce a position")
+
+
+def test_plan_fill_alignment_classifies_every_pair_identically(plugin_source):
+    """Re-derive the plugin's alignment from its own pinned action buckets and
+    compare the full plan × fill grid (including an action outside both buckets)
+    against the dashboard's implementation. This is the contract the plugin
+    renders as 与计划同向/反向 — a divergence here would tell the reader the
+    wrong story in one of the two places that show it."""
+    plugin_add, plugin_reduce = _action_sets(plugin_source)
+    actions = sorted(plugin_add | plugin_reduce | {"hold"})  # + one unknown
+
+    def plugin_alignment(plan, fill):
+        # Literal re-read of src/ledger.ts::planFillAlignment.
+        if not isinstance(plan, str) or not isinstance(fill, str):
+            return None
+        if plan == fill:
+            return "same"
+        def side(a):
+            return "add" if a in plugin_add else "reduce" if a in plugin_reduce else None
+        plan_side, fill_side = side(plan), side(fill)
+        if plan_side is None or fill_side is None:
+            return "other"
+        return "same" if plan_side == fill_side else "opposite"
+
+    for plan in actions:
+        for fill in actions:
+            assert plugin_alignment(plan, fill) == dashboard._plan_fill_alignment(plan, fill), (plan, fill)
+        assert plugin_alignment(plan, None) is dashboard._plan_fill_alignment(plan, None) is None
+
+
+def test_breach_hash_strip_pattern_matches(plugin_source):
+    """Both sides strip the same internal risk-engine marker from rationales
+    (`(breach risk-<hex> 30d)`). If the patterns drift, one side leaks a hash
+    the reader cannot decode while the other hides it."""
+    m = re.search(r"readableRationale\(.*?replace\(/([^/]+)/g,", plugin_source, re.S)
+    assert m, "the plugin's breach-strip regex is no longer recognisable"
+    js_pattern = m[1]
+    src = Path(dashboard.__file__).read_text(encoding="utf-8")
+    fn = src[src.index("def _readable_rationale("):src.index("def build_decision_trace_scope(")]
+    ours = re.search(r"re\.sub\(r'([^']+)'", fn)
+    assert ours, "the dashboard's breach-strip regex is no longer recognisable"
+    assert js_pattern == ours[1], (
+        f"the two sides strip different breach markers:\n"
+        f"  plugin:    {js_pattern}\n"
+        f"  dashboard: {ours[1]}")


### PR DESCRIPTION
## 背景

Closes #741

#738/#742 把公开 dashboard「决策轨迹」卡的文案表意问题修好了。**DSH 插件那一半
有一模一样的四处问题**(#739:两边是各自手写的实现,修一边不会自动修另一边),
这版把四条口径搬进插件。

## 改了什么

1. **「执行」节点 → 「真实成交」**。`execution.status` 是**计划的自评**,不是这笔
   成交的执行结果;贴在一笔真实成交上「未执行」自相矛盾(#738 同源)。现在它降级
   为「账本自评」小标签,真实成交节点只剩事实(动作+股数@价),并新增 **alignment**
   字段显式说出「与计划同向 / 与计划反向 / 计划未指向买卖」(真实数据 22/40 反向,
   以前要读者从两行相邻文字里自己推断)。
2. **「盈亏」拆成「本笔已实现」/「该持仓当前浮动(非本笔)」**。以前同一个标签同时
   装本笔金额和持仓整体浮动百分比;未平仓也显式写「— 未平仓」而不是裸 em-dash。
3. **「挂接决策」改人话**:「有当日计划 / 无当日计划」,过滤按钮同步改
   (全部 / 无当日计划 / 卖出复盘 / 有当日计划)。
4. **抬头统计每个数字带真实分母**:T+1 卖飞/卖对改为「判出 X/Y 笔卖出」
   (分母是卖出侧 = `side==='reduce'`,以前「基于 39 笔」里那些数连买入都算进去了)、
   有当日计划 m/n、有「无侧向」笔数兜底。T+1 判定统一显示 verdict 词(不再 gate 在
   `action==='sell'` 上,cut/trim/trim_on_rebound 从此有判词),未判出显式写
   「T+1 未判」。

## 结构上钉住同一契约

- **浏览器侧不再持有任何动作集副本**:`side`(add/reduce,未知动作保持 null)由 host
  用 `isSellAction`/`ADD_ACTIONS` 算好随 payload 下发,T+1 判词显示、卖出过滤
  (`sold` filter)全部读它 —— 以前 `action === 'sell'` 特判漏掉 cut/trim/#739 漂移
  的根源就是第二个动作集副本。
- **`tests/test_decision_trace_parity.py` 新增三条例行钉住**:ADD/REDUCE 侧集合
  双边一致、`planFillAlignment` ↔ `dashboard._plan_fill_alignment` 全 action 格
  分类一致、rationale 的 breach 正则双边一致。插件代码注释之前声称被这条测试钉住,
  实际上并没有 —— 现在是真的了。
- README(根 + 插件)把旧口径(快照收盘/执行/挂接)全部换成新口径。

## 测试

- `tests/decision_studio_plugin.spec.js`:15/15 本地通过(fixture 补 alignment,
  断言改为新口径,并加了「execution.status 不得再树节点」「盈亏标签不得裸带数字」)。
- `tests/test_decision_trace_parity.py`:10/10 本地通过(含 3 条新增)。
- `tests/dsh_plugin_package_contract.mjs`:5/5 通过。
- `npm run build` 后 `git diff --exit-code -- lib` 零 diff(CI 同款机检闸)。