### PR TITLE
release: 0.1.8 发布准备 —— 把 #741 的插件文案修复发出去 (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The newest heading here has to match the version in `pyproject.toml` — CI fails
 otherwise, so a release cannot ship an entry that was never written.
 
+## [0.1.8] — 2026-08-17
+
+The Python package's code is identical to 0.1.7. This version exists to ship the
+plugin: `clawock-dsh` is the release.
+
+### Fixed
+
+- **The Decision Mind plugin rendered the same four copy/verdict
+  misrepresentations the dashboard card fixed in #742 — written by hand on that
+  side, so fixing one side never fixed the other ([#741]).** `execution.status`
+  is the *plan's* self-report, not the fill's outcome, yet it headed the fill's
+  timeline node as 执行/未执行 —「未执行」on a completed buy read as a flat
+  contradiction. The 盈亏 label loaded two different quantities (this fill's
+  realized money and the whole position's floating percent) into one word. The
+  pairing was called 挂接决策, jargon that implied evidence the data did not
+  carry. The T+1 chip only showed a verdict for `action === 'sell'`, silently
+  dropping cut/trim/trim_on_rebound. Now the fill node is 真实成交 with the
+  plan-vs-fill relation stated as 与计划同向/反向 (`alignment`, host-computed;
+  live data is 22/40 reversals), `execution.status` survives only as a labelled
+  账本自评 chip, the P&L node splits into 本笔已实现 vs 该持仓当前浮动（非本笔),
+  pairing reads 有当日计划/无当日计划, every header stat shows the denominator
+  it is a fraction of (判出 X/Y 笔卖出, not a buy-and-sell-mixed total), and
+  unjudged fills say T+1 未判 instead of lying by omission. The browser bundle
+  keeps no second copy of the action set — `side` is computed host-side — and
+  the alignment/action-set/breach-strip rules are now pinned against the
+  dashboard half in `tests/test_decision_trace_parity.py`, which previously
+  claimed to pin them without doing so. ([#744])
+
 ## [0.1.7] — 2026-08-17
 
 The Python package's code is identical to 0.1.6. This version exists to ship the

--- a/examples/dsh/packages/clawock-dsh/package-lock.json
+++ b/examples/dsh/packages/clawock-dsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawock-dsh",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",

--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Mind conversation-view tab",
   "license": "MIT",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawock"
-version = "0.1.7"
+version = "0.1.8"
 description = "Agent-native decision-workflow plugin with a verifiable harness"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## 背景

#741 的修复已在 #744 合并进 master(插件决策轨迹文案表意)。这一版是纯发布准备:
Python 侧代码与 0.1.7 完全相同,0.1.8 的存在意义就是把那份修复发到 npm
(与 0.1.7 为插件而发的先例一致)。

## 改了什么

- `pyproject.toml` 0.1.7 → 0.1.8(`test_versions_agree.py` 唯一版本真源)
- `CHANGELOG.md` 补 `[0.1.8]` 段,与 bump 同 PR(同一条测试强制,先 bump 后补
  条目会红)
- `examples/dsh/packages/clawock-dsh/package.json` + `package-lock.json`
  0.1.7 → 0.1.8(静态清单先对齐;release 工作流发版时从 pyproject 读版本,
  两边不会对不上导致 npm 侧发错号)

## 发版动作(合并后执行)

```bash
git tag v0.1.8 && git push origin v0.1.8
```

tag 触发 release.yml 全量发布:PyPI → npm → GitHub Release。npm 那侧发完会
把 registry 上那份下载回来逐文件核对(#728),所以「发出去了」和「发出去的是
这份代码」是两条独立证据。

## 测试

- `tests/test_versions_agree.py` / `test_github_release_contract.py` /
  `test_version_flag.py`:18/18 本地通过
- README 相对路径、从 PyPI 安装验收等既有闸不变