### PR TITLE
fix(cli): 接上 clawock record + 本机跑最新代码的规则(不为每个修复发版) (#745)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ documentation:
 7. Do not merge while any required check is pending or failing. Fix the branch, push,
    and let the PR rerun its checks.
 8. Squash-merge only after required checks pass, then remove the task worktree/branch.
+9. Apply the merge to this host with `ops/host/refresh_live.sh` — **merging is what
+   makes a fix live here; a release is for people who are not this host.** 本机不用为
+   每个修复发版。The install is editable, so a fast-forward is usually the whole job;
+   the script re-runs the launcher installer only when `pyproject.toml` moved and the
+   DSH plugin installer only when `examples/dsh/packages/clawock-dsh/` moved, then
+   verifies what is actually serving. Rule and evidence:
+   `docs/operations/release.md` § Running the latest code on this host.
 
 Runtime-generated market data, snapshots, reports, ledgers, and dashboard artifacts
 remain on the existing direct-to-`master` bot path. They do not open high-frequency PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Entry pointer for Claude Code in kcn's investment workspace. Same workflow as `A
 | Heartbeat workflow | `HEARTBEAT.md` (heartbeat poll only) |
 | Auto-commit rules | `AGENTS.md` |
 | Interactive code PR/worktree rules | `AGENTS.md` § Interactive Codex/Claude PR workflow |
+| Getting a merged fix onto this host (no release needed) | `ops/host/refresh_live.sh`; rule in `docs/operations/release.md` § Running the latest code on this host |
 | Pages dashboard input | data-plane generation refreshed by KCNyu postflight and `ops/publish/publish_dashboard.sh` |
 | Risk metrics snapshot | `assets/data/risk.json` (built by `clawock portfolio-risk`, refreshed daily via brief preflight) |
 | Decision execution marking | `memory/decisions.jsonl` `execution.status`; manual override via `clawock mark-followed DECISION_ID [--no]` |

--- a/config/information-layers.json
+++ b/config/information-layers.json
@@ -300,6 +300,9 @@
     "mark-followed": {
       "reason": "writes execution ground truth into the decision ledger"
     },
+    "record": {
+      "reason": "appends a conversation verdict to the decision-mind ledger — it records a decision that was already made, and collects nothing"
+    },
     "risk": {
       "reason": "durable governance ledger for breaches — a record of decisions, not an input to one"
     },

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -4,6 +4,52 @@ Only the `clawock` distribution is published. It owns lifecycle, strategies,
 scheduling, watchdogs and provider integrations. Declarative profiles and live
 workspace data are inputs to that distribution, never packages of their own.
 
+## Running the latest code on this host / 本机跑最新代码
+
+**A release is for people who are not this host. Merging is what makes a fix
+live here.** 本机不需要为每个修复发一次 release：合并即上线，发版只面向外部用户。
+
+The desk installs the distribution **editable**
+(`ops/host/install_clawock_launcher.sh`), so `/root/.openclaw/workspace` is the
+implementation rather than a copy of it, and a fast-forward changes behaviour
+with no reinstall (`tests/test_clawock_launcher.py` holds that property). One
+command applies a merge to the whole host:
+
+```bash
+ops/host/refresh_live.sh           # fast-forward, then reinstall only what moved
+ops/host/refresh_live.sh --check   # what is pending; writes nothing, exit 1 if behind
+```
+
+What it decides, and why the two exceptions exist:
+
+| what moved in the merge | what the desk needs | why |
+|---|---|---|
+| anything under `src/clawock/` | nothing beyond the fast-forward | the install is editable |
+| `pyproject.toml` | `ops/host/install_clawock_launcher.sh` | pip recorded the dependency set and the `[project.scripts]` entry points at install time; a new console script does not exist until it is re-run |
+| `examples/dsh/packages/clawock-dsh/**` | `ops/host/install_dsh_plugin.sh --restart` | pnpm installed a packed copy, not a link (#709) — no npm publish involved |
+
+Do not read `clawock --version` as the answer to "what is running here". On an
+editable install that number is the one pip recorded, and it says so itself once
+the checkout moves past it:
+
+```
+clawock 0.1.5 (editable install of /root/.openclaw/workspace, which now declares
+0.1.8 — the code that runs is the checkout's; re-run
+ops/host/install_clawock_launcher.sh to refresh this metadata)
+```
+
+That drift is cosmetic and expected; it was still read as a missing feature once
+([#745](https://github.com/KCNyu/clawock/issues/745)), which is why the string
+now names the checkout. `git -C /root/.openclaw/workspace log --oneline -1` is
+the real answer for the Python half, and for the plugin half it is
+`curl -s http://127.0.0.1:3081/plugins/clawock-dsh/client.js | cmp -
+examples/dsh/packages/clawock-dsh/lib/client.js` — `refresh_live.sh` runs both
+checks itself after it installs anything.
+
+Cut a release when the outside world needs the change — a PyPI/npm user, a
+documented install line, a version a skill contract names — and batch fixes into
+it. The rest of this page is that path.
+
 ## One-time setup (kcn, on the PyPI side)
 
 Trusted publishing is used instead of an API token, so nothing long-lived sits

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -26,7 +26,7 @@ title: clawock · command reference
 
 ## Installed commands / 已安装命令
 
-**63 commands** are installed by the single `clawock` distribution: 51 CLI subcommands and 12 standalone scripts. 41 of them collect or compute information and appear under the layer they feed; the remaining 22 publish, gate, record or schedule, and are listed with the reason they are not collection.
+**64 commands** are installed by the single `clawock` distribution: 52 CLI subcommands and 12 standalone scripts. 41 of them collect or compute information and appear under the layer they feed; the remaining 23 publish, gate, record or schedule, and are listed with the reason they are not collection.
 
 本节由生成器从两份 registry 与 `config/information-layers.json` 推导，不手写；新增或删除一条命令，这张表自己会变。
 
@@ -141,6 +141,7 @@ These are installed commands too. They are listed here so the catalog is the who
 | `clawock claim-provenance` | `clawock.evidence.claim_provenance` | gate: a quoted backtest number must still be in the card it cites |
 | `clawock provenance` | `clawock.evidence.research_provenance` | gate: a published research figure needs two independent sources |
 | `clawock mark-followed` | `clawock.decision.execution` | writes execution ground truth into the decision ledger |
+| `clawock record` | `clawock.decision.record` | appends a conversation verdict to the decision-mind ledger — it records a decision that was already made, and collects nothing |
 | `clawock risk` | `clawock.decision.risk` | durable governance ledger for breaches — a record of decisions, not an input to one |
 | `clawock thesis` | `clawock.decision.theses` | registry the model writes and reads back; its content is authored, not fetched |
 | `clawock entry-gate` | `clawock.decision.entry` | pre-investment gate applied to a candidate, after the information exists |

--- a/ops/host/refresh_live.sh
+++ b/ops/host/refresh_live.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# refresh_live.sh — bring this host's live clawock up to `origin/master`.
+#
+# The desk does not wait for a release to run a merged fix, and it should not:
+# `install_clawock_launcher.sh` installs the distribution **editable**, so
+# /root/.openclaw/workspace *is* the implementation and a fast-forward changes
+# behaviour with no reinstall (`tests/test_clawock_launcher.py` pins that).
+# Two halves of the install do not follow the checkout on their own, and this
+# script is the rule about them, executable:
+#
+#   1. the venv — pip recorded the dependency set and the `[project.scripts]`
+#      entry points at install time. A merge that adds either needs the
+#      installer re-run, or the new command is simply absent.
+#   2. the DSH plugin — pnpm installs a *copy* of the packed package, so
+#      `examples/dsh/packages/clawock-dsh` changes reach the desk only through
+#      `install_dsh_plugin.sh` (see its header for why it packs a tarball).
+#
+# Neither needs npm publish or a PyPI release: publishing is for people who are
+# not this host. See docs/operations/release.md § Running the latest code here.
+#
+# Usage:
+#   ops/host/refresh_live.sh            # fast-forward, then reinstall what moved
+#   ops/host/refresh_live.sh --check    # report what is pending; write nothing
+#                                       # (exit 1 when the desk is behind)
+#
+# Env: LIVE_CHECKOUT (default /root/.openclaw/workspace), LIVE_REMOTE (origin),
+#      LIVE_BRANCH (master).
+set -euo pipefail
+
+CHECKOUT="${LIVE_CHECKOUT:-/root/.openclaw/workspace}"
+REMOTE="${LIVE_REMOTE:-origin}"
+BRANCH="${LIVE_BRANCH:-master}"
+check_only=0
+[ "${1:-}" = "--check" ] && check_only=1
+
+test -d "$CHECKOUT/.git" || { echo "not a git checkout: $CHECKOUT" >&2; exit 2; }
+cd "$CHECKOUT"
+
+git fetch -q "$REMOTE" "$BRANCH"
+range="HEAD..$REMOTE/$BRANCH"
+behind="$(git rev-list --count "$range")"
+
+if [ "$behind" = "0" ]; then
+  echo "live checkout is at $REMOTE/$BRANCH ($(git rev-parse --short HEAD))"
+  exit 0
+fi
+
+changed="$(git diff --name-only "HEAD...$REMOTE/$BRANCH")"
+needs_venv=0
+needs_plugin=0
+grep -qx 'pyproject.toml' <<<"$changed" && needs_venv=1
+grep -q '^examples/dsh/packages/clawock-dsh/' <<<"$changed" && needs_plugin=1
+
+echo "behind $REMOTE/$BRANCH by $behind commit(s):"
+git --no-pager log --oneline "$range" | sed 's/^/  /'
+[ "$needs_venv" = "1" ] && echo "  → pyproject.toml moved: the venv needs install_clawock_launcher.sh"
+[ "$needs_plugin" = "1" ] && echo "  → clawock-dsh moved: the desk needs install_dsh_plugin.sh --restart"
+if [ "$needs_venv" = "0" ] && [ "$needs_plugin" = "0" ]; then
+  echo "  → python only: the editable install picks it up on fast-forward"
+fi
+
+if [ "$check_only" = "1" ]; then
+  echo "(--check: nothing written)"
+  exit 1
+fi
+
+# autostash because the live tree is nearly always dirty — cron writes market
+# data into it all day. Same reasoning as ops/publish/safe_push.sh.
+git -c rebase.autoStash=true pull --rebase -q "$REMOTE" "$BRANCH"
+echo "fast-forwarded to $(git rev-parse --short HEAD)"
+
+if [ "$needs_venv" = "1" ]; then
+  bash ops/host/install_clawock_launcher.sh "$CHECKOUT"
+fi
+if [ "$needs_plugin" = "1" ]; then
+  if command -v dsh >/dev/null; then
+    bash ops/host/install_dsh_plugin.sh --restart
+  else
+    echo "dsh CLI not on PATH — skipped the plugin install" >&2
+  fi
+fi
+
+# Say what is live now rather than assuming the steps above took: an install
+# that reports success while the desk serves the previous build is the failure
+# this repo has already had twice (#709, and the pnpm store reuse in #731).
+# By absolute path, not by name: under the user crontab's PATH=/usr/bin:/bin the
+# launcher is not resolvable (tests/test_no_bare_clawock_invocation.py).
+launcher="${CLAWOCK_LAUNCHER:-$HOME/.local/bin/clawock}"
+[ -x "$launcher" ] && "$launcher" --version
+if command -v dsh >/dev/null; then
+  bundle="examples/dsh/packages/clawock-dsh/lib/client.js"
+  if curl -fs http://127.0.0.1:3081/plugins/clawock-dsh/client.js \
+      | cmp -s - "$bundle"; then
+    echo "dsh serves the checkout's client bundle"
+  else
+    echo "dsh is NOT serving $bundle — investigate before trusting the desk" >&2
+    exit 1
+  fi
+fi

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -513,6 +513,7 @@ PACKAGED_UTILITIES = {
     "quant-review": "clawock.decision.signal_review",
     "realized": "clawock.portfolio.realized",
     "reconcile": "clawock.portfolio.reconcile",
+    "record": "clawock.decision.record",
     "regime": "clawock.decision.regime",
     "research": "clawock.evidence.research_surface",
     "risk": "clawock.decision.risk",
@@ -541,20 +542,125 @@ DOCSTRING_HELP_UTILITIES = frozenset({
     "fundflow", "quant", "quant-review", "t0", "t0-review", "us-quotes",
 })
 
+# One help line per table entry, keyed by it. The parser below is built from
+# PACKAGED_UTILITIES, not from this dict, because the two used to be a table and a
+# parallel name list: #745 is the drift that shape allows. `record` was added to the
+# name list on 2026-08-16 and never to the table, so `clawock record` — the only
+# write path into the decision-mind ledger — was advertised by `--help`, by the DSH
+# skill contract and by docs/, and reachable from none of them. A help line missing
+# here is now a KeyError while the parser is built, i.e. on every invocation.
+UTILITY_HELP = {
+    "aggregates": "recompute portfolio values and P&L from leaves",
+    "analyze-hk": "refresh and analyze active HK holdings",
+    "analyze-us": "refresh and analyze active US holdings",
+    "audit-resettle": "audit decision re-settlement without writing by default",
+    "benchmark": "fetch SPY, HSI, and HSTECH daily benchmark history",
+    "cash": "recompute cash from its reconciliation ledger",
+    "catalysts": "fetch upcoming earnings and macro catalysts",
+    "claim-provenance": "verify backtest claims against run cards",
+    "cross-factor": "rank a curated universe with sector-neutral factors",
+    "daily-bars": "maintain immutable canonical daily OHLC bars",
+    "dashboard-build": "build the configured workspace dashboard projection",
+    "dashboard-outputs": "compare one generated dashboard write set",
+    "earnings": "validate and release primary-source earnings reviews",
+    "em-news": "fetch Chinese news for active HK holdings",
+    "entry-gate": "validate or assess a pre-investment research gate",
+    "evaluate-add-alpha":
+        "walk-forward evaluate add factor and information interactions",
+    "evaluate-combined-regime": "backtest the combined configured regime dial",
+    "evaluate-hstech-regime": "backtest the HSTECH leverage regime",
+    "evaluate-us-leverage": "backtest US single-stock leverage regimes",
+    "evidence": "rebuild the artifact-backed public evidence page",
+    "fetch-peers": "price peer tickers from a JSON request on stdin",
+    "filings": "fetch SEC filings and point-in-time XBRL fundamentals",
+    "fundamentals": "fetch East Money HK/US statements and indicators",
+    "fundflow": "fetch East Money HK/US daily capital flow",
+    "fx": "fetch or convert the canonical USD/HKD rate",
+    "integrity": "verify portfolio money and market-data invariants",
+    "macro": "fetch a portable macro and major-index snapshot",
+    "mark-followed": "record execution ground truth in the decision ledger",
+    "mover-evidence": "probe bounded filing and news evidence for movers",
+    "news-evidence": "build the expiring news and filing evidence graph",
+    "peer-residual": "calibrate curated-peer residual and leadership rules",
+    "plan-context": "show still-open decisions for a downstream run",
+    "portfolio-risk": "compute portfolio beta, volatility, and tail risk",
+    "provenance": "verify numeric research provenance",
+    "quant": "compute holding-level trend, momentum, and risk factors",
+    "quant-review": "reconcile factor signals with forward returns",
+    "realized": "recompute realized P&L from the trade ledger",
+    "reconcile": "recompute all portfolio derivations and verify integrity",
+    "record": "append a conversation verdict to the decision-mind ledger",
+    "regime": "compute the configured leverage-risk regime",
+    "research": "show or check the configured research work queue",
+    "risk": "maintain the durable risk-breach governance ledger",
+    "run-card": "inspect durable backtest evidence",
+    "sentiment": "scan configured holdings across public sentiment sources",
+    "shadow": "simulate followed decisions against buy and hold",
+    "t0": "grade intraday setup quality from existing market data",
+    "t0-review": "reconcile setup grades with next-session returns",
+    "thesis": "validate thesis state or evaluate evidence-only drift",
+    "us-quotes": "refresh US holdings through the provider fallback chain",
+    "validate-regime-dial": "walk-forward validate the production regime dial",
+    "validate-sidecar": "validate a workflow-generated sidecar artifact",
+    "watch-list": "scan non-held AI watch names for price opportunities",
+}
+
+
+def _editable_drift(distribution) -> str:
+    """The checkout an editable install runs, when it no longer declares that version.
+
+    An editable install has two versions: the number pip recorded when it ran,
+    and the code the checkout holds now. They separate on the first merge after
+    the install, and only the stale one is printed — which is how #745 was
+    written. `clawock --version` said 0.1.5 on a host whose checkout was three
+    releases further on, so a command that was genuinely broken (`record`, see
+    PACKAGED_UTILITIES) was diagnosed as "the installed package is too old", and
+    the proposed remedy was a release nobody needed. The desk runs the checkout
+    on purpose — docs/operations/release.md § Running the latest code on this
+    host — so the honest answer names both numbers and where the code is.
+
+    Returns "" for a normal wheel install, or when the checkout cannot be read.
+    """
+    import json
+    import tomllib
+    from urllib.parse import unquote, urlparse
+
+    try:
+        raw = distribution.read_text("direct_url.json")
+        origin = json.loads(raw) if raw else {}
+        if not origin.get("dir_info", {}).get("editable"):
+            return ""
+        parsed = urlparse(origin.get("url", ""))
+        if parsed.scheme != "file":
+            return ""
+        checkout = Path(unquote(parsed.path))
+        declared = tomllib.loads(
+            (checkout / "pyproject.toml").read_text(encoding="utf-8")
+        )["project"]["version"]
+    except (OSError, ValueError, KeyError, json.JSONDecodeError):
+        return ""
+    if declared == distribution.version:
+        return ""
+    return (f" (editable install of {checkout}, which now declares {declared} — "
+            "the code that runs is the checkout's; re-run "
+            "ops/host/install_clawock_launcher.sh to refresh this metadata)")
+
 
 def _installed_version() -> str:
     """What pip actually put on this machine, or a sentinel saying it did not.
 
     A source tree that was never installed has no distribution metadata, and
     inventing a number for it would be the drift this indirection exists to
-    avoid — so it says so instead.
+    avoid — so it says so instead. An editable install is a third case:
+    `_editable_drift` above says why it gets a suffix instead of a number.
     """
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError, distribution
 
     try:
-        return version("clawock")
+        installed = distribution("clawock")
     except PackageNotFoundError:
         return "0+unknown (running from an uninstalled source tree)"
+    return installed.version + _editable_drift(installed)
 
 
 def main(argv=None) -> int:
@@ -665,61 +771,8 @@ def main(argv=None) -> int:
     tool.add_argument("--workspace", type=Path, default=None)
     tool.set_defaults(func=_tool)
 
-    for name, help_text in (
-        ("plan-context", "show still-open decisions for a downstream run"),
-        ("risk", "maintain the durable risk-breach governance ledger"),
-        ("watch-list", "scan non-held AI watch names for price opportunities"),
-        ("dashboard-outputs", "compare one generated dashboard write set"),
-        ("dashboard-build", "build the configured workspace dashboard projection"),
-        ("run-card", "inspect durable backtest evidence"),
-        ("provenance", "verify numeric research provenance"),
-        ("entry-gate", "validate or assess a pre-investment research gate"),
-        ("thesis", "validate thesis state or evaluate evidence-only drift"),
-        ("earnings", "validate and release primary-source earnings reviews"),
-        ("research", "show or check the configured research work queue"),
-        ("claim-provenance", "verify backtest claims against run cards"),
-        ("realized", "recompute realized P&L from the trade ledger"),
-        ("aggregates", "recompute portfolio values and P&L from leaves"),
-        ("cash", "recompute cash from its reconciliation ledger"),
-        ("shadow", "simulate followed decisions against buy and hold"),
-        ("fx", "fetch or convert the canonical USD/HKD rate"),
-        ("portfolio-risk", "compute portfolio beta, volatility, and tail risk"),
-        ("quant", "compute holding-level trend, momentum, and risk factors"),
-        ("regime", "compute the configured leverage-risk regime"),
-        ("t0", "grade intraday setup quality from existing market data"),
-        ("quant-review", "reconcile factor signals with forward returns"),
-        ("t0-review", "reconcile setup grades with next-session returns"),
-        ("cross-factor", "rank a curated universe with sector-neutral factors"),
-        ("peer-residual", "calibrate curated-peer residual and leadership rules"),
-        ("fetch-peers", "price peer tickers from a JSON request on stdin"),
-        ("filings", "fetch SEC filings and point-in-time XBRL fundamentals"),
-        ("fundamentals", "fetch East Money HK/US statements and indicators"),
-        ("fundflow", "fetch East Money HK/US daily capital flow"),
-        ("em-news", "fetch Chinese news for active HK holdings"),
-        ("daily-bars", "maintain immutable canonical daily OHLC bars"),
-        ("catalysts", "fetch upcoming earnings and macro catalysts"),
-        ("us-quotes", "refresh US holdings through the provider fallback chain"),
-        ("analyze-us", "refresh and analyze active US holdings"),
-        ("analyze-hk", "refresh and analyze active HK holdings"),
-        ("benchmark", "fetch SPY, HSI, and HSTECH daily benchmark history"),
-        ("macro", "fetch a portable macro and major-index snapshot"),
-        ("sentiment", "scan configured holdings across public sentiment sources"),
-        ("mover-evidence", "probe bounded filing and news evidence for movers"),
-        ("integrity", "verify portfolio money and market-data invariants"),
-        ("reconcile", "recompute all portfolio derivations and verify integrity"),
-        ("validate-sidecar", "validate a workflow-generated sidecar artifact"),
-        ("mark-followed", "record execution ground truth in the decision ledger"),
-        ("record", "append a conversation verdict to the decision-mind ledger"),
-        ("audit-resettle", "audit decision re-settlement without writing by default"),
-        ("evidence", "rebuild the artifact-backed public evidence page"),
-        ("news-evidence", "build the expiring news and filing evidence graph"),
-        ("evaluate-combined-regime", "backtest the combined configured regime dial"),
-        ("evaluate-hstech-regime", "backtest the HSTECH leverage regime"),
-        ("evaluate-us-leverage", "backtest US single-stock leverage regimes"),
-        ("evaluate-add-alpha", "walk-forward evaluate add factor and information interactions"),
-        ("validate-regime-dial", "walk-forward validate the production regime dial"),
-    ):
-        utility = sub.add_parser(name, help=help_text, add_help=False)
+    for name in PACKAGED_UTILITIES:
+        utility = sub.add_parser(name, help=UTILITY_HELP[name], add_help=False)
         utility.add_argument("utility_args", nargs=argparse.REMAINDER)
         utility.set_defaults(func=_packaged_utility)
 

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from clawock.cli import main
 from clawock.harness import AgentRun, AgentRunRequest
 from clawock.harness.model import Artifact, ArtifactSet
@@ -163,6 +165,57 @@ def test_every_packaged_utility_is_actually_callable():
         if command in HARD_EXIT_UTILITIES and not hasattr(module, "hard_exit"):
             broken.append(f"{command}: {target} has no hard_exit()")
     assert not broken, "packaged utilities the CLI cannot reach:\n" + "\n".join(broken)
+
+
+def test_every_subcommand_the_parser_offers_can_actually_be_dispatched():
+    """The other direction, and the one #745 broke: advertised but unreachable.
+
+    `record` was added to the parser's own utility name list on 2026-08-16 and
+    never to `PACKAGED_UTILITIES`. Every gate above iterates the *table*, so all
+    of them stayed green while `clawock record` — the only write path into the
+    decision-mind ledger, and the command `docs/decision-mind-ledger.md` calls
+    its "唯一写入入口" — died before reaching a module, for the three months of
+    its existence. `clawock --help` listed it the whole time.
+
+    The parser is built from the table now, so the old drift cannot recur in
+    that shape. This asserts the property itself rather than the shape: every
+    name argparse offers is either a table entry or one of the hand-built
+    commands named here, so a new subcommand registered anywhere else has to be
+    added to this list deliberately.
+    """
+    import io
+    import re
+    from contextlib import redirect_stdout
+
+    from clawock import cli
+
+    hand_built = {
+        "init", "run", "doctor", "calendar", "profile", "report", "brief",
+        "intraday", "tool", "context", "workflow",
+    }
+
+    out = io.StringIO()
+    with redirect_stdout(out), pytest.raises(SystemExit):
+        cli.main(["--help"])
+    choices = re.search(r"\{([a-z0-9,-]+)\}", out.getvalue().replace("\n", "")
+                        .replace(" ", ""))
+    assert choices, "clawock --help no longer prints its subcommand choices"
+    offered = set(choices.group(1).split(","))
+
+    unreachable = sorted(offered - set(cli.PACKAGED_UTILITIES) - hand_built)
+    assert not unreachable, (
+        f"`clawock --help` offers {unreachable}, which no registry can dispatch. "
+        "Add each to PACKAGED_UTILITIES (with its UTILITY_HELP line), or to the "
+        "hand-built set in this test if it really is its own parser.")
+
+    missing = sorted(set(cli.PACKAGED_UTILITIES) - offered)
+    assert not missing, f"packaged utilities the parser never registers: {missing}"
+
+    # A help string per table entry, because the parser reads UTILITY_HELP by
+    # key while it is being built: a missing one is a KeyError on every
+    # invocation, and an orphan one is a name that used to exist.
+    assert set(cli.UTILITY_HELP) == set(cli.PACKAGED_UTILITIES)
+    assert all(cli.UTILITY_HELP.values()), "a utility ships an empty help line"
 
 
 def test_every_packaged_utility_answers_help_without_running_anything():

--- a/tests/test_refresh_live.py
+++ b/tests/test_refresh_live.py
@@ -1,0 +1,112 @@
+"""`refresh_live.sh` decides what a merge costs the desk, so the decision is tested.
+
+The rule it encodes — the host runs the checkout, a release is for other people
+(docs/operations/release.md § Running the latest code on this host) — is only
+worth writing down if the follow-up work it names is right. Two of the three
+cases cost something: a `pyproject.toml` move needs the venv reinstalled (pip
+recorded the dependency set and the entry points at install time), and a
+`clawock-dsh` move needs the plugin reinstalled (pnpm installed a copy, not a
+link — #709). The third, ordinary Python, costs nothing because the install is
+editable, and claiming otherwise would reintroduce the reinstall-per-merge habit
+this script exists to remove.
+
+Driven through `--check` against a throwaway remote, so the test needs no venv,
+no dsh and no network.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops" / "host" / "refresh_live.sh"
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(repo),
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+@pytest.fixture
+def desk(tmp_path):
+    """An upstream repo and a checkout of it, in the shape the desk has."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-q", "-b", "master")
+    (upstream / "pyproject.toml").write_text('[project]\nversion = "0.1.0"\n')
+    plugin = upstream / "examples" / "dsh" / "packages" / "clawock-dsh"
+    plugin.mkdir(parents=True)
+    (plugin / "package.json").write_text("{}\n")
+    (upstream / "src").mkdir()
+    (upstream / "src" / "thing.py").write_text("x = 1\n")
+    _git(upstream, "add", "-A")
+    _git(upstream, "commit", "-qm", "base")
+
+    checkout = tmp_path / "checkout"
+    _git(tmp_path, "clone", "-q", str(upstream), str(checkout))
+    return upstream, checkout
+
+
+def _check(checkout):
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--check"], capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(checkout),
+             "LIVE_CHECKOUT": str(checkout)},
+    )
+
+
+def _advance(upstream, relative, body):
+    path = upstream / relative
+    path.write_text(body)
+    _git(upstream, "add", "-A")
+    _git(upstream, "commit", "-qm", f"touch {relative}")
+
+
+def test_it_is_quiet_and_exits_zero_when_the_desk_is_current(desk):
+    _upstream, checkout = desk
+    done = _check(checkout)
+    assert done.returncode == 0, done.stderr
+    assert "is at origin/master" in done.stdout
+    assert "needs" not in done.stdout
+
+
+def test_ordinary_python_needs_no_reinstall_because_the_install_is_editable(desk):
+    upstream, checkout = desk
+    _advance(upstream, "src/thing.py", "x = 2\n")
+    done = _check(checkout)
+    assert done.returncode == 1, "being behind must be reportable as a failure"
+    assert "editable install picks it up" in done.stdout
+    assert "install_clawock_launcher.sh" not in done.stdout
+    assert "install_dsh_plugin.sh" not in done.stdout
+
+
+def test_a_pyproject_move_names_the_venv_reinstall(desk):
+    upstream, checkout = desk
+    _advance(upstream, "pyproject.toml", '[project]\nversion = "0.2.0"\n')
+    done = _check(checkout)
+    assert done.returncode == 1
+    assert "install_clawock_launcher.sh" in done.stdout
+    assert "install_dsh_plugin.sh" not in done.stdout
+
+
+def test_a_plugin_move_names_the_plugin_reinstall(desk):
+    upstream, checkout = desk
+    _advance(upstream, "examples/dsh/packages/clawock-dsh/package.json", '{"a":1}\n')
+    done = _check(checkout)
+    assert done.returncode == 1
+    assert "install_dsh_plugin.sh --restart" in done.stdout
+    assert "install_clawock_launcher.sh" not in done.stdout
+
+
+def test_check_writes_nothing(desk):
+    """The half that makes `--check` usable from a cron or a review."""
+    upstream, checkout = desk
+    _advance(upstream, "src/thing.py", "x = 3\n")
+    before = _git(checkout, "rev-parse", "HEAD").stdout
+    _check(checkout)
+    assert _git(checkout, "rev-parse", "HEAD").stdout == before
+    assert (checkout / "src" / "thing.py").read_text() == "x = 1\n"

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -444,6 +444,10 @@ HOST_OWNED_SHELL = {
         2, "host cron wrapper that reads the Nostr key from this machine's "
            "runtime dir and posts from the live checkout — the broadcast has "
            "no meaning off this host"),
+    "ops/host/refresh_live.sh": (
+        1, "applies a merge to this host: the live checkout is the subject of "
+           "the script, not an incidental dependency — and $LIVE_CHECKOUT "
+           "overrides it, so it runs against any checkout"),
     "ops/growth/nostr_publish.js": (
         1, "locates nostr-tools inside the installed OpenClaw Nostr plugin "
            "instead of vendoring a duplicate dependency; NOSTR_TOOLS_PATH "

--- a/tests/test_version_flag.py
+++ b/tests/test_version_flag.py
@@ -60,7 +60,49 @@ def test_the_reported_version_is_the_installed_one():
     except Exception:
         pytest.skip("clawock is not installed in this environment")
 
-    assert _run("--version").stdout.strip() == f"clawock {installed}"
+    printed = " ".join(_run("--version").stdout.split())
+    assert printed.startswith(f"clawock {installed}")
+    # An editable install may append the drift note below; nothing else may.
+    assert printed == f"clawock {installed}" or "editable install of" in printed
+
+
+def test_an_editable_install_whose_checkout_moved_on_says_which_code_runs(tmp_path):
+    """#745 was written from a `--version` that was true and useless.
+
+    The desk host installs clawock editable and then runs whatever `git pull`
+    leaves in the checkout — deliberately, so a merged fix is live without a
+    release. pip's metadata keeps the number from install time, so `--version`
+    read 0.1.5 while the code was three releases ahead, and a genuinely broken
+    command was reported as a missing feature of an old package.
+    """
+    import json
+
+    from clawock import cli
+
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "9.9.9"\n')
+
+    class _Editable:
+        version = "0.1.5"
+
+        def read_text(self, name):
+            assert name == "direct_url.json"
+            return json.dumps({"dir_info": {"editable": True},
+                               "url": tmp_path.as_uri()})
+
+    note = cli._editable_drift(_Editable())
+    assert str(tmp_path) in note and "9.9.9" in note
+    assert "install_clawock_launcher.sh" in note, "the note must say how to fix it"
+
+    class _Wheel(_Editable):
+        def read_text(self, name):
+            return json.dumps({"dir_info": {}, "url": tmp_path.as_uri()})
+
+    assert cli._editable_drift(_Wheel()) == "", "a wheel install has no second version"
+
+    class _Agreeing(_Editable):
+        version = "9.9.9"
+
+    assert cli._editable_drift(_Agreeing()) == "", "no note while the two agree"
 
 
 def test_the_version_is_not_restated_anywhere_in_the_package():


### PR DESCRIPTION
Closes #745

## 1. `clawock record` 从上线那天起就是不可达的(真缺陷)

`record` 在 ddea63fd(2026-08-16)只加进了 parser 的名字列表,没加进
`PACKAGED_UTILITIES`。于是 `clawock --help` 一直列着它、DSH skill 合同和
docs/decision-mind-ledger.md 都把它写成决策心智账本的「唯一写入入口」,而实际调用
在 argparse 里就死了(`KeyError: 'record'` / `unrecognized arguments`)。

现有的三条闸全部遍历那张表,所以它们对这种漂移是结构性看不见的。这版:

- 表里补上 `record: clawock.decision.record`;
- **parser 改由表驱动**(`UTILITY_HELP` 只提供帮助行,按表 key 取),两份名单合成一份;
- 新增 `test_every_subcommand_the_parser_offers_can_actually_be_dispatched`:
  `--help` 提供的每个名字要么是表里的,要么在测试里显式列出的手写子命令。

红绿实证:给 parser 塞一个 `ghost-command` → 新测试报
「offers ['ghost-command'], which no registry can dispatch」;删掉一条 `UTILITY_HELP`
→ 构建 parser 时直接 KeyError(即每次调用都炸,不会静默)。

`record` 是 excluded(记录已做出的决策,不采集信息),
`config/information-layers.json` 与生成的 `docs/reference/commands.md` 同步
(63 → 64 条命令,excluded 22 → 23)。

## 2. `clawock --version` 说的是安装那一刻的数字(#745 的误诊来源)

editable 安装有两个版本:pip 记下的那个,和 checkout 现在的代码。本机它们差了三个
release,`--version` 报 0.1.5,于是一个真坏了的命令被写成「安装版太旧、缺功能」,
建议的解法是发一个没人需要的版本。现在漂移时它自己说清楚:

    clawock 0.1.5 (editable install of /root/.openclaw/workspace, which now
    declares 0.1.8 — the code that runs is the checkout's; re-run
    ops/host/install_clawock_launcher.sh to refresh this metadata)

wheel 安装、两边一致、checkout 读不到 —— 三种情况都不加后缀,单测覆盖。

## 3. 规则:合并即上线,发版只面向外部(kcn 要求)

`docs/operations/release.md` 新增「Running the latest code on this host /
本机跑最新代码」,AGENTS.md 的 PR 流程加第 9 步,CLAUDE.md 加索引行。规则是可执行的:

    ops/host/refresh_live.sh            # 快进,然后只重装动过的那半边
    ops/host/refresh_live.sh --check    # 只报告,不写;落后就 exit 1

三种情形(表在 docs 里):`src/clawock/` 变了 → editable,快进即可;
`pyproject.toml` 变了 → 重跑 launcher 安装器(依赖集和 entry point 是安装期记录的);
`examples/dsh/packages/clawock-dsh/` 变了 → `install_dsh_plugin.sh --restart`
(pnpm 装的是打包副本不是链接,#709)。装完自己核对线上真在跑什么,不假设。

`tests/test_refresh_live.py` 用一对临时 git 仓库钉住这三条判断(`--check` 模式,
不需要 venv / dsh / 网络),并断言 `--check` 不写任何东西。

## 测试

- 全套 2214 passed / 5 skipped / 4 xfailed(worktree 内跑)。
- 新增 7 条:parser↔表闸 1、editable 漂移 1、refresh_live 5。
