### PR TITLE
ci: 两条最贵的闸从来没在 master 上跑过 + detector 漏了 ops/ + 七份重复 setup (#750 #751 #752)

### DIFF
--- a/.github/actions/clawock-python/action.yml
+++ b/.github/actions/clawock-python/action.yml
@@ -1,0 +1,38 @@
+name: Set up clawock (Python)
+description: >-
+  Install the pinned Python and the clawock distribution the scheduled
+  workflows all need, in one place instead of seven copies.
+
+# Seven scheduled workflows opened with byte-identical steps: setup-python 3.11,
+# then `pip install --quiet -e .`. Seven copies is seven places to forget when
+# the pinned version moves or the install grows an extra, and #751 is what that
+# eventually costs. `actions/checkout` deliberately stays in the caller: it takes
+# per-workflow inputs (fetch-depth, token) and hiding it here would make those
+# invisible at the call site.
+inputs:
+  python-version:
+    description: Python to install. Pinned in one place; override only with a reason.
+    required: false
+    default: '3.11'
+  install:
+    description: >-
+      pip target for the editable install. Pass an extras selector such as
+      `.[compute]` when the job needs the heavier dependency set.
+    required: false
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        # Caching keyed on pyproject.toml: the scheduled jobs install the same
+        # dependency set every run, and a cold resolve is most of their runtime.
+        cache: pip
+        cache-dependency-path: pyproject.toml
+
+    - name: Install clawock
+      shell: bash
+      run: pip install --quiet -e '${{ inputs.install }}'

--- a/.github/workflows/dashboard-artifact-gate.yml
+++ b/.github/workflows/dashboard-artifact-gate.yml
@@ -6,6 +6,15 @@ on:
   # signal, a validation gate switched off by a change somewhere else entirely.
   # This is the same event the publisher raises for the Pages deploy, so the
   # payload is validated on exactly the generations that reach the site.
+  #
+  # #749 asked to fold this into pages.yml so a bad payload could not deploy.
+  # Deliberately not done: this gate runs *beside* the deploy, not in front of it,
+  # because "a payload failed validation" must not become "the site stops
+  # updating" — detect, never silence. A frozen site is the failure mode this desk
+  # has actually had (a stale generation with every check green), and it is worse
+  # than a visible red DATA badge on a generation the next tick supersedes. The
+  # badge in both READMEs is that visibility, and `tests/
+  # test_dashboard_artifact_gate_contract.py` holds this workflow's shape.
   repository_dispatch:
     types: [data-plane-published]
   workflow_dispatch:

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -22,12 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Append week-end snapshot
         run: |

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -95,20 +95,41 @@ jobs:
         # We must NOT path-filter the pull_request trigger itself: a required
         # check that is filtered out never reports and blocks the PR forever
         # (see actionlint.yml). Skipped *steps* count as success, so we gate here.
-        # Only runs on PRs; non-PR events force the steps on via the `if:` below.
+        # Runs on pushes too (#750). It used to be PR-only, with every heavy
+        # step reading `event_name != 'pull_request' || changes...` — which meant
+        # the browser contract and the DSH plugin gates, whose conditions were
+        # written the other way round (`event_name == 'pull_request' && ...`),
+        # could never run on a master push at all. The unit suite did run there
+        # (measured: run 31059122903 on a master push executed "Unit tests —
+        # money-integrity derivations" and skipped only the browser/plugin
+        # steps), so the hole was exactly the two expensive lanes.
         #
         # Keep this path set in sync with the `push:` trigger `paths:` at the top
-        # of this file, except the two core dashboard projections: their frequent
-        # automation commits use
+        # of this file — `test_detector_covers_every_push_trigger_path` now holds
+        # that, because the claim was already false: `ops/**` and
+        # `skills/tavily-search/**` triggered the workflow and then matched
+        # nothing here, so a PR touching only those skipped the entire suite
+        # while `validate` reported green in seconds. Except the two core
+        # dashboard projections: their frequent automation commits use
         # the cheap dashboard-artifact-gate on master, while a rare dashboard PR
         # still gets the full suite here.
         id: changes
-        if: github.event_name == 'pull_request'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # A PR compares its own base and head. A push compares the range it
+          # pushed. Anything else (`workflow_dispatch`, or a push whose `before`
+          # is the all-zero sha because the ref was just created) has no range to
+          # diff, and answers "everything changed" below — running the whole
+          # suite is the safe direction for a manual run.
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "no diffable base ($BASE_SHA) — treating every lane as changed"
+            { echo "code=true"; echo "ui=true"; echo "dsplugin=true"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # --no-renames: a rename OUT of a watched dir (e.g. scripts/x.py ->
           # docs/x.py) must still surface the old path and run the suite, since it
           # can break imports. No --diff-filter, so deletions count too, matching
@@ -124,7 +145,7 @@ jobs:
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
-              src/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*)
+              src/*|ops/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*|skills/tavily-search/*)
                 code=true
                 break
                 ;;
@@ -143,13 +164,13 @@ jobs:
           echo "code changed: $code"
 
       - name: Set up Node for dashboard browser contract
-        if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
+        if: steps.changes.outputs.ui == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Install dashboard browser contract runtime
-        if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: |
           npm install --no-save --silent playwright@1.60.0
           npx playwright install --with-deps chromium
@@ -159,15 +180,15 @@ jobs:
       # contract loads the real page and would time out waiting for a Hero that
       # never receives its projection.
       - name: Fetch the published generation
-        if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: python3 ops/pages/fetch_data_plane.py
 
       - name: Browser contract — Hero, detail tabs, and chart gestures
-        if: github.event_name == 'pull_request' && steps.changes.outputs.ui == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: node tests/dashboard_tab_runtime.spec.js
 
       - name: Set up Node for Decision Studio plugin contract
-        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        if: steps.changes.outputs.dsplugin == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: '22'
@@ -178,7 +199,7 @@ jobs:
       # class hash and the bundler's region paths are both package-relative),
       # so a rebuild here must produce a byte-identical tree.
       - name: Decision Studio artifacts match their sources (rebuild is a no-op)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        if: steps.changes.outputs.dsplugin == 'true'
         env:
           # Same runner hardening as the npm publish job (#732): a lockfile
           # regenerated behind a mirror registry stalls every fetch here and
@@ -200,7 +221,7 @@ jobs:
           }
 
       - name: Decision Studio plugin contract (scan + client bundle registration)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        if: steps.changes.outputs.dsplugin == 'true'
         run: node tests/decision_studio_plugin.spec.js
 
       # The spec above imports lib/ out of the checkout, where the repo's own
@@ -209,17 +230,17 @@ jobs:
       # production. This gate packs and installs the package standalone, which
       # is the only place that class of defect is visible.
       - name: Decision Studio package contract (standalone install + export entries)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.dsplugin == 'true'
+        if: steps.changes.outputs.dsplugin == 'true'
         run: node tests/dsh_plugin_package_contract.mjs
 
       - name: Set up Python
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
       - name: Install minimal deps
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         # numpy is required to *collect* tests/, not just to run one of them:
         # portfolio_risk_metrics imports it at module level, so without it pytest
         # aborts the whole run with a collection error and all 78 tests silently
@@ -230,7 +251,7 @@ jobs:
         run: pip install --quiet -e '.[test]'
 
       - name: Unit tests — money-integrity derivations
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           python3 -m pytest tests/ -q \
             --cov=clawock.publish.dashboard \
@@ -274,7 +295,7 @@ jobs:
         # Fails the PR when coverage drops below its floors — the badge is only a
         # readout, this is the part that holds. Runs on PRs too (not just the
         # publish job) so a regression is caught before merge, not after.
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: python3 ops/ci/coverage_badge.py --report coverage-report.json --check-only
 
       - name: Upload coverage report
@@ -290,14 +311,14 @@ jobs:
           retention-days: 1
 
       - name: Generated cron docs match contract
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: python3 ops/host/generate_cron_docs.py --check
 
       - name: Backtest claims cite a run card that still matches
         # A stale citation is the failure that matters: it points at real
         # evidence which no longer says what the claim says, so it reads as
         # maximally credible while being wrong.
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: clawock claim-provenance --check
 
       - name: Validate research lifecycle artifacts
@@ -305,11 +326,11 @@ jobs:
         # valid — including that a gate's stated verdict matches the recomputed
         # one. Work items (a due earnings review, an ungated position) only warn
         # in system_check; this step fails on integrity alone.
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: clawock research --check
 
       - name: Import-check all scripts
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           set -e
           find src ops -type f -name '*.py' -print0 |
@@ -319,7 +340,7 @@ jobs:
           done
 
       - name: argparse-check harness CLIs
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           set -e
           # `timeout` is the point of this step as much as the exit code. The two
@@ -339,7 +360,7 @@ jobs:
           echo "OK: all argparse parsers loadable"
 
       - name: Schema-validate portfolio.json
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           python3 << 'PY'
           import json, sys
@@ -356,11 +377,11 @@ jobs:
           PY
 
       - name: Schema-validate canonical instrument registry
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: python3 -m clawock.portfolio.instruments
 
       - name: Schema-validate memory/*-plan.json
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           python3 << 'PY'
           import json, glob
@@ -373,7 +394,7 @@ jobs:
           PY
 
       - name: Decision v2 unit tests and ledger audit
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           python3 -m unittest discover -s tests -p 'test_decision_v2.py' -v
           python3 << 'PY'
@@ -415,7 +436,7 @@ jobs:
           PY
 
       - name: Rebuild dashboard.json and validate
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           clawock dashboard-build
           clawock validate-sidecar dashboard
@@ -428,7 +449,7 @@ jobs:
           PY
 
       - name: Run build_dashboard sanity
-        if: github.event_name != 'pull_request' || steps.changes.outputs.code == 'true'
+        if: steps.changes.outputs.code == 'true'
         run: |
           # confirm it runs idempotently
           clawock dashboard-build

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -30,11 +30,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Fetch Trump/Musk + LLM relevance filter
         env:

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -29,12 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Fetch macro
         run: clawock macro --workspace .

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -21,11 +21,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Fetch news + LLM distill
         env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,13 @@ on:
   # documents `repository_dispatch` as creating a run even when sent with the
   # automatic GITHUB_TOKEN, so every publisher can ask — the host through its
   # own login, an Actions publisher through the token it already has.
+  #
+  # #748 asked whether this deploy is needed at all, since the dashboard polls
+  # the data branch directly. It is: `site/assets/js/dashboard.ui.js` keeps the
+  # **first paint** on this origin on purpose (`overview.json` is the only fetch
+  # on the LCP path, and a second origin's handshake there would be paid by every
+  # cold visit). Only the polls after that first paint read the branch. Drop this
+  # trigger and every cold visitor sees the generation from the last deploy.
   repository_dispatch:
     types: [data-plane-published]
   workflow_dispatch:

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -28,12 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Scan sentiment (Reddit + Google News)
         run: clawock sentiment --workspace .

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -19,12 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Compile all scripts
         run: |

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -22,11 +22,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 100
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: Run weekly review
         env:

--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -177,12 +177,14 @@ harness-agnostic 定位的一部分——同一份契约,OpenClaw skill / Claude
 1. DSH 后端直接开在 `http://127.0.0.1:3081/`(systemd `dsh.service`,
    `CLAWOCK_WORKSPACE` 指向 clawock 的 workspace)。本机截图直连这个地址,
    绕开 Tailscale/nginx/HTTPS 那一整套。
-2. Playwright 用系统 Chromium(不是 Playwright 自带那个,本机版本对不上),
+2. Playwright 用**自己管理**的 Chromium,不传 `executable_path`(本机已装,
+   `~/.cache/ms-playwright/`;新机器上 `npx playwright install chromium` 装一次)。
+   (原先这里写的系统 Chromium 是个 snap,2026-08-17 已从本机移除。)
    `device_scale_factor=2` 保证文字清晰:
    ```python
    from playwright.sync_api import sync_playwright
    with sync_playwright() as p:
-       b = p.chromium.launch(executable_path='/usr/bin/chromium-browser', args=['--no-sandbox'])
+       b = p.chromium.launch(args=['--no-sandbox'])
        page = b.new_page(viewport={'width': 1440, 'height': 1100}, device_scale_factor=2)
        page.goto('http://127.0.0.1:3081/', wait_until='networkidle', timeout=20000)
    ```

--- a/site/tools/build_brand_assets.js
+++ b/site/tools/build_brand_assets.js
@@ -2,7 +2,16 @@
 /**
  * Render the canonical vector app icon into the PNG sizes consumed by the site.
  *
- *   CHROME_EXE=/snap/bin/chromium node site/tools/build_brand_assets.js
+ *   node site/tools/build_brand_assets.js
+ *
+ * No browser flag needed: Playwright launches the Chromium it manages itself.
+ * This used to say `CHROME_EXE=/snap/bin/chromium` because the only Chromium on
+ * the desk was a snap (Ubuntu's `chromium-browser` is a snap wrapper, so `apt
+ * install` could not give you a real one) and Playwright's own build had not been
+ * downloaded yet. Both facts changed: the managed build is installed and is what
+ * the screenshot pipeline runs against, and the snap was removed on 2026-08-17.
+ * `CHROME_EXE` is still honoured for pointing at some other binary; on a machine
+ * with no managed build yet, `npx playwright install chromium` fetches it.
  *
  * The source of truth stays site/assets/icons/app-icon.svg. Do not hand-edit the PNGs.
  */

--- a/site/tools/shoot_dashboard.js
+++ b/site/tools/shoot_dashboard.js
@@ -29,8 +29,12 @@
  *   • deviceScaleFactor 2 → retina-crisp PNGs.
  *   • waits for the Hero panel to populate + every <canvas> to have real size before
  *     shooting — never captures mid-animation / blank charts.
- *   • the social card embeds the screenshot as a base64 data-URI (not file://) so it
- *     renders under snap-confined Chromium too.
+ *   • the social card embeds the screenshot as a base64 data-URI (not file://).
+ *     The reason was snap confinement — the snap Chromium this host used to run
+ *     could not read a file:// under /tmp — and that snap is gone since
+ *     2026-08-17. Keep the data-URI anyway: it is also what makes the card
+ *     renderable from a checkout with no writable temp path, and it removes one
+ *     way for the card to ship a broken image.
  */
 const { chromium, devices } = require('playwright');
 const fs = require('fs');

--- a/tests/test_harness_regression_paths.py
+++ b/tests/test_harness_regression_paths.py
@@ -66,3 +66,75 @@ def test_no_push_path_matches_nothing_in_the_checkout():
         if not any(fnmatch(name, pattern.replace("**", "*")) for name in tracked)
     ]
     assert dead == [], f"path filter matches no tracked file: {dead}"
+
+
+def _ui_and_plugin_regexes():
+    """The two lanes the `case` list does not cover — they use grep, not case."""
+    import re
+    found = re.findall(r"grep -Eq '([^']+)'", WORKFLOW)
+    assert len(found) >= 2, f"detector no longer greps for the ui/plugin lanes: {found}"
+    return found
+
+
+def test_detector_covers_every_push_trigger_path():
+    """A push path with no matching detector pattern is a gate that skips itself.
+
+    Both halves ran before #750 and both looked right in review: the trigger
+    listed `ops/**` and `skills/tavily-search/**`, and the `Detect code changes`
+    case list — whose own comment claims to be kept in sync with that trigger —
+    named neither. So a PR touching only `ops/` or the Tavily skill triggered
+    `validate`, matched nothing, skipped every Python step, and reported green in
+    seconds. That is the same shape as the dead `assets/css/**` filter below:
+    a gate that reads correctly and guards nothing.
+    """
+    import re
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert tracked, "empty checkout would make this assertion vacuous"
+
+    covering = [p.replace("*", "*") for p in case_patterns(WORKFLOW_PATH)]
+    regexes = [re.compile(pattern) for pattern in _ui_and_plugin_regexes()]
+
+    def covered(name):
+        return (any(fnmatch(name, pattern) for pattern in covering)
+                or any(regex.search(name) for regex in regexes))
+
+    uncovered = {}
+    for path in push_paths(WORKFLOW_PATH):
+        matches = [name for name in tracked
+                   if fnmatch(name, path.replace("**", "*"))]
+        if matches and not any(covered(name) for name in matches):
+            uncovered[path] = matches[:3]
+    assert uncovered == {}, (
+        "these push-trigger paths reach no detector pattern, so a change confined "
+        f"to them runs no test: {uncovered}")
+
+
+def test_the_heavy_lanes_are_not_gated_on_the_event_that_started_the_run():
+    """#750: the browser contract and the DSH plugin gates could not run on master.
+
+    Their conditions read `github.event_name == 'pull_request' && changes...`
+    while the `Detect code changes` step that feeds them was itself PR-only, so
+    on a master push the detector was skipped, the two conditions were false, and
+    the two most expensive gates in the repository never ran outside a PR. The
+    unit suite did run there — measured on run 31059122903 — which is why this
+    stayed invisible: `validate` was green and mostly busy.
+
+    The detector now runs on every event, so the lanes read only its answer.
+    """
+    import re
+
+    for lane in ("ui", "dsplugin", "code"):
+        gates = re.findall(rf"if: .*steps\.changes\.outputs\.{lane} == 'true'", WORKFLOW)
+        assert gates, f"no step gates on the {lane} lane any more"
+        offenders = [gate for gate in gates if "github.event_name" in gate]
+        assert not offenders, (
+            f"{lane} lane is gated on the event again: {offenders}")
+
+    detector = WORKFLOW.split("- name: Detect code changes", 1)[1].split("id: changes", 1)[1]
+    head = detector.split("run: |", 1)[0]
+    assert "if:" not in head, (
+        "the detector must run on every event; gating it is what made the "
+        "push-side lanes unreachable")


### PR DESCRIPTION
Closes #750, closes #751, closes #752

## 1. #750 —— 原 issue 的前提是错的,底下的洞比它说的窄也比它说的具体

实测(master push 上的 run 31059122903)证明 **master push 上单测是跑的**:
`Unit tests — money-integrity derivations`、coverage、schema 校验、dashboard 重建
全部 success。所以「数据提交直推 master 会整套跳过」的说法不成立,连带
`clawock-agent-pr-ci-workflow` / `clawock-size-gate-measured-the-wrong-bytes` 两份
memory 里的同款说法也一起更正了。

真正的洞:**浏览器契约(ui)和 DSH 插件(dsplugin)这两条最贵的闸,在 master push 上
从来没跑过**。它们的条件写成 `event_name == 'pull_request' && changes.X`,而喂它们的
`Detect code changes` 本身是 PR-only —— push 上 detector 被 skip、两个条件恒假。
它一直看不出来,正因为 `validate` 是绿的而且看起来很忙。

修法:detector 改成**任何事件都跑**(PR 比 base..head;push 比 before..sha;
workflow_dispatch 或 before=全零 时没有可 diff 的基准 → 三条 lane 全部当作变了,
手动跑就跑满,这是安全方向),23 处 step 条件统一成只读 detector 的答案。

## 2. 顺带挖出的第二个洞:detector 的清单声称与 push 触发器同步,其实漏了两个

`ops/**` 和 `skills/tavily-search/**` 在 push 触发器里,却不在 `case` 清单里 ——
**只改 `ops/` 的 PR 触发 validate、匹配不到任何模式、跳过全部 Python step、
几秒钟报绿。** 和 #399 那次 `assets/css/**` 死路径同一个形状:读起来对,守不住东西。
已补齐,并新增两条测试:

- `test_detector_covers_every_push_trigger_path`:每条 push 路径都必须有 tracked
  文件落到某个 detector 模式(case 清单或 ui/dsplugin 两条 grep)上。
- `test_the_heavy_lanes_are_not_gated_on_the_event_that_started_the_run`。

两条都做了反向变异:去掉 `ops/*` → 第一条红;把 `event_name` 门加回 ui lane → 第二条红。

## 3. #751 —— 七份逐字相同的 setup 收成一个 composite action

`.github/actions/clawock-python`(setup-python 3.11 + `pip install --quiet -e .`,
并新增 pip cache,键在 pyproject.toml)。eod-archive / influencer-scan / macro-scan /
news-digest / sentiment-scan / weekly-health / weekly-review 七个定时 workflow 各自
少三行、多一处真相。`actions/checkout` 故意留在调用方:它带 per-workflow 的
fetch-depth/token,藏进 composite 会让这些在调用点看不见。

按 issue 里写的分两步走,这次**只做抽取,不合并成 dispatcher** —— 合并会改 run 名字,
`cron_runs.py` / `cron_health_check.py` / 生成的 cron 文档都按名字对账,那是另一个 PR。

## 4. #752 —— 三处过时的 chromium 指路语

snap(本机唯一的系统 chromium)2026-08-17 已移除,playwright 自己管理的 chromium-1223
一直在且就是管线在用的那个。改掉 `build_brand_assets.js` 的用法注释、
`shoot_dashboard.js` 里「for snap-confined Chromium」那句理由(data-URI 的决定保留,
换成它现在真正的理由)、插件 README 截图配方里的 `executable_path='/usr/bin/chromium-browser'`
(那个 wrapper 随 snapd 一起 purge 了)。

## 5. #748 / #749 —— 前提被推翻,判据写进 workflow 注释,issue 关掉不做

- **#748**(Pages 每次数据发布都全量部署):`dashboard.ui.js` 故意把**首屏**留在 Pages
  同源(`overview.json` 是 LCP 路径上唯一的 fetch),只有首屏之后的轮询才读 data-plane
  分支。删掉这个触发器 = 每个冷访问都看上次部署的数据。
- **#749**(把 artifact gate 合进 pages,让它能拦部署):合进去等于「校验失败 → 站点停止
  更新」,撞 `feedback-detect-but-never-silence`;冻结站点是这台机器真出过的事故,比一个
  红的 DATA 徽章更糟。徽章那条可见性由 `test_dashboard_artifact_gate_contract` 钉着。

两条理由都写进了各自 workflow 的 `on:` 注释,免得下次再被重新提一遍。

## 测试

- 全套 2216 passed / 5 skipped / 4 xfailed(worktree 内)。
- `actionlint` 干净(pinned 1.7.12,和 CI 同一份)。
