### PR TITLE
feat(intraday): 盘中加仓侧读数 + site/tools 进闸 (#754 #755)

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -13,6 +13,10 @@ on:
       - 'site/assets/css/**'
       - 'site/assets/js/**'
       - 'site/index.html'
+      # The screenshot/GIF tooling. Until #754 it was in no trigger, in no
+      # detector lane and in no syntax check: the only thing that ever ran it
+      # was the weekly screenshot-refresh cron, which commits its output.
+      - 'site/tools/**'
       - 'portfolio.json'
       - 'memory/**-plan.json'
       # Research artifacts are validated by the suite below, so a
@@ -145,7 +149,7 @@ jobs:
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
-              src/*|ops/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*|skills/tavily-search/*)
+              src/*|ops/*|tests/*|pyproject.toml|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*|skills/tavily-search/*|site/tools/*)
                 code=true
                 break
                 ;;
@@ -333,10 +337,23 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: |
           set -e
-          find src ops -type f -name '*.py' -print0 |
+          find src ops site/tools -type f -name '*.py' -print0 |
           while IFS= read -r -d '' f; do
             echo "syntax check: $f"
             python3 -m py_compile "$f"
+          done
+
+      # The two Playwright tools are 22KB of JavaScript that only the weekly
+      # screenshot cron executes, and it commits what they produce — so a syntax
+      # error there surfaced on a Sunday, inside a job that writes to master.
+      # Bare `node`: the runner ships it, same as the Tavily ledger step above.
+      - name: Syntax-check the site tooling
+        if: steps.changes.outputs.code == 'true'
+        run: |
+          set -e
+          for f in site/tools/*.js; do
+            echo "node --check: $f"
+            node --check "$f"
           done
 
       - name: argparse-check harness CLIs

--- a/site/tools/assemble_dashboard_gif.py
+++ b/site/tools/assemble_dashboard_gif.py
@@ -22,7 +22,11 @@ from PIL import Image
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 FRAME_DIR = os.environ.get("FRAME_DIR", os.path.join(ROOT, ".gifframes"))
-OUT = os.path.join(ROOT, "site", "assets", "dashboard.gif")
+# Overridable so this script can be exercised without writing over the committed
+# animation. It used to be a hardcoded path, which meant the only way to run it
+# for verification was to copy the file into a throwaway directory tree and run
+# the copy — so nothing ever ran the real one outside the weekly cron (#754).
+OUT = os.environ.get("GIF_OUT") or os.path.join(ROOT, "site", "assets", "dashboard.gif")
 
 OW = 640             # output width (frames scaled to this; height follows aspect)
                      # 640 ≈ 2× the README's 300px display = crisp on retina; source

--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -108,6 +108,14 @@ clawock intraday preflight --market hk
 - 你交付的就是这一段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `anomalies` 非空，**必须**提其中至少一个票；主动一级信息本身也会令 `should_alert=true`，此时不能虚构一个价格异动。
   - `active_information_candidates.candidates` 非空时，至少写最相关一条：Bull 只陈述一手细节及预期传导，Bear 检查是否已 price-in/方向是否仍未知，Judge 照抄 harness 的 `candidate|wait|reject`、falsifier 与 next evidence；只能降级，不能自行补方向、价格、股数或授权。`degraded_issuers` 必须说“一级源降级”，不能说“没有消息”。
+  - 📈 **加仓侧读数(`add_side_reads.rows` 非空时必写 1 行)**:harness 已经把异动、机会雷达
+    (接近 20 日高)、早期趋势三条 lane 连同 thesis 红线和未了结的纪律动作 join 成
+    `candidate|wait|reject`。**照抄 `verdict` + `why` + `needs`,数字照抄 `evidence`**
+    (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
+    「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
+    排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
+    软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
+    `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
     - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -109,6 +109,14 @@ clawock intraday preflight --market us
 - 你交付的就是这一段：**至少 60 字（postflight 软下限），目标 2-3 行**
   - 若 `anomalies` 非空，**必须**提其中至少一个票；主动一级信息本身也会令 `should_alert=true`，此时不能虚构一个价格异动。
   - `active_information_candidates.candidates` 非空时，至少写最相关一条：Bull 只陈述一手细节及预期传导，Bear 检查是否已 price-in/方向是否仍未知，Judge 照抄 harness 的 `candidate|wait|reject`、falsifier 与 next evidence；只能降级，不能自行补方向、价格、股数或授权。`degraded_issuers` 必须说“一级源降级”，不能说“没有消息”。
+  - 📈 **加仓侧读数(`add_side_reads.rows` 非空时必写 1 行)**:harness 已经把异动、机会雷达
+    (接近 20 日高)、早期趋势三条 lane 连同 thesis 红线和未了结的纪律动作 join 成
+    `candidate|wait|reject`。**照抄 `verdict` + `why` + `needs`,数字照抄 `evidence`**
+    (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
+    「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
+    排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
+    软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
+    `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
     - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -1,0 +1,199 @@
+"""What an intraday anomaly means for the add side — read, not authorization.
+
+kcn, 2026-08-17: "我的诉求就是盘中能捕捉到因为情绪消息异动/股价异动分析出来的加仓信号."
+
+Everything this needs was already computed and already in the intraday packet, and
+none of it reached the message: `opportunity_radar` (a technical approach to the
+20-day high), `early_trend_candidates`, `anomalies` (the price move), `mover_news`
+(what filed, already triaged into interrupt/context) and `mover_thesis` (whether a
+red line is live). The prose template named the first three of those nowhere, so a
++6.4% move with three near-breakout rows beside it produced a report about
+holdings and open orders and nothing about adding (#755).
+
+This module only **joins** those answers and states a disposition in the vocabulary
+the rest of the desk already uses (`candidate` / `wait` / `reject`, as in
+`active_information.scan`). It invents no threshold, computes no size, and copies
+every number from its inputs — the rules below are the ones already written down:
+
+* **Discipline first.** A live thesis breach or an unexecuted `risk_rule` action
+  makes it `reject`: while a stop or a trim is outstanding, adding is not a
+  question the desk asks.
+* **Only a primary disclosure can promote.** `candidate` requires an
+  `interrupt`-class primary filing *and* a technical state that is at or near the
+  breakout. This is the existing catalyst gate: soft news and sentiment are colour,
+  never an active-operation reason.
+* **Everything else is `wait`, with what would change it.** A price anomaly with no
+  primary catalyst is the common case (02208 +6.4% on 2026-08-17), and the useful
+  output there is the falsifier — the level or the session that would settle it —
+  not a shrug.
+
+Deliberately absent: the daily `sentiment.json` scan. It carries no intraday
+threshold, so feeding it in would mean inventing one here; soft news already
+reaches these rows through `mover_news`, where it can raise a `wait` and cannot
+promote. Adding sentiment as a trigger is a decision for kcn, not a default.
+"""
+from __future__ import annotations
+
+VERDICTS = ("candidate", "wait", "reject")
+
+# The technical states `opportunity_radar` emits that mean "the breakout is in
+# play". Anything else (a name deep inside its range) is not an add-side read at
+# all and produces no row.
+IN_PLAY_STATES = ("breakout", "near_breakout", "at_high")
+
+
+def _radar_index(radar):
+    """holdings ticker -> radar row. A row can cover several holdings (an index
+    proxy: HSTECH covers 07226), so both the label and every holding map to it."""
+    index = {}
+    for row in (radar or {}).get("rows", []) or []:
+        if row.get("state") not in IN_PLAY_STATES:
+            continue
+        for key in [row.get("label"), *(row.get("holdings") or [])]:
+            if key:
+                index.setdefault(key, row)
+    return index
+
+
+def _primary_interrupt(news, ticker):
+    """The one item class the catalyst gate lets promote a read."""
+    entry = ((news or {}).get("tickers") or {}).get(ticker) or {}
+    for item in entry.get("items") or []:
+        if item.get("signal") == "interrupt" and item.get("tier") == "primary":
+            return item
+    return None
+
+
+def _soft_news(news, ticker):
+    entry = ((news or {}).get("tickers") or {}).get(ticker) or {}
+    items = entry.get("items") or []
+    soft = [i for i in items if i.get("signal") != "interrupt"
+            or i.get("tier") != "primary"]
+    return soft[0] if soft else None
+
+
+def _breach(thesis, ticker):
+    row = (thesis or {}).get(ticker) or {}
+    if row.get("status") in ("triggered", "breached"):
+        return row.get("reason") or row.get("status")
+    for line in row.get("triggered") or []:
+        if isinstance(line, dict):
+            return line.get("required_action") or line.get("label") or "thesis red line"
+        if line:
+            return str(line)
+    return None
+
+
+def _open_risk_action(plan_context, ticker):
+    for row in (plan_context or {}).get("open", []) or []:
+        if row.get("ticker") != ticker:
+            continue
+        if row.get("driven_by") == "risk_rule":
+            return row
+    return None
+
+
+def read_rows(*, anomalies=None, radar=None, early_trend=None, mover_news=None,
+              mover_thesis=None, plan_context=None):
+    """Join the packet's own answers into add-side reads, most acute first.
+
+    Every field is copied from an input; nothing here is derived arithmetic, so a
+    number that appears in a row can always be pointed at in the context.
+    """
+    radar_by_ticker = _radar_index(radar)
+    rows = []
+    seen = set()
+
+    def add(ticker, triggers, evidence):
+        if not ticker or ticker in seen:
+            return
+        seen.add(ticker)
+        breach = _breach(mover_thesis, ticker)
+        risk_action = _open_risk_action(plan_context, ticker)
+        primary = _primary_interrupt(mover_news, ticker)
+        soft = _soft_news(mover_news, ticker)
+        radar_row = radar_by_ticker.get(ticker)
+
+        if breach or risk_action:
+            verdict = "reject"
+            if risk_action:
+                why = (f"纪律动作未了结:{risk_action.get('action')} "
+                       f"{risk_action.get('shares')} 股(driven_by=risk_rule)")
+            else:
+                why = f"thesis 红线在触发状态:{breach}"
+            needs = "先把纪律动作走完,再谈加仓"
+        elif primary and radar_row:
+            verdict = "candidate"
+            why = (f"一手公告 + 技术面{radar_row.get('state_zh') or radar_row.get('state')}"
+                   f":{primary.get('title') or primary.get('headline') or 'primary filing'}")
+            needs = f"站上 {radar_row.get('prior_20d_high')} 并守住"
+        else:
+            verdict = "wait"
+            missing = []
+            if not primary:
+                missing.append("窗口内无一手公告" if soft is None else "只有软消息/情绪面")
+            if not radar_row:
+                missing.append("技术面未接近突破")
+            why = "、".join(missing) or "条件不齐"
+            if radar_row:
+                needs = (f"站上 {radar_row.get('prior_20d_high')}"
+                         f"(现距高 {radar_row.get('pct_from_high')}%)")
+            else:
+                needs = "等一手催化或技术面进入突破区"
+
+        rows.append({
+            "ticker": ticker,
+            "triggers": triggers,
+            "verdict": verdict,
+            "why": why,
+            "needs": needs,
+            "evidence": {k: v for k, v in evidence.items() if v is not None},
+            # Stated, not implied: this lane never sizes or authorises. The desk's
+            # add decisions stay with kcn; #755 asked for visibility, not a trader.
+            "authorization": None,
+        })
+
+    for anomaly in anomalies or []:
+        ticker = anomaly.get("ticker")
+        radar_row = radar_by_ticker.get(ticker)
+        triggers = ["price_anomaly"]
+        if _soft_news(mover_news, ticker) is not None:
+            triggers.append("news")
+        if radar_row:
+            triggers.append("near_breakout")
+        add(ticker, triggers, {
+            "move_pct": anomaly.get("move_pct"),
+            "severity": anomaly.get("severity"),
+            "state": (radar_row or {}).get("state"),
+            "pct_from_high": (radar_row or {}).get("pct_from_high"),
+            "prior_20d_high": (radar_row or {}).get("prior_20d_high"),
+        })
+
+    for row in (early_trend or {}).get("rows", []) or []:
+        add(row.get("label"), ["early_trend"], {
+            "state": row.get("state"),
+            "disposition": row.get("disposition"),
+        })
+
+    for ticker, radar_row in radar_by_ticker.items():
+        # Holdings-only: the radar also carries index labels (HSTECH) whose
+        # holdings row is the tradable one, and it was already added above.
+        if ticker in seen or ticker not in (radar_row.get("holdings") or []):
+            continue
+        add(ticker, ["near_breakout"], {
+            "state": radar_row.get("state"),
+            "pct_from_high": radar_row.get("pct_from_high"),
+            "prior_20d_high": radar_row.get("prior_20d_high"),
+        })
+
+    order = {"candidate": 0, "reject": 1, "wait": 2}
+    rows.sort(key=lambda r: (order[r["verdict"]],
+                             -abs(r["evidence"].get("move_pct") or 0)))
+    return {
+        "rows": rows,
+        "candidate_count": sum(r["verdict"] == "candidate" for r in rows),
+        "wait_count": sum(r["verdict"] == "wait" for r in rows),
+        "reject_count": sum(r["verdict"] == "reject" for r in rows),
+        "policy": ("一手披露才可能促成 candidate;软消息/情绪只能停在 wait;"
+                   "纪律动作未了结一律 reject。三态都不是下单授权。"),
+    }

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -43,6 +43,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from clawock.harness.validation import (
+    ADVISORY_MARK,
     REPORT_CHAR_LIMITS,
     advisory_prefix,
     categorize_issues,
@@ -249,6 +250,16 @@ def validate(text, ctx, prose_only=False, model_text=None):
         mentioned = [t for t in anomaly_tickers if t in checked]
         if anomaly_tickers and not mentioned:
             issues.append(f'should_alert=true 但报告未提任何异动票 ({", ".join(anomaly_tickers)})')
+
+    # 加仓侧的读数 (#755)。它的三条输入(异动/机会雷达/早期趋势)以前全都算好了却从没
+    # 进过正文,所以模板加了要求之后必须配一条闸——否则就是又一个「写了没人写」。
+    # advisory:它只能提醒漏写,不许把一份已经可发的报告变成不发
+    # (feedback-detect-but-never-silence)。
+    add_rows = (ctx.get('add_side_reads') or {}).get('rows') or []
+    if add_rows and not any(row.get('ticker') in checked for row in add_rows):
+        verdicts = '/'.join(f"{row['ticker']} {row['verdict']}" for row in add_rows[:3])
+        issues.append(
+            f'加仓侧读数非空但报告一个都没写 ({verdicts}) {ADVISORY_MARK}')
 
     issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
 

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -43,7 +43,7 @@ from clawock.evidence import research_surface
 from clawock.cli import PACKAGED_UTILITIES
 from clawock.market_data import known_catalysts, mover_evidence as mover_news, peer_scan
 from clawock.decision import active_information
-from clawock.decision import early_trend
+from clawock.decision import add_side, early_trend
 from clawock.portfolio.instruments import is_leveraged_holding
 
 WS = workspace_root(Path.cwd())
@@ -1009,6 +1009,13 @@ def main(argv=None):
         'provisional_setups': live_setups,
         'early_trend_candidates': early_candidates,
         'opportunity_radar': opportunity_radar,
+        # The add-side read over the three lanes above (#755). They were all
+        # computed and none of them reached the prose; this is the join the
+        # template is now required to write.
+        'add_side_reads': add_side.read_rows(
+            anomalies=anomalies, radar=opportunity_radar,
+            early_trend=early_candidates, mover_news=mover_news_ctx,
+            mover_thesis=mover_thesis, plan_context=plan_ctx),
         'signal_count':     signals,
         'signals_detail':   signals_detail,
         'anomalies':        anomalies,

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -1,0 +1,187 @@
+"""The add-side read is a join of answers the packet already had (#755).
+
+kcn's ask was to see, intraday, whether a price/news anomaly amounts to an add
+signal. Everything needed was already computed — `anomalies`, `opportunity_radar`,
+`early_trend_candidates`, `mover_news` (already triaged), `mover_thesis`,
+`plan_context` — and none of it reached the message, because the Mode 7 template
+named none of the three lanes.
+
+These tests pin the three rules the join encodes, each of which is a rule the desk
+already wrote down somewhere else:
+
+1. discipline outranks opportunity (an open `risk_rule` action ⇒ `reject`);
+2. only a primary `interrupt` filing can promote to `candidate`;
+3. everything else is `wait`, carrying the level that would settle it.
+
+Plus the two things that make it usable rather than decorative: the numbers are
+copied (never derived), and the postflight notices when the prose ignores the rows.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from clawock.decision import add_side  # noqa: E402
+
+RADAR = {"rows": [
+    {"label": "02208", "state": "near_breakout", "state_zh": "机会·接近",
+     "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": -4.01},
+    {"label": "HSTECH", "state": "near_breakout", "state_zh": "机会·接近",
+     "holdings": ["07226"], "prior_20d_high": 4948.5, "pct_from_high": -3.06},
+    {"label": "00700", "state": "mid_range", "holdings": ["00700"],
+     "prior_20d_high": 500.0, "pct_from_high": -12.0},
+]}
+PRIMARY = {"tickers": {"02208": {"status": "ok", "items": [
+    {"tier": "primary", "signal": "interrupt", "title": "盈喜:上半年净利预增 60%",
+     "age_minutes": 12},
+]}}}
+SOFT_ONLY = {"tickers": {"02208": {"status": "ok", "items": [
+    {"tier": "supporting", "signal": "context", "title": "券商上调目标价"},
+]}}}
+
+
+def _row(out, ticker):
+    return next(r for r in out["rows"] if r["ticker"] == ticker)
+
+
+def test_a_price_anomaly_without_a_primary_filing_waits_and_names_the_level():
+    """The common case, and the one that produced nothing before: 02208 +6.4%."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news={"tickers": {"02208": {"status": "no_recent_filing",
+                                                       "items": []}}})
+    row = _row(out, "02208")
+    assert row["verdict"] == "wait"
+    assert "无一手公告" in row["why"]
+    assert "11.72" in row["needs"], "a wait with no falsifier is a shrug"
+    assert row["evidence"]["move_pct"] == 6.4
+    assert row["triggers"] == ["price_anomaly", "near_breakout"]
+    assert row["authorization"] is None
+
+
+def test_soft_news_alone_cannot_promote_past_wait():
+    """The catalyst gate, restated here: sentiment and broker notes are colour.
+
+    This is the half kcn asked for ("情绪消息异动") and the half that must not turn
+    into an add authorisation — the rule predates this module.
+    """
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=SOFT_ONLY)
+    row = _row(out, "02208")
+    assert row["verdict"] == "wait"
+    assert "软消息" in row["why"] or "情绪" in row["why"]
+    assert "news" in row["triggers"]
+
+
+def test_a_primary_interrupt_plus_a_breakout_approach_is_a_candidate():
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=PRIMARY)
+    row = _row(out, "02208")
+    assert row["verdict"] == "candidate"
+    assert "盈喜" in row["why"]
+    assert "11.72" in row["needs"]
+    assert out["candidate_count"] == 1
+
+
+def test_a_primary_filing_without_the_technical_state_still_waits():
+    """Half the condition is not the condition."""
+    radar = {"rows": [r for r in RADAR["rows"] if r["label"] != "02208"]}
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=radar, mover_news=PRIMARY)
+    assert _row(out, "02208")["verdict"] == "wait"
+
+
+def test_an_unfinished_risk_rule_action_rejects_regardless_of_how_good_it_looks():
+    """Discipline outranks opportunity — even with a primary catalyst on the tape."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=PRIMARY,
+        plan_context={"open": [{"ticker": "02208", "action": "cut", "shares": 1200,
+                                "driven_by": "risk_rule"}]})
+    row = _row(out, "02208")
+    assert row["verdict"] == "reject"
+    assert "cut" in row["why"] and "1200" in row["why"]
+    assert "纪律" in row["needs"]
+
+
+def test_a_live_thesis_red_line_rejects_too():
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=PRIMARY,
+        mover_thesis={"02208": {"status": "triggered", "reason": "杠杆敞口 30.5% breach"}})
+    assert _row(out, "02208")["verdict"] == "reject"
+
+
+def test_an_unknown_thesis_is_not_a_red_line():
+    """`status: unknown` is the normal state for a name with no baseline (live data
+    on 2026-08-17 had exactly that for both anomaly tickers). Treating it as a
+    breach would make every read a `reject` and the lane useless."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=SOFT_ONLY,
+        mover_thesis={"02208": {"status": "unknown", "reason": "no canonical thesis"}})
+    assert _row(out, "02208")["verdict"] == "wait"
+
+
+def test_a_name_deep_in_its_range_produces_no_row_at_all():
+    """Only states the radar calls in-play are add-side reads; 00700 at -12% is not."""
+    out = add_side.read_rows(anomalies=[], radar=RADAR)
+    assert [r["ticker"] for r in out["rows"]] == ["02208", "07226"], out["rows"]
+
+
+def test_index_labels_resolve_to_the_tradable_holding():
+    """HSTECH has no ticker to add; 07226 is the thing that trades."""
+    out = add_side.read_rows(anomalies=[], radar=RADAR)
+    assert "HSTECH" not in [r["ticker"] for r in out["rows"]]
+    assert _row(out, "07226")["evidence"]["prior_20d_high"] == 4948.5
+
+
+def test_every_number_in_a_row_came_from_the_inputs():
+    """No derived arithmetic: a number in the report must be pointable-at in context."""
+    anomalies = [{"ticker": "02208", "move_pct": 6.4, "severity": "high"}]
+    out = add_side.read_rows(anomalies=anomalies, radar=RADAR, mover_news=SOFT_ONLY)
+    supplied = {6.4, 11.72, -4.01, 4948.5, -3.06}
+    for row in out["rows"]:
+        for key, value in row["evidence"].items():
+            if isinstance(value, (int, float)):
+                assert value in supplied, f"{key}={value} is not an input value"
+
+
+def test_the_live_context_shape_still_feeds_it():
+    """Runs the join on the real packet if this host has one — shape, not values.
+
+    The module reads six context keys; a rename in preflight would otherwise show
+    up as a quietly empty lane, which is how the three lanes it replaces got lost.
+    """
+    live = Path("/root/.openclaw/workspace/memory/.tmp/intraday-context-hk-latest.json")
+    if not live.exists():
+        pytest.skip("no live intraday context on this machine")
+    ctx = json.loads(live.read_text())
+    for key in ("anomalies", "opportunity_radar", "early_trend_candidates",
+                "mover_news", "mover_thesis", "plan_context"):
+        assert key in ctx, f"preflight no longer emits {key}"
+    out = add_side.read_rows(
+        anomalies=ctx["anomalies"], radar=ctx["opportunity_radar"],
+        early_trend=ctx["early_trend_candidates"], mover_news=ctx["mover_news"],
+        mover_thesis=ctx["mover_thesis"], plan_context=ctx["plan_context"])
+    assert set(out) == {"rows", "candidate_count", "wait_count", "reject_count",
+                        "policy"}
+    assert all(r["verdict"] in add_side.VERDICTS for r in out["rows"])
+
+
+def test_both_market_skills_require_the_line_in_the_same_words():
+    """Two hand-written templates that must not drift (#739's lesson)."""
+    texts = [(ROOT / "skills" / f"{market}-stock-analysis" / "SKILL.md").read_text()
+             for market in ("hk", "us")]
+    for text in texts:
+        assert "add_side_reads" in text
+        assert "三态都不是下单授权" in text
+    hk, us = (t.split("add_side_reads", 1)[1][:400] for t in texts)
+    assert hk == us, "the hk and us Mode 7 add-side instructions have drifted"

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -161,9 +161,14 @@ def test_the_live_context_shape_still_feeds_it():
     up as a quietly empty lane, which is how the three lanes it replaces got lost.
     """
     live = Path("/root/.openclaw/workspace/memory/.tmp/intraday-context-hk-latest.json")
-    if not live.exists():
-        pytest.skip("no live intraday context on this machine")
-    ctx = json.loads(live.read_text())
+    try:
+        # `exists()` is not the question — a CI runner has an unreadable /root that
+        # answers True and then raises on read (this test failed exactly that way
+        # on its first PR run). Try the read and let any OSError mean "not here".
+        raw = live.read_text()
+    except OSError:
+        pytest.skip("no readable live intraday context on this machine")
+    ctx = json.loads(raw)
     for key in ("anomalies", "opportunity_radar", "early_trend_candidates",
                 "mover_news", "mover_thesis", "plan_context"):
         assert key in ctx, f"preflight no longer emits {key}"

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -386,3 +386,54 @@ def test_preflight_stamps_a_per_generation_context_id():
     assert a != b
     assert a == common.compute_context_id({'raw_wechat_block': BLOCK, 'time': '00:30'})
     assert len(a) == 12
+
+
+# --- 加仓侧读数 (#755) ---------------------------------------------------------
+
+ADD_SIDE_CTX = {
+    'add_side_reads': {'rows': [
+        {'ticker': 'SKHY', 'verdict': 'wait', 'why': '窗口内无一手公告',
+         'needs': '站上 12.3', 'evidence': {'move_pct': -9.0}, 'authorization': None},
+    ]},
+}
+
+
+def test_prose_that_ignores_the_add_side_rows_is_flagged(pf):
+    """The template now demands a line; without a check that demand is decoration.
+
+    The three lanes this joins (anomalies / opportunity_radar /
+    early_trend_candidates) were computed and shipped in the packet for weeks and
+    never appeared in a report, precisely because nothing noticed (#755).
+    """
+    prose = ('▎我的看法\n'
+             'MSFT 今日 +1.2% 属板块普涨，纪律单继续挂着，其余持仓无变化，'
+             '继续按 08:00 计划执行，不新增动作，等收盘再看一次。\n')
+    ctx = _ctx(**ADD_SIDE_CTX)
+    issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
+                         prose_only=True, model_text=prose)
+    flagged = [i for i in issues if '加仓侧读数' in i]
+    assert flagged, issues
+    # Advisory: it may never turn a deliverable report into a non-delivery.
+    assert '(advisory)' in flagged[0]
+    assert pf.categorize([flagged[0]]) == 'warn'
+
+
+def test_prose_that_writes_the_row_is_not_flagged(pf):
+    prose = ('▎我的看法\n'
+             'SKHY -9.0% 是异动票，加仓侧读数 wait：窗口内无一手公告，站上 12.3 才算，'
+             '纪律单继续挂着；其余持仓按 08:00 计划不动。\n')
+    ctx = _ctx(**ADD_SIDE_CTX)
+    issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
+                         prose_only=True, model_text=prose)
+    assert not [i for i in issues if '加仓侧读数' in i], issues
+
+
+def test_no_rows_means_no_demand(pf):
+    """An empty lane must not nag: most slots have nothing on the add side."""
+    prose = ('▎我的看法\n'
+             'SKHY -9.0% 板块 risk-off，无一手公告；纪律单挂着不动，'
+             '其余持仓按计划，等收盘再看一次，不新增动作。\n')
+    ctx = _ctx(add_side_reads={'rows': []})
+    issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
+                         prose_only=True, model_text=prose)
+    assert not [i for i in issues if '加仓侧读数' in i], issues

--- a/tests/test_site_tools_contract.py
+++ b/tests/test_site_tools_contract.py
@@ -1,0 +1,137 @@
+"""The screenshot pipeline is two halves that agree on a filename, and nothing held that.
+
+`shoot_dashboard.js` writes per-tab scroll frames; `assemble_dashboard_gif.py`
+globs them back. Until #754 the pair was ungated end to end: `site/tools/` was in
+no workflow trigger, in no `Detect code changes` lane, and in no syntax check
+(`find src ops` did not reach it), and no test imported or ran either file. The
+only thing that executed them was the weekly `screenshot-refresh` cron — which
+commits what they produce. A rename on one side, or a seventh tab on the other,
+would surface on a Sunday inside a job that writes to master.
+
+These are behavioural where they can be: the assembler really runs, on real PNGs,
+and the GIF is inspected. The two cross-file contracts (frame naming, tab count)
+are read out of the sources, because the JS half cannot be imported from pytest.
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "site" / "tools"
+SHOOT = (TOOLS / "shoot_dashboard.js").read_text(encoding="utf-8")
+ASSEMBLER = TOOLS / "assemble_dashboard_gif.py"
+ASSEMBLER_SRC = ASSEMBLER.read_text(encoding="utf-8")
+
+
+def _tabs_in_shoot():
+    match = re.search(r"const TABS = \[([^\]]+)\]", SHOOT)
+    assert match, "shoot_dashboard.js no longer declares a TABS list"
+    return [name.strip().strip("'\"") for name in match.group(1).split(",")]
+
+
+def _tab_count_in_assembler():
+    counts = {int(n) for n in re.findall(r"range\((\d+)\)", ASSEMBLER_SRC)}
+    assert len(counts) == 1, (
+        f"the assembler now iterates several different tab counts {counts}; "
+        "one of them is wrong")
+    return counts.pop()
+
+
+def test_the_two_halves_agree_on_how_many_tabs_there_are():
+    """A seventh tab in the shooter makes the assembler exit 1, next Sunday.
+
+    `_load_tab` calls `sys.exit(1)` when a tab has no frames, so adding a tab to
+    `TABS` alone fails the GIF build — and adding one to the assembler alone
+    silently drops the last tab from the animation.
+    """
+    assert len(_tabs_in_shoot()) == _tab_count_in_assembler(), (
+        f"shoot_dashboard.js shoots {_tabs_in_shoot()} "
+        f"({len(_tabs_in_shoot())} tabs) but the assembler iterates "
+        f"range({_tab_count_in_assembler()})")
+
+
+def test_the_frame_names_one_half_writes_are_the_names_the_other_half_reads():
+    """The coupling is a filename, so assert on a filename, not on two regexes."""
+    written = re.findall(r"screenshot\(\{ path: `\$\{FRAME_DIR\}/([^`]+)`", SHOOT)
+    assert written, "shoot_dashboard.js no longer writes frames into FRAME_DIR"
+
+    glob_pattern = re.search(r'glob\.glob\(os\.path\.join\(FRAME_DIR, f"([^"]+)"\)',
+                             ASSEMBLER_SRC)
+    assert glob_pattern, "the assembler no longer globs FRAME_DIR"
+    sort_key = re.search(r'int\(re\.search\(r"([^"]+)", p\)', ASSEMBLER_SRC)
+    assert sort_key, "the assembler no longer sorts frames by their index"
+
+    # Render both sides for tab 3, frame 7, and check the produced name is the
+    # name the other side accepts.
+    for template in written:
+        name = (template.replace("${i}", "3").replace("${j}", "7")
+                        .replace("_0.png", "_0.png"))
+        assert re.fullmatch(r"f\d+_\d+\.png", name), (
+            f"frame name {name!r} is not the f<tab>_<index>.png the assembler reads")
+        assert re.fullmatch(glob_pattern.group(1).replace("{i}", r"\d+")
+                            .replace("*", r"\d+"), name), (
+            f"{name!r} does not match the assembler's glob "
+            f"{glob_pattern.group(1)!r}")
+        assert re.search(sort_key.group(1), name), (
+            f"{name!r} carries no index the assembler can sort by")
+
+
+def test_the_assembler_really_builds_a_gif_from_real_frames(tmp_path):
+    """Runs the committed script, on PNGs, into a temp path — no fake tree.
+
+    Copying the file elsewhere to test it was the old workaround and it proved
+    nothing about the committed one; `GIF_OUT` (#754) is what makes this possible.
+    """
+    Image = pytest.importorskip("PIL.Image", reason="Pillow is the assembler's only dep")
+
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    tabs = len(_tabs_in_shoot())
+    for tab in range(tabs):
+        for index in range(2):
+            # 800px wide like the real capture, so the 640 downscale is exercised.
+            colour = (10 + tab * 30, 40 + index * 60, 90)
+            Image.new("RGB", (800, 400), colour).save(frames / f"f{tab}_{index}.png")
+
+    out = tmp_path / "dashboard.gif"
+    done = subprocess.run(
+        [sys.executable, str(ASSEMBLER)],
+        env={**os.environ, "FRAME_DIR": str(frames), "GIF_OUT": str(out)},
+        capture_output=True, text=True, timeout=300,
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert out.is_file(), done.stdout + done.stderr
+
+    built = Image.open(out)
+    assert built.width == 640, (
+        f"OW is the README's retina budget; the GIF came out {built.width}px wide")
+    # Six tabs × (hold + one scroll frame) plus the horizontal tweens between
+    # them: the exact count is the assembler's business, but it must be an
+    # animation, not a single frame, and every tab must be represented.
+    assert getattr(built, "n_frames", 1) > tabs, (
+        f"only {getattr(built, 'n_frames', 1)} frames for {tabs} tabs")
+    assert f"{tabs} tabs" in done.stdout or "frames" in done.stdout, done.stdout
+
+
+def test_the_committed_gif_path_stays_the_default():
+    """`GIF_OUT` is a test seam, not a relocation: the cron passes nothing."""
+    assert 'os.environ.get("GIF_OUT")' in ASSEMBLER_SRC
+    assert 'os.path.join(ROOT, "site", "assets", "dashboard.gif")' in ASSEMBLER_SRC
+    workflow = (ROOT / ".github" / "workflows" / "screenshot-refresh.yml").read_text()
+    assert "GIF_OUT" not in workflow, (
+        "the publishing workflow must keep writing the committed path")
+
+
+def test_the_tooling_is_inside_the_regression_gate():
+    """The gate this file exists to close — assert the wiring, not just the tests."""
+    workflow = (ROOT / ".github" / "workflows" / "harness-regression.yml").read_text()
+    assert "'site/tools/**'" in workflow, "site/tools is outside the push trigger"
+    assert "site/tools/*)" in workflow or "|site/tools/*" in workflow, (
+        "site/tools is outside the Detect code changes lanes")
+    assert "find src ops site/tools" in workflow, (
+        "the Python syntax check does not reach site/tools")
+    assert "node --check" in workflow, "the two JS tools are not syntax-checked"


### PR DESCRIPTION
Closes #754, closes #755

## 1. #755 —— 盘中「异动 → 加仓信号」:三条 lane 早就算好了,没人读

kcn:「我的诉求就是盘中能捕捉到因为情绪消息异动/股价异动分析出来的加仓信号。」

`opportunity_radar`(接近 20 日高)、`early_trend_candidates`、`anomalies`(价格异动)
连同 `mover_news`(已 triage 成 interrupt/context)、`mover_thesis`(红线)、
`plan_context`(未了结纪律动作)**全都在 packet 里**,而 Mode 7 模板一条都没点名 ——
所以 08-17 那档 02208 +6.4%、雷达三行 near_breakout,送出去的正文全是持仓归因和挂单。
同 `clawock-inert-fixes-2026-08-10` 的判据:算了、进了 context、生产里没人消费。

新增 `src/clawock/decision/add_side.py`:**只做 join,不发明阈值、不算术、不定股数**,
verdict 沿用 `active_information` 的 `candidate|wait|reject` 词表,规则是既有的三条:

1. **纪律优先**:thesis 红线在触发状态、或 `driven_by=risk_rule` 的动作没走完 → `reject`
   (「先把纪律动作走完,再谈加仓」)。
2. **只有一手披露能促成 candidate**:需要 `tier=primary` + `signal=interrupt` **并且**
   技术面在突破区。这就是既有的 catalyst-gate ——**软消息/情绪是颜色,不是主动操作依据**。
3. **其余一律 wait,并带上能翻盘的那个位**(照抄 `prior_20d_high` / `pct_from_high`)。

拿 08-17 15:30 那档真实 context 跑出来:

| 票 | triggers | verdict | why | needs |
|---|---|---|---|---|
| 07226 | price_anomaly + near_breakout | **reject** | 纪律动作未了结:cut 1200 股 | 先走完纪律动作 |
| 02208 | price_anomaly + near_breakout | **wait** | 窗口内无一手公告 | 站上 11.72(现距高 -4.01%) |
| 03033 / 03032 | near_breakout | **wait** | 同上 | 站上 4.854 / 4.946 |

配套:hk 与 us 两份 SKILL 的 Mode 7 同步加「非空必写 1 行」(逐字相同,由测试钉住,
防 #739 那种两套漂移);postflight 加一条**advisory** 闸:rows 非空而正文一个票都没提
就提示——advisory 是刻意的,它永远不能把一份可发的报告变成不发
(`feedback-detect-but-never-silence`)。

**刻意没做**:日频 `sentiment.json` 不进 verdict —— 它没有盘中阈值,接进来就等于在这里
发明一个。软消息已经通过 `mover_news` 进到 rows 里(只能停在 wait)。要不要把情绪面
升级成 trigger 是 kcn 的决定,不该是默认值。

## 2. #754 —— site/tools/ 三个脚本以前在任何闸之外

不在 push 触发器、不在 detector、不被语法检查(`find src ops` 不含它)、没有测试;
唯一执行它们的是每周日那个**会 commit 产物**的 cron。今天(PR #753)改这两个文件的
注释时 CI 一条相关 step 都没跑,那就是证据。

- `site/tools/**` 进 push paths + detector case(PR #753 的
  `test_detector_covers_every_push_trigger_path` 会强制两边同步)。
- python 语法检查扩到 `site/tools`;两个 `.js` 加 `node --check`(runner 自带 node)。
- assembler 的 `OUT` 支持 `GIF_OUT` 覆盖 —— 以前只能把脚本拷进假目录树才能验,
  于是没人验过**提交的那一份**。
- `tests/test_site_tools_contract.py`:**真跑一遍 assembler**(Pillow 造 6×2 张 800px 帧,
  断言产物 640px 宽、帧数 > tab 数)+ 两条跨文件契约(帧名 `f{i}_{j}.png` 双边一致、
  `TABS` 长度 == assembler 的 `range(N)`)+ 断言闸本身接上了。

## 测试(全部做过反向变异)

- 让软消息也能促成 candidate → 3 条红;去掉纪律优先 → 1 条红;去掉 postflight 闸 → 1 条红。
- `TABS` 加一个元素 → tab 数测试红;帧名改 `f{i}-{j}.png` → 命名测试红;`OW` 改 480 → 行为测试红。
- 全套 **2236 passed / 5 skipped / 4 xfailed**;`actionlint` 干净。
