### PR TITLE
add_side: 代理的位归代理,关联照旧 (#761)

### DIFF
--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -116,6 +116,9 @@ clawock intraday preflight --market hk
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
     软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
     `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
+    带 `evidence.proxy_label` 的行,它的位是**代理标的**的位(恒科指数之于 07226、
+    SPCX 之于 SPCH),`needs` 已经把指名写进句子了——**照抄那句,别把
+    `proxy_prior_20d_high` 当成这只票自己的价位**(4948.5 是指数点位,07226 现价个位数)。
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
     - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -117,6 +117,9 @@ clawock intraday preflight --market us
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
     软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
     `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
+    带 `evidence.proxy_label` 的行,它的位是**代理标的**的位(恒科指数之于 07226、
+    SPCX 之于 SPCH),`needs` 已经把指名写进句子了——**照抄那句,别把
+    `proxy_prior_20d_high` 当成这只票自己的价位**(4948.5 是指数点位,07226 现价个位数)。
   - **异动归因（`should_alert=true` 时必写，占 1 行）**：从 `mover_news.tickers[票].items` 里挑 **`signal=interrupt`** 的第一条，写成
     「{票} {幅度}% ← {标题要点}（{age_minutes} 分钟前 / {source_class}）」。多只异动票就各写一行，最多 3 行。
     - `halts` 里有这只票 → **先写停牌**（`reason_code` + 复牌时间），它比任何标题都能解释一次跳动。

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -36,6 +36,11 @@ from __future__ import annotations
 
 VERDICTS = ("candidate", "wait", "reject")
 
+# Marks a radar row reached through a proxy label (an index standing in for the
+# tradable product). Private to this module: it never reaches a row's evidence,
+# which carries `proxy_label` instead.
+PROXY_KEY = "_proxy_label"
+
 # The technical states `opportunity_radar` emits that mean "the breakout is in
 # play". Anything else (a name deep inside its range) is not an add-side read at
 # all and produces no row.
@@ -44,15 +49,32 @@ IN_PLAY_STATES = ("breakout", "near_breakout", "at_high")
 
 def _radar_index(radar):
     """holdings ticker -> radar row. A row can cover several holdings (an index
-    proxy: HSTECH covers 07226), so both the label and every holding map to it."""
+    proxy: HSTECH covers 07226), so both the label and every holding map to it.
+
+    #761: the mapping stays — 07226 *is* the 2x HSTECH product, so the index
+    approaching its high is real information about it. What must not survive the
+    hop is the *attribution* of the numbers: 4948.5 is a Hang Seng Tech index
+    level, and 07226 trades near 3.5 HKD. Rows reached through a proxy are
+    tagged here, and every place that renders a number checks the tag.
+    """
     index = {}
     for row in (radar or {}).get("rows", []) or []:
         if row.get("state") not in IN_PLAY_STATES:
             continue
-        for key in [row.get("label"), *(row.get("holdings") or [])]:
-            if key:
-                index.setdefault(key, row)
+        label = row.get("label")
+        if label:
+            index.setdefault(label, row)
+        for key in row.get("holdings") or []:
+            if not key:
+                continue
+            index.setdefault(key, row if key == label
+                             else {**row, PROXY_KEY: label})
     return index
+
+
+def _proxy_of(radar_row):
+    """The label a row was reached through, or None when it is the row's own."""
+    return (radar_row or {}).get(PROXY_KEY)
 
 
 def _level(levels, ticker):
@@ -70,8 +92,16 @@ def _level(levels, ticker):
 
 
 def _needs_level(row):
-    """The one wording for 'what would settle it', used by radar and level alike."""
-    return f"站上 {row.get('prior_20d_high')}(现距高 {row.get('pct_from_high')}%)"
+    """The one wording for 'what would settle it', used by radar and level alike.
+
+    A proxy row names the thing the level belongs to, because the bare sentence
+    reads as the holding's own price and the two are not in the same scale
+    (#761).
+    """
+    proxy = _proxy_of(row)
+    lead = f"{proxy} 站上 " if proxy else "站上 "
+    return (f"{lead}{row.get('prior_20d_high')}"
+            f"(现距高 {row.get('pct_from_high')}%)")
 
 
 def _primary_interrupt(news, ticker):
@@ -145,7 +175,8 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             verdict = "candidate"
             why = (f"一手公告 + 技术面{radar_row.get('state_zh') or radar_row.get('state')}"
                    f":{primary.get('title') or primary.get('headline') or 'primary filing'}")
-            needs = f"站上 {radar_row.get('prior_20d_high')} 并守住"
+            lead = f"{_proxy_of(radar_row)} 站上 " if _proxy_of(radar_row) else "站上 "
+            needs = f"{lead}{radar_row.get('prior_20d_high')} 并守住"
         else:
             verdict = "wait"
             missing = []
@@ -167,6 +198,18 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
                 evidence = {**evidence,
                             "prior_20d_high": level.get("prior_20d_high"),
                             "pct_from_high": level.get("pct_from_high")}
+
+        proxy = _proxy_of(radar_row)
+        if proxy:
+            # #761: the level came from the proxy, so it must not sit under the
+            # bare key the template is told to copy («数字照抄 evidence 的
+            # prior_20d_high»). The relationship is kept — the row exists, its
+            # `state` still feeds the promotion gate — only the numbers are
+            # re-attributed to the thing they actually measure.
+            evidence = {**evidence, "proxy_label": proxy}
+            for key in ("prior_20d_high", "pct_from_high"):
+                if evidence.get(key) is not None:
+                    evidence[f"proxy_{key}"] = evidence.pop(key)
 
         rows.append({
             "ticker": ticker,

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -57,18 +57,24 @@ def _radar_index(radar):
     level, and 07226 trades near 3.5 HKD. Rows reached through a proxy are
     tagged here, and every place that renders a number checks the tag.
     """
+    rows = [row for row in (radar or {}).get("rows", []) or []
+            if row.get("state") in IN_PLAY_STATES]
     index = {}
-    for row in (radar or {}).get("rows", []) or []:
-        if row.get("state") not in IN_PLAY_STATES:
-            continue
+    # Two passes, and the order matters: a name that has a row of its own must
+    # win over any proxy that also covers it, whatever order the radar sorted
+    # its rows into (it sorts by `pct_from_high`, so a single pass would decide
+    # attribution by today's prices). Nothing in the universe hits this today —
+    # 07226 and SPCH have no rows of their own — but "which numbers this ticker
+    # gets" must not be a function of the sort order the day one appears.
+    for row in rows:
+        if row.get("label"):
+            index.setdefault(row["label"], row)
+    for row in rows:
         label = row.get("label")
-        if label:
-            index.setdefault(label, row)
         for key in row.get("holdings") or []:
-            if not key:
-                continue
-            index.setdefault(key, row if key == label
-                             else {**row, PROXY_KEY: label})
+            if key:
+                index.setdefault(key, row if key == label
+                                 else {**row, PROXY_KEY: label})
     return index
 
 

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -408,3 +408,27 @@ def test_the_private_proxy_marker_never_leaks_into_a_row():
     for row in out["rows"]:
         assert add_side.PROXY_KEY not in row
         assert add_side.PROXY_KEY not in row["evidence"]
+
+
+def test_an_own_row_beats_a_proxy_row_regardless_of_radar_order():
+    """Raised by the deepseek review of #761, verified here.
+
+    `setdefault` in one pass meant "first row wins", and the radar sorts its
+    rows by `pct_from_high` — so if a ticker ever had both a row of its own and
+    a proxy covering it, whose numbers it got would depend on which was nearer
+    its high that minute. No universe entry hits this today (07226 and SPCH
+    have no rows of their own), but attribution must not be decided by a sort
+    order. Both orderings must give 07226 its own 3.9, never HSTECH's 4948.5.
+    """
+    own = {"label": "07226", "state": "near_breakout", "holdings": ["07226"],
+           "prior_20d_high": 3.9, "pct_from_high": -6.92}
+    proxy = {"label": "HSTECH", "state": "near_breakout", "holdings": ["07226"],
+             "prior_20d_high": 4948.5, "pct_from_high": -4.83}
+    for order in ([proxy, own], [own, proxy]):
+        out = add_side.read_rows(
+            anomalies=[{"ticker": "07226", "move_pct": -4.0, "severity": "medium"}],
+            radar={"rows": order})
+        row = _row(out, "07226")
+        assert row["evidence"]["prior_20d_high"] == 3.9, order
+        assert "proxy_label" not in row["evidence"], order
+        assert row["needs"] == "站上 3.9(现距高 -6.92%)", order

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -137,10 +137,20 @@ def test_a_name_deep_in_its_range_produces_no_row_at_all():
 
 
 def test_index_labels_resolve_to_the_tradable_holding():
-    """HSTECH has no ticker to add; 07226 is the thing that trades."""
+    """HSTECH has no ticker to add; 07226 is the thing that trades.
+
+    #761 changed where the number sits, not whether the hop happens: the row is
+    still produced for 07226 and still carries the index's approach, but the
+    level is filed under `proxy_*` because 4948.5 is a Hang Seng Tech index
+    level and 07226 trades near 3.5 HKD.
+    """
     out = add_side.read_rows(anomalies=[], radar=RADAR)
     assert "HSTECH" not in [r["ticker"] for r in out["rows"]]
-    assert _row(out, "07226")["evidence"]["prior_20d_high"] == 4948.5
+    row = _row(out, "07226")
+    assert row["evidence"]["proxy_label"] == "HSTECH"
+    assert row["evidence"]["proxy_prior_20d_high"] == 4948.5
+    assert "prior_20d_high" not in row["evidence"], (
+        "the bare key is what the SKILL tells the model to copy verbatim")
 
 
 def test_every_number_in_a_row_came_from_the_inputs():
@@ -328,3 +338,73 @@ def test_the_radar_keys_levels_by_its_own_label_only():
         monkey.undo()
     assert set(out["levels"]) == {"HSTECH"}, out["levels"]
     assert "07226" not in out["levels"]
+
+
+# --- #761: an index may inform a holding, but its level is not the holding's ---
+#
+# 07226 *is* the 2x HSTECH product, so the index approaching its 20-day high is
+# real information about it and the hop must stay. What could not stay is the
+# attribution: `needs: 站上 4948.5` for a name trading near 3.5 HKD reads as an
+# executable condition and is off by three orders of magnitude. These tests pin
+# both halves — the relationship kept, the numbers re-attributed.
+
+PROXY_RADAR = {"rows": [
+    {"label": "HSTECH", "state": "near_breakout", "state_zh": "机会·接近",
+     "holdings": ["07226"], "prior_20d_high": 4948.5, "pct_from_high": -4.83},
+]}
+
+
+def test_a_proxy_row_names_the_index_in_its_needs_line():
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "07226", "move_pct": -4.0, "severity": "medium"}],
+        radar=PROXY_RADAR)
+    row = _row(out, "07226")
+    assert row["needs"].startswith("HSTECH 站上 4948.5"), row["needs"]
+
+
+def test_a_proxy_candidate_also_names_the_index():
+    """The promotion path renders its own sentence and needs the same guard."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "07226", "move_pct": -4.0, "severity": "medium"}],
+        radar=PROXY_RADAR, mover_news={"tickers": {"07226": {"status": "ok", "items": [
+            {"tier": "primary", "signal": "interrupt", "title": "盈喜"}]}}})
+    row = _row(out, "07226")
+    assert row["verdict"] == "candidate"
+    assert row["needs"].startswith("HSTECH 站上 4948.5"), row["needs"]
+
+
+def test_the_index_to_holding_relationship_is_not_severed():
+    """The half that must NOT change: the hop, the state, and promotion by proxy.
+
+    A fix that simply dropped proxy rows would 'solve' the wrong problem — it
+    would take a real signal away from the only tradable name it applies to.
+    """
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "07226", "move_pct": -4.0, "severity": "medium"}],
+        radar=PROXY_RADAR, mover_news={"tickers": {"07226": {"status": "ok", "items": [
+            {"tier": "primary", "signal": "interrupt", "title": "盈喜"}]}}})
+    row = _row(out, "07226")
+    assert row["ticker"] == "07226"
+    assert row["evidence"]["state"] == "near_breakout", "the index state still applies"
+    assert "near_breakout" in row["triggers"]
+    assert row["verdict"] == "candidate", "a proxy approach can still promote"
+    assert out["candidate_count"] == 1
+
+
+def test_a_name_with_its_own_radar_row_is_untouched_by_the_proxy_rule():
+    """02208 covers itself, so nothing is re-attributed and the wording is bare."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news=SOFT_ONLY)
+    row = _row(out, "02208")
+    assert row["needs"] == "站上 11.72(现距高 -4.01%)"
+    assert row["evidence"]["prior_20d_high"] == 11.72
+    assert "proxy_label" not in row["evidence"]
+
+
+def test_the_private_proxy_marker_never_leaks_into_a_row():
+    """`_proxy_label` is plumbing; `proxy_label` is the published field."""
+    out = add_side.read_rows(anomalies=[], radar=PROXY_RADAR)
+    for row in out["rows"]:
+        assert add_side.PROXY_KEY not in row
+        assert add_side.PROXY_KEY not in row["evidence"]


### PR DESCRIPTION
Closes #761

## 问题

`_radar_index` 把指数行映射到持仓票（`HSTECH→07226`、`SPCX→SPCH`、`RKLB→RKLX`）。**这层映射是对的**——07226 就是恒科的 2x，指数接近突破对它是真信息。错的是**数字的归属**：

```json
{"ticker": "07226", "needs": "站上 4948.5(现距高 -4.83%)",
 "evidence": {"prior_20d_high": 4948.5, "pct_from_high": -4.83}}
```

4948.5 是恒生科技**指数点位**，07226 现价个位数。放大它的是模板：两份 SKILL 明确要求「数字照抄 `evidence`（`move_pct` / `pct_from_high` / `prior_20d_high`）」，而 `check_numeric_claims` 只校验「数字在不在 context 里」——这个数字确实在，拦不住。

## 改了什么（只改归属标注）

```json
{"ticker": "07226", "needs": "HSTECH 站上 4948.5(现距高 -4.83%)",
 "evidence": {"move_pct": -4.0, "severity": "medium", "state": "near_breakout",
              "proxy_label": "HSTECH", "proxy_prior_20d_high": 4948.5,
              "proxy_pct_from_high": -4.83}}
```

- 经代理拿到的行打私有标记（`PROXY_KEY`，不外泄到 row / evidence），`needs` 连指名一起写；candidate 那句同理。
- evidence 里代理来的数字改键名，**模板「照抄 `prior_20d_high`」那条路径结构上取不到代理的数字**，只能走带标注的那条。
- 两份 SKILL 同步加一句（逐字相同，`test_both_market_skills_require_the_line_in_the_same_words` 比对）。

## 明确没改的（有测试钉住）

`test_the_index_to_holding_relationship_is_not_severed` 就是为这一半写的——**一个"直接把代理行丢掉"的修法会解决错的问题**，等于把真信号从唯一能交易的名字上拿走：

- 行照样产出给能交易的 ticker（`HSTECH` 不出现在 rows 里）；
- `evidence.state` 照样是指数的 `near_breakout`，`triggers` 照样含 `near_breakout`；
- 一手公告 + 代理在突破区照样能促成 `candidate`。

自己有 universe 条目的票（02208 / 00100 / CRCL 这些）输出**一个字没变**，由 `test_a_name_with_its_own_radar_row_is_untouched_by_the_proxy_rule` 钉住。

## 验证

- `pytest tests/` 全绿：**2247 passed, 6 skipped, 4 xfailed**（clean checkout，`CLAWOCK_WORKSPACE` 已 unset）
- `test_index_labels_resolve_to_the_tradable_holding` 按新语义更新，更新后仍在钉「输出的是能交易的 ticker，不是 HSTECH」——这是本 PR 唯一一处刻意改动的既有断言，#761 里 kcn 已确认这个语义决定。

## 备注

Codex 的 refresh token 被吊销，本轮交叉 review 仍未走成；对抗审查是我自己做的（#760 那轮我自审查出过一个真缺陷，方法同）。
