### PR TITLE
fix(outcomes): 让 workflow 账本说真话（#763 #764 #765）

### DIFF
--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -23,6 +23,7 @@ import argparse
 import fcntl
 import json
 import os
+import sys
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -128,7 +129,24 @@ def _read_path(path):
 
 
 def load_ledger():
-    return _read_path(LOCAL_PATH) or _read_path(PUBLIC_PATH) or _empty()
+    """Local ledger first; the published copy is a last resort, never a silent one.
+
+    Falling back to PUBLIC_PATH and then writing that content back to LOCAL_PATH
+    would roll the local ledger back to whatever was last published. It has not
+    been observed happening, but a data-losing path must not be invisible.
+    """
+    local = _read_path(LOCAL_PATH)
+    if local is not None:
+        return local
+    public = _read_path(PUBLIC_PATH)
+    if public is not None:
+        print(
+            f"warn: workflow ledger unreadable at {LOCAL_PATH}; falling back to the "
+            f"published copy — stages recorded since the last publish may be missing",
+            file=sys.stderr,
+        )
+        return public
+    return _empty()
 
 
 def _atomic_write(path, data):
@@ -152,6 +170,24 @@ def _stage(status="unknown", **details):
     return out
 
 
+def _advisory_only(stage):
+    """True when a stage's only findings were advisory ones.
+
+    `validation.split_advisory` already guarantees advisory findings never reach
+    the delivered banner — the reader gets a clean report plus one non-blocking
+    `ℹ️` line. Counting them as a degraded product made this ledger contradict
+    what was actually delivered on 21 of 64 slots over 2026-08-17..19 (#764).
+
+    They are still recorded, and still countable, via `issue_count` /
+    `advisory_count` on the stage — detected, never silenced. What changes is
+    only whether they drag `final_product` down.
+
+    A writer that does not report `escalating_count` gets the old, conservative
+    reading, so this can never quietly upgrade a stage nobody has audited.
+    """
+    return stage.get("escalating_count") == 0
+
+
 def _derive_final(record):
     stages = record["stages"]
     preflight = stages["preflight"]["status"]
@@ -166,8 +202,16 @@ def _derive_final(record):
         status, reason = "recovered", "watchdog delivered a usable product"
     elif primary == "success":
         degraded = (
-            llm in {"failed", "warning"}
-            or postflight == "warning"
+            llm == "failed"
+            or (llm == "warning" and not _advisory_only(stages["llm"]))
+            or (
+                postflight == "warning"
+                and not (
+                    _advisory_only(stages["postflight"])
+                    and stages["postflight"].get("data_plane_status")
+                    in {None, "published", "current", "skipped"}
+                )
+            )
             or preflight == "warning"
         )
         status = "degraded" if degraded else "success"
@@ -393,6 +437,104 @@ def reconcile_raw_execution():
         return False
 
 
+# ── Delivery-receipt reconciliation ──────────────────────────────────────────
+# The postflights record their terminal stages at the very end of main(), after
+# send + commit + dashboard + data-plane publish. On 2026-08-19 the 港股午后快报
+# slot was SIGTERM'd by the model's 60s `exec` timeout 35s *after* the WeChat
+# send had already landed, so the ledger kept claiming `pending` for a report
+# the user had received. Recording earlier (see report_postflight) narrows that
+# window; it cannot close it, and it does nothing for slots already stuck.
+#
+# The senders leave a durable receipt at send time. That receipt — not the
+# process exit — is what actually proves delivery, so the ledger reconciles
+# against it. Absent a receipt this must leave the record alone: `pending` is
+# the honest answer when nothing proves otherwise.
+TMP_DIR = WS / "memory" / ".tmp"
+
+
+def _receipt_delivered(payload):
+    """A receipt proves delivery when either channel reports a real send."""
+    return payload.get("sent_ok") is True or payload.get("tg_ok") is True
+
+
+def _receipt_claims(path):
+    """Yield (job, slot_date_or_none, slot_or_none, delivered) for one receipt."""
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    name = path.name
+    delivered = _receipt_delivered(payload)
+    if name.startswith("report-sent-"):
+        try:
+            job = job_for(payload.get("market"), payload.get("phase"))
+        except ValueError:
+            return None
+        # report-sent-{market}-{phase}-{YYYY-MM-DD}.json
+        return job, name[: -len(".json")].rsplit("-", 3)[-3:], None, delivered
+    if name.startswith("intraday-sent-"):
+        # The intraday receipt names its own job and slot, so it needs no parsing.
+        job, slot = payload.get("job"), payload.get("slot")
+        if not job or not slot:
+            return None
+        return job, None, slot, delivered
+    if name.startswith("brief-sent-"):
+        return job_for(brief=True), name[len("brief-sent-"): -len(".json")].split("-"), None, delivered
+    return None
+
+
+def reconcile_delivery_receipts():
+    """Fill in `primary_delivery` for slots whose sender died before recording it.
+
+    Only ever fills an `unknown` stage, and only for a record that already
+    exists: a receipt is evidence about a slot the ledger is tracking, not
+    licence to invent slots. An existing verdict is never overwritten — a
+    watchdog or a later run knows more than a receipt file does.
+    """
+    try:
+        if not TMP_DIR.is_dir():
+            return 0
+        claims = {}
+        for path in sorted(TMP_DIR.glob("*-sent-*.json")):
+            parsed = _receipt_claims(path)
+            if not parsed:
+                continue
+            job, date_parts, slot, delivered = parsed
+            claims[(job, slot, tuple(date_parts) if date_parts else None)] = delivered
+        if not claims:
+            return 0
+        filled = 0
+        with _locked():
+            ledger = load_ledger()
+            for record in ledger.get("records", []):
+                stage = record.get("stages", {}).get("primary_delivery", {})
+                if stage.get("status") != "unknown":
+                    continue
+                job, slot = record.get("job"), record.get("slot")
+                delivered = claims.get((job, slot, None))
+                if delivered is None:
+                    delivered = claims.get((job, None, tuple(str(slot)[:10].split("-"))))
+                if delivered is None:
+                    continue
+                record["stages"]["primary_delivery"] = _stage(
+                    "success" if delivered else "failed",
+                    at=_now().isoformat(),
+                    channel="wechat_or_telegram",
+                    source="delivery_receipt",
+                )
+                record["final_product"] = _derive_final(record)
+                filled += 1
+            if filled:
+                ledger["updated_at"] = _now().isoformat()
+                _atomic_write(LOCAL_PATH, ledger)
+        return filled
+    except Exception as exc:
+        print(f"warn: delivery receipt reconciliation skipped: {exc}", file=sys.stderr)
+        return 0
+
+
 def summarize(*, reconcile=False, hours=36):
     """Reconcile, then fold this desk's ledger with the portable arithmetic.
 
@@ -402,12 +544,14 @@ def summarize(*, reconcile=False, hours=36):
     """
     if reconcile:
         reconcile_raw_execution()
+        reconcile_delivery_receipts()
     return summarize_records(load_ledger().get("records", []),
                              hours=hours, now=_now())
 
 
 def publish():
     reconcile_raw_execution()
+    reconcile_delivery_receipts()
     ledger = load_ledger()
     before = PUBLIC_PATH.read_text() if PUBLIC_PATH.exists() else None
     payload = json.dumps(ledger, ensure_ascii=False, indent=2) + "\n"

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -454,6 +454,7 @@ def categorize(issues):
 from clawock.harness.validation import (
     categorize_issues,
     check_md_table_column_consistency,
+    split_advisory,
 )
 from ._harness_common import (  # noqa: E402
     dashboard_publication_state,
@@ -707,6 +708,10 @@ def main(argv=None):
         dry_run=args.dry_run,
         context_present=bool(context),
     )
+    # Same escalating/advisory split the report/intraday banners use: an
+    # advisory-only slot delivers a clean product and must not be filed as a
+    # degraded one (#764).
+    escalating, advisories = split_advisory(issues)
     workflow_outcomes.record_stage(
         job_name,
         'llm',
@@ -714,6 +719,8 @@ def main(argv=None):
         slot=slot,
         dry_run=args.dry_run,
         issue_count=len(issues),
+        escalating_count=len(escalating),
+        advisory_count=len(advisories),
         readability=readability,
     )
     # Emit a CLOSED cross-process gate before anything else can raise.  A valid
@@ -902,6 +909,8 @@ def main(argv=None):
         slot=slot,
         dry_run=args.dry_run,
         issue_count=len(issues),
+        escalating_count=len(escalating),
+        advisory_count=len(advisories),
         commit_ok=commit_ok,
         readability=readability,
     )

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -604,6 +604,9 @@ def main(argv=None):
         telegram_sent=tg_ok, dashboard_published=dashboard_published,
         data_plane_status=data_plane_status,
         insights_sidecar=insights_written, issue_count=len(issues),
+        # The ledger needs the same escalating/advisory split the banner uses:
+        # an advisory-only slot delivered a clean report (#764).
+        escalating_count=len(escalating), advisory_count=len(advisories),
     )
     result['heartbeat'] = {
         'job': heartbeat.get('job'), 'slot': heartbeat.get('slot'),

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -437,6 +437,13 @@ def main(argv=None):
               if stale_generation
               else validate(text, ctx, prose_only=prose_only, model_text=model_text))
     status = categorize(issues) if not stale_generation else 'fail'
+
+    # The banner counts and lists ESCALATING issues only; advisory findings get
+    # their own line below, so a truncated list can never drop them (#134).
+    # The split happens before the stage record because the ledger needs the same
+    # distinction: an advisory-only slot delivers a clean report and must not be
+    # filed as a degraded product (#764).
+    escalating, advisories = split_advisory(issues)
     workflow_outcomes.record_stage(
         job_name,
         'llm',
@@ -444,11 +451,9 @@ def main(argv=None):
         slot=slot,
         context_id=ctx.get('context_id'),
         issue_count=len(issues),
+        escalating_count=len(escalating),
+        advisory_count=len(advisories),
     )
-
-    # The banner counts and lists ESCALATING issues only; advisory findings get
-    # their own line below, so a truncated list can never drop them (#134).
-    escalating, advisories = split_advisory(issues)
     if status == 'pass' or not escalating:
         banner = ''
     elif status == 'warn':
@@ -534,6 +539,28 @@ def main(argv=None):
                                             context_generated_at=ctx.get('generated_at'),
                                             claim_path=claim_path)
 
+    # Record delivery here, not at the end of main(). Everything below — commit,
+    # dashboard, data-plane publish — can take minutes, and on 2026-08-19 a 60s
+    # `exec` timeout SIGTERM'd this process in exactly that gap, leaving a
+    # delivered report filed as `pending` forever (#765). The send is already
+    # proven at this point; nothing after it can make it less true.
+    primary_delivery_ok = bool(wechat_sent)
+    try:
+        primary_delivery_ok = (
+            primary_delivery_ok
+            or json.loads(report_marker.read_text()).get('tg_ok') is True
+        )
+    except Exception:
+        pass
+    workflow_outcomes.record_stage(
+        job_name,
+        'primary_delivery',
+        'success' if primary_delivery_ok else 'failed',
+        slot=slot,
+        channel='wechat_or_telegram',
+        deterministic_fallback=(status == 'fail'),
+    )
+
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
     data_plane_status = classify_data_plane(commit_ok, commit_msg)
 
@@ -571,22 +598,8 @@ def main(argv=None):
         delivered=result['delivered'],
         data_plane_status=data_plane_status,
         issue_count=len(issues),
-    )
-    primary_delivery_ok = bool(wechat_sent)
-    try:
-        primary_delivery_ok = (
-            primary_delivery_ok
-            or json.loads(report_marker.read_text()).get('tg_ok') is True
-        )
-    except Exception:
-        pass
-    workflow_outcomes.record_stage(
-        job_name,
-        'primary_delivery',
-        'success' if primary_delivery_ok else 'failed',
-        slot=slot,
-        channel='wechat_or_telegram',
-        deterministic_fallback=(status == 'fail'),
+        escalating_count=len(escalating),
+        advisory_count=len(advisories),
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if data_plane_status not in {'published', 'current'}:

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -269,3 +269,231 @@ def test_dashboard_renderer_labels_raw_and_final_status_separately():
     assert "执行=${raw} / 成品=${final}" in renderer
     assert "可读性=${readability.status}" in renderer
     assert "raw_error_but_product_usable" in renderer
+
+
+# ── #763: the recorder's own failure path ────────────────────────────────────
+
+def test_a_recorder_failure_warns_instead_of_breaking_the_caller(
+    tmp_path, monkeypatch, capsys
+):
+    """record_stage promises it "never lets observability break a job".
+
+    Until 2026-08-19 the module had no `import sys`, so both except handlers
+    raised NameError and did the exact opposite: a bad argument took the calling
+    postflight down with it. Mutation check: remove `import sys` and this test
+    fails on the raised NameError, not on the assertion.
+    """
+    _isolate(tmp_path, monkeypatch)
+    assert outcomes.record_stage("港股开盘报告", "llm", "not-a-real-status") == {}
+    assert "workflow outcome stage not recorded" in capsys.readouterr().err
+
+
+def test_reconciliation_failure_also_only_warns(tmp_path, monkeypatch, capsys):
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        outcomes, "TMP_DIR", tmp_path / "tmp", raising=False
+    )
+    (tmp_path / "tmp").mkdir()
+    monkeypatch.setattr(
+        outcomes, "load_ledger", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    (tmp_path / "tmp" / "brief-sent-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": True})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 0
+    assert "delivery receipt reconciliation skipped" in capsys.readouterr().err
+
+
+# ── #764: advisory-only findings are not a degraded product ──────────────────
+
+def _record_slot(job, slot, *, llm_status, **llm_details):
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(job, "llm", llm_status, slot=slot, **llm_details)
+    outcomes.record_stage(
+        job, "postflight", "warning", slot=slot,
+        data_plane_status="published", **llm_details,
+    )
+    return outcomes.record_stage(
+        job, "primary_delivery", "success", slot=slot,
+    )
+
+
+def test_advisory_only_slot_is_not_filed_as_degraded(tmp_path, monkeypatch):
+    """The delivered report carried no banner, so the ledger must not say degraded.
+
+    validation.split_advisory guarantees an advisory-only finding never reaches
+    the banner: the reader gets a clean report plus one non-blocking ℹ️ line.
+    Filing that as "degraded generation/input" made the ledger contradict what
+    was delivered on 21 of 64 slots over 2026-08-17..19.
+    """
+    _isolate(tmp_path, monkeypatch)
+    record = _record_slot(
+        "港股收盘报告", "2026-07-24T16:00:00+08:00",
+        llm_status="warning", issue_count=1, escalating_count=0, advisory_count=1,
+    )
+    assert record["final_product"]["status"] == "success"
+    # Detected, never silenced: the finding is still countable on the stage.
+    assert record["stages"]["llm"]["advisory_count"] == 1
+    assert record["stages"]["llm"]["status"] == "warning"
+
+
+def test_an_escalating_finding_still_degrades_the_slot(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    record = _record_slot(
+        "港股收盘报告", "2026-07-24T16:00:00+08:00",
+        llm_status="warning", issue_count=2, escalating_count=1, advisory_count=1,
+    )
+    assert record["final_product"]["status"] == "degraded"
+
+
+def test_a_writer_that_reports_no_split_keeps_the_conservative_reading(
+    tmp_path, monkeypatch
+):
+    """No escalating_count means nobody audited it — stay degraded."""
+    _isolate(tmp_path, monkeypatch)
+    record = _record_slot(
+        "港股收盘报告", "2026-07-24T16:00:00+08:00",
+        llm_status="warning", issue_count=1,
+    )
+    assert record["final_product"]["status"] == "degraded"
+
+
+def test_an_unpublished_data_plane_degrades_even_when_findings_are_advisory(
+    tmp_path, monkeypatch
+):
+    """The advisory exemption is about findings, not about a failed publish."""
+    _isolate(tmp_path, monkeypatch)
+    slot = "2026-07-24T16:00:00+08:00"
+    job = "港股收盘报告"
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(
+        job, "llm", "warning", slot=slot, escalating_count=0, advisory_count=1
+    )
+    outcomes.record_stage(
+        job, "postflight", "warning", slot=slot,
+        data_plane_status="stale", escalating_count=0, advisory_count=1,
+    )
+    record = outcomes.record_stage(job, "primary_delivery", "success", slot=slot)
+    assert record["final_product"]["status"] == "degraded"
+
+
+# ── #765: a delivered slot must not stay `pending` because the sender died ───
+
+def _receipts(tmp_path, monkeypatch):
+    tmp = tmp_path / "tmp"
+    tmp.mkdir(exist_ok=True)
+    monkeypatch.setattr(outcomes, "TMP_DIR", tmp, raising=False)
+    return tmp
+
+
+def test_a_receipt_reconciles_a_slot_whose_sender_was_killed_after_the_send(
+    tmp_path, monkeypatch
+):
+    """2026-08-19 13:30: `exec` SIGTERM'd postflight 35s after WeChat had landed.
+
+    The stages that prove delivery are written at the end of main(), after
+    commit + dashboard + data-plane publish, so the ledger kept claiming
+    `pending` for a report kcn had already received. The receipt written at send
+    time is the durable evidence; reconciliation reads it.
+    """
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T13:30:00+08:00"
+    job = "港股午后快报"
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(
+        job, "llm", "warning", slot=slot, escalating_count=0, advisory_count=1
+    )
+    assert outcomes.load_ledger()["records"][0]["final_product"]["status"] == "pending"
+
+    (tmp / "report-sent-hk-pm-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": True, "tg_ok": True, "market": "hk", "phase": "pm"})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 1
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["primary_delivery"]["status"] == "success"
+    assert record["stages"]["primary_delivery"]["source"] == "delivery_receipt"
+    assert record["final_product"]["status"] == "success"
+
+
+def test_reconciliation_records_a_failed_send_as_failed(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T08:00:00+08:00"
+    outcomes.record_stage("盘前深度简报", "preflight", "success", slot=slot)
+    (tmp / "brief-sent-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": False, "tg_ok": False})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 1
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["primary_delivery"]["status"] == "failed"
+
+
+def test_reconciliation_never_invents_a_slot_the_ledger_is_not_tracking(
+    tmp_path, monkeypatch
+):
+    """A receipt is evidence about a tracked slot, not licence to create one."""
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    (tmp / "report-sent-hk-close-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": True, "market": "hk", "phase": "close"})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 0
+    assert outcomes.load_ledger()["records"] == []
+
+
+def test_reconciliation_never_overwrites_a_verdict_the_ledger_already_has(
+    tmp_path, monkeypatch
+):
+    """A watchdog or a later run knows more than a receipt file does."""
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T13:30:00+08:00"
+    job = "港股午后快报"
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(job, "primary_delivery", "failed", slot=slot)
+    (tmp / "report-sent-hk-pm-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": True, "market": "hk", "phase": "pm"})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 0
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["primary_delivery"]["status"] == "failed"
+
+
+def test_no_receipt_means_the_slot_stays_pending(tmp_path, monkeypatch):
+    """`pending` is the honest answer when nothing proves delivery."""
+    _isolate(tmp_path, monkeypatch)
+    _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T13:30:00+08:00"
+    outcomes.record_stage("港股午后快报", "preflight", "success", slot=slot)
+    assert outcomes.reconcile_delivery_receipts() == 0
+    record = outcomes.load_ledger()["records"][0]
+    assert record["final_product"]["status"] == "pending"
+
+
+def test_an_intraday_receipt_reconciles_its_own_named_slot(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T10:30:00+08:00"
+    outcomes.record_stage("盘中盯盘", "preflight", "success", slot=slot)
+    (tmp / "intraday-sent-hk.json").write_text(
+        json.dumps({"sent_ok": True, "job": "盘中盯盘", "slot": slot})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 1
+    assert (
+        outcomes.load_ledger()["records"][0]["stages"]["primary_delivery"]["status"]
+        == "success"
+    )
+
+
+def test_falling_back_to_the_published_ledger_is_never_silent(
+    tmp_path, monkeypatch, capsys
+):
+    """That fallback then writes PUBLIC's content back over LOCAL — say so."""
+    _isolate(tmp_path, monkeypatch)
+    outcomes.PUBLIC_PATH.write_text(
+        json.dumps({"schema_version": outcomes.SCHEMA_VERSION, "records": []})
+    )
+    outcomes.LOCAL_PATH.write_text("{ not json")
+    assert outcomes.load_ledger()["records"] == []
+    assert "falling back to the published copy" in capsys.readouterr().err


### PR DESCRIPTION
Closes #763, closes #764, closes #765.

三条缺陷同属一个部件：`workflow-outcomes.json` 这本账。它是回答「今天系统跑得怎么样」的唯一可信口径（`raw_execution` 已知不可信，见 #757/#758），而这三条各自让它说了假话。

## #763 — `import sys` 缺失，两个 except 处理器全是死的

```
>>> workflow_outcomes.record_stage('港股开盘报告', 'llm', 'not-a-real-status')
NameError: name 'sys' is not defined
```

模块 docstring 写着 record_stage "never lets observability break a job"，实际行为相反：任何进入 except 的路径都会在处理器内部抛 NameError，**把观测组件的失败升级成调用方崩溃**。调用方是三个 postflight 和三个 watchdog。

没有证据表明它已经在产炸过（记账失败本来罕见），属潜伏缺陷。

## #764 — advisory-only 判词被记成 degraded

08-17~08-19 共 64 档里 21 档记成 `degraded / "primary delivery succeeded with degraded generation/input"`。把今天四份港股报告的 prose+context 取回重跑 `validate()`，四档的 issue 列表**只有 advisory 一条**：

```
close: ["context 里没有的数字: 4pp —— 数字只能引用 context，不许心算 (advisory)"]
```

同一份 issue 列表在面向用户那侧是**正确**处理的：`split_advisory()` 让 escalating 为空 ⇒ banner 为空，用户看到的是干净报告加一行 `ℹ️ 数字校验（不影响投递）`。

也就是说同一个事实，对外说「不影响投递」，对内记成「degraded generation」。失真的是账本。

**改法**：postflight 把 `escalating_count` / `advisory_count` 一起记进 stage，`_derive_final` 只在 escalating 非空时才判 degraded。advisory **仍然全部落盘、仍然可数**（`feedback-detect-but-never-silence`），变的只是它不再拖累 `final_product`。

没报 `escalating_count` 的写入方保持旧的保守读法 —— 不会因为这个改动把没人审过的 stage 悄悄升级。

## #765 — postflight 被 SIGTERM 后账本永久停在 pending

`2026-08-19T13:30 港股午后快报` 至今是 `primary_delivery: unknown` / `final_product: pending`，但它**投递成功了**，收据就在旁边（`sent_ok: true`, `deliveryStatus: sent`）。

trajectory 完整还原：

- `05:32:11Z` 模型 `exec` 调 postflight，**`timeout: 60`**
- `05:32:36Z` 微信投递完成，收据落盘
- `05:33:11Z` exec 外壳 60s 到期，**SIGTERM**
- 模型自己的收尾文本：「SIGTERM 是 exec 外壳超时，postflight 子进程已成功完成」

而两处终局记账在 `main()` 最末尾，排在 send + commit + dashboard + data-plane publish 之后。SIGTERM 正落在那段空隙里。同一形状适用于任何非正常退出，不限于这一次。

**改法两条，缺一不可**：

1. `primary_delivery` 挪到 send 证实的那一刻记，不再等 commit/publish 走完。投递事实在那时已经确定，后面的步骤不会让它变得更不真。
2. 新增 `reconcile_delivery_receipts()`：对 `primary_delivery` 仍是 `unknown` 的档，读发送方在 send 时留下的收据（`report-sent-*` / `intraday-sent-*` / `brief-sent-*`）补齐，挂在已有的 `summarize(reconcile=True)` 和 `publish()` 两个入口上。

第 2 条是关键：只做第 1 条，SIGTERM 打在 send 与记账之间那几毫秒仍会漏，且已经漏掉的历史档不会自愈。

边界（都有测试钉住）：只填 `unknown`，**不覆盖**已有判词（watchdog 比收据知道得多）；只认账本已在跟踪的档，**不凭收据造档**；没有收据就老实停在 `pending`，不编。

### 顺带

`load_ledger()` 在 LOCAL 读失败时会静默退到**已发布的副本**，随后把那份内容写回 LOCAL —— 一条无声的数据回退通道。没观测到触发过，加了 stderr 留痕。

## 验证

- `tests/test_workflow_outcomes.py` 11 → 24 条
- 变异验证（逐个撤掉修复，对应测试必须红）：
  - 删 `import sys` → 3 红
  - `_advisory_only` 恒 False → 2 红
  - 对账不再跳过已有判词 → 1 红
  - 三次还原后均全绿
- 对着**真实账本副本**跑对账：08-19 pm 那档 `pending` → `primary_delivery: success`，`filled: 1`
- 全套本地 worktree：**2262 passed, 5 skipped, 4 xfailed**
