### PR TITLE
fix(disclosures): 一手披露多源兜底 + SEC 403 归因（#766）

### DIFF
--- a/src/clawock/market_data/calendar.py
+++ b/src/clawock/market_data/calendar.py
@@ -132,6 +132,11 @@ def read_finnhub_key():
                 line = line.strip()
                 if line.startswith('FINNHUB_API_KEY='):
                     return line.split('=', 1)[1].strip()
+    except FileNotFoundError:
+        # No key file is a normal deployment, and every caller handles None.
+        # Warning here put a line on stderr for each probe on CI, which is how a
+        # warning channel stops being read.
+        pass
     except Exception as e:
         print(f'  warn: read .api_keys failed: {e}', file=sys.stderr)
     return None

--- a/src/clawock/market_data/filings.py
+++ b/src/clawock/market_data/filings.py
@@ -62,8 +62,28 @@ def _load_user_agent() -> str:
     env_ua = os.environ.get('SEC_USER_AGENT', '').strip()
     if env_ua:
         return env_ua
-    # Fallback — works but SEC requests you identify yourself
-    return 'clawock-research/0.1 clawock@users.noreply.github.com'
+    return UNCONFIGURED_SEC_USER_AGENT
+
+
+# SEC's access policy wants a real, deliverable contact address in the
+# User-Agent. This default has neither a name nor a reachable mailbox, and SEC
+# rejects it — measured 2026-08-19, same URL and second, only the UA changed:
+#
+#   'clawock-research/0.1 clawock@users.noreply.github.com'  -> 403 (this value)
+#   'Clawock Research clawock@users.noreply.github.com'      -> 403
+#   'clawock-research/0.1 <deliverable mailbox>'             -> 200
+#   'Clawock Research kcn <deliverable mailbox>'             -> 200
+#
+# The deciding factor is the mailbox domain: @users.noreply.github.com does not
+# receive mail. So this is not a "works but impolite" fallback — it is a
+# guaranteed 403, and for weeks it read downstream as an ordinary upstream
+# outage. Keep the constant nameable so a degraded source can say *why*.
+UNCONFIGURED_SEC_USER_AGENT = 'clawock-research/0.1 clawock@users.noreply.github.com'
+
+
+def sec_user_agent_configured() -> bool:
+    """False when nothing set SEC_USER_AGENT, i.e. SEC will refuse every call."""
+    return _load_user_agent() != UNCONFIGURED_SEC_USER_AGENT
 
 
 SESSION = requests.Session()

--- a/src/clawock/market_data/primary_disclosures.py
+++ b/src/clawock/market_data/primary_disclosures.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import re
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
@@ -25,6 +26,15 @@ SEC_SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
 TENCENT_NEWS = "https://web.ifzq.gtimg.cn/appstock/news/info/search"
 TENCENT_FILINGS_TYPE = 0
 NASDAQ_FILINGS = "https://api.nasdaq.com/api/company/{issuer}/sec-filings"
+FINNHUB_FILINGS = "https://finnhub.io/api/v1/stock/filings"
+# Finnhub stamps `acceptedDate` in US market time, not UTC. Measured against the
+# same filings from data.sec.gov on 2026-08-19: RKLB 8-K reads
+# `2026-08-13T11:10:48Z` at SEC and `2026-08-13 07:10:48` at Finnhub — exactly
+# EDT. Reading it as UTC would misplace every event by 4-5 hours, which for a
+# 30-minute intraday window is the difference between "in this window" and not.
+FINNHUB_TZ = ZoneInfo("America/New_York")
+# One US session plus the pre/after-hours filing tails around it.
+SESSION_LOOKBACK_MINUTES = 24 * 60
 UA = "Mozilla/5.0 (clawock primary disclosure provider)"
 CACHE_SCHEMA_VERSION = 1
 
@@ -46,6 +56,20 @@ def _parse_tencent_time(value):
         return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(tzinfo=HKT)
     except (TypeError, ValueError):
         return None
+
+
+def _parse_finnhub_time(value):
+    """Parse Finnhub's `acceptedDate` (US market time) into an aware UTC datetime."""
+    try:
+        naive = datetime.strptime(str(value).strip(), "%Y-%m-%d %H:%M:%S")
+    except (TypeError, ValueError):
+        return None
+    if naive.hour == 0 and naive.minute == 0 and naive.second == 0:
+        # Finnhub uses midnight as a "date only" placeholder (that is exactly what
+        # `filedDate` carries). Treating it as 00:00:00 ET would invent a precision
+        # this row does not have.
+        return None
+    return naive.replace(tzinfo=FINNHUB_TZ).astimezone(timezone.utc)
 
 
 def _parse_sec_time(value):
@@ -104,10 +128,22 @@ def fetch_sec(issuer, *, now, window_minutes, http=None):
     if not cik:
         return [], f"no CIK for {issuer}"
     digits = re.sub(r"\D", "", str(cik))
-    payload = http(
-        SEC_SUBMISSIONS.format(cik=digits.zfill(10)),
-        headers={"User-Agent": fetch_us_filings._load_user_agent()},
-    )
+    try:
+        payload = http(
+            SEC_SUBMISSIONS.format(cik=digits.zfill(10)),
+            headers={"User-Agent": fetch_us_filings._load_user_agent()},
+        )
+    except urllib.error.HTTPError as exc:
+        # A 403 on an unconfigured UA is a configuration error that will never
+        # self-heal, not an upstream outage that might. Saying so is the whole
+        # point: for weeks this lane reported a generic degradation and nobody
+        # had a reason to look (#766).
+        if exc.code == 403 and not fetch_us_filings.sec_user_agent_configured():
+            return [], (
+                "sec_user_agent_unconfigured: SEC refuses the default User-Agent "
+                "(no deliverable contact address) — set SEC_USER_AGENT in .api_keys"
+            )
+        raise
     recent = ((payload or {}).get("filings") or {}).get("recent") or {}
     forms = recent.get("form") or []
     accepted = recent.get("acceptanceDateTime") or []
@@ -194,8 +230,152 @@ def fetch_nasdaq_filings(issuer, *, now, window_minutes, http=None):
     return items, None
 
 
+def fetch_finnhub_filings(issuer, *, now, window_minutes, http=None, api_key=None,
+                          session_lookback_minutes=None):
+    """Third primary source: Finnhub's filing index, which keeps the accept time.
+
+    Its role is deliberately narrow. Measured 2026-08-19: Finnhub **lags** —
+    the Nasdaq mirror already listed SKHY's 08/19 6-K while Finnhub's newest
+    row for that issuer was 08/14. So it is not a faster discovery source and
+    must not be sold as one. What it uniquely provides when SEC direct is
+    unreachable is the minute-level acceptance timestamp that the date-only
+    mirror cannot supply, which is the whole difference between an event that
+    can clear `filing_time_unavailable` and one that cannot.
+    """
+    from clawock.market_data.calendar import read_finnhub_key  # noqa: PLC0415
+
+    http = http or _http_json
+    key = api_key if api_key is not None else read_finnhub_key()
+    if not key:
+        return [], "no FINNHUB_API_KEY"
+    # Deliberately wider than the caller's window. A filing the window rejects is
+    # still the evidence that resolves a same-day mirror row's missing time — and
+    # knowing it landed outside the window is the point. `probe` enforces the
+    # real window once, after the two sources have been reconciled.
+    session_lookback_minutes = (
+        session_lookback_minutes if session_lookback_minutes is not None
+        else max(window_minutes, SESSION_LOOKBACK_MINUTES)
+    )
+    query = urllib.parse.urlencode({"symbol": str(issuer).upper(), "token": key})
+    payload = http(f"{FINNHUB_FILINGS}?{query}")
+    rows = payload if isinstance(payload, list) else []
+    items = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        when = _parse_finnhub_time(row.get("acceptedDate"))
+        if when is None:
+            continue
+        age = _age_minutes(when, now)
+        if age < 0 or age > session_lookback_minutes:
+            continue
+        form = re.sub(r"\s+", " ", str(row.get("form") or "")).strip()
+        filed = str(row.get("filedDate") or "")[:10] or None
+        items.append({
+            "published_at": when.isoformat(),
+            "filed_date": filed,
+            "age_minutes": age,
+            "time_precision": "datetime",
+            "freshness_status": "accepted_time_reported",
+            "title": re.sub(r"\s+", " ", f"{form} {row.get('symbol') or issuer}").strip(),
+            "source_class": "finnhub_filing",
+            "evidence_tier": "primary",
+            "source_url": row.get("reportUrl") or None,
+            "accession": str(row.get("accessNumber") or "") or None,
+            "form": form or None,
+            "filing_items": None,
+        })
+    return items, None
+
+
+def _filing_key(row):
+    """Identity used to line a mirror row up with a timestamped one."""
+    form = (row.get("form") or "").strip().upper()
+    filed = str(row.get("filed_date") or "")[:10]
+    return (form, filed) if form and filed else None
+
+
+def upgrade_mirror_precision(events, *, now, window_minutes):
+    """Let a timestamped source resolve the date-only mirror's missing time.
+
+    The mirror is the fastest US source and the only one that had SKHY's 08/19
+    6-K on the day, but it carries no acceptance time, so every row it finds is
+    precomputed to `wait` behind `filing_time_unavailable`. When another source
+    holds the same filing with a real timestamp, adopting it is a strict gain.
+
+    Three rules keep it honest:
+
+    * **Ambiguity is refused, not guessed.** (form, filed_date) is not unique —
+      SKHY filed three 6-Ks on 2026-08-19 alone. More than one candidate match
+      means we cannot say *which* filing the time belongs to, so the blocker
+      stays. See clawock-json-repair-lossless-invariant.
+    * A unique match whose real time falls **outside** the window drops the row:
+      the mirror kept it only because it could not tell, and now we can.
+    * No match changes nothing.
+
+    Returns (events, notes).
+    """
+    timed = {}
+    ambiguous = set()
+    for row in events:
+        if row.get("source_class") == "sec_filing_mirror":
+            continue
+        if row.get("time_precision") != "datetime" and not row.get("published_at"):
+            continue
+        key = _filing_key(row)
+        if key is None:
+            continue
+        if key in timed:
+            ambiguous.add(key)
+        timed[key] = row
+
+    kept, notes = [], []
+    for row in events:
+        if (row.get("source_class") != "sec_filing_mirror"
+                or row.get("time_precision") != "date"):
+            kept.append(row)
+            continue
+        key = _filing_key(row)
+        match = timed.get(key) if key and key not in ambiguous else None
+        if match is None:
+            if key in ambiguous:
+                notes.append(
+                    f"precision: {key[0]} {key[1]} has multiple timestamped matches "
+                    f"— refusing to guess which one, keeping the date-only blocker"
+                )
+            kept.append(row)
+            continue
+        when = datetime.fromisoformat(str(match["published_at"]))
+        age = _age_minutes(when, now)
+        if age < 0 or age > window_minutes:
+            notes.append(
+                f"precision: {key[0]} {key[1]} accepted at {match['published_at']} "
+                f"— outside the {window_minutes}min window, dropping the mirror row"
+            )
+            continue
+        upgraded = dict(row)
+        upgraded.update({
+            "published_at": match["published_at"],
+            "age_minutes": age,
+            "time_precision": "datetime",
+            "freshness_status": "accepted_time_recovered_from_secondary_index",
+            "precision_source": match.get("source_class"),
+        })
+        kept.append(upgraded)
+    # One place enforces the window for the reconciled set. Rows that never had a
+    # time (the mirror's own, when nothing resolved them) are not age-prunable and
+    # keep their existing blocker instead.
+    windowed = [
+        row for row in kept
+        if not isinstance(row.get("age_minutes"), (int, float))
+        or 0 <= row["age_minutes"] <= window_minutes
+    ]
+    return windowed, notes
+
+
 def probe(issuers, *, market: str, now=None, window_minutes: int,
-          budget_s: float, max_issuers: int, http=None, clock=None) -> dict:
+          budget_s: float, max_issuers: int, http=None, clock=None,
+          finnhub_key=None) -> dict:
     """Return normalized primary disclosures and honest source status.
 
     Every bound is supplied by the caller.  A provider must not smuggle one
@@ -222,6 +402,13 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
             ("nasdaq_filing_mirror", (lambda t=issuer: fetch_nasdaq_filings(
                 t, now=now, window_minutes=window_minutes, http=http
             )) if market == "us" else None),
+            # Only consulted when SEC direct is unavailable: it is slower to see
+            # a filing than either source above, so with SEC healthy it would
+            # spend a request and a rate-limit slot to learn nothing new.
+            ("finnhub", (lambda t=issuer: fetch_finnhub_filings(
+                t, now=now, window_minutes=window_minutes, http=http,
+                api_key=finnhub_key,
+            )) if market == "us" else None),
             ("exchange", (lambda s=symbol: fetch_exchange(
                 s, now=now, window_minutes=window_minutes, http=http
             )) if symbol else None),
@@ -229,11 +416,11 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
         for label, call in calls:
             if call is None:
                 continue
-            if (label in {"nasdaq_filing_mirror", "exchange"}
+            if (label in {"nasdaq_filing_mirror", "finnhub", "exchange"}
                     and any(row["source_class"] == "sec_filing" for row in entry["events"])):
                 continue
             if (label == "exchange"
-                    and any(row["source_class"] == "sec_filing_mirror"
+                    and any(row["source_class"] in {"sec_filing_mirror", "finnhub_filing"}
                             for row in entry["events"])):
                 continue
             if clock() - started > budget_s:
@@ -249,14 +436,21 @@ def probe(issuers, *, market: str, now=None, window_minutes: int,
                 entry["degraded_sources"].append(label)
                 continue
             if note:
+                # A source that returned a note did not answer cleanly — a failed
+                # ticker-to-CIK lookup, a refused User-Agent or an absent API key
+                # is not evidence of no filing. Only `sec` used to be held to this;
+                # every note-returning source is now, so a keyless `finnhub` can
+                # never be counted as a healthy fallback (#766).
                 entry["notes"].append(f"{label}: {note}")
-                # A failed ticker-to-CIK lookup is not evidence of no filing.
-                if label == "sec":
-                    entry["status"] = "degraded"
-                    entry["degraded_sources"].append(label)
+                entry["status"] = "degraded"
+                entry["degraded_sources"].append(label)
             entry["events"].extend(items)
-            if not (label == "sec" and note):
+            if not note:
                 entry["healthy_sources"].append(label)
+        entry["events"], precision_notes = upgrade_mirror_precision(
+            entry["events"], now=now, window_minutes=window_minutes
+        )
+        entry["notes"].extend(precision_notes)
         entry["events"].sort(key=lambda row: row.get("published_at") or "", reverse=True)
         entry["degraded_sources"] = sorted(set(entry["degraded_sources"]))
         entry["healthy_sources"] = sorted(set(entry["healthy_sources"]))

--- a/tests/test_active_information.py
+++ b/tests/test_active_information.py
@@ -212,18 +212,21 @@ def test_sec_403_falls_back_to_healthy_nasdaq_primary_mirror(monkeypatch):
                 "formType": "8-K", "filed": "08/13/2026",
                 "view": {"htmlLink": "https://mirror.test/crcl-8k"},
             }]}}
+        if host == "finnhub.io":
+            return []
         raise AssertionError(url)
 
     result = primary_disclosures.probe(
         ["CRCL"], market="us", now=NOW, window_minutes=240,
-        budget_s=20, max_issuers=1, http=http,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
     )["issuers"]["CRCL"]
 
     assert result["status"] == "found"
     assert result["partial_degradation"] is True
     assert result["degraded_sources"] == ["sec"]
-    assert result["healthy_sources"] == ["nasdaq_filing_mirror"]
+    assert result["healthy_sources"] == ["finnhub", "nasdaq_filing_mirror"]
     assert result["events"][0]["source_class"] == "sec_filing_mirror"
+    # Finnhub had nothing for this filing, so the blocker honestly survives.
     assert result["events"][0]["time_precision"] == "date"
 
 
@@ -250,3 +253,195 @@ def test_date_only_primary_mirror_event_waits_instead_of_unlocking_exploration()
     assert row["disposition"] == "wait"
     assert row["exploration_hint"] is None
     assert "filing_time_unavailable" in row["blockers"]
+
+
+# ── #766: a third primary source, and honest attribution of SEC's refusal ────
+
+def test_finnhub_accepted_time_is_read_as_us_market_time_not_utc():
+    """Measured 2026-08-19: SEC says 11:10:48Z, Finnhub says 07:10:48 — EDT.
+
+    Reading it as UTC would place every US filing 4-5 hours off. For a
+    30-minute intraday window that is the whole difference between "inside this
+    window" and "not", so the timezone is load-bearing, not cosmetic.
+    """
+    now = datetime(2026, 8, 13, 11, 30, tzinfo=timezone.utc)
+
+    def http(url, **_kwargs):
+        assert urlsplit(url).hostname == "finnhub.io"
+        return [{"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+                 "acceptedDate": "2026-08-13 07:10:48",
+                 "reportUrl": "https://sec.test/rklb-8k", "symbol": "RKLB"}]
+
+    items, note = primary_disclosures.fetch_finnhub_filings(
+        "RKLB", now=now, window_minutes=60, http=http, api_key="test-key",
+    )
+    assert note is None
+    assert items[0]["published_at"] == "2026-08-13T11:10:48+00:00"
+    assert items[0]["age_minutes"] == 19
+    assert items[0]["time_precision"] == "datetime"
+
+
+def test_finnhub_midnight_placeholder_is_not_treated_as_a_timestamp():
+    """`acceptedDate` at exactly midnight is Finnhub's date-only placeholder."""
+    def http(_url, **_kwargs):
+        return [{"form": "6-K", "filedDate": "2026-08-13 00:00:00",
+                 "acceptedDate": "2026-08-13 00:00:00"}]
+
+    items, _ = primary_disclosures.fetch_finnhub_filings(
+        "SKHY", now=NOW, window_minutes=1440, http=http, api_key="test-key",
+    )
+    assert items == []
+
+
+def test_finnhub_without_a_key_is_degraded_not_healthy():
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            raise RuntimeError("SEC unreachable")
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": []}}
+        raise AssertionError(url)
+
+    result = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="",
+    )["issuers"]["CRCL"]
+    assert "finnhub" in result["degraded_sources"]
+    assert "finnhub" not in result["healthy_sources"]
+
+
+def _mirror_and_finnhub_http(finnhub_rows, *, filed="08/13/2026"):
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            raise RuntimeError("SEC unreachable")
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": [{
+                "companyName": "Circle Internet Group Inc.",
+                "formType": "8-K", "filed": filed,
+                "view": {"htmlLink": "https://mirror.test/crcl-8k"},
+            }]}}
+        if host == "finnhub.io":
+            return finnhub_rows
+        raise AssertionError(url)
+    return http
+
+
+def test_a_timestamped_match_clears_the_date_only_blocker():
+    """The mirror sees the filing first; Finnhub supplies the time it lacks."""
+    http = _mirror_and_finnhub_http([
+        {"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+         "acceptedDate": "2026-08-13 01:30:00", "symbol": "CRCL"},
+    ])
+    event = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]["events"][0]
+
+    assert event["source_class"] == "sec_filing_mirror"
+    assert event["time_precision"] == "datetime"
+    assert event["published_at"] == "2026-08-13T05:30:00+00:00"
+    assert event["precision_source"] == "finnhub_filing"
+    # ai turns the date-only precision into the blocker, so clearing it here is
+    # what actually reopens the candidate leg.
+    assert event["freshness_status"] != "same_session_date_time_unavailable"
+
+
+def test_two_matching_filings_refuse_to_guess_and_keep_the_blocker():
+    """SKHY filed three 6-Ks on 2026-08-19: (form, date) is not an identity.
+
+    Adopting either timestamp would be a coin flip presented as evidence.
+    """
+    http = _mirror_and_finnhub_http([
+        {"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+         "acceptedDate": "2026-08-13 01:30:00", "symbol": "CRCL"},
+        {"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+         "acceptedDate": "2026-08-13 00:45:00", "symbol": "CRCL"},
+    ])
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]
+
+    mirror = [e for e in entry["events"] if e["source_class"] == "sec_filing_mirror"]
+    assert mirror[0]["time_precision"] == "date"
+    assert any("refusing to guess" in note for note in entry["notes"])
+
+
+def test_a_recovered_time_outside_the_window_drops_the_mirror_row():
+    """The mirror kept it only because it could not tell. Now it can."""
+    http = _mirror_and_finnhub_http([
+        {"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+         "acceptedDate": "2026-08-12 20:00:00", "symbol": "CRCL"},
+    ])
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=60,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]
+
+    assert [e for e in entry["events"] if e["source_class"] == "sec_filing_mirror"] == []
+    assert any("outside the 60min window" in note for note in entry["notes"])
+
+
+def test_a_refused_default_user_agent_is_named_as_configuration(monkeypatch):
+    """Not "SEC is flaky" — a 403 on the unconfigured UA never self-heals."""
+    from urllib.error import HTTPError
+
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+    monkeypatch.setattr(
+        "clawock.market_data.filings.sec_user_agent_configured", lambda: False
+    )
+
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            raise HTTPError(url, 403, "Forbidden", {}, None)
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": []}}
+        if host == "finnhub.io":
+            return []
+        raise AssertionError(url)
+
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]
+
+    assert "sec" in entry["degraded_sources"]
+    assert any("sec_user_agent_unconfigured" in note for note in entry["notes"])
+    assert any("SEC_USER_AGENT" in note for note in entry["notes"])
+
+
+def test_a_403_with_a_configured_user_agent_is_still_reported_as_an_outage(
+    monkeypatch
+):
+    """Don't blame configuration for something configuration already satisfied."""
+    from urllib.error import HTTPError
+
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+    monkeypatch.setattr(
+        "clawock.market_data.filings.sec_user_agent_configured", lambda: True
+    )
+
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            raise HTTPError(url, 403, "Forbidden", {}, None)
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": []}}
+        if host == "finnhub.io":
+            return []
+        raise AssertionError(url)
+
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]
+
+    assert "sec" in entry["degraded_sources"]
+    assert not any("sec_user_agent_unconfigured" in n for n in entry["notes"])
+    assert any("HTTPError" in note for note in entry["notes"])


### PR DESCRIPTION
Closes #766.

美股「一手披露 → 加仓 candidate」这条腿三天 0 产出：46 个盘中窗口、138 行 `add_side_reads`，`candidate` 一个都没有（93 wait / 45 reject）。根因不在策略，在数据面。

## 根因：SEC 的 403 是 UA 的邮箱域，不是 IP 封锁

本机实测，同一 URL、同一时刻、只换 User-Agent：

```
'clawock-research/0.1 clawock@users.noreply.github.com'  → 403 ×2   ← 一直在用的兜底值
'Clawock Research clawock@users.noreply.github.com'      → 403 ×2
'clawock-research/0.1 <可投递邮箱>'                        → 200 ×2
'Clawock Research kcn <可投递邮箱>'                        → 200 ×2
```

决定性因素是**邮箱域**：`@users.noreply.github.com` 收不到信，SEC 按其公开接入政策拒。`data.sec.gov` 和 `www.sec.gov` 表现一致。

`filings.py` 本来就支持从 `.api_keys` 的 `SEC_USER_AGENT=` 读，只是这台机器从没配过。**配置已在宿主侧落好**（`.api_keys`，600，gitignored），实测 SEC 直连恢复：

```
$ probe(['RKLB','CRCL','SKHY'], market='us', ...)
SKHY  status=found  healthy=['sec']  degraded=[]
      sec_filing 6-K 2026-08-19T07:22:24+00:00
      sec_filing 6-K 2026-08-19T07:19:25+00:00
```

秒级时间戳回来了，`filing_time_unavailable` 这条闸自然就开了。

## 为什么它能潜伏几周（这才是要修的部分）

`probe()` 一直**正确**地把 SEC 记进了 `degraded_sources`，也照约定显示了降级。但显示的是**通用降级**，读起来像「上游偶发不可用」。可自愈的故障和永不自愈的配置错误长得一模一样，就没人去查。

所以本 PR 把这件事变成不可静默的：

- `filings.UNCONFIGURED_SEC_USER_AGENT` 成为具名常量，`sec_user_agent_configured()` 可判定
- `fetch_sec` 在「403 且 UA 未配置」时返回 `sec_user_agent_unconfigured: … set SEC_USER_AGENT in .api_keys`，而不是让异常冒泡成 `sec: HTTPError`
- UA **已配置**时的 403 仍按上游故障报告 —— 不许拿配置背锅（单独一条测试钉住）

## 多源兜底：新增 Finnhub filings

SEC 好了不等于以后不会再断。新增第三个 primary 源，key 已在 `.api_keys`。

**诚实的定位（实测，别高估）**：Finnhub **滞后**。Nasdaq 镜像当天就有 SKHY 08/19 的 6-K，Finnhub 最新只到 08-14。它不是更快的发现源，唯一不可替代的是**分钟级 `acceptedDate`**。

| 源 | 速度 | 时间精度 | 角色 |
|---|---|---|---|
| `sec_filing` | 快 | 秒级 | 主源 |
| `sec_filing_mirror` (Nasdaq) | 最快 | **仅日期** | SEC 挂时的发现源 |
| `finnhub_filing` (新) | 滞后数天 | 分钟级 | SEC 挂时的兜底 + **精度补齐器** |

因此 Finnhub 只在 SEC 未出结果时才调用（SEC 健康时它学不到新东西，白花一次请求和限流额度）。

### 精度补齐 `upgrade_mirror_precision()`

镜像发现的当日事件，若另有带时间戳的源持有同一份文件，就采纳它的受理时间，把 `time_precision` 从 `date` 升到 `datetime`。`active_information.py:212` 正是按 `time_precision == "date"` 挂 `filing_time_unavailable` 并把 candidate 降级成 wait，所以这一步直接决定那条腿开不开。

三条守则，各配红绿测试：

1. **歧义拒绝，不猜**。`(form, filed_date)` 不是唯一键 —— SKHY 光 08-19 一天就报了三份 6-K。多于一个匹配就说不清时间属于哪一份，blocker 原样保留（`clawock-json-repair-lossless-invariant`）
2. 唯一匹配但真实时间落在窗口**之外** → 丢掉该镜像行。镜像当初留着它只是因为分不清，现在分得清了
3. 匹配不上 → 什么都不改

### 时区（这条是承重的，不是洁癖）

Finnhub 的 `acceptedDate` 是**美东时间不是 UTC**。同一份 RKLB 8-K：SEC 记 `2026-08-13T11:10:48Z`，Finnhub 记 `2026-08-13 07:10:48` —— 正好 EDT。当 UTC 读会把每条事件挪错 4-5 小时，对 30 分钟的盘中窗口就是「在不在这个窗口里」的区别。另外 Finnhub 用**午夜整点当日期占位**，也不能当成 00:00:00 ET 的真时间。

## 顺带

- 「返回 note 的源不算 healthy」从只管 `sec` 推广到所有源 —— 否则一个没 key 的 `finnhub` 会被记成健康兜底。三个 fetcher 里只有 `fetch_sec` / `fetch_finnhub_filings` 会返回 note，行为变化面是封闭的
- `calendar.read_finnhub_key()` 不再对「`.api_keys` 不存在」告警。那是正常部署状态且调用方都处理 None，每次 probe 往 stderr 写一行正是警告通道失效的方式

## 已排除的源（实测，省得再试）

- Polygon `/vX/reference/sec-filings`：当前 plan 404
- Nasdaq `press_release` topic：对这批 issuer 返回空
- Nasdaq `articlebysymbol`：二手新闻，不构成一手披露

## 验证

- `tests/test_active_information.py` 8 → 17 条
- 变异验证（撤掉修复，对应测试必须红）：
  - Finnhub 时间当 UTC 读 → 2 红
  - 歧义时照猜 → 1 红
  - 403 不再归因配置 → 1 红
  - 午夜占位当真时间 → 1 红
  - 四次还原后均全绿
- 全套本地 worktree：**2257 passed, 5 skipped, 4 xfailed**
