### PR TITLE
fix(growth): 恢复 IndexNow 提交链（#767）

### DIFF
--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -14,6 +14,7 @@
   ],
   "required_pages": [
     "index.html",
+    "4fb2df1611ed42e5b67fd6171a237acb.txt",
     "google7be5b41525cebe9d.html",
     "briefs.html",
     "evidence.html",
@@ -33,6 +34,7 @@
   ],
   "artifact_include": [
     "index.html",
+    "4fb2df1611ed42e5b67fd6171a237acb.txt",
     "google7be5b41525cebe9d.html",
     "briefs.html",
     "evidence.html",

--- a/ops/growth/indexnow_submit.py
+++ b/ops/growth/indexnow_submit.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Submit clawock URLs to IndexNow (Bing / Yandex / Seznam — NOT Google).
+
+Zero-touch indexing accelerator. Reads the IndexNow key from the site-owned
+`site/<key>.txt` file (32-hex), pulls URLs from the live sitemap, and POSTs the ones
+that are new or whose content actually changed.
+
+Google does not consume IndexNow — for Google use GSC "Request Indexing".
+
+Change detection uses each page's HTTP validator (ETag, else Last-Modified) from
+a cheap HEAD request, recorded per URL in `logs/indexnow_seen.json`
+(machine-local, gitignored). A URL-only ledger would mean an edited brief, a
+revised weekly, or a `_layouts/` change is never re-announced — silently, and
+forever. IndexNow asks publishers to submit on change, so re-POSTing unchanged
+URLs daily is equally wrong in the other direction.
+
+Usage:
+  python3 ops/growth/indexnow_submit.py             # new + changed URLs
+  python3 ops/growth/indexnow_submit.py --all       # every sitemap URL
+  python3 ops/growth/indexnow_submit.py <url> ...   # submit specific URLs
+  python3 ops/growth/indexnow_submit.py --record-only  # seed ledger, no POST
+  python3 ops/growth/indexnow_submit.py --dry-run   # print, do not POST
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+HOST = "kcnyu.github.io"
+SITE = "https://kcnyu.github.io/clawock"
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SITE_SOURCE = os.path.join(ROOT, "site")
+STATE = os.path.join(ROOT, "logs", "indexnow_seen.json")
+
+
+def find_key():
+    for p in glob.glob(os.path.join(SITE_SOURCE, "*.txt")):
+        name = os.path.splitext(os.path.basename(p))[0]
+        if re.fullmatch(r"[0-9a-f]{32}", name):
+            return name
+    raise SystemExit("ERROR: no IndexNow key file (site/<32-hex>.txt)")
+
+
+def sitemap_urls():
+    try:
+        with urllib.request.urlopen(f"{SITE}/sitemap.xml", timeout=20) as r:
+            xml = r.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError) as e:
+        raise SystemExit(f"ERROR: cannot fetch {SITE}/sitemap.xml ({e})")
+    return re.findall(r"<loc>([^<]+)</loc>", xml)
+
+
+def validator(url):
+    """ETag (preferred) or Last-Modified for a URL. None if unreachable — an
+    unreachable page is skipped rather than guessed at in either direction."""
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.headers.get("ETag") or r.headers.get("Last-Modified")
+    except (urllib.error.URLError, OSError) as e:
+        print(f"WARN: HEAD {url} failed ({e}) — skipping this URL", file=sys.stderr)
+        return None
+
+
+def load_seen():
+    """URL -> validator. A missing/corrupt ledger degrades to empty: that
+    re-submits once, which beats the cron dying on a bad file."""
+    try:
+        with open(STATE, encoding="utf-8") as f:
+            data = json.load(f)
+        seen = data["validators"]
+        if not isinstance(seen, dict):
+            raise TypeError("validators is not an object")
+        return seen
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        print(f"WARN: unreadable {STATE} ({e}) — treating as empty", file=sys.stderr)
+        return {}
+
+
+def save_seen(updates):
+    """Merge `updates` into whatever is on disk right now.
+
+    A concurrent run (daily cron overlapping a manual --all) must not clobber
+    the other's entries, so this re-reads before writing and uses a
+    PID-suffixed temp file — two processes sharing one `.tmp` path can make
+    os.replace race into FileNotFoundError.
+    """
+    merged = load_seen()
+    merged.update(updates)
+    os.makedirs(os.path.dirname(STATE), exist_ok=True)
+    tmp = f"{STATE}.{os.getpid()}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"validators": dict(sorted(merged.items()))}, f, indent=1)
+        os.replace(tmp, STATE)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def select(args):
+    """Return (urls_to_submit, {url: validator} to record on success)."""
+    if args.urls:
+        return args.urls, {u: v for u in args.urls if (v := validator(u))}
+    urls = sitemap_urls()
+    if not urls:
+        raise SystemExit("ERROR: sitemap returned no URLs")
+    seen = load_seen()
+    current = {u: v for u in urls if (v := validator(u)) is not None}
+    if args.all:
+        return urls, current
+    changed = [u for u in urls if u in current and current[u] != seen.get(u)]
+    return changed, {u: current[u] for u in changed}
+
+
+def post(key, urls):
+    payload = {
+        "host": HOST,
+        "key": key,
+        "keyLocation": f"{SITE}/{key}.txt",
+        "urlList": urls,
+    }
+    req = urllib.request.Request(
+        "https://api.indexnow.org/indexnow",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        print(f"IndexNow HTTP {r.status} — submitted {len(urls)} URL(s)")
+        body = r.read().decode("utf-8", "replace").strip()
+        if body:
+            print(body)
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("urls", nargs="*", help="submit these URLs instead of the sitemap")
+    p.add_argument("--all", action="store_true", help="submit every sitemap URL")
+    p.add_argument("--dry-run", action="store_true", help="print, do not POST")
+    p.add_argument("--record-only", action="store_true",
+                   help="record current validators without submitting "
+                        "(seeds the ledger after a manual backfill)")
+    args = p.parse_args(argv)
+    if args.urls and args.all:
+        p.error("--all cannot be combined with explicit URLs")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    # A real submission cannot possibly succeed without the public key. Resolve
+    # it before fetching the sitemap and issuing one HEAD per URL, so a deleted
+    # or unpublished key fails cheaply instead of doing guaranteed-wasted work.
+    # Inspection modes deliberately remain useful while the key is being fixed.
+    key = None if args.record_only or args.dry_run else find_key()
+    urls, record = select(args)
+    if args.record_only:
+        save_seen(record)
+        print(f"IndexNow — recorded {len(record)} validator(s), submitted nothing")
+        return
+    if not urls:
+        print("IndexNow — nothing new or changed to submit")
+        return
+    if args.dry_run:
+        print(f"IndexNow dry-run — would submit {len(urls)} URL(s):")
+        print("\n".join(urls))
+        return
+    post(key, urls)
+    # Record only after the POST is accepted, so a failed run retries instead of
+    # marking the URLs as done forever.
+    save_seen(record)
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/host/cron_timeline.py
+++ b/ops/host/cron_timeline.py
@@ -246,6 +246,8 @@ def load_crontab():
             name = 'gold_dca_refresh'
         elif 'rick_broadcast_nostr' in cmd:
             name = 'nostr_broadcast'
+        elif 'indexnow_submit' in cmd:
+            name = 'indexnow_submit'
         elif re.search(r'(^|/)git\b', cmd) and re.search(r'\bgc\b', cmd):
             name = 'git gc'
         else:

--- a/site/4fb2df1611ed42e5b67fd6171a237acb.txt
+++ b/site/4fb2df1611ed42e5b67fd6171a237acb.txt
@@ -1,0 +1,1 @@
+4fb2df1611ed42e5b67fd6171a237acb

--- a/tests/test_indexnow_submit.py
+++ b/tests/test_indexnow_submit.py
@@ -1,0 +1,110 @@
+"""IndexNow submitter: the pieces that have to exist together to be alive.
+
+#592 deleted `ops/growth/indexnow_submit.py`; the host crontab line then failed
+daily with `can't open file` until #672/#679 removed the key file, the deploy
+contract entries and the crontab line too. Nothing decided whether the feature
+should exist — it just stopped, quietly, over three PRs. kcn restored it in
+#767.
+
+These tests pin the parts that made it *silently* dead rather than loudly dead:
+the script has to be there, and its inspection modes must not reach the network
+(a `--help` that POSTs would be discovered only in production).
+
+They deliberately do not assert anything about search-engine outcomes. Measured
+2026-07-24: a month of accepted IndexNow pings produced zero Bing coverage, and
+2026-08-19 GSC still shows the homepage last crawled 2026-06-22. `HTTP 200` from
+IndexNow means received, not crawled, and certainly not indexed.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops/growth/indexnow_submit.py"
+KEY = "4fb2df1611ed42e5b67fd6171a237acb"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("indexnow_submit", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_script_the_host_cron_calls_actually_exists():
+    """The failure mode was a crontab line pointing at a deleted file."""
+    assert SCRIPT.is_file()
+
+
+def test_the_published_key_matches_the_key_file_name():
+    """IndexNow validates ownership by fetching {key}.txt and comparing bodies."""
+    assert (ROOT / "site" / f"{KEY}.txt").read_text().strip() == KEY
+    assert _load().find_key() == KEY
+
+
+def test_help_never_reaches_the_network():
+    """argparse must exit before any HTTP work — including the sitemap fetch."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0
+    assert "--dry-run" in result.stdout
+
+
+def test_explicit_urls_and_all_are_refused_together():
+    module = _load()
+    with pytest.raises(SystemExit):
+        module.parse_args(["--all", "https://kcnyu.github.io/clawock/"])
+
+
+def test_dry_run_prints_without_posting(monkeypatch, capsys):
+    """The mode kcn is told to verify with must not be able to submit."""
+    module = _load()
+    monkeypatch.setattr(
+        module, "select",
+        lambda _args: (["https://kcnyu.github.io/clawock/"], {}),
+    )
+    monkeypatch.setattr(
+        module, "post",
+        lambda *_a, **_k: pytest.fail("dry-run must not POST"),
+    )
+    monkeypatch.setattr(
+        module, "find_key",
+        lambda: pytest.fail("dry-run must not need the key"),
+    )
+    module.main(["--dry-run"])
+    assert "would submit 1 URL(s)" in capsys.readouterr().out
+
+
+def test_a_successful_post_is_what_marks_urls_as_done(monkeypatch):
+    """Recording before the POST would drop URLs forever on a failed run."""
+    module = _load()
+    order = []
+    monkeypatch.setattr(module, "find_key", lambda: KEY)
+    monkeypatch.setattr(module, "select", lambda _a: (["u"], {"u": "etag"}))
+    monkeypatch.setattr(
+        module, "post", lambda *_a, **_k: order.append("post"))
+    monkeypatch.setattr(
+        module, "save_seen", lambda _r: order.append("save"))
+    module.main([])
+    assert order == ["post", "save"]
+
+
+def test_a_failed_post_does_not_record_the_urls(monkeypatch):
+    module = _load()
+    saved = []
+    monkeypatch.setattr(module, "find_key", lambda: KEY)
+    monkeypatch.setattr(module, "select", lambda _a: (["u"], {"u": "etag"}))
+    monkeypatch.setattr(
+        module, "post",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("502")),
+    )
+    monkeypatch.setattr(module, "save_seen", lambda _r: saved.append(_r))
+    with pytest.raises(RuntimeError):
+        module.main([])
+    assert saved == []

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -181,7 +181,7 @@ def test_builder_stages_only_public_consumers(tmp_path):
     for path in (
         "briefs.html", "evidence.html", "faq.html", "llms.txt",
         "robots.txt", "manifest.webmanifest",
-        GOOGLE_VERIFICATION,
+        INDEXNOW_KEY, GOOGLE_VERIFICATION,
     ):
         (site / path).write_text("ok")
     (site / "sitemap.xml").write_text(

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -12,6 +12,7 @@ CONTRACT = json.loads((ROOT / "config/pages-public.json").read_text())
 WORKFLOW = (ROOT / ".github/workflows/pages.yml").read_text()
 UI = (ROOT / "site/assets/js/dashboard.ui.js").read_text()
 INDEX = (ROOT / "site/index.html").read_text()
+INDEXNOW_KEY = "4fb2df1611ed42e5b67fd6171a237acb.txt"
 GOOGLE_VERIFICATION = "google7be5b41525cebe9d.html"
 
 
@@ -66,6 +67,19 @@ def test_faq_page_is_required_public_and_has_an_entry_point():
     assert "faq.html" in CONTRACT["required_pages"]
     assert "faq.html" in CONTRACT["artifact_include"]
     assert 'href="faq.html"' in INDEX
+    assert WORKFLOW.count("'site/**'") == 2
+
+
+def test_indexnow_key_is_required_public_and_triggers_deploy():
+    """The key proves ownership to IndexNow; without it every submit 403s.
+
+    Retired with the submitter in #592/#679 and restored in #767 — the key file,
+    the deploy contract and the submitter have to come back together or the
+    feature is green-but-dead again.
+    """
+    assert (ROOT / "site" / INDEXNOW_KEY).read_text().strip() == INDEXNOW_KEY.removesuffix(".txt")
+    assert INDEXNOW_KEY in CONTRACT["required_pages"]
+    assert INDEXNOW_KEY in CONTRACT["artifact_include"]
     assert WORKFLOW.count("'site/**'") == 2
 
 
@@ -210,6 +224,7 @@ def test_builder_stages_only_public_consumers(tmp_path):
         if node.tag.rsplit("}", 1)[-1] == "loc"
     ]
     assert sitemap_locs == ["https://kcnyu.github.io/clawock/"]
+    assert (output / INDEXNOW_KEY).is_file()
     assert (output / GOOGLE_VERIFICATION).is_file()
     assert (output / "faq.html").is_file()
     assert (output / "llms.txt").is_file()


### PR DESCRIPTION
Closes #767.

## 先说清楚：这不会改善收录

必须写在最前面，免得下一个人误以为这是增长动作。

- 07-24 实测：Bing `site:kcnyu.github.io` / `site:github.io clawock` / 裸查 `clawock` 三个查询全部 0 结果 —— **一个月被接受的 IndexNow ping 换来零收录**
- 08-19 复查 GSC：近 90 天 67 曝光 / 1 点击，全部落在首页；query 维度返回空；首页 `lastCrawl` 仍是 `2026-06-22`（两个月没回来）；`briefs.html` / `dashboard.html` 仍是 `URL is unknown to Google`；sitemap 08-16 重新提交至今 `isPending: true`、`lastDownloaded: None`

`IndexNow HTTP 200` = 已接收，不等于会爬，更不等于收录。瓶颈仍是外链 / 抓取预算。

恢复它的价值只有一条：**让仓库状态自洽**。kcn 08-19 明确要求恢复。

## 它是怎么死的（三个 PR，没有一个决定过要不要留）

1. `4c159c12`（#592，08-16 00:17「ops/growth 清理」）删掉 `ops/growth/indexnow_submit.py`
2. 宿主 crontab 那行还在，08-16 12:00 起每天 `can't open file`；最后一条成功日志是 `submitted 85 URL(s)`
3. `4e99697b`（#679，修 #663/#672）把剩下的痕迹一并清掉：key 文件、`config/pages-public.json` 的两处条目、部署契约测试、`cron_timeline` 的解析分支，宿主 crontab 行由操作者手工移除

每一步单独看都对。合起来是一个功能在没人做决定的情况下消失了。同一个 #592 删掉的 `rick_broadcast_nostr.sh` 已在 #671 恢复，IndexNow 漏了。

## 恢复内容

- `ops/growth/indexnow_submit.py` —— 从 `0fc9c0bb`（#24 的**增量 + ETag/Last-Modified 变更感知**版本）恢复，逐字节确认与被删版本一致，**不是**更早那个写死单 URL 的版本
- `site/4fb2df1611ed42e5b67fd6171a237acb.txt` —— 所有权校验用的 key。实测两个 origin 现在都 404（`/clawock/<key>.txt` 与 `/<key>.txt`），不恢复它任何提交都会被拒
- `config/pages-public.json` —— `required_pages` 与 `artifact_include` 两处条目
- `tests/test_pages_deployment_contract.py` —— `INDEXNOW_KEY` 常量、对应测试与两处 staging 断言
- `ops/host/cron_timeline.py` —— `indexnow_submit` 解析分支（`rick_broadcast_nostr` 那条已随 #671 回来了）

台账 `logs/indexnow_seen.json` 一直在（08-15 最后写入），复用即可，首跑走增量不会刷屏。

## 新增 `tests/test_indexnow_submit.py`（7 条）

钉住的是「让它**静默**死掉」的那几个点，不是搜索引擎结果：

- 宿主 cron 调用的脚本路径真的存在（当初的失败形态就是 crontab 指向已删文件）
- 发布的 key 文件名与内容一致（IndexNow 靠拉 `{key}.txt` 比对来验所有权）
- `--help` 不碰网络 —— 一个会 POST 的 `--help` 只会在生产上被发现
- `--dry-run` 不 POST、也不需要 key
- **POST 成功之后才写台账**：反过来写会让一次失败的 run 把 URL 永久标记成已提交（正反两条测试）

## 宿主侧（不在本 PR 内，合并后由操作者执行一条）

```
0 12 * * * /usr/bin/python3 /root/.openclaw/workspace/ops/growth/indexnow_submit.py >> /root/.openclaw/workspace/logs/indexnow.log 2>&1
```

注意 #679 加的 `system_check.check_host_crontab_targets` 会对指向不存在文件的 crontab 行报 CRITICAL —— 所以这条必须在本 PR 合并**之后**再加。

## 验证

- `tests/test_indexnow_submit.py` 7 passed
- `tests/test_pages_deployment_contract.py` 恢复后的 key 契约测试通过
- 全套本地 worktree：2269 passed, 5 skipped, 4 xfailed，1 failed =
  `test_builder_stages_only_public_consumers`，**master 上同样红**（stash 后复跑确认），
  真因是该测试依赖 `assets/data/overview.json` 等 gitignored 的生成产物，
  新 worktree 里没有；builder 报的 `missing_pages` 里**不含** key 文件，
  说明恢复的条目已正常入包。CI 的 validate 会先重建 dashboard，这条在 CI 上是绿的。
