### PR TITLE
fix(outcomes): 让微信掉投可数（#771）

### DIFF
--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -164,6 +164,24 @@ def _locked():
         yield
 
 
+def delivery_channel(wechat_ok, telegram_ok):
+    """Name which channel actually carried a slot, rather than which two could.
+
+    The ledger used to store the constant string "wechat_or_telegram", which is
+    a description of the design, not an observation. WeChat drops a handful of
+    slots a week to an upstream-wontfix `ret=-2 prepare failed`, Telegram covers
+    them, and nothing anywhere recorded that it happened — the send receipts are
+    pruned within days (#771).
+    """
+    if wechat_ok and telegram_ok:
+        return "wechat+telegram"
+    if wechat_ok:
+        return "wechat"
+    if telegram_ok:
+        return "telegram"
+    return "none"
+
+
 def _stage(status="unknown", **details):
     out = {"status": status}
     out.update({key: value for key, value in details.items() if value is not None})
@@ -344,13 +362,17 @@ def record_from_heartbeat(event):
             slot=slot,
             **details,
         )
-        delivered = event.get("wechat_sent") is True or event.get("telegram_sent") is True
+        wechat_ok = event.get("wechat_sent") is True
+        telegram_ok = event.get("telegram_sent") is True
         record_stage(
             job,
             "primary_delivery",
-            "success" if delivered else "failed",
+            "success" if (wechat_ok or telegram_ok) else "failed",
             slot=slot,
-            **details,
+            **{**details,
+               "channel": delivery_channel(wechat_ok, telegram_ok),
+               "wechat_ok": wechat_ok,
+               "telegram_ok": telegram_ok},
         )
     elif state == "watchdog_backstop":
         record_stage(job, "watchdog_delivery", "success", slot=slot, **details)

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -921,7 +921,9 @@ def main(argv=None):
          ('not_required' if status == 'fail' else 'failed')),
         slot=slot,
         dry_run=args.dry_run,
-        channel='wechat_or_telegram',
+        channel=workflow_outcomes.delivery_channel(bool(wechat_sent), bool(tg_ok)),
+        wechat_ok=bool(wechat_sent),
+        telegram_ok=bool(tg_ok),
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if (not args.dry_run and status in ('pass', 'warn')

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -544,20 +544,27 @@ def main(argv=None):
     # `exec` timeout SIGTERM'd this process in exactly that gap, leaving a
     # delivered report filed as `pending` forever (#765). The send is already
     # proven at this point; nothing after it can make it less true.
-    primary_delivery_ok = bool(wechat_sent)
+    # Record the two channels separately. `channel='wechat_or_telegram'` folded
+    # them into one label, which is exactly the fact needed to answer "how many
+    # slots did WeChat drop this week" — a question that currently has no answer
+    # because the receipts are pruned within days (#771). WeChat's `ret=-2
+    # prepare failed` is a known, upstream-wontfix, periodic failure that kcn has
+    # decided not to chase; that is a reason to make it countable, not invisible.
+    wechat_ok = bool(wechat_sent)
+    telegram_ok = False
     try:
-        primary_delivery_ok = (
-            primary_delivery_ok
-            or json.loads(report_marker.read_text()).get('tg_ok') is True
-        )
+        telegram_ok = json.loads(report_marker.read_text()).get('tg_ok') is True
     except Exception:
         pass
+    primary_delivery_ok = wechat_ok or telegram_ok
     workflow_outcomes.record_stage(
         job_name,
         'primary_delivery',
         'success' if primary_delivery_ok else 'failed',
         slot=slot,
-        channel='wechat_or_telegram',
+        channel=workflow_outcomes.delivery_channel(wechat_ok, telegram_ok),
+        wechat_ok=wechat_ok,
+        telegram_ok=telegram_ok,
         deterministic_fallback=(status == 'fail'),
     )
 

--- a/src/clawock/publish/outcomes.py
+++ b/src/clawock/publish/outcomes.py
@@ -46,17 +46,27 @@ def summarize_records(records, *, hours: int = 36, now: datetime | None = None) 
 
     counts: dict[str, int] = {}
     false_reds = 0
+    wechat_dropped = 0
     for record in recent:
         final = (record.get("final_product") or {}).get("status", "pending")
         counts[final] = counts.get(final, 0) + 1
         if ((record.get("raw_execution") or {}).get("status") == "error"
                 and final in USABLE_PRODUCT_STATES):
             false_reds += 1
+        # WeChat drops slots to an upstream-wontfix `ret=-2 prepare failed` and
+        # Telegram covers them, so the product is fine and nothing shows it. This
+        # is the count, not an alert: kcn has ruled out chasing the failure, and
+        # per-run cron alerts are unwanted (feedback_no_individual_cron_alerts).
+        # Absent flags are not counted — an old record proves nothing either way.
+        delivery = (record.get("stages") or {}).get("primary_delivery") or {}
+        if delivery.get("wechat_ok") is False and delivery.get("telegram_ok") is True:
+            wechat_dropped += 1
 
     return {
         "generated_at": now.isoformat(),
         "window_hours": hours,
         "counts": counts,
         "raw_error_but_product_usable": false_reds,
+        "wechat_dropped_telegram_covered": wechat_dropped,
         "recent": recent[:MAX_RECENT],
     }

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 from clawock.automation import workflow_outcomes as outcomes  # noqa: E402
+from clawock.publish.outcomes import summarize_records  # noqa: E402
 
 
 # Every write prunes the ledger against KEEP_HOURS, so a slot literal is only
@@ -497,3 +498,93 @@ def test_falling_back_to_the_published_ledger_is_never_silent(
     outcomes.LOCAL_PATH.write_text("{ not json")
     assert outcomes.load_ledger()["records"] == []
     assert "falling back to the published copy" in capsys.readouterr().err
+
+
+# ── #771: which channel actually carried the slot ────────────────────────────
+
+def test_a_wechat_drop_covered_by_telegram_is_still_a_successful_product(
+    tmp_path, monkeypatch
+):
+    """The backstop working is not a failure — that is the whole design."""
+    _isolate(tmp_path, monkeypatch)
+    slot = "2026-07-24T12:00:00+08:00"
+    job = "港股午盘报告"
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(
+        job, "llm", "warning", slot=slot, escalating_count=0, advisory_count=1
+    )
+    record = outcomes.record_stage(
+        job, "primary_delivery", "success", slot=slot,
+        channel=outcomes.delivery_channel(False, True),
+        wechat_ok=False, telegram_ok=True,
+    )
+    assert record["final_product"]["status"] == "success"
+    # …but the drop is now on the record instead of only in a pruned receipt.
+    assert record["stages"]["primary_delivery"]["channel"] == "telegram"
+    assert record["stages"]["primary_delivery"]["wechat_ok"] is False
+
+
+def test_delivery_channel_names_what_carried_it():
+    assert outcomes.delivery_channel(True, True) == "wechat+telegram"
+    assert outcomes.delivery_channel(True, False) == "wechat"
+    assert outcomes.delivery_channel(False, True) == "telegram"
+    assert outcomes.delivery_channel(False, False) == "none"
+
+
+def test_intraday_heartbeats_record_the_channel_too(tmp_path, monkeypatch):
+    """Intraday reaches the ledger through cron_heartbeat, not record_stage."""
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat({
+        "job": "盘中盯盘",
+        "slot": "2026-07-24T10:30:00+08:00",
+        "state": "completed",
+        "postflight_status": "pass",
+        "data_plane_status": "published",
+        "wechat_sent": False,
+        "telegram_sent": True,
+    })
+    delivery = outcomes.load_ledger()["records"][0]["stages"]["primary_delivery"]
+    assert delivery["status"] == "success"
+    assert delivery["channel"] == "telegram"
+    assert delivery["wechat_ok"] is False
+
+
+def test_wechat_drops_covered_by_telegram_are_counted():
+    """A known, upstream-wontfix failure that nothing chased was also uncounted.
+
+    2026-08-18..19 dropped 5 slots to `ret=-2 prepare failed`; Telegram covered
+    every one, so no product was lost and no signal existed. Answering "how many
+    this week" meant grepping receipts that are pruned within days (#771).
+    """
+    now = datetime(2026, 7, 24, 20, 0, tzinfo=outcomes.HKT)
+
+    def slot(hour, wechat_ok, telegram_ok):
+        return {
+            "job": "盘中盯盘",
+            "slot": f"2026-07-24T{hour:02d}:00:00+08:00",
+            "stages": {"primary_delivery": {
+                "status": "success",
+                "wechat_ok": wechat_ok, "telegram_ok": telegram_ok,
+            }},
+            "final_product": {"status": "success"},
+        }
+
+    summary = summarize_records(
+        [slot(10, False, True), slot(11, True, True), slot(12, False, True)],
+        hours=36, now=now,
+    )
+    assert summary["wechat_dropped_telegram_covered"] == 2
+
+
+def test_a_record_without_channel_flags_is_not_counted_as_a_drop():
+    """An older record proves nothing either way — do not invent a failure."""
+    now = datetime(2026, 7, 24, 20, 0, tzinfo=outcomes.HKT)
+    summary = summarize_records([{
+        "job": "盘中盯盘",
+        "slot": "2026-07-24T10:00:00+08:00",
+        "stages": {"primary_delivery": {
+            "status": "success", "channel": "wechat_or_telegram",
+        }},
+        "final_product": {"status": "success"},
+    }], hours=36, now=now)
+    assert summary["wechat_dropped_telegram_covered"] == 0


### PR DESCRIPTION
Closes #771.

## 这个 PR 不做什么

08-18~08-19 有 5 个档微信主渠道报 `ret=-2 errmsg=prepare failed`（08-18 09:30 / 10:00 / 10:30 / 21:30，08-19 12:01），5 次全被 Telegram cosend 兜住。

网关日志里的形态与 `openclaw-wechat-cold-session-drop` 记的完全一致 —— 连掉几档，出现恢复标记，下一档立刻好：

```
Aug 18 10:34:03 [openclaw-weixin] [weixin] config cached    for o9cq80-…@im.wechat
Aug 18 21:42:05 [openclaw-weixin] [weixin] config refreshed for o9cq80-…@im.wechat
Aug 19 01:34:49 [openclaw-weixin] [weixin] config refreshed for o9cq80-…@im.wechat
```

上游 openclaw#81096 / #81316 均 CLOSED / NOT_PLANNED，插件无 issue 入口。kcn 2026-08-18 已明确否掉这条路：**「WeChat 不支持 refresh token」，补发/保活类方案不要再提**。

所以本 PR **不含**任何补投、预热、双发、切主通道的动作，也**不新增告警**（`feedback_no_individual_cron_alerts`）。`_watchdog_common` 里「Telegram 成功即算 delivered」的取舍也原样保留。

## 只修一件事：让它可数

要回答「这周微信掉了几档」，现在唯一办法是逐个翻 `memory/.tmp/report-sent-*.json` 数 `sent_ok` —— 而排查当天那批文件只剩 6 份，08-18 的四次里三次已经查不到；盘中档的 `intraday-sent-{market}.json` 只有最新一份，历史根本不存在。

一个**已知会周期性发生、且已决定不追**的故障，连发生频率都答不上来。这不是要盯着它，是不该连基数都没有。

`workflow_outcomes` 的 `primary_delivery` stage 记的是常量字符串 `channel: "wechat_or_telegram"` —— 那是对设计的描述，不是一次观测，恰好把这个信息折叠没了。账本已经保留 96 小时、已经发布，是现成的载体。

### 改动

- 新增 `workflow_outcomes.delivery_channel(wechat_ok, telegram_ok)` → `wechat` / `telegram` / `wechat+telegram` / `none`
- 三条投递路径都改记真实渠道 + `wechat_ok` / `telegram_ok` 两个布尔：
  - `report_postflight`（顺带把原来那段 `primary_delivery_ok` 的 try/except 拆清楚，微信与 Telegram 不再混在一个变量里）
  - `brief_postflight`
  - 盘中经 `cron_heartbeat` → `record_from_heartbeat`，那里本来就收到了 `wechat_sent`/`telegram_sent`，只是没归一化成 stage 字段
- `publish.outcomes.summarize_records()` 增加 `wechat_dropped_telegram_covered` 计数

**缺字段的旧记录不计入**：一条没有 `wechat_ok` 的历史记录既不证明掉了也不证明没掉，把它算成掉投就是拿沉默当证据（单独一条测试钉住）。

## 验证

- `tests/test_workflow_outcomes.py` 24 → 29 条
- 变异验证（撤掉修复，对应测试必须红）：
  - 不再统计微信掉投 → 1 红
  - 把缺字段也当掉投 → 1 红
  - 盘中退回折叠标签 → 1 红
  - 三次还原后均全绿
- 「微信失败 + Telegram 成功」的档 `final_product` 仍是 `success` —— 兜底生效不是失败，这是设计本身，有测试钉住
- 全套本地 worktree：**2267 passed, 5 skipped, 4 xfailed**
