### PR TITLE
fix(disclosures): 同场次回溯接给 SEC（#773）

### DIFF
--- a/src/clawock/market_data/primary_disclosures.py
+++ b/src/clawock/market_data/primary_disclosures.py
@@ -119,8 +119,19 @@ def fetch_exchange(symbol, *, now, window_minutes, http=None):
     return items, None
 
 
-def fetch_sec(issuer, *, now, window_minutes, http=None):
-    """Fetch normalized SEC submissions for one reporting issuer."""
+def fetch_sec(issuer, *, now, window_minutes, http=None,
+              session_lookback_minutes=None):
+    """Fetch normalized SEC submissions for one reporting issuer.
+
+    Like `fetch_finnhub_filings`, this deliberately reaches wider than the
+    caller's window. SEC is the only source that knows a filing's exact
+    acceptance time, so it is also the best answer to "is this date-only mirror
+    row actually inside the window" — but #769 gave the wider lookback to
+    Finnhub alone. On 2026-08-19 that left three SKHY 6-Ks sitting at
+    `filing_time_unavailable` while SEC, healthy in the same request, held
+    07:22:24Z for them (#773). `probe` enforces the real window once, after the
+    sources have been reconciled.
+    """
     from clawock.market_data import filings as fetch_us_filings  # noqa: PLC0415
 
     http = http or _http_json
@@ -144,6 +155,10 @@ def fetch_sec(issuer, *, now, window_minutes, http=None):
                 "(no deliverable contact address) — set SEC_USER_AGENT in .api_keys"
             )
         raise
+    lookback = (
+        session_lookback_minutes if session_lookback_minutes is not None
+        else max(window_minutes, SESSION_LOOKBACK_MINUTES)
+    )
     recent = ((payload or {}).get("filings") or {}).get("recent") or {}
     forms = recent.get("form") or []
     accepted = recent.get("acceptanceDateTime") or []
@@ -157,7 +172,7 @@ def fetch_sec(issuer, *, now, window_minutes, http=None):
         if when is None:
             continue
         age = _age_minutes(when, now)
-        if age < 0 or age > window_minutes:
+        if age < 0 or age > lookback:
             continue
         description = docs[index] if index < len(docs) else ""
         accession = accessions[index] if index < len(accessions) else ""

--- a/tests/test_active_information.py
+++ b/tests/test_active_information.py
@@ -445,3 +445,126 @@ def test_a_403_with_a_configured_user_agent_is_still_reported_as_an_outage(
     assert "sec" in entry["degraded_sources"]
     assert not any("sec_user_agent_unconfigured" in n for n in entry["notes"])
     assert any("HTTPError" in note for note in entry["notes"])
+
+
+# ── #773: SEC's own timestamps must reach the precision reconciler ───────────
+
+def _sec_payload(accepted):
+    """A submissions payload with one 8-K per accepted timestamp."""
+    return {"filings": {"recent": {
+        "form": ["8-K"] * len(accepted),
+        "acceptanceDateTime": list(accepted),
+        "primaryDocDescription": ["PRIMARY DOCUMENT"] * len(accepted),
+        "accessionNumber": [f"0001876042-26-00000{i}" for i in range(len(accepted))],
+        "primaryDocument": [f"crcl-8k-{i}.htm" for i in range(len(accepted))],
+        "items": [""] * len(accepted),
+    }}}
+
+
+def _sec_http(accepted, *, mirror_rows=None):
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            return _sec_payload(accepted)
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": mirror_rows or []}}
+        if host == "finnhub.io":
+            return []
+        raise AssertionError(url)
+    return http
+
+
+def test_a_same_day_filing_outside_the_window_leaves_no_date_only_row(monkeypatch):
+    """2026-08-19: three SKHY 6-Ks were 416min old, the window was 240min.
+
+    SEC held 07:22:24Z for them the whole time, but only Finnhub had the wider
+    lookback, so the mirror's date-only copies survived as `wait` rows carrying
+    `filing_time_unavailable` — stale evidence that would not retire until the
+    session ended.
+    """
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, finnhub_key="test-key",
+        http=_sec_http(
+            ["2026-08-12T23:05:00.000Z"],
+            mirror_rows=[{
+                "companyName": "Circle Internet Group Inc.",
+                "formType": "8-K", "filed": "08/13/2026",
+                "view": {"htmlLink": "https://mirror.test/crcl-8k"},
+            }],
+        ),
+    )["issuers"]["CRCL"]
+
+    assert entry["events"] == []
+    assert entry["status"] == "no_recent_disclosure"
+    assert entry["degraded_sources"] == []
+
+
+def test_a_filing_inside_the_window_is_unchanged(monkeypatch):
+    """The widened lookback must not widen what actually counts as recent."""
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, finnhub_key="test-key",
+        http=_sec_http(["2026-08-13T05:30:00.000Z"]),
+    )["issuers"]["CRCL"]
+
+    assert entry["status"] == "found"
+    assert [e["source_class"] for e in entry["events"]] == ["sec_filing"]
+    assert entry["events"][0]["age_minutes"] == 30
+
+
+def test_sec_reconciles_a_mirror_row_it_shares_a_filing_with(monkeypatch):
+    """When both sources hold it, SEC's timestamp is the one that resolves it."""
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+    entry = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, finnhub_key="test-key",
+        http=_sec_http(["2026-08-13T05:30:00.000Z"], mirror_rows=[{
+            "companyName": "Circle Internet Group Inc.",
+            "formType": "8-K", "filed": "08/13/2026",
+            "view": {"htmlLink": "https://mirror.test/crcl-8k"},
+        }]),
+    )["issuers"]["CRCL"]
+
+    # SEC answered, so the mirror short-circuit means there is nothing date-only
+    # left to carry a blocker.
+    assert all(e.get("time_precision") != "date" for e in entry["events"])
+
+
+def test_the_finnhub_reconciliation_path_still_works_when_sec_is_down(monkeypatch):
+    """#769's path must not regress now that SEC can short-circuit the mirror."""
+    monkeypatch.setattr(
+        "clawock.market_data.filings.lookup_cik", lambda _t: "CIK0001876042"
+    )
+
+    def http(url, **_kwargs):
+        host = urlsplit(url).hostname
+        if host == "data.sec.gov":
+            raise RuntimeError("SEC unreachable")
+        if host == "api.nasdaq.com":
+            return {"data": {"rows": [{
+                "companyName": "Circle Internet Group Inc.",
+                "formType": "8-K", "filed": "08/13/2026",
+                "view": {"htmlLink": "https://mirror.test/crcl-8k"},
+            }]}}
+        if host == "finnhub.io":
+            return [{"form": "8-K", "filedDate": "2026-08-13 00:00:00",
+                     "acceptedDate": "2026-08-13 01:30:00", "symbol": "CRCL"}]
+        raise AssertionError(url)
+
+    event = primary_disclosures.probe(
+        ["CRCL"], market="us", now=NOW, window_minutes=240,
+        budget_s=20, max_issuers=1, http=http, finnhub_key="test-key",
+    )["issuers"]["CRCL"]["events"][0]
+
+    assert event["source_class"] == "sec_filing_mirror"
+    assert event["time_precision"] == "datetime"
+    assert event["precision_source"] == "finnhub_filing"


### PR DESCRIPTION
Closes #773.

#769 修好了 SEC 直连，但那个 PR 的核心意图（清掉 `filing_time_unavailable`）在最该生效的路径上落空了。08-19 22:02 —— 修复后第一个美股盘中档 —— 就撞上了。

## 症状

`degraded_sources: []`（SEC 健康），可 SKHY 的三份 6-K 仍然是：

```json
{"source_class": "sec_filing_mirror", "time_precision": "date",
 "freshness_status": "same_session_date_time_unavailable",
 "disposition": "wait",
 "blockers": [..., "filing_time_unavailable", ...]}
```

同一时刻直接问 SEC，时间清清楚楚，而且**明确在 240 分钟窗口之外**：

```
6-K  2026-08-19T07:22:24+00:00  age=416min
6-K  2026-08-19T07:19:25+00:00  age=419min
6-K  2026-08-19T07:14:46+00:00  age=424min
```

## 根因：加宽回溯只接给了 Finnhub

`upgrade_mirror_precision()` 本身没问题，三条守则都有测试。问题在**喂给它的候选集**：

- `fetch_finnhub_filings` 拿到了 `session_lookback_minutes`（刻意宽于调用方窗口，因为「落在窗口外」本身就是要用的证据）
- `fetch_sec` 没有 —— 仍按 240 分钟过滤 ⇒ 416 分钟前那三份返回 0 条
- 0 条 ⇒ 镜像短路不触发 ⇒ 镜像跑，拿回同场次日期行（无时间）
- 补齐器手上只剩 Finnhub，而 Finnhub 滞后（SKHY 最新只到 08-14）⇒ 匹配不上 ⇒ blocker 保留

**SEC 是唯一知道精确受理时间的源，也就是最好的补齐器，偏偏是我没接的那个。**

## 实际伤害不是「少一个 candidate」

是**陈旧事件不退场**：三份 7 小时前的 6-K 会在之后每个盘中窗口继续以 `wait` 出现，直到当天结束。若 SKHY 技术腿此时触发，加仓侧读到的是「有一手公告但时间不详」—— 而真相是那份公告早过期了。这比没有信息更糟。

## 修法

给 `fetch_sec` 同样的 `session_lookback_minutes`，之后链路自然收敛：

1. SEC 返回同场次全部行（带真实时间戳）
2. 已有的镜像短路生效 —— SEC 健康且有当日文件时，镜像本来就提供不了新东西
3. `upgrade_mirror_precision()` 末尾那道统一窗口闸按真实 `age_minutes` 剪掉窗口外的

对 SKHY 的预期结果：`status` 从 `found`（带 3 条 `filing_time_unavailable` 的 wait）变成 `no_recent_disclosure`。这才是事实 —— 它今天确实发过公告，但**不在这个窗口里**。

## 验证

- `tests/test_active_information.py` 17 → 21 条，新增四条覆盖：窗口外不留日期行 / 窗口内行为不变（`age_minutes == 30`）/ SEC 与镜像共有同一份时由 SEC 收口 / **#769 的 Finnhub 补齐路径在 SEC 挂掉时不回归**
- 变异验证：
  - `fetch_sec` 退回窄窗口（即本 issue 的 bug）→ 1 红
  - 去掉末尾统一窗口闸 → 1 红
  - 两次还原后均全绿
- 全套本地 worktree：**2287 passed, 5 skipped, 4 xfailed**
