### PR TITLE
fix(cron): 契约不再按 cwd 解析，主机 cron 崩溃从此有闸 (#775 #776)

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -14,6 +14,7 @@ Used by:
 import glob
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -795,6 +796,103 @@ def check_host_crontab_targets(r):
         r.add('host crontab targets', OK, f'{len(rows)} lines · no missing targets')
 
 
+# A cron job that dies writes its traceback to the log the crontab line
+# redirects into, and its exit code into cron's mail — which this host has no
+# MTA for. Both are unread, so "crashes on every run" is as invisible as the
+# deleted-script case #663 already gates. These are the shapes a crashed run
+# leaves at the end of such a log.
+HOST_CRON_LOG_CRASH_MARKERS = (
+    re.compile(r'^Traceback \(most recent call last\):'),
+    re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Interrupt)\b'),
+    re.compile(r'command not found'),
+    re.compile(r'No such file or directory'),
+    re.compile(r'Permission denied'),
+)
+# Only the tail is read: these logs are append-only for months (the dashboard
+# publisher's is already several MB) and the question is about the last run.
+HOST_CRON_LOG_TAIL_BYTES = 8192
+
+
+def _host_cron_log_targets(crontab_text):
+    """Log files the host crontab appends job output into, under the workspace.
+
+    Derived from the crontab rather than listed here, for the same reason
+    `_host_crontab_target_audit` derives its roots: an absolute host path in
+    this file is the coupling the ratchet bans, and the set of host jobs is the
+    operator's, not this repository's.
+    """
+    from clawock.scheduling import parse_crontab_lines
+
+    targets = set()
+    for row in parse_crontab_lines(crontab_text):
+        for match in re.finditer(r'>>?\s*(\S+)', row['command']):
+            target = Path(match.group(1))
+            if target.is_absolute() and target.is_relative_to(LIVE_WORKSPACE):
+                targets.add(target)
+    return targets
+
+
+def _last_meaningful_line(path):
+    """The final non-blank line of a file's tail, or None."""
+    with path.open('rb') as fh:
+        try:
+            fh.seek(-HOST_CRON_LOG_TAIL_BYTES, os.SEEK_END)
+        except OSError:
+            fh.seek(0)
+        tail = fh.read().decode('utf-8', 'replace')
+    lines = [line.strip() for line in tail.splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def check_host_cron_logs(r):
+    """A host cron job whose log ends in a crash has been failing unnoticed.
+
+    #775 is the case this exists for: the DST synchroniser died on the same
+    `FileNotFoundError` eight days running and every repository-side gate stayed
+    green, because they all ask different questions — `check_host_crontab_targets`
+    asks whether the script still exists (it did), the GitHub cron-health job
+    only sees the eleven agent slots, and the outcome ledger does not carry host
+    maintenance jobs at all.
+
+    The criterion is deliberately modest and stated as what it is: **the last
+    thing this job wrote looks like a crash.** Host cron does not hand anyone an
+    exit code, so any design claiming to report one would be inventing it. Two
+    honest limits follow: a job that dies without writing anything is invisible
+    here, and one crash keeps reporting until a later run pushes it off the tail
+    (at most one schedule period for a job that runs at all).
+
+    WARN, not CRITICAL: `.githooks/pre-push` runs this file before every push to
+    master, and a stalled maintenance job must not wedge the market-data
+    publisher. WARN still surfaces on every run of the 20-minute publisher.
+    """
+    try:
+        out = subprocess.run(
+            ['crontab', '-l'], capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return  # no crontab on this host — nothing to check
+    if out.returncode != 0 or not out.stdout.strip():
+        return
+    targets = _host_cron_log_targets(out.stdout)
+    if not targets:
+        return
+
+    crashed, checked = [], 0
+    for path in sorted(targets):
+        if not path.is_file() or path.stat().st_size == 0:
+            continue  # never written, or written and then rotated away
+        checked += 1
+        last = _last_meaningful_line(path)
+        if last and any(m.search(last) for m in HOST_CRON_LOG_CRASH_MARKERS):
+            crashed.append((path.name, last))
+    if not checked:
+        return
+    for name, last in crashed:
+        r.add('host cron logs', WARNING, f'{name} ends on a crash: {last[:140]}')
+    if not crashed:
+        r.add('host cron logs', OK, f'{checked} host cron logs · none end on a crash')
+
+
 def check_generated_cron_docs(r):
     """Generated schedule documentation must exactly match the contract."""
     result = subprocess.run(
@@ -1004,6 +1102,7 @@ def main():
         check_context_capability,
         check_cron_paths_exist,
         check_host_crontab_targets,
+        check_host_cron_logs,
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -402,13 +402,25 @@ def _brief_job_names():
 
     The contract already names exactly one `daily-deep-brief` job, so renaming
     it there cannot leave a watchdog looking for a job that no longer exists.
+
+    An unreadable contract still degrades to the empty set — the caller has a
+    None branch and a watchdog must not crash a cron slot over its own lookup —
+    but it no longer does so *silently*. Empty here disables the entire re-run
+    limb of the brief watchdog, which is exactly the shape of gate this
+    repository requires to carry its own no-op assertion: #775 had a contract
+    that could not be read at all, and this function was the one place that
+    would have noticed — sitting behind a bare `except Exception: return set()`.
     """
     try:
         from clawock.scheduling import load_contract
 
         return {job.get('name') for job in load_contract().get('jobs', [])
                 if job.get('mode') == BRIEF_CONTRACT_MODE}
-    except Exception:
+    except Exception as e:
+        log({'tag': 'brief', 'action': 'contract-unreadable',
+             'error': f'{type(e).__name__}: {e}',
+             'effect': 'brief watchdog cannot identify its cron job — '
+                       're-run and retry-budget limbs are inert this slot'})
         return set()
 
 

--- a/src/clawock/scheduling.py
+++ b/src/clawock/scheduling.py
@@ -28,11 +28,33 @@ class ScheduleContract(dict):
 
 def _contract_path(path: str | Path | None, workspace: str | Path | None,
                    profile: str | Path | None) -> tuple[Path, Path]:
+    """(contract_path, workspace_root) for one `load_contract` call.
+
+    The last fallback is deliberately NOT `Path.cwd()`. `workspace_root`'s
+    contract is "unset behaves exactly like the 42 `parents[2]` sites", i.e. the
+    workspace the importing module physically sits in; passing the process's
+    current directory instead makes every bare `load_contract()` resolve against
+    wherever its caller happened to be started.
+
+    That is not hypothetical: cron starts `ops/host/sync_us_cron_dst.py` with a
+    bare interpreter and cwd `/root`, so from 2026-08-14 the DST synchroniser
+    went looking for `/root/config/cron-schedules.json` and died on every single
+    run for eight days (#775). The other cron lines survived only because the
+    `/root/.local/bin` launcher exports `CLAWOCK_WORKSPACE`, and an env override
+    outranks the fallback — so the bug hid everywhere except the one line that
+    does not use the launcher.
+
+    Precedence is unchanged: an explicit `path`, then `CLAWOCK_WORKSPACE`,
+    then an explicit `workspace=`, then the module's own tree. Only the last
+    step moves — from "wherever this process was started" to "where this code
+    lives", which is the one of the two that cannot be changed by a caller's
+    accident.
+    """
     if path is not None:
         resolved = Path(path).expanduser().resolve()
         root = Path(workspace).expanduser().resolve() if workspace else resolved.parent.parent
         return resolved, root
-    root = workspace_root(workspace or Path.cwd())
+    root = workspace_root(workspace)
     if profile is not None or os.environ.get(PROFILE_ENV_VAR):
         selected = load_profile(root, profile)
         return selected.resource_path("schedule_contract"), root
@@ -42,6 +64,16 @@ def _contract_path(path: str | Path | None, workspace: str | Path | None,
 def load_contract(path: str | Path | None = None, *, workspace: str | Path | None = None,
                   profile: str | Path | None = None) -> ScheduleContract:
     contract_path, root = _contract_path(path, workspace, profile)
+    if not contract_path.exists():
+        # A bare FileNotFoundError names the file it wanted and nothing about
+        # why it wanted *that* one, which is what made #775 read like a missing
+        # file rather than a misresolved workspace. Say which root was chosen
+        # and how to choose another: the reader has to be able to tell "wait for
+        # it to come back" apart from "you have to change a setting".
+        raise FileNotFoundError(
+            f"cron contract not found: {contract_path} "
+            f"(workspace resolved to {root}; set CLAWOCK_WORKSPACE, "
+            f"pass workspace=, or pass an explicit contract path)")
     data = ScheduleContract(json.loads(contract_path.read_text()), workspace=root)
     if data.get("schema_version") != 2:
         raise ValueError("cron contract schema_version must be 2")
@@ -182,7 +214,7 @@ def render_payload_message(contract: dict, expected_job: dict) -> str | None:
     if template_path is None:
         return None
 
-    workspace = getattr(contract, "workspace", workspace_root(Path.cwd()))
+    workspace = getattr(contract, "workspace", workspace_root())
     path = (workspace / template_path).resolve()
     try:
         path.relative_to(workspace.resolve())
@@ -302,7 +334,7 @@ def payload_errors(contract: dict, expected_job: dict, live_job: dict) -> list[s
     if expected_trigger:
         variables = expected_job.get("payload_vars") or {}
         script_path = _format_required(expected_trigger["script_path"], variables)
-        workspace = getattr(contract, "workspace", workspace_root(Path.cwd()))
+        workspace = getattr(contract, "workspace", workspace_root())
         expected_script = (workspace / script_path).read_text().strip()
         if not isinstance(trigger, dict):
             errors.append("condition trigger missing")

--- a/tests/test_brief_watchdog_contract_unreadable.py
+++ b/tests/test_brief_watchdog_contract_unreadable.py
@@ -1,0 +1,44 @@
+"""An unreadable cron contract must not silence the brief watchdog (#775).
+
+`_brief_job_names` is the only place in the running system that touches the
+schedule contract on a watchdog's behalf, and it sat behind a bare
+`except Exception: return set()`. Empty means `brief_cron_job()` returns None,
+which switches off the re-run and retry-budget limbs entirely — the exact
+"discovery gate that quietly discovers nothing" this repository keeps having to
+re-learn. It still degrades rather than crashing a cron slot; it just has to say
+so.
+
+The exception path is the whole point here: #768 was a fallback handler that had
+been dead since the day it was written, because nothing ever executed it. This
+test executes it.
+"""
+from clawock.harness import _watchdog_common
+
+
+def test_unreadable_contract_is_logged_not_swallowed(monkeypatch):
+    written = []
+    monkeypatch.setattr(_watchdog_common, 'log', written.append)
+
+    def explode():
+        raise FileNotFoundError('cron contract not found: /root/config/cron-schedules.json')
+
+    monkeypatch.setattr('clawock.scheduling.load_contract', explode)
+
+    assert _watchdog_common._brief_job_names() == set()
+
+    assert len(written) == 1, 'contract failure left no trace at all'
+    event = written[0]
+    assert event['action'] == 'contract-unreadable'
+    assert 'FileNotFoundError' in event['error']
+    assert event['effect'], 'the trace must say what stopped working, not just that it failed'
+
+
+def test_a_readable_contract_logs_nothing(monkeypatch):
+    """The trace is for the failure, not a per-slot heartbeat."""
+    written = []
+    monkeypatch.setattr(_watchdog_common, 'log', written.append)
+
+    names = _watchdog_common._brief_job_names()
+
+    assert names, 'the tracked contract still has to name the daily deep brief'
+    assert written == []

--- a/tests/test_contract_workspace_resolution.py
+++ b/tests/test_contract_workspace_resolution.py
@@ -1,0 +1,94 @@
+"""The cron contract must resolve from the tree, not from the caller's cwd (#775).
+
+`ops/host/sync_us_cron_dst.py` is started by cron as a bare
+`python3 <abs path>`, so its process cwd is `/root`. While `load_contract()`
+fell back to `Path.cwd()` that made the DST synchroniser look for
+`/root/config/cron-schedules.json` and fail on every run for eight days, with
+the traceback going to a log nobody reads. Every other cron line survived only
+because the launcher exports `CLAWOCK_WORKSPACE`.
+
+These tests pin the resolution order itself rather than that one script: an
+explicit path wins, then the env var, then an explicit `workspace=`, and the
+last fallback is the tree the module physically sits in.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'ops' / 'host'))
+
+from clawock import scheduling
+
+
+@pytest.fixture
+def no_workspace_env(monkeypatch):
+    """Neither override set, so the tests exercise the fallback itself."""
+    monkeypatch.delenv('CLAWOCK_WORKSPACE', raising=False)
+    monkeypatch.delenv('CLAWOCK_PROFILE', raising=False)
+
+
+def test_load_contract_ignores_the_process_cwd(tmp_path, monkeypatch, no_workspace_env):
+    """Ran from a directory with no `config/`, it still finds its own contract."""
+    monkeypatch.chdir(tmp_path)
+    assert not (tmp_path / 'config' / 'cron-schedules.json').exists()
+
+    contract = scheduling.load_contract()
+
+    assert contract['jobs'], 'contract resolved but came back empty'
+    assert contract.workspace == ROOT
+
+
+def test_a_foreign_cwd_containing_a_contract_does_not_hijack_the_lookup(
+        tmp_path, monkeypatch, no_workspace_env):
+    """The failure mode is silent substitution, not only a missing file.
+
+    A cwd that happens to hold a `config/cron-schedules.json` is the worse half
+    of the same bug: one book's schedules would be applied to another book's
+    runtime with no error at all.
+    """
+    (tmp_path / 'config').mkdir()
+    (tmp_path / 'config' / 'cron-schedules.json').write_text(json.dumps({
+        'schema_version': 2,
+        'jobs': [{'name': 'not-our-job', 'schedule': {'kind': 'cron', 'expr': '0 0 * * *'}}],
+    }))
+    monkeypatch.chdir(tmp_path)
+
+    contract = scheduling.load_contract()
+
+    assert 'not-our-job' not in [job['name'] for job in contract['jobs']]
+    assert contract.workspace == ROOT
+
+
+def test_explicit_workspace_still_wins_over_the_tree(tmp_path, no_workspace_env):
+    with pytest.raises(FileNotFoundError) as excinfo:
+        scheduling.load_contract(workspace=tmp_path)
+    assert str(tmp_path) in str(excinfo.value)
+
+
+def test_env_override_still_wins_over_the_tree(tmp_path, monkeypatch, no_workspace_env):
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        scheduling.load_contract()
+    assert str(tmp_path) in str(excinfo.value)
+
+
+def test_missing_contract_says_which_workspace_it_chose(tmp_path, no_workspace_env):
+    """The message has to separate "wait for it" from "you must change a setting"."""
+    with pytest.raises(FileNotFoundError) as excinfo:
+        scheduling.load_contract(workspace=tmp_path)
+    message = str(excinfo.value)
+    assert 'workspace resolved to' in message
+    assert 'CLAWOCK_WORKSPACE' in message
+
+
+def test_dst_sync_runs_from_crons_own_cwd(tmp_path, monkeypatch, no_workspace_env):
+    """The regression, reproduced through the script cron actually starts."""
+    import sync_us_cron_dst
+
+    monkeypatch.chdir(tmp_path)
+    contract = sync_us_cron_dst.load_contract()
+    assert contract['jobs']

--- a/tests/test_system_check_host_cron_logs.py
+++ b/tests/test_system_check_host_cron_logs.py
@@ -1,0 +1,176 @@
+"""The health gate must catch a host cron job that crashes on every run (#776).
+
+`check_host_crontab_targets` gates the deleted-script half of this family: the
+line fires, the file is gone, nothing sees it (#663). The other half is the file
+being *there* and dying every time — which is how the DST synchroniser failed
+eight days running on one `FileNotFoundError` with every repository-side gate
+still green (#775). Host cron hands out no exit code, so the criterion is the
+honest one: the last thing the job wrote looks like a crash.
+
+Behavioural, driven through a fake `crontab -l` and scratch logs, so deleting
+the check's body or making it blind to a traceback turns these red.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TRACEBACK_TAIL = (
+    "US cron DST: ok · daylight · openclaw=0 watchdog=0\n"
+    "Traceback (most recent call last):\n"
+    '  File "/x/sync_us_cron_dst.py", line 216, in <module>\n'
+    "    raise SystemExit(main())\n"
+    "FileNotFoundError: [Errno 2] No such file or directory: "
+    "'/root/config/cron-schedules.json'\n"
+)
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_logs", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def workspace(system_check, monkeypatch, tmp_path):
+    ws = tmp_path / "workspace"
+    (ws / "logs").mkdir(parents=True)
+    monkeypatch.setattr(system_check, "LIVE_WORKSPACE", ws)
+    return ws
+
+
+def _crontab(workspace, *log_names):
+    return "".join(
+        f"20 6 * * * /usr/bin/python3 {workspace}/ops/host/job.py >> "
+        f"{workspace}/logs/{name} 2>&1\n"
+        for name in log_names
+    )
+
+
+def _run(system_check, monkeypatch, stdout="", returncode=0):
+    def fake_crontab(*args, **kwargs):
+        return subprocess.CompletedProcess(["crontab", "-l"], returncode, stdout, "")
+
+    monkeypatch.setattr(subprocess, "run", fake_crontab)
+    result = system_check.Result()
+    system_check.check_host_cron_logs(result)
+    return result.checks
+
+
+def test_a_log_ending_in_a_traceback_warns(system_check, monkeypatch, workspace):
+    (workspace / "logs" / "dst-sync.log").write_text(TRACEBACK_TAIL)
+
+    checks = _run(system_check, monkeypatch, _crontab(workspace, "dst-sync.log"))
+
+    assert len(checks) == 1
+    name, severity, message = checks[0]
+    assert (name, severity) == ("host cron logs", system_check.WARNING)
+    assert "dst-sync.log" in message
+    assert "cron-schedules.json" in message, "the operator needs the failing line itself"
+
+
+def test_a_log_whose_last_run_succeeded_stays_green(
+        system_check, monkeypatch, workspace):
+    """A crash earlier in the file is history; the last run is the question."""
+    (workspace / "logs" / "dst-sync.log").write_text(
+        TRACEBACK_TAIL + "US cron DST: ok · daylight · openclaw=0 watchdog=0\n")
+
+    checks = _run(system_check, monkeypatch, _crontab(workspace, "dst-sync.log"))
+
+    assert checks == [("host cron logs", system_check.OK,
+                       "1 host cron logs · none end on a crash")]
+
+
+def test_trailing_blank_lines_do_not_hide_the_crash(
+        system_check, monkeypatch, workspace):
+    (workspace / "logs" / "dst-sync.log").write_text(TRACEBACK_TAIL + "\n\n   \n")
+
+    checks = _run(system_check, monkeypatch, _crontab(workspace, "dst-sync.log"))
+
+    assert checks[0][1] == system_check.WARNING
+
+
+def test_only_the_tail_is_read(system_check, monkeypatch, workspace):
+    """The publisher's log is already several MB; this must not slurp it."""
+    log = workspace / "logs" / "publish_dashboard.log"
+    log.write_text(("· data-plane: already holds this generation\n" * 200000)
+                   + "· data-plane: already holds this generation\n")
+    assert log.stat().st_size > system_check.HOST_CRON_LOG_TAIL_BYTES * 100
+
+    checks = _run(system_check, monkeypatch,
+                  _crontab(workspace, "publish_dashboard.log"))
+
+    assert checks[0][1] == system_check.OK
+
+
+def test_a_shell_failure_line_counts_as_a_crash(system_check, monkeypatch, workspace):
+    (workspace / "logs" / "gold_dca.log").write_text(
+        "/bin/bash: line 1: python4: command not found\n")
+
+    checks = _run(system_check, monkeypatch, _crontab(workspace, "gold_dca.log"))
+
+    assert checks[0][1] == system_check.WARNING
+
+
+def test_each_crashed_job_is_reported_separately(
+        system_check, monkeypatch, workspace):
+    (workspace / "logs" / "dst-sync.log").write_text(TRACEBACK_TAIL)
+    (workspace / "logs" / "gc_sessions.log").write_text(
+        "PermissionError: [Errno 13] Permission denied: '/root/x'\n")
+    (workspace / "logs" / "indexnow.log").write_text("IndexNow HTTP 200 — 91 URL(s)\n")
+
+    checks = _run(system_check, monkeypatch, _crontab(
+        workspace, "dst-sync.log", "gc_sessions.log", "indexnow.log"))
+
+    assert len(checks) == 2
+    assert {c[1] for c in checks} == {system_check.WARNING}
+    assert {"dst-sync.log", "gc_sessions.log"} == {c[2].split()[0] for c in checks}
+
+
+def test_a_never_written_log_is_not_a_finding(system_check, monkeypatch, workspace):
+    """A job that has not run yet, and `gitgc.log`, which is legitimately empty."""
+    (workspace / "logs" / "gitgc.log").write_text("")
+
+    assert _run(system_check, monkeypatch,
+                _crontab(workspace, "gitgc.log", "never-written.log")) == []
+
+
+def test_logs_outside_the_workspace_are_not_judged(
+        system_check, monkeypatch, workspace, tmp_path):
+    foreign = tmp_path / "elsewhere.log"
+    foreign.write_text(TRACEBACK_TAIL)
+
+    checks = _run(system_check, monkeypatch,
+                  f"0 9 * * * /usr/bin/some-tool >> {foreign} 2>&1\n")
+
+    assert checks == []
+
+
+def test_an_empty_crontab_is_not_a_finding(system_check, monkeypatch, workspace):
+    assert _run(system_check, monkeypatch, stdout="") == []
+
+
+def test_an_unreadable_crontab_is_not_a_finding(system_check, monkeypatch, workspace):
+    assert _run(system_check, monkeypatch, stdout="x", returncode=1) == []
+
+
+def test_a_host_without_the_crontab_binary_is_not_a_finding(
+        system_check, monkeypatch, workspace):
+    def no_crontab(*args, **kwargs):
+        raise FileNotFoundError("no crontab on this host")
+
+    monkeypatch.setattr(subprocess, "run", no_crontab)
+    result = system_check.Result()
+    system_check.check_host_cron_logs(result)
+    assert result.checks == []


### PR DESCRIPTION
Closes #775, closes #776.

## #775 —— 一条 cron 行静默死了 8 天

`20 6 * * *` 的 DST 同步任务自 2026-08-14 起 8/8 全败，每次都是同一个
`FileNotFoundError: /root/config/cron-schedules.json`，没有一条告警。

根因是 `_contract_path` 的兜底写成了 `workspace_root(workspace or Path.cwd())`。
`workspace_root` 承诺的兜底是「模块自己所在的那棵树」（树里另外 42 处都是这么解析的），
传 `Path.cwd()` 之后变成了「谁在哪儿启动就用哪儿」。cron 用裸 `python3 <abs path>` 起这个
脚本，cwd 是 `/root`，于是它去 `/root/config/` 找契约。其余 cron 行活着只是因为
`/root/.local/bin` 的 launcher 壳导出了 `CLAWOCK_WORKSPACE`，env 覆盖赢过兜底 —— 于是这个
缺陷藏在所有地方，只在唯一一条不走 launcher 的线上现形。

改动只挪最后一级：从「进程在哪启动」改成「代码在哪」，这两个里只有后者不会被调用方的
意外改变。`path` / `CLAWOCK_WORKSPACE` / `workspace=` 三级优先级一字未动。

顺带把 `load_contract` 的报错改成会说话的：契约缺失时报出**它选中了哪个工作区**以及换一个
的三种办法。原来那句裸 `FileNotFoundError` 只说了「文件不在」，读起来像「等它自己回来」，
而真相是「你得改配置」—— 这正是 8 天没人动它的一半原因。

### 第二个缺陷：唯一能看见它的地方把异常吞了

`_brief_job_names()` 是运行期唯一会撞上这个异常的调用方，而它是
`except Exception: return set()`。空集合让 `brief_cron_job()` 恒返回 None，简报 watchdog 的
重跑与重试预算两条腿整个失效，不报错、不留痕。它今天没坏，仅仅因为 launcher 设了那个环境
变量 —— 会用到坏兜底的那条路是坏的，而唯一该发现它的那双眼睛是闭着的。

现在仍然降级返回空集合（watchdog 不该因为自己的查表把一个 cron 档搞崩），但会往
`watchdog.jsonl` 写一条 `contract-unreadable`，并写明**什么因此不工作了**。配套测试真的会
走进那个 except —— #768 的教训是只在异常路径里用到的代码静态和测试都跑不到。

## #776 —— 崩溃零观测

退出码进 cron 的邮件（本机无 MTA），traceback 进没人读的日志。#663 已经给这一族的另一半
上过闸（脚本被删、crontab 还在调），这次补上孪生的那一半：**文件在，但每次跑都死**。

`ops/system_check.py` 新增 `check_host_cron_logs`：从 `crontab -l` 解析出落在 live workspace
下的重定向目标，读每个日志的尾部 8KB，最后一条非空行命中崩溃特征就报 WARN。

判据老老实实写成它本来的样子 ——「这个任务最后写下的东西看起来像崩溃」。主机 cron 不提供
退出码，任何声称能报退出码的设计都是在编。两条边界写进 docstring：跑挂之后什么都不写的任务
它抓不到；一次崩溃会一直报到下一次运行把它挤出尾巴为止。

取 WARN 不取 CRITICAL：`.githooks/pre-push` 每次 push master 前都会跑 system_check，
CRITICAL 会卡住行情发布器，而主机维护任务挂掉不该拦住发布。

本机实测 10 个日志命中 1 个，正是唯一真坏的那个，无噪声。

## 验证

- 4 条新测试在修复前红、修复后绿（含「cwd 里恰好有另一本账的契约」这种静默顶替）
- 把 `check_host_cron_logs` 掏空 → 11 条里 6 条转红
- 相关既有套件 114 passed
- 本机 `system_check.py`：0 critical，新闸输出恰好一条 WARN 指向 dst-sync.log

Claude-Session: https://claude.ai/code/session_01P5BsCeDZeyAKHTtE6AnKHd


https://claude.ai/code/session_01P5BsCeDZeyAKHTtE6AnKHd
