### PR TITLE
fix(skills): 简报里的 tavily 路径改成能跑的，并给「命令跑不起来」上闸 (#777)

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -17,6 +17,10 @@ clawock brief preflight
 **持仓相关数字**（FX、book USD/HKD、concentration HHI、retrospective、单股 RSI/MA/PnL）只从这个 JSON 取，不要凭空造。
 **板块全景/同行涨幅榜/当日催化** context.json 没覆盖 — Step 3 用 tavily-search 拉实时。
 
+**跑命令的两条硬约束（同属「工具报错=整轮记 error」那一族）**
+- 脚本路径**照抄 SKILL.md，不要猜**。猜错了不许全盘扫描：`find /` 会被转入后台会话，而**主动 `process kill` 掉它的 toolResult 带 isError**，整个 cron 会被记成 error —— 2026-08-21 的简报就是这样在两个渠道都投递成功之后仍然判红的。
+- 任何可能长跑的命令自己用 `timeout` 包住（如 `timeout 20 <cmd>`），让它自己结束，这样就永远不需要 kill。
+
 **Step 3 - Swarm 分析（你的创造性工作）**
 - ⚡ **板块全景**（必跑 tavily-search）：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓动态，不要写死任何 ticker），每个板块拉今日 Top 涨幅榜 + 你持仓在榜单的位置（领涨/落后/中位）+ 1 句归因（催化时点/早盘抛压/β 错配）
 - Regime（US/HK 分开打 tag）

--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -152,6 +152,8 @@
         "首次生成和 postflight 修复 Step 4 产物都只用 `write` 完整覆盖；禁止 `edit` 精确文本替换",
         "唯一微信路径",
         "同步 Telegram",
+        "猜错了不许全盘扫描",
+        "不需要 kill",
         "绝不要",
         "message"
       ],

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -218,8 +218,8 @@ manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 c
 
 - 板块来源是动态的：读 `memory/peer-map.json`，**每个 active ticker 的 `theme` 字段就是它的板块名**（如 "HK AI 大模型" / "HK 科技指数 2x leveraged (HSTECH 标的)" / "商业航天"）。持仓变了，板块自动跟变 — 不要在 SKILL.md / 报告里写死任何特定 ticker
 - 对每个去重后的 theme 跑一次 web search — **本 skill（盘前深度简报）已放开 `tavily-search`，优先用它**（`TAVILY_API_KEY` 已配置）；tavily 无结果或超时再退回内置 web search。⚠️ 免费档 1000 credits/月是全局共享，本 skill 每天只 1 次、按去重后的 theme 数搜（通常 ≤10 次/天），别对同一 theme 重复搜。**调用必须带 `--bucket brief`**（走本 skill 的月度配额 300；不带 bucket 会落 default 桶只有 60，很快被硬护栏挡回）：
-  - HK 板块 → `node ../tavily-search/scripts/search.mjs "今日 HK {theme} 涨幅榜 板块异动" --topic news --days 2 --bucket brief`
-  - US 板块 → `node ../tavily-search/scripts/search.mjs "{sector ETF 如 SOXX/QQQ/ARK} 今日成分涨跌" --topic news --days 2 --bucket brief`
+  - HK 板块 → `node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "今日 HK {theme} 涨幅榜 板块异动" --topic news --days 2 --bucket brief`
+  - US 板块 → `node /root/.openclaw/workspace/skills/tavily-search/scripts/search.mjs "{sector ETF 如 SOXX/QQQ/ARK} 今日成分涨跌" --topic news --days 2 --bucket brief`
   - 护栏是硬闸：额度用尽时脚本返回 "Web search unavailable" 并 exit 0，**别当报错**，退回内置搜索即可
 - 每个板块输出：Top 3-5 涨幅 + 你持仓票在榜单中的位置（领涨/落后/中位）
 - **归因句必带**：落后是因为(a) 利好时点（盘后才公布）/ (b) 早盘异常抛压 / (c) β 错配 / (d) 个股逻辑滞后？

--- a/tests/test_skill_commands_are_runnable.py
+++ b/tests/test_skill_commands_are_runnable.py
@@ -1,0 +1,73 @@
+"""A command written in a SKILL.md has to be a command that runs (#777).
+
+SKILL.md is not prose for a human to skim — it is handed to an execution engine
+that types what it reads. `skills/daily-deep-brief/SKILL.md` told it to run
+`node ../tavily-search/scripts/search.mjs`, which resolves only from inside
+`skills/daily-deep-brief/`, and nothing ever puts it there. On 2026-08-21 the
+model took four `Cannot find module` hits, guessed the path from openclaw's own
+bundled-skills prefix, fell back to a whole-filesystem `find /`, then killed
+that background session — and the kill's `isError` toolResult marked the entire
+cron run as failed, on a morning where the brief had in fact been generated and
+delivered to both channels.
+
+So the invariant is not about that one line: **every script path a SKILL.md
+tells the agent to run must name a file that exists in this repository.**
+`{placeholder}` templates are exempt — those are for the loader to fill in.
+
+This is the skills-side twin of #663's host-crontab gate: a command that cannot
+run is a silent no-op wherever it is written down.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+
+# `node scripts/x.mjs`, `python3 ops/y.py`, `bash ops/z.sh` — the interpreter
+# forms these documents actually use. Backticks/quotes end the path.
+INVOCATION = re.compile(r'\b(?:node|python3|bash)\s+([^\s`"\']+\.(?:mjs|js|py|sh))')
+# Repository directories a documented absolute host path can be re-rooted from,
+# so the gate works both on this host and on a CI checkout that lives elsewhere.
+REPO_DIRS = ("skills", "ops", "scripts", "src", "config", "tests")
+
+
+def _candidates(raw):
+    """Every place `raw` could legitimately name, most specific first."""
+    path = Path(raw)
+    if not path.is_absolute():
+        yield ROOT / path
+        return
+    parts = path.parts
+    for marker in REPO_DIRS:
+        if marker in parts:
+            yield ROOT.joinpath(*parts[parts.index(marker):])
+    yield path  # a genuine host path, on the host that has it
+
+
+def _documented_commands():
+    for skill_md in sorted(SKILLS.rglob("*.md")):
+        for lineno, line in enumerate(skill_md.read_text().splitlines(), 1):
+            for raw in INVOCATION.findall(line):
+                yield skill_md.relative_to(ROOT), lineno, raw
+
+
+def test_the_scan_actually_finds_commands():
+    """A regex that matches nothing would make every assertion below vacuous."""
+    found = list(_documented_commands())
+    assert len(found) >= 10, f"only {len(found)} documented commands — the scan broke"
+
+
+@pytest.mark.parametrize(
+    "doc,lineno,raw",
+    [pytest.param(d, n, raw, id=f"{d}:{n}") for d, n, raw in _documented_commands()],
+)
+def test_every_documented_script_path_resolves(doc, lineno, raw):
+    if "{" in raw:
+        return  # loader-substituted template, e.g. `node {baseDir}/scripts/search.mjs`
+    assert any(c.is_file() for c in _candidates(raw)), (
+        f"{doc}:{lineno} tells the agent to run `{raw}`, which resolves to no file "
+        f"in this repository — the agent will improvise a path instead"
+    )


### PR DESCRIPTION
Closes #777.

## 一条跑不起来的命令，代价是一整轮假红

2026-08-21 的盘前深度简报**两个渠道都投递成功了，却被记成 cron error**
（`lastRunError: ⚠️ 🧰 Process: fast-cedar failed`，`consecutiveErrors=1`，而
`failureAlert.after=2` —— 再来一天就会往微信推一条假告警）。

会话 03cd697a 逐行还原：

1. 模型按 SKILL.md 跑板块扫描，四次 `Error: Cannot find module`
2. 「Path issue. Let me find the actual location.」→ `find / -name search.mjs`
3. 全盘扫描超时被转入后台会话 `fast-cedar`
4. 模型换招 `ls skills/` 找到了真路径，回头 `process kill fast-cedar`
5. 这次 kill 的 toolResult 是 `isError: true` / `status: failed` → **整轮 cron 判 error**

真口径三条全绿：trajectory `finalStatus: success`、`brief_postflight_status.json`
`{"status":"pass"}`、账本 08:00 档 `wechat_ok + telegram_ok`。判据再次生效：**cron outcome 与
`trajectory.finalStatus` 不一致时，trajectory + postflight 收据才是真的。**

## 根因

`skills/daily-deep-brief/SKILL.md` 写的是相对路径 `node ../tavily-search/scripts/search.mjs`。
相对于谁？模型的 cwd 是工作区根，`../tavily-search/…` 落在 `/root/.openclaw/`，不存在；
只有站在 `skills/daily-deep-brief/` 里才对，而没有任何一步要求它 cd 过去。

同一棵树里另外两个技能（hk-/us-stock-analysis）写的是能跑的绝对路径，从没出过这个事。拿不到
能跑的路径，模型就自己猜 —— 猜成了 openclaw 自带技能那个带版本号的前缀。改成与那两个一致。

## 上闸：SKILL.md 里的命令必须真的能跑

`tests/test_skill_commands_are_runnable.py` 扫 `skills/**/*.md` 里每一条
`node|python3|bash <script>`，要求它解析到本仓库里真实存在的文件；带 `{placeholder}` 的模板
行豁免（那是给 loader 填的）。绝对路径按仓库目录段重新落根，所以本机和 CI checkout 都成立。
失败信息指名 `文件:行号`。

判据可以推广：**SKILL.md 不是给人略读的散文，是交给一个会照着敲的执行体的**。敲不动就等于
写错了。这是 #663「删掉的脚本仍被 crontab 调用」在 skills 侧的孪生 —— 一条跑不起来的命令，
写在哪儿都是静默空转。

改回相对路径 → 那两行转红；改对 → 16 条全绿。

## 兜底

简报 payload 加两条硬约束并用 `required_substrings` 钉住（防止后续改文案时静默丢失）：路径
照抄 SKILL.md 不要猜、猜错也不许全盘扫描、被转入后台的命令不要主动 kill；可能长跑的命令自己
用 `timeout` 包住，让它自己结束，就永远不需要 kill。

只加在 brief 一个 profile 上：report/intraday 的路径本来就是对的，这条 hazard 在那边从未触发，
而 payload 是每天真的要付的 context 成本。真正防复发的是上面那条闸，不是这段话。

**合并后必须同步 live**：`ops/host/sync_cron_payloads.py --apply`（payload 是真实执行面，
改了契约不同步等于没改，而且 system_check 会因契约与 live 漂移报 CRITICAL）。

Claude-Session: https://claude.ai/code/session_01P5BsCeDZeyAKHTtE6AnKHd


https://claude.ai/code/session_01P5BsCeDZeyAKHTtE6AnKHd
