### PR TITLE
ci: PR 级并发控制 + Playwright 缓存 + Dependabot 补 pip/npm 两棵树

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 
 updates:
-  # clawock intentionally has no Python dependency manifest today, so keep this
-  # focused on the Actions actually used by the repository.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -13,6 +11,51 @@ updates:
     open-pull-requests-limit: 5
     groups:
       safe-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # `pyproject.toml` is the one place the Python dependencies are declared (they
+  # used to be drifting `pip install` lines in nine workflows). Until #784 this
+  # file claimed the repository had no Python manifest at all, so the dependency
+  # surface of the package published to PyPI was watched by nobody — and
+  # repository-level Dependabot security updates only produce alerts for trees
+  # an ecosystem entry makes visible.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    # Deliberately small: Dependabot's own branches cannot satisfy this
+    # repository's required checks, so every PR it opens has to be reopened from
+    # a `claude/…` or `codex/…` branch by hand. A high limit just piles up work
+    # that cannot be merged where it stands.
+    open-pull-requests-limit: 3
+    groups:
+      python-safe:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # The npm side of the release train. clawock-dsh ships a full lockfile and has
+  # already broken a release once through it (0.1.6: mirror-registry URLs left in
+  # `resolved`), so this tree is not hypothetical.
+  - package-ecosystem: npm
+    directory: /examples/dsh/packages/clawock-dsh
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 3
+    groups:
+      npm-safe:
         patterns:
           - "*"
         update-types:

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -39,6 +39,15 @@ on:
 permissions:
   contents: read
 
+# A superseded PR run is worth nothing: the only result anybody reads is the one
+# for the tip of the branch. On master the opposite holds — every green there is
+# part of the ledger, so those runs are never cancelled. Deliberately NOT the
+# `cancel-in-progress: false` that pages.yml uses; that one exists so a burst of
+# deploys cannot lose a generation, which is the opposite requirement.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -173,11 +182,29 @@ jobs:
         with:
           node-version: '22'
 
+      # The browser build is ~150MB downloaded from scratch on every UI run. The
+      # version is already pinned on the line below, so it is also a complete
+      # cache key: a bump changes the key and misses on purpose.
+      - name: Cache the Playwright browser build
+        if: steps.changes.outputs.ui == 'true'
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-1.60.0-${{ runner.os }}
+
       - name: Install dashboard browser contract runtime
         if: steps.changes.outputs.ui == 'true'
         run: |
           npm install --no-save --silent playwright@1.60.0
-          npx playwright install --with-deps chromium
+          # The apt-level dependencies live outside ~/.cache/ms-playwright and are
+          # not restored by the cache, so they are installed either way; only the
+          # browser download is skipped on a hit.
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       # The dashboard's four outputs and two sidecars live on the data branch,
       # not on master (#314), so a checkout does not carry them. The browser

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # The four dashboard outputs are published to an orphan data branch, not
       # to master (#314). The staging step reads them from the checkout, so they

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -75,7 +75,7 @@ jobs:
         # instruction or a DeepSeek Harness agent (examples/).
         run: examples/cli/run.sh dist/*.whl
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: distributions
           path: dist/
@@ -100,7 +100,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist/
@@ -180,7 +180,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist/

--- a/.github/workflows/seo-visibility.yml
+++ b/.github/workflows/seo-visibility.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Closes #783, closes #784

## 1. `harness-regression` 的并发控制（#783）

它是仓库里唯一没有 `concurrency` 的 workflow —— 9 个 data-write workflow 和 `pages.yml` 都有，偏偏 required check `validate` 所在的这个没有。一个 PR 连推两次，第一次的完整套件不会被取消，两遍并行跑完（单次 123–156 秒）。

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**刻意不照抄 `pages.yml` 的 `cancel-in-progress: false`** —— 那条是为了「一串部署不能丢掉任何一代」，语义和 CI 相反：被取代的 PR 跑没人要，而 master 上的每次绿是账本的一部分，所以 master 不取消。

## 2. Playwright 浏览器缓存（#783）

```
npm install --no-save --silent playwright@1.60.0
npx playwright install --with-deps chromium     # ~150MB，每次现下
```

版本已经钉死在上一行，所以它本身就是完整的 cache key。命中时改跑 `install-deps`（apt 依赖在 `~/.cache/ms-playwright` 之外，缓存恢复不了，两条路都要装；省掉的是浏览器本体的下载）。

## 3. Dependabot 补上 pip 和 npm（#784）

原配置只看 `github-actions`，理由写在注释里：

> clawock intentionally has no Python dependency manifest today

这句话已经不成立。`pyproject.toml` 现在是 Python 依赖**唯一**的声明处（它自己的注释说明了这点：以前散在九个 workflow 的 `pip install` 行里各自漂移），而 `examples/dsh/packages/clawock-dsh/package-lock.json` 是发布到 npm 的包的完整 lockfile —— 后者已经因为 lockfile 里残留镜像源 URL 弄挂过一次 0.1.6 发布。

两棵树对 Dependabot 都不可见。仓库级 `dependabot_security_updates` 是 enabled，但**安全告警只在 ecosystem 条目让 Dependabot 解析得到清单时才产出**，所以「当前 0 open alert」不等于没有漏洞，等于没人在看。

`open-pull-requests-limit` 给到 3 而不是 5：Dependabot 自己的分支满足不了本仓库的 required check，每个 PR 都要人肉搬到 `claude/…` 重开，限额开大只是堆积开不动的 PR。

## 4. 顺带：action 版本对齐

发现时**发布链跑在旧版本上**，其余地方早就升过了：

| action | 修改前 | 修改后 |
|---|---|---|
| `setup-python` | release.yml + seo-visibility.yml 在 `@v6`，其余 7 处 `@v7` | 全部 `@v7` |
| `checkout` | pages.yml 1 处 `@v6`，其余 20 处 `@v7` | 全部 `@v7` |
| `upload-artifact` | release.yml `@v5`，harness-regression `@v7` | 全部 `@v7` |
| `download-artifact` | release.yml `@v6`，harness-regression `@v8` | 全部 `@v8` |

upload@v7 + download@v8 这个配对是 `harness-regression.yml` 里已经在跑的组合，不是新配的。

## 验证

- `/tmp/actionlint`（与 CI 同一个 pinned 1.7.12，sha256 校验过）exit 0
- `pytest tests/test_workflow_health.py tests/test_workflow_improvements.py tests/test_pr_publish_gate_contract.py tests/test_portable_workflow.py tests/test_cron_contracts.py` → 65 passed
- 并发生效的证据只能在这个 PR 自己身上看：本 PR 若连推两次，第一次的 `validate` 应显示 cancelled
