### PR TITLE
npm: 发布补 provenance，并把包页面的出口还回来

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,13 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/v') || inputs.npm_only == 'true' || inputs.npm_only == true) && inputs.repository != 'testpypi'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # The OIDC token npm exchanges for a provenance attestation. Without it
+      # `npm publish --provenance` cannot run, and the publish script degrades
+      # to an unsigned publish rather than failing — so this line is the whole
+      # difference between a signed and an unsigned release.
+      id-token: write
     env:
       # 2026-08-17: the 0.1.6 npm job died because its package-lock.json had
       # been regenerated on the desk under a mirror registry — every `resolved`

--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -1,5 +1,36 @@
 # clawock-dsh
 
+**AI argues. Code settles. The losses stay on the page.**
+
+The [clawock](https://github.com/KCNyu/clawock) investment-decision workflow, as
+a DeepSeek Harness plugin. A skill package that makes the agent walk four steps —
+read the request, research and argue both sides, write the decision, then let
+Python validate and settle it — plus a Decision Studio tab that renders the
+request, the debate and the receipt as a conversation view inside the DSH web GUI.
+
+The fourth step is the one that matters: the model never touches settlement.
+Prices, FX, P&L and the scorecard are computed by code the agent cannot write to,
+so a wrong call shows up as a loss on a public page instead of as a
+better-sounding paragraph.
+
+- **Live proof** — a real Hong Kong + US brokerage account, run this way every
+  trading day: <https://kcnyu.github.io/clawock/>
+- **Evidence, wins and losses both** — <https://kcnyu.github.io/clawock/evidence.html>
+- **Source and issues** — <https://github.com/KCNyu/clawock>
+
+![Decision Mind tab inside the DSH web GUI](https://raw.githubusercontent.com/KCNyu/clawock/refs/heads/master/site/assets/dsh-decision-mind.png)
+
+```bash
+dsh plugin --profile web add clawock-dsh
+```
+
+Skill discovery needs one more step on rc.6 and later, covered in the
+installation section below. The rest of this README is in Chinese; the full
+English overview lives in the
+[repository README](https://github.com/KCNyu/clawock#readme).
+
+---
+
 clawock 的 DeepSeek Harness 插件:skill 包 + Decision Studio 面板,把
 investment-decision 决策工作流注入 DSH agent。skill 负责告诉 agent 怎么走
 「读请求 → 研究 + 正反辩论 → 写决策 → Python 校验结算」四步;面板把

--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -3,6 +3,16 @@
   "version": "0.1.8",
   "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Mind conversation-view tab",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KCNyu/clawock.git",
+    "directory": "examples/dsh/packages/clawock-dsh"
+  },
+  "homepage": "https://kcnyu.github.io/clawock/",
+  "bugs": {
+    "url": "https://github.com/KCNyu/clawock/issues"
+  },
+  "author": "Shengyu Li",
   "keywords": [
     "dsh",
     "deepseek-harness",

--- a/ops/publish/publish_dsh_plugin.sh
+++ b/ops/publish/publish_dsh_plugin.sh
@@ -99,7 +99,24 @@ const listed = JSON.parse(execFileSync("npm", ["pack", "--dry-run", "--json"], {
 process.stdout.write(JSON.stringify(listed[0].files.map((f) => f.path).sort()));
 ')"
 
-(cd "$PKG_DIR" && npm publish --access public)
+# npm provenance: a signed, publicly verifiable statement of which repository,
+# workflow and commit produced this tarball, rendered as a "Built and signed on
+# GitHub Actions" block on the package page. It is the npm-side equivalent of
+# the trusted publishing the PyPI half already uses, and the package page is
+# this project's highest-traffic landing surface.
+#
+# npm only accepts it from a supported CI with an OIDC token, and hard-fails
+# when asked for it anywhere else — so a human running this script directly
+# (a documented path, see the header) must not pass the flag.
+provenance_args=()
+if [ "${GITHUB_ACTIONS:-}" = "true" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+  echo "provenance: OIDC token available — publishing with --provenance"
+  provenance_args+=(--provenance)
+else
+  echo "provenance: no Actions OIDC token — publishing without provenance"
+fi
+
+(cd "$PKG_DIR" && npm publish --access public "${provenance_args[@]}")
 
 published="$(cd "$PKG_DIR" && node -p "require('./package.json').version")"
 

--- a/tests/dsh_plugin_package_contract.mjs
+++ b/tests/dsh_plugin_package_contract.mjs
@@ -99,3 +99,49 @@ test('packed clawock-dsh installs standalone and every export entry imports', as
     rmSync(work, { recursive: true, force: true })
   }
 })
+
+/**
+ * The npm page is this project's highest-traffic landing surface — more people
+ * reach clawock-dsh through npm than through the repository — and until #790 it
+ * was a dead end: `repository`, `homepage`, `bugs` and `author` were all absent
+ * from the published metadata, so npm rendered no sidebar links at all, and the
+ * README was Chinese-only with no link back to the live proof. A thousand
+ * installs a month landed on a page with no exit.
+ *
+ * Two of these are load-bearing beyond presentation:
+ *   - `repository` is what `npm publish --provenance` checks against the
+ *     building repository; without it the release silently publishes unsigned.
+ *   - relative image paths render as broken images on the npm page, because it
+ *     is not served from the repository.
+ */
+test('the npm page keeps its links back to the repository and the live proof', () => {
+  const pkg = JSON.parse(readFileSync(join(PLUGIN, 'package.json'), 'utf8'))
+
+  assert.equal(pkg.repository?.type, 'git')
+  assert.match(pkg.repository?.url ?? '', /github\.com\/KCNyu\/clawock/)
+  assert.equal(pkg.repository?.directory, 'examples/dsh/packages/clawock-dsh')
+  assert.match(pkg.homepage ?? '', /^https:\/\//)
+  assert.match(pkg.bugs?.url ?? '', /github\.com\/KCNyu\/clawock\/issues/)
+  assert.ok(pkg.author, 'package.json must name an author')
+
+  const readme = readFileSync(join(PLUGIN, 'README.md'), 'utf8')
+  for (const url of [
+    'https://kcnyu.github.io/clawock/',
+    'https://kcnyu.github.io/clawock/evidence.html',
+    'https://github.com/KCNyu/clawock',
+  ]) {
+    assert.ok(readme.includes(url), `README.md must link to ${url}`)
+  }
+
+  // The lead has to be readable by someone who does not read Chinese: the npm
+  // audience is every DSH user, not only the ones who found the repo first.
+  const lead = readme.split('\n---\n')[0]
+  assert.ok(/[一-鿿]/.test(readme), 'the Chinese body must stay')
+  assert.ok(!/[一-鿿]/.test(lead),
+    'the section above the first --- must be the English lead, with no Chinese in it')
+
+  for (const m of readme.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g)) {
+    assert.match(m[1], /^https:\/\/raw\.githubusercontent\.com\//,
+      `README image ${m[1]} must be an absolute raw.githubusercontent.com URL`)
+  }
+})

--- a/tests/test_github_release_contract.py
+++ b/tests/test_github_release_contract.py
@@ -218,3 +218,33 @@ def test_the_publish_verifies_what_the_registry_actually_serves():
     assert "published tarball is missing" in tail, (
         "every file the pack listed must exist in the registry copy"
     )
+
+
+def test_the_npm_publish_carries_provenance():
+    """The two halves of the release train must carry equivalent credentials.
+
+    The PyPI half publishes through trusted publishing: PyPI verifies the
+    workflow's OIDC identity and no long-lived token exists to leak. The npm
+    half had none of that (#785) — it published with a plain `NPM_TOKEN` and no
+    `--provenance`, so the package page, which is this project's
+    highest-traffic landing surface, carried no verifiable statement of what
+    built the tarball.
+
+    Two things have to hold together or the flag degrades to a no-op:
+    the job must be granted the OIDC token, and the script must ask for it.
+    """
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    npm_job = workflow.split("\n  npm:\n", 1)[1].split("\n  github-release:", 1)[0]
+    assert "id-token: write" in npm_job, (
+        "the npm job needs the OIDC token npm exchanges for a provenance attestation"
+    )
+
+    script = (ROOT / "ops" / "publish" / "publish_dsh_plugin.sh").read_text(encoding="utf-8")
+    assert "--provenance" in script, "the publish has to ask for provenance"
+    # A human running the script directly is a documented path, and npm hard-fails
+    # when asked for provenance outside a supported CI — so the flag has to be
+    # conditional, never unconditional.
+    assert "ACTIONS_ID_TOKEN_REQUEST_URL" in script, (
+        "provenance must be gated on an actually-present OIDC token, so a local "
+        "publish degrades instead of failing"
+    )


### PR DESCRIPTION
Closes #785, closes #790

两条本来是两个 issue，合成一个 PR 是因为它们**物理耦合**：`npm publish --provenance` 会拿 `package.json` 的 `repository` 字段去和「正在构建的仓库」比对，字段不存在就发不了 provenance。所以元数据那半是签名那半的前置条件。

## 1. 包页面此前是个死胡同（#790）

实测口径：

| 面 | 近 30 天 |
|---|---|
| PyPI `clawock` 下载 | 896（近 7 天 615）|
| npm `clawock-dsh` 下载 | 1,126 |
| GitHub 仓库 unique visitor | 110（14 天）|
| star | 10 |

**最大的落地页不是仓库首页，是包页面。** 而 npm 那一页：

```
$ curl -s https://registry.npmjs.org/clawock-dsh/latest | jq '{repository,homepage,bugs,author}'
{"repository": null, "homepage": null, "bugs": null, "author": null}
```

四个字段全空 ⇒ npm 页面右栏的 Repository / Homepage / Issues 三个链接一个都没有；README 209 行全中文，没有 live dashboard、没有 evidence、没有截图。1,126 次下载落在一个**没有任何出口**的页面上。对照 14 天 referrer：`github.com` 253、`Google` 4、`chatgpt.com` 2、`zhihu.com` 1 —— **npmjs.com 和 pypi.org 一次都没出现过**。

PyPI 那半反而是满配（英文 README 完整渲染、project_urls 六条、classifiers 齐全），所以这不是「还没做」，是 npm 这半掉了。

修：

- `package.json` 补 `repository`（含 `directory`，monorepo 子包需要）/ `homepage` / `bugs` / `author`
- README 顶部加英文 lead：主张 + live dashboard + evidence + 源码三个链接 + Decision Mind 截图 + 一行安装命令，`---` 之下中文正文**原样保留**
- 图片用 `raw.githubusercontent.com` 绝对路径 —— npm 页面不是从仓库服务的，相对路径就是死图

## 2. npm 发布补 provenance（#785）

发布链两半的凭证等级此前不对等：

| | PyPI | npm（修改前）|
|---|---|---|
| 凭证 | trusted publishing（OIDC）| 长期 `NPM_TOKEN` |
| job 权限 | `id-token: write` | 无 |
| 包页面可验证声明 | attestation | 无 |

修：npm job 加 `permissions: id-token: write`，`publish_dsh_plugin.sh` 加 `--provenance`。

**flag 是条件式的，不是无条件加上去**：脚本头部明确写了「a human can call it directly for a standalone bump」，而 npm 在非 CI 环境被要求 provenance 时是硬失败。所以只在 `GITHUB_ACTIONS=true` **且** `ACTIONS_ID_TOKEN_REQUEST_URL` 真的存在时才带上，否则打印一行降级说明照常发布。

## 3. 两条闸，防止这一页再次悄悄掉出口

`tests/dsh_plugin_package_contract.mjs`（`examples/dsh/**` 变更时在 CI 跑）新增：四个元数据字段、三个链接必须在 README 里、`---` 之上必须无中文、所有 README 图片必须是绝对 raw URL。

`tests/test_github_release_contract.py` 新增：npm job 必须有 `id-token: write`，脚本必须求 provenance 且必须是条件式的。

## 验证

```
$ node --test tests/dsh_plugin_package_contract.mjs      # pass 6, fail 0
$ pytest tests/test_github_release_contract.py           # 13 passed
$ bash -n ops/publish/publish_dsh_plugin.sh              # ok
$ /tmp/actionlint                                        # exit 0
```

反向验证过这条闸不是摆设 —— 临时删掉 `package.json` 的 `repository` 字段：

```
# pass 5
# fail 1        ← 变红
```

恢复后重新 6/0。

## 上线后需要人工确认的

provenance 只有在**下一次真正发版**时才会体现。发完后核：`https://www.npmjs.com/package/clawock-dsh` 出现 Provenance 区块、`npm view clawock-dsh dist.attestations` 非空、右栏三个链接可点。
