### PR TITLE
codeql: 用带路径过滤的 advanced setup 替掉 default setup（省 ~55 分钟/天空转）

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,84 @@
+name: CodeQL
+
+# Advanced setup, replacing GitHub's default setup (#782).
+#
+# Default setup cannot be path-filtered, and this repository pushes to master
+# ~35 times a day of which ~85% are pure data commits written by automation
+# (assets/data/**, memory/**). Measured over three days: 98 CodeQL runs, ~33 a
+# day at 92–105 seconds each — about 55 minutes of runner time daily spent
+# re-analysing a byte-identical code tree, plus an Actions list where the real
+# CI results were buried under "Push on master" rows.
+#
+# What is deliberately NOT filtered: the `pull_request` trigger. `Analyze
+# (actions)`, `Analyze (javascript-typescript)`, `Analyze (python)` and `CodeQL`
+# are required status checks, and a required check that is filtered out never
+# reports and blocks the PR forever — the same trap actionlint.yml documents.
+# So every PR is analysed in full; only the master-push lane, which is not a
+# required check and is where all of the measured waste lives, is filtered.
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      # Everything automation rewrites all day. None of it is analysable code.
+      - 'assets/data/**'
+      - 'memory/**'
+      - 'logs/**'
+      - 'site/assets/data/**'
+      - 'portfolio.json'
+      - 'monitor_state.json'
+      - 'openclaw-workspace-state.json'
+  pull_request:
+  # The backstop for a paths-ignore that is written too widely: a weekly full
+  # analysis of master runs whatever the push lane skipped. Saturday 03:41 UTC —
+  # an uncontended slot, because measured schedule drift in this repository runs
+  # 10–160 minutes and is driven by how busy the UTC hour is (#781).
+  schedule:
+    - cron: '41 3 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    # The explicit `name` is what keeps the check-run contexts byte-identical to
+    # the ones default setup produced, which is what the branch ruleset requires.
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Same language set default setup was configured with, minus the two
+          # aliases: `javascript` and `typescript` are both analysed by the
+          # `javascript-typescript` extractor, and listing them separately just
+          # produced duplicate work.
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Left on the default query suite on purpose: default setup ran
+          # `query_suite: default`, and this change is about the trigger surface,
+          # not about widening coverage. Widening the suite is a separate
+          # decision with its own alert backlog.
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #782

## 为什么

CodeQL 走的是 **default setup**，而 default setup **不支持路径过滤**。这个仓库每天往 master 推 32–39 次，最近 60 个 commit 里 **51 个（85%）只动了 `assets/data/` 和 `memory/`**：

```
$ gh api 'repos/KCNyu/clawock/actions/runs?event=dynamic' --jq '[.workflow_runs[]|select(.created_at>"2026-08-19")]|length'
98                                    # 3 天，≈ 33 次/天

$ gh api 'repos/KCNyu/clawock/actions/runs?event=dynamic&per_page=5' \
    --jq '.workflow_runs[] | "\(.head_sha[0:8]) \(.head_commit.message|split("\n")[0])"'
d0b7d459 dashboard: intraday refresh (us 01:02 HKT)
318569ef dashboard: intraday refresh (us 00:02 HKT)
2fbd3b6a gold: 黄金定投净值刷新 2026-08-21
08a0a632 dashboard: intraday refresh (us 23:31 HKT)
91862d4c dashboard: intraday refresh (us 23:04 HKT)
```

每次 92–105 秒 ⇒ **约 55 分钟/天**在重扫一棵逐字节没变的代码树。附带成本是 Actions 列表被 33 条/天的 `Push on master` 淹没，真 CI 结果要翻页。

## 关键设计：`pull_request` 刻意不过滤

`Analyze (actions)` / `Analyze (javascript-typescript)` / `Analyze (python)` / `CodeQL` 四个都是 ruleset 里的 **required status check**：

```
$ gh api repos/KCNyu/clawock/rulesets/19140068 \
    --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'
validate
lint
Analyze (actions)
Analyze (javascript-typescript)
Analyze (python)
CodeQL
```

**被路径过滤掉的 required check 永远不上报，PR 就永远合不了** —— `actionlint.yml` 里已经写下过这个坑。所以 PR 一侧全量分析，只过滤 master-push 那条 lane：实测的浪费 100% 在那条 lane 上，而它不是 required check。

`name: Analyze (${{ matrix.language }})` 是显式写的，目的就是让 check-run 的 context 名与 default setup 产出的**逐字节一致**，ruleset 不用动。

## 其余是等价迁移

| | default setup | 本 PR |
|---|---|---|
| languages | `actions, javascript, javascript-typescript, python, typescript` | `actions, javascript-typescript, python` |
| query suite | `default` | `default`（**刻意不升 security-extended**）|
| cadence | weekly | weekly（`41 3 * * 6`）|

语言那栏少两个是因为 `javascript` 和 `typescript` 都由 `javascript-typescript` 这个 extractor 分析，default setup 同时列三个只是在做重复功。

query suite **没有**顺手升到 `security-extended`：这个 PR 改的是触发面，不是覆盖面；扩查询套件会带出一批新告警，是另一个决策。

`schedule` 那档从「default setup 的周扫」变成**paths-ignore 写太宽时的兜底** —— 万一某条真代码路径被误挡在 push lane 外，一周内必被全量扫到。

## 切换步骤（已执行）

default setup 和 advanced setup **不能共存**，共存时 advanced 的 SARIF 会被拒绝。所以顺序是先关 default 再让 advanced 跑：

```
$ gh api -X PATCH repos/KCNyu/clawock/code-scanning/default-setup -f state=not-configured
$ gh api repos/KCNyu/clawock/code-scanning/default-setup --jq .state
not-configured
```

本 PR 自己的四个 CodeQL check 就是新 workflow 产出的 —— **它们绿了，就同时证明了 context 名对得上、SARIF 能上传、required check 不会悬空**。

## 验证

- `/tmp/actionlint`（pinned 1.7.12）exit 0
- 本 PR 的 `Analyze (actions)` / `Analyze (javascript-typescript)` / `Analyze (python)` / `CodeQL` 四个 required check 必须由这个 workflow 报绿（见下方 checks）
- 合并后：推一次纯数据 commit，Actions 里**不应**出现新的 CodeQL run
