### PR TITLE
growth: 在 14 天窗口把数据丢掉之前，开始采集仓库 traffic

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -1,0 +1,72 @@
+name: Repo Traffic Capture
+
+# GitHub's Traffic API keeps 14 days. Nothing captured it until #789, so every
+# week that passed permanently erased the only first-party measurement of who
+# reaches this project and from where. This is the one kind of data loss that
+# cannot be repaired later by trying harder.
+#
+# On GitHub rather than the VPS, per the standing rule for new automation (and
+# kcn, 2026-08-22: nothing new on the box). Also the right host on the merits —
+# the token that can read traffic is already here.
+#
+# Twice a week, not weekly. The window is 14 days so weekly would suffice in
+# theory, but one missed run then silently costs 7 days that no retry can
+# recover. Two runs, four days apart, make a single failure harmless. Minutes
+# chosen off the hour and off the contended UTC hours; measured schedule drift
+# in this repository is 10-160 minutes and is driven by how busy the hour is
+# (#781), which for a rolling-window capture is irrelevant anyway.
+on:
+  schedule:
+    - cron: '38 3 * * 2'
+    - cron: '38 3 * * 6'
+  workflow_dispatch:
+
+# Shares the repository's single writer lane: this commits to master like every
+# other data producer, and must queue behind them rather than race.
+concurrency:
+  group: data-write
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Capture traffic and package downloads
+        env:
+          # The Traffic API requires push access; the workflow token has it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 ops/growth/repo_traffic.py | tee /tmp/traffic.txt
+          {
+            echo '### Repository traffic'
+            echo '```'
+            cat /tmp/traffic.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit the merged history
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/data/repo-traffic.json
+          if git diff --cached --quiet; then
+            echo "no new traffic days — nothing to commit"
+            exit 0
+          fi
+          git commit -m "growth: repo traffic capture $(date -u +%Y-%m-%d)"
+          # Automation commits to master all day; rebase onto whatever landed
+          # while this job ran rather than failing on a stale ref.
+          git pull --rebase --autostash origin master
+          git push origin HEAD:master

--- a/assets/data/repo-traffic.json
+++ b/assets/data/repo-traffic.json
@@ -1,0 +1,260 @@
+{
+  "generated_at": "2026-08-21T17:26:26Z",
+  "repo": "KCNyu/clawock",
+  "note": "views/clones are per-day series merged across runs. referrers/paths are 14-day aggregates captured as dated snapshots and must not be summed or differenced as daily values.",
+  "views": [
+    {
+      "timestamp": "2026-08-07T00:00:00Z",
+      "count": 1,
+      "uniques": 1
+    },
+    {
+      "timestamp": "2026-08-08T00:00:00Z",
+      "count": 215,
+      "uniques": 4
+    },
+    {
+      "timestamp": "2026-08-09T00:00:00Z",
+      "count": 82,
+      "uniques": 7
+    },
+    {
+      "timestamp": "2026-08-10T00:00:00Z",
+      "count": 71,
+      "uniques": 50
+    },
+    {
+      "timestamp": "2026-08-11T00:00:00Z",
+      "count": 14,
+      "uniques": 10
+    },
+    {
+      "timestamp": "2026-08-12T00:00:00Z",
+      "count": 1,
+      "uniques": 1
+    },
+    {
+      "timestamp": "2026-08-13T00:00:00Z",
+      "count": 5,
+      "uniques": 5
+    },
+    {
+      "timestamp": "2026-08-14T00:00:00Z",
+      "count": 1,
+      "uniques": 1
+    },
+    {
+      "timestamp": "2026-08-15T00:00:00Z",
+      "count": 9,
+      "uniques": 7
+    },
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "count": 30,
+      "uniques": 13
+    },
+    {
+      "timestamp": "2026-08-17T00:00:00Z",
+      "count": 35,
+      "uniques": 10
+    },
+    {
+      "timestamp": "2026-08-18T00:00:00Z",
+      "count": 9,
+      "uniques": 4
+    },
+    {
+      "timestamp": "2026-08-19T00:00:00Z",
+      "count": 22,
+      "uniques": 9
+    },
+    {
+      "timestamp": "2026-08-20T00:00:00Z",
+      "count": 19,
+      "uniques": 10
+    }
+  ],
+  "clones": [
+    {
+      "timestamp": "2026-08-07T00:00:00Z",
+      "count": 410,
+      "uniques": 89
+    },
+    {
+      "timestamp": "2026-08-08T00:00:00Z",
+      "count": 1059,
+      "uniques": 165
+    },
+    {
+      "timestamp": "2026-08-09T00:00:00Z",
+      "count": 918,
+      "uniques": 130
+    },
+    {
+      "timestamp": "2026-08-10T00:00:00Z",
+      "count": 1042,
+      "uniques": 173
+    },
+    {
+      "timestamp": "2026-08-11T00:00:00Z",
+      "count": 870,
+      "uniques": 154
+    },
+    {
+      "timestamp": "2026-08-12T00:00:00Z",
+      "count": 719,
+      "uniques": 131
+    },
+    {
+      "timestamp": "2026-08-13T00:00:00Z",
+      "count": 1187,
+      "uniques": 196
+    },
+    {
+      "timestamp": "2026-08-14T00:00:00Z",
+      "count": 500,
+      "uniques": 79
+    },
+    {
+      "timestamp": "2026-08-15T00:00:00Z",
+      "count": 1022,
+      "uniques": 96
+    },
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "count": 1759,
+      "uniques": 89
+    },
+    {
+      "timestamp": "2026-08-17T00:00:00Z",
+      "count": 965,
+      "uniques": 127
+    },
+    {
+      "timestamp": "2026-08-18T00:00:00Z",
+      "count": 2266,
+      "uniques": 94
+    },
+    {
+      "timestamp": "2026-08-19T00:00:00Z",
+      "count": 1668,
+      "uniques": 83
+    },
+    {
+      "timestamp": "2026-08-20T00:00:00Z",
+      "count": 482,
+      "uniques": 68
+    }
+  ],
+  "referrers_snapshots": [
+    {
+      "captured_at": "2026-08-21T17:26:26Z",
+      "window_days": 14,
+      "rows": [
+        {
+          "referrer": "github.com",
+          "count": 253,
+          "uniques": 18
+        },
+        {
+          "referrer": "Google",
+          "count": 4,
+          "uniques": 4
+        },
+        {
+          "referrer": "chatgpt.com",
+          "count": 2,
+          "uniques": 1
+        },
+        {
+          "referrer": "zhihu.com",
+          "count": 1,
+          "uniques": 1
+        }
+      ]
+    }
+  ],
+  "paths_snapshots": [
+    {
+      "captured_at": "2026-08-21T17:26:26Z",
+      "window_days": 14,
+      "rows": [
+        {
+          "path": "/KCNyu/clawock",
+          "title": "Overview",
+          "count": 165,
+          "uniques": 41
+        },
+        {
+          "path": "/KCNyu/clawock/pulls",
+          "title": "/pulls",
+          "count": 38,
+          "uniques": 4
+        },
+        {
+          "path": "/KCNyu/clawock/issues",
+          "title": "/issues",
+          "count": 27,
+          "uniques": 6
+        },
+        {
+          "path": "/KCNyu/clawock/blob/master/README.zh.md",
+          "title": "/blob/master/README.zh.md",
+          "count": 13,
+          "uniques": 8
+        },
+        {
+          "path": "/KCNyu/clawock/tree/master",
+          "title": "/tree/master",
+          "count": 6,
+          "uniques": 1
+        },
+        {
+          "path": "/KCNyu/clawock/tree/master/instances/kcnyu",
+          "title": "/tree/master/instances/kcnyu",
+          "count": 6,
+          "uniques": 1
+        },
+        {
+          "path": "/KCNyu/clawock/blob/master/examples/README.md",
+          "title": "/blob/master/examples/README.md",
+          "count": 5,
+          "uniques": 5
+        },
+        {
+          "path": "/KCNyu/clawock/blob/master/skills/hk-stock-analysis/SKILL.md",
+          "title": "/blob/master/skills/hk-stock-analysis/SKILL.md",
+          "count": 5,
+          "uniques": 5
+        },
+        {
+          "path": "/KCNyu/clawock/commits/master",
+          "title": "/commits/master",
+          "count": 5,
+          "uniques": 1
+        },
+        {
+          "path": "/KCNyu/clawock/issues/380",
+          "title": "/issues/380",
+          "count": 5,
+          "uniques": 1
+        }
+      ]
+    }
+  ],
+  "package_downloads": [
+    {
+      "captured_at": "2026-08-21T17:26:26Z",
+      "pypi": {
+        "last_day": 3,
+        "last_month": 896,
+        "last_week": 615
+      },
+      "npm": {
+        "downloads": 1126,
+        "start": "2026-07-21",
+        "end": "2026-08-19"
+      }
+    }
+  ]
+}

--- a/ops/growth/repo_traffic.py
+++ b/ops/growth/repo_traffic.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Capture GitHub repository traffic before the 14-day window drops it.
+
+GitHub's Traffic API is the only first-party measurement of who reaches this
+project and from where, and it keeps **14 days**. Nothing captured it until
+#789, so every week that passed erased a week of the only distribution data
+that exists.
+
+The snapshot that motivated this, taken 2026-08-22, already had three things in
+it that cannot be answered without history:
+
+    views   514 / 110 unique          clones 14,867 / 1,147 unique
+    referrers: github.com 253 · Google 4 · chatgpt.com 2 · zhihu.com 1
+    paths:  / 165/41u · /pulls 38/4u · /issues 27/6u · README.zh.md 13/8u
+
+  - clone uniques are 10x view uniques, and this repository's own CI accounts
+    for maybe 200 of the ~1,060 daily clones. Nobody knows what the rest is.
+  - Google sent 4 unique visitors in 14 days, which is the crawl-budget
+    constraint finally expressed as a number rather than an inference.
+  - README.zh.md outdraws every English entry point.
+
+Precision boundary, and it is not cosmetic: `views` and `clones` come back as
+**per-day series**, so they can be merged into a real timeline. `referrers` and
+`popular/paths` come back only as a **single aggregate over the trailing 14
+days** — there is no per-day breakdown to recover. Those are stored as dated
+snapshots and must never be summed or differenced as if they were daily.
+
+Package downloads ride along because they are the same kind of perishable
+rolling window, and because the package pages turn out to be the highest-traffic
+surface this project has (#790).
+
+Usage:
+    repo_traffic.py                      # merge into assets/data/repo-traffic.json
+    repo_traffic.py --print              # show what would be written, write nothing
+    repo_traffic.py --out other.json
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = os.environ.get("CLAWOCK_TRAFFIC_REPO", "KCNyu/clawock")
+DEFAULT_OUT = Path(__file__).resolve().parents[2] / "assets" / "data" / "repo-traffic.json"
+
+PYPI_PACKAGE = "clawock"
+NPM_PACKAGE = "clawock-dsh"
+
+
+class TrafficError(RuntimeError):
+    """A source could not be read. Never silently becomes an empty reading."""
+
+
+def _get_json(url: str, token: str | None = None, timeout: int = 20) -> Any:
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        # GitHub rejects requests without one, and a mailbox that cannot receive
+        # mail is what got the SEC leg 403'd for three days.
+        "User-Agent": "clawock-repo-traffic (+https://github.com/KCNyu/clawock)",
+    })
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise TrafficError(f"{url} -> HTTP {exc.code} {exc.reason}") from exc
+    except Exception as exc:  # noqa: BLE001 - the caller decides what a failure means
+        raise TrafficError(f"{url} -> {exc}") from exc
+
+
+def fetch_github(token: str) -> dict[str, Any]:
+    base = f"https://api.github.com/repos/{REPO}/traffic"
+    views = _get_json(f"{base}/views?per=day", token)
+    clones = _get_json(f"{base}/clones?per=day", token)
+    referrers = _get_json(f"{base}/popular/referrers", token)
+    paths = _get_json(f"{base}/popular/paths", token)
+    return {"views": views, "clones": clones, "referrers": referrers, "paths": paths}
+
+
+def fetch_packages() -> dict[str, Any]:
+    """Downloads are advisory: a registry being down must not lose a traffic run.
+
+    The GitHub half is the part that cannot be re-fetched later. PyPI and npm
+    both expose longer history through their own APIs, so a miss here is
+    recoverable and should not fail the job.
+    """
+    out: dict[str, Any] = {}
+    try:
+        out["pypi"] = _get_json(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent")["data"]
+    except (TrafficError, KeyError, TypeError) as exc:
+        out["pypi_error"] = str(exc)
+    try:
+        npm = _get_json(f"https://api.npmjs.org/downloads/point/last-month/{NPM_PACKAGE}")
+        out["npm"] = {"downloads": npm["downloads"], "start": npm["start"], "end": npm["end"]}
+    except (TrafficError, KeyError, TypeError) as exc:
+        out["npm_error"] = str(exc)
+    return out
+
+
+def _merge_series(existing: list[dict], incoming: list[dict]) -> tuple[list[dict], int, int]:
+    """Upsert a per-day series keyed on timestamp.
+
+    The 14-day window and a weekly cadence overlap by 7 days on purpose: the
+    overlap is a free consistency check. A day whose numbers changed is reported
+    rather than silently overwritten — GitHub does revise a day while it is
+    still in progress, but a revision to a settled day means the merge key or
+    the source is wrong.
+    """
+    by_day = {row["timestamp"]: row for row in existing}
+    added = revised = 0
+    for row in incoming:
+        key = row["timestamp"]
+        prior = by_day.get(key)
+        if prior is None:
+            added += 1
+        elif prior != row:
+            revised += 1
+        by_day[key] = row
+    return [by_day[k] for k in sorted(by_day)], added, revised
+
+
+def find_gap(existing: list[dict], incoming: list[dict]) -> tuple[str, str] | None:
+    """Days that fell between the stored history and the incoming window.
+
+    This is the failure mode that cannot be repaired: if the newest stored day
+    is older than the oldest day the API is still willing to return, the days
+    in between aged out of the 14-day window while nobody was capturing, and no
+    retry brings them back. It has to be said out loud at the moment it is
+    detectable, because a month later the series just looks shorter.
+    """
+    if not existing or not incoming:
+        return None
+    newest_stored = max(row["timestamp"] for row in existing)
+    oldest_incoming = min(row["timestamp"] for row in incoming)
+    stored_day = dt.date.fromisoformat(newest_stored[:10])
+    incoming_day = dt.date.fromisoformat(oldest_incoming[:10])
+    if (incoming_day - stored_day).days > 1:
+        return newest_stored[:10], oldest_incoming[:10]
+    return None
+
+
+def merge(previous: dict[str, Any], github: dict[str, Any], packages: dict[str, Any],
+          now: dt.datetime) -> tuple[dict[str, Any], dict[str, int]]:
+    stamp = now.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    merged: dict[str, Any] = {
+        "generated_at": stamp,
+        "repo": REPO,
+        "note": (
+            "views/clones are per-day series merged across runs. referrers/paths "
+            "are 14-day aggregates captured as dated snapshots and must not be "
+            "summed or differenced as daily values."
+        ),
+    }
+    views, v_add, v_rev = _merge_series(previous.get("views", []), github["views"]["views"])
+    clones, c_add, c_rev = _merge_series(previous.get("clones", []), github["clones"]["clones"])
+    merged["views"] = views
+    merged["clones"] = clones
+
+    for name, payload in (("referrers", github["referrers"]), ("paths", github["paths"])):
+        history = list(previous.get(f"{name}_snapshots", []))
+        history = [s for s in history if s.get("captured_at") != stamp]
+        history.append({"captured_at": stamp, "window_days": 14, "rows": payload})
+        merged[f"{name}_snapshots"] = sorted(history, key=lambda s: s["captured_at"])
+
+    pkg_history = [s for s in previous.get("package_downloads", [])
+                   if s.get("captured_at") != stamp]
+    pkg_history.append({"captured_at": stamp, **packages})
+    merged["package_downloads"] = sorted(pkg_history, key=lambda s: s["captured_at"])
+
+    return merged, {
+        "views_added": v_add, "views_revised": v_rev,
+        "clones_added": c_add, "clones_revised": c_rev,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--print", dest="dry_run", action="store_true",
+                    help="report what would be written and exit without writing")
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        # Loud, not empty. A traffic capture that cannot see is not a capture of
+        # zero traffic, and the data it missed cannot be fetched again later.
+        print("::error::GITHUB_TOKEN/GH_TOKEN is unset — traffic cannot be read, "
+              "and this window is unrecoverable once it ages out", file=sys.stderr)
+        return 2
+
+    try:
+        github = fetch_github(token)
+    except TrafficError as exc:
+        print(f"::error::GitHub traffic read failed: {exc}", file=sys.stderr)
+        return 2
+
+    packages = fetch_packages()
+
+    previous: dict[str, Any] = {}
+    if args.out.exists():
+        previous = json.loads(args.out.read_text(encoding="utf-8"))
+
+    gap = find_gap(previous.get("views", []), github["views"]["views"])
+    merged, stats = merge(previous, github, packages, dt.datetime.now(dt.timezone.utc))
+
+    if gap:
+        # A warning, not an error: the run still has to store the window it can
+        # still see. Failing here would turn one lost gap into two.
+        print(f"::warning::traffic history has an unrecoverable gap between {gap[0]} "
+              f"and {gap[1]} — those days aged out of the 14-day window uncaptured")
+
+    v14 = github["views"]
+    c14 = github["clones"]
+    print(f"views  14d: {v14['count']} / {v14['uniques']} unique")
+    print(f"clones 14d: {c14['count']} / {c14['uniques']} unique")
+    print("referrers: " + ", ".join(
+        f"{r['referrer']} {r['count']}/{r['uniques']}u" for r in github["referrers"][:6]) or "(none)")
+    print(f"series: +{stats['views_added']} view days, +{stats['clones_added']} clone days, "
+          f"{stats['views_revised'] + stats['clones_revised']} revised")
+    print(f"history now spans {len(merged['views'])} view days / {len(merged['clones'])} clone days")
+    for key in ("pypi", "npm"):
+        if key in packages:
+            print(f"{key}: {packages[key]}")
+        elif f"{key}_error" in packages:
+            print(f"{key}: unavailable ({packages[f'{key}_error']})")
+
+    if args.dry_run:
+        return 0
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(merged, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repo_traffic_capture.py
+++ b/tests/test_repo_traffic_capture.py
@@ -1,0 +1,159 @@
+"""Repo traffic capture: the merge has to be lossless, and the precision
+boundary between series and snapshots has to survive.
+
+GitHub's Traffic API keeps 14 days. A capture that quietly drops or double
+counts a day is worse than no capture, because the mistake is undetectable
+after the window closes.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops" / "growth" / "repo_traffic.py"
+
+spec = importlib.util.spec_from_file_location("repo_traffic", SCRIPT)
+repo_traffic = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(repo_traffic)
+
+
+def _day(ts: str, count: int, uniques: int) -> dict:
+    return {"timestamp": ts, "count": count, "uniques": uniques}
+
+
+def _github(views: list[dict], clones: list[dict], referrers=None, paths=None) -> dict:
+    return {
+        "views": {"count": sum(d["count"] for d in views),
+                  "uniques": 1, "views": views},
+        "clones": {"count": sum(d["count"] for d in clones),
+                   "uniques": 1, "clones": clones},
+        "referrers": referrers if referrers is not None else [],
+        "paths": paths if paths is not None else [],
+    }
+
+
+NOW = dt.datetime(2026, 8, 22, 3, 38, tzinfo=dt.timezone.utc)
+LATER = dt.datetime(2026, 8, 26, 3, 38, tzinfo=dt.timezone.utc)
+
+
+def test_overlapping_windows_upsert_instead_of_appending():
+    """Weekly capture over a 14-day window overlaps by 7 days every time.
+
+    The overlap is deliberate — it is a free consistency check — but only if
+    the merge is keyed on the day. Appending would double every overlapping day
+    and make the whole series a fiction within one month.
+    """
+    first, _ = repo_traffic.merge(
+        {}, _github([_day("2026-08-20T00:00:00Z", 10, 3), _day("2026-08-21T00:00:00Z", 20, 5)],
+                    [_day("2026-08-20T00:00:00Z", 1, 1)]), {}, NOW)
+    second, stats = repo_traffic.merge(
+        first, _github([_day("2026-08-21T00:00:00Z", 20, 5), _day("2026-08-22T00:00:00Z", 30, 7)],
+                       [_day("2026-08-22T00:00:00Z", 2, 2)]), {}, LATER)
+
+    assert [d["timestamp"] for d in second["views"]] == [
+        "2026-08-20T00:00:00Z", "2026-08-21T00:00:00Z", "2026-08-22T00:00:00Z"]
+    assert [d["count"] for d in second["views"]] == [10, 20, 30]
+    assert stats["views_added"] == 1
+    assert stats["views_revised"] == 0
+
+
+def test_a_day_whose_numbers_changed_is_reported_not_hidden():
+    """A settled day that comes back different means the key or the source is
+    wrong. The value is still taken — GitHub does revise a day in progress —
+    but the run has to say so."""
+    first, _ = repo_traffic.merge({}, _github([_day("2026-08-21T00:00:00Z", 20, 5)], []), {}, NOW)
+    second, stats = repo_traffic.merge(
+        first, _github([_day("2026-08-21T00:00:00Z", 99, 9)], []), {}, LATER)
+
+    assert stats["views_revised"] == 1
+    assert second["views"][0]["count"] == 99
+
+
+def test_referrers_and_paths_are_dated_snapshots_never_a_series():
+    """The API returns these only as a single 14-day aggregate. Storing them as
+    if they were daily would invite exactly the arithmetic that cannot be done
+    on them — summing or differencing two overlapping windows."""
+    first, _ = repo_traffic.merge(
+        {}, _github([], [], referrers=[{"referrer": "Google", "count": 4, "uniques": 4}]), {}, NOW)
+    second, _ = repo_traffic.merge(
+        first, _github([], [], referrers=[{"referrer": "Google", "count": 6, "uniques": 5}]), {}, LATER)
+
+    snaps = second["referrers_snapshots"]
+    assert [s["captured_at"] for s in snaps] == [
+        "2026-08-22T03:38:00Z", "2026-08-26T03:38:00Z"]
+    assert all(s["window_days"] == 14 for s in snaps)
+    assert snaps[0]["rows"][0]["count"] == 4
+    assert snaps[1]["rows"][0]["count"] == 6
+    assert "referrers" not in second, "aggregates must not masquerade as a merged series"
+
+
+def test_a_rerun_in_the_same_minute_replaces_its_snapshot_rather_than_duplicating():
+    first, _ = repo_traffic.merge({}, _github([], [], referrers=[{"referrer": "a", "count": 1, "uniques": 1}]), {}, NOW)
+    second, _ = repo_traffic.merge(first, _github([], [], referrers=[{"referrer": "a", "count": 2, "uniques": 1}]), {}, NOW)
+    assert len(second["referrers_snapshots"]) == 1
+    assert second["referrers_snapshots"][0]["rows"][0]["count"] == 2
+
+
+def test_the_stored_note_states_the_precision_boundary():
+    merged, _ = repo_traffic.merge({}, _github([], []), {}, NOW)
+    assert "must not be" in merged["note"]
+    assert "14-day" in merged["note"]
+
+
+def test_package_downloads_are_advisory_and_never_lose_the_github_half():
+    """PyPI and npm both expose longer history through their own APIs, so a
+    registry outage is recoverable. The GitHub window is not — a failure there
+    must not be papered over by a partial write."""
+    merged, _ = repo_traffic.merge(
+        {}, _github([_day("2026-08-21T00:00:00Z", 20, 5)], []),
+        {"npm_error": "HTTP 503", "pypi": {"last_month": 896}}, NOW)
+    assert merged["views"][0]["count"] == 20
+    assert merged["package_downloads"][0]["npm_error"] == "HTTP 503"
+    assert merged["package_downloads"][0]["pypi"]["last_month"] == 896
+
+
+def test_a_missing_token_is_an_error_not_an_empty_reading(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert repo_traffic.main([]) == 2
+    assert "unrecoverable" in capsys.readouterr().err
+
+
+def test_the_workflow_captures_often_enough_to_survive_one_miss():
+    """The window is 14 days, so weekly would work on paper — until one run
+    fails and takes 7 unrecoverable days with it."""
+    workflow = (ROOT / ".github" / "workflows" / "repo-traffic.yml").read_text(encoding="utf-8")
+    crons = [line for line in workflow.splitlines() if "- cron:" in line]
+    assert len(crons) >= 2, "one scheduled capture a week cannot absorb a single failure"
+    assert "group: data-write" in workflow, "it commits to master; it must share the writer lane"
+
+
+@pytest.mark.parametrize("field", ["views", "clones", "referrers_snapshots",
+                                   "paths_snapshots", "package_downloads"])
+def test_the_committed_file_carries_every_section(field):
+    path = ROOT / "assets" / "data" / "repo-traffic.json"
+    if not path.exists():
+        pytest.skip("no capture committed yet")
+    assert field in json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_a_capture_gap_is_named_at_the_moment_it_is_still_detectable():
+    """Days that aged out of the window while nobody was capturing are gone for
+    good. A month later the series just looks shorter, so the only chance to
+    say so is the run that first sees the discontinuity."""
+    stored = [_day("2026-08-01T00:00:00Z", 5, 2)]
+    incoming = [_day("2026-08-20T00:00:00Z", 7, 3)]
+    assert repo_traffic.find_gap(stored, incoming) == ("2026-08-01", "2026-08-20")
+
+
+def test_a_contiguous_or_overlapping_window_is_not_a_gap():
+    stored = [_day("2026-08-20T00:00:00Z", 5, 2)]
+    assert repo_traffic.find_gap(stored, [_day("2026-08-20T00:00:00Z", 5, 2)]) is None
+    assert repo_traffic.find_gap(stored, [_day("2026-08-21T00:00:00Z", 6, 2)]) is None
+    assert repo_traffic.find_gap([], [_day("2026-08-21T00:00:00Z", 6, 2)]) is None


### PR DESCRIPTION
Closes #789

## 为什么现在做

GitHub Traffic API 是这个项目**唯一**的第一方分发口径，它只保留 **14 天**。此前从未采集过 —— 每过一周就永久抹掉一周数据，这是唯一一类事后再努力也补不回来的损失。

本 PR 里 `assets/data/repo-traffic.json` 是**今天真跑出来的第一份**，不是占位：

```
views  14d: 514 / 110 unique
clones 14d: 14867 / 1147 unique
referrers: github.com 253/18u, Google 4/4u, chatgpt.com 2/1u, zhihu.com 1/1u
pypi: {'last_day': 3, 'last_month': 896, 'last_week': 615}
npm:  {'downloads': 1126, 'start': '2026-07-21', 'end': '2026-08-19'}
```

这一份里已经有三件没有历史就答不了的事：

1. **clone unique 是 view unique 的 10 倍**（1,147 vs 110）。本仓库自己的 CI 大概只能解释 ~1,060 次/天里的 200 次，剩下的没人知道是谁。
2. **Google 14 天带来 4 个独立访客** —— 「瓶颈是抓取预算」第一次从推断变成数字。
3. **`README.zh.md` 的独立访客（8）多过任何一个英文入口**（`examples/README.md` 5、SKILL.md 5）。

## 跑在 GitHub 上，不碰 VPS

kcn 2026-08-22:「不要主机触发，VPS 负载够高了」。这条也符合 `seo-visibility.yml` 里已经写下的规矩 —— 新自动化默认放 GitHub。而且从道理上也该在这边：能读 traffic 的 token 本来就在这。

**一周两次而不是一次**（周二 + 周六 03:38 UTC）。窗口 14 天，理论上周频够用 —— 直到某一次跑挂，就静默带走 7 天不可恢复的数据。两档四天错开，单次失败无害。

## 两条精度边界是用断言钉住的，不是写在注释里

| 数据 | API 返回形态 | 存法 |
|---|---|---|
| `views` / `clones` | **按天序列** | 按 `timestamp` upsert 成真实时间轴 |
| `referrers` / `popular/paths` | **只有 14 天聚合，没有按天分解** | 存成带日期的快照序列 |

- upsert 而不是 append：14 天窗口 + 周频采集必然重叠 7 天，重叠是**免费的一致性校验**；append 的话一个月内整条序列就是假的。
- 聚合值绝不混进序列：`assert "referrers" not in second` —— 防止后来的人把两个重叠窗口相减当成日频增量。
- **已结算的某天数值变了要报出来**（`views_revised`），不是静默覆盖。GitHub 确实会修正「进行中」的当天，但一个已结算的天变了意味着 merge key 或数据源错了。
- **窗口断层在第一次能看见它的那次运行里点名**：库存最新日与来数最老日之间隔了 >1 天，说明中间那些天在没人采集的时候滑出了 14 天窗口，永远回不来了。一个月后这条序列只是「看起来短了点」，所以唯一的机会就是当场说。这条取 `::warning::` 不取失败 —— 失败会让一个断层变成两个。

包下载（PyPI / npm）顺路采，因为它们是同一类会过期的滚动窗口，而且实测**包页面才是流量最大的落地页**（见 #790）。这一路是 advisory 的：registry 挂了不能让 GitHub 那半丢掉，两家都有更长的自有历史可以补。

## 验证

```
$ pytest tests/test_repo_traffic_capture.py            # 15 passed
$ GITHUB_TOKEN=… python3 ops/growth/repo_traffic.py    # 真实拉取，见上方输出
$ /tmp/actionlint                                      # exit 0
```

无 token 时是**响亮失败**（exit 2 + `::error::`）而不是写入一份空读数 —— 采集不到不等于流量为零，而这个窗口过期就没了。

已知的本地预存红（**与本 PR 无关**）：`tests/test_pages_deployment_contract.py` 的两条在本机 stash 掉全部改动后仍然红，是本地缺 data-plane 产物导致，CI 上是绿的。
