### PR TITLE
repo: 给「不是来报 bug 的读者」开一扇门（Discussions + release 公告）

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,19 @@
+# Issues stay for actionable, evidenced problems — the bug template is the only
+# form on purpose, and the discipline in it (symptom, evidence, acceptance) is
+# what makes the tracker worth reading. Everything that is a question, an idea
+# or a report of using this elsewhere now has somewhere to go that is not a
+# fake bug report (#786).
 blank_issues_enabled: true
 contact_links:
+  - name: Ask a question
+    url: https://github.com/KCNyu/clawock/discussions/categories/q-a
+    about: How to run this against a different broker, a different harness, or only half the workflow. Answers get marked, so the next person finds them.
+  - name: Propose an idea
+    url: https://github.com/KCNyu/clawock/discussions/categories/ideas
+    about: Anything that is not yet a defect with evidence behind it. If it turns into one, it becomes an issue from there.
+  - name: Show what you built
+    url: https://github.com/KCNyu/clawock/discussions/categories/show-and-tell
+    about: Your own instance, your own harness, your own scorecard — including the losses.
   - name: Report a security vulnerability
     url: https://github.com/KCNyu/clawock/security/advisories/new
     about: Private disclosure, read only by the maintainer. Never use a public issue for this.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+      # Opening the Announcements thread that carries the release notes (#786).
+      discussions: write
     steps:
       - uses: actions/checkout@v7
 
@@ -220,3 +222,20 @@ jobs:
             --verify-tag \
             --title "clawock $GITHUB_REF_NAME" \
             --notes-file /tmp/release-notes.md
+
+      - name: Announce the release in Discussions
+        # A release becomes something a reader can reply to, and a page search
+        # engines index, instead of a one-way artifact drop (#786).
+        #
+        # A separate best-effort step on purpose. Passing --discussion-category
+        # to `gh release create` would put the announcement on the critical path
+        # of publishing: a failure there leaves a tagged version whose GitHub
+        # Release was never created, and the retry then collides with the
+        # release that partially exists. The release is the deliverable; the
+        # thread is not.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "$GITHUB_REF_NAME" --discussion-category Announcements \
+            || echo "::warning::no Announcements thread for $GITHUB_REF_NAME — the release itself is unaffected"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,11 @@ seo = ["google-auth>=2.30"]
 # workflow line is a second source of truth that drifts unseen.
 release = ["build>=1.2", "twine>=5"]
 # Everything the test suite needs to *collect*, not just to pass.
-test = ["pytest>=8", "pytest-cov>=5", "numpy>=1.26", "Pillow>=10"]
+# PyYAML is here for the same reason as the rest: the public-entry-point test
+# parses .github/ISSUE_TEMPLATE/config.yml as structured data rather than
+# substring-matching it, and a test module that cannot import does not fail —
+# it stops the whole suite at collection while the run still looks like it ran.
+test = ["pytest>=8", "pytest-cov>=5", "numpy>=1.26", "Pillow>=10", "PyYAML>=6"]
 
 [project.urls]
 Homepage = "https://github.com/KCNyu/clawock"

--- a/tests/test_public_entry_points.py
+++ b/tests/test_public_entry_points.py
@@ -1,0 +1,81 @@
+"""The repository's public front door.
+
+An outside reader arrives with one of four things: a defect, a question, an
+idea, or something they built. Until #786 only the first had anywhere to go —
+Discussions was off and the only issue form was `bug_report` — so the other
+three either became a fake bug report or, far more likely, nothing at all. In
+14 days /issues had 6 unique visitors and /pulls had 4, so people were looking.
+
+These assertions are about keeping the door open, not about taste. The failure
+mode is silent: nobody files an issue saying "I had a question and left".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml"
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+
+
+@pytest.fixture(scope="module")
+def contact_links() -> list[dict]:
+    return yaml.safe_load(CONFIG.read_text(encoding="utf-8"))["contact_links"]
+
+
+@pytest.mark.parametrize("category", ["q-a", "ideas", "show-and-tell"])
+def test_the_non_bug_visitor_has_somewhere_to_go(contact_links, category):
+    urls = [link["url"] for link in contact_links]
+    wanted = f"https://github.com/KCNyu/clawock/discussions/categories/{category}"
+    assert wanted in urls, (
+        f"no entry point for {category}; a reader with something that is not a "
+        "defect is pushed into filing a fake bug report"
+    )
+
+
+def test_every_contact_link_says_what_it_is_for(contact_links):
+    for link in contact_links:
+        assert link.get("name"), f"contact link without a name: {link}"
+        assert link.get("about"), f"contact link without an about: {link['name']}"
+        assert link["url"].startswith("https://"), link["url"]
+
+
+def test_the_security_route_stays_ahead_of_the_public_ones(contact_links):
+    """A vulnerability must never be the thing someone files publicly because
+    the private route was buried under three friendly links."""
+    names = [link["name"] for link in contact_links]
+    security = next(i for i, n in enumerate(names) if "security" in n.lower())
+    assert security < len(names) - 1, "the private disclosure route must not be last"
+
+
+def test_a_release_opens_an_announcement_thread_without_being_able_to_break_the_release():
+    """The thread is worth having — it makes a release repliable and indexable —
+    but it is not the deliverable. Putting --discussion-category on
+    `gh release create` would let a Discussions failure leave a tagged version
+    with no GitHub Release at all, and the retry then collides with the release
+    that partially exists.
+    """
+    workflow = RELEASE.read_text(encoding="utf-8")
+    job = workflow.split("\n  github-release:\n", 1)[1]
+
+    assert "discussions: write" in job, "the job needs permission to open the thread"
+    assert "--discussion-category Announcements" in job
+
+    # Comments in this job discuss --discussion-category at length; only the
+    # executable lines decide what actually happens.
+    code = "\n".join(line for line in job.splitlines()
+                     if not line.lstrip().startswith("#"))
+
+    create = code.index("gh release create")
+    edit = code.index("gh release edit")
+    assert edit > create, "the announcement must come after the release exists"
+    assert "--discussion-category" not in code[create:edit], (
+        "the announcement must not be an argument to `gh release create` — a "
+        "failure there would abort publishing the release itself"
+    )
+    assert "continue-on-error: true" in code[:edit], (
+        "a missing announcement thread must not fail the release job"
+    )


### PR DESCRIPTION
Closes #786

## 已在仓库设置里做掉的部分

```
$ gh api -X PATCH repos/KCNyu/clawock -F has_discussions=true --jq .has_discussions
true
```

默认分类已经带齐了需要的四个：`Announcements` / `Q&A`（answerable）/ `Ideas` / `Show and tell`。

## 这个 PR 改的部分

### 1. 非 bug 的访客终于有地方去了

此前 Discussions 关着、issue 模板只有 `bug_report` 一种。一个外部读者带着「问题 / 想法 / 我拿它搭了什么」过来，只有两条路：**伪装成一个 bug 报告**，或者（大概率）**走人**。而 14 天里 `/issues` 有 6 个独立访客、`/pulls` 有 4 个 —— 有人在翻。

`config.yml` 新增三条 contact link 指向对应分类。

**issue 模板刻意保持只有 bug 一种**：issue 留给「可执行 + 有证据」的问题，那条纪律正是这个 tracker 值得读的原因，不该被提问贴稀释。

### 2. 发版顺带开一条 Announcements 贴

让 release 变成**可回复**的东西，也给这个项目多一个搜索引擎能索引的页面 —— 在「Google 14 天带来 4 个独立访客」的现状下，这不是小事。

### 3. 关键设计：公告绝不能弄坏发版

最直觉的写法是给 `gh release create` 加一个 `--discussion-category`。**没有这么写**，因为那样会把公告放到发版的关键路径上：Discussions 那边一旦失败，就会留下一个「tag 有了、GitHub Release 没有」的版本，而重试又会撞上已经部分存在的 release。

所以拆成独立的 `gh release edit` 步骤 + `continue-on-error: true`，失败只打一条 `::warning::`。

新增的测试钉的是**这个顺序本身**，不是「flag 在不在」：

```python
assert "--discussion-category" not in code[create:edit], (
    "the announcement must not be an argument to `gh release create` — a "
    "failure there would abort publishing the release itself")
assert "continue-on-error: true" in code[:edit]
```

（断言先剥掉注释行再判断 —— 那段注释里本身就在讨论 `--discussion-category`，不剥就是自己骗自己。）

### 4. 顺带钉住的两条

- 每条 contact link 必须有 `name` + `about` + https URL
- **私密披露入口不能沉到最底下**：一个漏洞被公开提交，往往只是因为私密通道被三条友好链接埋了

## 验证

```
$ pytest tests/test_public_entry_points.py tests/test_github_release_contract.py   # 19 passed
$ /tmp/actionlint                                                                  # exit 0
```

`--discussion-category` 那条只有在**下一次真正发版**时才会被执行到，届时核 Releases 页是否挂上了 Announcements 贴。
