### PR TITLE
devcontainer: 把 CI 已经在跑的那个证明，交到读者手里

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "clawock",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+
+  // Everything the test suite needs to *collect*, plus the numeric extra the
+  // risk and regime code imports. Named extras rather than a hand-written
+  // package list, for the same reason the workflows stopped writing their own
+  // `pip install` lines: a second source of truth drifts unseen. A CI assertion
+  // holds this line and pyproject's extras together.
+  "postCreateCommand": "pip install --upgrade pip && pip install -e '.[compute,test]'",
+
+  "postAttachCommand": {
+    "next-steps": "bash .devcontainer/welcome.sh"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  },
+
+  "features": {
+    // The DSH plugin contract and the Tavily ledger tests are pure Node, and
+    // the dashboard's browser contract needs a runtime too. Cheap to have,
+    // annoying to discover missing.
+    "ghcr.io/devcontainers/features/node:1": { "version": "22" }
+  }
+}

--- a/.devcontainer/welcome.sh
+++ b/.devcontainer/welcome.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Printed when a Codespace attaches. The distance between "read the README" and
+# "watched it settle one decision" is the expensive part of this project's
+# funnel (#788); this is the shortest path across it.
+cat <<'TXT'
+
+  clawock — ready.
+
+  One complete run, from a clean virtualenv, no credentials, no broker:
+
+      examples/cli/minimal-run/run.sh
+
+  This is the same script release.yml executes against every published wheel,
+  so what CI proves and what you just ran are one file, not two copies.
+
+  The same contract with no harness at all:
+
+      examples/cli/run.sh
+
+  Tests:               pytest -q tests/
+  Live public instance: https://kcnyu.github.io/clawock/
+  Wins and losses:      https://kcnyu.github.io/clawock/evidence.html
+
+  Nothing here reaches a market or needs an API key. The parts that do — price
+  feeds, disclosure pulls, delivery — are the instance's, not the package's.
+
+TXT

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Install it with `pip install clawock`, or
 all. The model proposes; Python owns the prices, the risk limits, the ledger,
 the settlement, and the grading.
 
+To watch it settle one decision before installing anything, open a Codespace and
+run `examples/cli/minimal-run/run.sh` — a clean virtualenv, no credentials, no
+broker, and the same script CI executes against every published wheel:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/KCNyu/clawock)
+
 ### What makes it different
 
 - **A workflow plugin, not another agent — and not another harness.** The external runtime keeps its model, chat, memory, skills engine, tool loop, and permissions; clawock makes the investment-decision contract portable across runtimes and across harnesses. The harness debate (OpenClaw vs Codex vs DeepSeek Harness) is a debate clawock does not participate in.

--- a/tests/test_devcontainer_contract.py
+++ b/tests/test_devcontainer_contract.py
@@ -1,0 +1,91 @@
+"""The zero-install trial path.
+
+The README's claim is "install the same decision workflow into your own agent,
+in any harness". Between reading that and seeing it run there was nothing but
+`pip install clawock` on the reader's own machine — and the funnel says that
+step is where people are lost: PyPI 896 downloads a month and npm 1,126 against
+110 unique repository visitors in 14 days and 10 stars. Plenty install; almost
+nobody leaves a trace.
+
+CI already proves a stranger can finish a run from a clean environment — it
+runs examples/cli/minimal-run/run.sh against every published wheel. Until #788
+that proof was executable only by GitHub. The devcontainer hands the same script
+to the reader.
+
+These assertions exist because a devcontainer rots quietly: it is exercised only
+by people who are not yet contributors, so nobody notices when it stops working.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DEVCONTAINER = ROOT / ".devcontainer" / "devcontainer.json"
+WELCOME = ROOT / ".devcontainer" / "welcome.sh"
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    # devcontainer.json is JSONC. Strip whole-line comments only; nothing here
+    # needs a general parser and a general parser would eat "https://".
+    raw = DEVCONTAINER.read_text(encoding="utf-8")
+    return json.loads(re.sub(r"^\s*//.*$", "", raw, flags=re.M))
+
+
+def test_the_install_uses_named_extras_that_actually_exist(config):
+    """A hand-written package list here would be the tenth place dependencies
+    are declared — the exact drift pyproject was made to end."""
+    command = config["postCreateCommand"]
+    extras = set(re.findall(r"\[([a-z,]+)\]", command)[0].split(","))
+    declared = set(tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["optional-dependencies"])
+
+    assert extras, "the devcontainer must install the package"
+    unknown = extras - declared
+    assert not unknown, f"devcontainer.json installs extras pyproject does not declare: {unknown}"
+    assert "test" in extras, "a contributor's first `pytest` must not fail on collection"
+
+
+def test_the_image_satisfies_the_declared_python_floor(config):
+    floor = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    required = floor["project"]["requires-python"]
+    minimum = tuple(int(p) for p in re.search(r"(\d+)\.(\d+)", required).groups())
+    image = re.search(r"(\d+)\.(\d+)", config["image"])
+    assert image, f"cannot read a Python version out of {config['image']}"
+    assert tuple(int(p) for p in image.groups()) >= minimum, (
+        f"the devcontainer image is older than requires-python {required}"
+    )
+
+
+def test_the_first_thing_offered_is_a_run_that_needs_no_credentials():
+    """The trial has to work with nothing configured. A quickstart that opens
+    with "obtain five API keys" is not a trial, and the package half of clawock
+    genuinely does not need any."""
+    welcome = WELCOME.read_text(encoding="utf-8")
+    assert "examples/cli/minimal-run/run.sh" in welcome
+    script = (ROOT / "examples" / "cli" / "minimal-run" / "run.sh")
+    assert script.exists() and script.stat().st_mode & 0o111, (
+        "the script the welcome message offers must exist and be executable"
+    )
+
+
+def test_the_offered_script_is_the_one_ci_runs_against_the_wheel():
+    """What CI proves and what a reader runs must stay one file. Two copies
+    would drift, and the drift would only show up on someone else's machine."""
+    release = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    welcome = WELCOME.read_text(encoding="utf-8")
+    for script in ("examples/cli/minimal-run/run.sh", "examples/cli/run.sh"):
+        assert script in release, f"{script} is no longer exercised by release.yml"
+        assert script in welcome, f"{script} is no longer offered to the reader"
+
+
+def test_the_readme_advertises_the_trial():
+    """A one-click trial nobody can find is not a trial."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "codespaces.new/KCNyu/clawock" in readme, "the README must offer the Codespace"

--- a/tests/test_readme_renders_off_github.py
+++ b/tests/test_readme_renders_off_github.py
@@ -48,6 +48,15 @@ def test_the_readme_has_no_relative_references():
     )
 
 
+# Static images GitHub serves itself, which are not repository content and have
+# no raw.githubusercontent equivalent. Each entry is an exact (host, path) pair,
+# never a host-wide exemption: `github.com` also serves the blob viewer, and
+# that is precisely what the rule below exists to keep out.
+GITHUB_SERVED_ASSETS = frozenset({
+    ('github.com', '/codespaces/badge.svg'),   # the official Open-in-Codespaces badge
+})
+
+
 def test_assets_point_at_raw_not_the_blob_viewer():
     """A `github.com/.../blob/...` URL serves an HTML page, so an <img> using one
     shows nothing. Assets have to come from raw.githubusercontent.
@@ -59,7 +68,21 @@ def test_assets_point_at_raw_not_the_blob_viewer():
     text = README.read_text()
     for target in _references(text):
         if target.endswith(ASSET_SUFFIXES) and target.startswith('http'):
-            assert urlparse(target).hostname == 'raw.githubusercontent.com', target
+            parsed = urlparse(target)
+            if (parsed.hostname, parsed.path) in GITHUB_SERVED_ASSETS:
+                continue
+            assert parsed.hostname == 'raw.githubusercontent.com', target
+
+
+def test_the_github_served_allowlist_cannot_be_widened_into_the_blob_viewer():
+    """The exemption above is the kind that rots into `hostname == github.com`.
+    A blob URL must stay rejected no matter what is on the list."""
+    for host, path in GITHUB_SERVED_ASSETS:
+        assert not path.startswith('/KCNyu/'), (
+            f'{host}{path} is repository content — it has a raw.githubusercontent '
+            'equivalent and must use it'
+        )
+        assert '/blob/' not in path, f'{host}{path} is a blob viewer URL'
 
 
 def test_the_readme_is_what_the_package_ships():


### PR DESCRIPTION
Closes #788

## 问题不是「没写 devcontainer」，是那个证明只有 GitHub 能执行

`release.yml` 每次发版都在证明「一个陌生人能把包装进干净环境、跑完一次完整的 run」：

```yaml
- name: Isolated install completes one real run
  run: examples/cli/minimal-run/run.sh dist/*.whl
- name: Harness-free run (harness-agnostic contract)
  run: examples/cli/run.sh dist/*.whl
```

而那个脚本自己的注释早就说清楚了它为什么是一个文件而不是一段 workflow step：

> the claim is "a stranger can install the package and finish a run without this repository", and a snippet buried in release.yml is not something a stranger can execute

**但读者仍然执行不了它** —— 他得先有本机 Python、先 clone、先知道这个脚本存在。

漏斗数字说这一步就是最贵的一步：

| 面 | 近 30 天 |
|---|---|
| PyPI `clawock` 下载 | 896 |
| npm `clawock-dsh` 下载 | 1,126 |
| 仓库 unique visitor | 110（14 天）|
| star | 10 |

装的人不少，留下痕迹的人极少。从「读完 README」到「亲眼看它结算一次」中间，此前只有「在你自己机器上 pip install」。

## 做了什么

- `.devcontainer/devcontainer.json` —— Python 3.12 + Node 22，`postCreateCommand` 装 `-e '.[compute,test]'`
- `.devcontainer/welcome.sh` —— attach 时打印下一步，**第一条就是那个不需要任何凭据的 run**
- README 加 Open in Codespaces 徽章

**零凭据是硬要求**，不是附带说明。`minimal-run/run.sh` 默认从 PyPI 装、用 `env -i` 清空环境、把 `HOME` 重定向到临时目录，全程不碰任何 key，也不碰任何市场。需要 key 的那些（行情、披露、投递）属于那个 live 实例，不属于这个包 —— 这恰好也是这个项目最想让人看到的那一半。

## 四条断言，因为 devcontainer 是会烂在角落里的东西

它只被「还不是贡献者的人」用到，所以坏了没人会发现。断言钉住的是：

1. `postCreateCommand` 里的 extras 必须是 `pyproject.toml` 真的声明过的（手写包名列表就会变成第十个依赖声明处，正是 pyproject 当初被建出来终结的那种漂移），且必须含 `test` —— 否则新人第一条 `pytest` 会挂在 collection 上
2. 镜像的 Python 版本不低于 `requires-python`
3. **welcome 里推荐的脚本，必须就是 `release.yml` 执行的那个** —— 两份副本会漂，而漂移只会在别人的机器上显形
4. README 必须真的把这个入口露出来（找不到的一键试用不算试用）

## 一处对既有闸的收窄，不是放宽

Codespaces 徽章由 `github.com` 直接托管，没有 raw.githubusercontent 对应物，撞上了 `test_assets_point_at_raw_not_the_blob_viewer`。

**没有把它改成放行整个 host**，而是加了一条精确的 `(host, path)` 白名单 + 再加一条测试防止这条白名单腐化：

```python
def test_the_github_served_allowlist_cannot_be_widened_into_the_blob_viewer():
    for host, path in GITHUB_SERVED_ASSETS:
        assert not path.startswith('/KCNyu/')   # 仓库内容有 raw 对应物，必须用
        assert '/blob/' not in path             # blob viewer 正是原规则要挡的东西
```

原规则挡的是 `github.com/.../blob/...`（返回 HTML 页面，`<img>` 什么都不显示），而 `github.com/codespaces/badge.svg` 不是 blob URL。这条收窄是把规则改成它本来想表达的意思。

## 验证

```
$ pytest tests/ -q                       # 全套通过，exit 0（本地 worktree）
$ pytest tests/test_devcontainer_contract.py tests/test_readme_renders_off_github.py tests/test_readme_parity.py
  27 passed
```

Codespace 本身要合并后才能真开一个来验（badge 指向 master）。合并后我会开一个跑一遍 `minimal-run`，把收据贴回这个 issue。
