### PR TITLE
schedule: 让兜底真的能跑，并让它的沉默可见（brief-fallback + 漂移记账）

### DIFF
--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -5,10 +5,49 @@ name: Brief Fallback (off-host LLM)
 # 5min 太窄会在主 brief 落地前误判"没出"→重复生成→push 撞主 cron commit 的 rebase 冲突
 # 如果今天的 pre-open.md 已存在（git log 只作兜底）→ skip
 # 否则用远端 MiniMax（可选 opencode-go DeepSeek V4 Flash fallback）直跑 brief
+#
+# #780: this backstop had never once produced a brief. Every one of the 34
+# scheduled runs between 2026-07-07 and 2026-08-21 finished in 11-21 seconds on
+# the "already exists" branch, and the only five runs that ever reached the
+# generation branch were manual dispatches, all of which failed. Three separate
+# defects kept it that way and all three are addressed here:
+#
+#  1. The provider chain could not finish inside the job (see the deadline env
+#     below) — that is why every manual dispatch died.
+#  2. GitHub's scheduler delivered this workflow 89-159 minutes late, at or past
+#     its own `HOUR >= 10 HKT` lateness gate, so on a day the primary really
+#     failed the backstop would have skipped itself. Answered by firing three
+#     times instead of once: the skip check is idempotent, so extra attempts
+#     cost 15 seconds each and the earliest one to arrive in-window wins.
+#     Deliberately NOT answered by moving it earlier — anything before ~00:25
+#     UTC races the primary brief that is still generating.
+#  3. Nothing anywhere could see that a branch had never been taken. The run now
+#     records which branch it took, and rehearses the real generation chain
+#     weekly so "can this thing work" stops being an untested assumption.
 on:
   schedule:
+    # Three attempts across the usable window rather than one. Measured drift
+    # for this slot is +89..159 minutes (#781) and it is driven by how contended
+    # the UTC hour is, not by the minute, so no single choice is reliable.
     - cron: '25 0 * * 1-5'
+    - cron: '47 0 * * 1-5'
+    - cron: '9 1 * * 1-5'
+    # Weekly rehearsal of the generation chain: real providers, real preflight,
+    # output discarded — see `rehearse` below. Wednesday 12:23 HKT, on a trading
+    # day and well clear of the fallback window above. Deliberately not a
+    # weekend: preflight on a closed market would produce a red that says
+    # nothing about whether the backstop works.
+    - cron: '23 4 * * 3'
   workflow_dispatch:
+    inputs:
+      rehearse:
+        description: >-
+          exercise the full generation chain and discard the result. Never
+          commits, never publishes, and ignores the "already exists" skip. This
+          is the only thing that answers "would the backstop work today".
+        required: false
+        default: 'false'
+        type: boolean
 
 concurrency:
   group: data-write
@@ -17,10 +56,24 @@ concurrency:
 jobs:
   fallback:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 20, not 15. The old budget was shorter than the provider chain it
+    # contained; see CLAWOCK_LLM_DEADLINE_SECONDS below.
+    timeout-minutes: 20
     env:
       CLAWOCK_PROFILE: kcnyu
       CLAWOCK_WORKSPACE: ${{ github.workspace }}
+      # The whole provider chain must finish inside this job, and `timeout` alone
+      # cannot say that: timeout=900 x MAX_RETRIES=3 is a 45-minute budget for
+      # MiniMax alone. On 2026-08-17 (run 31985473431) MiniMax hit
+      # RemoteDisconnected, started retrying, and the runner killed the job at 15
+      # minutes — opencode-go was never asked. Not once, in any of the five
+      # manual dispatches this workflow has ever had.
+      #
+      # 660s of a 20-minute job: MiniMax gets 60% of it and the remainder belongs
+      # to opencode-go, leaving ~9 minutes for postflight, the dashboard rebuild
+      # and the push.
+      CLAWOCK_LLM_DEADLINE_SECONDS: '660'
+      REHEARSE: ${{ inputs.rehearse == true || inputs.rehearse == 'true' || github.event.schedule == '23 4 * * 3' }}
     permissions:
       contents: write
     steps:
@@ -53,18 +106,36 @@ jobs:
           # presence in the checkout is depth-proof. The old git-log grep broke on
           # 2026-06-10: fetch-depth 10 + a busy morning (brief at depth 19) + 4.5h
           # GHA delay → "no brief found" → near-duplicate brief at 12:53 HKT.
-          if [ -f "memory/${TODAY}-pre-open.md" ] || \
+          if [ "$REHEARSE" = "true" ]; then
+            # A rehearsal deliberately ignores every skip: its purpose is to
+            # reach the generation chain. It cannot commit or publish — the
+            # later steps are gated on `rehearsal` too.
+            echo "rehearsal — running the generation chain and discarding the result"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "branch=rehearsal" >> "$GITHUB_OUTPUT"
+          elif [ -f "memory/${TODAY}-pre-open.md" ] || \
              git log --since "$TODAY 00:00" --grep "daily deep brief $TODAY" --oneline | grep -q "."; then
             echo "today's brief already exists — skip fallback"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "branch=already-exists" >> "$GITHUB_OUTPUT"
           elif [ "$HOUR" -ge 10 ]; then
             # Lateness gate: a "pre-open" brief generated after HK open is stale
             # noise (intraday reports already cover the session) — never generate.
+            #
+            # This is the branch that made the backstop structurally useless for
+            # a month: GitHub delivered the 00:25 UTC schedule at 03:0x-04:2x UTC
+            # (11:00-12:30 HKT), so on a day the primary failed, the fallback
+            # would have arrived and shut itself off. It stays — a stale pre-open
+            # brief really is worse than none — but it is now recorded rather
+            # than silent, so "the backstop declined" is a fact somebody can see.
+            echo "::warning::brief-fallback arrived at ${HOUR}:xx HKT, past its own usefulness window — if today's primary brief failed, nothing replaced it"
             echo "too late to be useful (hour=$HOUR HKT >= 10) — skip"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "branch=too-late" >> "$GITHUB_OUTPUT"
           else
             echo "no brief found — fallback will run"
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "branch=generated" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run preflight (collect deterministic data)
@@ -80,8 +151,37 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: clawock-brief-fallback
 
+      - name: Rehearsal — did the chain actually produce a brief?
+        # A rehearsal stops here, before postflight. postflight validates AND
+        # commits AND pushes (its maybe_commit does all three), so letting a
+        # rehearsal reach it would risk publishing a brief nobody asked for —
+        # the exact opposite of a safe drill. What a rehearsal has to answer is
+        # narrower and is fully answered by this point: can the provider chain
+        # generate today's brief inside the job's budget. Postflight is
+        # exercised for real by the primary path every trading day.
+        if: steps.check.outputs.branch == 'rehearsal'
+        run: |
+          set -euo pipefail
+          TODAY=$(TZ=Asia/Hong_Kong date +%Y-%m-%d)
+          target="memory/${TODAY}-pre-open.md"
+          if [ ! -s "$target" ]; then
+            echo "::error::rehearsal produced no brief at $target — the backstop would NOT have worked today"
+            exit 1
+          fi
+          bytes=$(wc -c < "$target")
+          echo "rehearsal produced $bytes bytes at $target"
+          {
+            echo "### Rehearsal"
+            echo
+            echo "The generation chain produced **${bytes} bytes**. Discarding it."
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Leave nothing behind that a later step or a human could mistake for
+          # a real brief.
+          git checkout -- . 2>/dev/null || true
+          git clean -fd memory assets/data 2>/dev/null || true
+
       - name: Postflight validation
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.check.outputs.branch != 'rehearsal'
         # postflight exits 0=pass, 1=warn (both publishable), 2=fail. pass/warn keep the
         # job green; a real fail (2) blocks the commit. Exit 1 can also mean an uncaught
         # Python exception, so the next step requires the gate file that a legitimate
@@ -105,7 +205,7 @@ jobs:
         # does anything), so it answers for itself, on the run that did it,
         # instead of a corpus scan days later. Not a gate — recovering those
         # cards is this job's purpose; this is the record that it happened.
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.check.outputs.branch != 'rehearsal'
         run: |
           python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, pathlib
@@ -135,7 +235,9 @@ jobs:
         # Reached when postflight exits <2: pass/warn, or an uncaught exception (exit 1).
         # The publish gate distinguishes a legitimate warn from a crash-before-gate;
         # missing gate fails the job, while explicit publish_ok=false publishes nothing.
-        if: steps.check.outputs.skip != 'true'
+        # A rehearsal proves the chain runs; it must not put its output anywhere
+        # a reader could mistake for a real brief.
+        if: steps.check.outputs.skip != 'true' && steps.check.outputs.branch != 'rehearsal'
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
@@ -168,3 +270,25 @@ jobs:
           else
             echo "nothing to push — HEAD not ahead of origin/master (or fetch failed)"
           fi
+
+      - name: Record which branch this run took
+        # The defect this exists for is not a crash — it is six weeks of green
+        # runs that never once entered the generation branch, with nothing
+        # anywhere able to notice. A run that only ever skips has to leave a
+        # trace, or "the backstop is fine" stays unfalsifiable.
+        if: always()
+        env:
+          BRANCH: ${{ steps.check.outputs.branch }}
+          REHEARSAL_RESULT: ${{ steps.check.outputs.branch == 'rehearsal' && job.status || '' }}
+        run: |
+          {
+            echo "### brief-fallback"
+            echo
+            echo "Branch taken: \`${BRANCH:-unknown}\`"
+            case "${BRANCH:-unknown}" in
+              already-exists) echo; echo "The primary brief landed. Nothing to do — but note that this branch, and only this branch, has been taken on every scheduled run since 2026-07-07." ;;
+              too-late)       echo; echo "**The backstop declined.** It arrived past its usefulness window. If today's primary brief failed, nothing replaced it." ;;
+              generated)      echo; echo "The generation chain ran for real." ;;
+              rehearsal)      echo; echo "Rehearsal — the generation chain ran and the result was discarded. Job status: ${REHEARSAL_RESULT}." ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -1,7 +1,19 @@
 name: Cron Health Check
 
 # 17:17 HKT = 09:17 UTC 工作日 — 港股收盘后、美股开盘前 一窗口。
-# 避开整点：GitHub 官方说明整点高负载会延迟甚至丢弃 scheduled runs。
+#
+# 这里原来写着「避开整点：GitHub 官方说明整点高负载会延迟甚至丢弃 scheduled
+# runs」，隐含「非整点就准时」。**这条被本档自己的数据证伪了**（#781）：它就在
+# `17 9`，20 次实测漂移 30–198 分钟、中位 71 分钟。真正决定延迟的是 **UTC 小时
+# 有多拥挤**，不是分钟好不好看：`45 21` 中位 46 分钟、`0 13` 中位 74 分钟、
+# `25 0` 中位 124 分钟。
+#
+# ⇒ 任何「靠准时才有价值」的任务都不能只靠挑一个分钟来保证（brief-fallback 就是
+# 这么失效的，见 #780）。当前漂移表由 `ops/ci/schedule_drift.py` 每周采两次写进
+# `assets/data/schedule-drift.json`，别再凭印象猜。
+#
+# 本档自身对漂移不敏感：它读的是当天已落地的 git 产物与 heartbeat，晚一小时读到
+# 的是同一批事实。
 # 报告任务对 git 产物（缺 commit 时再查 workflow-outcomes 是否是 Telegram backstop
 # 接管——那条路径设计上不产 commit，见 #696）；盘中任务对逐 slot heartbeat
 # 缺漏 → workflow fail（Actions 可见；不做 README 首屏 badge）

--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -1,5 +1,7 @@
-name: Repo Traffic Capture
+name: Measurement Capture
 
+# Two rolling-window measurements that are lost if nobody writes them down.
+#
 # GitHub's Traffic API keeps 14 days. Nothing captured it until #789, so every
 # week that passed permanently erased the only first-party measurement of who
 # reaches this project and from where. This is the one kind of data loss that
@@ -55,17 +57,35 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure how late GitHub delivers the scheduled workflows
+        # Every scheduled workflow in this repository is late and nobody kept a
+        # number (#781). The Actions API ages runs out too, so this is the same
+        # shape of perishable measurement as the traffic above — and the numbers
+        # it produces are what a scheduling decision has to be argued from
+        # instead of a nice-looking cron minute.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 ops/ci/schedule_drift.py | tee /tmp/drift.txt
+          {
+            echo '### Scheduled-run drift'
+            echo '```'
+            cat /tmp/drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Commit the merged history
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/data/repo-traffic.json
+          git add assets/data/repo-traffic.json assets/data/schedule-drift.json
           if git diff --cached --quiet; then
-            echo "no new traffic days — nothing to commit"
+            echo "no new measurements — nothing to commit"
             exit 0
           fi
-          git commit -m "growth: repo traffic capture $(date -u +%Y-%m-%d)"
+          git commit -m "measurement: repo traffic + schedule drift $(date -u +%Y-%m-%d)"
           # Automation commits to master all day; rebase onto whatever landed
           # while this job ran rather than failing on a stale ref.
           git pull --rebase --autostash origin master

--- a/assets/data/schedule-drift.json
+++ b/assets/data/schedule-drift.json
@@ -1,0 +1,1377 @@
+{
+  "generated_at": "2026-08-21T18:08:59Z",
+  "repo": "KCNyu/clawock",
+  "note": "drift_minutes = run.created_at - the reconstructed cron instant. GitHub does not report the scheduled instant, so a run delayed past its own next occurrence is attributed to that later one: every figure here is a lower bound.",
+  "workflows": [
+    {
+      "workflow": "brief-fallback.yml",
+      "crons": [
+        "25 0 * * 1-5",
+        "47 0 * * 1-5",
+        "9 1 * * 1-5",
+        "23 4 * * 3"
+      ],
+      "samples": 20,
+      "drift_min": 45.7,
+      "drift_median": 124.1,
+      "drift_max": 181.4,
+      "runs": [
+        {
+          "run_id": 32438448196,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-21T01:09:00Z",
+          "started_at": "2026-08-21T02:02:49Z",
+          "drift_minutes": 53.8
+        },
+        {
+          "run_id": 32322796091,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-20T01:09:00Z",
+          "started_at": "2026-08-20T01:55:52Z",
+          "drift_minutes": 46.9
+        },
+        {
+          "run_id": 32206765829,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-19T01:09:00Z",
+          "started_at": "2026-08-19T01:56:53Z",
+          "drift_minutes": 47.9
+        },
+        {
+          "run_id": 32089912312,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-18T01:09:00Z",
+          "started_at": "2026-08-18T01:54:44Z",
+          "drift_minutes": 45.7
+        },
+        {
+          "run_id": 31986556241,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-17T01:09:00Z",
+          "started_at": "2026-08-17T01:58:46Z",
+          "drift_minutes": 49.8
+        },
+        {
+          "run_id": 31765613452,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-14T01:09:00Z",
+          "started_at": "2026-08-14T03:03:21Z",
+          "drift_minutes": 114.3
+        },
+        {
+          "run_id": 31662767739,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-13T01:09:00Z",
+          "started_at": "2026-08-13T03:04:04Z",
+          "drift_minutes": 115.1
+        },
+        {
+          "run_id": 31558726205,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-12T01:09:00Z",
+          "started_at": "2026-08-12T03:01:05Z",
+          "drift_minutes": 112.1
+        },
+        {
+          "run_id": 31452660315,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-11T01:09:00Z",
+          "started_at": "2026-08-11T02:32:00Z",
+          "drift_minutes": 83.0
+        },
+        {
+          "run_id": 31350350003,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-10T01:09:00Z",
+          "started_at": "2026-08-10T02:38:41Z",
+          "drift_minutes": 89.7
+        },
+        {
+          "run_id": 31144138752,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-07T01:09:00Z",
+          "started_at": "2026-08-07T03:22:13Z",
+          "drift_minutes": 133.2
+        },
+        {
+          "run_id": 31069370958,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-06T01:09:00Z",
+          "started_at": "2026-08-06T03:46:37Z",
+          "drift_minutes": 157.6
+        },
+        {
+          "run_id": 30972949606,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-05T01:09:00Z",
+          "started_at": "2026-08-05T03:40:50Z",
+          "drift_minutes": 151.8
+        },
+        {
+          "run_id": 30875615571,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-04T01:09:00Z",
+          "started_at": "2026-08-04T03:44:29Z",
+          "drift_minutes": 155.5
+        },
+        {
+          "run_id": 30783345471,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-08-03T01:09:00Z",
+          "started_at": "2026-08-03T04:03:21Z",
+          "drift_minutes": 174.3
+        },
+        {
+          "run_id": 30602885556,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-07-31T01:09:00Z",
+          "started_at": "2026-07-31T03:57:30Z",
+          "drift_minutes": 168.5
+        },
+        {
+          "run_id": 30511727518,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-07-30T01:09:00Z",
+          "started_at": "2026-07-30T03:38:39Z",
+          "drift_minutes": 149.7
+        },
+        {
+          "run_id": 30420488158,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-07-29T01:09:00Z",
+          "started_at": "2026-07-29T03:46:58Z",
+          "drift_minutes": 158.0
+        },
+        {
+          "run_id": 30326693454,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-07-28T01:09:00Z",
+          "started_at": "2026-07-28T03:43:04Z",
+          "drift_minutes": 154.1
+        },
+        {
+          "run_id": 30236356880,
+          "cron": "9 1 * * 1-5",
+          "scheduled_at": "2026-07-27T01:09:00Z",
+          "started_at": "2026-07-27T04:10:24Z",
+          "drift_minutes": 181.4
+        }
+      ]
+    },
+    {
+      "workflow": "cron-health.yml",
+      "crons": [
+        "17 9 * * 1-5"
+      ],
+      "samples": 20,
+      "drift_min": 30.2,
+      "drift_median": 70.8,
+      "drift_max": 198.3,
+      "runs": [
+        {
+          "run_id": 32469833091,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-21T09:17:00Z",
+          "started_at": "2026-08-21T09:50:54Z",
+          "drift_minutes": 33.9
+        },
+        {
+          "run_id": 32355796463,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-20T09:17:00Z",
+          "started_at": "2026-08-20T09:48:56Z",
+          "drift_minutes": 31.9
+        },
+        {
+          "run_id": 32239442786,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-19T09:17:00Z",
+          "started_at": "2026-08-19T09:47:55Z",
+          "drift_minutes": 30.9
+        },
+        {
+          "run_id": 32123417757,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-18T09:17:00Z",
+          "started_at": "2026-08-18T09:47:12Z",
+          "drift_minutes": 30.2
+        },
+        {
+          "run_id": 32017674502,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-17T09:17:00Z",
+          "started_at": "2026-08-17T09:55:58Z",
+          "drift_minutes": 39.0
+        },
+        {
+          "run_id": 31791473973,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-14T09:17:00Z",
+          "started_at": "2026-08-14T10:15:22Z",
+          "drift_minutes": 58.4
+        },
+        {
+          "run_id": 31690649433,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-13T09:17:00Z",
+          "started_at": "2026-08-13T10:20:30Z",
+          "drift_minutes": 63.5
+        },
+        {
+          "run_id": 31586875709,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-12T09:17:00Z",
+          "started_at": "2026-08-12T10:19:08Z",
+          "drift_minutes": 62.1
+        },
+        {
+          "run_id": 31480935433,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-11T09:17:00Z",
+          "started_at": "2026-08-11T10:09:14Z",
+          "drift_minutes": 52.2
+        },
+        {
+          "run_id": 31379781639,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-10T09:17:00Z",
+          "started_at": "2026-08-10T10:35:15Z",
+          "drift_minutes": 78.2
+        },
+        {
+          "run_id": 31168903810,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-07T09:17:00Z",
+          "started_at": "2026-08-07T10:09:11Z",
+          "drift_minutes": 52.2
+        },
+        {
+          "run_id": 31097625377,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-06T09:17:00Z",
+          "started_at": "2026-08-06T11:31:50Z",
+          "drift_minutes": 134.8
+        },
+        {
+          "run_id": 31001555448,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-05T09:17:00Z",
+          "started_at": "2026-08-05T11:27:53Z",
+          "drift_minutes": 130.9
+        },
+        {
+          "run_id": 30905242623,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-04T09:17:00Z",
+          "started_at": "2026-08-04T11:32:45Z",
+          "drift_minutes": 135.8
+        },
+        {
+          "run_id": 30814191784,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-08-03T09:17:00Z",
+          "started_at": "2026-08-03T12:35:16Z",
+          "drift_minutes": 198.3
+        },
+        {
+          "run_id": 30627116869,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-07-31T09:17:00Z",
+          "started_at": "2026-07-31T11:27:54Z",
+          "drift_minutes": 130.9
+        },
+        {
+          "run_id": 30537207199,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-07-30T09:17:00Z",
+          "started_at": "2026-07-30T11:05:27Z",
+          "drift_minutes": 108.5
+        },
+        {
+          "run_id": 30447439583,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-07-29T09:17:00Z",
+          "started_at": "2026-07-29T11:24:25Z",
+          "drift_minutes": 127.4
+        },
+        {
+          "run_id": 30354038601,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-07-28T09:17:00Z",
+          "started_at": "2026-07-28T11:15:12Z",
+          "drift_minutes": 118.2
+        },
+        {
+          "run_id": 30265522209,
+          "cron": "17 9 * * 1-5",
+          "scheduled_at": "2026-07-27T09:17:00Z",
+          "started_at": "2026-07-27T12:20:44Z",
+          "drift_minutes": 183.7
+        }
+      ]
+    },
+    {
+      "workflow": "eod-archive.yml",
+      "crons": [
+        "0 22 * * 5"
+      ],
+      "samples": 13,
+      "drift_min": 14.1,
+      "drift_median": 53.8,
+      "drift_max": 69.5,
+      "runs": [
+        {
+          "run_id": 31845802094,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-08-14T22:00:00Z",
+          "started_at": "2026-08-14T22:14:03Z",
+          "drift_minutes": 14.1
+        },
+        {
+          "run_id": 31223811427,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-08-07T22:00:00Z",
+          "started_at": "2026-08-07T22:26:19Z",
+          "drift_minutes": 26.3
+        },
+        {
+          "run_id": 30671289746,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-07-31T22:00:00Z",
+          "started_at": "2026-07-31T22:52:42Z",
+          "drift_minutes": 52.7
+        },
+        {
+          "run_id": 30132333602,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-07-24T22:00:00Z",
+          "started_at": "2026-07-24T22:54:48Z",
+          "drift_minutes": 54.8
+        },
+        {
+          "run_id": 29618587737,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-07-17T22:00:00Z",
+          "started_at": "2026-07-17T22:40:42Z",
+          "drift_minutes": 40.7
+        },
+        {
+          "run_id": 29128970215,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-07-10T22:00:00Z",
+          "started_at": "2026-07-10T22:53:45Z",
+          "drift_minutes": 53.8
+        },
+        {
+          "run_id": 28686829518,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-07-03T22:00:00Z",
+          "started_at": "2026-07-03T22:55:42Z",
+          "drift_minutes": 55.7
+        },
+        {
+          "run_id": 28269962845,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-06-26T22:00:00Z",
+          "started_at": "2026-06-26T22:59:40Z",
+          "drift_minutes": 59.7
+        },
+        {
+          "run_id": 27851829004,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-06-19T22:00:00Z",
+          "started_at": "2026-06-19T22:47:04Z",
+          "drift_minutes": 47.1
+        },
+        {
+          "run_id": 27448288345,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-06-12T22:00:00Z",
+          "started_at": "2026-06-12T23:09:29Z",
+          "drift_minutes": 69.5
+        },
+        {
+          "run_id": 27044529831,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-06-05T22:00:00Z",
+          "started_at": "2026-06-05T23:00:05Z",
+          "drift_minutes": 60.1
+        },
+        {
+          "run_id": 26666713598,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-05-29T22:00:00Z",
+          "started_at": "2026-05-29T23:06:11Z",
+          "drift_minutes": 66.2
+        },
+        {
+          "run_id": 26315771884,
+          "cron": "0 22 * * 5",
+          "scheduled_at": "2026-05-22T22:00:00Z",
+          "started_at": "2026-05-22T22:51:38Z",
+          "drift_minutes": 51.6
+        }
+      ]
+    },
+    {
+      "workflow": "influencer-scan.yml",
+      "crons": [
+        "40 21 * * 0-4",
+        "50 12 * * 1-5"
+      ],
+      "samples": 20,
+      "drift_min": 9.9,
+      "drift_median": 41.3,
+      "drift_max": 80.2,
+      "runs": [
+        {
+          "run_id": 32487554689,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-21T12:50:00Z",
+          "started_at": "2026-08-21T13:34:30Z",
+          "drift_minutes": 44.5
+        },
+        {
+          "run_id": 32421846027,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-20T21:40:00Z",
+          "started_at": "2026-08-20T21:55:54Z",
+          "drift_minutes": 15.9
+        },
+        {
+          "run_id": 32375109907,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-20T12:50:00Z",
+          "started_at": "2026-08-20T13:35:11Z",
+          "drift_minutes": 45.2
+        },
+        {
+          "run_id": 32306205663,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-19T21:40:00Z",
+          "started_at": "2026-08-19T21:54:07Z",
+          "drift_minutes": 14.1
+        },
+        {
+          "run_id": 32258738619,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-19T12:50:00Z",
+          "started_at": "2026-08-19T13:33:07Z",
+          "drift_minutes": 43.1
+        },
+        {
+          "run_id": 32189917818,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-18T21:40:00Z",
+          "started_at": "2026-08-18T21:51:52Z",
+          "drift_minutes": 11.9
+        },
+        {
+          "run_id": 32142864590,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-18T12:50:00Z",
+          "started_at": "2026-08-18T13:31:31Z",
+          "drift_minutes": 41.5
+        },
+        {
+          "run_id": 32073423105,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-17T21:40:00Z",
+          "started_at": "2026-08-17T21:53:53Z",
+          "drift_minutes": 13.9
+        },
+        {
+          "run_id": 32035293320,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-17T12:50:00Z",
+          "started_at": "2026-08-17T13:28:15Z",
+          "drift_minutes": 38.2
+        },
+        {
+          "run_id": 31974640663,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-16T21:40:00Z",
+          "started_at": "2026-08-16T21:49:56Z",
+          "drift_minutes": 9.9
+        },
+        {
+          "run_id": 31807717770,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-14T12:50:00Z",
+          "started_at": "2026-08-14T14:04:20Z",
+          "drift_minutes": 74.3
+        },
+        {
+          "run_id": 31749594345,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-13T21:40:00Z",
+          "started_at": "2026-08-13T22:21:19Z",
+          "drift_minutes": 41.3
+        },
+        {
+          "run_id": 31708729478,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-13T12:50:00Z",
+          "started_at": "2026-08-13T14:10:12Z",
+          "drift_minutes": 80.2
+        },
+        {
+          "run_id": 31646567376,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-12T21:40:00Z",
+          "started_at": "2026-08-12T22:21:00Z",
+          "drift_minutes": 41.0
+        },
+        {
+          "run_id": 31605178313,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-12T12:50:00Z",
+          "started_at": "2026-08-12T14:08:39Z",
+          "drift_minutes": 78.7
+        },
+        {
+          "run_id": 31542049369,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-11T21:40:00Z",
+          "started_at": "2026-08-11T22:21:24Z",
+          "drift_minutes": 41.4
+        },
+        {
+          "run_id": 31499859056,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-11T12:50:00Z",
+          "started_at": "2026-08-11T14:07:42Z",
+          "drift_minutes": 77.7
+        },
+        {
+          "run_id": 31437098222,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-10T21:40:00Z",
+          "started_at": "2026-08-10T22:09:34Z",
+          "drift_minutes": 29.6
+        },
+        {
+          "run_id": 31396500301,
+          "cron": "50 12 * * 1-5",
+          "scheduled_at": "2026-08-10T12:50:00Z",
+          "started_at": "2026-08-10T14:07:56Z",
+          "drift_minutes": 77.9
+        },
+        {
+          "run_id": 31338296727,
+          "cron": "40 21 * * 0-4",
+          "scheduled_at": "2026-08-09T21:40:00Z",
+          "started_at": "2026-08-09T22:00:40Z",
+          "drift_minutes": 20.7
+        }
+      ]
+    },
+    {
+      "workflow": "macro-scan.yml",
+      "crons": [
+        "45 21 * * 0-4"
+      ],
+      "samples": 20,
+      "drift_min": 10.2,
+      "drift_median": 46.0,
+      "drift_max": 199.0,
+      "runs": [
+        {
+          "run_id": 32422210384,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-20T21:45:00Z",
+          "started_at": "2026-08-20T22:00:21Z",
+          "drift_minutes": 15.3
+        },
+        {
+          "run_id": 32306620796,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-19T21:45:00Z",
+          "started_at": "2026-08-19T21:59:13Z",
+          "drift_minutes": 14.2
+        },
+        {
+          "run_id": 32190321898,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-18T21:45:00Z",
+          "started_at": "2026-08-18T21:56:41Z",
+          "drift_minutes": 11.7
+        },
+        {
+          "run_id": 32073811641,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-17T21:45:00Z",
+          "started_at": "2026-08-17T21:58:37Z",
+          "drift_minutes": 13.6
+        },
+        {
+          "run_id": 31974889907,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-16T21:45:00Z",
+          "started_at": "2026-08-16T21:55:12Z",
+          "drift_minutes": 10.2
+        },
+        {
+          "run_id": 31749750978,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-13T21:45:00Z",
+          "started_at": "2026-08-13T22:23:35Z",
+          "drift_minutes": 38.6
+        },
+        {
+          "run_id": 31646738181,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-12T21:45:00Z",
+          "started_at": "2026-08-12T22:23:25Z",
+          "drift_minutes": 38.4
+        },
+        {
+          "run_id": 31542232226,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-11T21:45:00Z",
+          "started_at": "2026-08-11T22:23:55Z",
+          "drift_minutes": 38.9
+        },
+        {
+          "run_id": 31437765707,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-10T21:45:00Z",
+          "started_at": "2026-08-10T22:18:52Z",
+          "drift_minutes": 33.9
+        },
+        {
+          "run_id": 31338411387,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-09T21:45:00Z",
+          "started_at": "2026-08-09T22:03:14Z",
+          "drift_minutes": 18.2
+        },
+        {
+          "run_id": 31136794248,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-06T21:45:00Z",
+          "started_at": "2026-08-07T01:03:59Z",
+          "drift_minutes": 199.0
+        },
+        {
+          "run_id": 31053729690,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-05T21:45:00Z",
+          "started_at": "2026-08-05T22:42:03Z",
+          "drift_minutes": 57.0
+        },
+        {
+          "run_id": 30957440927,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-04T21:45:00Z",
+          "started_at": "2026-08-04T22:43:07Z",
+          "drift_minutes": 58.1
+        },
+        {
+          "run_id": 30859476883,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-03T21:45:00Z",
+          "started_at": "2026-08-03T22:39:31Z",
+          "drift_minutes": 54.5
+        },
+        {
+          "run_id": 30770549045,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-08-02T21:45:00Z",
+          "started_at": "2026-08-02T22:38:32Z",
+          "drift_minutes": 53.5
+        },
+        {
+          "run_id": 30588243396,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-07-30T21:45:00Z",
+          "started_at": "2026-07-30T22:45:21Z",
+          "drift_minutes": 60.4
+        },
+        {
+          "run_id": 30496819257,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-07-29T21:45:00Z",
+          "started_at": "2026-07-29T22:38:03Z",
+          "drift_minutes": 53.0
+        },
+        {
+          "run_id": 30405454477,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-07-28T21:45:00Z",
+          "started_at": "2026-07-28T22:41:20Z",
+          "drift_minutes": 56.3
+        },
+        {
+          "run_id": 30311585713,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-07-27T21:45:00Z",
+          "started_at": "2026-07-27T22:40:57Z",
+          "drift_minutes": 56.0
+        },
+        {
+          "run_id": 30223600995,
+          "cron": "45 21 * * 0-4",
+          "scheduled_at": "2026-07-26T21:45:00Z",
+          "started_at": "2026-07-26T22:40:14Z",
+          "drift_minutes": 55.2
+        }
+      ]
+    },
+    {
+      "workflow": "news-digest.yml",
+      "crons": [
+        "0 13 * * 1-5"
+      ],
+      "samples": 20,
+      "drift_min": 31.9,
+      "drift_median": 74.2,
+      "drift_max": 157.2,
+      "runs": [
+        {
+          "run_id": 32487766514,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-21T13:00:00Z",
+          "started_at": "2026-08-21T13:36:54Z",
+          "drift_minutes": 36.9
+        },
+        {
+          "run_id": 32375354662,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-20T13:00:00Z",
+          "started_at": "2026-08-20T13:37:46Z",
+          "drift_minutes": 37.8
+        },
+        {
+          "run_id": 32259023168,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-19T13:00:00Z",
+          "started_at": "2026-08-19T13:36:08Z",
+          "drift_minutes": 36.1
+        },
+        {
+          "run_id": 32143167046,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-18T13:00:00Z",
+          "started_at": "2026-08-18T13:34:40Z",
+          "drift_minutes": 34.7
+        },
+        {
+          "run_id": 32035614394,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-17T13:00:00Z",
+          "started_at": "2026-08-17T13:31:55Z",
+          "drift_minutes": 31.9
+        },
+        {
+          "run_id": 31808058435,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-14T13:00:00Z",
+          "started_at": "2026-08-14T14:08:34Z",
+          "drift_minutes": 68.6
+        },
+        {
+          "run_id": 31709161069,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-13T13:00:00Z",
+          "started_at": "2026-08-13T14:14:55Z",
+          "drift_minutes": 74.9
+        },
+        {
+          "run_id": 31605621406,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-12T13:00:00Z",
+          "started_at": "2026-08-12T14:13:37Z",
+          "drift_minutes": 73.6
+        },
+        {
+          "run_id": 31500261281,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-11T13:00:00Z",
+          "started_at": "2026-08-11T14:12:11Z",
+          "drift_minutes": 72.2
+        },
+        {
+          "run_id": 31396934676,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-10T13:00:00Z",
+          "started_at": "2026-08-10T14:12:49Z",
+          "drift_minutes": 72.8
+        },
+        {
+          "run_id": 31185800037,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-07T13:00:00Z",
+          "started_at": "2026-08-07T14:04:52Z",
+          "drift_minutes": 64.9
+        },
+        {
+          "run_id": 31114239678,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-06T13:00:00Z",
+          "started_at": "2026-08-06T15:06:25Z",
+          "drift_minutes": 126.4
+        },
+        {
+          "run_id": 31018703580,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-05T13:00:00Z",
+          "started_at": "2026-08-05T15:07:41Z",
+          "drift_minutes": 127.7
+        },
+        {
+          "run_id": 30923161219,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-04T13:00:00Z",
+          "started_at": "2026-08-04T15:14:53Z",
+          "drift_minutes": 134.9
+        },
+        {
+          "run_id": 30828345132,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-08-03T13:00:00Z",
+          "started_at": "2026-08-03T15:37:09Z",
+          "drift_minutes": 157.2
+        },
+        {
+          "run_id": 30641889055,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-07-31T13:00:00Z",
+          "started_at": "2026-07-31T15:12:29Z",
+          "drift_minutes": 132.5
+        },
+        {
+          "run_id": 30554667235,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-07-30T13:00:00Z",
+          "started_at": "2026-07-30T15:02:00Z",
+          "drift_minutes": 122.0
+        },
+        {
+          "run_id": 30464057012,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-07-29T13:00:00Z",
+          "started_at": "2026-07-29T15:04:22Z",
+          "drift_minutes": 124.4
+        },
+        {
+          "run_id": 30372133541,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-07-28T13:00:00Z",
+          "started_at": "2026-07-28T15:11:30Z",
+          "drift_minutes": 131.5
+        },
+        {
+          "run_id": 30280833657,
+          "cron": "0 13 * * 1-5",
+          "scheduled_at": "2026-07-27T13:00:00Z",
+          "started_at": "2026-07-27T15:36:51Z",
+          "drift_minutes": 156.8
+        }
+      ]
+    },
+    {
+      "workflow": "repo-traffic.yml",
+      "crons": [
+        "38 3 * * 2",
+        "38 3 * * 6"
+      ],
+      "samples": 0,
+      "note": "no scheduled runs yet"
+    },
+    {
+      "workflow": "screenshot-refresh.yml",
+      "crons": [
+        "0 22 * * 0"
+      ],
+      "samples": 14,
+      "drift_min": 28.9,
+      "drift_median": 63.9,
+      "drift_max": 83.5,
+      "runs": [
+        {
+          "run_id": 31976451145,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-08-16T22:00:00Z",
+          "started_at": "2026-08-16T22:28:51Z",
+          "drift_minutes": 28.9
+        },
+        {
+          "run_id": 31339910218,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-08-09T22:00:00Z",
+          "started_at": "2026-08-09T22:38:42Z",
+          "drift_minutes": 38.7
+        },
+        {
+          "run_id": 30771340359,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-08-02T22:00:00Z",
+          "started_at": "2026-08-02T23:00:41Z",
+          "drift_minutes": 60.7
+        },
+        {
+          "run_id": 30224437299,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-07-26T22:00:00Z",
+          "started_at": "2026-07-26T23:04:00Z",
+          "drift_minutes": 64.0
+        },
+        {
+          "run_id": 29707109553,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-07-19T22:00:00Z",
+          "started_at": "2026-07-19T22:58:34Z",
+          "drift_minutes": 58.6
+        },
+        {
+          "run_id": 29212485488,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-07-12T22:00:00Z",
+          "started_at": "2026-07-12T22:56:42Z",
+          "drift_minutes": 56.7
+        },
+        {
+          "run_id": 28758099849,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-07-05T22:00:00Z",
+          "started_at": "2026-07-05T23:08:55Z",
+          "drift_minutes": 68.9
+        },
+        {
+          "run_id": 28339237426,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-06-28T22:00:00Z",
+          "started_at": "2026-06-28T23:11:40Z",
+          "drift_minutes": 71.7
+        },
+        {
+          "run_id": 27920794443,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-06-21T22:00:00Z",
+          "started_at": "2026-06-21T23:23:27Z",
+          "drift_minutes": 83.5
+        },
+        {
+          "run_id": 27515232204,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-06-14T22:00:00Z",
+          "started_at": "2026-06-14T23:17:43Z",
+          "drift_minutes": 77.7
+        },
+        {
+          "run_id": 27107730491,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-06-07T22:00:00Z",
+          "started_at": "2026-06-07T23:13:21Z",
+          "drift_minutes": 73.3
+        },
+        {
+          "run_id": 26727188680,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-05-31T22:00:00Z",
+          "started_at": "2026-05-31T23:09:35Z",
+          "drift_minutes": 69.6
+        },
+        {
+          "run_id": 26375238646,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-05-24T22:00:00Z",
+          "started_at": "2026-05-24T23:03:40Z",
+          "drift_minutes": 63.7
+        },
+        {
+          "run_id": 26005221043,
+          "cron": "0 22 * * 0",
+          "scheduled_at": "2026-05-17T22:00:00Z",
+          "started_at": "2026-05-17T22:59:44Z",
+          "drift_minutes": 59.7
+        }
+      ]
+    },
+    {
+      "workflow": "sentiment-scan.yml",
+      "crons": [
+        "30 21 * * 0-4"
+      ],
+      "samples": 20,
+      "drift_min": 15.0,
+      "drift_median": 49.8,
+      "drift_max": 213.2,
+      "runs": [
+        {
+          "run_id": 32421667281,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-20T21:30:00Z",
+          "started_at": "2026-08-20T21:53:43Z",
+          "drift_minutes": 23.7
+        },
+        {
+          "run_id": 32305953238,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-19T21:30:00Z",
+          "started_at": "2026-08-19T21:51:00Z",
+          "drift_minutes": 21.0
+        },
+        {
+          "run_id": 32189616902,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-18T21:30:00Z",
+          "started_at": "2026-08-18T21:48:21Z",
+          "drift_minutes": 18.4
+        },
+        {
+          "run_id": 32073148609,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-17T21:30:00Z",
+          "started_at": "2026-08-17T21:50:30Z",
+          "drift_minutes": 20.5
+        },
+        {
+          "run_id": 31974408614,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-16T21:30:00Z",
+          "started_at": "2026-08-16T21:44:58Z",
+          "drift_minutes": 15.0
+        },
+        {
+          "run_id": 31748878736,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-13T21:30:00Z",
+          "started_at": "2026-08-13T22:10:56Z",
+          "drift_minutes": 40.9
+        },
+        {
+          "run_id": 31645788863,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-12T21:30:00Z",
+          "started_at": "2026-08-12T22:10:03Z",
+          "drift_minutes": 40.0
+        },
+        {
+          "run_id": 31541356615,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-11T21:30:00Z",
+          "started_at": "2026-08-11T22:11:51Z",
+          "drift_minutes": 41.9
+        },
+        {
+          "run_id": 31436909005,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-10T21:30:00Z",
+          "started_at": "2026-08-10T22:06:56Z",
+          "drift_minutes": 36.9
+        },
+        {
+          "run_id": 31338190760,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-09T21:30:00Z",
+          "started_at": "2026-08-09T21:58:13Z",
+          "drift_minutes": 28.2
+        },
+        {
+          "run_id": 31136749451,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-06T21:30:00Z",
+          "started_at": "2026-08-07T01:03:09Z",
+          "drift_minutes": 213.2
+        },
+        {
+          "run_id": 31053251041,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-05T21:30:00Z",
+          "started_at": "2026-08-05T22:34:18Z",
+          "drift_minutes": 64.3
+        },
+        {
+          "run_id": 30956993205,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-04T21:30:00Z",
+          "started_at": "2026-08-04T22:35:55Z",
+          "drift_minutes": 65.9
+        },
+        {
+          "run_id": 30859086772,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-03T21:30:00Z",
+          "started_at": "2026-08-03T22:33:17Z",
+          "drift_minutes": 63.3
+        },
+        {
+          "run_id": 30770145537,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-08-02T21:30:00Z",
+          "started_at": "2026-08-02T22:27:40Z",
+          "drift_minutes": 57.7
+        },
+        {
+          "run_id": 30587674509,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-07-30T21:30:00Z",
+          "started_at": "2026-07-30T22:35:25Z",
+          "drift_minutes": 65.4
+        },
+        {
+          "run_id": 30496300512,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-07-29T21:30:00Z",
+          "started_at": "2026-07-29T22:29:13Z",
+          "drift_minutes": 59.2
+        },
+        {
+          "run_id": 30405001647,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-07-28T21:30:00Z",
+          "started_at": "2026-07-28T22:33:53Z",
+          "drift_minutes": 63.9
+        },
+        {
+          "run_id": 30311145953,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-07-27T21:30:00Z",
+          "started_at": "2026-07-27T22:33:29Z",
+          "drift_minutes": 63.5
+        },
+        {
+          "run_id": 30223250405,
+          "cron": "30 21 * * 0-4",
+          "scheduled_at": "2026-07-26T21:30:00Z",
+          "started_at": "2026-07-26T22:30:02Z",
+          "drift_minutes": 60.0
+        }
+      ]
+    },
+    {
+      "workflow": "seo-visibility.yml",
+      "crons": [
+        "30 6 * * 1"
+      ],
+      "samples": 1,
+      "drift_min": 64.5,
+      "drift_median": 64.5,
+      "drift_max": 64.5,
+      "runs": [
+        {
+          "run_id": 32006409806,
+          "cron": "30 6 * * 1",
+          "scheduled_at": "2026-08-17T06:30:00Z",
+          "started_at": "2026-08-17T07:34:27Z",
+          "drift_minutes": 64.5
+        }
+      ]
+    },
+    {
+      "workflow": "weekly-health.yml",
+      "crons": [
+        "0 23 * * 0"
+      ],
+      "samples": 14,
+      "drift_min": 13.8,
+      "drift_median": 56.0,
+      "drift_max": 66.5,
+      "runs": [
+        {
+          "run_id": 31978539398,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-08-16T23:00:00Z",
+          "started_at": "2026-08-16T23:13:49Z",
+          "drift_minutes": 13.8
+        },
+        {
+          "run_id": 31341824876,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-08-09T23:00:00Z",
+          "started_at": "2026-08-09T23:24:54Z",
+          "drift_minutes": 24.9
+        },
+        {
+          "run_id": 30773203831,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-08-02T23:00:00Z",
+          "started_at": "2026-08-02T23:53:36Z",
+          "drift_minutes": 53.6
+        },
+        {
+          "run_id": 30226284201,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-07-26T23:00:00Z",
+          "started_at": "2026-07-26T23:55:53Z",
+          "drift_minutes": 55.9
+        },
+        {
+          "run_id": 29708619649,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-07-19T23:00:00Z",
+          "started_at": "2026-07-19T23:52:19Z",
+          "drift_minutes": 52.3
+        },
+        {
+          "run_id": 29214046299,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-07-12T23:00:00Z",
+          "started_at": "2026-07-12T23:47:58Z",
+          "drift_minutes": 48.0
+        },
+        {
+          "run_id": 28759456729,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-07-05T23:00:00Z",
+          "started_at": "2026-07-06T00:01:30Z",
+          "drift_minutes": 61.5
+        },
+        {
+          "run_id": 28340525012,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-06-28T23:00:00Z",
+          "started_at": "2026-06-29T00:03:25Z",
+          "drift_minutes": 63.4
+        },
+        {
+          "run_id": 27921866007,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-06-21T23:00:00Z",
+          "started_at": "2026-06-22T00:06:27Z",
+          "drift_minutes": 66.5
+        },
+        {
+          "run_id": 27516349229,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-06-14T23:00:00Z",
+          "started_at": "2026-06-15T00:04:24Z",
+          "drift_minutes": 64.4
+        },
+        {
+          "run_id": 27108804408,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-06-07T23:00:00Z",
+          "started_at": "2026-06-08T00:02:18Z",
+          "drift_minutes": 62.3
+        },
+        {
+          "run_id": 26728327981,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-05-31T23:00:00Z",
+          "started_at": "2026-06-01T00:03:10Z",
+          "drift_minutes": 63.2
+        },
+        {
+          "run_id": 26376342860,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-05-24T23:00:00Z",
+          "started_at": "2026-05-24T23:56:00Z",
+          "drift_minutes": 56.0
+        },
+        {
+          "run_id": 26006392167,
+          "cron": "0 23 * * 0",
+          "scheduled_at": "2026-05-17T23:00:00Z",
+          "started_at": "2026-05-17T23:53:57Z",
+          "drift_minutes": 54.0
+        }
+      ]
+    },
+    {
+      "workflow": "weekly-review.yml",
+      "crons": [
+        "0 14 * * 0"
+      ],
+      "samples": 13,
+      "drift_min": 13.7,
+      "drift_median": 56.4,
+      "drift_max": 106.2,
+      "runs": [
+        {
+          "run_id": 31952091127,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-08-16T14:00:00Z",
+          "started_at": "2026-08-16T14:13:42Z",
+          "drift_minutes": 13.7
+        },
+        {
+          "run_id": 31318380705,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-08-09T14:00:00Z",
+          "started_at": "2026-08-09T14:25:00Z",
+          "drift_minutes": 25.0
+        },
+        {
+          "run_id": 30753127819,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-08-02T14:00:00Z",
+          "started_at": "2026-08-02T14:53:55Z",
+          "drift_minutes": 53.9
+        },
+        {
+          "run_id": 30207132993,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-07-26T14:00:00Z",
+          "started_at": "2026-07-26T14:56:23Z",
+          "drift_minutes": 56.4
+        },
+        {
+          "run_id": 29691534108,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-07-19T14:00:00Z",
+          "started_at": "2026-07-19T14:47:36Z",
+          "drift_minutes": 47.6
+        },
+        {
+          "run_id": 29196932815,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-07-12T14:00:00Z",
+          "started_at": "2026-07-12T14:47:29Z",
+          "drift_minutes": 47.5
+        },
+        {
+          "run_id": 28745059371,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-07-05T14:00:00Z",
+          "started_at": "2026-07-05T15:06:28Z",
+          "drift_minutes": 66.5
+        },
+        {
+          "run_id": 28326585691,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-06-28T14:00:00Z",
+          "started_at": "2026-06-28T15:12:34Z",
+          "drift_minutes": 72.6
+        },
+        {
+          "run_id": 27909402749,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-06-21T14:00:00Z",
+          "started_at": "2026-06-21T15:46:14Z",
+          "drift_minutes": 106.2
+        },
+        {
+          "run_id": 27503859156,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-06-14T14:00:00Z",
+          "started_at": "2026-06-14T15:43:15Z",
+          "drift_minutes": 103.2
+        },
+        {
+          "run_id": 27096548327,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-06-07T14:00:00Z",
+          "started_at": "2026-06-07T15:19:12Z",
+          "drift_minutes": 79.2
+        },
+        {
+          "run_id": 26716330779,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-05-31T14:00:00Z",
+          "started_at": "2026-05-31T15:13:13Z",
+          "drift_minutes": 73.2
+        },
+        {
+          "run_id": 26364527824,
+          "cron": "0 14 * * 0",
+          "scheduled_at": "2026-05-24T14:00:00Z",
+          "started_at": "2026-05-24T14:56:17Z",
+          "drift_minutes": 56.3
+        }
+      ]
+    }
+  ]
+}

--- a/ops/ci/schedule_drift.py
+++ b/ops/ci/schedule_drift.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Measure how late GitHub actually delivers this repository's scheduled runs.
+
+Every scheduled workflow here is late, systematically, and until #781 nobody
+kept a number. Measured 2026-08-21 over the last 5-8 runs of each workflow:
+
+    45 21 / 40 21   +10..15 min      30 21   +14..23 min
+    0 22 / 0 23     +13..71 min      17 9    +30..63 min
+    0 13 / 50 12    +31..74 min      25 0    +89..159 min
+
+Two things follow, and both were being got wrong:
+
+  - What drives the delay is the **UTC hour**, not whether the minute is round.
+    `cron-health.yml` carried a comment saying the opposite ("避开整点" avoids
+    delay) while sitting at `17 9` and drifting 30-63 minutes. A workflow whose
+    value depends on arriving before a deadline cannot be scheduled by picking
+    a nice-looking minute.
+  - The delay is large enough to invalidate a design. brief-fallback's own
+    lateness gate turns it off at 10:00 HKT, and GitHub was delivering it at
+    11:00-12:30 HKT (#780).
+
+`drift = run.created_at - the cron instant it was scheduled for`. GitHub does
+not report the scheduled instant, so it is reconstructed: the most recent cron
+occurrence at or before `created_at`, searched back over a bounded window. A run
+delayed past its own next occurrence would be attributed to that later one, so
+the reported drift is a **lower bound** — which is the right direction to be
+wrong in for a number used to argue that things are late.
+
+Usage:
+    schedule_drift.py                 # merge into assets/data/schedule-drift.json
+    schedule_drift.py --print         # table only, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import statistics
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO = os.environ.get("CLAWOCK_TRAFFIC_REPO", "KCNyu/clawock")
+DEFAULT_OUT = Path(__file__).resolve().parents[2] / "assets" / "data" / "schedule-drift.json"
+WORKFLOW_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+RUNS_PER_WORKFLOW = 20
+# How far back to search for the cron occurrence a run belongs to. Beyond this a
+# run is left unattributed rather than matched to a guess.
+LOOKBACK_MINUTES = 24 * 60
+
+
+class DriftError(RuntimeError):
+    pass
+
+
+def _api(path: str, token: str) -> Any:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "clawock-schedule-drift (+https://github.com/KCNyu/clawock)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise DriftError(f"{path} -> HTTP {exc.code} {exc.reason}") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise DriftError(f"{path} -> {exc}") from exc
+
+
+def _cron_fields(expr: str) -> tuple[set[int], set[int], set[int]]:
+    """Parse the minute, hour and day-of-week fields of a 5-field cron.
+
+    Only the forms this repository actually uses: `*`, a number, a `a-b` range,
+    and comma lists of those. Anything else raises rather than silently matching
+    everything, because a cron nobody can parse must not be reported as
+    perfectly on time.
+    """
+    parts = expr.split()
+    if len(parts) != 5:
+        raise DriftError(f"not a 5-field cron: {expr!r}")
+
+    def field(raw: str, low: int, high: int) -> set[int]:
+        if raw == "*":
+            return set(range(low, high + 1))
+        out: set[int] = set()
+        try:
+            for chunk in raw.split(","):
+                if "-" in chunk:
+                    a, b = chunk.split("-", 1)
+                    out |= set(range(int(a), int(b) + 1))
+                else:
+                    out.add(int(chunk))
+        except ValueError as exc:
+            # Steps (`*/5`) and names (`MON`) are valid cron this parser does
+            # not implement. Raising is the point: treating an unread field as
+            # `*` would report a late workflow as perfectly punctual.
+            raise DriftError(f"unsupported cron field {raw!r} in {expr!r}") from exc
+        if not out or min(out) < low or max(out) > high:
+            raise DriftError(f"cron field {raw!r} out of range in {expr!r}")
+        return out
+
+    minutes = field(parts[0], 0, 59)
+    hours = field(parts[1], 0, 23)
+    dow = {d % 7 for d in field(parts[4], 0, 7)}  # cron allows both 0 and 7 for Sunday
+    if parts[2] != "*" or parts[3] != "*":
+        raise DriftError(f"day-of-month/month fields are not supported: {expr!r}")
+    return minutes, hours, dow
+
+
+def previous_occurrence(expr: str, when: dt.datetime) -> dt.datetime | None:
+    """The latest cron instant at or before `when`, within the lookback window."""
+    minutes, hours, dow = _cron_fields(expr)
+    cursor = when.replace(second=0, microsecond=0)
+    for _ in range(LOOKBACK_MINUTES + 1):
+        # cron's day-of-week is Sunday=0; Python's weekday() is Monday=0.
+        if (cursor.minute in minutes and cursor.hour in hours
+                and ((cursor.weekday() + 1) % 7) in dow):
+            return cursor
+        cursor -= dt.timedelta(minutes=1)
+    return None
+
+
+def scheduled_crons(path: Path) -> list[str]:
+    """Cron expressions of a workflow, read as text.
+
+    Deliberately not a YAML parse: `on:` is the YAML 1.1 boolean and the schedule
+    block is unambiguous as text, so this stays dependency-free and cannot be
+    thrown off by the rest of the file.
+    """
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- cron:"):
+            out.append(stripped.split(":", 1)[1].strip().strip("'\""))
+    return out
+
+
+def measure(token: str, workflows: Iterable[Path]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(workflows):
+        crons = scheduled_crons(path)
+        if not crons:
+            continue
+        try:
+            runs = _api(f"actions/workflows/{path.name}/runs"
+                        f"?event=schedule&per_page={RUNS_PER_WORKFLOW}", token)
+        except DriftError as exc:
+            # A newly added workflow has no run history yet, and GitHub answers
+            # 404 rather than an empty list. That is not a measurement failure.
+            if "404" in str(exc):
+                rows.append({"workflow": path.name, "crons": crons,
+                             "samples": 0, "note": "no scheduled runs yet"})
+                continue
+            raise
+        samples: list[dict[str, Any]] = []
+        for run in runs.get("workflow_runs", []):
+            created = dt.datetime.fromisoformat(
+                run["created_at"].replace("Z", "+00:00")).replace(tzinfo=None)
+            # A workflow with several crons: attribute the run to whichever
+            # occurrence is closest before it.
+            best: tuple[float, str, dt.datetime] | None = None
+            for expr in crons:
+                occurrence = previous_occurrence(expr, created)
+                if occurrence is None:
+                    continue
+                delta = (created - occurrence).total_seconds() / 60
+                if best is None or delta < best[0]:
+                    best = (delta, expr, occurrence)
+            if best is None:
+                continue
+            samples.append({
+                "run_id": run["id"],
+                "cron": best[1],
+                "scheduled_at": best[2].isoformat() + "Z",
+                "started_at": run["created_at"],
+                "drift_minutes": round(best[0], 1),
+            })
+        if not samples:
+            continue
+        drifts = [s["drift_minutes"] for s in samples]
+        rows.append({
+            "workflow": path.name,
+            "crons": crons,
+            "samples": len(samples),
+            "drift_min": min(drifts),
+            "drift_median": round(statistics.median(drifts), 1),
+            "drift_max": max(drifts),
+            "runs": samples,
+        })
+    return rows
+
+
+def render(rows: list[dict[str, Any]]) -> str:
+    lines = [f"{'workflow':<28} {'cron(s)':<26} {'n':>3} {'min':>7} {'med':>7} {'max':>7}"]
+    for row in sorted(rows, key=lambda r: -r.get("drift_median", -1)):
+        if not row["samples"]:
+            lines.append(f"{row['workflow']:<28} {','.join(row['crons'])[:26]:<26} "
+                         f"{0:>3} {'—':>7} {'—':>7} {'—':>7}")
+            continue
+        lines.append(
+            f"{row['workflow']:<28} {','.join(row['crons'])[:26]:<26} "
+            f"{row['samples']:>3} {row['drift_min']:>7.1f} "
+            f"{row['drift_median']:>7.1f} {row['drift_max']:>7.1f}"
+        )
+    lines.append("")
+    lines.append("drift in minutes; a lower bound (a run delayed past its own next "
+                 "occurrence is attributed to that later one)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--print", dest="dry_run", action="store_true")
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("::error::GITHUB_TOKEN/GH_TOKEN is unset — drift cannot be measured, "
+              "and a missing measurement is not a measurement of zero", file=sys.stderr)
+        return 2
+
+    try:
+        rows = measure(token, WORKFLOW_DIR.glob("*.yml"))
+    except DriftError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    print(render(rows))
+    if args.dry_run:
+        return 0
+
+    payload = {
+        "generated_at": dt.datetime.now(dt.timezone.utc)
+            .replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repo": REPO,
+        "note": ("drift_minutes = run.created_at - the reconstructed cron instant. "
+                 "GitHub does not report the scheduled instant, so a run delayed "
+                 "past its own next occurrence is attributed to that later one: "
+                 "every figure here is a lower bound."),
+        "workflows": rows,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+                        encoding="utf-8")
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -72,6 +72,27 @@ ANTHROPIC_VERSION = '2023-06-01'
 TIMEOUT = 180  # 3 min per call
 MAX_RETRIES = 3
 
+# A total wall-clock budget shared by the whole provider chain, in seconds.
+#
+# Without one the retry ladder can be longer than the job that contains it, and
+# then the second provider is not a fallback — it is unreachable code. Measured
+# on 2026-08-17 (release run 31985473431): brief_fallback calls chat() with
+# timeout=900 and MAX_RETRIES is 3, so MiniMax alone may spend 45 minutes inside
+# a job whose `timeout-minutes` is 15. MiniMax hit RemoteDisconnected, started
+# retrying, and the runner killed the job before opencode-go was ever asked.
+# Every manual dispatch of that workflow failed the same way, which is why a
+# backstop nobody had ever seen produce output looked merely untested rather
+# than broken.
+#
+# Set it from the workflow that knows its own job budget, via
+# CLAWOCK_LLM_DEADLINE_SECONDS, or pass deadline_seconds= explicitly. Unset
+# keeps the historical behaviour exactly.
+DEADLINE_ENV = 'CLAWOCK_LLM_DEADLINE_SECONDS'
+# The share of the budget the primary may consume before the chain moves on.
+# The remainder is reserved for the fallback, so a slow primary can cost the
+# run quality but never the fallback's chance to answer.
+PRIMARY_BUDGET_SHARE = 0.6
+
 
 def _clean(s: str) -> str:
     """Strip a leading assistant-prefill artifact and an outer ```/```json fence
@@ -131,8 +152,46 @@ def _split_system(messages):
     return '\n\n'.join(p for p in sys_parts if p), rest
 
 
+def _remaining(deadline):
+    """Seconds left before the chain must give up on this provider, or None."""
+    if deadline is None:
+        return None
+    return deadline - time.monotonic()
+
+
+def _attempt_timeout(timeout, deadline, label):
+    """Per-attempt timeout clamped to the budget, or None when out of time.
+
+    Returning None rather than sleeping-then-failing matters: the point of the
+    budget is to hand the remaining seconds to the next provider while there
+    are still seconds to hand over.
+    """
+    left = _remaining(deadline)
+    if left is None:
+        return timeout
+    if left <= 1:
+        print(f'  {label}: budget exhausted — yielding to the next provider',
+              file=sys.stderr)
+        return None
+    return max(1, min(timeout, int(left)))
+
+
+def _backoff(seconds, deadline, label):
+    """Sleep between attempts without spending the next provider's seconds.
+
+    An un-clamped backoff is the same bug as an un-clamped timeout, only more
+    embarrassing: the budget gets burned doing nothing at all.
+    """
+    left = _remaining(deadline)
+    if left is not None:
+        seconds = min(seconds, max(0.0, left))
+    if seconds > 0:
+        time.sleep(seconds)
+
+
 def _call_provider(label, base_url, api_key, model, messages, max_tokens,
-                   temperature, json_response, thinking, timeout=None):
+                   temperature, json_response, thinking, timeout=None,
+                   deadline=None):
     """One provider over Anthropic Messages, with retries. Returns content str
     or raises RuntimeError."""
     timeout = timeout or TIMEOUT
@@ -169,9 +228,13 @@ def _call_provider(label, base_url, api_key, model, messages, max_tokens,
 
     last_err = None
     for attempt in range(1, MAX_RETRIES + 1):
+        per_attempt = _attempt_timeout(timeout, deadline, label)
+        if per_attempt is None:
+            last_err = last_err or 'budget exhausted before any attempt completed'
+            break
         try:
             r = requests.post(f'{base_url}/v1/messages',
-                              json=body, headers=headers, timeout=timeout)
+                              json=body, headers=headers, timeout=per_attempt)
             if r.status_code == 200:
                 data = r.json()
                 blocks = data.get('content', []) or []
@@ -189,24 +252,24 @@ def _call_provider(label, base_url, api_key, model, messages, max_tokens,
             elif r.status_code == 429:
                 wait = 5 * attempt
                 print(f'  {label}: 429 rate limit, sleeping {wait}s', file=sys.stderr)
-                time.sleep(wait)
+                _backoff(wait, deadline, label)
                 continue
             else:
                 last_err = f'HTTP {r.status_code}: {r.text[:300]}'
                 print(f'  {label}: {last_err}', file=sys.stderr)
         except requests.Timeout:
-            last_err = 'timeout after 180s'
+            last_err = f'timeout after {per_attempt}s'
             print(f'  {label}: {last_err} (attempt {attempt})', file=sys.stderr)
         except Exception as e:
             last_err = f'{type(e).__name__}: {e}'
             print(f'  {label}: {last_err}', file=sys.stderr)
-        time.sleep(2 * attempt)
+        _backoff(2 * attempt, deadline, label)
     raise RuntimeError(f'{label} failed after {MAX_RETRIES} attempts: {last_err}')
 
 
 def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
                                      max_tokens, temperature, json_response,
-                                     thinking, timeout=None):
+                                     thinking, timeout=None, deadline=None):
     """One provider over the OpenAI-compatible /chat/completions shape, with
     retries. Returns content str or raises RuntimeError. Unlike Anthropic
     Messages: system stays inline as a message role (no lift-out needed), and
@@ -226,9 +289,13 @@ def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
 
     last_err = None
     for attempt in range(1, MAX_RETRIES + 1):
+        per_attempt = _attempt_timeout(timeout, deadline, label)
+        if per_attempt is None:
+            last_err = last_err or 'budget exhausted before any attempt completed'
+            break
         try:
             r = requests.post(f'{base_url}/chat/completions',
-                              json=body, headers=headers, timeout=timeout)
+                              json=body, headers=headers, timeout=per_attempt)
             if r.status_code == 200:
                 data = r.json()
                 choices = data.get('choices', []) or []
@@ -244,18 +311,18 @@ def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
             elif r.status_code == 429:
                 wait = 5 * attempt
                 print(f'  {label}: 429 rate limit, sleeping {wait}s', file=sys.stderr)
-                time.sleep(wait)
+                _backoff(wait, deadline, label)
                 continue
             else:
                 last_err = f'HTTP {r.status_code}: {r.text[:300]}'
                 print(f'  {label}: {last_err}', file=sys.stderr)
         except requests.Timeout:
-            last_err = 'timeout after 180s'
+            last_err = f'timeout after {per_attempt}s'
             print(f'  {label}: {last_err} (attempt {attempt})', file=sys.stderr)
         except Exception as e:
             last_err = f'{type(e).__name__}: {e}'
             print(f'  {label}: {last_err}', file=sys.stderr)
-        time.sleep(2 * attempt)
+        _backoff(2 * attempt, deadline, label)
     raise RuntimeError(f'{label} failed after {MAX_RETRIES} attempts: {last_err}')
 
 
@@ -264,7 +331,7 @@ def chat(system: str = '', user: str = '', messages: list = None,
          model: str = OPENCODE_MODEL, base_url: str = OPENCODE_BASE,
          api_key: str = None, thinking_disabled: bool = False,
          json_response: bool = False, fallback: bool = True,
-         timeout: int = None) -> str:
+         timeout: int = None, deadline_seconds: float = None) -> str:
     """Call MiniMax M3; on total failure fall back to opencode-go's DeepSeek V4
     Flash. The two are NOT the same wire protocol (Anthropic Messages vs
     OpenAI-compatible) — see module docstring. Returns assistant content
@@ -274,8 +341,16 @@ def chat(system: str = '', user: str = '', messages: list = None,
     timeout: per-attempt seconds, default TIMEOUT (180). Big jobs need more: the
     daily brief prefills ~100KB of context and generates ~20K tokens with thinking
     on, which blew straight through 180s x3 on 2026-07-16 (callers see the retries
-    as "timeout after 180s (attempt N)"). Raise it rather than shrink the prompt —
+    as "timeout after Ns (attempt N)"). Raise it rather than shrink the prompt —
     trimming the brief's context is what made it blind to half the book.
+
+    deadline_seconds: total wall clock for the WHOLE chain, defaulting to
+    CLAWOCK_LLM_DEADLINE_SECONDS. `timeout` alone cannot keep the chain inside
+    the job that contains it — timeout x MAX_RETRIES is the primary's budget,
+    and on 2026-08-17 that was 45 minutes inside a 15-minute job, so opencode-go
+    was never reached even once. With a budget set, the primary is capped at
+    PRIMARY_BUDGET_SHARE of it and the remainder belongs to the fallback: a slow
+    primary can cost quality, never the fallback's chance to answer.
     """
     if messages is None:
         messages = []
@@ -287,13 +362,27 @@ def chat(system: str = '', user: str = '', messages: list = None,
     thinking = {'type': 'disabled'} if thinking_disabled else {'type': 'enabled'}
     errors = []
 
+    if deadline_seconds is None:
+        raw = os.environ.get(DEADLINE_ENV)
+        if raw:
+            try:
+                deadline_seconds = float(raw)
+            except ValueError:
+                print(f'  ⚠️ {DEADLINE_ENV}={raw!r} is not a number — ignoring',
+                      file=sys.stderr)
+    started = time.monotonic()
+    chain_deadline = None if not deadline_seconds else started + float(deadline_seconds)
+    primary_deadline = (None if chain_deadline is None
+                        else started + float(deadline_seconds) * PRIMARY_BUDGET_SHARE)
+
     # ── Primary: MiniMax M3 (Anthropic Messages) ──
     mm_key = os.environ.get('MINIMAX_API_KEY')
     if mm_key:
         try:
             return _call_provider('minimax', MINIMAX_BASE, mm_key, MINIMAX_MODEL,
                                   messages, min(max_tokens, MINIMAX_MAX_TOKENS),
-                                  temperature, json_response, thinking, timeout)
+                                  temperature, json_response, thinking, timeout,
+                                  deadline=primary_deadline)
         except Exception as e:
             errors.append(f'minimax[{e}]')
             print('  ⚠️ minimax exhausted — falling back to opencode-go DeepSeek V4 Flash',
@@ -311,7 +400,8 @@ def chat(system: str = '', user: str = '', messages: list = None,
             return _call_provider_openai_compatible(
                 'opencode', base_url, opencode_key, model, messages,
                 min(max_tokens, OPENCODE_MAX_TOKENS),
-                temperature, json_response, thinking, timeout)
+                temperature, json_response, thinking, timeout,
+                deadline=chain_deadline)
         except Exception as e:
             errors.append(f'opencode[{e}]')
     elif fallback and not opencode_key:

--- a/tests/test_brief_fallback_workflow_contract.py
+++ b/tests/test_brief_fallback_workflow_contract.py
@@ -1,0 +1,147 @@
+"""The backstop has to be able to run, and its silence has to be visible.
+
+Between 2026-07-07 and 2026-08-21, brief-fallback had 34 scheduled runs. All 34
+finished in 11-21 seconds on the "already exists" branch. The only five runs
+that ever reached the generation branch were manual dispatches, and all five
+failed. Nothing anywhere could see either fact, so the backstop read as healthy.
+
+These assertions cover the three defects behind that, and they are written
+against the mechanism rather than the wording, because the wording will change.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "brief-fallback.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    # `on:` is the YAML 1.1 boolean True, which is why this reads it back with
+    # a lookup rather than the obvious key.
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def job(workflow) -> dict:
+    return workflow["jobs"]["fallback"]
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow) -> dict:
+    return workflow[True] if True in workflow else workflow["on"]
+
+
+def _steps_by_name(job) -> dict:
+    return {step.get("name", ""): step for step in job["steps"]}
+
+
+def test_the_provider_chain_is_given_less_time_than_the_job(job):
+    """The defect that killed every manual dispatch.
+
+    `timeout` is per attempt, so timeout=900 with MAX_RETRIES=3 is a 45-minute
+    budget for the primary alone — inside a job whose limit was 15 minutes. The
+    runner killed the job mid-retry and opencode-go was never asked. A budget
+    for the whole chain is the only thing that can express "finish in time".
+    """
+    budget = float(job["env"]["CLAWOCK_LLM_DEADLINE_SECONDS"])
+    job_seconds = float(job["timeout-minutes"]) * 60
+    assert budget < job_seconds, (
+        "the LLM budget must fit inside the job, or the second provider is "
+        "unreachable code rather than a fallback"
+    )
+    assert job_seconds - budget >= 300, (
+        "postflight, the dashboard rebuild and the push still have to fit in "
+        "what is left"
+    )
+
+
+def test_the_backstop_gets_more_than_one_shot_at_its_window(triggers):
+    """Measured drift for this slot is +89..159 minutes, which lands the run at
+    or past its own `HOUR >= 10 HKT` gate. One attempt is a coin flip; the skip
+    check is idempotent, so extra attempts cost seconds."""
+    weekday = [c["cron"] for c in triggers["schedule"] if c["cron"].endswith("1-5")]
+    assert len(weekday) >= 3, "one scheduled attempt cannot absorb the measured drift"
+
+    minutes = sorted(int(c.split()[0]) + 60 * int(c.split()[1]) for c in weekday)
+    assert minutes[0] >= 25, (
+        "nothing may fire before 00:25 UTC — earlier races the primary brief "
+        "that is still generating, which is what produced a duplicate on 2026-06-10"
+    )
+    assert minutes[-1] <= 90, (
+        "an attempt scheduled past 01:30 UTC cannot land inside the usefulness "
+        "window even with no drift at all"
+    )
+
+
+def test_a_rehearsal_exists_and_can_never_publish(job):
+    """Five manual dispatches all failed and nobody learned anything from it,
+    because the only way to exercise the chain was to run it for real. A drill
+    that could publish would not be a drill."""
+    steps = _steps_by_name(job)
+    rehearsal = next((n for n in steps if "Rehearsal" in n), None)
+    assert rehearsal, "there must be a way to exercise the generation chain on purpose"
+
+    publishing = [name for name, step in steps.items()
+                  if "safe_push" in str(step.get("run", ""))
+                  or "postflight" in str(step.get("run", ""))
+                  or "Commit" in name]
+    assert publishing, "this test is worthless if it stops matching the publishing steps"
+    for name in publishing:
+        assert "!= 'rehearsal'" in steps[name].get("if", ""), (
+            f"step {name!r} can run during a rehearsal — a drill must not "
+            "publish, commit or push"
+        )
+
+
+def test_the_rehearsal_fails_when_the_chain_produces_nothing(job):
+    """A rehearsal that passes whatever happens answers no question at all."""
+    steps = _steps_by_name(job)
+    rehearsal = next(step for name, step in steps.items() if "Rehearsal" in name)
+    run = rehearsal["run"]
+    assert "::error::" in run and "exit 1" in run, (
+        "the rehearsal must go red when no brief was produced"
+    )
+
+
+def test_the_rehearsal_runs_on_a_trading_day(triggers):
+    """preflight on a closed market produces a red that says nothing about
+    whether the backstop works — the false-red pattern this repo keeps paying
+    for."""
+    schedules = [c["cron"] for c in triggers["schedule"]]
+    rehearsal = [c for c in schedules if not c.endswith("1-5")]
+    assert rehearsal, "the rehearsal must be scheduled, not only dispatchable"
+    for cron in rehearsal:
+        dow = cron.split()[4]
+        assert dow not in {"0", "6", "7"}, f"{cron} falls on a weekend"
+
+
+def test_every_branch_of_the_skip_decision_is_recorded(job):
+    """The whole defect was six weeks of green runs that never entered the
+    generation branch, with nothing able to notice."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    decision = text.split("id: check", 1)[1].split("- name:", 1)[0]
+    branches = set(re.findall(r'branch=([a-z-]+)', decision))
+    assert branches == {"rehearsal", "already-exists", "too-late", "generated"}, (
+        f"a skip path with no recorded branch is an invisible one: {branches}"
+    )
+
+    steps = _steps_by_name(job)
+    recorder = next(step for name, step in steps.items() if "Record which branch" in name)
+    assert recorder.get("if") == "always()", (
+        "the branch record is the only trace a skipped run leaves; it cannot "
+        "itself be conditional"
+    )
+
+
+def test_declining_to_help_is_a_warning_not_a_silence():
+    """`too-late` means: the primary may have failed and nothing replaced it.
+    That is the one outcome that must never scroll past unremarked."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    late = text.split('elif [ "$HOUR" -ge 10 ]', 1)[1].split("else", 1)[0]
+    assert "::warning::" in late

--- a/tests/test_llm_chain_budget.py
+++ b/tests/test_llm_chain_budget.py
@@ -1,0 +1,110 @@
+"""The fallback provider has to be reachable inside the job that calls it.
+
+2026-08-17, release run 31985473431: brief_fallback calls chat() with
+timeout=900 and MAX_RETRIES is 3, so MiniMax alone may spend 45 minutes — inside
+a job whose `timeout-minutes` is 15. MiniMax hit RemoteDisconnected, began
+retrying, and the runner killed the job. opencode-go was never asked. Every
+manual dispatch of brief-fallback failed exactly this way, which is why a
+backstop that had never once produced output looked untested rather than broken.
+
+A per-attempt timeout cannot express "the chain must finish in time". Only a
+budget can, and only if the primary is forbidden from spending all of it.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from clawock.automation import llm
+
+
+class _Boom(Exception):
+    pass
+
+
+@pytest.fixture
+def keys(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "x")
+    monkeypatch.setenv("OPENCODE_API_KEY", "y")
+    monkeypatch.delenv(llm.DEADLINE_ENV, raising=False)
+
+
+def _record(monkeypatch, primary_delay: float):
+    """Primary burns `primary_delay` per attempt and always fails; fallback answers."""
+    seen: dict = {"primary_attempts": 0, "fallback_called": False,
+                  "primary_timeouts": [], "fallback_timeout": None}
+
+    def fake_primary(label, base_url, api_key, model, messages, max_tokens,
+                     temperature, json_response, thinking, timeout=None, deadline=None):
+        while True:
+            per = llm._attempt_timeout(timeout, deadline, label)
+            if per is None:
+                break
+            seen["primary_attempts"] += 1
+            seen["primary_timeouts"].append(per)
+            # A real attempt cannot outlive the timeout it was given; requests
+            # enforces that. The fake has to model it or it is testing a
+            # provider that ignores its own deadline.
+            time.sleep(min(primary_delay, per))
+            if seen["primary_attempts"] >= llm.MAX_RETRIES:
+                break
+        raise RuntimeError("primary exhausted")
+
+    def fake_fallback(label, base_url, api_key, model, messages, max_tokens,
+                      temperature, json_response, thinking, timeout=None, deadline=None):
+        seen["fallback_called"] = True
+        seen["fallback_timeout"] = llm._attempt_timeout(timeout, deadline, label)
+        return "fallback answered"
+
+    monkeypatch.setattr(llm, "_call_provider", fake_primary)
+    monkeypatch.setattr(llm, "_call_provider_openai_compatible", fake_fallback)
+    return seen
+
+
+def test_a_slow_primary_cannot_spend_the_whole_budget(keys, monkeypatch):
+    """The regression itself: without a budget the primary's retry ladder
+    outlives the job and the fallback is unreachable code."""
+    seen = _record(monkeypatch, primary_delay=30.0)  # a primary that would hang forever
+    assert llm.chat(user="hi", timeout=900, deadline_seconds=6.0) == "fallback answered"
+    assert seen["fallback_called"], "the fallback must still get its turn"
+    assert seen["fallback_timeout"] is not None and seen["fallback_timeout"] >= 1
+
+
+def test_the_primary_is_capped_at_its_declared_share(keys, monkeypatch):
+    seen = _record(monkeypatch, primary_delay=0)
+    llm.chat(user="hi", timeout=900, deadline_seconds=10.0)
+    # Each attempt is clamped to what is left of the primary's slice, never to
+    # the caller's optimistic 900s.
+    assert seen["primary_timeouts"], "the primary must have been tried"
+    assert max(seen["primary_timeouts"]) <= 10.0 * llm.PRIMARY_BUDGET_SHARE + 1
+
+
+def test_the_budget_can_come_from_the_environment(keys, monkeypatch):
+    """The workflow is the thing that knows its own job budget, and it can only
+    speak to the script through the environment."""
+    monkeypatch.setenv(llm.DEADLINE_ENV, "10")
+    seen = _record(monkeypatch, primary_delay=0)
+    llm.chat(user="hi", timeout=900)
+    assert max(seen["primary_timeouts"]) <= 10.0 * llm.PRIMARY_BUDGET_SHARE + 1
+
+
+def test_a_junk_budget_is_ignored_loudly_and_never_shortens_a_call(keys, monkeypatch, capsys):
+    monkeypatch.setenv(llm.DEADLINE_ENV, "soon")
+    seen = _record(monkeypatch, primary_delay=0)
+    llm.chat(user="hi", timeout=900)
+    assert "not a number" in capsys.readouterr().err
+    assert seen["primary_timeouts"] == [900] * llm.MAX_RETRIES
+
+
+def test_no_budget_keeps_the_historical_behaviour_exactly(keys, monkeypatch):
+    seen = _record(monkeypatch, primary_delay=0)
+    llm.chat(user="hi", timeout=900)
+    assert seen["primary_timeouts"] == [900] * llm.MAX_RETRIES
+
+
+def test_an_exhausted_budget_yields_instead_of_burning_the_last_seconds():
+    assert llm._attempt_timeout(900, time.monotonic() - 5, "x") is None
+    assert llm._attempt_timeout(900, None, "x") == 900
+    clamped = llm._attempt_timeout(900, time.monotonic() + 30, "x")
+    assert 25 <= clamped <= 30

--- a/tests/test_schedule_drift.py
+++ b/tests/test_schedule_drift.py
@@ -1,0 +1,115 @@
+"""Reconstructing which cron instant a scheduled run belongs to.
+
+GitHub does not report the instant a scheduled run was meant to fire, only when
+it actually started. Drift is therefore a reconstruction, and a wrong
+reconstruction produces a confident wrong number — which is worse than no number
+for an argument that is entirely about numbers.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "schedule_drift", ROOT / "ops" / "ci" / "schedule_drift.py")
+drift = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(drift)
+
+
+def at(s: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(s)
+
+
+def test_the_reconstructed_instant_is_the_latest_one_at_or_before_the_run():
+    # 2026-08-21 is a Friday.
+    assert drift.previous_occurrence("25 0 * * 1-5", at("2026-08-21T02:02:49")) \
+        == at("2026-08-21T00:25:00")
+    # Exactly on time is drift zero, not a jump back a day.
+    assert drift.previous_occurrence("25 0 * * 1-5", at("2026-08-21T00:25:00")) \
+        == at("2026-08-21T00:25:00")
+
+
+def test_a_weekday_cron_does_not_match_the_weekend():
+    """2026-08-22 is a Saturday: a `1-5` cron's last occurrence is Friday's,
+    and a Saturday-morning start belongs to it, not to a Saturday that has no
+    occurrence at all."""
+    assert drift.previous_occurrence("0 22 * * 1-5", at("2026-08-22T02:00:00")) \
+        == at("2026-08-21T22:00:00")
+
+
+def test_a_run_further_back_than_the_lookback_is_not_guessed_at():
+    """A `25 0 * * 1-5` run that started Saturday 01:00 would be 24.5 hours
+    after Friday's occurrence — far outside anything GitHub has ever done (the
+    worst measured is 213 minutes). Attributing it anyway would invent a
+    headline drift figure out of a clock problem."""
+    assert drift.previous_occurrence("25 0 * * 1-5", at("2026-08-22T01:00:00")) is None
+
+
+@pytest.mark.parametrize("dow", ["0", "7"])
+def test_sunday_is_accepted_in_both_of_crons_spellings(dow):
+    # 2026-08-16 is a Sunday.
+    assert drift.previous_occurrence(f"0 23 * * {dow}", at("2026-08-16T23:30:00")) \
+        == at("2026-08-16T23:00:00")
+
+
+def test_python_and_cron_disagree_about_which_day_is_zero():
+    """cron: Sunday=0. Python: Monday=0. Getting this backwards shifts every
+    weekly workflow's drift by a day and nothing visibly breaks."""
+    # 2026-08-21 Friday -> cron dow 5.
+    assert drift.previous_occurrence("0 22 * * 5", at("2026-08-21T22:30:00")) \
+        == at("2026-08-21T22:00:00")
+    # ...and Friday must not satisfy a Saturday cron.
+    assert drift.previous_occurrence("0 22 * * 6", at("2026-08-21T22:30:00")) \
+        != at("2026-08-21T22:00:00")
+
+
+def test_a_cron_this_parser_does_not_understand_raises_instead_of_matching():
+    """Silently treating an unparsed field as `*` would report a late workflow
+    as perfectly punctual."""
+    for expr in ["*/5 * * * *", "0 0 1 * *", "0 0 * 3 *", "0 0 *", "0 99 * * *"]:
+        with pytest.raises(drift.DriftError):
+            drift.previous_occurrence(expr, at("2026-08-21T00:00:00"))
+
+
+def test_lists_and_ranges_both_parse():
+    minutes, hours, dow = drift._cron_fields("0,30 21-22 * * 0-4")
+    assert minutes == {0, 30}
+    assert hours == {21, 22}
+    assert dow == {0, 1, 2, 3, 4}
+
+
+def test_a_run_older_than_the_lookback_is_left_unattributed():
+    """Better an omitted sample than one matched to a guess."""
+    assert drift.previous_occurrence("0 22 * * 5", at("2026-08-21T21:00:00")) is None
+
+
+def test_the_crons_are_read_out_of_the_workflow_files(tmp_path):
+    wf = tmp_path / "x.yml"
+    wf.write_text("on:\n  schedule:\n    - cron: '25 0 * * 1-5'\n"
+                  "    - cron: \"9 1 * * 1-5\"\n  workflow_dispatch:\n")
+    assert drift.scheduled_crons(wf) == ["25 0 * * 1-5", "9 1 * * 1-5"]
+    assert drift.scheduled_crons(tmp_path / "none.yml") if (tmp_path / "none.yml").exists() else True
+
+
+def test_the_real_workflows_all_parse():
+    """A cron this repository actually uses that the parser cannot read would
+    silently drop that workflow out of the measurement."""
+    seen = 0
+    for path in (ROOT / ".github" / "workflows").glob("*.yml"):
+        for expr in drift.scheduled_crons(path):
+            drift._cron_fields(expr)   # raises if unsupported
+            seen += 1
+    assert seen >= 10, "the measurement must cover the scheduled workflows, not a subset"
+
+
+def test_the_stored_note_admits_the_figures_are_a_lower_bound():
+    payload = ROOT / "assets" / "data" / "schedule-drift.json"
+    if not payload.exists():
+        pytest.skip("no capture committed yet")
+    import json
+    assert "lower bound" in json.loads(payload.read_text(encoding="utf-8"))["note"]


### PR DESCRIPTION
Closes #780, closes #781

> **约束**：kcn 2026-08-22「不要主机触发，VPS 负载够高了」。两个 issue 原本提的「主机 cron `gh workflow run` 主触发」方案作废，本 PR **完全在 GitHub 侧**，没有给 VPS 增加任何一行 cron、任何一个进程。

## 一、先把漂移变成数据（#781）

`ops/ci/schedule_drift.py` 反推每次 scheduled run 属于哪个 cron 时刻，每周两次写进 `assets/data/schedule-drift.json`。**每档 20 次采样**的实测（比 issue 里 5 次目测的数字严重得多）：

```
workflow                     cron(s)                      n     min     med     max
brief-fallback.yml           25 0 * * 1-5,…               20    45.7   124.1   181.4
news-digest.yml              0 13 * * 1-5                 20    31.9    74.2   157.2
cron-health.yml              17 9 * * 1-5                 20    30.2    70.8   198.3
screenshot-refresh.yml       0 22 * * 0                   14    28.9    63.9    83.5
weekly-review.yml            0 14 * * 0                   13    13.7    56.4   106.2
weekly-health.yml            0 23 * * 0                   14    13.8    56.0    66.5
eod-archive.yml              0 22 * * 5                   13    14.1    53.8    69.5
sentiment-scan.yml           30 21 * * 0-4                20    15.0    49.8   213.2
macro-scan.yml               45 21 * * 0-4                20    10.2    46.0   199.0
influencer-scan.yml          40 21 * * 0-4,…              20     9.9    41.3    80.2
```

**所有数字都是下界**：GitHub 不报告「本该几点跑」，只报告实际启动时刻，所以一次晚到超过自己下一个 occurrence 的运行会被算到那个更晚的 occurrence 头上。用于「论证东西很晚」的数字，错也要错在保守的方向。

### 顺带修掉一条被自己证伪的注释

`cron-health.yml` 一直写着：

> 避开整点：GitHub 官方说明整点高负载会延迟甚至丢弃 scheduled runs

隐含「非整点就准时」。它自己就在 `17 9`，**中位漂移 71 分钟、最大 198**。真正决定延迟的是 **UTC 小时有多拥挤**，不是分钟好不好看。注释改成实测口径而不是删掉 —— 那个错误的版本正是 `25 0` 当初看起来像个安全选择的原因。

## 二、brief-fallback 从未兜底过（#780）：三个独立缺陷

### 缺陷 1（真凶）：provider 链装不进它自己的 job

`timeout` 是**每次尝试**的。`brief_fallback` 传 `timeout=900`，`MAX_RETRIES=3` ⇒ **光 MiniMax 一家就有 45 分钟预算**，而 job 的 `timeout-minutes` 是 **15**。

run 31985473431 逐步还原：

```
success    Run preflight
cancelled  Call off-host LLM to generate brief
skipped    Postflight validation
skipped    Commit + push

01:44:57  minimax: ConnectionError RemoteDisconnected
01:52:03  ##[error]The operation was canceled.        ← 15 分钟到点
```

**opencode-go 一次都没被问过** —— 它不是 fallback，是不可达代码。五次手动 dispatch 全部这样死的。

修：`chat()` 增加**整条链的总预算**（`deadline_seconds` / `CLAWOCK_LLM_DEADLINE_SECONDS`），主 provider 最多用掉 `PRIMARY_BUDGET_SHARE = 0.6`，剩下的**属于** fallback。每次尝试的 timeout 和**退避 sleep** 都夹到剩余预算内 —— 不夹退避的话就是同一个 bug 的更尴尬版本：预算花在什么都不干上。

不设预算时行为**逐字节不变**（有测试钉住），四个调用方各自按自己的 job 预算声明即可。

红绿都验过：把 `PRIMARY_BUDGET_SHARE` 临时改成 `1.0` ⇒ `test_a_slow_primary_cannot_spend_the_whole_budget` 变红。

### 缺陷 2：到点时间压在自己的杀死开关上

workflow 自带 `HOUR >= 10 HKT → skip`。而 GitHub 把 `25 0` 送到 03:0x–04:2x UTC（11:00–12:30 HKT）—— **主链真挂的那天，兜底会到场然后把自己关掉**。

修：**一档变三档**（`25 0` / `47 0` / `9 1`）。skip 判据本来就是幂等的，多余的尝试各花 15 秒。

- **刻意不往前挪**：早于 ~00:25 UTC 会和还在生成中的主 brief 抢，那正是 2026-06-10 生成重复简报的原因。
- 断言钉住了这个边界：最早不得早于 00:25、最晚不得晚于 01:30（再晚就算零漂移也进不了窗口）。

### 缺陷 3：分支从没被走过，而没有任何东西能看见

skip 决策的**四条分支全部记账**（`rehearsal` / `already-exists` / `too-late` / `generated`），记账步骤 `if: always()` —— 一次只 skip 的运行留下的唯一痕迹，不能自己也是有条件的。

`too-late` 现在**发 `::warning::`**：它的含义是「主链可能挂了而且没有东西补上」，这是唯一绝不能默默滚过去的结局。

**每周一次演练**（周三 12:23 HKT + 可手动 dispatch）：跑真的 preflight、真的 provider，产出后**扔掉**。

- 演练**停在 postflight 之前**。postflight 会 commit 会 push（它的 `maybe_commit` 三件事都做），让演练走到那里就有发布假简报的风险 —— 那是演习的反面。演练要回答的问题更窄，到 LLM 这一步已经完全回答了。
- 演练**没产出就变红**（`::error::` + `exit 1`）。一个无论如何都绿的演练什么问题都没回答。
- **刻意不放周末**：闭市日的 preflight 会产生一个与「兜底能不能用」无关的红 —— 正是这个仓库反复付学费的假红。

## 验证

```
$ pytest tests/ -q
2375 passed, 5 skipped, 4 xfailed in 174.56s

$ pytest -q tests/test_schedule_drift.py tests/test_brief_fallback_workflow_contract.py \
          tests/test_llm_chain_budget.py
25 passed

$ GITHUB_TOKEN=… python3 ops/ci/schedule_drift.py --print     # 上表即真实输出
$ /tmp/actionlint                                             # exit 0
```

新增 25 条断言全部写在**机制**上而不是措辞上：预算必须小于 job、必须给 postflight 留 ≥5 分钟、发布类步骤必须全部带 `!= 'rehearsal'`、演练必须能红、四条分支必须都有记账、cron 解析器遇到看不懂的字段必须**抛错而不是当成 `*`**（否则会把一个晚点的 workflow 报成完美准时）。

## 合并后要做的一件事

手动 dispatch 一次 `rehearse=true`，把「兜底今天能不能用」这个六周没人知道答案的问题，第一次变成一条收据贴回 #780。
