### PR TITLE
security: 让那两个只能人肉点的开关不至于被忘掉

### DIFF
--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -65,6 +65,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 ops/ci/workflow_health.py
 
+      - name: GitHub security features still off
+        # #787 found two free secret-scanning switches disabled, and neither can
+        # be turned on from here: `PATCH /repos/{owner}/{repo}` returns 200 and
+        # ignores the field (confirmed by sending an invalid value, which was
+        # also accepted and also ignored), while the code-security
+        # configurations API is organization-only and this is a user account.
+        #
+        # A finding that needs a human click has a short half-life in a chat log
+        # and an indefinite one in a weekly check. Report-only: nagging about a
+        # setting must not be able to red a health run.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 ops/ci/security_posture.py --warn
+
       - name: Peer-map coverage check
         run: |
           python3 << 'PY'

--- a/ops/ci/security_posture.py
+++ b/ops/ci/security_posture.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Report which of GitHub's free security features this repository is not using.
+
+Written for #787, where two toggles were found off:
+
+    secret_scanning_non_provider_patterns   disabled
+    secret_scanning_validity_checks         disabled
+
+Neither can be turned on from here. `PATCH /repos/{owner}/{repo}` returns 200
+and silently ignores both fields — verified by sending a deliberately invalid
+value, which was also accepted and also ignored — and the code-security
+configurations API is organization-only while this is a user account. They are
+web-UI switches.
+
+So the useful thing a script can do is refuse to let them be forgotten. A
+finding that requires a human click has a short half-life in a chat log and an
+indefinite one in a weekly check.
+
+Why these two matter here specifically: the default secret scanner only knows
+patterns with a recognisable provider prefix. Non-provider patterns are what
+catch a private key block, a connection string, or a credential pasted into
+prose — and this repository commits a great deal of model-written prose under
+memory/ and logs/, while holding a deploy key and a .api_keys file whose names
+are already explicitly blocked from PRs. That block is on filenames. It cannot
+see content. Validity checks answer the only question that matters during an
+actual leak: is this credential still live.
+
+Usage:
+    security_posture.py            # report; exit 1 if something is off
+    security_posture.py --warn     # report; always exit 0 (annotations only)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+REPO = os.environ.get("CLAWOCK_TRAFFIC_REPO", "KCNyu/clawock")
+
+# (field, human name, why it is not decoration here)
+EXPECTED = [
+    ("secret_scanning", "Secret scanning",
+     "the baseline; everything else here is an extension of it"),
+    ("secret_scanning_push_protection", "Push protection",
+     "blocks the commit rather than reporting it afterwards"),
+    ("secret_scanning_non_provider_patterns", "Non-provider patterns",
+     "the only thing that sees a private key or connection string pasted into "
+     "prose; the PR path policy blocks filenames, not content"),
+    ("secret_scanning_validity_checks", "Validity checks",
+     "answers 'is this credential still live', which is the first question "
+     "during a real leak and the slowest one to answer by hand"),
+    ("dependabot_security_updates", "Dependabot security updates",
+     "only produces alerts for trees an ecosystem entry makes visible"),
+]
+
+SETTINGS_URL = f"https://github.com/{REPO}/settings/security_analysis"
+
+
+def fetch(token: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "clawock-security-posture (+https://github.com/KCNyu/clawock)",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def evaluate(security: dict) -> list[tuple[str, str, str, str]]:
+    """Returns (field, name, state, why) for everything not enabled."""
+    off = []
+    for field, name, why in EXPECTED:
+        state = (security.get(field) or {}).get("status", "absent")
+        if state != "enabled":
+            off.append((field, name, state, why))
+    return off
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--warn", action="store_true",
+                    help="annotate but never fail the job")
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("::error::GITHUB_TOKEN/GH_TOKEN is unset — the security posture "
+              "cannot be read, which is not the same as it being fine",
+              file=sys.stderr)
+        return 2
+
+    try:
+        security = fetch(token).get("security_and_analysis") or {}
+    except urllib.error.HTTPError as exc:
+        # A fine-grained token without administration:read gets 200 on the repo
+        # but no security_and_analysis block. A hard error is different and
+        # should say so rather than read as "all clear".
+        print(f"::error::cannot read repository settings: HTTP {exc.code}", file=sys.stderr)
+        return 2
+
+    if not security:
+        print("::warning::the token cannot see security_and_analysis — posture unknown, "
+              "not verified")
+        return 0 if args.warn else 1
+
+    for field, name, why in EXPECTED:
+        state = (security.get(field) or {}).get("status", "absent")
+        mark = "✓" if state == "enabled" else "✗"
+        print(f"{mark} {name:<32} {state}")
+
+    off = evaluate(security)
+    if not off:
+        print("\nall of GitHub's free secret-scanning features are on")
+        return 0
+
+    print(f"\n{len(off)} feature(s) off. None of these can be enabled from the API — "
+          f"`PATCH /repos/{{owner}}/{{repo}}` accepts the field and ignores it "
+          f"(#787), so they are web-UI switches:")
+    print(f"  {SETTINGS_URL}")
+    for _, name, state, why in off:
+        print(f"\n  {name} — {state}")
+        print(f"    {why}")
+        print(f"::warning::{name} is {state}: {why}")
+
+    return 0 if args.warn else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,0 +1,78 @@
+"""Reporting GitHub security features that are off.
+
+#787: two free secret-scanning switches were disabled and could not be enabled
+from the API — the repo PATCH endpoint returns 200 and ignores those fields, so
+they are web-UI switches. What a script can still do is refuse to let them be
+forgotten, and the failure mode to guard against is the reporter that says
+nothing when it cannot see.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "security_posture", ROOT / "ops" / "ci" / "security_posture.py")
+posture = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(posture)
+
+
+def _all_on() -> dict:
+    return {field: {"status": "enabled"} for field, _, _ in posture.EXPECTED}
+
+
+def test_everything_on_reports_nothing():
+    assert posture.evaluate(_all_on()) == []
+
+
+def test_a_disabled_feature_is_named_with_the_reason_it_matters_here():
+    settings = _all_on()
+    settings["secret_scanning_validity_checks"] = {"status": "disabled"}
+    off = posture.evaluate(settings)
+    assert [row[0] for row in off] == ["secret_scanning_validity_checks"]
+    assert off[0][2] == "disabled"
+    assert off[0][3], "a switch with no stated reason gets flipped off again next year"
+
+
+def test_an_absent_field_counts_as_off_not_as_fine():
+    """A field GitHub stops returning must not read as enabled. Silence about a
+    security control is the one thing this script exists to prevent."""
+    off = posture.evaluate({})
+    assert len(off) == len(posture.EXPECTED)
+    assert all(row[2] == "absent" for row in off)
+
+
+def test_an_unreadable_posture_is_reported_rather_than_passed(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    monkeypatch.setattr(posture, "fetch", lambda token: {})
+    assert posture.main(["--warn"]) == 0
+    out = capsys.readouterr().out
+    assert "posture unknown, not verified" in out
+
+
+def test_a_missing_token_is_loud(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert posture.main([]) == 2
+    assert "not the same as it being fine" in capsys.readouterr().err
+
+
+def test_warn_never_fails_the_job_but_the_default_does(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    broken = {"security_and_analysis": {"secret_scanning": {"status": "disabled"}}}
+    monkeypatch.setattr(posture, "fetch", lambda token: broken)
+    assert posture.main(["--warn"]) == 0
+    assert posture.main([]) == 1
+
+
+def test_the_weekly_check_runs_it_and_cannot_be_reddened_by_it():
+    workflow = (ROOT / ".github" / "workflows" / "weekly-health.yml").read_text(encoding="utf-8")
+    step = workflow.split("GitHub security features still off", 1)[1].split("- name:", 1)[0]
+    assert "ops/ci/security_posture.py --warn" in step
+    assert "continue-on-error: true" in step, (
+        "nagging about a repository setting must not be able to red a health run"
+    )


### PR DESCRIPTION
Refs #787（**不关闭** —— 真正的两下点击只能由 kcn 在网页上做）

## 先说结论：那两个开关，API 改不了

试过了，`PATCH /repos/{owner}/{repo}` 对这两个字段是**只读的** —— 返回 200，然后原样忽略：

```
$ echo '{"security_and_analysis":{"secret_scanning_validity_checks":{"status":"enabled"}}}' \
    | gh api -X PATCH repos/KCNyu/clawock --input -
...  "secret_scanning_validity_checks": {"status": "disabled"}      ← 没变
```

不是权限也不是语法问题 —— **塞一个非法值进去同样返回 200 且同样被忽略**：

```
$ echo '{"security_and_analysis":{"secret_scanning_validity_checks":{"status":"bogus"}}}' \
    | gh api -X PATCH repos/KCNyu/clawock --input -
HTTP 200，字段仍是 disabled
```

token 是 `repo` scope、`permissions.admin: true`。`/orgs/{org}/code-security/configurations` 只对 organization 开放，`KCNyu` 是 user 账号。⇒ **这是网页开关。**

## 所以这个 PR 做的不是「打开它」，是「不让它被忘掉」

一条需要人肉点击的发现，在聊天记录里的半衰期很短，在每周巡检里的半衰期是无限。`weekly-health.yml` 现在会报：

```
✓ Secret scanning                  enabled
✓ Push protection                  enabled
✗ Non-provider patterns            disabled
✗ Validity checks                  disabled
✓ Dependabot security updates      enabled

2 feature(s) off. None of these can be enabled from the API …
  https://github.com/KCNyu/clawock/settings/security_analysis
```

**report-only**（`--warn` + `continue-on-error`）—— 为一个仓库设置唠叨，不该有能力把一次健康巡检判红。

## 为什么是这两个，而不是泛泛的「安全卫生」

- **Non-provider patterns**：默认扫描只认有 provider 前缀的凭证（`ghp_`、`sk-`…）。非 provider pattern 才覆盖私钥块、连接串、贴进散文里的凭据 —— 而这个仓库在 `memory/` 和 `logs/` 下提交**大量模型写的散文**，同时持有一把 deploy key 和一个 `.api_keys`。`harness-regression.yml` 里那条 PR 路径策略挡的是**文件名**，它看不见**内容**。
- **Validity checks**：真出事时的第一个问题是「这把 key 还活着吗」，也是人肉去 provider 那边试最慢的一步。

## 两个「宁可吵也不要装没事」的设计

- **读不到 = unknown，不是 clear。** token 看不见 `security_and_analysis` 时报 `posture unknown, not verified`，绝不静默通过。
- **字段缺失 = off。** GitHub 哪天不再返回某个字段，不能被读成 enabled。

两条都有断言。

## 验证

```
$ pytest tests/test_security_posture.py     # 7 passed
$ GITHUB_TOKEN=… python3 ops/ci/security_posture.py --warn    # 上面那段即真实输出
$ /tmp/actionlint                            # exit 0
```

## kcn 需要做的两下

`https://github.com/KCNyu/clawock/settings/security_analysis`

1. Secret scanning → **Non-provider patterns** → Enable
2. Secret scanning → **Validity checks** → Enable

点完会对历史提交回扫，预计冒出一批告警（`memory/`、`logs/` 下的散文会有误报）。**先看一遍再批量 dismiss** —— 那正是这两个开关唯一能给出信息的地方。点完之后 weekly-health 这一步会自动安静，#787 也就可以关了。
