### PR TITLE
fix: 采集 workflow 绕过了 safe_push.sh，第一次排期就会丢掉采到的数据

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -75,7 +75,15 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # master's ruleset bypasses exactly one actor — the deploy key. The
+      # workflow token cannot push there, so the plain `git push` this shipped
+      # with (#798) would have failed on the first scheduled run, after
+      # capturing a 14-day window that cannot be re-fetched. Every other
+      # data-write workflow goes through safe_push.sh for the same reason, and
+      # it also owns the rebase-retry and the conflict-marker guard.
       - name: Commit the merged history
+        env:
+          CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -86,7 +94,4 @@ jobs:
             exit 0
           fi
           git commit -m "measurement: repo traffic + schedule drift $(date -u +%Y-%m-%d)"
-          # Automation commits to master all day; rebase onto whatever landed
-          # while this job ran rather than failing on a stale ref.
-          git pull --rebase --autostash origin master
-          git push origin HEAD:master
+          bash ops/publish/safe_push.sh

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -130,6 +130,37 @@ def test_a_checkout_that_is_not_the_live_workspace_gets_no_publish_identity(tmp_
         f"{probe.stdout!r}")
 
 
+def test_no_workflow_pushes_to_master_around_safe_push():
+    """master's ruleset bypasses exactly one actor — the deploy key.
+
+    A workflow that runs `git push origin ... master` with the workflow token is
+    rejected by the ruleset, and it discovers this on its first scheduled run,
+    after doing the work, with the runner about to be discarded. repo-traffic
+    shipped exactly that in #798: it captured a 14-day window that cannot be
+    re-fetched and would then have failed to store it.
+
+    Routing everything through safe_push.sh is not only about the credential —
+    it also owns the rebase-retry against a repository that commits all day and
+    the conflict-marker guard that once blanked the dashboard.
+    """
+    offenders = []
+    for path in sorted((ROOT / ".github" / "workflows").glob("*.yml")):
+        text = path.read_text()
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("git push"):
+                continue
+            # The data-plane publisher owns its own orphan branch and never
+            # touches master; safe_push.sh itself is the sanctioned path.
+            if "master" not in stripped and "HEAD:" not in stripped:
+                continue
+            offenders.append(f"{path.name}: {stripped}")
+
+    assert not offenders, (
+        "these push to master directly instead of through safe_push.sh, which "
+        f"the branch ruleset will reject: {offenders}")
+
+
 def test_every_workflow_that_stages_the_money_file_pushes_through_the_gate():
     """The money-conservation check lived only in .githooks/pre-push, which a
     fresh actions/checkout never installs (no workflow sets core.hooksPath). So


### PR DESCRIPTION
自查发现的一个**我自己在 #798 里引入的缺陷**，在它第一次真跑之前修掉。

## 症状（尚未发生，因为那个 workflow 还没到第一次排期）

`repo-traffic.yml` 提交时用的是：

```bash
git pull --rebase --autostash origin master
git push origin HEAD:master
```

而 master 的 ruleset 只放行**一个** actor：

```
$ gh api repos/KCNyu/clawock/rulesets/19140068 --jq '.bypass_actors'
[{"actor_id":null,"actor_type":"DeployKey","bypass_mode":"always"}]
```

workflow token 推不上去。⇒ 它会在**周二 03:38 UTC 第一次排期运行时**才发现：**采完一个再也拿不回来的 14 天窗口，然后推送失败，runner 销毁，数据没了。**

仓库里其他六个 data-write workflow（`eod-archive` / `news-digest` / `weekly-review` / `screenshot-refresh` / `brief-fallback` / …）无一例外走 `ops/publish/safe_push.sh`。我漏看了这条既有约定。

## 修复

改走 `safe_push.sh`。它值得走的原因不止是那把 key：

- **rebase 重试** —— 这个仓库每天往 master 提交 ~35 次，一次朴素的 push 撞上并发提交就是失败
- **conflict-marker 闸** —— 它存在是因为一份半合并的 `dashboard.json` 曾经把公开面板整个刷白

## 加一条闸，防止这类 bug 再来

```python
def test_no_workflow_pushes_to_master_around_safe_push():
    ...
    assert not offenders, (
        "these push to master directly instead of through safe_push.sh, which "
        f"the branch ruleset will reject: {offenders}")
```

断言在**机制**上而不是在这个文件上：任何 workflow 都不许绕过 `safe_push.sh` 推 master。

## 顺带一件说明既有闸有效的事

我这个修复的**第一版**把注释写在了 `env:` 和 secret 绑定之间，`test_each_publishing_workflow_scopes_deploy_key_to_push_step` 立刻变红：

```
assert lines[index - 1].strip() == "env:", (
    f"{workflow.name} publish key is not in a step env block")
```

那条闸挡的是「deploy key 暴露到 step 作用域之上」，它做得对。注释挪到步骤上方了。

## 验证

```
$ pytest tests/test_pr_publish_gate_contract.py     # 13 passed（含新增那条）
$ /tmp/actionlint                                    # exit 0
```
