### PR TITLE
security: 别再为这个仓库根本拿不到的开关每周报警

### DIFF
--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -66,15 +66,21 @@ jobs:
         run: python3 ops/ci/workflow_health.py
 
       - name: GitHub security features still off
-        # #787 found two free secret-scanning switches disabled, and neither can
-        # be turned on from here: `PATCH /repos/{owner}/{repo}` returns 200 and
-        # ignores the field (confirmed by sending an invalid value, which was
-        # also accepted and also ignored), while the code-security
-        # configurations API is organization-only and this is a user account.
+        # #787 closed at a platform boundary, not a to-do: non-provider patterns
+        # and validity checks cannot be enabled on a public repository at all.
+        # GitHub refuses `advanced_security` with "always available for public
+        # repos" while scan-history answers "Advanced Security is disabled on
+        # this repository" — both true at once, and the two switches hang off
+        # the second one.
         #
-        # A finding that needs a human click has a short half-life in a chat log
-        # and an indefinite one in a weekly check. Report-only: nagging about a
-        # setting must not be able to red a health run.
+        # So this reports the distinction rather than a count: off-and-available
+        # is a to-do and warns; off-because-GitHub-does-not-offer-it-here is a
+        # fact and stays quiet. A weekly warning nobody can act on is a false
+        # alarm with a schedule, and it teaches people to skim the one check
+        # that is supposed to be worth reading. If this repo ever goes private
+        # with GHAS or moves under an organization, those two start warning
+        # again on their own. Report-only either way: nagging about a setting
+        # must not be able to red a health run.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/ops/ci/security_posture.py
+++ b/ops/ci/security_posture.py
@@ -6,15 +6,37 @@ Written for #787, where two toggles were found off:
     secret_scanning_non_provider_patterns   disabled
     secret_scanning_validity_checks         disabled
 
-Neither can be turned on from here. `PATCH /repos/{owner}/{repo}` returns 200
-and silently ignores both fields — verified by sending a deliberately invalid
-value, which was also accepted and also ignored — and the code-security
-configurations API is organization-only while this is a user account. They are
-web-UI switches.
+Neither can be turned on at all on this repository, and the reason is not
+permissions — it is what kind of repository this is:
 
-So the useful thing a script can do is refuse to let them be forgotten. A
-finding that requires a human click has a short half-life in a chat log and an
-indefinite one in a weekly check.
+  * `PATCH /repos/{owner}/{repo}` returns 200 and silently drops both fields.
+    That endpoint does validate what it actually processes (asking it for
+    `code_security` returns 422 "Code Security can only be enabled if Advanced
+    Security is enabled"), so a silently dropped field never reached the
+    handler.
+  * Asking for `advanced_security` returns 422 "Advanced security is always
+    available for public repos" — it cannot be enabled because it is nominally
+    already there.
+  * And yet `GET /repos/{owner}/{repo}/secret-scanning/scan-history` answers
+    "Advanced Security is disabled on this repository."
+
+"Always available" and "is disabled" hold at the same time. That is the real
+state of a public repository: secret scanning itself is free, but the switches
+layered on top of it hang off an enablement that exists only for GitHub
+Advanced Security customers — a private repo with GHAS, or an organization's
+code security configurations. This is a user account, so
+`/orgs/{org}/code-security/configurations` 404s.
+
+kcn confirmed on 2026-08-22 that the settings page offers nothing further:
+"能开的都开了".
+
+So this script must NOT nag about them. A weekly warning nobody can act on is a
+false alarm with a schedule, and it trains people to skim exactly the check that
+is supposed to be worth reading. What it reports instead is the distinction that
+matters: a feature that is off **and available** is a to-do; a feature that is
+off because the platform does not offer it here is a fact, and it only becomes a
+to-do again if that changes — the repository going private with GHAS, or moving
+under an organization.
 
 Why these two matter here specifically: the default secret scanner only knows
 patterns with a recognisable provider prefix. Non-provider patterns are what
@@ -39,6 +61,14 @@ import urllib.error
 import urllib.request
 
 REPO = os.environ.get("CLAWOCK_TRAFFIC_REPO", "KCNyu/clawock")
+
+# Features whose enablement is gated behind GitHub Advanced Security being
+# genuinely enabled — which never happens on a public repository (see the module
+# docstring). Off is reported as unavailable, not as a to-do.
+GHAS_GATED = frozenset({
+    "secret_scanning_non_provider_patterns",
+    "secret_scanning_validity_checks",
+})
 
 # (field, human name, why it is not decoration here)
 EXPECTED = [
@@ -72,14 +102,58 @@ def fetch(token: str) -> dict:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def evaluate(security: dict) -> list[tuple[str, str, str, str]]:
-    """Returns (field, name, state, why) for everything not enabled."""
-    off = []
+def evaluate(security: dict, ghas_enabled: bool) -> tuple[list, list]:
+    """Split what is off into (actionable, unavailable).
+
+    `ghas_enabled` decides which side the GHAS-gated features land on. Passing
+    it in rather than reading it here keeps the classification testable without
+    a network call, and keeps the probe honest: unknown must never quietly mean
+    "unavailable", which would suppress a real finding forever.
+    """
+    actionable, unavailable = [], []
     for field, name, why in EXPECTED:
         state = (security.get(field) or {}).get("status", "absent")
-        if state != "enabled":
-            off.append((field, name, state, why))
-    return off
+        if state == "enabled":
+            continue
+        row = (field, name, state, why)
+        if field in GHAS_GATED and not ghas_enabled:
+            unavailable.append(row)
+        else:
+            actionable.append(row)
+    return actionable, unavailable
+
+
+def ghas_is_enabled(token: str) -> bool:
+    """Probe whether the GHAS-gated switches can be set on this repository.
+
+    scan-history is the honest read: it answers "Advanced Security is disabled
+    on this repository" for a public repo, while the repository PATCH endpoint
+    insists advanced security is "always available". Nothing in
+    security_and_analysis distinguishes the two states, so the probe has to be a
+    separate endpoint.
+
+    Fails closed toward *actionable*: if the probe cannot tell, the feature is
+    reported as a to-do rather than silently written off.
+    """
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/secret-scanning/scan-history",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "clawock-security-posture (+https://github.com/KCNyu/clawock)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20):
+            return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            body = exc.read().decode("utf-8", "replace")
+            if "Advanced Security is disabled" in body:
+                return False
+        return True
+    except Exception:  # noqa: BLE001
+        return True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -110,21 +184,40 @@ def main(argv: list[str] | None = None) -> int:
               "not verified")
         return 0 if args.warn else 1
 
+    ghas = ghas_is_enabled(token)
+    actionable, unavailable = evaluate(security, ghas)
+    unavailable_fields = {row[0] for row in unavailable}
+
     for field, name, why in EXPECTED:
         state = (security.get(field) or {}).get("status", "absent")
-        mark = "✓" if state == "enabled" else "✗"
+        if state == "enabled":
+            mark = "✓"
+        elif field in unavailable_fields:
+            mark = "—"
+            state = f"{state} (not offered on this repository)"
+        else:
+            mark = "✗"
         print(f"{mark} {name:<32} {state}")
 
-    off = evaluate(security)
-    if not off:
-        print("\nall of GitHub's free secret-scanning features are on")
+    if unavailable:
+        print("\nOff because GitHub does not offer them here, not because nobody got "
+              "round to it (#787). These switches hang off GitHub Advanced Security "
+              "being genuinely enabled, which does not happen on a public repository: "
+              "the repo endpoint says advanced security is \"always available for public "
+              "repos\" and refuses to enable it, while scan-history answers \"Advanced "
+              "Security is disabled on this repository\". Both are true at once. They "
+              "become to-dos again only if this repo goes private with GHAS, or moves "
+              "under an organization with a code security configuration.")
+        for _, name, _, _ in unavailable:
+            print(f"  — {name}")
+
+    if not actionable:
+        print("\nevery secret-scanning feature this repository can have is on")
         return 0
 
-    print(f"\n{len(off)} feature(s) off. None of these can be enabled from the API — "
-          f"`PATCH /repos/{{owner}}/{{repo}}` accepts the field and ignores it "
-          f"(#787), so they are web-UI switches:")
+    print(f"\n{len(actionable)} feature(s) off and enable-able:")
     print(f"  {SETTINGS_URL}")
-    for _, name, state, why in off:
+    for _, name, state, why in actionable:
         print(f"\n  {name} — {state}")
         print(f"    {why}")
         print(f"::warning::{name} is {state}: {why}")

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,14 +1,23 @@
-"""Reporting GitHub security features that are off.
+"""Reporting GitHub security features that are off — and only nagging about the
+ones somebody can actually turn on.
 
-#787: two free secret-scanning switches were disabled and could not be enabled
-from the API — the repo PATCH endpoint returns 200 and ignores those fields, so
-they are web-UI switches. What a script can still do is refuse to let them be
-forgotten, and the failure mode to guard against is the reporter that says
-nothing when it cannot see.
+#787 chased two disabled secret-scanning switches and ended at a platform
+boundary: on a public repository they cannot be enabled at all. The repo
+endpoint refuses `advanced_security` with "always available for public repos"
+while scan-history answers "Advanced Security is disabled on this repository";
+both hold at once, and the switches hang off the second one. kcn confirmed the
+settings page offers nothing further.
+
+That makes the first version of this reporter wrong in a specific way: a weekly
+warning nobody can act on is a false alarm with a schedule, and it trains people
+to skim exactly the check that is meant to be worth reading. So the thing under
+test is the *distinction* — off-and-available is a to-do, off-and-not-offered is
+a fact — plus the two ways that distinction could rot into silence.
 """
 from __future__ import annotations
 
 import importlib.util
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -26,32 +35,85 @@ def _all_on() -> dict:
 
 
 def test_everything_on_reports_nothing():
-    assert posture.evaluate(_all_on()) == []
+    actionable, unavailable = posture.evaluate(_all_on(), ghas_enabled=False)
+    assert actionable == [] and unavailable == []
 
 
-def test_a_disabled_feature_is_named_with_the_reason_it_matters_here():
+def test_a_ghas_gated_feature_is_a_fact_not_a_todo_when_ghas_is_off():
     settings = _all_on()
     settings["secret_scanning_validity_checks"] = {"status": "disabled"}
-    off = posture.evaluate(settings)
-    assert [row[0] for row in off] == ["secret_scanning_validity_checks"]
-    assert off[0][2] == "disabled"
-    assert off[0][3], "a switch with no stated reason gets flipped off again next year"
+    actionable, unavailable = posture.evaluate(settings, ghas_enabled=False)
+    assert actionable == []
+    assert [row[0] for row in unavailable] == ["secret_scanning_validity_checks"]
+
+
+def test_the_same_feature_becomes_a_todo_again_once_ghas_is_available():
+    """The repo going private with GHAS, or moving under an organization, is
+    exactly when this should start nagging again."""
+    settings = _all_on()
+    settings["secret_scanning_validity_checks"] = {"status": "disabled"}
+    actionable, unavailable = posture.evaluate(settings, ghas_enabled=True)
+    assert [row[0] for row in actionable] == ["secret_scanning_validity_checks"]
+    assert unavailable == []
+
+
+def test_an_ungated_feature_is_always_a_todo():
+    """Push protection has nothing to do with GHAS. Being generous about one
+    class of feature must not leak into the rest."""
+    settings = _all_on()
+    settings["secret_scanning_push_protection"] = {"status": "disabled"}
+    actionable, _ = posture.evaluate(settings, ghas_enabled=False)
+    assert [row[0] for row in actionable] == ["secret_scanning_push_protection"]
 
 
 def test_an_absent_field_counts_as_off_not_as_fine():
-    """A field GitHub stops returning must not read as enabled. Silence about a
-    security control is the one thing this script exists to prevent."""
-    off = posture.evaluate({})
-    assert len(off) == len(posture.EXPECTED)
-    assert all(row[2] == "absent" for row in off)
+    actionable, unavailable = posture.evaluate({}, ghas_enabled=True)
+    assert len(actionable) == len(posture.EXPECTED)
+    assert all(row[2] == "absent" for row in actionable)
+
+
+def test_every_gated_feature_is_one_this_script_actually_reports():
+    """A typo in GHAS_GATED would silently exempt nothing, or worse, exempt a
+    field that no longer exists while the real one keeps warning."""
+    known = {field for field, _, _ in posture.EXPECTED}
+    assert posture.GHAS_GATED <= known
+
+
+class _Resp:
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def test_the_ghas_probe_reads_disabled_only_from_githubs_own_words(monkeypatch):
+    def raise_404(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url, 404, "Not Found", {},
+            __import__("io").BytesIO(b'{"message":"Advanced Security is disabled on this repository."}'))
+    monkeypatch.setattr(posture.urllib.request, "urlopen", raise_404)
+    assert posture.ghas_is_enabled("x") is False
+
+
+@pytest.mark.parametrize("outcome", ["other-404", "500", "network"])
+def test_an_inconclusive_probe_fails_toward_reporting_not_toward_silence(monkeypatch, outcome):
+    """The dangerous direction is exempting a real finding forever. If the probe
+    cannot tell, the feature stays a to-do."""
+    def fail(req, timeout=None):
+        if outcome == "other-404":
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {},
+                                         __import__("io").BytesIO(b'{"message":"Not Found"}'))
+        if outcome == "500":
+            raise urllib.error.HTTPError(req.full_url, 500, "Server Error", {},
+                                         __import__("io").BytesIO(b"{}"))
+        raise OSError("connection reset")
+    monkeypatch.setattr(posture.urllib.request, "urlopen", fail)
+    assert posture.ghas_is_enabled("x") is True
 
 
 def test_an_unreadable_posture_is_reported_rather_than_passed(monkeypatch, capsys):
     monkeypatch.setenv("GITHUB_TOKEN", "x")
     monkeypatch.setattr(posture, "fetch", lambda token: {})
     assert posture.main(["--warn"]) == 0
-    out = capsys.readouterr().out
-    assert "posture unknown, not verified" in out
+    assert "posture unknown, not verified" in capsys.readouterr().out
 
 
 def test_a_missing_token_is_loud(monkeypatch, capsys):
@@ -61,18 +123,23 @@ def test_a_missing_token_is_loud(monkeypatch, capsys):
     assert "not the same as it being fine" in capsys.readouterr().err
 
 
-def test_warn_never_fails_the_job_but_the_default_does(monkeypatch):
+def test_this_repository_currently_has_everything_it_can_have(monkeypatch):
+    """The state #787 closed on: the only two features off are the two GitHub
+    does not offer here, so the weekly check must be quiet."""
     monkeypatch.setenv("GITHUB_TOKEN", "x")
-    broken = {"security_and_analysis": {"secret_scanning": {"status": "disabled"}}}
-    monkeypatch.setattr(posture, "fetch", lambda token: broken)
-    assert posture.main(["--warn"]) == 0
-    assert posture.main([]) == 1
+    monkeypatch.setattr(posture, "ghas_is_enabled", lambda token: False)
+    monkeypatch.setattr(posture, "fetch", lambda token: {"security_and_analysis": {
+        "secret_scanning": {"status": "enabled"},
+        "secret_scanning_push_protection": {"status": "enabled"},
+        "dependabot_security_updates": {"status": "enabled"},
+        "secret_scanning_non_provider_patterns": {"status": "disabled"},
+        "secret_scanning_validity_checks": {"status": "disabled"},
+    }})
+    assert posture.main([]) == 0, "a finding nobody can act on must not fail the check"
 
 
 def test_the_weekly_check_runs_it_and_cannot_be_reddened_by_it():
     workflow = (ROOT / ".github" / "workflows" / "weekly-health.yml").read_text(encoding="utf-8")
     step = workflow.split("GitHub security features still off", 1)[1].split("- name:", 1)[0]
     assert "ops/ci/security_posture.py --warn" in step
-    assert "continue-on-error: true" in step, (
-        "nagging about a repository setting must not be able to red a health run"
-    )
+    assert "continue-on-error: true" in step


### PR DESCRIPTION
Closes #787

## #787 的结局不是「做完了」，是**撞到平台边界**

kcn 已经在网页上确认：「能开的都开了」。那两个开关这个仓库**根本不提供**。

追到的机制（完整证据链在 #787 里）：

```
$ gh api -X PATCH repos/KCNyu/clawock -f 'security_and_analysis[code_security][status]=enabled'
422  "Code Security can only be enabled if Advanced Security is enabled."   ← 这个端点是会报错的

$ gh api -X PATCH repos/KCNyu/clawock -f 'security_and_analysis[advanced_security][status]=enabled'
422  "Advanced security is always available for public repos."              ← 开不了，"本来就有"

$ gh api repos/KCNyu/clawock/secret-scanning/scan-history
404  "Advanced Security is disabled on this repository."                     ← 又说它是关的
```

**「always available」和「is disabled」同时成立。** 那两个开关挂在后者上。能设置它们的 REST 路径限定给 GHAS customers（买了 GHAS 的私有仓库，或 organization 的 code security configuration），而这是 user 账号。

## 所以我在 #802 里写的东西是错的，得改

那版 reporter 会**每周警告一次，永远，关于一件谁也做不了的事**。

一个按周排期的假警报比没有这个检查更糟 —— 它会训练人去跳过那份本该值得读的报告。这个仓库为「假红」已经付过好几次学费了，我不该再造一个。

## 改成报「区别」而不是报「数量」

```
✓ Secret scanning                  enabled
✓ Push protection                  enabled
— Non-provider patterns            disabled (not offered on this repository)
— Validity checks                  disabled (not offered on this repository)
✓ Dependabot security updates      enabled

Off because GitHub does not offer them here, not because nobody got round to it (#787).
…They become to-dos again only if this repo goes private with GHAS, or moves under an
organization with a code security configuration.
  — Non-provider patterns
  — Validity checks

every secret-scanning feature this repository can have is on
```

exit 0，零 warning，**但事实仍然记在报告里**——不是删掉，是归类。

## 两条不让它烂掉的设计

**① 不是硬编码豁免，是探测。** `ghas_is_enabled()` 去问 `scan-history`。仓库哪天转私有开了 GHAS、或者搬到 organization 下，这两条**自己就会重新开始警告**，不需要有人记得回来改。

**② 探测失败一律倒向「报出来」。** 只有 GitHub 自己说出 `"Advanced Security is disabled"` 才算不可用；**其他任何 404、任何 500、任何网络错误都保持 to-do**。

```python
@pytest.mark.parametrize("outcome", ["other-404", "500", "network"])
def test_an_inconclusive_probe_fails_toward_reporting_not_toward_silence(...):
    assert posture.ghas_is_enabled("x") is True
```

把一条真的发现永久豁免掉，是这里面代价最大的错法。

## 验证

```
$ pytest tests/test_security_posture.py                    # 14 passed
$ GITHUB_TOKEN=… python3 ops/ci/security_posture.py        # exit 0，即上面那段
$ /tmp/actionlint                                          # exit 0
```

其中一条钉的就是当下这个状态：`test_this_repository_currently_has_everything_it_can_have` —— 唯二关着的正是 GitHub 不提供的那两个，所以每周巡检必须是安静的。
