### PR TITLE
ci: Python setup 和 master 提交各收敛成一个门（#806）

### DIFF
--- a/.github/actions/clawock-commit/action.yml
+++ b/.github/actions/clawock-commit/action.yml
@@ -1,0 +1,61 @@
+name: Commit and publish to master
+description: >-
+  The one way a scheduled workflow puts its output on master: bot identity,
+  stage, skip when nothing changed, commit, and push through safe_push.sh.
+
+# Six workflows carried byte-identical copies of this (#806), and the copies were
+# not harmless. `safe_push.sh` is not a stylistic preference: master's ruleset
+# bypasses exactly one actor, the deploy key, so a copy that reaches for a plain
+# `git push` is rejected — and it finds out on its first scheduled run, after
+# doing the work, with the runner about to be discarded. That is #803, written by
+# the session that had just finished reading the other five copies.
+#
+# safe_push.sh also owns the rebase-retry against a repository that commits ~35
+# times a day and the conflict-marker guard that exists because a half-merged
+# dashboard.json once blanked the public page. Every one of those is a reason the
+# push must not be reinvented per workflow.
+#
+# The deploy key is deliberately NOT an input: it stays an `env:` on the calling
+# step, at step scope, which is the shape `test_each_publishing_workflow_scopes_
+# deploy_key_to_push_step` enforces.
+inputs:
+  paths:
+    description: >-
+      Paths to stage, space-separated. Passed to `git add --` so a caller can
+      compute them, and so a leading dash cannot turn into a flag.
+    required: true
+  message:
+    description: Commit message. The caller owns the wording and any date stamp.
+    required: true
+
+outputs:
+  committed:
+    description: '"true" when something was committed and pushed.'
+    value: ${{ steps.commit.outputs.committed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Commit and push
+      id: commit
+      shell: bash
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Unquoted on purpose: `paths` is a space-separated list and each element
+        # has to become its own argument. `--` keeps a path that starts with a
+        # dash from being read as a flag.
+        # shellcheck disable=SC2086
+        git add -- ${{ inputs.paths }}
+
+        if git diff --cached --quiet; then
+          echo "nothing to commit"
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git commit -m "${{ inputs.message }}"
+        bash ops/publish/safe_push.sh
+        echo "committed=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/clawock-python/action.yml
+++ b/.github/actions/clawock-python/action.yml
@@ -6,7 +6,13 @@ description: >-
 # Seven scheduled workflows opened with byte-identical steps: setup-python 3.11,
 # then `pip install --quiet -e .`. Seven copies is seven places to forget when
 # the pinned version moves or the install grows an extra, and #751 is what that
-# eventually costs. `actions/checkout` deliberately stays in the caller: it takes
+# eventually costs.
+#
+# Writing that down did not stop it (#806): seven OTHER workflows kept hand-rolling
+# the same two steps, versions drifted into two setup-python majors with the older
+# one sitting on the release chain, and the most recent hand-rolled copy was added
+# by the same session that was quoting this comment. So every caller now comes
+# through here, and a test refuses a bare `setup-python@` anywhere else. `actions/checkout` deliberately stays in the caller: it takes
 # per-workflow inputs (fetch-depth, token) and hiding it here would make those
 # invisible at the call site.
 inputs:
@@ -17,7 +23,10 @@ inputs:
   install:
     description: >-
       pip target for the editable install. Pass an extras selector such as
-      `.[compute]` when the job needs the heavier dependency set.
+      `.[compute]` when the job needs the heavier dependency set, or `none` when
+      the job only runs stdlib scripts and wants nothing but the pinned Python.
+      `none` exists so those jobs still come through this door: the version has
+      to be decided in one place even when the install is not.
     required: false
     default: '.'
 
@@ -34,5 +43,6 @@ runs:
         cache-dependency-path: pyproject.toml
 
     - name: Install clawock
+      if: inputs.install != 'none'
       shell: bash
       run: pip install --quiet -e '${{ inputs.install }}'

--- a/.github/workflows/brief-fallback.yml
+++ b/.github/workflows/brief-fallback.yml
@@ -82,11 +82,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 50
 
-      - uses: actions/setup-python@v7
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e '.[compute]'
+          install: '.[compute]'
 
       # Set git identity up front: brief_postflight commits internally (rebuild
       # dashboard + auto-commit), so it needs an identity well before the final

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -34,10 +34,13 @@ jobs:
         with:
           fetch-depth: 100  # 需要看今日 commit history
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      # `install: none` — this job runs stdlib scripts against the fetched
+      # generation and needs no package, but the Python version still gets
+      # decided in exactly one place.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
-          python-version: '3.11'
+          install: none
 
       # The heartbeat ledger is published to the data branch, not committed
       # (#325), so it has to be fetched before the check can read it. Loud on

--- a/.github/workflows/eod-archive.yml
+++ b/.github/workflows/eod-archive.yml
@@ -65,16 +65,16 @@ jobs:
       - name: Validate EOD archive coverage
         run: clawock validate-sidecar eod-archive
 
+      # The message needs a date, and a composite's `with:` cannot run shell —
+      # so the stamp is computed here and the composite stays declarative.
+      - name: Compose the commit message
+        run: |
+          echo "COMMIT_MESSAGE=archive: EOD snapshot $(date -u +%Y-W%W)" >> "$GITHUB_ENV"
+
       - name: Commit
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add memory/archive/
-          if git diff --cached --quiet; then
-            echo "no change"
-            exit 0
-          fi
-          git commit -m "archive: EOD snapshot $(date -u +%Y-W%W)"
-          bash ops/publish/safe_push.sh
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: memory/archive/
+          message: ${{ env.COMMIT_MESSAGE }}

--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -264,22 +264,18 @@ jobs:
         if: steps.changes.outputs.dsplugin == 'true'
         run: node tests/dsh_plugin_package_contract.mjs
 
-      - name: Set up Python
+      # numpy is required to *collect* tests/, not just to run one of them:
+      # portfolio_risk_metrics imports it at module level, so without it pytest
+      # aborts the whole run with a collection error and all 78 tests silently
+      # stop being enforced — a green-looking local run hides this completely.
+      # Pillow: validate_sidecars now fully-decodes screenshots/GIF (finding #12);
+      # the real asset checks run in screenshot-refresh.yml (which has Pillow) but
+      # the unit tests here exercise the same validators, so pytest needs it too.
+      - name: Set up clawock (Python)
         if: steps.changes.outputs.code == 'true'
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/clawock-python
         with:
-          python-version: '3.11'
-
-      - name: Install minimal deps
-        if: steps.changes.outputs.code == 'true'
-        # numpy is required to *collect* tests/, not just to run one of them:
-        # portfolio_risk_metrics imports it at module level, so without it pytest
-        # aborts the whole run with a collection error and all 78 tests silently
-        # stop being enforced — a green-looking local run hides this completely.
-        # Pillow: validate_sidecars now fully-decodes screenshots/GIF (finding #12);
-        # the real asset checks run in screenshot-refresh.yml (which has Pillow) but
-        # the unit tests here exercise the same validators, so pytest needs it too.
-        run: pip install --quiet -e '.[test]'
+          install: '.[test]'
 
       - name: Unit tests — money-integrity derivations
         if: steps.changes.outputs.code == 'true'
@@ -515,14 +511,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      # No dependency install and no second test run: the suite was already
+      # `install: none` — no dependency install and no second test run: the
+      # suite was already
       # measured in `validate`. The package validator runs from `src/` with the
       # stock runner so this cheap publishing job stays stdlib-only.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
+        with:
+          install: none
       - name: Download coverage report
         uses: actions/download-artifact@v8
         with:
@@ -554,12 +550,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - run: pip install --quiet -e .
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
 
       - name: FX fallback chain
         run: |

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Validate generated digest
         run: clawock validate-sidecar news-digest
 
+      - name: Compose the commit message
+        run: |
+          echo "COMMIT_MESSAGE=news: US digest $(TZ=Asia/Hong_Kong date +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - name: Commit + push
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/data/us_news_digest.json
-          if ! git diff --cached --quiet; then
-            git commit -m "news: US digest $(TZ=Asia/Hong_Kong date +%Y-%m-%d)"
-            bash ops/publish/safe_push.sh
-          fi
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: assets/data/us_news_digest.json
+          message: ${{ env.COMMIT_MESSAGE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
-          python-version: '3.11'
+          install: '.[release]'
 
       - name: Build sdist and wheel
         run: |
-          pip install --quiet -e '.[release]'
           python -m build
           python -m twine check dist/*
 

--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -39,9 +39,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      # `install: none` — both capture scripts are stdlib only.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
           python-version: '3.12'
+          install: none
 
       - name: Capture traffic and package downloads
         env:
@@ -75,23 +78,14 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # master's ruleset bypasses exactly one actor — the deploy key. The
-      # workflow token cannot push there, so the plain `git push` this shipped
-      # with (#798) would have failed on the first scheduled run, after
-      # capturing a 14-day window that cannot be re-fetched. Every other
-      # data-write workflow goes through safe_push.sh for the same reason, and
-      # it also owns the rebase-retry and the conflict-marker guard.
+      - name: Compose the commit message
+        run: |
+          echo "COMMIT_MESSAGE=measurement: repo traffic + schedule drift $(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - name: Commit the merged history
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/data/repo-traffic.json assets/data/schedule-drift.json
-          if git diff --cached --quiet; then
-            echo "no new measurements — nothing to commit"
-            exit 0
-          fi
-          git commit -m "measurement: repo traffic + schedule drift $(date -u +%Y-%m-%d)"
-          bash ops/publish/safe_push.sh
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: assets/data/repo-traffic.json assets/data/schedule-drift.json
+          message: ${{ env.COMMIT_MESSAGE }}

--- a/.github/workflows/screenshot-refresh.yml
+++ b/.github/workflows/screenshot-refresh.yml
@@ -43,10 +43,14 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      # `.[imaging]` up front: the GIF steps below are dispatch-only but
+      # validate_sidecar screenshots fully decodes the PNGs on every run, so
+      # Pillow is needed unconditionally. Installing it once here replaces two
+      # separate `pip install` lines that had to stay in sync.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
-          python-version: "3.11"
+          install: '.[imaging]'
 
       - name: Install Playwright + Chromium
         run: |
@@ -68,21 +72,11 @@ jobs:
       # UI actually changed); the two small PNGs still refresh every week.
       - name: Assemble tab-cycle GIF
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          python3 -m pip install --quiet -e '.[imaging]'
-          python3 site/tools/assemble_dashboard_gif.py
+        run: python3 site/tools/assemble_dashboard_gif.py
 
       - name: Validate tab-cycle GIF
         if: github.event_name == 'workflow_dispatch'
         run: clawock validate-sidecar gif
-
-      # validate_screenshots now fully decodes the PNGs (finding #12), and this
-      # runs on BOTH schedule and dispatch — the GIF steps above install Pillow
-      # only on workflow_dispatch, so install it unconditionally here. Kept as a
-      # separate step so the validate step's command stays exactly the validator
-      # invocation (workflow-contract test).
-      - name: Install Pillow for screenshot decode
-        run: python3 -m pip install --quiet -e '.[imaging]'
 
       - name: Validate screenshots
         run: clawock validate-sidecar screenshots
@@ -98,22 +92,22 @@ jobs:
           python ops/growth/refresh_readme_metrics.py --data-plane data-plane/assets/data \
             || [ $? -eq 1 ]
 
+      - name: Compose the commit target
+        run: |
+          # Only a manual run rebuilds the GIF, so only a manual run may commit it.
+          paths="site/assets/shadow-backtest.png site/assets/social-card.png"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            paths="$paths site/assets/dashboard.gif"
+          fi
+          # README metrics placeholders + audit file (refreshed above).
+          paths="$paths README.zh.md README.md assets/data/readme_metrics.json"
+          echo "COMMIT_PATHS=$paths" >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=docs: README refresh (visuals + metrics) $(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - name: Commit if changed
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -- site/assets/shadow-backtest.png site/assets/social-card.png
-          # Only a manual run rebuilds the GIF, so only a manual run may commit it.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git add -- site/assets/dashboard.gif
-          fi
-          # README metrics placeholders + audit file (refreshed above).
-          git add README.zh.md README.md assets/data/readme_metrics.json
-          if git diff --cached --quiet; then
-            echo "no change"
-            exit 0
-          fi
-          git commit -m "docs: README refresh (visuals + metrics) $(date -u +%Y-%m-%d)"
-          bash ops/publish/safe_push.sh
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: ${{ env.COMMIT_PATHS }}
+          message: ${{ env.COMMIT_MESSAGE }}

--- a/.github/workflows/seo-visibility.yml
+++ b/.github/workflows/seo-visibility.yml
@@ -27,14 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      # The extra, not a hand-written package line — dependencies live in
+      # pyproject so a version cannot drift between here and there.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
         with:
           python-version: '3.12'
-
-      - name: Install
-        # The extra, not a hand-written package line — dependencies live in
-        # pyproject so a version cannot drift between here and there.
-        run: pip install --quiet -e '.[seo]'
+          install: '.[seo]'
 
       - name: Query Search Console
         env:

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -34,15 +34,15 @@ jobs:
       - name: Validate generated review
         run: clawock validate-sidecar weekly-review
 
+      - name: Compose the commit target
+        run: |
+          echo "COMMIT_PATHS=memory/weekly/$(date -u +%G-W%V).md" >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=memory: weekly review $(date -u +%Y-W%V)" >> "$GITHUB_ENV"
+
       - name: Commit + push
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          review_path="memory/weekly/$(date -u +%G-W%V).md"
-          git add -- "$review_path"
-          if ! git diff --cached --quiet; then
-            git commit -m "memory: weekly review $(date -u +%Y-W%V)"
-            bash ops/publish/safe_push.sh
-          fi
+        uses: ./.github/actions/clawock-commit
+        with:
+          paths: ${{ env.COMMIT_PATHS }}
+          message: ${{ env.COMMIT_MESSAGE }}

--- a/tests/test_coverage_badge.py
+++ b/tests/test_coverage_badge.py
@@ -242,9 +242,16 @@ def test_the_coverage_plugin_is_installed_where_it_is_used():
     # guarantee is checked at the new source of truth instead.
     import tomllib
 
+    # The install moved into the clawock-python composite (#806), so the extra
+    # is now named at the call site rather than in a `pip install` line. Same
+    # guarantee, one indirection: exactly one place in this workflow asks for it.
     installs = [line for line in strip_hash_comments(WORKFLOW.read_text()).splitlines()
-                if 'pip install' in line and '[test]' in line]
+                if "'.[test]'" in line]
     assert len(installs) == 1, 'the suite must install the test extra exactly once'
+    assert 'clawock-python' in WORKFLOW.read_text(), (
+        'the install has to go through the one composite, or the pinned Python '
+        'and the extra drift apart again'
+    )
 
     extras = tomllib.load(open(ROOT / 'pyproject.toml', 'rb'))[
         'project']['optional-dependencies']

--- a/tests/test_eod_archive_workflow_contract.py
+++ b/tests/test_eod_archive_workflow_contract.py
@@ -2,7 +2,7 @@
 import re
 from pathlib import Path
 
-from workflow_contract_helpers import assert_validator_step, step_run, steps
+from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,7 +26,6 @@ def test_eod_archive_requires_current_snapshot_coverage_before_publish():
 
     append_run = _step_run('Append week-end snapshot')
     assert "fpath = 'memory/archive/eod-history.csv'" in append_run
-    commit_run = _step_run('Commit')
-    add_lines = [line.strip() for line in commit_run.splitlines()
-                 if re.match(r'^\s*git add(?:\s|$)', line)]
-    assert add_lines == ['git add memory/archive/']
+    # The step moved to the clawock-commit composite (#806); the contract is
+    # unchanged — exactly this path, and only after the validator.
+    assert staged_paths(WORKFLOW, 'Commit') == ['memory/archive/']

--- a/tests/test_news_digest_workflow_contract.py
+++ b/tests/test_news_digest_workflow_contract.py
@@ -2,7 +2,7 @@
 import re
 from pathlib import Path
 
-from workflow_contract_helpers import assert_validator_step, step_run, steps
+from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +26,6 @@ def test_news_digest_is_validated_before_publish():
 
     assert_validator_step(WORKFLOW, 'Validate generated digest', 'news-digest')
 
-    commit_run = _step_run('Commit + push')
-    assert 'git add assets/data/us_news_digest.json' in commit_run
-    assert not re.search(r'(?m)^\s*git add\s+assets/data/?\s*$', commit_run)
+    # Moved to the clawock-commit composite (#806). Staging the whole of
+    # assets/data/ would sweep up whatever else the runner happened to write.
+    assert staged_paths(WORKFLOW, 'Commit + push') == ['assets/data/us_news_digest.json']

--- a/tests/test_screenshot_refresh_workflow_contract.py
+++ b/tests/test_screenshot_refresh_workflow_contract.py
@@ -2,7 +2,7 @@
 import re
 from pathlib import Path
 
-from workflow_contract_helpers import assert_validator_step, step_block, step_run, steps
+from workflow_contract_helpers import assert_validator_step, step_block, step_run, steps, staged_paths
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,17 +30,26 @@ def test_screenshots_are_validated_and_exactly_staged_before_publish():
 
     assert_validator_step(WORKFLOW, validate, 'screenshots')
 
-    commit_run = _step_run(commit)
-    add_lines = [line.strip() for line in commit_run.splitlines()
-                 if re.match(r'^git add(?:\s|$)', line.strip())]
     # The staged set is a contract: the two PNGs always, the GIF only on manual
-    # dispatch, and exactly the README metrics files. No other `git add` may
-    # creep in (this was relaxed to any(...) once and had to be pinned back).
-    assert add_lines == [
-        'git add -- site/assets/shadow-backtest.png site/assets/social-card.png',
-        'git add -- site/assets/dashboard.gif',
-        'git add README.zh.md README.md assets/data/readme_metrics.json',
-    ], add_lines
+    # dispatch, and exactly the README metrics files. No other path may creep in
+    # (this was relaxed to any(...) once and had to be pinned back). The step
+    # moved to the clawock-commit composite in #806, so the list is now read
+    # from the env var the workflow computes rather than from `git add` lines —
+    # same contract, one indirection.
+    assert staged_paths(WORKFLOW, commit) == [
+        'site/assets/shadow-backtest.png',
+        'site/assets/social-card.png',
+        'site/assets/dashboard.gif',
+        'README.zh.md',
+        'README.md',
+        'assets/data/readme_metrics.json',
+    ]
+
+    # And the GIF must still be conditional on a manual dispatch — the composite
+    # takes a flat list, so the condition lives in the step that builds it.
+    composer = _step_run('Compose the commit target')
+    assert "github.event_name }}\" = \"workflow_dispatch\"" in composer
+    assert 'site/assets/dashboard.gif' in composer.split('workflow_dispatch', 1)[1]
 
 
 def test_metrics_step_tolerates_only_the_no_change_exit_code():

--- a/tests/test_weekly_review_workflow_contract.py
+++ b/tests/test_weekly_review_workflow_contract.py
@@ -2,7 +2,7 @@
 import re
 from pathlib import Path
 
-from workflow_contract_helpers import assert_validator_step, step_run, steps
+from workflow_contract_helpers import assert_validator_step, step_run, steps, staged_paths
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -23,9 +23,8 @@ def test_weekly_review_is_validated_and_exactly_staged_before_publish():
 
     assert_validator_step(WORKFLOW, 'Validate generated review', 'weekly-review')
 
-    commit_run = _step_run('Commit + push')
-    assert 'review_path="memory/weekly/$(date -u +%G-W%V).md"' in commit_run
-    add_lines = [line.strip() for line in commit_run.splitlines()
-                 if re.match(r'^\s*git add(?:\s|$)', line)]
-    assert add_lines == ['git add -- "$review_path"']
-    assert not re.search(r'(?m)^\s*git add\s+(?:--\s+)?memory/weekly/?\s*$', commit_run)
+    staged = staged_paths(WORKFLOW, 'Commit + push')
+    assert 'memory/weekly/$(date -u +%G-W%V).md' in _step_run('Compose the commit target')
+    # Moved to the clawock-commit composite (#806): exactly this week's file,
+    # never the whole memory/weekly/ directory.
+    assert staged == ['memory/weekly/$(date -u +%G-W%V).md'], staged

--- a/tests/test_workflow_composites.py
+++ b/tests/test_workflow_composites.py
@@ -1,0 +1,112 @@
+"""One door for Python setup, one door for publishing to master.
+
+Both composites already existed in spirit. `clawock-python` even documents the
+problem in its own header — "Seven copies is seven places to forget" — and seven
+*other* workflows went on hand-rolling the same two steps anyway (#806). The
+versions then drifted into two setup-python majors with the older one sitting on
+the release chain, and the most recently hand-rolled copy was added by the same
+session that was quoting that header.
+
+The publishing side is not a tidiness question at all. master's ruleset bypasses
+exactly one actor, the deploy key, so a copy that reaches for a plain `git push`
+is rejected — and it finds out on its first scheduled run, after doing the work,
+with the runner about to be discarded (#803).
+
+A comment did not hold either of these. An assertion might.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+ACTIONS = ROOT / ".github" / "actions"
+
+# brief-fallback publishes through its own step on purpose: it gates on
+# logs/brief_postflight_status.json before committing, and pushes only when HEAD
+# is genuinely ahead of FETCH_HEAD — postflight's internal commit can succeed
+# while its push fails, and gating on a dirty index would strand that commit on
+# a runner about to be destroyed. That is a documented difference, not a copy.
+PUBLISHES_ITS_OWN = {"brief-fallback.yml"}
+
+
+def test_the_workflows_exist_so_none_of_this_passes_vacuously():
+    assert len(WORKFLOWS) > 10
+    assert (ACTIONS / "clawock-python" / "action.yml").is_file()
+    assert (ACTIONS / "clawock-commit" / "action.yml").is_file()
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_no_workflow_sets_up_python_by_hand(workflow):
+    """The pinned version has to be decided in one place. When it was not, the
+    release chain quietly stayed a major version behind everything else."""
+    assert "actions/setup-python@" not in workflow.read_text(encoding="utf-8"), (
+        f"{workflow.name} pins its own Python. Use ./.github/actions/clawock-python "
+        "— it takes `python-version` and `install` (including `install: none` for "
+        "jobs that need no package)."
+    )
+
+
+def test_the_composite_is_the_only_place_that_pins_python():
+    composite = (ACTIONS / "clawock-python" / "action.yml").read_text(encoding="utf-8")
+    assert "actions/setup-python@" in composite
+
+
+def test_the_no_install_escape_hatch_actually_skips_the_install():
+    """`install: none` exists so a stdlib-only job still comes through the one
+    door. If the guard is dropped, those jobs silently gain a pip install and
+    the escape hatch becomes a lie."""
+    composite = (ACTIONS / "clawock-python" / "action.yml").read_text(encoding="utf-8")
+    assert "if: inputs.install != 'none'" in composite
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_no_workflow_hand_rolls_the_commit_and_push(workflow):
+    text = workflow.read_text(encoding="utf-8")
+    if "git config user.name" not in text:
+        return
+    assert workflow.name in PUBLISHES_ITS_OWN, (
+        f"{workflow.name} hand-rolls the bot identity and commit. Use "
+        "./.github/actions/clawock-commit, which is also the only thing that "
+        "guarantees the push goes through safe_push.sh — master's ruleset "
+        "rejects anything else, and a copy discovers that on its first "
+        "scheduled run, after doing the work."
+    )
+
+
+def test_the_documented_exception_still_earns_it():
+    """If brief-fallback ever loses the two things that make it different, it is
+    a copy again and belongs in the composite."""
+    text = (ROOT / ".github" / "workflows" / "brief-fallback.yml").read_text(encoding="utf-8")
+    assert "brief_postflight_status.json" in text, "the publish gate is gone"
+    assert "FETCH_HEAD" in text, "the ahead-of-remote check is gone"
+    assert "safe_push.sh" in text
+
+
+def test_the_commit_composite_can_only_publish_through_safe_push():
+    action = (ACTIONS / "clawock-commit" / "action.yml").read_text(encoding="utf-8")
+    assert "ops/publish/safe_push.sh" in action
+    code = "\n".join(l for l in action.splitlines() if not l.lstrip().startswith("#"))
+    assert "git push" not in code, (
+        "the composite must not push directly; safe_push.sh owns the deploy key, "
+        "the rebase-retry and the conflict-marker guard"
+    )
+
+
+def test_the_commit_composite_stages_nothing_when_nothing_changed():
+    """Every copy it replaced had this, and a composite that lost it would turn
+    ~35 quiet scheduled runs a week into ~35 empty commits."""
+    action = (ACTIONS / "clawock-commit" / "action.yml").read_text(encoding="utf-8")
+    assert "git diff --cached --quiet" in action
+    assert "committed=false" in action
+
+
+def test_the_deploy_key_is_not_an_input_to_the_composite():
+    """It stays an `env:` at step scope, which is the shape the deploy-key
+    scoping test enforces. Threading it through `with:` would move a secret into
+    a place that test cannot see."""
+    action = (ACTIONS / "clawock-commit" / "action.yml").read_text(encoding="utf-8")
+    inputs = action.split("inputs:", 1)[1].split("runs:", 1)[0]
+    assert "CLAWOCK_PUBLISH_SSH_KEY" not in inputs

--- a/tests/workflow_contract_helpers.py
+++ b/tests/workflow_contract_helpers.py
@@ -92,3 +92,79 @@ def assert_validator_step(workflow: Path, step_name: str, validator_name: str) -
     block = step_block(workflow, step_name)
     assert 'continue-on-error' not in block
     assert step_run(workflow, step_name) == f'{VALIDATOR_COMMAND} {validator_name}'
+
+
+def staged_paths(workflow: Path, name: str) -> list[str]:
+    """What a publishing step stages, whichever shape it is written in.
+
+    Five workflows moved from an inline `git add` to the `clawock-commit`
+    composite (#806). The contract those tests protect is unchanged — exactly
+    these paths, and only after validation — so the extraction adapts rather
+    than the assertions being dropped.
+
+    The composite form can name the paths inline (`paths: a b`) or through an
+    env var the caller computed (`paths: ${{ env.COMMIT_PATHS }}`), because a
+    `with:` cannot run shell. In the second case the literal is read out of the
+    step that wrote it, so a workflow cannot hide what it stages behind an
+    indirection.
+    """
+    block = step_block(workflow, name)
+    if 'clawock-commit' in block:
+        line = next(ln for ln in block.splitlines() if ln.strip().startswith('paths:'))
+        value = line.split('paths:', 1)[1].strip()
+        if value.startswith('${{'):
+            var = value.split('env.', 1)[1].split('}', 1)[0].strip()
+            text = strip_hash_comments(workflow.read_text())
+            assign = next(ln for ln in text.splitlines()
+                          if f'{var}=' in ln and 'GITHUB_ENV' in ln)
+            value = assign.split(f'{var}=', 1)[1].split('"', 1)[0].strip()
+            # A computed list is spelled `$paths`; resolve the shell variable it
+            # accumulates so the assertion still sees real paths.
+            if value.startswith('$'):
+                shell = strip_hash_comments(step_block(workflow, _writer_step(workflow, var)))
+                parts: list[str] = []
+                for ln in shell.splitlines():
+                    stripped = ln.strip()
+                    if stripped.startswith('paths='):
+                        chunk = stripped.split('=', 1)[1].strip().strip('"')
+                        parts += [t for t in chunk.split() if not t.startswith('$')]
+                return parts
+        return _split_paths(value)
+
+    add_lines = [ln.strip() for ln in step_run(workflow, name).splitlines()
+                 if ln.strip().startswith('git add')]
+    out: list[str] = []
+    for line in add_lines:
+        out += [t for t in line.removeprefix('git add').split() if t != '--']
+    return out
+
+
+def _split_paths(value: str) -> list[str]:
+    """Split on spaces, but keep a `$(date ...)` substitution as one token.
+
+    A naive split turns `memory/weekly/$(date -u +%G-W%V).md` into three paths
+    and the assertion then compares nonsense to nonsense.
+    """
+    out, buf, depth = [], '', 0
+    for ch in value:
+        if ch == '(' and buf.endswith('$'):
+            depth += 1
+        elif ch == ')' and depth:
+            depth -= 1
+        if ch == ' ' and not depth:
+            if buf:
+                out.append(buf)
+            buf = ''
+            continue
+        buf += ch
+    if buf:
+        out.append(buf)
+    return out
+
+
+def _writer_step(workflow: Path, var: str) -> str:
+    """Name of the step that writes `var` into GITHUB_ENV."""
+    for _, name in steps(workflow):
+        if f'{var}=' in step_block(workflow, name):
+            return name
+    raise AssertionError(f'nothing writes {var} into GITHUB_ENV')


### PR DESCRIPTION
Closes #806

kcn:「action 太多了而且很杂」。上一批我只做了「能 skip 的」那半（CodeQL 跳过纯数据 commit、PR 级并发取消、版本对齐），**「统一化」那半从清单里掉了**。这个 PR 是补票。

## 1. composite 早就存在，一半 workflow 不用它

`.github/actions/clawock-python` 的文件头自己写着：

> Seven scheduled workflows opened with byte-identical steps … **Seven copies is seven places to forget when the pinned version moves**

结果**另外 7 个 workflow 照样手搓**，而且代价已经付过了：`setup-python` 漂成 v6/v7 两套、`upload-artifact` v5/v7、`download-artifact` v6/v8，**旧的那份正好落在发布链上**（#791 才对齐）。

最扎眼的是 `repo-traffic` —— **我上周自己加的**，一边引用这个 composite 的存在一边没用它。说明这不是「大家忘了」，是没有任何东西阻止下一个人再手搓一份。

现在：

```
$ grep -c "setup-python@" .github/workflows/*.yml | grep -v ":0"
（空）
```

composite 加了 `install: none`，让只需要「钉死的版本」而不装包的 job（cron-health、repo-traffic、harness-regression 的 publish-coverage）也走同一个门 —— **版本只在一个地方定，哪怕安装不在**。

顺带清掉了 `screenshot-refresh` 里两条必须互相保持同步的 `pip install '.[imaging]'`。

## 2. commit+push 样板复制了 6 份，而这不是洁癖问题

master 的 ruleset 只放行**一个** actor（deploy key）。一份拷贝里把 `safe_push.sh` 写成裸 `git push`，就会**在第一次排期运行时才炸** —— 活干完了、数据采完了、推送失败、runner 销毁。

那就是 **#803**，而写出它的正是刚读完其他五份拷贝的那个会话（我）。

新增 `.github/actions/clawock-commit`，收掉 5 处。`safe_push.sh` 还负责另外两件不该被每个 workflow 重新发明的事：对每天 ~35 次提交的 rebase 重试，和那条因为半合并的 `dashboard.json` 把公开面板刷白过而存在的 conflict-marker 闸。

**`brief-fallback` 不动**：它 commit 前要过 `logs/brief_postflight_status.json` 发布闸，push 前要判 HEAD 是否真的领先 FETCH_HEAD（postflight 内部 commit 可能成功而 push 失败，按脏索引判断会把那个 commit 遗留在即将销毁的 runner 上）。这是**被文档化的差异，不是重复**，而且加了断言 —— 哪天它丢了这两个特征，就该并回 composite。

deploy key **刻意不做成 input**，仍然是调用步骤上的 `env:` —— 那正是 `test_each_publishing_workflow_scopes_deploy_key_to_push_step` 检查的形状（这条闸在我第一次改 #803 时就当场逮到过我）。

## 3. 一条断言都没删

4 个既有 workflow 契约测试是按内联形状写的（`git add` 行）。**没有降级成 `any(...)`，也没有删掉** —— 给共享 helper 加了 `staged_paths()`，同时能从内联 `git add` 和 composite 的 `with: paths:` 两种形状里读出暂存集合，包括「caller 用 shell 算出来再经 `$GITHUB_ENV` 传进去」那种（`with:` 跑不了 shell）：

```python
assert staged_paths(WORKFLOW, commit) == [
    'site/assets/shadow-backtest.png', 'site/assets/social-card.png',
    'site/assets/dashboard.gif', 'README.zh.md', 'README.md',
    'assets/data/readme_metrics.json',
]
# GIF 仍必须只在手动 dispatch 时进暂存 —— composite 收的是扁平列表，
# 所以那个条件挪到了算列表的那一步，断言跟过去了
```

保护的不变量一字未改：**只暂存这些路径，且在校验之后**。

## 4. 新增 8 条闸，防止一年后原样再来一次

- 任何 workflow 出现裸 `setup-python@` → 红
- 任何 workflow 手搓 `git config user.name` → 红（`brief-fallback` 是名单内唯一例外，且它必须仍然带着那两个特征）
- composite 里出现 `git push` → 红
- `install: none` 的跳过逻辑被拿掉 → 红（否则那些 job 会静默多出一个 pip install，逃生舱变成谎言）
- deploy key 被挪进 `with:` → 红

## 不做什么

- **`pull_request` 不加路径过滤**。`validate` / `lint` / 四个 CodeQL context 是 required check，被过滤掉就永不上报、PR 永远合不了（`actionlint.yml` 已记过这个坑）。核过了，现在所有 `NO-FILTER` 都是这个原因。
- **`Dashboard Artifact Gate` 不折进 `pages.yml`**。#749 提过并被明确否决，理由写在文件头（detect, never silence），不翻案。

## 验证

```
$ pytest tests/ -q
2433 passed, 5 skipped, 4 xfailed

$ /tmp/actionlint     # pinned 1.7.12，与 CI 同一个
exit 0
```

一处诚实记录：某一次全套运行里 `test_dropped_blocks_are_still_reachable_elsewhere` 红过一次，**单独跑绿、重跑全套绿、master 全套也绿**。是既有的测试间产物污染（跑测试会重写发布产物），不是这个 diff 引入的；我没有深挖它，先记在这里。
