### PR TITLE
release: 钉死发布器、让 environment 的注释变成真的、PR 上加依赖审查

### DIFF
--- a/.github/workflows/harness-regression.yml
+++ b/.github/workflows/harness-regression.yml
@@ -76,6 +76,25 @@ jobs:
         # degrade), never a non-zero that reds the whole cron. Offline + pure Node.
         run: node skills/tavily-search/scripts/search.test.mjs
 
+      - name: Dependency review
+        # #784 gave Dependabot the pip and npm trees, but that only reports
+        # AFTER a dependency is on master. This is the PR-time half: GitHub's
+        # own action reads the dependency diff and objects to a newly introduced
+        # known-vulnerable package, or one whose licence the project cannot take.
+        #
+        # Deliberately advisory (`continue-on-error`) and deliberately NOT a
+        # required check. Its red is decided by the outside world — a CVE
+        # disclosed this morning against a dependency nobody touched — not by
+        # the diff under review. Making that block every PR is how a gate turns
+        # into something people route around. Start at `high`, watch what it
+        # actually catches, tighten later with data.
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: false
+
       - name: PR file safety policy
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,22 @@ jobs:
     # Trusted publishing: PyPI verifies this workflow's OIDC identity, so there is
     # no long-lived API token in repository secrets to leak or rotate. One-time
     # setup on the PyPI side is documented in docs/operations/release.md.
+    #
+    # The environment is also the gate on WHERE a publish may come from. It used
+    # to be neither: #810 found `protection_rules: []` and
+    # `deployment_branch_policy: null`, while this comment asserted the
+    # environment also carried a reviewer requirement — describing a control
+    # nobody had configured, which is worse than saying nothing, because the
+    # next reader assumes someone is watching that door.
+    #
+    # It now carries a deployment branch policy of exactly one entry, tag `v*`.
+    # Measured both directions before trusting it: dispatching this workflow
+    # from a branch with `repository: pypi` fails with the publish job running
+    # ZERO steps (run 32551418697), while the same dispatch from a tag runs the
+    # job for real (run 32551500712, which then stopped at PyPI's own "File
+    # already exists" because the version was unchanged). No required reviewer:
+    # that is friction on every release and is a preference, not a defect —
+    # unlike the branch hole, which was reachable.
     environment: ${{ inputs.repository || 'pypi' }}
     permissions:
       id-token: write
@@ -106,7 +122,25 @@ jobs:
           path: dist/
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to a commit, not to the moving `release/v1` (#808). This
+        # repository has already paid for letting something outside it decide
+        # which version of a publishing tool runs: v0.1.6 half-published because
+        # the runner image's bundled npm crashed, and the fix was pinning npm.
+        # The PyPI half was still on a mutable ref.
+        #
+        # NOT the SHA that `refs/tags/v1.14.2` points at — that is an annotated
+        # tag object (a892a5a6…). The commit is one dereference further in.
+        #
+        # `attestations` is deliberately not set: the action defaults it to
+        # 'true' and PEP 740 attestations are already being issued. Verified on
+        # the published artifact rather than assumed:
+        #   GET https://pypi.org/integrity/clawock/0.1.8/<file>/provenance
+        #   -> publisher {kind: GitHub, repository: KCNyu/clawock,
+        #                 workflow: release.yml, environment: pypi}
+        # (The /pypi/{pkg}/json view reports `provenance: null` for every
+        # package including sigstore and uv, so it cannot be used to check this.
+        # #808 was originally filed off that mistake.)
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: ${{ inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
 

--- a/tests/test_github_release_contract.py
+++ b/tests/test_github_release_contract.py
@@ -1,5 +1,6 @@
 """A PyPI version must leave a matching, honest first-party release page."""
 from pathlib import Path
+import re
 
 import pytest
 import json
@@ -248,3 +249,40 @@ def test_the_npm_publish_carries_provenance():
         "provenance must be gated on an actually-present OIDC token, so a local "
         "publish degrades instead of failing"
     )
+
+
+def test_the_pypi_publisher_is_pinned_to_a_commit():
+    """A moving ref decides, from outside this repository, what code performs an
+    irreversible publish.
+
+    This is not hypothetical here. v0.1.6 half-published — PyPI accepted it,
+    npm died — because the runner image's bundled npm crashed, and the fix was
+    to pin npm. The PyPI half was still on `@release/v1`, whose contents change
+    without anything in this repository moving (#808).
+    """
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    publish = workflow.split("\n      - name: Publish\n", 1)[1].split("\n  npm:", 1)[0]
+    ref = next(line.split("@", 1)[1].split()[0]
+               for line in publish.splitlines()
+               if "gh-action-pypi-publish@" in line)
+    assert re.fullmatch(r"[0-9a-f]{40}", ref), (
+        f"the PyPI publisher must be pinned to a 40-character commit sha, got {ref!r}"
+    )
+    assert "# v" in publish, "the pin needs a human-readable version comment beside it"
+
+
+def test_the_environment_comment_does_not_claim_controls_that_do_not_exist():
+    """#810: the comment claimed the pypi environment carried a required
+    reviewer while `protection_rules` was empty. A comment describing a control
+    nobody configured is worse than none — the next reader assumes somebody is
+    watching that door.
+
+    The claim is now a branch policy, which is what is actually configured, and
+    the comment records the two runs that measured it in both directions.
+    """
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    publish_job = workflow.split("\n  publish:\n", 1)[1].split("\n  npm:", 1)[0]
+    assert "required reviewer as well" not in publish_job, (
+        "the environment carries no required reviewer; do not say it does"
+    )
+    assert "deployment branch policy" in publish_job

--- a/tests/test_workflow_composites.py
+++ b/tests/test_workflow_composites.py
@@ -17,6 +17,7 @@ A comment did not hold either of these. An assertion might.
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 import pytest
 
@@ -110,3 +111,39 @@ def test_the_deploy_key_is_not_an_input_to_the_composite():
     action = (ACTIONS / "clawock-commit" / "action.yml").read_text(encoding="utf-8")
     inputs = action.split("inputs:", 1)[1].split("runs:", 1)[0]
     assert "CLAWOCK_PUBLISH_SSH_KEY" not in inputs
+
+
+def test_dependency_review_runs_on_prs_without_being_able_to_block_them():
+    """#811. Dependabot reports after a dependency lands on master; this is the
+    PR-time half.
+
+    It is advisory on purpose. Its red is decided by the outside world — a CVE
+    disclosed this morning against a package nobody in this PR touched — rather
+    than by the diff. A gate whose failures are unrelated to the change under
+    review is one people learn to route around, and this repository has already
+    paid for false reds several times over.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "harness-regression.yml").read_text(encoding="utf-8")
+    assert "dependency-review-action@" in workflow
+
+    step = workflow.split("- name: Dependency review", 1)[1].split("- name:", 1)[0]
+    assert "github.event_name == 'pull_request'" in step, "it can only read a PR diff"
+    assert "continue-on-error: true" in step, (
+        "dependency review must not be able to fail the required `validate` check"
+    )
+
+    ref = next(line.split("@", 1)[1].split()[0] for line in step.splitlines()
+               if "dependency-review-action@" in line)
+    assert re.fullmatch(r"[0-9a-f]{40}", ref), f"pin it to a commit, got {ref!r}"
+
+
+def test_the_required_check_list_has_not_quietly_grown():
+    """If dependency review is ever added to the ruleset's required contexts,
+    the reasoning above is void and this should be a deliberate decision, not a
+    side effect."""
+    workflow = (ROOT / ".github" / "workflows" / "harness-regression.yml").read_text(encoding="utf-8")
+    job = workflow.split("\n  validate:", 1)[1].split("\n  smoke-data-fetch:", 1)[0]
+    advisory = [name for name in ("Dependency review",) if f"- name: {name}" in job]
+    for name in advisory:
+        block = job.split(f"- name: {name}", 1)[1].split("- name:", 1)[0]
+        assert "continue-on-error: true" in block


### PR DESCRIPTION
Closes #808, closes #810, closes #811

三条都落在发布链这条**不可回退**的路上。

## 1. `pypi` environment 的注释在说谎（#810）

原注释：

> the `pypi` environment lets that decision **carry a required reviewer** as well

实测：

```
$ gh api repos/KCNyu/clawock/environments/pypi --jq '{protection_rules,deployment_branch_policy}'
{"protection_rules": [], "deployment_branch_policy": null}
```

**一条规则都没有。** 而这个洞是**可达**的：`workflow_dispatch` 带 `repository: pypi` 输入，可以从任意分支触发。

### 修法 + 双向实测（先验证再信，不是反过来）

加了 deployment branch policy，只有一条：tag `v*`。

| 触发方式 | publish job | 结论 |
|---|---|---|
| 从分支 dispatch（`repository=pypi`）| **steps=0** | 被 environment 挡在门外，一步没跑 |
| 从 tag dispatch | **steps=5** | 正常进入，止于 PyPI 自己的 `400 File already exists` |

两次 run：[32551418697](https://github.com/KCNyu/clawock/actions/runs/32551418697)（分支，拦住）/ [32551500712](https://github.com/KCNyu/clawock/actions/runs/32551500712)（tag，放行）。第二次刻意用了一个**版本号没变**的构建，PyPI 直接拒重传，**没有发出任何新东西**。

**不加 required reviewer**：那是每次发版都要付的摩擦，属于偏好不是缺陷；而分支那个洞是真实可达的，属于缺陷。

注释改成与实际配置一致，并加断言钉住 —— 描述一个不存在的安全控制，比不写更糟。

## 2. 发布器跑在移动 ref 上（#808，范围已收窄）

```yaml
uses: pypa/gh-action-pypi-publish@release/v1        # 内容会变
```

这不是假想问题：**v0.1.6 半发布**的根因就是 runner 镜像自带的 npm，修法是把 npm 钉到 `10.9.8`。PyPI 这半一直没受同等待遇。

现钉到 v1.14.2 的 commit。**一个容易踩的坑**：`refs/tags/v1.14.2` 指向的是 annotated tag 对象 `a892a5a6…`，真正的 commit 要再解一层才是 `dc37677b…`。钉错了那层就是钉了个假东西。

## 3. `attestations` 刻意不加 —— 因为 #808 的原始论点是我搞错了

原 issue 说「PyPI 侧没有 attestation」。**那是错的**，我用错了 API。

```
/pypi/{pkg}/json 的 urls[].provenance
  cryptography=None  pydantic-core=None  httpx=None  uv=None  sigstore=None
```

五个对照组全是 `None`，包括 `sigstore` 和 `uv` —— 那显然不是「大家都没有」。正确的是 integrity API：

```
$ curl -s https://pypi.org/integrity/clawock/0.1.8/clawock-0.1.8-py3-none-any.whl/provenance
publisher: {"kind":"GitHub","repository":"KCNyu/clawock",
            "workflow":"release.yml","environment":"pypi"}
```

**wheel 和 sdist 都有 attestation，一直都有**（action 的 `attestations` 默认就是 `'true'`）。所以显式写 `attestations: true` 是多余的，我没加，只把这段经过写进注释，免得下一个人重犯。

**方法学教训**：「查不到」≠「不存在」。任何「X 没有 Y」的结论，先拿一个已知有 Y 的对照组验测量方法 —— 这次五个对照组一起翻红，问题立刻现形。

## 4. PR 时点的依赖闸（#811）

Dependabot 只在依赖**已经进 master** 之后报。PR 这一侧此前什么都没有。

加进已有的 `validate` job（**不新开 workflow** —— #806 刚把「action 太多而且很杂」收敛完，别马上又加一个文件）。

**advisory，且刻意不设为 required**：它的红由外部世界决定（今早新披露的 CVE，打在这个 PR 根本没碰的包上），不是由 diff 决定。让这种红卡住所有 PR，就是把闸变成人人绕行的东西 —— 这个仓库为假红付过太多次学费。先 `high` 起步，看它一个月里真正抓到什么，有数据再收紧。

## 验证

```
$ pytest tests/ -q
2437 passed, 5 skipped, 4 xfailed

$ /tmp/actionlint
exit 0
```

新增 4 条断言：publisher 必须是 40 位 commit SHA 且带版本注释、环境注释不得声称不存在的控制、dependency-review 必须 `continue-on-error` 且只在 PR 上跑、pin 必须是 commit。
