### PR TITLE
docs: v* tag 已冻结，以及打错 tag 时该怎么办（#809）

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -92,6 +92,34 @@ The workflow refuses a tag that disagrees with `pyproject.toml`, because a
 mismatch publishes a version nobody asked for under a name the changelog already
 uses for something else.
 
+### A `v*` tag cannot be moved or deleted once pushed
+
+Ruleset `21184290` (`target: tag`, `refs/tags/v*`) carries `deletion`, `update`
+and `non_fast_forward`. It exists because `--verify-tag` only checks that a tag
+exists, not that it still points where it did: a moved tag puts different code
+behind a version number that has already been announced, and this repository has
+already shipped one same-version-two-builds incident on the npm side (#712).
+
+**So a mistyped tag cannot be fixed in place.** The recovery is deliberate
+friction, not a bug:
+
+```bash
+gh api -X PUT repos/KCNyu/clawock/rulesets/21184290 -f enforcement=disabled
+git push --delete origin v0.2.0        # or force it to the right commit
+gh api -X PUT repos/KCNyu/clawock/rulesets/21184290 -f enforcement=active
+```
+
+Prefer burning the next patch number over reopening the gate. Reaching for the
+`disabled` switch on a tag that has already been published anywhere — PyPI, npm,
+a GitHub Release — is the wrong move regardless: those consumers kept a copy,
+and moving the tag only makes the three disagree.
+
+One trap worth knowing, because it cost a real tag to find: `non_fast_forward`
+alone does **not** stop this. Moving an old release tag *forward* onto newer code
+is a fast-forward, so it passes that rule — `update` is the one that blocks it.
+Verify rules like this on a throwaway tag, never on a published one.
+
+
 After real PyPI publication succeeds, the same workflow creates the matching
 GitHub Release, attaches the verified sdist/wheel and renders only that version's
 `CHANGELOG.md` section plus its versioned PyPI link. TestPyPI dispatches do not

--- a/tests/test_github_release_contract.py
+++ b/tests/test_github_release_contract.py
@@ -286,3 +286,20 @@ def test_the_environment_comment_does_not_claim_controls_that_do_not_exist():
         "the environment carries no required reviewer; do not say it does"
     )
     assert "deployment branch policy" in publish_job
+
+
+def test_the_runbook_explains_that_a_pushed_version_tag_is_frozen():
+    """#809 made `v*` tags immutable, which changes what a mistyped tag costs.
+
+    A rule that silently makes the normal recovery impossible is how somebody
+    concludes the repository is broken at 2am. The runbook has to carry both the
+    escape hatch and the reason not to reach for it.
+    """
+    runbook = (ROOT / "docs" / "operations" / "release.md").read_text(encoding="utf-8")
+    assert "cannot be moved or deleted once pushed" in runbook
+    assert "enforcement=disabled" in runbook, "the recovery path must be written down"
+    assert "enforcement=active" in runbook, "and so must putting the rule back"
+    assert "non_fast_forward" in runbook and "update" in runbook, (
+        "the trap that cost a real tag — a forward move passes non_fast_forward — "
+        "has to be recorded, or the next person configures the same weak rule"
+    )


### PR DESCRIPTION
Closes #809

ruleset `21184290` 已经上线并双向验过（详见 #809 的评论）。这个 PR 补的是**它带来的操作后果**。

## 规则本身

`target: tag` / `refs/tags/v*` / `deletion` + `update` + `non_fast_forward`，bypass actor 与 master 那条一致（只有 DeployKey）。

一次性 tag 上的三向验证：

```
创建 v0.0.0-ruletest   → * [new tag]                      ✅ 允许（发版要能打新 tag）
快进移动               → ! [remote rejected] … violations  ✅ 拦住
删除                   → ! [remote rejected] … violations  ✅ 拦住
```

## 为什么要写进 runbook

**打错的 tag 从此不能就地改。** 一条静默取消了常规恢复手段的规则，就是有人半夜断定「仓库坏了」的原因。所以逃生舱和「不该用它」的理由都得写下来：

```bash
gh api -X PUT repos/KCNyu/clawock/rulesets/21184290 -f enforcement=disabled
git push --delete origin v0.2.0
gh api -X PUT repos/KCNyu/clawock/rulesets/21184290 -f enforcement=active
```

**宁可烧掉下一个 patch 号，也别开这个闸。** 一个已经发到 PyPI / npm / GitHub Release 的版本，那三个消费方都留了副本 —— 这时候移 tag 只会让三者互相矛盾。

## 一个花了一个真 tag 才发现的坑

`non_fast_forward` **挡不住真正危险的那种移动**。把一个旧版本 tag **往前移到新代码上恰恰是快进**，那条规则会放行 —— 而这正是这个 issue 想防的场景。必须是 `update`。

我是怎么发现的：我把负向测试打在了**真实的 `v0.1.0`** 上，它被移到了当时的 master。修复时还撞到第二层 —— 规则生效后**连移回去都被拒**（往回是非快进），只能临时 `enforcement=disabled` 再复原。

`v0.1.0` 已回到 `57b14b0b`，9 个 tag 全部核对完好。

**教训写进了 runbook**：破坏性规则要在一次性 tag 上验，不要在已发布的 tag 上验。这个仓库一直强调「闸要验它真的会红」，但验红这个动作本身不能拿生产数据做 —— 我正好演示了为什么。

## 验证

```
$ pytest tests/test_versions_agree.py tests/test_github_release_contract.py
19 passed
```

新增断言要求 runbook 必须同时写着：tag 冻结、恢复路径（`enforcement=disabled` → 改 → `active`）、以及 `non_fast_forward` vs `update` 这个区别 —— 最后一条是防止下一个人照着配出同样的弱规则。
