### PR TITLE
arch: 给 import 图上棘轮，并修掉 harness→cli 这处倒置（#814 第一步）

### DIFF
--- a/ops/ci/generate_tool_reference.py
+++ b/ops/ci/generate_tool_reference.py
@@ -7,7 +7,7 @@ removed (#489). The inventory half is now derived from the two command
 registries in the single `clawock` distribution that
 `config/information-layers.json` partitions:
 
-- `clawock.cli.PACKAGED_UTILITIES` — the public CLI's own dispatch table;
+- `clawock.utilities.PACKAGED_UTILITIES` — the public CLI's own dispatch table;
 - `[project.scripts]` in the root `pyproject.toml`.
 
 Both are read from source rather than imported, so the generator works in a
@@ -46,12 +46,14 @@ END = "<!-- END GENERATED INVENTORY -->"
 
 def packaged_utilities(root: Path = ROOT) -> dict:
     """The public CLI's dispatch table, read from source."""
-    source = (root / "src" / PUBLIC / "cli.py").read_text()
+    source = (root / "src" / PUBLIC / "utilities.py").read_text()
     for node in ast.walk(ast.parse(source)):
         if (isinstance(node, ast.Assign)
                 and getattr(node.targets[0], "id", "") == "PACKAGED_UTILITIES"):
             return ast.literal_eval(node.value)
-    raise SystemExit("PACKAGED_UTILITIES is no longer a literal in clawock/cli.py")
+    raise SystemExit(
+        "PACKAGED_UTILITIES is no longer a literal in clawock/utilities.py "
+        "(it moved out of cli.py in #814)")
 
 
 def installed_scripts(root: Path = ROOT) -> dict:

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -470,140 +470,16 @@ def _workflow(args) -> int:
         return 1
 
 
-# Command -> module owning its `main(argv)`. One table, not a name list plus a
-# parallel dispatch chain: those were two copies of the same 49 entries, and the
-# four `evaluate-*` commands shipped in #429 pointing at a module with no `main`
-# because only one copy was updated.
-PACKAGED_UTILITIES = {
-    "aggregates": "clawock.portfolio.aggregates",
-    "analyze-hk": "clawock.market_data.hk_analysis",
-    "analyze-us": "clawock.market_data.us_analysis",
-    "audit-resettle": "clawock.decision.settlement",
-    "benchmark": "clawock.market_data.benchmarks",
-    "cash": "clawock.portfolio.cash",
-    "catalysts": "clawock.market_data.calendar",
-    "claim-provenance": "clawock.evidence.claim_provenance",
-    "cross-factor": "clawock.market_data.factors",
-    "daily-bars": "clawock.market_data.bars",
-    "dashboard-build": "clawock.publish.dashboard",
-    "dashboard-outputs": "clawock.publish.outputs",
-    "earnings": "clawock.decision.earnings",
-    "em-news": "clawock.market_data.eastmoney_news",
-    "entry-gate": "clawock.decision.entry",
-    "evaluate-combined-regime": "clawock.evaluation.combined_regime",
-    "evaluate-hstech-regime": "clawock.evaluation.hstech_regime",
-    "evaluate-us-leverage": "clawock.evaluation.us_leverage",
-    "evaluate-add-alpha": "clawock.evaluation.add_alpha_walkforward",
-    "evidence": "clawock.evidence.build_evidence",
-    "fetch-peers": "clawock.market_data.peer_quotes",
-    "filings": "clawock.market_data.filings",
-    "fundamentals": "clawock.market_data.fundamentals",
-    "fundflow": "clawock.market_data.fund_flows",
-    "fx": "clawock.portfolio.fx",
-    "integrity": "clawock.portfolio.integrity",
-    "macro": "clawock.market_data.macro",
-    "mark-followed": "clawock.decision.execution",
-    "mover-evidence": "clawock.market_data.mover_evidence",
-    "news-evidence": "clawock.evidence.news_evidence_graph",
-    "peer-residual": "clawock.market_data.peer_residuals",
-    "plan-context": "clawock.decision.plans",
-    "portfolio-risk": "clawock.portfolio.risk",
-    "provenance": "clawock.evidence.research_provenance",
-    "quant": "clawock.decision.signals",
-    "quant-review": "clawock.decision.signal_review",
-    "realized": "clawock.portfolio.realized",
-    "reconcile": "clawock.portfolio.reconcile",
-    "record": "clawock.decision.record",
-    "regime": "clawock.decision.regime",
-    "research": "clawock.evidence.research_surface",
-    "risk": "clawock.decision.risk",
-    "run-card": "clawock.evidence.run_card",
-    "sentiment": "clawock.market_data.sentiment",
-    "shadow": "clawock.portfolio.shadow",
-    "t0": "clawock.decision.setups",
-    "t0-review": "clawock.decision.setup_review",
-    "thesis": "clawock.decision.theses",
-    "us-quotes": "clawock.market_data.us_quotes",
-    "validate-regime-dial": "clawock.evaluation.regime_validation",
-    "validate-sidecar": "clawock.publish.artifacts",
-    "watch-list": "clawock.decision.watch_list",
-}
-
-# Its own exit-code convention: a partial peer fetch must not read as success.
-HARD_EXIT_UTILITIES = frozenset({"fetch-peers"})
-
-# These scan `argv` for flags by hand instead of using argparse, so `--help` is
-# not a flag to them — it is an unrecognised token they ignore while going on to
-# do the real work. `clawock analyze-hk --help` fetched live quotes and rewrote
-# portfolio.json. Answering here keeps that one input from reaching them; their
-# contract is the module docstring, which is what gets printed.
-DOCSTRING_HELP_UTILITIES = frozenset({
-    "analyze-hk", "analyze-us", "fetch-peers", "filings", "fundamentals",
-    "fundflow", "quant", "quant-review", "t0", "t0-review", "us-quotes",
-})
-
-# One help line per table entry, keyed by it. The parser below is built from
-# PACKAGED_UTILITIES, not from this dict, because the two used to be a table and a
-# parallel name list: #745 is the drift that shape allows. `record` was added to the
-# name list on 2026-08-16 and never to the table, so `clawock record` — the only
-# write path into the decision-mind ledger — was advertised by `--help`, by the DSH
-# skill contract and by docs/, and reachable from none of them. A help line missing
-# here is now a KeyError while the parser is built, i.e. on every invocation.
-UTILITY_HELP = {
-    "aggregates": "recompute portfolio values and P&L from leaves",
-    "analyze-hk": "refresh and analyze active HK holdings",
-    "analyze-us": "refresh and analyze active US holdings",
-    "audit-resettle": "audit decision re-settlement without writing by default",
-    "benchmark": "fetch SPY, HSI, and HSTECH daily benchmark history",
-    "cash": "recompute cash from its reconciliation ledger",
-    "catalysts": "fetch upcoming earnings and macro catalysts",
-    "claim-provenance": "verify backtest claims against run cards",
-    "cross-factor": "rank a curated universe with sector-neutral factors",
-    "daily-bars": "maintain immutable canonical daily OHLC bars",
-    "dashboard-build": "build the configured workspace dashboard projection",
-    "dashboard-outputs": "compare one generated dashboard write set",
-    "earnings": "validate and release primary-source earnings reviews",
-    "em-news": "fetch Chinese news for active HK holdings",
-    "entry-gate": "validate or assess a pre-investment research gate",
-    "evaluate-add-alpha":
-        "walk-forward evaluate add factor and information interactions",
-    "evaluate-combined-regime": "backtest the combined configured regime dial",
-    "evaluate-hstech-regime": "backtest the HSTECH leverage regime",
-    "evaluate-us-leverage": "backtest US single-stock leverage regimes",
-    "evidence": "rebuild the artifact-backed public evidence page",
-    "fetch-peers": "price peer tickers from a JSON request on stdin",
-    "filings": "fetch SEC filings and point-in-time XBRL fundamentals",
-    "fundamentals": "fetch East Money HK/US statements and indicators",
-    "fundflow": "fetch East Money HK/US daily capital flow",
-    "fx": "fetch or convert the canonical USD/HKD rate",
-    "integrity": "verify portfolio money and market-data invariants",
-    "macro": "fetch a portable macro and major-index snapshot",
-    "mark-followed": "record execution ground truth in the decision ledger",
-    "mover-evidence": "probe bounded filing and news evidence for movers",
-    "news-evidence": "build the expiring news and filing evidence graph",
-    "peer-residual": "calibrate curated-peer residual and leadership rules",
-    "plan-context": "show still-open decisions for a downstream run",
-    "portfolio-risk": "compute portfolio beta, volatility, and tail risk",
-    "provenance": "verify numeric research provenance",
-    "quant": "compute holding-level trend, momentum, and risk factors",
-    "quant-review": "reconcile factor signals with forward returns",
-    "realized": "recompute realized P&L from the trade ledger",
-    "reconcile": "recompute all portfolio derivations and verify integrity",
-    "record": "append a conversation verdict to the decision-mind ledger",
-    "regime": "compute the configured leverage-risk regime",
-    "research": "show or check the configured research work queue",
-    "risk": "maintain the durable risk-breach governance ledger",
-    "run-card": "inspect durable backtest evidence",
-    "sentiment": "scan configured holdings across public sentiment sources",
-    "shadow": "simulate followed decisions against buy and hold",
-    "t0": "grade intraday setup quality from existing market data",
-    "t0-review": "reconcile setup grades with next-session returns",
-    "thesis": "validate thesis state or evaluate evidence-only drift",
-    "us-quotes": "refresh US holdings through the provider fallback chain",
-    "validate-regime-dial": "walk-forward validate the production regime dial",
-    "validate-sidecar": "validate a workflow-generated sidecar artifact",
-    "watch-list": "scan non-held AI watch names for price opportunities",
-}
+# The command registry moved to `clawock.utilities` (#814): two harness
+# preflights need `PACKAGED_UTILITIES`, and reaching up into the CLI entry point
+# for it made `harness` and `cli` mutually dependent. Re-exported here because
+# `clawock.cli.PACKAGED_UTILITIES` is referenced by ops/ and by five tests.
+from clawock.utilities import (  # noqa: F401  (re-export)
+    DOCSTRING_HELP_UTILITIES,
+    HARD_EXIT_UTILITIES,
+    PACKAGED_UTILITIES,
+    UTILITY_HELP,
+)
 
 
 def _editable_drift(distribution) -> str:

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -40,7 +40,7 @@ from clawock.market_data import sessions as trading_calendar
 from clawock.decision import plans as plan_surface
 from clawock.decision import signals as quant_signals
 from clawock.evidence import research_surface
-from clawock.cli import PACKAGED_UTILITIES
+from clawock.utilities import PACKAGED_UTILITIES
 from clawock.market_data import known_catalysts, mover_evidence as mover_news, peer_scan
 from clawock.decision import active_information
 from clawock.decision import add_side, early_trend

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -55,7 +55,7 @@ from clawock.market_data import sessions as trading_calendar
 from clawock.decision import plans as plan_surface
 from clawock.evidence import research_surface
 from clawock.market_data import mover_evidence as mover_news
-from clawock.cli import PACKAGED_UTILITIES
+from clawock.utilities import PACKAGED_UTILITIES
 from clawock.market_data import peer_scan
 
 WS = workspace_root(Path.cwd())

--- a/src/clawock/utilities.py
+++ b/src/clawock/utilities.py
@@ -1,0 +1,148 @@
+"""The command registry: every `clawock <utility>` and the module that owns it.
+
+Lives here rather than in `cli` because it is data, not an entry point, and two
+harness preflights need it (#814). They used to reach up into `clawock.cli` for
+it — a module in a lower layer importing the top-level entry point, which is the
+most clear-cut import inversion in the package and the one that put `harness` and
+`cli` in the same dependency cycle.
+
+Nothing in this module imports anything from clawock. That is the point: it can
+be read from any layer without dragging the CLI, argparse, or a single utility
+module in behind it.
+"""
+from __future__ import annotations
+
+# Command -> module owning its `main(argv)`. One table, not a name list plus a
+# parallel dispatch chain: those were two copies of the same 49 entries, and the
+# four `evaluate-*` commands shipped in #429 pointing at a module with no `main`
+# because only one copy was updated.
+PACKAGED_UTILITIES = {
+    "aggregates": "clawock.portfolio.aggregates",
+    "analyze-hk": "clawock.market_data.hk_analysis",
+    "analyze-us": "clawock.market_data.us_analysis",
+    "audit-resettle": "clawock.decision.settlement",
+    "benchmark": "clawock.market_data.benchmarks",
+    "cash": "clawock.portfolio.cash",
+    "catalysts": "clawock.market_data.calendar",
+    "claim-provenance": "clawock.evidence.claim_provenance",
+    "cross-factor": "clawock.market_data.factors",
+    "daily-bars": "clawock.market_data.bars",
+    "dashboard-build": "clawock.publish.dashboard",
+    "dashboard-outputs": "clawock.publish.outputs",
+    "earnings": "clawock.decision.earnings",
+    "em-news": "clawock.market_data.eastmoney_news",
+    "entry-gate": "clawock.decision.entry",
+    "evaluate-combined-regime": "clawock.evaluation.combined_regime",
+    "evaluate-hstech-regime": "clawock.evaluation.hstech_regime",
+    "evaluate-us-leverage": "clawock.evaluation.us_leverage",
+    "evaluate-add-alpha": "clawock.evaluation.add_alpha_walkforward",
+    "evidence": "clawock.evidence.build_evidence",
+    "fetch-peers": "clawock.market_data.peer_quotes",
+    "filings": "clawock.market_data.filings",
+    "fundamentals": "clawock.market_data.fundamentals",
+    "fundflow": "clawock.market_data.fund_flows",
+    "fx": "clawock.portfolio.fx",
+    "integrity": "clawock.portfolio.integrity",
+    "macro": "clawock.market_data.macro",
+    "mark-followed": "clawock.decision.execution",
+    "mover-evidence": "clawock.market_data.mover_evidence",
+    "news-evidence": "clawock.evidence.news_evidence_graph",
+    "peer-residual": "clawock.market_data.peer_residuals",
+    "plan-context": "clawock.decision.plans",
+    "portfolio-risk": "clawock.portfolio.risk",
+    "provenance": "clawock.evidence.research_provenance",
+    "quant": "clawock.decision.signals",
+    "quant-review": "clawock.decision.signal_review",
+    "realized": "clawock.portfolio.realized",
+    "reconcile": "clawock.portfolio.reconcile",
+    "record": "clawock.decision.record",
+    "regime": "clawock.decision.regime",
+    "research": "clawock.evidence.research_surface",
+    "risk": "clawock.decision.risk",
+    "run-card": "clawock.evidence.run_card",
+    "sentiment": "clawock.market_data.sentiment",
+    "shadow": "clawock.portfolio.shadow",
+    "t0": "clawock.decision.setups",
+    "t0-review": "clawock.decision.setup_review",
+    "thesis": "clawock.decision.theses",
+    "us-quotes": "clawock.market_data.us_quotes",
+    "validate-regime-dial": "clawock.evaluation.regime_validation",
+    "validate-sidecar": "clawock.publish.artifacts",
+    "watch-list": "clawock.decision.watch_list",
+}
+
+# Its own exit-code convention: a partial peer fetch must not read as success.
+HARD_EXIT_UTILITIES = frozenset({"fetch-peers"})
+
+# These scan `argv` for flags by hand instead of using argparse, so `--help` is
+# not a flag to them — it is an unrecognised token they ignore while going on to
+# do the real work. `clawock analyze-hk --help` fetched live quotes and rewrote
+# portfolio.json. Answering here keeps that one input from reaching them; their
+# contract is the module docstring, which is what gets printed.
+DOCSTRING_HELP_UTILITIES = frozenset({
+    "analyze-hk", "analyze-us", "fetch-peers", "filings", "fundamentals",
+    "fundflow", "quant", "quant-review", "t0", "t0-review", "us-quotes",
+})
+
+# One help line per table entry, keyed by it. The parser below is built from
+# PACKAGED_UTILITIES, not from this dict, because the two used to be a table and a
+# parallel name list: #745 is the drift that shape allows. `record` was added to the
+# name list on 2026-08-16 and never to the table, so `clawock record` — the only
+# write path into the decision-mind ledger — was advertised by `--help`, by the DSH
+# skill contract and by docs/, and reachable from none of them. A help line missing
+# here is now a KeyError while the parser is built, i.e. on every invocation.
+UTILITY_HELP = {
+    "aggregates": "recompute portfolio values and P&L from leaves",
+    "analyze-hk": "refresh and analyze active HK holdings",
+    "analyze-us": "refresh and analyze active US holdings",
+    "audit-resettle": "audit decision re-settlement without writing by default",
+    "benchmark": "fetch SPY, HSI, and HSTECH daily benchmark history",
+    "cash": "recompute cash from its reconciliation ledger",
+    "catalysts": "fetch upcoming earnings and macro catalysts",
+    "claim-provenance": "verify backtest claims against run cards",
+    "cross-factor": "rank a curated universe with sector-neutral factors",
+    "daily-bars": "maintain immutable canonical daily OHLC bars",
+    "dashboard-build": "build the configured workspace dashboard projection",
+    "dashboard-outputs": "compare one generated dashboard write set",
+    "earnings": "validate and release primary-source earnings reviews",
+    "em-news": "fetch Chinese news for active HK holdings",
+    "entry-gate": "validate or assess a pre-investment research gate",
+    "evaluate-add-alpha":
+        "walk-forward evaluate add factor and information interactions",
+    "evaluate-combined-regime": "backtest the combined configured regime dial",
+    "evaluate-hstech-regime": "backtest the HSTECH leverage regime",
+    "evaluate-us-leverage": "backtest US single-stock leverage regimes",
+    "evidence": "rebuild the artifact-backed public evidence page",
+    "fetch-peers": "price peer tickers from a JSON request on stdin",
+    "filings": "fetch SEC filings and point-in-time XBRL fundamentals",
+    "fundamentals": "fetch East Money HK/US statements and indicators",
+    "fundflow": "fetch East Money HK/US daily capital flow",
+    "fx": "fetch or convert the canonical USD/HKD rate",
+    "integrity": "verify portfolio money and market-data invariants",
+    "macro": "fetch a portable macro and major-index snapshot",
+    "mark-followed": "record execution ground truth in the decision ledger",
+    "mover-evidence": "probe bounded filing and news evidence for movers",
+    "news-evidence": "build the expiring news and filing evidence graph",
+    "peer-residual": "calibrate curated-peer residual and leadership rules",
+    "plan-context": "show still-open decisions for a downstream run",
+    "portfolio-risk": "compute portfolio beta, volatility, and tail risk",
+    "provenance": "verify numeric research provenance",
+    "quant": "compute holding-level trend, momentum, and risk factors",
+    "quant-review": "reconcile factor signals with forward returns",
+    "realized": "recompute realized P&L from the trade ledger",
+    "reconcile": "recompute all portfolio derivations and verify integrity",
+    "record": "append a conversation verdict to the decision-mind ledger",
+    "regime": "compute the configured leverage-risk regime",
+    "research": "show or check the configured research work queue",
+    "risk": "maintain the durable risk-breach governance ledger",
+    "run-card": "inspect durable backtest evidence",
+    "sentiment": "scan configured holdings across public sentiment sources",
+    "shadow": "simulate followed decisions against buy and hold",
+    "t0": "grade intraday setup quality from existing market data",
+    "t0-review": "reconcile setup grades with next-session returns",
+    "thesis": "validate thesis state or evaluate evidence-only drift",
+    "us-quotes": "refresh US holdings through the provider fallback chain",
+    "validate-regime-dial": "walk-forward validate the production regime dial",
+    "validate-sidecar": "validate a workflow-generated sidecar artifact",
+    "watch-list": "scan non-held AI watch names for price opportunities",
+}

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -1,0 +1,254 @@
+"""The package import graph, held where it is.
+
+#814 measured `src/clawock`: 137 modules, ~345 intra-package imports, and two
+package-level dependency cycles tangling nine subpackages. Nothing in the suite
+constrained import direction — the existing boundary tests
+(`test_quant_package_boundary`, `test_harness_import_independence`,
+`test_core_utilities_moved`) are about packaging and ownership, about whether
+code ships from the wheel, not about which layer may import which.
+
+This is a ratchet, not a fix. The cycles that exist are listed below and
+tolerated; a cycle that is NOT listed fails. The list may only shrink — a test
+asserts that too, so "just add it to the allowlist" is not a way past this.
+
+The direction that matters: a cycle is cheap to add and expensive to remove.
+`harness` imported `clawock.cli` for a constant table, which is the most
+clear-cut inversion in the package, and nothing noticed for as long as it took
+someone to go looking.
+"""
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+PKG = "clawock"
+
+# Package-level cycles that exist today, each as a frozenset of subpackages.
+# Every entry is a debt with a name. Removing one means deleting its line here;
+# nothing may ever be added.
+KNOWN_PACKAGE_CYCLES = {
+    # #814: market_data <-> portfolio via portfolio.instruments and
+    # market_data.sessions (two foundation modules living in the wrong package),
+    # closed by portfolio.shadow -> decision.ledger and
+    # decision.earnings -> evidence.research_provenance.
+    frozenset({"decision", "evidence", "market_data", "portfolio"}),
+    # #814: publish.dashboard -> harness.brief_preflight and
+    # workflows.{improvements,validators} -> harness.{config,model}.
+    # `cli` was in this set until PACKAGED_UTILITIES moved out of it; the
+    # remaining four are the untouched half.
+    frozenset({"automation", "harness", "publish", "workflows"}),
+}
+
+# Module-level cycles. `tools` is the registry pattern and is not a defect: the
+# package __init__ owns the base classes, submodules import them, and
+# build_registry() imports the submodules lazily. The other two are real.
+KNOWN_MODULE_CYCLES = {
+    frozenset({"clawock.tools", "clawock.tools.context_tools"}),
+    frozenset({"clawock.decision.ledger", "clawock.decision.record"}),
+    frozenset({"clawock.harness.config", "clawock.workflows",
+               "clawock.workflows.improvements"}),
+}
+
+
+def _modules() -> dict[str, Path]:
+    out = {}
+    for path in sorted((SRC / PKG).rglob("*.py")):
+        if "__pycache__" in str(path):
+            continue
+        parts = list(path.relative_to(SRC).with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        out[".".join(parts)] = path
+    return out
+
+
+def _graph() -> dict[str, set[str]]:
+    """Intra-package imports, parsed rather than grepped.
+
+    A grep cannot tell `from clawock.decision import ledger` (a module) from
+    `from clawock.decision import ACTIVE_ACTIONS` (a name in the package
+    __init__), and getting that wrong invents edges that are not there.
+    """
+    mods = _modules()
+
+    def nearest(name: str) -> str | None:
+        while name and name not in mods:
+            if "." not in name:
+                return None
+            name = name.rsplit(".", 1)[0]
+        return name or None
+
+    edges: dict[str, set[str]] = defaultdict(set)
+    for name, path in mods.items():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    target = nearest(alias.name)
+                    if target and target != name and target.startswith(PKG):
+                        edges[name].add(target)
+            elif isinstance(node, ast.ImportFrom):
+                base = node.module or ""
+                if node.level:
+                    own = name.split(".")
+                    if mods[name].name != "__init__.py":
+                        own = own[:-1]
+                    if node.level > 1:
+                        own = own[: len(own) - (node.level - 1)]
+                    base = ".".join(own + ([base] if base else []))
+                if not base.startswith(PKG):
+                    continue
+                hit = False
+                for alias in node.names:
+                    target = nearest(f"{base}.{alias.name}")
+                    if target and target != name:
+                        edges[name].add(target)
+                        hit = True
+                if not hit:
+                    target = nearest(base)
+                    if target and target != name:
+                        edges[name].add(target)
+    for name in mods:
+        edges.setdefault(name, set())
+    return edges
+
+
+def _cycles(adj: dict[str, set[str]]) -> list[frozenset[str]]:
+    """Strongly connected components of size > 1, iteratively (Tarjan).
+
+    Iterative because a recursive walk over 137 modules is a stack risk for a
+    test that must never be the flaky one.
+    """
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    stack: list[str] = []
+    found: list[frozenset[str]] = []
+    counter = 0
+
+    for root in sorted(adj):
+        if root in index:
+            continue
+        work = [(root, iter(sorted(adj[root])))]
+        index[root] = low[root] = counter
+        counter += 1
+        stack.append(root)
+        on_stack[root] = True
+        while work:
+            node, children = work[-1]
+            advanced = False
+            for child in children:
+                if child not in index:
+                    index[child] = low[child] = counter
+                    counter += 1
+                    stack.append(child)
+                    on_stack[child] = True
+                    work.append((child, iter(sorted(adj[child]))))
+                    advanced = True
+                    break
+                if on_stack.get(child):
+                    low[node] = min(low[node], index[child])
+            if advanced:
+                continue
+            work.pop()
+            if work:
+                low[work[-1][0]] = min(low[work[-1][0]], low[node])
+            if low[node] == index[node]:
+                component = []
+                while True:
+                    popped = stack.pop()
+                    on_stack[popped] = False
+                    component.append(popped)
+                    if popped == node:
+                        break
+                if len(component) > 1:
+                    found.append(frozenset(component))
+    return found
+
+
+@pytest.fixture(scope="module")
+def graph() -> dict[str, set[str]]:
+    return _graph()
+
+
+def test_the_graph_is_actually_populated(graph):
+    """Every assertion below passes vacuously against an empty graph, and an
+    import-parser that silently matches nothing is exactly the failure mode this
+    repository keeps finding in its own gates."""
+    assert len(graph) > 100, "the module scan found almost nothing"
+    assert sum(len(v) for v in graph.values()) > 200
+
+
+def test_no_module_cycle_beyond_the_known_ones(graph):
+    new = [c for c in _cycles(graph) if c not in KNOWN_MODULE_CYCLES]
+    assert not new, (
+        "new import cycle(s) between modules: "
+        + "; ".join(" <-> ".join(sorted(c)) for c in new)
+        + ". A cycle is cheap to add and expensive to remove — break it now, or "
+          "argue for it in #814 before listing it here."
+    )
+
+
+def test_no_package_cycle_beyond_the_known_ones(graph):
+    def pkg(module: str) -> str:
+        parts = module.split(".")
+        return parts[1] if len(parts) > 1 else "(root)"
+
+    coarse: dict[str, set[str]] = defaultdict(set)
+    for src, targets in graph.items():
+        for target in targets:
+            if pkg(src) != pkg(target):
+                coarse[pkg(src)].add(pkg(target))
+    for node in list(coarse):
+        coarse.setdefault(node, set())
+
+    new = [c for c in _cycles(coarse) if c not in KNOWN_PACKAGE_CYCLES]
+    assert not new, (
+        "new dependency cycle(s) between subpackages: "
+        + "; ".join(" <-> ".join(sorted(c)) for c in new)
+    )
+
+
+def test_nothing_below_the_cli_imports_the_cli(graph):
+    """`cli` is the entry point. Anything importing it is upside down.
+
+    This had two violations: both harness preflights pulled `PACKAGED_UTILITIES`
+    out of `clawock.cli`, which is a data table, not an entry point. It now
+    lives in `clawock.utilities`, which imports nothing at all.
+    """
+    offenders = sorted(m for m, targets in graph.items()
+                       if f"{PKG}.cli" in targets and m != f"{PKG}.__main__")
+    assert not offenders, (
+        f"these import the CLI entry point from below it: {offenders}. "
+        "If it is data they need, it belongs in a module the CLI imports, not "
+        "the other way round."
+    )
+
+
+@pytest.mark.parametrize("leaf", ["workspace", "safe_io", "json_repair", "utilities"])
+def test_the_foundation_modules_stay_leaves(graph, leaf):
+    """These are imported from everywhere — workspace by 67 modules, safe_io by
+    30. A single import added here reaches the whole package, and the reason
+    `clawock.utilities` exists at all is that a table with 24 consumers was
+    living somewhere that could not be imported from below."""
+    name = f"{PKG}.{leaf}"
+    assert name in graph, f"{name} disappeared; update this list deliberately"
+    assert not graph[name], (
+        f"{name} must import nothing from clawock, now imports {sorted(graph[name])}"
+    )
+
+
+def test_the_allowlists_only_ever_shrink():
+    """The counts are written down so that adding an entry is a visible edit to
+    a number, not a quiet append to a set."""
+    assert len(KNOWN_PACKAGE_CYCLES) <= 2, (
+        "a package cycle was added to the allowlist; #814 is about removing these"
+    )
+    assert len(KNOWN_MODULE_CYCLES) <= 3, (
+        "a module cycle was added to the allowlist; #814 is about removing these"
+    )

--- a/tests/test_information_layer_taxonomy.py
+++ b/tests/test_information_layer_taxonomy.py
@@ -54,12 +54,15 @@ def _packaged_utilities():
     test meaningful in a checkout where the package is not installed — the case
     that hid a missing subpackage from CI for a week (#270).
     """
-    source = (ROOT / "src" / PUBLIC / "cli.py").read_text()
+    source = (ROOT / "src" / PUBLIC / "utilities.py").read_text()
     for node in ast.walk(ast.parse(source)):
         if (isinstance(node, ast.Assign)
                 and getattr(node.targets[0], "id", "") == "PACKAGED_UTILITIES"):
             return ast.literal_eval(node.value)
-    raise AssertionError("PACKAGED_UTILITIES is no longer a literal in clawock/cli.py")
+    raise AssertionError(
+        "PACKAGED_UTILITIES is no longer a literal in clawock/utilities.py "
+        "(it moved out of cli.py in #814 so the harness could stop importing "
+        "the CLI entry point)")
 
 
 def _installed_scripts():


### PR DESCRIPTION
Refs #814（**不关闭** —— 这只是第一步：上棘轮 + 修最明显的那一处倒置）

## 先上棘轮，因为环是「加起来便宜、拆起来贵」

#814 用 AST 量了 `src/clawock`：**137 个模块、~345 条包内 import、2 个包级环缠住 9 个子包**，而套件里**没有任何一条约束 import 方向** —— 现有的 `test_quant_package_boundary` / `test_harness_import_independence` / `test_core_utilities_moved` 管的是打包归属，不是层次方向。

`tests/test_import_layering.py`：已知的环列进 allowlist 被容忍，**没列进去的环就红**，另有一条断言防止 allowlist 变长 ——「加进白名单」不是绕过这道闸的办法。

**负向验证过**（往 `portfolio/fx.py` 加一条 `from clawock import cli`）：

```
E  new dependency cycle(s) between subpackages:
   automation <-> cli <-> decision <-> evidence <-> harness <->
   market_data <-> portfolio <-> publish <-> tools <-> workflows
E  these import the CLI entry point from below it: ['clawock.portfolio.fx']
```

**一条回边就把十个包并成一个环。** 这就是为什么它值得先堵。

另外几条：`workspace` / `safe_io` / `json_repair` / `utilities` 四个基础模块必须保持零 clawock import（`workspace` 有 67 个导入方、`safe_io` 30 个，这里加一条 import 就是全包可达）；还有一条「图必须真的解析出东西」的反空转断言 —— 一个静默匹配不到任何东西的 import 解析器，正是这个仓库反复找到的那类假闸。

## 修掉的那一处：`harness -> cli`

```
harness/intraday_preflight.py:43  from clawock.cli import PACKAGED_UTILITIES
harness/report_preflight.py:58    from clawock.cli import PACKAGED_UTILITIES
```

下层模块向上伸手，**只为拿一张数据表** —— 全包最没有争议的一处倒置。表搬到 `clawock/utilities.py`（**自己不 import 任何东西**），`cli` 再 re-export，因为 `ops/` 和五个测试都在用 `clawock.cli.PACKAGED_UTILITIES` 这个名字。

顺带一提，这张表本身**已经付过一次代价**：`clawock record` 从上线起不可达，就是因为「只进了 parser 名单没进 `PACKAGED_UTILITIES`」（#745）。一张关键的表放在最上层，下面的人只好倒着 import。

**效果立刻可见**：第二个包级环从 5 个子包缩到 4 个（`cli` 出去了），allowlist 已相应改小 —— 棘轮第一次生效就是往变短的方向。

## 两个「从源码读表」的消费方跟着搬了

`test_information_layer_taxonomy` 和 `ops/ci/generate_tool_reference.py` 都是**故意**用 AST 读字面量而不是 import（这样在包没安装的 checkout 里仍然有效 —— #270 就是这么藏了一周的），所以是**改指向、不是改成 import**。

## 验证

```
$ pytest tests/ -q
2446 passed, 5 skipped, 4 xfailed

$ pytest -q tests/test_import_layering.py tests/test_information_layer_taxonomy.py \
          tests/test_harness_cli_contract.py tests/test_tool_reference_is_generated.py
33 passed
```

## 剩下的 5 处不在这个 PR 里

#814 里算过最小反馈边集：再改 5 处 import + `market_data.sessions` 下沉，整张包图就是 DAG。但那几处涉及 `sessions`（18 个导入方）和 `instruments`（24 个导入方）的搬迁，是需要单独决策的大改，不该和棘轮混在一起。每做掉一处，allowlist 收窄一次。
