### PR TITLE
test: 点名那些往 checkout 里写东西的测试，并修掉造成偶发红的那一个

### DIFF
--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -38,10 +38,41 @@ from clawock import scheduling as schedule
 # is overridable, so resolving our own modules through WS would read them out of
 # someone else's data directory — or silently pick up whatever happens to be
 # there. Same expression WS is seeded from, kept separate on purpose (#269).
-WS = workspace_root(Path.cwd())
-LOCAL_PATH = WS / "memory" / ".tmp" / "workflow-outcomes.json"
-PUBLIC_PATH = WS / "assets" / "data" / "workflow-outcomes.json"
-LOCK_PATH = WS / "memory" / ".tmp" / "workflow-outcomes.lock"
+def _ws() -> Path:
+    """The workspace, resolved per call rather than frozen at import.
+
+    These were module constants computed from `Path.cwd()` when the module was
+    first imported. `clawock.workspace` documents `CLAWOCK_WORKSPACE` as the way
+    to point the computation at a different workspace "without touching the
+    modules" — and for this module that override did nothing, because by the
+    time anything could set it the paths were already decided.
+
+    The visible cost was a test: #816 traced an order-dependent failure to
+    `rebuild_dashboard(tmp_path)` writing `assets/data/workflow-outcomes.json`
+    into the real checkout. The test passed a workspace; the ledger ignored it,
+    wrote to wherever pytest happened to be started from, and left an untracked
+    file behind that armed a dormant assertion in a different module.
+
+    Resolved per call, `CLAWOCK_WORKSPACE` reaches this module like the
+    docstring always claimed. Unset, behaviour is unchanged.
+    """
+    return workspace_root(Path.cwd())
+
+
+def local_path() -> Path:
+    return _ws() / "memory" / ".tmp" / "workflow-outcomes.json"
+
+
+def public_path() -> Path:
+    return _ws() / "assets" / "data" / "workflow-outcomes.json"
+
+
+def lock_path() -> Path:
+    return _ws() / "memory" / ".tmp" / "workflow-outcomes.lock"
+
+
+def tmp_dir() -> Path:
+    return _ws() / "memory" / ".tmp"
 SCHEMA_VERSION = 1
 KEEP_HOURS = 96
 HKT = ZoneInfo("Asia/Hong_Kong")
@@ -131,17 +162,17 @@ def _read_path(path):
 def load_ledger():
     """Local ledger first; the published copy is a last resort, never a silent one.
 
-    Falling back to PUBLIC_PATH and then writing that content back to LOCAL_PATH
+    Falling back to public_path() and then writing that content back to local_path()
     would roll the local ledger back to whatever was last published. It has not
     been observed happening, but a data-losing path must not be invisible.
     """
-    local = _read_path(LOCAL_PATH)
+    local = _read_path(local_path())
     if local is not None:
         return local
-    public = _read_path(PUBLIC_PATH)
+    public = _read_path(public_path())
     if public is not None:
         print(
-            f"warn: workflow ledger unreadable at {LOCAL_PATH}; falling back to the "
+            f"warn: workflow ledger unreadable at {local_path()}; falling back to the "
             f"published copy — stages recorded since the last publish may be missing",
             file=sys.stderr,
         )
@@ -158,8 +189,8 @@ def _atomic_write(path, data):
 
 @contextmanager
 def _locked():
-    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with LOCK_PATH.open("a+") as lock:
+    lock_path().parent.mkdir(parents=True, exist_ok=True)
+    with lock_path().open("a+") as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         yield
 
@@ -318,7 +349,7 @@ def record_stage(job_name, stage, status, *, slot=None, at=None, dry_run=False, 
             )
             if not ledger.get("monitoring_started_at"):
                 ledger["monitoring_started_at"] = slot
-            _atomic_write(LOCAL_PATH, ledger)
+            _atomic_write(local_path(), ledger)
         return current
     except Exception as exc:
         print(f"warn: workflow outcome stage not recorded: {exc}", file=sys.stderr)
@@ -452,7 +483,7 @@ def reconcile_raw_execution():
                             "raw_execution", {"status": "unknown"}
                         )
                 latest["updated_at"] = ledger["updated_at"]
-                _atomic_write(LOCAL_PATH, latest)
+                _atomic_write(local_path(), latest)
         return changed
     except Exception as exc:
         print(f"warn: raw workflow status reconciliation skipped: {exc}", file=sys.stderr)
@@ -471,7 +502,6 @@ def reconcile_raw_execution():
 # process exit — is what actually proves delivery, so the ledger reconciles
 # against it. Absent a receipt this must leave the record alone: `pending` is
 # the honest answer when nothing proves otherwise.
-TMP_DIR = WS / "memory" / ".tmp"
 
 
 def _receipt_delivered(payload):
@@ -516,10 +546,10 @@ def reconcile_delivery_receipts():
     watchdog or a later run knows more than a receipt file does.
     """
     try:
-        if not TMP_DIR.is_dir():
+        if not tmp_dir().is_dir():
             return 0
         claims = {}
-        for path in sorted(TMP_DIR.glob("*-sent-*.json")):
+        for path in sorted(tmp_dir().glob("*-sent-*.json")):
             parsed = _receipt_claims(path)
             if not parsed:
                 continue
@@ -550,7 +580,7 @@ def reconcile_delivery_receipts():
                 filled += 1
             if filled:
                 ledger["updated_at"] = _now().isoformat()
-                _atomic_write(LOCAL_PATH, ledger)
+                _atomic_write(local_path(), ledger)
         return filled
     except Exception as exc:
         print(f"warn: delivery receipt reconciliation skipped: {exc}", file=sys.stderr)
@@ -575,11 +605,11 @@ def publish():
     reconcile_raw_execution()
     reconcile_delivery_receipts()
     ledger = load_ledger()
-    before = PUBLIC_PATH.read_text() if PUBLIC_PATH.exists() else None
+    before = public_path().read_text() if public_path().exists() else None
     payload = json.dumps(ledger, ensure_ascii=False, indent=2) + "\n"
     if before == payload:
         return False
-    _atomic_write(PUBLIC_PATH, ledger)
+    _atomic_write(public_path(), ledger)
     return True
 
 
@@ -589,7 +619,7 @@ def main():
     parser.add_argument("--summary", action="store_true")
     args = parser.parse_args()
     if args.publish:
-        print(json.dumps({"published": publish(), "path": str(PUBLIC_PATH)}))
+        print(json.dumps({"published": publish(), "path": str(public_path())}))
     else:
         print(json.dumps(summarize(reconcile=True), ensure_ascii=False, indent=2))
     return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,135 @@ def _git_status(paths):
     return done.stdout if done.returncode == 0 else None
 
 
+# Directories a test has no business writing to. `assets/data` and `memory` are
+# published state; `logs` and `site/assets` are build output. The publish-owned
+# subset of these is snapshotted and restored by the session fixture below, but
+# that only covers four files and only at session END — which is exactly how a
+# test can leave state that changes what a LATER test sees.
+WATCHED_DIRS = ("assets/data", "memory", "logs", "site/assets")
+
+
+def _watched_state():
+    """Path -> (size, mtime_ns) for everything under the watched directories.
+
+    Cheap enough to run around every test: stat only, no hashing. It catches
+    creation, deletion and rewrite, which is the whole failure class. A rewrite
+    that preserves size AND mtime_ns would slip through, and nothing observed
+    here does that.
+    """
+    state = {}
+    for name in WATCHED_DIRS:
+        base = ROOT / name
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if path.is_file():
+                try:
+                    st = path.stat()
+                except OSError:
+                    continue
+                state[path] = (st.st_size, st.st_mtime_ns)
+    return state
+
+
+_WRITE_LOG = []
+_LAST_SEEN = {}
+
+
+def pytest_sessionstart(session):
+    """Baseline before ANY fixture runs.
+
+    Taking it inside the first test's fixture setup does not work: session-scoped
+    fixtures are set up first, so the session dashboard rebuild is already baked
+    into the baseline and the run reports itself clean. That was the second
+    wrong version of this.
+    """
+    _LAST_SEEN.clear()
+    _LAST_SEEN.update(_watched_state())
+
+
+@pytest.fixture(autouse=True)
+def _attribute_writes_to_the_test_that_made_them(request):
+    """Name the test that touched published state.
+
+    #816: `test_dropped_blocks_are_still_reachable_elsewhere` failed only in
+    full-suite order and passed alone, because an UNTRACKED file
+    (`assets/data/workflow-outcomes.json`) is absent in a clean checkout, gets
+    created during a run, and then persists — silently arming an assertion that
+    is dormant otherwise. Nothing could say which test created it.
+
+    Compares against a running checkpoint rather than snapshotting inside the
+    test's own window, because a higher-scoped fixture is set up BEFORE any
+    function-scoped one: the session rebuild would happen outside a
+    before/after pair and be missed entirely. That was the first version of
+    this fixture, and it reported a clean run against a module that definitely
+    rewrites four files.
+
+    This records rather than forbids. Attribution first, cleanup second —
+    guessing at the writer is what let this sit unexplained through two
+    sightings.
+    """
+    yield
+    after = _watched_state()
+
+    created = sorted(set(after) - set(_LAST_SEEN))
+    removed = sorted(set(_LAST_SEEN) - set(after))
+    changed = sorted(p for p in set(_LAST_SEEN) & set(after)
+                     if _LAST_SEEN[p] != after[p])
+    if created or removed or changed:
+        _WRITE_LOG.append({
+            "test": request.node.nodeid,
+            "created": [str(p.relative_to(ROOT)) for p in created],
+            "removed": [str(p.relative_to(ROOT)) for p in removed],
+            "changed": [str(p.relative_to(ROOT)) for p in changed],
+        })
+    _LAST_SEEN.clear()
+    _LAST_SEEN.update(after)
+
+
+# Writers that are known and, for now, tolerated. Each entry is a test-id prefix
+# with the reason it writes. The list may only shrink — the assertion in
+# `test_no_new_test_writes_to_published_state` is what makes that true, so a new
+# writer has to be argued for rather than appended to.
+#
+# `memory/.tmp/**` is the workspace's own scratch area and gitignored, but it is
+# still shared state between tests: two modules writing one ledger there is the
+# same class of coupling, one directory further down. Listed, not exempted.
+TOLERATED_WRITERS = {
+    # The session dashboard rebuild, attributed to whichever test first requests
+    # the fixture. Load-bearing, and the session fixture restores its output.
+    "tests/test_dashboard_payload_size.py::test_payload_stays_under_the_published_cap",
+    # #816 debt: writes logs/watchdog.jsonl into the checkout.
+    "tests/test_intraday_watchdog_retry_parity.py",
+    # #816 debt: writes assets/data/integrity_report.json into the checkout.
+    "tests/test_pr_publish_gate_contract.py::test_safe_push_uses_and_cleans_ephemeral_actions_key",
+    # #816 debt: share one memory/.tmp ledger instead of an isolated workspace.
+    "tests/test_report_assembly.py",
+    "tests/test_report_context_path.py",
+}
+
+
+def _tolerated(node_id: str) -> bool:
+    return any(node_id.startswith(prefix) for prefix in TOLERATED_WRITERS)
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Print the attribution table, so a polluted run explains itself."""
+    if not _WRITE_LOG:
+        return
+    terminalreporter.section("tests that wrote to published state (#816)")
+    for entry in _WRITE_LOG:
+        parts = []
+        for kind in ("created", "removed", "changed"):
+            if entry[kind]:
+                shown = ", ".join(entry[kind][:4])
+                more = f" (+{len(entry[kind]) - 4} more)" if len(entry[kind]) > 4 else ""
+                parts.append(f"{kind}: {shown}{more}")
+        mark = "" if _tolerated(entry["test"]) else "  <-- NEW"
+        terminalreporter.write_line(
+            f"{entry['test']}{mark}\n    " + "\n    ".join(parts))
+
+
 @pytest.fixture(scope="session", autouse=True)
 def publish_owned_artifacts_are_left_as_found():
     from clawock.publish.outputs import output_paths

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -252,3 +252,38 @@ def test_the_allowlists_only_ever_shrink():
     assert len(KNOWN_MODULE_CYCLES) <= 3, (
         "a module cycle was added to the allowlist; #814 is about removing these"
     )
+
+
+def test_no_new_test_writes_to_published_state(request):
+    """A test that writes into the checkout changes what later tests see.
+
+    #816: `assets/data/workflow-outcomes.json` is untracked and absent in a
+    clean tree. One test created it, it persisted between runs, and it armed an
+    assertion in a different module that is dormant otherwise — a failure that
+    only ever appeared in full-suite order and passed on its own, twice, before
+    anyone could say which test was responsible.
+
+    This runs last by name and reads the attribution log the conftest fixture
+    builds. It is also what makes the suite parallelisable: shared files are
+    the reason `-n auto` cannot be turned on.
+    """
+    from conftest import _WRITE_LOG, _tolerated  # noqa: PLC0415
+
+    if not _WRITE_LOG:
+        pytest.skip("no writes recorded — this ran outside a full-suite session")
+
+    offenders = sorted({e["test"] for e in _WRITE_LOG if not _tolerated(e["test"])})
+    assert not offenders, (
+        "these tests wrote into the checkout and are not on the tolerated list: "
+        f"{offenders}. Point them at an isolated workspace "
+        "(monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))) rather than "
+        "adding them to TOLERATED_WRITERS — that list is meant to shrink."
+    )
+
+
+def test_the_tolerated_writer_list_only_shrinks():
+    from conftest import TOLERATED_WRITERS  # noqa: PLC0415
+
+    assert len(TOLERATED_WRITERS) <= 5, (
+        "a test was added to the write allowlist; #816 is about emptying it"
+    )

--- a/tests/test_json_repair_wiring.py
+++ b/tests/test_json_repair_wiring.py
@@ -209,6 +209,12 @@ def test_rebuild_fails_closed_when_the_publication_push_fails(
         ),
     ])
     monkeypatch.setattr(_harness_common.subprocess, 'run', lambda *a, **k: next(results))
+    # rebuild_dashboard takes a workspace, but the workflow ledger it calls
+    # resolves its own paths from CLAWOCK_WORKSPACE (falling back to cwd), so
+    # without this the ledger wrote assets/data/workflow-outcomes.json into the
+    # real checkout — an untracked file that then persisted and armed a dormant
+    # assertion in test_dashboard_payload_size (#816).
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))
 
     ok, detail = _harness_common.rebuild_dashboard(tmp_path)
     status = json.loads(

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -20,9 +20,16 @@ FROZEN_NOW = datetime(2026, 7, 24, 23, 0, tzinfo=outcomes.HKT)
 
 
 def _isolate(tmp_path, monkeypatch):
-    monkeypatch.setattr(outcomes, "LOCAL_PATH", tmp_path / "local.json")
-    monkeypatch.setattr(outcomes, "PUBLIC_PATH", tmp_path / "public.json")
-    monkeypatch.setattr(outcomes, "LOCK_PATH", tmp_path / "outcomes.lock")
+    # Isolate the WORKSPACE, not three individual paths. The ledger used to
+    # freeze its paths at import from `Path.cwd()`, so patching the constants
+    # was the only seam available — and any production caller that named a
+    # different workspace was ignored, which is how #816's stray
+    # `assets/data/workflow-outcomes.json` got written into the real checkout.
+    # The paths resolve per call now, so `CLAWOCK_WORKSPACE` is the real seam.
+    workspace = tmp_path / "ws"
+    (workspace / "memory" / ".tmp").mkdir(parents=True, exist_ok=True)
+    (workspace / "assets" / "data").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CLAWOCK_WORKSPACE", str(workspace))
     monkeypatch.setattr(
         outcomes,
         "_now",
@@ -30,6 +37,7 @@ def _isolate(tmp_path, monkeypatch):
         if (at or FROZEN_NOW).tzinfo
         else at.replace(tzinfo=timezone.utc),
     )
+    return workspace
 
 
 def test_stages_remain_independent_and_primary_delivery_can_be_degraded(
@@ -100,9 +108,9 @@ def test_raw_error_is_reported_beside_usable_final_product(tmp_path, monkeypatch
     outcomes.record_stage(job, "postflight", "success", slot=slot)
     outcomes.record_stage(job, "primary_delivery", "success", slot=slot)
 
-    ledger = json.loads(outcomes.LOCAL_PATH.read_text())
+    ledger = json.loads(outcomes.local_path().read_text())
     ledger["records"][0]["raw_execution"] = {"status": "error"}
-    outcomes.LOCAL_PATH.write_text(json.dumps(ledger))
+    outcomes.local_path().write_text(json.dumps(ledger))
     summary = outcomes.summarize(hours=100000)
 
     assert summary["counts"] == {"success": 1}
@@ -241,7 +249,7 @@ def test_reconcile_adds_raw_error_without_changing_final_product(tmp_path, monke
         "error_present": True,
     }
     assert record["final_product"]["status"] == "success"
-    assert "private provider detail" not in outcomes.LOCAL_PATH.read_text()
+    assert "private provider detail" not in outcomes.local_path().read_text()
 
 
 def test_slots_older_than_the_retention_window_are_pruned(tmp_path, monkeypatch):
@@ -290,15 +298,12 @@ def test_a_recorder_failure_warns_instead_of_breaking_the_caller(
 
 
 def test_reconciliation_failure_also_only_warns(tmp_path, monkeypatch, capsys):
-    _isolate(tmp_path, monkeypatch)
-    monkeypatch.setattr(
-        outcomes, "TMP_DIR", tmp_path / "tmp", raising=False
-    )
-    (tmp_path / "tmp").mkdir()
+    ws = _isolate(tmp_path, monkeypatch)
+    receipts = ws / "memory" / ".tmp"
     monkeypatch.setattr(
         outcomes, "load_ledger", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
     )
-    (tmp_path / "tmp" / "brief-sent-2026-07-24.json").write_text(
+    (receipts / "brief-sent-2026-07-24.json").write_text(
         json.dumps({"sent_ok": True})
     )
     assert outcomes.reconcile_delivery_receipts() == 0
@@ -381,10 +386,13 @@ def test_an_unpublished_data_plane_degrades_even_when_findings_are_advisory(
 # ── #765: a delivered slot must not stay `pending` because the sender died ───
 
 def _receipts(tmp_path, monkeypatch):
-    tmp = tmp_path / "tmp"
-    tmp.mkdir(exist_ok=True)
-    monkeypatch.setattr(outcomes, "TMP_DIR", tmp, raising=False)
-    return tmp
+    """The isolated workspace's own receipt directory.
+
+    Receipts have to sit where the ledger looks for them, and since #816 that
+    is `<workspace>/memory/.tmp` resolved per call — not a path the test picks
+    and patches in.
+    """
+    return _isolate(tmp_path, monkeypatch) / "memory" / ".tmp"
 
 
 def test_a_receipt_reconciles_a_slot_whose_sender_was_killed_after_the_send(
@@ -492,10 +500,10 @@ def test_falling_back_to_the_published_ledger_is_never_silent(
 ):
     """That fallback then writes PUBLIC's content back over LOCAL — say so."""
     _isolate(tmp_path, monkeypatch)
-    outcomes.PUBLIC_PATH.write_text(
+    outcomes.public_path().write_text(
         json.dumps({"schema_version": outcomes.SCHEMA_VERSION, "records": []})
     )
-    outcomes.LOCAL_PATH.write_text("{ not json")
+    outcomes.local_path().write_text("{ not json")
     assert outcomes.load_ledger()["records"] == []
     assert "falling back to the published copy" in capsys.readouterr().err
 


### PR DESCRIPTION
Refs #816（**不关闭** —— 容忍名单还没清空）

## 先做归因，不先做修复

那个偶发红我在两个互不相关的分支上各撞到一次，第一次当噪音放过了。追下去发现**问题不在那个测试**：

`assets/data/workflow-outcomes.json` 是**未跟踪的、干净 checkout 里根本不存在**的文件。那条断言写在 `if outcomes_path.is_file():` 里 —— 平时休眠。别的测试把它创建出来、它**在多次运行之间残留**下来，于是断言自己上了膛，去校验一份没人有意写过的内容。

而当时**没有任何东西能说出是谁创建的**。所以这个 PR 加的第一样东西是归因，不是修复。

## 归因夹具（两次写错才写对，都记在注释里）

session 起始基线 + 每个测试一次快照，覆盖 `assets/data` / `memory` / `logs` / `site/assets`，逐个点名。

**前两版都是错的**：函数作用域的 before/after 对，**漏掉 session 夹具做的一切** —— 因为高作用域夹具先于函数作用域建立。第一版和第二版都对一个明明会重写四个文件的模块报告「干净」。基线最后挪到了 `pytest_sessionstart`。

跑出来的结果：

```
tests/test_json_repair_wiring.py::test_rebuild_fails_closed_when_the_publication_push_fails
    created: assets/data/workflow-outcomes.json          ← 元凶
```

## 元凶背后是一个生产代码缺陷

那个测试**写得没问题** —— 它把 `tmp_path` 传给了 `rebuild_dashboard`。**是底下的账本无视了它**：

```python
WS = workspace_root(Path.cwd())          # import 期就冻死
LOCAL_PATH  = WS / "memory" / ".tmp" / "workflow-outcomes.json"
PUBLIC_PATH = WS / "assets" / "data" / "workflow-outcomes.json"
```

而 `clawock/workspace.py` 的文档承诺：

> `CLAWOCK_WORKSPACE`, so the computation can run against a foreign workspace **without touching the modules**

**对这个模块，那个承诺是空的** —— 等任何人能设上环境变量时，路径早就定死了。改成每次调用解析（未设时行为逐字节不变）。

它自己的测试也跟着从「patch 三个路径常量」变成「隔离 workspace」—— 后者才是它们本来想表达的意思，前者只是当时唯一可用的接缝。

（顺带：`workspace_root(Path.cwd())` 这个 import 期解析在 `src/clawock` 里**还有 67 处**。这个 PR 只动了被证据指到的那一个，没有顺手全改。）

## 剩下的写入方：列出来，不静音

```python
TOLERATED_WRITERS = {
    "...test_payload_stays_under_the_published_cap",   # session 重建，本来就该写，且会还原
    "tests/test_intraday_watchdog_retry_parity.py",    # #816 债：写 logs/watchdog.jsonl
    "...test_safe_push_uses_and_cleans_ephemeral_actions_key",  # #816 债：写 integrity_report.json
    "tests/test_report_assembly.py",                   # #816 债：共用 memory/.tmp 账本
    "tests/test_report_context_path.py",
}
```

两条断言钉住形状：**名单外的写入者直接红**，且**名单只能变短**。

`memory/.tmp` 是 gitignore 的临时区，但两个模块共用那里的一份账本**仍然是同一类耦合**，只是往下挪了一层。所以是**列为债务，不是豁免**。

## 验证

```
$ pytest tests/ -q          # 连跑两次
2449 passed, 5 skipped, 4 xfailed
2449 passed, 5 skipped, 4 xfailed

$ git status --porcelain    # 跑完无残留
（空）
```

归因表里**不再出现 `<-- NEW`**，`assets/data/workflow-outcomes.json` 跑完也不再被创建。

## 为什么这条通向 CI 提速

`validate` 126 秒里 **pytest 占 89 秒**。`-n auto` 本可砍到 ~30 秒，但**测试之间共用真实文件就不能并行** —— 并行只会把这个偶发红变成常态红。容忍名单清空之日，就是能开 xdist 之时。
