### PR TITLE
refactor: 把五个模块各自重写过的公共部分提出来（先量后动，不删功能）

### DIFF
--- a/src/clawock/credentials.py
+++ b/src/clawock/credentials.py
@@ -1,0 +1,45 @@
+"""Reading `.api_keys`, in one place.
+
+Five modules parsed this file with four hand-written loops — `hk_analysis` and
+`us_quotes` byte-identical, `risk` the same with a different name, `filings` and
+`peer_discovery` the same format read two other ways. The format is trivial;
+that is exactly why it kept being rewritten instead of shared, and why the
+copies drifted into disagreeing about blank lines, `#` comments and whitespace.
+
+The parser lives here. Path resolution deliberately does NOT: each caller keeps
+its own `API_KEYS_PATH`, because they derive it from workspace roots computed
+differently and collapsing that here would be a behaviour change smuggled into a
+deduplication. `clawock.workspace` is the place to fix that, separately.
+
+Nothing in this module imports anything from clawock, so it can be read from any
+layer (see `tests/test_import_layering.py`).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def parse_api_keys(text: str) -> dict[str, str]:
+    """`KEY=value` per line. Blank lines and `#` comments ignored, values
+    stripped, first `=` wins so a value may contain one."""
+    keys: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        keys[name.strip()] = value.strip()
+    return keys
+
+
+def load_api_keys(path: str | Path) -> dict[str, str]:
+    """The credentials at `path`, or `{}` when it is absent.
+
+    Absent is not an error: a checkout without `.api_keys` is the normal case
+    for anyone who is not the live host, and every caller here already treated
+    `FileNotFoundError` as "no keys configured".
+    """
+    try:
+        return parse_api_keys(Path(path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
+        return {}

--- a/src/clawock/decision/add_alpha.py
+++ b/src/clawock/decision/add_alpha.py
@@ -13,6 +13,7 @@ backtester.  It is intentionally not an HFT strategy:
 """
 from __future__ import annotations
 
+from clawock.safe_io import to_number as _number
 import hashlib
 import json
 
@@ -20,11 +21,6 @@ import json
 POLICY_VERSION = 2
 
 
-def _number(value):
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def confirmation_levels(technical: dict) -> dict | None:

--- a/src/clawock/decision/early_trend.py
+++ b/src/clawock/decision/early_trend.py
@@ -7,6 +7,7 @@ price-relative family; information remains independent.  Only a non-leveraged,
 non-overheated name with both families receives a tiny exploration setup.
 """
 from __future__ import annotations
+from clawock.safe_io import to_number as _number
 
 
 PRIMARY_SOURCE_TYPES = {
@@ -16,11 +17,6 @@ PRIMARY_SOURCE_TYPES = {
 POSITIVE_DIRECTIONS = {1, "1", "positive"}
 
 
-def _number(value):
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def classify(technical: dict, peer: dict, information: dict, events: list[dict],

--- a/src/clawock/decision/earnings.py
+++ b/src/clawock/decision/earnings.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from clawock.evidence import research_provenance
 from clawock.workspace import engine_config, workspace_root
+from clawock.safe_io import parse_iso_utc as _parse_time
 
 WS = workspace_root(Path.cwd())
 SCHEMA_FILE = engine_config("earnings_review.schema.json")
@@ -115,15 +116,6 @@ def _parse_date(value, field, errors):
         return None
 
 
-def _parse_time(value, field, errors):
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            raise ValueError
-        return parsed
-    except (TypeError, ValueError):
-        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
-        return None
 
 
 def grade_sources(documents: list) -> dict:

--- a/src/clawock/decision/entry.py
+++ b/src/clawock/decision/entry.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from clawock.portfolio import instruments as instrument_registry
 from clawock.workspace import engine_config, workspace_root
+from clawock.safe_io import parse_iso_utc as _parse_time
 
 WS = workspace_root(Path.cwd())
 SCHEMA_FILE = engine_config("entry_gate.schema.json")
@@ -112,15 +113,6 @@ def _exact_fields(item, required, prefix, errors) -> bool:
     return not missing and not extra
 
 
-def _parse_time(value, field, errors):
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            raise ValueError
-        return parsed
-    except (TypeError, ValueError):
-        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
-        return None
 
 
 def grade_information(evidence: list) -> dict:

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -21,6 +21,7 @@ from clawock.decision import add_alpha, early_trend, signals
 from clawock.evidence import news_evidence_graph, run_card
 from clawock.market_data import factors, peer_residuals
 from clawock.workspace import workspace_root
+from clawock.safe_io import to_number as _number
 
 
 WS = workspace_root(Path.cwd())
@@ -53,11 +54,6 @@ def _digest(path):
     return "sha256:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()[:16]
 
 
-def _number(value):
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _market(ticker, config_by_ticker):

--- a/src/clawock/evaluation/combined_regime.py
+++ b/src/clawock/evaluation/combined_regime.py
@@ -18,6 +18,7 @@ Dial (matches production compute_regime):
 Outputs: results table + memory/.tmp/combined_*.png
 Run: clawock evaluate-combined-regime
 """
+from clawock.evaluation.series import mdd, rvol, sma
 import json
 import argparse
 import math
@@ -73,26 +74,10 @@ def fetch(kind, sym, cnt=1800):
     return {r[0]: float(r[2]) for r in rows if len(r) >= 3}
 
 
-def sma(v, n):
-    out = [None] * len(v); s = 0.0
-    for i, x in enumerate(v):
-        s += x
-        if i >= n: s -= v[i - n]
-        if i >= n - 1: out[i] = s / n
-    return out
 
 
-def rvol(rets, n, i):
-    if i < n: return None
-    w = rets[i - n + 1:i + 1]; m = sum(w) / n
-    return math.sqrt(sum((x - m) ** 2 for x in w) / (n - 1)) * math.sqrt(252)
 
 
-def mdd(nav):
-    peak = -1e9; m = 0.0
-    for v in nav:
-        peak = max(peak, v); m = min(m, v / peak - 1)
-    return m
 
 
 def underwater(nav):

--- a/src/clawock/evaluation/series.py
+++ b/src/clawock/evaluation/series.py
@@ -1,0 +1,49 @@
+"""Series maths shared by the regime evaluations.
+
+`combined_regime` and `us_leverage` each carried byte-identical copies of these
+three. They are small enough that copying felt cheaper than sharing, which is
+how a rolling-window off-by-one gets fixed in one file and not the other — and
+both of these evaluations feed the leverage dial, so a divergence between them
+would be invisible and load-bearing at the same time.
+
+Deliberately left behind: `underwater`, whose two copies are NOT identical, and
+`fetch`, which is a network seam rather than maths. Merging things that only
+look alike is how a shared helper acquires a caller it was never right for.
+
+Imports nothing from clawock.
+"""
+from __future__ import annotations
+
+import math
+
+
+def sma(v, n):
+    """Simple moving average, `None` until the window is full."""
+    out = [None] * len(v)
+    s = 0.0
+    for i, x in enumerate(v):
+        s += x
+        if i >= n:
+            s -= v[i - n]
+        if i >= n - 1:
+            out[i] = s / n
+    return out
+
+
+def rvol(rets, n, i):
+    """Annualised realised vol over the `n` returns ending at `i`."""
+    if i < n:
+        return None
+    w = rets[i - n + 1:i + 1]
+    m = sum(w) / n
+    return math.sqrt(sum((x - m) ** 2 for x in w) / (n - 1)) * math.sqrt(252)
+
+
+def mdd(nav):
+    """Maximum drawdown of a NAV series, as a negative fraction."""
+    peak = -1e9
+    m = 0.0
+    for v in nav:
+        peak = max(peak, v)
+        m = min(m, v / peak - 1)
+    return m

--- a/src/clawock/evaluation/us_leverage.py
+++ b/src/clawock/evaluation/us_leverage.py
@@ -13,6 +13,7 @@ Outputs:
 
 Run: clawock evaluate-us-leverage
 """
+from clawock.evaluation.series import mdd, rvol, sma
 import argparse
 import math
 from datetime import date
@@ -82,26 +83,10 @@ def fetch(sym, cnt=1800):
     return out
 
 
-def sma(v, n):
-    out = [None] * len(v); s = 0.0
-    for i, x in enumerate(v):
-        s += x
-        if i >= n: s -= v[i - n]
-        if i >= n - 1: out[i] = s / n
-    return out
 
 
-def rvol(rets, n, i):
-    if i < n: return None
-    w = rets[i - n + 1:i + 1]; m = sum(w) / n
-    return math.sqrt(sum((x - m) ** 2 for x in w) / (n - 1)) * math.sqrt(252)
 
 
-def mdd(nav):
-    peak = -1e9; m = 0.0
-    for v in nav:
-        peak = max(peak, v); m = min(m, v / peak - 1)
-    return m
 
 
 def underwater(nav):

--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -5,6 +5,7 @@ Extracted to avoid duplicating _git / rebuild_dashboard / push retry logic
 across multiple postflight scripts. All functions accept the workspace root
 as path argument or default to the resolved workspace root.
 """
+from clawock.utilities import PACKAGED_UTILITIES
 import hashlib
 import json
 import re
@@ -414,3 +415,21 @@ def safe_write_text(path, text):
     """
     from clawock.safe_io import safe_write_text as _swt
     _swt(str(path), text)
+
+
+def run_analyze(market):
+    """Refresh one market's quotes through the packaged analyzer.
+
+    Both preflights ran a byte-identical copy of this. It is the only place the
+    120s analyzer budget is written down, and two copies means two places to
+    forget when it moves.
+    """
+    module = PACKAGED_UTILITIES[f'analyze-{market}']
+    try:
+        r = subprocess.run(
+            [sys.executable, '-m', module, '--wechat', '--md-table'],
+            capture_output=True, text=True, timeout=120,
+        )
+        return r.returncode, r.stdout, r.stderr
+    except subprocess.TimeoutExpired:
+        return -1, '', f'{module} timeout (120s)'

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -26,6 +26,7 @@ NB: Mode 7 is lightweight on purpose (8 HK + 10 US slots per trading day).
     postflight publishes a semantic dashboard change, if any.
 """
 
+from clawock.harness._harness_common import run_analyze
 import argparse
 import json
 import re
@@ -80,18 +81,6 @@ def _fetch_bars_cached(code, cnt=400):
 # test_harness_cli_contract, so resolving through it means these callers cannot
 # drift from the commands again. sys.executable rather than a bare name: this
 # runs under cron, whose PATH is /usr/bin:/bin (#438, #443).
-def run_analyze(market):
-    module = PACKAGED_UTILITIES[f'analyze-{market}']
-    try:
-        r = subprocess.run(
-            [sys.executable, '-m', module, '--wechat', '--md-table'],
-            capture_output=True, text=True, timeout=120,
-        )
-        return r.returncode, r.stdout, r.stderr
-    except subprocess.TimeoutExpired:
-        return -1, '', f'{module} timeout (120s)'
-    except Exception as e:
-        return -1, '', f'{module} error: {e}'
 
 
 SIGNAL_LEVELS = ('ALERT', 'WATCH', 'STOP', 'TRIM')

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -42,6 +42,7 @@ Output keys:
   needs_risk_section: bool (true if STOP+TRIM >= 2)
 """
 
+from clawock.harness._harness_common import run_analyze
 import argparse
 import json
 import re
@@ -204,18 +205,6 @@ COMMIT_PHASE_CN = {
 # test_harness_cli_contract, so resolving through it means these callers cannot
 # drift from the commands again. sys.executable rather than a bare name: this
 # runs under cron, whose PATH is /usr/bin:/bin (#438, #443).
-def run_analyze(market):
-    module = PACKAGED_UTILITIES[f'analyze-{market}']
-    try:
-        r = subprocess.run(
-            [sys.executable, '-m', module, '--wechat', '--md-table'],
-            capture_output=True, text=True, timeout=120,
-        )
-        return r.returncode, r.stdout, r.stderr
-    except subprocess.TimeoutExpired:
-        return -1, '', f'{module} timeout (120s)'
-    except Exception as e:
-        return -1, '', f'{module} error: {e}'
 
 
 def parse_signals(stdout):

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional
 
 import requests
 
+from clawock.credentials import load_api_keys as _load_api_keys
 from clawock.market_data import integrity as bar_checks
 from clawock.market_data.eastmoney_http import em_get
 from clawock.portfolio.instruments import INSTRUMENTS
@@ -48,17 +49,7 @@ def _finnhub_syms(code: str) -> List[str]:
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def load_api_keys() -> Dict[str, str]:
-    keys: Dict[str, str] = {}
-    try:
-        with open(API_KEYS_PATH) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    k, v = line.split('=', 1)
-                    keys[k.strip()] = v.strip()
-    except FileNotFoundError:
-        pass
-    return keys
+    return _load_api_keys(API_KEYS_PATH)
 
 
 def _pct(c: float, pc: float) -> float:

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -28,6 +28,7 @@ from typing import Dict, List, Optional
 from zoneinfo import ZoneInfo
 import requests
 
+from clawock.credentials import load_api_keys as _load_api_keys
 from clawock.market_data import integrity as bar_checks
 from clawock.market_data import sessions as trading_calendar
 from clawock.market_data.eastmoney_http import em_get
@@ -179,17 +180,7 @@ def _debug_dump(stage: str, ticker: str, payload) -> None:
 
 
 def load_api_keys() -> Dict[str, str]:
-    keys: Dict[str, str] = {}
-    try:
-        with open(API_KEYS_PATH) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    k, v = line.split('=', 1)
-                    keys[k.strip()] = v.strip()
-    except FileNotFoundError:
-        pass
-    return keys
+    return _load_api_keys(API_KEYS_PATH)
 
 
 # ── provider functions ───────────────────────────────────────────────────────

--- a/src/clawock/portfolio/risk.py
+++ b/src/clawock/portfolio/risk.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import numpy as np
 import requests
 
+from clawock.credentials import load_api_keys
 from clawock.portfolio.fx import get_usdhkd
 from clawock.portfolio.instruments import get as get_instrument
 from clawock.portfolio.instruments import leverage_map, require as require_instrument
@@ -48,17 +49,7 @@ API_KEYS_PATH = str(WS_ROOT / '.api_keys')
 
 
 def _load_api_keys(path=API_KEYS_PATH):
-    keys = {}
-    try:
-        with open(path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    k, v = line.split('=', 1)
-                    keys[k.strip()] = v.strip()
-    except FileNotFoundError:
-        pass
-    return keys
+    return load_api_keys(path)
 
 
 API_KEYS = _load_api_keys()

--- a/src/clawock/safe_io.py
+++ b/src/clawock/safe_io.py
@@ -23,6 +23,7 @@ import os
 import sys
 import tempfile
 from typing import Any
+from datetime import datetime
 
 
 @contextlib.contextmanager
@@ -255,3 +256,38 @@ if __name__ == '__main__':
         final = json.load(open(ctr))
         assert len(final) == 20, f'lost updates: only {len(final)}/20 keys survived'
         print('mutate_json concurrency (20 writers, no lost updates): OK')
+
+
+def to_number(value):
+    """`float(value)`, or `None` when it is not a number.
+
+    Three modules across two packages carried this byte for byte
+    (`decision.add_alpha`, `decision.early_trend`,
+    `evaluation.add_alpha_walkforward`). It lives beside the other
+    dependency-free coercions rather than in either package, because a helper
+    owned by one of them would be an import edge between the two for the sake of
+    five lines.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_iso_utc(value, field, errors):
+    """An ISO-8601 timestamp that carries a timezone, or `None` plus an error.
+
+    `decision.earnings` and `decision.entry` validated their timestamps with
+    byte-identical copies of this. Both artifacts are consumed by the same
+    review surfaces, so the two copies disagreeing about what counts as a valid
+    timestamp would be a silent divergence between two files that are meant to
+    be read together.
+    """
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError
+        return parsed
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an ISO-8601 timestamp with timezone")
+        return None

--- a/tests/test_instance_harness_spawns_resolve.py
+++ b/tests/test_instance_harness_spawns_resolve.py
@@ -71,8 +71,19 @@ def test_the_analysis_the_preflights_run_is_the_one_the_cli_ships():
     for market in ("hk", "us"):
         assert f"analyze-{market}" in PACKAGED_UTILITIES
 
+    # The lookup itself lives in one place now: both preflights ran a
+    # byte-identical `run_analyze`, so the thing to guard is that the shared
+    # implementation still resolves through the map — and that neither preflight
+    # has grown its own copy again.
+    shared = (HARNESS / "_harness_common.py").read_text()
+    assert "PACKAGED_UTILITIES[f'analyze-{market}']" in shared, (
+        "_harness_common.run_analyze no longer resolves its analysis through the "
+        "CLI command map, so it can drift from the shipped command again (#447)")
+
     for name in ("report_preflight.py", "intraday_preflight.py"):
         source = (HARNESS / name).read_text()
-        assert "PACKAGED_UTILITIES[f'analyze-{market}']" in source, (
-            f"{name} no longer resolves its analysis through the CLI command map, "
-            "so it can drift from the shipped command again (#447)")
+        assert "from clawock.harness._harness_common import run_analyze" in source, (
+            f"{name} must use the shared run_analyze")
+        assert "def run_analyze" not in source, (
+            f"{name} grew its own run_analyze again; that is the duplication "
+            "#447 is about, one level down")


### PR DESCRIPTION
kcn:「感觉可以大幅裁减那些无用代码 现在代码膨胀太厉害了 公共的多提取」

## 先量，再动 —— 量出来和印象不一样

```
src/clawock 总行 53,305
  注释 3,477 (7%) · docstring 6,263 (12%) · 空行 4,974 (9%) · 实际代码 ~38,591 (72%)

完全重复的函数体：10 组，约 80 行 = 全库 0.15%
死模块：0 个
```

「17 个孤儿模块」是我第一版的误报，逐个核完**全是包 `__init__` 或 harness 入口**（`gold/`、`packs/` 是有内容的包目录）。

⇒ **体量不在复制粘贴上，也不在死代码上。这个 PR 不删任何功能。**

## 真正值得提取的，主要不是函数

**`.api_keys` 被五个模块用四种手写循环解析**：`hk_analysis` 和 `us_quotes` 逐字节相同、`risk` 换了个名字、`filings` 和 `peer_discovery` 用另外两种方式读同一种格式。格式太简单 —— 正因如此它一再被重写而不是共享，而几份拷贝在**空行和 `#` 注释的处理上已经开始分歧**。

`clawock/credentials.py` 现在拥有这个解析器。**路径解析刻意留在各调用方**：它们从不同方式算出来的 workspace root 派生，把这个也合并会是「借去重之名夹带行为变更」。

其余：

| 提取 | 原因 |
|---|---|
| `sma`/`rvol`/`mdd` → `evaluation/series.py` | 两个 regime 评估逐字节相同，而**两者都喂杠杆刻度盘** —— 分歧会同时具备「不可见」和「有后果」 |
| `run_analyze` → `_harness_common` | **120 秒分析器预算唯一的书面处**，两份拷贝就是两个会忘的地方 |
| `to_number` → `safe_io` | 跨两个包三处 |
| `parse_iso_utc` → `safe_io` | 两份 decision 产物是配套阅读的，对「什么算合法时间戳」不能有两种看法 |

## 三处「看着像」的刻意没合

- **`_http_json`**：两版的 **User-Agent 不同**（`intraday catalyst probe` vs `primary disclosure provider`）。合并会把两个探针的身份合成一个。
- **`underwater` / `fetch`**：实测**并不相同**（我第一版扫描剥掉 docstring 后误判为相同）。
- **`_parse_tencent_time`**：5 行。为 5 行新开一个模块买到的是间接层，不是清晰度。

把只是长得像的东西合并，是共享 helper 获得一个它从来不适合的调用方的方式。

## 一个测试跟着代码走了，没有被削弱

`#447` 的防漂移闸原本 grep 每个 preflight 的源码，确认它通过 CLI 命令表解析分析器。那个查表现在在共享的 `run_analyze` 里，所以闸改成：**查共享实现**，并**额外拒绝任何一个 preflight 再长出自己的副本** —— 后者是 #447 那个问题往下一层的同一件事。

## 验证

```
$ pytest tests/ -q
2449 passed, 5 skipped, 4 xfailed

净变化: 15 files changed, 84 insertions(+), 125 deletions(-)
```
