### PR TITLE
test: 把剩下四个写入方隔离到各自的 workspace（#816，名单 5→1）

### DIFF
--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -30,7 +30,17 @@ from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
 _CHECKOUT = WS
-LOG = WS / 'logs' / 'watchdog.jsonl'
+
+
+def log_path() -> Path:
+    """`logs/watchdog.jsonl` in the CURRENT workspace.
+
+    Was a module constant computed from `Path.cwd()` at import, which meant
+    `CLAWOCK_WORKSPACE` could not reach it and a test exercising the watchdog
+    appended to the real checkout's log (#816). Resolved per call; unset, the
+    path is what it always was.
+    """
+    return workspace_root(Path.cwd()) / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
 # The binary path, the cron CLI call and the cron-state fallback chain moved
 # into src/clawock/providers/openclaw.py so this module stops being the largest
@@ -59,8 +69,8 @@ def log(event):
     """Append one JSON line to logs/watchdog.jsonl. Never raises."""
     try:
         event['ts'] = datetime.now(HKT).isoformat()
-        LOG.parent.mkdir(parents=True, exist_ok=True)
-        with LOG.open('a') as f:
+        log_path().parent.mkdir(parents=True, exist_ok=True)
+        with log_path().open('a') as f:
             f.write(json.dumps(event, ensure_ascii=False) + '\n')
     except Exception as e:
         print(f'(watchdog log failed: {e})', file=sys.stderr)

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -68,7 +68,10 @@ from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
 PORTFOLIO = WS / 'portfolio.json'
-OUT = WS / 'assets' / 'data' / 'integrity_report.json'
+def out_path() -> Path:
+    """Resolved per call so `CLAWOCK_WORKSPACE` reaches it (#816); frozen at
+    import, a test writing a report landed it in the real checkout."""
+    return workspace_root(Path.cwd()) / 'assets' / 'data' / 'integrity_report.json'
 
 from clawock.instruments import INSTRUMENTS
 from clawock.portfolio.math import (
@@ -561,7 +564,7 @@ def main(argv=None):
                         help='ledger to check (default: this workspace)')
     path = parser.parse_args(argv).portfolio
     report = check(path)
-    safe_write_json(str(OUT), report)
+    safe_write_json(str(out_path()), report)
 
     icon = {'ERROR': '🔴', 'WARN': '🟡'}
     if not report['findings']:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,84 @@ def _watched_state():
     return state
 
 
+@pytest.fixture
+def isolated_workflow_ledger(tmp_path_factory, monkeypatch):
+    """Point the workflow-outcome ledger at a temp directory.
+
+    The report-assembly suites drive real postflights, which record stages. The
+    ledger resolves its paths per call now (#816), but these tests need the rest
+    of the real workspace — the book, the config — so redirecting
+    CLAWOCK_WORKSPACE wholesale would break them. Patching the four path
+    functions isolates exactly the shared file and nothing else.
+
+    Returns the directory, for a test that wants to read back what was written.
+    """
+    from clawock.automation import workflow_outcomes  # noqa: PLC0415
+
+    # A directory of its own, NOT a child of the test's `tmp_path`: several of
+    # these tests list their tmp_path and assert on exactly what is in it.
+    ledger = tmp_path_factory.mktemp("workflow-ledger")
+    monkeypatch.setattr(workflow_outcomes, "local_path", lambda: ledger / "local.json")
+    monkeypatch.setattr(workflow_outcomes, "public_path", lambda: ledger / "public.json")
+    monkeypatch.setattr(workflow_outcomes, "lock_path", lambda: ledger / "lock")
+    monkeypatch.setattr(workflow_outcomes, "tmp_dir", lambda: ledger)
+    return ledger
+
+
+@pytest.fixture
+def isolated_watchdog_log(tmp_path_factory, monkeypatch):
+    """Point `logs/watchdog.jsonl` at a temp directory.
+
+    Same shape as the ledger: the watchdog appends a line per run, and a test
+    driving a real watchdog appended to the checkout's own log (#816). The path
+    resolves per call now, so patching the one function is enough.
+    """
+    from clawock.harness import _watchdog_common  # noqa: PLC0415
+
+    target = tmp_path_factory.mktemp("watchdog") / "watchdog.jsonl"
+    monkeypatch.setattr(_watchdog_common, "log_path", lambda: target)
+    return target
+
+
+@pytest.fixture
+def isolated_integrity_report(tmp_path_factory, monkeypatch):
+    """Point `assets/data/integrity_report.json` at a temp directory (#816)."""
+    from clawock.portfolio import integrity  # noqa: PLC0415
+
+    target = tmp_path_factory.mktemp("integrity") / "integrity_report.json"
+    monkeypatch.setattr(integrity, "out_path", lambda: target)
+    return target
+
+
+@pytest.fixture
+def restores_untracked_artifact():
+    """Undo an artifact a subprocess necessarily wrote into the checkout.
+
+    Some gates can only be tested by running them for real against this
+    repository. `money_checker.sh` is one: it pins CLAWOCK_WORKSPACE to the root
+    it is guarding, on purpose, so no environment the test sets can redirect it
+    — the point of the gate is that it checks the repo being pushed. Its
+    `assets/data/integrity_report.json` is therefore a correct side effect, and
+    the fix is to put the tree back rather than to weaken the test (#816).
+
+    Restores to the exact bytes found, or deletes the file if it was absent.
+    """
+    saved: dict = {}
+
+    def track(relative):
+        path = ROOT / relative
+        saved[path] = path.read_bytes() if path.exists() else None
+        return path
+
+    yield track
+
+    for path, blob in saved.items():
+        if blob is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_bytes(blob)
+
+
 _WRITE_LOG = []
 _LAST_SEEN = {}
 
@@ -163,17 +241,13 @@ def _attribute_writes_to_the_test_that_made_them(request):
 # same class of coupling, one directory further down. Listed, not exempted.
 TOLERATED_WRITERS = {
     # The session dashboard rebuild, attributed to whichever test first requests
-    # the fixture. Load-bearing, and the session fixture restores its output.
+    # the fixture. This one is not debt: the builder is supposed to run against
+    # the real tree — the money-reconciliation tests compare its payload with
+    # portfolio.json, and a rebuild into a temp copy would be checking a
+    # different book. Its residue, not its writes, was ever the problem, and the
+    # session fixture below restores all four files.
     "tests/test_dashboard_payload_size.py::test_payload_stays_under_the_published_cap",
-    # #816 debt: writes logs/watchdog.jsonl into the checkout.
-    "tests/test_intraday_watchdog_retry_parity.py",
-    # #816 debt: writes assets/data/integrity_report.json into the checkout.
-    "tests/test_pr_publish_gate_contract.py::test_safe_push_uses_and_cleans_ephemeral_actions_key",
-    # #816 debt: share one memory/.tmp ledger instead of an isolated workspace.
-    "tests/test_report_assembly.py",
-    "tests/test_report_context_path.py",
 }
-
 
 def _tolerated(node_id: str) -> bool:
     return any(node_id.startswith(prefix) for prefix in TOLERATED_WRITERS)

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -268,13 +268,29 @@ def test_no_new_test_writes_to_published_state(request):
     anyone could say which test was responsible.
 
     This runs last by name and reads the attribution log the conftest fixture
-    builds. It is also what makes the suite parallelisable: shared files are
-    the reason `-n auto` cannot be turned on.
+    builds.
+
+    On parallelism, measured rather than assumed: with the four other writers
+    isolated, `-n 4` does pass — but not safely. Every xdist worker gets its own
+    session, so four workers each run the dashboard rebuild against the same
+    four files concurrently, and that it passed is luck rather than a property.
+    Turning `-n auto` on needs that rebuild to be per-session-shared or
+    group-pinned first; it is not just a flag.
     """
     from conftest import _WRITE_LOG, _tolerated  # noqa: PLC0415
 
     if not _WRITE_LOG:
         pytest.skip("no writes recorded — this ran outside a full-suite session")
+
+    # Under xdist the attribution is not trustworthy and neither is the result:
+    # every worker gets its own session, so N workers each run the dashboard
+    # rebuild against the same four files at once, and a write by one worker
+    # lands in whatever test another worker happened to be running. Measured on
+    # `-n 4`: this named test_hook_entrypoints_can_import_clawock, which writes
+    # nothing. The suite is not parallel-safe yet — see the module docstring —
+    # and pretending to check it here would be worse than saying so.
+    if getattr(request.config, "workerinput", None) is not None:
+        pytest.skip("write attribution is not valid under xdist; see #816")
 
     offenders = sorted({e["test"] for e in _WRITE_LOG if not _tolerated(e["test"])})
     assert not offenders, (
@@ -288,8 +304,10 @@ def test_no_new_test_writes_to_published_state(request):
 def test_the_tolerated_writer_list_only_shrinks():
     from conftest import TOLERATED_WRITERS  # noqa: PLC0415
 
-    assert len(TOLERATED_WRITERS) <= 5, (
-        "a test was added to the write allowlist; #816 is about emptying it"
+    assert len(TOLERATED_WRITERS) <= 1, (
+        "a test was added to the write allowlist. The one entry left is the "
+        "session dashboard rebuild, which is supposed to run against the real "
+        "tree; everything else now isolates its workspace (#816)."
     )
 
 

--- a/tests/test_intraday_watchdog_retry_parity.py
+++ b/tests/test_intraday_watchdog_retry_parity.py
@@ -27,6 +27,15 @@ this file.
 """
 import json
 from datetime import datetime
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _watchdog_log(isolated_watchdog_log):
+    """These drive the real watchdog, which appends a line per run. Without it
+    they append to the checkout's own logs/watchdog.jsonl (#816)."""
+
+
 
 JOB = '盘中盯盘'
 SLOT = '2026-08-10T10:30:00+08:00'

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -48,7 +48,7 @@ def test_each_publishing_workflow_scopes_deploy_key_to_push_step():
         )
 
 
-def test_safe_push_uses_and_cleans_ephemeral_actions_key(tmp_path):
+def test_safe_push_uses_and_cleans_ephemeral_actions_key(tmp_path, restores_untracked_artifact):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     git_log = tmp_path / "git.log"
@@ -69,6 +69,10 @@ exit 1
     fake_git.chmod(0o755)
 
     fake_secret = "not-a-real-private-key"
+    # The money gate runs for real against this repository and writes its
+    # report there; that is the behaviour under test, so put the tree back
+    # afterwards instead of trying to redirect it (#816).
+    restores_untracked_artifact("assets/data/integrity_report.json")
     env = os.environ.copy()
     env.update(
         {

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -39,6 +39,13 @@ def _load(name):
     return importlib.import_module(f'clawock.harness.{name}')
 
 
+@pytest.fixture(autouse=True)
+def _ledger(isolated_workflow_ledger, isolated_watchdog_log):
+    """Every test here drives a real postflight, which records a workflow stage,
+    and one drives the watchdog, which appends a log line. Without this they
+    write into the checkout (#816)."""
+
+
 @pytest.fixture
 def pf():
     return _load('report_postflight')

--- a/tests/test_report_context_path.py
+++ b/tests/test_report_context_path.py
@@ -35,6 +35,12 @@ def _load(name):
     return importlib.import_module(f'clawock.harness.{name}')
 
 
+@pytest.fixture(autouse=True)
+def _ledger(isolated_workflow_ledger):
+    """Every test here drives a real postflight, which records a workflow stage.
+    Without this they all append to the checkout's own ledger (#816)."""
+
+
 @pytest.fixture
 def preflight():
     return _load('report_preflight')


### PR DESCRIPTION
Refs #816（**不关闭** —— 名单从 5 条降到 1 条，剩下那条不是债）

## 四个写入方各有各的原因，所以各有各的修法

**① 和账本同一个「import 期冻死」缺陷**：`_watchdog_common.LOG` 和 `portfolio.integrity.OUT` 都是模块加载时用 `Path.cwd()` 算好的，所以 `CLAWOCK_WORKSPACE` 够不到它们 —— 一个驱动真实 watchdog 的测试就往 checkout 自己的日志里追加了一行。两个都改成**每次调用解析**；未设时路径和以前一模一样。

**② report-assembly 两套需要真实 workspace 的其余部分**（账本、配置），所以整体重定向 `CLAWOCK_WORKSPACE` 会把它们弄坏。改成一个 fixture **只 patch 那四个账本路径函数** —— 这只有在它们变成函数之后才做得到。

分配用 `tmp_path_factory` 而不是 `tmp_path`：**那几个测试里有几个会列出自己的 `tmp_path` 并断言里面恰好有什么**，我第一版把 ledger 目录建在 `tmp_path` 下，当场就红了。

**③ 最后一个不能重定向，也不该重定向。** `safe_push.sh` 通过 `env CLAWOCK_WORKSPACE=$root` 调用 money gate，**刻意把 workspace 钉死在它正在守护的那个仓库上** —— 而那个钉死正是被测的行为。它写出的 integrity report 是**正确的副作用**，所以测试改成**事后还原**，而不是削弱它所验证的东西。

## 剩下那一条不是债

session 的 dashboard 重建**本来就该跑在真实树上**：money 对账测试拿它的 payload 和 `portfolio.json` 比，重建到副本里等于在核对另一本账。它的**残留**才是问题，而 session fixture 已经在还原。

## 并行：实测过，不是假设

`-n 4` **现在能过了** —— 但**不安全**：

- 每个 xdist worker 有自己的 session，**四个 worker 各自对同样那四个文件跑一遍重建**。这次过了是运气，不是性质。
- 更糟的是**写入归因在并行下没有意义**：`-n 4` 那次它指控了 `test_hook_entrypoints_can_import_clawock` —— **那个测试什么都不写**。

所以归因断言在 xdist 下 skip 并把原因写在代码里，`-n auto` 保持关闭。**要开它得先让那个重建变成跨 worker 共享或 group-pin，不是加个 flag 的事。**

## 验证

```
$ pytest tests/ -q          # 串行
2452 passed, 5 skipped, 4 xfailed

归因表只剩：
tests/test_dashboard_payload_size.py::test_payload_stays_under_the_published_cap
    changed: dashboard.json, decision_audit.json, overview.json, shadow_portfolio.json
```

容忍名单的断言从 `<= 5` 收到 `<= 1`。
