### PR TITLE
arch: 任何层级都不再有 import 环；并行那条结论就地更正（#816 收官）

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -28,6 +28,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from clawock import sessions as _cal
+from clawock.decision.mind_record import validate_mind_record
 from clawock.decision.actions import (
     ACTIVE_ACTIONS,
     ADD_ACTIONS,
@@ -308,7 +309,6 @@ def validate_decision(d: dict) -> list[str]:
     # schema_version 0 is exclusively the mind ledger; every record.SOURCES
     # harness (conversation/openclaw/claude/codex/cli) writes this row type.
     if d.get("schema_version") == 0:
-        from clawock.decision.record import validate_mind_record
         return validate_mind_record(d)
     errors = []
     for key in ("decision_id", "episode_id", "plan_date", "created_at", "ticker", "strategy_id", "action", "condition"):

--- a/src/clawock/decision/mind_record.py
+++ b/src/clawock/decision/mind_record.py
@@ -1,0 +1,57 @@
+"""The conversation-verdict (schema_version 0) record shape and its validator.
+
+Split out of `decision.record` to break a real import cycle (#814):
+`record` appends through `decision.ledger`, and `ledger` had to reach back into
+`record` to validate one row type — a dependency it papered over with a
+function-level import. The schema depends on neither module, so both can sit
+above it.
+
+The vocabularies below are the frozen contract described in
+docs/decision-mind-ledger.md; changing one changes what the ledger will accept.
+"""
+from __future__ import annotations
+
+ACTIONS = {"buy", "add", "trim", "sell", "hold", "watch", "reject", "abstain"}
+
+
+DRIVEN_BY = {"technical", "fundamental", "sentiment", "mixed"}
+
+
+EMOTIONS = {"calm", "fomo", "revenge", "averaging_down", "fear", "euphoria", "mixed"}
+
+
+# Which harness produced the verdict. `conversation` is the DSH default and
+# the historical value; other harnesses pass their own so the ledger can say
+# where a mind record came from. `brief` is the desk's daily plan writer and
+# is not a valid record() value — it is produced by the brief postflight.
+SOURCES = {"conversation", "openclaw", "claude", "codex", "cli"}
+
+
+def validate_mind_record(record: dict) -> list[str]:
+    """Return human-readable issues; empty means the record is appendable."""
+    issues: list[str] = []
+    subject = record.get("subject") or {}
+    for field in ("ticker", "market", "currency"):
+        if not isinstance(subject.get(field), str) or not subject.get(field, "").strip():
+            issues.append(f"subject.{field} is required")
+    if record.get("action") not in ACTIONS:
+        issues.append(f"action must be one of {sorted(ACTIONS)}")
+    if record.get("source") not in SOURCES:
+        issues.append(f"source must be one of {sorted(SOURCES)}")
+    confidence = record.get("confidence")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        issues.append("confidence must be between 0 and 1")
+    if record.get("driven_by") not in DRIVEN_BY:
+        issues.append(f"driven_by must be one of {sorted(DRIVEN_BY)}")
+    mind = record.get("mind") or {}
+    for side in ("bull", "bear"):
+        case = mind.get(side) or {}
+        if not isinstance(case.get("summary"), str) or not case.get("summary", "").strip():
+            issues.append(f"mind.{side}.summary is required (opposing case is mandatory)")
+    if not isinstance(mind.get("invalidation"), list) or not mind.get("invalidation"):
+        issues.append("mind.invalidation must be a non-empty list of observable conditions")
+    emotion = record.get("emotion") or {}
+    if emotion.get("pressure") not in EMOTIONS:
+        issues.append(f"emotion.pressure must be one of {sorted(EMOTIONS)}")
+    return issues
+

--- a/src/clawock/decision/record.py
+++ b/src/clawock/decision/record.py
@@ -20,6 +20,13 @@ Usage:
 """
 from __future__ import annotations
 
+from clawock.decision.mind_record import (  # noqa: F401  (re-export)
+    ACTIONS,
+    DRIVEN_BY,
+    EMOTIONS,
+    SOURCES,
+    validate_mind_record,
+)
 import argparse
 import json
 import sys
@@ -28,14 +35,6 @@ from pathlib import Path
 
 from clawock.decision import ledger as decision_v2
 
-ACTIONS = {"buy", "add", "trim", "sell", "hold", "watch", "reject", "abstain"}
-DRIVEN_BY = {"technical", "fundamental", "sentiment", "mixed"}
-EMOTIONS = {"calm", "fomo", "revenge", "averaging_down", "fear", "euphoria", "mixed"}
-# Which harness produced the verdict. `conversation` is the DSH default and
-# the historical value; other harnesses pass their own so the ledger can say
-# where a mind record came from. `brief` is the desk's daily plan writer and
-# is not a valid record() value — it is produced by the brief postflight.
-SOURCES = {"conversation", "openclaw", "claude", "codex", "cli"}
 MIND_SCHEMA_VERSION = 0
 
 
@@ -43,33 +42,6 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
 
 
-def validate_mind_record(record: dict) -> list[str]:
-    """Return human-readable issues; empty means the record is appendable."""
-    issues: list[str] = []
-    subject = record.get("subject") or {}
-    for field in ("ticker", "market", "currency"):
-        if not isinstance(subject.get(field), str) or not subject.get(field, "").strip():
-            issues.append(f"subject.{field} is required")
-    if record.get("action") not in ACTIONS:
-        issues.append(f"action must be one of {sorted(ACTIONS)}")
-    if record.get("source") not in SOURCES:
-        issues.append(f"source must be one of {sorted(SOURCES)}")
-    confidence = record.get("confidence")
-    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
-        issues.append("confidence must be between 0 and 1")
-    if record.get("driven_by") not in DRIVEN_BY:
-        issues.append(f"driven_by must be one of {sorted(DRIVEN_BY)}")
-    mind = record.get("mind") or {}
-    for side in ("bull", "bear"):
-        case = mind.get(side) or {}
-        if not isinstance(case.get("summary"), str) or not case.get("summary", "").strip():
-            issues.append(f"mind.{side}.summary is required (opposing case is mandatory)")
-    if not isinstance(mind.get("invalidation"), list) or not mind.get("invalidation"):
-        issues.append("mind.invalidation must be a non-empty list of observable conditions")
-    emotion = record.get("emotion") or {}
-    if emotion.get("pressure") not in EMOTIONS:
-        issues.append(f"emotion.pressure must be one of {sorted(EMOTIONS)}")
-    return issues
 
 
 def build_record(args) -> dict:

--- a/src/clawock/tools/__init__.py
+++ b/src/clawock/tools/__init__.py
@@ -28,94 +28,16 @@ audit chain, so the tools read the precompiled protocol — they do not replace 
 """
 from __future__ import annotations
 
+from clawock.tools.base import BaseTool, ToolError, ToolRegistry  # noqa: F401
+
 import json
 from typing import Any
 
 
-class ToolError(RuntimeError):
-    """A tool refused. The message is shown to the caller verbatim."""
 
 
-class BaseTool:
-    """One callable capability, described well enough for an LLM to use it."""
-
-    name: str = ""
-    description: str = ""
-    parameters: dict[str, Any] = {}
-    # Read-only tools are safe to run speculatively or in parallel. Anything that
-    # writes must say so, because the caller's batching depends on it.
-    is_readonly: bool = True
-
-    @classmethod
-    def check_available(cls, workspace) -> bool:
-        """Whether this tool can run against `workspace`.
-
-        Returning False excludes it from the registry, which is far better than
-        surfacing a missing-file traceback in the middle of a model turn.
-        """
-        return True
-
-    def execute(self, workspace, **kwargs: Any) -> str:
-        raise NotImplementedError
-
-    # ── schema export ───────────────────────────────────────────────────────
-
-    def to_openai_schema(self) -> dict[str, Any]:
-        return {
-            "type": "function",
-            "function": {
-                "name": self.name,
-                "description": self.description.strip(),
-                "parameters": self.parameters or {
-                    "type": "object", "properties": {}, "required": []},
-            },
-        }
-
-    def to_anthropic_schema(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "description": self.description.strip(),
-            "input_schema": self.parameters or {
-                "type": "object", "properties": {}, "required": []},
-        }
 
 
-class ToolRegistry:
-    """The tools available for one workspace."""
-
-    def __init__(self, workspace):
-        self.workspace = workspace
-        self._tools: dict[str, BaseTool] = {}
-
-    def register(self, tool: BaseTool) -> bool:
-        if not tool.name:
-            raise ValueError("a tool must have a name")
-        if not type(tool).check_available(self.workspace):
-            return False
-        self._tools[tool.name] = tool
-        return True
-
-    def __contains__(self, name: str) -> bool:
-        return name in self._tools
-
-    def __len__(self) -> int:
-        return len(self._tools)
-
-    def names(self) -> list[str]:
-        return sorted(self._tools)
-
-    def get(self, name: str) -> BaseTool:
-        if name not in self._tools:
-            raise ToolError(f"unknown tool: {name}")
-        return self._tools[name]
-
-    def call(self, name: str, **kwargs: Any) -> str:
-        return self.get(name).execute(self.workspace, **kwargs)
-
-    def schemas(self, dialect: str = "openai") -> list[dict[str, Any]]:
-        render = {"openai": lambda t: t.to_openai_schema(),
-                  "anthropic": lambda t: t.to_anthropic_schema()}[dialect]
-        return [render(self._tools[name]) for name in self.names()]
 
 
 def build_registry(workspace, tools=None) -> ToolRegistry:

--- a/src/clawock/tools/base.py
+++ b/src/clawock/tools/base.py
@@ -1,0 +1,102 @@
+"""The tool vocabulary: what a capability is, and how a registry holds them.
+
+Split out of `tools/__init__` to break an import cycle (#814). Every tool module
+imports `BaseTool` and `ToolError` from the package, and the package imported
+the tool modules back to build the registry. The shape is common enough to read
+as idiomatic — `build_registry` defers its import inside the function, so it
+works — but it is still a cycle, and it costs one file to remove: these
+definitions have no dependencies, so both sides can sit above them.
+
+`clawock.tools` re-exports all three; that is the name every tool module and
+caller already uses.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class ToolError(RuntimeError):
+    """A tool refused. The message is shown to the caller verbatim."""
+
+
+class BaseTool:
+    """One callable capability, described well enough for an LLM to use it."""
+
+    name: str = ""
+    description: str = ""
+    parameters: dict[str, Any] = {}
+    # Read-only tools are safe to run speculatively or in parallel. Anything that
+    # writes must say so, because the caller's batching depends on it.
+    is_readonly: bool = True
+
+    @classmethod
+    def check_available(cls, workspace) -> bool:
+        """Whether this tool can run against `workspace`.
+
+        Returning False excludes it from the registry, which is far better than
+        surfacing a missing-file traceback in the middle of a model turn.
+        """
+        return True
+
+    def execute(self, workspace, **kwargs: Any) -> str:
+        raise NotImplementedError
+
+    # ── schema export ───────────────────────────────────────────────────────
+
+    def to_openai_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description.strip(),
+                "parameters": self.parameters or {
+                    "type": "object", "properties": {}, "required": []},
+            },
+        }
+
+    def to_anthropic_schema(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description.strip(),
+            "input_schema": self.parameters or {
+                "type": "object", "properties": {}, "required": []},
+        }
+
+
+class ToolRegistry:
+    """The tools available for one workspace."""
+
+    def __init__(self, workspace):
+        self.workspace = workspace
+        self._tools: dict[str, BaseTool] = {}
+
+    def register(self, tool: BaseTool) -> bool:
+        if not tool.name:
+            raise ValueError("a tool must have a name")
+        if not type(tool).check_available(self.workspace):
+            return False
+        self._tools[tool.name] = tool
+        return True
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._tools
+
+    def __len__(self) -> int:
+        return len(self._tools)
+
+    def names(self) -> list[str]:
+        return sorted(self._tools)
+
+    def get(self, name: str) -> BaseTool:
+        if name not in self._tools:
+            raise ToolError(f"unknown tool: {name}")
+        return self._tools[name]
+
+    def call(self, name: str, **kwargs: Any) -> str:
+        return self.get(name).execute(self.workspace, **kwargs)
+
+    def schemas(self, dialect: str = "openai") -> list[dict[str, Any]]:
+        render = {"openai": lambda t: t.to_openai_schema(),
+                  "anthropic": lambda t: t.to_anthropic_schema()}[dialect]
+        return [render(self._tools[name]) for name in self.names()]

--- a/src/clawock/tools/context_tools.py
+++ b/src/clawock/tools/context_tools.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from clawock.context import brief as brief_context
 from clawock.decision import packet as brief_decision_packet
-from clawock.tools import BaseTool, ToolError
+from clawock.tools.base import BaseTool, ToolError
 
 SECTIONS = ("facts", "technical", "quant", "sentiment", "evidence", "risk",
             "constraints")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,10 @@ So: snapshot before, restore after, and verify the restore actually worked.
 Restoring to the session's starting bytes rather than to HEAD keeps a
 developer's own uncommitted edits intact.
 """
+import fcntl
 import os
 import subprocess
+import tempfile
 import sys
 from pathlib import Path
 
@@ -292,8 +294,14 @@ def publish_owned_artifacts_are_left_as_found():
             f"code PR:\n{status_after}")
 
 
+def _xdist_worker(config) -> str | None:
+    """This worker's id under xdist, or None when running serially."""
+    info = getattr(config, "workerinput", None)
+    return info.get("workerid") if info else None
+
+
 @pytest.fixture(scope="session")
-def freshly_built_dashboard(publish_owned_artifacts_are_left_as_found):
+def freshly_built_dashboard(request, publish_owned_artifacts_are_left_as_found):
     """The real builder run once, against the real tree, before anything reads
     the payload it produces.
 
@@ -306,10 +314,29 @@ def freshly_built_dashboard(publish_owned_artifacts_are_left_as_found):
     from the fixture is what makes each of them state the dependency instead of
     reaching for a module constant that may or may not be fresh.
     """
-    # Run through the source tree explicitly; CI installs first, but a focused
-    # local invocation should exercise the same package without editable state.
-    subprocess.run([sys.executable, "-m", "clawock.publish.dashboard"],
-                   cwd=ROOT, check=True, capture_output=True,
-                   env={**os.environ, "CLAWOCK_PROFILE": "kcnyu",
-                        "PYTHONPATH": str(ROOT / "src")})
+    # Session-scoped means once per PROCESS, and under xdist every worker is its
+    # own process — so `-n 4` would run four builders against these same four
+    # files at once. They are not written atomically, and a reader in another
+    # worker can see a half-built payload. A file lock makes the build happen
+    # once per run and makes every other worker wait for it, which is both
+    # correct and no slower than the serial case (#816).
+    lock_path = Path(tempfile.gettempdir()) / "clawock-test-dashboard-build.lock"
+    stamp = lock_path.with_suffix(".stamp")
+    build_id = os.environ.get("PYTEST_XDIST_TESTRUNUID", str(os.getpid()))
+
+    with lock_path.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            already = stamp.read_text(encoding="utf-8") if stamp.exists() else ""
+            if already != build_id:
+                # Run through the source tree explicitly; CI installs first, but a
+                # focused local invocation should exercise the same package
+                # without editable state.
+                subprocess.run([sys.executable, "-m", "clawock.publish.dashboard"],
+                               cwd=ROOT, check=True, capture_output=True,
+                               env={**os.environ, "CLAWOCK_PROFILE": "kcnyu",
+                                    "PYTHONPATH": str(ROOT / "src")})
+                stamp.write_text(build_id, encoding="utf-8")
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
     return DASHBOARD

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -51,12 +51,19 @@ KNOWN_PACKAGE_CYCLES: set[frozenset[str]] = set()
 # Module-level cycles. `tools` is the registry pattern and is not a defect: the
 # package __init__ owns the base classes, submodules import them, and
 # build_registry() imports the submodules lazily. The other two are real.
-KNOWN_MODULE_CYCLES = {
-    frozenset({"clawock.tools", "clawock.tools.context_tools"}),
-    frozenset({"clawock.decision.ledger", "clawock.decision.record"}),
-
-}
-
+KNOWN_MODULE_CYCLES: set[frozenset[str]] = set()
+# Empty as of #814. Both entries that were here are gone:
+#
+#   tools <-> tools.context_tools          — the registry pattern. Common enough
+#       to read as idiomatic, and `build_registry` deferred its import so it
+#       worked, but a cycle all the same. `tools.base` now holds the three
+#       definitions every tool module needs, so both sides sit above it.
+#   decision.ledger <-> decision.record    — `record` appends through `ledger`,
+#       and `ledger` reached back to validate one row type behind a
+#       function-level import. The schema moved to `decision.mind_record`.
+#
+# A function-level import is not a fix for a cycle; it is a cycle that starts
+# working. Both of these were that.
 
 def _modules() -> dict[str, Path]:
     out = {}
@@ -253,8 +260,9 @@ def test_the_allowlists_only_ever_shrink():
     assert not KNOWN_PACKAGE_CYCLES, (
         "the package graph is a DAG as of #814; an entry here means a cycle came back"
     )
-    assert len(KNOWN_MODULE_CYCLES) <= 2, (
-        "a module cycle was added to the allowlist; #814 is about removing these"
+    assert not KNOWN_MODULE_CYCLES, (
+        "the import graph has no cycles at all as of #814 — module or package. "
+        "An entry here means one came back."
     )
 
 
@@ -270,12 +278,19 @@ def test_no_new_test_writes_to_published_state(request):
     This runs last by name and reads the attribution log the conftest fixture
     builds.
 
-    On parallelism, measured rather than assumed: with the four other writers
-    isolated, `-n 4` does pass — but not safely. Every xdist worker gets its own
-    session, so four workers each run the dashboard rebuild against the same
-    four files concurrently, and that it passed is luck rather than a property.
-    Turning `-n auto` on needs that rebuild to be per-session-shared or
-    group-pinned first; it is not just a flag.
+    On parallelism, measured rather than assumed — and the measurement killed
+    the idea. #816 claimed emptying this list would unlock `-n auto` and take
+    the pytest step from 89s to ~30s. With the writers isolated and the session
+    rebuild behind a file lock, `-n 4` does pass, three runs at 175/182/191s
+    against ~195s serial: **5-10%, not 3x**. The top twelve tests account for
+    ~121s of a 208s run and every one of them is subprocess-bound — an
+    installer, a wheel install, safe_push, watchdogs with real waits — so the
+    suite is not wide, it is deep in a few places. A fourth parallel run also
+    produced one failure that would not reproduce.
+
+    So xdist stays off: a few percent is not worth a flake class. The isolation
+    was still worth doing on its own — it fixed a real order-dependent failure.
+    The way to make this suite faster is those twelve tests, not more workers.
     """
     from conftest import _WRITE_LOG, _tolerated  # noqa: PLC0415
 


### PR DESCRIPTION
Closes #816

kcn:「有最终不满足的解耦就接着修复而不是放着，直到完成」

## 两个模块环也清掉了 —— 现在**任何层级都没有环**

`KNOWN_MODULE_CYCLES` 和 `KNOWN_PACKAGE_CYCLES` **都是空的**，断言都是「一个都不能有」。

```
=== 强连通分量（真循环，>1 个模块）===
  无
=== 自环 / 直接互相 import 的成对 ===
  无
```

**① `tools ↔ tools.context_tools`** —— 我上一轮把它判成「惯用法，不是缺陷」就放过了。它确实常见（每个 tool 模块从包里 import `BaseTool`，包又 import 回那些 tool 模块建注册表，而 `build_registry` 用函数内 import 所以能跑），**但「常见」不等于「无环」**。`tools.base` 现在持有那三个零依赖的定义，两边都在它之上。

**② `decision.ledger ↔ decision.record`** —— 同一个把戏往下一层：`record` 通过 `ledger` 追加，而 `ledger` 从**函数体内部**伸回 `record` 去校验一种行类型。那个 schema 和它的四个词表对两个模块都没有依赖，移到 `decision.mind_record`，延迟 import 变回普通 import。

> **函数内 import 不是「解决了环」，是「环开始工作了」。这两个都是。**

负向验证过：往 `mind_record` 加一条回边 → `new import cycle(s) between modules: ledger <-> mind_record <-> record`。

## 并行：**我在 #816 里的说法是错的，就地更正**

原 issue 说清空写入名单就能开 `-n auto`、把 pytest 那 89 秒砍到 ~30 秒。

session 重建现在加了**文件锁**（四个 worker 不会同时构建同样那四个文件），`-n 4` 也确实能过 —— **但只快 5~10%**：

| | 耗时 |
|---|---|
| 串行 | ~195s |
| `-n 4` 三次 | 175s / 182s / 191s |

原因：**最慢的 12 个测试占了 208 秒里的 ~121 秒，而且全是 subprocess 型的**（installer、wheel 安装、safe_push、带真实等待的 watchdog）。这个套件不是「宽」，是**在少数几处很深**。而且四次并行里有一次失败且**无法复现**。

⇒ **xdist 保持关闭。几个百分点买不来一类 flake。** 真要提速，该动的是那 12 个测试，不是加 worker。

隔离本身仍然值得做 —— 它修掉了一个真实的顺序依赖假红；那把锁无论有没有人开 worker 都是对的。

## 验证

```
$ pytest tests/ -q                    # 串行
2452 passed, 5 skipped, 4 xfailed

$ pytest tests/ -q -n 4               # 并行三次
2451 passed  ×3
```
