### PR TITLE
fix: .devcontainer 补 root-allowlist 登记 (#800 遗漏, 卡住宿主推送)

### DIFF
--- a/config/root-allowlist.json
+++ b/config/root-allowlist.json
@@ -5,6 +5,10 @@
    "owner": "repository safety",
    "consumer": "git core.hooksPath"
   },
+  ".devcontainer": {
+   "owner": "development container",
+   "consumer": "VS Code / devcontainer CLI"
+  },
   ".github": {
    "owner": "repository automation",
    "consumer": "GitHub Actions"


### PR DESCRIPTION
## 背景

PR #800 新增顶层目录 `.devcontainer/`，但未在 `config/root-allowlist.json` 登记 owner/consumer。`ops/system_check.py` 的 root ownership 检查因此报 CRITICAL（`unexplained: .devcontainer`），宿主 pre-push 钩子在 CRITICAL 时 fail-closed，**卡住了所有 master 推送**——包括 bot 的运行时数据推送（本地已堆积 3 个未推送数据提交）。

## 修复

在 `config/root-allowlist.json` 补 `.devcontainer` 登记（按 #800 的实际用途：开发容器，VS Code / devcontainer CLI 消费），保持按字母序插入。

## 验证

- `python3 ops/system_check.py` 在本机复跑：root ownership 检查由 CRITICAL 转 OK（其余 18 OK / 2 WARN 不变）。
- 本机 pre-push 钩子将恢复放行 master 数据推送。
