### PR TITLE
feat(plugin): 缓存实例化 + 数字防御 + README 标准与边界

### DIFF
--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -102,6 +102,18 @@ python -m pip install clawock
 
 模型永远不能给自己打分——价格、风控、账本、战绩全部由 Python 独立结算。
 
+## 这个插件不做什么(边界)
+
+- **不改任何文件**。面板是只读 Remote;结算、账本写入、发布仍只走
+  clawock 自己的机制(`clawock run` / brief 管线)。
+- **不替代 clawock**。skill 只是把「什么时候跑、产出什么」讲给 agent
+  听;agent 调用的仍是同一套 CLI 与文件契约。
+- **不发明判定**。T+1 数字来自 `memory/bars/` 的官方逐日收盘,不是面板
+  自己算的;没有 bar 就显式显示「T+1 未判」,绝不编一个结论。
+- **不把计划当成交**。`execution.status` 只渲染为「账本自评」小标签,
+  成交与计划同向/反向另有独立的 `alignment` 判定(二者曾在 #739 漂移,
+  现由 `tests/test_decision_trace_parity.py` 钉住)。
+
 ## 快速上手对话
 
 ```
@@ -181,6 +193,30 @@ pass 全部就地跑真实源码树,不再复刻临时 workspace(#731)。生成�
 验证状态:node 半区(扫描、run id 防路径穿越、Remote 标记)与 client 半区
 (注册、模型投影)有单元测试;**tab 的浏览器目验需要在带 DSH 源码/工具链的
 机器上 boot 后确认**(本仓库 CI 无法渲染 GUI)。
+
+## 标准与机器门
+
+接线标准(与 DSH rc.6 官方写法逐项对齐,历史偏离记录见 #729-732):
+
+| 项 | 标准 | 本插件 |
+| --- | --- | --- |
+| 包位置 | 生成器只认 `<root>/packages/` 下的 project reference | `examples/dsh/packages/clawock-dsh`,workspace 根 `examples/dsh` |
+| Host Remote | `TypertRemoteService` + `@Remote`,构建期由 `@deepseek-ai/dsh-typert-generator` 生成反射与 client contribution | ✅ |
+| Client 纪律 | `register` 只在 `apply`;store 必须是 `createXxxStore()` 工厂;模块级零副作用;组件只吃 props | ✅ |
+| 样式 | 构建期 CSS Modules,`<style data-plugin>` 由模块 loader 认领/卸载;手捏 `<style>` 即绕过归属 | ✅ |
+| 产物 | `lib/` 提交入库且**可复现**;类名哈希取包相对路径、region 注释去绝对路径 | ✅ |
+| 依赖 | 安装态必须自足——`dsh_plugin_package_contract.mjs` 在空目录装 tarball 验证(曾因此 83 次崩溃循环,#709) | ✅ |
+
+机器门(每个插件 PR 由 `harness-regression.yml` 把关,无需人记):
+
+1. `npm run build` 重跑三个 pass(`lib/` 与 `src/` 零 diff,否则 CI 红);
+2. `tests/decision_studio_plugin.spec.js` —— node 半区扫描/路径安全 + client
+   bundle 注册/投影;
+3. `tests/dsh_plugin_package_contract.mjs` —— 打包安装后每个 export 可加载;
+4. `tests/test_decision_trace_parity.py` —— 插件 TS 与 dashboard Python 的
+   判词表共用同一份常量(#739/#740 漂移的钉)。
+
+所以「这个插件标准不标准」不是记性问题:上面任何一条被破坏,CI 直接红。
 
 ## 为什么是 skill + 面板而不是工具
 

--- a/examples/dsh/packages/clawock-dsh/lib/index.js
+++ b/examples/dsh/packages/clawock-dsh/lib/index.js
@@ -54,8 +54,6 @@ var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializ
 	done = true;
 };
 const workspaceOf = () => process.env.CLAWOCK_WORKSPACE || process.cwd();
-/** Signature-keyed trace cache per workspace (see freshness.ts). */
-const tracesCache = createTraceCache();
 let ClawockStudioGateway = (() => {
 	let _classSuper = TypertRemoteService;
 	let _instanceExtraInitializers = [];
@@ -148,9 +146,16 @@ let ClawockStudioGateway = (() => {
 			});
 		}
 		static inject = [];
+		/**
+		* Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
+		* service instance rather than module scope: a module-level cache would
+		* outlive plugin stop/update (the module stays in the process cache), so a
+		* stopped plugin could keep serving a stale enriched view through a new
+		* instance. Instance lifetime follows the fiber; a hit still costs µs.
+		*/
+		tracesCache = (__runInitializers(this, _instanceExtraInitializers), createTraceCache());
 		constructor(ctx) {
 			super(ctx, "clawockStudio");
-			__runInitializers(this, _instanceExtraInitializers);
 		}
 		/** @returns Prepared runs (newest first), with decision/receipt presence flags. */
 		list() {
@@ -187,14 +192,14 @@ let ClawockStudioGateway = (() => {
 		traces() {
 			const ws = workspaceOf();
 			const signature = workspaceSignature(ws);
-			const hit = tracesCache.get(ws, signature);
+			const hit = this.tracesCache.get(ws, signature);
 			if (hit !== void 0) return hit;
 			const value = {
 				workspaceKey: workspaceKeyOf(ws),
 				signature,
 				...readTraces(ws)
 			};
-			tracesCache.set(ws, signature, value);
+			this.tracesCache.set(ws, signature, value);
 			return value;
 		}
 	};

--- a/examples/dsh/packages/clawock-dsh/lib/ledger.js
+++ b/examples/dsh/packages/clawock-dsh/lib/ledger.js
@@ -19,6 +19,20 @@ function readJson(path) {
 	}
 }
 /**
+* A finite number, or null. `Number('')` is 0 and `Number('abc')` is NaN —
+* both would otherwise render a bogus "+0%" or a red "—" on a fill the desk
+* never priced. Only machine-written numbers (or their numeric-string twins)
+* are accepted; everything else reads as absent.
+*/
+function num(value) {
+	if (typeof value === "number") return isFinite(value) ? value : null;
+	if (typeof value === "string" && value.trim() !== "") {
+		const n = Number(value);
+		return isFinite(n) ? n : null;
+	}
+	return null;
+}
+/**
 * Parse the decision ledger (memory/decisions.jsonl) — one JSON object per
 * line. Malformed lines are skipped, never fatal: the desk's own writer
 * round-trips the file and this view must survive any of its states.
@@ -67,10 +81,10 @@ function readPortfolio(workspace) {
 		const holdings = rawHoldings.filter((h) => Number(h["shares"] ?? h["quantity"] ?? 0) > 0).map((h) => ({
 			ticker: String(h["ticker"] ?? h["stock_name"] ?? h["name"] ?? "?"),
 			shares: Number(h["shares"] ?? h["quantity"] ?? 0),
-			cost: h["cost_basis"] == null ? null : Number(h["cost_basis"]),
-			price: h["current_price"] == null ? null : Number(h["current_price"]),
-			pnlPct: h["pnl_percent"] == null ? null : Number(h["pnl_percent"]),
-			pnlAbs: h["pnl_abs"] == null ? null : Number(h["pnl_abs"])
+			cost: num(h["cost_basis"]),
+			price: num(h["current_price"]),
+			pnlPct: num(h["pnl_percent"]),
+			pnlAbs: num(h["pnl_abs"])
 		}));
 		if (holdings.length === 0) continue;
 		const market = /^hk/i.test(name) ? "HK" : "US";
@@ -78,7 +92,7 @@ function readPortfolio(workspace) {
 		books.push({
 			name,
 			currency,
-			truePrincipal: bookObj["true_principal"] == null ? null : Number(bookObj["true_principal"]),
+			truePrincipal: num(bookObj["true_principal"]),
 			holdings
 		});
 		for (const holding of rawHoldings) {
@@ -94,8 +108,8 @@ function readPortfolio(workspace) {
 					date: typeof trObj["date"] === "string" ? trObj["date"] : null,
 					action: typeof trObj["action"] === "string" ? trObj["action"] : "buy",
 					shares: Number(trObj["shares"] ?? 0),
-					price: trObj["price"] == null ? null : Number(trObj["price"]),
-					realizedPnl: trObj["realized_pnl"] == null ? null : Number(trObj["realized_pnl"]),
+					price: num(trObj["price"]),
+					realizedPnl: num(trObj["realized_pnl"]),
 					note: typeof trObj["note"] === "string" ? trObj["note"] : null
 				});
 			}
@@ -348,7 +362,7 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 		out.decision = {
 			planDate: typeof b["plan_date"] === "string" ? b["plan_date"] : typeof b["decided_at"] === "string" ? b["decided_at"].slice(0, 10) : null,
 			action: typeof b["action"] === "string" ? b["action"] : null,
-			confidence: b["confidence"] == null ? null : Number(b["confidence"]),
+			confidence: num(b["confidence"]),
 			drivenBy: typeof b["driven_by"] === "string" ? b["driven_by"] : null,
 			rationale: readableRationale(typeof b["rationale"] === "string" ? b["rationale"] : null),
 			bull: typeof bull["summary"] === "string" ? bull["summary"] : null,
@@ -357,9 +371,9 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 			emotionNote: typeof emotion["note"] === "string" ? emotion["note"] : null,
 			execution: typeof execution["status"] === "string" ? execution["status"] : null,
 			condition: typeof condition["description"] === "string" ? condition["description"] : null,
-			sizeShares: size["shares"] == null ? null : Number(size["shares"]),
-			sizePct: size["pct"] == null ? null : Number(size["pct"]),
-			plannedPrice: evaluation["execution_price"] != null ? Number(evaluation["execution_price"]) : b["simulated_entry_price"] != null ? Number(b["simulated_entry_price"]) : null,
+			sizeShares: num(size["shares"]),
+			sizePct: num(size["pct"]),
+			plannedPrice: num(evaluation["execution_price"]) ?? num(b["simulated_entry_price"]),
 			source: typeof b["source"] === "string" ? b["source"] : "brief",
 			alignment: planFillAlignment(typeof b["action"] === "string" ? b["action"] : null, trade.action)
 		};

--- a/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
@@ -13,6 +13,14 @@ import type { Context } from '@deepseek-ai/cordis';
 import type { LedgerResult, ListRunsResult, PlansResult, PortfolioResult, RunDetailResult, TracesResult } from './types.ts';
 export declare class ClawockStudioGateway extends TypertRemoteService {
     static inject: readonly [];
+    /**
+     * Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
+     * service instance rather than module scope: a module-level cache would
+     * outlive plugin stop/update (the module stays in the process cache), so a
+     * stopped plugin could keep serving a stale enriched view through a new
+     * instance. Instance lifetime follows the fiber; a hit still costs µs.
+     */
+    private readonly tracesCache;
     constructor(ctx: Context);
     /** @returns Prepared runs (newest first), with decision/receipt presence flags. */
     list(): ListRunsResult;

--- a/examples/dsh/packages/clawock-dsh/src/index.ts
+++ b/examples/dsh/packages/clawock-dsh/src/index.ts
@@ -20,11 +20,17 @@ import { createTraceCache, workspaceKeyOf, workspaceSignature } from './freshnes
 
 const workspaceOf = (): string => process.env.CLAWOCK_WORKSPACE || process.cwd()
 
-/** Signature-keyed trace cache per workspace (see freshness.ts). */
-const tracesCache = createTraceCache()
-
 export class ClawockStudioGateway extends TypertRemoteService {
   static inject = [] as const
+
+  /**
+   * Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
+   * service instance rather than module scope: a module-level cache would
+   * outlive plugin stop/update (the module stays in the process cache), so a
+   * stopped plugin could keep serving a stale enriched view through a new
+   * instance. Instance lifetime follows the fiber; a hit still costs µs.
+   */
+  private readonly tracesCache = createTraceCache()
 
   constructor(ctx: Context) {
     super(ctx, 'clawockStudio')
@@ -76,14 +82,14 @@ export class ClawockStudioGateway extends TypertRemoteService {
   traces(): TracesResult {
     const ws = workspaceOf()
     const signature = workspaceSignature(ws)
-    const hit = tracesCache.get(ws, signature)
+    const hit = this.tracesCache.get(ws, signature)
     if (hit !== undefined) return hit as TracesResult
     const value: TracesResult = {
       workspaceKey: workspaceKeyOf(ws),
       signature,
       ...readTraces(ws),
     }
-    tracesCache.set(ws, signature, value)
+    this.tracesCache.set(ws, signature, value)
     return value
   }
 }

--- a/examples/dsh/packages/clawock-dsh/src/ledger.ts
+++ b/examples/dsh/packages/clawock-dsh/src/ledger.ts
@@ -26,6 +26,21 @@ function readJson(path: string): JsonValue | null {
 }
 
 /**
+ * A finite number, or null. `Number('')` is 0 and `Number('abc')` is NaN —
+ * both would otherwise render a bogus "+0%" or a red "—" on a fill the desk
+ * never priced. Only machine-written numbers (or their numeric-string twins)
+ * are accepted; everything else reads as absent.
+ */
+function num(value: unknown): number | null {
+  if (typeof value === 'number') return isFinite(value) ? value : null
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    return isFinite(n) ? n : null
+  }
+  return null
+}
+
+/**
  * Parse the decision ledger (memory/decisions.jsonl) — one JSON object per
  * line. Malformed lines are skipped, never fatal: the desk's own writer
  * round-trips the file and this view must survive any of its states.
@@ -74,10 +89,10 @@ export function readPortfolio(workspace: string): PortfolioRead {
         .map((h) => ({
           ticker: String(h['ticker'] ?? h['stock_name'] ?? h['name'] ?? '?'),
           shares: Number(h['shares'] ?? h['quantity'] ?? 0),
-          cost: h['cost_basis'] == null ? null : Number(h['cost_basis']),
-          price: h['current_price'] == null ? null : Number(h['current_price']),
-          pnlPct: h['pnl_percent'] == null ? null : Number(h['pnl_percent']),
-          pnlAbs: h['pnl_abs'] == null ? null : Number(h['pnl_abs']),
+          cost: num(h['cost_basis']),
+          price: num(h['current_price']),
+          pnlPct: num(h['pnl_percent']),
+          pnlAbs: num(h['pnl_abs']),
         }))
       if (holdings.length === 0) continue // a book with no positions is not shown
       const market = /^hk/i.test(name) ? 'HK' : 'US'
@@ -87,7 +102,7 @@ export function readPortfolio(workspace: string): PortfolioRead {
       books.push({
         name,
         currency,
-        truePrincipal: bookObj['true_principal'] == null ? null : Number(bookObj['true_principal']),
+        truePrincipal: num(bookObj['true_principal']),
         holdings,
       })
       // Actual operations: every recorded trade across all holdings, newest
@@ -106,8 +121,8 @@ export function readPortfolio(workspace: string): PortfolioRead {
             date: typeof trObj['date'] === 'string' ? trObj['date'] : null,
             action: typeof trObj['action'] === 'string' ? trObj['action'] : 'buy',
             shares: Number(trObj['shares'] ?? 0),
-            price: trObj['price'] == null ? null : Number(trObj['price']),
-            realizedPnl: trObj['realized_pnl'] == null ? null : Number(trObj['realized_pnl']),
+            price: num(trObj['price']),
+            realizedPnl: num(trObj['realized_pnl']),
             note: typeof trObj['note'] === 'string' ? trObj['note'] : null,
           })
         }
@@ -411,7 +426,7 @@ function enrichTrade(
     const decision: TraceDecision = {
       planDate: planDate as string | null,
       action: typeof b['action'] === 'string' ? b['action'] : null,
-      confidence: b['confidence'] == null ? null : Number(b['confidence']),
+      confidence: num(b['confidence']),
       drivenBy: typeof b['driven_by'] === 'string' ? b['driven_by'] : null,
       rationale: readableRationale(typeof b['rationale'] === 'string' ? b['rationale'] : null),
       bull: typeof bull['summary'] === 'string' ? bull['summary'] : null,
@@ -420,10 +435,9 @@ function enrichTrade(
       emotionNote: typeof emotion['note'] === 'string' ? emotion['note'] : null,
       execution: typeof execution['status'] === 'string' ? execution['status'] : null,
       condition: typeof condition['description'] === 'string' ? condition['description'] : null,
-      sizeShares: size['shares'] == null ? null : Number(size['shares']),
-      sizePct: size['pct'] == null ? null : Number(size['pct']),
-      plannedPrice: evaluation['execution_price'] != null ? Number(evaluation['execution_price'])
-        : (b['simulated_entry_price'] != null ? Number(b['simulated_entry_price']) : null),
+      sizeShares: num(size['shares']),
+      sizePct: num(size['pct']),
+      plannedPrice: num(evaluation['execution_price']) ?? num(b['simulated_entry_price']),
       source: typeof b['source'] === 'string' ? b['source'] : 'brief',
       alignment: planFillAlignment(
         typeof b['action'] === 'string' ? b['action'] : null, trade.action),


### PR DESCRIPTION
## 背景

对 clawock-dsh 插件做一轮实现审查后的三个收尾优化（审查结论：接线已全部符合 DSH rc.6 官方标准，历史四条非官方残留 #729-732 已清；本次只动三个确定性问题）。

## 改动

1. **缓存生命周期**（`src/index.ts`）：`tracesCache` 从模块级移到 `ClawockStudioGateway` 实例。模块级缓存的生命周期是进程级，插件 stop/update 后仍留在进程缓存里，新的实例会继续读到旧实例的数据（虽然按 signature 校验不会返回错误数据，但违背 fiber 生命周期纪律）。
2. **数字字段有限性防御**（`src/ledger.ts`）：新增 `num()`，替换 portfolio/trades/决策字段上裸 `Number(...)`。`Number('') === 0`、`Number('abc') === NaN` 会渲染成假 "+0%" 或红色 "—"；现在脏数据一律读作缺失。
3. **README「作用与标准」**：新增「这个插件不做什么(边界)」和「标准与机器门」（接线标准表 + 四条机器门清单），让读者一眼知道插件的契约边界和"标准不标准是机检问题"。

## 验证

- `npm run build` 三 pass 通过，`lib/` 与 `src/` 一致（CI 会再跑零 diff 门）
- `node tests/decision_studio_plugin.spec.js` 15/15 通过
- `node tests/dsh_plugin_package_contract.mjs` 6/6 通过
- `tests/test_decision_trace_parity.py` 钉的常量未动（不触碰判词/死区/窗口）
