### PR TITLE
chore(dsh): npm 元数据面向搜索优化

### DIFF
--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawock-dsh",
   "version": "0.1.8",
-  "description": "clawock investment-decision workflow for DeepSeek Harness — evidence, opposing case, deterministic settlement, public scorecard, plus the Decision Mind conversation-view tab",
+  "description": "DSH (DeepSeek Harness) plugin for investment decisions: evidence-gated research, a forced bull/bear debate, Python-settled outcomes the model cannot grade, and the Decision Mind tab that pins every real trade to its plan and T+1 verdict",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -15,12 +15,20 @@
   "author": "Shengyu Li",
   "keywords": [
     "dsh",
+    "deepseek",
     "deepseek-harness",
+    "plugin",
     "clawock",
     "investment",
+    "decision",
+    "settlement",
     "agent",
+    "skill",
     "trading",
-    "skill"
+    "portfolio",
+    "ledger",
+    "pnl",
+    "quantitative-finance"
   ],
   "type": "module",
   "main": "./lib/index.js",


### PR DESCRIPTION
## 背景

DSH 没有独立插件市场,`dsh plugin add <name>` 直达 npm registry——
npm 搜索结果卡片(description + keywords)就是这个插件唯一的"市场页面"
入口。旧元数据:

- description 不含 "plugin",搜 "dsh plugin" 时只靠 name 部分匹配
- keywords 7 个词,漏掉 deepseek/decision/portfolio/pnl 等搜索路径

## 改动

- description 改为以 "DSH (DeepSeek Harness) plugin" 开头,把
  evidence-gated research / bull-bear debate / Python-settled /
  Decision Mind tab / T+1 放进卡片文案
- keywords 7 → 15:补 deepseek、plugin、decision、settlement、
  portfolio、ledger、pnl、quantitative-finance

不改版本号,随下次发版生效。GitHub repo 侧已达标(topics 含
deepseek-harness / dsh-plugin,description 含 DeepSeek Harness)。