### PR TITLE
fix(dsh): FX rate 改读真实通道 memory/fx-rates.jsonl;未知市场不再谎报 US

### DIFF
--- a/examples/dsh/packages/clawock-dsh/lib/freshness.js
+++ b/examples/dsh/packages/clawock-dsh/lib/freshness.js
@@ -39,10 +39,10 @@ function barsSignature(ws) {
 	return `${names.length}:${hash.digest("hex").slice(0, 16)}`;
 }
 /**
-* Freshness signature over the three sources that feed the trace view:
+* Freshness signature over the four sources that feed the trace view:
 * portfolio.json (fills + notes), every canonical bar file's stat (T+1
-* closes), and decisions.jsonl (soft pairing). All stat-level reads, no
-* parsing. The
+* closes), decisions.jsonl (soft pairing), and the FX ledger (USDHKD
+* conversion for the header total). All stat-level reads, no parsing. The
 * enriched trace view is valid to reuse iff this signature is unchanged.
 */
 function workspaceSignature(ws) {
@@ -57,7 +57,8 @@ function workspaceSignature(ws) {
 	return [
 		sig(join(ws, "portfolio.json")),
 		barsSignature(ws),
-		sig(join(ws, "memory", "decisions.jsonl"))
+		sig(join(ws, "memory", "decisions.jsonl")),
+		sig(join(ws, "memory", "fx-rates.jsonl"))
 	].join("|");
 }
 /** Opaque per-workspace key for the client cache; hashing avoids shipping the host path to the browser. */

--- a/examples/dsh/packages/clawock-dsh/lib/ledger.js
+++ b/examples/dsh/packages/clawock-dsh/lib/ledger.js
@@ -57,6 +57,39 @@ function readLedger(workspace) {
 	};
 }
 /**
+* Latest USDHKD rate from the append-only FX ledger
+* (`memory/fx-rates.jsonl`, one line per day, written by
+* `clawock.portfolio.fx`). The last valid line wins.
+*
+* This is the *actual* FX channel. The previous reader looked at
+* `portfolio.json`'s `market_context.usdhk_rate` — a field no Python writer
+* has ever produced — so `rate` was permanently null and the header's
+* "已实现 (USD 等值)" silently dropped every HKD figure (#838).
+*/
+function readFxRate(workspace) {
+	const path = join(workspace, "memory", "fx-rates.jsonl");
+	if (!existsSync(path)) return null;
+	let last = null;
+	try {
+		const lines = readFileSync(path, "utf8").split("\n");
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			try {
+				last = JSON.parse(line);
+			} catch {}
+		}
+	} catch {
+		return null;
+	}
+	if (last === null || typeof last !== "object" || Array.isArray(last)) return null;
+	const rate = num(last["rate"]);
+	if (rate === null || rate <= 0) return null;
+	return {
+		rate,
+		source: typeof last["source"] === "string" ? last["source"] : null
+	};
+}
+/**
 * Summarize the portfolio (portfolio.json): per-book holdings with the desk's
 * own money fields, plus the flattened trade log (newest first).
 * @param workspace - desk workspace root.
@@ -67,8 +100,7 @@ function readPortfolio(workspace) {
 	if (doc === null || typeof doc !== "object" || Array.isArray(doc)) return {
 		books: [],
 		trades: [],
-		lastUpdated: null,
-		marketContext: {}
+		lastUpdated: null
 	};
 	const books = [];
 	const trades = [];
@@ -87,7 +119,7 @@ function readPortfolio(workspace) {
 			pnlAbs: num(h["pnl_abs"])
 		}));
 		if (holdings.length === 0) continue;
-		const market = /^hk/i.test(name) ? "HK" : "US";
+		const market = /^hk/i.test(name) ? "HK" : /us/i.test(name) ? "US" : name;
 		const currency = typeof bookObj["currency"] === "string" ? bookObj["currency"] : market === "HK" ? "HKD" : "USD";
 		books.push({
 			name,
@@ -119,8 +151,7 @@ function readPortfolio(workspace) {
 	return {
 		books,
 		trades,
-		lastUpdated: typeof doc["last_updated"] === "string" ? doc["last_updated"] : null,
-		marketContext: doc["market_context"] ?? {}
+		lastUpdated: typeof doc["last_updated"] === "string" ? doc["last_updated"] : null
 	};
 }
 /**
@@ -393,7 +424,7 @@ function enrichTrade(trade, byTicker, decByTicker, books) {
 *          published one in portfolio.json market_context (else null).
 */
 function readTraces(workspace) {
-	const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace);
+	const { books, trades, lastUpdated } = readPortfolio(workspace);
 	const byTicker = readBarCloses(workspace, trades.map((t) => t.ticker));
 	const decByKey = {};
 	const { entries } = readLedger(workspace);
@@ -418,12 +449,14 @@ function readTraces(workspace) {
 			entry
 		});
 	}
+	const enriched = trades.map((t) => enrichTrade(t, byTicker, decByTicker, books));
+	const fx = readFxRate(workspace);
 	return {
-		trades: trades.map((t) => enrichTrade(t, byTicker, decByTicker, books)),
-		rate: typeof marketContext["usdhk_rate"] === "number" ? marketContext["usdhk_rate"] : null,
-		rateSource: typeof marketContext["usdhk_source"] === "string" ? marketContext["usdhk_source"] : null,
+		trades: enriched,
+		rate: fx === null ? null : fx.rate,
+		rateSource: fx === null ? null : fx.source,
 		lastUpdated
 	};
 }
 //#endregion
-export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, planFillAlignment, readBarCloses, readLedger, readPlans, readPortfolio, readTraces, readableRationale, t1ToneOf, t1VerdictOf };
+export { T1_FLAT_BAND_PCT, T1_MAX_GAP_DAYS, dayGap, isSellAction, planFillAlignment, readBarCloses, readFxRate, readLedger, readPlans, readPortfolio, readTraces, readableRationale, t1ToneOf, t1VerdictOf };

--- a/examples/dsh/packages/clawock-dsh/lib/types/freshness.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/freshness.d.ts
@@ -4,10 +4,10 @@
  * typert-protocol dependency, and reused by the benchmark scripts.
  */
 /**
- * Freshness signature over the three sources that feed the trace view:
+ * Freshness signature over the four sources that feed the trace view:
  * portfolio.json (fills + notes), every canonical bar file's stat (T+1
- * closes), and decisions.jsonl (soft pairing). All stat-level reads, no
- * parsing. The
+ * closes), decisions.jsonl (soft pairing), and the FX ledger (USDHKD
+ * conversion for the header total). All stat-level reads, no parsing. The
  * enriched trace view is valid to reuse iff this signature is unchanged.
  */
 export declare function workspaceSignature(ws: string): string;

--- a/examples/dsh/packages/clawock-dsh/lib/types/ledger.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/ledger.d.ts
@@ -6,7 +6,7 @@
  * These are the files the OpenClaw runtime produces every day, so whatever
  * OpenClaw writes, this DSH plugin can show.
  */
-import type { LedgerResult, PlansResult, PortfolioRead, TracesResult } from './types.ts';
+import type { LedgerResult, PlansResult, PortfolioResult, TracesResult } from './types.ts';
 /**
  * Parse the decision ledger (memory/decisions.jsonl) — one JSON object per
  * line. Malformed lines are skipped, never fatal: the desk's own writer
@@ -16,12 +16,26 @@ import type { LedgerResult, PlansResult, PortfolioRead, TracesResult } from './t
  */
 export declare function readLedger(workspace: string): LedgerResult;
 /**
+ * Latest USDHKD rate from the append-only FX ledger
+ * (`memory/fx-rates.jsonl`, one line per day, written by
+ * `clawock.portfolio.fx`). The last valid line wins.
+ *
+ * This is the *actual* FX channel. The previous reader looked at
+ * `portfolio.json`'s `market_context.usdhk_rate` — a field no Python writer
+ * has ever produced — so `rate` was permanently null and the header's
+ * "已实现 (USD 等值)" silently dropped every HKD figure (#838).
+ */
+export declare function readFxRate(workspace: string): {
+    rate: number;
+    source: string | null;
+} | null;
+/**
  * Summarize the portfolio (portfolio.json): per-book holdings with the desk's
  * own money fields, plus the flattened trade log (newest first).
  * @param workspace - desk workspace root.
  * @returns `{ books, trades, lastUpdated }`.
  */
-export declare function readPortfolio(workspace: string): PortfolioRead;
+export declare function readPortfolio(workspace: string): PortfolioResult;
 /**
  * List recent daily plans (memory/YYYY-MM-DD-plan.json), newest first.
  * @param workspace - desk workspace root.

--- a/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
@@ -65,18 +65,6 @@ export interface PortfolioResult {
     trades: Trade[];
     lastUpdated: string | null;
 }
-/**
- * What `readPortfolio` actually returns: the Remote-visible `PortfolioResult`
- * plus the raw `market_context` block, so `readTraces` can reach the FX rate
- * without reading and parsing portfolio.json a second time. `marketContext`
- * stays off the Remote face — the `portfolio()` method declares
- * `PortfolioResult`, so the generated codec never puts it on the wire.
- */
-export interface PortfolioRead extends PortfolioResult {
-    marketContext: {
-        [key: string]: JsonValue;
-    };
-}
 /** One decision-ledger row indexed for soft pairing, with its plan date. */
 export interface DecisionRow {
     date: string;

--- a/examples/dsh/packages/clawock-dsh/src/freshness.ts
+++ b/examples/dsh/packages/clawock-dsh/src/freshness.ts
@@ -43,10 +43,10 @@ function barsSignature(ws: string): string {
 }
 
 /**
- * Freshness signature over the three sources that feed the trace view:
+ * Freshness signature over the four sources that feed the trace view:
  * portfolio.json (fills + notes), every canonical bar file's stat (T+1
- * closes), and decisions.jsonl (soft pairing). All stat-level reads, no
- * parsing. The
+ * closes), decisions.jsonl (soft pairing), and the FX ledger (USDHKD
+ * conversion for the header total). All stat-level reads, no parsing. The
  * enriched trace view is valid to reuse iff this signature is unchanged.
  */
 export function workspaceSignature(ws: string): string {
@@ -62,6 +62,7 @@ export function workspaceSignature(ws: string): string {
     sig(join(ws, 'portfolio.json')),
     barsSignature(ws),
     sig(join(ws, 'memory', 'decisions.jsonl')),
+    sig(join(ws, 'memory', 'fx-rates.jsonl')),
   ].join('|')
 }
 

--- a/examples/dsh/packages/clawock-dsh/src/ledger.ts
+++ b/examples/dsh/packages/clawock-dsh/src/ledger.ts
@@ -11,7 +11,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type {
   Book, DecisionRow, EnrichedTrade, Holding, JsonValue, LedgerResult, PlanRow, PlansResult,
-  PortfolioRead, TraceDecision, TraceT1, TracesResult, Trade,
+  PortfolioResult, TraceDecision, TraceT1, TracesResult, Trade,
 } from './types.ts'
 
 const PLAN_PATTERN = /^(\d{4}-\d{2}-\d{2})-plan\.json$/
@@ -65,15 +65,51 @@ export function readLedger(workspace: string): LedgerResult {
 }
 
 /**
+ * Latest USDHKD rate from the append-only FX ledger
+ * (`memory/fx-rates.jsonl`, one line per day, written by
+ * `clawock.portfolio.fx`). The last valid line wins.
+ *
+ * This is the *actual* FX channel. The previous reader looked at
+ * `portfolio.json`'s `market_context.usdhk_rate` — a field no Python writer
+ * has ever produced — so `rate` was permanently null and the header's
+ * "已实现 (USD 等值)" silently dropped every HKD figure (#838).
+ */
+export function readFxRate(workspace: string): { rate: number; source: string | null } | null {
+  const path = join(workspace, 'memory', 'fx-rates.jsonl')
+  if (!existsSync(path)) return null
+  let last: JsonValue = null
+  try {
+    const lines = readFileSync(path, 'utf8').split('\n')
+    for (const line of lines) {
+      if (!line.trim()) continue
+      try {
+        last = JSON.parse(line) as JsonValue
+      } catch {
+        /* skip one malformed line */
+      }
+    }
+  } catch {
+    return null
+  }
+  if (last === null || typeof last !== 'object' || Array.isArray(last)) return null
+  const rate = num((last as { rate?: unknown })['rate'])
+  if (rate === null || rate <= 0) return null
+  const source = typeof (last as { source?: unknown })['source'] === 'string'
+    ? (last as { source?: unknown })['source'] as string
+    : null
+  return { rate, source }
+}
+
+/**
  * Summarize the portfolio (portfolio.json): per-book holdings with the desk's
  * own money fields, plus the flattened trade log (newest first).
  * @param workspace - desk workspace root.
  * @returns `{ books, trades, lastUpdated }`.
  */
-export function readPortfolio(workspace: string): PortfolioRead {
+export function readPortfolio(workspace: string): PortfolioResult {
   const doc = readJson(join(workspace, 'portfolio.json'))
   if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
-    return { books: [], trades: [], lastUpdated: null, marketContext: {} }
+    return { books: [], trades: [], lastUpdated: null }
   }
   const books: Book[] = []
   const trades: Trade[] = []
@@ -95,7 +131,9 @@ export function readPortfolio(workspace: string): PortfolioRead {
           pnlAbs: num(h['pnl_abs']),
         }))
       if (holdings.length === 0) continue // a book with no positions is not shown
-      const market = /^hk/i.test(name) ? 'HK' : 'US'
+      // Known books map by name; an unknown one keeps its own name instead of
+      // being silently filed under US (#839).
+      const market = /^hk/i.test(name) ? 'HK' : (/us/i.test(name) ? 'US' : name)
       const currency = typeof bookObj['currency'] === 'string'
         ? bookObj['currency']
         : (market === 'HK' ? 'HKD' : 'USD')
@@ -136,10 +174,7 @@ export function readPortfolio(workspace: string): PortfolioRead {
   const lastUpdated = typeof (doc as { last_updated?: unknown })['last_updated'] === 'string'
     ? (doc as { last_updated?: unknown })['last_updated'] as string
     : null
-  // Returned so `readTraces` does not have to read and parse portfolio.json a
-  // second time just to reach `market_context`.
-  const marketContext = ((doc as { market_context?: unknown })['market_context'] ?? {}) as { [key: string]: JsonValue }
-  return { books, trades, lastUpdated, marketContext }
+  return { books, trades, lastUpdated }
 }
 
 /**
@@ -465,7 +500,7 @@ function enrichTrade(
  *          published one in portfolio.json market_context (else null).
  */
 export function readTraces(workspace: string): Omit<TracesResult, 'workspaceKey' | 'signature'> {
-  const { books, trades, lastUpdated, marketContext } = readPortfolio(workspace)
+  const { books, trades, lastUpdated } = readPortfolio(workspace)
   const byTicker = readBarCloses(workspace, trades.map((t) => t.ticker))
   const decByKey: Record<string, JsonValue[]> = {}
   const { entries } = readLedger(workspace)
@@ -495,11 +530,11 @@ export function readTraces(workspace: string): Omit<TracesResult, 'workspaceKey'
     ;(decByTicker[ticker] ??= []).push({ date: key.slice(sep + 1), entry })
   }
   const enriched = trades.map((t) => enrichTrade(t, byTicker, decByTicker, books))
-  const rate = typeof marketContext['usdhk_rate'] === 'number' ? marketContext['usdhk_rate'] : null
+  const fx = readFxRate(workspace)
   return {
     trades: enriched,
-    rate,
-    rateSource: typeof marketContext['usdhk_source'] === 'string' ? marketContext['usdhk_source'] : null,
+    rate: fx === null ? null : fx.rate,
+    rateSource: fx === null ? null : fx.source,
     lastUpdated,
   }
 }

--- a/examples/dsh/packages/clawock-dsh/src/types.ts
+++ b/examples/dsh/packages/clawock-dsh/src/types.ts
@@ -73,17 +73,6 @@ export interface PortfolioResult {
   lastUpdated: string | null
 }
 
-/**
- * What `readPortfolio` actually returns: the Remote-visible `PortfolioResult`
- * plus the raw `market_context` block, so `readTraces` can reach the FX rate
- * without reading and parsing portfolio.json a second time. `marketContext`
- * stays off the Remote face — the `portfolio()` method declares
- * `PortfolioResult`, so the generated codec never puts it on the wire.
- */
-export interface PortfolioRead extends PortfolioResult {
-  marketContext: { [key: string]: JsonValue }
-}
-
 /** One decision-ledger row indexed for soft pairing, with its plan date. */
 export interface DecisionRow {
   date: string

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -882,7 +882,7 @@ test("readBarCloses: T+1 marks against the canonical bar store, never snapshots 
   }
 });
 
-test("freshness: signature moves on each of the three data sources", async () => {
+test("freshness: signature moves on each of the four data sources", async () => {
   const freshness = await import(pathToFileURL(path.join(PLUGIN, "lib", "freshness.js")).href);
   const root = makeDesk();
   const barsDir = path.join(root, "memory", "bars");
@@ -890,7 +890,7 @@ test("freshness: signature moves on each of the three data sources", async () =>
   try {
     const before = freshness.workspaceSignature(root);
     assert.ok(before.length > 0);
-    assert.equal(before.split("|").length, 3, "shape: portfolio stat | bars digest | decisions stat");
+    assert.equal(before.split("|").length, 4, "shape: portfolio stat | bars digest | decisions stat | fx stat");
     assert.equal(before.split("|")[1], "none", "no bar files yet → the bars term is 'none'");
 
     // portfolio.json 变化 → 签名变(内容长度不同,size 兜底 mtime 同刻度)
@@ -920,6 +920,38 @@ test("freshness: signature moves on each of the three data sources", async () =>
     const beforeLedger = freshness.workspaceSignature(root);
     fs.writeFileSync(path.join(root, "memory", "decisions.jsonl"), JSON.stringify({ decision_id: "x" }) + "\n");
     assert.notEqual(freshness.workspaceSignature(root), beforeLedger, "decisions.jsonl change must move the signature");
+
+    // fx-rates.jsonl 变化(FX 通道,#838)→ 签名变
+    const beforeFx = freshness.workspaceSignature(root);
+    fs.writeFileSync(path.join(root, "memory", "fx-rates.jsonl"), '{"day":"2026-08-21","rate":7.8438,"source":"Frankfurter"}\n');
+    assert.notEqual(freshness.workspaceSignature(root), beforeFx, "fx-rates.jsonl change must move the signature (#838)");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("readFxRate: last valid line wins; missing/malformed degrade to null (#838)", async () => {
+  const ledger = await import(pathToFileURL(path.join(PLUGIN, "lib", "ledger.js")).href);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawock-fx-"));
+  const memory = path.join(root, "memory");
+  fs.mkdirSync(memory, { recursive: true });
+  try {
+    assert.equal(ledger.readFxRate(root), null, "no file → null");
+    const fxPath = path.join(memory, "fx-rates.jsonl");
+    fs.writeFileSync(fxPath, [
+      '{"day":"2026-08-19","rate":7.8437,"source":"Frankfurter"}',
+      'not json at all',
+      '{"day":"2026-08-20","rate":7.8416,"source":"Frankfurter"}',
+      "",
+    ].join("\n"));
+    const got = ledger.readFxRate(root);
+    assert.equal(got.rate, 7.8416, "the last valid line wins");
+    assert.equal(got.source, "Frankfurter");
+    // A non-positive or non-numeric rate reads as absent, never as a number.
+    fs.writeFileSync(fxPath, '{"day":"2026-08-21","rate":0,"source":"x"}\n');
+    assert.equal(ledger.readFxRate(root), null, "rate 0 → null");
+    fs.writeFileSync(fxPath, '{"day":"2026-08-21","rate":"abc","source":"x"}\n');
+    assert.equal(ledger.readFxRate(root), null, "non-numeric rate → null");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## #838 FX 死通道

`readTraces` 从 `portfolio.json` 的 `market_context.usdhk_rate` 读 rate,
该字段没有任何 Python writer 产生(FX 实际落在 `memory/fx-rates.jsonl`,
dashboard 侧在 `dashboard.json` 的 `fx.usdhkd`)。rate 恒为 null,头部
「已实现 (USD 等值)」静默漏掉全部 HKD 已实现。

live 实测修复前后:
- 前:rate null,USD 等值只算 2347.68
- 后:rate 7.8438 (Frankfurter),USD 等值 3273.14(补上 12 笔 HKD 已实现
  7259.16 ≈ 925.47 USD)

改动:
- 新增 `readFxRate`:读 `memory/fx-rates.jsonl` 最后一条有效行
  (rate>0 才接受;缺失/坏行/非数值降级 null)
- `workspaceSignature` 纳入该文件(freshness 第四个源)
- 删除 `PortfolioRead.marketContext` 死字段(types/ledger 清理)

## #839 未知市场

book 名不匹配 hk/us 时 market 保留原名(不再静默归 US),client 端
未知市场显示原名而非「美」。

## 验证

- spec 16/16(新增 readFxRate 单测 + freshness 四源断言)
- package contract 6/6,parity 10/10
- lib/ 已重建零漂移