### PR TITLE
fix: 时区三处正确性 + requests 地板抬到 2.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ classifiers = [
 # pytest collection and silently stopped enforcing the whole suite while the
 # run still looked green.
 dependencies = [
-    "requests>=2.31",
+    # 2.32 is the floor past CVE-2024-35195 (redirect header leak in 2.31.x).
+    "requests>=2.32",
 ]
 
 [project.optional-dependencies]

--- a/src/clawock/market_data/peer_quotes.py
+++ b/src/clawock/market_data/peer_quotes.py
@@ -38,6 +38,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeout
 from datetime import datetime, timezone
 from typing import Dict
+from zoneinfo import ZoneInfo
 
 import requests
 
@@ -139,7 +140,12 @@ def _apply_quote_age(out: Dict, parts) -> None:
     out['quote_time'] = raw
     for fmt in ('%Y-%m-%d %H:%M:%S', '%Y/%m/%d %H:%M:%S'):
         try:
-            age = (datetime.now() - datetime.strptime(raw, fmt)).days
+            # gtimg stamps are Beijing time; a naive subtraction would use this
+            # machine's local zone, so the stale gate only ever fired on a
+            # UTC+8 host — anywhere else the age came out negative and the
+            # quote was treated as fresh forever (#845).
+            quoted = datetime.strptime(raw, fmt).replace(tzinfo=ZoneInfo('Asia/Shanghai'))
+            age = (datetime.now(timezone.utc) - quoted).days
         except ValueError:
             continue
         if age > STALE_QUOTE_DAYS:

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -170,7 +170,10 @@ def _debug_dump(stage: str, ticker: str, payload) -> None:
     try:
         tmp = os.path.join(WS_ROOT, 'memory', '.tmp')
         os.makedirs(tmp, exist_ok=True)
-        now = datetime.now(timezone(timedelta(hours=-4)))
+        # America/New_York, not a fixed UTC-4: a fixed offset labels standard
+        # time (EST, Nov–Mar) as if it were EDT — timestamps and the day-based
+        # debug filename drift by one hour for half the year (#844).
+        now = datetime.now(ZoneInfo('America/New_York'))
         rec = {'ts': now.isoformat(), 'stage': stage, 'ticker': ticker, 'payload': payload}
         path = os.path.join(tmp, f"us_fetch_debug_{now.strftime('%Y-%m-%d')}.jsonl")
         with open(path, 'a') as f:
@@ -568,7 +571,7 @@ def fetch_us_indices() -> Dict[str, Dict]:
         ('usDJI', '^DJI',  'DIA', 'DJI', 'Dow Jones'),
     ]
     out = {}
-    now_et = datetime.now(timezone(timedelta(hours=-4))).strftime('%Y-%m-%d %H:%M ET')
+    now_et = datetime.now(ZoneInfo('America/New_York')).strftime('%Y-%m-%d %H:%M ET')
     for tx_sym, yh_sym, etf, short, name in symbols:
         # 1. Tencent real index points (preferred)
         q = get_tencent_us_index(tx_sym)
@@ -624,7 +627,7 @@ def get_prev_close_polygon(ticker: str, api_key: str) -> Optional[tuple]:
         if ts_ms:
             date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime('%Y-%m-%d')
         else:
-            date_str = (datetime.now(timezone(timedelta(hours=-4))) - timedelta(days=1)).strftime('%Y-%m-%d')
+            date_str = (datetime.now(ZoneInfo('America/New_York')) - timedelta(days=1)).strftime('%Y-%m-%d')
         return (close, date_str)
     except Exception as e:
         print(f"  ⚠ Polygon prev-close {ticker} failed: {type(e).__name__}: {e}",


### PR DESCRIPTION
全面 review 的严重项修复:

- #844 `us_quotes.py` 三处 `timezone(timedelta(hours=-4))` → `ZoneInfo('America/New_York')`:EST 期间(11-3 月)时间戳/调试文件名/prev-close 兜底日期错 1 小时
- #845 `peer_quotes.py` gtimg 时间绑定 `Asia/Shanghai` 再与 UTC 比较:旧写法非 +8 机器 stale_quote 闸静默失效
- #849 `requests>=2.32`(CVE-2024-35195);macro failover 末段已有 stderr 告警,无需 degraded 字段

验证:`-k "us_quote or peer or macro"` 124 passed。