### PR TITLE
fix: FX/SEC 缓存原子写、发布 subprocess 超时、gold 推送失败不再静默

### DIFF
--- a/src/clawock/market_data/filings.py
+++ b/src/clawock/market_data/filings.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import requests
 
+from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 WS_ROOT = workspace_root(Path.cwd())
@@ -140,8 +141,10 @@ def _load_ticker_map() -> Dict[str, str]:
     raw = r.json()
     mapping = {entry['ticker'].upper(): f"CIK{int(entry['cik_str']):010d}"
                for entry in raw.values()}
-    with TICKER_CACHE.open('w') as f:
-        json.dump(mapping, f)
+    # Atomic write: a torn cache file used to crash the loader on its next
+    # read (only FileNotFoundError was caught), taking the whole SEC leg down
+    # with it (#847).
+    safe_write_json(str(TICKER_CACHE), mapping)
     return mapping
 
 

--- a/src/clawock/market_data/gold/update.py
+++ b/src/clawock/market_data/gold/update.py
@@ -136,9 +136,22 @@ def main():
     if a.publish:
         print('  提交 + 推送上线…')
         os.chdir(WS_ROOT)
-        subprocess.run(['git', 'add', 'portfolio.json'], check=False)
-        subprocess.run(['git', 'commit', '-q', '-m', f'gold: 定投对账 {rdate}（本金{principal:.0f}/份额{units:.0f}）'], check=False)
-        subprocess.run(['bash', os.path.join(WS_ROOT, 'ops/publish/safe_push.sh')], check=False)
+        # Each step's exit status is real: a commit or push that fails must
+        # surface as a failed DCA reconciliation, not a silent no-op (#848).
+        failed = False
+        for cmd in (
+            ['git', 'add', 'portfolio.json'],
+            ['git', 'commit', '-q', '-m', f'gold: 定投对账 {rdate}（本金{principal:.0f}/份额{units:.0f}）'],
+            ['bash', os.path.join(WS_ROOT, 'ops/publish/safe_push.sh')],
+        ):
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print(f'  ✗ 步骤失败 (exit {result.returncode}): {" ".join(cmd)}',
+                      file=sys.stderr)
+                failed = True
+                break
+        if failed:
+            return 2
     else:
         print('  未推送。要上线：git add portfolio.json && '
               'git commit + bash ops/publish/safe_push.sh（或加 --publish）')

--- a/src/clawock/portfolio/fx.py
+++ b/src/clawock/portfolio/fx.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional, Dict
 import requests
 
+from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 WS_ROOT = workspace_root(Path.cwd())
@@ -75,8 +76,10 @@ def _from_cache(allow_stale: bool = False) -> Optional[Dict]:
 
 def _save_cache(data: Dict):
     os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
-    with open(CACHE_PATH, 'w') as f:
-        json.dump(data, f)
+    # Atomic write: a torn cache file used to make `_from_cache` return None,
+    # silently killing the "all live sources failed → use stale cached rate"
+    # fallback exactly when it was needed (#847).
+    safe_write_json(CACHE_PATH, data)
     _record_rate(data)
 
 

--- a/src/clawock/publish/deploy.py
+++ b/src/clawock/publish/deploy.py
@@ -88,5 +88,8 @@ class GitHubDispatchDeployer:
             ["gh", "api", "--method", "POST",
              f"repos/{self.repository}/dispatches", "--input", "-"],
             input=json.dumps(body), check=True, capture_output=True, text=True,
+            # A hung dispatch request must surface as a failed deploy, not an
+            # endless wait (#848).
+            timeout=120,
         )
         return f"{self.event_type} → {self.repository}"

--- a/src/clawock/publish/store.py
+++ b/src/clawock/publish/store.py
@@ -225,6 +225,9 @@ class GitBranchStore:
         result = subprocess.run(
             self._argv(*args),
             input=stdin, capture_output=True, text=True, env=env, check=True,
+            # A hung git remote must fail the publish, not park the process
+            # forever (#848).
+            timeout=120,
         )
         return result.stdout.strip()
 
@@ -240,6 +243,7 @@ class GitBranchStore:
         result = subprocess.run(
             self._argv("cat-file", "blob", f"{ref}:{name}"),
             capture_output=True, check=True,
+            timeout=120,
         )
         return result.stdout.decode("utf-8")
 


### PR DESCRIPTION
- #847 `fx._save_cache` / `filings.py` TICKER_CACHE 改 `safe_write_json`(原子写)
- #848 `store._git` / `_git_blob` / `deploy` 的 `gh api` POST 加 `timeout=120`;
  `gold/update.py` add/commit/safe_push 检查 returncode,失败 exit 2 + stderr

验证:`-k "store or deploy or fx or filings or gold"` 三连 119 passed。