### PR TITLE
fix(ci): repo-traffic 改用 PAT secret 读 Traffic API (#843)

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -48,8 +48,10 @@ jobs:
 
       - name: Capture traffic and package downloads
         env:
-          # The Traffic API requires push access; the workflow token has it.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The Traffic API does not answer to GITHUB_TOKEN — it only takes a
+          # PAT/OAuth token with repo scope (measured 2026-08-23: the workflow
+          # token got 403 on every run since the first schedule, #843).
+          GITHUB_TOKEN: ${{ secrets.REPO_METRICS_TOKEN }}
         run: |
           set -euo pipefail
           python3 ops/growth/repo_traffic.py | tee /tmp/traffic.txt
@@ -67,7 +69,7 @@ jobs:
         # it produces are what a scheduling decision has to be argued from
         # instead of a nice-looking cron minute.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_METRICS_TOKEN }}
         run: |
           set -euo pipefail
           python3 ops/ci/schedule_drift.py | tee /tmp/drift.txt


### PR DESCRIPTION
GITHUB_TOKEN 对 `/traffic/*` 端点恒 403(8-22 首次 schedule 起每次复现,
含手动 dispatch)。GitHub 只认 PAT/OAuth token——本机 gh 的 OAuth
token 读同一端点 200。

- kcn 授权后,该 token 已存入 repo secret `REPO_METRICS_TOKEN`
- capture 与 schedule-drift 两步统一改用该 secret

合并后手动 dispatch 验证一次(PR 分支的 dispatch 会跑分支版本,
先等 CI 过门再合并验证)。