### PR TITLE
fix: cron/automation 兜底换到 OpenCode Zen deepseek-v4-flash

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -17,13 +17,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash",
+        "zen/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash"
+        "zen/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/report.md",
@@ -67,13 +67,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash",
+        "zen/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash"
+        "zen/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
@@ -130,13 +130,13 @@
       "model_candidates": [
         "minimax/MiniMax-M3",
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash",
+        "zen/deepseek-v4-flash",
         "openai/gpt-5.6-sol",
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
         "minimax-2/MiniMax-M3",
-        "opencode-go/deepseek-v4-flash"
+        "zen/deepseek-v4-flash"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/brief.md",

--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -2,18 +2,18 @@
 """
 Minimal LLM client for KCNyu GitHub Actions workflows.
 
-Primary: MiniMax M3 (Anthropic Messages protocol). Fallback: opencode-go's
+Primary: MiniMax M3 (Anthropic Messages protocol). Fallback: OpenCode Zen's
 DeepSeek V4 Flash (OpenAI-compatible protocol — https://opencode.ai/docs/zen).
 The two providers do NOT share a wire protocol, so this module carries two
 request/response shapes: `_call_provider` speaks Anthropic `/v1/messages` for
 MiniMax; `_call_provider_openai_compatible` speaks `/chat/completions` for
-opencode-go. Used by brief-fallback / weekly-review / news-digest /
+OpenCode Zen. Used by brief-fallback / weekly-review / news-digest /
 influencer-scan — none of which can reach the local openclaw gateway, so they
 call the vendor API directly.
 
 Why a fallback (2026-05-30, kcn 要求): one vendor can hit empty-turn,
 sensitive-content or rate-limit failures that blank a scheduled job. MiniMax is
-primary; opencode-go / DeepSeek V4 Flash is the fallback.
+primary; OpenCode Zen / DeepSeek V4 Flash is the fallback.
 
 History:
 - 2026-06-01 (kcn "都改吧变成稳妥的anthropic的"): switched both providers onto
@@ -62,7 +62,7 @@ MINIMAX_BASE = 'https://api.minimaxi.com/anthropic'
 MINIMAX_MODEL = 'MiniMax-M3'
 MINIMAX_MAX_TOKENS = 131072  # M3 maxOutput
 # OpenAI-compatible endpoint (base, no trailing /chat/completions — added per call).
-OPENCODE_BASE = 'https://opencode.ai/zen/go/v1'
+OPENCODE_BASE = 'https://opencode.ai/zen/v1'
 OPENCODE_MODEL = 'deepseek-v4-flash'
 # Vendor cap is 384000 (see /root/.cache/opencode/models.json), but this is a
 # last-resort fallback, not a primary route — keep it in the same conservative
@@ -385,12 +385,12 @@ def chat(system: str = '', user: str = '', messages: list = None,
                                   deadline=primary_deadline)
         except Exception as e:
             errors.append(f'minimax[{e}]')
-            print('  ⚠️ minimax exhausted — falling back to opencode-go DeepSeek V4 Flash',
+            print('  ⚠️ minimax exhausted — falling back to OpenCode Zen DeepSeek V4 Flash',
                   file=sys.stderr)
     else:
         errors.append('minimax[no MINIMAX_API_KEY]')
 
-    # ── Fallback: opencode-go / DeepSeek V4 Flash (OpenAI-compatible) ──
+    # ── Fallback: OpenCode Zen / DeepSeek V4 Flash (OpenAI-compatible) ──
     # 2026-08-16, kcn: Xiaomi's token-plan key had already died (HTTP 401,
     # issue #695) — swapped the fallback to opencode-go's DeepSeek V4 Flash
     # (issue #697). If unset, the fallback is auto-skipped (no OPENCODE_API_KEY).

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -532,33 +532,33 @@ def test_strategy_cron_provider_order_is_fixed_policy():
     } == {
         'report': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
-                'opencode-go/deepseek-v4-flash',
+                'zen/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],
         },
         'intraday': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
-                'opencode-go/deepseek-v4-flash',
+                'zen/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],
         },
         'brief': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'opencode-go/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
-                'opencode-go/deepseek-v4-flash',
+                'zen/deepseek-v4-flash',
                 'openai/gpt-5.6-sol',
                 'anthropic/claude-sonnet-4-6',
             ],


### PR DESCRIPTION
## 背景

opencode-go(OpenCode Go 套餐, endpoint https://opencode.ai/zen/go/v1) 周/月配额双双耗尽:
usage API 实测 weekly=100% rate-limited(08-24 重置)、monthly=100% rate-limited(09-15 重置),
请求返回 CreditsError: Insufficient balance。即 go tier 在 9 月中前不可用。

kcn 指示: 定时任务兜底改用 OpenCode Zen(https://opencode.ai/zen/v1) 的 deepseek-v4-flash
(zen tier 按量付费, 同款模型, 价格 $0.14/$0.28 per MTok)。

## 改动

- config/cron-schedules.json: report/intraday/brief 三档 payload 的 model_candidates 与
  fallbacks 中 opencode-go/deepseek-v4-flash 全部替换为 zen/deepseek-v4-flash(6 处)。
- src/clawock/automation/llm.py: OPENCODE_BASE 从 https://opencode.ai/zen/go/v1 改为
  https://opencode.ai/zen/v1(GH 定时工作流 weekly-review / brief-fallback / news-digest /
  influencer-scan 的 fallback 腿, 模型 id deepseek-v4-flash 不变), 相关当前态注释同步。

host 侧(不入库)已先行: openclaw.json 增加 zen provider(同 opencode-go 那把 key,
baseUrl 换 zen/v1), 网关已热加载确认。本 PR 合并后跑 ops/host/sync_cron_payloads.py --apply
把新 fallback 落到 live cron jobs。

## 验证

- 两文件语法校验通过(json.load / py_compile)。
- zen/v1/models 实测包含 deepseek-v4-flash(200)。
- 注意: 当前 key 在 zen tier 上余额为 0(实测 CreditsError), 已提示 kcn 充值;
  兜底链 minmax-2 -> zen 在余额到账前与现状(go 已死)等价, 不会更差。
