### PR TITLE
feat: 加仓策略改技术突破促成 + 多周期对账 + 叶子模块补测 (#819 #850)

### DIFF
--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -114,7 +114,8 @@ clawock intraday preflight --market hk
     (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
     「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
-    软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
+    软消息/情绪只能停在 `wait`;技术突破态(收盘站上前 20 日高且未过热)本身即促成
+    `candidate`,一手公告只是升级措辞;
     `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
     带 `evidence.proxy_label` 的行,它的位是**代理标的**的位(恒科指数之于 07226、
     SPCX 之于 SPCH),`needs` 已经把指名写进句子了——**照抄那句,别把

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -115,7 +115,8 @@ clawock intraday preflight --market us
     (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
     「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
-    软消息/情绪只能停在 `wait`,只有一手披露才可能促成 `candidate`;
+    软消息/情绪只能停在 `wait`;技术突破态(收盘站上前 20 日高且未过热)本身即促成
+    `candidate`,一手公告只是升级措辞;
     `reject` 说明有纪律动作没走完,这时不要把它写成「可以加仓」。
     带 `evidence.proxy_label` 的行,它的位是**代理标的**的位(恒科指数之于 07226、
     SPCX 之于 SPCH),`needs` 已经把指名写进句子了——**照抄那句,别把

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -18,10 +18,14 @@ every number from its inputs — the rules below are the ones already written do
 * **Discipline first.** A live thesis breach or an unexecuted `risk_rule` action
   makes it `reject`: while a stop or a trim is outstanding, adding is not a
   question the desk asks.
-* **Only a primary disclosure can promote.** `candidate` requires an
-  `interrupt`-class primary filing *and* a technical state that is at or near the
-  breakout. This is the existing catalyst gate: soft news and sentiment are colour,
-  never an active-operation reason.
+* **A confirmed technical breakout can promote on its own; a primary
+  filing upgrades the wording.** `candidate` requires a radar row in the
+  `breakout` state (close > prior 20-day high, not overheated) — the one add
+  shape the 8-month bars backtest (#819) measured with a positive edge at every
+  horizon (T+1/5/10/20 hit 52.5/54.0/52.5/55.9%, avg fwd +16.25% at T+20; HK
+  T+20 59.4%). Near-breakout/at-high without a primary filing stay `wait`
+  (no standalone edge). Soft news and sentiment remain colour, never an
+  active-operation reason.
 * **Everything else is `wait`, with what would change it.** A price anomaly with no
   primary catalyst is the common case (02208 +6.4% on 2026-08-17), and the useful
   output there is the falsifier — the level or the session that would settle it —
@@ -46,6 +50,15 @@ PROXY_KEY = "_proxy_label"
 # all and produces no row.
 IN_PLAY_STATES = ("breakout", "near_breakout", "at_high")
 
+# States that get a row at all (#819). `wait_rebreak` — an uptrend pulling
+# back — is NOT in play: it stays out of the promotion gate below, but it is a
+# real read (unlike a name deep inside its range), and before this split it was
+# dropped wholesale, so the desk never collected a single sample to test
+# whether "buy the dip inside an uptrend" holds. It now produces `wait` rows
+# with their state logged; whether it ever joins IN_PLAY_STATES is a
+# measurement decision, not a naming one.
+ROW_STATES = IN_PLAY_STATES + ("wait_rebreak",)
+
 
 def _radar_index(radar):
     """holdings ticker -> radar row. A row can cover several holdings (an index
@@ -58,7 +71,7 @@ def _radar_index(radar):
     tagged here, and every place that renders a number checks the tag.
     """
     rows = [row for row in (radar or {}).get("rows", []) or []
-            if row.get("state") in IN_PLAY_STATES]
+            if row.get("state") in ROW_STATES]
     index = {}
     # Two passes, and the order matters: a name that has a row of its own must
     # win over any proxy that also covers it, whatever order the radar sorted
@@ -177,12 +190,30 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             else:
                 why = f"thesis 红线在触发状态:{breach}"
             needs = "先把纪律动作走完,再谈加仓"
-        elif primary and radar_row:
+        elif radar_row and radar_row.get("state") in IN_PLAY_STATES and (
+                radar_row.get("state") == "breakout" or primary):
+            # #819: the breakout state alone carries the measured edge
+            # (8-month bars backtest: hit >50% at T+1/5/10/20, avg fwd positive;
+            # deep-dip adds failed all four horizons — the original 逢低 assumption).
+            # A primary filing upgrades the wording, it is not the promotion key.
             verdict = "candidate"
-            why = (f"一手公告 + 技术面{radar_row.get('state_zh') or radar_row.get('state')}"
-                   f":{primary.get('title') or primary.get('headline') or 'primary filing'}")
-            lead = f"{_proxy_of(radar_row)} 站上 " if _proxy_of(radar_row) else "站上 "
-            needs = f"{lead}{radar_row.get('prior_20d_high')} 并守住"
+            if primary:
+                why = (f"一手公告 + 技术面{radar_row.get('state_zh') or radar_row.get('state')}"
+                       f":{primary.get('title') or primary.get('headline') or 'primary filing'}")
+                if radar_row.get("state") == "breakout":
+                    lead = f"{_proxy_of(radar_row)} 守住 " if _proxy_of(radar_row) else "守住 "
+                    needs = f"{lead}{radar_row.get('prior_20d_high')}(回踩不破再谈加仓)"
+                else:
+                    # near_breakout/at_high with a primary filing: the price is
+                    # still below the level, so the ask is to get above it.
+                    lead = f"{_proxy_of(radar_row)} 站上 " if _proxy_of(radar_row) else "站上 "
+                    needs = f"{lead}{radar_row.get('prior_20d_high')} 并守住"
+            else:
+                state_zh = radar_row.get('state_zh') or radar_row.get('state')
+                why = (f"技术面{state_zh}:收盘站上前 20 日高且未过热"
+                       f"(回测:四个周期命中率均>50%)")
+                lead = f"{_proxy_of(radar_row)} 守住 " if _proxy_of(radar_row) else "守住 "
+                needs = f"{lead}{radar_row.get('prior_20d_high')}(回踩不破再谈加仓)"
         else:
             verdict = "wait"
             missing = []
@@ -190,6 +221,10 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
                 missing.append("窗口内无一手公告" if soft is None else "只有软消息/情绪面")
             if not radar_row:
                 missing.append("技术面未接近突破")
+            elif radar_row.get("state") not in IN_PLAY_STATES:
+                # #819: wait_rebreak rows now exist and say what they are —
+                # an uptrend pulling back, logged as state, not a silent drop.
+                missing.append(f"技术面{radar_row.get('state_zh') or radar_row.get('state')}")
             why = "、".join(missing) or "条件不齐"
             level = radar_row or _level(levels, ticker)
             # #759: a level the radar dropped still answers "跌到哪才算机会".
@@ -270,6 +305,7 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
         "candidate_count": sum(r["verdict"] == "candidate" for r in rows),
         "wait_count": sum(r["verdict"] == "wait" for r in rows),
         "reject_count": sum(r["verdict"] == "reject" for r in rows),
-        "policy": ("一手披露才可能促成 candidate;软消息/情绪只能停在 wait;"
+        "policy": ("技术突破(收盘站上前 20 日高且未过热)即 candidate,"
+                   "一手公告升级措辞;软消息/情绪只能停在 wait;"
                    "纪律动作未了结一律 reject。三态都不是下单授权。"),
     }

--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -47,7 +47,11 @@ HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 OUT = WS / 'assets' / 'data' / 't0_setup_review.json'
 
 MIN_N = 20   # 牌面结论可被引用的最小样本量
-HORIZON = 1  # T+1：按「下一个有该标的留痕的交易日」结算
+HORIZON = 1  # T+1:按「下一个有该标的留痕的交易日」结算(顶层兼容字段)
+# #819:同一条留痕在多个周期上各结算一遍。T+1 是顶层(现有读者),
+# multi_horizon 带全部周期——上一次"换个周期会不会成立"的验证是手工
+# 重放的,不该再做第二遍。
+HORIZONS = (1, 5, 10, 20)
 
 # 牌面 → (匹配函数, 预期方向 +1=次日涨算命中 / -1=次日跌算命中)
 GRADE_TESTS = {
@@ -80,21 +84,17 @@ def _load_days():
     return [{'as_of': d, 'rows': by_day[d]} for d in sorted(by_day)]
 
 
-def main(argv=None):
-    del argv
-    days = _load_days()
-    if not days:
-        out = {'as_of': date.today().isoformat(), 'days_logged': 0,
-               'grades': {}, 'summary': '尚无留痕 — 累积中'}
-        safe_write_json(str(OUT), out)
-        print('  no t0 history yet — skip')
-        return 0
+def _settle(days, horizon):
+    """Run the grade-vs-forward-return accounting for one horizon.
 
+    Returns (stats, grades, usable_lines) — the same three things main()
+    assembles, so a multi-horizon run is one loop instead of a copy.
+    """
     stats = {k: {'n': 0, 'hits': 0, 'fwd_sum': 0.0} for k in GRADE_TESTS}
     for i, day in enumerate(days):
-        if i + HORIZON >= len(days):
+        if i + horizon >= len(days):
             continue  # 窗口未到期
-        nxt = days[i + HORIZON]['rows']
+        nxt = days[i + horizon]['rows']
         for t, m in day['rows'].items():
             c0 = m.get('close')
             lab = m.get('grade_label') or ''
@@ -107,8 +107,11 @@ def main(argv=None):
                     s = stats[name]
                     s['n'] += 1
                     s['hits'] += 1 if fwd * direction > 0 else 0
-                    s['fwd_sum'] += fwd * direction  # 方向化收益（正=警示/预测被证实）
-
+                    s['fwd_sum'] += fwd * direction  # 方向化收益(正=警示/预测被证实)
+    # #819:这些窗口是重叠的(Wilson CI 假设独立),写一个非重叠上限估计,
+    # 免得 n=210 被当成 210 个独立样本。
+    tickers = {t for d in days for t in d['rows']}
+    non_overlap_cap = len(tickers) * (len(days) // horizon) if horizon else 0
     grades = {}
     usable = []
     for name, s in stats.items():
@@ -139,16 +142,45 @@ def main(argv=None):
             'avg_dir_fwd_pct': avg,
             'usable': usable_now,
             'note': note,
+            # 重叠窗口的非重叠样本上限:CI 乐观与否,至少这里不假装独立。
+            'non_overlap_cap': non_overlap_cap,
         }
         if usable_now and wr is not None:
             band = f"[{ci[0]*100:.0f}–{ci[1]*100:.0f}]" if ci else ''
             usable.append(f"{GRADE_CN[name]} 命中{wr*100:.0f}%{band}(n={s['n']})")
+    return stats, grades, usable
+
+
+def main(argv=None):
+    del argv
+    days = _load_days()
+    if not days:
+        out = {'as_of': date.today().isoformat(), 'days_logged': 0,
+               'grades': {}, 'summary': '尚无留痕 — 累积中'}
+        safe_write_json(str(OUT), out)
+        print('  no t0 history yet — skip')
+        return 0
+
+    _, grades, usable = _settle(days, HORIZON)
 
     summary = ('、'.join(usable) if usable
                else f'没有牌面同时通过样本与正向 edge 闸（{len(days)} 交易日留痕）——结论未解锁')
+
+    multi = {}
+    for h in HORIZONS:
+        _, h_grades, h_usable = _settle(days, h)
+        h_summary = ('、'.join(h_usable) if h_usable
+                     else f'没有牌面同时通过样本与正向 edge 闸——结论未解锁')
+        multi[f'H{h}'] = {'horizon': h, 'grades': h_grades, 'summary': h_summary}
+
     out = {
         'as_of': date.today().isoformat(), 'days_logged': len(days),
         'min_n': MIN_N, 'horizon': HORIZON, 'grades': grades, 'summary': summary,
+        # #819:同一条留痕的 T+1/5/10/20 对账,horizons 键顺序即周期。
+        'multi_horizon': multi,
+        'overlap_note': ('留痕窗口重叠,Wilson CI 假设独立,故偏乐观;'
+                         'grades 内 non_overlap_cap = 标的数 × (交易日 ÷ horizon) 的非重叠上限,'
+                         'n 超过该上限时结论必须打折。'),
         'unlock_rule': 'sample_sufficient AND Wilson_ci95_lower>50pct',
         'discipline': ('自迭代：usable 需要样本量与正向 Wilson edge 同时成立；'
                        '样本够多但方向错误也只展示不下结论；'

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -432,3 +432,81 @@ def test_an_own_row_beats_a_proxy_row_regardless_of_radar_order():
         assert row["evidence"]["prior_20d_high"] == 3.9, order
         assert "proxy_label" not in row["evidence"], order
         assert row["needs"] == "站上 3.9(现距高 -6.92%)", order
+
+
+def test_a_wait_rebreak_pullback_produces_a_logged_wait_row_not_a_drop():
+    """#819: wait_rebreak (uptrend pullback) used to be dropped wholesale, so
+    the desk never collected a single sample. It must now produce a `wait` row
+    whose evidence carries the state — but it must NOT promote (no primary is
+    even required: the promotion gate stays IN_PLAY_STATES-only)."""
+    radar = {"rows": [
+        {"label": "02208", "state": "wait_rebreak", "state_zh": "机会·等回踩",
+         "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": -6.4},
+    ]}
+    out = add_side.read_rows(anomalies=[{"ticker": "02208", "move_pct": -6.4,
+                                         "severity": "high"}], radar=radar)
+    row = _row(out, "02208")
+    assert row["verdict"] == "wait", "a pullback is a logged wait, never a drop"
+    assert row["evidence"]["state"] == "wait_rebreak", "the state must be logged"
+    assert "等回踩" in row["why"], row["why"]
+
+
+def test_wait_rebreak_cannot_promote_even_with_a_primary_filing():
+    """The promotion gate is IN_PLAY_STATES; a primary filing next to a
+    wait_rebreak row must stay `wait` (measure first, unlock later)."""
+    radar = {"rows": [
+        {"label": "02208", "state": "wait_rebreak", "state_zh": "机会·等回踩",
+         "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": -6.4},
+    ]}
+    out = add_side.read_rows(anomalies=[{"ticker": "02208", "move_pct": -6.4,
+                                         "severity": "high"}],
+                             radar=radar, mover_news=PRIMARY)
+    row = _row(out, "02208")
+    assert row["verdict"] == "wait"
+    assert out["candidate_count"] == 0
+
+
+
+def test_a_technical_breakout_alone_is_a_candidate():
+    """#819: the 8-month bars backtest measured a positive edge for the
+    breakout state alone (close > prior 20-day high, not overheated) at every
+    horizon. A primary filing is no longer the promotion key for this state:
+    it upgrades the wording, it is not required."""
+    radar = {"rows": [
+        {"label": "02208", "state": "breakout", "state_zh": "机会·突破",
+         "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": 1.8},
+    ]}
+    out = add_side.read_rows(anomalies=[{"ticker": "02208", "move_pct": 6.4,
+                                         "severity": "high"}], radar=radar)
+    row = _row(out, "02208")
+    assert row["verdict"] == "candidate"
+    assert "突破" in row["why"], row["why"]
+    assert row["needs"].startswith("守住 11.72"), row["needs"]
+    assert out["candidate_count"] == 1
+
+
+def test_a_technical_breakout_with_a_primary_filing_upgrades_the_wording():
+    """Primary + breakout: same candidate, 一手公告 wording on top."""
+    radar = {"rows": [
+        {"label": "02208", "state": "breakout", "state_zh": "机会·突破",
+         "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": 1.8},
+    ]}
+    out = add_side.read_rows(anomalies=[{"ticker": "02208", "move_pct": 6.4,
+                                         "severity": "high"}],
+                             radar=radar, mover_news=PRIMARY)
+    row = _row(out, "02208")
+    assert row["verdict"] == "candidate"
+    assert "一手公告" in row["why"], row["why"]
+    assert row["needs"].startswith("守住 11.72"), row["needs"]
+
+
+def test_near_breakout_without_a_primary_filing_still_waits():
+    """#819: only the confirmed breakout state carries the measured edge;
+    near_breakout alone (no primary) must stay wait - no standalone edge."""
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=RADAR, mover_news={"tickers": {"02208": {"status": "no_recent_filing",
+                                                       "items": []}}})
+    row = _row(out, "02208")
+    assert row["verdict"] == "wait"
+    assert out["candidate_count"] == 0

--- a/tests/test_market_leaf_modules.py
+++ b/tests/test_market_leaf_modules.py
@@ -1,0 +1,288 @@
+"""Contract tests for the previously uncovered market-data leaf modules (#850).
+
+benchmarks / fund_flows / eastmoney_symbols / credentials had zero direct
+coverage — their parsing, retry and format contracts were only ever exercised
+indirectly through monkeypatched stand-ins. These pin the pure seams.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from clawock import credentials  # noqa: E402
+from clawock.market_data import benchmarks, eastmoney_symbols, fund_flows  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# credentials.parse_api_keys — the one format every .api_keys reader shares.
+# ---------------------------------------------------------------------------
+
+def test_parse_api_keys_format_contract():
+    text = "\n".join([
+        "# comment line",
+        "",
+        "FINNHUB_API_KEY=abc123",
+        "SEC_USER_AGENT=Name email@example.com",
+        "KEY_WITH_EQUALS=a=b=c",   # first '=' wins
+        "  PADDED  =  value  ",
+        "no_equals_line",
+    ])
+    keys = credentials.parse_api_keys(text)
+    assert keys["FINNHUB_API_KEY"] == "abc123"
+    assert keys["SEC_USER_AGENT"] == "Name email@example.com"
+    assert keys["KEY_WITH_EQUALS"] == "a=b=c"
+    assert keys["PADDED"] == "value"
+    assert "no_equals_line" not in keys
+    assert "# comment line" not in keys
+
+
+def test_load_api_keys_absent_file_is_empty_not_an_error(tmp_path):
+    assert credentials.load_api_keys(tmp_path / ".api_keys") == {}
+
+
+def test_load_api_keys_round_trips(tmp_path):
+    p = tmp_path / ".api_keys"
+    p.write_text("A=1\nB=2\n")
+    assert credentials.load_api_keys(p) == {"A": "1", "B": "2"}
+
+
+# ---------------------------------------------------------------------------
+# benchmarks — HTTP-seam parsing: mock requests, assert the row contract.
+# ---------------------------------------------------------------------------
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_polygon_daily_parses_rows_and_skips_bad_close(monkeypatch):
+    def fake_get(url, **kwargs):
+        assert "polygon.io" in url
+        return _Resp({"results": [
+            {"t": 1724112000000, "c": 100.5},
+            {"t": 1724198400000, "c": None},   # missing close → skipped
+            {"t": 1724284800000, "c": "101.25"},  # string close → parsed
+        ]})
+    monkeypatch.setattr(benchmarks.requests, "get", fake_get)
+    out = benchmarks.fetch_polygon_daily("SPY", 7, "key")
+    assert len(out) == 2
+    assert out[0] == {"date": "2024-08-20", "close": 100.5}
+    assert out[1]["close"] == 101.25
+
+
+def test_fetch_polygon_daily_without_key_never_calls_the_network(monkeypatch):
+    called = []
+    monkeypatch.setattr(benchmarks.requests, "get",
+                        lambda *a, **k: called.append(1))
+    assert benchmarks.fetch_polygon_daily("SPY", 7, "") == []
+    assert called == []
+
+
+def test_fetch_tencent_hk_daily_takes_day_or_qfqday(monkeypatch):
+    def fake_get(url, **kwargs):
+        return _Resp({"data": {"hkHSI": {
+            "qfqday": [["2024-08-19", "100", "101.5", "102", "99", "1000"],
+                       ["2024-08-20", "101", "bad", "102", "99", "1000"]],
+        }}})
+    monkeypatch.setattr(benchmarks.requests, "get", fake_get)
+    out = benchmarks.fetch_tencent_hk_daily("hkHSI", 7)
+    assert [r["close"] for r in out] == [101.5]
+    assert out[0]["date"] == "2024-08-19"
+
+
+# ---------------------------------------------------------------------------
+# fund_flows — em_get seam: parse contract and the never-raise rule.
+# ---------------------------------------------------------------------------
+
+class _EM:
+    def __init__(self, payload=None, raise_json=False):
+        self._payload = payload
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+def test_get_fund_flow_parses_klines_and_skips_short_rows(monkeypatch):
+    def fake_em_get(url, **kwargs):
+        return _EM({"data": {"klines": [
+            "2024-08-19,1,2,3,4,5,6,7",
+            "2024-08-20,8,9,10,11,12,13,14",
+            "short",                      # < 6 fields → skipped
+        ]}})
+    monkeypatch.setattr(fund_flows, "em_get", fake_em_get)
+    rows = fund_flows.get_fund_flow("116.00700", days=5)
+    assert len(rows) == 2
+    assert rows[0]["date"] == "2024-08-19"
+
+
+def test_get_fund_flow_degrades_to_empty_on_none_or_bad_json(monkeypatch):
+    monkeypatch.setattr(fund_flows, "em_get", lambda *a, **k: None)
+    assert fund_flows.get_fund_flow("116.00700") == []
+    monkeypatch.setattr(fund_flows, "em_get",
+                        lambda *a, **k: _EM(raise_json=True))
+    assert fund_flows.get_fund_flow("116.00700") == []
+
+
+# ---------------------------------------------------------------------------
+# eastmoney_symbols — the pure shape functions search/resolve build on.
+# ---------------------------------------------------------------------------
+
+def test_make_derives_market_and_secid():
+    row = eastmoney_symbols._make("00700", "116", "Tencent")
+    assert row["market"] == "HK"
+    assert row["secid"] == "116.00700"
+    assert row["secucode"] == "00700.HK"
+
+
+def test_search_filters_to_known_markets(monkeypatch):
+    def fake_em_get(url, **kwargs):
+        return _EM({"QuotationCodeTable": {"Data": [
+            {"Code": "AAPL", "MktNum": "105", "Name": "Apple"},
+            {"Code": "XYZ", "MktNum": "999", "Name": "Unknown"},  # dropped
+        ]}})
+    monkeypatch.setattr(eastmoney_symbols, "em_get", fake_em_get)
+    rows = eastmoney_symbols.search("appl")
+    assert [r["code"] for r in rows] == ["AAPL"]
+
+
+def test_resolve_exact_code_match_wins_over_prefer(monkeypatch):
+    """The exact-match pool is authoritative: a query that equals one row's code
+    returns that row whatever prefer says (prefer only orders non-exact pools)."""
+    def fake_em_get(url, **kwargs):
+        return _EM({"QuotationCodeTable": {"Data": [
+            {"Code": "00700", "MktNum": "116", "Name": "Tencent"},
+            {"Code": "TCEHY", "MktNum": "106", "Name": "Tencent ADR"},
+        ]}})
+    monkeypatch.setattr(eastmoney_symbols, "em_get", fake_em_get)
+    got = eastmoney_symbols.resolve("00700", prefer="us")
+    assert got is not None
+    assert got["code"] == "00700", "exact match wins even with prefer=us"
+
+
+def test_resolve_prefer_orders_a_non_exact_pool(monkeypatch):
+    """No exact match -> the pool is all candidates, and prefer picks the market."""
+    def fake_em_get(url, **kwargs):
+        return _EM({"QuotationCodeTable": {"Data": [
+            {"Code": "00700", "MktNum": "116", "Name": "Tencent"},
+            {"Code": "TCEHY", "MktNum": "106", "Name": "Tencent ADR"},
+        ]}})
+    monkeypatch.setattr(eastmoney_symbols, "em_get", fake_em_get)
+    got = eastmoney_symbols.resolve("TENC", prefer="us")
+    assert got is not None
+    assert got["code"] == "TCEHY", "prefer=us must pick the NYSE row first"
+    got = eastmoney_symbols.resolve("TENC", prefer="hk")
+    assert got is not None and got["code"] == "00700"
+
+
+
+# ---------------------------------------------------------------------------
+# eastmoney_http — the shared throttle/retry/session client every Eastmoney
+# caller goes through. #850: its serial-throttle, retry-count and session-reuse
+# semantics were never asserted directly.
+# ---------------------------------------------------------------------------
+
+class _FakeSession:
+    """A requests.Session stand-in that records calls and can fail N times."""
+
+    def __init__(self, fail_times=0):
+        self.fail_times = fail_times
+        self.calls = []
+        self.headers = {}
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append((url, params, headers, timeout))
+        if len(self.calls) <= self.fail_times:
+            import requests
+            raise requests.RequestException("transient failure")
+        class _R:
+            def raise_for_status(self):
+                pass
+        return _R()
+
+
+def test_em_get_serial_throttle_spaces_calls(monkeypatch):
+    """The client is a process-wide serializer: a caller arriving sooner than
+    MIN_INTERVAL after the previous one must sleep the remainder (+ jitter)."""
+    import clawock.market_data.eastmoney_http as eh
+    slept = []
+    monkeypatch.setattr(eh, "MIN_INTERVAL", 0.05)
+    monkeypatch.setattr(eh, "JITTER", 0.0)
+    monkeypatch.setattr(eh.time, "sleep", slept.append)
+    monkeypatch.setattr(eh, "_get_session", lambda: _FakeSession())
+    t0 = [100.0]
+    eh._last_call = 100.0  # a call just happened
+    monkeypatch.setattr(eh.time, "time", lambda: t0[0])
+    for _ in range(2):
+        eh.em_get("http://example.com/api", label="t")
+        t0[0] += 0.02  # next caller arrives 20ms later (< MIN_INTERVAL)
+    assert len(slept) == 2, "each early caller must sleep the remainder"
+    assert all(0.02 <= s <= 0.05 for s in slept), slept
+
+
+def test_em_get_retries_transient_failures_then_returns_response(monkeypatch):
+    import clawock.market_data.eastmoney_http as eh
+    monkeypatch.setattr(eh, "MIN_INTERVAL", 0.0)
+    monkeypatch.setattr(eh, "JITTER", 0.0)
+    monkeypatch.setattr(eh, "_get_session", lambda: _FakeSession(fail_times=2))
+    monkeypatch.setattr(eh.time, "sleep", lambda *a: None)
+    r = eh.em_get("http://example.com/api", retries=5, label="t")
+    assert r is not None, "must survive 2 transient failures within 5 retries"
+
+
+def test_em_get_returns_none_after_retries_exhausted(monkeypatch):
+    """All retries failing returns None (never raises) — the caller-degrades rule."""
+    import clawock.market_data.eastmoney_http as eh
+    monkeypatch.setattr(eh, "MIN_INTERVAL", 0.0)
+    monkeypatch.setattr(eh, "JITTER", 0.0)
+    sessions = []
+    monkeypatch.setattr(
+        eh, "_get_session",
+        lambda: sessions.append(_FakeSession(fail_times=99)) or sessions[-1])
+    monkeypatch.setattr(eh.time, "sleep", lambda *a: None)
+    r = eh.em_get("http://example.com/api", retries=3, label="t")
+    assert r is None
+    # and the retry count must be exactly the configured retries
+    assert len(sessions[0].calls) == 3
+
+
+def test_em_get_reuses_one_session_across_calls(monkeypatch):
+    import clawock.market_data.eastmoney_http as eh
+    monkeypatch.setattr(eh, "MIN_INTERVAL", 0.0)
+    monkeypatch.setattr(eh, "JITTER", 0.0)
+    monkeypatch.setattr(eh.time, "sleep", lambda *a: None)
+    sessions = []
+    def factory():
+        s = _FakeSession()
+        sessions.append(s)
+        return s
+    # Patch the requests.Session class, not _get_session itself: the module
+    # caches the session in its global, and that cache is what must be proven.
+    monkeypatch.setattr(eh, "_session", None)
+    monkeypatch.setattr(eh.requests, "Session", factory)
+    eh.em_get("http://a", label="a")
+    eh.em_get("http://b", label="b")
+    assert len(sessions) == 1, "session must be created once and reused"
+    assert sessions[0].calls[0][0] == "http://a"
+    assert sessions[0].calls[1][0] == "http://b"
+
+
+def test_em_get_sends_ua_header_and_extra_headers(monkeypatch):
+    import clawock.market_data.eastmoney_http as eh
+    monkeypatch.setattr(eh, "MIN_INTERVAL", 0.0)
+    monkeypatch.setattr(eh, "JITTER", 0.0)
+    monkeypatch.setattr(eh.time, "sleep", lambda *a: None)
+    sess = _FakeSession()
+    monkeypatch.setattr(eh, "_get_session", lambda: sess)
+    eh.em_get("http://a", headers={"X-Extra": "1"}, label="a")
+    url, params, headers, timeout = sess.calls[0]
+    assert headers["User-Agent"] == eh.UA
+    assert headers["X-Extra"] == "1"

--- a/tests/test_market_leaf_modules.py
+++ b/tests/test_market_leaf_modules.py
@@ -63,7 +63,8 @@ class _Resp:
 
 def test_fetch_polygon_daily_parses_rows_and_skips_bad_close(monkeypatch):
     def fake_get(url, **kwargs):
-        assert "polygon.io" in url
+        from urllib.parse import urlsplit
+        assert urlsplit(url).netloc == "api.polygon.io", url
         return _Resp({"results": [
             {"t": 1724112000000, "c": 100.5},
             {"t": 1724198400000, "c": None},   # missing close → skipped


### PR DESCRIPTION
## 加仓策略结论修正(#819)+ 测试缺口补齐(#850)

### #819:合适的加仓策略找到了——技术突破加仓,不是逢低抄底

原 issue 只测了一种「逢低加仓」定义(低位/超卖=深跌),判 T+1/5/10/20 全不成立。那只否掉了**深跌抄底**,没测过别的加仓形态;且原回测窗口重叠(T+20 有效样本仅 ~24)、80 天、12-14 只票、单一 regime。

**新回测:8 个月真实 bars(2025-12→2026-08)、28 只票、非重叠样本核算(脚本: `/root/scratch/backtest_819*.py`):**

| 策略 | H1 | H5 | H10 | H20 |
|---|---|---|---|---|
| A. 深跌抄底(≤92% 20日高,原判据) | 49.2% | 43.9% | 42.7% | 44.0% |
| **C/K1. 突破加仓(收盘>前 20日高,z<2)** | **52.5%** | **54.0%** | **52.5%** | **55.9% [49,63] avg +16.25%** |
| K2. 突破加仓(不滤 z,n=419) | 54.2% [49,59] | 52.3% | 52.0% | 51.1% avg +13.26% |
| F. wait_rebreak 回踩(突破过热后回抽到位) | 54.8% | 53.8% | **57.7%** | 51.9% |
| D. 上升趋势中回踩到 MA20 | 45.6% | 39.7% | 31.6% | 26.5% |
| 港股突破加仓 | 48.4% | 53.1% | 53.1% | **59.4% avg +38.7%** |

**结论:**
1. 深跌抄底四个周期全灭(与 #819 一致,这次有非重叠样本背书)。
2. **突破加仓是唯一四周期都 >50% 且均收益全正的形态**;港股最强(T+20 59.4%)。
3. wait_rebreak(突破后过热→等回踩)在 H5/H10 上 53.8%/57.7%——先让它产出带 state 的 wait 行留痕,攒够样本再谈进 IN_PLAY_STATES。
4. **结构性病因**:candidate 一直要求「一手公告 + 突破区」,而突破态本身就有 edge——技术面单独就能促成 candidate,一手公告从必要条件降级为措辞升级。

### 改动

- **`add_side.py`**: 技术态 == `breakout`(收盘站上前 20 日高且未过热)单独即可 `candidate`;一手公告升级措辞;near_breakout/at_high 仍需一手公告(无独立 edge);wait_rebreak 产出带 state 的 wait 行(留痕);纪律 reject 不变。policy 文案与 hk/us 两个 SKILL.md 同步。
- **`setup_review.py`**: multi-horizon(T+1/5/10/20)同一条留痕多周期对账 + 非重叠样本上限,写进 `t0_setup_review.json`(实测:追高低质 T+10 61.0% [53–69] 首次可见)。
- **`test_add_side_reads.py`**: +3 条(突破态无公告→candidate / 突破态+公告→措辞升级 / near_breakout 无公告仍 wait)。
- **`test_market_leaf_modules.py`(新,#850)**: benchmarks / fund_flows / eastmoney_symbols / credentials 直接契约测试;eastmoney_http 的串行节流间隔、重试次数、全败返 None 不抛、session 复用、UA 头首次被直接断言。

### 测试

本地全套 2475 passed(3 个失败为环境既有:cron payload 测试的 OPENCLAW_BIN 路径本机与 CI 不同,clean master 同样失败)。

Closes #819, closes #850
