### PR TITLE
fix: add-side 行带出 close/zscore20,加仓判据盘中可见 (#819 补充)

### DIFF
--- a/skills/hk-stock-analysis/SKILL.md
+++ b/skills/hk-stock-analysis/SKILL.md
@@ -111,7 +111,7 @@ clawock intraday preflight --market hk
   - 📈 **加仓侧读数(`add_side_reads.rows` 非空时必写 1 行)**:harness 已经把异动、机会雷达
     (接近 20 日高)、早期趋势三条 lane 连同 thesis 红线和未了结的纪律动作 join 成
     `candidate|wait|reject`。**照抄 `verdict` + `why` + `needs`,数字照抄 `evidence`**
-    (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
+    (`move_pct` / `close` / `zscore20` / `pct_from_high` / `prior_20d_high`),写成
     「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
     软消息/情绪只能停在 `wait`;技术突破态(收盘站上前 20 日高且未过热)本身即促成

--- a/skills/us-stock-analysis/SKILL.md
+++ b/skills/us-stock-analysis/SKILL.md
@@ -112,7 +112,7 @@ clawock intraday preflight --market us
   - 📈 **加仓侧读数(`add_side_reads.rows` 非空时必写 1 行)**:harness 已经把异动、机会雷达
     (接近 20 日高)、早期趋势三条 lane 连同 thesis 红线和未了结的纪律动作 join 成
     `candidate|wait|reject`。**照抄 `verdict` + `why` + `needs`,数字照抄 `evidence`**
-    (`move_pct` / `pct_from_high` / `prior_20d_high`),写成
+    (`move_pct` / `close` / `zscore20` / `pct_from_high` / `prior_20d_high`),写成
     「{票} {verdict}:{why} → {needs}」。多条就写最急的 1-2 条(rows 已按 candidate→reject→wait
     排序)。纪律铁律不变:**三态都不是下单授权**,不许自行补方向、价格、股数;
     软消息/情绪只能停在 `wait`;技术突破态(收盘站上前 20 日高且未过热)本身即促成

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -238,6 +238,7 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
                 # packet, not only inside a sentence (数字只能引用 context).
                 evidence = {**evidence,
                             "prior_20d_high": level.get("prior_20d_high"),
+                            "close": level.get("close"),
                             "pct_from_high": level.get("pct_from_high")}
 
         proxy = _proxy_of(radar_row)
@@ -248,7 +249,7 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             # `state` still feeds the promotion gate — only the numbers are
             # re-attributed to the thing they actually measure.
             evidence = {**evidence, "proxy_label": proxy}
-            for key in ("prior_20d_high", "pct_from_high"):
+            for key in ("prior_20d_high", "pct_from_high", "close", "zscore20"):
                 if evidence.get(key) is not None:
                     evidence[f"proxy_{key}"] = evidence.pop(key)
 
@@ -276,6 +277,8 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             "move_pct": anomaly.get("move_pct"),
             "severity": anomaly.get("severity"),
             "state": (radar_row or {}).get("state"),
+            "close": (radar_row or {}).get("close"),
+            "zscore20": (radar_row or {}).get("zscore20"),
             "pct_from_high": (radar_row or {}).get("pct_from_high"),
             "prior_20d_high": (radar_row or {}).get("prior_20d_high"),
         })
@@ -293,6 +296,8 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             continue
         add(ticker, ["near_breakout"], {
             "state": radar_row.get("state"),
+            "close": radar_row.get("close"),
+            "zscore20": radar_row.get("zscore20"),
             "pct_from_high": radar_row.get("pct_from_high"),
             "prior_20d_high": radar_row.get("prior_20d_high"),
         })

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -29,10 +29,13 @@ from clawock.decision import add_side  # noqa: E402
 
 RADAR = {"rows": [
     {"label": "02208", "state": "near_breakout", "state_zh": "机会·接近",
-     "holdings": ["02208"], "prior_20d_high": 11.72, "pct_from_high": -4.01},
+     "holdings": ["02208"], "close": 11.31, "zscore20": 1.4,
+     "prior_20d_high": 11.72, "pct_from_high": -4.01},
     {"label": "HSTECH", "state": "near_breakout", "state_zh": "机会·接近",
-     "holdings": ["07226"], "prior_20d_high": 4948.5, "pct_from_high": -3.06},
+     "holdings": ["07226"], "close": 4798.0, "zscore20": 1.1,
+     "prior_20d_high": 4948.5, "pct_from_high": -3.06},
     {"label": "00700", "state": "mid_range", "holdings": ["00700"],
+     "close": 440.0, "zscore20": -1.2,
      "prior_20d_high": 500.0, "pct_from_high": -12.0},
 ]}
 PRIMARY = {"tickers": {"02208": {"status": "ok", "items": [
@@ -157,11 +160,41 @@ def test_every_number_in_a_row_came_from_the_inputs():
     """No derived arithmetic: a number in the report must be pointable-at in context."""
     anomalies = [{"ticker": "02208", "move_pct": 6.4, "severity": "high"}]
     out = add_side.read_rows(anomalies=anomalies, radar=RADAR, mover_news=SOFT_ONLY)
-    supplied = {6.4, 11.72, -4.01, 4948.5, -3.06}
+    supplied = {6.4, 11.31, 1.4, 11.72, -4.01, 4798.0, 1.1, 4948.5, -3.06}
     for row in out["rows"]:
         for key, value in row["evidence"].items():
             if isinstance(value, (int, float)):
                 assert value in supplied, f"{key}={value} is not an input value"
+
+
+def test_the_technical_basis_of_a_candidate_is_pointable_in_evidence():
+    """#819: the new promotion gate rests on close vs prior_20d_high AND z<2
+    (未过热). The message writer can only quote evidence numbers, so a breakout
+    candidate must carry close and zscore20 verbatim from the radar row."""
+    radar = {"rows": [
+        {"label": "02208", "state": "breakout", "state_zh": "机会·突破",
+         "holdings": ["02208"], "close": 11.31, "zscore20": 1.4,
+         "prior_20d_high": 11.72, "pct_from_high": 1.8},
+    ]}
+    out = add_side.read_rows(
+        anomalies=[{"ticker": "02208", "move_pct": 6.4, "severity": "high"}],
+        radar=radar)
+    row = _row(out, "02208")
+    assert row["verdict"] == "candidate"
+    assert row["evidence"]["close"] == 11.31
+    assert row["evidence"]["zscore20"] == 1.4
+    assert row["evidence"]["prior_20d_high"] == 11.72
+
+
+def test_the_proxy_renames_close_and_zscore_too():
+    """#761's attribution rule covers every number: a proxy row's close and
+    zscore belong to the index (HSTECH), not to the tradable holding."""
+    out = add_side.read_rows(anomalies=[], radar=RADAR)
+    row = _row(out, "07226")
+    assert row["evidence"]["proxy_close"] == 4798.0
+    assert row["evidence"]["proxy_zscore20"] == 1.1
+    assert "close" not in row["evidence"]
+    assert "zscore20" not in row["evidence"]
 
 
 def test_the_live_context_shape_still_feeds_it():


### PR DESCRIPTION
## 补:加仓判据的技术指标要能进盘中消息(#819 补充)

kcn 指出:突破加仓的新闸基于「收盘站上前 20 日高 **且未过热(z<2)**」,
但 `add_side_reads` 的 evidence 只带出 `state/pct_from_high/prior_20d_high`,
**`close` 和 `zscore20` 被丢掉**——模板只让模型照抄 `move_pct/pct_from_high/prior_20d_high`,
于是「未过热」这个判据在盘中消息里看不见、没法引用(数字只能照抄 evidence 的规矩)。

实测 live packet(2026-08-22 US):radar 行有 `close=87.73, zscore20=2.49`,
但 add_side 行 evidence 里只有 `pct_from_high/prior_20d_high`——z=2.49 过热这个
「为什么 wait 而非 candidate」的关键数字根本到不了消息。

## 改动

- `add_side.py`:anomaly 路径和 radar-only 路径的 evidence 都带出 `close` + `zscore20`;
  proxy 重归属规则(#761)同步覆盖这两个字段(`proxy_close`/`proxy_zscore20`);
  level 兜底合并也带 `close`。
- 两个 SKILL.md:数字照抄清单加 `close` / `zscore20`。
- 测试:RADAR fixture 补 close/zscore20;新加 2 条——candidate 的技术依据在
  evidence 里可指、proxy 的 close/zscore 必须改名。

## 验证

本地全套 2477 passed(3 个失败为环境既有 OPENCLAW_BIN 路径,clean master 同样红)。
E2E:live 形状的 wait_rebreak 行现在带出 `close=87.73, zscore20=2.49`,消息可写
「z 2.49 过热,等回踩」。

Closes #819 的可见性部分(issue 已关,此为同题补充)
