### PR TITLE
feat: dashboard 去 AI 味 + 高级感动画

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -266,6 +266,13 @@
     content: ""; position: absolute; width: 22px; height: 2px;
     left: 50%; bottom: 3px; transform: translateX(-50%);
     border-radius: 999px; background: var(--accent);
+    /* Grows in place instead of teleporting: scaleX is transform-only and
+       150ms is near-imperceptible even at tab-switch frequency. */
+    transform-origin: center;
+    animation: tab-indicator-in 150ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @keyframes tab-indicator-in {
+    from { transform: translateX(-50%) scaleX(0); }
   }
   .tab-btn:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
 
@@ -521,6 +528,13 @@
     box-shadow: var(--shadow-card);
     padding: var(--space-4);
     margin-bottom: var(--gap);
+    transition: transform 150ms cubic-bezier(.23,1,.32,1);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .panel.active > .card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 2px 4px rgba(18,33,48,.06), 0 16px 36px rgba(18,33,48,.1);
+    }
   }
   .card.is-pending { visibility: hidden; }
   @media (prefers-color-scheme: light) {
@@ -816,7 +830,11 @@
     border-left: 3px solid var(--red);
   }
   .risk-alert.medium { border-left-color: var(--warning); }
-  .risk-alert .icon { font-size: 14px; }
+  .risk-alert .icon {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--red); flex: none; margin-top: 4px;
+  }
+  .risk-alert.medium .icon { background: var(--warning); }
   @media (max-width: 480px) {
     .risk-grid { grid-template-columns: repeat(2, 1fr); }
   }
@@ -969,7 +987,13 @@
   .anomaly.high { border-left-color: var(--red); }
   .anomaly.medium { border-left-color: var(--amber); }
   .anomaly.low { border-left-color: var(--gray); }
-  .anomaly .icon { font-size: 16px; line-height: 1; }
+  .anomaly .icon {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: currentColor; flex: none; margin-top: 5px;
+  }
+  .anomaly.high .icon { background: var(--red); }
+  .anomaly.medium .icon { background: var(--amber); }
+  .anomaly.low .icon { background: var(--gray); }
   .anomaly .body { min-width: 0; flex: 1; }
   .anomaly .ticker { font-weight: 600; font-family: var(--mono); }
   .anomaly .detail { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
@@ -1237,7 +1261,13 @@
     margin-bottom: var(--space-2); border-radius: var(--radius-sm); background: var(--card-2);
     font-size: 13px; line-height: 1.5;
   }
-  .br-point .br-icon { flex: 0 0 auto; font-size: 12px; margin-top: 1px; }
+  .br-point .br-icon {
+    flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%;
+    background: currentColor; margin-top: 5px;
+  }
+  .br-point.br-edge { color: var(--green); }
+  .br-point.br-bias { color: var(--warning); }
+  .br-point.br-warn { color: var(--red); }
   .br-point.br-edge { border-left: 3px solid var(--green); }
   .br-point.br-bias { border-left: 3px solid var(--amber); }
   .br-point.br-warn { border-left: 3px solid var(--red); }
@@ -1330,8 +1360,15 @@
   .desk-rail-expanded {
     display: flex; align-items: stretch; gap: 10px;
     padding: 0 10px 10px; border-top: 1px solid var(--border);
+    /* Toggling the rail is an occasional action, so the content may bridge
+       its arrival — 240ms, transform+opacity only. Closing snaps (the global
+       reduced-motion rule also zeroes this). */
+    animation: desk-rail-in 240ms cubic-bezier(.22,1,.36,1);
   }
   .desk-rail-expanded[hidden] { display: none; }
+  @keyframes desk-rail-in {
+    from { opacity: 0; transform: translateY(-4px); }
+  }
   .desk-rail .dr-narrative {
     margin: 10px 0 0; flex: 1 1 300px; min-width: 0;
   }
@@ -2121,7 +2158,13 @@
     font-size: 13px; line-height: 1.3; font-weight: 500;
     background: var(--card-2); border: 1px solid var(--border); color: var(--text);
   }
-  .hl-chip .hl-ic { font-size: 13px; }
+  /* The icon slot is a status dot now — the emoji that lived here read as
+     AI-flavoured (ui-ux-pro-max: no emoji as icons). Colour inherits from the
+     chip's semantic state class below. */
+  .hl-chip .hl-ic {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: currentColor; flex: none;
+  }
   .hl-chip.hl-alert { border-color: var(--red); background: color-mix(in srgb, var(--red) 14%, var(--card)); color: var(--red); font-weight: 600; }
   .hl-chip.hl-warn  { border-color: var(--amber); color: var(--amber); }
   .hl-chip.hl-up    { border-color: var(--green); color: var(--green); }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -100,9 +100,9 @@
     // 0. Regime — the day's default stance (same risk_on/neutral/risk_off the brief acts on)
     const rg = safe(DATA, "regime");
     if (rg && rg.label) {
-      const map = { risk_on:  { cls:"hl-up",    ic:"🟢", stance:"默认持有, 别瞎动" },
-                    neutral:  { cls:"hl-info",  ic:"⚪", stance:"按 frame 常规" },
-                    risk_off: { cls:"hl-alert", ic:"🔴", stance:"防御, 优先减杠杆" } };
+      const map = { risk_on:  { cls:"hl-up",    ic:"", stance:"默认持有, 别瞎动" },
+                    neutral:  { cls:"hl-info",  ic:"", stance:"按 frame 常规" },
+                    risk_off: { cls:"hl-alert", ic:"", stance:"防御, 优先减杠杆" } };
       const r = map[rg.label] || map.neutral;
       chips.push({ cls: r.cls, icon: r.ic,
         txt: `Regime ${escapeHtml(rg.label.replace("_"," "))} · ${escapeHtml(r.stance)}` });
@@ -117,7 +117,7 @@
     if (dd.has_material_change || changedN || newN || triggeredN) {
       chips.push({
         cls: triggeredN ? "hl-alert" : "hl-info",
-        icon: triggeredN ? "⚡" : "↻",
+        icon: "",
         txt: `决策变化 · 新增 ${newN} · 修改 ${changedN} · 触发 ${triggeredN}`,
       });
     }
@@ -129,7 +129,7 @@
     const near = (computeWatchRows().rows || []).find(r => r.ad != null);
     if (near) {
       const fire = near.ad < 2;
-      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: fire ? "⚠️" : "🎯",
+      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: "",
         txt: `${escapeHtml(near.who)} ${escapeHtml(near.label)} ${fmtMoney(near.val, near.ccy)}`
            + ` · 现 ${fmtMoney(near.cur, near.ccy)} (${fmtPct(near.dist,1)})${fire ? " 即将触发" : ""}` });
     }
@@ -138,7 +138,7 @@
     const movers = safe(DATA, "today_movers") || [];
     if (movers.length) {
       const m = movers[0]; const up = (m.today_change_pct || 0) >= 0;
-      chips.push({ cls: up ? "hl-up" : "hl-down", icon: up ? "📈" : "📉",
+      chips.push({ cls: up ? "hl-up" : "hl-down", icon: "",
         txt: `今日最大波动 ${escapeHtml(m.ticker)} ${fmtPct(m.today_change_pct,1)}` });
     }
 
@@ -148,7 +148,7 @@
     if (anomalies.length) {
       const a = anomalies[0];
       const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "🚩",
+      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "",
         txt: (highN > 1 ? `${highN} 项高危异常 · ` : `异常 `)
            + `${escapeHtml(a.ticker)}: ${escapeHtml(a.detail)}` });
     }
@@ -163,7 +163,7 @@
     (cat.macro_events||[]).forEach(e => { if (e.date === today) todays.push(`${e.type} ${e.detail}`); });
     (cat.earnings||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`财报 ${e.ticker||e.symbol||""}`); });
     (cat.fomc||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`FOMC ${e.detail||""}`); });
-    if (todays.length) chips.push({ cls:"hl-info", icon:"📅", txt:`今日事件 · ${escapeHtml(todays[0])}` });
+    if (todays.length) chips.push({ cls:"hl-info", icon:"", txt:`今日事件 · ${escapeHtml(todays[0])}` });
 
     if (!chips.length) {
       el.style.display = "";
@@ -702,7 +702,7 @@
     }
     const breaches = g.breaches || [], stops = g.hard_stop_watch || [];
     const n = g.breach_count || 0;
-    const ICON = { single_name: '🎯', factor_concentration: '🧬', leveraged_exposure: '⚡', beta: '📈', regime_delever: '🧭' };
+    const ICON = { single_name: '', factor_concentration: '', leveraged_exposure: '', beta: '', regime_delever: '' };
     const row = (icon, sev, detail, action) =>
       `<div class="risk-alert ${sev || 'high'}">
          <span class="icon">${icon}</span>
@@ -710,19 +710,19 @@
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '⚠️', severity: b.severity, detail: b.detail, action: b.action })),
-      ...stops.map(s => ({ icon: '🛑', severity: 'high', detail: s.detail, action: s.action })),
+      ...stops.map(s => ({ icon: '', severity: 'high', detail: s.detail, action: s.action })),
     ];
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
-      countEl.textContent = n ? `${n} 触发` : '✅ 无';
+      countEl.textContent = n ? `${n} 触发` : '无';
       countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
         ? (g.directive || "")
         : [g.directive, g.reentry_rule].filter(Boolean).join(' ');
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内 ✅</div>';
+      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -119,9 +119,9 @@
     // 0. Regime — the day's default stance (same risk_on/neutral/risk_off the brief acts on)
     const rg = safe(DATA, "regime");
     if (rg && rg.label) {
-      const map = { risk_on:  { cls:"hl-up",    ic:"🟢", stance:"默认持有, 别瞎动" },
-                    neutral:  { cls:"hl-info",  ic:"⚪", stance:"按 frame 常规" },
-                    risk_off: { cls:"hl-alert", ic:"🔴", stance:"防御, 优先减杠杆" } };
+      const map = { risk_on:  { cls:"hl-up",    ic:"", stance:"默认持有, 别瞎动" },
+                    neutral:  { cls:"hl-info",  ic:"", stance:"按 frame 常规" },
+                    risk_off: { cls:"hl-alert", ic:"", stance:"防御, 优先减杠杆" } };
       const r = map[rg.label] || map.neutral;
       chips.push({ cls: r.cls, icon: r.ic,
         txt: `Regime ${escapeHtml(rg.label.replace("_"," "))} · ${escapeHtml(r.stance)}` });
@@ -136,7 +136,7 @@
     if (dd.has_material_change || changedN || newN || triggeredN) {
       chips.push({
         cls: triggeredN ? "hl-alert" : "hl-info",
-        icon: triggeredN ? "⚡" : "↻",
+        icon: "",
         txt: `决策变化 · 新增 ${newN} · 修改 ${changedN} · 触发 ${triggeredN}`,
       });
     }
@@ -148,7 +148,7 @@
     const near = (computeWatchRows().rows || []).find(r => r.ad != null);
     if (near) {
       const fire = near.ad < 2;
-      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: fire ? "⚠️" : "🎯",
+      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: "",
         txt: `${escapeHtml(near.who)} ${escapeHtml(near.label)} ${fmtMoney(near.val, near.ccy)}`
            + ` · 现 ${fmtMoney(near.cur, near.ccy)} (${fmtPct(near.dist,1)})${fire ? " 即将触发" : ""}` });
     }
@@ -157,7 +157,7 @@
     const movers = safe(DATA, "today_movers") || [];
     if (movers.length) {
       const m = movers[0]; const up = (m.today_change_pct || 0) >= 0;
-      chips.push({ cls: up ? "hl-up" : "hl-down", icon: up ? "📈" : "📉",
+      chips.push({ cls: up ? "hl-up" : "hl-down", icon: "",
         txt: `今日最大波动 ${escapeHtml(m.ticker)} ${fmtPct(m.today_change_pct,1)}` });
     }
 
@@ -167,7 +167,7 @@
     if (anomalies.length) {
       const a = anomalies[0];
       const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "🚩",
+      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "",
         txt: (highN > 1 ? `${highN} 项高危异常 · ` : `异常 `)
            + `${escapeHtml(a.ticker)}: ${escapeHtml(a.detail)}` });
     }
@@ -182,7 +182,7 @@
     (cat.macro_events||[]).forEach(e => { if (e.date === today) todays.push(`${e.type} ${e.detail}`); });
     (cat.earnings||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`财报 ${e.ticker||e.symbol||""}`); });
     (cat.fomc||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`FOMC ${e.detail||""}`); });
-    if (todays.length) chips.push({ cls:"hl-info", icon:"📅", txt:`今日事件 · ${escapeHtml(todays[0])}` });
+    if (todays.length) chips.push({ cls:"hl-info", icon:"", txt:`今日事件 · ${escapeHtml(todays[0])}` });
 
     if (!chips.length) {
       el.style.display = "";
@@ -729,10 +729,10 @@
       return;
     }
     const ICONS = {
-      rsi_overbought: "🔥",
+      rsi_overbought: "",
       peer_divergence: "↗",
-      high_weight_loss: "❗",
-      leveraged_etf_stop: "🛑",
+      high_weight_loss: "",
+      leveraged_etf_stop: "",
     };
     wrap.innerHTML = list.map(a => {
       const icon = ICONS[a.type] || "⚠";
@@ -1146,7 +1146,7 @@
     if (!hits.length) { wrap.style.display = 'none'; wrap.innerHTML = ''; return; }
     wrap.style.display = '';
     wrap.innerHTML =
-      `<div class="rb-hdr">⚠ Risk keywords (${hits.length})</div>` +
+      `<div class="rb-hdr">Risk keywords (${hits.length})</div>` +
       hits.map(h =>
         `<div class="rb-row"><span class="rb-tk">${h.ticker}</span>` +
         h.kws.map(k => `<span class="rb-kw">${k}</span>`).join('') +
@@ -1168,10 +1168,10 @@
         const a = vb.avg_benefit_pct;
         const col = a > 0 ? "var(--green)" : (a < 0 ? "var(--red)" : "var(--gray)");
         const ci = vb.cluster_ci95 ? ` · cluster CI [${vb.cluster_ci95[0].toFixed(2)}, ${vb.cluster_ci95[1].toFixed(2)}]` : "";
-        alphaEl.innerHTML = `🎯 主动决策 episode · <b style="color:${col}">${a > 0 ? "+" : ""}${a.toFixed(2)}%</b>`
+        alphaEl.innerHTML = `主动决策 episode · <b style="color:${col}">${a > 0 ? "+" : ""}${a.toFixed(2)}%</b>`
           + `<span style="color:var(--text-faint)">${ci} · n=${vb.n_episodes || 0}</span>`;
       } else {
-        alphaEl.textContent = "🎯 LLM vs 全持有基线 · 数据不足";
+        alphaEl.textContent = "LLM vs 全持有基线 · 数据不足";
       }
     }
     if (cal.brier == null) {
@@ -1619,10 +1619,10 @@
 
     const alerts = r.alerts || [];
     document.getElementById('risk-alert-count').textContent = alerts.length ? `(${alerts.length})` : '';
-    const ICONS = { high_beta: '⚡', high_vol: '🌊', deep_dd: '📉', high_leverage: '⚠️', negative_sharpe: '➖' };
+    const ICONS = {};
     const html = alerts.map(a =>
       `<div class="risk-alert ${a.severity || 'high'}">
-         <span class="icon">${ICONS[a.type] || '⚠️'}</span>
+         <span class="icon"></span>
          <div><strong>${a.type}</strong>: ${a.detail || ''}</div>
        </div>`
     ).join('');
@@ -1659,7 +1659,7 @@
     }
     const breaches = g.breaches || [], stops = g.hard_stop_watch || [];
     const n = g.breach_count || 0;
-    const ICON = { single_name: '🎯', factor_concentration: '🧬', leveraged_exposure: '⚡', beta: '📈', regime_delever: '🧭' };
+    const ICON = {};
     const row = (icon, sev, detail, action) =>
       `<div class="risk-alert ${sev || 'high'}">
          <span class="icon">${icon}</span>
@@ -1667,19 +1667,19 @@
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '⚠️', severity: b.severity, detail: b.detail, action: b.action })),
-      ...stops.map(s => ({ icon: '🛑', severity: 'high', detail: s.detail, action: s.action })),
+      ...stops.map(s => ({ icon: '', severity: 'high', detail: s.detail, action: s.action })),
     ];
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
-      countEl.textContent = n ? `${n} 触发` : '✅ 无';
+      countEl.textContent = n ? `${n} 触发` : '无';
       countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
         ? (g.directive || "")
         : [g.directive, g.reentry_rule].filter(Boolean).join(' ');
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内 ✅</div>';
+      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 
@@ -1698,7 +1698,7 @@
                 (r.swap_1x ? ` · 换 1x(${r.swap_1x}) 后需 +${r.underlying_need_if_1x_pct}%` : '') + `</div>`;
       }
       return `<div class="risk-alert ${r.leveraged ? 'high' : 'medium'}">
-         <span class="icon">${r.leveraged ? '⚡' : '📐'}</span>
+         <span class="icon"></span>
          <div><strong>${r.ticker}</strong> 浮亏 ${r.pnl_pct}% → 回本需 +${r.breakeven_need_pct}%${extra}</div>
        </div>`;
     }).join('');
@@ -1774,7 +1774,7 @@
     const rev = safe(DATA, "t0_setup_review");
     let backing = '';
     if (rev && rev.summary) {
-      backing = ` ｜ 📐 牌面背书（${rev.days_logged || 0}日留痕·T+1）：${rev.summary}`;
+      backing = ` ｜ 牌面背书（${rev.days_logged || 0}日留痕·T+1）：${rev.summary}`;
     }
     document.getElementById('t0-note').textContent =
       (t0.note || '') + ' 区间位=现价在当日高低区间位置（越高越接近追在顶部）；振幅/ATR>1=今日已跑过一个典型日。' + backing;
@@ -1800,12 +1800,12 @@
     const hkRe = reclaim(hk.close, hk.ma);
     if (hk.ma == null) { trigEl.innerHTML = ''; }
     else if (hk.trend_on) {
-      trigEl.innerHTML = `<span class="neutral">📍 HK 触发线 200线 ${Math.round(hk.ma)} · 已在线上 +${(-hkRe).toFixed(0)}% 缓冲（杠杆解锁中）</span>`;
+      trigEl.innerHTML = `<span class="neutral">HK 触发线 200线 ${Math.round(hk.ma)} · 已在线上 +${(-hkRe).toFixed(0)}% 缓冲（杠杆解锁中）</span>`;
     } else {
-      trigEl.innerHTML = `<span class="warn-text">📍 HK 触发线：恒科站回 200线 <strong>${Math.round(hk.ma)}</strong>（需 +${hkRe.toFixed(0)}%）→ 杠杆腿上限放回 50%</span>`;
+      trigEl.innerHTML = `<span class="warn-text">HK 触发线：恒科站回 200线 <strong>${Math.round(hk.ma)}</strong>（需 +${hkRe.toFixed(0)}%）→ 杠杆腿上限放回 50%</span>`;
     }
     // US per-name rows
-    const STATE = { cut: ['red', '⛔ 砍杠杆'], watch: ['warn-text', '👀 观察'], ok: ['neutral', '✅ 趋势ON'], unknown: ['neutral', '—'] };
+    const STATE = { cut: ['red', '砍杠杆'], watch: ['warn-text', '观察'], ok: ['neutral', '趋势ON'], unknown: ['neutral', '—'] };
     const us = r.us || {};
     const usEl = document.getElementById('lev-regime-us');
     const rows = (us.names || []).map(n => {
@@ -1818,9 +1818,9 @@
       const trig = (n.trend_on || re == null) ? '' : ` · <span class="warn-text">站回 ${Math.round(n.ma)}（+${re.toFixed(0)}%）${n.ma_window && n.ma_window < 200 ? '右侧再上2x' : '解锁2x'}</span>`;
       const basisNote = n.regime_basis && n.regime_basis.startsWith('short_ma')
         ? ` · <span class="muted">新上市不足200日线,短均线替代</span>` : '';
-      return `<div class="risk-alert ${sev}"><span class="icon">🧭</span>
+      return `<div class="risk-alert ${sev}"><span class="icon"></span>
         <div><strong>${n.etf}=2x ${n.underlying} <span class="${cls}">${tag}</span></strong>
-        <div class="muted" style="font-size:11px;margin-top:2px">距${maLbl} ${n.dist_ma_pct ?? '—'}% · 20日波动 ${vol}${n.vol_hot ? ' 🔥' : ''}${trig}${basisNote}</div></div></div>`;
+        <div class="muted" style="font-size:11px;margin-top:2px">距${maLbl} ${n.dist_ma_pct ?? '—'}% · 20日波动 ${vol}${trig}${basisNote}</div></div></div>`;
     }).join('');
     usEl.innerHTML = rows || '<div class="muted" style="font-size:12px">无持仓 2x 单股 ETF</div>';
     document.getElementById('lev-regime-asof').textContent =
@@ -2255,7 +2255,7 @@
     const tagMeta = {
       edge:    { cls: "br-edge", icon: "✓" },
       bias:    { cls: "br-bias", icon: "⚠" },
-      warning: { cls: "br-warn", icon: "🚩" },
+      warning: { cls: "br-warn", icon: "" },
     };
     document.getElementById("br-points").innerHTML = (br.points || []).map(p => {
       const tm = tagMeta[(p.tag || "").toLowerCase()] || { cls: "br-bias", icon: "·" };
@@ -2919,7 +2919,7 @@
       </div>
       ${chips ? `<div class="tr-chips">${chips}</div>` : ""}
       ${why ? `<div class="tr-note why">${esc(why)}</div>` : ""}
-      ${emo ? `<div class="tr-note emo">⚡ 当时情绪:${esc(emo)}${d.emotionNote ? " — " + esc(d.emotionNote) : ""}</div>` : ""}
+      ${emo ? `<div class="tr-note emo">当时情绪:${esc(emo)}${d.emotionNote ? " — " + esc(d.emotionNote) : ""}</div>` : ""}
       ${t.note ? `<div class="tr-note">${esc(t.note)}</div>` : ""}`;
     }
 
@@ -3083,7 +3083,7 @@
     if (dm && dm.decisiveness_pct != null)
       bits.push(`辩论决断率 ${dm.decisiveness_pct}%`);
     if (bits.length) el.insertAdjacentHTML("afterbegin",
-      `<div style="font-size:11px;opacity:.75;margin-bottom:var(--space-2)">🎯 ${bits.join(" · ")}</div>`);
+      `<div style="font-size:11px;opacity:.75;margin-bottom:var(--space-2)">${bits.join(" · ")}</div>`);
   }
 
   // =========================================================


### PR DESCRIPTION
## 背景

kcn:「动画可以看着加保持高级感,原来的 dashboard ai味儿太重了」。

## 去 AI 味(ui-ux-pro-max: no emoji as icons)

- hero 速读 chips / risk-alerts / anomaly / 杠杆制度 / bear points 的图标 emoji(🎯⚡📈📅🚩🔥🛑🧭📐…)全部移除,icon 槽改 **7px 语义圆点**,颜色跟随状态类(红/黄/绿/蓝)—— Linear/Apple 式 status dot
- 文案装饰 emoji(✅ 无 / 📐 牌面背书 / 📍 触发线 / ⛔ 砍杠杆 / 👀 观察)清理
- 保留:数据健康 🟢🔴🟡(语义状态点)、✓/⚠(排版符号)、叙事内容里的 🧭(LLM 文案非 UI 图标)

## 高级感动画(apple-design + emil 频率门,全部 transform/opacity)

- tab 激活指示器:150ms scaleX 生长(高频操作 → 近不可感知,状态指示)
- desk rail 展开:240ms 淡入+上移(偶尔触发 → 空间一致性)
- 卡片 hover:桌面 fine-pointer 下 -2px 轻抬 + 阴影加深(150ms,GPU only)
-  全局闸已覆盖;新增动画全是 transform/opacity

## 验证

-  exit 0、parity 10/10、payload 16/16、brand 5/5
- DOM 实证:chips 渲染为 7px 色点、无图标 emoji 残留