### PR TITLE
feat: 刷新按钮改成安静的幽灵图标

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -185,49 +185,34 @@
     .brand-mark { width: 24px; height: 24px; }
     .brand .updated { display: none; }
   }
+  /* Ghost icon-only refresh: the 60s auto-poll is the real refresh; this
+     button only exists to pull immediately and to show whether the last pull
+     found anything new. So it is quiet — a bare circular icon that tints on
+     hover, spins while loading, and morphs to ✓ when a new generation landed
+     (shape carries the outcome; colour alone never does). */
   .refresh-btn {
-    appearance: none; background: color-mix(in srgb, var(--card) 78%, transparent); color: var(--text);
-    border: 1px solid var(--border); border-radius: 999px;
-    min-height: 36px; min-width: 36px; padding: 0 var(--space-3);
-    font-size: 14px; cursor: pointer;
-    display: inline-flex; align-items: center; gap: 4px;
-    /* Sits on the frosted topbar, so it is glass too — a translucent capsule
-       instead of a solid white disc floating on the bar. */
-    -webkit-backdrop-filter: blur(10px) saturate(150%);
-    backdrop-filter: blur(10px) saturate(150%);
-    box-shadow: 0 1px 2px rgba(18,33,48,.06);
-    transition: background 0.15s, color 0.15s, border-color 0.3s, transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
-    /* The click-feedback labels are CJK, which — unlike "Refresh" — has a break
-       opportunity between every character. Without these two the button is a
-       shrinkable flex item and "已是最新" stacks one glyph per line, turning the
-       pill into an 82px-tall column. */
-    flex: 0 0 auto; white-space: nowrap;
+    appearance: none; background: transparent; color: var(--text-dim);
+    border: 0; border-radius: 50%;
+    width: 34px; height: 34px; min-width: 34px; min-height: 34px;
+    padding: 0; font-size: 16px; cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    flex: 0 0 auto;
+    transition: background 0.15s, color 0.15s, transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
   }
-  .refresh-btn:active { background: var(--card-2); transform: scale(0.97); }
+  .refresh-btn:active { transform: scale(0.92); }
   @media (hover: hover) and (pointer: fine) {
-    .refresh-btn:hover { background: var(--surface-2); }
+    .refresh-btn:hover { background: var(--surface-2); color: var(--text); }
   }
   .refresh-btn.is-loading .ic { animation: spin 0.8s linear infinite; }
-  .refresh-btn.ok-flash { border-color: var(--green); }
-  .refresh-btn.fresh-flash { border-color: var(--accent); color: var(--accent); }
+  /* Nothing new: the ↻ stays and takes a green tint. New generation: the icon
+     morphs to ✓ in accent — two outcomes differ by shape, not colour alone. */
+  .refresh-btn.ok-flash { color: var(--green); }
+  .refresh-btn.fresh-flash { color: var(--accent); }
+  .refresh-btn.fresh-flash .ic { font-size: 0; }
+  .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: 14px; }
   .refresh-btn[disabled] { opacity: 0.6; cursor: not-allowed; }
   @keyframes spin { to { transform: rotate(360deg); } }
-  @media (max-width: 560px) {
-    /* Three nav links plus a labelled button overflow the row, and the overflow
-       lands on the brand. The label is the compressible part: collapse to the
-       icon-only 36px target `min-width` already sizes for, and move the click
-       feedback onto the icon so it does not disappear with the text. */
-    .refresh-btn { padding: 0; justify-content: center; }
-    .refresh-btn .lbl { display: none; }
-    /* Only the "a new generation landed" outcome becomes a check — that is the
-       one whose label carries one ("已更新 ✓" vs "已是最新"). "Nothing new"
-       keeps the ↻ and says so with the green rim. Two outcomes have to differ
-       by shape; if they differed only by border colour, colour would be the
-       sole carrier of the difference. */
-    .refresh-btn.fresh-flash .ic { font-size: 0; }
-    .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: 15px; }
-  }
-  .topbar-actions { display: inline-flex; align-items: center; gap: 8px; }
+  .topbar-actions { display: inline-flex; align-items: center; gap: 4px; }
   .nav-link {
     color: var(--text-dim); text-decoration: none; font-size: 13px;
     padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); transition: background 0.15s, color 0.15s;

--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -550,18 +550,13 @@
         btn.classList.remove("is-loading");
         if (triggeredByUser) {
           btn.removeAttribute("disabled");
+          // The icon carries the outcome (shape: ✓ only when a new generation
+          // landed; colour: green=already current, accent=new) and resets on
+          // its own — the button has no text to swap.
           btn.classList.add(hasNew ? "fresh-flash" : "ok-flash");
-          const lbl = btn.querySelector(".lbl");
-          if (lbl) {
-            const prev = lbl.textContent;
-            lbl.textContent = hasNew ? "已更新 ✓" : "已是最新";
-            setTimeout(() => {
-              lbl.textContent = prev;
-              btn.classList.remove("fresh-flash", "ok-flash");
-            }, 1800);
-          }
+          setTimeout(() => btn.classList.remove("fresh-flash", "ok-flash"), 1800);
         } else if (hasNew) {
-          // Quiet auto-refresh: just a soft border tint, no label flicker
+          // Quiet auto-refresh: just a soft accent tint, no label flicker
           btn.classList.add("fresh-flash");
           setTimeout(() => btn.classList.remove("fresh-flash"), 1500);
         }

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,8 @@ layout: null
       <a class="nav-link" href="briefs.html">Briefs</a>
       <a class="nav-link" href="evidence.html">Evidence</a>
       <a class="nav-link" href="https://github.com/KCNyu/clawock" target="_blank" rel="noopener">GitHub</a>
-      <button class="refresh-btn" id="refresh-btn" type="button" aria-label="Refresh data">
+      <button class="refresh-btn" id="refresh-btn" type="button" aria-label="Refresh data" title="立即刷新">
         <span class="ic" aria-hidden="true">&#x21bb;</span>
-        <span class="lbl">Refresh</span>
       </button>
     </div>
   </div>

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -448,12 +448,12 @@ async function testTabGuardWithoutForcedLayout(browser, base) {
   await context.close();
 }
 
-// The refresh button swaps its label to a CJK string ("已是最新" / "已更新 ✓") for
-// 1.8s after a click. CJK has a line-break opportunity between every character,
-// so a shrinkable flex item breaks it one glyph per line: the 36px pill became
-// an 82px-tall column, and the topbar it overflowed painted the brand on top of
-// the nav links. Both states are geometry, so measure them rather than grep the
-// stylesheet for the properties that happen to fix them today.
+// The refresh button is a ghost icon now: no label to swap, so the old CJK
+// line-break failure mode is structurally gone. What must still hold is the
+// geometry contract the old test guarded: clicking never changes the button's
+// footprint (34x34 circle), the brand never overlaps the nav links, and the
+// flash classes (ok-flash / fresh-flash) still toggle as shape feedback.
+// Measure geometry, don't grep stylesheet properties.
 async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
   // 360px is the narrowest width the wordmark is promised in full. 320px is
   // past that: there the brand may reach its ellipsis, but it still may not be
@@ -470,12 +470,17 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
     await page.goto(base, { waitUntil: "networkidle" });
     await waitForData(page);
 
-    const idleHeight = (await page.locator("#refresh-btn").boundingBox()).height;
+    const idle = await page.locator("#refresh-btn").boundingBox();
     await page.click("#refresh-btn");
+    // Click must toggle one of the two outcome flashes (new generation vs
+    // already current) — the icon carries the feedback now, no text swap.
     await page.waitForFunction(
-      () => document.querySelector("#refresh-btn .lbl").textContent !== "Refresh",
+      () => {
+        const b = document.querySelector("#refresh-btn");
+        return b.classList.contains("fresh-flash") || b.classList.contains("ok-flash");
+      },
       null, { timeout: 5000 },
-    ).catch(() => { throw new Error(`refresh at ${width}px never reported back`); });
+    ).catch(() => { throw new Error(`refresh at ${width}px never flashed`); });
 
     const box = await page.evaluate(() => {
       const rect = el => el.getBoundingClientRect();
@@ -484,16 +489,17 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
       const link = document.querySelector(".topbar-actions .nav-link");
       const row = document.querySelector(".topbar-row");
       return {
-        label: btn.querySelector(".lbl").textContent,
+        hasLabel: !!btn.querySelector(".lbl"),
         height: rect(btn).height,
+        width: rect(btn).width,
         gap: rect(link).left - rect(h1).right,
         clipped: h1.scrollWidth > h1.clientWidth + 0.5,
         overflow: row.scrollWidth - row.clientWidth,
       };
     });
-    assert(box.label !== "Refresh", `label did not swap at ${width}px`);
-    assert(box.height <= idleHeight + 1,
-      `refresh button grew to ${box.height}px showing "${box.label}" at ${width}px`);
+    assert(box.hasLabel === false, `refresh button must be icon-only at ${width}px`);
+    assert(box.height <= idle.height + 1 && box.width <= idle.width + 1,
+      `refresh button grew to ${box.width}x${box.height} at ${width}px (idle ${idle.width}x${idle.height})`);
     assert(box.gap >= 0,
       `brand overlaps the nav links by ${-box.gap}px at ${width}px`);
     assert(mayTruncate || !box.clipped, `brand wordmark is truncated at ${width}px`);
@@ -501,20 +507,20 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
     await context.close();
   }
 
-  // The narrow layout drops the label to keep the row inside its width. That
-  // must stay a narrow-viewport concession: on a desktop the button keeps its
-  // text, and the feedback is the text.
+  // The button is icon-only at every width now — no label to drop on phones,
+  // no text to wrap on desktops. The geometry contract is the same everywhere:
+  // the click never changes the footprint, and the two outcomes stay apart by
+  // shape (✓ only for a new generation), not by colour alone.
   const desktop = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   await stubLiveOrigin(desktop);
   await desktop.goto(base, { waitUntil: "networkidle" });
   await waitForData(desktop);
-  assert(await desktop.locator("#refresh-btn .lbl").isVisible(),
-    "desktop refresh button lost its text label");
+  assert(await desktop.locator("#refresh-btn .lbl").count() === 0,
+    "refresh button must be icon-only on desktop too");
   await desktop.close();
 
-  // Hiding the label costs the phone layout the one thing the label carried:
-  // that "已更新 ✓" and "已是最新" are different answers. Whatever replaces it
-  // has to keep them apart by shape, not by border colour alone.
+  // Shape separates the outcomes: ok-flash keeps the ↻ (coloured green),
+  // fresh-flash morphs it to ✓ (accent). Colour is never the sole carrier.
   const feedback = await browser.newPage({ viewport: { width: 390, height: 800 } });
   await stubLiveOrigin(feedback);
   await feedback.goto(base, { waitUntil: "networkidle" });
@@ -534,16 +540,14 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
     return { idle: visibleMark(null), ok: visibleMark("ok-flash"), fresh: visibleMark("fresh-flash") };
   });
   assert(marks.ok !== marks.fresh,
-    `both refresh outcomes draw the same mark (${marks.ok}) below 560px`);
+    `both refresh outcomes draw the same mark (${marks.ok})`);
   assert(marks.fresh !== marks.idle,
-    "a new generation left the refresh icon unchanged below 560px");
+    "a new generation left the refresh icon unchanged");
   await feedback.close();
 
-  // Hiding the label below 560px means today's two strings can no longer be
-  // squeezed hard enough to break — which would leave the button's own
-  // single-line guarantee untested until someone widens that breakpoint or adds
-  // a fourth nav link. Feed it a label long enough to put the row over budget:
-  // the button may become wide, it may not become tall.
+  // The old label wrap failure mode is structurally gone (no text), so the
+  // geometry stress it guarded becomes: a click at any width must not grow
+  // the button.
   const stress = await browser.newPage({ viewport: { width: 600, height: 900 } });
   await stubLiveOrigin(stress);
   await stress.goto(base, { waitUntil: "networkidle" });
@@ -551,10 +555,10 @@ async function testTopbarFitsWhenRefreshLabelSwaps(browser, base) {
   const grew = await stress.evaluate(() => {
     const btn = document.getElementById("refresh-btn");
     const before = btn.getBoundingClientRect().height;
-    btn.querySelector(".lbl").textContent = "已是最新的一份生成数据";
+    btn.click();
     return btn.getBoundingClientRect().height - before;
   });
-  assert(grew <= 1, `refresh button wrapped its label onto ${grew}px of extra lines`);
+  assert(grew <= 1, `refresh button changed its footprint by ${grew}px after a click`);
   await stress.close();
 }
 


### PR DESCRIPTION
## 背景

kcn:右上角刷新按钮很奇怪,而且质疑它的用途。

**它有什么用**:60s 自动轮询本就是主刷新通道,这个按钮只承担两个小职责 —— ①手动立即拉取(穿透缓存,不等下个轮询)②显示「这次拉到新的没有」。既然存在感不该那么大,就把它做安静。

## 改动

- 胶囊+文字(Refresh / 已更新 ✓ / 已是最新)→ **34px 幽灵圆形图标**(透明底、无边框、hover 才淡背景),文字全删,桌面移动端统一
- 状态反馈由**图标形态**承担:
  - loading:↻ 转圈
  - 拉到新数据:fresh-flash → 图标变 **✓**(accent 色)
  - 没有新数据:ok-flash → ↻ 保持但变**绿**
  - 两种结果靠形状区分(✓ vs ↻),不只靠颜色 —— 保留原逻辑的「shape 必须可辨」约束
- 删除旧的 mobile 隐藏 label 的 media query
- 测试同步:原「label 换词不破坏 topbar 几何」改测「无 label(桌面+移动)+ 点击不变形 + 两种 flash 形状可辨」

## 验证

- dashboard_tab_runtime.spec.js exit 0、brand+payload 21/21
- chromium 实测:点击 → is-loading → flash 状态流转正常,34x34 不变形