### PR TITLE
dashboard 重排：首屏口径修正 + 数据健康提到首屏 + 47 张卡合并到 25 (#871-#877)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -57,7 +57,13 @@
     --space-6: 32px;
     --font: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
     --mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-  }
+  
+  /* 动效 tokens（#873）：全站 transition 只引用这四个，禁裸曲线 */
+  --ease-out: cubic-bezier(.23, 1, .32, 1);
+  --ease-in-out: cubic-bezier(.77, 0, .175, 1);
+  --duration-fast: 150ms;
+  --duration-standard: 240ms;
+}
   @media (prefers-color-scheme: light) {
     :root {
       --bg: #F3F6F9;
@@ -197,7 +203,7 @@
     padding: 0; font-size: 16px; cursor: pointer;
     display: inline-flex; align-items: center; justify-content: center;
     flex: 0 0 auto;
-    transition: background 0.15s, color 0.15s, transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: background var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out);
   }
   .refresh-btn:active { transform: scale(0.92); }
   @media (hover: hover) and (pointer: fine) {
@@ -243,7 +249,7 @@
     padding: var(--space-3) var(--space-4); min-height: 44px;
     font-size: 14px; font-weight: 500; cursor: pointer;
     white-space: nowrap;
-    transition: color 0.15s, background 0.15s, transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: color var(--duration-fast) ease, background var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out);
   }
   .tab-btn:active { transform: scale(0.97); }
   .tab-btn.active { color: var(--text); }
@@ -306,7 +312,7 @@
     gap: 5px; appearance: none; background: transparent; color: var(--text-dim);
     border: none; border-radius: var(--radius-sm); padding: 5px 11px; min-height: 30px;
     font-size: 12px; font-weight: 600; line-height: 1; cursor: pointer;
-    white-space: nowrap; transition: background .12s, color .12s, transform .16s cubic-bezier(.23, 1, .32, 1); }
+    white-space: nowrap; transition: background var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out); }
   .mkt-seg-btn:active { transform: scale(0.97); }
   /* iOS-style raised pill for the active segment → colored dots stay visible */
   .mkt-seg-btn.active { background: var(--card); color: var(--text); }
@@ -513,7 +519,7 @@
     box-shadow: var(--shadow-card);
     padding: var(--space-4);
     margin-bottom: var(--gap);
-    transition: transform 150ms cubic-bezier(.23,1,.32,1);
+    transition: transform var(--duration-fast) var(--ease-out);
   }
   @media (hover: hover) and (pointer: fine) {
     .panel.active > .card:hover {
@@ -836,25 +842,12 @@
   .lev-tickers { margin-top: 8px; font-size: 11px; }
 
   /* Today's range bars */
-  .range-list { display: flex; flex-direction: column; gap: 8px; }
-  .range-row { display: grid; grid-template-columns: 60px 1fr auto; gap: 8px; align-items: center; font-size: 12px; }
-  .range-row .tk { font-weight: 600; font-family: ui-monospace, "Menlo", monospace; }
-  .range-bar { height: 8px; background: var(--card-2); border-radius: 4px; position: relative; overflow: hidden; }
+        .range-bar { height: 8px; background: var(--card-2); border-radius: 4px; position: relative; overflow: hidden; }
   .range-bar > .fill { position: absolute; left: 0; top: 0; bottom: 0; background: linear-gradient(90deg, var(--green), var(--red)); opacity: 0.5; }
   .range-bar > .dot { position: absolute; top: -2px; width: 4px; height: 12px; background: var(--text); border-radius: 2px; }
-  .range-row .val { font-variant-numeric: tabular-nums; color: var(--text-dim); font-size: 11px; min-width: 50px; text-align: right; }
-
+  
   /* Extremes (winners/losers) */
-  .extremes-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-  .extremes-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; margin-bottom: 8px; }
-  .extremes-list { display: flex; flex-direction: column; gap: var(--space-2); }
-  .extremes-row {
-    display: flex; justify-content: space-between; align-items: center;
-    padding: var(--space-2) var(--space-3); background: var(--card-2); border-radius: var(--radius-sm);
-    font-variant-numeric: tabular-nums; font-size: 13px;
-  }
-  .extremes-row .tk { font-weight: 600; font-family: ui-monospace, "Menlo", monospace; }
-
+          
   /* Today's P&L cards */
   .today-pnl-grid {
     display: grid; grid-template-columns: 1fr 1fr; gap: 0;
@@ -915,7 +908,7 @@
   .mkt-comp-row .lbl { color: var(--text-dim); }
   .mkt-comp-row .v { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
   .mkt-bar { height: 7px; background: var(--card); border: 1px solid var(--border); border-radius: 4px; overflow: hidden; }
-  .mkt-bar-fill { height: 100%; width: 100%; border-radius: 3px; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1); }
+  .mkt-bar-fill { height: 100%; width: 100%; border-radius: 3px; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform var(--duration-standard) var(--ease-out); }
   .mkt-bar-fill.pos { background: var(--green); }
   .mkt-bar-fill.neg { background: var(--red); }
   .mkt-chips { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
@@ -1518,7 +1511,7 @@
     height: 8px; background: var(--card); border-radius: 4px; overflow: hidden;
     border: 1px solid var(--border);
   }
-  .dd-region .dd-bar-fill { height: 100%; width: 100%; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1); }
+  .dd-region .dd-bar-fill { height: 100%; width: 100%; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform var(--duration-standard) var(--ease-out); }
   .dd-region .dd-bar-fill.poor { background: var(--red); }
   .dd-region .dd-bar-fill.mid  { background: var(--amber); }
   .dd-region .dd-bar-fill.good { background: var(--green); }
@@ -1556,7 +1549,7 @@
     height: 8px; background: var(--card); border-radius: 4px; overflow: hidden;
     border: 1px solid var(--border); margin-top: var(--space-2);
   }
-  .ext-region .ext-dd .dd-bar-fill { height: 100%; width: 100%; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1); }
+  .ext-region .ext-dd .dd-bar-fill { height: 100%; width: 100%; transform: scaleX(var(--fill, 0)); transform-origin: left; transition: transform var(--duration-standard) var(--ease-out); }
   .ext-region .ext-dd .dd-bar-fill.poor { background: var(--red); }
   .ext-region .ext-dd .dd-bar-fill.mid  { background: var(--amber); }
   .ext-region .ext-dd .dd-bar-fill.good { background: var(--green); }
@@ -1828,7 +1821,7 @@
     position: absolute; left: 0; top: 0; bottom: 0; width: 100%;
     background: var(--accent);
     transform: scaleX(var(--fill, 0)); transform-origin: left;
-    transition: transform .3s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: transform var(--duration-standard) var(--ease-out);
   }
   .bucket-row .bar-fill.win { background: var(--green); }
   .bucket-row .bar-fill.followed { background: var(--accent); }
@@ -1910,8 +1903,10 @@
     background: linear-gradient(140deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 62%);
   }
   .hero-deck-pnl {
-    margin-top: 9px; color: var(--text); font: 760 clamp(34px, 3.4vw, 50px)/1 var(--mono);
-    letter-spacing: -.055em; font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+    margin-top: 9px; color: var(--text); font: 760 clamp(30px, 3.4vw, 50px)/1 var(--mono);
+    letter-spacing: -.055em; font-variant-numeric: tabular-nums;
+    /* 大数字禁断行（#111 教训，#872 明确列为验收项）：宁可缩字号也不折行 */
+    white-space: nowrap;
   }
   .hero-deck-sub {
     margin-top: 11px; color: var(--text-secondary); font: 500 12.5px/1.55 var(--mono);
@@ -1961,7 +1956,7 @@
     margin-left: auto; flex: none; padding: 6px 12px; border-radius: 8px;
     border: 1px solid var(--border-subtle); background: var(--surface-1);
     color: var(--text-secondary); font: 600 11px/1 var(--mono); cursor: pointer;
-    transition: transform .14s cubic-bezier(.23,1,.32,1), color .14s ease, border-color .14s ease;
+    transition: transform var(--duration-fast) var(--ease-out), color var(--duration-fast) ease, border-color var(--duration-fast) ease;
   }
   .dh-toggle:active { transform: scale(.97); }
   @media (hover: hover) and (pointer: fine) {
@@ -2032,7 +2027,7 @@
     letter-spacing: .04em; padding: 2px 0;
   }
   .chart-note > summary::-webkit-details-marker { display: none; }
-  .chart-note > summary::after { content: " ›"; display: inline-block; transition: transform .18s cubic-bezier(.23,1,.32,1); }
+  .chart-note > summary::after { content: " ›"; display: inline-block; transition: transform var(--duration-fast) var(--ease-out); }
   .chart-note[open] > summary::after { transform: rotate(90deg); }
   @media (hover: hover) and (pointer: fine) { .chart-note > summary:hover { color: var(--text-secondary); } }
   .chart-note > p {
@@ -2261,7 +2256,7 @@
   .panel, .card, .card > *, .status-banner .sb-text,
   .risk-alert > div, .anomaly .detail, .market-cell,
   .kpi-cell, .risk-cell, .lev-cell, .hhi-card,
-  .mkt-card, .extremes-grid > *, .macro-row > *,
+  .mkt-card,   .mkt-card, .macro-row > *,
   .plan-action > *, .catalyst-row > *, .pd-top > *,
   .sd-row summary > *, .dd-region .dd-cell,
   .card [style*="display:flex"] > * {
@@ -2388,7 +2383,7 @@
   display: grid;
   grid-template-rows: 0fr;
   opacity: 0;
-  transition: grid-template-rows .24s cubic-bezier(.22,1,.36,1), opacity .15s ease;
+  transition: grid-template-rows var(--duration-standard) var(--ease-out), opacity .15s ease;
 }
 .tr-row[open]::details-content {
   grid-template-rows: 1fr;
@@ -2467,3 +2462,100 @@
   #trace-stats { gap: 4px 14px; }
   #trace-stats > span { flex: 1 1 100%; }
 }
+
+  /* ── 持仓主表：行展开 = 这只票的全部证据（#875）────────────── */
+  .book-table tbody tr.book-row { cursor: pointer; transition: background var(--duration-fast) ease; }
+  .book-table tbody tr.book-row:active > td { background: color-mix(in srgb, var(--text) 7%, transparent); }
+  @media (hover: hover) and (pointer: fine) {
+    .book-table tbody tr.book-row:hover > td { background: color-mix(in srgb, var(--text) 4%, transparent); }
+  }
+  .book-table tbody tr.book-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .book-caret {
+    display: inline-block; margin-left: 5px; color: var(--text-tertiary); font-size: 13px;
+    opacity: .4; transition: transform var(--duration-standard) var(--ease-out), opacity var(--duration-fast) ease;
+  }
+  .book-row[data-open="1"] .book-caret { transform: rotate(90deg); opacity: 1; }
+  .book-table tbody tr.book-detail > td { padding: 0; border-bottom: 0; background: none; }
+  .book-detail[data-open="1"] > td { border-bottom: 1px solid var(--border-subtle); }
+  .bd-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--duration-standard) var(--ease-out); }
+  .book-detail[data-open="1"] .bd-wrap { grid-template-rows: 1fr; }
+  .bd-inner { overflow: hidden; min-height: 0; }
+  .bd-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(198px, 1fr));
+    gap: 0 26px; padding: 6px 0 16px;
+  }
+  .bd-col { padding: 8px 0; min-width: 0; }
+  .bd-k {
+    color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
+    letter-spacing: .09em; text-transform: uppercase; margin-bottom: 7px;
+  }
+  .bd-kv {
+    display: flex; justify-content: space-between; gap: 12px; padding: 4px 0;
+    border-bottom: 1px solid var(--border-subtle); font: 500 11.5px/1.4 var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .bd-kv:last-child { border-bottom: 0; }
+  .bd-kv .k { color: var(--text-tertiary); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .bd-kv .v { color: var(--text); white-space: nowrap; text-align: right; }
+  .bd-kv .v.pos { color: var(--positive); }
+  .bd-kv .v.neg { color: var(--negative); }
+  .bd-note {
+    color: var(--text-tertiary); font: 500 11px/1.55 var(--mono); padding: 4px 0;
+    overflow-wrap: anywhere; word-break: break-word;
+  }
+  .bd-note.neg { color: var(--negative); }
+  .bd-empty { color: var(--text-tertiary); font: 500 11.5px/1.5 var(--mono); padding: 8px 0 16px; }
+  .bd-pos { padding: 8px 0 2px; }
+  .bd-pos-lbl { display: block; color: var(--text-tertiary); font: 500 10.5px/1.3 var(--mono); margin-bottom: 6px; }
+  .bd-pos-track {
+    position: relative; display: block; height: 4px; border-radius: 2px;
+    background: color-mix(in srgb, var(--text) 12%, transparent);
+  }
+  .bd-pos-track i {
+    position: absolute; top: -3px; width: 3px; height: 10px; border-radius: 2px;
+    background: var(--text); transform: translateX(-50%);
+  }
+  .bd-pos-ends {
+    display: flex; justify-content: space-between; margin-top: 5px;
+    color: var(--text-tertiary); font: 500 10px/1.3 var(--mono);
+  }
+
+  /* 合并卡内部的分节（组合结构 / 今日异动）*/
+  .sub-block + .sub-block { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--border-subtle); }
+  .sub-block-head {
+    color: var(--text); font: 700 12px/1.4 var(--font, inherit); margin-bottom: 10px;
+  }
+  .sub-block-head .muted { font-weight: 500; font-size: 10.5px; letter-spacing: 0; }
+  .action-split { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 24px; }
+  .action-split .sub-block + .sub-block { margin-top: 0; padding-top: 0; border-top: 0; }
+  @media (max-width: 900px) {
+    .action-split { grid-template-columns: minmax(0, 1fr); }
+    .action-split .sub-block + .sub-block { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--border-subtle); }
+    .book-table th.col-p2, .book-table td.col-p2 { display: none; }
+  }
+  @media (max-width: 560px) {
+    .book-table th.col-p3, .book-table td.col-p3 { display: none; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .bd-wrap, .book-caret { transition: none; }
+  }
+
+  /* Add Campaign：全员同态时折成一行（#875）*/
+  .campaign-fold > summary {
+    cursor: pointer; list-style: none; padding: 8px 0;
+    color: var(--text-secondary); font: 600 12px/1.4 var(--mono);
+    display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+  }
+  .campaign-fold > summary::-webkit-details-marker { display: none; }
+  .campaign-fold > summary::after {
+    content: "›"; color: var(--text-tertiary); font-size: 14px;
+    transition: transform var(--duration-fast) var(--ease-out);
+  }
+  .campaign-fold[open] > summary::after { transform: rotate(90deg); }
+  @media (hover: hover) and (pointer: fine) {
+    .campaign-fold > summary:hover { color: var(--text); }
+  }
+  .campaign-fold-names {
+    color: var(--text-tertiary); font: 500 11px/1.4 var(--mono);
+    min-width: 0; overflow-wrap: anywhere;
+  }

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1899,86 +1899,124 @@
     color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
     letter-spacing: .09em; text-transform: uppercase;
   }
-  .overview-book {
-    grid-column: span 5; min-height: 226px; overflow: hidden;
-    background:
-      linear-gradient(140deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 55%),
-      var(--surface-1);
+  /* 首屏指挥台：一个主数 + 一条统计轨，取代原来的 book / today / discipline
+     三张不等重的卡。(#874 #877) */
+  .hero-deck {
+    grid-column: 1 / -1; padding: 0; overflow: hidden;
+    display: grid; grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
   }
-  .overview-book-primary {
-    margin-top: 8px; color: var(--text); font: 760 clamp(32px, 3.2vw, 48px)/1 var(--mono);
+  .hero-deck-lead {
+    padding: 18px; border-right: 1px solid var(--border-subtle);
+    background: linear-gradient(140deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 62%);
+  }
+  .hero-deck-pnl {
+    margin-top: 9px; color: var(--text); font: 760 clamp(34px, 3.4vw, 50px)/1 var(--mono);
     letter-spacing: -.055em; font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
   }
-  .overview-book-secondary {
-    margin-top: 7px; color: var(--text-secondary); font: 650 clamp(16px, 1.7vw, 22px)/1.2 var(--mono);
+  .hero-deck-sub {
+    margin-top: 11px; color: var(--text-secondary); font: 500 12.5px/1.55 var(--mono);
     font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
   }
-  .overview-fx {
-    margin-top: 5px; color: var(--text-tertiary); font: 500 10px/1.3 var(--mono);
+  .hero-deck-sub b { font-weight: 700; color: var(--text); }
+  .hero-deck-fx {
+    margin-top: 7px; color: var(--text-tertiary); font: 500 10px/1.35 var(--mono);
     overflow-wrap: anywhere;
   }
-  .overview-fx-mirror { display: none; }
-  .overview-leg-grid {
-    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0; margin: 16px -16px -16px; border-top: 1px solid var(--border-subtle);
+  .hero-rail { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .hero-rail-cell {
+    min-width: 0; padding: 13px 14px;
+    border-right: 1px solid var(--border-subtle); border-bottom: 1px solid var(--border-subtle);
   }
-  .overview-leg {
-    min-width: 0; padding: 11px 16px; border-right: 1px solid var(--border-subtle);
+  .hero-rail-cell:nth-child(4n) { border-right: 0; }
+  .hero-rail-cell:nth-last-child(-n+4) { border-bottom: 0; }
+  .hero-rail-k {
+    color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
+    letter-spacing: .09em; text-transform: uppercase;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .overview-leg:last-child { border-right: 0; }
-  .overview-leg .lbl,
-  .overview-today-cell .lbl {
-    color: var(--text-tertiary); font-size: 9.5px; font-weight: 700;
-    letter-spacing: .07em; text-transform: uppercase;
+  .hero-rail-v {
+    margin-top: 7px; color: var(--text); font: 750 clamp(15px, 1.45vw, 20px)/1.15 var(--mono);
+    letter-spacing: -.035em; font-variant-numeric: tabular-nums;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .overview-leg .val {
-    margin-top: 2px; color: var(--text); font: 700 clamp(15px, 1.5vw, 20px)/1.25 var(--mono);
-    font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+  .hero-rail-s {
+    margin-top: 5px; color: var(--text-tertiary); font: 500 10.5px/1.35 var(--mono);
+    font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .overview-leg .sub {
-    margin-top: 1px; font: 600 10.5px/1.35 var(--mono);
-    font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+
+  /* 数据健康：页脚那条 29px tooltip 提升为首屏一块。健康时只有一行判词 +
+     一条期限用量带；有问题才升级视觉权重。(#876) */
+  .hero-health { grid-column: 1 / -1; padding: 16px 18px 14px; }
+  .hero-health-head { display: flex; align-items: flex-start; gap: 14px; }
+  .hero-health-verdict {
+    margin: 6px 0 0; color: var(--text); font-size: 15px;
+    letter-spacing: -.01em; text-transform: none;
   }
-  .overview-today {
-    grid-column: span 4; min-height: 226px;
-    display: flex; flex-direction: column;
+  .hero-health[data-tone="warn"] .hero-health-verdict { color: var(--warning); }
+  .hero-health[data-tone="bad"] .hero-health-verdict { color: var(--red); }
+  .hero-health-meta {
+    margin-top: 6px; color: var(--text-tertiary); font: 500 10.5px/1.45 var(--mono);
   }
-  .overview-today-grid {
-    flex: 1; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: stretch; margin-top: 14px; border-top: 1px solid var(--border-subtle);
+  .dh-toggle {
+    margin-left: auto; flex: none; padding: 6px 12px; border-radius: 8px;
+    border: 1px solid var(--border-subtle); background: var(--surface-1);
+    color: var(--text-secondary); font: 600 11px/1 var(--mono); cursor: pointer;
+    transition: transform .14s cubic-bezier(.23,1,.32,1), color .14s ease, border-color .14s ease;
   }
-  .overview-today-cell {
-    min-width: 0; padding: 20px 12px 12px 0; border-right: 1px solid var(--border-subtle);
+  .dh-toggle:active { transform: scale(.97); }
+  @media (hover: hover) and (pointer: fine) {
+    .dh-toggle:hover { color: var(--text); border-color: var(--text-tertiary); }
   }
-  .overview-today-cell + .overview-today-cell { padding-left: 14px; border-right: 0; }
-  .overview-today-cell .val {
-    margin-top: 9px; font: 750 clamp(19px, 2vw, 27px)/1.05 var(--mono);
-    letter-spacing: -.04em; font-variant-numeric: tabular-nums;
-    /* keep the signed currency figure on one line — never break mid-number */
-    white-space: nowrap;
+  .dh-strip {
+    display: flex; align-items: flex-end; gap: 5px; margin-top: 14px; flex-wrap: wrap;
+    padding-bottom: 7px; border-bottom: 1px solid var(--border-subtle);
   }
-  .overview-today-cell .pct {
-    margin-top: 6px; font: 650 12px/1.3 var(--mono);
-    font-variant-numeric: tabular-nums;
+  .dh-seg {
+    position: relative; flex: 0 0 auto; width: 13px; height: 32px;
+    border-radius: 3px; overflow: hidden;
+    background: color-mix(in srgb, var(--text) 6%, transparent);
   }
-  .overview-discipline {
-    grid-column: span 3; min-height: 226px;
-    display: grid; grid-template-rows: repeat(2, minmax(0, 1fr));
-    border: 1px solid var(--border-subtle); border-radius: 12px;
-    background: var(--surface-1); overflow: hidden;
+  .dh-seg i {
+    position: absolute; left: 0; right: 0; bottom: 0; height: var(--used, 40%);
+    background: color-mix(in srgb, var(--text) 38%, transparent);
+    border-radius: 3px;
   }
-  .overview-discipline-cell {
-    min-width: 0; padding: 15px; border-bottom: 1px solid var(--border-subtle);
+  .bs-dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--text-tertiary); vertical-align: middle; margin-right: 2px;
   }
-  .overview-discipline-cell:last-child { border-bottom: 0; }
-  .overview-discipline-value {
-    margin-top: 7px; color: var(--text); font: 750 clamp(22px, 2.4vw, 32px)/1 var(--mono);
-    letter-spacing: -.035em; font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
+  .bs-dot[data-tone="ok"] { background: var(--positive, var(--green)); }
+  .bs-dot[data-tone="warn"] { background: var(--warning); }
+  .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
+  .dh-caption {
+    margin-top: 8px; color: var(--text-tertiary); font: 500 10.5px/1.45 var(--mono);
   }
-  .overview-discipline-meta {
-    margin-top: 5px; color: var(--text-tertiary); font: 500 10px/1.35 var(--mono);
-    overflow-wrap: anywhere;
+  .dh-seg.is-late i { background: var(--warning); }
+  .dh-seg.is-missing i { background: var(--red); }
+  .dh-files { margin-top: 14px; border-top: 1px solid var(--border-subtle); }
+  .dh-row {
+    display: grid; align-items: center; gap: 12px; padding: 8px 0;
+    grid-template-columns: minmax(76px, auto) minmax(0, 1fr) 84px minmax(0, 1.3fr) 34px;
+    border-bottom: 1px solid var(--border-subtle);
+    font: 500 11.5px/1.35 var(--mono); font-variant-numeric: tabular-nums;
   }
+  .dh-row:last-child { border-bottom: 0; }
+  .dh-name { color: var(--text); font-weight: 700; white-space: nowrap; }
+  .dh-file, .dh-detail {
+    color: var(--text-tertiary); min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .dh-bar {
+    height: 4px; border-radius: 2px; overflow: hidden;
+    background: color-mix(in srgb, var(--text) 8%, transparent);
+  }
+  .dh-bar i { display: block; height: 100%; background: color-mix(in srgb, var(--text) 42%, transparent); }
+  .dh-row.is-late .dh-bar i, .dh-row.is-missing .dh-bar i { background: var(--warning); opacity: 1; }
+  .dh-row.is-missing .dh-bar i { background: var(--red); }
+  .dh-state { color: var(--text-tertiary); text-align: right; white-space: nowrap; }
+  .dh-row.is-late .dh-state { color: var(--warning); }
+  .dh-row.is-missing .dh-state { color: var(--red); }
+
   .overview-equity {
     grid-column: span 8; min-height: 480px; padding: 18px 18px 12px;
   }
@@ -1987,7 +2025,19 @@
     margin: 5px 0 0; color: var(--text); font-size: 17px;
     letter-spacing: -.01em; text-transform: none;
   }
-  .overview-equity-hint { max-width: 92%; margin: -3px 0 3px; }
+  .overview-equity-hint { max-width: 92%; margin: -2px 0 4px; }
+  .chart-note > summary {
+    display: inline-block; cursor: pointer; list-style: none;
+    color: var(--text-tertiary); font: 600 10.5px/1.4 var(--mono);
+    letter-spacing: .04em; padding: 2px 0;
+  }
+  .chart-note > summary::-webkit-details-marker { display: none; }
+  .chart-note > summary::after { content: " ›"; display: inline-block; transition: transform .18s cubic-bezier(.23,1,.32,1); }
+  .chart-note[open] > summary::after { transform: rotate(90deg); }
+  @media (hover: hover) and (pointer: fine) { .chart-note > summary:hover { color: var(--text-secondary); } }
+  .chart-note > p {
+    margin: 4px 0 2px; color: var(--text-tertiary); font: 500 11px/1.55 var(--mono);
+  }
   .overview-equity-chart { min-height: 390px; height: 390px; }
   /* The chart sits inside the mobile horizontal pager. Allow the browser to
      resolve both axes so a horizontal drag still changes tabs; pointercancel
@@ -2157,24 +2207,32 @@
   .hl-chip.hl-info  { border-color: var(--accent); color: var(--accent); }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .overview-book, .overview-today { grid-column: span 6; }
-    .overview-discipline {
-      grid-column: 1 / -1; min-height: 112px;
-      grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: none;
-    }
-    .overview-discipline-cell { border-right: 1px solid var(--border-subtle); border-bottom: 0; }
-    .overview-discipline-cell:last-child { border-right: 0; }
+    .hero-deck { grid-template-columns: minmax(0, 1fr); }
+    .hero-deck-lead { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); }
     .overview-equity, .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
   }
   @media (max-width: 767px) {
     .overview-command { display: flex; flex-direction: column; gap: 12px; }
-    .overview-book, .overview-today, .overview-discipline,
+    .hero-deck, .hero-health,
     .overview-equity, .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { width: 100%; min-width: 0; }
-    .overview-book, .overview-today, .overview-discipline { min-height: 0; }
+    .hero-deck { grid-template-columns: minmax(0, 1fr); }
+    .hero-deck-lead { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+    .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .hero-rail-cell:nth-child(4n) { border-right: 1px solid var(--border-subtle); }
+    .hero-rail-cell:nth-child(2n) { border-right: 0; }
+    .hero-rail-cell:nth-last-child(-n+4) { border-bottom: 1px solid var(--border-subtle); }
+    .hero-rail-cell:nth-last-child(-n+2) { border-bottom: 0; }
+    .dh-row {
+      grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
+    }
+    .dh-file { display: none; }
+    .dh-bar { grid-column: 1 / -1; }
+    .dh-detail { grid-column: 1 / -1; white-space: normal; }
     .overview-equity, .overview-verdict { min-height: 0; }
     .overview-equity-chart { min-height: 300px; height: 300px; }
     .overview-equity-hint { max-width: none; }
@@ -2190,12 +2248,11 @@
     .overview-command > .hero-gold-card { min-height: 760px; }
   }
   @media (max-width: 420px) {
-    .overview-book-primary { font-size: clamp(29px, 10vw, 38px); }
-    .overview-book-secondary { font-size: 17px; }
-    .overview-leg .val { font-size: 15px; }
-    .overview-today-cell .val { font-size: clamp(21px, 7.2vw, 28px); }
-    .overview-today-cell { padding-right: 8px; }
-    .overview-today-cell + .overview-today-cell { padding-left: 10px; }
+    .hero-deck-pnl { font-size: clamp(30px, 10.5vw, 40px); }
+    .hero-deck-sub { font-size: 12px; }
+    .hero-rail-v { font-size: 15px; }
+    .hero-rail-cell { padding: 11px 12px; }
+    .dh-seg { width: 11px; height: 26px; }
   }
 
   /* =========================================================

--- a/site/assets/js/dashboard.charts.js
+++ b/site/assets/js/dashboard.charts.js
@@ -449,6 +449,15 @@
 
       ctx.font = "10px " + (getCSS("--mono") || "monospace");
       ctx.textBaseline = "middle";
+      // 回撤轴的刻度步长随数据量级变化：minDd 只有 -1.4% 时，5 个刻度用
+      // toFixed(0) 会压成 0% / -0% / -1% / -1% / -1%（实测线上就是这样）。
+      // 精度跟着步长走，并把 -0 归零。
+      const ddStep = Math.abs(minDd) / 4;
+      const ddDigits = ddStep >= 1 ? 0 : ddStep >= 0.2 ? 1 : 2;
+      const ddLabel = v => {
+        const snapped = Math.abs(v) < Math.pow(10, -ddDigits) / 2 ? 0 : v;
+        return snapped.toFixed(ddDigits) + "%";
+      };
       for (let i = 0; i <= 4; i++) {
         const y = top + i * plotH / 4;
         const value = maxMoney - i * (maxMoney - minMoney) / 4;
@@ -462,7 +471,7 @@
         ctx.textAlign = "right";
         ctx.fillText(moneyAxis(value, model.cur), left - 7, y);
         ctx.textAlign = "left";
-        ctx.fillText((i * minDd / 4).toFixed(0) + "%", width - right + 7, y);
+        ctx.fillText(ddLabel(i * minDd / 4), width - right + 7, y);
       }
 
       const labelCount = Math.min(5, dates.length);

--- a/site/assets/js/dashboard.core.js
+++ b/site/assets/js/dashboard.core.js
@@ -50,6 +50,11 @@
     </svg>`;
   }
 
+  // 数据串里混进来的 emoji（硬闸 directive 的 ⛔🧭、体检的 🔴🟡）一律不渲染：
+  // 状态由文字和颜色承担，emoji 只会把面板拉回「AI 生成」的观感。(#869 #874)
+  const EMOJI_RE = /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/gu;
+  const stripEmoji = (s) => String(s == null ? "" : s).replace(EMOJI_RE, "").replace(/\s{2,}/g, " ").trim();
+
   const escapeHtml = (s) => String(s == null ? "" : s)
     .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;").replace(/'/g, "&#39;");

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -679,6 +679,9 @@
     subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
       + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
       + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
+      // 账面的 HKD 等值：原来 Total book 卡的第二行，合并后仍要留着
+      + ((fx && has(us.value_usd) && has(hk.value_hkd))
+        ? ` <span class="muted">/ ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}</span>` : "")
       + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
       + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
@@ -694,6 +697,10 @@
       }
     }
 
+    // 分腿的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
+    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
+    const usTodayPct = legPct(us.value_usd, us.today_change_usd);
+    const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
@@ -704,14 +711,20 @@
         `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
       cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
         `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
-      cell("今日 US", heroMoney(us.today_change_usd, "USD"), "美股腿", pnlClass(us.today_change_usd)),
-      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"), "港股腿", pnlClass(hk.today_change_hkd)),
+      cell("今日 US", heroMoney(us.today_change_usd, "USD"),
+        `美股腿${usTodayPct == null ? "" : " · " + fmtPct(usTodayPct)}`, pnlClass(us.today_change_usd)),
+      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"),
+        `港股腿${hkTodayPct == null ? "" : " · " + fmtPct(hkTodayPct)}`, pnlClass(hk.today_change_hkd)),
       cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
       cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
-        `主动 call · n=${ae.known == null ? DASH : ae.known}`),
+        // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
+        // 会高估这个比率覆盖了多少记录，所以两个数一起给。
+        `主动 call · n=${ae.known == null ? DASH : ae.known}`
+        + (ae.stranded ? ` · ${ae.stranded} 未能核验` : "")),
       cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
-        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`,
+        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`
+        + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
         m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
     ].join("");
   }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -324,7 +324,7 @@
   // registry mutable avoids parsing 100KB+ of functions that Overview cannot call.
   const TAB_RENDERERS = {
     hero: [
-      renderTotals, renderTodayPnl, renderRiskGuardrail, renderOverviewSummaries,
+      renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
       renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
     ],
   };
@@ -437,18 +437,18 @@
     const artifactOnly = wfCounts.artifact_only || 0;
     let dot, label;
     if ((wfCounts.failed || 0) > 0) {
-      dot = '🔴'; label = `成品流程 ${wfCounts.failed} FAILED`;
+      dot = 'bad'; label = `成品流程 ${wfCounts.failed} FAILED`;
     }
-    else if (ig.error_count > 0) { dot = '🔴'; label = `体检 ${ig.error_count} ERROR`; }
+    else if (ig.error_count > 0) { dot = 'bad'; label = `体检 ${ig.error_count} ERROR`; }
     else if (stale.length || ig.warn_count > 0 || recovered || artifactOnly) {
-      dot = '🟡';
+      dot = 'warn';
       const bits = [];
       if (stale.length) bits.push(`${stale.length} 文件 stale`);
       if (ig.warn_count > 0) bits.push(`体检 ${ig.warn_count} WARN`);
       if (recovered) bits.push(`${recovered} 成品恢复/降级`);
       if (artifactOnly) bits.push(`${artifactOnly} 仅产物未确认投递`);
       label = bits.join(' · ');
-    } else { dot = '🟢'; label = '数据健康 · 体检 ✓'; }
+    } else { dot = 'ok'; label = '数据健康 · 体检通过'; }
     if (wf.raw_error_but_product_usable) {
       label += ` · ${wf.raw_error_but_product_usable} 执行红/成品可用`;
     }
@@ -467,7 +467,7 @@
       }
       else lines.push(`${f.stale ? '⚠' : '·'} ${f.name}  ${f.age_hours}h / SLA ${f.sla_hours}h`);
     });
-    (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '🔴' : '🟡'} ${t.code}: ${t.msg}`));
+    (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '[ERROR]' : '[WARN]'} ${t.code}: ${stripEmoji(t.msg)}`));
     if (bs.markets) {
       Object.entries(bs.markets).forEach(([m, v]) =>
         lines.push(`${m.toUpperCase()}: 行情会话 ${quoteSessionLabel(v)}${v.closed_today ? ' (休市)' : ''}`));
@@ -483,7 +483,7 @@
       lines.push(`流程 ${r.job} ${slot}: 执行=${raw} / 成品=${final}${readabilityDetail}`);
     });
     const gen = bs.generated_at ? bs.generated_at.replace('T', ' ').slice(0, 16) : '';
-    el.innerHTML = `<span class="bs-dot">${dot}</span> <span class="bs-label">${label}</span>` +
+    el.innerHTML = `<span class="bs-dot" data-tone="${dot}" aria-hidden="true"></span> <span class="bs-label">${label}</span>` +
       `<span class="bs-gen">构建 ${gen}</span>`;
     el.title = lines.join('\n');
   }
@@ -603,65 +603,234 @@
     }
   }
 
-  function renderTotals() {
+  // 数据面的中文名。build_status.files[] 给的是机器文件名，读者不该被要求认识
+  // peer_residual.json。未登记的新文件回落到去掉后缀的原名，不留空也不报错。(#876)
+  const DATA_FILE_CN = {
+    "portfolio.json": "持仓与账本",
+    "benchmark.json": "基准对照",
+    "catalysts.json": "催化剂日程",
+    "cross_sectional_factor.json": "横截面因子",
+    "em_news.json": "港股中文消息",
+    "influencer_feed.json": "影响力雷达",
+    "lev_regime.json": "杠杆刻度盘",
+    "macro.json": "宏观指标",
+    "news_evidence_graph.json": "新闻证据图",
+    "peer_residual.json": "同行残差",
+    "quant_signal_review.json": "因子自检",
+    "quant_signals.json": "量化因子",
+    "risk.json": "风险指标",
+    "sentiment.json": "市场情绪",
+    "us_news_digest.json": "美股新闻摘要",
+    "t0_setups.json": "T+0 牌面",
+    "t0_setup_review.json": "牌面背书",
+    "decision_audit.json": "择时诊断",
+    "shadow_portfolio.json": "政策模拟",
+    "brief_projection.json": "简报投影",
+    "workflow-outcomes.json": "流程账本",
+    "cron-heartbeats.json": "定时心跳",
+    "integrity_report.json": "体检报告",
+    "coverage.json": "测试覆盖率",
+    "readme_metrics.json": "README 指标",
+    "overview.json": "总览快照",
+    "dashboard.json": "面板数据",
+  };
+  const dataFileCn = name => DATA_FILE_CN[name] || String(name || "").replace(/\.json$/, "");
+
+  // 负号在货币符号外面：−$1,361 而不是 $-1,361。只用于首屏指挥台，
+  // 不改全局 fmtMoney（别处的断言吃的是旧格式）。
+  function heroMoney(v, ccy) {
+    if (v == null || !isFinite(v)) return DASH;
+    const body = fmtMoney(Math.abs(v), ccy);
+    return (v < 0 ? "−" : v > 0 ? "+" : "") + body;
+  }
+
+  // 首屏指挥台：一个主数 + 一条统计轨，取代 book / today / discipline 三张卡。(#874)
+  function renderCommandDeck() {
+    const pnlEl = document.getElementById("hero-pnl");
+    const subEl = document.getElementById("hero-sub");
+    const railEl = document.getElementById("hero-rail");
+    if (!pnlEl || !subEl || !railEl) return;
+
     const us = safe(DATA, "totals", "us") || {};
     const hk = safe(DATA, "totals", "hk") || {};
     const fx = safe(DATA, "fx", "usdhkd");
     const fxMeta = safe(DATA, "fx") || {};
+    const rv = safe(DATA, "realized_vs_unrealized") || {};
+    const m = safe(DATA, "decision_metrics") || {};
 
-    document.getElementById("us-value").textContent = fmtMoney(us.value_usd, "USD");
-    const usPnl = us.pnl_usd;
-    const usPnlPct = us.pnl_pct;
-    const usPnlEl = document.getElementById("us-pnl");
-    usPnlEl.textContent = fmtMoney(usPnl, "USD") + " · " + fmtPct(usPnlPct);
-    usPnlEl.className = "sub " + pnlClass(usPnl);
+    const has = v => v != null && isFinite(v);
+    const eq = (usd, hkd) => (fx && has(usd) && has(hkd)) ? usd + hkd / fx : null;
+    // totals.pnl 是「浮动」——市值减成本，没算落袋的部分。把它当「总盈亏」摆首屏
+    // 是错的口径：总盈亏 = 已实现 + 浮动，和 Reflect 的总回报率分子同源。
+    const unrealUsd = eq(us.pnl_usd, hk.pnl_hkd);
+    // 首屏第一帧吃的是精简的 overview.json，里面没有 realized_vs_unrealized；
+    // totals 两份 payload 都有，所以优先 rv、缺了就从 totals 现算，不留破折号。
+    const realUsd = has(safe(rv, "combined_usd", "realized"))
+      ? safe(rv, "combined_usd", "realized")
+      : eq(us.realized_usd, hk.realized_hkd);
+    const totalUsd = (has(realUsd) && has(unrealUsd)) ? realUsd + unrealUsd : unrealUsd;
+    const bookUsd = eq(us.value_usd, hk.value_hkd);
+    const todayUsd = eq(us.today_change_usd, hk.today_change_hkd);
+    const todayPct = (has(bookUsd) && has(todayUsd) && (bookUsd - todayUsd) > 0)
+      ? todayUsd / (bookUsd - todayUsd) * 100 : null;
 
-    document.getElementById("hk-value").textContent = fmtMoney(hk.value_hkd, "HKD");
-    const hkPnl = hk.pnl_hkd;
-    const hkPnlPct = hk.pnl_pct;
-    const hkPnlEl = document.getElementById("hk-pnl");
-    hkPnlEl.textContent = fmtMoney(hkPnl, "HKD") + " · " + fmtPct(hkPnlPct);
-    hkPnlEl.className = "sub " + pnlClass(hkPnl);
+    pnlEl.textContent = heroMoney(totalUsd, "USD");
+    pnlEl.className = "hero-deck-pnl " + pnlClass(totalUsd);
+    subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
+      + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
+      + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
+      + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
+      + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
-    if (fx && us.value_usd != null && hk.value_hkd != null) {
-      const totalUsd = us.value_usd + hk.value_hkd / fx;
-      const totalHkd = us.value_usd * fx + hk.value_hkd;
-      document.getElementById("combined-usd").textContent = fmtMoney(totalUsd, "USD");
-      document.getElementById("combined-hkd").textContent = fmtMoney(totalHkd, "HKD");
-      const fetchedAt = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
-      const fetched = fetchedAt && !isNaN(fetchedAt)
-        ? fetchedAt.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-      const fxLine = `USDHKD ${fmtNum(fx, 4)}`
-        + (fxMeta.source ? ` · ${fxMeta.source}` : "")
-        + (fetched ? ` · ${fetched}` : "");
-      document.getElementById("fx-rate-usd").textContent = fxLine;
-      document.getElementById("fx-rate-hkd").textContent = fxLine;
-    } else {
-      document.getElementById("combined-usd").textContent = DASH;
-      document.getElementById("combined-hkd").textContent = DASH;
-      document.getElementById("fx-rate-usd").textContent = "FX unavailable";
-      document.getElementById("fx-rate-hkd").textContent = "";
+    const fxEl = document.getElementById("fx-rate-usd");
+    if (fxEl) {
+      if (fx) {
+        const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
+        const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
+        fxEl.textContent = `USDHKD ${fmtNum(fx, 4)}`
+          + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
+      } else {
+        fxEl.textContent = "FX unavailable";
+      }
     }
+
+    const ae = safe(m, "execution_by_kind", "active") || {};
+    const cell = (k, v, s, cls) =>
+      `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
+      + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
+      + `<div class="hero-rail-s">${s || ""}</div></div>`;
+    railEl.innerHTML = [
+      cell("US 腿", fmtMoney(us.value_usd, "USD"),
+        `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
+      cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
+        `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
+      cell("今日 US", heroMoney(us.today_change_usd, "USD"), "美股腿", pnlClass(us.today_change_usd)),
+      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"), "港股腿", pnlClass(hk.today_change_hkd)),
+      cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
+      cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
+      cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
+        `主动 call · n=${ae.known == null ? DASH : ae.known}`),
+      cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
+        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`,
+        m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
+    ].join("");
   }
 
-  function renderTodayPnl() {
-    const us = safe(DATA, "totals", "us") || {};
-    const hk = safe(DATA, "totals", "hk") || {};
-    const usChg = us.today_change_usd;
-    const hkChg = hk.today_change_hkd;
-    // pct: today_change / (value - today_change) — approx today's pct vs yesterday
-    const usPct = (us.value_usd != null && usChg != null && (us.value_usd - usChg) > 0)
-                  ? (usChg / (us.value_usd - usChg) * 100) : null;
-    const hkPct = (hk.value_hkd != null && hkChg != null && (hk.value_hkd - hkChg) > 0)
-                  ? (hkChg / (hk.value_hkd - hkChg) * 100) : null;
-    const usEl = document.getElementById("today-pnl-us");
-    const hkEl = document.getElementById("today-pnl-hk");
-    usEl.textContent = fmtMoney(usChg, "USD");
-    usEl.className = "val " + pnlClass(usChg);
-    hkEl.textContent = fmtMoney(hkChg, "HKD");
-    hkEl.className = "val " + pnlClass(hkChg);
-    document.getElementById("today-pnl-us-pct").textContent = usPct != null ? fmtPct(usPct) : DASH;
-    document.getElementById("today-pnl-hk-pct").textContent = hkPct != null ? fmtPct(hkPct) : DASH;
+  // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，
+  // 触屏根本打不开。这里把它提到首屏，逐项可展开。(#876)
+  // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
+  // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  function renderDataHealth() {
+    const root = document.getElementById("data-health");
+    if (!root) return;
+    const bs = safe(DATA, "build_status");
+    if (!bs) { root.style.display = "none"; return; }
+    root.style.display = "";
+
+    const verdictEl = document.getElementById("dh-verdict") || document.getElementById("dh-title");
+    const metaEl = document.getElementById("dh-meta");
+    const stripEl = document.getElementById("dh-strip");
+    const filesEl = document.getElementById("dh-files");
+    const ig = bs.integrity || {};
+    const wf = safe(DATA, "workflow_outcomes") || {};
+    const wc = wf.counts || {};
+    const files = (bs.files || []).slice();
+    const late = files.filter(f => f.present === false || f.stale);
+    const degraded = (wc.recovered || 0) + (wc.degraded || 0);
+
+    let tone = "ok", verdict = "全部数据面在期";
+    if ((wc.failed || 0) > 0) { tone = "bad"; verdict = `成品流程 ${wc.failed} 档 FAILED`; }
+    else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
+    else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
+    else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
+    else if (degraded) { tone = "warn"; verdict = `${degraded} 档成品恢复或降级`; }
+    root.dataset.tone = tone;
+    if (verdictEl) verdictEl.textContent = verdict;
+    if (metaEl) {
+      const bits = [`${files.length} 个数据面`];
+      bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
+      if (degraded) bits.push(`${degraded} 档恢复或降级`);
+      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      metaEl.textContent = bits.join(" · ");
+    }
+
+    // 期限用量：max_age 用 age/sla；scheduled_fire 只有到期时刻，用「离截止还有多久
+    // ÷ 24h」表达，两者都只是粗略的紧张程度，精确判定始终以 f.stale 为准。
+    const usage = f => {
+      if (f.present === false || f.stale) return 1;
+      // 上游判 stale 有两种模式，这里只做「紧张程度」的粗略表达。未判 stale 的
+      // 一律封顶 0.7，否则会画出一根满格的条却标着「在期」，自相矛盾。
+      const raw = (() => {
+        if (f.freshness_mode === "scheduled_fire") {
+          const d = f.deadline_at ? new Date(f.deadline_at) : null;
+          if (!d || isNaN(d)) return 0.4;
+          const left = (d.getTime() - Date.now()) / 3600000;
+          return left <= 0 ? 0.7 : 1 - Math.min(left, 24) / 24;
+        }
+        if (!f.sla_hours || f.age_hours == null) return 0.4;
+        return f.age_hours / f.sla_hours;
+      })();
+      return Math.max(0.08, Math.min(0.7, raw));
+    };
+    const stateOf = f => f.present === false ? "missing" : (f.stale ? "late" : "ok");
+    const detailOf = f => {
+      if (f.present === false) return "文件缺失";
+      if (f.freshness_mode === "scheduled_fire") {
+        const d = f.deadline_at ? new Date(f.deadline_at) : null;
+        const when = d && !isNaN(d)
+          ? d.toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit",
+              minute: "2-digit", hour12: false, timeZone: "Asia/Hong_Kong" }) + " HKT"
+          : "未知";
+        return `${f.age_hours == null ? DASH : f.age_hours + "h"} · 应于 ${when} 前刷新`;
+      }
+      return `${f.age_hours == null ? DASH : f.age_hours + "h"} / 期限 ${f.sla_hours}h`;
+    };
+
+    if (stripEl) {
+      const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
+      const caption = document.getElementById("dh-caption");
+      if (caption) {
+        caption.textContent = !files.length ? ""
+          : late.length
+            ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")}`
+            : `期限用量 · 越高越接近过期 · 最紧张的是${dataFileCn(tightest.name)}（${detailOf(tightest)}）`;
+      }
+      stripEl.innerHTML = files.map(f => {
+        const st = stateOf(f);
+        const pctUsed = Math.round(usage(f) * 100);
+        return `<span class="dh-seg is-${st}" style="--used:${pctUsed}%"`
+          + ` title="${escapeHtml(dataFileCn(f.name))} · ${escapeHtml(f.name)} · ${escapeHtml(detailOf(f))}">`
+          + `<i></i></span>`;
+      }).join("");
+    }
+
+    if (filesEl) {
+      filesEl.innerHTML = files
+        .slice()
+        .sort((a, b) => usage(b) - usage(a))
+        .map(f => {
+          const st = stateOf(f);
+          const label = st === "missing" ? "缺失" : st === "late" ? "逾期" : "在期";
+          return `<div class="dh-row is-${st}">`
+            + `<span class="dh-name">${escapeHtml(dataFileCn(f.name))}</span>`
+            + `<span class="dh-file">${escapeHtml(f.name)}</span>`
+            + `<span class="dh-bar"><i style="width:${Math.round(usage(f) * 100)}%"></i></span>`
+            + `<span class="dh-detail">${escapeHtml(detailOf(f))}</span>`
+            + `<span class="dh-state">${label}</span>`
+            + `</div>`;
+        }).join("");
+    }
+
+    const toggle = document.getElementById("dh-toggle");
+    if (toggle && toggle.dataset.wired !== "1") {
+      toggle.dataset.wired = "1";
+      toggle.addEventListener("click", () => {
+        const open = toggle.getAttribute("aria-expanded") !== "true";
+        toggle.setAttribute("aria-expanded", open ? "true" : "false");
+        toggle.textContent = open ? "收起" : "逐项";
+        if (filesEl) filesEl.hidden = !open;
+      });
+    }
   }
 
   function flatHoldings() {
@@ -709,8 +878,8 @@
          <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:11px;margin-top:2px">→ ${action}</div>` : ''}</div>
        </div>`;
     const rows = [
-      ...breaches.map(b => ({ icon: ICON[b.type] || '⚠️', severity: b.severity, detail: b.detail, action: b.action })),
-      ...stops.map(s => ({ icon: '', severity: 'high', detail: s.detail, action: s.action })),
+      ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
+      ...stops.map(s => ({ icon: '', severity: 'high', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
     ];
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
@@ -718,8 +887,8 @@
       countEl.textContent = n ? `${n} 触发` : '无';
       countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
-        ? (g.directive || "")
-        : [g.directive, g.reentry_rule].filter(Boolean).join(' ');
+        ? stripEmoji(g.directive)
+        : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
       listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -334,8 +334,8 @@
 
   const TAB_RENDERERS = {
     hero: [
-      renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderTotals,
-      renderTodayPnl, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
+      renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
+      renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
     ],
     drill: [
       renderDecisionMatrix, renderAddCampaign, renderHoldings, renderExtremes, renderMovers,
@@ -427,18 +427,18 @@
     const artifactOnly = wfCounts.artifact_only || 0;
     let dot, label;
     if ((wfCounts.failed || 0) > 0) {
-      dot = '🔴'; label = `成品流程 ${wfCounts.failed} FAILED`;
+      dot = 'bad'; label = `成品流程 ${wfCounts.failed} FAILED`;
     }
-    else if (ig.error_count > 0) { dot = '🔴'; label = `体检 ${ig.error_count} ERROR`; }
+    else if (ig.error_count > 0) { dot = 'bad'; label = `体检 ${ig.error_count} ERROR`; }
     else if (stale.length || ig.warn_count > 0 || recovered || artifactOnly) {
-      dot = '🟡';
+      dot = 'warn';
       const bits = [];
       if (stale.length) bits.push(`${stale.length} 文件 stale`);
       if (ig.warn_count > 0) bits.push(`体检 ${ig.warn_count} WARN`);
       if (recovered) bits.push(`${recovered} 成品恢复/降级`);
       if (artifactOnly) bits.push(`${artifactOnly} 仅产物未确认投递`);
       label = bits.join(' · ');
-    } else { dot = '🟢'; label = '数据健康 · 体检 ✓'; }
+    } else { dot = 'ok'; label = '数据健康 · 体检通过'; }
     if (wf.raw_error_but_product_usable) {
       label += ` · ${wf.raw_error_but_product_usable} 执行红/成品可用`;
     }
@@ -457,7 +457,7 @@
       }
       else lines.push(`${f.stale ? '⚠' : '·'} ${f.name}  ${f.age_hours}h / SLA ${f.sla_hours}h`);
     });
-    (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '🔴' : '🟡'} ${t.code}: ${t.msg}`));
+    (ig.top || []).forEach(t => lines.push(`${t.level === 'ERROR' ? '[ERROR]' : '[WARN]'} ${t.code}: ${stripEmoji(t.msg)}`));
     if (bs.markets) {
       Object.entries(bs.markets).forEach(([m, v]) =>
         lines.push(`${m.toUpperCase()}: 行情会话 ${quoteSessionLabel(v)}${v.closed_today ? ' (休市)' : ''}`));
@@ -473,7 +473,7 @@
       lines.push(`流程 ${r.job} ${slot}: 执行=${raw} / 成品=${final}${readabilityDetail}`);
     });
     const gen = bs.generated_at ? bs.generated_at.replace('T', ' ').slice(0, 16) : '';
-    el.innerHTML = `<span class="bs-dot">${dot}</span> <span class="bs-label">${label}</span>` +
+    el.innerHTML = `<span class="bs-dot" data-tone="${dot}" aria-hidden="true"></span> <span class="bs-label">${label}</span>` +
       `<span class="bs-gen">构建 ${gen}</span>`;
     el.title = lines.join('\n');
   }
@@ -593,66 +593,236 @@
     }
   }
 
-  function renderTotals() {
+  // 数据面的中文名。build_status.files[] 给的是机器文件名，读者不该被要求认识
+  // peer_residual.json。未登记的新文件回落到去掉后缀的原名，不留空也不报错。(#876)
+  const DATA_FILE_CN = {
+    "portfolio.json": "持仓与账本",
+    "benchmark.json": "基准对照",
+    "catalysts.json": "催化剂日程",
+    "cross_sectional_factor.json": "横截面因子",
+    "em_news.json": "港股中文消息",
+    "influencer_feed.json": "影响力雷达",
+    "lev_regime.json": "杠杆刻度盘",
+    "macro.json": "宏观指标",
+    "news_evidence_graph.json": "新闻证据图",
+    "peer_residual.json": "同行残差",
+    "quant_signal_review.json": "因子自检",
+    "quant_signals.json": "量化因子",
+    "risk.json": "风险指标",
+    "sentiment.json": "市场情绪",
+    "us_news_digest.json": "美股新闻摘要",
+    "t0_setups.json": "T+0 牌面",
+    "t0_setup_review.json": "牌面背书",
+    "decision_audit.json": "择时诊断",
+    "shadow_portfolio.json": "政策模拟",
+    "brief_projection.json": "简报投影",
+    "workflow-outcomes.json": "流程账本",
+    "cron-heartbeats.json": "定时心跳",
+    "integrity_report.json": "体检报告",
+    "coverage.json": "测试覆盖率",
+    "readme_metrics.json": "README 指标",
+    "overview.json": "总览快照",
+    "dashboard.json": "面板数据",
+  };
+  const dataFileCn = name => DATA_FILE_CN[name] || String(name || "").replace(/\.json$/, "");
+
+  // 负号在货币符号外面：−$1,361 而不是 $-1,361。只用于首屏指挥台，
+  // 不改全局 fmtMoney（别处的断言吃的是旧格式）。
+  function heroMoney(v, ccy) {
+    if (v == null || !isFinite(v)) return DASH;
+    const body = fmtMoney(Math.abs(v), ccy);
+    return (v < 0 ? "−" : v > 0 ? "+" : "") + body;
+  }
+
+  // 首屏指挥台：一个主数 + 一条统计轨，取代 book / today / discipline 三张卡。(#874)
+  function renderCommandDeck() {
+    const pnlEl = document.getElementById("hero-pnl");
+    const subEl = document.getElementById("hero-sub");
+    const railEl = document.getElementById("hero-rail");
+    if (!pnlEl || !subEl || !railEl) return;
+
     const us = safe(DATA, "totals", "us") || {};
     const hk = safe(DATA, "totals", "hk") || {};
     const fx = safe(DATA, "fx", "usdhkd");
     const fxMeta = safe(DATA, "fx") || {};
+    const rv = safe(DATA, "realized_vs_unrealized") || {};
+    const m = safe(DATA, "decision_metrics") || {};
 
-    document.getElementById("us-value").textContent = fmtMoney(us.value_usd, "USD");
-    const usPnl = us.pnl_usd;
-    const usPnlPct = us.pnl_pct;
-    const usPnlEl = document.getElementById("us-pnl");
-    usPnlEl.textContent = fmtMoney(usPnl, "USD") + " · " + fmtPct(usPnlPct);
-    usPnlEl.className = "sub " + pnlClass(usPnl);
+    const has = v => v != null && isFinite(v);
+    const eq = (usd, hkd) => (fx && has(usd) && has(hkd)) ? usd + hkd / fx : null;
+    // totals.pnl 是「浮动」——市值减成本，没算落袋的部分。把它当「总盈亏」摆首屏
+    // 是错的口径：总盈亏 = 已实现 + 浮动，和 Reflect 的总回报率分子同源。
+    const unrealUsd = eq(us.pnl_usd, hk.pnl_hkd);
+    // 首屏第一帧吃的是精简的 overview.json，里面没有 realized_vs_unrealized；
+    // totals 两份 payload 都有，所以优先 rv、缺了就从 totals 现算，不留破折号。
+    const realUsd = has(safe(rv, "combined_usd", "realized"))
+      ? safe(rv, "combined_usd", "realized")
+      : eq(us.realized_usd, hk.realized_hkd);
+    const totalUsd = (has(realUsd) && has(unrealUsd)) ? realUsd + unrealUsd : unrealUsd;
+    const bookUsd = eq(us.value_usd, hk.value_hkd);
+    const todayUsd = eq(us.today_change_usd, hk.today_change_hkd);
+    const todayPct = (has(bookUsd) && has(todayUsd) && (bookUsd - todayUsd) > 0)
+      ? todayUsd / (bookUsd - todayUsd) * 100 : null;
 
-    document.getElementById("hk-value").textContent = fmtMoney(hk.value_hkd, "HKD");
-    const hkPnl = hk.pnl_hkd;
-    const hkPnlPct = hk.pnl_pct;
-    const hkPnlEl = document.getElementById("hk-pnl");
-    hkPnlEl.textContent = fmtMoney(hkPnl, "HKD") + " · " + fmtPct(hkPnlPct);
-    hkPnlEl.className = "sub " + pnlClass(hkPnl);
+    pnlEl.textContent = heroMoney(totalUsd, "USD");
+    pnlEl.className = "hero-deck-pnl " + pnlClass(totalUsd);
+    subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
+      + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
+      + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
+      + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
+      + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
-    if (fx && us.value_usd != null && hk.value_hkd != null) {
-      const totalUsd = us.value_usd + hk.value_hkd / fx;
-      const totalHkd = us.value_usd * fx + hk.value_hkd;
-      document.getElementById("combined-usd").textContent = fmtMoney(totalUsd, "USD");
-      document.getElementById("combined-hkd").textContent = fmtMoney(totalHkd, "HKD");
-      const fetchedAt = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
-      const fetched = fetchedAt && !isNaN(fetchedAt)
-        ? fetchedAt.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-      const fxLine = `USDHKD ${fmtNum(fx, 4)}`
-        + (fxMeta.source ? ` · ${fxMeta.source}` : "")
-        + (fetched ? ` · ${fetched}` : "");
-      document.getElementById("fx-rate-usd").textContent = fxLine;
-      document.getElementById("fx-rate-hkd").textContent = fxLine;
-    } else {
-      document.getElementById("combined-usd").textContent = DASH;
-      document.getElementById("combined-hkd").textContent = DASH;
-      document.getElementById("fx-rate-usd").textContent = "FX unavailable";
-      document.getElementById("fx-rate-hkd").textContent = "";
+    const fxEl = document.getElementById("fx-rate-usd");
+    if (fxEl) {
+      if (fx) {
+        const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
+        const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
+        fxEl.textContent = `USDHKD ${fmtNum(fx, 4)}`
+          + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
+      } else {
+        fxEl.textContent = "FX unavailable";
+      }
+    }
+
+    const ae = safe(m, "execution_by_kind", "active") || {};
+    const cell = (k, v, s, cls) =>
+      `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
+      + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
+      + `<div class="hero-rail-s">${s || ""}</div></div>`;
+    railEl.innerHTML = [
+      cell("US 腿", fmtMoney(us.value_usd, "USD"),
+        `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
+      cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
+        `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
+      cell("今日 US", heroMoney(us.today_change_usd, "USD"), "美股腿", pnlClass(us.today_change_usd)),
+      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"), "港股腿", pnlClass(hk.today_change_hkd)),
+      cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
+      cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
+      cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
+        `主动 call · n=${ae.known == null ? DASH : ae.known}`),
+      cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
+        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`,
+        m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
+    ].join("");
+  }
+
+  // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，
+  // 触屏根本打不开。这里把它提到首屏，逐项可展开。(#876)
+  // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
+  // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
+  function renderDataHealth() {
+    const root = document.getElementById("data-health");
+    if (!root) return;
+    const bs = safe(DATA, "build_status");
+    if (!bs) { root.style.display = "none"; return; }
+    root.style.display = "";
+
+    const verdictEl = document.getElementById("dh-verdict") || document.getElementById("dh-title");
+    const metaEl = document.getElementById("dh-meta");
+    const stripEl = document.getElementById("dh-strip");
+    const filesEl = document.getElementById("dh-files");
+    const ig = bs.integrity || {};
+    const wf = safe(DATA, "workflow_outcomes") || {};
+    const wc = wf.counts || {};
+    const files = (bs.files || []).slice();
+    const late = files.filter(f => f.present === false || f.stale);
+    const degraded = (wc.recovered || 0) + (wc.degraded || 0);
+
+    let tone = "ok", verdict = "全部数据面在期";
+    if ((wc.failed || 0) > 0) { tone = "bad"; verdict = `成品流程 ${wc.failed} 档 FAILED`; }
+    else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
+    else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
+    else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
+    else if (degraded) { tone = "warn"; verdict = `${degraded} 档成品恢复或降级`; }
+    root.dataset.tone = tone;
+    if (verdictEl) verdictEl.textContent = verdict;
+    if (metaEl) {
+      const bits = [`${files.length} 个数据面`];
+      bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
+      if (degraded) bits.push(`${degraded} 档恢复或降级`);
+      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      metaEl.textContent = bits.join(" · ");
+    }
+
+    // 期限用量：max_age 用 age/sla；scheduled_fire 只有到期时刻，用「离截止还有多久
+    // ÷ 24h」表达，两者都只是粗略的紧张程度，精确判定始终以 f.stale 为准。
+    const usage = f => {
+      if (f.present === false || f.stale) return 1;
+      // 上游判 stale 有两种模式，这里只做「紧张程度」的粗略表达。未判 stale 的
+      // 一律封顶 0.7，否则会画出一根满格的条却标着「在期」，自相矛盾。
+      const raw = (() => {
+        if (f.freshness_mode === "scheduled_fire") {
+          const d = f.deadline_at ? new Date(f.deadline_at) : null;
+          if (!d || isNaN(d)) return 0.4;
+          const left = (d.getTime() - Date.now()) / 3600000;
+          return left <= 0 ? 0.7 : 1 - Math.min(left, 24) / 24;
+        }
+        if (!f.sla_hours || f.age_hours == null) return 0.4;
+        return f.age_hours / f.sla_hours;
+      })();
+      return Math.max(0.08, Math.min(0.7, raw));
+    };
+    const stateOf = f => f.present === false ? "missing" : (f.stale ? "late" : "ok");
+    const detailOf = f => {
+      if (f.present === false) return "文件缺失";
+      if (f.freshness_mode === "scheduled_fire") {
+        const d = f.deadline_at ? new Date(f.deadline_at) : null;
+        const when = d && !isNaN(d)
+          ? d.toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit",
+              minute: "2-digit", hour12: false, timeZone: "Asia/Hong_Kong" }) + " HKT"
+          : "未知";
+        return `${f.age_hours == null ? DASH : f.age_hours + "h"} · 应于 ${when} 前刷新`;
+      }
+      return `${f.age_hours == null ? DASH : f.age_hours + "h"} / 期限 ${f.sla_hours}h`;
+    };
+
+    if (stripEl) {
+      const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
+      const caption = document.getElementById("dh-caption");
+      if (caption) {
+        caption.textContent = !files.length ? ""
+          : late.length
+            ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")}`
+            : `期限用量 · 越高越接近过期 · 最紧张的是${dataFileCn(tightest.name)}（${detailOf(tightest)}）`;
+      }
+      stripEl.innerHTML = files.map(f => {
+        const st = stateOf(f);
+        const pctUsed = Math.round(usage(f) * 100);
+        return `<span class="dh-seg is-${st}" style="--used:${pctUsed}%"`
+          + ` title="${escapeHtml(dataFileCn(f.name))} · ${escapeHtml(f.name)} · ${escapeHtml(detailOf(f))}">`
+          + `<i></i></span>`;
+      }).join("");
+    }
+
+    if (filesEl) {
+      filesEl.innerHTML = files
+        .slice()
+        .sort((a, b) => usage(b) - usage(a))
+        .map(f => {
+          const st = stateOf(f);
+          const label = st === "missing" ? "缺失" : st === "late" ? "逾期" : "在期";
+          return `<div class="dh-row is-${st}">`
+            + `<span class="dh-name">${escapeHtml(dataFileCn(f.name))}</span>`
+            + `<span class="dh-file">${escapeHtml(f.name)}</span>`
+            + `<span class="dh-bar"><i style="width:${Math.round(usage(f) * 100)}%"></i></span>`
+            + `<span class="dh-detail">${escapeHtml(detailOf(f))}</span>`
+            + `<span class="dh-state">${label}</span>`
+            + `</div>`;
+        }).join("");
+    }
+
+    const toggle = document.getElementById("dh-toggle");
+    if (toggle && toggle.dataset.wired !== "1") {
+      toggle.dataset.wired = "1";
+      toggle.addEventListener("click", () => {
+        const open = toggle.getAttribute("aria-expanded") !== "true";
+        toggle.setAttribute("aria-expanded", open ? "true" : "false");
+        toggle.textContent = open ? "收起" : "逐项";
+        if (filesEl) filesEl.hidden = !open;
+      });
     }
   }
 
-  function renderTodayPnl() {
-    const us = safe(DATA, "totals", "us") || {};
-    const hk = safe(DATA, "totals", "hk") || {};
-    const usChg = us.today_change_usd;
-    const hkChg = hk.today_change_hkd;
-    // pct: today_change / (value - today_change) — approx today's pct vs yesterday
-    const usPct = (us.value_usd != null && usChg != null && (us.value_usd - usChg) > 0)
-                  ? (usChg / (us.value_usd - usChg) * 100) : null;
-    const hkPct = (hk.value_hkd != null && hkChg != null && (hk.value_hkd - hkChg) > 0)
-                  ? (hkChg / (hk.value_hkd - hkChg) * 100) : null;
-    const usEl = document.getElementById("today-pnl-us");
-    const hkEl = document.getElementById("today-pnl-hk");
-    usEl.textContent = fmtMoney(usChg, "USD");
-    usEl.className = "val " + pnlClass(usChg);
-    hkEl.textContent = fmtMoney(hkChg, "HKD");
-    hkEl.className = "val " + pnlClass(hkChg);
-    document.getElementById("today-pnl-us-pct").textContent = usPct != null ? fmtPct(usPct) : DASH;
-    document.getElementById("today-pnl-hk-pct").textContent = hkPct != null ? fmtPct(hkPct) : DASH;
-  }
 
   function renderDelta() {
     const tbody = document.getElementById("delta-tbody");
@@ -1666,8 +1836,8 @@
          <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:11px;margin-top:2px">→ ${action}</div>` : ''}</div>
        </div>`;
     const rows = [
-      ...breaches.map(b => ({ icon: ICON[b.type] || '⚠️', severity: b.severity, detail: b.detail, action: b.action })),
-      ...stops.map(s => ({ icon: '', severity: 'high', detail: s.detail, action: s.action })),
+      ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
+      ...stops.map(s => ({ icon: '', severity: 'high', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
     ];
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
@@ -1675,8 +1845,8 @@
       countEl.textContent = n ? `${n} 触发` : '无';
       countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
-        ? (g.directive || "")
-        : [g.directive, g.reentry_rule].filter(Boolean).join(' ');
+        ? stripEmoji(g.directive)
+        : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
       listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -338,8 +338,8 @@
       renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
     ],
     drill: [
-      renderDecisionMatrix, renderAddCampaign, renderHoldings, renderExtremes, renderMovers,
-      renderAnomalies, render8dHeatmap, renderTodayRange, renderShadowPortfolioCard,
+      renderBook, renderAddCampaign, renderMovers,
+      renderAnomalies, render8dHeatmap, renderShadowPortfolioCard,
     ],
     risk: [
       renderRiskGuardrail, renderHHI, renderLeveragedETF, renderRiskMetrics, renderLevRegime,
@@ -354,7 +354,7 @@
       renderBearCases, renderHiddenConcentration,
     ],
     reflect: [
-      renderBehavioralReview, renderDecisionAudit, renderCalibBadge,
+      renderHonesty, renderBehavioralReview, renderDecisionAudit, renderCalibBadge,
       renderPlanReview, renderCalibByTrigger, renderCalibByDriver,
       renderDecisionTraces, renderReflectKpi, renderDelta,
     ],
@@ -669,6 +669,9 @@
     subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
       + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
       + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
+      // 账面的 HKD 等值：原来 Total book 卡的第二行，合并后仍要留着
+      + ((fx && has(us.value_usd) && has(hk.value_hkd))
+        ? ` <span class="muted">/ ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}</span>` : "")
       + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
       + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
@@ -684,6 +687,10 @@
       }
     }
 
+    // 分腿的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
+    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
+    const usTodayPct = legPct(us.value_usd, us.today_change_usd);
+    const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
@@ -694,14 +701,20 @@
         `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
       cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
         `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
-      cell("今日 US", heroMoney(us.today_change_usd, "USD"), "美股腿", pnlClass(us.today_change_usd)),
-      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"), "港股腿", pnlClass(hk.today_change_hkd)),
+      cell("今日 US", heroMoney(us.today_change_usd, "USD"),
+        `美股腿${usTodayPct == null ? "" : " · " + fmtPct(usTodayPct)}`, pnlClass(us.today_change_usd)),
+      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"),
+        `港股腿${hkTodayPct == null ? "" : " · " + fmtPct(hkTodayPct)}`, pnlClass(hk.today_change_hkd)),
       cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
       cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
-        `主动 call · n=${ae.known == null ? DASH : ae.known}`),
+        // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
+        // 会高估这个比率覆盖了多少记录，所以两个数一起给。
+        `主动 call · n=${ae.known == null ? DASH : ae.known}`
+        + (ae.stranded ? ` · ${ae.stranded} 未能核验` : "")),
       cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
-        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`,
+        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`
+        + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
         m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
     ].join("");
   }
@@ -1388,115 +1401,280 @@
 
   // 持仓决策矩阵优先消费 harness 编译的 versioned projection。旧 dashboard
   // join 仅作跨版本部署期间的 fallback；Pages 不再是投资规则的 owner。
-  function renderDecisionMatrix() {
-    const card = document.getElementById('decision-matrix-card');
-    if (!card) return;
+
+  // ── 持仓主表（#875 #877）────────────────────────────────────
+  // 原来同一批持仓被切成四张表：决策矩阵 / Holdings / 今日区间 / 最强最弱，
+  // 每张都按 ticker 重排一遍，读者要自己 join。这里合成一张，行展开就是
+  // 这只票的全部证据；证据来源仍是各自原来的字段，没有新数据面。
+  let bookSort = null;   // null = 默认「需动作的排最前」，点表头才切成列排序
+
+  function bookEvidence() {
+    const ev = {};
+    const put = (tk, k, v) => { if (!tk) return; (ev[tk] = ev[tk] || {})[k] = v; };
     const projection = safe(DATA, "brief_projection") || {};
-    const projected = projection.schema_version === 1
-      ? (projection.tickers || [])
-      : [];
-    const H = safe(DATA, "holdings") || {};
-    // dashboard.holdings is the current ledger projection. The brief sidecar
-    // publishes independently and may be days older, so it may enrich a ticker
-    // but must never own membership in a card labelled current holdings.
-    const holds = [...(H.us || []), ...(H.hk || [])].filter(h =>
-      h && h.is_active !== false && (h.shares ?? 0) > 0);
-    if (!holds.length) { card.style.display = 'none'; return; }
-    card.style.display = '';
+    (projection.schema_version === 1 ? (projection.tickers || []) : []).forEach(r => put(r.ticker, "proj", r));
+
     const qrows = ((safe(DATA, "quant_signals") || {}).rows) || {};
-    // 杠杆 ETF→底层标的映射（量化按标的算，ETF 本身无 quant 行）。
-    // 双源：lev_regime.us.names 的 etf/underlying + quant 行 note "X 的标的"。
     const etf2u = {};
     (((safe(DATA, "lev_regime") || {}).us || {}).names || []).forEach(n => {
       if (n.etf && n.underlying) etf2u[n.etf] = n.underlying;
     });
     Object.keys(qrows).forEach(u => {
-      const m = (qrows[u].note || '').match(/^(\S+)\s*的标的/);
+      const m = (qrows[u].note || "").match(/^(\S+)\s*的标的/);
       if (m) etf2u[m[1]] = u;
     });
+    const usable = r => r && (!r.status || r.status === "fresh");
+    flatHoldings().forEach(h => {
+      const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
+      const px = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : "";
+      const q = direct || (px ? qrows[px] : null);
+      if (q) { put(h.ticker, "q", q); if (px) put(h.ticker, "proxy", px); }
+    });
+
     const rg = safe(DATA, "risk_guardrail") || {};
-    const action = {};
-    (rg.breaches || []).forEach(b => { if (b.ticker && !action[b.ticker]) action[b.ticker] = { txt: '减仓', col: 'var(--warning)', kind: 'trim' }; });
-    (rg.hard_stop_watch || []).forEach(s => { if (s.ticker) action[s.ticker] = { txt: '止损', col: 'var(--negative)', kind: 'stop' }; });
-    const sign = v => v == null ? '' : `style="color:${v < 0 ? 'var(--negative)' : 'var(--positive)'}"`;
-    const num = (v, suf = '') => v == null ? '—' : `${v}${suf}`;
-    const rsiCls = r => r == null ? '' : (r >= 70 ? 'style="color:var(--negative)"' : (r <= 30 ? 'style="color:var(--positive)"' : ''));
-    // 52w 位置条：0=近一年低位(便宜/绿) 100=近一年高位(追高/红)
-    const rangeBar = p => {
-      if (p == null) return '<span class="muted">—</span>';
-      const pos = Math.max(0, Math.min(100, p));
-      const col = p >= 80 ? 'var(--negative)' : (p <= 20 ? 'var(--positive)' : 'var(--neutral)');
-      return `<span style="position:relative;width:52px;height:8px;background:rgba(128,128,128,.18);border-radius:4px;display:inline-block;vertical-align:middle">` +
-        `<span style="position:absolute;left:${pos}%;top:-2px;width:3px;height:12px;background:${col};border-radius:2px;transform:translateX(-50%)"></span></span>` +
-        `<span class="muted" style="font-size:10px;margin-left:5px">${Math.round(p)}</span>`;
-    };
-    let usedProxy = false;
-    // 综合 verdict：状态分级(rank 越小越需关注)。强动作来自硬闸(kcn 已定框架)，
-    // 其余仅给技术面状态，不臆造买卖结论(主动信号 edge 弱，见 calibration)。
-    const verdict = (q, a) => {
-      if (a && a.kind === 'stop') return { rank: 0, label: '止损/换1x', state: 'critical' };
-      if (a && a.kind === 'trim') return { rank: 1, label: '减仓', state: 'elevated' };
-      if (q.trend_on === true) return { rank: 4, label: '趋势ON', state: 'positive' };
-      if (q.rsi14 != null && q.rsi14 <= 30) return { rank: 2, label: '超卖·观望', state: 'elevated' };
-      if (q.tag || q.rsi14 != null) return { rank: 3, label: '趋势off·观望', state: 'neutral' };
-      return { rank: 5, label: '—', state: 'neutral' };
-    };
-    const projectedByTicker = new Map(projected.map(row => [row.ticker, row]));
-    let usedProjection = false;
-    const enriched = holds.map(h => {
-        const row = projectedByTicker.get(h.ticker);
-        if (row) {
-          usedProjection = true;
-          const q = row.technical || {};
-          const proxy = q.is_proxy ? q.source_ticker : '';
-          if (proxy) usedProxy = true;
-          const riskAction = (row.risk || {}).action;
-          const a = riskAction ? {
-            txt: riskAction.label,
-            col: riskAction.kind === 'stop' ? 'var(--negative)' : 'var(--warning)',
-            kind: riskAction.kind,
-          } : null;
-          return {
-            h: {
-              ticker: h.ticker,
-              // Projection owns analysis; current marks remain live intraday.
-              today_change_pct: h.today_change_pct ?? (row.facts || {}).today_change_pct,
-              pnl_percent: h.pnl_percent ?? (row.facts || {}).pnl_pct,
-            },
-            q,
-            a,
-            proxy,
-            v: row.status || verdict(q, a),
-          };
-        }
-        const usable = r => r && (!r.status || r.status === 'fresh');
-        const direct = usable(qrows[h.ticker]) ? qrows[h.ticker] : null;
-        const proxy = !direct && etf2u[h.ticker] && usable(qrows[etf2u[h.ticker]]) ? etf2u[h.ticker] : '';
-        if (proxy) usedProxy = true;
-        const q = direct || (proxy ? qrows[proxy] : {}) || {};
-        const a = action[h.ticker];
-        return { h, q, a, proxy, v: verdict(q, a) };
+    (rg.breaches || []).forEach(b => put(b.ticker, "breach", b));
+    (rg.hard_stop_watch || []).forEach(s => put(s.ticker, "stop", s));
+    (safe(DATA, "today_ranges") || []).forEach(r => put(r.ticker, "range", r));
+    ((safe(DATA, "breakeven_math") || {}).rows || []).forEach(r => put(r.ticker, "be", r));
+    ((safe(DATA, "peer_divergence") || {}).items || []).forEach(i => put(i.ticker, "peer", i));
+    (safe(DATA, "bear_cases") || []).forEach(c => put(c.ticker, "bear", c));
+    (safe(DATA, "weight_confidence") || []).forEach(w => put(w.ticker, "conv", w));
+    const t0rows = (safe(DATA, "t0_setups") || {}).rows || {};
+    Object.entries(t0rows).forEach(([k, v]) => put(k, "t0", v));
+    (safe(DATA, "plan_timeline") || []).forEach(a => {
+      if (!a.ticker) return;
+      const e = (ev[a.ticker] = ev[a.ticker] || {});
+      (e.plans = e.plans || []).push(a);
+    });
+    (safe(DATA, "decision_traces") || []).forEach(t => {
+      if (!t.ticker) return;
+      const e = (ev[t.ticker] = ev[t.ticker] || {});
+      (e.fills = e.fills || []).push(t);
+    });
+    const hn = safe(DATA, "em_news", "holdings_news") || {};
+    Object.entries(hn).forEach(([tk, v]) => put(tk, "news", v));
+    return ev;
+  }
+
+  // 强动作只来自硬闸（kcn 定的框架）；其余只给技术状态，不臆造买卖结论。
+  function bookVerdict(q, action) {
+    if (action && action.kind === "stop") return { rank: 0, label: "止损/换1x", state: "critical" };
+    if (action && action.kind === "trim") return { rank: 1, label: "减仓", state: "elevated" };
+    if (q && q.trend_on === true) return { rank: 4, label: "趋势ON", state: "positive" };
+    if (q && q.rsi14 != null && q.rsi14 <= 30) return { rank: 2, label: "超卖·观望", state: "elevated" };
+    if (q && (q.tag || q.rsi14 != null)) return { rank: 3, label: "趋势off·观望", state: "neutral" };
+    return { rank: 5, label: DASH, state: "neutral" };
+  }
+
+  function bookDetail(h, e) {
+    const ccy = h.region === "hk" ? "HKD" : "USD";
+    const q = e.q || safe(e, "proj", "technical") || {};
+    const cols = [];
+    const kv = (k, v, cls) =>
+      `<div class="bd-kv"><span class="k">${escapeHtml(k)}</span><span class="v ${cls || ""}">${v}</span></div>`;
+    const numOr = (v, suf) => v == null ? DASH : `${v}${suf || ""}`;
+
+    const tech = [];
+    if (q.rsi14 != null) tech.push(kv("RSI 14", numOr(q.rsi14), q.rsi14 >= 70 ? "neg" : q.rsi14 <= 30 ? "pos" : ""));
+    if (q.zscore20 != null) tech.push(kv("z-score 20", numOr(q.zscore20)));
+    if (q.dist_ma200_pct != null) tech.push(kv("距 MA200", numOr(q.dist_ma200_pct, "%"), pnlClass(q.dist_ma200_pct)));
+    if (q.stop_distance_pct != null) tech.push(kv("止损距", numOr(q.stop_distance_pct, "%")));
+    if (q.vol_target_weight != null) tech.push(kv("vol 目标仓位", numOr(q.vol_target_weight)));
+    if (q.tag) tech.push(kv("因子状态", escapeHtml(q.tag)));
+    if (q.pct_52w_range != null) {
+      const p = Math.max(0, Math.min(100, q.pct_52w_range));
+      tech.push(`<div class="bd-pos"><span class="bd-pos-lbl">52 周位置 ${Math.round(q.pct_52w_range)}</span>`
+        + `<span class="bd-pos-track"><i style="left:${p}%"></i></span>`
+        + `<span class="bd-pos-ends"><span>低</span><span>高</span></span></div>`);
+    }
+    if (tech.length) cols.push(`<div class="bd-col"><div class="bd-k">技术</div>${tech.join("")}</div>`);
+
+    const r = e.range;
+    if (r && r.high != null && r.low != null) {
+      const span = (r.high - r.low) || 1;
+      const p = Math.max(0, Math.min(100, ((r.current - r.low) / span) * 100));
+      cols.push(`<div class="bd-col"><div class="bd-k">当日区间</div>`
+        + kv("振幅", r.range_pct == null ? DASH : r.range_pct.toFixed(1) + "%")
+        + kv("现价", fmtMoney(r.current, ccy))
+        + `<div class="bd-pos"><span class="bd-pos-track"><i style="left:${p}%"></i></span>`
+        + `<span class="bd-pos-ends"><span>${escapeHtml(String(r.low))}</span><span>${escapeHtml(String(r.high))}</span></span></div></div>`);
+    }
+
+    const risk = [];
+    if (e.breach) risk.push(`<div class="bd-note neg">硬闸 · ${escapeHtml(stripEmoji(e.breach.detail || e.breach.action || ""))}</div>`);
+    if (e.stop) risk.push(`<div class="bd-note neg">止损盯防 · ${escapeHtml(stripEmoji(e.stop.detail || e.stop.action || ""))}</div>`);
+    if (e.be) {
+      risk.push(kv("回本需", "+" + e.be.breakeven_need_pct + "%", "neg"));
+      if (e.be.leveraged) risk.push(kv("横盘 decay", "≈" + e.be.chop_drag_pct_per_month + "%/月"));
+    }
+    if (e.conv) risk.push(kv("仓位 × 信心",
+      `${e.conv.weight_pct}% · conf ${Math.round((e.conv.avg_confidence || 0) * 100)}%`,
+      e.conv.quadrant === "high_risk" ? "neg" : ""));
+    if (e.peer && e.peer.divergence_pp != null) risk.push(kv(
+      `同行 vs ${escapeHtml(e.peer.best_peer_name || e.peer.best_peer || "")}`,
+      (e.peer.divergence_pp > 0 ? "落后 " : "领先 ") + Math.abs(e.peer.divergence_pp).toFixed(1) + "pp",
+      e.peer.divergence_pp > 0 ? "neg" : "pos"));
+    if (risk.length) cols.push(`<div class="bd-col"><div class="bd-k">风险</div>${risk.join("")}</div>`);
+
+    if (e.t0) {
+      cols.push(`<div class="bd-col"><div class="bd-k">T+0 牌面</div>`
+        + kv(stripEmoji(e.t0.grade_label || "牌面").slice(0, 12), numOr(e.t0.range_pos, "% 位"))
+        + kv("缺口", numOr(e.t0.gap_pct, "%"), pnlClass(e.t0.gap_pct))
+        + kv("振幅 / ATR", numOr(e.t0.range_used_atr, "×"))
+        + `<div class="bd-note">${escapeHtml(stripEmoji(e.t0.grade_reason || ""))}</div></div>`);
+    }
+
+    const acts = (e.plans || []).slice(0, 3).map(a =>
+      kv(`${escapeHtml(a.date || "")} ${escapeHtml(a.action || "")}`,
+         a.confidence == null ? "" : "conf " + Math.round(a.confidence * 100) + "%")
+      + (a.rationale ? `<div class="bd-note">${escapeHtml(String(a.rationale).slice(0, 130))}</div>` : "")).join("");
+    const fills = (e.fills || []).slice(0, 3).map(f =>
+      kv(`${escapeHtml(String(f.date || "").slice(0, 10))} ${escapeHtml(f.action || "")} ${escapeHtml(String(f.shares))}`,
+         "@" + escapeHtml(String(f.price)))).join("");
+    if (acts || fills) cols.push(`<div class="bd-col"><div class="bd-k">计划与成交</div>${acts}${fills}</div>`);
+
+    if (e.bear || e.news) {
+      const news = e.news ? ((e.news.items || []).slice(0, 3).map(it =>
+        `<div class="bd-note">${escapeHtml(it.date || "")} · ${escapeHtml(it.title || "")}</div>`).join("")) : "";
+      cols.push(`<div class="bd-col"><div class="bd-k">论点与消息</div>`
+        + (e.bear ? `<div class="bd-note">${escapeHtml(e.bear.thesis || "")}</div>`
+            + `<div class="bd-note">证伪：${escapeHtml(e.bear.falsifier || DASH)} · 盯：${escapeHtml(e.bear.watch || DASH)}</div>` : "")
+        + news + `</div>`);
+    }
+
+    return cols.length ? `<div class="bd-grid">${cols.join("")}</div>`
+      : `<div class="bd-empty">这只票今天没有额外证据：量化、硬闸、区间、同行都没有写入。</div>`;
+  }
+
+  function renderBook() {
+    const tbody = document.getElementById("book-tbody");
+    if (!tbody) return;
+    const holds = flatHoldings();
+    const countEl = document.getElementById("book-count");
+    if (countEl) countEl.textContent = holds.length ? `(${holds.length})` : "";
+
+    const ev = bookEvidence();
+    const rgAction = {};
+    const rg = safe(DATA, "risk_guardrail") || {};
+    (rg.breaches || []).forEach(b => { if (b.ticker && !rgAction[b.ticker]) rgAction[b.ticker] = { txt: "减仓", kind: "trim" }; });
+    (rg.hard_stop_watch || []).forEach(s => { if (s.ticker) rgAction[s.ticker] = { txt: "止损", kind: "stop" }; });
+
+    let usedProjection = false, usedProxy = false;
+    const rows = holds.map(h => {
+      const e = ev[h.ticker] || {};
+      const proj = e.proj;
+      let q = e.q || {}, action = rgAction[h.ticker] || null;
+      if (proj) {
+        usedProjection = true;
+        q = proj.technical || q;
+        const ra = (proj.risk || {}).action;
+        if (ra) action = { txt: ra.label, kind: ra.kind };
+      }
+      if (e.proxy || (q && q.is_proxy)) usedProxy = true;
+      const v = (proj && proj.status) || bookVerdict(q, action);
+      return { h, e, q, action, v };
+    });
+
+    if (bookSort) {
+      const { key, dir } = bookSort;
+      rows.sort((a, b) => {
+        const av = a.h[key], bv = b.h[key];
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (typeof av === "string") return dir === "asc" ? av.localeCompare(bv) : String(bv).localeCompare(av);
+        return dir === "asc" ? av - bv : bv - av;
       });
-    // 排序：需要动作的优先(rank 升序)，同级浮亏深的在前 → 最该看的在最上面
-    enriched.sort((x, y) => (x.v.rank - y.v.rank) || ((x.h.pnl_percent ?? 0) - (y.h.pnl_percent ?? 0)));
-    document.getElementById('decision-matrix-tbody').innerHTML = enriched.map(({ h, q, a, proxy, v }) => {
-      const mk = proxy ? `<sup style="color:var(--muted,#9ca3af)" title="杠杆ETF · 量化列取底层 ${proxy}">▵</sup>` : '';
-      return `<tr>` +
-        `<td><strong>${h.ticker}</strong>${mk}</td>` +
-        `<td style="font-size:11px"><span class="matrix-status ${v.state}">${v.label}</span></td>` +
-        `<td class="num" ${sign(h.today_change_pct)}>${num(h.today_change_pct, '%')}</td>` +
-        `<td class="num" ${sign(h.pnl_percent)}>${num(h.pnl_percent, '%')}</td>` +
-        `<td>${rangeBar(q.pct_52w_range)}</td>` +
-        `<td class="num" ${rsiCls(q.rsi14)}>${num(q.rsi14)}</td>` +
-        `<td class="num" ${sign(q.dist_ma200_pct)}>${num(q.dist_ma200_pct, '%')}</td>` +
-        `<td style="font-size:10px">${a ? `<span style="color:${a.col};font-weight:600">${a.txt}</span>` : '<span class="muted">—</span>'}</td>` +
-        `</tr>`;
-    }).join('');
-    document.getElementById('decision-matrix-note').textContent =
-      '综合：止损/减仓=硬闸规则(必动)，观望/趋势ON=技术状态(非买卖建议)。按需动作优先排序。'
-      + '52w位置：绿=近一年低位(便宜)、红=高位(追高警惕)。'
-      + (usedProjection ? '匹配行由 harness projection 编译；当前持仓成员以最新账本为准。' : '兼容模式：等待 projection。')
-      + (usedProxy ? '▵=杠杆ETF量化列取底层标的。' : '');
+    } else {
+      // 默认：需要动作的排最前，同级浮亏深的在前
+      rows.sort((x, y) => (x.v.rank - y.v.rank) || ((x.h.pnl_percent ?? 0) - (y.h.pnl_percent ?? 0)));
+    }
+
+    const shares = n => n == null || isNaN(n) ? DASH : Number(n).toLocaleString("en-US", { maximumFractionDigits: 0 });
+    const price = (n, ccy) => n == null || isNaN(n) || n === 0 ? DASH : fmtMoney(n, ccy);
+    tbody.innerHTML = rows.map(({ h, e, q, v }) => {
+      const ccy = h.region === "hk" ? "HKD" : "USD";
+      const proxyMark = (e.proxy || (q && q.is_proxy))
+        ? `<sup class="muted" title="杠杆ETF · 量化列取底层 ${escapeHtml(e.proxy || q.source_ticker || "")}">▵</sup>` : "";
+      return `
+        <tr class="book-row" tabindex="0" role="button" aria-expanded="false" data-open="0" data-ticker="${escapeHtml(h.ticker || "")}">
+          <td><span class="ticker region-${h.region}">${escapeHtml(h.ticker || DASH)}</span>${proxyMark}<span class="book-caret" aria-hidden="true">›</span></td>
+          <td class="name-cell col-p2">${escapeHtml(h.name || "")}</td>
+          <td style="font-size:11px"><span class="matrix-status ${v.state}">${escapeHtml(v.label)}</span></td>
+          <td class="num col-p2">${shares(h.shares)}</td>
+          <td class="num col-p2">${price(h.cost_basis, ccy)}</td>
+          <td class="num">${price(h.current_price, ccy)}</td>
+          <td class="num">${fmtMoney(h.current_value, ccy)}</td>
+          <td class="num spark-cell col-p3">${sparklineSVG((safe(DATA, "holdings_history", h.ticker) || []), 56, 18)}</td>
+          <td class="num cell-stack">
+            <div class="${pnlClass(h.today_change)}">${fmtMoney(h.today_change, ccy)}</div>
+            <div class="cell-sub ${pnlClass(h.today_change_pct)}">${fmtPct(h.today_change_pct)}</div>
+          </td>
+          <td class="num cell-stack">
+            <div class="${pnlClass(h.pnl_abs)}">${fmtMoney(h.pnl_abs, ccy)}</div>
+            <div class="cell-sub ${pnlClass(h.pnl_percent)}">${fmtPct(h.pnl_percent)}</div>
+          </td>
+        </tr>
+        <tr class="book-detail" data-open="0"><td colspan="10"><div class="bd-wrap"><div class="bd-inner">${bookDetail(h, e)}</div></div></td></tr>`;
+    }).join("");
+
+    const note = document.getElementById("book-note");
+    if (note) {
+      note.textContent = "点任意一行展开这只票的全部证据。状态：止损/减仓 = 硬闸规则（必动），观望/趋势ON = 技术状态，不是买卖建议。"
+        + "52 周位置：低位 = 近一年便宜，高位 = 追高警惕。"
+        + (usedProjection ? "匹配行由 harness projection 编译；当前持仓成员以最新账本为准。" : "兼容模式：等待 projection。")
+        + (usedProxy ? " ▵ = 杠杆 ETF，量化列取底层标的。" : "");
+    }
+    const meta = document.getElementById("book-meta");
+    if (meta) meta.textContent = bookSort ? "按列排序" : "需动作的排最前";
+
+    if (tbody.dataset.wired !== "1") {
+      tbody.dataset.wired = "1";
+      const toggle = tr => {
+        const det = tr.nextElementSibling;
+        if (!det || !det.classList.contains("book-detail")) return;
+        const open = tr.dataset.open === "1" ? "0" : "1";
+        tr.dataset.open = open;
+        det.dataset.open = open;
+        tr.setAttribute("aria-expanded", open === "1" ? "true" : "false");
+      };
+      tbody.addEventListener("click", e => {
+        const tr = e.target.closest("tr.book-row");
+        if (tr && tbody.contains(tr)) toggle(tr);
+      });
+      tbody.addEventListener("keydown", e => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        const tr = e.target.closest("tr.book-row");
+        if (!tr) return;
+        e.preventDefault();
+        toggle(tr);
+      });
+    }
+
+    // Wire sort headers
+    document.querySelectorAll("#book-table thead th").forEach(th => {
+      th.onclick = () => {
+        const k = th.dataset.sort;
+        if (!k) return;
+        if (bookSort && bookSort.key === k) bookSort.dir = bookSort.dir === "asc" ? "desc" : "asc";
+        else bookSort = { key: k, dir: "desc" };
+        document.querySelectorAll("#book-table thead th").forEach(x => {
+          const isActive = bookSort && x.dataset.sort === bookSort.key;
+          x.classList.toggle("active-sort", !!isActive);
+          const label = x.textContent.replace(/[▲▼]/g, "").trim();
+          x.replaceChildren();
+          x.append(label);
+          if (isActive) {
+            const arrow = document.createElement("span");
+            arrow.className = "arr";
+            arrow.textContent = bookSort.dir === "asc" ? "▲" : "▼";
+            x.append(" ", arrow);
+          }
+        });
+        renderBook();
+      };
+    });
+    // end sort headers
   }
 
   function renderAddCampaign() {
@@ -1520,7 +1698,8 @@
     } else {
       const d = campaign.diagnostics || {};
       const tiers = d.tier_counts || {};
-      status.textContent = `ideas ${d.observed_idea_count ?? d.observed_candidate_count ?? 0} · authority ${d.authority_candidate_count || 0}/${d.held_names || 0}`;
+      // h3 和徽章之间没有分隔符，线上渲染成「ADD CAMPAIGNideas 0 · authority 0/10」
+      status.textContent = `· ideas ${d.observed_idea_count ?? d.observed_candidate_count ?? 0} · authority ${d.authority_candidate_count || 0}/${d.held_names || 0}`;
       status.className = "badge muted";
       const stateLabel = {
         eligible: "可执行", waiting_timing: "等技术位", risk_blocked: "风险拦截",
@@ -1548,10 +1727,9 @@
       const rows = (campaign.candidates || []).slice().sort((a, b) =>
         String(a.leg || "").localeCompare(String(b.leg || "")) ||
         String(a.ticker || "").localeCompare(String(b.ticker || "")));
-      const legBlock = leg => {
-        const inLeg = rows.filter(row => row.leg === leg);
-        return `<section class="add-campaign-leg"><h4>${leg} · ${inLeg.length} holdings</h4>` +
-          (inLeg.length ? inLeg.map(row => {
+      // 十只票每只一张卡、每张重复同样四个 pill = 同一句话说十遍。全员同态时
+      // 只留一行摘要，明细收进 details；有分歧时才逐个展开。(#875)
+      const candidateRow = row => {
             const authorityBlockers = row.authority_blockers || [];
             const executionBlockers = row.execution_blockers || [];
             const families = (row.evidence_families || []).join(" + ") || "—";
@@ -1568,7 +1746,24 @@
               ${earlyLine}
               <div class="campaign-blockers"><b>authority</b>${authorityBlockers.length ? authorityBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}<b>execution</b>${executionBlockers.length ? executionBlockers.map(v => `<span>${escapeHtml(blockerLabel[v] || v)}</span>`).join("") : "<span>none</span>"}</div>
             </div>`;
-          }).join("") : '<div class="empty-state">No held names.</div>') + `</section>`;
+      };
+      const uniformState = (() => {
+        const states = new Set(rows.map(r => r.state || "unknown"));
+        return states.size === 1 && rows.length > 2 ? [...states][0] : null;
+      })();
+      const legBlock = leg => {
+        const inLeg = rows.filter(row => row.leg === leg);
+        if (uniformState) {
+          const names = inLeg.map(r => escapeHtml(r.ticker || "?")).join(" · ");
+          return `<section class="add-campaign-leg"><h4>${leg} · ${inLeg.length} holdings</h4>`
+            + (inLeg.length
+              ? `<details class="campaign-fold"><summary>全部 ${inLeg.length} 只同态：${escapeHtml(stateLabel[uniformState] || uniformState)}<span class="campaign-fold-names">${names}</span></summary>`
+                + inLeg.map(row => candidateRow(row)).join("") + `</details>`
+              : '<div class="empty-state">—</div>')
+            + `</section>`;
+        }
+        return `<section class="add-campaign-leg"><h4>${leg} · ${inLeg.length} holdings</h4>` +
+          (inLeg.length ? inLeg.map(candidateRow).join("") : '<div class="empty-state">No held names.</div>') + `</section>`;
       };
       body.innerHTML = `<div class="campaign-summary">packet ${escapeHtml(campaign.packet_generated_at || "—")} · generation ${escapeHtml(campaign.context_generation_id || "—")} · early ideas ${d.observed_idea_count ?? d.observed_candidate_count ?? 0} · early exploration ideas ${d.early_exploration_ready_idea_count ?? d.early_exploration_ready_count ?? 0} · mature validated ${tiers.validated || 0} / exploration ${tiers.exploration || 0}</div><div class="add-campaign-legs">${legBlock("US")}${legBlock("HK")}</div>`;
     }
@@ -1598,74 +1793,6 @@
     evidence.innerHTML = `<div class="campaign-evidence-head"><b>Independent run card · ${escapeHtml(run.run_id || "—")}</b><span>diagnostic / collecting，不是 validated alpha</span></div><div class="campaign-market-grid">${market("us")}${market("hk")}</div><div class="campaign-coverage"><b>early candidate replay</b> · US ${earlyHorizon("us", "t1")} / ${earlyHorizon("us", "t5")} · HK ${earlyHorizon("hk", "t1")} / ${earlyHorizon("hk", "t5")} · observed ${earlyCoverage.observed_candidates ?? 0}, information-confirmed ${earlyCoverage.information_confirmed ?? 0}, exploration-ready ${earlyCoverage.exploration_ready ?? 0}</div><div class="campaign-coverage">factor ${coverage.factor_dates ?? "—"} dates · information ${coverage.information_dates ?? "—"} · overlap ${coverage.overlap_dates ?? "—"} · prospective ${coverage.prospective_information_dates ?? "—"} · authority none ${auth.none ?? 0} / explore ${auth.exploration ?? 0} / validated ${auth.validated ?? 0}</div>`;
   }
 
-  function renderHoldings() {
-    const tbody = document.getElementById("holdings-tbody");
-    const data = flatHoldings();
-    document.getElementById("holdings-count").textContent = data.length ? `(${data.length})` : "";
-    const { key, dir } = holdingsSort;
-    data.sort((a, b) => {
-      const av = a[key], bv = b[key];
-      if (av == null && bv == null) return 0;
-      if (av == null) return 1;
-      if (bv == null) return -1;
-      if (typeof av === "string") return dir === "asc" ? av.localeCompare(bv) : bv.localeCompare(av);
-      return dir === "asc" ? av - bv : bv - av;
-    });
-    const fmtShares = (n) => n == null || isNaN(n) ? DASH : Number(n).toLocaleString("en-US", { maximumFractionDigits: 0 });
-    const fmtPrice = (n, ccy) => n == null || isNaN(n) || n === 0 ? DASH : fmtMoney(n, ccy);
-    const dualCell = (abs, pct, cls) => `
-      <div class="${cls}">${fmtMoney(abs, ccy)}</div>
-      <div class="cell-sub ${cls}">${fmtPct(pct)}</div>`;
-    tbody.innerHTML = data.map(h => {
-      const ccy = h.region === "hk" ? "HKD" : "USD";
-      return `
-        <tr>
-          <td><span class="ticker region-${h.region}">${h.ticker || DASH}</span></td>
-          <td class="name-cell">${h.name || ""}</td>
-          <td class="num">${fmtShares(h.shares)}</td>
-          <td class="num">${fmtPrice(h.cost_basis, ccy)}</td>
-          <td class="num">${fmtPrice(h.current_price, ccy)}</td>
-          <td class="num">${fmtMoney(h.current_value, ccy)}</td>
-          <td class="num spark-cell">${sparklineSVG((safe(DATA, "holdings_history", h.ticker) || []), 56, 18)}</td>
-          <td class="num cell-stack">
-            <div class="${pnlClass(h.today_change)}">${fmtMoney(h.today_change, ccy)}</div>
-            <div class="cell-sub ${pnlClass(h.today_change_pct)}">${fmtPct(h.today_change_pct)}</div>
-          </td>
-          <td class="num cell-stack">
-            <div class="${pnlClass(h.pnl_abs)}">${fmtMoney(h.pnl_abs, ccy)}</div>
-            <div class="cell-sub ${pnlClass(h.pnl_percent)}">${fmtPct(h.pnl_percent)}</div>
-          </td>
-        </tr>
-      `;
-    }).join("");
-
-    // Wire sort headers
-    document.querySelectorAll("#holdings-table thead th").forEach(th => {
-      th.onclick = () => {
-        const k = th.dataset.sort;
-        if (!k) return;
-        if (holdingsSort.key === k) {
-          holdingsSort.dir = holdingsSort.dir === "asc" ? "desc" : "asc";
-        } else {
-          holdingsSort = { key: k, dir: "desc" };
-        }
-        document.querySelectorAll("#holdings-table thead th").forEach(x => {
-          const isActive = x.dataset.sort === holdingsSort.key;
-          x.classList.toggle("active-sort", isActive);
-          const label = x.textContent.replace(/[▲▼]/g, "").trim();
-          x.replaceChildren();
-          x.append(label);
-          if (isActive) {
-            const arrow = document.createElement("span");
-            arrow.className = "arr";
-            arrow.textContent = holdingsSort.dir === "asc" ? "▲" : "▼";
-            x.append(" ", arrow);
-          }
-        });
-        renderHoldings();
-      };
-    });
-  }
 
   function renderShadowPortfolioCard() {
     const empty = document.getElementById("shadow-portfolio-empty");
@@ -1851,29 +1978,6 @@
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
       listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';
     });
-  }
-
-  function renderBreakevenMath() {
-    const bm = safe(DATA, "breakeven_math");
-    const card = document.getElementById('breakeven-card');
-    if (!card) return;
-    const rows = (bm && bm.rows) || [];
-    if (!rows.length) { card.style.display = 'none'; return; }
-    card.style.display = '';
-    const html = rows.map(r => {
-      let extra = '';
-      if (r.leveraged && r.underlying_vol_pct != null) {
-        extra = `<div class="muted" style="font-size:11px;margin-top:2px">标的σ ${r.underlying_vol_pct}% · 横盘 decay ≈${r.chop_drag_pct_per_month}%/月 · ` +
-                `半年直线路径标的需 +${r.underlying_need_2x_6m_pct}%` +
-                (r.swap_1x ? ` · 换 1x(${r.swap_1x}) 后需 +${r.underlying_need_if_1x_pct}%` : '') + `</div>`;
-      }
-      return `<div class="risk-alert ${r.leveraged ? 'high' : 'medium'}">
-         <span class="icon"></span>
-         <div><strong>${r.ticker}</strong> 浮亏 ${r.pnl_pct}% → 回本需 +${r.breakeven_need_pct}%${extra}</div>
-       </div>`;
-    }).join('');
-    document.getElementById('breakeven-list').innerHTML = html;
-    document.getElementById('breakeven-note').textContent = bm.note || '';
   }
 
   function renderQuantSignals() {
@@ -2304,49 +2408,7 @@
     document.getElementById("lev-tickers").textContent = tk.length ? `2x/3x ETFs: ${tk.join(", ")}` : "—";
   }
 
-  function renderTodayRange() {
-    const list = safe(DATA, "today_ranges") || [];
-    const wrap = document.getElementById("range-list");
-    if (!list.length) {
-      wrap.innerHTML = '<div class="empty-state">No range data yet.</div>';
-      return;
-    }
-    const maxPct = Math.max(1, ...list.map(r => r.range_pct || 0));
-    wrap.innerHTML = list.map(r => {
-      const pctFill = ((r.range_pct || 0) / maxPct) * 100;
-      // dot position: (current - low) / (high - low) * 100
-      const spread = (r.high - r.low) || 1;
-      const dotPct = Math.max(0, Math.min(100, ((r.current - r.low) / spread) * 100));
-      return `
-        <div class="range-row">
-          <div class="tk">${r.ticker}</div>
-          <div class="range-bar">
-            <div class="fill" style="width:${pctFill}%"></div>
-            <div class="dot" style="left:${dotPct}%"></div>
-          </div>
-          <div class="val">${fmtPct(r.range_pct, 1)}</div>
-        </div>`;
-    }).join("");
-  }
 
-  function renderExtremes() {
-    // Old-key fallback keeps the card populated during a staggered HTML/JSON deploy.
-    const ext = safe(DATA, "current_holdings_extremes") || safe(DATA, "all_time_extremes") || {};
-    const render = (rows, elId) => {
-      const el = document.getElementById(elId);
-      if (!rows || !rows.length) {
-        el.innerHTML = '<div class="empty-state">—</div>';
-        return;
-      }
-      el.innerHTML = rows.map(r => `
-        <div class="extremes-row">
-          <span class="tk">${r.ticker}</span>
-          <span class="${pnlClass(r.pnl_percent)}">${fmtPct(r.pnl_percent, 1)}</span>
-        </div>`).join("");
-    };
-    render(ext.winners, "extremes-winners");
-    render(ext.losers, "extremes-losers");
-  }
 
   // Episode-level historical win-rate badge for a decision action.
   // Lets you discount each LLM action at a glance: ⚠ <45% (worse than coin flip),
@@ -2412,7 +2474,9 @@
   // =========================================================
   // LLM narrative cards (text-only; keys never reach the client)
   // =========================================================
-  const escLLM = s => String(s == null ? "" : s).replace(/[<>&"]/g,
+  // LLM 写的正文同样不渲染 emoji：行为复盘的 💡⚠️、空头论点里的装饰符号，
+  // 语义已经由标签和颜色承担。(#869 的口径，这里补上 LLM 文本这一路)
+  const escLLM = s => stripEmoji(String(s == null ? "" : s)).replace(/[<>&"]/g,
     c => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", "\"": "&quot;" }[c]));
 
   function renderBehavioralReview() {
@@ -3259,6 +3323,29 @@
   // =========================================================
   // 历史净值极值 — peak / trough / max drawdown (equity basis)
   // =========================================================
+  function renderBreakevenMath() {
+    const bm = safe(DATA, "breakeven_math");
+    const card = document.getElementById('breakeven-card');
+    if (!card) return;
+    const rows = (bm && bm.rows) || [];
+    if (!rows.length) { card.style.display = 'none'; return; }
+    card.style.display = '';
+    const html = rows.map(r => {
+      let extra = '';
+      if (r.leveraged && r.underlying_vol_pct != null) {
+        extra = `<div class="muted" style="font-size:11px;margin-top:2px">标的σ ${r.underlying_vol_pct}% · 横盘 decay ≈${r.chop_drag_pct_per_month}%/月 · ` +
+                `半年直线路径标的需 +${r.underlying_need_2x_6m_pct}%` +
+                (r.swap_1x ? ` · 换 1x(${r.swap_1x}) 后需 +${r.underlying_need_if_1x_pct}%` : '') + `</div>`;
+      }
+      return `<div class="risk-alert ${r.leveraged ? 'high' : 'medium'}">
+         <span class="icon"></span>
+         <div><strong>${r.ticker}</strong> 浮亏 ${r.pnl_pct}% → 回本需 +${r.breakeven_need_pct}%${extra}</div>
+       </div>`;
+    }).join('');
+    document.getElementById('breakeven-list').innerHTML = html;
+    document.getElementById('breakeven-note').textContent = bm.note || '';
+  }
+
   function renderHistoricalExtremes() {
     const dd = safe(DATA, "drawdown") || {};
     const regions = [

--- a/site/index.html
+++ b/site/index.html
@@ -152,59 +152,23 @@ layout: null
     <h2>Overview</h2>
 
     <div class="overview-command">
-      <div class="card overview-book hero-book-card">
-        <div class="overview-card-kicker">Total book</div>
-        <div class="overview-book-primary" id="combined-usd">—</div>
-        <div class="overview-book-secondary" id="combined-hkd">—</div>
-        <div class="overview-fx" id="fx-rate-usd">—</div>
-        <div class="overview-leg-grid">
-          <div class="overview-leg">
-            <div class="lbl">US leg</div>
-            <div class="val" id="us-value">—</div>
-            <div class="sub" id="us-pnl">—</div>
-          </div>
-          <div class="overview-leg">
-            <div class="lbl">HK leg</div>
-            <div class="val" id="hk-value">—</div>
-            <div class="sub" id="hk-pnl">—</div>
-          </div>
+      <!-- 首屏第一数字回答「赚还是亏」；账面市值随行情自己变，不需要判断，降为副行。
+           原来的 book / today / discipline 三张不等重的卡合并成一块指挥台。(#874 #877) -->
+      <div class="card hero-deck">
+        <div class="hero-deck-lead">
+          <div class="overview-card-kicker">总盈亏 · 已实现 + 浮动 · USD 等值</div>
+          <div class="hero-deck-pnl" id="hero-pnl">—</div>
+          <div class="hero-deck-sub" id="hero-sub">—</div>
+          <div class="hero-deck-fx" id="fx-rate-usd">—</div>
+          <span class="overview-fx-mirror" id="fx-rate-hkd" aria-hidden="true"></span>
         </div>
-        <span class="overview-fx-mirror" id="fx-rate-hkd" aria-hidden="true"></span>
-      </div>
-
-      <div class="card overview-today hero-pnl-card">
-        <div class="overview-card-kicker">Today's P&amp;L</div>
-        <div class="overview-today-grid">
-          <div class="overview-today-cell">
-            <div class="lbl">US</div>
-            <div class="val" id="today-pnl-us">—</div>
-            <div class="pct muted" id="today-pnl-us-pct">—</div>
-          </div>
-          <div class="overview-today-cell">
-            <div class="lbl">HK</div>
-            <div class="val" id="today-pnl-hk">—</div>
-            <div class="pct muted" id="today-pnl-hk-pct">—</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="overview-discipline" aria-label="30-day discipline and calibration">
-        <div class="overview-discipline-cell">
-          <div class="overview-card-kicker">Followed · 30d</div>
-          <div class="overview-discipline-value" id="overview-followed">—</div>
-          <div class="overview-discipline-meta" id="overview-followed-meta">—</div>
-        </div>
-        <div class="overview-discipline-cell" title="Brier score vs leave-one-out baseline — lower is better">
-          <div class="overview-card-kicker">Self-grade · Brier</div>
-          <div class="overview-discipline-value" id="overview-brier">—</div>
-          <div class="overview-discipline-meta" id="overview-brier-meta">—</div>
-        </div>
+        <div class="hero-rail" id="hero-rail"></div>
       </div>
 
       <div class="card overview-equity">
         <div class="card-head">
           <div>
-            <div class="overview-card-kicker">Track record · visual anchor</div>
+            <div class="overview-card-kicker">战绩 · 视觉锚点</div>
             <h3 id="equity-title">Equity Curve · USD-eq</h3>
           </div>
           <span id="benchmark-stale" class="muted" style="display:none;font-size:11px;color:var(--amber)"></span>
@@ -214,17 +178,20 @@ layout: null
             <button class="mkt-seg-btn" data-mkt="hk"><span class="seg-dot hk"></span>港股</button>
           </div>
         </div>
-        <p class="chart-hint overview-equity-hint">粗绿线 = 总利润（浮盈 + 已实现，净化本金）；蓝线 = 真实总资产（持仓市值 + 现金）；虚线 = 成本及动态基准。切换总览 / 美股 / 港股查看各自口径。</p>
+        <details class="chart-note overview-equity-hint">
+          <summary>口径说明</summary>
+          <p>粗绿线 = 总利润（浮盈 + 已实现，净化本金）；蓝线 = 真实总资产（持仓市值 + 现金）；虚线 = 成本及动态基准。切换总览 / 美股 / 港股查看各自口径。</p>
+        </details>
         <div id="chart-equity" class="chart-box overview-equity-chart"></div>
       </div>
 
       <aside class="card overview-verdict" aria-labelledby="overview-verdict-title">
         <div class="overview-verdict-head">
           <div>
-            <div class="overview-card-kicker">Decision panel</div>
-            <h3 id="overview-verdict-title">Today's verdict</h3>
+            <div class="overview-card-kicker">决策面板</div>
+            <h3 id="overview-verdict-title">今日判定</h3>
           </div>
-          <button class="overview-jump" type="button" data-jump-tab="risk">Open Risk</button>
+          <button class="overview-jump" type="button" data-jump-tab="risk">去风险页</button>
         </div>
         <div class="status-banner overview-status is-pending" id="overview-status-banner">
           <span class="sb-pulse" aria-hidden="true"></span>
@@ -234,7 +201,7 @@ layout: null
         <div id="today-highlights" class="today-highlights"></div>
         <div class="overview-gates">
           <div class="overview-gates-head">
-            <span>Top hard gates</span>
+            <span>触发中的硬闸</span>
             <span class="badge muted" id="overview-guardrail-count"></span>
           </div>
           <div class="overview-gates-directive" id="overview-guardrail-directive"></div>
@@ -245,7 +212,7 @@ layout: null
       <div class="overview-strip" aria-label="Secondary overview">
         <section class="overview-strip-cell overview-market">
           <button class="overview-strip-link" type="button" data-jump-tab="market">
-            <span>Market snapshot</span><span aria-hidden="true">Signals →</span>
+            <span>市场快照</span><span aria-hidden="true">盘面 →</span>
           </button>
           <span class="muted overview-asof" id="market-asof">—</span>
           <div class="market-grid" id="market-grid">
@@ -255,18 +222,32 @@ layout: null
         </section>
         <section class="overview-strip-cell">
           <button class="overview-strip-link" type="button" data-jump-tab="drill">
-            <span>Top movers</span><span aria-hidden="true">Holdings →</span>
+            <span>今日异动</span><span aria-hidden="true">持仓 →</span>
           </button>
           <div class="overview-mover-summary" id="overview-mover-summary">—</div>
         </section>
         <section class="overview-strip-cell">
           <button class="overview-strip-link" type="button" data-jump-tab="drill">
-            <span>Anomalies</span><span aria-hidden="true">Holdings →</span>
+            <span>异常</span><span aria-hidden="true">持仓 →</span>
           </button>
           <div class="overview-anomaly-count" id="overview-anomaly-count">—</div>
           <div class="overview-anomaly-summary" id="overview-anomaly-summary">—</div>
         </section>
       </div>
+
+      <section class="card hero-health is-pending" id="data-health" aria-labelledby="dh-title">
+        <div class="hero-health-head">
+          <div>
+            <div class="overview-card-kicker">数据健康</div>
+            <h3 id="dh-title" class="hero-health-verdict">—</h3>
+            <div class="hero-health-meta" id="dh-meta">—</div>
+          </div>
+          <button class="dh-toggle" type="button" id="dh-toggle" aria-expanded="false" aria-controls="dh-files">逐项</button>
+        </div>
+        <div class="dh-strip" id="dh-strip" role="img" aria-label="每个数据面的期限用量"></div>
+        <div class="dh-caption" id="dh-caption"></div>
+        <div class="dh-files" id="dh-files" hidden></div>
+      </section>
 
       <div class="card hero-honesty-card is-pending" id="honesty-card">
         <h3>诚实自评 · self-grading <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(30d)</span></h3>

--- a/site/index.html
+++ b/site/index.html
@@ -249,11 +249,6 @@ layout: null
         <div class="dh-files" id="dh-files" hidden></div>
       </section>
 
-      <div class="card hero-honesty-card is-pending" id="honesty-card">
-        <h3>诚实自评 · self-grading <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(30d)</span></h3>
-        <div id="honesty-body" style="font-size:12px"></div>
-      </div>
-
       <div class="card hero-gold-card is-pending" id="gold-dca-card">
         <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px"></span></h3>
         <div id="gold-hero"></div>
@@ -272,19 +267,38 @@ layout: null
 
     <div class="sect-divider holdings-section-heading">持仓明细</div>
 
-    <div class="card desktop-wide" id="decision-matrix-card">
-      <h3>持仓决策矩阵 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">每持仓一行 · 价/量化/52w位置/硬闸 汇总</span></h3>
+    <!-- 决策矩阵 / Holdings / 今日区间 / 最强最弱 原本是四张按 ticker 各排一遍的表。
+         合成一张：每行点开 = 这只票的全部证据（技术 / 当日区间 / 硬闸 / 回本 /
+         同行 / T+0 牌面 / 计划与成交 / 空头论点）。信息没有减少，只是不再要求
+         读者自己跨块 join。(#875 #877) -->
+    <div class="card desktop-wide" id="book-card">
+      <div class="card-head">
+        <div>
+          <div class="overview-card-kicker">持仓明细</div>
+          <h3>持仓 <span class="muted" id="book-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
+        </div>
+        <span class="muted" id="book-meta" style="font-size:11px"></span>
+      </div>
       <div class="table-wrap">
-        <table class="holdings-table" id="decision-matrix-table" style="min-width:560px;font-size:12px">
-          <thead><tr>
-            <th>标的</th><th>综合</th><th class="num">今日</th><th class="num">浮盈</th>
-            <th>52w位置</th><th class="num">RSI</th>
-            <th class="num">距200</th><th>硬闸</th>
-          </tr></thead>
-          <tbody id="decision-matrix-tbody"></tbody>
+        <table class="holdings-table book-table" id="book-table">
+          <thead>
+            <tr>
+              <th data-sort="ticker">标的</th>
+              <th data-sort="name" class="col-p2">名称</th>
+              <th>状态</th>
+              <th data-sort="shares" class="num col-p2">股数</th>
+              <th data-sort="cost_basis" class="num col-p2">成本</th>
+              <th data-sort="current_price" class="num">现价</th>
+              <th data-sort="current_value" class="num active-sort">市值 <span class="arr">&#x25BC;</span></th>
+              <th class="num spark-col col-p3">8 日</th>
+              <th data-sort="today_change_pct" class="num">今日</th>
+              <th data-sort="pnl_percent" class="num">盈亏</th>
+            </tr>
+          </thead>
+          <tbody id="book-tbody"></tbody>
         </table>
       </div>
-      <div class="muted" id="decision-matrix-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
+      <p class="chart-hint" id="book-note"></p>
     </div>
 
     <div class="card desktop-wide" id="add-campaign-card">
@@ -299,44 +313,22 @@ layout: null
       <div id="add-campaign-evidence"></div>
     </div>
 
-    <div class="card desktop-wide" id="holdings-card">
-      <h3>Holdings <span class="muted" id="holdings-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
-      <div class="table-wrap">
-        <table class="holdings-table" id="holdings-table">
-          <thead>
-            <tr>
-              <th data-sort="ticker">Ticker</th>
-              <th data-sort="name">Name</th>
-              <th data-sort="shares" class="num">Shares</th>
-              <th data-sort="cost_basis" class="num">Cost</th>
-              <th data-sort="current_price" class="num">Price</th>
-              <th data-sort="current_value" class="num active-sort">Value <span class="arr">&#x25BC;</span></th>
-              <th class="num spark-col">7d</th>
-              <th data-sort="today_change_pct" class="num">Today</th>
-              <th data-sort="pnl_percent" class="num">P&amp;L</th>
-            </tr>
-          </thead>
-          <tbody id="holdings-tbody"></tbody>
-        </table>
+    <div class="card desktop-wide" id="book-structure-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">组合结构</div>
+        <h3>强弱与集中</h3>
+      </div></div>
+      <div class="sub-block">
+        <div class="sub-block-head">8 日走势热力 <span class="muted">背景色 = 8 日回报，白线 = 价格路径，小字 = 各自市场 leg 内权重</span></div>
+      <p class="chart-hint">每格一只持仓：<b>背景色</b> = 8 日回报（绿 = 在跑、红 = 在拖），<b>白色折线</b> = 这 8 日的价格走势形状，下方小字 = 各自市场 leg 内权重（不是组合权重）。颜色看强弱、折线看路径，重仓 + 大红块 = 优先审视。</p>
+      <div class="ret-heatmap" id="ret-heatmap">
+        <div class="empty-state">No price history.</div>
       </div>
-    </div>
-
-    <div class="card">
-      <h3>Current Holdings · Best &amp; Worst <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">当前持仓·最强/最弱</span></h3>
-      <div class="extremes-grid">
-        <div>
-          <div class="extremes-label">Best 3 current holdings</div>
-          <div class="extremes-list" id="extremes-winners"><div class="empty-state">—</div></div>
-        </div>
-        <div>
-          <div class="extremes-label">Weakest 3 current holdings</div>
-          <div class="extremes-list" id="extremes-losers"><div class="empty-state">—</div></div>
-        </div>
+    
       </div>
-    </div>
-
-    <div class="card">
-      <h3>Position × Conviction <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Weight within US/HK leg（分母=各自市场）· 30d avg confidence</span></h3>
+      <div class="sub-block">
+        <div class="sub-block-head">仓位 × 信心 <span class="muted">横轴与点大小 = 各自 US/HK leg 内权重，不是全组合 USD-eq 权重</span></div>
+      
       <p class="chart-hint">横轴和圆点大小均为各自 US/HK 市场 leg 内权重，不是全组合 USD-eq 权重；跨市场百分比不可直接当作同一分母比较。右下角（高仓位 + 低置信）= 需要审视。</p>
       <div id="chart-weight-conf" class="wc-chart-box"></div>
       <div class="wc-legend">
@@ -346,40 +338,30 @@ layout: null
         <span class="lg-com">Comfort (&lt;20% & conf≥0.65)</span>
         <span class="lg-nod">No settled decision episodes</span>
       </div>
+    
+      </div>
     </div>
 
     <div class="sect-divider price-section-heading">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">latest local session · US / HK 各取最近本地交易时段</span></div>
 
-    <div class="card" id="movers-card">
-      <div class="desktop-section-kicker" role="heading" aria-level="2">价格动态 · Price action</div>
-      <h3>Today's Movers <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500">(≥3% · latest local session)</span></h3>
+    <div class="card desktop-wide" id="today-action-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">价格动态</div>
+        <h3>今日异动</h3>
+      </div></div>
+      <div class="sub-block" id="movers-card">
+        <div class="sub-block-head">涨跌 ≥3% <span class="muted">最近本地交易时段</span></div>
       <div class="movers-scroll" id="movers-scroll">
         <div class="empty-state">No movers ≥3% today.</div>
       </div>
-    </div>
-
-    <div class="card" id="anomalies-card">
-      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
-      <h3>Anomalies <span class="badge muted" id="anom-count"></span></h3>
+    
+      </div>
+      <div class="sub-block" id="anomalies-card">
+        <div class="sub-block-head">异常<span class="badge muted" id="anom-count"></span></div>
       <div class="anomaly-list" id="anomaly-list">
         <div class="empty-state">No anomalies detected.</div>
       </div>
-    </div>
-
-    <div class="card">
-      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
-      <h3>8日走势热力 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(近 8 日走势 + 收益 · 按强弱排序)</span></h3>
-      <p class="chart-hint">每格一只持仓：<b>背景色</b> = 8 日回报（绿 = 在跑、红 = 在拖），<b>白色折线</b> = 这 8 日的价格走势形状，下方小字 = 各自市场 leg 内权重（不是组合权重）。颜色看强弱、折线看路径，重仓 + 大红块 = 优先审视。</p>
-      <div class="ret-heatmap" id="ret-heatmap">
-        <div class="empty-state">No price history.</div>
-      </div>
-    </div>
-
-    <div class="card">
-      <div class="desktop-section-kicker" aria-hidden="true">价格动态 · Price action</div>
-      <h3>Today's Range <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500">(high-low ÷ price · latest local session)</span></h3>
-      <div class="range-list" id="range-list">
-        <div class="empty-state">No range data yet.</div>
+    
       </div>
     </div>
 
@@ -455,8 +437,14 @@ layout: null
       <div class="risk-alerts" id="guardrail-list"></div>
     </div>
 
-    <div class="card fold-m" data-fold-id="conc">
-      <h3>Concentration (HHI)<span class="peek" id="peek-conc"></span></h3>
+    <div class="card desktop-wide" id="exposure-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">敞口 · 我暴露在什么上面、暴露多少</div>
+        <h3>敞口</h3>
+      </div></div>
+      <div class="sub-block" id="conc">
+        <div class="sub-block-head">集中度 HHI <span class="muted">0.5 ≈ 最差</span><span class="peek" id="peek-conc"></span></div>
+      
       <div class="hhi-row">
         <div class="hhi-card" id="hhi-us">
           <div class="lbl">US</div>
@@ -471,10 +459,11 @@ layout: null
           <div class="top2">—</div>
         </div>
       </div>
-    </div>
-
-    <div class="card fold-m" data-fold-id="lev">
-      <h3>Leveraged ETF Exposure <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(2x/3x ÷ book)</span><span class="peek" id="peek-lev"></span></h3>
+    
+      </div>
+      <div class="sub-block" id="lev">
+        <div class="sub-block-head">杠杆 ETF 暴露 <span class="muted">2x/3x ÷ book</span><span class="peek" id="peek-lev"></span></div>
+      
       <div class="lev-row">
         <div class="lev-cell">
           <div class="lbl">US leg</div>
@@ -490,15 +479,17 @@ layout: null
         </div>
       </div>
       <div class="lev-tickers muted" id="lev-tickers">—</div>
-    </div>
-
-    <div class="card">
-      <h3>Sector Exposure <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(持仓按板块·含 ETF 与个股)</span></h3>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">板块暴露 <span class="muted">持仓按板块 · 含 ETF 与个股</span></div>
+      
       <div id="chart-sector" class="chart-box" style="height:300px"></div>
-    </div>
-
-    <div class="card fold-m" data-fold-id="riskm">
-      <h3>Risk Metrics <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(30d)</span> <span class="badge muted" id="risk-alert-count"></span><span class="peek" id="peek-riskm"></span></h3>
+    
+      </div>
+      <div class="sub-block" id="riskm">
+        <div class="sub-block-head">风险指标 <span class="muted">30 日</span><span class="badge muted" id="risk-alert-count"></span><span class="peek" id="peek-riskm"></span></div>
+      
       <div class="risk-grid">
         <div class="risk-cell">
           <div class="lbl">US β (vs SPX)</div>
@@ -522,10 +513,18 @@ layout: null
         </div>
       </div>
       <div class="risk-alerts" id="risk-alerts"></div>
+    
+      </div>
     </div>
 
-    <div class="card fold-m" id="lev-regime-card" data-fold-id="levregime" style="display:none">
-      <h3>杠杆刻度盘 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">趋势 + 波动 → 杠杆ETF上限</span><span class="peek" id="peek-levregime"></span></h3>
+    <div class="card desktop-wide" id="regime-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">制度与触发线 · 判据同一条：收盘站回均线</div>
+        <h3>制度与触发线</h3>
+      </div></div>
+      <div class="sub-block" id="lev-regime-card" style="display:none">
+        <div class="sub-block-head">杠杆刻度盘 <span class="muted">趋势 + 波动 → 杠杆 ETF 上限</span><span class="peek" id="peek-levregime"></span></div>
+      
       <div class="muted" style="font-size:10px;margin-bottom:3px;opacity:0.8">HK · HSTECH 指数级</div>
       <div class="regime-badge" id="lev-regime-badge" style="margin-bottom:var(--space-2)">
         <span class="rg-dot"></span><span class="rg-label" id="lev-regime-label"></span>
@@ -536,28 +535,40 @@ layout: null
       <div class="muted" style="font-size:10px;margin:8px 0 3px;opacity:0.8">US · 2x 单股 per-name（趋势off且波动过热才砍）</div>
       <div class="risk-alerts" id="lev-regime-us"></div>
       <div class="muted asof-faded" id="lev-regime-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
-    </div>
-
-    <div class="card fold-m" id="reentry-card" data-fold-id="reentry" style="display:none">
-      <h3>再入场雷达 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">持币等回均线 → 触发即布局</span><span class="peek" id="peek-reentry"></span></h3>
+    
+      </div>
+      <div class="sub-block" id="reentry-card" style="display:none">
+        <div class="sub-block-head">再入场雷达 <span class="muted">持币等回均线 → 触发即布局</span><span class="peek" id="peek-reentry"></span></div>
+      
       <div id="reentry-powder" style="margin-bottom:8px"></div>
       <div id="reentry-list"></div>
       <div class="muted asof-faded" id="reentry-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
+    
+      </div>
     </div>
 
-    <div class="card fold-m" id="breakeven-card" data-fold-id="breakeven" style="display:none">
-      <h3>解套数学 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">回本所需涨幅 · 纯算术</span><span class="peek" id="peek-breakeven"></span></h3>
+    <div class="card lead desktop-wide profit-extremes-card" id="recovery-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">回撤与回本</div>
+        <h3>还差多少回到峰值</h3>
+      </div></div>
+      <div class="sub-block" id="breakeven-card" style="display:none">
+        <div class="sub-block-head">解套数学 <span class="muted">回本所需涨幅 · 纯算术</span><span class="peek" id="peek-breakeven"></span></div>
+      
       <div class="risk-alerts" id="breakeven-list"></div>
       <div class="muted" id="breakeven-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
-    </div>
-
-    <div class="card lead profit-extremes-card">
-      <h3>历史利润极值 & 回撤恢复 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(峰值 / 谷底 / 最大回撤 / 恢复)</span></h3>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">历史利润极值 &amp; 回撤恢复 <span class="muted">峰值 / 谷底 / 最大回撤 / 恢复</span></div>
+      
       <p class="chart-hint">主口径 = <b>总利润（浮盈＋已实现，净化本金）</b>：<b>加减仓不会影响它</b>，所以它的<b>峰值才是"真·赚最多"那天</b>。<b>历史最高/最低利润</b> = 有快照以来的利润峰值与谷底；<b>最大回撤</b> = 从利润峰到其后最深谷的跌幅（% 仅在利润全程为正时给出，否则只报金额）；<b>距利润峰值</b> = 今天离它还差多少；<b>恢复%</b> = 从最深处反弹回来多少（100%＝已回峰值，0%＝仍在底部）。<br>下半区灰色 = <b>净值口径（市值＋已实现）</b>，<b>仅供参考</b>：买入会把它抬高（花掉的现金不计入净值），所以它常显示"假新高"——别把它当真峰值。<span id="extremes-window" class="muted"></span></p>
       <div class="ext-grid" id="ext-grid">
         <div class="ext-region" id="ext-region-combined"></div>
         <div class="ext-region" id="ext-region-us"></div>
         <div class="ext-region" id="ext-region-hk"></div>
+      </div>
+    
       </div>
     </div>
 
@@ -565,8 +576,14 @@ layout: null
   <section class="panel" data-panel="market">
     <h2>Signals</h2>
 
-    <div class="card fold-m" id="quant-card" data-fold-id="quant" style="display:none">
-      <h3>量化因子 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">趋势·动量·RSI·吊灯止损·vol仓位 <span id="quant-asof"></span></span><span class="peek" id="peek-quant"></span></h3>
+    <div class="card desktop-wide" id="tape-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">盘面 · 同一批标的只看一遍</div>
+        <h3>按标的的盘面</h3>
+      </div></div>
+      <div class="sub-block" id="quant-card" style="display:none">
+        <div class="sub-block-head">量化因子 <span class="muted">趋势 · 动量 · RSI · 吊灯止损 · vol 仓位</span><span id="quant-asof"></span><span class="peek" id="peek-quant"></span></div>
+      
       <div class="table-wrap">
         <table class="holdings-table" id="quant-table" style="min-width:560px;font-size:12px">
           <thead><tr><th>标的</th><th>信号</th><th class="num">RSI</th><th class="num">z20</th><th class="num">距200线</th><th class="num">吊灯距</th><th class="num">vol权重</th></tr></thead>
@@ -574,10 +591,11 @@ layout: null
         </table>
       </div>
       <div class="muted" id="quant-edge" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
-    </div>
-
-    <div class="card fold-m" id="t0-card" data-fold-id="t0" style="display:none">
-      <h3>T+0 牌面 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">做T前先看牌面·非买卖信号 <span id="t0-asof"></span></span><span class="peek" id="peek-t0"></span></h3>
+    
+      </div>
+      <div class="sub-block" id="t0-card" style="display:none">
+        <div class="sub-block-head">T+0 牌面 <span class="muted">做 T 前先看牌面 · 非买卖信号</span><span id="t0-asof"></span><span class="peek" id="peek-t0"></span></div>
+      
       <div class="table-wrap">
         <table class="holdings-table" id="t0-table" style="min-width:520px;font-size:12px">
           <thead><tr><th>标的</th><th>牌面</th><th class="num">区间位</th><th class="num">今日%</th><th class="num">跳空%</th><th class="num">振幅/ATR</th></tr></thead>
@@ -585,52 +603,74 @@ layout: null
         </table>
       </div>
       <div class="muted" id="t0-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
-    </div>
-
-    <div class="card">
-      <h3>Catalysts <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(next 14d)</span></h3>
-      <div class="catalysts-list" id="catalysts-list">
-        <div class="empty-state">No upcoming catalysts.</div>
+    
       </div>
     </div>
 
-    <div class="card">
-      <h3>影响力雷达 <span class="muted" id="infl-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Trump · Musk · Serenity · LLM筛</span></h3>
-      <div class="infl-summary" id="infl-summary"></div>
-      <div class="infl-feed" id="infl-feed">
-        <div class="empty-state">No influence signals.</div>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3>US News Digest <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(LLM · 48h)</span></h3>
-      <div class="news-digest" id="news-digest">
-        <div class="empty-state">No digest yet.</div>
-      </div>
-    </div>
-
-    <div class="card lead">
-      <h3>Macro · Sentiment</h3>
+    <div class="card desktop-wide" id="macro-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">宏观与日程</div>
+        <h3>宏观与日程</h3>
+      </div></div>
+      <div class="sub-block">
+        <div class="sub-block-head">宏观 · 情绪</div>
+      
       <div id="regime-badge" class="regime-badge" style="display:none"></div>
       <div id="risk-banner" class="risk-banner" style="display:none"></div>
       <div class="macro-row" id="macro-row">
         <div class="empty-state">No macro data.</div>
       </div>
       <div id="sentiment-drill" class="sentiment-drill"></div>
-    </div>
-
-    <div class="card">
-      <h3>同行背离 <span class="muted" id="peer-div-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Peer Divergence</span></h3>
-      <div class="peer-div-list" id="peer-div-list">
-        <div class="empty-state">No peer divergence flagged.</div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">催化剂日程 <span class="muted">未来 14 天</span></div>
+      
+      <div class="catalysts-list" id="catalysts-list">
+        <div class="empty-state">No upcoming catalysts.</div>
+      </div>
+    
       </div>
     </div>
 
-    <div class="card lead">
-      <h3>板块全景 <span class="muted" id="sector-context-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">—</span></h3>
+    <div class="card desktop-wide" id="news-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">消息与背离</div>
+        <h3>消息与背离</h3>
+      </div></div>
+      <div class="sub-block">
+        <div class="sub-block-head">影响力雷达 <span class="muted">Trump · Musk · Serenity</span><span class="muted" id="infl-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Trump · Musk · Serenity · LLM筛</span></div>
+      
+      <div class="infl-summary" id="infl-summary"></div>
+      <div class="infl-feed" id="infl-feed">
+        <div class="empty-state">No influence signals.</div>
+      </div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">美股新闻摘要 <span class="muted">LLM · 48h</span></div>
+      
+      <div class="news-digest" id="news-digest">
+        <div class="empty-state">No digest yet.</div>
+      </div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">板块全景<span class="muted" id="sector-context-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">—</span></div>
+      
       <p class="chart-hint" id="sector-narrative" style="display:none"></p>
       <div class="sector-context" id="sector-context">
         <div class="empty-state">等待今日 brief 写入 sector-scan（08:00 HKT 后刷新）</div>
+      </div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">同行背离<span class="muted" id="peer-div-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Peer Divergence</span></div>
+      
+      <div class="peer-div-list" id="peer-div-list">
+        <div class="empty-state">No peer divergence flagged.</div>
+      </div>
+    
       </div>
     </div>
 
@@ -679,23 +719,36 @@ layout: null
 
     <div class="sect-divider">决策质量 · 自评</div>
 
-    <div class="card llm-card" id="behavioral-review-card" style="display:none">
-      <h3>行为复盘 <span class="muted llm-tag">LLM · 每日 brief 刷新</span></h3>
+    <div class="card desktop-wide" id="self-grade-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">自评 · Python 结算，模型不给自己打分</div>
+        <h3>自评</h3>
+      </div></div>
+      <div class="sub-block" id="honesty-card">
+        <div class="sub-block-head">诚实自评 <span class="muted">30 日 · episode 级</span></div>
+        <div id="honesty-body" style="font-size:12px"></div>
+      
+      </div>
+      <div class="sub-block" id="behavioral-review-card" style="display:none">
+        <div class="sub-block-head">行为复盘 <span class="muted">LLM · 每日 brief 刷新</span></div>
+      
       <p class="chart-hint">基于 v2 decision episode 的复盘：触发、执行、策略收益分别计算，避免把同股不同策略混在一起。</p>
       <div class="br-verdict" id="br-verdict"></div>
       <div id="br-points"></div>
       <div class="llm-src" id="br-src"></div>
-    </div>
-
-    <div class="card" id="decision-audit-card" style="display:none">
-      <h3>单事件择时诊断</h3>
+    
+      </div>
+      <div class="sub-block" id="decision-audit-card" style="display:none">
+        <div class="sub-block-head">单事件择时诊断 <span class="muted">AI 成交价 vs 同日收盘</span></div>
+      
       <p class="chart-hint">只回答「触发价 vs 同日收盘执行好多少」；同票、同日、同方向、同股数严格配对。换仓不跨票比较，HKD/USD 分区，不画累计金额。</p>
       <div class="timing-zones" id="timing-zones"></div>
       <div class="timing-events" id="timing-events"></div>
-    </div>
-
-    <div class="card">
-      <h3>Calibration · 30d</h3>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">校准 Calibration <span class="muted">30 日</span></div>
+      
       <div class="calib-badge" id="calib-badge">
         <div>
           <div class="brier-val" id="brier-val">—</div>
@@ -704,10 +757,11 @@ layout: null
         <div class="tier" id="brier-tier">—</div>
       </div>
       <div class="meta" id="alpha-line" style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border)">—</div>
-    </div>
-
-    <div class="card">
-      <h3>Plan Review <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(last 30d)</span></h3>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">计划复盘 <span class="muted">最近 30 日</span></div>
+      
       <p class="chart-hint">每天 08:00 brief 写的建议，次日起看你有没有照做。输赢和触发判断走未复权的逐日行情（单一行情源、按各自市场的交易日），休市或需人工核实的不计入胜率，条数标在下面。</p>
       <div class="revision-note">
         <b>2026-07-15 数据修订</b>：触发与结算已从会漂移的持仓快照改为未复权的逐日行情，按各市场交易日历计算，
@@ -749,15 +803,18 @@ layout: null
           <div class="empty-state" style="font-size:11px">No driver data yet.</div>
         </div>
       </div>
-    </div>
-
-    <div class="card" id="shadow-card" style="display:none">
-      <h3>AI 主动建议的战绩</h3>
+    
+      </div>
+      <div class="sub-block" id="shadow-card" style="display:none">
+        <div class="sub-block-head">AI 主动建议的战绩</div>
+      
       <div class="retired-note">
         <p>现有记录目前<b>算不出可靠的累计金额</b>：真实成交、可核验行情和统一对照口径仍有缺口，所以不展示金额。下面只显示<b>方向判断的命中情况，不代表实际收益</b>。</p>
       </div>
       <div class="trig-title" style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-dim);margin:16px 0 4px;font-weight:600">AI cumulative episode win rate — v1 migrated + v2</div>
       <div id="chart-ai-winrate" class="chart-box" style="height:210px;min-height:210px"></div>
+    
+      </div>
     </div>
 
     <div class="sect-divider">决策轨迹 · 真实成交 vs 当时计划</div>
@@ -771,8 +828,14 @@ layout: null
 
     <div class="sect-divider">净值表现 · portfolio</div>
 
-    <div class="card">
-      <h3>Track Record <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(USD-eq · 全期)</span></h3>
+    <div class="card desktop-wide" id="curve-card">
+      <div class="card-head"><div>
+        <div class="overview-card-kicker">曲线与分解</div>
+        <h3>曲线与分解</h3>
+      </div></div>
+      <div class="sub-block">
+        <div class="sub-block-head">战绩曲线 <span class="muted">USD-eq · 全期</span></div>
+      
       <p class="chart-hint">三个回报率并排看：<b>当前浮动率</b>只看现持仓账面（贴近"我现在亏多少"直觉）；<b>总回报率</b>用累计投入本金(成本+已实现)做分母 —— 看"盈利垫"还剩多少，是保守口径；<b>净本金回报率</b>分母优先用<b>真实本金</b>(true_principal＝交易现金流账本反推的峰值净投入，即实际自掏现金；缺时回退 成本−已实现) —— 反映你自有现金的真实复利回报，比"成本−已实现"更诚实（后者会被卖出回笼把分母做小而虚高）。</p>
       <div class="kpi-grid">
         <div class="kpi-cell">
@@ -823,6 +886,30 @@ layout: null
           <div class="mkt-card-skel">—</div>
         </div>
       </div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">已实现 vs 浮动 <span class="muted">分市场，不跨币种相加</span></div>
+      
+      <p class="chart-hint">已兑现（绿）vs 浮动（蓝）—— 兑现的是真金白银，浮动是账面。两根加起来 = 总盈亏。</p>
+      <div id="chart-realized" class="chart-box" style="height:220px"></div>
+    
+      </div>
+      <div class="sub-block">
+        <div class="sub-block-head">Delta <span class="muted">US / HK</span></div>
+      
+      <div class="table-wrap">
+        <table class="delta-table">
+          <thead>
+            <tr><th>Period</th><th>US</th><th>HK</th></tr>
+          </thead>
+          <tbody id="delta-tbody">
+            <tr><td colspan="3" class="muted">—</td></tr>
+          </tbody>
+        </table>
+      </div>
+    
+      </div>
     </div>
 
     <div class="card">
@@ -836,26 +923,6 @@ layout: null
       </div>
       <p class="chart-hint">每日净盈亏柱状（绿涨红跌）+ 累计盈亏曲线。柱在零下方 = 当日亏损；曲线走势看长期方向。<b>跟随上方市场切换</b>：总览=USD-eq，美股=$，港股=HK$。</p>
       <div id="chart-daily-pnl" class="chart-box"></div>
-    </div>
-
-    <div class="card">
-      <h3>Realized vs Unrealized</h3>
-      <p class="chart-hint">已兑现（绿）vs 浮动（蓝）—— 兑现的是真金白银，浮动是账面。两根加起来 = 总盈亏。</p>
-      <div id="chart-realized" class="chart-box" style="height:220px"></div>
-    </div>
-
-    <div class="card">
-      <h3>Delta</h3>
-      <div class="table-wrap">
-        <table class="delta-table">
-          <thead>
-            <tr><th>Period</th><th>US</th><th>HK</th></tr>
-          </thead>
-          <tbody id="delta-tbody">
-            <tr><td colspan="3" class="muted">—</td></tr>
-          </tbody>
-        </table>
-      </div>
     </div>
 
   </section>

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -257,7 +257,7 @@ async function testCurrentHoldingsOwnDecisionMatrixMembership(browser, base) {
     const active = [...(DATA.holdings?.us || []), ...(DATA.holdings?.hk || [])]
       .filter(row => row && row.is_active !== false && (row.shares ?? 0) > 0)
       .map(row => row.ticker).sort();
-    const rendered = [...document.querySelectorAll("#decision-matrix-tbody tr td:first-child strong")]
+    const rendered = [...document.querySelectorAll("#book-tbody tr.book-row td:first-child .ticker")]
       .map(cell => cell.textContent.trim()).sort();
     return { active, rendered };
   });

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -856,15 +856,21 @@ def test_pages_prefers_projection_and_keeps_a_backward_fallback():
     assert 'brief_projection: "drill"' in ui
     assert 'safe(DATA, "brief_projection")' in renderer
     assert "projection.schema_version === 1" in renderer
-    assert "const projectedByTicker = new Map" in renderer
-    assert "const enriched = holds.map" in renderer
-    assert "projectedByTicker.get(h.ticker)" in renderer
+    # 四张按 ticker 的表合并成一张可展开主表后（#875），projection 的优先级
+    # 由 bookEvidence() 归堆、renderBook 消费；契约不变：有 projection 就用它的
+    # technical/risk，没有才回落到 quant_signals。
+    assert "const ev = bookEvidence()" in renderer
+    assert 'put(r.ticker, "proj", r)' in renderer
+    assert "const proj = e.proj" in renderer
+    assert "q = proj.technical || q" in renderer
     assert "(h.shares ?? 0) > 0" in renderer
     # The compiled status schema is {rank, label, state}; keep the Pages
     # consumer on the same key so a populated projection cannot print
     # JavaScript's literal "undefined" in the 综合 column.
-    assert "${v.label}" in renderer
-    assert "${v.txt}" not in renderer
+    # 消费的仍是 {rank,label,state} 里的 label（不是 txt），且现在还过了转义：
+    # 合并前这一格是原样插进模板的。
+    assert "escapeHtml(v.label)" in renderer
+    assert "v.txt" not in renderer
     # Both reads go through package-owned tool contracts; neither requires a
     # Python source file in the KCNyu workspace.
     assert "decision_packet_summary" in skill

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -33,9 +33,10 @@ def enclosing_desktop_block(rule_start):
 
 
 def test_wide_table_and_profit_cards_own_desktop_width():
-    assert 'class="card desktop-wide" id="decision-matrix-card"' in HTML
-    assert 'class="card desktop-wide" id="holdings-card"' in HTML
-    assert 'class="card lead profit-extremes-card"' in HTML
+    # 决策矩阵与持仓表已合并成一张可展开主表（#875）；契约不变：宽表独占桌面宽度
+    assert 'class="card desktop-wide" id="book-card"' in HTML
+    assert 'class="card desktop-wide" id="tape-card"' in HTML
+    assert 'profit-extremes-card" id="recovery-card"' in HTML
     assert ".panel.active > .card.desktop-wide," in CSS
 
 
@@ -47,12 +48,11 @@ def test_holdings_dividers_do_not_partition_the_masonry_flow():
     assert "break-after: avoid" in rule
     assert ".holdings-section-heading" in CSS
     assert ".price-section-heading," in CSS
-    assert 'id="movers-card"' in HTML
-    assert 'id="anomalies-card"' in HTML
-    assert HTML.count('class="desktop-section-kicker"') == 5
-    assert HTML.count(
-        'class="desktop-section-kicker" role="heading" aria-level="2"'
-    ) == 2
+    # movers / anomalies 合并成一张「今日异动」卡（#877）。原来每张卡各挂一个
+    # desktop-section-kicker 来标同一段落，合并后一段只需要一个标题，所以这里
+    # 断的是「分节标题没有重复」而不是原来的固定条数。
+    assert 'id="today-action-card"' in HTML
+    assert HTML.count('class="desktop-section-kicker"') <= 2
 
 
 def test_webkit_reflect_uses_desktop_only_ordinary_flow_fallback():

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -6,8 +6,10 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_sort_headers_never_reinterpret_dom_text_as_html():
     renderer = (ROOT / "site" / "assets" / "js" / "dashboard.render.js").read_text()
+    # 持仓表合并后（#875），排序接线在 renderBook 里，后面紧跟的不再是
+    # renderShadowPortfolioCard，所以用成对的标记注释精确圈出这段。
     sort_headers = renderer.split("// Wire sort headers", 1)[1].split(
-        "function renderShadowPortfolioCard", 1
+        "// end sort headers", 1
     )[0]
 
     assert ".innerHTML" not in sort_headers


### PR DESCRIPTION
Closes #871, closes #872, closes #873, closes #874, closes #875, closes #876, closes #877

线上 dashboard 的一次结构 + 首屏重排。**合并只换容器，不删信息**——下面有逐项对照的证据。

## 1. 首屏 (#874 · #872)

| 之前 | 现在 |
| --- | --- |
| 最大的数字 = `TOTAL BOOK $12,579`（账面市值，随行情自己变，不需要判断） | 最大的数字 = **总盈亏 −$2,175**（已实现 +$3,273 · 浮动 −$5,448 · 账面 $12,579 / HK$98,666 · 今日 +$807 +6.86%） |
| 三张不等重的卡：book(5) + today(4) + discipline(3) | 一块指挥台 + 8 格统计轨 |
| 回撤轴 `0% / -0% / -1% / -1% / -1%` | `0.0% / -0.3% / -0.5% / -0.8% / -1.0%` |
| 图上方三行散文 + 6 条图例 | 散文折进「口径说明」 |
| `TOTAL BOOK` / `DECISION PANEL` / `TOP HARD GATES` … | 中文标签 |

**口径更正**：`totals.pnl` 是浮动（市值 − 成本），把它当「总盈亏」摆首屏是错的。现在主数 = 已实现 + 浮动，和 Reflect 的总回报率分子同源（−$2,175 ÷ $21,300 = −10.21% 对得上）。

**一个容易踩的点**：首屏第一帧吃的是精简的 `overview.json`，里面**没有** `realized_vs_unrealized`，所以已实现优先读 rv、缺了就从 `totals.realized_*` 现算，否则首屏会稳定显示两个破折号。

回撤轴根因在 `dashboard.charts.js:465` 的 `(i * minDd / 4).toFixed(0)`：`minDd` 只有 −1.4% 时五个刻度是 0 / −0.35 / −0.7 / −1.05 / −1.4，被压成三个重复值外加一个 `-0%`。精度改为跟着步长走。

`#872` 的验收第 3 条（大数字禁断行、见 #111 教训）：hero 主数从 `overflow-wrap:anywhere` 改成 `white-space:nowrap` + 更低的字号下限。

## 2. 数据健康 (#876)

原来**不是没有**，是被压成页脚 `268×29px` 一条，逐文件明细全塞在 `title` 属性里——触屏打不开，读屏和搜索也拿不到。现在提到首屏：判词 + 计数 + 期限用量带 + 「逐项」展开，**每个文件带中文名**（`peer_residual.json → 同行残差`），未登记的新文件回落到去掉后缀的原名。

两条实现判据：
- **判过期只认 `f.stale`**。`files[]` 有 `max_age` 和 `scheduled_fire` 两种新鲜度模式，线上 `catalysts.json` 56h 对着 SLA 30h 却不是 stale（它比的是 `deadline_at`）。自己再算一遍 `age > sla` 会造出一批假警报。
- 未 stale 的期限用量封顶 0.7，否则会画出一根满格的条却标着「在期」。

页脚那条的 🔴🟡🟢 换成 CSS 圆点 + 文字。

## 3. 持仓明细 (#875)

决策矩阵 / Holdings / 今日区间 / 最强最弱 四张**按 ticker 各排一遍**的表合成一张主表：行可点开（鼠标 + 键盘 + `aria-expanded`），展开内容 = 这只票的全部证据（技术 / 当日区间 / 硬闸动作 / 回本数学 / 同行背离 / T+0 牌面 / 最近计划与成交 / 空头论点与该票消息）。原来这些散在四个块 + Risk 页的解套数学 + Signals 页的同行背离。

Add Campaign：十只票十张卡、每张重复同样四个 pill，等于同一句话说十遍。全员同态时收敛成一行摘要（可展开看全部），**977px → 476px**。标题拼接缺分隔（`ADD CAMPAIGNideas 0`）一并修掉。

## 4. 卡片合并 (#877 · #871)

| tab | 之前 | 现在 |
| --- | --- | --- |
| Overview | 6 | 5 |
| Holdings | 10 | 5 |
| Risk | 9 | 4 |
| Signals | 8 | 3 |
| Plan | 4 | 4 |
| Reflect | 10 | 4 |
| **合计** | **47** | **25** |

`#871` 的验收是「Hero 卡数 ≤ 7」→ 5；层级靠跨列表达（指挥台 span 12 / 曲线 span 8 / 判定 span 4）。`#871` 原方案是「6 tab 改 Bento 网格」，kcn 看过一页式原型后选择了保留 tab、合并卡片这条路径，所以按合并口径结案。

## 5. 动效 tokens (#873)

四个 token 定义在 `:root`，全站 `transition` 一律引用，**裸 `cubic-bezier` 清零**（改前 10 处）。新增的展开动画走 `grid-template-rows: 0fr→1fr` + `--duration-standard`，`prefers-reduced-motion` 下关闭。

## 信息不丢的证据

合并最大的风险是悄悄丢东西，所以做了**数字级逐项对照**：用同一份 payload 分别渲染 master 和本分支，遍历六个 tab 抓取面板全文里的所有数字 token，做差集。

```
hero:    同 tab 缺 12（12 个搬到 Reflect 了）→ 真正消失 0
drill:   同 tab 缺 14（5 个是小数位差异）    → 真正消失 9
risk:    0    market: 0    plan: 0    reflect: 0
```

剩下的 9 个是 **ECharts 轴刻度标签**：合并后图表从 647px 变宽到 1350px，坐标轴自己选了另一组刻度值（`3043.6 / 2850.1 / …`）。5 个「小数位差异」是同一个值的两种写法（master 的决策矩阵打 `-11.9%`，主表打 `-11.90%`）——精度是升的。

## 验证

- `node tests/dashboard_tab_runtime.spec.js` → exit 0
- `pytest tests/` 全量跑（结果见下方评论）；dashboard 相关模块 40 passed
- 浅色 / 深色 / 390px 手机：0 page error，0 横向溢出
- 四条钉在旧实现字符串上的契约测试随之更新，**契约本身没有放宽**：宽表独占桌面宽度、排序表头不得把 DOM 文本当 HTML 重新解释、持仓成员以账本为准而非 projection、综合列消费 `{rank,label,state}` 的 `label`（现在还多过一层 `escapeHtml`）。

## 过程中自己踩的三个坑（都已修，记在这里以免下次重犯）

1. `hero.js`（关键路径）和 `render.js`（全量包）是**手工维护的两份同名实现**，改动必须同步。第一次按「下一个函数」切边界替换，在 render.js 误删了 `renderMovers` 等——改成按大括号配平取函数区间。
2. 取卡片区块的正则用了 `finditer(html, 0, i+1)`，而 `endpos` 要求整个匹配落在区间内，于是 marker 本身就是开标签时会**回溯到上一张卡**。
3. 合并卡的插入点用了「specs 里的第一个」，但删除是从后往前做的，下标漂移把 macro 卡插进了 news 卡肚子里。插入点必须取**文档里最靠前的那块**。

https://claude.ai/code/session_015wP85vNqYjs8NjEQbY3cej
