### PR TITLE
开屏减负 + 全站字阶 token 化 + 走势并进持仓表，修 holdings 溢出 (#879 #880 #881)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -63,6 +63,17 @@
   --ease-in-out: cubic-bezier(.77, 0, .175, 1);
   --duration-fast: 150ms;
   --duration-standard: 240ms;
+
+  /* 字阶（#880）：全站只有这 8 档，禁裸 px 字号。
+     mono 只用于数字与代码，sans 用于所有文字。 */
+  --fs-display: clamp(30px, 3.4vw, 48px);
+  --fs-xxl: 26px;
+  --fs-xl: 19px;
+  --fs-lg: 15px;
+  --fs-md: 13px;
+  --fs-sm: 12px;
+  --fs-xs: 11px;
+  --fs-micro: 10px;
 }
   @media (prefers-color-scheme: light) {
     :root {
@@ -140,14 +151,14 @@
     background-attachment: fixed;
     color: var(--text);
     font-family: var(--font);
-    font-size: 14px;
+    font-size: var(--fs-md);
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     padding-bottom: env(safe-area-inset-bottom);
   }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  code { font-family: var(--mono); font-size: 0.9em; }
+  code { font-family: var(--mono); font-size: var(--fs-xs); }
 
   /* =========================================================
      Sticky header + tab bar
@@ -178,13 +189,13 @@
     width: 26px; height: 26px; flex: 0 0 auto; display: block;
   }
   .brand h1 {
-    margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.01em;
+    margin: 0; font-size: var(--fs-xl); font-weight: 700; letter-spacing: -0.01em;
     /* `.brand` may shrink (min-width: 0), and an un-clipped h1 then paints on
        top of the nav links instead of getting narrower. Truncate instead. */
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .brand .updated {
-    font-size: 11px; color: var(--text-dim);
+    font-size: var(--fs-xs); color: var(--text-dim);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   @media (max-width: 480px) {
@@ -200,7 +211,7 @@
     appearance: none; background: transparent; color: var(--text-dim);
     border: 0; border-radius: 50%;
     width: 34px; height: 34px; min-width: 34px; min-height: 34px;
-    padding: 0; font-size: 16px; cursor: pointer;
+    padding: 0; font-size: var(--fs-lg); cursor: pointer;
     display: inline-flex; align-items: center; justify-content: center;
     flex: 0 0 auto;
     transition: background var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out);
@@ -215,25 +226,25 @@
   .refresh-btn.ok-flash { color: var(--green); }
   .refresh-btn.fresh-flash { color: var(--accent); }
   .refresh-btn.fresh-flash .ic { font-size: 0; }
-  .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: 14px; }
+  .refresh-btn.fresh-flash .ic::after { content: "✓"; font-size: var(--fs-md); }
   .refresh-btn[disabled] { opacity: 0.6; cursor: not-allowed; }
   @keyframes spin { to { transform: rotate(360deg); } }
   .topbar-actions { display: inline-flex; align-items: center; gap: 4px; }
   .nav-link {
-    color: var(--text-dim); text-decoration: none; font-size: 13px;
+    color: var(--text-dim); text-decoration: none; font-size: var(--fs-md);
     padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); transition: background 0.15s, color 0.15s;
   }
   @media (hover: hover) and (pointer: fine) {
     .nav-link:hover { color: var(--text); background: var(--card-2); }
   }
   @media (max-width: 480px) {
-    .nav-link { padding: var(--space-2); font-size: 12px; }
+    .nav-link { padding: var(--space-2); font-size: var(--fs-sm); }
   }
   @media (max-width: 400px) {
     /* Last few pixels at 360–390: tighten the row rather than let the brand
        hit its ellipsis. Nav-link padding stays put — it is the tap target. */
     .topbar-actions { gap: 4px; }
-    .brand h1 { font-size: 18px; }
+    .brand h1 { font-size: var(--fs-xl); }
   }
 
   .tabs {
@@ -247,7 +258,7 @@
     appearance: none; background: transparent; color: var(--text-dim);
     border: none; position: relative;
     padding: var(--space-3) var(--space-4); min-height: 44px;
-    font-size: 14px; font-weight: 500; cursor: pointer;
+    font-size: var(--fs-md); font-weight: 500; cursor: pointer;
     white-space: nowrap;
     transition: color var(--duration-fast) ease, background var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out);
   }
@@ -290,7 +301,7 @@
          it either way. */
     }
     .tab-btn {
-      padding: 10px 18px; min-height: 40px; font-size: 13.5px; font-weight: 550;
+      padding: 10px 18px; min-height: 40px; font-size: var(--fs-md); font-weight: 500;
       border-radius: 8px 8px 0 0; transition: color .15s, background .15s;
     }
     @media (hover: hover) and (pointer: fine) {
@@ -311,7 +322,7 @@
   .mkt-seg-btn { display: inline-flex; align-items: center; justify-content: center;
     gap: 5px; appearance: none; background: transparent; color: var(--text-dim);
     border: none; border-radius: var(--radius-sm); padding: 5px 11px; min-height: 30px;
-    font-size: 12px; font-weight: 600; line-height: 1; cursor: pointer;
+    font-size: var(--fs-sm); font-weight: 600; line-height: 1; cursor: pointer;
     white-space: nowrap; transition: background var(--duration-fast) ease, color var(--duration-fast) ease, transform var(--duration-fast) var(--ease-out); }
   .mkt-seg-btn:active { transform: scale(0.97); }
   /* iOS-style raised pill for the active segment → colored dots stay visible */
@@ -359,7 +370,7 @@
       content: "Not investment advice · point-in-time · past performance ≠ future results";
       display: block; margin-top: 16px; padding: 12px 0 4px;
       border-top: 1px solid var(--border);
-      font-size: 10px; color: var(--text-faint); text-align: center; line-height: 1.5;
+      font-size: var(--fs-micro); color: var(--text-faint); text-align: center; line-height: 1.5;
     }
     main {
       flex: 1 1 auto; min-height: 0; min-width: 0; max-width: 100%;
@@ -465,7 +476,7 @@
       display: block;
       margin-bottom: 10px;
       color: var(--text-dim);
-      font: 700 10px var(--mono);
+      font: 700 var(--fs-micro) var(--mono);
       letter-spacing: .06em;
       text-transform: uppercase;
     }
@@ -533,7 +544,7 @@
   }
   .card h3 {
     margin: 0 0 var(--space-3);
-    font-size: 12px; font-weight: 600;
+    font-size: var(--fs-sm); font-weight: 600;
     color: var(--text-dim); text-transform: uppercase;
     letter-spacing: 0.06em;
   }
@@ -547,7 +558,7 @@
      ========================================================= */
   .card.fold-m > h3 .peek {
     display: none; text-transform: none; letter-spacing: 0;
-    font-family: var(--mono); font-weight: 600; font-size: 11px;
+    font-family: var(--mono); font-weight: 600; font-size: var(--fs-xs);
     color: var(--text); margin-left: 8px; vertical-align: middle;
   }
   @media (max-width: 1023px) {
@@ -560,7 +571,7 @@
     .card.fold-m > h3::after {
       content: "›"; position: absolute; right: 2px; top: 50%;
       transform: translateY(-50%) rotate(90deg); transition: transform .15s;
-      color: var(--text-faint); font-size: 15px; font-weight: 400;
+      color: var(--text-faint); font-size: var(--fs-lg); font-weight: 400;
     }
     .card.fold-m.open > h3 { margin-bottom: var(--space-3); }
     .card.fold-m.open > h3::after { transform: translateY(-50%) rotate(-90deg); }
@@ -601,23 +612,23 @@
   }
   .market-cell .lbl {
     grid-column: 1 / -1;
-    font-size: 10px; color: var(--text-dim);
+    font-size: var(--fs-micro); color: var(--text-dim);
     text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;
   }
   .market-cell .val {
-    font-size: 20px; font-weight: 700; margin: var(--space-1) 0 0;
+    font-size: var(--fs-xl); font-weight: 700; margin: var(--space-1) 0 0;
   }
   .market-cell .pct {
-    font-size: 13px; font-weight: 600; text-align: right;
+    font-size: var(--fs-md); font-weight: 600; text-align: right;
   }
   .market-cell .src {
     grid-column: 1 / -1;
-    font-size: 9px; color: var(--text-faint); margin-top: var(--space-1);
+    font-size: var(--fs-micro); color: var(--text-faint); margin-top: var(--space-1);
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .market-cell.stale::after {
     content: "⚠"; position: absolute; top: 4px; right: 8px;
-    color: var(--text-faint); font-size: 11px;
+    color: var(--text-faint); font-size: var(--fs-xs);
   }
   @media (max-width: 560px) {
     .market-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -646,9 +657,9 @@
     border-bottom: 1px solid var(--border-subtle);
     min-height: 82px;
   }
-  .total-leg .lbl { font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
-  .total-leg .val { font-size: 24px; font-weight: 700; margin: var(--space-1) 0 0; font-variant-numeric: tabular-nums; }
-  .total-leg .sub { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .total-leg .lbl { font-size: var(--fs-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
+  .total-leg .val { font-size: var(--fs-xxl); font-weight: 700; margin: var(--space-1) 0 0; font-variant-numeric: tabular-nums; }
+  .total-leg .sub { font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
   .total-combined {
     margin-top: 0;
     background: var(--surface-1);
@@ -658,12 +669,12 @@
     border-bottom: 1px solid var(--border-subtle);
   }
   .total-combined > div { flex: 1 1 130px; min-width: 0; min-height: 66px; }
-  .total-combined .lbl { font-size: 11px; color: var(--text-dim); }
+  .total-combined .lbl { font-size: var(--fs-xs); color: var(--text-dim); }
   .total-combined .val {
-    font-size: 32px; line-height: 1.15; font-weight: 700;
+    font-size: var(--fs-xxl); line-height: 1.15; font-weight: 700;
     margin-top: var(--space-1); font-variant-numeric: tabular-nums;
   }
-  .total-combined .fx { font-size: 11px; color: var(--text-faint); }
+  .total-combined .fx { font-size: var(--fs-xs); color: var(--text-faint); }
 
   .pos { color: var(--green); }
   .neg { color: var(--red); }
@@ -673,7 +684,7 @@
   .catalysts-list { display: flex; flex-direction: column; gap: var(--space-2); max-height: 240px; overflow-y: auto; }
   .catalyst-row {
     padding: var(--space-2) var(--space-3); background: var(--card-2); border-radius: var(--radius-sm);
-    font-size: 12px; display: grid; grid-template-columns: 70px 80px 1fr; gap: var(--space-2);
+    font-size: var(--fs-sm); display: grid; grid-template-columns: 70px 80px 1fr; gap: var(--space-2);
   }
   .catalyst-row .date { font-family: var(--mono); color: var(--text-dim); }
   .catalyst-row .ticker { font-family: var(--mono); font-weight: 600; color: var(--accent); }
@@ -682,13 +693,13 @@
   .catalyst-row.macro .ticker { color: var(--warning); }
 
   /* News digest markdown */
-  .news-digest { font-size: 13px; line-height: 1.5; max-height: 360px; overflow-y: auto; }
-  .news-digest h3 { font-size: 13px; color: var(--accent); margin: 12px 0 4px; }
+  .news-digest { font-size: var(--fs-md); line-height: 1.5; max-height: 360px; overflow-y: auto; }
+  .news-digest h3 { font-size: var(--fs-md); color: var(--accent); margin: 12px 0 4px; }
   .news-digest h3:first-child { margin-top: 0; }
   .news-digest ul { padding-left: 18px; margin: 4px 0; }
   .news-digest li { margin: 3px 0; }
   .news-digest strong { color: var(--text); }
-  .news-digest .digest-meta { color: var(--text-dim); font-size: 11px; margin-bottom: 8px; }
+  .news-digest .digest-meta { color: var(--text-dim); font-size: var(--fs-xs); margin-bottom: 8px; }
 
   /* Macro row */
   .macro-row { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
@@ -696,18 +707,18 @@
     background: var(--card-2); border-radius: var(--radius-sm);
     padding: var(--space-3) var(--space-2); text-align: center; font-variant-numeric: tabular-nums;
   }
-  .macro-cell .lbl { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
-  .macro-cell .val { font-size: 17px; font-weight: 700; }
-  .macro-cell .sub { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+  .macro-cell .lbl { font-size: var(--fs-micro); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .macro-cell .val { font-size: var(--fs-lg); font-weight: 700; }
+  .macro-cell .sub { font-size: var(--fs-xs); color: var(--text-dim); margin-top: 2px; }
   .macro-cell.up   .sub { color: var(--positive); }
   .macro-cell.down .sub { color: var(--negative); }
 
   /* Regime badge (top of macro card) — risk_on / neutral / risk_off */
   .regime-badge { display:flex; align-items:center; gap:8px; padding:8px 12px; border-radius:var(--radius-sm);
-    margin-bottom:var(--space-3); font-size:12px; border:1px solid var(--border); }
+    margin-bottom:var(--space-3); font-size: var(--fs-sm); border:1px solid var(--border); }
   .regime-badge .rg-dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
-  .regime-badge .rg-label { font-weight:800; text-transform:uppercase; letter-spacing:0.04em; }
-  .regime-badge .rg-reasons { color: var(--text-dim); font-size:11px; }
+  .regime-badge .rg-label { font-weight:700; text-transform:uppercase; letter-spacing:0.04em; }
+  .regime-badge .rg-reasons { color: var(--text-dim); font-size: var(--fs-xs); }
   .regime-badge.risk_on  { background: color-mix(in srgb, var(--positive) 10%, transparent); border-color: color-mix(in srgb, var(--positive) 35%, transparent); }
   .regime-badge.risk_on  .rg-dot { background:var(--positive); } .regime-badge.risk_on  .rg-label { color:var(--positive); }
   .regime-badge.neutral  { background: rgba(148,163,184,0.10); border-color: rgba(148,163,184,0.35); }
@@ -725,14 +736,14 @@
   .risk-banner {
     margin-bottom: var(--space-3); padding: var(--space-2) var(--space-3);
     background: color-mix(in srgb, var(--negative) 10%, transparent); border-left: 3px solid var(--negative);
-    border-radius: var(--radius-sm); font-size: 12px; line-height: 1.5;
+    border-radius: var(--radius-sm); font-size: var(--fs-sm); line-height: 1.5;
   }
-  .risk-banner .rb-hdr { color: var(--negative); font-weight: 700; font-size: 11px;
+  .risk-banner .rb-hdr { color: var(--negative); font-weight: 700; font-size: var(--fs-xs);
     text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }
   .risk-banner .rb-row { color: var(--text); margin: 2px 0; }
   .risk-banner .rb-tk  { font-weight: 700; color: var(--negative); margin-right: 8px; }
   .risk-banner .rb-kw  { background: color-mix(in srgb, var(--negative) 15%, transparent); padding: 1px 5px;
-    border-radius: 3px; font-size: 11px; margin: 0 3px; }
+    border-radius: 3px; font-size: var(--fs-xs); margin: 0 3px; }
 
   /* Per-ticker sentiment drill (collapsible) */
   .sentiment-drill { margin-top: var(--space-3); display: flex; flex-direction: column; gap: 4px; }
@@ -740,25 +751,25 @@
   .sd-row summary {
     list-style: none; cursor: pointer; padding: var(--space-2) var(--space-3);
     display: grid; grid-template-columns: 56px 28px 1fr auto; gap: 8px; align-items: center;
-    font-size: 12px; font-variant-numeric: tabular-nums;
+    font-size: var(--fs-sm); font-variant-numeric: tabular-nums;
   }
   .sd-row summary::-webkit-details-marker { display: none; }
-  .sd-row summary::after { content: '▸'; color: var(--text-dim); font-size: 10px; }
+  .sd-row summary::after { content: '▸'; color: var(--text-dim); font-size: var(--fs-micro); }
   .sd-row[open] summary::after { content: '▾'; }
   .sd-row .sd-tk { font-weight: 700; color: var(--text); }
-  .sd-row .sd-reg { font-size: 10px; color: var(--text-dim); text-transform: uppercase; }
-  .sd-row .sd-counts { color: var(--text-dim); font-size: 11px; }
+  .sd-row .sd-reg { font-size: var(--fs-micro); color: var(--text-dim); text-transform: uppercase; }
+  .sd-row .sd-counts { color: var(--text-dim); font-size: var(--fs-xs); }
   .sd-row .sd-counts strong { color: var(--text); }
-  .sd-body { padding: 4px 12px 12px; font-size: 11.5px; line-height: 1.5; color: var(--text-dim); }
-  .sd-body .sd-grp { color: var(--text-dim); font-size: 10px; text-transform: uppercase;
+  .sd-body { padding: 4px 12px 12px; font-size: var(--fs-xs); line-height: 1.5; color: var(--text-dim); }
+  .sd-body .sd-grp { color: var(--text-dim); font-size: var(--fs-micro); text-transform: uppercase;
     letter-spacing: 0.05em; margin-top: var(--space-2); }
   .sd-body ul { margin: 2px 0 0; padding-left: 16px; }
   .sd-body li { margin: 1px 0; color: var(--text); }
-  .sd-body .sd-empty { color: var(--text-dim); font-style: italic; font-size: 11px; }
+  .sd-body .sd-empty { color: var(--text-dim); font-style: italic; font-size: var(--fs-xs); }
 
   /* Influence radar (Trump / Musk / Serenity feed) */
   .infl-feed { display: flex; flex-direction: column; gap: var(--space-2); max-height: 420px; overflow-y: auto; }
-  .infl-summary { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-bottom: 4px; font-size: 11px; }
+  .infl-summary { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-bottom: 4px; font-size: var(--fs-xs); }
   .infl-chip { padding: 2px 8px; border-radius: 999px; font-weight: 700; }
   .infl-chip.held { background: color-mix(in srgb, var(--negative) 14%, transparent); color: var(--negative); }
   .infl-chip.idea { background: color-mix(in srgb, var(--warning) 16%, transparent); color: var(--warning); }
@@ -769,23 +780,23 @@
   }
   .infl-row.is-held { border-left-color: var(--negative); }
   .infl-row.is-idea { border-left-color: var(--warning); }
-  .infl-hdr { display: flex; align-items: center; gap: var(--space-2); margin-bottom: 4px; font-size: 11px; flex-wrap: wrap; }
-  .infl-who { font-weight: 800; padding: 2px 8px; border-radius: 4px; font-size: 11px; }
+  .infl-hdr { display: flex; align-items: center; gap: var(--space-2); margin-bottom: 4px; font-size: var(--fs-xs); flex-wrap: wrap; }
+  .infl-who { font-weight: 700; padding: 2px 8px; border-radius: 4px; font-size: var(--fs-xs); }
   .infl-who.trump { background: color-mix(in srgb, var(--negative) 16%, transparent); color: var(--negative); }
   .infl-who.musk  { background: rgba(59,130,246,0.16); color: #3b82f6; }
-  .infl-stance { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em;
+  .infl-stance { font-size: var(--fs-micro); text-transform: uppercase; letter-spacing: 0.04em;
     padding: 2px 8px; border-radius: 3px; font-weight: 700; }
   .infl-stance.up   { background: color-mix(in srgb, var(--positive) 16%, transparent); color: var(--positive); }
   .infl-stance.down { background: color-mix(in srgb, var(--negative) 16%, transparent); color: var(--negative); }
   .infl-stance.flat { background: var(--card); color: var(--text-dim); }
-  .infl-rel { margin-left: auto; color: var(--text-dim); font-size: 10px; font-variant-numeric: tabular-nums; }
-  .infl-sum { font-size: 12.5px; line-height: 1.45; color: var(--text); }
-  .infl-tags { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 5px; font-size: 10.5px; }
+  .infl-rel { margin-left: auto; color: var(--text-dim); font-size: var(--fs-micro); font-variant-numeric: tabular-nums; }
+  .infl-sum { font-size: var(--fs-sm); line-height: 1.45; color: var(--text); }
+  .infl-tags { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 5px; font-size: var(--fs-micro); }
   .infl-tag { padding: 2px 8px; border-radius: 4px; font-weight: 700; }
   .infl-tag.held { background: color-mix(in srgb, var(--negative) 14%, transparent); color: var(--negative); }
   .infl-tag.idea { background: color-mix(in srgb, var(--warning) 16%, transparent); color: var(--warning); }
   .infl-tag.sect { background: var(--card); color: var(--text-dim); font-weight: 500; }
-  .infl-meta { color: var(--text-dim); font-size: 10px; margin-top: 4px; }
+  .infl-meta { color: var(--text-dim); font-size: var(--fs-micro); margin-top: 4px; }
 
   /* Peer divergence (your holding vs its sector peers, 1d) */
   .peer-div-list { display: flex; flex-direction: column; gap: var(--space-2); }
@@ -795,15 +806,15 @@
   }
   .peer-div-row.lag  { border-left-color: var(--negative); }   /* you trail peers */
   .peer-div-row.lead { border-left-color: var(--positive); }   /* you beat peers */
-  .pd-top { display: flex; align-items: baseline; gap: 8px; font-size: 13px; }
-  .pd-tk { font-weight: 800; color: var(--text); }
+  .pd-top { display: flex; align-items: baseline; gap: 8px; font-size: var(--fs-md); }
+  .pd-tk { font-weight: 700; color: var(--text); }
   .pd-self { font-weight: 700; }
-  .pd-gap { margin-left: auto; font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; }
+  .pd-gap { margin-left: auto; font-size: var(--fs-xs); font-weight: 700; padding: 2px 8px; border-radius: 4px; }
   .pd-gap.lag  { background: color-mix(in srgb, var(--negative) 14%, transparent); color: var(--negative); }
   .pd-gap.lead { background: color-mix(in srgb, var(--positive) 16%, transparent); color: var(--positive); }
-  .pd-vs { font-size: 11.5px; color: var(--text-dim); margin-top: 3px; }
+  .pd-vs { font-size: var(--fs-xs); color: var(--text-dim); margin-top: 3px; }
   .pd-vs b { color: var(--text); font-weight: 600; }
-  .pd-caveat { color: var(--text-dim); font-size: 10px; margin-top: 8px; font-style: italic; }
+  .pd-caveat { color: var(--text-dim); font-size: var(--fs-micro); margin-top: 8px; font-style: italic; }
 
   /* Risk metrics grid */
   .risk-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
@@ -812,12 +823,12 @@
     padding: var(--space-3); text-align: left; font-variant-numeric: tabular-nums;
     border-top: 1px solid var(--border-subtle);
   }
-  .risk-cell .lbl { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
-  .risk-cell .val { font-size: 20px; font-weight: 700; margin-top: var(--space-1); }
+  .risk-cell .lbl { font-size: var(--fs-micro); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .risk-cell .val { font-size: var(--fs-xl); font-weight: 700; margin-top: var(--space-1); }
   .risk-alerts { margin-top: var(--space-3); display: flex; flex-direction: column; gap: var(--space-2); }
   .risk-alert {
     padding: var(--space-2) var(--space-3); background: var(--card-2); border-radius: var(--radius-sm);
-    font-size: 12px; display: flex; align-items: center; gap: var(--space-2);
+    font-size: var(--fs-sm); display: flex; align-items: center; gap: var(--space-2);
     border-left: 3px solid var(--red);
   }
   .risk-alert.medium { border-left-color: var(--warning); }
@@ -837,9 +848,9 @@
     padding: var(--space-3); text-align: left; font-variant-numeric: tabular-nums;
     border-top: 1px solid var(--border-subtle);
   }
-  .lev-cell .lbl { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
-  .lev-cell .val { font-size: 20px; font-weight: 700; }
-  .lev-tickers { margin-top: 8px; font-size: 11px; }
+  .lev-cell .lbl { font-size: var(--fs-micro); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .lev-cell .val { font-size: var(--fs-xl); font-weight: 700; }
+  .lev-tickers { margin-top: 8px; font-size: var(--fs-xs); }
 
   /* Today's range bars */
         .range-bar { height: 8px; background: var(--card-2); border-radius: 4px; position: relative; overflow: hidden; }
@@ -861,9 +872,9 @@
     border-bottom: 1px solid var(--border-subtle);
     min-height: 86px;
   }
-  .today-pnl-cell .lbl { font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; margin-bottom: 4px; }
-  .today-pnl-cell .val { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; }
-  .today-pnl-cell .pct { font-size: 12px; margin-top: 2px; }
+  .today-pnl-cell .lbl { font-size: var(--fs-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; margin-bottom: 4px; }
+  .today-pnl-cell .val { font-size: var(--fs-xl); font-weight: 700; letter-spacing: -0.01em; }
+  .today-pnl-cell .pct { font-size: var(--fs-sm); margin-top: 2px; }
 
   /* Delta table */
   .delta-table {
@@ -871,19 +882,19 @@
     font-variant-numeric: tabular-nums;
   }
   .delta-table th, .delta-table td {
-    padding: 8px; text-align: right; font-size: 13px;
+    padding: 8px; text-align: right; font-size: var(--fs-md);
     border-bottom: 1px solid var(--border);
   }
   .delta-table th:first-child, .delta-table td:first-child {
     text-align: left; color: var(--text-dim); font-weight: 500;
   }
-  .delta-table thead th { font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+  .delta-table thead th { font-size: var(--fs-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
   .delta-table tbody tr:last-child td { border-bottom: none; }
 
   /* Per-market return breakdown cards */
   .mkt-breakdown { margin-top: 16px; border-top: 1px solid var(--border); padding-top: 12px; }
-  .mkt-breakdown-head { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: var(--space-3); }
-  .mkt-breakdown-head .muted { font-weight: 500; font-size: 11px; }
+  .mkt-breakdown-head { font-size: var(--fs-md); font-weight: 600; color: var(--text); margin-bottom: var(--space-3); }
+  .mkt-breakdown-head .muted { font-weight: 500; font-size: var(--fs-xs); }
   .mkt-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
   @media (max-width: 560px) { .mkt-cards { grid-template-columns: 1fr; } }
   .mkt-card {
@@ -892,19 +903,19 @@
     padding: var(--space-3) var(--space-4);
   }
   .mkt-card[data-mkt="hk"] { border-top-color: var(--accent-2); }
-  .mkt-head { font-size: 12px; font-weight: 700; letter-spacing: 0.04em; color: var(--text);
+  .mkt-head { font-size: var(--fs-sm); font-weight: 700; letter-spacing: 0.04em; color: var(--text);
     display: flex; align-items: center; gap: var(--space-2); }
   .mkt-head .muted { font-weight: 500; }
   .mkt-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
   .mkt-card[data-mkt="hk"] .mkt-dot { background: var(--accent-2); }
-  .mkt-ret-label { font-size: 11px; color: var(--text-dim); margin-top: 9px; }
-  .mkt-ret { font-size: 27px; font-weight: 700; line-height: 1.1; font-variant-numeric: tabular-nums; margin-top: 1px; }
+  .mkt-ret-label { font-size: var(--fs-xs); color: var(--text-dim); margin-top: 9px; }
+  .mkt-ret { font-size: var(--fs-xxl); font-weight: 700; line-height: 1.1; font-variant-numeric: tabular-nums; margin-top: 1px; }
   .mkt-stats { margin-top: 11px; display: grid; gap: 5px; }
-  .mkt-stat { display: flex; justify-content: space-between; font-size: 13px; }
+  .mkt-stat { display: flex; justify-content: space-between; font-size: var(--fs-md); }
   .mkt-stat .lbl { color: var(--text-dim); }
   .mkt-stat .v { font-variant-numeric: tabular-nums; font-weight: 600; }
   .mkt-comp { margin-top: 11px; display: grid; gap: var(--space-2); }
-  .mkt-comp-row { display: grid; grid-template-columns: 44px 1fr 62px; align-items: center; gap: 8px; font-size: 12px; }
+  .mkt-comp-row { display: grid; grid-template-columns: 44px 1fr 62px; align-items: center; gap: 8px; font-size: var(--fs-sm); }
   .mkt-comp-row .lbl { color: var(--text-dim); }
   .mkt-comp-row .v { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
   .mkt-bar { height: 7px; background: var(--card); border: 1px solid var(--border); border-radius: 4px; overflow: hidden; }
@@ -912,7 +923,7 @@
   .mkt-bar-fill.pos { background: var(--green); }
   .mkt-bar-fill.neg { background: var(--red); }
   .mkt-chips { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
-  .mkt-chip { font-size: 11px; color: var(--text-dim); background: var(--card);
+  .mkt-chip { font-size: var(--fs-xs); color: var(--text-dim); background: var(--card);
     border: 1px solid var(--border); border-radius: 999px; padding: 4px 12px; }
   .mkt-chip b { font-weight: 600; font-variant-numeric: tabular-nums; margin-left: 2px; }
   .mkt-card-skel { color: var(--text-faint); padding: 20px; text-align: center; }
@@ -924,7 +935,7 @@
     padding: var(--space-3) var(--space-3) var(--space-5); text-align: center;
     border-top: 1px solid var(--border-subtle);
   }
-  .hhi-card .lbl { font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
+  .hhi-card .lbl { font-size: var(--fs-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
   .hhi-ring {
     --pct: 0;
     --color: var(--accent);
@@ -941,19 +952,19 @@
   .hhi-ring .inner {
     position: relative; z-index: 1;
     display: flex; flex-direction: column; align-items: center;
-    font: 700 16px/1.1 var(--mono); font-variant-numeric: tabular-nums;
+    font: 700 var(--fs-lg)/1.1 var(--mono); font-variant-numeric: tabular-nums;
   }
   .hhi-ring .inner::before {
-    content: "HHI"; color: var(--text-faint); font: 600 9px/1 var(--mono);
+    content: "HHI"; color: var(--text-faint); font: 600 var(--fs-micro)/1 var(--mono);
     letter-spacing: .08em; margin-bottom: var(--space-1);
   }
   .hhi-ring::after {
     content: "0 → .50"; position: absolute; left: 50%; top: calc(100% + 4px);
     transform: translateX(-50%); white-space: nowrap;
-    color: var(--text-faint); font: 500 9px/1 var(--mono);
+    color: var(--text-faint); font: 500 var(--fs-micro)/1 var(--mono);
   }
-  .hhi-card .verdict { font-size: 12px; font-weight: 600; }
-  .hhi-card .top2 { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+  .hhi-card .verdict { font-size: var(--fs-sm); font-weight: 600; }
+  .hhi-card .top2 { font-size: var(--fs-xs); color: var(--text-dim); margin-top: 2px; }
 
   /* Anomalies */
   .anomaly-list { display: flex; flex-direction: column; gap: 8px; }
@@ -974,8 +985,8 @@
   .anomaly.low .icon { background: var(--gray); }
   .anomaly .body { min-width: 0; flex: 1; }
   .anomaly .ticker { font-weight: 600; font-family: var(--mono); }
-  .anomaly .detail { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
-  .empty-state { font-size: 12px; color: var(--text-faint); font-style: italic; padding: 8px 0; }
+  .anomaly .detail { font-size: var(--fs-sm); color: var(--text-dim); margin-top: 2px; }
+  .empty-state { font-size: var(--fs-sm); color: var(--text-faint); font-style: italic; padding: 8px 0; }
 
   /* Movers — horizontal scroll cards */
   .movers-scroll {
@@ -992,21 +1003,21 @@
   }
   .mover-card.up { border-top-color: var(--green); }
   .mover-card.down { border-top-color: var(--red); }
-  .mover-card .tk { font-family: var(--mono); font-weight: 700; font-size: 13px; }
-  .mover-card .nm { font-size: 11px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .mover-card .pct { font-size: 18px; font-weight: 700; margin-top: 4px; font-variant-numeric: tabular-nums; }
-  .mover-card .px { font-size: 11px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
+  .mover-card .tk { font-family: var(--mono); font-weight: 700; font-size: var(--fs-md); }
+  .mover-card .nm { font-size: var(--fs-xs); color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mover-card .pct { font-size: var(--fs-xl); font-weight: 700; margin-top: 4px; font-variant-numeric: tabular-nums; }
+  .mover-card .px { font-size: var(--fs-xs); color: var(--text-faint); font-variant-numeric: tabular-nums; }
 
   /* Sector Context — vertical sector blocks with top-movers + self position */
   .sector-context { display: flex; flex-direction: column; gap: var(--space-3); }
   .sector-block { background: var(--card-2); border-radius: var(--radius-sm); padding: var(--space-3); }
-  .sector-block .theme { font-weight: 700; font-size: 13px; margin-bottom: var(--space-2); display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
-  .sector-block .theme .in-book { font-size: 10.5px; font-weight: 500; color: var(--text-dim); font-family: var(--mono); }
-  .sector-block .movers { display: flex; flex-wrap: wrap; gap: var(--space-2) 12px; font-size: 11.5px; }
+  .sector-block .theme { font-weight: 700; font-size: var(--fs-md); margin-bottom: var(--space-2); display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .sector-block .theme .in-book { font-size: var(--fs-micro); font-weight: 500; color: var(--text-dim); font-family: var(--mono); }
+  .sector-block .movers { display: flex; flex-wrap: wrap; gap: var(--space-2) 12px; font-size: var(--fs-xs); }
   .sector-block .mover-inline { font-family: var(--mono); font-variant-numeric: tabular-nums; }
   .sector-block .mover-inline .nm { color: var(--text-dim); font-family: var(--font); margin-left: 4px; }
-  .sector-block .mover-inline .cat { color: var(--text-faint); font-family: var(--font); font-size: 10.5px; margin-left: 4px; }
-  .sector-block .self { margin-top: var(--space-2); font-size: 11.5px; padding-top: var(--space-2); border-top: 1px dashed var(--card); color: var(--text-dim); }
+  .sector-block .mover-inline .cat { color: var(--text-faint); font-family: var(--font); font-size: var(--fs-micro); margin-left: 4px; }
+  .sector-block .self { margin-top: var(--space-2); font-size: var(--fs-xs); padding-top: var(--space-2); border-top: 1px dashed var(--card); color: var(--text-dim); }
   .sector-block .self .tk { font-family: var(--mono); color: var(--text); font-weight: 600; }
   .sector-block .self .rank.lead { color: var(--green); }
   .sector-block .self .rank.lag { color: var(--red); }
@@ -1018,11 +1029,11 @@
     padding: var(--space-3); background: var(--card-2); border-radius: var(--radius-sm);
   }
   .calib-badge .brier-val {
-    font-size: 24px; font-weight: 700; font-variant-numeric: tabular-nums;
+    font-size: var(--fs-xxl); font-weight: 700; font-variant-numeric: tabular-nums;
   }
-  .calib-badge .meta { font-size: 12px; color: var(--text-dim); }
+  .calib-badge .meta { font-size: var(--fs-sm); color: var(--text-dim); }
   .calib-badge .tier {
-    font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 999px;
+    font-size: var(--fs-xs); font-weight: 600; padding: 3px 8px; border-radius: 999px;
     background: var(--card); color: var(--text);
   }
   .tier.excellent { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
@@ -1044,7 +1055,7 @@
   .holdings-table {
     width: 100%; border-collapse: separate; border-spacing: 0;
     font-variant-numeric: tabular-nums;
-    font-size: 12.5px;
+    font-size: var(--fs-sm);
     min-width: 720px;
   }
   .holdings-table th, .holdings-table td {
@@ -1063,7 +1074,7 @@
     box-shadow: none;
   }
   .holdings-table thead th:first-child { z-index: 3; background: var(--surface-2); }
-  .holdings-table .name-cell { max-width: 140px; overflow: hidden; text-overflow: ellipsis; color: var(--text-dim); font-size: 11.5px; }
+  .holdings-table .name-cell { max-width: 140px; overflow: hidden; text-overflow: ellipsis; color: var(--text-dim); font-size: var(--fs-xs); }
   .holdings-table .spark-cell { padding: 4px 8px; line-height: 0; vertical-align: middle; min-width: 60px; }
   .holdings-table .spark { display: inline-block; vertical-align: middle; }
   .holdings-table .spark.spark-up   { color: var(--green); }
@@ -1075,18 +1086,18 @@
   .watch-levels { display: flex; flex-direction: column; }
   .wl-row { display: grid; grid-template-columns: 50px 1fr auto auto auto; gap: 8px;
     align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--border);
-    font-size: 12.5px; font-variant-numeric: tabular-nums; }
+    font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
   .wl-row:last-child { border-bottom: none; }
   .wl-who { font-weight: 700; color: var(--text); }
-  .wl-label { color: var(--text-dim); font-size: 11.5px; }
+  .wl-label { color: var(--text-dim); font-size: var(--fs-xs); }
   .wl-target { color: var(--text); text-align: right; }
-  .wl-cur { color: var(--text-dim); font-size: 11.5px; text-align: right; }
+  .wl-cur { color: var(--text-dim); font-size: var(--fs-xs); text-align: right; }
   .wl-dist { text-align: right; font-weight: 700; white-space: nowrap; }
   .wl-dist.near { color: var(--red); }
   .wl-dist.mid  { color: var(--amber); }
   .wl-dist.far  { color: var(--text-faint); }
   .wl-cond { grid-template-columns: 50px 1fr; }
-  .wl-cond-txt { color: var(--text-dim); font-size: 11.5px; }
+  .wl-cond-txt { color: var(--text-dim); font-size: var(--fs-xs); }
   /* Sparkline column is dense; hide it whenever the holdings table sits in a narrow
    * column. The dashboard uses a 3-column grid ≥1024px (each column ≈ 1/3 of the
    * viewport), so Drill only has room for the sparkline once the viewport is wider
@@ -1096,10 +1107,10 @@
   }
   .holdings-table .spark-cell svg { width: 56px; height: 18px; }
   .holdings-table .cell-stack { line-height: 1.3; }
-  .holdings-table .cell-sub { font-size: 10.5px; opacity: 0.75; }
+  .holdings-table .cell-sub { font-size: var(--fs-micro); opacity: 0.75; }
   .holdings-table thead th {
     position: sticky; top: 0; background: var(--surface-2);
-    font-size: 11px; color: var(--text-dim); text-transform: uppercase;
+    font-size: var(--fs-xs); color: var(--text-dim); text-transform: uppercase;
     letter-spacing: 0.05em; cursor: pointer;
     user-select: none; height: 44px;
   }
@@ -1134,13 +1145,13 @@
     padding: var(--space-3); background: var(--card-2); border-radius: var(--radius-sm);
     display: grid; grid-template-columns: auto 1fr auto; gap: 8px 12px;
     align-items: center;
-    font-size: 13px;
+    font-size: var(--fs-md);
   }
-  .plan-action .date { font-size: 11px; color: var(--text-faint); font-family: var(--mono); }
+  .plan-action .date { font-size: var(--fs-xs); color: var(--text-faint); font-family: var(--mono); }
   .plan-action .tk { font-family: var(--mono); font-weight: 600; }
-  .plan-action .meta { font-size: 11px; color: var(--text-dim); }
+  .plan-action .meta { font-size: var(--fs-xs); color: var(--text-dim); }
   .plan-action .outcome {
-    font-size: 11px; padding: 3px 8px; border-radius: 999px; font-weight: 600;
+    font-size: var(--fs-xs); padding: 3px 8px; border-radius: 999px; font-weight: 600;
   }
   .outcome.win { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
   .outcome.loss { background: color-mix(in srgb, var(--negative) 15%, transparent); color: var(--negative); }
@@ -1148,7 +1159,7 @@
   .outcome.flat { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
   /* Add campaign — one deterministic public projection, split by market. */
   .campaign-summary, .campaign-coverage {
-    color: var(--text-dim); font: 11px/1.55 var(--mono);
+    color: var(--text-dim); font: var(--fs-xs)/1.55 var(--mono);
     padding: 8px 0;
   }
   .add-campaign-legs, .campaign-market-grid {
@@ -1161,7 +1172,7 @@
   }
   .add-campaign-leg h4, .campaign-market h4 {
     margin: 0; padding: 9px 11px; border-bottom: 1px solid var(--border);
-    color: var(--text-dim); font: 700 11px var(--mono); letter-spacing: .04em;
+    color: var(--text-dim); font: 700 var(--fs-xs) var(--mono); letter-spacing: .04em;
   }
   .add-campaign-row { padding: 10px 11px; border-bottom: 1px dashed var(--border); }
   .add-campaign-row:last-child { border-bottom: 0; }
@@ -1169,24 +1180,24 @@
   .add-campaign-row > div:nth-child(2) { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
   .campaign-tier, .campaign-state, .campaign-blockers span {
     display: inline-flex; padding: 2px 6px; border-radius: 999px;
-    font: 600 10px var(--mono); background: rgba(107,118,145,.14); color: var(--text-dim);
+    font: 600 var(--fs-micro) var(--mono); background: rgba(107,118,145,.14); color: var(--text-dim);
   }
   .campaign-state.state-eligible { color: var(--positive); background: color-mix(in srgb, var(--positive) 14%, transparent); }
   .campaign-state.state-risk_blocked, .campaign-state.state-constraint_blocked { color: var(--negative); background: color-mix(in srgb, var(--negative) 12%, transparent); }
   .campaign-state.state-waiting_timing { color: var(--warning); background: color-mix(in srgb, var(--warning) 12%, transparent); }
-  .campaign-families, .campaign-detail { color: var(--text-dim); font-size: 11px; line-height: 1.5; }
+  .campaign-families, .campaign-detail { color: var(--text-dim); font-size: var(--fs-xs); line-height: 1.5; }
   .campaign-detail { margin-top: 5px; font-family: var(--mono); }
   .campaign-blockers { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
-  .campaign-blockers b { color: var(--text-faint); font: 600 9px/20px var(--mono); text-transform: uppercase; }
+  .campaign-blockers b { color: var(--text-faint); font: 600 var(--fs-micro)/20px var(--mono); text-transform: uppercase; }
   .campaign-evidence-head {
     display: flex; justify-content: space-between; gap: 8px; flex-wrap: wrap;
     margin-top: var(--space-4); padding: 10px 0 8px; border-top: 1px solid var(--border);
-    color: var(--text-dim); font-size: 11px;
+    color: var(--text-dim); font-size: var(--fs-xs);
   }
   .campaign-evidence-head b { color: var(--text); }
   .campaign-horizon {
     display: flex; justify-content: space-between; gap: 8px;
-    padding: 8px 10px; border-bottom: 1px dashed var(--border); font-size: 11px;
+    padding: 8px 10px; border-bottom: 1px dashed var(--border); font-size: var(--fs-xs);
   }
   .campaign-horizon:last-child { border-bottom: 0; }
   .campaign-horizon b { font-family: var(--mono); color: var(--text); }
@@ -1197,10 +1208,10 @@
   /* Bucket historical win-rate badge (from calibration.per_bucket) */
   .bucket-wr {
     display: inline-block; margin-left: 8px; padding: 2px 8px;
-    border-radius: 6px; font-size: 10px; font-family: var(--mono);
+    border-radius: 6px; font-size: var(--fs-micro); font-family: var(--mono);
     font-weight: 600; vertical-align: middle; white-space: nowrap;
   }
-  .bucket-wr .wr-n { font-weight: 400; opacity: .55; font-size: 9px; margin-left: 2px; }
+  .bucket-wr .wr-n { font-weight: 400; opacity: .55; font-size: var(--fs-micro); margin-left: 2px; }
   .bucket-wr.wr-bad { background: color-mix(in srgb, var(--negative) 15%, transparent); color: var(--negative); }
   .bucket-wr.wr-mid { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
   .bucket-wr.wr-ok  { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
@@ -1209,7 +1220,7 @@
   /* driven_by chip — which data source drove the call (color encodes edge) */
   .drv-chip {
     display: inline-block; margin-left: 8px; padding: 2px 8px;
-    border-radius: 6px; font-size: 10px; font-weight: 600;
+    border-radius: 6px; font-size: var(--fs-micro); font-weight: 600;
     vertical-align: middle; white-space: nowrap;
   }
   .drv-chip.drv-catalyst   { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
@@ -1219,25 +1230,25 @@
   .drv-chip.drv-macro      { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
   .drv-chip.drv-peer       { background: rgba(45,212,191,.15); color: #2dd4bf; }
   @media (max-width: 600px) {
-    .drv-chip { font-size: 9px; padding: 1px 5px; margin-left: 4px; }
+    .drv-chip { font-size: var(--fs-micro); padding: 1px 5px; margin-left: 4px; }
   }
 
   /* ── LLM narrative cards (behavioral review / bear cases / hidden concentration) ── */
   .llm-card { border-left: 3px solid rgba(167,139,250,.55); }
   .llm-tag {
-    text-transform: none; letter-spacing: 0; font-weight: 500; font-size: 11px;
+    text-transform: none; letter-spacing: 0; font-weight: 500; font-size: var(--fs-xs);
     color: var(--accent);
   }
-  .llm-src { margin-top: var(--space-3); font-size: 10px; color: var(--text-faint); font-family: var(--mono); }
+  .llm-src { margin-top: var(--space-3); font-size: var(--fs-micro); color: var(--text-faint); font-family: var(--mono); }
   /* behavioral review */
   .br-verdict {
-    font-size: 15px; font-weight: 700; line-height: 1.45; margin: 2px 0 12px;
+    font-size: var(--fs-lg); font-weight: 700; line-height: 1.45; margin: 2px 0 12px;
     color: var(--text);
   }
   .br-point {
     display: flex; gap: 8px; align-items: flex-start; padding: var(--space-2) var(--space-3);
     margin-bottom: var(--space-2); border-radius: var(--radius-sm); background: var(--card-2);
-    font-size: 13px; line-height: 1.5;
+    font-size: var(--fs-md); line-height: 1.5;
   }
   .br-point .br-icon {
     flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%;
@@ -1254,30 +1265,30 @@
     padding: var(--space-3); margin-bottom: 8px; border-radius: var(--radius-sm);
     background: var(--card-2); border-left: 3px solid color-mix(in srgb, var(--negative) 50%, transparent);
   }
-  .bear-tk { font-weight: 700; font-family: var(--mono); font-size: 14px; margin-bottom: 4px; }
-  .bear-thesis { font-size: 13px; line-height: 1.5; margin-bottom: 8px; color: var(--text); }
-  .bear-meta { font-size: 12px; line-height: 1.45; color: var(--text-dim); margin-top: 4px; }
+  .bear-tk { font-weight: 700; font-family: var(--mono); font-size: var(--fs-md); margin-bottom: 4px; }
+  .bear-thesis { font-size: var(--fs-md); line-height: 1.5; margin-bottom: 8px; color: var(--text); }
+  .bear-meta { font-size: var(--fs-sm); line-height: 1.45; color: var(--text-dim); margin-top: 4px; }
   .bear-lbl {
-    display: inline-block; font-size: 10px; font-weight: 700; padding: 2px 8px;
+    display: inline-block; font-size: var(--fs-micro); font-weight: 700; padding: 2px 8px;
     border-radius: 5px; margin-right: 8px; vertical-align: middle;
   }
   .bear-lbl.bl-fal   { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
   .bear-lbl.bl-watch { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
   /* hidden concentration */
-  .hc-headline { font-size: 14px; font-weight: 600; line-height: 1.45; margin-bottom: 12px; }
+  .hc-headline { font-size: var(--fs-md); font-weight: 600; line-height: 1.45; margin-bottom: 12px; }
   .hc-bar-row { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }
-  .hc-factor { flex: 0 0 auto; font-size: 12px; font-weight: 600; color: var(--accent); max-width: 40%; }
+  .hc-factor { flex: 0 0 auto; font-size: var(--fs-sm); font-weight: 600; color: var(--accent); max-width: 40%; }
   .hc-bar { flex: 1 1 auto; height: 10px; background: var(--card-2); border-radius: 5px; overflow: hidden; }
   .hc-bar-fill {
     height: 100%; border-radius: 5px;
     background: linear-gradient(90deg, rgba(124,140,242,.7), color-mix(in srgb, var(--negative) 80%, transparent));
   }
-  .hc-pct { flex: 0 0 auto; font-family: var(--mono); font-weight: 700; font-size: 14px; }
-  .hc-detail { font-size: 12px; line-height: 1.55; color: var(--text-dim); }
+  .hc-pct { flex: 0 0 auto; font-family: var(--mono); font-weight: 700; font-size: var(--fs-md); }
+  .hc-detail { font-size: var(--fs-sm); line-height: 1.55; color: var(--text-dim); }
   @media (max-width: 600px) {
-    .br-verdict { font-size: 14px; }
-    .br-point, .bear-thesis { font-size: 12.5px; }
-    .hc-factor { max-width: 36%; font-size: 11px; }
+    .br-verdict { font-size: var(--fs-md); }
+    .br-point, .bear-thesis { font-size: var(--fs-sm); }
+    .hc-factor { max-width: 36%; font-size: var(--fs-xs); }
   }
 
   /* LLM status banner — intraday one-liner, sticky top across tabs */
@@ -1288,14 +1299,14 @@
     border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent); border-radius: var(--radius-sm);
     -webkit-backdrop-filter: blur(12px) saturate(150%);
     backdrop-filter: blur(12px) saturate(150%);
-    font-size: 13.5px; line-height: 1.45;
+    font-size: var(--fs-md); line-height: 1.45;
   }
   .status-banner .sb-pulse {
     flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%;
     background: var(--accent);
   }
   .status-banner .sb-text { flex: 1 1 auto; font-weight: 500; color: var(--text); }
-  .status-banner .sb-time { flex: 0 0 auto; font-size: 10px; color: var(--text-faint); font-family: var(--mono); white-space: nowrap; }
+  .status-banner .sb-time { flex: 0 0 auto; font-size: var(--fs-micro); color: var(--text-faint); font-family: var(--mono); white-space: nowrap; }
   .status-banner.is-pending { visibility: hidden; }
 
   /* ── Desk rail — collapsed one-line pulse on detail tabs ── */
@@ -1319,12 +1330,12 @@
     outline: 2px solid var(--focus); outline-offset: -2px;
   }
   .dr-toggle-label {
-    color: var(--text-tertiary); font: 700 9.5px/1 var(--mono);
+    color: var(--text-tertiary); font: 700 var(--fs-micro)/1 var(--mono);
     letter-spacing: .08em; text-transform: uppercase; white-space: nowrap;
   }
   .dr-compact {
     min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    color: var(--text-secondary); font: 650 11px/1.3 var(--mono);
+    color: var(--text-secondary); font: 600 var(--fs-xs)/1.3 var(--mono);
     font-variant-numeric: tabular-nums;
   }
   .dr-chevron {
@@ -1362,11 +1373,11 @@
   }
   .dr-kpi:first-child { border-left: none; }
   .dr-k {
-    color: var(--text-tertiary); font-size: 9px; font-weight: 600;
+    color: var(--text-tertiary); font-size: var(--fs-micro); font-weight: 600;
     letter-spacing: .05em; text-transform: uppercase; white-space: nowrap;
   }
   .dr-v {
-    min-width: 0; color: var(--text); font: 700 13.5px/1.2 var(--mono);
+    min-width: 0; color: var(--text); font: 700 var(--fs-md)/1.2 var(--mono);
     font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
   }
   @media (max-width: 1023px) {
@@ -1392,13 +1403,13 @@
   .mover-card.has-note { min-height: auto; }
   .mover-note {
     margin-top: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--border);
-    font-size: 10.5px; line-height: 1.4; color: var(--text-dim);
+    font-size: var(--fs-micro); line-height: 1.4; color: var(--text-dim);
     white-space: normal; max-width: 220px;
   }
   @media (max-width: 600px) {
-    .status-banner { font-size: 12.5px; padding: 9px 11px; gap: 8px; }
+    .status-banner { font-size: var(--fs-sm); padding: 9px 11px; gap: 8px; }
     .status-banner .sb-time { display: none; }
-    .mover-note { max-width: 160px; font-size: 10px; }
+    .mover-note { max-width: 160px; font-size: var(--fs-micro); }
   }
 
   /* Plan timeline (Reflect) — fuller decision cards: plan + rationale + outcome */
@@ -1407,7 +1418,7 @@
     padding: 12px; background: var(--card-2); border-radius: var(--radius-sm);
     border-left: 3px solid var(--border);
     display: grid; grid-template-columns: auto 1fr auto; gap: var(--space-2) 12px;
-    align-items: start; font-size: 13px;
+    align-items: start; font-size: var(--fs-md);
   }
   .pt-row.outcome-win { border-left-color: var(--green); }
   .pt-row.outcome-loss { border-left-color: var(--red); }
@@ -1415,38 +1426,38 @@
   .pt-row .pt-head {
     display: flex; flex-direction: column; gap: 2px; min-width: 78px;
   }
-  .pt-row .pt-date { font-size: 11px; color: var(--text-faint); font-family: var(--mono); }
-  .pt-row .pt-ticker { font-family: var(--mono); font-weight: 700; font-size: 14px; }
-  .pt-row .pt-region { font-size: 10px; color: var(--text-faint); }
+  .pt-row .pt-date { font-size: var(--fs-xs); color: var(--text-faint); font-family: var(--mono); }
+  .pt-row .pt-ticker { font-family: var(--mono); font-weight: 700; font-size: var(--fs-md); }
+  .pt-row .pt-region { font-size: var(--fs-micro); color: var(--text-faint); }
   .pt-row .pt-body { min-width: 0; }
   .pt-row .pt-action {
     font-weight: 600; color: var(--text);
   }
   .pt-row .pt-trigger {
-    font-size: 11px; color: var(--text-dim); margin-top: 2px;
+    font-size: var(--fs-xs); color: var(--text-dim); margin-top: 2px;
     font-family: var(--mono);
   }
   .pt-row .pt-rationale {
-    font-size: 12px; color: var(--text-dim); margin-top: var(--space-2);
+    font-size: var(--fs-sm); color: var(--text-dim); margin-top: var(--space-2);
     line-height: 1.5;
     overflow-wrap: anywhere;
   }
   .pt-row .pt-side { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
   .pt-row .pt-conf {
-    font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    font-size: var(--fs-xs); padding: 2px 8px; border-radius: 999px;
     background: rgba(91,141,239,.12); color: var(--accent); font-weight: 600;
     font-family: var(--mono);
   }
-  .pt-row .pt-followed-true { color: var(--green); font-size: 10px; font-weight: 600; }
-  .pt-row .pt-followed-false { color: var(--text-faint); font-size: 10px; }
-  .pt-row .pt-pnl { font-size: 11px; font-family: var(--mono); font-weight: 600; }
+  .pt-row .pt-followed-true { color: var(--green); font-size: var(--fs-micro); font-weight: 600; }
+  .pt-row .pt-followed-false { color: var(--text-faint); font-size: var(--fs-micro); }
+  .pt-row .pt-pnl { font-size: var(--fs-xs); font-family: var(--mono); font-weight: 600; }
   .pt-row .pt-pnl.pos { color: var(--green); }
   .pt-row .pt-pnl.neg { color: var(--red); }
 
   /* Trigger-type breakdown bars (extends Plan Review card) */
   .trig-block { margin-top: 16px; padding-top: 16px; border-top: 1px dashed var(--border); }
   .trig-block .trig-title {
-    font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+    font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: 0.06em;
     color: var(--text-dim); margin-bottom: var(--space-3); font-weight: 600;
     overflow-wrap: anywhere; word-break: break-word;
   }
@@ -1456,7 +1467,7 @@
     grid-template-columns: 1fr auto;
     grid-template-areas: "name stat" "bar bar";
     column-gap: var(--space-3); row-gap: 4px;
-    align-items: center; margin-bottom: var(--space-3); font-size: 12px;
+    align-items: center; margin-bottom: var(--space-3); font-size: var(--fs-sm);
   }
   .trig-row > * { min-width: 0; }  /* let grid children shrink instead of overflowing */
   .trig-row .trig-name { grid-area: name; font-family: var(--mono); color: var(--text);
@@ -1470,7 +1481,7 @@
   .trig-row .trig-bar .seg-loss { background: var(--red); }
   .trig-row .trig-bar .seg-pending { background: var(--gray); opacity: 0.5; }
   .trig-row .trig-stat {
-    grid-area: stat; font-family: var(--mono); font-size: 11px;
+    grid-area: stat; font-family: var(--mono); font-size: var(--fs-xs);
     text-align: right; color: var(--text-dim);
   }
   .trig-row .trig-stat.alert { color: var(--red); font-weight: 700; }
@@ -1499,12 +1510,12 @@
   .dd-region.recovery-mid  { border-left-color: var(--amber); }
   .dd-region.recovery-good { border-left-color: var(--green); }
   .dd-region .dd-region-name {
-    font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+    font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: 0.08em;
     color: var(--text-dim); font-weight: 600; margin-bottom: 8px;
   }
   .dd-region .dd-stats { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-bottom: var(--space-3); }
-  .dd-region .dd-cell .lbl { font-size: 10px; color: var(--text-faint); }
-  .dd-region .dd-cell .val { font-size: 18px; font-weight: 700; font-family: var(--mono); margin-top: 2px; }
+  .dd-region .dd-cell .lbl { font-size: var(--fs-micro); color: var(--text-faint); }
+  .dd-region .dd-cell .val { font-size: var(--fs-xl); font-weight: 700; font-family: var(--mono); margin-top: 2px; }
   .dd-region .dd-cell .val.neg { color: var(--red); }
   .dd-region .dd-cell .val.pos { color: var(--green); }
   .dd-region .dd-bar {
@@ -1516,7 +1527,7 @@
   .dd-region .dd-bar-fill.mid  { background: var(--amber); }
   .dd-region .dd-bar-fill.good { background: var(--green); }
   .dd-region .dd-status {
-    margin-top: var(--space-2); font-size: 11px; color: var(--text-dim);
+    margin-top: var(--space-2); font-size: var(--fs-xs); color: var(--text-dim);
   }
 
   /* 历史净值极值 (peak / trough / max drawdown) */
@@ -1530,20 +1541,20 @@
   .ext-region .ext-head {
     display: flex; align-items: baseline; justify-content: space-between; margin-bottom: var(--space-3);
   }
-  .ext-region .ext-name { font-size: 13px; font-weight: 700; letter-spacing: .04em; }
-  .ext-region .ext-flag { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
+  .ext-region .ext-name { font-size: var(--fs-md); font-weight: 700; letter-spacing: .04em; }
+  .ext-region .ext-flag { font-size: var(--fs-micro); font-weight: 700; padding: 2px 8px; border-radius: 999px; }
   .ext-region .ext-flag.low { background: rgba(229,72,77,.16); color: var(--red); }
   .ext-region .ext-flag.ok  { background: rgba(48,164,108,.16); color: var(--green); }
   .ext-row { display: flex; justify-content: space-between; align-items: baseline; padding: 4px 0; }
-  .ext-row .k { font-size: 11px; color: var(--text-faint); }
-  .ext-row .v { font-size: 15px; font-weight: 700; font-family: var(--mono); }
+  .ext-row .k { font-size: var(--fs-xs); color: var(--text-faint); }
+  .ext-row .v { font-size: var(--fs-lg); font-weight: 700; font-family: var(--mono); }
   .ext-row .v.neg { color: var(--red); }
-  .ext-row .v small { font-size: 10px; color: var(--text-faint); font-weight: 500; margin-left: 5px; font-family: inherit; }
+  .ext-row .v small { font-size: var(--fs-micro); color: var(--text-faint); font-weight: 500; margin-left: 5px; font-family: inherit; }
   .ext-region .ext-dd {
     margin-top: 8px; padding-top: 8px; border-top: 1px dashed var(--border);
   }
-  .ext-region .ext-dd .v { font-size: 20px; color: var(--red); }
-  .ext-region .ext-dd .span { font-size: 10px; color: var(--text-dim); margin-top: 3px; }
+  .ext-region .ext-dd .v { font-size: var(--fs-xl); color: var(--red); }
+  .ext-region .ext-dd .span { font-size: var(--fs-micro); color: var(--text-dim); margin-top: 3px; }
   /* 回撤恢复条 (并入历史利润极值卡) */
   .ext-region .ext-dd .dd-bar {
     height: 8px; background: var(--card); border-radius: 4px; overflow: hidden;
@@ -1576,13 +1587,13 @@
     .ret-cell:hover { transform: translateY(-1px); }
   }
   .ret-cell .rc-ticker {
-    font-family: var(--mono); font-weight: 700; font-size: 13px;
+    font-family: var(--mono); font-weight: 700; font-size: var(--fs-md);
     color: var(--text);
   }
   .ret-cell .rc-ret {
-    font-family: var(--mono); font-weight: 600; font-size: 12px;
+    font-family: var(--mono); font-weight: 600; font-size: var(--fs-sm);
   }
-  .ret-cell .rc-meta { font-size: 9px; color: var(--text-faint); }
+  .ret-cell .rc-meta { font-size: var(--fs-micro); color: var(--text-faint); }
 
   /* Weight × Confidence scatter (Drill) */
   .wc-chart-box { width: 100%; min-height: 300px; height: 300px; }
@@ -1590,7 +1601,7 @@
     .wc-chart-box { min-height: 380px; height: 380px; }
   }
   .wc-legend {
-    display: flex; flex-wrap: wrap; gap: var(--space-3) 18px; font-size: 11px;
+    display: flex; flex-wrap: wrap; gap: var(--space-3) 18px; font-size: var(--fs-xs);
     color: var(--text-dim); margin-top: 8px;
   }
   .wc-legend span::before {
@@ -1615,17 +1626,17 @@
     outline: 2px solid var(--accent); outline-offset: 5px; border-radius: 4px;
   }
   .shadow-toggle-title {
-    color: var(--text-dim); font-size: 12px; font-weight: 600;
+    color: var(--text-dim); font-size: var(--fs-sm); font-weight: 600;
     text-transform: uppercase; letter-spacing: 0.06em;
   }
   .shadow-toggle::after {
     content: "›"; grid-column: 2; grid-row: 1 / span 2;
-    color: var(--text-faint); font-size: 18px;
+    color: var(--text-faint); font-size: var(--fs-xl);
     transform: rotate(90deg); transition: transform .15s;
   }
   .shadow-toggle[aria-expanded="true"]::after { transform: rotate(-90deg); }
   .shadow-summary {
-    grid-column: 1; color: var(--text); font: 650 11px/1.5 var(--mono);
+    grid-column: 1; color: var(--text); font: 600 var(--fs-xs)/1.5 var(--mono);
     overflow-wrap: anywhere;
   }
   .shadow-expanded { margin-top: 12px; }
@@ -1634,13 +1645,13 @@
     margin: 0 0 var(--space-3); padding: 4px 12px;
     border: 1px solid rgba(229,72,77,.55); border-radius: 999px;
     background: rgba(229,72,77,.14); color: var(--red);
-    font-size: 12px; font-weight: 800; letter-spacing: .08em;
+    font-size: var(--fs-sm); font-weight: 700; letter-spacing: .08em;
   }
   .shadow-estimand {
     margin: 0 0 12px; padding: var(--space-3);
     border-left: 3px solid var(--amber); border-radius: 0 7px 7px 0;
     background: color-mix(in srgb, var(--warning) 7%, transparent); color: var(--text-dim);
-    font-size: 12px; line-height: 1.55;
+    font-size: var(--fs-sm); line-height: 1.55;
   }
   .shadow-diff-grid, .shadow-fill-grid {
     display: grid; gap: 8px; margin: var(--space-3) 0;
@@ -1652,11 +1663,11 @@
     border-radius: var(--radius-sm); background: var(--card-2);
   }
   .shadow-stat .lbl {
-    color: var(--text-faint); font-size: 10px; line-height: 1.3;
+    color: var(--text-faint); font-size: var(--fs-micro); line-height: 1.3;
     overflow-wrap: anywhere;
   }
   .shadow-stat .val {
-    margin-top: 4px; color: var(--text); font: 700 18px var(--mono);
+    margin-top: 4px; color: var(--text); font: 700 var(--fs-xl) var(--mono);
   }
   .shadow-stat .val.pos { color: var(--green); }
   .shadow-stat .val.neg { color: var(--red); }
@@ -1668,20 +1679,20 @@
     border-radius: var(--radius-sm); padding: 9px 8px 3px;
   }
   .shadow-chart-title {
-    padding-left: 4px; color: var(--text); font: 700 12px var(--mono);
+    padding-left: 4px; color: var(--text); font: 700 var(--fs-sm) var(--mono);
   }
   .shadow-chart-box { width: 100%; height: 235px; min-height: 235px; }
   .shadow-constraint-note {
-    margin: 8px 0; color: var(--red); font-size: 11px;
-    font-weight: 650; line-height: 1.45;
+    margin: 8px 0; color: var(--red); font-size: var(--fs-xs);
+    font-weight: 600; line-height: 1.45;
   }
   .shadow-coverage-note {
-    margin: 8px 0; color: var(--amber); font-size: 11px;
+    margin: 8px 0; color: var(--amber); font-size: var(--fs-xs);
     font-weight: 700; line-height: 1.45;
   }
   .shadow-limitations {
     margin-top: var(--space-3); padding-top: 9px; border-top: 1px dashed var(--border);
-    color: var(--text-faint); font-size: 10px; line-height: 1.55;
+    color: var(--text-faint); font-size: var(--fs-micro); line-height: 1.55;
   }
   @media (max-width: 600px) {
     .shadow-fill-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -1700,19 +1711,19 @@
     .chart-box { min-height: 360px; height: 360px; }
   }
   .chart-hint {
-    font-size: 11px; color: var(--text-faint);
+    font-size: var(--fs-xs); color: var(--text-faint);
     margin: -4px 0 8px; line-height: 1.4;
   }
   /* Says why a number is absent, in two lines. Not a post-mortem: the audit trail
      for why the money view came down belongs in the repo, not on kcn's dashboard. */
   .retired-note {
-    font-size: 12px; line-height: 1.6; color: var(--text-dim);
+    font-size: var(--fs-sm); line-height: 1.6; color: var(--text-dim);
     border: 1px dashed var(--border); border-radius: var(--radius-sm);
     padding: 11px 13px; margin: 4px 0 12px;
   }
   .retired-note p { margin: 0; }
   .revision-note {
-    font-size: 11px; line-height: 1.55; color: var(--text-dim);
+    font-size: var(--fs-xs); line-height: 1.55; color: var(--text-dim);
     border-left: 2px solid var(--accent); background: var(--bg-soft, transparent);
     padding: var(--space-2) var(--space-3); margin: 0 0 12px; border-radius: 0 6px 6px 0;
   }
@@ -1727,11 +1738,11 @@
     border-radius: var(--radius-sm); padding: var(--space-3); min-width: 0;
   }
   .audit-stat .n, .timing-zone .median {
-    font: 700 18px var(--mono); color: var(--text);
+    font: 700 var(--fs-xl) var(--mono); color: var(--text);
   }
   .sect-divider {
     display: flex; align-items: center; gap: var(--space-3);
-    font: 700 12px var(--mono); letter-spacing: 0.04em;
+    font: 700 var(--fs-sm) var(--mono); letter-spacing: 0.04em;
     color: var(--text-dim); margin: 2px 2px 4px; padding-top: 4px;
   }
   .sect-divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
@@ -1743,14 +1754,14 @@
   .audit-row summary {
     cursor: pointer; list-style: none; display: grid;
     grid-template-columns: 86px minmax(0,1fr) auto; gap: 8px;
-    align-items: center; padding: var(--space-3); font-size: 12px;
+    align-items: center; padding: var(--space-3); font-size: var(--fs-sm);
   }
   .audit-row summary::-webkit-details-marker { display: none; }
   .audit-row .audit-title { overflow-wrap: anywhere; }
-  .audit-state { font: 600 10px var(--mono); color: var(--text-dim); }
+  .audit-state { font: 600 var(--fs-micro) var(--mono); color: var(--text-dim); }
   .audit-detail {
     padding: 0 12px 12px; border-top: 1px solid var(--border);
-    font-size: 11px; color: var(--text-dim); line-height: 1.5;
+    font-size: var(--fs-xs); color: var(--text-dim); line-height: 1.5;
   }
   .audit-detail-grid {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr));
@@ -1762,7 +1773,7 @@
   }
   .audit-path { width: 100%; height: 54px; margin-top: var(--space-2); display: block; }
   .timing-events { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-top: 8px; }
-  .timing-events table { min-width: 560px; width: 100%; font-size: 10px; }
+  .timing-events table { min-width: 560px; width: 100%; font-size: var(--fs-micro); }
   @media (max-width: 600px) {
     .audit-row summary { grid-template-columns: 72px minmax(0,1fr); }
     .audit-row summary .audit-state { grid-column: 2; }
@@ -1785,16 +1796,16 @@
     min-height: 82px;
   }
   .kpi-cell .lbl {
-    font-size: 11px; color: var(--text-dim);
+    font-size: var(--fs-xs); color: var(--text-dim);
     text-transform: uppercase; letter-spacing: 0.06em;
   }
   .kpi-cell .val {
-    font-size: 20px; font-weight: 700;
+    font-size: var(--fs-xl); font-weight: 700;
     margin: var(--space-1) 0 0;
     font-variant-numeric: tabular-nums;
   }
   .kpi-cell .sub {
-    font-size: 12px;
+    font-size: var(--fs-sm);
     color: var(--text-dim);
     font-variant-numeric: tabular-nums;
   }
@@ -1805,7 +1816,7 @@
     grid-template-columns: 130px 1fr 90px;
     gap: var(--space-3); align-items: center;
     padding: 8px 0;
-    font-size: 12px;
+    font-size: var(--fs-sm);
     border-bottom: 1px dashed var(--border);
   }
   .bucket-row:last-child { border-bottom: none; }
@@ -1835,21 +1846,21 @@
     text-align: right;
     font-variant-numeric: tabular-nums;
     color: var(--text-dim);
-    font-size: 11px;
+    font-size: var(--fs-xs);
   }
   .bucket-row .stat .n { color: var(--text); font-weight: 600; }
 
   /* Footer */
   footer {
     padding: 24px 16px 32px;
-    text-align: center; font-size: 11px; color: var(--text-faint);
+    text-align: center; font-size: var(--fs-xs); color: var(--text-faint);
   }
   footer a { color: var(--text-dim); }
   .build-status {
     display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap;
     justify-content: center; margin: 0 auto 12px; padding: 5px 12px;
     border: 1px solid var(--border, #2a2f3a); border-radius: 999px;
-    font-size: 11px; color: var(--text-dim); cursor: help; max-width: 92%;
+    font-size: var(--fs-xs); color: var(--text-dim); cursor: help; max-width: 92%;
   }
   .build-status .bs-label { color: var(--text); }
   .build-status .bs-gen { color: var(--text-faint); font-family: var(--mono); }
@@ -1889,53 +1900,65 @@
   }
   .overview-command > * { min-width: 0; margin: 0; }
   .overview-card-kicker {
-    color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
+    color: var(--text-tertiary); font: 600 var(--fs-micro)/1.2 var(--font);
     letter-spacing: .09em; text-transform: uppercase;
   }
   /* 首屏指挥台：一个主数 + 一条统计轨，取代原来的 book / today / discipline
      三张不等重的卡。(#874 #877) */
+  /* 首屏只有一个焦点：主数。8 格统计轨从右侧「八个中号数字」改成主数下方
+     一条低对比的统计带 —— 信息一条不少，但不再和主数抢注意力。(#879) */
   .hero-deck {
     grid-column: 1 / -1; padding: 0; overflow: hidden;
-    display: grid; grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
+    display: grid; grid-template-columns: minmax(0, 1fr);
   }
   .hero-deck-lead {
-    padding: 18px; border-right: 1px solid var(--border-subtle);
-    background: linear-gradient(140deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 62%);
+    padding: 26px 22px 22px;
+    background: linear-gradient(140deg, color-mix(in srgb, var(--accent) 6%, transparent), transparent 58%);
   }
   .hero-deck-pnl {
-    margin-top: 9px; color: var(--text); font: 760 clamp(30px, 3.4vw, 50px)/1 var(--mono);
+    margin-top: 12px; color: var(--text); font: 700 var(--fs-display)/1 var(--mono);
     letter-spacing: -.055em; font-variant-numeric: tabular-nums;
     /* 大数字禁断行（#111 教训，#872 明确列为验收项）：宁可缩字号也不折行 */
     white-space: nowrap;
   }
   .hero-deck-sub {
-    margin-top: 11px; color: var(--text-secondary); font: 500 12.5px/1.55 var(--mono);
+    margin-top: 13px; color: var(--text-secondary); font: 500 var(--fs-md)/1.5 var(--mono);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
   }
   .hero-deck-sub b { font-weight: 700; color: var(--text); }
   .hero-deck-fx {
-    margin-top: 7px; color: var(--text-tertiary); font: 500 10px/1.35 var(--mono);
+    margin-top: 9px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.4 var(--mono);
     overflow-wrap: anywhere;
   }
-  .hero-rail { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
-  .hero-rail-cell {
-    min-width: 0; padding: 13px 14px;
-    border-right: 1px solid var(--border-subtle); border-bottom: 1px solid var(--border-subtle);
+  .hero-rail {
+    display: grid; grid-template-columns: repeat(8, minmax(0, 1fr));
+    border-top: 1px solid var(--border-subtle);
   }
-  .hero-rail-cell:nth-child(4n) { border-right: 0; }
-  .hero-rail-cell:nth-last-child(-n+4) { border-bottom: 0; }
+  .hero-rail-cell {
+    min-width: 0; padding: 11px 14px;
+    border-right: 1px solid var(--border-subtle);
+  }
+  .hero-rail-cell:last-child { border-right: 0; }
   .hero-rail-k {
-    color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
+    color: var(--text-tertiary); font: 600 var(--fs-micro)/1.2 var(--font);
     letter-spacing: .09em; text-transform: uppercase;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .hero-rail-v {
-    margin-top: 7px; color: var(--text); font: 750 clamp(15px, 1.45vw, 20px)/1.15 var(--mono);
-    letter-spacing: -.035em; font-variant-numeric: tabular-nums;
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    margin-top: 6px; color: var(--text-secondary); font: 600 var(--fs-md)/1.35 var(--mono);
+    letter-spacing: -.01em; font-variant-numeric: tabular-nums;
+    overflow-wrap: normal; word-break: keep-all;
   }
+  /* 变化值独占一行：并排时 US/HK 腿会不齐地折行，读起来比两行更乱 */
+  .hero-rail-d {
+    display: block; margin-top: 3px; color: var(--text-tertiary);
+    font-size: var(--fs-xs); font-weight: 500; white-space: nowrap;
+  }
+  .hero-rail-d.pos { color: var(--positive); }
+  .hero-rail-d.neg { color: var(--negative); }
   .hero-rail-s {
-    margin-top: 5px; color: var(--text-tertiary); font: 500 10.5px/1.35 var(--mono);
+    margin-top: 5px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.35 var(--font);
     font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
 
@@ -1944,18 +1967,18 @@
   .hero-health { grid-column: 1 / -1; padding: 16px 18px 14px; }
   .hero-health-head { display: flex; align-items: flex-start; gap: 14px; }
   .hero-health-verdict {
-    margin: 6px 0 0; color: var(--text); font-size: 15px;
+    margin: 6px 0 0; color: var(--text); font-size: var(--fs-lg);
     letter-spacing: -.01em; text-transform: none;
   }
   .hero-health[data-tone="warn"] .hero-health-verdict { color: var(--warning); }
   .hero-health[data-tone="bad"] .hero-health-verdict { color: var(--red); }
   .hero-health-meta {
-    margin-top: 6px; color: var(--text-tertiary); font: 500 10.5px/1.45 var(--mono);
+    margin-top: 6px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.45 var(--mono);
   }
   .dh-toggle {
     margin-left: auto; flex: none; padding: 6px 12px; border-radius: 8px;
     border: 1px solid var(--border-subtle); background: var(--surface-1);
-    color: var(--text-secondary); font: 600 11px/1 var(--mono); cursor: pointer;
+    color: var(--text-secondary); font: 600 var(--fs-xs)/1 var(--mono); cursor: pointer;
     transition: transform var(--duration-fast) var(--ease-out), color var(--duration-fast) ease, border-color var(--duration-fast) ease;
   }
   .dh-toggle:active { transform: scale(.97); }
@@ -1984,7 +2007,7 @@
   .bs-dot[data-tone="warn"] { background: var(--warning); }
   .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
   .dh-caption {
-    margin-top: 8px; color: var(--text-tertiary); font: 500 10.5px/1.45 var(--mono);
+    margin-top: 8px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.45 var(--mono);
   }
   .dh-seg.is-late i { background: var(--warning); }
   .dh-seg.is-missing i { background: var(--red); }
@@ -1993,7 +2016,7 @@
     display: grid; align-items: center; gap: 12px; padding: 8px 0;
     grid-template-columns: minmax(76px, auto) minmax(0, 1fr) 84px minmax(0, 1.3fr) 34px;
     border-bottom: 1px solid var(--border-subtle);
-    font: 500 11.5px/1.35 var(--mono); font-variant-numeric: tabular-nums;
+    font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
   }
   .dh-row:last-child { border-bottom: 0; }
   .dh-name { color: var(--text); font-weight: 700; white-space: nowrap; }
@@ -2017,13 +2040,13 @@
   }
   .overview-equity .card-head { align-items: flex-start; }
   .overview-equity .card-head h3 {
-    margin: 5px 0 0; color: var(--text); font-size: 17px;
+    margin: 5px 0 0; color: var(--text); font-size: var(--fs-lg);
     letter-spacing: -.01em; text-transform: none;
   }
   .overview-equity-hint { max-width: 92%; margin: -2px 0 4px; }
   .chart-note > summary {
     display: inline-block; cursor: pointer; list-style: none;
-    color: var(--text-tertiary); font: 600 10.5px/1.4 var(--mono);
+    color: var(--text-tertiary); font: 600 var(--fs-micro)/1.4 var(--mono);
     letter-spacing: .04em; padding: 2px 0;
   }
   .chart-note > summary::-webkit-details-marker { display: none; }
@@ -2031,7 +2054,7 @@
   .chart-note[open] > summary::after { transform: rotate(90deg); }
   @media (hover: hover) and (pointer: fine) { .chart-note > summary:hover { color: var(--text-secondary); } }
   .chart-note > p {
-    margin: 4px 0 2px; color: var(--text-tertiary); font: 500 11px/1.55 var(--mono);
+    margin: 4px 0 2px; color: var(--text-tertiary); font: 500 var(--fs-xs)/1.55 var(--mono);
   }
   .overview-equity-chart { min-height: 390px; height: 390px; }
   /* The chart sits inside the mobile horizontal pager. Allow the browser to
@@ -2042,31 +2065,30 @@
     position: absolute; z-index: 3; pointer-events: none; max-width: 240px;
     padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px;
     background: var(--card); color: var(--text); box-shadow: 0 12px 32px rgba(0,0,0,.28);
-    font: 11px/1.55 var(--mono);
+    font: var(--fs-xs)/1.55 var(--mono);
   }
   .native-equity-window {
     display: flex; align-items: center; gap: 8px; height: 26px;
-    color: var(--text-faint); font: 9px var(--mono);
+    color: var(--text-faint); font: var(--fs-micro) var(--mono);
   }
   .native-equity-window[hidden] { display: none; }
   .native-equity-window input { min-width: 0; flex: 1; accent-color: var(--accent); }
   .overview-equity-chart { position: relative; }
   .overview-verdict {
     grid-column: span 4; min-height: 480px; padding: 18px;
-    border-top: 2px solid var(--warning);
   }
   .overview-verdict-head,
   .overview-gates-head {
     display: flex; align-items: center; justify-content: space-between; gap: 10px;
   }
   .overview-verdict-head h3 {
-    margin: 5px 0 0; color: var(--text); font-size: 17px;
+    margin: 5px 0 0; color: var(--text); font-size: var(--fs-lg);
     letter-spacing: -.01em; text-transform: uppercase;
   }
   .overview-jump,
   .overview-strip-link {
     appearance: none; border: 0; background: transparent; color: var(--accent);
-    font: 650 10px/1.2 var(--mono); cursor: pointer;
+    font: 600 var(--fs-micro)/1.2 var(--mono); cursor: pointer;
   }
   .overview-jump { padding: 6px 0 6px 8px; white-space: nowrap; }
   .overview-jump:focus-visible,
@@ -2074,31 +2096,30 @@
     outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 3px;
   }
   .overview-status {
-    margin: 14px 0 12px; padding: 10px 11px; font-size: 12.5px;
+    margin: 14px 0 12px; padding: 10px 11px; font-size: var(--fs-sm);
   }
   .overview-verdict .today-highlights {
     display: grid; grid-template-columns: 1fr; gap: 6px;
     margin: 0 0 14px; min-height: 0;
   }
   .overview-verdict .hl-chip {
-    min-width: 0; padding: 7px 9px; border-radius: var(--radius-sm);
-    font-size: 11.5px; overflow-wrap: anywhere;
+    min-width: 0; padding: 7px 0; font-size: var(--fs-sm); overflow-wrap: anywhere;
   }
   .overview-gates {
     padding-top: 12px; border-top: 1px solid var(--border-subtle);
   }
   .overview-gates-head {
-    color: var(--text-secondary); font: 700 10px/1.2 var(--mono);
+    color: var(--text-secondary); font: 700 var(--fs-micro)/1.2 var(--mono);
     letter-spacing: .06em; text-transform: uppercase;
   }
   .overview-gates-directive {
     display: -webkit-box; margin-top: 7px; overflow: hidden;
     -webkit-box-orient: vertical; -webkit-line-clamp: 2;
-    color: var(--text-tertiary); font-size: 10.5px; line-height: 1.45;
+    color: var(--text-tertiary); font-size: var(--fs-micro); line-height: 1.45;
   }
   .overview-gates .risk-alerts { margin-top: 8px; gap: 6px; }
   .overview-gates .risk-alert {
-    align-items: flex-start; padding: 7px 9px; font-size: 10.5px; line-height: 1.35;
+    align-items: flex-start; padding: 7px 9px; font-size: var(--fs-micro); line-height: 1.35;
   }
   .overview-strip {
     grid-column: 1 / -1; min-width: 0;
@@ -2119,30 +2140,30 @@
   }
   .overview-strip-link span:last-child { color: var(--accent); letter-spacing: 0; text-transform: none; }
   .overview-asof {
-    position: absolute; top: 31px; left: 14px; font: 500 9px/1.2 var(--mono);
+    position: absolute; top: 31px; left: 14px; font: 500 var(--fs-micro)/1.2 var(--mono);
   }
   .overview-market .market-grid {
     grid-template-columns: repeat(5, minmax(0, 1fr)); min-height: 58px; margin-top: 9px;
   }
   .overview-market .market-cell { min-height: 58px; padding: 7px 9px; }
-  .overview-market .market-cell .val { font-size: 14px; }
-  .overview-market .market-cell .pct { font-size: 10.5px; }
+  .overview-market .market-cell .val { font-size: var(--fs-md); }
+  .overview-market .market-cell .pct { font-size: var(--fs-micro); }
   .overview-market .market-cell .src { display: none; }
   .overview-market .rs-row {
-    min-height: 0; margin-top: 5px; font-size: 9.5px; white-space: normal;
+    min-height: 0; margin-top: 5px; font-size: var(--fs-micro); white-space: normal;
     overflow-wrap: anywhere;
   }
   .overview-mover-summary {
-    color: var(--text); font: 750 clamp(19px, 2vw, 27px)/1.15 var(--mono);
+    color: var(--text); font: 700 var(--fs-xl)/1.15 var(--mono);
     font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
   }
-  .overview-mover-summary .tk { display: block; color: var(--text-secondary); font: 700 12px/1.3 var(--mono); }
+  .overview-mover-summary .tk { display: block; color: var(--text-secondary); font: 700 var(--fs-sm)/1.3 var(--mono); }
   .overview-anomaly-count {
-    color: var(--warning); font: 760 clamp(25px, 2.6vw, 36px)/1 var(--mono);
+    color: var(--warning); font: 700 var(--fs-xxl)/1 var(--mono);
     font-variant-numeric: tabular-nums;
   }
   .overview-anomaly-summary {
-    margin-top: 6px; color: var(--text-tertiary); font-size: 10.5px;
+    margin-top: 6px; color: var(--text-tertiary); font-size: var(--fs-micro);
     line-height: 1.35; overflow-wrap: anywhere;
   }
   .overview-command > .hero-honesty-card { grid-column: span 5; min-height: 220px; }
@@ -2182,12 +2203,16 @@
   /* Data arrives after the scaffold. Fixed grid rows + floors reserve the same
      geometry, preserving the existing CLS=0 behavior without hiding active data. */
   #guardrail-card { min-height: 560px; }
+  /* 彩色描边胶囊 → 文本行（#879）：一屏里三个不同颜色的圆角描边框是最强的
+     「AI 生成」信号；语义交给左侧小圆点和文字颜色，盒子本身取消。 */
   .hl-chip {
-    display: inline-flex; align-items: center; gap: var(--space-2);
-    padding: 8px 12px; border-radius: 999px;
-    font-size: 13px; line-height: 1.3; font-weight: 500;
-    background: var(--card-2); border: 1px solid var(--border); color: var(--text);
+    display: flex; align-items: baseline; gap: var(--space-2);
+    padding: 6px 0; border-radius: 0;
+    font-size: var(--fs-md); line-height: 1.45; font-weight: 500;
+    background: none; border: 0; border-bottom: 1px solid var(--border-subtle);
+    color: var(--text);
   }
+  .hl-chip:last-child { border-bottom: 0; }
   /* The icon slot is a status dot now — the emoji that lived here read as
      AI-flavoured (ui-ux-pro-max: no emoji as icons). Colour inherits from the
      chip's semantic state class below. */
@@ -2195,16 +2220,18 @@
     width: 7px; height: 7px; border-radius: 50%;
     background: currentColor; flex: none;
   }
-  .hl-chip.hl-alert { border-color: var(--red); background: color-mix(in srgb, var(--red) 14%, var(--card)); color: var(--red); font-weight: 600; }
-  .hl-chip.hl-warn  { border-color: var(--amber); color: var(--amber); }
-  .hl-chip.hl-up    { border-color: var(--green); color: var(--green); }
-  .hl-chip.hl-down  { border-color: var(--red); color: var(--red); }
-  .hl-chip.hl-info  { border-color: var(--accent); color: var(--accent); }
+  /* 颜色只留给圆点；文字保持墨色，除了真正的告警 */
+  .hl-chip.hl-alert { color: var(--red); font-weight: 600; }
+  .hl-chip.hl-warn  .hl-ic { background: var(--amber); }
+  .hl-chip.hl-up    .hl-ic { background: var(--green); }
+  .hl-chip.hl-down  .hl-ic { background: var(--red); }
+  .hl-chip.hl-info  .hl-ic { background: var(--accent); }
+  .hl-chip .hl-ic { align-self: center; }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .hero-deck { grid-template-columns: minmax(0, 1fr); }
-    .hero-deck-lead { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .hero-rail-cell:nth-child(4n) { border-right: 0; }
+    .hero-rail-cell:nth-child(-n+4) { border-bottom: 1px solid var(--border-subtle); }
     .overview-equity, .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
@@ -2218,9 +2245,8 @@
     .hero-deck { grid-template-columns: minmax(0, 1fr); }
     .hero-deck-lead { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
     .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .hero-rail-cell:nth-child(4n) { border-right: 1px solid var(--border-subtle); }
+    .hero-rail-cell { border-bottom: 1px solid var(--border-subtle); }
     .hero-rail-cell:nth-child(2n) { border-right: 0; }
-    .hero-rail-cell:nth-last-child(-n+4) { border-bottom: 1px solid var(--border-subtle); }
     .hero-rail-cell:nth-last-child(-n+2) { border-bottom: 0; }
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
@@ -2243,9 +2269,9 @@
     .overview-command > .hero-gold-card { min-height: 760px; }
   }
   @media (max-width: 420px) {
-    .hero-deck-pnl { font-size: clamp(30px, 10.5vw, 40px); }
-    .hero-deck-sub { font-size: 12px; }
-    .hero-rail-v { font-size: 15px; }
+    .hero-deck-pnl { font-size: var(--fs-display); }
+    .hero-deck-sub { font-size: var(--fs-sm); }
+    .hero-rail-v { font-size: var(--fs-lg); }
     .hero-rail-cell { padding: 11px 12px; }
     .dh-seg { width: 11px; height: 26px; }
   }
@@ -2310,7 +2336,7 @@
    Decision traces — real fills as the spine with soft-paired
    decisions and T+1 verdicts (public mirror of the DSH plugin)
    ========================================================= */
-#decision-traces-card { font-size: 13px; }
+#decision-traces-card { font-size: var(--fs-md); }
 #trace-stats b { font-variant-numeric: tabular-nums; }
 /* A day is one container of hairline-separated rows, not a stack of floating
    cards. Rows draw on the day's own tracks (`subgrid`, declared after the
@@ -2351,7 +2377,7 @@
 .tr-row summary:active { background: color-mix(in srgb, var(--accent) 12%, transparent); }
 .tr-row[open] summary { background: color-mix(in srgb, var(--accent) 7%, transparent); box-shadow: inset 3px 0 0 var(--accent); }
 .tr-row[open] summary::after { transform: rotate(180deg); }
-.tr-row summary::after { content: '▾'; grid-area: 1 / 9; justify-self: end; color: var(--text-dim); font-size: 10px; transition: transform 0.15s; }
+.tr-row summary::after { content: '▾'; grid-area: 1 / 9; justify-self: end; color: var(--text-dim); font-size: var(--fs-micro); transition: transform 0.15s; }
 .tr-row summary > .tr-dot { grid-area: 1 / 2; }
 .tr-row summary > .tr-tk { grid-area: 1 / 3; }
 .tr-row summary > .tr-act { grid-area: 1 / 4; justify-self: start; }
@@ -2362,17 +2388,17 @@
 .tr-row summary > .tr-spacer { display: none; }
 .tr-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--border-strong, var(--text-dim)); flex: none; }
 .tr-dot.has { background: var(--accent); }
-.tr-tk { font-weight: 700; font-size: 13.5px; }
-.tr-act { font-size: 11.5px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
+.tr-tk { font-weight: 700; font-size: var(--fs-md); }
+.tr-act { font-size: var(--fs-xs); font-weight: 600; padding: 2px 8px; border-radius: 999px; }
 .tr-act.pos { color: var(--pos); background: color-mix(in srgb, var(--pos) 12%, transparent); }
 .tr-act.neg { color: var(--neg); background: color-mix(in srgb, var(--neg) 12%, transparent); }
 .tr-act.muted { color: var(--text-dim); background: var(--bg-soft, rgba(0,0,0,0.04)); }
-.tr-qty { color: var(--text-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+.tr-qty { color: var(--text-dim); font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
 .tr-spacer { flex: 1; }
-.tr-t1 { font-size: 11px; font-weight: 700; padding: 2px 7px; border-radius: 5px; white-space: nowrap; }
+.tr-t1 { font-size: var(--fs-xs); font-weight: 700; padding: 2px 7px; border-radius: 5px; white-space: nowrap; }
 .tr-t1.pos { color: var(--pos); background: color-mix(in srgb, var(--pos) 10%, transparent); }
 .tr-t1.neg { color: var(--neg); background: color-mix(in srgb, var(--neg) 10%, transparent); }
-.tr-pnl { font-weight: 700; font-size: 15px; font-variant-numeric: tabular-nums; min-width: 88px; text-align: right; }
+.tr-pnl { font-weight: 700; font-size: var(--fs-lg); font-variant-numeric: tabular-nums; min-width: 88px; text-align: right; }
 .tr-pnl.pos { color: var(--pos); } .tr-pnl.neg { color: var(--neg); }
 /* The details content box is the animatable wrapper (Chrome 131+, Safari
    18.4+, Firefox 132+): grid-template-rows 0fr -> 1fr is the same motion the
@@ -2402,27 +2428,27 @@
 .tr-node.skip::before { border-color: var(--warning); }
 .tr-node.pos::before { border-color: var(--pos); }
 .tr-node.neg::before { border-color: var(--neg); }
-.tr-n { font-size: 10.5px; font-weight: 700; letter-spacing: 0.05em; color: var(--text-dim); text-transform: uppercase; }
-.tr-v { font-size: 12.5px; font-weight: 600; margin-top: 2px; }
+.tr-n { font-size: var(--fs-micro); font-weight: 700; letter-spacing: 0.05em; color: var(--text-dim); text-transform: uppercase; }
+.tr-v { font-size: var(--fs-sm); font-weight: 600; margin-top: 2px; }
 .tr-v.pos { color: var(--pos); } .tr-v.neg { color: var(--neg); } .tr-v.ok { color: var(--pos); } .tr-v.skip { color: var(--warning); }
 .tr-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0 8px; }
-.tr-chip { font-size: 11px; padding: 2px 8px; border-radius: 6px; background: var(--bg-soft, rgba(0,0,0,0.04)); border: 1px solid var(--border); color: var(--text-dim); }
-.tr-note { margin: 6px 0; padding: 3px 0 3px 10px; border-left: 3px solid var(--border); font-size: 12px; color: var(--text-secondary); line-height: 1.6; white-space: pre-wrap; overflow-wrap: anywhere; }
+.tr-chip { font-size: var(--fs-xs); padding: 2px 8px; border-radius: 6px; background: var(--bg-soft, rgba(0,0,0,0.04)); border: 1px solid var(--border); color: var(--text-dim); }
+.tr-note { margin: 6px 0; padding: 3px 0 3px 10px; border-left: 3px solid var(--border); font-size: var(--fs-sm); color: var(--text-secondary); line-height: 1.6; white-space: pre-wrap; overflow-wrap: anywhere; }
 .tr-note.why { border-left-color: var(--accent); }
 .tr-note.emo { border-left-color: var(--warning); }
-.tr-miss { margin: 8px 0; padding: 7px 10px; border: 1px dashed var(--border); border-radius: 6px; font-size: 11.5px; color: var(--text-dim); }
+.tr-miss { margin: 8px 0; padding: 7px 10px; border: 1px dashed var(--border); border-radius: 6px; font-size: var(--fs-xs); color: var(--text-dim); }
 .trace-day { margin-bottom: 12px; }
-.trace-day-h { font-size: 11px; font-weight: 700; color: var(--text-dim); letter-spacing: 0.05em; margin: 10px 0 6px; display: flex; align-items: center; gap: 6px; }
+.trace-day-h { font-size: var(--fs-xs); font-weight: 700; color: var(--text-dim); letter-spacing: 0.05em; margin: 10px 0 6px; display: flex; align-items: center; gap: 6px; }
 .trace-day-h::after { content: ''; flex: 1; height: 1px; background: var(--border); }
-.tr-pnl-k { font-size: 10px; font-weight: 600; color: var(--text-dim); margin-right: 3px; }
-.tr-align { font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 5px; white-space: nowrap; }
+.tr-pnl-k { font-size: var(--fs-micro); font-weight: 600; color: var(--text-dim); margin-right: 3px; }
+.tr-align { font-size: var(--fs-xs); font-weight: 700; padding: 1px 6px; border-radius: 5px; white-space: nowrap; }
 /* 与计划反向 is a deviation, not an accent: amber here and in the plugin
    (styles.module.css `--warn`), so the two implementations of this card read
    the same signal the same way. */
 .tr-align.skip { color: var(--warning); background: color-mix(in srgb, var(--warning) 12%, transparent); border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent); }
 .tr-align.ok { color: var(--pos); background: color-mix(in srgb, var(--pos) 12%, transparent); }
 .tr-align.na { color: var(--text-dim); background: var(--bg-soft, rgba(0,0,0,0.04)); }
-#trace-stats { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 8px 0 10px; font-size: 12px; line-height: 1.5; }
+#trace-stats { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 8px 0 10px; font-size: var(--fs-sm); line-height: 1.5; }
 
 /* The summary row is a nowrap flex line whose min-content is ~367px — wider
    than any phone — and .tr-row clips instead of scrolling, so below ~420px the
@@ -2444,7 +2470,7 @@
   .tr-row summary > .tr-dot { grid-area: 1 / 1; }
   .tr-row summary > .tr-tk { grid-area: 1 / 2; }
   .tr-row summary > .tr-act { grid-area: 1 / 3; justify-self: start; }
-  .tr-row summary > .tr-pnl { grid-area: 1 / 4; min-width: 0; font-size: 14.5px; white-space: nowrap; justify-self: end; }
+  .tr-row summary > .tr-pnl { grid-area: 1 / 4; min-width: 0; font-size: var(--fs-md); white-space: nowrap; justify-self: end; }
   .tr-row summary > .tr-qty { grid-area: 2 / 2 / 3 / 3; }
   /* 反向 and the T+1 chip share line 2 with the size; every child has a cell,
      which is what keeps anything from being pushed outside the row (#736). */
@@ -2471,11 +2497,19 @@
   }
   .book-table tbody tr.book-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
   .book-caret {
-    display: inline-block; margin-left: 5px; color: var(--text-tertiary); font-size: 13px;
+    display: inline-block; margin-left: 5px; color: var(--text-tertiary); font-size: var(--fs-md);
     opacity: .4; transition: transform var(--duration-standard) var(--ease-out), opacity var(--duration-fast) ease;
   }
   .book-row[data-open="1"] .book-caret { transform: rotate(90deg); opacity: 1; }
-  .book-table tbody tr.book-detail > td { padding: 0; border-bottom: 0; background: none; }
+  /* 展开行整段都在一个 <td> 里，会继承 .holdings-table td 的 white-space:nowrap，
+     于是长句一行不折、直接撑出列外（kcn 报的「holdings 展示溢出」）。 */
+  .book-table tbody tr.book-detail > td {
+    padding: 0; border-bottom: 0; background: none;
+    white-space: normal; height: auto; text-align: left;
+  }
+  .book-detail .bd-grid, .book-detail .bd-col, .book-detail .bd-note,
+  .book-detail .bd-kv, .book-detail .bd-kv .k { white-space: normal; }
+  .book-detail .bd-kv .v { white-space: nowrap; }
   .book-detail[data-open="1"] > td { border-bottom: 1px solid var(--border-subtle); }
   .bd-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--duration-standard) var(--ease-out); }
   .book-detail[data-open="1"] .bd-wrap { grid-template-rows: 1fr; }
@@ -2486,12 +2520,12 @@
   }
   .bd-col { padding: 8px 0; min-width: 0; }
   .bd-k {
-    color: var(--text-tertiary); font: 700 9.5px/1.2 var(--mono);
+    color: var(--text-tertiary); font: 700 var(--fs-micro)/1.2 var(--mono);
     letter-spacing: .09em; text-transform: uppercase; margin-bottom: 7px;
   }
   .bd-kv {
     display: flex; justify-content: space-between; gap: 12px; padding: 4px 0;
-    border-bottom: 1px solid var(--border-subtle); font: 500 11.5px/1.4 var(--mono);
+    border-bottom: 1px solid var(--border-subtle); font: 500 var(--fs-xs)/1.4 var(--mono);
     font-variant-numeric: tabular-nums;
   }
   .bd-kv:last-child { border-bottom: 0; }
@@ -2500,13 +2534,13 @@
   .bd-kv .v.pos { color: var(--positive); }
   .bd-kv .v.neg { color: var(--negative); }
   .bd-note {
-    color: var(--text-tertiary); font: 500 11px/1.55 var(--mono); padding: 4px 0;
+    color: var(--text-tertiary); font: 500 var(--fs-xs)/1.55 var(--mono); padding: 4px 0;
     overflow-wrap: anywhere; word-break: break-word;
   }
   .bd-note.neg { color: var(--negative); }
-  .bd-empty { color: var(--text-tertiary); font: 500 11.5px/1.5 var(--mono); padding: 8px 0 16px; }
+  .bd-empty { color: var(--text-tertiary); font: 500 var(--fs-xs)/1.5 var(--mono); padding: 8px 0 16px; }
   .bd-pos { padding: 8px 0 2px; }
-  .bd-pos-lbl { display: block; color: var(--text-tertiary); font: 500 10.5px/1.3 var(--mono); margin-bottom: 6px; }
+  .bd-pos-lbl { display: block; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.3 var(--mono); margin-bottom: 6px; }
   .bd-pos-track {
     position: relative; display: block; height: 4px; border-radius: 2px;
     background: color-mix(in srgb, var(--text) 12%, transparent);
@@ -2517,15 +2551,15 @@
   }
   .bd-pos-ends {
     display: flex; justify-content: space-between; margin-top: 5px;
-    color: var(--text-tertiary); font: 500 10px/1.3 var(--mono);
+    color: var(--text-tertiary); font: 500 var(--fs-micro)/1.3 var(--mono);
   }
 
   /* 合并卡内部的分节（组合结构 / 今日异动）*/
   .sub-block + .sub-block { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--border-subtle); }
   .sub-block-head {
-    color: var(--text); font: 700 12px/1.4 var(--font, inherit); margin-bottom: 10px;
+    color: var(--text); font: 700 var(--fs-sm)/1.4 var(--font, inherit); margin-bottom: 10px;
   }
-  .sub-block-head .muted { font-weight: 500; font-size: 10.5px; letter-spacing: 0; }
+  .sub-block-head .muted { font-weight: 500; font-size: var(--fs-micro); letter-spacing: 0; }
   .action-split { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 24px; }
   .action-split .sub-block + .sub-block { margin-top: 0; padding-top: 0; border-top: 0; }
   @media (max-width: 900px) {
@@ -2543,12 +2577,12 @@
   /* Add Campaign：全员同态时折成一行（#875）*/
   .campaign-fold > summary {
     cursor: pointer; list-style: none; padding: 8px 0;
-    color: var(--text-secondary); font: 600 12px/1.4 var(--mono);
+    color: var(--text-secondary); font: 600 var(--fs-sm)/1.4 var(--mono);
     display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
   }
   .campaign-fold > summary::-webkit-details-marker { display: none; }
   .campaign-fold > summary::after {
-    content: "›"; color: var(--text-tertiary); font-size: 14px;
+    content: "›"; color: var(--text-tertiary); font-size: var(--fs-md);
     transition: transform var(--duration-fast) var(--ease-out);
   }
   .campaign-fold[open] > summary::after { transform: rotate(90deg); }
@@ -2556,6 +2590,34 @@
     .campaign-fold > summary:hover { color: var(--text); }
   }
   .campaign-fold-names {
-    color: var(--text-tertiary); font: 500 11px/1.4 var(--mono);
+    color: var(--text-tertiary); font: 500 var(--fs-xs)/1.4 var(--mono);
     min-width: 0; overflow-wrap: anywhere;
   }
+  /* 没写字号的按钮会掉到浏览器默认 13.3333px，落在字阶之外（#880） */
+  .trace-more, button:not([class*="tab"]):not(.rf) { font-size: var(--fs-sm); }
+  /* 日收益热力：与持仓主表同序的行网格（#881） */
+  .book-heat {
+    --heat-cols: 7;
+    display: grid; gap: 2px; min-width: 520px;
+    grid-template-columns: 76px repeat(var(--heat-cols), minmax(30px, 44px)) 64px 64px;
+    justify-content: start;
+  }
+  .book-heat .bh-row { display: contents; }
+  .book-heat .bh-tk, .book-heat .bh-c, .book-heat .bh-v, .book-heat .bh-s {
+    display: flex; align-items: center; height: 26px; font-size: var(--fs-xs);
+    font-variant-numeric: tabular-nums;
+  }
+  .book-heat .bh-tk { padding-right: 8px; }
+  .book-heat .bh-c { justify-content: center; border-radius: 3px; color: var(--text-secondary); font-size: var(--fs-micro); }
+  .book-heat .bh-c.is-empty { background: color-mix(in srgb, var(--text) 5%, transparent); }
+  .book-heat .bh-v { justify-content: flex-end; padding-left: 10px; }
+  .book-heat .bh-s { justify-content: flex-end; padding-left: 10px; }
+  /* 走势线的方向色只挂在 .holdings-table 下，热力行不在那棵树里 */
+  .book-heat .spark.spark-up { color: var(--green); }
+  .book-heat .spark.spark-down { color: var(--red); }
+  .book-heat .spark.spark-flat { color: var(--text-tertiary); }
+  .book-heat .bh-head > * { height: 20px; color: var(--text-tertiary); font-size: var(--fs-micro); }
+  .book-heat .bh-head .bh-c { justify-content: center; }
+  .book-heat .bh-head .bh-v, .book-heat .bh-head .bh-s { justify-content: flex-end; }
+  :root { --heat-up: #12864c; --heat-down: #c4291f; }
+  @media (prefers-color-scheme: dark) { :root { --heat-up: #32d272; --heat-down: #ff5a4e; } }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -217,7 +217,7 @@
     });
     if (fe.length) rows.push(row("消息源 edge", fe.join(" · "), "var(--text-dim)"));
     el.innerHTML = rows.join("")
-      + `<div style="color:var(--text-dim);font-size:10px;margin-top:var(--space-2)">算账在 Python：同策略连续决策按 episode 去重；一个 episode 只出一个样本、取其内部平均而非选某一条；被判定未触发的不结算；执行与建议质量分开统计。</div>`;
+      + `<div style="color:var(--text-dim);font-size:var(--fs-micro);margin-top:var(--space-2)">算账在 Python：同策略连续决策按 episode 去重；一个 episode 只出一个样本、取其内部平均而非选某一条；被判定未触发的不结算；执行与建议质量分开统计。</div>`;
     card.style.display = "";
   }
 
@@ -676,12 +676,11 @@
 
     pnlEl.textContent = heroMoney(totalUsd, "USD");
     pnlEl.className = "hero-deck-pnl " + pnlClass(totalUsd);
+    // 首屏只回答三件事：赚亏多少、其中落袋多少、今天涨没涨。账面与 FX 降到
+    // 下面那条安静行 —— 原来它们挤在同一行，1440 宽下必折行，折行是首屏最
+    // 显眼的「乱」。(#879)
     subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
       + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
-      + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
-      // 账面的 HKD 等值：原来 Total book 卡的第二行，合并后仍要留着
-      + ((fx && has(us.value_usd) && has(hk.value_hkd))
-        ? ` <span class="muted">/ ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}</span>` : "")
       + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
       + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
@@ -690,7 +689,10 @@
       if (fx) {
         const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
         const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-        fxEl.textContent = `USDHKD ${fmtNum(fx, 4)}`
+        fxEl.textContent = `账面 ${fmtMoney(bookUsd, "USD")}`
+          + (has(us.value_usd) && has(hk.value_hkd)
+            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")
+          + ` · USDHKD ${fmtNum(fx, 4)}`
           + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
       } else {
         fxEl.textContent = "FX unavailable";
@@ -702,21 +704,25 @@
     const usTodayPct = legPct(us.value_usd, us.today_change_usd);
     const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
+    // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
+    // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
       + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
-      + `<div class="hero-rail-s">${s || ""}</div></div>`;
+      + (s ? `<div class="hero-rail-s">${s}</div>` : "") + `</div>`;
+    const withDelta = (v, delta, cls) =>
+      `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
     railEl.innerHTML = [
-      cell("US 腿", fmtMoney(us.value_usd, "USD"),
-        `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
-      cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
-        `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
-      cell("今日 US", heroMoney(us.today_change_usd, "USD"),
-        `美股腿${usTodayPct == null ? "" : " · " + fmtPct(usTodayPct)}`, pnlClass(us.today_change_usd)),
-      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"),
-        `港股腿${hkTodayPct == null ? "" : " · " + fmtPct(hkTodayPct)}`, pnlClass(hk.today_change_hkd)),
-      cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
-      cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
+      cell("US 腿", withDelta(fmtMoney(us.value_usd, "USD"),
+        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
+      cell("HK 腿", withDelta(fmtMoney(hk.value_hkd, "HKD"),
+        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
+      cell("今日 US", withDelta(heroMoney(us.today_change_usd, "USD"),
+        usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
+      cell("今日 HK", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
+        hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
+      cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
+      cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -877,7 +883,7 @@
         countEl.style.color = 'var(--warning)';
         if (dirEl) dirEl.textContent = '风控数据计算失败，本次不作“无触发”判断。';
         listEl.innerHTML = '<div class="risk-alert medium"><span class="icon">⚠️</span>'
-          + '<div><strong>风控卡不可用</strong><div class="muted" style="font-size:11px;margin-top:2px">'
+          + '<div><strong>风控卡不可用</strong><div class="muted" style="font-size:var(--fs-xs);margin-top:2px">'
           + '等待下次数据刷新重算</div></div></div>';
       });
       return;
@@ -888,7 +894,7 @@
     const row = (icon, sev, detail, action) =>
       `<div class="risk-alert ${sev || 'high'}">
          <span class="icon">${icon}</span>
-         <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:11px;margin-top:2px">→ ${action}</div>` : ''}</div>
+         <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:var(--fs-xs);margin-top:2px">→ ${action}</div>` : ''}</div>
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
@@ -904,7 +910,7 @@
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';
+      listEl.innerHTML = html || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 
@@ -926,18 +932,18 @@
     // hero: 现值 + 盈亏
     document.getElementById('gold-hero').innerHTML =
       `<div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin:2px 0 12px">
-         <span style="font-size:26px;font-weight:800">¥${num(g.current_value)}</span>
-         <span style="font-size:17px;font-weight:700;color:${pnlColor}">${sign}${num(g.pnl_percent, 2)}%</span>
-         <span style="font-size:13px;color:${pnlColor}">${(g.pnl_abs >= 0 ? '+' : '')}¥${num(g.pnl_abs)}</span>
+         <span style="font-size:var(--fs-xxl);font-weight:700">¥${num(g.current_value)}</span>
+         <span style="font-size:var(--fs-lg);font-weight:700;color:${pnlColor}">${sign}${num(g.pnl_percent, 2)}%</span>
+         <span style="font-size:var(--fs-md);color:${pnlColor}">${(g.pnl_abs >= 0 ? '+' : '')}¥${num(g.pnl_abs)}</span>
        </div>`;
 
     // stats grid
     const navChg = g.nav_change_pct;
     const navChgStr = navChg == null ? '' :
-      ` <span style="color:${navChg >= 0 ? 'var(--positive)' : 'var(--negative)'};font-size:11px">${navChg >= 0 ? '+' : ''}${navChg.toFixed(2)}%</span>`;
+      ` <span style="color:${navChg >= 0 ? 'var(--positive)' : 'var(--negative)'};font-size:var(--fs-xs)">${navChg >= 0 ? '+' : ''}${navChg.toFixed(2)}%</span>`;
     const cell = (label, val) => `<div style="flex:1 1 30%;min-width:90px;margin:5px 0">
-        <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">${label}</div>
-        <div style="font-size:15px;font-weight:700;margin-top:1px">${val}</div></div>`;
+        <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">${label}</div>
+        <div style="font-size:var(--fs-lg);font-weight:700;margin-top:1px">${val}</div></div>`;
     document.getElementById('gold-stats').innerHTML =
       `<div style="display:flex;flex-wrap:wrap;gap:2px 8px;padding:8px 0;border-top:1px solid var(--border,#2a2a2a)">
         ${cell('累计投入', '¥' + num(g.principal_effective != null ? g.principal_effective : g.principal_invested))}
@@ -954,7 +960,7 @@
     if (goldDomestic) {
       if (!dg || dg.price_cny_g == null) {
         goldDomestic.innerHTML =
-          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:11px">
+          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:var(--fs-xs)">
              上金所 Au99.99 暂无有效行情
            </div>`;
       } else {
@@ -963,18 +969,18 @@
         const retained = dg.quote_status === 'retained';
         goldDomestic.innerHTML =
           `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
+             <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
-               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:21px;font-weight:800;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:10px">我的回本价</div><div style="font-size:21px;font-weight:800;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
              </div>
-             <div class="muted" style="font-size:11px;margin-top:7px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-xs);margin-top:7px;text-transform:none;letter-spacing:0">
                距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
                ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
                ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
              </div>
-             <div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-micro);margin-top:4px;text-transform:none;letter-spacing:0">
                ${dg.date || ''} 收盘 · 上金所${retained ? ' · ⚠️ 本次抓取失败，沿用上次有效值' : ''}
              </div>
            </div>`;
@@ -990,7 +996,7 @@
       else {
         const xchg = ld.xau_change_pct;
         const xcolor = (xchg == null ? 'var(--neutral)' : (xchg >= 0 ? 'var(--positive)' : 'var(--negative)'));
-        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
+        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:var(--fs-xs)">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
         const fundBeXau = ld.fund_breakeven_usd_oz != null
           ? ld.fund_breakeven_usd_oz
           : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
@@ -999,13 +1005,13 @@
         // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
+             <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
-               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:19px;font-weight:800;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:10px">按当前汇率回本</div><div style="font-size:19px;font-weight:800;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
              </div>
-             <div class="muted" style="font-size:11px;margin-top:5px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-xs);margin-top:5px;text-transform:none;letter-spacing:0">
                距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
                · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
@@ -1017,11 +1023,11 @@
           unavailable: '历史抓取失败',
           not_attempted: '历史未抓取',
         };
-        html += `<div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+        html += `<div class="muted" style="font-size:var(--fs-micro);margin-top:4px;text-transform:none;letter-spacing:0">
           历史源 ${escapeHtml(histNames[histSource.name] || histSource.name || '未知')} · ${num(histSource.points || 0)} 点
         </div>`;
         if (ld.hist_advisory) {
-          html += `<div role="status" style="font-size:10px;color:var(--warning);margin-top:4px;text-transform:none;letter-spacing:0">
+          html += `<div role="status" style="font-size:var(--fs-micro);color:var(--warning);margin-top:4px;text-transform:none;letter-spacing:0">
             ℹ️ ${escapeHtml(ld.hist_advisory)}
           </div>`;
         }
@@ -1032,13 +1038,13 @@
           const dColor = de.pnl_pct >= 0 ? 'var(--positive)' : 'var(--negative)';
           html +=
             `<details style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
-               <summary class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
+               <summary class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
                <div style="margin-top:6px">
                <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;margin-top:2px">
-                 <span style="font-size:17px;font-weight:800">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:11px;font-weight:600;color:var(--muted,#999)">/oz</span></span>
-                 <span style="font-size:12px;font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
+                 <span style="font-size:var(--fs-lg);font-weight:700">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:var(--fs-xs);font-weight:600;color:var(--muted,#999)">/oz</span></span>
+                 <span style="font-size:var(--fs-sm);font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
                </div>
-               <div class="muted" style="font-size:11px;margin-top:3px;text-transform:none;letter-spacing:0">
+               <div class="muted" style="font-size:var(--fs-xs);margin-top:3px;text-transform:none;letter-spacing:0">
                  现货 <b style="color:var(--text,#eee)">$${num(de.spot_usd_oz, 2)}</b>/oz · 回本需涨 <b style="color:${beColor}">${de.breakeven_upside_pct >= 0 ? '+' : ''}${num(de.breakeven_upside_pct, 2)}%</b>
                  ${de.current_value_cny != null ? `· 对应现值 <b style="color:${dColor}">¥${num(de.current_value_cny)}</b> (${de.pnl_pct >= 0 ? '+' : ''}${num(de.pnl_pct, 2)}%)` : ''}
                </div>
@@ -1052,9 +1058,9 @@
                 <td style="padding:4px 8px;text-align:right">$${num(p.avg_cost_usd_oz, 0)}</td>
                 <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
             html +=
-              `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
-               <table style="width:100%;font-size:12px;border-collapse:collapse">
-                 <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
+               <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
+                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
                ${lrows}</table>`;
           }
           html += `</div></details>`;
@@ -1077,7 +1083,7 @@
                <polyline points="${lineL}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
                <polyline points="${lineF}" fill="none" stroke="${fColor}" stroke-width="1.6" stroke-dasharray="4 2"/>
              </svg>
-             <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0;margin-top:1px">
+             <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0;margin-top:1px">
                <span style="color:var(--warning)">伦敦金 ${lLast >= 100 ? '+' : ''}${num(lLast - 100, 1)}%</span>
                <span style="color:${fColor}">你的基金 ${fLast >= 100 ? '+' : ''}${num(fLast - 100, 1)}%</span>
                <span>起投=100 · 差因:汇率+费率</span>
@@ -1111,7 +1117,7 @@
           <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
-        <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
+        <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
           <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
           <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
@@ -1127,9 +1133,9 @@
           <td style="padding:4px 8px;text-align:right">${num(p.avg_cost, 3)}</td>
           <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
       document.getElementById('gold-proj').innerHTML =
-        `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
-         <table style="width:100%;font-size:12px;border-collapse:collapse">
-           <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
+         <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
+           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
            ${rows}</table>`;
     } else { document.getElementById('gold-proj').innerHTML = ''; }
 

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -236,7 +236,7 @@
     });
     if (fe.length) rows.push(row("消息源 edge", fe.join(" · "), "var(--text-dim)"));
     el.innerHTML = rows.join("")
-      + `<div style="color:var(--text-dim);font-size:10px;margin-top:var(--space-2)">算账在 Python：同策略连续决策按 episode 去重；一个 episode 只出一个样本、取其内部平均而非选某一条；被判定未触发的不结算；执行与建议质量分开统计。</div>`;
+      + `<div style="color:var(--text-dim);font-size:var(--fs-micro);margin-top:var(--space-2)">算账在 Python：同策略连续决策按 episode 去重；一个 episode 只出一个样本、取其内部平均而非选某一条；被判定未触发的不结算；执行与建议质量分开统计。</div>`;
     card.style.display = "";
   }
 
@@ -339,7 +339,7 @@
     ],
     drill: [
       renderBook, renderAddCampaign, renderMovers,
-      renderAnomalies, render8dHeatmap, renderShadowPortfolioCard,
+      renderAnomalies, renderShadowPortfolioCard,
     ],
     risk: [
       renderRiskGuardrail, renderHHI, renderLeveragedETF, renderRiskMetrics, renderLevRegime,
@@ -666,12 +666,11 @@
 
     pnlEl.textContent = heroMoney(totalUsd, "USD");
     pnlEl.className = "hero-deck-pnl " + pnlClass(totalUsd);
+    // 首屏只回答三件事：赚亏多少、其中落袋多少、今天涨没涨。账面与 FX 降到
+    // 下面那条安静行 —— 原来它们挤在同一行，1440 宽下必折行，折行是首屏最
+    // 显眼的「乱」。(#879)
     subEl.innerHTML = `已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b>`
       + ` · 浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b>`
-      + ` · 账面 <b>${fmtMoney(bookUsd, "USD")}</b>`
-      // 账面的 HKD 等值：原来 Total book 卡的第二行，合并后仍要留着
-      + ((fx && has(us.value_usd) && has(hk.value_hkd))
-        ? ` <span class="muted">/ ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}</span>` : "")
       + ` · 今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
       + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "");
 
@@ -680,7 +679,10 @@
       if (fx) {
         const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
         const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-        fxEl.textContent = `USDHKD ${fmtNum(fx, 4)}`
+        fxEl.textContent = `账面 ${fmtMoney(bookUsd, "USD")}`
+          + (has(us.value_usd) && has(hk.value_hkd)
+            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")
+          + ` · USDHKD ${fmtNum(fx, 4)}`
           + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
       } else {
         fxEl.textContent = "FX unavailable";
@@ -692,21 +694,25 @@
     const usTodayPct = legPct(us.value_usd, us.today_change_usd);
     const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
+    // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
+    // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
       + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
-      + `<div class="hero-rail-s">${s || ""}</div></div>`;
+      + (s ? `<div class="hero-rail-s">${s}</div>` : "") + `</div>`;
+    const withDelta = (v, delta, cls) =>
+      `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
     railEl.innerHTML = [
-      cell("US 腿", fmtMoney(us.value_usd, "USD"),
-        `<span class="${pnlClass(us.pnl_usd)}">${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}</span>`),
-      cell("HK 腿", fmtMoney(hk.value_hkd, "HKD"),
-        `<span class="${pnlClass(hk.pnl_hkd)}">${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}</span>`),
-      cell("今日 US", heroMoney(us.today_change_usd, "USD"),
-        `美股腿${usTodayPct == null ? "" : " · " + fmtPct(usTodayPct)}`, pnlClass(us.today_change_usd)),
-      cell("今日 HK", heroMoney(hk.today_change_hkd, "HKD"),
-        `港股腿${hkTodayPct == null ? "" : " · " + fmtPct(hkTodayPct)}`, pnlClass(hk.today_change_hkd)),
-      cell("已实现", heroMoney(realUsd, "USD"), "落袋 · USD-eq", pnlClass(realUsd)),
-      cell("浮动", heroMoney(unrealUsd, "USD"), "账面 · USD-eq", pnlClass(unrealUsd)),
+      cell("US 腿", withDelta(fmtMoney(us.value_usd, "USD"),
+        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
+      cell("HK 腿", withDelta(fmtMoney(hk.value_hkd, "HKD"),
+        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
+      cell("今日 US", withDelta(heroMoney(us.today_change_usd, "USD"),
+        usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
+      cell("今日 HK", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
+        hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
+      cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
+      cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -987,7 +993,7 @@
       const inBook = (s.tickers_in_book || []).join(", ");
       return `<div class="sector-block">
         <div class="theme">${escape(s.theme)} ${inBook ? `<span class="in-book">[持仓: ${escape(inBook)}]</span>` : ""}</div>
-        <div class="movers">${movers || '<span class="muted" style="font-size:11px;opacity:0.55">— LLM 未填 top movers</span>'}</div>
+        <div class="movers">${movers || '<span class="muted" style="font-size:var(--fs-xs);opacity:0.55">— LLM 未填 top movers</span>'}</div>
         ${selfRows ? `<div class="self">${selfRows}</div>` : ""}
       </div>`;
     }).join("");
@@ -1049,7 +1055,7 @@
     const c2 = safe(DATA, 'catalysts') || {};
     if ((c2.summary?.earnings_count || 0) === 0 && (c2.summary?.fomc_in_window || 0) === 0) {
       const hint = document.createElement('div');
-      hint.style.cssText = 'margin-top:var(--space-2);font-size:10.5px;color:var(--text-dim);text-align:center;';
+      hint.style.cssText = 'margin-top:var(--space-2);font-size:var(--fs-micro);color:var(--text-dim);text-align:center;';
       hint.textContent = 'No earnings / FOMC in 14d window; only macro events surfaced';
       wrap.appendChild(hint);
     }
@@ -1170,7 +1176,7 @@
         const v = hn[tk] || {};
         emHtml += `<div style="margin:3px 0"><strong>${escapeHtml(tk)} ${escapeHtml(v.name || '')}</strong>`;
         (v.items || []).slice(0, 2).forEach(it => {
-          emHtml += `<div style="font-size:11px;opacity:.8">· [${escapeHtml(it.date || '')}] ${escapeHtml(it.title || '')}</div>`;
+          emHtml += `<div style="font-size:var(--fs-xs);opacity:.8">· [${escapeHtml(it.date || '')}] ${escapeHtml(it.title || '')}</div>`;
         });
         emHtml += '</div>';
       });
@@ -1248,13 +1254,13 @@
     if (m.fed_press?.length) {
       const fedDiv = document.createElement('div');
       fedDiv.className = 'fed-latest';
-      fedDiv.style.cssText = 'margin-top:8px;padding: var(--space-2) var(--space-3);background:var(--card-2);border-radius:var(--radius-sm);font-size:11.5px;border-left:3px solid var(--accent-2);';
+      fedDiv.style.cssText = 'margin-top:8px;padding: var(--space-2) var(--space-3);background:var(--card-2);border-radius:var(--radius-sm);font-size:var(--fs-xs);border-left:3px solid var(--accent-2);';
       const rows = m.fed_press.slice(0, 3).map(p =>
         `<div style="margin:3px 0;">
-          <span style="color:var(--text-dim);font-size:10px;margin-right:8px;">${p.date}</span>
+          <span style="color:var(--text-dim);font-size:var(--fs-micro);margin-right:8px;">${p.date}</span>
           <a href="${p.url}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none;">${(p.title || '').substring(0, 130)}</a>
         </div>`).join('');
-      fedDiv.innerHTML = `<div style="color:var(--text-dim);font-size:10px;margin-bottom:2px;">Fed press · past 7d</div>${rows}`;
+      fedDiv.innerHTML = `<div style="color:var(--text-dim);font-size:var(--fs-micro);margin-bottom:2px;">Fed press · past 7d</div>${rows}`;
       wrap.appendChild(fedDiv);
     }
 
@@ -1286,7 +1292,7 @@
       const newsLis = t.news.slice(0, 3).map(n =>
         `<li>${(n.title || '').replace(/</g, '&lt;')}</li>`).join('');
       const redditLis = t.reddit_posts.slice(0, 3).map(p =>
-        `<li>${(p.title || '').replace(/</g, '&lt;')} <span style="color:var(--text-dim);font-size:10px;">· ${p.score || 0}↑ ${p.num_comments || 0}💬</span></li>`).join('');
+        `<li>${(p.title || '').replace(/</g, '&lt;')} <span style="color:var(--text-dim);font-size:var(--fs-micro);">· ${p.score || 0}↑ ${p.num_comments || 0}💬</span></li>`).join('');
       return `<details class="sd-row">
         <summary>
           <span class="sd-tk">${t.ticker}</span>
@@ -1546,6 +1552,60 @@
       : `<div class="bd-empty">这只票今天没有额外证据：量化、硬闸、区间、同行都没有写入。</div>`;
   }
 
+
+  // 日收益热力：与主表同一批 ticker、同一排序的行网格（#881）。
+  // 原来是另一张卡里的色块 tile，读者要在两处对同一批标的；tile 里的白线和
+  // 表里的 sparkline 还是两种表达。这里合成一处：逐日格 + 累计 + 走势线。
+  function renderBookHeat(order) {
+    const el = document.getElementById("book-heat");
+    if (!el) return;
+    const hist = safe(DATA, "holdings_history") || {};
+    const cells = order.map(({ h }) => {
+      const series = (hist[h.ticker] || []).slice(-8)
+        .filter(v => typeof v === "number" && isFinite(v));
+      if (series.length < 2 || series[0] <= 0) return null;
+      const diffs = series.slice(1).map((v, i) => (v / series[i] - 1) * 100).filter(v => isFinite(v));
+      if (!diffs.length) return null;
+      return { ticker: h.ticker, region: h.region, diffs, series,
+               total: (series[series.length - 1] / series[0] - 1) * 100 };
+    }).filter(Boolean);
+
+    const meta = document.getElementById("book-heat-meta");
+    if (!cells.length) {
+      el.innerHTML = '<div class="empty-state">无历史序列</div>';
+      if (meta) meta.textContent = "";
+      return;
+    }
+    const n = Math.max(...cells.map(c => c.diffs.length));
+    // 满量程夹在 [2.5%, 9%]：低波动的日子不该被拉成满色，高波动的也不该全部撞顶
+    const full = Math.max(2.5, Math.min(9, Math.max(...cells.flatMap(c => c.diffs.map(Math.abs)))));
+    if (meta) meta.textContent = `收盘价序列 · 与上表同序 · 色深 = |当日涨跌| ÷ ${full.toFixed(1)}%`;
+
+    const head = `<div class="bh-row bh-head"><div class="bh-tk">标的</div>`
+      + Array.from({ length: n }, (_, i) =>
+          `<div class="bh-c">${i === n - 1 ? "最新" : "-" + (n - 1 - i)}</div>`).join("")
+      + `<div class="bh-v">8 日</div><div class="bh-s">走势</div></div>`;
+
+    const body = cells.map(c => {
+      const pad = n - c.diffs.length;
+      const blanks = Array.from({ length: pad }, () => `<div class="bh-c is-empty"></div>`).join("");
+      const heat = c.diffs.map(d => {
+        // gamma 提亮弱值：线性 alpha 会让 ±1% 的格子近乎全白，读起来像窟窿
+        const a = Math.pow(Math.min(Math.abs(d) / full, 1), 0.62) * 0.78 + 0.05;
+        const rgb = d >= 0 ? "var(--heat-up)" : "var(--heat-down)";
+        return `<div class="bh-c" style="background:color-mix(in srgb, ${rgb} ${(a * 100).toFixed(0)}%, transparent)"`
+          + ` title="${escapeHtml(c.ticker)} ${d >= 0 ? "+" : "−"}${Math.abs(d).toFixed(2)}%">${d.toFixed(1)}</div>`;
+      }).join("");
+      return `<div class="bh-row"><div class="bh-tk"><span class="ticker region-${c.region}">${escapeHtml(c.ticker)}</span></div>`
+        + blanks + heat
+        + `<div class="bh-v ${pnlClass(c.total)}">${fmtPct(c.total)}</div>`
+        + `<div class="bh-s">${sparklineSVG(c.series, 56, 16)}</div></div>`;
+    }).join("");
+
+    el.style.setProperty("--heat-cols", String(n));
+    el.innerHTML = head + body;
+  }
+
   function renderBook() {
     const tbody = document.getElementById("book-tbody");
     if (!tbody) return;
@@ -1600,7 +1660,7 @@
         <tr class="book-row" tabindex="0" role="button" aria-expanded="false" data-open="0" data-ticker="${escapeHtml(h.ticker || "")}">
           <td><span class="ticker region-${h.region}">${escapeHtml(h.ticker || DASH)}</span>${proxyMark}<span class="book-caret" aria-hidden="true">›</span></td>
           <td class="name-cell col-p2">${escapeHtml(h.name || "")}</td>
-          <td style="font-size:11px"><span class="matrix-status ${v.state}">${escapeHtml(v.label)}</span></td>
+          <td style="font-size:var(--fs-xs)"><span class="matrix-status ${v.state}">${escapeHtml(v.label)}</span></td>
           <td class="num col-p2">${shares(h.shares)}</td>
           <td class="num col-p2">${price(h.cost_basis, ccy)}</td>
           <td class="num">${price(h.current_price, ccy)}</td>
@@ -1617,6 +1677,8 @@
         </tr>
         <tr class="book-detail" data-open="0"><td colspan="10"><div class="bd-wrap"><div class="bd-inner">${bookDetail(h, e)}</div></div></td></tr>`;
     }).join("");
+
+    renderBookHeat(rows);
 
     const note = document.getElementById("book-note");
     if (note) {
@@ -1949,7 +2011,7 @@
         countEl.style.color = 'var(--warning)';
         if (dirEl) dirEl.textContent = '风控数据计算失败，本次不作“无触发”判断。';
         listEl.innerHTML = '<div class="risk-alert medium"><span class="icon">⚠️</span>'
-          + '<div><strong>风控卡不可用</strong><div class="muted" style="font-size:11px;margin-top:2px">'
+          + '<div><strong>风控卡不可用</strong><div class="muted" style="font-size:var(--fs-xs);margin-top:2px">'
           + '等待下次数据刷新重算</div></div></div>';
       });
       return;
@@ -1960,7 +2022,7 @@
     const row = (icon, sev, detail, action) =>
       `<div class="risk-alert ${sev || 'high'}">
          <span class="icon">${icon}</span>
-         <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:11px;margin-top:2px">→ ${action}</div>` : ''}</div>
+         <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:var(--fs-xs);margin-top:2px">→ ${action}</div>` : ''}</div>
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
@@ -1976,7 +2038,7 @@
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:12px">仓位/单因子/杠杆均在阈值内</div>';
+      listEl.innerHTML = html || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 
@@ -1994,10 +2056,10 @@
     document.getElementById('quant-tbody').innerHTML = names.map(k => {
       const r = rows[k];
       const state = r.status && r.status !== 'fresh'
-        ? `<div style="font-size:10px;color:var(--warning)">⚠ ${r.status} · ${r.row_as_of || r.last_good_as_of || '无日期'}${r.stale_reason ? ` · ${r.stale_reason}` : ''}</div>`
+        ? `<div style="font-size:var(--fs-micro);color:var(--warning)">⚠ ${r.status} · ${r.row_as_of || r.last_good_as_of || '无日期'}${r.stale_reason ? ` · ${r.stale_reason}` : ''}</div>`
         : '';
-      return `<tr><td><strong>${k}</strong>${r.note ? `<div class="muted" style="font-size:10px">${r.note}</div>` : ''}</td>` +
-        `<td style="text-align:left;font-size:11px">${r.tag || ''}${state}</td>` +
+      return `<tr><td><strong>${k}</strong>${r.note ? `<div class="muted" style="font-size:var(--fs-micro)">${r.note}</div>` : ''}</td>` +
+        `<td style="text-align:left;font-size:var(--fs-xs)">${r.tag || ''}${state}</td>` +
         `<td class="num">${num(r.rsi14)}</td>` +
         `<td class="num">${num(r.zscore20)}</td>` +
         `<td class="num" ${cls(r.dist_ma200_pct)}>${num(r.dist_ma200_pct, '%')}</td>` +
@@ -2033,12 +2095,12 @@
     names.sort((a, b) => (order[rows[a].grade] ?? 3) - (order[rows[b].grade] ?? 3));
     document.getElementById('t0-tbody').innerHTML = names.map(k => {
       const r = rows[k];
-      const lev = r.leveraged ? `<span class="muted" style="font-size:10px"> ${r.leveraged}</span>` : '';
+      const lev = r.leveraged ? `<span class="muted" style="font-size:var(--fs-micro)"> ${r.leveraged}</span>` : '';
       const vw = (r.vs_vwap_pct != null)
-        ? `<div class="muted" style="font-size:10px">VWAP ${r.vs_vwap_pct > 0 ? '+' : ''}${r.vs_vwap_pct}%</div>` : '';
+        ? `<div class="muted" style="font-size:var(--fs-micro)">VWAP ${r.vs_vwap_pct > 0 ? '+' : ''}${r.vs_vwap_pct}%</div>` : '';
       return `<tr><td><strong>${k}</strong>${lev}</td>` +
-        `<td style="text-align:left;font-size:11px">${r.grade} ${r.grade_label}` +
-        `<div class="muted" style="font-size:10px">${r.grade_reason || ''}</div>${vw}</td>` +
+        `<td style="text-align:left;font-size:var(--fs-xs)">${r.grade} ${r.grade_label}` +
+        `<div class="muted" style="font-size:var(--fs-micro)">${r.grade_reason || ''}</div>${vw}</td>` +
         `<td class="num">${num(r.range_pos, '%')}</td>` +
         `<td class="num" ${cls(r.today_change_pct)}>${num(r.today_change_pct, '%')}</td>` +
         `<td class="num" ${cls(r.gap_pct)}>${num(r.gap_pct, '%')}</td>` +
@@ -2094,9 +2156,9 @@
         ? ` · <span class="muted">新上市不足200日线,短均线替代</span>` : '';
       return `<div class="risk-alert ${sev}"><span class="icon"></span>
         <div><strong>${n.etf}=2x ${n.underlying} <span class="${cls}">${tag}</span></strong>
-        <div class="muted" style="font-size:11px;margin-top:2px">距${maLbl} ${n.dist_ma_pct ?? '—'}% · 20日波动 ${vol}${trig}${basisNote}</div></div></div>`;
+        <div class="muted" style="font-size:var(--fs-xs);margin-top:2px">距${maLbl} ${n.dist_ma_pct ?? '—'}% · 20日波动 ${vol}${trig}${basisNote}</div></div></div>`;
     }).join('');
-    usEl.innerHTML = rows || '<div class="muted" style="font-size:12px">无持仓 2x 单股 ETF</div>';
+    usEl.innerHTML = rows || '<div class="muted" style="font-size:var(--fs-sm)">无持仓 2x 单股 ETF</div>';
     document.getElementById('lev-regime-asof').textContent =
       `HSTECH ${r.as_of || ''} · 200日线 ${hk.ma ?? '?'} · HK波动 ${hk.vol_annualized != null ? (hk.vol_annualized*100).toFixed(0)+'%' : '?'} · US砍线 ${us.vol_hot_cap != null ? (us.vol_hot_cap*100).toFixed(0)+'%' : '?'}`;
   }
@@ -2115,9 +2177,9 @@
     if (p.hk_cash_hkd != null) bits.push(`HK $${num(p.hk_cash_hkd, 0)}`);
     document.getElementById('reentry-powder').innerHTML =
       `<div style="padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--accent) 8%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,transparent)">
-         <span class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">待布局弹药</span>
-         <div style="font-size:15px;font-weight:800;margin-top:2px">${bits.join('  ·  ') || DASH}</div>
-         <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;margin-top:2px">${r.triggered_count}/${r.total} 已触发 · 触发=收盘站回均线,右侧再布局</div>
+         <span class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">待布局弹药</span>
+         <div style="font-size:var(--fs-lg);font-weight:700;margin-top:2px">${bits.join('  ·  ') || DASH}</div>
+         <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;margin-top:2px">${r.triggered_count}/${r.total} 已触发 · 触发=收盘站回均线,右侧再布局</div>
        </div>`;
     // 每个受监控标的一行
     const rows = r.watches.map(w => {
@@ -2131,23 +2193,23 @@
         : `<span style="color:${color}">还需 +${need != null ? need.toFixed(1) : '?'}% 站回${mw}</span>`;
       const prox = dist == null ? 0 : Math.max(0, Math.min(100, (1 + dist / 20) * 100));
       const mkt = w.market === 'HK' ? '🇭🇰' : '🇺🇸';
-      const nameLine = w.etf ? `${w.name} <span class="muted" style="font-size:10px">(${w.etf} 2x)</span>` : w.name;
+      const nameLine = w.etf ? `${w.name} <span class="muted" style="font-size:var(--fs-micro)">(${w.etf} 2x)</span>` : w.name;
       return `
         <div style="padding:8px 0;border-top:1px solid var(--border,#2a2a2a)">
           <div style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
-            <span style="font-weight:700;font-size:13px">${mkt} ${nameLine}</span>
-            <span style="font-size:12px">${badge}</span>
+            <span style="font-weight:700;font-size:var(--fs-md)">${mkt} ${nameLine}</span>
+            <span style="font-size:var(--fs-sm)">${badge}</span>
           </div>
           <div style="display:flex;align-items:center;gap:8px;margin-top:4px">
             <div style="flex:1;height:5px;border-radius:3px;background:var(--border,#2a2a2a);position:relative;overflow:hidden">
               <div style="position:absolute;left:0;top:0;bottom:0;width:${prox.toFixed(0)}%;background:${color};opacity:0.55"></div>
             </div>
-            <span style="font-size:11px;color:${color};min-width:52px;text-align:right">${dist != null ? (dist > 0 ? '+' : '') + dist.toFixed(1) + '%' : DASH}</span>
+            <span style="font-size:var(--fs-xs);color:${color};min-width:52px;text-align:right">${dist != null ? (dist > 0 ? '+' : '') + dist.toFixed(1) + '%' : DASH}</span>
           </div>
-          <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;margin-top:2px">
+          <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;margin-top:2px">
             现价 ${num(w.close, 2)} · ${mw} ${num(w.ma, 2)}${w.state ? ' · ' + w.state : ''}
           </div>
-          ${w.note ? `<div class="muted" style="font-size:9px;text-transform:none;letter-spacing:0;margin-top:2px;opacity:0.75">${w.note}</div>` : ''}
+          ${w.note ? `<div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;margin-top:2px;opacity:0.75">${w.note}</div>` : ''}
         </div>`;
     }).join('');
     document.getElementById('reentry-list').innerHTML = rows;
@@ -2173,18 +2235,18 @@
     // hero: 现值 + 盈亏
     document.getElementById('gold-hero').innerHTML =
       `<div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin:2px 0 12px">
-         <span style="font-size:26px;font-weight:800">¥${num(g.current_value)}</span>
-         <span style="font-size:17px;font-weight:700;color:${pnlColor}">${sign}${num(g.pnl_percent, 2)}%</span>
-         <span style="font-size:13px;color:${pnlColor}">${(g.pnl_abs >= 0 ? '+' : '')}¥${num(g.pnl_abs)}</span>
+         <span style="font-size:var(--fs-xxl);font-weight:700">¥${num(g.current_value)}</span>
+         <span style="font-size:var(--fs-lg);font-weight:700;color:${pnlColor}">${sign}${num(g.pnl_percent, 2)}%</span>
+         <span style="font-size:var(--fs-md);color:${pnlColor}">${(g.pnl_abs >= 0 ? '+' : '')}¥${num(g.pnl_abs)}</span>
        </div>`;
 
     // stats grid
     const navChg = g.nav_change_pct;
     const navChgStr = navChg == null ? '' :
-      ` <span style="color:${navChg >= 0 ? 'var(--positive)' : 'var(--negative)'};font-size:11px">${navChg >= 0 ? '+' : ''}${navChg.toFixed(2)}%</span>`;
+      ` <span style="color:${navChg >= 0 ? 'var(--positive)' : 'var(--negative)'};font-size:var(--fs-xs)">${navChg >= 0 ? '+' : ''}${navChg.toFixed(2)}%</span>`;
     const cell = (label, val) => `<div style="flex:1 1 30%;min-width:90px;margin:5px 0">
-        <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">${label}</div>
-        <div style="font-size:15px;font-weight:700;margin-top:1px">${val}</div></div>`;
+        <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">${label}</div>
+        <div style="font-size:var(--fs-lg);font-weight:700;margin-top:1px">${val}</div></div>`;
     document.getElementById('gold-stats').innerHTML =
       `<div style="display:flex;flex-wrap:wrap;gap:2px 8px;padding:8px 0;border-top:1px solid var(--border,#2a2a2a)">
         ${cell('累计投入', '¥' + num(g.principal_effective != null ? g.principal_effective : g.principal_invested))}
@@ -2201,7 +2263,7 @@
     if (goldDomestic) {
       if (!dg || dg.price_cny_g == null) {
         goldDomestic.innerHTML =
-          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:11px">
+          `<div role="status" style="margin:12px 0 4px;padding:10px 12px;border-radius:6px;border:1px solid color-mix(in srgb,var(--warning) 25%,transparent);color:var(--warning);font-size:var(--fs-xs)">
              上金所 Au99.99 暂无有效行情
            </div>`;
       } else {
@@ -2210,18 +2272,18 @@
         const retained = dg.quote_status === 'retained';
         goldDomestic.innerHTML =
           `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
+             <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
-               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:21px;font-weight:800;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:10px">我的回本价</div><div style="font-size:21px;font-weight:800;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:11px;color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
              </div>
-             <div class="muted" style="font-size:11px;margin-top:7px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-xs);margin-top:7px;text-transform:none;letter-spacing:0">
                距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
                ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
                ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
              </div>
-             <div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-micro);margin-top:4px;text-transform:none;letter-spacing:0">
                ${dg.date || ''} 收盘 · 上金所${retained ? ' · ⚠️ 本次抓取失败，沿用上次有效值' : ''}
              </div>
            </div>`;
@@ -2237,7 +2299,7 @@
       else {
         const xchg = ld.xau_change_pct;
         const xcolor = (xchg == null ? 'var(--neutral)' : (xchg >= 0 ? 'var(--positive)' : 'var(--negative)'));
-        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:11px">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
+        const xchgStr = xchg == null ? '' : ` · 当日 <span style="color:${xcolor};font-size:var(--fs-xs)">${xchg >= 0 ? '+' : ''}${Number(xchg).toFixed(2)}%</span>`;
         const fundBeXau = ld.fund_breakeven_usd_oz != null
           ? ld.fund_breakeven_usd_oz
           : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
@@ -2246,13 +2308,13 @@
         // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
-             <div class="muted" style="font-size:10px;text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
+             <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国际辅助 · 伦敦金 XAU/USD</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
-               <div><div class="muted" style="font-size:10px">当前金价</div><div style="font-size:19px;font-weight:800;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:10px">按当前汇率回本</div><div style="font-size:19px;font-weight:800;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:11px;color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
              </div>
-             <div class="muted" style="font-size:11px;margin-top:5px;text-transform:none;letter-spacing:0">
+             <div class="muted" style="font-size:var(--fs-xs);margin-top:5px;text-transform:none;letter-spacing:0">
                距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
                · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
@@ -2264,11 +2326,11 @@
           unavailable: '历史抓取失败',
           not_attempted: '历史未抓取',
         };
-        html += `<div class="muted" style="font-size:10px;margin-top:4px;text-transform:none;letter-spacing:0">
+        html += `<div class="muted" style="font-size:var(--fs-micro);margin-top:4px;text-transform:none;letter-spacing:0">
           历史源 ${escapeHtml(histNames[histSource.name] || histSource.name || '未知')} · ${num(histSource.points || 0)} 点
         </div>`;
         if (ld.hist_advisory) {
-          html += `<div role="status" style="font-size:10px;color:var(--warning);margin-top:4px;text-transform:none;letter-spacing:0">
+          html += `<div role="status" style="font-size:var(--fs-micro);color:var(--warning);margin-top:4px;text-transform:none;letter-spacing:0">
             ℹ️ ${escapeHtml(ld.hist_advisory)}
           </div>`;
         }
@@ -2279,13 +2341,13 @@
           const dColor = de.pnl_pct >= 0 ? 'var(--positive)' : 'var(--negative)';
           html +=
             `<details style="margin-top:8px;padding-top:8px;border-top:1px dashed color-mix(in srgb,var(--warning) 28%,transparent)">
-               <summary class="muted" style="font-size:10px;text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
+               <summary class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0;cursor:pointer">模拟对照 · 若每个基金交易日直接买伦敦金</summary>
                <div style="margin-top:6px">
                <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;margin-top:2px">
-                 <span style="font-size:17px;font-weight:800">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:11px;font-weight:600;color:var(--muted,#999)">/oz</span></span>
-                 <span style="font-size:12px;font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
+                 <span style="font-size:var(--fs-lg);font-weight:700">$${num(de.avg_cost_usd_oz, 2)}<span style="font-size:var(--fs-xs);font-weight:600;color:var(--muted,#999)">/oz</span></span>
+                 <span style="font-size:var(--fs-sm);font-weight:700;color:var(--muted,#999)">¥${num(de.avg_cost_cny_g, 2)}/克</span>
                </div>
-               <div class="muted" style="font-size:11px;margin-top:3px;text-transform:none;letter-spacing:0">
+               <div class="muted" style="font-size:var(--fs-xs);margin-top:3px;text-transform:none;letter-spacing:0">
                  现货 <b style="color:var(--text,#eee)">$${num(de.spot_usd_oz, 2)}</b>/oz · 回本需涨 <b style="color:${beColor}">${de.breakeven_upside_pct >= 0 ? '+' : ''}${num(de.breakeven_upside_pct, 2)}%</b>
                  ${de.current_value_cny != null ? `· 对应现值 <b style="color:${dColor}">¥${num(de.current_value_cny)}</b> (${de.pnl_pct >= 0 ? '+' : ''}${num(de.pnl_pct, 2)}%)` : ''}
                </div>
@@ -2299,9 +2361,9 @@
                 <td style="padding:4px 8px;text-align:right">$${num(p.avg_cost_usd_oz, 0)}</td>
                 <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
             html +=
-              `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
-               <table style="width:100%;font-size:12px;border-collapse:collapse">
-                 <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
+               <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
+                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
                ${lrows}</table>`;
           }
           html += `</div></details>`;
@@ -2324,7 +2386,7 @@
                <polyline points="${lineL}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
                <polyline points="${lineF}" fill="none" stroke="${fColor}" stroke-width="1.6" stroke-dasharray="4 2"/>
              </svg>
-             <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0;margin-top:1px">
+             <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0;margin-top:1px">
                <span style="color:var(--warning)">伦敦金 ${lLast >= 100 ? '+' : ''}${num(lLast - 100, 1)}%</span>
                <span style="color:${fColor}">你的基金 ${fLast >= 100 ? '+' : ''}${num(fLast - 100, 1)}%</span>
                <span>起投=100 · 差因:汇率+费率</span>
@@ -2358,7 +2420,7 @@
           <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
-        <div class="muted" style="font-size:10px;display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
+        <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
           <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
           <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
@@ -2374,9 +2436,9 @@
           <td style="padding:4px 8px;text-align:right">${num(p.avg_cost, 3)}</td>
           <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
       document.getElementById('gold-proj').innerHTML =
-        `<div class="muted" style="font-size:10px;margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
-         <table style="width:100%;font-size:12px;border-collapse:collapse">
-           <tr class="muted" style="font-size:10px"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
+         <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
+           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
            ${rows}</table>`;
     } else { document.getElementById('gold-proj').innerHTML = ''; }
 
@@ -2927,7 +2989,7 @@
       .join("");
 
     container.innerHTML = rows ||
-      `<div style="text-align:center; color:var(--text-faint); font-size:12px; padding:20px 0;">
+      `<div style="text-align:center; color:var(--text-faint); font-size:var(--fs-sm); padding:20px 0;">
          No settled decision episodes yet.
        </div>`;
   }
@@ -3229,7 +3291,7 @@
       .map(([k, v]) => ({ name: k, ...v }))
       .filter(e => (e.n_episodes || 0) > 0);
     if (!entries.length) {
-      el.innerHTML = '<div class="empty-state" style="font-size:11px">No trigger data yet.</div>';
+      el.innerHTML = '<div class="empty-state" style="font-size:var(--fs-xs)">No trigger data yet.</div>';
       return;
     }
     // Sort: lowest win rate first (most actionable: "改/砍这类")
@@ -3275,7 +3337,7 @@
       .map(([k, v]) => ({ name: k, ...v }))
       .filter(e => (e.n_episodes || 0) > 0);
     if (!entries.length) {
-      el.innerHTML = '<div class="empty-state" style="font-size:11px">No driver data yet — '
+      el.innerHTML = '<div class="empty-state" style="font-size:var(--fs-xs)">No driver data yet — '
         + 'plan actions need a driven_by tag (backfilling from next brief).</div>';
       return;
     }
@@ -3317,7 +3379,7 @@
     if (dm && dm.decisiveness_pct != null)
       bits.push(`辩论决断率 ${dm.decisiveness_pct}%`);
     if (bits.length) el.insertAdjacentHTML("afterbegin",
-      `<div style="font-size:11px;opacity:.75;margin-bottom:var(--space-2)">${bits.join(" · ")}</div>`);
+      `<div style="font-size:var(--fs-xs);opacity:.75;margin-bottom:var(--space-2)">${bits.join(" · ")}</div>`);
   }
 
   // =========================================================
@@ -3333,7 +3395,7 @@
     const html = rows.map(r => {
       let extra = '';
       if (r.leveraged && r.underlying_vol_pct != null) {
-        extra = `<div class="muted" style="font-size:11px;margin-top:2px">标的σ ${r.underlying_vol_pct}% · 横盘 decay ≈${r.chop_drag_pct_per_month}%/月 · ` +
+        extra = `<div class="muted" style="font-size:var(--fs-xs);margin-top:2px">标的σ ${r.underlying_vol_pct}% · 横盘 decay ≈${r.chop_drag_pct_per_month}%/月 · ` +
                 `半年直线路径标的需 +${r.underlying_need_2x_6m_pct}%` +
                 (r.swap_1x ? ` · 换 1x(${r.swap_1x}) 后需 +${r.underlying_need_if_1x_pct}%` : '') + `</div>`;
       }
@@ -3470,83 +3532,6 @@
   // =========================================================
   // 8d Return Heatmap (Drill)
   // =========================================================
-  function render8dHeatmap() {
-    const el = document.getElementById("ret-heatmap");
-    if (!el) return;
-    const hh = safe(DATA, "holdings_history") || {};
-    const wc = safe(DATA, "weight_confidence") || [];
-    const weightMap = {};
-    wc.forEach(w => { weightMap[w.ticker] = w.weight_pct; });
-
-    // Active tickers from holdings, then compute 8d return from history
-    const active = [
-      ...(safe(DATA, "holdings", "us") || []),
-      ...(safe(DATA, "holdings", "hk") || []),
-    ].filter(h => h.is_active !== false && (h.shares ?? 0) > 0);
-
-    const rows = active.map(h => {
-      // holdings_history pads missing days with null (e.g. a freshly-bought name
-      // has null before entry) — filter to finite numbers so a null base doesn't
-      // divide to Infinity (null===0 is false, then x/null → x/0 → Infinity).
-      const series = (hh[h.ticker] || []).slice(-8)
-        .filter(v => typeof v === "number" && isFinite(v));
-      if (series.length < 2 || series[0] <= 0) return null;
-      const ret = (series[series.length - 1] - series[0]) / series[0] * 100;
-      if (!isFinite(ret)) return null;
-      return {
-        ticker: h.ticker,
-        region: (h.currency === "HKD" ? "HK" : "US"),
-        ret,
-        weight: weightMap[h.ticker] ?? null,
-        n: series.length,
-        series,
-      };
-    }).filter(Boolean);
-
-    if (!rows.length) {
-      el.innerHTML = '<div class="empty-state">No price history.</div>';
-      return;
-    }
-
-    rows.sort((a, b) => b.ret - a.ret);
-
-    // Color: lerp red(<-5%)↔neutral(0%)↔green(>+5%); saturation maxes at ±10%
-    const colorFor = (ret) => {
-      const clamp = Math.max(-10, Math.min(10, ret));
-      const t = (clamp + 10) / 20; // 0..1
-      // red rgb(239,68,68) -> grey rgb(60,68,90) -> green rgb(52,211,153)
-      let r, g, b;
-      if (t < 0.5) {
-        const k = t / 0.5;
-        r = Math.round(239 + (60 - 239) * k);
-        g = Math.round(68 + (68 - 68) * k);
-        b = Math.round(68 + (90 - 68) * k);
-      } else {
-        const k = (t - 0.5) / 0.5;
-        r = Math.round(60 + (52 - 60) * k);
-        g = Math.round(68 + (211 - 68) * k);
-        b = Math.round(90 + (153 - 90) * k);
-      }
-      // softer fill (alpha) + opaque text
-      return { fill: `rgba(${r},${g},${b},0.85)`, text: "#fff" };
-    };
-
-    el.innerHTML = rows.map(r => {
-      const { fill, text } = colorFor(r.ret);
-      const sign = r.ret >= 0 ? "+" : "";
-      const meta = r.weight != null
-        ? `${r.weight.toFixed(1)}% ${r.region} leg内`
-        : `${r.region}`;
-      return `
-        <div class="ret-cell" style="background:${fill}; color:${text}; border-color:transparent">
-          <div class="rc-ticker" style="color:${text}">${escapeHtml(r.ticker)}</div>
-          <div class="rc-spark">${sparklineSVG(r.series, 84, 22)}</div>
-          <div class="rc-ret" style="color:${text}">${sign}${r.ret.toFixed(2)}%</div>
-          <div class="rc-meta" style="color:rgba(255,255,255,0.75)">${meta}</div>
-        </div>`;
-    }).join("");
-  }
-
   window.registerDetailRenderers({
     drill: TAB_RENDERERS.drill,
     risk: TAB_RENDERERS.risk,

--- a/site/index.html
+++ b/site/index.html
@@ -80,7 +80,7 @@ layout: null
 <link rel="stylesheet" href="assets/css/dashboard.css">
 </head>
 <body>
-<noscript><div style="padding: var(--space-4);max-width:680px;margin:0 auto;color:var(--text-secondary);font-size:13px;line-height:1.6">
+<noscript><div style="padding: var(--space-4);max-width:680px;margin:0 auto;color:var(--text-secondary);font-size:var(--fs-md);line-height:1.6">
   <p><strong>clawock</strong> installs portable investment decision workflows into external AI agents. OpenClaw, Claude Code, Codex, or another runtime keeps its model, conversation, memory, and tools; clawock supplies evidence and opposition contracts, deterministic financial reconciliation, outcome evaluation, and reviewable improvement.</p>
   <p>clawock 把可迁移的投资决策 workflow 装进外部 Agent：runtime 保留模型、对话、记忆和工具，clawock 负责证据与反方契约、确定性资金对账、结果评估和可审改进。这一页展示真实港股 + 美股实例。</p>
   <p>This dashboard renders with JavaScript · raw data: <a href="assets/data/dashboard.json" style="color:var(--accent)">dashboard.json</a> · source: <a href="https://github.com/KCNyu/clawock" style="color:var(--accent)">github.com/KCNyu/clawock</a></p>
@@ -171,7 +171,7 @@ layout: null
             <div class="overview-card-kicker">战绩 · 视觉锚点</div>
             <h3 id="equity-title">Equity Curve · USD-eq</h3>
           </div>
-          <span id="benchmark-stale" class="muted" style="display:none;font-size:11px;color:var(--amber)"></span>
+          <span id="benchmark-stale" class="muted" style="display:none;font-size:var(--fs-xs);color:var(--amber)"></span>
           <div class="mkt-seg" role="group" aria-label="市场切换">
             <button class="mkt-seg-btn active" data-mkt="combined"><span class="seg-dot"></span>总览</button>
             <button class="mkt-seg-btn" data-mkt="us"><span class="seg-dot us"></span>美股</button>
@@ -179,7 +179,7 @@ layout: null
           </div>
         </div>
         <details class="chart-note overview-equity-hint">
-          <summary>口径说明</summary>
+          <summary>口径说明与图例</summary>
           <p>粗绿线 = 总利润（浮盈 + 已实现，净化本金）；蓝线 = 真实总资产（持仓市值 + 现金）；虚线 = 成本及动态基准。切换总览 / 美股 / 港股查看各自口径。</p>
         </details>
         <div id="chart-equity" class="chart-box overview-equity-chart"></div>
@@ -250,14 +250,14 @@ layout: null
       </section>
 
       <div class="card hero-gold-card is-pending" id="gold-dca-card">
-        <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px"></span></h3>
+        <h3>Gold DCA <span class="muted" id="gold-sub" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)"></span></h3>
         <div id="gold-hero"></div>
         <div id="gold-stats"></div>
         <div id="gold-domestic"></div>
         <div id="gold-london"></div>
         <div id="gold-spark"></div>
         <div id="gold-proj"></div>
-        <div class="muted asof-faded" id="gold-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
+        <div class="muted asof-faded" id="gold-asof" style="font-size:var(--fs-micro);margin-top:var(--space-2)"></div>
       </div>
     </div>
 
@@ -277,7 +277,7 @@ layout: null
           <div class="overview-card-kicker">持仓明细</div>
           <h3>持仓 <span class="muted" id="book-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
         </div>
-        <span class="muted" id="book-meta" style="font-size:11px"></span>
+        <span class="muted" id="book-meta" style="font-size:var(--fs-xs)"></span>
       </div>
       <div class="table-wrap">
         <table class="holdings-table book-table" id="book-table">
@@ -299,6 +299,10 @@ layout: null
         </table>
       </div>
       <p class="chart-hint" id="book-note"></p>
+      <div class="sub-block" id="book-heat-block">
+        <div class="sub-block-head">日收益热力 <span class="muted" id="book-heat-meta"></span></div>
+        <div class="table-wrap"><div class="book-heat" id="book-heat"></div></div>
+      </div>
     </div>
 
     <div class="card desktop-wide" id="add-campaign-card">
@@ -316,16 +320,8 @@ layout: null
     <div class="card desktop-wide" id="book-structure-card">
       <div class="card-head"><div>
         <div class="overview-card-kicker">组合结构</div>
-        <h3>强弱与集中</h3>
+        <h3>仓位 × 信心</h3>
       </div></div>
-      <div class="sub-block">
-        <div class="sub-block-head">8 日走势热力 <span class="muted">背景色 = 8 日回报，白线 = 价格路径，小字 = 各自市场 leg 内权重</span></div>
-      <p class="chart-hint">每格一只持仓：<b>背景色</b> = 8 日回报（绿 = 在跑、红 = 在拖），<b>白色折线</b> = 这 8 日的价格走势形状，下方小字 = 各自市场 leg 内权重（不是组合权重）。颜色看强弱、折线看路径，重仓 + 大红块 = 优先审视。</p>
-      <div class="ret-heatmap" id="ret-heatmap">
-        <div class="empty-state">No price history.</div>
-      </div>
-    
-      </div>
       <div class="sub-block">
         <div class="sub-block-head">仓位 × 信心 <span class="muted">横轴与点大小 = 各自 US/HK leg 内权重，不是全组合 USD-eq 权重</span></div>
       
@@ -433,7 +429,7 @@ layout: null
 
     <div class="card lead" id="guardrail-card">
       <h3>仓位/杠杆硬闸 <span class="badge muted" id="guardrail-count"></span></h3>
-      <div class="muted" id="guardrail-directive" style="font-size:12px;margin-bottom:8px;line-height:1.5"></div>
+      <div class="muted" id="guardrail-directive" style="font-size:var(--fs-sm);margin-bottom:8px;line-height:1.5"></div>
       <div class="risk-alerts" id="guardrail-list"></div>
     </div>
 
@@ -525,16 +521,16 @@ layout: null
       <div class="sub-block" id="lev-regime-card" style="display:none">
         <div class="sub-block-head">杠杆刻度盘 <span class="muted">趋势 + 波动 → 杠杆 ETF 上限</span><span class="peek" id="peek-levregime"></span></div>
       
-      <div class="muted" style="font-size:10px;margin-bottom:3px;opacity:0.8">HK · HSTECH 指数级</div>
+      <div class="muted" style="font-size:var(--fs-micro);margin-bottom:3px;opacity:0.8">HK · HSTECH 指数级</div>
       <div class="regime-badge" id="lev-regime-badge" style="margin-bottom:var(--space-2)">
         <span class="rg-dot"></span><span class="rg-label" id="lev-regime-label"></span>
         <span class="rg-reasons" id="lev-regime-cap"></span>
       </div>
-      <div class="muted" id="lev-regime-rationale" style="font-size:12px;line-height:1.5"></div>
-      <div id="lev-regime-trigger" style="font-size:11px;margin-top:5px;line-height:1.5"></div>
-      <div class="muted" style="font-size:10px;margin:8px 0 3px;opacity:0.8">US · 2x 单股 per-name（趋势off且波动过热才砍）</div>
+      <div class="muted" id="lev-regime-rationale" style="font-size:var(--fs-sm);line-height:1.5"></div>
+      <div id="lev-regime-trigger" style="font-size:var(--fs-xs);margin-top:5px;line-height:1.5"></div>
+      <div class="muted" style="font-size:var(--fs-micro);margin:8px 0 3px;opacity:0.8">US · 2x 单股 per-name（趋势off且波动过热才砍）</div>
       <div class="risk-alerts" id="lev-regime-us"></div>
-      <div class="muted asof-faded" id="lev-regime-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
+      <div class="muted asof-faded" id="lev-regime-asof" style="font-size:var(--fs-micro);margin-top:var(--space-2)"></div>
     
       </div>
       <div class="sub-block" id="reentry-card" style="display:none">
@@ -542,7 +538,7 @@ layout: null
       
       <div id="reentry-powder" style="margin-bottom:8px"></div>
       <div id="reentry-list"></div>
-      <div class="muted asof-faded" id="reentry-asof" style="font-size:10px;margin-top:var(--space-2)"></div>
+      <div class="muted asof-faded" id="reentry-asof" style="font-size:var(--fs-micro);margin-top:var(--space-2)"></div>
     
       </div>
     </div>
@@ -556,7 +552,7 @@ layout: null
         <div class="sub-block-head">解套数学 <span class="muted">回本所需涨幅 · 纯算术</span><span class="peek" id="peek-breakeven"></span></div>
       
       <div class="risk-alerts" id="breakeven-list"></div>
-      <div class="muted" id="breakeven-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
+      <div class="muted" id="breakeven-note" style="font-size:var(--fs-xs);margin-top:var(--space-2);line-height:1.5"></div>
     
       </div>
       <div class="sub-block">
@@ -585,24 +581,24 @@ layout: null
         <div class="sub-block-head">量化因子 <span class="muted">趋势 · 动量 · RSI · 吊灯止损 · vol 仓位</span><span id="quant-asof"></span><span class="peek" id="peek-quant"></span></div>
       
       <div class="table-wrap">
-        <table class="holdings-table" id="quant-table" style="min-width:560px;font-size:12px">
+        <table class="holdings-table" id="quant-table" style="min-width:560px;font-size:var(--fs-sm)">
           <thead><tr><th>标的</th><th>信号</th><th class="num">RSI</th><th class="num">z20</th><th class="num">距200线</th><th class="num">吊灯距</th><th class="num">vol权重</th></tr></thead>
           <tbody id="quant-tbody"></tbody>
         </table>
       </div>
-      <div class="muted" id="quant-edge" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
+      <div class="muted" id="quant-edge" style="font-size:var(--fs-xs);margin-top:var(--space-2);line-height:1.5"></div>
     
       </div>
       <div class="sub-block" id="t0-card" style="display:none">
         <div class="sub-block-head">T+0 牌面 <span class="muted">做 T 前先看牌面 · 非买卖信号</span><span id="t0-asof"></span><span class="peek" id="peek-t0"></span></div>
       
       <div class="table-wrap">
-        <table class="holdings-table" id="t0-table" style="min-width:520px;font-size:12px">
+        <table class="holdings-table" id="t0-table" style="min-width:520px;font-size:var(--fs-sm)">
           <thead><tr><th>标的</th><th>牌面</th><th class="num">区间位</th><th class="num">今日%</th><th class="num">跳空%</th><th class="num">振幅/ATR</th></tr></thead>
           <tbody id="t0-tbody"></tbody>
         </table>
       </div>
-      <div class="muted" id="t0-note" style="font-size:11px;margin-top:var(--space-2);line-height:1.5"></div>
+      <div class="muted" id="t0-note" style="font-size:var(--fs-xs);margin-top:var(--space-2);line-height:1.5"></div>
     
       </div>
     </div>
@@ -639,7 +635,7 @@ layout: null
         <h3>消息与背离</h3>
       </div></div>
       <div class="sub-block">
-        <div class="sub-block-head">影响力雷达 <span class="muted">Trump · Musk · Serenity</span><span class="muted" id="infl-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Trump · Musk · Serenity · LLM筛</span></div>
+        <div class="sub-block-head">影响力雷达 <span class="muted">Trump · Musk · Serenity</span><span class="muted" id="infl-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">Trump · Musk · Serenity · LLM筛</span></div>
       
       <div class="infl-summary" id="infl-summary"></div>
       <div class="infl-feed" id="infl-feed">
@@ -656,7 +652,7 @@ layout: null
     
       </div>
       <div class="sub-block">
-        <div class="sub-block-head">板块全景<span class="muted" id="sector-context-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">—</span></div>
+        <div class="sub-block-head">板块全景<span class="muted" id="sector-context-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">—</span></div>
       
       <p class="chart-hint" id="sector-narrative" style="display:none"></p>
       <div class="sector-context" id="sector-context">
@@ -665,7 +661,7 @@ layout: null
     
       </div>
       <div class="sub-block">
-        <div class="sub-block-head">同行背离<span class="muted" id="peer-div-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Peer Divergence</span></div>
+        <div class="sub-block-head">同行背离<span class="muted" id="peer-div-asof" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">Peer Divergence</span></div>
       
       <div class="peer-div-list" id="peer-div-list">
         <div class="empty-state">No peer divergence flagged.</div>
@@ -679,7 +675,7 @@ layout: null
     <h2>Plan</h2>
 
     <div class="card" id="watch-levels-card" style="display:none">
-      <h3>今日触发位 <span class="muted" id="watch-levels-date" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">Watch Levels</span></h3>
+      <h3>今日触发位 <span class="muted" id="watch-levels-date" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">Watch Levels</span></h3>
       <p class="chart-hint">盘前计划写死的触发价位 vs 现价。距离越近越该盯，&lt;2% 标红。</p>
       <div class="watch-levels" id="watch-levels-list"></div>
     </div>
@@ -692,7 +688,7 @@ layout: null
     </div>
 
     <div class="card lead">
-      <h3>Plan Timeline <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">(last 15 actions · 包含 rationale)</span></h3>
+      <h3>Plan Timeline <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">(last 15 actions · 包含 rationale)</span></h3>
       <p class="chart-hint">每条卡片 = 一个策略决策；同一股票同一天可有多个策略。只有条件触发的 episode 才结算，是否执行单独统计。</p>
       <div class="plan-timeline" id="plan-timeline">
         <div class="empty-state">No timeline data yet.</div>
@@ -726,7 +722,7 @@ layout: null
       </div></div>
       <div class="sub-block" id="honesty-card">
         <div class="sub-block-head">诚实自评 <span class="muted">30 日 · episode 级</span></div>
-        <div id="honesty-body" style="font-size:12px"></div>
+        <div id="honesty-body" style="font-size:var(--fs-sm)"></div>
       
       </div>
       <div class="sub-block" id="behavioral-review-card" style="display:none">
@@ -789,18 +785,18 @@ layout: null
           <div class="sub" id="plan-brier-sub">—</div>
         </div>
       </div>
-      <div class="trig-title" style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-dim);margin:4px 0 12px;font-weight:600">By Bucket — 各类动作 30d 胜率（与建议徽章同源）</div>
+      <div class="trig-title" style="font-size:var(--fs-xs);text-transform:uppercase;letter-spacing:0.06em;color:var(--text-dim);margin:4px 0 12px;font-weight:600">By Bucket — 各类动作 30d 胜率（与建议徽章同源）</div>
       <div id="plan-bucket-bars"></div>
       <div class="trig-block">
         <div class="trig-title">By Trigger Type — 哪类计划最该信 / 最该改</div>
         <div id="plan-trigger-bars">
-          <div class="empty-state" style="font-size:11px">No trigger data yet.</div>
+          <div class="empty-state" style="font-size:var(--fs-xs)">No trigger data yet.</div>
         </div>
       </div>
       <div class="trig-block">
         <div class="trig-title">By Driver — 哪个数据源有 edge / 最该降权</div>
         <div id="plan-driver-bars">
-          <div class="empty-state" style="font-size:11px">No driver data yet.</div>
+          <div class="empty-state" style="font-size:var(--fs-xs)">No driver data yet.</div>
         </div>
       </div>
     
@@ -811,7 +807,7 @@ layout: null
       <div class="retired-note">
         <p>现有记录目前<b>算不出可靠的累计金额</b>：真实成交、可核验行情和统一对照口径仍有缺口，所以不展示金额。下面只显示<b>方向判断的命中情况，不代表实际收益</b>。</p>
       </div>
-      <div class="trig-title" style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-dim);margin:16px 0 4px;font-weight:600">AI cumulative episode win rate — v1 migrated + v2</div>
+      <div class="trig-title" style="font-size:var(--fs-xs);text-transform:uppercase;letter-spacing:0.06em;color:var(--text-dim);margin:16px 0 4px;font-weight:600">AI cumulative episode win rate — v1 migrated + v2</div>
       <div id="chart-ai-winrate" class="chart-box" style="height:210px;min-height:210px"></div>
     
       </div>
@@ -820,7 +816,7 @@ layout: null
     <div class="sect-divider">决策轨迹 · 真实成交 vs 当时计划</div>
 
     <div class="card" id="decision-traces-card">
-      <h3>决策轨迹 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:11px">一笔真实成交 + 那几天写下的计划 + 官方收盘给的结果</span></h3>
+      <h3>决策轨迹 <span class="muted" style="text-transform:none;letter-spacing:0;font-weight:500;font-size:var(--fs-xs)">一笔真实成交 + 那几天写下的计划 + 官方收盘给的结果</span></h3>
       <p class="chart-hint">点开一笔成交看四件事：<b>当时的计划</b>（同标的前后 3 天内的账本记录，没有就写明没有）、<b>真实成交</b>（并标出它与计划同向还是反向）、<b>T+1 收盘</b>（官方逐日行情，间隔超过 4 天的下一根不算 T+1）、<b>钱</b>（已平仓看本笔已实现金额，未平仓只有该持仓整体浮动 —— 两者不共用标签）。卡内统计只覆盖显示的这些成交，全期口径单独标注；港币美元分开计。</p>
       <div id="trace-stats"></div>
       <div id="trace-list"></div>


### PR DESCRIPTION
Closes #879, closes #880, closes #881

接着 #878 改。三件事都有实测数字，最后一节写了两个没打到自己定的验收线的地方和原因。

## 1. 开屏减负 (#879)

| | 之前 | 现在 |
| --- | --- | --- |
| 首屏含数字的叶子元素 | 31 | **22** |
| 主数副行 | 1440 宽下必折行（`+6.86%` 被挤到第四行） | 不折行 |
| 统计轨 | 右侧 8 个 20px 中号数字 + 8 条副行 | 主数下方一条 13px 低对比统计带 |
| 今日判定 | 三个彩色描边圆角胶囊 + 卡顶金色描边 | 文本行，语义交给左侧小圆点 |

做法是**并行不是删行**：值和「它自己的变化」并进一格（`$3,245` / `−$1,361 · −29.55%`），限定语进标签（`已实现 · USD-EQ`），只有真正额外的信息（`n=81 · 10 未能核验`、`vs LOO 0.266 · active n=20`）才留副行。账面与 FX 降到主数下面那条安静行。

## 2. 字阶 token 化 (#880)

实测线上渲染后的 computed style：

| | 之前 | 现在 |
| --- | --- | --- |
| 不同字号 | **19** 种（48.96 / 36 / 26 / 20 / 17 / 16 / 15 / 14 / 13.5 / 13 / 12.5 / 12 / 11 / 10.5 / 10 / 9.9 / 9.5 / 9 / 1px） | **8** 档 |
| 字重 | 9 档（800/760/750/700/650/600/550/500/400） | 4 档 |
| 字号 × 字重 组合 | 46 | 22 |

8 档 token 定义在 `:root`：`--fs-display / xxl / xl / lg / md / sm / xs / micro`。CSS、`index.html` 的内联 style、JS 模板字符串里的裸 px 字号全部换成 token；`clamp()` 的两端也落在档位上。

两个具体来源被揪出来：
- `.overview-card-kicker` 等标签用 mono，`.muted` 等文字也用 mono ⇒ **mono 只留给数字与代码**，标签改回 sans
- `.trace-more` 这类没写字号的按钮会掉到浏览器默认 `13.3333px`，落在字阶之外

`.panel > h2` 的 `font-size: 1px` 保留：那是视觉隐藏（不能用 `position:absolute`，否则会escape 横向 scroll-snap pager），源码里有注释说明，不是漏网的字号。

## 3. 走势并进持仓表 (#881)

日收益热力从「另一张卡里的色块 tile」改成**与主表同序的行网格**，并进持仓卡：

```
标的 | -6 -5 -4 -3 -2 -1 最新 | 8 日累计 | 走势线
```

- 行序跟随主表当前排序（默认「需动作的排最前」），实测两处 ticker 顺序完全一致
- tile 里的白线和表里的 sparkline 本来是同一件事的两种画法，现在只剩一种
- 每格写出数值，色深 = |当日涨跌| ÷ 满量程，满量程夹在 [2.5%, 9%]；弱值走 gamma 提亮，避免 ±1% 的格子近乎全白读成窟窿
- 「强弱与集中」卡因此只剩仓位 × 信心，改名

## 4. 顺带修掉 kcn 报的「holdings 展示溢出」

两个真缺陷：

1. **展开行不折行**：整段内容在一个 `<td colspan=10>` 里，继承了 `.holdings-table td` 的 `white-space: nowrap`，于是硬闸那种长句一行不折、直接撑出列外（实测 203px 的列里放 878px 的内容）。1440 / 768 / 390 三个宽度现在都是 0 溢出。
2. **热力网格外层错用了 `.tw`**：那是我原型里的滚动容器类名，这份样式表没有它 ⇒ `min-width: 520px` 的网格撑宽了 `#pager`，把 tab 的滚动数学搞坏，`dashboard_tab_runtime.spec.js` 的 `currentTab() drifted` 就是它。换成 `.table-wrap`。

## 没打到自己定的验收线的两处（说明原因）

- **#879 我写的是「首屏数字元素 ≤ 18」，实到 22。** 差的 4 个是统计带里 8 格的值与两条副行。要打到 18 只能删格子，而 kcn 明确说过「不要减少信息展示，只是看情况的合并」，所以停在并行、不删行。
- **#880 我写的是「字号×字重×字体族 组合 ≤ 16」，实到 39。** 这个指标当初定错了：mono/sans 这一维是**由容器决定**的（`.muted` 出现在数字块里就是 mono、出现在文字块里就是 sans），这是正确行为不是不一致。真正衡量字阶纪律的是「字号 × 字重」，那个是 46 → **22**。

## 验证

- `node tests/dashboard_tab_runtime.spec.js` → exit 0
- `pytest`（dashboard 相关六个模块）→ 162 passed, 1 xfailed
- 浅色 / 深色 / 390px：0 page error，0 横向溢出，主数不断行

https://claude.ai/code/session_015wP85vNqYjs8NjEQbY3cej
