### PR TITLE
feat: 首屏指挥台 Apple 毛玻璃 + 全站去「腿」直译 + holdings 抬头精简

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -46,6 +46,9 @@
     --shadow-topbar: 0 1px 0 rgba(0,0,0,.2), 0 8px 24px rgba(0,0,0,.22);
     --shadow-card: 0 1px 2px rgba(0,0,0,.25), 0 12px 28px rgba(0,0,0,.3);
     --glass-topbar: rgba(11,16,23,.6);
+    /* 指挥台毛玻璃：整页第二块浮动层。Apple「更大的表面 = 更厚的材质」——
+       主面比 topbar 更实一点、blur 更深；light 主题由 color-mix 随 surface-1 走。 */
+    --glass-card: color-mix(in srgb, var(--surface-1) 55%, transparent);
     --radius: 10px;
     --radius-sm: 6px;
     --gap: 12px;
@@ -100,6 +103,7 @@
       --shadow-topbar: 0 1px 0 rgba(18,33,48,.06), 0 8px 24px rgba(18,33,48,.08);
       --shadow-card: 0 1px 2px rgba(18,33,48,.05), 0 12px 28px rgba(18,33,48,.07);
       --glass-topbar: rgba(248,250,252,.72);
+      --glass-card: color-mix(in srgb, var(--surface-1) 58%, transparent);
     }
     /* Preserve the quiet timestamp hierarchy without blending below WCAG AA.
        Written as `.muted.asof-faded` on purpose: every element carrying this
@@ -131,7 +135,8 @@
     .topbar,
     .refresh-btn,
     .desk-rail,
-    .status-banner {
+    .status-banner,
+    .hero-deck {
       -webkit-backdrop-filter: none;
       backdrop-filter: none;
     }
@@ -139,6 +144,7 @@
     .refresh-btn { background: var(--card); }
     .desk-rail { background: var(--surface-1); }
     .status-banner { background: var(--accent-soft); }
+    .hero-deck { background: var(--surface-1); }
   }
   body {
     /* Layered page: a cool-tinted gradient replaces the flat fill, so the
@@ -1907,13 +1913,20 @@
      三张不等重的卡。(#874 #877) */
   /* 首屏只有一个焦点：主数。8 格统计轨从右侧「八个中号数字」改成主数下方
      一条低对比的统计带 —— 信息一条不少，但不再和主数抢注意力。(#879) */
+  /* Apple 材质：整页只有指挥台这一块毛玻璃 —— topbar 之外的第二块
+     浮动层。半透明 + 24px 模糊让 body 的冷调 radial 光晕透进来；主数区与统计
+     轨之间只留一条发丝线，格与格之间用留白不用盒子。 */
   .hero-deck {
     grid-column: 1 / -1; padding: 0; overflow: hidden;
     display: grid; grid-template-columns: minmax(0, 1fr);
+    background: var(--surface-1);
+    background: var(--glass-card);
+    -webkit-backdrop-filter: blur(24px) saturate(180%);
+    backdrop-filter: blur(24px) saturate(180%);
+    border-color: var(--border-subtle);
   }
   .hero-deck-lead {
-    padding: 26px 22px 22px;
-    background: linear-gradient(140deg, color-mix(in srgb, var(--accent) 6%, transparent), transparent 58%);
+    padding: 26px 24px 20px;
   }
   .hero-deck-pnl {
     margin-top: 12px; color: var(--text); font: 700 var(--fs-display)/1 var(--mono);
@@ -1936,10 +1949,8 @@
     border-top: 1px solid var(--border-subtle);
   }
   .hero-rail-cell {
-    min-width: 0; padding: 11px 14px;
-    border-right: 1px solid var(--border-subtle);
+    min-width: 0; padding: 14px 16px 16px;
   }
-  .hero-rail-cell:last-child { border-right: 0; }
   .hero-rail-k {
     color: var(--text-tertiary); font: 600 var(--fs-micro)/1.2 var(--font);
     letter-spacing: .09em; text-transform: uppercase;
@@ -1950,7 +1961,7 @@
     letter-spacing: -.01em; font-variant-numeric: tabular-nums;
     overflow-wrap: normal; word-break: keep-all;
   }
-  /* 变化值独占一行：并排时 US/HK 腿会不齐地折行，读起来比两行更乱 */
+  /* 变化值独占一行：并排时 US/HK 两市会不齐地折行，读起来比两行更乱 */
   .hero-rail-d {
     display: block; margin-top: 3px; color: var(--text-tertiary);
     font-size: var(--fs-xs); font-weight: 500; white-space: nowrap;
@@ -2230,8 +2241,6 @@
 
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-    .hero-rail-cell:nth-child(4n) { border-right: 0; }
-    .hero-rail-cell:nth-child(-n+4) { border-bottom: 1px solid var(--border-subtle); }
     .overview-equity, .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
@@ -2243,11 +2252,8 @@
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { width: 100%; min-width: 0; }
     .hero-deck { grid-template-columns: minmax(0, 1fr); }
-    .hero-deck-lead { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+    .hero-deck-lead { border-right: 0; }
     .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .hero-rail-cell { border-bottom: 1px solid var(--border-subtle); }
-    .hero-rail-cell:nth-child(2n) { border-right: 0; }
-    .hero-rail-cell:nth-last-child(-n+2) { border-bottom: 0; }
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
     }
@@ -2272,7 +2278,8 @@
     .hero-deck-pnl { font-size: var(--fs-display); }
     .hero-deck-sub { font-size: var(--fs-sm); }
     .hero-rail-v { font-size: var(--fs-lg); }
-    .hero-rail-cell { padding: 11px 12px; }
+    .hero-deck-lead { padding: 22px 18px 18px; }
+    .hero-rail-cell { padding: 12px 14px 14px; }
     .dh-seg { width: 11px; height: 26px; }
   }
 
@@ -2552,6 +2559,14 @@
   .bd-pos-ends {
     display: flex; justify-content: space-between; margin-top: 5px;
     color: var(--text-tertiary); font: 500 var(--fs-micro)/1.3 var(--mono);
+  }
+
+  /* 持仓主表脚注：核心一句 + 次要说明一行 —— 信息不减，层级分开。
+     renderBook 用 innerHTML 写两行；sub 行比主行更淡更小，不再是一坨小字。 */
+  #book-note { margin: 10px 0 0; line-height: 1.55; }
+  #book-note .book-note-sub {
+    display: block; margin-top: 3px;
+    color: var(--text-tertiary); font-size: var(--fs-micro);
   }
 
   /* 合并卡内部的分节（组合结构 / 今日异动）*/

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -699,7 +699,7 @@
       }
     }
 
-    // 分腿的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
+    // 分市场的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
     const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
     const usTodayPct = legPct(us.value_usd, us.today_change_usd);
     const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
@@ -713,13 +713,13 @@
     const withDelta = (v, delta, cls) =>
       `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
     railEl.innerHTML = [
-      cell("US 腿", withDelta(fmtMoney(us.value_usd, "USD"),
+      cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
         `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
-      cell("HK 腿", withDelta(fmtMoney(hk.value_hkd, "HKD"),
+      cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
-      cell("今日 US", withDelta(heroMoney(us.today_change_usd, "USD"),
+      cell("今日美股", withDelta(heroMoney(us.today_change_usd, "USD"),
         usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
-      cell("今日 HK", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
+      cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
         hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
       cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
       cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -689,7 +689,7 @@
       }
     }
 
-    // 分腿的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
+    // 分市场的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
     const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
     const usTodayPct = legPct(us.value_usd, us.today_change_usd);
     const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
@@ -703,13 +703,13 @@
     const withDelta = (v, delta, cls) =>
       `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
     railEl.innerHTML = [
-      cell("US 腿", withDelta(fmtMoney(us.value_usd, "USD"),
+      cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
         `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
-      cell("HK 腿", withDelta(fmtMoney(hk.value_hkd, "HKD"),
+      cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
-      cell("今日 US", withDelta(heroMoney(us.today_change_usd, "USD"),
+      cell("今日美股", withDelta(heroMoney(us.today_change_usd, "USD"),
         usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
-      cell("今日 HK", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
+      cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
         hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
       cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
       cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),
@@ -1682,10 +1682,13 @@
 
     const note = document.getElementById("book-note");
     if (note) {
-      note.textContent = "点任意一行展开这只票的全部证据。状态：止损/减仓 = 硬闸规则（必动），观望/趋势ON = 技术状态，不是买卖建议。"
-        + "52 周位置：低位 = 近一年便宜，高位 = 追高警惕。"
+      // 两行层级：核心一句 + 次要说明一行。信息不减，只是不再一坨小字。
+      // 全部是静态文案（projection/proxy 只换措辞），没有数据串，innerHTML 安全。
+      note.innerHTML =
+        "点任意一行展开这只票的全部证据。状态：止损/减仓 = 硬闸规则（必动），观望/趋势ON = 技术状态，不是买卖建议。"
+        + `<span class="book-note-sub">52 周位置：低位 ≈ 近一年便宜，高位 ≈ 追高警惕。`
         + (usedProjection ? "匹配行由 harness projection 编译；当前持仓成员以最新账本为准。" : "兼容模式：等待 projection。")
-        + (usedProxy ? " ▵ = 杠杆 ETF，量化列取底层标的。" : "");
+        + (usedProxy ? " ▵ = 杠杆 ETF，量化列取底层标的。" : "") + `</span>`;
     }
     const meta = document.getElementById("book-meta");
     if (meta) meta.textContent = bookSort ? "按列排序" : "需动作的排最前";
@@ -1941,8 +1944,8 @@
     if (constraint) {
       const skippedPct = total ? Math.round(skipped / total * 100) : 0;
       constraint.textContent = total
-        ? `受库存、现金或成交价约束：${skipped}/${total} 条腿未成交（${skippedPct}%）${skipped > filled ? "；绝大多数建议受约束未成交。" : "。"}`
-        : "暂无可统计的模拟成交腿。";
+        ? `受库存、现金或成交价约束：${skipped}/${total} 条未成交（${skippedPct}%）${skipped > filled ? "；绝大多数建议受约束未成交。" : "。"}`
+        : "暂无可统计的模拟成交。";
     }
     const asof = document.getElementById("shadow-asof");
     if (asof) asof.textContent = sidecar.as_of ? ` · 数据 ${sidecar.as_of}` : "";
@@ -2128,7 +2131,7 @@
     badge.className = 'regime-badge ' + hk.tier;
     document.getElementById('lev-regime-label').textContent = TIER[hk.tier] || hk.tier;
     document.getElementById('lev-regime-cap').textContent =
-      (hk.lev_cap_mult == null) ? '' : `杠杆ETF腿上限 ×${hk.lev_cap_mult}`;
+      (hk.lev_cap_mult == null) ? '' : `杠杆ETF上限 ×${hk.lev_cap_mult}`;
     document.getElementById('lev-regime-rationale').textContent = r.rationale || hk.label || '';
     // re-entry trigger: % the close must rise to reclaim its 200DMA (unlocks re-leveraging)
     const reclaim = (close, ma) => (close && ma) ? (ma / close - 1) * 100 : null;
@@ -2138,7 +2141,7 @@
     else if (hk.trend_on) {
       trigEl.innerHTML = `<span class="neutral">HK 触发线 200线 ${Math.round(hk.ma)} · 已在线上 +${(-hkRe).toFixed(0)}% 缓冲（杠杆解锁中）</span>`;
     } else {
-      trigEl.innerHTML = `<span class="warn-text">HK 触发线：恒科站回 200线 <strong>${Math.round(hk.ma)}</strong>（需 +${hkRe.toFixed(0)}%）→ 杠杆腿上限放回 50%</span>`;
+      trigEl.innerHTML = `<span class="warn-text">HK 触发线：恒科站回 200线 <strong>${Math.round(hk.ma)}</strong>（需 +${hkRe.toFixed(0)}%）→ 杠杆上限放回 50%</span>`;
     }
     // US per-name rows
     const STATE = { cut: ['red', '砍杠杆'], watch: ['warn-text', '观察'], ok: ['neutral', '趋势ON'], unknown: ['neutral', '—'] };

--- a/site/index.html
+++ b/site/index.html
@@ -153,10 +153,11 @@ layout: null
 
     <div class="overview-command">
       <!-- 首屏第一数字回答「赚还是亏」；账面市值随行情自己变，不需要判断，降为副行。
-           原来的 book / today / discipline 三张不等重的卡合并成一块指挥台。(#874 #877) -->
+           原来的 book / today / discipline 三张不等重的卡合并成一块指挥台。(#874 #877)
+           指挥台是整页唯一的毛玻璃面：主数 + 一行拆解 + 一条低对比统计轨。 -->
       <div class="card hero-deck">
         <div class="hero-deck-lead">
-          <div class="overview-card-kicker">总盈亏 · 已实现 + 浮动 · USD 等值</div>
+          <div class="overview-card-kicker">总盈亏 · USD 等值</div>
           <div class="hero-deck-pnl" id="hero-pnl">—</div>
           <div class="hero-deck-sub" id="hero-sub">—</div>
           <div class="hero-deck-fx" id="fx-rate-usd">—</div>
@@ -168,7 +169,7 @@ layout: null
       <div class="card overview-equity">
         <div class="card-head">
           <div>
-            <div class="overview-card-kicker">战绩 · 视觉锚点</div>
+            <div class="overview-card-kicker">战绩</div>
             <h3 id="equity-title">Equity Curve · USD-eq</h3>
           </div>
           <span id="benchmark-stale" class="muted" style="display:none;font-size:var(--fs-xs);color:var(--amber)"></span>
@@ -274,7 +275,7 @@ layout: null
     <div class="card desktop-wide" id="book-card">
       <div class="card-head">
         <div>
-          <div class="overview-card-kicker">持仓明细</div>
+          <div class="overview-card-kicker">决策矩阵 · 每行一只仓位</div>
           <h3>持仓 <span class="muted" id="book-count" style="text-transform:none;letter-spacing:0;font-weight:500"></span></h3>
         </div>
         <span class="muted" id="book-meta" style="font-size:var(--fs-xs)"></span>
@@ -308,11 +309,11 @@ layout: null
     <div class="card desktop-wide" id="add-campaign-card">
       <div class="card-head">
         <div>
-          <div class="overview-card-kicker">Quant × information · low frequency</div>
+          <div class="overview-card-kicker">量化 × 信息 · 低频</div>
           <h3>Add Campaign <span class="badge muted" id="add-campaign-status">—</span></h3>
         </div>
       </div>
-      <p class="chart-hint">先由价格相对强弱 + 点时信息共同授权资金，再等技术价位安排 tranche。这里是新 campaign 的独立状态与样本；Reflect 的旧 <code>add_only_on_trigger</code> 桶不是它的战绩。</p>
+      <p class="chart-hint">先由价格相对强弱 + 点时信息共同授权资金，再等技术价位分批（tranche）安排。这里是新 campaign 的独立状态与样本；Reflect 的旧 <code>add_only_on_trigger</code> 桶不是它的战绩。</p>
       <div id="add-campaign-body"><div class="empty-state">等待今日 brief projection。</div></div>
       <div id="add-campaign-evidence"></div>
     </div>
@@ -323,9 +324,9 @@ layout: null
         <h3>仓位 × 信心</h3>
       </div></div>
       <div class="sub-block">
-        <div class="sub-block-head">仓位 × 信心 <span class="muted">横轴与点大小 = 各自 US/HK leg 内权重，不是全组合 USD-eq 权重</span></div>
+        <div class="sub-block-head">仓位 × 信心 <span class="muted">横轴与点大小 = 各自市场内权重，不是全组合 USD-eq</span></div>
       
-      <p class="chart-hint">横轴和圆点大小均为各自 US/HK 市场 leg 内权重，不是全组合 USD-eq 权重；跨市场百分比不可直接当作同一分母比较。右下角（高仓位 + 低置信）= 需要审视。</p>
+      <p class="chart-hint">横轴和圆点大小均为各自市场内权重，不是全组合 USD-eq 权重；跨市场百分比不能直接当作同一分母比较。右下角（高仓位 + 低置信）= 需要审视。</p>
       <div id="chart-weight-conf" class="wc-chart-box"></div>
       <div class="wc-legend">
         <span class="lg-high">High risk (≥20% & conf&lt;0.65)</span>
@@ -338,7 +339,7 @@ layout: null
       </div>
     </div>
 
-    <div class="sect-divider price-section-heading">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">latest local session · US / HK 各取最近本地交易时段</span></div>
+    <div class="sect-divider price-section-heading">价格动态 <span class="muted" style="font-weight:500;letter-spacing:0">US / HK 各取最近本地交易时段</span></div>
 
     <div class="card desktop-wide" id="today-action-card">
       <div class="card-head"><div>
@@ -462,15 +463,15 @@ layout: null
       
       <div class="lev-row">
         <div class="lev-cell">
-          <div class="lbl">US leg</div>
+          <div class="lbl">美股</div>
           <div class="val" id="lev-us">—</div>
         </div>
         <div class="lev-cell">
-          <div class="lbl">HK leg</div>
+          <div class="lbl">港股</div>
           <div class="val" id="lev-hk">—</div>
         </div>
         <div class="lev-cell">
-          <div class="lbl">Combined</div>
+          <div class="lbl">合计</div>
           <div class="val" id="lev-combined">—</div>
         </div>
       </div>

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -327,7 +327,7 @@ Bull/Bear 是决策框架的一部分，不能因升级账本而删除：
 preflight 已算好,直接读 `context.risk_guardrail`:
 - `breaches[]` — 每条 = 一个超限的硬闸(single_name / factor_concentration / leveraged_exposure / beta),带 `detail` + 现成 `action`(含具体减仓金额)。
 - `hard_stop_watch[]` — 杠杆 ETF 浮亏跌破 −18% 的硬止损触发。
-- `directive` — 本次总指令；`caps` — 当前阈值（非杠杆单名 35–60% review、>60% mandatory；杠杆单名 35%；实测多票相关 cluster 70% 且覆盖≥80%；杠杆 ETF 腿 50%；US β 3.0；杠杆止损 −18%）。Top2 仅展示，不再冒充同因子。
+- `directive` — 本次总指令；`caps` — 当前阈值（非杠杆单名 35–60% review、>60% mandatory；杠杆单名 35%；实测多票相关 cluster 70% 且覆盖≥80%；杠杆 ETF 50%；US β 3.0；杠杆止损 −18%）。Top2 仅展示，不再冒充同因子。
 - `context.risk_discipline.records[]` — 同一 breach 的持久状态：`breach_id`、严重度、`age_days`、首次/最后变化、required reduction、acknowledgement、限时 override、execution evidence。每日重新生成的 plan 不是状态账本。
 
 硬性规则:
@@ -338,7 +338,7 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 - 这些减仓 **strategy_id=`risk_rebalance`、driven_by=`risk_rule`**（纪律性再平衡，不是择时预测），并在 rationale 注明组合政策依据。
 - **这是 risk_on HOLD 默认的唯一豁免**:证伪铁律已写明纪律性再平衡正常走;别因为 regime=risk_on 就把降杠杆/降集中也按住。牛市里恰恰要借强减杠杆,不是等回调后。
 - **降 β/降杠杆优先削杠杆 ETF**(β 的主要来源),不要去砍高信念单票的 thesis。
-- **杠杆腿解套口径(kcn 2026-06-11 定)**:杠杆 ETF 的 breach/hard_stop 动作 = **2x→1x 同因子换仓而非清仓**(映射在 `brief_preflight.LEV_1X_SWAP`:07226→03033、PLTU→PLTR、ROBN→HOOD、MSFU→MSFT)——敞口不变、反弹一点不踏空,但停掉日内重置 decay;`context.risk_guardrail.reentry_rule` 满足(🧭转 green,标的收复 200 线)才允许 1x→2x 换回。**现货(非杠杆)套牢 kcn 方针=持有等待合法**(现货等待免费,2x 等待收费),对现货超限的最低要求是"不补仓、借反弹分批",别反复催清仓。
+- **杠杆ETF解套口径(kcn 2026-06-11 定)**:杠杆 ETF 的 breach/hard_stop 动作 = **2x→1x 同因子换仓而非清仓**(映射在 `brief_preflight.LEV_1X_SWAP`:07226→03033、PLTU→PLTR、ROBN→HOOD、MSFU→MSFT)——敞口不变、反弹一点不踏空,但停掉日内重置 decay;`context.risk_guardrail.reentry_rule` 满足(🧭转 green,标的收复 200 线)才允许 1x→2x 换回。**现货(非杠杆)套牢 kcn 方针=持有等待合法**(现货等待免费,2x 等待收费),对现货超限的最低要求是"不补仓、借反弹分批",别反复催清仓。
 - 若 `breach_count=0` → 本段写"✅ 仓位硬闸无触发",照常决策。
 - **解套/回本数字只准引用 `context.breakeven_math`**(preflight 已算好:每只浮亏持仓回本所需涨幅、2x 的横盘 decay ≈σ²/12 每月、半年窗含 drag 等效标的涨幅),禁止自己心算或编造。解读纪律见其 `note`:直线涨→2x 回本更快;横盘→2x 每月白付 decay;再跌→2x 双倍挨打——换 1x 买的是后两种情景的保护,不是回本速度,别说反。
 - **技术面判断只准引用 `context.quant_signals` 中 `status=fresh` 的行**(每只持仓的趋势/动量/RSI/zscore20/吊灯止损线/vol_target_weight,杠杆 ETF 按标的算)；`stale/missing/retired` 行只用于披露数据缺口，禁止据此形成判断，也禁止自创"看图"结论。**因子话语权由 `context.quant_signal_review` 决定**(信号每日留痕 vs T+1/T+5 前瞻收益自动对账):必须公示 `n_events/n_dates/n_tickers`;`usable=false` 或聚类 CI 跨 50% 的因子只能当背景展示不入决策；`decision_direction=reverse` 仅在反向 CI 整体低于 50% 时成立，禁止因 raw hit_rate<50% 自动反向。T+0 牌面同样只在 `sample_sufficient=true AND edge_supported=true` 时可入决策；样本够多但 Wilson CI 不支持原方向仍是 `usable=false`，不得自动反向交易。`driven_by=technical` 的整体战绩一律读取 `context.decision_metrics.by_driver.technical` 的实时计算值，禁止引用固定百分比。这是自迭代环——哪个因子可信,数据说了算,每天自动更新。

--- a/src/clawock/decision/regime.py
+++ b/src/clawock/decision/regime.py
@@ -337,7 +337,7 @@ def main(argv=None):
         'rationale': (f'HSTECH {close:.0f} {"高于" if trend_on else "低于"} {MA_WINDOW}日线 '
                       f'{ma:.0f} ({dist:+.1f}%)；20日波动 {vol*100:.0f}% '
                       f'{"<" if vol_ok else "≥"} {int(VOL_CAP*100)}% 上限。'
-                      f'→ HK 杠杆ETF腿上限 ×{mult:g}（{tier}）'),
+                      f'→ HK 杠杆ETF上限 ×{mult:g}（{tier}）'),
     }
     # Top-level fields above describe the HK (HSTECH) dial; mirror under 'hk' and add 'us'.
     out['hk'] = {'tier': tier, 'lev_cap_mult': mult, 'label': label,

--- a/src/clawock/portfolio/guardrail.py
+++ b/src/clawock/portfolio/guardrail.py
@@ -86,7 +86,7 @@ GUARDRAIL_CAPS = {
 
 
 # 2x→1x 解套换仓映射（kcn 2026-06-11 口径）：现货套牢可以躺（等待免费），2x 日内重置
-# 套牢不能躺（震荡 decay 让等待持续收费）。所以杠杆腿的硬闸动作一律先给「换仓」而非
+# 套牢不能躺（震荡 decay 让等待持续收费）。所以杠杆仓的硬闸动作一律先给「换仓」而非
 # 「清仓 trim」——换成同因子 1x 后反弹敞口一点不丢、decay 出血停止，不算割肉离场。
 # 换回条件 = 🧭 lev_regime 转 green（标的收复 200 日线且波动正常），1x→2x 只在 green 档执行。
 LEV_1X_SWAP = one_x_swap_map()
@@ -322,7 +322,7 @@ def compute_risk_guardrail(hk_holdings, us_holdings, hk_conc, us_conc, risk,
                            f"(cap {caps['correlated_cluster_pct']}%, "
                            f"|rho|≥{correlation.get('cluster_rho')})"),
                 'action': (f"把相关集群 {', '.join(tickers)} 降到 "
-                           f"≤{caps['correlated_cluster_pct']}%，优先降其中杠杆腿"),
+                           f"≤{caps['correlated_cluster_pct']}%，优先降其中杠杆仓"),
                 'required_reduction': {
                     'kind': 'factor_market_value',
                     'minimum_value': factor_trim,
@@ -360,7 +360,7 @@ def compute_risk_guardrail(hk_holdings, us_holdings, hk_conc, us_conc, risk,
         directive = (f"⛔ {len(breaches)} 仓位硬闸 + {len(hard_stops)} 杠杆止损触发。"
                      "每条必须在 Judge 段出一个对应动作(driven_by=risk_rule,纪律性再平衡,"
                      "不算听消息、不受 risk_on HOLD 默认约束)；其余主动 call 仍按 regime guard。"
-                     "杠杆腿解套口径=2x→1x 同因子换仓而非清仓(见各 action)。")
+                     "杠杆ETF解套口径=2x→1x 同因子换仓而非清仓(见各 action)。")
     else:
         directive = "✅ 无仓位/杠杆硬闸触发，按常规决策。"
 


### PR DESCRIPTION
## 改了什么

**1. 首屏指挥台 → 整页唯一毛玻璃面（Apple 材质）**
- `.hero-deck` 半透明 + `backdrop-filter: blur(24px) saturate(180%)`，body 的冷调 radial 光晕透进来；light 主题由 `--glass-card` 随 surface-1 走
- 去掉蓝色渐变 wash 与 8 格统计轨的格子边框：格与格之间纯留白，只留主数区/统计带之间一条发丝线
- kicker 去重复：「总盈亏 · 已实现 + 浮动 · USD 等值」→「总盈亏 · USD 等值」（副行已列拆解）
- `prefers-reduced-transparency: reduce` 回退实色（含 deck）

**2. 去「腿」直译（用户可见文案 + 生成端）**
- 站点：`US 腿/HK 腿` → `美股/港股`，`今日 US/HK` → `今日美股/今日港股`；`条腿未成交`→`条未成交`；`杠杆ETF腿上限`→`杠杆ETF上限`；`US/HK leg`→`美股/港股/合计`；`leg 内权重`→`市场内权重`
- 生成端（防止新数据再带出）：`regime.py`、`guardrail.py`、`daily-deep-brief/SKILL.md` 里的「杠杆腿/分腿」措辞同步改
- 历史 decision_traces rationale 是 point-in-time 记录，不改

**3. holdings 抬头精简**
- 卡 kicker「持仓明细」与 section divider 重复 →「决策矩阵 · 每行一只仓位」
- Add Campaign kicker 中文化（Quant × information · low frequency → 量化 × 信息 · 低频）
- 表脚注拆两层：核心一句 + 次要说明一行（信息不减，层级分开）
- 「价格动态」divider 去掉英文残留

**4. 移动端**
- deck/rail 窄屏留白与两列排布重调；390/320 零横向溢出；reduced-motion 下 0 动画运行

## 验证
- playwright 断言 36 项全过（毛玻璃 alpha/blur、rail 无边框、kicker/标签文案、零「腿」、320/390 无溢出、light 主题、reduced-motion、reduced-transparency 静态回退）
- `tests/dashboard_tab_runtime.spec.js` 本机跑通（hero/detail tabs/chart gestures）
- `pytest test_validate_regime_dial.py test_brief_preflight_guardrail.py test_risk_discipline.py`：70 passed