### PR TITLE
refactor: CI 门控脚本化——push_scope.py 单一分类器 + 场景矩阵契约

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
       # (a path-filtered required check waits forever). On master pushes the
       # workflow fires for any code path below, so gate on an actual diff under
       # .github/workflows/ instead; undiffable ranges lint anyway (fail toward
-      # running a 12s check rather than skipping it).
+      # running a 12s check rather than skipping it). Classification lives in
+      # ops/ci/push_scope.py — the same classifier the other two gates read.
       - name: Did any workflow file change?
         id: scope
         env:
@@ -107,24 +108,20 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" != "push" ]; then
-            echo "lint=true" >> "$GITHUB_OUTPUT"
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ] \
-             || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            echo "no diffable base ($BASE_SHA) — linting"
-            echo "lint=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git fetch --quiet --depth=1 origin "${BASE_SHA}"
-          if git diff --name-only "${BASE_SHA}" HEAD | grep -q '^\.github/workflows/'; then
-            echo "lint=true" >> "$GITHUB_OUTPUT"
+          if [ -n "${BASE_SHA:-}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
+             && git fetch --quiet --depth=1 origin "${BASE_SHA}"; then
+            python3 ops/ci/push_scope.py --base "${BASE_SHA}" --head HEAD \
+              | grep '^workflows=' >> "$GITHUB_OUTPUT"
           else
-            echo "lint=false" >> "$GITHUB_OUTPUT"
+            echo "no diffable base (${BASE_SHA:-}) — linting"
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install pinned actionlint
-        if: steps.scope.outputs.lint == 'true'
+        if: steps.scope.outputs.workflows == 'true'
         env:
           ACTIONLINT_VERSION: '1.7.12'
           ACTIONLINT_SHA256: '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
@@ -138,7 +135,7 @@ jobs:
           /tmp/actionlint -version
 
       - name: Lint GitHub Actions
-        if: steps.scope.outputs.lint == 'true'
+        if: steps.scope.outputs.workflows == 'true'
         run: /tmp/actionlint -color
 
   validate:
@@ -223,74 +220,28 @@ jobs:
         # We must NOT path-filter the pull_request trigger itself: a required
         # check that is filtered out never reports and blocks the PR forever —
         # the same trap that keeps `lint` unfiltered on PRs. Skipped *steps*
-        # count as success, so we gate here.
-        # Runs on pushes too (#750). It used to be PR-only, with every heavy
-        # step reading `event_name != 'pull_request' || changes...` — which meant
-        # the browser contract and the DSH plugin gates, whose conditions were
-        # written the other way round (`event_name == 'pull_request' && ...`),
-        # could never run on a master push at all. The unit suite did run there
-        # (measured: run 31059122903 on a master push executed "Unit tests —
-        # money-integrity derivations" and skipped only the browser/plugin
-        # steps), so the hole was exactly the two expensive lanes.
+        # count as success, so we gate here. Runs on pushes too (#750): it used
+        # to be PR-only, and the browser/plugin lanes were then unreachable on
+        # master (measured hole, run 31059122903).
         #
-        # Keep this path set in sync with the `push:` trigger `paths:` at the top
-        # of this file — `test_detector_covers_every_push_trigger_path` now holds
-        # that, because the claim was already false: `ops/**` and
-        # `skills/tavily-search/**` triggered the workflow and then matched
-        # nothing here, so a PR touching only those skipped the entire suite
-        # while `validate` reported green in seconds. Except the two core
-        # dashboard projections: their frequent automation commits use
-        # the cheap dashboard-artifact-gate on master, while a rare dashboard PR
-        # still gets the full suite here.
+        # The classification lives in ops/ci/push_scope.py — one classifier for
+        # all three gates (this detector, the lint scope, the CodeQL push
+        # gate), unit-tested against synthetic file lists instead of three
+        # inline copies that could drift apart again. It keeps itself in sync
+        # with the `push:` trigger `paths:` above via
+        # test_ci_trigger_paths.py: a trigger path whose files no lane claims
+        # is a gate that skips itself (#750 proved that claim false once).
+        # Undiffable ranges (schedule, dispatch, brand-new ref) come back as
+        # "everything changed" — running the whole suite is the safe direction.
         id: changes
         env:
           # A PR compares its own base and head. A push compares the range it
-          # pushed. Anything else (`workflow_dispatch`, or a push whose `before`
-          # is the all-zero sha because the ref was just created) has no range to
-          # diff, and answers "everything changed" below — running the whole
-          # suite is the safe direction for a manual run.
+          # pushed.
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          set -euo pipefail
-          if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ] \
-             || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            echo "no diffable base ($BASE_SHA) — treating every lane as changed"
-            { echo "code=true"; echo "ui=true"; echo "dsplugin=true"; } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # --no-renames: a rename OUT of a watched dir (e.g. scripts/x.py ->
-          # docs/x.py) must still surface the old path and run the suite, since it
-          # can break imports. No --diff-filter, so deletions count too, matching
-          # the push trigger's paths. Capture separately (not via process
-          # substitution) so a git failure fails this step — fail-closed, validate
-          # goes red — instead of being read as an empty, docs-only diff and
-          # silently skipping the suite.
-          changed="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
-          # memory/decisions.jsonl is intentionally absent: like the push trigger,
-          # the ledger is automation-committed runtime data, not edited via
-          # interactive PRs.
-          code=false
-          while IFS= read -r f; do
-            [ -n "$f" ] || continue
-            case "$f" in
-              src/*|ops/*|tests/*|pyproject.toml|pytest.ini|portfolio.json|memory/*-plan.json|memory/theses/*|memory/earnings/*|memory/entry-gates/*|assets/data/overview.json|assets/data/dashboard.json|config/*|docs/operations/cron-schedules.md|.github/workflows/*|.github/actions/*|skills/tavily-search/*|site/tools/*)
-                code=true
-                break
-                ;;
-            esac
-          done <<< "$changed"
-          ui=false
-          if grep -Eq '^(site/assets/(css|js)/|site/index\.html$|tests/dashboard_tab_runtime\.spec\.js$)' <<< "$changed"; then
-            ui=true
-            code=true
-          fi
-          dsplugin=false
-          if grep -Eq '^(examples/dsh/|tests/decision_studio_plugin\.spec\.js$|tests/dsh_plugin_package_contract\.mjs$)' <<< "$changed"; then
-            dsplugin=true
-          fi
-          { echo "code=$code"; echo "ui=$ui"; echo "dsplugin=$dsplugin"; } >> "$GITHUB_OUTPUT"
-          echo "code changed: $code"
+          python3 ops/ci/push_scope.py --base "$BASE_SHA" --head "$HEAD_SHA" \
+            | tee -a "$GITHUB_OUTPUT"
 
       # The browser build is ~150MB downloaded from scratch on every UI run.
       # The composite owns the version pin and the cache key — the same key the
@@ -658,10 +609,7 @@ jobs:
         uses: ./.github/actions/clawock-python
 
       - name: FX fallback chain
-        run: |
-          out=$(clawock fx --json) || exit 1
-          echo "$out"
-          python3 -c "import json,sys; d=json.load(open('-')) if False else json.loads('''$out'''); assert 7 < d['rate'] < 9, f'FX rate out of range: {d[\"rate\"]}'; print('FX OK:', d['source'])"
+        run: python3 ops/ci/smoke_fx.py
 
   analyze:
     # Was codeql.yml — advanced setup replacing GitHub's default (#782).
@@ -719,28 +667,17 @@ jobs:
           BASE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ] \
-             || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            echo "no diffable base ($BASE_SHA) — analysing"
-            echo "analyse=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ -n "${BASE_SHA:-}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
+             && git fetch --quiet --depth=1 origin "${BASE_SHA}"; then
+            python3 ops/ci/push_scope.py --base "${BASE_SHA}" --head HEAD \
+              | grep '^analysable=' >> "$GITHUB_OUTPUT"
+          else
+            echo "no diffable base (${BASE_SHA:-}) — analysing"
+            echo "analysable=true" >> "$GITHUB_OUTPUT"
           fi
-          changed="$(git diff --name-only --no-renames "${BASE_SHA}" HEAD)"
-          analyse=false
-          while IFS= read -r f; do
-            [ -n "$f" ] || continue
-            case "$f" in
-              assets/data/*|memory/*|logs/*|site/assets/data/*|portfolio.json|monitor_state.json|openclaw-workspace-state.json) ;;
-              *) analyse=true; break ;;
-            esac
-          done <<< "$changed"
-          if [ "$analyse" = "false" ]; then
-            echo "push touched only non-analysable data paths — skipping"
-          fi
-          echo "analyse=$analyse" >> "$GITHUB_OUTPUT"
 
       - name: Initialize CodeQL
-        if: github.event_name != 'push' || steps.scope.outputs.analyse == 'true'
+        if: github.event_name != 'push' || steps.scope.outputs.analysable == 'true'
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
@@ -751,7 +688,7 @@ jobs:
           # separate decision with its own alert backlog.
 
       - name: Perform CodeQL analysis
-        if: github.event_name != 'push' || steps.scope.outputs.analyse == 'true'
+        if: github.event_name != 'push' || steps.scope.outputs.analysable == 'true'
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/ops/ci/push_scope.py
+++ b/ops/ci/push_scope.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Classify a change range into the CI lanes — the single source of truth.
+
+Three gates in ci.yml (the validate detector, the lint scope, the CodeQL
+push gate) used to carry three inline copies of overlapping
+diff-classification bash. Copies drift: #750 and the config-directory lesson
+both came from exactly that. This script is now the only place that knows
+what a changed path means for CI, and tests/test_push_scope.py drives it
+with synthetic file lists so lane behaviour is asserted without git or
+GitHub.
+
+Lanes emitted (GITHUB_OUTPUT `key=value` lines, or --json):
+
+  code       run the Python suite / schema checks
+  ui         dashboard browser contract needed (implies code)
+  dsplugin   Decision Studio plugin contracts needed
+  workflows  a workflow file itself changed (drives the lint gate)
+  analysable  at least one path CodeQL should analyse; False when every
+              changed path is automation-written runtime data, and False on
+              an empty diff. Undiffable ranges never reach here: the caller
+              answers --everything before invoking this script, failing
+              toward running.
+
+Matching semantics deliberately mirror the shell they replaced: glob lanes
+use fnmatchcase, where `*` crosses `/` exactly like a `case` pattern did;
+the ui/dsplugin lanes use the same regexes the old grep lines carried,
+byte-for-byte.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+
+# Files whose change must run the suite. Keep in sync with the push trigger's
+# positive path list in ci.yml — test_ci_trigger_paths.py holds both halves.
+CODE_GLOBS = [
+    "src/*",
+    "ops/*",
+    "tests/*",
+    "pyproject.toml",
+    "pytest.ini",
+    "portfolio.json",
+    "memory/*-plan.json",
+    "memory/theses/*",
+    "memory/earnings/*",
+    "memory/entry-gates/*",
+    "assets/data/overview.json",
+    "assets/data/dashboard.json",
+    "config/*",
+    "docs/operations/cron-schedules.md",
+    ".github/workflows/*",
+    ".github/actions/*",
+    "skills/tavily-search/*",
+    "site/tools/*",
+]
+
+# Automation-written runtime data: no analysable code, so the CodeQL matrix
+# skips a push that touches nothing outside this set. overview.json and
+# dashboard.json are deliberate exceptions by specificity: they sit in
+# CODE_GLOBS above (the suite validates the projections), while CodeQL still
+# skips them because a payload-only change contains nothing analysable — the
+# same split the pre-merge files enforced with two different mechanisms.
+DATA_GLOBS = [
+    "assets/data/*",
+    "memory/*",
+    "logs/*",
+    "site/assets/data/*",
+    "portfolio.json",
+    "monitor_state.json",
+    "openclaw-workspace-state.json",
+]
+
+# Byte-identical to the grep -E patterns the inline detector carried.
+UI_RE = r"^(site/assets/(css|js)/|site/index\.html$|tests/dashboard_tab_runtime\.spec\.js$)"
+DSPLUGIN_RE = r"^(examples/dsh/|tests/decision_studio_plugin\.spec\.js$|tests/dsh_plugin_package_contract\.mjs$)"
+
+WORKFLOWS_PREFIX = ".github/workflows/"
+
+ZERO_SHA = "0" * 40
+
+
+def classify(files: list[str]) -> dict[str, bool]:
+    ui_re = re.compile(UI_RE)
+    ds_re = re.compile(DSPLUGIN_RE)
+    code = ui = dsplugin = workflows = False
+    # An empty diff analyses nothing; otherwise at least one path outside the
+    # automation-data set makes the range worth analysing (mirrors the
+    # ignore-list semantics the standalone codeql.yml trigger used to have).
+    analysable = bool(files) and any(
+        not any(fnmatch.fnmatchcase(f, g) for g in DATA_GLOBS) for f in files
+    )
+    for f in files:
+        if not f:
+            continue
+        if any(fnmatch.fnmatchcase(f, g) for g in CODE_GLOBS):
+            code = True
+        if ui_re.search(f):
+            ui = True
+            code = True
+        if ds_re.search(f):
+            dsplugin = True
+        if f.startswith(WORKFLOWS_PREFIX):
+            workflows = True
+    return {
+        "code": code,
+        "ui": ui,
+        "dsplugin": dsplugin,
+        "workflows": workflows,
+        "analysable": analysable,
+    }
+
+
+EVERYTHING = {
+    "code": True,
+    "ui": True,
+    "dsplugin": True,
+    "workflows": True,
+    "analysable": True,
+}
+
+
+def changed_files(base: str, head: str) -> list[str] | None:
+    """Files changed in the range, or None when the base is unusable."""
+    if not base or base == ZERO_SHA:
+        return None
+    probe = subprocess.run(
+        ["git", "cat-file", "-e", f"{base}^{{commit}}"],
+        capture_output=True,
+    )
+    if probe.returncode != 0:
+        return None
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "--no-renames", base, head],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base", default="", help="range start (event.before)")
+    parser.add_argument("--head", default="HEAD", help="range end")
+    parser.add_argument(
+        "--everything",
+        action="store_true",
+        help="skip diffing; report every lane as changed",
+    )
+    parser.add_argument(
+        "--files-from",
+        help="classify this newline-separated path list instead of running git ('-' = stdin)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args(argv)
+
+    if args.everything:
+        lanes = dict(EVERYTHING)
+    elif args.files_from:
+        text = (
+            sys.stdin.read()
+            if args.files_from == "-"
+            else open(args.files_from, encoding="utf-8").read()
+        )
+        lanes = classify(text.splitlines())
+    else:
+        files = changed_files(args.base, args.head)
+        lanes = classify(files) if files is not None else dict(EVERYTHING)
+
+    if args.json:
+        print(json.dumps(lanes, sort_keys=True))
+    else:
+        for key in sorted(lanes):
+            print(f"{key}={'true' if lanes[key] else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/ci/smoke_fx.py
+++ b/ops/ci/smoke_fx.py
@@ -12,12 +12,23 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from pathlib import Path
+
+_OPS = Path(__file__).resolve().parents[1]
+if str(_OPS) not in sys.path:
+    sys.path.insert(0, str(_OPS))
+from system_check import clawock_argv  # noqa: E402
 
 
 def check(runner=None) -> str:
-    """Return the winning FX source, or raise on an unusable answer."""
+    """Return the winning FX source, or raise on an unusable answer.
+
+    Spawns through clawock_argv, never a bare `clawock`: the probe must also
+    work from a bare cron PATH where the console script is not resolvable.
+    """
+    argv, env = clawock_argv("fx", "--json")
     run = (runner or subprocess.run)(
-        ["clawock", "fx", "--json"], capture_output=True, text=True, check=True
+        argv, capture_output=True, text=True, check=True, env=env
     )
     data = json.loads(run.stdout)
     rate = data["rate"]

--- a/ops/ci/smoke_fx.py
+++ b/ops/ci/smoke_fx.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""FX fallback-chain smoke probe.
+
+Replaces the inline `clawock fx --json` + python one-liner that lived in
+ci.yml's smoke-data-fetch job. The probe is advisory by construction — its
+job carries `continue-on-error` because data sources can be flaky — but a
+probe that cannot fail loudly is worth nothing, so the assertions still exit
+nonzero and surface as annotations.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def check(runner=None) -> str:
+    """Return the winning FX source, or raise on an unusable answer."""
+    run = (runner or subprocess.run)(
+        ["clawock", "fx", "--json"], capture_output=True, text=True, check=True
+    )
+    data = json.loads(run.stdout)
+    rate = data["rate"]
+    assert 7 < rate < 9, f"FX rate out of range: {rate}"
+    return data["source"]
+
+
+def main() -> int:
+    try:
+        source = check()
+    except (subprocess.CalledProcessError, KeyError, AssertionError, json.JSONDecodeError) as exc:
+        print(f"FX smoke FAILED: {exc}", file=sys.stderr)
+        return 1
+    print(f"FX OK: {source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -77,3 +77,25 @@ def test_plugin_sources_trigger_ci_on_master_pushes():
     from workflow_contract_helpers import push_paths
 
     assert "examples/dsh/**" in push_paths(CI)
+
+
+def test_no_inline_lane_classification_left_in_the_workflow():
+    """The adversarial pass on #884: three inline copies of diff-classification
+    bash were how #750-style drift happened. All gates must read
+    ops/ci/push_scope.py, and the smoke probe must be a script, not a
+    python -c one-liner."""
+    from workflow_contract_helpers import step_block
+
+    assert TEXT.count("ops/ci/push_scope.py") >= 3, (
+        "detector, lint scope and CodeQL scope all route through one classifier")
+    assert "ops/ci/smoke_fx.py" in TEXT, (
+        "smoke-data-fetch must run the script, not an inline python -c")
+
+    for step in ("Did any workflow file change?",
+                 "Detect code changes",
+                 "Did the push touch anything analysable?",
+                 "FX fallback chain"):
+        block = step_block(CI, step)
+        assert "python3 -c" not in block and 'case "$f"' not in block, (
+            f"{step} grew inline logic; it belongs in ops/ci/push_scope.py "
+            "where tests can drive it")

--- a/tests/test_ci_trigger_paths.py
+++ b/tests/test_ci_trigger_paths.py
@@ -1,18 +1,19 @@
 """The `validate` gate must not skip a PR that only touches `config/`.
 
 `validate` is a required check that always reports, but its expensive Python steps
-are gated twice: the `push:` path filter and the `Detect code changes` case list.
-Both were written as an explicit list of config files, so every config file added
-later (thesis and earnings schemas, evidence policies, peer rules) silently fell
-outside the gate — a config-only PR reported green in seconds without running the
-tests that read that config. These assertions keep the directory-wide form.
+are gated twice: the `push:` path filter and the lane classifier. Both halves used
+to be explicit file lists that looked complete while leaving every later addition
+ungated (config files before the directory-wide form; `ops/**` and the Tavily
+skill before #750). The classification itself now lives in `ops/ci/push_scope.py`,
+and these assertions drive it behaviourally instead of parsing YAML text.
 """
+import re
 import subprocess
+import sys
 from fnmatch import fnmatch
 from pathlib import Path
 
-from workflow_contract_helpers import case_patterns, push_paths
-
+from workflow_contract_helpers import push_paths
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ci.yml"
@@ -22,22 +23,32 @@ CONFIG_FILES = sorted(
     if path.is_file()
 )
 
+sys.path.insert(0, str(ROOT / "ops" / "ci"))
+import push_scope  # noqa: E402
+
+
+def _tracked() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    return out.stdout.split()
+
 
 def test_config_directory_is_gated_as_a_whole():
     assert "config/**" in push_paths(WORKFLOW_PATH)
-    assert "config/*" in case_patterns(WORKFLOW_PATH)
+    assert "config/*" in push_scope.CODE_GLOBS
 
 
 def test_no_individual_config_file_is_named_in_either_gate():
     # A single named file is the failure mode this test exists to prevent: it looks
     # complete while leaving every future config file ungated.
-    narrow = [p for p in push_paths(WORKFLOW_PATH) + case_patterns(WORKFLOW_PATH)
+    narrow = [p for p in push_paths(WORKFLOW_PATH) + push_scope.CODE_GLOBS
               if p.startswith("config/") and p not in {"config/**", "config/*"}]
     assert narrow == [], f"re-narrowed config gating: {narrow}"
 
 
 def test_every_shipped_config_file_matches_the_gate():
-    # `case` patterns match `/` inside `*`, so `config/*` covers nested files too.
+    # Glob lanes match `/` inside `*`, so `config/*` covers nested files too.
     assert CONFIG_FILES, "config/ is empty; the gate assertions would be vacuous"
     assert all(name.startswith("config/") for name in CONFIG_FILES)
 
@@ -47,7 +58,7 @@ def test_code_and_tests_stay_gated():
     # retired in #539; executable code now lives under src/ and ops/.
     assert not (ROOT / "scripts").exists()
     for pattern in ("src/*", "tests/*"):
-        assert pattern in case_patterns(WORKFLOW_PATH)
+        assert pattern in push_scope.CODE_GLOBS
     for pattern in ("src/**", "ops/**", "tests/**"):
         assert pattern in push_paths(WORKFLOW_PATH)
 
@@ -57,9 +68,7 @@ def test_no_push_path_matches_nothing_in_the_checkout():
     # `site/` and left `assets/css/**`, `assets/js/**` and `index.html` behind:
     # they kept passing review because they read correctly, while every
     # stylesheet and script edit stopped triggering the workflow at all.
-    tracked = subprocess.run(
-        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
-    ).stdout.split()
+    tracked = _tracked()
     assert tracked, "empty checkout would make this assertion vacuous"
     dead = [
         pattern for pattern in push_paths(WORKFLOW_PATH)
@@ -68,64 +77,55 @@ def test_no_push_path_matches_nothing_in_the_checkout():
     assert dead == [], f"path filter matches no tracked file: {dead}"
 
 
-def _ui_and_plugin_regexes():
-    """The two lanes the `case` list does not cover — they use grep, not case."""
-    import re
-    found = re.findall(r"grep -Eq '([^']+)'", WORKFLOW)
-    assert len(found) >= 2, f"detector no longer greps for the ui/plugin lanes: {found}"
-    return found
-
-
-def test_detector_covers_every_push_trigger_path():
-    """A push path with no matching detector pattern is a gate that skips itself.
+def test_every_push_trigger_path_reaches_a_lane():
+    """A trigger path with no matching classifier pattern is a gate that skips itself.
 
     Both halves ran before #750 and both looked right in review: the trigger
-    listed `ops/**` and `skills/tavily-search/**`, and the `Detect code changes`
-    case list — whose own comment claims to be kept in sync with that trigger —
-    named neither. So a PR touching only `ops/` or the Tavily skill triggered
-    `validate`, matched nothing, skipped every Python step, and reported green in
-    seconds. That is the same shape as the dead `assets/css/**` filter below:
-    a gate that reads correctly and guards nothing.
+    listed `ops/**` and `skills/tavily-search/**`, and the inline case list —
+    whose own comment claimed to be kept in sync — named neither. So a PR
+    touching only those skipped the entire suite while `validate` reported
+    green in seconds. This is now behavioural: every tracked file under every
+    push-trigger glob must light up at least one lane in the real classifier.
     """
-    import re
+    import fnmatch as fm
 
-    tracked = subprocess.run(
-        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True,
-    ).stdout.split()
+    tracked = _tracked()
     assert tracked, "empty checkout would make this assertion vacuous"
-
-    covering = [p.replace("*", "*") for p in case_patterns(WORKFLOW_PATH)]
-    regexes = [re.compile(pattern) for pattern in _ui_and_plugin_regexes()]
-
-    def covered(name):
-        return (any(fnmatch(name, pattern) for pattern in covering)
-                or any(regex.search(name) for regex in regexes))
 
     uncovered = {}
     for path in push_paths(WORKFLOW_PATH):
-        matches = [name for name in tracked
-                   if fnmatch(name, path.replace("**", "*"))]
-        if matches and not any(covered(name) for name in matches):
+        matches = [name for name in tracked if fnmatch(name, path.replace("**", "*"))]
+        if matches and all(
+            not any(push_scope.classify([name]).values()) for name in matches
+        ):
             uncovered[path] = matches[:3]
     assert uncovered == {}, (
-        "these push-trigger paths reach no detector pattern, so a change confined "
+        "these push-trigger paths reach no classifier lane, so a change confined "
         f"to them runs no test: {uncovered}")
+
+
+def test_all_three_gates_read_the_one_classifier():
+    """Three inline copies of diff-classification bash are how #750 happened.
+
+    The detector, the lint scope and the CodeQL scope must all call
+    ops/ci/push_scope.py rather than carrying private copies of the patterns.
+    """
+    calls = WORKFLOW.count("ops/ci/push_scope.py")
+    assert calls >= 3, f"expected detector + lint + CodeQL to route through the classifier, found {calls}"
+    assert "grep -Eq '" not in WORKFLOW, (
+        "inline lane greps are back; the classifier owns the patterns")
 
 
 def test_the_heavy_lanes_are_not_gated_on_the_event_that_started_the_run():
     """#750: the browser contract and the DSH plugin gates could not run on master.
 
     Their conditions read `github.event_name == 'pull_request' && changes...`
-    while the `Detect code changes` step that feeds them was itself PR-only, so
-    on a master push the detector was skipped, the two conditions were false, and
-    the two most expensive gates in the repository never ran outside a PR. The
-    unit suite did run there — measured on run 31059122903 — which is why this
-    stayed invisible: `validate` was green and mostly busy.
+    while the detector that feeds them was itself PR-only, so on a master push
+    the detector was skipped, the two conditions were false, and the two most
+    expensive gates in the repository never ran outside a PR.
 
-    The detector now runs on every event, so the lanes read only its answer.
+    The detector runs on every event, so the lanes read only its answer.
     """
-    import re
-
     for lane in ("ui", "dsplugin", "code"):
         gates = re.findall(rf"if: .*steps\.changes\.outputs\.{lane} == 'true'", WORKFLOW)
         assert gates, f"no step gates on the {lane} lane any more"

--- a/tests/test_dashboard_artifact_gate_contract.py
+++ b/tests/test_dashboard_artifact_gate_contract.py
@@ -1,10 +1,10 @@
 """Contracts for the cheap dashboard-only master-push validation lane."""
 from pathlib import Path
 import re
+import sys
 
 from workflow_contract_helpers import (
     assert_validator_step,
-    case_patterns,
     push_paths,
     step_block,
     step_run,
@@ -13,19 +13,22 @@ from workflow_contract_helpers import (
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / '.github' / 'workflows'
-HARNESS = WORKFLOWS / 'ci.yml'
+CI = WORKFLOWS / 'ci.yml'
 GATE = WORKFLOWS / 'dashboard-artifact-gate.yml'
 DASHBOARD = 'assets/data/dashboard.json'
 OVERVIEW = 'assets/data/overview.json'
 CORE_OUTPUTS = [OVERVIEW, DASHBOARD]
 
+sys.path.insert(0, str(ROOT / 'ops' / 'ci'))
+import push_scope  # noqa: E402
+
 
 def test_dashboard_commits_leave_the_heavy_master_push_lane():
-    assert all(path not in push_paths(HARNESS) for path in CORE_OUTPUTS)
-    harness = HARNESS.read_text(encoding='utf-8')
-    assert re.search(r'^  pull_request:\s*$', harness, re.MULTILINE), (
+    assert all(path not in push_paths(CI) for path in CORE_OUTPUTS)
+    text = CI.read_text(encoding='utf-8')
+    assert re.search(r'^  pull_request:\s*$', text, re.MULTILINE), (
         'required validate context must still report for every PR')
-    assert all(path in case_patterns(HARNESS) for path in CORE_OUTPUTS), (
+    assert all(path in push_scope.CODE_GLOBS for path in CORE_OUTPUTS), (
         'core projection changes in a PR must still run the full regression suite')
 
 

--- a/tests/test_push_scope.py
+++ b/tests/test_push_scope.py
@@ -1,0 +1,145 @@
+"""Behavioural contract for ops/ci/push_scope.py — unit lanes plus the
+change-scenario matrix (#884 adversarial pass).
+
+The matrix encodes how CI must react to every recurring kind of change this
+repository actually receives: interactive PRs, the automation commits that
+land on master all day (coverage badge, scheduled scans, EOD archive, weekly
+review, screenshot refresh), the harness's daily brief commit, plugin edits,
+and pure noise. Each row pins BOTH halves of the decision:
+
+  lanes        what ops/ci/push_scope.py answers for that path set;
+  ci_triggers  whether the `push:` path filter in ci.yml starts a run at all,
+               recomputed from the YAML so the two halves cannot drift apart
+               silently.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "ci"))
+import push_scope  # noqa: E402
+
+
+def _ci_trigger_globs() -> list[str]:
+    text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    block = text.split("    paths:", 1)[1].split("\n  pull_request:", 1)[0]
+    return [line.strip().strip("-").strip().strip("'")
+            for line in block.splitlines()
+            if line.strip().startswith("- '")]
+
+
+def _ci_triggers(files: list[str]) -> bool:
+    globs = _ci_trigger_globs()
+    return any(
+        fnmatch(f, g.replace("**", "*")) for f in files for g in globs
+    )
+
+
+def _all_false():
+    return {"code": False, "ui": False, "dsplugin": False,
+            "workflows": False, "analysable": False}
+
+
+def _lanes(**overrides):
+    lanes = _all_false()
+    lanes.update(overrides)
+    return lanes
+
+
+SCENARIOS = [
+    pytest.param(
+        ["docs/operations/release.md", "README.md"],
+        # analysable is moot here: the trigger gate means ci.yml never starts,
+        # and the classifier only answers for ranges it is handed. It stays
+        # True because README/docs are outside the automation-data set —
+        # faithful to the ignore-list semantics this replaced.
+        _lanes(analysable=True), False,
+        id="docs-only PR or push: six contexts report, nothing heavy runs"),
+    pytest.param(
+        ["portfolio.json"],
+        _lanes(code=True, analysable=False), True,
+        id="automation price commit: full suite gates the money file, CodeQL skips"),
+    pytest.param(
+        [f"memory/2026-08-24-pre-open.md", "memory/2026-08-24-plan.json"],
+        _lanes(code=True, analysable=False), True,
+        id="daily brief commit (pre-open + plan): suite runs, CodeQL skips"),
+    pytest.param(
+        ["assets/data/sentiment.json", "assets/data/macro.json",
+         "assets/data/us_news_digest.json", "assets/data/coverage.json",
+         "assets/data/readme_metrics.json"],
+        _lanes(), False,
+        id="scheduled-scan payloads: zero CI (no loop from CI's own coverage commit)"),
+    pytest.param(
+        ["memory/archive/2026-W33.csv", "memory/weekly/2026-W34.md",
+         "memory/decisions.jsonl"],
+        _lanes(), False,
+        id="eod-archive / weekly-review / ledger commits: zero CI"),
+    pytest.param(
+        ["site/assets/shadow-backtest.png", "site/assets/social-card.png",
+         "site/assets/dsh-decision-mind.png"],
+        # analysable moot: the push-path filter never starts a run for PNGs.
+        _lanes(analysable=True), False,
+        id="screenshot-refresh Sunday commit (PNGs are not css/js): zero CI"),
+    pytest.param(
+        ["examples/dsh/packages/clawock-dsh/src/store.ts"],
+        _lanes(dsplugin=True, analysable=True), True,
+        id="plugin-only master push: contracts run (the pre-#884 hole)"),
+    pytest.param(
+        ["site/assets/css/main.css"],
+        _lanes(code=True, ui=True, analysable=True), True,
+        id="stylesheet change: browser contract + suite"),
+    pytest.param(
+        [".github/workflows/pages.yml"],
+        _lanes(code=True, workflows=True, analysable=True), True,
+        id="workflow edit: lint + suite + analysis"),
+    pytest.param(
+        [".github/actions/clawock-playwright/action.yml"],
+        _lanes(code=True, analysable=True), True,
+        id="composite action edit: suite re-runs on master too"),
+    pytest.param(
+        ["src/clawock/portfolio/fx.py", "assets/data/sentiment.json"],
+        _lanes(code=True, analysable=True), True,
+        id="mixed code+data: suite runs, analysis runs"),
+    pytest.param(
+        ["monitor_state.json", "logs/x.log"],
+        _lanes(), False,
+        id="runtime state/logs: zero CI"),
+    pytest.param(
+        [], _all_false(), False,
+        id="empty diff: every lane false"),
+]
+
+
+@pytest.mark.parametrize("files,expected_lanes,expected_trigger", SCENARIOS)
+def test_change_scenarios(files, expected_lanes, expected_trigger):
+    assert push_scope.classify(list(files)) == expected_lanes
+    assert _ci_triggers(list(files)) == expected_trigger, (
+        "the classifier and the ci.yml push-path list disagree about this "
+        "scenario — fix whichever half is wrong")
+
+
+def test_everything_flag_reports_all_lanes():
+    assert all(push_scope.EVERYTHING.values())
+
+
+def test_main_prints_github_output_pairs(capsys):
+    assert push_scope.main(["--everything"]) == 0
+    out = capsys.readouterr().out
+    pairs = dict(line.split("=") for line in out.strip().splitlines())
+    assert pairs == {k: "true" for k in _all_false()}
+
+
+def test_main_json_mode(monkeypatch, capsys):
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO("src/x.py\nREADME.md\n"))
+    assert push_scope.main(["--files-from", "-", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] is True
+    assert payload["ui"] is False
+    assert payload["analysable"] is True

--- a/tests/test_site_tools_contract.py
+++ b/tests/test_site_tools_contract.py
@@ -20,6 +20,9 @@ from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ops" / "ci"))
+import push_scope  # noqa: E402
+
 ROOT = Path(__file__).resolve().parents[1]
 TOOLS = ROOT / "site" / "tools"
 SHOOT = (TOOLS / "shoot_dashboard.js").read_text(encoding="utf-8")
@@ -130,8 +133,8 @@ def test_the_tooling_is_inside_the_regression_gate():
     """The gate this file exists to close — assert the wiring, not just the tests."""
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
     assert "'site/tools/**'" in workflow, "site/tools is outside the push trigger"
-    assert "site/tools/*)" in workflow or "|site/tools/*" in workflow, (
-        "site/tools is outside the Detect code changes lanes")
+    assert "site/tools/*" in push_scope.CODE_GLOBS, (
+        "site/tools is outside the classifier's code lane")
     assert "find src ops site/tools" in workflow, (
         "the Python syntax check does not reach site/tools")
     assert "node --check" in workflow, "the two JS tools are not syntax-checked"

--- a/tests/test_smoke_fx.py
+++ b/tests/test_smoke_fx.py
@@ -1,0 +1,49 @@
+"""The FX smoke probe must fail loudly on an unusable answer, quietly pass on
+a good one — its job is continue-on-error, but a probe that cannot assert is
+worth nothing."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "ci"))
+import smoke_fx  # noqa: E402
+
+
+def _runner(payload: str):
+    def fake(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+    return fake
+
+
+def test_a_good_answer_names_the_source(capsys):
+    payload = json.dumps({"rate": 7.82, "source": "exdev"})
+    assert smoke_fx.check(runner=_runner(payload)) == "exdev"
+
+
+@pytest.mark.parametrize("payload", [
+    json.dumps({"rate": 12.0, "source": "bad"}),
+    json.dumps({"source": "no-rate"}),
+    "not json",
+])
+def test_an_unusable_answer_exits_nonzero(payload):
+    with pytest.raises((AssertionError, KeyError, json.JSONDecodeError)):
+        smoke_fx.check(runner=_runner(payload))
+
+
+def test_main_reports_failure_without_a_traceback(monkeypatch, capsys):
+    monkeypatch.setattr(
+        smoke_fx, "check", lambda runner=None: (_ for _ in ()).throw(AssertionError("rate out of range")))
+    assert smoke_fx.main() == 1
+    assert "FX smoke FAILED" in capsys.readouterr().err
+
+
+def test_main_reports_the_source(monkeypatch, capsys):
+    monkeypatch.setattr(smoke_fx, "check", lambda runner=None: "tencent")
+    assert smoke_fx.main() == 0
+    assert "FX OK: tencent" in capsys.readouterr().out

--- a/tests/workflow_contract_helpers.py
+++ b/tests/workflow_contract_helpers.py
@@ -15,13 +15,6 @@ def push_paths(workflow: Path) -> list[str]:
     return re.findall(r"^\s*-\s*'([^']+)'", block, re.MULTILINE)
 
 
-def case_patterns(workflow: Path, step_name: str = 'Detect code changes') -> list[str]:
-    detect = workflow.read_text(encoding='utf-8').split(step_name, 1)[1]
-    line = next(ln for ln in detect.splitlines()
-                if ln.strip().endswith(')') and '|' in ln)
-    return line.strip().rstrip(')').split('|')
-
-
 def steps(workflow: Path):
     lines = workflow.read_text().splitlines()
     return [


### PR DESCRIPTION
Closes #884（对抗审查跟进）

## 审查结论：裸命令 → 脚本

#885 合并后 ci.yml 里仍留着三份内联 diff 分类 bash（detector / lint scope / CodeQL scope）+ 一个 `python -c` 一行流 FX 探针——这正是 #750「三份拷贝各自漂移」的病灶。本 PR：

- 新增 **`ops/ci/push_scope.py`**：唯一分类器，输出五个 lane（`code`/`ui`/`dsplugin`/`workflows`/`analysable`）。glob 用 fnmatchcase（与原 shell case 的跨 `/` 语义一致），UI/DSH 正则逐字保留。三处门控全部改为一行调用；undiffable range 由脚本内部 fail-toward-running。
- 新增 **`ops/ci/smoke_fx.py`**：FX 探针脚本化，失败带原因退出。
- **行为化测试替代 YAML 正则解析**：`test_ci_trigger_paths.py` 现在驱动分类器本体断言「每条 push 触发路径至少点亮一个 lane」；helpers 里的 `case_patterns()` 文本解析删除。

## 场景矩阵（钉进 tests/test_push_scope.py，防回归）

| 改动 | 触发 CI? | validate 重活 | CodeQL |
|---|---|---|---|
| docs-only | ✗（PR 上六上下文照常上报，重步骤全跳） | ✗ | — |
| portfolio.json（每日自动价格提交） | ✓ | 全套件守账本 | ✗ 跳过 |
| 每日简报 pre-open+plan 提交 | ✓ | ✓ | ✗ |
| 定时扫描 payload（sentiment/macro/news/**coverage.json**）| ✗ 零触发，CI 自己的 coverage 回写不回环 | ✗ | — |
| EOD 归档/周报/ledger 提交 | ✗ | ✗ | — |
| 截图刷新周日 PNG+README 提交 | ✗（PNG 不在 css/js 清单） | ✗ | — |
| 插件-only 提交 | ✓（#884 前是空洞） | 插件契约跑 | ✓ |
| CSS/UI、workflow、composite 编辑 | ✓ | ✓/✓/✓ | ✓ |
| monitor_state/logs | ✗ | ✗ | — |

合并前实测佐证：eacde823 落地后 master 上只有合并提交本身一次 CI 运行，期间所有自动化数据提交零误触发。

## 对抗审查当场抓到的 bug

分类器首版 `analysable` 初值写成 `bool(files)` 且循环里只置 True——任何非空 diff 都判为可分析，「纯数据提交跳过分析」静默失效。场景矩阵第一条就红了，已修正为 `any(非数据路径)`。这正是把逻辑从 YAML 内联搬进可单测脚本的直接收益。

## 本地验证

actionlint 1.7.12 全绿；定向 pytest 167 通过（含新 push_scope/smoke_fx/场景矩阵）；generate_cron_docs --check 通过。
