### PR TITLE
feat(dashboard): 首屏主数带涨跌色 + 右侧缩略走势 + 统计轨去重 8→6

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -94,7 +94,10 @@
 
   /* 字阶（#880）：全站只有这 8 档，禁裸 px 字号。
      mono 只用于数字与代码，sans 用于所有文字。 */
-  --fs-display: clamp(30px, 3.4vw, 48px);
+  /* 48px 在 1440 宽、240 高的整幅卡片里读起来是「一个统计数字」而不是
+     标题；上限提到 64，下限不动（390px 上仍是 30px，主数禁断行的约束
+     没有变松）。 */
+  --fs-display: clamp(30px, 4.4vw, 64px);
   --fs-xxl: 26px;
   --fs-xl: 19px;
   --fs-lg: 15px;
@@ -2058,10 +2061,65 @@
     background: radial-gradient(closest-side, var(--bg-glow), transparent 78%);
     pointer-events: none;
   }
+  /* 宽屏两栏：文字一栏 + 缩略走势一栏。主数左对齐后卡片右侧本来是一大片
+     空白 —— 那不是留白，是构图没写完（主数越大越明显）。右栏放的不是第二
+     张图，是同一个数的历史形状。 */
   .hero-deck-lead {
-    padding: 26px 24px 20px;
+    padding: 32px 28px 26px;
     position: relative;
+    display: grid; grid-template-columns: minmax(0, 1fr);
   }
+  @media (min-width: 1024px) {
+    .hero-deck-lead {
+      grid-template-columns: minmax(0, auto) minmax(260px, 1fr);
+      column-gap: 44px; align-items: center;
+    }
+  }
+  .hero-deck-copy { min-width: 0; }
+
+  /* 缩略走势：纯形状，没有坐标轴/刻度/图例。高度由 CSS 固定占住，数据没到
+     或点数不足时容器仍然是这个高度 —— 不占的话它一到就是一次 CLS。 */
+  .hero-spark {
+    position: relative; height: 56px; margin-top: 18px; min-width: 0;
+  }
+  @media (min-width: 1024px) {
+    .hero-spark { height: 108px; margin-top: 0; }
+  }
+  .hero-spark-svg { display: block; width: 100%; height: 100%; }
+  .hero-spark-svg.pos { color: var(--positive); }
+  .hero-spark-svg.neg { color: var(--negative); }
+  .hero-spark-svg.flat { color: var(--text-tertiary); }
+  /* 面积以零轴为界分色（渐变在 zeroY 处硬停）：零上用涨色、零下用跌色。
+     用单一色填满会把曲线前半段的盈利期涂成亏损色 —— 图会说谎。 */
+  .hs-area { opacity: .9; }
+  .hs-up { stop-color: var(--positive); stop-opacity: .14; }
+  .hs-down { stop-color: var(--negative); stop-opacity: .14; }
+  .hs-zero { stroke: var(--border-strong); stroke-width: 1; vector-effect: non-scaling-stroke; }
+  /* viewBox 被 preserveAspectRatio="none" 拉伸，描边必须 non-scaling 才不会
+     在宽屏上被横向拉成粗细不匀的一条。 */
+  /* 线本身取中性色：正负已经由填充和主数说清楚了，再给线上色就会出现
+     「红线压在绿色盈利区上」这种自相矛盾的画面。 */
+  .hs-line {
+    fill: none; stroke: var(--text-secondary); stroke-width: 1.75;
+    stroke-linejoin: round; stroke-linecap: round;
+    vector-effect: non-scaling-stroke;
+  }
+  /* 端点用 DOM 元素而不是 SVG 圆：同样因为 preserveAspectRatio="none"，
+     SVG 里的正圆会被压成椭圆。 */
+  .hero-spark-dot {
+    position: absolute; width: 7px; height: 7px; border-radius: 50%;
+    transform: translate(-50%, -50%); pointer-events: none;
+    box-shadow: 0 0 0 3px var(--surface-1);
+  }
+  .hero-spark-dot.pos { background: var(--positive); }
+  .hero-spark-dot.neg { background: var(--negative); }
+  .hero-spark-dot.flat { background: var(--text-tertiary); }
+  /* 主数以前恒定 var(--text)：`.hero-deck-pnl` 和 `.pos/.neg` 同为一个类，
+     按源序前者赢 —— 于是全页最大的那个数字是唯一一个不带涨跌色的数字，
+     而它正下方那行三个小数字全都带色。全站规矩是「颜色只留涨跌」，
+     这里就是最该用掉那次配额的地方。显式提到 0,2,0 特异度。 */
+  .hero-deck-pnl.pos { color: var(--positive); }
+  .hero-deck-pnl.neg { color: var(--negative); }
   .hero-deck-pnl {
     margin-top: 12px; color: var(--text); font: 700 var(--fs-display)/1 var(--mono);
     letter-spacing: var(--tr-display); font-variant-numeric: tabular-nums;
@@ -2082,9 +2140,21 @@
   /* 折行后行首不留孤立的间隔点 */
   .hero-deck-sub .hds-seg { display: inline-flex; align-items: baseline; gap: 5px; }
   .hero-deck-sub b { font-weight: 700; color: var(--text); }
+  .hero-deck-line {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 10px 28px; flex-wrap: wrap;
+  }
   .hero-deck-fx {
     margin-top: 9px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.4 var(--mono);
     overflow-wrap: anywhere;
+  }
+  /* 同一行时不要再压 9px 的上边距，两段按基线对齐 */
+  .hero-deck-line > .hero-deck-fx { margin-top: 0; text-align: right; }
+  @media (max-width: 1023px) {
+    /* 换行之后它又是「下面一行」，把间距还回去 */
+    .hero-deck-line { gap: 0; }
+    .hero-deck-line > .hero-deck-fx { margin-top: 9px; text-align: left; }
+    .hero-deck-line > * { flex: 1 1 100%; }
   }
   /* 首屏最大的一次跳：8 格统计轨在数据到达前是空的（高 1px），到达后
      撑到 85px —— 实测这一下就占了整页 CLS 0.26 里的大头，而它每次加载
@@ -2092,7 +2162,7 @@
      行数是固定的（标签 / 值 / 变化 / 备注），不会因为数据长短再变。
      min-height 而不是 height：真渲染出来更高时不裁。 */
   .hero-rail {
-    display: grid; grid-template-columns: repeat(8, minmax(0, 1fr));
+    display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
     border-top: 1px solid var(--border-subtle);
     min-height: 85px;
   }
@@ -2388,7 +2458,7 @@
   .hl-chip .hl-ic { align-self: center; }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 170px; }
+    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 168px; }
     .overview-equity, .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
@@ -2401,10 +2471,10 @@
     .overview-command > .hero-gold-card { width: 100%; min-width: 0; }
     .hero-deck { grid-template-columns: minmax(0, 1fr); }
     .hero-deck-lead { border-right: 0; }
-    /* 317 而不是 312：430-767px 这一段「主动 call · n=76 · 9 未能核验」那格
-       的备注折成两行，比 390px 窄档高 5px。取上界，宁可窄档多留 5px 空白
-       也不要宽档跳一下。 */
-    .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 317px; }
+    /* 252 而不是 248：430-767px 这一段「主动 call · n=76 · 9 未能核验」那格
+       的备注折成两行，比 390px 窄档高 4px。取上界，宁可窄档多留 4px 空白
+       也不要宽档跳一下。（去掉两格重复后是 3 行，不是原来的 4 行。） */
+    .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 252px; }
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
     }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -728,8 +728,11 @@
         usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
       cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
         hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
-      cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
-      cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),
+      // 「已实现 · USD-eq」和「浮动 · USD-eq」曾经在这里各占一格，而它们和
+      // 主数下面那行副行是**逐字相同**的两个数（跨 tab 数字差集实测：这两个
+      // 值在全站只出现在这两处，副行一处、统计轨一处，相距 30px）。同一个
+      // 数字在一屏内说两遍不是「信息更全」，是把八格里的两格用掉了。
+      // 副行保留它们，这里不再重复。
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -740,6 +743,76 @@
         + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
         m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
     ].join("");
+
+    renderHeroSpark();
+  }
+
+  // 首屏缩略走势：主数（总盈亏 = 已实现 + 浮动）自己的历史。
+  // 口径必须和下面那张 Equity Curve 的「总利润」线**同源同算法**，否则一屏里
+  // 两条线画同一件事却形状不同 —— 所以这里照抄 charts.js 的合并视图逻辑：
+  // 同一日期只留一条、连续两条属于同一交易时段的只留后一条（美股时段跨港股
+  // 午夜会落进两个港股日期，见 openclaw-us-crossday-double-count）。
+  function heroProfitSeries() {
+    const fx = safe(DATA, "fx", "usdhkd");
+    if (!fx) return [];
+    const snaps = (safe(DATA, "overview_equity") || safe(DATA, "snapshots") || [])
+      .filter(s => s.us_total_value != null || s.hk_total_value != null);
+    const byDate = new Map();
+    snaps.forEach(s => byDate.set(s.date, s));
+    let series = Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
+    series = series.filter((s, i) => {
+      const next = series[i + 1];
+      if (!next) return true;
+      if (s.us_asof && s.hk_asof && next.us_asof && next.hk_asof) {
+        return !(s.us_asof === next.us_asof && s.hk_asof === next.hk_asof);
+      }
+      return true;
+    });
+    return series
+      .map(s => (s.us_profit == null || s.hk_profit == null) ? null : s.us_profit + s.hk_profit / fx)
+      .filter(v => v != null && isFinite(v));
+  }
+
+  function renderHeroSpark() {
+    const host = document.getElementById("hero-spark");
+    if (!host) return;
+    const vals = heroProfitSeries();
+    // 两点以下画不出趋势。容器高度由 CSS 占住，所以这里清空不会让页面跳。
+    if (vals.length < 3) { host.replaceChildren(); return; }
+
+    const W = 1000, H = 200, PAD = 6;            // viewBox 坐标，实际尺寸由 CSS 给
+    const lo = Math.min(...vals, 0), hi = Math.max(...vals, 0);
+    const span = (hi - lo) || 1;
+    const x = i => PAD + i * (W - PAD * 2) / (vals.length - 1);
+    const y = v => PAD + (hi - v) * (H - PAD * 2) / span;
+    const line = vals.map((v, i) => `${i ? "L" : "M"}${x(i).toFixed(1)} ${y(v).toFixed(1)}`).join(" ");
+    const zeroY = y(0);
+    const area = `${line} L${x(vals.length - 1).toFixed(1)} ${zeroY.toFixed(1)} L${x(0).toFixed(1)} ${zeroY.toFixed(1)} Z`;
+    const last = vals[vals.length - 1];
+    const tone = last > 0 ? "pos" : last < 0 ? "neg" : "flat";
+
+    // 填充按**零轴**分色，不是按最后一个值分色：这条曲线前半段是赚的、后半段
+    // 才转亏，用单一色填满会把一段盈利期涂成亏损色 —— 图会说谎。硬停在 zeroY
+    // 的渐变正好在零轴处换色，不需要 clipPath。
+    const stop = Math.max(0, Math.min(1, zeroY / H));
+    const gid = "hs-grad";
+    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lo, "USD")}`
+      + `，最高 ${heroMoney(hi, "USD")}，当前 ${heroMoney(last, "USD")}`;
+    host.innerHTML =
+      `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
+      + ` role="img" aria-label="${escapeHtml(label)}">`
+      + `<defs><linearGradient id="${gid}" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="0" y2="1">`
+      + `<stop offset="0" class="hs-up"/><stop offset="${stop.toFixed(4)}" class="hs-up"/>`
+      + `<stop offset="${stop.toFixed(4)}" class="hs-down"/><stop offset="1" class="hs-down"/>`
+      + `</linearGradient></defs>`
+      + `<path class="hs-area" d="${area}" fill="url(#${gid})"/>`
+      + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
+      + `<path class="hs-line" d="${line}"/>`
+      + `</svg>`
+      // 端点标记不能用 SVG 圆：preserveAspectRatio="none" 会把它压成椭圆。
+      // 用绝对定位的 DOM 点，按百分比放，形状不受拉伸影响。
+      + `<i class="hero-spark-dot ${tone}" style="left:${(x(vals.length - 1) / W * 100).toFixed(2)}%;`
+      + `top:${(y(last) / H * 100).toFixed(2)}%"></i>`;
   }
 
   // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -718,8 +718,11 @@
         usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
       cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
         hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
-      cell("已实现 · USD-eq", heroMoney(realUsd, "USD"), "", pnlClass(realUsd)),
-      cell("浮动 · USD-eq", heroMoney(unrealUsd, "USD"), "", pnlClass(unrealUsd)),
+      // 「已实现 · USD-eq」和「浮动 · USD-eq」曾经在这里各占一格，而它们和
+      // 主数下面那行副行是**逐字相同**的两个数（跨 tab 数字差集实测：这两个
+      // 值在全站只出现在这两处，副行一处、统计轨一处，相距 30px）。同一个
+      // 数字在一屏内说两遍不是「信息更全」，是把八格里的两格用掉了。
+      // 副行保留它们，这里不再重复。
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -730,6 +733,77 @@
         + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
         m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
     ].join("");
+
+    renderHeroSpark();
+  }
+
+
+  // 首屏缩略走势：主数（总盈亏 = 已实现 + 浮动）自己的历史。
+  // 口径必须和下面那张 Equity Curve 的「总利润」线**同源同算法**，否则一屏里
+  // 两条线画同一件事却形状不同 —— 所以这里照抄 charts.js 的合并视图逻辑：
+  // 同一日期只留一条、连续两条属于同一交易时段的只留后一条（美股时段跨港股
+  // 午夜会落进两个港股日期，见 openclaw-us-crossday-double-count）。
+  function heroProfitSeries() {
+    const fx = safe(DATA, "fx", "usdhkd");
+    if (!fx) return [];
+    const snaps = (safe(DATA, "overview_equity") || safe(DATA, "snapshots") || [])
+      .filter(s => s.us_total_value != null || s.hk_total_value != null);
+    const byDate = new Map();
+    snaps.forEach(s => byDate.set(s.date, s));
+    let series = Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
+    series = series.filter((s, i) => {
+      const next = series[i + 1];
+      if (!next) return true;
+      if (s.us_asof && s.hk_asof && next.us_asof && next.hk_asof) {
+        return !(s.us_asof === next.us_asof && s.hk_asof === next.hk_asof);
+      }
+      return true;
+    });
+    return series
+      .map(s => (s.us_profit == null || s.hk_profit == null) ? null : s.us_profit + s.hk_profit / fx)
+      .filter(v => v != null && isFinite(v));
+  }
+
+  function renderHeroSpark() {
+    const host = document.getElementById("hero-spark");
+    if (!host) return;
+    const vals = heroProfitSeries();
+    // 两点以下画不出趋势。容器高度由 CSS 占住，所以这里清空不会让页面跳。
+    if (vals.length < 3) { host.replaceChildren(); return; }
+
+    const W = 1000, H = 200, PAD = 6;            // viewBox 坐标，实际尺寸由 CSS 给
+    const lo = Math.min(...vals, 0), hi = Math.max(...vals, 0);
+    const span = (hi - lo) || 1;
+    const x = i => PAD + i * (W - PAD * 2) / (vals.length - 1);
+    const y = v => PAD + (hi - v) * (H - PAD * 2) / span;
+    const line = vals.map((v, i) => `${i ? "L" : "M"}${x(i).toFixed(1)} ${y(v).toFixed(1)}`).join(" ");
+    const zeroY = y(0);
+    const area = `${line} L${x(vals.length - 1).toFixed(1)} ${zeroY.toFixed(1)} L${x(0).toFixed(1)} ${zeroY.toFixed(1)} Z`;
+    const last = vals[vals.length - 1];
+    const tone = last > 0 ? "pos" : last < 0 ? "neg" : "flat";
+
+    // 填充按**零轴**分色，不是按最后一个值分色：这条曲线前半段是赚的、后半段
+    // 才转亏，用单一色填满会把一段盈利期涂成亏损色 —— 图会说谎。硬停在 zeroY
+    // 的渐变正好在零轴处换色，不需要 clipPath。
+    const stop = Math.max(0, Math.min(1, zeroY / H));
+    const gid = "hs-grad";
+    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lo, "USD")}`
+      + `，最高 ${heroMoney(hi, "USD")}，当前 ${heroMoney(last, "USD")}`;
+    host.innerHTML =
+      `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
+      + ` role="img" aria-label="${escapeHtml(label)}">`
+      + `<defs><linearGradient id="${gid}" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="0" y2="1">`
+      + `<stop offset="0" class="hs-up"/><stop offset="${stop.toFixed(4)}" class="hs-up"/>`
+      + `<stop offset="${stop.toFixed(4)}" class="hs-down"/><stop offset="1" class="hs-down"/>`
+      + `</linearGradient></defs>`
+      + `<path class="hs-area" d="${area}" fill="url(#${gid})"/>`
+      + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
+      + `<path class="hs-line" d="${line}"/>`
+      + `</svg>`
+      // 端点标记不能用 SVG 圆：preserveAspectRatio="none" 会把它压成椭圆。
+      // 用绝对定位的 DOM 点，按百分比放，形状不受拉伸影响。
+      + `<i class="hero-spark-dot ${tone}" style="left:${(x(vals.length - 1) / W * 100).toFixed(2)}%;`
+      + `top:${(y(last) / H * 100).toFixed(2)}%"></i>`;
   }
 
   // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，

--- a/site/index.html
+++ b/site/index.html
@@ -157,11 +157,22 @@ layout: null
            指挥台是整页唯一的毛玻璃面：主数 + 一行拆解 + 一条低对比统计轨。 -->
       <div class="card hero-deck">
         <div class="hero-deck-lead">
+          <div class="hero-deck-copy">
           <div class="overview-card-kicker">总盈亏 · USD 等值</div>
           <div class="hero-deck-pnl" id="hero-pnl">—</div>
-          <div class="hero-deck-sub" id="hero-sub">—</div>
-          <div class="hero-deck-fx" id="fx-rate-usd">—</div>
-          <span class="overview-fx-mirror" id="fx-rate-hkd" aria-hidden="true"></span>
+          <!-- 拆解行与出处行在宽屏共用一行：主数左对齐后，卡片右侧本来是一大片
+               空白，读起来像「没填满的表格格子」而不是留白。出处行靠右锚住右缘，
+               顺带省掉一行高度。窄屏 flex-wrap 自然回到上下两行。 -->
+          <div class="hero-deck-line">
+            <div class="hero-deck-sub" id="hero-sub">—</div>
+            <div class="hero-deck-fx" id="fx-rate-usd">—</div>
+          </div>
+            <span class="overview-fx-mirror" id="fx-rate-hkd" aria-hidden="true"></span>
+          </div>
+          <!-- 主数的历史，不是第二张图：同一个「总盈亏」口径画成纯形状（无坐标轴、
+               无刻度、无图例），回答大数字回答不了的那半个问题——它是一路跌下来的，
+               还是刚从更深的地方爬回来的。完整可交互的曲线仍在下面那张卡里。 -->
+          <div class="hero-spark" id="hero-spark"></div>
         </div>
         <div class="hero-rail" id="hero-rail"></div>
       </div>

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -770,11 +770,35 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     await context.close();
   }
 
+  // — 统计轨不得重复副行已经给过的数字 —
+  // 「已实现 · USD-eq」和「浮动 · USD-eq」曾各占一格，而它们和主数下面那行
+  // 是逐字相同的两个值，相距 30px。同一个数字在一屏内说两遍不是信息更全。
+  {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await context.newPage();
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    const dup = await page.evaluate(() => {
+      const sub = document.getElementById("hero-sub").textContent.replace(/\s+/g, "");
+      return [...document.querySelectorAll(".hero-rail-cell")]
+        .map(cell => ({
+          k: cell.querySelector(".hero-rail-k")?.textContent.trim(),
+          // 只比「值」本身，不含它自己的变化幅度：变化幅度是这一格独有的。
+          v: (cell.querySelector(".hero-rail-v")?.firstChild?.textContent || "").trim(),
+        }))
+        .filter(c => c.v && sub.includes(c.v.replace(/\s+/g, "")));
+    });
+    assert.deepEqual(dup, [],
+      "a hero rail cell restates a number the sub-line already shows");
+    await context.close();
+  }
+
   // — 首屏统计轨必须自己占住高度 —
   // 数据到达前 #hero-rail 是空的。在给它 min-height 之前它高 1px，填满后
   // 85px（桌面），每次加载都跳一次 —— 实测这一下就是整页 CLS 的大头
   // (0.26 -> 0.04)。这里量的是「预留 == 实测」，比断言一个 CLS 数字稳。
-  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 8]]) {
+  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 6]]) {
     const context = await browser.newContext({ viewport: { width, height: 900 } });
     const page = await context.newPage();
     await stubLiveOrigin(page);
@@ -796,6 +820,59 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     assert.equal(after.cols, expectCols, `hero rail column count changed at ${width}px`);
     assert.equal(reserved, after.height,
       `hero rail shifts by ${after.height - reserved}px when data lands at ${width}px`);
+    await context.close();
+  }
+
+  // — 首屏缩略走势：必须画的是主数自己，而且必须由首帧 bundle 画出来 —
+  // 这条走势线在 dashboard.hero.js（首屏加载的那份）和 dashboard.render.js
+  // 之间是手工双份。本轮第一次实现时只落进了 render.js，于是生产路径上
+  // 它根本不存在，而页面零报错。这里在**没有进过任何详情 tab**的状态下断言，
+  // 走的就是首帧那条路。
+  {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await context.newPage();
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "domcontentloaded" });
+    // 数据到达前容器就得占住高度，否则它一画出来就是一次 CLS。
+    const reserved = await page.evaluate(() =>
+      Math.round(document.getElementById("hero-spark").getBoundingClientRect().height));
+    assert(reserved > 40, `hero spark reserves no height before data (${reserved}px)`);
+    await waitForData(page);
+    await page.waitForSelector(".hero-spark-svg", { timeout: 5000 });
+
+    const spark = await page.evaluate(() => {
+      const host = document.getElementById("hero-spark");
+      const svg = host.querySelector(".hero-spark-svg");
+      const stops = [...svg.querySelectorAll("linearGradient stop")]
+        .map(s => ({ offset: s.getAttribute("offset"), cls: s.getAttribute("class") }));
+      return {
+        height: Math.round(host.getBoundingClientRect().height),
+        label: svg.getAttribute("aria-label") || "",
+        points: (svg.querySelector(".hs-line")?.getAttribute("d") || "").split("L").length,
+        stops,
+        headline: document.getElementById("hero-pnl").textContent.trim(),
+        tone: svg.classList.contains("neg") ? "neg"
+          : svg.classList.contains("pos") ? "pos" : "flat",
+        dotTone: host.querySelector(".hero-spark-dot")?.className || "",
+      };
+    });
+
+    assert.equal(spark.height, reserved,
+      `hero spark shifts by ${spark.height - reserved}px when it draws`);
+    assert(spark.points > 10, `hero spark drew only ${spark.points} points`);
+    // 画的必须是主数本身：aria-label 的「当前」值要和大数字逐字相同。
+    // 不比对的话，这条线画成「账面市值」「净值」都不会有人发现。
+    const current = /当前\s*(\S+)$/.exec(spark.label);
+    assert(current, `hero spark aria-label has no 当前 value: ${spark.label}`);
+    assert.equal(current[1], spark.headline,
+      "hero spark does not end at the headline number — it is plotting a different series");
+    // 填充必须在零轴分色，否则曲线里赚钱的那一段会被涂成亏损色。
+    assert.deepEqual(spark.stops.map(s => s.cls), ["hs-up", "hs-up", "hs-down", "hs-down"],
+      "hero spark fill is not split at the zero axis");
+    assert.equal(spark.stops[1].offset, spark.stops[2].offset,
+      "hero spark gradient does not hard-stop at the zero axis");
+    assert(spark.dotTone.includes(spark.tone),
+      `hero spark endpoint dot tone (${spark.dotTone}) disagrees with the curve (${spark.tone})`);
     await context.close();
   }
 

--- a/tests/test_dashboard_bundle_parity.py
+++ b/tests/test_dashboard_bundle_parity.py
@@ -1,0 +1,109 @@
+"""`dashboard.hero.js` 与 `dashboard.render.js` 是手工维护的两份实现。
+
+首屏只加载 hero.js（轻量首帧），进详情 tab 才拉 render.js，两边有大量同名
+同职责的函数。历史上这条「改了一份忘了另一份」反复出现过：2026-08-24 这轮
+里，`renderHeroSpark` 只落进 render.js，于是首屏那条缩略走势线在生产路径上
+根本不存在，而页面不报错、测试也不红 —— 典型的「源码里对、生产里死」。
+
+这条闸是**棘轮**：当下已经分叉的函数登记在 ALLOWED_DIVERGENT 里，其余同名
+函数必须逐字相同。名单只准变短：某个函数被重新对齐之后，它必须从名单里
+删掉，否则这条测试会失败。这样它不会因为历史包袱而失效。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HERO = ROOT / "site" / "assets" / "js" / "dashboard.hero.js"
+RENDER = ROOT / "site" / "assets" / "js" / "dashboard.render.js"
+
+# 已知分叉（2026-08-24 建闸时的现状）。hero.js 是首帧轻量实现，其中
+# render / renderTab / refreshTab 的差异是设计使然；其余五个是历史漂移，
+# 修一个删一行。**只准删，不准加** —— 加一行就等于默许了一次新的漂移。
+ALLOWED_DIVERGENT = {
+    "computeWatchRows",
+    "refreshTab",
+    "render",
+    "renderHonesty",
+    "renderRiskGuardrail",
+    "renderTab",
+    "renderTodayHighlights",
+    "syncDeskRail",
+}
+
+_DECL = re.compile(r"^  function ([A-Za-z_$][\w$]*)\s*\(")
+
+
+def _top_level_functions(path: Path) -> dict[str, str]:
+    """顶层（两空格缩进）函数声明 -> 函数体文本。
+
+    这两个文件都是没有 IIFE 包裹的经典脚本，顶层函数一律是 `  function x(`
+    开头、`  }` 单独一行结尾，缩进本身就是可靠的边界。不引第三方 JS 解析器
+    是刻意的：这条闸要能在最小依赖下跑。
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+    out: dict[str, str] = {}
+    i = 0
+    while i < len(lines):
+        match = _DECL.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        end = i + 1
+        while end < len(lines) and lines[end] != "  }":
+            end += 1
+        out[match.group(1)] = "\n".join(lines[i:end + 1])
+        i = end + 1
+    return out
+
+
+@pytest.fixture(scope="module")
+def bundles() -> tuple[dict[str, str], dict[str, str]]:
+    hero, render = _top_level_functions(HERO), _top_level_functions(RENDER)
+    # 解析器本身要能自证：两个文件都必须解出足够多的函数，否则一旦缩进
+    # 风格变了，这条闸会静默地什么都不检查。
+    assert len(hero) > 20, f"parsed only {len(hero)} functions from {HERO.name}"
+    assert len(render) > 40, f"parsed only {len(render)} functions from {RENDER.name}"
+    return hero, render
+
+
+def test_shared_functions_are_byte_identical(bundles):
+    hero, render = bundles
+    shared = sorted(set(hero) & set(render))
+    assert shared, "the two bundles share no function names — did the parser break?"
+    drifted = [
+        name for name in shared
+        if name not in ALLOWED_DIVERGENT and hero[name] != render[name]
+    ]
+    assert drifted == [], (
+        "these functions exist in both dashboard bundles but no longer match: "
+        f"{drifted}. 改了一份就要改另一份 —— 首屏走 hero.js，详情 tab 走 "
+        "render.js，只改一份的后果是生产路径上功能直接不存在。"
+    )
+
+
+def test_allowlist_only_shrinks(bundles):
+    hero, render = bundles
+    shared = set(hero) & set(render)
+    reconciled = sorted(
+        name for name in ALLOWED_DIVERGENT
+        if name in shared and hero[name] == render[name]
+    )
+    assert reconciled == [], (
+        f"these are identical again and must be removed from ALLOWED_DIVERGENT: {reconciled}"
+    )
+    stale = sorted(ALLOWED_DIVERGENT - shared)
+    assert stale == [], (
+        f"ALLOWED_DIVERGENT names a function that is no longer in both bundles: {stale}"
+    )
+
+
+def test_hero_spark_is_present_in_both(bundles):
+    """本轮的具体事故：这两个函数只落进了 render.js。"""
+    hero, render = bundles
+    for name in ("heroProfitSeries", "renderHeroSpark", "renderCommandDeck"):
+        assert name in hero, f"{name} missing from {HERO.name} (first-paint bundle)"
+        assert name in render, f"{name} missing from {RENDER.name}"


### PR DESCRIPTION
kcn:「开屏不够吸引人，而且太多信息太密了。」量了一下：桌面首屏之上 29 个数字，
其中两个是**逐字重复**的。

## 主数以前是全页唯一不带涨跌色的数字

`.hero-deck-pnl` 写死 `color: var(--text)`，而它和 `.pos/.neg` 同为一个类，
按源序前者赢 —— 于是 63px 的主数是白的，而它正下方那行三个小数字全都带色。
全站规矩是「颜色只留涨跌」，这里就是最该用掉那次配额的地方。

同时把 `--fs-display` 上限 48→64：48px 在 1440 宽、240 高的整幅卡片里读起来是
「一个统计数字」，不是标题。下限不动（390px 仍 30px，主数禁断行的约束没变松）。

## 统计轨 8 → 6：去掉两格逐字重复

跨 tab 数字差集实测：「已实现 · USD-eq」= `+$3,273`、「浮动 · USD-eq」= `−$5,448`
这两个值在全站只出现在两处 —— 主数下面那行副行一处、统计轨一处，相距 30px。
同一个数字在一屏内说两遍不是信息更全，是把八格里的两格用掉了。副行保留它们。
其余六格（美股/港股/今日美股/今日港股/遵守率/自评 Brier）在别处都没有第二份，
一格没删。min-height 预留同步重算（6 格：85 / 168 / 252），各断点实测「预留 == 实测」。

## 右侧那片空白：放主数自己的历史

主数放大后，卡片右侧约 65% 的空白从「留白」变成了「构图没写完」。放进去的不是
第二张图，是同一个「总盈亏」口径画成的纯形状：无坐标轴、无刻度、无图例，只有
一条零轴发丝线和端点。它回答大数字回答不了的那半个问题——一路跌下来的，还是刚
从更深的地方爬回来的。完整可交互的曲线仍在下面那张卡里，没有动。

口径与 Equity Curve 的「总利润」线**同源同算法**（照抄 charts.js 的合并视图逻辑：
同日期只留一条、连续两条同交易时段只留后一条），否则一屏里两条线画同一件事却
形状不同。

**填充按零轴分色，不是按最后一个值分色**：这条曲线前半段是赚的、后半段才转亏，
用单一色填满会把一段盈利期涂成亏损色 —— 图会说谎。渐变硬停在 zeroY 即可，不需要
clipPath。线本身取中性色（正负已由填充和主数说清楚），否则会出现「红线压在绿色
盈利区上」。端点用 DOM 元素不用 SVG 圆：`preserveAspectRatio="none"` 会把正圆压成椭圆。

## 新增一条棘轮闸：两个 bundle 不许再偷偷分叉

`renderHeroSpark` 第一次实现时**只落进了 render.js**，于是首屏那条线在生产路径上
根本不存在，页面零报错、测试也不红 —— 又一次「源码里对、生产里死」。
`tests/test_dashboard_bundle_parity.py` 逐函数比对两份 bundle：当下已分叉的 8 个
登记在 ALLOWED_DIVERGENT，其余同名函数必须逐字相同；名单只准变短（某个被重新
对齐后必须删掉，否则测试失败），这样它不会因为历史包袱而失效。

## 验证

- spec 新增：缩略走势必须由**首帧 bundle**画出（断言在没进过任何详情 tab 的状态下）、
  容器在数据到达前就占住高度、aria-label 的「当前」值必须和主数逐字相同
  （不比对的话画成「账面市值」都不会有人发现）、渐变必须四个 stop 在零轴硬停。
  红绿都验过：把 `last` 改成 `last + 1`，断言立刻报「plotting a different series」。
- 统计轨去重也上了断言：任何一格都不得重述副行已经给过的数字。
- 全套 spec 绿；26 个 dashboard 相关 pytest 绿；1440/390 零横向溢出、零 page error。
- CLS 与 master 持平（0.0376 vs 0.0388）。

（过程中一次 0.893 的手机端 CLS 是脏测量：当时 `dashboard.ui.js` 带着 stash 冲突
标记，JS 抛错、布局塌了。清干净后复测即为上面的数字。）

Claude-Session: https://claude.ai/code/session_01WdeXp3w4LcVkBYhAiCG4zu
