### PR TITLE
feat(dsh): 余额芯片周限额上头条 + 面板进度条(毛玻璃材质内复用)

### DIFF
--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -105,6 +105,36 @@ action / run_id,判定和结算是 Python 算的,不是模型说的:
 
 面板是只读 Remote,不改任何文件;结算仍归 clawock 自己的机制。
 
+### 会话头部的多 Provider 余额芯片
+
+会话标题行右侧一枚**毛玻璃余额芯片**(utilities 座位,所有 tab 可见、零常驻
+高度)——胶囊头条显示**一个** provider 的读数(默认第一行;在面板里点任意一行
+即钉选为头条,选择存在注册 store 里,重挂不丢),带双窗口的 provider(MiniMax
+5h+周、Claude 会话+本周)在头条直接附**周限额副读数**,不用点开就能看到;
+点开小面板看全部 provider 明细(每窗口一行文字读数 + 发丝进度条,低水位变红)
+与手动刷新。它不是 Decision Mind 的一部分:账户状态是应用级 chrome,
+不是交易语义:
+
+| Provider | 口径 | 读数 |
+| :--- | :--- | :--- |
+| DeepSeek | 官方 `GET /user/balance`(凭据缝 → 环境变量) | 余额 ¥(CNY 行优先),面板见赠金/充值拆分 |
+| MiniMax | 官方 `GET /v1/token_plan/remains`(Token Plan 配额窗口) | 窗口剩余 %(`general` 桶);key 解析链=凭据缝 → env → **openclaw 网关配置**(`~/.openclaw/openclaw.json` 的 `models.providers.minimax.apiKey`) |
+| Claude | 订阅制额度:OAuth `GET /api/oauth/usage`(`anthropic-beta: oauth-2025-04-20`),token 读自 `~/.claude/.credentials.json` | 会话窗口剩余 %(utilization 取补)+ 本周剩余;面板附各窗口重置时间 |
+
+- OpenCode Zen **无公开余额接口**(上游 issue 还开着),不做假装有数的行;
+- 某家未配置 = 面板里诚实的一行「未配置」,不隐藏也不报错;
+- 低额红点:DeepSeek ≤¥20、MiniMax 窗口余量 ≤20%、Claude 会话窗口 ≤20%
+  (各自可配);进度条按同一水位逐窗变红,不只标 provider 整体;
+- 刷新失败保留最近一次快照并标注 stale(黄点);瞬时 429 不抹掉真数字;
+- Claude 的 OAuth token 归 Claude Code 所有,本插件**只读不刷新**——过期时
+  面板显示「请在终端跑一次 claude 刷新登录」;
+- 宿主侧每 provider 60s TTL 缓存、并发合并;客户端静默轮询 ≥60s。
+
+可选配置(profile 的 `cordis.patch.yml` 行内,改后重启 dsh 生效):
+`balanceBaseUrl` / `balanceThreshold` / `balanceRefreshMs` /
+`minimaxBaseUrl` / `minimaxKeyRef` / `minimaxLowPct` / `minimaxOpenclawConfigPath` /
+`claudeCredentialsPath` / `claudeUsageUrl` / `claudeLowPct`。
+
 ## 它不做什么
 
 - **不改文件**。面板只读;账本写入、发布只走 `clawock run` / brief 管线。

--- a/examples/dsh/packages/clawock-dsh/build.mjs
+++ b/examples/dsh/packages/clawock-dsh/build.mjs
@@ -91,6 +91,94 @@ await run(['--config', 'tsdown.client.config.mjs'])
 await exec(node, [tsc, '-p', 'tsconfig.declarations.json', '--pretty', 'false'], { cwd: pkg })
 await wrapWebClient(join(pkg, 'lib/client.js'))
 await patchTypertAlignment()
+await patchTypertBalance()
+
+/**
+ * Same discipline as the alignment patch: the clawock checkout cannot
+ * regenerate the Typert host face, so the committed artifacts carry the
+ * balance wire fields by hand. Re-assert after every build, idempotently;
+ * a missing anchor throws instead of silently shipping a box the wire
+ * cannot carry.
+ */
+async function patchTypertBalance() {
+  const files = ['lib/typert.host.js', 'lib/typert.remote-client.js']
+  const invocationMarker = `id: 'clawock-dsh#clawockStudio/balance',`
+  const schemaAnchor = 'const clawock_dsh_clawockStudio_get_parameter_0$schema = z.string()'
+  const invocationAnchor = `    {
+      id: 'clawock-dsh#clawockStudio/get',`
+  const balanceSchemas = `const clawock_dsh_clawockStudio_balance_parameter_0$schema = z.boolean()
+const clawock_dsh_clawockStudio_balance_result$schema = z.object({
+  'providers': z.array(z.object({
+  'provider': z.string(),
+  'label': z.string(),
+  'result': z.object({
+  'configured': z.boolean(),
+  'snapshot': z.union([z.literal(null), z.object({
+  'isAvailable': z.boolean(),
+  'unit': z.string(),
+  'currency': z.string(),
+  'totalBalance': z.string(),
+  'grantedBalance': z.string(),
+  'toppedUpBalance': z.string(),
+  'asOf': z.string(),
+  'note': z.string(),
+  'windows': z.array(z.object({
+  'label': z.string(),
+  'percent': z.union([z.number(), z.literal(null)]),
+  'resetAt': z.string(),
+})),
+})]),
+  'status': z.union([z.literal("fresh"), z.literal("cached"), z.literal("stale"), z.literal("failed"), z.literal("no-key")]),
+  'low': z.boolean(),
+  'message': z.union([z.literal(null), z.string()]),
+  'threshold': z.number(),
+  'refreshMs': z.number(),
+}),
+})),
+  'refreshMs': z.number(),
+})
+`
+  const balanceInvocation = `    {
+      id: 'clawock-dsh#clawockStudio/balance',
+      service: 'clawockStudio',
+      namespace: 'clawockStudio',
+      method: 'balance',
+      invocation: { kind: 'direct' },
+      parameters: [
+        {
+          name: 'force',
+          wire: 'force',
+          source: 'json',
+          codec: {
+            mode: 'strict',
+            typeSymbol: 'clawock-dsh#clawockStudio/balance:force',
+            schema: clawock_dsh_clawockStudio_balance_parameter_0$schema,
+          },
+        },
+      ],
+      result: {
+        mode: 'strict',
+        typeSymbol: 'clawock-dsh/types#BalancesResult',
+        schema: clawock_dsh_clawockStudio_balance_result$schema,
+      },
+      sourceLocation: {"file":"packages/clawock-dsh/src/index.ts","line":121,"column":3},
+    },
+`
+  for (const rel of files) {
+    const file = join(pkg, rel)
+    let source = await readFile(file, 'utf8')
+    if (source.includes(invocationMarker)) continue
+    if (!source.includes(schemaAnchor) || !source.includes(invocationAnchor)) {
+      throw new Error(`patchTypertBalance: anchor missing in ${rel} — generator output changed?`)
+    }
+    source = source.replace(schemaAnchor, `${balanceSchemas}${schemaAnchor}`)
+    source = source.replace(invocationAnchor, `${balanceInvocation}${invocationAnchor}`)
+    await writeFile(file, source)
+    console.log(`patched ${rel}: +clawockStudio.balance`)
+  }
+}
+
+
 console.log('built clawock-dsh/lib')
 
 /**

--- a/examples/dsh/packages/clawock-dsh/cordis.patch.yml
+++ b/examples/dsh/packages/clawock-dsh/cordis.patch.yml
@@ -5,3 +5,20 @@
 - insert:
     - id: clawock-studio
       name: clawock-dsh
+      # The gateway's balance chip resolves each provider's key through the
+      # credentials seam; the row must declare the service so the profile
+      # mixes it into the plugin context (ctx.credentials).
+      inject: [credentials]
+      # Optional balance-chip overrides (defaults shown). The row config reaches
+      # the gateway's constructor; a change takes effect on the next dsh restart.
+      # config:
+      #   balanceBaseUrl: 'https://api.deepseek.com'   # DeepSeek upstream root
+      #   balanceThreshold: 20                         # red dot at/below this (CNY/USD)
+      #   balanceRefreshMs: 60000                      # suggested poll interval (min 60s)
+      #   minimaxBaseUrl: 'https://api.minimaxi.com'   # MiniMax upstream root
+      #   minimaxKeyRef: 'MINIMAX_API_KEY'             # credentials seam ref (env fallback same name)
+      #   minimaxLowPct: 20                            # red dot when quota windows <= this remaining %
+      #   minimaxOpenclawConfigPath: '/root/.openclaw/openclaw.json'  # key fallback: models.providers.minimax.apiKey
+      #   claudeCredentialsPath: '/root/.claude/.credentials.json'    # Claude Code OAuth file (read-only)
+      #   claudeUsageUrl: 'https://api.anthropic.com/api/oauth/usage' # subscription quota endpoint
+      #   claudeLowPct: 20                             # red dot when the session window <= this remaining %

--- a/examples/dsh/packages/clawock-dsh/lib/balance.js
+++ b/examples/dsh/packages/clawock-dsh/lib/balance.js
@@ -1,0 +1,421 @@
+import { readFileSync } from "node:fs";
+//#region src/balance.ts
+const DEFAULT_BALANCE_BASE_URL = "https://api.deepseek.com";
+const DEFAULT_BALANCE_THRESHOLD = 20;
+const DEFAULT_BALANCE_REFRESH_MS = 6e4;
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimaxi.com";
+const DEFAULT_MINIMAX_LOW_PCT = 20;
+const DEFAULT_OPENCLAW_CONFIG_PATH = "/root/.openclaw/openclaw.json";
+const DEFAULT_CLAUDE_CREDENTIALS_PATH = "/root/.claude/.credentials.json";
+const DEFAULT_CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const DEFAULT_CLAUDE_LOW_PCT = 20;
+const TTL_MS = 6e4;
+const TIMEOUT_MS = 15e3;
+/**
+* The credentials seam reference the official DeepSeek adapter resolves.
+* A plain string on purpose, not credentialRef(): the branding helper is a
+* no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+* cordis Events augmentation into the typert analysis — which registers this
+* package in the host face with zero discoverable services (the protocol
+* lives in node_modules, where the generator's symbol checks cannot see it)
+* and fails the "publishes Remote artifacts" gate. The seam itself resolves
+* by name, so the reference needs no import to work.
+*/
+/**
+* The credentials seam reference the official DeepSeek adapter resolves.
+* A plain string on purpose, not credentialRef(): the branding helper is a
+* no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+* cordis Events augmentation into the typert analysis — which registers this
+* package in the host face with zero discoverable services (the protocol
+* lives in node_modules, where the generator's symbol checks cannot see it)
+* and fails the "publishes Remote artifacts" gate. The seam itself resolves
+* by name, so the reference needs no import to work.
+*/
+const DEEPSEEK_KEY_REF = "DEEPSEEK_API_KEY";
+/** Same seam discipline for MiniMax: the harness's MiniMax adapter's ref. */
+const MINIMAX_KEY_REF = "MINIMAX_API_KEY";
+/**
+* Pick the CNY entry case-insensitively; fall back to the first entry when
+* the account has no CNY row. Mirrors upstream DeepSeekMonitorWindows'
+* eq_ignore_ascii_case.
+*/
+function pickCnyBalanceInfo(infos) {
+	if (!Array.isArray(infos) || infos.length === 0) return void 0;
+	return infos.find((entry) => (entry.currency ?? "").toUpperCase() === "CNY") ?? infos[0];
+}
+/**
+* Tolerant parse: a missing field degrades to '' / false rather than throwing,
+* so a shape drift upstream reads as an empty box, never as a crashed tab.
+*/
+function parseBalancePayload(body, asOf) {
+	const raw = typeof body === "object" && body !== null ? body : {};
+	const entry = pickCnyBalanceInfo(raw.balance_infos);
+	return {
+		isAvailable: raw.is_available === true,
+		unit: "money",
+		currency: typeof entry?.currency === "string" ? entry.currency : "",
+		totalBalance: typeof entry?.total_balance === "string" ? entry.total_balance : "",
+		grantedBalance: typeof entry?.granted_balance === "string" ? entry.granted_balance : "",
+		toppedUpBalance: typeof entry?.topped_up_balance === "string" ? entry.topped_up_balance : "",
+		asOf,
+		note: "",
+		windows: []
+	};
+}
+const finiteNumber = (value) => typeof value === "number" && isFinite(value) ? value : null;
+/**
+* Remaining percent of one quota window: the explicit percent field when the
+* plan reports one, otherwise derived from total/used counts (MiniMax ships
+* both shapes across plan generations). null = unreadable, never guessed.
+*/
+function windowRemainingPercent(entry) {
+	const direct = finiteNumber(entry.current_interval_remaining_percent);
+	if (direct !== null) return Math.min(100, Math.max(0, direct));
+	const total = finiteNumber(entry.current_interval_total_count);
+	const used = finiteNumber(entry.current_interval_usage_count);
+	if (total !== null && total > 0 && used !== null && used >= 0) return Math.min(100, Math.max(0, (total - used) / total * 100));
+	return null;
+}
+/**
+* Reset stamps the panel can lay out: within 48h a bare local clock,
+* farther out the weekday comes along ('周四 21:00'). Accepts epoch seconds,
+* epoch milliseconds and RFC3339 strings — MiniMax sends epochs while
+* Claude sends ISO.
+*/
+function formatReset(epochOrIso) {
+	let ms = null;
+	if (typeof epochOrIso === "number" && isFinite(epochOrIso) && epochOrIso > 0) ms = epochOrIso > 0xe8d4a51000 ? epochOrIso : epochOrIso * 1e3;
+	else if (typeof epochOrIso === "string" && epochOrIso !== "") {
+		const at = new Date(epochOrIso);
+		if (!isNaN(at.getTime())) ms = at.getTime();
+	}
+	if (ms === null) return "";
+	const at = new Date(ms);
+	const hhmm = String(at.getHours()).padStart(2, "0") + ":" + String(at.getMinutes()).padStart(2, "0");
+	if (at.getTime() - Date.now() < 1728e5) return hhmm;
+	return [
+		"周日",
+		"周一",
+		"周二",
+		"周三",
+		"周四",
+		"周五",
+		"周六"
+	][at.getDay()] + " " + hhmm;
+}
+/**
+* The successful Token Plan payload → snapshot. Percent-based by design:
+* plans report either percent fields or raw counts, and tokens are not money
+* — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+*/
+function parseMinimaxRemains(body, asOf) {
+	const raw = typeof body === "object" && body !== null ? body : {};
+	const buckets = Array.isArray(raw.model_remains) ? raw.model_remains : [];
+	const entry = buckets.find((b) => b.model === "general") ?? buckets[0];
+	if (entry === void 0) throw new Error("MiniMax 响应里没有 model_remains 数据");
+	const pct = windowRemainingPercent(entry);
+	const weekly = finiteNumber(entry.current_weekly_remaining_percent);
+	const windows = [];
+	if (pct !== null) windows.push({
+		label: "5h",
+		percent: Math.round(pct),
+		resetAt: formatReset(entry.end_time)
+	});
+	if (weekly !== null) windows.push({
+		label: "周",
+		percent: Math.round(weekly),
+		resetAt: formatReset(entry.weekly_end_time)
+	});
+	const notes = [];
+	if (pct !== null) notes.push("5h 窗口剩余 " + Math.round(pct) + "%");
+	if (weekly !== null) notes.push("周窗口剩余 " + Math.round(weekly) + "%");
+	return {
+		isAvailable: pct !== null && pct > 0,
+		unit: "pct",
+		currency: "",
+		totalBalance: pct === null ? "" : String(Math.round(pct)),
+		grantedBalance: "",
+		toppedUpBalance: "",
+		asOf,
+		note: notes.join(" · "),
+		windows
+	};
+}
+/** Seam reference first, then the ambient environment variable of the same name. */
+function resolveSeamThenEnv(deps, ref) {
+	return async () => {
+		const resolved = await deps.credentials.resolve(ref);
+		if (resolved !== void 0 && typeof resolved.value === "string" && resolved.value !== "") return resolved.value;
+		const ambient = process.env[ref];
+		return ambient !== void 0 && ambient !== "" ? ambient : void 0;
+	};
+}
+/** Tolerant JSON file read: missing/unreadable/invalid all yield undefined. */
+function readJsonFile(path) {
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		return typeof parsed === "object" && parsed !== null ? parsed : void 0;
+	} catch {
+		return;
+	}
+}
+/** kcn keeps provider keys in the openclaw gateway config at this pointer. */
+function readOpenclawProviderKey(configPath, provider) {
+	const key = (((readJsonFile(configPath)?.models ?? {}).providers ?? {})[provider] ?? {}).apiKey;
+	return typeof key === "string" && key !== "" ? key : void 0;
+}
+function createQuotaService(deps, spec) {
+	let snapshot = null;
+	let fetchedAt = 0;
+	let inFlight = null;
+	const resolveKey = async () => spec.resolveApiKey(deps);
+	const run = async (apiKey) => {
+		try {
+			snapshot = await spec.fetchFresh(apiKey);
+			fetchedAt = Date.now();
+			return {
+				configured: true,
+				snapshot,
+				status: "fresh",
+				low: spec.isLow(snapshot),
+				message: null,
+				threshold: spec.threshold,
+				refreshMs: spec.refreshMs
+			};
+		} catch (cause) {
+			const message = cause instanceof Error ? cause.message : String(cause);
+			if (snapshot !== null) return {
+				configured: true,
+				snapshot,
+				status: "stale",
+				low: spec.isLow(snapshot),
+				message,
+				threshold: spec.threshold,
+				refreshMs: spec.refreshMs
+			};
+			return {
+				configured: true,
+				snapshot: null,
+				status: "failed",
+				low: false,
+				message,
+				threshold: spec.threshold,
+				refreshMs: spec.refreshMs
+			};
+		}
+	};
+	const exec = async (force) => {
+		const apiKey = await resolveKey();
+		if (apiKey === void 0) return {
+			configured: false,
+			snapshot: null,
+			status: "no-key",
+			low: false,
+			message: spec.noKeyMessage,
+			threshold: spec.threshold,
+			refreshMs: spec.refreshMs
+		};
+		if (!force && snapshot !== null && Date.now() - fetchedAt < TTL_MS) return {
+			configured: true,
+			snapshot,
+			status: "cached",
+			low: spec.isLow(snapshot),
+			message: null,
+			threshold: spec.threshold,
+			refreshMs: spec.refreshMs
+		};
+		return run(apiKey);
+	};
+	return { 
+	/**
+	* Cached-or-fetch read. A concurrent caller (a poll tick racing a manual
+	* click) JOINS the in-flight run instead of stampeding the upstream —
+	* one request per window, however many faces ask.
+	*/
+async get(force) {
+		if (inFlight !== null) return inFlight;
+		const pending = exec(force);
+		inFlight = pending;
+		try {
+			return await pending;
+		} finally {
+			inFlight = null;
+		}
+	} };
+}
+const numOrInfinity = (value) => {
+	const parsed = Number.parseFloat(value);
+	return isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+};
+/** DeepSeek row: official money balance, CNY entry preferred. */
+function createBalanceService(deps, config = {}) {
+	const baseUrl = config.baseUrl ?? "https://api.deepseek.com";
+	const threshold = typeof config.threshold === "number" && isFinite(config.threshold) ? config.threshold : 20;
+	return createQuotaService(deps, {
+		resolveApiKey: resolveSeamThenEnv(deps, DEEPSEEK_KEY_REF),
+		noKeyMessage: "未配置 DeepSeek API Key(设置 → 模型 → DeepSeek)",
+		threshold,
+		refreshMs: typeof config.refreshMs === "number" && isFinite(config.refreshMs) ? config.refreshMs : DEFAULT_BALANCE_REFRESH_MS,
+		async fetchFresh(apiKey) {
+			let response;
+			try {
+				response = await fetch(`${baseUrl}/user/balance`, {
+					headers: {
+						authorization: `Bearer ${apiKey}`,
+						accept: "application/json"
+					},
+					signal: AbortSignal.timeout(TIMEOUT_MS)
+				});
+			} catch (cause) {
+				throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`);
+			}
+			if (response.status === 401) throw new Error("API Key 无效或已过期");
+			if (response.status === 429) throw new Error("请求过于频繁,请稍后再试");
+			if (!response.ok) throw new Error(`余额接口返回 HTTP ${response.status}`);
+			let body;
+			try {
+				body = await response.json();
+			} catch {
+				throw new Error("解析余额数据失败");
+			}
+			return parseBalancePayload(body, (/* @__PURE__ */ new Date()).toISOString());
+		},
+		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= threshold : snapshot.isAvailable && numOrInfinity(snapshot.totalBalance) <= threshold
+	});
+}
+/** MiniMax row: official Token Plan quota windows, percent-based. */
+function createMinimaxService(deps, config = {}) {
+	const baseUrl = config.baseUrl ?? "https://api.minimaxi.com";
+	const lowPct = typeof config.lowPct === "number" && isFinite(config.lowPct) ? config.lowPct : 20;
+	const seamEnv = resolveSeamThenEnv(deps, config.keyRef ?? "MINIMAX_API_KEY");
+	const openclawPath = config.openclawConfigPath ?? "/root/.openclaw/openclaw.json";
+	return createQuotaService(deps, {
+		resolveApiKey: async () => await seamEnv() ?? readOpenclawProviderKey(openclawPath, "minimax"),
+		noKeyMessage: "未配置 MiniMax API Key(凭据缝 / 环境变量 / openclaw 配置均无)",
+		threshold: lowPct,
+		refreshMs: DEFAULT_BALANCE_REFRESH_MS,
+		async fetchFresh(apiKey) {
+			let response;
+			try {
+				response = await fetch(`${baseUrl}/v1/token_plan/remains`, {
+					headers: {
+						authorization: `Bearer ${apiKey}`,
+						accept: "application/json"
+					},
+					signal: AbortSignal.timeout(TIMEOUT_MS)
+				});
+			} catch (cause) {
+				throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`);
+			}
+			if (!response.ok) throw new Error(`MiniMax 接口返回 HTTP ${response.status}`);
+			let body;
+			try {
+				body = await response.json();
+			} catch {
+				throw new Error("解析 MiniMax 数据失败");
+			}
+			const raw = typeof body === "object" && body !== null ? body : {};
+			const code = raw.base_resp?.status_code;
+			if (code !== void 0 && code !== 0) {
+				const msg = typeof raw.base_resp?.status_msg === "string" && raw.base_resp.status_msg !== "" ? raw.base_resp.status_msg : `错误码 ${code}`;
+				throw new Error(code === 1004 ? `MiniMax API Key 无效或已过期(${msg})` : `MiniMax 接口错误:${msg}`);
+			}
+			return parseMinimaxRemains(body, (/* @__PURE__ */ new Date()).toISOString());
+		},
+		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= lowPct : false
+	});
+}
+/**
+* Read Claude Code's OAuth credentials. The file belongs to Claude Code —
+* this service only READS it; rotating/refreshing stays their job, so an
+* expired token surfaces as a failed row telling kcn to run claude once.
+*/
+function readClaudeCredentials(path) {
+	const creds = readJsonFile(path)?.claudeAiOauth;
+	if (creds === void 0 || typeof creds !== "object") return void 0;
+	return { creds };
+}
+/**
+* Successful usage payload → snapshot, in REMAINING percent (utilization is
+* consumption). five_hour gates active sessions so it is the headline; any
+* bucket may be absent/null depending on plan.
+*/
+function parseClaudeUsage(body, asOf) {
+	const raw = typeof body === "object" && body !== null ? body : {};
+	const u5 = finiteNumber(raw.five_hour?.utilization);
+	const u7 = finiteNumber(raw.seven_day?.utilization);
+	if (u5 === null && u7 === null) throw new Error("Claude 响应里没有可用的用量窗口");
+	const remaining = u5 === null ? null : Math.round(Math.min(100, Math.max(0, 100 - u5)));
+	const windows = [];
+	if (u5 !== null) windows.push({
+		label: "会话",
+		percent: remaining,
+		resetAt: formatReset(raw.five_hour?.resets_at ?? null)
+	});
+	if (u7 !== null) windows.push({
+		label: "本周",
+		percent: Math.round(Math.min(100, Math.max(0, 100 - u7))),
+		resetAt: formatReset(raw.seven_day?.resets_at ?? null)
+	});
+	const notes = [];
+	if (u5 !== null) notes.push("会话窗口剩余 " + remaining + "%");
+	if (u7 !== null) notes.push("本周剩余 " + Math.round(100 - u7) + "%");
+	const extraUtil = raw.extra_usage?.is_enabled === true ? finiteNumber(raw.extra_usage?.utilization ?? void 0) : null;
+	if (extraUtil !== null) notes.push("附加额度已用 " + Math.round(extraUtil) + "%");
+	return {
+		isAvailable: remaining === null ? false : remaining > 0,
+		unit: "pct",
+		currency: "",
+		totalBalance: remaining === null ? "" : String(remaining),
+		grantedBalance: "",
+		toppedUpBalance: "",
+		asOf,
+		note: notes.join(" · "),
+		windows
+	};
+}
+/** Claude row: subscription rate-limit windows via the OAuth usage endpoint. */
+function createClaudeService(deps, config = {}) {
+	const credentialsPath = config.credentialsPath ?? "/root/.claude/.credentials.json";
+	const usageUrl = config.usageUrl ?? "https://api.anthropic.com/api/oauth/usage";
+	const lowPct = typeof config.lowPct === "number" && isFinite(config.lowPct) ? config.lowPct : 20;
+	return createQuotaService(deps, {
+		resolveApiKey: async () => readClaudeCredentials(credentialsPath)?.creds.accessToken,
+		noKeyMessage: "未找到 Claude 登录(~/.claude/.credentials.json)",
+		threshold: lowPct,
+		refreshMs: DEFAULT_BALANCE_REFRESH_MS,
+		async fetchFresh() {
+			const entry = readClaudeCredentials(credentialsPath);
+			if (entry === void 0) throw new Error("Claude 登录文件不存在或已损坏");
+			const { creds } = entry;
+			if (typeof creds.accessToken !== "string" || creds.accessToken === "") throw new Error("Claude 登录文件里没有 accessToken");
+			if (typeof creds.expiresAt === "number" && Date.now() > creds.expiresAt) throw new Error("Claude 登录已过期,请在终端跑一次 claude 刷新登录");
+			let response;
+			try {
+				response = await fetch(usageUrl, {
+					headers: {
+						authorization: `Bearer ${creds.accessToken}`,
+						accept: "application/json",
+						"anthropic-beta": "oauth-2025-04-20"
+					},
+					signal: AbortSignal.timeout(TIMEOUT_MS)
+				});
+			} catch (cause) {
+				throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`);
+			}
+			if (response.status === 401 || response.status === 403) throw new Error("Claude 登录无效或已过期");
+			if (response.status === 429) throw new Error("请求过于频繁,请稍后再试");
+			if (!response.ok) throw new Error(`Claude 用量接口返回 HTTP ${response.status}`);
+			let body;
+			try {
+				body = await response.json();
+			} catch {
+				throw new Error("解析 Claude 数据失败");
+			}
+			return parseClaudeUsage(body, (/* @__PURE__ */ new Date()).toISOString());
+		},
+		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= lowPct : false
+	});
+}
+//#endregion
+export { DEEPSEEK_KEY_REF, DEFAULT_BALANCE_BASE_URL, DEFAULT_BALANCE_REFRESH_MS, DEFAULT_BALANCE_THRESHOLD, DEFAULT_CLAUDE_CREDENTIALS_PATH, DEFAULT_CLAUDE_LOW_PCT, DEFAULT_CLAUDE_USAGE_URL, DEFAULT_MINIMAX_BASE_URL, DEFAULT_MINIMAX_LOW_PCT, DEFAULT_OPENCLAW_CONFIG_PATH, MINIMAX_KEY_REF, createBalanceService, createClaudeService, createMinimaxService, formatReset, parseBalancePayload, parseClaudeUsage, parseMinimaxRemains, pickCnyBalanceInfo, readClaudeCredentials, readJsonFile, windowRemainingPercent };

--- a/examples/dsh/packages/clawock-dsh/lib/client.js
+++ b/examples/dsh/packages/clawock-dsh/lib/client.js
@@ -4281,6 +4281,43 @@ const JsonValueRemoteCodec$schema3 = union([
 	array(lazy(() => JsonValueRemoteCodec$schema3)),
 	record(string(), lazy(() => JsonValueRemoteCodec$schema3))
 ]);
+const clawock_dsh_clawockStudio_balance_parameter_0$schema = boolean();
+const clawock_dsh_clawockStudio_balance_result$schema = object({
+	"providers": array(object({
+		"provider": string(),
+		"label": string(),
+		"result": object({
+			"configured": boolean(),
+			"snapshot": union([literal(null), object({
+				"isAvailable": boolean(),
+				"unit": string(),
+				"currency": string(),
+				"totalBalance": string(),
+				"grantedBalance": string(),
+				"toppedUpBalance": string(),
+				"asOf": string(),
+				"note": string(),
+				"windows": array(object({
+					"label": string(),
+					"percent": union([number(), literal(null)]),
+					"resetAt": string()
+				}))
+			})]),
+			"status": union([
+				literal("fresh"),
+				literal("cached"),
+				literal("stale"),
+				literal("failed"),
+				literal("no-key")
+			]),
+			"low": boolean(),
+			"message": union([literal(null), string()]),
+			"threshold": number(),
+			"refreshMs": number()
+		})
+	})),
+	"refreshMs": number()
+});
 const clawock_dsh_clawockStudio_get_parameter_0$schema = string();
 const clawock_dsh_clawockStudio_get_result$schema = object({
 	"runId": string(),
@@ -4443,6 +4480,33 @@ const TYPERT_REMOTE = {
 	package: "clawock-dsh",
 	descriptors: [
 		{
+			id: "clawock-dsh#clawockStudio/balance",
+			service: "clawockStudio",
+			namespace: "clawockStudio",
+			method: "balance",
+			invocation: { kind: "direct" },
+			parameters: [{
+				name: "force",
+				wire: "force",
+				source: "json",
+				codec: {
+					mode: "strict",
+					typeSymbol: "clawock-dsh#clawockStudio/balance:force",
+					schema: clawock_dsh_clawockStudio_balance_parameter_0$schema
+				}
+			}],
+			result: {
+				mode: "strict",
+				typeSymbol: "clawock-dsh/types#BalancesResult",
+				schema: clawock_dsh_clawockStudio_balance_result$schema
+			},
+			sourceLocation: {
+				"file": "packages/clawock-dsh/src/index.ts",
+				"line": 121,
+				"column": 3
+			}
+		},
+		{
 			id: "clawock-dsh#clawockStudio/get",
 			service: "clawockStudio",
 			namespace: "clawockStudio",
@@ -4563,7 +4627,7 @@ const TYPERT_REMOTE = {
 };
 //#endregion
 //#region \0dsh-css:src/styles.module.css.mjs
-const css = ".SPgITW_dmt{--col:var(--dsh-chat-content-width,748px);--page:var(--dsw-alias-bg-base,#f7f8fa);--surface:var(--dsw-alias-bg-layer-1,#fff);--text:var(--dsw-alias-label-primary,#15171b);--text2:var(--dsw-alias-label-secondary,#61666b);--text3:var(--dsw-alias-label-tertiary,#81858c);--cap:var(--dsw-alias-label-caption,#adb2b8);--brand:var(--dsw-alias-state-business-primary,#4176e6);--border:var(--dsw-alias-border-l1,#1118270f);--border2:var(--dsw-alias-border-l2,#1118271a);--hover:var(--dsw-alias-interactive-bg-hover,#1118270d);--brand-soft:#4176e612;--ok:#1b8644;--ok-soft:#e6faed;--bad:#c01313;--bad-soft:#fdebee;--warn:#aa6924;--warn-soft:#aa69241a;--shadow-sm:0 1px 2px #1018280a;--tint-soft:#00000008;--tint-border:#0000000d;--tint-mid:#00000014;--tint-strong:#0000001f;--t1-up-border:#1b84442e;--t1-down-border:#c013132e;--radius:12px;--font:var(--dsw-font-family,-apple-system,BlinkMacSystemFont,\"Segoe UI\",\"PingFang SC\",\"Hiragino Sans GB\",\"Microsoft YaHei\",sans-serif);--mono:var(--ds-font-family-code,ui-monospace,SFMono-Regular,Menlo,Consolas,monospace);font:13px/1.45 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;min-height:100%}body[data-ds-dark-theme] .SPgITW_dmt{--brand-soft:#6c97f21f;--ok:#3fcb74;--ok-soft:#153824;--bad:#f2554f;--bad-soft:#3b1516;--warn:#e0a752;--warn-soft:#e0a75224;--shadow-sm:0 1px 2px #0000004d;--tint-soft:#ffffff0f;--tint-border:#ffffff14;--tint-mid:#ffffff1f;--tint-strong:#ffffff2e;--t1-up-border:#3fcb7459;--t1-down-border:#f2554f59}.SPgITW_dmt .SPgITW_top{box-sizing:border-box;padding:10px 0 0}.SPgITW_dmt .SPgITW_tin{box-sizing:border-box;max-width:calc(var(--col) - 28px);background:var(--surface);border:1px solid var(--border2);border-radius:var(--radius);box-shadow:var(--dsw-shadow-lv2,var(--shadow-sm));margin:0 auto;padding:10px 12px 11px}.SPgITW_dmt .SPgITW_tt{font:650 15px/1.3 var(--font);letter-spacing:-.01em;flex-wrap:wrap;align-items:baseline;gap:3px 8px;display:flex}.SPgITW_dmt .SPgITW_tt:before{content:\"\";background:var(--brand);border-radius:3px;flex:none;align-self:center;width:8px;height:8px}.SPgITW_dmt .SPgITW_tt .SPgITW_rate{font:400 11px/1.3 var(--font);color:var(--cap);font-variant-numeric:tabular-nums;white-space:nowrap;margin-left:auto}.SPgITW_dmt .SPgITW_ts{min-width:0;font:400 11.5px/1.4 var(--font);color:var(--cap);text-overflow:ellipsis;white-space:nowrap;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_stats{flex-wrap:wrap;align-items:baseline;gap:6px 18px;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_sg{align-items:baseline;gap:6px;min-width:0;display:flex}.SPgITW_dmt .SPgITW_sl{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.03em}.SPgITW_dmt .SPgITW_sv{font:650 13.5px/1.3 var(--font);color:var(--text);font-variant-numeric:tabular-nums;white-space:nowrap}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font:700 16px/1.2 var(--font)}.SPgITW_dmt .SPgITW_sv.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_sv.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_bar{box-sizing:border-box;z-index:20;background:var(--page);background:color-mix(in srgb, var(--page) 72%, transparent);backdrop-filter:blur(10px)saturate(1.5);padding:8px 0 6px;position:sticky;top:0}.SPgITW_dmt .SPgITW_bin{box-sizing:border-box;max-width:calc(var(--col) - 28px);margin:0 auto}.SPgITW_dmt .SPgITW_filters{flex-wrap:wrap;gap:2px;margin-left:2px;display:flex}.SPgITW_dmt .SPgITW_ft{color:var(--text3);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border:0;border-radius:7px;padding:5px 10px;transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1)}.SPgITW_dmt .SPgITW_ft:active{transform:scale(.97)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_ft:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_ft.SPgITW_on{color:var(--text);background:var(--hover)}.SPgITW_dmt .SPgITW_ft:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_dmt .SPgITW_list{box-sizing:border-box;max-width:var(--col);padding:0 14px calc(var(--dsh-composer-height,152px) + 24px);margin:0 auto}.SPgITW_dmt .SPgITW_day{font:650 12.5px/1.3 var(--font);color:var(--text2);align-items:center;gap:8px;margin:18px 0 6px;display:flex}.SPgITW_dmt .SPgITW_day .SPgITW_n{color:var(--cap);font:400 10.5px/1.3 var(--mono);margin-left:auto}.SPgITW_dmt .SPgITW_day:after{content:\"\";background:var(--border);flex:1;height:1px;margin-left:6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold{cursor:pointer;border-radius:8px;margin-left:-6px;padding:3px 6px;transition:background .12s}.SPgITW_dmt .SPgITW_day.SPgITW_fold:active{background:var(--tint-mid)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_day.SPgITW_fold:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_day.SPgITW_fold:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_dmt .SPgITW_day.SPgITW_fold .SPgITW_chev{text-align:center;width:12px;color:var(--cap);flex:none;margin-left:0;font-size:10px}.SPgITW_dmt .SPgITW_group{border:1px solid var(--border2);border-radius:var(--radius);background:var(--surface);box-shadow:var(--dsw-shadow-lv2,var(--shadow-sm));grid-template-columns:2px 8px auto minmax(64px,auto) auto minmax(0,1fr) auto auto 104px 12px 2px;gap:0 10px;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell{grid-column:1/-1;grid-template-columns:2px 8px auto minmax(64px,auto) auto minmax(0,1fr) auto auto 104px 12px 2px;grid-template-columns:subgrid;cursor:pointer;align-items:center;gap:0 10px;padding:9px 0;transition:background .12s;display:grid;position:relative}.SPgITW_dmt .SPgITW_cell+.SPgITW_cell{border-top:1px solid var(--border)}.SPgITW_dmt .SPgITW_cell:active{background:var(--tint-mid)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_cell:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_cell:focus-visible{outline:1px solid var(--brand);outline-offset:-2px}.SPgITW_dmt .SPgITW_cell.SPgITW_open{background:linear-gradient(180deg, var(--brand-soft), transparent 72%);box-shadow:none}.SPgITW_dmt .SPgITW_cell.SPgITW_open:before{content:\"\";background:linear-gradient(180deg, var(--brand), color-mix(in srgb, var(--brand) 14%, transparent));border-radius:2px;width:3px;position:absolute;top:10px;bottom:10px;left:0}.SPgITW_dmt .SPgITW_main,.SPgITW_dmt .SPgITW_sub{display:contents}.SPgITW_dmt .SPgITW_dotm{background:var(--cap);border-radius:50%;grid-area:1/2;width:6px;height:6px}.SPgITW_dmt .SPgITW_cell.SPgITW_hasdec .SPgITW_dotm{background:var(--brand)}.SPgITW_dmt .SPgITW_sub .SPgITW_date{font:400 11px/1.4 var(--mono);color:var(--cap);font-variant-numeric:tabular-nums;white-space:nowrap;grid-area:1/3}.SPgITW_dmt .SPgITW_tk{min-width:0;font:650 14px/1.4 var(--font);letter-spacing:-.01em;text-overflow:ellipsis;white-space:nowrap;grid-area:1/4;overflow:hidden}.SPgITW_dmt .SPgITW_mkt{font:700 9.5px/1 var(--font);vertical-align:2px;color:var(--brand);margin-left:3px}.SPgITW_dmt .SPgITW_mkt.SPgITW_hk{color:var(--text3)}.SPgITW_dmt .SPgITW_tag{border:1px solid var(--tint-border);background:var(--tint-soft);height:20px;font:600 11.5px/1 var(--font);color:var(--text2);letter-spacing:.02em;white-space:nowrap;border-radius:6px;grid-area:1/5;justify-self:start;align-items:center;padding:0 7px;display:inline-flex}.SPgITW_dmt .SPgITW_qty{min-width:0;font:500 12.5px/1.4 var(--mono);color:var(--text2);font-variant-numeric:tabular-nums;white-space:nowrap;text-overflow:ellipsis;grid-area:1/6;justify-self:start;overflow:hidden}.SPgITW_dmt .SPgITW_sp{display:none}.SPgITW_dmt .SPgITW_pnl{text-align:right;font:700 15.5px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;grid-area:1/9;justify-self:end}.SPgITW_dmt .SPgITW_pnl.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_pnl.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_pnl.SPgITW_na{color:var(--cap);font-size:13px;font-weight:500}.SPgITW_dmt .SPgITW_pnlk{font:600 10.5px/1.2 var(--font);color:var(--cap);letter-spacing:0;margin-right:3px}.SPgITW_dmt .SPgITW_t1{height:19px;font:600 10.5px/1 var(--font);white-space:nowrap;font-variant-numeric:tabular-nums;border-radius:5px;grid-area:1/8;justify-self:end;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_t1.SPgITW_up{color:var(--ok);background:var(--ok-soft);border:1px solid var(--t1-up-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_down{color:var(--bad);background:var(--bad-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_flat{color:var(--text2);background:var(--tint-soft)}.SPgITW_dmt .SPgITW_al{height:19px;font:600 10.5px/1 var(--font);white-space:nowrap;letter-spacing:.02em;border-radius:5px;grid-area:1/7;justify-self:end;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_al.SPgITW_opp{color:var(--warn);background:var(--warn-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_chev{color:var(--cap);grid-area:1/10;justify-self:end;font-size:10px;transition:transform .15s}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_chev{transform:rotate(180deg)}.SPgITW_dmt .SPgITW_detail{opacity:0;grid-area:2/1/auto/-1;grid-template-rows:0fr;transition:grid-template-rows .24s cubic-bezier(.22,1,.36,1),opacity .15s;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{opacity:1;border-top:1px solid var(--tint-border);grid-template-rows:1fr;margin-top:9px}.SPgITW_dmt .SPgITW_dinner{min-height:0;padding:0;overflow:hidden}.SPgITW_dmt .SPgITW_dbody{padding:12px}.SPgITW_dmt .SPgITW_trhead{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.05em;align-items:center;gap:6px;margin-bottom:8px;display:flex}.SPgITW_dmt .SPgITW_trhead:before{content:\"\";background:var(--brand);border-radius:50%;width:6px;height:6px}.SPgITW_dmt .SPgITW_trace{padding-left:22px;position:relative}.SPgITW_dmt .SPgITW_trace:before{content:\"\";background:var(--tint-mid);width:2px;position:absolute;top:12px;bottom:10px;left:5px}.SPgITW_dmt .SPgITW_tnode{padding:2px 0 14px;position:relative}.SPgITW_dmt .SPgITW_tnode:last-child{padding-bottom:2px}.SPgITW_dmt .SPgITW_tnode:before{content:\"\";background:var(--surface);border:2px solid var(--cap);box-sizing:border-box;border-radius:50%;width:10px;height:10px;position:absolute;top:5px;left:-22px}.SPgITW_dmt .SPgITW_tnode.SPgITW_dec:before{border-color:var(--brand)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip:before{border-color:var(--warn)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss:before{border-color:var(--bad)}.SPgITW_dmt .SPgITW_tnode .SPgITW_tw{font:400 10px/1.4 var(--mono);color:var(--cap);margin-bottom:1px}.SPgITW_dmt .SPgITW_tnode .SPgITW_n{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.04em;margin-bottom:2px}.SPgITW_dmt .SPgITW_tnode .SPgITW_v{font:600 13px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss .SPgITW_v{color:var(--bad)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip .SPgITW_v{color:var(--warn)}.SPgITW_dmt .SPgITW_pchips{flex-wrap:wrap;gap:6px;margin:4px 0 8px;display:flex}.SPgITW_dmt .SPgITW_pc{font:400 11px/1.4 var(--font);background:var(--tint-soft);border:1px solid var(--border2);color:var(--text2);border-radius:6px;padding:2px 8px}.SPgITW_dmt .SPgITW_tnote{border-left:3px solid var(--tint-strong);font:400 11.5px/1.6 var(--font);color:var(--text2);white-space:pre-wrap;overflow-wrap:anywhere;margin:7px 0;padding:3px 0 3px 10px}.SPgITW_dmt .SPgITW_tnote.SPgITW_why{border-left-color:var(--brand)}.SPgITW_dmt .SPgITW_tnote.SPgITW_emo{border-left-color:var(--warn)}.SPgITW_dmt .SPgITW_tnote .SPgITW_k{color:var(--cap);font:600 10.5px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tmiss{border:1px dashed var(--border2);font:400 11.5px/1.5 var(--font);color:var(--cap);border-radius:6px;margin-top:8px;padding:7px 10px}.SPgITW_dmt .SPgITW_empty{text-align:center;color:var(--cap);font:400 13px/1.5 var(--font);padding:48px 20px}.SPgITW_dmt .SPgITW_trace-more{border:1px dashed var(--border2);width:100%;color:var(--text2);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border-radius:10px;margin:12px 0 0;padding:9px 12px;transition:background .12s,border-color .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1);display:block}.SPgITW_dmt .SPgITW_trace-more:active{transform:scale(.98)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_trace-more:hover{background:var(--hover);border-color:var(--brand);color:var(--text)}}.SPgITW_dmt .SPgITW_skel{border:1px solid var(--border2);border-radius:var(--radius);background:var(--surface);align-items:center;gap:12px;margin:8px 0;padding:13px 12px;display:flex}.SPgITW_dmt .SPgITW_skel-dot{background:var(--tint-strong);border-radius:50%;flex:none;width:6px;height:6px}.SPgITW_dmt .SPgITW_skel-bar{background:var(--tint-mid);border-radius:5px;height:10px;position:relative;overflow:hidden}.SPgITW_dmt .SPgITW_skel-bar:after{content:\"\";background:linear-gradient(90deg, transparent, var(--tint-strong), transparent);animation:1.2s ease-in-out infinite SPgITW_clawock-shimmer;position:absolute;inset:0;transform:translate(-100%)}@keyframes SPgITW_clawock-shimmer{to{transform:translate(100%)}}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w40{width:40%}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w20{width:20%}@media (prefers-reduced-motion:reduce){.SPgITW_dmt .SPgITW_chev{transition:none}.SPgITW_dmt .SPgITW_detail{transition:opacity .15s}.SPgITW_dmt .SPgITW_ft,.SPgITW_dmt .SPgITW_trace-more{transition:background .12s,color .12s,border-color .12s}.SPgITW_dmt .SPgITW_skel-bar:after{animation:none}}@media (width<=520px){.SPgITW_dmt .SPgITW_top{padding:8px 10px 0}.SPgITW_dmt .SPgITW_bar{padding:6px 10px}.SPgITW_dmt .SPgITW_bin{max-width:none}.SPgITW_dmt .SPgITW_tin{max-width:none;padding:10px 12px 9px}.SPgITW_dmt .SPgITW_ts{white-space:normal;flex:1 0 100%}.SPgITW_dmt .SPgITW_stats{margin-top:6px;display:block}.SPgITW_dmt .SPgITW_sg{justify-content:space-between;gap:10px;padding:3px 0}.SPgITW_dmt .SPgITW_sg+.SPgITW_sg{border-top:1px solid var(--border)}.SPgITW_dmt .SPgITW_sv{white-space:normal;text-align:right}.SPgITW_dmt .SPgITW_ft{min-height:32px;padding:6px 11px}.SPgITW_dmt .SPgITW_list{padding:0 10px calc(var(--dsh-composer-height,152px) + 24px)}.SPgITW_dmt .SPgITW_day.SPgITW_fold{padding:7px 6px}.SPgITW_dmt .SPgITW_group{display:block}.SPgITW_dmt .SPgITW_cell{padding:0;display:block}.SPgITW_dmt .SPgITW_main{align-items:center;gap:8px;padding:10px 12px 2px;display:flex}.SPgITW_dmt .SPgITW_sub{align-items:center;gap:8px;padding:2px 12px 10px;display:flex}.SPgITW_dmt .SPgITW_dotm{flex:none;width:7px;height:7px}.SPgITW_dmt .SPgITW_tk{flex:0 auto;font-size:14.5px}.SPgITW_dmt .SPgITW_tag{flex:none;height:19px;padding:0 6px}.SPgITW_dmt .SPgITW_qty{flex:0 auto;font-size:12px}.SPgITW_dmt .SPgITW_sp{flex:auto;min-width:6px;display:block}.SPgITW_dmt .SPgITW_pnl{flex:none;font-size:15px}.SPgITW_dmt .SPgITW_t1,.SPgITW_dmt .SPgITW_al,.SPgITW_dmt .SPgITW_sub .SPgITW_date{flex:none}.SPgITW_dmt .SPgITW_chev{flex:none;margin-left:auto}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{margin-top:0}.SPgITW_dmt .SPgITW_dbody{padding:10px 12px 12px}.SPgITW_dmt .SPgITW_trace{padding-left:16px}.SPgITW_dmt .SPgITW_tnode:before{left:-16px}.SPgITW_dmt .SPgITW_trace:before{left:3px}}";
+const css = ".SPgITW_dmt{--col:var(--dsh-chat-content-width,748px);--page:var(--dsw-alias-bg-base,#f7f8fa);--surface:var(--dsw-alias-bg-layer-1,#fff);--text:var(--dsw-alias-label-primary,#15171b);--text2:var(--dsw-alias-label-secondary,#61666b);--text3:var(--dsw-alias-label-tertiary,#81858c);--cap:var(--dsw-alias-label-caption,#adb2b8);--brand:var(--dsw-alias-state-business-primary,#4176e6);--border:var(--dsw-alias-border-l1,#1118270f);--border2:var(--dsw-alias-border-l2,#1118271a);--hover:var(--dsw-alias-interactive-bg-hover,#1118270d);--brand-soft:#4176e612;--ok:#1b8644;--ok-soft:#e6faed;--bad:#c01313;--bad-soft:#fdebee;--warn:#aa6924;--warn-soft:#aa69241a;--shadow-sm:0 1px 2px #1018280a;--tint-soft:#00000008;--tint-border:#0000000d;--tint-mid:#00000014;--tint-strong:#0000001f;--t1-up-border:#1b84442e;--t1-down-border:#c013132e;--radius:12px;--font:var(--dsw-font-family,-apple-system,BlinkMacSystemFont,\"Segoe UI\",\"PingFang SC\",\"Hiragino Sans GB\",\"Microsoft YaHei\",sans-serif);--mono:var(--ds-font-family-code,ui-monospace,SFMono-Regular,Menlo,Consolas,monospace);font:13px/1.45 var(--font);color:var(--text);-webkit-font-smoothing:antialiased;min-height:100%}body[data-ds-dark-theme] .SPgITW_dmt{--brand-soft:#6c97f21f;--ok:#3fcb74;--ok-soft:#153824;--bad:#f2554f;--bad-soft:#3b1516;--warn:#e0a752;--warn-soft:#e0a75224;--shadow-sm:0 1px 2px #0000004d;--tint-soft:#ffffff0f;--tint-border:#ffffff14;--tint-mid:#ffffff1f;--tint-strong:#ffffff2e;--t1-up-border:#3fcb7459;--t1-down-border:#f2554f59}.SPgITW_dmt .SPgITW_top{box-sizing:border-box;padding:10px 0 0}.SPgITW_dmt .SPgITW_tin{box-sizing:border-box;max-width:calc(var(--col) - 28px);background:var(--surface);border:1px solid var(--border2);border-radius:var(--radius);box-shadow:var(--dsw-shadow-lv2,var(--shadow-sm));margin:0 auto;padding:10px 12px 11px}.SPgITW_dmt .SPgITW_tt{font:650 15px/1.3 var(--font);letter-spacing:-.01em;flex-wrap:wrap;align-items:baseline;gap:3px 8px;display:flex}.SPgITW_dmt .SPgITW_tt:before{content:\"\";background:var(--brand);border-radius:3px;flex:none;align-self:center;width:8px;height:8px}.SPgITW_dmt .SPgITW_tt .SPgITW_rate{font:400 11px/1.3 var(--font);color:var(--cap);font-variant-numeric:tabular-nums;white-space:nowrap;margin-left:auto}.SPgITW_dmt .SPgITW_ts{min-width:0;font:400 11.5px/1.4 var(--font);color:var(--cap);text-overflow:ellipsis;white-space:nowrap;flex:0 auto;overflow:hidden}.SPgITW_dmt .SPgITW_stats{flex-wrap:wrap;align-items:baseline;gap:6px 18px;margin-top:8px;display:flex}.SPgITW_dmt .SPgITW_sg{align-items:baseline;gap:6px;min-width:0;display:flex}.SPgITW_dmt .SPgITW_sl{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.03em}.SPgITW_dmt .SPgITW_sv{font:650 13.5px/1.3 var(--font);color:var(--text);font-variant-numeric:tabular-nums;white-space:nowrap}.SPgITW_dmt .SPgITW_sv.SPgITW_focus{font:700 16px/1.2 var(--font)}.SPgITW_dmt .SPgITW_sv.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_sv.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_bar{box-sizing:border-box;z-index:20;background:var(--page);background:color-mix(in srgb, var(--page) 72%, transparent);backdrop-filter:blur(10px)saturate(1.5);padding:8px 0 6px;position:sticky;top:0}.SPgITW_dmt .SPgITW_bin{box-sizing:border-box;max-width:calc(var(--col) - 28px);margin:0 auto}.SPgITW_dmt .SPgITW_filters{flex-wrap:wrap;gap:2px;margin-left:2px;display:flex}.SPgITW_dmt .SPgITW_ft{color:var(--text3);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border:0;border-radius:7px;padding:5px 10px;transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1)}.SPgITW_dmt .SPgITW_ft:active{transform:scale(.97)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_ft:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_ft.SPgITW_on{color:var(--text);background:var(--hover)}.SPgITW_dmt .SPgITW_ft:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_dmt .SPgITW_list{box-sizing:border-box;max-width:var(--col);padding:0 14px calc(var(--dsh-composer-height,152px) + 24px);margin:0 auto}.SPgITW_dmt .SPgITW_day{font:650 12.5px/1.3 var(--font);color:var(--text2);align-items:center;gap:8px;margin:18px 0 6px;display:flex}.SPgITW_dmt .SPgITW_day .SPgITW_n{color:var(--cap);font:400 10.5px/1.3 var(--mono);margin-left:auto}.SPgITW_dmt .SPgITW_day:after{content:\"\";background:var(--border);flex:1;height:1px;margin-left:6px}.SPgITW_dmt .SPgITW_day.SPgITW_fold{cursor:pointer;border-radius:8px;margin-left:-6px;padding:3px 6px;transition:background .12s}.SPgITW_dmt .SPgITW_day.SPgITW_fold:active{background:var(--tint-mid)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_day.SPgITW_fold:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_day.SPgITW_fold:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_dmt .SPgITW_day.SPgITW_fold .SPgITW_chev{text-align:center;width:12px;color:var(--cap);flex:none;margin-left:0;font-size:10px}.SPgITW_dmt .SPgITW_group{border:1px solid var(--border2);border-radius:var(--radius);background:var(--surface);box-shadow:var(--dsw-shadow-lv2,var(--shadow-sm));grid-template-columns:2px 8px auto minmax(64px,auto) auto minmax(0,1fr) auto auto 104px 12px 2px;gap:0 10px;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell{grid-column:1/-1;grid-template-columns:2px 8px auto minmax(64px,auto) auto minmax(0,1fr) auto auto 104px 12px 2px;grid-template-columns:subgrid;cursor:pointer;align-items:center;gap:0 10px;padding:9px 0;transition:background .12s;display:grid;position:relative}.SPgITW_dmt .SPgITW_cell+.SPgITW_cell{border-top:1px solid var(--border)}.SPgITW_dmt .SPgITW_cell:active{background:var(--tint-mid)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_cell:hover{background:var(--hover)}}.SPgITW_dmt .SPgITW_cell:focus-visible{outline:1px solid var(--brand);outline-offset:-2px}.SPgITW_dmt .SPgITW_cell.SPgITW_open{background:linear-gradient(180deg, var(--brand-soft), transparent 72%);box-shadow:none}.SPgITW_dmt .SPgITW_cell.SPgITW_open:before{content:\"\";background:linear-gradient(180deg, var(--brand), color-mix(in srgb, var(--brand) 14%, transparent));border-radius:2px;width:3px;position:absolute;top:10px;bottom:10px;left:0}.SPgITW_dmt .SPgITW_main,.SPgITW_dmt .SPgITW_sub{display:contents}.SPgITW_dmt .SPgITW_dotm{background:var(--cap);border-radius:50%;grid-area:1/2;width:6px;height:6px}.SPgITW_dmt .SPgITW_cell.SPgITW_hasdec .SPgITW_dotm{background:var(--brand)}.SPgITW_dmt .SPgITW_sub .SPgITW_date{font:400 11px/1.4 var(--mono);color:var(--cap);font-variant-numeric:tabular-nums;white-space:nowrap;grid-area:1/3}.SPgITW_dmt .SPgITW_tk{min-width:0;font:650 14px/1.4 var(--font);letter-spacing:-.01em;text-overflow:ellipsis;white-space:nowrap;grid-area:1/4;overflow:hidden}.SPgITW_dmt .SPgITW_mkt{font:700 9.5px/1 var(--font);vertical-align:2px;color:var(--brand);margin-left:3px}.SPgITW_dmt .SPgITW_mkt.SPgITW_hk{color:var(--text3)}.SPgITW_dmt .SPgITW_tag{border:1px solid var(--tint-border);background:var(--tint-soft);height:20px;font:600 11.5px/1 var(--font);color:var(--text2);letter-spacing:.02em;white-space:nowrap;border-radius:6px;grid-area:1/5;justify-self:start;align-items:center;padding:0 7px;display:inline-flex}.SPgITW_dmt .SPgITW_qty{min-width:0;font:500 12.5px/1.4 var(--mono);color:var(--text2);font-variant-numeric:tabular-nums;white-space:nowrap;text-overflow:ellipsis;grid-area:1/6;justify-self:start;overflow:hidden}.SPgITW_dmt .SPgITW_sp{display:none}.SPgITW_dmt .SPgITW_pnl{text-align:right;font:700 15.5px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;grid-area:1/9;justify-self:end}.SPgITW_dmt .SPgITW_pnl.SPgITW_up{color:var(--ok)}.SPgITW_dmt .SPgITW_pnl.SPgITW_down{color:var(--bad)}.SPgITW_dmt .SPgITW_pnl.SPgITW_na{color:var(--cap);font-size:13px;font-weight:500}.SPgITW_dmt .SPgITW_pnlk{font:600 10.5px/1.2 var(--font);color:var(--cap);letter-spacing:0;margin-right:3px}.SPgITW_dmt .SPgITW_t1{height:19px;font:600 10.5px/1 var(--font);white-space:nowrap;font-variant-numeric:tabular-nums;border-radius:5px;grid-area:1/8;justify-self:end;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_t1.SPgITW_up{color:var(--ok);background:var(--ok-soft);border:1px solid var(--t1-up-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_down{color:var(--bad);background:var(--bad-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_t1.SPgITW_flat{color:var(--text2);background:var(--tint-soft)}.SPgITW_dmt .SPgITW_al{height:19px;font:600 10.5px/1 var(--font);white-space:nowrap;letter-spacing:.02em;border-radius:5px;grid-area:1/7;justify-self:end;align-items:center;padding:0 6px;display:inline-flex}.SPgITW_dmt .SPgITW_al.SPgITW_opp{color:var(--warn);background:var(--warn-soft);border:1px solid var(--t1-down-border)}.SPgITW_dmt .SPgITW_chev{color:var(--cap);grid-area:1/10;justify-self:end;font-size:10px;transition:transform .15s}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_chev{transform:rotate(180deg)}.SPgITW_dmt .SPgITW_detail{opacity:0;grid-area:2/1/auto/-1;grid-template-rows:0fr;transition:grid-template-rows .24s cubic-bezier(.22,1,.36,1),opacity .15s;display:grid;overflow:hidden}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{opacity:1;border-top:1px solid var(--tint-border);grid-template-rows:1fr;margin-top:9px}.SPgITW_dmt .SPgITW_dinner{min-height:0;padding:0;overflow:hidden}.SPgITW_dmt .SPgITW_dbody{padding:12px}.SPgITW_dmt .SPgITW_trhead{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.05em;align-items:center;gap:6px;margin-bottom:8px;display:flex}.SPgITW_dmt .SPgITW_trhead:before{content:\"\";background:var(--brand);border-radius:50%;width:6px;height:6px}.SPgITW_dmt .SPgITW_trace{padding-left:22px;position:relative}.SPgITW_dmt .SPgITW_trace:before{content:\"\";background:var(--tint-mid);width:2px;position:absolute;top:12px;bottom:10px;left:5px}.SPgITW_dmt .SPgITW_tnode{padding:2px 0 14px;position:relative}.SPgITW_dmt .SPgITW_tnode:last-child{padding-bottom:2px}.SPgITW_dmt .SPgITW_tnode:before{content:\"\";background:var(--surface);border:2px solid var(--cap);box-sizing:border-box;border-radius:50%;width:10px;height:10px;position:absolute;top:5px;left:-22px}.SPgITW_dmt .SPgITW_tnode.SPgITW_dec:before{border-color:var(--brand)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip:before{border-color:var(--warn)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win:before{border-color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss:before{border-color:var(--bad)}.SPgITW_dmt .SPgITW_tnode .SPgITW_tw{font:400 10px/1.4 var(--mono);color:var(--cap);margin-bottom:1px}.SPgITW_dmt .SPgITW_tnode .SPgITW_n{font:500 10.5px/1.3 var(--font);color:var(--cap);letter-spacing:.04em;margin-bottom:2px}.SPgITW_dmt .SPgITW_tnode .SPgITW_v{font:600 13px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tnode.SPgITW_win .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_loss .SPgITW_v{color:var(--bad)}.SPgITW_dmt .SPgITW_tnode.SPgITW_follow .SPgITW_v{color:var(--ok)}.SPgITW_dmt .SPgITW_tnode.SPgITW_skip .SPgITW_v{color:var(--warn)}.SPgITW_dmt .SPgITW_pchips{flex-wrap:wrap;gap:6px;margin:4px 0 8px;display:flex}.SPgITW_dmt .SPgITW_pc{font:400 11px/1.4 var(--font);background:var(--tint-soft);border:1px solid var(--border2);color:var(--text2);border-radius:6px;padding:2px 8px}.SPgITW_dmt .SPgITW_tnote{border-left:3px solid var(--tint-strong);font:400 11.5px/1.6 var(--font);color:var(--text2);white-space:pre-wrap;overflow-wrap:anywhere;margin:7px 0;padding:3px 0 3px 10px}.SPgITW_dmt .SPgITW_tnote.SPgITW_why{border-left-color:var(--brand)}.SPgITW_dmt .SPgITW_tnote.SPgITW_emo{border-left-color:var(--warn)}.SPgITW_dmt .SPgITW_tnote .SPgITW_k{color:var(--cap);font:600 10.5px/1.4 var(--font)}.SPgITW_dmt .SPgITW_tmiss{border:1px dashed var(--border2);font:400 11.5px/1.5 var(--font);color:var(--cap);border-radius:6px;margin-top:8px;padding:7px 10px}.SPgITW_dmt .SPgITW_empty{text-align:center;color:var(--cap);font:400 13px/1.5 var(--font);padding:48px 20px}.SPgITW_dmt .SPgITW_trace-more{border:1px dashed var(--border2);width:100%;color:var(--text2);font:600 12px/1.4 var(--font);cursor:pointer;background:0 0;border-radius:10px;margin:12px 0 0;padding:9px 12px;transition:background .12s,border-color .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1);display:block}.SPgITW_dmt .SPgITW_trace-more:active{transform:scale(.98)}@media (hover:hover) and (pointer:fine){.SPgITW_dmt .SPgITW_trace-more:hover{background:var(--hover);border-color:var(--brand);color:var(--text)}}.SPgITW_dmt .SPgITW_skel{border:1px solid var(--border2);border-radius:var(--radius);background:var(--surface);align-items:center;gap:12px;margin:8px 0;padding:13px 12px;display:flex}.SPgITW_dmt .SPgITW_skel-dot{background:var(--tint-strong);border-radius:50%;flex:none;width:6px;height:6px}.SPgITW_dmt .SPgITW_skel-bar{background:var(--tint-mid);border-radius:5px;height:10px;position:relative;overflow:hidden}.SPgITW_dmt .SPgITW_skel-bar:after{content:\"\";background:linear-gradient(90deg, transparent, var(--tint-strong), transparent);animation:1.2s ease-in-out infinite SPgITW_clawock-shimmer;position:absolute;inset:0;transform:translate(-100%)}@keyframes SPgITW_clawock-shimmer{to{transform:translate(100%)}}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w40{width:40%}.SPgITW_dmt .SPgITW_skel-bar.SPgITW_w20{width:20%}@media (prefers-reduced-motion:reduce){.SPgITW_dmt .SPgITW_chev{transition:none}.SPgITW_dmt .SPgITW_detail{transition:opacity .15s}.SPgITW_dmt .SPgITW_ft,.SPgITW_dmt .SPgITW_trace-more{transition:background .12s,color .12s,border-color .12s}.SPgITW_dmt .SPgITW_skel-bar:after{animation:none}}@media (width<=520px){.SPgITW_dmt .SPgITW_top{padding:8px 10px 0}.SPgITW_dmt .SPgITW_bar{padding:6px 10px}.SPgITW_dmt .SPgITW_bin{max-width:none}.SPgITW_dmt .SPgITW_tin{max-width:none;padding:10px 12px 9px}.SPgITW_dmt .SPgITW_ts{white-space:normal;flex:1 0 100%}.SPgITW_dmt .SPgITW_stats{margin-top:6px;display:block}.SPgITW_dmt .SPgITW_sg{justify-content:space-between;gap:10px;padding:3px 0}.SPgITW_dmt .SPgITW_sg+.SPgITW_sg{border-top:1px solid var(--border)}.SPgITW_dmt .SPgITW_sv{white-space:normal;text-align:right}.SPgITW_dmt .SPgITW_ft{min-height:32px;padding:6px 11px}.SPgITW_dmt .SPgITW_list{padding:0 10px calc(var(--dsh-composer-height,152px) + 24px)}.SPgITW_dmt .SPgITW_day.SPgITW_fold{padding:7px 6px}.SPgITW_dmt .SPgITW_group{display:block}.SPgITW_dmt .SPgITW_cell{padding:0;display:block}.SPgITW_dmt .SPgITW_main{align-items:center;gap:8px;padding:10px 12px 2px;display:flex}.SPgITW_dmt .SPgITW_sub{align-items:center;gap:8px;padding:2px 12px 10px;display:flex}.SPgITW_dmt .SPgITW_dotm{flex:none;width:7px;height:7px}.SPgITW_dmt .SPgITW_tk{flex:0 auto;font-size:14.5px}.SPgITW_dmt .SPgITW_tag{flex:none;height:19px;padding:0 6px}.SPgITW_dmt .SPgITW_qty{flex:0 auto;font-size:12px}.SPgITW_dmt .SPgITW_sp{flex:auto;min-width:6px;display:block}.SPgITW_dmt .SPgITW_pnl{flex:none;font-size:15px}.SPgITW_dmt .SPgITW_t1,.SPgITW_dmt .SPgITW_al,.SPgITW_dmt .SPgITW_sub .SPgITW_date{flex:none}.SPgITW_dmt .SPgITW_chev{flex:none;margin-left:auto}.SPgITW_dmt .SPgITW_cell.SPgITW_open .SPgITW_detail{margin-top:0}.SPgITW_dmt .SPgITW_dbody{padding:10px 12px 12px}.SPgITW_dmt .SPgITW_trace{padding-left:16px}.SPgITW_dmt .SPgITW_tnode:before{left:-16px}.SPgITW_dmt .SPgITW_trace:before{left:3px}}.SPgITW_pbc{--surface:var(--dsw-alias-bg-layer-1,#fff);--text:var(--dsw-alias-label-primary,#15171b);--text3:var(--dsw-alias-label-tertiary,#81858c);--cap:var(--dsw-alias-label-caption,#adb2b8);--brand:var(--dsw-alias-state-business-primary,#4176e6);--hover:var(--dsw-alias-interactive-bg-hover,#1118270d);--ok:#1b8644;--bad:#c01313;--warn:#aa6924;--shadow-lg:0 16px 40px #10182829, 0 2px 10px #10182814;--tint-border:#0000000d;--pop-surface:#ffffffb8;--edge-light:#ffffff8c;--font:var(--dsw-font-family,-apple-system,BlinkMacSystemFont,\"Segoe UI\",\"PingFang SC\",\"Hiragino Sans GB\",\"Microsoft YaHei\",sans-serif);display:inline-flex;position:relative}body[data-ds-dark-theme] .SPgITW_pbc{--ok:#3fcb74;--bad:#f2554f;--warn:#e0a752;--shadow-lg:0 16px 40px #00000085, 0 2px 10px #0000005c;--tint-border:#ffffff14;--pop-surface:#1c1e22c7;--edge-light:#ffffff1f}.SPgITW_pbc .SPgITW_bchip{border:1px solid var(--tint-border);background:var(--surface);background:color-mix(in srgb, var(--surface) 62%, transparent);backdrop-filter:blur(10px)saturate(1.6);height:26px;box-shadow:var(--dsw-shadow-lv1,0 1px 2px #1018280a), inset 0 1px 0 var(--edge-light);font:500 12px/1 var(--font);color:var(--text3);cursor:pointer;border-radius:13px;align-items:center;gap:10px;padding:0 11px;transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1);display:inline-flex;position:relative}.SPgITW_pbc .SPgITW_bchip:after{content:\"\";border-radius:20px;position:absolute;inset:-7px}.SPgITW_pbc .SPgITW_bchip:active{transform:scale(.96)}@media (hover:hover) and (pointer:fine){.SPgITW_pbc .SPgITW_bchip:hover{background:color-mix(in srgb, var(--surface) 80%, transparent)}}.SPgITW_pbc .SPgITW_bchip:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_pbc .SPgITW_bchip-item{align-items:center;gap:5px;display:inline-flex}.SPgITW_pbc .SPgITW_bchip-dot{background:var(--cap);border-radius:50%;flex:none;width:6px;height:6px;transition:background .15s}.SPgITW_pbc .SPgITW_bchip-item[data-balance-state=ok] .SPgITW_bchip-dot{background:var(--ok)}.SPgITW_pbc .SPgITW_bchip-item[data-balance-state=low] .SPgITW_bchip-dot{background:var(--bad)}.SPgITW_pbc .SPgITW_bchip-item[data-balance-state=stale] .SPgITW_bchip-dot{background:var(--warn)}.SPgITW_pbc .SPgITW_bchip-v{font:600 12px/1 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;white-space:nowrap;color:var(--text)}.SPgITW_pbc .SPgITW_bchip-v[data-balance-state=low]{color:var(--bad)}.SPgITW_pbc .SPgITW_bchip-v[data-balance-state=none]{color:var(--cap);font-weight:500}.SPgITW_pbc .SPgITW_bchip-sub{font:500 11px/1 var(--font);font-variant-numeric:tabular-nums;letter-spacing:.01em;white-space:nowrap;color:var(--text3)}.SPgITW_pbc .SPgITW_bp{z-index:60;border:1px solid var(--tint-border);background:var(--surface);background:color-mix(in srgb, var(--pop-surface) 100%, transparent);backdrop-filter:blur(28px)saturate(1.8);width:max-content;min-width:min(220px,100vw - 24px);max-width:min(300px,100vw - 24px);box-shadow:var(--shadow-lg), inset 0 1px 0 var(--edge-light);transform-origin:100% 0;border-radius:12px;padding:10px 12px 8px;transition:transform .16s cubic-bezier(.23,1,.32,1),opacity .16s cubic-bezier(.23,1,.32,1);position:absolute;top:calc(100% + 8px);right:0}.SPgITW_pbc .SPgITW_bp[data-open=false]{opacity:0;pointer-events:none;transform:scale(.97)translateY(-4px)}.SPgITW_pbc .SPgITW_bp-head{justify-content:space-between;align-items:center;margin-bottom:2px;display:flex}.SPgITW_pbc .SPgITW_bp-title{font:600 11px/1.3 var(--font);letter-spacing:.04em;color:var(--cap)}.SPgITW_pbc .SPgITW_bp-row{width:100%;font:inherit;color:inherit;text-align:left;cursor:pointer;background:0 0;border:0;border-radius:8px;grid-template-columns:auto auto 1fr;align-items:center;gap:3px 8px;margin:0 -6px;padding:8px 6px;transition:background .12s,transform .16s cubic-bezier(.23,1,.32,1);display:grid}.SPgITW_pbc .SPgITW_bp-row+.SPgITW_bp-row{border-radius:0 0 8px 8px;position:relative}.SPgITW_pbc .SPgITW_bp-row+.SPgITW_bp-row:before{content:\"\";background:var(--tint-border);height:1px;position:absolute;top:0;left:6px;right:6px}@media (hover:hover) and (pointer:fine){.SPgITW_pbc .SPgITW_bp-row:hover{background:var(--hover)}}.SPgITW_pbc .SPgITW_bp-row:active{background:var(--hover);transform:scale(.98)}.SPgITW_pbc .SPgITW_bp-row:focus-visible{outline:1px solid var(--brand);outline-offset:-1px}.SPgITW_pbc .SPgITW_bp-dot{background:var(--cap);border-radius:50%;width:7px;height:7px}.SPgITW_pbc .SPgITW_bp-dot[data-balance-state=ok]{background:var(--ok)}.SPgITW_pbc .SPgITW_bp-dot[data-balance-state=low]{background:var(--bad)}.SPgITW_pbc .SPgITW_bp-dot[data-balance-state=stale]{background:var(--warn)}.SPgITW_pbc .SPgITW_bp-label{font:500 12px/1.4 var(--font);color:var(--text);align-items:center;gap:5px;display:inline-flex}.SPgITW_pbc .SPgITW_bp-pin{background:var(--brand);border-radius:50%;flex:none;width:5px;height:5px}.SPgITW_pbc .SPgITW_bp-v{font:650 13px/1.2 var(--font);font-variant-numeric:tabular-nums;letter-spacing:-.01em;white-space:nowrap;color:var(--text);justify-self:end}.SPgITW_pbc .SPgITW_bp-v.SPgITW_bad{color:var(--bad)}.SPgITW_pbc .SPgITW_bp-wins{flex-direction:column;grid-column:1/-1;gap:6px;margin-top:2px;display:flex}.SPgITW_pbc .SPgITW_bp-win{flex-direction:column;gap:3px;font-size:11px;display:flex}.SPgITW_pbc .SPgITW_bp-win-line{align-items:baseline;gap:8px;line-height:1.5;display:flex}.SPgITW_pbc .SPgITW_bp-win-label{color:var(--cap);letter-spacing:.02em;min-width:30px}.SPgITW_pbc .SPgITW_bp-win-pct{color:var(--text);font-variant-numeric:tabular-nums;margin-left:auto;font-weight:600}.SPgITW_pbc .SPgITW_bp-win-reset{color:var(--cap);font-family:var(--mono);text-align:right;font-variant-numeric:tabular-nums;min-width:58px;font-size:10.5px}.SPgITW_pbc .SPgITW_bp-win-bar{background:color-mix(in srgb, var(--text) 9%, transparent);border-radius:2px;height:3px;overflow:hidden}.SPgITW_pbc .SPgITW_bp-win-fill{background:color-mix(in srgb, var(--text) 42%, transparent);border-radius:2px;height:100%;transition:background .15s}.SPgITW_pbc .SPgITW_bp-win-fill[data-balance-state=low]{background:var(--bad)}.SPgITW_pbc .SPgITW_bp-win-fill[data-balance-state=stale]{background:var(--warn)}.SPgITW_pbc .SPgITW_bp-note,.SPgITW_pbc .SPgITW_bp-sub{font:400 11px/1.5 var(--font);overflow-wrap:anywhere;grid-column:1/-1}.SPgITW_pbc .SPgITW_bp-sub{color:var(--cap)}.SPgITW_pbc .SPgITW_bp-note.SPgITW_warn{color:var(--warn)}.SPgITW_pbc .SPgITW_bp-note.SPgITW_bad{color:var(--bad)}.SPgITW_pbc .SPgITW_bp-empty{font:400 12px/1.5 var(--font);color:var(--cap);padding:8px 0 10px}.SPgITW_pbc .SPgITW_bal-rf{width:22px;height:22px;color:var(--text3);font:600 12px/1 var(--font);cursor:pointer;background:0 0;border:0;border-radius:50%;justify-content:center;align-items:center;padding:0;transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1);display:inline-flex;position:relative}.SPgITW_pbc .SPgITW_bal-rf:after{content:\"\";border-radius:50%;position:absolute;inset:-9px}.SPgITW_pbc .SPgITW_bal-rf:active{transform:scale(.95)}@media (hover:hover) and (pointer:fine){.SPgITW_pbc .SPgITW_bal-rf:hover{background:var(--hover);color:var(--text)}}.SPgITW_pbc .SPgITW_bal-rf:focus-visible{outline:1px solid var(--brand);outline-offset:1px}.SPgITW_pbc .SPgITW_bal-rf.SPgITW_spin{animation:.8s linear infinite SPgITW_clawock-spin}.SPgITW_pbc .SPgITW_bal-rf.SPgITW_flash-ok{color:var(--brand)}.SPgITW_pbc .SPgITW_bal-rf.SPgITW_flash-same{color:var(--ok)}@keyframes SPgITW_clawock-spin{to{transform:rotate(360deg)}}@media (prefers-reduced-motion:reduce){.SPgITW_pbc .SPgITW_bchip,.SPgITW_pbc .SPgITW_bal-rf{transition:background .12s,color .12s}.SPgITW_pbc .SPgITW_bp{transition:opacity .16s}.SPgITW_pbc .SPgITW_bp[data-open=false],.SPgITW_pbc .SPgITW_bchip:active,.SPgITW_pbc .SPgITW_bal-rf:active{transform:none}.SPgITW_pbc .SPgITW_bal-rf.SPgITW_spin{animation:none}.SPgITW_pbc .SPgITW_bp-win-fill{transition:none}}@media (width<=520px){.SPgITW_pbc .SPgITW_bchip{backdrop-filter:blur(7px)saturate(1.4)}.SPgITW_pbc .SPgITW_bp{backdrop-filter:blur(14px)saturate(1.5)}}@media (prefers-reduced-transparency:reduce){.SPgITW_pbc .SPgITW_bchip,.SPgITW_pbc .SPgITW_bp{background:var(--surface);backdrop-filter:none}}";
 const tagId = "clawock-dsh/styles.module.css";
 if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
 	const tag = document.createElement("style");
@@ -4574,11 +4638,38 @@ if (typeof document !== "undefined" && document.querySelector("style[data-plugin
 }
 var styles_module_css_default = {
 	"al": "SPgITW_al",
+	"bad": "SPgITW_bad",
+	"bal-rf": "SPgITW_bal-rf",
 	"bar": "SPgITW_bar",
+	"bchip": "SPgITW_bchip",
+	"bchip-dot": "SPgITW_bchip-dot",
+	"bchip-item": "SPgITW_bchip-item",
+	"bchip-sub": "SPgITW_bchip-sub",
+	"bchip-v": "SPgITW_bchip-v",
 	"bin": "SPgITW_bin",
+	"bp": "SPgITW_bp",
+	"bp-dot": "SPgITW_bp-dot",
+	"bp-empty": "SPgITW_bp-empty",
+	"bp-head": "SPgITW_bp-head",
+	"bp-label": "SPgITW_bp-label",
+	"bp-note": "SPgITW_bp-note",
+	"bp-pin": "SPgITW_bp-pin",
+	"bp-row": "SPgITW_bp-row",
+	"bp-sub": "SPgITW_bp-sub",
+	"bp-title": "SPgITW_bp-title",
+	"bp-v": "SPgITW_bp-v",
+	"bp-win": "SPgITW_bp-win",
+	"bp-win-bar": "SPgITW_bp-win-bar",
+	"bp-win-fill": "SPgITW_bp-win-fill",
+	"bp-win-label": "SPgITW_bp-win-label",
+	"bp-win-line": "SPgITW_bp-win-line",
+	"bp-win-pct": "SPgITW_bp-win-pct",
+	"bp-win-reset": "SPgITW_bp-win-reset",
+	"bp-wins": "SPgITW_bp-wins",
 	"cell": "SPgITW_cell",
 	"chev": "SPgITW_chev",
 	"clawock-shimmer": "SPgITW_clawock-shimmer",
+	"clawock-spin": "SPgITW_clawock-spin",
 	"date": "SPgITW_date",
 	"day": "SPgITW_day",
 	"dbody": "SPgITW_dbody",
@@ -4591,6 +4682,8 @@ var styles_module_css_default = {
 	"emo": "SPgITW_emo",
 	"empty": "SPgITW_empty",
 	"filters": "SPgITW_filters",
+	"flash-ok": "SPgITW_flash-ok",
+	"flash-same": "SPgITW_flash-same",
 	"flat": "SPgITW_flat",
 	"focus": "SPgITW_focus",
 	"fold": "SPgITW_fold",
@@ -4609,6 +4702,7 @@ var styles_module_css_default = {
 	"on": "SPgITW_on",
 	"open": "SPgITW_open",
 	"opp": "SPgITW_opp",
+	"pbc": "SPgITW_pbc",
 	"pc": "SPgITW_pc",
 	"pchips": "SPgITW_pchips",
 	"pnl": "SPgITW_pnl",
@@ -4622,6 +4716,7 @@ var styles_module_css_default = {
 	"skip": "SPgITW_skip",
 	"sl": "SPgITW_sl",
 	"sp": "SPgITW_sp",
+	"spin": "SPgITW_spin",
 	"stats": "SPgITW_stats",
 	"sub": "SPgITW_sub",
 	"sv": "SPgITW_sv",
@@ -4643,6 +4738,7 @@ var styles_module_css_default = {
 	"v": "SPgITW_v",
 	"w20": "SPgITW_w20",
 	"w40": "SPgITW_w40",
+	"warn": "SPgITW_warn",
 	"why": "SPgITW_why",
 	"win": "SPgITW_win"
 };
@@ -4928,6 +5024,251 @@ function relativeDay(iso, today) {
 	if (days >= 2 && days <= 7) return days + "天前";
 	return parseInt(iso.slice(5, 7)) + "月" + parseInt(iso.slice(8, 10)) + "日";
 }
+/**
+* Display projection of ONE provider's answer (test seam, like _displayEntry):
+* the chip and panel render only these fields, so the view never keeps
+* a second copy of the tone rules — the host already decided status and low.
+* The title is the whole hover story: split, quota windows, stale reason,
+* fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
+* and carry the second window ('周'/'本周') as a muted pill suffix — both
+* limits visible at the header without opening the panel.
+*/
+function _rowDisplay(result) {
+	if (result === null) return {
+		tone: "none",
+		value: "—",
+		sub: null,
+		title: "余额加载中"
+	};
+	if (!result.configured) return {
+		tone: "none",
+		value: "未配置",
+		sub: null,
+		title: result.message ?? "未配置 API Key"
+	};
+	if (result.snapshot === null) return {
+		tone: "none",
+		value: "—",
+		sub: null,
+		title: result.message ?? "余额获取失败"
+	};
+	const snapshot = result.snapshot;
+	const isPct = snapshot.unit === "pct";
+	const symbol = isPct ? "" : snapshot.currency === "USD" ? "$" : snapshot.currency === "CNY" ? "¥" : "";
+	const pctWins = isPct && Array.isArray(snapshot.windows) ? snapshot.windows.filter((w) => w.percent !== null) : [];
+	const parsed = Number.parseFloat(snapshot.totalBalance);
+	const value = isFinite(parsed) ? isPct ? String(Math.round(parsed)) + "%" : symbol + parsed.toLocaleString(void 0, { maximumFractionDigits: 2 }) : pctWins.length > 0 ? String(Math.round(pctWins[0].percent)) + "%" : snapshot.totalBalance === "" ? "—" : symbol + snapshot.totalBalance;
+	const second = pctWins.length > 1 ? pctWins[1] : null;
+	const sub = second !== null ? "· " + second.label + " " + Math.round(second.percent) + "%" : null;
+	return {
+		tone: result.status === "stale" ? "stale" : result.low || !snapshot.isAvailable ? "low" : "ok",
+		value,
+		sub,
+		title: [
+			snapshot.unit === "pct" ? snapshot.note !== "" ? snapshot.note : "配额窗口余量" : "API 余额",
+			!isPct && snapshot.grantedBalance !== "" ? "赠金 " + symbol + snapshot.grantedBalance : null,
+			!isPct && snapshot.toppedUpBalance !== "" ? "充值 " + symbol + snapshot.toppedUpBalance : null,
+			snapshot.isAvailable ? null : isPct ? "该窗口额度已用尽" : "官方接口判定余额不足",
+			result.status === "stale" && result.message !== null ? "刷新失败,显示最近一次: " + result.message : null
+		].filter((part) => part !== null).join(" · ")
+	};
+}
+/**
+* The one line a panel row says out loud when something is wrong — stale
+* reason, unconfigured key, insufficient balance/quota. A healthy number
+* earns no caption at all; null means silence.
+*/
+function _balanceNote(result) {
+	if (result === null) return null;
+	if (!result.configured) return result.message ?? "未配置 API Key";
+	if (result.snapshot === null) return result.message ?? "余额获取失败";
+	if (result.status === "stale") return "刷新失败,显示最近一次" + (result.message !== null ? ":" + result.message : "");
+	if (!result.snapshot.isAvailable) return result.snapshot.unit === "pct" ? "该窗口额度已用尽" : "官方接口判定余额不足";
+	if (result.low) {
+		if (result.snapshot.unit === "pct") return "窗口余量不足 " + result.threshold + "%";
+		return "余额偏低,低于阈值 " + (result.snapshot.currency === "USD" ? "$" : result.snapshot.currency === "CNY" ? "¥" : "") + result.threshold;
+	}
+	return null;
+}
+/** Store factory — called inside `apply`, never a module-level handle. */
+function createBalanceStore() {
+	return defineStore({
+		init: () => ({ selected: null }),
+		actions: { select: (draft, provider) => {
+			draft.selected = provider;
+		} }
+	});
+}
+/**
+* The session-header chip (#871's final home): account status is app chrome,
+* not decision data and not its own tab. The pill headlines ONE provider —
+* the pinned one (registration store) or the first configured row — and the
+* panel lists every provider; clicking a row pins it as the headline, which
+* reads as "the balance of whichever service I'm actually burning". Same
+* contracts: [data-balance-state], [data-pb-provider], [data-pb-role],
+* [data-refresh], no emoji.
+*/
+/**
+* The per-provider detail under its headline: quota providers get one line
+* per window — label / remaining / reset right-aligned — so the 5h and week
+* resets scan as a column instead of drowning in a sentence. Money rows keep
+* their granted/topped-up split. Abnormal notes render above this path.
+*/
+function renderRowDetail(row) {
+	if (row.note !== null) return null;
+	const wins = row.result.snapshot?.windows ?? [];
+	if (wins.length > 0) return h("div", { className: cx("bp-wins") }, wins.map((w) => {
+		const pct = w.percent === null ? null : Math.max(0, Math.min(100, Math.round(w.percent)));
+		const state = pct !== null && row.result.snapshot?.unit === "pct" && pct <= row.result.threshold ? "low" : row.view.tone === "stale" ? "stale" : "ok";
+		return h("div", {
+			className: cx("bp-win"),
+			key: w.label
+		}, h("div", { className: cx("bp-win-line") }, h("span", { className: cx("bp-win-label") }, w.label), h("span", { className: cx("bp-win-pct") }, w.percent === null ? "—" : Math.round(w.percent) + "%"), h("span", { className: cx("bp-win-reset") }, w.resetAt === "" ? "" : "↻ " + w.resetAt)), h("div", { className: cx("bp-win-bar") }, h("div", {
+			className: cx("bp-win-fill"),
+			style: pct === null ? { width: "0%" } : { width: pct + "%" },
+			"data-balance-state": state
+		})));
+	}));
+	const title = row.view.title;
+	if (title === "") return null;
+	const body = title.startsWith("API 余额 · ") ? title.slice(9) : title;
+	return h("div", { className: cx("bp-sub") }, body);
+}
+function ProviderBalanceChip(props) {
+	const mountedRef = useRef(true);
+	const [data, setData] = useState(() => ({
+		result: props.cachedBalances(),
+		loading: false
+	}));
+	const selected = props.useStore((state) => state.selected);
+	const select = (provider) => {
+		props.actions.select(provider);
+	};
+	const [open, setOpen] = useState(false);
+	const [flash, setFlash] = useState(null);
+	const flashTimerRef = useRef(null);
+	const rootRef = useRef(null);
+	const runBalances = (force) => {
+		props.fetchBalances(force).then((result) => {
+			if (!mountedRef.current) return;
+			setData({
+				result,
+				loading: false
+			});
+			if (force) {
+				setFlash(result.providers.some((p) => p.result.status === "fresh") ? "ok" : "same");
+				if (flashTimerRef.current !== null) clearTimeout(flashTimerRef.current);
+				flashTimerRef.current = setTimeout(() => {
+					setFlash(null);
+				}, 1200);
+			}
+		}, () => {
+			if (mountedRef.current) setData((current) => ({
+				...current,
+				loading: false
+			}));
+		});
+	};
+	useEffect(() => {
+		mountedRef.current = true;
+		runBalances(false);
+		return () => {
+			mountedRef.current = false;
+			if (flashTimerRef.current !== null) clearTimeout(flashTimerRef.current);
+		};
+	}, [props.sessionId]);
+	useEffect(() => {
+		const intervalMs = Math.max(6e4, data.result?.refreshMs ?? 6e4);
+		const timer = setInterval(() => {
+			runBalances(false);
+		}, intervalMs);
+		return () => clearInterval(timer);
+	}, [data.result?.refreshMs, props.sessionId]);
+	useEffect(() => {
+		if (!open || typeof document === "undefined") return void 0;
+		const onKey = (event) => {
+			if (event.key === "Escape") setOpen(false);
+		};
+		const onDown = (event) => {
+			const root = rootRef.current;
+			if (root !== null && event.target instanceof Node && !root.contains(event.target)) setOpen(false);
+		};
+		document.addEventListener("keydown", onKey);
+		document.addEventListener("mousedown", onDown);
+		return () => {
+			document.removeEventListener("keydown", onKey);
+			document.removeEventListener("mousedown", onDown);
+		};
+	}, [open]);
+	const rows = (data.result?.providers ?? []).map((provider) => ({
+		...provider,
+		view: _rowDisplay(provider.result),
+		note: _balanceNote(provider.result)
+	}));
+	const primary = rows.find((row) => row.provider === selected) ?? rows[0];
+	const refresh = () => {
+		setData((current) => ({
+			...current,
+			loading: true
+		}));
+		runBalances(true);
+	};
+	return h("span", {
+		className: cx("pbc"),
+		ref: rootRef
+	}, h("button", {
+		type: "button",
+		className: cx("bchip"),
+		"data-balance-state": primary !== void 0 ? primary.view.tone : "none",
+		"data-pb-provider": primary !== void 0 ? primary.provider : "",
+		"aria-expanded": open,
+		"aria-haspopup": "dialog",
+		"aria-label": "各模型服务余额",
+		title: primary !== void 0 ? primary.label + " · " + primary.view.title + (rows.length > 1 ? "(点击查看其他服务)" : "") : "余额加载中",
+		onClick: () => {
+			setOpen(!open);
+		}
+	}, primary === void 0 ? h("span", { className: cx("bchip-item") }, h("span", { className: cx("bchip-dot") }), "—") : h("span", {
+		className: cx("bchip-item"),
+		"data-pb-provider": primary.provider,
+		"data-pb-role": "chip",
+		"data-balance-state": primary.view.tone
+	}, h("span", { className: cx("bchip-dot") }), h("span", {
+		className: cx("bchip-v"),
+		"data-balance-state": primary.view.tone
+	}, primary.view.value), primary.view.sub === null ? null : h("span", {
+		className: cx("bchip-sub"),
+		"aria-hidden": "true"
+	}, primary.view.sub))), h("div", {
+		className: cx("bp"),
+		"data-open": open ? "true" : "false",
+		role: open ? "dialog" : "none",
+		"aria-label": "各模型服务余额"
+	}, h("div", { className: cx("bp-head") }, h("span", { className: cx("bp-title") }, "API 余额"), h("button", {
+		type: "button",
+		className: cx("bal-rf", data.loading && "spin", flash === "ok" && "flash-ok", flash === "same" && "flash-same"),
+		"data-refresh": "true",
+		"aria-label": "刷新全部余额",
+		title: "立即刷新",
+		onClick: refresh
+	}, flash === "ok" ? "✓" : "↻")), rows.length === 0 ? h("div", { className: cx("bp-empty") }, "正在读取各服务余额…") : rows.map((row) => h("button", {
+		type: "button",
+		key: row.provider,
+		className: cx("bp-row"),
+		"data-pb-provider": row.provider,
+		"data-pb-role": "panel",
+		"aria-pressed": row.provider === (primary !== void 0 ? primary.provider : ""),
+		onClick: () => {
+			select(row.provider);
+		}
+	}, h("span", {
+		className: cx("bp-dot"),
+		"data-balance-state": row.view.tone
+	}), h("span", { className: cx("bp-label") }, row.label, row.provider === (primary !== void 0 ? primary.provider : "") ? h("span", { className: cx("bp-pin") }) : null), h("span", {
+		className: cx("bp-v", row.view.tone === "low" ? "bad" : ""),
+		"data-balance-state": row.view.tone
+	}, row.view.value), row.note !== null ? h("div", { className: cx("bp-note", row.view.tone === "stale" ? "warn" : "bad") }, row.note) : renderRowDetail(row)))));
+}
 function DecisionMind(props) {
 	const filter = props.useStore((state) => state.filter);
 	const open = props.useStore((state) => state.open);
@@ -5114,6 +5455,7 @@ async function apply(ctx) {
 	await ctx.remote.$mount(TYPERT_REMOTE);
 	const studioRemote = ctx.get("remote.clawockStudio");
 	let cached = null;
+	let cachedBalances = null;
 	const call = async (method, args = []) => {
 		const result = await studioRemote[method](...args);
 		if (!result.ok) throw new Error("clawockStudio." + method + " failed: " + result.error.code + ": " + result.error.message);
@@ -5137,6 +5479,14 @@ async function apply(ctx) {
 			};
 		}
 	});
+	const balancesInjected = () => ({
+		cachedBalances: () => cachedBalances,
+		fetchBalances: async (force) => {
+			const result = await call("balance", [force]);
+			cachedBalances = result;
+			return result;
+		}
+	});
 	const store = createDecisionMindStore();
 	ctx.slots.inject("conversation.view", () => ctx.slots.register({
 		name: "conversation.view",
@@ -5146,10 +5496,18 @@ async function apply(ctx) {
 		store,
 		inject: injected
 	}, DecisionMind));
+	const balancesStore = createBalanceStore();
+	ctx.slots.inject("conversation.session.header.utilities", () => ctx.slots.register({
+		name: "conversation.session.header.utilities",
+		id: "provider-balance",
+		order: 90,
+		store: balancesStore,
+		inject: balancesInjected
+	}, ProviderBalanceChip));
 }
 //#endregion
 
-    Object.assign(exports, { DecisionMind, _displayEntry, apply, createDecisionMindStore, inject, t1ChipClass, t1NodeClass });
+    Object.assign(exports, { DecisionMind, ProviderBalanceChip, _balanceNote, _displayEntry, _rowDisplay, apply, createBalanceStore, createDecisionMindStore, inject, t1ChipClass, t1NodeClass });
     return module.exports;
   }
 });

--- a/examples/dsh/packages/clawock-dsh/lib/index.js
+++ b/examples/dsh/packages/clawock-dsh/lib/index.js
@@ -1,3 +1,4 @@
+import { createBalanceService, createClaudeService, createMinimaxService } from "./balance.js";
 import { getRun, listRuns } from "./scan.js";
 import { readLedger, readPlans, readPortfolio, readTraces } from "./ledger.js";
 import { createTraceCache, workspaceKeyOf, workspaceSignature } from "./freshness.js";
@@ -54,6 +55,14 @@ var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializ
 	done = true;
 };
 const workspaceOf = () => process.env.CLAWOCK_WORKSPACE || process.cwd();
+/**
+* The row config apply() hands to the next gateway instance. Module-level
+* on purpose and safe: apply() assigns it synchronously before ctx.plugin
+* constructs the service, and the balance method reads it lazily on first
+* use — a plugin reload therefore gets its own value and nothing serves
+* config past its lifetime.
+*/
+let pendingConfig = {};
 let ClawockStudioGateway = (() => {
 	let _classSuper = TypertRemoteService;
 	let _instanceExtraInitializers = [];
@@ -63,6 +72,7 @@ let ClawockStudioGateway = (() => {
 	let _portfolio_decorators;
 	let _plans_decorators;
 	let _traces_decorators;
+	let _balance_decorators;
 	return class ClawockStudioGateway extends _classSuper {
 		static {
 			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(_classSuper[Symbol.metadata] ?? null) : void 0;
@@ -72,6 +82,7 @@ let ClawockStudioGateway = (() => {
 			_portfolio_decorators = [Remote];
 			_plans_decorators = [Remote];
 			_traces_decorators = [Remote];
+			_balance_decorators = [Remote];
 			__esDecorate(this, null, _list_decorators, {
 				kind: "method",
 				name: "list",
@@ -138,6 +149,17 @@ let ClawockStudioGateway = (() => {
 				},
 				metadata: _metadata
 			}, null, _instanceExtraInitializers);
+			__esDecorate(this, null, _balance_decorators, {
+				kind: "method",
+				name: "balance",
+				static: false,
+				private: false,
+				access: {
+					has: (obj) => "balance" in obj,
+					get: (obj) => obj.balance
+				},
+				metadata: _metadata
+			}, null, _instanceExtraInitializers);
 			if (_metadata) Object.defineProperty(this, Symbol.metadata, {
 				enumerable: true,
 				configurable: true,
@@ -145,7 +167,12 @@ let ClawockStudioGateway = (() => {
 				value: _metadata
 			});
 		}
-		static inject = [];
+		static inject = ["credentials"];
+		/**
+		* cordis mixes the injected services onto the instance at construction;
+		* this type-only declaration types `this.credentials` without a cast,
+		* and `declare` fields emit nothing at runtime.
+		*/
 		/**
 		* Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
 		* service instance rather than module scope: a module-level cache would
@@ -154,7 +181,13 @@ let ClawockStudioGateway = (() => {
 		* instance. Instance lifetime follows the fiber; a hit still costs µs.
 		*/
 		tracesCache = (__runInitializers(this, _instanceExtraInitializers), createTraceCache());
-		constructor(ctx) {
+		/**
+		* Per-provider balance services, built lazily on first use — instance-scoped
+		* like tracesCache, and constructed here rather than in the constructor so
+		* the gateway constructor keeps the exact super(ctx, serviceKey) shape.
+		*/
+		balanceServices = null;
+		constructor(ctx, config = {}) {
 			super(ctx, "clawockStudio");
 		}
 		/** @returns Prepared runs (newest first), with decision/receipt presence flags. */
@@ -202,11 +235,80 @@ let ClawockStudioGateway = (() => {
 			this.tracesCache.set(ws, signature, value);
 			return value;
 		}
+		/**
+		* The header chip's answer: every provider's official endpoint, each
+		* answered with that adapter's own key. In-band by design — never throws;
+		* per-provider statuses 'no-key' / 'failed' / 'stale' carry a Chinese
+		* message and a stale read keeps the last good snapshot. A provider with
+		* no key configured is an honest row, not a hidden one.
+		* @param force - bypass the TTL caches (the manual refresh button).
+		*/
+		async balance(force) {
+			if (this.balanceServices === null) this.balanceServices = {
+				deepseek: createBalanceService({ credentials: credentialsOf(this.ctx) }, {
+					baseUrl: pendingConfig.balanceBaseUrl,
+					threshold: pendingConfig.balanceThreshold,
+					refreshMs: pendingConfig.balanceRefreshMs
+				}),
+				minimax: createMinimaxService({ credentials: credentialsOf(this.ctx) }, {
+					baseUrl: pendingConfig.minimaxBaseUrl,
+					keyRef: pendingConfig.minimaxKeyRef,
+					lowPct: pendingConfig.minimaxLowPct,
+					openclawConfigPath: pendingConfig.minimaxOpenclawConfigPath
+				}),
+				claude: createClaudeService({ credentials: credentialsOf(this.ctx) }, {
+					credentialsPath: pendingConfig.claudeCredentialsPath,
+					usageUrl: pendingConfig.claudeUsageUrl,
+					lowPct: pendingConfig.claudeLowPct
+				})
+			};
+			const [deepseek, minimax, claude] = await Promise.all([
+				this.balanceServices.deepseek.get(force),
+				this.balanceServices.minimax.get(force),
+				this.balanceServices.claude.get(force)
+			]);
+			return {
+				providers: [
+					{
+						provider: "deepseek",
+						label: "DeepSeek",
+						result: deepseek
+					},
+					{
+						provider: "minimax",
+						label: "MiniMax",
+						result: minimax
+					},
+					{
+						provider: "claude",
+						label: "Claude",
+						result: claude
+					}
+				],
+				refreshMs: Math.min(deepseek.refreshMs, minimax.refreshMs, claude.refreshMs)
+			};
+		}
 	};
 })();
+/**
+* Services the profile mixes into this plugin's context (the function-
+* plugin form — the class's `static inject` is its type mirror). The
+* gateway reaches the credential seam through `this.ctx.credentials`.
+*/
+const inject = ["credentials"];
+/**
+* Typed access to the injected credentials seam. Deliberately a cast, not
+* an import of @deepseek-ai/dsh-credentials: that package's cordis
+* augmentation would register this package in the typert host face and
+* fail the Remote-artifacts gate (see balance.ts).
+*/
+function credentialsOf(ctx) {
+	return ctx.credentials;
+}
 const name = "clawock-dsh";
-function apply(ctx) {
-	ctx.plugin(ClawockStudioGateway);
+function apply(ctx, config = {}) {
+	pendingConfig = config;
+	ctx.plugin(ClawockStudioGateway, config);
 }
 //#endregion
-export { ClawockStudioGateway, apply, name };
+export { ClawockStudioGateway, apply, inject, name };

--- a/examples/dsh/packages/clawock-dsh/lib/typert.host.js
+++ b/examples/dsh/packages/clawock-dsh/lib/typert.host.js
@@ -4,6 +4,37 @@ import { z } from 'zod'
 const JsonValueRemoteCodec$schema = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema))])
 const JsonValueRemoteCodec$schema2 = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema2)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema2))])
 const JsonValueRemoteCodec$schema3 = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema3)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema3))])
+const clawock_dsh_clawockStudio_balance_parameter_0$schema = z.boolean()
+const clawock_dsh_clawockStudio_balance_result$schema = z.object({
+  'providers': z.array(z.object({
+  'provider': z.string(),
+  'label': z.string(),
+  'result': z.object({
+  'configured': z.boolean(),
+  'snapshot': z.union([z.literal(null), z.object({
+  'isAvailable': z.boolean(),
+  'unit': z.string(),
+  'currency': z.string(),
+  'totalBalance': z.string(),
+  'grantedBalance': z.string(),
+  'toppedUpBalance': z.string(),
+  'asOf': z.string(),
+  'note': z.string(),
+  'windows': z.array(z.object({
+  'label': z.string(),
+  'percent': z.union([z.number(), z.literal(null)]),
+  'resetAt': z.string(),
+})),
+})]),
+  'status': z.union([z.literal("fresh"), z.literal("cached"), z.literal("stale"), z.literal("failed"), z.literal("no-key")]),
+  'low': z.boolean(),
+  'message': z.union([z.literal(null), z.string()]),
+  'threshold': z.number(),
+  'refreshMs': z.number(),
+}),
+})),
+  'refreshMs': z.number(),
+})
 const clawock_dsh_clawockStudio_get_parameter_0$schema = z.string()
 const clawock_dsh_clawockStudio_get_result$schema = z.object({
   'runId': z.string(),
@@ -121,6 +152,31 @@ export const TYPERT = {
   schemas: [
   ],
   invocations: [
+    {
+      id: 'clawock-dsh#clawockStudio/balance',
+      service: 'clawockStudio',
+      namespace: 'clawockStudio',
+      method: 'balance',
+      invocation: { kind: 'direct' },
+      parameters: [
+        {
+          name: 'force',
+          wire: 'force',
+          source: 'json',
+          codec: {
+            mode: 'strict',
+            typeSymbol: 'clawock-dsh#clawockStudio/balance:force',
+            schema: clawock_dsh_clawockStudio_balance_parameter_0$schema,
+          },
+        },
+      ],
+      result: {
+        mode: 'strict',
+        typeSymbol: 'clawock-dsh/types#BalancesResult',
+        schema: clawock_dsh_clawockStudio_balance_result$schema,
+      },
+      sourceLocation: {"file":"packages/clawock-dsh/src/index.ts","line":121,"column":3},
+    },
     {
       id: 'clawock-dsh#clawockStudio/get',
       service: 'clawockStudio',

--- a/examples/dsh/packages/clawock-dsh/lib/typert.remote-client.js
+++ b/examples/dsh/packages/clawock-dsh/lib/typert.remote-client.js
@@ -4,6 +4,37 @@ import { z } from 'zod'
 const JsonValueRemoteCodec$schema = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema))])
 const JsonValueRemoteCodec$schema2 = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema2)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema2))])
 const JsonValueRemoteCodec$schema3 = z.union([z.literal(null), z.string(), z.number(), z.literal(false), z.literal(true), z.array(z.lazy(() => JsonValueRemoteCodec$schema3)), z.record(z.string(), z.lazy(() => JsonValueRemoteCodec$schema3))])
+const clawock_dsh_clawockStudio_balance_parameter_0$schema = z.boolean()
+const clawock_dsh_clawockStudio_balance_result$schema = z.object({
+  'providers': z.array(z.object({
+  'provider': z.string(),
+  'label': z.string(),
+  'result': z.object({
+  'configured': z.boolean(),
+  'snapshot': z.union([z.literal(null), z.object({
+  'isAvailable': z.boolean(),
+  'unit': z.string(),
+  'currency': z.string(),
+  'totalBalance': z.string(),
+  'grantedBalance': z.string(),
+  'toppedUpBalance': z.string(),
+  'asOf': z.string(),
+  'note': z.string(),
+  'windows': z.array(z.object({
+  'label': z.string(),
+  'percent': z.union([z.number(), z.literal(null)]),
+  'resetAt': z.string(),
+})),
+})]),
+  'status': z.union([z.literal("fresh"), z.literal("cached"), z.literal("stale"), z.literal("failed"), z.literal("no-key")]),
+  'low': z.boolean(),
+  'message': z.union([z.literal(null), z.string()]),
+  'threshold': z.number(),
+  'refreshMs': z.number(),
+}),
+})),
+  'refreshMs': z.number(),
+})
 const clawock_dsh_clawockStudio_get_parameter_0$schema = z.string()
 const clawock_dsh_clawockStudio_get_result$schema = z.object({
   'runId': z.string(),
@@ -113,6 +144,31 @@ const clawock_dsh_clawockStudio_traces_result$schema = z.object({
 export const TYPERT_REMOTE = {
   package: 'clawock-dsh',
   descriptors: [
+    {
+      id: 'clawock-dsh#clawockStudio/balance',
+      service: 'clawockStudio',
+      namespace: 'clawockStudio',
+      method: 'balance',
+      invocation: { kind: 'direct' },
+      parameters: [
+        {
+          name: 'force',
+          wire: 'force',
+          source: 'json',
+          codec: {
+            mode: 'strict',
+            typeSymbol: 'clawock-dsh#clawockStudio/balance:force',
+            schema: clawock_dsh_clawockStudio_balance_parameter_0$schema,
+          },
+        },
+      ],
+      result: {
+        mode: 'strict',
+        typeSymbol: 'clawock-dsh/types#BalancesResult',
+        schema: clawock_dsh_clawockStudio_balance_result$schema,
+      },
+      sourceLocation: {"file":"packages/clawock-dsh/src/index.ts","line":121,"column":3},
+    },
     {
       id: 'clawock-dsh#clawockStudio/get',
       service: 'clawockStudio',

--- a/examples/dsh/packages/clawock-dsh/lib/types/balance.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/balance.d.ts
@@ -1,0 +1,185 @@
+/**
+ * Provider account balances for the session header chip — official endpoints
+ * answered with the SAME keys the harness's adapters use (credentials seam
+ * references, falling back to ambient environment variables):
+ *
+ *   - deepseek: `GET https://api.deepseek.com/user/balance` (money, CNY row)
+ *   - minimax:  `GET {base}/v1/token_plan/remains` (Token Plan quota windows;
+ *     `base_resp.status_code` is the business verdict — 0 ok, 1004 auth —
+ *     and a HTTP-200 body can still be an auth failure)
+ *
+ * One cache per provider, one source of truth: the gateway instance owns
+ * them, so a stale read, a failed refresh and a rotated key all resolve
+ * against the same object. Upstream is hit at most once per TTL window
+ * unless the client forces a refresh; a failed refresh keeps the last good
+ * snapshot and reports 'stale' instead of dropping a real number for a
+ * transient 429. Keys are never logged, shipped, or stored anywhere here.
+ *
+ * All error reporting is in-band: `get()` never throws — statuses
+ * 'no-key' / 'failed' / 'stale' carry a Chinese `message` the view renders
+ * verbatim.
+ */
+import type { BalanceResult, BalanceSnapshot } from './types.ts';
+export declare const DEFAULT_BALANCE_BASE_URL = "https://api.deepseek.com";
+export declare const DEFAULT_BALANCE_THRESHOLD = 20;
+export declare const DEFAULT_BALANCE_REFRESH_MS = 60000;
+export declare const DEFAULT_MINIMAX_BASE_URL = "https://api.minimaxi.com";
+export declare const DEFAULT_MINIMAX_LOW_PCT = 20;
+export declare const DEFAULT_OPENCLAW_CONFIG_PATH = "/root/.openclaw/openclaw.json";
+export declare const DEFAULT_CLAUDE_CREDENTIALS_PATH = "/root/.claude/.credentials.json";
+export declare const DEFAULT_CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+export declare const DEFAULT_CLAUDE_LOW_PCT = 20;
+/** The credentials capability, narrowed to what these services use. */
+export interface BalanceCredentials {
+    resolve(ref: string): Promise<{
+        value: string;
+    } | undefined>;
+}
+export interface BalanceConfig {
+    /** DeepSeek upstream base; the service appends /user/balance. */
+    baseUrl?: string;
+    /** Red-dot threshold in the displayed entry's currency (CNY/USD units). */
+    threshold?: number;
+    /** Suggested client poll interval in ms. */
+    refreshMs?: number;
+}
+export interface MinimaxConfig {
+    /** Upstream base; the service appends /v1/token_plan/remains. */
+    baseUrl?: string;
+    /** Credentials seam reference for the MiniMax key (env fallback same name). */
+    keyRef?: string;
+    /** Red dot when a quota window's remaining percent drops to/below this. */
+    lowPct?: number;
+    /**
+     * openclaw gateway config to fall back to when the seam and env are both
+     * unset — kcn keeps provider keys at models.providers.<name>.apiKey there.
+     */
+    openclawConfigPath?: string;
+}
+export interface ClaudeConfig {
+    /** Claude Code's OAuth credentials file (claudeAiOauth.accessToken). */
+    credentialsPath?: string;
+    /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
+    usageUrl?: string;
+    /** Red dot when the session window's remaining percent drops to/below this. */
+    lowPct?: number;
+}
+/**
+ * The credentials seam reference the official DeepSeek adapter resolves.
+ * A plain string on purpose, not credentialRef(): the branding helper is a
+ * no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+ * cordis Events augmentation into the typert analysis — which registers this
+ * package in the host face with zero discoverable services (the protocol
+ * lives in node_modules, where the generator's symbol checks cannot see it)
+ * and fails the "publishes Remote artifacts" gate. The seam itself resolves
+ * by name, so the reference needs no import to work.
+ */
+/**
+ * The credentials seam reference the official DeepSeek adapter resolves.
+ * A plain string on purpose, not credentialRef(): the branding helper is a
+ * no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+ * cordis Events augmentation into the typert analysis — which registers this
+ * package in the host face with zero discoverable services (the protocol
+ * lives in node_modules, where the generator's symbol checks cannot see it)
+ * and fails the "publishes Remote artifacts" gate. The seam itself resolves
+ * by name, so the reference needs no import to work.
+ */
+export declare const DEEPSEEK_KEY_REF = "DEEPSEEK_API_KEY";
+/** Same seam discipline for MiniMax: the harness's MiniMax adapter's ref. */
+export declare const MINIMAX_KEY_REF = "MINIMAX_API_KEY";
+/** The credentials capability, narrowed to what this service uses. */
+/** One balance_infos entry, as far as this service reads it. */
+export interface BalanceInfoEntry {
+    currency?: string;
+    total_balance?: string;
+    granted_balance?: string;
+    topped_up_balance?: string;
+}
+/**
+ * Pick the CNY entry case-insensitively; fall back to the first entry when
+ * the account has no CNY row. Mirrors upstream DeepSeekMonitorWindows'
+ * eq_ignore_ascii_case.
+ */
+export declare function pickCnyBalanceInfo(infos: readonly BalanceInfoEntry[] | undefined): BalanceInfoEntry | undefined;
+/**
+ * Tolerant parse: a missing field degrades to '' / false rather than throwing,
+ * so a shape drift upstream reads as an empty box, never as a crashed tab.
+ */
+export declare function parseBalancePayload(body: unknown, asOf: string): BalanceSnapshot;
+/** One model_remains bucket, as far as this service reads it. */
+export interface MinimaxRemainsEntry {
+    model?: string;
+    current_interval_remaining_percent?: number;
+    current_interval_total_count?: number;
+    current_interval_usage_count?: number;
+    current_weekly_remaining_percent?: number;
+    end_time?: number;
+    [key: string]: unknown;
+}
+/**
+ * Remaining percent of one quota window: the explicit percent field when the
+ * plan reports one, otherwise derived from total/used counts (MiniMax ships
+ * both shapes across plan generations). null = unreadable, never guessed.
+ */
+export declare function windowRemainingPercent(entry: MinimaxRemainsEntry): number | null;
+/**
+ * Reset stamps the panel can lay out: within 48h a bare local clock,
+ * farther out the weekday comes along ('周四 21:00'). Accepts epoch seconds,
+ * epoch milliseconds and RFC3339 strings — MiniMax sends epochs while
+ * Claude sends ISO.
+ */
+export declare function formatReset(epochOrIso: number | string | null | undefined): string;
+/**
+ * The successful Token Plan payload → snapshot. Percent-based by design:
+ * plans report either percent fields or raw counts, and tokens are not money
+ * — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+ */
+export declare function parseMinimaxRemains(body: unknown, asOf: string): BalanceSnapshot;
+/** Tolerant JSON file read: missing/unreadable/invalid all yield undefined. */
+export declare function readJsonFile(path: string): Record<string, unknown> | undefined;
+/** DeepSeek row: official money balance, CNY entry preferred. */
+export declare function createBalanceService(deps: {
+    credentials: BalanceCredentials;
+}, config?: BalanceConfig): {
+    get(force: boolean): Promise<BalanceResult>;
+};
+/** MiniMax row: official Token Plan quota windows, percent-based. */
+export declare function createMinimaxService(deps: {
+    credentials: BalanceCredentials;
+}, config?: MinimaxConfig): {
+    get(force: boolean): Promise<BalanceResult>;
+};
+/** Claude Code's stored OAuth identity — token plus the plan it belongs to. */
+interface ClaudeCredentials {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    subscriptionType?: string;
+    rateLimitTier?: string;
+}
+/** One usage window: utilization is the % already consumed (0-100). */
+export interface ClaudeUsageWindow {
+    utilization?: number;
+    resets_at?: string;
+}
+/**
+ * Read Claude Code's OAuth credentials. The file belongs to Claude Code —
+ * this service only READS it; rotating/refreshing stays their job, so an
+ * expired token surfaces as a failed row telling kcn to run claude once.
+ */
+export declare function readClaudeCredentials(path: string): {
+    creds: ClaudeCredentials;
+} | undefined;
+/**
+ * Successful usage payload → snapshot, in REMAINING percent (utilization is
+ * consumption). five_hour gates active sessions so it is the headline; any
+ * bucket may be absent/null depending on plan.
+ */
+export declare function parseClaudeUsage(body: unknown, asOf: string): BalanceSnapshot;
+/** Claude row: subscription rate-limit windows via the OAuth usage endpoint. */
+export declare function createClaudeService(deps: {
+    credentials: BalanceCredentials;
+}, config?: ClaudeConfig): {
+    get(force: boolean): Promise<BalanceResult>;
+};
+export {};

--- a/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
@@ -25,7 +25,7 @@ import type { Context } from '@deepseek-ai/cordis';
 import type { TypertClientRemote } from '@deepseek-ai/dsh-typert-protocol';
 import type { PropsStore } from '@deepseek-ai/dsh-client-ui-slots';
 import * as React from 'react';
-import type { EnrichedTrade, TraceDecision, TraceT1 } from './types.ts';
+import type { BalanceResult, BalancesResult, EnrichedTrade, TraceDecision, TraceT1 } from './types.ts';
 /** The four trace filters offered above the list. */
 export type TraceFilter = 'all' | 'miss' | 'sold' | 'dec';
 /**
@@ -119,6 +119,54 @@ export interface DisplayEntry {
 }
 /** Display projection of one trace (test seam). */
 export declare function _displayEntry(trace: EnrichedTrade): DisplayEntry;
+/** The four visual states one provider's reading can take. */
+export type BalanceTone = 'ok' | 'low' | 'stale' | 'none';
+/**
+ * Display projection of ONE provider's answer (test seam, like _displayEntry):
+ * the chip and panel render only these fields, so the view never keeps
+ * a second copy of the tone rules — the host already decided status and low.
+ * The title is the whole hover story: split, quota windows, stale reason,
+ * fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
+ * and carry the second window ('周'/'本周') as a muted pill suffix — both
+ * limits visible at the header without opening the panel.
+ */
+export declare function _rowDisplay(result: BalanceResult | null): {
+    tone: BalanceTone;
+    value: string;
+    sub: string | null;
+    title: string;
+};
+/**
+ * The one line a panel row says out loud when something is wrong — stale
+ * reason, unconfigured key, insufficient balance/quota. A healthy number
+ * earns no caption at all; null means silence.
+ */
+export declare function _balanceNote(result: BalanceResult | null): string | null;
+/** What the header chip's `inject` factory hands the component. */
+export interface BalancesInjected {
+    /** The last multi-provider answer this registration fetched, or null cold. */
+    cachedBalances: () => BalancesResult | null;
+    /** Fetch all providers; `force` bypasses the host TTLs (the manual refresh). */
+    fetchBalances: (force: boolean) => Promise<BalancesResult>;
+}
+/**
+ * Which provider the pill headlines. null = auto (first configured row);
+ * a click on a panel row pins that provider. Registration-store state, so
+ * the choice survives the ring's remounts.
+ */
+export interface BalanceUiState {
+    selected: string | null;
+}
+/** Store factory — called inside `apply`, never a module-level handle. */
+export declare function createBalanceStore(): import("@deepseek-ai/dsh-client-runtime/client").EngineStoreHandle<BalanceUiState, {
+    select: (draft: BalanceUiState, provider: string) => void;
+}>;
+/** The chip's registration store handle type (derived, like DecisionMind's). */
+export type BalanceStore = ReturnType<typeof createBalanceStore>;
+export type BalanceChipProps = BalancesInjected & PropsStore<BalanceStore> & {
+    sessionId: string;
+};
+export declare function ProviderBalanceChip(props: BalanceChipProps): React.ReactElement;
 export declare function DecisionMind(props: DecisionMindProps): React.ReactElement;
 /** Services required by the registration and the mounted Remote face. */
 export declare const inject: string[];

--- a/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
@@ -10,9 +10,39 @@
  */
 import { TypertRemoteService } from '@deepseek-ai/dsh-typert-protocol';
 import type { Context } from '@deepseek-ai/cordis';
-import type { LedgerResult, ListRunsResult, PlansResult, PortfolioResult, RunDetailResult, TracesResult } from './types.ts';
+import type { BalancesResult, LedgerResult, ListRunsResult, PlansResult, PortfolioResult, RunDetailResult, TracesResult } from './types.ts';
+/**
+ * Row-level config the profile patch may set (see cordis.patch.yml).
+ */
+export interface ClawockStudioConfig {
+    /** DeepSeek upstream root for the balance chip; /user/balance is appended. */
+    balanceBaseUrl?: string;
+    /** Red-dot threshold in the displayed entry's currency (CNY/USD units). */
+    balanceThreshold?: number;
+    /** Suggested client poll interval in ms. */
+    balanceRefreshMs?: number;
+    /** MiniMax upstream root; /v1/token_plan/remains is appended. */
+    minimaxBaseUrl?: string;
+    /** Credentials seam reference for the MiniMax key (env fallback same name). */
+    minimaxKeyRef?: string;
+    /** Red dot when MiniMax quota windows drop to/below this remaining percent. */
+    minimaxLowPct?: number;
+    /** openclaw gateway config fallback for provider keys (models.providers.*). */
+    minimaxOpenclawConfigPath?: string;
+    /** Claude Code OAuth credentials file (claudeAiOauth.accessToken). */
+    claudeCredentialsPath?: string;
+    /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
+    claudeUsageUrl?: string;
+    /** Red dot when the Claude session window's remaining percent is low. */
+    claudeLowPct?: number;
+}
 export declare class ClawockStudioGateway extends TypertRemoteService {
-    static inject: readonly [];
+    static inject: readonly ['credentials'];
+    /**
+     * cordis mixes the injected services onto the instance at construction;
+     * this type-only declaration types `this.credentials` without a cast,
+     * and `declare` fields emit nothing at runtime.
+     */
     /**
      * Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
      * service instance rather than module scope: a module-level cache would
@@ -21,7 +51,13 @@ export declare class ClawockStudioGateway extends TypertRemoteService {
      * instance. Instance lifetime follows the fiber; a hit still costs µs.
      */
     private readonly tracesCache;
-    constructor(ctx: Context);
+    /**
+     * Per-provider balance services, built lazily on first use — instance-scoped
+     * like tracesCache, and constructed here rather than in the constructor so
+     * the gateway constructor keeps the exact super(ctx, serviceKey) shape.
+     */
+    private balanceServices;
+    constructor(ctx: Context, config?: ClawockStudioConfig);
     /** @returns Prepared runs (newest first), with decision/receipt presence flags. */
     list(): ListRunsResult;
     /**
@@ -45,6 +81,21 @@ export declare class ClawockStudioGateway extends TypertRemoteService {
      * client can cache across tab mounts and re-fetch only on a real change.
      */
     traces(): TracesResult;
+    /**
+     * The header chip's answer: every provider's official endpoint, each
+     * answered with that adapter's own key. In-band by design — never throws;
+     * per-provider statuses 'no-key' / 'failed' / 'stale' carry a Chinese
+     * message and a stale read keeps the last good snapshot. A provider with
+     * no key configured is an honest row, not a hidden one.
+     * @param force - bypass the TTL caches (the manual refresh button).
+     */
+    balance(force: boolean): Promise<BalancesResult>;
 }
+/**
+ * Services the profile mixes into this plugin's context (the function-
+ * plugin form — the class's `static inject` is its type mirror). The
+ * gateway reaches the credential seam through `this.ctx.credentials`.
+ */
+export declare const inject: string[];
 export declare const name = "clawock-dsh";
-export declare function apply(ctx: Context): void;
+export declare function apply(ctx: Context, config?: ClawockStudioConfig): void;

--- a/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
@@ -142,3 +142,78 @@ export interface TracesResult {
     rateSource: string | null;
     lastUpdated: string | null;
 }
+/** One quota window worth its own line in the panel's per-window grid. */
+export interface BalanceWindow {
+    /** Short label rendered verbatim: '5h' | '周' | '会话' | '本周'. */
+    label: string;
+    /** Remaining percent of this window; null when the plan doesn't report it. */
+    percent: number | null;
+    /** Preformatted LOCAL reset stamp ('15:00' / '周四 21:00'); '' when unknown. */
+    resetAt: string;
+}
+/**
+ * One account/quota reading as answered by the provider's official endpoint,
+ * with the entry the host picked to display. Numeric readings stay strings so
+ * no rounding happens on the wire; the client formats for display only.
+ */
+export interface BalanceSnapshot {
+    /** Whether the API reports the account usable (sufficient balance / quota left). */
+    isAvailable: boolean;
+    /**
+     * How `totalBalance` reads: 'money' carries a currency symbol via
+     * `currency` ('CNY' | 'USD' | ''), 'pct' carries a remaining-percent number
+     * (quota windows). '' defaults to 'money'.
+     */
+    unit: string;
+    /** 'CNY' | 'USD' | '' — the displayed entry's currency (money unit only). */
+    currency: string;
+    /** Total available balance ("110.00") or remaining percent ("62"). */
+    totalBalance: string;
+    /** Not-expired granted balance (DeepSeek money accounts; '' elsewhere). */
+    grantedBalance: string;
+    /** Topped-up balance (DeepSeek money accounts; '' elsewhere). */
+    toppedUpBalance: string;
+    /** ISO timestamp of the upstream fetch that produced this snapshot. */
+    asOf: string;
+    /** One context line for the panel (quota windows, resets); '' when none. */
+    note: string;
+    /** Per-window grid for the panel; money accounts send []. */
+    windows: BalanceWindow[];
+}
+/** One provider's row in the balance panel: identity plus the same in-band answer. */
+export interface ProviderBalance {
+    /** Stable id: 'deepseek' | 'minimax'. */
+    provider: string;
+    /** Human label rendered verbatim ('DeepSeek', 'MiniMax'). */
+    label: string;
+    result: BalanceResult;
+}
+/**
+ * The whole balance answer across providers. In-band by design: balance()
+ * never throws — per-provider 'no-key' / 'failed' / 'stale' statuses carry a
+ * Chinese message the view renders verbatim, and a stale read keeps the last
+ * good snapshot so a transient 429 cannot erase a real number.
+ */
+export interface BalancesResult {
+    /** Rows in stable display order (deepseek first). */
+    providers: ProviderBalance[];
+    /** Suggested client poll interval in ms. */
+    refreshMs: number;
+}
+/** One provider's answer. Same in-band contract the single-provider box had. */
+export interface BalanceResult {
+    /** Whether this provider's API key is configured at all (seam or env). */
+    configured: boolean;
+    /** Last good snapshot, kept across failed refreshes (null on cold start). */
+    snapshot: BalanceSnapshot | null;
+    /** 'fresh' | 'cached' | 'stale' | 'failed' | 'no-key' — decided host-side. */
+    status: 'fresh' | 'cached' | 'stale' | 'failed' | 'no-key';
+    /** Balance/quota at or below the low threshold (only when readable). */
+    low: boolean;
+    /** Human-readable reason for failed/no-key, null while good. */
+    message: string | null;
+    /** Effective low threshold, in the displayed entry's unit. */
+    threshold: number;
+    /** Suggested client poll interval in ms. */
+    refreshMs: number;
+}

--- a/examples/dsh/packages/clawock-dsh/package-lock.json
+++ b/examples/dsh/packages/clawock-dsh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawock-dsh",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.144.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
-      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1578,10 +1578,27 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
-      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -1596,9 +1613,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -1613,9 +1630,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -1630,9 +1647,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
-      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -1647,9 +1664,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
-      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -1664,9 +1681,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
-      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -1681,9 +1698,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
-      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -1698,9 +1715,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
-      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -1715,9 +1732,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
-      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -1732,9 +1749,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
-      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -1749,9 +1766,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
-      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -1766,9 +1783,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
-      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1783,9 +1800,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
-      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -1800,9 +1817,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
-      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -3130,13 +3147,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
-      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.144.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3146,20 +3163,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.4",
-        "@rolldown/binding-darwin-arm64": "1.2.4",
-        "@rolldown/binding-darwin-x64": "1.2.4",
-        "@rolldown/binding-freebsd-x64": "1.2.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
-        "@rolldown/binding-linux-arm64-musl": "1.2.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-musl": "1.2.4",
-        "@rolldown/binding-openharmony-arm64": "1.2.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
-        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/rolldown-plugin-dts": {

--- a/examples/dsh/packages/clawock-dsh/package.json
+++ b/examples/dsh/packages/clawock-dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawock-dsh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "DSH (DeepSeek Harness) plugin for investment decisions: evidence-gated research, a forced bull/bear debate, Python-settled outcomes the model cannot grade, and the Decision Mind tab that pins every real trade to its plan and T+1 verdict",
   "license": "MIT",
   "repository": {
@@ -62,6 +62,7 @@
     "skills",
     "lib/index.js",
     "lib/client.js",
+    "lib/balance.js",
     "lib/scan.js",
     "lib/ledger.js",
     "lib/freshness.js",

--- a/examples/dsh/packages/clawock-dsh/src/balance.ts
+++ b/examples/dsh/packages/clawock-dsh/src/balance.ts
@@ -1,0 +1,617 @@
+/**
+ * Provider account balances for the session header chip — official endpoints
+ * answered with the SAME keys the harness's adapters use (credentials seam
+ * references, falling back to ambient environment variables):
+ *
+ *   - deepseek: `GET https://api.deepseek.com/user/balance` (money, CNY row)
+ *   - minimax:  `GET {base}/v1/token_plan/remains` (Token Plan quota windows;
+ *     `base_resp.status_code` is the business verdict — 0 ok, 1004 auth —
+ *     and a HTTP-200 body can still be an auth failure)
+ *
+ * One cache per provider, one source of truth: the gateway instance owns
+ * them, so a stale read, a failed refresh and a rotated key all resolve
+ * against the same object. Upstream is hit at most once per TTL window
+ * unless the client forces a refresh; a failed refresh keeps the last good
+ * snapshot and reports 'stale' instead of dropping a real number for a
+ * transient 429. Keys are never logged, shipped, or stored anywhere here.
+ *
+ * All error reporting is in-band: `get()` never throws — statuses
+ * 'no-key' / 'failed' / 'stale' carry a Chinese `message` the view renders
+ * verbatim.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import type { BalanceResult, BalanceSnapshot, BalanceWindow } from './types.ts'
+
+export const DEFAULT_BALANCE_BASE_URL = 'https://api.deepseek.com'
+export const DEFAULT_BALANCE_THRESHOLD = 20
+export const DEFAULT_BALANCE_REFRESH_MS = 60000
+export const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimaxi.com'
+export const DEFAULT_MINIMAX_LOW_PCT = 20
+export const DEFAULT_OPENCLAW_CONFIG_PATH = '/root/.openclaw/openclaw.json'
+export const DEFAULT_CLAUDE_CREDENTIALS_PATH = '/root/.claude/.credentials.json'
+export const DEFAULT_CLAUDE_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
+export const DEFAULT_CLAUDE_LOW_PCT = 20
+const TTL_MS = 60000
+const TIMEOUT_MS = 15000
+
+/** The credentials capability, narrowed to what these services use. */
+export interface BalanceCredentials {
+  resolve(ref: string): Promise<{ value: string } | undefined>
+}
+
+export interface BalanceConfig {
+  /** DeepSeek upstream base; the service appends /user/balance. */
+  baseUrl?: string
+  /** Red-dot threshold in the displayed entry's currency (CNY/USD units). */
+  threshold?: number
+  /** Suggested client poll interval in ms. */
+  refreshMs?: number
+}
+
+export interface MinimaxConfig {
+  /** Upstream base; the service appends /v1/token_plan/remains. */
+  baseUrl?: string
+  /** Credentials seam reference for the MiniMax key (env fallback same name). */
+  keyRef?: string
+  /** Red dot when a quota window's remaining percent drops to/below this. */
+  lowPct?: number
+  /**
+   * openclaw gateway config to fall back to when the seam and env are both
+   * unset — kcn keeps provider keys at models.providers.<name>.apiKey there.
+   */
+  openclawConfigPath?: string
+}
+
+export interface ClaudeConfig {
+  /** Claude Code's OAuth credentials file (claudeAiOauth.accessToken). */
+  credentialsPath?: string
+  /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
+  usageUrl?: string
+  /** Red dot when the session window's remaining percent drops to/below this. */
+  lowPct?: number
+}
+
+/**
+ * The credentials seam reference the official DeepSeek adapter resolves.
+ * A plain string on purpose, not credentialRef(): the branding helper is a
+ * no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+ * cordis Events augmentation into the typert analysis — which registers this
+ * package in the host face with zero discoverable services (the protocol
+ * lives in node_modules, where the generator's symbol checks cannot see it)
+ * and fails the "publishes Remote artifacts" gate. The seam itself resolves
+ * by name, so the reference needs no import to work.
+ */
+/**
+ * The credentials seam reference the official DeepSeek adapter resolves.
+ * A plain string on purpose, not credentialRef(): the branding helper is a
+ * no-op at runtime, and importing @deepseek-ai/dsh-credentials would drag its
+ * cordis Events augmentation into the typert analysis — which registers this
+ * package in the host face with zero discoverable services (the protocol
+ * lives in node_modules, where the generator's symbol checks cannot see it)
+ * and fails the "publishes Remote artifacts" gate. The seam itself resolves
+ * by name, so the reference needs no import to work.
+ */
+export const DEEPSEEK_KEY_REF = 'DEEPSEEK_API_KEY'
+
+/** Same seam discipline for MiniMax: the harness's MiniMax adapter's ref. */
+export const MINIMAX_KEY_REF = 'MINIMAX_API_KEY'
+
+/** The credentials capability, narrowed to what this service uses. */
+/** One balance_infos entry, as far as this service reads it. */
+export interface BalanceInfoEntry {
+  currency?: string
+  total_balance?: string
+  granted_balance?: string
+  topped_up_balance?: string
+}
+
+/**
+ * Pick the CNY entry case-insensitively; fall back to the first entry when
+ * the account has no CNY row. Mirrors upstream DeepSeekMonitorWindows'
+ * eq_ignore_ascii_case.
+ */
+export function pickCnyBalanceInfo(
+  infos: readonly BalanceInfoEntry[] | undefined,
+): BalanceInfoEntry | undefined {
+  if (!Array.isArray(infos) || infos.length === 0) return undefined
+  return infos.find((entry) => (entry.currency ?? '').toUpperCase() === 'CNY') ?? infos[0]
+}
+
+/** The upstream payload, as far as this service reads it. */
+interface RawBalanceBody {
+  is_available?: boolean
+  balance_infos?: BalanceInfoEntry[]
+}
+
+/**
+ * Tolerant parse: a missing field degrades to '' / false rather than throwing,
+ * so a shape drift upstream reads as an empty box, never as a crashed tab.
+ */
+export function parseBalancePayload(body: unknown, asOf: string): BalanceSnapshot {
+  const raw = (typeof body === 'object' && body !== null ? body : {}) as RawBalanceBody
+  const entry = pickCnyBalanceInfo(raw.balance_infos)
+  return {
+    isAvailable: raw.is_available === true,
+    unit: 'money',
+    currency: typeof entry?.currency === 'string' ? entry.currency : '',
+    totalBalance: typeof entry?.total_balance === 'string' ? entry.total_balance : '',
+    grantedBalance: typeof entry?.granted_balance === 'string' ? entry.granted_balance : '',
+    toppedUpBalance: typeof entry?.topped_up_balance === 'string' ? entry.topped_up_balance : '',
+    asOf,
+    note: '',
+    windows: [],
+  }
+}
+
+/** One model_remains bucket, as far as this service reads it. */
+export interface MinimaxRemainsEntry {
+  model?: string
+  current_interval_remaining_percent?: number
+  current_interval_total_count?: number
+  current_interval_usage_count?: number
+  current_weekly_remaining_percent?: number
+  end_time?: number
+  [key: string]: unknown
+}
+
+interface RawRemainsBody {
+  base_resp?: { status_code?: number; status_msg?: string }
+  model_remains?: MinimaxRemainsEntry[]
+}
+
+const finiteNumber = (value: unknown): number | null =>
+  typeof value === 'number' && isFinite(value) ? value : null
+
+/**
+ * Remaining percent of one quota window: the explicit percent field when the
+ * plan reports one, otherwise derived from total/used counts (MiniMax ships
+ * both shapes across plan generations). null = unreadable, never guessed.
+ */
+export function windowRemainingPercent(entry: MinimaxRemainsEntry): number | null {
+  const direct = finiteNumber(entry.current_interval_remaining_percent)
+  if (direct !== null) return Math.min(100, Math.max(0, direct))
+  const total = finiteNumber(entry.current_interval_total_count)
+  const used = finiteNumber(entry.current_interval_usage_count)
+  if (total !== null && total > 0 && used !== null && used >= 0) {
+    return Math.min(100, Math.max(0, ((total - used) / total) * 100))
+  }
+  return null
+}
+
+/**
+ * Reset stamps the panel can lay out: within 48h a bare local clock,
+ * farther out the weekday comes along ('周四 21:00'). Accepts epoch seconds,
+ * epoch milliseconds and RFC3339 strings — MiniMax sends epochs while
+ * Claude sends ISO.
+ */
+export function formatReset(epochOrIso: number | string | null | undefined): string {
+  let ms: number | null = null
+  if (typeof epochOrIso === 'number' && isFinite(epochOrIso) && epochOrIso > 0) {
+    ms = epochOrIso > 1e12 ? epochOrIso : epochOrIso * 1000
+  } else if (typeof epochOrIso === 'string' && epochOrIso !== '') {
+    const at = new Date(epochOrIso)
+    if (!isNaN(at.getTime())) ms = at.getTime()
+  }
+  if (ms === null) return ''
+  const at = new Date(ms)
+  const hhmm = String(at.getHours()).padStart(2, '0') + ':' + String(at.getMinutes()).padStart(2, '0')
+  if (at.getTime() - Date.now() < 48 * 3600_000) return hhmm
+  const week = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
+  return week[at.getDay()] + ' ' + hhmm
+}
+
+/** Epoch ms/sec heuristic → local reset stamp (legacy note helper). */
+function resetClock(epoch: unknown): string | null {
+  const raw = finiteNumber(epoch)
+  if (raw === null || raw <= 0) return null
+  return formatReset(raw)
+}
+
+/**
+ * The successful Token Plan payload → snapshot. Percent-based by design:
+ * plans report either percent fields or raw counts, and tokens are not money
+ * — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+ */
+export function parseMinimaxRemains(body: unknown, asOf: string): BalanceSnapshot {
+  const raw = (typeof body === 'object' && body !== null ? body : {}) as RawRemainsBody
+  const buckets = Array.isArray(raw.model_remains) ? raw.model_remains : []
+  // `general` is the text/coding bucket every plan carries; video et al are add-ons.
+  const entry = buckets.find((b) => b.model === 'general') ?? buckets[0]
+  if (entry === undefined) throw new Error('MiniMax 响应里没有 model_remains 数据')
+  const pct = windowRemainingPercent(entry)
+  const weekly = finiteNumber(entry.current_weekly_remaining_percent)
+  const windows: BalanceWindow[] = []
+  if (pct !== null) windows.push({ label: '5h', percent: Math.round(pct), resetAt: formatReset(entry.end_time as number | undefined) })
+  if (weekly !== null) windows.push({ label: '周', percent: Math.round(weekly), resetAt: formatReset(entry.weekly_end_time as number | undefined) })
+  const notes: string[] = []
+  if (pct !== null) notes.push('5h 窗口剩余 ' + Math.round(pct) + '%')
+  if (weekly !== null) notes.push('周窗口剩余 ' + Math.round(weekly) + '%')
+  return {
+    isAvailable: pct !== null && pct > 0,
+    unit: 'pct',
+    currency: '',
+    totalBalance: pct === null ? '' : String(Math.round(pct)),
+    grantedBalance: '',
+    toppedUpBalance: '',
+    asOf,
+    note: notes.join(' · '),
+    windows,
+  }
+}
+
+/**
+ * The shared cadence shell — TTL cache, in-flight join, stale-on-failure —
+ * parameterized by provider. Both services below differ only in key
+ * resolution, endpoint, parse and low-reading; everything temporal is here
+ * once.
+ */
+interface QuotaServiceSpec {
+  /**
+   * Where this provider's secret comes from. Returning undefined means
+   * "not configured" → the in-band no-key row; the message is spec-level.
+   */
+  resolveApiKey(deps: { credentials: BalanceCredentials }): Promise<string | undefined>
+  noKeyMessage: string
+  threshold: number
+  refreshMs: number
+  fetchFresh(apiKey: string): Promise<BalanceSnapshot>
+  /** The low reading in the snapshot's own unit (money amount / percent). */
+  isLow(snapshot: BalanceSnapshot): boolean
+}
+
+/** Seam reference first, then the ambient environment variable of the same name. */
+function resolveSeamThenEnv(
+  deps: { credentials: BalanceCredentials },
+  ref: string,
+): () => Promise<string | undefined> {
+  return async () => {
+    const resolved = await deps.credentials.resolve(ref)
+    if (resolved !== undefined && typeof resolved.value === 'string' && resolved.value !== '') {
+      return resolved.value
+    }
+    const ambient = process.env[ref]
+    return ambient !== undefined && ambient !== '' ? ambient : undefined
+  }
+}
+
+/** Tolerant JSON file read: missing/unreadable/invalid all yield undefined. */
+export function readJsonFile(path: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    return typeof parsed === 'object' && parsed !== null ? parsed as Record<string, unknown> : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** kcn keeps provider keys in the openclaw gateway config at this pointer. */
+function readOpenclawProviderKey(configPath: string, provider: string): string | undefined {
+  const cfg = readJsonFile(configPath)
+  const providers = cfg?.models as Record<string, unknown> | undefined ?? {}
+  const list = providers.providers as Record<string, Record<string, unknown>> | undefined ?? {}
+  const entry = list[provider] ?? {}
+  const key = entry.apiKey
+  return typeof key === 'string' && key !== '' ? key : undefined
+}
+
+function createQuotaService(
+  deps: { credentials: BalanceCredentials },
+  spec: QuotaServiceSpec,
+): { get(force: boolean): Promise<BalanceResult> } {
+  let snapshot: BalanceSnapshot | null = null
+  let fetchedAt = 0
+  let inFlight: Promise<BalanceResult> | null = null
+
+  const resolveKey = async (): Promise<string | undefined> => spec.resolveApiKey(deps)
+
+  const run = async (apiKey: string): Promise<BalanceResult> => {
+    try {
+      snapshot = await spec.fetchFresh(apiKey)
+      fetchedAt = Date.now()
+      return {
+        configured: true,
+        snapshot,
+        status: 'fresh',
+        low: spec.isLow(snapshot),
+        message: null,
+        threshold: spec.threshold,
+        refreshMs: spec.refreshMs,
+      }
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause)
+      if (snapshot !== null) {
+        return {
+          configured: true,
+          snapshot,
+          status: 'stale',
+          low: spec.isLow(snapshot),
+          message,
+          threshold: spec.threshold,
+          refreshMs: spec.refreshMs,
+        }
+      }
+      return { configured: true, snapshot: null, status: 'failed', low: false, message, threshold: spec.threshold, refreshMs: spec.refreshMs }
+    }
+  }
+
+  const exec = async (force: boolean): Promise<BalanceResult> => {
+    const apiKey = await resolveKey()
+    if (apiKey === undefined) {
+      return {
+        configured: false,
+        snapshot: null,
+        status: 'no-key',
+        low: false,
+        message: spec.noKeyMessage,
+        threshold: spec.threshold,
+        refreshMs: spec.refreshMs,
+      }
+    }
+    if (!force && snapshot !== null && Date.now() - fetchedAt < TTL_MS) {
+      return {
+        configured: true,
+        snapshot,
+        status: 'cached',
+        low: spec.isLow(snapshot),
+        message: null,
+        threshold: spec.threshold,
+        refreshMs: spec.refreshMs,
+      }
+    }
+    return run(apiKey)
+  }
+
+  return {
+    /**
+     * Cached-or-fetch read. A concurrent caller (a poll tick racing a manual
+     * click) JOINS the in-flight run instead of stampeding the upstream —
+     * one request per window, however many faces ask.
+     */
+    async get(force: boolean): Promise<BalanceResult> {
+      if (inFlight !== null) return inFlight
+      // The guard is claimed synchronously, BEFORE exec's first await: a
+      // caller that checks inFlight while the first one is suspended at
+      // resolveKey() must still join instead of starting a second fetch.
+      const pending = exec(force)
+      inFlight = pending
+      try {
+        return await pending
+      } finally {
+        inFlight = null
+      }
+    },
+  }
+}
+
+const numOrInfinity = (value: string): number => {
+  const parsed = Number.parseFloat(value)
+  return isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY
+}
+
+/** DeepSeek row: official money balance, CNY entry preferred. */
+export function createBalanceService(
+  deps: { credentials: BalanceCredentials },
+  config: BalanceConfig = {},
+): { get(force: boolean): Promise<BalanceResult> } {
+  const baseUrl = config.baseUrl ?? DEFAULT_BALANCE_BASE_URL
+  const threshold = typeof config.threshold === 'number' && isFinite(config.threshold)
+    ? config.threshold
+    : DEFAULT_BALANCE_THRESHOLD
+  return createQuotaService(deps, {
+    resolveApiKey: resolveSeamThenEnv(deps, DEEPSEEK_KEY_REF),
+    noKeyMessage: '未配置 DeepSeek API Key(设置 → 模型 → DeepSeek)',
+    threshold,
+    refreshMs: typeof config.refreshMs === 'number' && isFinite(config.refreshMs)
+      ? config.refreshMs
+      : DEFAULT_BALANCE_REFRESH_MS,
+    async fetchFresh(apiKey) {
+      let response: Response
+      try {
+        response = await fetch(`${baseUrl}/user/balance`, {
+          headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        })
+      } catch (cause) {
+        throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`)
+      }
+      if (response.status === 401) throw new Error('API Key 无效或已过期')
+      if (response.status === 429) throw new Error('请求过于频繁,请稍后再试')
+      if (!response.ok) throw new Error(`余额接口返回 HTTP ${response.status}`)
+      let body: unknown
+      try {
+        body = await response.json()
+      } catch {
+        throw new Error('解析余额数据失败')
+      }
+      return parseBalancePayload(body, new Date().toISOString())
+    },
+    isLow: (snapshot) => snapshot.unit === 'pct'
+      ? numOrInfinity(snapshot.totalBalance) <= threshold
+      : snapshot.isAvailable && numOrInfinity(snapshot.totalBalance) <= threshold,
+  })
+}
+
+/** MiniMax row: official Token Plan quota windows, percent-based. */
+export function createMinimaxService(
+  deps: { credentials: BalanceCredentials },
+  config: MinimaxConfig = {},
+): { get(force: boolean): Promise<BalanceResult> } {
+  const baseUrl = config.baseUrl ?? DEFAULT_MINIMAX_BASE_URL
+  const lowPct = typeof config.lowPct === 'number' && isFinite(config.lowPct)
+    ? config.lowPct
+    : DEFAULT_MINIMAX_LOW_PCT
+  const seamEnv = resolveSeamThenEnv(deps, config.keyRef ?? MINIMAX_KEY_REF)
+  const openclawPath = config.openclawConfigPath ?? DEFAULT_OPENCLAW_CONFIG_PATH
+  return createQuotaService(deps, {
+    // kcn keeps the real key in the openclaw gateway's own config — that file
+    // is the working fallback when the dsh seam and env are both unset.
+    resolveApiKey: async () => (await seamEnv()) ?? readOpenclawProviderKey(openclawPath, 'minimax'),
+    noKeyMessage: '未配置 MiniMax API Key(凭据缝 / 环境变量 / openclaw 配置均无)',
+    threshold: lowPct,
+    refreshMs: DEFAULT_BALANCE_REFRESH_MS,
+    async fetchFresh(apiKey) {
+      let response: Response
+      try {
+        response = await fetch(`${baseUrl}/v1/token_plan/remains`, {
+          headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        })
+      } catch (cause) {
+        throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`)
+      }
+      if (!response.ok) throw new Error(`MiniMax 接口返回 HTTP ${response.status}`)
+      let body: unknown
+      try {
+        body = await response.json()
+      } catch {
+        throw new Error('解析 MiniMax 数据失败')
+      }
+      // A HTTP-200 body can still be a business failure (auth=1004); the
+      // envelope's status_code is the verdict, status_msg the reason.
+      const raw = (typeof body === 'object' && body !== null ? body : {}) as RawRemainsBody
+      const code = raw.base_resp?.status_code
+      if (code !== undefined && code !== 0) {
+        const msg = typeof raw.base_resp?.status_msg === 'string' && raw.base_resp.status_msg !== ''
+          ? raw.base_resp.status_msg
+          : `错误码 ${code}`
+        throw new Error(code === 1004 ? `MiniMax API Key 无效或已过期(${msg})` : `MiniMax 接口错误:${msg}`)
+      }
+      return parseMinimaxRemains(body, new Date().toISOString())
+    },
+    isLow: (snapshot) => snapshot.unit === 'pct'
+      ? numOrInfinity(snapshot.totalBalance) <= lowPct
+      : false,
+  })
+}
+
+/** Claude Code's stored OAuth identity — token plus the plan it belongs to. */
+interface ClaudeCredentials {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: number
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+/** One usage window: utilization is the % already consumed (0-100). */
+export interface ClaudeUsageWindow {
+  utilization?: number
+  resets_at?: string
+}
+
+interface RawClaudeUsage {
+  five_hour?: ClaudeUsageWindow | null
+  seven_day?: ClaudeUsageWindow | null
+  extra_usage?: { is_enabled?: boolean; utilization?: number | null } | null
+  [key: string]: unknown
+}
+
+/**
+ * Read Claude Code's OAuth credentials. The file belongs to Claude Code —
+ * this service only READS it; rotating/refreshing stays their job, so an
+ * expired token surfaces as a failed row telling kcn to run claude once.
+ */
+export function readClaudeCredentials(path: string): { creds: ClaudeCredentials } | undefined {
+  const parsed = readJsonFile(path)
+  const creds = parsed?.claudeAiOauth as ClaudeCredentials | undefined
+  if (creds === undefined || typeof creds !== 'object') return undefined
+  return { creds }
+}
+
+const localClock = (iso: string): string | null => {
+  const at = new Date(iso)
+  if (isNaN(at.getTime())) return null
+  return String(at.getHours()).padStart(2, '0') + ':' + String(at.getMinutes()).padStart(2, '0')
+}
+
+/**
+ * Successful usage payload → snapshot, in REMAINING percent (utilization is
+ * consumption). five_hour gates active sessions so it is the headline; any
+ * bucket may be absent/null depending on plan.
+ */
+export function parseClaudeUsage(body: unknown, asOf: string): BalanceSnapshot {
+  const raw = (typeof body === 'object' && body !== null ? body : {}) as RawClaudeUsage
+  const u5 = finiteNumber(raw.five_hour?.utilization)
+  const u7 = finiteNumber(raw.seven_day?.utilization)
+  if (u5 === null && u7 === null) throw new Error('Claude 响应里没有可用的用量窗口')
+  const remaining = u5 === null ? null : Math.round(Math.min(100, Math.max(0, 100 - u5)))
+  const windows: BalanceWindow[] = []
+  if (u5 !== null) windows.push({ label: '会话', percent: remaining, resetAt: formatReset(raw.five_hour?.resets_at ?? null) })
+  if (u7 !== null) windows.push({ label: '本周', percent: Math.round(Math.min(100, Math.max(0, 100 - u7))), resetAt: formatReset(raw.seven_day?.resets_at ?? null) })
+  const notes: string[] = []
+  if (u5 !== null) notes.push('会话窗口剩余 ' + remaining + '%')
+  if (u7 !== null) notes.push('本周剩余 ' + Math.round(100 - u7) + '%')
+  const extraUtil = raw.extra_usage?.is_enabled === true ? finiteNumber(raw.extra_usage?.utilization ?? undefined) : null
+  if (extraUtil !== null) notes.push('附加额度已用 ' + Math.round(extraUtil) + '%')
+  return {
+    isAvailable: remaining === null ? false : remaining > 0,
+    unit: 'pct',
+    currency: '',
+    totalBalance: remaining === null ? '' : String(remaining),
+    grantedBalance: '',
+    toppedUpBalance: '',
+    asOf,
+    note: notes.join(' · '),
+    windows,
+  }
+}
+
+/** Claude row: subscription rate-limit windows via the OAuth usage endpoint. */
+export function createClaudeService(
+  deps: { credentials: BalanceCredentials },
+  config: ClaudeConfig = {},
+): { get(force: boolean): Promise<BalanceResult> } {
+  const credentialsPath = config.credentialsPath ?? DEFAULT_CLAUDE_CREDENTIALS_PATH
+  const usageUrl = config.usageUrl ?? DEFAULT_CLAUDE_USAGE_URL
+  const lowPct = typeof config.lowPct === 'number' && isFinite(config.lowPct)
+    ? config.lowPct
+    : DEFAULT_CLAUDE_LOW_PCT
+  // The seam plays no role here — the secret is Claude Code's own login file.
+  void deps
+  return createQuotaService(deps, {
+    resolveApiKey: async () => readClaudeCredentials(credentialsPath)?.creds.accessToken,
+    noKeyMessage: '未找到 Claude 登录(~/.claude/.credentials.json)',
+    threshold: lowPct,
+    refreshMs: DEFAULT_BALANCE_REFRESH_MS,
+    async fetchFresh() {
+      const entry = readClaudeCredentials(credentialsPath)
+      if (entry === undefined) throw new Error('Claude 登录文件不存在或已损坏')
+      const { creds } = entry
+      if (typeof creds.accessToken !== 'string' || creds.accessToken === '') {
+        throw new Error('Claude 登录文件里没有 accessToken')
+      }
+      if (typeof creds.expiresAt === 'number' && Date.now() > creds.expiresAt) {
+        throw new Error('Claude 登录已过期,请在终端跑一次 claude 刷新登录')
+      }
+      let response: Response
+      try {
+        response = await fetch(usageUrl, {
+          headers: {
+            authorization: `Bearer ${creds.accessToken}`,
+            accept: 'application/json',
+            'anthropic-beta': 'oauth-2025-04-20',
+          },
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        })
+      } catch (cause) {
+        throw new Error(`网络请求失败:${cause instanceof Error ? cause.message : String(cause)}`)
+      }
+      if (response.status === 401 || response.status === 403) throw new Error('Claude 登录无效或已过期')
+      if (response.status === 429) throw new Error('请求过于频繁,请稍后再试')
+      if (!response.ok) throw new Error(`Claude 用量接口返回 HTTP ${response.status}`)
+      let body: unknown
+      try {
+        body = await response.json()
+      } catch {
+        throw new Error('解析 Claude 数据失败')
+      }
+      return parseClaudeUsage(body, new Date().toISOString())
+    },
+    isLow: (snapshot) => snapshot.unit === 'pct'
+      ? numOrInfinity(snapshot.totalBalance) <= lowPct
+      : false,
+  })
+}

--- a/examples/dsh/packages/clawock-dsh/src/client.ts
+++ b/examples/dsh/packages/clawock-dsh/src/client.ts
@@ -31,7 +31,7 @@ import { defineStore } from '@deepseek-ai/dsh-client-runtime/client'
 // @types/react devDependency.
 import * as React from 'react'
 import styles from './styles.module.css'
-import type { EnrichedTrade, TraceDecision, TraceT1, TracesResult } from './types.ts'
+import type { BalanceResult, BalancesResult, EnrichedTrade, TraceDecision, TraceT1, TracesResult } from './types.ts'
 
 const { createElement, useEffect, useRef, useState } = React
 
@@ -462,6 +462,289 @@ function relativeDay(iso: string, today: string): string {
   return parseInt(iso.slice(5, 7)) + '月' + parseInt(iso.slice(8, 10)) + '日'
 }
 
+/** The four visual states one provider's reading can take. */
+export type BalanceTone = 'ok' | 'low' | 'stale' | 'none'
+
+/**
+ * Display projection of ONE provider's answer (test seam, like _displayEntry):
+ * the chip and panel render only these fields, so the view never keeps
+ * a second copy of the tone rules — the host already decided status and low.
+ * The title is the whole hover story: split, quota windows, stale reason,
+ * fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
+ * and carry the second window ('周'/'本周') as a muted pill suffix — both
+ * limits visible at the header without opening the panel.
+ */
+export function _rowDisplay(result: BalanceResult | null): { tone: BalanceTone; value: string; sub: string | null; title: string } {
+  if (result === null) return { tone: 'none', value: '—', sub: null, title: '余额加载中' }
+  if (!result.configured) return { tone: 'none', value: '未配置', sub: null, title: result.message ?? '未配置 API Key' }
+  if (result.snapshot === null) return { tone: 'none', value: '—', sub: null, title: result.message ?? '余额获取失败' }
+  const snapshot = result.snapshot
+  const isPct = snapshot.unit === 'pct'
+  const symbol = isPct ? '' : snapshot.currency === 'USD' ? '$' : snapshot.currency === 'CNY' ? '¥' : ''
+  // The headline reads the first window (parsers mirror it into totalBalance);
+  // when the primary window is absent this cycle (Claude between sessions),
+  // the first readable window steps up instead of rendering a bare '—'.
+  const pctWins = isPct && Array.isArray(snapshot.windows)
+    ? snapshot.windows.filter((w) => w.percent !== null)
+    : []
+  const parsed = Number.parseFloat(snapshot.totalBalance)
+  const value = isFinite(parsed)
+    ? (isPct ? String(Math.round(parsed)) + '%' : symbol + parsed.toLocaleString(undefined, { maximumFractionDigits: 2 }))
+    : pctWins.length > 0
+      ? String(Math.round(pctWins[0].percent as number)) + '%'
+      : (snapshot.totalBalance === '' ? '—' : symbol + snapshot.totalBalance)
+  const second = pctWins.length > 1 ? pctWins[1] : null
+  const sub = second !== null ? '· ' + second.label + ' ' + Math.round(second.percent as number) + '%' : null
+  const tone: BalanceTone = result.status === 'stale'
+    ? 'stale'
+    : (result.low || !snapshot.isAvailable ? 'low' : 'ok')
+  // 更新时间不重复展示:轮询是静默的,手动刷新有 ✓ 反馈——时间戳只增加噪音。
+  const parts = [
+    snapshot.unit === 'pct'
+      ? (snapshot.note !== '' ? snapshot.note : '配额窗口余量')
+      : 'API 余额',
+    !isPct && snapshot.grantedBalance !== '' ? '赠金 ' + symbol + snapshot.grantedBalance : null,
+    !isPct && snapshot.toppedUpBalance !== '' ? '充值 ' + symbol + snapshot.toppedUpBalance : null,
+    snapshot.isAvailable ? null : (isPct ? '该窗口额度已用尽' : '官方接口判定余额不足'),
+    result.status === 'stale' && result.message !== null ? '刷新失败,显示最近一次: ' + result.message : null,
+  ].filter((part): part is string => part !== null)
+  return { tone, value, sub, title: parts.join(' · ') }
+}
+
+/**
+ * The one line a panel row says out loud when something is wrong — stale
+ * reason, unconfigured key, insufficient balance/quota. A healthy number
+ * earns no caption at all; null means silence.
+ */
+export function _balanceNote(result: BalanceResult | null): string | null {
+  if (result === null) return null
+  if (!result.configured) return result.message ?? '未配置 API Key'
+  if (result.snapshot === null) return result.message ?? '余额获取失败'
+  if (result.status === 'stale') {
+    return '刷新失败,显示最近一次' + (result.message !== null ? ':' + result.message : '')
+  }
+  if (!result.snapshot.isAvailable) {
+    return result.snapshot.unit === 'pct' ? '该窗口额度已用尽' : '官方接口判定余额不足'
+  }
+  if (result.low) {
+    if (result.snapshot.unit === 'pct') return '窗口余量不足 ' + result.threshold + '%'
+    const symbol = result.snapshot.currency === 'USD' ? '$' : result.snapshot.currency === 'CNY' ? '¥' : ''
+    return '余额偏低,低于阈值 ' + symbol + result.threshold
+  }
+  return null
+}
+
+/** What the header chip's `inject` factory hands the component. */
+export interface BalancesInjected {
+  /** The last multi-provider answer this registration fetched, or null cold. */
+  cachedBalances: () => BalancesResult | null
+  /** Fetch all providers; `force` bypasses the host TTLs (the manual refresh). */
+  fetchBalances: (force: boolean) => Promise<BalancesResult>
+}
+
+/**
+ * Which provider the pill headlines. null = auto (first configured row);
+ * a click on a panel row pins that provider. Registration-store state, so
+ * the choice survives the ring's remounts.
+ */
+export interface BalanceUiState {
+  selected: string | null
+}
+
+/** Store factory — called inside `apply`, never a module-level handle. */
+export function createBalanceStore() {
+  return defineStore({
+    init: (): BalanceUiState => ({ selected: null }),
+    actions: {
+      select: (draft, provider: string) => { draft.selected = provider },
+    },
+  })
+}
+
+/** The chip's registration store handle type (derived, like DecisionMind's). */
+export type BalanceStore = ReturnType<typeof createBalanceStore>
+
+export type BalanceChipProps = BalancesInjected & PropsStore<BalanceStore> & { sessionId: string }
+
+/**
+ * The session-header chip (#871's final home): account status is app chrome,
+ * not decision data and not its own tab. The pill headlines ONE provider —
+ * the pinned one (registration store) or the first configured row — and the
+ * panel lists every provider; clicking a row pins it as the headline, which
+ * reads as "the balance of whichever service I'm actually burning". Same
+ * contracts: [data-balance-state], [data-pb-provider], [data-pb-role],
+ * [data-refresh], no emoji.
+ */
+/**
+ * The per-provider detail under its headline: quota providers get one line
+ * per window — label / remaining / reset right-aligned — so the 5h and week
+ * resets scan as a column instead of drowning in a sentence. Money rows keep
+ * their granted/topped-up split. Abnormal notes render above this path.
+ */
+function renderRowDetail(row: {
+  provider: string
+  result: BalanceResult
+  view: { tone: BalanceTone; value: string; title: string }
+  note: string | null
+}): React.ReactElement | null {
+  if (row.note !== null) return null
+  const wins = row.result.snapshot?.windows ?? []
+  if (wins.length > 0) {
+    // 每窗一行:文字读数 + 发丝进度条。条的语义=剩余量,低水位换警示色;
+    // 静态渲染不做 width 动画(宽度动画在审校里是红线),数据刷新整帧替换。
+    return h('div', { className: cx('bp-wins') },
+      wins.map((w) => {
+        const pct = w.percent === null ? null : Math.max(0, Math.min(100, Math.round(w.percent)))
+        const low = pct !== null && row.result.snapshot?.unit === 'pct' && pct <= row.result.threshold
+        const state = low ? 'low' : row.view.tone === 'stale' ? 'stale' : 'ok'
+        return h('div', { className: cx('bp-win'), key: w.label },
+          h('div', { className: cx('bp-win-line') },
+            h('span', { className: cx('bp-win-label') }, w.label),
+            h('span', { className: cx('bp-win-pct') }, w.percent === null ? '—' : Math.round(w.percent) + '%'),
+            h('span', { className: cx('bp-win-reset') }, w.resetAt === '' ? '' : '↻ ' + w.resetAt)),
+          h('div', { className: cx('bp-win-bar') },
+            h('div', {
+              className: cx('bp-win-fill'),
+              style: pct === null ? { width: '0%' } : { width: pct + '%' },
+              'data-balance-state': state,
+            })))
+      }))
+  }
+  const title = row.view.title
+  if (title === '') return null
+  // Money rows: drop the leading 'API 余额' label — the row already says who.
+  const body = title.startsWith('API 余额 · ') ? title.slice('API 余额 · '.length) : title
+  return h('div', { className: cx('bp-sub') }, body)
+}
+
+export function ProviderBalanceChip(props: BalanceChipProps): React.ReactElement {
+  const mountedRef = useRef(true)
+  const [data, setData] = useState<{ result: BalancesResult | null; loading: boolean }>(
+    () => ({ result: props.cachedBalances(), loading: false }),
+  )
+  const selected = props.useStore((state) => state.selected)
+  const select = (provider: string): void => { props.actions.select(provider) }
+  const [open, setOpen] = useState(false)
+  const [flash, setFlash] = useState<'ok' | 'same' | null>(null)
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rootRef = useRef<HTMLSpanElement | null>(null)
+
+  const runBalances = (force: boolean): void => {
+    props.fetchBalances(force).then((result) => {
+      if (!mountedRef.current) return
+      setData({ result, loading: false })
+      if (force) {
+        // #870 语义:拉到新数据 → ✓(品牌色),命中缓存 → ↻ 变绿,1.2s 回落。
+        setFlash(result.providers.some((p) => p.result.status === 'fresh') ? 'ok' : 'same')
+        if (flashTimerRef.current !== null) clearTimeout(flashTimerRef.current)
+        flashTimerRef.current = setTimeout(() => { setFlash(null) }, 1200)
+      }
+    }, () => {
+      if (mountedRef.current) setData((current) => ({ ...current, loading: false }))
+    })
+  }
+
+  useEffect(() => {
+    mountedRef.current = true
+    runBalances(false)
+    return () => {
+      mountedRef.current = false
+      if (flashTimerRef.current !== null) clearTimeout(flashTimerRef.current)
+    }
+  }, [props.sessionId])
+
+  useEffect(() => {
+    const intervalMs = Math.max(60000, data.result?.refreshMs ?? 60000)
+    const timer = setInterval(() => { runBalances(false) }, intervalMs)
+    return () => clearInterval(timer)
+  }, [data.result?.refreshMs, props.sessionId])
+
+  // 打开时:Escape 关闭,点外面关闭(document 存在才挂——测试环境无 DOM)。
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') return undefined
+    const onKey = (event: KeyboardEvent): void => { if (event.key === 'Escape') setOpen(false) }
+    const onDown = (event: MouseEvent): void => {
+      const root = rootRef.current
+      if (root !== null && event.target instanceof Node && !root.contains(event.target)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [open])
+
+  const rows = (data.result?.providers ?? []).map((provider) => ({
+    ...provider,
+    view: _rowDisplay(provider.result),
+    note: _balanceNote(provider.result),
+  }))
+  // 胶囊只讲一个 provider:选中的优先,否则第一行(稳定的 deepseek-first 序)。
+  const primary = rows.find((row) => row.provider === selected) ?? rows[0]
+  const refresh = (): void => {
+    setData((current) => ({ ...current, loading: true }))
+    runBalances(true)
+  }
+
+  return h('span', { className: cx('pbc'), ref: rootRef },
+    h('button', {
+      type: 'button',
+      className: cx('bchip'),
+      'data-balance-state': primary !== undefined ? primary.view.tone : 'none',
+      'data-pb-provider': primary !== undefined ? primary.provider : '',
+      'aria-expanded': open,
+      'aria-haspopup': 'dialog',
+      'aria-label': '各模型服务余额',
+      title: primary !== undefined
+        ? primary.label + ' · ' + primary.view.title + (rows.length > 1 ? '(点击查看其他服务)' : '')
+        : '余额加载中',
+      onClick: () => { setOpen(!open) },
+    },
+      primary === undefined
+        ? h('span', { className: cx('bchip-item') }, h('span', { className: cx('bchip-dot') }), '—')
+        : h('span', { className: cx('bchip-item'), 'data-pb-provider': primary.provider, 'data-pb-role': 'chip', 'data-balance-state': primary.view.tone },
+          h('span', { className: cx('bchip-dot') }),
+          h('span', { className: cx('bchip-v'), 'data-balance-state': primary.view.tone }, primary.view.value),
+          // 周限额副读数:装饰性重复(面板/悬浮里有完整版),对读屏静音。
+          primary.view.sub === null
+            ? null
+            : h('span', { className: cx('bchip-sub'), 'aria-hidden': 'true' }, primary.view.sub))),
+    h('div', { className: cx('bp'), 'data-open': open ? 'true' : 'false', role: open ? 'dialog' : 'none', 'aria-label': '各模型服务余额' },
+      h('div', { className: cx('bp-head') },
+        h('span', { className: cx('bp-title') }, 'API 余额'),
+        h('button', {
+          type: 'button',
+          className: cx('bal-rf', data.loading && 'spin', flash === 'ok' && 'flash-ok', flash === 'same' && 'flash-same'),
+          'data-refresh': 'true',
+          'aria-label': '刷新全部余额',
+          title: '立即刷新',
+          onClick: refresh,
+        }, flash === 'ok' ? '✓' : '↻')),
+      rows.length === 0
+        ? h('div', { className: cx('bp-empty') }, '正在读取各服务余额…')
+        : rows.map((row) => h('button', {
+          type: 'button',
+          key: row.provider,
+          className: cx('bp-row'),
+          'data-pb-provider': row.provider,
+          'data-pb-role': 'panel',
+          // 点行=把该 provider 钉成胶囊头条;当前头条行带 aria-pressed。
+          'aria-pressed': row.provider === (primary !== undefined ? primary.provider : ''),
+          onClick: () => { select(row.provider) },
+        },
+          h('span', { className: cx('bp-dot'), 'data-balance-state': row.view.tone }),
+          h('span', { className: cx('bp-label') },
+            row.label,
+            row.provider === (primary !== undefined ? primary.provider : '')
+              ? h('span', { className: cx('bp-pin') })
+              : null),
+          h('span', { className: cx('bp-v', row.view.tone === 'low' ? 'bad' : ''), 'data-balance-state': row.view.tone }, row.view.value),
+          row.note !== null
+            ? h('div', { className: cx('bp-note', row.view.tone === 'stale' ? 'warn' : 'bad') }, row.note)
+            : renderRowDetail(row)))))
+}
+
 export function DecisionMind(props: DecisionMindProps): React.ReactElement {
   const filter = props.useStore((state) => state.filter)
   const open = props.useStore((state) => state.open)
@@ -698,6 +981,7 @@ export async function apply(ctx: Context & ClientContributionContext): Promise<v
   // data belongs to this plugin instance, never to a module-level singleton
   // (which would leak across plugin reloads) and never to the UI store.
   let cached: TraceSnapshot | null = null
+  let cachedBalances: BalancesResult | null = null
   const call = async <T>(method: string, args: unknown[] = []): Promise<T> => {
     const result = await studioRemote[method]!(...args) as RemoteResult<T>
     if (!result.ok) {
@@ -724,6 +1008,17 @@ export async function apply(ctx: Context & ClientContributionContext): Promise<v
       return { snapshot, changed }
     },
   })
+  // The chip is app-level account chrome, not decision data — it lives in the
+  // session header's utilities seat with its own inject face and cache, so
+  // the Decision Mind view carries trading semantics only.
+  const balancesInjected = (): BalancesInjected => ({
+    cachedBalances: () => cachedBalances,
+    fetchBalances: async (force) => {
+      const result = await call<BalancesResult>('balance', [force])
+      cachedBalances = result
+      return result
+    },
+  })
   const store = createDecisionMindStore()
   ctx.slots.inject('conversation.view', () => ctx.slots.register({
     name: 'conversation.view',
@@ -733,4 +1028,12 @@ export async function apply(ctx: Context & ClientContributionContext): Promise<v
     store,
     inject: injected,
   }, DecisionMind))
+  const balancesStore = createBalanceStore()
+  ctx.slots.inject('conversation.session.header.utilities', () => ctx.slots.register({
+    name: 'conversation.session.header.utilities',
+    id: 'provider-balance',
+    order: 90,
+    store: balancesStore,
+    inject: balancesInjected,
+  }, ProviderBalanceChip))
 }

--- a/examples/dsh/packages/clawock-dsh/src/index.ts
+++ b/examples/dsh/packages/clawock-dsh/src/index.ts
@@ -12,16 +12,58 @@
 import { Remote, TypertRemoteService } from '@deepseek-ai/dsh-typert-protocol'
 import type { Context } from '@deepseek-ai/cordis'
 import type {
-  LedgerResult, ListRunsResult, PlansResult, PortfolioResult, RunDetailResult, TracesResult,
+  BalancesResult, LedgerResult, ListRunsResult, PlansResult, PortfolioResult, RunDetailResult, TracesResult,
 } from './types.ts'
+import { createBalanceService, createClaudeService, createMinimaxService, type BalanceCredentials } from './balance.ts'
 import { getRun, listRuns } from './scan.ts'
 import { readLedger, readPlans, readPortfolio, readTraces } from './ledger.ts'
 import { createTraceCache, workspaceKeyOf, workspaceSignature } from './freshness.ts'
 
 const workspaceOf = (): string => process.env.CLAWOCK_WORKSPACE || process.cwd()
 
+/**
+ * Row-level config the profile patch may set (see cordis.patch.yml).
+ */
+export interface ClawockStudioConfig {
+  /** DeepSeek upstream root for the balance chip; /user/balance is appended. */
+  balanceBaseUrl?: string
+  /** Red-dot threshold in the displayed entry's currency (CNY/USD units). */
+  balanceThreshold?: number
+  /** Suggested client poll interval in ms. */
+  balanceRefreshMs?: number
+  /** MiniMax upstream root; /v1/token_plan/remains is appended. */
+  minimaxBaseUrl?: string
+  /** Credentials seam reference for the MiniMax key (env fallback same name). */
+  minimaxKeyRef?: string
+  /** Red dot when MiniMax quota windows drop to/below this remaining percent. */
+  minimaxLowPct?: number
+  /** openclaw gateway config fallback for provider keys (models.providers.*). */
+  minimaxOpenclawConfigPath?: string
+  /** Claude Code OAuth credentials file (claudeAiOauth.accessToken). */
+  claudeCredentialsPath?: string
+  /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
+  claudeUsageUrl?: string
+  /** Red dot when the Claude session window's remaining percent is low. */
+  claudeLowPct?: number
+}
+
+/**
+ * The row config apply() hands to the next gateway instance. Module-level
+ * on purpose and safe: apply() assigns it synchronously before ctx.plugin
+ * constructs the service, and the balance method reads it lazily on first
+ * use — a plugin reload therefore gets its own value and nothing serves
+ * config past its lifetime.
+ */
+let pendingConfig: ClawockStudioConfig = {}
+
 export class ClawockStudioGateway extends TypertRemoteService {
-  static inject = [] as const
+  static inject = ['credentials'] as const
+
+  /**
+   * cordis mixes the injected services onto the instance at construction;
+   * this type-only declaration types `this.credentials` without a cast,
+   * and `declare` fields emit nothing at runtime.
+   */
 
   /**
    * Signature-keyed trace cache per workspace (see freshness.ts). Owned by the
@@ -32,8 +74,20 @@ export class ClawockStudioGateway extends TypertRemoteService {
    */
   private readonly tracesCache = createTraceCache()
 
-  constructor(ctx: Context) {
+  /**
+   * Per-provider balance services, built lazily on first use — instance-scoped
+   * like tracesCache, and constructed here rather than in the constructor so
+   * the gateway constructor keeps the exact super(ctx, serviceKey) shape.
+   */
+  private balanceServices: {
+    deepseek: { get(force: boolean): Promise<import('./types.ts').BalanceResult> }
+    minimax: { get(force: boolean): Promise<import('./types.ts').BalanceResult> }
+    claude: { get(force: boolean): Promise<import('./types.ts').BalanceResult> }
+  } | null = null
+
+  constructor(ctx: Context, config: ClawockStudioConfig = {}) {
     super(ctx, 'clawockStudio')
+    void config
   }
 
   /** @returns Prepared runs (newest first), with decision/receipt presence flags. */
@@ -92,10 +146,75 @@ export class ClawockStudioGateway extends TypertRemoteService {
     this.tracesCache.set(ws, signature, value)
     return value
   }
+
+  /**
+   * The header chip's answer: every provider's official endpoint, each
+   * answered with that adapter's own key. In-band by design — never throws;
+   * per-provider statuses 'no-key' / 'failed' / 'stale' carry a Chinese
+   * message and a stale read keeps the last good snapshot. A provider with
+   * no key configured is an honest row, not a hidden one.
+   * @param force - bypass the TTL caches (the manual refresh button).
+   */
+  @Remote
+  async balance(force: boolean): Promise<BalancesResult> {
+    if (this.balanceServices === null) {
+      this.balanceServices = {
+        deepseek: createBalanceService(
+          { credentials: credentialsOf(this.ctx) },
+          { baseUrl: pendingConfig.balanceBaseUrl, threshold: pendingConfig.balanceThreshold, refreshMs: pendingConfig.balanceRefreshMs },
+        ),
+        minimax: createMinimaxService(
+          { credentials: credentialsOf(this.ctx) },
+          {
+            baseUrl: pendingConfig.minimaxBaseUrl,
+            keyRef: pendingConfig.minimaxKeyRef,
+            lowPct: pendingConfig.minimaxLowPct,
+            openclawConfigPath: pendingConfig.minimaxOpenclawConfigPath,
+          },
+        ),
+        claude: createClaudeService(
+          { credentials: credentialsOf(this.ctx) },
+          {
+            credentialsPath: pendingConfig.claudeCredentialsPath,
+            usageUrl: pendingConfig.claudeUsageUrl,
+            lowPct: pendingConfig.claudeLowPct,
+          },
+        ),
+      }
+    }
+    const [deepseek, minimax, claude] = await Promise.all([
+      this.balanceServices.deepseek.get(force),
+      this.balanceServices.minimax.get(force),
+      this.balanceServices.claude.get(force),
+    ])
+    return { providers: [
+      { provider: 'deepseek', label: 'DeepSeek', result: deepseek },
+      { provider: 'minimax', label: 'MiniMax', result: minimax },
+      { provider: 'claude', label: 'Claude', result: claude },
+    ], refreshMs: Math.min(deepseek.refreshMs, minimax.refreshMs, claude.refreshMs) }
+  }
+}
+
+/**
+ * Services the profile mixes into this plugin's context (the function-
+ * plugin form — the class's `static inject` is its type mirror). The
+ * gateway reaches the credential seam through `this.ctx.credentials`.
+ */
+export const inject = ['credentials']
+
+/**
+ * Typed access to the injected credentials seam. Deliberately a cast, not
+ * an import of @deepseek-ai/dsh-credentials: that package's cordis
+ * augmentation would register this package in the typert host face and
+ * fail the Remote-artifacts gate (see balance.ts).
+ */
+function credentialsOf(ctx: Context): BalanceCredentials {
+  return (ctx as unknown as { credentials: BalanceCredentials }).credentials
 }
 
 export const name = 'clawock-dsh'
 
-export function apply(ctx: Context): void {
-  ctx.plugin(ClawockStudioGateway)
+export function apply(ctx: Context, config: ClawockStudioConfig = {}): void {
+  pendingConfig = config
+  ctx.plugin(ClawockStudioGateway, config)
 }

--- a/examples/dsh/packages/clawock-dsh/src/styles.module.css
+++ b/examples/dsh/packages/clawock-dsh/src/styles.module.css
@@ -881,3 +881,391 @@ body[data-ds-dark-theme] .dmt {
     left:3px
   }
 }
+
+/* API balance — session-header utility chip (the standalone tab AND the
+   Decision-Mind-header capsule each lasted one round): account status is app
+   chrome, so it renders beside the session title on every tab — one glass
+   pill carrying every provider's reading inline, tap = small origin-aware
+   panel with the per-provider story and the manual refresh. This renders
+   OUTSIDE .dmt, so it owns its variable scope; same #868/#869 material
+   recipe (translucent theme surface + backdrop blur + saturate), opaque
+   colour first. Contracts: [data-balance-state], [data-pb-provider],
+   [data-open], [data-refresh], no emoji. */
+.pbc {
+  --surface:var(--dsw-alias-bg-layer-1, #FFFFFF);
+  --text:var(--dsw-alias-label-primary, #15171B);
+  --text3:var(--dsw-alias-label-tertiary, #81858C);
+  --cap:var(--dsw-alias-label-caption, #ADB2B8);
+  --brand:var(--dsw-alias-state-business-primary, #4176E6);
+  --hover:var(--dsw-alias-interactive-bg-hover, rgba(17,24,39,.05));
+  --ok:#1B8644;
+  --bad:#C01313;
+  --warn:#AA6924;
+  --shadow-lg:0 16px 40px rgba(16,24,40,.16), 0 2px 10px rgba(16,24,40,.08);
+  --tint-border:rgba(0,0,0,.05);
+  --pop-surface:rgba(255,255,255,.72);
+  --edge-light:rgba(255,255,255,.55);
+  --font:var(--dsw-font-family, -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif);
+  position:relative;
+  display:inline-flex
+}
+body[data-ds-dark-theme] .pbc {
+  --ok:#3FCB74;
+  --bad:#F2554F;
+  --warn:#E0A752;
+  --shadow-lg:0 16px 40px rgba(0,0,0,.52), 0 2px 10px rgba(0,0,0,.36);
+  --tint-border:rgba(255,255,255,.08);
+  --pop-surface:rgba(28,30,34,.78);
+  --edge-light:rgba(255,255,255,.12)
+}
+.pbc .bchip {
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  height:26px;
+  padding:0 11px;
+  border-radius:13px;
+  border:1px solid var(--tint-border);
+  background:var(--surface);
+  background:color-mix(in srgb, var(--surface) 62%, transparent);
+  -webkit-backdrop-filter:blur(10px) saturate(1.6);
+  backdrop-filter:blur(10px) saturate(1.6);
+  box-shadow:var(--dsw-shadow-lv1, 0 1px 2px rgba(16,24,40,.04)), inset 0 1px 0 var(--edge-light);
+  font:500 12px/1 var(--font);
+  color:var(--text3);
+  cursor:pointer;
+  transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1)
+}
+.pbc .bchip::after {
+  content:"";
+  position:absolute;
+  inset:-7px;
+  border-radius:20px
+}
+.pbc .bchip:active {
+  transform:scale(.96)
+}
+@media (hover: hover) and (pointer: fine) {
+  .pbc .bchip:hover {
+    background:color-mix(in srgb, var(--surface) 80%, transparent)
+  }
+}
+.pbc .bchip:focus-visible {
+  outline:1px solid var(--brand);
+  outline-offset:1px
+}
+.pbc .bchip-item {
+  display:inline-flex;
+  align-items:center;
+  gap:5px
+}
+.pbc .bchip-dot {
+  flex:none;
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:var(--cap);
+  transition:background .15s
+}
+.pbc .bchip-item[data-balance-state="ok"] .bchip-dot { background:var(--ok) }
+.pbc .bchip-item[data-balance-state="low"] .bchip-dot { background:var(--bad) }
+.pbc .bchip-item[data-balance-state="stale"] .bchip-dot { background:var(--warn) }
+.pbc .bchip-v {
+  font:600 12px/1 var(--font);
+  font-variant-numeric:tabular-nums;
+  letter-spacing:-.01em;
+  white-space:nowrap;
+  color:var(--text)
+}
+.pbc .bchip-v[data-balance-state="low"] { color:var(--bad) }
+.pbc .bchip-v[data-balance-state="none"] { color:var(--cap); font-weight:500 }
+/* 第二窗口(周限额)副读数:比主读数低一级,同轴排版,不挤主数。 */
+.pbc .bchip-sub {
+  font:500 11px/1 var(--font);
+  font-variant-numeric:tabular-nums;
+  letter-spacing:.01em;
+  white-space:nowrap;
+  color:var(--text3)
+}
+/* The panel: anchored to its trigger (transform-origin top right), enters
+   from scale(.97)+4px up — nothing appears from nowhere — and never steals
+   a click while leaving (pointer-events none). */
+.pbc .bp {
+  position:absolute;
+  top:calc(100% + 8px);
+  right:0;
+  z-index:60;
+  width:max-content;
+  max-width:min(300px, calc(100vw - 24px));
+  min-width:min(220px, calc(100vw - 24px));
+  padding:10px 12px 8px;
+  border-radius:12px;
+  border:1px solid var(--tint-border);
+  background:var(--surface);
+  background:color-mix(in srgb, var(--pop-surface) 100%, transparent);
+  -webkit-backdrop-filter:blur(28px) saturate(1.8);
+  backdrop-filter:blur(28px) saturate(1.8);
+  box-shadow:var(--shadow-lg), inset 0 1px 0 var(--edge-light);
+  transform-origin:top right;
+  transition:transform .16s cubic-bezier(.23,1,.32,1),opacity .16s cubic-bezier(.23,1,.32,1)
+}
+.pbc .bp[data-open="false"] {
+  opacity:0;
+  transform:scale(.97) translateY(-4px);
+  pointer-events:none
+}
+.pbc .bp-head {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  margin-bottom:2px
+}
+.pbc .bp-title {
+  font:600 11px/1.3 var(--font);
+  letter-spacing:.04em;
+  color:var(--cap)
+}
+.pbc .bp-row {
+  display:grid;
+  grid-template-columns:auto auto 1fr;
+  align-items:center;
+  column-gap:8px;
+  row-gap:3px;
+  width:100%;
+  padding:8px 6px;
+  margin:0 -6px;
+  border:0;
+  background:transparent;
+  font:inherit;
+  color:inherit;
+  text-align:left;
+  cursor:pointer;
+  border-radius:8px;
+  transition:background .12s,transform .16s cubic-bezier(.23,1,.32,1)
+}
+.pbc .bp-row + .bp-row {
+  position:relative;
+  border-radius:0 0 8px 8px
+}
+.pbc .bp-row + .bp-row::before {
+  content:"";
+  position:absolute;
+  top:0;
+  left:6px;
+  right:6px;
+  height:1px;
+  background:var(--tint-border)
+}
+@media (hover: hover) and (pointer: fine) {
+  .pbc .bp-row:hover {
+    background:var(--hover)
+  }
+}
+.pbc .bp-row:active {
+  transform:scale(.98);
+  background:var(--hover)
+}
+.pbc .bp-row:focus-visible {
+  outline:1px solid var(--brand);
+  outline-offset:-1px
+}
+.pbc .bp-dot {
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  background:var(--cap)
+}
+.pbc .bp-dot[data-balance-state="ok"] { background:var(--ok) }
+.pbc .bp-dot[data-balance-state="low"] { background:var(--bad) }
+.pbc .bp-dot[data-balance-state="stale"] { background:var(--warn) }
+.pbc .bp-label {
+  display:inline-flex;
+  align-items:center;
+  gap:5px;
+  font:500 12px/1.4 var(--font);
+  color:var(--text)
+}
+.pbc .bp-pin {
+  flex:none;
+  width:5px;
+  height:5px;
+  border-radius:50%;
+  background:var(--brand)
+}
+.pbc .bp-v {
+  justify-self:end;
+  font:650 13px/1.2 var(--font);
+  font-variant-numeric:tabular-nums;
+  letter-spacing:-.01em;
+  white-space:nowrap;
+  color:var(--text)
+}
+.pbc .bp-v.bad {
+  color:var(--bad)
+}
+/* Per-window grid: one line per quota window — label / remaining / reset —
+   plus a hairline remaining-bar under it. The bar is a translucent ink track
+   ON the frosted panel (no second glass layer — glass inside glass reads as
+   mud), fill at ink strength, warning tones only below the low watermark. */
+.pbc .bp-wins {
+  grid-column:1 / -1;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  margin-top:2px
+}
+.pbc .bp-win {
+  display:flex;
+  flex-direction:column;
+  gap:3px;
+  font-size:11px
+}
+.pbc .bp-win-line {
+  display:flex;
+  align-items:baseline;
+  gap:8px;
+  line-height:1.5
+}
+.pbc .bp-win-label {
+  color:var(--cap);
+  min-width:30px;
+  letter-spacing:.02em
+}
+.pbc .bp-win-pct {
+  margin-left:auto;
+  font-weight:600;
+  color:var(--text);
+  font-variant-numeric:tabular-nums
+}
+.pbc .bp-win-reset {
+  color:var(--cap);
+  font-family:var(--mono);
+  font-size:10.5px;
+  min-width:58px;
+  text-align:right;
+  font-variant-numeric:tabular-nums
+}
+.pbc .bp-win-bar {
+  height:3px;
+  border-radius:2px;
+  overflow:hidden;
+  background:color-mix(in srgb, var(--text) 9%, transparent)
+}
+.pbc .bp-win-fill {
+  height:100%;
+  border-radius:2px;
+  background:color-mix(in srgb, var(--text) 42%, transparent);
+  transition:background .15s
+}
+.pbc .bp-win-fill[data-balance-state="low"] { background:var(--bad) }
+.pbc .bp-win-fill[data-balance-state="stale"] { background:var(--warn) }
+.pbc .bp-note, .pbc .bp-sub {
+  grid-column:1 / -1;
+  font:400 11px/1.5 var(--font);
+  overflow-wrap:anywhere
+}
+.pbc .bp-sub { color:var(--cap) }
+.pbc .bp-note.warn { color:var(--warn) }
+.pbc .bp-note.bad { color:var(--bad) }
+.pbc .bp-empty {
+  padding:8px 0 10px;
+  font:400 12px/1.5 var(--font);
+  color:var(--cap)
+}
+/* The manual refresh is a ghost circular icon button (#870): transparent,
+   no border, tint only on hover; its state is the icon's shape. The ::after
+   ring extends the hit target to ~36px without moving a visual pixel. */
+.pbc .bal-rf {
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:22px;
+  height:22px;
+  border:0;
+  border-radius:50%;
+  padding:0;
+  background:transparent;
+  color:var(--text3);
+  font:600 12px/1 var(--font);
+  cursor:pointer;
+  transition:background .12s,color .12s,transform .16s cubic-bezier(.23,1,.32,1)
+}
+.pbc .bal-rf::after {
+  content:"";
+  position:absolute;
+  inset:-9px;
+  border-radius:50%
+}
+.pbc .bal-rf:active {
+  transform:scale(.95)
+}
+@media (hover: hover) and (pointer: fine) {
+  .pbc .bal-rf:hover {
+    background:var(--hover);
+    color:var(--text)
+  }
+}
+.pbc .bal-rf:focus-visible {
+  outline:1px solid var(--brand);
+  outline-offset:1px
+}
+.pbc .bal-rf.spin {
+  animation:clawock-spin .8s linear infinite
+}
+.pbc .bal-rf.flash-ok {
+  color:var(--brand)
+}
+.pbc .bal-rf.flash-same {
+  color:var(--ok)
+}
+@keyframes clawock-spin {
+  to { transform:rotate(360deg) }
+}
+/* Reduced motion: no scale/translate travel anywhere; opacity carries the
+   enter/exit and the colour flashes remain — they aid comprehension. */
+@media (prefers-reduced-motion: reduce) {
+  .pbc .bchip, .pbc .bal-rf {
+    transition:background .12s,color .12s
+  }
+  .pbc .bp {
+    transition:opacity .16s ease
+  }
+  .pbc .bp[data-open="false"] {
+    transform:none
+  }
+  .pbc .bchip:active, .pbc .bal-rf:active {
+    transform:none
+  }
+  .pbc .bal-rf.spin {
+    animation:none
+  }
+  .pbc .bp-win-fill {
+    transition:none
+  }
+}
+/* Mobile: blur is the expensive part on phone GPUs — halve the radius,
+   keep the saturate lift so the material still reads as glass. */
+@media (max-width: 520px) {
+  .pbc .bchip {
+    -webkit-backdrop-filter:blur(7px) saturate(1.4);
+    backdrop-filter:blur(7px) saturate(1.4)
+  }
+  .pbc .bp {
+    -webkit-backdrop-filter:blur(14px) saturate(1.5);
+    backdrop-filter:blur(14px) saturate(1.5)
+  }
+}
+/* Reduced transparency: frost over — solid surfaces, no blur cost. */
+@media (prefers-reduced-transparency: reduce) {
+  .pbc .bchip {
+    background:var(--surface);
+    -webkit-backdrop-filter:none;
+    backdrop-filter:none
+  }
+  .pbc .bp {
+    background:var(--surface);
+    -webkit-backdrop-filter:none;
+    backdrop-filter:none
+  }

--- a/examples/dsh/packages/clawock-dsh/src/types.ts
+++ b/examples/dsh/packages/clawock-dsh/src/types.ts
@@ -156,3 +156,83 @@ export interface TracesResult {
   rateSource: string | null
   lastUpdated: string | null
 }
+
+/** One quota window worth its own line in the panel's per-window grid. */
+export interface BalanceWindow {
+  /** Short label rendered verbatim: '5h' | '周' | '会话' | '本周'. */
+  label: string
+  /** Remaining percent of this window; null when the plan doesn't report it. */
+  percent: number | null
+  /** Preformatted LOCAL reset stamp ('15:00' / '周四 21:00'); '' when unknown. */
+  resetAt: string
+}
+
+/**
+ * One account/quota reading as answered by the provider's official endpoint,
+ * with the entry the host picked to display. Numeric readings stay strings so
+ * no rounding happens on the wire; the client formats for display only.
+ */
+export interface BalanceSnapshot {
+  /** Whether the API reports the account usable (sufficient balance / quota left). */
+  isAvailable: boolean
+  /**
+   * How `totalBalance` reads: 'money' carries a currency symbol via
+   * `currency` ('CNY' | 'USD' | ''), 'pct' carries a remaining-percent number
+   * (quota windows). '' defaults to 'money'.
+   */
+  unit: string
+  /** 'CNY' | 'USD' | '' — the displayed entry's currency (money unit only). */
+  currency: string
+  /** Total available balance ("110.00") or remaining percent ("62"). */
+  totalBalance: string
+  /** Not-expired granted balance (DeepSeek money accounts; '' elsewhere). */
+  grantedBalance: string
+  /** Topped-up balance (DeepSeek money accounts; '' elsewhere). */
+  toppedUpBalance: string
+  /** ISO timestamp of the upstream fetch that produced this snapshot. */
+  asOf: string
+  /** One context line for the panel (quota windows, resets); '' when none. */
+  note: string
+  /** Per-window grid for the panel; money accounts send []. */
+  windows: BalanceWindow[]
+}
+
+/** One provider's row in the balance panel: identity plus the same in-band answer. */
+export interface ProviderBalance {
+  /** Stable id: 'deepseek' | 'minimax'. */
+  provider: string
+  /** Human label rendered verbatim ('DeepSeek', 'MiniMax'). */
+  label: string
+  result: BalanceResult
+}
+
+/**
+ * The whole balance answer across providers. In-band by design: balance()
+ * never throws — per-provider 'no-key' / 'failed' / 'stale' statuses carry a
+ * Chinese message the view renders verbatim, and a stale read keeps the last
+ * good snapshot so a transient 429 cannot erase a real number.
+ */
+export interface BalancesResult {
+  /** Rows in stable display order (deepseek first). */
+  providers: ProviderBalance[]
+  /** Suggested client poll interval in ms. */
+  refreshMs: number
+}
+
+/** One provider's answer. Same in-band contract the single-provider box had. */
+export interface BalanceResult {
+  /** Whether this provider's API key is configured at all (seam or env). */
+  configured: boolean
+  /** Last good snapshot, kept across failed refreshes (null on cold start). */
+  snapshot: BalanceSnapshot | null
+  /** 'fresh' | 'cached' | 'stale' | 'failed' | 'no-key' — decided host-side. */
+  status: 'fresh' | 'cached' | 'stale' | 'failed' | 'no-key'
+  /** Balance/quota at or below the low threshold (only when readable). */
+  low: boolean
+  /** Human-readable reason for failed/no-key, null while good. */
+  message: string | null
+  /** Effective low threshold, in the displayed entry's unit. */
+  threshold: number
+  /** Suggested client poll interval in ms. */
+  refreshMs: number
+}

--- a/examples/dsh/packages/clawock-dsh/tsdown.host.config.mjs
+++ b/examples/dsh/packages/clawock-dsh/tsdown.host.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig({
     scan: 'src/scan.ts',
     ledger: 'src/ledger.ts',
     freshness: 'src/freshness.ts',
+    balance: 'src/balance.ts',
   },
   outDir: 'lib',
   format: ['esm'],

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -1213,16 +1213,16 @@ test("balance: CNY picking, tolerant parsing and the service's polite-cadence st
     globalThis.fetch = originalFetch;
   }
 
-  // MiniMax with no key configured ANYWHERE (seam/env/openclaw config) is an
-  // honest panel row, not an error. The openclaw fallback must be pointed at
-  // a missing file — the real one on this host carries the production key.
+  // MiniMax with no key configured ANYWHERE (seam, env, then the gateway
+  // config fallback) is an honest panel row, not an error. That fallback must
+  // be pointed at a missing file — the real one carries the production key.
   const mmMissing = { credentials: { resolve: async () => undefined }, env: {} };
   const savedEnv = process.env.MINIMAX_API_KEY;
   delete process.env.MINIMAX_API_KEY;
   try {
     const mmNoKey = await createMinimaxService(
       { credentials: { resolve: async () => undefined } },
-      { openclawConfigPath: "/nonexistent/openclaw.json" },
+      { openclawConfigPath: "/nonexistent/provider-keys.json" },
     ).get(false);
     assert.equal(mmNoKey.status, "no-key");
     assert.match(mmNoKey.message, /未配置/);
@@ -1236,7 +1236,7 @@ test("balance: CNY picking, tolerant parsing and the service's polite-cadence st
   const fsMod = await import("node:fs");
   const pathMod = await import("node:path");
   const tmpCfg = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pb-"));
-  const cfgPath = pathMod.join(tmpCfg, "openclaw.json");
+  const cfgPath = pathMod.join(tmpCfg, "gateway-keys.json");
   fsMod.writeFileSync(cfgPath, JSON.stringify({ models: { providers: { minimax: { apiKey: "mm-from-openclaw" } } } }));
   let sawAuth = "";
   globalThis.fetch = async (url, init) => {

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -166,9 +166,25 @@ function clientUrl() {
   return pathToFileURL(path.join(PLUGIN, "lib", "client.js")).href + "?v=" + importCounter;
 }
 
+// Effect cleanups the stub collects: the view's poll effect arms a real
+// interval, and a leaked one would keep the test runner's loop alive.
+let reactEffectCleanups = [];
+function disposeReactEffects() {
+  for (const cleanup of reactEffectCleanups) {
+    if (typeof cleanup === "function") cleanup();
+  }
+  reactEffectCleanups = [];
+}
+
 function makeReactStub() {
-  let state = null;
+  // Cursor-based slots: useState(n) binds to slot n for EVERY render, so a
+  // setter write survives re-renders the way React state does. Callers that
+  // render the same component twice and want fresh state call _resetCursor()
+  // first (the old append-per-render behaviour, kept for older tests).
+  const slots = [];
+  let cursor = 0;
   return {
+    _resetCursor() { cursor = 0; },
     createElement(type, props, ...children) {
       if (typeof type === "function") {
         // Mini-renderer: invoke function components so their subtrees appear.
@@ -177,22 +193,54 @@ function makeReactStub() {
       return { type, props: props || {}, children };
     },
     useState(initial) {
-      if (state === null) state = typeof initial === "function" ? initial() : initial;
+      const index = cursor++;
+      if (index >= slots.length) slots.push(typeof initial === "function" ? initial() : initial);
       return [
-        state,
+        slots[index],
         (updater) => {
-          state = typeof updater === "function" ? updater(state) : updater;
+          slots[index] = typeof updater === "function" ? updater(slots[index]) : updater;
         },
       ];
     },
     useEffect(fn) {
-      fn(); // React runs effects after render; cleanup only on unmount/re-run
+      reactEffectCleanups.push(fn()); // runs like a mount; cleanup is collected
     },
     useRef(initial) {
-      // The view uses a ref for its own root element; without a DOM the
-      // scroll-restore effect must simply do nothing.
+      // The views use refs for roots, mount flags and timers; without a DOM
+      // the scroll/outside-click effects must simply do nothing, and the rest
+      // are plain { current } holders.
       return { current: initial === undefined ? null : initial };
     },
+  };
+}
+
+/** Balance fixtures: per-provider rows and the whole-chip envelope. */
+const AS_OF = "2026-08-23T10:00:00.000Z";
+const DS_ROW_OK = {
+  provider: "deepseek", label: "DeepSeek",
+  result: { configured: true, snapshot: { isAvailable: true, unit: "money", currency: "CNY", totalBalance: "110.00", grantedBalance: "10.00", toppedUpBalance: "100.00", asOf: AS_OF, note: "", windows: [] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
+};
+const MM_ROW_OK = {
+  provider: "minimax", label: "MiniMax",
+  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "76", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "5h 窗口剩余 76% · 周窗口剩余 90%", windows: [{ label: "5h", percent: 76, resetAt: "21:00" }, { label: "周", percent: 90, resetAt: "周四 21:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
+};
+const CL_ROW_OK = {
+  provider: "claude", label: "Claude",
+  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "64", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "会话窗口剩余 64% · 本周剩余 31%", windows: [{ label: "会话", percent: 64, resetAt: "10:00" }, { label: "本周", percent: 31, resetAt: "周四 10:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
+};
+const BALANCES_OK = { providers: [DS_ROW_OK, MM_ROW_OK, CL_ROW_OK], refreshMs: 60000 };
+const QUIET_BALANCES = { providers: [], refreshMs: 60000 };
+/** The balances channel stub for renders that don't exercise the chip. */
+function balanceProps() {
+  return { cachedBalances: () => null, fetchBalances: async () => QUIET_BALANCES };
+}
+/** Chip selection store stub: same surface the registration store provides. */
+function makeBalanceStoreStub(initial = null) {
+  let s = { selected: initial };
+  return {
+    useStore: (sel) => sel(s),
+    actions: { select(provider) { s = { ...s, selected: provider }; } },
+    _get: () => s,
   };
 }
 
@@ -252,48 +300,66 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
   });
   assert.deepEqual(api.inject, ["slots", "remote"]);
 
-  let registered = null;
-  let component = null;
   const remoteFace = {
     ledger: async () => ({ ok: true, value: { entries: [] } }),
     portfolio: async () => ({ ok: true, value: { books: [] } }),
     plans: async () => ({ ok: true, value: { plans: [] } }),
     traces: async () => ({ ok: true, value: { workspaceKey: "ws1", signature: "sig1", trades: [], rate: null } }),
     get: async (runId) => ({ ok: true, value: { runId } }),
+    balance: async () => ({ ok: true, value: BALANCES_OK }),
   };
   const ctx = {
     effect() {},
     get(name) { assert.equal(name, "remote.clawockStudio"); return remoteFace; },
     slots: {
-      inject(name, fn) { assert.equal(name, "conversation.view"); this._fn = fn; },
-      register(definition, Component) { registered = definition; component = Component; },
+      inject(name, fn) { (this._seats ??= []).push(name); (this._fns ??= []).push(fn); },
+      register(definition, Component) { (this._regs ??= []).push({ definition, Component }); },
     },
     remote: {
       $mount: async (descriptors) => {
-        assert.equal(descriptors.descriptors.length, 6);
+        assert.equal(descriptors.descriptors.length, 7);
         // gateway invoke() validates args against descriptor.parameters.length —
         // get(runId) must declare its argument or every call would throw.
         const getDesc = descriptors.descriptors.find((d) => d.method === "get");
         assert.ok(getDesc, "get descriptor present");
         assert.equal(getDesc.parameters.length, 1, "get(runId) must declare its argument");
         assert.equal(getDesc.parameters[0].name, "runId");
+        // The balance box rides the same Remote face: its descriptor must
+        // declare the force argument the host's balance(force) takes.
+        const balDesc = descriptors.descriptors.find((d) => d.method === "balance");
+        assert.ok(balDesc, "balance descriptor present");
+        assert.equal(balDesc.parameters.length, 1, "balance(force) must declare its argument");
+        assert.equal(balDesc.parameters[0].name, "force");
       },
     },
   };
   await api.apply(ctx);
-  ctx.slots._fn();
-  assert.equal(registered.id, "decision-studio");
+  for (const fn of ctx.slots._fns) fn();
+  // Two registrations, two different seats: the tab ring carries Decision
+  // Mind ONLY (the standalone 余额 tab lasted one session), and account
+  // status lives in the session header's utilities seat as app chrome.
+  assert.deepEqual(ctx.slots._seats, ["conversation.view", "conversation.session.header.utilities"],
+    "tab ring for decisions, utilities seat for account chrome — nothing else");
+  assert.equal(ctx.slots._regs.length, 2, "tab + header utility, nothing else");
+  const registered = ctx.slots._regs.find((r) => r.definition.id === "decision-studio").definition;
+  const chipReg = ctx.slots._regs.find((r) => r.definition.id === "provider-balance");
+  assert.ok(chipReg, "the balance chip is registered");
   assert.equal(registered.order, 30);
   assert.equal(registered.label(), "Decision Mind");
+  assert.equal(chipReg.definition.name, "conversation.session.header.utilities",
+    "the chip must ride the utilities seat, never the tab ring");
+  assert.equal(chipReg.definition.order, 90);
   // Official registration store: UI state survives the ring's unmount/remount.
   assert.ok(registered.store, "registration must declare a per-session store");
   assert.deepEqual(registered.store.spec.init(), { filter: "all", open: null, visibleDateCount: 3, foldedDates: [], scrollTop: 0 });
 
   const injected = registered.inject("s1");
   // The inject face is the view's only live-data channel: a snapshot reader
-  // plus a fetch that reports whether the host's answer actually changed.
+  // plus a fetch that reports whether the host answered actually changed.
   assert.equal(typeof injected.cachedTraces, "function");
   assert.equal(typeof injected.fetchTraces, "function");
+  assert.equal(injected.cachedBalance === undefined && injected.cachedBalances === undefined, true,
+    "Decision Mind carries no balance channel — trading semantics only");
   assert.equal(injected.cachedTraces(), null, "a fresh registration has no snapshot yet");
   const first = await injected.fetchTraces();
   assert.deepEqual(first.snapshot.trades, []);
@@ -301,7 +367,18 @@ test("client: registers the Decision Mind tab and mounts the remote face", async
   assert.ok(injected.cachedTraces(), "the fetched snapshot is cached in the apply closure");
   const second = await injected.fetchTraces();
   assert.equal(second.changed, false, "the same workspace signature must not re-render");
-  assert.equal(typeof component, "function");
+
+  // The chip's inject face owns the balance channel with its own cache.
+  const balInjected = chipReg.definition.inject("s1");
+  assert.equal(typeof balInjected.cachedBalances, "function");
+  assert.equal(balInjected.cachedBalances(), null, "a fresh registration has no balances answer yet");
+  const bal = await balInjected.fetchBalances(false);
+  assert.deepEqual(bal.providers.map((r) => r.provider), ["deepseek", "minimax", "claude"],
+    "stable display order across the three providers");
+  assert.equal(bal.providers[0].result.snapshot.totalBalance, "110.00");
+  assert.ok(balInjected.cachedBalances(), "the fetched answer is cached in the apply closure");
+  // The chip's pinned-provider choice is registration-store state.
+  assert.deepEqual(chipReg.definition.store.spec.init(), { selected: null });
 });
 
 test("client: _displayEntry projects a trace with its decision and T+1", async () => {
@@ -343,8 +420,6 @@ test("client: renders the single decision-trace view from the mounted remote", a
     throw new Error(`unexpected require: ${s}`);
   });
 
-  let registered = null;
-  let component = null;
   const remoteFace = {
     traces: async () => ({ ok: true, value: { workspaceKey: "ws1", signature: "sig1", trades: [
       { ticker: "SPCH", market: "US", currency: "USD", date: "2026-08-15", action: "buy",
@@ -375,14 +450,16 @@ test("client: renders the single decision-trace view from the mounted remote", a
     effect() {},
     get() { return remoteFace; },
     slots: {
-      inject(name, fn) { this._fn = fn; },
-      register(definition, Component) { registered = definition; component = Component; },
+      inject(name, fn) { (this._fns ??= []).push(fn); },
+      register(definition, Component) { this._regs ??= []; this._regs.push({ definition, Component }); },
     },
     remote: { $mount: async () => {} },
   };
   await api.apply(ctx);
-  ctx.slots._fn();
-  const injected = registered.inject("s1");
+  for (const fn of ctx.slots._fns) fn();
+  const __ds = ctx.slots._regs.find((r) => r.definition.id === "decision-studio");
+  const component = __ds.Component;
+  const injected = __ds.definition.inject("s1");
 
   const store = makeStoreStub();
   const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -503,6 +580,7 @@ test("client: renders the single decision-trace view from the mounted remote", a
   // so it shows the position's figure, marked as the position's.
   assert.match(joined2, /该持仓当前浮动/);
   assert.doesNotMatch(joined2, /盈亏\s*[-+\d]/, "a bare 盈亏 label may not carry either figure");
+  disposeReactEffects();
 });
 
 test("T+1 reading: one host-side dead zone drives chip, node and verdict (#665/#713)", async () => {
@@ -580,8 +658,6 @@ test("client: trace list batches older days behind 'show earlier' and folds by d
     mk("EEE", "2026-08-05"),
   ];
 
-  let registered = null;
-  let component = null;
   const remoteFace = {
     traces: async () => ({ ok: true, value: { workspaceKey: "ws1", signature: "sig1", trades, rate: null } }),
     ledger: async () => ({ ok: true, value: { entries: [] } }),
@@ -591,12 +667,14 @@ test("client: trace list batches older days behind 'show earlier' and folds by d
   const ctx = {
     effect() {},
     get() { return remoteFace; },
-    slots: { inject(n, fn) { this._fn = fn; }, register(definition, Component) { registered = definition; component = Component; } },
+    slots: { inject(n, fn) { (this._fns ??= []).push(fn); }, register(definition, Component) { (this._regs ??= []).push({ definition, Component }); } },
     remote: { $mount: async () => {} },
   };
   await api.apply(ctx);
-  ctx.slots._fn();
-  const injected = registered.inject("s1");
+  for (const fn of ctx.slots._fns) fn();
+  const __ds = ctx.slots._regs.find((r) => r.definition.id === "decision-studio");
+  const component = __ds.Component;
+  const injected = __ds.definition.inject("s1");
 
   const store = makeStoreStub();
   const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -674,6 +752,7 @@ test("client: trace list batches older days behind 'show earlier' and folds by d
   await tick();
   tree = render();
   assert.match(collectText(), /AAA/, "unfolding restores the cell");
+  disposeReactEffects();
 });
 
 test("client: the bundle loads with no DOM and owns no module-level state (#729)", async () => {
@@ -694,15 +773,19 @@ test("client: the bundle loads with no DOM and owns no module-level state (#729)
 
   const ctx = {
     effect() {}, get() { return { traces: async () => ({ ok: true, value: { trades: [] } }) }; },
-    slots: { inject(n, fn) { this._fn = fn; }, register() {} },
+    slots: { inject(n, fn) { (this._fns ??= []).push(fn); }, register() {} },
     remote: { $mount: async () => {} },
   };
   await api.apply(ctx);
-  ctx.slots._fn();
-  assert.equal(counter.calls, 1, "apply() creates exactly one store handle");
+  for (const fn of ctx.slots._fns) fn();
+  assert.equal(counter.calls, 2, "apply() creates exactly two store handles (Decision Mind + chip selection)");
   const one = api.createDecisionMindStore();
   const two = api.createDecisionMindStore();
   assert.notEqual(one, two, "each factory call must yield its own handle, never a shared singleton");
+  const chipA = api.createBalanceStore();
+  const chipB = api.createBalanceStore();
+  assert.notEqual(chipA, chipB, "the chip store is also per-call, never a module singleton");
+  assert.deepEqual(chipA.spec.init(), { selected: null });
 });
 
 test("client: stylesheet is loader-owned and keeps the dark-theme and tone contract (#704/#685/#729)", async () => {
@@ -735,6 +818,20 @@ test("client: stylesheet is loader-owned and keeps the dark-theme and tone contr
   assert.match(css, /_detail\{[^}]*grid-template-rows:0fr/, "folded detail must default to 0fr");
   assert.match(css, hashed("stats"), "header stats block required");
   assert.match(css, hashed("filters"), "filter row block required");
+  // The balance capsule is part of the same sheet contract: its classes must
+  // exist (a cx() token with no rule renders verbatim, unhashed) and the low
+  // state's red dot must be selectable through the stable data attribute.
+  assert.match(css, hashed("bchip"), "header balance chip block required");
+  assert.match(css, hashed("bchip-dot"), "per-provider chip dot required");
+  assert.match(css, hashed("bchip-sub"), "weekly sub-reading class required");
+  assert.match(css, hashed("bp"), "provider panel block required");
+  assert.match(css, hashed("bp-row"), "panel per-provider row required");
+  assert.match(css, hashed("bal-rf"), "ghost refresh button required");
+  assert.match(css, hashed("bp-win-bar"), "per-window progress bar required");
+  // lightningcss minifies the attribute selector's quotes away; the
+  // contract is the data attribute itself, not its quoting.
+  assert.match(css, /_bchip-v\[data-balance-state=low\]/, "chip low value selector required");
+  assert.match(css, /_bp\[data-open=false\]/, "closed-panel state selector required");
   assert.match(css, hashed("skel"), "cold-start skeleton block required");
   // The three host-layout contracts this tab lives inside. Each of them was a
   // visible defect before 2026-08-22, and none is observable from the rendered
@@ -973,5 +1070,524 @@ test("freshness: trace cache is signature-keyed and µs-hit", async () => {
   assert.match(key, /^[0-9a-f]{12}$/);
   assert.notEqual(key, freshness.workspaceKeyOf("/tmp/ws-b"));
 });
+
+test("balance: CNY picking, tolerant parsing and the service's polite-cadence states", async () => {
+  const balance = await import(pathToFileURL(path.join(PLUGIN, "lib", "balance.js")).href);
+  const { createBalanceService, parseBalancePayload, pickCnyBalanceInfo } = balance;
+
+  // Entry picking: CNY preferred case-insensitively; the first entry is the
+  // fallback; an empty payload reads as absent, never as a throw.
+  const infos = [
+    { currency: "USD", total_balance: "5.00" },
+    { currency: "cny", total_balance: "110.00" },
+  ];
+  assert.equal(pickCnyBalanceInfo(infos).currency, "cny");
+  assert.equal(pickCnyBalanceInfo([{ currency: "USD" }]).currency, "USD");
+  assert.equal(pickCnyBalanceInfo(undefined), undefined);
+  assert.equal(pickCnyBalanceInfo([]), undefined);
+
+  // Parsing is tolerant: a shape drift degrades to '' / false instead of
+  // throwing, so the box reads empty rather than crashing the tab.
+  const parsed = parseBalancePayload({
+    is_available: true,
+    balance_infos: [{ currency: "CNY", total_balance: "110.00", granted_balance: "10.00", topped_up_balance: "100.00" }],
+  }, "2026-08-23T10:00:00.000Z");
+  assert.equal(parsed.totalBalance, "110.00");
+  assert.equal(parsed.grantedBalance, "10.00");
+  assert.equal(parsed.isAvailable, true);
+  const degraded = parseBalancePayload({ nope: true }, "2026-08-23T10:00:00.000Z");
+  assert.equal(degraded.totalBalance, "");
+  assert.equal(degraded.isAvailable, false);
+
+  // Service: key from the credentials seam, TTL cache, forced refresh,
+  // in-flight join, stale retention and the host-side low reading.
+  let upstreamCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    upstreamCalls += 1;
+    assert.match(String(url), /\/user\/balance$/);
+    assert.equal(init.headers.authorization, "Bearer sk-test");
+    return new Response(JSON.stringify({
+      is_available: true,
+      balance_infos: [{ currency: "CNY", total_balance: "9.00", granted_balance: "0.00", topped_up_balance: "9.00" }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  };
+  try {
+    const service = createBalanceService({ credentials: { resolve: async () => ({ value: "sk-test" }) } }, { threshold: 10, refreshMs: 60000 });
+
+    const fresh = await service.get(false);
+    assert.equal(fresh.status, "fresh");
+    assert.equal(fresh.snapshot.totalBalance, "9.00");
+    assert.equal(fresh.low, true, "9 ≤ 10 must read low, decided host-side");
+    assert.equal(fresh.threshold, 10);
+
+    const cached = await service.get(false);
+    assert.equal(cached.status, "cached");
+    assert.equal(upstreamCalls, 1, "the TTL window serves from cache");
+
+    const forced = await service.get(true);
+    assert.equal(forced.status, "fresh");
+    assert.equal(upstreamCalls, 2, "force bypasses the TTL");
+
+    // Two concurrent callers join one upstream request.
+    const [a, b] = await Promise.all([service.get(true), service.get(true)]);
+    assert.equal(a.snapshot.totalBalance, "9.00");
+    assert.equal(b.snapshot.totalBalance, "9.00");
+    assert.equal(upstreamCalls, 3, "a racing poll joins the in-flight run");
+
+    // A failed refresh keeps the last good snapshot and reports stale —
+    // a transient 429 cannot erase a real number.
+    globalThis.fetch = async () => { throw new Error("down"); };
+    const stale = await service.get(true);
+    assert.equal(stale.status, "stale");
+    assert.equal(stale.snapshot.totalBalance, "9.00");
+    assert.match(stale.message, /down/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  // No key anywhere → in-band no-key, never a throw.
+  const noKeyService = createBalanceService({ credentials: { resolve: async () => undefined } });
+  const noKey = await noKeyService.get(false);
+  assert.equal(noKey.status, "no-key");
+  assert.equal(noKey.status, "no-key");
+  assert.equal(noKey.configured, false);
+  assert.equal(noKey.snapshot, null);
+  assert.match(noKey.message, /未配置/);
+
+  // --- MiniMax: Token Plan quota windows, percent-based, HTTP-200 failures ---
+  const { createMinimaxService, parseMinimaxRemains, windowRemainingPercent } = balance;
+
+  // Percent field wins; counts derive it; unreadable stays null (never guessed).
+  assert.equal(windowRemainingPercent({ current_interval_remaining_percent: 88.4 }), 88.4);
+  assert.equal(windowRemainingPercent({ current_interval_total_count: 5000000, current_interval_usage_count: 1250000 }), 75);
+  assert.equal(windowRemainingPercent({ current_interval_total_count: 0, current_interval_usage_count: 0 }), null);
+  assert.equal(windowRemainingPercent({}), null);
+
+  // The general bucket is the text/coding plan every account carries.
+  const mmParsed = parseMinimaxRemains({
+    base_resp: { status_code: 0, status_msg: "success" },
+    model_remains: [
+      { model: "video", current_interval_remaining_percent: 40 },
+      { model: "general", current_interval_remaining_percent: 76.4, current_weekly_remaining_percent: 90, end_time: Date.now() + 3600_000 },
+    ],
+  }, AS_OF);
+  assert.equal(mmParsed.unit, "pct");
+  assert.equal(mmParsed.totalBalance, "76", "percent is rounded for display only");
+  assert.deepEqual(mmParsed.windows.map((w) => [w.label, w.percent]), [["5h", 76], ["周", 90]]);
+  assert.match(mmParsed.windows[0].resetAt, /^\d{2}:\d{2}$/);
+  assert.throws(() => parseMinimaxRemains({ base_resp: { status_code: 0 } }, AS_OF), /model_remains/);
+  // Epoch seconds AND milliseconds both read; garbage does not crash.
+  const withReset = parseMinimaxRemains({
+    base_resp: { status_code: 0 },
+    model_remains: [{ model: "general", current_interval_remaining_percent: 50, end_time: 1785196800000 }],
+  }, AS_OF);
+  assert.match(withReset.windows[0].resetAt, /^\d{2}:\d{2}$/);
+
+  let minimaxCalls = 0;
+  globalThis.fetch = async (url, init) => {
+    minimaxCalls += 1;
+    assert.match(String(url), /\/v1\/token_plan\/remains$/);
+    assert.equal(init.headers.authorization, "Bearer mm-test");
+    // A HTTP-200 body can still be a business failure — the envelope decides.
+    return new Response(JSON.stringify({
+      base_resp: { status_code: 1004, status_msg: "login fail" },
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  };
+  try {
+    const mmService = createMinimaxService({ credentials: { resolve: async () => ({ value: "mm-test" }) } });
+    const authFail = await mmService.get(true);
+    assert.equal(authFail.status, "failed");
+    assert.match(authFail.message, /无效或已过期/);
+    assert.match(authFail.message, /login fail/, "the upstream reason rides along");
+
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      base_resp: { status_code: 0, status_msg: "success" },
+      model_remains: [{ model: "general", current_interval_remaining_percent: 12 }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+    const lowQuota = await createMinimaxService({ credentials: { resolve: async () => ({ value: "mm-test" }) } }).get(true);
+    assert.equal(lowQuota.status, "fresh");
+    assert.equal(lowQuota.low, true, "12% remaining must read low against the 20% default");
+    assert.equal(lowQuota.snapshot.unit, "pct");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  // MiniMax with no key configured ANYWHERE (seam/env/openclaw config) is an
+  // honest panel row, not an error. The openclaw fallback must be pointed at
+  // a missing file — the real one on this host carries the production key.
+  const mmMissing = { credentials: { resolve: async () => undefined }, env: {} };
+  const savedEnv = process.env.MINIMAX_API_KEY;
+  delete process.env.MINIMAX_API_KEY;
+  try {
+    const mmNoKey = await createMinimaxService(
+      { credentials: { resolve: async () => undefined } },
+      { openclawConfigPath: "/nonexistent/openclaw.json" },
+    ).get(false);
+    assert.equal(mmNoKey.status, "no-key");
+    assert.match(mmNoKey.message, /未配置/);
+  } finally {
+    if (savedEnv !== undefined) process.env.MINIMAX_API_KEY = savedEnv;
+  }
+
+  // The openclaw-config fallback: when seam and env are both empty, the
+  // gateway's own models.providers.<name>.apiKey answers.
+  const osMod = await import("node:os");
+  const fsMod = await import("node:fs");
+  const pathMod = await import("node:path");
+  const tmpCfg = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pb-"));
+  const cfgPath = pathMod.join(tmpCfg, "openclaw.json");
+  fsMod.writeFileSync(cfgPath, JSON.stringify({ models: { providers: { minimax: { apiKey: "mm-from-openclaw" } } } }));
+  let sawAuth = "";
+  globalThis.fetch = async (url, init) => {
+    sawAuth = init.headers.authorization;
+    return new Response(JSON.stringify({
+      base_resp: { status_code: 0, status_msg: "success" },
+      model_remains: [{ model: "general", current_interval_remaining_percent: 50 }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  };
+  try {
+    const mmFallback = await createMinimaxService(
+      { credentials: { resolve: async () => undefined } },
+      { openclawConfigPath: cfgPath },
+    ).get(true);
+    assert.equal(sawAuth, "Bearer mm-from-openclaw", "key resolved from the openclaw gateway config");
+    assert.equal(mmFallback.status, "fresh");
+  } finally {
+    globalThis.fetch = originalFetch;
+    fsMod.rmSync(tmpCfg, { recursive: true, force: true });
+  }
+});
+
+test("balance: claude subscription windows via the OAuth usage endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+  const balance = await import(pathToFileURL(path.join(PLUGIN, "lib", "balance.js")).href);
+  const { createClaudeService, parseClaudeUsage, readClaudeCredentials } = balance;
+  const osMod = await import("node:os");
+  const fsMod = await import("node:fs");
+  const pathMod = await import("node:path");
+
+  // Credentials file parsing: tolerant of absence.
+  assert.equal(readClaudeCredentials("/nonexistent/creds.json"), undefined);
+
+  const tmp = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pc-"));
+  const credsPath = pathMod.join(tmp, ".credentials.json");
+  const future = Date.now() + 3600_000;
+  const past = Date.now() - 1000;
+  fsMod.writeFileSync(credsPath, JSON.stringify({
+    claudeAiOauth: { accessToken: "sk-ant-oat01-test", refreshToken: "ort01", expiresAt: future, subscriptionType: "max" },
+  }));
+
+  // utilization is consumption; our reading is REMAINING percent.
+  const usageBody = {
+    five_hour: { utilization: 36, resets_at: "2026-08-24T02:00:00Z" },
+    seven_day: { utilization: 69 },
+  };
+  let sawHeaders = {};
+  globalThis.fetch = async (url, init) => {
+    sawHeaders = init.headers;
+    assert.match(String(url), /api\.anthropic\.com\/api\/oauth\/usage$/);
+    return new Response(JSON.stringify(usageBody), { status: 200, headers: { "content-type": "application/json" } });
+  };
+  try {
+    const svc = createClaudeService(
+      { credentials: { resolve: async () => undefined } },
+      { credentialsPath: credsPath, usageUrl: "https://api.anthropic.com/api/oauth/usage" },
+    );
+    const fresh = await svc.get(true);
+    assert.equal(fresh.status, "fresh");
+    assert.equal(fresh.snapshot.unit, "pct");
+    assert.equal(fresh.snapshot.totalBalance, "64", "100 - 36 utilized = 64 remaining");
+    assert.deepEqual(fresh.snapshot.windows.map((w) => [w.label, w.percent]), [["会话", 64], ["本周", 31]]);
+    assert.match(fresh.snapshot.windows[0].resetAt, /^\d{2}:\d{2}$/);
+    assert.match(fresh.snapshot.note, /会话窗口剩余 64%/);
+    assert.match(fresh.snapshot.note, /本周剩余 31%/, "note mirrors the weekly window");
+    assert.equal(sawHeaders["anthropic-beta"], "oauth-2025-04-20", "the beta header is required");
+    assert.equal(sawHeaders.authorization, "Bearer sk-ant-oat01-test");
+
+    // Expired login → honest failed row telling kcn to re-run claude once.
+    fsMod.writeFileSync(credsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: "stale", refreshToken: "r", expiresAt: past },
+    }));
+    const expired = await createClaudeService(
+      { credentials: { resolve: async () => undefined } },
+      { credentialsPath: credsPath, usageUrl: "https://api.anthropic.com/api/oauth/usage" },
+    ).get(true);
+    assert.equal(expired.status, "failed");
+    assert.match(expired.message, /过期/);
+
+    // Missing file entirely → in-band no-key.
+    const none = await createClaudeService(
+      { credentials: { resolve: async () => undefined } },
+      { credentialsPath: "/nonexistent/creds.json", usageUrl: "https://api.anthropic.com/api/oauth/usage" },
+    ).get(false);
+    assert.equal(none.status, "no-key");
+  } finally {
+    globalThis.fetch = originalFetch;
+    fsMod.rmSync(tmp, { recursive: true, force: true });
+  }
+
+  // Both windows absent → honest failure, never a fabricated number.
+  assert.throws(() => parseClaudeUsage({}, AS_OF), /用量窗口/);
+});
+
+test("typert: the frozen artifacts carry the balance wire on both faces", () => {
+  // The clawock checkout cannot regenerate the Typert face (see build.mjs):
+  // these committed files ARE the wire. A method missing here is a method
+  // the client cannot call — the same class of failure as #738's alignment.
+  for (const rel of ["lib/typert.host.js", "lib/typert.remote-client.js"]) {
+    const src = fs.readFileSync(path.join(PLUGIN, rel), "utf8");
+    assert.match(src, /id: 'clawock-dsh#clawockStudio\/balance'/, rel);
+    assert.match(src, /clawock_dsh_clawockStudio_balance_parameter_0\$schema = z\.boolean\(\)/, rel + " force codec");
+    assert.match(src, /typeSymbol: 'clawock-dsh\/types#BalancesResult'/, rel + " result type (multi-provider envelope)");
+    assert.match(src, /'providers': z\.array\(z\.object\(/, rel + " per-provider rows on the wire");
+    assert.match(src, /'unit': z\.string\(\)/, rel + " snapshot unit discriminator");
+    assert.match(src, /'refreshMs': z\.number\(\)/, rel + " result schema field");
+  }
+});
+
+test("client: the header chip headlines one provider and the panel pins the rest", async () => {
+  const loaded = await loadClient();
+  const reactStub = makeReactStub();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "react") return reactStub;
+    throw new Error(`unexpected require: ${s}`);
+  });
+
+  // DeepSeek low + MiniMax healthy: the pill headlines the FIRST row until a
+  // panel click pins another one.
+  const envelope = { providers: [DS_ROW_OK, MM_ROW_OK, CL_ROW_OK], refreshMs: 60000 };
+  const remoteFace = { balance: async () => ({ ok: true, value: envelope }) };
+  const ctx = {
+    effect() {},
+    get() { return remoteFace; },
+    slots: { inject(n, fn) { (this._fns ??= []).push(fn); }, register(definition, Component) { (this._regs ??= []).push({ definition, Component }); } },
+    remote: { $mount: async () => {} },
+  };
+  await api.apply(ctx);
+  for (const fn of ctx.slots._fns) fn();
+  const __chip = ctx.slots._regs.find((r) => r.definition.id === "provider-balance");
+  const Chip = __chip.Component;
+  const injected = __chip.definition.inject("s1");
+  const store = makeBalanceStoreStub();
+
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  const render = () => { reactStub._resetCursor(); return Chip({ sessionId: "s1", useStore: store.useStore, actions: store.actions, ...injected }); };
+
+  // Collect chip item / panel rows separately via data-pb-role.
+  const collect = (tree) => {
+    const found = { chip: [], panel: [], openAttr: null, trigger: null, refresh: null, texts: [] };
+    (function walk(node) {
+      if (node == null) return;
+      if (Array.isArray(node)) { node.forEach(walk); return; }
+      if (typeof node === "string") { found.texts.push(node); return; }
+      const p = node.props || {};
+      if (p["data-pb-role"] === "chip") found.chip.push(p);
+      if (p["data-pb-role"] === "panel") found.panel.push(node);
+      if (p["data-open"] !== undefined) found.openAttr = p["data-open"];
+      if (p["aria-haspopup"] === "dialog") found.trigger = node;
+      if (p["data-refresh"] === "true") found.refresh = node;
+      (node.children || []).forEach(walk);
+    })(tree);
+    return found;
+  };
+
+  let tree = render();
+  await tick(); await tick(); await tick();
+  tree = render();
+  let f = collect(tree);
+  // Pill: exactly ONE headline reading — deepseek, the stable first row.
+  assert.equal(f.chip.length, 1, "the pill headlines exactly one provider");
+  assert.equal(f.chip[0]["data-pb-provider"], "deepseek", "default headline is the first configured row");
+  assert.equal(f.chip[0]["data-balance-state"], "ok");
+  assert.ok(f.texts.includes("¥110"), "the headlined value renders");
+  // Panel: mounted closed, every provider listed with its own tone.
+  assert.equal(f.openAttr, "false", "the panel renders closed but mounted");
+  assert.deepEqual(f.panel.map((n) => n.props["data-pb-provider"]), ["deepseek", "minimax", "claude"]);
+  assert.ok(f.refresh, "the manual refresh lives in the panel header");
+
+  // Open → click the minimax row → the pill re-headlines minimax (persisted).
+  f.trigger.props.onClick();
+  tree = render();
+  f = collect(tree);
+  assert.equal(f.openAttr, "true", "the panel opens from the trigger");
+  const mmRow = f.panel.find((n) => n.props["data-pb-provider"] === "minimax");
+  assert.ok(mmRow, "panel rows are buttons");
+  mmRow.props.onClick();
+  tree = render();
+  f = collect(tree);
+  assert.equal(f.chip[0]["data-pb-provider"], "minimax", "clicking a panel row pins it as the headline");
+  assert.equal(f.chip[0]["data-balance-state"], "ok");
+  assert.equal(store._get().selected, "minimax", "the pin survives in registration-store state");
+  assert.ok(f.texts.includes("76%"), "the pinned quota reading renders");
+  assert.ok(
+    f.texts.some((t) => t.includes("周 90%")),
+    "the weekly limit rides along on the pill as a muted sub-reading",
+  );
+
+  // Manual refresh resolves through the same remote face without throwing.
+  f.refresh.props.onClick();
+  await tick(); await tick();
+  assert.ok(true, "manual refresh resolves without throwing");
+  disposeReactEffects();
+});
+
+test("client: the panel says each provider's story once, abnormal rows loudest", async () => {
+  const loaded = await loadClient();
+  const reactStub = makeReactStub();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "react") return reactStub;
+    throw new Error(`unexpected require: ${s}`);
+  });
+
+  const envelope = {
+    providers: [
+      { provider: "deepseek", label: "DeepSeek", result: { configured: false, snapshot: null, status: "no-key", low: false, message: "未配置 DeepSeek API Key(设置 → 模型 → DeepSeek)", threshold: 20, refreshMs: 60000 } },
+      MM_ROW_OK,
+    ],
+    refreshMs: 60000,
+  };
+  const ctx = {
+    effect() {},
+    get() { return { balance: async () => ({ ok: true, value: envelope }) }; },
+    slots: { inject(n, fn) { (this._fns ??= []).push(fn); }, register(definition, Component) { (this._regs ??= []).push({ definition, Component }); } },
+    remote: { $mount: async () => {} },
+  };
+  await api.apply(ctx);
+  for (const fn of ctx.slots._fns) fn();
+  const __pb = ctx.slots._regs.find((r) => r.definition.id === "provider-balance");
+  const Chip = __pb.Component;
+  const injected = __pb.definition.inject("s1");
+  const store = makeBalanceStoreStub();
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  const render = () => { reactStub._resetCursor(); return Chip({ sessionId: "s1", useStore: store.useStore, actions: store.actions, ...injected }); };
+
+  let tree = render();
+  await tick(); await tick(); await tick();
+  // Open the panel.
+  (function findTrigger(node) {
+    if (node == null || Array.isArray(node)) return null;
+    if (node.props && node.props["aria-haspopup"] === "dialog") { node.props.onClick(); return node; }
+    for (const child of node.children || []) { const hit = findTrigger(child); if (hit) return hit; }
+    return null;
+  })(tree);
+  tree = render();
+
+  const texts = [];
+  (function walk(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (typeof node === "string") { texts.push(node); return; }
+    (node.children || []).forEach(walk);
+  })(tree);
+  assert.ok(texts.includes("API 余额"), "panel carries its title");
+  assert.ok(texts.some((t) => t.includes("未配置")), "a keyless provider is an honest row, not hidden");
+  assert.ok(texts.includes("MiniMax"), "provider labels render verbatim");
+  assert.ok(texts.includes("5h"), "per-window labels render as a scannable column");
+  assert.ok(texts.includes("周"), "both windows surface their own line");
+  const fills = [];
+  (function walkFills(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walkFills); return; }
+    if (typeof node === "object" && node.props !== null && typeof node.props === "object" &&
+        typeof node.props.className === "string" && node.props.className.includes("bp-win-fill")) {
+      fills.push(node.props);
+    }
+    (node.children || []).forEach(walkFills);
+  })(tree);
+  assert.equal(fills.length, 2, "each quota window renders one remaining-bar");
+  assert.deepEqual(fills.map((p) => p.style.width), ["76%", "90%"], "bar length mirrors the window reading");
+  assert.deepEqual(
+    fills.map((p) => p["data-balance-state"]),
+    ["ok", "ok"],
+    "healthy windows stay ink-toned",
+  );
+  disposeReactEffects();
+
+  // Below the low watermark the bar itself flips to the warning tone — the
+  // same discipline as the dots, applied per window rather than per provider.
+  const LOW_MM = JSON.parse(JSON.stringify(MM_ROW_OK));
+  LOW_MM.result.snapshot.windows = [{ label: "5h", percent: 76, resetAt: "" }, { label: "周", percent: 12, resetAt: "" }];
+  const ctx2 = {
+    effect() {},
+    get() { return { balance: async () => ({ ok: true, value: { providers: [LOW_MM], refreshMs: 60000 } }) }; },
+    slots: { inject(n, fn) { (this._fns ??= []).push(fn); }, register(definition, Component) { (this._regs ??= []).push({ definition, Component }); } },
+    remote: { $mount: async () => {} },
+  };
+  await api.apply(ctx2);
+  for (const fn of ctx2.slots._fns) fn();
+  const __pb2 = ctx2.slots._regs.find((r) => r.definition.id === "provider-balance");
+  const store2 = makeBalanceStoreStub();
+  const render2 = () => { reactStub._resetCursor(); return __pb2.Component({ sessionId: "s2", useStore: store2.useStore, actions: store2.actions, ...__pb2.definition.inject("s2") }); };
+  let tree2 = render2();
+  await tick(); await tick(); await tick();
+  tree2 = render2();
+  const fills2 = [];
+  (function walkFills(node) {
+    if (node == null) return;
+    if (Array.isArray(node)) { node.forEach(walkFills); return; }
+    if (typeof node === "object" && node.props !== null && typeof node.props === "object" &&
+        typeof node.props.className === "string" && node.props.className.includes("bp-win-fill")) {
+      fills2.push(node.props);
+    }
+    (node.children || []).forEach(walkFills);
+  })(tree2);
+  assert.deepEqual(fills2.map((p) => p["data-balance-state"]), ["ok", "low"], "only the starved window goes warning-red");
+  disposeReactEffects();
+});
+
+test("client: _rowDisplay and _balanceNote project one provider's answer", async () => {
+  const loaded = await loadClient();
+  const api = loaded.factory((s) => {
+    if (s === "@deepseek-ai/dsh-client-runtime/client") return makeRuntimeStub();
+    if (s === "react") return makeReactStub();
+    throw new Error(`unexpected require: ${s}`);
+  });
+
+  const snap = (total, extra = {}) => ({ isAvailable: true, unit: "money", currency: "CNY", totalBalance: total, grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "", windows: [], ...extra });
+  const answer = (over = {}) => ({ configured: true, snapshot: snap("110.00"), status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000, ...over });
+  // Money rows keep the old shape; quota rows read as remaining percent and
+  // surface the second window (周限额) as a muted pill suffix.
+  assert.deepEqual(api._rowDisplay(null), { tone: "none", value: "—", sub: null, title: "余额加载中" });
+  const okRow = api._rowDisplay(answer());
+  assert.equal(okRow.tone, "ok");
+  assert.equal(okRow.sub, null, "money rows carry no window suffix");
+  assert.ok(!okRow.title.includes("更新于"), "the fetch timestamp must not repeat in the row");
+  assert.match(api._rowDisplay(answer({ snapshot: snap("7.50", { currency: "USD" }) })).value, /^\$7\.5/);
+  const pct = api._rowDisplay(answer({ snapshot: snap("76", { unit: "pct", currency: "" }) }));
+  assert.equal(pct.value, "76%", "quota reads as percent, never money");
+  assert.equal(pct.sub, null, "a single-window plan has no suffix");
+  const dual = api._rowDisplay(answer({
+    snapshot: snap("76", {
+      unit: "pct", currency: "",
+      windows: [{ label: "5h", percent: 76, resetAt: "21:00" }, { label: "周", percent: 90, resetAt: "" }],
+    }),
+  }));
+  assert.equal(dual.sub, "· 周 90%", "the weekly limit is the pill's second reading");
+  const primaryGone = api._rowDisplay(answer({
+    snapshot: snap("", {
+      unit: "pct", currency: "", isAvailable: true,
+      windows: [{ label: "会话", percent: null, resetAt: "" }, { label: "本周", percent: 31, resetAt: "" }],
+    }),
+  }));
+  assert.equal(primaryGone.value, "31%", "when the headline window is absent the readable one steps up");
+  assert.equal(api._rowDisplay(answer({ snapshot: snap("9.00", { isAvailable: false }) })).tone, "low");
+  // Healthy = silence. Every abnormal reading gets exactly one sentence.
+  assert.equal(api._balanceNote(null), null);
+  assert.equal(api._balanceNote(answer()), null);
+  assert.match(api._balanceNote(answer({ snapshot: snap("5.00"), low: true })), /低于阈值 ¥20/);
+  assert.match(api._balanceNote(answer({ status: "stale", message: "请求过于频繁" })), /刷新失败.*请求过于频繁/);
+  assert.match(api._balanceNote({ configured: false, snapshot: null, status: "no-key", low: false, message: "未配置 DeepSeek API Key", threshold: 20, refreshMs: 60000 }), /未配置/);
+  assert.match(api._balanceNote(answer({ snapshot: null, status: "failed", message: "网络请求失败" })), /网络请求失败/);
+  assert.match(api._balanceNote(answer({ snapshot: snap("9.00", { isAvailable: false }) })), /余额不足/);
+  assert.match(
+    api._balanceNote(answer({ snapshot: snap("12", { unit: "pct", currency: "", isAvailable: true }), low: true })),
+    /窗口余量不足 20%/,
+    "quota lows speak in percent",
+  );
+});
+
 
 

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -453,6 +453,11 @@ HOST_OWNED_SHELL = {
            "instead of vendoring a duplicate dependency; NOSTR_TOOLS_PATH "
            "overrides the path and a missing OpenClaw install falls through "
            "to a bare require() rather than silently using stale data"),
+    "examples/dsh/packages/clawock-dsh/lib/balance.js": (
+        2, "the balance chip's key-resolution chain ends at the gateway's own "
+           "provider config — the documented default IS the feature on this "
+           "host: credentials seam and env resolve first, and the "
+           "openclawConfigPath setting overrides the constant"),
 }
 
 def _shell_files():


### PR DESCRIPTION
接 #871 定稿的会话头部余额芯片,把「周限额」提到看得见的地方:

## 改了什么
- **胶囊头条双读数**:主窗口剩余之外,直接附第二窗口副读数(`· 周 90%`),MiniMax(5h+周)与 Claude(会话+本周)不用点开面板就能看到周限额;DeepSeek 单值行不变。副读数 aria-hidden,读屏走面板。
- **主窗口缺席兜底**:Claude 会话窗为 null 时由可读窗口顶上头条,不再渲染裸 `—`。
- **面板进度条**:每窗口一行 = 文字读数 + 3px 发丝进度条。静态渲染整帧替换,**无 width 动画**(审校红线);低水位(≤ 各自 lowPct)逐窗变红、stale 变黄,与圆点同一套 tone 纪律;`prefers-reduced-motion` 下去掉 fill transition。
- **毛玻璃的取舍**:不加第二层玻璃——玻璃里叠玻璃只会糊;进度条用半透明墨水轨道(color-mix on --text)让面板 blur 透出来,深浅主题自动跟随。
- 服务层/wire 沿用已定稿的三 provider 实现(typert 双脸字节迁移已含 windows 字段);README 删掉一段重复的旧配置块并补双读数/进度条说明。

## 验证
- `tests/decision_studio_plugin.spec.js` 22/22 绿(新增:副读数上胶囊、进度条长度镜像读数、低水位单窗翻红、_rowDisplay 投影形状)
- `tests/dsh_plugin_package_contract.mjs` 绿(standalone 安装闸)
- lib/ 由 `npm run build` 再生,CI 复现闸应零 diff
