### PR TITLE
feat(dsh): 余额芯片配额读数「剩余」→「已使用」

### DIFF
--- a/examples/dsh/packages/clawock-dsh/README.md
+++ b/examples/dsh/packages/clawock-dsh/README.md
@@ -111,20 +111,22 @@ action / run_id,判定和结算是 Python 算的,不是模型说的:
 高度)——胶囊头条显示**一个** provider 的读数(默认第一行;在面板里点任意一行
 即钉选为头条,选择存在注册 store 里,重挂不丢),带双窗口的 provider(MiniMax
 5h+周、Claude 会话+本周)在头条直接附**周限额副读数**,不用点开就能看到;
-点开小面板看全部 provider 明细(每窗口一行文字读数 + 发丝进度条,低水位变红)
-与手动刷新。它不是 Decision Mind 的一部分:账户状态是应用级 chrome,
-不是交易语义:
+点开小面板看全部 provider 明细(每窗口一行文字读数 + 发丝进度条,用到接近
+满格变红)与手动刷新。它不是 Decision Mind 的一部分:账户状态是应用级 chrome,
+不是交易语义。配额读数一律是**已使用 %**(kcn:「剩余」不直观;进度条填充=
+已使用量,越满越接近红线):
 
 | Provider | 口径 | 读数 |
 | :--- | :--- | :--- |
-| DeepSeek | 官方 `GET /user/balance`(凭据缝 → 环境变量) | 余额 ¥(CNY 行优先),面板见赠金/充值拆分 |
-| MiniMax | 官方 `GET /v1/token_plan/remains`(Token Plan 配额窗口) | 窗口剩余 %(`general` 桶);key 解析链=凭据缝 → env → **openclaw 网关配置**(`~/.openclaw/openclaw.json` 的 `models.providers.minimax.apiKey`) |
-| Claude | 订阅制额度:OAuth `GET /api/oauth/usage`(`anthropic-beta: oauth-2025-04-20`),token 读自 `~/.claude/.credentials.json` | 会话窗口剩余 %(utilization 取补)+ 本周剩余;面板附各窗口重置时间 |
+| DeepSeek | 官方 `GET /user/balance`(凭据缝 → 环境变量) | 余额 ¥(CNY 行优先,金额口径不变),面板见赠金/充值拆分 |
+| MiniMax | 官方 `GET /v1/token_plan/remains`(Token Plan 配额窗口) | 窗口已使用 %(上游报剩余则取补;`general` 桶);key 解析链=凭据缝 → env → **openclaw 网关配置**(`~/.openclaw/openclaw.json` 的 `models.providers.minimax.apiKey`) |
+| Claude | 订阅制额度:OAuth `GET /api/oauth/usage`(`anthropic-beta: oauth-2025-04-20`),token 读自 `~/.claude/.credentials.json` | 会话窗口已使用 %(utilization 本来就是用量,**直读不再取补**)+ 本周已使用;面板附各窗口重置时间 |
 
 - OpenCode Zen **无公开余额接口**(上游 issue 还开着),不做假装有数的行;
 - 某家未配置 = 面板里诚实的一行「未配置」,不隐藏也不报错;
-- 低额红点:DeepSeek ≤¥20、MiniMax 窗口余量 ≤20%、Claude 会话窗口 ≤20%
-  (各自可配);进度条按同一水位逐窗变红,不只标 provider 整体;
+- 低额红点:DeepSeek ≤¥20、MiniMax/Claude **已使用 ≥80%**(即剩余 ≤20%);
+  `*LowPct` 配置字段保持「剩余水位」原义不动,已有配置值无需改,只是展示
+  方向翻转了;进度条按同一水位逐窗变红,不只标 provider 整体;
 - 刷新失败保留最近一次快照并标注 stale(黄点);瞬时 429 不抹掉真数字;
 - Claude 的 OAuth token 归 Claude Code 所有,本插件**只读不刷新**——过期时
   面板显示「请在终端跑一次 claude 刷新登录」;

--- a/examples/dsh/packages/clawock-dsh/lib/balance.js
+++ b/examples/dsh/packages/clawock-dsh/lib/balance.js
@@ -64,16 +64,18 @@ function parseBalancePayload(body, asOf) {
 }
 const finiteNumber = (value) => typeof value === "number" && isFinite(value) ? value : null;
 /**
-* Remaining percent of one quota window: the explicit percent field when the
-* plan reports one, otherwise derived from total/used counts (MiniMax ships
-* both shapes across plan generations). null = unreadable, never guessed.
+* Used percent of one quota window — the chip's display direction (kcn:
+* 「已使用」比「剩余」直观). The explicit percent field reports REMAINING and
+* is complemented here; raw counts are already consumption and divide as-is
+* (MiniMax ships both shapes across plan generations). null = unreadable,
+* never guessed.
 */
-function windowRemainingPercent(entry) {
+function windowUsedPercent(entry) {
 	const direct = finiteNumber(entry.current_interval_remaining_percent);
-	if (direct !== null) return Math.min(100, Math.max(0, direct));
+	if (direct !== null) return Math.min(100, Math.max(0, 100 - direct));
 	const total = finiteNumber(entry.current_interval_total_count);
 	const used = finiteNumber(entry.current_interval_usage_count);
-	if (total !== null && total > 0 && used !== null && used >= 0) return Math.min(100, Math.max(0, (total - used) / total * 100));
+	if (total !== null && total > 0 && used !== null && used >= 0) return Math.min(100, Math.max(0, used / total * 100));
 	return null;
 }
 /**
@@ -106,34 +108,35 @@ function formatReset(epochOrIso) {
 /**
 * The successful Token Plan payload → snapshot. Percent-based by design:
 * plans report either percent fields or raw counts, and tokens are not money
-* — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+* — the chip reads "窗口额度用了多少"(已使用方向), never a fabricated ¥ figure.
 */
 function parseMinimaxRemains(body, asOf) {
 	const raw = typeof body === "object" && body !== null ? body : {};
 	const buckets = Array.isArray(raw.model_remains) ? raw.model_remains : [];
 	const entry = buckets.find((b) => b.model === "general") ?? buckets[0];
 	if (entry === void 0) throw new Error("MiniMax 响应里没有 model_remains 数据");
-	const pct = windowRemainingPercent(entry);
-	const weekly = finiteNumber(entry.current_weekly_remaining_percent);
+	const used = windowUsedPercent(entry);
+	const weeklyRemaining = finiteNumber(entry.current_weekly_remaining_percent);
+	const weeklyUsed = weeklyRemaining === null ? null : Math.min(100, Math.max(0, 100 - weeklyRemaining));
 	const windows = [];
-	if (pct !== null) windows.push({
+	if (used !== null) windows.push({
 		label: "5h",
-		percent: Math.round(pct),
+		percent: Math.round(used),
 		resetAt: formatReset(entry.end_time)
 	});
-	if (weekly !== null) windows.push({
+	if (weeklyUsed !== null) windows.push({
 		label: "周",
-		percent: Math.round(weekly),
+		percent: Math.round(weeklyUsed),
 		resetAt: formatReset(entry.weekly_end_time)
 	});
 	const notes = [];
-	if (pct !== null) notes.push("5h 窗口剩余 " + Math.round(pct) + "%");
-	if (weekly !== null) notes.push("周窗口剩余 " + Math.round(weekly) + "%");
+	if (used !== null) notes.push("5h 窗口已使用 " + Math.round(used) + "%");
+	if (weeklyUsed !== null) notes.push("周窗口已使用 " + Math.round(weeklyUsed) + "%");
 	return {
-		isAvailable: pct !== null && pct > 0,
+		isAvailable: used !== null && used < 100,
 		unit: "pct",
 		currency: "",
-		totalBalance: pct === null ? "" : String(Math.round(pct)),
+		totalBalance: used === null ? "" : String(Math.round(used)),
 		grantedBalance: "",
 		toppedUpBalance: "",
 		asOf,
@@ -247,6 +250,18 @@ const numOrInfinity = (value) => {
 	const parsed = Number.parseFloat(value);
 	return isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
 };
+/**
+* The snapshot's used-percent reading, or null when it isn't a percent unit
+* or carries no parseable number. The null guard is the point: under the old
+* REMAINING direction an unreadable value read as +∞ and safely missed the
+* watermark; under USED that same +∞ would read as "everything consumed" and
+* light every red dot. An absent reading must stay silent.
+*/
+function usedPercentOf(snapshot) {
+	if (snapshot.unit !== "pct") return null;
+	const parsed = Number.parseFloat(snapshot.totalBalance);
+	return isFinite(parsed) ? parsed : null;
+}
 /** DeepSeek row: official money balance, CNY entry preferred. */
 function createBalanceService(deps, config = {}) {
 	const baseUrl = config.baseUrl ?? "https://api.deepseek.com";
@@ -280,7 +295,7 @@ function createBalanceService(deps, config = {}) {
 			}
 			return parseBalancePayload(body, (/* @__PURE__ */ new Date()).toISOString());
 		},
-		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= threshold : snapshot.isAvailable && numOrInfinity(snapshot.totalBalance) <= threshold
+		isLow: (snapshot) => snapshot.unit === "money" && snapshot.isAvailable && numOrInfinity(snapshot.totalBalance) <= threshold
 	});
 }
 /** MiniMax row: official Token Plan quota windows, percent-based. */
@@ -322,7 +337,10 @@ function createMinimaxService(deps, config = {}) {
 			}
 			return parseMinimaxRemains(body, (/* @__PURE__ */ new Date()).toISOString());
 		},
-		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= lowPct : false
+		isLow: (snapshot) => {
+			const used = usedPercentOf(snapshot);
+			return used !== null && used >= 100 - lowPct;
+		}
 	});
 }
 /**
@@ -336,37 +354,38 @@ function readClaudeCredentials(path) {
 	return { creds };
 }
 /**
-* Successful usage payload → snapshot, in REMAINING percent (utilization is
-* consumption). five_hour gates active sessions so it is the headline; any
-* bucket may be absent/null depending on plan.
+* Successful usage payload → snapshot, in USED percent — utilization already
+* IS consumption, so it renders verbatim with no complementing (kcn:
+* 「已使用」比「剩余」直观). five_hour gates active sessions so it is the
+* headline; any bucket may be absent/null depending on plan.
 */
 function parseClaudeUsage(body, asOf) {
 	const raw = typeof body === "object" && body !== null ? body : {};
 	const u5 = finiteNumber(raw.five_hour?.utilization);
 	const u7 = finiteNumber(raw.seven_day?.utilization);
 	if (u5 === null && u7 === null) throw new Error("Claude 响应里没有可用的用量窗口");
-	const remaining = u5 === null ? null : Math.round(Math.min(100, Math.max(0, 100 - u5)));
+	const used = u5 === null ? null : Math.round(Math.min(100, Math.max(0, u5)));
 	const windows = [];
 	if (u5 !== null) windows.push({
 		label: "会话",
-		percent: remaining,
+		percent: used,
 		resetAt: formatReset(raw.five_hour?.resets_at ?? null)
 	});
 	if (u7 !== null) windows.push({
 		label: "本周",
-		percent: Math.round(Math.min(100, Math.max(0, 100 - u7))),
+		percent: Math.round(Math.min(100, Math.max(0, u7))),
 		resetAt: formatReset(raw.seven_day?.resets_at ?? null)
 	});
 	const notes = [];
-	if (u5 !== null) notes.push("会话窗口剩余 " + remaining + "%");
-	if (u7 !== null) notes.push("本周剩余 " + Math.round(100 - u7) + "%");
+	if (u5 !== null) notes.push("会话窗口已使用 " + used + "%");
+	if (u7 !== null) notes.push("本周已使用 " + Math.round(u7) + "%");
 	const extraUtil = raw.extra_usage?.is_enabled === true ? finiteNumber(raw.extra_usage?.utilization ?? void 0) : null;
 	if (extraUtil !== null) notes.push("附加额度已用 " + Math.round(extraUtil) + "%");
 	return {
-		isAvailable: remaining === null ? false : remaining > 0,
+		isAvailable: used === null ? false : used < 100,
 		unit: "pct",
 		currency: "",
-		totalBalance: remaining === null ? "" : String(remaining),
+		totalBalance: used === null ? "" : String(used),
 		grantedBalance: "",
 		toppedUpBalance: "",
 		asOf,
@@ -414,8 +433,11 @@ function createClaudeService(deps, config = {}) {
 			}
 			return parseClaudeUsage(body, (/* @__PURE__ */ new Date()).toISOString());
 		},
-		isLow: (snapshot) => snapshot.unit === "pct" ? numOrInfinity(snapshot.totalBalance) <= lowPct : false
+		isLow: (snapshot) => {
+			const used = usedPercentOf(snapshot);
+			return used !== null && used >= 100 - lowPct;
+		}
 	});
 }
 //#endregion
-export { DEEPSEEK_KEY_REF, DEFAULT_BALANCE_BASE_URL, DEFAULT_BALANCE_REFRESH_MS, DEFAULT_BALANCE_THRESHOLD, DEFAULT_CLAUDE_CREDENTIALS_PATH, DEFAULT_CLAUDE_LOW_PCT, DEFAULT_CLAUDE_USAGE_URL, DEFAULT_MINIMAX_BASE_URL, DEFAULT_MINIMAX_LOW_PCT, DEFAULT_OPENCLAW_CONFIG_PATH, MINIMAX_KEY_REF, createBalanceService, createClaudeService, createMinimaxService, formatReset, parseBalancePayload, parseClaudeUsage, parseMinimaxRemains, pickCnyBalanceInfo, readClaudeCredentials, readJsonFile, windowRemainingPercent };
+export { DEEPSEEK_KEY_REF, DEFAULT_BALANCE_BASE_URL, DEFAULT_BALANCE_REFRESH_MS, DEFAULT_BALANCE_THRESHOLD, DEFAULT_CLAUDE_CREDENTIALS_PATH, DEFAULT_CLAUDE_LOW_PCT, DEFAULT_CLAUDE_USAGE_URL, DEFAULT_MINIMAX_BASE_URL, DEFAULT_MINIMAX_LOW_PCT, DEFAULT_OPENCLAW_CONFIG_PATH, MINIMAX_KEY_REF, createBalanceService, createClaudeService, createMinimaxService, formatReset, parseBalancePayload, parseClaudeUsage, parseMinimaxRemains, pickCnyBalanceInfo, readClaudeCredentials, readJsonFile, windowUsedPercent };

--- a/examples/dsh/packages/clawock-dsh/lib/client.js
+++ b/examples/dsh/packages/clawock-dsh/lib/client.js
@@ -5029,9 +5029,10 @@ function relativeDay(iso, today) {
 * the chip and panel render only these fields, so the view never keeps
 * a second copy of the tone rules — the host already decided status and low.
 * The title is the whole hover story: split, quota windows, stale reason,
-* fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
-* and carry the second window ('周'/'本周') as a muted pill suffix — both
-* limits visible at the header without opening the panel.
+* fetch time. Quota rows ('pct' unit) read as USED percent (kcn: 「已使用」
+* 比「剩余」直观), not money, and carry the second window ('周'/'本周') as a
+* muted pill suffix — both limits visible at the header without opening the
+* panel.
 */
 function _rowDisplay(result) {
 	if (result === null) return {
@@ -5065,7 +5066,7 @@ function _rowDisplay(result) {
 		value,
 		sub,
 		title: [
-			snapshot.unit === "pct" ? snapshot.note !== "" ? snapshot.note : "配额窗口余量" : "API 余额",
+			snapshot.unit === "pct" ? snapshot.note !== "" ? snapshot.note : "配额窗口已使用" : "API 余额",
 			!isPct && snapshot.grantedBalance !== "" ? "赠金 " + symbol + snapshot.grantedBalance : null,
 			!isPct && snapshot.toppedUpBalance !== "" ? "充值 " + symbol + snapshot.toppedUpBalance : null,
 			snapshot.isAvailable ? null : isPct ? "该窗口额度已用尽" : "官方接口判定余额不足",
@@ -5085,7 +5086,7 @@ function _balanceNote(result) {
 	if (result.status === "stale") return "刷新失败,显示最近一次" + (result.message !== null ? ":" + result.message : "");
 	if (!result.snapshot.isAvailable) return result.snapshot.unit === "pct" ? "该窗口额度已用尽" : "官方接口判定余额不足";
 	if (result.low) {
-		if (result.snapshot.unit === "pct") return "窗口余量不足 " + result.threshold + "%";
+		if (result.snapshot.unit === "pct") return "窗口已使用达 " + (100 - result.threshold) + "%";
 		return "余额偏低,低于阈值 " + (result.snapshot.currency === "USD" ? "$" : result.snapshot.currency === "CNY" ? "¥" : "") + result.threshold;
 	}
 	return null;
@@ -5119,7 +5120,7 @@ function renderRowDetail(row) {
 	const wins = row.result.snapshot?.windows ?? [];
 	if (wins.length > 0) return h("div", { className: cx("bp-wins") }, wins.map((w) => {
 		const pct = w.percent === null ? null : Math.max(0, Math.min(100, Math.round(w.percent)));
-		const state = pct !== null && row.result.snapshot?.unit === "pct" && pct <= row.result.threshold ? "low" : row.view.tone === "stale" ? "stale" : "ok";
+		const state = pct !== null && row.result.snapshot?.unit === "pct" && pct >= 100 - row.result.threshold ? "low" : row.view.tone === "stale" ? "stale" : "ok";
 		return h("div", {
 			className: cx("bp-win"),
 			key: w.label

--- a/examples/dsh/packages/clawock-dsh/lib/types/balance.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/balance.d.ts
@@ -48,7 +48,12 @@ export interface MinimaxConfig {
     baseUrl?: string;
     /** Credentials seam reference for the MiniMax key (env fallback same name). */
     keyRef?: string;
-    /** Red dot when a quota window's remaining percent drops to/below this. */
+    /**
+     * Red dot watermark in REMAINING terms: warn when a quota window's
+     * remaining percent has fallen to/below this (default 20). The chip
+     * displays the used direction (≥ `100 - lowPct`% used), but the config
+     * keeps its original meaning so existing values stay valid.
+     */
     lowPct?: number;
     /**
      * openclaw gateway config to fall back to when the seam and env are both
@@ -61,7 +66,11 @@ export interface ClaudeConfig {
     credentialsPath?: string;
     /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
     usageUrl?: string;
-    /** Red dot when the session window's remaining percent drops to/below this. */
+    /**
+     * Red dot watermark in REMAINING terms for the session window: warn when
+     * remaining has fallen to/below this (default 20, i.e. ≥80% used). The
+     * displayed number is used percent; the config meaning is unchanged.
+     */
     lowPct?: number;
 }
 /**
@@ -117,11 +126,13 @@ export interface MinimaxRemainsEntry {
     [key: string]: unknown;
 }
 /**
- * Remaining percent of one quota window: the explicit percent field when the
- * plan reports one, otherwise derived from total/used counts (MiniMax ships
- * both shapes across plan generations). null = unreadable, never guessed.
+ * Used percent of one quota window — the chip's display direction (kcn:
+ * 「已使用」比「剩余」直观). The explicit percent field reports REMAINING and
+ * is complemented here; raw counts are already consumption and divide as-is
+ * (MiniMax ships both shapes across plan generations). null = unreadable,
+ * never guessed.
  */
-export declare function windowRemainingPercent(entry: MinimaxRemainsEntry): number | null;
+export declare function windowUsedPercent(entry: MinimaxRemainsEntry): number | null;
 /**
  * Reset stamps the panel can lay out: within 48h a bare local clock,
  * farther out the weekday comes along ('周四 21:00'). Accepts epoch seconds,
@@ -132,7 +143,7 @@ export declare function formatReset(epochOrIso: number | string | null | undefin
 /**
  * The successful Token Plan payload → snapshot. Percent-based by design:
  * plans report either percent fields or raw counts, and tokens are not money
- * — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+ * — the chip reads "窗口额度用了多少"(已使用方向), never a fabricated ¥ figure.
  */
 export declare function parseMinimaxRemains(body: unknown, asOf: string): BalanceSnapshot;
 /** Tolerant JSON file read: missing/unreadable/invalid all yield undefined. */
@@ -171,9 +182,10 @@ export declare function readClaudeCredentials(path: string): {
     creds: ClaudeCredentials;
 } | undefined;
 /**
- * Successful usage payload → snapshot, in REMAINING percent (utilization is
- * consumption). five_hour gates active sessions so it is the headline; any
- * bucket may be absent/null depending on plan.
+ * Successful usage payload → snapshot, in USED percent — utilization already
+ * IS consumption, so it renders verbatim with no complementing (kcn:
+ * 「已使用」比「剩余」直观). five_hour gates active sessions so it is the
+ * headline; any bucket may be absent/null depending on plan.
  */
 export declare function parseClaudeUsage(body: unknown, asOf: string): BalanceSnapshot;
 /** Claude row: subscription rate-limit windows via the OAuth usage endpoint. */

--- a/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/client.d.ts
@@ -126,9 +126,10 @@ export type BalanceTone = 'ok' | 'low' | 'stale' | 'none';
  * the chip and panel render only these fields, so the view never keeps
  * a second copy of the tone rules — the host already decided status and low.
  * The title is the whole hover story: split, quota windows, stale reason,
- * fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
- * and carry the second window ('周'/'本周') as a muted pill suffix — both
- * limits visible at the header without opening the panel.
+ * fetch time. Quota rows ('pct' unit) read as USED percent (kcn: 「已使用」
+ * 比「剩余」直观), not money, and carry the second window ('周'/'本周') as a
+ * muted pill suffix — both limits visible at the header without opening the
+ * panel.
  */
 export declare function _rowDisplay(result: BalanceResult | null): {
     tone: BalanceTone;

--- a/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/index.d.ts
@@ -25,7 +25,11 @@ export interface ClawockStudioConfig {
     minimaxBaseUrl?: string;
     /** Credentials seam reference for the MiniMax key (env fallback same name). */
     minimaxKeyRef?: string;
-    /** Red dot when MiniMax quota windows drop to/below this remaining percent. */
+    /**
+     * Red dot watermark in REMAINING terms: warn when MiniMax windows'
+     * remaining percent falls to/below this (default 20 = ≥80% used). The
+     * chip displays used percent; this field's meaning is unchanged.
+     */
     minimaxLowPct?: number;
     /** openclaw gateway config fallback for provider keys (models.providers.*). */
     minimaxOpenclawConfigPath?: string;
@@ -33,7 +37,10 @@ export interface ClawockStudioConfig {
     claudeCredentialsPath?: string;
     /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
     claudeUsageUrl?: string;
-    /** Red dot when the Claude session window's remaining percent is low. */
+    /**
+     * Red dot watermark in REMAINING terms for the Claude session window
+     * (default 20 = ≥80% used); displayed number is used percent.
+     */
     claudeLowPct?: number;
 }
 export declare class ClawockStudioGateway extends TypertRemoteService {

--- a/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
+++ b/examples/dsh/packages/clawock-dsh/lib/types/types.d.ts
@@ -146,7 +146,7 @@ export interface TracesResult {
 export interface BalanceWindow {
     /** Short label rendered verbatim: '5h' | '周' | '会话' | '本周'. */
     label: string;
-    /** Remaining percent of this window; null when the plan doesn't report it. */
+    /** Used percent of this window (0-100); null when the plan doesn't report it. */
     percent: number | null;
     /** Preformatted LOCAL reset stamp ('15:00' / '周四 21:00'); '' when unknown. */
     resetAt: string;
@@ -161,13 +161,13 @@ export interface BalanceSnapshot {
     isAvailable: boolean;
     /**
      * How `totalBalance` reads: 'money' carries a currency symbol via
-     * `currency` ('CNY' | 'USD' | ''), 'pct' carries a remaining-percent number
-     * (quota windows). '' defaults to 'money'.
+     * `currency` ('CNY' | 'USD' | ''), 'pct' carries a used-percent number
+     * (quota windows; utilization direction — kcn 口径). '' defaults to 'money'.
      */
     unit: string;
     /** 'CNY' | 'USD' | '' — the displayed entry's currency (money unit only). */
     currency: string;
-    /** Total available balance ("110.00") or remaining percent ("62"). */
+    /** Total available balance ("110.00") or used percent ("62"). */
     totalBalance: string;
     /** Not-expired granted balance (DeepSeek money accounts; '' elsewhere). */
     grantedBalance: string;

--- a/examples/dsh/packages/clawock-dsh/src/balance.ts
+++ b/examples/dsh/packages/clawock-dsh/src/balance.ts
@@ -56,7 +56,12 @@ export interface MinimaxConfig {
   baseUrl?: string
   /** Credentials seam reference for the MiniMax key (env fallback same name). */
   keyRef?: string
-  /** Red dot when a quota window's remaining percent drops to/below this. */
+  /**
+   * Red dot watermark in REMAINING terms: warn when a quota window's
+   * remaining percent has fallen to/below this (default 20). The chip
+   * displays the used direction (≥ `100 - lowPct`% used), but the config
+   * keeps its original meaning so existing values stay valid.
+   */
   lowPct?: number
   /**
    * openclaw gateway config to fall back to when the seam and env are both
@@ -70,7 +75,11 @@ export interface ClaudeConfig {
   credentialsPath?: string
   /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
   usageUrl?: string
-  /** Red dot when the session window's remaining percent drops to/below this. */
+  /**
+   * Red dot watermark in REMAINING terms for the session window: warn when
+   * remaining has fallen to/below this (default 20, i.e. ≥80% used). The
+   * displayed number is used percent; the config meaning is unchanged.
+   */
   lowPct?: number
 }
 
@@ -166,17 +175,19 @@ const finiteNumber = (value: unknown): number | null =>
   typeof value === 'number' && isFinite(value) ? value : null
 
 /**
- * Remaining percent of one quota window: the explicit percent field when the
- * plan reports one, otherwise derived from total/used counts (MiniMax ships
- * both shapes across plan generations). null = unreadable, never guessed.
+ * Used percent of one quota window — the chip's display direction (kcn:
+ * 「已使用」比「剩余」直观). The explicit percent field reports REMAINING and
+ * is complemented here; raw counts are already consumption and divide as-is
+ * (MiniMax ships both shapes across plan generations). null = unreadable,
+ * never guessed.
  */
-export function windowRemainingPercent(entry: MinimaxRemainsEntry): number | null {
+export function windowUsedPercent(entry: MinimaxRemainsEntry): number | null {
   const direct = finiteNumber(entry.current_interval_remaining_percent)
-  if (direct !== null) return Math.min(100, Math.max(0, direct))
+  if (direct !== null) return Math.min(100, Math.max(0, 100 - direct))
   const total = finiteNumber(entry.current_interval_total_count)
   const used = finiteNumber(entry.current_interval_usage_count)
   if (total !== null && total > 0 && used !== null && used >= 0) {
-    return Math.min(100, Math.max(0, ((total - used) / total) * 100))
+    return Math.min(100, Math.max(0, (used / total) * 100))
   }
   return null
 }
@@ -213,7 +224,7 @@ function resetClock(epoch: unknown): string | null {
 /**
  * The successful Token Plan payload → snapshot. Percent-based by design:
  * plans report either percent fields or raw counts, and tokens are not money
- * — the chip reads "还剩多少窗口额度", never a fabricated ¥ figure.
+ * — the chip reads "窗口额度用了多少"(已使用方向), never a fabricated ¥ figure.
  */
 export function parseMinimaxRemains(body: unknown, asOf: string): BalanceSnapshot {
   const raw = (typeof body === 'object' && body !== null ? body : {}) as RawRemainsBody
@@ -221,19 +232,20 @@ export function parseMinimaxRemains(body: unknown, asOf: string): BalanceSnapsho
   // `general` is the text/coding bucket every plan carries; video et al are add-ons.
   const entry = buckets.find((b) => b.model === 'general') ?? buckets[0]
   if (entry === undefined) throw new Error('MiniMax 响应里没有 model_remains 数据')
-  const pct = windowRemainingPercent(entry)
-  const weekly = finiteNumber(entry.current_weekly_remaining_percent)
+  const used = windowUsedPercent(entry)
+  const weeklyRemaining = finiteNumber(entry.current_weekly_remaining_percent)
+  const weeklyUsed = weeklyRemaining === null ? null : Math.min(100, Math.max(0, 100 - weeklyRemaining))
   const windows: BalanceWindow[] = []
-  if (pct !== null) windows.push({ label: '5h', percent: Math.round(pct), resetAt: formatReset(entry.end_time as number | undefined) })
-  if (weekly !== null) windows.push({ label: '周', percent: Math.round(weekly), resetAt: formatReset(entry.weekly_end_time as number | undefined) })
+  if (used !== null) windows.push({ label: '5h', percent: Math.round(used), resetAt: formatReset(entry.end_time as number | undefined) })
+  if (weeklyUsed !== null) windows.push({ label: '周', percent: Math.round(weeklyUsed), resetAt: formatReset(entry.weekly_end_time as number | undefined) })
   const notes: string[] = []
-  if (pct !== null) notes.push('5h 窗口剩余 ' + Math.round(pct) + '%')
-  if (weekly !== null) notes.push('周窗口剩余 ' + Math.round(weekly) + '%')
+  if (used !== null) notes.push('5h 窗口已使用 ' + Math.round(used) + '%')
+  if (weeklyUsed !== null) notes.push('周窗口已使用 ' + Math.round(weeklyUsed) + '%')
   return {
-    isAvailable: pct !== null && pct > 0,
+    isAvailable: used !== null && used < 100,
     unit: 'pct',
     currency: '',
-    totalBalance: pct === null ? '' : String(Math.round(pct)),
+    totalBalance: used === null ? '' : String(Math.round(used)),
     grantedBalance: '',
     toppedUpBalance: '',
     asOf,
@@ -391,6 +403,19 @@ const numOrInfinity = (value: string): number => {
   return isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY
 }
 
+/**
+ * The snapshot's used-percent reading, or null when it isn't a percent unit
+ * or carries no parseable number. The null guard is the point: under the old
+ * REMAINING direction an unreadable value read as +∞ and safely missed the
+ * watermark; under USED that same +∞ would read as "everything consumed" and
+ * light every red dot. An absent reading must stay silent.
+ */
+function usedPercentOf(snapshot: BalanceSnapshot): number | null {
+  if (snapshot.unit !== 'pct') return null
+  const parsed = Number.parseFloat(snapshot.totalBalance)
+  return isFinite(parsed) ? parsed : null
+}
+
 /** DeepSeek row: official money balance, CNY entry preferred. */
 export function createBalanceService(
   deps: { credentials: BalanceCredentials },
@@ -428,9 +453,11 @@ export function createBalanceService(
       }
       return parseBalancePayload(body, new Date().toISOString())
     },
-    isLow: (snapshot) => snapshot.unit === 'pct'
-      ? numOrInfinity(snapshot.totalBalance) <= threshold
-      : snapshot.isAvailable && numOrInfinity(snapshot.totalBalance) <= threshold,
+    // DeepSeek is money, not quota — its snapshots are always unit 'money'
+    // (parseBalancePayload), so the low check stays a plain balance floor.
+    isLow: (snapshot) => snapshot.unit === 'money'
+      && snapshot.isAvailable
+      && numOrInfinity(snapshot.totalBalance) <= threshold,
   })
 }
 
@@ -481,9 +508,13 @@ export function createMinimaxService(
       }
       return parseMinimaxRemains(body, new Date().toISOString())
     },
-    isLow: (snapshot) => snapshot.unit === 'pct'
-      ? numOrInfinity(snapshot.totalBalance) <= lowPct
-      : false,
+    // lowPct keeps its 「剩余水位」meaning (warn when remaining ≤ lowPct) so
+    // existing configs survive the display flip verbatim; in the used
+    // direction that is used ≥ 100 − lowPct.
+    isLow: (snapshot) => {
+      const used = usedPercentOf(snapshot)
+      return used !== null && used >= 100 - lowPct
+    },
   })
 }
 
@@ -528,29 +559,30 @@ const localClock = (iso: string): string | null => {
 }
 
 /**
- * Successful usage payload → snapshot, in REMAINING percent (utilization is
- * consumption). five_hour gates active sessions so it is the headline; any
- * bucket may be absent/null depending on plan.
+ * Successful usage payload → snapshot, in USED percent — utilization already
+ * IS consumption, so it renders verbatim with no complementing (kcn:
+ * 「已使用」比「剩余」直观). five_hour gates active sessions so it is the
+ * headline; any bucket may be absent/null depending on plan.
  */
 export function parseClaudeUsage(body: unknown, asOf: string): BalanceSnapshot {
   const raw = (typeof body === 'object' && body !== null ? body : {}) as RawClaudeUsage
   const u5 = finiteNumber(raw.five_hour?.utilization)
   const u7 = finiteNumber(raw.seven_day?.utilization)
   if (u5 === null && u7 === null) throw new Error('Claude 响应里没有可用的用量窗口')
-  const remaining = u5 === null ? null : Math.round(Math.min(100, Math.max(0, 100 - u5)))
+  const used = u5 === null ? null : Math.round(Math.min(100, Math.max(0, u5)))
   const windows: BalanceWindow[] = []
-  if (u5 !== null) windows.push({ label: '会话', percent: remaining, resetAt: formatReset(raw.five_hour?.resets_at ?? null) })
-  if (u7 !== null) windows.push({ label: '本周', percent: Math.round(Math.min(100, Math.max(0, 100 - u7))), resetAt: formatReset(raw.seven_day?.resets_at ?? null) })
+  if (u5 !== null) windows.push({ label: '会话', percent: used, resetAt: formatReset(raw.five_hour?.resets_at ?? null) })
+  if (u7 !== null) windows.push({ label: '本周', percent: Math.round(Math.min(100, Math.max(0, u7))), resetAt: formatReset(raw.seven_day?.resets_at ?? null) })
   const notes: string[] = []
-  if (u5 !== null) notes.push('会话窗口剩余 ' + remaining + '%')
-  if (u7 !== null) notes.push('本周剩余 ' + Math.round(100 - u7) + '%')
+  if (u5 !== null) notes.push('会话窗口已使用 ' + used + '%')
+  if (u7 !== null) notes.push('本周已使用 ' + Math.round(u7) + '%')
   const extraUtil = raw.extra_usage?.is_enabled === true ? finiteNumber(raw.extra_usage?.utilization ?? undefined) : null
   if (extraUtil !== null) notes.push('附加额度已用 ' + Math.round(extraUtil) + '%')
   return {
-    isAvailable: remaining === null ? false : remaining > 0,
+    isAvailable: used === null ? false : used < 100,
     unit: 'pct',
     currency: '',
-    totalBalance: remaining === null ? '' : String(remaining),
+    totalBalance: used === null ? '' : String(used),
     grantedBalance: '',
     toppedUpBalance: '',
     asOf,
@@ -610,8 +642,11 @@ export function createClaudeService(
       }
       return parseClaudeUsage(body, new Date().toISOString())
     },
-    isLow: (snapshot) => snapshot.unit === 'pct'
-      ? numOrInfinity(snapshot.totalBalance) <= lowPct
-      : false,
+    // Same 「剩余水位」 contract as MiniMax: lowPct means remaining ≤ lowPct,
+    // which in the used direction is used ≥ 100 − lowPct.
+    isLow: (snapshot) => {
+      const used = usedPercentOf(snapshot)
+      return used !== null && used >= 100 - lowPct
+    },
   })
 }

--- a/examples/dsh/packages/clawock-dsh/src/client.ts
+++ b/examples/dsh/packages/clawock-dsh/src/client.ts
@@ -470,9 +470,10 @@ export type BalanceTone = 'ok' | 'low' | 'stale' | 'none'
  * the chip and panel render only these fields, so the view never keeps
  * a second copy of the tone rules — the host already decided status and low.
  * The title is the whole hover story: split, quota windows, stale reason,
- * fetch time. Quota rows ('pct' unit) read as remaining percent, not money,
- * and carry the second window ('周'/'本周') as a muted pill suffix — both
- * limits visible at the header without opening the panel.
+ * fetch time. Quota rows ('pct' unit) read as USED percent (kcn: 「已使用」
+ * 比「剩余」直观), not money, and carry the second window ('周'/'本周') as a
+ * muted pill suffix — both limits visible at the header without opening the
+ * panel.
  */
 export function _rowDisplay(result: BalanceResult | null): { tone: BalanceTone; value: string; sub: string | null; title: string } {
   if (result === null) return { tone: 'none', value: '—', sub: null, title: '余额加载中' }
@@ -501,7 +502,7 @@ export function _rowDisplay(result: BalanceResult | null): { tone: BalanceTone; 
   // 更新时间不重复展示:轮询是静默的,手动刷新有 ✓ 反馈——时间戳只增加噪音。
   const parts = [
     snapshot.unit === 'pct'
-      ? (snapshot.note !== '' ? snapshot.note : '配额窗口余量')
+      ? (snapshot.note !== '' ? snapshot.note : '配额窗口已使用')
       : 'API 余额',
     !isPct && snapshot.grantedBalance !== '' ? '赠金 ' + symbol + snapshot.grantedBalance : null,
     !isPct && snapshot.toppedUpBalance !== '' ? '充值 ' + symbol + snapshot.toppedUpBalance : null,
@@ -527,7 +528,8 @@ export function _balanceNote(result: BalanceResult | null): string | null {
     return result.snapshot.unit === 'pct' ? '该窗口额度已用尽' : '官方接口判定余额不足'
   }
   if (result.low) {
-    if (result.snapshot.unit === 'pct') return '窗口余量不足 ' + result.threshold + '%'
+    // threshold 是「剩余水位」(lowPct),已使用方向 = 100 − threshold。
+    if (result.snapshot.unit === 'pct') return '窗口已使用达 ' + (100 - result.threshold) + '%'
     const symbol = result.snapshot.currency === 'USD' ? '$' : result.snapshot.currency === 'CNY' ? '¥' : ''
     return '余额偏低,低于阈值 ' + symbol + result.threshold
   }
@@ -590,12 +592,14 @@ function renderRowDetail(row: {
   if (row.note !== null) return null
   const wins = row.result.snapshot?.windows ?? []
   if (wins.length > 0) {
-    // 每窗一行:文字读数 + 发丝进度条。条的语义=剩余量,低水位换警示色;
-    // 静态渲染不做 width 动画(宽度动画在审校里是红线),数据刷新整帧替换。
+    // 每窗一行:文字读数 + 发丝进度条。percent 是已使用方向(kcn 定的口径),
+    // 条的填充=已使用量,用到接近满格才亮红(used ≥ 100−threshold);与旧
+    // 「剩余」语义正好相反,警示方向已随数据同步翻转。静态渲染不做 width
+    // 动画(宽度动画在审校里是红线),数据刷新整帧替换。
     return h('div', { className: cx('bp-wins') },
       wins.map((w) => {
         const pct = w.percent === null ? null : Math.max(0, Math.min(100, Math.round(w.percent)))
-        const low = pct !== null && row.result.snapshot?.unit === 'pct' && pct <= row.result.threshold
+        const low = pct !== null && row.result.snapshot?.unit === 'pct' && pct >= 100 - row.result.threshold
         const state = low ? 'low' : row.view.tone === 'stale' ? 'stale' : 'ok'
         return h('div', { className: cx('bp-win'), key: w.label },
           h('div', { className: cx('bp-win-line') },

--- a/examples/dsh/packages/clawock-dsh/src/index.ts
+++ b/examples/dsh/packages/clawock-dsh/src/index.ts
@@ -35,7 +35,11 @@ export interface ClawockStudioConfig {
   minimaxBaseUrl?: string
   /** Credentials seam reference for the MiniMax key (env fallback same name). */
   minimaxKeyRef?: string
-  /** Red dot when MiniMax quota windows drop to/below this remaining percent. */
+  /**
+   * Red dot watermark in REMAINING terms: warn when MiniMax windows'
+   * remaining percent falls to/below this (default 20 = ≥80% used). The
+   * chip displays used percent; this field's meaning is unchanged.
+   */
   minimaxLowPct?: number
   /** openclaw gateway config fallback for provider keys (models.providers.*). */
   minimaxOpenclawConfigPath?: string
@@ -43,7 +47,10 @@ export interface ClawockStudioConfig {
   claudeCredentialsPath?: string
   /** The undocumented /api/oauth/usage endpoint; overridable for tests. */
   claudeUsageUrl?: string
-  /** Red dot when the Claude session window's remaining percent is low. */
+  /**
+   * Red dot watermark in REMAINING terms for the Claude session window
+   * (default 20 = ≥80% used); displayed number is used percent.
+   */
   claudeLowPct?: number
 }
 

--- a/examples/dsh/packages/clawock-dsh/src/types.ts
+++ b/examples/dsh/packages/clawock-dsh/src/types.ts
@@ -161,7 +161,7 @@ export interface TracesResult {
 export interface BalanceWindow {
   /** Short label rendered verbatim: '5h' | '周' | '会话' | '本周'. */
   label: string
-  /** Remaining percent of this window; null when the plan doesn't report it. */
+  /** Used percent of this window (0-100); null when the plan doesn't report it. */
   percent: number | null
   /** Preformatted LOCAL reset stamp ('15:00' / '周四 21:00'); '' when unknown. */
   resetAt: string
@@ -177,13 +177,13 @@ export interface BalanceSnapshot {
   isAvailable: boolean
   /**
    * How `totalBalance` reads: 'money' carries a currency symbol via
-   * `currency` ('CNY' | 'USD' | ''), 'pct' carries a remaining-percent number
-   * (quota windows). '' defaults to 'money'.
+   * `currency` ('CNY' | 'USD' | ''), 'pct' carries a used-percent number
+   * (quota windows; utilization direction — kcn 口径). '' defaults to 'money'.
    */
   unit: string
   /** 'CNY' | 'USD' | '' — the displayed entry's currency (money unit only). */
   currency: string
-  /** Total available balance ("110.00") or remaining percent ("62"). */
+  /** Total available balance ("110.00") or used percent ("62"). */
   totalBalance: string
   /** Not-expired granted balance (DeepSeek money accounts; '' elsewhere). */
   grantedBalance: string

--- a/tests/decision_studio_plugin.spec.js
+++ b/tests/decision_studio_plugin.spec.js
@@ -222,11 +222,11 @@ const DS_ROW_OK = {
 };
 const MM_ROW_OK = {
   provider: "minimax", label: "MiniMax",
-  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "76", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "5h 窗口剩余 76% · 周窗口剩余 90%", windows: [{ label: "5h", percent: 76, resetAt: "21:00" }, { label: "周", percent: 90, resetAt: "周四 21:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
+  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "24", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "5h 窗口已使用 24% · 周窗口已使用 10%", windows: [{ label: "5h", percent: 24, resetAt: "21:00" }, { label: "周", percent: 10, resetAt: "周四 21:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
 };
 const CL_ROW_OK = {
   provider: "claude", label: "Claude",
-  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "64", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "会话窗口剩余 64% · 本周剩余 31%", windows: [{ label: "会话", percent: 64, resetAt: "10:00" }, { label: "本周", percent: 31, resetAt: "周四 10:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
+  result: { configured: true, snapshot: { isAvailable: true, unit: "pct", currency: "", totalBalance: "36", grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "会话窗口已使用 36% · 本周已使用 69%", windows: [{ label: "会话", percent: 36, resetAt: "10:00" }, { label: "本周", percent: 69, resetAt: "周四 10:00" }] }, status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000 },
 };
 const BALANCES_OK = { providers: [DS_ROW_OK, MM_ROW_OK, CL_ROW_OK], refreshMs: 60000 };
 const QUIET_BALANCES = { providers: [], refreshMs: 60000 };
@@ -1155,14 +1155,16 @@ test("balance: CNY picking, tolerant parsing and the service's polite-cadence st
   assert.equal(noKey.snapshot, null);
   assert.match(noKey.message, /未配置/);
 
-  // --- MiniMax: Token Plan quota windows, percent-based, HTTP-200 failures ---
-  const { createMinimaxService, parseMinimaxRemains, windowRemainingPercent } = balance;
+  // --- MiniMax: Token Plan quota windows, USED-percent display direction ---
+  const { createMinimaxService, parseMinimaxRemains, windowUsedPercent } = balance;
 
-  // Percent field wins; counts derive it; unreadable stays null (never guessed).
-  assert.equal(windowRemainingPercent({ current_interval_remaining_percent: 88.4 }), 88.4);
-  assert.equal(windowRemainingPercent({ current_interval_total_count: 5000000, current_interval_usage_count: 1250000 }), 75);
-  assert.equal(windowRemainingPercent({ current_interval_total_count: 0, current_interval_usage_count: 0 }), null);
-  assert.equal(windowRemainingPercent({}), null);
+  // The upstream percent field reports REMAINING and is complemented; raw
+  // counts already are consumption and divide as-is; unreadable stays null.
+  assert.equal(windowUsedPercent({ current_interval_remaining_percent: 88.4 }), 100 - 88.4);
+  assert.equal(windowUsedPercent({ current_interval_remaining_percent: 0 }), 100, "a fresh window reads as fully unused");
+  assert.equal(windowUsedPercent({ current_interval_total_count: 5000000, current_interval_usage_count: 1250000 }), 25);
+  assert.equal(windowUsedPercent({ current_interval_total_count: 0, current_interval_usage_count: 0 }), null);
+  assert.equal(windowUsedPercent({}), null);
 
   // The general bucket is the text/coding plan every account carries.
   const mmParsed = parseMinimaxRemains({
@@ -1173,8 +1175,8 @@ test("balance: CNY picking, tolerant parsing and the service's polite-cadence st
     ],
   }, AS_OF);
   assert.equal(mmParsed.unit, "pct");
-  assert.equal(mmParsed.totalBalance, "76", "percent is rounded for display only");
-  assert.deepEqual(mmParsed.windows.map((w) => [w.label, w.percent]), [["5h", 76], ["周", 90]]);
+  assert.equal(mmParsed.totalBalance, "24", "remaining 76.4 → used 23.6, rounded for display only");
+  assert.deepEqual(mmParsed.windows.map((w) => [w.label, w.percent]), [["5h", 24], ["周", 10]]);
   assert.match(mmParsed.windows[0].resetAt, /^\d{2}:\d{2}$/);
   assert.throws(() => parseMinimaxRemains({ base_resp: { status_code: 0 } }, AS_OF), /model_remains/);
   // Epoch seconds AND milliseconds both read; garbage does not crash.
@@ -1207,7 +1209,7 @@ test("balance: CNY picking, tolerant parsing and the service's polite-cadence st
     }), { status: 200, headers: { "content-type": "application/json" } });
     const lowQuota = await createMinimaxService({ credentials: { resolve: async () => ({ value: "mm-test" }) } }).get(true);
     assert.equal(lowQuota.status, "fresh");
-    assert.equal(lowQuota.low, true, "12% remaining must read low against the 20% default");
+    assert.equal(lowQuota.low, true, "remaining 12% → used 88% ≥ 100−20, the watermark in used direction");
     assert.equal(lowQuota.snapshot.unit, "pct");
   } finally {
     globalThis.fetch = originalFetch;
@@ -1278,7 +1280,8 @@ test("balance: claude subscription windows via the OAuth usage endpoint", async 
     claudeAiOauth: { accessToken: "sk-ant-oat01-test", refreshToken: "ort01", expiresAt: future, subscriptionType: "max" },
   }));
 
-  // utilization is consumption; our reading is REMAINING percent.
+  // utilization IS the used percent (kcn: 「已使用」直观) — rendered verbatim,
+  // no complementing anywhere.
   const usageBody = {
     five_hour: { utilization: 36, resets_at: "2026-08-24T02:00:00Z" },
     seven_day: { utilization: 69 },
@@ -1297,11 +1300,11 @@ test("balance: claude subscription windows via the OAuth usage endpoint", async 
     const fresh = await svc.get(true);
     assert.equal(fresh.status, "fresh");
     assert.equal(fresh.snapshot.unit, "pct");
-    assert.equal(fresh.snapshot.totalBalance, "64", "100 - 36 utilized = 64 remaining");
-    assert.deepEqual(fresh.snapshot.windows.map((w) => [w.label, w.percent]), [["会话", 64], ["本周", 31]]);
+    assert.equal(fresh.snapshot.totalBalance, "36", "utilization reads through untouched");
+    assert.deepEqual(fresh.snapshot.windows.map((w) => [w.label, w.percent]), [["会话", 36], ["本周", 69]]);
     assert.match(fresh.snapshot.windows[0].resetAt, /^\d{2}:\d{2}$/);
-    assert.match(fresh.snapshot.note, /会话窗口剩余 64%/);
-    assert.match(fresh.snapshot.note, /本周剩余 31%/, "note mirrors the weekly window");
+    assert.match(fresh.snapshot.note, /会话窗口已使用 36%/);
+    assert.match(fresh.snapshot.note, /本周已使用 69%/, "note mirrors the weekly window");
     assert.equal(sawHeaders["anthropic-beta"], "oauth-2025-04-20", "the beta header is required");
     assert.equal(sawHeaders.authorization, "Bearer sk-ant-oat01-test");
 
@@ -1420,9 +1423,9 @@ test("client: the header chip headlines one provider and the panel pins the rest
   assert.equal(f.chip[0]["data-pb-provider"], "minimax", "clicking a panel row pins it as the headline");
   assert.equal(f.chip[0]["data-balance-state"], "ok");
   assert.equal(store._get().selected, "minimax", "the pin survives in registration-store state");
-  assert.ok(f.texts.includes("76%"), "the pinned quota reading renders");
+  assert.ok(f.texts.includes("24%"), "the pinned quota reading renders (used direction)");
   assert.ok(
-    f.texts.some((t) => t.includes("周 90%")),
+    f.texts.some((t) => t.includes("周 10%")),
     "the weekly limit rides along on the pill as a muted sub-reading",
   );
 
@@ -1498,7 +1501,7 @@ test("client: the panel says each provider's story once, abnormal rows loudest",
     (node.children || []).forEach(walkFills);
   })(tree);
   assert.equal(fills.length, 2, "each quota window renders one remaining-bar");
-  assert.deepEqual(fills.map((p) => p.style.width), ["76%", "90%"], "bar length mirrors the window reading");
+  assert.deepEqual(fills.map((p) => p.style.width), ["24%", "10%"], "bar length mirrors the window reading");
   assert.deepEqual(
     fills.map((p) => p["data-balance-state"]),
     ["ok", "ok"],
@@ -1506,10 +1509,11 @@ test("client: the panel says each provider's story once, abnormal rows loudest",
   );
   disposeReactEffects();
 
-  // Below the low watermark the bar itself flips to the warning tone — the
-  // same discipline as the dots, applied per window rather than per provider.
+  // Past the watermark the bar itself flips to the warning tone — the same
+  // discipline as the dots, applied per window rather than per provider. In
+  // used direction: warn at ≥ 100−threshold = 80%.
   const LOW_MM = JSON.parse(JSON.stringify(MM_ROW_OK));
-  LOW_MM.result.snapshot.windows = [{ label: "5h", percent: 76, resetAt: "" }, { label: "周", percent: 12, resetAt: "" }];
+  LOW_MM.result.snapshot.windows = [{ label: "5h", percent: 24, resetAt: "" }, { label: "周", percent: 88, resetAt: "" }];
   const ctx2 = {
     effect() {},
     get() { return { balance: async () => ({ ok: true, value: { providers: [LOW_MM], refreshMs: 60000 } }) }; },
@@ -1548,7 +1552,7 @@ test("client: _rowDisplay and _balanceNote project one provider's answer", async
 
   const snap = (total, extra = {}) => ({ isAvailable: true, unit: "money", currency: "CNY", totalBalance: total, grantedBalance: "", toppedUpBalance: "", asOf: AS_OF, note: "", windows: [], ...extra });
   const answer = (over = {}) => ({ configured: true, snapshot: snap("110.00"), status: "fresh", low: false, message: null, threshold: 20, refreshMs: 60000, ...over });
-  // Money rows keep the old shape; quota rows read as remaining percent and
+  // Money rows keep the old shape; quota rows read as used percent and
   // surface the second window (周限额) as a muted pill suffix.
   assert.deepEqual(api._rowDisplay(null), { tone: "none", value: "—", sub: null, title: "余额加载中" });
   const okRow = api._rowDisplay(answer());
@@ -1583,9 +1587,9 @@ test("client: _rowDisplay and _balanceNote project one provider's answer", async
   assert.match(api._balanceNote(answer({ snapshot: null, status: "failed", message: "网络请求失败" })), /网络请求失败/);
   assert.match(api._balanceNote(answer({ snapshot: snap("9.00", { isAvailable: false }) })), /余额不足/);
   assert.match(
-    api._balanceNote(answer({ snapshot: snap("12", { unit: "pct", currency: "", isAvailable: true }), low: true })),
-    /窗口余量不足 20%/,
-    "quota lows speak in percent",
+    api._balanceNote(answer({ snapshot: snap("88", { unit: "pct", currency: "", isAvailable: true }), low: true })),
+    /窗口已使用达 80%/,
+    "quota lows speak in used percent (remaining watermark 20 flipped)",
   );
 });
 


### PR DESCRIPTION
接 #893。kcn 反馈「剩余容量」不直观,配额读数全部翻转到已使用方向:

## 改了什么
- **Claude**:`utilization` 本来就是已使用百分比,`parseClaudeUsage` 直读渲染,删掉 `100−u` 取补。
- **MiniMax**:`windowRemainingPercent` → `windowUsedPercent`(上游报剩余字段则取补;报 total/used counts 则直接算已用份额);周窗口 `current_weekly_remaining_percent` 同样取补为已使用。
- **同步翻转的语义**:windows.percent / totalBalance / note 文案(「剩余 X%」→「已使用 X%」)/ `_rowDisplay` title fallback(「配额窗口余量」→「配额窗口已使用」)/ 面板进度条填充(填充=已使用量,越满越接近红线)。
- **红点阈值换向**:`used ≥ 100 − lowPct` 才亮红。`*LowPct` 配置字段保持「剩余水位」原义不动(默认 20:剩余≤20% ⟺ 已使用≥80%),已有配置值无需迁移——只有展示方向翻了。README 与字段注释都写明了这一点。
- **新增 `usedPercentOf` 守卫**:旧语义下不可解析值读作 +∞ 天然错过水位;新语义下 +∞ 会变成「全部耗尽」误报所有红点。空读数必须静默,这个坑用注释钉住了。
- **DeepSeek 不动**(金额口径);typert wire 字段名不变(percent 数值语义翻新),无需字节迁移。

## 测试
- spec 22/22:fixtures 全部换算(MM 76/90 剩余 → 24/10 已使用;CL utilization 36/69 直读),新增「剩余0=已使用100」边界与 low 方向断言
- package contract 6/6;ratchet 宿主路径闸 7/7(豁免计数仍准)
- lib/ 由 build 再生
