### PR TITLE
dashboard: Equity Curve 挪出 Overview 首屏，与 Reflect 净值表现区合并

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2076,6 +2076,13 @@
     }
   }
   .hero-deck-copy { min-width: 0; }
+  /* 脚手架（「—」占位）到数据态的高度差必须先占住，否则副行折行会把
+     deck 以下整列推下去 —— Equity 卡挪走后它下方直接是判定卡/统计条，
+     可见位移面积变大，CLS 实测 390px 从 ~0.037 回退到 ~0.11。142 = 数据态
+     实测（sub 两行 + fx 一行）；桌面单行放得下，不需要预留。 */
+  @media (max-width: 1023px) {
+    .hero-deck-copy { min-height: 142px; }
+  }
 
   /* 缩略走势：纯形状，没有坐标轴/刻度/图例。高度由 CSS 固定占住，数据没到
      或点数不足时容器仍然是这个高度 —— 不占的话它一到就是一次 CLS。 */
@@ -2264,15 +2271,8 @@
   .dh-row.is-late .dh-state { color: var(--warning); }
   .dh-row.is-missing .dh-state { color: var(--red); }
 
-  .overview-equity {
-    grid-column: span 8; min-height: 480px; padding: 18px 18px 12px;
-  }
-  .overview-equity .card-head { align-items: flex-start; }
-  .overview-equity .card-head h3 {
-    margin: 5px 0 0; color: var(--text); font-size: var(--fs-lg);
-    letter-spacing: -.01em; text-transform: none;
-  }
-  .overview-equity-hint { max-width: 92%; margin: -2px 0 4px; }
+  /* Equity Curve 卡的专属规则随卡片一起挪走了：标题用通用 .card h3，
+     图高用通用 .chart-box（与相邻 Daily P&L 同高成对）。 */
   .chart-note > summary {
     display: inline-block; cursor: pointer; list-style: none;
     color: var(--text-tertiary); font: 600 var(--fs-micro)/1.4 var(--mono);
@@ -2285,7 +2285,6 @@
   .chart-note > p {
     margin: 4px 0 2px; color: var(--text-tertiary); font: 500 var(--fs-xs)/1.55 var(--mono);
   }
-  .overview-equity-chart { min-height: 390px; height: 390px; }
   /* The chart sits inside the mobile horizontal pager. Allow the browser to
      resolve both axes so a horizontal drag still changes tabs; pointercancel
      below clears chart hover state once scrolling takes ownership. */
@@ -2302,9 +2301,17 @@
   }
   .native-equity-window[hidden] { display: none; }
   .native-equity-window input { min-width: 0; flex: 1; accent-color: var(--accent); }
-  .overview-equity-chart { position: relative; }
+  /* tooltip 以 #chart-equity 为定位父级（原 overview-equity-chart 的 relative 职责） */
+  #chart-equity { position: relative; }
+  /* Equity Curve 卡已挪去 Reflect 净值表现区（与 Daily P&L 同区、共用市场切换器）。
+     Overview 首屏只留 hero-deck 的 spark 一条形状；今日判定从「Equity(8) + 判定(4)」
+     的伴排改为独占整行。 */
   .overview-verdict {
-    grid-column: span 4; min-height: 480px; padding: 18px;
+    grid-column: 1 / -1; padding: 18px;
+    /* 原来的 480px 地板是为和 Equity 卡凑同一行；挪走后按各档实测内容高度
+       重新预留（数据到达前占位，否则判定卡长高会把下方整列推下去 —— CLS
+       实测 0.11，预留后回到基线）。 */
+    min-height: 420px;
   }
   .overview-verdict-head,
   .overview-gates-head {
@@ -2459,14 +2466,15 @@
 
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 168px; }
-    .overview-equity, .overview-verdict, .overview-strip,
+    .overview-verdict { min-height: 430px; }
+    .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
   }
   @media (max-width: 767px) {
     .overview-command { display: flex; flex-direction: column; gap: 12px; }
     .hero-deck, .hero-health,
-    .overview-equity, .overview-verdict, .overview-strip,
+    .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { width: 100%; min-width: 0; }
     .hero-deck { grid-template-columns: minmax(0, 1fr); }
@@ -2481,9 +2489,8 @@
     .dh-file { display: none; }
     .dh-bar { grid-column: 1 / -1; }
     .dh-detail { grid-column: 1 / -1; white-space: normal; }
-    .overview-equity, .overview-verdict { min-height: 0; }
-    .overview-equity-chart { min-height: 300px; height: 300px; }
-    .overview-equity-hint { max-width: none; }
+    /* 390px 实测 486：窄屏判定卡内容折行更多，地板取上界（同 hero-rail 的取舍）。 */
+    .overview-verdict { min-height: 490px; }
     .overview-strip { display: flex; flex-direction: column; }
     .overview-strip-cell {
       min-height: 0; border-right: 0; border-bottom: 1px solid var(--border-subtle);

--- a/site/assets/js/dashboard.charts.js
+++ b/site/assets/js/dashboard.charts.js
@@ -1,9 +1,10 @@
   // ── Lazy chart init (perf) ──────────────────────────────────────────────
-  // Hero's visual anchor is native Canvas, so first paint does not fetch or parse
-  // ECharts. The heavier bundle remains tab-lazy for analytical detail charts.
+  // Overview 首屏只剩 hero-spark（render bundle 内联 SVG），不再初始化任何 canvas；
+  // 全站唯一的 native canvas 图（Equity Curve）随 Reflect 首次展示绘制。
+  // The heavier ECharts bundle remains tab-lazy for analytical detail charts.
   // Never initialize a chart in display:none.
   const NATIVE_CHART_FNS = {
-    hero: () => { renderEquityChart(); },
+    reflect: () => { renderEquityChart(); },
   };
   const CHART_FNS = {
     drill:   () => { renderShadowPortfolioChart(); renderWeightConfidence(); },
@@ -33,10 +34,11 @@
   }
   function paintCharts(t) {
     if (!DATA) return;
+    // Native 先画（无网络依赖），ECharts 系随后到随画 —— 同一 tab 可以两类都有
+    // （Reflect：Equity 是 native，其余三个是 ECharts）。
     if (NATIVE_CHART_FNS[t]) {
       readThemeCSS();
       NATIVE_CHART_FNS[t]();
-      return;
     }
     if (!CHART_FNS[t]) return;
     whenEcharts(() => {
@@ -97,13 +99,13 @@
     const dt = document.getElementById("dailypnl-title");
     if (et) et.textContent = `Equity Curve ${sfx}`;
     if (dt) dt.textContent = `Daily P&L + Cumulative ${sfx}`;
-    // A deep link can land on Reflect before Hero has ever been visible. In that
-    // case do not create Equity inside the hidden Hero panel at zero width; Hero's
-    // lazy paint will pick up MARKET_VIEW when it is eventually opened.
-    if (charts.equity || currentTab() === "hero") renderEquityChart();
-    // Reflect has already loaded ECharts. A market switch on Hero must not fetch
-    // the heavy bundle merely to refresh a hidden detail chart.
-    if (window.echarts) renderDailyPnlChart();
+    // Switcher 与两张图同住 Reflect：能点到按钮，面板必然可见。深链直达 Reflect
+    // 的首绘由 ensureVisibleCharts 负责，这里只处理切换本身；两个渲染函数各自
+    // 兜底（native 直接画，ECharts 未就绪时内部 early-return，等懒加载完成后重画）。
+    if (currentTab() === "reflect") {
+      renderEquityChart();
+      renderDailyPnlChart();
+    }
     requestAnimationFrame(() => {
       charts.equity && charts.equity.resize();
       charts.dailyPnl && charts.dailyPnl.resize();

--- a/site/index.html
+++ b/site/index.html
@@ -75,8 +75,10 @@ layout: null
      ECharts 5.6.0 (~620KB vs ~1MB full) — only the chart types and components the
      dashboard actually uses are registered, so it parses ~40% faster on mobile while
      rendering pixel-identically. Rebuild steps + component list: ops/pages/echarts-custom-bundle.md.
-     Loaded ON DEMAND by whenEcharts() the first time a chart tab is shown — Hero/Signals/
-     Plan have no charts, so phones landing on Hero never download this bundle. -->
+     Loaded ON DEMAND by whenEcharts() the first time a chart tab is shown — Overview/
+     Signals/Plan have no ECharts needs (Overview's spark is inline SVG in the render
+     bundle; its only former canvas chart moved to Reflect), so phones landing on
+     Overview never download this bundle. -->
 <link rel="stylesheet" href="assets/css/dashboard.css">
 </head>
 <body>
@@ -171,30 +173,11 @@ layout: null
           </div>
           <!-- 主数的历史，不是第二张图：同一个「总盈亏」口径画成纯形状（无坐标轴、
                无刻度、无图例），回答大数字回答不了的那半个问题——它是一路跌下来的，
-               还是刚从更深的地方爬回来的。完整可交互的曲线仍在下面那张卡里。 -->
+               还是刚从更深的地方爬回来的。完整可交互的曲线（含基准对照）在 Reflect
+               的净值表现区；首屏只保留这一条形状，不再两条同源曲线上下堆叠。 -->
           <div class="hero-spark" id="hero-spark"></div>
         </div>
         <div class="hero-rail" id="hero-rail"></div>
-      </div>
-
-      <div class="card overview-equity">
-        <div class="card-head">
-          <div>
-            <div class="overview-card-kicker">战绩</div>
-            <h3 id="equity-title">Equity Curve · USD-eq</h3>
-          </div>
-          <span id="benchmark-stale" class="muted" style="display:none;font-size:var(--fs-xs);color:var(--amber)"></span>
-          <div class="mkt-seg" role="group" aria-label="市场切换">
-            <button class="mkt-seg-btn active" data-mkt="combined"><span class="seg-dot"></span>总览</button>
-            <button class="mkt-seg-btn" data-mkt="us"><span class="seg-dot us"></span>美股</button>
-            <button class="mkt-seg-btn" data-mkt="hk"><span class="seg-dot hk"></span>港股</button>
-          </div>
-        </div>
-        <details class="chart-note overview-equity-hint">
-          <summary>口径说明与图例</summary>
-          <p>粗绿线 = 总利润（浮盈 + 已实现，净化本金）；蓝线 = 真实总资产（持仓市值 + 现金）；虚线 = 成本及动态基准。切换总览 / 美股 / 港股查看各自口径。</p>
-        </details>
-        <div id="chart-equity" class="chart-box overview-equity-chart"></div>
       </div>
 
       <aside class="card overview-verdict" aria-labelledby="overview-verdict-title">
@@ -920,16 +903,32 @@ layout: null
       </div>
     </div>
 
-    <div class="card">
+    <!-- Equity Curve 原在 Overview 首屏，和 hero-spark 是同源同算法的同一件事
+         （总盈亏历史）上下堆叠 —— kcn 反馈「首屏曲线堆叠」。挪进 Reflect 净值表现区：
+         首屏只留 spark 一条纯形状，深度曲线（总利润/总资产/成本/SPY/恒科等值 + 回撤）
+         与 Daily P&L 同区相邻、共用同一个市场切换器。id 一律不动（JS 与测试契约）。 -->
+    <div class="card" id="perf-equity-card">
       <div class="card-head">
-        <h3 id="dailypnl-title">Daily P&amp;L + Cumulative · USD-eq</h3>
+        <div>
+          <div class="overview-card-kicker">战绩</div>
+          <h3 id="equity-title">Equity Curve · USD-eq</h3>
+        </div>
+        <span id="benchmark-stale" class="muted" style="display:none;font-size:var(--fs-xs);color:var(--amber)"></span>
         <div class="mkt-seg" role="group" aria-label="市场切换">
           <button class="mkt-seg-btn active" data-mkt="combined"><span class="seg-dot"></span>总览</button>
           <button class="mkt-seg-btn" data-mkt="us"><span class="seg-dot us"></span>美股</button>
           <button class="mkt-seg-btn" data-mkt="hk"><span class="seg-dot hk"></span>港股</button>
         </div>
       </div>
-      <p class="chart-hint">每日净盈亏柱状（绿涨红跌）+ 累计盈亏曲线。柱在零下方 = 当日亏损；曲线走势看长期方向。<b>跟随上方市场切换</b>：总览=USD-eq，美股=$，港股=HK$。</p>
+      <p class="chart-hint">粗绿线 = 总利润（浮盈 + 已实现，净化本金）；蓝线 = 真实总资产（持仓市值 + 现金）；虚线 = 成本及动态基准。切换总览 / 美股 / 港股查看各自口径。</p>
+      <div id="chart-equity" class="chart-box"></div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">
+        <h3 id="dailypnl-title">Daily P&amp;L + Cumulative · USD-eq</h3>
+      </div>
+      <p class="chart-hint">每日净盈亏柱状（绿涨红跌）+ 累计盈亏曲线。柱在零下方 = 当日亏损；曲线走势看长期方向。<b>跟随上方 Equity Curve 的市场切换</b>：总览=USD-eq，美股=$，港股=HK$。</p>
       <div id="chart-daily-pnl" class="chart-box"></div>
     </div>
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -350,6 +350,9 @@ async function testEquityTouch(browser, base) {
   await stubLiveOrigin(page);
   await page.goto(base, { waitUntil: "networkidle" });
   await waitForData(page);
+  // Equity Curve 已从 Overview 挪进 Reflect（首屏曲线减负），触屏契约跟着卡片走。
+  await page.locator('.tab-btn[data-tab="reflect"]').click();
+  await waitForTab(page, "reflect");
   await page.locator(".native-equity-canvas").scrollIntoViewIfNeeded();
   const box = await page.locator(".native-equity-canvas").boundingBox();
   assert(box, "equity canvas has no layout box");
@@ -373,14 +376,16 @@ async function testEquityTouch(browser, base) {
   assert.match(hkTooltip, /% 不适用/,
     "negative-profit HK drawdown did not explain its amount fallback");
 
-  const xs = [box.x + box.width - 5, 300, 250, 200, 150, 100, 45];
+  // Reflect 已是 pager 最后一页：向左滑没有下一页，改为向右滑回上一页（plan），
+  // 验证的仍是「离开图表所在页后，悬停/点选留下的 tooltip 必须清掉」。
+  const xs = [45, 100, 150, 200, 250, 300, box.x + box.width - 5];
   await dispatchTouch(session, "touchStart", [{ x: xs[0], y }]);
   for (const x of xs.slice(1)) {
     await dispatchTouch(session, "touchMove", [{ x, y }]);
     await page.waitForTimeout(20);
   }
   await dispatchTouch(session, "touchEnd", []);
-  await page.waitForFunction(() => document.querySelector(".tab-btn.active")?.dataset.tab === "drill");
+  await page.waitForFunction(() => document.querySelector(".tab-btn.active")?.dataset.tab === "plan");
   assert.equal(await page.locator(".native-equity-tooltip").isVisible(), false,
     "pager swipe left a stale chart tooltip");
   assert.deepEqual(state.failures, []);

--- a/tests/test_dashboard_hero_native_chart.py
+++ b/tests/test_dashboard_hero_native_chart.py
@@ -6,22 +6,32 @@ CHARTS = (ROOT / "site/assets/js/dashboard.charts.js").read_text()
 UI = (ROOT / "site/assets/js/dashboard.ui.js").read_text()
 
 
-def test_hero_renderer_is_native_and_outside_echarts_gate():
+def test_equity_chart_is_native_and_outside_echarts_gate():
+    # Equity Curve 已随卡片挪到 Reflect（首屏曲线减负），但它仍是全站唯一的
+    # native canvas 图：注册在 NATIVE_CHART_FNS，绝不进 ECharts 懒加载闸 ——
+    # 否则展示它就得先拖 ~620KB 的包。
     native_block = CHARTS.split("const NATIVE_CHART_FNS", 1)[1].split("const CHART_FNS", 1)[0]
     echarts_block = CHARTS.split("const CHART_FNS", 1)[1].split("const _chartTabsShown", 1)[0]
 
-    assert "hero:" in native_block
+    assert "reflect:" in native_block
     assert "renderEquityChart()" in native_block
-    assert "hero:" not in echarts_block
+    assert "hero:" not in native_block
+    # ECharts 系注册表只管自己的三张图，不得染指 equity
+    assert "renderEquityChart" not in echarts_block
     assert "createNativeEquityChart" in CHARTS
 
 
-def test_market_switch_does_not_load_echarts_from_hero():
+def test_market_switch_renders_in_place_without_forcing_echarts_fetch():
+    # 切换器与两张图同住 Reflect：能点到按钮 = 面板可见。切换必须就地重画
+    # 两张图（native 直画；ECharts 未就绪时由其内部 early-return 兜住，
+    # 懒加载完成后经 ensureTabCharts 重画），而不是自己去 whenEcharts 拉包。
     market_block = CHARTS.split("function setMarketView", 1)[1].split(
         "function renderShadowPortfolioChart", 1
     )[0]
 
-    assert "if (window.echarts) renderDailyPnlChart()" in market_block
+    assert 'if (currentTab() === "reflect")' in market_block
+    assert "renderEquityChart()" in market_block
+    assert "renderDailyPnlChart()" in market_block
     assert "whenEcharts" not in market_block
 
 


### PR DESCRIPTION
## 背景

kcn 反馈：Overview 首屏曲线堆叠。量化确认：首屏竖向排着**两条同源曲线**——hero-deck 的 `hero-spark`（#892 加的「主数自己的历史」）和正下方 Equity Curve 卡的「总利润」线，两者数据同源、算法相同（同一个去重/同时段合并逻辑），等于同一件事在首屏画了两遍。

## 改法（挪位置 + 顺带合并控制，不删任何信息）

- **整张 Equity Curve 卡挪进 Reflect 的「净值表现 · portfolio」区**，置于 Daily P&L 卡之前：深度曲线（总利润/真实总资产/成本基础/SPY 等值/恒科等值 + 回撤）与每日 P&L 相邻成对，本来就是复盘材料。
- 两图**共用同一个市场切换器**：删掉 Daily P&L 卡头上重复的第二组 `mkt-seg`（其提示文案「跟随上方市场切换」原本就是指 Equity 的切换器，现在字面终于成立）。切换器从「在 Overview 却遥控隐藏 tab 里的图」变成所见即所控。
- **效果**：Overview 首屏曲线 2 → 1（只留 spark 一条纯形状）；判定卡从 span4 改为独占整行，首屏少一层卡片盒子。
- 所有 id 不动（`chart-equity`/`equity-title`/`benchmark-stale`），JS 与测试契约零变更面。

## 接线

- `dashboard.charts.js`：`NATIVE_CHART_FNS.hero` → `reflect`；`paintCharts` 去掉 early-return，允许同一 tab 混跑 native + ECharts（Reflect 实际就是 1 native + 3 ECharts）；`setMarketView` 守卫改为 `currentTab() === "reflect"`（切换器与两图同面板，能点到就可见）。
- Overview 首帧不再创建任何 canvas；ECharts 包依旧只在 chart tab 首次展示时按需加载。

## CLS（改动引入过一次回退，已修）

- 判定卡失去原 480px 配平地板后，数据到达长高把下方推下去：390px 实测 0.11。修法=按断点重新预留（420/430/490）+ 钉住 deck-copy 副行折行的高差（<1024px min-height:142px）。复测：**390px 0.014~0.024（master 基线 0.0376）、1440px 0.048（master 0.021）**。桌面增量来自判定卡变宽放大了既有的 highlights→gates 内部回流（master 同源现象），量级远低于 0.1 good 线，刻意不追。
- 残余归因用同 harness 对 master 复测过（含等高占位对照实验），非猜测归属。

## 验证

- 本地全量浏览器契约 `tests/dashboard_tab_runtime.spec.js` 通过（触屏契约随卡片更新：先切 Reflect 再测 tooltip/HK 切换；pager 末页改右滑回 plan 验证 tooltip 清理）
- `test_dashboard_bundle_parity.py` / brand-assets / contrast / desktop-layout-contract / pages-deployment-contract 共 31 passed
- playwright 双断点自检：Overview 曲线计数=1、无横向溢出、Reflect 双图有尺寸、单一切换器联动两卡标题、0 page error
