### PR TITLE
fix(dashboard): 移除 hero spark 末端涨跌色端点

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2127,14 +2127,6 @@
   }
   /* 端点用 DOM 元素而不是 SVG 圆：同样因为 preserveAspectRatio="none"，
      SVG 里的正圆会被压成椭圆。 */
-  .hero-spark-dot {
-    position: absolute; width: 7px; height: 7px; border-radius: 50%;
-    transform: translate(-50%, -50%); pointer-events: none;
-    box-shadow: 0 0 0 3px var(--surface-1);
-  }
-  .hero-spark-dot.pos { background: var(--positive); }
-  .hero-spark-dot.neg { background: var(--negative); }
-  .hero-spark-dot.flat { background: var(--text-tertiary); }
   /* 主数以前恒定 var(--text)：`.hero-deck-pnl` 和 `.pos/.neg` 同为一个类，
      按源序前者赢 —— 于是全页最大的那个数字是唯一一个不带涨跌色的数字，
      而它正下方那行三个小数字全都带色。全站规矩是「颜色只留涨跌」，

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -812,10 +812,7 @@
       + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
-      // 端点标记不能用 SVG 圆：preserveAspectRatio="none" 会把它压成椭圆。
-      // 用绝对定位的 DOM 点，按百分比放，形状不受拉伸影响。
-      + `<i class="hero-spark-dot ${tone}" style="left:${(x(vals.length - 1) / W * 100).toFixed(2)}%;`
-      + `top:${(y(last) / H * 100).toFixed(2)}%"></i>`;
+      // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 
   // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -803,10 +803,7 @@
       + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
-      // 端点标记不能用 SVG 圆：preserveAspectRatio="none" 会把它压成椭圆。
-      // 用绝对定位的 DOM 点，按百分比放，形状不受拉伸影响。
-      + `<i class="hero-spark-dot ${tone}" style="left:${(x(vals.length - 1) / W * 100).toFixed(2)}%;`
-      + `top:${(y(last) / H * 100).toFixed(2)}%"></i>`;
+      // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 
   // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -858,7 +858,6 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
         headline: document.getElementById("hero-pnl").textContent.trim(),
         tone: svg.classList.contains("neg") ? "neg"
           : svg.classList.contains("pos") ? "pos" : "flat",
-        dotTone: host.querySelector(".hero-spark-dot")?.className || "",
       };
     });
 
@@ -876,8 +875,6 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
       "hero spark fill is not split at the zero axis");
     assert.equal(spark.stops[1].offset, spark.stops[2].offset,
       "hero spark gradient does not hard-stop at the zero axis");
-    assert(spark.dotTone.includes(spark.tone),
-      `hero spark endpoint dot tone (${spark.dotTone}) disagrees with the curve (${spark.tone})`);
     await context.close();
   }
 


### PR DESCRIPTION
kcn 反馈：开屏 overview 折线（spark）末端的涨跌色圆点没用，去掉。

- dashboard.hero.js / dashboard.render.js：删除端点 DOM 渲染（双份同步）
- dashboard.css：删除 .hero-spark-dot 样式（pos/neg/flat）
- dashboard_tab_runtime.spec.js：删除 dotTone 断言

social card 链路未动。