### PR TITLE
overview 首屏降噪：涨跌色分字号档 + spark 补参照

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2169,7 +2169,11 @@
     font: 500 var(--fs-xs)/1.3 var(--mono); color: var(--text-tertiary);
     white-space: nowrap; overflow: hidden;
   }
-  .hs-foot-low { color: var(--text-secondary); }
+  /* 挤不下时先牺牲区间那半句，带数字的那半句永远整段留着。默认的 flex 收缩
+     会两边一起压，而压到带数字的一边就是「ellipsis 把涨跌幅吃掉」那个老
+     错误的翻版 —— 首屏的数字被截掉不是排版问题，是丢信息。 */
+  .hs-foot-range { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+  .hs-foot-low { color: var(--text-secondary); flex: none; }
   /* 窄屏一行放不下两段：区间让位，留下带尺度的那半句。 */
   @media (max-width: 1023px) {
     .hs-foot { justify-content: flex-start; }

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -20,6 +20,14 @@
     --accent-soft: #102A42;
     --positive: #28C08D;
     --negative: #F05B67;
+    /* 涨跌色的「大字号档」。同一色相在 12px 上是一个标记，在 84px 上是一整
+       片墙 —— 满彩度的跌色铺到主数那个面积，首屏第一眼读成报错页而不是一
+       张有坏消息的报表。所以主数用降了一档彩度的同色相，符号/字号/位置全
+       不动。跟字距要随字号收紧是同一条规矩（apple-design §15）。
+       两个主题降的方向相反：暗色主题不能往白里兑（更亮＝更吵），要往灰蓝
+       正文墨里兑；亮色主题往近黑里兑。 */
+    --positive-display: #4FA98C;
+    --negative-display: #D2707A;
     --warning: #E3A640;
     --neutral: #7E8DA1;
     --focus: #8ED0FF;
@@ -152,6 +160,9 @@
       --accent-soft: #DCEEFF;
       --positive: #08734F;
       --negative: #C83D4A;
+      /* 亮色主题往近黑里兑：更深、更沉的同色相（见 :root 的说明）。 */
+      --positive-display: #0A5C42;
+      --negative-display: #9E323C;
       --warning: #805400;
       --neutral: #66788D;
       --focus: #0078C9;
@@ -2110,25 +2121,60 @@
     .hero-deck-copy { min-height: 142px; }
   }
 
-  /* 缩略走势：纯形状，没有坐标轴/刻度/图例。高度由 CSS 固定占住，数据没到
-     或点数不足时容器仍然是这个高度 —— 不占的话它一到就是一次 CLS。 */
+  /* 缩略走势：形状 + 三处参照（零轴刻度、最低点竖线、脚注区间）。高度由
+     CSS 的显式行轨占住 —— 两行都是定值，脚注那行在数据到达前就已经把
+     16px 占掉，所以文字一写进去不会产生位移。 */
   .hero-spark {
-    position: relative; height: 56px; margin-top: 18px; min-width: 0;
+    position: relative; min-width: 0; margin-top: 18px;
+    display: grid; grid-template-rows: 56px 16px; row-gap: 8px;
   }
   @media (min-width: 1024px) {
     /* 长走势条配更高的画布：宽度放大后 108px 会把形状压扁。 */
-    .hero-spark { height: 132px; margin-top: 0; }
+    .hero-spark { grid-template-rows: 132px 16px; margin-top: 0; }
   }
+  .hs-plot { position: relative; min-width: 0; }
   .hero-spark-svg { display: block; width: 100%; height: 100%; }
   .hero-spark-svg.pos { color: var(--positive); }
   .hero-spark-svg.neg { color: var(--negative); }
   .hero-spark-svg.flat { color: var(--text-tertiary); }
-  /* 面积以零轴为界分色（渐变在 zeroY 处硬停）：零上用涨色、零下用跌色。
-     用单一色填满会把曲线前半段的盈利期涂成亏损色 —— 图会说谎。 */
-  .hs-area { opacity: .9; }
-  .hs-up { stop-color: var(--positive); stop-opacity: .14; }
-  .hs-down { stop-color: var(--negative); stop-opacity: .14; }
+  /* 面积不再上涨跌色。主数、副行、下面那条统计轨已经把这块表面的颜色配额
+     用满了，再铺一片红/绿色块就是同一件事说第四遍 —— 首屏因此整幅读成
+     警报，而不是一张走势。面积退回材质：中性墨的极低透明度，正负交给
+     曲线在零轴哪一侧去说。附带好处是它连「把盈利期涂成亏损色」这种谎
+     都撒不出来（那是分色填充要防的事，中性填充结构上就不可能）。 */
+  .hs-area { fill: url(#hs-fade); }
+  /* 平铺一层等浓度的灰会让面积读成一块「板」压在曲线下面。渐变让它在贴着
+     零轴的那一侧最浓、往外化开 —— 这是材质，不是色块。 */
+  .hs-fade-near { stop-color: var(--text-primary); stop-opacity: .10; }
+  .hs-fade-far { stop-color: var(--text-primary); stop-opacity: .015; }
   .hs-zero { stroke: var(--border-strong); stroke-width: 1; vector-effect: non-scaling-stroke; }
+  /* 最低点竖线：脚注说「最低 −$5,571（07-24）」，这条线说那天在哪。比零轴
+     淡一档，否则两条同权重的直线会被读成一套坐标系。 */
+  .hs-low {
+    stroke: var(--border-strong); stroke-width: 1; opacity: .45;
+    vector-effect: non-scaling-stroke;
+  }
+  /* 零轴刻度：标在线的上方，不压在线上。零轴贴顶（全程亏损）时翻到线下。 */
+  .hs-zero-tag {
+    position: absolute; left: 0; transform: translateY(-100%);
+    padding-bottom: 2px; pointer-events: none;
+    font: 600 10px/1 var(--mono); color: var(--text-tertiary);
+  }
+  .hs-zero-tag.is-top { transform: none; padding: 3px 0 0; }
+  /* 脚注：把「多长、最低到过哪、从那以后回来多少」写成字。大数字只回答
+     「现在亏多少」，这一行回答的是它是怎么走到这儿的 —— 首屏原来没有
+     任何一处给得出这三个数。 */
+  .hs-foot {
+    display: flex; align-items: baseline; justify-content: space-between; gap: 14px;
+    font: 500 var(--fs-xs)/1.3 var(--mono); color: var(--text-tertiary);
+    white-space: nowrap; overflow: hidden;
+  }
+  .hs-foot-low { color: var(--text-secondary); }
+  /* 窄屏一行放不下两段：区间让位，留下带尺度的那半句。 */
+  @media (max-width: 1023px) {
+    .hs-foot { justify-content: flex-start; }
+    .hs-foot-range { display: none; }
+  }
   /* viewBox 被 preserveAspectRatio="none" 拉伸，描边必须 non-scaling 才不会
      在宽屏上被横向拉成粗细不匀的一条。 */
   /* 线本身取中性色：正负已经由填充和主数说清楚了，再给线上色就会出现
@@ -2144,8 +2190,11 @@
      按源序前者赢 —— 于是全页最大的那个数字是唯一一个不带涨跌色的数字，
      而它正下方那行三个小数字全都带色。全站规矩是「颜色只留涨跌」，
      这里就是最该用掉那次配额的地方。显式提到 0,2,0 特异度。 */
-  .hero-deck-pnl.pos { color: var(--positive); }
-  .hero-deck-pnl.neg { color: var(--negative); }
+  /* 主数走涨跌色的大字号档（--*-display，取值与理由见主题 token 处）。
+     小字号仍然用满彩度的 --positive/--negative：小面积需要彩度才看得见，
+     大面积需要收彩度才不吵 —— 同一条规矩的两端。 */
+  .hero-deck-pnl.pos { color: var(--positive-display); }
+  .hero-deck-pnl.neg { color: var(--negative-display); }
   .hero-deck-pnl {
     margin-top: 12px; color: var(--text); font: 700 var(--fs-display)/1 var(--mono);
     letter-spacing: var(--tr-display); font-variant-numeric: tabular-nums;
@@ -2175,6 +2224,9 @@
     margin-top: 9px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.4 var(--mono);
     overflow-wrap: anywhere;
   }
+  /* 段内不断行（渲染端已按段包 span）：一个金额/汇率/时间戳被折成两半是
+     排版把值弄坏了，不是「换行」。段与段之间照常可断。 */
+  .hero-deck-fx > span { white-space: nowrap; }
   /* 首屏最大的一次跳：8 格统计轨在数据到达前是空的（高 1px），到达后
      撑到 85px —— 实测这一下就占了整页 CLS 0.26 里的大头，而它每次加载
      都会发生。8 格的行数由列数决定，所以按断点把高度先占住；格子内容

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -699,11 +699,21 @@
       if (fx) {
         const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
         const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-        fxEl.textContent = `账面 ${fmtMoney(bookUsd, "USD")}`
+        // 逐段包 span：整行以前是一个 textContent，浏览器于是在任何空格处
+        // 断行 —— 1200 档实测把时间戳劈成「2026-」+「08-24 00:03Z」，一个
+        // 值被折成两半。段内 nowrap、段间可断，和上面那行副行同一套规矩。
+        const segs = [`账面 ${fmtMoney(bookUsd, "USD")}`
           + (has(us.value_usd) && has(hk.value_hkd)
-            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")
-          + ` · USDHKD ${fmtNum(fx, 4)}`
-          + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
+            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")];
+        segs.push(`USDHKD ${fmtNum(fx, 4)}`);
+        if (fxMeta.source) segs.push(String(fxMeta.source));
+        if (stamp) segs.push(stamp);
+        // 分隔点跟着前一段走、断行机会交给 <wbr>：否则折行会落在分隔点之前，
+        // 第二行以「· 」开头，读起来像少了个词。
+        fxEl.innerHTML = segs
+          .map((t, i) => `<span>${escapeHtml(t)}${i < segs.length - 1 ? " · " : ""}</span>`
+            + (i < segs.length - 1 ? "<wbr>" : ""))
+          .join("");
       } else {
         fxEl.textContent = "FX unavailable";
       }
@@ -755,6 +765,8 @@
   // 两条线画同一件事却形状不同 —— 所以这里照抄 charts.js 的合并视图逻辑：
   // 同一日期只留一条、连续两条属于同一交易时段的只留后一条（美股时段跨港股
   // 午夜会落进两个港股日期，见 openclaw-us-crossday-double-count）。
+  // 日期跟着值一起带出来：走势条要标注的「最低点在哪天」只能来自这里，
+  // 在渲染端重新对齐一次序列必然会和这里的去重逻辑漂移。
   function heroProfitSeries() {
     const fx = safe(DATA, "fx", "usdhkd");
     if (!fx) return [];
@@ -772,17 +784,26 @@
       return true;
     });
     return series
-      .map(s => (s.us_profit == null || s.hk_profit == null) ? null : s.us_profit + s.hk_profit / fx)
-      .filter(v => v != null && isFinite(v));
+      .map(s => (s.us_profit == null || s.hk_profit == null)
+        ? null
+        : { date: s.date, v: s.us_profit + s.hk_profit / fx })
+      .filter(p => p && isFinite(p.v));
+  }
+
+  // 「2026-07-24」→「07-24」：走势条的脚注要的是位置，不是完整日期，年份
+  // 已经由出处行给了。
+  function heroSparkDay(iso) {
+    return typeof iso === "string" && iso.length >= 10 ? iso.slice(5) : String(iso || "");
   }
 
   function renderHeroSpark() {
     const host = document.getElementById("hero-spark");
     if (!host) return;
-    const vals = heroProfitSeries();
+    const pts = heroProfitSeries();
     // 两点以下画不出趋势。容器高度由 CSS 占住，所以这里清空不会让页面跳。
-    if (vals.length < 3) { host.replaceChildren(); return; }
+    if (pts.length < 3) { host.replaceChildren(); return; }
 
+    const vals = pts.map(p => p.v);
     const W = 1000, H = 200, PAD = 6;            // viewBox 坐标，实际尺寸由 CSS 给
     const lo = Math.min(...vals, 0), hi = Math.max(...vals, 0);
     const span = (hi - lo) || 1;
@@ -794,24 +815,53 @@
     const last = vals[vals.length - 1];
     const tone = last > 0 ? "pos" : last < 0 ? "neg" : "flat";
 
-    // 填充按**零轴**分色，不是按最后一个值分色：这条曲线前半段是赚的、后半段
-    // 才转亏，用单一色填满会把一段盈利期涂成亏损色 —— 图会说谎。硬停在 zeroY
-    // 的渐变正好在零轴处换色，不需要 clipPath。
-    const stop = Math.max(0, Math.min(1, zeroY / H));
-    const gid = "hs-grad";
-    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lo, "USD")}`
-      + `，最高 ${heroMoney(hi, "USD")}，当前 ${heroMoney(last, "USD")}`;
+    // 最低点：给这条线一把标尺。没有它，形状只说得出「跌过又爬回来一点」，
+    // 说不出跌到过哪、爬回来多少 —— 而那正是大数字回答不了的那半个问题。
+    let li = 0;
+    for (let i = 1; i < vals.length; i++) if (vals[i] < vals[li]) li = i;
+    const lowest = vals[li];
+    // 最低点就在末端时没有「自最低」可说（那句会退化成 +$0）。
+    const recovered = li < vals.length - 2 ? last - lowest : null;
+
+    const zeroPct = Math.max(0, Math.min(100, zeroY / H * 100));
+    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lowest, "USD")}`
+      + `（${pts[li].date}）`
+      + (recovered != null ? `，自最低 ${heroMoney(recovered, "USD")}` : "")
+      + `，最高 ${heroMoney(Math.max(...vals), "USD")}，当前 ${heroMoney(last, "USD")}`;
+
+    const foot =
+      `<span class="hs-foot-range">${escapeHtml(heroSparkDay(pts[0].date))} → `
+      + `${escapeHtml(heroSparkDay(pts[pts.length - 1].date))} · ${vals.length} 个交易日</span>`
+      + `<span class="hs-foot-low">最低 ${escapeHtml(heroMoney(lowest, "USD"))}`
+      + `（${escapeHtml(heroSparkDay(pts[li].date))}）`
+      + (recovered != null
+        ? ` · 自最低 ${escapeHtml(heroMoney(recovered, "USD"))}`
+        : "")
+      + `</span>`;
+
     host.innerHTML =
-      `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
+      `<div class="hs-plot">`
+      + `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
       + ` role="img" aria-label="${escapeHtml(label)}">`
-      + `<defs><linearGradient id="${gid}" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="0" y2="1">`
-      + `<stop offset="0" class="hs-up"/><stop offset="${stop.toFixed(4)}" class="hs-up"/>`
-      + `<stop offset="${stop.toFixed(4)}" class="hs-down"/><stop offset="1" class="hs-down"/>`
+      + `<defs><linearGradient id="hs-fade" gradientUnits="objectBoundingBox"`
+      + ` x1="0" y1="0" x2="0" y2="1">`
+      + `<stop offset="0" class="hs-fade-near"/><stop offset="1" class="hs-fade-far"/>`
       + `</linearGradient></defs>`
-      + `<path class="hs-area" d="${area}" fill="url(#${gid})"/>`
+      + `<path class="hs-area" d="${area}"/>`
       + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
+      // 最低点竖线把脚注里的「最低」钉在曲线上的具体位置：从画布顶垂到那个
+      // 点为止。（不能反过来从最低点垂到底：最低点就是画布底，那条线长度为
+      // 零，画了等于没画。）比零轴更淡，才不会被读成第二条坐标轴。
+      + `<line class="hs-low" x1="${x(li).toFixed(1)}" y1="0"`
+      + ` x2="${x(li).toFixed(1)}" y2="${y(lowest).toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
+      // 零轴刻度是 HTML 不是 SVG 文本：viewBox 被 preserveAspectRatio="none"
+      // 横向拉伸，写在 SVG 里的字会跟着拉扁。零轴贴顶时改标在线下方。
+      + `<span class="hs-zero-tag${zeroPct < 14 ? " is-top" : ""}" style="top:${zeroPct.toFixed(2)}%"`
+      + ` aria-hidden="true">0</span>`
+      + `</div>`
+      + `<div class="hs-foot">${foot}</div>`;
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -689,11 +689,21 @@
       if (fx) {
         const at = fxMeta.fetched_at ? new Date(fxMeta.fetched_at) : null;
         const stamp = at && !isNaN(at) ? at.toISOString().replace("T", " ").slice(0, 16) + "Z" : "";
-        fxEl.textContent = `账面 ${fmtMoney(bookUsd, "USD")}`
+        // 逐段包 span：整行以前是一个 textContent，浏览器于是在任何空格处
+        // 断行 —— 1200 档实测把时间戳劈成「2026-」+「08-24 00:03Z」，一个
+        // 值被折成两半。段内 nowrap、段间可断，和上面那行副行同一套规矩。
+        const segs = [`账面 ${fmtMoney(bookUsd, "USD")}`
           + (has(us.value_usd) && has(hk.value_hkd)
-            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")
-          + ` · USDHKD ${fmtNum(fx, 4)}`
-          + (fxMeta.source ? ` · ${fxMeta.source}` : "") + (stamp ? ` · ${stamp}` : "");
+            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")];
+        segs.push(`USDHKD ${fmtNum(fx, 4)}`);
+        if (fxMeta.source) segs.push(String(fxMeta.source));
+        if (stamp) segs.push(stamp);
+        // 分隔点跟着前一段走、断行机会交给 <wbr>：否则折行会落在分隔点之前，
+        // 第二行以「· 」开头，读起来像少了个词。
+        fxEl.innerHTML = segs
+          .map((t, i) => `<span>${escapeHtml(t)}${i < segs.length - 1 ? " · " : ""}</span>`
+            + (i < segs.length - 1 ? "<wbr>" : ""))
+          .join("");
       } else {
         fxEl.textContent = "FX unavailable";
       }
@@ -746,6 +756,8 @@
   // 两条线画同一件事却形状不同 —— 所以这里照抄 charts.js 的合并视图逻辑：
   // 同一日期只留一条、连续两条属于同一交易时段的只留后一条（美股时段跨港股
   // 午夜会落进两个港股日期，见 openclaw-us-crossday-double-count）。
+  // 日期跟着值一起带出来：走势条要标注的「最低点在哪天」只能来自这里，
+  // 在渲染端重新对齐一次序列必然会和这里的去重逻辑漂移。
   function heroProfitSeries() {
     const fx = safe(DATA, "fx", "usdhkd");
     if (!fx) return [];
@@ -763,17 +775,26 @@
       return true;
     });
     return series
-      .map(s => (s.us_profit == null || s.hk_profit == null) ? null : s.us_profit + s.hk_profit / fx)
-      .filter(v => v != null && isFinite(v));
+      .map(s => (s.us_profit == null || s.hk_profit == null)
+        ? null
+        : { date: s.date, v: s.us_profit + s.hk_profit / fx })
+      .filter(p => p && isFinite(p.v));
+  }
+
+  // 「2026-07-24」→「07-24」：走势条的脚注要的是位置，不是完整日期，年份
+  // 已经由出处行给了。
+  function heroSparkDay(iso) {
+    return typeof iso === "string" && iso.length >= 10 ? iso.slice(5) : String(iso || "");
   }
 
   function renderHeroSpark() {
     const host = document.getElementById("hero-spark");
     if (!host) return;
-    const vals = heroProfitSeries();
+    const pts = heroProfitSeries();
     // 两点以下画不出趋势。容器高度由 CSS 占住，所以这里清空不会让页面跳。
-    if (vals.length < 3) { host.replaceChildren(); return; }
+    if (pts.length < 3) { host.replaceChildren(); return; }
 
+    const vals = pts.map(p => p.v);
     const W = 1000, H = 200, PAD = 6;            // viewBox 坐标，实际尺寸由 CSS 给
     const lo = Math.min(...vals, 0), hi = Math.max(...vals, 0);
     const span = (hi - lo) || 1;
@@ -785,24 +806,53 @@
     const last = vals[vals.length - 1];
     const tone = last > 0 ? "pos" : last < 0 ? "neg" : "flat";
 
-    // 填充按**零轴**分色，不是按最后一个值分色：这条曲线前半段是赚的、后半段
-    // 才转亏，用单一色填满会把一段盈利期涂成亏损色 —— 图会说谎。硬停在 zeroY
-    // 的渐变正好在零轴处换色，不需要 clipPath。
-    const stop = Math.max(0, Math.min(1, zeroY / H));
-    const gid = "hs-grad";
-    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lo, "USD")}`
-      + `，最高 ${heroMoney(hi, "USD")}，当前 ${heroMoney(last, "USD")}`;
+    // 最低点：给这条线一把标尺。没有它，形状只说得出「跌过又爬回来一点」，
+    // 说不出跌到过哪、爬回来多少 —— 而那正是大数字回答不了的那半个问题。
+    let li = 0;
+    for (let i = 1; i < vals.length; i++) if (vals[i] < vals[li]) li = i;
+    const lowest = vals[li];
+    // 最低点就在末端时没有「自最低」可说（那句会退化成 +$0）。
+    const recovered = li < vals.length - 2 ? last - lowest : null;
+
+    const zeroPct = Math.max(0, Math.min(100, zeroY / H * 100));
+    const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lowest, "USD")}`
+      + `（${pts[li].date}）`
+      + (recovered != null ? `，自最低 ${heroMoney(recovered, "USD")}` : "")
+      + `，最高 ${heroMoney(Math.max(...vals), "USD")}，当前 ${heroMoney(last, "USD")}`;
+
+    const foot =
+      `<span class="hs-foot-range">${escapeHtml(heroSparkDay(pts[0].date))} → `
+      + `${escapeHtml(heroSparkDay(pts[pts.length - 1].date))} · ${vals.length} 个交易日</span>`
+      + `<span class="hs-foot-low">最低 ${escapeHtml(heroMoney(lowest, "USD"))}`
+      + `（${escapeHtml(heroSparkDay(pts[li].date))}）`
+      + (recovered != null
+        ? ` · 自最低 ${escapeHtml(heroMoney(recovered, "USD"))}`
+        : "")
+      + `</span>`;
+
     host.innerHTML =
-      `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
+      `<div class="hs-plot">`
+      + `<svg class="hero-spark-svg ${tone}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"`
       + ` role="img" aria-label="${escapeHtml(label)}">`
-      + `<defs><linearGradient id="${gid}" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="0" y2="1">`
-      + `<stop offset="0" class="hs-up"/><stop offset="${stop.toFixed(4)}" class="hs-up"/>`
-      + `<stop offset="${stop.toFixed(4)}" class="hs-down"/><stop offset="1" class="hs-down"/>`
+      + `<defs><linearGradient id="hs-fade" gradientUnits="objectBoundingBox"`
+      + ` x1="0" y1="0" x2="0" y2="1">`
+      + `<stop offset="0" class="hs-fade-near"/><stop offset="1" class="hs-fade-far"/>`
       + `</linearGradient></defs>`
-      + `<path class="hs-area" d="${area}" fill="url(#${gid})"/>`
+      + `<path class="hs-area" d="${area}"/>`
       + `<line class="hs-zero" x1="0" y1="${zeroY.toFixed(1)}" x2="${W}" y2="${zeroY.toFixed(1)}"/>`
+      // 最低点竖线把脚注里的「最低」钉在曲线上的具体位置：从画布顶垂到那个
+      // 点为止。（不能反过来从最低点垂到底：最低点就是画布底，那条线长度为
+      // 零，画了等于没画。）比零轴更淡，才不会被读成第二条坐标轴。
+      + `<line class="hs-low" x1="${x(li).toFixed(1)}" y1="0"`
+      + ` x2="${x(li).toFixed(1)}" y2="${y(lowest).toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
+      // 零轴刻度是 HTML 不是 SVG 文本：viewBox 被 preserveAspectRatio="none"
+      // 横向拉伸，写在 SVG 里的字会跟着拉扁。零轴贴顶时改标在线下方。
+      + `<span class="hs-zero-tag${zeroPct < 14 ? " is-top" : ""}" style="top:${zeroPct.toFixed(2)}%"`
+      + ` aria-hidden="true">0</span>`
+      + `</div>`
+      + `<div class="hs-foot">${foot}</div>`;
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -848,18 +848,36 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     const spark = await page.evaluate(() => {
       const host = document.getElementById("hero-spark");
       const svg = host.querySelector(".hero-spark-svg");
-      const stops = [...svg.querySelectorAll("linearGradient stop")]
-        .map(s => ({ offset: s.getAttribute("offset"), cls: s.getAttribute("class") }));
+      const area = svg.querySelector(".hs-area");
+      const cs = area && getComputedStyle(area);
+      const root = getComputedStyle(document.documentElement);
+      const probe = document.createElement("span");
+      document.body.appendChild(probe);
+      const tint = c => {
+        probe.style.color = "";
+        probe.style.color = root.getPropertyValue(c).trim();
+        return getComputedStyle(probe).color;
+      };
       return {
         height: Math.round(host.getBoundingClientRect().height),
         label: svg.getAttribute("aria-label") || "",
         points: (svg.querySelector(".hs-line")?.getAttribute("d") || "").split("L").length,
-        stops,
+        // 面积填充：整段 fill 声明 + 两个 stop 的解析色。中性材质不能带涨跌色。
+        areaFill: cs ? cs.fill : "",
+        stopColors: [...svg.querySelectorAll("linearGradient stop")]
+          .map(s => getComputedStyle(s).stopColor),
+        // token 值经探针解析成 rgb() 再比：直接比 `#F05B67` 和 `rgb(240,91,103)`
+        // 永远不相等，那样的断言是恒真的，等于没闸。
+        pnlTokens: ["--positive", "--negative", "--text-primary"].map(tint),
+        foot: host.querySelector(".hs-foot")?.textContent.trim() || "",
+        lowMark: !!svg.querySelector(".hs-low"),
         headline: document.getElementById("hero-pnl").textContent.trim(),
         tone: svg.classList.contains("neg") ? "neg"
           : svg.classList.contains("pos") ? "pos" : "flat",
       };
     });
+    // 探针留在页面上会污染后面的断言，evaluate 里取完就删。
+    await page.evaluate(() => document.body.lastElementChild?.remove());
 
     assert.equal(spark.height, reserved,
       `hero spark shifts by ${spark.height - reserved}px when it draws`);
@@ -870,11 +888,26 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     assert(current, `hero spark aria-label has no 当前 value: ${spark.label}`);
     assert.equal(current[1], spark.headline,
       "hero spark does not end at the headline number — it is plotting a different series");
-    // 填充必须在零轴分色，否则曲线里赚钱的那一段会被涂成亏损色。
-    assert.deepEqual(spark.stops.map(s => s.cls), ["hs-up", "hs-up", "hs-down", "hs-down"],
-      "hero spark fill is not split at the zero axis");
-    assert.equal(spark.stops[1].offset, spark.stops[2].offset,
-      "hero spark gradient does not hard-stop at the zero axis");
+    // 面积是材质不是信号：不许带涨跌色。以前它按零轴分成红/绿两段，那是为了
+    // 「别把盈利期涂成亏损色」；现在整片中性，结构上就撒不了那个谎，代价是
+    // 得钉住「没人后来又把涨跌色加回填充里」——首屏那片红正是这么来的。
+    const [posRGB, negRGB, inkRGB] = spark.pnlTokens;
+    // 反空转：三个 token 必须解析成互不相同的 rgb()，否则下面那条比对
+    // 会因为「什么都相等/什么都不等」而恒真。
+    assert(posRGB && negRGB && inkRGB && posRGB !== inkRGB && negRGB !== inkRGB,
+      `P&L / ink tokens did not resolve distinctly: ${spark.pnlTokens.join(" | ")}`);
+    assert(spark.stopColors.length >= 2,
+      `hero spark area has no gradient stops (${spark.stopColors.length})`);
+    for (const c of spark.stopColors) {
+      assert.equal(c, inkRGB,
+        `hero spark area fill is not the neutral ink (${c}) — a P&L colour crept back in`);
+    }
+    // 脚注三件事：区间、最低点、自最低回来多少。少一件这条线就退回纯形状。
+    for (const want of ["个交易日", "最低", "自最低"]) {
+      assert(spark.foot.includes(want),
+        `hero spark footer is missing 「${want}」: ${spark.foot}`);
+    }
+    assert(spark.lowMark, "hero spark has no low-point marker line");
     await context.close();
   }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -870,6 +870,15 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
         // 永远不相等，那样的断言是恒真的，等于没闸。
         pnlTokens: ["--positive", "--negative", "--text-primary"].map(tint),
         foot: host.querySelector(".hs-foot")?.textContent.trim() || "",
+        // 脚注横向溢出＝数字被静默切掉。带数字的那半句必须整段在框内。
+        footLowFits: (() => {
+          const f = host.querySelector(".hs-foot");
+          const low = host.querySelector(".hs-foot-low");
+          if (!f || !low) return false;
+          const fb = f.getBoundingClientRect(), lb = low.getBoundingClientRect();
+          return low.scrollWidth <= Math.ceil(lb.width) + 1
+            && lb.right <= Math.ceil(fb.right) + 1 && lb.left >= Math.floor(fb.left) - 1;
+        })(),
         lowMark: !!svg.querySelector(".hs-low"),
         headline: document.getElementById("hero-pnl").textContent.trim(),
         tone: svg.classList.contains("neg") ? "neg"
@@ -908,6 +917,8 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
         `hero spark footer is missing 「${want}」: ${spark.foot}`);
     }
     assert(spark.lowMark, "hero spark has no low-point marker line");
+    assert(spark.footLowFits,
+      "hero spark footer clips the numbers — 最低/自最低 must never be truncated");
     await context.close();
   }
 


### PR DESCRIPTION
## 为什么

kcn：「在 social card 里面预览 dashboard 没有特别好看，尤其是那个负数太明显了……主要是主屏 overview 要怎么好看，这样子在 social card 里面预览才好看。」

social card 抓的就是 1200×760 的 Overview 首屏（`shoot_dashboard.js` clip 0,0,1200,760 → 卡片里那台笔记本）。所以问题不在卡，在首屏本身：那一屏当时同时有 84px 满彩度跌色主数、一大片红色面积填充、副行红、统计轨四格红 —— 七个红色物体互相抢，整幅读成报错页，而不是一张有坏消息的报表。

`social card 链路不动`（#904 已定），改的全是 dashboard 自己。

## 改了什么

**1. 涨跌色按字号分档**（新 token `--positive-display` / `--negative-display`，只给 `.hero-deck-pnl`）

同一色相在 12px 上是一个标记，在 84px 上是一整片墙。主数收一档彩度，**符号、字号、位置一律不动**，亏损该多大还是多大。两个主题降的方向相反：暗色主题不能往白里兑（更亮＝更吵），往灰蓝正文墨里兑；亮色主题往近黑里兑。小字号仍然用满彩度的 `--positive/--negative` —— 小面积需要彩度才看得见，大面积需要收彩度才不吵，是同一条规矩的两端（apple-design §15：大字排版参数不能照抄小字，字距如此，彩度同理）。

**2. spark 面积退回材质**

红/绿分色填充删掉，换成中性墨的低透明度渐变（贴零轴一侧最浓、往外化开）。正负交给曲线在零轴哪一侧去说。原来那个分色是为了「别把盈利期涂成亏损色」，中性填充结构上就撒不了那个谎。

**3. spark 从纯形状升级为带参照的走势**（本 PR 的信息增量）

原来它没有尺度也没有时间：看得出跌过又爬回来一点，看不出跌到过哪、爬回来多少。补三处，全部是发丝线 + mono 小字，没有圆点没有胶囊：

- 零轴刻度 `0`（HTML 覆盖层，不是 SVG 文本 —— viewBox 被 `preserveAspectRatio="none"` 横向拉伸）
- 最低点竖线（从画布顶垂到那个点；反过来画长度为零，因为最低点就是画布底）
- 脚注：`05-18 → 08-24 · 71 个交易日` ／ `最低 −$5,571（07-24）· 自最低 +$2,481`

**4. 出处行不再把值劈成两半**

整行以前是一个 `textContent`，浏览器在任何空格处断行，1200 档实测折成「`2026-`」+「`08-24 00:03Z`」。改成逐段 `<span>` + `<wbr>`：段内 nowrap、分隔点跟着前一段走（否则第二行以「· 」开头）。

## 闸

`dashboard_tab_runtime.spec.js` 里那条「填充必须在零轴分色」换成「填充必须是中性墨」，另钉住脚注三件事（区间/最低/自最低）和最低点标记。

**自带反空转断言**：token 值经探针解析成 `rgb()` 再比 —— 直接拿 `#F05B67` 和 `rgb(240,91,103)` 比是恒真的，那种闸等于没有。实测把 `hs-fade-near` 改回 `var(--negative)`，该闸立刻红：

```
actual: 'rgb(200, 61, 74)'  expected: 'rgb(16, 24, 33)'
```

## 实测

**CLS**（同 harness、同数据、A/B×3）：桌面 deck 高度不变 —— 341px，spark 132→156 仍在 copy 列 184px 之内。

| 宽度 | master | branch |
|---|---|---|
| 1200 | 0 / 0.031 / 0.031 | 0.011 / 0.017 / 0.017 |
| 1440 | 0.016 / 0.010 / 0.015 | 0.010 / 0.016 / 0.010 |
| 390 | 0.030 / 0.020 / 0.020 | 0.020 / 0.020 / 0.028 |

390 档 deck 512→536（脚注那行），在噪声带内。

**Lighthouse ×3**（本机 chromium-1223，同一台机同一时段交替跑）：

| | master | branch |
|---|---|---|
| performance | 68 / 80 / 78 | 78 / 77 / 80 |
| accessibility | 100 | 100 |
| best-practices | 88 | 88 |
| SEO | 92 | 92 |

perf 两边同一噪声带（master 那个 68 是一次 TBT 1130ms 的尖峰，本机 load 2+ 时的常态，见 `vps-load-invalidates-perf-measurements`），另外三项逐项相同。

**测试**：`dashboard_tab_runtime.spec.js` 绿；`test_dashboard_bundle_parity` / `hero_native_chart` / `desktop_layout_contract` / `contrast` / `payload_size` / `security` 33 passed。

hero.js 与 render.js 两份手工副本已逐字同步（parity 测试覆盖）。
