### PR TITLE
CI: CodeQL push 闸搬到 job 的 if——数据 commit 不再起三个 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
     # Was actionlint.yml: a 12-second lint should not pay for its own workflow
     # file, its own trigger block and its own runner on every event. The job
     # name keeps the required `lint` context byte-identical.
+    #
+    # It is also this workflow's scope job, and deliberately not a *new* job:
+    # it already runs on every event and already pays a checkout to classify
+    # the push, so `analyze` can read the answer from here instead of starting
+    # three runners to compute it again (#910). Adding a separate `scope` job
+    # would have cost every run an extra runner to save three on 22% of pushes.
+    outputs:
+      analysable: ${{ steps.scope.outputs.analysable }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -101,23 +109,28 @@ jobs:
       # .github/workflows/ instead; undiffable ranges lint anyway (fail toward
       # running a 12s check rather than skipping it). Classification lives in
       # ops/ci/push_scope.py — the same classifier the other two gates read.
-      - name: Did any workflow file change?
+      #
+      # The whole classification is published (not just `workflows=`): the
+      # `analysable` lane is what gates CodeQL below. Non-push events answer
+      # "everything" for both lanes — a PR is always linted and always
+      # analysed, which is what the required contexts need.
+      - name: Classify this event
         id: scope
         env:
           BASE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" != "push" ]; then
-            echo "workflows=true" >> "$GITHUB_OUTPUT"
+            printf 'workflows=true\nanalysable=true\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ -n "${BASE_SHA:-}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
              && git fetch --quiet --depth=1 origin "${BASE_SHA}"; then
             python3 ops/ci/push_scope.py --base "${BASE_SHA}" --head HEAD \
-              | grep '^workflows=' >> "$GITHUB_OUTPUT"
+              | tee -a "$GITHUB_OUTPUT"
           else
-            echo "no diffable base (${BASE_SHA:-}) — linting"
-            echo "workflows=true" >> "$GITHUB_OUTPUT"
+            echo "no diffable base (${BASE_SHA:-}) — linting and analysing"
+            printf 'workflows=true\nanalysable=true\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install pinned actionlint
@@ -631,7 +644,26 @@ jobs:
     # private ignore-list — plus the data-path guard below for the handful of
     # watched-but-unanalysable files this trigger does list (portfolio.json,
     # memory plans/theses).
+    #
+    # The gate moved from a step to the job (#910). It used to live in two
+    # `if:`s on the CodeQL steps, which meant an unanalysable push still
+    # started three runners, checked out the tree and re-ran the classifier
+    # just to conclude there was nothing to do — measured 6 of the last 27
+    # push runs, three jobs each. Reading `lint`'s classification instead
+    # skips the jobs outright.
+    #
+    # `always()` is required because `needs: lint` would otherwise cancel this
+    # job whenever lint is skipped, and `needs.lint.result != 'success'` is the
+    # fail-open half: if the classifier could not run, analyse. A gate that
+    # silently drops CodeQL when its input is missing is the failure mode this
+    # repository has been bitten by before — a discovery gate must fail toward
+    # doing the work. test_ci_codeql_gate.py pins both halves.
     name: Analyze (${{ matrix.language }})
+    needs: lint
+    if: >-
+      ${{ always() && (github.event_name != 'push'
+          || needs.lint.result != 'success'
+          || needs.lint.outputs.analysable == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -656,28 +688,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Push lane only: skip the analysis when every changed path is one of the
-      # automation-written data paths that carry no analysable code. Mirrors
-      # the ignore-list codeql.yml carried when this lived in its own file;
-      # undiffable ranges analyse anyway (fail toward running).
-      - name: Did the push touch anything analysable?
-        id: scope
-        if: github.event_name == 'push'
-        env:
-          BASE_SHA: ${{ github.event.before }}
-        run: |
-          set -euo pipefail
-          if [ -n "${BASE_SHA:-}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
-             && git fetch --quiet --depth=1 origin "${BASE_SHA}"; then
-            python3 ops/ci/push_scope.py --base "${BASE_SHA}" --head HEAD \
-              | grep '^analysable=' >> "$GITHUB_OUTPUT"
-          else
-            echo "no diffable base (${BASE_SHA:-}) — analysing"
-            echo "analysable=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Initialize CodeQL
-        if: github.event_name != 'push' || steps.scope.outputs.analysable == 'true'
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
@@ -688,7 +699,6 @@ jobs:
           # separate decision with its own alert backlog.
 
       - name: Perform CodeQL analysis
-        if: github.event_name != 'push' || steps.scope.outputs.analysable == 'true'
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/tests/test_ci_codeql_gate.py
+++ b/tests/test_ci_codeql_gate.py
@@ -1,0 +1,55 @@
+"""CodeQL's push gate lives in exactly one place and fails toward analysing.
+
+#910 moved the gate out of the `analyze` job's steps and into its `if:`, so a
+pure-data push stops three runners from starting at all instead of starting
+them to discover there is nothing to do.  That is a cheap win with an expensive
+failure mode: a gate whose input goes missing must not silently drop CodeQL.
+The `if:` therefore has three independent escapes, and this test pins all of
+them — plus the fact that nobody re-added a second gate inside the steps.
+"""
+import pathlib
+import yaml
+
+CI = pathlib.Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
+WF = yaml.safe_load(CI.read_text(encoding="utf-8"))
+JOBS = WF["jobs"]
+
+
+def test_lint_publishes_the_classification_analyze_reads():
+    outputs = JOBS["lint"].get("outputs") or {}
+    assert "analysable" in outputs, (
+        "lint is the workflow's scope job; it must publish `analysable`")
+    assert "steps." in outputs["analysable"], (
+        "the output must come from the classifier step, not a literal")
+    step = next(s for s in JOBS["lint"]["steps"] if s.get("id") == "scope")
+    assert "ops/ci/push_scope.py" in step["run"], (
+        "the published classification must come from the shared classifier")
+
+
+def test_analyze_is_gated_on_lint_and_fails_open():
+    analyze = JOBS["analyze"]
+    needs = analyze["needs"]
+    assert needs == "lint" or "lint" in needs, "analyze must read lint's output"
+
+    cond = " ".join(analyze["if"].split())
+    # 1) a skipped/failed `needs` skips the dependent job unless always()
+    assert "always()" in cond, (
+        "without always() a failed lint would silently skip CodeQL")
+    # 2) never gate a pull_request — those contexts are required checks
+    assert "github.event_name != 'push'" in cond, (
+        "PRs must always be analysed; their CodeQL contexts are required")
+    # 3) classifier unavailable => analyse anyway
+    assert "needs.lint.result != 'success'" in cond, (
+        "a lint that did not succeed must fail toward analysing")
+    # 4) the actual scope answer
+    assert "needs.lint.outputs.analysable == 'true'" in cond
+
+
+def test_the_gate_is_not_duplicated_inside_the_steps():
+    """Two gates drift apart; that is how #750 happened. The job-level `if:` is
+    the only one, so the CodeQL steps themselves must carry no condition."""
+    for step in JOBS["analyze"]["steps"]:
+        uses = step.get("uses", "")
+        if "codeql-action" in uses:
+            assert "if" not in step, (
+                f"{uses} re-grew its own gate; the job-level if: owns this")

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -86,14 +86,18 @@ def test_no_inline_lane_classification_left_in_the_workflow():
     python -c one-liner."""
     from workflow_contract_helpers import step_block
 
-    assert TEXT.count("ops/ci/push_scope.py") >= 3, (
-        "detector, lint scope and CodeQL scope all route through one classifier")
+    # Two invocations, not three: #910 deleted CodeQL's own copy and made the
+    # `analyze` job read `lint`'s published classification instead of starting
+    # three runners to recompute it. What must stay true is the property this
+    # test was written for — every gate reads the one classifier, and none of
+    # them grows its own diff-parsing bash.
+    assert TEXT.count("ops/ci/push_scope.py") >= 2, (
+        "the lint/scope job and the detector both route through one classifier")
     assert "ops/ci/smoke_fx.py" in TEXT, (
         "smoke-data-fetch must run the script, not an inline python -c")
 
-    for step in ("Did any workflow file change?",
+    for step in ("Classify this event",
                  "Detect code changes",
-                 "Did the push touch anything analysable?",
                  "FX fallback chain"):
         block = step_block(CI, step)
         assert "python3 -c" not in block and 'case "$f"' not in block, (


### PR DESCRIPTION
## 为什么

kcn：「如果 skip 的话是不是可以连 CI 都不用启动？就前置跳过做得到吗」+「不过要看看当初为什么拆成那么多个」。

**先查了「当初为什么拆成三个」——不是设计，是三个月里各自长出来的：**

| 文件 | 出生 | 当时的理由 |
|---|---|---|
| `harness-regression.yml` | 2026-05-16 | 和 ECharts dashboard 一起诞生，就是测试套件本体 |
| `actionlint.yml` | 2026-07-16 | 加固 cron 契约时新增的关注点 → 顺手开了个新文件 |
| `codeql.yml` | 2026-08-22 | 只比合并早两天：default setup 不能路径过滤，为了省 ~55 分钟/天才切 advanced，必须自带文件 |

三者之间没有任何结构性理由要分开（permissions 是 job 级、concurrency 合并后更对、required context 取自 job 名不是文件名）。所以 #885 是补债，这一步同理。

## 实测的浪费

过去 27 次 push CI，**6 次（22%）是 `analysable=false`**，全是 `portfolio:` / `dashboard: intraday refresh`。这 6 次里三个 `Analyze` job 各起一个 runner、各 checkout、各跑一次分类器，然后跳过两个真步骤收工——每个 6-9 秒（今天 run 32736632417 实测：6s / 9s / 7s）。

## 改法：不新增 job

`lint` 本来就每个事件都跑、本来就 checkout 并跑了一次 `push_scope.py`。让它把分类发布出去，`analyze` 用 `needs` + job 级 `if` 读：

```yaml
lint:
  outputs:
    analysable: ${{ steps.scope.outputs.analysable }}

analyze:
  needs: lint
  if: >-
    ${{ always() && (github.event_name != 'push'
        || needs.lint.result != 'success'
        || needs.lint.outputs.analysable == 'true') }}
```

**为什么不加一个独立的 `scope` job**：那样每次运行都多付一个 runner，去省 22% 的 push 上的三个——账是反的。`lint` 已经在做这件事了。

## 闸朝「分析」失败，三条独立逃生口

静默丢掉 CodeQL 正是这仓库反复踩的形状，所以：

1. `always()` —— 没有它，`needs` 被跳过/失败时依赖 job 会**静默跳过**；
2. `github.event_name != 'push'` —— PR 永远全量分析（它的 CodeQL 上下文是 required check，被过滤掉就永远 pending）；
3. `needs.lint.result != 'success'` —— 分类器拿不到答案就分析；外加 `lint` 自己对无法 diff 的 push 答 `analysable=true`。

## 闸的闸

新增 `tests/test_ci_codeql_gate.py`：钉住四条 `if` 子句、`lint.outputs` 的接线来源（必须来自 `push_scope.py` 那个 step，不能是字面量），以及**「步骤里不许再长出第二个闸」**——两个闸必然漂移，#750 就是这么来的。

`test_ci_consolidation_contract` 里「三处 `push_scope.py`」改成两处（CodeQL 那份被删了），它真正要守的性质（任何 gate 都不许长出内联 diff 解析 bash）原样保留，step 名单同步。

## 验证

- `actionlint 1.7.12` 绿（与 CI 用的同一版本、同一 SHA256）
- `test_ci_codeql_gate.py` / `test_ci_consolidation_contract.py` / `test_push_scope.py` / `test_ci_trigger_paths.py` → 37 passed
- required check 上下文一个字没动：`lint` / `validate` / `Analyze (actions)` / `Analyze (javascript-typescript)` / `Analyze (python)` / `CodeQL`
