### PR TITLE
perf-review wave 1: fail-closed brief postflight + delivery-first ordering + per-slot IO trims

### DIFF
--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -37,6 +37,13 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          # Chain deadline (brief-fallback 2026-08-17 defect class): a hung
+          # primary must not eat the whole job before the fallback answers.
+          # This scan retries the whole chain once on failure, so the budget is
+          # sized for two chains inside the 8-minute job: 2 x 210s = 7min,
+          # leaving setup/validate/commit their share. Relevance-filter outputs
+          # are tiny — both legs fit comfortably.
+          CLAWOCK_LLM_DEADLINE_SECONDS: '210'
         run: clawock-influencer-scan
 
       - name: Validate influencer coverage

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -29,6 +29,12 @@ jobs:
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          # Same defect brief-fallback fixed on 2026-08-17: without a chain
+          # deadline a hung primary burns timeout(180)x3 per provider and the
+          # runner kills this 10-minute job before the fallback is ever asked.
+          # 360s leaves room for the serial fetch loop (~3.6min worst case)
+          # plus validate/commit/push inside the job budget.
+          CLAWOCK_LLM_DEADLINE_SECONDS: '360'
         run: clawock-news-digest
 
       - name: Validate generated digest

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -29,6 +29,12 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          # Chain deadline (brief-fallback 2026-08-17 defect class): without it
+          # a hung primary burns timeout(180)x3 per provider inside a 12-minute
+          # job and the fallback is unreachable. 600s of 720s leaves the
+          # validate + commit steps their share; the review prose fits both
+          # legs at that size.
+          CLAWOCK_LLM_DEADLINE_SECONDS: '600'
         run: clawock-weekly-review
 
       - name: Validate generated review

--- a/src/clawock/automation/cron_heartbeat.py
+++ b/src/clawock/automation/cron_heartbeat.py
@@ -8,9 +8,11 @@ under the same lock, avoiding another independent git writer.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -78,50 +80,68 @@ def _atomic_write(path: Path, data: dict) -> None:
     os.replace(tmp, path)
 
 
+@contextmanager
+def _locked():
+    """Same convention as workflow_outcomes._locked(): record() is an unlocked
+    read-modify-write over a shared ledger and the writers genuinely overlap —
+    the intraday watchdog fires slot+10min while the model turn can run ~16min,
+    so postflight's 'completed' and a watchdog backstop can race. Without the
+    lock one writer's ledger silently erases the other's event (false gap in
+    the published coverage sidecar). Derived from LOCAL_PATH so test fixtures
+    that redirect it stay isolated."""
+    lock_path = LOCAL_PATH.with_suffix(LOCAL_PATH.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        yield
+
+
 def record(market: str, state: str, *, at: datetime | None = None,
            job_name: str | None = None, slot: str | None = None, **details) -> dict:
     now = _now(at)
     derived_name, derived_slot = slot_for(market, now)
     job_name = job_name or derived_name
     slot = slot or derived_slot
-    ledger, from_disk = _load()
-    # A brand-new ledger gets stamped with real wall-clock now inside _empty();
-    # anchor monitoring_started_at to this first record's slot boundary instead,
-    # otherwise the current slot (crons fire a few minutes past the boundary)
-    # is judged as "before monitoring began" and silently dropped from coverage.
-    # Only re-anchor when no ledger existed on disk — a valid ledger that merely
-    # has no live events keeps its real monitoring epoch (don't erase earlier gaps).
-    was_fresh = not from_disk
-    cutoff = now - timedelta(hours=KEEP_HOURS)
-    events = []
-    current = None
-    for event in ledger.get("events", []):
-        try:
-            event_time = datetime.fromisoformat(event["slot"])
-            if event_time.tzinfo is None:
-                event_time = event_time.replace(tzinfo=HKT)
-        except Exception:
-            continue
-        if event_time.astimezone(timezone.utc) < cutoff:
-            continue
-        if event.get("job") == job_name and event.get("slot") == slot:
-            current = dict(event)
-        else:
-            events.append(event)
-    current = current or {"job": job_name, "market": market, "slot": slot}
-    current.update({"state": state, "updated_at": now.isoformat()})
-    for key, value in details.items():
-        if value is not None:
-            current[key] = value
-    events.append(current)
-    events.sort(key=lambda e: (e.get("slot", ""), e.get("job", "")))
-    ledger["schema_version"] = SCHEMA_VERSION
-    if was_fresh:
-        ledger["monitoring_started_at"] = slot
-    ledger.setdefault("monitoring_started_at", now.isoformat())
-    ledger["updated_at"] = now.isoformat()
-    ledger["events"] = events
-    _atomic_write(LOCAL_PATH, ledger)
+    # Lock spans load→merge→write (same convention as workflow_outcomes).
+    with _locked():
+        ledger, from_disk = _load()
+        # A brand-new ledger gets stamped with real wall-clock now inside _empty();
+        # anchor monitoring_started_at to this first record's slot boundary instead,
+        # otherwise the current slot (crons fire a few minutes past the boundary)
+        # is judged as "before monitoring began" and silently dropped from coverage.
+        # Only re-anchor when no ledger existed on disk — a valid ledger that merely
+        # has no live events keeps its real monitoring epoch (don't erase earlier gaps).
+        was_fresh = not from_disk
+        cutoff = now - timedelta(hours=KEEP_HOURS)
+        events = []
+        current = None
+        for event in ledger.get("events", []):
+            try:
+                event_time = datetime.fromisoformat(event["slot"])
+                if event_time.tzinfo is None:
+                    event_time = event_time.replace(tzinfo=HKT)
+            except Exception:
+                continue
+            if event_time.astimezone(timezone.utc) < cutoff:
+                continue
+            if event.get("job") == job_name and event.get("slot") == slot:
+                current = dict(event)
+            else:
+                events.append(event)
+        current = current or {"job": job_name, "market": market, "slot": slot}
+        current.update({"state": state, "updated_at": now.isoformat()})
+        for key, value in details.items():
+            if value is not None:
+                current[key] = value
+        events.append(current)
+        events.sort(key=lambda e: (e.get("slot", ""), e.get("job", "")))
+        ledger["schema_version"] = SCHEMA_VERSION
+        if was_fresh:
+            ledger["monitoring_started_at"] = slot
+        ledger.setdefault("monitoring_started_at", now.isoformat())
+        ledger["updated_at"] = now.isoformat()
+        ledger["events"] = events
+        _atomic_write(LOCAL_PATH, ledger)
     # Tests and one-off callers redirect LOCAL_PATH to an isolated fixture. Do
     # not let that write a second ledger in the real workspace.
     if LOCAL_PATH == WS / "memory" / ".tmp" / "cron-heartbeats.json":

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -261,7 +261,7 @@ def _derive_final(record):
                     in {None, "published", "current", "skipped"}
                 )
             )
-            or preflight == "warning"
+            or preflight in {"warning", "failed"}
         )
         status = "degraded" if degraded else "success"
         reason = (

--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -171,11 +171,21 @@ def sync_gha_data_files(ws=None):
         if fetch.returncode != 0:
             return False, f'fetch failed: {fetch.stderr[-150:]}'
 
+        relpaths = [f'assets/data/{f}' for f in GHA_DATA_FILES]
+        # Fast path: one checkout for the whole batch (this chain runs on every
+        # postflight slot; N spawns here were N needless git startups).
+        batch = subprocess.run(
+            ['git', 'checkout', 'origin/master', '--', *relpaths],
+            capture_output=True, text=True, timeout=10, cwd=str(ws),
+        )
+        if batch.returncode == 0:
+            return True, f'synced {len(GHA_DATA_FILES)}/{len(GHA_DATA_FILES)}'
+        # A missing artifact on origin would fail the whole batch — fall back to
+        # the per-file checkout so the files that do exist still refresh.
         synced = []
         for f in GHA_DATA_FILES:
-            relpath = f'assets/data/{f}'
             r = subprocess.run(
-                ['git', 'checkout', 'origin/master', '--', relpath],
+                ['git', 'checkout', 'origin/master', '--', f'assets/data/{f}'],
                 capture_output=True, text=True, timeout=10, cwd=str(ws),
             )
             if r.returncode == 0:

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -541,8 +541,10 @@ BRIEF_FALLBACK_WORKFLOW = 'brief-fallback.yml'
 # brief-fallback.yml refuses to build a pre-open brief anyway. Observed runtime is
 # ~5-8 min (2026-08-11: 8m01s), so 15 min covers a slow run without risking the
 # hard cutoff, and a timeout here is reported as 'pending', never as success.
+# 60s polling halves the gh spawn count against a ~5-8min run; the worst-case
+# +30s detection lag is irrelevant for a message that lives for hours.
 BRIEF_FALLBACK_POLL_BUDGET_S = 15 * 60
-BRIEF_FALLBACK_POLL_INTERVAL_S = 30
+BRIEF_FALLBACK_POLL_INTERVAL_S = 60
 
 
 def _parse_iso(value):
@@ -885,6 +887,11 @@ def last_report_text(session_id, first_line):
     found = None
     try:
         for line in p.read_text().splitlines():
+            # Substring prefilter before json.loads: transcripts are dominated
+            # by tool-result lines this function can never match, and each
+            # parsed-but-rejected line costs a full json.loads.
+            if not first_line or first_line not in line:
+                continue
             try:
                 e = json.loads(line)
             except Exception:
@@ -952,6 +959,11 @@ def transcript_loop_score(session_id):
     txt = []
     try:
         for line in p.read_text().splitlines():
+            # Cheap prefilter: only assistant-role lines serialize the literal
+            # `"assistant"`, and tool-result bulk (most of every transcript)
+            # never contributes text here.
+            if '"assistant"' not in line:
+                continue
             try:
                 e = json.loads(line)
             except Exception:

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -800,15 +800,6 @@ def main(argv=None):
                          + ('\n- ...' if len(issues) > 5 else '')
                          + '\n\n')
 
-    commit_ok, commit_msg = maybe_commit(
-        publication_status, today, dry_run=args.dry_run
-    )
-    if (status in ('pass', 'warn') and projection_ready
-            and not args.dry_run):
-        data_plane_status = dashboard_publication_state(WS)
-    else:
-        data_plane_status = 'skipped'
-
     # ── WeChat delivery (decoupled from the cron's announce) ──────────────────
     # The cron now runs delivery=none. The announce used to fire at the END of a
     # long agent turn with a token captured at turn START → expired mid-turn
@@ -895,6 +886,23 @@ def main(argv=None):
             if not wechat_sent:
                 print(f'warn: WeChat send failed (watchdog will retry): {str(send_out)[:200]}',
                       file=sys.stderr)
+
+    # ── Commit AFTER delivery (report/intraday order, #765) ───────────────────
+    # maybe_commit runs log_decisions + rebuild_dashboard + git push — seconds of
+    # local work the reader never sees. Delivering first means the card lands a
+    # full dashboard-rebuild earlier and brief_watchdog's 08:30 pass finds the
+    # sent-marker already written instead of racing a still-running postflight
+    # (the TG double-card window). The card itself is order-independent: it reads
+    # the LLM's brief-card file, or plan fields (book/decisions) that
+    # log_decisions never rewrites.
+    commit_ok, commit_msg = maybe_commit(
+        publication_status, today, dry_run=args.dry_run
+    )
+    if (status in ('pass', 'warn') and projection_ready
+            and not args.dry_run):
+        data_plane_status = dashboard_publication_state(WS)
+    else:
+        data_plane_status = 'skipped'
 
     result = {
         'status':        status,

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from clawock.workspace import workspace_root
+from clawock.safe_io import safe_write_json, safe_write_text
 from clawock import sessions as trading_calendar
 from clawock.context import brief as brief_context
 from clawock.decision import ledger as decision_v2
@@ -251,9 +252,10 @@ def normalize_plan_json(path, ledger_path=None, *, decision_packet=None,
                 normalized, decision_packet
             )
         if write and normalized != authored:
-            path.write_text(
-                json.dumps(normalized, ensure_ascii=False, indent=2) + '\n'
-            )
+            # Atomic write: this process is SIGTERM-prone (60s exec timeout,
+            # #508/#765) and a torn plan.json would fail every downstream
+            # consumer the same day.
+            safe_write_json(str(path), normalized)
     except Exception as exc:
         return _normalization_result(
             [f'plan.json 标准化失败: {exc}'], authored, return_plan
@@ -375,6 +377,22 @@ def validate_plan_json(path, context=None, decision_packet=None):
             if s.get('ticker') not in cut_tickers:
                 issues.append(f'杠杆硬止损未处理: {s["ticker"]} ({s["detail"]}) — plan 里没有对应 cut')
     return issues
+
+
+def load_preflight_context(ctx_path):
+    """Return (context, blocking_issue) for today's preflight bundle.
+
+    Fail closed: with a missing or unparseable context every context-dependent
+    gate in main() would silently no-op while the ledger still recorded
+    ``success`` — so both cases surface as a critical issue ('解析失败' /
+    '缺失' are in CRITICAL_KEYWORDS) instead of a quiet None.
+    """
+    if not ctx_path.exists():
+        return None, 'brief context 缺失（preflight 未产出 memory/.tmp bundle）'
+    try:
+        return json.loads(ctx_path.read_text()), None
+    except Exception as exc:
+        return None, f'brief context 解析失败: {exc}'
 
 
 def validate_markdown(path, context=None):
@@ -501,7 +519,7 @@ def log_decisions(today):
     for d in plan['decisions']:
         if d.get('simulated_entry_price') is None:
             d['simulated_entry_price'] = _current_price_for(d.get('ticker'))
-    plan_path.write_text(json.dumps(plan, ensure_ascii=False, indent=2) + '\n')
+    safe_write_json(str(plan_path), plan)
     inserted, updated = decision_v2.upsert_plan_decisions(plan)
     ledger = decision_v2.load_decisions()
     settled = decision_v2.settle_decisions(ledger)
@@ -627,7 +645,9 @@ def _ensure_jekyll_front_matter(md_path, date):
             f'风控硬闸与 AI 自评战绩（诚实公开，承认主动操作跑输躺平）。')
     fm = (f'---\nlayout: default\ntitle: 盘前深度简报 · {date}\n'
           f'description: "{desc}"\n---\n\n')
-    md_path.write_text(fm + content)
+    # Atomic write — the GHA fallback publishes this file straight to Pages; a
+    # torn write here would ship half a brief.
+    safe_write_text(str(md_path), fm + content)
 
 
 def main(argv=None):
@@ -662,17 +682,17 @@ def main(argv=None):
     # Ensure Jekyll can render this brief as a Pages page (not just GitHub blob jump)
     _ensure_jekyll_front_matter(md_path, today)
 
-    # Load preflight context (for cross-validation)
+    # Load preflight context (for cross-validation). Fail closed: a missing or
+    # unparseable context would silently skip every context-dependent hard gate
+    # below (generation pin, position/leverage回查, peer divergence,
+    # macro/sentiment) while the ledger still recorded success.
     ctx_path = WS / 'memory' / '.tmp' / f'brief-context-{today}.json'
-    context = None
-    if ctx_path.exists():
-        try:
-            context = json.loads(ctx_path.read_text())
-        except Exception:
-            pass
+    context, context_issue = load_preflight_context(ctx_path)
 
     readability = assess_brief_readability(md_path)
     issues = []
+    if context_issue:
+        issues.append(context_issue)
     manifest_path = ctx_path.with_suffix('') / 'manifest.json'
     decision_packet = None
     if context and context.get('generation_id'):

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -207,6 +207,11 @@ def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
         "date": today,
         "decisions": [_authored_decision()],
     }))
+    # A present-but-minimal context: postflight fails closed without one, and
+    # this test exercises plan normalization, not the context gate.
+    ctx_dir = tmp_path / "memory" / ".tmp"
+    ctx_dir.mkdir()
+    (ctx_dir / f"brief-context-{today}.json").write_text("{}")
     observed = {}
 
     def assert_normalized(path, **_kwargs):
@@ -247,6 +252,10 @@ def test_dry_run_validates_normalized_plan_without_rewriting_source(
         "decisions": [_authored_decision()],
     })
     plan_path.write_text(authored)
+    # Present-but-minimal context: postflight fails closed without one.
+    ctx_dir = tmp_path / "memory" / ".tmp"
+    ctx_dir.mkdir(parents=True, exist_ok=True)
+    (ctx_dir / f"brief-context-{today}.json").write_text("{}")
     before_mtime = plan_path.stat().st_mtime_ns
     observed = {}
     validate = brief_postflight.validate_plan_json

--- a/tests/test_brief_postflight_fail_closed.py
+++ b/tests/test_brief_postflight_fail_closed.py
@@ -1,0 +1,48 @@
+"""brief_postflight must fail closed when the preflight context is unusable.
+
+Regression for the silent-green path: a missing or unparseable
+memory/.tmp/brief-context-{today}.json used to leave ``context=None``, which
+skipped every context-dependent hard gate (generation pin, position/leverage
+回查, peer divergence, macro/sentiment) while the ledger recorded success.
+"""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+from clawock.harness import brief_postflight  # noqa: E402
+from clawock.harness.validation import categorize_issues  # noqa: E402
+
+
+def test_missing_context_yields_a_critical_issue(tmp_path):
+    context, issue = brief_postflight.load_preflight_context(
+        tmp_path / 'brief-context-2026-08-25.json'
+    )
+
+    assert context is None
+    assert issue and '缺失' in issue
+    status = categorize_issues([issue], brief_postflight.CRITICAL_KEYWORDS, warn_max=4)
+    assert status == 'fail'
+
+
+def test_unparseable_context_yields_a_critical_issue(tmp_path):
+    ctx = tmp_path / 'brief-context-2026-08-25.json'
+    ctx.write_text('{"generation_id": "truncated"', encoding='utf-8')
+
+    context, issue = brief_postflight.load_preflight_context(ctx)
+
+    assert context is None
+    assert issue and '解析失败' in issue
+    status = categorize_issues([issue], brief_postflight.CRITICAL_KEYWORDS, warn_max=4)
+    assert status == 'fail'
+
+
+def test_readable_context_still_loads_without_an_issue(tmp_path):
+    ctx = tmp_path / 'brief-context-2026-08-25.json'
+    ctx.write_text('{"generation_id": "abc123"}', encoding='utf-8')
+
+    context, issue = brief_postflight.load_preflight_context(ctx)
+
+    assert context == {'generation_id': 'abc123'}
+    assert issue is None

--- a/tests/test_llm_workflow_deadlines.py
+++ b/tests/test_llm_workflow_deadlines.py
@@ -1,0 +1,62 @@
+"""Every off-host LLM workflow must give its provider chain a deadline.
+
+brief-fallback learned this on 2026-08-17: MiniMax hit RemoteDisconnected,
+started retrying inside a per-attempt timeout=900 x MAX_RETRIES=3 budget, and
+the runner killed the 15-minute job before opencode-go was ever asked. The
+chain deadline (`CLAWOCK_LLM_DEADLINE_SECONDS`) is opt-in — a workflow that
+forgets it silently re-creates that failure mode. This file exists so the next
+new workflow cannot forget.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DEADLINE_KEY = "CLAWOCK_LLM_DEADLINE_SECONDS"
+
+# (workflow file, job id) for every job that invokes an LLM provider chain.
+LLM_JOBS = [
+    ("brief-fallback.yml", "fallback"),
+    ("news-digest.yml", "digest"),
+    ("influencer-scan.yml", "scan"),
+    ("weekly-review.yml", "review"),
+]
+
+
+def _workflow(name):
+    return yaml.safe_load(
+        (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+    )
+
+
+def _deadline_seconds(job):
+    """The chain budget wherever the workflow declares it: job-level env or any
+    step-level env."""
+    scopes = [job.get("env") or {}]
+    scopes += [step.get("env") or {} for step in job.get("steps", [])]
+    values = [s[DEADLINE_KEY] for s in scopes if DEADLINE_KEY in s]
+    assert values, (
+        f"{DEADLINE_KEY} missing — without a chain deadline a hung primary "
+        f"makes the fallback provider unreachable (2026-08-17 defect class)"
+    )
+    return float(values[0])
+
+
+@pytest.mark.parametrize("workflow_name,job_id", LLM_JOBS)
+def test_the_provider_chain_fits_inside_the_job(workflow_name, job_id):
+    job = _workflow(workflow_name)["jobs"][job_id]
+
+    budget = _deadline_seconds(job)
+    job_seconds = float(job["timeout-minutes"]) * 60
+
+    assert budget < job_seconds, (
+        f"{workflow_name}: the LLM budget must fit inside the job, or the "
+        f"second provider is unreachable code rather than a fallback"
+    )
+    assert job_seconds - budget >= 60, (
+        f"{workflow_name}: setup, validation and commit still have to fit in "
+        f"what is left of the job"
+    )

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -58,6 +58,22 @@ def test_stages_remain_independent_and_primary_delivery_can_be_degraded(
     assert record["stages"]["watchdog_delivery"]["status"] == "unknown"
 
 
+def test_preflight_failure_degrades_a_delivered_product(tmp_path, monkeypatch):
+    # A failed preflight (e.g. unreadable context bundle) must never combine
+    # with a successful primary delivery into a clean "success" verdict.
+    _isolate(tmp_path, monkeypatch)
+    slot = "2026-07-24T08:00:00+08:00"
+    job = "盘前深度简报"
+
+    outcomes.record_stage(job, "preflight", "failed", slot=slot,
+                          reason="brief context 解析失败")
+    outcomes.record_stage(job, "llm", "success", slot=slot)
+    outcomes.record_stage(job, "postflight", "success", slot=slot)
+    record = outcomes.record_stage(job, "primary_delivery", "success", slot=slot)
+
+    assert record["final_product"]["status"] == "degraded"
+
+
 def test_readability_advisory_detail_does_not_degrade_a_delivered_product(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Wave 1 of the 4-agent perf/stability review (ctx / harness / providers+automation slices). Fixes #911, fixes #912, fixes #913, fixes #914.

## Commits

**fix: fail closed on unusable brief context; atomic postflight writes**
- brief_postflight: missing/unparseable `brief-context-{date}.json` used to leave `context=None` — every context-dependent hard gate silently no-oped while the ledger recorded success. Now a critical issue → status=fail → no commit/delivery (watchdog still mirrors raw artifacts). Safe for the GHA fallback path: its workflow always runs preflight before postflight.
- brief_postflight: plan.json write-back, log_decisions rewrite and Jekyll front-matter rewrite go through `safe_io` (tmp+os.replace) — this process is SIGTERM-prone (#508/#765 class torn-file risk).
- workflow_outcomes: primary success + preflight failed now derives `degraded`, not `success`.
- cron_heartbeat: record() load→merge→write holds a flock (same convention as workflow_outcomes) — the watchdog backstop at slot+10min genuinely overlaps a ≤16min model turn.

**perf: deliver the brief before the slow local commit; trim per-slot IO**
- brief_postflight: WeChat/TG delivery now happens BEFORE maybe_commit (report/intraday order, #765) — card lands one dashboard-rebuild earlier and brief_watchdog's slot+30min pass no longer races a running postflight (TG double-card window). Card content is order-independent: it reads the LLM card file or plan fields log_decisions never rewrites.
- sync_gha_data_files: one batched git checkout for all GHA data files (per-file fallback kept).
- _watchdog_common: transcript scans skip json.loads on lines that cannot match; brief-fallback poll interval 30s→60s (budget unchanged, timeout still reports pending).

## Tests
- new `tests/test_brief_postflight_fail_closed.py` (missing/unparseable context → critical)
- outcomes regression: preflight failed + primary success → degraded
- normalization tests pin the minimal-context path
- full suite: 470 passed, 2 xfailed; only failure is `test_context_audit_covers_every_profile.py::test_the_bare_command_audits_every_profile`, which fails identically on clean e9cbb1b4 (pre-existing, unrelated)

Wave 2 candidates filed as #915 (workflow deadlines), #916 (DAG orchestration + caches), #917 (llm/providers cleanup), #918 (deferred bundle).