### PR TITLE
overview 首屏第四层：主数收字号 + 去重复 + 统计轨四格带图（玻璃质感）

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -105,7 +105,11 @@
   /* 主数是首屏唯一主角（Stocks 个股页的报价位）：5.8vw 斜率让 1440 落在
      ~84px、1200 落在 ~70px；下限提到 32，390px 端 nowrap 禁断行的约束
      没有变松（7 字形 ≈150px，远窄于内容列）。 */
-  --fs-display: clamp(32px, 5.8vw, 84px);
+  /* 84px 是给「第一次看见」设计的；这块面板是天天看的东西，一眼扫的是形状
+     不是逐位读数，84px 让主数变成一堵墙（kcn 2026-08-24：「数字太大了，
+     dashboard 一眼天天看」）。收到 56px：仍然是全页最大、仍然一眼先看到，
+     但和判词、统计轨回到同一张版面里。 */
+  --fs-display: clamp(30px, 4vw, 56px);
   /* 判词档（overview-status 的盘中判定句）：display(64) 与 lg(15) 之间原来
      是真空，而判词此前只有 12px —— 全页语义最重的一句话是全页最小的字之一，
      比统计轨的 13px 还小（语义倒置）。补在 28-34 档，桌面落在区间内。 */
@@ -2107,7 +2111,10 @@
        副行单行宽），数据一到 deck 就长高 ~20px。按 <1024 的 142px 同款
        思路，≥1024 也按数据态实高占位：184 = 锁列后扫宽 copy 数据态实高
        上界（副行两行触顶），pre/post 同高即零位移。 */
-    .hero-deck-copy { min-height: 184px; }
+    /* 数据态实测上界 111px（≥1300 档，主数 56px + 副行一行 + 出处行一行），
+       取 112。主数从 84 收到 56、副行去掉「今日」、出处行去掉账面之后，原来
+       那个 184 就成了一块 70px 的空洞：左栏文字停在半空，右栏图一直到底。 */
+    .hero-deck-copy { min-height: 112px; }
     /* 光学对位：主数基线与 spark 零轴带（零轴的纵位随数据浮动，能钉住的
        是这条带）差 ≤ 半行。整体上提 4px 纯绘制偏移，不动布局、不产生位移。 */
     .hero-deck-copy { position: relative; top: -4px; }
@@ -2118,7 +2125,7 @@
      可见位移面积变大，CLS 实测 390px 从 ~0.037 回退到 ~0.11。142 = 数据态
      实测（sub 两行 + fx 一行）；桌面单行放得下，不需要预留。 */
   @media (max-width: 1023px) {
-    .hero-deck-copy { min-height: 142px; }
+    .hero-deck-copy { min-height: 88px; }
   }
 
   /* 缩略走势：形状 + 三处参照（零轴刻度、最低点竖线、脚注区间）。高度由
@@ -2129,10 +2136,25 @@
     display: grid; grid-template-rows: 56px 16px; row-gap: 8px;
   }
   @media (min-width: 1024px) {
-    /* 长走势条配更高的画布：宽度放大后 108px 会把形状压扁。 */
-    .hero-spark { grid-template-rows: 132px 16px; margin-top: 0; }
+    /* 长走势条配更高的画布：宽度放大后 108px 会把形状压扁。主数收到 56px 之后
+       这块面板的重心从「一个大数字」挪到「一张图」，画布跟着抬到 190px。 */
+    .hero-spark { grid-template-rows: 190px 16px; margin-top: 0; }
   }
-  .hs-plot { position: relative; min-width: 0; }
+  /* 图坐在一格玻璃凹槽里：顶边受光、内壁一圈发丝、槽底比面板略沉。
+     刻意不是第二层毛玻璃 —— 半透明面叠半透明面会把可读性叠没
+     （apple-design §12），凹槽只借它的光影语汇，不再叠一层 blur。 */
+  .hs-plot {
+    position: relative; min-width: 0; border-radius: 14px; overflow: hidden;
+    background:
+      linear-gradient(180deg,
+        color-mix(in srgb, var(--surface-1) 60%, transparent),
+        color-mix(in srgb, var(--surface-1) 12%, transparent) 62%,
+        transparent);
+    box-shadow:
+      inset 0 1px 0 var(--spec-1),
+      inset 0 0 0 1px color-mix(in srgb, var(--border-subtle) 55%, transparent),
+      inset 0 -14px 24px -22px rgba(0, 0, 0, .45);
+  }
   .hero-spark-svg { display: block; width: 100%; height: 100%; }
   .hero-spark-svg.pos { color: var(--positive); }
   .hero-spark-svg.neg { color: var(--negative); }
@@ -2145,8 +2167,12 @@
   .hs-area { fill: url(#hs-fade); }
   /* 平铺一层等浓度的灰会让面积读成一块「板」压在曲线下面。渐变让它在贴着
      零轴的那一侧最浓、往外化开 —— 这是材质，不是色块。 */
-  .hs-fade-near { stop-color: var(--text-primary); stop-opacity: .10; }
-  .hs-fade-far { stop-color: var(--text-primary); stop-opacity: .015; }
+  /* 面积从中性墨换成品牌蓝：中性那版把首屏读成了一张灰卡（kcn 2026-08-24：
+     「灰度太灰了，作为开屏不吸引人」）。蓝不是涨跌色 —— 它不参与「这段是赚
+     还是亏」的表述，那件事由曲线在零轴哪一侧、以及主数的符号回答，所以它既
+     不会撒谎，也不会再给首屏添一块红。 */
+  .hs-fade-near { stop-color: var(--accent); stop-opacity: .20; }
+  .hs-fade-far { stop-color: var(--accent); stop-opacity: .015; }
   .hs-zero { stroke: var(--border-strong); stroke-width: 1; vector-effect: non-scaling-stroke; }
   /* 最低点竖线：脚注说「最低 −$5,571（07-24）」，这条线说那天在哪。比零轴
      淡一档，否则两条同权重的直线会被读成一套坐标系。 */
@@ -2156,7 +2182,7 @@
   }
   /* 零轴刻度：标在线的上方，不压在线上。零轴贴顶（全程亏损）时翻到线下。 */
   .hs-zero-tag {
-    position: absolute; left: 0; transform: translateY(-100%);
+    position: absolute; left: 10px; transform: translateY(-100%);
     padding-bottom: 2px; pointer-events: none;
     font: 600 10px/1 var(--mono); color: var(--text-tertiary);
   }
@@ -2184,7 +2210,7 @@
   /* 线本身取中性色：正负已经由填充和主数说清楚了，再给线上色就会出现
      「红线压在绿色盈利区上」这种自相矛盾的画面。 */
   .hs-line {
-    fill: none; stroke: var(--text-secondary); stroke-width: 1.75;
+    fill: none; stroke: var(--accent-strong); stroke-width: 2;
     stroke-linejoin: round; stroke-linecap: round;
     vector-effect: non-scaling-stroke;
   }
@@ -2237,9 +2263,11 @@
      行数是固定的（标签 / 值 / 变化 / 备注），不会因为数据长短再变。
      min-height 而不是 height：真渲染出来更高时不裁。 */
   .hero-rail {
-    display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
+    display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
     border-top: 1px solid var(--border-subtle);
-    min-height: 85px;
+    /* 每格多了一件图形（比例条 / 每日柱）+ 一行说明，比纯数字那版高一档。
+       152 = 四格并排时的数据态实测（768~1920 全档同高）。 */
+    min-height: 152px;
     /* 左基线走容器 inset（track 内缩），列距用 gap —— 格内不再各带左
        padding，第一格文本与 hero-deck-lead 的内容左缘严格对齐。 */
     padding: 0 var(--card-inset); column-gap: 16px;
@@ -2264,6 +2292,52 @@
   }
   .hero-rail-d.pos { color: var(--positive); }
   .hero-rail-d.neg { color: var(--negative); }
+  /* 比例条 = 玻璃凹槽 + 受光填充：槽内壁一圈高光边、槽口一道内阴影，填充
+     顶边亮一线。和 spark 的凹槽同一套光影语汇，一眼是同族材质。 */
+  .rc-meter {
+    /* 和每日柱共用一条 30px 的图形带（上下留白把 6px 的条压在中线上）：
+       否则一行里 6px 的条和 30px 的柱图会让四格的说明行高低不齐。 */
+    margin-top: 9px; height: 6px; border-radius: 3px; overflow: hidden;
+    margin-top: 21px; margin-bottom: 12px;
+    background: color-mix(in srgb, var(--text-primary) 7%, transparent);
+    box-shadow: inset 0 1px 1.5px rgba(0, 0, 0, .10), inset 0 0 0 1px var(--spec-1);
+  }
+  .rc-meter > i {
+    display: block; height: 100%; border-radius: 3px;
+    background: linear-gradient(180deg,
+      color-mix(in srgb, var(--accent) 72%, #fff), var(--accent));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .55);
+  }
+  /* 每日盈亏柱：零轴居中，正上负下。柱子小、面积小，所以用满彩度的涨跌色
+     ——「小面积要彩度才看得见，大面积要收彩度才不吵」是同一条规矩的两端。 */
+  .rc-bars {
+    position: relative; margin-top: 9px; height: 30px; border-radius: 6px;
+    margin-bottom: 9px;
+    background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border-subtle) 45%, transparent);
+  }
+  .rc-bars::before {
+    content: ""; position: absolute; left: 6px; right: 6px; top: 50%; height: 1px;
+    background: color-mix(in srgb, var(--border-strong) 70%, transparent);
+  }
+  .rc-bars > i {
+    position: absolute; border-radius: 1.5px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .4);
+  }
+  .rc-bars > i.up { background: var(--positive); }
+  .rc-bars > i.down { background: var(--negative); }
+  .rc-bars > i.flat { background: var(--text-tertiary); }
+  .rc-cap {
+    color: var(--text-tertiary);
+    font: 500 var(--fs-xs)/1.3 var(--mono);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  /* 窄屏两列时「主动 call · n=82 · 3 未能核验」放不下一行，nowrap+ellipsis
+     会把「3 未能核验」整段吃掉 —— 那不是排版取舍，是把一个数字删了
+     （和 #909 脚注、#890 副行同一族缺陷）。窄屏改成允许折行。 */
+  @media (max-width: 767px) {
+    .rc-cap { white-space: normal; overflow: visible; text-overflow: clip; }
+  }
   .hero-rail-s {
     margin-top: 5px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.35 var(--font);
     font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -2557,7 +2631,7 @@
   .hl-chip.hl-alert { color: var(--red); font-weight: 600; }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 168px; }
+    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
     /* 506：要点行升到 44px 后 768px 端横幅折行的实测上界（504）+2。 */
     .overview-verdict { min-height: 506px; }
     .overview-verdict, .overview-strip,
@@ -2576,7 +2650,8 @@
     /* 252 而不是 248：430-767px 这一段「主动 call · n=76 · 9 未能核验」那格
        的备注折成两行，比 390px 窄档高 4px。取上界，宁可窄档多留 4px 空白
        也不要宽档跳一下。（去掉两格重复后是 3 行，不是原来的 4 行。） */
-    .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 252px; }
+    /* 两列 × 两行 + 每格一件图形：293 = 360~600 全档数据态实测上界。 */
+    .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 293px; }
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
     }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -685,14 +685,14 @@
     // 三段各自成一个 span：CSS 让段内 nowrap、段间可折行。原来整行是
     // `nowrap + text-overflow: ellipsis`，390px 上稳定截在「今日 +$807.18…」，
     // 今日涨跌幅从来没显示过 —— 首屏截掉一个数字就是丢信息，不是排版取舍。
+    // 「今日」从这里拿掉：它在下面统计轨里有自己的一格，而且那一格还带 14 天
+    // 的每日柱。同一个数在一屏里出现两次不是信息更全，是把首屏读成一张对账单
+    // （kcn 2026-08-24：「下面其实和中间数字信息重复」）。副行只留主数拆不出来
+    // 的那一半：落袋 vs 浮动。
     subEl.innerHTML =
       `<span class="hds-seg">已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b></span>`
       + `<span class="hds-sep">·</span>`
-      + `<span class="hds-seg">浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b></span>`
-      + `<span class="hds-sep">·</span>`
-      + `<span class="hds-seg">今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
-      + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "")
-      + `</span>`;
+      + `<span class="hds-seg">浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b></span>`;
 
     const fxEl = document.getElementById("fx-rate-usd");
     if (fxEl) {
@@ -702,10 +702,10 @@
         // 逐段包 span：整行以前是一个 textContent，浏览器于是在任何空格处
         // 断行 —— 1200 档实测把时间戳劈成「2026-」+「08-24 00:03Z」，一个
         // 值被折成两半。段内 nowrap、段间可断，和上面那行副行同一套规矩。
-        const segs = [`账面 ${fmtMoney(bookUsd, "USD")}`
-          + (has(us.value_usd) && has(hk.value_hkd)
-            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")];
-        segs.push(`USDHKD ${fmtNum(fx, 4)}`);
+        // 账面总额也拿掉了：它逐字等于统计轨里美股 + 港股两格之和（换算后），
+        // 首屏因此有两处在说同一笔钱。这一行退回它本来的职责——出处：汇率、
+        // 汇率来源、取数时刻。
+        const segs = [`USDHKD ${fmtNum(fx, 4)}`];
         if (fxMeta.source) segs.push(String(fxMeta.source));
         if (stamp) segs.push(stamp);
         // 分隔点跟着前一段走、断行机会交给 <wbr>：否则折行会落在分隔点之前，
@@ -720,9 +720,6 @@
     }
 
     // 分市场的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
-    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
-    const usTodayPct = legPct(us.value_usd, us.today_change_usd);
-    const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
     // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
     // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
@@ -732,29 +729,70 @@
       + (s ? `<div class="hero-rail-s">${s}</div>` : "") + `</div>`;
     const withDelta = (v, delta, cls) =>
       `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
+
+    // 比例条：玻璃凹槽 + 受光的填充。条本身不带涨跌色 —— 它答的是「这笔钱有
+    // 多大一块」，不是赚还是亏，上涨跌色会把两个问题搅在一起。
+    const railMeter = (pct, caption) => {
+      const w = (pct == null || !isFinite(pct)) ? null : Math.max(0, Math.min(100, pct));
+      return `<div class="rc-meter" aria-hidden="true">`
+        + (w == null ? "" : `<i style="width:${w.toFixed(1)}%"></i>`)
+        + `</div><div class="rc-cap">${caption}</div>`;
+    };
+
+    // 近 n 个交易日的每日盈亏柱。数据源就是 spark 那条序列的一阶差分 ——
+    // 同源同算法，不另开一条口径（首屏两处画同一件事却对不上，是这块面板
+    // 反复出过的问题）。
+    const railDailyBars = (n) => {
+      const pts = heroProfitSeries();
+      if (pts.length < 3) return `<div class="rc-bars" aria-hidden="true"></div>`;
+      const d = [];
+      for (let i = Math.max(1, pts.length - n); i < pts.length; i++) {
+        d.push({ date: pts[i].date, v: pts[i].v - pts[i - 1].v });
+      }
+      const maxAbs = Math.max(...d.map(x => Math.abs(x.v)), 1);
+      const w = 100 / d.length;
+      const bars = d.map((x, i) => {
+        const h = Math.max(4, Math.abs(x.v) / maxAbs * 46);
+        const cls = x.v > 0 ? "up" : x.v < 0 ? "down" : "flat";
+        const pos = x.v >= 0 ? `bottom:50%` : `top:50%`;
+        return `<i class="${cls}" style="left:${(i * w).toFixed(2)}%;`
+          + `width:${Math.max(1.2, w * 0.58).toFixed(2)}%;${pos};height:${h.toFixed(1)}%"></i>`;
+      }).join("");
+      const up = d.filter(x => x.v > 0).length;
+      return `<div class="rc-bars" role="img" aria-label="`
+        + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
+        + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
+    };
+    // 统计轨 6 格 → 4 格，每格自带一件图形。六格全是数字时它读成一张对账单，
+    // 而首屏是天天看的东西：看的是形状，不是逐位读数（kcn 2026-08-24：「数字
+    // 太多太乱，下面多点图好看」）。
+    //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
+    //   · 今日 —— 美港合并成一个 USD-eq 数（原来两格是同一件事的两个货币面），
+    //             省下的位置给近 14 个交易日的每日盈亏柱：一格里第一次能看出
+    //             「今天这根在最近的分布里算大还是算小」
+    //   · 遵守率 30d —— 值 + 量表条
+    // 自评 Brier 挪出首屏：它在 Reflect 的 Brier 卡、决策带 KPI、Plan 三处都在，
+    // 首屏这一格是全站第四份。
+    const shareUs = (has(us.value_usd) && has(bookUsd) && bookUsd > 0)
+      ? us.value_usd / bookUsd * 100 : null;
+    const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
+      ? (hk.value_hkd / fx) / bookUsd * 100 : null;
     railEl.innerHTML = [
       cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
-        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
+        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd)),
+        railMeter(shareUs, `占账面 ${shareUs == null ? DASH : shareUs.toFixed(0) + "%"}`)),
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
-        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
-      cell("今日美股", withDelta(heroMoney(us.today_change_usd, "USD"),
-        usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
-      cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
-        hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
-      // 「已实现 · USD-eq」和「浮动 · USD-eq」曾经在这里各占一格，而它们和
-      // 主数下面那行副行是**逐字相同**的两个数（跨 tab 数字差集实测：这两个
-      // 值在全站只出现在这两处，副行一处、统计轨一处，相距 30px）。同一个
-      // 数字在一屏内说两遍不是「信息更全」，是把八格里的两格用掉了。
-      // 副行保留它们，这里不再重复。
+        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
+        railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
+      cell("今日", withDelta(heroMoney(todayUsd, "USD"),
+        todayPct == null ? "" : fmtPct(todayPct), pnlClass(todayPct)),
+        railDailyBars(20), pnlClass(todayUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
-        `主动 call · n=${ae.known == null ? DASH : ae.known}`
-        + (ae.stranded ? ` · ${ae.stranded} 未能核验` : "")),
-      cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
-        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`
-        + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
-        m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
+        railMeter(ae.rate == null ? null : ae.rate * 100,
+          `主动 call · n=${ae.known == null ? DASH : ae.known}`
+          + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
     ].join("");
 
     renderHeroSpark();

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -675,14 +675,14 @@
     // 三段各自成一个 span：CSS 让段内 nowrap、段间可折行。原来整行是
     // `nowrap + text-overflow: ellipsis`，390px 上稳定截在「今日 +$807.18…」，
     // 今日涨跌幅从来没显示过 —— 首屏截掉一个数字就是丢信息，不是排版取舍。
+    // 「今日」从这里拿掉：它在下面统计轨里有自己的一格，而且那一格还带 14 天
+    // 的每日柱。同一个数在一屏里出现两次不是信息更全，是把首屏读成一张对账单
+    // （kcn 2026-08-24：「下面其实和中间数字信息重复」）。副行只留主数拆不出来
+    // 的那一半：落袋 vs 浮动。
     subEl.innerHTML =
       `<span class="hds-seg">已实现 <b class="${pnlClass(realUsd)}">${heroMoney(realUsd, "USD")}</b></span>`
       + `<span class="hds-sep">·</span>`
-      + `<span class="hds-seg">浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b></span>`
-      + `<span class="hds-sep">·</span>`
-      + `<span class="hds-seg">今日 <b class="${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}</b>`
-      + (todayPct != null ? ` <span class="${pnlClass(todayPct)}">${fmtPct(todayPct)}</span>` : "")
-      + `</span>`;
+      + `<span class="hds-seg">浮动 <b class="${pnlClass(unrealUsd)}">${heroMoney(unrealUsd, "USD")}</b></span>`;
 
     const fxEl = document.getElementById("fx-rate-usd");
     if (fxEl) {
@@ -692,10 +692,10 @@
         // 逐段包 span：整行以前是一个 textContent，浏览器于是在任何空格处
         // 断行 —— 1200 档实测把时间戳劈成「2026-」+「08-24 00:03Z」，一个
         // 值被折成两半。段内 nowrap、段间可断，和上面那行副行同一套规矩。
-        const segs = [`账面 ${fmtMoney(bookUsd, "USD")}`
-          + (has(us.value_usd) && has(hk.value_hkd)
-            ? ` / ${fmtMoney(us.value_usd * fx + hk.value_hkd, "HKD")}` : "")];
-        segs.push(`USDHKD ${fmtNum(fx, 4)}`);
+        // 账面总额也拿掉了：它逐字等于统计轨里美股 + 港股两格之和（换算后），
+        // 首屏因此有两处在说同一笔钱。这一行退回它本来的职责——出处：汇率、
+        // 汇率来源、取数时刻。
+        const segs = [`USDHKD ${fmtNum(fx, 4)}`];
         if (fxMeta.source) segs.push(String(fxMeta.source));
         if (stamp) segs.push(stamp);
         // 分隔点跟着前一段走、断行机会交给 <wbr>：否则折行会落在分隔点之前，
@@ -710,9 +710,6 @@
     }
 
     // 分市场的今日涨跌幅：原来的 Today's P&L 卡有这两个数，合并后不能丢
-    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
-    const usTodayPct = legPct(us.value_usd, us.today_change_usd);
-    const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
     const ae = safe(m, "execution_by_kind", "active") || {};
     // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
     // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
@@ -722,29 +719,70 @@
       + (s ? `<div class="hero-rail-s">${s}</div>` : "") + `</div>`;
     const withDelta = (v, delta, cls) =>
       `${v} <span class="hero-rail-d ${cls || ""}">${delta}</span>`;
+
+    // 比例条：玻璃凹槽 + 受光的填充。条本身不带涨跌色 —— 它答的是「这笔钱有
+    // 多大一块」，不是赚还是亏，上涨跌色会把两个问题搅在一起。
+    const railMeter = (pct, caption) => {
+      const w = (pct == null || !isFinite(pct)) ? null : Math.max(0, Math.min(100, pct));
+      return `<div class="rc-meter" aria-hidden="true">`
+        + (w == null ? "" : `<i style="width:${w.toFixed(1)}%"></i>`)
+        + `</div><div class="rc-cap">${caption}</div>`;
+    };
+
+    // 近 n 个交易日的每日盈亏柱。数据源就是 spark 那条序列的一阶差分 ——
+    // 同源同算法，不另开一条口径（首屏两处画同一件事却对不上，是这块面板
+    // 反复出过的问题）。
+    const railDailyBars = (n) => {
+      const pts = heroProfitSeries();
+      if (pts.length < 3) return `<div class="rc-bars" aria-hidden="true"></div>`;
+      const d = [];
+      for (let i = Math.max(1, pts.length - n); i < pts.length; i++) {
+        d.push({ date: pts[i].date, v: pts[i].v - pts[i - 1].v });
+      }
+      const maxAbs = Math.max(...d.map(x => Math.abs(x.v)), 1);
+      const w = 100 / d.length;
+      const bars = d.map((x, i) => {
+        const h = Math.max(4, Math.abs(x.v) / maxAbs * 46);
+        const cls = x.v > 0 ? "up" : x.v < 0 ? "down" : "flat";
+        const pos = x.v >= 0 ? `bottom:50%` : `top:50%`;
+        return `<i class="${cls}" style="left:${(i * w).toFixed(2)}%;`
+          + `width:${Math.max(1.2, w * 0.58).toFixed(2)}%;${pos};height:${h.toFixed(1)}%"></i>`;
+      }).join("");
+      const up = d.filter(x => x.v > 0).length;
+      return `<div class="rc-bars" role="img" aria-label="`
+        + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
+        + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
+    };
+    // 统计轨 6 格 → 4 格，每格自带一件图形。六格全是数字时它读成一张对账单，
+    // 而首屏是天天看的东西：看的是形状，不是逐位读数（kcn 2026-08-24：「数字
+    // 太多太乱，下面多点图好看」）。
+    //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
+    //   · 今日 —— 美港合并成一个 USD-eq 数（原来两格是同一件事的两个货币面），
+    //             省下的位置给近 14 个交易日的每日盈亏柱：一格里第一次能看出
+    //             「今天这根在最近的分布里算大还是算小」
+    //   · 遵守率 30d —— 值 + 量表条
+    // 自评 Brier 挪出首屏：它在 Reflect 的 Brier 卡、决策带 KPI、Plan 三处都在，
+    // 首屏这一格是全站第四份。
+    const shareUs = (has(us.value_usd) && has(bookUsd) && bookUsd > 0)
+      ? us.value_usd / bookUsd * 100 : null;
+    const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
+      ? (hk.value_hkd / fx) / bookUsd * 100 : null;
     railEl.innerHTML = [
       cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
-        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd))),
+        `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd)),
+        railMeter(shareUs, `占账面 ${shareUs == null ? DASH : shareUs.toFixed(0) + "%"}`)),
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
-        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd))),
-      cell("今日美股", withDelta(heroMoney(us.today_change_usd, "USD"),
-        usTodayPct == null ? "" : fmtPct(usTodayPct), pnlClass(usTodayPct)), "", pnlClass(us.today_change_usd)),
-      cell("今日港股", withDelta(heroMoney(hk.today_change_hkd, "HKD"),
-        hkTodayPct == null ? "" : fmtPct(hkTodayPct), pnlClass(hkTodayPct)), "", pnlClass(hk.today_change_hkd)),
-      // 「已实现 · USD-eq」和「浮动 · USD-eq」曾经在这里各占一格，而它们和
-      // 主数下面那行副行是**逐字相同**的两个数（跨 tab 数字差集实测：这两个
-      // 值在全站只出现在这两处，副行一处、统计轨一处，相距 30px）。同一个
-      // 数字在一屏内说两遍不是「信息更全」，是把八格里的两格用掉了。
-      // 副行保留它们，这里不再重复。
+        `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
+        railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
+      cell("今日", withDelta(heroMoney(todayUsd, "USD"),
+        todayPct == null ? "" : fmtPct(todayPct), pnlClass(todayPct)),
+        railDailyBars(20), pnlClass(todayUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
-        `主动 call · n=${ae.known == null ? DASH : ae.known}`
-        + (ae.stranded ? ` · ${ae.stranded} 未能核验` : "")),
-      cell("自评 Brier", m.brier == null ? DASH : m.brier.toFixed(3),
-        `vs LOO ${m.brier_baseline_loo == null ? DASH : m.brier_baseline_loo.toFixed(3)}`
-        + (safe(m, "calibration", "active", "n") != null ? ` · active n=${m.calibration.active.n}` : ""),
-        m.brier_beats_baseline === true ? "pos" : m.brier_beats_baseline === false ? "neg" : ""),
+        railMeter(ae.rate == null ? null : ae.rate * 100,
+          `主动 call · n=${ae.known == null ? DASH : ae.known}`
+          + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
     ].join("");
 
     renderHeroSpark();

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -703,10 +703,35 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
         segCount: segs.length,
       };
     });
-    assert.equal(sub.segCount, 3, "hero sub-line should render 已实现 / 浮动 / 今日 as three segments");
+    // 副行现在是两段：「今日」连同它的涨跌幅搬进了统计轨自己的一格（#911，
+    // 去掉一屏内说两遍同一个数）。这条闸守的是「数字不许被静默切掉」，所以
+    // 它跟着搬 —— 断言从「副行里有 %」改成「今日那个 % 仍然在首屏、且没被
+    // 截断」。只放松不跟随，等于把闸删了。
+    assert.equal(sub.segCount, 2, "hero sub-line should render 已实现 / 浮动 as two segments");
     assert.equal(sub.lineClipped, false, "hero sub-line is clipped at 390px");
     assert.deepEqual(sub.segClipped, [], "a hero sub-line segment is clipped");
-    assert.match(sub.text, /%/, "hero sub-line dropped the today percentage");
+
+    const today = await page.evaluate(() => {
+      const cell = [...document.querySelectorAll(".hero-rail-cell")]
+        .find(c => c.querySelector(".hero-rail-k")?.textContent.trim() === "今日");
+      if (!cell) return null;
+      const parts = [...cell.querySelectorAll(".hero-rail-v, .hero-rail-d, .rc-cap")];
+      return {
+        text: cell.textContent,
+        clipped: parts.filter(p => p.scrollWidth > p.clientWidth + 1).map(p => p.textContent),
+        bars: cell.querySelectorAll(".rc-bars > i").length,
+      };
+    });
+    assert(today, "the 今日 rail cell is gone — today's move left the first screen");
+    assert.match(today.text, /%/, "the 今日 rail cell dropped the today percentage");
+    assert.deepEqual(today.clipped, [], "the 今日 rail cell truncates a value");
+    assert(today.bars > 5, `今日 cell drew ${today.bars} daily bars — the chart is missing`);
+
+    // 统计轨每一格的说明行同理：它们带着样本量和「未能核验」的条数，
+    // nowrap + ellipsis 一挤就把这些数字整段吃掉。
+    const caps = await page.evaluate(() => [...document.querySelectorAll(".hero-rail .rc-cap")]
+      .filter(c => c.scrollWidth > c.clientWidth + 1).map(c => c.textContent));
+    assert.deepEqual(caps, [], "a hero rail caption is truncated at 390px");
     await context.close();
   }
 
@@ -803,7 +828,10 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
   // 数据到达前 #hero-rail 是空的。在给它 min-height 之前它高 1px，填满后
   // 85px（桌面），每次加载都跳一次 —— 实测这一下就是整页 CLS 的大头
   // (0.26 -> 0.04)。这里量的是「预留 == 实测」，比断言一个 CLS 数字稳。
-  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 6]]) {
+  // 六格 → 四格（#911：每格换一件图形，今日两格并一格，Brier 出首屏），所以
+  // 宽屏这档从 6 改成 4。这条闸量的从来不是格数本身，而是「预留 == 实测」，
+  // 格数只是用来钉住某次改版没有把断点改塌。
+  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 4]]) {
     const context = await browser.newContext({ viewport: { width, height: 900 } });
     const page = await context.newPage();
     await stubLiveOrigin(page);
@@ -907,9 +935,12 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
       `P&L / ink tokens did not resolve distinctly: ${spark.pnlTokens.join(" | ")}`);
     assert(spark.stopColors.length >= 2,
       `hero spark area has no gradient stops (${spark.stopColors.length})`);
+    // 面积可以有颜色（#911 从中性墨换成品牌蓝，因为中性那版把首屏读成灰卡），
+    // 但**不能是涨跌色**：那正是「一屏四块红」的来路，而且面积一旦上涨跌色，
+    // 零轴两侧就有一侧在说谎。守的是这条，不是某个具体色值。
     for (const c of spark.stopColors) {
-      assert.equal(c, inkRGB,
-        `hero spark area fill is not the neutral ink (${c}) — a P&L colour crept back in`);
+      assert(c !== posRGB && c !== negRGB,
+        `hero spark area fill carries a P&L colour (${c}) — the area is material, not signal`);
     }
     // 脚注三件事：区间、最低点、自最低回来多少。少一件这条线就退回纯形状。
     for (const want of ["个交易日", "最低", "自最低"]) {


### PR DESCRIPTION
## 为什么

kcn 看完 #909：

> 首页卡片还是很奇怪呀，数字太多太乱，多一些图会不会好一点。现在这个还是不符合预期。而且灰度太灰了，作为开屏不吸引人
> 那个数字太大了 dashboard 一眼天天看…然后下面其实和中间数字信息重复
> 我是觉得下面多点图好看，而且图可以做成玻璃质感

先做了五个真改在本地副本上的方案给 kcn 选（V1 全宽大图 / V2 分栏+柔和跌色 / V3 极简 / V4 分栏+蓝图 / V5 = V4+统计轨带图），kcn 选 V5 方向并补了上面三条。这个 PR 是 V5 + 那三条。

## 改了什么

**1. 主数 84px → 56px**

84 是给「第一次看见」设计的；这块面板是天天看的东西，一眼扫的是形状不是逐位读数。收到 56 仍然是全页最大、仍然第一眼看到，但和判词、统计轨回到同一张版面里。

**2. 一屏内不再说两遍同一个数**

| 拿掉的 | 它原来在哪重复 |
|---|---|
| 副行的「今日 −$844.99 −6.74%」 | 统计轨自己有「今日」一格，还带 20 天每日柱 |
| 出处行的「账面 $11,693 / HK$91,683」 | 逐字等于统计轨 美股 + 港股 两格换算后之和 |

出处行退回它本来的职责：汇率、来源、取数时刻。

**3. 统计轨 6 格纯数字 → 4 格各带一件图形**

- **美股 / 港股** — 值 + 占账面比例条（比例是形状问题，不是数字问题）
- **今日** — 美港合并成一个 USD-eq 数（原来两格是同一件事的两个货币面），省下的位置放**近 20 个交易日每日盈亏柱**：一格里第一次能看出「今天这根在最近的分布里算大还是算小」。数据源是 spark 那条序列的一阶差分，**同源同算法**，不另开口径。
- **遵守率 30d** — 值 + 量表条

自评 Brier 挪出首屏：Reflect 的 Brier 卡、决策带 KPI、Plan 三处都在，首屏这格是全站第四份。

**4. 灰改蓝 + 玻璃质感**

面积从中性墨换成品牌蓝——中性那版（#909）把首屏读成了一张灰卡。蓝**不是涨跌色**：它不参与「这段是赚还是亏」的表述，那件事由曲线在零轴哪一侧、以及主数的符号回答，所以既不会撒谎，也不会再给首屏添一块红。

图坐进一格**玻璃凹槽**：顶边受光 + 内壁一圈发丝 + 槽底内阴影；比例条和柱图共用同一套光影语汇，一眼是同族材质。**刻意不是第二层毛玻璃**——半透明面叠半透明面会把可读性叠没（apple-design §12），凹槽只借它的光影语汇，不再叠一层 blur。

## 闸跟着数字搬，不是放松

| 原来的闸 | 现在 |
|---|---|
| 副行「三段 + 必须有 %」 | 「两段 + **今日的 % 仍在首屏的统计轨里且不被截断** + 那一格确实画出了柱」 |
| spark 面积「必须等于中性墨」 | 「**不许是涨跌色**」——守的是性质（面积是材质不是信号），不是某个具体色值 |
| — | **新增**：统计轨每格说明行不许被截断（窄屏「主动 call · n=82 · 3 未能核验」原会被 ellipsis 吃掉后半段；窄屏改成允许折行） |
| 统计轨列数 6 | 4 —— 它量的从来是「预留 == 实测」，格数只是钉住断点没被改塌 |

只放松不跟随，等于把闸删了。

## 实测

**CLS**（同 harness、同数据、A/B×3）：

| 宽度 | master | 本 PR |
|---|---|---|
| 1200 | 0.017 / 0.017 / 0.011 | 0.018 / 0.011 / 0.011 |
| 1440 | 0.010 / 0.016 / 0.015 | 0.010 / 0.005 / 0.011 |
| 390 | 0.030 / 0.030 / 0.020 | **0.009 / 0.016 / 0.009** |

高度预留全部重新量过：`.hero-deck-copy` 184 → **112**（≥1024）/ 142 → **88**；`.hero-rail` 122 → **152**（768~1920 全档同高）、244 → **293**（360~600）。deck 桌面 341 → 438px（图更高 + 统计轨带图），1200×760 的 social card 取景里今日判定的判词仍然在框内。

**Lighthouse**：a11y **100** / best-practices **88** / SEO **92**，两边逐项相同。**perf 分本轮不做结论**——机器 load 6.25（两个 opencode review agent 在跑），master 自己三轮就在 54~68 之间摆，这种噪声带里比较没有意义（`vps-load-invalidates-perf-measurements`）。CLS 那一项两边都测到了，新版 0.010 vs master 0.019~0.034，与上面自测一致。

**测试**：`dashboard_tab_runtime.spec.js` 绿；`pytest -k "dashboard or hero or push_scope or ci_"` 216 passed。hero.js / render.js 两份手工副本的 deck 段与 spark 段逐字相同（parity 测试覆盖）。
