### PR TITLE
overview 首屏第五层：今日独占一行 + 补回美港分项 + 去零轴刻度 + 判词去大字报

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -113,7 +113,6 @@
   /* 判词档（overview-status 的盘中判定句）：display(64) 与 lg(15) 之间原来
      是真空，而判词此前只有 12px —— 全页语义最重的一句话是全页最小的字之一，
      比统计轨的 13px 还小（语义倒置）。补在 28-34 档，桌面落在区间内。 */
-  --fs-verdict: clamp(24px, 2.4vw, 34px);
   --fs-xxl: 26px;
   --fs-xl: 19px;
   --fs-lg: 15px;
@@ -2094,7 +2093,7 @@
      空白 —— 那不是留白，是构图没写完（主数越大越明显）。右栏放的不是第二
      张图，是同一个数的历史形状。 */
   .hero-deck-lead {
-    padding: 38px var(--card-inset) 32px;
+    padding: 28px var(--card-inset) 24px;
     position: relative;
     display: grid; grid-template-columns: minmax(0, 1fr);
   }
@@ -2138,7 +2137,7 @@
   @media (min-width: 1024px) {
     /* 长走势条配更高的画布：宽度放大后 108px 会把形状压扁。主数收到 56px 之后
        这块面板的重心从「一个大数字」挪到「一张图」，画布跟着抬到 190px。 */
-    .hero-spark { grid-template-rows: 190px 16px; margin-top: 0; }
+    .hero-spark { grid-template-rows: 148px 16px; margin-top: 0; }
   }
   /* 图坐在一格玻璃凹槽里：顶边受光、内壁一圈发丝、槽底比面板略沉。
      刻意不是第二层毛玻璃 —— 半透明面叠半透明面会把可读性叠没
@@ -2180,13 +2179,6 @@
     stroke: var(--border-strong); stroke-width: 1; opacity: .45;
     vector-effect: non-scaling-stroke;
   }
-  /* 零轴刻度：标在线的上方，不压在线上。零轴贴顶（全程亏损）时翻到线下。 */
-  .hs-zero-tag {
-    position: absolute; left: 10px; transform: translateY(-100%);
-    padding-bottom: 2px; pointer-events: none;
-    font: 600 10px/1 var(--mono); color: var(--text-tertiary);
-  }
-  .hs-zero-tag.is-top { transform: none; padding: 3px 0 0; }
   /* 脚注：把「多长、最低到过哪、从那以后回来多少」写成字。大数字只回答
      「现在亏多少」，这一行回答的是它是怎么走到这儿的 —— 首屏原来没有
      任何一处给得出这三个数。 */
@@ -2263,7 +2255,7 @@
      行数是固定的（标签 / 值 / 变化 / 备注），不会因为数据长短再变。
      min-height 而不是 height：真渲染出来更高时不裁。 */
   .hero-rail {
-    display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+    display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
     border-top: 1px solid var(--border-subtle);
     /* 每格多了一件图形（比例条 / 每日柱）+ 一行说明，比纯数字那版高一档。
        152 = 四格并排时的数据态实测（768~1920 全档同高）。 */
@@ -2273,7 +2265,7 @@
     padding: 0 var(--card-inset); column-gap: 16px;
   }
   .hero-rail-cell {
-    min-width: 0; padding: 14px 0 16px;
+    min-width: 0; padding: 12px 0 14px;
   }
   .hero-rail-k {
     color: var(--text-tertiary); font: 600 var(--fs-micro)/1.2 var(--font);
@@ -2292,13 +2284,65 @@
   }
   .hero-rail-d.pos { color: var(--positive); }
   .hero-rail-d.neg { color: var(--negative); }
+  /* 今日行：左侧数字（合计 + 美股/港股分项）、右侧一条与上方走势图同宽的
+     每日盈亏柱。列比和上面那行一致（3:5），所以两张图左缘对齐、右缘对齐，
+     读成同一张版面的上下两层，而不是两块拼贴。 */
+  .hero-today {
+    display: grid; grid-template-columns: minmax(0, 1fr);
+    gap: 12px; padding: 13px var(--card-inset) 15px;
+    border-top: 1px solid var(--border-subtle);
+    /* 三档预留，每档都是「该宽度下的确定高度」：≤1023 单列（数字在上、柱图
+       在下）208；1024~1199 双列但分项竖排 126；≥1200 分项一行 104。 */
+    min-height: 208px;
+  }
+  @media (min-width: 1024px) {
+    .hero-today {
+      grid-template-columns: minmax(0, 3fr) minmax(400px, 5fr);
+      column-gap: 64px; align-items: center; min-height: 126px;
+    }
+  }
+  @media (min-width: 1200px) {
+    .hero-today { min-height: 104px; }
+  }
+  .ht-nums { min-width: 0; }
+  .ht-total {
+    margin-top: 7px; color: var(--text); font: 700 var(--fs-xxl)/1.15 var(--mono);
+    letter-spacing: -.015em; font-variant-numeric: tabular-nums; white-space: nowrap;
+  }
+  /* 和主数同一条规矩：这是全屏第二大的数字，用降过彩度的那一档，
+     小字（%、分项）仍然满彩度。 */
+  .ht-total.pos { color: var(--positive-display); }
+  .ht-total.neg { color: var(--negative-display); }
+  .ht-total-pct { font-size: var(--fs-lg); font-weight: 600; }
+  /* 分项行：宽屏一行，窄屏每边各占一行。**不靠 flex-wrap 自己折** —— 折不折
+     取决于列宽和数字位数，行高因此在不同宽度、不同数字下不一样，预留就没法
+     量准（这一行的高度必须是宽度的确定函数，不能是数据的函数）。 */
+  .ht-legs {
+    margin-top: 8px; display: flex; flex-wrap: nowrap; align-items: baseline; gap: 8px;
+    color: var(--text-secondary); font: 500 var(--fs-md)/1.4 var(--mono);
+  }
+  @media (max-width: 1199px) {
+    .ht-legs { flex-direction: column; align-items: flex-start; gap: 4px; }
+    .ht-legs > .hds-sep { display: none; }
+  }
+  .ht-leg { display: inline-flex; align-items: baseline; gap: 5px; white-space: nowrap; }
+  .ht-leg-k { color: var(--text-tertiary); }
+  .ht-leg b { font-weight: 700; color: var(--text); }
+  .ht-leg b.pos, .ht-legs .pos { color: var(--positive); }
+  .ht-leg b.neg, .ht-legs .neg { color: var(--negative); }
+  .ht-chart { min-width: 0; }
+  /* 柱子拿到整行宽度之后可以更高：原来挤在 ~230px 的格子里，20 根柱缩略看
+     像一排随机方块。 */
+  .ht-chart .rc-bars { margin-top: 0; height: 46px; }
+  .ht-chart .rc-cap { margin-top: 8px; }
+
   /* 比例条 = 玻璃凹槽 + 受光填充：槽内壁一圈高光边、槽口一道内阴影，填充
      顶边亮一线。和 spark 的凹槽同一套光影语汇，一眼是同族材质。 */
   .rc-meter {
-    /* 和每日柱共用一条 30px 的图形带（上下留白把 6px 的条压在中线上）：
-       否则一行里 6px 的条和 30px 的柱图会让四格的说明行高低不齐。 */
-    margin-top: 9px; height: 6px; border-radius: 3px; overflow: hidden;
-    margin-top: 21px; margin-bottom: 12px;
+    /* 和每日柱共用一条图形带（上下留白把 6px 的条压在中线上），说明行才齐。
+       封顶 220px：三格版每格 ~590px，满宽的细条读成加载进度条而不是比例。 */
+    height: 6px; border-radius: 3px; overflow: hidden; max-width: 220px;
+    margin: 21px 0 12px;
     background: color-mix(in srgb, var(--text-primary) 7%, transparent);
     box-shadow: inset 0 1px 1.5px rgba(0, 0, 0, .10), inset 0 0 0 1px var(--spec-1);
   }
@@ -2322,6 +2366,10 @@
   }
   .rc-bars > i {
     position: absolute; border-radius: 1.5px;
+    /* 槽位给的是百分比宽，行拉宽之后 20 根柱会长成 30px 的方块（缩略看像
+       一排随机色块）。封顶 9px 并按槽位中心对齐：疏密随宽度变，柱子本身
+       的粗细不变。 */
+    max-width: 9px; transform: translateX(-50%);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, .4);
   }
   .rc-bars > i.up { background: var(--positive); }
@@ -2459,15 +2507,18 @@
        地板保持整卡一级、不下沉到子行：盘中横幅在 overview 是
        is-pending 不占位的（#890），横幅日它出现时会在卡内把要点/硬闸往下推
        —— 整卡地板吸收这种内部重排，子行地板会把这次重排漏成页面级位移。
-       地板值 = 构图定稿后横幅日扫宽实测上界 +2（见各断点注释）。 */
-    min-height: 478px;
+       地板值 = 构图定稿后横幅日扫宽实测上界 +2（见各断点注释）。
+       504：判词从 34px 大字报降到 19px 导语后重量的上界（1024 档 503）——
+       原来的 478 比数据态还矮，数据一到卡就长 10~25px，等于这条地板一直是
+       空的。 */
+    min-height: 504px;
   }
   .overview-verdict-head,
   .overview-gates-head {
     display: flex; align-items: center; justify-content: space-between; gap: 10px;
   }
-  /* 「今日判定」降级为 kicker：这张卡真正的话是下面的判词（--fs-verdict），
-     标题本身退成与「决策面板」同档的眉标，把字阶让给内容。 */
+  /* 「今日判定」降级为 kicker：这张卡真正的话是下面那句判词，标题本身退成
+     与「决策面板」同档的眉标，把字阶让给内容。 */
   .overview-verdict-head h3 {
     margin: 5px 0 0; color: var(--text-tertiary);
     font-size: var(--fs-micro); font-weight: 600;
@@ -2483,19 +2534,24 @@
   .overview-strip-link:focus-visible {
     outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 3px;
   }
-  /* 判词行：这张卡的主句，升到 --fs-verdict 档（原 12px 是全页最小字之一，
-     语义倒置）。三种行式样统一为无盒 + 发丝线：去胶囊底色与蓝点，
-     上下发丝线夹住，字重 600 承担告警语气；时间戳保持 mono micro。 */
+  /* 判词行：这张卡的主句。三种行式样统一为无盒 + 发丝线：去胶囊底色与蓝点，
+     上下发丝线夹住；时间戳保持 mono micro。 */
+  /* 2026-08-24：--fs-verdict（24~34px、600 字重）把这句话渲染成了一张大字报
+     （kcn：「今日判定那个大字报不要，太奇怪了」）。它不是标题，是这张卡的
+     导语句 —— 一句会天天变的状态描述。降到 --fs-xl / 550 字重 / 1.55 行高，
+     并把负字距收回 0：字距是随字号定的，19px 上再收紧只会挤。
+     仍然是这张卡里最大的字（其余行 13px），层级没丢，只是不再喊。 */
   .overview-status {
-    margin: 14px 0 12px; padding: 12px 0;
+    margin: 14px 0 12px; padding: 13px 0;
     background: none; border: 0; border-radius: 0;
     border-top: 1px solid var(--border-subtle);
     border-bottom: 1px solid var(--border-subtle);
     -webkit-backdrop-filter: none; backdrop-filter: none;
-    font-size: var(--fs-verdict); line-height: 1.3; letter-spacing: -.01em;
+    font-size: var(--fs-xl); line-height: 1.55; letter-spacing: 0;
+    max-width: 68ch;
   }
   .overview-status .sb-pulse { display: none; }
-  .overview-status .sb-text { font-weight: 600; }
+  .overview-status .sb-text { font-weight: 550; }
   .overview-verdict .today-highlights {
     display: grid; grid-template-columns: 1fr; gap: 6px;
     margin: 0 0 14px; min-height: 0;
@@ -2631,7 +2687,7 @@
   .hl-chip.hl-alert { color: var(--red); font-weight: 600; }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
+    .hero-rail { grid-template-columns: repeat(3, minmax(0, 1fr)); min-height: 152px; }
     /* 506：要点行升到 44px 后 768px 端横幅折行的实测上界（504）+2。 */
     .overview-verdict { min-height: 506px; }
     .overview-verdict, .overview-strip,

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -723,6 +723,7 @@
     const ae = safe(m, "execution_by_kind", "active") || {};
     // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
     // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
+    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
       + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
@@ -742,7 +743,7 @@
     // 近 n 个交易日的每日盈亏柱。数据源就是 spark 那条序列的一阶差分 ——
     // 同源同算法，不另开一条口径（首屏两处画同一件事却对不上，是这块面板
     // 反复出过的问题）。
-    const railDailyBars = (n) => {
+    const dailyBars = (n) => {
       const pts = heroProfitSeries();
       if (pts.length < 3) return `<div class="rc-bars" aria-hidden="true"></div>`;
       const d = [];
@@ -763,16 +764,11 @@
         + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
         + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
     };
-    // 统计轨 6 格 → 4 格，每格自带一件图形。六格全是数字时它读成一张对账单，
-    // 而首屏是天天看的东西：看的是形状，不是逐位读数（kcn 2026-08-24：「数字
-    // 太多太乱，下面多点图好看」）。
+    // 统计轨只剩「钱在哪、守不守纪律」三格，每格自带一件图形：
     //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
-    //   · 今日 —— 美港合并成一个 USD-eq 数（原来两格是同一件事的两个货币面），
-    //             省下的位置给近 14 个交易日的每日盈亏柱：一格里第一次能看出
-    //             「今天这根在最近的分布里算大还是算小」
     //   · 遵守率 30d —— 值 + 量表条
-    // 自评 Brier 挪出首屏：它在 Reflect 的 Brier 卡、决策带 KPI、Plan 三处都在，
-    // 首屏这一格是全站第四份。
+    // 今日搬进了自己那一行（上面），自评 Brier 挪出首屏（Reflect 的 Brier 卡、
+    // 决策带 KPI、Plan 三处都在，首屏这格是全站第四份）。
     const shareUs = (has(us.value_usd) && has(bookUsd) && bookUsd > 0)
       ? us.value_usd / bookUsd * 100 : null;
     const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
@@ -784,9 +780,6 @@
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
         railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
-      cell("今日", withDelta(heroMoney(todayUsd, "USD"),
-        todayPct == null ? "" : fmtPct(todayPct), pnlClass(todayPct)),
-        railDailyBars(20), pnlClass(todayUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -794,6 +787,34 @@
           `主动 call · n=${ae.known == null ? DASH : ae.known}`
           + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
     ].join("");
+
+    // 今日行：一个 USD-eq 合计 + 美股/港股两个分项 + 一条与上方走势图同宽的
+    // 每日盈亏柱。三个数放在一起才有意义（合计回答「今天亏了多少」，分项回答
+    // 「亏在哪边」），柱子回答「这根在最近的分布里算大还是算小」。
+    const todayEl = document.getElementById("hero-today");
+    if (todayEl) {
+      const usTodayPct = legPct(us.value_usd, us.today_change_usd);
+      const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
+      const leg = (k, v, pct, cls) =>
+        `<span class="ht-leg"><span class="ht-leg-k">${k}</span>`
+        + `<b class="${cls}">${v}</b>`
+        + (pct == null ? "" : ` <span class="${pnlClass(pct)}">${fmtPct(pct)}</span>`)
+        + `</span>`;
+      todayEl.innerHTML =
+        `<div class="ht-nums">`
+        + `<div class="overview-card-kicker">今日 · USD 等值</div>`
+        + `<div class="ht-total ${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}`
+        + (todayPct == null ? "" : ` <span class="ht-total-pct">${fmtPct(todayPct)}</span>`)
+        + `</div>`
+        + `<div class="ht-legs">`
+        + leg("美股", heroMoney(us.today_change_usd, "USD"), usTodayPct,
+          pnlClass(us.today_change_usd))
+        + `<span class="hds-sep">·</span>`
+        + leg("港股", heroMoney(hk.today_change_hkd, "HKD"), hkTodayPct,
+          pnlClass(hk.today_change_hkd))
+        + `</div></div>`
+        + `<div class="ht-chart">${dailyBars(20)}</div>`;
+    }
 
     renderHeroSpark();
   }
@@ -861,7 +882,6 @@
     // 最低点就在末端时没有「自最低」可说（那句会退化成 +$0）。
     const recovered = li < vals.length - 2 ? last - lowest : null;
 
-    const zeroPct = Math.max(0, Math.min(100, zeroY / H * 100));
     const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lowest, "USD")}`
       + `（${pts[li].date}）`
       + (recovered != null ? `，自最低 ${heroMoney(recovered, "USD")}` : "")
@@ -894,10 +914,9 @@
       + ` x2="${x(li).toFixed(1)}" y2="${y(lowest).toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
-      // 零轴刻度是 HTML 不是 SVG 文本：viewBox 被 preserveAspectRatio="none"
-      // 横向拉伸，写在 SVG 里的字会跟着拉扁。零轴贴顶时改标在线下方。
-      + `<span class="hs-zero-tag${zeroPct < 14 ? " is-top" : ""}" style="top:${zeroPct.toFixed(2)}%"`
-      + ` aria-hidden="true">0</span>`
+      // 零轴刻度已去掉（kcn 2026-08-24：「大图的 0 可以不要」）。零轴那条线
+      // 本身留着 —— 它是曲线读正负的唯一参照，标签只是给它写名字，而这条线
+      // 在一张只有一个量纲的图里不需要名字。
       + `</div>`
       + `<div class="hs-foot">${foot}</div>`;
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -713,6 +713,7 @@
     const ae = safe(m, "execution_by_kind", "active") || {};
     // 一格一次视觉起停：值和「它自己的变化」并成一行，限定语进标签，
     // 只有真正额外的信息（样本量、基线）才留副行。信息一条不少。(#879)
+    const legPct = (v, chg) => (has(v) && has(chg) && (v - chg) > 0) ? chg / (v - chg) * 100 : null;
     const cell = (k, v, s, cls) =>
       `<div class="hero-rail-cell"><div class="hero-rail-k">${k}</div>`
       + `<div class="hero-rail-v ${cls || ""}">${v}</div>`
@@ -732,7 +733,7 @@
     // 近 n 个交易日的每日盈亏柱。数据源就是 spark 那条序列的一阶差分 ——
     // 同源同算法，不另开一条口径（首屏两处画同一件事却对不上，是这块面板
     // 反复出过的问题）。
-    const railDailyBars = (n) => {
+    const dailyBars = (n) => {
       const pts = heroProfitSeries();
       if (pts.length < 3) return `<div class="rc-bars" aria-hidden="true"></div>`;
       const d = [];
@@ -753,16 +754,11 @@
         + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
         + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
     };
-    // 统计轨 6 格 → 4 格，每格自带一件图形。六格全是数字时它读成一张对账单，
-    // 而首屏是天天看的东西：看的是形状，不是逐位读数（kcn 2026-08-24：「数字
-    // 太多太乱，下面多点图好看」）。
+    // 统计轨只剩「钱在哪、守不守纪律」三格，每格自带一件图形：
     //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
-    //   · 今日 —— 美港合并成一个 USD-eq 数（原来两格是同一件事的两个货币面），
-    //             省下的位置给近 14 个交易日的每日盈亏柱：一格里第一次能看出
-    //             「今天这根在最近的分布里算大还是算小」
     //   · 遵守率 30d —— 值 + 量表条
-    // 自评 Brier 挪出首屏：它在 Reflect 的 Brier 卡、决策带 KPI、Plan 三处都在，
-    // 首屏这一格是全站第四份。
+    // 今日搬进了自己那一行（上面），自评 Brier 挪出首屏（Reflect 的 Brier 卡、
+    // 决策带 KPI、Plan 三处都在，首屏这格是全站第四份）。
     const shareUs = (has(us.value_usd) && has(bookUsd) && bookUsd > 0)
       ? us.value_usd / bookUsd * 100 : null;
     const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
@@ -774,9 +770,6 @@
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
         railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
-      cell("今日", withDelta(heroMoney(todayUsd, "USD"),
-        todayPct == null ? "" : fmtPct(todayPct), pnlClass(todayPct)),
-        railDailyBars(20), pnlClass(todayUsd)),
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
@@ -784,6 +777,34 @@
           `主动 call · n=${ae.known == null ? DASH : ae.known}`
           + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
     ].join("");
+
+    // 今日行：一个 USD-eq 合计 + 美股/港股两个分项 + 一条与上方走势图同宽的
+    // 每日盈亏柱。三个数放在一起才有意义（合计回答「今天亏了多少」，分项回答
+    // 「亏在哪边」），柱子回答「这根在最近的分布里算大还是算小」。
+    const todayEl = document.getElementById("hero-today");
+    if (todayEl) {
+      const usTodayPct = legPct(us.value_usd, us.today_change_usd);
+      const hkTodayPct = legPct(hk.value_hkd, hk.today_change_hkd);
+      const leg = (k, v, pct, cls) =>
+        `<span class="ht-leg"><span class="ht-leg-k">${k}</span>`
+        + `<b class="${cls}">${v}</b>`
+        + (pct == null ? "" : ` <span class="${pnlClass(pct)}">${fmtPct(pct)}</span>`)
+        + `</span>`;
+      todayEl.innerHTML =
+        `<div class="ht-nums">`
+        + `<div class="overview-card-kicker">今日 · USD 等值</div>`
+        + `<div class="ht-total ${pnlClass(todayUsd)}">${heroMoney(todayUsd, "USD")}`
+        + (todayPct == null ? "" : ` <span class="ht-total-pct">${fmtPct(todayPct)}</span>`)
+        + `</div>`
+        + `<div class="ht-legs">`
+        + leg("美股", heroMoney(us.today_change_usd, "USD"), usTodayPct,
+          pnlClass(us.today_change_usd))
+        + `<span class="hds-sep">·</span>`
+        + leg("港股", heroMoney(hk.today_change_hkd, "HKD"), hkTodayPct,
+          pnlClass(hk.today_change_hkd))
+        + `</div></div>`
+        + `<div class="ht-chart">${dailyBars(20)}</div>`;
+    }
 
     renderHeroSpark();
   }
@@ -852,7 +873,6 @@
     // 最低点就在末端时没有「自最低」可说（那句会退化成 +$0）。
     const recovered = li < vals.length - 2 ? last - lowest : null;
 
-    const zeroPct = Math.max(0, Math.min(100, zeroY / H * 100));
     const label = `总盈亏 ${vals.length} 个交易日走势：最低 ${heroMoney(lowest, "USD")}`
       + `（${pts[li].date}）`
       + (recovered != null ? `，自最低 ${heroMoney(recovered, "USD")}` : "")
@@ -885,10 +905,9 @@
       + ` x2="${x(li).toFixed(1)}" y2="${y(lowest).toFixed(1)}"/>`
       + `<path class="hs-line" d="${line}"/>`
       + `</svg>`
-      // 零轴刻度是 HTML 不是 SVG 文本：viewBox 被 preserveAspectRatio="none"
-      // 横向拉伸，写在 SVG 里的字会跟着拉扁。零轴贴顶时改标在线下方。
-      + `<span class="hs-zero-tag${zeroPct < 14 ? " is-top" : ""}" style="top:${zeroPct.toFixed(2)}%"`
-      + ` aria-hidden="true">0</span>`
+      // 零轴刻度已去掉（kcn 2026-08-24：「大图的 0 可以不要」）。零轴那条线
+      // 本身留着 —— 它是曲线读正负的唯一参照，标签只是给它写名字，而这条线
+      // 在一张只有一个量纲的图里不需要名字。
       + `</div>`
       + `<div class="hs-foot">${foot}</div>`;
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。

--- a/site/index.html
+++ b/site/index.html
@@ -177,6 +177,12 @@ layout: null
                的净值表现区；首屏只保留这一条形状，不再两条同源曲线上下堆叠。 -->
           <div class="hero-spark" id="hero-spark"></div>
         </div>
+        <!-- 「今日」独占一行：它原来是统计轨里的一格，20 根日盈亏柱被压在
+             ~230px 宽的格子里，缩略看像一排随机方块（kcn 2026-08-24：「柱状图
+             缩略看很奇怪，比如说单独成一行」）。独立成行之后柱子拿到和上面
+             那张走势图同宽的画布，美股/港股的当日分项也回得来 —— 那两个数在
+             并成一格时被合掉了。 -->
+        <div class="hero-today" id="hero-today"></div>
         <div class="hero-rail" id="hero-rail"></div>
       </div>
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -711,25 +711,32 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     assert.equal(sub.lineClipped, false, "hero sub-line is clipped at 390px");
     assert.deepEqual(sub.segClipped, [], "a hero sub-line segment is clipped");
 
+    // 「今日」在 #911 里从统计轨的一格搬成了自己一行（柱图挤在 ~230px 的格子
+    // 里缩略看像随机方块），同时把美股/港股当日分项补了回来 —— 并成一格时
+    // 那两个数被合掉了。闸跟着搬：合计的 %、两个市场的分项、以及那张柱图，
+    // 三样都必须在首屏且不被截断。
     const today = await page.evaluate(() => {
-      const cell = [...document.querySelectorAll(".hero-rail-cell")]
-        .find(c => c.querySelector(".hero-rail-k")?.textContent.trim() === "今日");
-      if (!cell) return null;
-      const parts = [...cell.querySelectorAll(".hero-rail-v, .hero-rail-d, .rc-cap")];
+      const row = document.getElementById("hero-today");
+      if (!row || !row.textContent.trim()) return null;
+      const parts = [...row.querySelectorAll(".ht-total, .ht-leg, .rc-cap")];
       return {
-        text: cell.textContent,
+        text: row.textContent,
+        legs: row.querySelectorAll(".ht-leg").length,
         clipped: parts.filter(p => p.scrollWidth > p.clientWidth + 1).map(p => p.textContent),
-        bars: cell.querySelectorAll(".rc-bars > i").length,
+        bars: row.querySelectorAll(".rc-bars > i").length,
       };
     });
-    assert(today, "the 今日 rail cell is gone — today's move left the first screen");
-    assert.match(today.text, /%/, "the 今日 rail cell dropped the today percentage");
-    assert.deepEqual(today.clipped, [], "the 今日 rail cell truncates a value");
-    assert(today.bars > 5, `今日 cell drew ${today.bars} daily bars — the chart is missing`);
+    assert(today, "the 今日 row is gone — today's move left the first screen");
+    assert.match(today.text, /%/, "the 今日 row dropped the today percentage");
+    assert.equal(today.legs, 2, "the 今日 row must keep the US / HK split, not just the total");
+    assert.match(today.text, /美股/, "the 今日 row lost the US leg");
+    assert.match(today.text, /港股/, "the 今日 row lost the HK leg");
+    assert.deepEqual(today.clipped, [], "the 今日 row truncates a value");
+    assert(today.bars > 5, `今日 row drew ${today.bars} daily bars — the chart is missing`);
 
     // 统计轨每一格的说明行同理：它们带着样本量和「未能核验」的条数，
     // nowrap + ellipsis 一挤就把这些数字整段吃掉。
-    const caps = await page.evaluate(() => [...document.querySelectorAll(".hero-rail .rc-cap")]
+    const caps = await page.evaluate(() => [...document.querySelectorAll(".hero-rail .rc-cap, .hero-today .rc-cap")]
       .filter(c => c.scrollWidth > c.clientWidth + 1).map(c => c.textContent));
     assert.deepEqual(caps, [], "a hero rail caption is truncated at 390px");
     await context.close();
@@ -828,10 +835,10 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
   // 数据到达前 #hero-rail 是空的。在给它 min-height 之前它高 1px，填满后
   // 85px（桌面），每次加载都跳一次 —— 实测这一下就是整页 CLS 的大头
   // (0.26 -> 0.04)。这里量的是「预留 == 实测」，比断言一个 CLS 数字稳。
-  // 六格 → 四格（#911：每格换一件图形，今日两格并一格，Brier 出首屏），所以
-  // 宽屏这档从 6 改成 4。这条闸量的从来不是格数本身，而是「预留 == 实测」，
-  // 格数只是用来钉住某次改版没有把断点改塌。
-  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 4]]) {
+  // 六格 → 四格 → 三格（今日搬进自己那一行，Brier 出首屏）。这条闸量的从来
+  // 不是格数本身，而是「预留 == 实测」，格数只是用来钉住某次改版没有把断点
+  // 改塌。
+  for (const [width, expectCols] of [[390, 2], [900, 3], [1440, 3]]) {
     const context = await browser.newContext({ viewport: { width, height: 900 } });
     const page = await context.newPage();
     await stubLiveOrigin(page);


### PR DESCRIPTION
kcn 四条反馈，逐条：

| 反馈 | 改法 |
|---|---|
| 少了今日美股港股分别的 | 补回来。上一轮并成一个 USD-eq 合计时把这两个数合掉了——合计答「今天亏多少」，分项答「亏在哪边」，是两个问题 |
| 柱状图缩略看很奇怪，比如说单独成一行 | 今日从统计轨的一格搬成 `.hero-today` 独占一行，列比与上面一致（3:5），两张图左右缘对齐。柱子封顶 9px 并按槽位中心对齐——疏密随宽度变，粗细不变（原来在 ~230px 格子里被拉成 30px 的方块） |
| 大图的 0 可以不要 | 去掉零轴刻度标签；零轴那条线留着——它是曲线读正负的唯一参照，而一张只有一个量纲的图不需要给这条线写名字 |
| 今日判定那个大字报不要 | 34px/600 → **19px/550/1.55**，负字距收回 0，加 68ch 行宽上限。它不是标题，是天天变的导语句；仍是卡里最大的字（其余 13px），层级没丢 |

统计轨因此回到三格（美股 / 港股 / 遵守率 30d），每格仍自带一件图形。`--fs-verdict` 已无消费者，一并退役。

## 预留全部重量（pre == post，九个宽度逐一验过）

- `.hero-today` 三档 **208 / 126 / 104**，每档都是「该宽度下的确定高度」——分项行改成 `nowrap` + 窄屏竖排，**不靠 flex-wrap 自己折**：折不折取决于列宽和数字位数，行高就会变成数据的函数，预留没法量准。
- `.overview-verdict` 地板 **478 → 504**。原来的 478 比数据态还矮（1024 档实测 503），数据一到卡就长 10~25px —— **那条地板一直是空的**。
- deck 桌面 438 → 482px（多了一行），压回来的部分来自 lead 内边距 38/32→28/24 与走势图 190→148px。

CLS 抽测：1200 档 0 / 0.017，390 档 0.003 / 0.010，与 master 同带或更低。

## 闸

spec 里「今日那格」的断言整体搬到「今日那一行」，并**加钉「必须保留美股/港股两个分项」**——这正是上一轮丢掉的东西，闸没跟上就会再丢一次。柱图仍在、不被截断、说明行截断闸扩到今日行；列数断言 4→3（它量的从来是「预留 == 实测」）。

`pytest -k "dashboard or hero or ci_ or push_scope"` 219 passed；`dashboard_tab_runtime.spec.js` 绿；hero.js / render.js 双份 deck 段与 spark 段逐字相同。