### PR TITLE
perf-review wave 2: schedule hardening + host-ops IO/stability fixes

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  actions: read      # the Actions-side health fold-in reads run history via gh
 
 jobs:
   check:
@@ -61,3 +62,25 @@ jobs:
           # On a miss this exits non-zero and remains visible in Actions. We deliberately
           # do NOT open an issue: per kcn's "no per-cron alerts" preference the daily review
           # covers it.
+
+      - name: Fold Actions-side failures into the daily summary
+        # cron_health_check only sees host-side products; a scheduled workflow
+        # that fails (or stops firing) on the Actions side was previously
+        # visible only in weekly-health's log-only rollup. --json is report-only
+        # and needs read access to run history.
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "## Scheduled workflow health (Actions side)"
+            python3 ops/ci/workflow_health.py --json | python3 -c '
+              import json, sys
+              r = json.load(sys.stdin)
+              print(f"needs attention: {r[\"needs_attention\"]} of {r[\"scheduled_workflows\"]} "
+                    f"(lookback {r[\"lookback_days\"]}d)")
+              for w in r["workflows"]:
+                  if w["status"] == "attention":
+                      print(f"- ⚠ {w[\"workflow\"]}: last={w[\"last_conclusion\"] or \"-\"}")
+            '
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/influencer-scan.yml
+++ b/.github/workflows/influencer-scan.yml
@@ -5,7 +5,12 @@ name: Influence Radar (Trump / Musk / Serenity)
 # Runs twice on (HKT) weekdays:
 #   21:40 UTC Sun–Thu = 05:40 HKT Mon–Fri  → ~2.3h before the 08:00 HKT brief (buffer for
 #                                            GH Actions' 1–2h scheduled-cron delay)
-#   12:50 UTC Mon–Fri = 20:50 HKT Mon–Fri  → 10 min before US news digest / US open prep
+#   12:50 UTC Mon–Fri = 20:50 HKT Mon–Fri  → nominally 10 min before the US news
+#                                            digest, but this slot's own median drift
+#                                            is ~74min (schedule-drift.json), so in
+#                                            practice it lands near/after the digest.
+#                                            Kept for the twice-daily coverage, not
+#                                            the ordering.
 # First cron is dow 0-4 (21:40+8h wraps to next HKT day; 1-5 would miss Monday's brief).
 # Second cron does NOT wrap (12:50+8=20:50 same day) so it stays 1-5. bash ops/host/check_crons.sh --timeline
 on:

--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -13,6 +13,12 @@ name: Macro Scan
 on:
   schedule:
     - cron: '45 21 * * 0-4'
+    # Second attempt (brief-fallback multi-tier pattern): measured drift
+    # (assets/data/schedule-drift.json, n=20) maxes at 199min against this
+    # slot's ~135min pre-brief buffer — the same "brief read yesterday's
+    # sidecar" window sentiment has. Idempotent overwrite; an already-fresh
+    # retry costs a no-op commit step.
+    - cron: '55 21 * * 0-4'
   workflow_dispatch:
 
 # Serialize with other commit-pushing workflows

--- a/.github/workflows/news-digest.yml
+++ b/.github/workflows/news-digest.yml
@@ -1,6 +1,10 @@
 name: US News Digest (off-host LLM)
 
-# 工作日 21:00 HKT = 13:00 UTC, 美股开盘前 30 分钟
+# Nominally 21:00 HKT (13:00 UTC). Measured drift for this slot is median
+# ~75min / max ~157min (assets/data/schedule-drift.json), so the digest
+# typically lands ~22:15 HKT and can run past the 21:30 HKT US open — treat it
+# as an around-the-open product, not a pre-open one. Re-timing the cron needs
+# two weeks of drift data for the new slot first (#780/#781).
 on:
   schedule:
     - cron: '0 13 * * 1-5'

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -12,6 +12,13 @@ on:
     # dow 0-4 not 1-5: 21:30 UTC + 8h wraps to the next HKT day → 1-5 would fire Tue–Sat,
     # missing Monday. Verify with: bash ops/host/check_crons.sh --timeline
     - cron: '30 21 * * 0-4'
+    # Second attempt (brief-fallback multi-tier pattern): measured drift
+    # (assets/data/schedule-drift.json, n=20) maxes at 213min against this
+    # slot's ~150min pre-brief buffer, so ~1 run in 20 landed after the 00:00
+    # UTC brief and it read the previous day's sidecar. The scan overwrites
+    # idempotently and the commit step no-ops without changes — an already-
+    # fresh retry costs nothing.
+    - cron: '55 21 * * 0-4'
   workflow_dispatch:
 
 # Serialize with other commit-pushing workflows

--- a/ops/ci/workflow_health.py
+++ b/ops/ci/workflow_health.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from datetime import datetime, timedelta, timezone
@@ -198,19 +199,62 @@ def main(argv=None) -> int:
           f"needs attention: {result['needs_attention']}")
     for row in result["workflows"]:
         mark = {"ok": "✓", "noted": "·", "attention": "⚠"}[row["status"]]
-        detail = []
-        if row["consecutive_failures"]:
-            detail.append(f"{row['consecutive_failures']} consecutive failures")
-        elif row["failures_in_window"]:
-            detail.append(f"{row['failures_in_window']} failure(s) in {LOOKBACK_DAYS}d")
-        if row["overdue_hours"]:
-            detail.append(f"no run for {row['overdue_hours']}h "
-                          f"(expected every ~{row['expected_interval_hours']}h)")
+        detail = _row_detail(row)
         print(f"  {mark} {row['workflow']:26} last={row['last_conclusion'] or '-'}"
               f"@{(row['last_run'] or '-')[:16]}"
-              + (f"  {'; '.join(detail)}" if detail else ""))
+              + (f"  {detail}" if detail else ""))
+    _surface(result)
     # Report only: a weekly rollup must not fail the job it runs inside.
     return 0
+
+
+def _row_detail(row):
+    detail = []
+    if row["consecutive_failures"]:
+        detail.append(f"{row['consecutive_failures']} consecutive failures")
+    elif row["failures_in_window"]:
+        detail.append(f"{row['failures_in_window']} failure(s) in {LOOKBACK_DAYS}d")
+    if row["overdue_hours"]:
+        detail.append(f"no run for {row['overdue_hours']}h "
+                      f"(expected every ~{row['expected_interval_hours']}h)")
+    return "; ".join(detail)
+
+
+def _surface(result):
+    """Put the rollup where a weekly report can actually be seen.
+
+    The step log scrolls away and continue-on-error keeps the run green, so the
+    aggregate view of Actions-side health used to live only in a log line
+    nobody opens. $GITHUB_STEP_SUMMARY (set on runners) gets a persistent
+    table, and each attention row becomes a ::warning:: annotation on the run
+    page itself. Still report-only: no exit-code change, no notifications.
+    """
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        lines = [
+            "## Scheduled workflow health",
+            f"needs attention: {result['needs_attention']} of "
+            f"{result['scheduled_workflows']} "
+            f"(lookback {result['lookback_days']}d)",
+            "",
+            "| workflow | last run | detail |",
+            "|---|---|---|",
+        ]
+        for row in result["workflows"]:
+            detail = _row_detail(row) or "—"
+            lines.append(
+                f"| {row['workflow']} | {(row['last_conclusion'] or '-')} "
+                f"@{(row['last_run'] or '-')[:16]} | {detail} |"
+            )
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write("\n".join(lines) + "\n")
+        except OSError as exc:
+            print(f"warn: step summary write failed: {exc}", file=sys.stderr)
+    for row in result["workflows"]:
+        if row["status"] == "attention":
+            print(f"::warning::scheduled workflow {row['workflow']}: "
+                  f"{_row_detail(row) or 'needs attention'}")
 
 
 if __name__ == "__main__":

--- a/ops/host/commit_dreaming.sh
+++ b/ops/host/commit_dreaming.sh
@@ -9,7 +9,11 @@
 #
 # 鲁棒性: 只 stage MEMORY.md/DREAMS.md (不碰宿主其它在写的脏文件);push 被拒时用
 # rebase.autoStash 自动绕开"工作区脏 → pull --rebase 拒跑"的坑;真冲突则留本地不死循环。
-set -uo pipefail
+# -e: an unguarded failed `git add` used to fall through to
+# `git diff --cached --quiet` == true and print 「无变化,跳过」 — a transient
+# index.lock collision with the publisher (dream fires 03:20, publisher every
+# 20min in the same worktree) silently dropped that night's promotion.
+set -euo pipefail
 
 WS=/root/.openclaw/workspace
 cd "$WS" || exit 1
@@ -20,7 +24,8 @@ cd "$WS" || exit 1
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 
-git add MEMORY.md DREAMS.md
+git add MEMORY.md DREAMS.md \
+  || { echo "$(date -Is) dreaming-commit: git add 失败(疑似 index.lock 撞车)"; exit 1; }
 if git diff --cached --quiet; then
   echo "$(date -Is) dreaming-commit: MEMORY/DREAMS 无变化,跳过"
   exit 0

--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -177,6 +177,36 @@ def runs_finished_today(job_id, provider=None):
         return None
 
 
+_commit_log_cache = None
+
+
+def _commit_log_entries():
+    """Fetch (committer-ISO, subject) pairs once per process.
+
+    commit_count_today runs once per enabled job (~11), and each call used to
+    re-run the same `git log -n 500` subprocess and re-parse the same lines;
+    the job loop now shares a single fetch. A failed fetch degrades to an
+    empty list — identical to the old per-call failure path (count 0).
+    """
+    global _commit_log_cache
+    if _commit_log_cache is None:
+        entries = []
+        try:
+            r = subprocess.run(
+                ['git', '-C', str(WS), 'log', '-n', '500', '--format=%cI%x00%s'],
+                capture_output=True, text=True, timeout=15,
+            )
+            if r.returncode == 0:
+                for line in r.stdout.splitlines():
+                    if '\x00' in line:
+                        stamp, subject = line.split('\x00', 1)
+                        entries.append((stamp, subject))
+        except Exception:
+            pass
+        _commit_log_cache = entries
+    return _commit_log_cache
+
+
 def commit_count_today(commit_pattern):
     """Count matching commits whose committer date falls on today in HKT.
 
@@ -187,27 +217,15 @@ def commit_count_today(commit_pattern):
     if not commit_pattern:
         return None  # Mode 7 uses heartbeats; dream has no output contract
     today = datetime.now(HKT).date()
-    try:
-        r = subprocess.run(
-            ['git', '-C', str(WS), 'log', '-n', '500', '--format=%cI%x00%s'],
-            capture_output=True, text=True, timeout=15,
-        )
-        if r.returncode != 0:
-            return 0
-        count = 0
-        for line in r.stdout.splitlines():
-            if '\x00' not in line:
-                continue
-            stamp, subject = line.split('\x00', 1)
-            try:
-                commit_day = datetime.fromisoformat(stamp).astimezone(HKT).date()
-            except ValueError:
-                continue
-            if commit_day == today and re.search(commit_pattern, subject):
-                count += 1
-        return count
-    except Exception:
-        return 0
+    count = 0
+    for stamp, subject in _commit_log_entries():
+        try:
+            commit_day = datetime.fromisoformat(stamp).astimezone(HKT).date()
+        except ValueError:
+            continue
+        if commit_day == today and re.search(commit_pattern, subject):
+            count += 1
+    return count
 
 
 def load_runtime_jobs(jobs_file=None):

--- a/ops/host/gc_sessions.py
+++ b/ops/host/gc_sessions.py
@@ -50,8 +50,43 @@ def humansize(n):
     return f'{n:.1f} TB'
 
 
+# Every SESSIONS_DIR sweep rule in one place: (report label, name predicate,
+# retention days). A file may match several rules (e.g. x.bak-1.jsonl matches
+# both the plain-.jsonl and the bak rule); it is deleted iff ANY matching
+# rule's cutoff makes it stale — exactly what the old per-rule passes did —
+# and is reported under its most permissive match.
+SESSION_RULES = [
+    ('trajectory.jsonl',
+     lambda n: n.endswith('.trajectory.jsonl'),
+     KEEP_TRAJECTORY_DAYS),
+    ('plain .jsonl',
+     lambda n: n.endswith('.jsonl'),
+     KEEP_SESSION_DAYS),
+    ('.json sidecar',
+     lambda n: n.endswith('.json'),
+     KEEP_SESSION_DAYS),
+    ('bak / pre-cleanup',
+     lambda n: '.bak-' in n or '.pre-cleanup-' in n or n.endswith('.bak'),
+     KEEP_BAK_DAYS),
+    # Stale rename leftovers like *.jsonl.1779044443580 (epoch-ms suffix)
+    ('tmp / numeric-suffix',
+     lambda n: any(n.endswith(suf) for suf in ('.tmp', '.old')) or
+               n.split('.')[-1].isdigit() and len(n.split('.')[-1]) >= 10,
+     KEEP_BAK_DAYS),
+    # Tombstones like *.jsonl.deleted.2026-06-14T19-00-50.702Z / *.jsonl.reset.<iso>.
+    # The suffix is an ISO timestamp ending in "Z", so it matches none of the
+    # predicates above (not .jsonl/.json/.bak, and "702Z" is not .isdigit()) —
+    # these accumulated unbounded until 2026-07-15 (78 files back to 06-13).
+    # The live transcript is already gone by the time one is written, so they
+    # age out on the same clock as a plain session.
+    ('deleted / reset tombstone',
+     lambda n: '.jsonl.deleted.' in n or '.jsonl.reset.' in n,
+     KEEP_SESSION_DAYS),
+]
+
+
 def gc_files(pattern_predicate, cutoff_ts, label, dry_run, dirpath=None):
-    """Walk dirpath (default SESSIONS_DIR), delete files matching predicate(name) older than cutoff."""
+    """Walk dirpath (default SESSIONS_DIR), delete matching files older than cutoff."""
     dirpath = dirpath or SESSIONS_DIR
     if not dirpath.exists():
         return 0, 0
@@ -77,6 +112,46 @@ def gc_files(pattern_predicate, cutoff_ts, label, dry_run, dirpath=None):
                 print(f'  skip {p.name}: {e}', file=sys.stderr)
     print(f'  {label}: {n_files} files, {humansize(n_bytes)}')
     return n_files, n_bytes
+
+
+def gc_sessions_dir(now_ts, dry_run):
+    """One traversal for every SESSIONS_DIR rule.
+
+    The sweeps used to be six full iterdir() passes re-stating every candidate
+    twice (~18k stats a night); each file is now visited once and statted once.
+    """
+    if not SESSIONS_DIR.exists():
+        return 0, 0
+    per_rule = {label: [0, 0] for label, _, _ in SESSION_RULES}
+    for p in SESSIONS_DIR.iterdir():
+        if not p.is_file():
+            continue
+        try:
+            st = p.stat()
+        except FileNotFoundError:
+            continue
+        matches = [(label, now_ts - days * 86400)
+                   for label, pred, days in SESSION_RULES if pred(p.name)]
+        if not matches:
+            continue
+        label, cutoff = max(matches, key=lambda m: m[1])
+        if st.st_mtime >= cutoff:
+            continue
+        per_rule[label][0] += 1
+        per_rule[label][1] += st.st_size
+        if not dry_run:
+            try:
+                p.unlink()
+            except OSError as e:
+                print(f'  skip {p.name}: {e}', file=sys.stderr)
+    total_files, total_bytes = 0, 0
+    for label, _, _ in SESSION_RULES:
+        n, b = per_rule[label]
+        if n:
+            print(f'  {label}: {n} files, {humansize(b)}')
+        total_files += n
+        total_bytes += b
+    return total_files, total_bytes
 
 
 def gc_handoff(dry_run):
@@ -110,67 +185,7 @@ def main():
     print(f'  keep trajectory ≤ {KEEP_TRAJECTORY_DAYS}d, session ≤ {KEEP_SESSION_DAYS}d, '
           f'bak ≤ {KEEP_BAK_DAYS}d, workspace .tmp ≤ {KEEP_TMP_DAYS}d')
 
-    total_files, total_bytes = 0, 0
-
-    # trajectory.jsonl — biggest disk hog, shortest retention
-    f, b = gc_files(
-        lambda n: n.endswith('.trajectory.jsonl'),
-        now - KEEP_TRAJECTORY_DAYS * 86400,
-        'trajectory.jsonl', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
-
-    # Plain .jsonl (no trajectory suffix) — main session log
-    f, b = gc_files(
-        lambda n: n.endswith('.jsonl') and not n.endswith('.trajectory.jsonl'),
-        now - KEEP_SESSION_DAYS * 86400,
-        'plain .jsonl', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
-
-    # .json sidecars (metadata)
-    f, b = gc_files(
-        lambda n: n.endswith('.json'),
-        now - KEEP_SESSION_DAYS * 86400,
-        '.json sidecar', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
-
-    # *.bak-{PID}-{ts}, *.pre-cleanup-*, *.bak — anywhere in name
-    f, b = gc_files(
-        lambda n: '.bak-' in n or '.pre-cleanup-' in n or n.endswith('.bak'),
-        now - KEEP_BAK_DAYS * 86400,
-        'bak / pre-cleanup', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
-
-    # Stale rename leftovers like *.jsonl.1779044443580 (epoch-ms suffix)
-    f, b = gc_files(
-        lambda n: any(n.endswith(suf) for suf in ('.tmp', '.old')) or
-                  n.split('.')[-1].isdigit() and len(n.split('.')[-1]) >= 10,
-        now - KEEP_BAK_DAYS * 86400,
-        'tmp / numeric-suffix', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
-
-    # Tombstones like *.jsonl.deleted.2026-06-14T19-00-50.702Z / *.jsonl.reset.<iso>.
-    # The suffix is an ISO timestamp ending in "Z", so it matches none of the
-    # predicates above (not .jsonl/.json/.bak, and "702Z" is not .isdigit()) —
-    # these accumulated unbounded until 2026-07-15 (78 files back to 06-13).
-    # The live transcript is already gone by the time one is written, so they
-    # age out on the same clock as a plain session.
-    f, b = gc_files(
-        lambda n: '.jsonl.deleted.' in n or '.jsonl.reset.' in n,
-        now - KEEP_SESSION_DAYS * 86400,
-        'deleted / reset tombstone', args.dry_run,
-    )
-    total_files += f
-    total_bytes += b
+    total_files, total_bytes = gc_sessions_dir(now, args.dry_run)
 
     # workspace memory/.tmp — preflight contexts / sidecars / scratch PNGs.
     # Everything here is per-date scratch that builders read by "newest mtime"

--- a/ops/host/gold_dca_refresh.sh
+++ b/ops/host/gold_dca_refresh.sh
@@ -9,7 +9,11 @@
 # 本脚本刚写入的 gold 字段(2026-06-10 23:30 撞车,gold 数据被回退一天,06-11 复盘后挪到 23:50)。
 #
 # 真值字段 principal_invested / units_held 由 kcn 对账后手填,本脚本绝不改。
-set -uo pipefail
+# -e: an unguarded failed step used to fall through to `git diff --cached
+# --quiet` == true and report 「净值无变化」 — e.g. losing the night's NAV to a
+# transient index.lock collision with the 20-minute publisher looked identical
+# to "nothing changed". Every remaining command is either guarded or fatal.
+set -euo pipefail
 
 WS=/root/.openclaw/workspace
 cd "$WS" || exit 1
@@ -21,14 +25,18 @@ cd "$WS" || exit 1
 # 重建本机副本,但不再入库:四个产物已随 #314 迁到 data-plane 分支,
 # 由定时 publisher 发布(最多落后 20 分钟)。这里再 `git add` 它们会因为
 # .gitignore 直接失败,而不是静默跳过。
-/root/.local/bin/clawock dashboard-build     || { echo "$(date -Is) gold dashboard-build 失败"; exit 1; }
+# --skip-if-unchanged (#846): 节假日/重复值之夜指纹不变就跳过整场 ~12MB 重建,
+# 与 publisher 同一语义。有新净值时照常全量构建。
+/root/.local/bin/clawock dashboard-build --skip-if-unchanged \
+  || { echo "$(date -Is) gold dashboard-build 失败"; exit 1; }
 
 # 自动任务 → 用 bot 身份提交,但走 `git -c`(单次注入)而非 `git config`(持久),
 # 否则会污染交互 Claude-Code 会话的提交身份(kcn 要那些 = KCNyu)。
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 
-git add portfolio.json
+git add portfolio.json \
+  || { echo "$(date -Is) gold-refresh: git add 失败(疑似 index.lock 撞车),当晚数据不入库"; exit 1; }
 if git diff --cached --quiet; then
   echo "$(date -Is) gold-refresh: 净值无变化,跳过"
   exit 0

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -80,6 +80,12 @@ OPENCLAW_CONFIG = _OPENCLAW_PATHS.config_file
 # runtime coupling the ratchet bans, and the host tools directory belongs to
 # whoever runs the check, not to this repository.
 HOST_TOOLS_DIR = Path.home() / 'tools'
+# The pipx-style launcher directory: every watchdog/DST entry point in
+# config/cron-schedules.json starts with <home>/.local/bin/clawock-*, so an
+# audit that only knows ~/tools skips exactly the commands whose silent death
+# matters most (#775 class — the DST syncer died for 8 days while every
+# repository-side gate stayed green).
+LAUNCHER_BIN_DIR = Path.home() / '.local' / 'bin'
 
 MEMORY_INDEX_LOG = LIVE_WORKSPACE / 'logs' / 'memory_index.log'
 # Nightly reindex is 05:10 HKT; 30h lets one run slip into the next daily review
@@ -764,7 +770,8 @@ def _host_crontab_target_audit(crontab_text):
                 continue
             target = Path(token)
             if not any(target.is_relative_to(root)
-                       for root in (LIVE_WORKSPACE, HOST_TOOLS_DIR)):
+                       for root in (LIVE_WORKSPACE, HOST_TOOLS_DIR,
+                                    LAUNCHER_BIN_DIR)):
                 continue
             if not os.path.exists(target):
                 missing.append(token)

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -868,19 +868,36 @@ def test_gha_freshness_registry_matches_workflow_crons():
         assert len(expressions) == text.count("- cron:"), (
             f"unsupported cron syntax in {workflow}"
         )
-        actual = set()
-        for expression in expressions:
+        def _key(expression):
             minute, hour, dom, month, dow = expression.split()
             assert dom == month == "*"
             assert minute.isdigit() and hour.isdigit()
-            actual.add(("UTC", _cron_python_weekdays(dow), int(hour), int(minute)))
+            return ("UTC", _cron_python_weekdays(dow), int(hour), int(minute))
 
+        keys = [_key(expression) for expression in expressions]
         policy = dashboard._FRESHNESS_POLICY[artifact]["schedule"]
         expected = {
             (fire["timezone"], tuple(fire["weekdays"]), fire["hour"], fire["minute"])
             for fire in policy["fires"]
         }
-        assert actual == expected, f"{artifact} cadence drifted from {workflow}"
+        # Multi-tier workflows (the brief-fallback pattern): every declared
+        # fire keeps a verbatim cron tier, but extra LATER same-day tiers are
+        # allowed as idempotent retries. A retry must never move the freshness
+        # expectation — on a low-drift day the primary already committed and
+        # the retry no-ops, so demanding data newer than the retry would
+        # false-red every calm day.
+        missing = expected - set(keys)
+        assert not missing, f"{artifact} lost its cron for {missing}"
+        extras = [key for key in keys if key not in expected]
+        for _, weekdays, hour, minute in extras:
+            earlier = [
+                e for e in expected
+                if e[1] == weekdays and (e[2], e[3]) < (hour, minute)
+            ]
+            assert earlier, (
+                f"{workflow}: extra tier {(hour, minute)} on {weekdays} is not "
+                f"a later same-day retry of a declared fire"
+            )
         assert sorted(fire["grace_hours"] for fire in policy["fires"]) == (
             expected_graces[artifact]
         )

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -159,3 +159,34 @@ def test_a_closed_weekend_is_silence_by_design():
         result = cron_health_check.check_scheduled_publisher(now=now, path=stale)
     assert result["state"] == "ok"
     assert "非交易日" in result["detail"]
+
+
+def test_commit_evidence_is_fetched_once_not_once_per_job(monkeypatch):
+    """Eleven enabled jobs used to mean eleven near-identical `git log`
+    subprocesses; the job loop now shares a single fetch."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        stamp = datetime.now(HKT).isoformat()
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"{stamp}\x00dashboard: 港股收盘报告 (hk 15:06 HKT)\n",
+        )
+
+    monkeypatch.setattr(cron_health_check.subprocess, "run", fake_run)
+    monkeypatch.setattr(cron_health_check, "_commit_log_cache", None)
+
+    patterns = ["港股收盘报告", "港股收盘报告", "美股.*收盘", "no-such-pattern"]
+    counts = [cron_health_check.commit_count_today(p) for p in patterns]
+
+    assert counts == [1, 1, 0, 0]
+    assert len(calls) == 1
+
+
+def test_commit_evidence_degrades_to_zero_when_git_fails(monkeypatch):
+    monkeypatch.setattr(cron_health_check, "_commit_log_cache", None)
+    monkeypatch.setattr(
+        cron_health_check.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=128, stdout=""))
+    assert cron_health_check.commit_count_today("anything") == 0

--- a/tests/test_gc_sessions_rules.py
+++ b/tests/test_gc_sessions_rules.py
@@ -1,0 +1,123 @@
+"""gc_sessions must delete exactly what the per-rule sweeps deleted.
+
+The nightly sweep used to be six full iterdir() passes; it is now one pass
+that deletes a file iff ANY matching rule's cutoff makes it stale. The subtle
+case is a name matching two rules with different retentions — e.g.
+`2026-08-01.bak-1.jsonl` matches both the plain-.jsonl rule (14d) and the
+bak rule (3d): three days after creation it must go, even though it is far
+younger than the session retention, because the old pass-4 would have caught
+it. Behavioural tests drive main() with scratch directories.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_gc_sessions", ROOT / "ops" / "host" / "gc_sessions.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gc = _load()
+
+
+def _point_dirs(monkeypatch, tmp_path):
+    sessions = tmp_path / "sessions"
+    tmp = tmp_path / "mem" / ".tmp"
+    sessions.mkdir()
+    tmp.mkdir(parents=True)
+    monkeypatch.setattr(gc, "SESSIONS_DIR", sessions)
+    monkeypatch.setattr(gc, "WORKSPACE_TMP", tmp)
+    monkeypatch.setattr(gc, "HANDOFF_FILE", tmp_path / "absent-handoff.json")
+    return sessions
+
+
+def test_a_multi_match_name_ages_out_on_its_shortest_retention(
+        monkeypatch, tmp_path):
+    """bak-1.jsonl: 5 days old → bak rule (3d) fires even though the jsonl
+    rule (14d) alone would keep it."""
+    sessions = _point_dirs(monkeypatch, tmp_path)
+    f = sessions / "2026-08-01.bak-1.jsonl"
+    f.write_text("{}")
+    import os
+    old = gc.KEEP_BAK_DAYS + 2
+    stamp = __import__("time").time() - old * 86400
+    os.utime(f, (stamp, stamp))
+
+    total_files, _ = gc.gc_sessions_dir(__import__("time").time(), False)
+
+    assert total_files == 1 and not f.exists()
+
+
+def test_a_young_multi_match_name_survives(monkeypatch, tmp_path):
+    sessions = _point_dirs(monkeypatch, tmp_path)
+    f = sessions / "2026-08-20.bak-1.jsonl"
+    f.write_text("{}")  # mtime = now
+
+    total_files, _ = gc.gc_sessions_dir(__import__("time").time(), True)
+
+    assert total_files == 0 and f.exists()
+
+
+def test_one_pass_deletes_the_same_set_the_six_passes_did(
+        monkeypatch, tmp_path):
+    """Golden set spanning every rule, mixed fresh and stale, plus a file no
+    rule matches (must survive forever)."""
+    import os
+    import time
+
+    now = time.time()
+    cases = {
+        # name: (age_days, should_be_deleted)
+        "s1.trajectory.jsonl": (8, True),
+        "s2.trajectory.jsonl": (2, False),
+        "s3.jsonl": (15, True),
+        "s4.jsonl": (10, False),
+        "s5.json": (15, True),
+        "x.bak-1.jsonl": (4, True),      # multi-match: bak retention wins
+        "y.pre-cleanup-2.json": (2, False),
+        "s6.jsonl.1779044443580": (4, True),
+        "t7.jsonl.deleted.2026-06-14T19-00-50.702Z": (20, True),
+        "t8.jsonl.reset.2026-08-20T01-00-00.000Z": (1, False),
+        "unmatched.txt": (400, False),   # nothing matches .txt
+    }
+    sessions = _point_dirs(monkeypatch, tmp_path)
+    for name, (age, _) in cases.items():
+        p = sessions / name
+        p.write_text("x")
+        stamp = now - age * 86400
+        os.utime(p, (stamp, stamp))
+
+    total_files, _ = gc.gc_sessions_dir(now, False)
+
+    expected = sum(1 for _, gone in cases.values() if gone)
+    assert total_files == expected
+    for name, (_, gone) in cases.items():
+        assert (sessions / name).exists() is not gone, name
+
+
+def test_main_reports_totals_and_never_touches_unmatched(
+        monkeypatch, tmp_path, capsys):
+    sessions = _point_dirs(monkeypatch, tmp_path)
+    dead = sessions / "old.trajectory.jsonl"
+    dead.write_text("x")
+    import os
+    import time
+    stamp = time.time() - (gc.KEEP_TRAJECTORY_DAYS + 1) * 86400
+    os.utime(dead, (stamp, stamp))
+    monkeypatch.setattr(sys, "argv", ["gc_sessions.py"])
+
+    gc.main()
+
+    out = capsys.readouterr().out
+    assert "trajectory.jsonl: 1 files" in out
+    assert "freed 1 files" in out or "would free 1 files" not in out
+    assert not dead.exists()

--- a/tests/test_system_check_host_crontab.py
+++ b/tests/test_system_check_host_crontab.py
@@ -40,11 +40,14 @@ def host_roots(system_check, monkeypatch, tmp_path):
     this machine's real workspace or tools directory."""
     workspace = tmp_path / "workspace"
     tools = tmp_path / "tools"
+    launchers = tmp_path / ".local" / "bin"
     workspace.mkdir()
     tools.mkdir()
+    launchers.mkdir(parents=True)
     monkeypatch.setattr(system_check, "LIVE_WORKSPACE", workspace)
     monkeypatch.setattr(system_check, "HOST_TOOLS_DIR", tools)
-    return workspace, tools
+    monkeypatch.setattr(system_check, "LAUNCHER_BIN_DIR", launchers)
+    return workspace, tools, launchers
 
 
 def _run(system_check, monkeypatch, stdout="", returncode=0):
@@ -60,7 +63,7 @@ def _run(system_check, monkeypatch, stdout="", returncode=0):
 
 def test_a_workspace_script_behind_python3_that_vanished_is_critical(
         system_check, monkeypatch, host_roots):
-    workspace, _ = host_roots
+    workspace, _, _ = host_roots
     dead = workspace / "ops" / "growth" / "indexnow_submit.py"
     checks = _run(system_check, monkeypatch, stdout=(
         f"0 12 * * * /usr/bin/python3 {dead} >> {workspace}/logs/indexnow.log 2>&1\n"
@@ -74,7 +77,7 @@ def test_a_workspace_script_behind_python3_that_vanished_is_critical(
 
 def test_a_tools_script_that_vanished_is_critical(
         system_check, monkeypatch, host_roots):
-    _, tools = host_roots
+    _, tools, _ = host_roots
     dead = tools / "clawock-autoloop" / "run.sh"
     checks = _run(system_check, monkeypatch, stdout=f"0 23 * * * {dead}\n")
 
@@ -86,7 +89,7 @@ def test_a_tools_script_that_vanished_is_critical(
 
 def test_existing_scripts_keep_the_gate_green(
         system_check, monkeypatch, host_roots):
-    workspace, _ = host_roots
+    workspace, _, _ = host_roots
     live = workspace / "ops" / "host" / "sync_us_cron_dst.py"
     live.parent.mkdir(parents=True)
     live.write_text("")
@@ -101,7 +104,7 @@ def test_existing_scripts_keep_the_gate_green(
 
 def test_a_redirect_target_is_not_judged_as_a_missing_file(
         system_check, monkeypatch, host_roots):
-    workspace, _ = host_roots
+    workspace, _, _ = host_roots
     live = workspace / "ops" / "host" / "sync_us_cron_dst.py"
     live.parent.mkdir(parents=True)
     live.write_text("")
@@ -136,6 +139,32 @@ def test_absolute_paths_outside_the_host_roots_are_not_judged(
         system_check, monkeypatch, host_roots):
     checks = _run(system_check, monkeypatch, stdout=(
         "0 9 * * * /usr/bin/python3 /opt/missing_thing.py\n"))
+
+    assert checks == [("host crontab targets", system_check.OK,
+                       "1 lines · no missing targets")]
+
+
+def test_a_vanished_launcher_is_critical_not_skipped(
+        system_check, monkeypatch, host_roots):
+    """Every watchdog command in the contract starts with a ~/.local/bin
+    launcher; before this root joined the audit those tokens were skipped, so
+    a renamed launcher would have silenced the whole fallback layer invisibly
+    (#775 class)."""
+    launchers = host_roots[-1]
+    dead = launchers / "clawock-brief-watchdog"
+    checks = _run(system_check, monkeypatch, stdout=f"*/10 0-1 * * * {dead}\n")
+
+    assert checks == [
+        ("host crontab targets", system_check.CRITICAL,
+         f"crontab points at missing file: {dead}"),
+    ]
+
+
+def test_a_present_launcher_stays_clean(system_check, monkeypatch, host_roots):
+    launchers = host_roots[-1]
+    alive = launchers / "clawock-intraday-watchdog"
+    alive.write_text("#!/bin/sh\n")
+    checks = _run(system_check, monkeypatch, stdout=f"*/10 22-23 * * * {alive}\n")
 
     assert checks == [("host crontab targets", system_check.OK,
                        "1 lines · no missing targets")]

--- a/tests/test_workflow_health.py
+++ b/tests/test_workflow_health.py
@@ -127,3 +127,43 @@ def test_weekly_health_runs_it_with_the_permission_it_needs():
     assert "ops/ci/workflow_health.py" in workflow
     assert "actions: read" in workflow
     assert "GH_TOKEN: ${{ github.token }}" in workflow
+
+
+def test_the_rollup_surfaces_on_the_run_page(tmp_path, monkeypatch, capsys):
+    """A green continue-on-error step with log-only output is how three days of
+    news-digest failures stayed invisible; the summary table and the
+    ::warning:: annotations are what make a bad week visible on the run page."""
+    summary = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    result = {
+        "as_of": NOW.isoformat(),
+        "lookback_days": wh.LOOKBACK_DAYS,
+        "scheduled_workflows": 2,
+        "needs_attention": 1,
+        "workflows": [
+            {"workflow": "healthy.yml", "status": "ok", "last_run": NOW.isoformat(),
+             "last_conclusion": "success", "consecutive_failures": 0,
+             "failures_in_window": 0, "overdue_hours": None,
+             "expected_interval_hours": 24},
+            {"workflow": "broken.yml", "status": "attention",
+             "last_run": NOW.isoformat(), "last_conclusion": "failure",
+             "consecutive_failures": 3, "failures_in_window": 3,
+             "overdue_hours": 30, "expected_interval_hours": 24},
+        ],
+    }
+
+    wh._surface(result)
+
+    text = summary.read_text()
+    assert "Scheduled workflow health" in text
+    assert "broken.yml" in text and "3 consecutive failures" in text
+    assert "no run for 30h" in text
+    out = capsys.readouterr().out
+    assert "::warning::scheduled workflow broken.yml:" in out
+    assert "healthy.yml" not in out.split("::warning::")[-1]
+
+
+def test_surface_is_a_noop_without_a_runner_summary(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    wh._surface({"needs_attention": 0, "scheduled_workflows": 0,
+                 "lookback_days": 7, "workflows": []})  # must not raise


### PR DESCRIPTION
Second wave from the four-agent perf review (agents A–D), covering the GitHub Actions schedule layer and the host ops scripts. Fixes #921, fixes #922, fixes #923, fixes #924, fixes #925, fixes #926.

## What changed
| Issue | Fix | Test |
|---|---|---|
| #921 sentiment/macro pre-brief buffer busted by measured drift (max 213/199min vs 150/135min buffers) | second cron tier `55 21 * * 0-4` on both workflows (brief-fallback multi-tier pattern; idempotent overwrite) | contract tests still green |
| #922 news-digest/influencer comments contradict measured reality | comments cite schedule-drift.json medians; no behavior change | — |
| #923 weekly-health is the only Actions-side aggregate and it is log-only + always green | rollup written to `$GITHUB_STEP_SUMMARY`, `::warning::` per attention row (still exit 0); cron-health.yml folds needs_attention into the daily summary (`actions: read` added) | `test_the_rollup_surfaces_on_the_run_page`, `test_surface_is_a_noop_without_a_runner_summary` |
| #924 system_check audit skips `/root/.local/bin` — where every watchdog launcher lives | third audit root `LAUNCHER_BIN_DIR`; vanished launcher → CRITICAL instead of skip | `test_a_vanished_launcher_is_critical_not_skipped`, `test_a_present_launcher_stays_clean` |
| #925 cron_health_check ran the same `git log -n 500` once per enabled job (~11×) | one shared fetch per process, same failure semantics | `test_commit_evidence_is_fetched_once_not_once_per_job`, degrade test |
| #925 gc_sessions: six full iterdir passes, two stat() per candidate | single traversal + single stat; deletion set provably identical (OR over matching rules' cutoffs) | new `tests/test_gc_sessions_rules.py` incl. multi-match golden set |
| #926 gold_dca_refresh / commit_dreaming: no `-e`, unguarded `git add` → index.lock collision masquerades as 「无变化」 | `set -euo pipefail`, guarded add, gold build gets `--skip-if-unchanged` (#846 gate) | bash -n |

## Not changed
No gates removed, no provider order touched, no delivery-contract seams moved. All acceptance criteria are structural (process counts, traversal counts, audit coverage) rather than wall-clock claims — this box runs two cores under load ~2.2.