### PR TITLE
perf: memoize _shares_at_date two-level lookup (#916 item 2)

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -341,22 +341,44 @@ def collect_peer_scan(portfolio):
     return peer_scan.collect(portfolio)
 
 
+# Two-level memo for the follow-up verification sweep (#916): every decision
+# row asks the same one-or-two dates, and each ask used to cost a `git log`
+# plus a `git show` with a full JSON re-parse (~5s/slot of pure re-read).
+_shares_sha_cache = {}   # date_iso -> commit sha
+_shares_pf_cache = {}    # sha -> parsed portfolio.json
+
+
 def _shares_at_date(ticker, date_iso):
     """Get shares of `ticker` from portfolio.json as committed on/before `date_iso`.
-    Returns int shares, or None if can't determine."""
+    Returns int shares, or None if can't determine.
+
+    Past-date answers are immutable — today's commits cannot rewrite what was
+    HEAD before a past day — so the caches are exact there. A today-keyed sha
+    can go stale if a bot commits mid-preflight; the verdict self-heals on the
+    next slot's fresh process.
+    """
     try:
-        r = subprocess.run(
-            ['git', '-C', str(WS), 'log', '--pretty=%H',
-             f'--before={date_iso} 23:59:59', '-1', '--', 'portfolio.json'],
-            capture_output=True, text=True, timeout=10)
-        sha = r.stdout.strip()
-        if not sha:
-            return None
-        r = subprocess.run(['git', '-C', str(WS), 'show', f'{sha}:portfolio.json'],
-                           capture_output=True, text=True, timeout=10)
-        if r.returncode != 0:
-            return None
-        pf = json.loads(r.stdout)
+        sha = _shares_sha_cache.get(date_iso)
+        if sha is None:
+            r = subprocess.run(
+                ['git', '-C', str(WS), 'log', '--pretty=%H',
+                 f'--before={date_iso} 23:59:59', '-1', '--', 'portfolio.json'],
+                capture_output=True, text=True, timeout=10)
+            sha = r.stdout.strip()
+            if not sha:
+                return None
+            _shares_sha_cache[date_iso] = sha
+        pf = _shares_pf_cache.get(sha)
+        if pf is None:
+            r = subprocess.run(['git', '-C', str(WS), 'show', f'{sha}:portfolio.json'],
+                               capture_output=True, text=True, timeout=10)
+            if r.returncode != 0:
+                return None
+            try:
+                pf = json.loads(r.stdout)
+            except ValueError:
+                return None
+            _shares_pf_cache[sha] = pf
         for region in ('hk_stocks', 'us_stocks'):
             for h in pf['portfolios'][region]['holdings']:
                 if h['ticker'] == ticker:

--- a/tests/test_decision_v2.py
+++ b/tests/test_decision_v2.py
@@ -895,3 +895,34 @@ def test_assign_episode_ids_skips_mind_ledger_rows():
     broken = {"decision_id": "d3", "ticker": "00100", "strategy_id": "core", "action": "hold"}
     assign_episode_ids([broken])
     assert "episode_id" not in broken
+
+
+class TestSharesLookupMemoization(unittest.TestCase):
+    """#916: the verification sweep asks the same dates once per decision row;
+    each repeat must not re-run git log + git show + full JSON parse."""
+
+    def test_repeated_dates_and_tickers_are_served_from_cache(self):
+        import json as _json
+        from types import SimpleNamespace
+        from clawock.harness import brief_preflight
+
+        calls = []
+        pf = {"portfolios": {"hk_stocks": {"holdings": [
+            {"ticker": "00700", "shares": 100}]}},
+            "us_stocks": {"holdings": []}}
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd[:3])
+            if cmd[1] == "log":
+                return SimpleNamespace(returncode=0, stdout="abc123\n")
+            return SimpleNamespace(returncode=0, stdout=_json.dumps(pf))
+
+        monkey = mock.patch.object
+        with monkey(brief_preflight.subprocess, "run", fake_run), \
+             monkey(brief_preflight, "_shares_sha_cache", {}), \
+             monkey(brief_preflight, "_shares_pf_cache", {}):
+            self.assertEqual(brief_preflight._shares_at_date("00700", "2026-08-01"), 100)
+            self.assertEqual(brief_preflight._shares_at_date("00700", "2026-08-01"), 100)
+            self.assertEqual(len(calls), 2)      # log+show once, then cached
+            self.assertIsNone(brief_preflight._shares_at_date("00388", "2026-08-01"))
+            self.assertEqual(len(calls), 2)      # second ticker reuses the file


### PR DESCRIPTION
Part of #916 (item 2 only — DAG orchestration and decisions-ledger reuse land separately).

## Change
`_shares_at_date` ran `git log` + `git show` + full JSON parse per (ticker, date) ask; the follow-up verification sweep asks the same one-or-two dates once per decision row (~5s/slot of pure re-read). Now:

- `date_iso -> sha` cache: past-date answers are immutable (today's commits cannot rewrite what was HEAD before a past day), so caching is exact.
- `sha -> parsed portfolio.json` cache: repeated tickers over the same commit reuse one parse.

A today-keyed sha can go stale if a bot postflight commits mid-preflight; the verdict self-heals on the next slot's fresh process (documented in-code).

## Test
`TestSharesLookupMemoization`: repeated date → 2 subprocesses total; second ticker on same date → still 2. Existing `_detect_followed` suite untouched and green (60 passed).