### PR TITLE
perf-review wave 3a: decisions single-pass + gc bulk-deletion guards + review P2s

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -72,9 +72,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Report-only end to end: a gh hiccup here must cost a note in the
+          # summary, not redden a health check that has its own verdict.
           {
             echo "## Scheduled workflow health (Actions side)"
-            python3 ops/ci/workflow_health.py --json | python3 -c '
+            python3 ops/ci/workflow_health.py --json 2>/dev/null | python3 -c '
               import json, sys
               r = json.load(sys.stdin)
               print(f"needs attention: {r[\"needs_attention\"]} of {r[\"scheduled_workflows\"]} "
@@ -82,5 +84,5 @@ jobs:
               for w in r["workflows"]:
                   if w["status"] == "attention":
                       print(f"- ⚠ {w[\"workflow\"]}: last={w[\"last_conclusion\"] or \"-\"}")
-            '
+            ' || echo "(Actions-side rollup unavailable this run — see weekly-health)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ logs/*
 
 # Preflight transient context (regenerated every brief run)
 memory/.tmp/
+memory/.tmp-*
 
 # OpenClaw memory system internals (not for public consumption)
 memory/.dreams/

--- a/ops/host/gc_sessions.py
+++ b/ops/host/gc_sessions.py
@@ -41,6 +41,16 @@ KEEP_SESSION_DAYS    = int(os.environ.get('GC_KEEP_SESSION_DAYS',    '14'))
 KEEP_BAK_DAYS        = int(os.environ.get('GC_KEEP_BAK_DAYS',        '3'))
 KEEP_TMP_DAYS        = int(os.environ.get('GC_KEEP_TMP_DAYS',        '14'))
 
+for _name, _days in (('GC_KEEP_TRAJECTORY_DAYS', KEEP_TRAJECTORY_DAYS),
+                     ('GC_KEEP_SESSION_DAYS', KEEP_SESSION_DAYS),
+                     ('GC_KEEP_BAK_DAYS', KEEP_BAK_DAYS),
+                     ('GC_KEEP_TMP_DAYS', KEEP_TMP_DAYS)):
+    if _days < 0:
+        # A negative retention makes "older than cutoff" true for files that
+        # do not exist yet — i.e. delete everything, then keep deleting.
+        raise SystemExit(f'gc_sessions: {_name}={_days} is negative; '
+                         f'refusing to run (see #930)')
+
 
 def humansize(n):
     for unit in ['B', 'KB', 'MB', 'GB']:
@@ -114,12 +124,23 @@ def gc_files(pattern_predicate, cutoff_ts, label, dry_run, dirpath=None):
     return n_files, n_bytes
 
 
-def gc_sessions_dir(now_ts, dry_run):
+def gc_sessions_dir(now_ts, dry_run, allow_future=False):
     """One traversal for every SESSIONS_DIR rule.
 
     The sweeps used to be six full iterdir() passes re-stating every candidate
     twice (~18k stats a night); each file is now visited once and statted once.
+
+    A far-future ``now_ts`` makes every file stale by definition — one wrong
+    argument deletes the whole tree (the agent-E incident, #930: a review
+    simulation passed a synthetic 2027 timestamp against the real default
+    SESSIONS_DIR). Refuse such clocks loudly; the CLI passes time.time() and
+    never trips this.
     """
+    if not allow_future and now_ts > time.time() + 300:
+        raise ValueError(
+            f'now_ts ({now_ts}) is more than 5 minutes ahead of the wall '
+            f'clock — refusing bulk deletion; pass allow_future=True only '
+            f'from a test/simulation with an explicit scratch directory')
     if not SESSIONS_DIR.exists():
         return 0, 0
     per_rule = {label: [0, 0] for label, _, _ in SESSION_RULES}

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -468,8 +468,17 @@ def write_decisions(decisions: list[dict], path: Path = LEDGER) -> None:
             os.unlink(tmp)
 
 
-def upsert_plan_decisions(plan: dict, path: Path = LEDGER) -> tuple[int, int]:
-    existing = load_decisions(path)
+def upsert_plan_decisions(
+    plan: dict, path: Path = LEDGER,
+    ledger: list[dict] | None = None, write: bool = True,
+) -> tuple[int, int]:
+    """Upsert one plan's decisions into the ledger.
+
+    Callers orchestrating several ledger steps in one invocation (#916) pass
+    their already-loaded ``ledger`` and ``write=False``, then settle and write
+    once; standalone callers keep the old load-mutate-write behavior.
+    """
+    existing = ledger if ledger is not None else load_decisions(path)
     by_id = {d.get("decision_id"): d for d in existing}
     inserted = updated = 0
     for d in plan.get("decisions") or []:
@@ -490,7 +499,8 @@ def upsert_plan_decisions(plan: dict, path: Path = LEDGER) -> tuple[int, int]:
             by_id[did] = d
             inserted += 1
     assign_episode_ids(existing)
-    write_decisions(existing, path)
+    if write:
+        write_decisions(existing, path)
     return inserted, updated
 
 

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -520,10 +520,17 @@ def log_decisions(today):
         if d.get('simulated_entry_price') is None:
             d['simulated_entry_price'] = _current_price_for(d.get('ticker'))
     safe_write_json(str(plan_path), plan)
-    inserted, updated = decision_v2.upsert_plan_decisions(plan)
+    # One load, mutate in memory, write once only if something changed (#916):
+    # the old sequence was upsert(load+write) then load+settle+write — two full
+    # rewrites per brief even on the common no-new-decisions day.
     ledger = decision_v2.load_decisions()
+    before = json.dumps(ledger, ensure_ascii=False, sort_keys=True)
+    inserted, updated = decision_v2.upsert_plan_decisions(
+        plan, ledger=ledger, write=False)
     settled = decision_v2.settle_decisions(ledger)
-    decision_v2.write_decisions(ledger)
+    after = json.dumps(ledger, ensure_ascii=False, sort_keys=True)
+    if after != before:
+        decision_v2.write_decisions(ledger)
     print(f'  decisions.jsonl: +{inserted}, updated {updated}, settled {settled} ({len(ledger)} total)')
 
 

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -888,6 +888,9 @@ def test_gha_freshness_registry_matches_workflow_crons():
         # false-red every calm day.
         missing = expected - set(keys)
         assert not missing, f"{artifact} lost its cron for {missing}"
+        assert len(keys) == len(set(keys)), (
+            f"{workflow}: duplicated identical cron tiers are always a typo"
+        )
         extras = [key for key in keys if key not in expected]
         for _, weekdays, hour, minute in extras:
             earlier = [

--- a/tests/test_gc_sessions_rules.py
+++ b/tests/test_gc_sessions_rules.py
@@ -121,3 +121,39 @@ def test_main_reports_totals_and_never_touches_unmatched(
     assert "trajectory.jsonl: 1 files" in out
     assert "freed 1 files" in out or "would free 1 files" not in out
     assert not dead.exists()
+
+
+def test_a_far_future_clock_is_refused_not_obeyed(monkeypatch, tmp_path):
+    """The agent-E incident (#930): a simulation passed a synthetic 2027
+    timestamp against the real default SESSIONS_DIR and every file was stale
+    by definition. The sweep must refuse such clocks loudly instead."""
+    import time as _time
+    sessions = _point_dirs(monkeypatch, tmp_path)
+    f = sessions / "recent.jsonl"
+    f.write_text("x")  # mtime = now
+
+    try:
+        gc.gc_sessions_dir(_time.time() + 86400 * 365, False)
+    except ValueError as exc:
+        assert "allow_future" in str(exc)
+    else:
+        raise AssertionError("far-future clock must be refused")
+    assert f.exists()
+
+
+def test_negative_retention_env_is_rejected_at_import(monkeypatch, tmp_path):
+    """GC_KEEP_*=-1 would make 'older than cutoff' true for files that do not
+    exist yet; the module must die at load, not run."""
+    import importlib.util
+    import os
+
+    monkeypatch.setenv("GC_KEEP_TRAJECTORY_DAYS", "-1")
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_gc_sessions_neg", ROOT / "ops" / "host" / "gc_sessions.py")
+    try:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except SystemExit as exc:
+        assert "negative" in str(exc)
+    else:
+        raise AssertionError("negative retention must abort the module")

--- a/tests/test_llm_workflow_deadlines.py
+++ b/tests/test_llm_workflow_deadlines.py
@@ -18,11 +18,15 @@ ROOT = Path(__file__).resolve().parents[1]
 DEADLINE_KEY = "CLAWOCK_LLM_DEADLINE_SECONDS"
 
 # (workflow file, job id) for every job that invokes an LLM provider chain.
+# CHAINS: how many independent provider chains the job can run (influencer
+# scans twice daily in one workflow — two dispatch invocations, but one chain
+# per RUN). A job that legitimately chains N provider calls back-to-back must
+# declare a deadline covering the aggregate, not one leg (E-P2④).
 LLM_JOBS = [
-    ("brief-fallback.yml", "fallback"),
-    ("news-digest.yml", "digest"),
-    ("influencer-scan.yml", "scan"),
-    ("weekly-review.yml", "review"),
+    ("brief-fallback.yml", "fallback", 1),
+    ("news-digest.yml", "digest", 1),
+    ("influencer-scan.yml", "scan", 1),
+    ("weekly-review.yml", "review", 1),
 ]
 
 
@@ -45,16 +49,17 @@ def _deadline_seconds(job):
     return float(values[0])
 
 
-@pytest.mark.parametrize("workflow_name,job_id", LLM_JOBS)
-def test_the_provider_chain_fits_inside_the_job(workflow_name, job_id):
+@pytest.mark.parametrize("workflow_name,job_id,chains", LLM_JOBS)
+def test_the_provider_chain_fits_inside_the_job(workflow_name, job_id, chains):
     job = _workflow(workflow_name)["jobs"][job_id]
 
-    budget = _deadline_seconds(job)
+    budget = _deadline_seconds(job) * chains
     job_seconds = float(job["timeout-minutes"]) * 60
 
     assert budget < job_seconds, (
-        f"{workflow_name}: the LLM budget must fit inside the job, or the "
-        f"second provider is unreachable code rather than a fallback"
+        f"{workflow_name}: {chains} chain(s) x deadline must fit inside the "
+        f"job, or the second provider is unreachable code rather than a "
+        f"fallback"
     )
     assert job_seconds - budget >= 60, (
         f"{workflow_name}: setup, validation and commit still have to fit in "


### PR DESCRIPTION
Part of #916 (item 3). Fixes #930. Carries agent-E's adversarial pass on waves 1–2: **0 P0 / 0 P1 / 6 P2** — the actionable P2s land here.

## Commits
1. **decisions ledger single-pass** (#916 item 3) — `log_decisions` did upsert(load+write) then load+settle+write: two full rewrites per brief even on the common no-new-decisions day. Now one load → mutate in memory → conditional write via canonical serialization compare. `upsert_plan_decisions` gains optional `ledger=`/`write=` so standalone callers keep the old behavior.
2. **#930 guards** — `gc_sessions_dir` refuses far-future clocks (> wall +300s) unless `allow_future=True`; negative `GC_KEEP_*` retention aborts at load; `.gitignore memory/.tmp-*`.
3. **E-P2 batch** — cron-health fold-in degrades to a summary note instead of reddening the daily check on a gh hiccup; freshness registry test rejects duplicated identical cron tiers; deadline contract test models aggregate chain budgets per job.

## Incident note (#930)
Agent-E's differential simulation called `gc_sessions_dir(now=2027, dry_run=False)` without redirecting the module-global `SESSIONS_DIR` and deleted live session transcripts (designed-ephemeral class, 7–14d retention). Workspace ledgers/portfolio/git verified untouched. The guard turns that misuse class into a loud error.