### PR TITLE
perf: reuse one requests Session across LLM provider legs (#917 slice)

### DIFF
--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -58,6 +58,11 @@ import time
 
 import requests
 
+# Module-level session: provider legs reuse one connection pool instead of a
+# fresh TCP+TLS handshake per attempt (C-F2). Retry chains are exactly where
+# this pays — the fallback leg often fires seconds after the primary died.
+_SESSION = requests.Session()
+
 MINIMAX_BASE = 'https://api.minimaxi.com/anthropic'
 MINIMAX_MODEL = 'MiniMax-M3'
 MINIMAX_MAX_TOKENS = 131072  # M3 maxOutput
@@ -233,7 +238,7 @@ def _call_provider(label, base_url, api_key, model, messages, max_tokens,
             last_err = last_err or 'budget exhausted before any attempt completed'
             break
         try:
-            r = requests.post(f'{base_url}/v1/messages',
+            r = _SESSION.post(f'{base_url}/v1/messages',
                               json=body, headers=headers, timeout=per_attempt)
             if r.status_code == 200:
                 data = r.json()
@@ -294,7 +299,7 @@ def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
             last_err = last_err or 'budget exhausted before any attempt completed'
             break
         try:
-            r = requests.post(f'{base_url}/chat/completions',
+            r = _SESSION.post(f'{base_url}/chat/completions',
                               json=body, headers=headers, timeout=per_attempt)
             if r.status_code == 200:
                 data = r.json()

--- a/tests/test_llm_chain_budget.py
+++ b/tests/test_llm_chain_budget.py
@@ -108,3 +108,31 @@ def test_an_exhausted_budget_yields_instead_of_burning_the_last_seconds():
     assert llm._attempt_timeout(900, None, "x") == 900
     clamped = llm._attempt_timeout(900, time.monotonic() + 30, "x")
     assert 25 <= clamped <= 30
+
+
+def test_both_provider_legs_reuse_one_session(monkeypatch):
+    """C-F2: retry chains used to open a fresh TCP+TLS handshake per attempt;
+    both legs must go through the module-level Session pool instead."""
+    calls = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"content": [{"type": "text", "text": "ok"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+    class _FakeSession:
+        def post(self, url, **kwargs):
+            calls.append(url)
+            return _FakeResponse()
+
+    monkeypatch.setattr(llm, "_SESSION", _FakeSession())
+
+    out = llm._call_provider(
+        label="primary", base_url="https://p.example", api_key="k",
+        model="m", messages=[{"role": "user", "content": "hi"}],
+        max_tokens=8, timeout=5, temperature=0.5,
+        json_response=False, thinking=None)
+    assert out == "ok"
+    assert calls == ["https://p.example/v1/messages"]


### PR DESCRIPTION
Part of #917 (C-F2). Module-level `_SESSION = requests.Session()`; both provider legs (Anthropic Messages + OpenAI-compatible) post through the pool.

## Why
Every attempt opened a fresh TCP+TLS handshake. Retry chains are exactly where that bites: the fallback leg often fires seconds after the primary died, paying full handshake latency again on a bad night.

## Scope
- Zero control-flow change, zero new dependencies — `requests` already pools; the code just was not using it.
- Regression test pins both legs through one session object.