### PR TITLE
fix: signal_review MIN_N gate + reverse-readings display-only (#934)

### DIFF
--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -12,8 +12,10 @@
   stop_breached   → 破吊灯线后 T+5 继续跌的比例（止损线是否值得执行）
 
 写 assets/data/quant_signal_review.json。公开 events/dates/tickers 三种样本数并使用
-date×ticker 双向聚类 bootstrap CI。CI 跨 50% 不入决策；低于 50% 也只有在反向
-CI 整体成立时才允许反向解读，不按 raw n 自动解锁。
+date×ticker 双向聚类 bootstrap CI。解锁纪律与 t0_setup_review 对齐（#934）：
+MIN_N=20 样本不足不得当结论引用，CI 跨 50% 不入决策；低于 50% 也只有在反向
+CI 整体成立时才允许反向解读。T+5/T+20 窗口逐日重叠 → 披露 non_overlap_cap
+（标的数 × 天数 ÷ horizon），n 超过它时结论打折。
 纯本地文件运算，无网络请求，brief preflight 每日顺跑。
 """
 import json
@@ -27,6 +29,10 @@ from clawock.workspace import workspace_root
 WS = workspace_root(Path.cwd())
 HIST = WS / 'assets' / 'data' / 'quant_signals_history.jsonl'
 OUT = WS / 'assets' / 'data' / 'quant_signal_review.json'
+
+# 因子结论可被引用的最小样本量——与 setup_review.MIN_N 同一条纪律。此前文档
+# 承诺「样本<20 不解锁」但代码没有这个闸（#934），小样本假解锁全部偏向高估。
+MIN_N = 20
 
 # 因子 → (触发条件, 预期方向: +1=涨算命中 / -1=跌算命中, 结算窗口天数)
 FACTOR_TESTS = {
@@ -86,7 +92,8 @@ def main(argv=None):
                 continue
     days.sort(key=lambda d: d['as_of'])
 
-    stats = {k: {'n': 0, 'hits': 0, 'observations': []} for k in FACTOR_TESTS}
+    stats = {k: {'n': 0, 'hits': 0, 'observations': [], 'horizon': h}
+             for k, (_, _, h) in FACTOR_TESTS.items()}
     for i, day in enumerate(days):
         for sym, sig in (day.get('rows') or {}).items():
             c0 = sig.get('close')
@@ -120,15 +127,23 @@ def main(argv=None):
         reverse_sig = ci is not None and ci[1] < 0.5
         direction = ('original' if edge_sig else
                      'reverse' if reverse_sig else None)
-        usable_now = direction is not None
-        if ci is None:
+        # Unlock discipline, aligned with setup_review (#934): the sample-size
+        # gate comes first — a tiny-n CI clearing 50% is noise, not edge — then
+        # the cluster-CI gate decides the direction.
+        sample_sufficient = s['n'] >= MIN_N
+        if not sample_sufficient:
+            note = f'样本 < {MIN_N}，方向结论不入决策（#934 与文档承诺对齐）'
+            direction = None
+        elif ci is None:
             note = 'date/ticker 聚类不足，方向结论不入决策'
-        elif not usable_now:
+        elif direction is None:
             note = '聚类 CI 跨 50%，方向结论不入决策'
         elif reverse_sig:
             note = '反向聚类 CI 完全低于 50%，仅允许反向解读'
         else:
             note = ''
+        usable_now = (sample_sufficient and ci is not None
+                      and direction == 'original')
         factors[name] = {'n_events': s['n'],
                          'n_dates': len(dates),
                          'n_tickers': len(tickers),
@@ -137,7 +152,11 @@ def main(argv=None):
                          'ci_method': 'date_ticker_two_way_cluster_bootstrap',
                          'edge_significant': edge_sig,
                          'reverse_edge_significant': reverse_sig,
-                         'decision_direction': direction,
+                         'sample_sufficient': sample_sufficient,
+                         'min_n': MIN_N,
+                         'non_overlap_cap': (len(tickers) * (len(days) // s['horizon'])
+                                             if s['horizon'] else 0),
+                         'decision_direction': direction if usable_now else None,
                          'usable': usable_now,
                          'note': note}
         if usable_now and wr is not None:

--- a/tests/test_quant_signal_review.py
+++ b/tests/test_quant_signal_review.py
@@ -122,9 +122,12 @@ def test_empty_history_has_no_rates_or_unlocked_factors(monkeypatch):
             "ci_method": "date_ticker_two_way_cluster_bootstrap",
             "edge_significant": False,
             "reverse_edge_significant": False,
+            "sample_sufficient": False,
+            "min_n": 20,
+            "non_overlap_cap": 0,
             "decision_direction": None,
             "usable": False,
-            "note": "date/ticker 聚类不足，方向结论不入决策",
+            "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）",
         }
         for factor in result["factors"].values()
     )
@@ -172,9 +175,16 @@ def test_low_hit_rate_reverses_only_when_cluster_ci_is_below_half(monkeypatch):
     assert factor["ci95"] == [0.0, 0.0]
     assert factor["edge_significant"] is False
     assert factor["reverse_edge_significant"] is True
-    assert factor["decision_direction"] == "reverse"
-    assert factor["usable"] is True
-    assert "反向" in result["summary"]
+    # #934 alignment with setup_review: decision_direction only carries a
+    # value when the conclusion is actually usable; a reverse reading is
+    # surfaced via reverse_edge_significant/note, never auto-traded.
+    assert factor["decision_direction"] is None
+    assert factor["usable"] is False
+    assert "反向" in factor["note"]
+    # 旧契约把「反向 CI 成立」也标 usable=True 并写进 summary —— 等于自动反向
+    # 入决策。对齐 setup_review（#819/#934）：反向只展示（reverse_edge_
+    # significant/note），永不解锁，更不自动反向交易。
+    assert "trend_on_follow" not in result["summary"]
 
 
 def test_cluster_ci_crossing_half_stays_out_of_decisions(monkeypatch):
@@ -247,3 +257,21 @@ def test_cluster_ci_requires_both_date_and_ticker_clusters():
     ]
     assert review.clustered_ci(one_date) is None
     assert review.clustered_ci(one_ticker) is None
+
+
+def test_twenty_events_with_perfect_ci_still_need_min_n(monkeypatch):
+    """The #934 core case: 15 events, every one a hit — the cluster CI clears
+    50% entirely, but the documented 「样本<20 不解锁」 rule must hold. Under
+    the old code this exact shape unlocked usable=True on n=15."""
+    result = _run_review(
+        monkeypatch,
+        _clustered_factor_days("trend_on_follow", [[True] * 5] * 3),
+    )
+
+    factor = result["factors"]["trend_on_follow"]
+    assert factor["n_events"] == 15
+    assert factor["hit_rate"] == 1.0
+    assert factor["sample_sufficient"] is False
+    assert factor["usable"] is False
+    assert factor["decision_direction"] is None
+    assert "trend_on_follow" not in result["summary"]


### PR DESCRIPTION
Fixes #934 (the code half; the comment reword lands after wave-3b to avoid a conflict in brief_preflight.py).

## What kcn's instinct turned out to mean
Audit verdict: t0-review was already disciplined (MIN_N + Wilson + overlap cap); **signal_review was not**. Three gaps, all biasing toward overestimating factor edge:

| Gap | Old behavior | New |
|---|---|---|
| No sample floor despite docs promising 样本<20 不解锁 | n=3 could unlock | MIN_N=20 gate first, `sample_sufficient`/`min_n` published |
| Overlapping T+5 windows, no disclosure | cluster bootstrap only | `non_overlap_cap` = tickers × days ÷ horizon |
| Reverse-CI readings set usable=True and entered the brief summary | auto-reverse into decisions | display-only (`reverse_edge_significant` + note), mirroring setup_review's 不自动反向交易 |

## Visible change
Brief summaries can list fewer "usable" factors than before — small-n and reverse-only factors drop out. That is the point.