### PR TITLE
feat: point-in-time factor snapshots for scan sidecars (#936 slice)

### DIFF
--- a/.github/workflows/macro-scan.yml
+++ b/.github/workflows/macro-scan.yml
@@ -44,10 +44,20 @@ jobs:
       - name: Validate macro coverage
         run: clawock validate-sidecar macro
 
+      - name: Snapshot point-in-time copy
+        # factor-snapshots/ keeps a verbatim dated copy of every sidecar
+        # generation (#936): the live file is overwritten in place, so any
+        # later factor research reading it would see today's data, not what
+        # the day's decisions actually saw. Research reads the dated row.
+        run: python3 ops/ci/snapshot_factor_sidecar.py --source assets/data/macro.json
+
       - name: Commit
         # Shared helper commits only this workflow's sidecar. The frontend fetches
         # it directly; dashboard.json is not rebuilt for it.
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
-          bash ops/publish/gha_commit_push.sh "macro: daily snapshot $(date -u +%Y-%m-%d)" assets/data/macro.json
+          bash ops/publish/gha_commit_push.sh \
+            "macro: daily snapshot $(date -u +%Y-%m-%d)" \
+            assets/data/macro.json \
+            assets/data/factor-snapshots/macro

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -44,10 +44,20 @@ jobs:
       - name: Validate sentiment coverage
         run: clawock validate-sidecar sentiment
 
+      - name: Snapshot point-in-time copy
+        # factor-snapshots/ keeps a verbatim dated copy of every sidecar
+        # generation (#936): the live file is overwritten in place, so any
+        # later factor research reading it would see today's data, not what
+        # the day's decisions actually saw. Research reads the dated row.
+        run: python3 ops/ci/snapshot_factor_sidecar.py --source assets/data/sentiment.json
+
       - name: Commit
         # Shared helper commits only this workflow's sidecar. The frontend fetches
         # it directly; dashboard.json is not rebuilt for it.
         env:
           CLAWOCK_PUBLISH_SSH_KEY: ${{ secrets.CLAWOCK_PUBLISH_SSH_KEY }}
         run: |
-          bash ops/publish/gha_commit_push.sh "sentiment: daily Reddit + Google News scan $(date -u +%Y-%m-%d)" assets/data/sentiment.json
+          bash ops/publish/gha_commit_push.sh \
+            "sentiment: daily Reddit + Google News scan $(date -u +%Y-%m-%d)" \
+            assets/data/sentiment.json \
+            assets/data/factor-snapshots/sentiment

--- a/ops/ci/snapshot_factor_sidecar.py
+++ b/ops/ci/snapshot_factor_sidecar.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Snapshot an overwrite-in-place data sidecar into a date-keyed archive.
+
+factor-snapshots/ gives the factor-research layer a point-in-time record
+(#936): sentiment.json / macro.json are overwritten in place by their scan
+workflows, so any backtest reading them after the fact sees TODAY's file,
+not the one the day's decisions actually saw — the classic look-ahead trap.
+Each daily scan now archives a verbatim byte copy under
+assets/data/factor-snapshots/<name>/<UTC-date>.json before the overwrite
+cycle continues; research reads the dated row, never the live file.
+
+Verbatim bytes, not a re-serialization: the snapshot must be exactly what
+the producer wrote, so later schema evolution cannot retroactively rewrite
+history. Idempotent per (name, date): an identical re-run (workflow retry)
+is a no-op; genuinely different content on the same UTC date wins as the
+final version of that day.
+"""
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOT_ROOT = _REPO_ROOT / 'assets' / 'data' / 'factor-snapshots'
+
+
+def snapshot(source: Path, bucket: str, run_date: str, root: Path = SNAPSHOT_ROOT):
+    """Copy source verbatim into root/bucket/run_date.json. Returns action."""
+    if not source.exists():
+        print(f'  ⚠ factor snapshot: source missing: {source}', file=sys.stderr)
+        return 'missing'
+    target = root / bucket / f'{run_date}.json'
+    data = source.read_bytes()
+    if target.exists() and target.read_bytes() == data:
+        print(f'  factor snapshot: {target} unchanged')
+        return 'unchanged'
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existed = target.exists()
+    tmp = target.with_suffix('.json.tmp')
+    tmp.write_bytes(data)
+    os_replace(tmp, target)
+    verb = 'updated' if existed else 'created'
+    print(f'  factor snapshot: {verb} {target} ({len(data)} bytes)')
+    return verb
+
+
+def os_replace(src: Path, dst: Path):
+    import os
+    os.replace(src, dst)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--source', required=True, help='sidecar produced this run')
+    ap.add_argument('--bucket', default=None,
+                    help='snapshot subdirectory (default: source stem)')
+    args = ap.parse_args(argv)
+
+    source = Path(args.source)
+    bucket = args.bucket or source.stem
+    run_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    action = snapshot(source, bucket, run_date)
+    # A missing source is a real defect upstream — fail loudly so the job
+    # does not green-light a night with no archived data.
+    return 1 if action == 'missing' else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_factor_snapshots.py
+++ b/tests/test_factor_snapshots.py
@@ -1,0 +1,75 @@
+"""factor-snapshots must be verbatim, dated, and idempotent (#936).
+
+The live sidecars (sentiment.json / macro.json) are overwritten in place by
+their scan workflows; any backtest reading them after the fact sees today's
+file instead of what a past day actually looked like. The snapshotter archives
+a byte-exact copy per UTC date before the overwrite cycle continues.
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "ci"))
+
+import importlib.util
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "snapshot_factor_sidecar", ROOT / "ops" / "ci" / "snapshot_factor_sidecar.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+snap = _load()
+
+
+def _write_source(tmp_path, body):
+    src = tmp_path / "sentiment.json"
+    src.write_bytes(body)
+    return src
+
+
+def test_first_run_creates_a_verbatim_dated_copy(tmp_path):
+    src = _write_source(tmp_path, b'{"tickers": {"AAPL": {}}}')
+    root = tmp_path / "snaps"
+
+    action = snap.snapshot(src, "sentiment", "2026-08-25", root=root)
+
+    assert action == "created"
+    target = root / "sentiment" / "2026-08-25.json"
+    assert target.read_bytes() == src.read_bytes()  # byte-exact, not re-dumped
+
+
+def test_rerun_with_identical_content_is_a_noop(tmp_path):
+    """Workflow retries must not churn the archive."""
+    src = _write_source(tmp_path, b'{"v": 1}')
+    root = tmp_path / "snaps"
+    snap.snapshot(src, "sentiment", "2026-08-25", root=root)
+
+    action = snap.snapshot(src, "sentiment", "2026-08-25", root=root)
+
+    assert action == "unchanged"
+
+
+def test_same_date_different_content_wins_as_final_version(tmp_path):
+    """A drifted rerun legitimately overwrites that day's row — the archive
+    keeps one final version per date, like the ledger's last-write rule."""
+    src = _write_source(tmp_path, b'{"v": 1}')
+    root = tmp_path / "snaps"
+    snap.snapshot(src, "macro", "2026-08-25", root=root)
+
+    src.write_bytes(b'{"v": 2}')
+    action = snap.snapshot(src, "macro", "2026-08-25", root=root)
+
+    assert action == "updated"
+    assert (root / "macro" / "2026-08-25.json").read_bytes() == b'{"v": 2}'
+
+
+def test_missing_source_fails_loudly_not_silently(tmp_path):
+    """A scan job whose sidecar vanished must not green-light a night with no
+    archived data — exit non-zero so the workflow shows it."""
+    rc = snap.main(["--source", str(tmp_path / "absent.json"),
+                    "--bucket", "sentiment"])
+    assert rc == 1

--- a/tests/test_macro_scan_workflow_contract.py
+++ b/tests/test_macro_scan_workflow_contract.py
@@ -6,6 +6,25 @@ from workflow_contract_helpers import assert_validator_step, step_run, steps
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _logical_commit_command(commit_run):
+    """Join backslash continuations so multi-path gha_commit_push calls read
+    as one logical command (the snapshots slice added a second data path)."""
+    logical, buf = [], ""
+    for raw in commit_run.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        buf = f"{buf} {line}".strip() if buf else line
+        if buf.endswith("\\"):
+            buf = buf[:-1].rstrip()
+            continue
+        logical.append(buf)
+        buf = ""
+    if buf:
+        logical.append(buf)
+    return [l for l in logical if l.startswith("bash ops/publish/gha_commit_push.sh")]
 WORKFLOW = ROOT / '.github' / 'workflows' / 'macro-scan.yml'
 
 
@@ -24,8 +43,15 @@ def test_macro_snapshot_requires_coverage_before_exact_publish():
     assert_validator_step(WORKFLOW, 'Validate macro coverage', 'macro')
 
     commit_run = _step_run('Commit')
-    publish_lines = [line.strip() for line in commit_run.splitlines()
-                     if line.strip().startswith('bash ops/publish/gha_commit_push.sh')]
+    publish_lines = _logical_commit_command(commit_run)
     assert len(publish_lines) == 1
-    assert re.search(r'\sassets/data/macro\.json$', publish_lines[0])
-    assert 'assets/data/' not in publish_lines[0].removesuffix('assets/data/macro.json')
+    tokens = publish_lines[0].split()
+    data_paths = [t for t in tokens if t.startswith('assets/data/')]
+    # This job commits exactly its own sidecar plus its dated snapshot
+    # bucket (#936) — nothing else may ride along.
+    assert data_paths == [
+        'assets/data/macro.json',
+        'assets/data/factor-snapshots/macro',
+    ]
+    names = [n for n in names]
+    assert names.index('Snapshot point-in-time copy') == len(names) - 2

--- a/tests/test_sentiment_scan_workflow_contract.py
+++ b/tests/test_sentiment_scan_workflow_contract.py
@@ -6,6 +6,25 @@ from workflow_contract_helpers import assert_validator_step, step_run, steps
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _logical_commit_command(commit_run):
+    """Join backslash continuations so multi-path gha_commit_push calls read
+    as one logical command (the snapshots slice added a second data path)."""
+    logical, buf = [], ""
+    for raw in commit_run.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        buf = f"{buf} {line}".strip() if buf else line
+        if buf.endswith("\\"):
+            buf = buf[:-1].rstrip()
+            continue
+        logical.append(buf)
+        buf = ""
+    if buf:
+        logical.append(buf)
+    return [l for l in logical if l.startswith("bash ops/publish/gha_commit_push.sh")]
 WORKFLOW = ROOT / '.github' / 'workflows' / 'sentiment-scan.yml'
 
 
@@ -24,8 +43,15 @@ def test_sentiment_snapshot_requires_coverage_before_exact_publish():
     assert_validator_step(WORKFLOW, 'Validate sentiment coverage', 'sentiment')
 
     commit_run = _step_run('Commit')
-    publish_lines = [line.strip() for line in commit_run.splitlines()
-                     if line.strip().startswith('bash ops/publish/gha_commit_push.sh')]
+    publish_lines = _logical_commit_command(commit_run)
     assert len(publish_lines) == 1
-    assert re.search(r'\sassets/data/sentiment\.json$', publish_lines[0])
-    assert 'assets/data/' not in publish_lines[0].removesuffix('assets/data/sentiment.json')
+    tokens = publish_lines[0].split()
+    data_paths = [t for t in tokens if t.startswith('assets/data/')]
+    # This job commits exactly its own sidecar plus its dated snapshot
+    # bucket (#936) — nothing else may ride along.
+    assert data_paths == [
+        'assets/data/sentiment.json',
+        'assets/data/factor-snapshots/sentiment',
+    ]
+    names = [n for n in names]
+    assert names.index('Snapshot point-in-time copy') == len(names) - 2


### PR DESCRIPTION
Foundation for kcn's 情绪面+技术面 Actions 跑批 direction (#936 discussion): combined-factor research needs point-in-time data, and today every sidecar is overwrite-in-place — reading it after the fact is look-ahead by construction.

## What
- `ops/ci/snapshot_factor_sidecar.py`: verbatim byte copy of the produced sidecar into `assets/data/factor-snapshots/<bucket>/<UTC-date>.json`. Idempotent per (bucket, date); same-date rerun with different content wins as that day's final version. Missing source exits non-zero — no silently unarchived nights.
- `sentiment-scan.yml` / `macro-scan.yml`: snapshot step between validate and commit; commit gains exactly one extra path (its own snapshot bucket).
- Contract tests updated to pin the two-path commit shape.

## Deliberately not in this slice
No factor computation, no schema decisions — pure accumulation infrastructure. What fields go into future derived factors waits on real usage; the archive keeps producer bytes so nothing is foreclosed.