### PR TITLE
overview 首屏五项整改 + 黄金回本话术（柱图槽位/玻璃判定卡/四格轨/健康蓝/去大字报构图）

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -217,7 +217,8 @@
     .refresh-btn,
     .desk-rail,
     .status-banner,
-    .hero-deck {
+    .hero-deck,
+    .overview-verdict {
       -webkit-backdrop-filter: none;
       backdrop-filter: none;
     }
@@ -229,6 +230,10 @@
     .desk-rail { background: var(--surface-1); }
     .status-banner { background: var(--accent-soft); }
     .hero-deck { background: var(--surface-1); }
+    /* 判定卡的玻璃底是 55% 半透明面：blur 关掉后必须整体回实色，否则变成
+       「无模糊的透底」，背后的文字会从卡里透出来叠字。两段类名提高特异度
+       —— 这条闸在源码里排在 .overview-verdict 本体之前，同特异度会输。 */
+    .card.overview-verdict { background: var(--surface-1); }
     /* Same reason the sheens go: they are light passing through a material.
        On an opaque surface they are just a gradient nobody asked for. */
     .card, .hero-deck, .overview-strip { background-image: none; }
@@ -246,9 +251,13 @@
        page is not dead flat. Both are wide and low-contrast on purpose —
        visible as depth, never as a visible band. `background-attachment:
        fixed` keeps them still while panels scroll (apple-design §14: no
-       full-viewport moving background). */
+       full-viewport moving background).
+       2026-08-24: key light 拉高到 860px —— 判定卡改成半透明毛玻璃后，它
+       背后必须真的有光可糊（#887 判据）：原来的 620px 衰减在判定卡那一段
+       已经归零，玻璃糊的是一片平色。拉高之后光穿过两张玻璃面，材质才读得
+       出来。 */
     background:
-      radial-gradient(1100px 620px at 50% -14%, var(--bg-glow), transparent 68%),
+      radial-gradient(1240px 860px at 50% -12%, var(--bg-glow), transparent 70%),
       radial-gradient(900px 700px at 88% 108%, var(--bg-glow-2), transparent 72%),
       var(--bg);
     background-attachment: fixed;
@@ -2255,7 +2264,7 @@
      行数是固定的（标签 / 值 / 变化 / 备注），不会因为数据长短再变。
      min-height 而不是 height：真渲染出来更高时不裁。 */
   .hero-rail {
-    display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+    display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
     border-top: 1px solid var(--border-subtle);
     /* 每格多了一件图形（比例条 / 每日柱）+ 一行说明，比纯数字那版高一档。
        152 = 四格并排时的数据态实测（768~1920 全档同高）。 */
@@ -2425,14 +2434,18 @@
   }
   .dh-seg i {
     position: absolute; left: 0; right: 0; bottom: 0; height: var(--used, 40%);
-    background: color-mix(in srgb, var(--text) 38%, transparent);
+    /* 在期=品牌蓝（#920「灰改品牌蓝」同判据）：数据新鲜度不是涨跌，
+       灰一片读不出「健康」和「没数据」的区别，涨跌色又不参与赚亏之外的
+       表述。逾期/缺失仍由 --warning/--red 接管（下方 is-* 覆盖）。
+       色彩预算仍是：涨跌两色 + 真告警红 + 品牌蓝，没有第四种装饰色。 */
+    background: color-mix(in srgb, var(--accent) 82%, transparent);
     border-radius: 3px;
   }
   .bs-dot {
     display: inline-block; width: 7px; height: 7px; border-radius: 50%;
     background: var(--text-tertiary); vertical-align: middle; margin-right: 2px;
   }
-  .bs-dot[data-tone="ok"] { background: var(--positive, var(--green)); }
+  .bs-dot[data-tone="ok"] { background: var(--accent); }
   .bs-dot[data-tone="warn"] { background: var(--warning); }
   .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
   .dh-caption {
@@ -2457,7 +2470,7 @@
     height: 4px; border-radius: 2px; overflow: hidden;
     background: color-mix(in srgb, var(--text) 8%, transparent);
   }
-  .dh-bar i { display: block; height: 100%; background: color-mix(in srgb, var(--text) 42%, transparent); }
+  .dh-bar i { display: block; height: 100%; background: color-mix(in srgb, var(--accent) 75%, transparent); }
   .dh-row.is-late .dh-bar i, .dh-row.is-missing .dh-bar i { background: var(--warning); opacity: 1; }
   .dh-row.is-missing .dh-bar i { background: var(--red); }
   .dh-state { color: var(--text-tertiary); text-align: right; white-space: nowrap; }
@@ -2501,6 +2514,16 @@
      的伴排改为独占整行。 */
   .overview-verdict {
     grid-column: 1 / -1; padding: 20px var(--card-inset) 18px;
+    /* 首屏第二块浮起来的表面（指挥台之后）：DSH 插件同款玻璃配方 ——
+       不透明色写在前（引擎不支持 color-mix/backdrop-filter 时退回实色卡），
+       半透明主题面 + backdrop blur + saturate。结构判据（#887）：毛玻璃
+       成立先证明背后有东西可糊 —— body 两盏 fixed 光已拉高到覆盖这一段，
+       指挥台的落影也从这层透出去；凹槽/量表那套光影不叠 blur，不做
+       「玻璃里再糊一层玻璃」。 */
+    background: var(--surface-1);
+    background: var(--sheen-1), var(--glass-card);
+    -webkit-backdrop-filter: blur(24px) saturate(170%);
+    backdrop-filter: blur(24px) saturate(170%);
     /* 原来的 480px 地板是为和 Equity 卡凑同一行；挪走后按各档实测内容高度
        重新预留（数据到达前占位，否则判定卡长高会把下方整列推下去 —— CLS
        实测 0.11，预留后回到基线）。
@@ -2508,21 +2531,52 @@
        is-pending 不占位的（#890），横幅日它出现时会在卡内把要点/硬闸往下推
        —— 整卡地板吸收这种内部重排，子行地板会把这次重排漏成页面级位移。
        地板值 = 构图定稿后横幅日扫宽实测上界 +2（见各断点注释）。
-       504：判词从 34px 大字报降到 19px 导语后重量的上界（1024 档 503）——
-       原来的 478 比数据态还矮，数据一到卡就长 10~25px，等于这条地板一直是
-       空的。 */
-    min-height: 504px;
+       2026-08-24 构图改双栏（宽屏左判词右硬闸），整卡数据态高度大幅收窄，
+       三档地板随之重量（值见 min-height 与各断点覆盖，横幅日扫宽取上界）。 */
+    min-height: 296px;
+  }
+  /* 宽屏双栏：左列=这张卡「说的话」（判定句 + 要点），右列=这张卡「管的
+     事」（触发中的硬闸）。此前四段全宽竖排、段段一条发丝线，整卡读成一摞
+     通栏横幅 —— 「大字报」的第二层（第一层字号 #927 已收）：构图要有主次
+     分栏。DOM 不动，grid-areas 重排；<1024 回单列自然流。 */
+  @media (min-width: 1024px) {
+    .overview-verdict {
+      display: grid;
+      grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+      grid-template-rows: auto auto 1fr;
+      grid-template-areas:
+        "head gates"
+        "verdict gates"
+        "points gates";
+      align-items: stretch; align-content: start;
+    }
+    .overview-verdict-head { grid-area: head; }
+    .overview-status { grid-area: verdict; }
+    .overview-verdict .today-highlights { grid-area: points; align-content: start; }
+    .overview-gates {
+      grid-area: gates; height: 100%;
+      border-top: 0; border-left: 1px solid var(--border-subtle);
+      padding-left: 28px; margin-left: 28px;
+    }
   }
   .overview-verdict-head,
   .overview-gates-head {
     display: flex; align-items: center; justify-content: space-between; gap: 10px;
   }
+  /* 眉标并成一行：「决策面板 · 今日判定」—— 两条竖排的 micro 眉标是同一层
+      语义说了两遍版式。h3 语义保留（卡的 accessible name），视觉降为行内。 */
+  .overview-verdict-head > div:first-child {
+    display: flex; align-items: baseline; gap: 9px; min-width: 0;
+  }
   /* 「今日判定」降级为 kicker：这张卡真正的话是下面那句判词，标题本身退成
      与「决策面板」同档的眉标，把字阶让给内容。 */
   .overview-verdict-head h3 {
-    margin: 5px 0 0; color: var(--text-tertiary);
+    margin: 0; color: var(--text-tertiary);
     font-size: var(--fs-micro); font-weight: 600;
     letter-spacing: .09em; text-transform: uppercase;
+  }
+  .overview-verdict-head h3::before {
+    content: "·"; margin-right: 9px; color: var(--text-faint);
   }
   .overview-jump,
   .overview-strip-link {
@@ -2535,30 +2589,44 @@
     outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 3px;
   }
   /* 判词行：这张卡的主句。三种行式样统一为无盒 + 发丝线：去胶囊底色与蓝点，
-     上下发丝线夹住；时间戳保持 mono micro。 */
+      上下发丝线夹住。 */
   /* 2026-08-24：--fs-verdict（24~34px、600 字重）把这句话渲染成了一张大字报
      （kcn：「今日判定那个大字报不要，太奇怪了」）。它不是标题，是这张卡的
      导语句 —— 一句会天天变的状态描述。降到 --fs-xl / 550 字重 / 1.55 行高，
      并把负字距收回 0：字距是随字号定的，19px 上再收紧只会挤。
-     仍然是这张卡里最大的字（其余行 13px），层级没丢，只是不再喊。 */
+     仍然是这张卡里最大的字（其余行 13px），层级没丢，只是不再喊。
+     时间戳从句中挪到句下：原来 sb-time 是行内 flex 尾巴，句子一折行它就
+     悬在第一行行尾的半空中，读起来像句子的一部分。 */
   .overview-status {
-    margin: 14px 0 12px; padding: 13px 0;
+    display: block;
+    margin: 14px 0 0; padding: 13px 0 12px;
     background: none; border: 0; border-radius: 0;
     border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
+    border-bottom: 0;
     -webkit-backdrop-filter: none; backdrop-filter: none;
     font-size: var(--fs-xl); line-height: 1.55; letter-spacing: 0;
     max-width: 68ch;
   }
   .overview-status .sb-pulse { display: none; }
   .overview-status .sb-text { font-weight: 550; }
+  .overview-status .sb-time {
+    display: block; margin-top: 7px;
+    font-size: var(--fs-micro); color: var(--text-faint);
+    font-family: var(--mono); white-space: nowrap;
+  }
+  /* 要点行 = 判定句的注脚：整块左缩进挂一条发丝竖线（引文层级），行间不再
+      一条条横线 —— 横线节奏和硬闸区重复，竖线才读得出来「这几行是上面那句
+      的展开」。真告警行仍整行红字。 */
   .overview-verdict .today-highlights {
-    display: grid; grid-template-columns: 1fr; gap: 6px;
-    margin: 0 0 14px; min-height: 0;
+    display: grid; grid-template-columns: 1fr; gap: 0;
+    margin: 12px 0 0; min-height: 0;
   }
   .overview-verdict .hl-chip {
-    min-width: 0; padding: 12px 0; font-size: var(--fs-sm); overflow-wrap: anywhere;
+    min-width: 0; padding: 7px 0 7px 13px; font-size: var(--fs-sm);
+    overflow-wrap: anywhere; color: var(--text-secondary);
+    border-bottom: 0; border-left: 2px solid var(--border-subtle);
   }
+  .overview-verdict .hl-chip:last-child { padding-bottom: 0; }
   .overview-gates {
     padding-top: 16px; border-top: 1px solid var(--border-subtle);
   }
@@ -2687,7 +2755,7 @@
   .hl-chip.hl-alert { color: var(--red); font-weight: 600; }
 
   @media (min-width: 768px) and (max-width: 1023px) {
-    .hero-rail { grid-template-columns: repeat(3, minmax(0, 1fr)); min-height: 152px; }
+    .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
     /* 506：要点行升到 44px 后 768px 端横幅折行的实测上界（504）+2。 */
     .overview-verdict { min-height: 506px; }
     .overview-verdict, .overview-strip,

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -756,7 +756,11 @@
         const h = Math.max(4, Math.abs(x.v) / maxAbs * 46);
         const cls = x.v > 0 ? "up" : x.v < 0 ? "down" : "flat";
         const pos = x.v >= 0 ? `bottom:50%` : `top:50%`;
-        return `<i class="${cls}" style="left:${(i * w).toFixed(2)}%;`
+        // 槽位中心对齐：(i+0.5)/n 让每根柱落在自己槽位的正中，首末柱两侧
+        // 各留半个槽位。此前用 i/n 对齐，第一根柱的中心正好压在容器左缘，
+        // 9px 柱的一半（4.5px）被推出容器外 —— 疏密随宽度变、粗细不变
+        // 的规矩不动，动的只是柱在槽内的落点。
+        return `<i class="${cls}" style="left:${((i + 0.5) * w).toFixed(2)}%;`
           + `width:${Math.max(1.2, w * 0.58).toFixed(2)}%;${pos};height:${h.toFixed(1)}%"></i>`;
       }).join("");
       const up = d.filter(x => x.v > 0).length;
@@ -764,8 +768,9 @@
         + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
         + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
     };
-    // 统计轨只剩「钱在哪、守不守纪律」三格，每格自带一件图形：
+    // 统计轨四格，每格自带一件图形：
     //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
+    //   · 距峰值 —— 峰→现回撤 + 自最低收复量表（同一序列的第三个参照点）
     //   · 遵守率 30d —— 值 + 量表条
     // 今日搬进了自己那一行（上面），自评 Brier 挪出首屏（Reflect 的 Brier 卡、
     // 决策带 KPI、Plan 三处都在，首屏这格是全站第四份）。
@@ -773,6 +778,26 @@
       ? us.value_usd / bookUsd * 100 : null;
     const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
       ? (hk.value_hkd / fx) / bookUsd * 100 : null;
+    // 距峰值：与 spark/柱图同一条序列上的「峰 → 现」。主数答「比起投点」，
+    // 今日行答「比昨天」，这一格答「比这一轮最高点」—— 三个参照点互相不可
+    // 推导，少了它，「这轮回撤收复了多少」在首屏没有答案（风控页那套回撤
+    // 闸问的是同一个问题）。量表是自最低点的收复进度，说明行给峰值本身。
+    const ptsAll = heroProfitSeries();
+    let peakCell = null;
+    if (ptsAll.length >= 3) {
+      let hi = -Infinity, hiAt = "", lo = Infinity;
+      ptsAll.forEach(p => {
+        if (p.v > hi) { hi = p.v; hiAt = p.date; }
+        if (p.v < lo) lo = p.v;
+      });
+      const nowV = ptsAll[ptsAll.length - 1].v;
+      const dd = nowV - hi;
+      const span = hi - lo;
+      const recov = span > 0 ? Math.max(0, Math.min(100, (nowV - lo) / span * 100)) : null;
+      peakCell = cell("距峰值",
+        `<span class="${pnlClass(dd)}">${heroMoney(dd, "USD")}</span>`,
+        railMeter(recov, `峰值 ${heroMoney(hi, "USD")} · ${String(hiAt || "").slice(5)}`));
+    }
     railEl.innerHTML = [
       cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
         `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd)),
@@ -780,13 +805,14 @@
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
         railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
+      peakCell,
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
         railMeter(ae.rate == null ? null : ae.rate * 100,
           `主动 call · n=${ae.known == null ? DASH : ae.known}`
           + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
-    ].join("");
+    ].filter(Boolean).join("");
 
     // 今日行：一个 USD-eq 合计 + 美股/港股两个分项 + 一条与上方走势图同宽的
     // 每日盈亏柱。三个数放在一起才有意义（合计回答「今天亏了多少」，分项回答
@@ -1113,6 +1139,10 @@
     const loss = (g.pnl_abs || 0) < 0;
     const pnlColor = loss ? 'var(--negative)' : 'var(--positive)';
     const sign = (g.pnl_percent || 0) >= 0 ? '+' : '';
+    // 回本状态分档：净值在成本线上方（含打平）之后，整套「回本需涨」的话术
+    // 都要换方向 —— 需涨变负数不是「要跌」，是已经在上面了。2026-08-24 起
+    // 持仓真实越线（avg_cost 3.3538 / nav 3.3774），下面所有回本表述按此分档。
+    const aboveWater = g.breakeven_upside_pct != null && g.breakeven_upside_pct <= 0;
 
     document.getElementById('gold-sub').textContent = `${g.fund_code} · ${g.fund_name}`;
 
@@ -1136,7 +1166,9 @@
         ${cell('累计投入', '¥' + num(g.principal_effective != null ? g.principal_effective : g.principal_invested))}
         ${cell('平均成本', num(g.avg_cost, 4))}
         ${cell('当前净值', num(g.nav, 4) + navChgStr)}
-        ${cell('回本需涨', `<span style="color:${loss ? 'var(--warning)' : 'var(--positive)'}">${(g.breakeven_upside_pct >= 0 ? '+' : '') + num(g.breakeven_upside_pct, 1)}%</span>`)}
+        ${aboveWater
+          ? cell('成本线上方', `<span style="color:var(--positive)">+${num(-(g.breakeven_upside_pct || 0), 1)}%</span>`)
+          : cell('回本需涨', `<span style="color:var(--warning)">${g.breakeven_upside_pct == null ? DASH : '+' + num(g.breakeven_upside_pct, 1) + '%'}</span>`)}
         ${cell('已投', `${g.days_invested ?? DASH} 交易日`)}
         ${cell('约定投', `${g.installments_est ?? DASH} 笔 ×¥${num(g.daily_amount)}`)}
       </div>`;
@@ -1154,16 +1186,22 @@
         const dchg = dg.change_pct;
         const dcolor = dchg == null ? 'var(--neutral)' : (dchg >= 0 ? 'var(--positive)' : 'var(--negative)');
         const retained = dg.quote_status === 'retained';
+        // 国内口径自己的回本分档（与基金口径同号，但各自算，不借用）。
+        const dgAbove = dg.breakeven_upside_pct != null && dg.breakeven_upside_pct <= 0;
+        const dgBeColor = dgAbove ? 'var(--positive)' : 'var(--warning)';
+        const dgBeTxt = dgAbove
+          ? `成本线上方 <b style="color:${dgBeColor}">${num(-(dg.breakeven_upside_pct || 0), 2)}%</b>`
+          : `距回本 <b style="color:${dgBeColor}">${dg.breakeven_upside_pct == null ? DASH : '+' + num(dg.breakeven_upside_pct, 2) + '%'}</b>`;
         goldDomestic.innerHTML =
           `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
              <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
                <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:${dgBeColor};white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
              </div>
              <div class="muted" style="font-size:var(--fs-xs);margin-top:7px;text-transform:none;letter-spacing:0">
-               距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
+               ${dgBeTxt}
                ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
                ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
              </div>
@@ -1189,6 +1227,11 @@
           : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
         const fundBePct = ld.fund_breakeven_upside_pct != null
           ? ld.fund_breakeven_upside_pct : g.breakeven_upside_pct;
+        const fundAbove = fundBePct != null && fundBePct <= 0;
+        const fundBeColor = fundAbove ? 'var(--positive)' : 'var(--warning)';
+        const fundBeTxt = fundAbove
+          ? `成本线上方 <b style="color:${fundBeColor}">${num(-fundBePct, 2)}%</b>`
+          : `距回本 <b style="color:${fundBeColor}">${fundBePct == null ? DASH : '+' + num(fundBePct, 2) + '%'}</b>`;
         // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
@@ -1196,10 +1239,10 @@
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
                <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:${fundBeColor};white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
              </div>
              <div class="muted" style="font-size:var(--fs-xs);margin-top:5px;text-transform:none;letter-spacing:0">
-               距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
+               ${fundBeTxt}${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
                · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
              </div>`;
@@ -1236,18 +1279,22 @@
                  ${de.current_value_cny != null ? `· 对应现值 <b style="color:${dColor}">¥${num(de.current_value_cny)}</b> (${de.pnl_pct >= 0 ? '+' : ''}${num(de.pnl_pct, 2)}%)` : ''}
                </div>
              </div>`;
-          // 摊薄轨迹：继续同额定投伦敦金 → 均成本 $/oz 往下移、回本门槛下降
+          // 摊薄轨迹：继续同额定投伦敦金 → 均成本 $/oz 移动方向由数据说话
+          //（现货在均价下方时摊薄下移、上方时反而上抬 —— 回本后这句文案
+          // 曾固定写「下移」，与它自己表格里的数字打架）。
           const lproj = (de.projection || []).filter(p => p && p.avg_cost_usd_oz != null);
           if (lproj.length) {
             const MON = { 20: '+1月', 40: '+2月', 60: '+3月', 120: '+半年', 250: '+1年' };
+            const lDir = de.avg_cost_usd_oz != null && lproj[lproj.length - 1].avg_cost_usd_oz >= de.avg_cost_usd_oz ? '上移' : '下移';
+            const deAbove = de.breakeven_upside_pct != null && de.breakeven_upside_pct <= 0;
             const lrows = lproj.map(p =>
               `<tr><td style="padding:4px 8px">${MON[p.days] || ('+' + p.days + '日')}</td>
                 <td style="padding:4px 8px;text-align:right">$${num(p.avg_cost_usd_oz, 0)}</td>
-                <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
+                <td style="padding:4px 8px;text-align:right;color:${deAbove ? 'var(--text-secondary)' : 'var(--positive)'}">${p.breakeven_upside_pct == null ? DASH : (p.breakeven_upside_pct >= 0 ? '+' : '') + num(p.breakeven_upside_pct, 1) + '%'}</td></tr>`).join('');
             html +=
-              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
+              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz ${lDir}</div>
                <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
-                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">距成本线</th></tr>
                ${lrows}</table>`;
           }
           html += `</div></details>`;
@@ -1297,32 +1344,38 @@
       const avg = g.avg_cost;
       const avgY = (avg >= lo && avg <= hi) ? y(avg) : null;
       const lastV = hist[hist.length - 1][1];
+      // 成本线的颜色跟着回本状态走：在上方=要守的线（amber），越线之后=
+      // 已经站上去的参照（绿）。线本身语义不变，只换情绪。
+      const costColor = aboveWater ? 'var(--positive)' : 'var(--warning)';
       sp.innerHTML =
         `<svg viewBox="0 0 ${W} ${H}" width="100%" height="${H}" preserveAspectRatio="none" style="margin-top:4px">
-          ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="var(--warning)" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
+          ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="${costColor}" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
           <polyline points="${pts}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
           <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
         <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
           <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
-          <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
+          <span style="color:${costColor}">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
         </div>`;
     } else { sp.innerHTML = ''; }
 
-    // 定投摊薄预测 (假设净值不动, 继续投 → 回本门槛下移)
+    // 定投摊薄预测 (假设净值不动, 继续投 → 成本线移动方向由数据说话：
+    // 净值在成本线下方时定投把它往下拽，越线之后同样的机制反过来把它
+    // 抬高 —— 文案跟着数字走，不再固定写「下移」。)
     const proj = g.projection || [];
     if (proj.length) {
       const MONTH = { 20: '+1月', 40: '+2月', 60: '+3月', 120: '+半年', 250: '+1年' };
+      const projDir = g.avg_cost != null && proj[proj.length - 1].avg_cost >= g.avg_cost ? '上移、安全垫收窄' : '下移';
       const rows = proj.map(p =>
         `<tr><td style="padding:4px 8px">${MONTH[p.days] || ('+' + p.days + '日')}</td>
           <td style="padding:4px 8px;text-align:right">${num(p.avg_cost, 3)}</td>
-          <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
+          <td style="padding:4px 8px;text-align:right;color:${aboveWater ? 'var(--text-secondary)' : 'var(--positive)'}">${p.breakeven_upside_pct == null ? DASH : (p.breakeven_upside_pct >= 0 ? '+' : '') + num(p.breakeven_upside_pct, 1) + '%'}</td></tr>`).join('');
       document.getElementById('gold-proj').innerHTML =
-        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
+        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线${projDir}</div>
          <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
-           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">距成本线</th></tr>
            ${rows}</table>`;
     } else { document.getElementById('gold-proj').innerHTML = ''; }
 

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -746,7 +746,11 @@
         const h = Math.max(4, Math.abs(x.v) / maxAbs * 46);
         const cls = x.v > 0 ? "up" : x.v < 0 ? "down" : "flat";
         const pos = x.v >= 0 ? `bottom:50%` : `top:50%`;
-        return `<i class="${cls}" style="left:${(i * w).toFixed(2)}%;`
+        // 槽位中心对齐：(i+0.5)/n 让每根柱落在自己槽位的正中，首末柱两侧
+        // 各留半个槽位。此前用 i/n 对齐，第一根柱的中心正好压在容器左缘，
+        // 9px 柱的一半（4.5px）被推出容器外 —— 疏密随宽度变、粗细不变
+        // 的规矩不动，动的只是柱在槽内的落点。
+        return `<i class="${cls}" style="left:${((i + 0.5) * w).toFixed(2)}%;`
           + `width:${Math.max(1.2, w * 0.58).toFixed(2)}%;${pos};height:${h.toFixed(1)}%"></i>`;
       }).join("");
       const up = d.filter(x => x.v > 0).length;
@@ -754,8 +758,9 @@
         + `近 ${d.length} 个交易日每日盈亏：${up} 天为正、${d.length - up} 天为负">`
         + `${bars}</div><div class="rc-cap">近 ${d.length} 日 · ${up} 涨 ${d.length - up} 跌</div>`;
     };
-    // 统计轨只剩「钱在哪、守不守纪律」三格，每格自带一件图形：
+    // 统计轨四格，每格自带一件图形：
     //   · 美股 / 港股 —— 值 + 占账面比例条（比例是形状问题，不是数字问题）
+    //   · 距峰值 —— 峰→现回撤 + 自最低收复量表（同一序列的第三个参照点）
     //   · 遵守率 30d —— 值 + 量表条
     // 今日搬进了自己那一行（上面），自评 Brier 挪出首屏（Reflect 的 Brier 卡、
     // 决策带 KPI、Plan 三处都在，首屏这格是全站第四份）。
@@ -763,6 +768,26 @@
       ? us.value_usd / bookUsd * 100 : null;
     const shareHk = (has(hk.value_hkd) && has(bookUsd) && fx && bookUsd > 0)
       ? (hk.value_hkd / fx) / bookUsd * 100 : null;
+    // 距峰值：与 spark/柱图同一条序列上的「峰 → 现」。主数答「比起投点」，
+    // 今日行答「比昨天」，这一格答「比这一轮最高点」—— 三个参照点互相不可
+    // 推导，少了它，「这轮回撤收复了多少」在首屏没有答案（风控页那套回撤
+    // 闸问的是同一个问题）。量表是自最低点的收复进度，说明行给峰值本身。
+    const ptsAll = heroProfitSeries();
+    let peakCell = null;
+    if (ptsAll.length >= 3) {
+      let hi = -Infinity, hiAt = "", lo = Infinity;
+      ptsAll.forEach(p => {
+        if (p.v > hi) { hi = p.v; hiAt = p.date; }
+        if (p.v < lo) lo = p.v;
+      });
+      const nowV = ptsAll[ptsAll.length - 1].v;
+      const dd = nowV - hi;
+      const span = hi - lo;
+      const recov = span > 0 ? Math.max(0, Math.min(100, (nowV - lo) / span * 100)) : null;
+      peakCell = cell("距峰值",
+        `<span class="${pnlClass(dd)}">${heroMoney(dd, "USD")}</span>`,
+        railMeter(recov, `峰值 ${heroMoney(hi, "USD")} · ${String(hiAt || "").slice(5)}`));
+    }
     railEl.innerHTML = [
       cell("美股", withDelta(fmtMoney(us.value_usd, "USD"),
         `${heroMoney(us.pnl_usd, "USD")} · ${fmtPct(us.pnl_pct)}`, pnlClass(us.pnl_usd)),
@@ -770,13 +795,14 @@
       cell("港股", withDelta(fmtMoney(hk.value_hkd, "HKD"),
         `${heroMoney(hk.pnl_hkd, "HKD")} · ${fmtPct(hk.pnl_pct)}`, pnlClass(hk.pnl_hkd)),
         railMeter(shareHk, `占账面 ${shareHk == null ? DASH : shareHk.toFixed(0) + "%"}`)),
+      peakCell,
       cell("遵守率 30d", ae.rate == null ? DASH : (ae.rate * 100).toFixed(1) + "%",
         // stranded = 核验窗口关闭时仍没有答案的 call，永远不会结算。只报 known
         // 会高估这个比率覆盖了多少记录，所以两个数一起给。
         railMeter(ae.rate == null ? null : ae.rate * 100,
           `主动 call · n=${ae.known == null ? DASH : ae.known}`
           + (ae.stranded ? ` · ${ae.stranded} 未能核验` : ""))),
-    ].join("");
+    ].filter(Boolean).join("");
 
     // 今日行：一个 USD-eq 合计 + 美股/港股两个分项 + 一条与上方走势图同宽的
     // 每日盈亏柱。三个数放在一起才有意义（合计回答「今天亏了多少」，分项回答
@@ -2420,6 +2446,10 @@
     const loss = (g.pnl_abs || 0) < 0;
     const pnlColor = loss ? 'var(--negative)' : 'var(--positive)';
     const sign = (g.pnl_percent || 0) >= 0 ? '+' : '';
+    // 回本状态分档：净值在成本线上方（含打平）之后，整套「回本需涨」的话术
+    // 都要换方向 —— 需涨变负数不是「要跌」，是已经在上面了。2026-08-24 起
+    // 持仓真实越线（avg_cost 3.3538 / nav 3.3774），下面所有回本表述按此分档。
+    const aboveWater = g.breakeven_upside_pct != null && g.breakeven_upside_pct <= 0;
 
     document.getElementById('gold-sub').textContent = `${g.fund_code} · ${g.fund_name}`;
 
@@ -2443,7 +2473,9 @@
         ${cell('累计投入', '¥' + num(g.principal_effective != null ? g.principal_effective : g.principal_invested))}
         ${cell('平均成本', num(g.avg_cost, 4))}
         ${cell('当前净值', num(g.nav, 4) + navChgStr)}
-        ${cell('回本需涨', `<span style="color:${loss ? 'var(--warning)' : 'var(--positive)'}">${(g.breakeven_upside_pct >= 0 ? '+' : '') + num(g.breakeven_upside_pct, 1)}%</span>`)}
+        ${aboveWater
+          ? cell('成本线上方', `<span style="color:var(--positive)">+${num(-(g.breakeven_upside_pct || 0), 1)}%</span>`)
+          : cell('回本需涨', `<span style="color:var(--warning)">${g.breakeven_upside_pct == null ? DASH : '+' + num(g.breakeven_upside_pct, 1) + '%'}</span>`)}
         ${cell('已投', `${g.days_invested ?? DASH} 交易日`)}
         ${cell('约定投', `${g.installments_est ?? DASH} 笔 ×¥${num(g.daily_amount)}`)}
       </div>`;
@@ -2461,16 +2493,22 @@
         const dchg = dg.change_pct;
         const dcolor = dchg == null ? 'var(--neutral)' : (dchg >= 0 ? 'var(--positive)' : 'var(--negative)');
         const retained = dg.quote_status === 'retained';
+        // 国内口径自己的回本分档（与基金口径同号，但各自算，不借用）。
+        const dgAbove = dg.breakeven_upside_pct != null && dg.breakeven_upside_pct <= 0;
+        const dgBeColor = dgAbove ? 'var(--positive)' : 'var(--warning)';
+        const dgBeTxt = dgAbove
+          ? `成本线上方 <b style="color:${dgBeColor}">${num(-(dg.breakeven_upside_pct || 0), 2)}%</b>`
+          : `距回本 <b style="color:${dgBeColor}">${dg.breakeven_upside_pct == null ? DASH : '+' + num(dg.breakeven_upside_pct, 2) + '%'}</b>`;
         goldDomestic.innerHTML =
           `<div style="margin:12px 0 4px;padding:12px;border-radius:6px;background:color-mix(in srgb,var(--positive) 6%,transparent);border:1px solid color-mix(in srgb,var(--positive) 24%,transparent)">
              <div class="muted" style="font-size:var(--fs-micro);text-transform:none;letter-spacing:0">国内基准 · 上金所 Au99.99</div>
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
                <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">¥${num(dg.price_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">我的回本价</div><div style="font-size:var(--fs-xl);font-weight:700;color:${dgBeColor};white-space:nowrap">¥${num(dg.breakeven_cny_g, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/克</span></div></div>
              </div>
              <div class="muted" style="font-size:var(--fs-xs);margin-top:7px;text-transform:none;letter-spacing:0">
-               距回本 <b style="color:var(--warning)">+${num(dg.breakeven_upside_pct, 2)}%</b>
+               ${dgBeTxt}
                ${dchg == null ? '' : ` · 当日 <b style="color:${dcolor}">${dchg >= 0 ? '+' : ''}${num(dchg, 2)}%</b>`}
                ${dg.low_cny_g != null && dg.high_cny_g != null ? ` · 日内 ¥${num(dg.low_cny_g, 0)}~${num(dg.high_cny_g, 0)}` : ''}
              </div>
@@ -2496,6 +2534,11 @@
           : (g.nav ? ld.xau_usd * g.avg_cost / g.nav : null);
         const fundBePct = ld.fund_breakeven_upside_pct != null
           ? ld.fund_breakeven_upside_pct : g.breakeven_upside_pct;
+        const fundAbove = fundBePct != null && fundBePct <= 0;
+        const fundBeColor = fundAbove ? 'var(--positive)' : 'var(--warning)';
+        const fundBeTxt = fundAbove
+          ? `成本线上方 <b style="color:${fundBeColor}">${num(-fundBePct, 2)}%</b>`
+          : `距回本 <b style="color:${fundBeColor}">${fundBePct == null ? DASH : '+' + num(fundBePct, 2) + '%'}</b>`;
         // 伦敦金保留为国际辅助口径，显式区分现价与真基金回本映射。
         let html =
           `<div style="margin:12px 0 4px;padding:8px 12px;border-radius:6px;background:color-mix(in srgb,var(--warning) 7%,transparent);border:1px solid color-mix(in srgb,var(--warning) 25%,transparent)">
@@ -2503,10 +2546,10 @@
              <div style="display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:end;gap:10px;margin-top:7px">
                <div><div class="muted" style="font-size:var(--fs-micro)">当前金价</div><div style="font-size:var(--fs-xl);font-weight:700;white-space:nowrap">$${num(ld.xau_usd, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
                <div class="muted" aria-hidden="true" style="padding-bottom:4px">→</div>
-               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:var(--warning);white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
+               <div><div class="muted" style="font-size:var(--fs-micro)">按当前汇率回本</div><div style="font-size:var(--fs-xl);font-weight:700;color:${fundBeColor};white-space:nowrap">$${num(fundBeXau, 2)}<span style="font-size:var(--fs-xs);color:var(--muted,#999)">/oz</span></div></div>
              </div>
              <div class="muted" style="font-size:var(--fs-xs);margin-top:5px;text-transform:none;letter-spacing:0">
-               距回本 <b style="color:var(--warning)">+${num(fundBePct, 2)}%</b>${xchgStr}
+               ${fundBeTxt}${xchgStr}
                ${ld.xau_high != null && ld.xau_low != null ? ` · 日内 ${num(ld.xau_low, 0)}~${num(ld.xau_high, 0)}` : ''}
                · USDCNY ${num(ld.usdcny, 4)} · 假设汇率/内外盘价差不变
              </div>`;
@@ -2543,18 +2586,22 @@
                  ${de.current_value_cny != null ? `· 对应现值 <b style="color:${dColor}">¥${num(de.current_value_cny)}</b> (${de.pnl_pct >= 0 ? '+' : ''}${num(de.pnl_pct, 2)}%)` : ''}
                </div>
              </div>`;
-          // 摊薄轨迹：继续同额定投伦敦金 → 均成本 $/oz 往下移、回本门槛下降
+          // 摊薄轨迹：继续同额定投伦敦金 → 均成本 $/oz 移动方向由数据说话
+          //（现货在均价下方时摊薄下移、上方时反而上抬 —— 回本后这句文案
+          // 曾固定写「下移」，与它自己表格里的数字打架）。
           const lproj = (de.projection || []).filter(p => p && p.avg_cost_usd_oz != null);
           if (lproj.length) {
             const MON = { 20: '+1月', 40: '+2月', 60: '+3月', 120: '+半年', 250: '+1年' };
+            const lDir = de.avg_cost_usd_oz != null && lproj[lproj.length - 1].avg_cost_usd_oz >= de.avg_cost_usd_oz ? '上移' : '下移';
+            const deAbove = de.breakeven_upside_pct != null && de.breakeven_upside_pct <= 0;
             const lrows = lproj.map(p =>
               `<tr><td style="padding:4px 8px">${MON[p.days] || ('+' + p.days + '日')}</td>
                 <td style="padding:4px 8px;text-align:right">$${num(p.avg_cost_usd_oz, 0)}</td>
-                <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
+                <td style="padding:4px 8px;text-align:right;color:${deAbove ? 'var(--text-secondary)' : 'var(--positive)'}">${p.breakeven_upside_pct == null ? DASH : (p.breakeven_upside_pct >= 0 ? '+' : '') + num(p.breakeven_upside_pct, 1) + '%'}</td></tr>`).join('');
             html +=
-              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz 下移</div>
+              `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若金价/汇率不动、继续每日定投 → 持金成本 $/oz ${lDir}</div>
                <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
-                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+                 <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">均成本/oz</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">距成本线</th></tr>
                ${lrows}</table>`;
           }
           html += `</div></details>`;
@@ -2604,32 +2651,38 @@
       const avg = g.avg_cost;
       const avgY = (avg >= lo && avg <= hi) ? y(avg) : null;
       const lastV = hist[hist.length - 1][1];
+      // 成本线的颜色跟着回本状态走：在上方=要守的线（amber），越线之后=
+      // 已经站上去的参照（绿）。线本身语义不变，只换情绪。
+      const costColor = aboveWater ? 'var(--positive)' : 'var(--warning)';
       sp.innerHTML =
         `<svg viewBox="0 0 ${W} ${H}" width="100%" height="${H}" preserveAspectRatio="none" style="margin-top:4px">
-          ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="var(--warning)" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
+          ${avgY != null ? `<line x1="0" y1="${avgY.toFixed(1)}" x2="${W}" y2="${avgY.toFixed(1)}" stroke="${costColor}" stroke-width="1" stroke-dasharray="3 2" opacity="0.7"/>` : ''}
           <polyline points="${pts}" fill="none" stroke="var(--warning)" stroke-width="1.6"/>
           <circle cx="${x(startIdx).toFixed(1)}" cy="${y(hist[startIdx][1]).toFixed(1)}" r="2.6" fill="var(--accent)"/>
           <circle cx="${x(hist.length - 1).toFixed(1)}" cy="${y(lastV).toFixed(1)}" r="2.6" fill="${pnlColor}"/>
         </svg>
         <div class="muted" style="font-size:var(--fs-micro);display:flex;justify-content:space-between;text-transform:none;letter-spacing:0">
           <span style="color:var(--accent)">${hist[startIdx][0]} 起投 ${num(hist[startIdx][1], 3)}</span>
-          <span style="color:var(--warning)">成本线 ${num(avg, 3)}</span>
+          <span style="color:${costColor}">成本线 ${num(avg, 3)}</span>
           <span>区间 ${num(lo, 3)}~${num(hi, 3)}</span>
         </div>`;
     } else { sp.innerHTML = ''; }
 
-    // 定投摊薄预测 (假设净值不动, 继续投 → 回本门槛下移)
+    // 定投摊薄预测 (假设净值不动, 继续投 → 成本线移动方向由数据说话：
+    // 净值在成本线下方时定投把它往下拽，越线之后同样的机制反过来把它
+    // 抬高 —— 文案跟着数字走，不再固定写「下移」。)
     const proj = g.projection || [];
     if (proj.length) {
       const MONTH = { 20: '+1月', 40: '+2月', 60: '+3月', 120: '+半年', 250: '+1年' };
+      const projDir = g.avg_cost != null && proj[proj.length - 1].avg_cost >= g.avg_cost ? '上移、安全垫收窄' : '下移';
       const rows = proj.map(p =>
         `<tr><td style="padding:4px 8px">${MONTH[p.days] || ('+' + p.days + '日')}</td>
           <td style="padding:4px 8px;text-align:right">${num(p.avg_cost, 3)}</td>
-          <td style="padding:4px 8px;text-align:right;color:var(--positive)">+${num(p.breakeven_upside_pct, 1)}%</td></tr>`).join('');
+          <td style="padding:4px 8px;text-align:right;color:${aboveWater ? 'var(--text-secondary)' : 'var(--positive)'}">${p.breakeven_upside_pct == null ? DASH : (p.breakeven_upside_pct >= 0 ? '+' : '') + num(p.breakeven_upside_pct, 1) + '%'}</td></tr>`).join('');
       document.getElementById('gold-proj').innerHTML =
-        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线/回本门槛下移</div>
+        `<div class="muted" style="font-size:var(--fs-micro);margin:8px 0 2px;text-transform:none;letter-spacing:0">若净值原地不动、继续每日定投 → 成本线${projDir}</div>
          <table style="width:100%;font-size:var(--fs-sm);border-collapse:collapse">
-           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">回本只需涨</th></tr>
+           <tr class="muted" style="font-size:var(--fs-micro)"><th scope="col" style="padding:4px 8px;text-align:left;font-weight:inherit">继续</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">平均成本</th><th scope="col" style="padding:4px 8px;text-align:right;font-weight:inherit">距成本线</th></tr>
            ${rows}</table>`;
     } else { document.getElementById('gold-proj').innerHTML = ''; }
 

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -835,10 +835,10 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
   // 数据到达前 #hero-rail 是空的。在给它 min-height 之前它高 1px，填满后
   // 85px（桌面），每次加载都跳一次 —— 实测这一下就是整页 CLS 的大头
   // (0.26 -> 0.04)。这里量的是「预留 == 实测」，比断言一个 CLS 数字稳。
-  // 六格 → 四格 → 三格（今日搬进自己那一行，Brier 出首屏）。这条闸量的从来
-  // 不是格数本身，而是「预留 == 实测」，格数只是用来钉住某次改版没有把断点
-  // 改塌。
-  for (const [width, expectCols] of [[390, 2], [900, 3], [1440, 3]]) {
+  // 六格 → 四格 → 今日搬进自己那一行后是美股/港股/距峰值/遵守率四格。
+  // 这条闸量的从来不是格数本身，而是「预留 == 实测」，格数只是用来钉住
+  // 某次改版没有把断点改塌。
+  for (const [width, expectCols] of [[390, 2], [900, 4], [1440, 4]]) {
     const context = await browser.newContext({ viewport: { width, height: 900 } });
     const page = await context.newPage();
     await stubLiveOrigin(page);
@@ -860,6 +860,58 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
     assert.equal(after.cols, expectCols, `hero rail column count changed at ${width}px`);
     assert.equal(reserved, after.height,
       `hero rail shifts by ${after.height - reserved}px when data lands at ${width}px`);
+
+    // 每日盈亏柱必须整体落在自己的槽位容器里：柱子按槽位中心对齐后，首末
+    // 柱两侧各留半个槽位。此前 left:i/n 把第一根柱的中心压在容器左缘，
+    // max-width 9px 的柱有一半（4.5px）悬在容器外 —— 修的是落点，不是粗细：
+    // 「疏密随宽度变、粗细不变」的规矩由 max-width 继续承担，这里只闸
+    // 「柱体不得溢出容器左右缘」。
+    const barFit = await page.evaluate(() => {
+      const bars = document.querySelector(".ht-chart .rc-bars");
+      if (!bars) return null;
+      const bc = bars.getBoundingClientRect();
+      let minL = Infinity, maxR = -Infinity, count = 0;
+      for (const b of bars.querySelectorAll("i")) {
+        const r = b.getBoundingClientRect();
+        minL = Math.min(minL, r.left); maxR = Math.max(maxR, r.right); count += 1;
+      }
+      // clearance 语义：≥0 = 柱体在容器内，负数 = 溢出该侧的像素数。
+      return count ? { clearL: minL - bc.left, clearR: bc.right - maxR, count } : null;
+    });
+    assert(barFit && barFit.count > 5, `daily bars missing at ${width}px`);
+    assert(barFit.clearL >= -0.5 && barFit.clearR >= -0.5,
+      `daily bars overflow their container at ${width}px ` +
+      `(left ${barFit.clearL.toFixed(1)}px, right ${barFit.clearR.toFixed(1)}px)`);
+
+    // 数据健康的「在期」分段必须是品牌蓝，不是灰墨也不是涨跌色（#920 判据：
+    // 数据状态不参与赚亏表述）。color-mix 的计算值序列化成 color(srgb …)，
+    // 和 rgb() 形式的 token 比字符串永不相等 —— 期望值用探针走同一条
+    // color-mix 路径解析出来，两边同一序列化才比得出真伪。
+    const health = await page.evaluate(() => {
+      const probe = document.createElement("span");
+      document.body.appendChild(probe);
+      const tint = c => {
+        probe.style.color = "";
+        probe.style.color = c;
+        return getComputedStyle(probe).color;
+      };
+      const okSegs = [...document.querySelectorAll(".dh-seg.is-ok i")];
+      const fills = okSegs.map(s => getComputedStyle(s).backgroundColor);
+      // 探针读完再摘：摘掉之后 getComputedStyle 读的是游离节点，颜色恒为空。
+      const accentBlue = tint("color-mix(in srgb, var(--accent) 82%, transparent)");
+      const oldGrey = tint("color-mix(in srgb, var(--text) 38%, transparent)");
+      const negRed = tint("var(--negative)");
+      probe.remove();
+      return { accentBlue, oldGrey, negRed, fills };
+    });
+    if (health.fills.length) {
+      assert(health.fills.every(f => f === health.accentBlue),
+        `in-period health segments drifted off the brand blue: ${health.fills[0]} vs ${health.accentBlue}`);
+      assert(health.fills[0] !== health.oldGrey,
+        "in-period health segments render as plain ink — the ok state went back to grey");
+      assert(health.fills[0] !== health.negRed,
+        "in-period health segments carry a P&L colour — data state is not an up/down");
+    }
     await context.close();
   }
 


### PR DESCRIPTION
kcn 2026-08-24 口头批注的五项首屏整改 + 黄金回本展示层。范围只碰 Overview 首屏与黄金卡；social card 链路（shoot_dashboard.js / socialCardHTML / social-card.png）未动；gold_dca 写入链路（23:50 单一 committer）未动，策略层建议见交付报告不动参数。

## 1. 柱状图溢出
`dailyBars` 落点 `i/n` → `(i+0.5)/n` 槽位居中：第一根柱的中心原来压在容器左缘，9px 柱一半（4.5px）悬出容器外。修的是落点不是粗细——「疏密随宽度变、粗细封顶 9px 不变」保持。新闸：390/900/1440 三档量柱体 bounding box 必须在 `.rc-bars` 容器内（clearance ≥ -0.5px）。

## 2. 毛玻璃（参照 DSH 插件）
判定卡 = 首屏第二块玻璃面：`--glass-card`（55% 面）+ `blur(24px) saturate(170%)`，不透明色写在前。结构性判据（#887）同步满足：body 主光 620px→860px 拉高到判定卡段，玻璃背后真的有光可糊；`prefers-reduced-transparency: reduce` 回退实色（`.card.overview-verdict` 两段类名赢特异度）；凹槽/量表不叠 blur。

## 3. 四格只填满 3 格
= hero-rail（#927 把「今日」搬走后剩三格）。补第四格「距峰值」：与 spark/柱图同一条序列（同源同算法）的峰→现回撤 + 自最低收复量表 + 峰值/日期说明行——三个参照点（比起投/比昨天/比峰值）互相不可推导，非重复数字。桌面 768+ 四列、移动 ≤767 由 3 格 2×2 缺角变满 2×2。地板 152/293 实测不变，pre==post。

## 4. 数据健康全灰
在期 dh-seg 分段、逐项 dh-bar、build-status 圆点 → 品牌蓝（--accent 色阶；蓝不是涨跌色）。warn/bad 仍 --warning/--red。色彩预算不变：涨跌两色 + 真告警红 + 品牌蓝。新闸经 color-mix 探针解析比对（color(srgb…) 序列化两侧同路）。

## 5. 决策面板重构（去大字报）
字号不动（#927 的 19px 保持），重构构图：宽屏 ≥1024 grid-areas 双栏——左列判词+要点（说的话）、右列硬闸（管的事），竖发丝线分栏；眉标「决策面板 · 今日判定」并成一行；时间戳从句中挪到句下；要点行改引文式左缩进（去横线节奏）。DOM 零改动、h3 语义保留。三档地板重量的 pre==post：296（≥1024）/506（768–1023）/564（≤767），横幅日扫宽 360–1920 实测上界 +2。

## 6. 黄金回本（展示层）
portfolio.json gold_dca 实证：avg_cost 3.3538 < nav 3.3774（08-24），pnl +0.7%，已越线。回本话术按 `aboveWater` 分档：统计格「回本需涨 +X%」→「成本线上方 +0.7%」；修「距回本 +-0.70%」双符号 bug（国内/伦敦两处）；摊薄预测表头「回本只需涨」→「距成本线」+ 带符号数值；摊薄方向文案改数据驱动（越线后继续定投 = 成本线上移、安全垫收窄，不再固定写「下移」）；spark 成本线颜色随状态（线上方=绿）。双渲染端逐字同步（parity 棘轮保持 8 项不动）。

## 验证
- `tests/dashboard_tab_runtime.spec.js` 本机全绿（含三条新闸）；`test_dashboard_bundle_parity.py` 及 dashboard/gold/site 相关 pytest 148 passed
- CLS A/B×3 同 harness 同数据（master vs branch）：1200×760 median 0.0117→0.0067；1440×900 0.0136→0.0056；390×844 0.0095 持平
- 360–1920 扫宽无横向溢出；暗/亮主题截图核对；index.html 未改
