### PR TITLE
perf: DAG-wave orchestration of the brief preflight spawn chain (#916)

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -38,12 +38,14 @@ from clawock.portfolio.guardrail import (  # noqa: F401  (re-export)
     compute_risk_guardrail,
 )
 import argparse
+import concurrent.futures
 import json
 import math
 import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime, date, timezone, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -1397,6 +1399,48 @@ def benchmark_node():
     return None, issues
 
 
+NODE_ORDER = [
+    # Every spawn node in today's textual execution order (#916). After each
+    # wave joins, the parent extends `issues` from the wave's results in this
+    # order — so an identical failure set produces a byte-identical
+    # context['issues'] (and therefore generation_id) regardless of thread
+    # completion order.
+    'analyze_us', 'analyze_hk', 'fx_rate', '_node_filings',
+    'peer_scan_node', 'daily_bars_node', 'portfolio_risk_node',
+    'regime_node', 'quant_node', 'quant_review_node',
+    'cross_factor_node', 'evidence_node', 'peer_residual_node',
+    't0_node', 't0_review_node', 'em_news_node',
+    'catalysts_node', 'news_evidence_node', 'benchmark_node',
+]
+
+
+def _timed(fn):
+    """Run one node callable; return (payload, issues, wall_s).
+
+    Timing only — deliberately no try/except here: every node keeps its own
+    original except branch and timeout cap verbatim, and a wrapper handler
+    would change per-node failure semantics (#916)."""
+    started = time.monotonic()
+    payload, node_issues = fn()
+    return payload, node_issues, time.monotonic() - started
+
+
+def _run_wave(nodes, *, max_workers=2):
+    """Run one DAG wave of subprocess nodes concurrently.
+
+    nodes maps a NODE_ORDER name to a zero-arg callable returning
+    (payload, issues); returns {name: (payload, issues, wall_s)}. Process
+    isolation is unchanged — still one clawock subprocess per node; only the
+    scheduling is concurrent, capped at max_workers=2 for the 2C/2GB box (#916).
+    """
+    results = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        pending = {pool.submit(_timed, fn): name for name, fn in nodes.items()}
+        for future in concurrent.futures.as_completed(pending):
+            results[pending[future]] = future.result()
+    return results
+
+
 def main(argv=None):
     # This script took no arguments at all, so `--help` was not "unsupported" —
     # it was ignored, and the full preflight ran: live price fetches, SEC EDGAR,
@@ -1453,16 +1497,35 @@ def main(argv=None):
 
     print(f'═════ brief_preflight.py | {today} ═════')
 
-    # [1] Refresh prices
-    _, node_issues = analyze_us()
-    issues.extend(node_issues)
+    step_timings = {}
 
-    _, node_issues = analyze_hk()
-    issues.extend(node_issues)
+    def _join(results):
+        """Merge one wave into `issues`/`step_timings`; return {name: payload}.
 
-    # [3] FX
-    fx, node_issues = fx_rate()
-    issues.extend(node_issues)
+        Issue strings are appended by the parent AFTER the wave join, in
+        NODE_ORDER (= today's textual order), so an identical failure set
+        yields a byte-identical context['issues'] — and therefore generation_id
+        — regardless of thread completion order (#916)."""
+        payloads = {}
+        for name in NODE_ORDER:
+            if name not in results:
+                continue
+            payload, node_issues, wall_s = results[name]
+            issues.extend(node_issues)
+            step_timings[name] = {'ok': not node_issues, 'wall_s': wall_s}
+            payloads[name] = payload
+        return payloads
+
+    def _run_serial(name, fn):
+        """Serial-prefix node: identical accounting to waved nodes."""
+        return _join({name: _timed(fn)})[name]
+
+    # [1]+[2] Price refreshes are STRICTLY SERIAL, never parallel: analyze-us
+    # then analyze-hk each read-modify-write the SAME portfolio.json
+    # (us_analysis.update_us_portfolio writes it; hk_analysis writes the same
+    # path), so concurrent execution would lose one side's update (#916 §1.2).
+    _run_serial('analyze_us', analyze_us)
+    _run_serial('analyze_hk', analyze_hk)
 
     # [4] Snapshot
     print('[4/14] Portfolio snapshot')
@@ -1486,21 +1549,10 @@ def main(argv=None):
     print(f'   Look-through: HK factor HHI={lookthrough["hk"]["factor_hhi"]:.3f}; '
           f'US factor HHI={lookthrough["us"]["factor_hhi"]:.3f}')
 
-    # Book totals (FX-aware)
-    rate = fx['rate']
-    hk_pnl_hkd = portfolio['portfolios']['hk_stocks'].get('total_pnl', 0)
-    us_pnl_usd = portfolio['portfolios']['us_stocks'].get('total_pnl', 0)
-    book = {
-        'hk_pnl_hkd':      round(hk_pnl_hkd, 2),
-        'us_pnl_usd':      round(us_pnl_usd, 2),
-        'usd_base_total':  round(hk_pnl_hkd / rate + us_pnl_usd, 2),
-        'hkd_base_total':  round(hk_pnl_hkd + us_pnl_usd * rate, 2),
-        'fx_used':         rate,
-    }
-
-    # [6] SEC EDGAR
-    us_fund, node_issues = _node_filings(portfolio)
-    issues.extend(node_issues)
+    # [6] SEC EDGAR — strictly serial loop inside collect_us_fundamentals: the
+    # SEC rate limiter is an in-process global, so parallel spawns would clone
+    # N copies of it (#916 §1.4).
+    us_fund = _run_serial('_node_filings', lambda: _node_filings(portfolio))
 
     # [7] Retrospective
     print('[7/14] Retrospective')
@@ -1518,14 +1570,78 @@ def main(argv=None):
     else:
         print(f'   first run (no prior plan)')
 
-    # [8] Peer scan — for each active holding, fetch peer prices + flag divergence
-    peer_scan, _ = peer_scan_node(portfolio)
+    # [8]-[13] DAG waves (#916 §1.2/§1.3): serial prefix done, now three
+    # concurrent waves separated by barriers, each capped at max_workers=2.
+    # Wave membership carries every true dependency edge:
+    #   WAVE1 — inputs are self-sufficient (fx, peers, bars, risk, regime,
+    #           quant, em-news, catalysts, peer-residual); write targets are
+    #           pairwise disjoint.
+    #   barrier
+    #   WAVE2 — quant-review/cross-factor/t0 read quant's outputs from WAVE1;
+    #           news-evidence builds its graph from the em-news + catalysts
+    #           artifacts finished at the barrier; benchmark STARTS only after
+    #           regime FINISHED at the barrier — regime must read YESTERDAY'S
+    #           benchmark.json while the benchmark node rewrites that same
+    #           file, so this ordering is a byte-determinism constraint, not a
+    #           data dependency (#916 §1.2).
+    #   barrier
+    #   WAVE3 — t0-review reconciles t0's history jsonl from WAVE2; evidence
+    #           rebuilds the page from the quant-review + cross-factor
+    #           artifacts finalized at the barrier.
+    w1 = _join(_run_wave({
+        'fx_rate': fx_rate,
+        'peer_scan_node': lambda: peer_scan_node(portfolio),
+        'daily_bars_node': daily_bars_node,
+        'portfolio_risk_node': portfolio_risk_node,
+        'regime_node': regime_node,
+        'quant_node': quant_node,
+        'em_news_node': em_news_node,
+        'catalysts_node': catalysts_node,
+        'peer_residual_node': lambda: peer_residual_node(portfolio),
+    }))
+    fx = w1['fx_rate']
+    peer_scan = w1['peer_scan_node']
+    risk = w1['portfolio_risk_node']
+    lev_regime = w1['regime_node']
+    quant_signals = w1['quant_node']
+    catalysts = w1['catalysts_node']
+    peer_residual_ctx = w1['peer_residual_node']
 
-    # [9] Canonical bars — must precede [10]: settling only reads this store.
-    _, node_issues = daily_bars_node()
-    issues.extend(node_issues)
+    # Book totals (FX-aware) — moved here from the old [5] block: fx now
+    # completes in WAVE1 and rate is its only input (pure arithmetic; nothing
+    # between the prefix and this point consumes it).
+    rate = fx['rate']
+    hk_pnl_hkd = portfolio['portfolios']['hk_stocks'].get('total_pnl', 0)
+    us_pnl_usd = portfolio['portfolios']['us_stocks'].get('total_pnl', 0)
+    book = {
+        'hk_pnl_hkd':      round(hk_pnl_hkd, 2),
+        'us_pnl_usd':      round(us_pnl_usd, 2),
+        'usd_base_total':  round(hk_pnl_hkd / rate + us_pnl_usd, 2),
+        'hkd_base_total':  round(hk_pnl_hkd + us_pnl_usd * rate, 2),
+        'fx_used':         rate,
+    }
 
-    # [10] V2 episode metrics — triggered-only, strategy-aware, cluster-bootstrap
+    w2 = _join(_run_wave({
+        'quant_review_node': quant_review_node,
+        'cross_factor_node': lambda: cross_factor_node(portfolio),
+        't0_node': t0_node,
+        'news_evidence_node': news_evidence_node,
+        'benchmark_node': benchmark_node,
+    }))
+    quant_review = w2['quant_review_node']
+    cross_sectional_factor_ctx = w2['cross_factor_node']
+    t0_setups = w2['t0_node']
+    news_evidence_ctx = w2['news_evidence_node']
+
+    w3 = _join(_run_wave({
+        't0_review_node': t0_review_node,
+        'evidence_node': evidence_node,
+    }))
+    t0_review = w3['t0_review_node']
+
+    # [10] V2 episode metrics — triggered-only, strategy-aware, cluster-bootstrap.
+    # Settle runs only AFTER daily-bars finished at the WAVE1 barrier: settling
+    # reads the canonical bar store and never fetches (#916 §1.2).
     print('[10/14] Decision metrics v2')
     decision_metrics = compute_decision_metrics()
     # Brier is never printed bare: alone it reads as "0.295, close enough to 0".
@@ -1551,45 +1667,6 @@ def main(argv=None):
     reflections = compute_reflections(portfolio)
     if reflections:
         print(f'[9b/11] Reflections: {len(reflections)} held tickers with prior-call history')
-
-    # [10] Risk metrics — Tier 2: β / vol / DD / Sharpe / margin sim
-    risk, _ = portfolio_risk_node()
-
-    # [10b] Leverage dial — HSTECH 200DMA trend + 20d vol → leveraged-ETF cap multiplier
-    lev_regime, _ = regime_node()
-
-    # [10b2] 量化因子层 — 趋势/动量/RSI/z-score/ATR吊灯止损/vol-target（纯算术，
-    # LLM 技术面判断只准引用此表）。merge-not-overwrite，单只抓空保留旧值。
-    quant_signals, _ = quant_node()
-
-    # [10b3] 因子 edge 自检 — 历史留痕 vs forward return 对账（自迭代：因子话语权由
-    # hit_rate 决定，样本<20 不解锁）。纯本地文件运算。
-    quant_review, _ = quant_review_node()
-
-    # [10b3b] Cross-sectional factor research — curated peers + 1x underlyings,
-    # sector-neutral ranks and strictly prospective activation. The full artifact
-    # stays on disk; context gets a compact view to avoid spending brief tokens on
-    # 38 complete research rows. `usable_for_decisions=false` is a hard boundary.
-    cross_sectional_factor_ctx, _ = cross_factor_node(portfolio)
-
-    evidence_node()
-
-    # [10b3c] Curated peer residual/leadership research. HK taxonomy is explicitly
-    # manual-only; leveraged products are folded to 1x before basket construction.
-    # As with the broader cross-sectional layer, inactive rules are display-only.
-    peer_residual_ctx, _ = peer_residual_node(portfolio)
-
-    # [10b4] T+0 牌面评级 — 零额外请求（从已抓字段 + quant ATR 推导），追高检测。
-    # 紧跟 quant_signals 之后跑（依赖其 ATR 刷新）。
-    t0_setups, _ = t0_node()
-
-    # [10b4b] T+0 牌面 edge 自检 — 牌面评级对账 T+1 forward return（数据背书）。
-    # 零网络：结算用历史留痕的 close，绝不每分钟抓价。
-    t0_review, _ = t0_review_node()
-
-    # [10b6] 中文消息源 — Eastmoney HK 持仓新闻 + 7x24 快讯（信息广度，喂 catalyst-gate）。
-    # 借鉴 UZI-Skill 的数据源广度；信息收集是 LLM 强项 + kcn token 充足。失败 fail-soft。
-    em_news_node()
 
     # [10b5] 数据体检闸 — 把历史踩过的数字 bug 固化成自动门。warn-only 注入 context
     # （遵 feedback_no_individual_cron_alerts 不推送），ERROR 由 build_status 健康卡暴露。
@@ -1640,21 +1717,6 @@ def main(argv=None):
         portfolio['portfolios']['hk_stocks']['holdings'],
         portfolio['portfolios']['us_stocks']['holdings'], lev_regime=lev_regime)
     print(f'   breakeven: {len(breakeven["rows"])} 只浮亏持仓入表')
-
-    # [11] Catalyst calendar — next 14d earnings + FOMC + macro
-    catalysts, node_issues = catalysts_node()
-    issues.extend(node_issues)
-
-    # [11b] News evidence graph — normalize filings/news/calendar nodes, expire
-    # repeated summaries and apply deterministic source/novelty/confirmation
-    # gates. Only a compact decision envelope enters the LLM context.
-    news_evidence_ctx, node_issues = news_evidence_node()
-    issues.extend(node_issues)
-
-    # Benchmark history (SPY + HSI/HSTECH) for the Equity Curve overlay.
-    # Refreshed once per day at brief time; consumed by build_dashboard.
-    _, node_issues = benchmark_node()
-    issues.extend(node_issues)
 
     # [13] Macro + sentiment snapshots — written by GH Action (macro-scan / sentiment-scan).
     # Read-only here; brief LLM consumes the trimmed subset so "▎大盘速读" and
@@ -1789,6 +1851,7 @@ def main(argv=None):
         context_path=str(ctx_path),
         context_generation_id=context['generation_id'],
         model_context_bytes=bundle_manifest['budget']['always_loaded_bytes'],
+        step_timings=step_timings,  # additive detail: per-node ok/wall_s (#916 §1.5)
     )
     return 0 if not issues else 1
 

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -924,63 +924,9 @@ def load_influencer_feed(issues):
         return {}
 
 
-def main(argv=None):
-    # This script took no arguments at all, so `--help` was not "unsupported" —
-    # it was ignored, and the full preflight ran: live price fetches, SEC EDGAR,
-    # Tavily. A probe meant to cost nothing did a minutes-long real run.
-    #
-    # CI wraps this call in `|| true`, which reads like the case was handled. It
-    # is not: `|| true` catches a non-zero exit, and this never exited non-zero —
-    # it hung. On 2026-08-06 that consumed the validate job's entire 10-minute
-    # budget and failed a PR that had nothing to do with it.
-    #
-    # Parsing argv also restores the contract the repo relies on when an agent
-    # probes a script: `--help` exits 0 having done nothing, and an unknown flag
-    # exits 2 rather than being silently ignored — the latter is what turns
-    # "mistyped argument plus valid input" into a successful-looking no-op.
-    argparse.ArgumentParser(
-        description=(
-            "Deterministic data collection for the daily-deep-brief harness. "
-            "Takes no arguments; the date comes from TODAY or HKT now()."
-        ),
-    ).parse_args(argv)
-
-    # Date in HKT (the system's canonical TZ), or honor the TODAY env that the
-    # brief-fallback workflow exports — so the context filename here always matches
-    # the date the fallback script reads. Naive now() = runner UTC, which mismatched
-    # HKT in the 16:00–23:59 UTC window and broke off-schedule fallback runs.
-    today = (os.environ.get('TODAY')
-             or datetime.now(timezone(timedelta(hours=8))).strftime('%Y-%m-%d'))
-    TMP_DIR.mkdir(parents=True, exist_ok=True)
-    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
-    issues = []
-    job_name = '盘前深度简报'
-    slot = workflow_outcomes.slot_for_job(job_name)
-    workflow_outcomes.record_stage(job_name, 'preflight', 'pending', slot=slot)
-
-    # Holiday/weekend gate: the brief covers both markets, so skip ONLY when both
-    # HK and US are closed (still runs if either trades). At 08:00 HKT the relevant
-    # US session is the just-closed NY day, which trading_calendar reads correctly
-    # (NY-local date is still the prior calendar day at that hour).
-    hk_closed = trading_calendar.closed_reason('hk')
-    us_closed = trading_calendar.closed_reason('us')
-    if hk_closed and us_closed:
-        workflow_outcomes.record_stage(
-            job_name, 'preflight', 'skipped', slot=slot,
-            reason=f'港股{hk_closed}+美股{us_closed}',
-        )
-        result = {'status': 'market_closed', 'date': today,
-                  'reason': f'港股{hk_closed}+美股{us_closed}', 'skip': True}
-        (TMP_DIR / f'brief-context-{today}.json').write_text(
-            json.dumps(result, ensure_ascii=False, indent=2))
-        print(f'=== MARKET CLOSED — 港股{hk_closed} + 美股{us_closed} ({today}) ===')
-        print('SKIP：两市均休市，不生成简报、不调用 send/postflight，本回合结束。')
-        print(json.dumps(result, ensure_ascii=False, indent=2))
-        return 0
-
-    print(f'═════ brief_preflight.py | {today} ═════')
-
+def analyze_us():
     # [1] Refresh prices
+    issues = []
     print('\n[1/14] Refresh US prices')
     us_out, us_ok = _run_clawock('analyze-us', ['--no-news'])
     if not us_ok:
@@ -988,7 +934,11 @@ def main(argv=None):
         print(f'   ⚠️  {issues[-1]}')
     else:
         print('   ✓ done')
+    return None, issues
 
+
+def analyze_hk():
+    issues = []
     print('[2/14] Refresh HK prices')
     hk_out, hk_ok = _run_clawock('analyze-hk', ['--no-news'])
     if not hk_ok:
@@ -996,49 +946,23 @@ def main(argv=None):
         print(f'   ⚠️  {issues[-1]}')
     else:
         print('   ✓ done')
+    return None, issues
 
+
+def fx_rate():
     # [3] FX
+    issues = []
     print('[3/14] FX rate')
     fx = fetch_fx_rate()
     if 'error' in fx:
         issues.append(f'FX fallback used: {fx["error"][-200:]}')
     print(f'   USDHKD = {fx["rate"]}  ({fx["source"]})')
+    return fx, issues
 
-    # [4] Snapshot
-    print('[4/14] Portfolio snapshot')
-    portfolio_path = WS / 'portfolio.json'
-    snapshot_path  = SNAPSHOT_DIR / f'{today}.json'
-    snapshot_path.write_bytes(portfolio_path.read_bytes())
-    print(f'   ✓ {snapshot_path.name}')
 
-    # Load for downstream
-    portfolio = json.loads(portfolio_path.read_text())
-
-    # [5] Concentration
-    print('[5/14] Concentration')
-    hk_conc = compute_concentration(portfolio['portfolios']['hk_stocks']['holdings'])
-    us_conc = compute_concentration(portfolio['portfolios']['us_stocks']['holdings'])
-    lookthrough = compute_lookthrough_exposure(portfolio)
-    print(f'   HK: HHI={hk_conc.get("hhi"):.3f} {hk_conc.get("verdict")} '
-          f'(Top2 {hk_conc.get("top2_pct")}%)')
-    print(f'   US: HHI={us_conc.get("hhi"):.3f} {us_conc.get("verdict")} '
-          f'(Top2 {us_conc.get("top2_pct")}%)')
-    print(f'   Look-through: HK factor HHI={lookthrough["hk"]["factor_hhi"]:.3f}; '
-          f'US factor HHI={lookthrough["us"]["factor_hhi"]:.3f}')
-
-    # Book totals (FX-aware)
-    rate = fx['rate']
-    hk_pnl_hkd = portfolio['portfolios']['hk_stocks'].get('total_pnl', 0)
-    us_pnl_usd = portfolio['portfolios']['us_stocks'].get('total_pnl', 0)
-    book = {
-        'hk_pnl_hkd':      round(hk_pnl_hkd, 2),
-        'us_pnl_usd':      round(us_pnl_usd, 2),
-        'usd_base_total':  round(hk_pnl_hkd / rate + us_pnl_usd, 2),
-        'hkd_base_total':  round(hk_pnl_hkd + us_pnl_usd * rate, 2),
-        'fx_used':         rate,
-    }
-
+def _node_filings(portfolio):
     # [6] SEC EDGAR
+    issues = []
     print('[6/14] SEC EDGAR US singles')
     us_fund = collect_us_fundamentals(portfolio)
     for t, data in us_fund.items():
@@ -1048,29 +972,21 @@ def main(argv=None):
         else:
             kf = data.get('key_financials', {})
             print(f'   ✓ {t}: {len(kf)} concepts')
+    return us_fund, issues
 
-    # [7] Retrospective
-    print('[7/14] Retrospective')
-    prior_plan = find_prior_plan(today)
-    retro = compute_retrospective(prior_plan, portfolio)
-    if retro.get('prior_plan_date'):
-        actions = retro['decisions']
-        fired = sum(1 for a in actions if a.get('trigger_fired') is True)
-        not_fired = sum(1 for a in actions if a.get('trigger_fired') is False)
-        ambiguous = sum(1 for a in actions if a.get('trigger_fired') is None and 'error' not in a)
-        print(f'   prior plan: {retro["prior_plan_date"]}')
-        print(f'   fired: {fired}   not fired: {not_fired}   ambiguous (manual/event): {ambiguous}')
-        print(f'   conf cal: 80%+ {retro["confidence_calibration"]["conf_80_100"]}, '
-              f'60-79% {retro["confidence_calibration"]["conf_60_79"]}')
-    else:
-        print(f'   first run (no prior plan)')
 
+def peer_scan_node(portfolio):
     # [8] Peer scan — for each active holding, fetch peer prices + flag divergence
+    issues = []
     print('[8/14] Peer scan')
     peer_scan = collect_peer_scan(portfolio)
     print(f'   {len(peer_scan)} holdings with peer data; {sum(1 for h in peer_scan.values() if h.get("divergence_signal"))} divergence signals')
+    return peer_scan, issues
 
+
+def daily_bars_node():
     # [9] Canonical bars — must precede [10]: settling only reads this store.
+    issues = []
     print('[9/14] Refresh canonical daily bars')
     bars = refresh_daily_bars()
     if not bars.get('ok'):
@@ -1109,35 +1025,12 @@ def main(argv=None):
             # Informational: thin names skip sessions legitimately. See bars_staleness.
             print(f'     {leg} behind leg: '
                   + ', '.join(f'{t}@{d}' for t, d in st['laggards'].items()))
+    return None, issues
 
-    # [10] V2 episode metrics — triggered-only, strategy-aware, cluster-bootstrap
-    print('[10/14] Decision metrics v2')
-    decision_metrics = compute_decision_metrics()
-    # Brier is never printed bare: alone it reads as "0.295, close enough to 0".
-    # It only means something against the constant-forecast baseline it has to beat.
-    print(f'   {decision_metrics.get("settled_episodes", 0)} settled episodes / '
-          f'{decision_metrics.get("raw_decisions", 0)} raw decisions; '
-          f'Brier={decision_metrics.get("brier")} vs constant-forecast baseline '
-          f'{decision_metrics.get("brier_baseline_loo")} '
-          f'({"beats" if decision_metrics.get("brier_beats_baseline") else "LOSES to"} it)')
-    hierarchical = decision_metrics.get('hierarchical_calibration') or {}
-    prequential = hierarchical.get('after_warmup') or {}
-    print(f'   hierarchical prequential: n={prequential.get("n", 0)} '
-          f'Brier={prequential.get("calibrated_brier")} vs raw '
-          f'{prequential.get("raw_brier")}; '
-          f'{hierarchical.get("abstained_predictions", 0)} historical abstentions / '
-          f'{hierarchical.get("edge_supported_predictions", 0)} edge-supported')
-    active_v2 = decision_metrics.get('active') or {}
-    print(f'   active: n={active_v2.get("n_episodes", 0)} '
-          f'avg benefit={active_v2.get("avg_benefit_pct")}%, '
-          f'cluster CI={active_v2.get("cluster_ci95")}')
 
-    # [9b] Reflection memory — per held ticker, prior call outcomes (TradingAgents-style)
-    reflections = compute_reflections(portfolio)
-    if reflections:
-        print(f'[9b/11] Reflections: {len(reflections)} held tickers with prior-call history')
-
+def portfolio_risk_node():
     # [10] Risk metrics — Tier 2: β / vol / DD / Sharpe / margin sim
+    issues = []
     print('[11/14] Risk metrics')
     risk = {}
     try:
@@ -1164,8 +1057,12 @@ def main(argv=None):
                 print(f'   ⚠ {a["type"]:18s} ({a["severity"]:6s}) {a["detail"][:80]}')
     except Exception as e:
         print(f'   ⚠ risk metrics failed: {e}')
+    return risk, issues
 
+
+def regime_node():
     # [10b] Leverage dial — HSTECH 200DMA trend + 20d vol → leveraged-ETF cap multiplier
+    issues = []
     lev_regime = None
     try:
         subprocess.run(['clawock', 'regime'],
@@ -1176,9 +1073,13 @@ def main(argv=None):
             print(f'   🧭 lev_regime: {lev_regime.get("tier")} (×{lev_regime.get("lev_cap_mult")}) — {lev_regime.get("label","")}')
     except Exception as e:
         print(f'   ⚠ lev_regime compute failed: {e}')
+    return lev_regime, issues
 
+
+def quant_node():
     # [10b2] 量化因子层 — 趋势/动量/RSI/z-score/ATR吊灯止损/vol-target（纯算术，
     # LLM 技术面判断只准引用此表）。merge-not-overwrite，单只抓空保留旧值。
+    issues = []
     quant_signals = {}
     try:
         subprocess.run(['clawock', 'quant'],
@@ -1195,9 +1096,13 @@ def main(argv=None):
                   + '; '.join(f'{k}:{v}' for k, v in list(tags.items())[:4]) + ' …')
     except Exception as e:
         print(f'   ⚠ quant_signals compute failed: {e}')
+    return quant_signals, issues
 
+
+def quant_review_node():
     # [10b3] 因子 edge 自检 — 历史留痕 vs forward return 对账（自迭代：因子话语权由
     # hit_rate 决定，样本<20 不解锁）。纯本地文件运算。
+    issues = []
     quant_review = {}
     try:
         subprocess.run(['clawock', 'quant-review'],
@@ -1208,11 +1113,15 @@ def main(argv=None):
             print(f'   📐 factor edge: {quant_review.get("summary", "")[:80]}')
     except Exception as e:
         print(f'   ⚠ quant_signal_review failed: {e}')
+    return quant_review, issues
 
+
+def cross_factor_node(portfolio):
     # [10b3b] Cross-sectional factor research — curated peers + 1x underlyings,
     # sector-neutral ranks and strictly prospective activation. The full artifact
     # stays on disk; context gets a compact view to avoid spending brief tokens on
     # 38 complete research rows. `usable_for_decisions=false` is a hard boundary.
+    issues = []
     cross_sectional_factor = {}
     cross_sectional_factor_ctx = {}
     try:
@@ -1260,17 +1169,25 @@ def main(argv=None):
             )
     except Exception as e:
         print(f'   ⚠ cross-sectional factor failed: {e}')
+    return cross_sectional_factor_ctx, issues
 
+
+def evidence_node():
     # 证据页：读上面刚刷新的产物重新生成，保证「测了什么、什么没通过」不落后于事实。
+    issues = []
     try:
         subprocess.run(['clawock', 'evidence'],
                        capture_output=True, text=True, timeout=60, check=False)
     except Exception as e:
         print(f'   ⚠ evidence page rebuild failed: {e}')
+    return None, issues
 
+
+def peer_residual_node(portfolio):
     # [10b3c] Curated peer residual/leadership research. HK taxonomy is explicitly
     # manual-only; leveraged products are folded to 1x before basket construction.
     # As with the broader cross-sectional layer, inactive rules are display-only.
+    issues = []
     peer_residual_ctx = {}
     try:
         subprocess.run(
@@ -1312,9 +1229,13 @@ def main(argv=None):
             )
     except Exception as e:
         print(f'   ⚠ peer residual engine failed: {e}')
+    return peer_residual_ctx, issues
 
+
+def t0_node():
     # [10b4] T+0 牌面评级 — 零额外请求（从已抓字段 + quant ATR 推导），追高检测。
     # 紧跟 quant_signals 之后跑（依赖其 ATR 刷新）。
+    issues = []
     t0_setups = {}
     try:
         subprocess.run(['clawock', 't0'],
@@ -1327,9 +1248,13 @@ def main(argv=None):
                   + (f' — 🔴 追高: {", ".join(chase)}' if chase else ''))
     except Exception as e:
         print(f'   ⚠ t0_setups compute failed: {e}')
+    return t0_setups, issues
 
+
+def t0_review_node():
     # [10b4b] T+0 牌面 edge 自检 — 牌面评级对账 T+1 forward return（数据背书）。
     # 零网络：结算用历史留痕的 close，绝不每分钟抓价。
+    issues = []
     t0_review = {}
     try:
         subprocess.run(['clawock', 't0-review'],
@@ -1340,67 +1265,24 @@ def main(argv=None):
             print(f'   🎯 T+0 牌面背书: {t0_review.get("summary", "")[:80]}')
     except Exception as e:
         print(f'   ⚠ t0_setup_review failed: {e}')
+    return t0_review, issues
 
+
+def em_news_node():
     # [10b6] 中文消息源 — Eastmoney HK 持仓新闻 + 7x24 快讯（信息广度，喂 catalyst-gate）。
     # 借鉴 UZI-Skill 的数据源广度；信息收集是 LLM 强项 + kcn token 充足。失败 fail-soft。
+    issues = []
     try:
         subprocess.run(['clawock', 'em-news'], cwd=WS,
                        capture_output=True, text=True, timeout=60, check=False)
     except Exception as e:
         print(f'   ⚠ clawock em-news failed: {e}')
+    return None, issues
 
-    # [10b5] 数据体检闸 — 把历史踩过的数字 bug 固化成自动门。warn-only 注入 context
-    # （遵 feedback_no_individual_cron_alerts 不推送），ERROR 由 build_status 健康卡暴露。
-    integrity = {}
-    try:
-        from clawock.portfolio import integrity as _pi
-        integrity = _pi.check()
-        if not integrity['ok']:
-            print(f'   🔴 数据体检 {integrity["error_count"]} ERROR：')
-            for f in integrity['findings']:
-                if f['level'] == 'ERROR':
-                    print(f'      • {f["code"]}: {f["msg"][:90]}')
-        elif integrity['warn_count']:
-            print(f'   🟡 数据体检 {integrity["warn_count"]} WARN（见 integrity_report.json）')
-        else:
-            print('   ✅ 数据体检全过')
-    except Exception as e:
-        print(f'   ⚠ integrity check failed: {e}')
 
-    # [10c] Risk guardrails — position-sizing / leverage hard caps → trim/cut directives
-    guardrail = compute_risk_guardrail(
-        portfolio['portfolios']['hk_stocks']['holdings'],
-        portfolio['portfolios']['us_stocks']['holdings'],
-        hk_conc, us_conc, risk, lev_regime=lev_regime)
-    guardrail = risk_discipline.attach_breach_ids(guardrail)
-    _append_guardrail_history(today, guardrail, hk_conc, us_conc, risk)
-    discipline = {}
-    try:
-        discipline = risk_discipline.reconcile_guardrail(
-            guardrail, portfolio)
-    except Exception as e:
-        discipline = {'error': f'{type(e).__name__}: {e}', 'records': []}
-        issues.append(f'risk discipline reconcile failed: {type(e).__name__}')
-    print(f'   guardrail: {guardrail["breach_count"]} breaches/stops — {guardrail["directive"][:64]}')
-    if discipline.get('error'):
-        print(f'   🔴 durable risk ledger failed: {discipline["error"]}')
-    else:
-        print(f'   durable risk ledger: {discipline.get("open_count", 0)} open / '
-              f'{discipline.get("overridden_count", 0)} overridden / '
-              f'oldest {discipline.get("oldest_open_days", 0)}d')
-    for b in guardrail['breaches']:
-        print(f'   ⛔ {b["type"]:20s} ({b["severity"]:6s}) {b["detail"][:78]}')
-    for s in guardrail['hard_stop_watch']:
-        print(f'   🛑 {s["detail"][:78]}')
-
-    # [10d] 解套数学 — 纯算术回本表（浮亏持仓回本所需涨幅 / 2x 横盘 decay 成本）
-    breakeven = compute_breakeven_math(
-        portfolio['portfolios']['hk_stocks']['holdings'],
-        portfolio['portfolios']['us_stocks']['holdings'], lev_regime=lev_regime)
-    print(f'   breakeven: {len(breakeven["rows"])} 只浮亏持仓入表')
-
+def catalysts_node():
     # [11] Catalyst calendar — next 14d earnings + FOMC + macro
-    print('[12/14] Fetch catalysts')
+    issues = []
     catalysts = {}
     try:
         result = subprocess.run(
@@ -1424,10 +1306,14 @@ def main(argv=None):
     except Exception as e:
         print(f'   ⚠ catalysts step failed: {e}')
         issues.append(f'catalysts step exception: {type(e).__name__}')
+    return catalysts, issues
 
+
+def news_evidence_node():
     # [11b] News evidence graph — normalize filings/news/calendar nodes, expire
     # repeated summaries and apply deterministic source/novelty/confirmation
     # gates. Only a compact decision envelope enters the LLM context.
+    issues = []
     news_evidence_ctx = {}
     try:
         graph_run = subprocess.run(
@@ -1488,9 +1374,13 @@ def main(argv=None):
         issues.append(
             f'news evidence graph exception: {type(e).__name__}'
         )
+    return news_evidence_ctx, issues
 
+
+def benchmark_node():
     # Benchmark history (SPY + HSI/HSTECH) for the Equity Curve overlay.
     # Refreshed once per day at brief time; consumed by build_dashboard.
+    issues = []
     print('[13/14] Fetch benchmark history')
     try:
         bm_out, bm_ok = _run_clawock('benchmark', timeout=30)
@@ -1504,6 +1394,267 @@ def main(argv=None):
     except Exception as e:
         print(f'   ⚠ benchmark step failed: {e}')
         issues.append(f'benchmark step exception: {type(e).__name__}')
+    return None, issues
+
+
+def main(argv=None):
+    # This script took no arguments at all, so `--help` was not "unsupported" —
+    # it was ignored, and the full preflight ran: live price fetches, SEC EDGAR,
+    # Tavily. A probe meant to cost nothing did a minutes-long real run.
+    #
+    # CI wraps this call in `|| true`, which reads like the case was handled. It
+    # is not: `|| true` catches a non-zero exit, and this never exited non-zero —
+    # it hung. On 2026-08-06 that consumed the validate job's entire 10-minute
+    # budget and failed a PR that had nothing to do with it.
+    #
+    # Parsing argv also restores the contract the repo relies on when an agent
+    # probes a script: `--help` exits 0 having done nothing, and an unknown flag
+    # exits 2 rather than being silently ignored — the latter is what turns
+    # "mistyped argument plus valid input" into a successful-looking no-op.
+    argparse.ArgumentParser(
+        description=(
+            "Deterministic data collection for the daily-deep-brief harness. "
+            "Takes no arguments; the date comes from TODAY or HKT now()."
+        ),
+    ).parse_args(argv)
+
+    # Date in HKT (the system's canonical TZ), or honor the TODAY env that the
+    # brief-fallback workflow exports — so the context filename here always matches
+    # the date the fallback script reads. Naive now() = runner UTC, which mismatched
+    # HKT in the 16:00–23:59 UTC window and broke off-schedule fallback runs.
+    today = (os.environ.get('TODAY')
+             or datetime.now(timezone(timedelta(hours=8))).strftime('%Y-%m-%d'))
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    issues = []
+    job_name = '盘前深度简报'
+    slot = workflow_outcomes.slot_for_job(job_name)
+    workflow_outcomes.record_stage(job_name, 'preflight', 'pending', slot=slot)
+
+    # Holiday/weekend gate: the brief covers both markets, so skip ONLY when both
+    # HK and US are closed (still runs if either trades). At 08:00 HKT the relevant
+    # US session is the just-closed NY day, which trading_calendar reads correctly
+    # (NY-local date is still the prior calendar day at that hour).
+    hk_closed = trading_calendar.closed_reason('hk')
+    us_closed = trading_calendar.closed_reason('us')
+    if hk_closed and us_closed:
+        workflow_outcomes.record_stage(
+            job_name, 'preflight', 'skipped', slot=slot,
+            reason=f'港股{hk_closed}+美股{us_closed}',
+        )
+        result = {'status': 'market_closed', 'date': today,
+                  'reason': f'港股{hk_closed}+美股{us_closed}', 'skip': True}
+        (TMP_DIR / f'brief-context-{today}.json').write_text(
+            json.dumps(result, ensure_ascii=False, indent=2))
+        print(f'=== MARKET CLOSED — 港股{hk_closed} + 美股{us_closed} ({today}) ===')
+        print('SKIP：两市均休市，不生成简报、不调用 send/postflight，本回合结束。')
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f'═════ brief_preflight.py | {today} ═════')
+
+    # [1] Refresh prices
+    _, node_issues = analyze_us()
+    issues.extend(node_issues)
+
+    _, node_issues = analyze_hk()
+    issues.extend(node_issues)
+
+    # [3] FX
+    fx, node_issues = fx_rate()
+    issues.extend(node_issues)
+
+    # [4] Snapshot
+    print('[4/14] Portfolio snapshot')
+    portfolio_path = WS / 'portfolio.json'
+    snapshot_path  = SNAPSHOT_DIR / f'{today}.json'
+    snapshot_path.write_bytes(portfolio_path.read_bytes())
+    print(f'   ✓ {snapshot_path.name}')
+
+    # Load for downstream
+    portfolio = json.loads(portfolio_path.read_text())
+
+    # [5] Concentration
+    print('[5/14] Concentration')
+    hk_conc = compute_concentration(portfolio['portfolios']['hk_stocks']['holdings'])
+    us_conc = compute_concentration(portfolio['portfolios']['us_stocks']['holdings'])
+    lookthrough = compute_lookthrough_exposure(portfolio)
+    print(f'   HK: HHI={hk_conc.get("hhi"):.3f} {hk_conc.get("verdict")} '
+          f'(Top2 {hk_conc.get("top2_pct")}%)')
+    print(f'   US: HHI={us_conc.get("hhi"):.3f} {us_conc.get("verdict")} '
+          f'(Top2 {us_conc.get("top2_pct")}%)')
+    print(f'   Look-through: HK factor HHI={lookthrough["hk"]["factor_hhi"]:.3f}; '
+          f'US factor HHI={lookthrough["us"]["factor_hhi"]:.3f}')
+
+    # Book totals (FX-aware)
+    rate = fx['rate']
+    hk_pnl_hkd = portfolio['portfolios']['hk_stocks'].get('total_pnl', 0)
+    us_pnl_usd = portfolio['portfolios']['us_stocks'].get('total_pnl', 0)
+    book = {
+        'hk_pnl_hkd':      round(hk_pnl_hkd, 2),
+        'us_pnl_usd':      round(us_pnl_usd, 2),
+        'usd_base_total':  round(hk_pnl_hkd / rate + us_pnl_usd, 2),
+        'hkd_base_total':  round(hk_pnl_hkd + us_pnl_usd * rate, 2),
+        'fx_used':         rate,
+    }
+
+    # [6] SEC EDGAR
+    us_fund, node_issues = _node_filings(portfolio)
+    issues.extend(node_issues)
+
+    # [7] Retrospective
+    print('[7/14] Retrospective')
+    prior_plan = find_prior_plan(today)
+    retro = compute_retrospective(prior_plan, portfolio)
+    if retro.get('prior_plan_date'):
+        actions = retro['decisions']
+        fired = sum(1 for a in actions if a.get('trigger_fired') is True)
+        not_fired = sum(1 for a in actions if a.get('trigger_fired') is False)
+        ambiguous = sum(1 for a in actions if a.get('trigger_fired') is None and 'error' not in a)
+        print(f'   prior plan: {retro["prior_plan_date"]}')
+        print(f'   fired: {fired}   not fired: {not_fired}   ambiguous (manual/event): {ambiguous}')
+        print(f'   conf cal: 80%+ {retro["confidence_calibration"]["conf_80_100"]}, '
+              f'60-79% {retro["confidence_calibration"]["conf_60_79"]}')
+    else:
+        print(f'   first run (no prior plan)')
+
+    # [8] Peer scan — for each active holding, fetch peer prices + flag divergence
+    peer_scan, _ = peer_scan_node(portfolio)
+
+    # [9] Canonical bars — must precede [10]: settling only reads this store.
+    _, node_issues = daily_bars_node()
+    issues.extend(node_issues)
+
+    # [10] V2 episode metrics — triggered-only, strategy-aware, cluster-bootstrap
+    print('[10/14] Decision metrics v2')
+    decision_metrics = compute_decision_metrics()
+    # Brier is never printed bare: alone it reads as "0.295, close enough to 0".
+    # It only means something against the constant-forecast baseline it has to beat.
+    print(f'   {decision_metrics.get("settled_episodes", 0)} settled episodes / '
+          f'{decision_metrics.get("raw_decisions", 0)} raw decisions; '
+          f'Brier={decision_metrics.get("brier")} vs constant-forecast baseline '
+          f'{decision_metrics.get("brier_baseline_loo")} '
+          f'({"beats" if decision_metrics.get("brier_beats_baseline") else "LOSES to"} it)')
+    hierarchical = decision_metrics.get('hierarchical_calibration') or {}
+    prequential = hierarchical.get('after_warmup') or {}
+    print(f'   hierarchical prequential: n={prequential.get("n", 0)} '
+          f'Brier={prequential.get("calibrated_brier")} vs raw '
+          f'{prequential.get("raw_brier")}; '
+          f'{hierarchical.get("abstained_predictions", 0)} historical abstentions / '
+          f'{hierarchical.get("edge_supported_predictions", 0)} edge-supported')
+    active_v2 = decision_metrics.get('active') or {}
+    print(f'   active: n={active_v2.get("n_episodes", 0)} '
+          f'avg benefit={active_v2.get("avg_benefit_pct")}%, '
+          f'cluster CI={active_v2.get("cluster_ci95")}')
+
+    # [9b] Reflection memory — per held ticker, prior call outcomes (TradingAgents-style)
+    reflections = compute_reflections(portfolio)
+    if reflections:
+        print(f'[9b/11] Reflections: {len(reflections)} held tickers with prior-call history')
+
+    # [10] Risk metrics — Tier 2: β / vol / DD / Sharpe / margin sim
+    risk, _ = portfolio_risk_node()
+
+    # [10b] Leverage dial — HSTECH 200DMA trend + 20d vol → leveraged-ETF cap multiplier
+    lev_regime, _ = regime_node()
+
+    # [10b2] 量化因子层 — 趋势/动量/RSI/z-score/ATR吊灯止损/vol-target（纯算术，
+    # LLM 技术面判断只准引用此表）。merge-not-overwrite，单只抓空保留旧值。
+    quant_signals, _ = quant_node()
+
+    # [10b3] 因子 edge 自检 — 历史留痕 vs forward return 对账（自迭代：因子话语权由
+    # hit_rate 决定，样本<20 不解锁）。纯本地文件运算。
+    quant_review, _ = quant_review_node()
+
+    # [10b3b] Cross-sectional factor research — curated peers + 1x underlyings,
+    # sector-neutral ranks and strictly prospective activation. The full artifact
+    # stays on disk; context gets a compact view to avoid spending brief tokens on
+    # 38 complete research rows. `usable_for_decisions=false` is a hard boundary.
+    cross_sectional_factor_ctx, _ = cross_factor_node(portfolio)
+
+    evidence_node()
+
+    # [10b3c] Curated peer residual/leadership research. HK taxonomy is explicitly
+    # manual-only; leveraged products are folded to 1x before basket construction.
+    # As with the broader cross-sectional layer, inactive rules are display-only.
+    peer_residual_ctx, _ = peer_residual_node(portfolio)
+
+    # [10b4] T+0 牌面评级 — 零额外请求（从已抓字段 + quant ATR 推导），追高检测。
+    # 紧跟 quant_signals 之后跑（依赖其 ATR 刷新）。
+    t0_setups, _ = t0_node()
+
+    # [10b4b] T+0 牌面 edge 自检 — 牌面评级对账 T+1 forward return（数据背书）。
+    # 零网络：结算用历史留痕的 close，绝不每分钟抓价。
+    t0_review, _ = t0_review_node()
+
+    # [10b6] 中文消息源 — Eastmoney HK 持仓新闻 + 7x24 快讯（信息广度，喂 catalyst-gate）。
+    # 借鉴 UZI-Skill 的数据源广度；信息收集是 LLM 强项 + kcn token 充足。失败 fail-soft。
+    em_news_node()
+
+    # [10b5] 数据体检闸 — 把历史踩过的数字 bug 固化成自动门。warn-only 注入 context
+    # （遵 feedback_no_individual_cron_alerts 不推送），ERROR 由 build_status 健康卡暴露。
+    integrity = {}
+    try:
+        from clawock.portfolio import integrity as _pi
+        integrity = _pi.check()
+        if not integrity['ok']:
+            print(f'   🔴 数据体检 {integrity["error_count"]} ERROR：')
+            for f in integrity['findings']:
+                if f['level'] == 'ERROR':
+                    print(f'      • {f["code"]}: {f["msg"][:90]}')
+        elif integrity['warn_count']:
+            print(f'   🟡 数据体检 {integrity["warn_count"]} WARN（见 integrity_report.json）')
+        else:
+            print('   ✅ 数据体检全过')
+    except Exception as e:
+        print(f'   ⚠ integrity check failed: {e}')
+
+    # [10c] Risk guardrails — position-sizing / leverage hard caps → trim/cut directives
+    guardrail = compute_risk_guardrail(
+        portfolio['portfolios']['hk_stocks']['holdings'],
+        portfolio['portfolios']['us_stocks']['holdings'],
+        hk_conc, us_conc, risk, lev_regime=lev_regime)
+    guardrail = risk_discipline.attach_breach_ids(guardrail)
+    _append_guardrail_history(today, guardrail, hk_conc, us_conc, risk)
+    discipline = {}
+    try:
+        discipline = risk_discipline.reconcile_guardrail(
+            guardrail, portfolio)
+    except Exception as e:
+        discipline = {'error': f'{type(e).__name__}: {e}', 'records': []}
+        issues.append(f'risk discipline reconcile failed: {type(e).__name__}')
+    print(f'   guardrail: {guardrail["breach_count"]} breaches/stops — {guardrail["directive"][:64]}')
+    if discipline.get('error'):
+        print(f'   🔴 durable risk ledger failed: {discipline["error"]}')
+    else:
+        print(f'   durable risk ledger: {discipline.get("open_count", 0)} open / '
+              f'{discipline.get("overridden_count", 0)} overridden / '
+              f'oldest {discipline.get("oldest_open_days", 0)}d')
+    for b in guardrail['breaches']:
+        print(f'   ⛔ {b["type"]:20s} ({b["severity"]:6s}) {b["detail"][:78]}')
+    for s in guardrail['hard_stop_watch']:
+        print(f'   🛑 {s["detail"][:78]}')
+
+    # [10d] 解套数学 — 纯算术回本表（浮亏持仓回本所需涨幅 / 2x 横盘 decay 成本）
+    breakeven = compute_breakeven_math(
+        portfolio['portfolios']['hk_stocks']['holdings'],
+        portfolio['portfolios']['us_stocks']['holdings'], lev_regime=lev_regime)
+    print(f'   breakeven: {len(breakeven["rows"])} 只浮亏持仓入表')
+
+    # [11] Catalyst calendar — next 14d earnings + FOMC + macro
+    catalysts, node_issues = catalysts_node()
+    issues.extend(node_issues)
+
+    # [11b] News evidence graph — normalize filings/news/calendar nodes, expire
+    # repeated summaries and apply deterministic source/novelty/confirmation
+    # gates. Only a compact decision envelope enters the LLM context.
+    news_evidence_ctx, node_issues = news_evidence_node()
+    issues.extend(node_issues)
+
+    # Benchmark history (SPY + HSI/HSTECH) for the Equity Curve overlay.
+    # Refreshed once per day at brief time; consumed by build_dashboard.
+    _, node_issues = benchmark_node()
+    issues.extend(node_issues)
 
     # [13] Macro + sentiment snapshots — written by GH Action (macro-scan / sentiment-scan).
     # Read-only here; brief LLM consumes the trimmed subset so "▎大盘速读" and

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -42,7 +42,7 @@ def test_brief_actually_calls_the_installed_bar_fetcher(monkeypatch):
 def test_bars_are_fetched_before_the_ledger_settles():
     """Settling only reads the store, so a fetch after it lands a day late."""
     body = inspect.getsource(brief_preflight.main)
-    fetch_at = body.index('refresh_daily_bars()')
+    fetch_at = body.index('daily_bars_node()')
     settle_at = body.index('compute_decision_metrics()')
     assert fetch_at < settle_at, (
         'bars are refreshed after the ledger settles; the fetch would only take '

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -39,14 +39,20 @@ def test_brief_actually_calls_the_installed_bar_fetcher(monkeypatch):
     assert calls[0][1]['cwd'] == brief_preflight.WS
 
 
-def test_bars_are_fetched_before_the_ledger_settles():
-    """Settling only reads the store, so a fetch after it lands a day late."""
-    body = inspect.getsource(brief_preflight.main)
-    fetch_at = body.index('daily_bars_node()')
-    settle_at = body.index('compute_decision_metrics()')
-    assert fetch_at < settle_at, (
+def test_bars_are_fetched_before_the_ledger_settles(tmp_path, monkeypatch):
+    """Settling only reads the store, so a fetch after it lands a day late.
+
+    Runtime-order assertion driven by the #916 DAG harness (replaces the old
+    inspect.getsource(main) textual check — same intent, but now it fails if
+    the orchestration ever reorders settle ahead of the bar refresh)."""
+    from test_brief_preflight_dag import run_stubbed_preflight
+
+    run = run_stubbed_preflight(tmp_path, monkeypatch)
+    tl = run.timeline
+    assert tl.end['daily_bars_node'] <= tl.start['_decision_metrics'], (
         'bars are refreshed after the ledger settles; the fetch would only take '
         'effect on the following run.')
+    assert run.exit_code == 0
 
 
 def test_staleness_uses_the_trading_calendar_not_a_weekday_guess():

--- a/tests/test_brief_preflight_dag.py
+++ b/tests/test_brief_preflight_dag.py
@@ -1,0 +1,390 @@
+"""Runtime DAG contracts for the brief_preflight wave orchestrator (#916).
+
+These tests drive the REAL ``main()`` against a throwaway workspace: every
+``clawock`` subprocess is answered by an in-process recorder (no network, no
+provider), fresh GH-Action sidecars keep the warn-only loaders silent, and the
+extracted node functions are wrapped with a timeline recorder so wave barriers,
+the parallelism cap, the NODE_ORDER issue joins and the step_timings ledger
+detail are asserted against exactly the code production runs.
+
+The workspace switch works through ``CLAWOCK_WORKSPACE`` plus a reload of every
+module that freezes a workspace path at import time; monkeypatch restores both
+the env var and the previous module objects afterwards.
+
+Run: python3 -m pytest tests/test_brief_preflight_dag.py -q
+"""
+import importlib
+import json
+import subprocess
+import sys
+import threading
+import time
+from collections import defaultdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Modules that freeze WS-derived paths at import time, dependencies first and
+# brief_preflight last, so its `from X import Y` bindings pick up reloaded
+# objects.
+RELOAD_TARGETS = (
+    'clawock.instruments',
+    'clawock.decision.risk',
+    'clawock.decision.ledger',
+    'clawock.decision.plans',
+    'clawock.decision.theses',
+    'clawock.evidence.research_surface',
+    'clawock.portfolio.integrity',
+    'clawock.market_data.peer_scan',
+    'clawock.harness.brief_preflight',
+)
+
+TODAY = '2026-08-25'
+
+# Two boring legs: no guardrail breach, one non-leveraged US single for the
+# SEC loop, known total_pnl values for the book arithmetic.
+PORTFOLIO = {
+    'portfolios': {
+        'hk_stocks': {
+            'total_pnl': 12345.67,
+            'holdings': [
+                {'ticker': '0700', 'name': 'Tencent', 'shares': 100,
+                 'cost_basis': 300.0, 'current_price': 330.0},
+                {'ticker': '9988', 'name': 'Alibaba', 'shares': 200,
+                 'cost_basis': 80.0, 'current_price': 90.0},
+            ],
+        },
+        'us_stocks': {
+            'total_pnl': 2345.67,
+            'holdings': [
+                {'ticker': 'PLTR', 'name': 'Palantir', 'shares': 100,
+                 'cost_basis': 10.0, 'current_price': 11.0},
+                {'ticker': 'MSFT', 'name': 'Microsoft', 'shares': 50,
+                 'cost_basis': 30.0, 'current_price': 31.0},
+            ],
+        },
+    },
+}
+
+# clawock command -> (returncode, stdout). Anything absent succeeds silently;
+# artifacts on disk are absent, so nodes take their "file not written" branch.
+DEFAULT_PLAN = {
+    'fx': (0, '{"rate": 7.81, "source": "TEST"}'),
+    'filings': (0, '{"key_financials": {"Revenues": {}}}'),
+    'daily-bars': (0, '3 bars added, 0 revised'),
+    'catalysts': (0, '{"summary": {}}'),
+}
+
+SIDE_CARS = ('macro.json', 'sentiment.json', 'influencer_feed.json', 'em_news.json')
+
+
+def _build_workspace(root):
+    """Minimal book + config + freshly-stamped sidecars: zero background issues."""
+    (root / 'config').mkdir(parents=True, exist_ok=True)
+    # Every tracked engine-facing config comes along (the decision packet reads
+    # several), EXCEPT watch-list.json: a populated watch list makes
+    # watch_list.collect fetch live bars.
+    for src in sorted((ROOT / 'config').glob('*.json')):
+        if src.name == 'watch-list.json':
+            continue
+        (root / 'config' / src.name).write_text(src.read_text())
+    # slot_for_job validates every contract profile, including message-template
+    # paths, so the payloads tree must come along with the contract file.
+    payloads = root / 'config' / 'cron-payloads'
+    payloads.mkdir(exist_ok=True)
+    for src in (ROOT / 'config' / 'cron-payloads').iterdir():
+        if src.is_file():
+            (payloads / src.name).write_text(src.read_text())
+    (root / 'assets' / 'data').mkdir(parents=True, exist_ok=True)
+    for name in SIDE_CARS:
+        (root / 'assets' / 'data' / name).write_text(
+            json.dumps({'generated_at': _fresh_stamp()}))
+    (root / 'portfolio.json').write_text(json.dumps(PORTFOLIO))
+    return root
+
+
+def _fresh_stamp():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _SpawnRecorder:
+    """Stands in for subprocess.run and _run_clawock inside preflight."""
+
+    def __init__(self, plan=None, delays=None):
+        self.plan = plan or {}
+        self.delays = delays or {}
+        self.calls = []
+        self.lock = threading.Lock()
+        self.running = defaultdict(int)
+        self.max_parallel_filings = 0
+
+    def subprocess_run(self, argv, **kwargs):
+        command = argv[1] if len(argv) > 1 else argv[0]
+        with self.lock:
+            self.calls.append(('subprocess', command, list(argv)))
+            self.running[command] += 1
+            if command == 'filings':
+                self.max_parallel_filings = max(
+                    self.max_parallel_filings, self.running['filings'])
+        try:
+            time.sleep(self.delays.get(command, 0))
+            rc, out = self.plan.get(command, (0, ''))
+            return subprocess.CompletedProcess(argv, rc, stdout=out, stderr='')
+        finally:
+            with self.lock:
+                self.running[command] -= 1
+
+    def clawock(self, command, args=None, timeout=120):
+        with self.lock:
+            self.calls.append(('clawock', command, [command] + list(args or [])))
+        time.sleep(self.delays.get(command, 0))
+        rc, out = self.plan.get(command, (0, 'ok'))
+        if rc == 0:
+            return out, True
+        return f'{command}-failed-marker', False
+
+
+class _Timeline:
+    """Per-node start/end monotonic stamps + concurrency tracking."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.start = {}
+        self.end = {}
+        self.count = defaultdict(int)
+        self.running = 0
+        self.max_parallel = 0
+
+    def wrap(self, fn, name):
+        def wrapped(*args, **kwargs):
+            with self.lock:
+                self.start[name] = time.monotonic()
+                self.count[name] += 1
+                self.running += 1
+                self.max_parallel = max(self.max_parallel, self.running)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                with self.lock:
+                    self.end[name] = time.monotonic()
+                    self.running -= 1
+        return wrapped
+
+
+def run_stubbed_preflight(tmp_path, monkeypatch, *, plan=None, delays=None):
+    """Drive the real brief_preflight.main() against a stubbed workspace."""
+    ws = _build_workspace(Path(tmp_path))
+
+    # Workspace switch without reload(): importlib.reload would re-execute the
+    # ORIGINAL module object in place, poisoning every other holder of that
+    # reference (a test module's collection-time import included). Instead the
+    # current object is dropped from sys.modules so a FRESH one is created
+    # against CLAWOCK_WORKSPACE, and afterwards the untouched originals are put
+    # back — in sys.modules AND as parent-package attributes, because
+    # `from clawock.harness import brief_preflight` reads the latter, not the
+    # former. Modules first imported inside the window are dropped again.
+    saved_modules = {name: sys.modules.get(name) for name in RELOAD_TARGETS}
+    saved_keys = frozenset(sys.modules)
+    saved_parent_attrs = {}
+    for name in RELOAD_TARGETS:
+        pname, _, pattr = name.rpartition('.')
+        parent = sys.modules.get(pname)
+        if parent is not None:
+            saved_parent_attrs[name] = (parent, pattr,
+                                        vars(parent).get(pattr, _MISSING))
+    try:
+        for name in RELOAD_TARGETS:
+            sys.modules.pop(name, None)
+        return _run_with_reloaded_modules(
+            ws, monkeypatch, plan=plan, delays=delays)
+    finally:
+        created = [k for k in sys.modules if k not in saved_keys
+                   and (k == 'clawock' or k.startswith('clawock.'))]
+        for key in created:
+            del sys.modules[key]
+        for key in created:
+            pname, _, pattr = key.rpartition('.')
+            parent = sys.modules.get(pname)
+            if parent is not None and pattr in vars(parent):
+                delattr(parent, pattr)
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        for name, (parent, pattr, original) in saved_parent_attrs.items():
+            current = vars(parent).get(pattr, _MISSING)
+            if original is _MISSING:
+                if current is not _MISSING:
+                    delattr(parent, pattr)
+            elif current is not original:
+                setattr(parent, pattr, original)
+
+
+_MISSING = object()
+
+
+def _run_with_reloaded_modules(ws, monkeypatch, *, plan, delays):
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(ws))
+    monkeypatch.setenv('TODAY', TODAY)
+    for name in RELOAD_TARGETS:
+        importlib.import_module(name)
+
+    from clawock import sessions as trading_calendar
+    from clawock.automation import workflow_outcomes
+
+    pf = sys.modules['clawock.harness.brief_preflight']
+
+    recorder = _SpawnRecorder(plan=dict(plan or DEFAULT_PLAN), delays=delays or {})
+    monkeypatch.setattr(pf.subprocess, 'run', recorder.subprocess_run)
+    monkeypatch.setattr(pf, '_run_clawock', recorder.clawock)
+    # Both markets open: the holiday gate must not skip the run.
+    monkeypatch.setattr(trading_calendar, 'closed_reason', lambda market, d=None: None)
+    # research_surface's HK results probe would otherwise hit Tencent.
+    monkeypatch.setattr(pf, '_fetch_hk_results_notices', lambda ticker: [])
+
+    timeline = _Timeline()
+    for name in pf.NODE_ORDER:
+        monkeypatch.setattr(pf, name, timeline.wrap(getattr(pf, name), name))
+    monkeypatch.setattr(
+        pf, 'compute_decision_metrics',
+        timeline.wrap(pf.compute_decision_metrics, '_decision_metrics'))
+
+    stage_calls = []
+
+    def _stage_spy(job_name, stage, status, **kwargs):
+        stage_calls.append({'job': job_name, 'stage': stage,
+                            'status': status, 'kwargs': kwargs})
+        return {}
+
+    monkeypatch.setattr(workflow_outcomes, 'record_stage', _stage_spy)
+
+    exit_code = pf.main([])
+    ctx_path = ws / 'memory' / '.tmp' / f'brief-context-{TODAY}.json'
+    context = json.loads(ctx_path.read_text())
+    return SimpleNamespace(exit_code=exit_code, context=context,
+                           issues=context['issues'], stage_calls=stage_calls,
+                           timeline=timeline, recorder=recorder, workspace=ws,
+                           pf=pf)
+
+
+def _final_preflight_stage(run):
+    finals = [s for s in run.stage_calls
+              if s['stage'] == 'preflight' and s['status'] in ('success', 'warning')]
+    assert finals, f'no final preflight stage recorded: {run.stage_calls}'
+    return finals[-1]
+
+
+def test_wave_nodes_execute_exactly_once_and_respect_edges(tmp_path, monkeypatch):
+    run = run_stubbed_preflight(tmp_path, monkeypatch, delays=_stagger_delays())
+    tl, pf = run.timeline, run.pf
+
+    wanted = set(pf.NODE_ORDER) | {'_decision_metrics'}
+    assert set(tl.count) == wanted, 'every node must run exactly once'
+    assert all(v == 1 for v in tl.count.values()), dict(tl.count)
+
+    # quant → t0 (ATR), quant → quant-review/cross-factor (history/artifacts)
+    assert tl.start['t0_node'] >= tl.end['quant_node']
+    assert tl.start['quant_review_node'] >= tl.end['quant_node']
+    assert tl.start['cross_factor_node'] >= tl.end['quant_node']
+    # em-news + catalysts complete before news-evidence builds its graph
+    assert tl.start['news_evidence_node'] >= max(tl.end['em_news_node'],
+                                                 tl.end['catalysts_node'])
+    # evidence page rebuilds only after quant-review + cross-factor finalize
+    assert tl.start['evidence_node'] >= max(tl.end['quant_review_node'],
+                                            tl.end['cross_factor_node'])
+    # t0-review reconciles t0's history jsonl
+    assert tl.start['t0_review_node'] >= tl.end['t0_node']
+    # determinism edge: regime FINISHES before benchmark STARTS (#916 §1.2)
+    assert tl.start['benchmark_node'] >= tl.end['regime_node']
+    # settle reads the canonical bar store, so bars finish first
+    assert tl.start['_decision_metrics'] >= tl.end['daily_bars_node']
+
+    # SEC filings stay strictly serial inside collect_us_fundamentals
+    assert run.recorder.max_parallel_filings == 1
+
+    assert run.exit_code == 0
+    assert run.issues == []
+
+
+def test_max_parallelism_never_exceeds_two(tmp_path, monkeypatch):
+    run = run_stubbed_preflight(tmp_path, monkeypatch, delays=_stagger_delays())
+
+    assert run.timeline.max_parallel <= 2, '_run_wave must cap workers at 2'
+    assert run.timeline.max_parallel >= 2, (
+        'waves never actually ran two nodes concurrently — the schedule '
+        'degenerated to serial')
+
+
+def test_issues_order_is_deterministic_regardless_of_completion_order(tmp_path, monkeypatch):
+    expected = [
+        'US refresh failed: analyze-us-failed-marker',
+        'SEC EDGAR PLTR failed',
+        'SEC EDGAR MSFT failed',
+        'FX fallback used: provider down',
+        'daily bar refresh failed',
+        'catalysts fetch failed',
+        'news evidence graph failed',
+        'benchmark history fetch failed',
+    ]
+    failures = {
+        'analyze-us': (1, ''),
+        'fx': (1, 'provider down'),
+        'filings': (1, 'sec down'),
+        'daily-bars': (1, ''),
+        'catalysts': (1, 'cat down'),
+        'news-evidence': (1, 'graph down'),
+        'benchmark': (1, ''),
+    }
+    # Two opposite delay profiles scramble completion order within each wave;
+    # the context issues must come out in NODE_ORDER both times (#916).
+    fast_first = {'analyze-us': 0.01, 'filings': 0.02, 'fx': 0.30,
+                  'daily-bars': 0.25, 'catalysts': 0.01,
+                  'news-evidence': 0.20, 'benchmark': 0.01}
+    slow_first = {'analyze-us': 0.05, 'filings': 0.01, 'fx': 0.01,
+                  'daily-bars': 0.03, 'catalysts': 0.30,
+                  'news-evidence': 0.25, 'benchmark': 0.20}
+
+    seen = []
+    for delays in (fast_first, slow_first):
+        run = run_stubbed_preflight(tmp_path, monkeypatch,
+                                    plan=failures, delays=delays)
+        assert run.exit_code == 1
+        assert run.issues == expected, run.issues
+        assert _final_preflight_stage(run)['status'] == 'warning'
+        seen.append(run.context['issues'])
+
+    assert seen[0] == seen[1]
+
+
+def test_step_timings_recorded_in_preflight_stage(tmp_path, monkeypatch):
+    run = run_stubbed_preflight(tmp_path, monkeypatch)
+    final = _final_preflight_stage(run)
+
+    timings = final['kwargs']['step_timings']
+    assert set(timings) == set(run.pf.NODE_ORDER), (
+        'step_timings must carry exactly one entry per node')
+    for name, entry in timings.items():
+        assert set(entry) == {'ok', 'wall_s'}, (name, entry)
+        assert entry['ok'] is True, name
+        assert isinstance(entry['wall_s'], float) and entry['wall_s'] >= 0.0
+    # earlier pending/skipped stages carry no step_timings detail
+    pendings = [s for s in run.stage_calls if s['status'] == 'pending']
+    assert pendings and all('step_timings' not in s['kwargs'] for s in pendings)
+
+
+def _stagger_delays():
+    """Long enough to force overlap inside waves; short enough to stay fast."""
+    return {
+        'analyze-us': 0.02, 'analyze-hk': 0.02, 'filings': 0.03,
+        'fx': 0.18, 'peer-scan': 0.05, 'daily-bars': 0.15,
+        'portfolio-risk': 0.20, 'regime': 0.12, 'quant': 0.25,
+        'em-news': 0.08, 'catalysts': 0.06, 'peer-residual': 0.10,
+        'quant-review': 0.10, 'cross-factor': 0.12, 't0': 0.08,
+        'news-evidence': 0.10, 'benchmark': 0.05,
+        't0-review': 0.06, 'evidence': 0.05,
+    }


### PR DESCRIPTION
Closes #916 (item 1 — the last outstanding piece; items 2/3 landed in #929/#931).

Implemented by agent-H from agent-F's blueprint (both opencode), adopted and committed by the review session after H hit its time budget pre-commit. My verbatim-check on the extraction commit: 11 node bodies, every nontrivial line character-identical to the pre-extraction source.

## Structure
Serial prefix (analyze-us → analyze-hk same-file RMW, snapshot/load, filings loop strictly serial) → WAVE1 {fx, peer-scan, daily-bars, risk, regime, quant, em-news, catalysts, peer-residual} → barrier → WAVE2 {quant-review, cross-factor, t0, news-evidence, benchmark} → barrier → WAVE3 {t0-review, evidence}.

Every true edge carried with evidence in-code; the regime→benchmark ordering is a byte-determinism constraint (regime reads yesterday's benchmark.json before benchmark rewrites it), not a data dependency.

## Determinism
issues[] appended in NODE_ORDER after each wave join → identical failure set ⇒ byte-identical context bundle and generation_id regardless of thread completion order.

## Observability
step_timings {'node': {ok, wall_s}} added to the preflight stage record via workflow_outcomes additive detail — this is the data that lets timeout caps be calibrated from reality instead of guesses.

## Tests
New tests/test_brief_preflight_dag.py: wave-edge holds, max-parallelism ≤2, issues determinism under scrambled completion, step_timings recorded. test_bars_freshness moved from source-text assertion to runtime ordering. Guard ring green: 181 passed + 1 xfailed locally.