### PR TITLE
feat: per-leg LLM chain stats + brief-fallback chain summary line (#917 slice)

### DIFF
--- a/src/clawock/automation/brief_fallback.py
+++ b/src/clawock/automation/brief_fallback.py
@@ -289,8 +289,19 @@ def main():
     # recovery path could not physically emit a complete brief.
     # timeout=900: the full-context brief prefills ~116KB and thinks before emitting
     # ~20K tokens; the 180s default timed out 3x on 2026-07-16 and killed the run.
+    stats = {}
     out = chat(system=system, user=user, max_tokens=BRIEF_MAX_TOKENS,
-               temperature=0.6, timeout=900)
+               temperature=0.6, timeout=900, stats_out=stats)
+    # C-F3a: one grep-able line saying which leg won and what each cost —
+    # before this, the job log had per-attempt token lines but nothing that
+    # answered "did the fallback write today's brief, and how slow was it?".
+    legs = stats.get('legs') or []
+    if legs:
+        print('LLM chain: ' + ' | '.join(
+            f"{l['provider']} {'OK' if l['ok'] else 'FAIL'} "
+            f"attempts={l['attempts']} {l['wall_s']}s"
+            + (f" ({l.get('error', '')[:60]})" if not l['ok'] else '')
+            for l in legs))
 
     # Split markdown + plan.json (see split_brief_and_plan for the tolerance rules).
     md_part, json_part = split_brief_and_plan(out)

--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -206,7 +206,7 @@ class _HTTPErr(Exception):
     """Non-200/429 answer; str() is exactly the historical last_err text."""
 
 
-def _run_with_retries(label, timeout, deadline, once):
+def _run_with_retries(label, timeout, deadline, once, attempts_sink=None):
     """Shared retry skeleton for both provider legs (C-F5).
 
     once(attempt, per_attempt) returns the assistant content string on a 200,
@@ -215,15 +215,23 @@ def _run_with_retries(label, timeout, deadline, once):
     Budget exhaustion breaks the loop with the same message both legs have
     always produced. Kept as one copy so the two wire protocols cannot drift
     apart in retry semantics again.
+
+    attempts_sink: optional list; receives the number of attempts actually
+    run when the leg settles either way (C-F3a leg stats).
     """
     last_err = None
+    attempts_run = 0
     for attempt in range(1, MAX_RETRIES + 1):
         per_attempt = _attempt_timeout(timeout, deadline, label)
         if per_attempt is None:
             last_err = last_err or 'budget exhausted before any attempt completed'
             break
+        attempts_run = attempt
         try:
-            return once(attempt, per_attempt)
+            content = once(attempt, per_attempt)
+            if attempts_sink is not None:
+                attempts_sink.append(attempt)
+            return content
         except requests.Timeout:
             last_err = f'timeout after {per_attempt}s'
             print(f'  {label}: {last_err} (attempt {attempt})', file=sys.stderr)
@@ -238,6 +246,8 @@ def _run_with_retries(label, timeout, deadline, once):
             last_err = f'{type(e).__name__}: {e}'
             print(f'  {label}: {last_err}', file=sys.stderr)
         _backoff(2 * attempt, deadline, label)
+    if attempts_sink is not None:
+        attempts_sink.append(attempts_run)
     raise RuntimeError(f'{label} failed after {MAX_RETRIES} attempts: {last_err}')
 
 
@@ -352,7 +362,8 @@ def chat(system: str = '', user: str = '', messages: list = None,
          fallback_base_url: str = OPENCODE_BASE,
          fallback_api_key: str = None, thinking_disabled: bool = False,
          json_response: bool = False, fallback: bool = True,
-         timeout: int = None, deadline_seconds: float = None) -> str:
+         timeout: int = None, deadline_seconds: float = None,
+         stats_out: dict = None) -> str:
     """Call MiniMax M3; on total failure fall back to opencode-go's DeepSeek V4
     Flash. The two are NOT the same wire protocol (Anthropic Messages vs
     OpenAI-compatible) — see module docstring. Returns assistant content
@@ -403,13 +414,34 @@ def chat(system: str = '', user: str = '', messages: list = None,
                         else started + float(deadline_seconds) * PRIMARY_BUDGET_SHARE)
 
     # ── Primary: MiniMax M3 (Anthropic Messages) ──
+    # C-F3a: per-leg wall time + attempts land in stats_out when the caller
+    # wants them — the job log otherwise shows only per-attempt token lines
+    # and nothing about which leg won or what the chain actually cost.
+    def _leg(provider, fn):
+        if stats_out is None:
+            return fn()          # zero-overhead path: no kwarg reaches fakes
+        t0 = time.monotonic()
+        attempts = []
+        try:
+            out = fn(attempts_sink=attempts)
+            stats_out.setdefault('legs', []).append(
+                {'provider': provider, 'ok': True, 'attempts': len(attempts),
+                 'wall_s': round(time.monotonic() - t0, 2)})
+            return out
+        except Exception as e:
+            stats_out.setdefault('legs', []).append(
+                {'provider': provider, 'ok': False, 'attempts': len(attempts),
+                 'wall_s': round(time.monotonic() - t0, 2), 'error': str(e)[:160]})
+            raise
+
     mm_key = os.environ.get('MINIMAX_API_KEY')
     if mm_key:
         try:
-            return _call_provider('minimax', MINIMAX_BASE, mm_key, MINIMAX_MODEL,
-                                  messages, min(max_tokens, MINIMAX_MAX_TOKENS),
-                                  temperature, json_response, thinking, timeout,
-                                  deadline=primary_deadline)
+            return _leg('minimax', lambda **kw: _call_provider(
+                'minimax', MINIMAX_BASE, mm_key, MINIMAX_MODEL,
+                messages, min(max_tokens, MINIMAX_MAX_TOKENS),
+                temperature, json_response, thinking, timeout,
+                deadline=primary_deadline, **kw))
         except Exception as e:
             errors.append(f'minimax[{e}]')
             print('  ⚠️ minimax exhausted — falling back to OpenCode Zen DeepSeek V4 Flash',
@@ -425,11 +457,11 @@ def chat(system: str = '', user: str = '', messages: list = None,
                     or os.environ.get('OPENCODE_API_KEY'))
     if fallback and opencode_key:
         try:
-            return _call_provider_openai_compatible(
+            return _leg('opencode', lambda **kw: _call_provider_openai_compatible(
                 'opencode', fallback_base_url, opencode_key, fallback_model,
                 messages, min(max_tokens, OPENCODE_MAX_TOKENS),
                 temperature, json_response, timeout,
-                deadline=chain_deadline)
+                deadline=chain_deadline, **kw))
         except Exception as e:
             errors.append(f'opencode[{e}]')
     elif fallback and not opencode_key:

--- a/tests/test_llm_chain_budget.py
+++ b/tests/test_llm_chain_budget.py
@@ -197,3 +197,43 @@ def test_budget_exhausted_before_any_attempt_names_the_cause(monkeypatch):
             max_tokens=8, timeout=30, temperature=0.5,
             json_response=False, thinking=None)
     assert calls == []   # no request was ever fired
+
+
+def test_stats_out_records_leg_outcomes_and_attempts(keys, monkeypatch):
+    """C-F3a: the job log used to show only per-attempt token lines — nothing
+    about which leg won or what each cost. stats_out now carries per-leg
+    {provider, ok, attempts, wall_s} for whoever prints or ships it."""
+    seen = {"primary_attempts": 0}
+
+    def fake_primary(label, base_url, api_key, model, messages, max_tokens,
+                     temperature, json_response, thinking, timeout=None,
+                     deadline=None, attempts_sink=None):
+        for attempt in range(1, llm.MAX_RETRIES + 1):
+            per = llm._attempt_timeout(timeout, deadline, label)
+            if per is None:
+                break
+            seen["primary_attempts"] += 1
+            time.sleep(0.01)
+            if attempts_sink is not None:
+                attempts_sink.append(attempt)   # model the real leg's reporting
+        raise RuntimeError("primary exhausted")
+
+    def fake_fallback(label, base_url, api_key, model, messages, max_tokens,
+                      temperature, json_response, timeout=None, deadline=None,
+                      attempts_sink=None):
+        if attempts_sink is not None:
+            attempts_sink.append(1)
+        return "fallback answered"
+
+    monkeypatch.setattr(llm, "_call_provider", fake_primary)
+    monkeypatch.setattr(llm, "_call_provider_openai_compatible", fake_fallback)
+
+    stats = {}
+    out = llm.chat(user="hi", timeout=30, deadline_seconds=20.0,
+                   stats_out=stats)
+
+    assert out == "fallback answered"
+    legs = {leg["provider"]: leg for leg in stats["legs"]}
+    assert legs["minimax"]["ok"] is False and legs["minimax"]["attempts"] == 3
+    assert legs["opencode"]["ok"] is True and legs["opencode"]["attempts"] == 1
+    assert legs["minimax"]["wall_s"] >= 0 and "error" in legs["minimax"]


### PR DESCRIPTION
Part of #917 (C-F3a).

## What
- `chat(stats_out=dict)`: one entry per leg — `{provider, ok, attempts, wall_s, error?}` — collected through the retry skeleton's attempts sink. Stats-off path passes zero new kwargs (fakes and callers untouched).
- `brief_fallback` prints a grep-able summary into the job log: `LLM chain: minimax FAIL attempts=3 415s | opencode OK attempts=1 88s`.

## Why
The job log had per-attempt token lines but nothing answering "which leg wrote today's brief and what did the chain cost?" — the exact blind spot that let slow-primary-quietly-falls-back-to-weaker-model persist unnoticed. This is also the data needed to recalibrate the 660s/0.6 budget split from real distributions.

## Deliberately open
Shipping these stats into the outcome ledger needs a GHA→ledger transport decision; noted as remaining scope on #917.