### PR TITLE
fix: 杠杆刻度盘健壮性两处(#942 mdd 峰日未绑定, #943 缺数 TypeError 静默滞留) [audit:business]

### DIFF
--- a/src/clawock/decision/regime.py
+++ b/src/clawock/decision/regime.py
@@ -315,6 +315,18 @@ def main(argv=None):
     close = closes[-1]
     trend_on, vol_ok, tier, mult, label = classify(close, ma, vol)
     dist = round((close / ma - 1) * 100, 1) if ma else None
+    missing_inputs = [name for name, value in (('ma', ma), ('vol', vol))
+                      if value is None]
+    if missing_inputs:
+        rationale = (
+            f'HSTECH 数据不完整（bars={len(closes)}，'
+            f'{"、".join(missing_inputs)}不可用）→ 保守档处理：'
+            f'HK 杠杆ETF上限 ×{mult:g}（{tier}）')
+    else:
+        rationale = (f'HSTECH {close:.0f} {"高于" if trend_on else "低于"} {MA_WINDOW}日线 '
+                     f'{ma:.0f} ({dist:+.1f}%)；20日波动 {vol*100:.0f}% '
+                     f'{"<" if vol_ok else "≥"} {int(VOL_CAP*100)}% 上限。'
+                     f'→ HK 杠杆ETF上限 ×{mult:g}（{tier}）')
 
     out = {
         'generated_at': datetime.now(timezone.utc).isoformat(),
@@ -334,11 +346,10 @@ def main(argv=None):
         'tier': tier,
         'lev_cap_mult': mult,
         'label': label,
-        'rationale': (f'HSTECH {close:.0f} {"高于" if trend_on else "低于"} {MA_WINDOW}日线 '
-                      f'{ma:.0f} ({dist:+.1f}%)；20日波动 {vol*100:.0f}% '
-                      f'{"<" if vol_ok else "≥"} {int(VOL_CAP*100)}% 上限。'
-                      f'→ HK 杠杆ETF上限 ×{mult:g}（{tier}）'),
+        'rationale': rationale,
     }
+    if missing_inputs:
+        out['missing_inputs'] = missing_inputs
     # Top-level fields above describe the HK (HSTECH) dial; mirror under 'hk' and add 'us'.
     out['hk'] = {'tier': tier, 'lev_cap_mult': mult, 'label': label,
                  'close': out['close'], 'ma': out['ma'], 'dist_ma_pct': dist,

--- a/src/clawock/evaluation/hstech_regime.py
+++ b/src/clawock/evaluation/hstech_regime.py
@@ -73,6 +73,7 @@ def max_drawdown(nav, dates=None):
     peak_i = 0
     mdd = 0.0
     trough_i = 0
+    mdd_peak_i = 0
     for i, v in enumerate(nav):
         if v > peak:
             peak = v

--- a/tests/test_hstech_regime_mdd.py
+++ b/tests/test_hstech_regime_mdd.py
@@ -1,0 +1,36 @@
+"""max_drawdown must stay total on every NAV shape — it is the evidence
+replay primitive behind the leverage dial's run cards (#942).
+
+A no-drawdown path used to raise UnboundLocalError (mdd_peak_i was only bound
+inside `if dd < mdd`), so any monotonic segment crashed the evaluation CLI
+mid-table instead of reporting a 0.0 drawdown.
+"""
+from clawock.evaluation.hstech_regime import max_drawdown
+
+
+def test_no_drawdown_returns_zero_with_window_bounds():
+    mdd, peak_day, trough_day = max_drawdown(
+        [1.0, 1.2, 1.5, 1.6], ["d1", "d2", "d3", "d4"])
+    assert mdd == 0.0
+
+
+def test_flat_series_is_zero_drawdown():
+    assert max_drawdown([2.0, 2.0, 2.0]) == 0.0
+
+
+def test_drawdown_reports_peak_and_trough_dates():
+    nav = [1.0, 1.5, 0.75, 1.0]
+    mdd, peak_day, trough_day = max_drawdown(
+        nav, ["a", "b", "c", "d"])
+    assert mdd == (0.75 - 1.5) / 1.5
+    assert peak_day == "b"
+    assert trough_day == "c"
+
+
+def test_later_new_high_resets_the_peak_reference():
+    nav = [1.0, 0.9, 2.0, 1.4]
+    mdd, peak_day, trough_day = max_drawdown(
+        nav, ["a", "b", "c", "d"])
+    assert mdd == (1.4 - 2.0) / 2.0
+    assert peak_day == "c"
+    assert trough_day == "d"

--- a/tests/test_regime_incomplete_fetch.py
+++ b/tests/test_regime_incomplete_fetch.py
@@ -1,0 +1,61 @@
+"""`clawock regime` must survive an incomplete HSTECH fetch (#943).
+
+A short series leaves `compute()` with ma and/or vol as None; the rationale
+f-string used to format them unconditionally, so main() died with TypeError,
+the preflight subprocess swallowed it, and the stale lev_regime.json kept
+feeding the guardrail multiplier with no marker. The contract here: the dial
+still publishes a conservative tier/multiplier plus a machine-readable
+missing_inputs list, offline.
+"""
+import json
+
+import pytest
+
+from clawock.decision import regime
+
+
+@pytest.fixture
+def offline_dial(monkeypatch):
+    """Pin every network/workspace seam so main() runs on synthetic bars."""
+    monkeypatch.setattr(regime, "compute_us", lambda: {
+        "names": [], "tier": "green", "label": "test",
+        "cut_count": 0, "watch_count": 0})
+    monkeypatch.setattr(regime, "load_spy_series", lambda: ([], []))
+
+
+def _run(monkeypatch, bars):
+    monkeypatch.setattr(
+        regime, "fetch_hstech",
+        lambda: [(f"2026-01-{i + 1:02d}", float(bars[i])) for i in range(len(bars))])
+    buf = {}
+    import io
+    import contextlib
+    with contextlib.redirect_stdout(io.StringIO()) as out:
+        regime.main(["--dry-run"])
+    return json.loads(out.getvalue())
+
+
+def test_short_fetch_missing_ma_and_vol_stays_conservative(offline_dial, monkeypatch):
+    payload = _run(monkeypatch, [100.0] * 15)
+    assert payload["missing_inputs"] == ["ma", "vol"]
+    assert payload["ma"] is None and payload["vol_annualized"] is None
+    assert payload["tier"] in ("amber", "red")
+    assert payload["lev_cap_mult"] == pytest.approx((0.5, 0.0)[payload["tier"] == "red"])
+    assert "不可用" in payload["rationale"]
+    assert "×" in payload["rationale"]
+
+
+def test_full_history_path_is_unchanged(offline_dial, monkeypatch):
+    closes = [100.0 + i for i in range(regime.MA_WINDOW + 25)]
+    payload = _run(monkeypatch, closes)
+    assert "missing_inputs" not in payload
+    assert payload["ma"] is not None and payload["vol_annualized"] is not None
+    assert payload["trend_on"] is True
+    assert payload["lev_cap_mult"] == 1.0
+
+
+def test_mid_history_has_vol_but_no_ma(offline_dial, monkeypatch):
+    closes = [100.0 + (i % 7) * 0.2 for i in range(regime.MA_WINDOW - 10)]
+    payload = _run(monkeypatch, closes)
+    assert payload["missing_inputs"] == ["ma"]
+    assert payload["vol_annualized"] is not None


### PR DESCRIPTION
## 审计范围与结论

business 切片（signals/gates/candidate、settle、portfolio/fx/risk 数学、股数账本、quant factor 层 + 钉住它们的测试）对抗性审查。核心账本/结算/风控数学（`decision/ledger.py` settle 链、`portfolio/math.py` 派生原语、`integrity.py` 全部闸、`guardrail.py` trim 解 algebra、FX 分腿口径、Wilson CI / n≥20 / T+1 口径、load_snapshots self-heal 方向）逐块核过：**未发现真错**，历史判据全部仍然成立。

本 PR 修两处真缺陷（均在杠杆刻度盘证据/计算链上），对应 issue #942 #943：

### 1. hstech_regime.max_drawdown UnboundLocalError (#942)
- `src/clawock/evaluation/hstech_regime.py:71` — `mdd_peak_i` 只在 `if dd < mdd` 内赋值；无回撤 NAV 路径三元解包即崩。初始化修复。

### 2. regime.main 对 ma/vol=None 直接 TypeError (#943)
- `src/clawock/decision/regime.py` — HSTECH 短序列时 rationale f-string 崩溃 → preflight subprocess 吞非零退出 → `lev_regime.json` 无标记滞留旧值继续喂 guardrail 硬闸乘子。改为保守档 + 机读 `missing_inputs` 字段；完整数据路径输出不变。

## 测试

- 新增 `tests/test_hstech_regime_mdd.py`（4 条，行为断言：无回撤/平坦/峰谷日期/新高重置参考峰）
- 新增 `tests/test_regime_incomplete_fetch.py`（3 条，离线 monkeypatch 三个网络/workspace seam，断言缺数时 tier/mult 保守且带 missing_inputs，全史路径逐字段不变）
- 本地：7 passed + 相邻 `test_validate_regime_dial.py` 23 passed。未跑全量套件（按流程由 CI 把关）。

Closes #942
Closes #943
