### PR TITLE
docs: correct quant-review unlock-rule comment (#934 follow-up)

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -1102,8 +1102,9 @@ def quant_node():
 
 
 def quant_review_node():
-    # [10b3] 因子 edge 自检 — 历史留痕 vs forward return 对账（自迭代：因子话语权由
-    # hit_rate 决定，样本<20 不解锁）。纯本地文件运算。
+    # [10b3] 因子 edge 自检 — 历史留痕 vs forward return 对账（自迭代：MIN_N=20
+    # 样本闸 + 聚类 CI 越线才解锁，#934 与 t0_setup_review 同纪律；反向只展示
+    # 不入决策）。纯本地文件运算。
     issues = []
     quant_review = {}
     try:


### PR DESCRIPTION
One-comment fix deferred from #935 to avoid conflicting with wave-3b's node extraction (now merged).

brief_preflight's quant_review_node claimed 「因子话语权由 hit_rate 决定，样本<20 不解锁」 — a rule that was NOT in signal_review's code until #935 added it. The comment now states the actual contract: MIN_N=20 sample gate + cluster-CI threshold, reverse readings display-only, same discipline as t0_setup_review.