### PR TITLE
fix: render.js 四张卡 sidecar/外部自由文本转义后入 innerHTML(#948) [audit:dashboard]

### DIFF
--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1144,9 +1144,9 @@
         <div class="anomaly ${sev}">
           <span class="icon">${icon}</span>
           <div class="body">
-            <span class="ticker">${a.ticker || DASH}</span>
-            <span class="muted"> · ${a.type || ""}</span>
-            <div class="detail">${a.detail || ""}</div>
+            <span class="ticker">${escapeHtml(a.ticker || DASH)}</span>
+            <span class="muted"> · ${escapeHtml(a.type || "")}</span>
+            <div class="detail">${escapeHtml(a.detail || "")}</div>
           </div>
         </div>
       `;
@@ -1259,9 +1259,9 @@
                   (x.type || 'MACRO');
       const detail = x.detail || x.title || x.time || '—';
       return `<div class="catalyst-row ${x._type}">
-        <span class="date">${x.date || '—'}</span>
-        <span class="ticker">${tag}</span>
-        <span class="detail">${detail}</span>
+        <span class="date">${escapeHtml(x.date || '—')}</span>
+        <span class="ticker">${escapeHtml(tag)}</span>
+        <span class="detail">${escapeHtml(detail)}</span>
       </div>`;
     }).join('');
 
@@ -1503,13 +1503,16 @@
     if (!withSignal.length) { wrap.innerHTML = ''; return; }
     const regionTag = (r) => r === 'us_stocks' ? 'US' : (r === 'hk_stocks' ? 'HK' : '');
     wrap.innerHTML = withSignal.map(t => {
+      // 标题是 Google News / Reddit 的第三方文本：完整转义，不做 `<`-only 的
+      // 半吊子处理 —— 后者只防标签注入，任何把标题挪进属性的后续改动都会
+      // 把它变成洞。与 influencer feed 的 escapeHtml 同一约定。
       const newsLis = t.news.slice(0, 3).map(n =>
-        `<li>${(n.title || '').replace(/</g, '&lt;')}</li>`).join('');
+        `<li>${escapeHtml(n.title || '')}</li>`).join('');
       const redditLis = t.reddit_posts.slice(0, 3).map(p =>
-        `<li>${(p.title || '').replace(/</g, '&lt;')} <span style="color:var(--text-dim);font-size:var(--fs-micro);">· ${p.score || 0}↑ ${p.num_comments || 0}💬</span></li>`).join('');
+        `<li>${escapeHtml(p.title || '')} <span style="color:var(--text-dim);font-size:var(--fs-micro);">· ${p.score || 0}↑ ${p.num_comments || 0}💬</span></li>`).join('');
       return `<details class="sd-row">
         <summary>
-          <span class="sd-tk">${t.ticker}</span>
+          <span class="sd-tk">${escapeHtml(t.ticker)}</span>
           <span class="sd-reg">${regionTag(t.region)}</span>
           <span class="sd-counts"><strong>${t.reddit}</strong>R · <strong>${t.news.length}</strong>N</span>
         </summary>
@@ -1551,7 +1554,7 @@
     wrap.innerHTML =
       `<div class="rb-hdr">Risk keywords (${hits.length})</div>` +
       hits.map(h =>
-        `<div class="rb-row"><span class="rb-tk">${h.ticker}</span>` +
+        `<div class="rb-row"><span class="rb-tk">${escapeHtml(h.ticker)}</span>` +
         h.kws.map(k => `<span class="rb-kw">${k}</span>`).join('') +
         `</div>`).join('');
   }

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,19 +1,56 @@
+"""Free text from sidecars / external sources may only reach innerHTML escaped.
+
+The page's own convention: LLM narrative goes through `escLLM`, every other
+sidecar string through `escapeHtml`. Four market-tab cards predate that
+convention and interpolated brief-context / RSS-sourced strings raw (#948) —
+`innerHTML` executes event-attribute payloads (`<img onerror=…>`) even though it
+never executes `<script>`, so the gap is a real injection class, not style.
+
+Sections are sliced out of the source the same way
+test_dashboard_bundle_parity.py finds top-level functions: two-space indented
+declarations, closed by a lone `  }`. Source assertions rather than a browser
+run because the invariant is about what the template interpolates; the runtime
+cost of booting the whole spec for four greps is not justified.
+"""
+import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+RENDERER = ROOT / "site" / "assets" / "js" / "dashboard.render.js"
+
+_DECL = re.compile(r"^  function ([A-Za-z_$][\w$]*)\s*\(")
 
 
-def test_sort_headers_never_reinterpret_dom_text_as_html():
-    renderer = (ROOT / "site" / "assets" / "js" / "dashboard.render.js").read_text()
-    # 持仓表合并后（#875），排序接线在 renderBook 里，后面紧跟的不再是
-    # renderShadowPortfolioCard，所以用成对的标记注释精确圈出这段。
-    sort_headers = renderer.split("// Wire sort headers", 1)[1].split(
-        "// end sort headers", 1
-    )[0]
+def _function_body(name: str) -> str:
+    lines = RENDERER.read_text(encoding="utf-8").split("\n")
+    starts = [i for i, line in enumerate(lines) if _DECL.match(line)]
+    names = {i: _DECL.match(lines[i]).group(1) for i in starts}
+    own = next((i for i in starts if names[i] == name), None)
+    assert own is not None, f"{name} not found in {RENDERER.name}"
+    end = own + 1
+    while end < len(lines) and lines[end] != "  }":
+        end += 1
+    return "\n".join(lines[own:end + 1])
 
-    assert ".innerHTML" not in sort_headers
-    assert "x.replaceChildren()" in sort_headers
-    assert "x.append(label)" in sort_headers
-    assert 'document.createElement("span")' in sort_headers
-    assert "arrow.textContent" in sort_headers
+
+def test_sidecar_free_text_never_reaches_innerhtml_raw():
+    anomalies = _function_body("renderAnomalies")
+    catalysts = _function_body("renderCatalysts")
+    sentiment = _function_body("renderSentimentDrill")
+    risk_banner = _function_body("renderRiskBanner")
+
+    # anomalies: ticker/type/detail come from the brief-context (agent-written).
+    assert "escapeHtml(a.ticker || DASH)" in anomalies
+    for field in ("a.ticker", "a.type", "a.detail"):
+        assert "${%s}" % field not in anomalies, (
+            f"{field} reaches innerHTML unescaped")
+    # catalysts: earnings ticker + LLM-assembled detail.
+    assert "escapeHtml(tag)" in catalysts and "escapeHtml(detail)" in catalysts
+    # sentiment drill: third-party headline text was `<`-only before #948.
+    assert ".replace(/</g, '&lt;')" not in sentiment
+    assert "escapeHtml(n.title || '')" in sentiment
+    assert "escapeHtml(p.title || '')" in sentiment
+    assert "escapeHtml(t.ticker)" in sentiment
+    # risk keyword banner reads the same sidecar.
+    assert "escapeHtml(h.ticker)" in risk_banner


### PR DESCRIPTION
## 背景

audit:dashboard 切片对抗性审查的一条 finding（#948）。dashboard.render.js 对「sidecar / LLM / 外部源
自由文本进 innerHTML」已有明确约定 —— LLM 叙事走 `escLLM`（:2785），其余走 `escapeHtml`（peer
divergence :1356、influencer feed :1305-1320、hero 要点条对同一份 anomalies 数据的转义 :172）—— 但
四张 market 侧卡片漏网，把字符串原样插进模板：

- renderAnomalies：`a.ticker` / `a.type` / `a.detail` 原样。ticker 源自 brief-context 的
  concentration weights 与 peer_scan 键（src/clawock/publish/dashboard.py:1681,1730），是 agent 写的数据。
- renderCatalysts：earnings 的 `x.ticker` 与 LLM 组装的 `detail` 原样。
- sentiment digest：`${t.ticker}` 原样；Google News/Reddit 第三方标题只做 `<`-only 转义。
- risk banner：`${h.ticker}` 原样。

innerHTML 不执行 `<script>` 但执行事件属性（`<img onerror=…>`），这是公开 payload 上真实的注入类缺口；
validate_sentiment 只断言 ticker 非空且覆盖持仓，不约束字符集，渲染端是最后一道闸。

## 改动

1. 四处共 9 个插值点改为经 `escapeHtml` 后入 innerHTML；标题从 `<`-only 升级为完整转义。
   不动结构、不动样式；四张卡都只在 render.js（IIFE 内），无 hero/render bundle parity 影响
   （test_dashboard_bundle_parity.py 全绿）。
2. tests/test_dashboard_security.py 新增分节钉子（沿用该文件 sort-header 的既有切割法）：
   - 四张卡的自由文本字段不得再以 `${field}` 形态直插 innerHTML，必须经 escapeHtml；
   - sentiment 标题不得退回 `<`-only 转义。

## 验证

- 红→绿：stash 掉修复后用 playwright 探针注入 `<img src=x onerror=…>`，旧码在 anomalies/catalysts
  卡解析出真实 `<img>` 元素；恢复修复后同一探针 `window.__XSS === 0`、零 img 元素、载荷以文本呈现。
- `python3 -m pytest tests/test_dashboard_security.py tests/test_dashboard_bundle_parity.py -q` → 4 passed
- `node tests/dashboard_tab_runtime.spec.js` → exit 0

Closes #948
