### PR TITLE
fix: wave-3 adversarial catches — stats_out P0 + WAVE2 factor-read race

### DIFF
--- a/src/clawock/automation/llm.py
+++ b/src/clawock/automation/llm.py
@@ -253,7 +253,7 @@ def _run_with_retries(label, timeout, deadline, once, attempts_sink=None):
 
 def _call_provider(label, base_url, api_key, model, messages, max_tokens,
                    temperature, json_response, thinking, timeout=None,
-                   deadline=None):
+                   deadline=None, attempts_sink=None):
     """One provider over Anthropic Messages, with retries. Returns content str
     or raises RuntimeError."""
     timeout = timeout or TIMEOUT
@@ -309,12 +309,14 @@ def _call_provider(label, base_url, api_key, model, messages, max_tokens,
         cleaned = _clean(text)
         return _extract_json(cleaned) if json_response else cleaned
 
-    return _run_with_retries(label, timeout, deadline, once)
+    return _run_with_retries(label, timeout, deadline, once,
+                             attempts_sink=attempts_sink)
 
 
 def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
                                      max_tokens, temperature, json_response,
-                                     timeout=None, deadline=None):
+                                     timeout=None, deadline=None,
+                                     attempts_sink=None):
     """One provider over the OpenAI-compatible /chat/completions shape, with
     retries. Returns content str or raises RuntimeError. Unlike Anthropic
     Messages: system stays inline as a message role (no lift-out needed), and
@@ -353,7 +355,8 @@ def _call_provider_openai_compatible(label, base_url, api_key, model, messages,
         cleaned = _clean(text)
         return _extract_json(cleaned) if json_response else cleaned
 
-    return _run_with_retries(label, timeout, deadline, once)
+    return _run_with_retries(label, timeout, deadline, once,
+                             attempts_sink=attempts_sink)
 
 
 def chat(system: str = '', user: str = '', messages: list = None,

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -1406,12 +1406,14 @@ NODE_ORDER = [
     # order — so an identical failure set produces a byte-identical
     # context['issues'] (and therefore generation_id) regardless of thread
     # completion order.
+    # Order follows actual wave-append sequence (#941 + J-P1-1): news-evidence
+    # joined WAVE3 so it never races cross-factor's rewrite of its input file.
     'analyze_us', 'analyze_hk', 'fx_rate', '_node_filings',
     'peer_scan_node', 'daily_bars_node', 'portfolio_risk_node',
     'regime_node', 'quant_node', 'quant_review_node',
     'cross_factor_node', 'evidence_node', 'peer_residual_node',
     't0_node', 't0_review_node', 'em_news_node',
-    'catalysts_node', 'news_evidence_node', 'benchmark_node',
+    'catalysts_node', 'benchmark_node', 'news_evidence_node',
 ]
 
 
@@ -1622,23 +1624,28 @@ def main(argv=None):
         'fx_used':         rate,
     }
 
+    # news-evidence sits in WAVE3, not WAVE2: it reads
+    # cross_sectional_factor.json for its confirmation gate (J-P1-1), which
+    # cross-factor rewrites atomically in WAVE2 — same-wave scheduling would
+    # silently feed yesterday's factors when news-evidence reached its read
+    # first. em-news/catalysts inputs were satisfied at the WAVE1 barrier.
     w2 = _join(_run_wave({
         'quant_review_node': quant_review_node,
         'cross_factor_node': lambda: cross_factor_node(portfolio),
         't0_node': t0_node,
-        'news_evidence_node': news_evidence_node,
         'benchmark_node': benchmark_node,
     }))
     quant_review = w2['quant_review_node']
     cross_sectional_factor_ctx = w2['cross_factor_node']
     t0_setups = w2['t0_node']
-    news_evidence_ctx = w2['news_evidence_node']
 
     w3 = _join(_run_wave({
         't0_review_node': t0_review_node,
         'evidence_node': evidence_node,
+        'news_evidence_node': news_evidence_node,
     }))
     t0_review = w3['t0_review_node']
+    news_evidence_ctx = w3['news_evidence_node']
 
     # [10] V2 episode metrics — triggered-only, strategy-aware, cluster-bootstrap.
     # Settle runs only AFTER daily-bars finished at the WAVE1 barrier: settling

--- a/tests/test_brief_preflight_dag.py
+++ b/tests/test_brief_preflight_dag.py
@@ -291,7 +291,10 @@ def test_wave_nodes_execute_exactly_once_and_respect_edges(tmp_path, monkeypatch
     assert tl.start['t0_node'] >= tl.end['quant_node']
     assert tl.start['quant_review_node'] >= tl.end['quant_node']
     assert tl.start['cross_factor_node'] >= tl.end['quant_node']
-    # em-news + catalysts complete before news-evidence builds its graph
+    # em-news + catalysts complete before news-evidence builds its graph,
+    # and cross-factor's rewrite of cross_sectional_factor.json lands before
+    # news-evidence reads it for the confirmation gate (J-P1-1)
+    assert tl.start['news_evidence_node'] >= tl.end['cross_factor_node']
     assert tl.start['news_evidence_node'] >= max(tl.end['em_news_node'],
                                                  tl.end['catalysts_node'])
     # evidence page rebuilds only after quant-review + cross-factor finalize
@@ -328,8 +331,8 @@ def test_issues_order_is_deterministic_regardless_of_completion_order(tmp_path, 
         'FX fallback used: provider down',
         'daily bar refresh failed',
         'catalysts fetch failed',
-        'news evidence graph failed',
         'benchmark history fetch failed',
+        'news evidence graph failed',
     ]
     failures = {
         'analyze-us': (1, ''),

--- a/tests/test_llm_chain_budget.py
+++ b/tests/test_llm_chain_budget.py
@@ -237,3 +237,32 @@ def test_stats_out_records_leg_outcomes_and_attempts(keys, monkeypatch):
     assert legs["minimax"]["ok"] is False and legs["minimax"]["attempts"] == 3
     assert legs["opencode"]["ok"] is True and legs["opencode"]["attempts"] == 1
     assert legs["minimax"]["wall_s"] >= 0 and "error" in legs["minimax"]
+
+
+def test_stats_out_over_the_real_provider_signature(keys, monkeypatch):
+    """J-P0-1 regression: the stats plumbing once called the real provider
+    functions with attempts_sink while neither accepted it — TypeError before
+    any request, killing exactly the fallback path that runs when things are
+    already broken. The earlier test's fake had quietly grown the parameter;
+    this one fakes only the wire."""
+    class R:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"},
+                                 "finish_reason": "stop"}], "usage": {}}
+
+    class S:
+        def post(self, url, **kw):
+            assert "attempts_sink" not in kw, "sink must not reach wire kwargs"
+            return R()
+
+    monkeypatch.setattr(llm, "_SESSION", S())
+
+    stats = {}
+    llm.chat(user="hi", timeout=10, temperature=0.5, fallback=False,
+             stats_out=stats)
+
+    leg = stats["legs"][0]
+    assert leg == {"provider": "minimax", "ok": True, "attempts": 1,
+                   "wall_s": leg["wall_s"]}


### PR DESCRIPTION
From agent-J's adversarial review of 43501e7e..master (report: /root/logs/perf-review/J-wave3-adversarial.md).

## P0 — brief fallback chain was dead on master (J-P0-1)
chat(stats_out=…) forwarded `attempts_sink` to both provider functions, neither of which accepted it → TypeError before any request → RuntimeError. Trigger path: brief-fallback workflow is the ONLY stats_out caller, and it dispatches exactly when the primary brief already failed — a double-fault amplifier. Tonight's 23:25 UTC run would have died.
Fix: both signatures accept + forward the sink. New smoke test fakes only the wire (the earlier fake had grown the parameter itself, masking the break).

## P1 — WAVE2 race (J-P1-1)
news-evidence reads cross_sectional_factor.json for its confirmation gate while same-wave cross-factor atomically rewrites it; a first-reaching reader silently confirms against yesterday's factors with no issue recorded. news_evidence_node → WAVE3; NODE_ORDER follows actual append sequence; DAG test pins the edge.

## P2s noted, not in this PR
stage stuck pending on uncaught node exception (parity with old behavior); snapshot date-key semantics need a contract before backtests consume them; evidence page still colors by edge_significant instead of #935's usable gate.