### PR TITLE
perf: 首屏 overview 提前起跑 + repository_only 从文档变闸 [audit:performance]

### DIFF
--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -61,6 +61,7 @@
     "assets/dashboard.gif",
     "assets/data/*.jsonl",
     "memory/*.jsonl",
+    "docs/visual-regression/**",
     "tests/**"
   ]
 }

--- a/ops/pages/prepare_pages_artifact.py
+++ b/ops/pages/prepare_pages_artifact.py
@@ -96,13 +96,21 @@ def prepare(
 
     # Stage by allowlist instead of pruning the Jekyll tree: a new internal file
     # cannot become public merely because Jekyll learned how to render it.
+    # repository_only is enforced here too, not just documented: an include
+    # pattern that starts overlapping a repository-only path must fail toward
+    # excluding the file (and say so), never publish it by accident.
     copied: list[str] = []
+    skipped: list[str] = []
     for pattern in includes:
         for source in site_dir.glob(pattern):
             if not source.is_file():
                 continue
             source.resolve().relative_to(site_dir)
             relative = source.relative_to(site_dir)
+            if any(fnmatch.fnmatch(relative.as_posix(), pattern)
+                   for pattern in repository_only):
+                skipped.append(relative.as_posix())
+                continue
             destination = output_dir / relative
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)
@@ -131,6 +139,7 @@ def prepare(
     print(
         f"Pages artifact: {before:,} -> {after:,} bytes "
         f"({before - after:,} excluded; {len(set(copied))} public files; "
+        f"{len(skipped)} repository-only files skipped; "
         f"{removed_sitemap_urls} sitemap URLs excluded)"
     )
     return before, after

--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -493,14 +493,26 @@
     if (btn) btn.classList.add("is-loading");
     if (triggeredByUser && btn) btn.setAttribute("disabled", "true");
     try {
-      // Auto-polls revalidate the small Overview projection via ETag/Last-Modified.
-      // The full cross-tab document is fetched only at the detail consumer boundary.
-      // A user-initiated refresh keeps the old cache-buster so it ALWAYS punches
-      // through stale intermediary caches (WeChat webview / carrier proxies).
-      const url = _dataUrl("overview", triggeredByUser ? "?t=" + Date.now() : "");
-      const res = await fetch(url, { cache: triggeredByUser ? "no-store" : "no-cache" });
-      if (!res.ok) throw new Error("HTTP " + res.status);
-      const json = await res.json();
+      // index.html starts the first overview.json fetch while the head is still
+      // parsing, because this deferred script only runs after every stylesheet
+      // has downloaded. Adopt that promise on the cold automatic load so the
+      // request overlaps the CSS/JS download instead of serializing behind it.
+      // The handle is consumed once and deleted: polls and manual refreshes
+      // always take the fetch below, and so does a null adoption (offline,
+      // non-200, bad JSON at boot time) — same contract, one request saved.
+      let json = window.__overviewBoot && !triggeredByUser
+        ? await window.__overviewBoot : null;
+      delete window.__overviewBoot;
+      if (!json) {
+        // Auto-polls revalidate the small Overview projection via ETag/Last-Modified.
+        // The full cross-tab document is fetched only at the detail consumer boundary.
+        // A user-initiated refresh keeps the old cache-buster so it ALWAYS punches
+        // through stale intermediary caches (WeChat webview / carrier proxies).
+        const url = _dataUrl("overview", triggeredByUser ? "?t=" + Date.now() : "");
+        const res = await fetch(url, { cache: triggeredByUser ? "no-store" : "no-cache" });
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        json = await res.json();
+      }
       if (json.schema_version !== 1 || json.projection !== "overview" ||
           !_generation(json)) {
         throw new Error("invalid Overview projection envelope");

--- a/site/index.html
+++ b/site/index.html
@@ -80,6 +80,18 @@ layout: null
      bundle; its only former canvas chart moved to Reflect), so phones landing on
      Overview never download this bundle. -->
 <link rel="stylesheet" href="assets/css/dashboard.css">
+<!-- First-paint data race: the four deferred scripts only execute after this
+     stylesheet has downloaded, and dashboard.ui.js is the last of them, so its
+     overview.json request used to serialize behind ~250KB of CSS+JS on every
+     cold visit. Start the one LCP fetch here instead; loadData() adopts the
+     promise exactly once and deletes it, so polls and manual refreshes are
+     untouched, and any failure falls back to that normal fetch path. -->
+<script>
+  window.__overviewBoot =
+    fetch("assets/data/overview.json", { cache: "no-cache" })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .catch(function () { return null; });
+</script>
 </head>
 <body>
 <noscript><div style="padding: var(--space-4);max-width:680px;margin:0 auto;color:var(--text-secondary);font-size:var(--fs-md);line-height:1.6">

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -66,13 +66,16 @@ async function stubLiveOrigin(page, options = {}) {
 }
 
 function observe(page) {
-  const result = { detailRequests: 0, fullRequests: 0, failures: [], errors: [] };
+  const result = { detailRequests: 0, fullRequests: 0, overviewRequests: 0, failures: [], errors: [] };
   page.on("request", request => {
     const pathname = new URL(request.url()).pathname;
     if (pathname === DETAIL_PATH) result.detailRequests += 1;
     // Counted on either origin: the point of the assertion is that detail tabs
     // share one request for the full document, not where it was served from.
     if (pathname.endsWith("/assets/data/dashboard.json")) result.fullRequests += 1;
+    // Same either-origin rule: the cold load must fetch the LCP projection
+    // exactly once no matter who started it (head boot fetch vs loadData).
+    if (pathname.endsWith("/assets/data/overview.json")) result.overviewRequests += 1;
   });
   page.on("response", response => {
     const url = new URL(response.url());
@@ -118,6 +121,11 @@ async function testRuntime(browser, base) {
   await waitForData(page);
   assert.equal(state.detailRequests, 0, "Overview downloaded the detail renderer");
   assert.equal(state.fullRequests, 0, "Overview downloaded the full dashboard document");
+  // The head boot fetch and the loadData() fetch must dedupe into one request:
+  // two downloads of the LCP projection would mean the adoption handoff broke
+  // and every cold visitor pays the projection twice.
+  assert.equal(state.overviewRequests, 1,
+    "cold load fetched the Overview projection more than once");
   await page.evaluate(() => {
     const original = window.render;
     window.__coreRenderCalls = 0;
@@ -129,6 +137,9 @@ async function testRuntime(browser, base) {
   await page.evaluate(() => loadData(false));
   assert.equal(await page.evaluate(() => window.__coreRenderCalls), 0,
     "unchanged Overview poll replayed the core renderer");
+  // The boot handle is gone after the cold load, so this poll does its own fetch.
+  assert.equal(state.overviewRequests, 2,
+    "the poll did not issue its own Overview request (boot handle leaked?)");
 
   for (const tab of TABS) {
     await page.click(`.tab-btn[data-tab="${tab}"]`);

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -195,6 +195,12 @@ def test_builder_stages_only_public_consumers(tmp_path):
     (site / "tests/private.txt").write_text("not public")
     (site / "memory").mkdir()
     (site / "memory/decisions.jsonl").write_text("{}\n")
+    # QA fixtures ride inside docs/, which IS publicly included as a whole —
+    # they are kept out only by the repository_only contract, so this pair
+    # pins both halves: the sibling doc ships, the regression captures do not.
+    (site / "docs/visual-regression/issue-206").mkdir(parents=True)
+    (site / "docs/visual-regression/issue-206/before-1440.jpg").write_bytes(b"\xff\xd8")
+    (site / "docs/architecture.md").write_text("ok")
     source_gif_size = (ROOT / "site/assets/dashboard.gif").stat().st_size
     source_jsonl = sorted((ROOT / "assets/data").glob("*.jsonl"))
 
@@ -219,6 +225,8 @@ def test_builder_stages_only_public_consumers(tmp_path):
     assert not list((output / "assets/data").glob("*.jsonl"))
     assert not (output / "memory/decisions.jsonl").exists()
     assert not (output / "tests").exists()
+    assert not (output / "docs/visual-regression/issue-206").exists()
+    assert (output / "docs/architecture.md").is_file()
     sitemap_locs = [
         node.text for node in ET.parse(output / "sitemap.xml").getroot().iter()
         if node.tag.rsplit("}", 1)[-1] == "loc"


### PR DESCRIPTION
## 改动

两个聚焦修复，各对应一个本轮审计建的问题：

**#953 — LCP 唯一数据请求提前起跑**
- `site/index.html`：head 内联 boot fetch，在样式表/defer JS 下载期间就发出 `assets/data/overview.json` 请求（首帧照旧只走本源相对路径，不碰 data-plane 策略）。
- `site/assets/js/dashboard.ui.js`：`loadData()` 冷自动路径收编 `window.__overviewBoot`（消费一次即删）；手动刷新、60s poll、boot 失败（offline/non-200/坏 JSON）一律回退原 fetch 路径，错误契约不变。
- 此前关键路径：HTML → CSS(166KB) → 四段 defer JS 全部执行完 → 才开始拉 overview.json → Hero 渲染。现在数据与 CSS/JS 并行，冷访问省一个串行尾巴（典型移动网络 ~100-250ms LCP）。
- `tests/dashboard_tab_runtime.spec.js`：observe() 增加 overviewRequests 计数；断言冷加载恰好 1 次请求（收编去重生效）、其后 poll 自发第 2 次（句柄确实被删）。本地全绿（exit 0）。

**#952 — repository_only 从纯文档变成真闸**
- `ops/pages/prepare_pages_artifact.py`：拷贝循环此前只看 artifact_include，repository_only 不参与过滤——include 一旦新写一条重叠 pattern 就会静默发布。现按相对路径强制跳过并在 stdout 报数。
- `config/pages-public.json`：`docs/visual-regression/**` 入名单。实测公开 artifact 因此少 872KB QA before/after JPG（约总字节 17%），无任何公开页面链接它们。
- `tests/test_pages_deployment_contract.py`：钉住两半——普通 docs 文件照常发布、回归截图目录不进 `_pages`。

Closes #952

Closes #953

## 审计范围备忘（不改代码的部分）

- #951（issue-only）：news_evidence_history.jsonl 无上限增长 ~26KB/天且加速；因 `cluster_old_but_recurrent` 语义与 walkforward 全历史回放两个消费方，朴素 cap 会改行为，需先定保留策略。
- 其余性能面核查为健康：dashboard-build 本地 2.5s 且幂等零 diff；echarts 已 tree-shake+懒加载；render.js 懒加载；pages.yml/ci.yml 的路径闸与并发策略均有量化注释支撑；t0_setups_history 已有 4000 行封顶。
