### PR TITLE
fix: 跨午夜美股槽位按场次日核验 + cron-health 补周六运行 (#955)

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -1,6 +1,10 @@
 name: Cron Health Check
 
-# 17:17 HKT = 09:17 UTC 工作日 — 港股收盘后、美股开盘前 一窗口。
+# 17:17 HKT = 09:17 UTC, 周一至周六 — 港股收盘后、美股开盘前 一窗口。
+# 周六也要跑：美股盘中盯盘-overnight 的最后六个槽（00:00–02:30 HKT, dow 6）和
+# 美股收盘报告的 04:00 槽属于**周五的美股场次**（dow 掩码 2-6 正因此跨到周六），
+# 健康闸按场次日（slot 本地日期 −1）判定（#955）；没有周六这一次运行，这些槽的
+# heartbeat/commit 就写进 ledger 后无人核验——每周固定一个场次的两张网失明。
 #
 # 这里原来写着「避开整点：GitHub 官方说明整点高负载会延迟甚至丢弃 scheduled
 # runs」，隐含「非整点就准时」。**这条被本档自己的数据证伪了**（#781）：它就在
@@ -20,6 +24,10 @@ name: Cron Health Check
 on:
   schedule:
     - cron: '17 9 * * 1-5'
+    # Saturday: the overnight monitor's last slots and the US close report land
+    # on Sat 00:00-04:00 HKT but belong to FRIDAY's session — without a weekend
+    # run nobody ever verified them (#955).
+    - cron: '17 9 * * 6'
   workflow_dispatch:
 
 permissions:

--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -505,16 +505,32 @@ def check_dashboard_build():
             'ok': True, 'warn_count': 0, 'repair_count': 0, 'age_hours': age_hours}
 
 
-def _market_closed_today(market):
-    """True if `market` ('hk'/'us') is on holiday/weekend today (its own TZ). Used to
-    suppress false 'missing commit' reds: a market-report cron on that market's holiday
-    is correctly skipped by preflight's holiday gate (memory: openclaw-market-holiday-gate),
+def _market_closed_on(market, day=None):
+    """True if `market` ('hk'/'us') is closed on `day` (default: today, its own TZ).
+
+    Used to suppress false 'missing commit' reds: a market-report cron on that market's
+    holiday is correctly skipped by preflight's holiday gate (memory: openclaw-market-holiday-gate),
     so it produces no commit by design. Fail-open (False) if the calendar is unavailable."""
     try:
         from clawock import sessions as _tc
-        return not _tc.is_trading_day(market)
+        return not _tc.is_trading_day(market, day)
     except Exception:
         return False
+
+
+def _market_closed_today(market):
+    return _market_closed_on(market)
+
+
+# Jobs whose slots exist only because the US session crosses HKT midnight: their
+# Tue–Sat slots monitor the PREVIOUS day's US session (#454's rule — a fill typed
+# Saturday 01:08 HKT traded Friday). Judging them on the slot's own calendar date
+# got both directions wrong at once: every Saturday read as "US closed" (always
+# true) so the Friday-session slots were recorded in the ledgers and verified by
+# no one, while a US holiday's own skip surfaced as a missing report on the NEXT
+# trading morning, whose calendar says open. The holiday gate must ask about the
+# session day, not the wall-clock day (#955).
+SESSION_DAY_OFFSET_JOBS = frozenset({'美股收盘报告', '美股盘中盯盘-overnight'})
 
 
 def main():
@@ -568,7 +584,19 @@ def main():
         both_closed = name == '盘前深度简报' and all(
             _market_closed_today(m) for m in ('hk', 'us')
         )
-        if expected_past and ((mkt and _market_closed_today(mkt)) or both_closed):
+        market_closed = False
+        if mkt:
+            session_day = None
+            if name in SESSION_DAY_OFFSET_JOBS:
+                try:
+                    session_day = (
+                        now.astimezone(ZoneInfo(tz)).date() - timedelta(days=1))
+                except Exception:
+                    session_day = None  # fail open into the same-day gate below
+            market_closed = (
+                _market_closed_on(mkt, session_day)
+                if session_day is not None else _market_closed_today(mkt))
+        if expected_past and (market_closed or both_closed):
             label = f'{mkt.upper()} 休市' if mkt else 'HK + US 均休市'
             report.append({
                 'name': name, 'schedule': expr, 'tz': tz,

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -190,3 +190,113 @@ def test_commit_evidence_degrades_to_zero_when_git_fails(monkeypatch):
         cron_health_check.subprocess, "run",
         lambda *a, **k: SimpleNamespace(returncode=128, stdout=""))
     assert cron_health_check.commit_count_today("anything") == 0
+
+
+# ── #955: cross-midnight US jobs are judged on their SESSION day ────────────
+# 美股盘中盯盘-overnight (00:00–02:30 HKT dow 2-6) and 美股收盘报告 (04:00 HKT
+# dow 2-6) monitor the PREVIOUS day's US session — the dow mask reaches into
+# Saturday precisely because the session crosses HKT midnight (#454's rule).
+# Judging on the slot's own calendar date got both directions wrong: every
+# Saturday read as "US closed" so the Friday-session slots were written into
+# the ledgers and verified by no one, while a US holiday's own preflight skip
+# surfaced as a missing report on the next trading morning.
+
+_CONTRACT = ROOT / "config" / "cron-schedules.json"
+
+
+def _run_health_at(monkeypatch, capsys, now_utc, *, heartbeats=None,
+                   commit_stamps=()):
+    """Drive cron_health_check.main() against the real contract at a frozen instant."""
+    ledger = {
+        "schema_version": 1,
+        "monitoring_started_at": "2026-08-01T00:00:00+08:00",
+        "events": [
+            {"job": job, "slot": slot, "state": state}
+            for job, slot, state in (heartbeats or [])
+        ],
+    }
+    import tempfile
+    handle, hb_name = tempfile.mkstemp(suffix=".json")
+    hb = Path(hb_name)
+    hb.write_text(json.dumps(ledger))
+    out_file = hb.with_name("outcomes.json")
+    out_file.write_text(json.dumps({"schema_version": 1, "records": []}))
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now_utc if tz is None else now_utc.astimezone(tz)
+
+    monkeypatch.setattr(cron_health_check, "datetime", _Frozen)
+    # The holiday gate must judge the frozen instant, not the real wall clock:
+    # is_trading_day(market) with no date falls back to sessions' own "today".
+    from clawock import sessions as _sessions
+    monkeypatch.setattr(
+        _sessions, "_today_in_market",
+        lambda market: now_utc.astimezone(ZoneInfo(
+            "America/New_York" if market == "us" else "Asia/Hong_Kong")).date())
+    cache = [(stamp, subject) for stamp, subject in commit_stamps] or None
+    monkeypatch.setattr(cron_health_check, "_commit_log_cache",
+                        [] if commit_stamps == () else cache)
+    monkeypatch.setattr(cron_health_check, "check_dashboard_build",
+                        lambda: {"state": "absent", "detail": "t", "age_hours": None})
+    monkeypatch.setattr(cron_health_check, "check_scheduled_publisher",
+                        lambda now=None, path=None: {"state": "ok", "detail": "t",
+                                                     "age_hours": 1.0})
+    monkeypatch.setattr(sys, "argv", [
+        "cron_health_check.py", "--json",
+        "--jobs-file", str(_CONTRACT),
+        "--heartbeats-file", str(hb),
+        "--outcomes-file", str(out_file),
+    ])
+    try:
+        cron_health_check.main()
+    except SystemExit as exc:  # exit codes are asserted nowhere here; the row
+        assert exc.code in (0, 1, 2), exc  # statuses above carry the verdicts
+    return {r["name"]: r for r in json.loads(capsys.readouterr().out)["jobs"]}
+
+
+def _overnight_slots():
+    """The six Saturday-2026-08-22 overnight slots, all completed."""
+    return [
+        ("美股盘中盯盘-overnight", f"2026-08-22T0{h}:{m:02d}:00+08:00", "completed")
+        for h, m in ((0, 0), (0, 30), (1, 0), (1, 30), (2, 0), (2, 30))
+    ]
+
+
+def test_saturday_run_verifies_the_friday_session_slots(monkeypatch, capsys):
+    """Sat 2026-08-22 17:17 HKT after a normal Friday session: the six overnight
+    slots are heartbeat-verified and the close report's 04:00 commit is counted —
+    not waved off as 'holiday' by a calendar that only knows Saturday is closed."""
+    rows = _run_health_at(
+        monkeypatch, capsys,
+        datetime(2026, 8, 22, 9, 17, tzinfo=timezone.utc),
+        heartbeats=_overnight_slots(),
+        commit_stamps=[("2026-08-22T04:06:00+08:00", "dashboard: 美股收盘报告 (us close)")],
+    )
+    overnight = rows["美股盘中盯盘-overnight"]
+    assert overnight["status"] == "ok-heartbeat", overnight
+    assert "6/6" in overnight["detail"]
+    close = rows["美股收盘报告"]
+    assert close["status"] == "ok", close
+    assert "1/1 commits OK" in close["detail"]
+
+
+def test_a_us_holiday_session_suppresses_its_saturday_slots_without_a_red(monkeypatch, capsys):
+    """Sat 2026-07-04 17:17 HKT: Friday Jul 3 was Independence Day (observed), so
+    the session genuinely did not happen — 'holiday' is correct and must not be
+    reported as a miss even though no Saturday evidence exists."""
+    rows = _run_health_at(
+        monkeypatch, capsys, datetime(2026, 7, 4, 9, 17, tzinfo=timezone.utc))
+    assert rows["美股盘中盯盘-overnight"]["status"] == "holiday"
+    assert rows["美股收盘报告"]["status"] == "holiday"
+
+
+def test_a_monday_holiday_does_not_red_the_tuesday_close_report(monkeypatch, capsys):
+    """Tue 2026-05-26 17:17 HKT: Monday May 25 was Memorial Day, so preflight had
+    skipped the Tue 04:00 close slot by design. The old gate judged Tuesday's own
+    calendar (a trading day) and read that skip as a missing commit."""
+    rows = _run_health_at(
+        monkeypatch, capsys, datetime(2026, 5, 26, 9, 17, tzinfo=timezone.utc))
+    assert rows["美股收盘报告"]["status"] == "holiday"
+    assert rows["美股盘中盯盘-overnight"]["status"] == "holiday"


### PR DESCRIPTION
## 审计结论（cron 切片，SRE 视角）

全量对抗审查了 `.github/workflows` schedule 触发面（13 个 workflow）、`ops/host` 主机侧脚本（check_crons/cron_health_check/cron_runs/cron_timeline/cron_token_audit/sync_us_cron_dst/sync_cron_payloads/generate_cron_docs）、brief 兜底链（brief-fallback.yml + automation/brief_fallback.py）、postflight/marker 闸序（brief_postflight publish gate、send claim、sent_ok/tg_ok marker）与三个 watchdog 的闸序。历史判据逐条回归：#775 DST 静默死的 check_host_cron_logs 闸接线完好（system_check.py:854 → pre-push 注册）；sent_ok/trajectory 判据仍成立；US overnight 02:30 截止与 dow 跨日坑均有注释与实现一致；payload 模板 required/forbidden substrings 由 system_check 在推送前强制。

**本片唯一可修缺陷 = #955**：跨午夜美股任务（美股盘中盯盘-overnight、美股收盘报告）的 slot 属于前一日的美股场次（dow 2-6 正因此跨到周六），但假日闸按 slot 自身历法判定——周六恒「休市」→ 周五场次的 6+1 个槽写入 ledger 后无人核验；反向在美周中假日的次日早上会把 preflight 的设计性跳过读成 missing commit 假红（Juneteenth 未炸只因被周六 accident 掩护）。其余观察均属「仅记录」级（如 港股午后快报 2/1 commits OK 的计数膨胀方向无害），不为产出而产出。

## 修复

1. `ops/host/cron_health_check.py`：新增 `SESSION_DAY_OFFSET_JOBS` 与 `_market_closed_on(market, day)`；这两个 job 的假日闸改按场次日（slot 本地日期 −1）判定，`is_trading_day` 显式收日期，消除对隐式「今天」的依赖。
2. `.github/workflows/cron-health.yml`：schedule 增加 `17 9 * * 6`，周六 17:17 HKT 运行一次，让周五场次进入核验范围（其余 job 周六无槽，天然 idle）。
3. `tests/test_cron_health_check.py`：冻结时钟驱动 main() 全链路的三个场景测试（周六核验、独立日周六抑制、Memorial Day 次日不假红）；前两个在修复前代码上为红，第三个钉住抑制不被过矫正破坏。

Closes #955

## 验证

- `pytest tests/test_cron_health_check.py tests/test_workflow_health.py tests/test_generate_cron_docs.py -q` → 36 passed
- 修复前 stash 对照：新测试按预期红
- `python3 ops/host/generate_cron_docs.py --check` 通过（生成文档只覆盖 host contract，不受本 PR 影响）
