### PR TITLE
fix: publish-coverage 在 dsh-only master push 上不再假红 (#957)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,10 @@ jobs:
         # instead of running the tests again, so the published badge is the same
         # number this job gated on — not a second, independently drifting
         # measurement. Only master pushes have a consumer; PR runs skip the upload.
+        # Deliberately NOT gated on the code lane as well: a dsh-only master push
+        # then warns about zero files here (#957) — noise, but gating a lane read
+        # on the starting event is the exact shape test_ci_trigger_paths.py bans
+        # after #750, and the consuming job below carries the real gate.
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7
         with:
@@ -562,10 +566,16 @@ jobs:
   publish-coverage:
     # Master only: the README badge must show what is on master, never a number
     # from an unmerged branch. PRs still get the floor gate in `validate` above.
+    # Gated on the same lane answer that produced the artifact: a dsh-only
+    # master push runs no pytest, uploads no coverage-report.json, and this job
+    # used to start anyway and die in download-artifact on the missing file —
+    # four of the last eight red master runs were exactly that false alarm (#957).
     runs-on: ubuntu-latest
     timeout-minutes: 4
     needs: validate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      ${{ github.event_name == 'push' && github.ref == 'refs/heads/master'
+          && needs.validate.outputs.code == 'true' }}
     # Serialize with the other commit-pushing workflows (job-scoped, so PR runs of
     # `validate` are never queued behind a data-write job).
     concurrency:

--- a/tests/test_ci_consolidation_contract.py
+++ b/tests/test_ci_consolidation_contract.py
@@ -66,6 +66,22 @@ def test_smoke_data_fetch_only_boots_for_code_changes():
     assert "if: needs.validate.outputs.code == 'true'" in job
 
 
+def test_coverage_publish_chain_reads_the_lane_that_produces_the_artifact():
+    """publish-coverage must not outlive the artifact it downloads.
+
+    `examples/dsh/**` lights only the dsplugin lane (ops/ci/push_scope.py), so a
+    dsh-only master push runs no pytest and produces no coverage-report.json.
+    The consuming job used to start anyway and die hard in download-artifact on
+    the missing file — four of the last eight red master runs were that false
+    alarm (#957, runs 32760585564 / 32759484885 / 32680826301 / 32680290940).
+    The upload side stays warn-only on purpose: gating a lane read on the
+    starting event is the shape test_ci_trigger_paths.py bans after #750.
+    """
+    job = TEXT.split("\n  publish-coverage:", 1)[1].split("\n  smoke-data-fetch:", 1)[0]
+    assert "needs.validate.outputs.code == 'true'" in job, (
+        "publish-coverage must skip when the suite never measured anything")
+
+
 def test_validate_publishes_its_detector_answer_as_a_job_output():
     job = TEXT.split("\n  validate:", 1)[1].split("\n  publish-coverage:", 1)[0]
     assert "code: ${{ steps.changes.outputs.code }}" in job

--- a/tests/test_coverage_badge.py
+++ b/tests/test_coverage_badge.py
@@ -266,7 +266,10 @@ def _publish_job():
 def test_publish_job_is_master_push_only_and_needs_validate():
     job = _publish_job()
     assert 'needs: validate' in job
-    assert ("if: github.event_name == 'push' && github.ref == 'refs/heads/master'") in job
+    assert ('github.event_name == \'push\' && github.ref == \'refs/heads/master\'') in job
+    # #957: a dsh-only master push runs no pytest and produces no artifact, so
+    # the consuming job must read the same lane answer before it may start.
+    assert 'needs.validate.outputs.code == \'true\'' in job
     assert 'group: data-write' in job, 'publish must serialize with the other writers'
 
 


### PR DESCRIPTION
Closes #957

## 问题

`publish-coverage` 在 dsh-plugin-only 的 master push 上必假红。证据链（run 32760585564，2026-08-24）：

1. `examples/dsh/**` 在 push 触发面里（ci.yml），但分类器只点亮 `dsplugin` lane——`DSPLUGIN_RE` 匹配、`CODE_GLOBS` 不含该前缀 → `code=false`；
2. validate 跳过全部 Python 步骤，`coverage-report.json` 从未生成；"Upload coverage report" 步骤只按 event/ref 门控，upload-artifact 默认 `if-no-files-found: warn` 报 warning 后通过：
   `##[warning]No files were found with the provided path: coverage-report.json`
3. validate 整体 success → `publish-coverage` 的 `if:` 不读 `needs.validate.outputs.code`，job 照常启动；
4. "Download coverage report" 对缺失 artifact 硬失败 → 假红。

近 8 个失败的 master run 中 4 个是本类（#937、#939、两个 examples/dsh 依赖 bump），其中两个在最近 24h。

## 修复

- **ci.yml**：`publish-coverage` 的 `if:` 增加 `needs.validate.outputs.code == 'true'`——suite 没测量时 job 直接 skip；
- **tests/test_ci_consolidation_contract.py**：新增行为断言钉住该门（镜像既有 smoke-data-fetch 门测试的形状）。

## 刻意不做

upload 步骤不加同款 lane 门：把 lane 读取与 event gate 组合进步骤级 `if` 正是 `test_ci_trigger_paths.py::test_the_heavy_lanes_are_not_gated_on_the_event_that_started_the_run` 在 #750 后禁止的形状（首稿即被该测试拦下）。残留的只是一行 warn-noise，真正的消费方已被门住。

## 验证

- `pytest tests/test_ci_consolidation_contract.py tests/test_ci_codeql_gate.py tests/test_ci_trigger_paths.py tests/test_push_scope.py -q` → 38 passed
- 未跑全量套件（任务规则）；六个必需检查交给远端 CI。
