### PR TITLE
fix: weekly-review/news-digest prompt 结构化投影替代裸字符串截断 (#959)

### DIFF
--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -25,6 +25,39 @@ from clawock import instruments as instrument_registry
 from clawock.automation.llm import chat
 from clawock.market_data.sentiment import fetch_google_news
 
+# Serialized-size budget for the raw-news JSON embedded in the prompt. The old
+# `json.dumps(raw)[:25000]` slice cut mid-string on busy days: a malformed JSON
+# tail plus tickers that silently vanished while the digest was still expected
+# to cover them (#959). Tickers are now included or skipped WHOLE; skipped ones
+# are declared in `_omitted_tickers` so the model reports the gap instead of
+# inventing around it.
+NEWS_PROMPT_BUDGET_CHARS = 25_000
+
+
+def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
+    """Whole-ticker projection of the fetched news under a serialized budget.
+
+    Inclusion order follows `raw` so earlier (portfolio-order) tickers win
+    contention. The `_omitted_tickers` manifest is sized into the budget from
+    the start so adding it can never push the payload back over budget.
+    """
+    def compact(value):
+        return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+    included = {}
+    omitted = []
+    used = len(compact({'_omitted_tickers': omitted}))
+    for ticker, items in raw.items():
+        piece = len(compact({ticker: items})) + 1  # + separator overhead
+        if used + piece <= budget:
+            included[ticker] = items
+            used += piece
+        else:
+            omitted.append(ticker)
+    if omitted:
+        included['_omitted_tickers'] = omitted
+    return included
+
 
 def _fetch_finnhub(ticker, since, until, key):
     """Returns list of dicts (may be empty) or None on error."""
@@ -178,6 +211,8 @@ def main():
 
     system = "You are Rick, kcn's stock analyst. Distill US holding news into actionable bullets."
 
+    news_payload = build_news_payload(raw)
+
     user = (
         "下面 US holdings 过去 48h 新闻 (来源 Finnhub 或 Google News RSS, "
         "每条 `origin` 字段标注). 提炼成 markdown digest:\n\n"
@@ -197,9 +232,11 @@ def main():
         "- 不许说 \"需要进一步研究\" 这种废话\n"
         + (f"- 持仓映射: 以下公司是通过杠杆 ETF 持有的 {json.dumps(held_via, ensure_ascii=False)};"
            " 写 implication 时点明持有的是哪只 ETF, 并说明 2x 会放大该消息\n" if held_via else "")
+        + "- 若 Raw news 含 `_omitted_tickers`，这些 ticker 的新闻因 prompt 预算被整体省略，"
+          "对应小节必须如实写数据缺口，禁止编造\n"
         + "- 直接出 markdown\n\n"
         +
-        f"Raw news (JSON):\n```json\n{json.dumps(raw, ensure_ascii=False)[:25000]}\n```\n"
+        f"Raw news (JSON):\n```json\n{json.dumps(news_payload, ensure_ascii=False)}\n```\n"
     )
 
     # News digest: short output but enable thinking helps prioritize signal vs noise

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -19,6 +19,37 @@ from pathlib import Path
 from clawock.automation.llm import chat
 from clawock.decision import ledger as decision_v2
 
+# Prompt budget for the single-turn weekly review, measured in serialized-JSON
+# characters. A sanity bound, not a writing target: the old prompt embedded
+# `json.dumps(bundle)[:40000]`, sized when the bundle was small. By 2026-08 the
+# bundle serialized to 702K characters, so the slice kept 5.7% of it, landed
+# mid-string (a malformed JSON tail), and silently hid decision_metrics /
+# snapshots / current_risk / input_warnings behind a cut the model could not
+# see — while the prompt's question 3 asks for exactly the current risk
+# numbers (#959). Same defect class brief_fallback.prepare_context fixed for
+# the daily brief: never cut a serialized string; drop whole values instead
+# and declare what was dropped.
+PROMPT_BUDGET_CHARS = 200_000
+
+# Machine-owned fields on decision / episode records that no review question
+# consumes; the harness already distills them into decision_episodes /
+# decision_metrics. signal_provenance alone was ~76% of the decisions bytes in
+# committed plans and also rides on every episode representative.
+DECISION_PROMPT_DROP_FIELDS = ('signal_provenance',)
+
+# Per-holding fields the review questions can actually use (book composition
+# start-vs-end for contributor/drag attribution). Intraday OHLCV/volume/
+# trade-tape detail and gold_dca stay out of the prompt; the NAV series they
+# would support lives in bundle_evidence.nav_points.
+HOLDING_PROMPT_FIELDS = ('ticker', 'name', 'current_value',
+                         'pnl_percent', 'today_change_pct')
+
+# Top-level sections that may be omitted WHOLE, largest first, when the
+# projected payload still exceeds the budget. Everything else — window,
+# bundle_evidence, decision_episodes, current_risk, input_warnings — is small
+# and load-bearing for specific questions, so it is never dropped.
+OMITTABLE_SECTIONS = ('plans', 'snapshots', 'decision_metrics')
+
 
 def _load_json(path, kind, errors):
     try:
@@ -211,6 +242,93 @@ def validate_bundle(bundle):
     return evidence
 
 
+def _compact(value):
+    return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+
+def _slim_decision(decision):
+    if not isinstance(decision, dict):
+        return decision
+    return {k: v for k, v in decision.items()
+            if k not in DECISION_PROMPT_DROP_FIELDS}
+
+
+def _slim_snapshot(snapshot):
+    """Keep per-leg totals plus per-holding attribution fields for a snapshot day."""
+    slim = {'last_updated': snapshot.get('last_updated')}
+    portfolios = snapshot.get('portfolios')
+    legs = {}
+    for leg, pf in (portfolios or {}).items():
+        if not isinstance(pf, dict):
+            legs[leg] = pf
+            continue
+        cash = pf.get('cash_usd') if leg == 'us_stocks' else pf.get('cash_hkd')
+        holdings = [
+            {field: holding.get(field) for field in HOLDING_PROMPT_FIELDS}
+            for holding in pf.get('holdings') or []
+            if isinstance(holding, dict)
+        ]
+        legs[leg] = {
+            'total_current_value': pf.get('total_current_value'),
+            'total_pnl': pf.get('total_pnl'),
+            'today_total_change': pf.get('today_total_change'),
+            'cash': cash,
+            'holdings': holdings,
+        }
+    slim['portfolios'] = legs
+    return slim
+
+
+def build_prompt_payload(bundle, budget=PROMPT_BUDGET_CHARS):
+    """Project the aggregated bundle into the payload the LLM prompt embeds.
+
+    Two layers, both structural:
+
+    1. Projection — strip machine-owned bulk no question consumes (per-decision
+       provenance; per-holding market microdetail). On committed 2026-08 data
+       this takes the bundle from 702K to 145–280K characters depending on how
+       decision-heavy the week was.
+    2. Whole-value omission — if the projected payload still exceeds `budget`,
+       drop entire sections largest-first from OMITTABLE_SECTIONS and declare
+       each in a top-level `_omitted` manifest that rides inside the payload,
+       so the model is told about the gap instead of silently reading a sliced
+       half-JSON. On heavy weeks this drops `plans` first, which is deliberate:
+       its content is the daily raw view of the same decisions decision_episodes
+       and decision_metrics already distill. The serialized result must always
+       json.loads cleanly; there is deliberately no character-slice fallback.
+    """
+    def project_plan(entry):
+        data = entry.get('data') or {}
+        projected = dict(data)
+        if isinstance(data.get('decisions'), list):
+            projected['decisions'] = [_slim_decision(d) for d in data['decisions']]
+        return {'date': entry.get('date'), 'data': projected}
+
+    payload = dict(bundle)
+    payload['plans'] = [project_plan(p) for p in bundle.get('plans') or []]
+    payload['snapshots'] = [_slim_snapshot(s) for s in bundle.get('snapshots') or []]
+    if isinstance(bundle.get('decision_episodes'), list):
+        payload['decision_episodes'] = [
+            _slim_decision(e) for e in bundle['decision_episodes']]
+
+    omitted = []
+    while True:
+        # The manifest is part of the payload, so it is re-attached every pass:
+        # dropping a section may let a smaller one survive, and the final
+        # manifest must name exactly what is missing from this payload.
+        payload['_omitted'] = omitted
+        if len(_compact(payload)) <= budget:
+            break
+        sizes = [(len(_compact(payload[name])), name)
+                 for name in OMITTABLE_SECTIONS if name in payload]
+        if not sizes:
+            break  # nothing omittable left: stay honest rather than slice
+        size, name = max(sizes)
+        payload.pop(name)
+        omitted.append({'section': name, 'bytes': size})
+    return payload
+
+
 def main():
     bundle = aggregate_week()
     validate_bundle(bundle)
@@ -218,6 +336,7 @@ def main():
 
     system = "You are Rick, kcn's HK+US stock analyst. Write a weekly portfolio review."
 
+    payload = build_prompt_payload(bundle)
     user = (
         f"根据这一周（{week_id}）的 brief / plan / decision v2 / risk 数据, "
         f"写一篇 markdown 周复盘。长度 1500-2500 字。"
@@ -228,7 +347,9 @@ def main():
         "2. **决策兑现**: 按 strategy episode 汇总触发、执行和 win/loss；不要把每日重复 call 当独立样本\n"
         "3. **风险演变**: 当前 risk.json 数值, β/Vol/Max DD/Sharpe 怎么走?\n"
         "4. **下周关注 3 条**: actionable (ticker + 触发条件 + 仓位影响)\n\n"
-        f"数据 bundle (JSON):\n```json\n{json.dumps(bundle, ensure_ascii=False)[:40000]}\n```\n\n"
+        f"数据 bundle (JSON):\n```json\n{json.dumps(payload, ensure_ascii=False)}\n```\n\n"
+        "若上面 JSON 含 `_omitted`，对应 section 因 prompt 预算被整体省略——"
+        "相关小节必须如实写数据缺口，禁止编造。\n\n"
         "直接出 markdown, 不要客套."
     )
 

--- a/tests/test_news_digest_prompt_payload.py
+++ b/tests/test_news_digest_prompt_payload.py
@@ -1,0 +1,66 @@
+"""News-digest prompt payload: whole-ticker inclusion, declared omissions.
+
+Regression guard for #959: the prompt embedded `json.dumps(raw)[:25000]`, which
+on busy days cut mid-string (malformed JSON tail) and silently dropped whole
+tickers from a digest that was still expected to cover them.
+"""
+from __future__ import annotations
+
+import json
+
+from clawock.automation.news_digest import build_news_payload
+
+
+def _news_item(seed):
+    return {
+        'headline': f'headline {seed} ' + 'w' * 180,
+        'summary': 'summary ' + 's' * 380,
+        'datetime': 1756000000 + seed,
+        'source': 'Example Wire',
+        'origin': 'finnhub',
+        'url': f'https://example.com/{seed}',
+    }
+
+
+def _raw(tickers):
+    return {ticker: [_news_item(i) for i in range(len(tickers))]
+            for i, ticker in enumerate(tickers)}
+
+
+def _compact(value):
+    return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+
+def test_under_budget_every_ticker_rides_and_nothing_is_declared():
+    raw = _raw(['PLTR', 'HOOD', 'MSFT'])
+
+    payload = build_news_payload(raw, budget=25_000)
+
+    assert set(payload) == {'PLTR', 'HOOD', 'MSFT'}
+    assert payload == raw
+    assert json.loads(_compact(payload)) == payload
+
+
+def test_over_budget_tickers_are_included_or_skipped_whole():
+    tickers = [f'T{i:02d}' for i in range(20)]
+    raw = _raw(tickers)
+
+    budget = 5000
+    payload = build_news_payload(raw, budget=budget)
+    serialized = _compact(payload)
+
+    assert json.loads(serialized) == payload
+    assert len(serialized) <= budget
+
+    skipped = payload.get('_omitted_tickers')
+    assert isinstance(skipped, list) and skipped, 'omissions must be declared'
+    included = [t for t in tickers if t in payload]
+    assert set(included) & set(skipped) == set()
+    assert sorted(included + skipped) == sorted(tickers)
+    # Included tickers ride with their items byte-for-byte intact.
+    for ticker in included:
+        assert payload[ticker] == raw[ticker]
+    # Inclusion follows input order: no later ticker jumps an earlier skip.
+    first_skip = min(tickers.index(t) for t in skipped)
+    last_include = max((tickers.index(t) for t in included), default=-1)
+    assert last_include < first_skip

--- a/tests/test_weekly_review_prompt_payload.py
+++ b/tests/test_weekly_review_prompt_payload.py
@@ -1,0 +1,125 @@
+"""The weekly-review prompt payload must be whole, declared, and complete.
+
+Regression guard for #959: the prompt used to embed `json.dumps(bundle)[:40000]`,
+which on committed 2026-08 data kept 5.7% of a 702K-character bundle, cut the
+string mid-JSON (malformed tail), and silently hid decision_metrics /
+snapshots / current_risk / input_warnings — while question 3 of the same prompt
+asks for the current risk numbers.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+from clawock.automation import weekly_review as weekly
+
+
+def _compact(value):
+    return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+
+def _oversized_bundle():
+    filler = 'x' * 4000
+    return {
+        'week': '2026-W33',
+        'window': '2026-08-17 -> 2026-08-24',
+        'bundle_evidence': {'plan_days': 1, 'nav_points': [
+            {'date': '2026-08-17', 'total_nav_usd': 1.0},
+            {'date': '2026-08-24', 'total_nav_usd': 2.0},
+        ]},
+        'plans': [
+            {'date': f'2026-08-{day:02d}', 'data': {'decisions': [], 'note': filler}}
+            for day in range(17, 24)
+        ],
+        'decision_episodes': [],
+        'decision_metrics': {'per_strategy': {f'strat_{i}': filler for i in range(40)}},
+        'snapshots': [{'portfolios': {}, 'gold_dca': filler} for _ in range(7)],
+        'current_risk': {'combined': {'beta': 1.2}},
+        'input_warnings': [],
+    }
+
+
+def test_real_committed_week_payload_is_whole_and_complete():
+    bundle = weekly.aggregate_week(today=date(2026, 7, 24))
+
+    payload = weekly.build_prompt_payload(bundle)
+    serialized = _compact(payload)
+
+    # The payload must parse as one JSON value — no sliced mid-string tail.
+    assert json.loads(serialized) == payload
+    assert len(serialized) <= weekly.PROMPT_BUDGET_CHARS
+
+    # Everything the four questions consume must actually reach the model;
+    # these are exactly the keys the old slice silently dropped, and they are
+    # never omittable no matter how heavy the week.
+    for key in ('bundle_evidence', 'decision_metrics', 'current_risk',
+                'input_warnings'):
+        assert key in payload
+    # Machine-owned provenance blobs never belonged in the prompt.
+    assert 'signal_provenance' not in serialized
+    # Any budget-driven omission must be whole-section and declared; nothing
+    # outside OMITTABLE_SECTIONS may ever disappear.
+    omitted = {row['section'] for row in payload.get('_omitted', [])}
+    assert omitted <= set(weekly.OMITTABLE_SECTIONS)
+    for section in omitted:
+        assert section not in payload
+
+
+def test_oversized_bundle_omits_whole_sections_and_declares_them():
+    bundle = _oversized_bundle()
+
+    payload = weekly.build_prompt_payload(bundle, budget=8000)
+    serialized = _compact(payload)
+
+    assert json.loads(serialized) == payload
+    assert len(serialized) <= 8000
+
+    omitted = {row['section'] for row in payload.get('_omitted', [])}
+    assert omitted, 'an oversized bundle must declare what was dropped'
+    for section in omitted:
+        assert section not in payload
+    # Sections the questions cannot do without are never omittable.
+    assert 'current_risk' in payload
+    assert 'bundle_evidence' in payload
+
+
+def test_snapshot_slimming_keeps_attribution_fields_only():
+    snapshot = {
+        'last_updated': '2026-08-24T00:00:00',
+        'portfolios': {
+            'us_stocks': {
+                'total_current_value': 1000.0,
+                'total_pnl': -10.0,
+                'today_total_change': -5.0,
+                'cash_usd': 100.0,
+                'holdings': [{
+                    'ticker': 'PLTU',
+                    'name': 'PLTR 2X',
+                    'current_value': 900.0,
+                    'pnl_percent': 12.5,
+                    'today_change_pct': -1.0,
+                    'volume': 987654,
+                    'trades': [{'side': 'buy'}],
+                    'day_high': 11.0,
+                }],
+            },
+            'hk_stocks': {
+                'total_current_value': 7800.0,
+                'cash_hkd': 780.0,
+                'holdings': [],
+            },
+        },
+        'gold_dca': {'lots': ['irrelevant to the review questions']},
+    }
+
+    slim = weekly._slim_snapshot(snapshot)
+
+    us = slim['portfolios']['us_stocks']
+    assert us['total_current_value'] == 1000.0
+    assert us['cash'] == 100.0
+    holding = us['holdings'][0]
+    assert holding['ticker'] == 'PLTU'
+    assert holding['pnl_percent'] == 12.5
+    serialized = _compact(slim)
+    for noise in ('volume', 'trades', 'day_high', 'gold_dca'):
+        assert noise not in serialized


### PR DESCRIPTION
## 问题

`[audit:prompt]` 切片发现：两支 off-host LLM 产物的 prompt 拼装用裸字符串切片截断序列化 JSON，在真实数据上已腐烂成静默数据丢失 + 坏 JSON 输入。

### weekly-review（每周日 live）

- `src/clawock/automation/weekly_review.py` 旧代码：`json.dumps(bundle, ensure_ascii=False)[:40000]`
- 本仓 committed 数据实测：bundle 序列化 **702,253** 字符，40k 截断只留 5.7%，截断点落在 `plans` 内部
- 后果：`decision_metrics`(35KB) / `snapshots`(344KB) / `current_risk`(10KB) / `input_warnings` 四个键整体不可见且切口是坏 JSON——而 prompt 第 3 问要求「当前 risk.json 数值」；`.github/workflows/weekly-review.yml` 每周日固定踩中

### news-digest（每日美股新闻卡）

- 同型 `json.dumps(raw)[:25000]`：重新闻日可越限，同类别静默丢 ticker + 坏尾

同缺陷类 brief_fallback 已修过并有先例（`prepare_context` 结构化裁剪 + manifest）。

## 修复

- **weekly_review.build_prompt_payload**：两层结构化处理
  1. 投影：剥掉机器字段（decisions/episodes 的 `signal_provenance`，实测占单日 plan decisions 字节 ~76%；快照投影为逐 leg 合计 + 逐持仓归因五字段）
  2. 整值省略：仍超预算（200K chars sanity bound）时按整节省略最大者并在 payload 内 `_omitted` 声明；`bundle_evidence/current_risk/input_warnings` 等必需小节永不省略；全路径无字符串切片
- **news_digest.build_news_payload**：按 ticker 整体取舍，省略的以 `_omitted_tickers` 声明
- 两处 prompt 各加一句：出现 `_omitted*` 必须如实写数据缺口（harness 层兑现「数据缺口必说」）

## 测试

- 新增 `tests/test_weekly_review_prompt_payload.py`（3 条：真实 committed 周 payload 完整性/无 provenance/省略必须声明、超预算整值省略+坏 JSON 不可能、快照投影只留归因字段）
- 新增 `tests/test_news_digest_prompt_payload.py`（2 条：预算内全量、超预算整 ticker 取舍+输入序+字节保真）
- 定向跑 12 passed。`tests/test_validate_sidecars.py` 有 9 个失败，已在干净 master 基线复跑确认为既有问题，与本 PR 无关。

Closes #959

另：#960（weekly「1500-2500 字」/news「≤500 字」字数 KPI 与 #334 已撤方向的一致性问题）本轮仅立 issue 论证，未动代码。
