### PR TITLE
fix: ctx 注入面两处坏源 — fallback system prompt 整文件化 + price-in 信号改读 canonical bars (#962, #963)

### DIFF
--- a/src/clawock/automation/brief_fallback.py
+++ b/src/clawock/automation/brief_fallback.py
@@ -248,6 +248,25 @@ def fail_closed_artifacts(today, prepared):
     return md, plan
 
 
+def build_system_prompt(soul: str, bootstrap: str) -> str:
+    """The off-host brief writer's system prompt: both files WHOLE.
+
+    This used to be `{soul[:1000]}\\n\\n{bootstrap[:2000]}` — slice sizes picked
+    when the files were smaller and never revisited. On committed 2026-08 text
+    the SOUL cut landed right before `## Operating mode (this workspace)`
+    ("Have a view, name the trade" / "Cite numbers, not vibes") and kept 39% of
+    the file; the BOOTSTRAP cut landed mid-sentence inside C+.2 and dropped C+.3
+    risk alerts, B+ research lifecycle and all of C. 输出约束 — the exact
+    constraint list postflight validates the fallback's output against
+    (#962). Same defect class as #959/#961, one layer up: never slice a
+    whole document into a prompt. Both files together are ~7.6KB against a
+    400KB context budget, so there is no size pressure to manage — any future
+    budget belongs in prepare_context, which trims structurally and declares
+    what it dropped.
+    """
+    return f"You are Rick, kcn's stock analyst. {soul.strip()}\n\n{bootstrap.strip()}"
+
+
 def main():
     today = (os.environ.get('TODAY') or date.today().isoformat()).strip()
     ctx_path = Path(f'memory/.tmp/brief-context-{today}.json')
@@ -268,7 +287,7 @@ def main():
     soul = Path('SOUL.md').read_text()
     bootstrap = Path('BOOTSTRAP.md').read_text()
 
-    system = f"You are Rick, kcn's stock analyst. {soul[:1000]}\n\n{bootstrap[:2000]}"
+    system = build_system_prompt(soul, bootstrap)
     user = (
         f"按下面 SKILL.md 规则跑 daily-deep-brief, 输出完整 markdown + 末尾 ```json``` block 给 plan.json schema.\n\n"
         f"SKILL.md:\n{skill}\n\n"

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -676,37 +676,38 @@ def bars_staleness():
 
 
 def _recent_price_moves(tickers, lookback_sessions=5):
-    """Per-ticker price move over the last N snapshot sessions — fuels the
+    """Per-ticker price move over the last N closed sessions — fuels the
     'is this news already priced in?' judgement (2026-05-30). A bull market
     prices good news fast: if the stock already ran on a catalyst, acting on
     that headline is chasing. Returns {ticker: {'px_pct': float, 'n_sessions': int}}.
-    Derived from memory/snapshots/{date}.json (current_price per holding); no fetch."""
-    import glob
+
+    Source discipline (2026-08 audit, #963): this used to string together
+    `current_price` from the last few memory/snapshots/*.json files, but that
+    field carries fetch vintage, not session identity — across 15 snapshots,
+    00100's current_price was the previous close 7 times, that day's close 3,
+    an intraday print 5 (see market_data/bars.py header). A priced-in signal
+    built from it can read "already ran" or "hasn't moved" purely as an
+    artefact of when each cron happened to fetch. The move now reads closes
+    from the canonical bar store: session-dated, raw, completed sessions only,
+    and [9] refreshes it earlier in this same preflight. A ticker the store
+    does not cover gets no move at all — SKILL.md already defines a null
+    recent_move as 无快照 — never a snapshot-vintage substitute."""
     want = set(tickers)
     if not want:
         return {}
-    files = sorted(f for f in glob.glob(str(SNAPSHOT_DIR / '*.json')))
-    # keep the most recent (lookback+1) snapshots so a 5-session move has both ends
-    files = files[-(lookback_sessions + 1):]
-    if len(files) < 2:
-        return {}
-    series = {t: [] for t in want}  # ticker -> [px oldest..newest]
-    for fp in files:
-        try:
-            snap = json.loads(Path(fp).read_text())
-        except Exception:
-            continue
-        for leg in ('us_stocks', 'hk_stocks'):
-            for h in (snap.get('portfolios', {}).get(leg, {}) or {}).get('holdings', []) or []:
-                tk = h.get('ticker')
-                px = h.get('current_price')
-                if tk in want and px not in (None, 0):
-                    series[tk].append(px)
     out = {}
-    for tk, pxs in series.items():
-        if len(pxs) >= 2 and pxs[0]:
-            out[tk] = {'px_pct': round((pxs[-1] / pxs[0] - 1) * 100, 1),
-                       'n_sessions': len(pxs) - 1}
+    for tk in sorted(want):
+        try:
+            doc = json.loads((WS / 'memory' / 'bars' / f'{tk}.json').read_text())
+            closes = [bar.get('close') for _, bar in sorted((doc.get('bars') or {}).items())]
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        closes = [c for c in closes if isinstance(c, (int, float)) and c]
+        window = closes[-(lookback_sessions + 1):]
+        if len(window) < 2 or not window[0]:
+            continue
+        out[tk] = {'px_pct': round((window[-1] / window[0] - 1) * 100, 1),
+                   'n_sessions': len(window) - 1}
     return out
 
 

--- a/tests/test_brief_fallback_system_prompt.py
+++ b/tests/test_brief_fallback_system_prompt.py
@@ -1,0 +1,86 @@
+"""The fallback's system prompt must carry SOUL.md and BOOTSTRAP.md whole.
+
+Regression guard for #962: the prompt used to embed `{soul[:1000]}\\n\\n
+{bootstrap[:2000]}`. On committed 2026-08 text the SOUL cut landed right before
+`## Operating mode (this workspace)` — the analyst disposition for exactly this
+writing job — and kept 39% of the file; the BOOTSTRAP cut landed mid-sentence
+and dropped C. 输出约束, the constraint list postflight validates the fallback
+output against. Same defect class as #959/#961: never slice a whole document
+into a prompt.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawock.automation import brief_fallback
+
+
+SOUL_TEXT = (
+    "# SOUL.md - Who You Are\n\n"
+    "intro text that fills up the first chunk of the file.\n"
+    + ("filler sentence.\n" * 120)
+    + "## Operating mode (this workspace)\n\nHave a view, name the trade.\n"
+)
+
+BOOTSTRAP_TEXT = (
+    "# BOOTSTRAP.md\n\nhard rules live here first.\n"
+    + ("more filler.\n" * 250)
+    + "### C. 输出约束\n\n禁止敷衍词；禁止 hedging 免责声明。\n"
+)
+
+
+def test_system_prompt_carries_both_files_whole():
+    prompt = brief_fallback.build_system_prompt(SOUL_TEXT, BOOTSTRAP_TEXT)
+
+    # Markers deliberately placed past both old cut points (char 1000 / 2000):
+    # under the slices these assertions failed, which is the exact data loss.
+    assert "## Operating mode (this workspace)" in prompt
+    assert "### C. 输出约束" in prompt
+    assert "禁止敷衍词" in prompt
+
+
+def test_system_prompt_preserves_the_final_lines_of_each_file():
+    """Nothing after either file's last line may go missing again."""
+    prompt = brief_fallback.build_system_prompt(SOUL_TEXT, BOOTSTRAP_TEXT)
+
+    assert prompt.endswith(BOOTSTRAP_TEXT.strip())
+    assert SOUL_TEXT.strip() in prompt
+
+
+def test_main_passes_the_untruncated_prompt_to_chat(tmp_path, monkeypatch):
+    """Wiring test: whatever main() sends as `system` must be the whole-file
+    build, proven end-to-end through the real file reads."""
+    today = '2026-08-25'
+    ws = tmp_path
+    (ws / 'memory' / '.tmp').mkdir(parents=True)
+    (ws / 'skills' / 'daily-deep-brief').mkdir(parents=True)
+    (ws / 'SOUL.md').write_text(SOUL_TEXT, encoding='utf-8')
+    (ws / 'BOOTSTRAP.md').write_text(BOOTSTRAP_TEXT, encoding='utf-8')
+    (ws / 'skills' / 'daily-deep-brief' / 'SKILL.md').write_text(
+        '# skill\n', encoding='utf-8')
+    context = {'portfolio': {'portfolios': {'hk_stocks': {}, 'us_stocks': {}}}}
+    (ws / 'memory' / '.tmp' / f'brief-context-{today}.json').write_text(
+        json.dumps(context), encoding='utf-8')
+
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured.update(kwargs)
+        return ('prose\n```json\n'
+                + json.dumps({'schema_version': 2, 'date': today,
+                              'decisions': []})
+                + '\n```')
+
+    monkeypatch.setenv('TODAY', today)
+    monkeypatch.chdir(ws)
+    monkeypatch.setattr(brief_fallback, 'chat', fake_chat)
+    # An empty decisions list fails schema validation by design; chat() has
+    # already been called by then, which is the moment under test.
+    with pytest.raises(SystemExit):
+        brief_fallback.main()
+
+    system = captured['system']
+    assert "## Operating mode (this workspace)" in system
+    assert "禁止敷衍词" in system

--- a/tests/test_recent_price_moves_source.py
+++ b/tests/test_recent_price_moves_source.py
@@ -1,0 +1,99 @@
+"""The priced-in signal must come from canonical bars, not snapshot vintage.
+
+Regression guard for #963: `_recent_price_moves` used to string together
+`current_price` from the last few memory/snapshots/*.json files. bars.py
+documents that field as fetch vintage rather than session identity — across 15
+snapshots 00100's current_price was the previous close 7 times, that day's
+close 3, an intraday print 5 — while SKILL.md makes the price-in judgement a
+required step built on exactly this number. The move now reads session-dated
+closes from memory/bars, and a ticker the store does not cover gets no move at
+all instead of a fabricated one.
+"""
+from __future__ import annotations
+
+import json
+
+from clawock.harness import brief_preflight
+
+
+def _write_bars(ws, ticker, closes_by_date):
+    doc = {
+        'schema_version': 1,
+        'ticker': ticker,
+        'leg': 'HK',
+        'bars': {d: {'open': c, 'high': c, 'low': c, 'close': c}
+                 for d, c in closes_by_date.items()},
+    }
+    path = ws / 'memory' / 'bars' / f'{ticker}.json'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc), encoding='utf-8')
+
+
+def _write_snapshot(ws, date, holdings_prices):
+    snap = {'portfolios': {
+        leg: {'holdings': [{'ticker': tk, 'current_price': px}]
+              for tk, px in prices.items()}
+        for leg, prices in (('hk_stocks', holdings_prices),
+                            ('us_stocks', {}))
+    }}
+    path = ws / 'memory' / 'snapshots' / f'{date}.json'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(snap), encoding='utf-8')
+
+
+def test_move_computes_from_bar_closes_not_snapshots(tmp_path, monkeypatch):
+    monkeypatch.setattr(brief_preflight, 'WS', tmp_path)
+    bars = {'2026-08-17': 100.0, '2026-08-18': 102.0, '2026-08-19': 101.0,
+            '2026-08-20': 104.0, '2026-08-21': 103.0, '2026-08-24': 110.0}
+    _write_bars(tmp_path, '00100', bars)
+    # Snapshot current_price values disagree with the bars on purpose: under
+    # the old source these numbers decided the answer.
+    for i, (date, px) in enumerate([('2026-08-18', 90.0), ('2026-08-19', 91.0),
+                                    ('2026-08-20', 92.0), ('2026-08-21', 93.0),
+                                    ('2026-08-24', 94.0)]):
+        _write_snapshot(tmp_path, date, {'00100': px})
+
+    moves = brief_preflight._recent_price_moves(['00100'])
+
+    assert moves == {'00100': {'px_pct': 10.0, 'n_sessions': 5}}
+
+
+def test_lookback_window_is_the_last_n_closed_sessions(tmp_path, monkeypatch):
+    monkeypatch.setattr(brief_preflight, 'WS', tmp_path)
+    bars = {'2026-08-10': 50.0, '2026-08-11': 51.0, '2026-08-12': 52.0,
+            '2026-08-13': 53.0, '2026-08-14': 54.0, '2026-08-17': 55.0,
+            '2026-08-18': 56.0, '2026-08-19': 70.0}
+    _write_bars(tmp_path, '07226', bars)
+
+    moves = brief_preflight._recent_price_moves(['07226'], lookback_sessions=5)
+
+    # window = last 6 closes (52..70) -> +34.6% over 5 sessions; the early
+    # bars (50/51) stay out of the window.
+    assert moves['07226'] == {'px_pct': round((70.0 / 52.0 - 1) * 100, 1),
+                              'n_sessions': 5}
+
+
+def test_ticker_without_bars_gets_no_move_even_when_snapshots_have_it(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(brief_preflight, 'WS', tmp_path)
+    for i, px in enumerate([10.0, 11.0, 12.0]):
+        _write_snapshot(tmp_path, f'2026-08-2{i}', {'NEWNAME': px})
+
+    moves = brief_preflight._recent_price_moves(['NEWNAME'])
+
+    assert moves == {}
+
+
+def test_thin_or_corrupt_bar_docs_are_skipped_silently(tmp_path, monkeypatch):
+    monkeypatch.setattr(brief_preflight, 'WS', tmp_path)
+    _write_bars(tmp_path, '00001', {'2026-08-20': 7.0})  # single session
+    bad = tmp_path / 'memory' / 'bars' / '00002.json'
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text('{not json', encoding='utf-8')
+    empty = tmp_path / 'memory' / 'bars' / '00003.json'
+    empty.write_text(json.dumps({'ticker': '00003', 'bars': {}}),
+                     encoding='utf-8')
+
+    moves = brief_preflight._recent_price_moves(['00001', '00002', '00003'])
+
+    assert moves == {}


### PR DESCRIPTION
## 背景

`[audit:ctx]` 切片（注入层敌意审计）：system 注入的 workspace 文件集合、context 组装函数、memory 检索调用面、各 lane 的上下文读取源选择。本 PR 修其中 ROI 最高的两处「喂错源/静默截断」；第三处（retrospective 双判词源）只立 issue 论证。

## 修复

### #962 — brief_fallback system prompt 裸字符串截断

`build_system_prompt()` 取代 `{soul[:1000]}\n\n{bootstrap[:2000]}`：

- SOUL.md 实测 2564 字符只保留 39%，切口正好丢掉 `## Operating mode (this workspace)`——"Have a view, name the trade"、"Cite numbers, not vibes"，恰好是给写简报模型准备的 disposition。
- BOOTSTRAP.md 实测 5017 字符只保留 40%，切口落在 C+.2 一行中间，整段丢失 **C. 输出约束**（postflight 会拦截的敷衍词表、禁 hedging、▎段标记）、C+.3 risk alerts 硬要求、B+ 研究生命周期。
- brief_fallback 是 cron 挂掉后唯一自动恢复路径，其输出要过 postflight 校验，但模型从未见过约 60% 的约束文本。两文件合计 ~7.6KB vs `CONTEXT_CAP=400_000`，无预算压力可言；与 #959/#961 同缺陷类，该 PR 修 JSON 投影时漏了这一层。

### #963 — `_recent_price_moves` 用 snapshots current_price 喂 price-in 判断

改读 canonical `memory/bars/{ticker}.json` 已收盘 session close 序列：

- bars.py 头注已在仓内判定 snapshot `current_price` 是 fetch vintage 而非 session identity（15 快照里 00100 该字段 7 次前收 / 3 次当日收盘 / 5 次盘中打印），`day_high/day_low` 还会跨日原样携带。
- 而 `skills/daily-deep-brief/SKILL.md:530` 规定 price-in 判断**必做**，输入正是这个数；`decision/packet.py:499` 也把它投进 sentiment 视图。错值双向皆可：假「已大涨→放弃出手」或假「没动→当新机会」。
- bars 不覆盖的名字现在返回缺失（SKILL 定义 null=无快照），绝不回退快照价；bars 由同一 preflight 的 [9] daily-bars 先行刷新，零新增请求。

## 测试

- 新增 `tests/test_brief_fallback_system_prompt.py`（3 条：两个旧切口之后的标记必须存活于 prompt、文件尾行保真、main→chat 全链路 wiring）。
- 新增 `tests/test_recent_price_moves_source.py`（4 条：bars 值优先于相异的 snapshot 序列、lookback 窗口语义、无 bars 不伪造、薄文档/坏 JSON 静默跳过）。
- 定向 26 passed。`tests/test_context_contract.py::test_every_command_the_injected_context_names_exists` 有 1 失败，已在干净 master 基线复跑确认为既有问题（TOOLS.md/MEMORY.md 引用的命令名），与本 PR 无关。

## 不动代码、仅立 issue

- #964：`compute_retrospective` 触发判词用快照 vintage 字段，与 decision_v2 的 bars 结算双轨并存——修法涉及 trigger 语义映射，超出本窗口，留 issue 论证。

Closes #962
Closes #963
