### PR TITLE
fix: messages 切片投递可靠性三修 — report_watchdog in-flight 闸、Nostr 连接失败计成功、reconcile 通道写穿 (#966 #967 #968)

### DIFF
--- a/ops/growth/nostr_publish.js
+++ b/ops/growth/nostr_publish.js
@@ -73,7 +73,27 @@ async function main() {
 
   const pool = new SimplePool();
   const results = await Promise.allSettled(pool.publish(RELAYS, evt));
-  const ok = results.filter((r) => r.status === "fulfilled").length;
+  // pool.publish RESOLVES a relay it could not even connect to, with the
+  // string "connection failure: …" (nostr-tools abstract-pool.js); only an
+  // explicit OK / rejection from a connected relay settles the promise the
+  // way its status suggests. Counting settled-fulfilled results as published
+  // therefore reported green on a day when every relay was unreachable —
+  // accepted, not confirmed, which for a broadcast is a silent drop.
+  const failed = [];
+  let ok = 0;
+  for (const r of results) {
+    if (r.status === "fulfilled" && !String(r.value ?? "").startsWith("connection failure")) {
+      ok += 1;
+    } else {
+      const why = r.status === "fulfilled"
+        ? String(r.value ?? "")
+        : String((r.reason && r.reason.message) || r.reason || "rejected");
+      failed.push(why);
+    }
+  }
+  if (failed.length) {
+    console.error(`not accepted (${failed.length}/${RELAYS.length}): ${failed.join(" | ")}`);
+  }
   console.error(`published to ${ok}/${RELAYS.length} relays`);
   console.error(`view   : https://njump.me/${nip19.neventEncode({ id: evt.id, relays: RELAYS.slice(0, 2) })}`);
   try { pool.close(RELAYS); } catch (_) { /* ignore */ }

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -510,7 +510,7 @@ def _receipt_delivered(payload):
 
 
 def _receipt_claims(path):
-    """Yield (job, slot_date_or_none, slot_or_none, delivered) for one receipt."""
+    """Yield (job, slot_date_or_none, slot_or_none, receipt) for one receipt."""
     try:
         payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
@@ -525,15 +525,20 @@ def _receipt_claims(path):
         except ValueError:
             return None
         # report-sent-{market}-{phase}-{YYYY-MM-DD}.json
-        return job, name[: -len(".json")].rsplit("-", 3)[-3:], None, delivered
+        return job, name[: -len(".json")].rsplit("-", 3)[-3:], None, payload
     if name.startswith("intraday-sent-"):
         # The intraday receipt names its own job and slot, so it needs no parsing.
         job, slot = payload.get("job"), payload.get("slot")
         if not job or not slot:
             return None
-        return job, None, slot, delivered
+        return job, None, slot, payload
     if name.startswith("brief-sent-"):
-        return job_for(brief=True), name[len("brief-sent-"): -len(".json")].split("-"), None, delivered
+        return (
+            job_for(brief=True),
+            name[len("brief-sent-"): -len(".json")].split("-"),
+            None,
+            payload,
+        )
     return None
 
 
@@ -553,8 +558,8 @@ def reconcile_delivery_receipts():
             parsed = _receipt_claims(path)
             if not parsed:
                 continue
-            job, date_parts, slot, delivered = parsed
-            claims[(job, slot, tuple(date_parts) if date_parts else None)] = delivered
+            job, date_parts, slot, receipt = parsed
+            claims[(job, slot, tuple(date_parts) if date_parts else None)] = receipt
         if not claims:
             return 0
         filled = 0
@@ -565,15 +570,26 @@ def reconcile_delivery_receipts():
                 if stage.get("status") != "unknown":
                     continue
                 job, slot = record.get("job"), record.get("slot")
-                delivered = claims.get((job, slot, None))
-                if delivered is None:
-                    delivered = claims.get((job, None, tuple(str(slot)[:10].split("-"))))
-                if delivered is None:
+                receipt = claims.get((job, slot, None))
+                if receipt is None:
+                    receipt = claims.get(
+                        (job, None, tuple(str(slot)[:10].split("-")))
+                    )
+                if receipt is None:
                     continue
+                delivered = _receipt_delivered(receipt)
+                # The receipt carries the per-channel facts (#771): write them
+                # through instead of the old constant "wechat_or_telegram",
+                # which made every reconciled slot invisible to the
+                # wechat-dropped / telegram-covered count.
+                wechat_ok = receipt.get("sent_ok") is True
+                telegram_ok = receipt.get("tg_ok") is True
                 record["stages"]["primary_delivery"] = _stage(
                     "success" if delivered else "failed",
                     at=_now().isoformat(),
-                    channel="wechat_or_telegram",
+                    channel=delivery_channel(wechat_ok, telegram_ok),
+                    wechat_ok=wechat_ok,
+                    telegram_ok=telegram_ok,
                     source="delivery_receipt",
                 )
                 record["final_product"] = _derive_final(record)

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -492,6 +492,46 @@ def cron_run_ended_in_failure(job, today, now=None):
     return False if last_status else None
 
 
+def attempt_still_running(context, last_run):
+    """Is a newer attempt in flight than the newest FINISHED run for this slot?
+
+    openclaw writes a run record only with `action: "finished"`, so an attempt
+    that is currently executing is invisible to a watchdog reading run history —
+    the newest *completed* run can be an `error` from an attempt that has
+    already been superseded. The preflight context is the signal that is already
+    on disk: it is written at the start of an attempt, so a context generated
+    AFTER the newest finished run ended means another attempt began after that
+    run and has not finished.
+
+    2026-08-11 00:00 US is the case this exists for: attempts at 00:00, 00:01:55
+    and 00:03:30 all errored, the fourth started 00:07:14 and ran 275s, and the
+    watchdog judged at 00:10:44 on attempt 3's error. It sent the deterministic
+    fallback one second before postflight delivered the real report.
+
+    Deferring is safe in one direction only, and it is the right direction: a
+    genuinely dead slot writes no newer context, so a real miss still gets its
+    backstop. Sending for work that then succeeds is a duplicate, which is what
+    this whole gate ordering exists to prevent.
+
+    Shared rather than copied on purpose: the rule was born in intraday_watchdog
+    and report_watchdog kept judging still-running slots for weeks because the
+    second mode never learned what lived in the first one's file — the exact
+    drift the same_generation_window sharing note (#458) already warned about.
+    """
+    generated_at = (context or {}).get('generated_at')
+    finished_ms = (last_run or {}).get('ts')
+    if not generated_at or not isinstance(finished_ms, (int, float)):
+        return False
+    try:
+        started = datetime.fromisoformat(generated_at)
+    except (TypeError, ValueError):
+        return False
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=HKT)
+    finished = datetime.fromtimestamp(finished_ms / 1000, HKT)
+    return started > finished
+
+
 def rerun_cron_job(job_id, dry_run=False):
     """Queue one more run of an on-host cron job. Returns (ok, tail)."""
     if dry_run:

--- a/src/clawock/harness/intraday_watchdog.py
+++ b/src/clawock/harness/intraday_watchdog.py
@@ -70,6 +70,10 @@ from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs, KCN_TELEGRAM,
     transcript_loop_score, last_report_text, send_telegram,
     same_generation_window,
+    # The in-flight gate lives beside the other shared run-record helpers; the
+    # re-export below keeps `intraday_watchdog.attempt_still_running` importable
+    # for the tests and callers that learned the rule here first.
+    attempt_still_running,
 )
 
 from clawock.automation import cron_heartbeat  # noqa: E402
@@ -172,42 +176,6 @@ def context_for_slot(path, job_name, slot):
         return None
     return context
 
-
-
-def attempt_still_running(context, last_run):
-    """Is a newer attempt in flight than the newest FINISHED run for this slot?
-
-    openclaw writes a run record only with `action: "finished"`, so an attempt
-    that is currently executing is invisible to `run_for_slot` — it returns the
-    newest *completed* run, which after a few retries can be an `error` from an
-    attempt that has already been superseded.
-
-    The preflight context is the signal that is already on disk. It is written
-    at the start of an attempt, so a context generated AFTER the newest finished
-    run ended means another attempt began after that run and has not finished.
-
-    2026-08-11 00:00 US is the case this exists for: attempts at 00:00, 00:01:55
-    and 00:03:30 all errored, the fourth started 00:07:14 and ran 275s, and the
-    watchdog judged at 00:10:44 on attempt 3's error. It sent the deterministic
-    fallback one second before postflight delivered the real report.
-
-    Deferring is safe in one direction only, and it is the right direction: a
-    genuinely dead slot writes no newer context, so a real miss still gets its
-    backstop. Sending for work that then succeeds is a duplicate, which is what
-    this whole gate ordering exists to prevent.
-    """
-    generated_at = (context or {}).get('generated_at')
-    finished_ms = (last_run or {}).get('ts')
-    if not generated_at or not isinstance(finished_ms, (int, float)):
-        return False
-    try:
-        started = datetime.fromisoformat(generated_at)
-    except (TypeError, ValueError):
-        return False
-    if started.tzinfo is None:
-        started = started.replace(tzinfo=HKT)
-    finished = datetime.fromtimestamp(finished_ms / 1000, HKT)
-    return started > finished
 
 
 def marker_covers_slot(marker, job_name, slot, raw_block_first, now_ms,

--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -50,7 +50,7 @@ from pathlib import Path
 from ._watchdog_common import (
     WS, HKT, log, find_job_id, today_runs,
     transcript_loop_score, last_report_text, send_telegram, KCN_TELEGRAM,
-    same_generation_window,
+    same_generation_window, attempt_still_running,
 )
 
 LOOP_THRESHOLD = 5                 # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
@@ -185,6 +185,22 @@ def main():
         return 0
 
     ctx_id = ctx.get('context_id')
+
+    # --- In-flight gate: never judge a slot that has not finished -------------
+    # Shared rule, born in intraday_watchdog after 2026-08-11 00:00 US: the run
+    # record only holds FINISHED attempts, so the newest completed run can be an
+    # error from an attempt a later retry has already superseded. Judging then
+    # sends the deterministic fallback while the real report is still being
+    # generated — kcn gets both, one minute apart. A context written after the
+    # newest finished run ended is the on-disk proof another attempt is live.
+    if attempt_still_running(ctx, last):
+        log({'tag': tag, 'action': 'defer',
+             'reason': 'a newer attempt is still running — preflight context '
+                       'postdates the newest finished run',
+             'context_generated_at': ctx.get('generated_at'),
+             'last_finished_ms': last.get('ts'),
+             'run_at': run_at})
+        return 0
 
     marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
     marker = None

--- a/tests/test_report_watchdog_inflight.py
+++ b/tests/test_report_watchdog_inflight.py
@@ -1,0 +1,73 @@
+"""report_watchdog must not judge a slot that has not finished running.
+
+The 2026-08-11 00:00 US incident taught intraday_watchdog this rule (attempts
+00:00 / 00:01:55 / 00:03:30 errored, the fourth started 00:07:14, and the
+watchdog sent the deterministic fallback at 00:10:44 one second before
+postflight delivered the real report). Mode 6 runs the same retry machinery —
+2026-08-03 港股开盘报告 / 港股午后快报 both auto-retried — so the same timeline
+must defer here too. The opposite direction stays pinned as well: a genuinely
+dead slot writes no newer context and still gets its backstop.
+"""
+from datetime import datetime, timedelta, timezone
+
+HKT = timezone(timedelta(hours=8))
+
+
+def _ms(hour, minute, second=0):
+    return int(datetime(2026, 8, 3, hour, minute, second,
+                        tzinfo=HKT).timestamp() * 1000)
+
+
+def test_a_retry_chain_still_running_is_deferred():
+    """Mode-6 shape of the 08-11 timeline: attempt N errored 13:05:14, the
+    retry's preflight rewrote the context at 13:07:27, watchdog due 13:45."""
+    from clawock.harness.report_watchdog import attempt_still_running
+
+    assert attempt_still_running(
+        {'generated_at': '2026-08-03T13:07:27'},
+        {'ts': _ms(13, 5, 14)})
+
+
+def test_the_slots_own_context_is_not_in_flight():
+    from clawock.harness.report_watchdog import attempt_still_running
+
+    assert not attempt_still_running(
+        {'generated_at': '2026-08-03T13:07:27'},
+        {'ts': _ms(13, 11, 48)})
+
+
+def test_a_dead_slot_is_not_deferred():
+    """Nothing started after the error → real miss → backstop must fire."""
+    from clawock.harness.report_watchdog import attempt_still_running
+
+    assert not attempt_still_running(
+        {'generated_at': '2026-08-03T13:00:13'},
+        {'ts': _ms(13, 5, 14)})
+
+
+def test_a_naive_timestamp_is_read_as_local_not_utc():
+    """report_preflight writes generated_at without an offset; reading it as
+    UTC would make every context look 8h older than its run and silently
+    disable the gate."""
+    from clawock.harness.report_watchdog import attempt_still_running
+
+    assert attempt_still_running(
+        {'generated_at': '2026-08-03T13:07:27'},
+        {'ts': _ms(13, 5, 14)})
+
+
+def test_the_gate_runs_before_any_branch_that_sends():
+    """Placement is the substance: it has to precede the delivery-evidence
+    judgment and both send branches (deterministic fallback + TG mirror),
+    because each of those can send while the slot is still running."""
+    import inspect
+
+    from clawock.harness import report_watchdog
+
+    source = inspect.getsource(report_watchdog.main)
+    defer = source.index('attempt_still_running(ctx, last)')
+    for later in ('slot_delivered(', "if not block_present or looped:",
+                  "'循环'"):
+        assert defer < source.index(later), (
+            f'the in-flight check must precede {later!r}, or the slot can '
+            'still be judged while it is running')

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -438,6 +438,11 @@ def test_a_receipt_reconciles_a_slot_whose_sender_was_killed_after_the_send(
     record = outcomes.load_ledger()["records"][0]
     assert record["stages"]["primary_delivery"]["status"] == "success"
     assert record["stages"]["primary_delivery"]["source"] == "delivery_receipt"
+    # The receipt carries the per-channel facts (#968): the reconciled stage
+    # must name them, not fold them back into "wechat_or_telegram".
+    assert record["stages"]["primary_delivery"]["channel"] == "wechat+telegram"
+    assert record["stages"]["primary_delivery"]["wechat_ok"] is True
+    assert record["stages"]["primary_delivery"]["telegram_ok"] is True
     assert record["final_product"]["status"] == "success"
 
 
@@ -452,6 +457,29 @@ def test_reconciliation_records_a_failed_send_as_failed(tmp_path, monkeypatch):
     assert outcomes.reconcile_delivery_receipts() == 1
     record = outcomes.load_ledger()["records"][0]
     assert record["stages"]["primary_delivery"]["status"] == "failed"
+
+
+def test_a_reconciled_wechat_drop_is_counted_by_the_summary(tmp_path, monkeypatch):
+    """#771's count reads wechat_ok/telegram_ok flags. A reconciled slot whose
+    receipt says WeChat failed and Telegram carried it must land in
+    `wechat_dropped_telegram_covered`, not vanish behind a constant string."""
+    from clawock.publish.outcomes import summarize_records
+
+    _isolate(tmp_path, monkeypatch)
+    tmp = _receipts(tmp_path, monkeypatch)
+    slot = "2026-07-24T13:30:00+08:00"
+    job = "港股午后快报"
+    outcomes.record_stage(job, "preflight", "success", slot=slot)
+    outcomes.record_stage(job, "llm", "success", slot=slot)
+    (tmp / "report-sent-hk-pm-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": False, "tg_ok": True, "market": "hk", "phase": "pm"})
+    )
+    assert outcomes.reconcile_delivery_receipts() == 1
+    summary = summarize_records(
+        outcomes.load_ledger()["records"], hours=36,
+        now=datetime(2026, 7, 24, 20, 0, tzinfo=outcomes.HKT),
+    )
+    assert summary["wechat_dropped_telegram_covered"] == 1
 
 
 def test_reconciliation_never_invents_a_slot_the_ledger_is_not_tracking(


### PR DESCRIPTION
## 改了什么（messages 切片对抗审计，3 项修复，对应 #966 #967 #968）

1. **report_watchdog 补 in-flight 闸 (#966)** — `attempt_still_running` 从 intraday_watchdog 上提到 `_watchdog_common.py` 共享；report_watchdog.main 在 delivery-evidence 判定与两个发送分支之前 defer「context 比最新已完成 run 新」的槽位。Mode 6 与 Mode 7 跑同一套 openclaw 重试机制，2026-08-11 US 00:00 那次「兜底比真报告早一秒、kcn 一分钟收两条」的事故在 Mode 6 同样可发生。死槽方向不 defer（不写新 context），兜底照发——detect-but-never-silence 不变。
2. **nostr_publish.js 连接失败不再计成功 (#967)** — nostr-tools 2.23.9 的 SimplePool.publish 对连不上的 relay 是 **resolve**("connection failure: …")，原代码按 settled=fulfilled 计数：4 个 relay 全不可达也打印 published 4/4 且 exit 0。现改为排除 connection failure 前缀、逐 relay 原因上 stderr、全失败 exit 1。每日 23:00 的 Rick 广播掉投不再带绿收据。
3. **reconcile_delivery_receipts 通道事实写穿 (#968)** — 回填 primary_delivery 时用 receipt 自带的 sent_ok/tg_ok 写 wechat_ok/telegram_ok + delivery_channel 四值，替换常量 "wechat_or_telegram"；回填 slot 回到 #771 wechat_dropped_telegram_covered 可数集合。

## 测试

- 新增 tests/test_report_watchdog_inflight.py（defer/不 defer/naive-tz/placement 四侧钉住）
- test_workflow_outcomes.py 增补 reconcile 通道断言 + 回填 slot 进掉投计数的端到端断言
- 针对性跑：inflight/retry-parity/slots/send-claim/delta-gate/always-full/preflight/prose/brief-watchdog/cron-runs-truth/workflow_outcomes 共 155 passed
- test_runtime_coupling_ratchet::test_the_cron_writes_moved_rather_than_vanished 在干净 origin/master 基线上同样红（既有问题，非本 PR 引入）

Closes #966, Closes #967, Closes #968
