### PR TITLE
fix: seo 切片两处真缺陷 — JSON-LD publisher logo 404 (#974)、IndexNow 每日全量重提 (#975)

### DIFF
--- a/ops/growth/indexnow_submit.py
+++ b/ops/growth/indexnow_submit.py
@@ -7,12 +7,18 @@ that are new or whose content actually changed.
 
 Google does not consume IndexNow — for Google use GSC "Request Indexing".
 
-Change detection uses each page's HTTP validator (ETag, else Last-Modified) from
-a cheap HEAD request, recorded per URL in `logs/indexnow_seen.json`
-(machine-local, gitignored). A URL-only ledger would mean an edited brief, a
-revised weekly, or a `_layouts/` change is never re-announced — silently, and
-forever. IndexNow asks publishers to submit on change, so re-POSTing unchanged
-URLs daily is equally wrong in the other direction.
+Change detection hashes each page's response body (sha256), recorded per URL
+in `logs/indexnow_seen.json` (machine-local, gitignored). A URL-only ledger
+would mean an edited brief, a revised weekly, or a `_layouts/` change is never
+re-announced — silently, and forever. IndexNow asks publishers to submit on
+change, so re-POSTing unchanged URLs daily is equally wrong in the other
+direction.
+
+Not an ETag/Last-Modified comparison: GitHub Pages rebuilds every page on each
+push to master and stamps the rebuild batch into every ETag prefix, so
+validator-based detection saw every URL as changed dozens of times a day and
+re-announced the whole sitemap daily (#975). Body hashing costs one GET per
+URL per run; that is the price of "actually changed" meaning anything.
 
 Usage:
   python3 ops/growth/indexnow_submit.py             # new + changed URLs
@@ -23,6 +29,7 @@ Usage:
 """
 import argparse
 import glob
+import hashlib
 import json
 import os
 import re
@@ -54,27 +61,28 @@ def sitemap_urls():
     return re.findall(r"<loc>([^<]+)</loc>", xml)
 
 
-def validator(url):
-    """ETag (preferred) or Last-Modified for a URL. None if unreachable — an
-    unreachable page is skipped rather than guessed at in either direction."""
-    req = urllib.request.Request(url, method="HEAD")
+def digest(url):
+    """sha256 of the response body. None if unreachable — an unreachable page
+    is skipped rather than guessed at in either direction."""
     try:
-        with urllib.request.urlopen(req, timeout=15) as r:
-            return r.headers.get("ETag") or r.headers.get("Last-Modified")
+        with urllib.request.urlopen(url, timeout=20) as r:
+            return hashlib.sha256(r.read()).hexdigest()
     except (urllib.error.URLError, OSError) as e:
-        print(f"WARN: HEAD {url} failed ({e}) — skipping this URL", file=sys.stderr)
+        print(f"WARN: GET {url} failed ({e}) — skipping this URL", file=sys.stderr)
         return None
 
 
 def load_seen():
-    """URL -> validator. A missing/corrupt ledger degrades to empty: that
-    re-submits once, which beats the cron dying on a bad file."""
+    """URL -> body digest. A missing/corrupt ledger degrades to empty: that
+    re-submits once, which beats the cron dying on a bad file. The old ETag-era
+    key ("validators") is gone by design (#975): reading it back would keep the
+    daily full-resubmit alive for one more generation."""
     try:
         with open(STATE, encoding="utf-8") as f:
             data = json.load(f)
-        seen = data["validators"]
+        seen = data["digests"]
         if not isinstance(seen, dict):
-            raise TypeError("validators is not an object")
+            raise TypeError("digests is not an object")
         return seen
     except FileNotFoundError:
         return {}
@@ -97,7 +105,7 @@ def save_seen(updates):
     tmp = f"{STATE}.{os.getpid()}.tmp"
     try:
         with open(tmp, "w", encoding="utf-8") as f:
-            json.dump({"validators": dict(sorted(merged.items()))}, f, indent=1)
+            json.dump({"digests": dict(sorted(merged.items()))}, f, indent=1)
         os.replace(tmp, STATE)
     finally:
         if os.path.exists(tmp):
@@ -105,14 +113,14 @@ def save_seen(updates):
 
 
 def select(args):
-    """Return (urls_to_submit, {url: validator} to record on success)."""
+    """Return (urls_to_submit, {url: digest} to record on success)."""
     if args.urls:
-        return args.urls, {u: v for u in args.urls if (v := validator(u))}
+        return args.urls, {u: d for u in args.urls if (d := digest(u))}
     urls = sitemap_urls()
     if not urls:
         raise SystemExit("ERROR: sitemap returned no URLs")
     seen = load_seen()
-    current = {u: v for u in urls if (v := validator(u)) is not None}
+    current = {u: d for u in urls if (d := digest(u)) is not None}
     if args.all:
         return urls, current
     changed = [u for u in urls if u in current and current[u] != seen.get(u)]
@@ -145,7 +153,7 @@ def parse_args(argv):
     p.add_argument("--all", action="store_true", help="submit every sitemap URL")
     p.add_argument("--dry-run", action="store_true", help="print, do not POST")
     p.add_argument("--record-only", action="store_true",
-                   help="record current validators without submitting "
+                   help="record current digests without submitting "
                         "(seeds the ledger after a manual backfill)")
     args = p.parse_args(argv)
     if args.urls and args.all:
@@ -156,14 +164,14 @@ def parse_args(argv):
 def main(argv=None):
     args = parse_args(sys.argv[1:] if argv is None else argv)
     # A real submission cannot possibly succeed without the public key. Resolve
-    # it before fetching the sitemap and issuing one HEAD per URL, so a deleted
+    # it before fetching the sitemap and fetching each URL body, so a deleted
     # or unpublished key fails cheaply instead of doing guaranteed-wasted work.
     # Inspection modes deliberately remain useful while the key is being fixed.
     key = None if args.record_only or args.dry_run else find_key()
     urls, record = select(args)
     if args.record_only:
         save_seen(record)
-        print(f"IndexNow — recorded {len(record)} validator(s), submitted nothing")
+        print(f"IndexNow — recorded {len(record)} digest(s), submitted nothing")
         return
     if not urls:
         print("IndexNow — nothing new or changed to submit")

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,7 +2,10 @@ title: clawock
 description: Agent-native investment decision workflows with deterministic reconciliation and a live HK + US proof
 url: https://kcnyu.github.io
 baseurl: /clawock
-logo: /clawock/assets/logo-mark.svg
+# Site-root relative on purpose: jekyll-seo-tag prepends url+baseurl itself,
+# so a baseurl-prefixed value here shipped clawock/clawock/… (404) in every
+# rendered page's JSON-LD publisher block (#974).
+logo: /assets/logo-mark.svg
 
 # SEO: jekyll-sitemap auto-generates /sitemap.xml on every build (lastmod stays fresh,
 # unlike a hand-written static file). GitHub Pages supports this plugin natively.

--- a/tests/test_indexnow_submit.py
+++ b/tests/test_indexnow_submit.py
@@ -108,3 +108,58 @@ def test_a_failed_post_does_not_record_the_urls(monkeypatch):
     with pytest.raises(RuntimeError):
         module.main([])
     assert saved == []
+
+
+# --- selection must compare page content, not per-build validators (#975) ---
+#
+# GitHub Pages rebuilds every page on each push to master and stamps the
+# rebuild batch into every ETag prefix, so the old HEAD/ETag ledger saw every
+# URL as changed dozens of times a day and re-announced the whole sitemap
+# daily. These tests pin that identical bodies are never resubmitted and only
+# real changes/new pages are.
+
+import argparse
+import hashlib
+
+
+ARGS = argparse.Namespace(urls=[], all=False)
+
+
+def test_identical_bodies_across_runs_are_not_resubmitted(monkeypatch):
+    module = _load()
+    bodies = {"https://x/a": b"same", "https://x/b": b"same"}
+    monkeypatch.setattr(module, "sitemap_urls", lambda: list(bodies))
+    monkeypatch.setattr(
+        module, "load_seen",
+        lambda: {u: hashlib.sha256(b).hexdigest() for u, b in bodies.items()})
+    monkeypatch.setattr(
+        module, "digest",
+        lambda u: hashlib.sha256(bodies[u]).hexdigest())
+    urls, record = module.select(ARGS)
+    assert urls == []
+    assert record == {}
+
+
+def test_changed_and_new_pages_are_submitted_unreachable_are_skipped(monkeypatch):
+    module = _load()
+    bodies = {"https://x/a": b"unchanged", "https://x/b": b"edited v2"}
+    seen = {"https://x/a": hashlib.sha256(b"unchanged").hexdigest(),
+            "https://x/b": hashlib.sha256(b"edited v1").hexdigest()}
+    monkeypatch.setattr(module, "sitemap_urls", lambda: list(bodies) + ["https://x/c"])
+    monkeypatch.setattr(module, "load_seen", lambda: dict(seen))
+    monkeypatch.setattr(
+        module, "digest",
+        lambda u: None if u.endswith("/c") else hashlib.sha256(bodies[u]).hexdigest())
+    urls, record = module.select(ARGS)
+    assert urls == ["https://x/b"]
+    assert record == {"https://x/b": hashlib.sha256(b"edited v2").hexdigest()}
+
+
+def test_ledger_schema_is_body_digests_not_etags(monkeypatch, tmp_path):
+    """The ETag-era ledger key must not be read back: its values change on
+    every Pages rebuild, so honoring them resurrects the daily full submit."""
+    module = _load()
+    (tmp_path / "seen.json").write_text('{"validators": {"u": "\"deadbeef-1\""}}')
+    monkeypatch.setattr(module, "STATE", str(tmp_path / "seen.json"))
+    assert module.load_seen() == {}
+

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -251,6 +251,19 @@ def test_readme_gif_stays_available_from_repository():
     ) in readme
 
 
+def test_seo_logo_resolves_once_to_a_real_asset():
+    """jekyll-seo-tag prepends url+baseurl to `logo` itself, so a baseurl-
+    prefixed value shipped clawock/clawock/… (404) in every rendered page's
+    JSON-LD publisher block (#974). The value must be site-root relative and
+    must land on an asset the Pages artifact actually ships."""
+    config = (ROOT / "site/_config.yml").read_text()
+    baseurl = re.search(r"^baseurl:\s*(\S+)", config, re.M).group(1)
+    logo = re.search(r"^logo:\s*(\S+)", config, re.M).group(1)
+    assert logo.startswith("/")
+    assert not logo.startswith(f"/{baseurl.strip('/')}")
+    assert (ROOT / "site" / logo.lstrip("/")).is_file()
+
+
 def test_site_staging_joins_owned_source_and_runtime_inputs(tmp_path):
     output = tmp_path / "site-source"
     subprocess.run(


### PR DESCRIPTION
## 背景

「seo」切片第 1 遍对抗性审计（前提现实：零外链零抓取预算，只收近零成本站内修正）。GSC API 实测：90 天 1 click / 69 impressions、仅首页收录（lastCrawl 2026-06-22）、sitemap 提交 9 天仍 pending——瓶颈确在站外，但站内仍查出两处真缺陷。

## 修复

### #974 JSON-LD publisher logo 双重 baseurl（真缺陷）
`site/_config.yml` 的 `logo:` 带了手写 `/clawock` 前缀，jekyll-seo-tag 自己再拼一次 → 线上 ~85 个渲染页的 `publisher.logo.url` 全部是 `…/clawock/clawock/assets/logo-mark.svg` = **404**（curl 已复现）。改回站点根相对路径 + 新契约测试钉住「不得含 baseurl 前缀且必须落在真实资产」。

### #975 IndexNow 每日全量重提（可靠性隐患）
变更检测用 HEAD+ETag，但 Pages 每次 master push 全量重建并把重建批次写进**所有**文件的 ETag 前缀——实测数月未改的 W21 页内容指纹段不变、前缀段天天变。结果 cron 日志里每天全量 re-POST 79→93 条，违反 IndexNow submit-on-change，docstring 声称的不变量从未成立过。改为 GET+sha256 内容指纹；ledger 键 `validators`→`digests`（旧账本按设计失效 → 一次性全量重提后自愈）。新测试：同 body 跨轮零提交 / 变更新增才提交 / 不可达跳过不入账 / ETag 账本不回读。

### #976 只记录不改
Google 发现链路现实（除首页外全站 unknown to Google）：无 API 可请求收录，唯一近零成本动作是 kcn 在 GSC UI 人工 Request indexing 三页；og:locale 与页面语言不一致属低 ROI churn，一并记录论证不做。

## 验证

- `pytest tests/test_indexnow_submit.py tests/test_pages_deployment_contract.py::test_seo_logo_resolves_once_to_a_real_asset` 全绿（11 passed）；
- `test_builder_stages_only_public_consumers` / `test_site_staging_joins_owned_source_and_runtime_inputs` 在干净 master 基线上同样红（本地缺 data-plane 的 `assets/data/overview.json`，#319），非本片引入；
- 改后脚本对线上 sitemap 实跑 `--dry-run` 通过（92 URL 枚举正常）。

Closes #974
Closes #975

_ref: [audit:seo] 第 1 遍切片审计_
