### PR TITLE
fix: geo 切片两处真缺陷 — Nostr 广播按变更发布(#978)、faq 雷达频率纠正(#979)

### DIFF
--- a/ops/growth/rick_broadcast_nostr.sh
+++ b/ops/growth/rick_broadcast_nostr.sh
@@ -24,4 +24,28 @@ NOSTR_PRIVATE_KEY="$(cat "$KEYFILE")"
 export NOSTR_PRIVATE_KEY
 
 # Generate the post from live data, then sign + publish to public relays.
-python3 ops/growth/rick_broadcast.py --lang en | node ops/growth/nostr_publish.js
+#
+# Broadcast-on-change: the scorecard text only moves when T+1 settlement moves
+# it, and reposting a byte-identical note every evening is machine spam on the
+# one channel that is fully automated (relay-verified: four consecutive days of
+# identical content in Aug 2026). Skip when the rendered text matches the last
+# SUCCESSFULLY published digest. Fail-open toward visibility: no state file or
+# an unreadable one publishes as before, and the state only advances after
+# nostr_publish.js exits 0 (a relay accepted), so a failed publish retries the
+# next night instead of eating that day's post.
+POST="$(python3 ops/growth/rick_broadcast.py --lang en)"
+DIGEST="$(printf '%s' "$POST" | sha256sum | cut -d' ' -f1)"
+STATE="$(pwd)/logs/nostr_last_post.sha256"
+
+if [[ -f "$STATE" ]] && [[ "$(cat "$STATE" 2>/dev/null)" == "$DIGEST" ]]; then
+  echo "$(date -Is) scorecard unchanged since last publish ($DIGEST) — skip duplicate"
+  exit 0
+fi
+
+if printf '%s\n' "$POST" | node ops/growth/nostr_publish.js; then
+  mkdir -p "$(dirname "$STATE")"
+  echo "$DIGEST" > "$STATE"
+else
+  echo "$(date -Is) publish failed; digest not recorded — will retry next run" >&2
+  exit 1
+fi

--- a/site/faq.md
+++ b/site/faq.md
@@ -90,8 +90,9 @@ free and open source (MIT).
 Polygon, SEC EDGAR, HKEX, Finnhub, Frankfurter, Reddit, Google News and more —
 bilingual HK + US coverage, with multi-source fallback on critical paths. The
 influencer radar scans Trump (Truth Social primary feed) and Musk (news
-aggregation) every 48 hours, links statements to your holdings, and records
-misses as well as hits.
+aggregation) twice every trading day over a rolling 48-hour lookback window
+(so weekend statements still surface before Monday's brief), links statements
+to your holdings, and records misses as well as hits.
 
 ## Why is it open source? What's the catch?
 

--- a/tests/test_intraday_provisional_setups.py
+++ b/tests/test_intraday_provisional_setups.py
@@ -13,7 +13,7 @@ two of the three rules are statements about a close, and the bar has not closed,
 so a row is a reason to look, never an entry that fired.
 """
 from pathlib import Path
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -321,8 +321,11 @@ def test_short_history_name_is_evaluated_not_reported_as_insufficient():
     no setup and no error. A mature name without a listing_date stays on the
     strict 30-bar gate (#608) and is covered in test_short_history_signals.
     """
+    # Relative to today because provisional_setups gates on date.today();
+    # a hardcoded 2026-07-10 aged out of the 45-day window (#981).
     universe = [{'label': 'SKHY', 'code': 'hkSKHY', 'region': 'US',
-                 'source_holdings': ['SKHY'], 'listing_date': '2026-07-10'}]
+                 'source_holdings': ['SKHY'],
+                 'listing_date': (date.today() - timedelta(days=10)).isoformat()}]
     out = S.provisional_setups(universe, fetch=lambda code, cnt: _flat(25, 10.0))
 
     assert out == {'rows': [], 'confirmed_at_close': False}

--- a/tests/test_rick_broadcast.py
+++ b/tests/test_rick_broadcast.py
@@ -73,3 +73,114 @@ def test_high_confidence_rate_is_active_only_and_renders_its_sample_size():
     assert s['high_conf_n'] == 1
     assert 'high-conviction active calls: 100% (n=1)' in rick_broadcast.render_en(s)
     assert '高信心主动判断:100%(n=1)' in rick_broadcast.render_zh(s)
+
+
+# ---------------------------------------------------------------------------
+# Broadcast-on-change gate (#978): the cron wrapper must not republish a
+# byte-identical note. Asserted on invocation counts of stubbed executables,
+# not on the script's text.
+# ---------------------------------------------------------------------------
+
+STUB_NODE = r'''#!/usr/bin/env bash
+echo "$@" >> "$GATE_TEST_LOG"
+if [[ -f "$GATE_TEST_NODE_FAIL" ]]; then exit 1; fi
+exit 0
+'''
+
+STUB_PY = r'''#!/usr/bin/env bash
+cat "$GATE_TEST_TEXT"
+'''
+
+
+def _run_wrapper(tmp_path, monkeypatch):
+    """Copy ops/growth/rick_broadcast_nostr.sh into a sandbox, point its two
+    host constants at the sandbox, and run it with stubbed python3/node."""
+    import os
+    import shutil
+    import subprocess
+    import textwrap
+
+    src = ROOT / 'ops' / 'growth' / 'rick_broadcast_nostr.sh'
+    script = tmp_path / 'wrapper.sh'
+    body = src.read_text(encoding='utf-8')
+    # The sandbox replaces exactly the two literals the coupling ratchet pins.
+    body = body.replace('cd /root/.openclaw/workspace', f'cd "{tmp_path}/ws"')
+    body = body.replace('KEYFILE=/root/.openclaw/nostr-rick.key',
+                        f'KEYFILE="{tmp_path}/nostr-rick.key"')
+    assert '/root/.openclaw' not in body, 'sandbox copy must not touch real host paths'
+    script.write_text(body, encoding='utf-8')
+    script.chmod(0o755)
+
+    (tmp_path / 'ws').mkdir(exist_ok=True)
+    (tmp_path / 'ws' / 'ops' / 'growth').mkdir(parents=True, exist_ok=True)
+    shutil.copy(src.parent / 'rick_broadcast.py',
+                tmp_path / 'ws' / 'ops' / 'growth' / 'rick_broadcast.py')
+    (tmp_path / 'nostr-rick.key').write_text('nsec-gate-test-only', encoding='utf-8')
+
+    log = tmp_path / 'calls.log'
+    log.write_text('', encoding='utf-8')
+    fail_flag = tmp_path / 'make-node-fail'
+    text_file = tmp_path / 'post.txt'
+    text_file.write_text('scorecard v1', encoding='utf-8')
+
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    for name, body_ in (('node', STUB_NODE), ('python3', STUB_PY)):
+        p = stubs / name
+        p.write_text(body_, encoding='utf-8')
+        p.chmod(0o755)
+
+    env = dict(os.environ)
+    env['PATH'] = f'{stubs}:{env["PATH"]}'
+    env['GATE_TEST_LOG'] = str(log)
+    env['GATE_TEST_NODE_FAIL'] = str(fail_flag)
+    env['GATE_TEST_TEXT'] = str(text_file)
+
+    def run():
+        return subprocess.run(['bash', str(script)], env=env,
+                              capture_output=True, text=True)
+
+    return run, log, fail_flag, text_file
+
+
+def test_wrapper_skips_a_byte_identical_republish_and_publishes_changes(tmp_path, monkeypatch):
+    import subprocess
+    run, log, fail_flag, text_file = _run_wrapper(tmp_path, monkeypatch)
+
+    first = run()
+    assert first.returncode == 0, first.stderr
+    assert len(log.read_text().splitlines()) == 1  # python3 + node → node called once
+
+    second = run()  # same scorecard text: the duplicate is skipped
+    assert second.returncode == 0, second.stderr
+    assert len(log.read_text().splitlines()) == 1, (
+        'an unchanged scorecard must not reach the publisher again')
+
+    text_file.write_text('scorecard v2 — settled 10 new', encoding='utf-8')
+    third = run()
+    assert third.returncode == 0, third.stderr
+    assert len(log.read_text().splitlines()) == 2, (
+        'changed scorecard text must publish')
+
+
+def test_wrapper_state_only_advances_after_a_confirmed_publish(tmp_path, monkeypatch):
+    import subprocess
+    run, log, fail_flag, text_file = _run_wrapper(tmp_path, monkeypatch)
+
+    assert run().returncode == 0
+    state = tmp_path / 'ws' / 'logs' / 'nostr_last_post.sha256'
+    digest_after_ok = state.read_text().strip()
+
+    text_file.write_text('scorecard v2', encoding='utf-8')
+    fail_flag.write_text('x', encoding='utf-8')  # relays reject everything
+    failed = run()
+    assert failed.returncode != 0
+    assert state.read_text().strip() == digest_after_ok, (
+        'a failed publish must not record its digest as published')
+
+    fail_flag.unlink()  # relays recover: the unpublished text retries next night
+    retried = run()
+    assert retried.returncode == 0, retried.stderr
+    assert len(log.read_text().splitlines()) == 3
+    assert state.read_text().strip() != digest_after_ok
+

--- a/tests/test_short_history_signals.py
+++ b/tests/test_short_history_signals.py
@@ -93,8 +93,11 @@ def test_short_history_window_is_config_driven(tmp_path, monkeypatch):
 def test_provisional_setups_fallback_only_for_new_listings(monkeypatch):
     """A 25-bar mature name (or one without a listing date) must NOT get the
     short view — it surfaces as insufficient_bars instead (#608)."""
+    # Relative to today because provisional_setups gates on date.today():
+    # a hardcoded listing_date aged out of the 45-day window on 2026-08-25
+    # and failed both suites from then on (#981).
     new_detail = {'label': 'SKHY', 'code': 'x', 'region': 'US',
-                  'listing_date': '2026-07-10'}
+                  'listing_date': (date.today() - timedelta(days=10)).isoformat()}
     mature = {'label': 'NVDA', 'code': 'y', 'region': 'US',
               'listing_date': '1999-01-22'}
     no_date = {'label': 'ZZZ', 'code': 'z', 'region': 'US'}


### PR DESCRIPTION
## geo 切片审计：两处真缺陷修复

范围：被 AI 引擎与外部读者引用的内容面（landing 事实结构 / PyPI·npm 包页 / README 可引用事实块 / Nostr 广播质量与频率）。

### Closes #978 — Nostr 每日广播逐字节重发

relay 实测（npub1uvt2…qta5v6r）：08-21→24 连续 4 天同文（sha256 `ee88d9d8`），08-13→16 又是四连，自 08-05 起每日一发。根因是记分卡只在 T+1 结算日变化，而 cron 无条件发布。

修复：`rick_broadcast_nostr.sh` 加 broadcast-on-change 闸——渲染文本 sha256 与上次**成功发布**的摘要相同即跳过；发布失败不推进状态（次日重试）；状态文件在 gitignored `logs/`，丢失则 fail-open 照发。真实增量永远发出，不是「检测降级成不发」。

测试：`tests/test_rick_broadcast.py` 新增两个行为测试（stub python3/node，断言调用次数）：同文不重发、变更才发、失败不记账、恢复后重试。HOST_OWNED_SHELL 白名单计数不变（新代码用 `$(pwd)` 不新增 runtime 字面量）。

### Closes #979 — faq.md 雷达频率事实错误

`site/faq.md` 写 "scans … every 48 hours"；实际 workflow 每 HKT 交易日跑两次（`40 21 * * 0-4` + `50 12 * * 1-5`），48 小时是回看窗口（`LOOKBACK_HOURS=48`）。FAQ 自 #577 诞生即错（把窗口常数误读为频率）。已改为 "twice every trading day over a rolling 48-hour lookback window (so weekend statements still surface before Monday's brief)"，保留 Trump/Musk 数据源标注。

### 审计中核查且无需改动

- PyPI 元数据与 registry 同步（0.1.8，README 全文渲染 39KB，Changelog/Evidence URL 齐）；
- 记分卡数字口径诚实：episode_representatives 只取已结算 episode，主动/被动不排名；
- landing 页静态面（noscript/JSON-LD/og）与 evidence.md（产物生成、带时间戳）无手写过期数字；
- readme 切片 #970-972 修复在本基线上完好（回归排查通过）。

### 仅记录

- npm `clawock-dsh` repo@0.1.9 vs registry latest 0.1.8：含 08-23 的 npm 元数据搜索优化 (#840) 尚未随下一个 tag 发布，正常发布流程状态，kcn 下次打 tag 时自然带出。

### 测试

- 定向：`test_rick_broadcast.py` 5 passed、`test_runtime_coupling_ratchet.py` ratchet 7 passed（`test_the_cron_writes_moved…` 与 `test_pages_deployment_contract` 两例在本机干净 master 基线同样红：host 解析出的 OPENCLAW_BIN 与本地缺 data-plane 载荷，非本片引入，CI 上 master 绿）。

### Closes #981 — 拆除 validate 定时炸弹（合并闸解堵，基线预红）

第二轮 CI 起两个 short-history 测试在 validate 转红；干净 origin/master 基线本地复现同样两红——`provisional_setups` 用 `date.today()` 做 ≤45 天新上市判定，而 fixture 写死 `listing_date='2026-07-10'`，08-25 恰好是第 46 天。这不是本 PR 引入的，但它堵死全仓必需检查。fixture 改为相对今天回推 10 天，断言不变、永不再到期。同文件固定 run 日期的边界测试不受影响。
