### PR TITLE
fix: business P2 两处 — evidence 页解锁口径对齐 #935 usable 闸(#982)、early_trend 清掉最后一处 #666 or-默认(#983)

### DIFF
--- a/src/clawock/decision/early_trend.py
+++ b/src/clawock/decision/early_trend.py
@@ -28,7 +28,11 @@ def classify(technical: dict, peer: dict, information: dict, events: list[dict],
     dispersion = _number(peer.get("dispersion_5d"))
     peers = int(peer.get("available_peer_count") or 0)
     market_policy = (policy.get("markets") or {}).get(str(market).upper()) or {}
-    multiple = _number(policy.get("early_peer_dispersion_multiple")) or 1.5
+    # #666: explicit None check — `early_peer_dispersion_multiple: 0` is legal
+    # config (any positive residual counts as leadership) and must not be
+    # swallowed into the default, same discipline as the keys below.
+    raw_multiple = policy.get("early_peer_dispersion_multiple")
+    multiple = float(raw_multiple) if raw_multiple is not None else 1.5
     # #666: explicit None checks, never `X or DEFAULT` — a config value of 0
     # (e.g. `minimum_peer_count: 0` = 不设同行样本下限) is legal and must not
     # be swallowed into the default.

--- a/src/clawock/evidence/build_evidence.py
+++ b/src/clawock/evidence/build_evidence.py
@@ -123,8 +123,12 @@ def factor_section() -> dict | None:
         single_cluster = (stats.get('n_tickers') or 0) < 2 or (stats.get('n_dates') or 0) < 2
         if single_cluster:
             verdict_text = '⚪ 样本只覆盖单一簇，算不出聚类 CI —— 无法解读'
-        elif stats.get('edge_significant'):
+        elif stats.get('sample_sufficient') is False:
+            verdict_text = '⚪ 样本不足 MIN_N，方向结论不入决策（#934）'
+        elif stats.get('usable'):
             verdict_text = '✅ 可入决策'
+        elif stats.get('reverse_edge_significant'):
+            verdict_text = '↩️ 反向聚类 CI 显著：仅允许反向解读，不入正向决策（#935）'
         else:
             verdict_text = '⚪ CI 跨 50%，锁定'
         rows.append((
@@ -133,13 +137,18 @@ def factor_section() -> dict | None:
             f"CI95 {'—' if not ci else f'[{ci[0] * 100:.1f}%, {ci[1] * 100:.1f}%]'} · "
             f"n={stats.get('n_events')}（{stats.get('n_dates')} 日 × {stats.get('n_tickers')} 标的）· "
             f"{verdict_text}"))
-    unlocked = sum(1 for s in factors.values() if s.get('edge_significant'))
+    # #935 made `usable` (sample floor first, then clustered-CI direction) the
+    # only decision-grade gate; `edge_significant` ignores the sample floor, so
+    # an n<4..19 factor with a clean CI would render as unlocked — the exact
+    # overestimate this page exists to prevent.
+    unlocked = sum(1 for s in factors.values() if s.get('usable'))
     return {
         'title': '量化因子 edge',
         'verdict': VERDICT['passed'] if unlocked else VERDICT['undecided'],
         'rows': rows,
         'reading': (
-            f"解锁规则是 `{review.get('unlock_rule')}`：置信区间必须整体落在 50% 一侧。"
+            f"解锁规则是 `{review.get('unlock_rule')}`：先过样本闸（MIN_N，#934），"
+            f"置信区间还必须整体落在 50% 一侧。"
             f"目前 {unlocked}/{len(factors)} 个因子达标。"
             f"**CI 跨 50% 是「样本还不够」，不是「因子无效」**——两者的处置相同（不入决策），"
             f"结论不同。"),

--- a/tests/test_build_evidence.py
+++ b/tests/test_build_evidence.py
@@ -188,3 +188,77 @@ def test_a_single_cluster_sample_is_labelled_instead_of_showing_a_bare_rate(
 
     assert "单一簇" in row
     assert "锁定" not in row, "a single-cluster sample is not the same as a CI that straddles 50%"
+
+
+def test_small_sample_ci_clearing_50pct_is_never_a_decision_grade_pass(
+        tmp_path, monkeypatch):
+    """#935 made the sample floor the first gate: an n<MIN_N factor whose
+    clustered CI clears 50% is noise, whatever edge_significant claims. The
+    evidence page must not render it as unlocked (#982)."""
+    monkeypatch.setattr(ev, "DATA", tmp_path)
+    (tmp_path / "quant_signal_review.json").write_text(json.dumps({
+        "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
+        "days_logged": 12,
+        "factors": {"tiny": {"hit_rate": 0.75, "ci95": [0.60, 0.90],
+                             "n_events": 4, "n_dates": 2, "n_tickers": 2,
+                             "edge_significant": True,
+                             "sample_sufficient": False, "min_n": 20,
+                             "usable": False}},
+    }))
+
+    section = ev.factor_section()
+
+    assert section["verdict"] == ev.VERDICT["undecided"]
+    assert section["verdict"] != ev.VERDICT["passed"]
+    row = section["rows"][0][1]
+    assert "可入决策" not in row
+    assert "样本不足" in row
+
+
+def test_unlock_count_and_verdict_follow_the_usable_gate(tmp_path, monkeypatch):
+    """unlocked/passed are keyed on #935's usable gate (#982): edge_significant
+    alone ignores the sample floor and would count a 4-event factor."""
+    monkeypatch.setattr(ev, "DATA", tmp_path)
+    (tmp_path / "quant_signal_review.json").write_text(json.dumps({
+        "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
+        "days_logged": 40,
+        "factors": {
+            "real_edge": {"hit_rate": 0.62, "ci95": [0.55, 0.70],
+                          "n_events": 120, "n_dates": 30, "n_tickers": 8,
+                          "edge_significant": True,
+                          "sample_sufficient": True, "usable": True},
+            "tiny": {"hit_rate": 0.75, "ci95": [0.60, 0.90],
+                     "n_events": 4, "n_dates": 2, "n_tickers": 2,
+                     "edge_significant": True,
+                     "sample_sufficient": False, "usable": False},
+        },
+    }))
+
+    section = ev.factor_section()
+
+    assert section["verdict"] == ev.VERDICT["passed"]
+    assert section["reading"].startswith(
+        "解锁规则是 `cluster_ci_entirely_above_or_below_50pct`")
+    assert any("✅ 可入决策" in text for _, text in section["rows"])
+    assert any("样本不足" in text for _, text in section["rows"])
+
+
+def test_reverse_only_factor_reads_as_reverse_not_straddling(
+        tmp_path, monkeypatch):
+    """A reverse-significant CI is a different verdict from a straddling one;
+    conflating them hides the only reading the data actually supports (#982)."""
+    monkeypatch.setattr(ev, "DATA", tmp_path)
+    (tmp_path / "quant_signal_review.json").write_text(json.dumps({
+        "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
+        "days_logged": 40,
+        "factors": {"inverted": {"hit_rate": 0.30, "ci95": [0.15, 0.42],
+                                 "n_events": 80, "n_dates": 25,
+                                 "n_tickers": 6, "edge_significant": False,
+                                 "reverse_edge_significant": True,
+                                 "sample_sufficient": True, "usable": False}},
+    }))
+
+    row = ev.factor_section()["rows"][0][1]
+
+    assert "反向" in row
+    assert "锁定" not in row

--- a/tests/test_early_trend.py
+++ b/tests/test_early_trend.py
@@ -114,3 +114,38 @@ def test_leveraged_candidate_never_gets_unvalidated_exploration():
     assert candidate["observed"] is True
     assert candidate["exploration_ready"] is False
     assert "leveraged_requires_validated_evidence" in candidate["blockers"]
+
+
+def test_peer_dispersion_multiple_zero_is_not_swallowed_into_default():
+    """#666: `early_peer_dispersion_multiple: 0` means any positive residual
+    counts as peer leadership; `X or DEFAULT` would silently restore 1.5."""
+    candidate = early_trend.classify(
+        {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},
+        {"residual_5d": .01, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {}, [], leveraged=False,
+        policy=dict(POLICY, early_peer_dispersion_multiple=0), market="US",
+    )
+
+    assert candidate["observed"] is True
+    assert "no_short_peer_leadership" not in candidate["blockers"]
+
+
+def test_missing_dispersion_multiple_still_defaults_to_one_point_five():
+    policy = {k: v for k, v in POLICY.items()
+              if k != "early_peer_dispersion_multiple"}
+    weak = early_trend.classify(
+        {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},
+        {"residual_5d": .04, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {}, [], leveraged=False, policy=policy, market="US",
+    )
+    strong = early_trend.classify(
+        {"usable": True, "close": 11, "prior_20d_high": 10, "zscore20": 1},
+        {"residual_5d": .2, "dispersion_5d": .05,
+         "available_peer_count": 4},
+        {}, [], leveraged=False, policy=policy, market="US",
+    )
+
+    assert weak["observed"] is False, "0.8x residual must stay below the 1.5 default"
+    assert strong["observed"] is True, "4x residual clears the 1.5 default"


### PR DESCRIPTION
business 切片第 2 遍对抗性审计（敌意对象=上一轮修复本身）。本轮两处修复均为上一轮的遗留面：

## #982 — evidence 页因子解锁口径未对齐 #935 usable 闸

- #935 把 signal_review 的权威解锁闸改为 `usable`（样本闸 MIN_N=20 先行 → 聚类 CI 原向），反向显著仅 display-only；但消费端 `build_evidence.factor_section` 仍用旧键 `edge_significant` 判「✅ 可入决策」并计 `unlocked`/`passed`。
- `clustered_ci` 只需 ≥2 date × ≥2 ticker 即可出区间，n 低至 4 也可能 CI 整体过 50% —— 小样本假解锁正是 #934/#935 要消灭的偏向，从展示端又漏回来。#950 提交信息已点名此 P2 未修。
- 修：verdict 分支按 single_cluster → 样本不足 → usable → 反向显著 → straddle 排序；unlocked/passed 改按 `usable` 键；反向显著有独立文案不再误标「CI 跨 50%，锁定」。旧 artifact 无新字段时行为不变（落回原分支），既有两个用例不改一字仍绿。

## #983 — early_trend 最后一处 #666 反模式

- `_number(policy.get("early_peer_dispersion_multiple")) or 1.5` 把合法配置 0 吞进默认值；同文件 minimum_peer_count / exploration_tranche_pct 两处早已按 #666 改为显式 None 检查并写明理由，此处是最后一个残留。改为显式 None 检查。

## 测试

- test_build_evidence.py +3（小样本 CI 过线不得渲染为可入决策 / unlocked 计数与 verdict 按 usable 键 / 反向显著独立文案）
- test_early_trend.py +2（multiple=0 不被吞、键缺省默认仍 1.5：0.8x 拒绝、4x 通过）
- 本地：18 passed + 相邻 test_quant_signal_review.py 16 passed；全量由 CI 把关。

Closes #982
Closes #983
