### PR TITLE
fix: #948 同类漏网三处 — plan-actions 决策字段、fed_press 外部文本+href、movers 持仓名转义(#985 #986) [audit:dashboard]

### DIFF
--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1229,8 +1229,8 @@
       const note = m.note ? `<div class="mover-note">${escLLM(m.note)}</div>` : "";
       return `
         <div class="mover-card ${dir}${m.note ? ' has-note' : ''}">
-          <div class="tk">${m.ticker || DASH}</div>
-          <div class="nm">${m.name || ""}</div>
+          <div class="tk">${escapeHtml(m.ticker || DASH)}</div>
+          <div class="nm">${escapeHtml(m.name || "")}</div>
           <div class="pct ${pnlClass(p)}">${fmtPct(p, 2)}</div>
           <div class="px">${fmtMoney(m.current_price, ccy)}</div>
           ${note}
@@ -1469,11 +1469,19 @@
       const fedDiv = document.createElement('div');
       fedDiv.className = 'fed-latest';
       fedDiv.style.cssText = 'margin-top:8px;padding: var(--space-2) var(--space-3);background:var(--card-2);border-radius:var(--radius-sm);font-size:var(--fs-xs);border-left:3px solid var(--accent-2);';
-      const rows = m.fed_press.slice(0, 3).map(p =>
-        `<div style="margin:3px 0;">
-          <span style="color:var(--text-dim);font-size:var(--fs-micro);margin-right:8px;">${p.date}</span>
-          <a href="${p.url}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none;">${(p.title || '').substring(0, 130)}</a>
-        </div>`).join('');
+      const rows = m.fed_press.slice(0, 3).map(p => {
+        // Fed RSS 的 title/link 是外部 XML 原文：文本完整转义；href 只接受
+        // https —— escapeHtml 防属性逃逸，但不防 javascript: scheme。
+        const safeUrl = /^https:\/\//i.test(p.url || '') ? escapeHtml(p.url) : null;
+        const title = escapeHtml((p.title || '').substring(0, 130));
+        const link = safeUrl
+          ? `<a href="${safeUrl}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none;">${title}</a>`
+          : title;
+        return `<div style="margin:3px 0;">
+          <span style="color:var(--text-dim);font-size:var(--fs-micro);margin-right:8px;">${escapeHtml(p.date)}</span>
+          ${link}
+        </div>`;
+      }).join('');
       fedDiv.innerHTML = `<div style="color:var(--text-dim);font-size:var(--fs-micro);margin-bottom:2px;">Fed press · past 7d</div>${rows}`;
       wrap.appendChild(fedDiv);
     }
@@ -2767,12 +2775,12 @@
       return `
         <div class="plan-action">
           <div>
-            <div class="tk">${a.ticker || DASH}</div>
-            <div class="date">${a.date || ""}</div>
+            <div class="tk">${escapeHtml(a.ticker || DASH)}</div>
+            <div class="date">${escapeHtml(a.date || "")}</div>
           </div>
           <div>
-            <div>${a.action || DASH}${bucketWinBadge(a.action)}${driverChip(a.driven_by)}</div>
-            <div class="meta">${a.strategy_id || DASH} · conf ${conf} · ${cond.type || DASH} · 方向分 ${pnl}</div>
+            <div>${escapeHtml(a.action || DASH)}${bucketWinBadge(a.action)}${driverChip(a.driven_by)}</div>
+            <div class="meta">${escapeHtml(a.strategy_id || DASH)} · conf ${conf} · ${escapeHtml(cond.type || DASH)} · 方向分 ${pnl}</div>
           </div>
           <div class="outcome ${oc}">${oc}</div>
         </div>

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,16 +1,18 @@
 """Free text from sidecars / external sources may only reach innerHTML escaped.
 
 The page's own convention: LLM narrative goes through `escLLM`, every other
-sidecar string through `escapeHtml`. Four market-tab cards predate that
-convention and interpolated brief-context / RSS-sourced strings raw (#948) —
-`innerHTML` executes event-attribute payloads (`<img onerror=…>`) even though it
-never executes `<script>`, so the gap is a real injection class, not style.
+sidecar string through `escapeHtml`. Several cards predated that convention
+and interpolated brief-context / ledger / RSS-sourced strings raw (#948 fixed
+four market-tab cards; #985/#986 cover the plan-tab and macro/mover stragglers
+the first sweep missed) — `innerHTML` executes event-attribute payloads
+(`<img onerror=…>`) even though it never executes `<script>`, so the gap is a
+real injection class, not style.
 
 Sections are sliced out of the source the same way
 test_dashboard_bundle_parity.py finds top-level functions: two-space indented
 declarations, closed by a lone `  }`. Source assertions rather than a browser
 run because the invariant is about what the template interpolates; the runtime
-cost of booting the whole spec for four greps is not justified.
+cost of booting the whole spec for these greps is not justified.
 """
 import re
 from pathlib import Path
@@ -54,3 +56,43 @@ def test_sidecar_free_text_never_reaches_innerhtml_raw():
     assert "escapeHtml(t.ticker)" in sentiment
     # risk keyword banner reads the same sidecar.
     assert "escapeHtml(h.ticker)" in risk_banner
+
+
+def test_plan_action_ledger_fields_never_reach_innerhtml_raw():
+    """recent_decisions is the agent-written decisions.jsonl verbatim; the peer
+    plan-timeline card escapes every one of these fields already (#985)."""
+    actions = _function_body("renderPlanActions")
+    for snippet in (
+        "escapeHtml(a.ticker || DASH)",
+        'escapeHtml(a.date || "")',
+        "escapeHtml(a.action || DASH)",
+        "escapeHtml(a.strategy_id || DASH)",
+        "escapeHtml(cond.type || DASH)",
+    ):
+        assert snippet in actions, f"missing escaped interpolation: {snippet}"
+    for field in ("a.ticker", "a.date", "a.action", "a.strategy_id", "cond.type"):
+        assert "${%s" % field not in actions, (
+            f"{field} reaches innerHTML unescaped")
+
+
+def test_fed_press_external_text_is_escaped_and_https_only():
+    """fed_press titles/links are raw federalreserve.gov RSS XML; the influencer
+    feed already escapes its external hrefs. escapeHtml stops attribute escape
+    but not javascript: URLs, so the anchor itself is https-gated (#986)."""
+    macro = _function_body("renderMacro")
+    assert "escapeHtml(p.date)" in macro
+    assert "escapeHtml((p.title || '').substring(0, 130))" in macro
+    assert "/^https:\\/\\//i.test(p.url || '')" in macro
+    assert '${p.url}' not in macro
+    assert '${p.title' not in macro
+    assert '${p.date}' not in macro
+
+
+def test_mover_provider_fields_never_reach_innerhtml_raw():
+    """movers ticker/name come from provider-sourced holdings (trim_holding);
+    hero.js escapes the same ticker, so render.js must not diverge (#986)."""
+    movers = _function_body("renderMovers")
+    assert "escapeHtml(m.ticker || DASH)" in movers
+    assert 'escapeHtml(m.name || "")' in movers
+    assert "${m.ticker" not in movers
+    assert "${m.name" not in movers


### PR DESCRIPTION
## 背景

P2 dashboard 切片是对上一轮审计修复（83845a56 / #949）的对抗复审。结论：那轮修复
本身方向正确、测试钉得住，但它只修了 market tab 四张卡，没有扫全文件的同信任级
插值点 —— 本轮找到三处同级漏网并全部补齐。

## 改动

- #985 renderPlanActions：agent 写的 decisions.jsonl 字段（a.ticker / a.date /
  a.action / a.strategy_id / cond.type）裸插 innerHTML；同文件决策轨迹卡
  renderPlanTimeline 对同一批字段全转义（双标即证据）。五个插值点改经 escapeHtml。
- #986 fed_press：Fed RSS 外部 title 裸插、url 裸进 href 属性。文本改经
  escapeHtml；escapeHtml 不防 javascript: scheme，anchor 加 https 前缀闸，
  非 https 退化为纯文本（对齐 influencer feed :1315 的外部 href 约定并堵上残留）。
- #986 renderMovers：provider 来源的 m.ticker/m.name 裸插，同模板 m.note 却走
  escLLM、hero.js:307 对同一 ticker 转义。两处改经 escapeHtml。

## 测试

tests/test_dashboard_security.py 沿用既有 _function_body 分节切割法补三个钉子，
含「不得退回裸 ${field}」反向断言：
- 红→绿：stash 掉修复后 3 failed / 1 passed，恢复后全绿；
- pytest security+parity → 7 passed；
- fetch_data_plane.py 后 node tests/dashboard_tab_runtime_spec.js → exit 0。

## 复审过但未改的（记录）

- risk banner `${k}`、driverChip `${d}`：值域被代码内 literal 表约束（KWS 表 /
  DRIVER_META 查表命中才渲染），今天不可注入；若未来改成动态表会变洞。
- parity 棘轮的 const 双份盲区（MARKET_INDICES/DATA_FILE_CN/dataFileCn 两 bundle
  各一份）：现状逐字节一致，P1 已记录，不翻案。
- perf 修复 b471c8de（首屏 overview 提前起跑 + repository_only 真闸）：adversarial
  复查通过 —— adoption 句柄一次性消费、失败回退原 fetch 契约不变、runtime spec
  新增两次请求数断言是行为钉子；prepare_pages_artifact 的 fnmatch 与 glob 语义差
  （`*` 跨目录）当前配置下不可达。
- escapeHtml 属性上下文安全性核实：core.js:58 转义 `"` 和 `'`，title/href 属性
  插值点全部安全。
- 决策轨迹卡渲染路径（renderPlanTimeline）：转义完整，fmtTriggerPrice 非数字路径
  也经 escapeHtml(trig) 兜住。

Closes #985

Closes #986
