### PR TITLE
fix: 夜班审计批复审两处真缺陷 — watchdog 兜底被 defer 静默吃掉(#988)、news payload 预算不是上界(#989)

### DIFF
--- a/ops/pages/prepare_pages_artifact.py
+++ b/ops/pages/prepare_pages_artifact.py
@@ -107,8 +107,8 @@ def prepare(
                 continue
             source.resolve().relative_to(site_dir)
             relative = source.relative_to(site_dir)
-            if any(fnmatch.fnmatch(relative.as_posix(), pattern)
-                   for pattern in repository_only):
+            if any(fnmatch.fnmatch(relative.as_posix(), blocked)
+                   for blocked in repository_only):
                 skipped.append(relative.as_posix())
                 continue
             destination = output_dir / relative

--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -38,8 +38,14 @@ def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
     """Whole-ticker projection of the fetched news under a serialized budget.
 
     Inclusion order follows `raw` so earlier (portfolio-order) tickers win
-    contention. The `_omitted_tickers` manifest is sized into the budget from
-    the start so adding it can never push the payload back over budget.
+    contention. The `_omitted_tickers` manifest rides inside the payload, so it
+    is reserved before the first ticker AND reconciled after the last: a long
+    omission list grows the manifest past its empty-list reservation, which is
+    how 288 omissions pushed a 25,000-char budget to 26,602 (#989). The
+    reconciliation demotes whole tickers from the tail of the included set —
+    never a slice — until the serialized payload really fits. The one case that
+    still exceeds `budget` is a manifest that alone is bigger than it: naming
+    what was dropped is the honesty record, so it is kept whole rather than cut.
     """
     def compact(value):
         return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
@@ -55,6 +61,15 @@ def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
         else:
             omitted.append(ticker)
     if omitted:
+        included['_omitted_tickers'] = omitted
+    # Demote from the tail so the surviving set stays a prefix of `raw` and the
+    # manifest stays in input order: a demoted ticker precedes every ticker the
+    # greedy pass had already skipped.
+    tail = [ticker for ticker in raw if ticker in included]
+    while tail and len(compact(included)) > budget:
+        ticker = tail.pop()
+        del included[ticker]
+        omitted.insert(0, ticker)
         included['_omitted_tickers'] = omitted
     return included
 

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -44,10 +44,20 @@ DECISION_PROMPT_DROP_FIELDS = ('signal_provenance',)
 HOLDING_PROMPT_FIELDS = ('ticker', 'name', 'current_value',
                          'pnl_percent', 'today_change_pct')
 
-# Top-level sections that may be omitted WHOLE, largest first, when the
-# projected payload still exceeds the budget. Everything else — window,
-# bundle_evidence, decision_episodes, current_risk, input_warnings — is small
-# and load-bearing for specific questions, so it is never dropped.
+# Top-level sections that may be omitted WHOLE when the projected payload still
+# exceeds the budget, IN THE ORDER THEY ARE SACRIFICED. Everything else —
+# window, bundle_evidence, decision_episodes, current_risk, input_warnings — is
+# small and load-bearing for a specific question, so it is never dropped.
+#
+# ORDER IS BY PURPOSE, NOT BY SIZE (#991). This used to drop the largest section
+# first. On 2026-W30 data that drops plans (83,809 chars) and would take
+# decision_metrics (32,380) next, ahead of snapshots (19,368) — question 2's
+# distilled per-strategy win/loss sacrificed to keep the raw daily book
+# composition, purely because that section happened to be bigger. `plans` is the
+# daily raw view of decisions that decision_episodes and decision_metrics already
+# distill, so it goes first; `snapshots` is book composition, which only question
+# 1's attribution touches; `decision_metrics` is question 2's answer and goes
+# last, only when dropping the other two was not enough.
 OMITTABLE_SECTIONS = ('plans', 'snapshots', 'decision_metrics')
 
 
@@ -289,7 +299,8 @@ def build_prompt_payload(bundle, budget=PROMPT_BUDGET_CHARS):
        this takes the bundle from 702K to 145–280K characters depending on how
        decision-heavy the week was.
     2. Whole-value omission — if the projected payload still exceeds `budget`,
-       drop entire sections largest-first from OMITTABLE_SECTIONS and declare
+       drop entire sections in OMITTABLE_SECTIONS order — by what each question
+       still needs, never by which happens to be biggest (#991) — and declare
        each in a top-level `_omitted` manifest that rides inside the payload,
        so the model is told about the gap instead of silently reading a sliced
        half-JSON. On heavy weeks this drops `plans` first, which is deliberate:
@@ -313,19 +324,17 @@ def build_prompt_payload(bundle, budget=PROMPT_BUDGET_CHARS):
 
     omitted = []
     while True:
-        # The manifest is part of the payload, so it is re-attached every pass:
-        # dropping a section may let a smaller one survive, and the final
-        # manifest must name exactly what is missing from this payload.
+        # The manifest is part of the payload and grows with every drop, so it
+        # is re-attached and re-measured each pass: the budget check must see
+        # the payload as it will actually be serialized, manifest included.
         payload['_omitted'] = omitted
         if len(_compact(payload)) <= budget:
             break
-        sizes = [(len(_compact(payload[name])), name)
-                 for name in OMITTABLE_SECTIONS if name in payload]
-        if not sizes:
+        name = next((s for s in OMITTABLE_SECTIONS if s in payload), None)
+        if name is None:
             break  # nothing omittable left: stay honest rather than slice
-        size, name = max(sizes)
-        payload.pop(name)
-        omitted.append({'section': name, 'bytes': size})
+        omitted.append({'section': name,
+                        'bytes': len(_compact(payload.pop(name)))})
     return payload
 
 

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -518,7 +518,9 @@ def _receipt_claims(path):
     if not isinstance(payload, dict):
         return None
     name = path.name
-    delivered = _receipt_delivered(payload)
+    # The whole receipt travels, not a pre-computed verdict: the caller needs
+    # the per-channel flags too (#968), and `_receipt_delivered` is applied at
+    # the point of use.
     if name.startswith("report-sent-"):
         try:
             job = job_for(payload.get("market"), payload.get("phase"))

--- a/src/clawock/harness/report_watchdog.py
+++ b/src/clawock/harness/report_watchdog.py
@@ -44,6 +44,7 @@ Exit 0 always (non-fatal cron); actions logged to logs/watchdog.jsonl.
 import argparse
 import json
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -54,6 +55,13 @@ from ._watchdog_common import (
 )
 
 LOOP_THRESHOLD = 5                 # transcript loop_score ≥ this ⇒ mimo repeat-loop ⇒ garbage
+# How long an in-flight attempt may hold this watchdog before it judges anyway.
+# 600s covers the measured single-attempt distribution with room to spare
+# (median 196s, p90 354s, max 576s across the six report jobs, last 50 runs each)
+# — see #988. Unlike intraday_watchdog, this one runs ONCE per slot, so the wait
+# is what replaces "the next pass will look again".
+INFLIGHT_WAIT_S = 600
+INFLIGHT_POLL_S = 30
 MARKER_FRESH_MS = 120 * 60 * 1000  # postflight send-marker older than this ⇒ treat as not-this-slot
 REGEN_WINDOW_S = 30 * 60           # context rebuilt within this of the delivered one ⇒ same slot
 REGEN_BACKWARD_S = 60              # tolerance for a context timestamped just before the marker's
@@ -136,13 +144,26 @@ def wechat_gap_reason(claim):
     return None
 
 
+def _read_json(path):
+    """Best-effort JSON read — a missing or half-written file reads as {}."""
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--market', choices=['hk', 'us'], required=True)
     ap.add_argument('--phase', choices=['open', 'mid', 'pm', 'close'], required=True)
     ap.add_argument('--job-name', required=True, help='cron job name to inspect')
     ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--inflight-wait-s', type=int, default=None,
+                    help='seconds to wait out an in-flight attempt before judging '
+                         f'anyway (default {INFLIGHT_WAIT_S}; 0 in --dry-run)')
     args = ap.parse_args()
+    inflight_wait_s = (args.inflight_wait_s if args.inflight_wait_s is not None
+                       else (0 if args.dry_run else INFLIGHT_WAIT_S))
 
     today = datetime.now(HKT).strftime('%Y-%m-%d')
     tag = f'{args.market}-{args.phase}'
@@ -173,18 +194,12 @@ def main():
     ctx_path = WS / 'memory' / '.tmp' / f'report-context-{args.market}-{args.phase}-{today}.json'
     # One read, one generation: a cron retry rewrites this file mid-flight, so
     # re-reading it per field could mix two generations' block and id.
-    ctx = {}
-    try:
-        ctx = json.loads(ctx_path.read_text())
-    except Exception:
-        ctx = {}
+    ctx = _read_json(ctx_path)
     raw_block = (ctx.get('raw_wechat_block') or '').strip()
     raw_block_first = raw_block.splitlines()[0] if raw_block else None
     if not raw_block_first:
         log({'tag': tag, 'action': 'skip', 'reason': 'no preflight raw_wechat_block (cron likely never ran)'})
         return 0
-
-    ctx_id = ctx.get('context_id')
 
     # --- In-flight gate: never judge a slot that has not finished -------------
     # Shared rule, born in intraday_watchdog after 2026-08-11 00:00 US: the run
@@ -193,14 +208,59 @@ def main():
     # sends the deterministic fallback while the real report is still being
     # generated — kcn gets both, one minute apart. A context written after the
     # newest finished run ended is the on-disk proof another attempt is live.
-    if attempt_still_running(ctx, last):
-        log({'tag': tag, 'action': 'defer',
+    #
+    # WAIT, DON'T DEFER (#988). intraday_watchdog can simply return: it runs at
+    # :10 and :40 all session, so deferring means "the next pass looks again".
+    # This watchdog is a single crontab line per slot — returning here IS the
+    # verdict, and a retry chain that never delivers would leave kcn with no
+    # report and no backstop, with one `defer` line as the only trace. So hold
+    # the slot open instead: poll until the attempt finishes (then judge on ITS
+    # run record and context), or until the budget runs out (then judge anyway
+    # and say so). The marker gate below still runs first either way, so an
+    # attempt that lands during the wait is recognised as delivered, not doubled.
+    waited = 0
+    while attempt_still_running(ctx, last) and waited < inflight_wait_s:
+        log({'tag': tag, 'action': 'wait-inflight',
              'reason': 'a newer attempt is still running — preflight context '
                        'postdates the newest finished run',
              'context_generated_at': ctx.get('generated_at'),
              'last_finished_ms': last.get('ts'),
+             'waited_s': waited, 'budget_s': inflight_wait_s,
              'run_at': run_at})
-        return 0
+        time.sleep(min(INFLIGHT_POLL_S, inflight_wait_s - waited))
+        waited += INFLIGHT_POLL_S
+        runs_today = today_runs(job_id) or runs_today
+        last = runs_today[-1]
+        ctx = _read_json(ctx_path)
+    if waited:
+        # Whatever the wait produced, the slot's facts moved: re-derive every
+        # field taken from `last` or `ctx` above before judging on them.
+        run_at = last.get('runAtMs')
+        session_id = last.get('sessionId')
+        summary = last.get('summary', '')
+        flag = WS / 'memory' / '.tmp' / f'watchdog-{tag}-{run_at}.done'
+        if flag.exists():
+            log({'tag': tag, 'action': 'skip',
+                 'reason': 'already handled this slot (dedupe flag, after wait)'})
+            return 0
+        raw_block = (ctx.get('raw_wechat_block') or '').strip()
+        raw_block_first = raw_block.splitlines()[0] if raw_block else None
+        if not raw_block_first:
+            log({'tag': tag, 'action': 'skip',
+                 'reason': 'no preflight raw_wechat_block after wait'})
+            return 0
+        still_running = attempt_still_running(ctx, last)
+        log({'tag': tag,
+             # Never `defer` again: this line always precedes a real verdict.
+             'action': 'proceed-after-wait' if still_running else 'attempt-finished',
+             'reason': ('in-flight budget exhausted — judging on the evidence '
+                        'that exists' if still_running else
+                        'the in-flight attempt finished; judging on its run'),
+             'waited_s': waited, 'budget_s': inflight_wait_s,
+             'context_generated_at': ctx.get('generated_at'),
+             'last_finished_ms': last.get('ts'), 'run_at': run_at})
+
+    ctx_id = ctx.get('context_id')
 
     marker_path = WS / 'memory' / '.tmp' / f'report-sent-{args.market}-{args.phase}-{today}.json'
     marker = None

--- a/tests/test_news_digest_prompt_payload.py
+++ b/tests/test_news_digest_prompt_payload.py
@@ -27,6 +27,13 @@ def _raw(tickers):
             for i, ticker in enumerate(tickers)}
 
 
+def _fixed_size_raw(tickers):
+    """Three items per ticker whatever the universe size — `_raw` scales items
+    with the ticker count, which starves a 300-ticker budget test of any
+    ticker small enough to include."""
+    return {ticker: [_news_item(i) for i in range(3)] for ticker in tickers}
+
+
 def _compact(value):
     return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
 
@@ -64,3 +71,41 @@ def test_over_budget_tickers_are_included_or_skipped_whole():
     first_skip = min(tickers.index(t) for t in skipped)
     last_include = max((tickers.index(t) for t in included), default=-1)
     assert last_include < first_skip
+
+
+def test_the_omission_manifest_cannot_push_the_payload_back_over_budget():
+    """#989: the manifest rides inside the payload, so reserving only the empty
+    list under-counted it. 300 oversized tickers serialized to 26,602 chars
+    against a 25,000 budget — the word "budget" only means something if it is
+    an upper bound."""
+    tickers = [f'T{i:03d}' for i in range(300)]
+    raw = _fixed_size_raw(tickers)
+
+    budget = 25_000
+    payload = build_news_payload(raw, budget=budget)
+    serialized = _compact(payload)
+
+    assert json.loads(serialized) == payload
+    assert len(serialized) <= budget
+    # Still whole-ticker, still declared, still input-ordered after the demotion.
+    skipped = payload['_omitted_tickers']
+    included = [t for t in tickers if t in payload]
+    assert included, 'the budget is big enough for some tickers'
+    assert sorted(included + skipped) == sorted(tickers)
+    for ticker in included:
+        assert payload[ticker] == raw[ticker]
+    assert max(tickers.index(t) for t in included) < min(
+        tickers.index(t) for t in skipped)
+
+
+def test_a_manifest_bigger_than_the_budget_is_kept_whole_not_sliced():
+    """The one honest overrun: when naming what was dropped costs more than the
+    budget itself, the manifest still ships intact — a sliced manifest would be
+    a payload that lies about what is missing."""
+    tickers = [f'T{i:03d}' for i in range(300)]
+
+    payload = build_news_payload(_fixed_size_raw(tickers), budget=500)
+
+    assert [t for t in tickers if t in payload] == []
+    assert payload['_omitted_tickers'] == tickers
+    assert json.loads(_compact(payload)) == payload

--- a/tests/test_report_watchdog_inflight.py
+++ b/tests/test_report_watchdog_inflight.py
@@ -71,3 +71,146 @@ def test_the_gate_runs_before_any_branch_that_sends():
         assert defer < source.index(later), (
             f'the in-flight check must precede {later!r}, or the slot can '
             'still be judged while it is running')
+
+
+# ── #988: the wait replaces the defer, because this watchdog runs ONCE ───────
+# `intraday_watchdog` may simply return when an attempt is in flight: crontab
+# runs it at :10 and :40 all session, so "defer" means "the next pass looks
+# again". report_watchdog is a single crontab line per slot — returning there IS
+# the verdict, so a retry chain that never delivers used to leave kcn with no
+# report AND no backstop, one `defer` line the only trace. These tests pin the
+# replacement: hold the slot open, then judge on whatever the wait produced.
+
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def wd(isolated_workflow_ledger, isolated_watchdog_log):
+    import importlib
+    return importlib.import_module('clawock.harness.report_watchdog')
+
+
+BLOCK = '🌙 美股收盘日报｜test\n数据块正文'
+
+
+def _drive(wd, tmp_path, monkeypatch, *, script, marker_at_step=None):
+    """Run main() with a scripted timeline.
+
+    `script` is the list of run-record sets today_runs() returns on successive
+    calls; every fake sleep advances one step. `marker_at_step` writes a
+    delivered postflight marker when that step is reached.
+    """
+    from datetime import datetime
+
+    monkeypatch.setattr(wd, 'WS', tmp_path)
+    tmp = tmp_path / 'memory' / '.tmp'
+    tmp.mkdir(parents=True)
+    now = datetime.now(wd.HKT)
+    today = now.strftime('%Y-%m-%d')
+    ctx = {'raw_wechat_block': BLOCK, 'context_id': 'ctx-under-test',
+           'generated_at': now.replace(tzinfo=None).isoformat()}
+    (tmp / f'report-context-us-close-{today}.json').write_text(
+        json.dumps(ctx, ensure_ascii=False))
+
+    step = {'i': 0}
+
+    def fake_sleep(_seconds):
+        step['i'] = min(step['i'] + 1, len(script) - 1)
+        if marker_at_step is not None and step['i'] >= marker_at_step:
+            (tmp / f'report-sent-us-close-{today}.json').write_text(json.dumps({
+                'ts': int(now.timestamp() * 1000), 'sent_ok': True, 'tg_ok': True,
+                'context_id': 'ctx-under-test', 'first_line': BLOCK.splitlines()[0]}))
+
+    slept = []
+    # Patch the stdlib module, not `wd.time`: these tests must be runnable
+    # against the pre-#988 module too, which imports no `time` at all.
+    import time as _time
+    monkeypatch.setattr(_time, 'sleep',
+                        lambda s: (slept.append(s), fake_sleep(s))[0])
+    # Budget as a module constant rather than the CLI flag, for the same reason.
+    monkeypatch.setattr(wd, 'INFLIGHT_WAIT_S', 90, raising=False)
+    monkeypatch.setattr(wd, 'find_job_id', lambda name: 'jid')
+    monkeypatch.setattr(wd, 'today_runs', lambda jid: script[step['i']])
+    monkeypatch.setattr(wd, 'transcript_loop_score', lambda s: (0, {}))
+    monkeypatch.setattr(wd, 'last_report_text', lambda s, first: f'{BLOCK}\n\n正文')
+    sent = []
+    monkeypatch.setattr(wd, 'send_telegram',
+                        lambda target, msg, dry: (sent.append(msg), (True, 'ok'))[1])
+    monkeypatch.setattr(sys, 'argv', [
+        'report_watchdog.py', '--market', 'us', '--phase', 'close',
+        '--job-name', '美股收盘报告'])
+    assert wd.main() == 0
+    return sent, slept
+
+
+def _run(*, finished_ms, summary=BLOCK):
+    return [{'runAtMs': finished_ms - 200_000, 'sessionId': 'sess',
+             'summary': summary, 'ts': finished_ms}]
+
+
+def test_the_backstop_still_fires_when_the_waited_out_attempt_delivered_nothing(
+        wd, tmp_path, monkeypatch):
+    """The hole #988 names: an attempt in flight at watchdog time finishes
+    during the wait without delivering. Deferring returned 0 here — no report,
+    no backstop. The wait must let the slot reach its verdict."""
+    from datetime import datetime
+    now_ms = int(datetime.now(wd.HKT).timestamp() * 1000)
+
+    sent, slept = _drive(
+        wd, tmp_path, monkeypatch,
+        # step 0: newest FINISHED run predates the context → an attempt is live.
+        # step 1: the retry finished (after the context) and delivered nothing.
+        script=[_run(finished_ms=now_ms - 120_000), _run(finished_ms=now_ms + 5_000)])
+
+    assert slept, 'the watchdog judged without ever waiting for the live attempt'
+    assert sent, 'a slot that finished undelivered must still get its backstop'
+    assert BLOCK.splitlines()[0] in sent[-1]
+
+
+def test_an_attempt_that_lands_during_the_wait_is_not_doubled(
+        wd, tmp_path, monkeypatch):
+    """The 2026-08-11 duplicate this gate exists for: the live attempt succeeds
+    while we wait, its postflight writes the marker, and the marker gate — which
+    still runs after the wait — must recognise the delivery."""
+    from datetime import datetime
+    now_ms = int(datetime.now(wd.HKT).timestamp() * 1000)
+
+    sent, slept = _drive(
+        wd, tmp_path, monkeypatch,
+        script=[_run(finished_ms=now_ms - 120_000), _run(finished_ms=now_ms + 5_000)],
+        marker_at_step=1)
+
+    assert slept, 'the watchdog did not wait for the live attempt'
+    assert sent == [], 'mirrored a report the slot had already delivered'
+
+
+def test_a_slot_still_in_flight_at_the_budget_is_judged_not_silently_dropped(
+        wd, tmp_path, monkeypatch):
+    """Budget exhausted with the attempt still live: the old code's answer was
+    `return 0` forever. The rule is detect-but-never-silence — judge on the
+    evidence that exists, with the marker gate still protecting against a
+    duplicate."""
+    from datetime import datetime
+    now_ms = int(datetime.now(wd.HKT).timestamp() * 1000)
+    stuck = _run(finished_ms=now_ms - 120_000)
+
+    sent, slept = _drive(wd, tmp_path, monkeypatch, script=[stuck, stuck, stuck])
+
+    assert len(slept) == 3, f'wait budget not honoured: {slept}'
+    assert sent, 'a hung slot must still reach kcn on Telegram'
+
+
+def test_a_normal_slot_never_sleeps(wd, tmp_path, monkeypatch):
+    """No in-flight attempt ⇒ not one second of added latency on the ~75% of
+    days that have no retry at all."""
+    from datetime import datetime
+    now_ms = int(datetime.now(wd.HKT).timestamp() * 1000)
+
+    sent, slept = _drive(wd, tmp_path, monkeypatch,
+                         script=[_run(finished_ms=now_ms + 5_000)])
+
+    assert slept == []
+    assert sent, 'an undelivered finished slot still gets the backstop'

--- a/tests/test_weekly_review_prompt_payload.py
+++ b/tests/test_weekly_review_prompt_payload.py
@@ -50,8 +50,9 @@ def test_real_committed_week_payload_is_whole_and_complete():
     assert len(serialized) <= weekly.PROMPT_BUDGET_CHARS
 
     # Everything the four questions consume must actually reach the model;
-    # these are exactly the keys the old slice silently dropped, and they are
-    # never omittable no matter how heavy the week.
+    # these are exactly the keys the old slice silently dropped. On real data
+    # dropping `plans` alone clears the budget, so decision_metrics survives —
+    # it is LAST in the sacrifice order (#991), not exempt from it.
     for key in ('bundle_evidence', 'decision_metrics', 'current_risk',
                 'input_warnings'):
         assert key in payload
@@ -123,3 +124,68 @@ def test_snapshot_slimming_keeps_attribution_fields_only():
     serialized = _compact(slim)
     for noise in ('volume', 'trades', 'day_high', 'gold_dca'):
         assert noise not in serialized
+
+
+def test_what_gets_dropped_is_decided_by_purpose_not_by_byte_count():
+    """#991: the drop used to take the largest section first. On 2026-W30 data
+    that takes plans (83,809 chars) and then decision_metrics (32,380) ahead of
+    snapshots (19,368) — question 2's distilled per-strategy win/loss sacrificed
+    to keep the raw daily book composition, purely on byte count. The order is
+    OMITTABLE_SECTIONS', so plans goes first even when it is the smallest of the
+    three, and decision_metrics only after snapshots was not enough."""
+    # Book composition survives _slim_snapshot, so the bulk has to live in the
+    # holdings the projection keeps — a `note` blob would be slimmed away and
+    # leave nothing to drop.
+    holdings = [{'ticker': f'T{i:02d}', 'name': 'n' * 60, 'current_value': 1.0,
+                 'pnl_percent': 1.0, 'today_change_pct': 1.0} for i in range(30)]
+    bundle = {
+        'week': '2026-W40',
+        'window': '2026-10-05 -> 2026-10-12',
+        'bundle_evidence': {'plan_days': 5, 'nav_points': []},
+        # plans is deliberately the SMALLEST omittable section: under the old
+        # largest-first rule it would have survived while the other two went.
+        'plans': [{'date': '2026-10-05', 'data': {'decisions': [], 'n': 'p' * 500}}],
+        'decision_episodes': [],
+        'decision_metrics': {'per_strategy': {f's{i}': 'y' * 3000 for i in range(4)}},
+        'snapshots': [{'portfolios': {'us_stocks': {'holdings': holdings}}}
+                      for _ in range(6)],
+        'current_risk': {'combined': {'beta': 1.1}},
+        'input_warnings': [],
+    }
+
+    payload = weekly.build_prompt_payload(bundle, budget=20_000)
+
+    dropped = [row['section'] for row in payload['_omitted']]
+    assert dropped == ['plans', 'snapshots'], dropped
+    assert 'decision_metrics' in payload, (
+        'question 2 lost its distilled input to a byte-count decision')
+    for key in ('bundle_evidence', 'decision_episodes', 'current_risk',
+                'input_warnings'):
+        assert key in payload
+    assert len(_compact(payload)) <= 20_000
+
+
+def test_decision_metrics_is_the_last_thing_sacrificed_not_the_first():
+    """When even plans + snapshots is not enough, decision_metrics may still go
+    — the budget has to stay enforceable — but only at the end of the order."""
+    bundle = {
+        'week': '2026-W41',
+        'window': '2026-10-12 -> 2026-10-19',
+        'bundle_evidence': {'plan_days': 5, 'nav_points': []},
+        'plans': [{'date': '2026-10-12', 'data': {'decisions': [], 'n': 'p' * 500}}],
+        'decision_episodes': [],
+        'decision_metrics': {'per_strategy': {f's{i}': 'y' * 3000 for i in range(4)}},
+        'snapshots': [{'portfolios': {}, 'note': 'z' * 3000} for _ in range(6)],
+        'current_risk': {'combined': {'beta': 1.1}},
+        'input_warnings': [],
+    }
+
+    payload = weekly.build_prompt_payload(bundle, budget=2_000)
+
+    assert [row['section'] for row in payload['_omitted']] == [
+        'plans', 'snapshots', 'decision_metrics']
+    assert weekly.OMITTABLE_SECTIONS == ('plans', 'snapshots', 'decision_metrics')
+    # The never-dropped set survives even at a budget nothing else fits in.
+    for key in ('bundle_evidence', 'decision_episodes', 'current_risk',
+                'input_warnings'):
+        assert key in payload


### PR DESCRIPTION
复审夜班切片审计批（#945–#984，15 个已合并 PR）的产出。每条改动都做了独立取证，
不只读 diff。绝大多数经得起复核；两处不行，这个 PR 修掉它们。

## 复核通过的（记一下，免得下次重查）

- **#965** priced-in 信号改读 canonical bars：`memory/bars/<ticker>.json` 命名与
  实现一致，当前 23 只持仓 + 10 只 signalled ticker **零缺覆盖**，不存在「换源之后
  信号整体消失」。
- **#950** news-evidence 挪进 WAVE3：evidence 页只读 quant_signal_review /
  cross_sectional_factor / decision_audit，**不读** news_evidence_graph，所以同波次
  里没有换一个新竞态出来。
- **#980 + #969** nostr：广播闸依赖 `nostr_publish.js` 在零 relay 接受时非零退出，
  该行 (`if (ok === 0) process.exit(1)`) 确实在。
- **#984** evidence 页改判 `usable`：线上 quant_signal_review.json 里
  `usable` / `sample_sufficient` / `reverse_edge_significant` 三个字段都真实存在，
  不会整页塌成「锁定」。
- **#973** CHANGELOG：41 个引用式链接双向闭合，无悬空、无孤儿。
- **#954** overview 首屏抢跑：first paint 本来就固定走同源（LIVE_ORIGIN 到首屏
  成功后才置位），head 里的相对路径 fetch 与 `_dataUrl` 首次取值一致，没有把
  数据面搞岔。
- **#949** 转义：漏网的 `k`（风险关键词）来自文件内硬编码常量数组，不是外部文本。
- master 当前全绿，全量 2609 passed。

## 修掉的两处

### #988 — report_watchdog 的 in-flight defer 是终局的

#969 把 `attempt_still_running` 从 intraday 搬了过来，规则本身对，**但两个
watchdog 的调度形状不同**：

| | 频率 | defer 的含义 |
|---|---|---|
| intraday_watchdog | `10,40` 每 30 分钟 | 下一趟再看 |
| report_watchdog | 每槽位一行 crontab，**只跑一次** | 这一槽的最终判决 |

本机 run 记录（每 job 最近 50 次）：

| job | 中位 | p90 | max | 有重试的天数 |
|---|---|---|---|---|
| 港股开盘报告 | 196s | 334s | 576s | 11/36 |
| 港股午盘报告 | 172s | 276s | 352s | 9/41 |
| 港股午后快报 | 202s | 301s | 372s | 11/39 |
| 港股收盘报告 | 176s | 287s | 355s | 11/38 |
| 美股开盘报告 | 223s | 354s | 455s | 9/41 |
| 美股收盘报告 | 239s | 324s | 434s | 9/41 |

约 1/4 交易日会重试，单次 attempt p90 就 5 分半；watchdog 距 cron 只有 12–20
分钟。重试链在 watchdog 到点时仍在飞是常态，不是极端情况。一旦那次 attempt
最后也没交付，kcn 这一槽既没报告也没兜底，日志里只留一行 `defer` —— 撞
`feedback-detect-but-never-silence`。

改成**有界等待 + 重新判定**：最多等 600s（30s 轮询，`--dry-run` 不等，
`--inflight-wait-s` 可调），每轮重读 runs / context；等完重新取 last run、
run_at、session_id、summary、dedupe flag、raw_block 再判。marker 闸仍在判定
之前，所以「等待期间真送到了」照旧走 ok 分支不重发；预算耗尽仍在飞则记
`proceed-after-wait` 后按现有证据判定，不再静默 return。正常日（无 in-flight）
一次 sleep 都不会发生。

### #989 — build_news_payload 的 budget 不是上界

`_omitted_tickers` 骑在 payload 里，但预留只按**空 list** 算了一次。实测
300 ticker / budget 25000 → **26,602 字符（+6.4%）**，而 #961 的 docstring
明确承诺过这不会发生。

改成事后按整只 ticker 从尾部降级，直到序列化结果真的塞得下 —— 永远不切串，
包含顺序仍跟随输入顺序。唯一仍会超预算的情形是 manifest 本身就比预算大：
声明「丢了什么」是这个 payload 的诚实记录，宁可整条留着也不切一半。

### #991 — weekly-review 丢 section 按字节而非按用途（复审第二轮追加）

#961 的代码与它自己的测试互相矛盾：代码把 `decision_metrics` 列进可丢集合并按
`max(sizes)` 谁大先丢谁，同 PR 的测试却断言它「never omittable no matter how heavy
the week」。测试现在能过，只是因为这周还没重到需要丢第二块。

2026-W30 真实数据（projection 之后）：

| section | 字符 |
|---|---|
| decision_episodes | 114,407 |
| plans | 83,809 |
| **decision_metrics** | **32,380** |
| snapshots | 19,368 |
| current_risk | 9,200 |
| **合计** | **260,596**（budget 200,000）|

丢掉 plans 后 176,825 —— **只剩 11.6% 余量**，而 decision_episodes 随交易活跃度增长。
再重一点，按字节丢的第二块是 decision_metrics（32K）而不是 snapshots（19K）：
第 2 问「按 strategy episode 汇总触发、执行和 win/loss」要吃的蒸馏结果先没，原始
每日持仓构成反而留着。

改成 `OMITTABLE_SECTIONS` 即牺牲顺序、按序取第一个还在的：
plans → snapshots → decision_metrics。保留 decision_metrics 可丢是故意的（预算得
可执行），但它排最后。同时把 #961 那条测试注释里过头的「never omittable」改成实际
成立的说法。旧实现在两条新测试上全红。

## 顺手清理（无行为变化）

- #969 之后 `_receipt_claims` 里的 `delivered` 成了死变量（整份 receipt 现在直接
  往下传，判定在使用点做）。
- #954 的 repository_only 判定用生成器把外层循环变量 `pattern` 遮蔽了。Python 3
  作用域上是对的，但读起来像 bug —— 改名 `blocked`。

## 测试

- 四条 watchdog 行为测试：等待后 attempt 结束且未交付 → 必须补发（旧代码静默
  return）；等待中 marker 出现 → 不重发；超预算仍在飞 → 判定而非静默；无
  in-flight → 一次 sleep 都没有。**旧代码上 3 红**。
- 两条预算测试：300 ticker 必须落在预算内（**旧代码红**）；manifest 大于预算时
  整条保留不切。
- weekly-review 两条：plans 即使是三者里最小也必须第一个丢；decision_metrics 只在最后才丢（**旧实现两条全红**）。
- 全量：2615 passed / 5 skipped（第一轮），第二轮改动跑了 176 个相关用例全绿，完整套件交给 CI。

Closes #988, closes #989, closes #991

https://claude.ai/code/session_01YJfK38K6yUTA1XPbXoJdE6
