### PR TITLE
feat: 判定卡第三次迭代 — 层级靠结构与材质，不靠字号

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2574,6 +2574,7 @@
      的伴排改为独占整行。 */
   .overview-verdict {
     grid-column: 1 / -1; padding: 20px var(--card-inset) 18px;
+    position: relative; /* 光池 ::before 的定位父级 */
     /* 首屏第二块浮起来的表面（指挥台之后）：DSH 插件同款玻璃配方 ——
        不透明色写在前（引擎不支持 color-mix/backdrop-filter 时退回实色卡），
        半透明主题面 + backdrop blur + saturate。结构判据（#887）：毛玻璃
@@ -2593,7 +2594,29 @@
        地板值 = 构图定稿后横幅日扫宽实测上界 +2（见各断点注释）。
        2026-08-24 构图改双栏（宽屏左判词右硬闸），整卡数据态高度大幅收窄，
        三档地板随之重量（值见 min-height 与各断点覆盖，横幅日扫宽取上界）。 */
-    min-height: 296px;
+    /* 地板 = 构图定稿后横幅日扫宽实测上界 +2。2026-08-25 第三次迭代后
+       重扫：mono 数字改变判词折行、右列改仪表面板，1200/1024 实测 317
+       （旧构图 314、旧地板 296 本就已低于当日横幅），地板提到 319。 */
+    min-height: 319px;
+  }
+  /* 自画光池：玻璃配方的最后一味（DSH 页面光同思路，收进材质自己）。
+     body 的 key light 已拉到 860px，但那是页面的光，长页下段会衰减；
+     材质在自己表面上方画一池极弱的冷光，frost 全卡都有东西可糊。画在
+     玻璃面之上、内容之下（backdrop-filter 让本卡成为 stacking context，
+     z-index:-1 落在两者之间），不叠第二层 blur —— 玻璃里再糊玻璃是泥。 */
+  .overview-verdict::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    border-radius: inherit; pointer-events: none;
+    background: radial-gradient(540px 210px at 14% -30px,
+      rgba(255,255,255,.05), transparent 70%);
+  }
+  @media (prefers-color-scheme: light) {
+    .overview-verdict::before {
+      /* 亮色主题白光不可见，换一池极弱的冷色；浓度仍以「读作深度、
+         绝不读作色带」为界。 */
+      background: radial-gradient(540px 210px at 14% -30px,
+        rgba(0,110,184,.045), transparent 70%);
+    }
   }
   /* 宽屏双栏：左列=这张卡「说的话」（判定句 + 要点），右列=这张卡「管的
      事」（触发中的硬闸）。此前四段全宽竖排、段段一条发丝线，整卡读成一摞
@@ -2614,9 +2637,27 @@
     .overview-status { grid-area: verdict; }
     .overview-verdict .today-highlights { grid-area: points; align-content: start; }
     .overview-gates {
-      grid-area: gates; height: 100%;
-      border-top: 0; border-left: 1px solid var(--border-subtle);
-      padding-left: 28px; margin-left: 28px;
+      grid-area: gates;
+      /* 右列从「发丝线分栏」升级为嵌进玻璃的仪表面板：材质分层（玻璃面上
+         一块实色内衬）替代字号分层 —— 这是「层级靠结构与材质」的正文。
+         内衬必须用不透明复合色 --card-2：玻璃上的凹槽若再走半透明，就是
+         「玻璃里开天窗」，糊出来是一团泥（#937 打孔判据）。内衬自己的
+         高光边（inset spec）让它读作下沉的 well 而不是贴上去的纸。 */
+      background: var(--card-2);
+      border: 1px solid var(--border-subtle);
+      border-radius: 12px;
+      padding: 14px 16px 12px; margin-left: 24px;
+      box-shadow: inset 0 1px 0 var(--spec-1);
+      /* 内衬只抱内容、不 stretch 到左列底：well 里的空白是「没有数据」，
+         玻璃上的空白是「构图留白」，两者别混。暗主题下面板与玻璃面只差
+         几个灰阶，边线提到 border-strong 才读得出边界（亮面玻璃差更大，
+         仍用 subtle）。 */
+      align-self: start;
+    }
+    /* 暗主题下面板与玻璃面只差几个灰阶，边线提到 border-strong 才读得出
+       边界；亮面玻璃对比更大，保持 subtle。 */
+    @media (prefers-color-scheme: dark) {
+      .overview-verdict .overview-gates { border-color: var(--border-strong); }
     }
   }
   .overview-verdict-head,
@@ -2711,6 +2752,46 @@
   }
   .overview-gates .risk-alert.medium { border-left-color: var(--warning); }
   .overview-gates .risk-alert .icon { display: none; }
+  /* 硬闸计数控件（JS renderRiskGuardrail 落进 overview-guardrail-count）：
+     10 槽点阵，on=触发中（红）/ off=空槽（发丝线色）。尺寸间距写死 ——
+     这个图形的宽度只随构图变、不随 breach_count 变。徽章自身的胶囊底
+     退场：面板里它是一枚读数，不是一枚按钮。 */
+  .overview-gates-head .badge { background: none; padding: 0; }
+  .overview-gates-head .gt-tally { display: inline-flex; align-items: center; gap: 4px; }
+  .overview-gates-head .gt-dot {
+    width: 5px; height: 5px; border-radius: 50%;
+    background: var(--border-strong); opacity: .45;
+  }
+  .overview-gates-head .gt-dot.on { background: var(--negative); opacity: 1; }
+  .overview-gates-head .gt-more {
+    margin-left: 2px; font: 600 var(--fs-micro)/1 var(--mono);
+    color: var(--negative);
+  }
+  /* 判词句的数字（JS verdictNums 包裹）：mono tabular，同字号同色 ——
+     仓库字规「mono 只用于数字」本来就该由这句话带头执行。层级靠字族
+     切换，不靠放大加重。.94em 是 mono 的光学补偿，两种字族同行等高。 */
+  .overview-status .sb-n {
+    font-family: var(--mono); font-size: .94em; font-weight: 500;
+    font-variant-numeric: tabular-nums; letter-spacing: 0;
+  }
+  /* 入场（#873 语言）：数据落位那一刻（横幅离开 is-pending 是数据到达的
+     唯一 DOM 信号），判词 → 要点 → 硬闸依次浮起 10px，一拍 60ms。只动
+     opacity/transform（不参与布局，CLS 不受影响）；刷新时类不翻转，不会
+     重播；不支持 :has 的引擎直接呈现；reduced-motion 由全局闸与本闸双覆盖。 */
+  @media (prefers-reduced-motion: no-preference) {
+    .overview-verdict:has(.overview-status:not(.is-pending)) .overview-status {
+      animation: verdict-rise var(--duration-standard) var(--ease-out) backwards;
+    }
+    .overview-verdict:has(.overview-status:not(.is-pending)) .today-highlights {
+      animation: verdict-rise var(--duration-standard) var(--ease-out) 60ms backwards;
+    }
+    .overview-verdict:has(.overview-status:not(.is-pending)) .overview-gates {
+      animation: verdict-rise var(--duration-standard) var(--ease-out) 120ms backwards;
+    }
+  }
+  @keyframes verdict-rise {
+    from { opacity: 0; transform: translateY(10px); }
+  }
   .overview-strip {
     grid-column: 1 / -1; min-width: 0;
     display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, .8fr) minmax(0, .8fr);
@@ -2823,7 +2904,7 @@
 
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
-    /* 506：要点行升到 44px 后 768px 端横幅折行的实测上界（504）+2。 */
+    /* 506：768px 端横幅日实测（504，与旧构图持平）+2。 */
     .overview-verdict { min-height: 506px; }
     .overview-verdict, .overview-strip,
     .overview-command > .hero-honesty-card,
@@ -2849,8 +2930,9 @@
     .dh-file { display: none; }
     .dh-bar { grid-column: 1 / -1; }
     .dh-detail { grid-column: 1 / -1; white-space: normal; }
-    /* 564：要点行升到 44px 后 390px 实测上界（562）+2（同 hero-rail 的取舍）。 */
-    .overview-verdict { min-height: 564px; }
+    /* 571：390px 横幅日实测 569（旧构图 566、旧地板 564 同样已破）
+       +2 —— 增量来自 mono 数字在窄列的折行变化。 */
+    .overview-verdict { min-height: 571px; }
     .overview-strip { display: flex; flex-direction: column; }
     .overview-strip-cell {
       min-height: 0; border-right: 0; border-bottom: 1px solid var(--border-subtle);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1116,8 +1116,20 @@
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
-      countEl.textContent = n ? `${n} 触发` : '无';
-      countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
+      // 「9 触发」红字是判定卡里最后一个裸读数：数量改用点阵计数表达
+      // （一眼扫出严重度，不用读数），精确值退到 aria-label/title。槽位
+      // 固定 10 个 —— 图形宽度是构图的函数，不是 breach_count 的函数
+      // （CLS 预留判据）；超容收进 +n，轨宽不变。
+      const CAP = 10;
+      const dots = [];
+      for (let i = 0; i < CAP; i++)
+        dots.push(`<i class="gt-dot${i < Math.min(n, CAP) ? " on" : ""}"></i>`);
+      if (n > CAP) dots.push(`<i class="gt-more">+${n - CAP}</i>`);
+      countEl.innerHTML = n
+        ? `<span class="gt-tally" role="img" aria-label="${n} 项硬闸触发中"`
+          + ` title="${n} 项触发">${dots.join("")}</span>`
+        : '无';
+      countEl.style.color = n ? '' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
         ? stripEmoji(g.directive)
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
@@ -1392,6 +1404,12 @@
 
   function renderStatusBanner() {
     const txt = safe(DATA, "status_banner");
+    // 判词句里的数字是这句话的骨架。仓库字规是「mono 只用于数字与代码」，
+    // 但这句话此前整句 sans，数字埋在 prose 里没有排版层级 —— 层级靠字族
+    // 切换，不靠放大加重（大字报的根子就是拿字号当层级）。escapeHtml 之
+    // 后再包：正则只命中 [+-0-9.%]，包出来的 span 无注入面。
+    const verdictNums = s => escapeHtml(s)
+      .replace(/[+-]?\d+(?:\.\d+)?%/g, m => `<span class="sb-n">${m}</span>`);
     const targets = [
       {
         banner: document.getElementById("status-banner"),
@@ -1427,7 +1445,7 @@
       banner.classList.remove("is-pending");
       banner.classList.remove("is-empty");
       banner.removeAttribute("aria-hidden");
-      if (text) text.textContent = txt;
+      if (text) text.innerHTML = verdictNums(txt);
       if (time) time.textContent = t;
     });
   }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2259,8 +2259,20 @@
     const compactRows = rows.slice().sort((a, b) =>
       Number(b.severity === "high") - Number(a.severity === "high"));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
-      countEl.textContent = n ? `${n} 触发` : '无';
-      countEl.style.color = n ? 'var(--negative)' : 'var(--positive)';
+      // 「9 触发」红字是判定卡里最后一个裸读数：数量改用点阵计数表达
+      // （一眼扫出严重度，不用读数），精确值退到 aria-label/title。槽位
+      // 固定 10 个 —— 图形宽度是构图的函数，不是 breach_count 的函数
+      // （CLS 预留判据）；超容收进 +n，轨宽不变。
+      const CAP = 10;
+      const dots = [];
+      for (let i = 0; i < CAP; i++)
+        dots.push(`<i class="gt-dot${i < Math.min(n, CAP) ? " on" : ""}"></i>`);
+      if (n > CAP) dots.push(`<i class="gt-more">+${n - CAP}</i>`);
+      countEl.innerHTML = n
+        ? `<span class="gt-tally" role="img" aria-label="${n} 项硬闸触发中"`
+          + ` title="${n} 项触发">${dots.join("")}</span>`
+        : '无';
+      countEl.style.color = n ? '' : 'var(--positive)';
       if (dirEl) dirEl.textContent = compact
         ? stripEmoji(g.directive)
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
@@ -2893,6 +2905,12 @@
 
   function renderStatusBanner() {
     const txt = safe(DATA, "status_banner");
+    // 判词句里的数字是这句话的骨架。仓库字规是「mono 只用于数字与代码」，
+    // 但这句话此前整句 sans，数字埋在 prose 里没有排版层级 —— 层级靠字族
+    // 切换，不靠放大加重（大字报的根子就是拿字号当层级）。escapeHtml 之
+    // 后再包：正则只命中 [+-0-9.%]，包出来的 span 无注入面。
+    const verdictNums = s => escapeHtml(s)
+      .replace(/[+-]?\d+(?:\.\d+)?%/g, m => `<span class="sb-n">${m}</span>`);
     const targets = [
       {
         banner: document.getElementById("status-banner"),
@@ -2928,7 +2946,7 @@
       banner.classList.remove("is-pending");
       banner.classList.remove("is-empty");
       banner.removeAttribute("aria-hidden");
-      if (text) text.textContent = txt;
+      if (text) text.innerHTML = verdictNums(txt);
       if (time) time.textContent = t;
     });
   }


### PR DESCRIPTION
## 判定卡第三次迭代：层级靠结构与材质，不靠字号

#927 收了字号（34→19px），#940 给了玻璃+双栏但方向被否。这一轮直接改结构：卡里不再有任何元素靠「大」来当主角，层级全部换成字族、材质分层和图形。

### 构图决定（每条一行为什么）

| 决定 | 为什么 |
|---|---|
| 判词句数字包 mono tabular（`.sb-n`） | 仓库字规「mono 只用于数字」由全卡语义最重的这句话带头执行（此前整句 sans）；层级靠字族切换，不靠放大加重 —— 大字报的根子就是拿字号当层级 |
| 硬闸「9 触发」红字 → 10 槽点阵计数 | 减数字加图：一眼扫出严重度，不用读数；轨宽固定、超容收 `+n`，图形宽度是构图的函数不是数据的函数；精确值退 aria-label/title |
| 右列发丝线分栏 → 玻璃面嵌入式仪表面板（≥1024） | 材质分层替代字号分层；内衬不透明 `--card-2`（打孔判据：玻璃上的凹槽走半透明就是泥）；只抱内容不 stretch，暗主题边线提 `border-strong` |
| 玻璃 blur 24px/170% → 14px/150% | 对齐 DSH 配方（styles.module.css:151），这是全站唯一偏离配方的玻璃面 |
| 自画光池 `::before` | 玻璃配方最后一味：页面 key light 衰减段材质自己有光可糊；画在玻璃面与内容之间，不叠第二层 blur（已用 20x 放大探针验证机制在画，生产 alpha .05/.045） |
| 入场动效 `verdict-rise` | 数据落位（`is-pending` 翻转）时判词→要点→硬闸依次浮起 10px / 240ms / 60ms 步进；只动 opacity+transform；不支持 `:has` 直接呈现；reduced-motion 全局闸双覆盖；刷新不重播 |

### DOM 契约

`index.html` 零改动。`overview-status-banner` / `overview-sb-text` / `overview-sb-time` / `is-pending` / `is-empty` 全部原样，`dashboard_tab_runtime.spec.js` 不需要动 —— 它钉的不变量（tab 路由、单次 overview 拉取、首帧本源）没有被这轮碰到。hero/render 双实现逐字同步，parity 棘轮名单没有变（`renderStatusBanner` 仍逐字相同）。

### 验证

- `node tests/dashboard_tab_runtime.spec.js` ✅（需先 `ops/pages/fetch_data_plane.py`，CI 已有该步）
- `pytest` dashboard 契约 137 passed + 1 xfailed（bundle_parity / desktop_layout / contrast / security / payload_size / tab_lifecycle / hero_native_chart / build / output_ownership / artifact_gate / input_fingerprint）
- CLS（stub 数据源实测，light/dark 同值）：1440=0.0056 · 1200=0.0067 · 1024=0.0078 · 768=0.0089 · 390=0.0095，全档 ≤ before 基线（768 反而 0.0149→0.0089）
- 地板重量（横幅日实测+2）：296→319（≥1024）、506 不变（768）、564→571（390）—— 旧地板本已低于当日横幅实测（314/566），增量来自 mono 折行与面板内衬

### 截图（/root/logs/decision-verdict/）

| | before | after |
|---|---|---|
| 判定卡 · 1200 · light | `before-verdict-1200-light.png` | `after-verdict-1200-light.png` |
| 判定卡 · 1200 · dark | `before-verdict-1200-dark.png` | `after-verdict-1200-dark.png` |
| 判定卡 · 390 · light | `before-verdict-390-light.png` | `after-verdict-390-light.png` |
| 判定卡 · 390 · dark | `before-verdict-390-dark.png` | `after-verdict-390-dark.png` |
| 首屏 1200x760（social card 口径） | `before-1200-*.png` | `after-1200-*.png` |
| 首屏 390x844 | `before-390-*.png` | `after-390-*.png` |

截图均为 playwright stub 数据源（`fixture-overview.json` = 2026-08-25 线上 overview.json 快照），非 live 依赖。

**按 kcn 指令：此 PR 不合并，等亲眼过目设计。**
