### PR TITLE
[audit:performance] P2: CI 假幂等检查换真确定性断言 + 测量产物补 repository_only (#993)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,7 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: |
           python3 -m pytest tests/ -q \
+            --durations=20 \
             --cov=clawock.publish.dashboard \
             --cov=clawock.evaluation \
             --cov=clawock.harness \
@@ -555,13 +556,48 @@ jobs:
           print('decision_audit.json: Reflect backtest OK')
           PY
 
-      - name: Run build_dashboard sanity
+      # The step this replaces ran the build twice more over a comment reading
+      # "confirm it runs idempotently" — two bare invocations, no comparison, so
+      # the claim was never checked (and byte equality is not even the
+      # invariant: measured on consecutive builds over unchanged inputs, exactly
+      # four kinds of bytes move — generation_id/generated_at/as_of, which are
+      # wall-clock by design, and build_status.files[].age_hours, which is
+      # round((now - source mtime)/3600, 1) at dashboard.py). So determinism is
+      # asserted where it actually holds: after stripping exactly those keys,
+      # a second build must be JSON-identical to the first. One build instead
+      # of two, and the check finally has teeth.
+      - name: Rebuild is deterministic apart from generation stamps
         if: steps.changes.outputs.code == 'true'
         run: |
-          # confirm it runs idempotently
-          clawock dashboard-build
-          clawock dashboard-build
-          echo "OK: build_dashboard idempotent"
+          set -euo pipefail
+          strip_volatile() {
+            python3 - "$1" <<'PY'
+            import json, sys
+            VOLATILE = {"generated_at", "generation_id", "as_of", "age_hours"}
+            def strip(node):
+                if isinstance(node, dict):
+                    return {k: strip(v) for k, v in node.items()
+                            if k not in VOLATILE}
+                if isinstance(node, list):
+                    return [strip(v) for v in node]
+                return node
+            with open(sys.argv[1]) as f:
+                print(json.dumps(strip(json.load(f)), sort_keys=True))
+            PY
+          }
+          tmp="$(mktemp -d)"
+          for name in overview dashboard decision_audit shadow_portfolio; do
+            strip_volatile "assets/data/$name.json" > "$tmp/$name.first"
+          done
+          clawock dashboard-build > /dev/null
+          for name in overview dashboard decision_audit shadow_portfolio; do
+            if ! strip_volatile "assets/data/$name.json" | diff -u "$tmp/$name.first" -; then
+              echo "::error::dashboard rebuild moved bytes beyond generation stamps ($name)"
+              exit 1
+            fi
+          done
+          rm -rf "$tmp"
+          echo "OK: rebuild deterministic modulo generation stamps"
 
   publish-coverage:
     # Master only: the README badge must show what is on master, never a number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,28 +570,27 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: |
           set -euo pipefail
-          strip_volatile() {
-            python3 - "$1" <<'PY'
-            import json, sys
-            VOLATILE = {"generated_at", "generation_id", "as_of", "age_hours"}
-            def strip(node):
-                if isinstance(node, dict):
-                    return {k: strip(v) for k, v in node.items()
-                            if k not in VOLATILE}
-                if isinstance(node, list):
-                    return [strip(v) for v in node]
-                return node
-            with open(sys.argv[1]) as f:
-                print(json.dumps(strip(json.load(f)), sort_keys=True))
-            PY
-          }
+          cat > "${RUNNER_TEMP:-/tmp}/strip_volatile.py" <<'PY'
+          import json, sys
+          VOLATILE = {"generated_at", "generation_id", "as_of", "age_hours"}
+          def strip(node):
+              if isinstance(node, dict):
+                  return {k: strip(v) for k, v in node.items()
+                          if k not in VOLATILE}
+              if isinstance(node, list):
+                  return [strip(v) for v in node]
+              return node
+          with open(sys.argv[1]) as f:
+              print(json.dumps(strip(json.load(f)), sort_keys=True))
+          PY
+          strip="${RUNNER_TEMP:-/tmp}/strip_volatile.py"
           tmp="$(mktemp -d)"
           for name in overview dashboard decision_audit shadow_portfolio; do
-            strip_volatile "assets/data/$name.json" > "$tmp/$name.first"
+            python3 "$strip" "assets/data/$name.json" > "$tmp/$name.first"
           done
           clawock dashboard-build > /dev/null
           for name in overview dashboard decision_audit shadow_portfolio; do
-            if ! strip_volatile "assets/data/$name.json" | diff -u "$tmp/$name.first" -; then
+            if ! python3 "$strip" "assets/data/$name.json" | diff -u "$tmp/$name.first" -; then
               echo "::error::dashboard rebuild moved bytes beyond generation stamps ($name)"
               exit 1
             fi

--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -60,6 +60,8 @@
   "repository_only": [
     "assets/dashboard.gif",
     "assets/data/*.jsonl",
+    "assets/data/repo-traffic.json",
+    "assets/data/schedule-drift.json",
     "memory/*.jsonl",
     "docs/visual-regression/**",
     "tests/**"

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -225,6 +225,13 @@ def test_builder_stages_only_public_consumers(tmp_path):
     assert not list((output / "assets/data").glob("*.jsonl"))
     assert not (output / "memory/decisions.jsonl").exists()
     assert not (output / "tests").exists()
+    # Ops-side measurement artifacts (#993): written by cron workflows and read
+    # back from the checkout/raw paths — no page or script fetches them from
+    # Pages, so the *.json include must not carry them into the artifact.
+    assert (site / "assets/data/schedule-drift.json").is_file()
+    assert (site / "assets/data/repo-traffic.json").is_file()
+    assert not (output / "assets/data/schedule-drift.json").exists()
+    assert not (output / "assets/data/repo-traffic.json").exists()
     assert not (output / "docs/visual-regression/issue-206").exists()
     assert (output / "docs/architecture.md").is_file()
     sitemap_locs = [


### PR DESCRIPTION
## 改动（P2 对抗审计：performance 切片，敌意对象=上一轮修复本身）

### 1. CI「幂等检查」从未验证过任何东西 → 换成真确定性断言

`ci.yml` 的 `Run build_dashboard sanity` 连跑两次构建后仅 `echo OK`——"confirm it runs idempotently" 是写在注释里的空头支票。且实测证明**字节级幂等根本不是该构建的不变量**：连续两次构建（输入不变）恰有四类字节移动——`generation_id`/`generated_at`/`as_of`（墙钟，by design）与 `build_status.files[].age_hours`（`= round((now-mtime)/3600, 1)`，dashboard.py:2795）。任何天真加 hash 对比的"修法"都会把 required check 变成随机红。

新步骤按真实不变量断言：剥离且仅剥离这四个键后，第二次构建必须与第一次 JSON 全等。证据链：37s 间隔 × 3 轮本地复现，raw diff 路径只含上述四类、normalized 恒 0 diff。构建次数 3→2。

附带：pytest 步骤加 `--durations=20`，慢测试目标从"猜"变成 CI 日志常驻数据（本机计时不可信是既定结论）。

### 2. 测量产物补 repository_only（Closes #993）

`schedule-drift.json`(42KB) + `repo-traffic.json`(8KB) 被 `assets/data/*.json` include 带进每次 Pages deploy，但全站零消费方（grep site/ 空集；真实消费方走 checkout/raw）。补两行 repository_only + staging 契约测试双向断言。#993 正文有完整证据与验收对照。

## 验证

- 本地复现脚本：4 键 strip 后三轮零 diff；rehearsal 全绿。
- 针对性测试：`test_ci_consolidation_contract.py + test_ci_trigger_paths.py + test_ci_codeql_gate.py` 22 passed；`test_pages_deployment_contract.py` 15 passed。
- 未跑全量套件（任务红线），远端六必需检查为合并闸。

## 审计范围备忘（核查过、不动的部分）

- P1 修复回归排查通过：boot-fetch 收编契约与 overviewRequests 计数仍在且自洽；repository_only 强制跳过语义正确（fnmatch 与 pathlib glob 对现 pattern 集合等价）；echarts/render 懒加载未回退；pages cancel-in-progress:false 未变。dashboard.ui.js:503 的 `await` 优先级怪相（manual refresh 会先 await boot promise）无可达触发路径，仅记录不改。
- #941 preflight DAG 波次化：结构不动（红线），tests/test_brief_preflight_dag.py 边/并发上限/NODE_ORDER 确定性断言完备，未发现缺口。
- assets/data 增长趋势复核：news_evidence_history 893KB（+38KB/3 天，与 #951 一致，维持 open 待 kcn 定保留窗口）；t0_setups_history 封顶 4000 行仍成立（setups.py:38）；workflow-outcomes 有 KEEP_HOURS 修剪；无新增无上限写入方。
- brief-fallback 三连发 skip 路径实测全程 9s（pip cache 命中 6s），注释里 "15 seconds each" 成立，无可修。
- pages.yml `assets/data/**` 触发面核实为真公开数据（macro/sentiment/influence/news digest 等），非浪费 deploy。
- seo-visibility.yml 的 `python-version: '3.12'` 覆盖 composite 默认 3.11 且无注释说明理由（违背 #806 单点钉版本精神）——影响极小（独立 pip cache 宇宙），仅记录不建 issue。

Closes #993
