### PR TITLE
fix: GitHub Release 的 dsh tgz 先重建再 pack，stale lib 从静默分叉变响亮红 (#998) [audit:action]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,15 @@ jobs:
       - name: Pack the DSH skill package for the release
         # Idempotent bump: `npm version <same>` exits non-zero (#617). When the
         # tag version already equals package.json, just pack what is there.
+        env:
+          # Same runner hardening as the npm publish job: a lockfile generated
+          # behind a mirror registry stalls every fetch here too (see that
+          # job's 2026-08-17 note).
+          NODE_OPTIONS: --dns-result-order=ipv4first
+          NO_UPDATE_NOTIFIER: '1'
+          npm_config_replace_registry_host: 'always'
         run: |
+          set -euo pipefail
           cd examples/dsh/packages/clawock-dsh
           target="${GITHUB_REF_NAME#v}"
           current="$(node -p "require('./package.json').version")"
@@ -240,6 +248,18 @@ jobs:
           else
             echo "dsh-plugin already at $target — skipping bump"
           fi
+          # Rebuild lib from src exactly like the npm job does before it
+          # publishes, then refuse to ship a stale tree. The release tgz and
+          # the npm tarball carry the same version number, so they must be the
+          # same build — #712 was that failure mode with two producers. A tag
+          # can point at a commit no CI run ever gated (validate's
+          # rebuild-is-no-op check is lane-gated), so this cannot be inherited.
+          npm install --include=dev --no-audit --no-fund
+          npm run build
+          git diff --exit-code -- lib || {
+            echo "::error::committed lib/ differs from a fresh build at this tag — the release tgz would diverge from the published npm tarball; fix lib on master and cut a new tag"
+            exit 1
+          }
           npm pack
 
       - name: Render the public-package changelog section

--- a/tests/test_github_release_contract.py
+++ b/tests/test_github_release_contract.py
@@ -102,6 +102,35 @@ def test_the_release_pins_the_npm_that_publishes():
     publish_at = workflow.index("publish_dsh_plugin.sh")
     assert pin_at < publish_at, "the pin has to come before the publish, not after"
 
+def test_the_release_tgz_is_rebuilt_from_source_and_refuses_a_stale_tree():
+    """The release asset and the npm tarball carry the same version number, so
+    they must be the same build.
+
+    #712 was "one version number, two sets of files", found by hand months
+    later. The npm half always rebuilds before publishing
+    (publish_dsh_plugin.sh); the GitHub Release half used to pack whatever
+    lib/ was committed at the tag — equal only when the tag happened to sit on
+    a commit whose lane-gated rebuild-is-no-op check ran (#998). A tag can
+    point at a commit no CI run ever gated, so the release job has to enforce
+    it itself: build, then hard-fail on a dirty lib/ instead of attaching a
+    divergent tgz to an immutable release page.
+    """
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_job = workflow.split("\n  github-release:\n", 1)[1]
+
+    bump_at = release_job.index('npm version "$target" --no-git-tag-version')
+    install_at = release_job.index("npm install --include=dev")
+    build_at = release_job.index("npm run build")
+    guard_at = release_job.index("git diff --exit-code -- lib")
+    pack_at = release_job.index("\n          npm pack")
+    assert bump_at < install_at < build_at < guard_at < pack_at, (
+        "the pack must come after a from-source rebuild and its stale-tree guard"
+    )
+    assert "diverge from the published npm tarball" in release_job, (
+        "the failure message must name what a stale tree actually breaks"
+    )
+
+
 def test_npm_only_dispatch_runs_only_npm_and_never_a_github_release():
     """Repairing the npm side of a half-published version must not need a tag
     and must not create a GitHub Release.


### PR DESCRIPTION
## 改动

Closes #998。

`release.yml` 的 github-release pack 步骤：`npm pack` 前补齐与 npm publish 路径完全相同的 `npm install --include=dev --no-audit --no-fund && npm run build`（含同一组 runner 加固 env：ipv4first / no-update-notifier / replace-registry-host），随后 `git diff --exit-code -- lib` 硬门——tag 指向的提交若 committed lib/ 与新构建不一致，release 直接红而不是把分叉 tgz 挂上不可变的 release 页。失败信息指明后果与出路（在 master 修 lib、另起新 tag）；原地恢复走 Re-run failed jobs。

## 为什么修在这里

- npm tarball 的生产者（publish_dsh_plugin.sh）总是重建；GitHub Release 资产原来直接 pack 提交树——同一版本号、两个生产者，只有 tag 恰好落在过闸提交上才相等。
- validate 的 rebuild-is-no-op 门是 dsplugin lane 条件性运行，tag 可以指向任何没跑过它的提交，该保障无法继承。
- 这是 #712「同版本号两套文件」的同类形态；tags immutable 使错误资产永久化。发错代码比不发更糟，所以选硬门而非警告。

## 验证

- 新契约测试 `test_the_release_tgz_is_rebuilt_from_source_and_refuses_a_stale_tree` 钉住 bump → install → build → diff-guard → pack 的顺序与失败语义，防止回归成"直接 pack"。
- 针对性测试：`pytest tests/test_github_release_contract.py tests/test_ci_consolidation_contract.py tests/test_ci_codeql_gate.py tests/test_ci_trigger_paths.py tests/test_push_scope.py tests/test_coverage_badge.py` → 84 passed。
- actionlint 1.7.12（CI 同版本、SHA256 核对后下载）本地对全部 workflow 全绿。
- 未跑全量套件（任务红线），远端六个必需检查为合并闸。

## 刻意不做

- 不给 PyPI/npm job 加任何改动——它们的生产路径本来就带重建。
- 不引入 artifact 跨 job 传递（让 release 复用 npm job 打的 tarball）：那会把 github-release 与 npm job 强耦合进同一次 run 的成败，且 npm_only 修复路径下 release 仍要独立可重放。
