### PR TITLE
fix: prompt 预算上界与实嵌序列化逐字节一致 (#1000) [audit:prompt]

### DIFF
--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -34,6 +34,10 @@ from clawock.market_data.sentiment import fetch_google_news
 NEWS_PROMPT_BUDGET_CHARS = 25_000
 
 
+def _compact(value):
+    return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+
+
 def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
     """Whole-ticker projection of the fetched news under a serialized budget.
 
@@ -47,14 +51,11 @@ def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
     still exceeds `budget` is a manifest that alone is bigger than it: naming
     what was dropped is the honesty record, so it is kept whole rather than cut.
     """
-    def compact(value):
-        return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
-
     included = {}
     omitted = []
-    used = len(compact({'_omitted_tickers': omitted}))
+    used = len(_compact({'_omitted_tickers': omitted}))
     for ticker, items in raw.items():
-        piece = len(compact({ticker: items})) + 1  # + separator overhead
+        piece = len(_compact({ticker: items})) + 1  # + separator overhead
         if used + piece <= budget:
             included[ticker] = items
             used += piece
@@ -66,7 +67,7 @@ def build_news_payload(raw, budget=NEWS_PROMPT_BUDGET_CHARS):
     # manifest stays in input order: a demoted ticker precedes every ticker the
     # greedy pass had already skipped.
     tail = [ticker for ticker in raw if ticker in included]
-    while tail and len(compact(included)) > budget:
+    while tail and len(_compact(included)) > budget:
         ticker = tail.pop()
         del included[ticker]
         omitted.insert(0, ticker)
@@ -191,6 +192,39 @@ def _write_artifact(tickers, raw, source_status, *, digest='', no_material_news=
     return out
 
 
+def build_user_prompt(news_payload, held_via):
+    """Assemble the user turn. The JSON fence embeds exactly the serialization
+    the budget was enforced against — `_compact`, byte for byte (#1000). The
+    first cut embedded `json.dumps(news_payload)` with default separators, so a
+    payload that measured just under 25,000 shipped larger and the budget was
+    not an upper bound on what actually left the door."""
+    return (
+        "下面 US holdings 过去 48h 新闻 (来源 Finnhub 或 Google News RSS, "
+        "每条 `origin` 字段标注). 提炼成 markdown digest:\n\n"
+        "## 格式 (严格遵守)\n\n"
+        "### Top 3-5 移动信号 (跨 ticker 排序)\n"
+        "- TICKER: 1 行核心 fact + 1 行 implication for kcn's position\n"
+        "- ...\n\n"
+        "### Per-ticker 简报 (有新闻才列)\n"
+        "- TICKER: 关键事件 - 影响判断 (1 行)\n\n"
+        "### 风险 watch (若有)\n"
+        "- 任何 financial guidance / regulatory / 大股东减持 / 失败合约 等 risk 关键词\n\n"
+        "要求:\n"
+        "- 总长 ≤ 500 字 (digest 不是 brief)\n"
+        "- 重复 / 营销稿 / 通用市场新闻 -> 忽略\n"
+        "- 优先 ticker-specific catalyst (财报 / 合约 / 监管 / 大单)\n"
+        "- gnews-rss 项只有标题没 summary, 要靠标题关键词判断, 不要编造细节\n"
+        "- 不许说 \"需要进一步研究\" 这种废话\n"
+        + (f"- 持仓映射: 以下公司是通过杠杆 ETF 持有的 {json.dumps(held_via, ensure_ascii=False)};"
+           " 写 implication 时点明持有的是哪只 ETF, 并说明 2x 会放大该消息\n" if held_via else "")
+        + "- 若 Raw news 含 `_omitted_tickers`，这些 ticker 的新闻因 prompt 预算被整体省略，"
+          "对应小节必须如实写数据缺口，禁止编造\n"
+        + "- 直接出 markdown\n\n"
+        +
+        f"Raw news (JSON):\n```json\n{_compact(news_payload)}\n```\n"
+    )
+
+
 def main():
     pf = json.load(open('portfolio.json'))
     held = [h['ticker'] for h in pf['portfolios']['us_stocks']['holdings']
@@ -228,31 +262,7 @@ def main():
 
     news_payload = build_news_payload(raw)
 
-    user = (
-        "下面 US holdings 过去 48h 新闻 (来源 Finnhub 或 Google News RSS, "
-        "每条 `origin` 字段标注). 提炼成 markdown digest:\n\n"
-        "## 格式 (严格遵守)\n\n"
-        "### Top 3-5 移动信号 (跨 ticker 排序)\n"
-        "- TICKER: 1 行核心 fact + 1 行 implication for kcn's position\n"
-        "- ...\n\n"
-        "### Per-ticker 简报 (有新闻才列)\n"
-        "- TICKER: 关键事件 - 影响判断 (1 行)\n\n"
-        "### 风险 watch (若有)\n"
-        "- 任何 financial guidance / regulatory / 大股东减持 / 失败合约 等 risk 关键词\n\n"
-        "要求:\n"
-        "- 总长 ≤ 500 字 (digest 不是 brief)\n"
-        "- 重复 / 营销稿 / 通用市场新闻 -> 忽略\n"
-        "- 优先 ticker-specific catalyst (财报 / 合约 / 监管 / 大单)\n"
-        "- gnews-rss 项只有标题没 summary, 要靠标题关键词判断, 不要编造细节\n"
-        "- 不许说 \"需要进一步研究\" 这种废话\n"
-        + (f"- 持仓映射: 以下公司是通过杠杆 ETF 持有的 {json.dumps(held_via, ensure_ascii=False)};"
-           " 写 implication 时点明持有的是哪只 ETF, 并说明 2x 会放大该消息\n" if held_via else "")
-        + "- 若 Raw news 含 `_omitted_tickers`，这些 ticker 的新闻因 prompt 预算被整体省略，"
-          "对应小节必须如实写数据缺口，禁止编造\n"
-        + "- 直接出 markdown\n\n"
-        +
-        f"Raw news (JSON):\n```json\n{json.dumps(news_payload, ensure_ascii=False)}\n```\n"
-    )
+    user = build_user_prompt(news_payload, held_via)
 
     # News digest: short output but enable thinking helps prioritize signal vs noise
     digest = chat(system=system, user=user, max_tokens=32000, temperature=0.5)

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -213,8 +213,9 @@ def aggregate_week(today=None):
     return {
         'week': week_id,
         'window': f'{start.isoformat()} -> {today.isoformat()}',
-        # Keep compact, deterministic evidence before bulky raw inputs: main()
-        # truncates the serialized bundle at 40k characters for the LLM prompt.
+        # Compact, deterministic evidence first, bulky raw inputs after: the
+        # reader meets verifiable numbers before prose-heavy raw views. Nothing
+        # is truncated here — budget enforcement lives in build_prompt_payload.
         'bundle_evidence': bundle_evidence,
         'plans': plans,
         'decision_episodes': decision_episodes,
@@ -338,16 +339,14 @@ def build_prompt_payload(bundle, budget=PROMPT_BUDGET_CHARS):
     return payload
 
 
-def main():
-    bundle = aggregate_week()
-    validate_bundle(bundle)
-    week_id = bundle['week']
-
-    system = "You are Rick, kcn's HK+US stock analyst. Write a weekly portfolio review."
-
-    payload = build_prompt_payload(bundle)
-    user = (
-        f"根据这一周（{week_id}）的 brief / plan / decision v2 / risk 数据, "
+def build_user_prompt(payload):
+    """Assemble the user turn. The JSON fence embeds exactly the serialization
+    the budget was enforced against — `_compact`, byte for byte (#1000). The
+    first cut embedded `json.dumps(payload)` with default separators, so every
+    shipped prompt carried ~7% more characters than the check had measured and
+    the sanity bound was not the bound of what actually left the door."""
+    return (
+        f"根据这一周（{payload['week']}）的 brief / plan / decision v2 / risk 数据, "
         f"写一篇 markdown 周复盘。长度 1500-2500 字。"
         "\n\n"
         "重点回答 4 个问题:\n"
@@ -356,11 +355,22 @@ def main():
         "2. **决策兑现**: 按 strategy episode 汇总触发、执行和 win/loss；不要把每日重复 call 当独立样本\n"
         "3. **风险演变**: 当前 risk.json 数值, β/Vol/Max DD/Sharpe 怎么走?\n"
         "4. **下周关注 3 条**: actionable (ticker + 触发条件 + 仓位影响)\n\n"
-        f"数据 bundle (JSON):\n```json\n{json.dumps(payload, ensure_ascii=False)}\n```\n\n"
+        f"数据 bundle (JSON):\n```json\n{_compact(payload)}\n```\n\n"
         "若上面 JSON 含 `_omitted`，对应 section 因 prompt 预算被整体省略——"
         "相关小节必须如实写数据缺口，禁止编造。\n\n"
         "直接出 markdown, 不要客套."
     )
+
+
+def main():
+    bundle = aggregate_week()
+    validate_bundle(bundle)
+    week_id = bundle['week']
+
+    system = "You are Rick, kcn's HK+US stock analyst. Write a weekly portfolio review."
+
+    payload = build_prompt_payload(bundle)
+    user = build_user_prompt(payload)
 
     # Weekly review benefits most from thinking + depth (1 turn, complex synthesis)
     out = chat(system=system, user=user, max_tokens=32000, temperature=0.6)

--- a/tests/test_news_digest_prompt_payload.py
+++ b/tests/test_news_digest_prompt_payload.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 
-from clawock.automation.news_digest import build_news_payload
+from clawock.automation.news_digest import build_news_payload, build_user_prompt
 
 
 def _news_item(seed):
@@ -96,6 +96,24 @@ def test_the_omission_manifest_cannot_push_the_payload_back_over_budget():
         assert payload[ticker] == raw[ticker]
     assert max(tickers.index(t) for t in included) < min(
         tickers.index(t) for t in skipped)
+
+
+def test_the_embedded_json_is_byte_identical_to_the_budget_checked_serialization():
+    """#1000: the fence embedded `json.dumps(news_payload)` with default
+    separators while the budget was enforced on compact serialization — a
+    payload measured just under 25,000 shipped larger, so the budget was not an
+    upper bound on what actually left the door."""
+    tickers = [f'T{i:02d}' for i in range(12)]
+    payload = build_news_payload(_fixed_size_raw(tickers), budget=6000)
+
+    prompt = build_user_prompt(payload, held_via={'PLTR': ['PLTU']})
+    embedded = prompt.split('```json\n', 1)[1].split('\n```', 1)[0]
+
+    assert embedded == _compact(payload), (
+        'the model must see exactly the bytes the budget was enforced against')
+    assert json.loads(embedded) == payload
+    assert len(embedded) <= 6000
+    assert '_omitted_tickers' in payload  # oversized fixture: omissions declared
 
 
 def test_a_manifest_bigger_than_the_budget_is_kept_whole_not_sliced():

--- a/tests/test_weekly_review_prompt_payload.py
+++ b/tests/test_weekly_review_prompt_payload.py
@@ -66,6 +66,23 @@ def test_real_committed_week_payload_is_whole_and_complete():
         assert section not in payload
 
 
+def test_the_embedded_json_is_byte_identical_to_the_budget_checked_serialization():
+    """#1000: main() embedded `json.dumps(payload)` with default separators while
+    the budget was enforced on `_compact` — the shipped prompt ran ~7% larger
+    than the checked bound (13,066 extra characters on committed W30 data), so
+    PROMPT_BUDGET_CHARS was not the bound of what actually left the door."""
+    bundle = weekly.aggregate_week(today=date(2026, 7, 24))
+
+    payload = weekly.build_prompt_payload(bundle)
+    prompt = weekly.build_user_prompt(payload)
+    embedded = prompt.split('```json\n', 1)[1].split('\n```', 1)[0]
+
+    assert embedded == _compact(payload), (
+        'the model must see exactly the bytes the budget was enforced against')
+    assert json.loads(embedded) == payload
+    assert len(embedded) <= weekly.PROMPT_BUDGET_CHARS
+
+
 def test_oversized_bundle_omits_whole_sections_and_declares_them():
     bundle = _oversized_bundle()
 


### PR DESCRIPTION
# [audit:prompt] P2 对抗复审：预算上界与实嵌序列化错配

上一轮（PR #961，#959）用结构化投影替代裸字符串截断；本轮首要敌意对象是该修复及其后续修补（#990/#989、aa640cea/#991）本身。

## Finding（真缺陷，已修）

**预算检查与实际嵌入的序列化不一致** → [#1000](https://github.com/KCNyu/clawock/issues/1000)

- 预算按 `_compact`（`separators=(',',':')`）测量：`weekly_review.py:331`、`news_digest.py` build 函数内部
- 实际嵌入却用默认分隔符 `json.dumps(payload)`：原 `weekly_review.py:359`、`news_digest.py:254`
- committed W30 数据实测：受检 176,825 vs 实发 189,891，**+13,066 字符（+7.4%）纯分隔符空白**；news 同类 +1.9%。重周/繁忙日贴满预算时，实发无声突破 sanity bound —— #989 刚立的「budget 必须是上界」原则被嵌入侧绕过
- `weekly_review.py:327-330` 注释自称 "the budget check must see the payload as it will actually be serialized"，被自己打破
- 现有测试全按 compact 口径断言，main() 实嵌零覆盖 → #961 引入后 9 条测试全绿（半吊子残留）
- 附带腐烂注释：`aggregate_week` 内仍描述 #959 已删除的 "40k 截断"

### 修复（本 PR）

- 抽出 `build_user_prompt(payload)` / `build_user_prompt(news_payload, held_via)`，JSON 围栏内嵌 `_compact` 产物，与预算检查逐字节一致；每周省 ~13K 字符输入
- 新增 2 条行为测试：从 user prompt 提取 JSON 块 `== _compact(payload)`、长度 ≤ budget、json.loads 恒过
- 清理腐烂注释。定向 19 passed（含 brief_fallback 相邻面回归）

## 排查过但无需改动

| 面 | 结论 |
|---|---|
| #991 省略顺序（plans→snapshots→metrics） | 测试钉住用途序，purpose-first 正确 |
| #989 manifest reconciliation | 尾部降级+整值声明逻辑正确，边界（manifest>budget）诚实 |
| brief_fallback prepare_context / system prompt 整文件化(#962) | serialized 全程 compact 口径，嵌入一致，无此病 |
| llm.py chat() | deadline 分桶 + per-leg stats + 固定 fallback 序（禁区合规），无成本泄漏 |
| 3 个 cron payload 模板 + 11 job payload_vars | 无腐烂数字；「长度自己判断」口径未被触碰 |
| Bull/Bear/Judge 结构 | postflight REQUIRED_MARKDOWN_SECTIONS + SKILL.md 80-120 字有界结论，符合判据 |
| influencer LLM_SYSTEM | 结构化提取 + 反联想硬塞约束，无对外社交文案路径，X/HN 人肉定案未动 |
| SKILL.md 数字 | 均在标注的历史案例/示例行内，非活数据 |

## 仅记录不改

- **brief.md payload 棘轮**：4145→5157 字节（8/8→8/21，+24%），但每段增量绑定真实事故教训（8/21 find/kill 判红案），属事故驱动护栏非堆料；继续观察即可。
- **#960（字数 KPI 残留两处）**：仍开放，归 kcn 定案延伸，本轮不碰。

## 流程记录

- Issue: [#1000](https://github.com/KCNyu/clawock/issues/1000)
- PR: 见下方合并记录（squash 合并，Closes #1000）
- 查重：open issues 中仅 #960 与本片重合（kcn 决策项，不重建）
