### PR TITLE
fix: postflight 停止用 vintage 现价伪造 simulated_entry_price + ledger 死 snapshot 助手清除 (#1003)

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -41,7 +41,6 @@ from clawock.workspace import workspace_root
 # from site-packages or a source checkout path.
 WS = workspace_root(Path.cwd())
 LEDGER = WS / "memory" / "decisions.jsonl"
-SNAP_DIR = WS / "memory" / "snapshots"
 
 SCHEMA_VERSION = 2
 # Bumped when the meaning of an evaluation changes, so a stale row is identifiable.
@@ -502,35 +501,6 @@ def upsert_plan_decisions(
     if write:
         write_decisions(existing, path)
     return inserted, updated
-
-
-_SNAP_CACHE: dict[str, dict | None] = {}
-
-
-def snapshot_dates() -> list[str]:
-    return sorted(p.stem for p in SNAP_DIR.glob("20*.json"))
-
-
-def load_snapshot(day: str) -> dict | None:
-    if day not in _SNAP_CACHE:
-        p = SNAP_DIR / f"{day}.json"
-        try:
-            _SNAP_CACHE[day] = json.loads(p.read_text()) if p.exists() else None
-        except Exception:
-            _SNAP_CACHE[day] = None
-    return _SNAP_CACHE[day]
-
-
-def holding_from_snapshot(snapshot: dict | None, ticker: str) -> dict | None:
-    for region in ("hk_stocks", "us_stocks"):
-        for h in (snapshot or {}).get("portfolios", {}).get(region, {}).get("holdings", []):
-            if str(h.get("ticker")) == str(ticker):
-                return h
-    return None
-
-
-def _price(snapshot: dict | None, ticker: str, field: str = "current_price"):
-    return _float((holding_from_snapshot(snapshot, ticker) or {}).get(field))
 
 
 # ---------------------------------------------------------------------------

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -486,26 +486,19 @@ from ._watchdog_common import (  # noqa: E402
 )
 
 
-def _current_price_for(ticker):
-    """Look up the freshest current_price for ticker in portfolio.json.
-    Used as fallback `sim_entry_price` when LLM forgot to set
-    `simulated_entry_price` on the plan action — without it the future
-    outcome resolver can't compute cut/trim/add win/loss (see
-    brief_preflight._resolve_pending_outcomes)."""
-    try:
-        pf = json.loads((WS / 'portfolio.json').read_text())
-    except Exception:
-        return ''
-    for region in ('us_stocks', 'hk_stocks'):
-        for h in pf['portfolios'].get(region, {}).get('holdings', []) or []:
-            if h.get('ticker') == ticker:
-                cp = h.get('current_price')
-                return cp if cp not in (None, 0) else ''
-    return ''
-
-
 def log_decisions(today):
-    """Upsert today's validated, normalized plan into the v2 decision ledger."""
+    """Upsert today's validated, normalized plan into the v2 decision ledger.
+
+    `simulated_entry_price` is never backfilled here (#1003): it used to be
+    filled from portfolio.json `current_price`, whose docstring justified the
+    write with `brief_preflight._resolve_pending_outcomes` — a function the v2
+    refactor (a563b3c0) deleted. The live resolver, decision_v2.settle_decisions,
+    derives every entry/fill from canonical memory/bars and never reads this
+    field; the only consumers left render it as the public dashboard's
+    plannedPrice when execution_price is absent. Backfilling it meant publishing
+    a fetch-vintage quote (bars.py: previous close 7/15, intraday 5/15 on 00100)
+    as a price nobody ever planned. What the LLM authored stays; nothing is
+    invented."""
     plan_path = WS / 'memory' / f'{today}-plan.json'
 
     if not plan_path.exists():
@@ -516,10 +509,6 @@ def log_decisions(today):
         return
     if plan.get('schema_version') != 2 or not plan.get('decisions'):
         return
-    for d in plan['decisions']:
-        if d.get('simulated_entry_price') is None:
-            d['simulated_entry_price'] = _current_price_for(d.get('ticker'))
-    safe_write_json(str(plan_path), plan)
     # One load, mutate in memory, write once only if something changed (#916):
     # the old sequence was upsert(load+write) then load+settle+write — two full
     # rewrites per brief even on the common no-new-decisions day.

--- a/tests/test_postflight_entry_price_source.py
+++ b/tests/test_postflight_entry_price_source.py
@@ -1,0 +1,105 @@
+"""The ledger entry price must never be fabricated from snapshot vintage (#1003).
+
+brief_postflight.log_decisions used to backfill simulated_entry_price from
+portfolio.json current_price whenever the plan omitted it, justifying the write
+with brief_preflight._resolve_pending_outcomes — a function the v2 refactor
+(a563b3c0) deleted. The live resolver, decision_v2.settle_decisions, derives
+every entry/fill from canonical memory/bars and never reads this field; the
+only consumers left render it as the public dashboard's plannedPrice when
+execution_price is absent, so the backfill published fetch-vintage quotes as a
+price nobody ever planned. These tests pin the contract both ways: nothing is
+invented, and what the model authored survives.
+"""
+import json
+
+from clawock.decision import ledger as decision_v2
+from clawock.harness import brief_postflight
+
+
+def _decision(entry_price=None):
+    d = {
+        "schema_version": 2,
+        "decision_id": "dec-20260824-00100-add_only_on_trigger",
+        "episode_id": "ep-20260824-00100-add_only_on_trigger",
+        "plan_date": "2026-08-24",
+        "created_at": "2026-08-24T08:10:00+08:00",
+        "ticker": "00100",
+        "leg": "HK",
+        "strategy_id": "tactical_entry",
+        "action": "add_only_on_trigger",
+        "condition": {"type": "price_above", "price": 300.0,
+                      "description": "breakout", "valid_for_sessions": 1},
+        "confidence": 0.7,
+        "driven_by": "technical",
+        "size": {"shares": 100},
+    }
+    if entry_price is not None:
+        d["simulated_entry_price"] = entry_price
+    return d
+
+
+def _setup(tmp_path, decisions):
+    # A portfolio quote that disagrees with everything authored, on purpose:
+    # under the old backfill exactly this number leaked into the ledger and
+    # onto the public dashboard's plannedPrice.
+    (tmp_path / "portfolio.json").write_text(json.dumps(
+        {"portfolios": {
+            "hk_stocks": {"holdings": [
+                {"ticker": "00100", "current_price": 123.45}]},
+            "us_stocks": {"holdings": []},
+        }}), encoding="utf-8")
+    plan = {"schema_version": 2, "date": "2026-08-24", "decisions": decisions}
+    mem = tmp_path / "memory"
+    mem.mkdir(parents=True, exist_ok=True)
+    (mem / "2026-08-24-plan.json").write_text(
+        json.dumps(plan, ensure_ascii=False), encoding="utf-8")
+
+
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(brief_postflight, "WS", tmp_path)
+    # LEDGER reaches load/upsert/write as a definition-time default argument,
+    # so patching the module attribute alone would silently leave the real
+    # workspace ledger wired in. Patch the bound defaults instead — the real
+    # file I/O stays under test.
+    ledger_path = tmp_path / "memory" / "decisions.jsonl"
+    monkeypatch.setattr(
+        decision_v2.load_decisions, "__defaults__", (ledger_path,))
+    monkeypatch.setattr(
+        decision_v2.write_decisions, "__defaults__", (ledger_path,))
+    monkeypatch.setattr(
+        decision_v2.upsert_plan_decisions, "__defaults__",
+        (ledger_path, None, True))
+    monkeypatch.setattr(decision_v2, "BARS_DIR", tmp_path / "memory" / "bars")
+    monkeypatch.setattr(decision_v2, "_BAR_CACHE", {})
+    monkeypatch.setattr(decision_v2, "_SESSION_CACHE", {})
+
+
+def _ledger_rows(tmp_path):
+    text = (tmp_path / "memory" / "decisions.jsonl").read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def test_missing_entry_price_is_never_invented_from_portfolio_vintage(
+        tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    _setup(tmp_path, [_decision()])
+
+    brief_postflight.log_decisions("2026-08-24")
+
+    rows = _ledger_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].get("simulated_entry_price") is None
+    plan_after = json.loads(
+        (tmp_path / "memory" / "2026-08-24-plan.json").read_text(encoding="utf-8"))
+    assert plan_after["decisions"][0].get("simulated_entry_price") is None
+
+
+def test_model_authored_entry_price_survives_log_decisions(
+        tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    _setup(tmp_path, [_decision(entry_price=299.5)])
+
+    brief_postflight.log_decisions("2026-08-24")
+
+    rows = _ledger_rows(tmp_path)
+    assert rows[0]["simulated_entry_price"] == 299.5


### PR DESCRIPTION
## 背景

`[audit:ctx]` 第 2 遍（敌意对象 = 第 1 遍修复自身 + 同族残余）。第 1 遍把 price-in 信号源迁到 canonical bars（#963）后，反查「snapshot vintage 作判词/结算输入」这一缺陷类还有没有残余——找到第三处，且是唯一一处**仍在每次 postflight 生效**的。

## 缺陷

`brief_postflight.log_decisions` 每天用 portfolio.json 的 fetch-vintage `current_price` 回填 plan 里所有缺 `simulated_entry_price` 的 decision。其实体正当性写在 docstring 里：「without it the future outcome resolver can't compute win/loss (see brief_preflight._resolve_pending_outcomes)」——该函数在 v2 episodes 重构（a563b3c0）中已被删除；现行结算器 `decision_v2.settle_decisions` 的 entry/fill 全部从 canonical `memory/bars` 推导，从不读这个字段。

实盘证据：今日 `memory/2026-08-25-plan.json` **10/10 decisions** 全带回填价（LLM 一个都没写），多只已与后续刷新分叉（00100: 312.2 vs 现价 296.2）。消费面只剩 dashboard.py:859 与 DSH 插件 ledger.ts:478 在 `execution_price` 缺位时把它当公开 dashboard 的 `plannedPrice` 渲染——一个没人计划过的价格被当作计划价公开展示，并永久写入 decisions.jsonl。

同族死代码一并清除：`decision/ledger.py` 的 `snapshot_dates()/load_snapshot()/holding_from_snapshot()/_price()/_SNAP_CACHE/SNAP_DIR` 全仓零消费者，是 v2 bars 迁移留下的「读快照价」现成助手——#964 验收标准第 2 条（不再存在第二套基于快照字段的判词实现）的直接反例，留着就是给下一个重蹈覆辙的人递刀。

## 改动

- 删除 `_current_price_for` + 回填循环 + 为持久化回填而写的 `safe_write_json(plan_path)`（plan 到达 log_decisions 前已完成 normalize+validate，重写未变内容无意义）；docstring 改为记录为什么永不回填。
- 删除 ledger.py 六个死 snapshot 助手与常量；bars 结算注释原样保留。
- 新增 `tests/test_postflight_entry_price_source.py`（2 条行为断言：哨兵价 123.45 不泄漏进 plan/ledger；模型自述的 299.5 原样保留）。
- DSH 侧无需同步：`plannedPrice` 已是 null-safe（`union([literal(null), number])`，client.ts 渲染判空）。

Closes #1003
