### PR TITLE
fix: 清掉 weekly_review/news_digest prompt 里最后两处字数 KPI(#960)

### DIFF
--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -210,7 +210,7 @@ def build_user_prompt(news_payload, held_via):
         "### 风险 watch (若有)\n"
         "- 任何 financial guidance / regulatory / 大股东减持 / 失败合约 等 risk 关键词\n\n"
         "要求:\n"
-        "- 总长 ≤ 500 字 (digest 不是 brief)\n"
+        "- 这是 digest 不是 brief：短即是特性，密度优先，长度自己判断\n"
         "- 重复 / 营销稿 / 通用市场新闻 -> 忽略\n"
         "- 优先 ticker-specific catalyst (财报 / 合约 / 监管 / 大单)\n"
         "- gnews-rss 项只有标题没 summary, 要靠标题关键词判断, 不要编造细节\n"

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -347,7 +347,7 @@ def build_user_prompt(payload):
     the sanity bound was not the bound of what actually left the door."""
     return (
         f"根据这一周（{payload['week']}）的 brief / plan / decision v2 / risk 数据, "
-        f"写一篇 markdown 周复盘。长度 1500-2500 字。"
+        f"写一篇 markdown 周复盘。长度自己判断，不设字数目标。"
         "\n\n"
         "重点回答 4 个问题:\n"
         "1. **本周净值**: 总市值 USD-base 周初 vs 周末, "


### PR DESCRIPTION
Closes #960

- weekly_review:「长度 1500-2500 字。」→「长度自己判断，不设字数目标。」
- news_digest:「总长 ≤ 500 字 (digest 不是 brief)」→「这是 digest 不是 brief：短即是特性，密度优先，长度自己判断」
- postflight 防复读天花板( sanctioned 机制)不动
- 定向测试 42 绿(prompt payload x2 + cron contracts)