### PR TITLE
fix: outcome 桥接补 publish_failed 分支 + 被拒 send claim 不再写 primary 判词 (#1005 #1006) [audit:messages]

### DIFF
--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -376,7 +376,15 @@ def record_from_heartbeat(event):
         if event.get("failure_stage") == "input":
             record_stage(job, "llm", "failed", slot=slot, **details)
         record_stage(job, "postflight", "failed", slot=slot, **details)
-    elif state == "completed":
+    elif state in {"completed", "publish_failed"}:
+        # `publish_failed` is the heartbeat intraday_postflight emits when the
+        # sends succeeded but the dashboard data plane did not publish. It used
+        # to fall through every branch here, so a slot kcn actually received
+        # kept no llm/postflight/primary evidence at all and its final_product
+        # stayed pending forever (#1005) — #765's "delivered report filed as
+        # pending" through the data-plane door. The completed mapping below
+        # already grades it honestly: data_plane_status outside the ok set
+        # makes postflight `warning`, not `success`.
         postflight = event.get("postflight_status")
         data_plane = event.get("data_plane_status")
         data_plane_ok = data_plane in {None, "published", "current"}
@@ -395,16 +403,28 @@ def record_from_heartbeat(event):
         )
         wechat_ok = event.get("wechat_sent") is True
         telegram_ok = event.get("telegram_sent") is True
-        record_stage(
-            job,
-            "primary_delivery",
-            "success" if (wechat_ok or telegram_ok) else "failed",
-            slot=slot,
-            **{**details,
-               "channel": delivery_channel(wechat_ok, telegram_ok),
-               "wechat_ok": wechat_ok,
-               "telegram_ok": telegram_ok},
-        )
+        if event.get("send_claim_declined") and not (wechat_ok or telegram_ok):
+            # This process was REFUSED the send right by claim_send, so it is
+            # not a witness of this slot's delivery — recording its
+            # wechat_sent=False as a verdict overwrote the concurrent claim
+            # holder's success whenever the declined process's slow
+            # commit/publish work let it write last (#1006). The holder owns
+            # the verdict; if it died, receipt reconciliation fills the unknown
+            # stage and the watchdog backstop still fires. Detect-but-never-
+            # silence is intact: nothing is downgraded, only left to the one
+            # process that actually sent.
+            pass
+        else:
+            record_stage(
+                job,
+                "primary_delivery",
+                "success" if (wechat_ok or telegram_ok) else "failed",
+                slot=slot,
+                **{**details,
+                   "channel": delivery_channel(wechat_ok, telegram_ok),
+                   "wechat_ok": wechat_ok,
+                   "telegram_ok": telegram_ok},
+            )
     elif state == "watchdog_backstop":
         record_stage(job, "watchdog_delivery", "success", slot=slot, **details)
     elif state in {"watchdog_failed", "watchdog_rejected"}:

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -808,6 +808,10 @@ def main(argv=None):
     # deterministic compact card from plan.json (build_brief_card).
     wechat_sent = None
     tg_ok = None
+    # Set when claim_send refuses this process the send right: it then holds no
+    # delivery evidence and must not file a primary_delivery verdict over the
+    # concurrent holder's (#1006).
+    claim_declined = False
     brief_marker = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'
     # Idempotency: brief marker is per-date, fires once/day. If it already shows a
     # delivery this run is an openclaw auto-retry of a turn that errored only in
@@ -839,6 +843,7 @@ def main(argv=None):
                   f'did not land', file=sys.stderr)
             log({'tag': 'brief', 'action': 'send-claim-declined', 'reason': claim_reason})
             wechat_sent, send_out = False, f'send-claim-declined: {claim_reason}'
+            claim_declined = True
         else:
             if not args.dry_run:
                 mark_send_started(claim_path)
@@ -938,17 +943,22 @@ def main(argv=None):
         commit_ok=commit_ok,
         readability=readability,
     )
-    workflow_outcomes.record_stage(
-        job_name,
-        'primary_delivery',
-        ('success' if (wechat_sent or tg_ok) else
-         ('not_required' if status == 'fail' else 'failed')),
-        slot=slot,
-        dry_run=args.dry_run,
-        channel=workflow_outcomes.delivery_channel(bool(wechat_sent), bool(tg_ok)),
-        wechat_ok=bool(wechat_sent),
-        telegram_ok=bool(tg_ok),
-    )
+    # A declined claim process never sent, so it must not file the primary
+    # verdict — the concurrent holder owns it, and a false `failed` written
+    # after the holder's `success` would stand (reconciliation only fills
+    # unknown stages) even though kcn got the card (#1006).
+    if not claim_declined:
+        workflow_outcomes.record_stage(
+            job_name,
+            'primary_delivery',
+            ('success' if (wechat_sent or tg_ok) else
+             ('not_required' if status == 'fail' else 'failed')),
+            slot=slot,
+            dry_run=args.dry_run,
+            channel=workflow_outcomes.delivery_channel(bool(wechat_sent), bool(tg_ok)),
+            wechat_ok=bool(wechat_sent),
+            telegram_ok=bool(tg_ok),
+        )
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if (not args.dry_run and status in ('pass', 'warn')
             and (not projection_ready or data_plane_status != 'published')):

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -466,6 +466,10 @@ def main(argv=None):
     # a CONFIRMED failure (never doubles a report that went out here).
     wechat_sent = None
     tg_ok = None
+    # Set when claim_send refuses this process the send right: it then has no
+    # evidence about whether delivery happened and must not file a
+    # primary_delivery verdict over the concurrent holder's (#1006).
+    send_claim_declined = False
     marker = TMP / f'intraday-sent-{args.market}.json'
     # Idempotency: if openclaw auto-retried this run (post-turn summary-gen failure),
     # the report already went out on the prior attempt — skip the re-send. Intraday's
@@ -514,6 +518,7 @@ def main(argv=None):
                 log({'tag': f'intraday-{args.market}', 'action': 'send-claim-declined',
                      'reason': claim_reason})
                 wechat_sent, send_out = False, f'send-claim-declined: {claim_reason}'
+                send_claim_declined = True
             else:
                 mark_send_started(claim_path)
                 try:
@@ -607,6 +612,9 @@ def main(argv=None):
         # The ledger needs the same escalating/advisory split the banner uses:
         # an advisory-only slot delivered a clean report (#764).
         escalating_count=len(escalating), advisory_count=len(advisories),
+        # None is dropped by record(): only a genuine decline carries the flag
+        # that tells the outcome bridge this process holds no delivery verdict.
+        send_claim_declined=send_claim_declined or None,
     )
     result['heartbeat'] = {
         'job': heartbeat.get('job'), 'slot': heartbeat.get('slot'),

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -503,6 +503,10 @@ def main(argv=None):
             upgrading = True
 
     send_claim = 'not-required'
+    # True when claim_send refused this process the send right: it then holds no
+    # delivery evidence and must not file a primary_delivery verdict over the
+    # concurrent holder's (#1006).
+    claim_declined = False
     if blocked:
         print(f'idempotency: {args.market}-{args.phase} already delivered today — skip re-send',
               file=sys.stderr)
@@ -532,6 +536,7 @@ def main(argv=None):
             log({'tag': f'{args.market}-{args.phase}', 'action': 'send-claim-declined',
                  'reason': send_claim})
             wechat_sent = False
+            claim_declined = True
         else:
             wechat_sent, _ = deliver_wechat(args.market, args.phase, today, wechat_prefix, body,
                                             delivery_state=delivery_state,
@@ -550,23 +555,27 @@ def main(argv=None):
     # because the receipts are pruned within days (#771). WeChat's `ret=-2
     # prepare failed` is a known, upstream-wontfix, periodic failure that kcn has
     # decided not to chase; that is a reason to make it countable, not invisible.
-    wechat_ok = bool(wechat_sent)
-    telegram_ok = False
-    try:
-        telegram_ok = json.loads(report_marker.read_text()).get('tg_ok') is True
-    except Exception:
-        pass
-    primary_delivery_ok = wechat_ok or telegram_ok
-    workflow_outcomes.record_stage(
-        job_name,
-        'primary_delivery',
-        'success' if primary_delivery_ok else 'failed',
-        slot=slot,
-        channel=workflow_outcomes.delivery_channel(wechat_ok, telegram_ok),
-        wechat_ok=wechat_ok,
-        telegram_ok=telegram_ok,
-        deterministic_fallback=(status == 'fail'),
-    )
+    # A declined claim process records nothing: the concurrent holder owns this
+    # verdict, and a late false `failed` would stand forever because receipt
+    # reconciliation only fills unknown stages (#1006).
+    if not claim_declined:
+        wechat_ok = bool(wechat_sent)
+        telegram_ok = False
+        try:
+            telegram_ok = json.loads(report_marker.read_text()).get('tg_ok') is True
+        except Exception:
+            pass
+        primary_delivery_ok = wechat_ok or telegram_ok
+        workflow_outcomes.record_stage(
+            job_name,
+            'primary_delivery',
+            'success' if primary_delivery_ok else 'failed',
+            slot=slot,
+            channel=workflow_outcomes.delivery_channel(wechat_ok, telegram_ok),
+            wechat_ok=wechat_ok,
+            telegram_ok=telegram_ok,
+            deterministic_fallback=(status == 'fail'),
+        )
 
     commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
     data_plane_status = classify_data_plane(commit_ok, commit_msg)

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -211,6 +211,82 @@ def test_heartbeat_bridge_marks_data_publish_failure_as_postflight_warning(
     assert record["final_product"]["status"] == "degraded"
 
 
+def test_heartbeat_bridge_maps_the_publish_failed_state_like_completed(
+    tmp_path, monkeypatch
+):
+    """intraday_postflight emits state='publish_failed' when the sends landed
+    but the data plane did not publish. That state used to fall through every
+    bridge branch, so a slot kcn actually received kept no llm/postflight/
+    primary evidence and its final_product stayed pending forever (#1005)."""
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat(
+        {
+            "job": "美股盘中盯盘",
+            "market": "us",
+            "slot": "2026-07-24T22:00:00+08:00",
+            "state": "publish_failed",
+            "postflight_status": "pass",
+            "data_plane_status": "committed_local",
+            "wechat_sent": True,
+            "telegram_sent": True,
+        }
+    )
+
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["llm"]["status"] == "success"
+    assert record["stages"]["postflight"]["status"] == "warning"
+    assert record["stages"]["primary_delivery"]["status"] == "success"
+    assert record["final_product"]["status"] == "degraded"
+
+
+def test_a_send_claim_declined_process_never_files_the_primary_verdict(
+    tmp_path, monkeypatch
+):
+    """A process claim_send refused is not a witness of the delivery: filing its
+    wechat_sent=False as a verdict overwrote the concurrent claim holder's
+    success whenever the declined process's slow commit work let it write last
+    (#1006). Its llm/postflight evidence still counts; only the primary verdict
+    is left to the process that actually sent."""
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat(
+        {
+            "job": "美股盘中盯盘",
+            "market": "us",
+            "slot": "2026-07-24T22:00:00+08:00",
+            "state": "completed",
+            "postflight_status": "pass",
+            "wechat_sent": False,
+            "send_claim_declined": True,
+        }
+    )
+
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["llm"]["status"] == "success"
+    assert record["stages"]["primary_delivery"]["status"] == "unknown"
+
+
+def test_a_declined_flag_does_not_suppress_a_confirmed_delivery(
+    tmp_path, monkeypatch
+):
+    _isolate(tmp_path, monkeypatch)
+    outcomes.record_from_heartbeat(
+        {
+            "job": "美股盘中盯盘",
+            "market": "us",
+            "slot": "2026-07-24T22:00:00+08:00",
+            "state": "completed",
+            "postflight_status": "pass",
+            "wechat_sent": False,
+            "telegram_sent": True,
+            "send_claim_declined": True,
+        }
+    )
+
+    record = outcomes.load_ledger()["records"][0]
+    assert record["stages"]["primary_delivery"]["status"] == "success"
+    assert record["stages"]["primary_delivery"]["channel"] == "telegram"
+
+
 def test_market_closed_is_a_skipped_product_not_a_failure(tmp_path, monkeypatch):
     _isolate(tmp_path, monkeypatch)
     record = outcomes.record_stage(


### PR DESCRIPTION
## 背景（P2 对抗对象 = 上一轮修复本身）

第 1 轮 messages 审计（#966/#967/#968，PR #969）修了 watchdog in-flight 闸、nostr 假绿收据、receipt 回填盲区。本轮回归排查确认三处修复在 vendored nostr-tools 2.23.9 与当前代码上仍然成立、无新耦合；随后找到两个上一轮没看到的判定层缺陷。

## 修复 1 — 心跳状态 `publish_failed` 无 outcome 桥接分支（Closes #1005）

- `intraday_postflight.py:592-598` 在「投递成功但数据面发布失败」时发的心跳 state 是字面量 `'publish_failed'`，而 `workflow_outcomes.record_from_heartbeat` 没有这个分支——事件静默落空，该槽位的 llm/postflight/primary_delivery 三段永远 unknown、final_product 永远 pending。kcn 实际收到了消息，公开台账却说无终态证据（#765 换门重演）。
- 修复：桥接把 `publish_failed` 并入 completed 同一套映射；`data_plane_status` 不在 ok 集合自然把 postflight 记成 warning、final=degraded。全仓 grep 确认没有消费方依赖该状态字符串字面值。
- 测试：`test_heartbeat_bridge_maps_the_publish_failed_state_like_completed`。

## 修复 2 — 被拒 send claim 的 postflight 会改写并发成功投递的判词（Closes #1006）

send claim（#508）存在的原因就是两个 postflight 会并发跑同一槽位。被拒绝的一方目前仍会记 primary_delivery：

- intraday/brief 的 declined 分支先跑慢的 publish/commit 再记录，持 claim 方发送完也要走同样的慢路径——谁后写谁生效，顺序近似随机，约一半概率把成功槽位判成 failed；
- report 的 declined 分支立即读 marker（对方还在发送途中必然不存在）→ 记 failed；
- 写错后无人纠偏：reconcile 只填 unknown 段，假 failed 挂满整个保留窗口。

修复（不沉默原则完整保留）：被拒绝 send 权的进程本来就不是这次投递的证人，不下判词——

1. 桥接层：completed/publish_failed 事件带 `send_claim_declined=True` 且两路布尔皆非 true 时跳过 primary_delivery；
2. intraday declined 分支给 heartbeat 附该标志（None 被 record() 丢弃，正常事件零变化）；
3. brief/report declined 分支跳过各自的 record_stage('primary_delivery')。

持 claim 方成功→success；失败→它自己的 failed；中途死亡→stage 停留 unknown 由 receipt reconcile 或 watchdog backstop 兜住，全程可检测。
测试：`test_a_send_claim_declined_process_never_files_the_primary_verdict`、`test_a_declined_flag_does_not_suppress_a_confirmed_delivery`，另以真实 `cron_heartbeat.record → record_from_heartbeat` 全链路手工验证 declined/normal 两形态。

## 验证

- 针对性跑：test_workflow_outcomes(34) / test_postflight_send_claim / test_report_watchdog_inflight / test_intraday_watchdog_inflight / test_intraday_delta_gate / test_brief_postflight_fail_closed / retry-parity×2 / slots / brief-watchdog×3 / claim_provenance ≈141 passed
- `test_runtime_coupling_ratchet::test_the_cron_writes_moved_rather_than_vanished` 在干净 origin/master 基线同样红——既有问题，与本 PR 无关（同 P1 结论）
- 未触碰 profile/instances/兼容包装层；无双实现 parity 面受影响
