### PR TITLE
判定卡第五次迭代：单词卡牌组 + 首页背景去蓝

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -173,13 +173,18 @@
   @media (prefers-color-scheme: light) {
     :root {
       /* 亮色 canvas 纸色：白玻璃要有可对的底。before 实测亮色面底只差
-         11~20 级且无色度差（strip 甚至纯白 255 打在 233 的底上）—— #995
-         同款判据：先给页面一个非白的 canvas，白玻璃才有得透。 */
-      --bg: #E7ECF3;
-      /* 副光同样从绿改蓝（理由同 :root：第四种装饰色 + 底色偏绿）。 */
-      --bg-glow: rgba(64,140,196,.22);
-      --bg-glow-2: rgba(48,132,226,.10);
-      --bg-glow-3: rgba(84,168,255,.07);
+          11~20 级且无色度差（strip 甚至纯白 255 打在 233 的底上）—— #995
+          同款判据：先给页面一个非白的 canvas，白玻璃才有得透。
+          2026-08-25 第五次迭代修正：纸色与三盏光池全部去蓝相 —— #1002 把
+          canvas 提到 #E7ECF3、光池抬到蓝 .22/.10/.07 后，页沟槽实测
+          (223,230,238)，B−R=16（改前 #F3F6F9 时代实测 (237,242,246)，
+          B−R=9），整页读成「蓝底」。canvas 回到原中性白；光池保留几何与
+          明度语言，色相同步中和：主光是白光池，两盏副光是中性灰的影池，
+          玻璃 saturate(182%) 再没有蓝色相可放大。暗主题不动。 */
+      --bg: #F3F6F9;
+      --bg-glow: rgba(255,255,255,.45);
+      --bg-glow-2: rgba(148,157,166,.09);
+      --bg-glow-3: rgba(148,157,166,.07);
       --surface-0: #F8FAFC;
       --surface-1: #FFFFFF;
       --surface-2: #F2F5F8;
@@ -291,6 +296,9 @@
        文字会从卡里透出来叠字。 */
     body .card.overview-verdict { background: var(--surface-1); }
     body .overview-strip { background: var(--surface-1); }
+    /* 判定卡自画光池（2026-08-25 第四次迭代起）同属「光穿过材质」，实色
+       表面上一并关掉 —— 本块注释自己的判据，v1 漏了这条。 */
+    body .card.overview-verdict::before { display: none; }
     /* Same reason the sheens go: they are light passing through a material.
        On an opaque surface they are just a gradient nobody asked for. */
     body .card, body .hero-deck, body .overview-strip { background-image: none; }

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -275,7 +275,7 @@
     body .desk-rail,
     body .status-banner,
     body .hero-deck,
-    body .card.overview-verdict,
+    body .card.verdict-deck .deck-card,
     body .overview-strip {
       -webkit-backdrop-filter: none;
       backdrop-filter: none;
@@ -294,11 +294,11 @@
     body .hero-deck { background: var(--surface-1); }
     /* 玻璃面 blur 关掉后必须整体回实色，否则变成「无模糊的透底」，背后的
        文字会从卡里透出来叠字。 */
-    body .card.overview-verdict { background: var(--surface-1); }
+    body .card.verdict-deck .deck-card { background: var(--surface-1); }
     body .overview-strip { background: var(--surface-1); }
-    /* 判定卡自画光池（2026-08-25 第四次迭代起）同属「光穿过材质」，实色
+    /* 判定牌自画光池（2026-08-25 第五次迭代起）同属「光穿过材质」，实色
        表面上一并关掉 —— 本块注释自己的判据，v1 漏了这条。 */
-    body .card.overview-verdict::before { display: none; }
+    body .verdict-deck .deck-card::before { display: none; }
     /* Same reason the sheens go: they are light passing through a material.
        On an opaque surface they are just a gradient nobody asked for. */
     body .card, body .hero-deck, body .overview-strip { background-image: none; }
@@ -2580,96 +2580,116 @@
   /* Equity Curve 卡已挪去 Reflect 净值表现区（与 Daily P&L 同区、共用市场切换器）。
      Overview 首屏只留 hero-deck 的 spark 一条形状；今日判定从「Equity(8) + 判定(4)」
      的伴排改为独占整行。 */
-  .overview-verdict {
-    grid-column: 1 / -1; padding: 20px var(--card-inset) 18px;
-    position: relative; /* 光池 ::before 的定位父级 */
-    /* 首屏第二块浮起来的表面（指挥台之后）：DSH 插件同款玻璃配方 ——
-       不透明色写在前（引擎不支持 color-mix/backdrop-filter 时退回实色卡），
-       半透明主题面 + backdrop blur + saturate。结构判据（#887）：毛玻璃
-       成立先证明背后有东西可糊 —— body 两盏 fixed 光已拉高到覆盖这一段，
-       指挥台的落影也从这层透出去；凹槽/量表那套光影不叠 blur，不做
-       「玻璃里再糊一层玻璃」。 */
-    background: var(--surface-1);
-    background: var(--sheen-1), var(--glass-card);
-    -webkit-backdrop-filter: var(--blur-card);
-    backdrop-filter: var(--blur-card);
-    /* 原来的 480px 地板是为和 Equity 卡凑同一行；挪走后按各档实测内容高度
-       重新预留（数据到达前占位，否则判定卡长高会把下方整列推下去 —— CLS
-       实测 0.11，预留后回到基线）。
-       地板保持整卡一级、不下沉到子行：盘中横幅在 overview 是
-       is-pending 不占位的（#890），横幅日它出现时会在卡内把要点/硬闸往下推
-       —— 整卡地板吸收这种内部重排，子行地板会把这次重排漏成页面级位移。
-       地板值 = 构图定稿后横幅日扫宽实测上界 +2（见各断点注释）。
-       2026-08-24 构图改双栏（宽屏左判词右硬闸），整卡数据态高度大幅收窄，
-       三档地板随之重量（值见 min-height 与各断点覆盖，横幅日扫宽取上界）。 */
-    /* 地板 = 构图定稿后横幅日扫宽实测上界 +2。2026-08-25 第三次迭代后
-       重扫：mono 数字改变判词折行、右列改仪表面板，1200/1024 实测 317
-       （旧构图 314、旧地板 296 本就已低于当日横幅），地板提到 319。 */
+  /* ── 判定牌组（第五次迭代）──────────────────────────────────────
+     大白板被否（kcn：完全重构成卡片堆叠/轮换播放），改单词卡式牌组：
+     顶牌全显，后续三张在下层以 scale+translateY 露边暗示可换。容器占
+     原 .overview-verdict 的栅格槽与地板；每张牌一个主题，玻璃配方不变
+     （半透明面 + 斜向 sheen + 高光切边 + 自画光池），从「一张大白板」
+     收成「一叠玻璃牌」。 */
+  .verdict-deck {
+    grid-column: 1 / -1;
+    display: flex; flex-direction: column; gap: 10px;
+    position: relative;
+    /* 地板跟随原判定卡三档（319/506/571，横幅日扫宽上界 +2）：牌组拆张
+       后单牌内容更短，旧地板是安全上界 —— 预留只增不减，CLS 不劣化。 */
     min-height: 319px;
   }
-  /* 自画光池：玻璃配方的最后一味（DSH 页面光同思路，收进材质自己）。
-     body 的 key light 已拉到 860px，但那是页面的光，长页下段会衰减；
-     材质在自己表面上方画一池极弱的冷光，frost 全卡都有东西可糊。画在
-     玻璃面之上、内容之下（backdrop-filter 让本卡成为 stacking context，
-     z-index:-1 落在两者之间），不叠第二层 blur —— 玻璃里再糊玻璃是泥。 */
-  .overview-verdict::before {
+  .verdict-deck-stage {
+    position: relative; flex: 1; min-height: 0;
+    /* 横滑是手势主通道；纵向滚动必须照常（pan-y 只锁横向）。 */
+    touch-action: pan-y; cursor: grab;
+  }
+  .verdict-deck-stage.is-dragging { cursor: grabbing; }
+  .deck-card {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column;
+    padding: 20px var(--card-inset) 18px;
+    overflow: hidden;
+    border-radius: var(--radius);
+    /* 牌本体 = 玻璃内表面（配方沿第四次迭代）：半透明面透出页面光，
+       斜向 sheen 给「斜着反光」的读感，inset 环是切边凭据，::before
+       是长页下段的自画光池。不透明色写在前兜底。凹槽/量表光影不叠
+       blur —— 玻璃里再糊玻璃是泥（#937）。 */
+    background: var(--surface-1);
+    background:
+      linear-gradient(115deg, rgba(255,255,255,.085), rgba(255,255,255,.02) 30%, transparent 52%),
+      var(--sheen-1), var(--glass-card);
+    -webkit-backdrop-filter: var(--blur-card);
+    backdrop-filter: var(--blur-card);
+    box-shadow:
+      inset 0 0 0 1px rgba(255,255,255,.055),
+      inset 0 1px 0 var(--spec-2),
+      var(--edge-bottom), var(--shadow-card);
+    /* 换牌动画只动 transform/opacity；transform 由 JS 逐帧写入
+       （弹簧积分），CSS 不再另给 transition 免得双重插值。 */
+    will-change: transform;
+  }
+  @media (prefers-color-scheme: light) {
+    .deck-card {
+      background:
+        linear-gradient(115deg, rgba(255,255,255,.8), rgba(255,255,255,.22) 30%, transparent 52%),
+        var(--sheen-1), var(--glass-card);
+      box-shadow:
+        inset 0 0 0 1px rgba(255,255,255,.95),
+        inset 0 1px 0 var(--spec-2),
+        var(--edge-bottom), var(--shadow-card);
+    }
+  }
+  .deck-card::before {
     content: ""; position: absolute; inset: 0; z-index: -1;
     border-radius: inherit; pointer-events: none;
     background: radial-gradient(540px 210px at 14% -30px,
       rgba(255,255,255,.05), transparent 70%);
   }
   @media (prefers-color-scheme: light) {
-    .overview-verdict::before {
-      /* 亮色主题白光不可见，换一池极弱的冷色；浓度仍以「读作深度、
-         绝不读作色带」为界。 */
+    .deck-card::before {
       background: radial-gradient(540px 210px at 14% -30px,
         rgba(0,110,184,.045), transparent 70%);
     }
   }
-  /* 宽屏双栏：左列=这张卡「说的话」（判定句 + 要点），右列=这张卡「管的
-     事」（触发中的硬闸）。此前四段全宽竖排、段段一条发丝线，整卡读成一摞
-     通栏横幅 —— 「大字报」的第二层（第一层字号 #927 已收）：构图要有主次
-     分栏。DOM 不动，grid-areas 重排；<1024 回单列自然流。 */
-  @media (min-width: 1024px) {
-    .overview-verdict {
-      display: grid;
-      grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
-      grid-template-rows: auto auto 1fr;
-      grid-template-areas:
-        "head gates"
-        "verdict gates"
-        "points gates";
-      align-items: stretch; align-content: start;
-    }
-    .overview-verdict-head { grid-area: head; }
-    .overview-status { grid-area: verdict; }
-    .overview-verdict .today-highlights { grid-area: points; align-content: start; }
-    .overview-gates {
-      grid-area: gates;
-      /* 右列从「发丝线分栏」升级为嵌进玻璃的仪表面板：材质分层（玻璃面上
-         一块实色内衬）替代字号分层 —— 这是「层级靠结构与材质」的正文。
-         内衬必须用不透明复合色 --card-2：玻璃上的凹槽若再走半透明，就是
-         「玻璃里开天窗」，糊出来是一团泥（#937 打孔判据）。内衬自己的
-         高光边（inset spec）让它读作下沉的 well 而不是贴上去的纸。 */
-      background: var(--card-2);
-      border: 1px solid var(--border-subtle);
-      border-radius: 12px;
-      padding: 14px 16px 12px; margin-left: 24px;
-      box-shadow: inset 0 1px 0 var(--spec-1);
-      /* 内衬只抱内容、不 stretch 到左列底：well 里的空白是「没有数据」，
-         玻璃上的空白是「构图留白」，两者别混。暗主题下面板与玻璃面只差
-         几个灰阶，边线提到 border-strong 才读得出边界（亮面玻璃差更大，
-         仍用 subtle）。 */
-      align-self: start;
-    }
-    /* 暗主题下面板与玻璃面只差几个灰阶，边线提到 border-strong 才读得出
-       边界；亮面玻璃对比更大，保持 subtle。 */
-    @media (prefers-color-scheme: dark) {
-      .overview-verdict .overview-gates { border-color: var(--border-strong); }
-    }
+  /* 进度指示点兼自动轮播进度条：轨是发丝底，填充 scaleX 由 JS 按
+     剩余时间逐帧写（禁 keyframes）。高度固定 —— 构图常量。 */
+  .deck-dots {
+    flex: 0 0 auto;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    height: 12px; padding: 1px 0;
   }
-  .overview-verdict-head,
-  .overview-gates-head {
+  .deck-dot {
+    appearance: none; border: 0; padding: 0; margin: 0;
+    width: 26px; height: 4px; border-radius: 2px;
+    background: var(--border-subtle); cursor: pointer;
+    position: relative; overflow: hidden;
+  }
+  .deck-dot i {
+    position: absolute; inset: 0; border-radius: inherit;
+    background: var(--text-faint);
+    transform: scaleX(0); transform-origin: left center;
+  }
+  .deck-dot[aria-current="true"] i { background: var(--text-secondary); }
+  .deck-dot:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+  /* 牌内元素入场 stagger（30~80ms）：临时类压住初态，去类后 transition
+     生效；delay 挂 nth-child，400ms 后由 JS 摘除 delay 类。 */
+  .deck-card > * { transition: opacity .24s var(--ease-out), transform .24s var(--ease-out); }
+  .deck-card.deck-preenter > * { transition: none; opacity: 0; transform: translateY(6px); }
+  .deck-card.deck-enter > *:nth-child(1) { transition-delay: 30ms; }
+  .deck-card.deck-enter > *:nth-child(2) { transition-delay: 55ms; }
+  .deck-card.deck-enter > *:nth-child(n+3) { transition-delay: 80ms; }
+  /* reduced-motion 全套退化：无位移、无轮播（JS 同源判断），换牌退化为
+     交叉淡化 + 指示点切换。 */
+  @media (prefers-reduced-motion: reduce) {
+    .deck-card,
+    .deck-card > * { transition-duration: .16s !important; transition-delay: 0s !important; }
+    .deck-preenter > * { opacity: 0; transform: none; }
+  }
+  /* 牌内硬闸区：原「段间发丝线」是通栏卡的分段语言；独立成牌后它就是
+     牌的正文，去掉段首线与顶垫。 */
+  .verdict-deck .overview-gates { border-top: 0; padding-top: 0; margin: 12px 0 0; }
+  /* 牌尾跳转钮：贴牌底（flex 列的 margin-top:auto），不随内容长短漂。 */
+  .deck-card-jump { margin-top: auto; align-self: flex-end; }
+  /* 牌组化后双栏 grid-areas 与「玻璃上的仪表面板 well」一并退场：硬闸
+     升为独立一张牌（主题即边界，比分栏更强），well 的材质分层职责由
+     「牌与牌的堆叠」接管 —— 玻璃上不再开凹槽（#937 判据不变）。 */
+  .overview-verdict-head {
     display: flex; align-items: center; justify-content: space-between; gap: 10px;
   }
   /* 眉标并成一行：「决策面板 · 今日判定」—— 两条竖排的 micro 眉标是同一层
@@ -2697,45 +2717,112 @@
   .overview-strip-link:focus-visible {
     outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 3px;
   }
-  /* 判词行：这张卡的主句。三种行式样统一为无盒 + 发丝线：去胶囊底色与蓝点，
-      上下发丝线夹住。 */
-  /* 2026-08-24：--fs-verdict（24~34px、600 字重）把这句话渲染成了一张大字报
-     （kcn：「今日判定那个大字报不要，太奇怪了」）。它不是标题，是这张卡的
-     导语句 —— 一句会天天变的状态描述。降到 --fs-xl / 550 字重 / 1.55 行高，
-     并把负字距收回 0：字距是随字号定的，19px 上再收紧只会挤。
-     仍然是这张卡里最大的字（其余行 13px），层级没丢，只是不再喊。
-     时间戳从句中挪到句下：原来 sb-time 是行内 flex 尾巴，句子一折行它就
-     悬在第一行行尾的半空中，读起来像句子的一部分。 */
+  /* 判词行：2026-08-24 从大字报降到 --fs-xl；第四次迭代再降一档 ——
+     券商终端里没有成段 prose，判词句退成一行 caption（--fs-sm / 次级色 /
+     单行截断，全文进 title），结构信息全部拆进下面的 chip。发丝线上下夹住
+     的版式保留：它就是终端里那行「快照注脚」。 */
   .overview-status {
     display: block;
-    margin: 14px 0 0; padding: 13px 0 12px;
+    margin: 12px 0 0; padding: 10px 0 0;
     background: none; border: 0; border-radius: 0;
     border-top: 1px solid var(--border-subtle);
     border-bottom: 0;
     -webkit-backdrop-filter: none; backdrop-filter: none;
-    font-size: var(--fs-xl); line-height: 1.55; letter-spacing: 0;
-    max-width: 68ch;
+    font-size: var(--fs-sm); line-height: 1.5; letter-spacing: 0;
   }
   .overview-status .sb-pulse { display: none; }
-  .overview-status .sb-text { font-weight: 550; }
+  .overview-status .sb-text {
+    font-weight: 500; color: var(--text-secondary);
+    display: -webkit-box; -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1; overflow: hidden;
+  }
   .overview-status .sb-time {
-    display: block; margin-top: 7px;
+    display: block; margin-top: 6px;
     font-size: var(--fs-micro); color: var(--text-faint);
     font-family: var(--mono); white-space: nowrap;
   }
-  /* 要点行 = 判定句的注脚：整块左缩进挂一条发丝竖线（引文层级），行间不再
-      一条条横线 —— 横线节奏和硬闸区重复，竖线才读得出来「这几行是上面那句
-      的展开」。真告警行仍整行红字。 */
-  .overview-verdict .today-highlights {
-    display: grid; grid-template-columns: 1fr; gap: 0;
+  /* 要点区 = 终端的状态行：同类信息一排徽章 chip，放不下折行，不做段落。
+     chip 三段式 label+value+delta；统一高度 24 / 圆角 7 / micro 字阶 /
+     发丝线描边；数值段 mono tabular（仓库字规：mono 只用于数字）。
+     底色用不透明 --card-2 —— 玻璃上的开孔必须不透明（#937 打孔判据），
+     tone 只染边线与 value，不染整底：满屏色底是行情软件最廉价的读感。 */
+  .deck-card .today-highlights {
+    display: flex; flex-wrap: wrap; gap: 6px;
     margin: 12px 0 0; min-height: 0;
   }
-  .overview-verdict .hl-chip {
-    min-width: 0; padding: 7px 0 7px 13px; font-size: var(--fs-sm);
-    overflow-wrap: anywhere; color: var(--text-secondary);
-    border-bottom: 0; border-left: 2px solid var(--border-subtle);
+  .deck-card .hl-chip {
+    display: inline-flex; align-items: center; gap: 7px;
+    min-width: 0; max-width: 100%; height: 24px; padding: 0 9px;
+    background: var(--card-2); border: 1px solid var(--border-subtle);
+    border-radius: 7px; font-size: var(--fs-micro); line-height: 1;
   }
-  .overview-verdict .hl-chip:last-child { padding-bottom: 0; }
+  .deck-card .hl-chip .hl-k {
+    flex: 0 0 auto; color: var(--text-tertiary);
+    font-weight: 600; white-space: nowrap;
+  }
+  .deck-card .hl-chip .hl-v {
+    font-family: var(--mono); font-size: var(--fs-xs); font-weight: 600;
+    font-variant-numeric: tabular-nums; white-space: nowrap;
+  }
+  .deck-card .hl-chip .hl-d {
+    min-width: 0; color: var(--text-faint); white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis;
+  }
+  /* tone 三档 + 中性：ok/warn/bad 只动边线与 value 色（delta 保持中性），
+     浓度取「读得出档位」的最低混色。 */
+  .deck-card .hl-chip.tone-ok { border-color: color-mix(in srgb, var(--positive) 32%, var(--border-subtle)); }
+  .deck-card .hl-chip.tone-ok .hl-v { color: var(--positive); }
+  .deck-card .hl-chip.tone-warn { border-color: color-mix(in srgb, var(--warning) 40%, var(--border-subtle)); }
+  .deck-card .hl-chip.tone-warn .hl-v { color: var(--warning); }
+  .deck-card .hl-chip.tone-bad { border-color: color-mix(in srgb, var(--negative) 45%, var(--border-subtle)); }
+  .deck-card .hl-chip.tone-bad .hl-v { color: var(--negative); }
+  /* 距离计量条（最近触发 chip 内）：到档位的接近度画成条，不写形容词。
+     轨宽写死 44px —— 图形宽度是构图的函数，不是 dist 的函数（CLS 判据）；
+     填充宽度由 JS 按 |dist| 归一后写入，精确值仍在 title。 */
+  .deck-card .hl-meter {
+    position: relative; flex: 0 0 auto; width: 44px; height: 4px;
+    border-radius: 2px; background: var(--border-subtle); overflow: hidden;
+  }
+  .deck-card .hl-meter i {
+    position: absolute; top: 0; bottom: 0; left: 0; border-radius: 2px;
+    background: var(--text-faint);
+  }
+  .deck-card .tone-warn .hl-meter i { background: var(--warning); }
+  .deck-card .tone-bad .hl-meter i { background: var(--negative); }
+  /* 异动迷你柱：今日 top movers 画成一排零轴柱（图为主），ticker+pct 退为
+     caption。柱高/柱位由 JS 写死 px —— 容器高度固定 26px，构图不随数据变。 */
+  .deck-card .hl-movers {
+    display: grid; width: 100%; max-width: 480px;
+    margin: 2px 0 0; padding: 10px 0 0;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .deck-card .hl-mv { min-width: 0; }
+  /* 40px 画布、零轴居中：柱最长 17px（JS 归一），上下各留 3px —— 柱永远
+     待在画布内，构图是常量，不是数据的函数。 */
+  .deck-card .hl-mv-bar { position: relative; height: 40px; }
+  .deck-card .hl-mv-bar::before {
+    content: ""; position: absolute; left: 0; right: 0; top: 50%;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .deck-card .hl-mv-bar i {
+    position: absolute; left: 50%; transform: translateX(-50%);
+    width: 14px; border-radius: 2px;
+  }
+  .deck-card .hl-mv-bar i.up { background: var(--positive); bottom: 50%; }
+  .deck-card .hl-mv-bar i.down { background: var(--negative); top: 50%; }
+  .deck-card .hl-mv-cap {
+    display: flex; align-items: baseline; justify-content: center;
+    gap: 6px; margin-top: 5px; min-width: 0;
+    font-size: var(--fs-micro); line-height: 1;
+  }
+  .deck-card .hl-mv-t {
+    color: var(--text-tertiary); font-weight: 600;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .deck-card .hl-mv-p {
+    flex: 0 0 auto; font-family: var(--mono); font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
   .overview-gates {
     padding-top: 16px; border-top: 1px solid var(--border-subtle);
   }
@@ -2745,14 +2832,14 @@
   }
   .overview-gates-directive {
     display: -webkit-box; margin-top: 8px; overflow: hidden;
-    -webkit-box-orient: vertical; -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical; -webkit-line-clamp: 1;
     color: var(--text-tertiary); font-size: var(--fs-micro); line-height: 1.45;
   }
   .overview-gates .risk-alerts { margin-top: 8px; gap: 0; }
-  /* 硬闸行与要点行统一为无盒 + 发丝线：去底色与圆角，行间发丝线分隔，
-     严重度由左侧 2px 色条承载（红=high / amber=medium），icon 圆点退场。 */
+  /* 硬闸行：无盒 + 发丝线，行间对齐列（终端读感）；严重度由左侧 2px 色条
+     承载（红=high / amber=medium），icon 圆点退场。计数本身已在表头点阵。 */
   .overview-gates .risk-alert {
-    align-items: flex-start; padding: 8px 0 8px 10px;
+    align-items: flex-start; padding: 7px 0 7px 10px;
     font-size: var(--fs-micro); line-height: 1.35;
     background: none; border: 0; border-radius: 0;
     border-top: 1px solid var(--border-subtle);
@@ -2763,15 +2850,16 @@
   /* 硬闸计数控件（JS renderRiskGuardrail 落进 overview-guardrail-count）：
      10 槽点阵，on=触发中（红）/ off=空槽（发丝线色）。尺寸间距写死 ——
      这个图形的宽度只随构图变、不随 breach_count 变。徽章自身的胶囊底
-     退场：面板里它是一枚读数，不是一枚按钮。 */
-  .overview-gates-head .badge { background: none; padding: 0; }
-  .overview-gates-head .gt-tally { display: inline-flex; align-items: center; gap: 4px; }
-  .overview-gates-head .gt-dot {
+     退场：面板里它是一枚读数，不是一枚按钮。牌组化后它挂在牌头右侧
+     （原 .overview-gates-head 已随双栏退场）。 */
+  .deck-card .badge { background: none; padding: 0; }
+  .deck-card .gt-tally { display: inline-flex; align-items: center; gap: 4px; }
+  .deck-card .gt-dot {
     width: 5px; height: 5px; border-radius: 50%;
     background: var(--border-strong); opacity: .45;
   }
-  .overview-gates-head .gt-dot.on { background: var(--negative); opacity: 1; }
-  .overview-gates-head .gt-more {
+  .deck-card .gt-dot.on { background: var(--negative); opacity: 1; }
+  .deck-card .gt-more {
     margin-left: 2px; font: 600 var(--fs-micro)/1 var(--mono);
     color: var(--negative);
   }
@@ -2787,14 +2875,11 @@
      opacity/transform（不参与布局，CLS 不受影响）；刷新时类不翻转，不会
      重播；不支持 :has 的引擎直接呈现；reduced-motion 由全局闸与本闸双覆盖。 */
   @media (prefers-reduced-motion: no-preference) {
-    .overview-verdict:has(.overview-status:not(.is-pending)) .overview-status {
+    .verdict-deck .deck-card:first-child:has(.overview-status:not(.is-pending)) .overview-status {
       animation: verdict-rise var(--duration-standard) var(--ease-out) backwards;
     }
-    .overview-verdict:has(.overview-status:not(.is-pending)) .today-highlights {
+    .verdict-deck .deck-card:first-child:has(.overview-status:not(.is-pending)) .today-highlights {
       animation: verdict-rise var(--duration-standard) var(--ease-out) 60ms backwards;
-    }
-    .overview-verdict:has(.overview-status:not(.is-pending)) .overview-gates {
-      animation: verdict-rise var(--duration-standard) var(--ease-out) 120ms backwards;
     }
   }
   @keyframes verdict-rise {
@@ -2913,8 +2998,8 @@
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
     /* 506：768px 端横幅日实测（504，与旧构图持平）+2。 */
-    .overview-verdict { min-height: 506px; }
-    .overview-verdict, .overview-strip,
+    .verdict-deck { min-height: 506px; }
+    .verdict-deck, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
   }
@@ -2922,7 +3007,7 @@
     :root { --card-inset: 20px; }
     .overview-command { display: flex; flex-direction: column; gap: 12px; }
     .hero-deck, .hero-health,
-    .overview-verdict, .overview-strip,
+    .verdict-deck, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { width: 100%; min-width: 0; }
     .hero-deck { grid-template-columns: minmax(0, 1fr); }
@@ -2940,7 +3025,7 @@
     .dh-detail { grid-column: 1 / -1; white-space: normal; }
     /* 571：390px 横幅日实测 569（旧构图 566、旧地板 564 同样已破）
        +2 —— 增量来自 mono 数字在窄列的折行变化。 */
-    .overview-verdict { min-height: 571px; }
+    .verdict-deck { min-height: 571px; }
     .overview-strip { display: flex; flex-direction: column; }
     .overview-strip-cell {
       min-height: 0; border-right: 0; border-bottom: 1px solid var(--border-subtle);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -92,20 +92,31 @@
 
   // A. Hero top "今日要点" triage strip — pure synthesis of the compiled
   // Overview projection. Answers "what should I look at today" in 5s.
+  // 第四次迭代修正二（券商终端化）：状态/数值/档位一律徽章 chip（label+
+  // value+delta 三段式，tone ok/warn/bad），同类一排、放不下折行，不做段落；
+  // 能画的数据画微图（接近度计量条、异动零轴迷你柱），文字退为 caption。
+  // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
     if (!el) return;
     const chips = [];
+    const chip = (tone, k, v, d, meterPct) =>
+      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
+      + (v ? `<span class="hl-v">${v}</span>` : "")
+      + (d ? `<span class="hl-d">${d}</span>` : "")
+      + (meterPct == null ? ""
+        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
+      + `</span>`;
 
     // 0. Regime — the day's default stance (same risk_on/neutral/risk_off the brief acts on)
     const rg = safe(DATA, "regime");
     if (rg && rg.label) {
-      const map = { risk_on:  { cls:"hl-up",    ic:"", stance:"默认持有, 别瞎动" },
-                    neutral:  { cls:"hl-info",  ic:"", stance:"按 frame 常规" },
-                    risk_off: { cls:"hl-alert", ic:"", stance:"防御, 优先减杠杆" } };
+      const map = { risk_on:  { tone:"ok",   stance:"默认持有" },
+                    neutral:  { tone:"flat", stance:"按 frame 常规" },
+                    risk_off: { tone:"bad",  stance:"防御·先减杠杆" } };
       const r = map[rg.label] || map.neutral;
-      chips.push({ cls: r.cls, icon: r.ic,
-        txt: `Regime ${escapeHtml(rg.label.replace("_"," "))} · ${escapeHtml(r.stance)}` });
+      chips.push(chip(r.tone, "Regime",
+        escapeHtml(rg.label.replace("_", " ")), escapeHtml(r.stance)));
     }
 
     // What changed since the previous decision set. Counts are dynamic and come
@@ -115,32 +126,31 @@
     const newN = dd.new_count || 0;
     const triggeredN = dd.triggered_count || 0;
     if (dd.has_material_change || changedN || newN || triggeredN) {
-      chips.push({
-        cls: triggeredN ? "hl-alert" : "hl-info",
-        icon: "",
-        txt: `决策变化 · 新增 ${newN} · 修改 ${changedN} · 触发 ${triggeredN}`,
-      });
+      chips.push(chip(triggeredN ? "bad" : changedN || newN ? "warn" : "ok",
+        "决策变化·新/改/触", `${newN}/${changedN}/${triggeredN}`));
     }
 
     // (30d 自评指标 — 主动 vs 持有 alpha + catalyst 纪律 — 不再在此重复;
     //  它们是回顾性统计,归属正下方的 🪞 诚实自评卡,不属于「今日速读」。)
 
-    // 1. Nearest-to-firing trigger (from the shared watch-level resolver)
+    // 1. Nearest-to-firing trigger (from the shared watch-level resolver)。
+    // 接近度画成计量条：|dist| 归一到 0~10%（10% 外一律读作「远」），条只答
+    // 「多近」，精确距离仍在 delta 文本；轨宽写死在 CSS，不随数据变。
     const near = (computeWatchRows().rows || []).find(r => r.ad != null);
     if (near) {
       const fire = near.ad < 2;
-      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: "",
-        txt: `${escapeHtml(near.who)} ${escapeHtml(near.label)} ${fmtMoney(near.val, near.ccy)}`
-           + ` · 现 ${fmtMoney(near.cur, near.ccy)} (${fmtPct(near.dist,1)})${fire ? " 即将触发" : ""}` });
+      const meter = Math.max(0, Math.min(100, 100 - near.ad * 10));
+      chips.push(chip(fire ? "bad" : near.ad < 5 ? "warn" : "flat",
+        `${escapeHtml(near.who)}·${escapeHtml(near.label)}`,
+        fmtMoney(near.val, near.ccy),
+        `现 ${fmtMoney(near.cur, near.ccy)} ${fmtPct(near.dist, 1)}${fire ? " ⚠" : ""}`,
+        meter));
     }
 
-    // 2. Biggest mover today (today_movers is pre-sorted by |pct| desc)
-    const movers = safe(DATA, "today_movers") || [];
-    if (movers.length) {
-      const m = movers[0]; const up = (m.today_change_pct || 0) >= 0;
-      chips.push({ cls: up ? "hl-up" : "hl-down", icon: "",
-        txt: `今日最大波动 ${escapeHtml(m.ticker)} ${fmtPct(m.today_change_pct,1)}` });
-    }
+    // 2. Movers today (today_movers is pre-sorted by |pct| desc)：不另设
+    //    「最大波动」chip —— top3 本来就画成零轴柱（图为主），首格即最大，
+    //    同一个数说两遍是把首屏读成对账单。
+    const movers = (safe(DATA, "today_movers") || []).slice(0, 3);
 
     // 3. Top anomaly (high severity first)
     const anomalies = (safe(DATA, "anomalies") || []).slice()
@@ -148,9 +158,9 @@
     if (anomalies.length) {
       const a = anomalies[0];
       const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "",
-        txt: (highN > 1 ? `${highN} 项高危异常 · ` : `异常 `)
-           + `${escapeHtml(a.ticker)}: ${escapeHtml(a.detail)}` });
+      chips.push(chip(a.severity === "high" ? "bad" : "warn",
+        highN > 1 ? `异常×${highN}` : "异常",
+        escapeHtml(a.ticker), escapeHtml(a.detail)));
     }
 
     // 4. Catalyst dated today
@@ -163,9 +173,13 @@
     (cat.macro_events||[]).forEach(e => { if (e.date === today) todays.push(`${e.type} ${e.detail}`); });
     (cat.earnings||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`财报 ${e.ticker||e.symbol||""}`); });
     (cat.fomc||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`FOMC ${e.detail||""}`); });
-    if (todays.length) chips.push({ cls:"hl-info", icon:"", txt:`今日事件 · ${escapeHtml(todays[0])}` });
+    if (todays.length) {
+      const head = todays[0].split(" ")[0] || "";
+      const rest = todays[0].slice(head.length).trim();
+      chips.push(chip("flat", "今日事件", escapeHtml(head), escapeHtml(rest)));
+    }
 
-    if (!chips.length) {
+    if (!chips.length && !movers.length) {
       el.style.display = "";
       el.replaceChildren();
       return;
@@ -177,8 +191,24 @@
     // No icon slot: the old 7px status dot read as AI-flavoured (kcn: 彩色圆点
     // = AI 味). Row semantics live in position, weight and — for true alerts —
     // the red text colour, never in a coloured dot.
-    el.innerHTML = chips.slice(0, 3).map(c =>
-      `<span class="hl-chip ${c.cls}">${c.txt}</span>`).join("");
+    // 异动零轴柱：top3 各一根，高度 = |pct| 归一（最低 3px 可见），px 写死 ——
+    // 构图不随数据变；ticker+pct 退为柱下 caption（图为主，文字只做注脚）。
+    const maxAbs = Math.max(...movers.map(x => Math.abs(x.today_change_pct || 0)), 1);
+    const mvCell = x => {
+      const pct = x.today_change_pct || 0;
+      const h = Math.max(3, Math.abs(pct) / maxAbs * 17);
+      return `<div class="hl-mv"><div class="hl-mv-bar">`
+        + `<i class="${pct >= 0 ? "up" : "down"}" style="height:${h.toFixed(1)}px"></i></div>`
+        + `<div class="hl-mv-cap"><span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
+        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div></div>`;
+    };
+    const moversRow = movers.length
+      ? `<div class="hl-movers" style="grid-template-columns:repeat(${movers.length},minmax(0,1fr))"`
+        + ` role="img" aria-label="今日异动前 ${movers.length}：`
+        + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
+        + `">${movers.map(mvCell).join("")}</div>`
+      : "";
+    el.innerHTML = chips.slice(0, 5).join("") + moversRow;
   }
 
   // 🪞 诚实自评卡 — 把这轮做的诚实层(风险调整判决 / catalyst 纪律 / 辩论决断 / 因子 CI)聚一处
@@ -329,6 +359,7 @@
     hero: [
       renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
       renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
+      renderVerdictDeckSides,
     ],
   };
   let RENDER_VERSION = 0;
@@ -1073,6 +1104,260 @@
 
   // 持仓决策矩阵优先消费 harness 编译的 versioned projection。旧 dashboard
   // join 仅作跨版本部署期间的 fallback；Pages 不再是投资规则的 owner。
+  // ── 判定牌组（第五次迭代）──────────────────────────────────────────
+  // 大白板被否（kcn），改单词卡式牌组：顶牌全显，下层三张以
+  // scale(.95/.90)+translateY 露边；换牌三通道 = 横滑手势 / 指示点 /
+  // 自动轮播（7s 一张，hover/交互即暂停，落位后恢复）。
+  // 物理按 Apple Fluid Interfaces：默认临界阻尼（damping 1.0，
+  // response .32s）；只有甩动释放才给 bounce；手势期 1:1 跟手、任意
+  // 时刻可打断可反向；释放把速度交给弹簧，落点用动量投影
+  // （current + (v/1000)·d/(1−d), d≈0.998）选最近吸附点；边界
+  // rubber-band 渐进抵抗。只写 transform/opacity，禁 keyframes；
+  // reduced-motion 全套退化为交叉淡化 + 指示点切换。
+  // ⚠ 与 dashboard.render.js 的本函数逐字同步（parity 棘轮只准同步）。
+  function setupVerdictDeck() {
+    const deck = document.getElementById("verdict-deck");
+    const stage = document.getElementById("verdict-deck-stage");
+    if (!deck || !stage || deck.dataset.deckBound) return;
+    deck.dataset.deckBound = "1";
+    const cards = Array.from(stage.querySelectorAll(".deck-card"));
+    const n = cards.length;
+    if (!n) return;
+    const dotsBox = document.getElementById("verdict-deck-dots");
+    const RM = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const AUTOPLAY_MS = 7000;      // 6~8s 一张
+    const RESPONSE = 0.32;         // 默认弹簧 response（秒）
+    const FLICK_ZETA = 0.62;       // 只有甩动释放允许 bounce（overshoot ~10%）
+    const PROJ_D = 0.998;          // 动量投影衰减（iOS 食谱）
+    const HORIZON = PROJ_D / (1 - PROJ_D) / 1000;   // ≈0.499s
+    let idx = 0;        // 吸附位
+    let cur = 0;        // 连续位置（牌为单位；静止时 == idx）
+    let velC = 0;       // 弹簧速度（cards/s；跟手速度在释放时换算交接）
+    let raf = 0;
+    let press = 1;      // 按压 scale（pointer-down 即响应，松开回 1）
+    let drag = null;    // { x0, lx, lt, moved }
+    let vPxMs = 0;      // 跟手速度（px/ms，EMA）
+    let hover = false, focused = false;   // 自动轮播的暂停条件
+    let movedFlag = false;               // 拖过的手不触发牌内点击
+    const dots = [];
+    for (let i = 0; i < n; i++) {
+      const b = document.createElement("button");
+      b.type = "button"; b.className = "deck-dot";
+      b.setAttribute("aria-label", `第 ${i + 1} 张：${cards[i].dataset.theme || ""}`);
+      b.appendChild(document.createElement("i"));
+      b.addEventListener("click", () => goTo(i));
+      dotsBox.appendChild(b); dots.push(b);
+    }
+    const W = () => stage.clientWidth || 1;
+    function pose(i) {
+      // 单一真值来源：由连续位置 cur 推每张牌的 transform/z。fr≠0 时
+      // 相邻两张构成「滑出 × 升起」对，其余按深度静置（露边暗示）。
+      const fr = cur - Math.floor(cur);
+      const base = fr >= 0 ? Math.floor(cur) : Math.floor(cur) + 1;
+      const dir = fr === 0 ? 0 : (fr > 0 ? 1 : -1);
+      let tx = 0, sc = 1, ty = 0, z = 1, vis = true;
+      if (dir !== 0 && i === base) {
+        tx = -fr * W(); z = n + 2;                 // 滑出层（一直在上）
+      } else if (dir !== 0 && i === base + dir) {
+        const u = Math.abs(fr);
+        sc = 0.95 + 0.05 * u; ty = 12 * (1 - u); z = n + 1;   // 升起层
+      } else {
+        const m = Math.abs(i - idx);
+        sc = Math.max(0.90, 1 - 0.05 * m);
+        ty = Math.min(22, 12 * m);
+        z = Math.max(1, n - m);
+        if (m === 0) { sc = 1; ty = 0; z = n; }    // 静止顶牌
+        if (m >= 3) vis = false;
+      }
+      const el = cards[i];
+      el.style.zIndex = z;
+      el.style.visibility = vis ? "visible" : "hidden";
+      el.style.transform =
+        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0)`
+        + ` scale(${(sc * press).toFixed(4)})`;
+      const top = i === idx && dir === 0;
+      if (el.inert !== !top) el.inert = !top;
+      el.setAttribute("aria-hidden", top ? "false" : "true");
+    }
+    function paint() { for (let i = 0; i < n; i++) pose(i); }
+    function paintDots() {
+      dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
+    }
+    function spring(target, zeta, response) {
+      cancelAnimationFrame(raf);
+      if (RM.matches) { cur = target; idx = target; enter(); paint(); paintDots(); return; }
+      const omega = 2 * Math.PI / response;
+      const k = omega * omega, c = 2 * zeta * omega;
+      let t0 = performance.now();
+      const step = (t) => {
+        const dt = Math.min(Math.max((t - t0) / 1000, 0.001), 1 / 30); t0 = t;
+        velC += (-k * (cur - target) - c * velC) * dt;
+        cur += velC * dt;
+        if (Math.abs(cur - target) < 0.0006 && Math.abs(velC) < 0.004) {
+          cur = target; velC = 0; idx = target; raf = 0;
+          enter(); paint(); paintDots(); restartAuto();
+          return;
+        }
+        paint();
+        raf = requestAnimationFrame(step);
+      };
+      raf = requestAnimationFrame(step);
+    }
+    function goTo(i) {
+      i = Math.max(0, Math.min(n - 1, i));
+      pauseAuto();
+      spring(i, 1.0, 0.36);
+    }
+    // 牌内元素入场 stagger（30~80ms）：只在每张牌第一次成为顶牌时播一次。
+    function enter() {
+      const el = cards[idx];
+      if (el.dataset.staggered || RM.matches) return;
+      el.dataset.staggered = "1";
+      el.classList.add("deck-preenter", "deck-enter");
+      // 强制 reflow 让初态落定后立即摘除 —— 不用双 rAF：落定后页面可能
+      // 不再产帧（headless/后台标签），rAF 回调会饿死，牌就永远停在初态。
+      void el.offsetWidth;
+      el.classList.remove("deck-preenter");
+      setTimeout(() => el.classList.remove("deck-enter"), 450);
+    }
+    stage.addEventListener("pointerdown", (e) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      pauseAuto();
+      if (raf) { cancelAnimationFrame(raf); raf = 0; }   // 弹簧随时可打断
+      drag = { x0: e.clientX, lx: e.clientX, lt: performance.now(), moved: false };
+      vPxMs = 0; press = 0.97;
+      try { stage.setPointerCapture(e.pointerId); } catch (_) {}
+      stage.classList.add("is-dragging");
+      paint();
+    });
+    stage.addEventListener("pointermove", (e) => {
+      if (!drag) return;
+      const now = performance.now();
+      const dx = e.clientX - drag.x0;
+      if (Math.abs(dx) > 6) { drag.moved = true; movedFlag = true; }
+      const instV = (e.clientX - drag.lx) / Math.max(now - drag.lt, 1);
+      vPxMs = instV * 0.75 + vPxMs * 0.25;               // EMA 平滑
+      drag.lx = e.clientX; drag.lt = now;
+      let off = dx;                                      // 1:1 跟手（尊重抓取偏移）
+      if ((idx === 0 && dx > 0) || (idx === n - 1 && dx < 0)) {
+        const over = Math.abs(dx);
+        off = Math.sign(dx) * over / (1 + over / 110);   // rubber-band 渐进抵抗
+      }
+      cur = idx - off / W();
+      paint();
+    });
+    const release = () => {
+      if (!drag) return;
+      const moved = drag.moved;
+      drag = null; press = 1;
+      stage.classList.remove("is-dragging");
+      if (!moved) { cur = idx; velC = 0; paint(); restartAuto(); return; }
+      // 速度交接给弹簧；落点 = 动量投影的最近吸附点。甩动（|v| 高）才用
+      // bounce 阻尼，普通释放临界阻尼。
+      velC = -vPxMs * 1000 / W();
+      const proj = cur + velC * HORIZON;
+      const target = Math.max(0, Math.min(n - 1, Math.round(proj)));
+      const fast = Math.abs(velC) > 0.9;
+      spring(target, fast ? FLICK_ZETA : 1.0, fast ? 0.36 : RESPONSE);
+    };
+    stage.addEventListener("pointerup", release);
+    stage.addEventListener("pointercancel", release);
+    // 拖过的手不触发牌内点击（capture 阶段吞掉）。
+    stage.addEventListener("click", (e) => {
+      if (movedFlag) { e.stopPropagation(); e.preventDefault(); movedFlag = false; }
+    }, true);
+    stage.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowLeft") { e.preventDefault(); goTo(idx - 1); }
+      if (e.key === "ArrowRight") { e.preventDefault(); goTo(idx + 1); }
+    });
+    deck.addEventListener("pointerenter", () => { hover = true; pauseAuto(); });
+    deck.addEventListener("pointerleave", () => { hover = false; restartAuto(); });
+    deck.addEventListener("focusin", () => { focused = true; pauseAuto(); });
+    deck.addEventListener("focusout", () => { focused = false; restartAuto(); });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) pauseAuto(); else restartAuto();
+    });
+    window.addEventListener("resize", () => { cur = idx; velC = 0; paint(); }, { passive: true });
+    // 自动轮播与指示点进度同源：一个 200ms tick 驱动推进与填充；
+    // 暂停即冻结（elapsed 累计制，不用绝对时刻）。
+    let elapsed = 0, autoOn = false, lastTick = 0;
+    function pauseAuto() { autoOn = false; }
+    function restartAuto() {
+      if (RM.matches || document.hidden || hover || focused || autoOn || raf) return;
+      autoOn = true; lastTick = performance.now();
+    }
+    setInterval(() => {
+      const now = performance.now();
+      if (autoOn) {
+        elapsed += now - lastTick;
+        if (elapsed >= AUTOPLAY_MS && !drag && !raf) {
+          elapsed = 0;
+          spring((idx + 1) % n, 1.0, 0.38);   // 自动切换 ≤400ms
+        }
+      }
+      lastTick = now;
+      const fill = dots[idx] && dots[idx].firstChild;
+      if (fill) fill.style.transform =
+        `scaleX(${autoOn ? Math.min(elapsed / AUTOPLAY_MS, 1).toFixed(3) : "0"})`;
+    }, 200);
+    paint(); paintDots(); enter(); restartAuto();
+  }
+
+  // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
+  // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。
+  function renderVerdictDeckSides() {
+    setupVerdictDeck();
+    const mk = (tone, k, v, d, meterPct) =>
+      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
+      + (v ? `<span class="hl-v">${v}</span>` : "")
+      + (d ? `<span class="hl-d">${d}</span>` : "")
+      + (meterPct == null ? ""
+        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
+      + `</span>`;
+    const disc = document.getElementById("deck-discipline");
+    if (disc) {
+      const m = safe(DATA, "decision_metrics") || {};
+      const act = safe(safe(m, "execution_by_kind"), "active") || {};
+      const chips = [];
+      if (m.brier != null) {
+        chips.push(mk(m.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
+          Number(m.brier).toFixed(3),
+          m.brier_baseline_loo == null ? "" : `基线 ${Number(m.brier_baseline_loo).toFixed(3)}`));
+      }
+      if (act.rate != null) {
+        chips.push(mk("flat", "执行率",
+          `${(act.rate * 100).toFixed(1)}%`,
+          act.known == null ? "" : `${act.known} 笔可核`));
+      }
+      if (m.raw_decisions != null) {
+        chips.push(mk("flat", "样本", `${m.raw_decisions}`, "近 30d 决策"));
+      }
+      disc.innerHTML = chips.length ? chips.join("")
+        : '<span class="hl-chip"><span class="hl-k">决策指标未生成</span></span>';
+    }
+    const gold = document.getElementById("deck-gold");
+    if (gold) {
+      const g = safe(DATA, "gold_dca") || {};
+      const badge = document.getElementById("deck-gold-badge");
+      if (badge) badge.textContent = g.fund_code ? String(g.fund_code) : "";
+      const ups = g.breakeven_upside_pct;
+      if (ups == null || g.nav == null) {
+        gold.innerHTML = '<span class="hl-chip"><span class="hl-k">回本数据缺</span></span>';
+      } else {
+        const above = ups <= 0;
+        const meter = Math.max(0, Math.min(100, 100 - Math.abs(ups) * 10));
+        const num = (v, dp) => Number(v).toLocaleString("zh-CN",
+          { minimumFractionDigits: dp, maximumFractionDigits: dp });
+        gold.innerHTML =
+          mk(above ? "ok" : Math.abs(ups) > 5 ? "bad" : "warn", "回本",
+            above ? `已越线 ${Math.abs(ups).toFixed(1)}%` : `需涨 ${ups.toFixed(1)}%`,
+            "", meter)
+          + mk("flat", "净值/成本", `${num(g.nav, 4)} / ${num(g.avg_cost, 4)}`)
+          + mk("flat", "现值", `¥${num(g.current_value, 0)}`,
+            (g.pnl_percent >= 0 ? "+" : "") + `${num(g.pnl_percent, 2)}%`);
+      }
+    }
+  }
   function renderRiskGuardrail() {
     const g = safe(DATA, "risk_guardrail") || {};
     const targets = [

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -111,20 +111,31 @@
 
   // A. Hero top "今日要点" triage strip — pure synthesis of data already in
   // dashboard.json (no new fetch). Answers "what should I look at today" in 5s.
+  // 第四次迭代修正二（券商终端化）：状态/数值/档位一律徽章 chip（label+
+  // value+delta 三段式，tone ok/warn/bad），同类一排、放不下折行，不做段落；
+  // 能画的数据画微图（接近度计量条、异动零轴迷你柱），文字退为 caption。
+  // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
     if (!el) return;
     const chips = [];
+    const chip = (tone, k, v, d, meterPct) =>
+      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
+      + (v ? `<span class="hl-v">${v}</span>` : "")
+      + (d ? `<span class="hl-d">${d}</span>` : "")
+      + (meterPct == null ? ""
+        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
+      + `</span>`;
 
     // 0. Regime — the day's default stance (same risk_on/neutral/risk_off the brief acts on)
     const rg = safe(DATA, "regime");
     if (rg && rg.label) {
-      const map = { risk_on:  { cls:"hl-up",    ic:"", stance:"默认持有, 别瞎动" },
-                    neutral:  { cls:"hl-info",  ic:"", stance:"按 frame 常规" },
-                    risk_off: { cls:"hl-alert", ic:"", stance:"防御, 优先减杠杆" } };
+      const map = { risk_on:  { tone:"ok",   stance:"默认持有" },
+                    neutral:  { tone:"flat", stance:"按 frame 常规" },
+                    risk_off: { tone:"bad",  stance:"防御·先减杠杆" } };
       const r = map[rg.label] || map.neutral;
-      chips.push({ cls: r.cls, icon: r.ic,
-        txt: `Regime ${escapeHtml(rg.label.replace("_"," "))} · ${escapeHtml(r.stance)}` });
+      chips.push(chip(r.tone, "Regime",
+        escapeHtml(rg.label.replace("_", " ")), escapeHtml(r.stance)));
     }
 
     // What changed since the previous decision set. Counts are dynamic and come
@@ -134,32 +145,31 @@
     const newN = (dd.new || []).length;
     const triggeredN = (dd.triggered || []).length;
     if (dd.has_material_change || changedN || newN || triggeredN) {
-      chips.push({
-        cls: triggeredN ? "hl-alert" : "hl-info",
-        icon: "",
-        txt: `决策变化 · 新增 ${newN} · 修改 ${changedN} · 触发 ${triggeredN}`,
-      });
+      chips.push(chip(triggeredN ? "bad" : changedN || newN ? "warn" : "ok",
+        "决策变化·新/改/触", `${newN}/${changedN}/${triggeredN}`));
     }
 
     // (30d 自评指标 — 主动 vs 持有 alpha + catalyst 纪律 — 不再在此重复;
     //  它们是回顾性统计,归属正下方的 🪞 诚实自评卡,不属于「今日速读」。)
 
-    // 1. Nearest-to-firing trigger (from the shared watch-level resolver)
+    // 1. Nearest-to-firing trigger (from the shared watch-level resolver)。
+    // 接近度画成计量条：|dist| 归一到 0~10%（10% 外一律读作「远」），条只答
+    // 「多近」，精确距离仍在 delta 文本；轨宽写死在 CSS，不随数据变。
     const near = (computeWatchRows().rows || []).find(r => r.ad != null);
     if (near) {
       const fire = near.ad < 2;
-      chips.push({ cls: fire ? "hl-alert" : "hl-info", icon: "",
-        txt: `${escapeHtml(near.who)} ${escapeHtml(near.label)} ${fmtMoney(near.val, near.ccy)}`
-           + ` · 现 ${fmtMoney(near.cur, near.ccy)} (${fmtPct(near.dist,1)})${fire ? " 即将触发" : ""}` });
+      const meter = Math.max(0, Math.min(100, 100 - near.ad * 10));
+      chips.push(chip(fire ? "bad" : near.ad < 5 ? "warn" : "flat",
+        `${escapeHtml(near.who)}·${escapeHtml(near.label)}`,
+        fmtMoney(near.val, near.ccy),
+        `现 ${fmtMoney(near.cur, near.ccy)} ${fmtPct(near.dist, 1)}${fire ? " ⚠" : ""}`,
+        meter));
     }
 
-    // 2. Biggest mover today (today_movers is pre-sorted by |pct| desc)
-    const movers = safe(DATA, "today_movers") || [];
-    if (movers.length) {
-      const m = movers[0]; const up = (m.today_change_pct || 0) >= 0;
-      chips.push({ cls: up ? "hl-up" : "hl-down", icon: "",
-        txt: `今日最大波动 ${escapeHtml(m.ticker)} ${fmtPct(m.today_change_pct,1)}` });
-    }
+    // 2. Movers today (today_movers is pre-sorted by |pct| desc)：不另设
+    //    「最大波动」chip —— top3 本来就画成零轴柱（图为主），首格即最大，
+    //    同一个数说两遍是把首屏读成对账单。
+    const movers = (safe(DATA, "today_movers") || []).slice(0, 3);
 
     // 3. Top anomaly (high severity first)
     const anomalies = (safe(DATA, "anomalies") || []).slice()
@@ -167,9 +177,9 @@
     if (anomalies.length) {
       const a = anomalies[0];
       const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push({ cls: a.severity === "high" ? "hl-alert" : "hl-warn", icon: "",
-        txt: (highN > 1 ? `${highN} 项高危异常 · ` : `异常 `)
-           + `${escapeHtml(a.ticker)}: ${escapeHtml(a.detail)}` });
+      chips.push(chip(a.severity === "high" ? "bad" : "warn",
+        highN > 1 ? `异常×${highN}` : "异常",
+        escapeHtml(a.ticker), escapeHtml(a.detail)));
     }
 
     // 4. Catalyst dated today
@@ -182,9 +192,13 @@
     (cat.macro_events||[]).forEach(e => { if (e.date === today) todays.push(`${e.type} ${e.detail}`); });
     (cat.earnings||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`财报 ${e.ticker||e.symbol||""}`); });
     (cat.fomc||[]).forEach(e => { if (String(e.date||"").slice(0,10) === today) todays.push(`FOMC ${e.detail||""}`); });
-    if (todays.length) chips.push({ cls:"hl-info", icon:"", txt:`今日事件 · ${escapeHtml(todays[0])}` });
+    if (todays.length) {
+      const head = todays[0].split(" ")[0] || "";
+      const rest = todays[0].slice(head.length).trim();
+      chips.push(chip("flat", "今日事件", escapeHtml(head), escapeHtml(rest)));
+    }
 
-    if (!chips.length) {
+    if (!chips.length && !movers.length) {
       el.style.display = "";
       el.replaceChildren();
       return;
@@ -196,8 +210,24 @@
     // No icon slot: the old 7px status dot read as AI-flavoured (kcn: 彩色圆点
     // = AI 味). Row semantics live in position, weight and — for true alerts —
     // the red text colour, never in a coloured dot.
-    el.innerHTML = chips.slice(0, 3).map(c =>
-      `<span class="hl-chip ${c.cls}">${c.txt}</span>`).join("");
+    // 异动零轴柱：top3 各一根，高度 = |pct| 归一（最低 3px 可见），px 写死 ——
+    // 构图不随数据变；ticker+pct 退为柱下 caption（图为主，文字只做注脚）。
+    const maxAbs = Math.max(...movers.map(x => Math.abs(x.today_change_pct || 0)), 1);
+    const mvCell = x => {
+      const pct = x.today_change_pct || 0;
+      const h = Math.max(3, Math.abs(pct) / maxAbs * 17);
+      return `<div class="hl-mv"><div class="hl-mv-bar">`
+        + `<i class="${pct >= 0 ? "up" : "down"}" style="height:${h.toFixed(1)}px"></i></div>`
+        + `<div class="hl-mv-cap"><span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
+        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div></div>`;
+    };
+    const moversRow = movers.length
+      ? `<div class="hl-movers" style="grid-template-columns:repeat(${movers.length},minmax(0,1fr))"`
+        + ` role="img" aria-label="今日异动前 ${movers.length}：`
+        + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
+        + `">${movers.map(mvCell).join("")}</div>`
+      : "";
+    el.innerHTML = chips.slice(0, 5).join("") + moversRow;
   }
 
   // 🪞 诚实自评卡 — 把这轮做的诚实层(风险调整判决 / catalyst 纪律 / 辩论决断 / 因子 CI)聚一处
@@ -339,6 +369,7 @@
     hero: [
       renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
       renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
+      renderVerdictDeckSides,
     ],
     drill: [
       renderBook, renderAddCampaign, renderMovers,
@@ -2216,6 +2247,260 @@
     document.getElementById('risk-alerts').innerHTML = html;
   }
 
+  // ── 判定牌组（第五次迭代）──────────────────────────────────────────
+  // 大白板被否（kcn），改单词卡式牌组：顶牌全显，下层三张以
+  // scale(.95/.90)+translateY 露边；换牌三通道 = 横滑手势 / 指示点 /
+  // 自动轮播（7s 一张，hover/交互即暂停，落位后恢复）。
+  // 物理按 Apple Fluid Interfaces：默认临界阻尼（damping 1.0，
+  // response .32s）；只有甩动释放才给 bounce；手势期 1:1 跟手、任意
+  // 时刻可打断可反向；释放把速度交给弹簧，落点用动量投影
+  // （current + (v/1000)·d/(1−d), d≈0.998）选最近吸附点；边界
+  // rubber-band 渐进抵抗。只写 transform/opacity，禁 keyframes；
+  // reduced-motion 全套退化为交叉淡化 + 指示点切换。
+  // ⚠ 与 dashboard.render.js 的本函数逐字同步（parity 棘轮只准同步）。
+  function setupVerdictDeck() {
+    const deck = document.getElementById("verdict-deck");
+    const stage = document.getElementById("verdict-deck-stage");
+    if (!deck || !stage || deck.dataset.deckBound) return;
+    deck.dataset.deckBound = "1";
+    const cards = Array.from(stage.querySelectorAll(".deck-card"));
+    const n = cards.length;
+    if (!n) return;
+    const dotsBox = document.getElementById("verdict-deck-dots");
+    const RM = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const AUTOPLAY_MS = 7000;      // 6~8s 一张
+    const RESPONSE = 0.32;         // 默认弹簧 response（秒）
+    const FLICK_ZETA = 0.62;       // 只有甩动释放允许 bounce（overshoot ~10%）
+    const PROJ_D = 0.998;          // 动量投影衰减（iOS 食谱）
+    const HORIZON = PROJ_D / (1 - PROJ_D) / 1000;   // ≈0.499s
+    let idx = 0;        // 吸附位
+    let cur = 0;        // 连续位置（牌为单位；静止时 == idx）
+    let velC = 0;       // 弹簧速度（cards/s；跟手速度在释放时换算交接）
+    let raf = 0;
+    let press = 1;      // 按压 scale（pointer-down 即响应，松开回 1）
+    let drag = null;    // { x0, lx, lt, moved }
+    let vPxMs = 0;      // 跟手速度（px/ms，EMA）
+    let hover = false, focused = false;   // 自动轮播的暂停条件
+    let movedFlag = false;               // 拖过的手不触发牌内点击
+    const dots = [];
+    for (let i = 0; i < n; i++) {
+      const b = document.createElement("button");
+      b.type = "button"; b.className = "deck-dot";
+      b.setAttribute("aria-label", `第 ${i + 1} 张：${cards[i].dataset.theme || ""}`);
+      b.appendChild(document.createElement("i"));
+      b.addEventListener("click", () => goTo(i));
+      dotsBox.appendChild(b); dots.push(b);
+    }
+    const W = () => stage.clientWidth || 1;
+    function pose(i) {
+      // 单一真值来源：由连续位置 cur 推每张牌的 transform/z。fr≠0 时
+      // 相邻两张构成「滑出 × 升起」对，其余按深度静置（露边暗示）。
+      const fr = cur - Math.floor(cur);
+      const base = fr >= 0 ? Math.floor(cur) : Math.floor(cur) + 1;
+      const dir = fr === 0 ? 0 : (fr > 0 ? 1 : -1);
+      let tx = 0, sc = 1, ty = 0, z = 1, vis = true;
+      if (dir !== 0 && i === base) {
+        tx = -fr * W(); z = n + 2;                 // 滑出层（一直在上）
+      } else if (dir !== 0 && i === base + dir) {
+        const u = Math.abs(fr);
+        sc = 0.95 + 0.05 * u; ty = 12 * (1 - u); z = n + 1;   // 升起层
+      } else {
+        const m = Math.abs(i - idx);
+        sc = Math.max(0.90, 1 - 0.05 * m);
+        ty = Math.min(22, 12 * m);
+        z = Math.max(1, n - m);
+        if (m === 0) { sc = 1; ty = 0; z = n; }    // 静止顶牌
+        if (m >= 3) vis = false;
+      }
+      const el = cards[i];
+      el.style.zIndex = z;
+      el.style.visibility = vis ? "visible" : "hidden";
+      el.style.transform =
+        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0)`
+        + ` scale(${(sc * press).toFixed(4)})`;
+      const top = i === idx && dir === 0;
+      if (el.inert !== !top) el.inert = !top;
+      el.setAttribute("aria-hidden", top ? "false" : "true");
+    }
+    function paint() { for (let i = 0; i < n; i++) pose(i); }
+    function paintDots() {
+      dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
+    }
+    function spring(target, zeta, response) {
+      cancelAnimationFrame(raf);
+      if (RM.matches) { cur = target; idx = target; enter(); paint(); paintDots(); return; }
+      const omega = 2 * Math.PI / response;
+      const k = omega * omega, c = 2 * zeta * omega;
+      let t0 = performance.now();
+      const step = (t) => {
+        const dt = Math.min(Math.max((t - t0) / 1000, 0.001), 1 / 30); t0 = t;
+        velC += (-k * (cur - target) - c * velC) * dt;
+        cur += velC * dt;
+        if (Math.abs(cur - target) < 0.0006 && Math.abs(velC) < 0.004) {
+          cur = target; velC = 0; idx = target; raf = 0;
+          enter(); paint(); paintDots(); restartAuto();
+          return;
+        }
+        paint();
+        raf = requestAnimationFrame(step);
+      };
+      raf = requestAnimationFrame(step);
+    }
+    function goTo(i) {
+      i = Math.max(0, Math.min(n - 1, i));
+      pauseAuto();
+      spring(i, 1.0, 0.36);
+    }
+    // 牌内元素入场 stagger（30~80ms）：只在每张牌第一次成为顶牌时播一次。
+    function enter() {
+      const el = cards[idx];
+      if (el.dataset.staggered || RM.matches) return;
+      el.dataset.staggered = "1";
+      el.classList.add("deck-preenter", "deck-enter");
+      // 强制 reflow 让初态落定后立即摘除 —— 不用双 rAF：落定后页面可能
+      // 不再产帧（headless/后台标签），rAF 回调会饿死，牌就永远停在初态。
+      void el.offsetWidth;
+      el.classList.remove("deck-preenter");
+      setTimeout(() => el.classList.remove("deck-enter"), 450);
+    }
+    stage.addEventListener("pointerdown", (e) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      pauseAuto();
+      if (raf) { cancelAnimationFrame(raf); raf = 0; }   // 弹簧随时可打断
+      drag = { x0: e.clientX, lx: e.clientX, lt: performance.now(), moved: false };
+      vPxMs = 0; press = 0.97;
+      try { stage.setPointerCapture(e.pointerId); } catch (_) {}
+      stage.classList.add("is-dragging");
+      paint();
+    });
+    stage.addEventListener("pointermove", (e) => {
+      if (!drag) return;
+      const now = performance.now();
+      const dx = e.clientX - drag.x0;
+      if (Math.abs(dx) > 6) { drag.moved = true; movedFlag = true; }
+      const instV = (e.clientX - drag.lx) / Math.max(now - drag.lt, 1);
+      vPxMs = instV * 0.75 + vPxMs * 0.25;               // EMA 平滑
+      drag.lx = e.clientX; drag.lt = now;
+      let off = dx;                                      // 1:1 跟手（尊重抓取偏移）
+      if ((idx === 0 && dx > 0) || (idx === n - 1 && dx < 0)) {
+        const over = Math.abs(dx);
+        off = Math.sign(dx) * over / (1 + over / 110);   // rubber-band 渐进抵抗
+      }
+      cur = idx - off / W();
+      paint();
+    });
+    const release = () => {
+      if (!drag) return;
+      const moved = drag.moved;
+      drag = null; press = 1;
+      stage.classList.remove("is-dragging");
+      if (!moved) { cur = idx; velC = 0; paint(); restartAuto(); return; }
+      // 速度交接给弹簧；落点 = 动量投影的最近吸附点。甩动（|v| 高）才用
+      // bounce 阻尼，普通释放临界阻尼。
+      velC = -vPxMs * 1000 / W();
+      const proj = cur + velC * HORIZON;
+      const target = Math.max(0, Math.min(n - 1, Math.round(proj)));
+      const fast = Math.abs(velC) > 0.9;
+      spring(target, fast ? FLICK_ZETA : 1.0, fast ? 0.36 : RESPONSE);
+    };
+    stage.addEventListener("pointerup", release);
+    stage.addEventListener("pointercancel", release);
+    // 拖过的手不触发牌内点击（capture 阶段吞掉）。
+    stage.addEventListener("click", (e) => {
+      if (movedFlag) { e.stopPropagation(); e.preventDefault(); movedFlag = false; }
+    }, true);
+    stage.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowLeft") { e.preventDefault(); goTo(idx - 1); }
+      if (e.key === "ArrowRight") { e.preventDefault(); goTo(idx + 1); }
+    });
+    deck.addEventListener("pointerenter", () => { hover = true; pauseAuto(); });
+    deck.addEventListener("pointerleave", () => { hover = false; restartAuto(); });
+    deck.addEventListener("focusin", () => { focused = true; pauseAuto(); });
+    deck.addEventListener("focusout", () => { focused = false; restartAuto(); });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) pauseAuto(); else restartAuto();
+    });
+    window.addEventListener("resize", () => { cur = idx; velC = 0; paint(); }, { passive: true });
+    // 自动轮播与指示点进度同源：一个 200ms tick 驱动推进与填充；
+    // 暂停即冻结（elapsed 累计制，不用绝对时刻）。
+    let elapsed = 0, autoOn = false, lastTick = 0;
+    function pauseAuto() { autoOn = false; }
+    function restartAuto() {
+      if (RM.matches || document.hidden || hover || focused || autoOn || raf) return;
+      autoOn = true; lastTick = performance.now();
+    }
+    setInterval(() => {
+      const now = performance.now();
+      if (autoOn) {
+        elapsed += now - lastTick;
+        if (elapsed >= AUTOPLAY_MS && !drag && !raf) {
+          elapsed = 0;
+          spring((idx + 1) % n, 1.0, 0.38);   // 自动切换 ≤400ms
+        }
+      }
+      lastTick = now;
+      const fill = dots[idx] && dots[idx].firstChild;
+      if (fill) fill.style.transform =
+        `scaleX(${autoOn ? Math.min(elapsed / AUTOPLAY_MS, 1).toFixed(3) : "0"})`;
+    }, 200);
+    paint(); paintDots(); enter(); restartAuto();
+  }
+
+  // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
+  // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。
+  function renderVerdictDeckSides() {
+    setupVerdictDeck();
+    const mk = (tone, k, v, d, meterPct) =>
+      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
+      + (v ? `<span class="hl-v">${v}</span>` : "")
+      + (d ? `<span class="hl-d">${d}</span>` : "")
+      + (meterPct == null ? ""
+        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
+      + `</span>`;
+    const disc = document.getElementById("deck-discipline");
+    if (disc) {
+      const m = safe(DATA, "decision_metrics") || {};
+      const act = safe(safe(m, "execution_by_kind"), "active") || {};
+      const chips = [];
+      if (m.brier != null) {
+        chips.push(mk(m.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
+          Number(m.brier).toFixed(3),
+          m.brier_baseline_loo == null ? "" : `基线 ${Number(m.brier_baseline_loo).toFixed(3)}`));
+      }
+      if (act.rate != null) {
+        chips.push(mk("flat", "执行率",
+          `${(act.rate * 100).toFixed(1)}%`,
+          act.known == null ? "" : `${act.known} 笔可核`));
+      }
+      if (m.raw_decisions != null) {
+        chips.push(mk("flat", "样本", `${m.raw_decisions}`, "近 30d 决策"));
+      }
+      disc.innerHTML = chips.length ? chips.join("")
+        : '<span class="hl-chip"><span class="hl-k">决策指标未生成</span></span>';
+    }
+    const gold = document.getElementById("deck-gold");
+    if (gold) {
+      const g = safe(DATA, "gold_dca") || {};
+      const badge = document.getElementById("deck-gold-badge");
+      if (badge) badge.textContent = g.fund_code ? String(g.fund_code) : "";
+      const ups = g.breakeven_upside_pct;
+      if (ups == null || g.nav == null) {
+        gold.innerHTML = '<span class="hl-chip"><span class="hl-k">回本数据缺</span></span>';
+      } else {
+        const above = ups <= 0;
+        const meter = Math.max(0, Math.min(100, 100 - Math.abs(ups) * 10));
+        const num = (v, dp) => Number(v).toLocaleString("zh-CN",
+          { minimumFractionDigits: dp, maximumFractionDigits: dp });
+        gold.innerHTML =
+          mk(above ? "ok" : Math.abs(ups) > 5 ? "bad" : "warn", "回本",
+            above ? `已越线 ${Math.abs(ups).toFixed(1)}%` : `需涨 ${ups.toFixed(1)}%`,
+            "", meter)
+          + mk("flat", "净值/成本", `${num(g.nav, 4)} / ${num(g.avg_cost, 4)}`)
+          + mk("flat", "现值", `¥${num(g.current_value, 0)}`,
+            (g.pnl_percent >= 0 ? "+" : "") + `${num(g.pnl_percent, 2)}%`);
+      }
+    }
+  }
   function renderRiskGuardrail() {
     const g = safe(DATA, "risk_guardrail") || {};
     const targets = [

--- a/site/index.html
+++ b/site/index.html
@@ -198,29 +198,65 @@ layout: null
         <div class="hero-rail" id="hero-rail"></div>
       </div>
 
-      <aside class="card overview-verdict" aria-labelledby="overview-verdict-title">
-        <div class="overview-verdict-head">
-          <div>
-            <div class="overview-card-kicker">决策面板</div>
-            <h3 id="overview-verdict-title">今日判定</h3>
-          </div>
-          <button class="overview-jump" type="button" data-jump-tab="risk">去风险页</button>
+      <!-- 判定卡第五次迭代：大白板否掉（kcn），改单词卡式牌组 —— 顶牌全显，
+           后续三张 scale+translateY 露边；横滑手势 / 指示点 / 自动轮播三通道
+           换牌。每张牌一个主题，按现有数据面拆：今日判定 / 触发中的硬闸 /
+           执行纪律 / 黄金回本。引擎在 dashboard.hero.js 与 dashboard.render.js
+           双实现逐字同步（setupVerdictDeck）。 -->
+      <section class="card verdict-deck" id="verdict-deck" aria-roledescription="轮播" aria-label="决策面板">
+        <div class="verdict-deck-stage" id="verdict-deck-stage">
+          <article class="deck-card" data-theme="今日判定" aria-labelledby="overview-verdict-title">
+            <div class="overview-verdict-head">
+              <div>
+                <div class="overview-card-kicker">决策面板</div>
+                <h3 id="overview-verdict-title">今日判定</h3>
+              </div>
+              <button class="overview-jump" type="button" data-jump-tab="risk">去风险页</button>
+            </div>
+            <div class="status-banner overview-status is-pending" id="overview-status-banner">
+              <span class="sb-pulse" aria-hidden="true"></span>
+              <span class="sb-text" id="overview-sb-text"></span>
+              <span class="sb-time" id="overview-sb-time"></span>
+            </div>
+            <div id="today-highlights" class="today-highlights"></div>
+          </article>
+          <article class="deck-card" data-theme="硬闸" aria-labelledby="deck-gates-title">
+            <div class="overview-verdict-head">
+              <div>
+                <div class="overview-card-kicker">风险</div>
+                <h3 id="deck-gates-title">触发中的硬闸</h3>
+              </div>
+              <span class="badge muted" id="overview-guardrail-count"></span>
+            </div>
+            <div class="overview-gates">
+              <div class="overview-gates-directive" id="overview-guardrail-directive"></div>
+              <div class="risk-alerts" id="overview-guardrail-list"></div>
+            </div>
+            <button class="overview-jump deck-card-jump" type="button" data-jump-tab="risk">去风险页 →</button>
+          </article>
+          <article class="deck-card" data-theme="纪律" aria-labelledby="deck-discipline-title">
+            <div class="overview-verdict-head">
+              <div>
+                <div class="overview-card-kicker">纪律</div>
+                <h3 id="deck-discipline-title">执行纪律</h3>
+              </div>
+              <button class="overview-jump" type="button" data-jump-tab="drill">看持仓</button>
+            </div>
+            <div id="deck-discipline" class="today-highlights"></div>
+          </article>
+          <article class="deck-card" data-theme="黄金回本" aria-labelledby="deck-gold-title">
+            <div class="overview-verdict-head">
+              <div>
+                <div class="overview-card-kicker">黄金 DCA</div>
+                <h3 id="deck-gold-title">黄金回本</h3>
+              </div>
+              <span class="badge muted" id="deck-gold-badge"></span>
+            </div>
+            <div id="deck-gold" class="today-highlights"></div>
+          </article>
         </div>
-        <div class="status-banner overview-status is-pending" id="overview-status-banner">
-          <span class="sb-pulse" aria-hidden="true"></span>
-          <span class="sb-text" id="overview-sb-text"></span>
-          <span class="sb-time" id="overview-sb-time"></span>
-        </div>
-        <div id="today-highlights" class="today-highlights"></div>
-        <div class="overview-gates">
-          <div class="overview-gates-head">
-            <span>触发中的硬闸</span>
-            <span class="badge muted" id="overview-guardrail-count"></span>
-          </div>
-          <div class="overview-gates-directive" id="overview-guardrail-directive"></div>
-          <div class="risk-alerts" id="overview-guardrail-list"></div>
-        </div>
-      </aside>
+        <div class="deck-dots" id="verdict-deck-dots" role="group" aria-label="换牌"></div>
+      </section>
 
       <div class="overview-strip" aria-label="Secondary overview">
         <section class="overview-strip-cell overview-market">


### PR DESCRIPTION
## 背景

kcn 两条指令（handoff-v3-deck）：首页亮色背景太蓝调回中性白；判定卡完全重构成卡片堆叠/轮换播放（大白板否掉）。

## 任务 A：背景去蓝（1e0aa0d9）

**归因（像素取证）**：#1002 把亮色 canvas `#F3F6F9→#E7ECF3`、三盏光池抬到蓝 `.22/.10/.07`。页沟槽实测 `(223,230,238)`，B−R=16（#F3F6F9 时代 `(237,242,246)`，B−R=9）；远离一切品牌色元素的沟槽同样偏蓝 → 环境层色相偏移，非健康态外溢。

**修正**：canvas 回 `#F3F6F9`；主光改白光池 `rgba(255,255,255,.45)`，两盏副光改中性灰影池 `rgba(148,157,166,.09/.07)` —— 三池几何与明度语言不动，仅中和色相；玻璃 `saturate(182%)` 不再有蓝色相可放大。**after 实测**：沟槽 `(240,243,246)`、顶带 `(244,247,250)`，B−R=6，优于原时代。暗主题逐点复测不变。

## 任务 B：单词卡牌组（c367dc25）

四张主题牌按现有数据面拆：今日判定 / 触发中的硬闸 / 执行纪律 / 黄金回本。顶牌全显，下层 scale(.95/.90)+translateY 露边。换牌三通道：横滑手势（1:1 跟手、setPointerCapture、可随时打断反向）、指示点、自动轮播 7s（hover/focus/交互/隐藏页暂停）。

物理：默认临界阻尼（damping 1.0 / response .32s）；只有甩动释放给 bounce；释放速度交接弹簧，落点=动量投影 `(v/1000)·d/(1−d), d≈.998` 最近吸附；边界 rubber-band。只动 transform+opacity、禁 keyframes；入场 stagger 30/55/80ms（强制 reflow 而非双 rAF —— 落定后页面可能不产帧，rAF 饿死会让牌永远停在初态，headless 实测踩坑）；reduced-motion 退化交叉淡化+指示点；reduced-transparency 走既有 RT 闸。

## 验证

- 契约 pytest 107 passed + 1 xfailed；`dashboard_tab_runtime.spec.js` 绿
- parity：`setupVerdictDeck` / `renderVerdictDeckSides` 双实现 diff 级 byte-sync
- CLS 0.0056/0.0067/0.0078/0.0089/0.0095（1440→390）与基线逐档持平；实测高 317/504/569 落在 319/506/571 地板内
- 截图（fixture=2026-08-25 快照）：deck-{1200,390}-{light,dark} + deck-verdict-*（顶牌状态）+ deck2/3/4-*（三张副牌）+ deck-midswipe-1200-light（堆叠中间态）
- 新增 font-size 零；live checkout 只经 refresh 脚本