### PR TITLE
dashboard: 判定牌组第六次迭代 —— 堆叠交互去诡异 + 留白收敛

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2580,12 +2580,14 @@
   /* Equity Curve 卡已挪去 Reflect 净值表现区（与 Daily P&L 同区、共用市场切换器）。
      Overview 首屏只留 hero-deck 的 spark 一条形状；今日判定从「Equity(8) + 判定(4)」
      的伴排改为独占整行。 */
-  /* ── 判定牌组（第五次迭代）──────────────────────────────────────
+  /* ── 判定牌组（第五次迭代建形，第六次迭代调交互与间距）──────────
      大白板被否（kcn：完全重构成卡片堆叠/轮换播放），改单词卡式牌组：
-     顶牌全显，后续三张在下层以 scale+translateY 露边暗示可换。容器占
-     原 .overview-verdict 的栅格槽与地板；每张牌一个主题，玻璃配方不变
-     （半透明面 + 斜向 sheen + 高光切边 + 自画光池），从「一张大白板」
-     收成「一叠玻璃牌」。 */
+     顶牌全显，后续两张在下层露边暗示可换。容器占原 .overview-verdict
+     的栅格槽与地板；每张牌一个主题，玻璃配方不变（半透明面 + 斜向 sheen
+     + 高光切边 + 自画光池），从「一张大白板」收成「一叠玻璃牌」。
+     第六次迭代（kcn：「堆叠交互太诡异，而且留白太多」）只动两件事：
+     交互几何（露边尺度 / 台面裁剪 / 撤自动轮播，见 stage 与 JS 注释）
+     与间距（外层托盘、牌内纵向内衬、三档地板）。画风与配色一字未动。 */
   .verdict-deck {
     grid-column: 1 / -1;
     display: flex; flex-direction: column; gap: 10px;
@@ -2598,10 +2600,15 @@
     position: relative; flex: 1; min-height: 0;
     /* 横滑是手势主通道；纵向滚动必须照常（pan-y 只锁横向）。 */
     touch-action: pan-y; cursor: grab;
+    /* 牌桌要有边：before 实测抽走的牌横移到 x=-160（牌组左缘 x=28 之外）
+       盖住相邻区块 —— 这是「堆叠交互诡异」的头号来源。clip 而不是 hidden，
+       不产生滚动容器；clip-margin 只留牌影出边的余量。 */
+    overflow: clip; overflow-clip-margin: 8px;
   }
   .verdict-deck-stage.is-dragging { cursor: grabbing; }
   .deck-card {
-    position: absolute; inset: 0;
+    /* 底部留出两层露边的位置（2 × 8px），下层牌不越出台面。 */
+    position: absolute; inset: 0 0 16px 0;
     display: flex; flex-direction: column;
     padding: 20px var(--card-inset) 18px;
     overflow: hidden;
@@ -2647,26 +2654,25 @@
         rgba(0,110,184,.045), transparent 70%);
     }
   }
-  /* 进度指示点兼自动轮播进度条：轨是发丝底，填充 scaleX 由 JS 按
-     剩余时间逐帧写（禁 keyframes）。高度固定 —— 构图常量。 */
+  /* 指示点：自动轮播撤掉之后它不再兼任进度条，26px 的条状点也就没有
+     理由了 —— 收成 5px 圆点，跟同一张牌里的硬闸点阵（.gt-dot）同一套
+     计数语言。高度固定 10px —— 构图常量。 */
   .deck-dots {
     flex: 0 0 auto;
-    display: flex; align-items: center; justify-content: center; gap: 8px;
-    height: 12px; padding: 1px 0;
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+    height: 10px;
   }
   .deck-dot {
     appearance: none; border: 0; padding: 0; margin: 0;
-    width: 26px; height: 4px; border-radius: 2px;
-    background: var(--border-subtle); cursor: pointer;
-    position: relative; overflow: hidden;
+    width: 5px; height: 5px; border-radius: 50%;
+    background: var(--border-strong); opacity: .45; cursor: pointer;
+    transition: opacity var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
   }
-  .deck-dot i {
-    position: absolute; inset: 0; border-radius: inherit;
-    background: var(--text-faint);
-    transform: scaleX(0); transform-origin: left center;
-  }
-  .deck-dot[aria-current="true"] i { background: var(--text-secondary); }
-  .deck-dot:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+  .deck-dot[aria-current="true"] { background: var(--text-secondary); opacity: 1; }
+  .deck-dot:active { transform: scale(.8); }
+  .deck-dot:focus-visible { outline: 2px solid var(--focus); outline-offset: 3px; }
+  @media (prefers-reduced-motion: reduce) { .deck-dot { transition: none; } }
   /* 牌内元素入场 stagger（30~80ms）：临时类压住初态，去类后 transition
      生效；delay 挂 nth-child，400ms 后由 JS 摘除 delay 类。 */
   .deck-card > * { transition: opacity .24s var(--ease-out), transform .24s var(--ease-out); }

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2590,11 +2590,21 @@
      与间距（外层托盘、牌内纵向内衬、三档地板）。画风与配色一字未动。 */
   .verdict-deck {
     grid-column: 1 / -1;
-    display: flex; flex-direction: column; gap: 10px;
+    display: flex; flex-direction: column; gap: 8px;
     position: relative;
-    /* 地板跟随原判定卡三档（319/506/571，横幅日扫宽上界 +2）：牌组拆张
-       后单牌内容更短，旧地板是安全上界 —— 预留只增不减，CLS 不劣化。 */
-    min-height: 319px;
+    /* 外层那圈 .card 的面/边/影/内衬全部撤掉（第六次迭代）：牌自己就是
+       玻璃面，外面再套一层就是玻璃里糊玻璃（#937），而且那 16px 内衬把
+       牌面推得比正上方 hero 卡窄 17px —— 首屏三块面的左缘本来就该对齐。
+       撤掉之后横向省 34px、纵向省 32px，全是纯留白。 */
+    padding: 0; border: 0; border-radius: 0;
+    background: none; box-shadow: none;
+    /* 地板三档全部按新构图重测：360~1920 每 20px 扫一遍，每档取「忙日」
+       上界（5 枚 chip 全到位 + 硬闸 3 行长 detail，都是渲染端的构图上限，
+       不是今天这份数据）。≥1024 档 = 226.39 + 露边 16 + gap 8 + 指示点 10
+       = 260.39，+2。牌是绝对定位的，牌组高度本来就只由这条 min-height 决定
+       ——预留是宽度的确定函数，不是数据的函数；数据变多的失败模式是牌内
+       截断，所以余量按构图上限留，不按当日实测留。 */
+    min-height: 262px;
   }
   .verdict-deck-stage {
     position: relative; flex: 1; min-height: 0;
@@ -2610,7 +2620,9 @@
     /* 底部留出两层露边的位置（2 × 8px），下层牌不越出台面。 */
     position: absolute; inset: 0 0 16px 0;
     display: flex; flex-direction: column;
-    padding: 20px var(--card-inset) 18px;
+    /* 纵向内衬 20/18 → 16/16：横向仍走 --card-inset，和上方 hero 卡同列
+       对齐；「留白太多」收的是纵向那一档。 */
+    padding: 16px var(--card-inset);
     overflow: hidden;
     border-radius: var(--radius);
     /* 牌本体 = 玻璃内表面（配方沿第四次迭代）：半透明面透出页面光，
@@ -2689,7 +2701,7 @@
   }
   /* 牌内硬闸区：原「段间发丝线」是通栏卡的分段语言；独立成牌后它就是
      牌的正文，去掉段首线与顶垫。 */
-  .verdict-deck .overview-gates { border-top: 0; padding-top: 0; margin: 12px 0 0; }
+  .verdict-deck .overview-gates { border-top: 0; padding-top: 0; margin: 10px 0 0; }
   /* 牌尾跳转钮：贴牌底（flex 列的 margin-top:auto），不随内容长短漂。 */
   .deck-card-jump { margin-top: auto; align-self: flex-end; }
   /* 牌组化后双栏 grid-areas 与「玻璃上的仪表面板 well」一并退场：硬闸
@@ -2729,7 +2741,7 @@
      的版式保留：它就是终端里那行「快照注脚」。 */
   .overview-status {
     display: block;
-    margin: 12px 0 0; padding: 10px 0 0;
+    margin: 10px 0 0; padding: 9px 0 0;
     background: none; border: 0; border-radius: 0;
     border-top: 1px solid var(--border-subtle);
     border-bottom: 0;
@@ -2754,7 +2766,7 @@
      tone 只染边线与 value，不染整底：满屏色底是行情软件最廉价的读感。 */
   .deck-card .today-highlights {
     display: flex; flex-wrap: wrap; gap: 6px;
-    margin: 12px 0 0; min-height: 0;
+    margin: 10px 0 0; min-height: 0;
   }
   .deck-card .hl-chip {
     display: inline-flex; align-items: center; gap: 7px;
@@ -3003,8 +3015,10 @@
 
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
-    /* 506：768px 端横幅日实测（504，与旧构图持平）+2。 */
-    .verdict-deck { min-height: 506px; }
+    /* 292：768~1023 扫宽忙日实测上界 256.39（在 780）+ 露边 16 + gap 8
+       + 指示点 10 = 290.39，+2。旧值 506 是通栏卡时代的安全上界，牌组
+       拆张后高出 214px 纯留白。 */
+    .verdict-deck { min-height: 292px; }
     .verdict-deck, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
@@ -3029,9 +3043,9 @@
     .dh-file { display: none; }
     .dh-bar { grid-column: 1 / -1; }
     .dh-detail { grid-column: 1 / -1; white-space: normal; }
-    /* 571：390px 横幅日实测 569（旧构图 566、旧地板 564 同样已破）
-       +2 —— 增量来自 mono 数字在窄列的折行变化。 */
-    .verdict-deck { min-height: 571px; }
+    /* 382：360~767 扫宽忙日实测上界 346.39（在 360）+ 露边 16 + gap 8
+       + 指示点 10 = 380.39，+2。窄档是留白重灾区：旧 571 高出 189px。 */
+    .verdict-deck { min-height: 382px; }
     .overview-strip { display: flex; flex-direction: column; }
     .overview-strip-cell {
       min-height: 0; border-right: 0; border-bottom: 1px solid var(--border-subtle);

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -1104,16 +1104,27 @@
 
   // 持仓决策矩阵优先消费 harness 编译的 versioned projection。旧 dashboard
   // join 仅作跨版本部署期间的 fallback；Pages 不再是投资规则的 owner。
-  // ── 判定牌组（第五次迭代）──────────────────────────────────────────
-  // 大白板被否（kcn），改单词卡式牌组：顶牌全显，下层三张以
-  // scale(.95/.90)+translateY 露边；换牌三通道 = 横滑手势 / 指示点 /
-  // 自动轮播（7s 一张，hover/交互即暂停，落位后恢复）。
-  // 物理按 Apple Fluid Interfaces：默认临界阻尼（damping 1.0，
-  // response .32s）；只有甩动释放才给 bounce；手势期 1:1 跟手、任意
-  // 时刻可打断可反向；释放把速度交给弹簧，落点用动量投影
-  // （current + (v/1000)·d/(1−d), d≈0.998）选最近吸附点；边界
-  // rubber-band 渐进抵抗。只写 transform/opacity，禁 keyframes；
-  // reduced-motion 全套退化为交叉淡化 + 指示点切换。
+  // ── 判定牌组（第六次迭代）──────────────────────────────────────────
+  // 形态不变（单词卡牌组：顶牌全显、下层露边、横滑/指示点/方向键换牌），
+  // 画风与配色一字未动；这一轮只修「堆叠交互诡异」的四个几何/行为来源：
+  //  1. 滑出层的位移 before 实测跑到 x=-160（牌组左缘 x=28 之外），盖住
+  //     相邻区块 —— 牌桌没有边。stage 改 overflow:clip，抽走的牌消失在
+  //     台面边缘（CSS 侧）。
+  //  2. 中间态是两套牌位拼出来的：滑出层横移 × 升起层原地缩放，而第三张
+  //     在整段过程里冻在 m=2、等 idx 一变才跳。改成单一连续模型 —— 每张
+  //     牌的位姿只由「深度 d = i - cur」推出，d<0 是正在抽走，d≥0 是台面
+  //     第 d 层。没有分支，也就没有撕裂。
+  //  3. 深度改成固定 8px 露边 + 固定 8px 单边缩进（由 scaleX 换算）。原来
+  //     的 uniform scale 让露边随宽度变，1200 档只露 4px，读作「牌没放齐」。
+  //     z-index 同时降为静态 n-i：牌只会往左抽走，压序永远是「序号小的在
+  //     上」，逐帧改 z 是多余的闪烁源。
+  //  4. 撤掉两件自我表演：7s 自动轮播（首屏不该有自己转的东西；换牌三通道
+  //     仍在）与整叠 0.97 按压缩放（1144px 的面缩 3% 读作版面抽搐，跟手
+  //     位移本身就是按压反馈）。
+  // 物理保留 Apple Fluid Interfaces 那套：手势 1:1 跟手、任意时刻可打断可
+  // 反向、释放把速度交给弹簧、落点用动量投影、边界 rubber-band 渐进抵抗；
+  // 阻尼统一临界（换牌不弹），一次只走一张。只写 transform/opacity，禁
+  // keyframes；reduced-motion 直接落位。
   // ⚠ 与 dashboard.render.js 的本函数逐字同步（parity 棘轮只准同步）。
   function setupVerdictDeck() {
     const deck = document.getElementById("verdict-deck");
@@ -1125,57 +1136,51 @@
     if (!n) return;
     const dotsBox = document.getElementById("verdict-deck-dots");
     const RM = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const AUTOPLAY_MS = 7000;      // 6~8s 一张
-    const RESPONSE = 0.32;         // 默认弹簧 response（秒）
-    const FLICK_ZETA = 0.62;       // 只有甩动释放允许 bounce（overshoot ~10%）
-    const PROJ_D = 0.998;          // 动量投影衰减（iOS 食谱）
+    const SPRING = 0.26;      // 换牌弹簧 response（秒）：实测到位（≤1.7px
+                              // 残差）397ms，压在「轮播切换 ≤400ms」之内
+    const PROJ_D = 0.998;     // 动量投影衰减（iOS 食谱）
     const HORIZON = PROJ_D / (1 - PROJ_D) / 1000;   // ≈0.499s
+    const PEEK = 8;           // 每层露边（px；恒定，不随宽度变）
+    const INSET = 8;          // 每层单边缩进（px；由 scaleX 换算）
+    const DEPTH = 2;          // 台面上最多两层露边
+    const SNAP = 0.25;        // 换一张的位移阈值（牌宽占比；动量投影后判）
     let idx = 0;        // 吸附位
     let cur = 0;        // 连续位置（牌为单位；静止时 == idx）
     let velC = 0;       // 弹簧速度（cards/s；跟手速度在释放时换算交接）
     let raf = 0;
-    let press = 1;      // 按压 scale（pointer-down 即响应，松开回 1）
     let drag = null;    // { x0, lx, lt, moved }
     let vPxMs = 0;      // 跟手速度（px/ms，EMA）
-    let hover = false, focused = false;   // 自动轮播的暂停条件
-    let movedFlag = false;               // 拖过的手不触发牌内点击
+    let movedFlag = false;   // 拖过的手不触发牌内点击
     const dots = [];
     for (let i = 0; i < n; i++) {
       const b = document.createElement("button");
       b.type = "button"; b.className = "deck-dot";
       b.setAttribute("aria-label", `第 ${i + 1} 张：${cards[i].dataset.theme || ""}`);
-      b.appendChild(document.createElement("i"));
       b.addEventListener("click", () => goTo(i));
       dotsBox.appendChild(b); dots.push(b);
+      cards[i].style.zIndex = n - i;
     }
     const W = () => stage.clientWidth || 1;
     function pose(i) {
-      // 单一真值来源：由连续位置 cur 推每张牌的 transform/z。fr≠0 时
-      // 相邻两张构成「滑出 × 升起」对，其余按深度静置（露边暗示）。
-      const fr = cur - Math.floor(cur);
-      const base = fr >= 0 ? Math.floor(cur) : Math.floor(cur) + 1;
-      const dir = fr === 0 ? 0 : (fr > 0 ? 1 : -1);
-      let tx = 0, sc = 1, ty = 0, z = 1, vis = true;
-      if (dir !== 0 && i === base) {
-        tx = -fr * W(); z = n + 2;                 // 滑出层（一直在上）
-      } else if (dir !== 0 && i === base + dir) {
-        const u = Math.abs(fr);
-        sc = 0.95 + 0.05 * u; ty = 12 * (1 - u); z = n + 1;   // 升起层
-      } else {
-        const m = Math.abs(i - idx);
-        sc = Math.max(0.90, 1 - 0.05 * m);
-        ty = Math.min(22, 12 * m);
-        z = Math.max(1, n - m);
-        if (m === 0) { sc = 1; ty = 0; z = n; }    // 静止顶牌
-        if (m >= 3) vis = false;
-      }
       const el = cards[i];
-      el.style.zIndex = z;
+      const d = i - cur;
+      let tx = 0, ty = 0, sx = 1, op = 1, vis = true;
+      if (d <= -1 || d > DEPTH + 0.2) {
+        vis = false;                                   // 抽完的 / 太深的
+      } else if (d < 0) {
+        const u = -d;                                  // 抽走进度 0→1
+        tx = -u * W();
+        op = u <= 0.5 ? 1 : Math.max(0, 1 - (u - 0.5) / 0.5);
+      } else {
+        const dd = Math.min(d, DEPTH);                 // 台面第 d 层
+        ty = PEEK * dd;
+        sx = Math.max(0, 1 - 2 * INSET * dd / W());
+      }
       el.style.visibility = vis ? "visible" : "hidden";
+      el.style.opacity = op === 1 ? "" : op.toFixed(3);
       el.style.transform =
-        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0)`
-        + ` scale(${(sc * press).toFixed(4)})`;
-      const top = i === idx && dir === 0;
+        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0) scaleX(${sx.toFixed(5)})`;
+      const top = i === idx && d === 0;
       if (el.inert !== !top) el.inert = !top;
       el.setAttribute("aria-hidden", top ? "false" : "true");
     }
@@ -1183,19 +1188,19 @@
     function paintDots() {
       dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
     }
-    function spring(target, zeta, response) {
+    function spring(target) {
       cancelAnimationFrame(raf);
-      if (RM.matches) { cur = target; idx = target; enter(); paint(); paintDots(); return; }
-      const omega = 2 * Math.PI / response;
-      const k = omega * omega, c = 2 * zeta * omega;
+      if (RM.matches) { cur = target; idx = target; velC = 0; raf = 0; enter(); paint(); paintDots(); return; }
+      const omega = 2 * Math.PI / SPRING;
+      const k = omega * omega, c = 2 * omega;     // ζ=1：临界阻尼，换牌不过冲
       let t0 = performance.now();
       const step = (t) => {
         const dt = Math.min(Math.max((t - t0) / 1000, 0.001), 1 / 30); t0 = t;
         velC += (-k * (cur - target) - c * velC) * dt;
         cur += velC * dt;
-        if (Math.abs(cur - target) < 0.0006 && Math.abs(velC) < 0.004) {
+        if (Math.abs(cur - target) < 0.0015 && Math.abs(velC) < 0.02) {
           cur = target; velC = 0; idx = target; raf = 0;
-          enter(); paint(); paintDots(); restartAuto();
+          enter(); paint(); paintDots();
           return;
         }
         paint();
@@ -1205,8 +1210,12 @@
     }
     function goTo(i) {
       i = Math.max(0, Math.min(n - 1, i));
-      pauseAuto();
-      spring(i, 1.0, 0.36);
+      // 指示点点到第 4 张不该让中间两张各飞一遍（实测 >1s，破 400ms 闸）：
+      // 先把位置瞬移到目标的邻位，只演一张牌的抽走/上浮，换牌时长有界。
+      if (Math.abs(i - idx) > 1) {
+        idx = i - Math.sign(i - idx); cur = idx; velC = 0; paint(); paintDots();
+      }
+      spring(i);
     }
     // 牌内元素入场 stagger（30~80ms）：只在每张牌第一次成为顶牌时播一次。
     function enter() {
@@ -1222,13 +1231,11 @@
     }
     stage.addEventListener("pointerdown", (e) => {
       if (e.pointerType === "mouse" && e.button !== 0) return;
-      pauseAuto();
       if (raf) { cancelAnimationFrame(raf); raf = 0; }   // 弹簧随时可打断
       drag = { x0: e.clientX, lx: e.clientX, lt: performance.now(), moved: false };
-      vPxMs = 0; press = 0.97;
+      vPxMs = 0;
       try { stage.setPointerCapture(e.pointerId); } catch (_) {}
       stage.classList.add("is-dragging");
-      paint();
     });
     stage.addEventListener("pointermove", (e) => {
       if (!drag) return;
@@ -1249,16 +1256,17 @@
     const release = () => {
       if (!drag) return;
       const moved = drag.moved;
-      drag = null; press = 1;
+      drag = null;
       stage.classList.remove("is-dragging");
-      if (!moved) { cur = idx; velC = 0; paint(); restartAuto(); return; }
-      // 速度交接给弹簧；落点 = 动量投影的最近吸附点。甩动（|v| 高）才用
-      // bounce 阻尼，普通释放临界阻尼。
-      velC = -vPxMs * 1000 / W();
-      const proj = cur + velC * HORIZON;
-      const target = Math.max(0, Math.min(n - 1, Math.round(proj)));
-      const fast = Math.abs(velC) > 0.9;
-      spring(target, fast ? FLICK_ZETA : 1.0, fast ? 0.36 : RESPONSE);
+      if (!moved) { cur = idx; velC = 0; paint(); return; }
+      // 速度交接给弹簧；落点 = 动量投影过阈值就走一张，绝不跳两张 ——
+      // 一叠牌一次只抽一张，这是牌组的语言，也让 1:1 跟手不必拖满整张牌宽。
+      // 速度上限 4 cards/s ≈ 两倍于人手最猛的甩动：不夹的话一次抽动能
+      // 灌进十几 cards/s，弹簧被推得大幅过冲，落位要 500ms 以上。
+      velC = Math.max(-4, Math.min(4, -vPxMs * 1000 / W()));
+      const proj = cur + velC * HORIZON - idx;
+      const step = Math.abs(proj) > SNAP ? Math.sign(proj) : 0;
+      spring(Math.max(0, Math.min(n - 1, idx + step)));
     };
     stage.addEventListener("pointerup", release);
     stage.addEventListener("pointercancel", release);
@@ -1270,38 +1278,10 @@
       if (e.key === "ArrowLeft") { e.preventDefault(); goTo(idx - 1); }
       if (e.key === "ArrowRight") { e.preventDefault(); goTo(idx + 1); }
     });
-    deck.addEventListener("pointerenter", () => { hover = true; pauseAuto(); });
-    deck.addEventListener("pointerleave", () => { hover = false; restartAuto(); });
-    deck.addEventListener("focusin", () => { focused = true; pauseAuto(); });
-    deck.addEventListener("focusout", () => { focused = false; restartAuto(); });
-    document.addEventListener("visibilitychange", () => {
-      if (document.hidden) pauseAuto(); else restartAuto();
-    });
     window.addEventListener("resize", () => { cur = idx; velC = 0; paint(); }, { passive: true });
-    // 自动轮播与指示点进度同源：一个 200ms tick 驱动推进与填充；
-    // 暂停即冻结（elapsed 累计制，不用绝对时刻）。
-    let elapsed = 0, autoOn = false, lastTick = 0;
-    function pauseAuto() { autoOn = false; }
-    function restartAuto() {
-      if (RM.matches || document.hidden || hover || focused || autoOn || raf) return;
-      autoOn = true; lastTick = performance.now();
-    }
-    setInterval(() => {
-      const now = performance.now();
-      if (autoOn) {
-        elapsed += now - lastTick;
-        if (elapsed >= AUTOPLAY_MS && !drag && !raf) {
-          elapsed = 0;
-          spring((idx + 1) % n, 1.0, 0.38);   // 自动切换 ≤400ms
-        }
-      }
-      lastTick = now;
-      const fill = dots[idx] && dots[idx].firstChild;
-      if (fill) fill.style.transform =
-        `scaleX(${autoOn ? Math.min(elapsed / AUTOPLAY_MS, 1).toFixed(3) : "0"})`;
-    }, 200);
-    paint(); paintDots(); enter(); restartAuto();
+    paint(); paintDots(); enter();
   }
+
 
   // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
   // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2247,16 +2247,27 @@
     document.getElementById('risk-alerts').innerHTML = html;
   }
 
-  // ── 判定牌组（第五次迭代）──────────────────────────────────────────
-  // 大白板被否（kcn），改单词卡式牌组：顶牌全显，下层三张以
-  // scale(.95/.90)+translateY 露边；换牌三通道 = 横滑手势 / 指示点 /
-  // 自动轮播（7s 一张，hover/交互即暂停，落位后恢复）。
-  // 物理按 Apple Fluid Interfaces：默认临界阻尼（damping 1.0，
-  // response .32s）；只有甩动释放才给 bounce；手势期 1:1 跟手、任意
-  // 时刻可打断可反向；释放把速度交给弹簧，落点用动量投影
-  // （current + (v/1000)·d/(1−d), d≈0.998）选最近吸附点；边界
-  // rubber-band 渐进抵抗。只写 transform/opacity，禁 keyframes；
-  // reduced-motion 全套退化为交叉淡化 + 指示点切换。
+  // ── 判定牌组（第六次迭代）──────────────────────────────────────────
+  // 形态不变（单词卡牌组：顶牌全显、下层露边、横滑/指示点/方向键换牌），
+  // 画风与配色一字未动；这一轮只修「堆叠交互诡异」的四个几何/行为来源：
+  //  1. 滑出层的位移 before 实测跑到 x=-160（牌组左缘 x=28 之外），盖住
+  //     相邻区块 —— 牌桌没有边。stage 改 overflow:clip，抽走的牌消失在
+  //     台面边缘（CSS 侧）。
+  //  2. 中间态是两套牌位拼出来的：滑出层横移 × 升起层原地缩放，而第三张
+  //     在整段过程里冻在 m=2、等 idx 一变才跳。改成单一连续模型 —— 每张
+  //     牌的位姿只由「深度 d = i - cur」推出，d<0 是正在抽走，d≥0 是台面
+  //     第 d 层。没有分支，也就没有撕裂。
+  //  3. 深度改成固定 8px 露边 + 固定 8px 单边缩进（由 scaleX 换算）。原来
+  //     的 uniform scale 让露边随宽度变，1200 档只露 4px，读作「牌没放齐」。
+  //     z-index 同时降为静态 n-i：牌只会往左抽走，压序永远是「序号小的在
+  //     上」，逐帧改 z 是多余的闪烁源。
+  //  4. 撤掉两件自我表演：7s 自动轮播（首屏不该有自己转的东西；换牌三通道
+  //     仍在）与整叠 0.97 按压缩放（1144px 的面缩 3% 读作版面抽搐，跟手
+  //     位移本身就是按压反馈）。
+  // 物理保留 Apple Fluid Interfaces 那套：手势 1:1 跟手、任意时刻可打断可
+  // 反向、释放把速度交给弹簧、落点用动量投影、边界 rubber-band 渐进抵抗；
+  // 阻尼统一临界（换牌不弹），一次只走一张。只写 transform/opacity，禁
+  // keyframes；reduced-motion 直接落位。
   // ⚠ 与 dashboard.render.js 的本函数逐字同步（parity 棘轮只准同步）。
   function setupVerdictDeck() {
     const deck = document.getElementById("verdict-deck");
@@ -2268,57 +2279,51 @@
     if (!n) return;
     const dotsBox = document.getElementById("verdict-deck-dots");
     const RM = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const AUTOPLAY_MS = 7000;      // 6~8s 一张
-    const RESPONSE = 0.32;         // 默认弹簧 response（秒）
-    const FLICK_ZETA = 0.62;       // 只有甩动释放允许 bounce（overshoot ~10%）
-    const PROJ_D = 0.998;          // 动量投影衰减（iOS 食谱）
+    const SPRING = 0.26;      // 换牌弹簧 response（秒）：实测到位（≤1.7px
+                              // 残差）397ms，压在「轮播切换 ≤400ms」之内
+    const PROJ_D = 0.998;     // 动量投影衰减（iOS 食谱）
     const HORIZON = PROJ_D / (1 - PROJ_D) / 1000;   // ≈0.499s
+    const PEEK = 8;           // 每层露边（px；恒定，不随宽度变）
+    const INSET = 8;          // 每层单边缩进（px；由 scaleX 换算）
+    const DEPTH = 2;          // 台面上最多两层露边
+    const SNAP = 0.25;        // 换一张的位移阈值（牌宽占比；动量投影后判）
     let idx = 0;        // 吸附位
     let cur = 0;        // 连续位置（牌为单位；静止时 == idx）
     let velC = 0;       // 弹簧速度（cards/s；跟手速度在释放时换算交接）
     let raf = 0;
-    let press = 1;      // 按压 scale（pointer-down 即响应，松开回 1）
     let drag = null;    // { x0, lx, lt, moved }
     let vPxMs = 0;      // 跟手速度（px/ms，EMA）
-    let hover = false, focused = false;   // 自动轮播的暂停条件
-    let movedFlag = false;               // 拖过的手不触发牌内点击
+    let movedFlag = false;   // 拖过的手不触发牌内点击
     const dots = [];
     for (let i = 0; i < n; i++) {
       const b = document.createElement("button");
       b.type = "button"; b.className = "deck-dot";
       b.setAttribute("aria-label", `第 ${i + 1} 张：${cards[i].dataset.theme || ""}`);
-      b.appendChild(document.createElement("i"));
       b.addEventListener("click", () => goTo(i));
       dotsBox.appendChild(b); dots.push(b);
+      cards[i].style.zIndex = n - i;
     }
     const W = () => stage.clientWidth || 1;
     function pose(i) {
-      // 单一真值来源：由连续位置 cur 推每张牌的 transform/z。fr≠0 时
-      // 相邻两张构成「滑出 × 升起」对，其余按深度静置（露边暗示）。
-      const fr = cur - Math.floor(cur);
-      const base = fr >= 0 ? Math.floor(cur) : Math.floor(cur) + 1;
-      const dir = fr === 0 ? 0 : (fr > 0 ? 1 : -1);
-      let tx = 0, sc = 1, ty = 0, z = 1, vis = true;
-      if (dir !== 0 && i === base) {
-        tx = -fr * W(); z = n + 2;                 // 滑出层（一直在上）
-      } else if (dir !== 0 && i === base + dir) {
-        const u = Math.abs(fr);
-        sc = 0.95 + 0.05 * u; ty = 12 * (1 - u); z = n + 1;   // 升起层
-      } else {
-        const m = Math.abs(i - idx);
-        sc = Math.max(0.90, 1 - 0.05 * m);
-        ty = Math.min(22, 12 * m);
-        z = Math.max(1, n - m);
-        if (m === 0) { sc = 1; ty = 0; z = n; }    // 静止顶牌
-        if (m >= 3) vis = false;
-      }
       const el = cards[i];
-      el.style.zIndex = z;
+      const d = i - cur;
+      let tx = 0, ty = 0, sx = 1, op = 1, vis = true;
+      if (d <= -1 || d > DEPTH + 0.2) {
+        vis = false;                                   // 抽完的 / 太深的
+      } else if (d < 0) {
+        const u = -d;                                  // 抽走进度 0→1
+        tx = -u * W();
+        op = u <= 0.5 ? 1 : Math.max(0, 1 - (u - 0.5) / 0.5);
+      } else {
+        const dd = Math.min(d, DEPTH);                 // 台面第 d 层
+        ty = PEEK * dd;
+        sx = Math.max(0, 1 - 2 * INSET * dd / W());
+      }
       el.style.visibility = vis ? "visible" : "hidden";
+      el.style.opacity = op === 1 ? "" : op.toFixed(3);
       el.style.transform =
-        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0)`
-        + ` scale(${(sc * press).toFixed(4)})`;
-      const top = i === idx && dir === 0;
+        `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0) scaleX(${sx.toFixed(5)})`;
+      const top = i === idx && d === 0;
       if (el.inert !== !top) el.inert = !top;
       el.setAttribute("aria-hidden", top ? "false" : "true");
     }
@@ -2326,19 +2331,19 @@
     function paintDots() {
       dots.forEach((d, i) => d.setAttribute("aria-current", i === idx ? "true" : "false"));
     }
-    function spring(target, zeta, response) {
+    function spring(target) {
       cancelAnimationFrame(raf);
-      if (RM.matches) { cur = target; idx = target; enter(); paint(); paintDots(); return; }
-      const omega = 2 * Math.PI / response;
-      const k = omega * omega, c = 2 * zeta * omega;
+      if (RM.matches) { cur = target; idx = target; velC = 0; raf = 0; enter(); paint(); paintDots(); return; }
+      const omega = 2 * Math.PI / SPRING;
+      const k = omega * omega, c = 2 * omega;     // ζ=1：临界阻尼，换牌不过冲
       let t0 = performance.now();
       const step = (t) => {
         const dt = Math.min(Math.max((t - t0) / 1000, 0.001), 1 / 30); t0 = t;
         velC += (-k * (cur - target) - c * velC) * dt;
         cur += velC * dt;
-        if (Math.abs(cur - target) < 0.0006 && Math.abs(velC) < 0.004) {
+        if (Math.abs(cur - target) < 0.0015 && Math.abs(velC) < 0.02) {
           cur = target; velC = 0; idx = target; raf = 0;
-          enter(); paint(); paintDots(); restartAuto();
+          enter(); paint(); paintDots();
           return;
         }
         paint();
@@ -2348,8 +2353,12 @@
     }
     function goTo(i) {
       i = Math.max(0, Math.min(n - 1, i));
-      pauseAuto();
-      spring(i, 1.0, 0.36);
+      // 指示点点到第 4 张不该让中间两张各飞一遍（实测 >1s，破 400ms 闸）：
+      // 先把位置瞬移到目标的邻位，只演一张牌的抽走/上浮，换牌时长有界。
+      if (Math.abs(i - idx) > 1) {
+        idx = i - Math.sign(i - idx); cur = idx; velC = 0; paint(); paintDots();
+      }
+      spring(i);
     }
     // 牌内元素入场 stagger（30~80ms）：只在每张牌第一次成为顶牌时播一次。
     function enter() {
@@ -2365,13 +2374,11 @@
     }
     stage.addEventListener("pointerdown", (e) => {
       if (e.pointerType === "mouse" && e.button !== 0) return;
-      pauseAuto();
       if (raf) { cancelAnimationFrame(raf); raf = 0; }   // 弹簧随时可打断
       drag = { x0: e.clientX, lx: e.clientX, lt: performance.now(), moved: false };
-      vPxMs = 0; press = 0.97;
+      vPxMs = 0;
       try { stage.setPointerCapture(e.pointerId); } catch (_) {}
       stage.classList.add("is-dragging");
-      paint();
     });
     stage.addEventListener("pointermove", (e) => {
       if (!drag) return;
@@ -2392,16 +2399,17 @@
     const release = () => {
       if (!drag) return;
       const moved = drag.moved;
-      drag = null; press = 1;
+      drag = null;
       stage.classList.remove("is-dragging");
-      if (!moved) { cur = idx; velC = 0; paint(); restartAuto(); return; }
-      // 速度交接给弹簧；落点 = 动量投影的最近吸附点。甩动（|v| 高）才用
-      // bounce 阻尼，普通释放临界阻尼。
-      velC = -vPxMs * 1000 / W();
-      const proj = cur + velC * HORIZON;
-      const target = Math.max(0, Math.min(n - 1, Math.round(proj)));
-      const fast = Math.abs(velC) > 0.9;
-      spring(target, fast ? FLICK_ZETA : 1.0, fast ? 0.36 : RESPONSE);
+      if (!moved) { cur = idx; velC = 0; paint(); return; }
+      // 速度交接给弹簧；落点 = 动量投影过阈值就走一张，绝不跳两张 ——
+      // 一叠牌一次只抽一张，这是牌组的语言，也让 1:1 跟手不必拖满整张牌宽。
+      // 速度上限 4 cards/s ≈ 两倍于人手最猛的甩动：不夹的话一次抽动能
+      // 灌进十几 cards/s，弹簧被推得大幅过冲，落位要 500ms 以上。
+      velC = Math.max(-4, Math.min(4, -vPxMs * 1000 / W()));
+      const proj = cur + velC * HORIZON - idx;
+      const step = Math.abs(proj) > SNAP ? Math.sign(proj) : 0;
+      spring(Math.max(0, Math.min(n - 1, idx + step)));
     };
     stage.addEventListener("pointerup", release);
     stage.addEventListener("pointercancel", release);
@@ -2413,38 +2421,10 @@
       if (e.key === "ArrowLeft") { e.preventDefault(); goTo(idx - 1); }
       if (e.key === "ArrowRight") { e.preventDefault(); goTo(idx + 1); }
     });
-    deck.addEventListener("pointerenter", () => { hover = true; pauseAuto(); });
-    deck.addEventListener("pointerleave", () => { hover = false; restartAuto(); });
-    deck.addEventListener("focusin", () => { focused = true; pauseAuto(); });
-    deck.addEventListener("focusout", () => { focused = false; restartAuto(); });
-    document.addEventListener("visibilitychange", () => {
-      if (document.hidden) pauseAuto(); else restartAuto();
-    });
     window.addEventListener("resize", () => { cur = idx; velC = 0; paint(); }, { passive: true });
-    // 自动轮播与指示点进度同源：一个 200ms tick 驱动推进与填充；
-    // 暂停即冻结（elapsed 累计制，不用绝对时刻）。
-    let elapsed = 0, autoOn = false, lastTick = 0;
-    function pauseAuto() { autoOn = false; }
-    function restartAuto() {
-      if (RM.matches || document.hidden || hover || focused || autoOn || raf) return;
-      autoOn = true; lastTick = performance.now();
-    }
-    setInterval(() => {
-      const now = performance.now();
-      if (autoOn) {
-        elapsed += now - lastTick;
-        if (elapsed >= AUTOPLAY_MS && !drag && !raf) {
-          elapsed = 0;
-          spring((idx + 1) % n, 1.0, 0.38);   // 自动切换 ≤400ms
-        }
-      }
-      lastTick = now;
-      const fill = dots[idx] && dots[idx].firstChild;
-      if (fill) fill.style.transform =
-        `scaleX(${autoOn ? Math.min(elapsed / AUTOPLAY_MS, 1).toFixed(3) : "0"})`;
-    }, 200);
-    paint(); paintDots(); enter(); restartAuto();
+    paint(); paintDots(); enter();
   }
+
 
   // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
   // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。

--- a/site/index.html
+++ b/site/index.html
@@ -199,10 +199,11 @@ layout: null
       </div>
 
       <!-- 判定卡第五次迭代：大白板否掉（kcn），改单词卡式牌组 —— 顶牌全显，
-           后续三张 scale+translateY 露边；横滑手势 / 指示点 / 自动轮播三通道
-           换牌。每张牌一个主题，按现有数据面拆：今日判定 / 触发中的硬闸 /
-           执行纪律 / 黄金回本。引擎在 dashboard.hero.js 与 dashboard.render.js
-           双实现逐字同步（setupVerdictDeck）。 -->
+           后续两张固定 8px 露边；横滑手势 / 指示点 / 方向键三通道换牌
+           （第六次迭代撤掉 7s 自动轮播：首屏不该有自己转的东西）。每张牌一个
+           主题，按现有数据面拆：今日判定 / 触发中的硬闸 / 执行纪律 / 黄金回本。
+           引擎在 dashboard.hero.js 与 dashboard.render.js 双实现逐字同步
+           （setupVerdictDeck）。 -->
       <section class="card verdict-deck" id="verdict-deck" aria-roledescription="轮播" aria-label="决策面板">
         <div class="verdict-deck-stage" id="verdict-deck-stage">
           <article class="deck-card" data-theme="今日判定" aria-labelledby="overview-verdict-title">


### PR DESCRIPTION
判定卡「今日判定」单词卡牌组第六次迭代。kcn 反馈原话：「现在画风展示不错，还有配色。但是堆叠交互太诡异了，而且留白太多。」

**画风与配色一字未动**：玻璃配方（半透明面 + 斜向 sheen + 高光切边 + 自画光池）、色板 token、字阶、chip 样式全部沿用；本轮只改「交互怎么动」与「间距」。牌组形态保留（顶牌全显 + 下层露边 + 换牌），没有退回单张通栏卡。

## 任务一：「诡异」的归因（先取证，后动手）

before 截图 + 中间态几何实测（不是感觉）。诡异不来自「卡牌堆叠」这个形态，来自四个互相打架的几何/行为：

| # | 诡异源 | 实测证据 | 改成 |
|---|---|---|---|
| 1 | **牌桌没有边** | 滑出层 1:1 跟手横移到 `x=-160`，而牌组左缘在 `x=28` —— 抽走的牌盖在相邻区块上 | stage `overflow: clip`（clip-margin 8px 留牌影），牌消失在内容栏边缘 |
| 2 | **中间态是两套牌位拼的** | `pose()` 里滑出层横移 × 升起层原地缩放；第三张整段冻在 `m=2`，等 `idx` 变了才跳一下 | 单一连续模型：位姿只由「深度 `d = i - cur`」推出，`d<0` 抽走中、`d≥0` 台面第 d 层。无分支即无撕裂 —— 实测拖 300px 时第 2/3 张同步 8→5.84 / 16→13.84px |
| 3 | **露边尺度随宽度飘** | uniform scale 在 1200 档只露 4px / 6.5px 发丝，读作「牌没放齐」 | 固定 8px 露边 + 固定 8px 单边缩进（scaleX 换算）；z-index 降为静态 `n-i` |
| 4 | **两件自我表演** | 7s 自动轮播让首屏上牌自己转；整叠 0.97 按压缩放让 1144px 的面一碰就缩 3%（实测 1110→1077→1034→969） | 都撤掉。换牌三通道（横滑 / 指示点 / 方向键）不变，跟手位移本身就是按压反馈 |

顺带修两个**有界性**缺陷：

- 指示点点到第 4 张原来让中间两张各飞一遍，实测 >1s，破 400ms 闸 → 跳非邻位时先瞬移到邻位，只演一张牌。
- 释放速度不夹：一次抽动能灌进十几 cards/s 把弹簧推得大幅过冲 → 夹到 4 cards/s（≈两倍于人手最猛的甩动）。
- 弹簧统一临界阻尼、response `.26s`。解析解：到 1% 275ms、到 1.7px 397ms，压在「轮播切换 ≤400ms」内。（本机 headless 实测 rAF 只有 ~9fps，`dt` 被 1/30 夹住，墙钟数字在这台机器上不可用，故用解析解。）

指示点不再兼任轮播进度条，26px 条状点收成 5px 圆点（与同一张牌里硬闸点阵 `.gt-dot` 同一套计数语言），并补上 `:active` 按压反馈。

## 任务二：留白收敛

1. **撤掉外层托盘的 `.card` 面/边/影/内衬**。牌组容器本身继承了 `.card`：一块玻璃面里再摆四张玻璃牌 = 玻璃里糊玻璃（#937）；那 16px 内衬还把牌面推得比正上方 hero 卡窄 17px（实测 hero 卡面左缘 `x=28`、判定牌面左缘 `x=45`）。撤掉后横向省 34px、纵向省 32px，首屏三块面左缘对齐。
2. **牌内纵向内衬 20/18 → 16/16**（横向仍走 `--card-inset` 与 hero 同列对齐）；段间垫 12 → 10，gap 10 → 8，指示点轨 12 → 10。
3. **地板三档重测**。旧 319/506/571 是通栏大卡时代的安全上界；牌组拆张后 ≥1024 档实测最高牌只有 207px，地板比数据态高 90px 以上，短牌（纪律 100 / 黄金 93）更是二百多。重测方法：360~1920 每 20px 扫一遍，每档取**忙日上界**（5 枚 chip 全到位 = 渲染端上限，硬闸 3 行长 detail = compact 上限），不是今天这份数据。

| 档 | 忙日实测最高牌 | + 露边16 + gap8 + 点10 | 新地板 | 旧地板 |
|---|---|---|---|---|
| ≥1024 | 226.39 | 260.39 | **262** | 319 |
| 768~1023 | 256.39 | 290.39 | **292** | 506 |
| <768 | 346.39 | 380.39 | **382** | 571 |

预留仍是**宽度的确定函数**：牌是绝对定位的，牌组高度只由 `min-height` 决定，数据变多的失败模式是牌内截断而非把地板顶穿，所以余量按构图上限留、不按当日实测留。

## 验证

- **CLS A/B×3**（同 harness、同一份 assets/data、light=dark，median of 3）：

| 视口 | A (master) | B (v6) |
|---|---|---|
| 1200×760 | 0.0067 | 0.0067 |
| 1440×900 | 0.0056 | 0.0056 |
| 390×844 | 0.0095 | 0.0095 |

  一档没涨。

- **实测卡高落在新地板内**（数据态，after）：

| 视口 | 最高牌 | 需要 | 地板 | 余量 |
|---|---|---|---|---|
| 1200 / 1440 | 199.39 | 233.39 | 262 | 28.61 |
| 390 | 286.39 | 320.39 | 382 | 61.61 |

- `tests/dashboard_tab_runtime.spec.js` 绿（exit 0，静默即通过）
- `pytest tests/test_dashboard_bundle_parity.py tests/test_dashboard_desktop_layout_contract.py tests/test_dashboard_contrast.py tests/test_site_deploy.py tests/test_dashboard_payload_size.py tests/test_dashboard_security.py tests/test_dashboard_artifact_gate_contract.py` → 42 passed
- **parity 棘轮绿**：`setupVerdictDeck` 在 hero.js / render.js 两份逐字同步，`ALLOWED_DIVERGENT` 未加一条
- 红线自查：无新增 font-size；只动 transform/opacity；`prefers-reduced-motion` 全套退化保留（JS 直接落位 + CSS `.deck-dot` transition 关闭）；`prefers-reduced-transparency` 回退不变；hover 仍 `(hover:hover) and (pointer:fine)` 门控；`:active` 反馈新增在指示点上；playwright 全程 stub live 源（`ops/pages/fetch_data_plane.py --into` 拉的快照），选择器走 `data-*`/id；`assets/data` 是 gitignored 物化，未 add

## 截图

`/root/logs/decision-deck-v6/`

- before：`before-fold-{1200,1440,390}-{light,dark}.png`、`before-deck-*.png`、`before-drag-mid-1200-dark.png`（滑出层跑出牌组的那张）
- after：`after-fold-{1200,1440,390}-{light,dark}.png`、`after-deck-*.png`、`after-drag-mid-1200-dark.png`、`after-drag-viewport-1200-{dark,light}.png`（中间态被台面裁住的那张）
- 几何/扫宽原始数据：`before-geometry.json`、`after-geometry.json`、`sweep.json`、`cls.json`

## 取舍

- **自动轮播直接撤掉而不是放缓**：dashboard 首屏不该有不停自我表演的东西，而「自己会动」是「诡异」里最难归因的一份。想要回来是一个常量的事（原 `AUTOPLAY_MS = 7000` 那条 tick 已连同 `setInterval` 一并删除，恢复要重写这段 —— 若 kcn 要，改回来另开一个 commit）。
- **1:1 跟手保留 + 换牌阈值 25%**：一叠牌一次只抽一张，所以落点判据从 `Math.round(动量投影)` 改成「过阈值走一张」，既保住直接操纵的诚实，又不必拖满整张牌宽。
- **短牌（纪律 / 黄金）仍有余量**：地板由最高的一张牌定，短牌下方留白是那份忙日预留，不是白扔的空间；要再收就得让四张牌各自定高，那会让换牌时牌框变形，比留白更诡异。
