### PR TITLE
fix(hk-close): 移出 CAS 窗口 + prev_close_date 改上一交易日 + 写 volume

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -417,13 +417,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "0 16 * * 1-5",
+        "expr": "10 16 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "15 16 * * 1-5",
+          "expr": "20 16 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-report-watchdog --market hk --phase close --job-name \"港股收盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"

--- a/docs/operations/cron-schedules.md
+++ b/docs/operations/cron-schedules.md
@@ -35,7 +35,7 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
 | 盘中盯盘 | `*/30 10-11,14-15 * * 1-5` · Asia/Shanghai | Mode 7 | `intraday --hk` | `10,40 10-11,14-15 * * 1-5` · Asia/Hong_Kong |
 | 港股午盘报告 | `0 12 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk mid` | `12 12 * * 1-5` · Asia/Hong_Kong |
 | 港股午后快报 | `30 13 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk pm` | `42 13 * * 1-5` · Asia/Hong_Kong |
-| 港股收盘报告 | `0 16 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk close` | `15 16 * * 1-5` · Asia/Hong_Kong |
+| 港股收盘报告 | `10 16 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk close` | `20 16 * * 1-5` · Asia/Hong_Kong |
 | 美股开盘报告 | EDT `30 21 * * 1-5`<br>EST `30 22 * * 1-5` | Mode 6 | `report --us open` | EDT `45 21 * * 1-5`<br>EST `45 22 * * 1-5` |
 | 美股盘中盯盘 | EDT `*/30 22-23 * * 1-5`<br>EST `*/30 23 * * 1-5` | Mode 7 | `intraday --us` | EDT `10,40 22-23 * * 1-5`<br>EST `10,40 23 * * 1-5` |
 

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -24,6 +24,7 @@ import requests
 from clawock.credentials import load_api_keys as _load_api_keys
 from clawock.market_data import integrity as bar_checks
 from clawock.market_data.eastmoney_http import em_get
+from clawock import sessions as trading_calendar
 from clawock.instruments import INSTRUMENTS
 from clawock.portfolio.books import region_book
 from clawock.workspace import workspace_root
@@ -79,11 +80,18 @@ def _parse_gtimg(text: str) -> Optional[Dict]:
         lot_size = int(float(parts[60])) if len(parts) > 60 and parts[60] else None
         if lot_size is not None and lot_size <= 0:
             lot_size = None
+        # Tencent field 6 is the traded volume (shares). HK refresh historically
+        # never wrote it, leaving a stale legacy value in snapshots; capture it
+        # from the same wire line so a refresh can overwrite the stale field.
+        vol = int(float(parts[6])) if len(parts) > 6 and parts[6] else None
+        if vol is not None and vol <= 0:
+            vol = None
         return {
             'name': parts[1],
             'c': price, 'pc': pc, 'o': op,
             'h': hi, 'l': lo,
             'lot_size': lot_size,
+            'volume': vol,
             'dp': _pct(price, pc),
         }
     except Exception:
@@ -382,6 +390,13 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
     print(f"  Fetched {len(quotes)}/{len(codes)} prices from Tencent gtimg")
 
     today_date = now_hkt.strftime('%Y-%m-%d')
+    # A prior close belongs to the PRIOR HK session, never today. Stamping
+    # today_date here (the old behaviour) produced holdings whose
+    # prev_close_date equalled the session date — an impossible state that also
+    # switched off integrity's STALE_PRICE gate for exactly the rows that needed
+    # it. Align with the US path (us_quotes.py) and use the HK trading calendar.
+    hk_prev_session = trading_calendar.previous_trading_day(
+        'hk', now_hkt.date()).isoformat()
     updated, missing, range_warns = [], [], []
 
     for h in active:
@@ -411,7 +426,7 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
 
         h['current_price']    = round(c, 3)
         h['prev_close']       = round(pc, 3)
-        h['prev_close_date']  = today_date
+        h['prev_close_date']  = hk_prev_session
         h['today_change_pct'] = round(q['dp'], 2)
         h['current_value']    = round(c * shrs, 2)
         h['pnl_abs']          = round((c - cost) * shrs, 2)
@@ -423,6 +438,11 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
         # prior verified lot when absent, but never invent a one-share HK lot.
         if q.get('lot_size'):
             h['lot_size'] = int(q['lot_size'])
+        # Volume: Tencent primary carries traded volume (parts[6]); fallback
+        # sources generally do not. Overwrite when present, else preserve the
+        # prior verified value — never invent a volume.
+        if q.get('volume'):
+            h['volume'] = int(q['volume'])
 
         # 日内区间 — 仅当本次行情带 open/high/low 时覆盖，避免旧交易日残留值
         # （Tencent 主源有；stooq/yfinance fallback 没有则保持上次真值不写脏数据）

--- a/tests/test_analyze_hk_stocks.py
+++ b/tests/test_analyze_hk_stocks.py
@@ -4,7 +4,9 @@ All quote inputs are synthetic Tencent wire-format responses.  These tests do
 not call fetchers or patch a transport: the exercised surface is deterministic.
 """
 
+import json
 import sys
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 import pytest
@@ -78,6 +80,7 @@ def test_parse_gtimg_hk_quote_uses_definitional_price_and_day_range_fields():
         "h": 512.0,
         "l": 499.5,
         "lot_size": None,
+        "volume": None,
         "dp": 1.5,
     }
 
@@ -174,6 +177,145 @@ def test_parse_gtimg_valid_quote_without_day_range_does_not_fabricate_range():
     assert parsed is not None
     assert parsed["h"] is None
     assert parsed["l"] is None
+
+
+def test_parse_gtimg_carries_hk_volume_from_field_6():
+    fields = [""] * 40
+    fields[1] = "MINIMAX-W"
+    fields[3] = "299.600"
+    fields[4] = "312.200"
+    fields[5] = "312.000"
+    fields[6] = "12136215"
+    fields[33] = "323.600"
+    fields[34] = "290.400"
+
+    parsed = hk._parse_gtimg('v_hk00100="' + "~".join(fields) + '";')
+
+    assert parsed is not None
+    assert parsed["volume"] == 12136215
+
+
+def test_parse_gtimg_without_volume_field_does_not_fabricate_volume():
+    # Field 6 absent/empty → volume must stay None so callers preserve the
+    # prior verified value instead of inventing one.
+    fields = [""] * 40
+    fields[1] = "MINIMAX-W"
+    fields[3] = "299.600"
+    fields[4] = "312.200"
+
+    parsed = hk._parse_gtimg('v_hk00100="' + "~".join(fields) + '";')
+
+    assert parsed is not None
+    assert parsed["volume"] is None
+
+
+def test_update_hk_portfolio_stamps_prev_close_to_prior_session_and_writes_volume(
+    tmp_path, monkeypatch
+):
+    port = {
+        "portfolios": {
+            "hk_stocks": {
+                "holdings": [
+                    {
+                        "ticker": "00100",
+                        "shares": 100.0,
+                        "cost_basis": 300.0,
+                        "current_price": 312.0,
+                        "prev_close": 312.2,
+                        "prev_close_date": "2026-08-25",
+                        "day_session_date": "2026-08-25",
+                        "day_open": 312.0,
+                        "day_high": 323.6,
+                        "day_low": 290.4,
+                        "volume": 38060,
+                        "lot_size": 500,
+                    }
+                ]
+            }
+        }
+    }
+    p = tmp_path / "portfolio.json"
+    p.write_text(json.dumps(port))
+    monkeypatch.setattr(hk, "PORTFOLIO_PATH", str(p))
+
+    quote = {
+        "name": "MINIMAX-W",
+        "c": 299.6,
+        "pc": 312.2,
+        "o": 312.0,
+        "h": 323.6,
+        "l": 290.4,
+        "lot_size": 500,
+        "volume": 12136215,
+        "dp": -4.04,
+        "_src": "Tencent",
+    }
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": quote})
+    monkeypatch.setattr(hk, "fetch_indices", lambda: {})
+
+    data = hk.update_hk_portfolio(dry_run=True)
+    h = data["portfolios"]["hk_stocks"]["holdings"][0]
+
+    # prev_close_date must be the PRIOR HK trading session, never today — this
+    # is the fix that re-arms integrity's STALE_PRICE gate.
+    assert h["prev_close_date"] != "2026-08-25"
+    now_hkt = datetime.now(timezone(timedelta(hours=8)))
+    expected = hk.trading_calendar.previous_trading_day("hk", now_hkt.date()).isoformat()
+    assert h["prev_close_date"] == expected
+    assert h["prev_close_date"] < h["day_session_date"]
+
+    # Volume must be overwritten with the real traded volume from Tencent
+    # parts[6], replacing the stale legacy 38060.
+    assert h["volume"] == 12136215
+
+
+def test_update_hk_portfolio_preserves_volume_when_quote_lacks_volume(
+    tmp_path, monkeypatch
+):
+    port = {
+        "portfolios": {
+            "hk_stocks": {
+                "holdings": [
+                    {
+                        "ticker": "00100",
+                        "shares": 100.0,
+                        "cost_basis": 300.0,
+                        "current_price": 312.0,
+                        "prev_close": 312.2,
+                        "day_open": 312.0,
+                        "day_high": 323.6,
+                        "day_low": 290.4,
+                        "volume": 38060,
+                        "lot_size": 500,
+                    }
+                ]
+            }
+        }
+    }
+    p = tmp_path / "portfolio.json"
+    p.write_text(json.dumps(port))
+    monkeypatch.setattr(hk, "PORTFOLIO_PATH", str(p))
+
+    # Fallback source that does not expose volume.
+    quote = {
+        "name": "MINIMAX-W",
+        "c": 299.6,
+        "pc": 312.2,
+        "o": 312.0,
+        "h": 323.6,
+        "l": 290.4,
+        "lot_size": 500,
+        "dp": -4.04,
+        "_src": "Eastmoney",
+    }
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": quote})
+    monkeypatch.setattr(hk, "fetch_indices", lambda: {})
+
+    data = hk.update_hk_portfolio(dry_run=True)
+    h = data["portfolios"]["hk_stocks"]["holdings"][0]
+
+    # Without a volume on the quote, the prior verified value must be kept.
+    assert h["volume"] == 38060
 
 
 @pytest.mark.parametrize(

--- a/tests/test_preflight_integrity.py
+++ b/tests/test_preflight_integrity.py
@@ -542,6 +542,25 @@ def test_staleness_accepts_last_session_and_warns_one_session_behind(run_check):
     )
 
 
+def test_stale_price_gate_fires_only_when_prev_close_date_is_prior_session(run_check):
+    # current == prev_close: with the FIXED HK stamp (prev_close_date is the prior
+    # session, strictly before day_session_date) integrity's STALE_PRICE gate must
+    # fire. This is the gate that the old "stamp today" behaviour silently disabled.
+    fixed = _holding(ticker="00100", current=312.2, previous=312.2)
+    fixed["prev_close_date"] = "2026-07-16"
+    fixed["day_session_date"] = "2026-07-17"
+    report_fixed = run_check(_portfolio_data(region="hk_stocks", holdings=[fixed]))
+    assert any(f["code"] == "STALE_PRICE" for f in report_fixed["findings"])
+
+    # Legacy (broken) stamp: prev_close_date == day_session_date ("today"). The
+    # gate must NOT fire for exactly this row — reproducing the disabled-gate bug.
+    broken = _holding(ticker="00100", current=312.2, previous=312.2)
+    broken["prev_close_date"] = "2026-07-17"
+    broken["day_session_date"] = "2026-07-17"
+    report_broken = run_check(_portfolio_data(region="hk_stocks", holdings=[broken]))
+    assert not any(f["code"] == "STALE_PRICE" for f in report_broken["findings"])
+
+
 @pytest.mark.xfail(
     strict=True,
     reason=(


### PR DESCRIPTION
# 修复港股收盘 16:00 档踩 HKEX 收市竞价(CAS)窗口

## 根因
港股收盘 job 在 `0 16`（16:00 HKT）抓取，落在 CAS 窗口（16:00–16:08）内，腾讯对单只股的 `parts[3]` 现价返回竞价前参考值，被原样落盘（08-25 00100=312.0=今开、02208=9.42≈昨收）。叠加 `prev_close_date` 被写成"今天"导致 `integrity.STALE_PRICE` 闸失效，坏值漏网。

## 改动（Closes #1020）
- **时序**：港股收盘 job `expr` `0 16` → `10 16`（16:10 HKT，CAS 16:08 撮合后抓取）；同 job `watchdog.schedule` `15 16` → `20 16`（余量 5→10 分钟）。
- **prev_close_date**：`src/clawock/market_data/hk_analysis.py` 改为上一 HK 交易日（`clawock.sessions.previous_trading_day('hk', ...)`），对齐 US 路径，恢复 `STALE_PRICE` 闸。
- **volume**：`_parse_gtimg` 取 Tencent `parts[6]` 成交量；`update_hk_portfolio` 抓到时写入 `h['volume']`，fallback 无成交量则保留旧值（同 `lot_size` 写法，不发明数据）。消除 `volume=38060` 长期陈旧脏值。
- 同步重新生成 `docs/operations/cron-schedules.md`（`generate_cron_docs.py --check` 契约一致）。

## 测试
- `tests/test_analyze_hk_stocks.py`：`_parse_gtimg` 带 `volume`、缺字段时 `volume=None`；`update_hk_portfolio`（dry-run，mock `fetch_hk_quotes`/`fetch_indices`）验证 `prev_close_date`=上一交易日且 `< day_session_date`、`volume` 被真值覆盖（fallback 时保留旧值）。
- `tests/test_preflight_integrity.py`：`STALE_PRICE` 闸在 `prev_close_date` 为上一交易日且 `current==prev_close` 时触发；旧"写今天"语义下不触发（复现被关掉的闸）。

## 不在此 PR 的后续项
竞价前现价显式告警、`parts[30]` 时间戳守卫（≥16:08 才收）、00100 单源交叉校验兜底 —— 记于 #1020。

本地针对性测试全绿（`test_analyze_hk_stocks` / `test_preflight_integrity` / `test_cron_contracts` / `test_data_source_unification`）。
