### PR TITLE
判定牌组第七/八次迭代：四张收两张 + 牌面吃满预留、硬闸按严重度选行

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2603,8 +2603,9 @@
        不是今天这份数据）。≥1024 档 = 226.39 + 露边 16 + gap 8 + 指示点 10
        = 260.39，+2。牌是绝对定位的，牌组高度本来就只由这条 min-height 决定
        ——预留是宽度的确定函数，不是数据的函数；数据变多的失败模式是牌内
-       截断，所以余量按构图上限留，不按当日实测留。 */
-    min-height: 262px;
+       截断，所以余量按构图上限留，不按当日实测留。第八次迭代（正文吃满
+       盒子 + 异动条改横排）重扫：≥1024 忙日上界 220.89 + 34 = 254.89，+2。 */
+    min-height: 257px;
   }
   .verdict-deck-stage {
     position: relative; flex: 1; min-height: 0;
@@ -2701,7 +2702,24 @@
   }
   /* 牌内硬闸区：原「段间发丝线」是通栏卡的分段语言；独立成牌后它就是
      牌的正文，去掉段首线与顶垫。 */
-  .verdict-deck .overview-gates { border-top: 0; padding-top: 0; margin: 10px 0 0; }
+  .verdict-deck .overview-gates {
+    border-top: 0; padding-top: 0; margin: 10px 0 0;
+    display: flex; flex-direction: column; flex: 1; min-height: 0;
+  }
+  /* 同一条「正文吃满盒子」：三行硬闸把牌里剩下的高度分掉（行高上限 88px，
+     免得数据少的日子把三行拉成三块板），尾注与跳转钮不参与分配。 */
+  .verdict-deck .overview-gates .risk-alerts { flex: 1; }
+  .verdict-deck .overview-gates .risk-alert {
+    flex: 1 1 auto; max-height: 88px; align-items: center;
+  }
+  /* hard stop（critical）与限额超标（high）在牌上都是红条，用条宽分档：
+     3px = 已经跌穿硬止损线，2px = 限额/敞口超标。 */
+  .overview-gates .risk-alert.critical { border-left-width: 3px; }
+  .overview-gates-more {
+    flex: 0 0 auto; padding: 7px 0 0;
+    border-top: 1px solid var(--border-subtle);
+    color: var(--text-faint); font-size: var(--fs-micro); line-height: 1.35;
+  }
   /* 牌尾跳转钮：贴牌底（flex 列的 margin-top:auto），不随内容长短漂。 */
   .deck-card-jump { margin-top: auto; align-self: flex-end; }
   /* 牌组化后双栏 grid-areas 与「玻璃上的仪表面板 well」一并退场：硬闸
@@ -2764,9 +2782,29 @@
      发丝线描边；数值段 mono tabular（仓库字规：mono 只用于数字）。
      底色用不透明 --card-2 —— 玻璃上的开孔必须不透明（#937 打孔判据），
      tone 只染边线与 value，不染整底：满屏色底是行情软件最廉价的读感。 */
+  /* 第八次迭代：牌是绝对定位、撑满台面的（inset: 0 0 16px），而正文只有
+     判词 + chip + 三根柱 —— 实测 1200 档正文 196px 待在 244px 的牌里，390 档
+     256px 待在 364px 里，牌底那 48px / 108px 就是 kcn 说的「留白很多」。地板
+     本身不动（它是宽度的确定函数，CLS 判据不变），改成正文吃满盒子：chip 行
+     按内容占高，柱区 flex:1 拿走剩下的全部高度 —— 预留的空气变成画布。 */
+  /* 今日判定牌 ≥1024 是双栏：判词 + chip 走左栏，异动条走右栏并吃满两行高。
+     原来判词、chip、异动条是从上往下三条带，1144px 的牌上每条带右边都空着
+     一大截 —— kcn「几张卡留白很多」的另一半就是这个横向的空。栏宽是宽度的
+     函数，不是数据的函数（CLS 判据不变）；窄档回单栏（见下方两个媒体块）。 */
+  .verdict-deck .deck-card:first-child {
+    display: grid; column-gap: 18px;
+    grid-template-columns: minmax(0, 1fr) minmax(232px, 31%);
+    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-areas: "head head" "verdict movers" "chips movers";
+    align-content: stretch;
+  }
+  .verdict-deck .deck-card:first-child > .overview-verdict-head { grid-area: head; }
+  .verdict-deck .deck-card:first-child > .overview-status { grid-area: verdict; }
+  .verdict-deck .deck-card:first-child > .today-highlights { grid-area: chips; }
+  .verdict-deck .deck-card:first-child > .today-movers { grid-area: movers; }
   .deck-card .today-highlights {
-    display: flex; flex-wrap: wrap; gap: 6px;
-    margin: 10px 0 0; min-height: 0;
+    display: flex; flex-wrap: wrap; align-content: flex-start; gap: 6px;
+    margin: 10px 0 0; min-height: 0; min-width: 0;
   }
   .deck-card .hl-chip {
     display: inline-flex; align-items: center; gap: 7px;
@@ -2809,36 +2847,49 @@
   .deck-card .tone-bad .hl-meter i { background: var(--negative); }
   /* 异动迷你柱：今日 top movers 画成一排零轴柱（图为主），ticker+pct 退为
      caption。柱高/柱位由 JS 写死 px —— 容器高度固定 26px，构图不随数据变。 */
+  /* 异动条：一行一只，ticker | 零轴分叉条 | pct。左栏是判词 + chip，两栏之间
+     用发丝线分栏（单栏时改成上边线，见媒体块）。行随牌高分配（flex:1，
+     上限 48px —— 数据少的日子不把三行拉成三块板）。 */
+  .deck-card .today-movers {
+    display: flex; flex-direction: column; min-height: 0;
+    margin: 10px 0 0; padding-left: 18px;
+    border-left: 1px solid var(--border-subtle);
+  }
   .deck-card .hl-movers {
-    display: grid; width: 100%; max-width: 480px;
-    margin: 2px 0 0; padding: 10px 0 0;
-    border-top: 1px solid var(--border-subtle);
+    display: flex; flex-direction: column; gap: 6px; min-width: 0;
+    flex: 1; min-height: 0;
   }
-  .deck-card .hl-mv { min-width: 0; }
-  /* 40px 画布、零轴居中：柱最长 17px（JS 归一），上下各留 3px —— 柱永远
-     待在画布内，构图是常量，不是数据的函数。 */
-  .deck-card .hl-mv-bar { position: relative; height: 40px; }
-  .deck-card .hl-mv-bar::before {
-    content: ""; position: absolute; left: 0; right: 0; top: 50%;
-    border-top: 1px solid var(--border-subtle);
+  .deck-card .hl-mv-head {
+    flex: 0 0 auto; color: var(--text-tertiary);
+    font: 600 var(--fs-micro)/1 var(--mono); letter-spacing: .09em;
   }
-  .deck-card .hl-mv-bar i {
-    position: absolute; left: 50%; transform: translateX(-50%);
-    width: 14px; border-radius: 2px;
-  }
-  .deck-card .hl-mv-bar i.up { background: var(--positive); bottom: 50%; }
-  .deck-card .hl-mv-bar i.down { background: var(--negative); top: 50%; }
-  .deck-card .hl-mv-cap {
-    display: flex; align-items: baseline; justify-content: center;
-    gap: 6px; margin-top: 5px; min-width: 0;
+  .deck-card .hl-mv {
+    display: flex; align-items: center; gap: 8px;
+    flex: 1 1 auto; max-height: 48px; min-width: 0;
     font-size: var(--fs-micro); line-height: 1;
   }
+  /* 零轴居中的双向条：条长 = 半幅的 92%（JS 归一后写百分比），左右各留
+     4% —— 条永远待在轨内，构图随盒子变，不随数据变。 */
+  .deck-card .hl-mv-bar {
+    position: relative; flex: 1 1 auto; min-width: 0; height: 8px;
+    border-radius: 2px; background: var(--card-2);
+  }
+  .deck-card .hl-mv-bar::before {
+    content: ""; position: absolute; top: -3px; bottom: -3px; left: 50%;
+    border-left: 1px solid var(--border-subtle);
+  }
+  .deck-card .hl-mv-bar i {
+    position: absolute; top: 0; bottom: 0; min-width: 3px; border-radius: 2px;
+  }
+  .deck-card .hl-mv-bar i.up { left: 50%; background: var(--positive); }
+  .deck-card .hl-mv-bar i.down { right: 50%; background: var(--negative); }
   .deck-card .hl-mv-t {
-    color: var(--text-tertiary); font-weight: 600;
+    flex: 0 0 52px; color: var(--text-tertiary); font-weight: 600;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .deck-card .hl-mv-p {
-    flex: 0 0 auto; font-family: var(--mono); font-weight: 600;
+    flex: 0 0 52px; text-align: right;
+    font-family: var(--mono); font-weight: 600;
     font-variant-numeric: tabular-nums;
   }
   .overview-gates {
@@ -3013,13 +3064,30 @@
 
   @media (min-width: 768px) and (max-width: 1023px) {
     .hero-rail { grid-template-columns: repeat(4, minmax(0, 1fr)); min-height: 152px; }
-    /* 292：768~1023 扫宽忙日实测上界 256.39（在 780）+ 露边 16 + gap 8
-       + 指示点 10 = 290.39，+2。旧值 506 是通栏卡时代的安全上界，牌组
-       拆张后高出 214px 纯留白。 */
-    .verdict-deck { min-height: 292px; }
+    /* 296：768~1023 扫宽忙日实测上界 260.39（在 780）+ 露边 16 + gap 8
+       + 指示点 10 = 294.39，+2（第八次迭代重扫：异动条多一行小标题）。 */
+    .verdict-deck { min-height: 296px; }
+    /* 窄档回单栏：判词、chip、异动条上下三带，分栏线转成上边线。剩余高度
+       只给异动条那一带（chip 带按内容高，拉高它没有意义）。 */
+    .verdict-deck .deck-card:first-child {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: auto auto auto minmax(0, 1fr);
+      grid-template-areas: "head" "verdict" "chips" "movers";
+    }
+    .deck-card .today-movers {
+      padding: 10px 0 0; border-left: 0;
+      border-top: 1px solid var(--border-subtle);
+    }
+
     .verdict-deck, .overview-strip,
     .overview-command > .hero-honesty-card,
     .overview-command > .hero-gold-card { grid-column: 1 / -1; }
+  }
+  /* 1024~1199 单独一档（第八次迭代新增）：牌在 ≥1024 走双栏，左栏在这一档
+     只有 ~600px，忙日 5 枚 chip 要多折一行 ⇒ 忙日上界 249.39（在 1040）+ 露边
+     16 + gap 8 + 指示点 10 = 283.39，+2。≥1200 左栏够宽，回到 257。 */
+  @media (min-width: 1024px) and (max-width: 1199px) {
+    .verdict-deck { min-height: 285px; }
   }
   @media (max-width: 767px) {
     :root { --card-inset: 20px; }
@@ -3041,9 +3109,22 @@
     .dh-file { display: none; }
     .dh-bar { grid-column: 1 / -1; }
     .dh-detail { grid-column: 1 / -1; white-space: normal; }
-    /* 382：360~767 扫宽忙日实测上界 346.39（在 360）+ 露边 16 + gap 8
-       + 指示点 10 = 380.39，+2。窄档是留白重灾区：旧 571 高出 189px。 */
-    .verdict-deck { min-height: 382px; }
+    /* 386：360~767 扫宽忙日实测上界 350.39（在 360）+ 露边 16 + gap 8
+       + 指示点 10 = 384.39，+2（第八次迭代重扫）。窄档是留白重灾区，但那
+       段空高现在被异动条吃掉：地板不动，正文吃满。 */
+    .verdict-deck { min-height: 386px; }
+    /* 窄档回单栏：判词、chip、异动条上下三带，分栏线转成上边线。剩余高度
+       只给异动条那一带（chip 带按内容高，拉高它没有意义）。 */
+    .verdict-deck .deck-card:first-child {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: auto auto auto minmax(0, 1fr);
+      grid-template-areas: "head" "verdict" "chips" "movers";
+    }
+    .deck-card .today-movers {
+      padding: 10px 0 0; border-left: 0;
+      border-top: 1px solid var(--border-subtle);
+    }
+
     .overview-strip { display: flex; flex-direction: column; }
     .overview-strip-cell {
       min-height: 0; border-right: 0; border-bottom: 1px solid var(--border-subtle);

--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2905,7 +2905,10 @@
   }
   .overview-strip {
     grid-column: 1 / -1; min-width: 0;
-    display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, .8fr) minmax(0, .8fr);
+    /* 两格（第七次迭代前三格）：「今日异动」格印的首位异动与判定牌的零轴柱
+       是同一份 today_movers，留更全的那份。市场快照仍拿 2fr —— 它是五枚指数
+       格，另一格只有一个计数 + 一行注脚。 */
+    display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, .9fr);
     border: 1px solid var(--border-subtle); border-radius: 16px;
     /* 与 .card 同族的三件套（sheen/specular/负 spread 阴影）+ 同一 16px
        圆角 —— 它原来是裸 div，首屏三块表面里唯一的例外。
@@ -2946,11 +2949,6 @@
     min-height: 0; margin-top: 5px; font-size: var(--fs-micro); white-space: normal;
     overflow-wrap: anywhere;
   }
-  .overview-mover-summary {
-    color: var(--text); font: 700 var(--fs-xl)/1.15 var(--mono);
-    font-variant-numeric: tabular-nums; overflow-wrap: anywhere;
-  }
-  .overview-mover-summary .tk { display: block; color: var(--text-secondary); font: 700 var(--fs-sm)/1.3 var(--mono); }
   .overview-anomaly-count {
     color: var(--warning); font: 700 var(--fs-xxl)/1 var(--mono);
     font-variant-numeric: tabular-nums;

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -98,6 +98,7 @@
   // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
+    const mvEl = document.getElementById("today-movers");
     if (!el) return;
     const chips = [];
     const chip = (tone, k, v, d, meterPct) =>
@@ -183,6 +184,7 @@
     if (!chips.length && !movers.length) {
       el.style.display = "";
       el.replaceChildren();
+      if (mvEl) mvEl.replaceChildren();
       return;
     }
     el.style.display = "";
@@ -192,24 +194,29 @@
     // No icon slot: the old 7px status dot read as AI-flavoured (kcn: 彩色圆点
     // = AI 味). Row semantics live in position, weight and — for true alerts —
     // the red text colour, never in a coloured dot.
-    // 异动零轴柱：top3 各一根，高度 = |pct| 归一（最低 3px 可见），px 写死 ——
-    // 构图不随数据变；ticker+pct 退为柱下 caption（图为主，文字只做注脚）。
+    // 异动条（第八次迭代把竖柱转成横条）：竖柱在 1144px 宽的牌上是三根
+    // 14px 的孤棍，宽度全是空的；横条一行一只（ticker | 零轴分叉条 | pct），
+    // 窄盒宽盒都填得满，且 ticker/pct 回到同一行而不是柱下 caption。
+    // 条长 = |pct| 归一后取半幅的 92%，写百分比 —— 构图随盒子变、不随数据变。
     const maxAbs = Math.max(...movers.map(x => Math.abs(x.today_change_pct || 0)), 1);
-    const mvCell = x => {
+    const mvRow = x => {
       const pct = x.today_change_pct || 0;
-      const h = Math.max(3, Math.abs(pct) / maxAbs * 17);
-      return `<div class="hl-mv"><div class="hl-mv-bar">`
-        + `<i class="${pct >= 0 ? "up" : "down"}" style="height:${h.toFixed(1)}px"></i></div>`
-        + `<div class="hl-mv-cap"><span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
-        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div></div>`;
+      const w = Math.abs(pct) / maxAbs * 46;
+      return `<div class="hl-mv">`
+        + `<span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
+        + `<span class="hl-mv-bar"><i class="${pct >= 0 ? "up" : "down"}"`
+        + ` style="width:${w.toFixed(1)}%"></i></span>`
+        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div>`;
     };
     const moversRow = movers.length
-      ? `<div class="hl-movers" style="grid-template-columns:repeat(${movers.length},minmax(0,1fr))"`
-        + ` role="img" aria-label="今日异动前 ${movers.length}：`
+      ? `<div class="hl-movers" role="img" aria-label="今日异动前 ${movers.length}：`
         + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
-        + `">${movers.map(mvCell).join("")}</div>`
+        + `"><div class="hl-mv-head">今日异动</div>${movers.map(mvRow).join("")}</div>`
       : "";
-    el.innerHTML = chips.slice(0, 5).join("") + moversRow;
+    // chip 与异动条各自落到自己的挂载点：≥1024 时它们是牌上左右两栏，
+    // 窄档回到上下两带（版式全在 CSS，渲染端不判断宽度）。
+    el.innerHTML = chips.slice(0, 5).join("");
+    if (mvEl) mvEl.innerHTML = moversRow;
   }
 
   // 🪞 诚实自评卡 — 把这轮做的诚实层(风险调整判决 / catalyst 纪律 / 辩论决断 / 因子 CI)聚一处
@@ -1310,10 +1317,16 @@
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
-      ...stops.map(s => ({ icon: '', severity: 'high', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
+      ...stops.map(s => ({ icon: '', severity: s.severity || 'critical', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
     ];
+    // 严重度排序（第八次迭代）：原来把 hard stop 一律降写成 high，再按
+    // 「是不是 high」排 —— 同为 high 时排序稳定，于是 6 条 breach 永远排在
+    // 3 条 hard stop 前面，牌上那三个槽位只看得到限额比例，而「已经跌穿
+    // -18% 硬止损线」的三只（数据里本来就是 critical）从不上首屏。槽位按
+    // 数据自己的严重度给，不按数组下标给。
+    const SEV_RANK = { critical: 3, high: 2, medium: 1 };
     const compactRows = rows.slice().sort((a, b) =>
-      Number(b.severity === "high") - Number(a.severity === "high"));
+      (SEV_RANK[b.severity] || 0) - (SEV_RANK[a.severity] || 0));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
       // 「9 触发」红字是判定卡里最后一个裸读数：数量改用点阵计数表达
       // （一眼扫出严重度，不用读数），精确值退到 aria-label/title。槽位
@@ -1334,7 +1347,13 @@
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
+      // 牌上只有三个槽位，9 条里剩下的 6 条原来是无声消失的（表头点阵是
+      // 严重度密度，读不出「还有几条没列」）。补一行尾注说清被折叠的量。
+      const hidden = compact ? Math.max(0, compactRows.length - visibleRows.length) : 0;
+      const tail = hidden
+        ? `<div class="overview-gates-more">另有 ${hidden} 项未列出</div>` : '';
+      listEl.innerHTML = (html && html + tail)
+        || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -130,8 +130,16 @@
         "决策变化·新/改/触", `${newN}/${changedN}/${triggeredN}`));
     }
 
-    // (30d 自评指标 — 主动 vs 持有 alpha + catalyst 纪律 — 不再在此重复;
-    //  它们是回顾性统计,归属正下方的 🪞 诚实自评卡,不属于「今日速读」。)
+    // 30d 自评里只放一枚 Brier：它是「今日判定」这张牌自己的成绩单（判得准
+    // 不准 vs 留一法基线），首屏别处没有。执行率/样本不放 —— 正上方 hero-rail
+    // 第四格已经是「遵守率 30D 8.5% · 主动 call n=82」，同一个数说两遍。
+    // （第七次迭代把执行纪律牌删掉时，唯一独有的就是这一枚，并进来。）
+    const dm = safe(DATA, "decision_metrics") || {};
+    if (dm.brier != null) {
+      chips.push(chip(dm.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
+        Number(dm.brier).toFixed(3),
+        dm.brier_baseline_loo == null ? "" : `基线 ${Number(dm.brier_baseline_loo).toFixed(3)}`));
+    }
 
     // 1. Nearest-to-firing trigger (from the shared watch-level resolver)。
     // 接近度画成计量条：|dist| 归一到 0~10%（10% 外一律读作「远」），条只答
@@ -152,16 +160,9 @@
     //    同一个数说两遍是把首屏读成对账单。
     const movers = (safe(DATA, "today_movers") || []).slice(0, 3);
 
-    // 3. Top anomaly (high severity first)
-    const anomalies = (safe(DATA, "anomalies") || []).slice()
-      .sort((a,b) => (b.severity==="high"?1:0) - (a.severity==="high"?1:0));
-    if (anomalies.length) {
-      const a = anomalies[0];
-      const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push(chip(a.severity === "high" ? "bad" : "warn",
-        highN > 1 ? `异常×${highN}` : "异常",
-        escapeHtml(a.ticker), escapeHtml(a.detail)));
-    }
+    // 3. 异常不在这里出 chip：下面 overview-strip 的「异常」格印的是同一条
+    //    （实测两处都是「6 · SPCH weight 79.6% + pnl -31.0%」），而那格还多
+    //    一个 high 计数。同一个数在首屏出现两次就是 kcn 说的「和下面重复」。
 
     // 4. Catalyst dated today
     const cat = safe(DATA, "catalysts") || {};
@@ -320,24 +321,12 @@
     }
   }
 
+  // 「今日异动」那格在第七次迭代随 DOM 一起删了：它只印首位异动一个数，
+  // 而判定牌的零轴柱印的是同一份 today_movers 的 top3。这里只剩异常两格。
   function renderOverviewSummaries() {
-    const moverEl = document.getElementById("overview-mover-summary");
     const anomalyCount = document.getElementById("overview-anomaly-count");
     const anomalySummary = document.getElementById("overview-anomaly-summary");
-    const movers = (safe(DATA, "today_movers") || []).slice().sort((a, b) =>
-      Math.abs(b.today_change_pct || 0) - Math.abs(a.today_change_pct || 0)
-    );
     const anomalies = safe(DATA, "anomalies") || [];
-    if (moverEl) {
-      if (!movers.length) {
-        moverEl.textContent = "No ≥3% movers";
-        moverEl.className = "overview-mover-summary neutral";
-      } else {
-        const m = movers[0];
-        moverEl.innerHTML = `<span class="tk">${escapeHtml(m.ticker || DASH)}</span>${fmtPct(m.today_change_pct, 1)}`;
-        moverEl.className = "overview-mover-summary " + pnlClass(m.today_change_pct);
-      }
-    }
     if (anomalyCount) {
       anomalyCount.textContent = String(anomalies.length);
       anomalyCount.className = "overview-anomaly-count " +
@@ -359,7 +348,7 @@
     hero: [
       renderCommandDeck, renderDataHealth, renderRiskGuardrail, renderOverviewSummaries,
       renderMarketSnapshot, renderTodayHighlights, renderHonesty, renderGoldDca,
-      renderVerdictDeckSides,
+      setupVerdictDeck,
     ],
   };
   let RENDER_VERSION = 0;
@@ -1283,61 +1272,6 @@
   }
 
 
-  // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
-  // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。
-  function renderVerdictDeckSides() {
-    setupVerdictDeck();
-    const mk = (tone, k, v, d, meterPct) =>
-      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
-      + (v ? `<span class="hl-v">${v}</span>` : "")
-      + (d ? `<span class="hl-d">${d}</span>` : "")
-      + (meterPct == null ? ""
-        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
-      + `</span>`;
-    const disc = document.getElementById("deck-discipline");
-    if (disc) {
-      const m = safe(DATA, "decision_metrics") || {};
-      const act = safe(safe(m, "execution_by_kind"), "active") || {};
-      const chips = [];
-      if (m.brier != null) {
-        chips.push(mk(m.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
-          Number(m.brier).toFixed(3),
-          m.brier_baseline_loo == null ? "" : `基线 ${Number(m.brier_baseline_loo).toFixed(3)}`));
-      }
-      if (act.rate != null) {
-        chips.push(mk("flat", "执行率",
-          `${(act.rate * 100).toFixed(1)}%`,
-          act.known == null ? "" : `${act.known} 笔可核`));
-      }
-      if (m.raw_decisions != null) {
-        chips.push(mk("flat", "样本", `${m.raw_decisions}`, "近 30d 决策"));
-      }
-      disc.innerHTML = chips.length ? chips.join("")
-        : '<span class="hl-chip"><span class="hl-k">决策指标未生成</span></span>';
-    }
-    const gold = document.getElementById("deck-gold");
-    if (gold) {
-      const g = safe(DATA, "gold_dca") || {};
-      const badge = document.getElementById("deck-gold-badge");
-      if (badge) badge.textContent = g.fund_code ? String(g.fund_code) : "";
-      const ups = g.breakeven_upside_pct;
-      if (ups == null || g.nav == null) {
-        gold.innerHTML = '<span class="hl-chip"><span class="hl-k">回本数据缺</span></span>';
-      } else {
-        const above = ups <= 0;
-        const meter = Math.max(0, Math.min(100, 100 - Math.abs(ups) * 10));
-        const num = (v, dp) => Number(v).toLocaleString("zh-CN",
-          { minimumFractionDigits: dp, maximumFractionDigits: dp });
-        gold.innerHTML =
-          mk(above ? "ok" : Math.abs(ups) > 5 ? "bad" : "warn", "回本",
-            above ? `已越线 ${Math.abs(ups).toFixed(1)}%` : `需涨 ${ups.toFixed(1)}%`,
-            "", meter)
-          + mk("flat", "净值/成本", `${num(g.nav, 4)} / ${num(g.avg_cost, 4)}`)
-          + mk("flat", "现值", `¥${num(g.current_value, 0)}`,
-            (g.pnl_percent >= 0 ? "+" : "") + `${num(g.pnl_percent, 2)}%`);
-      }
-    }
-  }
   function renderRiskGuardrail() {
     const g = safe(DATA, "risk_guardrail") || {};
     const targets = [

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -149,8 +149,16 @@
         "决策变化·新/改/触", `${newN}/${changedN}/${triggeredN}`));
     }
 
-    // (30d 自评指标 — 主动 vs 持有 alpha + catalyst 纪律 — 不再在此重复;
-    //  它们是回顾性统计,归属正下方的 🪞 诚实自评卡,不属于「今日速读」。)
+    // 30d 自评里只放一枚 Brier：它是「今日判定」这张牌自己的成绩单（判得准
+    // 不准 vs 留一法基线），首屏别处没有。执行率/样本不放 —— 正上方 hero-rail
+    // 第四格已经是「遵守率 30D 8.5% · 主动 call n=82」，同一个数说两遍。
+    // （第七次迭代把执行纪律牌删掉时，唯一独有的就是这一枚，并进来。）
+    const dm = safe(DATA, "decision_metrics") || {};
+    if (dm.brier != null) {
+      chips.push(chip(dm.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
+        Number(dm.brier).toFixed(3),
+        dm.brier_baseline_loo == null ? "" : `基线 ${Number(dm.brier_baseline_loo).toFixed(3)}`));
+    }
 
     // 1. Nearest-to-firing trigger (from the shared watch-level resolver)。
     // 接近度画成计量条：|dist| 归一到 0~10%（10% 外一律读作「远」），条只答
@@ -171,16 +179,9 @@
     //    同一个数说两遍是把首屏读成对账单。
     const movers = (safe(DATA, "today_movers") || []).slice(0, 3);
 
-    // 3. Top anomaly (high severity first)
-    const anomalies = (safe(DATA, "anomalies") || []).slice()
-      .sort((a,b) => (b.severity==="high"?1:0) - (a.severity==="high"?1:0));
-    if (anomalies.length) {
-      const a = anomalies[0];
-      const highN = anomalies.filter(x => x.severity === "high").length;
-      chips.push(chip(a.severity === "high" ? "bad" : "warn",
-        highN > 1 ? `异常×${highN}` : "异常",
-        escapeHtml(a.ticker), escapeHtml(a.detail)));
-    }
+    // 3. 异常不在这里出 chip：下面 overview-strip 的「异常」格印的是同一条
+    //    （实测两处都是「6 · SPCH weight 79.6% + pnl -31.0%」），而那格还多
+    //    一个 high 计数。同一个数在首屏出现两次就是 kcn 说的「和下面重复」。
 
     // 4. Catalyst dated today
     const cat = safe(DATA, "catalysts") || {};
@@ -333,24 +334,12 @@
     }
   }
 
+  // 「今日异动」那格在第七次迭代随 DOM 一起删了：它只印首位异动一个数，
+  // 而判定牌的零轴柱印的是同一份 today_movers 的 top3。这里只剩异常两格。
   function renderOverviewSummaries() {
-    const moverEl = document.getElementById("overview-mover-summary");
     const anomalyCount = document.getElementById("overview-anomaly-count");
     const anomalySummary = document.getElementById("overview-anomaly-summary");
-    const movers = (safe(DATA, "today_movers") || []).slice().sort((a, b) =>
-      Math.abs(b.today_change_pct || 0) - Math.abs(a.today_change_pct || 0)
-    );
     const anomalies = safe(DATA, "anomalies") || [];
-    if (moverEl) {
-      if (!movers.length) {
-        moverEl.textContent = "No ≥3% movers";
-        moverEl.className = "overview-mover-summary neutral";
-      } else {
-        const m = movers[0];
-        moverEl.innerHTML = `<span class="tk">${escapeHtml(m.ticker || DASH)}</span>${fmtPct(m.today_change_pct, 1)}`;
-        moverEl.className = "overview-mover-summary " + pnlClass(m.today_change_pct);
-      }
-    }
     if (anomalyCount) {
       anomalyCount.textContent = String(anomalies.length);
       anomalyCount.className = "overview-anomaly-count " +
@@ -369,7 +358,7 @@
     hero: [
       renderTodayHighlights, renderHonesty, renderMarketSnapshot, renderCommandDeck,
       renderDataHealth, renderRiskGuardrail, renderOverviewSummaries, renderGoldDca,
-      renderVerdictDeckSides,
+      setupVerdictDeck,
     ],
     drill: [
       renderBook, renderAddCampaign, renderMovers,
@@ -2426,61 +2415,6 @@
   }
 
 
-  // 纪律 / 黄金回本两张副牌的内容渲染。数据缺口必须明说（muted 占位），
-  // 不装作没有这一格。⚠ 与 dashboard.render.js 逐字同步。
-  function renderVerdictDeckSides() {
-    setupVerdictDeck();
-    const mk = (tone, k, v, d, meterPct) =>
-      `<span class="hl-chip tone-${tone}"><span class="hl-k">${k}</span>`
-      + (v ? `<span class="hl-v">${v}</span>` : "")
-      + (d ? `<span class="hl-d">${d}</span>` : "")
-      + (meterPct == null ? ""
-        : `<span class="hl-meter" aria-hidden="true"><i style="width:${meterPct.toFixed(1)}%"></i></span>`)
-      + `</span>`;
-    const disc = document.getElementById("deck-discipline");
-    if (disc) {
-      const m = safe(DATA, "decision_metrics") || {};
-      const act = safe(safe(m, "execution_by_kind"), "active") || {};
-      const chips = [];
-      if (m.brier != null) {
-        chips.push(mk(m.brier_beats_baseline ? "ok" : "warn", "Brier·30d",
-          Number(m.brier).toFixed(3),
-          m.brier_baseline_loo == null ? "" : `基线 ${Number(m.brier_baseline_loo).toFixed(3)}`));
-      }
-      if (act.rate != null) {
-        chips.push(mk("flat", "执行率",
-          `${(act.rate * 100).toFixed(1)}%`,
-          act.known == null ? "" : `${act.known} 笔可核`));
-      }
-      if (m.raw_decisions != null) {
-        chips.push(mk("flat", "样本", `${m.raw_decisions}`, "近 30d 决策"));
-      }
-      disc.innerHTML = chips.length ? chips.join("")
-        : '<span class="hl-chip"><span class="hl-k">决策指标未生成</span></span>';
-    }
-    const gold = document.getElementById("deck-gold");
-    if (gold) {
-      const g = safe(DATA, "gold_dca") || {};
-      const badge = document.getElementById("deck-gold-badge");
-      if (badge) badge.textContent = g.fund_code ? String(g.fund_code) : "";
-      const ups = g.breakeven_upside_pct;
-      if (ups == null || g.nav == null) {
-        gold.innerHTML = '<span class="hl-chip"><span class="hl-k">回本数据缺</span></span>';
-      } else {
-        const above = ups <= 0;
-        const meter = Math.max(0, Math.min(100, 100 - Math.abs(ups) * 10));
-        const num = (v, dp) => Number(v).toLocaleString("zh-CN",
-          { minimumFractionDigits: dp, maximumFractionDigits: dp });
-        gold.innerHTML =
-          mk(above ? "ok" : Math.abs(ups) > 5 ? "bad" : "warn", "回本",
-            above ? `已越线 ${Math.abs(ups).toFixed(1)}%` : `需涨 ${ups.toFixed(1)}%`,
-            "", meter)
-          + mk("flat", "净值/成本", `${num(g.nav, 4)} / ${num(g.avg_cost, 4)}`)
-          + mk("flat", "现值", `¥${num(g.current_value, 0)}`,
-            (g.pnl_percent >= 0 ? "+" : "") + `${num(g.pnl_percent, 2)}%`);
-      }
-    }
-  }
   function renderRiskGuardrail() {
     const g = safe(DATA, "risk_guardrail") || {};
     const targets = [

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -117,6 +117,7 @@
   // 判词句本体由 CSS 压成一行 caption —— 成段 prose 在这张卡里没有位置。
   function renderTodayHighlights() {
     const el = document.getElementById("today-highlights");
+    const mvEl = document.getElementById("today-movers");
     if (!el) return;
     const chips = [];
     const chip = (tone, k, v, d, meterPct) =>
@@ -202,6 +203,7 @@
     if (!chips.length && !movers.length) {
       el.style.display = "";
       el.replaceChildren();
+      if (mvEl) mvEl.replaceChildren();
       return;
     }
     el.style.display = "";
@@ -211,24 +213,29 @@
     // No icon slot: the old 7px status dot read as AI-flavoured (kcn: 彩色圆点
     // = AI 味). Row semantics live in position, weight and — for true alerts —
     // the red text colour, never in a coloured dot.
-    // 异动零轴柱：top3 各一根，高度 = |pct| 归一（最低 3px 可见），px 写死 ——
-    // 构图不随数据变；ticker+pct 退为柱下 caption（图为主，文字只做注脚）。
+    // 异动条（第八次迭代把竖柱转成横条）：竖柱在 1144px 宽的牌上是三根
+    // 14px 的孤棍，宽度全是空的；横条一行一只（ticker | 零轴分叉条 | pct），
+    // 窄盒宽盒都填得满，且 ticker/pct 回到同一行而不是柱下 caption。
+    // 条长 = |pct| 归一后取半幅的 92%，写百分比 —— 构图随盒子变、不随数据变。
     const maxAbs = Math.max(...movers.map(x => Math.abs(x.today_change_pct || 0)), 1);
-    const mvCell = x => {
+    const mvRow = x => {
       const pct = x.today_change_pct || 0;
-      const h = Math.max(3, Math.abs(pct) / maxAbs * 17);
-      return `<div class="hl-mv"><div class="hl-mv-bar">`
-        + `<i class="${pct >= 0 ? "up" : "down"}" style="height:${h.toFixed(1)}px"></i></div>`
-        + `<div class="hl-mv-cap"><span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
-        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div></div>`;
+      const w = Math.abs(pct) / maxAbs * 46;
+      return `<div class="hl-mv">`
+        + `<span class="hl-mv-t">${escapeHtml(x.ticker || DASH)}</span>`
+        + `<span class="hl-mv-bar"><i class="${pct >= 0 ? "up" : "down"}"`
+        + ` style="width:${w.toFixed(1)}%"></i></span>`
+        + `<span class="hl-mv-p ${pct >= 0 ? "pos" : "neg"}">${fmtPct(pct, 1)}</span></div>`;
     };
     const moversRow = movers.length
-      ? `<div class="hl-movers" style="grid-template-columns:repeat(${movers.length},minmax(0,1fr))"`
-        + ` role="img" aria-label="今日异动前 ${movers.length}：`
+      ? `<div class="hl-movers" role="img" aria-label="今日异动前 ${movers.length}：`
         + movers.map(x => `${x.ticker} ${fmtPct(x.today_change_pct, 1)}`).join("、")
-        + `">${movers.map(mvCell).join("")}</div>`
+        + `"><div class="hl-mv-head">今日异动</div>${movers.map(mvRow).join("")}</div>`
       : "";
-    el.innerHTML = chips.slice(0, 5).join("") + moversRow;
+    // chip 与异动条各自落到自己的挂载点：≥1024 时它们是牌上左右两栏，
+    // 窄档回到上下两带（版式全在 CSS，渲染端不判断宽度）。
+    el.innerHTML = chips.slice(0, 5).join("");
+    if (mvEl) mvEl.innerHTML = moversRow;
   }
 
   // 🪞 诚实自评卡 — 把这轮做的诚实层(风险调整判决 / catalyst 纪律 / 辩论决断 / 因子 CI)聚一处
@@ -2453,10 +2460,16 @@
        </div>`;
     const rows = [
       ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
-      ...stops.map(s => ({ icon: '', severity: 'high', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
+      ...stops.map(s => ({ icon: '', severity: s.severity || 'critical', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
     ];
+    // 严重度排序（第八次迭代）：原来把 hard stop 一律降写成 high，再按
+    // 「是不是 high」排 —— 同为 high 时排序稳定，于是 6 条 breach 永远排在
+    // 3 条 hard stop 前面，牌上那三个槽位只看得到限额比例，而「已经跌穿
+    // -18% 硬止损线」的三只（数据里本来就是 critical）从不上首屏。槽位按
+    // 数据自己的严重度给，不按数组下标给。
+    const SEV_RANK = { critical: 3, high: 2, medium: 1 };
     const compactRows = rows.slice().sort((a, b) =>
-      Number(b.severity === "high") - Number(a.severity === "high"));
+      (SEV_RANK[b.severity] || 0) - (SEV_RANK[a.severity] || 0));
     targets.forEach(({ countEl, dirEl, listEl, compact }) => {
       // 「9 触发」红字是判定卡里最后一个裸读数：数量改用点阵计数表达
       // （一眼扫出严重度，不用读数），精确值退到 aria-label/title。槽位
@@ -2477,7 +2490,13 @@
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
       const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
-      listEl.innerHTML = html || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
+      // 牌上只有三个槽位，9 条里剩下的 6 条原来是无声消失的（表头点阵是
+      // 严重度密度，读不出「还有几条没列」）。补一行尾注说清被折叠的量。
+      const hidden = compact ? Math.max(0, compactRows.length - visibleRows.length) : 0;
+      const tail = hidden
+        ? `<div class="overview-gates-more">另有 ${hidden} 项未列出</div>` : '';
+      listEl.innerHTML = (html && html + tail)
+        || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
     });
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -198,12 +198,18 @@ layout: null
         <div class="hero-rail" id="hero-rail"></div>
       </div>
 
-      <!-- 判定卡第五次迭代：大白板否掉（kcn），改单词卡式牌组 —— 顶牌全显，
-           后续两张固定 8px 露边；横滑手势 / 指示点 / 方向键三通道换牌
-           （第六次迭代撤掉 7s 自动轮播：首屏不该有自己转的东西）。每张牌一个
-           主题，按现有数据面拆：今日判定 / 触发中的硬闸 / 执行纪律 / 黄金回本。
-           引擎在 dashboard.hero.js 与 dashboard.render.js 双实现逐字同步
-           （setupVerdictDeck）。 -->
+      <!-- 单词卡牌组：顶牌全显，后一张固定 8px 露边；横滑手势 / 指示点 /
+           方向键三通道换牌（第六次迭代撤掉 7s 自动轮播：首屏不该有自己转的
+           东西）。第七次迭代（kcn：「几张卡留白很多，切来切去其实就几个文字，
+           而且内容会和下面重复」）把四张收到两张 —— 清点见 PR：
+             · 黄金回本牌（实测高 85.5px）= 下方 #gold-dca-card 的逐字子集，
+               而后者还带金价/伦敦金/摊薄表/spark ⇒ 删牌，留完整卡。
+             · 执行纪律牌（实测高 92.4px）的「执行率 8.5% · 82 笔可核」= 正上方
+               hero-rail 第四格「遵守率 30D 8.5% · 主动 call n=82」⇒ 删牌，
+               牌上唯一独有的 Brier·30d 并进今日判定的 chip 行。
+           剩下的两张各自独有：今日判定（判词 + Regime + 决策变化 + 最近触发
+           + 异动零轴柱）/ 触发中的硬闸。引擎在 dashboard.hero.js 与
+           dashboard.render.js 双实现逐字同步（setupVerdictDeck）。 -->
       <section class="card verdict-deck" id="verdict-deck" aria-roledescription="轮播" aria-label="决策面板">
         <div class="verdict-deck-stage" id="verdict-deck-stage">
           <article class="deck-card" data-theme="今日判定" aria-labelledby="overview-verdict-title">
@@ -235,30 +241,13 @@ layout: null
             </div>
             <button class="overview-jump deck-card-jump" type="button" data-jump-tab="risk">去风险页 →</button>
           </article>
-          <article class="deck-card" data-theme="纪律" aria-labelledby="deck-discipline-title">
-            <div class="overview-verdict-head">
-              <div>
-                <div class="overview-card-kicker">纪律</div>
-                <h3 id="deck-discipline-title">执行纪律</h3>
-              </div>
-              <button class="overview-jump" type="button" data-jump-tab="drill">看持仓</button>
-            </div>
-            <div id="deck-discipline" class="today-highlights"></div>
-          </article>
-          <article class="deck-card" data-theme="黄金回本" aria-labelledby="deck-gold-title">
-            <div class="overview-verdict-head">
-              <div>
-                <div class="overview-card-kicker">黄金 DCA</div>
-                <h3 id="deck-gold-title">黄金回本</h3>
-              </div>
-              <span class="badge muted" id="deck-gold-badge"></span>
-            </div>
-            <div id="deck-gold" class="today-highlights"></div>
-          </article>
         </div>
         <div class="deck-dots" id="verdict-deck-dots" role="group" aria-label="换牌"></div>
       </section>
 
+      <!-- 两格（第七次迭代前是三格）：「今日异动」格只印首位异动一个数
+           （实测「RKLX -11.9%」），而判定牌的零轴柱印的是 top3 同一份
+           today_movers —— 同一个数在首屏出现两次，留更全的那份。 -->
       <div class="overview-strip" aria-label="Secondary overview">
         <section class="overview-strip-cell overview-market">
           <button class="overview-strip-link" type="button" data-jump-tab="market">
@@ -269,12 +258,6 @@ layout: null
             <div class="empty-state">No index data.</div>
           </div>
           <div class="rs-row muted" id="market-rs"></div>
-        </section>
-        <section class="overview-strip-cell">
-          <button class="overview-strip-link" type="button" data-jump-tab="drill">
-            <span>今日异动</span><span aria-hidden="true">持仓 →</span>
-          </button>
-          <div class="overview-mover-summary" id="overview-mover-summary">—</div>
         </section>
         <section class="overview-strip-cell">
           <button class="overview-strip-link" type="button" data-jump-tab="drill">

--- a/site/index.html
+++ b/site/index.html
@@ -226,6 +226,10 @@ layout: null
               <span class="sb-time" id="overview-sb-time"></span>
             </div>
             <div id="today-highlights" class="today-highlights"></div>
+            <!-- 异动条自己的挂载点（第八次迭代）：牌在 ≥1024 是双栏 grid，
+                 判词+chip 走左栏、异动条走右栏并吃满两行高。挂在 chip 里
+                 的时候它只能跟着 chip 走，右边那半张牌永远是空的。 -->
+            <div id="today-movers" class="today-movers"></div>
           </article>
           <article class="deck-card" data-theme="硬闸" aria-labelledby="deck-gates-title">
             <div class="overview-verdict-head">

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1044,6 +1044,71 @@ async function testHoldingsAndHeroNeverTruncate(browser, base) {
   }
 }
 
+// 判定牌组第八次迭代（kcn：「几张卡留白很多，切来切去其实就几个文字」）钉两条：
+//   1. 牌是绝对定位、撑满台面的，所以「牌里有多少空高」= 地板 − 正文。正文
+//      必须吃满盒子，剩余高度归异动条那一带 —— 否则地板每抬一档就多一段空气。
+//   2. 牌上只有三个槽位，选哪三条必须按数据自己的严重度，不按数组下标：
+//      hard stop（critical，已跌穿 -18% 硬止损线）不能被同为 high 的限额条挤掉。
+async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) {
+  const RANK = { critical: 3, high: 2, medium: 1 };
+  for (const [width, height] of [[1200, 900], [390, 844]]) {
+    const context = await browser.newContext({ viewport: { width, height } });
+    const page = await context.newPage();
+    await stubLiveOrigin(page);
+    await page.goto(base, { waitUntil: "networkidle" });
+    await waitForData(page);
+    await page.waitForSelector("#today-movers .hl-movers", { timeout: 5000 });
+
+    const fill = await page.evaluate(() => {
+      const card = document.querySelector(".verdict-deck .deck-card");
+      const movers = document.querySelector("#today-movers .hl-movers");
+      const bars = document.querySelectorAll("#today-movers .hl-mv-bar i");
+      const cs = getComputedStyle(card);
+      const inner = card.getBoundingClientRect().bottom - parseFloat(cs.paddingBottom);
+      return {
+        slack: inner - movers.getBoundingClientRect().bottom,
+        moversHeight: movers.getBoundingClientRect().height,
+        bars: bars.length,
+        widest: Math.max(0, ...[...bars].map(b => b.getBoundingClientRect().width)),
+      };
+    });
+    // 反空转：没有柱就谈不上「柱区吃满」，这条断言必须有东西可量。
+    assert(fill.bars > 0, `no mover bars rendered at ${width}px`);
+    assert(fill.widest > 1, `mover bars have no width at ${width}px`);
+    assert(fill.slack <= 16 && fill.slack >= -1,
+      `verdict card leaves ${Math.round(fill.slack)}px of dead air below its content `
+      + `at ${width}px — the reserved floor must be spent on the chart, not on air`);
+
+    const gate = await page.evaluate(() => {
+      // DATA 是脚本顶层的 let，不是 window 的属性 —— 走 window.DATA 会恒空，
+      // 于是下面的排序断言变成「空 vs 空」的恒真闸。
+      const g = (typeof DATA === "undefined" ? null : DATA.risk_guardrail) || {};
+      const all = [
+        ...(g.breaches || []).map(b => b.severity || "high"),
+        ...(g.hard_stop_watch || []).map(s => s.severity || "critical"),
+      ];
+      const list = document.getElementById("overview-guardrail-list");
+      const shown = [...list.querySelectorAll(".risk-alert")]
+        .map(el => [...el.classList].find(c => c !== "risk-alert") || "high");
+      const more = list.querySelector(".overview-gates-more");
+      return { all, shown, more: more ? more.textContent.trim() : null };
+    });
+    assert(gate.all.length > 0 && gate.shown.length > 0,
+      `gate card rendered nothing to rank at ${width}px`);
+    const ranked = gate.all.map(s => RANK[s] || 0).sort((a, b) => b - a);
+    const shownRanks = gate.shown.map(s => RANK[s] || 0).sort((a, b) => b - a);
+    assert.deepEqual(shownRanks, ranked.slice(0, gate.shown.length),
+      `gate card shows ${gate.shown.join("/")} but the payload's worst are `
+      + `${gate.all.slice().sort((a, b) => (RANK[b] || 0) - (RANK[a] || 0)).slice(0, gate.shown.length).join("/")}`);
+    const hidden = gate.all.length - gate.shown.length;
+    if (hidden > 0) {
+      assert(gate.more && gate.more.includes(String(hidden)),
+        `gate card hides ${hidden} rows without saying so (tail: ${gate.more})`);
+    }
+    await context.close();
+  }
+}
+
 async function main() {
   const server = serveWorkspace();
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -1062,6 +1127,7 @@ async function main() {
     await testHeaderSharesTheContentColumn(browser, base);
     await testTraceRowsFitPhoneWidths(browser, base);
     await testHoldingsAndHeroNeverTruncate(browser, base);
+    await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_dashboard_desktop_layout_contract.py
+++ b/tests/test_dashboard_desktop_layout_contract.py
@@ -130,3 +130,30 @@ def test_issue_206_visual_regression_evidence_is_shipped():
         assert image.stat().st_size > 20_000, f"missing/empty screenshot: {name}"
         assert name in readme
     assert "scrollWidth == clientWidth" in readme
+
+
+def test_overview_keeps_one_owner_per_first_screen_fact():
+    """首屏同一个数只能有一个 owner（第七次迭代，kcn：「内容会和下面重复」）。
+
+    v6 之前判定牌组四张里有两张是别处的子集：黄金回本牌是下方
+    ``#gold-dca-card`` 的逐字子集，执行纪律牌的「执行率 / 笔可核」是正上方
+    hero-rail 第四格「遵守率 30D · 主动 call n=」的同一对数字；牌组的异动
+    零轴柱与 strip 的「今日异动」格同吃 ``today_movers``。删掉的是重复的那
+    一份，留下的是更全的那份 —— 这条闸钉的就是「不许把它们加回来」，而不是
+    某个具体的牌数。
+    """
+    # 黄金 / 纪律：牌上的挂载点没了，完整卡还在
+    assert 'id="deck-gold"' not in HTML
+    assert 'id="deck-discipline"' not in HTML
+    assert 'id="gold-dca-card"' in HTML
+    # 异动：strip 的摘要格没了，判定牌的 top3 零轴柱还在（hl-mv 由 JS 生成，
+    # 这里钉的是它的样式契约仍在，且 strip 不再有第二个 owner）
+    assert 'id="overview-mover-summary"' not in HTML
+    assert ".deck-card .hl-mv-bar" in CSS
+    assert HTML.count('class="overview-strip-cell') == 2
+    # 异常：只留 strip 那一格（牌上的 chip 由 renderTodayHighlights 生成，
+    # 两份 bundle 里都不许再出现那枚 chip 的构造）
+    assert 'id="overview-anomaly-count"' in HTML
+    for bundle in ("dashboard.hero.js", "dashboard.render.js"):
+        js = (ROOT / "site" / "assets" / "js" / bundle).read_text()
+        assert "异常×${highN}" not in js


### PR DESCRIPTION
# 判定牌组第七次迭代：四张收两张，删掉与下方重复的内容

kcn 反馈原话：「再让claude看看呢，那个几张卡留白很多。切来切去其实就几个文字，而且内容会和下面重复。」（画风/配色已认可，一字不动）

## 内容清点（inventory.json + 截图取证）

| 牌/格 | 内容 | 下方重复对象 | 处置 |
|---|---|---|---|
| 黄金回本牌（实测高 85.5px） | 回本计量条 + 净值/成本/现值 chip | #gold-dca-card 的逐字子集，后者还带金价/伦敦金/摊薄表/spark | **删牌，留完整卡** |
| 执行纪律牌（实测高 92.4px） | Brier·30d + 执行率 8.5% + 82 笔可核 + 样本 208 | 「执行率 8.5% · 82 笔可核」= 正上方 hero-rail 第四格「遵守率 30D 8.5% · 主动 call n=82」同一对数字 | **删牌**，唯一独有的 Brier 并进今日判定 chip 行 |
| strip「今日异动」格 | 只印首位异动一个数（RKLX -11.9%） | 判定牌零轴柱印同一份 today_movers 的 top3 | **删格**（三格变两格，留更全的 top3） |
| 判定牌「异常×N」chip | 6 · SPCH weight 79.6% | strip「异常」格同一条，且那格还多一个 high 计数 | **删 chip**，留完整格 |

剩两张牌各自独有：今日判定（判词 + Regime/决策变化/Brier/最近触发 chip + 异动零轴柱）/ 触发中的硬闸。

## 改动

- site/index.html：删两牌 + 删「今日异动」格（-47 行）
- site/assets/js/dashboard.hero.js + dashboard.render.js：删 renderVerdictDeckSides（纪律/黄金渲染）、删异常 chip、删 mover summary 渲染，Brier 并入 renderTodayHighlights（双实现逐字同步，各 -98 行）
- site/assets/css/dashboard.css：strip 三格改两格（2fr/.9fr）、删 .overview-mover-summary 死规则
- tests/test_dashboard_desktop_layout_contract.py：新增 test_overview_keeps_one_owner_per_first_screen_fact

## 验证

- 契约 pytest（desktop_layout_contract / bundle_parity / contrast / site_deploy / payload_size / security / artifact_gate / site_tools）：**48 passed**
- parity 棘轮绿，ALLOWED_DIVERGENT 未加一条；setupVerdictDeck / renderOverviewSummaries 逐字同步
- CLS A/B×3 同 harness 同 fixture：1200 0.0067→0.0067、1440 0.0056→0、390 0.0095→0.0095，**一档没涨**
- 地板重测（两张牌，忙日上界）：360-767 need 380.39 / 768-1023 290.39 / 1024-1199 260.39 / 1200-1920 260.39 → 现 CSS 382/292/262 全部 +2 余量，无需再降
- dashboard_tab_runtime.spec.js：**唯一失败点是 hero spark 末端 vs headline 的既有数据漂移**（18:00 generation 含 #1021 修复前的港股 CAS 坏值：snap hk_total_value 66,624 vs totals value_hkd 65,112，差 HK$1,512；spark 快照口径 −$3,128.63 vs totals 口径 −$3,321.55）——stash 后 master 复测同样失败，与本次改动无关；#1021（19:19 合并）修复的是抓取时序，今天的快照不会回溯重算，明天收盘后的 generation 自愈

## 截图（/root/logs/decision-deck-v7/）

- before：before-deck-* / before-fold-* / before-geometry.json
- after：after-deck-*（两张牌落定位）/ after-fold-* / after-drag-mid-*（换牌中间态）/ after-deck2-*
- 工具：shoot.js / sweep.js / inventory.js

## PR

#1022


---

# 第八次迭代（同一 PR 续，kcn：「几张卡留白很多」仍在 + 「看看怎么优化，包括展现形式和卡片信息」）

## 留白的两个来源（都不是「地板留多了」）

| 方向 | 实测 | 归因 |
|---|---|---|
| 纵向 | 1200 档正文 196.4px 待在 244px 的牌里；390 档 256.4px 待在 364px 里 | 牌是绝对定位、撑满台面的（`inset: 0 0 16px`），**正文没吃满盒子** —— 地板每抬一档就多一段空气 |
| 横向 | 判词 / chip / 异动条三条带从上往下排，1144px 的牌上每条带右侧都空一大截；异动柱区还写死 `max-width: 480px`，是块浮在牌中间的孤岛 | 单栏版式放在通栏牌上 |

## 展现形式

- **今日判定牌 ≥1024 改双栏 grid**：判词 + chip 走左栏，异动条走右栏并吃满两行高；窄档（<1024）回上下三带。异动条从 `#today-highlights` 里拆出自己的挂载点 `#today-movers`（挂在 chip 里时它只能跟着 chip 走）。
- **异动图竖柱 → 横条**（`ticker | 零轴分叉条 | pct`）：竖柱在宽牌上是三根 14px 的孤棍，横条窄盒宽盒都填得满，ticker/pct 回到同一行而不是柱下 caption；条长写百分比（构图随盒子变，不随数据变），最短一根由 `min-width: 3px` 保底。
- **硬闸牌正文同样吃满**：三行分掉剩余高度（行高上限 88px，免得数据少的日子把三行拉成三块板），尾注与跳转钮不参与分配。
- **地板按新构图重扫**（360~1920 每 20px，忙日上界 + 露边 16 + gap 8 + 指示点 10，+2）：
  | 档 | 忙日上界 | 新地板 | 旧 |
  |---|---|---|---|
  | 360~767 | 350.39 | **386** | 382 |
  | 768~1023 | 260.39 | **296** | 292 |
  | 1024~1199 | 249.39 | **285**（新增这一档：双栏后左栏只有 ~600px，忙日 chip 多折一行） | 262 |
  | ≥1200 | 220.89 | **257** | 262 |

## 卡片信息：硬闸牌选错了行

`renderRiskGuardrail` 把 `hard_stop_watch` 的 `severity` 一律改写成 `'high'`，再按「是不是 high」排序 —— 同为 high 时排序稳定，于是 **6 条 breach 永远排在 3 条 hard stop 前面**。结果：牌上三个槽位只印限额比例（`SPCH = 79.61% of US`…），而「已经跌穿 -18% 硬止损线」的三只（数据里本来就是 `critical`：07226 −26.1% / RKLX −66.1% / SPCH −31.0%）**从不上首屏**；SPCH 那条还与下方 strip「异常」格重复。

- 改成按数据自己的严重度排（`critical > high > medium`），槽位按严重度给、不按数组下标给；`critical` 行左侧色条 3px（限额超标仍是 2px）。
- 9 条里被折叠的 6 条原来是**无声消失**的（表头点阵是严重度密度，读不出「还有几条没列」）——补一行尾注「另有 N 项未列出」。

## 验证

- **CLS A/B×3**（同 harness、同 fixture、before = origin/master 的三份 site 文件）：1200 `0.0067 → 0.0067`、1440 `0.0056 → 0.0056`、390 `0.0095 → 0.0095`，**逐档不变**；deck 高 262/262/382 → 257/257/386。
- 契约 pytest（desktop_layout_contract / bundle_parity / contrast / site_deploy / payload_size / site_tools_contract / site_internal_links）：**42 passed**；parity 棘轮绿，ALLOWED_DIVERGENT 未加一条。
- `dashboard_tab_runtime.spec.js` 绿，并新增 `testVerdictDeckFillsItsBoxAndRanksGatesBySeverity`：
  1. 「正文吃满盒子」= 异动条底边距牌内下沿 ≤16px（1200 与 390 各测一次），含反空转断言（必须真有柱、柱宽 > 1px）；
  2. 「三个槽位按严重度给」= 渲染出的行严重度多重集 == payload 按 rank 排序的前 N；被折叠的条数必须出现在尾注里。
  （`DATA` 是脚本顶层 `let`，测试里走 `window.DATA` 会恒空 —— 那样这条闸是恒真的，已避开。）
- 上一轮 `validate` 的红是**已发布 generation 的数据漂移**（hero spark 末端 vs 主数：18:00 那份 `overview_equity` 末行 hk 66,624 vs `totals` 65,112，差 HK$1,512，源于 #1021 修复前的港股 CAS 坏值）。22:40 的 generation 已自洽（两侧同为 65,112.4），本地拉最新 data-plane 后整套 spec 绿。

## 截图（/root/logs/decision-deck-v8/）

- `after-deck-{1200,1440,390}-{light,dark}` / `after-fold-*`（首屏）/ `after-card2-*`（硬闸牌）/ `band-deck-{1100,768}-light`（新分档）
- `base-*` = 第七次迭代态，同机同数据对照；工具 `shoot.js` / `shoot2.js` / `sweep.js` / `cls-ab.py`
