### PR TITLE
数据健康：降级/恢复点名是哪一档，微信掉投从「算得出」变成「看得见」

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2529,6 +2529,14 @@
     font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
   }
   .dh-row:last-child { border-bottom: 0; }
+  /* 逐项里的分组标题（投递 / 数据面）：两组读的是两件事，中间要有个界。 */
+  .dh-sub {
+    padding: 10px 0 4px; color: var(--text-tertiary);
+    font: 700 var(--fs-micro)/1.2 var(--mono); letter-spacing: .08em;
+  }
+  .dh-sub:first-child { padding-top: 4px; }
+  /* 投递行没有期限用量可画：空的灰槽会被读成「一根 0% 的条」。 */
+  .dh-row.is-delivery .dh-bar { background: none; }
   .dh-name { color: var(--text); font-weight: 700; white-space: nowrap; }
   .dh-file, .dh-detail {
     color: var(--text-tertiary); min-width: 0;

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -996,19 +996,48 @@
     const files = (bs.files || []).slice();
     const late = files.filter(f => f.present === false || f.stale);
     const degraded = (wc.recovered || 0) + (wc.degraded || 0);
+    // 「1 档成品恢复或降级」答不出是哪一档（kcn 2026-08-25：「如果有降级的应该
+    // 标注出来是哪个」）。台账 recent[] 里逐档带着 job/slot 与 final_product，
+    // 点名只是把已经在手的字段读出来。recent 有条数上限，点不满就说「等 N 档」，
+    // 不假装列全。
+    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
+                      failed: "FAILED" };
+    // 点名读的是台账自己给的 degraded_slots（全窗口、有上限），不是 recent ——
+    // recent 是尾巴不是集合，忙日里它一条降级都装不下（实测 16 条尾巴全是
+    // 盘中盯盘，16:00 那次「恢复」早被挤出去了）。
+    const jobsWith = (...states) => (wf.degraded_slots || [])
+      .filter(r => states.includes((r || {}).status))
+      .map(r => `${r.job || "未具名任务"} ${SOFT_CN[r.status] || ""}`.trim());
+    const nameThem = (total, names) => {
+      if (!names.length) return "";
+      const head = names.slice(0, 2).join(" · ");
+      return total > names.slice(0, 2).length
+        ? `${head} 等 ${total} 档` : head;
+    };
 
     let tone = "ok", verdict = "全部数据面在期";
-    if ((wc.failed || 0) > 0) { tone = "bad"; verdict = `成品流程 ${wc.failed} 档 FAILED`; }
+    if ((wc.failed || 0) > 0) {
+      tone = "bad";
+      verdict = nameThem(wc.failed, jobsWith("failed")) || `成品流程 ${wc.failed} 档 FAILED`;
+    }
     else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
     else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
     else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
-    else if (degraded) { tone = "warn"; verdict = `${degraded} 档成品恢复或降级`; }
+    else if (degraded) {
+      tone = "warn";
+      verdict = nameThem(degraded, jobsWith("recovered", "degraded"))
+        || `${degraded} 档成品恢复或降级`;
+    }
     root.dataset.tone = tone;
     if (verdictEl) verdictEl.textContent = verdict;
     if (metaEl) {
       const bits = [`${files.length} 个数据面`];
       bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
       if (degraded) bits.push(`${degraded} 档恢复或降级`);
+      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
+      // 窗口掉了几档」必须答得上来。它不改 tone —— 成品由 Telegram 兜住了。
+      if (wf.wechat_dropped_telegram_covered)
+        bits.push(`微信掉投 ${wf.wechat_dropped_telegram_covered} 档 · TG 已兜`);
       if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
       metaEl.textContent = bits.join(" · ");
     }
@@ -1064,7 +1093,31 @@
     }
 
     if (filesEl) {
-      filesEl.innerHTML = files
+      // 逐项里先摆投递：掉的是哪几档、几点的，只有这里答得出（表头那行只有
+      // 计数）。用同一套 dh-row 栅格，状态列写「TG 已兜」——它不是告警。
+      // 同理走 wechat_dropped_slots（全窗口）而不是 recent 里的通道位。
+      const dropped = wf.wechat_dropped_slots || [];
+      const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+      const unnamed = Math.max(0, droppedTotal - dropped.length);
+      const deliveryRows = dropped.length
+        ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
+          + dropped.map(r => `<div class="dh-row is-delivery">`
+            + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
+            + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
+            + `<span class="dh-bar"></span>`
+            + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
+            + `<span class="dh-state">TG 已兜</span></div>`).join("")
+          // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
+          // 会读成列全了。
+          + (unnamed
+            ? `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
+              + `<span class="dh-file"></span><span class="dh-bar"></span>`
+              + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
+              + `<span class="dh-state"></span></div>`
+            : "")
+          + `<div class="dh-sub">数据面</div>`
+        : "";
+      filesEl.innerHTML = deliveryRows + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -987,19 +987,48 @@
     const files = (bs.files || []).slice();
     const late = files.filter(f => f.present === false || f.stale);
     const degraded = (wc.recovered || 0) + (wc.degraded || 0);
+    // 「1 档成品恢复或降级」答不出是哪一档（kcn 2026-08-25：「如果有降级的应该
+    // 标注出来是哪个」）。台账 recent[] 里逐档带着 job/slot 与 final_product，
+    // 点名只是把已经在手的字段读出来。recent 有条数上限，点不满就说「等 N 档」，
+    // 不假装列全。
+    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
+                      failed: "FAILED" };
+    // 点名读的是台账自己给的 degraded_slots（全窗口、有上限），不是 recent ——
+    // recent 是尾巴不是集合，忙日里它一条降级都装不下（实测 16 条尾巴全是
+    // 盘中盯盘，16:00 那次「恢复」早被挤出去了）。
+    const jobsWith = (...states) => (wf.degraded_slots || [])
+      .filter(r => states.includes((r || {}).status))
+      .map(r => `${r.job || "未具名任务"} ${SOFT_CN[r.status] || ""}`.trim());
+    const nameThem = (total, names) => {
+      if (!names.length) return "";
+      const head = names.slice(0, 2).join(" · ");
+      return total > names.slice(0, 2).length
+        ? `${head} 等 ${total} 档` : head;
+    };
 
     let tone = "ok", verdict = "全部数据面在期";
-    if ((wc.failed || 0) > 0) { tone = "bad"; verdict = `成品流程 ${wc.failed} 档 FAILED`; }
+    if ((wc.failed || 0) > 0) {
+      tone = "bad";
+      verdict = nameThem(wc.failed, jobsWith("failed")) || `成品流程 ${wc.failed} 档 FAILED`;
+    }
     else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
     else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
     else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
-    else if (degraded) { tone = "warn"; verdict = `${degraded} 档成品恢复或降级`; }
+    else if (degraded) {
+      tone = "warn";
+      verdict = nameThem(degraded, jobsWith("recovered", "degraded"))
+        || `${degraded} 档成品恢复或降级`;
+    }
     root.dataset.tone = tone;
     if (verdictEl) verdictEl.textContent = verdict;
     if (metaEl) {
       const bits = [`${files.length} 个数据面`];
       bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
       if (degraded) bits.push(`${degraded} 档恢复或降级`);
+      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
+      // 窗口掉了几档」必须答得上来。它不改 tone —— 成品由 Telegram 兜住了。
+      if (wf.wechat_dropped_telegram_covered)
+        bits.push(`微信掉投 ${wf.wechat_dropped_telegram_covered} 档 · TG 已兜`);
       if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
       metaEl.textContent = bits.join(" · ");
     }
@@ -1055,7 +1084,31 @@
     }
 
     if (filesEl) {
-      filesEl.innerHTML = files
+      // 逐项里先摆投递：掉的是哪几档、几点的，只有这里答得出（表头那行只有
+      // 计数）。用同一套 dh-row 栅格，状态列写「TG 已兜」——它不是告警。
+      // 同理走 wechat_dropped_slots（全窗口）而不是 recent 里的通道位。
+      const dropped = wf.wechat_dropped_slots || [];
+      const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+      const unnamed = Math.max(0, droppedTotal - dropped.length);
+      const deliveryRows = dropped.length
+        ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
+          + dropped.map(r => `<div class="dh-row is-delivery">`
+            + `<span class="dh-name">${escapeHtml(r.job || "未具名任务")}</span>`
+            + `<span class="dh-file">${escapeHtml(String(r.slot || "").slice(0, 16).replace("T", " "))}</span>`
+            + `<span class="dh-bar"></span>`
+            + `<span class="dh-detail">微信 sendMessage ret=-2 prepare failed</span>`
+            + `<span class="dh-state">TG 已兜</span></div>`).join("")
+          // 名单有上限，超出的那几档必须说出来 —— 否则「掉投 9 档」配 8 行
+          // 会读成列全了。
+          + (unnamed
+            ? `<div class="dh-row is-delivery"><span class="dh-name muted">另有 ${unnamed} 档</span>`
+              + `<span class="dh-file"></span><span class="dh-bar"></span>`
+              + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
+              + `<span class="dh-state"></span></div>`
+            : "")
+          + `<div class="dh-sub">数据面</div>`
+        : "";
+      filesEl.innerHTML = deliveryRows + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -189,6 +189,13 @@ def compile_overview_projection(dashboard):
             'raw_execution': _fields(row.get('raw_execution'), ('status',)),
             'final_product': _fields(row.get('final_product'), ('status',)),
             'readability': _fields(row.get('readability'), ('status', 'bytes')),
+            # Channel truth per slot. The summary count answers "how many did
+            # WeChat drop"; only the per-row flags can answer "which ones", and
+            # the card is the only consumer that can show either (#771 made the
+            # count exist in the summarizer — it never reached a reader).
+            'primary_delivery': _fields(
+                (row.get('stages') or {}).get('primary_delivery'),
+                ('wechat_ok', 'telegram_ok')),
         }
         for row in workflow.get('recent') or [] if isinstance(row, dict)
     ]
@@ -247,7 +254,16 @@ def compile_overview_projection(dashboard):
             'calibration': {'active': active_calibration},
         },
         'workflow_outcomes': {
-            **_fields(workflow, ('counts', 'raw_error_but_product_usable')),
+            **_fields(workflow, (
+                'counts', 'raw_error_but_product_usable',
+                # Computed since #772 and, until now, dropped here: the card
+                # could not answer "how many did WeChat drop this window" even
+                # though the ledger knew. A count with no consumer is not a fix.
+                'wechat_dropped_telegram_covered',
+                # …and "which ones". Both lists are window-wide and capped;
+                # `recent` cannot answer this because it is a tail, not a set.
+                'wechat_dropped_slots', 'degraded_slots',
+            )),
             'recent': compact_recent,
         },
         'risk_guardrail': {
@@ -338,6 +354,14 @@ def trim_workflow_outcomes(summary):
         stages = record.get('stages')
         compact = {k: v for k, v in record.items() if k != 'stages'}
         if isinstance(stages, dict):
+            # 通道位随行留下：数据健康卡的逐项要答「微信掉的是哪几档」，
+            # 而全量 payload 在首帧之后会把 DATA 整个换掉 —— 只在 overview
+            # 投影里留，卡片一秒后就失忆。两个布尔，不是把 stages 加回来。
+            delivery = stages.get('primary_delivery')
+            if isinstance(delivery, dict):
+                compact['primary_delivery'] = {
+                    key: delivery.get(key) for key in ('wechat_ok', 'telegram_ok')
+                }
             # llm is written immediately before the dashboard build, so it is
             # current even on a same-slot retry whose older postflight detail is
             # still present. Both stages carry the same assessment on first run.

--- a/src/clawock/publish/outcomes.py
+++ b/src/clawock/publish/outcomes.py
@@ -22,6 +22,15 @@ USABLE_PRODUCT_STATES = {"success", "recovered", "degraded", "artifact_only"}
 
 MAX_RECENT = 16
 
+# A product that shipped but not on the happy path. These are the states the
+# health card must be able to name — "1 档恢复或降级" with no name is the
+# complaint that produced this list (kcn 2026-08-25).
+SOFT_PRODUCT_STATES = ("recovered", "degraded", "artifact_only", "failed")
+
+# Named lists are for reading, not for auditing: the full ledger is published
+# on its own. A cap keeps a bad stretch from turning the card into a log.
+MAX_NAMED = 8
+
 
 def summarize_records(records, *, hours: int = 36, now: datetime | None = None) -> dict:
     """Fold ledger records into counts, false-red tally and the recent window."""
@@ -47,9 +56,21 @@ def summarize_records(records, *, hours: int = 36, now: datetime | None = None) 
     counts: dict[str, int] = {}
     false_reds = 0
     wechat_dropped = 0
+    # Which slots, not just how many. `recent` is capped, so a card that scans
+    # it can only name what fits in the tail — on a busy day the answer is
+    # "none of them". These two lists are computed over the whole window and
+    # are what a reader can actually point at.
+    wechat_dropped_slots: list[dict] = []
+    degraded_slots: list[dict] = []
     for record in recent:
         final = (record.get("final_product") or {}).get("status", "pending")
         counts[final] = counts.get(final, 0) + 1
+        if final in SOFT_PRODUCT_STATES and len(degraded_slots) < MAX_NAMED:
+            degraded_slots.append({
+                "job": record.get("job"),
+                "slot": record.get("slot"),
+                "status": final,
+            })
         if ((record.get("raw_execution") or {}).get("status") == "error"
                 and final in USABLE_PRODUCT_STATES):
             false_reds += 1
@@ -61,6 +82,10 @@ def summarize_records(records, *, hours: int = 36, now: datetime | None = None) 
         delivery = (record.get("stages") or {}).get("primary_delivery") or {}
         if delivery.get("wechat_ok") is False and delivery.get("telegram_ok") is True:
             wechat_dropped += 1
+            if len(wechat_dropped_slots) < MAX_NAMED:
+                wechat_dropped_slots.append({
+                    "job": record.get("job"), "slot": record.get("slot"),
+                })
 
     return {
         "generated_at": now.isoformat(),
@@ -68,5 +93,7 @@ def summarize_records(records, *, hours: int = 36, now: datetime | None = None) 
         "counts": counts,
         "raw_error_but_product_usable": false_reds,
         "wechat_dropped_telegram_covered": wechat_dropped,
+        "wechat_dropped_slots": wechat_dropped_slots,
+        "degraded_slots": degraded_slots,
         "recent": recent[:MAX_RECENT],
     }

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1130,6 +1130,8 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
     }
     await context.close();
   }
+}
+
 // 数据健康卡：降级/恢复必须点名是哪一档（kcn 2026-08-25：「如果有降级的应该
 // 标注出来是哪个」），微信单通道掉投必须可数、可点名（#771 让它在 summarizer
 // 里可数，但那个计数从没进过任何读者能看到的地方）。

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -47,19 +47,42 @@ function serveWorkspace() {
 // assert both that the first paint never went there and that a poll always does.
 async function stubLiveOrigin(page, options = {}) {
   const served = [];
+  // 首帧的 overview.json 走同源（index.html 里那条 head 抢跑的 fetch），
+  // 只拦 LIVE origin 的话 patch 会漏掉第一帧、断言跑在真实数据上。
+  if (options.patch) {
+    await page.route("**/assets/data/*.json", async route => {
+      const name = path.basename(new URL(route.request().url()).pathname);
+      const file = path.resolve(ROOT, "assets/data", name);
+      if (!fs.existsSync(file)) return route.fallback();
+      const patched = options.patch(name, JSON.parse(fs.readFileSync(file, "utf8")));
+      if (!patched) return route.fallback();
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify(patched),
+      });
+    });
+  }
   await page.route(LIVE_DATA_ORIGIN + "**", async route => {
     const name = path.basename(new URL(route.request().url()).pathname);
     served.push(name);
     if (options.fail) return route.abort("failed");
     const file = path.resolve(ROOT, "assets/data", name);
     if (!fs.existsSync(file)) return route.fulfill({ status: 404, body: "not found" });
+    let body = fs.readFileSync(file, "utf8");
+    // 有些断言要的是「某个形状的 payload 会被渲染成什么」，而不是今天这份
+    // 数据长什么样。patch 让用例自己造那个形状，免得闸随当日数据时灵时不灵。
+    if (options.patch) {
+      const patched = options.patch(name, JSON.parse(body));
+      if (patched) body = JSON.stringify(patched);
+    }
     await route.fulfill({
       status: 200,
       headers: {
         "content-type": "application/json; charset=utf-8",
         "access-control-allow-origin": "*",
       },
-      body: fs.readFileSync(file, "utf8"),
+      body,
     });
   });
   return served;
@@ -1107,6 +1130,76 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
     }
     await context.close();
   }
+// 数据健康卡：降级/恢复必须点名是哪一档（kcn 2026-08-25：「如果有降级的应该
+// 标注出来是哪个」），微信单通道掉投必须可数、可点名（#771 让它在 summarizer
+// 里可数，但那个计数从没进过任何读者能看到的地方）。
+async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await stubLiveOrigin(page, {
+    patch: (name, json) => {
+      // overview 与 dashboard 两份都要打：首帧吃 overview，随后整份 dashboard
+      // 会把 DATA 换掉 —— 只打一份的话断言会跑在被覆盖后的真实数据上。
+      if (name !== "overview.json" && name !== "dashboard.json") return null;
+      // 体检干净、数据面全部在期 —— 把判词的其它分支让开，只留「恢复/降级」。
+      json.build_status = json.build_status || {};
+      json.build_status.integrity = { error_count: 0, warn_count: 0 };
+      json.build_status.files = (json.build_status.files || []).map(f => ({
+        ...f, present: true, stale: false,
+      }));
+      json.workflow_outcomes = {
+        counts: { success: 9, recovered: 1 },
+        raw_error_but_product_usable: 2,
+        wechat_dropped_telegram_covered: 3,
+        degraded_slots: [
+          { job: "港股收盘报告", slot: "2026-08-25T16:00:00+08:00", status: "recovered" },
+        ],
+        wechat_dropped_slots: [
+          { job: "港股收盘报告", slot: "2026-08-25T16:00:00+08:00" },
+          { job: "盘中盯盘", slot: "2026-08-25T15:30:00+08:00" },
+        ],
+        recent: [
+          {
+            job: "港股收盘报告", slot: "2026-08-25T16:00:00+08:00",
+            raw_execution: { status: "error" },
+            final_product: { status: "recovered" },
+            primary_delivery: { wechat_ok: false, telegram_ok: true },
+          },
+          {
+            job: "盘中盯盘", slot: "2026-08-25T15:30:00+08:00",
+            raw_execution: { status: "ok" },
+            final_product: { status: "success" },
+            primary_delivery: { wechat_ok: false, telegram_ok: true },
+          },
+        ],
+      };
+      return json;
+    },
+  });
+  await page.goto(base, { waitUntil: "networkidle" });
+  await waitForData(page);
+  await page.waitForSelector("#data-health:not(.is-pending)", { timeout: 5000 });
+
+  const head = await page.evaluate(() => ({
+    verdict: (document.getElementById("dh-verdict") || document.getElementById("dh-title")).textContent.trim(),
+    meta: document.getElementById("dh-meta").textContent.trim(),
+  }));
+  assert(head.verdict.includes("港股收盘报告"),
+    `data-health verdict does not name the degraded slot: ${head.verdict}`);
+  assert(head.verdict.includes("恢复"),
+    `data-health verdict does not say what happened to it: ${head.verdict}`);
+  assert(/微信掉投\s*3\s*档/.test(head.meta),
+    `data-health meta does not carry the WeChat drop count: ${head.meta}`);
+
+  await page.click("#dh-toggle");
+  const rows = await page.evaluate(() =>
+    [...document.querySelectorAll("#dh-files .dh-row")].map(r => r.textContent.replace(/\s+/g, " ").trim()));
+  const dropRows = rows.filter(t => t.includes("TG 已兜"));
+  assert.equal(dropRows.length, 2,
+    `expected both WeChat-dropped slots listed, got ${dropRows.length}: ${dropRows.join(" | ")}`);
+  assert(dropRows.some(t => t.includes("港股收盘报告") && t.includes("2026-08-25 16:00")),
+    `dropped slot rows do not name job + slot: ${dropRows.join(" | ")}`);
+  await context.close();
 }
 
 async function main() {
@@ -1128,6 +1221,7 @@ async function main() {
     await testTraceRowsFitPhoneWidths(browser, base);
     await testHoldingsAndHeroNeverTruncate(browser, base);
     await testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base);
+    await testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base);
   } finally {
     await browser.close();
     await new Promise(resolve => server.close(resolve));

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -122,6 +122,55 @@ def test_workflow_card_folds_the_published_ledger_into_counts(monkeypatch, tmp_p
     assert "stages" not in card["recent"][0]
 
 
+def test_the_overview_projection_carries_channel_truth_to_its_reader():
+    """微信掉投在 summarizer 里可数（#771/#772）却从没进过 payload。
+
+    数据健康卡要答两个问题：这一窗口掉了几档（计数）、掉的是哪几档（逐档
+    通道位）。两者都只有 overview 投影能送到读者面前，所以这条闸钉的是
+    「计数与逐档布尔一起过投影」，不是某个渲染字符串。
+    """
+    projection = dashboard.compile_overview_projection({
+        'workflow_outcomes': {
+            'counts': {'success': 2},
+            'raw_error_but_product_usable': 1,
+            'wechat_dropped_telegram_covered': 2,
+            'degraded_slots': [{
+                'job': '港股收盘报告', 'slot': '2026-08-25T16:00:00+08:00',
+                'status': 'recovered',
+            }],
+            'wechat_dropped_slots': [{
+                'job': '港股收盘报告', 'slot': '2026-08-25T16:00:00+08:00',
+            }],
+            'recent': [{
+                'job': '港股收盘报告',
+                'slot': '2026-08-25T16:00:00+08:00',
+                'raw_execution': {'status': 'error'},
+                'final_product': {'status': 'recovered'},
+                'stages': {'primary_delivery': {
+                    'status': 'success', 'channel': 'wechat+telegram',
+                    'wechat_ok': False, 'telegram_ok': True,
+                }},
+            }],
+        },
+    })
+
+    card = projection['workflow_outcomes']
+    assert card['wechat_dropped_telegram_covered'] == 2
+    # 点名用的两张表整张过投影：卡片要答「哪一档降级」「微信掉的是哪几档」，
+    # 而 recent 是尾巴（有条数上限），忙日里一条都装不下。
+    assert card['degraded_slots'] == [
+        {'job': '港股收盘报告', 'slot': '2026-08-25T16:00:00+08:00',
+         'status': 'recovered'},
+    ]
+    assert card['wechat_dropped_slots'] == [
+        {'job': '港股收盘报告', 'slot': '2026-08-25T16:00:00+08:00'},
+    ]
+    row = card['recent'][0]
+    assert row['primary_delivery'] == {'wechat_ok': False, 'telegram_ok': True}
+    # 心跳明细仍然不许整块跟过来（#816 的体积闸）。
+    assert 'stages' not in row
+
+
 def test_a_checkout_without_the_ledger_republishes_the_last_workflow_card(
         monkeypatch, tmp_path):
     """`--previous` must actually reach the published payload, not just `preserved`.

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -190,11 +190,16 @@ def test_the_unread_workflow_stage_detail_stays_out(payload):
 
     assert isinstance(wf["counts"], dict)
     assert "raw_error_but_product_usable" in wf
+    # 通道级真值（#772 起在台账里，2026-08-25 起才有读者）：窗口计数 + 逐档
+    # 两个布尔。这不是「把 stages 加回来」—— 上面那条闸删的是 24KB 无人读的
+    # 心跳明细，这里进来的是数据健康卡逐项要点名的那两位。
+    assert "wechat_dropped_telegram_covered" in wf
     for record in wf["recent"]:
         for field in ("job", "slot", "raw_execution", "final_product"):
             assert field in record, field
         assert record["raw_execution"]["status"]
         assert record["final_product"]["status"]
+        assert set(record["primary_delivery"]) == {"wechat_ok", "telegram_ok"}
 
 
 def test_dashboard_trim_keeps_readability_without_full_stage_detail():

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -535,6 +535,36 @@ def test_reconciliation_records_a_failed_send_as_failed(tmp_path, monkeypatch):
     assert record["stages"]["primary_delivery"]["status"] == "failed"
 
 
+def test_the_summary_names_the_slot_that_only_half_shipped(tmp_path, monkeypatch):
+    """「1 档成品恢复或降级」答不出是哪一档（kcn 2026-08-25）。
+
+    点名不能靠 ``recent`` —— 它是按时间截断的尾巴，忙日里 16 条全是盘中盯盘，
+    当天唯一那次 recovered 早被挤出去了。全窗口扫一遍、单独出一张有上限的表，
+    才是「哪一档」这个问题的答案。
+    """
+    from clawock.publish.outcomes import summarize_records
+
+    now = datetime(2026, 7, 24, 20, 0, tzinfo=outcomes.HKT)
+    records = [
+        {"job": "港股收盘报告", "slot": "2026-07-24T16:00:00+08:00",
+         "final_product": {"status": "recovered"}},
+    ] + [
+        # 16 条更晚的正常槽位：足够把上面那条挤出 recent 尾巴。
+        {"job": "盘中盯盘", "slot": f"2026-07-24T17:{minute:02d}:00+08:00",
+         "final_product": {"status": "success"}}
+        for minute in range(0, 32, 2)
+    ]
+
+    summary = summarize_records(records, hours=36, now=now)
+
+    assert all(row["job"] != "港股收盘报告" for row in summary["recent"]), (
+        "fixture no longer exercises the case: the soft slot still fits in recent")
+    assert summary["degraded_slots"] == [
+        {"job": "港股收盘报告", "slot": "2026-07-24T16:00:00+08:00",
+         "status": "recovered"},
+    ]
+
+
 def test_a_reconciled_wechat_drop_is_counted_by_the_summary(tmp_path, monkeypatch):
     """#771's count reads wechat_ok/telegram_ok flags. A reconciled slot whose
     receipt says WeChat failed and Telegram carried it must land in
@@ -556,6 +586,8 @@ def test_a_reconciled_wechat_drop_is_counted_by_the_summary(tmp_path, monkeypatc
         now=datetime(2026, 7, 24, 20, 0, tzinfo=outcomes.HKT),
     )
     assert summary["wechat_dropped_telegram_covered"] == 1
+    # 数得出还要点得出：卡片逐项要写「掉的是哪一档、几点的」。
+    assert summary["wechat_dropped_slots"] == [{"job": job, "slot": slot}]
 
 
 def test_reconciliation_never_invents_a_slot_the_ledger_is_not_tracking(


### PR DESCRIPTION
## 背景

kcn：「数据健康那个板块，如果有降级的应该标注出来是哪个」。

卡面此前只印计数：「1 档成品恢复或降级」——而台账 `workflow-outcomes.json` 逐档都带着 `job` / `slot` / `final_product.status`，点名要的字段一直在手。

## 改动

### 1. 判词点名

`1 档成品恢复或降级` → `港股收盘报告 恢复`（多档取前两个 + `等 N 档`）；`FAILED` 分支同样点名。

**点名不能读 `recent`**：它是按时间截断的尾巴（`MAX_RECENT = 16`），忙日里 16 条全是盘中盯盘 —— 实测今天唯一那次 `recovered`（港股收盘报告 16:00）早被挤出去了。所以 summarizer 另出一张**全窗口、有上限**的 `degraded_slots`，卡片读它。

### 2. 顺带修一条空转修复：微信掉投「算得出」但「看不见」

#771/#772 的结论是：`ret=-2 prepare failed` 是上游插件 config 缓存过期，**kcn 已定不修、也不要单次告警**，唯一要求是**可数**。#772 因此在 summarizer 里算出了 `wechat_dropped_telegram_covered`——但 `compile_overview_projection` 只挑了 `counts` 与 `raw_error_but_product_usable` 两个字段，这个计数**从没进过 payload**，任何读者都看不到它。一个没有消费者的计数不算修好（`clawock-inert-fixes` 同族）。

今天（2026-08-25）实测：**20 个档里 9 档微信投递失败**（`sent_ok:false` / `tg_ok:true`），Telegram 全部兜住，卡面此前一个字都没有。

- meta 行加一段：`微信掉投 9 档 · TG 已兜`（**不改 tone** —— 成品是全的，这是计数不是告警）；
- 「逐项」面板新增**投递**分组，逐档列 job + 槽位时间 + 错误串 + `TG 已兜`；名单有上限（8），超出写「另有 N 档 · 更早的槽位见 workflow-outcomes.json」，不假装列全；
- 通道位（`wechat_ok` / `telegram_ok` 两个布尔）随 `recent` 行过**投影与全量 payload**——首帧之后 `DATA` 会被整份 `dashboard.json` 换掉，只在 overview 投影里留，卡片一秒后就失忆（这一条是写测试时才实测出来的）。
  这不是把 #816 删掉的 `recent[].stages` 加回来：那是 24KB 无人读的心跳明细，这里进来的是两位有读者的布尔。

## 验证

- `pytest` **147 passed**，其中三条新闸：
  - `test_the_summary_names_the_slot_that_only_half_shipped` —— 造 1 条 recovered + 16 条更晚的正常槽位，**先断言那条确实被挤出了 `recent`**（反空转），再断言 `degraded_slots` 点得出名；
  - `test_the_overview_projection_carries_channel_truth_to_its_reader` —— 计数 + 两张点名表 + 逐行通道位过投影，且 `stages` 仍不许整块跟过来；
  - `test_a_reconciled_wechat_drop_is_counted_by_the_summary` 扩断言到 `wechat_dropped_slots`。
- `dashboard_tab_runtime.spec.js` 新增 `testDataHealthNamesTheDegradedSlotAndWeChatDrops`：注入 payload 断言判词点名、meta 计数、逐项两行 job+slot。
  stub 同时拦**同源**与 LIVE origin —— 首帧那条 `overview.json` 是 index.html 里 head 抢跑的**同源** fetch，只拦 LIVE 的话 patch 会漏掉第一帧、断言跑在真实数据上（写的时候正好踩到）。
- 截图：`/root/logs/decision-deck-v8/dh-{closed,open}-{light,dark}.png`（open 那张能看到 8 行投递明细 + 数据面分组）。

关联：#1009（同一条链路的另一半——补发那半按 #771 的结论不做，详见该 issue 的回复）。
