### PR TITLE
history: 四条 JSONL 留痕改成滚动窗口 + 冷段归档（#951）

### DIFF
--- a/assets/data/archive/.gitkeep
+++ b/assets/data/archive/.gitkeep
@@ -1,0 +1,5 @@
+# 冷段留痕（#951）：assets/data/*_history.jsonl 的滚动窗口之外的行搬到这里。
+# 由 clawock.history_store 写入；读者一律走 history_store.load_series（工作
+# 文件 + 归档），所以序列本身没有断点。这个占位文件让 brief_postflight 的
+# `git add assets/data/archive/` 在归档还没生成的日子也能匹配到路径 ——
+# 该 add 列表里的 pathspec 匹配不到就会让整次提交失败。

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -23,6 +23,7 @@ import random
 from datetime import date
 from pathlib import Path
 
+from clawock import history_store
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
@@ -80,17 +81,13 @@ def clustered_ci(observations, samples=2000):
 
 def main(argv=None):
     del argv
-    if not HIST.exists():
+    # 「文件还没有」才 skip；「文件在但今天零行」仍要出零状态卡（否则解锁
+    # 视图会因为一天没留痕而整块消失）。这条分界原来就在，别被 #951 改掉。
+    if not (HIST.exists() or history_store.archive_path(HIST).exists()):
         print('  no history yet — skip')
         return
-    days = []
-    for line in HIST.read_text().splitlines():
-        if line.strip():
-            try:
-                days.append(json.loads(line))
-            except Exception:
-                continue
-    days.sort(key=lambda d: d['as_of'])
+    # 归档 + 热窗（#951）：命中率是逐日回放算出来的，读窗口一短，n 就变小。
+    days = history_store.load_series(HIST)
 
     stats = {k: {'n': 0, 'hits': 0, 'observations': [], 'horizon': h}
              for k, (_, _, h) in FACTOR_TESTS.items()}

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -33,6 +33,7 @@ from zoneinfo import ZoneInfo
 import requests
 
 from clawock import sessions as trading_calendar
+from clawock import history_store
 from clawock.instruments import require as require_instrument
 from clawock.safe_io import load_json_cached, safe_write_json
 from clawock.workspace import workspace_root
@@ -707,13 +708,13 @@ def main(argv=None):
                                           'stop_distance_pct', 'mom_1m', 'dist_ma200_pct')}
                                      for k, v in rows.items()
                                      if v.get('status') == 'fresh'}}, ensure_ascii=False)
-    lines = []
-    if HIST.exists():
-        lines = [l for l in HIST.read_text().splitlines()
-                 if l.strip() and json.loads(l).get('as_of') != out['as_of']]
-    lines.append(hist_line)
-    HIST.write_text('\n'.join(lines) + '\n')
-    print(f'  history: {len(lines)} days in {HIST.name}')
+    # 热窗写工作文件、冷段进 archive（#951）；读侧（signal_review）走
+    # history_store.load_series，窗口与命中率不受影响。
+    rows = [row for row in history_store.load_series(HIST)
+            if row.get('as_of') != out['as_of']]
+    rows.append(json.loads(hist_line))
+    rows = history_store.write_series(HIST, rows)
+    print(f'  history: {len(rows)} days in {HIST.name}')
 
 
 if __name__ == '__main__':

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import hashlib
 import json
 import random
 import statistics
@@ -17,6 +16,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+from clawock import history_store
 from clawock.decision import add_alpha, early_trend, signals
 from clawock.evidence import news_evidence_graph, run_card
 from clawock.market_data import factors, peer_residuals
@@ -41,17 +41,9 @@ def _json(path):
 
 
 def _jsonl(path):
-    rows = []
-    for line in Path(path).read_text(encoding="utf-8").splitlines():
-        try:
-            rows.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return sorted(rows, key=lambda row: str(row.get("as_of") or ""))
-
-
-def _digest(path):
-    return "sha256:" + hashlib.sha256(Path(path).read_bytes()).hexdigest()[:16]
+    # 归档 + 热窗（#951）：point-in-time 回放是从第一行开始的，读窗口一短，
+    # episode 统计与评估区间就跟着变 —— 这正是当初不能「顺手加 cap」的原因。
+    return history_store.load_series(path)
 
 
 
@@ -598,7 +590,9 @@ def main(argv=None):
                 "bars": len(rows),
                 "first_session": str((rows[0] if rows else {}).get("as_of")),
                 "last_session": str((rows[-1] if rows else {}).get("as_of")),
-                "digest": _digest(path),
+                # 摘要必须覆盖被计数的那批行：拆出 archive 之后，工作文件
+                # 只剩热窗，按文件字节取摘要会与 bars（完整序列）不同源。
+                "digest": history_store.series_digest(path),
             })
         for spec in config["symbols"]:
             bars = (fetched.get(spec["ticker"]) or {}).get("bars") or []

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -20,6 +20,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from clawock import history_store
 from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
@@ -617,15 +618,9 @@ def deduplicate_events(events):
 
 
 def _load_history():
-    if not HISTORY.exists():
-        return []
-    out = []
-    for line in HISTORY.read_text().splitlines():
-        try:
-            out.append(json.loads(line))
-        except Exception:
-            continue
-    return out
+    # 归档 + 热窗 = 完整序列。只读工作文件就是 #951 要避免的那种截断：
+    # 越过 novelty_lookback 的 cluster 会从「旧事重提」(0.8) 变成「全新」(1.0)。
+    return history_store.load_series(HISTORY)
 
 
 def apply_novelty(policy, events, history, now):
@@ -1374,13 +1369,8 @@ def update_history(as_of, events, prior=None):
             for event in events
         ],
     })
-    snapshots.sort(key=lambda row: row['as_of'])
-    safe_write_text(
-        str(HISTORY),
-        '\n'.join(json.dumps(row, ensure_ascii=False, separators=(',', ':'))
-                  for row in snapshots) + '\n',
-    )
-    return snapshots
+    # 热窗写工作文件、冷段进 archive；返回的仍是完整序列（#951）。
+    return history_store.write_series(HISTORY, snapshots)
 
 
 def _backfill_information_components(policy, snapshots, cutoff):

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -595,6 +595,10 @@ def maybe_commit(status, today, dry_run=False):
                             'assets/data/catalysts.json',
                             'assets/data/news_evidence_graph.json',
                             'assets/data/news_evidence_history.jsonl',
+                            # 滚动窗口的冷段（#951）。目录里有 .gitkeep，所以
+                            # 归档还没生成的日子这条 pathspec 也匹配得到 ——
+                            # 匹配不到 git add 会失败，而失败会带走整次提交。
+                            'assets/data/archive/',
                             'assets/data/em_news.json',
                             'assets/data/guardrail_history.jsonl',
                             'assets/data/t0_setups.json',

--- a/src/clawock/history_store.py
+++ b/src/clawock/history_store.py
@@ -1,0 +1,152 @@
+"""Rolling storage for the dated JSONL histories under ``assets/data/``.
+
+The four point-in-time histories (news evidence, cross-sectional factors, peer
+residuals, quant signals) are **rewritten whole** every day by the jobs that
+append to them, and until now none of them had a bound: ``news_evidence_history``
+alone went 487KB → 855KB in fourteen days and was accelerating (#951). At that
+rate every daily commit carries the whole file again, and every ``fetch-depth: 0``
+checkout carries every one of those versions.
+
+The naive fix — truncate the file — is not available, because two readers
+legitimately want the entire series:
+
+* ``news_evidence_graph.apply_novelty`` scores a cluster last seen beyond the
+  30d lookback as ``cluster_old_but_recurrent`` (0.8) rather than
+  ``new_cluster`` (1.0). Cut the tail and「旧事重提」silently reads as brand new.
+* ``factors.prospective_walk_forward`` / ``add_alpha_walkforward`` replay from
+  the first row. Cut the tail and the evaluation window shortens, which moves
+  hit rates and episode counts.
+
+So the decision (2026-08-25) is a **storage split, not a semantic change**:
+
+* the working file keeps the most recent ``HOT_WINDOW_DAYS`` of snapshots — this
+  is the file the daily job rewrites, so daily churn is bounded from now on;
+* everything older moves once into ``assets/data/archive/<same name>``, which is
+  only ever appended to (a row moves in when it ages out and is never rewritten);
+* every reader that wants the series calls :func:`load_series`, which returns
+  archive + working. **Novelty semantics and the replay window are therefore
+  unchanged** — that is the point of doing it this way rather than capping.
+
+The archive is also the seam: moving cold rows off master (to the data branch or
+out of the repo) later becomes a change of one path here, instead of a migration
+of four writers and three readers.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from clawock.safe_io import safe_write_text
+
+# Six months of hot rows. Every in-run lookback the daily jobs use is far
+# shorter (novelty 30d, factor windows ≤ 120d), so this is not a behaviour
+# knob — it is how much a single day's rewrite is allowed to carry.
+HOT_WINDOW_DAYS = 180
+
+DATE_KEY = 'as_of'
+
+
+def archive_path(path) -> Path:
+    """Where the cold half of ``path`` lives."""
+    path = Path(path)
+    return path.parent / 'archive' / path.name
+
+
+def _read_jsonl(path) -> list:
+    path = Path(path)
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except Exception:
+            # A half-written line is a torn write, not a reason to lose the
+            # rest of the series. Same tolerance the previous loaders had.
+            continue
+    return rows
+
+
+def _dump(rows) -> str:
+    return '\n'.join(
+        json.dumps(row, ensure_ascii=False, separators=(',', ':'))
+        for row in rows
+    ) + '\n'
+
+
+def _day(row) -> str:
+    return str((row or {}).get(DATE_KEY) or '')[:10]
+
+
+def load_series(path) -> list:
+    """The whole logical series: archived rows first, then the hot window.
+
+    Readers must use this instead of reading the working file directly —
+    reading only the working file is exactly the truncation this module exists
+    to avoid.
+    """
+    rows = _read_jsonl(archive_path(path)) + _read_jsonl(path)
+    return sorted(rows, key=_day)
+
+
+def split_window(rows, *, keep_days=HOT_WINDOW_DAYS, today=None):
+    """Partition ``rows`` into (cold, hot) on the ``keep_days`` boundary.
+
+    Rows without a usable ``as_of`` stay hot: an undated row cannot be proven
+    old, and silently archiving it would hide it from the readers that still
+    scan the working file.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    if isinstance(today, str):
+        today = date.fromisoformat(today[:10])
+    if isinstance(today, datetime):
+        today = today.date()
+    cutoff = (today - timedelta(days=keep_days)).isoformat()
+    cold, hot = [], []
+    for row in rows:
+        day = _day(row)
+        (cold if (day and day < cutoff) else hot).append(row)
+    return cold, hot
+
+
+def write_series(path, rows, *, keep_days=HOT_WINDOW_DAYS, today=None) -> list:
+    """Persist the full series across the working file and its archive.
+
+    Returns the same rows it was given (sorted): callers keep operating on the
+    whole series — ``update_history`` returns it to walk-forward evaluators —
+    while only the hot half lands in the file the next commit rewrites.
+    """
+    rows = sorted(rows, key=_day)
+    cold, hot = split_window(rows, keep_days=keep_days, today=today)
+    if cold:
+        archive = archive_path(path)
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        # Rewriting the archive from `cold` (rather than appending) keeps it
+        # identical to "the series minus the hot window" even if a backfill
+        # rewrites old rows; the file is stable day to day because the same
+        # rows keep producing the same bytes.
+        safe_write_text(str(archive), _dump(cold))
+    safe_write_text(str(path), _dump(hot) if hot else '')
+    return rows
+
+
+def series_digest(path) -> str:
+    """Digest of the whole logical series, not of the working file's bytes.
+
+    Provenance in a run card names the rows the run actually read. After the
+    hot/cold split, hashing the working file would describe the last 180 days
+    while the count beside it describes the whole series.
+    """
+    hasher = hashlib.sha256()
+    for row in load_series(path):
+        hasher.update(
+            json.dumps(row, ensure_ascii=False, sort_keys=True,
+                       separators=(',', ':')).encode('utf-8')
+        )
+        hasher.update(b'\n')
+    return 'sha256:' + hasher.hexdigest()[:16]

--- a/src/clawock/market_data/factors.py
+++ b/src/clawock/market_data/factors.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import requests
 
+from clawock import history_store
 from clawock.safe_io import safe_write_json, safe_write_text
 from clawock.workspace import workspace_root
 
@@ -658,15 +659,9 @@ def retrospective_walk_forward(config, fetched):
 
 
 def _load_history():
-    if not HISTORY.exists():
-        return []
-    rows = []
-    for line in HISTORY.read_text().splitlines():
-        try:
-            rows.append(json.loads(line))
-        except Exception:
-            continue
-    return sorted(rows, key=lambda row: row.get('as_of') or '')
+    # 归档 + 热窗：prospective_walk_forward 是从第一行开始回放的，只读工作
+    # 文件会缩短评估窗口、改掉 hit rate（#951）。
+    return history_store.load_series(HISTORY)
 
 
 def prospective_walk_forward(config, fetched, history):
@@ -834,13 +829,7 @@ def update_history(as_of, rows, registered_at):
         if str(row.get('as_of') or '')[:10] != as_of
     ]
     existing.append(_history_snapshot(as_of, rows, registered_at))
-    existing.sort(key=lambda row: row['as_of'])
-    safe_write_text(
-        str(HISTORY),
-        '\n'.join(json.dumps(row, ensure_ascii=False, separators=(',', ':'))
-                  for row in existing) + '\n',
-    )
-    return existing
+    return history_store.write_series(HISTORY, existing)
 
 
 def main(argv=None):

--- a/src/clawock/market_data/peer_residuals.py
+++ b/src/clawock/market_data/peer_residuals.py
@@ -18,6 +18,7 @@ import statistics
 from datetime import date, datetime, timezone
 from pathlib import Path
 
+from clawock import history_store
 from clawock.market_data.factors import (
     _last_index,
     _liquidity,
@@ -451,15 +452,8 @@ def retrospective_calibration(rule_config, taxonomy, fetched):
 
 
 def _load_history():
-    if not HISTORY.exists():
-        return []
-    rows = []
-    for line in HISTORY.read_text().splitlines():
-        try:
-            rows.append(json.loads(line))
-        except Exception:
-            continue
-    return rows
+    # 归档 + 热窗（#951）：同行残差的回放同样从第一行开始。
+    return history_store.load_series(HISTORY)
 
 
 def update_history(as_of, live_rows, registered_at):
@@ -480,13 +474,7 @@ def update_history(as_of, live_rows, registered_at):
             for target, row in live_rows.items()
         },
     })
-    existing.sort(key=lambda row: row['as_of'])
-    safe_write_text(
-        str(HISTORY),
-        '\n'.join(json.dumps(row, ensure_ascii=False, separators=(',', ':'))
-                  for row in existing) + '\n',
-    )
-    return existing
+    return history_store.write_series(HISTORY, existing)
 
 
 def prospective_calibration(rule_config, taxonomy, fetched, history):

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -1,0 +1,114 @@
+"""#951 的验收闸：滚动窗口只改存储，不改任何读者看到的序列。
+
+「顺手加个 cap」在这四个 JSONL 上是不安全的，因为两个读者读的是完整历史：
+novelty 用它区分「旧事重提」(0.8) 与「全新」(1.0)，walk-forward 用它决定评估
+窗口。所以这里钉的不是「文件变小了」，而是**分档之后读者读到的东西逐行不变**。
+"""
+import json
+from datetime import date, datetime, timedelta, timezone
+
+from clawock import history_store
+from clawock.evidence import news_evidence_graph as graph
+
+
+TODAY = date(2026, 8, 25)
+
+
+def _rows(days, *, start=TODAY - timedelta(days=400)):
+    return [
+        {'as_of': (start + timedelta(days=offset)).isoformat(), 'payload': offset}
+        for offset in range(days)
+    ]
+
+
+def _write(tmp_path, rows, name='news_evidence_history.jsonl'):
+    path = tmp_path / name
+    history_store.write_series(path, rows, today=TODAY)
+    return path
+
+
+def test_the_reader_sees_the_same_series_the_writer_was_given(tmp_path):
+    rows = _rows(400)
+    path = _write(tmp_path, rows)
+
+    assert history_store.load_series(path) == rows
+    # …and the split actually happened, otherwise the assertion above is the
+    # old behaviour passing under a new name.
+    hot = [json.loads(line) for line in path.read_text().splitlines()]
+    cold = [json.loads(line)
+            for line in history_store.archive_path(path).read_text().splitlines()]
+    assert cold and hot
+    assert cold + hot == rows
+    assert len(hot) <= history_store.HOT_WINDOW_DAYS + 1
+    assert max(row['as_of'] for row in cold) < min(row['as_of'] for row in hot)
+
+
+def test_a_row_the_window_cannot_date_stays_in_the_working_file(tmp_path):
+    """无日期的行证明不了自己旧。悄悄归档等于让还在扫工作文件的读者丢行。"""
+    rows = [{'payload': 'undated'}, *_rows(400)]
+    path = _write(tmp_path, rows)
+
+    hot = [json.loads(line) for line in path.read_text().splitlines()]
+    assert {'payload': 'undated'} in hot
+
+
+def test_rewriting_the_series_does_not_churn_the_archive(tmp_path):
+    """归档必须是稳定字节：同样的冷段每天重写出同样的文件，否则 daily commit
+    还是照抄一遍全量 —— 那正是 #951 要消掉的成本。"""
+    rows = _rows(400)
+    path = _write(tmp_path, rows)
+    first = history_store.archive_path(path).read_bytes()
+
+    rows.append({'as_of': TODAY.isoformat(), 'payload': 'today'})
+    history_store.write_series(path, rows, today=TODAY)
+
+    assert history_store.archive_path(path).read_bytes() == first
+
+
+def test_the_digest_covers_the_whole_series_not_just_the_hot_window(tmp_path):
+    rows = _rows(400)
+    path = _write(tmp_path, rows)
+    full = history_store.series_digest(path)
+
+    # 把冷段删掉 —— 摘要必须跟着变，否则它描述的不是被计数的那批行。
+    history_store.archive_path(path).unlink()
+    assert history_store.series_digest(path) != full
+
+
+def test_an_old_cluster_stays_recurrent_after_it_moves_into_the_archive(
+        tmp_path, monkeypatch):
+    """#951 里点名的那条语义：>30d 未见的 cluster 给 0.8 而不是 1.0。
+
+    先让一条 300 天前的快照落进 archive，再走一遍生产读路径（``_load_history``
+    → ``apply_novelty``）。如果读者只读工作文件，这条会被判成 new_cluster，
+    也就是把「旧事重提」当成全新消息 —— 这条测试就是为拦这个而写的。
+    """
+    now = datetime(2026, 8, 25, 8, tzinfo=timezone.utc)
+    event = graph.make_event(
+        graph.load_policy(),
+        ticker='ABC', title='ABC faces SEC investigation',
+        published_at=now.isoformat(), event_time=now.isoformat(),
+        origin='sec_filing', source='SEC EDGAR',
+        url='https://www.sec.gov/Archives/abc.htm', event_type='filing_8k',
+    )
+    old_day = (TODAY - timedelta(days=300)).isoformat()
+    history = [{
+        'as_of': old_day,
+        'events': [{
+            'event_id': 'older-id',
+            'ticker': 'ABC',
+            'novelty_cluster': event['novelty_cluster'],
+            'published_at': f'{old_day}T00:00:00+00:00',
+        }],
+    }]
+    path = tmp_path / 'news_evidence_history.jsonl'
+    monkeypatch.setattr(graph, 'HISTORY', path)
+    history_store.write_series(path, history, today=TODAY)
+    # 反空转：这条必须真的在 archive 里，工作文件必须是空的。
+    assert history_store.archive_path(path).exists()
+    assert path.read_text().strip() == ''
+
+    graph.apply_novelty(graph.load_policy(), [event], graph._load_history(), now)
+
+    assert event['novelty_reason'] == 'cluster_old_but_recurrent'
+    assert event['novelty_score'] == 0.8

--- a/tests/test_quant_signal_review.py
+++ b/tests/test_quant_signal_review.py
@@ -1,4 +1,6 @@
 import json
+import pathlib
+import tempfile
 import sys
 from datetime import date as real_date
 from pathlib import Path
@@ -13,16 +15,37 @@ from clawock.decision import signal_review as review  # noqa: E402
 
 
 class _HistoryStub:
-    """In-memory stand-in that keeps aggregation tests free of file I/O."""
+    """A throwaway history file the aggregation tests can point ``HIST`` at.
+
+    Kept as a class (rather than a fixture) so the existing call sites stay
+    one-liners. It is a real file since #951: the reader now goes through
+    ``history_store.load_series``, which reads the working file *and* its
+    archive — an in-memory stand-in would silently bypass the half of the
+    series that split introduced.
+    """
 
     def __init__(self, days):
-        self._text = "\n".join(json.dumps(day) for day in days)
+        self._dir = tempfile.TemporaryDirectory()
+        self._path = pathlib.Path(self._dir.name) / "quant_signals_history.jsonl"
+        self._path.write_text(
+            "\n".join(json.dumps(day) for day in days) + "\n", encoding="utf-8")
+
+    def __fspath__(self):
+        return str(self._path)
+
+    @property
+    def parent(self):
+        return self._path.parent
+
+    @property
+    def name(self):
+        return self._path.name
 
     def exists(self):
-        return True
+        return self._path.exists()
 
-    def read_text(self):
-        return self._text
+    def read_text(self, *args, **kwargs):
+        return self._path.read_text(*args, **kwargs)
 
 
 class _FixedDate:


### PR DESCRIPTION
Closes #951

## 决策（issue 验收标准 1：先有书面决策）

| 项 | 决定 |
|---|---|
| 保留窗口 | 工作文件保留最近 **180 天**（`history_store.HOT_WINDOW_DAYS`）。日常读路径的回看窗口全都远短于它（novelty 30d、因子窗口 ≤120d），所以这不是行为旋钮，而是「一天的重写最多能带多少行」。 |
| 冷数据去向 | `assets/data/archive/<同名>.jsonl`，只在有行过期时写一次；内容 = 「完整序列 − 热窗」，同样的冷段每天写出同样的字节。 |
| `cluster_old_but_recurrent` 语义 | **不变**。读者一律走 `history_store.load_series()`（归档 + 热窗），拿到的仍是完整序列 —— 这正是选「分档」而不是「加 cap」的原因：issue 里点名的两个消费方（novelty 的 0.8 vs 1.0、walk-forward 的 point-in-time 回放）都要完整历史。 |

## 改了什么

- 新增 `src/clawock/history_store.py`：`load_series` / `write_series` / `split_window` / `series_digest`，模块 docstring 就是上面这张表的长版。
- 四条留痕的写侧改走 `write_series`：`news_evidence_graph` / `factors` / `peer_residuals` / `decision.signals`。
- 读侧改走 `load_series`：上述三个 `_load_history` + `signal_review` + `add_alpha_walkforward._jsonl`。
- `add_alpha_walkforward` 的 run card 摘要改成对**完整序列**取（原先按工作文件字节取，分档后会与它旁边的 `bars` 计数不同源）；随之删掉已无引用的 `_digest`。
- `signal_review` 保住原有分界：**文件不存在**才 skip，**文件在但今天零行**仍出零状态卡（否则解锁视图会因为一天没留痕整块消失）。
- `brief_postflight` 的 add 列表加 `assets/data/archive/`，并预置 `.gitkeep` —— 那个列表里任何一个 pathspec 匹配不到都会让整次提交失败（文件里那条既有注释记的就是这个教训）。

## 局限（免得后人以为它更强）

**总字节没有变小**，变小的是「每天被重写的那一份」。`assets/data/archive/` 就是把冷段搬出 master 的接口——换一个路径（data 分支 / 仓外）即可，要不要搬是 kcn 的决定。另外今天 `news_evidence_history` 只有 22 行（872KB / 约 40KB 一行，涨的是**每行里的事件数**不是行数），所以 180 天窗口今天还不会触发——这正是 issue 说的「趁文件还小时定策略」。

## 测试（验收标准 2：行为而非字段名）

`tests/test_history_store.py` 五条，钉的都是「分档之后读者看到的东西不变」：

1. `load_series` 逐行等于写进去的完整序列，**且分档确实发生**（冷热都非空、边界单调）——否则第一条断言就是旧行为换个名字通过；
2. 无 `as_of` 的行留在工作文件（证明不了自己旧的行不许被悄悄归档）；
3. 归档字节稳定：再写一天，archive 文件逐字节不变（这是「每日重写成本」那部分的验收）；
4. 摘要覆盖完整序列（删掉冷段摘要必须变）；
5. **语义闸**：300 天前的 cluster 落进 archive 后，走生产读路径（`graph._load_history()` → `apply_novelty`）仍判 `cluster_old_but_recurrent` / 0.8，不是 `new_cluster` / 1.0；前置断言确认那行确实在 archive、工作文件确实是空的。

另：`test_quant_signal_review.py` 的 `_HistoryStub` 从内存字符串改成真文件——读侧现在会同时看归档与工作文件，内存 stub 会绕开分档带来的那一半。