### PR TITLE
retrospective: 判词只留 ledger 那一份，不再拿快照字段自己判一遍（#964）

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -233,8 +233,27 @@ def _is_hk_ticker(t):
     return t.isdigit() and len(t) <= 5
 
 
-def compute_retrospective(prior_plan_path, portfolio):
-    """V2 retrospective: each strategy decision is scored only if its condition fired."""
+def compute_retrospective(prior_plan_path, portfolio, ledger_decisions=None):
+    """Yesterday's plan, scored by the settled ledger — never by a snapshot.
+
+    Until #964 this function recomputed its own trigger verdicts from the
+    portfolio snapshot's ``current_price`` / ``day_open`` / ``day_high`` /
+    ``day_low``. Those fields carry the vintage of whichever cron last fetched,
+    not of a trading session — the repo's own ``market_data/bars`` docstring
+    lists the damage (00100 showed one identical (high, low) across four
+    different sessions; ``current_price`` was the previous close in half the
+    snapshots). So the same decision could carry two contradictory verdicts in
+    one context bundle: the ledger's, settled against canonical bars, and this
+    one's. The LLM was fed both and asked to calibrate confidence on them.
+
+    There is now one verdict per decision, and it is the ledger's. This function
+    only *joins*: plan-side facts (what was authorised, at what confidence) meet
+    ``evaluation`` (what the bars say happened), and every scored field carries
+    ``verdict_source`` so a reader can tell join from judgement. The money-shaped
+    ``simulated_pnl`` is gone with the snapshot prices it was made of;
+    ``benefit_t1_pct`` from the ledger is the same question answered against
+    session-dated bars.
+    """
     if not prior_plan_path:
         return {'prior_plan_date': None, 'decisions': [], 'note': 'first run (no prior plan)'}
 
@@ -245,54 +264,35 @@ def compute_retrospective(prior_plan_path, portfolio):
 
     all_holdings = (portfolio['portfolios']['hk_stocks']['holdings'] +
                     portfolio['portfolios']['us_stocks']['holdings'])
-    htmap = {h['ticker']: h for h in all_holdings}
+    held = {h['ticker'] for h in all_holdings}
+
+    by_id = {}
+    by_plan = {}
+    for settled in ledger_decisions or []:
+        if settled.get('decision_id'):
+            by_id[settled['decision_id']] = settled
+        by_plan.setdefault(
+            (settled.get('plan_date'), settled.get('ticker'), settled.get('action')),
+            settled,
+        )
 
     results = []
     for action in prior.get('decisions', []):
         ticker = action.get('ticker')
-        h = htmap.get(ticker)
-        if not h:
-            results.append({
-                'ticker': ticker, 'error': 'ticker no longer in portfolio', 'plan': action,
-            })
-            continue
-
+        bucket = action.get('action', '')
         condition = action.get('condition') or {}
-        trigger_type  = condition.get('type', 'manual')
-        trigger_price = condition.get('price')
-        size_shares   = (action.get('size') or {}).get('shares')
-        bucket        = action.get('action', '')
+        # decision_id is the join key; the (date, ticker, action) fallback covers
+        # plans authored before ids existed. A miss is reported as a miss — an
+        # unsettled decision must not be silently scored here, because "score it
+        # myself" is exactly the second implementation #964 removed.
+        settled = (by_id.get(action.get('decision_id'))
+                   or by_plan.get((prior.get('date'), ticker, bucket)))
+        evaluation = (settled or {}).get('evaluation') or {}
 
-        current   = h.get('current_price', 0)
-        prev_close = h.get('prev_close', current)
-        open_px   = h.get('day_open', current)
-        day_high  = h.get('day_high', current)
-        day_low   = h.get('day_low', current)
-
-        fired = None
-        if trigger_type == 'open':
-            fired = True
-        elif trigger_type == 'price_above' and trigger_price is not None:
-            fired = day_high >= trigger_price
-        elif trigger_type == 'price_below' and trigger_price is not None:
-            fired = day_low <= trigger_price
-        # index_breakdown / event / manual → leave as None (LLM judges)
-
-        sim_pnl = None
-        execution_price = None
-        if fired and size_shares:
-            if trigger_type == 'open':
-                execution_price = open_px
-            elif trigger_price is not None:
-                execution_price = trigger_price
-
-            if execution_price is not None:
-                # Sell-side actions: PnL = (execution - current) × shares (positive = good)
-                if bucket in ('cut', 'trim_on_rebound', 't_only'):
-                    sim_pnl = round((execution_price - current) * size_shares, 2)
-                # Buy-side actions: PnL = (current - execution) × shares (positive = good)
-                elif bucket == 'add_only_on_trigger':
-                    sim_pnl = round((current - execution_price) * size_shares, 2)
+        session = evaluation.get('trigger_session')
+        if settled is not None and not session:
+            session, _reason = decision_v2.evaluation_session(settled)
+        day_bar = decision_v2.bar(ticker, session) if session else None
 
         results.append({
             'ticker':                   ticker,
@@ -300,21 +300,30 @@ def compute_retrospective(prior_plan_path, portfolio):
             'episode_id':               action.get('episode_id'),
             'thesis_id':                action.get('thesis_id'),
             'strategy_id':              action.get('strategy_id'),
-            'action':                    bucket,
-            'plan_trigger_type':        trigger_type,
-            'plan_trigger_price':       trigger_price,
-            'plan_size_shares':         size_shares,
+            'action':                   bucket,
+            'plan_trigger_type':        condition.get('type', 'manual'),
+            'plan_trigger_price':       condition.get('price'),
+            'plan_size_shares':         (action.get('size') or {}).get('shares'),
             'plan_confidence':          action.get('confidence'),
             'plan_rationale':           action.get('rationale'),
-            'actual_open':              open_px,
-            'actual_close':             current,
-            'actual_day_high':          day_high,
-            'actual_day_low':           day_low,
-            'actual_prev_close':        prev_close,
-            'trigger_fired':            fired,
-            'simulated_execution_price': execution_price,
-            'simulated_pnl':            sim_pnl,
-            'pnl_currency':             'HKD' if _is_hk_ticker(ticker) else 'USD',
+            'still_held':               ticker in held,
+            # —— 以下全部来自 decision_v2 的结算，本函数不自己判 ——
+            'trigger_fired':            evaluation.get('triggered'),
+            'trigger_session':          session,
+            'settlement_status':        evaluation.get('status'),
+            'outcome':                  evaluation.get('outcome'),
+            'execution_price':          (evaluation.get('execution_price')
+                                         if evaluation.get('execution_price') is not None
+                                         else evaluation.get('reference_price')),
+            'benefit_t1_pct':           evaluation.get('benefit_t1_pct'),
+            'session_bar':              ({k: day_bar[k] for k in ('open', 'high', 'low', 'close')}
+                                         if day_bar else None),
+            'verdict_source':           ('decision_ledger' if settled is not None
+                                         else 'unsettled_no_ledger_row'),
+            'verdict_basis':            'memory/bars (session-dated, unadjusted)',
+            'verdict_note':             (evaluation.get('not_evaluable_reason')
+                                         or evaluation.get('pending_reason')
+                                         or evaluation.get('fill_reason')),
         })
 
     # Confidence calibration buckets
@@ -329,6 +338,7 @@ def compute_retrospective(prior_plan_path, portfolio):
     return {
         'prior_plan_date': prior.get('date'),
         'prior_plan_path': str(prior_plan_path),
+        'verdict_source': 'decision_v2 ledger settled against memory/bars',
         'decisions':       results,
         'confidence_calibration': {
             'conf_80_100':  _calib(0.80, 1.01),
@@ -1558,21 +1568,10 @@ def main(argv=None):
     # N copies of it (#916 §1.4).
     us_fund = _run_serial('_node_filings', lambda: _node_filings(portfolio))
 
-    # [7] Retrospective
-    print('[7/14] Retrospective')
+    # [7] Retrospective — only the plan lookup happens here. The scoring moved
+    # below the settle step (#964): the verdicts are the ledger's now, and the
+    # ledger is not settled against today's bars until [10].
     prior_plan = find_prior_plan(today)
-    retro = compute_retrospective(prior_plan, portfolio)
-    if retro.get('prior_plan_date'):
-        actions = retro['decisions']
-        fired = sum(1 for a in actions if a.get('trigger_fired') is True)
-        not_fired = sum(1 for a in actions if a.get('trigger_fired') is False)
-        ambiguous = sum(1 for a in actions if a.get('trigger_fired') is None and 'error' not in a)
-        print(f'   prior plan: {retro["prior_plan_date"]}')
-        print(f'   fired: {fired}   not fired: {not_fired}   ambiguous (manual/event): {ambiguous}')
-        print(f'   conf cal: 80%+ {retro["confidence_calibration"]["conf_80_100"]}, '
-              f'60-79% {retro["confidence_calibration"]["conf_60_79"]}')
-    else:
-        print(f'   first run (no prior plan)')
 
     # [8]-[13] DAG waves (#916 §1.2/§1.3): serial prefix done, now three
     # concurrent waves separated by barriers, each capped at max_workers=2.
@@ -1671,6 +1670,24 @@ def main(argv=None):
     print(f'   active: n={active_v2.get("n_episodes", 0)} '
           f'avg benefit={active_v2.get("avg_benefit_pct")}%, '
           f'cluster CI={active_v2.get("cluster_ci95")}')
+
+    # [7b] Retrospective — deliberately after [10]. It reads the settled ledger
+    # (which reads canonical bars) instead of scoring yesterday's plan against
+    # the portfolio snapshot, so there is one verdict per decision rather than
+    # two contradictory ones in the same context bundle (#964).
+    print('[7b/14] Retrospective')
+    retro = compute_retrospective(prior_plan, portfolio, decision_v2.load_decisions())
+    if retro.get('prior_plan_date'):
+        actions = retro['decisions']
+        fired = sum(1 for a in actions if a.get('trigger_fired') is True)
+        not_fired = sum(1 for a in actions if a.get('trigger_fired') is False)
+        ambiguous = sum(1 for a in actions if a.get('trigger_fired') is None)
+        print(f'   prior plan: {retro["prior_plan_date"]} (verdicts from the v2 ledger)')
+        print(f'   fired: {fired}   not fired: {not_fired}   unsettled/ambiguous: {ambiguous}')
+        print(f'   conf cal: 80%+ {retro["confidence_calibration"]["conf_80_100"]}, '
+              f'60-79% {retro["confidence_calibration"]["conf_60_79"]}')
+    else:
+        print('   first run (no prior plan)')
 
     # [9b] Reflection memory — per held ticker, prior call outcomes (TradingAgents-style)
     reflections = compute_reflections(portfolio)

--- a/tests/test_brief_retrospective.py
+++ b/tests/test_brief_retrospective.py
@@ -1,0 +1,120 @@
+"""#964：昨日计划的判词只有一份，来自 decision_v2 的结算。
+
+原来 compute_retrospective 自己拿 portfolio 快照的 current_price / day_open /
+day_high / day_low 判「触发了没有」，而同一批 decision 的正式结算走 memory/bars。
+两套判词可以互相矛盾，且被同时喂进同一条 context 让 LLM 校准 confidence。
+"""
+import json
+
+from clawock.harness import brief_preflight
+
+
+PORTFOLIO = {
+    'portfolios': {
+        'us_stocks': {'holdings': [{
+            'ticker': 'ABC',
+            # 快照口径：这一天「看起来」冲到过 12，旧实现会据此判 price_above 10 已触发。
+            'current_price': 11.0, 'day_open': 9.0, 'day_high': 12.0,
+            'day_low': 8.5, 'prev_close': 9.5,
+        }]},
+        'hk_stocks': {'holdings': []},
+    },
+}
+
+
+def _plan(tmp_path, **overrides):
+    decision = {
+        'decision_id': 'dec-1',
+        'ticker': 'ABC',
+        'action': 'add_only_on_trigger',
+        'condition': {'type': 'price_above', 'price': 10.0},
+        'size': {'shares': 100},
+        'confidence': 0.9,
+        'rationale': 'breakout',
+    }
+    decision.update(overrides)
+    path = tmp_path / 'plan-2026-08-24.json'
+    path.write_text(json.dumps({'date': '2026-08-24', 'decisions': [decision]}))
+    return path
+
+
+def _ledger_row(**evaluation):
+    return {
+        'decision_id': 'dec-1',
+        'plan_date': '2026-08-24',
+        'ticker': 'ABC',
+        'leg': 'US',
+        'action': 'add_only_on_trigger',
+        'condition': {'type': 'price_above', 'price': 10.0},
+        'evaluation': evaluation,
+    }
+
+
+def test_the_ledger_verdict_wins_over_what_the_snapshot_would_have_said(tmp_path):
+    """快照说 day_high=12 ≥ 10（旧实现判 fired），canonical bars 说没触发。
+
+    留下的必须是后者 —— 这条测试的整个意义就是：两者矛盾时，输出里不能出现
+    快照那一份。
+    """
+    retro = brief_preflight.compute_retrospective(
+        _plan(tmp_path), PORTFOLIO,
+        [_ledger_row(triggered=False, status='not_triggered', outcome='not_triggered',
+                     fill_reason='high_below_trigger', trigger_session='2026-08-25')],
+    )
+
+    row = retro['decisions'][0]
+    assert row['trigger_fired'] is False
+    assert row['settlement_status'] == 'not_triggered'
+    assert row['verdict_source'] == 'decision_ledger'
+    assert row['verdict_basis'].startswith('memory/bars')
+    # 快照价格字段不许再出现在输出里：它们是另一套 vintage 的数字。
+    for gone in ('actual_open', 'actual_close', 'actual_day_high',
+                 'actual_day_low', 'actual_prev_close', 'simulated_pnl',
+                 'simulated_execution_price'):
+        assert gone not in row, gone
+
+
+def test_every_row_reconciles_with_the_ledger_row_it_joined(tmp_path):
+    ledger = [_ledger_row(triggered=True, status='settled', outcome='win',
+                          execution_price=10.0, benefit_t1_pct=1.25,
+                          trigger_session='2026-08-25')]
+
+    retro = brief_preflight.compute_retrospective(_plan(tmp_path), PORTFOLIO, ledger)
+
+    row = retro['decisions'][0]
+    settled = ledger[0]['evaluation']
+    assert (row['trigger_fired'], row['outcome'], row['execution_price'],
+            row['benefit_t1_pct'], row['trigger_session']) == (
+        settled['triggered'], settled['outcome'], settled['execution_price'],
+        settled['benefit_t1_pct'], settled['trigger_session'])
+    assert retro['confidence_calibration']['conf_80_100'] == '1/1'
+
+
+def test_an_unsettled_decision_is_reported_as_unsettled_not_scored(tmp_path):
+    """台账里没有这条 ⇒ 说「没有判词」，不许本函数自己补一个。"""
+    retro = brief_preflight.compute_retrospective(_plan(tmp_path), PORTFOLIO, [])
+
+    row = retro['decisions'][0]
+    assert row['trigger_fired'] is None
+    assert row['verdict_source'] == 'unsettled_no_ledger_row'
+    # 计划侧的事实照常带着（判词缺失不等于这条 decision 不存在）。
+    assert row['plan_trigger_price'] == 10.0
+    assert row['plan_confidence'] == 0.9
+    assert retro['confidence_calibration']['conf_80_100'] == 'n/a'
+
+
+def test_a_ticker_that_left_the_portfolio_still_gets_its_verdict(tmp_path):
+    """旧实现遇到「已不在持仓」直接 error 掉整行 —— 卖掉的票照样有判词要对账。"""
+    empty = {'portfolios': {'us_stocks': {'holdings': []}, 'hk_stocks': {'holdings': []}}}
+
+    retro = brief_preflight.compute_retrospective(
+        _plan(tmp_path), empty,
+        [_ledger_row(triggered=True, status='settled', outcome='loss',
+                     execution_price=10.0, benefit_t1_pct=-2.0,
+                     trigger_session='2026-08-25')],
+    )
+
+    row = retro['decisions'][0]
+    assert row['still_held'] is False
+    assert row['trigger_fired'] is True
+    assert row['outcome'] == 'loss'


### PR DESCRIPTION
Closes #964

## 问题

`compute_retrospective` 用**当天 08:00 刚刷新的 portfolio.json** 的 `current_price` / `day_open` / `day_high` / `day_low` 判 `trigger_fired` 并算 `simulated_pnl`；同一批 decision 的正式结算走 `decision_v2.settle_decisions`，只读 canonical `memory/bars`。

于是**同一个触发条件在同一条 context 里有两套判词**，可以互相矛盾，而 LLM 被同时喂了两份用来校准 confidence。

那套快照字段本仓早就判过不可用于判词 —— `market_data/bars.py` 的 Contract 段就是为此写的：00100 的 `day_high/day_low` 四天不变、`current_price` 过半是前收。

## 改法：本函数只 join，不判断

| 输出字段 | 来源 |
|---|---|
| `plan_*`（触发型别/价位/股数/信心/理由）、`still_held` | 昨日 plan + 当前持仓 |
| `trigger_fired` / `settlement_status` / `outcome` / `execution_price` / `benefit_t1_pct` / `trigger_session` | **ledger 的 `evaluation`**，逐字段照搬 |
| `verdict_source` / `verdict_basis` | `decision_ledger` / `memory/bars (session-dated, unadjusted)` |
| `session_bar` | canonical bar 的 OHLC（让读者看到判词所依据的那四个数） |

- 台账里没有对应行 ⇒ `verdict_source: unsettled_no_ledger_row`，**不补判词**（「自己补一个」正是这次要删掉的那套实现）。
- 快照价格字段（`actual_open/close/day_high/day_low/prev_close`）与 `simulated_pnl` 一并删除。同一个问题由 `benefit_t1_pct` 回答，口径是 session-dated bars。
- 顺带修一处：`ticker` 已不在持仓时旧实现把整行 error 掉 —— 卖掉的票照样有判词要对账，改成 `still_held` 标志。

## 调用顺序

`compute_retrospective` 从 `[7]` 移到 `[10]` 之后：判词是台账的，而台账要等 canonical bars 刷新（`[9]`）与结算（`[10]`）之后才是今天的。计划查找（`find_prior_plan`）仍留在 `[7]`。

## 验收（issue 的两条）

1. **每个 verdict 与 decision_v2 对同一 decision_id 的结算可对账** —— `test_every_row_reconciles_with_the_ledger_row_it_joined` 逐字段比对。
2. **仓库内不再存在第二套基于快照字段的触发判词实现** —— `test_the_ledger_verdict_wins_over_what_the_snapshot_would_have_said` 造矛盾：快照 `day_high=12 ≥ 触发价 10`（旧实现判 fired），台账说 `not_triggered`，断言输出是后者，且旧字段名一个都不许出现。

另两条：未结算的行报未结算（不许自评）、离场的票照样带判词。

`pytest -k "brief or preflight or ledger or decision"`：469 passed。