### PR TITLE
cleanup: filings 批量、异动解析合一、子进程走本解释器、死代码（#918 三项）

### DIFF
--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -307,8 +307,11 @@ def rebuild_dashboard(ws=None):
         from clawock.automation import workflow_outcomes
         workflow_outcomes.publish()
         r = subprocess.run(
+            # 走本解释器的 -m 而不是 PATH 上的 console script（#918）：装在
+            # 别处的入口点与这里 import 的包可能不是同一份，而缺失时的失败
+            # 是安静的（FileNotFoundError 被上面的宽 except 吞掉）。
             ['flock', DASHBOARD_PUBLISH_LOCK,
-             'clawock', 'dashboard-build',
+             sys.executable, '-m', 'clawock', 'dashboard-build',
              '--previous', str(previous / 'assets' / 'data' / 'dashboard.json')],
             capture_output=True, text=True, timeout=30, cwd=str(ws),
         )
@@ -443,3 +446,55 @@ def run_analyze(market):
         return r.returncode, r.stdout, r.stderr
     except subprocess.TimeoutExpired:
         return -1, '', f'{module} timeout (120s)'
+
+
+# ── holdings md-table anomalies ───────────────────────────────────────────
+# Both report_preflight and intraday_preflight parsed the same seven-column
+# holdings table with the same ≥3% rule and the same ≥5% split, in two copies
+# that had already drifted apart in what they emitted per row (`severity` vs
+# `reason`) — and a change to the row shape would have had to be made twice
+# (#918). One parser, superset row: callers keep reading the key they always
+# read. The gate itself (≥3% is an anomaly, ≥5% is the severe half) is
+# unchanged — this move is not the place to renegotiate it.
+_ANOMALY_PCT = re.compile(r'([+\-])([\d\.]+)%')
+ANOMALY_MOVE_PCT = 3.0
+ANOMALY_SEVERE_PCT = 5.0
+
+
+def parse_holdings_anomalies(stdout):
+    """Rows of the `--md-table` holdings block whose day move is ≥3%.
+
+    Row shape (7 cols, both markets, since 2026-05-21):
+      HK: `| 00100 | 60 | 822.83 | 722.00 | +5.1% | -12.2% | -6,050 |`
+      US: `| RKLB |  5 |  71.00 | 134.28 | +0.0% | +89.1% |   +316 |`
+    Cell[0]=ticker, [1]=shares, [2]=cost, [3]=price, [4]=today%, [5]=pnl%,
+    [6]=pnl_abs. Header / separator rows are filtered (代码 / `:---`).
+    """
+    anomalies = []
+    for line in (stdout or '').splitlines():
+        s = line.strip()
+        if not s.startswith('|') or not s.endswith('|'):
+            continue
+        cells = [c.strip() for c in s.strip('|').split('|')]
+        if len(cells) < 7:
+            continue
+        ticker = cells[0]
+        if ticker == '代码' or ticker.startswith(':'):  # header / separator
+            continue
+        match = _ANOMALY_PCT.search(cells[4])
+        if not match:
+            continue
+        sign, pct_str = match.groups()
+        pct = float(pct_str)
+        if pct < ANOMALY_MOVE_PCT:
+            continue
+        severe = pct >= ANOMALY_SEVERE_PCT
+        anomalies.append({
+            'ticker': ticker,
+            'move_pct': (1 if sign == '+' else -1) * pct,
+            # 两个键都给：severity 是 intraday（以及下游 add_side）读的，
+            # reason 是 report 的输出契约。合并时任何一边都不该丢字段。
+            'severity': 'high' if severe else 'medium',
+            'reason': '跳空/异动' if severe else '日内大幅波动',
+        })
+    return anomalies

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -97,11 +97,25 @@ def _run(script, args=None, timeout=120):
         return f'{type(e).__name__}: {e}', False
 
 
+def clawock_argv(command, *args):
+    """argv for one package command, run through *this* interpreter (#918).
+
+    Spawning the bare console script makes every one of these steps depend on
+    whatever is on PATH — and the failure mode is quiet: under the user
+    crontab's ``PATH=/usr/bin:/bin`` the entry point is simply not there,
+    ``FileNotFoundError`` gets swallowed by the callers' broad excepts, and the
+    step reports that it did nothing wrong. ``sys.executable -m clawock`` runs
+    the package that is actually imported here, so there is no second install
+    to keep in sync and no PATH to get wrong.
+    """
+    return [sys.executable, '-m', 'clawock', command, *args]
+
+
 def _run_clawock(command, args=None, timeout=120):
-    """Run one installed package command in the selected workspace."""
+    """Run one package command in the selected workspace."""
     try:
         result = subprocess.run(
-            ['clawock', command] + (args or []), cwd=WS,
+            clawock_argv(command, *(args or [])), cwd=WS,
             capture_output=True, text=True, timeout=timeout)
         return (result.stdout or '') + (result.stderr or ''), result.returncode == 0
     except Exception as exc:
@@ -127,7 +141,7 @@ def _technical_setup_usage():
 def fetch_fx_rate():
     try:
         result = subprocess.run(
-            ['clawock', 'fx', '--json'], cwd=WS, capture_output=True,
+            clawock_argv('fx', '--json'), cwd=WS, capture_output=True,
             text=True, timeout=30)
         out, ok = result.stdout, result.returncode == 0
     except Exception as exc:
@@ -143,28 +157,41 @@ def fetch_fx_rate():
 
 
 def collect_us_fundamentals(portfolio):
-    """Pull SEC EDGAR --financials for each non-leveraged US single."""
-    fundamentals = {}
-    for h in portfolio['portfolios']['us_stocks']['holdings']:
-        if h.get('shares', 0) <= 0 or _is_leveraged_etf(h):
-            continue
-        ticker = h['ticker']
-        try:
-            result = subprocess.run(
-                ['clawock', 'filings', ticker, '--financials', '--json'],
-                cwd=WS, capture_output=True, text=True, timeout=30,
-            )
-            out, ok = result.stdout, result.returncode == 0
-        except Exception as exc:
-            out, ok = f'{type(exc).__name__}: {exc}', False
-        if not ok:
-            fundamentals[ticker] = {'error': out[-300:]}
-            continue
-        try:
-            fundamentals[ticker] = json.loads(out)
-        except json.JSONDecodeError:
-            fundamentals[ticker] = {'error': 'parse failed', 'raw': out[:300]}
-    return fundamentals
+    """Pull SEC EDGAR --financials for the non-leveraged US singles, in one spawn.
+
+    One process for the whole list, not one per ticker (#918). The SEC throttle
+    inside ``market_data.filings`` is an in-process ``_last_call``, so N spawns
+    hold N independent limiters — which is why this loop could never simply be
+    parallelised, and why the batch mode exists instead. Sequential inside that
+    single process keeps the desk's request rate the one it declares.
+    """
+    tickers = [h['ticker'] for h in portfolio['portfolios']['us_stocks']['holdings']
+               if h.get('shares', 0) > 0 and not _is_leveraged_etf(h)]
+    if not tickers:
+        return {}
+    # 单只时保持原来的单只形状；两只以上走 batch。超时按只数给，别让第五只
+    # 去挤第一只的预算。
+    timeout = 30 if len(tickers) == 1 else 20 * len(tickers)
+    try:
+        result = subprocess.run(
+            clawock_argv('filings', *tickers, '--financials', '--json'),
+            cwd=WS, capture_output=True, text=True, timeout=timeout,
+        )
+        out, ok = result.stdout, result.returncode == 0
+    except Exception as exc:
+        out, ok = f'{type(exc).__name__}: {exc}', False
+    if not ok:
+        return {ticker: {'error': out[-300:]} for ticker in tickers}
+    try:
+        payload = json.loads(out)
+    except json.JSONDecodeError:
+        return {ticker: {'error': 'parse failed', 'raw': out[:300]}
+                for ticker in tickers}
+    if len(tickers) == 1:
+        return {tickers[0]: payload}
+    batch = payload.get('batch') or {}
+    return {ticker: batch.get(ticker, {'error': 'missing from batch response'})
+            for ticker in tickers}
 
 
 
@@ -587,7 +614,7 @@ def refresh_daily_bars():
     settled against; fetch_daily_bars never overwrites one, so that surfaces as an
     issue for a human to resolve with --repair rather than being applied here.
     """
-    cmd = ['clawock', 'daily-bars']
+    cmd = clawock_argv('daily-bars')
     try:
         r = subprocess.run(cmd, cwd=WS, capture_output=True, text=True, timeout=300)
     except Exception as e:
@@ -1037,7 +1064,7 @@ def portfolio_risk_node():
     print('[11/14] Risk metrics')
     risk = {}
     try:
-        r = subprocess.run(['clawock', 'portfolio-risk'], cwd=WS,
+        r = subprocess.run(clawock_argv('portfolio-risk'), cwd=WS,
                            capture_output=True, text=True, timeout=180, check=False)
         if r.returncode != 0:
             tail = (r.stderr or r.stdout or '')[-500:]
@@ -1068,7 +1095,7 @@ def regime_node():
     issues = []
     lev_regime = None
     try:
-        subprocess.run(['clawock', 'regime'],
+        subprocess.run(clawock_argv('regime'),
                        capture_output=True, text=True, timeout=60, check=False)
         lr_path = WS / 'assets' / 'data' / 'lev_regime.json'
         if lr_path.exists():
@@ -1085,7 +1112,7 @@ def quant_node():
     issues = []
     quant_signals = {}
     try:
-        subprocess.run(['clawock', 'quant'],
+        subprocess.run(clawock_argv('quant'),
                        capture_output=True, text=True, timeout=120, check=False)
         qs_path = WS / 'assets' / 'data' / 'quant_signals.json'
         if qs_path.exists():
@@ -1109,7 +1136,7 @@ def quant_review_node():
     issues = []
     quant_review = {}
     try:
-        subprocess.run(['clawock', 'quant-review'],
+        subprocess.run(clawock_argv('quant-review'),
                        capture_output=True, text=True, timeout=60, check=False)
         qr_path = WS / 'assets' / 'data' / 'quant_signal_review.json'
         if qr_path.exists():
@@ -1130,7 +1157,7 @@ def cross_factor_node(portfolio):
     cross_sectional_factor_ctx = {}
     try:
         subprocess.run(
-            ['clawock', 'cross-factor'],
+            clawock_argv('cross-factor'),
             capture_output=True, text=True, timeout=240, check=False,
         )
         cs_path = WS / 'assets' / 'data' / 'cross_sectional_factor.json'
@@ -1180,7 +1207,7 @@ def evidence_node():
     # 证据页：读上面刚刷新的产物重新生成，保证「测了什么、什么没通过」不落后于事实。
     issues = []
     try:
-        subprocess.run(['clawock', 'evidence'],
+        subprocess.run(clawock_argv('evidence'),
                        capture_output=True, text=True, timeout=60, check=False)
     except Exception as e:
         print(f'   ⚠ evidence page rebuild failed: {e}')
@@ -1195,7 +1222,7 @@ def peer_residual_node(portfolio):
     peer_residual_ctx = {}
     try:
         subprocess.run(
-            ['clawock', 'peer-residual'],
+            clawock_argv('peer-residual'),
             capture_output=True, text=True, timeout=180, check=False,
         )
         pr_path = WS / 'assets' / 'data' / 'peer_residual.json'
@@ -1242,7 +1269,7 @@ def t0_node():
     issues = []
     t0_setups = {}
     try:
-        subprocess.run(['clawock', 't0'],
+        subprocess.run(clawock_argv('t0'),
                        capture_output=True, text=True, timeout=60, check=False)
         t0_path = WS / 'assets' / 'data' / 't0_setups.json'
         if t0_path.exists():
@@ -1261,7 +1288,7 @@ def t0_review_node():
     issues = []
     t0_review = {}
     try:
-        subprocess.run(['clawock', 't0-review'],
+        subprocess.run(clawock_argv('t0-review'),
                        capture_output=True, text=True, timeout=60, check=False)
         tr_path = WS / 'assets' / 'data' / 't0_setup_review.json'
         if tr_path.exists():
@@ -1277,7 +1304,7 @@ def em_news_node():
     # 借鉴 UZI-Skill 的数据源广度；信息收集是 LLM 强项 + kcn token 充足。失败 fail-soft。
     issues = []
     try:
-        subprocess.run(['clawock', 'em-news'], cwd=WS,
+        subprocess.run(clawock_argv('em-news'), cwd=WS,
                        capture_output=True, text=True, timeout=60, check=False)
     except Exception as e:
         print(f'   ⚠ clawock em-news failed: {e}')
@@ -1290,7 +1317,7 @@ def catalysts_node():
     catalysts = {}
     try:
         result = subprocess.run(
-            ['clawock', 'catalysts', '--json'], cwd=WS,
+            clawock_argv('catalysts', '--json'), cwd=WS,
             capture_output=True, text=True, timeout=60)
         cat_out, cat_ok = result.stdout, result.returncode == 0
         if not cat_ok:
@@ -1321,7 +1348,7 @@ def news_evidence_node():
     news_evidence_ctx = {}
     try:
         graph_run = subprocess.run(
-            ['clawock', 'news-evidence'], capture_output=True, text=True,
+            clawock_argv('news-evidence'), capture_output=True, text=True,
             timeout=150, check=False,
         )
         graph_out = (graph_run.stdout or '') + (graph_run.stderr or '')

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -26,6 +26,7 @@ NB: Mode 7 is lightweight on purpose (8 HK + 10 US slots per trading day).
     postflight publishes a semantic dashboard change, if any.
 """
 
+from clawock.harness import _harness_common
 from clawock.harness._harness_common import run_analyze
 import argparse
 import json
@@ -755,40 +756,8 @@ def apply_active_information_alert(should_alert, reasons, active):
 
 
 def parse_anomalies(stdout):
-    """Parse markdown holdings table rows (--md-table form) and flag ≥3% moves.
-
-    Row shape (7 cols, both markets, since 2026-05-21):
-      HK: `| 00100 | 60 | 822.83 | 722.00 | +5.1% | -12.2% | -6,050 |`
-      US: `| RKLB |  5 |  71.00 | 134.28 | +0.0% | +89.1% |   +316 |`
-    Cell[0]=ticker, [4]=today%, [5]=pnl%, [6]=pnl_abs ($).
-    Header / separator rows are filtered (代码 / `:---`).
-    """
-    anomalies = []
-    pct_re = re.compile(r'([+\-])([\d\.]+)%')
-    for line in stdout.splitlines():
-        s = line.strip()
-        if not s.startswith('|') or not s.endswith('|'):
-            continue
-        cells = [c.strip() for c in s.strip('|').split('|')]
-        if len(cells) < 7:
-            continue
-        ticker = cells[0]
-        if ticker == '代码' or ticker.startswith(':'):  # header / separator
-            continue
-        today = cells[4]
-        m = pct_re.search(today)
-        if not m:
-            continue
-        sign, pct_str = m.groups()
-        pct = float(pct_str)
-        if pct < 3.0:
-            continue
-        anomalies.append({
-            'ticker':   ticker,
-            'move_pct': (1 if sign == '+' else -1) * pct,
-            'severity': 'high' if pct >= 5 else 'medium',
-        })
-    return anomalies
+    """≥3% 异动行。实现在 _harness_common —— 两个 preflight 曾各存一份（#918）。"""
+    return _harness_common.parse_holdings_anomalies(stdout)
 
 
 def collect_peers(market):

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -42,6 +42,7 @@ Output keys:
   needs_risk_section: bool (true if STOP+TRIM >= 2)
 """
 
+from clawock.harness import _harness_common
 from clawock.harness._harness_common import run_analyze
 import argparse
 import json
@@ -230,41 +231,8 @@ def parse_signals(stdout):
 
 
 def parse_anomalies(stdout):
-    """Find tickers with ≥3% intraday move from md-table holdings rows.
-
-    Row shape (7 cols, both markets, since 2026-05-21):
-      HK: `| 00100 | 60 | 822.83 | 722.00 | +5.1% | -12.2% | -6,050 |`
-      US: `| RKLB |  5 |  71.00 | 134.28 | +0.0% | +89.1% |   +316 |`
-    Cell[0]=ticker, [1]=shares, [2]=cost, [3]=price, [4]=today%,
-    [5]=pnl%, [6]=pnl_abs ($).
-    """
-    anomalies = []
-    pct_re = re.compile(r'([+\-])([\d\.]+)%')
-    for line in stdout.splitlines():
-        s = line.strip()
-        if not s.startswith('|') or not s.endswith('|'):
-            continue
-        cells = [c.strip() for c in s.strip('|').split('|')]
-        if len(cells) < 7:
-            continue
-        ticker = cells[0]
-        if ticker == '代码' or ticker.startswith(':'):  # header / separator
-            continue
-        today = cells[4]
-        m = pct_re.search(today)
-        if not m:
-            continue
-        sign, pct_str = m.groups()
-        pct = float(pct_str)
-        if pct < 3.0:
-            continue
-        direction = 1 if sign == '+' else -1
-        anomalies.append({
-            'ticker':   ticker,
-            'move_pct': direction * pct,
-            'reason':   '跳空/异动' if pct >= 5 else '日内大幅波动',
-        })
-    return anomalies
+    """≥3% 异动行。实现在 _harness_common —— 两个 preflight 曾各存一份（#918）。"""
+    return _harness_common.parse_holdings_anomalies(stdout)
 
 
 def parse_hk_indices(stdout):

--- a/src/clawock/market_data/filings.py
+++ b/src/clawock/market_data/filings.py
@@ -364,29 +364,43 @@ def summarize(ticker: str, as_json: bool = False) -> Dict:
     return result
 
 
-def _parse_args(argv: List[str]) -> Tuple[str, str, Optional[List[str]], bool]:
+def _parse_args(argv: List[str]) -> Tuple[List[str], str, Optional[List[str]], bool]:
+    """(tickers, mode, form_types, as_json).
+
+    More than one ticker is a *batch*, not a suggestion to run in parallel: the
+    SEC throttle below is an in-process ``_last_call``, so N concurrent spawns
+    each get their own limiter and the desk starts talking to EDGAR N times
+    faster than its own rule allows (#918). One process, tickers in sequence,
+    one limiter.
+    """
     args = [a for a in argv if not a.startswith('--')]
     as_json = '--json' in argv
 
     if not args:
         print(__doc__)
         sys.exit(1)
-    ticker = args[0].upper()
-
+    # A form-type list is positional too («--filings 8-K,10-Q»), so it must not
+    # be mistaken for a ticker.
+    form_type_arg = None
     if '--filings' in argv:
         idx = argv.index('--filings')
-        # Optional form-type list right after --filings
-        types = None
         if idx + 1 < len(argv) and not argv[idx + 1].startswith('--'):
-            types = [t.strip().upper() for t in argv[idx + 1].split(',')]
-        return ticker, 'filings', types, as_json
+            form_type_arg = argv[idx + 1]
+    tickers = [a.upper() for a in args if a != form_type_arg]
+    ticker = tickers[0]
+
+    del ticker
+    if '--filings' in argv:
+        types = ([t.strip().upper() for t in form_type_arg.split(',')]
+                 if form_type_arg else None)
+        return tickers, 'filings', types, as_json
     if '--form4' in argv:
-        return ticker, 'form4', None, as_json
+        return tickers, 'form4', None, as_json
     if '--financials' in argv:
-        return ticker, 'financials', None, as_json
+        return tickers, 'financials', None, as_json
     if '--13f' in argv:
-        return ticker, '13f', None, as_json
-    return ticker, 'summary', None, as_json
+        return tickers, '13f', None, as_json
+    return tickers, 'summary', None, as_json
 
 
 def main(argv=None):
@@ -394,8 +408,25 @@ def main(argv=None):
     if '-h' in argv or '--help' in argv:
         print(__doc__)
         return 0
-    ticker, mode, form_types, as_json = _parse_args(argv)
+    tickers, mode, form_types, as_json = _parse_args(argv)
 
+    if len(tickers) > 1:
+        # 批量：一个进程里顺序跑，共用同一个 _throttle。单只的输出形状一个字
+        # 不动，批量另包一层 batch —— 免得调用方要按 ticker 数目切换解析。
+        batch = {}
+        for one in tickers:
+            batch[one] = _run_one(one, mode, form_types, as_json)
+        if as_json:
+            print(json.dumps({'batch': batch}, indent=2, ensure_ascii=False))
+        return 0
+
+    result = _run_one(tickers[0], mode, form_types, as_json)
+    if as_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _run_one(ticker, mode, form_types, as_json):
     if mode == 'summary':
         result = summarize(ticker, as_json=as_json)
     elif mode == 'filings':
@@ -421,10 +452,7 @@ def main(argv=None):
             _print_filings(ticker, thirteen)
     else:
         result = {}
-
-    if as_json:
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-    return 0
+    return result
 
 
 if __name__ == '__main__':

--- a/src/clawock/market_data/gold/update.py
+++ b/src/clawock/market_data/gold/update.py
@@ -23,7 +23,6 @@
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -36,30 +35,6 @@ from clawock.workspace import workspace_root
 WS_ROOT = str(workspace_root(Path.cwd()))
 
 PORTFOLIO = os.path.join(WS_ROOT, 'portfolio.json')
-
-
-def _console(name):
-    """Locate a console script without trusting the caller's PATH.
-
-    Both of the commands below used to be spawned by bare name with
-    `check=False`, so under the user crontab's PATH=/usr/bin:/bin they raised
-    FileNotFoundError and were swallowed: the refresh silently did not happen
-    and the run still reported success. That is the quiet cousin of the bug
-    that blocked the 03:20 dreaming push, and quiet is worse.
-
-    The console scripts are installed beside the interpreter running this
-    module, so that directory is the reliable answer when PATH has nothing —
-    but only when this really is the environment they were installed into. Run
-    under the system interpreter it resolves to /usr/bin, where nothing lives,
-    so the candidate is checked before it is trusted and the bare name is
-    returned otherwise: an unresolvable command should fail with the message
-    everyone recognises rather than with a path this function invented.
-    """
-    found = shutil.which(name)
-    if found:
-        return found
-    beside = Path(sys.executable).parent / name
-    return str(beside) if beside.exists() else name
 
 
 def latest_nav(code):
@@ -126,11 +101,12 @@ def main():
 
     if not a.no_refresh:
         print('  刷新净值 + 重建 dashboard…')
-        subprocess.run([_console('clawock-gold-fetch')], check=False)
+        subprocess.run(
+            [sys.executable, '-m', 'clawock.market_data.gold.fetch'], check=False)
         # Rebuilt so this host's copy is current; NOT staged. The four outputs
         # left the repository in #314 — the scheduled publisher puts them on the
         # data branch, at most 20 minutes behind this commit.
-        subprocess.run([_console('clawock'), 'dashboard-build'],
+        subprocess.run([sys.executable, '-m', 'clawock', 'dashboard-build'],
                        check=False, stdout=subprocess.DEVNULL)
 
     if a.publish:

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1168,28 +1168,6 @@ def compute_debate_metrics(recent=20):
     }
 
 
-def _attach_pnl_swing(impact, snapshots):
-    """Size each leg's AI money impact against the P&L it was competing with.
-
-    On its own "-200 USD" is unreadable — small next to a fortune, huge next to
-    pocket change. The real profit series (cost-basis-netted, so it moves only on
-    P&L and not on deploying capital) is what these calls were up against, and its
-    peak-to-trough swing is the honest denominator: a call worth 0.1% of it did
-    not matter, whatever its benefit score compounded to.
-    """
-    for leg, key in (('US', 'us_profit'), ('HK', 'hk_profit')):
-        node = (impact.get('legs') or {}).get(leg)
-        if not node:
-            continue
-        vals = [s[key] for s in snapshots if s.get(key) is not None]
-        swing = round(max(vals) - min(vals), 2) if len(vals) > 1 else None
-        money = (node.get('all_active') or {}).get('money')
-        node['pnl_swing'] = swing
-        node['share_of_pnl_swing_pct'] = (
-            round(100 * abs(money) / swing, 2) if swing and money else None)
-    return impact
-
-
 def total_snapshots_count():
     return sum(
         1 for p in glob.glob(str(WS_ROOT / 'memory' / 'snapshots' / '*.json'))

--- a/tests/test_bars_freshness.py
+++ b/tests/test_bars_freshness.py
@@ -35,7 +35,8 @@ def test_brief_actually_calls_the_installed_bar_fetcher(monkeypatch):
     result = brief_preflight.refresh_daily_bars()
 
     assert result['ok'] is True
-    assert calls[0][0] == ['clawock', 'daily-bars']
+    # #918：走本解释器的 -m，不再依赖 PATH 上的 console script。
+    assert calls[0][0] == [sys.executable, '-m', 'clawock', 'daily-bars']
     assert calls[0][1]['cwd'] == brief_preflight.WS
 
 

--- a/tests/test_brief_data_ownership.py
+++ b/tests/test_brief_data_ownership.py
@@ -70,8 +70,16 @@ def test_preflight_writes_are_committed():
 
 
 def _preflight_utilities():
-    """The packaged commands preflight shells out to, read from its own source."""
-    return sorted(set(re.findall(r"\[\s*'clawock',\s*'([a-z0-9-]+)'", PREFLIGHT)))
+    """The packaged commands preflight shells out to, read from its own source.
+
+    The spawn shape moved twice: `scripts/data/<name>.py` → `['clawock', cmd]`
+    (#429) → `clawock_argv(cmd)` (#918, so the command runs through *this*
+    interpreter instead of whatever the PATH has). Both times the pattern had
+    to follow, and the failure mode of not following is this discovery quietly
+    returning nothing — which is what the anti-vacuity assertion below exists
+    to catch.
+    """
+    return sorted(set(re.findall(r"clawock_argv\(\s*'([a-z0-9-]+)'", PREFLIGHT)))
 
 
 def _utility_outputs():

--- a/tests/test_brief_preflight_dag.py
+++ b/tests/test_brief_preflight_dag.py
@@ -111,6 +111,42 @@ def _fresh_stamp():
     return datetime.now(timezone.utc).isoformat()
 
 
+def _spawned_command(argv):
+    """Which package command an argv spawns.
+
+    Since #918 preflight spawns ``[sys.executable, '-m', 'clawock', <cmd>, …]``
+    rather than the bare console script, so the command is no longer ``argv[1]``
+    — and reading position 1 would silently classify every spawn as ``-m``,
+    which is how the parallelism assertions below would go quietly vacuous.
+    """
+    argv = [str(a) for a in argv]
+    if 'clawock' in argv:
+        index = argv.index('clawock')
+        if index + 1 < len(argv):
+            return argv[index + 1]
+    return argv[1] if len(argv) > 1 else argv[0]
+
+
+def _filings_tickers(argv):
+    """Tickers in a `filings` spawn (#918 batch mode: one spawn, N tickers)."""
+    argv = [str(a) for a in argv]
+    index = argv.index('clawock') + 2 if 'clawock' in argv else 1
+    return [a for a in argv[index:] if not a.startswith('-')]
+
+
+def _filings_response(argv, single_payload):
+    """Mirror the CLI's contract: one ticker keeps its shape, N wrap in `batch`.
+
+    The fake has to honour this, otherwise it silently answers a batch request
+    with a single-ticker body and preflight files every US single as failed —
+    which is a defect in the fake, and would read as a defect in the code.
+    """
+    tickers = _filings_tickers(argv)
+    if len(tickers) <= 1:
+        return single_payload
+    return json.dumps({'batch': {t: json.loads(single_payload) for t in tickers}})
+
+
 class _SpawnRecorder:
     """Stands in for subprocess.run and _run_clawock inside preflight."""
 
@@ -123,7 +159,7 @@ class _SpawnRecorder:
         self.max_parallel_filings = 0
 
     def subprocess_run(self, argv, **kwargs):
-        command = argv[1] if len(argv) > 1 else argv[0]
+        command = _spawned_command(argv)
         with self.lock:
             self.calls.append(('subprocess', command, list(argv)))
             self.running[command] += 1
@@ -133,6 +169,8 @@ class _SpawnRecorder:
         try:
             time.sleep(self.delays.get(command, 0))
             rc, out = self.plan.get(command, (0, ''))
+            if command == 'filings' and rc == 0:
+                out = _filings_response(argv, out)
             return subprocess.CompletedProcess(argv, rc, stdout=out, stderr='')
         finally:
             with self.lock:
@@ -307,8 +345,17 @@ def test_wave_nodes_execute_exactly_once_and_respect_edges(tmp_path, monkeypatch
     # settle reads the canonical bar store, so bars finish first
     assert tl.start['_decision_metrics'] >= tl.end['daily_bars_node']
 
-    # SEC filings stay strictly serial inside collect_us_fundamentals
+    # SEC filings stay strictly serial inside collect_us_fundamentals — and
+    # since #918 they are one spawn for the whole list, not one spawn per
+    # ticker: the SEC throttle is an in-process `_last_call`, so N spawns would
+    # each hold their own limiter.
     assert run.recorder.max_parallel_filings == 1
+    filings_spawns = [argv for kind, command, argv in run.recorder.calls
+                      if kind == 'subprocess' and command == 'filings']
+    assert len(filings_spawns) == 1, (
+        f'filings spawned {len(filings_spawns)} times; batch mode means once')
+    assert len(_filings_tickers(filings_spawns[0])) > 1, (
+        'fixture no longer exercises the batch path')
 
     assert run.exit_code == 0
     assert run.issues == []

--- a/tests/test_filings_batch.py
+++ b/tests/test_filings_batch.py
@@ -1,0 +1,46 @@
+"""#918：filings 批量是「一个进程顺序跑」，不是并行。
+
+SEC 限速器是模块内的 `_last_call`，N 个 spawn 就是 N 份限速器 —— 这正是当初
+「不能简单并行」的原因，所以批量入口必须在同一个进程里把 ticker 走完。
+"""
+import json
+
+from clawock.market_data import filings
+
+
+def test_multiple_tickers_share_one_process_and_one_throttle(monkeypatch, capsys):
+    seen = []
+    monkeypatch.setattr(filings, 'get_key_financials',
+                        lambda ticker: seen.append(ticker) or {'Revenues': {ticker: 1}})
+
+    filings.main(['MSFT', 'AAPL', '--financials', '--json'])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert seen == ['MSFT', 'AAPL'], 'batch must run in order, in one process'
+    assert set(payload['batch']) == {'MSFT', 'AAPL'}
+    assert payload['batch']['AAPL']['key_financials'] == {'Revenues': {'AAPL': 1}}
+
+
+def test_one_ticker_keeps_the_single_shape(monkeypatch, capsys):
+    """单只的输出形状一个字不动 —— 否则每个调用方都要按只数切换解析。"""
+    monkeypatch.setattr(filings, 'get_key_financials', lambda ticker: {'Revenues': {}})
+
+    filings.main(['MSFT', '--financials', '--json'])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['ticker'] == 'MSFT'
+    assert 'batch' not in payload
+
+
+def test_a_form_type_list_is_not_mistaken_for_a_ticker(monkeypatch, capsys):
+    """`--filings 8-K,10-Q` 的表单清单也是位置参数，不能被当成第二只票。"""
+    monkeypatch.setattr(filings, 'get_filings',
+                        lambda ticker, form_types=None, limit=20: [
+                            {'form': form_types[0] if form_types else 'ANY'}])
+
+    filings.main(['MSFT', '--filings', '8-K,10-Q', '--json'])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['ticker'] == 'MSFT'
+    assert 'batch' not in payload
+    assert payload['filings'] == [{'form': '8-K'}]

--- a/tests/test_harness_anomaly_parser.py
+++ b/tests/test_harness_anomaly_parser.py
@@ -1,0 +1,45 @@
+"""#918：≥3% 异动行只有一份解析实现。
+
+report_preflight 与 intraday_preflight 曾各存一份逐行相同的表格解析，且两份
+输出的每行字段已经漂开（severity vs reason）。合并的判据不是「代码短了」，
+而是「两边读到的东西不变，且改一次表格形状不用改两处」。
+"""
+from clawock.harness import _harness_common, intraday_preflight, report_preflight
+
+
+TABLE = "\n".join([
+    "| 代码 | 股数 | 成本 | 现价 | 今日 | 盈亏% | 盈亏 |",
+    "| :--- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| 00100 | 60 | 822.83 | 722.00 | +5.1% | -12.2% | -6,050 |",
+    "| RKLB |  5 |  71.00 | 134.28 | -3.2% | +89.1% |   +316 |",
+    "| SPCX |  9 | 135.00 | 138.00 | +0.4% |  +2.2% |    +27 |",
+    "not a table row at all",
+])
+
+
+def test_both_preflights_read_the_same_rows():
+    assert (intraday_preflight.parse_anomalies(TABLE)
+            == report_preflight.parse_anomalies(TABLE)
+            == _harness_common.parse_holdings_anomalies(TABLE))
+
+
+def test_the_row_keeps_every_key_either_side_used_to_emit():
+    rows = _harness_common.parse_holdings_anomalies(TABLE)
+
+    assert [r["ticker"] for r in rows] == ["00100", "RKLB"], "≥3% 才算，表头/分隔行不算"
+    severe, mild = rows
+    # intraday 侧读 severity（下游 add_side 也读它）；report 侧读 reason。
+    assert (severe["severity"], severe["reason"]) == ("high", "跳空/异动")
+    assert (mild["severity"], mild["reason"]) == ("medium", "日内大幅波动")
+    # 方向保留在符号里，不在文案里。
+    assert severe["move_pct"] == 5.1 and mild["move_pct"] == -3.2
+
+
+def test_the_thresholds_are_named_not_scattered():
+    assert _harness_common.ANOMALY_MOVE_PCT == 3.0
+    assert _harness_common.ANOMALY_SEVERE_PCT == 5.0
+    # 边界：正好 3.0% 算异动，2.9% 不算（合并前后同一条闸）。
+    at_floor = "| AAA | 1 | 1.00 | 1.00 | +3.0% | +0.0% | 0 |"
+    below = "| BBB | 1 | 1.00 | 1.00 | +2.9% | +0.0% | 0 |"
+    assert [r["ticker"] for r in _harness_common.parse_holdings_anomalies(at_floor)] == ["AAA"]
+    assert _harness_common.parse_holdings_anomalies(below) == []


### PR DESCRIPTION
#918 四项做掉三项。第四项（`parse_signals` 的 gate 语义）按 issue 自己的约定留给 kcn 裁 —— 见文末。

## 1. filings 批量化（不是并行）

SEC 限速器是 `market_data/filings.py` 模块内的 `_last_call`：**N 个 spawn 就是 N 份限速器**，实际请求速率是声明值的 N 倍 —— 这正是 issue 里「不能简单并行」那句话的意思。

- `clawock filings A B C --financials --json`：一个进程顺序跑，共用同一个 `_throttle`。**单只输出形状一个字不动**，两只以上另包一层 `batch`（调用方不必按只数切换解析）。
- 顺带修 `_parse_args` 一处：`--filings 8-K,10-Q` 的表单清单也是位置参数，支持多 ticker 之后它会被当成第二只票，先排掉。
- `collect_us_fundamentals` 从「每票一个 spawn」改成一次 spawn，超时按只数给（`20s × n`），别让第五只挤第一只的预算。

## 2. 裸 `clawock` 子进程统一走本解释器

`[sys.executable, '-m', 'clawock', …]`，覆盖 brief_preflight 15 处 + `_harness_common` 的 flock 那处 + `gold/update` 两处。

console script 依赖 PATH，**而失败是安静的**：user crontab 的 `PATH=/usr/bin:/bin` 下入口点根本不在，`FileNotFoundError` 被调用方的宽 `except` 吞掉，步骤报告自己没出问题 —— `gold/update._console` 的注释记的就是这个事故。改成 `-m` 之后跑的就是这里 import 的那份包，没有第二份安装要同步，`_console` 随之退场。

## 3. 死代码

- `publish/dashboard._attach_pnl_swing` —— 金额曲线撤掉后无人调用，它写的 `pnl_swing` / `share_of_pnl_swing_pct` 也无人读；
- `add_alpha_walkforward._digest` —— 上一个 PR（#1024）把摘要口径改成完整序列后失去引用；
- `gold/update._console` 与随之无用的 `shutil` 导入。

判据是全仓 AST 扫描（私有函数全库引用计数 ≤1），扫出来的候选只有 `_attach_pnl_swing` 一个 —— 死代码这一项本来就不大。

## 4. parser 统一：做了安全的一半，另一半留给 kcn

**做了**：`parse_anomalies` 两份**逐行相同**的实现合到 `_harness_common.parse_holdings_anomalies`。两份此前已经在「每行发什么」上漂开（intraday 发 `severity`、report 发 `reason`），合并后**两个键都发**（下游 `add_side` 读 `severity`，report 的输出契约读 `reason`），3%/5% 提成具名常量。**闸本身不动** —— 搬家不是重谈阈值的场合。

**没做，需要 kcn 一句话**：两个 `parse_signals` **语义不同** ——

| | intraday_preflight | report_preflight |
|---|---|---|
| 计数来源 | `read_signal_line()`，含 **ALERT** | 字符串匹配 WATCH/STOP/TRIM，**ALERT 不计** |
| 返回 | `(counts, signals_detail)` | `counts` |

ALERT 是渲染端最严重的一行（-8% 那种）。intraday 侧当初专门修过「ALERT 不在任何计数里 ⇒ 比 STOP 还高的那一档对所有消费者不可见」；report 侧现在仍是旧行为。合并 = 让港股/美股各档**报告**的告警口径变严，这是 gate 语义改动，不是清理。要不要跟着改，kcn 定。

## 验证

- 新增 `tests/test_filings_batch.py`：批量在一个进程里顺序跑（断言调用顺序）、单只形状不变、表单清单不被当 ticker。
- 新增 `tests/test_harness_anomaly_parser.py`：两个 preflight 与共享实现逐行相同、每个键都保住、3.0% 与 2.9% 的边界。
- `tests/test_brief_preflight_dag.py`：fake 跟上新的 argv 形状（否则命令名会被读成 `-m`，并行断言会静默变恒真）与 batch 契约，并新增「filings 只 spawn 一次、且 fixture 确实是多只」的断言。
- `tests/test_bars_freshness.py` / `tests/test_brief_data_ownership.py`：发现式断言跟上 `clawock_argv(` —— 后者不跟上就会退回「发现 0 个 utility」的空转，那正是它自己注释里记的旧事故。
- 本地全量 `pytest tests`：**2642 passed / 1 failed**，唯一那条是 `test_safe_push_refuses_the_money_file_when_the_checker_is_missing` —— **本机环境导致，与本 PR 无关**：它把 PATH 掐成 `/usr/bin:/bin` 来模拟「钱闸检查器不在」，而本机 clawock 是系统级安装、`/usr/bin/python3` 仍能 import 到，于是检查器照跑（输出里就是「✅ 数据体检全过」）。在 master 与另一个 worktree 上背靠背复测同样失败。
