### PR TITLE
signals: 两个 harness 的信号计数合一，按语义分档而不是硬匹配（#918 收尾）

### DIFF
--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -498,3 +498,89 @@ def parse_holdings_anomalies(stdout):
             'reason': '跳空/异动' if severe else '日内大幅波动',
         })
     return anomalies
+
+
+# ── rendered signal lines ─────────────────────────────────────────────────
+# One reader for both harnesses (#918). The two used to differ in a way that
+# left each leg with its own blind spot:
+#
+#   * intraday matched whole tokens against ('ALERT','WATCH','STOP','TRIM'),
+#     so it never saw the **US** renderer's label, which is `STOP-LOSS`
+#     (`us_analysis.generate_signal`). Verified on the 2026-08-25 US close
+#     block: two `▼ STOP-LOSS …` lines counted as zero, and `decide_alert`
+#     wakes on `stop + alert`, so a US position hitting its stop line could
+#     pass a slot in silence.
+#   * report matched substrings (`'WATCH' in line`), which caught STOP-LOSS by
+#     accident but also reads `WATCHDOG` as a WATCH signal and never counted
+#     ALERT at all — the one level that outranks STOP.
+#
+# So: whole-token match (never a substring), against the vocabulary *both*
+# renderers actually emit. Severity is the level, not the spelling.
+SIGNAL_LEVELS = ('ALERT', 'WATCH', 'STOP', 'TRIM')
+
+# Rendered word (letters only, so `✋STOP?` / `STOP?` / `STOP-LOSS` all land)
+# → canonical level. HK writes `ALERT / WATCH / TRIM / STOP?`, US writes
+# `WATCH / TRIM / STOP-LOSS` (plus BUY/HOLD variants, which are not risk
+# signals and are deliberately absent here).
+SIGNAL_WORDS = {
+    'ALERT': 'ALERT',
+    'WATCH': 'WATCH',
+    'TRIM': 'TRIM',
+    'STOP': 'STOP',
+    'STOPLOSS': 'STOP',
+}
+
+_SIGNAL_SECTION = '⚠️ 信号'
+_REASON_BULLETS = ('·', '•', '-')
+_SECTION_ENDS = ('📉', '📰')
+
+
+def read_signal_line(line):
+    """`(level, ticker)` for a rendered signal line, or `(None, None)`.
+
+    Both renderers write `<marker> <LEVEL> <ticker> | …`, so the level is one
+    of the first two tokens — it never merely *appears inside* one. That
+    distinction is the whole point: `WATCHDOG` contains WATCH, and a substring
+    test reads that line as a signal and publishes the next word as its ticker.
+    """
+    tokens = (line or '').split()
+    # `· …` 是渲染器给理由行用的续行标记，不是一条信号 —— 理由文案里出现
+    # STOP/WATCH 这类词是正常的（「浮亏 -31.0% 警惕止损」那种），跟着数就会
+    # 把一条信号数成两条。
+    if tokens and tokens[0] in _REASON_BULLETS:
+        return None, None
+    for index, token in enumerate(tokens[:2]):
+        word = re.sub(r'[^A-Z]', '', token.upper())
+        level = SIGNAL_WORDS.get(word)
+        if level:
+            ticker = tokens[index + 1] if index + 1 < len(tokens) else None
+            return level, ticker
+    return None, None
+
+
+def parse_signal_lines(stdout):
+    """`(counts, detail)` over the rendered `⚠️ 信号` block.
+
+    The block runs until the risk (`📉`) or news (`📰`) line. Reason lines
+    inside it are indented `· …` continuations and carry no level, so they
+    fall out on their own.
+    """
+    counts = {level.lower(): 0 for level in SIGNAL_LEVELS}
+    detail = []
+    in_signals = False
+    for line in (stdout or '').splitlines():
+        if _SIGNAL_SECTION in line or line.strip() == '信号':
+            in_signals = True
+            continue
+        if not in_signals:
+            continue
+        stripped = line.strip()
+        if stripped.startswith(_SECTION_ENDS):
+            break
+        if not stripped:
+            continue
+        level, ticker = read_signal_line(stripped)
+        if level:
+            counts[level.lower()] += 1
+            detail.append({'level': level, 'line': stripped, 'ticker': ticker})
+    return counts, detail

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -84,54 +84,16 @@ def _fetch_bars_cached(code, cnt=400):
 # runs under cron, whose PATH is /usr/bin:/bin (#438, #443).
 
 
-SIGNAL_LEVELS = ('ALERT', 'WATCH', 'STOP', 'TRIM')
-
-
-def read_signal_line(line):
-    """`(level, ticker)` for a rendered signal line, or `(None, None)`.
-
-    The renderer writes `✋ STOP? 02208 金风科技 | …` — marker, level, code. The
-    level must therefore *be* one of the first two tokens, not appear inside
-    one: `WATCHDOG` contains WATCH and a substring test reads that line as a
-    signal, then publishes the following word as its ticker. Letters only, so
-    `✋STOP?` and `STOP?` both normalise to STOP however the emoji lands.
-
-    Reading the code here, once, is also what keeps consumers from matching the
-    display text — a substring test lets a one-letter US ticker match any word
-    on the line, and reads a bare figure in the P&L cell as a code.
-    """
-    tokens = (line or '').split()
-    for index, token in enumerate(tokens[:2]):
-        word = re.sub(r'[^A-Z]', '', token.upper())
-        if word in SIGNAL_LEVELS:
-            ticker = tokens[index + 1] if index + 1 < len(tokens) else None
-            return word, ticker
-    return None, None
+# 信号词表/读行/分段都在 _harness_common（#918：两个 preflight 曾各存一份，
+# 且各自有盲区 —— 这边不认 US 的 `STOP-LOSS`，那边拿子串匹配把 `WATCHDOG`
+# 读成 WATCH）。这里只保留名字，consumer 与测试引用的是这些。
+SIGNAL_LEVELS = _harness_common.SIGNAL_LEVELS
+read_signal_line = _harness_common.read_signal_line
 
 
 def parse_signals(stdout):
-    counts = {level.lower(): 0 for level in SIGNAL_LEVELS}
-    in_signals = False
-    signals_detail = []
-    for line in stdout.splitlines():
-        if '⚠️ 信号' in line:
-            in_signals = True
-            continue
-        if in_signals:
-            s = line.strip()
-            if s.startswith('📉') or s.startswith('📰'):
-                break
-            if not s:
-                continue
-            # ALERT is the most severe line the renderer emits (a -8% day) and
-            # it was in none of these counts — so the one level that outranks
-            # STOP was invisible to every consumer, including the entry/risk
-            # contradiction check below.
-            level, ticker = read_signal_line(s)
-            if level:
-                counts[level.lower()] += 1
-                signals_detail.append({'level': level, 'line': s, 'ticker': ticker})
-    return counts, signals_detail
+    """`(counts, detail)` —— 实现在 _harness_common.parse_signal_lines。"""
+    return _harness_common.parse_signal_lines(stdout)
 
 
 def decide_alert(signals, anomalies):

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -39,7 +39,7 @@ Output keys:
   plan_context:       {plan_date, exec_mode, open[<=12], carried_over} — what the
                       08:00 brief already decided for this leg and has not filled
                       yet; {} when there is no open decision (see plan_surface)
-  needs_risk_section: bool (true if STOP+TRIM >= 2)
+  needs_risk_section: bool (true if any ALERT, or STOP+TRIM >= 2)
 """
 
 from clawock.harness import _harness_common
@@ -209,24 +209,14 @@ COMMIT_PHASE_CN = {
 
 
 def parse_signals(stdout):
-    """Count WATCH/STOP/TRIM markers in the signals section."""
-    counts = {'watch': 0, 'stop': 0, 'trim': 0}
-    in_signals = False
-    for line in stdout.splitlines():
-        if '⚠️ 信号' in line or '信号' == line.strip():
-            in_signals = True
-            continue
-        if in_signals:
-            if line.startswith('📉') or line.startswith('📰') or not line.strip():
-                if line.startswith('📉') or line.startswith('📰'):
-                    break
-                continue
-            if 'WATCH' in line:
-                counts['watch'] += 1
-            elif 'STOP' in line:
-                counts['stop'] += 1
-            elif 'TRIM' in line:
-                counts['trim'] += 1
+    """本档的信号计数。实现在 _harness_common（#918）。
+
+    换成语义读行之后这份计数有两处真实变化，都不是重构副作用：
+    ALERT 第一次进得来（HK 渲染器 -8% 那档，此前这里一个字都不数），
+    而 `WATCHDOG` 这类含有 WATCH 子串的行不再被数成 WATCH。
+    US 的 `STOP-LOSS` 仍然算 STOP —— 词表认的是两个渲染器都会写的词。
+    """
+    counts, _detail = _harness_common.parse_signal_lines(stdout)
     return counts
 
 
@@ -372,7 +362,11 @@ def main(argv=None):
         'plan_context':       plan_ctx,
         'mover_thesis':       mover_thesis,
         'mover_news':         mover_news_ctx,
-        'needs_risk_section': (signals['stop'] + signals['trim']) >= 2,
+        # 语义分档，不是数数（kcn 2026-08-26：「根据合适的语意来告警，不要做
+        # 硬匹配」）：ALERT 是渲染端最严重的一行（当日 -8%），它单独一条就压
+        # 过两条 STOP/TRIM，所以它自己就要一段风险提示。
+        'needs_risk_section': (signals['alert'] >= 1
+                               or (signals['stop'] + signals['trim']) >= 2),
     }
     result['context_id'] = compute_context_id(result)
 

--- a/tests/test_harness_signal_parser.py
+++ b/tests/test_harness_signal_parser.py
@@ -1,0 +1,107 @@
+"""#918 收尾：两个 harness 的信号计数只有一份实现，且按**语义**分档。
+
+kcn 2026-08-26：「可以根据合适的语意来告警，不要做硬匹配」。
+
+合并前两份各有盲区，方向相反：
+  * intraday 按整词匹配 ('ALERT','WATCH','STOP','TRIM')，**不认 US 渲染器写的
+    `STOP-LOSS`** —— 2026-08-25 美股收盘那份真实 block 里两行 STOP-LOSS 被数成 0，
+    而 `decide_alert` 醒不醒看 `stop + alert`；
+  * report 用子串匹配（`'WATCH' in line`），顺手把 STOP-LOSS catch 住了，但也会把
+    `WATCHDOG` 读成 WATCH，且 **ALERT 一个都不数** —— 比 STOP 还高的那一档。
+"""
+from pathlib import Path
+
+from clawock.harness import _harness_common as common
+from clawock.harness import intraday_preflight, report_preflight
+
+
+# 两段都是渲染器真实写出来的形状（hk_analysis / us_analysis 的 f-string）：
+# HK 是 `<emoji> LEVEL <code> <name> | …`，US 是 `<arrow> LEVEL <ticker> | …`
+# 外加缩进的 `· 理由` 续行。
+US_BLOCK = "\n".join([
+    "📊 美股持仓",
+    "",
+    "⚠️ 信号",
+    "  ▼ STOP-LOSS RKLX | 今日-11.9% 浮-65.1%",
+    "     · 价格低于MA20 -17.9%",
+    "     · 跌破MA50",
+    "  ▼ STOP-LOSS SPCH | 今日-2.9% 浮-31.0%",
+    "     · 浮亏 -31.0% 警惕止损",
+    "",
+    "📉 亏损持仓 5/6  |  杠杆ETF敞口 85%",
+])
+
+HK_BLOCK = "\n".join([
+    "⚠️ 信号",
+    "  ⚠️ ALERT 07226 南方2倍做多 | 今日-8.3% 浮-26.3%",
+    "  △ WATCH 00100 MINIMA | 今日-5.1% 浮-46.5%",
+    "  ✋ STOP? 02208 金风科技 | 今日-0.7% 浮-33.6%",
+    "",
+    "📉 亏损持仓 4/5  |  2x杠杆敞口 30%",
+])
+
+
+def test_the_us_stop_loss_line_is_a_stop_on_both_sides():
+    """这条就是合并前 intraday 的盲区：真实 US block 里两行止损被数成 0。"""
+    counts, detail = common.parse_signal_lines(US_BLOCK)
+
+    assert counts == {"alert": 0, "watch": 0, "stop": 2, "trim": 0}
+    assert [row["ticker"] for row in detail] == ["RKLX", "SPCH"]
+    assert intraday_preflight.parse_signals(US_BLOCK)[0] == counts
+    assert report_preflight.parse_signals(US_BLOCK) == counts
+
+
+def test_alert_reaches_the_report_side_too():
+    """ALERT 是渲染端最严重的一行，report 侧此前一个字都不数。"""
+    counts = report_preflight.parse_signals(HK_BLOCK)
+
+    assert counts == {"alert": 1, "watch": 1, "stop": 1, "trim": 0}
+    assert intraday_preflight.parse_signals(HK_BLOCK)[0] == counts
+
+
+def test_a_word_that_merely_contains_a_level_is_not_a_signal():
+    """不做硬匹配：WATCHDOG 含 WATCH，子串测试会把它读成信号并把下一个词当代码。"""
+    block = "\n".join([
+        "⚠️ 信号",
+        "  ─ WATCHDOG 备注 | 这行不是信号",
+        "  · STOP 出现在理由行里也不算",
+        "📉 收尾",
+    ])
+
+    counts, detail = common.parse_signal_lines(block)
+
+    assert counts == {"alert": 0, "watch": 0, "stop": 0, "trim": 0}
+    assert detail == []
+
+
+def test_the_section_ends_where_the_renderer_ends_it():
+    """信号段之外的 STOP 字样不能被数进来（📉 风险行、📰 新闻段）。"""
+    block = "\n".join([
+        "⚠️ 信号",
+        "  ✋ STOP? 02208 金风科技 | 今日-0.7% 浮-33.6%",
+        "📉 亏损持仓 4/5",
+        "  ✋ STOP? 09999 段外的行 | 不该被数",
+        "📰 新闻",
+        "  ⚠️ ALERT 08888 也不该被数 | ",
+    ])
+
+    counts, _ = common.parse_signal_lines(block)
+
+    assert counts == {"alert": 0, "watch": 0, "stop": 1, "trim": 0}
+
+
+def test_one_alert_alone_asks_for_a_risk_section():
+    """语义分档：ALERT 压过两条 STOP/TRIM，它自己就要一段风险提示。
+
+    钉的是判据本身（`needs_risk_section` 的表达式），不是某次 preflight 的产物 ——
+    后者要跑整条行情链路才生得出来。
+    """
+    def gate(counts):
+        return counts["alert"] >= 1 or (counts["stop"] + counts["trim"]) >= 2
+
+    assert gate({"alert": 1, "watch": 0, "stop": 0, "trim": 0}) is True
+    assert gate({"alert": 0, "watch": 0, "stop": 1, "trim": 1}) is True
+    assert gate({"alert": 0, "watch": 3, "stop": 1, "trim": 0}) is False
+    # 与生产代码同源：闸的表达式改了，这条要跟着红。
+    source = Path(report_preflight.__file__).read_text(encoding="utf-8")
+    assert "signals['alert'] >= 1" in source


### PR DESCRIPTION
#918 的最后一项。kcn 2026-08-26：「可以根据合适的语意来告警，不要做硬匹配」。

## 合并前两份实现各有盲区，方向相反

| | `intraday_preflight` | `report_preflight` |
|---|---|---|
| 匹配方式 | 整词（`token in ('ALERT','WATCH','STOP','TRIM')`） | **子串**（`'WATCH' in line`） |
| US 的 `STOP-LOSS` | **数不到**（词表里只有 `STOP`） | 数得到（子串巧合） |
| `ALERT` | 数得到 | **一条都不数** |
| `WATCHDOG` 这类词 | 不算信号 | **算成 WATCH**，并把下一个词当代码 |

**intraday 那半是活的缺陷，不是洁癖**。拿 2026-08-25 美股收盘那份真实 block 实测：

```
⚠️ 信号
  ▼ STOP-LOSS RKLX | 今日-11.9% 浮-65.1%
  ▼ STOP-LOSS SPCH | 今日-2.9% 浮-31.0%
```

- 合并前：`intraday.parse_signals` → `{'alert':0,'watch':0,'stop':0,'trim':0}`
- 合并后：`{'alert':0,'watch':0,'stop':2,'trim':0}`

而 `decide_alert` 醒不醒看的是 `stop + alert` ⇒ **美股持仓跌穿止损线的那一档，盘中盯盘可以一声不吭地过去**。今天 SPCH 那行正是这个形状：今日 −2.9% 够不着 ≥3% 的异动闸，止损信号又不进计数，两条路都不响。

## 改法

`_harness_common.parse_signal_lines(stdout)` 一份实现，两个 preflight 都走它：

- **整词匹配，永不子串**；词表认两个渲染器**实际会写**的词 —— HK 的 `ALERT / WATCH / TRIM / STOP?`（`hk_analysis.signal`）与 US 的 `WATCH / TRIM / STOP-LOSS`（`us_analysis.generate_signal`），`STOPLOSS → STOP` 同档。BUY/HOLD 系列不是风险信号，词表里没有。
- `· 理由` 续行不算信号 —— 理由文案里出现「警惕止损」这种词是正常的，跟着数会把一条信号数成两条。
- 段落边界仍用渲染器自己的 `📉` / `📰`。

**告警语义（不是数数）**：report 的 `needs_risk_section` 从 `STOP+TRIM >= 2` 改成 `ALERT >= 1 or STOP+TRIM >= 2`。ALERT 是当日 −8% 那一档，一条就压过两条 STOP/TRIM，它自己就该要一段风险提示。

## 影响面

- 盘中盯盘：美股止损档现在会进 `stop` 计数，`decide_alert` 因此可能多醒 —— 这正是要的（此前是漏醒）。
- 各档报告：`signal_count` 多一个 `alert` 键（加键，不改既有键语义）；`needs_risk_section` 在有 ALERT 的档变 true。
- `intraday_delta.semantic_state` 读的 `signals_detail` 形状不变。

## 测试

`tests/test_harness_signal_parser.py` 五条，fixture 用两个渲染器**真实写出的行形状**（含 US 的 `· 理由` 续行）：

1. US `STOP-LOSS` 两侧都数得到，且 ticker 解析成 RKLX / SPCH；
2. `ALERT` 进得了 report 侧；
3. `WATCHDOG` 不算信号（不做硬匹配这条的直接闸）；
4. 段外（📉 之后、📰 之后）的 STOP/ALERT 不算；
5. 单条 ALERT 触发风险段，且断言与生产代码里的表达式同源 —— 闸改了这条要跟着红。

`pytest -k "intraday or report or signal or preflight or harness or delta"`：489 passed。