### PR TITLE
fix: 把会在午夜自己变红的日期断言修掉，并加一条闸挡住这一类（master CI 已红）

### DIFF
--- a/tests/test_analyze_hk_stocks.py
+++ b/tests/test_analyze_hk_stocks.py
@@ -212,6 +212,18 @@ def test_parse_gtimg_without_volume_field_does_not_fabricate_volume():
 def test_update_hk_portfolio_stamps_prev_close_to_prior_session_and_writes_volume(
     tmp_path, monkeypatch
 ):
+    """前收日必须是**上一个**港股交易日，永远不是今天（#1021 修的就是这个）。
+
+    夹具里的日期从真实时钟推出来，不写死：写死 "2026-08-25" 的那一版在
+    2026-08-26 00:00 HKT 整条 master 变红 —— 它当时代表「今天」，第二天就
+    代表「上一个交易日」，断言的意思跟着翻了个面。测试里的日期字面量和文案
+    里的实时数字是同一类东西：都会过期。
+    """
+    now_hkt = datetime.now(timezone(timedelta(hours=8)))
+    today = now_hkt.date().isoformat()
+    prior_session = hk.trading_calendar.previous_trading_day(
+        "hk", now_hkt.date()).isoformat()
+
     port = {
         "portfolios": {
             "hk_stocks": {
@@ -222,8 +234,9 @@ def test_update_hk_portfolio_stamps_prev_close_to_prior_session_and_writes_volum
                         "cost_basis": 300.0,
                         "current_price": 312.0,
                         "prev_close": 312.2,
-                        "prev_close_date": "2026-08-25",
-                        "day_session_date": "2026-08-25",
+                        # 坏状态：前收日 == 当日 session，正是要被修掉的那个
+                        "prev_close_date": today,
+                        "day_session_date": today,
                         "day_open": 312.0,
                         "day_high": 323.6,
                         "day_low": 290.4,
@@ -258,10 +271,8 @@ def test_update_hk_portfolio_stamps_prev_close_to_prior_session_and_writes_volum
 
     # prev_close_date must be the PRIOR HK trading session, never today — this
     # is the fix that re-arms integrity's STALE_PRICE gate.
-    assert h["prev_close_date"] != "2026-08-25"
-    now_hkt = datetime.now(timezone(timedelta(hours=8)))
-    expected = hk.trading_calendar.previous_trading_day("hk", now_hkt.date()).isoformat()
-    assert h["prev_close_date"] == expected
+    assert h["prev_close_date"] == prior_session
+    assert h["prev_close_date"] != today
     assert h["prev_close_date"] < h["day_session_date"]
 
     # Volume must be overwritten with the real traded volume from Tencent

--- a/tests/test_time_dependent_assertions.py
+++ b/tests/test_time_dependent_assertions.py
@@ -1,0 +1,59 @@
+"""闸：读实时时钟的测试，不许和日期字面量对断言。
+
+2026-08-26 00:00 HKT，master 的 CI 自己变红了 —— 没有人改任何代码：
+
+    assert h["prev_close_date"] != "2026-08-25"
+
+写这条的时候 "2026-08-25" 是「今天」，断言的意思是「前收日不能是今天」。
+第二天同一个字面量变成了「上一个交易日」，而被测代码算出来的正是它，于是
+断言的意思翻了个面。测试里的日期字面量与文案里的实时数字是同一类东西：
+都会过期，而且过期的时候**看起来仍然像在守规矩**。
+
+规则不是「测试里不许写日期」——夹具里当然要写。规则是：**同一个测试里，
+不能一边让被测代码读真实时钟，一边拿字面量当期望值**。要么冻住时钟（把
+now 传进去 / monkeypatch），要么从同一个时钟推出期望值。
+"""
+import ast
+import re
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+LIVE_CLOCK = ("datetime.now(", "date.today(")
+DATE_LITERAL = re.compile(r"assert[^\n]*[\"']20\d\d-\d\d-\d\d")
+
+
+def _offenders():
+    found = []
+    for path in sorted(TESTS.glob("*.py")):
+        # 本文件里那段样本是字符串常量，不是断言 —— 扫描自己会把它读成违例。
+        if path.name == Path(__file__).name:
+            continue
+        source = path.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test"):
+                continue
+            body = "\n".join(lines[node.lineno - 1:node.end_lineno])
+            if any(call in body for call in LIVE_CLOCK) and DATE_LITERAL.search(body):
+                found.append(f"{path.name}::{node.name}")
+    return found
+
+
+def test_no_test_compares_a_live_clock_against_a_date_literal():
+    assert _offenders() == [], (
+        "这些测试同时读了真实时钟并对日期字面量断言，它们会在某个午夜自己变红："
+        f"{_offenders()}。修法：冻住时钟，或者用同一个时钟推出期望值。")
+
+
+def test_the_scanner_can_actually_see_an_offender():
+    """反空转：上面那条闸必须真的能抓到东西，否则它就是一条恒真断言。"""
+    sample = (
+        "def test_sample():\n"
+        "    now = datetime.now(timezone.utc)\n"
+        "    assert row['session'] == \"2026-08-25\"\n"
+    )
+    lines = sample.splitlines()
+    node = ast.parse(sample).body[0]
+    body = "\n".join(lines[node.lineno - 1:node.end_lineno])
+    assert any(call in body for call in LIVE_CLOCK)
+    assert DATE_LITERAL.search(body)


### PR DESCRIPTION
**master 的 CI 现在是红的**，而且没有人改过任何代码 —— 2026-08-26 00:00 HKT 一过就红了。

```
tests/test_analyze_hk_stocks.py:261
assert h["prev_close_date"] != "2026-08-25"
E   AssertionError: assert '2026-08-25' != '2026-08-25'
```

（失败的 run：`CI / validate / Unit tests — money-integrity derivations`，master 与所有从它拉出去的分支都会带着这条红。）

## 为什么会这样

写这条的时候（#1021，08-25）`"2026-08-25"` 代表**今天**，断言的意思是「前收日不能是今天」。跨过午夜之后，同一个字面量代表的是**上一个交易日** —— 而被测代码算出来的正是它。断言的字面没变，**意思翻了个面**。

同一个函数里第三条 `prev_close_date < day_session_date` 也一起失效：夹具里的 `day_session_date` 是同一个写死的日子。

## 改法

夹具与期望值都从**同一个真实时钟**推出来：

- 坏状态（#1021 要修掉的那个）用「`prev_close_date == 今天`」构造；
- 期望值用 `trading_calendar.previous_trading_day('hk', today)`；
- 再断言它 `!= 今天`、且 `< day_session_date`。

任何一天跑都成立，周末也成立（上一个交易日是周五，严格早于周日）。

## 顺手加一条闸

`tests/test_time_dependent_assertions.py`：**同一个测试里，不许一边让被测代码读真实时钟、一边拿日期字面量当期望值**。

规则不是「测试里不许写日期」——夹具里当然要写。挡的是「读实时钟 + 字面量期望」这个组合：它是一颗定时炸弹，而且爆炸之前**看起来仍然像在守规矩**（绿的，而且天天绿）。全仓扫下来，修完这条之后是 **0 处违例**；闸自带反空转样本（构造一个违例，断言扫描器确实认得出）。

这和仓里既有的「静态文案不许引用会变的数字」是同一条判据的第二个载体 —— 测试断言。