### PR TITLE
fix: GIF 调色板种子化，修 README hero 动图发灰 (#1030)

### DIFF
--- a/site/tools/assemble_dashboard_gif.py
+++ b/site/tools/assemble_dashboard_gif.py
@@ -40,6 +40,29 @@ HOLD_BOTTOM_MS = 850         # pause once scrolled to the bottom
 VSCROLL_MS = 110     # each vertical-scroll frame
 SLIDE_MS = 80        # each horizontal-slide frame
 
+SEED_GLOBS = [       # where the UI's own chromatic colors are defined; scanned so
+                     # their exact values can be protected in the GIF palette below
+    os.path.join("site", "assets", "css", "dashboard.css"),
+    os.path.join("site", "_layouts", "default.html"),
+    os.path.join("site", "assets", "js", "*.js"),
+]
+
+
+def _ui_seed_colors():
+    """Exact chromatic hex colors the shipped dashboard sources define."""
+    found = set()
+    for pattern in SEED_GLOBS:
+        for path in glob.glob(os.path.join(ROOT, pattern)):
+            try:
+                text = open(path, encoding="utf-8", errors="ignore").read()
+            except OSError:
+                continue
+            for hx in re.findall(r"#[0-9a-fA-F]{6}\b", text):
+                color = tuple(int(hx[i:i + 2], 16) for i in (1, 3, 5))
+                if max(color) - min(color) > 40:   # chromatic only: neutrals quantize fine
+                    found.add(color)
+    return sorted(found)
+
 
 def _ease(t):        # ease-in-out cubic — smooth start & stop
     return 4 * t ** 3 if t < 0.5 else 1 - (-2 * t + 2) ** 3 / 2
@@ -83,13 +106,31 @@ for i in range(6):
         frames.append(canvas)
         durations.append(SLIDE_MS)
 
-# One global adaptive palette derived from every frame → colors stay true and stable
+# One global palette derived from every frame → colors stay true and stable
 # across frames (per-frame palettes drift toward grey and flicker). No dither: the UI
 # is flat color, and dithering just adds noise + bloats the file.
+#
+# MEDIANCUT alone washed the accents out: ~95% of every frame is near-white, so its
+# population-based box split spent ~205 of 256 slots on indistinguishable whites and
+# left the whole saturated UI sharing 2-3 muddy entries — #36A3FF mapped ~105 RGB
+# units away, which read as a grey hero animation. Seed the palette with the UI's
+# exact chromatic colors first (echarts' default light palette included — charts use
+# it whenever they don't override the series colors), then let MEDIANCUT fill the
+# rest with the neutrals it is good at; mapping stays nearest-color without dither.
 _stack = Image.new("RGB", (OW, VH * len(frames)))
 for _i, _f in enumerate(frames):
     _stack.paste(_f, (0, VH * _i))
-_pal = _stack.quantize(colors=COLORS, method=Image.MEDIANCUT)
+_seeds = _ui_seed_colors()
+_fill = _stack.quantize(colors=max(32, COLORS - len(_seeds)),
+                        method=Image.MEDIANCUT).getpalette()
+_palette, _seen = [], set()
+for _c in _seeds + list(zip(_fill[0::3], _fill[1::3], _fill[2::3])):
+    if _c not in _seen:
+        _seen.add(_c)
+        _palette.append(_c)
+_pal = Image.new("P", (1, 1))
+_flat = [v for _c in _palette[:COLORS] for v in _c]
+_pal.putpalette(_flat + [0] * (768 - len(_flat)))
 frames = [f.quantize(palette=_pal, dither=Image.Dither.NONE) for f in frames]
 frames[0].save(OUT, save_all=True, append_images=frames[1:],
                duration=durations, loop=0, optimize=True, disposal=2)


### PR DESCRIPTION
Closes #1030

## 改了什么

`site/tools/assemble_dashboard_gif.py` 的调色板构建：先扫 UI 自有源（`dashboard.css`、`_layouts/default.html`、`site/assets/js/*.js`）里 chroma>40 的十六进制色作为**精确种子**（80 个，含 echarts 默认浅色板），剩余席位由 MEDIANCUT 补中性色；映射仍是无抖动最近色，全局单色板/帧结构/duration 全部不变。

## 为什么

MEDIANCUT 按像素量分箱：全帧 ~95% 近白 ⇒ 205/256 席给了不可分辨的浅白差，全部饱和 UI 色共享 2–3 槽，`#36A3FF` 最近距离 105 —— hero 动图发灰的直接机制（#1030 有完整实测）。设计侧 #1002 去蓝后页面更中性，放大了观感。

## 实测（昨晚 #1027 同源真帧）

| 方案 | accent 平均距离 | worst | 体积 | uniq |
|---|---|---|---|---|
| 现行 | 80 | 105 | 8584KB | 108 |
| 本 PR | **0** | **0** | **8122KB** | 109 |

## 验证

- [x] 真帧重拼：72 帧、duration/disposal 不变、accent 距离全 0
- [x] `pytest tests/test_site_tools_contract.py` 5 passed
- [ ] 合并后 `gh workflow run screenshot-refresh` 手动 dispatch 重拍落新 GIF
