### PR TITLE
docs: fix stale product-vs-instance.md pointer in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ policy.
   the maintainer to want it. If the same fix can live in `src/clawock/`, that is
   where it belongs.
 
-`docs/reference/product-vs-instance.md` states the ownership rule per directory.
+`docs/reference/product-profile-operations.md` states the ownership rule per directory.
 The deciding question there is the same one to ask before opening a PR: *would a
 third party running clawock with their own book need this change?*
 


### PR DESCRIPTION
## 背景

md-cleanup 切片审计：对全仓 250 个 tracked `.md`（`git ls-files "*.md"`）建立「文件 × 消费者证据」矩阵后动手修。消费者取证覆盖：全仓 grep（源码/tests/.github/site/README 系/AGENTS/CLAUDE/TOOLS/skills/workflows）、Jekyll front-matter + `_config.yml`、CI validate 步骤、cron payload 注入清单、skill 加载约定。

## 审计结论（矩阵摘要）

- **249/250 有真实消费者或是受保护的 openclaw 原生工作区文件**，全部逐类核实，例如：
  - `config/cron-payloads/*.md` → `src/clawock/scheduling.py:128` + `config/profiles/kcnyu/profile.json:72-74` + tests；
  - `skills/trading/*.md` 子页 → `SKILL.md:78-86` Quick Reference 表内引用；
  - `BOOTSTRAP.md` → `config/root-allowlist.json:24`；`DREAMS.md` → openclaw dreaming diary 标记 + `ops/host/commit_dreaming.sh`；
  - `docs/decision-mind-ledger.md` → `src/clawock/decision/{ledger,record,mind_record}.py` 注释契约 + `tests/test_harness_cli_contract.py:176`；
  - `ops/pages/echarts-custom-bundle.md` → `site/index.html:77`；site 页面均有 front-matter + nav 链接。
- **唯一零消费者文件**：`docs/archive/openclaw-decoupling-plan.md`（自述 archived/superseded、`_config.yml` 显式排除 docs/archive/）。因自带免责横幅、删除 ROI 低且属 archive 政策问题 → 仅建 issue #1033 留 kcn 决策，未删。

## 本 PR 修复（Closes #1032）

`.github/CONTRIBUTING.md:35` 指向的 `docs/reference/product-vs-instance.md` 在 #541 重命名为 `product-profile-operations.md`，漏改此入口。现指向新路径；该段 "deciding question" 文案与新文件 § The deciding question 逐句对应，确认意图一致。单行 docs 改动。

- 修复后 `git grep product-vs-instance`（除 memory 外）零命中。
- 无测试消费 CONTRIBUTING.md（`tests/test_context_contract.py` 的路径契约只覆盖 manifest bootstrap 注入文档，不覆盖 .github/），交由 CI 六项必需检查验证。

## 未动项（仅记录）

- #1033：archive 文件去留由 kcn 定。
