### PR TITLE
fix: signal_review 冻结价闸——断源留痕不再进因子命中率 (#1035) [audit:strategy-review]

### DIFF
--- a/assets/data/quant_signal_review.json
+++ b/assets/data/quant_signal_review.json
@@ -1,32 +1,33 @@
 {
-  "as_of": "2026-08-25",
+  "as_of": "2026-08-26",
   "days_logged": 55,
   "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
+  "frozen_feed_excluded": 77,
   "factors": {
     "trend_on_follow": {
-      "n_events": 40,
-      "n_dates": 40,
+      "n_events": 8,
+      "n_dates": 8,
       "n_tickers": 1,
-      "hit_rate": 0.1,
+      "hit_rate": 0.375,
       "ci95": null,
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
       "reverse_edge_significant": false,
-      "sample_sufficient": true,
+      "sample_sufficient": false,
       "min_n": 20,
       "non_overlap_cap": 55,
       "decision_direction": null,
       "usable": false,
-      "note": "date/ticker 聚类不足，方向结论不入决策"
+      "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "trend_off_avoid": {
-      "n_events": 357,
+      "n_events": 344,
       "n_dates": 50,
       "n_tickers": 10,
-      "hit_rate": 0.485,
+      "hit_rate": 0.5,
       "ci95": [
-        0.36,
-        0.611
+        0.379,
+        0.619
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
@@ -96,13 +97,13 @@
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "stop_breach_continue": {
-      "n_events": 271,
+      "n_events": 239,
       "n_dates": 43,
       "n_tickers": 11,
-      "hit_rate": 0.487,
+      "hit_rate": 0.531,
       "ci95": [
-        0.327,
-        0.653
+        0.379,
+        0.669
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -17,6 +17,13 @@ MIN_N=20 样本不足不得当结论引用，CI 跨 50% 不入决策；低于 50
 CI 整体成立时才允许反向解读。T+5/T+20 窗口逐日重叠 → 披露 non_overlap_cap
 （标的数 × 天数 ÷ horizon），n 超过它时结论打折。
 纯本地文件运算，无网络请求，brief preflight 每日顺跑。
+
+冻结价闸：2026-06/07 的留痕里 RKLB 连续 30 个交易日卡在 114.78、HOOD 卡在
+112.9（写入侧当时还没有 per-row freshness 闸），forward return 对这种冻结对
+恒为 0，把每个因子的命中率系统性压低——trend_on_follow 公开值 10%，其中
+32/40 个观测是伪影。连续多个留痕日同一收盘价在真实市场几乎不出现（周末/
+假日顺延造成的同价 ≤2–3 天），≥4 判为断源：这些 ticker-日不产生任何观测，
+排除量披露在 frozen_feed_excluded，数据本身保留不作改写。
 """
 import json
 import random
@@ -34,6 +41,39 @@ OUT = WS / 'assets' / 'data' / 'quant_signal_review.json'
 # 因子结论可被引用的最小样本量——与 setup_review.MIN_N 同一条纪律。此前文档
 # 承诺「样本<20 不解锁」但代码没有这个闸（#934），小样本假解锁全部偏向高估。
 MIN_N = 20
+
+# 同一标的连续 ≥FROZEN_RUN_MIN 个留痕日收盘价完全相同 = 行情源断流（见
+# docstring 的 RKLB/HOOD 事故）。周末/假日顺延造成的合法同价最多 2–3 天。
+FROZEN_RUN_MIN = 4
+
+
+def frozen_ticker_days(days):
+    """{(ticker, as_of)} 收盘价处在 ≥FROZEN_RUN_MIN 连续同价行程里的 ticker-日。
+
+    只认「完全相等」：真实市场的平盘极少逐分不差，而断流的缓存价必然逐字节
+    相同——这正是 2026-06/07 污染被事后检出的签名。
+    """
+    series = {}
+    for day in days:
+        as_of = day.get('as_of')
+        if not as_of:
+            continue
+        for sym, sig in (day.get('rows') or {}).items():
+            close = (sig or {}).get('close')
+            if close is not None:
+                series.setdefault(sym, []).append((as_of, close))
+    frozen = set()
+    for sym, points in series.items():
+        run = []
+        for as_of, close in points:
+            if run and close != run[-1][1]:
+                if len(run) >= FROZEN_RUN_MIN:
+                    frozen.update((sym, d) for d, _ in run)
+                run = []
+            run.append((as_of, close))
+        if len(run) >= FROZEN_RUN_MIN:
+            frozen.update((sym, d) for d, _ in run)
+    return frozen
 
 # 因子 → (触发条件, 预期方向: +1=涨算命中 / -1=跌算命中, 结算窗口天数)
 FACTOR_TESTS = {
@@ -91,6 +131,8 @@ def main(argv=None):
 
     stats = {k: {'n': 0, 'hits': 0, 'observations': [], 'horizon': h}
              for k, (_, _, h) in FACTOR_TESTS.items()}
+    frozen = frozen_ticker_days(days)
+    frozen_excluded = 0
     for i, day in enumerate(days):
         for sym, sig in (day.get('rows') or {}).items():
             c0 = sig.get('close')
@@ -101,8 +143,13 @@ def main(argv=None):
                     continue          # 窗口未到期，留给未来结算
                 if not cond(sig):
                     continue
-                c1 = ((days[i + horizon].get('rows') or {}).get(sym) or {}).get('close')
+                settle_day = days[i + horizon]
+                c1 = ((settle_day.get('rows') or {}).get(sym) or {}).get('close')
                 if not c1:
+                    continue
+                if (sym, day['as_of']) in frozen or (sym, settle_day['as_of']) in frozen:
+                    # 冻结价观测：fwd 恒 0 或假跳变，两个方向都是伪影。
+                    frozen_excluded += 1
                     continue
                 fwd = c1 / c0 - 1
                 stats[name]['n'] += 1
@@ -167,13 +214,15 @@ def main(argv=None):
                else f'没有因子通过聚类 CI 50% 闸（{len(days)} 天留痕）——结论未解锁')
     out = {'as_of': date.today().isoformat(), 'days_logged': len(days),
            'unlock_rule': 'cluster_ci_entirely_above_or_below_50pct',
+           'frozen_feed_excluded': frozen_excluded,
            'factors': factors, 'summary': summary,
            'discipline': ('自迭代规则：公开 n_events/n_dates/n_tickers；date×ticker 双向聚类 '
                           'CI 跨 50% 不入决策；只有反向 CI 整体低于 50% 才允许反向解读。driven_by='
                           'technical 的整体战绩以 dashboard 的实时 decision_metrics.by_driver.technical '
                           '为准，不使用固定百分比。')}
     safe_write_json(OUT, out)
-    print(f'  review: {len(days)} days, summary: {summary}')
+    skipped = f'，冻结价剔除 {frozen_excluded} 个观测' if frozen_excluded else ''
+    print(f'  review: {len(days)} days, summary: {summary}{skipped}')
 
 
 if __name__ == '__main__':

--- a/tests/test_quant_signal_review.py
+++ b/tests/test_quant_signal_review.py
@@ -298,3 +298,47 @@ def test_twenty_events_with_perfect_ci_still_need_min_n(monkeypatch):
     assert factor["usable"] is False
     assert factor["decision_direction"] is None
     assert "trend_on_follow" not in result["summary"]
+
+
+def _frozen_feed_days():
+    """RKLB-shaped poison: five sessions pinned at 100 then a fake -40% snap.
+
+    Every pair inside the run settles fwd=0 (an automatic miss), and the
+    unfreeze boundary manufactures a move that never traded — exactly what
+    quant_signals_history.jsonl carried for RKLB/HOOD in 2026-06/07.
+    """
+    days = []
+    closes = {"FRZ": [100.0] * 5 + [60.0], "LIVE": [100.0, 110.0]}
+    for index in range(6):
+        rows = {}
+        for symbol, series in closes.items():
+            if index < len(series):
+                rows[symbol] = {"close": series[index], "trend_on": True}
+        days.append({"as_of": f"day-{index}", "rows": rows})
+    return days
+
+
+def test_frozen_feed_runs_never_become_factor_observations(monkeypatch):
+    result = _run_review(monkeypatch, _frozen_feed_days())
+
+    factor = result["factors"]["trend_on_follow"]
+    # LIVE contributes its one real observation; FRZ's five frozen-source
+    # pairs (four flat, one manufactured crash) contribute none.
+    assert factor["n_events"] == 1
+    assert factor["hit_rate"] == 1.0
+    assert result["frozen_feed_excluded"] == 5
+
+
+def test_weekend_flat_pairs_still_count_as_observations(monkeypatch):
+    # A legitimate 2-session flat stretch (weekend carry of Friday's close)
+    # is below FROZEN_RUN_MIN and must keep producing observations.
+    days = [
+        {"as_of": "fri", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "sat", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "sun", "rows": {"W": {"close": 100.5, "trend_on": True}}},
+    ]
+    result = _run_review(monkeypatch, days)
+
+    factor = result["factors"]["trend_on_follow"]
+    assert factor["n_events"] == 2
+    assert result["frozen_feed_excluded"] == 0


### PR DESCRIPTION
## 审计范围与结论

strategy-review 切片（signals/gates/candidate 链、盘中加仓侧读数、t0 setups、settle 口径、quant factor 层、lev_regime、gold DCA、risk.json、walkforward/backtest），对 2026-08-16 以来约 20 个策略面 commit 逐个攻击：#1028 信号计数合一、#1025 retrospective 单判词、#1004 simulated_entry_price 回填删除、#984 usable 口径对齐、#950 WAVE2 race、#719/#716 T+1 官方 bar、#945 杠杆刻度盘健壮性、#951 历史滚动窗口、#856/#857/#762/#760 加仓侧读数族、gold fetch/update、`decision/ledger.py` settle 链、`add_alpha_walkforward.py` point-in-time 形状。

历史修复反查：#934 MIN_N 闸、#964 判词单轨、#963 canonical bars、#645 exploration_ready 身份保留、数字出处链（add_side 引 #819 回测）——全部仍然成立。

**发现一处真缺陷（本 PR 修）+ 两处记录在案：**

1. **真缺陷（Closes #1035）**：quant_signals_history 冻结价污染。RKLB 连续 ~30 个留痕日卡在 114.78（canonical bars 同期 102→85 真实移动）、HOOD 卡 12 日；signal_review 把冻结对当合法观测，fwd 恒 0 全记 miss——trend_on_follow 公开命中率 10% 里 32/40 是伪影（真实 ~37.5%）。读取侧加 ≥4 连续同价断源闸 + `frozen_feed_excluded` 披露（77 个观测被剔除），数据不改写；重生成产物后所有因子依旧 usable=False，纪律闸结论无一翻转。
2. **可靠性隐患（issue-only #1036）**：guardrail β 硬闸消费 `_preserve_stale` 复活块时不看 `stale` 位；连续失败时 `stale_since` 逐次前移，陈旧时长被低估。触发低频、后果是硬闸建议建立在未知年龄的数据上。
3. **仅记录不改**：`decision/add_side.py:196` 内联注释「A primary filing … is not the promotion key」与同函数行为矛盾（near_breakout/at_high 状态下 primary 正是 wait→candidate 的促成键）；模块 docstring 与代码一致，仅该行注释误导。t0_setup_review 对 t0_setups_history 有同族结算形状（当前干净），已写入 #1035 影响面备查。

## 测试

- 新增两条行为断言（冻结行程不产生观测且披露计数；周末平盘对仍计数），断言行为而非字符串。
- 本地：`pytest tests/test_quant_signal_review.py tests/test_build_evidence.py tests/test_history_store.py` 34 passed。

## 数据改动

- `assets/data/quant_signal_review.json` 由修复后代码在本 workspace 重生成：n/hit_rate 按闸后观测计算，新增 frozen_feed_excluded=77；unlock 结论不变（无因子解锁）。
