### PR TITLE
docs: 修两处目录迁移后的 md 死引用（examples 索引 + issue-206 证据图）

### DIFF
--- a/docs/visual-regression/issue-206/README.md
+++ b/docs/visual-regression/issue-206/README.md
@@ -15,17 +15,17 @@ horizontal overflow (`scrollWidth == clientWidth`) at every measured width.
 
 | Before | After |
 |---|---|
-| ![Overview before at 1440px](../../../assets/visual-regression/issue-206/before-1440.jpg) | ![Overview after at 1440px](../../../assets/visual-regression/issue-206/after-1440.jpg) |
+| ![Overview before at 1440px](before-1440.jpg) | ![Overview after at 1440px](after-1440.jpg) |
 
 ## 1920px
 
 | Before | After |
 |---|---|
-| ![Overview before at 1920px](../../../assets/visual-regression/issue-206/before-1920.jpg) | ![Overview after at 1920px](../../../assets/visual-regression/issue-206/after-1920.jpg) |
+| ![Overview before at 1920px](before-1920.jpg) | ![Overview after at 1920px](after-1920.jpg) |
 
 ## 390px mobile regression
 
 The desktop media query does not apply. Card order, widths, pager behavior, and
 the Gold table's horizontal-scrolling rules are unchanged.
 
-![Overview after at 390px](../../../assets/visual-regression/issue-206/after-390.jpg)
+![Overview after at 390px](after-390.jpg)

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ harness's way in, and the contract never changes between them.
 | Claude Code | a CLAUDE.md instruction block, auto-loaded per workspace | [`claude-code/CLAUDE.md`](claude-code/CLAUDE.md) | `<workspace>/CLAUDE.md` |
 | Codex | an AGENTS.md instruction block, auto-loaded from the workspace root | [`codex/AGENTS.md`](codex/AGENTS.md) | `<workspace>/AGENTS.md` |
 | DeepSeek Harness | agent calls the clawock CLI through its bash tool; the contract is unchanged | [`dsh/instruction.md`](dsh/instruction.md) | workspace instruction / system prompt |
-| DSH plugin | npm-distributable skill package (and future Decision Studio UI) | [`dsh/plugin/`](dsh/plugin/) | `dsh plugin --profile web add clawock-dsh` + `cp` the skill into `~/.dsh/skills/` (see its [README](dsh/plugin/README.md)) |
+| DSH plugin | npm-distributable skill package (and future Decision Studio UI) | [`dsh/packages/clawock-dsh/`](dsh/packages/clawock-dsh/) | `dsh plugin --profile web add clawock-dsh` + `cp` the skill into `~/.dsh/skills/` (see its [README](dsh/packages/clawock-dsh/README.md)) |
 | Profiles | a second desk selects markets, workflows, resources, policy, presentation and delivery declaratively — the harness *profile* surface (e.g. the `intraday` desk workflow), distinct from the per-workspace decision contract above | [`profiles/`](profiles/) | reference |
 
 The point of the middle column is that it never changes: the harness only


### PR DESCRIPTION
## 背景

md-cleanup 切片第 2 遍审计（对抗对象=上一轮修复本身）。方法：对全仓 250 个 tracked `.md` 重跑两类机械取证——(1) 每个 .md 内的相对链接/href 逐个验证目标存在；(2) 源码/tests/ops/.github/site 引用的 .md 路径反向核对。另对上一轮 PR #1034 的修复与「249/250 健康」结论做了回归复核（均成立：`docs/reference/product-profile-operations.md` 存在且含 "The deciding question" §；BOOTSTRAP/cron-payloads/_config.yml 排除清单等历史判据今天仍成立）。

## 本 PR 修的两处（同类：目录迁移后 md 相对引用未同步）

### Closes #1041

- `examples/README.md:21` DSH plugin 行两个死链 `dsh/plugin/`、`dsh/plugin/README.md`。
- 成因：#652 写入时路径成立，#733（d91b9952）把插件迁到 `examples/dsh/packages/clawock-dsh/` 后此行漏改；全仓 grep `dsh/plugin` 仅此一处残留。
- 修复：指向 `dsh/packages/clawock-dsh/` 及其 README。

### Closes #1042

- `docs/visual-regression/issue-206/README.md` 五张证据图链接指向不存在的 `../../../assets/visual-regression/issue-206/*.jpg`。
- 成因：#210（8149531d）新增时图片在 `assets/` 下、链接正确；#399（ca634e21）把 jpg 迁到 README 同目录后前缀未同步，GitHub 视图自那时起全部裂图。
- 修复：改为同目录相对路径，文件名不动——契约测试 `test_issue_206_visual_regression_evidence_is_shipped` 断言的正是文件名+体积，不受影响。

## 验证

- 全量 .md 相对链接检查归零（剩余命中均为 memory/ 运行时笔记与 site Liquid 模板误报）；
- `pytest tests/test_dashboard_desktop_layout_contract.py::test_issue_206_visual_regression_evidence_is_shipped tests/test_examples_are_executed.py` → 8 passed。

## 仅建 issue 未动（机制级）

#1043：profile 级 `templates` 面自 #540 起零代码消费者，minimal 示例还指向不存在的 `config/intraday.md`——schema 去留需 kcn 定方向（接线或删除），不宜 drive-by。

## 未动项

#1033（archive 文件去留）：上轮已留给 kcn，维持 open。
