### PR TITLE
fix: β 硬闸吃 stale 复活块两处 + stale_since 连败前移 (#1036)；add_side 促升注释纠正 (#1045) [audit:strategy-review P2]

### DIFF
--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -195,7 +195,9 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
             # #819: the breakout state alone carries the measured edge
             # (8-month bars backtest: hit >50% at T+1/5/10/20, avg fwd positive;
             # deep-dip adds failed all four horizons — the original 逢低 assumption).
-            # A primary filing upgrades the wording, it is not the promotion key.
+            # Promotion shape: breakout promotes by itself; a primary filing is
+            # the promotion key only for near_breakout/at_high, where it never
+            # substitutes for the level — the ask stays "get above prior_20d_high".
             verdict = "candidate"
             if primary:
                 why = (f"一手公告 + 技术面{radar_row.get('state_zh') or radar_row.get('state')}"

--- a/src/clawock/portfolio/guardrail.py
+++ b/src/clawock/portfolio/guardrail.py
@@ -335,8 +335,13 @@ def compute_risk_guardrail(hk_holdings, us_holdings, hk_conc, us_conc, risk,
     # portfolio-level β from risk.json
     us_risk = risk.get('us') or {}
     us_beta = us_risk.get('beta_spx')
+    # A revived block (#1036) carries β of unknown age: risk.py only keeps the
+    # last good stats when this run's fetch failed, so `stale` means "not
+    # measured today". A HIGH-severity trim directive must not be sourced from
+    # data whose age the flag itself admits is unknown.
     beta_eligible = (
-        us_risk.get('threshold_eligible', True)
+        not us_risk.get('stale')
+        and us_risk.get('threshold_eligible', True)
         and us_risk.get('beta_threshold_eligible', True)
     )
     if (beta_eligible and isinstance(us_beta, (int, float))

--- a/src/clawock/portfolio/risk.py
+++ b/src/clawock/portfolio/risk.py
@@ -1057,8 +1057,13 @@ def build_alerts(us, hk, combined, leverage, correlation=None):
                 ),
             })
     combined_eligible = bool(combined and combined.get('threshold_eligible', True))
+    # β of unknown age must not raise a threshold action (#1036): a stale block
+    # is the last good measurement, not a current one. high_vol/deep_dd below
+    # read `combined`, which compute_combined only ever builds from current
+    # streams — it cannot be revived, so it needs no stale check.
     us_eligible = bool(
-        us and us.get('threshold_eligible', True)
+        us and not us.get('stale')
+        and us.get('threshold_eligible', True)
         and us.get('beta_threshold_eligible', True)
     )
     if (us_eligible and us.get('beta_spx') is not None
@@ -1166,6 +1171,32 @@ def load_risk_config(path: Path | str) -> dict[str, str]:
 
 
 # ----------------------------------------------------------------------------
+# Stale-block revival (#1036)
+# ----------------------------------------------------------------------------
+
+def _revive_stale_block(out_block, holdings, prev_block, value_key, value,
+                        prev_generated_at=None):
+    """If this run produced no stats but we still hold positions, reuse the
+    last good stats and mark stale; always refresh the live position value.
+
+    ``stale_since`` must survive consecutive failures: run N revives the block
+    written by run N-1, so seeding the timestamp from the previous file's
+    ``generated_at`` would walk it forward one failure at a time and shrink the
+    disclosed age of numbers that have not been re-measured since the FIRST
+    failed fetch. An already-stale block keeps its original stamp.
+    """
+    if out_block is not None or not holdings:
+        return out_block, False
+    if not isinstance(prev_block, dict):
+        return out_block, False
+    revived = dict(prev_block)
+    revived['stale'] = True
+    revived['stale_since'] = prev_block.get('stale_since') or prev_generated_at
+    revived[value_key] = round(value, 2)  # live value, never stale
+    return revived, True
+
+
+# ----------------------------------------------------------------------------
 # Main
 # ----------------------------------------------------------------------------
 
@@ -1230,25 +1261,14 @@ def main(argv=None):
         except Exception:
             prev = {}
 
-    def _preserve_stale(out_block, holdings, prev_block, value_key, value):
-        """If this run produced no stats but we still hold positions, reuse the
-        last good stats and mark stale; always refresh the live position value."""
-        if out_block is not None or not holdings:
-            return out_block, False
-        if not isinstance(prev_block, dict):
-            return out_block, False
-        revived = dict(prev_block)
-        revived['stale'] = True
-        revived['stale_since'] = prev.get('generated_at')
-        revived[value_key] = round(value, 2)  # live value, never stale
-        return revived, True
-
     us_value = sum(h['current_value'] for h in us_holdings)
     hk_value = sum(h['current_value'] for h in hk_holdings)
-    us_out, us_stale = _preserve_stale(us_out, us_holdings, prev.get('us'),
-                                       'current_value_usd', us_value)
-    hk_out, hk_stale = _preserve_stale(hk_out, hk_holdings, prev.get('hk'),
-                                       'current_value_hkd', hk_value)
+    us_out, us_stale = _revive_stale_block(us_out, us_holdings, prev.get('us'),
+                                           'current_value_usd', us_value,
+                                           prev.get('generated_at'))
+    hk_out, hk_stale = _revive_stale_block(hk_out, hk_holdings, prev.get('hk'),
+                                           'current_value_hkd', hk_value,
+                                           prev.get('generated_at'))
     if us_stale:
         print('  WARN: US risk fetch empty — kept previous β/vol block (stale), '
               'value refreshed from holdings', file=sys.stderr)

--- a/tests/test_brief_preflight_guardrail.py
+++ b/tests/test_brief_preflight_guardrail.py
@@ -275,6 +275,22 @@ def test_us_beta_action_is_withheld_when_benchmark_overlap_is_ineligible(preflig
     assert result["breach_count"] == 0
 
 
+def test_us_beta_action_is_withheld_while_the_block_is_stale_revived(preflight):
+    """#1036: a revived block carries β of unknown age — the flag itself says
+    this run failed to measure it, so it must not source a HIGH trim directive."""
+    result = _evaluate(
+        preflight,
+        risk={"us": {
+            "beta_spx": 4.2,
+            "stale": True,
+            "stale_since": "2026-08-20T00:00:00+00:00",
+        }},
+    )
+
+    assert result["breaches"] == []
+    assert result["breach_count"] == 0
+
+
 def test_leveraged_etf_loss_exactly_minus_18_triggers_inclusive_stop(preflight):
     result = _evaluate(preflight, us=[
         _holding("PLTU", 25, leveraged=True, pnl_pct=-18),

--- a/tests/test_portfolio_risk_metrics.py
+++ b/tests/test_portfolio_risk_metrics.py
@@ -277,6 +277,56 @@ def test_build_alerts_does_not_fire_at_the_strict_threshold_boundaries():
     assert risk.build_alerts(us, None, combined, leverage) == []
 
 
+def test_build_alerts_withholds_high_beta_from_a_stale_revived_block():
+    """#1036: `stale` means this run never measured β; the disclosure alert
+    fires instead of a threshold action sourced from unknown-age data."""
+    us = {"beta_spx": 4.4, "stale": True, "stale_since": "2026-08-20T00:00:00+00:00"}
+
+    alerts = risk.build_alerts(us, None, None, {"combined_avg": 1.0})
+
+    assert [alert["type"] for alert in alerts] == ["risk_data_stale"]
+
+
+def test_revive_stale_block_keeps_the_first_failure_timestamp_across_runs():
+    # First failed fetch: the stamp comes from the previous (good) file.
+    revived, stale = risk._revive_stale_block(
+        None, [{"ticker": "PLTU"}], {"beta_spx": 3.4},
+        "current_value_usd", 123.456, "2026-08-25T00:00:00+00:00",
+    )
+
+    assert stale is True
+    assert revived["stale"] is True
+    assert revived["stale_since"] == "2026-08-25T00:00:00+00:00"
+    assert revived["current_value_usd"] == 123.46
+
+    # Second consecutive failure revives an already-stale block: the original
+    # stamp must survive, not walk forward and shrink the disclosed age.
+    revived_again, stale_again = risk._revive_stale_block(
+        None, [{"ticker": "PLTU"}], revived,
+        "current_value_usd", 200.0, "2026-08-26T00:00:00+00:00",
+    )
+
+    assert stale_again is True
+    assert revived_again["stale_since"] == "2026-08-25T00:00:00+00:00"
+    assert revived_again["current_value_usd"] == 200.0
+
+
+def test_revive_stale_block_is_a_noop_without_the_failure_conditions():
+    block = {"beta_spx": 3.4}
+    # Stats exist this run → pass through untouched.
+    assert risk._revive_stale_block(
+        block, [{"ticker": "X"}], {}, "current_value_usd", 1.0,
+    ) == (block, False)
+    # No positions left → nothing to keep alive.
+    assert risk._revive_stale_block(
+        None, [], {"beta_spx": 3.4}, "current_value_usd", 1.0,
+    ) == (None, False)
+    # No usable previous block → nothing to revive from.
+    assert risk._revive_stale_block(
+        None, [{"ticker": "X"}], "junk", "current_value_usd", 1.0,
+    ) == (None, False)
+
+
 def test_dynamic_stream_does_not_let_a_new_listing_truncate_established_names():
     holdings = [
         {


### PR DESCRIPTION
## 背景

strategy-review 切片第 2 遍对抗性审计（敌意对象 = 第 1 遍修复自身 + 其遗留）。工作区 /root/wt-audit，基于最新 origin/master（8cd77339）。

## 第 1 遍修复的反查（全部成立，无回归）

- **#1037 冻结价闸**：当前 master 数据上重跑 `quant-review` 逐字节复现 committed 产物——`frozen_feed_excluded=77`、trend_on_follow n=8 hit 37.5%、无因子 usable 翻转；全历史扫描仅 RKLB(×31)/HOOD(×13) 两段冻结行程，闸边界（settle 日冻结/触发日冻结）都落在排除集里。
- **#1028 信号解析合一**：SIGNAL_WORDS 与 hk_analysis（ALERT/WATCH/TRIM/STOP?）/us_analysis（STOP-LOSS/WATCH/TRIM）实际写出的行形状逐 token 对上；`· 理由` 续行、段外行、WATCHDOG 均正确不计数；decide_alert 的 `stop+alert` 语义与 report 侧 needs_risk_section 同源。
- **#1025 判词单轨 / #1004 entry_price 回填删除 / #1021 hk-close**：行为与 docstring 断言一致，无复活路径（simulated_entry_price 全仓 grep 仅剩 legacy 读侧）。

## 本 PR 修两处（上一轮遗留）

**Closes #1036 —— stale 复活块的 β 阈值动作 + 时间戳漂移**

1. `guardrail.py` β 硬闸只查 threshold_eligible 族：US 行情断流时 risk.json 的 us 块整体复活为旧值（stale=true），HIGH 级 trim 建议仍可从未知年龄的 β 触发。stale 位现在使 β 闸失效——brief 与 dashboard 共用这一份实现，单点修两处受益。
2. 同族：`risk.py build_alerts` 的 high_beta 动作也不看 stale 位，而同函数的 risk_data_stale 披露写着「Combined vol/Sharpe are withheld」。high_vol/deep_dd 读的 combined 只从本次流现算、从不复活（compute_combined 对缺流返回 None），β 是唯一漏堵路径。
3. `_preserve_stale` 连续失败时拿上一个文件的 generated_at 当 stale_since，陈旧时长逐次缩短。提升为模块级 `_revive_stale_block`：已复活的块保留首败时间戳。

**Closes #1045 —— add_side 促升注释与同函数行为矛盾**

「A primary filing … is not the promotion key」在 near_breakout/at_high 分支恰与 `breakout or primary` 相反，按真实促升形状改写（P1 记录项收尾）。

## 测试

- guardrail：stale-β 不触发硬闸（非 stale 路径既有测试仍钉住）；
- build_alerts：stale 块只出 risk_data_stale，不出 high_beta；
- _revive_stale_block：连败保首戳 + 实值刷新 + 三个 no-op 分支；
- 本地针对性：`test_brief_preflight_guardrail + test_portfolio_risk_metrics` 75 passed；`test_add_side_reads + test_quant_signal_review` 50 passed。不跑全量套件。

不触碰 assets/data 发布产物；只 add 明确修改的 5 个源文件路径。
