### PR TITLE
fix: briefs 页删掉两个永远空渲染的区块——Liquid 迭代未定义 sorted (#1047) [audit:memory-lifecycle P2]

### DIFF
--- a/site/briefs.md
+++ b/site/briefs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: clawock · daily briefs
-description: 全部历史每日深度简报 + 手写笔记 + plan.json
+description: 全部历史每日深度简报 + 周复盘
 ---
 
 # Daily Briefs
@@ -31,34 +31,6 @@ description: 全部历史每日深度简报 + 手写笔记 + plan.json
   <li>
     <a href="{{ f.url | relative_url }}">{{ f.path | split: '/' | last | replace: '.md', '' }}</a>
   </li>
-{% endfor %}
-</ul>
-
-## Daily Notes · 手写笔记
-
-<ul class="brief-list">
-{% for f in sorted %}
-  {% if f.path contains '/memory/' and f.extname == '.md' and f.name != '_TEMPLATE.md' %}
-    {% unless f.path contains '-pre-open' or f.path contains 'recovery_log' or f.path contains '6_month_review' or f.path contains 'archive_index' %}
-  <li>
-    <a href="https://github.com/KCNyu/clawock/blob/master{{ f.path }}">{{ f.name | replace: '.md', '' }}</a>
-  </li>
-    {% endunless %}
-  {% endif %}
-{% endfor %}
-</ul>
-
-## Plan archive · 历史 plan.json
-
-Self-learning loop 用，给次日 retrospective 算 trigger / P&L / confidence calibration。
-
-<ul class="brief-list">
-{% for f in sorted %}
-  {% if f.path contains '/memory/' and f.extname == '.json' and f.path contains '-plan' %}
-  <li>
-    <a href="https://github.com/KCNyu/clawock/blob/master{{ f.path }}">{{ f.name }}</a>
-  </li>
-  {% endif %}
 {% endfor %}
 </ul>
 

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -70,6 +70,45 @@ def test_faq_page_is_required_public_and_has_an_entry_point():
     assert WORKFLOW.count("'site/**'") == 2
 
 
+def test_briefs_liquid_loops_iterate_defined_collections():
+    """#1047: `{% for f in sorted %}` iterated a variable nobody ever assigned.
+
+    Liquid renders zero passes for a nil iterable and raises nothing, so the
+    Daily Notes and Plan archive sections shipped as bare headings from the day
+    the page was created — while the front-matter description promised both.
+    Every ``for`` iterable in a site markdown page must therefore be either a
+    Jekyll-provided collection (``site.*``) or a name the same file assigns
+    (or an outer loop variable) before use.
+    """
+    pages = sorted((ROOT / "site").glob("*.md"))
+    liquid_pages = [p for p in pages if "{%" in p.read_text()]
+    assert liquid_pages, (
+        "no site markdown page carries Liquid anymore — this test has stopped "
+        "following the templates"
+    )
+    for page in liquid_pages:
+        text = page.read_text()
+        assigned = set(re.findall(r"{%-?\s*assign\s+(\w+)\s*=", text))
+        loop_vars: list[str] = []
+        problems = []
+        loops = 0
+        for m in re.finditer(r"{%-?\s*for\s+(\w+)\s+in\s+([\w.]+)", text):
+            var, iterable = m.groups()
+            base = iterable.split(".")[0]
+            loops += 1
+            if base in assigned or base == "site" or base in loop_vars:
+                loop_vars.append(var)
+                continue
+            problems.append(f"{page.name}: for {var} in {iterable}")
+            loop_vars.append(var)
+        if loops:
+            assert problems == [], (
+                f"{problems} iterate undefined Liquid variables — nil renders "
+                f"zero passes, so the section silently ships empty (#1047). "
+                f"Assign the variable first or iterate site.* directly."
+            )
+
+
 def test_indexnow_key_is_required_public_and_triggers_deploy():
     """The key proves ownership to IndexNow; without it every submit 403s.
 


### PR DESCRIPTION
## 问题

`site/briefs.html` 的「Daily Notes · 手写笔记」和「Plan archive · 历史 plan.json」两节自建页起永远渲染为空：模板 `{% for f in sorted %}`（site/briefs.md:40/:56）迭代了一个从未 `assign` 的变量，Liquid 对 nil 静默渲染零次。线上实测（2026-08-26）两节标题下零条目；`git log --all -S "assign sorted"` 零命中证明从未工作过。结构上也不可修复：stage_site.py 只 stage `*-pre-open.md` + `weekly/`，且 Jekyll `site.pages` 不含 `.json`。

页头 description 同时承诺「全部历史每日深度简报 + 手写笔记 + plan.json」——三项承诺两项从不交付，并每天随 Pages 部署发布。

对生命周期审计的直接干扰：这两节让 briefs 页**看起来**是 daily notes / plan.json 的站点级消费方，实际不是——#1038（日记停止提交政策）依赖的消费方图谱因此有被数错的风险。本 PR 把消费方图谱变诚实。

## 改动

1. `site/briefs.md`：删除两个死区块（不新增任何 staging/发布面——把日记或 plan.json 变成真消费方属于 #1038/#1039 的 kcn 决策域）；description 改为「全部历史每日深度简报 + 周复盘」。
2. `tests/test_pages_deployment_contract.py` 新增契约测试：site/*.md 中每个 Liquid `for` 的可迭代必须是 `site.*`、同文件已 assign 的变量或外层循环变量；发现未定义变量迭代即红（nil 静默空渲染正是本缺陷形态）。已验证先红后绿，非空洞断言。

Closes #1047

## 验证

- `pytest tests/test_pages_deployment_contract.py::test_briefs_liquid_loops_iterate_defined_collections -q`：新代码 1 passed；对 HEAD 旧版 briefs.md 复跑 1 failed（先红后绿）。
- 该文件全量 16 条中 14 passed；2 个失败（test_builder_stages_only_public_consumers / test_site_staging_joins_owned_source_and_runtime_inputs）在干净 origin/master 上同样失败，属本地 worktree 环境既有问题，与本 diff 无关。
