### PR TITLE
fix: 删除 profile 级 templates 死面 + 前两轮修复回归复核 (#1043) [audit:md-cleanup P3]

### DIFF
--- a/config/profiles/kcnyu/profile.json
+++ b/config/profiles/kcnyu/profile.json
@@ -21,20 +21,17 @@
     "brief": {
       "enabled": true,
       "markets": ["hk", "us"],
-      "policy": "brief",
-      "template": "brief"
+      "policy": "brief"
     },
     "report": {
       "enabled": true,
       "markets": ["hk", "us"],
-      "policy": "report",
-      "template": "report"
+      "policy": "report"
     },
     "intraday": {
       "enabled": true,
       "markets": ["hk", "us"],
-      "policy": "intraday",
-      "template": "intraday"
+      "policy": "intraday"
     }
   },
   "resources": {
@@ -67,11 +64,6 @@
     "brief": {
       "markets_must_both_be_closed_to_skip": true
     }
-  },
-  "templates": {
-    "brief": "config/cron-payloads/brief.md",
-    "report": "config/cron-payloads/report.md",
-    "intraday": "config/cron-payloads/intraday.md"
   },
   "delivery": {
     "provider": "openclaw",

--- a/docs/reference/product-profile-operations.md
+++ b/docs/reference/product-profile-operations.md
@@ -38,7 +38,7 @@ market_data provider DTO -> decision strategy -> package lifecycle -> runtime/pr
   scope, instrument look-through, signal state, risk/exploration contract and
   its bounded state. It accepts a generic workspace/book and explicit policy;
   it does not know KCNyu, OpenClaw, a delivery target or prose layout.
-- A profile supplies declarative markets, policies, templates, schedules,
+- A profile supplies declarative markets, policies, schedules,
   resources and delivery selection. Phase wiring, rendering, watchdog behavior
   and reusable policy stay in `src/clawock/`; host and repository side effects
   stay in `ops/`.
@@ -67,7 +67,7 @@ host/repository wiring belongs in operations.
 | `src/clawock/market_data/` | portable providers, canonical bars, sessions, quotes, filings and market context |
 | `src/clawock/evidence/` | provenance, run cards, research surface and public evidence generation |
 | `src/clawock/context/`, `harness/`, `automation/`, `publish/`, `workflows/`, `providers/` | complete lifecycle, scheduling/watchdogs, strategies, artifact protocol and runtime integrations |
-| `config/profiles/` | declarative profile values, resource references, schedules, locale/templates and delivery selection |
+| `config/profiles/` | declarative profile values, resource references, schedules, locale and delivery selection |
 | `ops/host/` | this host's cron, scheduler inspection, session maintenance and launcher wiring |
 | `ops/publish/` | the only protected-branch and data-plane publisher implementation |
 | `ops/ci/` | coverage and scheduled-workflow health used by GitHub Actions |

--- a/examples/profiles/minimal/profile.json
+++ b/examples/profiles/minimal/profile.json
@@ -15,8 +15,7 @@
     "intraday": {
       "enabled": true,
       "markets": ["hk"],
-      "policy": "intraday",
-      "template": "intraday"
+      "policy": "intraday"
     }
   },
   "resources": {
@@ -29,9 +28,6 @@
       "max_setup_lines": 3,
       "quote_fresh_minutes": 10
     }
-  },
-  "templates": {
-    "intraday": "config/intraday.md"
   },
   "delivery": {
     "provider": "filesystem",

--- a/src/clawock/config/profiles.py
+++ b/src/clawock/config/profiles.py
@@ -22,10 +22,10 @@ PROFILE_NAME = "profile.json"
 _ID = re.compile(r"^[a-z][a-z0-9_-]*$")
 _TOP_LEVEL = frozenset({
     "schema_version", "id", "locale", "timezone", "markets", "workflows",
-    "resources", "policies", "templates", "delivery",
+    "resources", "policies", "delivery",
 })
 _MARKET_FIELDS = frozenset({"timezone", "label", "analysis_command", "skill"})
-_WORKFLOW_FIELDS = frozenset({"enabled", "markets", "policy", "template"})
+_WORKFLOW_FIELDS = frozenset({"enabled", "markets", "policy"})
 _DELIVERY_FIELDS = frozenset({"provider", "targets"})
 _TARGET_FIELDS = frozenset({"source", "key"})
 
@@ -45,7 +45,6 @@ class WorkflowProfile:
     enabled: bool
     markets: tuple[str, ...]
     policy: str | None = None
-    template: str | None = None
 
 
 @dataclass(frozen=True)
@@ -63,7 +62,6 @@ class Profile:
     workflows: Mapping[str, WorkflowProfile]
     resources: Mapping[str, str]
     policies: Mapping[str, Any]
-    templates: Mapping[str, str]
     delivery_provider: str
     delivery_targets: Mapping[str, DeliveryTarget]
     path: Path
@@ -204,9 +202,6 @@ def load_profile(workspace: Path | str, profile: Path | str | None = None) -> Pr
         workflows[key] = WorkflowProfile(
             key=key, enabled=enabled, markets=tuple(selected_markets),
             policy=_optional_text(workflow.get("policy"), f"workflows.{key}.policy"),
-            template=_optional_text(
-                workflow.get("template"), f"workflows.{key}.template"
-            ),
         )
 
     raw_resources = _object(data.get("resources"), "resources")
@@ -215,11 +210,6 @@ def load_profile(workspace: Path | str, profile: Path | str | None = None) -> Pr
         for key, value in raw_resources.items()
     }
     policies = _object(data.get("policies"), "policies")
-    raw_templates = _object(data.get("templates"), "templates")
-    templates = {
-        key: _relative_path(value, f"templates.{key}")
-        for key, value in raw_templates.items()
-    }
 
     delivery = _object(data.get("delivery"), "delivery")
     _known_fields(delivery, _DELIVERY_FIELDS, "delivery")
@@ -250,7 +240,7 @@ def load_profile(workspace: Path | str, profile: Path | str | None = None) -> Pr
         markets=MappingProxyType(markets), workflows=MappingProxyType(workflows),
         resources=MappingProxyType(resources),
         policies=MappingProxyType(dict(policies)),
-        templates=MappingProxyType(templates), delivery_provider=provider,
+        delivery_provider=provider,
         delivery_targets=MappingProxyType(targets), path=path, workspace=root,
     )
 
@@ -276,13 +266,11 @@ def describe_profile(profile: Profile) -> dict:
                 "enabled": value.enabled,
                 "markets": list(value.markets),
                 "policy": value.policy,
-                "template": value.template,
             }
             for key, value in profile.workflows.items()
         },
         "resources": dict(profile.resources),
         "policies": dict(profile.policies),
-        "templates": dict(profile.templates),
         "delivery": {
             "provider": profile.delivery_provider,
             "targets": {

--- a/tests/test_harness_cli_contract.py
+++ b/tests/test_harness_cli_contract.py
@@ -78,7 +78,6 @@ def test_profile_selects_phase_and_scopes_runtime_environment(monkeypatch, tmp_p
         }},
         "resources": {"schedule_contract": "config/schedule.json"},
         "policies": {},
-        "templates": {},
         "delivery": {"provider": "filesystem", "targets": {}},
     }))
     monkeypatch.setattr(runner, "import_module", lambda name: Module)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -58,3 +58,20 @@ def test_profile_rejects_unknown_code_shaped_configuration(tmp_path):
         assert "unknown fields" in str(exc)
     else:
         raise AssertionError("profile accepted executable instance configuration")
+
+
+def test_profile_templates_surface_stays_deleted(tmp_path):
+    source = json.loads((ROOT / "examples/profiles/minimal/profile.json").read_text())
+    source["templates"] = {"intraday": "config/cron-payloads/intraday.md"}
+    path = tmp_path / "profile.json"
+    path.write_text(json.dumps(source))
+
+    try:
+        load_profile(tmp_path, "profile.json")
+    except ValueError as exc:
+        assert "unknown fields" in str(exc)
+    else:
+        raise AssertionError(
+            "profile accepted the unconsumed templates surface; "
+            "payload templates belong to config/cron-schedules.json"
+        )


### PR DESCRIPTION
## 背景

md-cleanup 切片第 3 遍审计（对抗对象=前两轮修复本身）。方法：

1. **前两轮修复回归复核（全部成立）**
   - P1 #1034：`.github/CONTRIBUTING.md:35` → `docs/reference/product-profile-operations.md` 存在且含 "The deciding question" §；
   - P2 #1044：`examples/README.md:21` 指向的 `dsh/packages/clawock-dsh/`+README 存在；`docs/visual-regression/issue-206/README.md` 五张同目录 jpg 齐全；
   - 契约测试回归：`test_issue_206_visual_regression_evidence_is_shipped` + `tests/test_examples_are_executed.py` 8 passed。
2. **独立重扫两个取证维度，换实现找盲区**：
   - 正向：250 个 tracked .md 全量相对/根绝对链接 + **锚点 fragment 校验**（上轮未做）→ 文件级死链 0（余项为 memory 运行时笔记与 site Liquid 误报），锚点缺失 0；
   - 反向：全部 .py/.yml/.json/.js/.ts/.sh/.toml/.html/.liquid + 非 memory .md 中引用的 `.md` 路径逐个验证存在性 → 未解析项经逐条人工核实均为运行时生成文件名、测试夹具、ASCII 树或外部 blob URL，**活代码指向死文档的方向干净**。
3. **接手本切片既有 open issue 并按裁决自治处置**（kcn 2026-08-26 授权）。

## 本 PR 修的一处

### Closes #1043 — profile 级 templates 死面删除（方案 B）

- 自 #540(3c1abdae) 引入起零代码消费：真实 payload 链路是 `config/cron-schedules.json → scheduling.py`（强制 `config/cron-payloads/` 前缀）；profile.templates/workflows.*.template 只有解析+回显；
- `examples/profiles/minimal/profile.json` 还指向不存在的 `config/intraday.md`——照示例配置静默失效；
- 删除面：`src/clawock/config/profiles.py` schema/字段/解析/回显、两份 profile.json 的顶层 templates 块与 workflows.*.template 死字段、`describe_profile` 输出两键；
- 回归闸 `test_profile_templates_surface_stays_deleted` 断言该面重现即 unknown fields；
- 文档同步：`docs/reference/product-profile-operations.md:41,70` 不再声称 profile 有 templates 面。

### Closes #1033 — archive 文件裁决保留（无代码改动）

`docs/archive/openclaw-decoupling-plan.md` 维持保留：site/_config.yml 成文排除注释表明 archive 是有意设计史区，文件自带 superseded 横幅自缓解；两面论证与裁决记录见 issue 评论。

## 验证

- `env -u CLAWOCK_WORKSPACE pytest tests/test_profiles.py tests/test_harness_cli_contract.py tests/test_cron_contracts.py` → 44 passed；
- kcnyu `load_profile`+`describe_profile` 端到端：输出无 templates 键、workflows 无 template 键。

## 备注

宿主机 shell 带 `CLAWOCK_WORKSPACE=/root/.openclaw/workspace` 时 `tests/test_profiles.py` 两个用例会读到 live workspace 而假失败；CI 无此变量不受影响。属环境注意事项非仓库缺陷，仅记录不改。
