### PR TITLE
fix: 结算自检剔除周末幽灵时段行——t0 解锁判词去压(#1050)；add_side 盘中口径如实(#1051) [audit:strategy-review P3]

### DIFF
--- a/assets/data/quant_signal_review.json
+++ b/assets/data/quant_signal_review.json
@@ -3,38 +3,39 @@
   "days_logged": 55,
   "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
   "frozen_feed_excluded": 77,
+  "weekend_rows_excluded": 13,
   "factors": {
     "trend_on_follow": {
-      "n_events": 8,
-      "n_dates": 8,
+      "n_events": 7,
+      "n_dates": 7,
       "n_tickers": 1,
-      "hit_rate": 0.375,
+      "hit_rate": 0.429,
       "ci95": null,
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
       "reverse_edge_significant": false,
       "sample_sufficient": false,
       "min_n": 20,
-      "non_overlap_cap": 55,
+      "non_overlap_cap": 53,
       "decision_direction": null,
       "usable": false,
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "trend_off_avoid": {
-      "n_events": 344,
-      "n_dates": 50,
+      "n_events": 333,
+      "n_dates": 48,
       "n_tickers": 10,
-      "hit_rate": 0.5,
+      "hit_rate": 0.502,
       "ci95": [
         0.379,
-        0.619
+        0.618
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
       "reverse_edge_significant": false,
       "sample_sufficient": true,
       "min_n": 20,
-      "non_overlap_cap": 110,
+      "non_overlap_cap": 100,
       "decision_direction": null,
       "usable": false,
       "note": "聚类 CI 跨 50%，方向结论不入决策"
@@ -53,16 +54,16 @@
       "reverse_edge_significant": false,
       "sample_sufficient": true,
       "min_n": 20,
-      "non_overlap_cap": 88,
+      "non_overlap_cap": 80,
       "decision_direction": null,
       "usable": false,
       "note": "聚类 CI 跨 50%，方向结论不入决策"
     },
     "rsi_overbought_fade": {
-      "n_events": 7,
-      "n_dates": 6,
-      "n_tickers": 3,
-      "hit_rate": 0.286,
+      "n_events": 5,
+      "n_dates": 5,
+      "n_tickers": 2,
+      "hit_rate": 0.4,
       "ci95": [
         0.0,
         1.0
@@ -72,7 +73,7 @@
       "reverse_edge_significant": false,
       "sample_sufficient": false,
       "min_n": 20,
-      "non_overlap_cap": 33,
+      "non_overlap_cap": 20,
       "decision_direction": null,
       "usable": false,
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
@@ -91,26 +92,26 @@
       "reverse_edge_significant": false,
       "sample_sufficient": false,
       "min_n": 20,
-      "non_overlap_cap": 66,
+      "non_overlap_cap": 60,
       "decision_direction": null,
       "usable": false,
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "stop_breach_continue": {
-      "n_events": 239,
-      "n_dates": 43,
+      "n_events": 237,
+      "n_dates": 42,
       "n_tickers": 11,
-      "hit_rate": 0.531,
+      "hit_rate": 0.536,
       "ci95": [
-        0.379,
-        0.669
+        0.375,
+        0.674
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
       "reverse_edge_significant": false,
       "sample_sufficient": true,
       "min_n": 20,
-      "non_overlap_cap": 121,
+      "non_overlap_cap": 110,
       "decision_direction": null,
       "usable": false,
       "note": "聚类 CI 跨 50%，方向结论不入决策"

--- a/assets/data/t0_setup_review.json
+++ b/assets/data/t0_setup_review.json
@@ -1,182 +1,183 @@
 {
-  "as_of": "2026-08-25",
+  "as_of": "2026-08-26",
   "days_logged": 82,
   "min_n": 20,
   "horizon": 1,
   "grades": {
     "chase_low_quality": {
       "label": "🔴 追高低质",
-      "n": 161,
-      "hit_rate": 0.54,
+      "n": 137,
+      "hit_rate": 0.591,
       "ci95": [
-        0.463,
-        0.616
+        0.508,
+        0.67
       ],
-      "edge_significant": false,
+      "edge_significant": true,
       "sample_sufficient": true,
-      "edge_supported": false,
+      "edge_supported": true,
       "reverse_edge_supported": false,
-      "decision_direction": null,
-      "avg_dir_fwd_pct": 0.71,
-      "usable": false,
-      "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-      "non_overlap_cap": 1230
+      "decision_direction": "original",
+      "avg_dir_fwd_pct": 0.92,
+      "usable": true,
+      "note": "",
+      "non_overlap_cap": 1080
     },
     "elevated": {
       "label": "🟡 偏高位",
-      "n": 71,
-      "hit_rate": 0.507,
+      "n": 67,
+      "hit_rate": 0.522,
       "ci95": [
-        0.393,
-        0.62
+        0.405,
+        0.637
       ],
       "edge_significant": false,
       "sample_sufficient": true,
       "edge_supported": false,
       "reverse_edge_supported": false,
       "decision_direction": null,
-      "avg_dir_fwd_pct": -0.01,
+      "avg_dir_fwd_pct": -0.06,
       "usable": false,
       "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-      "non_overlap_cap": 1230
+      "non_overlap_cap": 1080
     },
     "oversold_low": {
       "label": "🟡 低位/超卖",
-      "n": 258,
-      "hit_rate": 0.45,
+      "n": 226,
+      "hit_rate": 0.478,
       "ci95": [
-        0.39,
-        0.511
+        0.414,
+        0.543
       ],
       "edge_significant": false,
       "sample_sufficient": true,
       "edge_supported": false,
       "reverse_edge_supported": false,
       "decision_direction": null,
-      "avg_dir_fwd_pct": -0.18,
+      "avg_dir_fwd_pct": -0.2,
       "usable": false,
       "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-      "non_overlap_cap": 1230
+      "non_overlap_cap": 1080
     }
   },
-  "summary": "没有牌面同时通过样本与正向 edge 闸（82 交易日留痕）——结论未解锁",
+  "summary": "🔴 追高低质 命中59%[51–67](n=137)",
+  "weekend_rows_excluded": 60,
   "multi_horizon": {
     "H1": {
       "horizon": 1,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 161,
-          "hit_rate": 0.54,
+          "n": 137,
+          "hit_rate": 0.591,
           "ci95": [
-            0.463,
-            0.616
+            0.508,
+            0.67
           ],
-          "edge_significant": false,
+          "edge_significant": true,
           "sample_sufficient": true,
-          "edge_supported": false,
+          "edge_supported": true,
           "reverse_edge_supported": false,
-          "decision_direction": null,
-          "avg_dir_fwd_pct": 0.71,
-          "usable": false,
-          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 1230
+          "decision_direction": "original",
+          "avg_dir_fwd_pct": 0.92,
+          "usable": true,
+          "note": "",
+          "non_overlap_cap": 1080
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 71,
-          "hit_rate": 0.507,
+          "n": 67,
+          "hit_rate": 0.522,
           "ci95": [
-            0.393,
-            0.62
+            0.405,
+            0.637
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.01,
+          "avg_dir_fwd_pct": -0.06,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 1230
+          "non_overlap_cap": 1080
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 258,
-          "hit_rate": 0.45,
+          "n": 226,
+          "hit_rate": 0.478,
           "ci95": [
-            0.39,
-            0.511
+            0.414,
+            0.543
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.18,
+          "avg_dir_fwd_pct": -0.2,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 1230
+          "non_overlap_cap": 1080
         }
       },
-      "summary": "没有牌面同时通过样本与正向 edge 闸——结论未解锁"
+      "summary": "🔴 追高低质 命中59%[51–67](n=137)"
     },
     "H5": {
       "horizon": 5,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 154,
-          "hit_rate": 0.578,
+          "n": 131,
+          "hit_rate": 0.565,
           "ci95": [
-            0.499,
-            0.653
+            0.479,
+            0.647
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": 0.94,
+          "avg_dir_fwd_pct": 1.08,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 240
+          "non_overlap_cap": 210
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 70,
-          "hit_rate": 0.471,
+          "n": 65,
+          "hit_rate": 0.462,
           "ci95": [
-            0.359,
-            0.587
+            0.346,
+            0.581
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.73,
+          "avg_dir_fwd_pct": -1.79,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 240
+          "non_overlap_cap": 210
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 238,
-          "hit_rate": 0.479,
+          "n": 208,
+          "hit_rate": 0.457,
           "ci95": [
-            0.416,
-            0.542
+            0.39,
+            0.525
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.98,
+          "avg_dir_fwd_pct": -0.91,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 240
+          "non_overlap_cap": 210
         }
       },
       "summary": "没有牌面同时通过样本与正向 edge 闸——结论未解锁"
@@ -186,117 +187,117 @@
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 139,
-          "hit_rate": 0.619,
+          "n": 116,
+          "hit_rate": 0.603,
           "ci95": [
-            0.536,
-            0.695
+            0.512,
+            0.688
           ],
           "edge_significant": true,
           "sample_sufficient": true,
           "edge_supported": true,
           "reverse_edge_supported": false,
           "decision_direction": "original",
-          "avg_dir_fwd_pct": 3.44,
+          "avg_dir_fwd_pct": 3.02,
           "usable": true,
           "note": "",
-          "non_overlap_cap": 120
+          "non_overlap_cap": 105
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 63,
-          "hit_rate": 0.444,
+          "n": 57,
+          "hit_rate": 0.386,
           "ci95": [
-            0.328,
-            0.567
+            0.271,
+            0.516
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -1.31,
+          "avg_dir_fwd_pct": -1.3,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 120
+          "non_overlap_cap": 105
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 232,
-          "hit_rate": 0.444,
+          "n": 202,
+          "hit_rate": 0.47,
           "ci95": [
-            0.381,
-            0.508
+            0.403,
+            0.539
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.34,
+          "avg_dir_fwd_pct": -0.73,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 120
+          "non_overlap_cap": 105
         }
       },
-      "summary": "🔴 追高低质 命中62%[54–70](n=139)"
+      "summary": "🔴 追高低质 命中60%[51–69](n=116)"
     },
     "H20": {
       "horizon": 20,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 100,
-          "hit_rate": 0.53,
+          "n": 86,
+          "hit_rate": 0.488,
           "ci95": [
-            0.433,
-            0.625
+            0.386,
+            0.592
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": 4.24,
+          "avg_dir_fwd_pct": 3.01,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 60
+          "non_overlap_cap": 45
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 45,
-          "hit_rate": 0.467,
+          "n": 41,
+          "hit_rate": 0.439,
           "ci95": [
-            0.329,
-            0.609
+            0.299,
+            0.59
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": 1.22,
+          "avg_dir_fwd_pct": -0.13,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 60
+          "non_overlap_cap": 45
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 217,
-          "hit_rate": 0.452,
+          "n": 174,
+          "hit_rate": 0.42,
           "ci95": [
-            0.387,
-            0.518
+            0.349,
+            0.494
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
-          "reverse_edge_supported": false,
+          "reverse_edge_supported": true,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -1.45,
+          "avg_dir_fwd_pct": -4.82,
           "usable": false,
-          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 60
+          "note": "Wilson CI 支持相反方向；原牌面禁用，不自动反向交易",
+          "non_overlap_cap": 45
         }
       },
       "summary": "没有牌面同时通过样本与正向 edge 闸——结论未解锁"

--- a/src/clawock/decision/add_side.py
+++ b/src/clawock/decision/add_side.py
@@ -23,7 +23,10 @@ every number from its inputs — the rules below are the ones already written do
   `breakout` state (close > prior 20-day high, not overheated) — the one add
   shape the 8-month bars backtest (#819) measured with a positive edge at every
   horizon (T+1/5/10/20 hit 52.5/54.0/52.5/55.9%, avg fwd +16.25% at T+20; HK
-  T+20 59.4%). Near-breakout/at-high without a primary filing stay `wait`
+  T+20 59.4%). This module only ever runs in the intraday slot, where "close"
+  is the live print and the close itself is still pending — rows say so
+  explicitly, and the backtest numbers are quoted as close-confirmed. Near-
+  breakout/at-high without a primary filing stay `wait`
   (no standalone edge). Soft news and sentiment remain colour, never an
   active-operation reason.
 * **Everything else is `wait`, with what would change it.** A price anomaly with no
@@ -212,8 +215,11 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
                     needs = f"{lead}{radar_row.get('prior_20d_high')} 并守住"
             else:
                 state_zh = radar_row.get('state_zh') or radar_row.get('state')
-                why = (f"技术面{state_zh}:收盘站上前 20 日高且未过热"
-                       f"(回测:四个周期命中率均>50%)")
+                # 本模块只在盘中档运行（intraday_preflight）：雷达的 close 是
+                # 实时价，收盘未确认——#819 回测度量的是收盘确认的突破，文案
+                # 不得把现价触发说成已确认的收盘事实。
+                why = (f"技术面{state_zh}:现价站上前 20 日高且未过热(盘中、收盘未确认;"
+                       f"回测口径为收盘确认:四个周期命中率均>50%)")
                 lead = f"{_proxy_of(radar_row)} 守住 " if _proxy_of(radar_row) else "守住 "
                 needs = f"{lead}{radar_row.get('prior_20d_high')}(回踩不破再谈加仓)"
         else:
@@ -312,7 +318,7 @@ def read_rows(*, anomalies=None, radar=None, levels=None, early_trend=None,
         "candidate_count": sum(r["verdict"] == "candidate" for r in rows),
         "wait_count": sum(r["verdict"] == "wait" for r in rows),
         "reject_count": sum(r["verdict"] == "reject" for r in rows),
-        "policy": ("技术突破(收盘站上前 20 日高且未过热)即 candidate,"
+        "policy": ("技术突破(现价站上前 20 日高且未过热,盘中读数、收盘未确认)即 candidate,"
                    "一手公告升级措辞;软消息/情绪只能停在 wait;"
                    "纪律动作未了结一律 reject。三态都不是下单授权。"),
     }

--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -16,6 +16,11 @@
   • sample_sufficient 只回答样本够不够；edge_supported 只回答 Wilson CI
     是否完整高于 50%。两者同时为真才 usable，禁止再用 raw n 自动解锁
   • 结算按 (日期, 标的) 去重取当日最后一条（端午盘中多条 → 取收盘牌面）
+  • 周末留痕行不产生结算观测（#1050）：留痕器任何时刻跑都会落一行，而闭市日
+    报价源会漂移或与下一交易日盘前快照逐字重复——跨它算出的 forward return
+    是伪观测（实测把 chase_low_quality 的 T+1 命中率从干净段 63.0% 拖到公开值
+    54.0%，解锁判词被压翻转）。读取侧防御、数据不改写，与 quant_signal_review
+    的冻结价闸同一模式。
 
 输出 assets/data/t0_setup_review.json。brief preflight 每日顺跑，dashboard🎯卡展示。
 """
@@ -23,6 +28,7 @@ import json
 import math
 import sys
 from datetime import date
+from datetime import date as real_date
 from pathlib import Path
 
 
@@ -84,17 +90,49 @@ def _load_days():
     return [{'as_of': d, 'rows': by_day[d]} for d in sorted(by_day)]
 
 
+def _is_weekend(day):
+    """周六/周日永远不是 HK/US 交易时段；无法解析的日期按工作日保留。
+
+    用 real_date 而非模块级 date：测试会替换后者（_FixedDate 只造 today）。
+    """
+    try:
+        return real_date.fromisoformat(str(day)[:10]).weekday() >= 5
+    except ValueError:
+        return False
+
+
+def _weekend_trigger_rows(days):
+    """周末行里本会触发计数的牌面行数——它们不再产生任何观测（#1050）。"""
+    n = 0
+    for d in days:
+        if not _is_weekend(d.get('as_of')):
+            continue
+        for m in (d.get('rows') or {}).values():
+            if not m.get('close'):
+                continue
+            lab = m.get('grade_label') or ''
+            if any(cond(lab) for cond, _ in GRADE_TESTS.values()):
+                n += 1
+    return n
+
+
 def _settle(days, horizon):
     """Run the grade-vs-forward-return accounting for one horizon.
+
+    Settlement walks non-weekend rows only (#1050): a Friday trigger settles
+    against the next weekday row, and weekend rows produce no observations at
+    all — their closes are closed-market drift or duplicated pre-open
+    snapshots, never session closes.
 
     Returns (stats, grades, usable_lines) — the same three things main()
     assembles, so a multi-horizon run is one loop instead of a copy.
     """
+    sessions = [d for d in days if not _is_weekend(d.get('as_of'))]
     stats = {k: {'n': 0, 'hits': 0, 'fwd_sum': 0.0} for k in GRADE_TESTS}
-    for i, day in enumerate(days):
-        if i + horizon >= len(days):
+    for i, day in enumerate(sessions):
+        if i + horizon >= len(sessions):
             continue  # 窗口未到期
-        nxt = days[i + horizon]['rows']
+        nxt = sessions[i + horizon]['rows']
         for t, m in day['rows'].items():
             c0 = m.get('close')
             lab = m.get('grade_label') or ''
@@ -110,8 +148,8 @@ def _settle(days, horizon):
                     s['fwd_sum'] += fwd * direction  # 方向化收益(正=警示/预测被证实)
     # #819:这些窗口是重叠的(Wilson CI 假设独立),写一个非重叠上限估计,
     # 免得 n=210 被当成 210 个独立样本。
-    tickers = {t for d in days for t in d['rows']}
-    non_overlap_cap = len(tickers) * (len(days) // horizon) if horizon else 0
+    tickers = {t for d in sessions for t in d['rows']}
+    non_overlap_cap = len(tickers) * (len(sessions) // horizon) if horizon else 0
     grades = {}
     usable = []
     for name, s in stats.items():
@@ -161,6 +199,7 @@ def main(argv=None):
         print('  no t0 history yet — skip')
         return 0
 
+    weekend_rows = _weekend_trigger_rows(days)
     _, grades, usable = _settle(days, HORIZON)
 
     summary = ('、'.join(usable) if usable
@@ -176,6 +215,9 @@ def main(argv=None):
     out = {
         'as_of': date.today().isoformat(), 'days_logged': len(days),
         'min_n': MIN_N, 'horizon': HORIZON, 'grades': grades, 'summary': summary,
+        # #1050:周末行不结算。days_logged 是原始留痕天数；weekend_rows_excluded
+        # 是其中本会触发计数、现不再产生观测的牌面行数。
+        'weekend_rows_excluded': weekend_rows,
         # #819:同一条留痕的 T+1/5/10/20 对账,horizons 键顺序即周期。
         'multi_horizon': multi,
         'overlap_note': ('留痕窗口重叠,Wilson CI 假设独立,故偏乐观;'

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -24,9 +24,17 @@ CI 整体成立时才允许反向解读。T+5/T+20 窗口逐日重叠 → 披露
 32/40 个观测是伪影。连续多个留痕日同一收盘价在真实市场几乎不出现（周末/
 假日顺延造成的同价 ≤2–3 天），≥4 判为断源：这些 ticker-日不产生任何观测，
 排除量披露在 frozen_feed_excluded，数据本身保留不作改写。
+
+周末行闸（#1050）：留痕器任何时刻跑都会落一行，周六/周日永远没有 HK/US
+交易时段——闭市日报价源会漂移，或与下一交易日盘前快照逐字重复（实测
+07-26≡07-27、08-09≡08-10 全 ticker 收盘集相同），跨它结算的 forward
+return 是伪观测。触发日在周末的因子行不产生观测并计入 weekend_rows_excluded；
+工作日触发的观测改按非周末行序列结算（周五顺延到周一），horizon 数的是
+交易时段行数而不是原始行数。
 """
 import json
 import random
+from datetime import date as real_date
 from datetime import date
 from pathlib import Path
 
@@ -45,6 +53,31 @@ MIN_N = 20
 # 同一标的连续 ≥FROZEN_RUN_MIN 个留痕日收盘价完全相同 = 行情源断流（见
 # docstring 的 RKLB/HOOD 事故）。周末/假日顺延造成的合法同价最多 2–3 天。
 FROZEN_RUN_MIN = 4
+
+
+def _is_weekend(day):
+    """周六/周日永远不是 HK/US 交易时段；无法解析的日期按工作日保留。
+
+    用 real_date 而非模块级 date：测试会替换后者（_FixedDate 只造 today）。
+    """
+    try:
+        return real_date.fromisoformat(str(day)[:10]).weekday() >= 5
+    except ValueError:
+        return False
+
+
+def _weekend_trigger_rows(days):
+    """周末行里本会触发计数的因子行数——它们不再产生任何观测（#1050）。"""
+    n = 0
+    for day in days:
+        if not _is_weekend(day.get('as_of')):
+            continue
+        for sig in (day.get('rows') or {}).values():
+            if not sig.get('close'):
+                continue
+            if any(cond(sig) for cond, _, _ in FACTOR_TESTS.values()):
+                n += 1
+    return n
 
 
 def frozen_ticker_days(days):
@@ -133,17 +166,21 @@ def main(argv=None):
              for k, (_, _, h) in FACTOR_TESTS.items()}
     frozen = frozen_ticker_days(days)
     frozen_excluded = 0
-    for i, day in enumerate(days):
+    # 周末行不是交易时段（#1050）：结算只在非周末行序列上走，horizon 数的
+    # 是时段行数；触发日在周末的因子行由 _weekend_trigger_rows 单独披露。
+    sessions = [day for day in days if not _is_weekend(day.get('as_of'))]
+    weekend_excluded = _weekend_trigger_rows(days)
+    for i, day in enumerate(sessions):
         for sym, sig in (day.get('rows') or {}).items():
             c0 = sig.get('close')
             if not c0:
                 continue
             for name, (cond, direction, horizon) in FACTOR_TESTS.items():
-                if i + horizon >= len(days):
+                if i + horizon >= len(sessions):
                     continue          # 窗口未到期，留给未来结算
                 if not cond(sig):
                     continue
-                settle_day = days[i + horizon]
+                settle_day = sessions[i + horizon]
                 c1 = ((settle_day.get('rows') or {}).get(sym) or {}).get('close')
                 if not c1:
                     continue
@@ -198,7 +235,7 @@ def main(argv=None):
                          'reverse_edge_significant': reverse_sig,
                          'sample_sufficient': sample_sufficient,
                          'min_n': MIN_N,
-                         'non_overlap_cap': (len(tickers) * (len(days) // s['horizon'])
+                         'non_overlap_cap': (len(tickers) * (len(sessions) // s['horizon'])
                                              if s['horizon'] else 0),
                          'decision_direction': direction if usable_now else None,
                          'usable': usable_now,
@@ -215,6 +252,7 @@ def main(argv=None):
     out = {'as_of': date.today().isoformat(), 'days_logged': len(days),
            'unlock_rule': 'cluster_ci_entirely_above_or_below_50pct',
            'frozen_feed_excluded': frozen_excluded,
+           'weekend_rows_excluded': weekend_excluded,
            'factors': factors, 'summary': summary,
            'discipline': ('自迭代规则：公开 n_events/n_dates/n_tickers；date×ticker 双向聚类 '
                           'CI 跨 50% 不入决策；只有反向 CI 整体低于 50% 才允许反向解读。driven_by='
@@ -222,7 +260,8 @@ def main(argv=None):
                           '为准，不使用固定百分比。')}
     safe_write_json(OUT, out)
     skipped = f'，冻结价剔除 {frozen_excluded} 个观测' if frozen_excluded else ''
-    print(f'  review: {len(days)} days, summary: {summary}{skipped}')
+    wk = f'，周末行剔除 {weekend_excluded} 个观测' if weekend_excluded else ''
+    print(f'  review: {len(days)} days, summary: {summary}{skipped}{wk}')
 
 
 if __name__ == '__main__':

--- a/tests/test_add_side_reads.py
+++ b/tests/test_add_side_reads.py
@@ -514,6 +514,9 @@ def test_a_technical_breakout_alone_is_a_candidate():
     row = _row(out, "02208")
     assert row["verdict"] == "candidate"
     assert "突破" in row["why"], row["why"]
+    # 本模块只在盘中档运行：现价触发必须说成未确认，不得断言已收盘（#1051）
+    assert "收盘未确认" in row["why"], row["why"]
+    assert "收盘确认" in row["why"], row["why"]
     assert row["needs"].startswith("守住 11.72"), row["needs"]
     assert out["candidate_count"] == 1
 

--- a/tests/test_quant_signal_review.py
+++ b/tests/test_quant_signal_review.py
@@ -329,16 +329,51 @@ def test_frozen_feed_runs_never_become_factor_observations(monkeypatch):
     assert result["frozen_feed_excluded"] == 5
 
 
-def test_weekend_flat_pairs_still_count_as_observations(monkeypatch):
-    # A legitimate 2-session flat stretch (weekend carry of Friday's close)
-    # is below FROZEN_RUN_MIN and must keep producing observations.
+def test_short_flat_pairs_still_count_as_observations(monkeypatch):
+    # A legitimate 2-session flat stretch is below FROZEN_RUN_MIN and must
+    # keep producing observations (weekday labels: ISO weekends are a
+    # different gate — see test_weekend_as_of_rows_never_settle...).
     days = [
+        {"as_of": "thu", "rows": {"W": {"close": 100.0, "trend_on": True}}},
         {"as_of": "fri", "rows": {"W": {"close": 100.0, "trend_on": True}}},
-        {"as_of": "sat", "rows": {"W": {"close": 100.0, "trend_on": True}}},
-        {"as_of": "sun", "rows": {"W": {"close": 100.5, "trend_on": True}}},
+        {"as_of": "mon", "rows": {"W": {"close": 100.5, "trend_on": True}}},
     ]
     result = _run_review(monkeypatch, days)
 
     factor = result["factors"]["trend_on_follow"]
     assert factor["n_events"] == 2
     assert result["frozen_feed_excluded"] == 0
+
+
+def test_weekend_as_of_rows_never_settle_and_are_disclosed(monkeypatch):
+    """#1050: 周末留痕行不是交易时段。
+
+    周日触发不产生观测；周一盘前快照与周日逐字重复时，周一触发的观测
+    顺延到周二的真实收盘结算。旧实现会把两对重复快照都算成 fwd=0 的伪
+    miss（n=3/hits=1）。
+    """
+    days = [
+        {"as_of": "2026-08-07", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "2026-08-09", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "2026-08-10", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "2026-08-11", "rows": {"W": {"close": 110.0}}},
+    ]
+    result = _run_review(monkeypatch, days)
+
+    factor = result["factors"]["trend_on_follow"]
+    assert factor["n_events"] == 2   # 周日的触发被剔除，剩 Fri→Mon、Mon→Tue
+    assert factor["hit_rate"] == 0.5
+    assert result["weekend_rows_excluded"] == 1
+
+
+def test_all_weekend_history_unlocks_nothing(monkeypatch):
+    days = [
+        {"as_of": "2026-08-08", "rows": {"W": {"close": 100.0, "trend_on": True}}},
+        {"as_of": "2026-08-09", "rows": {"W": {"close": 90.0}}},
+    ]
+    result = _run_review(monkeypatch, days)
+
+    factor = result["factors"]["trend_on_follow"]
+    assert factor["n_events"] == 0
+    assert factor["usable"] is False
+    assert result["weekend_rows_excluded"] == 1

--- a/tests/test_t0_setup_review.py
+++ b/tests/test_t0_setup_review.py
@@ -49,8 +49,8 @@ def _two_day_fixture():
         first[f"E{i}"] = {"grade_label": "偏高位", "close": 100.0}
         second[f"E{i}"] = {"grade_label": "", "close": 90.0}
     return [
-        {"as_of": "2026-07-24", "rows": first},
-        {"as_of": "2026-07-25", "rows": second},
+        {"as_of": "2026-07-23", "rows": first},
+        {"as_of": "2026-07-24", "rows": second},
     ]
 
 
@@ -79,3 +79,39 @@ def test_small_sample_never_unlocks_even_with_perfect_hits(monkeypatch):
     assert elevated["sample_sufficient"] is False
     assert elevated["usable"] is False
     assert elevated["note"] == "样本不足，不得当结论引用方向"
+
+
+def test_weekend_rows_never_settle_and_are_disclosed(monkeypatch):
+    """#1050: 周五触发顺延到周一结算；周六幽灵行不产生观测且被披露。
+
+    闭市日报价源漂移（Sat 收盘既不等于 Fri 也不等于 Mon），跨它算出的
+    forward return 是伪观测——旧实现会给 n=40（含 Sat→Mon 的伪对）。
+    """
+    fri = {f"C{i}": {"grade_label": "追高低质", "close": 100.0} for i in range(20)}
+    sat = {f"C{i}": {"grade_label": "追高低质", "close": 101.0} for i in range(20)}
+    mon = {f"C{i}": {"grade_label": "", "close": 90.0} for i in range(20)}
+    days = [
+        {"as_of": "2026-08-07", "rows": fri},   # 周五：触发，顺延周一结算
+        {"as_of": "2026-08-08", "rows": sat},   # 周六：幽灵行，不产生观测
+        {"as_of": "2026-08-10", "rows": mon},   # 周一：真实下一时段
+    ]
+    result = _run(monkeypatch, days)
+
+    chase = result["grades"]["chase_low_quality"]
+    assert chase["n"] == 20                      # 只有周五的触发入账
+    assert chase["hit_rate"] == 1.0              # 100→90 跌，direction=-1 全命中
+    assert result["weekend_rows_excluded"] == 20  # 周六行的 20 条触发被剔除
+
+
+def test_weekend_only_history_produces_no_observations(monkeypatch):
+    """全部留痕都落在周末时，任何牌面都不产生观测、不得解锁。"""
+    sat = {f"C{i}": {"grade_label": "追高低质", "close": 100.0} for i in range(20)}
+    sun = {f"C{i}": {"grade_label": "", "close": 50.0} for i in range(20)}
+    result = _run(monkeypatch, [
+        {"as_of": "2026-08-08", "rows": sat},
+        {"as_of": "2026-08-09", "rows": sun},
+    ])
+    chase = result["grades"]["chase_low_quality"]
+    assert chase["n"] == 0
+    assert chase["usable"] is False
+    assert result["weekend_rows_excluded"] == 20


### PR DESCRIPTION
## strategy-review 切片第 3 遍审计（对抗对象 = 前两轮修复自身）

### 前两轮修复反查：全部成立，无回归

- **#1037 冻结价闸**（PR #1037）：当前 master 数据全量重扫，冻结行程仍只有 RKLB×31/HOOD×13 两段，闸边界正确；重跑 `signal_review` 复现 frozen_feed_excluded=77。
- **#1046 β-stale 闸**（PR #1046）：guardrail.py:342 / risk.py:1064 的 `not stale` 位成立；`_revive_stale_block` 连败保首戳验证无误；「combined 从不复活」注释断言经 compute_combined（risk.py:934）源码核对为真；stale 时 brief 仍收到 risk_data_stale 披露——β 闸失效不是静默降级。
- **kcn 定案漂移检查**：突破加仓成立（breakout 自促升）/深跌抄底不成立（wait_rebreak 不入 IN_PLAY_STATES）/SPCH 累计阈值无复活代码——现行实现与定案一致。

### 新发现 → 本 PR 修两项

**Closes #1050 —— 结算自检把周末幽灵时段行当交易日（真缺陷，高 ROI）**
- 证据：quant_signals_history 周末行 ×2 且 07-26≡07-27、08-09≡08-10 全 ticker 收盘集逐字节相同（周一盘前快照与周日重复）；t0_setups_history 82 天里 10 天是周末，闭市报价源漂移（CRCL 六 67.08/日 66.67/五 66.82/一 64.90，与相邻真实收盘都对不上）；两个 reviewer 都按行索引结算不看交易日历。
- 影响：chase_low_quality T+1 公开 54.0% CI[46.3,61.6]=未解锁，剔周末后 63.0% CI[54.1,71.2]=应解锁——解锁判词被压翻转，26% 观测涉幽灵时段。
- 修法：setup_review/signal_review 结算只在非周末行序列上走（周五触发顺延下一工作日结算），触发日在周末的不产生观测并披露 `weekend_rows_excluded`。读取侧防御、数据不改写（#1037 同模式）。产物已重生成：chase_low_quality usable False→True（59.1% [50.8,67.0] n=137），quant_signal_review 无解锁翻转（剔 13 个观测、frozen 77 不变）。

**Closes #1051 —— add_side 盘中 candidate 文案口径错位（中 ROI）**
- 证据：模块唯一调用方是盘中档（intraday_preflight.py:950），雷达 close 是实时价，文案却断言「收盘站上前 20 日高」并引用收盘确认口径的 #819 回测数字。
- 修法：why/policy/docstring 改为「现价站上…盘中、收盘未确认；回测口径为收盘确认」。promotion 形状不动（kcn 盘中捕捉诉求保留），只修不诚实的话术。

### 记录不改
1. guardrail_history 行记 us_beta_spx 不带 stale 标记（bookkeeping 歧义）；
2. 冻结闸对 <4 日断源行程不设防（FROZEN_RUN_MIN 折中，动它需新证据）；
3. dashboard render 对 stale β 数值照常着色，仅 alerts 区披露 staleness。

### 测试

- 新增 4 条行为断言：周末行不产生观测且披露计数、周五顺延周一结算、全周末历史零观测、breakout 文案含未确认语义；既有夹具恰好用周六日期的两处改为工作日（fixture 自己踩了本缺陷）。
- 针对性：test_t0_setup_review + test_quant_signal_review + test_add_side_reads 56 passed；test_quant_package_boundary + test_build_evidence + test_history_store 19 passed。不跑全量套件。

不触碰 portfolio.json 等运行时数据；只改 8 个明确路径（3 源 + 3 测试 + 2 重生成产物）。
