### PR TITLE
fix: memory/snapshots 落 180 天文件级滚动窗口 (#1040) [audit:memory-lifecycle P3]

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -52,6 +52,7 @@ from zoneinfo import ZoneInfo
 
 from clawock.workspace import workspace_root
 from clawock import sessions as trading_calendar
+from clawock import history_store
 from clawock.context import brief as brief_context
 from clawock.decision import ledger as decision_v2
 from clawock.decision import packet as brief_decision_packet
@@ -1574,6 +1575,17 @@ def main(argv=None):
     snapshot_path  = SNAPSHOT_DIR / f'{today}.json'
     snapshot_path.write_bytes(portfolio_path.read_bytes())
     print(f'   ✓ {snapshot_path.name}')
+
+    # Roll cold snapshots into _archive/ (#1040): readers look at ≤90 entries,
+    # storage was unbounded. Runs HERE and only here — this postflight commits
+    # with a directory-scoped `git add memory/` that carries the moves; the
+    # intraday/report postflights stage explicit paths and would strand them.
+    try:
+        rolled = history_store.roll_dated_files(SNAPSHOT_DIR, today=today)
+        if rolled:
+            print(f'   ✓ archived {len(rolled)} cold snapshot(s)')
+    except Exception as exc:  # non-fatal: rolling must never kill the brief
+        print(f'   ! snapshot roll skipped: {exc}')
 
     # Load for downstream
     portfolio = json.loads(portfolio_path.read_text())

--- a/src/clawock/history_store.py
+++ b/src/clawock/history_store.py
@@ -30,11 +30,19 @@ So the decision (2026-08-25) is a **storage split, not a semantic change**:
 The archive is also the seam: moving cold rows off master (to the data branch or
 out of the repo) later becomes a change of one path here, instead of a migration
 of four writers and three readers.
+
+#951 originally covered only row-level JSONL series. ``memory/snapshots/`` has
+the same disease in file form (#1040): one dated file per trading day, readers
+that look at at most the last 90 entries, storage that grows forever. Those are
+handled by :func:`roll_dated_files`, the file-level analogue of
+``split_window``: whole files past the hot window move into a sibling
+``_archive/`` directory instead of rows being partitioned across two files.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
@@ -46,6 +54,15 @@ from clawock.safe_io import safe_write_text
 HOT_WINDOW_DAYS = 180
 
 DATE_KEY = 'as_of'
+
+# A file whose entire name is a date — the memory/snapshots/ shape
+# (``2026-08-26.json``). Strict full match on purpose: tagged one-offs like
+# ``2026-05-16-saturday-baseline.json`` are not daily churn (never rewritten),
+# and the dashboard's snapshot filter must keep agreeing with this set, so
+# ``publish.dashboard.SNAPSHOT_FNAME_RE`` is aliased to this constant.
+DATED_FILE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}\.json$')
+
+ARCHIVE_DIR_NAME = '_archive'
 
 
 def archive_path(path) -> Path:
@@ -150,3 +167,45 @@ def series_digest(path) -> str:
         )
         hasher.update(b'\n')
     return 'sha256:' + hasher.hexdigest()[:16]
+
+
+def roll_dated_files(directory, *, keep_days=HOT_WINDOW_DAYS, today=None) -> list:
+    """Move dated files older than ``keep_days`` into ``directory/_archive/``.
+
+    The file-level analogue of :func:`split_window` (#1040): every consumer of
+    ``memory/snapshots/`` looks at a bounded recent window (dashboard embeds 90,
+    sparklines take 8, weekly review reads its own week), so keeping 180 days
+    flat costs nothing semantic and bounds what every future checkout carries.
+
+    Same conservatism as :func:`split_window`: a file whose name is not a bare
+    date cannot be proven old and is never touched — which also keeps this safe
+    to point at mixed directories. The archive directory itself is never
+    scanned or rewritten; like the JSONL archive it is write-once parking.
+
+    Returns the names moved (empty on nothing-to-do), so the caller can report
+    or no-op. Callers must commit from a pathspec that covers the archive dir
+    (the morning brief postflight's ``git add memory/`` does; the intraday
+    postflights' explicit-file adds do not, which is why only preflight rolls).
+    """
+    today = today or datetime.now(timezone.utc).date()
+    if isinstance(today, str):
+        today = date.fromisoformat(today[:10])
+    if isinstance(today, datetime):
+        today = today.date()
+    cutoff = (today - timedelta(days=keep_days)).isoformat()
+    directory = Path(directory)
+    if not directory.is_dir():
+        return []
+    archive = directory / ARCHIVE_DIR_NAME
+    moved = []
+    for p in sorted(directory.iterdir()):
+        if not p.is_file() or not DATED_FILE_RE.match(p.name):
+            continue
+        if p.name[:10] >= cutoff:
+            continue
+        archive.mkdir(parents=True, exist_ok=True)
+        target = archive / p.name
+        if not target.exists():
+            p.rename(target)
+            moved.append(p.name)
+    return moved

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -21,19 +21,23 @@ from pathlib import Path
 from typing import NamedTuple
 from zoneinfo import ZoneInfo
 
-# Strict YYYY-MM-DD.json — rejects baselines/backups/archives that share the
-# snapshots dir (e.g. 2026-05-16-saturday-baseline.json caused duplicate 5-16
-# rows in the equity curve before this filter was added).
-SNAPSHOT_FNAME_RE = re.compile(r'^\d{4}-\d{2}-\d{2}\.json$')
-# A session key inside a canonical bar document (memory/bars/<ticker>.json).
-SESSION_DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
-
 from clawock.workspace import workspace_root
+from clawock import history_store
 from clawock import instruments as instrument_registry
 from clawock import json_repair
 from clawock.decision import ledger as decision_v2
 from clawock.publish import outputs as dashboard_outputs
 from clawock.publish import outcomes as dashboard_outcomes
+
+# Strict YYYY-MM-DD.json — rejects baselines/backups/archives that share the
+# snapshots dir (e.g. 2026-05-16-saturday-baseline.json caused duplicate 5-16
+# rows in the equity curve before this filter was added). Aliased to the
+# history_store constant so the #1040 roller and this reader cannot drift
+# apart: what the roller archives must stay exactly what the equity curve
+# already ignores.
+SNAPSHOT_FNAME_RE = history_store.DATED_FILE_RE
+# A session key inside a canonical bar document (memory/bars/<ticker>.json).
+SESSION_DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
 WS_ROOT = workspace_root(Path.cwd())
 OUT_DIR = WS_ROOT / 'assets' / 'data'

--- a/tests/test_dashboard_input_fingerprint.py
+++ b/tests/test_dashboard_input_fingerprint.py
@@ -63,3 +63,15 @@ def test_fingerprint_cache_round_trips(tmp_path):
     # A torn cache must read as absent, never raise.
     (ws / FINGERPRINT_CACHE).write_text('not json')
     assert _read_fingerprint_cache(ws) is None
+
+
+def test_snapshot_filter_and_the_1040_roller_cannot_drift_apart():
+    """#1040: 滚动窗口把冷快照挪进 _archive/ 的前提是「dashboard 本来就不读它」。
+
+    这个前提靠两条定义完全一致来保证——所以直接断言同一个对象，而不是两份
+    各自维护、迟早漂移的正则字符串。
+    """
+    from clawock import history_store
+    from clawock.publish.dashboard import SNAPSHOT_FNAME_RE
+
+    assert SNAPSHOT_FNAME_RE is history_store.DATED_FILE_RE

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -112,3 +112,68 @@ def test_an_old_cluster_stays_recurrent_after_it_moves_into_the_archive(
 
     assert event['novelty_reason'] == 'cluster_old_but_recurrent'
     assert event['novelty_score'] == 0.8
+
+
+# ── #1040: 文件级滚动（memory/snapshots/ 的 dated file 形态）────────────────
+
+
+def _snap(tmp_path, name, body='{}'):
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_a_cold_dated_file_moves_into_the_archive_and_a_hot_one_stays(tmp_path):
+    old = _snap(tmp_path, '2026-01-05.json')
+    recent = _snap(tmp_path, '2026-08-20.json')
+
+    moved = history_store.roll_dated_files(tmp_path, today=TODAY)
+
+    assert moved == ['2026-01-05.json']
+    assert not old.exists()
+    assert (tmp_path / '_archive' / '2026-01-05.json').read_text() == '{}'
+    assert recent.exists()
+
+
+def test_undated_and_tagged_names_are_never_touched(tmp_path):
+    """名字证明不了日期的文件不动——和 split_window 对无 as_of 行的处理同一条
+    保守原则。带 tag 的一次性基线（2026-05-16-saturday-baseline.json 形态）
+    从不被改写，留着没有日成本，滚它只会白动 fingerprint。"""
+    baseline = _snap(tmp_path, '2026-01-05-saturday-baseline.json')
+    tickerish = _snap(tmp_path, 'notes.json')
+
+    moved = history_store.roll_dated_files(tmp_path, today=TODAY)
+
+    assert moved == []
+    assert baseline.exists() and tickerish.exists()
+
+
+def test_rolling_is_idempotent_and_never_rewrites_the_archive(tmp_path):
+    cold = _snap(tmp_path, '2026-01-05.json')
+    history_store.roll_dated_files(tmp_path, today=TODAY)
+    archived_bytes = (tmp_path / '_archive' / '2026-01-05.json').read_bytes()
+
+    moved_again = history_store.roll_dated_files(tmp_path, today=TODAY)
+
+    assert moved_again == []
+    assert not cold.exists()
+    # 冷档是一次性停放：二次滚动既不复制也不改写已归档内容。
+    assert list((tmp_path / '_archive').iterdir()) == \
+        [tmp_path / '_archive' / '2026-01-05.json']
+    assert (tmp_path / '_archive' / '2026-01-05.json').read_bytes() == archived_bytes
+
+
+def test_roll_never_scans_or_touches_the_archive_interior(tmp_path):
+    history_store.roll_dated_files(tmp_path, today=TODAY)  # creates nothing yet
+    archive = tmp_path / '_archive'
+    archive.mkdir()
+    ancient_in_archive = _snap(archive, '2025-01-01.json')
+
+    moved = history_store.roll_dated_files(tmp_path, today=TODAY)
+
+    assert moved == []
+    assert ancient_in_archive.exists()
+
+
+def test_roll_on_a_missing_directory_is_a_no_op(tmp_path):
+    assert history_store.roll_dated_files(tmp_path / 'nope', today=TODAY) == []


### PR DESCRIPTION
## memory-lifecycle 切片第 3 遍审计（对抗对象=前两轮修复本身）产出

Closes #1040

### 修复：memory/snapshots 文件级滚动窗口（#1040 落地）

P1 立项时按旧规属机制级禁区只立项；按 2026-08-26 裁决自治条本轮接手执行。bull/bear 全文见 [issue 评论](https://github.com/KCNyu/clawock/issues/1040#issuecomment-5416579067)。

- `history_store.roll_dated_files()`：#951 seam 的文件级 analogue。严格 `^\d{4}-\d{2}-\d{2}\.json$` **全**匹配才滚（undated/tagged 基线不动，同 split_window 对无日期行的保守原则）；冷档进既有的 `memory/snapshots/_archive/` 惯例位；幂等；从不扫描/改写冷档内部。
- 唯一挂点：`brief_preflight` [4/14] 写完当天快照后。原因：只有 deep-brief postflight 用目录级 `git add memory/`（brief_postflight.py:585）能 stage 移动；intraday/report postflight 只 add 显式路径，挂那里会搁浅。
- `dashboard.SNAPSHOT_FNAME_RE` 改为 alias `history_store.DATED_FILE_RE`——滚出去的必须恰好是 equity reader 本来就不读的集合，两处定义合一，身份测试钉住。
- decisions.jsonl 分项裁决为**维持现状**：评分/复盘/system_check 确需全史重放，且单文件 append-only 没有 JSONL rewrite 的每日放大病。理由留 issue。

### 验证

- 新测试 6 例全绿（roller 行为五例 + reader/roller 身份契约一例）
- 定向回归：test_push_scope、test_build_dashboard (80)、test_snapshot_realized_sessions、test_recent_price_moves_source、test_decision_traces 全绿
- test_workspace_portability 两例失败为本机干净 master 基线既有（环境性，非本 PR 引入）
- 真实快照副本 dry-run：76 文件 moved=0（最早 2026-05-16 尚在窗内）；首次实际归档预计 2026-11 中旬，与 #951 的 9 月观察点同列跟踪

### 本轮其余 finding（不随本 PR）

- #1038 反查出 P1 处置方案的落地危险：日记是 live box 上永远 dirty 的已跟踪文件，squash merge 后经 refresh_live.sh autostash pull 会 modify/delete 冲突甚至丢数据。安全落地配方（refresh 守卫 → rm --cached → AGENTS.md 表行）已写进 [issue 评论](https://github.com/KCNyu/clawock/issues/1038#issuecomment-5416586033)，留下一轮按序执行。
