### PR TITLE
test: 钉住 decision-contract.md 双胞胎 parity [audit:md-cleanup P4]

### DIFF
--- a/tests/test_portable_workflow.py
+++ b/tests/test_portable_workflow.py
@@ -1,4 +1,6 @@
 """High-cost invariants unique to the investment decision workflow."""
+from pathlib import Path
+
 import copy
 import json
 
@@ -6,6 +8,12 @@ from clawock.workflows import (
     load_workflow,
     render_workflow_schema,
     validators_for,
+)
+
+PLUGIN_CONTRACT_TWIN = (
+    Path(__file__).resolve().parents[1]
+    / "examples" / "dsh" / "packages" / "clawock-dsh"
+    / "skills" / "investment-decision" / "references" / "decision-contract.md"
 )
 
 
@@ -83,3 +91,32 @@ def test_codex_schema_is_a_relaxed_projection_not_the_final_validator():
     invalid = _example()
     invalid["decision"]["evidence_ids"] = ["filing-growth", "filing-growth"]
     assert "duplicate_evidence_reference" in _codes(invalid)
+
+
+def test_the_dsh_plugin_contract_twin_tracks_the_pack_copy():
+    """The decision contract ships twice on purpose: once in the wheel pack
+    that `clawock workflow install` copies into workspaces, once inside the
+    npm plugin package. Both teach the same contract the same validators.py
+    enforces, so they must not diverge — and they have before: #646 had to
+    hand-patch both trees because the prose taught fields publish rejects.
+
+    No build step shares the two files, so this pin is the only thing that
+    turns a silent fork into a required-check failure. If divergence is ever
+    deliberate, edit both copies consciously and relax this test in the same
+    commit with a reason.
+    """
+    pack_copy = load_workflow("investment-decision").resource.joinpath(
+        "references/decision-contract.md"
+    )
+    assert pack_copy.is_file(), f"pack contract missing: {pack_copy}"
+    assert PLUGIN_CONTRACT_TWIN.is_file(), (
+        f"plugin package contract missing: {PLUGIN_CONTRACT_TWIN}"
+    )
+    assert PLUGIN_CONTRACT_TWIN.read_bytes() == pack_copy.read_bytes(), (
+        "the two shipped copies of references/decision-contract.md diverged:\n"
+        f"  pack:   {pack_copy}\n"
+        f"  plugin: {PLUGIN_CONTRACT_TWIN}\n"
+        "Both teach one contract enforced by one validator. Copy the edited "
+        "side over the other (or, if the audiences truly need different docs, "
+        "consciously relax this pin with a reason in the same commit)."
+    )


### PR DESCRIPTION
## 背景

md-cleanup 切片第 4 遍审计（对抗对象=前三轮修复本身）。回归复核全部成立：

- P1 #1034：`.github/CONTRIBUTING.md:35` → `docs/reference/product-profile-operations.md` 存在且含 § The deciding question（docs/reference/product-profile-operations.md:8）；
- P2 #1044：examples/README.md:21 DSH 双链有效；docs/visual-regression/issue-206/README.md 五张同目录 jpg 齐全；
- P3 #1049：profile templates 面无残留（profiles.py / 两份 profile.json / docs 全部 grep 归零），回归闸 `test_profile_templates_surface_stays_deleted` 通过；
- #1048：site/briefs.md 被删区块无任何 workflow/模板残留消费（.github/workflows 零引用 briefs）。

本轮新增取证维度（前三轮未覆盖）：全量 tracked .md 的 **md5 内容去重**、**空文件扫描**、
**大小写敏感链接解析**（本机 Linux FS 即真实 Pages 构建语义）、P3 之后全部提交的 md 触碰面复查。
结果：死链 0、空文件 0、大小写陷阱 0；唯一命中是下述一对内容双胞胎。

## 修复（Closes #1054）

**decision-contract.md 双胞胎零 parity 钉。** 全仓 md5 去重只出一对手工维护的字节级相同文件：

- `src/clawock/workflows/packs/investment-decision/references/decision-contract.md`（wheel pack，install_workflow 经 registry.py:158-183 整树装入 workspace）
- `examples/dsh/packages/clawock-dsh/skills/investment-decision/references/decision-contract.md`（npm 插件包，SKILL.md:38,137 引用）

两侧都活着、都不是删除候选；问题是零自动钉 + 漂移前科 #646（教学散文教了 validator 拒绝的旧字段，
重同步靠人肉改两棵树）。按 AGENTS.md「两套实现由 parity 测试钉住」补一条 parity 闸：

- tests/test_portable_workflow.py 新增 test_the_dsh_plugin_contract_twin_tracks_the_pack_copy：
  断言两文件存在且 read_bytes 相等，失败消息点名两侧路径并写明「有意分叉须同 commit 有意识放松此钉」；
- 咬合验证：人为追加一行到插件侧副本 → 测试红；还原 → 绿。

## 验证

- `env -u CLAWOCK_WORKSPACE python3 -m pytest tests/test_portable_workflow.py -q` → 4 passed；
- 合并相关面 `tests/test_portable_workflow.py tests/test_wheel_contains_the_package.py -q` → 6 passed；
- 未跑全量套件（按审计流程只跑针对性目标），交由 CI 六项必需检查把关。

Closes #1054
