### PR TITLE
fix: 结算自检闭市日闸推广到交易日历节假日(#1056) [audit:strategy-review P4]

### DIFF
--- a/assets/data/quant_signal_review.json
+++ b/assets/data/quant_signal_review.json
@@ -2,8 +2,8 @@
   "as_of": "2026-08-26",
   "days_logged": 55,
   "unlock_rule": "cluster_ci_entirely_above_or_below_50pct",
-  "frozen_feed_excluded": 77,
-  "weekend_rows_excluded": 13,
+  "frozen_feed_excluded": 73,
+  "closed_market_rows_excluded": 35,
   "factors": {
     "trend_on_follow": {
       "n_events": 7,
@@ -16,19 +16,19 @@
       "reverse_edge_significant": false,
       "sample_sufficient": false,
       "min_n": 20,
-      "non_overlap_cap": 53,
+      "non_overlap_cap": 51,
       "decision_direction": null,
       "usable": false,
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "trend_off_avoid": {
-      "n_events": 333,
-      "n_dates": 48,
+      "n_events": 325,
+      "n_dates": 47,
       "n_tickers": 10,
-      "hit_rate": 0.502,
+      "hit_rate": 0.486,
       "ci95": [
-        0.379,
-        0.618
+        0.354,
+        0.607
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,
@@ -41,12 +41,12 @@
       "note": "聚类 CI 跨 50%，方向结论不入决策"
     },
     "rsi_oversold_bounce": {
-      "n_events": 28,
-      "n_dates": 18,
+      "n_events": 27,
+      "n_dates": 17,
       "n_tickers": 8,
-      "hit_rate": 0.643,
+      "hit_rate": 0.63,
       "ci95": [
-        0.333,
+        0.308,
         1.0
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
@@ -60,10 +60,10 @@
       "note": "聚类 CI 跨 50%，方向结论不入决策"
     },
     "rsi_overbought_fade": {
-      "n_events": 5,
-      "n_dates": 5,
+      "n_events": 4,
+      "n_dates": 4,
       "n_tickers": 2,
-      "hit_rate": 0.4,
+      "hit_rate": 0.25,
       "ci95": [
         0.0,
         1.0
@@ -98,13 +98,13 @@
       "note": "样本 < 20，方向结论不入决策（#934 与文档承诺对齐）"
     },
     "stop_breach_continue": {
-      "n_events": 237,
-      "n_dates": 42,
+      "n_events": 219,
+      "n_dates": 41,
       "n_tickers": 11,
-      "hit_rate": 0.536,
+      "hit_rate": 0.525,
       "ci95": [
-        0.375,
-        0.674
+        0.365,
+        0.662
       ],
       "ci_method": "date_ticker_two_way_cluster_bootstrap",
       "edge_significant": false,

--- a/assets/data/t0_setup_review.json
+++ b/assets/data/t0_setup_review.json
@@ -6,132 +6,132 @@
   "grades": {
     "chase_low_quality": {
       "label": "🔴 追高低质",
-      "n": 137,
-      "hit_rate": 0.591,
+      "n": 130,
+      "hit_rate": 0.585,
       "ci95": [
-        0.508,
-        0.67
+        0.499,
+        0.666
       ],
-      "edge_significant": true,
+      "edge_significant": false,
       "sample_sufficient": true,
-      "edge_supported": true,
+      "edge_supported": false,
       "reverse_edge_supported": false,
-      "decision_direction": "original",
-      "avg_dir_fwd_pct": 0.92,
-      "usable": true,
-      "note": "",
-      "non_overlap_cap": 1080
+      "decision_direction": null,
+      "avg_dir_fwd_pct": 0.85,
+      "usable": false,
+      "note": "Wilson CI 跨 50%，正向 edge 未获支持",
+      "non_overlap_cap": 1035
     },
     "elevated": {
       "label": "🟡 偏高位",
-      "n": 67,
-      "hit_rate": 0.522,
+      "n": 63,
+      "hit_rate": 0.492,
       "ci95": [
-        0.405,
-        0.637
+        0.373,
+        0.612
       ],
       "edge_significant": false,
       "sample_sufficient": true,
       "edge_supported": false,
       "reverse_edge_supported": false,
       "decision_direction": null,
-      "avg_dir_fwd_pct": -0.06,
+      "avg_dir_fwd_pct": -0.79,
       "usable": false,
       "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-      "non_overlap_cap": 1080
+      "non_overlap_cap": 1035
     },
     "oversold_low": {
       "label": "🟡 低位/超卖",
-      "n": 226,
-      "hit_rate": 0.478,
+      "n": 220,
+      "hit_rate": 0.482,
       "ci95": [
-        0.414,
-        0.543
+        0.417,
+        0.548
       ],
       "edge_significant": false,
       "sample_sufficient": true,
       "edge_supported": false,
       "reverse_edge_supported": false,
       "decision_direction": null,
-      "avg_dir_fwd_pct": -0.2,
+      "avg_dir_fwd_pct": -0.32,
       "usable": false,
       "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-      "non_overlap_cap": 1080
+      "non_overlap_cap": 1035
     }
   },
-  "summary": "🔴 追高低质 命中59%[51–67](n=137)",
-  "weekend_rows_excluded": 60,
+  "summary": "没有牌面同时通过样本与正向 edge 闸（82 交易日留痕）——结论未解锁",
+  "closed_market_rows_excluded": 78,
   "multi_horizon": {
     "H1": {
       "horizon": 1,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 137,
-          "hit_rate": 0.591,
+          "n": 130,
+          "hit_rate": 0.585,
           "ci95": [
-            0.508,
-            0.67
+            0.499,
+            0.666
           ],
-          "edge_significant": true,
+          "edge_significant": false,
           "sample_sufficient": true,
-          "edge_supported": true,
+          "edge_supported": false,
           "reverse_edge_supported": false,
-          "decision_direction": "original",
-          "avg_dir_fwd_pct": 0.92,
-          "usable": true,
-          "note": "",
-          "non_overlap_cap": 1080
+          "decision_direction": null,
+          "avg_dir_fwd_pct": 0.85,
+          "usable": false,
+          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
+          "non_overlap_cap": 1035
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 67,
-          "hit_rate": 0.522,
+          "n": 63,
+          "hit_rate": 0.492,
           "ci95": [
-            0.405,
-            0.637
+            0.373,
+            0.612
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.06,
+          "avg_dir_fwd_pct": -0.79,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 1080
+          "non_overlap_cap": 1035
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 226,
-          "hit_rate": 0.478,
+          "n": 220,
+          "hit_rate": 0.482,
           "ci95": [
-            0.414,
-            0.543
+            0.417,
+            0.548
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.2,
+          "avg_dir_fwd_pct": -0.32,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 1080
+          "non_overlap_cap": 1035
         }
       },
-      "summary": "🔴 追高低质 命中59%[51–67](n=137)"
+      "summary": "没有牌面同时通过样本与正向 edge 闸——结论未解锁"
     },
     "H5": {
       "horizon": 5,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 131,
-          "hit_rate": 0.565,
+          "n": 124,
+          "hit_rate": 0.573,
           "ci95": [
-            0.479,
-            0.647
+            0.485,
+            0.656
           ],
           "edge_significant": false,
           "sample_sufficient": true,
@@ -141,43 +141,43 @@
           "avg_dir_fwd_pct": 1.08,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 210
+          "non_overlap_cap": 195
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 65,
-          "hit_rate": 0.462,
+          "n": 60,
+          "hit_rate": 0.433,
           "ci95": [
-            0.346,
-            0.581
+            0.316,
+            0.559
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -1.79,
+          "avg_dir_fwd_pct": -2.51,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 210
+          "non_overlap_cap": 195
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 208,
-          "hit_rate": 0.457,
+          "n": 202,
+          "hit_rate": 0.45,
           "ci95": [
-            0.39,
-            0.525
+            0.383,
+            0.519
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.91,
+          "avg_dir_fwd_pct": -0.94,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 210
+          "non_overlap_cap": 195
         }
       },
       "summary": "没有牌面同时通过样本与正向 edge 闸——结论未解锁"
@@ -187,28 +187,46 @@
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 116,
-          "hit_rate": 0.603,
+          "n": 109,
+          "hit_rate": 0.596,
           "ci95": [
-            0.512,
-            0.688
+            0.502,
+            0.684
           ],
           "edge_significant": true,
           "sample_sufficient": true,
           "edge_supported": true,
           "reverse_edge_supported": false,
           "decision_direction": "original",
-          "avg_dir_fwd_pct": 3.02,
+          "avg_dir_fwd_pct": 2.33,
           "usable": true,
           "note": "",
-          "non_overlap_cap": 105
+          "non_overlap_cap": 90
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 57,
-          "hit_rate": 0.386,
+          "n": 52,
+          "hit_rate": 0.365,
           "ci95": [
-            0.271,
+            0.248,
+            0.501
+          ],
+          "edge_significant": false,
+          "sample_sufficient": true,
+          "edge_supported": false,
+          "reverse_edge_supported": false,
+          "decision_direction": null,
+          "avg_dir_fwd_pct": -2.13,
+          "usable": false,
+          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
+          "non_overlap_cap": 90
+        },
+        "oversold_low": {
+          "label": "🟡 低位/超卖",
+          "n": 195,
+          "hit_rate": 0.446,
+          "ci95": [
+            0.378,
             0.516
           ],
           "edge_significant": false,
@@ -216,87 +234,69 @@
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -1.3,
+          "avg_dir_fwd_pct": -0.71,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 105
-        },
-        "oversold_low": {
-          "label": "🟡 低位/超卖",
-          "n": 202,
-          "hit_rate": 0.47,
-          "ci95": [
-            0.403,
-            0.539
-          ],
-          "edge_significant": false,
-          "sample_sufficient": true,
-          "edge_supported": false,
-          "reverse_edge_supported": false,
-          "decision_direction": null,
-          "avg_dir_fwd_pct": -0.73,
-          "usable": false,
-          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
-          "non_overlap_cap": 105
+          "non_overlap_cap": 90
         }
       },
-      "summary": "🔴 追高低质 命中60%[51–69](n=116)"
+      "summary": "🔴 追高低质 命中60%[50–68](n=109)"
     },
     "H20": {
       "horizon": 20,
       "grades": {
         "chase_low_quality": {
           "label": "🔴 追高低质",
-          "n": 86,
-          "hit_rate": 0.488,
+          "n": 79,
+          "hit_rate": 0.481,
           "ci95": [
-            0.386,
-            0.592
+            0.374,
+            0.589
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": 3.01,
+          "avg_dir_fwd_pct": 1.83,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
           "non_overlap_cap": 45
         },
         "elevated": {
           "label": "🟡 偏高位",
-          "n": 41,
-          "hit_rate": 0.439,
+          "n": 36,
+          "hit_rate": 0.528,
           "ci95": [
-            0.299,
-            0.59
+            0.37,
+            0.68
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
           "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -0.13,
+          "avg_dir_fwd_pct": -0.81,
           "usable": false,
           "note": "Wilson CI 跨 50%，正向 edge 未获支持",
           "non_overlap_cap": 45
         },
         "oversold_low": {
           "label": "🟡 低位/超卖",
-          "n": 174,
-          "hit_rate": 0.42,
+          "n": 168,
+          "hit_rate": 0.44,
           "ci95": [
-            0.349,
-            0.494
+            0.368,
+            0.516
           ],
           "edge_significant": false,
           "sample_sufficient": true,
           "edge_supported": false,
-          "reverse_edge_supported": true,
+          "reverse_edge_supported": false,
           "decision_direction": null,
-          "avg_dir_fwd_pct": -4.82,
+          "avg_dir_fwd_pct": -4.87,
           "usable": false,
-          "note": "Wilson CI 支持相反方向；原牌面禁用，不自动反向交易",
+          "note": "Wilson CI 跨 50%，正向 edge 未获支持",
           "non_overlap_cap": 45
         }
       },

--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -11,18 +11,21 @@
 「命中」的含义：评级给出的方向警示是否被次日价格证实——不是「能赚钱」，是「这条牌面规则
 有没有预测力」。这正是 kcn 要的「数据背书」：以后报🔴追高时能引用历史命中率，而不是空口。
 
-铁律（同 quant_signal_review）：
-  • 纯本地文件运算，零网络（绝不每分钟抓价——结算用的是后续 preflight 已留痕的 close）
-  • sample_sufficient 只回答样本够不够；edge_supported 只回答 Wilson CI
-    是否完整高于 50%。两者同时为真才 usable，禁止再用 raw n 自动解锁
-  • 结算按 (日期, 标的) 去重取当日最后一条（端午盘中多条 → 取收盘牌面）
-  • 周末留痕行不产生结算观测（#1050）：留痕器任何时刻跑都会落一行，而闭市日
-    报价源会漂移或与下一交易日盘前快照逐字重复——跨它算出的 forward return
-    是伪观测（实测把 chase_low_quality 的 T+1 命中率从干净段 63.0% 拖到公开值
-    54.0%，解锁判词被压翻转）。读取侧防御、数据不改写，与 quant_signal_review
-    的冻结价闸同一模式。
-
-输出 assets/data/t0_setup_review.json。brief preflight 每日顺跑，dashboard🎯卡展示。
+ 铁律（同 quant_signal_review）：
+   • 纯本地文件运算，零网络（绝不每分钟抓价——结算用的是后续 preflight 已留痕的 close）
+   • sample_sufficient 只回答样本够不够；edge_supported 只回答 Wilson CI
+     是否完整高于 50%。两者同时为真才 usable，禁止再用 raw n 自动解锁
+   • 结算按 (日期, 标的) 去重取当日最后一条（端午盘中多条 → 取收盘牌面）
+   • 闭市留痕行不产生结算观测（#1050 剔周末，#1056 推广到交易日历整日休市）：
+     留痕器任何时刻跑都会落一行，而闭市日报价源会漂移、或与下一交易日的
+     盘前快照逐字重复——跨它算出的 forward return 是伪观测（实测周末行把
+     chase_low_quality 的 T+1 命中率从干净段 63.0% 拖到公开值 54.0%，解锁判词被压翻转；
+     节假日重复行 fwd 恒 0，对 ±方向都是必 miss）。结算按「标的所属市场的开市留痕日」
+     序列走：触发日闭市的行不产生观测，开市触发的窗口顺延到该标的自己的第 N 个
+     开市留痕日（周五顺延周一的同语义推广）。市场归属单一出处 instruments registry，
+     日历未覆盖的年份 fail-open 不剔数据。读取侧防御、数据不改写，与 quant_signal_review
+     的冻结价闸同一模式。
+ 输出 assets/data/t0_setup_review.json。brief preflight 每日顺跑，dashboard🎯卡展示。
 """
 import json
 import math
@@ -30,6 +33,9 @@ import sys
 from datetime import date
 from datetime import date as real_date
 from pathlib import Path
+
+from clawock import instruments
+from clawock import sessions as trading_calendar
 
 
 def wilson_ci(hits, n, z=1.96):
@@ -90,24 +96,33 @@ def _load_days():
     return [{'as_of': d, 'rows': by_day[d]} for d in sorted(by_day)]
 
 
-def _is_weekend(day):
-    """周六/周日永远不是 HK/US 交易时段；无法解析的日期按工作日保留。
+def _session_open(ticker, day):
+    """该标的所属市场在 day 是否有交易时段。
 
-    用 real_date 而非模块级 date：测试会替换后者（_FixedDate 只造 today）。
+    周六/周日与交易日历里的整日休市（节假日）都算闭市；日期无法解析或
+    日历未覆盖该年份时 fail-open 当开市——宁可少剔一行，绝不静默丢真时段。
     """
     try:
-        return real_date.fromisoformat(str(day)[:10]).weekday() >= 5
+        d = real_date.fromisoformat(str(day)[:10])
     except ValueError:
-        return False
+        return True
+    try:
+        return trading_calendar.is_trading_day(
+            instruments.market_for_symbol(ticker), d)
+    except Exception:
+        return True
 
 
-def _weekend_trigger_rows(days):
-    """周末行里本会触发计数的牌面行数——它们不再产生任何观测（#1050）。"""
+def _closed_trigger_rows(days):
+    """闭市留痕日里本会触发计数的牌面行数——它们不再产生任何观测（#1050/#1056）。
+
+    按标的各自的市场判断：US 休市日（07-03）的 HK 行是真时段，反之亦然。
+    """
     n = 0
     for d in days:
-        if not _is_weekend(d.get('as_of')):
-            continue
-        for m in (d.get('rows') or {}).values():
+        for t, m in (d.get('rows') or {}).items():
+            if _session_open(t, d.get('as_of')):
+                continue
             if not m.get('close'):
                 continue
             lab = m.get('grade_label') or ''
@@ -119,24 +134,29 @@ def _weekend_trigger_rows(days):
 def _settle(days, horizon):
     """Run the grade-vs-forward-return accounting for one horizon.
 
-    Settlement walks non-weekend rows only (#1050): a Friday trigger settles
-    against the next weekday row, and weekend rows produce no observations at
-    all — their closes are closed-market drift or duplicated pre-open
-    snapshots, never session closes.
+    Settlement walks each ticker's own open-market logged-day sequence
+    (#1050, extended to weekday holidays by #1056): a trigger on a closed
+    day produces no observation at all, and a window crossing a closed day
+    settles against that ticker's next open logged day — the same deferral
+    that already carried a Friday trigger to Monday.
 
     Returns (stats, grades, usable_lines) — the same three things main()
     assembles, so a multi-horizon run is one loop instead of a copy.
     """
-    sessions = [d for d in days if not _is_weekend(d.get('as_of'))]
     stats = {k: {'n': 0, 'hits': 0, 'fwd_sum': 0.0} for k in GRADE_TESTS}
-    for i, day in enumerate(sessions):
-        if i + horizon >= len(sessions):
-            continue  # 窗口未到期
-        nxt = sessions[i + horizon]['rows']
-        for t, m in day['rows'].items():
+    universe = sorted({t for d in days for t in (d.get('rows') or {})})
+    seq_max = 0
+    for t in universe:
+        # 该标的自己的时段序列：开市留痕日上有它一行才入列。
+        seq = [row for d in days if _session_open(t, d.get('as_of'))
+               for row in [(d.get('rows') or {}).get(t)] if row is not None]
+        seq_max = max(seq_max, len(seq))
+        for i, m in enumerate(seq):
+            if i + horizon >= len(seq):
+                continue  # 窗口未到期
             c0 = m.get('close')
             lab = m.get('grade_label') or ''
-            c1 = (nxt.get(t) or {}).get('close')
+            c1 = (seq[i + horizon] or {}).get('close')
             if not c0 or not c1:
                 continue
             fwd = c1 / c0 - 1
@@ -147,9 +167,8 @@ def _settle(days, horizon):
                     s['hits'] += 1 if fwd * direction > 0 else 0
                     s['fwd_sum'] += fwd * direction  # 方向化收益(正=警示/预测被证实)
     # #819:这些窗口是重叠的(Wilson CI 假设独立),写一个非重叠上限估计,
-    # 免得 n=210 被当成 210 个独立样本。
-    tickers = {t for d in sessions for t in d['rows']}
-    non_overlap_cap = len(tickers) * (len(sessions) // horizon) if horizon else 0
+    # 免得 n=210 被当成 210 个独立样本。交易日按标的自己的序列上限计。
+    non_overlap_cap = len(universe) * (seq_max // horizon) if horizon else 0
     grades = {}
     usable = []
     for name, s in stats.items():
@@ -199,7 +218,7 @@ def main(argv=None):
         print('  no t0 history yet — skip')
         return 0
 
-    weekend_rows = _weekend_trigger_rows(days)
+    closed_rows = _closed_trigger_rows(days)
     _, grades, usable = _settle(days, HORIZON)
 
     summary = ('、'.join(usable) if usable
@@ -215,9 +234,10 @@ def main(argv=None):
     out = {
         'as_of': date.today().isoformat(), 'days_logged': len(days),
         'min_n': MIN_N, 'horizon': HORIZON, 'grades': grades, 'summary': summary,
-        # #1050:周末行不结算。days_logged 是原始留痕天数；weekend_rows_excluded
-        # 是其中本会触发计数、现不再产生观测的牌面行数。
-        'weekend_rows_excluded': weekend_rows,
+        # #1050/#1056:闭市留痕行（周末+节假日，按各自市场）不结算。
+        # days_logged 是原始留痕天数；closed_market_rows_excluded 是其中本会
+        # 触发计数、现不再产生观测的牌面行数。
+        'closed_market_rows_excluded': closed_rows,
         # #819:同一条留痕的 T+1/5/10/20 对账,horizons 键顺序即周期。
         'multi_horizon': multi,
         'overlap_note': ('留痕窗口重叠,Wilson CI 假设独立,故偏乐观;'

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -25,12 +25,15 @@ CI 整体成立时才允许反向解读。T+5/T+20 窗口逐日重叠 → 披露
 假日顺延造成的同价 ≤2–3 天），≥4 判为断源：这些 ticker-日不产生任何观测，
 排除量披露在 frozen_feed_excluded，数据本身保留不作改写。
 
-周末行闸（#1050）：留痕器任何时刻跑都会落一行，周六/周日永远没有 HK/US
-交易时段——闭市日报价源会漂移，或与下一交易日盘前快照逐字重复（实测
-07-26≡07-27、08-09≡08-10 全 ticker 收盘集相同），跨它结算的 forward
-return 是伪观测。触发日在周末的因子行不产生观测并计入 weekend_rows_excluded；
-工作日触发的观测改按非周末行序列结算（周五顺延到周一），horizon 数的是
-交易时段行数而不是原始行数。
+闭市日行闸（#1050 剔周末，#1056 推广到交易日历整日休市）：留痕器任何时刻跑都会落
+一行，而周六/周日和节假日永远没有对应市场的交易时段——闭市日报价源会漂移，或与
+下一交易日盘前快照逐字重复（实测 07-26≡07-27、08-09≡08-10 全 ticker 收盘集相同；
+07-03 美股休市日 MSFT/HOOD 收盘 = 下周一遍），跨它结算的 forward return 是伪观测
+（重复行 fwd 恒 0，对 ±方向都是必 miss）。结算按「标的所属市场的开市留痕日」序列走：
+触发日闭市的因子行不产生观测并计入 closed_market_rows_excluded；开市触发的窗口
+顺延到该标的自己的第 N 个开市留痕行（周五顺延周一的同语义推广），horizon 数的是
+时段行而不是原始行。市场归属单一出处 instruments registry；日历未覆盖的年份
+fail-open 不剔数据。
 """
 import json
 import random
@@ -39,6 +42,8 @@ from datetime import date
 from pathlib import Path
 
 from clawock import history_store
+from clawock import instruments
+from clawock import sessions as trading_calendar
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
@@ -55,24 +60,35 @@ MIN_N = 20
 FROZEN_RUN_MIN = 4
 
 
-def _is_weekend(day):
-    """周六/周日永远不是 HK/US 交易时段；无法解析的日期按工作日保留。
+def _session_open(ticker, day):
+    """该标的所属市场在 day 是否有交易时段。
+
+    周六/周日与交易日历里的整日休市（节假日）都算闭市；日期无法解析或
+    日历未覆盖该年份时 fail-open 当开市——宁可少剔一行，绝不静默丢真时段。
 
     用 real_date 而非模块级 date：测试会替换后者（_FixedDate 只造 today）。
     """
     try:
-        return real_date.fromisoformat(str(day)[:10]).weekday() >= 5
+        d = real_date.fromisoformat(str(day)[:10])
     except ValueError:
-        return False
+        return True
+    try:
+        return trading_calendar.is_trading_day(
+            instruments.market_for_symbol(ticker), d)
+    except Exception:
+        return True
 
 
-def _weekend_trigger_rows(days):
-    """周末行里本会触发计数的因子行数——它们不再产生任何观测（#1050）。"""
+def _closed_trigger_rows(days):
+    """闭市留痕日里本会触发计数的因子行数——它们不再产生任何观测（#1050/#1056）。
+
+    按标的各自的市场判断：US 休市日（07-03）的 HK 行是真时段，反之亦然。
+    """
     n = 0
     for day in days:
-        if not _is_weekend(day.get('as_of')):
-            continue
-        for sig in (day.get('rows') or {}).values():
+        for sym, sig in (day.get('rows') or {}).items():
+            if _session_open(sym, day.get('as_of')):
+                continue
             if not sig.get('close'):
                 continue
             if any(cond(sig) for cond, _, _ in FACTOR_TESTS.values()):
@@ -166,25 +182,35 @@ def main(argv=None):
              for k, (_, _, h) in FACTOR_TESTS.items()}
     frozen = frozen_ticker_days(days)
     frozen_excluded = 0
-    # 周末行不是交易时段（#1050）：结算只在非周末行序列上走，horizon 数的
-    # 是时段行数；触发日在周末的因子行由 _weekend_trigger_rows 单独披露。
-    sessions = [day for day in days if not _is_weekend(day.get('as_of'))]
-    weekend_excluded = _weekend_trigger_rows(days)
-    for i, day in enumerate(sessions):
-        for sym, sig in (day.get('rows') or {}).items():
+    # 闭市留痕行不是交易时段（#1050/#1056）：每只标的走自己的开市留痕日序列，
+    # 触发日闭市的因子行由 _closed_trigger_rows 单独披露；horizon 数的是该
+    # 标的自己的时段行数，跨闭市日的窗口顺延到它的下一个时段行。
+    closed_excluded = _closed_trigger_rows(days)
+    universe = sorted({sym for day in days for sym in ((day.get('rows')) or {})})
+    seq_max = 0
+    for sym in universe:
+        seq = []
+        for day in days:
+            if not _session_open(sym, day.get('as_of')):
+                continue
+            sig = (day.get('rows') or {}).get(sym)
+            if sig is not None:
+                seq.append((day['as_of'], sig))
+        seq_max = max(seq_max, len(seq))
+        for i, (as_of, sig) in enumerate(seq):
             c0 = sig.get('close')
             if not c0:
                 continue
             for name, (cond, direction, horizon) in FACTOR_TESTS.items():
-                if i + horizon >= len(sessions):
+                if i + horizon >= len(seq):
                     continue          # 窗口未到期，留给未来结算
                 if not cond(sig):
                     continue
-                settle_day = sessions[i + horizon]
-                c1 = ((settle_day.get('rows') or {}).get(sym) or {}).get('close')
+                settle_as_of, settle_sig = seq[i + horizon]
+                c1 = settle_sig.get('close')
                 if not c1:
                     continue
-                if (sym, day['as_of']) in frozen or (sym, settle_day['as_of']) in frozen:
+                if (sym, as_of) in frozen or (sym, settle_as_of) in frozen:
                     # 冻结价观测：fwd 恒 0 或假跳变，两个方向都是伪影。
                     frozen_excluded += 1
                     continue
@@ -193,7 +219,7 @@ def main(argv=None):
                 hit = fwd * direction > 0
                 stats[name]['hits'] += 1 if hit else 0
                 stats[name]['observations'].append({
-                    'date': day['as_of'], 'ticker': sym, 'hit': hit,
+                    'date': as_of, 'ticker': sym, 'hit': hit,
                 })
 
     factors = {}
@@ -235,8 +261,8 @@ def main(argv=None):
                          'reverse_edge_significant': reverse_sig,
                          'sample_sufficient': sample_sufficient,
                          'min_n': MIN_N,
-                         'non_overlap_cap': (len(tickers) * (len(sessions) // s['horizon'])
-                                             if s['horizon'] else 0),
+                         'non_overlap_cap': (len(tickers) * (seq_max // s['horizon'])
+                                            if s['horizon'] else 0),
                          'decision_direction': direction if usable_now else None,
                          'usable': usable_now,
                          'note': note}
@@ -252,7 +278,7 @@ def main(argv=None):
     out = {'as_of': date.today().isoformat(), 'days_logged': len(days),
            'unlock_rule': 'cluster_ci_entirely_above_or_below_50pct',
            'frozen_feed_excluded': frozen_excluded,
-           'weekend_rows_excluded': weekend_excluded,
+           'closed_market_rows_excluded': closed_excluded,
            'factors': factors, 'summary': summary,
            'discipline': ('自迭代规则：公开 n_events/n_dates/n_tickers；date×ticker 双向聚类 '
                           'CI 跨 50% 不入决策；只有反向 CI 整体低于 50% 才允许反向解读。driven_by='
@@ -260,8 +286,8 @@ def main(argv=None):
                           '为准，不使用固定百分比。')}
     safe_write_json(OUT, out)
     skipped = f'，冻结价剔除 {frozen_excluded} 个观测' if frozen_excluded else ''
-    wk = f'，周末行剔除 {weekend_excluded} 个观测' if weekend_excluded else ''
-    print(f'  review: {len(days)} days, summary: {summary}{skipped}{wk}')
+    closed = f'，闭市日剔除 {closed_excluded} 个观测' if closed_excluded else ''
+    print(f'  review: {len(days)} days, summary: {summary}{skipped}{closed}')
 
 
 if __name__ == '__main__':

--- a/src/clawock/instruments.py
+++ b/src/clawock/instruments.py
@@ -223,6 +223,25 @@ def require(symbol: str) -> dict:
     return meta
 
 
+def market_for_symbol(symbol: str) -> str:
+    """The trading calendar this symbol settles on: ``'hk'`` or ``'us'``.
+
+    The registry's ``region`` is the single source; the fallbacks only exist so
+    a symbol that predates or outruns the registry still lands deterministically
+    instead of raising in an offline reviewer. Bare digit codes are HKEX stock
+    codes, ``HS*`` index proxies (HSTECH) ride the HK calendar, everything else
+    alphabetic is assumed US-listed — the same assumption every history row
+    writer already makes.
+    """
+    region = str((get(str(symbol)) or {}).get("region") or "").lower()
+    if region in ("hk", "us"):
+        return region
+    code = str(symbol or "")
+    if code.isdigit() or code.upper().startswith("HS"):
+        return "hk"
+    return "us"
+
+
 def is_leveraged(symbol: str) -> bool:
     meta = get(symbol)
     return bool(meta and meta["leverage_multiple"] > 1)

--- a/tests/test_instrument_registry.py
+++ b/tests/test_instrument_registry.py
@@ -184,3 +184,17 @@ def test_leveraged_exposure_ignores_closed_positions_with_stale_values():
     assert build_dashboard.compute_leveraged_etf_exposure(
         portfolio, fx_rate=7.84
     ) == live
+
+
+def test_market_for_symbol_registry_first_with_deterministic_fallback():
+    """#1056: settlement gates need each symbol's calendar. The registry's
+    region is the single source; the fallback only covers symbols that predate
+    or outrun it, and must stay deterministic (digits→HK, HS* index→HK,
+    other alphabetic→US)."""
+    registered = next(iter(instrument_registry.INSTRUMENTS))
+    assert instrument_registry.market_for_symbol(registered) == (
+        instrument_registry.INSTRUMENTS[registered]["region"].lower()
+    )
+    assert instrument_registry.market_for_symbol("0700") == "hk"
+    assert instrument_registry.market_for_symbol("HSOMEINDEX") == "hk"
+    assert instrument_registry.market_for_symbol("NOTINREG") == "us"

--- a/tests/test_quant_signal_review.py
+++ b/tests/test_quant_signal_review.py
@@ -363,7 +363,7 @@ def test_weekend_as_of_rows_never_settle_and_are_disclosed(monkeypatch):
     factor = result["factors"]["trend_on_follow"]
     assert factor["n_events"] == 2   # 周日的触发被剔除，剩 Fri→Mon、Mon→Tue
     assert factor["hit_rate"] == 0.5
-    assert result["weekend_rows_excluded"] == 1
+    assert result["closed_market_rows_excluded"] == 1
 
 
 def test_all_weekend_history_unlocks_nothing(monkeypatch):
@@ -376,4 +376,35 @@ def test_all_weekend_history_unlocks_nothing(monkeypatch):
     factor = result["factors"]["trend_on_follow"]
     assert factor["n_events"] == 0
     assert factor["usable"] is False
-    assert result["weekend_rows_excluded"] == 1
+    assert result["closed_market_rows_excluded"] == 1
+
+
+def test_holiday_ghost_rows_never_settle_and_windows_defer_per_market(monkeypatch):
+    """#1056: 工作日节假日（交易日历整日休市）与周末同判。
+
+    2026-07-03 是美股 Independence Day 观察日：US 标的周四的触发顺延到
+    下一个开市留痕日结算，周五幽灵行的重复收盘（fwd 恒 0、双向必 miss）
+    不产生观测；同一天 HK 开市，0700 的行是真时段照常结算。
+    旧实现（只剔周末）会给出 n=3/hits=1：周四→幽灵行 +10%、幽灵行→周一
+    fwd=0 的伪 miss 也入了账。
+    """
+    days = [
+        {"as_of": "2026-07-02", "rows": {
+            "W": {"close": 100.0, "trend_on": True},
+            "0700": {"close": 100.0, "trend_on": True},
+        }},
+        {"as_of": "2026-07-03", "rows": {
+            "W": {"close": 110.0, "trend_on": True},
+            "0700": {"close": 90.0},
+        }},
+        {"as_of": "2026-07-06", "rows": {"W": {"close": 110.0}}},
+        {"as_of": "2026-07-07", "rows": {"W": {"close": 121.0}}},
+    ]
+    result = _run_review(monkeypatch, days)
+
+    factor = result["factors"]["trend_on_follow"]
+    # W: 周四触发顺延周一(+10% hit)；HK: 周四触发按真实周五时段结算(-10% miss)。
+    assert factor["n_events"] == 2
+    assert factor["hit_rate"] == 0.5
+    # 只有 US 幽灵行上的那次本会触发的计数被剔除并披露。
+    assert result["closed_market_rows_excluded"] == 1

--- a/tests/test_t0_setup_review.py
+++ b/tests/test_t0_setup_review.py
@@ -100,7 +100,7 @@ def test_weekend_rows_never_settle_and_are_disclosed(monkeypatch):
     chase = result["grades"]["chase_low_quality"]
     assert chase["n"] == 20                      # 只有周五的触发入账
     assert chase["hit_rate"] == 1.0              # 100→90 跌，direction=-1 全命中
-    assert result["weekend_rows_excluded"] == 20  # 周六行的 20 条触发被剔除
+    assert result["closed_market_rows_excluded"] == 20  # 周六行的 20 条触发被剔除
 
 
 def test_weekend_only_history_produces_no_observations(monkeypatch):
@@ -114,4 +114,32 @@ def test_weekend_only_history_produces_no_observations(monkeypatch):
     chase = result["grades"]["chase_low_quality"]
     assert chase["n"] == 0
     assert chase["usable"] is False
-    assert result["weekend_rows_excluded"] == 20
+    assert result["closed_market_rows_excluded"] == 20
+
+
+def test_holiday_ghost_rows_never_settle_and_windows_defer_per_market(monkeypatch):
+    """#1056: 工作日节假日（交易日历整日休市）与周末同判，按各自市场。
+
+    2026-07-03 是美股 Independence Day 观察日：US 标的周四的触发顺延到
+    下一个开市留痕日结算；周五幽灵行的收盘不入账——旧实现（只剔周末）
+    会把周四→幽灵行、幽灵行→周一两对都算上，其中重复收盘对 fwd≡0 双向
+    必 miss。同一天 HK 开市，0700 的行是真时段照常结算。
+    """
+    us_thu = {"W": {"grade_label": "追高低质", "close": 100.0}}
+    us_ghost = {"W": {"grade_label": "追高低质", "close": 110.0}}
+    hk_fri = {"0700": {"grade_label": "", "close": 90.0}}
+    us_mon = {"W": {"grade_label": "", "close": 90.0}}
+    days = [
+        {"as_of": "2026-07-02", "rows": {**us_thu, "0700": us_thu["W"]}},
+        {"as_of": "2026-07-03", "rows": {**us_ghost, **hk_fri}},
+        {"as_of": "2026-07-06", "rows": dict(us_mon)},
+    ]
+    result = _run(monkeypatch, days)
+
+    chase = result["grades"]["chase_low_quality"]
+    # US: 周四触发顺延周一(100→90 跌，direction=-1 命中)；HK: 周四触发按
+    # 真实周五时段结算(100→90 命中)。幽灵行不产生观测。
+    assert chase["n"] == 2
+    assert chase["hit_rate"] == 1.0
+    # 只有 US 幽灵行的 1 条触发被剔除并披露（HK 同日是开市真时段）。
+    assert result["closed_market_rows_excluded"] == 1


### PR DESCRIPTION
Closes #1056

## strategy-review 切片第 4 遍对抗性审计（敌意对象 = 前三轮修复自身）

### 前三轮修复反查（全部成立，无回归）

- **#1037 冻结价闸**：per-ticker 序列重构后冻结检测/排除语义保持；重跑复现 frozen_feed_excluded（顺延语义下 77→73 的差异是跨闭市日伪对消失后的重对账，非闸失效）。
- **#1046 β-stale 闸**：guardrail.py `not stale` 位 + build_alerts high_beta 闸成立；`_revive_stale_block` 首戳保序无误；combined 只从现流现算、不可复活——β 之外无 revived-block 阈值动作漏堵。
- **#1050 周末闸**：行为正确但**只修了一半**——见下。
- kcn 定案漂移检查：突破加仓自促升/wait_rebreak 不入 IN_PLAY_STATES/SPCH 累计阈值无复活——全部符合。

### 本 PR 修一处（Closes #1056）：闭市日闸推广到交易日历节假日

**证据**：sessions.py 有 2025–2027 美港节假日表且全仓其他结算方（ledger/build_evidence/signals）都走 `is_trading_day`，唯独两个 reviewer 手写周末判断。留痕实测三个工作日节假日的幽灵行：06-19 全 ticker ==NEXT（盘前快照重复）、07-03 MSFT/HOOD ==NEXT、07-01 HK 标的报价漂移（CRCL −17.5% 幻影）。重复行跨结算 fwd≡0 = ±方向必 miss。

**影响**：chase_low_quality 是唯一 usable=True 的公开牌面背书（59.1% [50.8,67.0] n=137），其中 13 个观测跨闭市日；修正后 n=130、CI 下界 0.499<0.5 → **usable 翻转为 False**——与 #1050 认定「解锁判词被压翻转」同性质。该字段进每日 brief context 与公开 evidence 页。quant 因子侧全部维持锁定，无翻转。

**修法**：结算改按「标的所属市场的开市留痕日」序列（触发日闭市不产生观测；窗口顺延到该标的自己的第 N 个时段行，即 #1050 周五→周一的推广）；`instruments.market_for_symbol` 单一出处（registry region，数字码/HS* 回退），日历未覆盖年份 fail-open；披露字段推广为 `closed_market_rows_excluded`（周末+节假日按各自市场计数）。读取侧防御、数据不改写。

### 测试与产物

- 新增行为断言：US 节假日幽灵行不产生观测 + 跨节假日顺延结算 + HK 同日真时段照常结算（两个 reviewer 各一条，mixed-market fixture）；market_for_symbol 回退不变量一条；原周末闸断言随字段改名更新。5 个针对性测试文件 59 passed，未跑全量。
- 重生成 `t0_setup_review.json`（chase usable True→False）+ `quant_signal_review.json`（closed_market_rows_excluded=35）。

### 记录不改

1. 冻结检测序列仍含闭市日行（检测敏感性更高，合法平盘 ≤2–3 天的既有折中不变）。
2. `_closed_trigger_rows` 对「窗口本不会到期」的行也计数——披露口径与 #1050 一致。
3. 未注册字母符号回退 US 日历：若未来出现未注册 HK 字母码标的会被误判开市（fail-open 方向，少剔不误剔），registry 补录即消。
