### PR TITLE
fix: autostash pull 站点统一加 #1038 去追踪迁移守卫 [audit:memory-lifecycle P4]

### DIFF
--- a/ops/host/refresh_live.sh
+++ b/ops/host/refresh_live.sh
@@ -33,6 +33,12 @@ BRANCH="${LIVE_BRANCH:-master}"
 check_only=0
 [ "${1:-}" = "--check" ] && check_only=1
 
+# The pull below goes through the shared #1038 migration guard (same helper
+# safe_push.sh sources) so every autostash pull site protects dirty daily
+# notes identically.
+# shellcheck source=ops/publish/untrack_guard.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../publish/untrack_guard.sh"
+
 test -d "$CHECKOUT/.git" || { echo "not a git checkout: $CHECKOUT" >&2; exit 2; }
 cd "$CHECKOUT"
 
@@ -65,8 +71,14 @@ if [ "$check_only" = "1" ]; then
 fi
 
 # autostash because the live tree is nearly always dirty — cron writes market
-# data into it all day. Same reasoning as ops/publish/safe_push.sh.
-git -c rebase.autoStash=true pull --rebase -q "$REMOTE" "$BRANCH"
+# data into it all day. Same reasoning as ops/publish/safe_push.sh. The pull is
+# wrapped in the #1038 migration guard: while master carries the daily-notes
+# untracking, a dirty tracked diary meeting this pull would otherwise become a
+# modify/delete stash-pop conflict.
+if ! pull_guarded "$REMOTE" "$BRANCH" -q; then
+  echo "✗ pull --rebase failed — checkout left untouched, investigate before retrying" >&2
+  exit 1
+fi
 echo "fast-forwarded to $(git rev-parse --short HEAD)"
 
 if [ "$needs_venv" = "1" ]; then

--- a/ops/publish/safe_push.sh
+++ b/ops/publish/safe_push.sh
@@ -20,6 +20,10 @@ BRANCH="${2:-master}"
 # being restated per publisher. It also owns wiping an ephemeral Actions key.
 # shellcheck source=ops/publish/publish_identity.sh
 . "$(dirname "${BASH_SOURCE[0]}")/publish_identity.sh"
+# The autostash pull below goes through the shared #1038 migration guard so
+# every pull site protects dirty daily notes identically.
+# shellcheck source=ops/publish/untrack_guard.sh
+. "$(dirname "${BASH_SOURCE[0]}")/untrack_guard.sh"
 # Locating the money checker is shared with .githooks/pre-push for the same
 # reason: PATH is not a reliable way to find it, and one gate learning that
 # while the other does not is how a book gets published unverified.
@@ -91,7 +95,10 @@ for i in $(seq 1 $MAX_RETRIES); do
   echo "push failed attempt $i, trying rebase (autostash)…"
 
   # -c rebase.autoStash=true → tolerate a dirty working tree during the rebase.
-  if git -c rebase.autoStash=true pull --rebase "$REMOTE" "$BRANCH"; then
+  # Wrapped in the #1038 migration guard: while master carries the daily-notes
+  # untracking, a dirty tracked diary meeting this pull would otherwise become
+  # a modify/delete stash-pop conflict that aborts this push mid-flight.
+  if pull_guarded "$REMOTE" "$BRANCH"; then
     echo "  rebase clean, will retry push"
     sleep $((i * 3))
   else

--- a/ops/publish/untrack_guard.sh
+++ b/ops/publish/untrack_guard.sh
@@ -1,0 +1,99 @@
+# untrack_guard.sh — the one guarded autostash pull, shared by every pull site.
+#
+# Sourced (never executed) by ops/host/refresh_live.sh and ops/publish/safe_push.sh.
+#
+# Why this exists (#1038): master stops tracking the daily notes
+# `memory/YYYY-MM-DD.md`. On the live box those files are written all day by
+# openclaw sessions and committed by several autonomous writers, so a pull
+# carrying their deletion can meet a locally-dirty tracked copy. Under
+# `rebase.autoStash=true` that turns into a modify/delete stash-pop conflict —
+# an aborted postflight push at best, a re-staged diary or a lost day of notes
+# at worst. Before the pull, `pull_guard_backup` copies every dirty tracked
+# bare-dated daily note the incoming range deletes to
+# `memory/.tmp/pre-untrack-backup/`; after the pull (either outcome),
+# `pull_guard_restore` puts back any copy the rebase removed and cleans up.
+#
+# Scope is exactly `^memory/YYYY-MM-DD\.md$` — the untracking commit's surface.
+# Deletions of any other path are not guarded, so behaviour for them is
+# unchanged from the raw autostash pull this file wraps. Everything here is
+# best-effort: a guard failure degrades to today's behaviour (the plain
+# autostash pull), never blocks it.
+#
+# Removal condition: once the untracking commit has been on origin/master long
+# enough that no live checkout can be pulling it for the first time (a few
+# weeks of refreshes), no backup target can exist; delete this file together
+# with its two call sites. Deleting it earlier reopens the window.
+
+_pull_guard_root() {
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+pull_guard_backup() {
+  # $1 = remote, $2 = branch. Records dirty tracked dailies the incoming range
+  # deletes. Fetches first because callers reach here without a fresh
+  # remote-tracking ref (safe_push only fetches for its money check).
+  local root deleted f dest
+  root="$(_pull_guard_root)"
+  [ -n "$root" ] || return 0
+  git fetch -q "$1" "$2" >/dev/null 2>&1 || true
+  deleted="$(git diff --name-only "HEAD..$1/$2" -- memory/ 2>/dev/null \
+    | grep -E '^memory/[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true)"
+  [ -n "$deleted" ] || return 0
+  dest="$root/memory/.tmp/pre-untrack-backup"
+  mkdir -p "$dest" 2>/dev/null || return 0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    # Only a locally-modified tracked copy has something a stash pop can lose;
+    # a clean file just gets deleted, which is exactly what master wants.
+    if git diff --quiet HEAD -- "$f" 2>/dev/null; then
+      continue
+    fi
+    if [ ! -f "$root/$f" ]; then
+      continue  # already deleted locally — nothing to preserve
+    fi
+    mkdir -p "$dest/$(dirname "$f")" 2>/dev/null || continue
+    cp -p "$root/$f" "$dest/$f" 2>/dev/null &&
+      echo "pull-guard: backed up dirty $f before pull" >&2
+  done <<EOF
+$deleted
+EOF
+}
+
+pull_guard_restore() {
+  # Puts back any backup whose path the rebase removed, then clears the
+  # backup dir. Restored files are untracked (master no longer carries them);
+  # once the .gitignore rule from the same migration lands they are also
+  # ignored, so the tree ends quiet either way.
+  local root dest f rel
+  root="$(_pull_guard_root)"
+  [ -n "$root" ] || return 0
+  dest="$root/memory/.tmp/pre-untrack-backup"
+  [ -d "$dest" ] || return 0
+  find "$dest" -type f 2>/dev/null | while IFS= read -r f; do
+    rel="${f#"$dest"/}"
+    if [ ! -e "$root/$rel" ]; then
+      mkdir -p "$root/$(dirname "$rel")" 2>/dev/null || true
+      cp -p "$f" "$root/$rel" 2>/dev/null &&
+        echo "pull-guard: restored $rel after pull" >&2
+    fi
+    rm -f "$f" 2>/dev/null || true
+  done
+  # Remove the emptied tree bottom-up (the backup mirrors memory/… paths), so
+  # only the transient pre-untrack-backup directory ever disappears.
+  find "$dest" -depth -type d -empty -exec rmdir {} \; 2>/dev/null || true
+  rmdir "$dest" 2>/dev/null || true
+}
+
+pull_guarded() {
+  # Usage: pull_guarded REMOTE BRANCH [extra git-pull options…]
+  # The wrapped pull both host-side call sites use. Returns git-pull's exit
+  # code; the restore runs on failure too (a conflicted stash pop is exactly
+  # when the backup matters).
+  local remote="$1" branch="$2"
+  shift 2
+  local rc=0
+  pull_guard_backup "$remote" "$branch"
+  git -c rebase.autoStash=true pull --rebase "$remote" "$branch" "$@" || rc=$?
+  pull_guard_restore
+  return "$rc"
+}

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -283,7 +283,8 @@ def _safe_push_in(repo):
     push under whatever git happens to be configured with, and an unreadable
     money checker must fail rather than skip the money gate.
     """
-    for name in ("safe_push.sh", "publish_identity.sh", "money_checker.sh"):
+    for name in ("safe_push.sh", "publish_identity.sh", "money_checker.sh",
+                 "untrack_guard.sh"):
         (repo / name).write_text((ROOT / "ops" / "publish" / name).read_text())
     return repo / "safe_push.sh"
 

--- a/tests/test_untrack_guard.py
+++ b/tests/test_untrack_guard.py
@@ -1,0 +1,133 @@
+"""The #1038 untracking migration guard, driven against real repos.
+
+`pull_guarded` wraps the autostash pull that both host-side pull sites use
+(`refresh_live.sh`, `safe_push.sh`). While origin/master carries the deletion
+of the tracked daily notes, a checkout with a locally-dirty diary would hit a
+modify/delete stash-pop conflict — aborted automation at best, a re-staged or
+lost day of notes at worst. The guard backs those exact files up before the
+pull and restores whatever the rebase removed.
+
+These tests drive the real functions through real git history (upstream repo +
+clone in tmp_path), so the assertions are about outcomes — which files survive,
+which get deleted, what is left behind — not about the script's wording.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "ops" / "publish" / "untrack_guard.sh"
+
+DIARY = "memory/2026-01-01.md"
+BACKUP_DIR = "memory/.tmp/pre-untrack-backup"
+
+
+def _run(repo, *args, **kw):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(repo),
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+        **kw)
+
+
+def _guarded_pull(repo):
+    """Source the real guard file and run the real pull wrapper in `repo`."""
+    script = f'set -e\n. "{GUARD}"\npull_guarded origin master\n'
+    return subprocess.run(
+        ["bash", "-c", script], cwd=str(repo), capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(repo)})
+
+
+@pytest.fixture
+def desk(tmp_path):
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _run(upstream, "init", "-q", "-b", "master")
+    (upstream / "memory").mkdir()
+    (upstream / "memory" / DIARY.removeprefix("memory/")).write_text("base day log\n")
+    _run(upstream, "add", "-A")
+    _run(upstream, "commit", "-qm", "base")
+
+    checkout = tmp_path / "checkout"
+    _run(tmp_path, "clone", "-q", str(upstream), str(checkout))
+    return upstream, checkout
+
+
+def test_dirty_diary_meeting_its_deletion_is_restored(desk):
+    upstream, checkout = desk
+    # Local edits land after the clone; master then stops tracking the file.
+    (checkout / DIARY).write_text("local edits made today\n")
+    (upstream / DIARY).unlink()
+    _run(upstream, "commit", "-qam", "untrack daily notes")
+
+    r = _guarded_pull(checkout)
+    assert r.returncode == 0, r.stderr
+
+    restored = checkout / DIARY
+    assert restored.read_text() == "local edits made today\n"
+    assert not (checkout / BACKUP_DIR).exists(), "backup must clean up after itself"
+
+
+def test_clean_diary_is_deleted_not_resurrected(desk):
+    upstream, checkout = desk
+    (upstream / DIARY).unlink()
+    _run(upstream, "commit", "-qam", "untrack daily notes")
+
+    r = _guarded_pull(checkout)
+    assert r.returncode == 0, r.stderr
+    assert not (checkout / DIARY).exists(), \
+        "guard only protects dirty copies — a clean deletion must flow through"
+    assert not (checkout / BACKUP_DIR).exists()
+
+
+def test_guard_scope_is_bare_dated_dailies_only(desk):
+    upstream, checkout = desk
+    other = upstream / "memory" / "2026-01-01-notes.md"
+    other.write_text("tagged prose\n")
+    _run(upstream, "add", "-A")
+    _run(upstream, "commit", "-qm", "add tagged file")
+
+    _run(checkout, "pull", "-q", "origin", "master")
+    # Dirty only the bare-dated diary; the tagged sibling stays clean.
+    (checkout / DIARY).write_text("dirty\n")
+    (upstream / DIARY).unlink()
+    other.unlink()
+    _run(upstream, "commit", "-qam", "untrack daily notes")
+
+    r = _guarded_pull(checkout)
+    assert r.returncode == 0, r.stderr
+    assert (checkout / DIARY).read_text() == "dirty\n"
+    # The tagged file was clean and outside the guard's scope: deleted as asked.
+    assert not (checkout / "memory" / "2026-01-01-notes.md").exists()
+
+
+def test_no_deletions_means_plain_fast_forward(desk):
+    upstream, checkout = desk
+    (upstream / "README.md").write_text("x\n")
+    _run(upstream, "add", "-A")
+    _run(upstream, "commit", "-qm", "unrelated")
+    (checkout / "scratch.txt").write_text("in-flight work\n")
+
+    r = _guarded_pull(checkout)
+    assert r.returncode == 0, r.stderr
+    assert (checkout / "README.md").read_text() == "x\n"
+    assert (checkout / "scratch.txt").read_text() == "in-flight work\n", \
+        "ordinary dirty files must pass through exactly as before"
+    assert not (checkout / BACKUP_DIR).exists(), \
+        "no deletions in range → no backup machinery may even start"
+
+
+def test_both_host_side_pull_sites_use_the_guard():
+    """Contract pin: the two autostash pull sites must go through the shared
+    wrapper, so a third raw pull cannot quietly reopen the window."""
+    for script in (ROOT / "ops/host/refresh_live.sh",
+                   ROOT / "ops/publish/safe_push.sh"):
+        text = script.read_text(encoding="utf-8")
+        assert "ops/publish/untrack_guard.sh" in text, \
+            f"{script.name} no longer sources the guard"
+        assert "pull_guarded " in text, \
+            f"{script.name} no longer calls pull_guarded"
+    text = GUARD.read_text(encoding="utf-8")
+    assert "rebase.autoStash=true" in text, "the wrapper lost the autostash knob"


### PR DESCRIPTION
## PR-A：去追踪迁移守卫（#1038 落地配方第 1 步）

P3 在 #1038 里论证过：每日日记在 live box 是几乎永远 dirty 的已跟踪文件，`ops/host/refresh_live.sh:69` 与 `ops/publish/safe_push.sh:94` 两处 `rebase.autoStash=true pull --rebase` 若遇上「master 已带删除 + 本地日记脏」会变成 modify/delete stash-pop 冲突——轻则 postflight push 中断，重则日记被重新暂存回索引或当日笔记丢失。这是 #1038 处置方案（停止追踪）不能作为普通 PR 直接落的原因。

本 PR 落配方第 1 步：

- **新文件 `ops/publish/untrack_guard.sh`**（sourced）：`pull_guard_backup` 在 pull 前把「incoming range 删除 ∩ 本地脏的已跟踪裸日期日记」拷到 `memory/.tmp/pre-untrack-backup/`；`pull_guard_restore` 在 pull 后（无论成败）原位恢复被 rebase 移除的副本并自清备份树；`pull_guarded` 包装同一条 autostash pull。
- **范围严格** `^memory/[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$`——恰是 #1038 删除面的集合。其余任何路径的删除行为与改动前逐字节一致（有测试钉住）。全部 best-effort：守卫任何失败退化为现状，绝不阻塞 pull。
- **两个 autostash pull 站点接线**：`refresh_live.sh`（人工/迁移路径）与 `safe_push.sh` 重试循环（所有 postflight/dreaming/watchdog 的推送路径，GH Actions 上无脏日记、守卫自然 no-op）。每 20 分钟的 `publish_dashboard.sh` ff-only 合并不 stash、拒绝即停，无需也未加守卫。
- **测试 5 例**走真实 git 历史（upstream+clone fixture）：脏副本恢复且备份自清 / 干净删除照常穿透不复活 / 范围只限裸日期（tagged 兄弟文件不受庇护）/ 无删除时等价普通 fast-forward / 双站点接线契约。定向回归 test_refresh_live 全绿；test_runtime_coupling_ratchet 一例失败为本机干净 master 基线既有（OPENCLAW_BIN 环境泄漏，与本 PR 无关）。

### 验收

- 六必需检查全绿；
- 合入后 live box 下一次任意 autostash pull 即装上守卫（脚本随 checkout 分发）；
- PR-B（实际 `git rm --cached` 37 个日记 + .gitignore + AGENTS.md 表行删除）在本守卫合入后才允许合并——顺序即安全边界。

Closes 无（本 PR 是 #1038 的前置机制步，主处置随下一 PR 关闭）。
