### PR TITLE
fix: 守卫升级为磁盘保全+接入 publisher ff 路径（#1038 前置） [audit:memory-lifecycle P4]

### DIFF
--- a/ops/publish/publish_dashboard.sh
+++ b/ops/publish/publish_dashboard.sh
@@ -36,8 +36,17 @@ if ! flock -n 9; then
 fi
 
 # Fetch first so we build on top of the latest sidecars other writers pushed.
+# The ff-merge below goes through the shared #1038 migration guard: a plain
+# --ff-only merge silently DELETES clean daily notes from disk when master
+# stops tracking them — exactly what must not happen to workspace continuity.
+# The guard backs them up and restores them after; dirty ones make this merge
+# refuse outright (unchanged), which only delays the tick.
+# shellcheck source=ops/publish/untrack_guard.sh
+. "$(dirname "${BASH_SOURCE[0]}")/untrack_guard.sh"
 git fetch -q origin master || true
+pull_guard_backup origin master
 git merge -q --ff-only origin/master 2>/dev/null || true
+pull_guard_restore
 
 # The last published generation, materialised out of the data branch. Two things
 # need it and both used to get it from this repository: the recovery source for

--- a/ops/publish/untrack_guard.sh
+++ b/ops/publish/untrack_guard.sh
@@ -3,15 +3,21 @@
 # Sourced (never executed) by ops/host/refresh_live.sh and ops/publish/safe_push.sh.
 #
 # Why this exists (#1038): master stops tracking the daily notes
-# `memory/YYYY-MM-DD.md`. On the live box those files are written all day by
-# openclaw sessions and committed by several autonomous writers, so a pull
-# carrying their deletion can meet a locally-dirty tracked copy. Under
-# `rebase.autoStash=true` that turns into a modify/delete stash-pop conflict —
-# an aborted postflight push at best, a re-staged diary or a lost day of notes
-# at worst. Before the pull, `pull_guard_backup` copies every dirty tracked
-# bare-dated daily note the incoming range deletes to
-# `memory/.tmp/pre-untrack-backup/`; after the pull (either outcome),
-# `pull_guard_restore` puts back any copy the rebase removed and cleans up.
+# `memory/YYYY-MM-DD.md`. They stay workspace continuity — AGENTS.md reads
+# today+yesterday from disk, the openclaw memory index rglobs the tree — so
+# the untracking must remove them from the INDEX without removing them from
+# any DISK. Three merge paths reach a working tree:
+#   • ops/publish/safe_push.sh retry loop — autostash pull;
+#   • ops/host/refresh_live.sh — autostash pull;
+#   • ops/publish/publish_dashboard.sh — plain --ff-only merge (refuses on
+#     dirty files, so a dirty diary only ever delays it — but it SILENTLY
+#     DELETES clean ones, which is precisely what must not happen).
+# Before the merge, `pull_guard_backup` copies every locally-present daily
+# note the incoming range deletes (clean or dirty — clean ones are the ff
+# path's victim, dirty ones the stash-pop hazard) to
+# `memory/.tmp/pre-untrack-backup/`; afterwards `pull_guard_restore` puts
+# back whatever the merge removed and cleans up. Restored files are
+# untracked, and ignored once the matching .gitignore rule arrives.
 #
 # Scope is exactly `^memory/YYYY-MM-DD\.md$` — the untracking commit's surface.
 # Deletions of any other path are not guarded, so behaviour for them is
@@ -29,13 +35,14 @@ _pull_guard_root() {
 }
 
 pull_guard_backup() {
-  # $1 = remote, $2 = branch. Records dirty tracked dailies the incoming range
-  # deletes. Fetches first because callers reach here without a fresh
-  # remote-tracking ref (safe_push only fetches for its money check).
+  # $1 = remote, $2 = branch. Records every locally-present daily note the
+  # incoming range deletes — clean or dirty. Callers must have fetched the
+  # remote recently enough that "$1/$2" answers "what a merge would bring":
+  # pull_guarded fetches itself, publish_dashboard reuses the fetch its
+  # ff-merge already needed.
   local root deleted f dest
   root="$(_pull_guard_root)"
   [ -n "$root" ] || return 0
-  git fetch -q "$1" "$2" >/dev/null 2>&1 || true
   deleted="$(git diff --name-only "HEAD..$1/$2" -- memory/ 2>/dev/null \
     | grep -E '^memory/[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true)"
   [ -n "$deleted" ] || return 0
@@ -43,24 +50,21 @@ pull_guard_backup() {
   mkdir -p "$dest" 2>/dev/null || return 0
   while IFS= read -r f; do
     [ -n "$f" ] || continue
-    # Only a locally-modified tracked copy has something a stash pop can lose;
-    # a clean file just gets deleted, which is exactly what master wants.
-    if git diff --quiet HEAD -- "$f" 2>/dev/null; then
-      continue
-    fi
+    # Present on disk is the only criterion: a clean copy is what the ff
+    # merge deletes outright, a dirty one what a stash pop can mangle.
     if [ ! -f "$root/$f" ]; then
-      continue  # already deleted locally — nothing to preserve
+      continue
     fi
     mkdir -p "$dest/$(dirname "$f")" 2>/dev/null || continue
     cp -p "$root/$f" "$dest/$f" 2>/dev/null &&
-      echo "pull-guard: backed up dirty $f before pull" >&2
+      echo "pull-guard: backed up $f before merge" >&2
   done <<EOF
 $deleted
 EOF
 }
 
 pull_guard_restore() {
-  # Puts back any backup whose path the rebase removed, then clears the
+  # Puts back any backup whose path the merge removed, then clears the
   # backup dir. Restored files are untracked (master no longer carries them);
   # once the .gitignore rule from the same migration lands they are also
   # ignored, so the tree ends quiet either way.
@@ -92,6 +96,7 @@ pull_guarded() {
   local remote="$1" branch="$2"
   shift 2
   local rc=0
+  git fetch -q "$remote" "$branch" >/dev/null 2>&1 || true
   pull_guard_backup "$remote" "$branch"
   git -c rebase.autoStash=true pull --rebase "$remote" "$branch" "$@" || rc=$?
   pull_guard_restore

--- a/tests/test_untrack_guard.py
+++ b/tests/test_untrack_guard.py
@@ -70,15 +70,41 @@ def test_dirty_diary_meeting_its_deletion_is_restored(desk):
     assert not (checkout / BACKUP_DIR).exists(), "backup must clean up after itself"
 
 
-def test_clean_diary_is_deleted_not_resurrected(desk):
+def test_clean_diary_survives_the_untracking_on_disk(desk):
+    """The point of the guard: index deletion flows through, the DISK copy stays.
+
+    A plain --ff-only merge silently removes a clean tracked file whose path
+    master deleted — that is the data-loss path for workspace continuity
+    (AGENTS.md reads today+yesterday from disk)."""
     upstream, checkout = desk
     (upstream / DIARY).unlink()
     _run(upstream, "commit", "-qam", "untrack daily notes")
 
     r = _guarded_pull(checkout)
     assert r.returncode == 0, r.stderr
-    assert not (checkout / DIARY).exists(), \
-        "guard only protects dirty copies — a clean deletion must flow through"
+    # Untracked (master no longer carries it), but very much still on disk.
+    assert (checkout / DIARY).read_text() == "base day log\n"
+    assert not (checkout / BACKUP_DIR).exists()
+
+
+def test_ff_only_publisher_path_is_also_guarded(desk):
+    """publish_dashboard.sh merges --ff-only every 20 minutes; drive the same
+    backup/restore pair around its merge shape directly."""
+    upstream, checkout = desk
+    (upstream / DIARY).unlink()
+    _run(upstream, "commit", "-qam", "untrack daily notes")
+    _run(checkout, "fetch", "-q", "origin", "master")
+    script = (
+        f'set -e\n. "{GUARD}"\n'
+        'pull_guard_backup origin master\n'
+        f'rm "{DIARY}"   # what --ff-only does to a clean path master deleted\n'
+        'pull_guard_restore\n'
+    )
+    r = subprocess.run(["bash", "-c", script], cwd=str(checkout),
+                       capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", "HOME": str(checkout)})
+    assert r.returncode == 0, r.stderr
+    assert (checkout / DIARY).read_text() == "base day log\n"
     assert not (checkout / BACKUP_DIR).exists()
 
 
@@ -120,14 +146,19 @@ def test_no_deletions_means_plain_fast_forward(desk):
 
 
 def test_both_host_side_pull_sites_use_the_guard():
-    """Contract pin: the two autostash pull sites must go through the shared
-    wrapper, so a third raw pull cannot quietly reopen the window."""
+    """Contract pin: all three merge sites must go through the shared helper,
+    so a fourth raw merge cannot quietly reopen the window."""
     for script in (ROOT / "ops/host/refresh_live.sh",
-                   ROOT / "ops/publish/safe_push.sh"):
+                   ROOT / "ops/publish/safe_push.sh",
+                   ROOT / "ops/publish/publish_dashboard.sh"):
         text = script.read_text(encoding="utf-8")
         assert "ops/publish/untrack_guard.sh" in text, \
             f"{script.name} no longer sources the guard"
-        assert "pull_guarded " in text, \
-            f"{script.name} no longer calls pull_guarded"
+    for script, fn in ((ROOT / "ops/host/refresh_live.sh", "pull_guarded"),
+                       (ROOT / "ops/publish/safe_push.sh", "pull_guarded"),
+                       (ROOT / "ops/publish/publish_dashboard.sh",
+                        "pull_guard_backup")):
+        assert f"{fn} " in (script.read_text(encoding="utf-8")), \
+            f"{script.name} no longer calls {fn}"
     text = GUARD.read_text(encoding="utf-8")
     assert "rebase.autoStash=true" in text, "the wrapper lost the autostash knob"


### PR DESCRIPTION
## #1059 拆分（前置步）：守卫升级为磁盘保全 + 接入 publish_dashboard，先装代码、后到数据

合并 #1059 前自查发现顺序漏洞：该 PR 把 publish_dashboard 的守卫接线和删除面放在同一个 PR 里——而每 20 分钟一次的 `--ff-only` 合并是 live box 上最快的常规拉取方。删除面合入 master 后的**第一个** tick 仍由旧脚本执行：干树 ff 会把 master 不再追踪的干净日记直接从磁盘抹掉，restore 逻辑要再下一个 tick 才上线。「执行中的合并代码必须早于数据」不可绕过，故拆两步：

1. **本 PR（纯代码安装，无任何删除面）**：
   - `pull_guard_backup` 去掉 dirty 过滤——incoming 删除 ∩ 磁盘存在即备份。P3 配方的目的是磁盘保留，干净副本恰是 ff 路径的受害者；脏副本是 autostash 冲突的受害者，两者都要保。
   - `publish_dashboard.sh` 的 ff-merge 前后接 backup/restore；脏日记照旧让 ff 拒绝（只延迟当 tick），干净副本 restore 为 untracked 文件、树保持干净。
   - `pull_guarded` 自带 fetch；publisher 复用自己已有的 fetch，每 tick 零额外网络往返。
2. **后续 PR**：`git rm --cached` 37 篇日记 + `.gitignore` + AGENTS.md 表行删除。等本 PR 合入且 live box 装上（一个 publisher tick 内）后再合。

测试更新：原「干净删除穿透」断言反转为「干净副本磁盘存活」；新增 ff 路径直驱 backup/restore 用例；三处合并站点（refresh_live / safe_push / publish_dashboard）接线契约钉住。

关联：#1038、#1058。
