### PR TITLE
fix: 测试进程不再能碰别的 workspace + 账本进 CI 触发面 (#1063)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ on:
       - 'examples/dsh/**'
       - 'portfolio.json'
       - 'memory/**-plan.json'
+      # The decision ledger: three validate-job gates read it and nothing else
+      # feeds them, so a ledger-only commit used to start no run at all (#1063).
+      - 'memory/decisions.jsonl'
       # Research artifacts are validated by the suite below, so a
       # bad thesis/earnings/gate artifact must be able to red it.
       - 'memory/theses/**'

--- a/ops/ci/push_scope.py
+++ b/ops/ci/push_scope.py
@@ -45,6 +45,14 @@ CODE_GLOBS = [
     "pytest.ini",
     "portfolio.json",
     "memory/*-plan.json",
+    # The ledger itself (#1063). It is the sole input of three gates in the
+    # validate job — plan-origin cross-check, per-row schema, settle
+    # idempotence — and was in no lane, so a commit that touched ONLY
+    # decisions.jsonl ran none of them. That is how a fabricated row reached
+    # master on 2026-08-26 and how its removal had to be verified by a manual
+    # workflow_dispatch. Named exactly, not `memory/*.jsonl`: the sibling
+    # archive/history files are automation output nothing validates.
+    "memory/decisions.jsonl",
     "memory/theses/*",
     "memory/earnings/*",
     "memory/entry-gates/*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,37 @@ os.environ["CLAWOCK_DELIVERY_DISABLED"] = "1"
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "assets" / "data" / "dashboard.json"
 
+# A test process must also be physically incapable of writing ANOTHER
+# workspace's published state (#1063).
+#
+# `CLAWOCK_WORKSPACE` is a permanent export in this host's shell, so a suite run
+# from a worktree resolved `WS` — and `LEDGER`, which reaches load/upsert/write
+# as a definition-time default argument captured at import — to the LIVE
+# checkout instead of the checkout under test. That is how a fixture decision
+# (`dec-20260824-00100-add_only_on_trigger`) was written into the live
+# `memory/decisions.jsonl`, settled against real bars by the next brief,
+# committed to master by the daily memory commit, and finally caught by the
+# plan-origin cross-check in CI — a day later and three artifacts downstream.
+#
+# The write guard below could not see it: `_watched_state()` stats paths under
+# ROOT, and those writes landed in a different tree entirely. A guard anchored
+# to the wrong directory reports a clean run no matter what the suite does, so
+# the fix belongs here, before any test module imports anything.
+#
+# Removed rather than repointed at ROOT: unset is the shape every GitHub
+# Actions run already has, `workspace_root()` then falls back to the package's
+# own checkout (= ROOT, because the sys.path inserts below make clawock resolve
+# from src/ here), and a test that behaves differently when the variable merely
+# EXISTS stays honest — `test_context_audit_covers_every_profile` is one, and
+# pinning a value would have hidden that from every local run.
+# Per-test `monkeypatch.setenv` isolation is untouched: this runs once, at
+# import, and those tests set the variable to their own tmp_path afterwards.
+_foreign_workspace = os.environ.pop("CLAWOCK_WORKSPACE", None)
+if _foreign_workspace:
+    print(f"conftest: dropped CLAWOCK_WORKSPACE={_foreign_workspace}; the suite "
+          f"only ever touches the checkout under test ({ROOT}) — see #1063",
+          file=sys.stderr)
+
 # Import time, not fixture time: collection imports the test modules, which
 # import remaining operator scripts by bare name. See the module docstring.
 sys.path.insert(0, str(ROOT / "src"))

--- a/tests/test_push_scope.py
+++ b/tests/test_push_scope.py
@@ -76,10 +76,13 @@ SCENARIOS = [
         _lanes(), False,
         id="scheduled-scan payloads: zero CI (no loop from CI's own coverage commit)"),
     pytest.param(
-        ["memory/archive/2026-W33.csv", "memory/weekly/2026-W34.md",
-         "memory/decisions.jsonl"],
+        ["memory/archive/2026-W33.csv", "memory/weekly/2026-W34.md"],
         _lanes(), False,
-        id="eod-archive / weekly-review / ledger commits: zero CI"),
+        id="eod-archive / weekly-review commits: zero CI"),
+    pytest.param(
+        ["memory/decisions.jsonl"],
+        _lanes(code=True, analysable=False), True,
+        id="ledger-only commit: suite runs (#1063), CodeQL still skips"),
     pytest.param(
         ["site/assets/shadow-backtest.png", "site/assets/social-card.png",
          "site/assets/dsh-decision-mind.png"],

--- a/tests/test_suite_workspace_isolation.py
+++ b/tests/test_suite_workspace_isolation.py
@@ -1,0 +1,89 @@
+"""The suite may only ever write the checkout it is running from (#1063).
+
+`CLAWOCK_WORKSPACE` is exported permanently on the host that runs this
+repository, so `pytest` started in a worktree used to resolve the harness
+constants — `WS`, and the `LEDGER` default argument bound at definition time —
+to the LIVE workspace. A fixture decision written by
+`test_postflight_entry_price_source.py` during an iteration landed in the live
+`memory/decisions.jsonl`, was settled against real bars by the next brief,
+committed to master by the daily memory commit, and reddened CI a day later.
+
+`tests/conftest.py` drops the variable at import time, so a local run has the
+same shape as CI. These tests assert it from both ends: the constants really do
+resolve inside the checkout, and a hostile value handed to a fresh child
+process does not survive the conftest import.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_harness_constants_resolve_inside_this_checkout():
+    """The in-process half: what every real suite run must already be true of."""
+    from clawock.decision import ledger
+    from clawock.harness import brief_postflight
+
+    # The ledger path reaches load/upsert/write as a definition-time default,
+    # which is the seam that leaked: assert the bound default, not just the
+    # module constant a later patch could shadow.
+    bound = ledger.load_decisions.__defaults__[0]
+    for path in (ledger.LEDGER, bound, brief_postflight.WS):
+        assert ROOT in Path(path).resolve().parents or Path(path).resolve() == ROOT, (
+            f"{path} resolves outside the checkout under test ({ROOT})")
+
+    assert "CLAWOCK_WORKSPACE" not in os.environ, (
+        "a CLAWOCK_WORKSPACE override survived into the test process; the "
+        f"suite must run in the unset shape CI has, got {os.environ.get('CLAWOCK_WORKSPACE')}")
+
+
+def test_a_foreign_workspace_does_not_survive_conftest_import(tmp_path):
+    """The regression itself, in a fresh process handed the live-workspace hazard.
+
+    Importing `tests/conftest.py` is what pytest does before it imports any test
+    module, and the drop happens at exactly that moment — so a plain child
+    interpreter proves the seam without starting a second pytest session (which
+    would rewrite the four publish-owned artifacts through its own session
+    fixture and register this test as a new writer of published state).
+
+    Without the drop the child resolves the ledger to
+    `<hostile>/memory/decisions.jsonl` — which is precisely what a real run
+    against /root/.openclaw/workspace did silently, because nothing asserted it.
+    """
+    hostile = tmp_path / "another-workspace"
+    (hostile / "memory").mkdir(parents=True)
+    program = (
+        "import os, sys, json\n"
+        "sys.path.insert(0, 'tests')\n"
+        "import conftest\n"
+        "from clawock.decision import ledger\n"
+        "from clawock.harness import brief_postflight\n"
+        "print(json.dumps({\n"
+        "    'env': os.environ.get('CLAWOCK_WORKSPACE'),\n"
+        "    'ledger': str(ledger.LEDGER),\n"
+        "    'bound': str(ledger.load_decisions.__defaults__[0]),\n"
+        "    'ws': str(brief_postflight.WS),\n"
+        "}))\n"
+    )
+    done = subprocess.run(
+        [sys.executable, "-c", program], cwd=ROOT, capture_output=True, text=True,
+        env=dict(os.environ, CLAWOCK_WORKSPACE=str(hostile)),
+    )
+    assert done.returncode == 0, done.stderr[-2000:]
+    seen = json.loads(done.stdout.strip().splitlines()[-1])
+
+    assert seen["env"] is None, (
+        f"the hostile CLAWOCK_WORKSPACE survived conftest import: {seen['env']}")
+    for key in ("ledger", "bound", "ws"):
+        assert str(hostile) not in seen[key], (
+            f"{key} resolved into the hostile workspace: {seen[key]}")
+        assert seen[key].startswith(str(ROOT)), (
+            f"{key} resolved outside the checkout under test: {seen[key]}")
+    assert "dropped CLAWOCK_WORKSPACE" in done.stderr, (
+        "the child never reported the override, so the assertions above may be "
+        "passing for some other reason")
+    # And nothing may have been created in the workspace the hazard pointed at.
+    assert sorted(p.name for p in hostile.rglob("*")) == ["memory"]


### PR DESCRIPTION
Closes #1063.

## A 主因：一个常驻环境变量把整个测试套件指向 live checkout

`CLAWOCK_WORKSPACE` 在本机是常驻 export。从 worktree 跑 pytest 时，`WS` 和 `LEDGER`
（后者以**定义期默认参数**的形式到达 load/upsert/write）在 import 期就解析到 **live
checkout**。`tests/test_postflight_entry_price_source.py` 开发迭代期的夹具行因此写进
了真账本 → 次日 brief 按真实 00100 bars 结算成 loss → daily memory 提交带上 master →
CI 的 plan-origin 交叉校验打红。晚了一天、下游三个产物（含 shadow_portfolio 里
34,300 HKD 的幻影成交）。

conftest 现有的写入守卫结构性看不见它：`_watched_state()` stat 的是 `ROOT` 下的
`assets/data|memory|logs|site/assets`，而写入落在另一棵树里。**守卫锚在错误的目录上，
跑得再干净也证明不了任何事。**

**改法**：conftest 在 import 期把 `CLAWOCK_WORKSPACE` **摘掉**，而不是改指向 ROOT。

- unset 正是每次 GitHub Actions 运行的形态 —— 本地跑套件与 CI 同形；
- `workspace_root()` 于是回落到包自己的 checkout（= ROOT，因为 sys.path 让 clawock 从
  `src/` 解析）；
- 「变量只要存在就换一种行为」的测试继续如实报错：`test_context_audit_covers_every_profile`
  就是一个（在设了变量的机器上本来就红，与本 PR 无关），钉一个值会把它对本地永久藏起来；
- 逐测试 `monkeypatch.setenv` 的隔离完全不受影响。

**新测试** `tests/test_suite_workspace_isolation.py` 两条：
1. 进程内探针 —— `ledger.LEDGER`、`load_decisions` 的绑定默认值、`brief_postflight.WS`
   都在被测 checkout 内，且变量已不在 `os.environ` 里；
2. 真子进程递进敌意值 —— 断言子进程里变量为 None、三个路径都没落进敌意 workspace、
   stderr 打出摘除记录、且那个目录里什么都没被创建。
   用的是**裸 python 子进程而不是子 pytest**：子 pytest 会通过自己的 session fixture
   重写四个 publish-owned 产物，把这条测试变成 `test_no_new_test_writes_to_published_state`
   眼里的新写入者。

去掉修复两条都红（已验）。

## B 只改账本的 push 永远不跑账本闸

`memory/decisions.jsonl` 既不在 `CODE_GLOBS` 也不在 ci.yml 的 push paths 里，而它是
validate job 三个闸（plan-origin 交叉校验、逐行 schema、settle 幂等）的唯一输入。
今天那条清污染的修复 push 自己就没触发 CI，只能手工 `workflow_dispatch` 验绿。

两半一起补上；`test_push_scope.py` 的场景表按事实拆开：

| 场景 | 之前 | 现在 |
|---|---|---|
| eod-archive / weekly-review | 零 CI | 零 CI（不变） |
| ledger-only commit | 零 CI | 跑套件，CodeQL 仍跳过 |

代价是每天多一次 EOD 归档提交触发的 validate；换来的是账本任何改动都过闸。

## C 不做（记录判断）

把 plan-origin 校验放进 `.githooks/pre-push` 能更早拦截，但会让一次账本污染直接堵死每日
简报的发布路径 —— 与 `feedback-detect-but-never-silence` 冲突。A 落地后若仍出现同类
泄漏再议。

## 验证

- 新测试红/绿各验一次。
- 全量套件在 worktree 里带 `CLAWOCK_WORKSPACE=/root/.openclaw/workspace` 跑：
  **2694 passed, 1 failed**，唯一失败是 `test_safe_push_refuses_the_money_file_when_the_checker_is_missing`
  —— 在 stash 掉本 PR 全部改动后同样失败（本机没有到 github 的 SSH 出口，子进程 push
  先于被测分支失败），CI 上绿。
- 全程用 md5 证明 live `memory/decisions.jsonl` 未被改动。
