### PR TITLE
feat: workspace memory prose 按类隔离 + 定时清理 (#1069)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -137,5 +137,25 @@ if [ -n "$SECRETS_HIT" ]; then
   exit 1
 fi
 
+# ──────────────────────────────────────────────────────────────────────────
+# 5. No workspace memory prose (#1069)
+# ──────────────────────────────────────────────────────────────────────────
+# .gitignore keeps this class out of `git add memory/`, but `git add -f` and a
+# `git commit -a` on a file that was tracked before the rule existed both walk
+# straight past it — which is how forty chat transcripts carrying WeChat and
+# Telegram session keys reached a public repository. The prose is host-local
+# and pruned on a clock (`ops/host/prune_memory_prose.py`); nothing in the
+# repository reads it.
+PROSE=$(echo "$STAGED" | grep -E '^memory/[0-9]{4}-[0-9]{2}-[0-9]{2}(-[^/]*)?\.md$' \
+        | grep -vE -- '-pre-open\.md$' \
+        | grep -vE '^memory/2026-06-23-2225-spch-infinite-ammo\.md$' || true)
+if [ -n "$PROSE" ]; then
+  echo "  ✗ workspace memory prose is staged — it must not enter the repo (#1069):" >&2
+  echo "$PROSE" | sed 's/^/      /' >&2
+  echo "  → keep it on the host; the retention job ages it out." >&2
+  echo "  → deliberate exception? add it to .gitignore's re-include list first." >&2
+  exit 1
+fi
+
 # All checks passed
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -92,49 +92,34 @@ memory/.tmp-*
 memory/.dreams/
 memory/dreaming/
 
-# Promoted chat-session transcripts (`memory/YYYY-MM-DD-HHMM.md`). OpenClaw writes
-# them for its own memory search, which reads the working tree — so they stay on
-# the host and out of git. Forty of them were tracked into a public repository
-# carrying WeChat/Telegram session keys, and nothing in the codebase ever read
-# one: every reader globs `*-plan.json`, `*-pre-open.md`, or the dated
-# `memory/YYYY-MM-DD.md` day log, none of which match this shape.
-memory/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9].md
-
-# Daily notes (`memory/YYYY-MM-DD.md`) — untracked in #1038 and, since
-# 2026-08-26, gone from disk too: they were raw per-session logs with zero
-# consumers anywhere (stage_site globs only *-pre-open.md; no code, workflow or
-# test reads a bare-dated diary), and the curated surfaces — `MEMORY.md` here,
-# the interactive coding agents' own durable memory outside this repository —
-# are what actually gets read back. The rule stays so a writer that sweeps
-# `git add memory/` cannot re-introduce them; AGENTS.md no longer asks anyone
-# to write one.
+# ── Workspace memory prose (#1069) ──────────────────────────────────────────
+# kcn's rule, 2026-08-26: 「这些 memory 可以有但要定时清理而且不能进 repo」 —— the
+# same shape the interactive agents' own memory has: a curated index that is
+# kept (`MEMORY.md`), and raw per-session prose that lives on the host and ages
+# out. `ops/host/prune_memory_prose.py` owns the clock; these rules own the
+# "never in the repo" half.
+#
+# Everything dated under memory/ is prose unless it is one of the two tracked
+# product surfaces re-included below. Stated as a CLASS on purpose: #1062 named
+# sixteen files one by one, so the seventeenth — written by a session that had
+# no idea the list existed — went straight into a public repository. Three
+# shapes have already arrived this way: the bare day log
+# (`memory/YYYY-MM-DD.md`), the promoted chat transcript
+# (`memory/YYYY-MM-DD-HHMM.md`, forty of which were tracked carrying
+# WeChat/Telegram session keys), and one-off named notes
+# (`memory/YYYY-MM-DD-some-topic.md`: travel, OAuth setup, one-day policy memos).
+# No reader in the codebase globs any of them — every consumer asks for
+# `*-plan.json`, `*-pre-open.md`, or a directory that is not memory/ at all.
 memory/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md
+memory/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.md
 
-# One-off dated prose, untracked 2026-08-26 (#1038 follow-up): personal
-# workspace notes (travel, OAuth/larkbot setup, one-day policy memos) with zero
-# repo-level consumers — verified per file by grep across src/ops/site/tests/
-# docs before untracking. Listed by exact name because no glob separates them
-# from briefs that must stay tracked, and an ignore rule is what keeps the
-# postflight's directory-scoped `git add memory/` from re-tracking them.
-# Disk copies stay; git history preserves the public past. The two strategy
-# ruling source docs (2026-06-23-2225-spch-infinite-ammo.md,
-# analysis-2026-08-15-add-gap.md) deliberately remain tracked.
-memory/2026-04-05-skills-policy.md
-memory/2026-04-06-tools-access.md
-memory/2026-04-07-hk-storage.md
-memory/2026-04-07-larkbot-lock.md
-memory/2026-04-07-oauth-plan.md
-memory/2026-04-07-startup-greeting.md
-memory/2026-04-08-skills-policy.md
-memory/2026-04-12-trading-strategy.md
-memory/2026-04-14-leveraged-etf.md
-memory/2026-04-15-portfolio-review.md
-memory/2026-04-15-skillhub-policy.md
-memory/2026-04-15-trade-correction.md
-memory/2026-04-20-airport-lounge.md
-memory/2026-04-21-hongkong-defensive.md
-memory/2026-04-21-hotel-map.md
-memory/2026-06-07-rklb-serenity-research.md
+# The two dated surfaces that are repository data, not prose: the published
+# daily brief (stage_site renders it onto the site) and its schema-gated plan.
+!memory/*-pre-open.md
+!memory/*-plan.json
+# One deliberately tracked ruling source: kcn's own WeChat instruction for the
+# SPCH averaging-down campaign. Named, because it is an exception to the class.
+!memory/2026-06-23-2225-spch-infinite-ammo.md
 
 # Misc
 share/

--- a/ops/host/prune_memory_prose.py
+++ b/ops/host/prune_memory_prose.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Retention for the workspace's untracked memory prose (#1069).
+
+kcn's rule, 2026-08-26: 「这些 memory 可以有但要定时清理而且不能进 repo」 —— the
+same shape as the interactive agents' own durable memory: a curated index that
+is kept, and raw per-session prose that ages out on a schedule.
+
+`.gitignore` owns the second half (nothing here can enter the repository). This
+job owns the first: the prose classes below are deleted once they pass their
+retention window. Nothing curated is in scope — `MEMORY.md`, the daily briefs
+(`memory/*-pre-open.md`), the plans, bars, snapshots and the decision ledger are
+all tracked repository data and are structurally out of reach here.
+
+**The safety invariant is tracking, not the glob.** A file is deleted only when
+git both ignores it AND does not track it. A wrong pattern can therefore delete
+nothing that matters: every artifact the dashboards, the ledger or the site read
+is tracked, so it fails the check no matter what a glob says.
+
+Run daily from the host crontab; `--dry-run` prints the same report without
+deleting. The counts go to logs/memory_prune.log, which
+`ops/system_check.py::check_host_cron_logs` already watches for crash tails
+(it derives its targets from the crontab, so no registration is needed).
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Suffixes that share the dated prefix but are tracked repository data: the
+# daily brief and its plan. The tracked guard below would protect them anyway —
+# this keeps them out of the report so a real "protected" line stays a signal.
+KEEP_SUFFIXES = ("-pre-open.md", "-plan.json")
+
+# (label, glob relative to the workspace, retention days)
+#
+# Windows are deliberately different: session prose is re-read only while the
+# work it describes is still in flight, dreaming output is promoted into
+# MEMORY.md within a night and kept longer only for the memory index's recall,
+# and `.tmp` is same-day scratch that several harness phases hand to each other.
+CLASSES = (
+    ("session prose (dated)", "memory/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*.md", 14),
+    ("dreaming notes", "memory/dreaming/*/*.md", 30),
+    ("dream scratch", "memory/.dreams/**/*", 30),
+    ("harness scratch", "memory/.tmp/**/*", 7),
+)
+
+
+def _git(root: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(root), *args], input=stdin,
+                          capture_output=True, text=True)
+
+
+def _deletable(root: Path, candidates: list[Path]) -> list[Path]:
+    """The subset git ignores AND does not track.
+
+    Both halves are load-bearing. `check-ignore` answers about patterns, not
+    about tracking — a tracked file matching an ignore rule still reports as
+    ignored — so the tracked set is what actually protects repository data.
+    """
+    if not candidates:
+        return []
+    rel = [p.relative_to(root).as_posix() for p in candidates]
+    ignored = _git(root, "check-ignore", "--stdin", stdin="\n".join(rel) + "\n")
+    ignored_set = {line.strip() for line in ignored.stdout.splitlines() if line.strip()}
+    tracked = _git(root, "ls-files", "--", "memory")
+    tracked_set = {line.strip() for line in tracked.stdout.splitlines() if line.strip()}
+    return [p for p, name in zip(candidates, rel)
+            if name in ignored_set and name not in tracked_set]
+
+
+def prune(root: Path, *, now: float | None = None, dry_run: bool = False) -> list[dict]:
+    now = time.time() if now is None else now
+    report = []
+    for label, pattern, days in CLASSES:
+        cutoff = now - days * 86400
+        matched = [p for p in root.glob(pattern)
+                   if p.is_file() and not p.name.endswith(KEEP_SUFFIXES)]
+        old = [p for p in matched if p.stat().st_mtime < cutoff]
+        removable = _deletable(root, old)
+        freed = sum(p.stat().st_size for p in removable)
+        if not dry_run:
+            for path in removable:
+                try:
+                    path.unlink()
+                except OSError as exc:  # a writer holding it is not our problem
+                    print(f"  ! {path.name}: {exc}", file=sys.stderr)
+        report.append({
+            "label": label, "days": days, "matched": len(matched),
+            "removed": len(removable), "kept": len(matched) - len(removable),
+            "bytes": freed,
+            # A file that is old but neither ignored nor untracked is the
+            # interesting case: it means a pattern reaches repository data.
+            "protected": len(old) - len(removable),
+        })
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--workspace", type=Path,
+                    default=Path(__file__).resolve().parents[2])
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    root = args.workspace.resolve()
+    if not (root / ".git").exists():
+        print(f"not a git checkout: {root}", file=sys.stderr)
+        return 2
+
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    verb = "would remove" if args.dry_run else "removed"
+    total = 0
+    print(f"{stamp} memory-prune{' (dry run)' if args.dry_run else ''}")
+    for row in prune(root, dry_run=args.dry_run):
+        total += row["bytes"]
+        note = f" · {row['protected']} protected (tracked)" if row["protected"] else ""
+        print(f"  {row['label']:<22} >{row['days']}d: {verb} {row['removed']}, "
+              f"kept {row['kept']}, {row['bytes'] / 1024:.0f}K{note}")
+    print(f"  total {verb}: {total / 1024:.0f}K")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_memory_prose_retention.py
+++ b/tests/test_memory_prose_retention.py
@@ -1,0 +1,167 @@
+"""#1069: raw memory prose may exist, but on a clock — and never in the repo.
+
+kcn's rule (2026-08-26): 「这些 memory 可以有但要定时清理而且不能进 repo」, the
+same shape the interactive agents' own memory has — a curated index that is
+kept, raw per-session prose that ages out.
+
+Two halves, both asserted here: `.gitignore` keeps the prose out of the
+repository as a CLASS (the previous rule named sixteen files one by one, so the
+seventeenth would have been committed), and `ops/host/prune_memory_prose.py`
+deletes it on a retention window without ever being able to reach tracked data.
+"""
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SPEC = importlib.util.spec_from_file_location(
+    "prune_memory_prose", ROOT / "ops" / "host" / "prune_memory_prose.py")
+pruner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pruner)
+
+
+def _git(root, *args):
+    return subprocess.run(["git", "-C", str(root), *args],
+                          capture_output=True, text=True, check=True)
+
+
+def _repo(tmp_path):
+    """A workspace with the ignore rules under test and one tracked brief."""
+    root = tmp_path / "ws"
+    (root / "memory" / "dreaming" / "deep").mkdir(parents=True)
+    (root / "memory" / ".tmp").mkdir(parents=True)
+    _git(root.parent, "init", "-q", str(root))
+    (root / ".gitignore").write_text(
+        (ROOT / ".gitignore").read_text(encoding="utf-8"), encoding="utf-8")
+    return root
+
+
+def _write(root, rel, age_days):
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("prose\n", encoding="utf-8")
+    stamp = time.time() - age_days * 86400
+    import os
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def test_the_ignore_rule_covers_the_class_not_a_list_of_names():
+    """The seventeenth one-off note must be ignored without editing .gitignore.
+
+    #1062 listed sixteen exact filenames. Anything dated written after that —
+    by a session that had no idea the list existed — landed straight in the
+    index, which is how prose kept re-entering the repository.
+    """
+    probes = [
+        "memory/2099-01-01.md",                  # daily note
+        "memory/2099-01-01-1530.md",             # timestamped session note
+        "memory/2099-01-01-some-topic.md",       # one-off named prose
+    ]
+    keep = [
+        "memory/2099-01-01-pre-open.md",         # the published daily brief
+        "memory/2099-01-01-plan.json",           # schema-gated plan
+    ]
+    out = subprocess.run(["git", "-C", str(ROOT), "check-ignore", *probes, *keep],
+                         capture_output=True, text=True)
+    ignored = set(out.stdout.split())
+    assert set(probes) <= ignored, (
+        f"memory prose that is not ignored would enter the repo: "
+        f"{sorted(set(probes) - ignored)}")
+    assert not (set(keep) & ignored), (
+        f"the brief/plan surfaces must stay trackable: {sorted(set(keep) & ignored)}")
+
+
+def test_prune_removes_aged_prose_and_keeps_the_recent(tmp_path):
+    root = _repo(tmp_path)
+    old_daily = _write(root, "memory/2099-01-01.md", 30)
+    old_dream = _write(root, "memory/dreaming/deep/2099-01-01.md", 40)
+    old_scratch = _write(root, "memory/.tmp/insights-2099-01-01.json", 30)
+    fresh_daily = _write(root, "memory/2099-02-02.md", 2)
+    fresh_dream = _write(root, "memory/dreaming/deep/2099-02-02.md", 5)
+
+    pruner.prune(root)
+
+    assert not old_daily.exists() and not old_dream.exists()
+    assert not old_scratch.exists()
+    assert fresh_daily.exists(), "inside the window, prose stays"
+    assert fresh_dream.exists()
+
+
+def test_prune_cannot_delete_tracked_data_even_when_a_glob_reaches_it(tmp_path):
+    """The safety invariant: tracking, not the glob.
+
+    A brief is dated exactly like a diary and is old the day after it ships. If
+    the pattern were the only defence, one wrong character would delete the
+    published archive — so the pruner deletes a file only when git both ignores
+    it and does not track it, and this test forces the collision by tracking a
+    file the glob does match.
+    """
+    root = _repo(tmp_path)
+    trap = _write(root, "memory/2099-01-01-tracked-note.md", 90)
+    _git(root, "add", "-f", "memory/2099-01-01-tracked-note.md")
+    _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "track")
+    decoy = _write(root, "memory/2099-01-02-untracked-note.md", 90)
+
+    report = pruner.prune(root)
+
+    assert trap.exists(), "a tracked file was deleted; the guard is not holding"
+    assert not decoy.exists(), "the untracked twin should have been pruned"
+    prose = next(r for r in report if r["label"].startswith("session prose"))
+    assert prose["protected"] == 1, report
+
+
+def test_dry_run_reports_without_deleting(tmp_path):
+    root = _repo(tmp_path)
+    old = _write(root, "memory/2099-01-01.md", 30)
+    report = pruner.prune(root, dry_run=True)
+    assert old.exists()
+    assert sum(r["removed"] for r in report) == 1
+
+
+def test_every_class_has_a_window_and_none_reaches_curated_data():
+    """A retention table is a policy; keep it readable and out of the ledger."""
+    for label, pattern, days in pruner.CLASSES:
+        assert 1 <= days <= 365, (label, days)
+        assert pattern.startswith("memory/"), (
+            f"{label} reaches outside memory/: {pattern}")
+    patterns = [p for _, p, _ in pruner.CLASSES]
+    for owned in ("memory/bars", "memory/snapshots", "memory/theses",
+                  "memory/weekly", "memory/archive"):
+        assert not any(p.startswith(owned) for p in patterns), (
+            f"{owned} is repository data; no retention class may name it")
+
+
+def test_the_pre_commit_hook_refuses_staged_prose(tmp_path):
+    """`git add -f` walks past .gitignore; the hook is what stops it.
+
+    This is not hypothetical: forty `memory/YYYY-MM-DD-HHMM.md` transcripts
+    carrying WeChat and Telegram session keys reached a public repository
+    exactly this way, staged by a sweep that used -f.
+    """
+    repo = tmp_path / "repo"
+    (repo / "memory").mkdir(parents=True)
+    (repo / ".githooks").mkdir()
+    _git(repo.parent, "init", "-q", str(repo))
+    hook = repo / ".githooks" / "pre-commit"
+    hook.write_text((ROOT / ".githooks" / "pre-commit").read_text(encoding="utf-8"),
+                    encoding="utf-8")
+    hook.chmod(0o755)
+    _git(repo, "config", "core.hooksPath", ".githooks")
+
+    (repo / "memory" / "2099-01-01-note.md").write_text("prose\n", encoding="utf-8")
+    (repo / "memory" / "2099-01-01-pre-open.md").write_text("brief\n", encoding="utf-8")
+    _git(repo, "add", "-f", "memory/2099-01-01-note.md",
+         "memory/2099-01-01-pre-open.md")
+
+    done = subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-m", "sweep"], capture_output=True, text=True)
+    assert done.returncode != 0, "the hook let memory prose through"
+    assert "2099-01-01-note.md" in done.stderr
+    assert "pre-open" not in done.stderr, (
+        "the published brief is not prose; blocking it would break the daily "
+        "postflight commit")


### PR DESCRIPTION
kcn:「这些 memory 可以有但要定时清理而且不能进 repo」「类似于 Claude 的 memory 一样」
—— 一份策展索引长期保留（`MEMORY.md`），原始 per-session prose 留在主机、按窗口老化、
任何时候不进版本库。两半原来都没兑现。

## 「不能进 repo」：从文件名换成类

`.gitignore` 原来逐条写了 16 个一次性 prose 的确切文件名（#1062）。第 17 份——由一个
不知道这张名单存在的 session 写出来的——会直接进索引。这个仓库已经用三种形状踩过同
一个坑：裸日志、40 份带时刻的会话留痕（**其中带着微信/Telegram session key 进了公开
仓库**）、一次性命名笔记。现在是三条类规则 + 显式 re-include：`*-pre-open.md` 与
`*-plan.json` 是仓库数据不是 prose，另加一份刻意 tracked 的裁决留痕（SPCH 无限子弹流）。

`git add -f` / `git commit -a` 本来就绕过 .gitignore，所以 `.githooks/pre-commit` 补一
道闸：暂存区出现 memory prose 直接拒绝，并指出正确做法。同批的 `-pre-open.md` 不受影响
（否则每天的 postflight 提交会被自己拦死）。

## 「定时清理」：ops/host/prune_memory_prose.py

按类保留：session prose 14 天 / dreaming 30 天 / dream scratch 30 天 / harness scratch
7 天。窗口不同是因为读法不同：session prose 只在它描述的活还没干完时会被回看；dreaming
的产出当晚就促进进 MEMORY.md，留久一点只为记忆检索召回；`.tmp` 是同日 scratch。

**安全不变量是「tracked」而不是 glob**：只删「git 忽略且未跟踪」的文件。dashboard、
账本、站点读的每一个产物都是 tracked，所以任何 pattern 写错都伤不到它们——测试里专门
造了一个「glob 命中但文件 tracked」的陷阱来钉这条。

本机 dry-run：dreaming 303 份 / dream scratch 117 份可回收，约 9.6M；session prose 与
harness scratch 当前都在窗口内，0 删除。

## 验证

六条新测试（类规则覆盖三种形状且不误伤 brief/plan；pruner 删旧留新；tracked 陷阱；
dry-run 不删；保留表不许指向 bars/snapshots/theses/weekly/archive；pre-commit 闸对
`-f` 生效且放行 brief）。全量套件 2697 passed / 1 failed，唯一失败是
`test_safe_push_refuses_the_money_file_when_the_checker_is_missing`（本机没有到 github
的 SSH 出口，与本 PR 无关，CI 上绿）。

主机 crontab 那一行在合并后单独装（crontab 不在仓库里），日志走
`logs/memory_prune.log`，已被 `check_host_cron_logs` 自动纳入（它从 crontab 推导目标）。

Closes #1069

Claude-Session: https://claude.ai/code/session_01H27UeBzADyvpnvZ6cRrbHu