### PR TITLE
fix: memory 去追踪后 pre-push 闸把每一次 push 都挡了 (#1071 余波)

### DIFF
--- a/config/root-allowlist.json
+++ b/config/root-allowlist.json
@@ -1,5 +1,6 @@
 {
  "schema_version": 1,
+ "note": "Explains the TRACKED top-level surface only. MEMORY.md and DREAMS.md were entries here until #1071; they are the agent's memory — host-local and untracked — and an entry with no tracked path is a CRITICAL 'missing' that blocks every push, so they must not come back.",
  "entries": {
   ".githooks": {
    "owner": "repository safety",
@@ -33,10 +34,6 @@
    "owner": "runtime compatibility",
    "consumer": "Claude Code entry context"
   },
-  "DREAMS.md": {
-   "owner": "host-local, untracked (#1071)",
-   "consumer": "OpenClaw dreaming promotion writes it; nothing in the repo reads it"
-  },
   "HEARTBEAT.md": {
    "owner": "runtime compatibility",
    "consumer": "OpenClaw heartbeat"
@@ -52,10 +49,6 @@
   "LICENSE": {
    "owner": "legal",
    "consumer": "package metadata, GitHub and Pages staging"
-  },
-  "MEMORY.md": {
-   "owner": "host-local, untracked (#1071)",
-   "consumer": "OpenClaw main-session memory — the index of memory/*.md"
   },
   "NOTICE": {
    "owner": "legal",

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -111,10 +111,27 @@ class Result:
         return sum(1 for _, s, _ in self.checks if s == OK)
 
 
+# Shipped in the repository: every checkout, worktree and CI runner has them.
+BASELINE_TRACKED = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'TOOLS.md',
+                    'AGENTS.md', 'CLAUDE.md', 'BOOTSTRAP.md', 'portfolio.json']
+# The agent's memory index: host-local and untracked since #1071, so it is
+# required of the LIVE workspace and absent from every worktree by design.
+BASELINE_HOST_LOCAL = ['MEMORY.md']
+
+
 def check_baseline_files(r):
-    """All required bootstrap + workspace MD files exist."""
-    required = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'MEMORY.md', 'TOOLS.md',
-                'AGENTS.md', 'CLAUDE.md', 'BOOTSTRAP.md', 'portfolio.json']
+    """All required bootstrap + workspace files exist.
+
+    Two tiers, because they have two different truths. The tracked documents
+    must be in whatever checkout this runs from. `MEMORY.md` is the agent's
+    memory index — host-local by design — so requiring it everywhere would turn
+    every agent worktree's pre-push into a CRITICAL and block the PR flow; and
+    NOT requiring it on the live box would let the memory the runtime injects
+    disappear unnoticed. It is checked where it is supposed to be.
+    """
+    required = list(BASELINE_TRACKED)
+    if WS.resolve() == LIVE_WORKSPACE.resolve():
+        required += BASELINE_HOST_LOCAL
     missing = [f for f in required if not (WS / f).exists()]
     if missing:
         r.add('baseline files', CRITICAL, f'missing: {missing}')

--- a/tests/test_memory_lives_on_the_host.py
+++ b/tests/test_memory_lives_on_the_host.py
@@ -168,3 +168,44 @@ def test_a_missing_index_is_itself_the_warning(system_check, live):
     name, severity, message = _curation(system_check)
     assert severity == system_check.WARNING
     assert "MEMORY.md is missing" in message
+
+
+def test_the_health_gate_requires_the_index_where_it_lives_and_nowhere_else(
+        system_check, monkeypatch, tmp_path):
+    """#1071 fallout, caught by the gate blocking every push on the live box.
+
+    `check_root_allowlist` explains the TRACKED root surface, so leaving
+    MEMORY.md / DREAMS.md in `config/root-allowlist.json` after untracking them
+    reported "missing: DREAMS.md, MEMORY.md" as CRITICAL — and pre-push runs
+    this file, so the 20-minute publisher, every watchdog and every agent push
+    were blocked at once. The mirror-image mistake is just as bad: requiring
+    MEMORY.md of every checkout turns each agent worktree's pre-push CRITICAL.
+    So it is required exactly where it lives.
+    """
+    import json as _json
+    entries = _json.loads(
+        (ROOT / "config" / "root-allowlist.json").read_text(encoding="utf-8"))["entries"]
+    assert "MEMORY.md" not in entries and "DREAMS.md" not in entries, (
+        "an allowlist entry with no tracked path is a CRITICAL that blocks "
+        "every push on the live box")
+
+    assert "MEMORY.md" not in system_check.BASELINE_TRACKED
+    assert system_check.BASELINE_HOST_LOCAL == ["MEMORY.md"]
+
+    # A checkout that is not the live workspace: tracked baseline only.
+    elsewhere = tmp_path / "worktree"
+    elsewhere.mkdir()
+    for name in system_check.BASELINE_TRACKED:
+        (elsewhere / name).write_text("x", encoding="utf-8")
+    monkeypatch.setattr(system_check, "WS", elsewhere)
+    monkeypatch.setattr(system_check, "LIVE_WORKSPACE", tmp_path / "live")
+    result = system_check.Result()
+    system_check.check_baseline_files(result)
+    assert result.checks[0][1] == system_check.OK, result.checks
+
+    # The live workspace without its memory index: that is the CRITICAL.
+    monkeypatch.setattr(system_check, "LIVE_WORKSPACE", elsewhere)
+    result = system_check.Result()
+    system_check.check_baseline_files(result)
+    assert result.checks[0][1] == system_check.CRITICAL
+    assert "MEMORY.md" in result.checks[0][2]


### PR DESCRIPTION
`check_root_allowlist` 解释的是**被跟踪的**顶层面。#1072 把 MEMORY.md / DREAMS.md 去
追踪之后，两条 allowlist 条目再也对不上任何 tracked 路径，闸报
`root ownership CRITICAL missing: DREAMS.md, MEMORY.md`——而 pre-push 会跑这个文件，
于是 20 分钟发布器、所有 watchdog、所有 agent push 在合并后一起被挡住。

修法两半，都写成「在该在的地方要求」：

- 两条 allowlist 条目删除，顶层加一个 `note` 字段（在 `entries` 之外，否则它自己就变成
  一条对不上 tracked 路径的条目——试过，同一个 CRITICAL 又回来了）说明它们为什么不该回来。
- `check_baseline_files` 分两层：`BASELINE_TRACKED` 八个文件每个 checkout 都必须有；
  `BASELINE_HOST_LOCAL`（MEMORY.md）**只在 WS 就是 live workspace 时**要求。反过来同样
  是错的：要求每个 checkout 都有，会把每个 agent worktree 的 pre-push 变成 CRITICAL，
  PR 流程直接卡死。

新测试把两个方向都钉住（allowlist 里不许再出现这两个名字；worktree 形态 OK、live 形态
缺 MEMORY.md 必须 CRITICAL）。全量套件 2700 passed / 1 failed，唯一失败是本机没有到
github 的 SSH 出口那条，与本 PR 无关。

Claude-Session: https://claude.ai/code/session_01H27UeBzADyvpnvZ6cRrbHu