### PR TITLE
fix: t0 牌面判时段不判日历——港股时段别再把美股上一场 session 当今天 (#1077)

### DIFF
--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -76,10 +76,21 @@ GRADE_CN = {'chase_low_quality': '🔴 追高低质', 'elevated': '🟡 偏高�
 
 
 def _load_days():
-    """读 jsonl → 按 (date, ticker) 去重取当日最后一条 → 按日期排序的列表。"""
+    """读 jsonl → 按 (**该标的所属市场的交易日**, ticker) 去重取最后一条。
+
+    去重的键必须是行情自己的日子，不是留痕器的墙钟日子。`as_of` 是主机
+    HKT 日期，而美股一场 session 跨 HKT 午夜（21:30 开、次日 04:00 收），
+    于是同一个 `as_of` 下混着两场 session 的行：HKT 白天写的是**上一场**的
+    收盘，21:30 之后写的才是当天的。按 `as_of` 折叠 = 把两场行情压成一个
+    观测，而原注释「取收盘牌面」对美股名从来没兑现过——那一场的后半段
+    （00:00-04:00）已经落到下一个 `as_of` 里去了。
+
+    留痕器现在直接写 `session_date`（#1077）。老行没有这个字段，读取侧
+    回落到 `as_of`：与冻结价闸同一模式——防在读取侧，不改写已有数据。
+    """
     if not HIST.exists():
         return []
-    by_day = {}   # date -> {ticker: {grade_label, close}}
+    by_day = {}   # session date -> {ticker: {grade_label, close}}
     for line in HIST.read_text().splitlines():
         if not line.strip():
             continue
@@ -87,12 +98,12 @@ def _load_days():
             rec = json.loads(line)
         except Exception:
             continue
-        d = rec.get('as_of')
-        if not d:
+        fallback = rec.get('as_of')
+        if not fallback:
             continue
-        day = by_day.setdefault(d, {})
         for t, m in (rec.get('rows') or {}).items():
-            day[t] = m   # 后写覆盖 → 当日最后一条
+            d = m.get('session_date') or fallback
+            by_day.setdefault(d, {})[t] = m   # 后写覆盖 → 该 session 最后一条
     return [{'as_of': d, 'rows': by_day[d]} for d in sorted(by_day)]
 
 

--- a/src/clawock/decision/setups.py
+++ b/src/clawock/decision/setups.py
@@ -170,6 +170,7 @@ def compute(intraday=False):
 
     rows = {}
     market_closed = {}
+    session_date = {}
     for port in pf.get('portfolios', {}).values():
         if not isinstance(port, dict):
             continue
@@ -180,14 +181,33 @@ def compute(intraday=False):
             market = _market_of(t)
             if market and market not in market_closed:
                 try:
-                    market_closed[market] = tc.closed_reason(market) is not None
+                    # Clock, not calendar (#1077). `closed_reason` answers "does
+                    # this market trade today", which is None on any weekday —
+                    # so from Hong Kong's morning the US rows were enriched and
+                    # graded six hours before the US open, off the PREVIOUS
+                    # session's close, and filed under today's date.
+                    market_closed[market] = not tc.in_session(market)
                 except Exception:
                     market_closed[market] = None
-            do_intraday = intraday and not market_closed.get(market, True)
+            # `is False` on purpose: an unknown (the probe raised) records None,
+            # and `not None` is True — so the old form turned a crashed session
+            # check into permission to enrich. Enrich only when we positively
+            # know the market is open.
+            do_intraday = intraday and market_closed.get(market) is False
             cur = _num(h.get('current_price'))
             qrow = quant.get(t, {})
             if qrow.get('status') not in (None, 'fresh'):
                 qrow = {}
+            if market and market not in session_date:
+                try:
+                    day = tc.latest_completed_session(market)
+                    # Mid-session the bar being written IS today's, and it is
+                    # the one this card grades.
+                    if not market_closed.get(market, True):
+                        day = tc._today_in_market(market)
+                    session_date[market] = day.isoformat() if day else None
+                except Exception:
+                    session_date[market] = None
             m = {'market': market}
             m.update(holding_metrics(h, qrow))
             if t in LEVERAGED:
@@ -210,6 +230,11 @@ def compute(intraday=False):
     return {
         'as_of': datetime.now().astimezone().isoformat(timespec='seconds'),
         'market_closed': market_closed,
+        # Which market session each row's numbers belong to. `as_of` is a host
+        # wall clock in HKT, and a US session straddles the HKT midnight, so
+        # the two are NOT the same day for US names — settling on `as_of`
+        # folded two different sessions into one observation (#1077).
+        'session_date': session_date,
         'intraday_enriched': intraday,
         'note': '牌面质量评级，非买卖信号。追高检测 = 当日高位+振幅耗尽时买入为低质。',
         'rows': rows,
@@ -220,8 +245,10 @@ def persist_history(data):
     """每次运行追加一行留痕，供 t0_setup_review.py 对账（零网络）。
     只记结算需要的精简字段：grade_label + range_pos + close（= 记录时现价）。"""
     from datetime import date as _date
+    session_date = data.get('session_date') or {}
     rows = {t: {'grade_label': m.get('grade_label'), 'range_pos': m.get('range_pos'),
-                'close': m.get('current'), 'market': m.get('market')}
+                'close': m.get('current'), 'market': m.get('market'),
+                'session_date': session_date.get(m.get('market'))}
             for t, m in data.get('rows', {}).items() if m.get('current') is not None}
     if not rows:
         return

--- a/src/clawock/sessions.py
+++ b/src/clawock/sessions.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 # --- Full-day market closures (weekday ones are what matter; weekend-falling
@@ -223,6 +223,49 @@ def previous_trading_day(market: str, d: date) -> date:
             return probe
         probe -= timedelta(days=1)
     raise ValueError(f"no {market} trading day found before {d}")
+
+
+#: Regular-hours trading windows in market-local time. HK breaks for lunch; a
+#: half day is the morning window alone (`HK_HALF_DAYS`). Pre/post-market is
+#: deliberately NOT a session: every consumer of this predicate is asking "is
+#: today's bar still being written", and an extended-hours print does not move
+#: the day range these gates are built on.
+SESSION_WINDOWS = {
+    "hk": ((time(9, 30), time(12, 0)), (time(13, 0), time(16, 0))),
+    "us": ((time(9, 30), time(16, 0)),),
+}
+
+
+def in_session(market: str, at: datetime | None = None) -> bool:
+    """Is `market` trading RIGHT NOW — calendar day AND clock.
+
+    `closed_reason` answers a different question: whether the market trades on
+    a given DATE. Reading it as "is it open" is how `compute_t0_setups` came to
+    enrich US holdings from Hong Kong's afternoon: on any weekday
+    `closed_reason("us")` is None, so at 15:33 HKT — six hours before the US
+    open — the US rows were built from the previous session's close and filed
+    with today's `as_of`, graded "现价在当日区间 84% 高位" off a bar that had
+    closed the day before.
+
+    Past the holiday table's horizon `closed_reason` fails OPEN, and so does
+    this: an unextended table must never make a real trading day look shut.
+    """
+    market = market.lower()
+    if market not in SESSION_WINDOWS:
+        raise ValueError(f"unknown market {market!r} (use 'hk' or 'us')")
+    tz = ZoneInfo(MARKET_TZ[market])
+    now = at.astimezone(tz) if at else datetime.now(tz)
+    session = "afternoon" if market == "hk" else "full"
+    if closed_reason(market, now.date(), session=session) is not None:
+        # A HK half day is shut in the afternoon but open in the morning, so a
+        # blanket False here would call 11:00 on a half day closed.
+        if not (market == "hk" and now.date().isoformat() in HK_HALF_DAYS):
+            return False
+    windows = SESSION_WINDOWS[market]
+    if market == "hk" and now.date().isoformat() in HK_HALF_DAYS:
+        windows = windows[:1]
+    clock = now.time()
+    return any(start <= clock < end for start, end in windows)
 
 
 def closed_reason(market: str, d: date | None = None,

--- a/tests/test_quant_package_boundary.py
+++ b/tests/test_quant_package_boundary.py
@@ -61,7 +61,9 @@ def test_t0_derives_market_from_registry_not_the_book_name(tmp_path, monkeypatch
     quant_file.write_text(json.dumps({"rows": {}}), encoding="utf-8")
     monkeypatch.setattr(t0, "PORTFOLIO", portfolio)
     monkeypatch.setattr(t0, "QUANT", quant_file)
-    monkeypatch.setattr(t0.tc, "closed_reason", lambda market: "closed")
+    # `in_session` since #1077: the card is graded on whether the market is
+    # trading right now, not on whether it trades today.
+    monkeypatch.setattr(t0.tc, "in_session", lambda market: False)
 
     result = t0.compute()
 

--- a/tests/test_t0_session_boundary.py
+++ b/tests/test_t0_session_boundary.py
@@ -1,0 +1,137 @@
+"""A T+0 card grades a session, and a session is not a calendar day (#1077).
+
+Measured on 2026-08-26 at 15:33 HKT — six hours before the US open —
+`assets/data/t0_setups.json` carried:
+
+    "CRCL": {"current": 92.02, "today_change_pct": 4.902, "range_pos": 84.5,
+             "grade_label": "追高低质",
+             "grade_reason": "现价在当日区间 84% 高位、今日振幅已达典型日的 1.6×"}
+
+92.02 was CRCL's **2026-08-25** close (`prev_close_date` in portfolio.json says
+so) and 4.902% was 08-25's move. The card was filed with `as_of: 2026-08-26`.
+
+Cause: `closed_reason()` answers "does this market trade on this DATE", which is
+None on any weekday, so `market_closed["us"]` read False all through Hong Kong's
+session. Two consequences, both asserted here: the card is built from a stale
+bar, and the history line lands under an HKT date that folds two different US
+sessions into one settlement observation.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+HKT = ZoneInfo("Asia/Hong_Kong")
+
+
+@pytest.fixture(scope="module")
+def sessions():
+    return pytest.importorskip("clawock.sessions")
+
+
+@pytest.fixture(scope="module")
+def review():
+    return pytest.importorskip("clawock.decision.setup_review")
+
+
+# ── the clock half ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("when, market, expected", [
+    # The measured case: Hong Kong's afternoon, the US has not opened.
+    (datetime(2026, 8, 26, 15, 33, tzinfo=HKT), "us", False),
+    (datetime(2026, 8, 26, 15, 33, tzinfo=HKT), "hk", True),
+    # US regular hours (21:30 HKT = 09:30 ET).
+    (datetime(2026, 8, 26, 22, 0, tzinfo=HKT), "us", True),
+    (datetime(2026, 8, 26, 22, 0, tzinfo=HKT), "hk", False),
+    # HK lunch break is not a session.
+    (datetime(2026, 8, 26, 12, 30, tzinfo=HKT), "hk", False),
+    # Before the HK open, on a trading day: the calendar says open, the clock does not.
+    (datetime(2026, 8, 26, 9, 0, tzinfo=HKT), "hk", False),
+    # Weekend.
+    (datetime(2026, 8, 29, 11, 0, tzinfo=HKT), "hk", False),
+])
+def test_in_session_reads_the_clock_not_only_the_calendar(
+        sessions, when, market, expected):
+    assert sessions.in_session(market, when) is expected
+
+
+def test_the_calendar_gate_alone_would_have_said_open(sessions):
+    """The exact confusion that shipped: same instant, two different answers."""
+    when = datetime(2026, 8, 26, 15, 33, tzinfo=HKT)
+    assert sessions.closed_reason("us", when.date()) is None, (
+        "the calendar says the US trades on 2026-08-26 — it just is not 09:30 ET yet")
+    assert sessions.in_session("us", when) is False
+
+
+def test_an_unknown_session_does_not_grant_intraday_enrichment(monkeypatch):
+    """`not None` is True, so a crashed probe used to read as 'open'."""
+    t0 = pytest.importorskip("clawock.decision.setups")
+
+    def explode(market):
+        raise RuntimeError("holiday table unreadable")
+
+    monkeypatch.setattr(t0.tc, "in_session", explode)
+    fetched = []
+    monkeypatch.setattr(t0, "fetch_vwap_orb", lambda code: fetched.append(code))
+    t0.compute(intraday=True)
+    assert fetched == [], (
+        "an unknown session must not be read as permission to enrich")
+
+
+# ── the settlement half ──────────────────────────────────────────────────────
+
+def _line(as_of, ticker, market, label, close, session_date=None):
+    row = {"grade_label": label, "range_pos": 50.0, "close": close, "market": market}
+    if session_date is not None:
+        row["session_date"] = session_date
+    return json.dumps({"as_of": as_of, "ts": f"{as_of}T00:00:00+08:00",
+                       "rows": {ticker: row}}, ensure_ascii=False)
+
+
+def test_two_us_sessions_under_one_hkt_date_stay_two_observations(review, tmp_path,
+                                                                  monkeypatch):
+    """The shipped shape: an HKT day holds the tail of one session and the head
+    of the next, so folding on `as_of` loses one of them entirely."""
+    hist = tmp_path / "t0_setups_history.jsonl"
+    hist.write_text("\n".join([
+        # written 15:33 HKT on 08-26 — this is 08-25's closing bar
+        _line("2026-08-26", "CRCL", "us", "追高低质", 92.02, session_date="2026-08-25"),
+        # written 22:03 HKT on 08-26 — now it really is 08-26's bar
+        _line("2026-08-26", "CRCL", "us", "中性", 91.99, session_date="2026-08-26"),
+    ]) + "\n", encoding="utf-8")
+    monkeypatch.setattr(review, "HIST", hist)
+
+    days = review._load_days()
+    assert [d["as_of"] for d in days] == ["2026-08-25", "2026-08-26"], (
+        "settling on the host's HKT date folds two US sessions into one row")
+    assert days[0]["rows"]["CRCL"]["close"] == 92.02
+    assert days[1]["rows"]["CRCL"]["close"] == 91.99
+
+
+def test_rows_without_a_session_date_still_settle_on_as_of(review, tmp_path,
+                                                           monkeypatch):
+    """Read-side defence, data untouched — the frozen-price gate's pattern.
+
+    Every line written before #1077 lacks the field; rejecting them would throw
+    away the whole existing sample to fix its tail.
+    """
+    hist = tmp_path / "t0_setups_history.jsonl"
+    hist.write_text("\n".join([
+        _line("2026-08-20", "CRCL", "us", "追高低质", 84.49),
+        _line("2026-08-21", "CRCL", "us", "中性", 85.16),
+    ]) + "\n", encoding="utf-8")
+    monkeypatch.setattr(review, "HIST", hist)
+
+    days = review._load_days()
+    assert [d["as_of"] for d in days] == ["2026-08-20", "2026-08-21"]
+
+
+def test_the_producer_records_which_session_each_row_belongs_to():
+    """`persist_history` must carry the field the reader now settles on."""
+    import inspect
+    t0 = pytest.importorskip("clawock.decision.setups")
+    source = inspect.getsource(t0.persist_history)
+    assert "session_date" in source


### PR DESCRIPTION
fix: t0 牌面判时段不判日历——港股时段别再把美股上一场 session 当今天 (#1077)

## 实测（2026-08-26 15:33 HKT，美股 21:30 才开盘）

```json
"CRCL": {"current": 92.02, "today_change_pct": 4.902, "range_pos": 84.5,
         "grade": "🔴", "grade_label": "追高低质",
         "grade_reason": "现价在当日区间 84% 高位、今日振幅已达典型日的 1.6×"}
```

92.02 是 CRCL 的 **08-25 收盘**（`portfolio.json` 的 `prev_close_date` 写着），
4.902% 是 **08-25 的涨幅**，整张牌被打上 `as_of: 2026-08-26` 当今天的牌面。

根因：`closed_reason()` 回答的是「这个市场**这一天**开不开市」，工作日恒为 None，
于是港股整个交易时段里 `market_closed["us"]` 都读 False，美股行照走盘中分支。

## 修法

### 1. `sessions.in_session(market, at=None)` —— 时段判据落在唯一权威处

不在 `setups.py` 里另发明一份时段表。HK 含午休与半日市，US 09:30-16:00 ET；
**盘前盘后不算 session**（消费方问的都是「当日 bar 还在写吗」，一笔盘后成交不动
day range）。日历表 horizon 之外与 `closed_reason` 一样 fail-open。

### 2. 留痕带 `session_date`，结算按它去重

`as_of` 是主机 HKT 日期，而美股一场 session 跨 HKT 午夜（21:30 开 / 次日 04:00 收）。
同一个 `as_of` 下混着两场 session 的行：HKT 白天写的是**上一场**的收盘，21:30 之后
写的才是当天的。`_load_days` 原注释「取当日最后一条＝收盘牌面」对美股名**从来没有
兑现过**——那一场的后半段（00:00-04:00）已经落进下一个 `as_of` 了。

**在真实留痕上量了**：83 个留痕日、397 条美股观测，按 session 归属重算后是 **341**
条 —— **56 条（14%）是同一场 session 被两个 HKT 日期各记了一次**，跨这种零间隔配对
算出来的 forward return 是伪观测。老行没有该字段，读取侧回落到 `as_of`：与冻结价闸
同一模式，**防在读取侧、不改写已有数据**。

### 3. 顺带修一个方向反了的 fail-open

`do_intraday = intraday and not market_closed.get(market, True)`：探测抛异常时记
`None`，而 `not None` 是 **True** —— 会话判断崩溃反而**放行**盘中富集。改成
`market_closed.get(market) is False`，只在确知开市时富集。测试用抛异常的探针钉住。

## 验证

`tests/test_t0_session_boundary.py` 12 条：
- 同一时刻日历说开、时钟说没开（就是 shipped 的那个混淆）
- 港股午休 / 开盘前 / 周末 / 美股 22:00 HKT 各一条
- 崩溃探针不得换来富集许可
- 一个 HKT 日期下的两场美股 session 必须留成两条观测
- 无 `session_date` 的老行仍按 `as_of` 结算
- 生产侧确实写了消费侧结算所依赖的字段

`tests/test_quant_package_boundary.py` 的 t0 用例改 patch `in_session`（依赖变了）。
相关模块 131 passed + 新增 12 passed。

Closes #1077

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

