### PR TITLE
fix: 取整不是发明数字——advisory 40% 误报清掉；escalating=0 不再打 (validation warnings) (#1076)

### DIFF
--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -472,6 +472,7 @@ def categorize(issues):
 from clawock.harness.validation import (
     categorize_issues,
     check_md_table_column_consistency,
+    product_status,
     split_advisory,
 )
 from ._harness_common import (  # noqa: E402
@@ -732,10 +733,13 @@ def main(argv=None):
     # advisory-only slot delivers a clean product and must not be filed as a
     # degraded one (#764).
     escalating, advisories = split_advisory(issues)
+    # What shipped, not what the checker noticed — the same correction #768 made
+    # to final_product, applied to the stage and the commit subject (#1076).
+    product = product_status(status, escalating)
     workflow_outcomes.record_stage(
         job_name,
         'llm',
-        'success' if status == 'pass' else ('warning' if status == 'warn' else 'failed'),
+        'success' if product == 'pass' else ('warning' if product == 'warn' else 'failed'),
         slot=slot,
         dry_run=args.dry_run,
         issue_count=len(issues),
@@ -776,7 +780,7 @@ def main(argv=None):
         or status == 'fail'
         or projection_status in {'valid', 'missing', 'invalid'}
     )
-    publication_status = status if projection_ready else 'fail'
+    publication_status = product if projection_ready else 'fail'
     # This is the only release of the off-host committer.  Judgment validity is
     # deliberately not required: missing/invalid prose still writes a complete
     # deterministic projection.  A writer exception or absent decision packet is
@@ -933,10 +937,10 @@ def main(argv=None):
         job_name,
         'postflight',
         ('success'
-         if (status == 'pass' and projection_ready
+         if (product == 'pass' and projection_ready
              and data_plane_status in {'published', 'skipped'})
          else ('warning'
-               if (status == 'warn' and projection_ready
+               if (product == 'warn' and projection_ready
                    and data_plane_status in {'published', 'skipped'})
                else 'failed')),
         slot=slot,

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -49,6 +49,7 @@ from clawock.harness.validation import (
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
+    product_status,
     split_advisory,
     validate_forbidden_phrases,
 )
@@ -444,6 +445,8 @@ def main(argv=None):
     # The banner counts and lists ESCALATING issues only; advisory findings get
     # their own line below, so a truncated list can never drop them (#134).
     escalating, advisories = split_advisory(issues)
+    # What shipped, not what the checker noticed — see product_status (#1076).
+    product = product_status(status, escalating)
     if status == 'pass' or not escalating:
         banner = ''
     elif status == 'warn':
@@ -590,7 +593,7 @@ def main(argv=None):
         'data_plane_status': data_plane_status,
         'narrative_status': {
             'pass': 'success', 'warn': 'warning', 'fail': 'failed',
-        }[status],
+        }[product],
         'insights_sidecar': insights_written,
     }
     heartbeat = ctx.get('heartbeat') or {}
@@ -605,7 +608,7 @@ def main(argv=None):
         args.market,
         heartbeat_state,
         job_name=heartbeat.get('job'), slot=heartbeat.get('slot'),
-        postflight_status=status, wechat_sent=wechat_sent,
+        postflight_status=product, wechat_sent=wechat_sent,
         telegram_sent=tg_ok, dashboard_published=dashboard_published,
         data_plane_status=data_plane_status,
         insights_sidecar=insights_written, issue_count=len(issues),
@@ -623,7 +626,7 @@ def main(argv=None):
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if not publication_ok:
         return 2
-    return 0 if status == 'pass' else (1 if status == 'warn' else 2)
+    return 0 if product == 'pass' else (1 if product == 'warn' else 2)
 
 
 if __name__ == '__main__':

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -88,6 +88,7 @@ from clawock.harness.validation import (
     categorize_issues,
     check_numeric_claims,
     check_raw_tables_verbatim,
+    product_status,
     split_advisory,
     validate_forbidden_phrases,
 )
@@ -444,10 +445,12 @@ def main(argv=None):
     # distinction: an advisory-only slot delivers a clean report and must not be
     # filed as a degraded product (#764).
     escalating, advisories = split_advisory(issues)
+    # What shipped, not what the checker noticed — see product_status (#1076).
+    product = product_status(status, escalating)
     workflow_outcomes.record_stage(
         job_name,
         'llm',
-        'success' if status == 'pass' else ('warning' if status == 'warn' else 'failed'),
+        'success' if product == 'pass' else ('warning' if product == 'warn' else 'failed'),
         slot=slot,
         context_id=ctx.get('context_id'),
         issue_count=len(issues),
@@ -577,7 +580,7 @@ def main(argv=None):
             deterministic_fallback=(status == 'fail'),
         )
 
-    commit_ok, commit_msg = maybe_commit(status, ctx['commit_msg'])
+    commit_ok, commit_msg = maybe_commit(product, ctx['commit_msg'])
     data_plane_status = classify_data_plane(commit_ok, commit_msg)
 
     result = {
@@ -598,7 +601,7 @@ def main(argv=None):
         'data_plane_status': data_plane_status,
         'narrative_status': {
             'pass': 'success', 'warn': 'warning', 'fail': 'failed',
-        }[status],
+        }[product],
         'n_chars':       len(body),
     }
     # Even a rejected prose report can have a successful postflight: the harness
@@ -608,7 +611,7 @@ def main(argv=None):
         job_name,
         'postflight',
         'success'
-        if status == 'pass' and data_plane_status in {'published', 'current'}
+        if product == 'pass' and data_plane_status in {'published', 'current'}
         else 'warning',
         slot=slot,
         delivered=result['delivered'],
@@ -620,7 +623,7 @@ def main(argv=None):
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if data_plane_status not in {'published', 'current'}:
         return 2
-    return 0 if status == 'pass' else (1 if status == 'warn' else 2)
+    return 0 if product == 'pass' else (1 if product == 'warn' else 2)
 
 
 if __name__ == '__main__':

--- a/src/clawock/harness/validation.py
+++ b/src/clawock/harness/validation.py
@@ -118,6 +118,43 @@ MAX_NUMERIC_SAMPLES = 4
 MIN_CHECKED_AMOUNT = 1_000
 
 
+def _rounding_tolerance(raw, magnitude=None):
+    """Half a unit of the last digit the model actually wrote.
+
+    A report that writes "+8%" where the context says 8.2 has rounded for
+    readability; it has not invented a number. Demanding an exact match made
+    that indistinguishable from a fabrication, and the result was noise at a
+    rate nobody could keep reading past: over three days of live runs, 26 of 64
+    slots carried an advisory and every one of them was a rounding — measured,
+    not estimated. `advisory_prefix` is documented as needing to read as
+    information rather than a warning; a check that cries at 40% of clean
+    reports trains the opposite.
+
+    The width is derived from the writing, not configured: "8" claims one
+    significant place and admits [7.5, 8.5]; "8.2" claims a tenth and admits
+    [8.15, 8.25]. Writing more precisely therefore buys a tighter gate, which
+    is the right incentive. A magnitude suffix scales it with the value, so
+    "1.5 万" admits ±500 rather than ±0.05.
+    """
+    text = str(raw)
+    decimals = len(text.split('.', 1)[1]) if '.' in text else 0
+    return 0.5 * (10 ** -decimals) * _MAGNITUDE.get(magnitude, 1)
+
+
+def _states(known, value, tolerance):
+    """Does `known` hold a number `value` could be a rounding of?
+
+    Exact membership stays the fast path — the tolerance only ever widens what
+    already matched, so no previously-quiet report can start reporting.
+    """
+    if value is None:
+        return True
+    target = round(abs(value), 4)
+    if target in known:
+        return True
+    return any(abs(candidate - target) <= tolerance for candidate in known)
+
+
 def _as_number(raw, magnitude=None):
     try:
         value = float(str(raw).replace(',', ''))
@@ -215,31 +252,46 @@ def check_numeric_claims(text, ctx):
     known_by_unit = _context_unit_numbers(ctx)
     unverified = []
 
-    def check(value, label):
-        if value is None or round(abs(value), 4) in known:
+    def check(value, label, tolerance):
+        if _states(known, value, tolerance):
             return
         if label not in unverified:
             unverified.append(label)
 
     for raw, magnitude in _SHARE_CLAIM.findall(text):
-        check(_as_number(raw, magnitude), f'{raw}{magnitude or ""}股')
+        check(_as_number(raw, magnitude), f'{raw}{magnitude or ""}股',
+              _rounding_tolerance(raw, magnitude))
     for cur_num, cur_mag, num_cur, mag_cur in _CURRENCY_CLAIM.findall(text):
         raw, magnitude = (cur_num, cur_mag) if cur_num else (num_cur, mag_cur)
         amount = _as_number(raw, magnitude)
         if amount is not None and abs(amount) >= MIN_CHECKED_AMOUNT:
-            check(amount, f'{raw}{magnitude or ""}')
+            check(amount, f'{raw}{magnitude or ""}',
+                  _rounding_tolerance(raw, magnitude))
+
+    def check_unit(unit, raw, at):
+        if unit == 'percent' and _is_hypothetical_percent(text, at):
+            return
+        # The unit set stays exact-per-unit on purpose: a rounding is a rounding
+        # of the SAME quantity, so widening tolerance must not also let a percent
+        # authorize a multiple. Only the width changes here.
+        if _states(known_by_unit[unit], _as_number(raw), _rounding_tolerance(raw)):
+            return
+        label = f'{raw}{_UNIT_LABELS[unit]}'
+        if label not in unverified:
+            unverified.append(label)
 
     for unit, pattern in _UNIT_CLAIMS.items():
         for match in pattern.finditer(text):
-            if unit == 'percent' and _is_hypothetical_percent(text, match.start()):
-                continue
-            raw = match.group(1)
-            value = _as_number(raw)
-            if value is None or round(abs(value), 4) in known_by_unit[unit]:
-                continue
-            label = f'{raw}{_UNIT_LABELS[unit]}'
-            if label not in unverified:
-                unverified.append(label)
+            check_unit(unit, match.group(1), match.start())
+
+    # A range carries its unit once, at the end: `_UNIT_CLAIMS['percent']` only
+    # ever saw the upper bound, so the lower bound of "0.2~0.5%" was never
+    # checked against anything. That blind spot was invisible while the upper
+    # bound alone kept these findings alive — the shipped "+0.3~-0.4%" defect
+    # this gate exists for is a fabricated LOWER bound as much as an upper one.
+    for lo, hi in _RANGE.findall(text):
+        for raw in (lo, hi):
+            check_unit('percent', raw, text.find(raw))
 
     impossible = [
         f'{lo}~{hi}%' for lo, hi in _RANGE.findall(text)
@@ -298,6 +350,30 @@ def advisory_prefix(advisories, shown=2):
     body = '; '.join(a.replace(ADVISORY_MARK, '').strip() for a in advisories[:shown])
     more = f'；另 {len(advisories) - shown} 条' if len(advisories) > shown else ''
     return f'ℹ️ 数字校验（不影响投递）：{body}{more}\n\n'
+
+
+def product_status(status, escalating):
+    """What the run PRODUCED, as opposed to what the checker noticed.
+
+    `categorize_issues` answers "is there anything worth saying" and so returns
+    `warn` for an advisory-only run. That is right for the checker and wrong for
+    every reader downstream: `split_advisory` already leaves the banner empty,
+    so the delivered report is clean and says so with a `ℹ️ 不影响投递` line —
+    while the commit subject read `(validation warnings)` and the ledger stage
+    read `warning`. The same fact, told two ways, depending on where you looked.
+
+    #768 fixed exactly this for the ledger's `final_product` column and stopped
+    there; measured over the three days after it, 26 of 64 slots were filed as
+    degraded generation and **every one had `escalating_count == 0`**. This is
+    the same correction applied at the two remaining readers, from one place so
+    they cannot drift apart again.
+
+    `fail` is never softened: it is only reachable with a critical or with more
+    escalating issues than `warn_max`, both of which mean escalating is present.
+    """
+    if status == 'warn' and not escalating:
+        return 'pass'
+    return status
 
 
 def categorize_issues(issues, critical_substrings, warn_max=2, extra_critical=None):

--- a/tests/test_dashboard_tab_lifecycle.py
+++ b/tests/test_dashboard_tab_lifecycle.py
@@ -15,11 +15,43 @@ def _sidecar_keys() -> set[str]:
     return set(re.findall(r"([a-z][a-z0-9_]+)\s*:", block))
 
 
-def test_every_mapped_sidecar_has_a_valid_seed_before_browser_fetches_it():
-    """A new optional producer must not ship a first-party 404 window."""
+def _data_plane_outputs() -> set[str]:
+    """The artifacts the publisher puts on the `data-plane` branch (#314).
+
+    Declared in the repository, so this resolves identically in a clean
+    checkout, a worktree and CI.
+    """
+    config = json.loads(
+        (ROOT / "config" / "dashboard-outputs.json").read_text(encoding="utf-8"))
+    return set(config["outputs"])
+
+
+def test_every_mapped_sidecar_has_a_producer_before_browser_fetches_it():
+    """A new optional producer must not ship a first-party 404 window.
+
+    Two publication routes reach the browser and the test has to know both, or
+    it measures the machine instead of the contract. A sidecar either ships a
+    schema-valid seed in the repository, or it is one of the build outputs #314
+    took OUT of the repository and onto the `data-plane` branch — those are
+    gitignored by design, so requiring a checked-in file made this assertion
+    pass only where a dashboard build had already run. It failed in every clean
+    worktree and passed in CI purely because an earlier test wrote the file,
+    which is the worst shape a gate can have: green by side effect.
+
+    Asserted against the tracked declaration instead, it is strictly stronger —
+    a sidecar mapped with neither a seed nor a declared producer is a real 404
+    and is now caught anywhere.
+    """
+    published = _data_plane_outputs()
     for key in _sidecar_keys():
-        path = ROOT / "assets" / "data" / f"{key}.json"
-        assert path.is_file(), f"{path} needs a schema-valid seed before mapping"
+        relative = f"assets/data/{key}.json"
+        path = ROOT / relative
+        if relative in published:
+            continue
+        assert path.is_file(), (
+            f"{relative} is mapped in SIDECAR_TAB but has neither a seed in the "
+            f"repository nor an entry in config/dashboard-outputs.json — the "
+            f"browser would fetch a 404")
         assert isinstance(json.loads(path.read_text()), dict)
 
 

--- a/tests/test_numeric_claims.py
+++ b/tests/test_numeric_claims.py
@@ -219,3 +219,118 @@ def test_absent_market_units_stay_one_advisory(hc):
     issue = hc.check_numeric_claims("今日 +8.8%，背离 7pp，放大 3x，偏离 4σ。", CTX)
     assert len(issue) == 1
     assert all(label in issue[0] for label in ("+8.8%", "7pp", "3x", "4σ"))
+
+
+# ── Rounding is not invention (#1076) ─────────────────────────────────────────
+# Measured before the fix: over three days of live runs, 26 of 64 slots carried
+# an advisory and EVERY one of them had escalating_count == 0 — i.e. the gate
+# only ever fired on clean reports. Replaying the five reports of 2026-08-26
+# through it, four of the five findings were the model writing "+8%" where the
+# context said 8.2. A gate that cries on 40% of good reports teaches its reader
+# to skip the line, which is the failure `advisory_prefix` is documented to
+# avoid.
+
+@pytest.mark.parametrize("written, context_value", [
+    ("+8%", 8.2),        # 2026-08-26 hk-pm: 02208 +8.2%
+    ("-36%", 36.3),      # 2026-08-26 hk-open: 00100 浮亏 -36.3%
+    ("80%", 79.61),      # 2026-08-26 us-open: SPCH 单名 79.61%
+    ("-2.1σ", 2.13),     # 2026-08-26 hk-close: z=-2.13σ
+])
+def test_a_rounded_restatement_is_not_an_invented_number(hc, written, context_value):
+    ctx = {"peer_scan": {"X": {"self_pct_1d": context_value}}}
+    if written.endswith("σ"):
+        ctx = {"peer_scan": {"X": {"zscore20": context_value}}}
+    assert hc.check_numeric_claims(f"读数 {written}。", ctx) == []
+
+
+@pytest.mark.parametrize("written, context_value", [
+    ("+8%", 8.9),        # a whole-number claim admits ±0.5, not ±0.9
+    ("8.2%", 8.9),       # one decimal admits ±0.05
+    ("-2.1σ", 2.4),
+])
+def test_the_tolerance_is_not_wide_enough_to_swallow_an_invention(
+        hc, written, context_value):
+    ctx = {"peer_scan": {"X": {"self_pct_1d": context_value}}}
+    if written.endswith("σ"):
+        ctx = {"peer_scan": {"X": {"zscore20": context_value}}}
+    issue = hc.check_numeric_claims(f"读数 {written}。", ctx)
+    assert issue and "context 里没有的数字" in issue[0]
+
+
+def test_writing_more_precisely_buys_a_tighter_gate(hc):
+    """The width comes from the writing, which is the right incentive.
+
+    8.4 is inside what "8%" claims and outside what "8.4x"-precision claims —
+    so the same context answers differently depending on how precisely the
+    report chose to speak.
+    """
+    ctx = {"peer_scan": {"X": {"self_pct_1d": 8.4}}}
+    assert hc.check_numeric_claims("读数 8%。", ctx) == []
+    assert hc.check_numeric_claims("读数 8.3%。", ctx)
+
+
+def test_real_mental_arithmetic_still_reports(hc):
+    """2026-08-26 hk-close, the one true finding of the five.
+
+    The report divided 1.49 by 0.82 and wrote the quotient as "≈1.8x". Neither
+    1.8 nor anything within a rounding of it is in the context as a multiple,
+    and that is exactly what this gate is for.
+    """
+    ctx = {"raw_wechat_block": "07226 +1.49%  恒科 +0.82%"}
+    issue = hc.check_numeric_claims("杠杆放大比 ≈1.8x 正常区间。", ctx)
+    assert issue and "1.8x" in issue[0]
+
+
+def test_both_bounds_of_a_range_are_unit_checked(hc):
+    """The lower bound used to be checked against nothing at all.
+
+    `_UNIT_CLAIMS['percent']` matches the number adjacent to `%`, and a range
+    writes the unit once — so "0.2~0.5%" only ever tested 0.5. The defect this
+    gate was built for ("+0.3~-0.4%" against a context of +0.3% each) has a
+    fabricated bound on the low side too.
+    """
+    ctx = {"peer_scan": {"X": {"self_pct_1d": 0.5}}}
+    issue = hc.check_numeric_claims("同业今日在 0.2~0.5% 之间。", ctx)
+    assert issue and "0.2%" in issue[0], issue
+
+
+# ── An advisory-only run produced a clean report (#1076) ──────────────────────
+
+def test_product_status_reads_what_shipped_not_what_the_checker_noticed(hc):
+    advisory = [f"context 里没有的数字: 4pp {hc.ADVISORY_MARK}"]
+    escalating, advisories = hc.split_advisory(advisory)
+    status = hc.categorize_issues(advisory, ("严重",))
+    assert status == "warn", "the checker still notices it"
+    assert hc.product_status(status, escalating) == "pass", (
+        "but the reader downstream must see the clean report that shipped")
+
+
+def test_product_status_never_softens_a_real_finding(hc):
+    for issues, expected in (
+        ([], "pass"),
+        (["表格被改写"], "warn"),
+        (["表格被改写", f"数字 {hc.ADVISORY_MARK}"], "warn"),
+        (["严重: 数据块缺失"], "fail"),
+    ):
+        escalating, _ = hc.split_advisory(issues)
+        status = hc.categorize_issues(issues, ("严重",))
+        assert hc.product_status(status, escalating) == expected, issues
+
+
+@pytest.mark.parametrize("module_name", [
+    "clawock.harness.report_postflight",
+    "clawock.harness.intraday_postflight",
+    "clawock.harness.brief_postflight",
+])
+def test_every_postflight_reports_the_product_not_the_check(module_name):
+    """All three wrote `(validation warnings)` on clean reports (#1076).
+
+    #768 corrected the ledger's final_product column and stopped there. Reading
+    `product` instead of `status` at the stage record and the commit subject is
+    the rest of that same fix, asserted here per module so a fourth postflight
+    cannot be added with the old reading.
+    """
+    module = importlib.import_module(module_name)
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "product_status(status, escalating)" in source, (
+        f"{module_name} still files the checker's verdict as the product")


### PR DESCRIPTION
fix: 取整不是发明数字——advisory 40% 误报清掉；escalating=0 不再打 (validation warnings) (#1076)

## 一、advisory 基本在报取整

近 3 天 ledger 64 档里 26 档记 `llm: warning`，**这 26 档的 `escalating_count` 全是 0**，
一条不漏。把 2026-08-26 五份报告的 prose + context 取回来重跑 `validate()`，五条发现里
四条是模型把读数取整：

| 档 | 被标的数字 | context 真值 |
|---|---|---|
| us-open | `80%` | 79.61 / 80.08 |
| hk-close | `-2.1σ` | 2.13 |
| hk-pm | `-3% / +8% / -2σ` | 2.8 / 3.1、8.2、2.07 |
| hk-open | `-36%` | 36.3 |

`check_numeric_claims` 走 `round(abs(v),4) in set` 精确匹配，写 `+8%` 而 context 是 8.2
就算「context 里没有的数字」。`advisory_prefix` 的 docstring 写着这行**必须读起来像信息
不像告警**，否则下一个看到的人就开始把它当失败——一个在 40% 的干净报告上响的闸，训练出
来的正是「那行不用看」。

**修法**：容差 = 模型实际写出来的**最后一位的半个单位**。写 `8%` 认 [7.5, 8.5]，写
`8.2%` 认 [8.15, 8.25]，写得越精确闸越紧——宽度由写法推出，不是配置项。带量级后缀
（万/亿）时容差同比例放大。**跨单位仍然严格**：取整是同一个量的取整，不能让一个
percent 去授权一个 multiple。

结果（同五份报告重放）：四条误报清零，**真心算的那条仍然报**——hk-close 的 `1.8x` 是
模型拿 1.49÷0.82 自己除出来的，context 里没有任何 multiple 接近它。

## 二、顺带补一个先前就存在的盲区

`_UNIT_CLAIMS['percent']` 匹配的是**紧挨 `%`** 的那个数，而区间只在末尾写一次单位——
所以 `0.2~0.5%` 里的 `0.2` **从来没有被任何单位集校验过**。这一点原来被上界掩盖着：
`test_a_well_formed_range_still_requires_context_provenance` 一直是靠 `0.5` 绿的，而
`0.5` 恰恰是 0.52 的取整（恒科 ▲0.52%）——换句话说那条测试绿的理由本身就是本 PR 要
消掉的误报。本 gate 存在的原因（shipped 的 `+0.3~-0.4%`）低侧同样是编的。区间两端现在
都过单位校验。

## 三、escalating=0 不再被当成降级产品

新增 `validation.product_status(status, escalating)`：`warn` 且无 escalating ⇒ `pass`。
`fail` 永不被软化（它只能由 critical 或超过 `warn_max` 的 escalating 到达）。

#768 对 ledger 的 `final_product` 列做过这个修正就停了，剩下两个读者没跟上：commit
subject 和 stage 状态。于是同一个事实两种说法——用户收到干净报告 + 一行「ℹ️ 不影响
投递」，git log 里却是一片 `(validation warnings)`，ledger 里是 `warning`。三个
postflight（report / intraday / brief）现在都读 `product`，判据在一处、不会再各自漂。

## 四、修一条只在跑过 build 的机器上绿的测试

`test_every_mapped_sidecar_has_a_valid_seed_before_browser_fetches_it` 要求每个映射的
sidecar 在 checkout 里有种子文件，但 `shadow_portfolio.json` / `decision_audit.json` 是
#314 移出仓库、走 data-plane 分支发布的产物，被 gitignore。**它在任何干净 worktree 里
都失败，在 CI 里绿是因为更早的测试顺手写出了那个文件**——绿得靠副作用，是闸能有的最差
形状。改成认两条发布路径：仓库种子，或 `config/dashboard-outputs.json` 里声明的
data-plane 产物。这样反而更强：既无种子又无声明的映射是真 404，现在到哪都抓得到。
（实测 8 个映射里 6 个走种子、2 个走 data-plane，断言非空转。）

## 验证

`tests/test_numeric_claims.py` 新增 15 条，两个方向都钉：
- 四条实测取整（8.2→`+8%`、36.3→`-36%`、79.61→`80%`、2.13→`-2.1σ`）必须放行
- 容差不许宽到吃掉发明：`+8%` vs 8.9 仍报、`8.2%` vs 8.9 仍报
- 写得更精确闸更紧：同一个 context 下 `8%` 过、`8.3%` 报
- 真心算 `1.8x` 必须报
- 区间下界必须被校验
- `product_status` 两条（advisory-only ⇒ pass；四种输入不许软化真发现）
- 三个 postflight 各一条，逐模块钉住读的是 product 不是 status

全量套件 2715 passed / 5 skipped / 4 xfailed，1 failed =
`test_safe_push_refuses_the_money_file_when_the_checker_is_missing`，与本 PR 无关且
另有单独修复（money_checker 的 checkout 探针会被本机 editable 安装满足）。

Closes #1076

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

