### PR TITLE
fix: 钱闸的 checkout 探针会被本机 editable 安装满足，报的是机器不是契约

### DIFF
--- a/ops/publish/money_checker.sh
+++ b/ops/publish/money_checker.sh
@@ -28,7 +28,17 @@ money_checker_kind() {
     echo installed
     return 0
   fi
-  if [ -n "$1" ] && PYTHONPATH="$1/src" \
+  # Ask the filesystem BEFORE the interpreter. An editable install writes a
+  # .pth into site-packages, so `import clawock.cli` succeeds from anywhere on
+  # a developer box regardless of PYTHONPATH — this branch answered "checkout"
+  # for a root with no `src/` at all, and then verified the book with whatever
+  # copy of the package happened to be importable rather than the one being
+  # published. Same class as `clawock --version` on an editable install: the
+  # answer is about the host, not about the code under test. It is also why the
+  # gate's own contract test passed in CI (nothing installed) and failed on the
+  # live box (everything installed) — a gate that reports on the machine is not
+  # reporting on the contract.
+  if [ -n "$1" ] && [ -f "$1/src/clawock/cli.py" ] && PYTHONPATH="$1/src" \
        python3 -c 'import clawock.cli' >/dev/null 2>&1; then
     echo checkout
     return 0

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -364,3 +364,48 @@ def test_safe_push_runs_the_money_check_when_the_money_file_moves(tmp_path):
     assert result.returncode == 4
     assert marker.exists(), "the package integrity command was not invoked"
     assert "does not reconcile" in result.stdout
+
+
+def test_the_checkout_fallback_must_come_from_the_checkout(tmp_path):
+    """"Importable somewhere" is not "provided by the root being published".
+
+    `money_checker.sh` documents the fallback as running the package *out of
+    the checkout*. It probed that with a bare `import clawock.cli` under a
+    PYTHONPATH — but an editable install puts a .pth in site-packages, so the
+    import succeeds anywhere on a machine that has clawock installed, and the
+    probe answered "checkout" for a root with no `src/` in it. The gate then
+    verified the book with whatever copy of the package was importable instead
+    of the one being published.
+
+    That also made the gate's own contract test report on the machine rather
+    than on the contract: green in CI (nothing installed), red on the live box
+    (editable install). Asserted from both sides here, so neither environment
+    can make it pass for the wrong reason.
+    """
+    probe = (
+        f'set -e\n'
+        f'. "{ROOT}/ops/publish/money_checker.sh"\n'
+        f'money_checker_kind "$1" || echo unresolved\n'
+    )
+
+    def kind(root):
+        done = subprocess.run(
+            ["/bin/bash", "-c", probe, "bash", str(root)],
+            capture_output=True, text=True,
+            # `clawock` off PATH so the "installed" branch cannot answer first;
+            # os.environ is inherited on purpose, because an inherited editable
+            # install is exactly the condition that broke this.
+            env={**os.environ, "PATH": "/usr/bin:/bin"},
+        )
+        return done.stdout.strip()
+
+    bare = tmp_path / "no-src"
+    bare.mkdir()
+    assert kind(bare) == "unresolved", (
+        "a root that ships no src/ must not resolve as 'checkout', however "
+        "importable the package happens to be on this host")
+
+    with_src = tmp_path / "with-src"
+    with_src.mkdir()
+    (with_src / "src").symlink_to(ROOT / "src")
+    assert kind(with_src) == "checkout"


### PR DESCRIPTION
fix: 钱闸的 checkout 探针会被本机 editable 安装满足，报的是机器不是契约

## 现象

`test_safe_push_refuses_the_money_file_when_the_checker_is_missing` 在 CI 绿、在 live
box 红，红了至少从 #1072 起就被当成「本机没有 SSH 出口，与本 PR 无关」带过了三次。
真因不是 SSH：**闸根本没触发**，脚本一路走到了 `git push`（所以看到的是 3 次 push
retry 失败），而测试等的是 rc=4。

## 根因

`ops/publish/money_checker.sh::money_checker_kind` 的 fallback 分支：

```bash
if [ -n "$1" ] && PYTHONPATH="$1/src" python3 -c 'import clawock.cli' ...
```

editable 安装往 site-packages 写 `.pth`，于是 `import clawock.cli` 在装了 clawock 的
机器上**任何地方都成功，与 PYTHONPATH 无关**。测试给的 root 是个连 `src/` 都没有的
临时仓库，探针却回答 `checkout`。

两个后果，后者更重要：

1. 测试变成「测这台机器装没装 clawock」——CI 没装所以绿，live box 装了所以红。
2. **闸真的会用「碰巧能 import 到的那份代码」去验「正要发布的那本账」**。文件自己的
   注释写的是 "The fallback runs the same package **out of the checkout**"，实际不是。
   与 `clawock --version` 在 editable 安装下必然过时是同一类：答案是关于宿主的，
   不是关于被测代码的。

## 修法

先问文件系统再问解释器：`[ -f "$1/src/clawock/cli.py" ]` 通过了才做 import 探测。
一行判据，两个问题一起解决。

## 验证

新增 `test_the_checkout_fallback_must_come_from_the_checkout`，**两侧都断言**（无 src/
必须 unresolved；symlink 上 src/ 必须 checkout），并且**故意继承 os.environ**——继承
着的 editable 安装正是弄坏它的那个条件，不继承就等于把 bug 重新藏起来。

`tests/test_pr_publish_gate_contract.py` 本机 14 passed（此前 13 passed / 1 failed）。

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

