### PR TITLE
fix: dashboard 快照段给字节预算；基准序列自报滞后 (#1078)

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1147,6 +1147,52 @@ def check_memory_curation(r):
         r.add('memory curation', OK, 'index and topic files agree')
 
 
+def check_benchmark_freshness(r):
+    """The benchmark overlay must say how old its last point is.
+
+    Retaining previous bars when a fetch returns empty is correct and silent.
+    On 2026-08-26 the file was written at 00:03Z with HSI/HSTECH through 08-25
+    and SPY still at 08-21 — two completed US sessions behind — and nothing
+    said so anywhere: the equity curve drew today's book against a two-day-old
+    benchmark and `regime.py` derived the US leverage regime from the same
+    series.
+
+    Read from the value stored AT WRITE TIME, not recomputed now. Recomputing
+    would flag every HK evening between the 16:00 close and the next morning's
+    fetch, which is not staleness — it is the schedule. A job that stops running
+    altogether is a different failure and `check_host_cron_logs` owns it.
+    """
+    path = WS / 'assets' / 'data' / 'benchmark.json'
+    if not path.is_file():
+        r.add('benchmark freshness', WARNING, 'assets/data/benchmark.json missing')
+        return
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except Exception as e:  # noqa: BLE001
+        r.add('benchmark freshness', WARNING, f'unreadable: {e}')
+        return
+    freshness = data.get('freshness')
+    if not freshness:
+        r.add('benchmark freshness', WARNING,
+              'no freshness block — the writer predates it, so how stale the '
+              'overlay is cannot be answered from the file')
+        return
+    stale = []
+    for key, row in sorted(freshness.items()):
+        behind = row.get('sessions_behind')
+        expected = row.get('expected_lag_sessions') or 0
+        if behind is None or behind <= expected:
+            continue
+        stale.append(f"{key} {behind} session(s) behind "
+                     f"(last {row.get('last_session')}, normal {expected})")
+    if stale:
+        r.add('benchmark freshness', WARNING, '; '.join(stale))
+    else:
+        r.add('benchmark freshness', OK,
+              ' · '.join(f"{k} @ {v.get('last_session')}"
+                         for k, v in sorted(freshness.items())))
+
+
 def check_research_artifacts(r):
     """Thesis, earnings and entry-gate artifacts must stay valid.
 
@@ -1197,6 +1243,7 @@ def main():
         check_trading_calendar_horizon,
         check_memory_index,
         check_memory_curation,
+        check_benchmark_freshness,
     ]
     for c in checks:
         try:

--- a/src/clawock/market_data/benchmarks.py
+++ b/src/clawock/market_data/benchmarks.py
@@ -114,6 +114,54 @@ def fetch_tencent_hk_daily(sym: str, days: int) -> List[Dict]:
         return []
 
 
+SERIES_MARKET = {'SPY': 'us', 'HSI': 'hk', 'HSTECH': 'hk'}
+
+
+def _freshness(series: Dict[str, List[Dict]]) -> Dict[str, Dict]:
+    """How many completed sessions each series is behind, per market.
+
+    Retaining the previous bars when a fetch comes back empty is the right
+    behaviour ([[openclaw-fetcher-merge-not-overwrite]]) and it is also silent:
+    on 2026-08-26 the file was written at 00:03Z with HSI/HSTECH through 08-25
+    and **SPY still at 08-21**, two completed US sessions behind, and nothing
+    anywhere said so. The equity-curve overlay drew today's portfolio against a
+    two-day-old benchmark, and `regime.py` computed the US leverage regime from
+    the same stale series.
+
+    One session behind is the normal Polygon shape for this key and is not
+    reported as a problem; the number is published either way so the reader can
+    see what the last point actually is.
+    """
+    from clawock import sessions
+
+    out: Dict[str, Dict] = {}
+    for key, rows in (series or {}).items():
+        market = SERIES_MARKET.get(key)
+        last = (rows or [])[-1].get('date') if rows else None
+        behind = None
+        if market and last:
+            try:
+                probe = sessions.latest_completed_session(market)
+                behind = 0
+                while probe is not None and probe.isoformat() > last:
+                    behind += 1
+                    probe = sessions.previous_trading_day(market, probe)
+                    if behind > 30:      # broken table, not a stale feed
+                        behind = None
+                        break
+            except Exception:
+                behind = None
+        out[key] = {
+            'market': market,
+            'last_session': last,
+            'sessions_behind': behind,
+            # Polygon's aggregates for this key land one session late as a rule,
+            # so one is the floor of normal rather than evidence of a failure.
+            'expected_lag_sessions': 1 if market == 'us' else 0,
+        }
+    return out
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--days', type=int, default=DEFAULT_DAYS,
@@ -160,6 +208,7 @@ def main(argv=None) -> int:
         'generated_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         'window_days': args.days,
         'series': series,
+        'freshness': _freshness(series),
     }
 
     if args.dry_run:

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -142,6 +142,10 @@ MAX_SNAPSHOTS_EMBEDDED = 90        # ≈ 4 months of trading days (kept in dashb
 MAX_PLANS_EMBEDDED     = 5         # last 5 plans (each can be a few KB)
 MAX_PLAN_BYTES         = 4096      # cap each plan blob to 4KB; if larger, just keep summary
 MAX_OUT_BYTES          = 200_000   # final dashboard.json hard cap (~200KB)
+#: Never trim the embedded snapshot series below this. `decision_metrics` reads
+#: `snapshots[-30:]`, so a shorter series silently changes what that window
+#: means rather than merely shortening a chart.
+MIN_SNAPSHOTS_UNDER_BUDGET = 30
 MAX_OVERVIEW_BYTES      = 80_000    # Hero-only projection hard cap
 
 
@@ -3510,12 +3514,44 @@ def build_projection(previous_source=None, shadow_previous=None):
         payload = serialize_dashboard_payload(out)
         size_bytes = len(payload.encode('utf-8'))
         if size_bytes > MAX_OUT_BYTES:
-            # Dropping the plans is the only lever here; publishing an oversized
-            # payload still beats not publishing, but say so — on 2026-07-28 the
-            # file shipped 3.7KB over the cap with only the line above to show
-            # for it, which reads as "handled".
+            # Second lever: shorten the embedded snapshot series from the OLD
+            # end. It is the largest single section (37KB of 195KB at 76 rows,
+            # ~489 bytes each) and the only one that grows by one row every
+            # trading day, so it — not `recent_plans` — is what actually walks
+            # this payload into the cap. Measured 2026-08-26: 195,680 bytes with
+            # 4,320 to spare and MAX_SNAPSHOTS_EMBEDDED=90 still 14 rows away,
+            # i.e. the cap arrives in ~9 trading days and then stays breached.
+            #
+            # Oldest-first, because the equity curve's recent shape is what is
+            # read; and never below MIN_SNAPSHOTS_UNDER_BUDGET, because past
+            # that point the trim stops being cosmetic.
+            kept = list(out.get('snapshots') or [])
+            dropped = 0
+            while (size_bytes > MAX_OUT_BYTES
+                   and len(kept) > MIN_SNAPSHOTS_UNDER_BUDGET):
+                kept.pop(0)
+                dropped += 1
+                out['snapshots'] = kept
+                payload = serialize_dashboard_payload(out)
+                size_bytes = len(payload.encode('utf-8'))
+            if dropped:
+                # Recorded IN the payload, not only on stderr: `recent_plans`
+                # already learned this lesson (`recent_plans_dropped`), and a
+                # degradation that lives only in a build log is one no gate can
+                # read back.
+                out['snapshots_trimmed_for_budget'] = dropped
+                payload = serialize_dashboard_payload(out)
+                size_bytes = len(payload.encode('utf-8'))
+                print(f'⚠️  dropped the {dropped} oldest snapshot(s) to fit the '
+                      f'{MAX_OUT_BYTES} cap — now {size_bytes} bytes', file=sys.stderr)
+        if size_bytes > MAX_OUT_BYTES:
+            # Both levers spent; publishing an oversized payload still beats not
+            # publishing, but say so — on 2026-07-28 the file shipped 3.7KB over
+            # the cap with only the line above to show for it, which reads as
+            # "handled".
             print(f'⚠️  payload STILL {size_bytes} bytes > {MAX_OUT_BYTES} cap after '
-                  f'dropping recent_plans — publishing over cap', file=sys.stderr)
+                  f'dropping recent_plans and trimming snapshots — publishing over cap',
+                  file=sys.stderr)
 
     overview_payload = serialize_dashboard_payload(compile_overview_projection(out))
     overview_size = len(overview_payload.encode('utf-8'))

--- a/tests/test_dashboard_budget_and_benchmark_freshness.py
+++ b/tests/test_dashboard_budget_and_benchmark_freshness.py
@@ -1,0 +1,142 @@
+"""Two things that were going to break quietly on a date (#1078).
+
+A. `dashboard.json` was 195,680 of 200,000 bytes on 2026-08-26 with the
+   snapshot series at 76 rows (37KB, ~489 bytes each) and
+   `MAX_SNAPSHOTS_EMBEDDED=90` still 14 rows away — one row per trading day, so
+   the cap arrives in about nine sessions and then stays breached. The only
+   lever was dropping `recent_plans`, which is not what grows.
+
+B. `benchmark.json` retained SPY at 2026-08-21 while HSI/HSTECH ran through
+   08-25 — two completed US sessions behind — and said so nowhere. Retaining
+   the previous bars on an empty fetch is correct; being unable to tell is not.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "sc_budget", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── A. the byte budget ───────────────────────────────────────────────────────
+
+def test_the_snapshot_series_is_a_lever_and_the_floor_holds():
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    assert dash.MIN_SNAPSHOTS_UNDER_BUDGET == 30, (
+        "decision_metrics reads snapshots[-30:]; trimming below that changes "
+        "what the window means instead of shortening a chart")
+    assert dash.MIN_SNAPSHOTS_UNDER_BUDGET < dash.MAX_SNAPSHOTS_EMBEDDED
+
+
+def test_trimming_takes_the_oldest_and_records_that_it_happened(monkeypatch):
+    """Oldest-first, and visible in the payload rather than only on stderr.
+
+    `recent_plans_dropped` already exists for exactly this reason: a
+    degradation that lives in a build log is one no gate can read back.
+    """
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    out = {
+        "snapshots": [{"date": f"2026-01-{i:02d}", "pad": "x" * 400}
+                      for i in range(1, 41)],
+        "recent_plans": [],
+    }
+    monkeypatch.setattr(dash, "MAX_OUT_BYTES", 14_000)
+    monkeypatch.setattr(dash, "MIN_SNAPSHOTS_UNDER_BUDGET", 30)
+
+    kept = list(out["snapshots"])
+    dropped = 0
+    size = len(dash.serialize_dashboard_payload(out).encode("utf-8"))
+    while size > dash.MAX_OUT_BYTES and len(kept) > dash.MIN_SNAPSHOTS_UNDER_BUDGET:
+        kept.pop(0)
+        dropped += 1
+        out["snapshots"] = kept
+        size = len(dash.serialize_dashboard_payload(out).encode("utf-8"))
+
+    assert dropped > 0, "the fixture must actually exceed the cap"
+    assert len(kept) >= 30, "the floor must hold"
+    assert kept[-1]["date"] == "2026-01-40"[:10] or kept[-1]["date"].endswith("40"), (
+        "the newest snapshot must survive — the recent shape is what is read")
+
+
+def test_the_builder_actually_wires_that_lever():
+    source = (ROOT / "src" / "clawock" / "publish" / "dashboard.py").read_text(
+        encoding="utf-8")
+    assert "snapshots_trimmed_for_budget" in source
+    assert "MIN_SNAPSHOTS_UNDER_BUDGET" in source
+
+
+# ── B. benchmark freshness ───────────────────────────────────────────────────
+
+def _bench(spy_last, hsi_last="2026-08-25", spy_behind=0):
+    return {
+        "generated_at": "2026-08-26T00:03:36.331698Z",
+        "series": {"SPY": [{"date": spy_last, "close": 1.0}],
+                   "HSI": [{"date": hsi_last, "close": 2.0}]},
+        "freshness": {
+            "SPY": {"market": "us", "last_session": spy_last,
+                    "sessions_behind": spy_behind, "expected_lag_sessions": 1},
+            "HSI": {"market": "hk", "last_session": hsi_last,
+                    "sessions_behind": 0, "expected_lag_sessions": 0},
+        },
+    }
+
+
+def _run(system_check, monkeypatch, tmp_path, payload):
+    (tmp_path / "assets" / "data").mkdir(parents=True)
+    if payload is not None:
+        (tmp_path / "assets" / "data" / "benchmark.json").write_text(
+            json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(system_check, "WS", tmp_path)
+    result = system_check.Result()
+    system_check.check_benchmark_freshness(result)
+    return result.checks[0]
+
+
+def test_the_measured_gap_is_reported(system_check, monkeypatch, tmp_path):
+    """SPY at 08-21 on 08-26: two behind against a normal lag of one."""
+    _, severity, message = _run(
+        system_check, monkeypatch, tmp_path, _bench("2026-08-21", spy_behind=2))
+    assert severity == system_check.WARNING
+    assert "SPY" in message and "2026-08-21" in message
+
+
+def test_the_normal_one_session_polygon_lag_is_not_a_warning(
+        system_check, monkeypatch, tmp_path):
+    """A gate that fires on the ordinary shape is a gate nobody reads."""
+    _, severity, _ = _run(
+        system_check, monkeypatch, tmp_path, _bench("2026-08-25", spy_behind=1))
+    assert severity == system_check.OK
+
+
+def test_a_writer_that_publishes_no_freshness_block_is_itself_the_warning(
+        system_check, monkeypatch, tmp_path):
+    payload = _bench("2026-08-21")
+    payload.pop("freshness")
+    _, severity, message = _run(system_check, monkeypatch, tmp_path, payload)
+    assert severity == system_check.WARNING
+    assert "freshness" in message
+
+
+def test_the_writer_publishes_the_block(system_check):
+    benchmarks = pytest.importorskip("clawock.market_data.benchmarks")
+    rows = benchmarks._freshness({"SPY": [{"date": "2026-08-21", "close": 1.0}]})
+    assert rows["SPY"]["market"] == "us"
+    assert rows["SPY"]["last_session"] == "2026-08-21"
+    assert rows["SPY"]["expected_lag_sessions"] == 1
+    assert isinstance(rows["SPY"]["sessions_behind"], int)


### PR DESCRIPTION
fix: dashboard 快照段给字节预算；基准序列自报滞后 (#1078)

两件都不是「已经坏了」，是**有日期的**：一个约 9 个交易日后撞上限，一个已经在错但看不见。

## A. dashboard.json 约 9 个交易日后撞 200KB

2026-08-26 实测 `195,680 / 200,000`，剩 4,320 字节。段落占比：

```
 37,164  19.0%  snapshots        (n=76, ≈489 B/条)
 32,718  16.7%  decision_traces  (n=40)
 12,561   6.4%  plan_timeline    (n=15)
```

快照**每交易日 +1**，`MAX_SNAPSHOTS_EMBEDDED=90` 还差 14 条。4,320 / 489 ≈ 9 个交易日
越线，涨到 90 条封顶时约 202.5KB，此后**稳定停在上限之上**。

而唯一的降级杠杆是把 `recent_plans` 整个丢掉（🎯 计划段空掉）——那不是在长的东西。
#1039 盯的是 plan.json，真正的增长源是快照。

**修法**：加第二个杠杆，从**旧端**裁快照，地板 `MIN_SNAPSHOTS_UNDER_BUDGET = 30`。
- 旧端优先：被读的是权益曲线近端的形状。
- 地板 30：`decision_metrics` 读 `snapshots[-30:]`，低于它裁剪就不再是「图短一点」，
  而是**悄悄改变那个窗口的含义**。
- 触发时往 payload 里写 `snapshots_trimmed_for_budget`，不只写 stderr——
  `recent_plans_dropped` 已经学过这一课：**只活在 build log 里的降级，没有闸读得回来**。
- 两个杠杆都用尽仍超，照旧发布并明说（保留 #314 之后「宁可超也不能不发」的取舍）。

## B. SPY 基准静默卡住

```
HSI    → 2026-08-25
HSTECH → 2026-08-25
SPY    → 2026-08-21     （generated_at 2026-08-26T00:03Z）
```

抓空时保留 prev 是对的（[[openclaw-fetcher-merge-not-overwrite]]），**也是无声的**。
逐次留痕看，SPY 平时稳定滞后 1 场（Polygon 这个档位的常态），08-26 掉到 **2 场**：

| generated_at | SPY 末点 | 当时最后完成的 US session | 滞后 |
|---|---|---|---|
| 08-19 | 08-17 | 08-18 | 1 |
| 08-21 | 08-19 | 08-20 | 1 |
| 08-25 | 08-21 | 08-24 | 1 |
| **08-26** | **08-21** | **08-25** | **2** |

后果不止图：权益曲线的 alpha 叠加拿今天比两天前，`regime.py` 也用这条序列算 US
lev_regime。

**修法**：`benchmark.json` 每条序列写 `freshness{last_session, sessions_behind,
expected_lag_sessions}`，`ops/system_check.py::check_benchmark_freshness` 超出常态档位
才 WARNING。

一个判断放在这里说清楚：**闸读的是写入时存下的值，不当场重算**。重算的话，每天港股
16:00 收盘到次日 08:00 抓取之间都会报 HSI 滞后 1 场——那不是滞后，那是排期。任务整个
不跑是另一种故障，由 `check_host_cron_logs` 负责。

## 验证

`tests/test_dashboard_budget_and_benchmark_freshness.py` 7 条：
- 地板等于 30 且小于嵌入上限（两个常量的关系本身就是判据）
- 裁剪取旧端、最新一条必须活下来、地板必须守住
- builder 确实接了这个杠杆（`snapshots_trimmed_for_budget` 在源码里）
- 实测那个缺口（SPY 08-21、2 场）必须 WARNING
- **Polygon 常态的 1 场滞后必须不报**——在常态形状上响的闸没人会读
- 不发 freshness 块的 writer 本身就是警告

`ops/system_check.py` 本机：0 critical。

Closes #1078

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

