### PR TITLE
fix: 硬止损换仓的买腿脱离择时闸；breach 有出口；研究层空转不再报 OK (#1075)

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1168,6 +1168,20 @@ def check_research_artifacts(r):
     elif result['status'] == 'warn':
         r.add('research artifacts', WARNING,
               f"{tally} valid; open work: " + '; '.join(result['warnings'][:4]))
+    elif not any(counts.values()):
+        # "Zero valid artifacts" and "no open work" are the same sentence to a
+        # validator and opposite facts to a reader. All three directories hold
+        # nothing but their READMEs, no recurring job writes them (`clawock
+        # thesis` is a manual CLI), and this check has reported OK for it every
+        # push. That silence is load-bearing: `_execution_view` blocks every add
+        # on `no_approved_setup` and `thesis_gate` never leaves
+        # "exploration_only", so a permanently empty research layer holds the
+        # entire add side shut — 0 add decisions in the 26 days to 2026-08-26,
+        # the last one 2026-07-20 (#1075).
+        r.add('research artifacts', WARNING,
+              'no research artifact has ever been produced (0 theses · 0 earnings · '
+              '0 gates) and no recurring job writes them — the add side is gated '
+              'on a layer that never fills')
     else:
         r.add('research artifacts', OK, f'{tally} valid · no open research work')
 

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -338,6 +338,21 @@ preflight 已算好,直接读 `context.risk_guardrail`:
 - **这是 risk_on HOLD 默认的唯一豁免**:证伪铁律已写明纪律性再平衡正常走;别因为 regime=risk_on 就把降杠杆/降集中也按住。牛市里恰恰要借强减杠杆,不是等回调后。
 - **降 β/降杠杆优先削杠杆 ETF**(β 的主要来源),不要去砍高信念单票的 thesis。
 - **杠杆ETF解套口径(kcn 2026-06-11 定)**:杠杆 ETF 的 breach/hard_stop 动作 = **2x→1x 同因子换仓而非清仓**(映射在 `brief_preflight.LEV_1X_SWAP`:07226→03033、PLTU→PLTR、ROBN→HOOD、MSFU→MSFT)——敞口不变、反弹一点不踏空,但停掉日内重置 decay;`context.risk_guardrail.reentry_rule` 满足(🧭转 green,标的收复 200 线)才允许 1x→2x 换回。**现货(非杠杆)套牢 kcn 方针=持有等待合法**(现货等待免费,2x 等待收费),对现货超限的最低要求是"不补仓、借反弹分批",别反复催清仓。
+- **换仓的买腿怎么写(#1075)**:2x→1x 是**一砍一买两条腿**,买腿由**风控规则**授权,不需要
+  技术 setup。目标票的 `constraints.swap_mandate` 就是那份授权(`from_ticker` / `breach_id` /
+  `max_value` / `currency`);此时它的 `allowed_actions` 会含 `add_only_on_trigger`,直接用,
+  别因为它没有 setup 就退回 hold。三条硬约束:①只能买 mandate 指名的那一只 ②金额不超
+  `max_value` ③**两条腿必须共享同一个 `transaction_group_id`**,否则 decision_audit 会把买腿
+  当成裸买、对着错的基准结算。目标票自己也在 breach 时 mandate 为 `null`——那就是不许换过去。
+- **目标已清仓的处方也要写出来**:packet 顶层 `swap_mandates` 列出全部处方,含 `target_held:false`
+  的(例:RKLX→RKLB,RKLB 6/13 已清)。它们在 `tickers` 里没有行,但**必须在本段点名**——
+  一条看不见的处方,没人能有意否决它。
+- **standing 判词**:每条 breach 的 `risk[].standing`。`decision_overdue=true` 表示它已经站了
+  ≥`threshold_days` 天而 execute / acknowledge / override **三个出口一个都没走过**。这时不要
+  再写第 N 遍同样的提醒,写成一个要求:要么执行,要么用 `risk ack` 留痕"看见了、接受它继续开着",
+  要么用 `risk override --reason` 记下**为什么决定不做**。实测 2026-08-26:三条 hard_stop 站了
+  42 天、同一条砍单发了 136 次、执行 0 次,而 `override` 字段一次没用过——账本读起来像"没人看",
+  真相是有人每天看、每天决定不做。
 - 若 `breach_count=0` → 本段写"✅ 仓位硬闸无触发",照常决策。
 - **解套/回本数字只准引用 `context.breakeven_math`**(preflight 已算好:每只浮亏持仓回本所需涨幅、2x 的横盘 decay ≈σ²/12 每月、半年窗含 drag 等效标的涨幅),禁止自己心算或编造。解读纪律见其 `note`:直线涨→2x 回本更快;横盘→2x 每月白付 decay;再跌→2x 双倍挨打——换 1x 买的是后两种情景的保护,不是回本速度,别说反。
 - **技术面判断只准引用 `context.quant_signals` 中 `status=fresh` 的行**(每只持仓的趋势/动量/RSI/zscore20/吊灯止损线/vol_target_weight,杠杆 ETF 按标的算)；`stale/missing/retired` 行只用于披露数据缺口，禁止据此形成判断，也禁止自创"看图"结论。**因子话语权由 `context.quant_signal_review` 决定**(信号每日留痕 vs T+1/T+5 前瞻收益自动对账):必须公示 `n_events/n_dates/n_tickers`;`usable=false` 或聚类 CI 跨 50% 的因子只能当背景展示不入决策；`decision_direction=reverse` 仅在反向 CI 整体低于 50% 时成立，禁止因 raw hit_rate<50% 自动反向。T+0 牌面同样只在 `sample_sufficient=true AND edge_supported=true` 时可入决策；样本够多但 Wilson CI 不支持原方向仍是 `usable=false`，不得自动反向交易。`driven_by=technical` 的整体战绩一律读取 `context.decision_metrics.by_driver.technical` 的实时计算值，禁止引用固定百分比。这是自迭代环——哪个因子可信,数据说了算,每天自动更新。

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -548,6 +548,10 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
                 "severity": row.get("severity") or "high",
                 "detail": row.get("detail"),
                 "action_text": row.get("action"),
+                # Standing-without-a-decision travels with the breach: the plan
+                # writer is the one who can turn it into an execute, an
+                # acknowledge or an override (#1075).
+                "standing": row.get("standing") or {},
                 "required_reduction": {
                     key: reduction.get(key)
                     for key in (
@@ -570,6 +574,7 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
             "severity": "critical",
             "detail": row.get("detail"),
             "action_text": row.get("action"),
+            "standing": row.get("standing") or {},
             "required_reduction": {
                 key: reduction.get(key)
                 for key in (
@@ -580,6 +585,80 @@ def _risk_map(context: dict, active: set[str]) -> dict[str, list[dict]]:
             },
         })
     return out
+
+
+def _swap_mandates(risks: dict) -> dict:
+    """Target ticker → the open breaches that require buying INTO it.
+
+    A leveraged hard stop prescribes two legs, and says so in its own words:
+    「07226 触发杠杆 ETF 硬止损 → 换仓 1x 同因子 03033（敞口保留、停 decay,
+    **规则非择时**）」. Only the sell leg was ever expressible. `_constraints`
+    gates every add on `bool(setup_ids)` — an approved technical setup — so the
+    buy leg of a RULE was made conditional on TIMING, and the plan writer said
+    so out loud on 2026-08-26: 「07226 砍完 swap 03033 路径被 packet add 限制
+    阻挡 (allowed=[hold_and_watch, watch])」.
+
+    The gate it was waiting on has never opened. `memory/theses/`,
+    `memory/entry-gates/` and `memory/earnings/` hold nothing but READMEs and no
+    recurring job writes them, so `thesis_state` is permanently "unknown" and
+    `setups` permanently empty. Measured: 07226 / RKLX / SPCH have been told to
+    cut 53 / 38 / 45 times with **zero** executions, three hard stops have been
+    open 42 days unacknowledged, and the last `add_only_on_trigger` of any kind
+    was 2026-07-20. Half a prescription is not a smaller version of the
+    prescription — it is "sell and hold the cash", which is a different call
+    that nobody made.
+    """
+    out: dict[str, list[dict]] = {}
+    for source, rows in (risks or {}).items():
+        for row in rows or []:
+            reduction = row.get("required_reduction") or {}
+            target = str(reduction.get("swap_to") or "")
+            if not target or target == str(source):
+                continue
+            out.setdefault(target, []).append({
+                "from_ticker": str(source),
+                "breach_id": row.get("breach_id"),
+                "kind": row.get("kind"),
+                "severity": row.get("severity"),
+                "detail": row.get("detail"),
+                "action_text": row.get("action_text"),
+                "max_value": reduction.get("minimum_value"),
+                "currency": reduction.get("currency"),
+            })
+    return out
+
+
+def _swap_mandate_view(mandates: list[dict], risks: list[dict]) -> dict | None:
+    """The authorisation this ticker carries as a swap TARGET, or None.
+
+    Refused when the target is itself breaching: the rule moves exposure out of
+    a broken leg into an intact one, so buying into a second breach would
+    satisfy the letter of the swap while making the book worse.
+    """
+    if not mandates or risks:
+        return None
+    ranked = sorted(
+        mandates,
+        key=lambda m: (m.get("severity") != "critical", str(m.get("from_ticker"))),
+    )
+    primary = ranked[0]
+    return {
+        "authorised_by": "risk_rule",
+        "from_ticker": primary["from_ticker"],
+        "breach_id": primary.get("breach_id"),
+        "severity": primary.get("severity"),
+        "max_value": primary.get("max_value"),
+        "currency": primary.get("currency"),
+        # The two legs are one transaction. `decision_audit`'s swap pairing
+        # already refuses to pair cross-ticker legs without it
+        # (`swap_pairing_requires_transaction_group_id`), so a buy leg filed
+        # without one is measured as a naked buy against the wrong baseline.
+        "requires_transaction_group_id": True,
+        # Named, not free: the mandate authorises buying THIS ticker because a
+        # specific breach names it, and nothing else.
+        "requires_action": "add_only_on_trigger",
+        "all_mandates": ranked,
+    }
 
 
 def _status(technical: dict, risks: list[dict]) -> dict:
@@ -599,7 +678,8 @@ def _status(technical: dict, risks: list[dict]) -> dict:
 
 
 def _constraints(shares: int, risks: list[dict], actionable_ids: list[str],
-                 technical: dict, execution: dict) -> dict:
+                 technical: dict, execution: dict,
+                 swap_mandates: list[dict] | None = None) -> dict:
     hard_stop = any(row.get("kind") == "hard_stop" for row in risks)
     direct_risk = bool(risks)
     if hard_stop:
@@ -632,6 +712,13 @@ def _constraints(shares: int, risks: list[dict], actionable_ids: list[str],
         allowed += ["add_only_on_trigger"]
         if "confirmed_breakout" in setup_ids:
             allowed += ["add_on_breakout"]
+    # The buy leg of a hard-stop swap is authorised by the RULE, not by timing:
+    # it needs no setup, no thesis and no add authority, because the exposure it
+    # buys is exposure the book already holds in a decaying wrapper. See
+    # _swap_mandates for why gating it on `setup_ids` closed it permanently.
+    swap_mandate = _swap_mandate_view(swap_mandates or [], risks)
+    if swap_mandate:
+        allowed += ["add_only_on_trigger"]
     return {
         "allowed_actions": list(dict.fromkeys(allowed)),
         "forced_action_one_of": forced,
@@ -639,6 +726,7 @@ def _constraints(shares: int, risks: list[dict], actionable_ids: list[str],
         "active_action_requires_evidence": True,
         "actionable_evidence_ids": actionable_ids,
         "technical_setup_ids": setup_ids,
+        "swap_mandate": swap_mandate,
         "max_add_shares": execution.get("max_add_shares", 0),
         "position_room_shares": execution.get("position_room_shares", 0),
         "max_add_value": execution.get("max_add_value", 0),
@@ -692,6 +780,7 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
         )
     setup_usage = context.get("technical_setup_usage") or {}
     risks = _risk_map(context, active)
+    swap_mandates = _swap_mandates(risks)
     tickers = {}
     portfolios = (context.get("portfolio") or {}).get("portfolios") or {}
     invested = {
@@ -846,7 +935,8 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             "risk": ticker_risks,
             "status": _status(technical, ticker_risks),
             "constraints": _constraints(
-                shares, ticker_risks, actionable_ids, technical, execution
+                shares, ticker_risks, actionable_ids, technical, execution,
+                swap_mandates.get(ticker) or [],
             ),
         }
 
@@ -1016,6 +1106,21 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             "candidates": candidates,
             "zero_output_visible": True,
         },
+        # Every swap a breach prescribes, INCLUDING the ones whose target the
+        # book does not currently hold. `tickers` only carries active holdings,
+        # so RKLX's mandate — 「换仓 1x 同因子 RKLB」, and RKLB was cleared on
+        # 6/13 — had nowhere to appear at all: the sell leg was forced and the
+        # buy leg was not merely blocked, it was invisible. A prescription the
+        # plan writer cannot see is one nobody can decline on purpose either.
+        "swap_mandates": [
+            {
+                "to_ticker": target,
+                "target_held": target in tickers,
+                **mandate,
+            }
+            for target, mandates in sorted(swap_mandates.items())
+            for mandate in mandates
+        ],
     }
     size = len(_compact(packet).encode("utf-8"))
     if size > MAX_PACKET_BYTES:

--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -25,6 +25,25 @@ GUARDRAIL_HISTORY = WS / "assets" / "data" / "guardrail_history.jsonl"
 SCHEMA_VERSION = 1
 
 ADD_ACTIONS = {"add_only_on_trigger", "add_on_breakout"}
+
+#: How long an open breach may stand with nobody having decided anything about
+#: it before the ledger says so out loud.
+#:
+#: The worst state a risk system can be in is not "breached" — it is "breached,
+#: told every day, never executed, and never declined either". Measured on
+#: 2026-08-26: three `hard_stop / critical` records open **42 days**, every one
+#: `acknowledgement: unacknowledged` / `override: none` / `execution: pending`,
+#: while the plan re-issued the same three cuts 53 / 38 / 45 times with zero
+#: executions. The ledger read "nobody has looked at this", when what had
+#: actually happened is that somebody looked at it every single day and chose
+#: not to act. `override` exists to record exactly that and had never been used.
+#:
+#: Ten calendar days: long enough that an ordinary execution delay (a weekend, a
+#: holiday, waiting for a level) never trips it, short enough that six weeks is
+#: unambiguous. Deliberately NOT derived from `not_followed` counts in
+#: `decisions.jsonl` — that is a different file with a different write path, and
+#: a gate that needs a cross-file join is a gate that breaks quietly.
+STANDING_DECISION_DAYS = 10
 SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
 
 
@@ -315,6 +334,7 @@ def reconcile_guardrail(
             execution["status"] = "evidence_present"
         record["age_days"] = _age_days(
             record.get("current_opened_at"), current_time)
+        record["standing"] = _standing(record)
         by_id[breach_id] = record
 
     for breach_id, record in by_id.items():
@@ -363,7 +383,35 @@ def reconcile_guardrail(
         ),
         "oldest_open_days": max(
             [r.get("age_days") or 0 for r in active] or [0]),
+        "decision_overdue_count": sum(
+            bool((r.get("standing") or {}).get("decision_overdue")) for r in active),
         "records": active,
+    }
+
+
+def _standing(record: dict) -> dict:
+    """Has this breach been standing without anybody deciding anything?
+
+    Three exits close it, and the ledger accepts any of them: execute the
+    required action, acknowledge it (seen, accepted, still open), or override it
+    (declined on purpose, with a reason and a revisit date). Only the absence of
+    all three is overdue. See STANDING_DECISION_DAYS for the measurement that
+    made this necessary.
+    """
+    age = int(record.get("age_days") or 0)
+    acknowledged = (
+        (record.get("acknowledgement") or {}).get("status") == "acknowledged")
+    overridden = (record.get("override") or {}).get("status") == "active"
+    executed = (
+        (record.get("execution") or {}).get("status") == "confirmed")
+    undecided = not (acknowledged or overridden or executed)
+    return {
+        "days_open": age,
+        "threshold_days": STANDING_DECISION_DAYS,
+        "undecided": undecided,
+        "decision_overdue": bool(undecided and age >= STANDING_DECISION_DAYS),
+        # Named so the reader does not have to infer what would clear it.
+        "closes_with": ["execute", "acknowledge", "override"],
     }
 
 

--- a/tests/test_breach_standing_decision.py
+++ b/tests/test_breach_standing_decision.py
@@ -1,0 +1,74 @@
+"""A breach nobody decided about must not read as a breach nobody saw (#1075).
+
+`memory/risk_breaches.json` on 2026-08-26: three hard stops open 42 days, all
+`unacknowledged` / `override: none` / `execution: pending`. The ledger's own
+vocabulary said "nobody has looked at this". What had actually happened is that
+somebody looked every day and chose not to act — a decision the schema has a
+field for (`override`) that had never once been used.
+"""
+from __future__ import annotations
+
+import pytest
+
+risk = pytest.importorskip("clawock.decision.risk")
+
+
+def _record(age, *, ack="unacknowledged", override="none", execution="pending"):
+    return {
+        "age_days": age,
+        "acknowledgement": {"status": ack},
+        "override": {"status": override},
+        "execution": {"status": execution},
+    }
+
+
+def test_a_breach_standing_past_the_threshold_is_overdue():
+    standing = risk._standing(_record(42))
+    assert standing["decision_overdue"] is True
+    assert standing["undecided"] is True
+    assert standing["days_open"] == 42
+    assert standing["closes_with"] == ["execute", "acknowledge", "override"]
+
+
+def test_a_fresh_breach_is_not_overdue():
+    """An ordinary execution delay — a weekend, a level not yet reached."""
+    assert risk._standing(_record(3))["decision_overdue"] is False
+
+
+@pytest.mark.parametrize("field, value", [
+    ("ack", "acknowledged"),
+    ("override", "active"),
+    ("execution", "confirmed"),
+])
+def test_any_of_the_three_exits_closes_it(field, value):
+    """All three are real decisions; the ledger must accept any of them.
+
+    An override in particular: declining on purpose, with a reason, is what was
+    actually happening for six weeks and the ledger had no way to say it.
+    """
+    standing = risk._standing(_record(90, **{field: value}))
+    assert standing["undecided"] is False
+    assert standing["decision_overdue"] is False
+
+
+def test_the_threshold_is_long_enough_not_to_fire_on_normal_delay():
+    assert risk.STANDING_DECISION_DAYS >= 5, (
+        "a gate that fires over a long weekend is a gate nobody reads")
+    assert risk._standing(_record(risk.STANDING_DECISION_DAYS - 1))[
+        "decision_overdue"] is False
+    assert risk._standing(_record(risk.STANDING_DECISION_DAYS))[
+        "decision_overdue"] is True
+
+
+def test_the_plan_writer_sees_it(monkeypatch):
+    """The flag is useless in a file nobody reads at plan time."""
+    packet = pytest.importorskip("clawock.decision.packet")
+    guardrail = {"hard_stop_watch": [{
+        "ticker": "07226", "breach_id": "risk-1", "severity": "critical",
+        "detail": "浮亏 -26%", "action": "换仓 03033",
+        "standing": {"decision_overdue": True, "days_open": 42},
+        "required_reduction": {"swap_to": "03033", "minimum_value": 1.0,
+                               "currency": "HKD"},
+    }]}
+    rows = packet._risk_map({"risk_guardrail": guardrail}, {"07226"})
+    assert rows["07226"][0]["standing"]["decision_overdue"] is True

--- a/tests/test_risk_swap_leg.py
+++ b/tests/test_risk_swap_leg.py
@@ -149,3 +149,21 @@ def test_an_empty_research_layer_is_reported_not_blessed(monkeypatch, tmp_path):
     # is genuinely fine, and must not start warning.
     _, severity, _ = run({"theses": 2, "earnings_artifacts": 0, "entry_gates": 1})
     assert severity == sc.OK
+
+
+def test_the_skill_tells_the_writer_the_mandate_exists():
+    """A capability the plan writer is never told about is an inert fix.
+
+    The skill already said 「同一份 plan 中可证明净降 factor exposure 的 2x→1x 配对
+    换仓不受阻」 while `_constraints` forbade exactly that — the instruction and
+    the packet contradicted each other and the packet won, silently, for 42
+    days. Now that they agree, the writer still has to be told which field
+    carries the authorisation and that a mandated target needs no setup.
+    """
+    from pathlib import Path
+    skill = (Path(__file__).resolve().parents[1] / "skills" / "daily-deep-brief"
+             / "SKILL.md").read_text(encoding="utf-8")
+    for token in ("swap_mandate", "transaction_group_id", "target_held",
+                  "decision_overdue"):
+        assert token in skill, (
+            f"the packet publishes {token} and nothing tells the writer to read it")

--- a/tests/test_risk_swap_leg.py
+++ b/tests/test_risk_swap_leg.py
@@ -1,0 +1,151 @@
+"""A hard stop prescribes two legs; only one of them was expressible (#1075).
+
+Measured on 2026-08-26 in `memory/risk_breaches.json`: three `hard_stop /
+critical` records open **42 days**, each `acknowledgement: unacknowledged`,
+`override: none`, `execution: pending`. Over the same period the plan re-issued
+the same three cuts 53 (07226) / 38 (RKLX) / 45 (SPCH) times with **zero**
+executions, and the last `add_only_on_trigger` of any kind was 2026-07-20.
+
+The plan writer said why, in its own 2026-08-26 rationale for 03033:
+
+    07226 砍完 swap 03033 路径被 packet add 限制阻挡
+    (allowed=[hold_and_watch, watch])
+
+The breach's own text is 「换仓 1x 同因子 03033（敞口保留、停 decay,**规则非择时**）」
+— and `_constraints` gated its buy leg on `bool(setup_ids)`, i.e. on timing.
+"""
+from __future__ import annotations
+
+import pytest
+
+packet = pytest.importorskip("clawock.decision.packet")
+
+
+def _risks(**by_ticker):
+    return {t: list(rows) for t, rows in by_ticker.items()}
+
+
+def _hard_stop(swap_to, value=1000.0, currency="HKD", severity="critical"):
+    return {
+        "kind": "hard_stop", "scope": "ticker", "breach_id": "risk-abc",
+        "type": "leveraged_hard_stop", "severity": severity,
+        "detail": "浮亏 -26% ≤ 硬止损线 -18%",
+        "action_text": f"换仓 1x 同因子 {swap_to}（敞口保留、停 decay，规则非择时）",
+        "required_reduction": {
+            "kind": "full_leveraged_position", "swap_to": swap_to,
+            "minimum_value": value, "currency": currency,
+        },
+    }
+
+
+def _constraints(risks_for_ticker, mandates, *, setups=()):
+    """The add side with no technical setup — the permanent live condition."""
+    return packet._constraints(
+        shares=0,
+        risks=list(risks_for_ticker),
+        actionable_ids=[],
+        technical={"setups": [{"setup_id": s, "remaining_tranches": 1} for s in setups]},
+        execution={"blockers": ["no_approved_setup"], "thesis_gate": "exploration_only",
+                   "max_add_shares": 0, "position_room_shares": 0},
+        swap_mandates=mandates,
+    )
+
+
+def test_the_buy_leg_of_a_rule_does_not_wait_for_a_setup():
+    mandates = packet._swap_mandates(_risks(**{"07226": [_hard_stop("03033", 20001.2)]}))
+    assert set(mandates) == {"03033"}
+
+    c = _constraints([], mandates["03033"])
+    assert "add_only_on_trigger" in c["allowed_actions"], (
+        "the swap target could not be bought, so the prescription could only "
+        "ever be executed half-way")
+    mandate = c["swap_mandate"]
+    assert mandate["from_ticker"] == "07226"
+    assert mandate["authorised_by"] == "risk_rule"
+    assert mandate["max_value"] == 20001.2
+    assert mandate["requires_transaction_group_id"] is True
+
+
+def test_without_a_mandate_the_timing_gate_still_applies():
+    """The red half: nothing here loosens the ordinary add campaign."""
+    c = _constraints([], [])
+    assert c["swap_mandate"] is None
+    assert "add_only_on_trigger" not in c["allowed_actions"]
+    assert c["allowed_actions"] == ["hold_and_watch", "watch"]
+
+
+def test_a_target_that_is_itself_breaching_is_refused():
+    """Moving exposure into a second broken leg satisfies the letter, not the rule."""
+    mandates = packet._swap_mandates(_risks(**{"07226": [_hard_stop("03033")]}))
+    c = _constraints([_hard_stop("03032")], mandates["03033"])
+    assert c["swap_mandate"] is None
+    assert "add_only_on_trigger" not in c["allowed_actions"]
+
+
+def test_the_mandate_names_one_ticker_and_only_that_ticker():
+    mandates = packet._swap_mandates(_risks(**{
+        "07226": [_hard_stop("03033")],
+        "SPCH": [_hard_stop("SPCX", 2604.0, "USD")],
+    }))
+    assert sorted(mandates) == ["03033", "SPCX"]
+    assert mandates["03033"][0]["from_ticker"] == "07226"
+    assert mandates["SPCX"][0]["from_ticker"] == "SPCH"
+    # An unrelated holding gets nothing.
+    assert _constraints([], mandates.get("00100") or [])["swap_mandate"] is None
+
+
+def test_a_self_referential_swap_is_ignored():
+    assert packet._swap_mandates(_risks(**{"07226": [_hard_stop("07226")]})) == {}
+
+
+def test_the_critical_mandate_wins_when_a_target_carries_several():
+    mandates = packet._swap_mandates(_risks(**{
+        "A": [_hard_stop("T", 1.0, severity="high")],
+        "B": [_hard_stop("T", 2.0, severity="critical")],
+    }))
+    view = _constraints([], mandates["T"])["swap_mandate"]
+    assert view["severity"] == "critical" and view["from_ticker"] == "B"
+    assert len(view["all_mandates"]) == 2, "the others must stay visible"
+
+
+# ── The layer the timing gate waits on has never filled (#1075) ──────────────
+
+def test_an_empty_research_layer_is_reported_not_blessed(monkeypatch, tmp_path):
+    """"0 valid" and "no open work" are one sentence to a validator and
+    opposite facts to a reader.
+
+    `memory/theses/`, `memory/entry-gates/` and `memory/earnings/` hold nothing
+    but READMEs; `clawock thesis` is a manual CLI and no cron writes them. The
+    gate said OK on every push while `_execution_view` blocked every add on
+    `no_approved_setup` — the add side held shut by a layer that never fills.
+    """
+    import importlib.util, sys
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[1]
+    for path in (root, root / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "sc_research", root / "ops" / "system_check.py")
+    sc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sc)
+
+    def result_with(counts, status="pass"):
+        return {"status": status, "errors": [], "warnings": [], "counts": counts}
+
+    def run(counts, status="pass"):
+        import clawock.evidence.research_surface as rs
+        monkeypatch.setattr(rs, "check", lambda: result_with(counts, status))
+        r = sc.Result()
+        sc.check_research_artifacts(r)
+        return r.checks[0]
+
+    _, severity, message = run(
+        {"theses": 0, "earnings_artifacts": 0, "entry_gates": 0})
+    assert severity == sc.WARNING, "an empty layer read as 'no open research work'"
+    assert "never" in message
+
+    # Green half: a layer that HAS produced something and has nothing pending
+    # is genuinely fine, and must not start warning.
+    _, severity, _ = run({"theses": 2, "earnings_artifacts": 0, "entry_gates": 1})
+    assert severity == sc.OK


### PR DESCRIPTION
fix: 硬止损换仓的买腿脱离择时闸；breach 有出口；研究层空转不再报 OK (#1075)

## 现象：同一条砍单发了 136 次，执行 0 次

| 标的 | 累计 `cut` | followed |
|---|---|---|
| 07226 | 53 | 0 |
| RKLX | 38 | 0 |
| SPCH | 45 | 0 |

三条 `hard_stop / critical` 开了 **42 天**（`first_seen_at: 2026-07-15`），全部
`acknowledgement: unacknowledged` / `override: none` / `execution: pending`。

## 真因（模型自己写出来了）

2026-08-26 的 03033 rationale：

> 07226 砍完 swap 03033 路径被 packet add 限制阻挡 (allowed=[hold_and_watch, watch])

breach 的处方是**一砍一买**：「07226 触发杠杆 ETF 硬止损 → 换仓 1x 同因子 03033
（敞口保留、停 decay，**规则非择时**）」。而 `_constraints` 的 `can_add` 要
`bool(setup_ids)` —— **把规则的买腿挂在了择时闸上**。

**半张处方比没有处方更糟**：只能表达「砍」不能表达「买回」，执行出来是「砍完持币」，
那是另一个没人做过的决定。

## 再往下一层：那个择时闸从来没有开过

```
memory/theses/      → 只有 README.md
memory/entry-gates/ → 只有 README.md
memory/earnings/    → 只有 README.md
```

`clawock thesis` 是手工 CLI，`ops/host/` 与 crontab 全扫过，**没有任何 recurring path
写它们**。所以 `thesis_state` 恒 `unknown` ⇒ `thesis_gate` 恒 `exploration_only`，
`setups` 恒空 ⇒ `no_approved_setup` 恒亮。8 月至今 166 条决策 **0 条 add**，最后一条
`add_only_on_trigger`（strategy=risk_rebalance、标的正是换仓目标 03033）停在 **07-20**。

而 `check_research_artifacts` 报的是 **OK**：`0 theses · 0 earnings · 0 gates valid ·
no open research work`。**「0 条有效」和「没有待办」对校验器是同一句话，对读者是相反的
事实。**

## 修法

### 1. 买腿由规则授权，不由择时授权

`_swap_mandates(risks)` 把每条 breach 的 `required_reduction.swap_to` 反向索引成
「目标标的 → 授权它的那些 breach」；`_swap_mandate_view` 决定这份授权是否成立。
成立时 `allowed_actions` 加 `add_only_on_trigger`（**复用既有动作词，不发明新词**——
ledger / plans / risk / shadow 四个下游已经认它），并在 constraints 里挂
`swap_mandate{from_ticker, breach_id, severity, max_value, currency,
requires_transaction_group_id}`。

约束仍在，而且写死在授权里：只能换到 `swap_to` 那一只；金额不超过被砍腿的市值；
两腿必须共享 `transaction_group_id`（`decision_audit` 的 swap 配对本来就要求它，
缺了会把买腿当成裸买对错基准）。**目标自己也在 breach 时拒绝授权**——把敞口挪进第二条
坏腿满足了换仓的字面，账本反而更差。

实测（今天真实 context）：SPCX 拿到 SPCH 的授权（$2,604），03033 拿到 07226 的授权
（HK$20,001），其余持仓 `allowed_actions` 一字未变。

### 2. 目标不在 book 里的处方也要看得见

`tickers` 只含活跃持仓，而 RKLX 的目标 RKLB 已于 6/13 清仓 ⇒ 它的处方**连出现的地方
都没有**：卖腿是 forced，买腿不是被挡，是不可见。新增包级 `swap_mandates` 面，
带 `target_held`，三条处方现在全部在册。**看不见的处方，没人能有意否决。**

### 3. breach 要有出口

`risk_breaches` 每条加 `standing{days_open, undecided, decision_overdue, closes_with}`。
`STANDING_DECISION_DAYS = 10`：超期且 execute / acknowledge / override **三个出口一个
没走过**才算 overdue。

**最坏的状态不是「breach」，是「每天喊、没人做、也没人记为什么不做」。** 账本原来的
措辞是「没人看过这条」，而实际发生的是有人每天看、每天决定不做——`override` 字段就是
为记录这件事设计的，六周里一次没用过。

阈值用 age 不用 `decisions.jsonl` 的 `not_followed` 计数：那是另一个文件、另一条写入
路径，**需要跨文件 join 的闸会安静地坏掉**。10 天：长到周末/节假日/等价位不会误触，
短到六周毫无歧义。标志随 breach 一路带进 packet 的 risk 行，让**能把它变成决定的那个人**
（plan writer）看得到。

### 4. 零产出不再报 OK

`check_research_artifacts` 在三个计数全 0 时改报 WARNING，并直说后果：加仓侧被一个
从不填充的层锁着。

## 验证

- `tests/test_risk_swap_leg.py` 7 条：授权成立（不要 setup）／**无 mandate 时择时闸
  原样生效**（红半边，不许顺手放宽普通加仓）／目标自己 breach 时拒绝／只授权指名的那一只／
  自指忽略／多条授权取 critical 且其余仍可见／研究层闸两个方向。
- `tests/test_breach_standing_decision.py` 6 条：42 天必 overdue、3 天不 overdue、
  **三个出口各自都能关掉它**（尤其 override——六周里真正发生的就是它）、阈值不许短到
  被长周末触发、plan writer 确实看得到。
- 相关面 154 passed；全量套件 2714 passed / 1 failed，唯一失败是
  `test_safe_push_refuses_the_money_file_when_the_checker_is_missing`，本分支从合并
  #1082 之前的 master 切出，rebase 后已复验通过。

Closes #1075

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

