### PR TITLE
fix: thesis 闸的空转与我自己在 #1075 里写错的归因

### DIFF
--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1193,6 +1193,25 @@ def check_benchmark_freshness(r):
                          for k, v in sorted(freshness.items())))
 
 
+def _unthesised_holdings():
+    """Active holdings with no canonical thesis document, by ticker."""
+    try:
+        from clawock.decision import theses as thesis_registry
+        docs, _ = thesis_registry.load_registry(WS / 'memory' / 'theses')
+        have = {str(doc.get('ticker')) for doc in docs}
+        book = json.loads((WS / 'portfolio.json').read_text(encoding='utf-8'))
+    except Exception:      # noqa: BLE001 — a broken probe must not fail closed
+        return []
+    out = []
+    for port in (book.get('portfolios') or {}).values():
+        for holding in (port or {}).get('holdings') or []:
+            ticker = str(holding.get('ticker') or '')
+            shares = holding.get('shares') or 0
+            if ticker and shares > 0 and ticker not in have:
+                out.append(ticker)
+    return sorted(out)
+
+
 def check_research_artifacts(r):
     """Thesis, earnings and entry-gate artifacts must stay valid.
 
@@ -1214,20 +1233,32 @@ def check_research_artifacts(r):
     elif result['status'] == 'warn':
         r.add('research artifacts', WARNING,
               f"{tally} valid; open work: " + '; '.join(result['warnings'][:4]))
-    elif not any(counts.values()):
+    elif not counts['theses'] and _unthesised_holdings():
         # "Zero valid artifacts" and "no open work" are the same sentence to a
-        # validator and opposite facts to a reader. All three directories hold
-        # nothing but their READMEs, no recurring job writes them (`clawock
-        # thesis` is a manual CLI), and this check has reported OK for it every
-        # push. That silence is load-bearing: `_execution_view` blocks every add
-        # on `no_approved_setup` and `thesis_gate` never leaves
-        # "exploration_only", so a permanently empty research layer holds the
-        # entire add side shut — 0 add decisions in the 26 days to 2026-08-26,
-        # the last one 2026-07-20 (#1075).
+        # validator and opposite facts to a reader — but say the RIGHT thing
+        # about it. The first version of this branch claimed an empty research
+        # layer held the add side shut; it does not, and the wrong text shipped
+        # for one evening (#1075 → corrected same night).
+        #
+        # What is actually true: the canonical thesis registry is a KILL SWITCH.
+        # Only `state ∈ {broken, damaged, weakening}` changes a number — it
+        # zeroes the tranche. `intact` and "no document at all" size identically.
+        # So an empty registry does not block anything; it means the switch has
+        # never been armed, and the day a holding's story breaks there is nothing
+        # to trip. Named per holding because that is the unit somebody would act
+        # on.
+        #
+        # Entry gates and earnings artifacts are deliberately NOT part of this
+        # condition: `research-governance.json` requires a gate only for
+        # positions opened on or after `gate_required_from` (2026-07-27), and
+        # every current holding predates it. Zero gates is the policy working,
+        # not a gap — `ungated_positions` already warns about the real case.
+        names = _unthesised_holdings()
         r.add('research artifacts', WARNING,
-              'no research artifact has ever been produced (0 theses · 0 earnings · '
-              '0 gates) and no recurring job writes them — the add side is gated '
-              'on a layer that never fills')
+              f'{tally} valid; the thesis kill-switch is unarmed for '
+              f'{len(names)} active holding(s) ({", ".join(names[:4])}'
+              f'{"…" if len(names) > 4 else ""}) — nothing can trip when a '
+              f'story breaks')
     else:
         r.add('research artifacts', OK, f'{tally} valid · no open research work')
 

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -303,6 +303,15 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
     suggested = min(suggested, position_room_shares)
     max_tranche_shares = suggested
 
+    # The canonical thesis registry is a KILL SWITCH, not a licence. Only the
+    # first branch changes a number; `intact` and `exploration_only` size
+    # identically, and saying so plainly matters because the line that used to
+    # sit under `exploration_only` was `min(max_tranche_shares, suggested)` —
+    # applied one statement after `max_tranche_shares = suggested`, i.e. a
+    # no-op — under a comment claiming it stopped pyramiding. Pyramiding is
+    # stopped by the campaign's own `max_tranches` (1 for exploration), which is
+    # where it has always actually been enforced. A restriction that lives only
+    # in a comment is worse than no restriction: the next reader budgets for it.
     thesis_state = thesis.get("state") or "unknown"
     if thesis_state in {"broken", "damaged", "weakening"}:
         thesis_gate = "blocked"
@@ -310,10 +319,9 @@ def _execution_view(holding: dict, leg: str, capital: float, cash: float,
     elif thesis_state == "intact":
         thesis_gate = "intact"
     else:
-        # No canonical thesis is not treated as intact. It may gather one small
-        # prospective sample, but cannot pyramid multiple tranches.
+        # No canonical thesis. Not treated as intact, but it costs nothing here:
+        # a name with no thesis is sized by its evidence tier like any other.
         thesis_gate = "exploration_only"
-        max_tranche_shares = min(max_tranche_shares, suggested)
 
     blockers = []
     if leveraged and authority_tier != "validated":
@@ -598,15 +606,22 @@ def _swap_mandates(risks: dict) -> dict:
     so out loud on 2026-08-26: 「07226 砍完 swap 03033 路径被 packet add 限制
     阻挡 (allowed=[hold_and_watch, watch])」.
 
-    The gate it was waiting on has never opened. `memory/theses/`,
-    `memory/entry-gates/` and `memory/earnings/` hold nothing but READMEs and no
-    recurring job writes them, so `thesis_state` is permanently "unknown" and
-    `setups` permanently empty. Measured: 07226 / RKLX / SPCH have been told to
-    cut 53 / 38 / 45 times with **zero** executions, three hard stops have been
-    open 42 days unacknowledged, and the last `add_only_on_trigger` of any kind
-    was 2026-07-20. Half a prescription is not a smaller version of the
+    Measured: 07226 / RKLX / SPCH have been told to cut 53 / 38 / 45 times with
+    **zero** executions, and three hard stops have been open 42 days
+    unacknowledged. Half a prescription is not a smaller version of the
     prescription — it is "sell and hold the cash", which is a different call
     that nobody made.
+
+    CORRECTION (2026-08-26, same night): the first version of this docstring
+    blamed an empty `memory/theses/` for the closed buy leg. That was wrong and
+    is recorded here rather than quietly deleted, because the wrong version
+    shipped. The swap targets were blocked by `no_approved_setup` — they carry
+    no quant setup, which is ordinary for a name nobody is running an add
+    campaign on — and the thesis registry has nothing to do with it. The add
+    side at large is NOT shut: it is gated on `add_authority.tier`, which on the
+    same day rated CRCL `eligible`. What is true is narrower and is exactly what
+    this function fixes: a RULE's buy leg must not be gated on a TIMING artifact
+    at all.
     """
     out: dict[str, list[dict]] = {}
     for source, rows in (risks or {}).items():

--- a/tests/test_risk_swap_leg.py
+++ b/tests/test_risk_swap_leg.py
@@ -110,60 +110,93 @@ def test_the_critical_mandate_wins_when_a_target_carries_several():
 
 # ── The layer the timing gate waits on has never filled (#1075) ──────────────
 
-def test_an_empty_research_layer_is_reported_not_blessed(monkeypatch, tmp_path):
-    """"0 valid" and "no open work" are one sentence to a validator and
-    opposite facts to a reader.
+def test_the_thesis_gate_is_a_kill_switch_and_says_so(monkeypatch, tmp_path):
+    """The corrected version of a claim that shipped wrong for one evening.
 
-    `memory/theses/`, `memory/entry-gates/` and `memory/earnings/` hold nothing
-    but READMEs; `clawock thesis` is a manual CLI and no cron writes them. The
-    gate said OK on every push while `_execution_view` blocked every add on
-    `no_approved_setup` — the add side held shut by a layer that never fills.
+    The first pass of #1075 said an empty `memory/theses/` held the add side
+    shut. It does not. `_execution_view` only changes a number for
+    `state ∈ {broken, damaged, weakening}` — it zeroes the tranche; `intact` and
+    "no document" size identically, and the line that used to sit under
+    `exploration_only` was `min(x, x)` under a comment claiming it stopped
+    pyramiding (`max_tranches` does that). So an empty registry is not a closed
+    door, it is an unarmed switch — and the gate has to say the true thing,
+    because "0 valid · no open research work" said nothing at all.
+
+    Entry gates stay out of the condition on purpose: governance requires one
+    only for positions opened on/after `gate_required_from` (2026-07-27) and
+    every current holding predates it, so zero gates is the policy working.
     """
-    import importlib.util, sys
+    import importlib.util, json as _json, sys as _sys
     from pathlib import Path
     root = Path(__file__).resolve().parents[1]
     for path in (root, root / "src"):
-        if str(path) not in sys.path:
-            sys.path.insert(0, str(path))
+        if str(path) not in _sys.path:
+            _sys.path.insert(0, str(path))
     spec = importlib.util.spec_from_file_location(
         "sc_research", root / "ops" / "system_check.py")
     sc = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sc)
 
-    def result_with(counts, status="pass"):
-        return {"status": status, "errors": [], "warnings": [], "counts": counts}
+    book = tmp_path / "portfolio.json"
+    book.write_text(_json.dumps({"portfolios": {"hk": {"holdings": [
+        {"ticker": "00100", "shares": 120}, {"ticker": "07226", "shares": 6200},
+        {"ticker": "SOLD", "shares": 0},
+    ]}}}), encoding="utf-8")
+    (tmp_path / "memory" / "theses").mkdir(parents=True)
+    monkeypatch.setattr(sc, "WS", tmp_path)
 
     def run(counts, status="pass"):
         import clawock.evidence.research_surface as rs
-        monkeypatch.setattr(rs, "check", lambda: result_with(counts, status))
+        monkeypatch.setattr(rs, "check", lambda: {
+            "status": status, "errors": [], "warnings": [], "counts": counts})
         r = sc.Result()
         sc.check_research_artifacts(r)
         return r.checks[0]
 
     _, severity, message = run(
         {"theses": 0, "earnings_artifacts": 0, "entry_gates": 0})
-    assert severity == sc.WARNING, "an empty layer read as 'no open research work'"
-    assert "never" in message
+    assert severity == sc.WARNING
+    assert "kill-switch is unarmed" in message
+    assert "2 active holding" in message, "a cleared position is not a gap"
+    assert "SOLD" not in message
 
-    # Green half: a layer that HAS produced something and has nothing pending
-    # is genuinely fine, and must not start warning.
-    _, severity, _ = run({"theses": 2, "earnings_artifacts": 0, "entry_gates": 1})
-    assert severity == sc.OK
+    # Green half 1: a thesis for every active holding — nothing to report, even
+    # with zero entry gates and zero earnings artifacts.
+    _, severity, _ = run({"theses": 2, "earnings_artifacts": 0, "entry_gates": 0})
+    assert severity == sc.OK, (
+        "zero entry gates is the governance policy working, not a finding")
+
+    # Green half 2: real open work still comes through the existing warn path.
+    _, severity, message = run(
+        {"theses": 2, "earnings_artifacts": 1, "entry_gates": 1}, status="warn")
+    assert severity == sc.WARNING
 
 
-def test_the_skill_tells_the_writer_the_mandate_exists():
-    """A capability the plan writer is never told about is an inert fix.
+def test_a_thesis_only_ever_subtracts(monkeypatch):
+    """intact and unknown must size identically; only a broken story cuts.
 
-    The skill already said 「同一份 plan 中可证明净降 factor exposure 的 2x→1x 配对
-    换仓不受阻」 while `_constraints` forbade exactly that — the instruction and
-    the packet contradicted each other and the packet won, silently, for 42
-    days. Now that they agree, the writer still has to be told which field
-    carries the authorisation and that a mandated target needs no setup.
+    This is the assertion the removed `min(x, x)` pretended to be. If somebody
+    later wants a thesis to ENABLE something, this test is the one that has to
+    change on purpose.
     """
-    from pathlib import Path
-    skill = (Path(__file__).resolve().parents[1] / "skills" / "daily-deep-brief"
-             / "SKILL.md").read_text(encoding="utf-8")
-    for token in ("swap_mandate", "transaction_group_id", "target_held",
-                  "decision_overdue"):
-        assert token in skill, (
-            f"the packet publishes {token} and nothing tells the writer to read it")
+    holding = {"ticker": "T", "shares": 100, "current_price": 10.0}
+    technical = {"setups": [{"setup_id": "alpha_confirmation", "campaign_id": "c",
+                             "max_tranches": 1, "tranche_pct_of_position": 0.25}]}
+
+    def size(state):
+        view = packet._execution_view(
+            holding, "US", 10_000.0, 10_000.0, technical,
+            {"state": state}, False, authority_tier="exploration",
+        )
+        return view["max_add_shares"], view["thesis_gate"]
+
+    unknown, unknown_gate = size("unknown")
+    intact, intact_gate = size("intact")
+    broken, broken_gate = size("broken")
+
+    assert unknown == intact, (
+        "a canonical thesis must not silently change sizing — that is what the "
+        "no-op comment implied and the code never did")
+    assert (unknown_gate, intact_gate, broken_gate) == (
+        "exploration_only", "intact", "blocked")
+    assert broken == 0, "a broken story is the one case that must cut the tranche"


### PR DESCRIPTION
fix: thesis 闸的空转与我自己在 #1075 里写错的归因

本 PR 一半是修代码，一半是**收回昨晚 #1075 里一段错的断言**——它已经合进 master，
留在 packet 的 docstring 和 system_check 的告警文案里，会误导下一个读的人。

## 一、纠正：加仓侧没有被研究层关死

#1075 说「`memory/theses/` 空 ⇒ 加仓侧结构性关闭」。**错的。** 同一天的真实 packet：

```
ticker   tier        setups                    blockers
CRCL     exploration alpha_confirmation(1)     []            ← eligible，可加 1 股
SKHY     exploration alpha_confirmation(1)     tranche_below_market_unit
其余 8 只 none        []                        no_approved_setup
add_alpha_diagnostics: candidate_rate=0.2  blocker_counts={'independent_evidence_families': 8, ...}
```

真正的闸是 `add_authority.tier` 要的**独立证据族**（8/10 卡在这里），那是设计好的证据
门槛、在正常工作。8 月 0 条 add 的原因是合格候选稀少（2/10）且很小（CRCL 上限 1 股），
模型选了 hold——**那是策略按设计运行，不是缺陷**。

`memory/entry-gates/` 空同样不是缺口：`research-governance.json` 的
`gate_required_from = 2026-07-27`，而**所有持仓的首次买入都早于它**（最晚 SKHY 07-10），
按政策整体豁免。`ungated_positions` 本来就负责真正的情形。

#1075 的换仓修复本身仍然成立（03033 确实带着 `no_approved_setup`、确实拿不到买腿），
只是它的**归因**写错了。

## 二、真缺陷：thesis 闸有一行是空转

```python
suggested = min(suggested, position_room_shares)
max_tranche_shares = suggested
...
else:
    # No canonical thesis ... cannot pyramid multiple tranches.
    thesis_gate = "exploration_only"
    max_tranche_shares = min(max_tranche_shares, suggested)   # ← min(x, x)
```

上一行刚把 `max_tranche_shares` 赋成 `suggested`，所以这是恒等式。注释声称它挡住了
金字塔加仓，**而金字塔实际是被 campaign 自己的 `max_tranches`（exploration 档 = 1）
挡住的**。

⇒ 结论：**canonical thesis registry 是一个纯 kill-switch**。只有
`state ∈ {broken, damaged, weakening}` 会改数字（把 tranche 归零）；`intact` 与
「根本没有文档」的定价**完全相同**。它只能停加仓，不能开加仓。

**只活在注释里的限制比没有限制更糟：下一个读的人会按它做预算。** 空转行删掉，
把真正生效的东西写在原地。

## 三、告警文案改成真的

原文案（我昨晚写的）：「the add side is gated on a layer that never fills」——假的。
新文案按持仓点名，说的是这个 registry 的**实际**语义：

```
0 theses · 0 earnings · 0 gates valid; the thesis kill-switch is unarmed for
10 active holding(s) (00100, 02208, 03032, 03033…) — nothing can trip when a
story breaks
```

条件也收窄了：只看 theses × 活跃持仓，**不再把 entry_gates / earnings 计入**——
零 entry gate 是治理政策在生效，不是缺口。

## 验证

- `test_a_thesis_only_ever_subtracts`：`intact` 与 `unknown` 的 `max_add_shares`
  **必须相等**（这正是被删掉那行假装在做的断言），`broken` 必须归零，三个
  `thesis_gate` 取值各自正确。**将来若有人想让 thesis 去「开」什么，这条测试就是那个
  必须被有意改掉的地方。**
- `test_the_thesis_gate_is_a_kill_switch_and_says_so`：告警按活跃持仓计数、已清仓的
  不算、每只都有 thesis 时即使零 entry gate 也必须 OK、真正的 open work 仍走原告警路径。
- 全量套件 **2751 passed / 5 skipped / 4 xfailed / 0 failed**（干净树）。
  过程中出现过一次 `test_no_new_test_writes_to_published_state` 失败，原因是我在同一个
  worktree 里并发跑了两个 pytest 会话、互相改同一批 `assets/data/*.json`——那个闸如实
  抓到了污染，是操作失误不是缺陷，干净重跑即消失。

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

