### PR TITLE
feat: 确认过的技术突破成为第三个证据族——被验证的 edge 终于进了决策那条道 (#1086)

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -96,6 +96,17 @@ reference 的三种技术 staged setup，或 packet 编译出的 `alpha_confirma
 只安排未来 1–5 个本地交易日的执行。Bull/Bear 可反证、否决或降档，不能凭措辞
 创造 authority、提高 tier 或改股数。
 
+**证据族现在有三个(#1086)**：`price_relative`(因子/同业残差)、
+`point_in_time_information`(一手披露)、**`technical_breakout`**(收盘站上前 20 日高
+且 z < `early_no_chase_zscore`)。第三族是 #856 回测里**唯一四周期全绿**的形态
+(H20 55.9% avg +16.25%；港股 H20 59.4% avg +38.7%)，此前只喂给盘中消息、
+对决策没有任何权重。
+
+三条边界不许越：**门槛仍是两族**(突破单独不授权任何东西)；突破**不算 validated**
+(validated 仍要两侧都有 `usable_for_decisions` 的证据)；因此**杠杆腿不会被价格形态
+提拔**，`leveraged_requires_validated_evidence` 照旧。授权成立时
+`add_authority.technical_reasons` 会写明是哪一次突破——**引用它，不要自己重算价位**。
+
 `quant.early_trend.observed=true` 是 harness 已发现的提前布局候选：必须让 Bull 写最强的
 可证伪提前布局论点，让 Bear 写 priced-in/拥挤/来源质量反驳，Judge 再给
 `candidate|wait|reject`。Judge 只能把 deterministic candidate 保留、等待或否决；不得把

--- a/src/clawock/decision/add_alpha.py
+++ b/src/clawock/decision/add_alpha.py
@@ -149,6 +149,58 @@ def _information_support(
     return bool(modes), modes, sorted(set(positive_events + attention_events))
 
 
+def _technical_support(technical: dict, policy: dict) -> tuple[bool, list[str]]:
+    """A confirmed 20-day breakout, not overheated — the one shape with a measured edge.
+
+    #856 backtested eight months of real bars, 28 non-overlapping votes, and this
+    is the only formation that came back positive at every horizon:
+
+        breakout (close > prior 20d high, z < 2)
+            H1 52.5%  H5 54.0%  H10 52.5%  H20 55.9% [49,63] avg +16.25%
+            HK leg    H20 59.4% avg +38.7%
+        deep dip (<= 92% of the 20d high)
+            H1 49.2%  H5 43.9%  H10 42.7%  H20 44.0%   — a coin flip or worse
+
+    #856 wired it into `add_side.py`, which only `intraday_preflight` and
+    `intraday_postflight` import — the lane that TALKS. `classify_authority`,
+    the lane that DECIDES, took `(factor, peer, information)` and never saw a
+    price trend at all, so a clean breakout contributed exactly zero to add
+    authority. Measured 2026-08-26: `blocker_counts` was
+    `{'independent_evidence_families': 8}` on a ten-name book, and August closed
+    with zero add decisions.
+
+    Deliberately conservative in three ways:
+
+    * it is a THIRD family, not a relaxation — `minimum_evidence_families` stays
+      at 2, so a breakout still has to be joined by factor/peer or by first-hand
+      information before anything is authorised;
+    * it never contributes to `validated`, which keeps requiring evidence marked
+      `usable_for_decisions`. A price pattern is not a due-diligence artifact,
+      and the leveraged names in particular must keep failing
+      `leveraged_requires_validated_evidence`;
+    * the overheat filter is the policy's own `early_no_chase_zscore`, not a new
+      number. On the day this shipped it is what excluded CRCL (z = 2.13).
+    """
+    close = _number(technical.get("close"))
+    prior_high = _number(technical.get("prior_20d_high"))
+    zscore = _number(technical.get("zscore20"))
+    if close is None or prior_high is None or prior_high <= 0:
+        return False, []
+    if technical.get("status") not in (None, "fresh"):
+        # A stale technical row is not evidence of anything. Same discipline the
+        # packet already applies to quant rows.
+        return False, []
+    if close <= prior_high:
+        return False, []
+    ceiling = _number(policy.get("early_no_chase_zscore"))
+    if ceiling is not None and zscore is not None and zscore >= ceiling:
+        return False, [f"breakout 但 z={zscore:.2f} ≥ {ceiling:g} 过热,不追"]
+    return True, [
+        f"收盘 {close:g} 站上前 20 日高 {prior_high:g}"
+        + (f",z={zscore:.2f} 未过热" if zscore is not None else "")
+    ]
+
+
 def classify_authority(
     factor: dict,
     peer: dict,
@@ -158,6 +210,7 @@ def classify_authority(
     policy: dict,
     market: str,
     continuing: bool = False,
+    technical: dict | None = None,
 ) -> dict:
     """Return a stateful-campaign eligibility tier and auditable blockers."""
     market_policy = _market_policy(policy, market)
@@ -169,11 +222,14 @@ def classify_authority(
         information, policy, market_policy
     )
 
+    technical_ok, technical_reasons = _technical_support(technical or {}, policy)
+
     price_relative_ok = factor_ok or peer_ok
     families = [
         name for name, passed in (
             ("price_relative", price_relative_ok),
             ("point_in_time_information", info_ok),
+            ("technical_breakout", technical_ok),
         ) if passed
     ]
     sources = [
@@ -181,6 +237,7 @@ def classify_authority(
             ("factor", factor_ok),
             ("peer_residual", peer_ok),
             ("information", info_ok),
+            ("technical_breakout", technical_ok),
         ) if passed
     ]
     blockers = []
@@ -220,12 +277,26 @@ def classify_authority(
         "peer_rules": peer_reasons,
         "information_modes": info_modes,
         "information_event_ids": event_ids,
+        # Only when it fired. This dict is emitted once PER TICKER inside a
+        # 96KB packet, so a per-row string that is empty nine times out of ten
+        # is pure budget — the first cut of this blew the cap by 1.8KB.
+        **({"technical_reasons": technical_reasons} if technical_reasons else {}),
         "blockers": sorted(set(blockers)),
-        "discipline": (
-            "one price-relative family plus point-in-time information authorise "
-            "capital; technical confirmation only schedules the tranche"
-        ),
+        # `discipline` used to live here, one identical copy per ticker: 125
+        # bytes × 10 holdings inside a 96KB cap that had 873 bytes of headroom
+        # left, and nothing read it. A constant belongs in the packet once —
+        # see AUTHORITY_DISCIPLINE, published under `add_alpha_policy`.
     }
+
+
+#: What the tiers mean, stated once for the whole packet rather than per row.
+AUTHORITY_DISCIPLINE = (
+    "any two independent families authorise exploration capital "
+    "(price-relative / point-in-time information / confirmed un-overheated "
+    "20-day breakout); validated still needs decision-usable evidence on both "
+    "the price and information sides, so a price pattern never promotes a "
+    "leveraged name"
+)
 
 
 def confirmation_setup(

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -850,6 +850,10 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             policy=add_policy,
             market=leg,
             continuing=continuing_alpha,
+            # The decision lane never saw a price trend until #1086: the one
+            # formation #856 measured positive at every horizon fed only the
+            # intraday message.
+            technical=technical,
         )
         if alpha_authority.get("tier") == "exploration":
             # A current-universe backfill can discover an interaction worth
@@ -1056,15 +1060,19 @@ def compile_packet(context: dict, generation_id: str | None = None) -> dict:
             ],
         },
         "add_alpha_policy": {
-            key: add_policy.get(key)
-            for key in (
-                "schema_version", "registered_at", "minimum_evidence_families",
-                "confirmation_window_sessions", "exploration_max_tranches",
-                "exploration_tranche_pct", "validated_max_tranches",
-                "exploration_max_book_pct", "early_peer_dispersion_multiple",
-                "early_no_chase_zscore",
-                "validated_tranche_pct", "markets", "discipline",
-            )
+            **{
+                key: add_policy.get(key)
+                for key in (
+                    "schema_version", "registered_at", "minimum_evidence_families",
+                    "confirmation_window_sessions", "exploration_max_tranches",
+                    "exploration_tranche_pct", "validated_max_tranches",
+                    "exploration_max_book_pct", "early_peer_dispersion_multiple",
+                    "early_no_chase_zscore",
+                    "validated_tranche_pct", "markets", "discipline",
+                )
+            },
+            # Stated once for the packet instead of once per holding (#1086).
+            "authority_discipline": add_alpha.AUTHORITY_DISCIPLINE,
         },
         "add_alpha_diagnostics": {
             "held_names": len(tickers),

--- a/tests/test_breakout_evidence_family.py
+++ b/tests/test_breakout_evidence_family.py
@@ -1,0 +1,164 @@
+"""The measured edge had no vote in the lane that decides (#1086).
+
+kcn, 2026-08-26: 「我们现在主要是缺少加仓决策」.
+
+#856 backtested eight months of real bars, 28 non-overlapping votes, and one
+formation came back positive at every horizon:
+
+    breakout (close > prior 20d high, z < 2)
+        H1 52.5%  H5 54.0%  H10 52.5%  H20 55.9% [49,63] avg +16.25%
+        HK leg    H20 59.4% avg +38.7%
+    deep dip (<= 92% of the 20d high)
+        H1 49.2%  H5 43.9%  H10 42.7%  H20 44.0%
+
+#856 wired it into `add_side.py`, imported only by the two intraday harness
+modules — the lane that TALKS. `classify_authority` took
+`(factor, peer, information)` and never saw a price trend, so a clean breakout
+contributed exactly zero to add authority. Measured on 2026-08-26:
+`blocker_counts == {'independent_evidence_families': 8}` on a ten-name book,
+71 retained intraday contexts holding 46 reject / 102 wait / **0 candidate**,
+and August closed with zero add decisions.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def add_alpha():
+    return pytest.importorskip("clawock.decision.add_alpha")
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return json.loads(
+        (ROOT / "config" / "add-alpha-policy.json").read_text(encoding="utf-8"))
+
+
+# One family short on its own — exactly SPCX / SPCH / 00100 on the measured day.
+FACTOR_ONLY = {"market_percentile": 0.99, "coverage_pct": 99.0,
+               "sector_universe_size": 9, "usable_for_decisions": False}
+NO_PEER = {"triggered_rules": [], "available_peer_count": 5}
+NO_INFO = {"signed_score": 0.0}
+
+
+def _authority(add_alpha, policy, technical, *, leveraged=False):
+    return add_alpha.classify_authority(
+        FACTOR_ONLY, NO_PEER, NO_INFO, leveraged=leveraged,
+        policy=policy, market="US", technical=technical)
+
+
+def _breakout(z=1.2, status="fresh"):
+    return {"status": status, "close": 100.0, "prior_20d_high": 95.0, "zscore20": z}
+
+
+def test_a_confirmed_breakout_is_the_second_family(add_alpha, policy):
+    """The unlock. One price-relative family plus a breakout reaches exploration."""
+    before = _authority(add_alpha, policy, {})
+    assert before["tier"] == "none"
+    assert "independent_evidence_families" in before["blockers"]
+
+    after = _authority(add_alpha, policy, _breakout())
+    assert after["tier"] == "exploration"
+    assert after["evidence_families"] == ["price_relative", "technical_breakout"]
+    assert after["technical_reasons"], "the reason must be auditable, not implied"
+
+
+def test_the_bar_itself_does_not_move(add_alpha, policy):
+    """A third family is not a relaxation — two are still required.
+
+    A breakout ALONE must not authorise anything, or this stops being an
+    evidence bar and becomes a momentum trigger.
+    """
+    assert policy["minimum_evidence_families"] == 2
+    alone = add_alpha.classify_authority(
+        {}, NO_PEER, NO_INFO, leveraged=False, policy=policy,
+        market="US", technical=_breakout())
+    assert alone["evidence_families"] == ["technical_breakout"]
+    assert alone["tier"] == "none"
+    assert "independent_evidence_families" in alone["blockers"]
+
+
+@pytest.mark.parametrize("technical, why", [
+    ({}, "no technical row at all"),
+    ({"status": "fresh", "close": 90.0, "prior_20d_high": 95.0, "zscore20": -1.0},
+     "below the 20-day high — the deep-dip zone measured at 44%"),
+    (_breakout(z=2.4), "broken out but overheated"),
+    (_breakout(status="stale"), "a stale row is not evidence of anything"),
+    ({"status": "fresh", "close": 100.0, "prior_20d_high": None, "zscore20": 1.0},
+     "no level to break"),
+])
+def test_everything_that_is_not_a_clean_breakout_stays_blocked(
+        add_alpha, policy, technical, why):
+    result = _authority(add_alpha, policy, technical)
+    assert "technical_breakout" not in result["evidence_families"], why
+    assert result["tier"] == "none", why
+
+
+def test_the_overheat_ceiling_is_the_policy_value_not_a_new_number(add_alpha, policy):
+    """`early_no_chase_zscore` already exists; a second overheat constant would
+    be the twin that drifts."""
+    ceiling = policy["early_no_chase_zscore"]
+    assert _authority(add_alpha, policy, _breakout(z=ceiling - 0.01))["tier"] == "exploration"
+    assert _authority(add_alpha, policy, _breakout(z=ceiling))["tier"] == "none"
+
+
+def test_a_price_pattern_never_promotes_a_leveraged_name(add_alpha, policy):
+    """`validated` still needs decision-usable evidence on both sides.
+
+    The three names carrying open hard stops are all leveraged. If a chart could
+    promote them, this change would have re-opened the exact exposure the risk
+    ledger is trying to close.
+    """
+    result = _authority(add_alpha, policy, _breakout(), leveraged=True)
+    assert result["tier"] == "none"
+    assert "leveraged_requires_validated_evidence" in result["blockers"]
+
+
+def test_the_decision_lane_is_actually_wired_to_it():
+    """#856's edge reached only `add_side.py`, which the plan path never imports.
+
+    Asserted at the call site, because that is the thing that was missing —
+    the classifier could grow the parameter and still never be handed one.
+    """
+    source = (ROOT / "src" / "clawock" / "decision" / "packet.py").read_text(
+        encoding="utf-8")
+    call = source.split("add_alpha.classify_authority(", 1)[1].split(")", 1)[0]
+    assert "technical=technical" in call, (
+        "the packet must hand the classifier the price trend, or the family "
+        "can never fire in the lane that writes decisions")
+
+
+def test_the_authority_constant_is_stated_once_for_the_packet(add_alpha):
+    """It was 125 bytes duplicated per holding inside a 96KB cap with 873 to spare.
+
+    Measured before the move: the packet was 97,431/98,304 on a ten-name book —
+    0.9% headroom, growing with every position. A constant repeated per row is
+    waste by construction, and nothing read it.
+    """
+    import inspect
+    source = inspect.getsource(add_alpha.classify_authority)
+    assert '"discipline":' not in source, (
+        "the per-ticker copy is back; put constants in the packet-level policy")
+    assert isinstance(add_alpha.AUTHORITY_DISCIPLINE, str)
+    assert "two independent families" in add_alpha.AUTHORITY_DISCIPLINE
+
+
+def test_the_skill_tells_the_writer_the_third_family_exists():
+    """Shipping the capability without telling the writer is an inert fix.
+
+    The same anti-inert assertion #1075 needed: the packet can publish a family
+    the plan writer has never been told to read.
+    """
+    skill = (ROOT / "skills" / "daily-deep-brief" / "SKILL.md").read_text(
+        encoding="utf-8")
+    for token in ("technical_breakout", "technical_reasons",
+                  "early_no_chase_zscore"):
+        assert token in skill, f"the packet publishes {token}; nothing reads it"
+    assert "两族" in skill or "两个" in skill, (
+        "the writer must be told the bar did NOT move")

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -544,8 +544,13 @@ def test_early_exploration_reports_its_real_tranche_and_evidence_families():
 
     assert row["state"] == "exploration_ready"
     assert row["target_tranche_level"] == .25
+    # `close 11 > prior_20d_high 10` with `zscore20 1` is a clean, un-overheated
+    # breakout, so #1086's third family fires here too. That this fixture — built
+    # for a different purpose — lights it up end-to-end through `compile_packet`
+    # is the evidence that the classifier is actually handed the price trend,
+    # rather than merely having grown a parameter nobody passes.
     assert row["evidence_families"] == [
-        "point_in_time_information", "price_relative",
+        "point_in_time_information", "price_relative", "technical_breakout",
     ]
     assert row["entry_price"] == 11
 


### PR DESCRIPTION
feat: 确认过的技术突破成为第三个证据族——被验证的 edge 终于进了决策那条道 (#1086)

kcn：「我们现在主要是缺少加仓决策」。不是模型保守。

## 一句话

**从「确认过的技术突破」到「一条 add 决策」，此前根本不存在通路。**
而技术突破恰恰是 #856 的 8 个月 28 票非重叠回测里**唯一四周期全绿**的形态。

## 测量

`classify_authority(factor, peer, information, ...)` —— **签名里没有 technical**。
两个族是 `price_relative`（因子/同业残差）与 `point_in_time_information`（一手披露），
`minimum_evidence_families: 2` 两族都要。所以一次干净的突破对 `add_authority.tier`
的贡献是**零**。

2026-08-26 实测：`blocker_counts = {'independent_evidence_families': 8}`（10 只里 8 只
死在这），71 份留存盘中 context 里 **reject 46 / wait 102 / candidate 0**，8 月零 add。

#856 把这条 edge 接进了 `add_side.py`，而它的引用方只有 `intraday_preflight` /
`intraday_postflight` —— **说话的那条道**。

回测数字（#856，8 个月 / 28 票 / 非重叠）：

| 形态 | H1 | H5 | H10 | H20 |
|---|---|---|---|---|
| **突破（收盘>前 20 日高，z<2）** | **52.5** | **54.0** | **52.5** | **55.9% [49,63] avg +16.25%** |
| 港股突破 | 48.4 | 53.1 | 53.1 | **59.4% avg +38.7%** |
| 深跌抄底（≤92% 20 日高） | 49.2 | 43.9 | 42.7 | 44.0 |

## 修法：加一族，不动门槛

`_technical_support()` 判「收盘站上前 20 日高 且 z < `early_no_chase_zscore`」，
成立即 `technical_breakout` 族。**三条边界写死在实现里**：

1. **门槛仍是两族。** 突破单独不授权任何东西——否则这就不是证据闸，是动量触发器。
2. **突破不算 `validated`。** validated 仍要两侧都有 `usable_for_decisions` 的证据。
   一个价格形态不是尽调产物。
3. **因此杠杆腿不会被价格形态提拔**，`leveraged_requires_validated_evidence` 照旧。
   带着未平硬止损的三只全是杠杆腿——**如果一张图能提拔它们，这个改动就等于把风控
   账本正要关掉的敞口重新打开。**

过热闸复用政策里已有的 `early_no_chase_zscore`，**不新造常量**（第二个过热阈值就是
将来会漂的那对双胞胎）。stale 的技术行不算证据，与 packet 对 quant 行的既有纪律一致。

## 顺带修掉一个撑破预算的常量

加这一族时 packet 撞了 96KB 上限。查下去发现 `add_authority["discipline"]` 是个
**常量字符串、每只标的各存一份**（125 字节 × 10 只 = 1,250 字节），而且**没有任何
消费方读它**。提到包级 `add_alpha_policy.authority_discipline` 只存一份。

顺带量出另一个定时炸弹：**master 基线 97,431 / 98,304 —— 只剩 873 字节（0.9%）**，
且随持仓数增长。本 PR 之后是 **96,332，余量 1,972**（加了一族反而更宽）。

## 验证

`tests/test_breakout_evidence_family.py` 12 条：
- 解锁：一族 + 突破 = exploration，且 `technical_reasons` 必须可审计
- **门槛没动**：突破单独仍是 `tier=none` + `independent_evidence_families`
- 五种非干净突破全部保持挡住（无数据 / 深跌区 / 过热 / stale / 无前高）
- 过热天花板必须等于政策值（`ceiling-0.01` 过、`ceiling` 不过）
- **杠杆腿不得被价格形态提拔**
- **call site 必须真的传了 `technical=`** —— 分类器长了个参数却没人传，正是 #1075 那类
- `discipline` 不许回到 per-ticker
- skill 必须写明第三族与「两族门槛没变」（反空转）

`tests/test_brief_decision_packet.py` 一条期望更新：那个 fixture 的
`close 11 / prior_20d_high 10 / z=1` **本来就是一次干净突破**，新族正确点亮——
一个为别的目的搭的 fixture 端到端点亮它，正是「分类器真的拿到了价格趋势」的证据。

全量套件 **2763 passed / 5 skipped / 4 xfailed / 0 failed**。

## 不做的事

不放宽 `z<2`，不降 `minimum_evidence_families`，不给杠杆腿开后门，不擅自让观察池
（#556「绝不产生 add 授权」）产生授权——那是 kcn 的政策决定，见 #1086 正文第 3 条。

Closes #1086

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

