### PR TITLE
fix: 写入归属闸抓不到排在它后面的一半套件；SELL_ACTIONS 双胞胎 (#1089)

### DIFF
--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -44,7 +44,10 @@ ADD_ACTIONS = {"add_only_on_trigger", "add_on_breakout"}
 #: `decisions.jsonl` — that is a different file with a different write path, and
 #: a gate that needs a cross-file join is a gate that breaks quietly.
 STANDING_DECISION_DAYS = 10
-SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
+# Imported, not re-typed: `actions.py` calls itself the vocabulary "shared by
+# decision workflow components", and a second literal is a twin that agrees
+# until the day somebody adds an action word to one of them (#1089).
+from clawock.decision.actions import SELL_ACTIONS  # noqa: F401
 
 
 def _now(value=None) -> datetime:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,6 +286,50 @@ def _tolerated(node_id: str) -> bool:
     return any(node_id.startswith(prefix) for prefix in TOLERATED_WRITERS)
 
 
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the RUN when an untolerated writer touched published state.
+
+    This assertion used to live in
+    `test_import_layering.py::test_no_new_test_writes_to_published_state`, whose
+    docstring said "this runs last by name". It is not last: pytest collects by
+    path, and `test_i...` is followed by everything from `test_j` to `test_w` —
+    `test_validate_sidecars.py` among them. Measured on 2026-08-26, a full suite
+    printed
+
+        tests/test_validate_sidecars.py::test_real_committed_dashboard_passes  <-- NEW
+            created: assets/data/dashboard.json, ...
+
+    and reported no failure for it: the marker was rendered, the assertion had
+    already run. **A writer in any module sorting after the guard was invisible
+    to it** — which is the half of the suite the guard was least likely to be
+    watching, since the dashboard-shaped modules live there.
+
+    A session hook has no position in the collection order, so there is nothing
+    left to sort after it (#1089).
+    """
+    if session.config.getoption("collectonly", False):
+        return
+    # xdist: every worker gets its own session and its own copy of the four
+    # files, so attribution is meaningless — the reasoning is unchanged from the
+    # assertion this replaces.
+    if getattr(session.config, "workerinput", None) is not None:
+        return
+    offenders = sorted({e["test"] for e in _WRITE_LOG if not _tolerated(e["test"])})
+    if offenders:
+        session.exitstatus = 1
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            reporter.write_line("")
+            reporter.write_line(
+                "ERROR: these tests wrote into the checkout and are not on the "
+                f"tolerated list: {offenders}", red=True)
+            reporter.write_line(
+                "Point them at an isolated workspace "
+                "(monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))) rather "
+                "than adding them to TOLERATED_WRITERS — that list is meant to "
+                "shrink.", red=True)
+
+
 def pytest_terminal_summary(terminalreporter):
     """Print the attribution table, so a polluted run explains itself."""
     if not _WRITE_LOG:

--- a/tests/test_import_layering.py
+++ b/tests/test_import_layering.py
@@ -19,6 +19,7 @@ someone to go looking.
 from __future__ import annotations
 
 import ast
+import inspect
 from collections import defaultdict
 from pathlib import Path
 
@@ -266,54 +267,49 @@ def test_the_allowlists_only_ever_shrink():
     )
 
 
-def test_no_new_test_writes_to_published_state(request):
-    """A test that writes into the checkout changes what later tests see.
+def test_the_write_guard_has_no_position_in_the_collection_order(request):
+    """The guard moved to `pytest_sessionfinish` (#1089).
 
-    #816: `assets/data/workflow-outcomes.json` is untracked and absent in a
-    clean tree. One test created it, it persisted between runs, and it armed an
-    assertion in a different module that is dormant otherwise — a failure that
-    only ever appeared in full-suite order and passed on its own, twice, before
-    anyone could say which test was responsible.
+    It used to be this test, whose own docstring claimed "this runs last by
+    name". It was not last — pytest collects by path and `test_i...` is followed
+    by `test_j` through `test_w`, including `test_validate_sidecars.py`.
+    Measured 2026-08-26: a full suite rendered
 
-    This runs last by name and reads the attribution log the conftest fixture
-    builds.
+        tests/test_validate_sidecars.py::test_real_committed_dashboard_passes  <-- NEW
+
+    and failed for something else entirely. A writer in any module sorting after
+    the guard was invisible to it, and the dashboard-shaped modules — the ones
+    most likely to write — all live there.
+
+    What is left here is the reason it moved, plus the attribution log's own
+    shape. The enforcement is a session hook, which nothing can sort after.
 
     On parallelism, measured rather than assumed — and the measurement killed
-    the idea. #816 claimed emptying this list would unlock `-n auto` and take
-    the pytest step from 89s to ~30s. With the writers isolated and the session
-    rebuild behind a file lock, `-n 4` does pass, three runs at 175/182/191s
-    against ~195s serial: **5-10%, not 3x**. The top twelve tests account for
-    ~121s of a 208s run and every one of them is subprocess-bound — an
-    installer, a wheel install, safe_push, watchdogs with real waits — so the
-    suite is not wide, it is deep in a few places. A fourth parallel run also
-    produced one failure that would not reproduce.
-
-    So xdist stays off: a few percent is not worth a flake class. The isolation
-    was still worth doing on its own — it fixed a real order-dependent failure.
-    The way to make this suite faster is those twelve tests, not more workers.
+    the idea. #816 claimed emptying the tolerated list would unlock `-n auto`
+    and take the pytest step from 89s to ~30s. With the writers isolated and the
+    session rebuild behind a file lock, `-n 4` does pass, three runs at
+    175/182/191s against ~195s serial: **5-10%, not 3x**. The top twelve tests
+    account for ~121s of a 208s run and every one of them is subprocess-bound.
+    So xdist stays off: a few percent is not worth a flake class.
     """
-    from conftest import _WRITE_LOG, _tolerated  # noqa: PLC0415
+    import conftest  # noqa: PLC0415
 
-    if not _WRITE_LOG:
+    assert hasattr(conftest, "pytest_sessionfinish"), (
+        "the enforcement must be a session hook; a test can always be sorted "
+        "after by adding a module with a later name")
+    source = inspect.getsource(conftest.pytest_sessionfinish)
+    assert "_tolerated" in source and "exitstatus" in source, (
+        "the hook must both apply the allowlist and actually fail the run")
+
+    if not _WRITE_LOG_or_skip():
         pytest.skip("no writes recorded — this ran outside a full-suite session")
+    for entry in conftest._WRITE_LOG:
+        assert set(entry) >= {"test", "created", "removed", "changed"}, entry
 
-    # Under xdist the attribution is not trustworthy and neither is the result:
-    # every worker gets its own session, so N workers each run the dashboard
-    # rebuild against the same four files at once, and a write by one worker
-    # lands in whatever test another worker happened to be running. Measured on
-    # `-n 4`: this named test_hook_entrypoints_can_import_clawock, which writes
-    # nothing. The suite is not parallel-safe yet — see the module docstring —
-    # and pretending to check it here would be worse than saying so.
-    if getattr(request.config, "workerinput", None) is not None:
-        pytest.skip("write attribution is not valid under xdist; see #816")
 
-    offenders = sorted({e["test"] for e in _WRITE_LOG if not _tolerated(e["test"])})
-    assert not offenders, (
-        "these tests wrote into the checkout and are not on the tolerated list: "
-        f"{offenders}. Point them at an isolated workspace "
-        "(monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))) rather than "
-        "adding them to TOLERATED_WRITERS — that list is meant to shrink."
-    )
+def _WRITE_LOG_or_skip():
+    from conftest import _WRITE_LOG  # noqa: PLC0415
+    return _WRITE_LOG
 
 
 def test_the_tolerated_writer_list_only_shrinks():


### PR DESCRIPTION
fix: 写入归属闸抓不到排在它后面的一半套件；SELL_ACTIONS 双胞胎 (#1089)

## 一、写入归属闸有一半套件看不到

`test_no_new_test_writes_to_published_state` 的 docstring 写着
「This runs last by name」。**它不是最后一个** —— pytest 按路径排序，
`test_import_layering.py` 之后还有 `test_j` 到 `test_w` 一大片，而**面板形状的模块
（最可能写产物的那些）全在后面**。

实测证据（本机 2026-08-26 的一次全量套件）：终端摘要打出了

```
tests/test_validate_sidecars.py::test_real_committed_dashboard_passes  <-- NEW
    created: assets/data/dashboard.json, ...
```

而那次套件**只报了一个 failure，且是另一件事**。⇒ 标记打了、断言早就跑完了。

**修法**：把强制搬到 `pytest_sessionfinish`。session hook 在收集顺序里没有位置，
**没有任何东西能排在它后面**。`test_import_layering.py` 里留下的是「它为什么搬走」
以及归属日志自身的形状。

**红绿都验过**：临时放一个写 `assets/data/` 的 `tests/test_zzz_write_probe.py`
（名字故意排在闸后面），新闸抓到并且**真实退出码 = 1**（旧闸完全看不见它）。
xdist 下的跳过理由原样保留：每个 worker 一个 session，归属本来就不可信。

## 二、`SELL_ACTIONS` 有两份

```
src/clawock/decision/actions.py:6   SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
src/clawock/decision/risk.py:47     SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}   ← 字面量副本
src/clawock/decision/shadow.py:38   SELL_ACTIONS = set(decision_v2.SELL_ACTIONS)          ← 引用，对的
```

`actions.py` 自己的 docstring 是「Runtime-neutral vocabulary **shared** by decision
workflow components」，而 `risk.py` 抄了一份。今天两份内容相同所以没有症状；
**加一个动作词的那天会有**，而且会以「风控认得这个动作、别的模块不认得」的形状出现。
改成 import，全仓字面量定义降到 1 处。

全量套件 **2751 passed / 5 skipped / 4 xfailed / 0 failed**。

## 第三条（embedding cache）不在本 PR

`memory_index_maintenance.py` 在 `/root/tools/openclaw/current/`，**是主机脚本不在仓库**，
所以单独在主机上改并已在 DB 副本上验过（dry-run 不改动 / 真跑删 2,714 且 chunk 数不变 /
二次运行幂等 / 30 天窗口内 469 个正确保留）。详情见 #1089 与会话汇报。

Closes #1089

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

