### PR TITLE
fix: shadow 的 timing alpha 印在 10.5% 覆盖率上，分母不在同一处 (#1088)

### DIFF
--- a/src/clawock/decision/shadow.py
+++ b/src/clawock/decision/shadow.py
@@ -646,6 +646,39 @@ def attribute_fills(events: list[dict], final_prices: dict[str, float]) -> dict:
     }
 
 
+#: Below this share of legs actually filled, `cumulative_diff` is not a
+#: description of the policy — it is a description of 28 of its 266 legs.
+MIN_REPRESENTATIVE_FILL_RATE = 0.5
+
+
+def _coverage_view(curves: dict) -> dict:
+    """How much of the policy the simulated curve actually contains.
+
+    `estimand` claims the net value of following EVERY triggered active call.
+    When most legs never fill, that sentence is still printed and the number
+    beside it means something much narrower. This is the denominator, stated
+    where the numerator is.
+    """
+    filled = skipped = 0
+    for result in curves.values():
+        counts = (result.get("counts") or {}).get("fill_types") or {}
+        for kind, value in counts.items():
+            if kind == "skipped":
+                skipped += int(value or 0)
+            elif not str(kind).startswith("skipped:"):
+                filled += int(value or 0)
+    total = filled + skipped
+    rate = round(filled / total, 4) if total else None
+    return {
+        "filled_legs": filled,
+        "skipped_legs": skipped,
+        "fill_rate": rate,
+        "minimum_representative_fill_rate": MIN_REPRESENTATIVE_FILL_RATE,
+        "representative": bool(
+            rate is not None and rate >= MIN_REPRESENTATIVE_FILL_RATE),
+    }
+
+
 def _attribution_identity(attribution: dict, cumulative_diff) -> dict:
     """Does the decomposition reproduce the published gap?
 
@@ -817,7 +850,16 @@ def simulate_leg(
                 if leg_fill.get("filled_shares", 0) > 0:
                     fill_counts[leg_fill.get("fill_type") or "missing"] += 1
                 else:
+                    # Keep the reason. Every leg already carries one
+                    # (`skipped_no_fill_price` / `_no_inventory` / `_no_cash`),
+                    # and collapsing them into a single bucket is what made 238
+                    # skips unreadable: a missing bar is a DATA problem, no cash
+                    # is the simulation's own accounting, and no inventory means
+                    # the policy sold something it never held. Three different
+                    # answers to "why is coverage 10%", reported as one number.
                     fill_counts["skipped"] += 1
+                    reason = str(leg_fill.get("status") or "skipped_unknown")
+                    fill_counts[f"skipped:{reason}"] += 1
             filled_legs = sum(leg_fill.get("filled_shares", 0) > 0 for leg_fill in legs)
             events.append({
                 "date": day,
@@ -961,6 +1003,14 @@ def simulate_leg(
                 "ohlc_assumption": fill_counts["ohlc_assumption"],
                 "canonical_close_fallback": fill_counts["canonical_close_fallback"],
                 "skipped": fill_counts["skipped"],
+                # Why each skip happened. A hand-listed projection is what hid
+                # them: the loop had the reason and this dict dropped it, so
+                # "238 skipped" could not be read as data gap vs simulation
+                # accounting vs a policy selling what it never held.
+                **{
+                    key: value for key, value in sorted(fill_counts.items())
+                    if str(key).startswith("skipped:")
+                },
             },
         },
         "mark_coverage": {
@@ -1020,13 +1070,25 @@ def build_shadow_portfolio(
             currency: result["cumulative_diff"]
             for currency, result in curves.items()
         },
+        # In the SAME object as the number it qualifies, because the reader who
+        # takes `cumulative_diff` for "what following the advice is worth" is
+        # exactly the reader who will not go looking for a denominator in
+        # `fill_counts`. Measured 2026-08-26: HK$24,548 rested on 28 filled legs
+        # against 238 skipped — 10.5% — and nothing beside the number said so.
+        "coverage": _coverage_view(curves),
         "fill_counts": {
             kind: sum(
-                result["counts"]["fill_types"][kind] for result in curves.values()
+                (result["counts"]["fill_types"] or {}).get(kind, 0)
+                for result in curves.values()
             )
-            for kind in (
-                "real_trade", "ohlc_assumption",
-                "canonical_close_fallback", "skipped",
+            for kind in sorted(
+                {
+                    key
+                    for result in curves.values()
+                    for key in (result["counts"]["fill_types"] or {})
+                }
+                | {"real_trade", "ohlc_assumption",
+                   "canonical_close_fallback", "skipped"}
             )
         },
         "fx_policy": {

--- a/tests/test_shadow_coverage.py
+++ b/tests/test_shadow_coverage.py
@@ -1,0 +1,83 @@
+"""A simulated alpha printed without its denominator (#1088).
+
+`assets/data/shadow_portfolio.json` on 2026-08-26:
+
+    "cumulative_diff": {"USD": -510.09, "HKD": 24547.83}
+    "fill_counts": {"real_trade": 0, "ohlc_assumption": 28,
+                    "canonical_close_fallback": 0, "skipped": 238}
+
+`estimand` claims the net value of following **every** triggered active call.
+HK$24,548 rested on 28 filled legs out of 266 — 10.5% — and the number was
+printed with nothing beside it saying so. The denominator sat in a different
+object, and `skipped` was one bucket for three different causes.
+
+With the causes kept, the same run reads:
+
+    skipped:skipped_no_inventory  225
+    skipped:skipped_no_cash        13
+
+i.e. the simulated policy was mostly trying to sell what it never held. That is
+a much sharper statement than "10.5% coverage", and it was one dict projection
+away from being visible the whole time.
+"""
+from __future__ import annotations
+
+import pytest
+
+shadow = pytest.importorskip("clawock.decision.shadow")
+
+
+def _curves(filled, skipped, reasons=None):
+    types = {"real_trade": 0, "ohlc_assumption": filled,
+             "canonical_close_fallback": 0, "skipped": skipped}
+    types.update(reasons or {})
+    return {"HKD": {"counts": {"fill_types": types}}}
+
+
+def test_the_denominator_sits_with_the_number_it_qualifies():
+    view = shadow._coverage_view(_curves(28, 238))
+    assert view["filled_legs"] == 28
+    assert view["skipped_legs"] == 238
+    assert view["fill_rate"] == pytest.approx(0.1053, abs=1e-4)
+    assert view["representative"] is False
+
+
+def test_a_fully_filled_simulation_is_representative():
+    view = shadow._coverage_view(_curves(266, 0))
+    assert view["fill_rate"] == 1.0
+    assert view["representative"] is True
+
+
+def test_the_threshold_is_published_not_implied():
+    """A reader must not have to guess what "representative" was measured against."""
+    view = shadow._coverage_view(_curves(1, 1))
+    assert view["minimum_representative_fill_rate"] == (
+        shadow.MIN_REPRESENTATIVE_FILL_RATE)
+    assert 0 < shadow.MIN_REPRESENTATIVE_FILL_RATE <= 1
+
+
+def test_reason_buckets_never_double_count_the_total():
+    """`skipped:*` are a breakdown OF `skipped`, not extra filled legs.
+
+    Counting them as fills would inflate the very rate this exists to deflate.
+    """
+    view = shadow._coverage_view(_curves(
+        28, 238, {"skipped:skipped_no_inventory": 225,
+                  "skipped:skipped_no_cash": 13}))
+    assert view["filled_legs"] == 28
+    assert view["skipped_legs"] == 238
+
+
+def test_an_empty_simulation_does_not_claim_a_rate():
+    view = shadow._coverage_view({})
+    assert view["fill_rate"] is None
+    assert view["representative"] is False
+
+
+def test_the_projection_keeps_every_reason_it_was_given():
+    """The hand-listed dict is what dropped them; a new skip status must survive."""
+    import inspect
+    source = inspect.getsource(shadow)
+    assert 'str(key).startswith("skipped:")' in source, (
+        "the per-currency fill_types projection must forward reason buckets, "
+        "or a new skip status is invisible the day it is added")

--- a/tests/test_shadow_portfolio.py
+++ b/tests/test_shadow_portfolio.py
@@ -394,7 +394,14 @@ def test_fill_counts_separate_real_assumed_fallback_and_skipped():
         "ohlc_assumption": 1,
         "canonical_close_fallback": 1,
         "skipped": 1,
+        # #1088: the skip keeps its cause. DDD is a `cut` on a zero-share
+        # holding, so the simulated policy is selling what it never held — the
+        # bucket that turned out to be 225 of the live run's 238 skips.
+        "skipped:skipped_no_inventory": 1,
     }
+    assert sum(
+        value for key, value in counts.items() if key.startswith("skipped:")
+    ) == counts["skipped"], "the breakdown must partition the total, not extend it"
 
 
 def test_cumulative_diff_is_followed_minus_buy_hold_with_both_signs():


### PR DESCRIPTION
fix: shadow 的 timing alpha 印在 10.5% 覆盖率上，分母不在同一处 (#1088)

## 现象

```json
"estimand": "跟随全部已触发主动建议的政策模拟净值…累计差为模拟 timing alpha"
"cumulative_diff": {"USD": -510.09, "HKD": 24547.83}
"fill_counts": {"real_trade": 0, "ohlc_assumption": 28,
                "canonical_close_fallback": 0, "skipped": 238}
```

**HK$24,548 是 28 条腿撑起来的，238 条被跳过——覆盖率 10.5%**，而这个分母在另一个对象里。
不是算错，是**口径与呈现不匹配**：拿它当「听建议能赚多少」会读错一个数量级。

## 修法一：分母与它修饰的那个数放在同一个对象

```json
"coverage": {"filled_legs": 28, "skipped_legs": 238, "fill_rate": 0.1053,
             "minimum_representative_fill_rate": 0.5, "representative": false}
```

会把 `cumulative_diff` 当结论的那个读者，正是不会去 `fill_counts` 里自己算分母的那个。

## 修法二：skip 保留原因——这条挖出了真问题

每条腿本来就带着自己的 status（`skipped_no_fill_price` / `_no_inventory` / `_no_cash`），
而 `fill_counts` 把它们全压成一个桶。改成保留后，同一次真实运行读作：

```
skipped:skipped_no_inventory  225
skipped:skipped_no_cash        13
```

**238 个 skip 里 225 个是「模拟组合在卖它从来没持有过的东西」。** 这比「覆盖率 10.5%」
锋利得多——它说明模拟从空账起步，而绝大多数决策是对更早建立的仓位做 `cut`。
一个 dict 投影之隔，这件事本来一直是可见的。

（模拟起点该不该改成带初始持仓，是 estimand 的设计问题，本 PR 不擅自改口径；
先让它可诊断。）

## 验证

`tests/test_shadow_coverage.py` 6 条：
- 实测那组（28/238）必须 `fill_rate 0.1053 / representative false`
- 全填充必须 `representative true`
- **阈值必须公布**，读者不该猜「representative」是跟什么比的
- **分因桶不得被当成 filled 计数**（否则会抬高它本来要压低的那个比率）
- 空模拟不许声称一个比率
- 投影必须转发 reason 桶——手写字典正是当初丢掉它们的地方

`tests/test_shadow_portfolio.py` 一条期望更新：那个 fixture 的 DDD 是对 0 股持仓下
`cut`，新增的 `skipped:skipped_no_inventory: 1` 正好证明分因判对了；同时加一条断言
**分因之和必须等于 skipped 总数**（是拆分不是追加）。

全量套件 **2757 passed / 5 skipped / 4 xfailed / 0 failed**。

Closes #1088

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

