### PR TITLE
fix: followed 那一列在量市场不是量建议——passive 单列并写明每列量什么 (#1087)

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -2107,6 +2107,10 @@ def compute_backtest(decisions: list[dict]) -> dict:
         reps = episode_representatives(decisions, horizon)
         active = [r for r in reps if r.get("action") in ACTIVE_ACTIONS]
         followed = [r for r in reps if (r.get("execution") or {}).get("status") == "followed"]
+        passive = [r for r in reps if r.get("action") in PASSIVE_ACTIONS]
+        followed_active = [
+            r for r in followed if r.get("action") in ACTIVE_ACTIONS
+        ]
         horizons[horizon] = {
             # Keep the complete AI track record, including HOLD/WATCH episodes.
             # This is the v2 continuation of the migrated v1 "all calls" line;
@@ -2114,13 +2118,38 @@ def compute_backtest(decisions: list[dict]) -> dict:
             # as evidence that cut/trim/add timing has alpha.
             "all": _aggregate(reps, key),
             "active": _aggregate(active, key),
+            # The beta this book carried, shown rather than left implicit.
+            # `_benefit` gives a HOLD the underlying's own move, so a hold in a
+            # falling market scores a loss however right the hold was — and
+            # 103 of the 166 August decisions were holds on a book down 28-66%.
+            # Without this column the reader has no way to see how much of
+            # `all` and `followed` is simply the market (#1087).
+            "passive": _aggregate(passive, key),
             "followed": _aggregate(followed, key),
+            # `followed` mixes both, which is why it reads as "listening to the
+            # AI loses money, significantly" — measured 2026-08-26 at T+1:
+            # n=107, 32.7%, −1.86%, CI [−3.25, −0.62]. This is the same question
+            # asked of the calls that were actually a decision to do something.
+            "followed_active": _aggregate(followed_active, key),
             "by_strategy": _breakdown(reps, lambda r: r.get("strategy_id"), key),
             "all_curve": _compounded_curve(reps, key),
             "active_curve": _compounded_curve(active, key),
             "followed_curve": _compounded_curve(followed, key),
             "all_win_rate_curve": _cumulative_win_rate_curve(reps, key),
             "active_win_rate_curve": _cumulative_win_rate_curve(active, key),
+            # Named per column, because the columns do NOT answer the same
+            # question and nothing on the surface said so. A benchmark-relative
+            # benefit for the passive legs would be the richer fix and is not
+            # available: `benchmark.json` keeps a 60-day window (from
+            # 2026-06-29) while the episodes start 2026-05-17, so six weeks of
+            # the sample have no benchmark to be relative to.
+            "measures": {
+                "all": "every episode, active and passive — AI track record",
+                "active": "cut/trim/add timing only — the alpha question",
+                "passive": "hold/watch only — the underlying's own move, i.e. beta",
+                "followed": "every executed episode, active and passive mixed",
+                "followed_active": "executed episodes that were a decision to act",
+            },
         }
     return {
         "schema_version": SCHEMA_VERSION,

--- a/tests/test_passive_benefit_split.py
+++ b/tests/test_passive_benefit_split.py
@@ -1,0 +1,120 @@
+"""`followed` was measuring the market, not the advice (#1087).
+
+`assets/data/decision_audit.json` on 2026-08-26, T+1:
+
+    followed   n=107  win 32.7%  avg −1.86%  CI [−3.25, −0.62]
+
+Read plainly: acting on the advice loses money, significantly. Read correctly:
+`_benefit` gives a `hold_and_watch` the underlying's own move —
+
+    advantage = -underlying if action in SELL_ACTIONS else underlying
+
+— so a hold in a falling market scores a loss however right the hold was, and
+103 of August's 166 decisions were holds on a book down 28–66%. Splitting the
+column apart on the same data:
+
+    passive          n=105  win 32.4%  avg −1.84%  CI [−3.23, −0.64]
+    followed         n=107  win 32.7%  avg −1.86%  CI [−3.25, −0.62]
+    followed_active  n=  6  win 33.3%  avg −6.42%  CI [−18.14, +2.20]
+
+`followed` is `passive` plus six episodes. The significant negative was beta.
+The question it looked like it answered has n=6 and a CI straddling zero.
+
+A benchmark-relative benefit for the passive legs would be the richer fix and is
+not available: `benchmark.json` keeps a 60-day window (from 2026-06-29) while the
+episodes start 2026-05-17.
+"""
+from __future__ import annotations
+
+import pytest
+
+ledger = pytest.importorskip("clawock.decision.ledger")
+actions = pytest.importorskip("clawock.decision.actions")
+
+
+def _decision(idx, action, benefit, *, executed="followed"):
+    return {
+        "decision_id": f"dec-{idx}", "episode_id": f"ep-{idx}",
+        "ticker": "AAA", "leg": "US", "strategy_id": "core_position",
+        "action": action, "plan_date": f"2026-07-{(idx % 28) + 1:02d}",
+        "created_at": f"2026-07-{(idx % 28) + 1:02d}T00:00:00+08:00",
+        "size": {"shares": 1}, "confidence": 0.6,
+        "execution": {"status": executed},
+        # `triggered` is what `_episode_settled` filters on — a call that never
+        # fired has no number to average.
+        "evaluation": {"status": "settled", "triggered": True,
+                       "outcome": "win" if benefit > 0 else "loss",
+                       "benefit_t1_pct": benefit, "benefit_t5_pct": benefit},
+    }
+
+
+def _t1(decisions):
+    return ledger.compute_backtest(decisions)["horizons"]["t1"]
+
+
+def test_a_falling_market_no_longer_reads_as_bad_advice():
+    """Ten holds in a −5% tape and two profitable cuts.
+
+    Before the split the only executed-episode column mixed them and came out
+    negative. `followed_active` asks the question the reader thought they were
+    reading.
+    """
+    decisions = (
+        [_decision(i, "hold_and_watch", -5.0) for i in range(10)]
+        + [_decision(100 + i, "cut", +3.0) for i in range(2)]
+    )
+    t1 = _t1(decisions)
+
+    assert t1["passive"]["n_episodes"] == 10
+    assert t1["passive"]["avg_benefit_pct"] == pytest.approx(-5.0)
+    assert t1["followed"]["n_episodes"] == 12, "unchanged: continuity for readers"
+    assert t1["followed_active"]["n_episodes"] == 2
+    assert t1["followed_active"]["avg_benefit_pct"] == pytest.approx(3.0), (
+        "the cuts were right; the old column buried them under the tape")
+
+
+def test_passive_and_active_partition_the_whole_record():
+    decisions = (
+        [_decision(i, "hold_and_watch", -1.0) for i in range(7)]
+        + [_decision(50 + i, "cut", 1.0) for i in range(3)]
+    )
+    t1 = _t1(decisions)
+    assert (t1["passive"]["n_episodes"] + t1["active"]["n_episodes"]
+            == t1["all"]["n_episodes"])
+
+
+def test_followed_active_is_a_subset_of_both_its_parents():
+    decisions = (
+        [_decision(i, "cut", 1.0) for i in range(4)]
+        + [_decision(50 + i, "cut", 1.0, executed="not_followed") for i in range(3)]
+        + [_decision(80 + i, "hold_and_watch", -1.0) for i in range(5)]
+    )
+    t1 = _t1(decisions)
+    assert t1["followed_active"]["n_episodes"] == 4
+    assert t1["followed_active"]["n_episodes"] <= t1["active"]["n_episodes"]
+    assert t1["followed_active"]["n_episodes"] <= t1["followed"]["n_episodes"]
+
+
+def test_every_column_says_what_it_measures():
+    """The columns do not answer the same question and nothing said so.
+
+    This is the half of the fix that is not arithmetic: a reader taking
+    `followed` for "does the advice work" was not being careless, they were
+    reading a name with no stated meaning.
+    """
+    t1 = _t1([_decision(0, "cut", 1.0)])
+    measures = t1["measures"]
+    assert set(measures) == {
+        "all", "active", "passive", "followed", "followed_active"}
+    assert "beta" in measures["passive"]
+    assert "alpha" in measures["active"]
+    for column in measures:
+        assert column in t1, f"{column} is described but not published"
+
+
+def test_the_passive_vocabulary_is_the_shared_one():
+    """A local copy of the action set is the twin that drifts (#1089)."""
+    import inspect
+    source = inspect.getsource(ledger.compute_backtest)
+    assert "PASSIVE_ACTIONS" in source
+    assert actions.PASSIVE_ACTIONS == {"hold_and_watch", "watch"}


### PR DESCRIPTION
fix: followed 那一列在量市场不是量建议——passive 单列并写明每列量什么 (#1087)

## 现象

`decision_audit.json` T+1：`followed n=107 win 32.7% avg −1.86% CI [−3.25, −0.62]`。
读起来是「照建议做，显著亏钱」。

## 真相

`ledger._benefit()`：

```python
advantage = -underlying if action in SELL_ACTIONS else underlying
```

`hold_and_watch` 不在 `SELL_ACTIONS` 里，所以**它的 benefit 就是标的自己的涨跌**。
8 月 166 条决策里 **103 条是 hold**，而这本账 −28% 到 −66%。**下跌市里的 hold 必然
记 loss，无论那个 hold 判得对不对。**

代码自己其实知道（2113 行注释：「`active` 单列，免得 passive 的 beta 冒充 cut/trim/add
有 alpha」），只是**没有 passive 列可对照**，而且 `followed` 把两者混在一起。

## 在同一份真实数据上拆开

| 列 | n | 胜率 | avg | CI95 |
|---|---|---|---|---|
| all | 178 | 41.6% | −1.42% | [−2.66, −0.39] |
| active | 73 | 54.8% | −0.81% | [−3.43, 1.68] |
| **passive** | **105** | **32.4%** | **−1.84%** | **[−3.23, −0.64]** |
| followed | 107 | 32.7% | −1.86% | [−3.25, −0.62] |
| **followed_active** | **6** | 33.3% | −6.42% | **[−18.14, +2.20]** |

**`followed` 就是 `passive` 加六条。** 那个「显著为负」是 beta。
而它看起来在回答的那个问题，真实样本是 **n=6、CI 跨零**——什么都说不了。

（顺带看见的一件事：107 条 followed 里 101 条是 passive。「照做」这一列很大程度上
在统计「什么都没做，而本来也该什么都不做」。）

## 为什么是「单列」不是「换基准」

issue 里给了两个方案，选单列并说明理由：**换基准算不出来**。
`benchmark.json` 只保 60 天窗口（自 2026-06-29），而 episode 从 **2026-05-17** 开始——
样本的前六周没有基准可相对。硬做等于给一半样本编一个基准。

## 修法

- 新增 `passive` 列（把 beta 显式摆出来）
- 新增 `followed_active`（照做过的、且确实是「做点什么」的决策）
- `followed` **保持原义不动**（读者连续性；悄悄改一列的含义比不改更糟）
- 新增 `measures` 映射，**逐列写明它量的是什么** —— 把 `followed` 当「建议有没有用」
  的读者不是粗心，他读的是一个没有声明含义的列名

## 验证

`tests/test_passive_benefit_split.py` 5 条：
- 构造「−5% 行情里十个 hold + 两笔赚钱的 cut」：`passive` = −5.0，
  **`followed_active` = +3.0** —— 旧列把这两笔对的砍单埋在行情底下
- passive + active 必须等于 all（是划分不是追加）
- `followed_active` 必须同时是 active 与 followed 的子集
- **每一列都必须在 `measures` 里有说明，且说明里的列必须真的被发布**
- 动作词表必须用共享的 `PASSIVE_ACTIONS`，不许本地再抄一份（#1089 同一判据）

全量套件 **2756 passed / 5 skipped / 4 xfailed / 0 failed**。

Closes #1087

Claude-Session: https://claude.ai/code/session_01HfFyqAUBniTsSHR5SBm3ig

