### PR TITLE
fix: earnings annual 节奏也要 ≥4 个可比期 (#1097)

### DIFF
--- a/src/clawock/decision/earnings.py
+++ b/src/clawock/decision/earnings.py
@@ -47,7 +47,9 @@ SOURCE_CLASSES = PRIMARY_SOURCES | STRUCTURED_SOURCES | THIRD_PARTY_SOURCES
 # a separate basis and may never be compared against a GAAP one.
 BASES = {"GAAP", "IFRS", "HKFRS", "non_GAAP"}
 MARKET_BASES = {"US": {"GAAP", "non_GAAP"}, "HK": {"IFRS", "HKFRS", "non_GAAP"}}
-CADENCES = {"quarterly": 4, "semiannual": 4, "annual": 3}
+# README 契约:盈利质量从「至少四个可比期」算。每个节奏都要求 ≥4 期——
+# annual 发行人也需要四个财年(曾为 3,与文档口径不一致,见 #1097)。
+CADENCES = {"quarterly": 4, "semiannual": 4, "annual": 4}
 FOOTNOTE_CATEGORIES = {
     "related_party", "contingency", "accounting_policy_change",
     "goodwill_intangibles", "customer_concentration", "supplier_concentration",

--- a/tests/test_earnings_review.py
+++ b/tests/test_earnings_review.py
@@ -97,6 +97,20 @@ def test_short_history_and_out_of_order_history_fail(us):
     )
 
 
+def test_annual_cadence_also_needs_four_comparable_periods(us):
+    # README 契约是「至少四个可比期」,对 annual 发行人也一样(#1097):
+    # 三个财年的可比期必须被拒。
+    assert er.CADENCES == {"quarterly": 4, "semiannual": 4, "annual": 4}
+    annual = copy.deepcopy(us)
+    annual["cadence"] = "annual"
+    annual["comparables"] = annual["comparables"][:3]
+    errors = er.validate_artifact(annual, now=NOW)
+    assert any(
+        "annual cadence needs at least 4 comparable periods" in error
+        for error in errors
+    )
+
+
 def test_period_and_publication_dates_must_be_coherent(us):
     early = copy.deepcopy(us)
     early["published_at"] = "2026-01-05T20:05:00+00:00"


### PR DESCRIPTION
README 承诺「至少四个可比期」,代码 annual 只要求 3(quarterly/semiannual 是 4)。annual 提到 4,代码向文档契约对齐(更严格的质量闸);本地 32 passed,quarterly/semiannual 行为不变。