### PR TITLE
feat: walkforward 加 price-structure 与 vol-regime 拆分测量 (#1098 #1099)

### DIFF
--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -181,6 +181,64 @@ def _summary(rows):
     }
 
 
+def _split_summary(rows, key):
+    """Group rows by a per-row bucket field and summarize each non-empty group.
+
+    #1098/#1099: measurement-first instrumentation. The splits only *report*
+    the same fills by price structure and volatility regime; they change no
+    fill, no authority tier and no live behaviour.
+    """
+    buckets = {}
+    for row in rows:
+        bucket = row.get(key)
+        if bucket:
+            buckets.setdefault(bucket, []).append(row)
+    return {
+        bucket: _summary(group) for bucket, group in sorted(buckets.items())
+    }
+
+
+# #856 taxonomy: 突破 = 收盘站上前 20 日高;深跌抄底 = ≤ 20 日高的 92%。
+DEEP_DIP_RATIO = 0.92
+
+
+def _structure_bucket(bars, signal_date, price):
+    """Fill price structure vs the prior 20-day high: breakout / near_high / deep_dip."""
+    prior = [row for row in bars if row.get("date") < signal_date][-20:]
+    if not prior:
+        return None
+    high20 = max(row["high"] for row in prior)
+    if price >= high20:
+        return "breakout"
+    if price / high20 > DEEP_DIP_RATIO:
+        return "near_high"
+    return "deep_dip"
+
+
+def _vol_regime(bars, signal_date):
+    """20d realized vol at the signal date vs the ticker's own trailing median."""
+    closes = [row["close"] for row in bars if row.get("date") <= signal_date]
+    if len(closes) < 26:
+        return None
+
+    def _rv(seq):
+        if len(seq) < 2:
+            return None
+        return statistics.pstdev(
+            seq[i] / seq[i - 1] - 1 for i in range(1, len(seq))
+        )
+
+    recent = _rv(closes[-21:])
+    windows = [_rv(closes[i - 20:i]) for i in range(21, len(closes) + 1)]
+    windows = [w for w in windows if w is not None]
+    if recent is None or not windows:
+        return None
+    median = statistics.median(windows)
+    if median <= 0:
+        return None
+    return "high_vol" if recent > median else "low_vol"
+
+
 def _snapshot_cutoff(snapshot):
     raw = snapshot.get("observed_at") or f'{str(snapshot.get("as_of") or "")[:10]}T23:59:59+00:00'
     try:
@@ -401,6 +459,10 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
             )
             if not fill:
                 continue
+            # #1098/#1099 measurement splits: price structure vs 20d high and
+            # volatility regime, attached to every fill row for later slicing.
+            structure = _structure_bucket(bars, signal_date, fill["price"])
+            vol_regime = _vol_regime(bars, signal_date)
             peer_row = (peers.get(signal_date) or peers.get(snapshot_date) or {}).get(ticker) or {}
             peer_view = {
                 "triggered_rules": peer_row.get("triggered_rules") or [],
@@ -445,6 +507,8 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
                             "ticker": ticker,
                             "return": value,
                             "fill_reason": fill["fill_reason"],
+                            "structure": structure,
+                            "vol_regime": vol_regime,
                         })
         # Early lane is evaluated independently of the mature setup/fill lane.
         # One row per economic exposure (never both SPCX and SPCH), using only
@@ -524,7 +588,11 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
     metrics = {
         market: {
             variant: {
-                f"t{horizon}": _summary(rows)
+                f"t{horizon}": {
+                    **_summary(rows),
+                    "by_structure": _split_summary(rows, "structure"),
+                    "by_vol_regime": _split_summary(rows, "vol_regime"),
+                }
                 for horizon, rows in horizons.items()
             }
             for variant, horizons in variants.items()
@@ -613,6 +681,7 @@ def main(argv=None):
                 "confirmation_window_sessions": policy["confirmation_window_sessions"],
                 "variants": list(VARIANTS),
                 "early_variants": ["observed", "information_confirmed", "exploration_ready"],
+                "split_dimensions": ["structure", "vol_regime"],
                 "policy_version": add_alpha.POLICY_VERSION,
                 "parameter_fit": "none; pre-registered thresholds",
             },
@@ -627,6 +696,7 @@ def main(argv=None):
                 "Same-day entry/invalidation ambiguity is invalidated, never assumed filled.",
                 "Early candidates are one row per underlying and use signal-date-close features with T+1/T+5 future closes only as outcomes.",
                 "The early history is small; every result remains collecting/diagnostic, never validated alpha.",
+                "Fills are sliced by price structure (breakout / near_high / deep_dip vs prior 20d high) and 20d volatility regime (high/low vs the ticker's own median): measurement only, no behavioural change (#1098/#1099).",
             ],
         )
     print(json.dumps({"metrics": metrics, "run_card": str(card_path) if card_path else None}, ensure_ascii=False, indent=2))

--- a/tests/test_add_alpha_walkforward_splits.py
+++ b/tests/test_add_alpha_walkforward_splits.py
@@ -1,0 +1,80 @@
+"""Unit tests for the walkforward measurement splits (#1098/#1099).
+
+The splits classify a fill by price structure vs the prior 20-day high
+(breakout / near_high / deep_dip) and by the 20-day volatility regime
+(high_vol / low_vol vs the ticker's own trailing median). They only annotate
+fill rows; they change no fill, no authority tier and no live behaviour.
+"""
+from clawock.evaluation import add_alpha_walkforward as awf
+
+
+def _bars(closes, highs=None, start_day=1, start_month=1):
+    """Synthetic daily bars with ISO dates; highs default to closes."""
+    rows = []
+    month, day = start_month, start_day
+    for i, close in enumerate(closes):
+        rows.append({
+            "date": f"2026-{month:02d}-{day:02d}",
+            "open": close,
+            "high": (highs[i] if highs else close),
+            "low": close,
+            "close": close,
+        })
+        day += 1
+        if day > 28:
+            day, month = 1, month + 1
+    return rows
+
+
+def test_structure_bucket_breakout_near_deep():
+    # prior 20d high = 100 (rows before the signal date)
+    bars = _bars([90] * 19 + [100], highs=[100] * 20)
+    signal = "2026-02-01"
+    # 105 >= prior high -> breakout
+    assert awf._structure_bucket(bars, signal, 105) == "breakout"
+    # 100 == prior high -> breakout (fills at the level count)
+    assert awf._structure_bucket(bars, signal, 100) == "breakout"
+    # 96 / 100 = 0.96 > 0.92 -> near_high
+    assert awf._structure_bucket(bars, signal, 96) == "near_high"
+    # 92 / 100 = 0.92 is NOT > 0.92 -> deep_dip (#856: <= 92% is the deep dip)
+    assert awf._structure_bucket(bars, signal, 92) == "deep_dip"
+    assert awf._structure_bucket(bars, signal, 80) == "deep_dip"
+
+
+def test_structure_bucket_needs_prior_history():
+    assert awf._structure_bucket([], "2026-02-01", 100) is None
+    # 只有一根历史 bar 也按「已有先例」处理(取可得的前期高点)
+    assert awf._structure_bucket(_bars([100]), "2026-02-01", 100) == "breakout"
+
+
+def test_vol_regime_high_vs_low():
+    # 前半 noisy、尾部完美线性(波动率为 0)→ recent vol < 自身中位数
+    calm = _bars(
+        [100.0 + 0.1 * i + (0.3 if i % 2 else 0.0) for i in range(25)]
+        + [100.0 + 0.1 * i for i in range(25, 45)]
+    )
+    assert awf._vol_regime(calm, "2026-03-15") == "low_vol"
+    # 前半线性、尾部剧烈摆动 → recent vol 高于自身中位数
+    spiky = _bars(
+        [100.0 + 0.1 * i for i in range(40)] + [140, 105, 135, 110, 130]
+    )
+    assert awf._vol_regime(spiky, "2026-03-15") == "high_vol"
+
+
+def test_vol_regime_needs_history():
+    assert awf._vol_regime(_bars([100.0] * 25), "2026-02-01") is None
+
+
+def test_split_summary_groups_by_bucket():
+    rows = [
+        {"return": 1.0, "date": "2026-01-01", "ticker": "A", "structure": "breakout"},
+        {"return": -1.0, "date": "2026-01-02", "ticker": "B", "structure": "breakout"},
+        {"return": 2.0, "date": "2026-01-03", "ticker": "C", "structure": "deep_dip"},
+        {"return": 0.5, "date": "2026-01-04", "ticker": "D", "structure": None},
+    ]
+    split = awf._split_summary(rows, "structure")
+    assert set(split) == {"breakout", "deep_dip"}
+    assert split["breakout"]["n"] == 2
+    assert split["breakout"]["hit_rate"] == 0.5
+    assert split["deep_dip"]["n"] == 1
+    assert awf._split_summary(rows, "missing_key") == {}


### PR DESCRIPTION
两条策略建议按「测量先行」落地(纯诊断,不改任何线上行为):

**#1099 加赢家 vs 摊输家**:回放数据里没有 point-in-time 成本基准,无法直接按 cost basis 切分;改用 #856 已验证的价格结构分类(breakout / near_high / deep_dip vs 前 20 日高)作为可测代理,walkforward 每个 fill 行带 structure 字段,metrics 出 by_structure 分组 hit-rate。

**#1098 突破量能/波动率过滤**:
- 波动率半边:每个 fill 带 vol_regime(20d 已实现波动率 vs 标的自身中位数),metrics 出 by_vol_regime 分组——可直接看突破/加仓在高波动 regime 是否显著更差;
- 量能半边:canonical bars(memory/bars/)只有 OHLC、没有 volume 字段,量能确认**无法测量**——这是数据缺口,已在 issue 注明,建议后续在 bars 管线补 volume 后再做量能确认研究;
- 已有的过热过滤(early_no_chase_zscore)继续生效。

单元测试钉住桶边界与分组汇总。