### PR TITLE
feat: commit 身份闸——拒绝裸 username@users.noreply.github.com (#1108)

### DIFF
--- a/.githooks/_identity_check.sh
+++ b/.githooks/_identity_check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# clawock commit-identity whitelist — sourced by pre-commit and pre-push.
+#
+# 2026-08-27: one commit was authored as `kcn@users.noreply.github.com`
+# (bare username noreply, no numeric ID prefix); GitHub attributed it to a
+# stranger's account of the same name. Only these identities are valid:
+#   KCNyu <shengyu.li.evgeny@gmail.com>
+#   KCNyu <45508369+KCNyu@users.noreply.github.com>
+#   any    <ID+user@users.noreply.github.com>  (github-actions[bot],
+#            dependabot[bot], and other ID-prefixed noreply accounts)
+
+IDENTITY_RE='^[0-9]+\+[^@]+@users\.noreply\.github\.com$'
+
+_identity_ok() {
+  local email="$1"
+  [ "$email" = "shengyu.li.evgeny@gmail.com" ] && return 0
+  [ "$email" = "45508369+KCNyu@users.noreply.github.com" ] && return 0
+  printf '%s' "$email" | grep -qE "$IDENTITY_RE" && return 0
+  return 1
+}
+
+# check_identities "<Name <email>>" ... — prints violations, returns 1 if any.
+check_identities() {
+  local bad=0 ident email
+  for ident in "$@"; do
+    email="$(printf '%s' "$ident" | sed -n 's/^.*<\([^>]*\)>.*$/\1/p')"
+    if ! _identity_ok "$email"; then
+      echo "    ✗ unrecognized commit identity <$email>"
+      echo "      valid: KCNyu (shengyu.li.evgeny@gmail.com) or"
+      echo "      <ID>+<user>@users.noreply.github.com (ID-prefixed noreply only)"
+      bad=1
+    fi
+  done
+  return $bad
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,6 +15,21 @@ cd "$WS"
 STAGED=$(git diff --cached --name-only --diff-filter=ACM)
 
 # ──────────────────────────────────────────────────────────────────────────
+# 0. Commit identity — author/committer must map to a known account
+#    (2026-08-27: a bare `kcn@users.noreply.github.com` commit was attributed
+#    by GitHub to a stranger's account; the ID-prefixed noreply format or the
+#    KCNyu gmail are the only valid identities)
+# ──────────────────────────────────────────────────────────────────────────
+. "$(dirname "$0")/_identity_check.sh"
+AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-$(git var GIT_AUTHOR_IDENT | sed -n 's/^.*<\([^>]*\)>.*$/\1/p')}"
+COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$(git var GIT_COMMITTER_IDENT | sed -n 's/^.*<\([^>]*\)>.*$/\1/p')}"
+if ! check_identities "<$AUTHOR_EMAIL>" "<$COMMITTER_EMAIL>"; then
+  echo "    fix: git -c user.name=KCNyu -c user.email=shengyu.li.evgeny@gmail.com"
+  echo "         commit --amend --reset-author"
+  exit 1
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
 # 1. portfolio.json — must be valid JSON + have required structure
 # ──────────────────────────────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE '^portfolio\.json$'; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,6 +24,27 @@ if [ -n "$UPDATES" ] && ! printf '%s\n' "$UPDATES" | awk '$3 == "refs/heads/mast
   exit 0
 fi
 
+# ──────────────────────────────────────────────────────────────────────────
+# Identity whitelist on the pushed range (author AND committer).
+# 2026-08-27: a bare `kcn@users.noreply.github.com` commit pushed to master
+# was attributed by GitHub to a stranger's account.
+# ──────────────────────────────────────────────────────────────────────────
+. "$(dirname "$0")/_identity_check.sh"
+PUSHED_IDENTS="$(printf '%s\n' "$UPDATES" | \
+  awk '$3 == "refs/heads/master" && $4 !~ /^0+$/ { print $2, $4 }' | \
+  while read -r lsha rsha; do
+    git log --format='%an <%ae>|%cn <%ce>' "$rsha..$lsha" 2>/dev/null
+  done)"
+if [ -n "$PUSHED_IDENTS" ]; then
+  if ! printf '%s\n' "$PUSHED_IDENTS" | tr '|' '\n' | sort -u | \
+      while read -r ident; do check_identities "$ident"; done; then
+    echo "🚫 push blocked — a pushed commit carries an unrecognized identity"
+    echo "   fix: git commit --amend --author='KCNyu <shengyu.li.evgeny@gmail.com>'"
+    echo "   Override (rare): git push --no-verify"
+    exit 1
+  fi
+fi
+
 # A missing checker used to `exit 0` here, which did two wrong things at once:
 # it read "the checker is absent" as "the checks passed", and because this sits
 # ABOVE the money gate it also took preflight_integrity down with it — two

--- a/tests/test_commit_identity_guard.py
+++ b/tests/test_commit_identity_guard.py
@@ -1,0 +1,126 @@
+"""Commit-identity guard: bare `username@users.noreply.github.com` must fail.
+
+2026-08-27: one commit authored as `kcn@users.noreply.github.com` (bare
+username noreply, no numeric ID prefix) was attributed by GitHub to a
+stranger's account of the same name. The pre-commit and pre-push hooks now
+refuse every identity outside the whitelist: KCNyu's two addresses, or any
+ID-prefixed users.noreply.github.com address (github-actions[bot],
+dependabot[bot], ...).
+"""
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+GOOD_EMAILS = (
+    "shengyu.li.evgeny@gmail.com",
+    "45508369+KCNyu@users.noreply.github.com",
+    "41898282+github-actions[bot]@users.noreply.github.com",
+    "49699333+dependabot[bot]@users.noreply.github.com",
+)
+BAD_EMAILS = (
+    "kcn@users.noreply.github.com",        # bare username noreply — the 08-27 bug
+    "root@localhost.localdomain",          # the 08-27 openinference identity leak
+    "someone@example.com",
+)
+
+
+def _git(repo, *args, check=True, env=None, input=None):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=check,
+        capture_output=True, text=True, env=env, input=input)
+
+
+def _repo(tmp_path):
+    _git(tmp_path, "init", "-q")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir(exist_ok=True)
+    # absolute path: git resolves a relative core.hooksPath against the cwd
+    # of the invoking process, which in pytest is not the repo
+    _git(tmp_path, "config", "core.hooksPath", str(hooks))
+    (hooks / "pre-commit").write_text((ROOT / ".githooks" / "pre-commit").read_text())
+    (hooks / "pre-push").write_text((ROOT / ".githooks" / "pre-push").read_text())
+    (hooks / "_identity_check.sh").write_text(
+        (ROOT / ".githooks" / "_identity_check.sh").read_text())
+    for name in ("pre-commit", "pre-push", "_identity_check.sh"):
+        (hooks / name).chmod(0o755)
+    (tmp_path / "file.txt").write_text("x\n")
+    _git(tmp_path, "add", "file.txt")
+    return tmp_path
+
+
+def _commit(repo, email, name="Tester", no_verify=False):
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,
+           "GIT_COMMITTER_NAME": name, "GIT_COMMITTER_EMAIL": email}
+    args = ["commit", "-qm", "test"]
+    if no_verify:
+        args.insert(1, "--no-verify")
+    return _git(repo, *args, env=env, check=False)
+
+
+def test_bare_noreply_email_is_rejected(tmp_path):
+    repo = _repo(tmp_path)
+    result = _commit(repo, "kcn@users.noreply.github.com")
+    assert result.returncode != 0
+    assert "unrecognized commit identity" in (result.stdout + result.stderr)
+
+
+def test_foreign_and_localhost_emails_are_rejected(tmp_path):
+    for email in ("someone@example.com", "root@localhost.localdomain"):
+        repo = _repo(tmp_path)
+        result = _commit(repo, email)
+        assert result.returncode != 0, email
+        assert "unrecognized commit identity" in (result.stdout + result.stderr)
+
+
+def test_whitelisted_identities_are_allowed(tmp_path):
+    for i, email in enumerate(GOOD_EMAILS):
+        repo = _repo(tmp_path)
+        (repo / f"f{i}.txt").write_text("y\n")
+        _git(repo, "add", f"f{i}.txt")
+        result = _commit(repo, email)
+        assert result.returncode == 0, (email, result.stdout + result.stderr)
+
+
+def test_pre_push_rejects_bad_identity_in_the_pushed_range(tmp_path):
+    """The phantom commit reached master by push; pre-push must scan the range.
+
+    The hook is invoked directly like the other contract tests, with the
+    update line Git would feed it: master updated from seed to a commit whose
+    author email is the bare noreply form.
+    """
+    repo = _repo(tmp_path)
+    _commit(repo, "shengyu.li.evgeny@gmail.com")  # seed commit (good identity)
+    seed = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    # create the bad commit bypassing pre-commit (which already refuses it)
+    (repo / "bad.txt").write_text("z\n")
+    _git(repo, "add", "bad.txt")
+    _commit(repo, "kcn@users.noreply.github.com", no_verify=True)
+    bad = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert bad != seed
+    hook = repo / "hooks" / "pre-push"
+    result = subprocess.run(
+        ["bash", str(hook)], cwd=repo, capture_output=True, text=True,
+        input=f"refs/heads/master {bad} refs/heads/master {seed}\n")
+    assert result.returncode != 0
+    assert "unrecognized identity" in result.stdout
+
+
+def test_pre_push_allows_good_identity_range(tmp_path):
+    repo = _repo(tmp_path)
+    _commit(repo, "shengyu.li.evgeny@gmail.com")  # seed commit (good identity)
+    seed = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    (repo / "more.txt").write_text("y\n")
+    _git(repo, "add", "more.txt")
+    _commit(repo, "shengyu.li.evgeny@gmail.com")
+    good = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert good != seed
+    hook = repo / "hooks" / "pre-push"
+    result = subprocess.run(
+        ["bash", str(hook)], cwd=repo, capture_output=True, text=True,
+        input=f"refs/heads/master {good} refs/heads/master {seed}\n")
+    # no checker + no portfolio.json in the fixture → the rest of the hook
+    # takes the permissive path; the identity gate must not block it
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_hook_entrypoints_can_import_clawock.py
+++ b/tests/test_hook_entrypoints_can_import_clawock.py
@@ -43,10 +43,10 @@ def _stripped_env(repo: Path) -> dict:
     return {
         "PATH": "/usr/bin:/bin",
         "HOME": str(repo),
-        "GIT_AUTHOR_NAME": "t",
-        "GIT_AUTHOR_EMAIL": "t@example.com",
-        "GIT_COMMITTER_NAME": "t",
-        "GIT_COMMITTER_EMAIL": "t@example.com",
+        "GIT_AUTHOR_NAME": "KCNyu",
+        "GIT_AUTHOR_EMAIL": "shengyu.li.evgeny@gmail.com",
+        "GIT_COMMITTER_NAME": "KCNyu",
+        "GIT_COMMITTER_EMAIL": "shengyu.li.evgeny@gmail.com",
     }
 
 
@@ -65,6 +65,9 @@ def repo_with_staged_plan(tmp_path):
     hooks.mkdir()
     shutil.copy2(HOOK, hooks / "pre-commit")
     (hooks / "pre-commit").chmod(0o755)
+    shutil.copy2(ROOT / ".githooks" / "_identity_check.sh",
+                 hooks / "_identity_check.sh")
+    (hooks / "_identity_check.sh").chmod(0o755)
 
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     subprocess.run(["git", "config", "core.hooksPath", ".githooks"], cwd=repo, check=True)

--- a/tests/test_memory_lives_on_the_host.py
+++ b/tests/test_memory_lives_on_the_host.py
@@ -107,6 +107,11 @@ def test_the_pre_commit_hook_refuses_staged_memory(tmp_path):
     hook.write_text((ROOT / ".githooks" / "pre-commit").read_text(encoding="utf-8"),
                     encoding="utf-8")
     hook.chmod(0o755)
+    identity = repo / ".githooks" / "_identity_check.sh"
+    identity.write_text(
+        (ROOT / ".githooks" / "_identity_check.sh").read_text(encoding="utf-8"),
+        encoding="utf-8")
+    identity.chmod(0o755)
     _git(repo, "config", "core.hooksPath", ".githooks")
 
     (repo / "MEMORY.md").write_text("index\n", encoding="utf-8")
@@ -117,7 +122,8 @@ def test_the_pre_commit_hook_refuses_staged_memory(tmp_path):
 
     def commit():
         return subprocess.run(
-            ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+            ["git", "-C", str(repo), "-c", "user.email=shengyu.li.evgeny@gmail.com",
+             "-c", "user.name=KCNyu",
              "commit", "-m", "sweep"], capture_output=True, text=True)
 
     done = commit()

--- a/tests/test_pr_publish_gate_contract.py
+++ b/tests/test_pr_publish_gate_contract.py
@@ -205,14 +205,22 @@ def _ledger_repo(tmp_path, *, with_portfolio=True):
     return tmp_path
 
 
+def _install_prepush(repo):
+    """Copy pre-push plus the shared identity whitelist it sources."""
+    hook = repo / "pre-push"
+    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+    (repo / "_identity_check.sh").write_text(
+        (ROOT / ".githooks" / "_identity_check.sh").read_text())
+    return hook
+
+
 def test_pre_push_refuses_a_ledger_workspace_whose_checker_is_missing(tmp_path):
     """A missing checker used to `exit 0` — reading "absent" as "passed", and
     because that sits above the money gate it disarmed preflight_integrity too.
     Verified before the fix: system_check.py removed + an unreconciled book
     pushed clean."""
     repo = _ledger_repo(tmp_path)
-    hook = repo / "pre-push"
-    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+    hook = _install_prepush(repo)
 
     result = subprocess.run(["bash", str(hook)], cwd=repo, capture_output=True,
                             text=True, input="")
@@ -226,8 +234,7 @@ def test_pre_push_still_allows_a_repo_that_carries_no_money_file(tmp_path):
     """The fail-closed branch must not turn into a blanket block on any repo
     without the checker — only a ledger workspace is a broken install."""
     repo = _ledger_repo(tmp_path, with_portfolio=False)
-    hook = repo / "pre-push"
-    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+    hook = _install_prepush(repo)
 
     result = subprocess.run(["bash", str(hook)], cwd=repo, capture_output=True,
                             text=True, input="")
@@ -244,8 +251,7 @@ def test_pre_push_does_not_apply_master_ledger_gates_to_data_plane(tmp_path):
     deleting the hook body cannot satisfy both assertions.
     """
     repo = _ledger_repo(tmp_path)
-    hook = repo / "pre-push"
-    hook.write_text((ROOT / ".githooks" / "pre-push").read_text())
+    hook = _install_prepush(repo)
     zero = "0" * 40
     one = "1" * 40
 


### PR DESCRIPTION
背景:#1108 中一个用裸用户名 noreply 邮箱(kcn@users.noreply.github.com、无数字 ID 前缀)的提交被 GitHub 归因给 2014 年注册的陌生账号。根因是 git 身份配置不跟随 worktree(agent 在 worktree 里猜了邮箱)。

改动:
- `.githooks/_identity_check.sh`:共享白名单——KCNyu 两个合法邮箱 + 任何 ID 前缀 noreply(github-actions[bot]/dependabot[bot])
- `.githooks/pre-commit`:作者+提交者双校验,拒绝即拦 commit
- `.githooks/pre-push`:扫描推到 master 的 commit 范围,非白名单身份拒 push
- `tests/test_commit_identity_guard.py`:5 条(拒裸 noreply/root@localhost/陌生邮箱、放行白名单、pre-push 范围正反例)

Closes #1108
