### PR TITLE
examples: prove the foreign-workspace workflow run from an installed wheel (#1111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,6 +672,52 @@ jobs:
       - name: FX fallback chain
         run: python3 ops/ci/smoke_fx.py
 
+  portable-workflow:
+    # The headline claim, executed against a built wheel on every PR (#1111).
+    #
+    # `release.yml` already runs the two isolated examples, but only at tag
+    # time: a PR could break "a stranger can install this and finish a run" and
+    # nothing would say so until someone cut a version. And what those two
+    # scripts prove is the *base* loop — `init` with no workflow pinned,
+    # publishing a literal `{"answer":"smoke"}`. The investment-decision
+    # contract, which is what the README sells (`workflow install` -> `init
+    # --workflow` -> a real `decision.json`), was only ever exercised inside
+    # this checkout by `tests/test_portable_workflow.py`. A gate that lives in
+    # this repository's test suite is a promise about this repository.
+    #
+    # Runs on every PR rather than behind the code lane: the claim this backs
+    # is a documentation claim as much as a code one, so a docs-only PR that
+    # rewrites the "Run it on your own book" block must still face it. ~40s.
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    needs: validate
+    if: >-
+      ${{ github.event_name == 'pull_request'
+          || needs.validate.outputs.code == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same install as release.yml's build job — `build` is declared in the
+      # `release` extra, not hand-written here (tests/test_workspace_portability
+      # refuses a package list growing back into a workflow). The editable
+      # install lands in the runner's interpreter; the scripts below run in
+      # their own virtualenv and assert that the `clawock` they import came
+      # from it, so this cannot be what makes them pass.
+      - name: Set up clawock (Python)
+        uses: ./.github/actions/clawock-python
+        with:
+          install: '.[release]'
+
+      - name: Build the wheel under test
+        run: python -m build --wheel --outdir dist
+
+      - name: Foreign workspace publishes a real decision.json
+        run: examples/cli/workflow-run/run.sh dist/*.whl
+
+      - name: Isolated install completes one base run
+        # The release-time check, moved forward to the PR that would break it.
+        run: examples/cli/minimal-run/run.sh dist/*.whl
+
   analyze:
     # Was codeql.yml — advanced setup replacing GitHub's default (#782).
     #

--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ runtime. The emitted request is for the external agent to consume. The agent
 writes `decision.json`; `clawock run publish` validates it and emits the
 correlated generation receipt. The packaged example can smoke the lifecycle
 without a model (`bash examples/cli/minimal-run/run.sh`), and
+[`examples/cli/workflow-run/run.sh`](https://github.com/KCNyu/clawock/blob/master/examples/cli/workflow-run/run.sh)
+runs the four commands above verbatim on every pull request — clean virtualenv,
+emptied environment, wheel only — publishing a real `decision.json` taken from
+the pack the wheel installs, and checking that a decision with its opposing case
+removed is still *refused* in a directory that has never seen this repository.
 [`examples/`](https://github.com/KCNyu/clawock/blob/master/examples/README.md) shows the
 same run driven from a pure CLI, an OpenClaw skill, a Claude Code instruction, a Codex AGENTS.md,
 and a DeepSeek Harness agent — the harness never touches the contract.

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,8 @@ harness's way in, and the contract never changes between them.
 | harness | how the agent participates | file | copy to |
 |---|---|---|---|
 | CLI (no model) | a literal stands in for the agent; proves the whole loop with no model and no pinned workflow | [`cli/run.sh`](cli/run.sh) | run as-is |
-| CLI (isolated install) | clean virtualenv installs the wheel and finishes one complete run — `init` → `run prepare` → `run publish` — with no checkout, no Git, no OpenClaw and an emptied environment; exercised by `release.yml` | [`cli/minimal-run/run.sh`](cli/minimal-run/run.sh) | run as-is |
+| CLI (isolated install) | clean virtualenv installs the wheel and finishes one complete run — `init` → `run prepare` → `run publish` — with no checkout, no Git, no OpenClaw and an emptied environment; exercised by `release.yml` and by `ci.yml` on every pull request | [`cli/minimal-run/run.sh`](cli/minimal-run/run.sh) | run as-is |
+| CLI (foreign workspace) | the README's own "run it on your own book" order — `workflow install` into a directory that is not a workspace yet, `init --workflow`, then a real `decision.json` from the installed pack; asserts the contract gate refuses a one-sided decision from the wheel too | [`cli/workflow-run/run.sh`](cli/workflow-run/run.sh) | run as-is |
 | OpenClaw | a SKILL.md tells the agent to read `request.json` and write `decision.json` | [`openclaw/SKILL.md`](openclaw/SKILL.md) | `<workspace>/skills/investment-decision/SKILL.md` |
 | Claude Code | a CLAUDE.md instruction block, auto-loaded per workspace | [`claude-code/CLAUDE.md`](claude-code/CLAUDE.md) | `<workspace>/CLAUDE.md` |
 | Codex | an AGENTS.md instruction block, auto-loaded from the workspace root | [`codex/AGENTS.md`](codex/AGENTS.md) | `<workspace>/AGENTS.md` |

--- a/examples/cli/workflow-run/run.sh
+++ b/examples/cli/workflow-run/run.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# The README headline, executed: a stranger installs the package, installs the
+# decision workflow into their OWN directory, and publishes a real
+# `decision.json` — with this repository nowhere in the picture.
+#
+# `cli/minimal-run/run.sh` already proves the *base* loop from a wheel, but it
+# runs `init` with no workflow pinned and publishes a literal `{"answer":"smoke"}`.
+# That leaves the part the product is actually sold on unproven (#1111): that
+# `clawock workflow install investment-decision` ships the pack, its example
+# artifact and its validators inside the wheel, and that the contract gates fire
+# in a foreign workspace rather than only in this checkout's test suite.
+#
+# So this script asserts both directions:
+#   • a valid decision publishes             -> status: published
+#   • a decision with its opposing case cut   -> status: rejected, non-zero exit,
+#     naming `insufficient_opposing_evidence` and `unsupported_bear_case`
+#
+# The negative half is the one that matters. A gate that only exists in
+# `tests/test_portable_workflow.py` is a promise about this repository; the same
+# gate refusing a bad decision from an installed wheel, in `/tmp`, under `env -i`,
+# is a promise about the package.
+#
+# `env -i` clears the environment for every clawock call (and redirects HOME), so
+# a pass cannot come from a variable this machine happens to export — including a
+# PYTHONPATH or CLAWOCK_WORKSPACE pointing back at a checkout.
+#
+# Usage:
+#   examples/cli/workflow-run/run.sh                 # install clawock from PyPI
+#   examples/cli/workflow-run/run.sh dist/*.whl      # install the artifact under test
+set -euo pipefail
+
+wheel="${1:-}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "==> installing into a clean virtualenv"
+python3 -m venv "$workdir/venv"
+if [ -n "$wheel" ]; then
+  "$workdir/venv/bin/pip" install --quiet "$wheel"
+else
+  "$workdir/venv/bin/pip" install --quiet clawock
+fi
+clawock="$workdir/venv/bin/clawock"
+python="$workdir/venv/bin/python"
+
+iso() { env -i PATH=/usr/bin:/bin HOME="$workdir/home" "$@"; }
+mkdir -p "$workdir/home" "$workdir/newuser"
+cd "$workdir/newuser"
+
+echo "==> the clawock under test is the installed one, not a source tree"
+# Cheap, but it is the assumption every assertion below rests on: if the import
+# resolved to a checkout (a stray .pth, a PYTHONPATH), this script would be
+# testing the repository while claiming to test the package.
+iso "$python" - "$workdir/venv" <<'PY'
+import sys, clawock
+venv = sys.argv[1]
+assert clawock.__file__.startswith(venv), f"clawock imported from {clawock.__file__}, not {venv}"
+print("   ", clawock.__file__)
+PY
+
+echo "==> clawock workflow install investment-decision"
+# Installs into a directory that is not yet a workspace, exactly as README's
+# "Run it on your own book" orders the two commands.
+iso "$clawock" workflow install investment-decision --workspace book > install.json
+"$python" - <<'PY'
+import json, pathlib
+report = json.load(open('install.json'))
+assert report['workflow'] == 'investment-decision', report
+skill = pathlib.Path(report['skill'])
+assert skill.is_file(), skill
+# The agent-facing example ships with the pack: without it a stranger has no
+# shape to fill in, and "any harness works" would still require this repository.
+example = skill.parent / 'assets' / 'decision.example.json'
+assert example.is_file(), example
+print('    pack installed at', skill.parent)
+PY
+
+echo "==> clawock init --workflow investment-decision"
+iso "$clawock" init book --workflow investment-decision
+cd book
+mkdir -p .clawock/work
+
+echo "==> clawock run prepare"
+iso "$clawock" run prepare > .clawock/work/request.json
+
+# The agent's answer. A real runtime writes model output here; the packaged
+# example stands in, and it comes from the INSTALLED pack rather than from this
+# repository — copying it out of the checkout would quietly reintroduce the
+# dependency this script exists to rule out.
+cp .agents/skills/investment-decision/assets/decision.example.json decision.json
+
+echo "==> clawock run publish (valid decision)"
+iso "$clawock" run publish \
+  --request .clawock/work/request.json \
+  --artifact decision.json=decision.json > receipt.json
+
+"$python" - <<'PY'
+import json
+receipt = json.load(open('receipt.json'))
+assert receipt['status'] == 'published', receipt
+assert receipt['workflow']['id'] == 'investment-decision', receipt
+names = {artifact['name'] for artifact in receipt['artifacts']}
+assert {'decision.json', 'manifest.json'} <= names, names
+print('    published', receipt['run_id'], 'workflow', receipt['workflow']['version'])
+PY
+
+echo "==> clawock run publish (opposing case removed) must be refused"
+# A fresh run: a request is consumed by the publish it certified.
+iso "$clawock" run prepare > .clawock/work/request2.json
+"$python" - <<'PY'
+import json
+decision = json.load(open('decision.json'))
+decision['evidence'] = [row for row in decision['evidence'] if row['stance'] != 'opposing']
+decision['debate']['bear_case']['evidence_ids'] = ['filing-growth']
+json.dump(decision, open('one-sided.json', 'w'))
+PY
+
+status=0
+iso "$clawock" run publish \
+  --request .clawock/work/request2.json \
+  --artifact decision.json=one-sided.json > rejected.json || status=$?
+[ "$status" -ne 0 ] || {
+  echo "a one-sided decision published from an installed wheel — the contract gate is not in the package" >&2
+  exit 1
+}
+
+"$python" - <<'PY'
+import json
+receipt = json.load(open('rejected.json'))
+assert receipt['status'] == 'rejected', receipt
+codes = {issue['code'] for issue in receipt['validation_issues']}
+assert {'insufficient_opposing_evidence', 'unsupported_bear_case'} <= codes, codes
+assert receipt['publish']['receipt'] is None and receipt['publish']['changed'] is False, receipt
+print('    refused:', sorted(codes))
+PY
+
+echo "foreign-workspace workflow run OK"

--- a/tests/test_examples_are_executed.py
+++ b/tests/test_examples_are_executed.py
@@ -17,13 +17,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 EXAMPLE = ROOT / 'examples' / 'cli' / 'minimal-run' / 'run.sh'
+# The same discipline one level up: the *workflow* run, which is what the README
+# actually sells (#1111). minimal-run proves the base loop; this one proves the
+# investment-decision contract travels inside the wheel.
+WORKFLOW_EXAMPLE = ROOT / 'examples' / 'cli' / 'workflow-run' / 'run.sh'
+ISOLATED = (EXAMPLE, WORKFLOW_EXAMPLE)
 RELEASE = ROOT / '.github' / 'workflows' / 'release.yml'
+CI = ROOT / '.github' / 'workflows' / 'ci.yml'
 
 
 def test_the_example_exists_and_is_executable():
-    assert EXAMPLE.exists(), 'the blueprint lists examples/; this is the first one'
-    mode = EXAMPLE.stat().st_mode
-    assert mode & stat.S_IXUSR, 'a proof a reader cannot run is not a proof'
+    for path in ISOLATED:
+        assert path.exists(), f'{path} is referenced by CI and by the README'
+        mode = path.stat().st_mode
+        assert mode & stat.S_IXUSR, 'a proof a reader cannot run is not a proof'
 
 
 def test_the_release_workflow_runs_the_example_rather_than_its_own_copy():
@@ -40,32 +47,77 @@ def test_the_release_workflow_runs_the_example_rather_than_its_own_copy():
         'the inline copy is back; there must be exactly one set of steps')
 
 
+def test_the_foreign_workspace_example_is_run_on_every_pull_request():
+    """A release-time-only proof is a proof about the tag, not about the change
+    that breaks it. Both isolated scripts now run in ci.yml, and the
+    workflow-run one runs on every PR — including a docs-only PR, because the
+    claim it backs ("Run it on your own book") is a README claim."""
+    workflow = CI.read_text()
+    block = workflow.split('\n  portable-workflow:', 1)
+    assert len(block) == 2, 'ci.yml must carry the portable-workflow job'
+    job = block[1].split('\n  analyze:', 1)[0]
+    assert 'examples/cli/workflow-run/run.sh' in job
+    assert 'examples/cli/minimal-run/run.sh' in job, (
+        'the release-time isolated run belongs on the PR that would break it')
+    assert "github.event_name == 'pull_request'" in job, (
+        'a docs-only PR must still face the claim it is editing')
+    assert job.count('dist/*.whl') == 2, (
+        'both scripts must run against the wheel this job just built, not '
+        'against whatever PyPI is serving today')
+
+
+def test_the_foreign_workspace_example_asserts_both_directions():
+    """Publishing a valid decision only shows the pack ships. The assertion that
+    carries the weight is the refusal: the contract gate firing from an
+    installed wheel, in a directory that has never seen this repository."""
+    script = WORKFLOW_EXAMPLE.read_text()
+    assert 'workflow install investment-decision' in script
+    assert "status'] == 'published'" in script
+    assert "status'] == 'rejected'" in script
+    for code in ('insufficient_opposing_evidence', 'unsupported_bear_case'):
+        assert code in script, f'the refusal must name {code}'
+    assert '$status" -ne 0' in script, (
+        'a rejected publish must also exit non-zero, or a caller that only '
+        'reads the exit code treats a refusal as a success')
+    # The example artifact has to come out of the installed pack. Copying it
+    # from the checkout would reintroduce exactly the dependency under test.
+    assert '.agents/skills/investment-decision/assets/decision.example.json' in script
+
+
 def test_the_example_clears_the_environment_for_every_call():
     """`env -i` is the substance of the claim. Without it a pass can come from a
     variable the runner happens to export, which is exactly how "works on my
     box" survives to a user."""
-    script = EXAMPLE.read_text()
-    assert 'env -i' in script
-    assert re.search(r'HOME="?\$\{?workdir', script), (
-        'HOME must be redirected too, or the run reads the caller dotfiles')
+    for path in ISOLATED:
+        script = path.read_text()
+        assert 'env -i' in script, path
+        assert re.search(r'HOME="?\$\{?workdir', script), (
+            f'{path.name}: HOME must be redirected too, or the run reads the '
+            'caller dotfiles')
 
 
 def test_the_example_does_not_reach_back_into_the_repository():
     """It proves the package works *without* this checkout, so referring to the
     source tree would make the proof circular."""
-    script = EXAMPLE.read_text()
-    for forbidden in ('src/clawock', 'PYTHONPATH', 'pip install -e',
-                      'git clone', '/root/'):
-        assert forbidden not in script, f'{forbidden!r} makes the proof circular'
+    for path in ISOLATED:
+        script = path.read_text()
+        for forbidden in ('src/clawock', 'pip install -e', 'git clone', '/root/'):
+            assert forbidden not in script, (
+                f'{path.name}: {forbidden!r} makes the proof circular')
+        # PYTHONPATH may be *named* (workflow-run asserts the import did not
+        # come from one), but never set.
+        assert not re.search(r'PYTHONPATH=', script), (
+            f'{path.name}: setting PYTHONPATH makes the proof circular')
 
 
 def test_the_example_installs_from_the_index_when_given_no_artifact():
     """The default path is what a stranger runs after #379 lands. CI passes the
     wheel under test instead, and both have to keep working."""
-    script = EXAMPLE.read_text()
-    assert 'pip" install --quiet clawock' in script or \
-           'pip install --quiet clawock' in script, (
-        'the no-argument path must install the published package')
+    for path in ISOLATED:
+        script = path.read_text()
+        assert 'pip" install --quiet clawock' in script or \
+               'pip install --quiet clawock' in script, (
+            f'{path.name}: the no-argument path must install the published package')
 
 
 def test_every_example_directory_is_listed_in_the_readme():


### PR DESCRIPTION
Closes #1111.

## What the issue was right about

The portability claim (README "Run it on your own book") had no end-to-end proof outside this checkout:

- `tests/test_portable_workflow.py` loads the pack via `load_workflow(...)` from the source tree.
- The two scripts that *do* run from a wheel — `examples/cli/run.sh` and `examples/cli/minimal-run/run.sh` — both run `clawock init` **with no workflow pinned** and publish a literal `{"answer":"smoke"}`. The investment-decision contract they exist to sell was never exercised from a package.
- Those two only run in `release.yml`, i.e. at tag time. A PR could break "a stranger can install this and finish a run" and nothing would say so until someone cut a version.

## What the issue was wrong about

The claim itself holds. Measured before writing the test, against a locally built `clawock-0.1.9` wheel in `/tmp` under `env -i`:

- `clawock workflow install investment-decision --workspace book` → installs the pack, including `assets/decision.example.json`
- `init --workflow` → `run prepare` → `run publish` → `status: published`, workflow `1.1.0`
- the same publish with the opposing evidence stripped → exit 1, `status: rejected`, `validation_issues` = `insufficient_opposing_evidence`, `unsupported_bear_case`, `missing_evidence_reference`, `publish.receipt: null`

So the acceptance is a lock, not a fix, and the README claim does not need softening.

## What ships

- **`examples/cli/workflow-run/run.sh`** — README's four commands verbatim in a clean virtualenv, `env -i`, `HOME` redirected. Asserts both directions (published / refused with a non-zero exit) and that the imported `clawock` came from the venv, so a stray `PYTHONPATH` cannot make the proof circular. The decision artifact is copied out of the *installed pack*, never out of this repository. ~8s locally.
- **`portable-workflow` job in ci.yml** — builds the wheel and runs both isolated scripts on **every PR**, including docs-only ones (the claim under test is a README claim as much as a code one). The `build` dependency comes from the declared `release` extra, so `test_workspace_portability` stays green.
- **tests** extended so the new script cannot rot: it must be executable, invoked by CI, run against the wheel the job built, keep `env -i` + `HOME` redirection, never reach back into the checkout, install from the index when given no artifact, and keep asserting the *refusal* codes.

Full suite green locally (2787 passed, 5 skipped, 4 xfailed); actionlint clean.
