### PR TITLE
quotes: a degraded quote must publish as degraded (#1116)

### DIFF
--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -1748,6 +1748,15 @@ def main(argv=None):
             print(f'   🟡 数据体检 {integrity["warn_count"]} WARN（见 integrity_report.json）')
         else:
             print('   ✅ 数据体检全过')
+        # 报价来源台账（#1116）：主源没覆盖满时说一句「今天这本账是谁定的价」。
+        # 不是告警（全本走 fallback 是常态，见 integrity 的 quote_sources 注释），
+        # 但它此前只存在于某次 cron 的 stdout 里，等于不存在。
+        for _region, _row in (integrity.get('quote_sources') or {}).items():
+            if _row['primary_priced'] < _row['active']:
+                _others = ', '.join(
+                    f'{src}×{len(ts)}' for src, ts in _row['by_source'].items())
+                print(f'   ℹ️ {_region} 报价 {_row["primary_priced"]}/{_row["active"]} '
+                      f'来自主源 {_row["primary"]}（{_others}）')
     except Exception as e:
         print(f'   ⚠ integrity check failed: {e}')
 

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -411,6 +411,33 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
         cost = h['cost_basis']
         shrs = h['shares']
 
+        # A fallback that cannot supply a prior close must not be allowed to
+        # invent one. stooq returns OHLC only, and `_fetch_stooq` fills `pc`
+        # with the session OPEN — writing that through stamps an open as
+        # `prev_close`, dates it to the previous HK session, and prints an
+        # intraday move as the daily change. Every downstream gate then agrees
+        # with it: TODAY_LEG reconciles (it checks arithmetic, not provenance)
+        # and STALE_PRICE stays quiet (an open rarely equals the close). That is
+        # the shape this repository keeps paying for — a degraded fetch that
+        # publishes as a healthy one (#1116).
+        #
+        # The prior close is a stored fact, not something today's quote has to
+        # carry. So the approximation is dropped and the holding's own
+        # `prev_close` is used, keeping its real `prev_close_date`: the day
+        # change then remains arithmetically consistent with what is published
+        # (TODAY_LEG still reconciles) while the date says which session it is
+        # measured from. When that stored close is older than the session we
+        # should be comparing against — or absent entirely — the day change is
+        # not today's, and the holding says so through the same
+        # `quote_incomplete` flag the US path already sets and integrity
+        # already surfaces.
+        approximated_pc = q.get('_pc_quality') == 'open-as-pc'
+        raw_pc = h.get('prev_close')
+        stored_pc = float(raw_pc) if isinstance(raw_pc, (int, float)) and raw_pc > 0 else None
+        if approximated_pc and stored_pc:
+            pc = stored_pc
+            q = dict(q, pc=pc, dp=_pct(c, pc))
+
         # 越界闸：current 必须落在本次行情自带的当日 [low, high] 内（同一条 gtimg 行，
         # 同源才有可比性 — 别拿可能陈旧的 h['day_low/high'] 残留值来判）。破位 = 供应商
         # 坏 tick（如 2026-06-15 03033 现价 4.5 跌破区间 [4.644,4.696]，与同标的 2x 的
@@ -425,13 +452,27 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
                 f"[{lo_q}, {hi_q}]（prev_close {pc}，疑似坏 tick — {breach}）")
 
         h['current_price']    = round(c, 3)
-        h['prev_close']       = round(pc, 3)
-        h['prev_close_date']  = hk_prev_session
-        h['today_change_pct'] = round(q['dp'], 2)
         h['current_value']    = round(c * shrs, 2)
         h['pnl_abs']          = round((c - cost) * shrs, 2)
         h['pnl_percent']      = round((c - cost) / cost * 100, 2) if cost else 0
-        h['today_change']     = round((c - pc) * shrs, 2)
+        if approximated_pc:
+            # Everything above comes from the price the fallback did give. The
+            # four fields below are the ones that need a prior close.
+            if stored_pc:
+                h['today_change_pct'] = round(q['dp'], 2)
+                h['today_change']     = round((c - pc) * shrs, 2)
+            incomplete = not stored_pc or h.get('prev_close_date') != hk_prev_session
+            if incomplete:
+                h['quote_incomplete'] = True
+            else:
+                h.pop('quote_incomplete', None)
+        else:
+            h['prev_close']       = round(pc, 3)
+            h['prev_close_date']  = hk_prev_session
+            h['today_change_pct'] = round(q['dp'], 2)
+            h['today_change']     = round((c - pc) * shrs, 2)
+            # A healthy fetch clears it; a flag nobody retires is its own defect.
+            h.pop('quote_incomplete', None)
         h['stock_name']       = q.get('name', h.get('stock_name', code))
         h['data_source']      = f"{q.get('_src', 'Tencent')} {now_hkt.strftime('%b %d %H:%M HKT')}"
         # Fallback sources do not consistently expose board lots. Preserve a
@@ -452,8 +493,12 @@ def update_hk_portfolio(dry_run: bool = False) -> Dict:
 
         updated.append(code)
         pnl_s = '+' if h['pnl_abs'] >= 0 else ''
+        # 没有可信前收时这一格就是空的，不拿别的数顶上（顶上去的那一刻它就
+        # 和一个真的当日涨跌长得一模一样了）。
+        day = h.get('today_change_pct')
+        day_s = f"{day:+.2f}%" if isinstance(day, (int, float)) else "当日涨跌未知"
         print(f"  {code} {q.get('name','')[:6]:6s}  HK${c:.3f}  "
-              f"({h['today_change_pct']:+.2f}%)  "
+              f"({day_s})  "
               f"P&L: {pnl_s}HK${h['pnl_abs']:.0f} ({pnl_s}{h['pnl_percent']:.1f}%)")
 
     if range_warns:

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -39,6 +39,13 @@ cost_basis/prev_close/trades[])复原，且都有一道闸守着。计算链：
                    → 全绿放行。2026-07-27 PLTU 账面 0.00%（实为 +6.3%）、
                    SKHY 账面 -0.31%（实为 -6.2%）就是这么过闸的。
                    两个独立价格四位小数完全相等 ≈ 不可能，本身即是最强判据。
+报告里还有一段 quote_sources（不是闸，是台账）：逐区列出每只活跃持仓的报价
+provider 与去重计数。降级取回来的价与健康价在算术上完全一致，唯一的差别是
+data_source 里的 provider 名，而在这之前没有任何消费者读过那个名字 —— 于是
+「取到了价」和「主源还活着」是同一件事（#1116）。刻意不做成 WARN：实测
+2026-08-19..28 美股整本账天天走 Finnhub（Nasdaq 的 /info 端点不带前收，
+_quote_is_complete 因此弃用它——链在正常工作），逐日报警只会喂出一条没人看的
+黄灯。真正的降级另有其闸：报价源给不出前收 → quote_incomplete → STALE_PRICE。
   REALIZED_SUM   realized_pnl ≈ Σ(trades 里 realized_pnl)                WARN
   COST_BASIS     trades 账本完整(净股==shares)时 cost_basis==移动加权价  ERROR
                  → 算均价漏冲减 T+0 卖出 → 把已卖低价买单留在分母,均价偏低
@@ -145,6 +152,25 @@ def _extract_iso(s):
             except ValueError:
                 continue
     return None
+
+
+# 主源：报价链第一档。其余档都能取到价——那正是问题：降级后的账本在算术上
+# 自洽，唯一的差别是 data_source 里的 provider 名。
+PRIMARY_QUOTE_SOURCE = {'us': ('Nasdaq API',), 'hk': ('Tencent',)}
+
+
+def _quote_provider(data_source):
+    """data_source 形如 "Tencent+Eastmoney Aug 28 15:32 HKT" → provider 段。
+
+    时间戳部分由各 fetcher 自己格式化，provider 段永远在最前，所以按第一个
+    "月 日" 之前切；切不出来就整串当 provider（宁可多报一次也不要漏报）。
+    """
+    text = str(data_source or '').strip()
+    if not text:
+        return None
+    import re
+    m = re.search(r'\s+(?:\d{4}[/-]\d{1,2}|[A-Za-z]{3}\s+\d{1,2}|\d{1,2}:\d{2})', text)
+    return (text[:m.start()] if m else text).strip() or None
 
 
 def _prev_snapshot_cash(region, field):
@@ -256,6 +282,7 @@ def check(portfolio_path=PORTFOLIO):
         findings.append({'code': code, 'level': level, 'region': region,
                          'ticker': ticker, 'msg': msg})
 
+    quote_ledger = {}
     region_market = {'us_stocks': 'us', 'hk_stocks': 'hk'}
     region_ccy = {'us_stocks': 'USD', 'hk_stocks': 'HKD'}
 
@@ -328,6 +355,7 @@ def check(portfolio_path=PORTFOLIO):
         # 逐只 -----------------------------------------------------------
         sib_dirs = {}
         asofs = set()
+        quote_sources = {}
         for h in active:
             t = h.get('ticker')
             cur = _num(h.get('current_price'))
@@ -409,6 +437,12 @@ def check(portfolio_path=PORTFOLIO):
             if t in HSTECH_SIBLINGS and chg is not None:
                 sib_dirs[t] = chg
 
+            # 报价 provider 台账（#1116）。不判对错，只把此前只存在于 stdout
+            # 的东西记进报告，让「今天这本账是谁定的价」变成可读的一行。
+            provider = _quote_provider(h.get('data_source'))
+            if sh and provider:
+                quote_sources.setdefault(provider, []).append(t)
+
             # 收集 us_asof
             if market == 'us':
                 src = h.get('data_source') or ''
@@ -452,6 +486,16 @@ def check(portfolio_path=PORTFOLIO):
                     f'{t} 报价不完整（缺前收/日内区间），所有 provider 都没给全；'
                     f'day_high/day_low 仅由本地累积器推得，别当真实区间读',
                     region, t)
+
+        if quote_sources:
+            quote_ledger[region] = {
+                'primary': PRIMARY_QUOTE_SOURCE.get(market or '', [None])[0],
+                'by_source': {src: sorted(ts) for src, ts in sorted(quote_sources.items())},
+                'primary_priced': sum(
+                    len(ts) for src, ts in quote_sources.items()
+                    if src.startswith(PRIMARY_QUOTE_SOURCE.get(market or '', ('\0',)))),
+                'active': len(active),
+            }
 
         # LEV_DIRECTION：恒科族两只以上且方向不一致
         nz = {k: v for k, v in sib_dirs.items() if abs(v) > 0.05}
@@ -552,6 +596,9 @@ def check(portfolio_path=PORTFOLIO):
         'error_count': len(errors),
         'warn_count': len(warns),
         'findings': findings,
+        # 台账而非判决：消费者（brief context / 面板）读它就能说出「今天这本账
+        # 是谁定的价、主源覆盖了几只」，不必再去翻某次 cron 的 stdout。
+        'quote_sources': quote_ledger,
     }
     return report
 

--- a/tests/test_quote_source_degradation.py
+++ b/tests/test_quote_source_degradation.py
@@ -1,0 +1,197 @@
+"""A degraded quote must publish as degraded (#1116).
+
+The failure mode this file pins is not "the fetch failed" — that path is loud
+and already handled. It is the fetch that *succeeds on a worse source* and then
+becomes indistinguishable from a healthy one:
+
+* stooq carries OHLC only, so ``_fetch_stooq`` fills ``pc`` with the session
+  OPEN. Written through, that stamps an open as a prior close, dates it to the
+  previous HK session, and prints an intraday move as the daily change. Every
+  existing gate agrees with it: TODAY_LEG reconciles (it checks arithmetic, not
+  provenance) and STALE_PRICE stays quiet (an open rarely equals the close).
+* Which provider actually priced the book lived in `data_source` and in one
+  cron's stdout, and nothing read either. "We got a price" and "the primary
+  source is alive" were the same sentence.
+"""
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("requests")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from clawock.market_data import hk_analysis as hk  # noqa: E402
+from clawock.portfolio import integrity  # noqa: E402
+
+
+def _sessions():
+    now_hkt = datetime.now(timezone(timedelta(hours=8)))
+    prior = hk.trading_calendar.previous_trading_day(
+        "hk", now_hkt.date()).isoformat()
+    return now_hkt.date().isoformat(), prior
+
+
+def _book(tmp_path, monkeypatch, holding):
+    port = {"portfolios": {"hk_stocks": {"holdings": [holding]}}}
+    path = tmp_path / "portfolio.json"
+    path.write_text(json.dumps(port))
+    monkeypatch.setattr(hk, "PORTFOLIO_PATH", str(path))
+    monkeypatch.setattr(hk, "fetch_indices", lambda: {})
+    return path
+
+
+# stooq's shape: a real price, and a `pc` that is really the open.
+STOOQ_QUOTE = {
+    "name": "00100", "c": 299.6, "pc": 312.0, "o": 312.0,
+    "dp": -3.97, "_pc_quality": "open-as-pc", "_src": "stooq",
+}
+
+
+def test_stooq_open_is_never_published_as_a_prior_close(tmp_path, monkeypatch):
+    """The stored prior close wins over the approximation, and its date is kept.
+
+    Keeping the stored close (rather than blanking the fields) is what leaves
+    the published book arithmetically consistent: today_change still equals
+    shares x (current - prev_close), so TODAY_LEG does not start firing about a
+    problem it cannot see.
+    """
+    _, prior = _sessions()
+    _book(tmp_path, monkeypatch, {
+        "ticker": "00100", "shares": 100.0, "cost_basis": 300.0,
+        "current_price": 312.0, "prev_close": 312.2, "prev_close_date": prior,
+    })
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": STOOQ_QUOTE})
+
+    h = hk.update_hk_portfolio(dry_run=True)["portfolios"]["hk_stocks"]["holdings"][0]
+
+    assert h["prev_close"] == 312.2, "the open must not overwrite a real prior close"
+    assert h["prev_close_date"] == prior
+    # -4.04% against the real close, not -3.97% against the open.
+    assert h["today_change_pct"] == pytest.approx(-4.04, abs=0.01)
+    assert h["today_change"] == pytest.approx(100 * (299.6 - 312.2), abs=0.01)
+    assert not h.get("quote_incomplete"), (
+        "a verified prior close for the right session is not a degraded quote")
+
+
+def test_no_verified_prior_close_flags_the_holding_instead_of_inventing_one(
+        tmp_path, monkeypatch):
+    """Nothing on file to fall back to → the day change is unknown, and says so.
+
+    `quote_incomplete` is the flag the US path already sets and that integrity
+    and intraday_preflight already read — a new flag would be a fourth word for
+    the same thing.
+    """
+    today, prior = _sessions()
+    _book(tmp_path, monkeypatch, {
+        "ticker": "00100", "shares": 100.0, "cost_basis": 300.0,
+        "current_price": 312.0,
+    })
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": STOOQ_QUOTE})
+
+    h = hk.update_hk_portfolio(dry_run=True)["portfolios"]["hk_stocks"]["holdings"][0]
+
+    assert h["quote_incomplete"] is True
+    assert "prev_close" not in h, "an open is not a prior close"
+    assert "today_change_pct" not in h
+    # The price itself is fine — the fallback did supply that.
+    assert h["current_price"] == 299.6
+    assert h["current_value"] == pytest.approx(29960.0)
+
+
+def test_a_healthy_fetch_retires_the_flag(tmp_path, monkeypatch):
+    """A degradation flag nobody clears is its own defect."""
+    _, prior = _sessions()
+    _book(tmp_path, monkeypatch, {
+        "ticker": "00100", "shares": 100.0, "cost_basis": 300.0,
+        "current_price": 312.0, "prev_close": 312.2, "prev_close_date": prior,
+        "quote_incomplete": True,
+    })
+    healthy = {"name": "00100", "c": 299.6, "pc": 312.2, "o": 312.0,
+               "dp": -4.04, "_src": "Tencent"}
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": healthy})
+
+    h = hk.update_hk_portfolio(dry_run=True)["portfolios"]["hk_stocks"]["holdings"][0]
+
+    assert "quote_incomplete" not in h
+
+
+def test_a_stale_prior_close_is_degraded_even_though_it_is_real(
+        tmp_path, monkeypatch):
+    """The stored close belongs to an older session, so the change is not today's."""
+    _book(tmp_path, monkeypatch, {
+        "ticker": "00100", "shares": 100.0, "cost_basis": 300.0,
+        "current_price": 312.0, "prev_close": 305.0,
+        "prev_close_date": "2026-01-02",
+    })
+    monkeypatch.setattr(hk, "fetch_hk_quotes", lambda codes: {"00100": STOOQ_QUOTE})
+
+    h = hk.update_hk_portfolio(dry_run=True)["portfolios"]["hk_stocks"]["holdings"][0]
+
+    assert h["quote_incomplete"] is True
+    assert h["prev_close_date"] == "2026-01-02", (
+        "the date is what makes the staleness legible; restamping it hides it")
+
+
+def test_the_whole_chain_falling_back_to_stooq_still_marks_the_quality(monkeypatch):
+    """Both live sources out (the #1116 outage), stooq answers — and says how."""
+    class _Dead:
+        def get(self, *a, **k):
+            raise OSError("503 Service Unavailable")
+
+    monkeypatch.setattr(hk, "SESSION", _Dead())
+    monkeypatch.setattr(hk, "_fetch_eastmoney_hk", lambda codes: {})
+    monkeypatch.setattr(hk, "_fetch_stooq", lambda code: dict(STOOQ_QUOTE))
+
+    quotes = hk.fetch_hk_quotes(["00100"])
+
+    assert quotes["00100"]["_src"] == "stooq"
+    assert quotes["00100"]["_pc_quality"] == "open-as-pc", (
+        "the fetcher must hand the caller the quality, not just the number")
+
+
+def _ledger(tmp_path, holdings):
+    path = tmp_path / "portfolio.json"
+    path.write_text(json.dumps({"portfolios": {"us_stocks": {
+        "currency": "USD", "holdings": holdings}}}))
+    return path
+
+
+def test_the_report_names_who_priced_the_book(tmp_path):
+    """Provider coverage is a ledger line, not an alarm.
+
+    Measured 2026-08-19..28: the whole US book is priced by Finnhub nearly every
+    day, because Nasdaq's /info endpoint carries no prior close and
+    `_quote_is_complete` rejects it. The chain is working. A daily WARN about
+    it would be the fourth yellow light nobody reads, so this is reported as a
+    count instead — but it is reported, which is the change.
+    """
+    path = _ledger(tmp_path, [
+        {"ticker": "AAA", "shares": 10, "cost_basis": 1.0, "current_price": 2.0,
+         "data_source": "Nasdaq API (stocks) Aug 28 21:45 HKT"},
+        {"ticker": "BBB", "shares": 10, "cost_basis": 1.0, "current_price": 2.0,
+         "data_source": "Finnhub Aug 28 21:45 HKT"},
+    ])
+
+    ledger = integrity.check(path)["quote_sources"]["us_stocks"]
+
+    assert ledger["primary"] == "Nasdaq API"
+    assert ledger["primary_priced"] == 1 and ledger["active"] == 2
+    assert ledger["by_source"] == {
+        "Nasdaq API (stocks)": ["AAA"], "Finnhub": ["BBB"]}
+
+
+def test_provider_parsing_survives_every_stamp_format_in_use():
+    for stamp, want in (
+        ("Tencent+Eastmoney Aug 28 16:10 HKT", "Tencent+Eastmoney"),
+        ("Nasdaq API (etf) Aug 28 21:45 HKT", "Nasdaq API (etf)"),
+        ("stooq 2026/08/28 15:32", "stooq"),
+        ("Polygon (prev close) Aug 28 05:00 HKT", "Polygon (prev close)"),
+        ("", None),
+        (None, None),
+    ):
+        assert integrity._quote_provider(stamp) == want


### PR DESCRIPTION
Closes #1116.

## What I checked first

The issue's premise — "quote/fundamentals data is single-primary-gateway (Eastmoney)" — is **false for quotes**, and the README claim it doubts is true:

- **US**: `us_quotes.py` runs a 7-provider chain (Nasdaq → Eastmoney → Finnhub → Yahoo v8 → yfinance → Alpha Vantage → Polygon), with completeness checks between tiers.
- **HK**: `fetch_hk_quotes` runs Tencent → Eastmoney HK (independent cross-check, warns on >1% divergence) → stooq → yfinance.

Eastmoney is the single gateway for *fundamentals / news / fund flows*, not for prices. An Eastmoney 503 does not blank the desk.

## What is real

**1. A fallback that cannot supply a prior close was inventing one.** `_fetch_stooq` returns OHLC only and fills `pc` with the session **open**, tagging it `_pc_quality: open-as-pc`. `update_hk_portfolio` wrote that into `prev_close`, stamped it with the previous HK session's date, and published the move-off-the-open as the daily change. Both existing gates pass it: TODAY_LEG reconciles (arithmetic, not provenance), STALE_PRICE stays quiet (an open rarely equals a close). Exactly the "silent stale fallback" the issue is about — just not on the source it named.

**2. Nobody read the provider.** `data_source` = `"<provider> <timestamp>"`; every consumer (`integrity` STALENESS, `intraday_preflight`, `artifacts`, `dashboard`) parses only the date out of it. Whether the book was priced by the primary or by tier 4 was in one cron's stdout and nowhere else.

## What ships

- `hk_analysis`: the approximated close is dropped in favour of the holding's stored `prev_close`, keeping its real `prev_close_date`. Published fields stay arithmetically consistent; the date carries the provenance. Stored close too old, or missing → `quote_incomplete = True` (the flag the US path already sets and two consumers already read), the day-change fields are left alone rather than filled from the open, and the refresh line prints `当日涨跌未知` instead of a number that would look exactly like a real one. A healthy fetch retires the flag.
- `integrity`: a `quote_sources` ledger per book — provider → tickers, `primary_priced`, `active`. It rides into the brief context (`'integrity': integrity`), and `brief_preflight` prints one line whenever the primary did not cover the whole book.
- 7 new tests, all offline, including the outage the issue asked for: both live HK sources dead → stooq answers → the quality tag survives to the caller.

## Why the ledger is not a WARN

Measured over `memory/snapshots/2026-08-19..28`: **the entire US book is priced by Finnhub nearly every day.** Not an outage — Nasdaq's `/info` endpoint carries no `PreviousClose` (documented in `get_nasdaq_quote`'s own docstring), so `_quote_is_complete` rejects it and the chain moves on, which is the chain working. A per-holding WARN would fire ~5×/day forever and become the yellow light nobody reads — the failure mode `_last_session` already has a comment about. So the coverage is *reported* (always, as a count) and the *alarm* is reserved for a quote that cannot support the field it fills.

Full suite green locally: 2792 passed, 5 skipped, 4 xfailed.
