### PR TITLE
traffic: capture standing, not just reach (#1120)

### DIFF
--- a/ops/growth/repo_traffic.py
+++ b/ops/growth/repo_traffic.py
@@ -29,6 +29,12 @@ Package downloads ride along because they are the same kind of perishable
 rolling window, and because the package pages turn out to be the highest-traffic
 surface this project has (#790).
 
+Stars, forks and watchers ride along for the opposite reason (#1120): they are
+running totals that never age out, so no capture can lose them — but nothing was
+writing them down either, and "indexed but with no standing" is the real
+distribution gap, not crawl budget. Stored as dated snapshots so the KPI is a
+curve rather than whatever the number happened to be the day someone looked.
+
 Usage:
     repo_traffic.py                      # merge into assets/data/repo-traffic.json
     repo_traffic.py --print              # show what would be written, write nothing
@@ -81,7 +87,16 @@ def fetch_github(token: str) -> dict[str, Any]:
     clones = _get_json(f"{base}/clones?per=day", token)
     referrers = _get_json(f"{base}/popular/referrers", token)
     paths = _get_json(f"{base}/popular/paths", token)
-    return {"views": views, "clones": clones, "referrers": referrers, "paths": paths}
+    # Authority, alongside reach (#1120). The distribution problem was framed
+    # for a long time as crawl budget; it is not — the site is indexed, the
+    # package is on PyPI, a search returns all three surfaces. What is missing
+    # is standing: stars, forks, people watching. Those are the numbers a
+    # reader of this repository actually weighs it by, and until now the only
+    # place they existed was whatever `gh repo view` printed the day someone
+    # ran it.
+    repo = _get_json(f"https://api.github.com/repos/{REPO}", token)
+    return {"views": views, "clones": clones, "referrers": referrers,
+            "paths": paths, "repo": repo}
 
 
 def fetch_packages() -> dict[str, Any]:
@@ -169,6 +184,27 @@ def merge(previous: dict[str, Any], github: dict[str, Any], packages: dict[str, 
         history.append({"captured_at": stamp, "window_days": 14, "rows": payload})
         merged[f"{name}_snapshots"] = sorted(history, key=lambda s: s["captured_at"])
 
+    # Authority is a running total, not a window: unlike views and clones it
+    # cannot age out, so this is a dated snapshot series rather than a merge.
+    # It is also the one section that survives a missing input — an older
+    # capture file, or a caller that did not ask for the repo block, keeps its
+    # traffic half rather than failing over a secondary metric.
+    repo_meta = github.get("repo")
+    if isinstance(repo_meta, dict):
+        authority = [s for s in previous.get("authority_snapshots", [])
+                     if s.get("captured_at") != stamp]
+        authority.append({
+            "captured_at": stamp,
+            "stargazers": repo_meta.get("stargazers_count"),
+            "forks": repo_meta.get("forks_count"),
+            "watchers": repo_meta.get("subscribers_count"),
+            "open_issues": repo_meta.get("open_issues_count"),
+        })
+        merged["authority_snapshots"] = sorted(authority,
+                                               key=lambda s: s["captured_at"])
+    elif previous.get("authority_snapshots"):
+        merged["authority_snapshots"] = previous["authority_snapshots"]
+
     pkg_history = [s for s in previous.get("package_downloads", [])
                    if s.get("captured_at") != stamp]
     pkg_history.append({"captured_at": stamp, **packages})
@@ -223,6 +259,10 @@ def main(argv: list[str] | None = None) -> int:
     print(f"clones 14d: {c14['count']} / {c14['uniques']} unique")
     print("referrers: " + ", ".join(
         f"{r['referrer']} {r['count']}/{r['uniques']}u" for r in github["referrers"][:6]) or "(none)")
+    if merged.get("authority_snapshots"):
+        latest = merged["authority_snapshots"][-1]
+        print(f"authority: {latest['stargazers']}★ · {latest['forks']} forks · "
+              f"{latest['watchers']} watching")
     print(f"series: +{stats['views_added']} view days, +{stats['clones_added']} clone days, "
           f"{stats['views_revised'] + stats['clones_revised']} revised")
     print(f"history now spans {len(merged['views'])} view days / {len(merged['clones'])} clone days")

--- a/tests/test_repo_traffic_capture.py
+++ b/tests/test_repo_traffic_capture.py
@@ -27,8 +27,9 @@ def _day(ts: str, count: int, uniques: int) -> dict:
     return {"timestamp": ts, "count": count, "uniques": uniques}
 
 
-def _github(views: list[dict], clones: list[dict], referrers=None, paths=None) -> dict:
-    return {
+def _github(views: list[dict], clones: list[dict], referrers=None, paths=None,
+            repo=None) -> dict:
+    payload = {
         "views": {"count": sum(d["count"] for d in views),
                   "uniques": 1, "views": views},
         "clones": {"count": sum(d["count"] for d in clones),
@@ -36,6 +37,9 @@ def _github(views: list[dict], clones: list[dict], referrers=None, paths=None) -
         "referrers": referrers if referrers is not None else [],
         "paths": paths if paths is not None else [],
     }
+    if repo is not None:
+        payload["repo"] = repo
+    return payload
 
 
 NOW = dt.datetime(2026, 8, 22, 3, 38, tzinfo=dt.timezone.utc)
@@ -116,6 +120,50 @@ def test_package_downloads_are_advisory_and_never_lose_the_github_half():
     assert merged["views"][0]["count"] == 20
     assert merged["package_downloads"][0]["npm_error"] == "HTTP 503"
     assert merged["package_downloads"][0]["pypi"]["last_month"] == 896
+
+
+def test_authority_counts_are_snapshots_that_accumulate_into_a_curve():
+    """Stars/forks are running totals, so the point is the series, not the value.
+
+    Tracking them at all is the correction #1120 asked for: the distribution
+    gap is standing, not crawl budget, and the number was previously only
+    whatever `gh repo view` printed the day someone ran it.
+    """
+    first, _ = repo_traffic.merge({}, _github([], [], repo={
+        "stargazers_count": 13, "forks_count": 1,
+        "subscribers_count": 2, "open_issues_count": 12}), {}, NOW)
+    second, _ = repo_traffic.merge(first, _github([], [], repo={
+        "stargazers_count": 15, "forks_count": 1,
+        "subscribers_count": 2, "open_issues_count": 9}), {}, LATER)
+
+    snaps = second["authority_snapshots"]
+    assert [s["captured_at"] for s in snaps] == [
+        "2026-08-22T03:38:00Z", "2026-08-26T03:38:00Z"]
+    assert [s["stargazers"] for s in snaps] == [13, 15]
+    assert snaps[1]["open_issues"] == 9
+
+
+def test_a_rerun_in_the_same_minute_replaces_the_authority_snapshot():
+    first, _ = repo_traffic.merge({}, _github([], [], repo={"stargazers_count": 13}), {}, NOW)
+    second, _ = repo_traffic.merge(first, _github([], [], repo={"stargazers_count": 14}), {}, NOW)
+
+    assert len(second["authority_snapshots"]) == 1
+    assert second["authority_snapshots"][0]["stargazers"] == 14
+
+
+def test_a_missing_repo_block_keeps_both_the_traffic_and_the_prior_authority():
+    """Authority never ages out, so it must never be able to cost a capture.
+
+    A file written before this section existed, or a caller that did not ask
+    for the repo block, keeps its traffic half and its earlier snapshots
+    instead of failing over a secondary metric.
+    """
+    seeded, _ = repo_traffic.merge({}, _github([], [], repo={"stargazers_count": 13}), {}, NOW)
+    merged, _ = repo_traffic.merge(
+        seeded, _github([_day("2026-08-25T00:00:00Z", 7, 3)], []), {}, LATER)
+
+    assert merged["views"][-1]["count"] == 7
+    assert [s["stargazers"] for s in merged["authority_snapshots"]] == [13]
 
 
 def test_a_missing_token_is_an_error_not_an_empty_reading(monkeypatch, capsys):


### PR DESCRIPTION
Closes #1120.

## Premise re-checked (it holds)

- PyPI `clawock` 0.1.9 is live; `site/robots.txt` allows all and names the sitemap; `_config.yml` enables `jekyll-sitemap` + `jekyll-seo-tag`.
- The traffic capture itself now measures the reach half directly — 14-day window as of this run: **247 views / 70 unique, 14,037 clones / 801 unique**, referrers `github.com 48/24u · Google 8/3u · kcnyu.github.io 3/1u · chatgpt.com 2/1u`. Google is sending visits. The "zero crawl budget" framing is stale.

## The gap the issue names

Authority, and it was untracked. `assets/data/repo-traffic.json` carried views, clones, referrers, paths and package downloads — nothing about standing. Stars/forks lived wherever `gh repo view` printed them the day someone ran it, so there is no curve and no way to answer "is this going anywhere".

## What ships

`fetch_github` also reads the repository object; `merge` stores an `authority_snapshots` entry per capture — stargazers, forks, watchers, open issues — using the same dated-snapshot discipline as referrers/paths (deduped per capture minute), twice a week off the existing schedule.

The one design point worth stating: these are running totals, not a rolling window, so unlike views/clones they cannot be lost. That is exactly why a missing repo block must never cost a capture — a file written before this section existed, or a caller that did not pass it, keeps both its traffic half and its earlier snapshots. There is a test for that.

Live dry run: `authority: 14★ · 1 forks · 0 watching`.

Backlinks are deliberately not in scope here: GitHub's API cannot see them, and the referrer snapshots already carry the only first-party evidence of inbound traffic this project can measure.

Full suite: 2803 passed, 5 skipped, 4 xfailed.
