### PR TITLE
evaluation: purged CSCV and PBO for the leverage dial (#1114)

### DIFF
--- a/src/clawock/evaluation/cscv.py
+++ b/src/clawock/evaluation/cscv.py
@@ -1,0 +1,216 @@
+"""Combinatorially symmetric cross-validation: how much of a fit is selection.
+
+The gap this closes
+-------------------
+`regime_validation` already refuses the weakest form of evidence — it walks the
+dial forward, permutes its timing against the returns, and prints the threshold
+surface so a knife-edge fit is visible. What none of those answer is the
+question that actually decides whether a chosen threshold means anything:
+**16 configurations were searched, so how often does the one that looks best
+in-sample turn out to be below-median out-of-sample?**
+
+That is the probability of backtest overfitting (Bailey, Borwein, López de Prado
+and Zhu, *The Probability of Backtest Overfitting*, 2015). Its estimator is CSCV:
+split the sample into `S` contiguous groups, take every way of choosing `S/2` of
+them as the out-of-sample half, pick the best configuration on the in-sample
+half, and record where that configuration lands among the out-of-sample scores.
+PBO is the share of splits where it lands in the bottom half. A single
+walk-forward pass reports one such draw; CSCV reports the distribution, which is
+why a strategy with a real edge and one that was merely selected can produce the
+same walk-forward table and different PBO.
+
+Two properties of the estimator matter for reading its output:
+
+* it is **symmetric** — every group serves in both halves across the splits, so
+  the result does not depend on which end of the sample the test window fell on;
+* it measures **selection**, not skill. A single pre-registered configuration
+  has nothing to overfit, and this module refuses to report a PBO for one rather
+  than printing 0.0 as though that were evidence.
+
+Purging and the embargo
+-----------------------
+Plain CSCV assumes observations are independent across the split boundary. They
+are not here: a trailing 200-day mean at the first bar of a test group is built
+from bars sitting in a training group, and a forward-looking label spans the
+boundary in the other direction. `purge` drops the training observations within
+`embargo` bars on either side of every test block — López de Prado's purging and
+embargo, applied in both directions because these features look back and these
+labels look forward.
+
+The estimator is separated from the thing being estimated on purpose: it takes a
+matrix of per-observation values and a scoring function, so the regime dial, an
+add-side rule, or any future evaluator can be measured by the same code rather
+than by a second copy of the arithmetic.
+"""
+from __future__ import annotations
+
+import math
+from itertools import combinations
+
+#: Below this, the estimate is noise about noise. With four groups there are six
+#: splits and the rank of the selected configuration can take too few values for
+#: the share below the median to mean anything.
+MIN_GROUPS = 6
+
+#: A configuration set this small cannot express a selection effect: with one
+#: configuration there is no choice to overfit, and with two the out-of-sample
+#: rank is a coin flip by construction.
+MIN_CONFIGS = 3
+
+
+def contiguous_groups(n_observations: int, n_groups: int) -> list[list[int]]:
+    """Split observation indices into `n_groups` contiguous, near-equal blocks.
+
+    Contiguous rather than interleaved: the leakage this design fights lives in
+    time-adjacent bars, and interleaving would put a training bar next to every
+    test bar by construction.
+    """
+    if n_groups <= 0 or n_observations <= 0:
+        return []
+    edges = [round(n_observations * k / n_groups) for k in range(n_groups + 1)]
+    return [list(range(edges[k], edges[k + 1])) for k in range(n_groups)]
+
+
+def purge(train: list[int], test: list[int], embargo: int) -> list[int]:
+    """Drop training observations within `embargo` bars of any test observation.
+
+    Both directions, because both leaks are real: a trailing feature window
+    reaches backwards out of the test block into training bars, and a forward
+    label reaches forwards out of it. An embargo on one side only would leave
+    the other one open while looking rigorous.
+    """
+    if embargo <= 0 or not test:
+        return list(train)
+    blocked = set()
+    start, previous = test[0], test[0]
+    for index in test[1:] + [None]:
+        if index is not None and index == previous + 1:
+            previous = index
+            continue
+        blocked.update(range(start - embargo, previous + embargo + 1))
+        if index is None:
+            break
+        start = previous = index
+    return [index for index in train if index not in blocked]
+
+
+def splits(n_groups: int, n_test_groups: int | None = None):
+    """Every combinatorially symmetric (train, test) partition of the groups."""
+    if n_test_groups is None:
+        n_test_groups = n_groups // 2
+    for test in combinations(range(n_groups), n_test_groups):
+        chosen = set(test)
+        yield [g for g in range(n_groups) if g not in chosen], list(test)
+
+
+def probability_of_backtest_overfitting(
+        matrix, score, *, n_groups: int = 8, n_test_groups: int | None = None,
+        embargo: int = 0, higher_is_better: bool = True) -> dict:
+    """PBO over a per-observation value matrix.
+
+    ``matrix`` is indexed ``matrix[observation][configuration]`` and its cells
+    may be any value the scorer understands (a return, a tuple of strategy and
+    benchmark returns, …). ``score`` maps the selected cells of one
+    configuration to a scalar.
+
+    Returns the estimate plus the material to argue with it: the logit
+    distribution, the out-of-sample scores of each in-sample winner, and how
+    much performance the selection lost between the halves. When the sample
+    cannot support the estimator it returns ``status: insufficient_sample`` and
+    no number — a PBO computed from four splits would be a decoration with a
+    citation attached.
+    """
+    n_observations = len(matrix)
+    n_configs = len(matrix[0]) if n_observations else 0
+    if n_test_groups is None:
+        n_test_groups = n_groups // 2
+    reasons = []
+    if n_groups < MIN_GROUPS:
+        reasons.append(f'{n_groups} groups is below the {MIN_GROUPS}-group floor')
+    if n_configs < MIN_CONFIGS:
+        reasons.append(
+            f'{n_configs} configuration(s) cannot express a selection effect '
+            f'(floor {MIN_CONFIGS})')
+    if n_observations < n_groups * 2:
+        reasons.append(
+            f'{n_observations} observations cannot fill {n_groups} groups')
+    if reasons:
+        return {'status': 'insufficient_sample', 'reason': '; '.join(reasons),
+                'n_observations': n_observations, 'n_configs': n_configs,
+                'n_groups': n_groups, 'pbo': None}
+
+    groups = contiguous_groups(n_observations, n_groups)
+    records = []
+    for train_groups, test_groups in splits(n_groups, n_test_groups):
+        train = sorted(index for g in train_groups for index in groups[g])
+        test = sorted(index for g in test_groups for index in groups[g])
+        kept = purge(train, test, embargo)
+        if not kept or not test:
+            continue
+        in_sample = [score([matrix[i][c] for i in kept]) for c in range(n_configs)]
+        out_sample = [score([matrix[i][c] for i in test]) for c in range(n_configs)]
+        if any(value is None for value in in_sample + out_sample):
+            continue
+        chosen = (max(range(n_configs), key=lambda c: in_sample[c])
+                  if higher_is_better
+                  else min(range(n_configs), key=lambda c: in_sample[c]))
+        # Relative rank of the chosen configuration among the out-of-sample
+        # scores, in (0, 1) — 1 is best. Ties share the mid-rank so a flat
+        # surface does not resolve into a spurious win or loss.
+        worse = sum(1 for value in out_sample if value < out_sample[chosen])
+        equal = sum(1 for value in out_sample if value == out_sample[chosen])
+        rank = (worse + (equal - 1) / 2) / (n_configs - 1) if n_configs > 1 else 0.5
+        if not higher_is_better:
+            rank = 1 - rank
+        # Bounded away from the ends so a clean sweep still yields a finite
+        # logit; with 16 configurations the shift is one twentieth of a rank.
+        bounded = min(max(rank, 1 / (2 * n_configs)), 1 - 1 / (2 * n_configs))
+        records.append({
+            'chosen': chosen,
+            'in_sample_train_size': len(kept),
+            'purged': len(train) - len(kept),
+            'rank': round(rank, 4),
+            'logit': round(math.log(bounded / (1 - bounded)), 6),
+            'in_sample_score': round(in_sample[chosen], 6),
+            'out_of_sample_score': round(out_sample[chosen], 6),
+            'out_of_sample_median': round(sorted(out_sample)[n_configs // 2], 6),
+        })
+    if not records:
+        return {'status': 'insufficient_sample',
+                'reason': 'every split scored to None after purging',
+                'n_observations': n_observations, 'n_configs': n_configs,
+                'n_groups': n_groups, 'pbo': None}
+
+    logits = [record['logit'] for record in records]
+    degradation = [record['out_of_sample_score'] - record['in_sample_score']
+                   for record in records]
+    return {
+        'status': 'measured',
+        'method': ('combinatorially symmetric cross-validation; contiguous '
+                   'groups; purged with a two-sided embargo'),
+        'n_observations': n_observations,
+        'n_configs': n_configs,
+        'n_groups': n_groups,
+        'n_test_groups': n_test_groups,
+        'n_splits': len(records),
+        'embargo': embargo,
+        'purged_per_split': round(
+            sum(record['purged'] for record in records) / len(records), 1),
+        # The estimate: how often the in-sample winner lands in the bottom half
+        # out of sample. 0.5 is what a pure selection effect looks like.
+        'pbo': round(sum(1 for value in logits if value <= 0) / len(logits), 4),
+        'logit_median': round(sorted(logits)[len(logits) // 2], 4),
+        'mean_out_of_sample_degradation': round(
+            sum(degradation) / len(degradation), 6),
+        'splits_where_the_winner_stayed_above_median': sum(
+            1 for value in logits if value > 0),
+        # Which configurations the search actually picked, and how often. A
+        # PBO near 0.5 with one config winning every split says something
+        # different from the same number with the winner rotating: the first is
+        # a stable rule the estimator cannot separate from noise, the second is
+        # the search chasing the window.
+        'selection_counts': {
+            str(config): sum(1 for record in records if record['chosen'] == config)
+            for config in sorted({record['chosen'] for record in records})},
+        'selected_configs': sorted({record['chosen'] for record in records}),
+    }

--- a/src/clawock/evaluation/regime_validation.py
+++ b/src/clawock/evaluation/regime_validation.py
@@ -21,11 +21,17 @@ What this measures
 1. **Walk-forward** — thresholds are chosen on a training window and scored on
    the *next* window only, rolling forward. Per-window out-of-sample results, not
    one full-period headline.
-2. **Permutation** — the null is "the dial's timing carries no information". The
+2. **Selection (PBO)** — walk-forward reports four draws of "does the chosen
+   threshold hold up"; with 16 candidates on one index that is too few to
+   separate a rule from a search. Combinatorially symmetric cross-validation
+   ranks the same candidates in both halves of every symmetric split, purged
+   with a two-sided embargo, and reports how often the in-sample winner lands
+   below the out-of-sample median (#1114).
+3. **Permutation** — the null is "the dial's timing carries no information". The
    exposure path is circularly shifted against the returns, which preserves its
    length, its time-in-market and its autocorrelation while destroying the
    alignment. The p-value is where the observed improvement lands in that null.
-3. **Sensitivity** — the metric surface over the (MA, vol-cap) grid, so a
+4. **Sensitivity** — the metric surface over the (MA, vol-cap) grid, so a
    knife-edge fit is visible rather than implied.
 
 It models the *production* dial
@@ -39,7 +45,7 @@ This never writes to the live pipeline. It prints, and it leaves a run card.
 
 Run:
   clawock validate-regime-dial
-  clawock validate-regime-dial --folds 4 --permutations 5000
+  clawock validate-regime-dial --folds 4 --permutations 5000 --groups 8
 """
 from __future__ import annotations
 
@@ -53,6 +59,7 @@ from pathlib import Path
 import requests
 
 from clawock.decision import regime as compute_regime
+from clawock.evaluation import cscv
 from clawock.evidence import run_card
 from clawock.workspace import workspace_root
 
@@ -285,6 +292,113 @@ def walk_forward(dates, closes, *, folds=4, ma_grid=MA_GRID, vol_grid=VOL_CAP_GR
     }
 
 
+# ── 1b. selection: probability of backtest overfitting ──────────────────────
+
+#: Fraction of the sample embargoed on each side of a test block. One percent is
+#: López de Prado's default and is what the label horizon needs here (the dial's
+#: label is one session). It is deliberately *not* the 200-bar MA window: a
+#: trailing mean is available in real time, so sharing it across a boundary is
+#: not look-ahead, and embargoing it would delete most of every training half —
+#: a purge that leaves nothing to select on measures nothing.
+EMBARGO_FRACTION = 0.01
+
+
+def _config_columns(closes, ma_grid, vol_grid):
+    """Per-bar (dial return, always-on return) for every threshold pair.
+
+    Computed once over the whole sample and sliced afterwards, which is sound
+    precisely because `exposure_path` is trailing-only: bar i's exposure is
+    built from closes through i-1 whichever window it is later scored in.
+    """
+    configs, columns = [], []
+    for ma_window in ma_grid:
+        for vol_cap in vol_grid:
+            returns, exposure, _ = exposure_path(
+                closes, ma_window=ma_window, vol_cap=vol_cap)
+            if not returns:
+                continue
+            configs.append({'ma': ma_window, 'vol_cap': vol_cap})
+            columns.append([(exposure[i] * returns[i], BASE_LEVERAGE * returns[i])
+                            for i in range(len(returns))])
+    return configs, columns
+
+
+def _drawdown_improvement(pairs):
+    """The selection objective, over an arbitrary subset of bars.
+
+    Same quantity `_score` ranks on, so CSCV measures the search that
+    `best_thresholds` actually performs rather than a proxy for it.
+    """
+    if not pairs:
+        return None
+    dial = hold = 1.0
+    dial_peak = hold_peak = 1.0
+    dial_dd = hold_dd = 0.0
+    for dial_ret, hold_ret in pairs:
+        dial *= 1 + dial_ret
+        hold *= 1 + hold_ret
+        dial_peak, hold_peak = max(dial_peak, dial), max(hold_peak, hold)
+        dial_dd = min(dial_dd, dial / dial_peak - 1)
+        hold_dd = min(hold_dd, hold / hold_peak - 1)
+    return dial_dd - hold_dd
+
+
+def overfitting_probability(closes, *, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID,
+                            groups=8, embargo=None):
+    """How often the best in-sample threshold pair is below median out of sample.
+
+    Walk-forward answers this once per fold and reports the answer as a table;
+    with 16 candidates on one index and roughly one crash in the sample, four
+    draws cannot separate a rule from a search. CSCV takes every symmetric
+    half-split of the sample instead, so the same 16 candidates are ranked
+    against each other in both halves ~70 times.
+    """
+    configs, columns = _config_columns(closes, ma_grid, vol_grid)
+    if not configs:
+        return {'status': 'insufficient_sample',
+                'reason': 'no threshold pair produced a usable exposure path',
+                'pbo': None}
+    warmup = max(ma_grid) + PROD_VOL_WINDOW
+    length = min(len(column) for column in columns)
+    if length <= warmup:
+        return {'status': 'insufficient_sample',
+                'reason': (f'{length} scored bars do not clear a {warmup}-bar '
+                           'warmup'), 'pbo': None}
+    matrix = [[column[i] for column in columns] for i in range(warmup, length)]
+    if embargo is None:
+        embargo = max(1, round(EMBARGO_FRACTION * len(matrix)))
+    result = cscv.probability_of_backtest_overfitting(
+        matrix, _drawdown_improvement, n_groups=groups, embargo=embargo)
+    result['configs'] = configs
+    result['objective'] = 'drawdown improvement vs an always-on 2x sleeve'
+    # Read the number with this in hand: the shipped objective rewards being out
+    # of the market, and de-risking reduces drawdown whether or not the timing
+    # carries information. So a low PBO here says the *ranking* of thresholds is
+    # stable across halves — not that the dial pays. The permutation test below
+    # is what answers the second question, and the two are reported together for
+    # that reason.
+    result['caveat'] = (
+        'the objective is the shipped one (drawdown improvement), which any '
+        'de-risking rule improves; PBO measures rank stability of the search, '
+        'the permutation test measures whether the timing carries information')
+    result['warmup_bars_dropped'] = warmup
+    if result.get('status') == 'measured':
+        result['selected_thresholds'] = [
+            configs[index] for index in result['selected_configs']]
+        production = next(
+            (index for index, config in enumerate(configs)
+             if config['ma'] == PROD_MA
+             and abs(config['vol_cap'] - PROD_VOL_CAP) < 1e-9), None)
+        # How often the search would have landed on the thresholds that ship.
+        # A dial the search never picks is not disqualified — it was
+        # pre-registered, not fitted — but the gap belongs in the report rather
+        # than in the reader's head.
+        result['production_selected_share'] = round(
+            (result['selection_counts'].get(str(production), 0)
+             / result['n_splits']) if production is not None else 0.0, 4)
+    return result
+
+
 # ── 2. permutation ──────────────────────────────────────────────────────────
 
 def permutation_test(returns, exposure, *, permutations=2000, seed=20260802):
@@ -383,14 +497,22 @@ def sensitivity_surface(closes, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID):
 # ── CLI ─────────────────────────────────────────────────────────────────────
 
 def main(argv=None) -> int:
-    argparse.ArgumentParser(prog='clawock validate-regime-dial',
-                            description=__doc__).parse_args(argv)
-    ap = argparse.ArgumentParser(description=__doc__)
+    # One parser, parsing the argv it was handed. There used to be two: an empty
+    # one that consumed `argv` so `--help` would answer through the CLI, and a
+    # second that re-read `sys.argv` for the real flags. The first rejected every
+    # flag the second defined, so `clawock validate-regime-dial --folds 4` — the
+    # invocation this module's own docstring documents — exited 2 without ever
+    # running. A `--help` gate is satisfied by any parser; it does not need a
+    # parser that answers nothing else.
+    ap = argparse.ArgumentParser(prog='clawock validate-regime-dial',
+                                 description=__doc__)
     ap.add_argument('--folds', type=int, default=4)
     ap.add_argument('--permutations', type=int, default=2000)
+    ap.add_argument('--groups', type=int, default=8,
+                    help='CSCV groups; every symmetric half-split is scored')
     ap.add_argument('--no-card', action='store_true',
                     help='skip writing a run card (for ad-hoc exploration)')
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     data = fetch_hstech()
     if len(data) < 400:
@@ -429,6 +551,31 @@ def main(argv=None) -> int:
         print(f'  {wf["folds_with_shallower_drawdown"]}/{wf["n_folds"]} folds '
               f'improved drawdown out of sample · thresholds {wf["threshold_stability"]}')
 
+    pbo = overfitting_probability(closes, groups=args.groups)
+    print('\n--- selection (how much of the fit is the search itself?) ---')
+    if pbo.get('status') != 'measured':
+        print(f'  unavailable: {pbo.get("reason")}')
+    else:
+        print(f'  PBO {pbo["pbo"]:.2f} over {pbo["n_splits"]} symmetric splits of '
+              f'{pbo["n_configs"]} threshold pairs · '
+              f'embargo {pbo["embargo"]} bars '
+              f'(~{pbo["purged_per_split"]:.0f} training bars purged per split)')
+        print(f'  the in-sample winner stayed above the out-of-sample median in '
+              f'{pbo["splits_where_the_winner_stayed_above_median"]}/'
+              f'{pbo["n_splits"]} splits · '
+              f'mean OOS degradation {pbo["mean_out_of_sample_degradation"]*100:+.1f}pp')
+        ranked = sorted(pbo['selection_counts'].items(),
+                        key=lambda kv: -kv[1])[:3]
+        top = ' · '.join(
+            f'{pbo["configs"][int(index)]["ma"]}/'
+            f'{pbo["configs"][int(index)]["vol_cap"]:.2f} '
+            f'({count}/{pbo["n_splits"]})' for index, count in ranked)
+        print(f'  {len(pbo["selection_counts"])} distinct pairs won at least one '
+              f'split; most often {top}')
+        print(f'  production {PROD_MA}/{PROD_VOL_CAP:.2f} won '
+              f'{pbo["production_selected_share"]*100:.0f}% of splits · '
+              f'{pbo["caveat"]}')
+
     perm = permutation_test(full_returns, full_exposure,
                             permutations=args.permutations)
     print('\n--- permutation test (null: the timing carries no information) ---')
@@ -455,6 +602,7 @@ def main(argv=None) -> int:
         card = run_card.record(
             'regime_dial_validation',
             params={'folds': args.folds, 'permutations': args.permutations,
+                    'cscv_groups': args.groups,
                     'ma_grid': list(MA_GRID), 'vol_cap_grid': list(VOL_CAP_GRID),
                     'production': {'ma': PROD_MA, 'vol_cap': PROD_VOL_CAP,
                                    'vol_window': PROD_VOL_WINDOW},
@@ -464,11 +612,16 @@ def main(argv=None) -> int:
                      'last_session': dates[-1],
                      'digest': run_card.series_digest(data)}],
             metrics={'in_sample': in_sample, 'tier_distribution': tiers,
-                     'walk_forward': wf, 'permutation': perm,
+                     'walk_forward': wf, 'overfitting': pbo, 'permutation': perm,
                      'sensitivity': surface},
-            code_files=[__file__, Path(compute_regime.__file__)],
+            code_files=[__file__, Path(compute_regime.__file__),
+                        Path(cscv.__file__)],
             notes=['models the production tier mapping (green/amber/red -> '
-                   '1.0/0.5/0.0) applied to a 2x sleeve, not 2x->cash'],
+                   '1.0/0.5/0.0) applied to a 2x sleeve, not 2x->cash',
+                   'PBO is combinatorially symmetric cross-validation over the '
+                   'same 16 threshold pairs walk-forward selects from, purged '
+                   'with a two-sided embargo; it measures the search, not the '
+                   'skill of the shipped pre-registered dial'],
         )
         print(f'\nrun card: {card.relative_to(WS)}')
     return 0

--- a/tests/test_cscv_pbo.py
+++ b/tests/test_cscv_pbo.py
@@ -1,0 +1,162 @@
+"""The leverage dial must report how much of its fit is the search (#1114).
+
+`validate-regime-dial` already walked the dial forward and permuted its timing.
+Neither answers the question a 16-candidate grid raises: how often is the pair
+that looks best in-sample below the median out of sample? Four walk-forward
+folds cannot say; every symmetric half-split can.
+
+These tests hold the estimator to the two behaviours that make it worth
+publishing — it separates a real edge from a search over noise, and it refuses
+to produce a number from a sample that cannot support one.
+"""
+import random
+
+import pytest
+
+from clawock.evaluation import cscv
+from clawock.evaluation import regime_validation as rv
+
+
+def _sum(values):
+    return sum(values)
+
+
+def _noise_matrix(n_obs=600, n_configs=12, seed=7):
+    rnd = random.Random(seed)
+    return [[rnd.gauss(0, 0.01) for _ in range(n_configs)] for _ in range(n_obs)]
+
+
+def _matrix_with_one_real_edge(n_obs=600, n_configs=12, winner=3, seed=11):
+    rnd = random.Random(seed)
+    return [[rnd.gauss(0, 0.01) + (0.004 if c == winner else 0.0)
+             for c in range(n_configs)] for _ in range(n_obs)]
+
+
+def test_a_search_over_pure_noise_reports_a_coin_flip():
+    """The number that makes PBO worth having.
+
+    Twelve configurations of nothing but noise: whichever wins in-sample has no
+    reason to win out of sample, so the in-sample winner lands below the
+    out-of-sample median about half the time.
+    """
+    result = cscv.probability_of_backtest_overfitting(
+        _noise_matrix(), _sum, n_groups=8, embargo=6)
+
+    assert result['status'] == 'measured'
+    assert result['n_splits'] == 70, "every symmetric half-split must be scored"
+    assert 0.35 <= result['pbo'] <= 0.65, (
+        f"a pure search should look like a coin flip, got {result['pbo']}")
+
+
+def test_a_configuration_with_a_real_edge_is_not_flagged_as_overfit():
+    result = cscv.probability_of_backtest_overfitting(
+        _matrix_with_one_real_edge(), _sum, n_groups=8, embargo=6)
+
+    assert result['pbo'] <= 0.05, (
+        "an edge present in every window must not read as selection")
+    assert result['selection_counts'] == {'3': 70}, (
+        "the search should land on the same configuration in every split")
+    assert result['mean_out_of_sample_degradation'] is not None
+
+
+def test_the_estimator_refuses_a_sample_that_cannot_support_it():
+    """A PBO from six splits is a decoration with a citation attached."""
+    too_few_groups = cscv.probability_of_backtest_overfitting(
+        _noise_matrix(), _sum, n_groups=4)
+    assert too_few_groups['status'] == 'insufficient_sample'
+    assert too_few_groups['pbo'] is None
+    assert '4 groups' in too_few_groups['reason']
+
+    single_config = cscv.probability_of_backtest_overfitting(
+        _noise_matrix(n_configs=1), _sum, n_groups=8)
+    assert single_config['status'] == 'insufficient_sample'
+    assert single_config['pbo'] is None, (
+        "one pre-registered configuration has nothing to overfit; reporting "
+        "0.0 would read as evidence")
+
+
+def test_the_embargo_removes_training_bars_on_both_sides_of_every_test_block():
+    train = list(range(0, 10)) + list(range(20, 30))
+    test = list(range(10, 20))
+
+    kept = cscv.purge(train, test, embargo=3)
+
+    assert kept == [0, 1, 2, 3, 4, 5, 6, 23, 24, 25, 26, 27, 28, 29], (
+        "a trailing feature reaches backwards and a forward label reaches "
+        "forwards: embargoing one side only would look rigorous and leak")
+    assert cscv.purge(train, test, embargo=0) == train
+
+
+def test_the_embargo_spans_each_block_of_a_split_not_only_the_first():
+    train = list(range(0, 40))
+    test = [5, 6, 7, 25, 26, 27]
+
+    kept = cscv.purge(train, test, embargo=2)
+
+    for blocked in (3, 4, 8, 9, 23, 24, 28, 29):
+        assert blocked not in kept, f"{blocked} sits inside an embargo"
+    assert 0 in kept and 15 in kept and 39 in kept
+
+
+def test_groups_are_contiguous_and_partition_every_observation():
+    groups = cscv.contiguous_groups(101, 8)
+
+    assert sum(len(g) for g in groups) == 101
+    assert sorted(index for g in groups for index in g) == list(range(101))
+    for group in groups:
+        assert group == list(range(group[0], group[-1] + 1))
+
+
+def test_every_split_is_a_disjoint_cover_of_the_groups():
+    seen = set()
+    for train, test in cscv.splits(8):
+        assert not set(train) & set(test)
+        assert sorted(train + test) == list(range(8))
+        assert len(test) == 4
+        seen.add(tuple(test))
+    assert len(seen) == 70
+
+
+def _random_walk(n=1400, seed=3):
+    rnd = random.Random(seed)
+    closes = [100.0]
+    for _ in range(n):
+        closes.append(closes[-1] * (1 + rnd.gauss(0.0004, 0.015)))
+    return closes
+
+
+def test_the_dial_reports_pbo_over_the_same_grid_walk_forward_searches():
+    result = rv.overfitting_probability(_random_walk())
+
+    assert result['status'] == 'measured'
+    assert result['n_configs'] == len(rv.MA_GRID) * len(rv.VOL_CAP_GRID), (
+        "PBO must cover the grid the selection actually searches")
+    assert result['n_splits'] == 70
+    assert result['embargo'] >= 1 and result['purged_per_split'] > 0, (
+        "an unpurged CSCV over trailing-window features is the leak this closes")
+    assert 0.0 <= result['pbo'] <= 1.0
+    assert 'de-risking' in result['caveat'], (
+        "the objective rewards being out of the market; the report has to say so")
+
+
+def test_a_sample_shorter_than_the_warmup_reports_no_number():
+    result = rv.overfitting_probability(_random_walk(n=150))
+
+    assert result['status'] == 'insufficient_sample'
+    assert result['pbo'] is None
+
+
+def test_the_dial_objective_is_the_one_the_search_selects_on():
+    """CSCV has to score what `best_thresholds` ranks on, or it measures a proxy.
+
+    Same quantity as `_score`'s first element: dial drawdown minus always-on
+    drawdown over the same bars.
+    """
+    closes = _random_walk(n=600)
+    returns, exposure, _ = rv.exposure_path(closes, ma_window=100, vol_cap=0.5)
+    pairs = [(exposure[i] * returns[i], rv.BASE_LEVERAGE * returns[i])
+             for i in range(len(returns))]
+
+    expected = rv.summarize(returns, exposure)['drawdown_improvement']
+
+    assert rv._drawdown_improvement(pairs) == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
Addresses the methodology half of #1114 (purged CV + PBO). The asset-class half
of that thread — options, futures, crypto, non-HK/US equities — is a product
boundary question, not a rigour question, and is deliberately not touched here.

## Why walk-forward was not enough

`validate-regime-dial` chooses thresholds on a training window and scores the
next one, four times. But the dial is selected out of **16 threshold pairs** on
**one index** whose sample contains roughly one crash. Four draws cannot tell a
rule from a search — and on this data the four folds pick three different pairs
while reporting `2/4 folds improved drawdown`.

## What this adds

`src/clawock/evaluation/cscv.py` — contiguous groups, every combinatorially
symmetric half-split (70 for S=8), purged with a two-sided embargo, and PBO
(Bailey, Borwein, López de Prado, Zhu 2015): the share of splits where the
in-sample winner lands below the out-of-sample median. It takes a
per-observation matrix and a scoring callable, so the next evaluator that needs
it does not get a second copy of the arithmetic.

`regime_validation.overfitting_probability` wires the dial into it, scoring on
**the objective the search actually ranks on** (drawdown improvement vs an
always-on 2x sleeve) rather than a proxy.

## Measured, on the real series

```
HSTECH 1390 bars  2021-01-04 → 2026-08-28

--- selection (how much of the fit is the search itself?) ---
  PBO 0.21 over 70 symmetric splits of 16 threshold pairs · embargo 11 bars (~44 training bars purged per split)
  the in-sample winner stayed above the out-of-sample median in 55/70 splits · mean OOS degradation -8.4pp
  8 distinct pairs won at least one split; most often 250/0.40 (23/70) · 250/0.70 (22/70) · 200/0.70 (9/70)
  production 200/0.50 won 4% of splits · the objective is the shipped one (drawdown improvement), which any de-risking rule improves; PBO measures rank stability of the search, the permutation test measures whether the timing carries information
```

That caveat is printed, not buried: a de-risking rule improves drawdown whether
or not its timing means anything, so a lowish PBO here is about **rank
stability**, and the permutation test beside it (p = 0.92) is what says the
timing carries no information. The new line that does bite is the second one:
8 winners across 70 splits and -8.4pp mean out-of-sample degradation.

## Design points worth reviewing

- **Two-sided embargo.** A trailing mean at the first bar of a test block
  reaches backwards into training bars; a forward label reaches forwards. An
  embargo on one side only looks rigorous and leaks.
- **Embargo is 1% of the sample, not the 200-bar MA.** A trailing mean is
  available in real time, so sharing it across a boundary is not look-ahead, and
  a 200-bar two-sided embargo would delete most of every training half — a purge
  that leaves nothing to select on measures nothing.
- **It refuses rather than decorates.** Fewer than six groups, fewer than three
  configurations, or fewer observations than groups → `insufficient_sample` and
  `pbo: None`. One pre-registered configuration has nothing to overfit; printing
  0.0 there would read as evidence.
- **Contiguous, not interleaved groups.** Interleaving would place a training
  bar next to every test bar by construction.

## Drive-by fix

`main()` built two parsers: an empty one that consumed `argv` so `--help` would
answer through the CLI, then a second that re-read `sys.argv` for the real
flags. The first rejected every flag the second defined, so
`clawock validate-regime-dial --folds 4` — the invocation this module's own
docstring documents, and the one an earlier #1114 comment offered as the
reproducible path — exited 2 without running anything. One parser now.

## Tests

`tests/test_cscv_pbo.py` — 10 tests, all offline: a search over pure noise
reports ~0.5 (0.49 measured); a configuration with a real edge reports ≤0.05 and
wins all 70 splits; too few groups or one configuration refuse with no number;
the embargo blocks both sides of every test block, not just the first; groups
partition the sample; every split is a disjoint cover; the dial scores the same
quantity `summarize()['drawdown_improvement']` returns.

Full local suite: 2813 passed.
