### PR TITLE
decisions: let a decision carry the debate that produced it (#1117)

### DIFF
--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -3943,6 +3943,11 @@
       bits.push(`active overrides ${metrics.active_overrides}`);
     if (dm && dm.decisiveness_pct != null)
       bits.push(`辩论决断率 ${dm.decisiveness_pct}%`);
+    // 决断率说的是辩论得出了什么；这一条说的是辩论有没有留下能核对的反方案文
+    // —— 「我们真的辩过」在没有记录之前只是一句自述（#1117）。
+    const dc = dm && dm.debate_coverage;
+    if (dc && dc.bear_case_pct != null)
+      bits.push(`留了反方案文 ${dc.bear_case_pct}%（${dc.with_bear_case}/${dc.decisions}）`);
     if (bits.length) el.insertAdjacentHTML("afterbegin",
       `<div style="font-size:var(--fs-xs);opacity:.75;margin-bottom:var(--space-2)">${bits.join(" · ")}</div>`);
   }

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -713,7 +713,14 @@ postflight 严格 schema 校验：
       "regime": "risk_off",
       "contested": true,
       "rationale": "降低杠杆 beta；这是组合政策型再平衡，不是预测",
-      "thesis_invalidation": "若 crypto rev 环比转正 / DAU 回升 → 论点失效，停止减仓"
+      "thesis_invalidation": "若 crypto rev 环比转正 / DAU 回升 → 论点失效，停止减仓",
+      "debate": {
+        "bull": "crypto rev 若回暖，减到 50% 会踏空反弹",
+        "bear": "杠杆 beta 在 risk_off 下放大回撤，DAU 连续两季下滑无止跌迹象",
+        "attacked_consensus": "攻击的是「AI 板块整体还有一波」这条最强共识",
+        "frames": ["technical_breakdown", "relative_strength"],
+        "judge": "纪律优先：政策型减仓不等预测兑现"
+      }
     },
     {
       "strategy_id": "intraday_t",
@@ -752,6 +759,12 @@ postflight 严格 schema 校验：
 - `size.shares`（整数，**主动 call（`cut`/`trim_on_rebound`/`t_only`/`add_only_on_trigger`/`add_on_breakout`）必填**；`hold_and_watch`/`watch` 不需要)：股数是这条 call 日后唯一能被折算成钱的凭据。面板上那条金额曲线已撤（见上条铁律），但**重建一套可信对照账本必须有股数，当天没填就永远补不回来**。宁可给保守估数也别留空。填**你真的会动的股数**,不是仓位上限。
 - 所有 add 都必须逐字填写 packet setup 的 `technical_setup_id`、`technical_campaign_id`、`invalidation_price`、`condition.valid_for_sessions` 与 `tranche_number=next_tranche_number`。`alpha_confirmation` 的 `driven_by` 应按真正主导证据写 `peer`/`catalyst`/`sentiment`，不能因为技术只负责 timing 就洗成 `technical`。exploration 只是 0.25 target tranche 的前瞻采样，不是 validated；每日重置杠杆产品不能走 exploration。港股 `size.shares` 必须为 `lot_size` 的整手倍数；美股当前只支持整数股。已有 open add 或 `remaining_tranches=0` 时不得重复开单。
 - `contested` ∈ {`true`, `false`}（每个 decision 必填）：Tier 2 的 Bull 与 Bear 是否真的在该策略上分歧。
+- `debate`（object，主动 call 应填，`hold_and_watch`/`watch` 选填）：**把已经发生的辩论落成可核对的结构**（#1117）。Bull/Bear/devil's advocate/Judge frame 这四件事你本来就在 markdown 里写，但读者只能看到结论，无法核对反方是否真的存在——「我们辩过」在没有记录之前只是一句自述。字段：
+  - `bull` / `bear`：这条 decision 上双方最强的一句话（各 ≤600 字符，超出截断）。`bear` 是这块的重点：赢的那面本来就在 `rationale` 里。
+  - `attacked_consensus`：本轮 devil's advocate（见 § Tier 2 铁律）点名攻击的那条最强共识。与该票无关时可省略，别为了填而编。
+  - `frames`：`Judge — strategy frames` 表里为这条 action 选的 1–3 个 frame，逐字照抄枚举值。
+  - `judge`：Judge 的合成判词一句话（不是 Bull/Bear 的复述）。
+  - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。
 - `thesis_invalidation`（string，主动 cut/trim/add 必填；hold 选填）：**借鉴 UZI-Skill 的 thesis-tracking**——这个仓位的论点**会被什么具体催化推翻**？把 catalyst-gate(cut #1)落地成「论点+失效条件」：你只在这个**失效催化真的发生**时动手，而不是技术面波动。例：「crypto rev 环比转正则停止减仓」。这逼着每个主动 call 绑定一个可被证伪的硬催化，而非"看着toppy"。
 - `thesis_id` 必须沿用 `context.thesis_registry.theses.<ticker>.thesis_id`（resolved 时）；registry 为 `unknown` 时保留已有 decision ID，不得新造一个“看起来像历史”的 canonical thesis。`context.retrospective.decisions[].thesis_ref` 是只读解析结果。
 

--- a/src/clawock/decision/actions.py
+++ b/src/clawock/decision/actions.py
@@ -6,3 +6,13 @@ ACTIVE_ACTIONS = {
 SELL_ACTIONS = {"cut", "trim_on_rebound", "t_only"}
 ADD_ACTIONS = ACTIVE_ACTIONS - SELL_ACTIONS
 PASSIVE_ACTIONS = {"hold_and_watch", "watch"}
+
+# The Judge's strategy frames (skills/daily-deep-brief/SKILL.md § Strategy frame
+# menu). The brief already requires the Judge to name one to three of these per
+# action, in a markdown table nothing can read back. Naming them here lets a
+# decision carry the frame it was decided under as data (#1117).
+STRATEGY_FRAMES = {
+    "momentum", "mean_reversion", "breakout", "relative_strength",
+    "earnings_setup", "sentiment_shift", "technical_breakdown",
+    "sector_rotation",
+}

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -38,6 +38,7 @@ from clawock.decision.actions import (
     ADD_ACTIONS,
     PASSIVE_ACTIONS,
     SELL_ACTIONS,
+    STRATEGY_FRAMES,
 )
 from clawock.workspace import workspace_root
 
@@ -164,6 +165,56 @@ def infer_strategy(action: dict) -> str:
     return "core_position"
 
 
+#: Longest debate text kept per field. The block rides in every plan and every
+#: ledger row; a bear case that needs more than this is a brief section, and the
+#: brief is where it belongs.
+DEBATE_TEXT_CHARS = 600
+
+DEBATE_TEXT_FIELDS = ("bull", "bear", "attacked_consensus", "judge")
+
+
+def normalize_debate(raw) -> dict | None:
+    """The debate that produced one decision, as data rather than prose (#1117).
+
+    The brief already runs Bull, Bear, a named devil's advocate attack and a
+    Judge that must pick strategy frames — and then publishes a summary in which
+    none of it is separable. A reader cannot check that the opposing case
+    existed, only that the write-up says it did.
+
+    Deliberately lenient, and that is the whole design of this first step. This
+    field is written by a model, inside a cron that must produce a brief every
+    morning: a strict schema here buys structure by adding a new way for the
+    08:00 pipeline to go red. So unknown keys are dropped, values are coerced
+    and trimmed, unknown frames are discarded, and a block with nothing in it
+    becomes ``None`` rather than an empty object that would inflate coverage.
+
+    Nothing is silenced by that leniency: `compute_debate_metrics` publishes how
+    many decisions actually carry a bear case, so degradation shows up as a
+    falling series rather than as a quietly accepted empty block. Making the
+    field required is the next step, and it should be taken against that series,
+    not against a hope.
+    """
+    if not isinstance(raw, dict):
+        return None
+    out = {}
+    for field in DEBATE_TEXT_FIELDS:
+        value = raw.get(field)
+        if isinstance(value, str) and value.strip():
+            out[field] = value.strip()[:DEBATE_TEXT_CHARS]
+    frames = raw.get("frames")
+    if isinstance(frames, str):
+        frames = [frames]
+    if isinstance(frames, list):
+        kept = []
+        for frame in frames:
+            name = str(frame or "").strip()
+            if name in STRATEGY_FRAMES and name not in kept:
+                kept.append(name)
+        if kept:
+            out["frames"] = kept[:3]
+    return out or None
+
+
 def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) -> dict:
     ticker = str(action.get("ticker") or "").strip()
     act = action.get("action") or action.get("bucket") or "watch"
@@ -215,6 +266,10 @@ def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) ->
         "evidence_event_id": action.get("evidence_event_id"),
         "regime": action.get("regime") if action.get("regime") in REGIMES else "unknown",
         "rationale": action.get("rationale") or "",
+        # The Bull/Bear/devil's-advocate/Judge structure behind this row, when
+        # the brief emitted it. None, not {}, when it did not: absent and empty
+        # are different facts and coverage counts them differently (#1117).
+        "debate": normalize_debate(action.get("debate")),
         "technical_setup_id": action.get("technical_setup_id"),
         "technical_campaign_id": action.get("technical_campaign_id"),
         "invalidation_price": _float(action.get("invalidation_price")),
@@ -363,6 +418,26 @@ def validate_decision(d: dict) -> list[str]:
     override = d.get("override") or {}
     if override.get("status", "none") not in ("none", "active", "expired", "revoked"):
         errors.append(f"bad override.status {override.get('status')!r}")
+    # Shape only, and only when present. `normalize_debate` has already coerced
+    # anything the brief emitted, so this can only fire on a hand-written or
+    # externally produced plan — which is exactly where an unreadable debate
+    # block should be refused rather than stored (#1117).
+    debate = d.get("debate")
+    if debate is not None:
+        if not isinstance(debate, dict) or not debate:
+            errors.append("debate must be null or a non-empty object")
+        else:
+            unknown = set(debate) - set(DEBATE_TEXT_FIELDS) - {"frames"}
+            if unknown:
+                errors.append(f"unknown debate field(s) {sorted(unknown)}")
+            for field in DEBATE_TEXT_FIELDS:
+                if field in debate and not isinstance(debate[field], str):
+                    errors.append(f"debate.{field} must be text")
+            frames = debate.get("frames")
+            if frames is not None and (
+                    not isinstance(frames, list)
+                    or any(frame not in STRATEGY_FRAMES for frame in frames)):
+                errors.append("debate.frames must be strategy frames from the menu")
     return errors
 
 

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1163,6 +1163,7 @@ def compute_debate_metrics(recent=20):
     """
     paths = sorted(glob.glob(str(WS_ROOT / 'memory' / '*-plan.json')))[-recent:]
     n_actions = n_active = n_contested = n_contested_known = 0
+    n_debate = n_bear = n_attacked = n_frames = 0
     buckets = {}
     plans_n = 0
     for p in paths:
@@ -1184,6 +1185,19 @@ def compute_debate_metrics(recent=20):
             if isinstance(c, bool):
                 n_contested_known += 1
                 n_contested += 1 if c else 0
+            # `contested` is the debate's verdict compressed to one bit; these
+            # count whether the debate itself was recorded (#1117). A claim that
+            # both sides were argued is checkable only if the losing side is on
+            # the page, so `bear` is counted separately from "any block".
+            debate = a.get('debate')
+            if isinstance(debate, dict) and debate:
+                n_debate += 1
+                if str(debate.get('bear') or '').strip():
+                    n_bear += 1
+                if str(debate.get('attacked_consensus') or '').strip():
+                    n_attacked += 1
+                if debate.get('frames'):
+                    n_frames += 1
     if not n_actions:
         return None
     return {
@@ -1194,9 +1208,23 @@ def compute_debate_metrics(recent=20):
         'contested_rate': (round(n_contested / n_contested_known, 3)
                            if n_contested_known else None),
         'contested_coverage': n_contested_known,
+        # Stage 1 of #1117 is deliberately un-gated: the field is optional, so
+        # this series is what says whether the structure is actually being
+        # emitted. It is the evidence a later required-field gate should be
+        # argued from.
+        'debate_coverage': {
+            'decisions': n_actions,
+            'with_debate': n_debate,
+            'with_bear_case': n_bear,
+            'with_attacked_consensus': n_attacked,
+            'with_frames': n_frames,
+            'bear_case_pct': round(100 * n_bear / n_actions, 1) if n_actions else None,
+        },
         'note': ('辩论产出量化：decisiveness 低=risk_on 里 Judge 大多回 HOLD，'
                  '一行默认规则即可复现，3-5x token 的辩论边际可疑。contested_rate '
-                 '待 plan 开始标记后，与 calibration 联合检验「被争议的 call 是否校准更好」。'),
+                 '待 plan 开始标记后，与 calibration 联合检验「被争议的 call 是否校准更好」。'
+                 'debate_coverage 量的是另一件事：辩论本身有没有留下可核对的结构'
+                 '（反方案文、被攻击的共识、Judge frame），而不是它得出了什么结论。'),
     }
 
 

--- a/tests/test_structured_debate.py
+++ b/tests/test_structured_debate.py
@@ -1,0 +1,178 @@
+"""A decision must be able to carry the debate that produced it (#1117).
+
+The brief runs Bull, Bear, a named devil's-advocate attack and a Judge that has
+to pick strategy frames — and then publishes a summary in which none of that is
+separable. Measured before this change: every decision in a plan carried exactly
+one prose `rationale`, so "we argued both sides" was an assertion about a
+process, checkable by nobody outside the desk.
+
+This is the first step of that issue and it is deliberately optional: the field
+is written by a model inside the cron that must produce a brief every morning,
+so a strict schema would buy structure by adding a new way for 08:00 to go red.
+What these tests hold is that leniency does not become silence — the block is
+normalized rather than rejected, and how often it is actually emitted is
+published as a number.
+"""
+import json
+
+from clawock.decision import ledger as dv2
+from clawock.decision.actions import STRATEGY_FRAMES
+from clawock.publish import dashboard
+
+
+def authored(**over):
+    row = {
+        "ticker": "AAA", "action": "cut", "strategy_id": "core_position",
+        "condition": {"type": "open"}, "confidence": 0.6,
+        "driven_by": "technical", "size": {"shares": 1},
+    }
+    row.update(over)
+    return row
+
+
+def normalized(**over):
+    row = dv2.legacy_action_to_decision(authored(**over), "2026-08-28")
+    row["episode_id"] = "ep-test"
+    return row
+
+
+def test_a_decision_carries_the_debate_the_brief_already_ran():
+    row = normalized(debate={
+        "bull": "the position still has a catalyst ahead",
+        "bear": "leverage decay eats the thesis before the catalyst lands",
+        "attacked_consensus": "attacked the 'AI has another leg' consensus",
+        "frames": ["technical_breakdown", "relative_strength"],
+        "judge": "discipline first: policy trim does not wait for a prediction",
+    })
+
+    assert row["debate"]["bear"].startswith("leverage decay")
+    assert row["debate"]["frames"] == ["technical_breakdown", "relative_strength"]
+    assert dv2.validate_decision(row) == []
+
+
+def test_a_plan_without_a_debate_block_is_still_valid_and_says_so():
+    """Optional means optional — and absent must not read as an empty debate."""
+    row = normalized()
+
+    assert row["debate"] is None
+    assert dv2.validate_decision(row) == []
+
+
+def test_a_malformed_block_is_normalized_rather_than_failing_the_morning():
+    """The one property that decides whether this is safe to ship at all.
+
+    This field is model-written inside the 08:00 cron. Unknown keys, an
+    over-long case, a frame that is not on the menu and a bare string where a
+    list belongs must all normalize, because the alternative is a brief that
+    does not go out.
+    """
+    row = normalized(debate={
+        "bull": "  padded  ",
+        "bear": "x" * 5000,
+        "frames": "momentum",
+        "judge": 42,
+        "invented_field": "ignored",
+        "attacked_consensus": "",
+    })
+
+    debate = row["debate"]
+    assert debate["bull"] == "padded"
+    assert len(debate["bear"]) == dv2.DEBATE_TEXT_CHARS
+    assert debate["frames"] == ["momentum"], "a single frame may arrive unwrapped"
+    assert "judge" not in debate, "a non-string value is dropped, not coerced"
+    assert "invented_field" not in debate
+    assert "attacked_consensus" not in debate, "an empty string is not a case"
+    assert dv2.validate_decision(row) == []
+
+
+def test_frames_outside_the_judges_menu_are_discarded():
+    row = normalized(debate={"bear": "b", "frames": ["momentum", "vibes", "breakout"]})
+
+    assert row["debate"]["frames"] == ["momentum", "breakout"]
+    assert "vibes" not in STRATEGY_FRAMES
+
+
+def test_a_debate_block_with_nothing_in_it_is_recorded_as_absent():
+    """Otherwise an empty object inflates the coverage number it is measured by."""
+    for empty in ({}, {"bull": "   "}, {"frames": ["nonsense"]}, "not a dict", None):
+        assert dv2.normalize_debate(empty) is None
+
+
+def test_a_hand_written_plan_with_an_unreadable_block_is_refused():
+    """Leniency covers the model's output, which the normalizer has already seen.
+
+    Anything reaching validation unnormalized came from a hand-edited or foreign
+    plan, and there the right answer is to refuse rather than store a block no
+    consumer can read.
+    """
+    row = normalized()
+
+    row["debate"] = {"bear": ["not", "text"]}
+    assert "debate.bear must be text" in dv2.validate_decision(row)
+
+    row["debate"] = {"bear": "b", "smuggled": "x"}
+    assert any("unknown debate field" in e for e in dv2.validate_decision(row))
+
+    row["debate"] = {"bear": "b", "frames": ["vibes"]}
+    assert any("strategy frames" in e for e in dv2.validate_decision(row))
+
+    row["debate"] = {}
+    assert "debate must be null or a non-empty object" in dv2.validate_decision(row)
+
+
+def _plan(tmp_path, decisions):
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "memory" / "2026-08-28-plan.json").write_text(
+        json.dumps({"schema_version": 2, "date": "2026-08-28",
+                    "decisions": decisions}), encoding="utf-8")
+
+
+def test_the_dashboard_publishes_how_often_the_debate_was_actually_recorded(
+        tmp_path, monkeypatch):
+    """The number that keeps stage 1 honest.
+
+    An optional field with no series behind it decays quietly. This one is
+    counted per published plan, and the bear case is counted separately from
+    "some block exists" — the losing side is the half a reader cannot otherwise
+    check.
+    """
+    monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
+    _plan(tmp_path, [
+        {"action": "cut", "debate": {"bear": "b", "attacked_consensus": "c",
+                                     "frames": ["momentum"]}},
+        {"action": "hold_and_watch", "debate": {"bull": "only one side"}},
+        {"action": "watch"},
+    ])
+
+    coverage = dashboard.compute_debate_metrics()["debate_coverage"]
+
+    assert coverage == {
+        "decisions": 3, "with_debate": 2, "with_bear_case": 1,
+        "with_attacked_consensus": 1, "with_frames": 1,
+        "bear_case_pct": 33.3,
+    }
+
+
+def test_the_page_prints_the_coverage_rather_than_only_the_verdict():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "site" / "assets" / "js" / "dashboard.render.js").read_text(
+        encoding="utf-8")
+
+    assert "debate_coverage" in js and "bear_case_pct" in js, (
+        "decisiveness says what the debate concluded; nothing said whether the "
+        "debate left anything to check")
+
+
+def test_the_skill_documents_the_field_it_asks_the_model_to_emit():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    skill = (root / "skills" / "daily-deep-brief" / "SKILL.md").read_text(
+        encoding="utf-8")
+
+    assert '"debate"' in skill, "an undocumented field is never emitted"
+    assert "attacked_consensus" in skill and "frames" in skill
+    assert "debate_coverage" in skill, (
+        "the model has to be told the omission is counted, not merely allowed")


### PR DESCRIPTION
First step of #1117. It does **not** close it: the field is optional here, and
making it required is a second decision that should be argued from the coverage
series this PR starts publishing.

## Measured before writing anything

Every decision in `memory/2026-08-28-plan.json` carries one prose `rationale` —
no bull case, no bear case, no named consensus attacked, no judge attribution.
The debate genuinely runs (SKILL.md § Tier 2 requires the devil's advocate to
attack the strongest consensus; § Strategy frame menu requires the Judge to name
1–3 frames per action) but lands in markdown, so the published artifact contains
its conclusion and nothing that lets a reader check the losing side existed.

## What lands

An optional `debate` block on the decision:

```json
"debate": {
  "bull": "crypto rev 若回暖，减到 50% 会踏空反弹",
  "bear": "杠杆 beta 在 risk_off 下放大回撤，DAU 连续两季下滑无止跌迹象",
  "attacked_consensus": "攻击的是「AI 板块整体还有一波」这条最强共识",
  "frames": ["technical_breakdown", "relative_strength"],
  "judge": "纪律优先：政策型减仓不等预测兑现"
}
```

`frames` reuses the Judge's own eight-frame menu, promoted from a markdown table
to `decision.actions.STRATEGY_FRAMES` so it can be read back.

## Why optional and lenient, deliberately

This field is model-written inside the cron that must produce a brief every
morning. A strict schema would buy structure by adding a new way for 08:00 to go
red, which is the risk that kept this issue out of the previous batch.
`normalize_debate` trims over-long text, drops unknown keys, discards frames off
the menu, unwraps a single frame passed bare, and reduces an all-empty block to
`None` — absent and empty are different facts, and an empty object would inflate
the very number that measures this. Validation only fires on a block that
reached it unnormalized (hand-written or foreign plan), where refusing is right.

## Leniency is not silence

`debate_metrics.debate_coverage` counts, across the last 20 published plans, how
many decisions carry a block, a **bear case** (counted separately — the losing
side is the half a reader cannot otherwise check), an attacked consensus, and
frames. The card prints the bear-case share next to the existing decisiveness
rate: `decisiveness_pct` says what the debate concluded, this says whether it
left anything to check. SKILL.md tells the model the omission is counted, not
merely allowed.

## What is deliberately not here

- No required-field gate. That is the next step, and it should be taken against
  a real coverage series.
- No new publishing surface: `memory/*-plan.json` is already public and already
  committed each morning, so the artifact is observable the day the model starts
  emitting it. `brief_projection.json` and its strict overlay schema are
  untouched.
- Nothing in `plan-context` (the relay to later crons) grows: this is evidence
  for a reader, not context for the next model turn.

## Tests

`tests/test_structured_debate.py` — 9 tests: a block survives normalization and
validates; absent stays `None` and stays valid; a malformed block (5000-char
bear, bare-string frame, integer judge, invented key, empty string) normalizes
instead of failing the morning; off-menu frames are discarded; an all-empty
block records as absent; an unnormalized bad block is refused with a named
error; the coverage counter reports 1/3 bear cases on a fixture plan; the card
and the SKILL both name the field.

Full local suite: 2812 passed.
