### PR TITLE
peers: HK auto-discovery was on the wrong endpoint (#1122)

### DIFF
--- a/src/clawock/market_data/peer_discovery.py
+++ b/src/clawock/market_data/peer_discovery.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """Suggest same-industry peers without changing the curated peer map.
 
-US suggestions come from Finnhub's peer-symbol endpoint. HK suggestions use
-East Money to resolve the holding's industry board and then list that board's
-HK constituents. This module is deliberately fail-safe: source failures are
-diagnosed on stderr and always become an empty suggestion list.
+US suggestions come from Finnhub's peer-symbol endpoint. HK suggestions come
+from East Money's F10 industry-comparison report, which answers the whole
+question in one call: given ``00100.HK`` it returns the industry it is filed
+under and every other HK listing in it, with market cap to rank them by.
+
+This module is deliberately fail-safe: source failures are diagnosed on stderr
+and always become an empty suggestion list.
 """
 
 from __future__ import annotations
@@ -27,20 +30,42 @@ API_KEYS_PATH = WS / ".api_keys"
 MAX_AUTO_PEERS = 6
 TIMEOUT = 10
 
-# US same-industry peers via Finnhub are live and verified. HK is NOT wired yet:
-# East Money HK industry boards use ``HK\d+`` codes (00100's 软件服务 board is
-# HK28), not the A-share ``BK\d+``, and the board-constituent endpoint
-# ``clist/get?fs=b:HK28`` returns no rows — the HK constituent query is still
-# unresolved against live data. ``_suggest_hk`` keeps the resolved parts (industry
-# lookup + board match with the corrected code shape) behind this flag so it is
-# ready once the constituent endpoint is confirmed; until then HK holdings get no
-# auto peers and, importantly, make no wasted East Money calls per scan.
+# US same-industry peers via Finnhub are live and verified.
+#
+# HK was blocked for months on the wrong endpoint. The quote API's board
+# constituent query (``clist/get?fs=b:HK28``) does not accept the ``HK\d+``
+# board-code family that ``slist/get`` hands back, and no selector spelling
+# fixes that. The F10 industry-comparison report does not need one: filter
+# ``RPT_PCF10_INDUSTRY_SCALE`` by ``SECUCODE`` and East Money returns the
+# holding's industry plus its HK constituents ranked by market cap, in a single
+# call — 176 rows for 00100 (软件服务), verified live.
+#
+# The flag stays off anyway, and not because the mechanism is unproven.
+# ``peer_residuals.load_rule_config`` refuses to load unless
+# ``automatic_hk_peer_discovery`` is false: the peer-residual rules
+# (leader_continuation / laggard_avoidance / mean_reversion) were pre-registered
+# against the curated peer universe in ``memory/peer-map.json``. Turning
+# discovery on silently re-registers them against a different universe, which
+# invalidates the prospective evidence collected so far. That is a research
+# decision, taken deliberately with a re-registration, not a wiring change —
+# see #1122. Until then HK holdings get no auto peers and make no East Money
+# calls per scan.
 HK_AUTO_PEERS_ENABLED = False
 
 FINNHUB_PEERS_URL = "https://finnhub.io/api/v1/stock/peers"
-EM_STOCK_INFO_URL = "https://push2.eastmoney.com/api/qt/stock/get"
-EM_STOCK_BOARDS_URL = "https://push2.eastmoney.com/api/qt/slist/get"
-EM_BOARD_CONSTITUENTS_URL = "https://push2.eastmoney.com/api/qt/clist/get"
+EM_HK_INDUSTRY_URL = "https://datacenter.eastmoney.com/securities/api/data/v1/get"
+# 规模对比: the industry peer table behind the F10 page's 行业对比 tab. Chosen over
+# the valuation/growth reports because it is the only one carrying market cap,
+# and "the six biggest names in this industry" is the peer set a human would
+# pick — a PE-ranked list would hand back whichever six are cheapest today.
+EM_HK_INDUSTRY_REPORT = "RPT_PCF10_INDUSTRY_SCALE"
+# 8xxxx is the RMB counter of a dual-counter listing (80700 is 00700's), the
+# same company twice. Zero-padding keeps GEM codes like 08083 out of this.
+EM_HK_DUAL_COUNTER = re.compile(r"^8\d{4}$")
+# The report's rows are not all companies: it ends with aggregates such as
+# 行业平均, which carry a label where the code belongs. Measured live on 00100 —
+# 行业平均 was the sixth "peer" until this existed.
+EM_HK_CODE = re.compile(r"^\d{5}$")
 
 
 def _diag(ticker: str, message: str) -> None:
@@ -129,92 +154,59 @@ def _suggest_us(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
 
 
 def _suggest_hk(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
+    """Same-industry HK peers, ranked by market cap, in one East Money call.
+
+    The report is keyed by the holding itself: filtering ``SECUCODE`` to
+    ``00100.HK`` returns one row per company in 00100's industry, each carrying
+    the industry name and the peer's code, name and market cap. There is no
+    board code in the chain at all, which is why this works where the quote
+    API's ``fs=b:HK28`` constituent query never did.
+    """
     symbol = _norm_hk(ticker)
-    secid = f"116.{symbol}"
 
-    info_response = em_get(
-        EM_STOCK_INFO_URL,
+    response = em_get(
+        EM_HK_INDUSTRY_URL,
         params={
-            "fltt": "2",
-            "invt": "2",
-            "secid": secid,
-            "fields": "f57,f58,f127",
+            "reportName": EM_HK_INDUSTRY_REPORT,
+            "columns": ("SECUCODE,SECURITY_CODE,TYPE_ID,TYPE_NAME,"
+                        "CORRE_SECURITY_CODE,CORRE_SECUCODE,CORRE_SECURITY_NAME,"
+                        "HKTOTAL_MARKET_CAP"),
+            "filter": f'(SECUCODE="{symbol}.HK")',
+            "pageNumber": "1",
+            "pageSize": "50",
+            # Ranked here rather than in Python: the report is paged, so sorting
+            # after the fetch would rank page one instead of the industry.
+            "sortColumns": "HKTOTAL_MARKET_CAP",
+            "sortTypes": "-1",
+            "source": "F10",
+            "client": "PC",
         },
+        headers={"Referer": "https://emweb.securities.eastmoney.com/"},
         timeout=TIMEOUT,
-        label="auto-peer HK industry",
+        label="auto-peer HK industry peers",
     )
-    info = (_response_json(info_response, "East Money stock info").get("data") or {})
-    industry = str(info.get("f127") or "").strip()
-    if not industry:
-        _diag(symbol, "East Money returned no industry")
-        return []
-
-    boards_response = em_get(
-        EM_STOCK_BOARDS_URL,
-        params={
-            "fltt": "2",
-            "invt": "2",
-            "secid": secid,
-            "spt": "3",
-            "pi": "0",
-            "pz": "200",
-            "po": "1",
-            "fields": "f12,f14",
-        },
-        headers={"Referer": "https://quote.eastmoney.com/"},
-        timeout=TIMEOUT,
-        label="auto-peer HK board",
-    )
-    boards = _rows(_response_json(boards_response, "East Money stock boards"))
-    if not boards:
-        _diag(symbol, "East Money returned no board memberships")
-        return []
-
-    def board_match(row):
-        name = re.sub(r"\s+", "", str(row.get("f14") or ""))
-        target = re.sub(r"\s+", "", industry)
-        return name == target
-
-    board = next((row for row in boards if board_match(row)), None)
-    board_code = str((board or {}).get("f12") or "")
-    # HK industry boards are HK\d+ (e.g. HK28); A-share boards are BK\d+.
-    if not re.fullmatch(r"(?:BK|HK)\d+", board_code):
-        _diag(symbol, f"East Money could not map industry {industry!r} to a board")
-        return []
-
-    constituents_response = em_get(
-        EM_BOARD_CONSTITUENTS_URL,
-        params={
-            "pn": "1",
-            "pz": "200",
-            "po": "1",
-            "np": "1",
-            "fltt": "2",
-            "invt": "2",
-            "fid": "f20",
-            "fs": f"b:{board_code}",
-            "fields": "f12,f13,f14",
-        },
-        headers={"Referer": f"https://quote.eastmoney.com/bk/90.{board_code}.html"},
-        timeout=TIMEOUT,
-        label="auto-peer HK constituents",
-    )
-    rows = _rows(_response_json(constituents_response, "East Money constituents"))
+    payload = _response_json(response, "East Money HK industry comparison")
+    result = payload.get("result") if isinstance(payload, dict) else None
+    rows = (result or {}).get("data") or []
     if not rows:
-        _diag(symbol, f"East Money board {board_code} returned no constituents")
+        _diag(symbol, "East Money returned no HK industry comparison rows")
         return []
 
+    industry = str((rows[0] or {}).get("TYPE_NAME") or "").strip()
     blocked = _excluded(symbol, "hk", curated_tickers)
     out = []
     seen = set()
     for row in rows:
-        # f13 is East Money's market id. Requiring 116 prevents an A-share
-        # industry board with the same display name from leaking into HK peers.
-        if str(row.get("f13") or "") != "116":
-            continue
-        candidate = _norm_hk(row.get("f12"))
-        name = str(row.get("f14") or "").strip()
+        candidate = _norm_hk(row.get("CORRE_SECURITY_CODE"))
+        name = str(row.get("CORRE_SECURITY_NAME") or "").strip()
         if not candidate or not name or candidate in blocked or candidate in seen:
+            continue
+        # The dual counter is the same issuer trading in RMB; as a peer it is a
+        # copy of a name already in the list, and as a residual it would be that
+        # name's own FX basis.
+        if EM_HK_DUAL_COUNTER.match(candidate):
+            continue
+        if not EM_HK_CODE.match(candidate):
             continue
         seen.add(candidate)
         out.append({
@@ -222,11 +214,12 @@ def _suggest_hk(ticker: str, curated_tickers: Iterable[object]) -> list[dict]:
             "region": "hk",
             "name": name,
             "source": "eastmoney",
+            "industry": industry,
         })
         if len(out) == MAX_AUTO_PEERS:
             break
     if not out:
-        _diag(symbol, f"East Money board {board_code} returned no eligible HK peers")
+        _diag(symbol, f"East Money industry {industry or '?'} returned no eligible HK peers")
     return out
 
 
@@ -242,9 +235,12 @@ def suggest_auto_peers(ticker, region, curated_tickers) -> list[dict]:
             return _suggest_us(ticker, curated_tickers)
         if normalized_region == "hk":
             if not HK_AUTO_PEERS_ENABLED:
+                # The source works (see the flag's comment); what is off is the
+                # switch, because turning it on re-registers the peer-residual
+                # rules against a different peer universe.
                 _diag(str(ticker),
-                      "HK auto-peers not wired yet (East Money board-constituent "
-                      "endpoint unresolved); skipping")
+                      "HK auto-peers held off pending peer-residual rule "
+                      "re-registration (#1122); skipping")
                 return []
             return _suggest_hk(ticker, curated_tickers)
         _diag(str(ticker), f"unsupported region {region!r}")

--- a/tests/test_suggest_peers.py
+++ b/tests/test_suggest_peers.py
@@ -52,43 +52,48 @@ def test_us_outage_returns_empty_and_diagnoses(monkeypatch, capsys):
 
 
 def test_hk_gated_off_by_default_makes_no_em_calls(monkeypatch, capsys):
-    # HK auto-peers ship disabled (East Money HK constituent endpoint unresolved).
-    # The gate must short-circuit BEFORE any East Money call so a HK-heavy scan
-    # is not slowed by wasted/failing requests every cycle.
+    # HK auto-peers ship disabled — no longer because the source is unresolved
+    # (it works, see the parser test below) but because turning them on
+    # re-registers the peer-residual rules against a different peer universe
+    # (#1122). The gate must still short-circuit BEFORE any East Money call so a
+    # HK-heavy scan is not slowed by requests whose result is discarded.
     calls = []
     monkeypatch.setattr(sp, "em_get", lambda *a, **kw: calls.append(kw) or None)
 
     assert sp.suggest_auto_peers("00700", "hk", ["09988"]) == []
     assert calls == []
-    assert "not wired yet" in capsys.readouterr().err
+    assert "re-registration" in capsys.readouterr().err
 
 
-def test_hk_parser_resolves_industry_excludes_and_caps_six(monkeypatch):
-    # Guards `_suggest_hk` (called directly, bypassing the ship gate) so the parser
-    # is correct for when HK is enabled — using a realistic HK\d+ board code.
+def test_hk_peers_come_from_one_industry_report_call_ranked_by_market_cap(monkeypatch):
+    """Guards `_suggest_hk` directly, bypassing the ship gate.
+
+    The board-code chain this replaced took three calls and died on the last
+    one: `clist/get?fs=b:HK28` does not accept the `HK\\d+` family that
+    `slist/get` returns, and no spelling of the selector fixes it. The F10
+    industry report is keyed by the holding itself, so the whole answer —
+    industry name, constituents, market cap to rank them — arrives in one call
+    with no board code anywhere in the chain.
+    """
     calls = []
 
     def fake_em_get(url, **kwargs):
         calls.append((url, kwargs["params"]))
-        if url == sp.EM_STOCK_INFO_URL:
-            return FakeResponse({"data": {"f57": "00700", "f58": "腾讯控股", "f127": "互联网服务"}})
-        if url == sp.EM_STOCK_BOARDS_URL:
-            return FakeResponse({"data": {"diff": [
-                {"f12": "HK9999", "f14": "腾讯概念"},
-                {"f12": "HK28", "f14": "互联网服务"},
-            ]}})
-        assert url == sp.EM_BOARD_CONSTITUENTS_URL
-        return FakeResponse({"data": {"diff": [
-            {"f12": "00700", "f13": 116, "f14": "腾讯控股"},
-            {"f12": "09988", "f13": 116, "f14": "阿里巴巴-W"},
-            {"f12": "03690", "f13": 116, "f14": "美团-W"},
-            {"f12": "01024", "f13": 116, "f14": "快手-W"},
-            {"f12": "09626", "f13": 116, "f14": "哔哩哔哩-W"},
-            {"f12": "09888", "f13": 116, "f14": "百度集团-SW"},
-            {"f12": "09999", "f13": 116, "f14": "网易-S"},
-            {"f12": "03888", "f13": 116, "f14": "金山软件"},
-            {"f12": "00772", "f13": 116, "f14": "阅文集团"},
-            {"f12": "600519", "f13": 1, "f14": "贵州茅台"},
+        return FakeResponse({"result": {"count": 176, "data": [
+            {"TYPE_NAME": "互联网服务", "CORRE_SECURITY_CODE": code,
+             "CORRE_SECURITY_NAME": name}
+            for code, name in [
+                ("00700", "腾讯控股"),
+                ("80700", "腾讯控股-R"),
+                ("09988", "阿里巴巴-W"),
+                ("03690", "美团-W"),
+                ("01024", "快手-W"),
+                ("09626", "哔哩哔哩-W"),
+                ("09888", "百度集团-SW"),
+                ("09999", "网易-S"),
+                ("03888", "金山软件"),
+                ("00772", "阅文集团"),
+            ]
         ]}})
 
     monkeypatch.setattr(sp, "em_get", fake_em_get)
@@ -97,12 +102,57 @@ def test_hk_parser_resolves_industry_excludes_and_caps_six(monkeypatch):
 
     assert [p["ticker"] for p in peers] == [
         "03690", "01024", "09626", "09888", "09999", "03888"
-    ]
-    assert len(peers) == 6
+    ], "self and curated names are excluded, order is the report's market-cap rank"
+    assert len(calls) == 1, "the three-call board chain is gone"
+    url, params = calls[0]
+    assert url == sp.EM_HK_INDUSTRY_URL
+    assert params["filter"] == '(SECUCODE="00700.HK")'
+    assert params["sortColumns"] == "HKTOTAL_MARKET_CAP" and params["sortTypes"] == "-1", (
+        "the report is paged, so ranking after the fetch would rank page one")
     assert all(p["region"] == "hk" and p["source"] == "eastmoney" for p in peers)
-    assert calls[0][0] == sp.EM_STOCK_INFO_URL
-    assert calls[1][0] == sp.EM_STOCK_BOARDS_URL
-    assert calls[2][1]["fs"] == "b:HK28"
+    assert all(p["industry"] == "互联网服务" for p in peers)
+
+
+def test_the_rmb_dual_counter_is_not_offered_as_its_own_peer(monkeypatch):
+    """80700 is 00700 in RMB — the same issuer, and as a residual its own FX basis."""
+    monkeypatch.setattr(sp, "em_get", lambda *a, **kw: FakeResponse(
+        {"result": {"data": [
+            {"TYPE_NAME": "互联网服务", "CORRE_SECURITY_CODE": "80700",
+             "CORRE_SECURITY_NAME": "腾讯控股-R"},
+            {"TYPE_NAME": "互联网服务", "CORRE_SECURITY_CODE": "08083",
+             "CORRE_SECURITY_NAME": "中国先锋医药"},
+        ]}}))
+
+    peers = sp._suggest_hk("00700", [])
+
+    assert [p["ticker"] for p in peers] == ["08083"], (
+        "a GEM code starting 08 is a real listing; only the 8xxxx counter goes")
+
+
+def test_the_industry_average_row_is_not_a_company(monkeypatch):
+    """Measured live: 行业平均 was the sixth "peer" 00100 got back.
+
+    The report ends with aggregate rows that carry a label where the code
+    belongs, and every downstream consumer would then try to price a ticker
+    called 行业平均.
+    """
+    monkeypatch.setattr(sp, "em_get", lambda *a, **kw: FakeResponse(
+        {"result": {"data": [
+            {"TYPE_NAME": "软件服务", "CORRE_SECURITY_CODE": "00700",
+             "CORRE_SECURITY_NAME": "腾讯控股"},
+            {"TYPE_NAME": "软件服务", "CORRE_SECURITY_CODE": "行业平均",
+             "CORRE_SECURITY_NAME": "行业平均"},
+        ]}}))
+
+    assert [p["ticker"] for p in sp._suggest_hk("00100", [])] == ["00700"]
+
+
+def test_an_empty_industry_report_degrades_to_no_peers(monkeypatch, capsys):
+    monkeypatch.setattr(sp, "em_get", lambda *a, **kw: FakeResponse(
+        {"result": None, "success": True}))
+
+    assert sp._suggest_hk("00700", []) == []
+    assert "no HK industry comparison rows" in capsys.readouterr().err
 
 
 def test_hk_outage_returns_empty_and_diagnoses_when_enabled(monkeypatch, capsys):


### PR DESCRIPTION
Unblocks #1122's mechanism. It does **not** close the issue: the flag stays off, and turning it on is a research decision (below).

## The blocker was the endpoint, not the selector

`_suggest_hk` resolved the industry board (`slist/get` → `HK28`) and then asked the quote API for that board's constituents: `clist/get?fs=b:HK28`. That call has never returned a row, and the module has carried `# HK is NOT wired yet` with a disabled flag ever since. Every round of this issue went looking for the right *spelling* of the selector.

`clist/get` does serve HK — `fs=b:MK0144` returns 621 rows — it just does not accept the `HK\d+` board-code family that `slist/get` hands back. East Money's own F10 page never asks it to: the 行业对比 tab reads `RPT_PCF10_INDUSTRY_SCALE` from the datacenter API, keyed by the holding itself.

```
datacenter.eastmoney.com/securities/api/data/v1/get
  reportName=RPT_PCF10_INDUSTRY_SCALE
  filter=(SECUCODE="00100.HK")
  sortColumns=HKTOTAL_MARKET_CAP  sortTypes=-1
→ 176 rows: TYPE_NAME 软件服务 + every HK listing in it + market cap
```

One call instead of three, and no board code anywhere in the chain. (Found by reading how `akshare`'s `stock_hk_comparison_em.py` does it, then verifying live.)

## Live output

```
00100  软件服务  → 腾讯控股 · 网易 · 智谱 · 壁仞科技 · 地平线机器人-W · 商汤-W
02208  工业工程  → 宁德时代 · 潍柴动力 · 胜宏科技 · 三环集团 · 三一重工 · 中国中车
03032  (ETF)     → no industry comparison → no peers, not an error
```

That first list is what a human curating a peer map for an AI-software name would have written down.

## Two filters the live run earned

Neither is guessable from the response shape:

- **`行业平均` was the sixth "peer" 00100 came back with.** The report ends with aggregate rows that carry a label where the code belongs; everything downstream would then try to price a ticker called 行业平均.
- **80700 is 00700's RMB counter** — the same issuer twice, and as a *residual* it would be that name's own FX basis. The filter is `^8\d{4}$` on the zero-padded code, so GEM listings like 08083 are unaffected (test pins this).

Ranking is done by the API (`sortColumns`), not in Python: the report is paged, so sorting after the fetch would rank page one rather than the industry.

## Why the flag still stays off

`peer_residuals.load_rule_config` raises unless `automatic_hk_peer_discovery` is false, and that is not defensive plumbing — the three rules (`leader_continuation` / `laggard_avoidance` / `mean_reversion`) were **pre-registered against the curated universe** in `memory/peer-map.json`. Flipping discovery on re-registers them against a different peer universe and invalidates the prospective evidence collected against the old one.

So this PR changes the *reason* the flag is off, from "the source is unresolved" to "the re-registration has not been decided", and the gate's diagnostic now says so. The flip is a one-liner plus a rule re-registration whenever kcn wants it.

## Tests

`tests/test_suggest_peers.py` — the three-call board-chain test is replaced by: one call to the industry report with the right filter and sort; self and curated names excluded; the dual counter dropped while a GEM code survives; the 行业平均 aggregate row rejected; an empty report degrading to `[]` with a diagnostic; the ship gate still short-circuiting before any East Money call. 8 passed; full suite 2837 passed.
