### PR TITLE
evaluation: price the variant search — block bootstrap, deflated Sharpe, CSCV PBO

### DIFF
--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import math
 import random
 import statistics
 from collections import defaultdict
@@ -18,6 +19,8 @@ from pathlib import Path
 
 from clawock import history_store
 from clawock.decision import add_alpha, early_trend, signals
+from clawock.evaluation import bootstrap as block_bootstrap
+from clawock.evaluation import cscv, deflated_sharpe
 from clawock.evidence import news_evidence_graph, run_card
 from clawock.market_data import factors, peer_residuals
 from clawock.workspace import workspace_root
@@ -159,6 +162,23 @@ def _cluster_ci(rows, field, samples=1000):
     ]
 
 
+def _block_ci(rows, field):
+    """Cluster-and-block bootstrap interval for the mean of `field`.
+
+    `_cluster_ci` above resamples dates independently, which is right for the
+    fills sharing a session and wrong for the sessions sharing a regime. This
+    one resamples runs of consecutive sessions instead, choosing the run length
+    from the data (Politis & White) and reporting it, so a reader can tell a
+    genuinely serially-independent series from one where the choice mattered.
+    """
+    by_date = defaultdict(list)
+    for row in rows:
+        value = _number(row.get(field))
+        if value is not None:
+            by_date[row["date"]].append(value)
+    return block_bootstrap.clustered_block_ci(by_date)
+
+
 def _summary(rows):
     values = [row["return"] for row in rows]
     excess = [row["excess_vs_setup"] for row in rows if row.get("excess_vs_setup") is not None]
@@ -173,6 +193,11 @@ def _summary(rows):
             round(statistics.fmean(excess), 6) if excess else None
         ),
         "excess_date_cluster_ci95": _cluster_ci(rows, "excess_vs_setup"),
+        # The same quantity under a resampling that also keeps the serial
+        # dependence (#1148). Both are printed because the difference is the
+        # finding: when the block length comes back 1 the two agree by
+        # construction, and when it does not, the older interval was narrow.
+        "excess_block_ci95": _block_ci(rows, "excess_vs_setup"),
         "status": (
             "diagnostic"
             if len({row["date"] for row in rows}) >= 8 and len(rows) >= 20
@@ -376,6 +401,94 @@ def _factor_rows(snapshot, config_by_ticker):
             ),
             "usable_for_decisions": False,
         }
+    return out
+
+
+#: Every cell a reader's eye can land on in the variant table: four variants
+#: across three horizons. The deflation has to be for the whole table, not for
+#: the row that happened to win, because the winner was chosen from all of it.
+SEARCH_SIZE = len(VARIANTS) * len(HORIZONS)
+
+
+def _daily_variant_matrix(market_observations, horizon):
+    """Per-session mean return of every variant, on the sessions all of them traded.
+
+    Restricted to the common sessions on purpose: the comparison being priced is
+    "which variant would I have picked", and a variant that only traded in the
+    good weeks would win that comparison by having skipped the bad ones rather
+    than by ranking better.
+    """
+    by_variant = {}
+    for variant in VARIANTS:
+        by_date = defaultdict(list)
+        for row in market_observations[variant][horizon]:
+            by_date[row["date"]].append(row["return"])
+        by_variant[variant] = {day: statistics.fmean(values)
+                               for day, values in by_date.items()}
+    common = sorted(set.intersection(*(set(values) for values in by_variant.values()))
+                    if by_variant else [])
+    matrix = [[by_variant[variant][day] for variant in VARIANTS] for day in common]
+    return common, matrix
+
+
+def _selection_rigor(observations):
+    """Price the variant search itself: PBO across splits, DSR against the null.
+
+    The variant table is a search — twelve cells, and the sentence a reader
+    writes from it names the best one. Two independent corrections say what that
+    sentence is worth, and they are reported together because they fail in
+    different directions:
+
+    * **PBO** (`evaluation.cscv`) resamples the *ranking*. It answers "when I
+      pick the winner on half the sessions, how often is it below median on the
+      other half". It needs enough sessions to fill eight groups and says
+      `insufficient_sample` rather than guessing.
+    * **DSR** (`evaluation.deflated_sharpe`) deflates the *level*. It answers
+      "how much of this Sharpe is the expected maximum of twelve draws". It
+      needs twenty sessions and the spread of the twelve Sharpe ratios.
+
+    A high DSR with a high PBO is a real edge whose ranking among near-ties is
+    unstable; the reverse is a stable ranking of a difference too small to
+    distinguish from the search. Neither number is the other's complement.
+    """
+    out = {}
+    for market, market_observations in observations.items():
+        per_market = {}
+        for horizon in HORIZONS:
+            sessions, matrix = _daily_variant_matrix(market_observations, horizon)
+            entry = {
+                "n_sessions_all_variants_traded": len(sessions),
+                "variants": list(VARIANTS),
+                "search_size": SEARCH_SIZE,
+            }
+            if not matrix:
+                entry["status"] = "no_common_sessions"
+                entry["pbo"] = None
+                entry["deflated_sharpe"] = None
+                per_market[f"t{horizon}"] = entry
+                continue
+            # One session is one observation here, so the embargo is measured in
+            # sessions and one session on each side is enough: the label is the
+            # forward return of a fill entered on that session, and the feature
+            # is that session's close.
+            entry["pbo"] = cscv.probability_of_backtest_overfitting(
+                matrix, lambda values: statistics.fmean(values) if values else None,
+                n_groups=8, embargo=max(1, horizon))
+            sharpes = [deflated_sharpe.sharpe([row[index] for row in matrix])
+                       for index in range(len(VARIANTS))]
+            best = max(range(len(VARIANTS)),
+                       key=lambda index: sharpes[index] if sharpes[index] is not None else -math.inf)
+            entry["best_variant_by_sharpe"] = VARIANTS[best] if sharpes[best] is not None else None
+            entry["variant_sharpe"] = {
+                variant: (round(value, 6) if value is not None else None)
+                for variant, value in zip(VARIANTS, sharpes)}
+            entry["deflated_sharpe"] = deflated_sharpe.deflated_sharpe_ratio(
+                [row[best] for row in matrix],
+                n_trials=SEARCH_SIZE,
+                trial_sharpes=[value for value in sharpes if value is not None])
+            entry["status"] = "measured"
+            per_market[f"t{horizon}"] = entry
+        out[market] = per_market
     return out
 
 
@@ -609,6 +722,7 @@ def evaluate(config, policy, news_policy, fetched, factor_history, peer_history,
         }
         for market, states in early_observations.items()
     }
+    metrics["selection_rigor"] = _selection_rigor(observations)
     metrics["coverage"] = {
         **coverage,
         "authority_classifications": authority_counts,
@@ -684,6 +798,9 @@ def main(argv=None):
                 "split_dimensions": ["structure", "vol_regime"],
                 "policy_version": add_alpha.POLICY_VERSION,
                 "parameter_fit": "none; pre-registered thresholds",
+                "search_size": SEARCH_SIZE,
+                "selection_corrections": ["cscv_pbo", "deflated_sharpe"],
+                "interval_estimator": "stationary block bootstrap over session clusters; BCa",
             },
             inputs=inputs,
             metrics=metrics,
@@ -696,6 +813,8 @@ def main(argv=None):
                 "Same-day entry/invalidation ambiguity is invalidated, never assumed filled.",
                 "Early candidates are one row per underlying and use signal-date-close features with T+1/T+5 future closes only as outcomes.",
                 "The early history is small; every result remains collecting/diagnostic, never validated alpha.",
+                "The variant table is a twelve-cell search: selection_rigor prices it with CSCV PBO (ranking) and the deflated Sharpe ratio (level). They are separate corrections and 1-DSR is not PBO.",
+                "Interval estimates resample runs of consecutive sessions, not single sessions; block length is chosen by Politis & White and printed, and a block length of 1 means the data showed no serial dependence.",
                 "Fills are sliced by price structure (breakout / near_high / deep_dip vs prior 20d high) and 20d volatility regime (high/low vs the ticker's own median): measurement only, no behavioural change (#1098/#1099).",
             ],
         )

--- a/src/clawock/evaluation/bootstrap.py
+++ b/src/clawock/evaluation/bootstrap.py
@@ -1,0 +1,317 @@
+"""Resampling that keeps the dependence the sample actually has.
+
+The gap this closes
+-------------------
+`add_alpha_walkforward._cluster_ci` resamples **dates** with replacement and
+pools every fill inside a drawn date. That is the right answer to one of the two
+dependencies in this data — several tickers filling on the same session are not
+independent observations — and no answer at all to the other: consecutive
+sessions are not independent either. A momentum rule that is right for six weeks
+and wrong for six weeks produces a run structure that an i.i.d.-over-dates
+bootstrap cannot see, so the interval it prints is too narrow, and too narrow in
+the direction that makes a result look publishable.
+
+The fix is not a different confidence level. It is to resample **blocks** of
+consecutive dates, so a draw can contain a whole good stretch or a whole bad one
+the way the sample did. `stationary_bootstrap` implements Politis & Romano
+(1994): block lengths are Geometric(1/b) and the series is wrapped, which is
+what keeps the resampled series stationary — fixed-length blocks do not have
+that property at the ends.
+
+Choosing the block length
+-------------------------
+`b` is not a taste parameter. Too small and the bootstrap collapses back to the
+i.i.d. one it was meant to replace; too large and every draw is nearly the
+original sample and the interval collapses the other way. `optimal_block_length`
+implements Politis & White (2004) with Patton, Politis & White's (2009)
+correction: estimate the autocovariance out to a lag where the correlogram has
+gone quiet, weight it with the flat-top kernel, and solve for the length that
+minimises the MSE of the variance estimate. It returns lengths for both the
+stationary and circular schemes because the two have different constants, and it
+returns `1` for a series with no detectable serial dependence — which is the
+honest answer, and is also exactly the case where the old estimator was right.
+
+BCa rather than percentile
+--------------------------
+The statistic here is a mean of a skewed, bounded-below quantity (a return), and
+the percentile interval is biased whenever the bootstrap distribution is not
+centred on the estimate. `bca_interval` applies Efron's bias-correction and
+acceleration: `z0` from the share of draws below the point estimate, `a` from a
+delete-one jackknife **over the clusters**, not over the rows, because deleting
+one fill out of a date leaves the rest of that date's fills in place and would
+understate the influence of the date.
+
+Everything here is standard library. The repository has one hard dependency
+(`requests`) and this module is not a reason to acquire pandas, numpy, scipy or
+scikit-learn — none of the three algorithms above needs a matrix.
+"""
+from __future__ import annotations
+
+import math
+import random
+import statistics
+
+#: Politis & White's own bound. Beyond this the "block" is a sizeable fraction
+#: of the sample and the resample stops being a resample.
+def _max_block(n: int) -> int:
+    return max(1, math.ceil(min(3.0 * math.sqrt(n), n / 3.0)))
+
+
+def _flat_top(t: float) -> float:
+    """Politis & Romano's trapezoidal lag window: flat to 1/2, down to 0 at 1."""
+    t = abs(t)
+    if t <= 0.5:
+        return 1.0
+    if t <= 1.0:
+        return 2.0 * (1.0 - t)
+    return 0.0
+
+
+def autocovariances(series, max_lag: int) -> list[float]:
+    """Biased (divide-by-n) autocovariances, lag 0..max_lag.
+
+    Biased on purpose: the divide-by-n estimator is the one whose lag window
+    weighting Politis & White's constants were derived for, and it keeps the
+    implied spectral density non-negative.
+    """
+    n = len(series)
+    if n == 0:
+        return []
+    mean = statistics.fmean(series)
+    centred = [value - mean for value in series]
+    out = []
+    for lag in range(0, min(max_lag, n - 1) + 1):
+        out.append(sum(centred[i] * centred[i + lag] for i in range(n - lag)) / n)
+    return out
+
+
+def optimal_block_length(series) -> dict:
+    """Politis & White (2004), Patton/Politis/White (2009) correction.
+
+    Returns ``{'stationary': b_sb, 'circular': b_cb, 'm_hat': m, 'n': n}``.
+    ``b = 1`` means the correlogram never left the noise band: the series has no
+    detectable serial dependence at this length and block resampling would only
+    add variance.
+    """
+    values = [float(value) for value in series]
+    n = len(values)
+    if n < 8:
+        return {'stationary': 1, 'circular': 1, 'm_hat': 0, 'n': n}
+    variance = statistics.pvariance(values)
+    if variance <= 0:
+        return {'stationary': 1, 'circular': 1, 'm_hat': 0, 'n': n}
+
+    # The lag beyond which the correlogram is indistinguishable from noise.
+    # `k_n` consecutive lags must all sit inside the band before we accept that
+    # it has: a single dip below the threshold is not evidence of quiet.
+    k_n = max(5, int(math.ceil(math.sqrt(math.log10(n)))))
+    max_lag = min(n - 1, int(math.ceil(math.sqrt(n))) + k_n)
+    gamma = autocovariances(values, max_lag)
+    rho = [value / gamma[0] for value in gamma] if gamma[0] > 0 else [0.0] * len(gamma)
+    band = 2.0 * math.sqrt(math.log10(n) / n)
+
+    m_hat = 0
+    for lag in range(1, len(rho)):
+        window = rho[lag:lag + k_n]
+        if len(window) < k_n:
+            break
+        if all(abs(value) < band for value in window):
+            m_hat = lag - 1
+            break
+    else:
+        m_hat = max(0, len(rho) - 1)
+    if m_hat <= 0:
+        return {'stationary': 1, 'circular': 1, 'm_hat': 0, 'n': n}
+
+    big_m = min(2 * m_hat, n - 1)
+    # g_hat and d_hat are the two moments of the flat-top-weighted correlogram
+    # that the MSE-optimal length trades off: g_hat is the bias term (how much
+    # dependence is being smoothed away) and d_hat the variance term.
+    g_hat = 0.0
+    sum_weighted = gamma[0]
+    for lag in range(1, big_m + 1):
+        if lag >= len(gamma):
+            break
+        weight = _flat_top(lag / big_m)
+        g_hat += 2.0 * weight * lag * gamma[lag]
+        sum_weighted += 2.0 * weight * gamma[lag]
+    if g_hat == 0.0 or sum_weighted == 0.0:
+        return {'stationary': 1, 'circular': 1, 'm_hat': m_hat, 'n': n}
+
+    d_sb = 2.0 * sum_weighted ** 2
+    d_cb = (4.0 / 3.0) * sum_weighted ** 2
+    cap = _max_block(n)
+    b_sb = min(cap, max(1, round((2.0 * g_hat ** 2 / d_sb) ** (1.0 / 3.0) * n ** (1.0 / 3.0))))
+    b_cb = min(cap, max(1, round((2.0 * g_hat ** 2 / d_cb) ** (1.0 / 3.0) * n ** (1.0 / 3.0))))
+    return {'stationary': int(b_sb), 'circular': int(b_cb), 'm_hat': m_hat, 'n': n}
+
+
+def stationary_bootstrap_indices(n: int, block_length: float, rnd: random.Random):
+    """One resampled index path of length `n` (Politis & Romano 1994).
+
+    Geometric block lengths with mean `block_length`, wrapped at the end. The
+    wrap is what makes it *stationary*: without it the first and last
+    observations would be under-represented in every draw.
+    """
+    if n <= 0:
+        return []
+    probability = 1.0 / max(1.0, float(block_length))
+    out = []
+    index = rnd.randrange(n)
+    while len(out) < n:
+        out.append(index)
+        if rnd.random() < probability:
+            index = rnd.randrange(n)
+        else:
+            index = (index + 1) % n
+    return out
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+#: Acklam's rational approximation, refined once with Halley's method against
+#: `erf`. Accurate to well past the precision anything downstream rounds to, and
+#: it does not cost a scipy dependency.
+_A = (-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+      1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00)
+_B = (-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+      6.680131188771972e+01, -1.328068155288572e+01)
+_C = (-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+      -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00)
+_D = (7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+      3.754408661907416e+00)
+
+
+def norm_ppf(p: float) -> float:
+    """Inverse standard normal CDF."""
+    if p <= 0.0:
+        return -math.inf
+    if p >= 1.0:
+        return math.inf
+    low, high = 0.02425, 1 - 0.02425
+    if p < low:
+        q = math.sqrt(-2 * math.log(p))
+        x = (((((_C[0] * q + _C[1]) * q + _C[2]) * q + _C[3]) * q + _C[4]) * q + _C[5]) / \
+            ((((_D[0] * q + _D[1]) * q + _D[2]) * q + _D[3]) * q + 1)
+    elif p <= high:
+        q = p - 0.5
+        r = q * q
+        x = (((((_A[0] * r + _A[1]) * r + _A[2]) * r + _A[3]) * r + _A[4]) * r + _A[5]) * q / \
+            (((((_B[0] * r + _B[1]) * r + _B[2]) * r + _B[3]) * r + _B[4]) * r + 1)
+    else:
+        q = math.sqrt(-2 * math.log(1 - p))
+        x = -(((((_C[0] * q + _C[1]) * q + _C[2]) * q + _C[3]) * q + _C[4]) * q + _C[5]) / \
+            ((((_D[0] * q + _D[1]) * q + _D[2]) * q + _D[3]) * q + 1)
+    error = _norm_cdf(x) - p
+    density = math.exp(-x * x / 2) / math.sqrt(2 * math.pi)
+    if density > 0:
+        u = error / density
+        x = x - u / (1 + x * u / 2)
+    return x
+
+
+#: The acceleration term is a third moment of the jackknife replicates. Estimated
+#: from three clusters it is noise, and its failure mode is the bad one: it moved
+#: `hk/interaction/t5` from an interval crossing zero to one clearing it, on three
+#: sessions. Below this floor the correction is refused and the caller falls back
+#: to the percentile interval, which is merely wide rather than wrong.
+MIN_CLUSTERS_FOR_BCA = 8
+
+
+def bca_interval(draws, point_estimate, jackknife_values, alpha: float = 0.05) -> list[float] | None:
+    """Efron's bias-corrected and accelerated percentile interval.
+
+    `jackknife_values` are the statistic recomputed with each *cluster* left
+    out. Returns `None` when acceleration cannot be estimated — fewer than
+    `MIN_CLUSTERS_FOR_BCA` clusters, or a jackknife with no spread — because a
+    BCa interval whose `a` was silently set to zero is a percentile interval
+    wearing a citation, and one whose `a` came from three points is worse than
+    that: it narrows the interval using an estimate that has no business being
+    trusted.
+    """
+    if not draws:
+        return None
+    ordered = sorted(draws)
+    total = len(ordered)
+    below = sum(1 for value in ordered if value < point_estimate)
+    share = below / total
+    if share <= 0 or share >= 1:
+        return None
+    z0 = norm_ppf(share)
+
+    if len(jackknife_values) < MIN_CLUSTERS_FOR_BCA:
+        return None
+    mean_jack = statistics.fmean(jackknife_values)
+    deviations = [mean_jack - value for value in jackknife_values]
+    denominator = sum(d * d for d in deviations) ** 1.5
+    if denominator == 0:
+        return None
+    acceleration = sum(d ** 3 for d in deviations) / (6.0 * denominator)
+
+    out = []
+    for tail in (alpha / 2, 1 - alpha / 2):
+        z = norm_ppf(tail)
+        adjusted = z0 + (z0 + z) / (1 - acceleration * (z0 + z))
+        probability = min(max(_norm_cdf(adjusted), 1.0 / total), 1 - 1.0 / total)
+        out.append(ordered[min(total - 1, max(0, int(round(probability * (total - 1)))))])
+    return [round(out[0], 6), round(out[1], 6)]
+
+
+def clustered_block_ci(values_by_cluster: dict, *, samples: int = 2000,
+                       seed: int = 20260830, alpha: float = 0.05,
+                       block_length: float | None = None) -> dict | None:
+    """Confidence interval for the pooled mean under both dependencies.
+
+    `values_by_cluster` maps an orderable cluster key (a session date) to the
+    observations inside it. Clusters are resampled in **blocks of consecutive
+    keys** — that is the serial dependence — and every observation inside a
+    drawn cluster travels with it — that is the cross-sectional dependence.
+
+    The returned block length is part of the answer, not diagnostics: `1` means
+    the data showed no serial dependence and the interval is the i.i.d.-over-
+    dates one, so a reader can see when the two estimators agree by construction
+    rather than by coincidence.
+    """
+    keys = sorted(values_by_cluster)
+    if len(keys) < 3:
+        return None
+    per_cluster_mean = [statistics.fmean(values_by_cluster[key]) for key in keys]
+    pooled = [value for key in keys for value in values_by_cluster[key]]
+    if not pooled:
+        return None
+    point = statistics.fmean(pooled)
+
+    if block_length is None:
+        block_length = optimal_block_length(per_cluster_mean)['stationary']
+    rnd = random.Random(seed)
+    draws = []
+    for _ in range(samples):
+        indices = stationary_bootstrap_indices(len(keys), block_length, rnd)
+        resampled = [value for i in indices for value in values_by_cluster[keys[i]]]
+        draws.append(statistics.fmean(resampled))
+
+    jackknife = []
+    for skip in range(len(keys)):
+        kept = [value for i, key in enumerate(keys) if i != skip
+                for value in values_by_cluster[key]]
+        if kept:
+            jackknife.append(statistics.fmean(kept))
+    interval = bca_interval(draws, point, jackknife, alpha=alpha)
+    if interval is None:
+        ordered = sorted(draws)
+        interval = [round(ordered[int(alpha / 2 * (len(ordered) - 1))], 6),
+                    round(ordered[int((1 - alpha / 2) * (len(ordered) - 1))], 6)]
+        method = 'stationary block bootstrap; percentile'
+    else:
+        method = 'stationary block bootstrap; BCa'
+    return {
+        'point': round(point, 6),
+        'ci95': interval,
+        'block_length': int(block_length),
+        'n_clusters': len(keys),
+        'n_observations': len(pooled),
+        'samples': samples,
+        'method': method,
+    }

--- a/src/clawock/evaluation/deflated_sharpe.py
+++ b/src/clawock/evaluation/deflated_sharpe.py
@@ -1,0 +1,155 @@
+"""What a Sharpe ratio is worth once you count how many were computed.
+
+The gap this closes
+-------------------
+`add_alpha_walkforward` reports four variants across three horizons in two
+markets and the reader's eye goes to the best cell. `cscv` already answers one
+half of what that costs — how often the in-sample winner is below median out of
+sample — and answers it by resampling, which needs enough sessions to fill eight
+groups. The other half is cheaper and available immediately: **the maximum of N
+draws from a zero-mean Sharpe distribution is not zero.** With twenty-four cells
+searched, a best-of Sharpe around 0.5 on a short sample is the expected result
+of searching, not a finding.
+
+`expected_max_sharpe` is that null: the expected largest Sharpe under `n_trials`
+independent trials whose true Sharpe is zero (Bailey & López de Prado, *The
+Deflated Sharpe Ratio*, 2014, eq. 5), using the extreme-value approximation with
+the Euler-Mascheroni constant. `deflated_sharpe_ratio` then reports
+`P(true SR > 0)` after subtracting that null and correcting the standard error
+for the skewness and kurtosis of the returns — because the usual
+`SR·sqrt(T-1)` statistic assumes normal returns, and a negatively skewed,
+fat-tailed return stream makes a given Sharpe far less impressive than the
+normal approximation says.
+
+Two things this is not
+----------------------
+* **It is not PBO, and `1 - DSR` is not PBO.** They answer different questions
+  from different inputs: DSR deflates one estimate by the size of the search,
+  from the moments of one return stream; PBO measures how the ranking of the
+  searched configurations behaves out of sample, from the whole matrix. A rule
+  can have a high DSR and a high PBO (a real edge whose *selection* among near
+  ties is unstable) or the reverse. `evaluation.cscv` owns PBO; this module does
+  not compute it and must not be read as computing it.
+* **It is not a licence to report a number from three observations.** Both
+  functions refuse a sample too short for their own approximation rather than
+  returning a decoration.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+
+from clawock.evaluation.bootstrap import norm_ppf, _norm_cdf
+
+#: Euler-Mascheroni. It appears because the maximum of N i.i.d. normals
+#: converges to a Gumbel, whose location involves it.
+EULER_MASCHERONI = 0.5772156649015329
+
+#: Below this the moment estimates that carry the whole correction (skew and
+#: kurtosis, which are fourth-order quantities) are noise, and a DSR computed
+#: from them says more about the sample than the strategy.
+MIN_OBSERVATIONS = 20
+
+
+def expected_max_sharpe(n_trials: int, variance_of_trials: float) -> float | None:
+    """E[max Sharpe] over `n_trials` independent trials with true Sharpe 0.
+
+    `variance_of_trials` is the variance of the Sharpe ratios that the search
+    actually produced — the spread of the thing being maximised, not the
+    variance of returns. A search over configurations that all score nearly the
+    same has little to gain from being maximised, and this formula says so.
+    """
+    if n_trials < 2 or variance_of_trials <= 0:
+        return None
+    sigma = math.sqrt(variance_of_trials)
+    return sigma * (
+        (1 - EULER_MASCHERONI) * norm_ppf(1 - 1.0 / n_trials)
+        + EULER_MASCHERONI * norm_ppf(1 - 1.0 / (n_trials * math.e))
+    )
+
+
+def sharpe(returns, *, periods_per_year: int | None = None) -> float | None:
+    """Sharpe of a return series, unannualised unless a period count is given."""
+    values = [float(value) for value in returns]
+    if len(values) < 2:
+        return None
+    deviation = statistics.stdev(values)
+    if deviation == 0:
+        return None
+    ratio = statistics.fmean(values) / deviation
+    if periods_per_year:
+        ratio *= math.sqrt(periods_per_year)
+    return ratio
+
+
+def _skew_kurtosis(values) -> tuple[float, float]:
+    """Population skewness and *non-excess* kurtosis (normal = 3)."""
+    n = len(values)
+    mean = statistics.fmean(values)
+    m2 = sum((value - mean) ** 2 for value in values) / n
+    if m2 == 0:
+        return 0.0, 3.0
+    m3 = sum((value - mean) ** 3 for value in values) / n
+    m4 = sum((value - mean) ** 4 for value in values) / n
+    return m3 / m2 ** 1.5, m4 / m2 ** 2
+
+
+def deflated_sharpe_ratio(returns, *, n_trials: int,
+                          variance_of_trials: float | None = None,
+                          trial_sharpes=None) -> dict:
+    """P(true Sharpe > 0) after deflating for the size of the search.
+
+    Give either `variance_of_trials` or the `trial_sharpes` the search produced;
+    with the latter the variance is measured rather than assumed. Returns the
+    probability alongside every input it was computed from, because a DSR quoted
+    without its trial count and its benchmark Sharpe cannot be argued with.
+    """
+    values = [float(value) for value in returns]
+    n = len(values)
+    if n < MIN_OBSERVATIONS:
+        return {'status': 'insufficient_sample', 'dsr': None,
+                'reason': f'{n} observations is below the {MIN_OBSERVATIONS} floor',
+                'n_observations': n, 'n_trials': n_trials}
+    observed = sharpe(values)
+    if observed is None:
+        return {'status': 'insufficient_sample', 'dsr': None,
+                'reason': 'return series has no dispersion',
+                'n_observations': n, 'n_trials': n_trials}
+
+    if variance_of_trials is None and trial_sharpes:
+        finite = [float(value) for value in trial_sharpes if value is not None]
+        variance_of_trials = statistics.pvariance(finite) if len(finite) > 1 else None
+    if not variance_of_trials or variance_of_trials <= 0 or n_trials < 2:
+        return {'status': 'insufficient_search', 'dsr': None,
+                'reason': ('a deflation needs at least two trials with different '
+                           'Sharpe ratios; a single pre-registered configuration '
+                           'has no search to deflate'),
+                'n_observations': n, 'n_trials': n_trials,
+                'observed_sharpe': round(observed, 6)}
+
+    benchmark = expected_max_sharpe(n_trials, variance_of_trials)
+    skewness, kurtosis = _skew_kurtosis(values)
+    # Bailey & López de Prado eq. 9. The denominator is the standard error of a
+    # Sharpe estimate under non-normal returns; it grows with negative skew and
+    # with excess kurtosis, which is why a fat-tailed stream needs a larger
+    # Sharpe to reach the same significance.
+    variance_term = 1 - skewness * observed + (kurtosis - 1) / 4.0 * observed ** 2
+    if variance_term <= 0:
+        return {'status': 'insufficient_sample', 'dsr': None,
+                'reason': 'moment correction is non-positive; sample too extreme',
+                'n_observations': n, 'n_trials': n_trials}
+    statistic = (observed - benchmark) * math.sqrt(n - 1) / math.sqrt(variance_term)
+    return {
+        'status': 'measured',
+        'method': 'Bailey & Lopez de Prado (2014) deflated Sharpe ratio',
+        'dsr': round(_norm_cdf(statistic), 6),
+        'observed_sharpe': round(observed, 6),
+        'benchmark_sharpe': round(benchmark, 6),
+        'n_trials': n_trials,
+        'variance_of_trials': round(variance_of_trials, 8),
+        'n_observations': n,
+        'skewness': round(skewness, 4),
+        'kurtosis': round(kurtosis, 4),
+        'reading': ('probability the true Sharpe exceeds zero once the expected '
+                    'maximum of the search is subtracted; not one minus PBO'),
+    }

--- a/tests/test_block_bootstrap.py
+++ b/tests/test_block_bootstrap.py
@@ -1,0 +1,109 @@
+"""The interval has to widen when the sample is serially dependent (#1148).
+
+`add_alpha_walkforward._cluster_ci` resamples sessions independently. That is
+right for the fills sharing a session and silent about the sessions sharing a
+regime, and the direction of the silence is the dangerous one: a series with
+runs in it gets a narrower interval than it deserves. These tests hold the
+replacement to the three properties that make it worth the extra code — it
+recovers a block length that matches the dependence, it agrees with the old
+estimator exactly when the data says it should, and it refuses the
+bias-correction on a sample too short to estimate it.
+"""
+import random
+import statistics
+
+from clawock.evaluation import bootstrap
+
+
+def _ar1(rho, n=800, seed=17, scale=1.0):
+    rnd = random.Random(seed)
+    series = [0.0] * n
+    for t in range(1, n):
+        series[t] = rho * series[t - 1] + rnd.gauss(0, scale)
+    return series
+
+
+def test_white_noise_asks_for_no_blocks():
+    """The honest answer for an independent series is a block length of one.
+
+    It also means the older estimator was not wrong here, which is why the
+    length is published rather than hidden inside the interval.
+    """
+    rnd = random.Random(5)
+    assert bootstrap.optimal_block_length(
+        [rnd.gauss(0, 1) for _ in range(800)])['stationary'] == 1
+
+
+def test_block_length_grows_with_persistence():
+    weak = bootstrap.optimal_block_length(_ar1(0.2))['stationary']
+    strong = bootstrap.optimal_block_length(_ar1(0.8))['stationary']
+    assert weak < strong
+    # Politis & White's own cap: a block that is a third of the sample is not a
+    # resample any more.
+    assert strong <= bootstrap._max_block(800)
+
+
+def test_serial_dependence_widens_the_interval():
+    """The whole reason for the module.
+
+    Same series, same point estimate; the i.i.d.-over-clusters bootstrap and the
+    block bootstrap disagree, and the block one is wider. If this ever fails in
+    the other direction the block length is being chosen wrong.
+    """
+    series = _ar1(0.85, n=400, scale=0.01)
+    by_cluster = {index: [value] for index, value in enumerate(series)}
+    blocked = bootstrap.clustered_block_ci(by_cluster, samples=1500)
+    iid = bootstrap.clustered_block_ci(by_cluster, samples=1500, block_length=1)
+    assert blocked['block_length'] > 1
+    assert (blocked['ci95'][1] - blocked['ci95'][0]) > (iid['ci95'][1] - iid['ci95'][0])
+
+
+def test_every_observation_in_a_drawn_cluster_travels_with_it():
+    """Cross-sectional dependence: a session is drawn whole or not at all."""
+    by_cluster = {'a': [1.0, 1.0, 1.0], 'b': [2.0], 'c': [3.0], 'd': [4.0]}
+    rnd = random.Random(0)
+    keys = sorted(by_cluster)
+    indices = bootstrap.stationary_bootstrap_indices(len(keys), 1.0, rnd)
+    resampled = [value for i in indices for value in by_cluster[keys[i]]]
+    assert resampled.count(1.0) % 3 == 0
+
+
+def test_bca_is_refused_on_too_few_clusters():
+    """The defect this floor exists for.
+
+    Acceleration is a third moment of the jackknife replicates. From three
+    clusters it is noise, and it narrows the interval — on the live walk-forward
+    it moved `hk/interaction/t5` from crossing zero to clearing it, on three
+    sessions. Below the floor the caller must fall back to the percentile
+    interval, which is merely wide.
+    """
+    draws = [random.Random(1).gauss(0, 1) for _ in range(500)]
+    assert bootstrap.bca_interval(draws, 0.0, [0.1, 0.2, 0.3]) is None
+    by_cluster = {index: [float(index)] for index in range(3)}
+    result = bootstrap.clustered_block_ci(by_cluster, samples=400)
+    assert result['method'].endswith('percentile')
+
+
+def test_bca_is_used_once_there_are_enough_clusters():
+    by_cluster = {index: [random.Random(index).gauss(0.01, 0.02)] for index in range(60)}
+    assert bootstrap.clustered_block_ci(by_cluster, samples=800)['method'].endswith('BCa')
+
+
+def test_inverse_normal_matches_the_forward_one():
+    for probability in (0.001, 0.025, 0.1, 0.5, 0.9, 0.975, 0.999):
+        assert abs(bootstrap._norm_cdf(bootstrap.norm_ppf(probability)) - probability) < 1e-12
+
+
+def test_the_interval_covers_a_known_mean():
+    """Coverage, not shape: 40 independent runs of a known mean should trap it.
+
+    A bootstrap that produces a plausible-looking interval which systematically
+    misses is the failure this catches, and it is invisible in a single run.
+    """
+    hits = 0
+    for seed in range(40):
+        rnd = random.Random(1000 + seed)
+        by_cluster = {index: [rnd.gauss(0.5, 1.0) for _ in range(3)] for index in range(80)}
+        interval = bootstrap.clustered_block_ci(by_cluster, samples=600, seed=seed)['ci95']
+        hits += interval[0] <= 0.5 <= interval[1]
+    assert hits >= 34

--- a/tests/test_deflated_sharpe.py
+++ b/tests/test_deflated_sharpe.py
@@ -1,0 +1,154 @@
+"""A Sharpe ratio has to be deflated by the size of the search (#1134/#1145).
+
+The walk-forward prints twelve cells and the sentence a reader writes from it
+names the best one. The maximum of twelve zero-mean draws is not zero, so that
+sentence needs a null to be compared against. These tests hold the deflation to
+the properties that make it a null rather than a decoration: it grows with the
+number of trials, it kills a winner selected out of noise, it survives a real
+edge, it charges fat tails, and it refuses a search of one.
+"""
+import math
+import random
+import statistics
+
+import pytest
+
+from clawock.evaluation import bootstrap, cscv, deflated_sharpe as ds
+
+
+def _returns(mean, sigma, n, seed):
+    rnd = random.Random(seed)
+    return [rnd.gauss(mean, sigma) for _ in range(n)]
+
+
+def _rescaled_to_sharpe(series, target):
+    """Scale a series about its own mean until its Sharpe equals `target`."""
+    mean = statistics.fmean(series)
+    deviation = statistics.stdev(series)
+    wanted = mean / target
+    return [mean + (value - mean) * (wanted / deviation) for value in series]
+
+
+def test_the_null_grows_with_the_number_of_trials():
+    """Search harder and the bar rises. That is the whole mechanism."""
+    small = ds.expected_max_sharpe(4, 0.01)
+    large = ds.expected_max_sharpe(400, 0.01)
+    assert 0 < small < large
+
+
+def test_the_null_is_zero_width_when_the_trials_do_not_differ():
+    """Twelve configurations that all score the same have nothing to maximise."""
+    assert ds.expected_max_sharpe(12, 0.0) is None
+
+
+def test_a_winner_picked_out_of_noise_does_not_survive_deflation():
+    """Twelve pure-noise streams; deflate the best one against its own search.
+
+    Without the deflation the best of twelve noise streams has a positive
+    Sharpe and a t-statistic that looks like evidence. With it, the probability
+    the true Sharpe is positive collapses — that is the correction earning its
+    place, on the exact shape the walk-forward's variant table has.
+    """
+    trials = [_returns(0.0, 0.02, 500, seed) for seed in range(12)]
+    sharpes = [ds.sharpe(series) for series in trials]
+    best = max(range(12), key=lambda index: sharpes[index])
+    result = ds.deflated_sharpe_ratio(trials[best], n_trials=12, trial_sharpes=sharpes)
+    assert result['status'] == 'measured'
+    # Undeflated, the winner reads as a finding: a t-statistic past 1.6 and a
+    # one-sided probability past 0.94.
+    undeflated = bootstrap._norm_cdf(result['observed_sharpe'] * math.sqrt(499))
+    assert undeflated > 0.9
+    # Deflated, it lands where a search over nothing belongs: the winner's
+    # Sharpe is the expected maximum of the search, so the probability that its
+    # true Sharpe is positive is a coin flip, not a finding.
+    assert result['observed_sharpe'] == pytest.approx(result['benchmark_sharpe'], abs=0.03)
+    assert 0.3 < result['dsr'] < 0.7
+
+
+def test_a_real_edge_survives_the_same_deflation():
+    """The other half: the correction must not simply reject everything.
+
+    Same search size, same sample length, same deflation — one stream with a
+    real drift. The two tests together are what separate a null from a filter
+    that says no to whatever it is shown.
+    """
+    trials = [_returns(0.0, 0.02, 500, seed) for seed in range(11)]
+    edge = _returns(0.006, 0.02, 500, 99)
+    sharpes = [ds.sharpe(series) for series in trials + [edge]]
+    result = ds.deflated_sharpe_ratio(edge, n_trials=12, trial_sharpes=sharpes)
+    assert result['dsr'] > 0.95
+
+
+def test_fat_tails_are_charged_for():
+    """Same Sharpe, heavier tails, lower probability.
+
+    The plain `SR*sqrt(T-1)` statistic assumes normal returns. A stream with the
+    same mean and the same standard deviation but a fatter tail deserves less
+    confidence, and the moment correction is what makes it get less.
+    """
+    rnd = random.Random(4)
+    normal = [rnd.gauss(0.004, 0.02) for _ in range(500)]
+    # A normal mixture: 95% of the days at the same scale, 5% at four times it.
+    # Same mean, fatter tail — the shape a return stream with occasional gaps
+    # actually has, and the one the normal approximation flatters.
+    heavy = [0.004 + (value - 0.004) * (4.0 if rnd.random() < 0.05 else 1.0)
+             for value in normal]
+    # Rescale so both carry the *same* Sharpe and only the shape differs.
+    heavy = _rescaled_to_sharpe(heavy, ds.sharpe(normal))
+    common = dict(n_trials=12, variance_of_trials=0.01)
+    normal_result = ds.deflated_sharpe_ratio(normal, **common)
+    heavy_result = ds.deflated_sharpe_ratio(heavy, **common)
+    assert heavy_result['kurtosis'] > normal_result['kurtosis'] + 1.0
+    assert abs(heavy_result['observed_sharpe'] - normal_result['observed_sharpe']) < 1e-6
+    assert heavy_result['dsr'] < normal_result['dsr']
+
+
+def test_a_single_pre_registered_configuration_is_refused():
+    """There is nothing to deflate, and printing 1.0 would read as evidence."""
+    result = ds.deflated_sharpe_ratio(_returns(0.004, 0.02, 250, 1), n_trials=1)
+    assert result['dsr'] is None
+    assert result['status'] == 'insufficient_search'
+
+
+def test_a_short_sample_is_refused_rather_than_estimated():
+    result = ds.deflated_sharpe_ratio(_returns(0.004, 0.02, 8, 1),
+                                      n_trials=12, variance_of_trials=0.01)
+    assert result['dsr'] is None
+    assert result['status'] == 'insufficient_sample'
+
+
+def test_deflated_sharpe_is_not_one_minus_pbo():
+    """The two corrections are independent, and the issue text conflated them.
+
+    Construct a search where one configuration has a genuine edge and the rest
+    are noise: PBO is low (the ranking is stable) and DSR is high (the level
+    survives). If DSR were `1 - PBO` these two would sum to one, and they do
+    not. They answer different questions from different inputs and are reported
+    side by side for that reason.
+    """
+    def search(drift, seed):
+        rnd = random.Random(seed)
+        matrix = [[rnd.gauss(drift, 0.01) for _ in range(8)] for _ in range(600)]
+        pbo = cscv.probability_of_backtest_overfitting(
+            matrix, lambda values: statistics.fmean(values) if values else None)
+        sharpes = [ds.sharpe([row[column] for row in matrix]) for column in range(8)]
+        best = max(range(8), key=lambda column: sharpes[column])
+        dsr = ds.deflated_sharpe_ratio([row[best] for row in matrix],
+                                       n_trials=8, trial_sharpes=sharpes)
+        return pbo['pbo'], dsr['dsr']
+
+    # Two searches over eight configurations each. They differ only by a common
+    # drift added to every configuration, so the *ranking* problem is identical
+    # in both — same seed, same relative order, same splits.
+    without_edge = [search(0.0, seed) for seed in range(6)]
+    with_edge = [search(0.004, seed) for seed in range(6)]
+
+    # PBO cannot tell them apart, and should not: picking between eight
+    # identical configurations is a coin flip whether or not they all make
+    # money.
+    assert [row[0] for row in without_edge] == [row[0] for row in with_edge]
+    # DSR moves the whole way, because the level is what it prices.
+    assert statistics.fmean([row[1] for row in without_edge]) < 0.6
+    assert statistics.fmean([row[1] for row in with_edge]) > 0.95
+    # A quantity that is byte-identical across two samples whose DSR differs by
+    # half cannot be one minus that DSR.

--- a/tests/test_walkforward_selection_rigor.py
+++ b/tests/test_walkforward_selection_rigor.py
@@ -1,0 +1,112 @@
+"""The variant table is a search, and the report has to price it (#1143/#1145).
+
+`add_alpha_walkforward` prints four variants across three horizons in two
+markets. Nothing in the output said how many of those cells were compared to
+produce the sentence a reader writes, and nothing said how many sessions the
+comparison rests on. `selection_rigor` adds both, and these tests hold it to the
+part that matters most on this dataset: when the common sample is three sessions
+it must say so and produce no number, because a decorated PBO on three sessions
+is worse than no PBO at all.
+"""
+import random
+import statistics
+
+from clawock.evaluation import add_alpha_walkforward as wf
+
+
+def _observations(per_variant_dates, seed=3, drift=None):
+    """Build the `observations[market][variant][horizon]` shape `evaluate` makes."""
+    rnd = random.Random(seed)
+    drift = drift or {}
+    market = {variant: {horizon: [] for horizon in wf.HORIZONS} for variant in wf.VARIANTS}
+    for variant, dates in per_variant_dates.items():
+        for day in dates:
+            for horizon in wf.HORIZONS:
+                market[variant][horizon].append({
+                    "date": day,
+                    "ticker": "TEST",
+                    "return": rnd.gauss(drift.get(variant, 0.0), 0.02),
+                })
+    return {"test": market}
+
+
+def _dates(n, start=1):
+    return [f"2026-01-{index:02d}" for index in range(start, start + n)]
+
+
+def test_only_sessions_every_variant_traded_enter_the_comparison():
+    """A variant that skipped the bad weeks must not win by having skipped them.
+
+    `price_relative` trades every session; `interaction` trades three. The
+    comparison is restricted to the three they share, and the count is published
+    so a reader can see the comparison is three sessions wide rather than
+    twenty-three.
+    """
+    observations = _observations({
+        "setup_only": _dates(20),
+        "price_relative": _dates(20),
+        "information": _dates(20),
+        "interaction": _dates(3),
+    })
+    sessions, matrix = wf._daily_variant_matrix(observations["test"], 1)
+    assert len(sessions) == 3
+    assert len(matrix) == 3 and len(matrix[0]) == len(wf.VARIANTS)
+
+
+def test_a_three_session_overlap_produces_no_number():
+    """The live shape as of 2026-08-30, and the reason this block exists.
+
+    On the real ledger the four variants share nine, six and one session in the
+    US and three in HK. Both corrections must refuse: PBO because eight groups
+    cannot be filled, DSR because twenty observations are not there.
+    """
+    observations = _observations({variant: _dates(3) for variant in wf.VARIANTS})
+    rigor = wf._selection_rigor(observations)["test"]["t1"]
+    assert rigor["n_sessions_all_variants_traded"] == 3
+    assert rigor["pbo"]["status"] == "insufficient_sample"
+    assert rigor["pbo"]["pbo"] is None
+    assert rigor["deflated_sharpe"]["dsr"] is None
+
+
+def test_a_long_enough_overlap_produces_both_numbers():
+    observations = _observations({variant: _dates(28) for variant in wf.VARIANTS})
+    rigor = wf._selection_rigor(observations)["test"]["t1"]
+    assert rigor["pbo"]["status"] == "measured"
+    assert 0.0 <= rigor["pbo"]["pbo"] <= 1.0
+    assert rigor["deflated_sharpe"]["status"] == "measured"
+    assert rigor["best_variant_by_sharpe"] in wf.VARIANTS
+    # The deflation is for the whole table, not for the row that won.
+    assert rigor["search_size"] == len(wf.VARIANTS) * len(wf.HORIZONS)
+    assert rigor["deflated_sharpe"]["n_trials"] == rigor["search_size"]
+
+
+def test_a_variant_search_over_noise_does_not_look_like_a_finding():
+    """Four variants of nothing; the best one must not deflate to a claim."""
+    observations = _observations({variant: _dates(28) for variant in wf.VARIANTS}, seed=11)
+    rigor = wf._selection_rigor(observations)["test"]["t1"]
+    assert rigor["deflated_sharpe"]["dsr"] < 0.9
+
+
+def test_no_common_sessions_is_a_named_state_not_an_empty_number():
+    observations = _observations({
+        "setup_only": _dates(5, start=1),
+        "price_relative": _dates(5, start=1),
+        "information": _dates(5, start=1),
+        "interaction": _dates(5, start=20),
+    })
+    rigor = wf._selection_rigor(observations)["test"]["t1"]
+    assert rigor["status"] == "no_common_sessions"
+    assert rigor["pbo"] is None and rigor["deflated_sharpe"] is None
+
+
+def test_the_block_interval_is_reported_next_to_the_old_one():
+    """Both intervals ship. The block length is how a reader tells them apart."""
+    rows = [{"date": f"2026-02-{index:02d}", "ticker": "T", "return": 0.0,
+             "excess_vs_setup": random.Random(index).gauss(0.001, 0.01)}
+            for index in range(1, 26)]
+    summary = wf._summary(rows)
+    assert summary["excess_date_cluster_ci95"] is not None
+    block = summary["excess_block_ci95"]
+    assert block["n_clusters"] == 25
+    assert block["block_length"] >= 1
+    assert block["ci95"][0] <= summary["mean_excess_vs_same_date_setup"] <= block["ci95"][1]


### PR DESCRIPTION
Closes #1134, closes #1136, closes #1143, closes #1145, closes #1148.

## 先说一条:那五条 issue 的「改法」前提是错的

它们都写着「依赖 `pandas`/`scikit-learn`/`joblib`/`scipy`(已在 `pyproject.toml`)」。
**没有。** `pyproject.toml` 的硬依赖只有 `requests`,numpy 是 `[compute]` 可选组,
pandas / sklearn / joblib / scipy 一个都不在。按原文照抄会给一个「装进任何 agent 的插件包」
加四个重依赖。所以这里移植的是**机制**,实现全部是标准库。

同理,`#1145` 写的 `pbo = 1 - DSR` 也是错的 —— 两者的输入和问题都不同,见下。

## 做了什么

### 1. `evaluation/deflated_sharpe.py`(新,标准库)

Bailey & López de Prado (2014)。十二次搜索的零均值最大值不是零:把观测 Sharpe 减去
`expected_max_sharpe(n_trials, var_of_trials)`,再用偏度/峰度校正标准误。
单一预注册配置 → `insufficient_search`;样本 < 20 → `insufficient_sample`。都不印数字。

### 2. `selection_rigor`(接进 `add_alpha_walkforward`)

复用**已有的** `evaluation/cscv.py`(#1114 那次上线的 purged CSCV),不新写 splitter。
按 session 构 variant 矩阵,**只保留四个 variant 都成交过的 session** —— 否则一个只在好行情
里成交的 variant 会靠「躲过了坏周」赢,而不是靠排得更好。

### 3. `evaluation/bootstrap.py`(新,标准库)

`_cluster_ci` 按 session 独立重抽,对「同一天多笔成交」是对的,对「相邻交易日同处一个 regime」
是沉默的,而且沉默的方向是让区间偏窄。换成 Politis & Romano 平稳 bootstrap(几何块长 + 环绕),
块长按 Politis & White (2004) + Patton 修正**从数据里选并印出来**,BCa 区间的 jackknife
按 **cluster** 而不是按行删。两条区间并排发布。

## 实测(2026-08-30 live ledger)

**selection_rigor —— 这就是结论**:四个 variant 共同成交的 session 数
US `t1/t5/t20 = 9 / 6 / 1`,HK `= 3 / 3 / 0`。
两条校正**全部返回 `insufficient_sample`**。variant 表一直在被当成「interaction 更好」读,
它从来没有过那张表暗示的样本量。这不是闸太严,这是闸第一次说话。

**块长**:全部 12 个 (market, variant, horizon) 格都是 `block_length = 1` ⇒
这份数据在 session 维度上**没有可测的序列相关**,老估计量在这里是对的。
现在这是一个测量结果,不再是一个假设。

## 上线前在新代码里抓到的一个缺陷

BCa 的 acceleration 是 jackknife 复制值的三阶矩。用 **3 个 cluster** 估出来是噪声,
而且它把 `hk/interaction/t5` 从 `[-0.045, +0.019]`(跨 0)**改成了 `[-0.045, -0.002]`(清零)** ——
narrowing 的方向,最危险的那个方向。现在有 `MIN_CLUSTERS_FOR_BCA = 8` 的地板,不够就退回
percentile 区间(只是宽,不是错),并有测试钉住。修完 `hk/interaction/t5` 已回到跨 0。

## 高压线

- ❌ 不碰 live 每日流水线的模型输出契约
- ❌ 不碰 `peer_residuals.load_rule_config` 预注册
- ❌ 不碰 dashboard 200KB payload 闸(输出只进 run_card / 命令 stdout)
- ❌ 不新增依赖、不新增 cron、不新增 CLI 命令

## 测试

`tests/test_block_bootstrap.py`(8)、`tests/test_deflated_sharpe.py`(8)、
`tests/test_walkforward_selection_rigor.py`(6)。含三条会真失败的行为断言:
序列相关必须**加宽**区间、噪声里挑出的赢家 deflate 后必须落回硬币、
**PBO 与 DSR 不是互补** —— 两个只差一个共同 drift 的搜索,PBO 逐位相同而 DSR 从 0.5 变到 0.99。
