### PR TITLE
signal-panel: where the information sits, and what holding it costs (#1161)

### DIFF
--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -435,6 +435,155 @@ def score_signal(rows, horizon: str) -> dict:
     return result
 
 
+#: Tertiles, not quintiles. The cross-section is about twenty-one names on a
+#: good session; five buckets leaves four names each, and a "quintile return" of
+#: four names is one name's bad week wearing a statistic's name.
+QUANTILES = 3
+
+#: Below this the session's cross-section cannot be split into `QUANTILES`
+#: buckets with anything in them.
+MIN_CROSS_SECTION = QUANTILES * 2
+
+
+def _quantile_buckets(pairs, quantiles: int = QUANTILES):
+    """Assign one session's (value, forward) pairs to near-equal buckets by value.
+
+    Ties are broken by the order the sort produced rather than shared across the
+    boundary. That is deliberate and it is the conservative choice: a signal that
+    is constant across the cross-section gets buckets that differ only by noise,
+    so its spread goes to zero rather than becoming undefined and dropping the
+    session — which would silently restrict the measurement to the days the
+    signal happened to be lively.
+    """
+    ordered = sorted(pairs, key=lambda pair: pair[0])
+    edges = [round(len(ordered) * index / quantiles) for index in range(quantiles + 1)]
+    return [ordered[edges[index]:edges[index + 1]] for index in range(quantiles)]
+
+
+def quantile_structure(rows, horizon: str, *, quantiles: int = QUANTILES) -> dict:
+    """Mean forward return by signal quantile, and the long-short spread (#1161).
+
+    The rank IC beside this answers "does the ordering carry information". It
+    cannot answer the question that decides how a signal would be used: **is the
+    information on both ends, or one?** A signal whose top bucket outperforms
+    while its bottom bucket is indistinguishable from the middle is a long-only
+    screen; one whose bottom bucket carries everything is an avoid-list; only a
+    signal with both ends live supports a long-short reading. An IC of the same
+    magnitude is produced by all three.
+
+    The spread interval is bootstrapped over sessions, like every other interval
+    on this panel: a session where twenty names all moved together is one
+    observation, not twenty.
+    """
+    by_day = defaultdict(list)
+    for row in rows:
+        value, forward = row.get('value'), row.get(horizon)
+        if value is not None and forward is not None:
+            by_day[row['as_of']].append((float(value), float(forward)))
+    usable = {day: pairs for day, pairs in by_day.items()
+              if len(pairs) >= MIN_CROSS_SECTION}
+    if len(usable) < MIN_SESSIONS:
+        return {'status': 'collecting', 'n_sessions': len(usable),
+                'n_sessions_too_narrow': len(by_day) - len(usable),
+                'quantiles': quantiles, 'spread': None, 'buckets': None}
+    per_day_bucket_means = defaultdict(dict)
+    for day, pairs in usable.items():
+        for index, bucket in enumerate(_quantile_buckets(pairs, quantiles)):
+            if bucket:
+                per_day_bucket_means[day][index] = statistics.fmean(
+                    forward for _, forward in bucket)
+    buckets = {}
+    for index in range(quantiles):
+        values = {day: means[index] for day, means in per_day_bucket_means.items()
+                  if index in means}
+        buckets[f'q{index + 1}'] = {
+            'mean_forward_return': round(statistics.fmean(values.values()), 6)
+            if values else None,
+            'n_sessions': len(values),
+        }
+    spread_by_day = {
+        day: means[quantiles - 1] - means[0]
+        for day, means in per_day_bucket_means.items()
+        if 0 in means and quantiles - 1 in means
+    }
+    interval = _cluster_ci(spread_by_day) if spread_by_day else None
+    monotone = [buckets[f'q{index + 1}']['mean_forward_return']
+                for index in range(quantiles)]
+    return {
+        'status': 'diagnostic',
+        'quantiles': quantiles,
+        'n_sessions': len(usable),
+        'n_sessions_too_narrow': len(by_day) - len(usable),
+        'buckets': buckets,
+        'spread': round(statistics.fmean(spread_by_day.values()), 6)
+        if spread_by_day else None,
+        'spread_ci95': interval,
+        'spread_clears_zero': bool(interval and (interval[0] > 0 or interval[1] < 0)),
+        # Which end carries it. Reported as the two halves of the spread rather
+        # than as a verdict, because the reader's threshold for "one-sided" is
+        # not this function's to pick.
+        'top_minus_middle': (
+            round(monotone[-1] - monotone[quantiles // 2], 6)
+            if None not in monotone else None),
+        'middle_minus_bottom': (
+            round(monotone[quantiles // 2] - monotone[0], 6)
+            if None not in monotone else None),
+        'monotone': (all(monotone[index] <= monotone[index + 1]
+                         for index in range(quantiles - 1))
+                     or all(monotone[index] >= monotone[index + 1]
+                            for index in range(quantiles - 1)))
+        if None not in monotone else None,
+    }
+
+
+def persistence(rows, *, quantiles: int = QUANTILES) -> dict:
+    """How fast the signal churns, and how fast its ordering decays (#1161).
+
+    Two costs a mean IC hides. **Turnover** is how much of the top bucket has to
+    be replaced between consecutive sessions — a signal with a real edge and 90%
+    daily turnover pays for that edge in spread every day, and a report that
+    prints the edge without the turnover is quoting a gross number. **Rank
+    autocorrelation** is the same thing from the other side: how much of
+    yesterday's ordering survives into today.
+
+    Both are computed only across *consecutive registered sessions*, so a gap in
+    the history is a gap rather than an artificially low turnover.
+    """
+    by_day = defaultdict(dict)
+    for row in rows:
+        if row.get('value') is not None:
+            by_day[row['as_of']][row['ticker']] = float(row['value'])
+    days = sorted(by_day)
+    turnovers, autocorrelations = [], []
+    for previous, current in zip(days, days[1:]):
+        before, after = by_day[previous], by_day[current]
+        shared = sorted(set(before) & set(after))
+        if len(shared) >= MIN_CROSS_SECTION:
+            autocorrelation = _spearman(
+                [(before[ticker], after[ticker]) for ticker in shared])
+            if autocorrelation is not None:
+                autocorrelations.append(autocorrelation)
+        for source, target, bucket in ((before, after, 'top'),):
+            if len(source) < MIN_CROSS_SECTION or len(target) < MIN_CROSS_SECTION:
+                continue
+            def top_names(values):
+                ordered = sorted(values, key=lambda name: values[name], reverse=True)
+                return set(ordered[:max(1, len(ordered) // quantiles)])
+            was, now = top_names(source), top_names(target)
+            if now:
+                turnovers.append(len(now - was) / len(now))
+    return {
+        'n_session_pairs': max(0, len(days) - 1),
+        'top_bucket_turnover': round(statistics.fmean(turnovers), 4)
+        if turnovers else None,
+        'rank_autocorrelation': round(statistics.fmean(autocorrelations), 4)
+        if autocorrelations else None,
+        'reading': ('turnover is the share of the top bucket replaced between '
+                    'consecutive registered sessions; an edge quoted without it '
+                    'is a gross number'),
+    }
+
+
 def selection_pbo(panel, horizon: str, *, groups: int = 8) -> dict:
     """How much of the best-looking source is the thirteen-way search itself.
 
@@ -592,8 +741,16 @@ def evaluate(panel) -> dict:
     for row in panel:
         by_signal[row['signal']].append(row)
     signals = {
-        signal: {horizon: score_signal(rows, horizon)
-                 for horizon in ('t1', 't5', 't20')}
+        signal: {
+            **{horizon: score_signal(rows, horizon)
+               for horizon in ('t1', 't5', 't20')},
+            # Alphalens' two questions that a mean IC cannot answer (#1161):
+            # where in the cross-section the information sits, and what holding
+            # the signal would cost to maintain.
+            'quantiles': {horizon: quantile_structure(rows, horizon)
+                          for horizon in ('t1', 't5', 't20')},
+            'persistence': persistence(rows),
+        }
         for signal, rows in sorted(by_signal.items())
     }
     sessions = sorted({row['as_of'] for row in panel})
@@ -687,6 +844,31 @@ def main(argv=None) -> int:
         if picked:
             print('  most often selected: '
                   + ' · '.join(f'{name} ({count})' for name, count in picked))
+    print(f'\n--- {args.horizon} quantile structure and cost to hold '
+          f'({QUANTILES} buckets) ---')
+    print(f'{"signal":<28}{"q1":>9}{"q2":>9}{"q3":>9}{"spread":>9}'
+          f'{"turnover":>10}{"rank AC":>9}')
+    for signal, sections in result['signals'].items():
+        quantiles = sections['quantiles'][args.horizon]
+        holding = sections['persistence']
+        if quantiles.get('status') != 'diagnostic':
+            continue
+        cells = [quantiles['buckets'][f'q{index + 1}']['mean_forward_return']
+                 for index in range(quantiles['quantiles'])]
+        text = ''.join(f'{value:>+9.4f}' if value is not None else f'{"—":>9}'
+                       for value in cells)
+        spread = quantiles['spread']
+        turnover = holding['top_bucket_turnover']
+        autocorrelation = holding['rank_autocorrelation']
+        print(f'{signal:<28}{text}'
+              f'{(f"{spread:+.4f}" if spread is not None else "—"):>9}'
+              f'{(f"{turnover:.2f}" if turnover is not None else "—"):>10}'
+              f'{(f"{autocorrelation:+.2f}" if autocorrelation is not None else "—"):>9}'
+              f'{" *" if quantiles["spread_clears_zero"] else ""}')
+    print('  q1 = lowest signal value. spread = q3 - q1, interval clustered by '
+          'session. turnover = share of the top bucket replaced between '
+          'consecutive registered sessions: an edge quoted without it is gross.')
+
     polarity = result['composite_polarity'][args.horizon]
     if polarity.get('status') == 'measured':
         print(f'\n--- composite: polarity or regime? ({polarity["n_constituents"]} '

--- a/tests/test_signal_quantiles_and_turnover.py
+++ b/tests/test_signal_quantiles_and_turnover.py
@@ -1,0 +1,162 @@
+"""A mean IC cannot say where the information is, or what holding it costs (#1161).
+
+Rank IC is one number for a whole cross-section, and two questions it silently
+merges decide how a signal would actually be used:
+
+* **Which end carries it.** A signal whose top bucket outperforms while its
+  bottom bucket is indistinguishable from the middle is a long-only screen; one
+  whose bottom bucket carries everything is an avoid-list. The same IC is
+  produced by both, and by a signal with both ends live.
+* **What it costs to hold.** An edge with 90% daily turnover is paid back in
+  spread every session. An edge quoted without its turnover is a gross number.
+
+`quantile_structure` and `persistence` answer those two. These tests hold them
+to the cases where the IC and the buckets disagree — which is the entire reason
+for adding them.
+"""
+import statistics
+
+from clawock.evaluation import signal_panel
+
+
+def _rows(per_session, signal='test.signal', horizon='t5'):
+    """per_session: {session: {ticker: (value, forward_return)}}"""
+    out = []
+    for session, names in per_session.items():
+        for ticker, (value, forward) in names.items():
+            out.append({'as_of': session, 'ticker': ticker, 'signal': signal,
+                        'value': value, horizon: forward, 'leg': 'us'})
+    return out
+
+
+def _monotone_panel(sessions=12, names=12, slope=1.0, seed=5):
+    import random
+    rnd = random.Random(seed)
+    per_session = {}
+    for index in range(sessions):
+        session = f'2026-06-{index + 1:02d}'
+        per_session[session] = {
+            f'T{name}': (float(name), slope * name + rnd.gauss(0, 0.5))
+            for name in range(names)}
+    return per_session
+
+
+def test_a_monotone_signal_has_a_spread_that_clears_zero():
+    result = signal_panel.quantile_structure(_rows(_monotone_panel()), 't5')
+    assert result['status'] == 'diagnostic'
+    assert result['spread'] > 0
+    assert result['spread_clears_zero']
+    assert result['monotone'] is True
+
+
+def test_a_one_sided_signal_is_visible_as_one_sided():
+    """Only the top bucket moves; the other two are the same.
+
+    The IC and the spread both come out positive. Splitting the spread into its
+    two halves is what says this is a long-only screen rather than a long-short
+    signal — and that distinction is the whole difference between two ways of
+    using it.
+    """
+    per_session = {}
+    for index in range(12):
+        session = f'2026-06-{index + 1:02d}'
+        names = {}
+        for name in range(12):
+            forward = 5.0 if name >= 8 else 0.0
+            names[f'T{name}'] = (float(name), forward)
+        per_session[session] = names
+    result = signal_panel.quantile_structure(_rows(per_session), 't5')
+    assert result['top_minus_middle'] > 4.0
+    assert abs(result['middle_minus_bottom']) < 0.001
+
+
+def test_a_hump_is_invisible_to_both_the_ic_and_the_spread():
+    """The live case this catches: `quant.dist_ma200_pct`.
+
+    Its mean IC is -0.001 — indistinguishable from nothing — while its tertile
+    means are -6.05 / -0.36 / -2.70: the middle third outperformed both ends by
+    several points. Rank correlation cancels across a hump, and so does a
+    top-minus-bottom spread. Only the buckets show it, which is why all three
+    are published rather than one summary of them.
+
+    Here the middle third outperforms by five points and *both* summary numbers
+    say nothing is happening.
+    """
+    per_session = {}
+    for index in range(12):
+        session = f'2026-06-{index + 1:02d}'
+        per_session[session] = {
+            f'T{name}': (float(name), 5.0 if 4 <= name <= 7 else 0.0)
+            for name in range(12)}
+    rows = _rows(per_session)
+    ic = signal_panel.score_signal(rows, 't5')['mean_ic']
+    result = signal_panel.quantile_structure(rows, 't5')
+    assert abs(ic) < 0.25                       # the ordering says nothing
+    assert abs(result['spread']) < 1e-9         # and neither does top-minus-bottom
+    assert result['middle_minus_bottom'] > 4.9  # while the middle carries five points
+    assert result['top_minus_middle'] < -4.9
+    assert result['monotone'] is False
+
+
+def test_turnover_is_zero_for_a_signal_that_never_reorders():
+    per_session = {f'2026-06-{index + 1:02d}':
+                   {f'T{name}': (float(name), 0.0) for name in range(12)}
+                   for index in range(10)}
+    holding = signal_panel.persistence(_rows(per_session))
+    assert holding['top_bucket_turnover'] == 0.0
+    assert holding['rank_autocorrelation'] == 1.0
+
+
+def test_turnover_is_high_for_a_signal_that_reshuffles_every_session():
+    import random
+    rnd = random.Random(3)
+    per_session = {}
+    for index in range(30):
+        values = list(range(12))
+        rnd.shuffle(values)
+        per_session[f'2026-06-{index + 1:02d}'] = {
+            f'T{name}': (float(values[name]), 0.0) for name in range(12)}
+    holding = signal_panel.persistence(_rows(per_session))
+    assert holding['top_bucket_turnover'] > 0.5
+    assert abs(holding['rank_autocorrelation']) < 0.4
+
+
+def test_turnover_and_the_spread_are_reported_together():
+    """The pairing is the point.
+
+    On the live panel `news.signed_score` is the only source whose t5 spread
+    clears zero (+3.30) and it replaces 63% of its top bucket every session with
+    a rank autocorrelation of +0.02. Either number alone tells the wrong story.
+    """
+    panel = signal_panel.evaluate(
+        _rows(_monotone_panel(), signal='news.signed_score'))
+    section = panel['signals']['news.signed_score']
+    assert 'quantiles' in section and 'persistence' in section
+    assert section['quantiles']['t5']['spread'] is not None
+    assert section['persistence']['top_bucket_turnover'] is not None
+
+
+def test_a_narrow_cross_section_is_refused_rather_than_bucketed():
+    """Three names cannot be split into three buckets and mean anything."""
+    per_session = {f'2026-06-{index + 1:02d}':
+                   {f'T{name}': (float(name), float(name)) for name in range(3)}
+                   for index in range(12)}
+    result = signal_panel.quantile_structure(_rows(per_session), 't5')
+    assert result['status'] == 'collecting'
+    assert result['spread'] is None
+    assert result['n_sessions_too_narrow'] == 12
+
+
+def test_a_flat_cross_section_scores_zero_spread_rather_than_dropping_the_session():
+    """Dropping flat days would restrict the measurement to lively ones.
+
+    That is a selection: an event-count signal is flat most days, and scoring it
+    only on the days it fired would quietly change the population being measured.
+    """
+    per_session = {f'2026-06-{index + 1:02d}':
+                   {f'T{name}': (0.0, 1.0) for name in range(12)}
+                   for index in range(12)}
+    result = signal_panel.quantile_structure(_rows(per_session), 't5')
+    assert result['status'] == 'diagnostic'
+    assert result['n_sessions'] == 12
+    assert abs(result['spread']) < 1e-9


### PR DESCRIPTION
Closes #1161。

## 先说 issue 前提的问题

`#1161` 的「改法」要 500 LOC / 三个模块 / `pd.DataFrame` MultiIndex `factor_data` / matplotlib 撕裂报告,
前提是 pandas 和 matplotlib 已经是依赖。**不是。** `pyproject.toml` 的必需依赖只有 `requests`;
matplotlib 只在 `[evaluation]` 可选组里,pandas 根本不在。

所以这里移植的是**机制**,不是 Alphalens 的数据结构:两个 IC 答不了、但决定「这个信号怎么用」的问题。

## 1. 信息在截面的哪一端 — `quantile_structure`

每个 session 把截面切成**三分位**(不是五分位:好日子截面 21 个名字,五桶每桶 4 个,
「五分位收益」就是某一个名字的坏一周披着统计量的名),按桶取远期收益均值再按 session 平均,
long-short spread 走 session 聚簇 bootstrap。

spread 还拆成两半(`top_minus_middle` / `middle_minus_bottom`)—— 一个只有上端会动的信号是**选股清单**,
只有下端会动的是**回避清单**,两端都活才支持多空读法。**三者的 IC 完全一样。**

## 2. 持有成本 — `persistence`

相邻注册 session 之间,top 桶被换掉的比例 + 排序的 rank 自相关。

## 实测(t5,live panel)—— IC 那一列藏起来的三件事

```
signal                             q1       q2       q3   spread  turnover  rank AC
factor.composite_score        +7.1228  +5.8785  +1.7504  -5.3723      0.19    +0.71 *
factor.rank.breadth           +4.4532  +4.7268  +6.4445  +1.9913      0.00        —
factor.rank.liquidity         +4.0254  +4.8721  +5.4987  +1.4733      0.00    +0.99
news.signed_score             +4.2391  +4.1553  +7.5367  +3.2976      0.63    +0.02 *
quant.dist_ma200_pct          -6.0462  -0.3584  -2.7005  +3.3457      0.15    +0.96 *
setup.range_pos               +0.7465  +0.4560  -0.3570  -1.1036      0.64    +0.09
```

1. **`news.signed_score` 是唯一 spread 清零的源(+3.30),但它每个 session 换掉 63% 的 top 桶**,
   rank 自相关 +0.02。两个数都真,单看任何一个都会讲错故事 —— 这正是「毛收益」这个词的意思。
2. **`quant.dist_ma200_pct` 的 mean IC = −0.0012,看着像死的**,而三分位是 −6.05 / −0.36 / −2.70:
   **中间那三分之一跑赢了两端**。秩相关在驼峰上会抵消,top-minus-bottom 也会。只有桶能看见。
   已用一条测试钉住这个案例。
3. **`factor.rank.liquidity` / `breadth` 的 turnover = 0.00** —— 它们不是换手快,是**几乎不动**,
   这也是 `breadth` 在任何一个 session 上都排不出序的另一半原因。

(所有桶都是正的:这一个月标的宇宙普遍上涨,因子内容在 **spread** 里,不在水平上。)

## 高压线

- ❌ 不碰 live 模型输出契约 / 预注册研究契约 / 200KB payload 闸(只进 `signal-panel` 输出与 run_card)
- ❌ 不新增依赖、不新增 cron、不新增 CLI 命令(挂在已有 `signal-panel` 上)

## 测试

`tests/test_signal_quantiles_and_turnover.py`(8)。含三条会真失败的:
单边信号必须被认出是单边、**驼峰形对 IC 和 spread 同时不可见而对桶可见**、
截面太窄要拒绝而不是硬切、**截面全平要记 0 spread 而不是丢掉那个 session**
(丢掉就把测量限制在「信号活跃的日子」上,那是一次选择)。
