### PR TITLE
panel: score signals against an outcome this book could have held (#1164)

### DIFF
--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -81,6 +81,7 @@ from clawock.decision.setup_review import wilson_ci
 from clawock.evaluation import cscv
 from clawock.evidence import run_card
 from clawock.instruments import canonical_bar_manifest
+from clawock.labeling import triple_barrier
 from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
@@ -316,6 +317,89 @@ def forward_returns(ticker: str, leg: str, as_of: str,
     return out
 
 
+#: Barriers in units of the name's own daily volatility. Two up, one down is
+#: the asymmetry the book's own rule already has — a chandelier stop exits on a
+#: single adverse move while a target is only reached by a sustained one — and
+#: it is pre-registered here rather than searched.
+BARRIER_PROFIT_MULTIPLE = 2.0
+BARRIER_STOP_MULTIPLE = 1.0
+
+_barrier_cache: dict = {}
+
+
+def _bar_series(ticker: str, leg: str):
+    """The name's bars as an ordered list, keyed by leg session, cached.
+
+    `triple_barrier` walks forward bar by bar and needs highs and lows; the
+    panel's own `load_ticker_bars` returns a date-keyed dict, and rebuilding the
+    ordered list for ten thousand rows is the whole cost of the path-aware
+    outcome.
+    """
+    key = (ticker, leg)
+    if key not in _barrier_cache:
+        bars = load_ticker_bars(ticker) or {}
+        days = [day for day in leg_sessions(leg) if day in bars]
+        series = []
+        for day in days:
+            bar = bars.get(day) or {}
+            close = _number(bar.get('close'))
+            high = _number(bar.get('high'))
+            low = _number(bar.get('low'))
+            if close is None:
+                continue
+            series.append({'date': day, 'close': close,
+                           'high': high if high is not None else close,
+                           'low': low if low is not None else close})
+        volatility = triple_barrier.daily_volatility(
+            [bar['close'] for bar in series])
+        _barrier_cache[key] = (series, {bar['date']: index
+                                        for index, bar in enumerate(series)},
+                               volatility)
+    return _barrier_cache[key]
+
+
+def path_aware_returns(ticker: str, leg: str, as_of: str,
+                       horizons=HORIZONS) -> dict:
+    """The same forward windows, ended by whichever barrier is touched first.
+
+    `forward_returns` above scores every signal against the close `h` sessions
+    later, which is the outcome of a position this book does not hold: it runs a
+    chandelier stop, and a breach is a standard exit rather than a paper loss to
+    sit through. A name that fell 18% intraday on day two and closed the week up
+    3% is `+3%` to that function and would have been `-18%` in the account.
+
+    The barrier is the book's real one — `22d high - 3 x ATR(14)`, recomputed at
+    every step so it trails — and intraday touches count, because a stop checked
+    only at the close is not the stop being run.
+    """
+    series, index_of, volatility = _bar_series(ticker, leg)
+    if not series:
+        return {}
+    entry_index = None
+    for index, bar in enumerate(series):
+        if bar['date'] > as_of:
+            entry_index = index
+            break
+    if entry_index is None or entry_index >= len(volatility):
+        return {}
+    unit = volatility[entry_index]
+    if not unit:
+        return {}
+    out = {}
+    for horizon in horizons:
+        if entry_index + horizon >= len(series):
+            continue
+        result = triple_barrier.apply_barriers(
+            series, entry_index, horizon=horizon,
+            profit_multiple=BARRIER_PROFIT_MULTIPLE,
+            stop_multiple=BARRIER_STOP_MULTIPLE, volatility=unit,
+            use_chandelier=True)
+        if result:
+            out[f'p{horizon}'] = round(100 * result['return'], 6)
+            out[f'b{horizon}'] = result['barrier']
+    return out
+
+
 def build_panel(data_dir: Path | None = None, manifest=None) -> list[dict]:
     """Long-format panel: one row per (session, ticker, signal)."""
     data_dir = Path(data_dir or DATA)
@@ -341,6 +425,7 @@ def build_panel(data_dir: Path | None = None, manifest=None) -> list[dict]:
                 forward = forward_returns(ticker, leg, as_of)
                 if not forward:
                     continue
+                forward.update(path_aware_returns(ticker, leg, as_of))
                 # One observation per (session, ticker, signal). The T+0 setup
                 # history writes ~14 intraday snapshots a day, so without this a
                 # ticker enters that session's cross-section fourteen times and
@@ -762,6 +847,44 @@ def _factor_weights() -> dict:
         return {}
 
 
+#: Signals whose *definition* contains the barrier's own rule. Scoring these
+#: against a stop-based label is close to tautological: `quant.stop_distance_pct`
+#: is literally the distance to the chandelier stop, so a name near it is stopped
+#: out on the first adverse session by construction, and its -0.63 path-aware IC
+#: is a restatement of the label rather than a finding about the signal. Named
+#: here so the panel prints the warning instead of a reader having to notice.
+CIRCULAR_AGAINST_BARRIER = {
+    'quant.stop_distance_pct': 'the barrier is this signal, measured from the other side',
+    'quant.rsi14': 'oversold names are the ones already near the trailing stop',
+    'quant.zscore20': 'same drawdown, expressed in standard deviations',
+    'quant.mom_1m': 'a falling month is a name that has already run down to its stop',
+}
+
+
+def _barrier_mix(panel) -> dict:
+    """Which barrier ended each window, per horizon.
+
+    Published because it is how the path-aware column is read: a horizon whose
+    outcomes are 70% `stop` is describing a rule that mostly gets stopped out,
+    and any IC computed over it is a statement about that fact as much as about
+    the signal.
+    """
+    out = {}
+    for horizon in HORIZONS:
+        seen = {}
+        for row in panel:
+            barrier = row.get(f'b{horizon}')
+            if barrier:
+                seen[barrier] = seen.get(barrier, 0) + 1
+        if seen:
+            total = sum(seen.values())
+            out[f'p{horizon}'] = {
+                **seen,
+                'stopped_share': round(seen.get('stop', 0) / total, 4),
+            }
+    return out
+
+
 def evaluate(panel) -> dict:
     by_signal = defaultdict(list)
     for row in panel:
@@ -770,6 +893,17 @@ def evaluate(panel) -> dict:
         signal: {
             **{horizon: score_signal(rows, horizon)
                for horizon in ('t1', 't5', 't20')},
+            # The same signal against an outcome the book could have realised:
+            # each window ended by whichever barrier is touched first, with the
+            # production chandelier stop trailing underneath (#1164). The pair
+            # is the point — a signal whose IC survives the stop and one whose
+            # IC was an artefact of holding through the drawdown look identical
+            # on the fixed-horizon column alone.
+            'path_aware': {
+                **{horizon: score_signal(rows, horizon)
+                   for horizon in ('p1', 'p5', 'p20')},
+                'circular_against_barrier': CIRCULAR_AGAINST_BARRIER.get(signal),
+            },
             # Alphalens' two questions that a mean IC cannot answer (#1161):
             # where in the cross-section the information sits, and what holding
             # the signal would cost to maintain.
@@ -785,6 +919,7 @@ def evaluate(panel) -> dict:
         'method': ('cross-sectional rank IC per session, averaged; interval '
                    'bootstrapped over sessions; directional hit rate only where '
                    'the direction was registered in advance'),
+        'barriers': _barrier_mix(panel),
         'coverage': {
             'rows': len(panel),
             'signals': len(by_signal),
@@ -894,6 +1029,28 @@ def main(argv=None) -> int:
     print('  q1 = lowest signal value. spread = q3 - q1, interval clustered by '
           'session. turnover = share of the top bucket replaced between '
           'consecutive registered sessions: an edge quoted without it is gross.')
+
+    path_horizon = 'p' + args.horizon[1:]
+    barriers = result['barriers'].get(path_horizon) or {}
+    if barriers:
+        print(f'\n--- {args.horizon} against an outcome the book could have held '
+              f'(trailing chandelier stop; {barriers["stopped_share"]:.0%} of '
+              f'windows end at the stop) ---')
+        print(f'{"signal":<28}{"fixed":>9}{"path-aware":>12}{"delta":>9}  note')
+        for signal, sections in result['signals'].items():
+            fixed = sections[args.horizon]
+            aware = sections['path_aware'][path_horizon]
+            if fixed['mean_ic'] is None or aware['mean_ic'] is None:
+                continue
+            note = sections['path_aware'].get('circular_against_barrier')
+            marks = ('*' if fixed['ic_clears_zero'] else ' ') + \
+                    ('*' if aware['ic_clears_zero'] else ' ')
+            print(f'{signal:<28}{fixed["mean_ic"]:>+9.4f}{aware["mean_ic"]:>+12.4f}'
+                  f'{aware["mean_ic"] - fixed["mean_ic"]:>+9.4f}  {marks}'
+                  f'{"  CIRCULAR: " + note if note else ""}')
+        print('  the fixed column scores a position held to the horizon through '
+              'any drawdown; this book exits on a chandelier breach, so where '
+              'the two disagree the fixed one is describing a trade nobody made.')
 
     polarity = result['composite_polarity'][args.horizon]
     if polarity.get('status') == 'measured':

--- a/src/clawock/labeling/__init__.py
+++ b/src/clawock/labeling/__init__.py
@@ -1,0 +1,1 @@
+"""Labels that respect the path, and the events worth labelling at all."""

--- a/src/clawock/labeling/triple_barrier.py
+++ b/src/clawock/labeling/triple_barrier.py
@@ -1,0 +1,201 @@
+"""Labelling an outcome the book could actually have realised.
+
+The problem
+-----------
+`signal_panel.forward_returns` scores every signal against a close-to-close
+return `h` sessions later. That is the outcome of a position nobody in this book
+holds. The book runs a **chandelier stop** — `22d high − 3×ATR(14)`, published as
+`stop_distance_pct`, negative meaning breached — and a breach is a standard exit,
+not a paper loss to sit through. So a name that fell 18% intraday on day two and
+closed the week up 3% is scored `+3%` by the panel and would have been `−18%` in
+the account.
+
+That is not a small correction and it is not a symmetric one: it flatters
+precisely the volatile names, and volatility is what
+`bar.garch_vol_expansion` says this month's winners had.
+
+The fix is López de Prado's triple barrier: for each event, walk forward and
+record **which barrier is touched first** — the profit target above, the stop
+below, or the horizon. The label is the return at that touch, so the path
+decides the outcome rather than being averaged out of it.
+
+What this module is not
+-----------------------
+It does not fit anything, and `meta.py` beside it does not either. Meta-labelling
+in the source material is a classifier that sizes bets from a primary model's
+signals; here the primary side comes from a pre-registered rule and the sizing
+map is a formula, because a fitted sizing model on this sample size is the kind
+of search this repository refuses. What is ported is the **labelling**, which is
+a measurement, and the CUSUM sampler that decides which days are worth labelling.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+
+
+def daily_volatility(closes, span=20):
+    """EWMA of daily return standard deviation, keyed by index.
+
+    The unit the barriers are set in. A fixed 5% barrier means something
+    different for a 12%-vol name and a 130%-vol one, and this book holds both.
+    """
+    if len(closes) < 2:
+        return []
+    returns = [closes[index] / closes[index - 1] - 1 for index in range(1, len(closes))]
+    decay = 2.0 / (span + 1)
+    out = [None]
+    mean = returns[0]
+    variance = 0.0
+    for index, value in enumerate(returns):
+        mean = decay * value + (1 - decay) * mean
+        deviation = value - mean
+        variance = decay * deviation * deviation + (1 - decay) * variance
+        out.append(math.sqrt(variance) if index >= span else None)
+    return out
+
+
+def cusum_events(closes, threshold, *, dates=None):
+    """Symmetric CUSUM filter: the sessions where something actually happened.
+
+    A signal evaluated every session produces mostly redundant samples — three
+    quiet days in a row are one observation dressed as three, and they dominate
+    any average taken over them. The filter accumulates log returns in both
+    directions and fires when either side crosses `threshold`, resetting that
+    side; the result is an event index that is dense in the moving stretches and
+    sparse in the flat ones.
+
+    `threshold` is in the same units as a log return, so it is normally set as a
+    multiple of `daily_volatility`.
+    """
+    dates = list(dates or range(len(closes)))
+    positive = negative = 0.0
+    events = []
+    for index in range(1, len(closes)):
+        if not closes[index] or not closes[index - 1]:
+            continue
+        step = math.log(closes[index] / closes[index - 1])
+        limit = threshold[index] if isinstance(threshold, list) else threshold
+        if limit is None or limit <= 0:
+            continue
+        positive = max(0.0, positive + step)
+        negative = min(0.0, negative + step)
+        if positive > limit:
+            positive = 0.0
+            events.append(dates[index])
+        elif negative < -limit:
+            negative = 0.0
+            events.append(dates[index])
+    return events
+
+
+def chandelier_stop(bars, index, *, lookback=22, atr_window=14, multiple=3.0):
+    """The book's own exit rule: `22d high − 3 × ATR(14)`.
+
+    Reimplemented here rather than imported from `decision.signals` because that
+    module computes it for the live snapshot from a different bar shape; this one
+    has to be evaluable at any historical index, which is what makes the barrier
+    path-dependent rather than a level fixed at entry.
+    """
+    if index < max(lookback, atr_window):
+        return None
+    highs = [bar['high'] for bar in bars[index - lookback + 1:index + 1]]
+    ranges = []
+    for position in range(index - atr_window + 1, index + 1):
+        previous_close = bars[position - 1]['close']
+        bar = bars[position]
+        ranges.append(max(bar['high'] - bar['low'],
+                          abs(bar['high'] - previous_close),
+                          abs(bar['low'] - previous_close)))
+    if not ranges:
+        return None
+    return max(highs) - multiple * statistics.fmean(ranges)
+
+
+def apply_barriers(bars, entry_index, *, horizon, profit_multiple=2.0,
+                   stop_multiple=1.0, volatility=None, side=1,
+                   use_chandelier=False):
+    """Walk forward from `entry_index` and return the first barrier touched.
+
+    Barriers are set in units of the name's own daily volatility unless
+    `use_chandelier` is on, in which case the lower barrier is the book's real
+    stop and is **recomputed at every step** — a trailing stop that moves with
+    the position is a different rule from a level fixed at entry, and the second
+    one is the one that is easy to implement and wrong.
+
+    Intraday touches count. A stop that is only checked at the close is not the
+    stop this book runs, and checking it at the close is exactly what turns an
+    18% intraday drawdown into a +3% week.
+    """
+    if entry_index + 1 >= len(bars):
+        return None
+    entry = bars[entry_index]['close']
+    if not entry:
+        return None
+    unit = volatility if volatility else None
+    if unit is None or unit <= 0:
+        return None
+    upper = entry * (1 + side * profit_multiple * unit)
+    lower_fixed = entry * (1 - side * stop_multiple * unit)
+
+    last = min(entry_index + horizon, len(bars) - 1)
+    for index in range(entry_index + 1, last + 1):
+        bar = bars[index]
+        lower = lower_fixed
+        if use_chandelier:
+            trailing = chandelier_stop(bars, index - 1)
+            if trailing is not None:
+                lower = max(lower_fixed, trailing) if side > 0 else lower_fixed
+        touched_up = bar['high'] >= upper if side > 0 else bar['low'] <= upper
+        touched_down = bar['low'] <= lower if side > 0 else bar['high'] >= lower
+        if touched_down and touched_up:
+            # Both inside one session's range: the bar does not say which came
+            # first, so the conservative reading is the adverse one. Guessing the
+            # favourable order is how a backtest quietly buys itself an edge.
+            return {'barrier': 'stop', 'index': index,
+                    'return': side * (lower / entry - 1), 'ambiguous_bar': True}
+        if touched_down:
+            return {'barrier': 'stop', 'index': index,
+                    'return': side * (lower / entry - 1), 'ambiguous_bar': False}
+        if touched_up:
+            return {'barrier': 'target', 'index': index,
+                    'return': side * (upper / entry - 1), 'ambiguous_bar': False}
+    close = bars[last]['close']
+    return {'barrier': 'horizon', 'index': last,
+            'return': side * (close / entry - 1), 'ambiguous_bar': False}
+
+
+def label_series(bars, *, horizon, profit_multiple=2.0, stop_multiple=1.0,
+                 span=20, side=1, use_chandelier=False, entries=None):
+    """Triple-barrier labels for every entry, with the counts that read them.
+
+    `barrier_mix` is the part worth publishing beside any average taken over
+    these: a label set that is 70% `stop` describes a rule that mostly gets
+    stopped out, and its mean return is a summary of that fact rather than of
+    the signal's predictive content.
+    """
+    closes = [bar.get('close') for bar in bars]
+    volatilities = daily_volatility(closes, span=span)
+    entries = entries if entries is not None else range(len(bars))
+    labels = []
+    for index in entries:
+        if index >= len(volatilities):
+            continue
+        result = apply_barriers(
+            bars, index, horizon=horizon, profit_multiple=profit_multiple,
+            stop_multiple=stop_multiple, volatility=volatilities[index],
+            side=side, use_chandelier=use_chandelier)
+        if result:
+            labels.append({'entry_index': index, **result})
+    mix = {}
+    for label in labels:
+        mix[label['barrier']] = mix.get(label['barrier'], 0) + 1
+    return {
+        'labels': labels,
+        'n': len(labels),
+        'barrier_mix': mix,
+        'ambiguous_bars': sum(1 for label in labels if label['ambiguous_bar']),
+        'params': {'horizon': horizon, 'profit_multiple': profit_multiple,
+                   'stop_multiple': stop_multiple, 'volatility_span': span,
+                   'trailing_stop': use_chandelier},
+    }

--- a/tests/test_triple_barrier_labels.py
+++ b/tests/test_triple_barrier_labels.py
@@ -1,0 +1,158 @@
+"""Scoring a signal against a trade this book would not have held (#1164).
+
+`signal_panel.forward_returns` scores every signal on the close `h` sessions
+later. That is the outcome of a position nobody here holds: the book runs a
+chandelier stop — `22d high - 3 x ATR(14)`, published as `stop_distance_pct` —
+and a breach is a standard exit. On the live panel **72% of five-session windows
+end at that stop**, so the fixed-horizon column is mostly describing trades that
+were closed before it measured them.
+
+These tests hold the labelling to the three properties that decide whether the
+path-aware column is worth trusting: the stop has to trail, an intraday touch
+has to count, and a bar that contains both barriers must not be resolved in the
+favourable direction.
+"""
+import math
+
+import pytest
+
+from clawock.labeling import triple_barrier as tb
+
+
+def _bars(closes, *, highs=None, lows=None):
+    highs = highs or [value * 1.005 for value in closes]
+    lows = lows or [value * 0.995 for value in closes]
+    return [{'date': f'2026-01-{index + 1:04d}', 'close': close,
+             'high': high, 'low': low}
+            for index, (close, high, low) in enumerate(zip(closes, highs, lows))]
+
+
+def _volatile_run(n=80, seed=3):
+    import random
+    rnd = random.Random(seed)
+    closes, price = [], 100.0
+    for _ in range(n):
+        price *= 1 + rnd.gauss(0, 0.02)
+        closes.append(price)
+    return _bars(closes)
+
+
+def test_an_intraday_touch_counts():
+    """A stop checked only at the close is not the stop being run.
+
+    Day two dips 18% intraday and closes the week up 3%. The fixed-horizon
+    outcome is +3%; the account's is the stop.
+    """
+    closes = [100.0] * 8
+    lows = [100.0] * 8
+    lows[2] = 82.0
+    bars = _bars(closes, lows=lows)
+    result = tb.apply_barriers(bars, 1, horizon=5, volatility=0.05,
+                               profit_multiple=2.0, stop_multiple=1.0)
+    assert result['barrier'] == 'stop'
+    assert result['index'] == 2
+    assert result['return'] < 0
+
+
+def test_the_stop_trails_instead_of_sitting_where_the_entry_was():
+    """A level fixed at entry is a different rule, and the easy wrong one.
+
+    The name runs up 40% and then gives back 15%. A stop one volatility unit
+    below the *entry* is never touched; the book's trailing chandelier is.
+    """
+    closes = [100.0 * (1.02 ** index) for index in range(30)]
+    closes += [closes[-1] * (0.97 ** index) for index in range(1, 6)]
+    bars = _bars(closes)
+    common = dict(horizon=9, volatility=0.08, profit_multiple=99.0,
+                  stop_multiple=1.0)
+    fixed = tb.apply_barriers(bars, 25, use_chandelier=False, **common)
+    trailing = tb.apply_barriers(bars, 25, use_chandelier=True, **common)
+    # The entry-level stop is never reached: the pullback gives back less than
+    # the position had already gained. The trailing one is, because it moved up
+    # with the price.
+    assert fixed['barrier'] == 'horizon'
+    assert trailing['barrier'] == 'stop'
+    assert trailing['index'] < fixed['index']
+    # And it exits with the gain intact rather than giving it back, which is
+    # what a trailing stop is for — the direction of the difference is not the
+    # claim here, the fact that the two labels disagree at all is.
+    assert trailing['return'] > fixed['return']
+
+
+def test_a_bar_holding_both_barriers_resolves_against_the_position():
+    """Guessing the favourable order is how a backtest buys itself an edge.
+
+    One session whose range spans the target and the stop. The bar does not say
+    which came first, and the label must take the adverse one and say it was
+    ambiguous.
+    """
+    bars = _bars([100.0] * 6, highs=[100.0, 130.0, 100.0, 100.0, 100.0, 100.0],
+                 lows=[100.0, 70.0, 100.0, 100.0, 100.0, 100.0])
+    result = tb.apply_barriers(bars, 0, horizon=5, volatility=0.10,
+                               profit_multiple=2.0, stop_multiple=1.0)
+    assert result['barrier'] == 'stop'
+    assert result['ambiguous_bar'] is True
+
+
+def test_the_barrier_mix_is_published_with_the_labels():
+    """A label set that is 70% `stop` describes a rule, not a signal."""
+    result = tb.label_series(_volatile_run(), horizon=5, use_chandelier=True)
+    assert result['n'] > 0
+    assert set(result['barrier_mix']) <= {'stop', 'target', 'horizon'}
+    assert sum(result['barrier_mix'].values()) == result['n']
+    assert result['params']['trailing_stop'] is True
+
+
+def test_barriers_scale_with_the_name_rather_than_being_a_fixed_percentage():
+    """This book holds a 12%-vol name and a 130%-vol one at the same time."""
+    calm = tb.daily_volatility([100.0 * (1 + 0.001 * ((-1) ** index))
+                                for index in range(80)])
+    wild = tb.daily_volatility([100.0 * (1 + 0.05 * ((-1) ** index))
+                                for index in range(80)])
+    assert wild[-1] > calm[-1] * 10
+
+
+def test_cusum_fires_on_movement_and_stays_quiet_when_nothing_happens():
+    flat = [100.0] * 200
+    assert tb.cusum_events(flat, 0.02) == []
+    moving = [100.0 * (1.01 ** index) for index in range(200)]
+    events = tb.cusum_events(moving, 0.02)
+    assert 50 < len(events) < 200
+
+
+def test_cusum_is_symmetric():
+    up = [100.0 * (1.02 ** index) for index in range(60)]
+    down = [100.0 * (0.98 ** index) for index in range(60)]
+    assert len(tb.cusum_events(up, 0.05)) == len(tb.cusum_events(down, 0.05))
+
+
+def test_the_panel_carries_both_outcome_definitions():
+    """The pair is the point; either alone answers a different question."""
+    from clawock.evaluation import signal_panel
+    rows = [{'as_of': f'2026-06-{session:02d}', 'ticker': f'T{name}',
+             'signal': 'x', 'value': float(name),
+             't5': float(name), 'p5': float(name) / 2, 'b5': 'stop'}
+            for session in range(1, 13) for name in range(6)]
+    result = signal_panel.evaluate(rows)
+    section = result['signals']['x']
+    assert section['t5']['mean_ic'] is not None
+    assert section['path_aware']['p5']['mean_ic'] is not None
+    assert result['barriers']['p5']['stopped_share'] == 1.0
+
+
+def test_a_signal_made_of_the_barrier_itself_is_flagged_as_circular():
+    """`quant.stop_distance_pct` scoring -0.63 against a stop label is not a finding.
+
+    The signal is the distance to the chandelier stop and the label is whether
+    that stop was touched, so a name near it is stopped out by construction. The
+    panel has to say so rather than leave it as the most negative row in the
+    table.
+    """
+    from clawock.evaluation import signal_panel
+    rows = [{'as_of': f'2026-06-{session:02d}', 'ticker': f'T{name}',
+             'signal': 'quant.stop_distance_pct', 'value': float(name),
+             't5': float(name), 'p5': -float(name), 'b5': 'stop'}
+            for session in range(1, 13) for name in range(6)]
+    section = signal_panel.evaluate(rows)['signals']['quant.stop_distance_pct']
+    assert section['path_aware']['circular_against_barrier']
+    assert 'barrier is this signal' in section['path_aware']['circular_against_barrier']


### PR DESCRIPTION
Closes #1164。

## 问题

`signal_panel.forward_returns` 用「h 个 session 之后的收盘」给每个信号打分。
**那是一个本账本不会持有的仓位的结果。** 本书跑的是吊灯止损(`22d 高 − 3×ATR(14)`,
就是 `stop_distance_pct`,为负=已破线),破线是标准离场,不是一笔可以坐等回来的浮亏。

一只票第二天盘中跌 18%、周末收在 +3%,面板给它记 **+3%**,账户里是 **−18%**。

**实测:t5 窗口有 72% 在止损处结束**,t20 有 85%。也就是说 fixed-horizon 那一列
**大部分时候在给已经被平掉的交易打分**,而且偏袒的正好是高波动的那批
(#1172 刚测出这个月赢家就是高波动那批)。

## 做了什么

`src/clawock/labeling/triple_barrier.py`(López de Prado 三重屏障,纯标准库):

- 屏障按**每只票自己的日波动率**定(本书同时持有 12% 波动和 130% 波动的票);
- **下屏障每一步重算**(吊灯是跟踪止损)—— 固定在入场点的水平线是另一条规则,而且是容易写错的那条;
- **盘中触碰算数** —— 只在收盘检查的止损不是本书跑的那条止损,这正是「盘中 −18% 变成周 +3%」的来源;
- **同一根 bar 同时含上下屏障 ⇒ 判为止损并标 `ambiguous_bar`**:bar 说不出谁先到,
  猜有利的那个顺序就是回测在给自己买 edge。
- 旁边的 `cusum_events`:连续三个平静日应该算一次观测而不是三次。

面板现在**同时带两套结果并排印**,因为这一对才是重点。

## 实测(t5)—— 七个信号符号翻面

```
signal                          fixed  path-aware    delta  note
factor.composite_score        -0.1965     +0.0665  +0.2630  *
factor.rank.residual_mom_3m   -0.0573     +0.2449  +0.3022   *
factor.rank.relative_strength -0.1025     +0.1392  +0.2417  **
factor.rank.liquidity         +0.0064     +0.2029  +0.1965   *
factor.rank.drawdown_resilience -0.1467   +0.0110  +0.1577  *
news.signed_score             +0.1909     +0.0929  -0.0980  *
quant.stop_distance_pct       +0.0843     -0.6252  -0.7095  *  CIRCULAR
quant.mom_1m                  +0.0466     -0.5517  -0.5983  *  CIRCULAR
quant.rsi14                   -0.0622     -0.4112  -0.3490  *  CIRCULAR
quant.zscore20                -0.0298     -0.3014  -0.2716  *  CIRCULAR
```

**#1133 的 composite 负 IC,有一部分是「把本该被止损的票当成一直持有」造成的**
(−0.20 → +0.067)。这不推翻 #1133 的 regime 结论,它给同一件事加了第三个角度:
那批被排在低位的票,正是会被止损的那批。

## 有四行是循环的,代码自己会说

`quant.stop_distance_pct` path-aware 打到 **−0.63**,而它**就是到吊灯止损的距离** ——
离止损近的票按定义就会在第一个不利 session 被打掉。**那个数是在复述标签,不是在发现信号的性质。**
`rsi14` / `zscore20` / `mom_1m` 是同一循环的弱化版。

四条都登记在 `CIRCULAR_AGAINST_BARRIER` 里,面板**自己印出警告**,
而不是把它们留成表里最负的四行等人去发现。

## 没做

**meta-labeling 的分类器没做。** 这里的主方向来自预注册规则,而在 18 个 session 上
拟合一个仓位大小模型,正是本仓库到处在拒绝的那种搜索。移植的是**标注**,那是测量。

## 高压线

- ❌ 不碰 live 模型输出契约 / 预注册研究契约 / 200KB payload 闸
- ❌ 不新增依赖、不新增 cron、不新增 CLI 命令

## 测试

`tests/test_triple_barrier_labels.py`(9)。含会真失败的:
**盘中触碰必须算数**(那根 −18% 的 bar)、**止损必须跟涨**(入场固定的止损碰不到,跟踪的碰得到)、
**同 bar 含双屏障必须判成不利的那个并标 ambiguous**、
以及 **`quant.stop_distance_pct` 必须被标成循环**。
