### PR TITLE
risk: weight is not risk, and this covariance is not the truth (#1162/#1165/#1186)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,29 @@ classifiers = [
 dependencies = [
     # 2.32 is the floor past CVE-2024-35195 (redirect header leak in 2.31.x).
     "requests>=2.32",
+    # numpy was in an optional `compute` extra while `portfolio/risk.py` — the
+    # module behind the packaged `portfolio-risk` command — imported it at the
+    # top level unconditionally. A clean `pip install clawock` therefore shipped
+    # a first-class command that raised ImportError on its first line. It is
+    # required because it already was; the metadata was the part that was wrong.
+    "numpy>=1.26",
+    # Required for the same reason, from 2026-08-30: the evaluation and risk
+    # lanes (shrinkage estimators, hierarchical clustering, optimisation,
+    # distribution tails, eigendecomposition) are not code that should be
+    # hand-rolled to keep a wheel small. The alternative on offer was a package
+    # where half the analysis commands fail on a clean install, which is worse
+    # for "install decision intelligence into any agent" than a bigger download.
+    "scipy>=1.11",
 ]
 
 [project.optional-dependencies]
-# Numeric work: risk metrics, correlation x-ray, regime validation.
-compute = ["numpy>=1.26"]
-evaluation = ["numpy>=1.26", "matplotlib>=3.8"]
+# Kept as an alias, not a set: numpy and scipy are required dependencies as of
+# 2026-08-30, so `.[compute]` now installs the base package. The name stays
+# because three call sites use it (a workflow, the launcher installer, and the
+# composite action's documentation) and breaking those to delete an empty list
+# is a worse trade than one line of explanation.
+compute = []
+evaluation = ["matplotlib>=3.8"]
 # Screenshot and social-card validation.
 imaging = ["Pillow>=10"]
 # Search Console visibility pull (ops/growth/crawl_visibility.py). Declared here
@@ -63,7 +80,7 @@ release = ["build>=1.2", "twine>=5"]
 # parses .github/ISSUE_TEMPLATE/config.yml as structured data rather than
 # substring-matching it, and a test module that cannot import does not fail —
 # it stops the whole suite at collection while the run still looks like it ran.
-test = ["pytest>=8", "pytest-cov>=5", "numpy>=1.26", "Pillow>=10", "PyYAML>=6"]
+test = ["pytest>=8", "pytest-cov>=5", "Pillow>=10", "PyYAML>=6"]
 
 [project.urls]
 Homepage = "https://github.com/KCNyu/clawock"

--- a/src/clawock/portfolio/allocation.py
+++ b/src/clawock/portfolio/allocation.py
@@ -1,0 +1,283 @@
+"""Where the risk in this book actually sits, and what a diversified one looks like.
+
+The question this is for
+------------------------
+`correlation_xray` reports that the book has 3.78 effective names and **1.98
+effective bets**: eight positions behaving as two. It says that clearly, and
+then stops, because knowing the book is concentrated does not say *which*
+position is carrying the concentration, or what the alternative would have been.
+
+Two things close that gap and neither is an optimiser telling anyone what to
+hold:
+
+* **Risk contribution.** Weight is not risk. A 40% position in an uncorrelated
+  name and a 40% position that co-moves with the other 60% are the same number
+  on the holdings table and different books. `risk_contributions` splits total
+  portfolio volatility into per-name shares that sum to it exactly (Euler
+  decomposition), so "00100 is 40% of the money" can be read next to "and N% of
+  the risk".
+* **A reference allocation.** `hierarchical_risk_parity` (López de Prado 2016)
+  builds the weights a purely diversification-driven allocator would hold on the
+  same covariance — no expected returns, no matrix inversion, so it is stable at
+  the sample sizes this book has. It is a *ruler*, not a recommendation: the
+  distance between the live weights and HRP's is a measurement of how much of
+  the concentration is a choice rather than an accident.
+
+Why HRP rather than mean-variance
+---------------------------------
+Mean-variance needs `Σ⁻¹`, and at eight names on sixty sessions the smallest
+eigenvalue of the sample correlation is inside the Marchenko–Pastur noise band
+(see `portfolio.covariance.spectrum_report`) — inverting it puts the largest
+weights on the directions that are purest estimation error. HRP never inverts:
+it clusters, orders the matrix so similar names are adjacent, and splits capital
+down the tree by inverse variance. `minimum_variance` is still here, because the
+comparison between the two is informative, but it takes the shrunk covariance
+and says so.
+"""
+from __future__ import annotations
+
+import numpy as np
+from scipy.cluster.hierarchy import linkage, to_tree
+from scipy.spatial.distance import squareform
+
+from clawock.portfolio.covariance import correlation_from
+
+
+def _as_weights(weights) -> np.ndarray:
+    vector = np.asarray(weights, dtype=float)
+    total = vector.sum()
+    if total <= 0:
+        raise ValueError('weights must sum to a positive number')
+    return vector / total
+
+
+def portfolio_volatility(weights, covariance) -> float:
+    vector = _as_weights(weights)
+    return float(np.sqrt(vector @ np.asarray(covariance, dtype=float) @ vector))
+
+
+def risk_contributions(weights, covariance, names=None) -> dict:
+    """Euler decomposition of portfolio volatility into per-name shares.
+
+    `RC_i = w_i * (Σw)_i / sqrt(wᵀΣw)`, and the shares sum to the portfolio
+    volatility exactly — which is the property that makes this a decomposition
+    rather than an attribution heuristic, and which the tests check.
+
+    The interesting column is `risk_share - weight_share`: positive means the
+    name carries more of the book's risk than its size, which is what a
+    correlated overweight looks like from the inside.
+    """
+    vector = _as_weights(weights)
+    matrix = np.asarray(covariance, dtype=float)
+    total_volatility = float(np.sqrt(vector @ matrix @ vector))
+    if total_volatility <= 0:
+        return {'status': 'degenerate', 'reason': 'portfolio variance is zero'}
+    marginal = matrix @ vector / total_volatility
+    contributions = vector * marginal
+    names = list(names or range(len(vector)))
+    rows = [
+        {
+            'name': str(name),
+            'weight_share': round(float(vector[index]), 6),
+            'risk_contribution': round(float(contributions[index]), 8),
+            'risk_share': round(float(contributions[index] / total_volatility), 6),
+            'risk_share_minus_weight_share': round(
+                float(contributions[index] / total_volatility - vector[index]), 6),
+            'marginal_risk': round(float(marginal[index]), 8),
+        }
+        for index, name in enumerate(names)
+    ]
+    rows.sort(key=lambda row: -row['risk_share'])
+    return {
+        'status': 'measured',
+        'portfolio_volatility': round(total_volatility, 8),
+        'rows': rows,
+        'sums_to_volatility': round(float(contributions.sum()), 8),
+        'method': 'Euler decomposition; shares sum to portfolio volatility exactly',
+    }
+
+
+def effective_bets(weights, covariance) -> dict:
+    """Two concentration numbers that disagree on purpose.
+
+    `1 / sum(w²)` counts *names* and knows nothing about how they move.
+    `1 / (wᵀρw)` counts *bets* and collapses toward one as the book co-moves.
+    The gap between them is the part of the diversification that is nominal.
+    """
+    vector = _as_weights(weights)
+    correlation = correlation_from(np.asarray(covariance, dtype=float))
+    quadratic = float(vector @ correlation @ vector)
+    deviations = np.sqrt(np.diag(np.asarray(covariance, dtype=float)))
+    weighted_sigma = float(vector @ deviations)
+    volatility = portfolio_volatility(vector, covariance)
+    return {
+        'effective_names': round(1.0 / float(np.sum(vector ** 2)), 4),
+        'effective_bets': round(1.0 / quadratic, 4) if quadratic > 0 else None,
+        'diversification_ratio': round(weighted_sigma / volatility, 4)
+        if volatility > 0 else None,
+    }
+
+
+def _quasi_diagonal_order(link) -> list[int]:
+    """Leaf order of the dendrogram: similar names end up adjacent."""
+    return list(to_tree(link).pre_order(lambda node: node.id))
+
+
+def _inverse_variance_weights(covariance: np.ndarray, indices) -> np.ndarray:
+    variances = np.diag(covariance)[indices]
+    with np.errstate(divide='ignore'):
+        inverse = np.where(variances > 0, 1.0 / variances, 0.0)
+    total = inverse.sum()
+    return inverse / total if total > 0 else np.full(len(indices), 1.0 / len(indices))
+
+
+def _cluster_variance(covariance: np.ndarray, indices) -> float:
+    block = covariance[np.ix_(indices, indices)]
+    weights = _inverse_variance_weights(covariance, indices)
+    return float(weights @ block @ weights)
+
+
+def hierarchical_risk_parity(covariance, names=None, *, method='single') -> dict:
+    """López de Prado (2016). Cluster, reorder, then bisect by inverse variance.
+
+    The distance is `sqrt((1 - rho) / 2)`, the standard correlation metric, so
+    two names that move together are close. Recursive bisection splits capital
+    between the two halves of each split in inverse proportion to their cluster
+    variance, which means the concentrated half gets less without anyone
+    inverting anything.
+    """
+    matrix = np.asarray(covariance, dtype=float)
+    n = matrix.shape[0]
+    names = list(names or range(n))
+    if n < 2:
+        return {'status': 'degenerate', 'reason': 'need at least two names'}
+    correlation = np.clip(correlation_from(matrix), -1.0, 1.0)
+    distance = np.sqrt(np.maximum(0.0, (1.0 - correlation) / 2.0))
+    np.fill_diagonal(distance, 0.0)
+    link = linkage(squareform(distance, checks=False), method=method)
+    order = _quasi_diagonal_order(link)
+
+    weights = np.ones(n)
+    clusters = [order]
+    while clusters:
+        clusters = [
+            half
+            for cluster in clusters
+            for half in (cluster[:len(cluster) // 2], cluster[len(cluster) // 2:])
+            if len(cluster) > 1
+        ]
+        for index in range(0, len(clusters), 2):
+            left, right = clusters[index], clusters[index + 1]
+            left_variance = _cluster_variance(matrix, left)
+            right_variance = _cluster_variance(matrix, right)
+            total = left_variance + right_variance
+            factor = 1 - left_variance / total if total > 0 else 0.5
+            weights[left] *= factor
+            weights[right] *= 1 - factor
+        clusters = [cluster for cluster in clusters if len(cluster) > 1]
+
+    weights = weights / weights.sum()
+    return {
+        'status': 'measured',
+        'weights': {str(names[index]): round(float(weights[index]), 6)
+                    for index in range(n)},
+        'leaf_order': [str(names[index]) for index in order],
+        'linkage_method': method,
+        'method': ('Lopez de Prado (2016) hierarchical risk parity; no matrix '
+                   'inversion and no expected returns'),
+        'reading': ('a reference allocation for comparison, not a '
+                    'recommendation: the distance from the live weights is a '
+                    'measurement of how much concentration is deliberate'),
+    }
+
+
+def minimum_variance(covariance, names=None, *, long_only=True) -> dict:
+    """The long-only minimum-variance weights, by projected gradient descent.
+
+    Deliberately *not* the closed form `Σ⁻¹1 / 1ᵀΣ⁻¹1`. That inverts a matrix
+    whose smallest eigenvalues are, at this sample size, inside the
+    Marchenko–Pastur noise band, and it answers with large offsetting long and
+    short positions in whichever pair of names happened to look most correlated.
+    A simplex-projected descent stays inside the set of allocations the book
+    could actually hold, and it converges in a few hundred steps on a matrix this
+    size.
+
+    Feed it a *shrunk* covariance. `used_shrunk_covariance` is recorded by the
+    caller, not inferred here, because this function cannot tell.
+    """
+    matrix = np.asarray(covariance, dtype=float)
+    n = matrix.shape[0]
+    names = list(names or range(n))
+    weights = np.full(n, 1.0 / n)
+    if not long_only:
+        ones = np.ones(n)
+        inverse = np.linalg.pinv(matrix)
+        weights = inverse @ ones / float(ones @ inverse @ ones)
+        return {'status': 'measured', 'long_only': False,
+                'weights': {str(names[i]): round(float(weights[i]), 6)
+                            for i in range(n)},
+                'method': 'closed form; may be leveraged and short'}
+    step = 1.0 / (np.linalg.norm(matrix, 2) * 2 + 1e-12)
+    for _ in range(2000):
+        gradient = 2 * matrix @ weights
+        weights = _project_to_simplex(weights - step * gradient)
+    return {
+        'status': 'measured',
+        'long_only': True,
+        'weights': {str(names[index]): round(float(weights[index]), 6)
+                    for index in range(n)},
+        'volatility': round(portfolio_volatility(weights, matrix), 8),
+        'method': 'projected gradient descent on the long-only simplex',
+    }
+
+
+def _project_to_simplex(vector: np.ndarray) -> np.ndarray:
+    """Euclidean projection onto {w : w >= 0, sum(w) = 1} (Duchi et al. 2008)."""
+    n = len(vector)
+    ordered = np.sort(vector)[::-1]
+    cumulative = np.cumsum(ordered)
+    indices = np.arange(1, n + 1)
+    condition = ordered - (cumulative - 1) / indices > 0
+    rho = int(indices[condition][-1])
+    theta = (cumulative[rho - 1] - 1) / rho
+    return np.maximum(vector - theta, 0.0)
+
+
+def allocation_report(returns, weights, names, *, covariance_estimate) -> dict:
+    """Everything above on one covariance, with the live weights beside it.
+
+    `covariance_estimate` is the dict from `portfolio.covariance` — passed in
+    rather than computed here so the report records which estimator produced the
+    numbers and how hard it shrank.
+    """
+    matrix = covariance_estimate['covariance']
+    live = _as_weights(weights)
+    reference = hierarchical_risk_parity(matrix, names)
+    hrp_weights = np.array([reference['weights'][str(name)] for name in names]) \
+        if reference.get('status') == 'measured' else None
+    report = {
+        'covariance': {
+            'method': covariance_estimate.get('method'),
+            'shrinkage': covariance_estimate.get('shrinkage'),
+            'n_sessions': covariance_estimate.get('n_sessions'),
+            'n_names': covariance_estimate.get('n_names'),
+        },
+        'live': {
+            **effective_bets(live, matrix),
+            'volatility': round(portfolio_volatility(live, matrix), 8),
+        },
+        'risk_contributions': risk_contributions(live, matrix, names),
+        'hierarchical_risk_parity': reference,
+    }
+    if hrp_weights is not None:
+        report['reference_comparison'] = {
+            **{f'hrp_{key}': value
+               for key, value in effective_bets(hrp_weights, matrix).items()},
+            'hrp_volatility': round(portfolio_volatility(hrp_weights, matrix), 8),
+            # L1 distance between the two allocations, in the units a reader
+            # thinks in: half of it is the share of the book that would have to
+            # change hands to get from one to the other.
+            'turnover_to_reference': round(
+                float(np.abs(live - hrp_weights).sum() / 2), 6),
+        }
+    return report

--- a/src/clawock/portfolio/covariance.py
+++ b/src/clawock/portfolio/covariance.py
@@ -1,0 +1,244 @@
+"""Estimating a covariance matrix from fewer sessions than it has entries.
+
+The problem this is for
+-----------------------
+`correlation_xray` publishes `effective_bets`, `diversification_ratio`, VaR and
+the cluster map from `np.corrcoef` over a 60-session window. Every one of those
+is a functional of the correlation matrix, so every one of them inherits that
+estimator's error — and at this shape the error is not small and not symmetric.
+
+A sample covariance of `n` names from `T` observations estimates `n(n+1)/2`
+numbers from `nT`. With eight holdings and sixty sessions that is 36 parameters
+from 480 observations, a ratio where the Marchenko–Pastur law says the sample
+eigenvalues are *systematically* spread wider than the true ones: the largest is
+biased up and the smallest is biased down. Anything that inverts the matrix, or
+divides by a small eigenvalue, amplifies exactly the part that is noise.
+`effective_bets = 1 / (wᵀρw)` does not invert it, but it is dominated by the
+top eigenvalue, which is the biased-up one — so a concentrated book's
+concentration is *understated* by the estimator that measures it.
+
+Shrinkage is the standard answer and it is not a smoothing preference: Ledoit &
+Wolf derive the intensity that minimises expected squared error against the true
+matrix, so there is a right amount and it can be computed rather than chosen.
+
+What is here
+------------
+* `ledoit_wolf` — shrink toward the constant-correlation target (Ledoit & Wolf,
+  *Honey, I Shrunk the Sample Covariance Matrix*, 2004). The right target for
+  equities: it keeps each name's own variance and pulls only the correlations
+  toward their common mean.
+* `oas` — Oracle Approximating Shrinkage toward a scaled identity (Chen, Wiesel,
+  Eldar & Hero 2010). Stronger shrinkage in very short samples, and the honest
+  choice when even the average correlation is unstable.
+* `ewma_covariance` — exponential weighting, for when the question is "what is
+  the correlation *now*" rather than "over the window".
+* `spectrum_report` — where the sample eigenvalues sit relative to the
+  Marchenko–Pastur edge, i.e. how many of them are distinguishable from noise at
+  this `T/n`. This is the number that says whether shrinkage is a refinement or
+  a rescue.
+
+None of this decides anything on its own. It is the input to
+`portfolio.allocation`, and it is published beside the sample estimate rather
+than replacing it, so the size of the correction is visible.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _validate(returns: np.ndarray) -> np.ndarray:
+    matrix = np.asarray(returns, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError('returns must be a 2-D array of shape (sessions, names)')
+    if matrix.shape[0] < 3 or matrix.shape[1] < 2:
+        raise ValueError('need at least three sessions and two names')
+    if not np.isfinite(matrix).all():
+        raise ValueError('returns contain non-finite values')
+    return matrix
+
+
+def sample_covariance(returns) -> np.ndarray:
+    """Plain sample covariance, divided by `T` rather than `T - 1`.
+
+    The maximum-likelihood normalisation, because the shrinkage intensities
+    below are derived for it; mixing the two would apply a correction computed
+    for one estimator to another.
+    """
+    matrix = _validate(returns)
+    centred = matrix - matrix.mean(axis=0)
+    return centred.T @ centred / matrix.shape[0]
+
+
+def _constant_correlation_target(covariance: np.ndarray) -> tuple[np.ndarray, float]:
+    variances = np.diag(covariance)
+    deviations = np.sqrt(variances)
+    outer = np.outer(deviations, deviations)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        correlation = np.where(outer > 0, covariance / outer, 0.0)
+    n = covariance.shape[0]
+    off_diagonal = (correlation.sum() - np.trace(correlation)) / (n * (n - 1))
+    target = off_diagonal * outer
+    np.fill_diagonal(target, variances)
+    return target, float(off_diagonal)
+
+
+def ledoit_wolf(returns) -> dict:
+    """Shrink the sample covariance toward constant correlation.
+
+    Returns the shrunk matrix, the intensity that produced it, and the target's
+    average correlation — because an intensity of 0.6 means something different
+    when the target correlation is 0.9 (the book is already one bet and the
+    target agrees) than when it is 0.1.
+    """
+    matrix = _validate(returns)
+    sessions, names = matrix.shape
+    centred = matrix - matrix.mean(axis=0)
+    sample = centred.T @ centred / sessions
+    target, average_correlation = _constant_correlation_target(sample)
+
+    # pi: the sum of the asymptotic variances of the sample covariance entries.
+    squared = centred ** 2
+    pi_matrix = (squared.T @ squared) / sessions - sample ** 2
+    pi = float(pi_matrix.sum())
+
+    # rho: the covariance between the sample entries and the target's entries.
+    variances = np.diag(sample)
+    deviations = np.sqrt(variances)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        ratio = np.where(deviations > 0, 1.0 / deviations, 0.0)
+    term = (centred ** 3).T @ centred / sessions - variances * sample
+    rho = float(np.trace(pi_matrix))
+    for i in range(names):
+        for j in range(names):
+            if i == j:
+                continue
+            rho += average_correlation * 0.5 * (
+                deviations[j] * ratio[i] * term[i, j]
+                + deviations[i] * ratio[j] * term[j, i])
+
+    gamma = float(((target - sample) ** 2).sum())
+    if gamma <= 0:
+        intensity = 0.0
+    else:
+        intensity = max(0.0, min(1.0, (pi - rho) / gamma / sessions))
+    shrunk = intensity * target + (1 - intensity) * sample
+    return {
+        'covariance': shrunk,
+        'sample_covariance': sample,
+        'target': target,
+        'shrinkage': round(intensity, 6),
+        'target_average_correlation': round(average_correlation, 6),
+        'method': 'Ledoit & Wolf (2004), constant-correlation target',
+        'n_sessions': sessions,
+        'n_names': names,
+    }
+
+
+def oas(returns) -> dict:
+    """Oracle Approximating Shrinkage toward a scaled identity.
+
+    Chen, Wiesel, Eldar & Hero (2010). A stronger, simpler target than constant
+    correlation: it assumes nothing about the average correlation, which is what
+    makes it the right choice when the sample is short enough that even that
+    average is unstable. The cost is that it shrinks the structure the book
+    actually has, so it is offered beside `ledoit_wolf` rather than instead.
+    """
+    matrix = _validate(returns)
+    sessions, names = matrix.shape
+    centred = matrix - matrix.mean(axis=0)
+    sample = centred.T @ centred / sessions
+    mean_variance = float(np.trace(sample)) / names
+    target = mean_variance * np.eye(names)
+
+    trace_squared = float(np.trace(sample @ sample))
+    squared_trace = float(np.trace(sample)) ** 2
+    numerator = (1 - 2.0 / names) * trace_squared + squared_trace
+    denominator = (sessions + 1 - 2.0 / names) * (
+        trace_squared - squared_trace / names)
+    intensity = 1.0 if denominator <= 0 else max(0.0, min(1.0, numerator / denominator))
+    return {
+        'covariance': intensity * target + (1 - intensity) * sample,
+        'sample_covariance': sample,
+        'target': target,
+        'shrinkage': round(intensity, 6),
+        'method': 'Chen et al. (2010) oracle approximating shrinkage, identity target',
+        'n_sessions': sessions,
+        'n_names': names,
+    }
+
+
+def ewma_covariance(returns, decay: float = 0.94) -> dict:
+    """Exponentially weighted covariance (RiskMetrics).
+
+    Answers "what is the covariance now" rather than "over the window". The
+    effective sample size is `(1 + decay) / (1 - decay)`, and it is returned,
+    because an EWMA at 0.94 on sixty sessions is roughly thirty-two effective
+    observations — fewer than the window suggests, which matters for every
+    conditioning question in this module.
+    """
+    matrix = _validate(returns)
+    sessions, names = matrix.shape
+    centred = matrix - matrix.mean(axis=0)
+    weights = decay ** np.arange(sessions - 1, -1, -1)
+    weights = weights / weights.sum()
+    weighted = centred * weights[:, None]
+    covariance = centred.T @ weighted
+    return {
+        'covariance': covariance,
+        'decay': decay,
+        'effective_sessions': round((1 + decay) / (1 - decay), 2),
+        'n_sessions': sessions,
+        'n_names': names,
+        'method': 'RiskMetrics exponentially weighted covariance',
+    }
+
+
+def correlation_from(covariance: np.ndarray) -> np.ndarray:
+    deviations = np.sqrt(np.diag(covariance))
+    outer = np.outer(deviations, deviations)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        correlation = np.where(outer > 0, covariance / outer, 0.0)
+    np.fill_diagonal(correlation, 1.0)
+    return correlation
+
+
+def spectrum_report(returns) -> dict:
+    """How many eigenvalues are distinguishable from noise at this T/n.
+
+    Under the null that the returns are independent, the sample eigenvalues of
+    the correlation matrix fall inside the Marchenko–Pastur support
+    `[(1 ± sqrt(n/T))²]`. Eigenvalues above the upper edge are structure; those
+    inside it are the estimator's own noise, and any weight the book places on
+    them is being placed on nothing.
+
+    This is what decides whether shrinkage is a refinement or a rescue: with one
+    eigenvalue above the edge and the rest inside it, the sample matrix is
+    describing a single common factor plus noise, and the concentration numbers
+    computed from it are describing the noise too.
+    """
+    matrix = _validate(returns)
+    sessions, names = matrix.shape
+    correlation = correlation_from(sample_covariance(matrix))
+    eigenvalues = np.sort(np.linalg.eigvalsh(correlation))[::-1]
+    ratio = names / sessions
+    upper = (1 + np.sqrt(ratio)) ** 2
+    lower = (1 - np.sqrt(ratio)) ** 2
+    above = int((eigenvalues > upper).sum())
+    total = float(eigenvalues.sum())
+    return {
+        'n_sessions': sessions,
+        'n_names': names,
+        'observations_per_parameter': round(
+            sessions * names / (names * (names + 1) / 2), 2),
+        'eigenvalues': [round(float(value), 6) for value in eigenvalues],
+        'marchenko_pastur_edges': [round(float(lower), 4), round(float(upper), 4)],
+        'eigenvalues_above_noise': above,
+        'variance_share_of_top_eigenvalue': round(
+            float(eigenvalues[0]) / total, 4) if total > 0 else None,
+        'condition_number': round(
+            float(eigenvalues[0] / eigenvalues[-1]), 2)
+        if eigenvalues[-1] > 1e-12 else None,
+        'reading': ('eigenvalues inside the Marchenko-Pastur band are what an '
+                    'independent book would produce at this T/n; only the ones '
+                    'above the upper edge are structure'),
+    }

--- a/src/clawock/portfolio/risk.py
+++ b/src/clawock/portfolio/risk.py
@@ -28,6 +28,9 @@ import numpy as np
 import requests
 
 from clawock.credentials import load_api_keys
+from clawock.portfolio import allocation as _allocation
+from clawock.portfolio import covariance as _covariance
+from clawock.portfolio import stress as _stress
 from clawock.portfolio.fx import get_usdhkd
 from clawock.instruments import get as get_instrument
 from clawock.instruments import leverage_map, require as require_instrument
@@ -846,10 +849,22 @@ def correlation_xray(holdings_by_leg, series_by_leg, fx_hkd_to_usd):
     pairs = [p for p in pairs if p['rho'] is not None]
     pairs.sort(key=lambda p: -abs(p['rho']))
 
+    # Everything above this line is computed from `np.corrcoef`, and at this
+    # shape that estimator is not a neutral choice: ten names on ~35 common
+    # sessions is 55 parameters from 350 observations, where the Marchenko-
+    # Pastur law says the sample eigenvalues are systematically spread wider
+    # than the true ones. `effective_bets` is dominated by the top eigenvalue,
+    # the biased-up one, so a concentrated book's concentration is *understated*
+    # by the estimator measuring it. The blocks below publish the shrunk version
+    # beside the sample one rather than replacing it, so the size of the
+    # correction is visible instead of assumed (#1186/#1162/#1165).
+    deep = _deep_risk_view(matrix, w, tickers, common)
+
     return {
         'effective_names': _round_finite(1.0 / hhi if hhi > 0 else None, 2),
         'effective_bets': _round_finite(
             1.0 / quadratic if quadratic > 0 else None, 2),
+        **deep,
         'diversification_ratio': _round_finite(
             weighted_sigma / sigma_p if sigma_p > 0 else None, 3),
         'var_95': _round_finite(float(np.percentile(portfolio, 5))),
@@ -869,6 +884,61 @@ def correlation_xray(holdings_by_leg, series_by_leg, fx_hkd_to_usd):
             100 * total / book_value if book_value > 0 else None, 2),
         'cluster_rho': CLUSTER_RHO,
         'basis': 'USD-converted current weights over sessions both legs traded',
+    }
+
+
+def _deep_risk_view(matrix, weights, tickers, dates) -> dict:
+    """Conditioning, shrinkage, risk attribution and stress, on one covariance.
+
+    Wrapped in its own function and its own try/except because these are an
+    addition to a payload the dashboard already depends on: a new estimator that
+    raises on some future degenerate window must not take the whole correlation
+    x-ray — and the risk card built on it — down with it. The failure is
+    reported in the payload rather than swallowed.
+    """
+    try:
+        spectrum = _covariance.spectrum_report(matrix)
+        shrunk = _covariance.ledoit_wolf(matrix)
+        covariance = shrunk['covariance']
+        contributions = _allocation.risk_contributions(weights, covariance, tickers)
+        reference = _allocation.hierarchical_risk_parity(covariance, tickers)
+        shrunk_bets = _allocation.effective_bets(weights, covariance)
+        scenarios = _stress.scenario_suite(
+            covariance, weights, tickers, returns=matrix, dates=dates)
+    except (ValueError, np.linalg.LinAlgError) as error:
+        return {'deep_risk': {'status': 'unavailable', 'reason': str(error)}}
+
+    rows = contributions.get('rows') or []
+    widest = max(rows, key=lambda row: row['risk_share_minus_weight_share'],
+                 default=None)
+    return {
+        'deep_risk': {
+            'status': 'measured',
+            # Whether the numbers above are a refinement or a rescue. Only the
+            # eigenvalues above the upper Marchenko-Pastur edge are structure;
+            # the rest is what an independent book of this shape would produce.
+            'conditioning': {
+                'observations_per_parameter': spectrum['observations_per_parameter'],
+                'eigenvalues_above_noise': spectrum['eigenvalues_above_noise'],
+                'n_names': spectrum['n_names'],
+                'marchenko_pastur_edges': spectrum['marchenko_pastur_edges'],
+                'condition_number': spectrum['condition_number'],
+                'variance_share_of_top_eigenvalue': spectrum[
+                    'variance_share_of_top_eigenvalue'],
+            },
+            'shrinkage': {
+                'intensity': shrunk['shrinkage'],
+                'target_average_correlation': shrunk['target_average_correlation'],
+                'method': shrunk['method'],
+                'effective_bets': shrunk_bets['effective_bets'],
+                'diversification_ratio': shrunk_bets['diversification_ratio'],
+            },
+            # Weight is not risk. This is the sentence the x-ray could not say.
+            'risk_contributions': rows,
+            'largest_risk_overweight': widest,
+            'reference_allocation': reference,
+            'stress': scenarios,
+        }
     }
 
 

--- a/src/clawock/portfolio/stress.py
+++ b/src/clawock/portfolio/stress.py
@@ -1,0 +1,182 @@
+"""Three questions a volatility number does not answer.
+
+`correlation_xray` publishes a 30-day volatility, a 95% VaR and an expected
+shortfall. Those describe the middle of the distribution and one point in its
+tail, under the window that happened to be sampled. The questions that actually
+come up when a position is being sized are shaped differently:
+
+* **"What has this book already survived?"** — `historical_worst_windows` replays
+  the realised weights over the sample and reports the worst k-session stretches
+  with their dates. Not a model: the loss the current allocation would have taken
+  through the specific weeks that happened.
+* **"If the big one halves, what happens to the rest?"** — `correlated_shock`
+  propagates a move in named positions to the others through the covariance,
+  `E[r_rest | r_shocked] = Σ_rs Σ_ss⁻¹ shock`. Shocking a name and holding the
+  rest still is the mistake this exists to prevent: in a book whose top two
+  eigenvalues carry most of the variance, the rest do not hold still.
+* **"What is the most likely way to lose 15%?"** — `reverse_stress` inverts the
+  question. Among all return vectors producing a given portfolio loss, it returns
+  the one with the smallest Mahalanobis distance, i.e. the *least improbable*
+  one: `r* = -loss · Σw / (wᵀΣw)`. That vector is the scenario worth writing down,
+  because it is the shape the market would most plausibly take to get there — and
+  it is usually not "everything falls equally".
+
+Every function takes a covariance the caller chose. Feed it a shrunk one: at
+this book's sample size, three of ten eigenvalues sit essentially at zero, and
+`Σ_ss⁻¹` on the sample matrix would put the whole shock into whichever direction
+is purest estimation error.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _weights(vector) -> np.ndarray:
+    array = np.asarray(vector, dtype=float)
+    total = array.sum()
+    if total <= 0:
+        raise ValueError('weights must sum to a positive number')
+    return array / total
+
+
+def historical_worst_windows(returns, weights, *, sessions=(1, 5, 20),
+                             dates=None, top=3) -> dict:
+    """Worst k-session realised losses for the current allocation.
+
+    Weights are held fixed at today's — this is "what would this book have done
+    through those weeks", not a replay of a rebalancing history it did not have.
+    The distinction matters and is stated in the payload rather than assumed.
+    """
+    matrix = np.asarray(returns, dtype=float)
+    vector = _weights(weights)
+    if matrix.ndim != 2 or matrix.shape[1] != len(vector):
+        raise ValueError('returns and weights disagree on the number of names')
+    portfolio = matrix @ vector
+    dates = list(dates or range(len(portfolio)))
+    out = {}
+    for window in sessions:
+        if len(portfolio) < window:
+            continue
+        cumulative = [
+            (float(np.prod(1 + portfolio[start:start + window]) - 1), start)
+            for start in range(len(portfolio) - window + 1)
+        ]
+        cumulative.sort()
+        out[f'worst_{window}_session'] = [
+            {
+                'return': round(value, 6),
+                'from': str(dates[start]),
+                'to': str(dates[min(start + window - 1, len(dates) - 1)]),
+            }
+            for value, start in cumulative[:top]
+        ]
+    return {
+        'status': 'measured',
+        'n_sessions': len(portfolio),
+        'basis': 'current weights held fixed through past returns; not a rebalancing replay',
+        **out,
+    }
+
+
+def correlated_shock(covariance, weights, shocks, names) -> dict:
+    """Propagate a shock in named positions to the rest through the covariance.
+
+    `shocks` maps a name to its return under the scenario. The others are not
+    held still: their conditional expectation is
+    `Σ_rest,shocked @ pinv(Σ_shocked,shocked) @ shock`.
+
+    The unconditional version — shock one name, freeze the others — understates
+    the loss in exactly the books where it matters, because a concentrated book
+    is concentrated *through* correlation.
+    """
+    matrix = np.asarray(covariance, dtype=float)
+    names = list(names)
+    vector = _weights(weights)
+    index_of = {str(name): position for position, name in enumerate(names)}
+    shocked = [index_of[str(name)] for name in shocks if str(name) in index_of]
+    if not shocked:
+        return {'status': 'no_named_position', 'names': list(shocks)}
+    rest = [position for position in range(len(names)) if position not in set(shocked)]
+    shock_vector = np.array([float(shocks[str(names[position])])
+                             for position in shocked])
+
+    moves = np.zeros(len(names))
+    moves[shocked] = shock_vector
+    if rest:
+        block_ss = matrix[np.ix_(shocked, shocked)]
+        block_rs = matrix[np.ix_(rest, shocked)]
+        moves[rest] = block_rs @ np.linalg.pinv(block_ss) @ shock_vector
+
+    naive = float(sum(vector[position] * moves[position] for position in shocked))
+    return {
+        'status': 'measured',
+        'shocked': {str(names[position]): round(float(moves[position]), 6)
+                    for position in shocked},
+        'implied': {str(names[position]): round(float(moves[position]), 6)
+                    for position in rest},
+        'portfolio_return': round(float(vector @ moves), 6),
+        'portfolio_return_if_others_held_still': round(naive, 6),
+        'contagion_share': round(
+            float(1 - naive / (vector @ moves)), 4) if abs(vector @ moves) > 0 else None,
+        'method': 'conditional expectation under the supplied covariance',
+    }
+
+
+def reverse_stress(covariance, weights, loss, names) -> dict:
+    """The least improbable return vector that produces a given portfolio loss.
+
+    Among all `r` with `wᵀr = -loss`, the one minimising `rᵀΣ⁻¹r` is
+    `r* = -loss · Σw / (wᵀΣw)`, which needs no inversion. Its Mahalanobis
+    distance is `loss / sqrt(wᵀΣw)` — the number of portfolio standard deviations
+    the scenario is away, and the honest way to say how far-fetched it is.
+
+    The output is deliberately per-name: the useful part is that the scenario is
+    almost never "everything falls equally", and seeing which name has to move
+    most is what turns a limit into a decision.
+    """
+    matrix = np.asarray(covariance, dtype=float)
+    vector = _weights(weights)
+    names = list(names)
+    variance = float(vector @ matrix @ vector)
+    if variance <= 0:
+        return {'status': 'degenerate', 'reason': 'portfolio variance is zero'}
+    moves = -abs(float(loss)) * (matrix @ vector) / variance
+    return {
+        'status': 'measured',
+        'target_loss': round(-abs(float(loss)), 6),
+        'moves': {str(names[index]): round(float(moves[index]), 6)
+                  for index in range(len(names))},
+        'largest_mover': str(names[int(np.argmin(moves))]),
+        'sigmas_away': round(abs(float(loss)) / float(np.sqrt(variance)), 3),
+        'method': ('minimum-Mahalanobis scenario reaching the loss; the least '
+                   'improbable shape, not the worst one'),
+    }
+
+
+def scenario_suite(covariance, weights, names, *, returns=None, dates=None,
+                   shock_top_position=-0.20, losses=(0.10, 0.20)) -> dict:
+    """The three questions above, run together on one covariance.
+
+    The top position is shocked because that is the scenario a concentrated book
+    is actually exposed to; `shock_top_position` is the size of that move and is
+    recorded rather than hidden, so a reader can tell a -20% assumption from a
+    -50% one.
+    """
+    vector = _weights(weights)
+    names = list(names)
+    top = str(names[int(np.argmax(vector))])
+    report = {
+        'top_position': top,
+        'top_position_weight': round(float(vector.max()), 6),
+        'correlated_shock': correlated_shock(
+            covariance, vector, {top: shock_top_position}, names),
+        'reverse_stress': {
+            f'loss_{int(loss * 100)}pct': reverse_stress(
+                covariance, vector, loss, names)
+            for loss in losses
+        },
+    }
+    if returns is not None:
+        report['historical'] = historical_worst_windows(
+            returns, vector, dates=dates)
+    return report

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -326,6 +326,55 @@ def trim_decision_metrics(metrics):
     return metrics
 
 
+def trim_deep_risk(risk):
+    """Keep the sentences, drop the working, for the copy embedded in the payload.
+
+    `correlation.deep_risk` is about 4KB of per-name risk contributions, an HRP
+    reference allocation and three stress scenarios — the same shape as the
+    calibrator and regime-history trims above, and here for the same reason: the
+    card reads a handful of headline numbers and the detail is already published
+    in full at `assets/data/risk.json`, one fetch away. The payload has roughly
+    20KB of headroom under the 200KB cap and this block would take a fifth of it
+    to be rendered by nothing.
+
+    What survives is what a reader would act on: how badly conditioned the
+    estimate is, how hard it had to be shrunk, the single largest risk
+    overweight, and the two numbers from the shock.
+    """
+    if not isinstance(risk, dict):
+        return risk
+    correlation = risk.get('correlation')
+    if not isinstance(correlation, dict):
+        return risk
+    deep = correlation.get('deep_risk')
+    if not isinstance(deep, dict) or deep.get('status') != 'measured':
+        return risk
+    shock = ((deep.get('stress') or {}).get('correlated_shock') or {})
+    reverse = ((deep.get('stress') or {}).get('reverse_stress') or {})
+    summary = {
+        'status': 'measured',
+        'conditioning': deep.get('conditioning'),
+        'shrinkage': deep.get('shrinkage'),
+        'largest_risk_overweight': deep.get('largest_risk_overweight'),
+        'top_position_shock': {
+            'name': (deep.get('stress') or {}).get('top_position'),
+            'move': (shock.get('shocked') or {}).get(
+                (deep.get('stress') or {}).get('top_position')),
+            'portfolio_return': shock.get('portfolio_return'),
+            'portfolio_return_if_others_held_still':
+                shock.get('portfolio_return_if_others_held_still'),
+            'contagion_share': shock.get('contagion_share'),
+        },
+        'sigmas_to_lose': {
+            key: value.get('sigmas_away')
+            for key, value in reverse.items() if isinstance(value, dict)
+        },
+        'detail_source': 'assets/data/risk.json',
+    }
+    return {**risk,
+            'correlation': {**correlation, 'deep_risk': summary}}
+
+
 def trim_lev_regime(lev_regime):
     """The dial as the card needs it: everything except the unrendered history."""
     if not isinstance(lev_regime, dict):
@@ -3332,7 +3381,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     risk_path = WS_ROOT / 'assets' / 'data' / 'risk.json'
     if risk_path.exists():
         try:
-            out['risk'] = json.loads(risk_path.read_text())
+            out['risk'] = trim_deep_risk(json.loads(risk_path.read_text()))
         except Exception as e:
             print(f'  warn: risk.json parse fail: {e}', file=sys.stderr)
             out['risk'] = None

--- a/tests/test_portfolio_risk_math.py
+++ b/tests/test_portfolio_risk_math.py
@@ -1,0 +1,242 @@
+"""Weight is not risk, and a sample covariance of this shape is not the truth.
+
+`correlation_xray` publishes `effective_bets` and a diversification ratio from
+`np.corrcoef` over sixty sessions. On the live book that is ten names on
+thirty-five common sessions — 55 parameters from 350 observations, where the
+Marchenko–Pastur law says the sample eigenvalues are systematically spread wider
+than the true ones and three of ten sit essentially at zero. Every number
+downstream inherits that, and it inherits it in the flattering direction:
+`effective_bets` is dominated by the top eigenvalue, which is the biased-up one.
+
+These tests hold the additions to the properties that make them worth having
+rather than a longer payload — shrinkage has to *help*, a risk decomposition has
+to add up, a shock has to propagate, and a reverse-stress scenario has to be the
+one it claims to be.
+"""
+import json
+
+import numpy as np
+import pytest
+
+from clawock.portfolio import allocation, covariance, stress
+from clawock.publish.dashboard import trim_deep_risk
+
+
+def _true_covariance(n=8, seed=1):
+    """Two blocks: a tight one, a loose one, and a weak link between them."""
+    rng = np.random.default_rng(seed)
+    correlation = np.full((n, n), 0.15)
+    correlation[:n // 2, :n // 2] = 0.85
+    correlation[n // 2:, n // 2:] = 0.35
+    np.fill_diagonal(correlation, 1.0)
+    deviations = rng.uniform(0.01, 0.05, size=n)
+    return np.outer(deviations, deviations) * correlation
+
+
+def _draw(true, sessions, seed):
+    root = np.linalg.cholesky(true + 1e-12 * np.eye(len(true)))
+    return np.random.default_rng(seed).normal(size=(sessions, len(true))) @ root.T
+
+
+def test_shrinkage_decays_as_the_sample_grows():
+    """The intensity is derived, not chosen, so it has to behave like one."""
+    true = _true_covariance()
+    intensities = [
+        np.mean([covariance.ledoit_wolf(_draw(true, sessions, seed))['shrinkage']
+                 for seed in range(15)])
+        for sessions in (30, 60, 250, 2000)
+    ]
+    assert all(intensities[index] > intensities[index + 1]
+               for index in range(len(intensities) - 1)), intensities
+    assert intensities[0] > 0.2
+    assert intensities[-1] < 0.05
+
+
+def test_shrinkage_buys_a_lower_out_of_sample_portfolio_variance():
+    """The metric that decides whether this is worth the code.
+
+    Frobenius error on the matrix is not the point; what a covariance is used
+    for is sizing. Build the long-only minimum-variance portfolio on each
+    estimate from one sample, then measure the variance it actually realises
+    under the true covariance. Averaged over draws, the shrunk estimate has to
+    win — that is the whole claim.
+    """
+    true = _true_covariance()
+    sample_variance, shrunk_variance = [], []
+    for seed in range(25):
+        returns = _draw(true, 40, seed)
+        estimate = covariance.ledoit_wolf(returns)
+        for source, sink in ((estimate['sample_covariance'], sample_variance),
+                             (estimate['covariance'], shrunk_variance)):
+            weights = np.array(list(
+                allocation.minimum_variance(source)['weights'].values()))
+            sink.append(float(weights @ true @ weights))
+    assert np.mean(shrunk_variance) < np.mean(sample_variance)
+
+
+def test_the_spectrum_separates_a_factor_from_noise():
+    rng = np.random.default_rng(4)
+    noise = rng.normal(size=(60, 8))
+    assert covariance.spectrum_report(noise)['eigenvalues_above_noise'] == 0
+    factor = rng.normal(size=(60, 1)) @ rng.uniform(0.5, 1.5, size=(1, 8))
+    assert covariance.spectrum_report(
+        factor + 0.3 * rng.normal(size=(60, 8)))['eigenvalues_above_noise'] >= 1
+
+
+def test_risk_contributions_sum_to_the_portfolio_volatility():
+    """The property that makes it a decomposition rather than a heuristic."""
+    true = _true_covariance()
+    weights = np.array([0.40, 0.12, 0.12, 0.09, 0.09, 0.08, 0.06, 0.04])
+    report = allocation.risk_contributions(weights, true)
+    assert report['sums_to_volatility'] == pytest.approx(
+        report['portfolio_volatility'], rel=1e-9)
+    assert sum(row['risk_share'] for row in report['rows']) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_a_correlated_overweight_carries_more_risk_than_its_weight():
+    """The sentence the x-ray could not say.
+
+    On the live book `00100` is 40% of the money and 70% of the risk. Here: one
+    name inside the tight block, held at the same weight as one outside it, must
+    come back with a larger risk share.
+    """
+    true = _true_covariance()
+    weights = np.full(8, 1 / 8)
+    rows = {row['name']: row for row in
+            allocation.risk_contributions(weights, true, range(8))['rows']}
+    inside = statistics_mean([rows[str(index)]['risk_share'] for index in range(4)])
+    outside = statistics_mean([rows[str(index)]['risk_share'] for index in range(4, 8)])
+    assert inside > outside
+
+
+def statistics_mean(values):
+    return sum(values) / len(values)
+
+
+def test_hrp_produces_a_long_only_allocation_without_inverting_anything():
+    true = _true_covariance()
+    names = [f'N{index}' for index in range(8)]
+    result = allocation.hierarchical_risk_parity(true, names)
+    weights = np.array([result['weights'][name] for name in names])
+    assert result['status'] == 'measured'
+    assert (weights >= 0).all()
+    # 1e-5, not 1e-9: the published weights are rounded to six places, so eight
+    # of them can miss the simplex by four parts in a million. Asserting tighter
+    # than the payload's own precision would be testing the rounding.
+    assert weights.sum() == pytest.approx(1.0, abs=1e-5)
+    # The tight block should not receive four independent allocations.
+    assert weights[:4].sum() < weights[4:].sum()
+
+
+def test_hrp_survives_a_singular_covariance_that_would_break_an_inverse():
+    """Two identical names make the matrix singular. HRP must still answer.
+
+    This is not hypothetical: `SPCH`/`SPCX` have a sample correlation of exactly
+    1.000 in the live x-ray, and the closed-form minimum-variance weights on that
+    matrix are whatever `pinv` decides to return.
+    """
+    base = _true_covariance(6)
+    duplicated = np.zeros((7, 7))
+    duplicated[:6, :6] = base
+    duplicated[6, :6] = base[0]
+    duplicated[:6, 6] = base[:, 0]
+    duplicated[6, 6] = base[0, 0]
+    result = allocation.hierarchical_risk_parity(duplicated)
+    assert result['status'] == 'measured'
+    assert sum(result['weights'].values()) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_long_only_minimum_variance_stays_on_the_simplex():
+    true = _true_covariance()
+    weights = np.array(list(allocation.minimum_variance(true)['weights'].values()))
+    assert (weights >= -1e-9).all()
+    assert weights.sum() == pytest.approx(1.0, abs=1e-6)
+    # And it must actually be lower variance than equal weight, or it is not
+    # solving the problem it names.
+    equal = np.full(len(true), 1 / len(true))
+    assert weights @ true @ weights < equal @ true @ equal
+
+
+def test_a_shock_propagates_instead_of_leaving_the_others_still():
+    """The mistake this exists to prevent.
+
+    Shocking the top position and holding the rest still understates the loss in
+    exactly the books where it matters, because a concentrated book is
+    concentrated *through* correlation.
+    """
+    true = _true_covariance()
+    weights = np.full(8, 1 / 8)
+    names = [f'N{index}' for index in range(8)]
+    result = stress.correlated_shock(true, weights, {'N0': -0.20}, names)
+    assert result['portfolio_return'] < result['portfolio_return_if_others_held_still']
+    assert result['contagion_share'] > 0
+    # Names inside N0's block move more than names outside it.
+    implied = result['implied']
+    assert implied['N1'] < implied['N7']
+
+
+def test_reverse_stress_hits_the_loss_it_was_asked_for():
+    true = _true_covariance()
+    weights = np.array([0.40, 0.12, 0.12, 0.09, 0.09, 0.08, 0.06, 0.04])
+    names = [f'N{index}' for index in range(8)]
+    result = stress.reverse_stress(true, weights, 0.15, names)
+    moves = np.array([result['moves'][name] for name in names])
+    assert float(weights / weights.sum() @ moves) == pytest.approx(-0.15, abs=1e-5)
+
+
+def test_reverse_stress_returns_the_least_improbable_shape_not_a_uniform_one():
+    """Among all vectors reaching the loss, this is the closest one to the mean.
+
+    A uniform fall reaching the same loss must be *further* away in Mahalanobis
+    distance, or the scenario being published is not the one it claims to be.
+    """
+    true = _true_covariance()
+    weights = np.array([0.40, 0.12, 0.12, 0.09, 0.09, 0.08, 0.06, 0.04])
+    normalised = weights / weights.sum()
+    names = [f'N{index}' for index in range(8)]
+    result = stress.reverse_stress(true, weights, 0.15, names)
+    chosen = np.array([result['moves'][name] for name in names])
+    uniform = np.full(8, -0.15 / normalised.sum())
+    inverse = np.linalg.pinv(true)
+    assert chosen @ inverse @ chosen < uniform @ inverse @ uniform
+    # And the scenario is not "everything falls equally".
+    assert chosen.max() - chosen.min() > 0.02
+
+
+def test_historical_windows_report_the_dates_they_found():
+    true = _true_covariance()
+    returns = _draw(true, 80, 3)
+    dates = [f'2026-01-{index + 1:04d}' for index in range(80)]
+    report = stress.historical_worst_windows(
+        returns, np.full(8, 1 / 8), dates=dates)
+    worst = report['worst_5_session'][0]
+    assert worst['return'] < 0
+    assert worst['from'] in dates and worst['to'] in dates
+    assert report['worst_5_session'][0]['return'] <= report['worst_5_session'][1]['return']
+
+
+def test_the_deep_block_degrades_instead_of_taking_the_x_ray_down():
+    """It is an addition to a payload the risk card already depends on."""
+    from clawock.portfolio import risk
+    out = risk._deep_risk_view(np.zeros((2, 2)), [0.5, 0.5], ['A', 'B'], ['d', 'e'])
+    assert out['deep_risk']['status'] == 'unavailable'
+    assert out['deep_risk']['reason']
+
+
+def test_the_embedded_copy_keeps_the_sentences_and_drops_the_working():
+    from clawock.portfolio import risk
+    returns = _draw(_true_covariance(), 40, 9)
+    deep = risk._deep_risk_view(returns, np.full(8, 1 / 8),
+                                [f'N{index}' for index in range(8)],
+                                [f'd{index}' for index in range(40)])
+    payload = {'correlation': {'effective_bets': 2.0, **deep}}
+    trimmed = trim_deep_risk(payload)
+    assert len(json.dumps(trimmed)) < len(json.dumps(payload)) / 2
+    summary = trimmed['correlation']['deep_risk']
+    assert summary['conditioning'] and summary['shrinkage']
+    assert summary['largest_risk_overweight']['name']
+    assert summary['top_position_shock']['portfolio_return'] is not None
+    assert summary['detail_source'] == 'assets/data/risk.json'
+    # The detail is gone from the embedded copy, not from the file.
+    assert 'risk_contributions' not in summary
+    assert 'reference_allocation' not in summary

--- a/tests/test_workspace_portability.py
+++ b/tests/test_workspace_portability.py
@@ -45,13 +45,27 @@ def test_no_workflow_reinstates_a_hand_written_package_list():
 
 
 def test_the_declared_extras_cover_what_the_suite_imports():
-    extras = tomllib.load(open(ROOT / "pyproject.toml", "rb"))[
-        "project"]["optional-dependencies"]
-    names = {dep.split(">")[0].split("=")[0].strip().lower()
-             for dep in extras["test"]}
+    """`.[test]` plus the required dependencies must cover every suite import.
 
-    # numpy is required to *collect* tests, not merely to pass one of them.
-    assert {"pytest", "pytest-cov", "numpy", "pillow"} <= names, names
+    The gate used to read `extras["test"]` alone, which was right while numpy
+    lived in an optional group. It is a required dependency as of 2026-08-30 —
+    `portfolio/risk.py` had been importing it at the top level all along, so a
+    clean install already shipped a `portfolio-risk` command that raised on its
+    first line. Requiring a package to *also* be listed in the test extra would
+    make the correct declaration fail this gate, so the union is what is checked.
+    """
+    project = tomllib.load(open(ROOT / "pyproject.toml", "rb"))["project"]
+
+    def distributions(specifiers):
+        return {re.split(r"[><=!\[~;]", spec)[0].strip().lower()
+                for spec in specifiers}
+
+    installed = (distributions(project["dependencies"])
+                 | distributions(project["optional-dependencies"]["test"]))
+    # Every one of these is needed to *collect* the suite, not merely to pass
+    # one of its tests: a module that cannot import does not fail, it stops the
+    # run at collection while the run still looks like it ran.
+    assert {"pytest", "pytest-cov", "numpy", "scipy", "pillow"} <= installed, installed
 
 
 def test_the_engine_runs_against_a_workspace_that_is_not_this_one(tmp_path):


### PR DESCRIPTION
Closes #1162, closes #1165, closes #1186。

## 依赖变更(kcn 已授权「必要的依赖和破坏性升级都可以做」)

**numpy 与 scipy 变成必需依赖。**

- **numpy 本来就是必需的,只有元数据是错的**:`portfolio/risk.py` 在模块顶层无条件
  `import numpy as np`,而它就是打包命令 `portfolio-risk` 的落点 ⇒
  **干净 `pip install clawock` 一直在发一个第一行就 ImportError 的一级命令。**
- **scipy 加进来**是因为另一条路是手写层次聚类、特征分解和约束优化来省一个 wheel,
  那比多下载几十 MB 更糟。
- `test_the_declared_extras_cover_what_the_suite_imports` 改成检查
  `dependencies | extras["test"]` 的并集 —— 原来只看 `extras["test"]`,
  会让「正确的声明」反而挂掉这道闸。

## 问题:`effective_bets 1.98` 是从一个什么样的估计量里出来的

实测 live book:**10 个名字,34 个共同 session** ⇒ 55 个参数、340 个观测。

```
Marchenko-Pastur 边界   [0.21, 2.38]
10 个特征值里高于上边界的  2
最小的三个                0.007 / 0.003 / 0.000
条件数                    13,241
Ledoit-Wolf 收缩强度      0.63
```

**`effective_bets` 由最大特征值主导,而那正是理论说被高估的那一个** ⇒
**一个集中的账本,它的集中度被测量它的那个估计量低估了。** 0.63 的收缩强度不是「精修」。

## 做了什么(三个模块,与样本估计**并排**发布,不替换)

- `portfolio/covariance.py` — Ledoit & Wolf (2004) 常相关目标收缩、Chen et al. (2010) OAS、
  EWMA,以及 **Marchenko-Pastur 谱报告**(这个 T/n 下有几个特征值能和噪声区分开)。
  最后那个数决定「收缩是精修还是抢救」。
- `portfolio/allocation.py` — **Euler 风险贡献**,以及 **HRP**(López de Prado 2016)当**标尺,不是建议**。
  用 HRP 不用均值方差:后者要求逆矩阵,而这里最小的几个特征值就是纯估计误差。
  最小方差也改成单纯形投影梯度下降,同一个理由。
- `portfolio/stress.py` — 历史最差 k-session 窗口(带日期)、
  **沿协方差传导的冲击**(不是把别的名字按住不动)、
  以及**反向压力测试:给定亏损下最不离奇的那个情景**(最小马氏距离),不是「所有票等比例跌」。

## 实测:x-ray 说不出来的两句话

### 1. **00100 占 40.2% 的钱,占 69.6% 的风险** —— 29 个百分点的差,持仓表上看不到

```
00100  w 0.402  risk 0.696  diff +0.294
SPCH   w 0.119  risk 0.143  diff +0.024
03032  w 0.091  risk 0.014  diff -0.078
```

### 2. **10% 的回撤只有 1.93 σ 远**,而且它最可能的形状不是「一起跌」

```
loss 10%  → 1.93 sigma   00100 -17.3% / SPCH -12.0% / 03032 -1.5%
loss 20%  → 3.86 sigma
00100 −20% 的冲击 → 全书 −9.9%,其中 19% 是传导到另外九个名字
                    (「别的按住不动」的答案是 −8.0%)
```

## payload

完整块 4KB。`trim_deep_risk` 只把 **0.9KB 的摘要**嵌进 dashboard payload
(和 calibrator / regime-history 那两处 trim 同一个做法、同一个理由:卡片只读表头,
明细在 `assets/data/risk.json` 一次 fetch 之外)。
新块还包在 try/except 里 —— 它是加在一个 risk 卡片已经依赖的 payload 上的,
将来某个退化窗口必须降级成 `status: unavailable`,不能把整张卡带下去。

## 测试

`tests/test_portfolio_risk_math.py`(14)。含会真失败的行为断言:
**收缩强度必须随样本变大而单调衰减**、
**收缩必须买到更低的样本外组合方差**(在真协方差下实测最小方差组合的实现方差,25 次抽样平均)、
**风险贡献必须精确加总到组合波动率**、
**冲击必须传导**(把别的按住不动的答案必须更小)、
**反向压力的情景必须比同等亏损的均匀下跌马氏距离更近**,
以及 **HRP 在奇异协方差上必须还能答**(`SPCH`/`SPCX` 的样本相关就是 1.000)。
