### PR TITLE
run_card: the reproduction key now covers what it claimed to (#1139)

### DIFF
--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -27,6 +27,7 @@ from collections import Counter, defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+from clawock import seeds
 from clawock import sessions as _cal
 from clawock.decision.mind_record import validate_mind_record
 # One implementation of the interval, not a second copy of the algebra: the
@@ -1134,7 +1135,7 @@ def _paired_block_ci(events: list[dict], samples: int = 2000) -> list[float] | N
     blocks = sorted(groups)
     if len(blocks) < 3:
         return None
-    rnd = random.Random(20260717)
+    rnd = random.Random(seeds.seed('decision_cluster_bootstrap'))
     draws = []
     for _ in range(samples):
         values = []
@@ -1402,7 +1403,7 @@ def _cluster_ci(rows: list[dict], value_fn, samples: int = 1000) -> list[float] 
     dates = sorted(groups)
     if len(dates) < 3:
         return None
-    rnd = random.Random(20260714)
+    rnd = random.Random(seeds.seed('decision_episode_bootstrap'))
     stats = []
     for _ in range(samples):
         vals = []

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -41,6 +41,7 @@ from datetime import date as real_date
 from datetime import date
 from pathlib import Path
 
+from clawock import seeds
 from clawock import history_store
 from clawock import instruments
 from clawock import sessions as trading_calendar
@@ -143,7 +144,7 @@ def clustered_ci(observations, samples=2000):
     tickers = sorted({row['ticker'] for row in observations})
     if len(dates) < 2 or len(tickers) < 2:
         return None
-    rnd = random.Random(20260717)
+    rnd = random.Random(seeds.seed('decision_cluster_bootstrap'))
     draws = []
     for _ in range(samples):
         date_counts = {d: 0 for d in dates}

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -13,10 +13,12 @@ import json
 import math
 import random
 import statistics
+import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+from clawock import seeds
 from clawock import history_store
 from clawock.decision import add_alpha, early_trend, signals
 from clawock.evaluation import bootstrap as block_bootstrap
@@ -149,7 +151,7 @@ def _cluster_ci(rows, field, samples=1000):
     dates = sorted(by_date)
     if len(dates) < 3:
         return None
-    rnd = random.Random(20260813)
+    rnd = random.Random(seeds.seed('add_alpha_cluster_bootstrap'))
     draws = []
     for _ in range(samples):
         chosen = [rnd.choice(dates) for _ in dates]
@@ -747,6 +749,7 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--no-card", action="store_true")
     args = parser.parse_args(argv)
+    started_at = time.monotonic()
     config = _json(FACTOR_CONFIG)
     policy = _json(ALPHA_POLICY)
     news_policy = _json(NEWS_POLICY)
@@ -805,6 +808,11 @@ def main(argv=None):
             inputs=inputs,
             metrics=metrics,
             code_files=[Path(__file__), Path(add_alpha.__file__), Path(early_trend.__file__)],
+            # The thresholds this run used come out of these files; recording
+            # only the ones passed explicitly described a policy whose other
+            # contents also decided the answer (#1139).
+            config_files=[FACTOR_CONFIG, ALPHA_POLICY, NEWS_POLICY],
+            started_at=started_at,
             notes=[
                 "US and HK are ranked and evaluated separately.",
                 "Production classify_authority and confirmation primitives are reused directly.",

--- a/src/clawock/evaluation/bootstrap.py
+++ b/src/clawock/evaluation/bootstrap.py
@@ -51,6 +51,8 @@ import math
 import random
 import statistics
 
+from clawock import seeds
+
 #: Politis & White's own bound. Beyond this the "block" is a sizeable fraction
 #: of the sample and the resample stops being a resample.
 def _max_block(n: int) -> int:
@@ -260,7 +262,7 @@ def bca_interval(draws, point_estimate, jackknife_values, alpha: float = 0.05) -
 
 
 def clustered_block_ci(values_by_cluster: dict, *, samples: int = 2000,
-                       seed: int = 20260830, alpha: float = 0.05,
+                       seed: int = seeds.seed('block_bootstrap'), alpha: float = 0.05,
                        block_length: float | None = None) -> dict | None:
     """Confidence interval for the pooled mean under both dependencies.
 

--- a/src/clawock/evaluation/regime_validation.py
+++ b/src/clawock/evaluation/regime_validation.py
@@ -58,6 +58,7 @@ from pathlib import Path
 
 import requests
 
+from clawock import seeds
 from clawock.decision import regime as compute_regime
 from clawock.evaluation import cscv
 from clawock.evidence import run_card
@@ -401,7 +402,7 @@ def overfitting_probability(closes, *, ma_grid=MA_GRID, vol_grid=VOL_CAP_GRID,
 
 # ── 2. permutation ──────────────────────────────────────────────────────────
 
-def permutation_test(returns, exposure, *, permutations=2000, seed=20260802):
+def permutation_test(returns, exposure, *, permutations=2000, seed=seeds.seed('regime_permutation')):
     """Circular-shift null: same exposure path, wrong place in time.
 
     Shuffling the exposure vector outright would destroy its autocorrelation and

--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -72,9 +72,11 @@ import argparse
 import json
 import math
 import statistics
+import time
 from collections import defaultdict
 from pathlib import Path
 
+from clawock import seeds
 from clawock import history_store
 from clawock.decision.ledger import leg_sessions, load_ticker_bars
 from clawock.decision.setup_review import wilson_ci
@@ -486,7 +488,7 @@ def daily_ics(rows, horizon: str) -> dict:
     return out
 
 
-def _cluster_ci(values_by_day: dict, samples: int = 2000, seed: int = 20260829):
+def _cluster_ci(values_by_day: dict, samples: int = 2000, seed: int = seeds.seed('signal_panel_cluster_bootstrap')):
     """Bootstrap over sessions, not rows — one busy day is one observation."""
     import random
 
@@ -962,6 +964,7 @@ def main(argv=None) -> int:
                         help='print the panel rows instead of the scorecard')
     parser.add_argument('--no-card', action='store_true')
     args = parser.parse_args(argv)
+    started_at = time.monotonic()
 
     panel = build_panel()
     if args.panel:
@@ -1083,6 +1086,8 @@ def main(argv=None) -> int:
                     'floors': {'min_sessions': MIN_SESSIONS,
                                'min_observations': MIN_OBSERVATIONS},
                     'entry': 'first close strictly after the snapshot'},
+            config_files=[WS / 'config' / 'factor-universe.json'],
+            started_at=started_at,
             inputs=[{'symbol': name, 'source': 'registered point-in-time history',
                      'bars': len(history_store.load_series(DATA / name)),
                      'first_session': None, 'last_session': None,

--- a/src/clawock/evidence/run_card.py
+++ b/src/clawock/evidence/run_card.py
@@ -22,6 +22,27 @@ A run card records what would otherwise be lost:
   behaviour the result depends on;
 * **metrics** — the numbers the prose quotes, as JSON rather than as stdout.
 
+What the reproduction key did not cover (#1139, schema 2)
+---------------------------------------------------------
+Its docstring below promises that "two runs sharing it must produce the same
+metrics". Three things could break that promise while the key stayed identical:
+
+* **the seeds.** Eight modules held a literal like `random.Random(20260813)`
+  inline. They are declared in `clawock.seeds` now and recorded here.
+* **the environment.** numpy and scipy are required dependencies and the
+  evaluation lane leans on them; a minor release that changes a random stream or
+  a linear-algebra path moves the metrics under an unchanged key.
+* **the configuration files.** `params` recorded whatever the caller passed
+  explicitly. A run that reads `config/factor-universe.json` and reports the
+  thresholds it used is describing a file whose *other* contents also changed
+  the answer.
+
+All three are in the key from schema 2, which means **every card written before
+this stops matching a rerun's key**. That is the intended consequence and not a
+migration to paper over: the old keys were asserting a coverage they did not
+have. `metrics_digest` is recorded separately so a drift can be detected without
+recomputing anything, and `explain_mismatch` says which of the four inputs moved.
+
 What it deliberately does not record
 ------------------------------------
 Raw vendor bars. The card carries derived metrics and source *names* only, which
@@ -44,15 +65,17 @@ import hashlib
 import json
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from clawock import seeds as seed_registry
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 WS = workspace_root(Path.cwd())
 CARDS_DIR = WS / 'memory' / 'backtests'
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def series_digest(series) -> str:
@@ -90,18 +113,98 @@ def _git_commit() -> str | None:
     return out.stdout.strip() or None if out.returncode == 0 else None
 
 
+#: The libraries whose version can move a number without any code changing.
+#: Recorded by import rather than from metadata so the card describes the
+#: interpreter that ran, not what a lockfile said should have.
+FINGERPRINTED_MODULES = ('numpy', 'scipy', 'requests')
+
+
+def environment() -> dict:
+    """Interpreter and numeric-library identity for this run."""
+    import platform
+
+    versions = {}
+    for name in FINGERPRINTED_MODULES:
+        try:
+            versions[name] = __import__(name).__version__
+        except Exception:                                  # noqa: BLE001
+            versions[name] = None
+    return {
+        'python': platform.python_version(),
+        'implementation': platform.python_implementation(),
+        'platform': platform.system().lower(),
+        'libraries': versions,
+    }
+
+
+def config_digests(paths) -> list[dict]:
+    """Content hashes of the configuration a run read.
+
+    `params` records the thresholds the caller chose to name. This records the
+    files those thresholds came out of, so a change to a weight nobody passed
+    explicitly still moves the key.
+    """
+    out = []
+    for path in paths:
+        path = Path(path).resolve()
+        out.append({
+            'file': str(path.relative_to(WS)) if path.is_relative_to(WS) else path.name,
+            'digest': file_digest(path),
+        })
+    return sorted(out, key=lambda row: row['file'])
+
+
+def metrics_digest(metrics) -> str:
+    """Digest of the numbers themselves.
+
+    Lets two cards be compared for drift without either being recomputed, which
+    is the only way to notice that a dependency upgrade moved a result: the
+    reproduction key answers "were the inputs the same", this answers "was the
+    answer the same", and the interesting case is when they disagree.
+    """
+    return 'sha256:' + hashlib.sha256(
+        _canonical(metrics).encode()).hexdigest()[:16]
+
+
+def _execution(started_at: float | None) -> dict:
+    """Wall time and peak memory, where the platform reports them."""
+    out = {}
+    if started_at is not None:
+        out['wall_seconds'] = round(time.monotonic() - started_at, 3)
+    try:
+        import resource
+
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # Linux reports kilobytes, macOS bytes. Both are stated rather than
+        # normalised blindly, because a silently wrong unit in an evidence
+        # record is worse than an absent one.
+        out['peak_rss_kb'] = int(peak if sys.platform.startswith('linux')
+                                 else peak / 1024)
+    except (ImportError, OSError):
+        pass
+    return out
+
+
 def _canonical(payload) -> str:
     return json.dumps(payload, sort_keys=True, ensure_ascii=False,
                       separators=(',', ':'))
 
 
 def build_card(name: str, *, params: dict, inputs: list, metrics: dict,
-               code_files=(), notes=(), generated_at: str | None = None) -> dict:
+               code_files=(), notes=(), generated_at: str | None = None,
+               config_files=(), seeds=None, started_at: float | None = None) -> dict:
     """Assemble the card. Pure — writing is a separate step, so it is testable."""
     code = []
     for path in code_files:
         path = Path(path)
         code.append({'file': path.name, 'digest': file_digest(path)})
+    configs = config_digests(config_files)
+    # The whole registry unless the caller narrows it. A run that used three of
+    # the seven seeds and recorded only those would still be reproducible, but a
+    # later reader could not tell "this seed was not used" from "this seed was
+    # not recorded", and the second is the one that matters.
+    used_seeds = dict(seeds if seeds is not None else seed_registry.SEEDS)
+    env = environment()
 
     # The reproduction key covers everything that can change the answer:
     # parameters, the exact input series, and the code that consumed them. Two
@@ -111,6 +214,13 @@ def build_card(name: str, *, params: dict, inputs: list, metrics: dict,
         'params': params,
         'inputs': [{k: v for k, v in row.items() if k != 'note'} for row in inputs],
         'code': code,
+        'config': configs,
+        'seeds': used_seeds,
+        # Library versions, not the whole environment: the platform and the
+        # interpreter's patch level are recorded on the card for a reader, but
+        # putting them in the key would invalidate every card on a routine
+        # security update that cannot change a float.
+        'libraries': env['libraries'],
     }).encode()).hexdigest()[:16]
 
     stamp = generated_at or datetime.now(timezone.utc).isoformat(timespec='seconds')
@@ -124,7 +234,12 @@ def build_card(name: str, *, params: dict, inputs: list, metrics: dict,
         'params': params,
         'inputs': inputs,
         'code': code,
+        'config': configs,
+        'seeds': used_seeds,
+        'environment': env,
+        'execution': _execution(started_at),
         'metrics': metrics,
+        'metrics_digest': metrics_digest(metrics),
         'notes': list(notes),
         'data_boundary': 'derived metrics and source names only; no raw vendor bars',
     }
@@ -143,12 +258,56 @@ def write_card(card: dict, cards_dir: Path | None = None) -> Path:
 
 
 def record(name: str, *, params: dict, inputs: list, metrics: dict,
-           code_files=(), notes=(), cards_dir: Path | None = None) -> Path:
+           code_files=(), notes=(), cards_dir: Path | None = None,
+           config_files=(), seeds=None, started_at: float | None = None) -> Path:
     """Build and write in one call — what the backtest scripts use."""
     return write_card(
         build_card(name, params=params, inputs=inputs, metrics=metrics,
-                   code_files=code_files, notes=notes),
+                   code_files=code_files, notes=notes,
+                   config_files=config_files, seeds=seeds, started_at=started_at),
         cards_dir=cards_dir)
+
+
+def explain_mismatch(card: dict, other: dict) -> dict:
+    """Which of the recorded inputs differs between two cards.
+
+    The question a reproduction key raises and cannot answer: the metrics moved,
+    so *what* moved. Comparing two cards field by field turns "not reproducible"
+    into "scipy went from 1.11 to 1.14 and nothing else changed", which is a
+    thing someone can act on.
+    """
+    def _digests(rows, key='file'):
+        return {row.get(key): row.get('digest') for row in rows or []}
+
+    differences = {}
+    for field in ('params', 'seeds'):
+        if card.get(field) != other.get(field):
+            differences[field] = {'card': card.get(field), 'other': other.get(field)}
+    for field, key in (('code', 'file'), ('config', 'file'), ('inputs', 'symbol')):
+        left, right = _digests(card.get(field), key), _digests(other.get(field), key)
+        moved = {name: [left.get(name), right.get(name)]
+                 for name in sorted(set(left) | set(right))
+                 if left.get(name) != right.get(name)}
+        if moved:
+            differences[field] = moved
+    left_env = (card.get('environment') or {}).get('libraries') or {}
+    right_env = (other.get('environment') or {}).get('libraries') or {}
+    moved_libraries = {name: [left_env.get(name), right_env.get(name)]
+                       for name in sorted(set(left_env) | set(right_env))
+                       if left_env.get(name) != right_env.get(name)}
+    if moved_libraries:
+        differences['libraries'] = moved_libraries
+    return {
+        'run_ids': [card.get('run_id'), other.get('run_id')],
+        'same_reproduction_key': card.get('reproduction_key') == other.get('reproduction_key'),
+        'same_metrics': card.get('metrics_digest') == other.get('metrics_digest'),
+        'differences': differences,
+        # The case worth naming. Identical inputs and different answers means the
+        # card does not describe everything that decided the result.
+        'unexplained': (card.get('reproduction_key') == other.get('reproduction_key')
+                        and card.get('metrics_digest') != other.get('metrics_digest')
+                        and not differences),
+    }
 
 
 def load_cards(cards_dir: Path | None = None) -> list[dict]:
@@ -168,9 +327,46 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--list', action='store_true', help='list stored run cards')
     ap.add_argument('--run-id', help='print one card')
+    ap.add_argument('--diff', nargs=2, metavar=('RUN_ID', 'RUN_ID'),
+                    help='say which recorded input differs between two cards')
+    ap.add_argument('--verify', metavar='RUN_ID',
+                    help='compare a card against the environment running now')
     args = ap.parse_args(argv)
 
     cards = load_cards()
+    by_id = {card.get('run_id'): card for card in cards}
+
+    if args.diff:
+        missing = [name for name in args.diff if name not in by_id]
+        if missing:
+            print(f'no such run card: {", ".join(missing)}', file=sys.stderr)
+            return 1
+        print(json.dumps(explain_mismatch(by_id[args.diff[0]], by_id[args.diff[1]]),
+                         ensure_ascii=False, indent=2))
+        return 0
+
+    if args.verify:
+        card = by_id.get(args.verify)
+        if card is None:
+            print(f'no such run card: {args.verify}', file=sys.stderr)
+            return 1
+        now = environment()
+        recorded = card.get('environment') or {}
+        moved = {name: [(recorded.get('libraries') or {}).get(name), value]
+                 for name, value in now['libraries'].items()
+                 if (recorded.get('libraries') or {}).get(name) != value}
+        print(json.dumps({
+            'run_id': args.verify,
+            'schema_version': card.get('schema_version'),
+            'environment_recorded': recorded,
+            'environment_now': now,
+            'libraries_moved': moved,
+            'reproducible_here': not moved and card.get('schema_version') == SCHEMA_VERSION,
+            'note': ('a card written before schema 2 recorded no environment, so '
+                     'it cannot be verified against one — rerun to get a card '
+                     'that can'),
+        }, ensure_ascii=False, indent=2))
+        return 0
     if args.run_id:
         for card in cards:
             if card.get('run_id') == args.run_id:

--- a/src/clawock/market_data/factors.py
+++ b/src/clawock/market_data/factors.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import requests
 
+from clawock import seeds
 from clawock import history_store
 from clawock.market_data import bar_signals
 from clawock.safe_io import safe_write_json, safe_write_text
@@ -555,7 +556,7 @@ def clustered_mean_ci(observations, samples=1000):
     tickers = sorted({row['ticker'] for row in observations})
     if len(dates) < 2 or len(tickers) < 2:
         return None
-    rnd = random.Random(20260726)
+    rnd = random.Random(seeds.seed('factor_walk_forward_bootstrap'))
     draws = []
     for _ in range(samples):
         date_counts = {value: 0 for value in dates}

--- a/src/clawock/seeds.py
+++ b/src/clawock/seeds.py
@@ -1,0 +1,52 @@
+"""Every seed in the repository, declared once, in one place.
+
+Eight modules held a literal like `random.Random(20260813)` inline. Each was
+deliberate and each was invisible: a run card recorded the parameters, the input
+digests and the code digests, and then claimed that "two runs sharing this
+reproduction key must produce the same metrics" — while the number that decides
+which bootstrap draws are taken lived nowhere in the card.
+
+It lives at the top of the package rather than under `evidence/` for a reason
+the layering test would otherwise have caught: `decision` may not import
+`evidence` (`test_import_layering` pins both directions), and two of the eight
+seeds are in `decision/ledger.py`. A registry every layer has to reach is a leaf
+module with no imports of its own.
+
+That claim was not quite true for a second reason too. The key covers params,
+inputs and code; it does not cover the *environment*. `numpy` and `scipy` are
+required dependencies now and the evaluation lane leans on them, so a minor
+release that changes a random stream or a linear-algebra path moves the metrics
+under an unchanged key. `run_card.environment()` closes that half; this module
+closes the other.
+
+The dates are the day the seed was chosen and carry no meaning beyond being
+arbitrary and fixed. **Never change one to make a result look better** — that is
+a search over a nuisance parameter, and it is the cheapest possible way to
+overfit. If a seed genuinely has to change, change it, and expect every card
+whose reproduction key it touches to stop matching, which is the system working.
+"""
+from __future__ import annotations
+
+#: seed name -> value. The name is what a run card records, so it must describe
+#: what the seed governs rather than where it lives.
+SEEDS = {
+    'decision_episode_bootstrap': 20260714,
+    'decision_cluster_bootstrap': 20260717,
+    'factor_walk_forward_bootstrap': 20260726,
+    'regime_permutation': 20260802,
+    'add_alpha_cluster_bootstrap': 20260813,
+    'signal_panel_cluster_bootstrap': 20260829,
+    'block_bootstrap': 20260830,
+}
+
+
+def seed(name: str) -> int:
+    """The registered seed, or a KeyError naming the ones that exist.
+
+    Deliberately not `.get(name, default)`: a typo silently falling back to a
+    default seed would produce a run that is reproducible and not the one the
+    caller meant.
+    """
+    if name not in SEEDS:
+        raise KeyError(f'unregistered seed {name!r}; registered: {sorted(SEEDS)}')
+    return SEEDS[name]

--- a/tests/test_run_card_reproducibility.py
+++ b/tests/test_run_card_reproducibility.py
@@ -1,0 +1,164 @@
+"""The reproduction key promised more coverage than it had (#1139).
+
+`run_card.build_card`'s docstring said "two runs sharing this key must produce
+the same metrics". Three things could break that while the key stayed identical:
+the seeds (eight literals inline in eight modules), the environment (numpy and
+scipy are required dependencies and the evaluation lane leans on them), and the
+configuration files a run read but did not pass explicitly.
+
+These tests hold the schema-2 card to that promise — each of the three has to
+move the key — and to the thing that makes a broken promise actionable: when two
+cards disagree, `explain_mismatch` has to name which input moved, and has to say
+so out loud when *nothing* recorded moved and the answer did anyway.
+"""
+import json
+
+import pytest
+
+from clawock import seeds
+from clawock.evidence import run_card
+
+
+def _card(**overrides):
+    base = dict(params={'threshold': 0.5}, inputs=[{'symbol': 'X', 'digest': 'sha256:aa'}],
+                metrics={'sharpe': 1.0})
+    base.update(overrides)
+    return run_card.build_card('demo', **base)
+
+
+def test_every_seed_in_the_repository_is_registered():
+    """The literal is the problem, not the number.
+
+    A seed inline in a module is deliberate and invisible: the card recorded
+    params, inputs and code, and the number deciding which bootstrap draws were
+    taken lived nowhere in it.
+
+    Walked with `ast` rather than matched with a regex, so a docstring that
+    *mentions* a seed — including the one above `run_card.build_card` explaining
+    why this gate exists — is not itself a violation.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(run_card.__file__).parent.parent
+    offenders = []
+    for path in sorted(root.rglob('*.py')):
+        if path.name == 'seeds.py':
+            continue
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            big = None
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'Random'
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, int)
+                    and node.args[0].value >= 100000):
+                big = node.args[0]
+            elif isinstance(node, ast.arguments):
+                for name, default in zip(
+                        [arg.arg for arg in node.kwonlyargs], node.kw_defaults):
+                    if (name in ('seed', 'random_state')
+                            and isinstance(default, ast.Constant)
+                            and isinstance(default.value, int)
+                            and default.value >= 100000):
+                        big = default
+            if big is not None:
+                offenders.append(f'{path.name}:{big.lineno}: {big.value}')
+    assert not offenders, (
+        'seeds must come from clawock.seeds, not from a literal:\n'
+        + '\n'.join(offenders))
+
+
+def test_an_unregistered_seed_raises_instead_of_defaulting():
+    """A typo falling back to a default would be reproducible and wrong."""
+    with pytest.raises(KeyError) as caught:
+        seeds.seed('not_a_real_seed')
+    assert 'registered' in str(caught.value)
+
+
+def test_a_different_seed_changes_the_reproduction_key():
+    first = _card(seeds={'block_bootstrap': 1})
+    second = _card(seeds={'block_bootstrap': 2})
+    assert first['reproduction_key'] != second['reproduction_key']
+
+
+def test_a_different_library_version_changes_the_reproduction_key(monkeypatch):
+    """The half the key could not see.
+
+    A minor numpy release that changes a random stream moves every metric under
+    an unchanged key, which is the failure mode a reproduction key exists to
+    make impossible.
+    """
+    baseline = _card()['reproduction_key']
+    monkeypatch.setattr(run_card, 'environment', lambda: {
+        'python': '3.12.3', 'implementation': 'CPython', 'platform': 'linux',
+        'libraries': {'numpy': '9.9.9', 'scipy': '1.11.4', 'requests': '2.34.2'}})
+    assert _card()['reproduction_key'] != baseline
+
+
+def test_a_changed_config_file_changes_the_key(tmp_path):
+    config = tmp_path / 'policy.json'
+    config.write_text('{"weight": 1}')
+    first = _card(config_files=[config])['reproduction_key']
+    config.write_text('{"weight": 2}')
+    assert _card(config_files=[config])['reproduction_key'] != first
+
+
+def test_the_platform_alone_does_not_invalidate_every_card(monkeypatch):
+    """A patch-level interpreter bump cannot change a float, and the key says so.
+
+    The environment is recorded on the card for a reader; only the library
+    versions are in the key. Putting the interpreter's patch level in it would
+    invalidate every card on a routine security update.
+    """
+    libraries = run_card.environment()['libraries']
+    baseline = _card()['reproduction_key']
+    monkeypatch.setattr(run_card, 'environment', lambda: {
+        'python': '3.12.9', 'implementation': 'CPython', 'platform': 'darwin',
+        'libraries': libraries})
+    assert _card()['reproduction_key'] == baseline
+
+
+def test_the_metrics_digest_is_independent_of_the_key():
+    """The interesting case is when the two disagree.
+
+    The key answers "were the inputs the same"; the digest answers "was the
+    answer the same". Identical key with a different digest is the one that
+    means the card does not describe everything deciding the result.
+    """
+    same_inputs_different_answer = (_card(metrics={'sharpe': 1.0}),
+                                    _card(metrics={'sharpe': 1.4}))
+    first, second = same_inputs_different_answer
+    assert first['reproduction_key'] == second['reproduction_key']
+    assert first['metrics_digest'] != second['metrics_digest']
+    report = run_card.explain_mismatch(first, second)
+    assert report['unexplained'] is True
+    assert report['same_reproduction_key'] and not report['same_metrics']
+
+
+def test_explain_mismatch_names_the_input_that_moved(tmp_path):
+    config = tmp_path / 'policy.json'
+    config.write_text('{"weight": 1}')
+    first = _card(config_files=[config])
+    config.write_text('{"weight": 2}')
+    second = _card(config_files=[config])
+    report = run_card.explain_mismatch(first, second)
+    assert report['unexplained'] is False
+    assert 'config' in report['differences']
+    assert 'params' not in report['differences']
+
+
+def test_execution_metadata_is_recorded_when_a_start_time_is_given():
+    import time
+    card = _card(started_at=time.monotonic() - 0.5)
+    assert card['execution']['wall_seconds'] >= 0.5
+    assert card['execution'].get('peak_rss_kb', 1) > 0
+
+
+def test_the_card_still_serialises_and_carries_its_schema():
+    card = _card(config_files=[])
+    assert card['schema_version'] == 2
+    assert set(card) >= {'seeds', 'environment', 'config', 'metrics_digest', 'execution'}
+    json.dumps(card)


### PR DESCRIPTION
Closes #1139。

## 问题:`reproduction_key` 承诺的覆盖面比它实际有的大

`build_card` 的 docstring 写着「**两次共享这个 key 的运行必须产出相同的 metrics**」。
有三样东西可以在 key 不变的情况下把这句话变成假的。

### 1. 种子

**八个模块各自内联了一个字面量**:`random.Random(20260813)`、`seed: int = 20260829`、还有六个。
每一个都是有意的,每一个对「声称在描述这次运行」的那张卡都是不可见的。

现在集中在 `src/clawock/seeds.py` 一处声明并记录进卡。

**它放在包顶层而不是 `evidence/` 下**,是因为 `decision` 不能 import `evidence`
(`test_import_layering` 两个方向都钉死),而八个种子里有两个在 `decision/ledger.py` ——
**一个所有层都要够得着的注册表必须是没有自己依赖的叶子模块**。
(第一版我确实先写进了 `evidence/`,层级测试当场就该红,已改。)

### 2. 环境

numpy 与 scipy 现在是必需依赖,evaluation 一整条道都压在它们身上。
**一个改了随机流或线性代数路径的小版本,会在 key 不变的情况下移动每一个 metric。**

库版本进 key;**解释器补丁号和平台故意留在卡上但不进 key** ——
一次例行安全更新不可能改变一个浮点数,为它作废所有卡是噪音。

### 3. 配置文件内容

`params` 只记调用方点名传进来的那些。一次读了 `config/factor-universe.json` 并报告
「我用了这两个阈值」的运行,描述的是一个**其它内容也决定了答案**的文件。
`add_alpha_walkforward` 和 `signal_panel` 现在声明自己读了哪些配置文件。

## 破坏性变更:schema 2,**旧卡的 key 全部不再匹配重跑**

这是**故意的结果,不是要抹平的迁移**:旧 key 断言了一个它没有的覆盖面,
保住它们就是保住那个错误的断言。(kcn 已授权破坏性升级。)

## 新增:`metrics_digest` + `run-card --diff` + `--verify`

- **key 回答「输入一样吗」,digest 回答「答案一样吗」,值得命名的情况是两者不一致。**
- `run-card --diff A B` 说出 params / seeds / code / config / inputs / libraries 里**哪一个动了**;
  当**没有任何记录在案的东西动过而答案动了**时,标 `unexplained: true` ——
  那意味着卡仍然没有描述全部决定结果的东西。
- `run-card --verify RUN_ID` 把卡和**现在这个环境**比。
- `execution` 记 wall time 与 peak RSS:性能回归和数值回归出现在同一条证据里。

## 防止种子飘回内联的闸走 AST 不走正则

否则**一段提到种子的 docstring**(包括解释这道闸为什么存在的那一段)自己就会把闸打红 ——
第一版正是这样红的。

## 测试

`tests/test_run_card_reproducibility.py`(10)。含会真失败的:
换种子 / 换库版本 / 改配置文件内容**都必须改变 key**;
**换解释器补丁号和平台必须不改变 key**;
**同 key 不同 metrics 必须被标成 `unexplained`**;
以及「仓库里不许再有内联种子字面量」的 AST 闸。
