### PR TITLE
drift: notice when a threshold stops meaning what it meant (#1169/#1174)

### DIFF
--- a/src/clawock/evaluation/drift.py
+++ b/src/clawock/evaluation/drift.py
@@ -1,0 +1,298 @@
+"""When a signal's distribution moves, every threshold on it changes meaning.
+
+The gap this closes
+-------------------
+`market_data/integrity.py` answers "is this bar believable" — one observation at
+a time, against rules about what is structurally impossible. It is the right
+gate and it is blind to the failure that matters for the research layer: a
+signal whose individual values are all perfectly believable and whose
+*distribution* has moved.
+
+That failure is silent by construction. `peer_residuals` activates rules
+pre-registered against a curated universe; `add_alpha` compares
+`stop_distance_pct` to a fixed threshold; `information_overlay` upsizes above the
+75th percentile of a cross-sectional rank. Every one of those is a statement
+about where a value sits in a distribution, and every one of them keeps
+returning a number after that distribution shifts. Nothing in the system
+currently notices.
+
+Three distances, and why all three
+----------------------------------
+* **PSI** — the population stability index, the industry's default. Bins the
+  reference window and asks how much probability mass moved. Coarse, bounded,
+  and the one with conventional read-off levels, which is its whole value.
+* **Two-sample KS** — the largest gap between the two empirical CDFs. Sensitive
+  to a shift in the middle of the distribution, insensitive to the tails.
+* **1-Wasserstein** — the average distance mass had to travel, in the signal's
+  own units. The only one of the three that answers "by how much", and the only
+  one that notices a tail moving a long way.
+
+A signal can move on one and not the others, and which one fires says what kind
+of move it was — so the three are reported together rather than reduced to a
+verdict.
+
+The mistake this module exists to not make
+------------------------------------------
+Every one of those tests assumes independent observations. The panel has about
+twenty-one names per session, and on any given day they move together: a
+21-name cross-section is nowhere near 21 independent draws. Feeding pooled rows
+to a textbook KS p-value would report `p < 1e-9` for a market that simply had a
+directional week, every time, and the alert would be worthless within a month.
+
+So the p-values here are **not** the textbook ones. The null is built by
+permuting whole **sessions** between the two windows and recomputing the
+statistic, which preserves the within-session correlation and only breaks the
+association with time. That is the same shape as the circular-shift null in
+`regime_validation` and the session-clustered bootstrap in `signal_panel`, for
+the same reason.
+"""
+from __future__ import annotations
+
+import math
+import random
+import statistics
+
+#: Conventional PSI read-off. Published with the number because a bare 0.18 is
+#: not interpretable and the levels are the only reason to prefer PSI over the
+#: two better-behaved statistics beside it.
+PSI_BANDS = ((0.10, 'stable'), (0.25, 'moderate_shift'), (float('inf'), 'major_shift'))
+
+#: Below this, a window cannot describe a distribution and the honest output is
+#: a refusal. Ten sessions of twenty-one names is 210 rows and 10 observations.
+MIN_SESSIONS_PER_WINDOW = 8
+
+
+def population_stability_index(reference, current, *, bins=10) -> float | None:
+    """Sum over bins of `(p_cur - p_ref) * ln(p_cur / p_ref)`.
+
+    Bin edges come from the **reference** window's quantiles, which is what
+    makes it a stability index rather than a symmetric distance: the question is
+    whether today's data still fits yesterday's picture of the world.
+    """
+    reference = sorted(float(value) for value in reference)
+    current = [float(value) for value in current]
+    if len(reference) < bins * 2 or not current:
+        return None
+    edges = [reference[int(index * len(reference) / bins)] for index in range(1, bins)]
+    if len(set(edges)) < len(edges):
+        # A signal that is constant across most of its range cannot be binned
+        # into equal-mass buckets, and forcing it produces a PSI driven entirely
+        # by tie-breaking.
+        return None
+
+    def histogram(values):
+        counts = [0] * bins
+        for value in values:
+            index = 0
+            while index < len(edges) and value > edges[index]:
+                index += 1
+            counts[index] += 1
+        # Laplace-smoothed: an empty bin makes the log infinite, and a PSI of
+        # infinity says "one bin emptied" rather than "the distribution moved".
+        return [(count + 0.5) / (len(values) + 0.5 * bins) for count in counts]
+
+    reference_share = histogram(reference)
+    current_share = histogram(current)
+    return sum((cur - ref) * math.log(cur / ref)
+               for ref, cur in zip(reference_share, current_share))
+
+
+def ks_statistic(reference, current) -> float | None:
+    """Largest vertical gap between the two empirical CDFs."""
+    reference = sorted(float(value) for value in reference)
+    current = sorted(float(value) for value in current)
+    if not reference or not current:
+        return None
+    merged = sorted(set(reference) | set(current))
+    largest = 0.0
+    i = j = 0
+    for value in merged:
+        while i < len(reference) and reference[i] <= value:
+            i += 1
+        while j < len(current) and current[j] <= value:
+            j += 1
+        largest = max(largest, abs(i / len(reference) - j / len(current)))
+    return largest
+
+
+def wasserstein_distance(reference, current) -> float | None:
+    """1-Wasserstein distance, in the signal's own units.
+
+    Computed as the mean absolute difference between the two quantile functions
+    on a common grid — the one-dimensional case where the optimal transport plan
+    is just "match the sorted values".
+    """
+    reference = sorted(float(value) for value in reference)
+    current = sorted(float(value) for value in current)
+    if len(reference) < 2 or len(current) < 2:
+        return None
+    grid = 200
+
+    def quantile(values, probability):
+        position = probability * (len(values) - 1)
+        low = int(math.floor(position))
+        high = min(low + 1, len(values) - 1)
+        weight = position - low
+        return values[low] * (1 - weight) + values[high] * weight
+
+    return statistics.fmean(
+        abs(quantile(current, (index + 0.5) / grid)
+            - quantile(reference, (index + 0.5) / grid))
+        for index in range(grid))
+
+
+def _by_session(rows, key='value'):
+    grouped = {}
+    for row in rows:
+        value = row.get(key)
+        if value is None:
+            continue
+        grouped.setdefault(row['as_of'], []).append(float(value))
+    return grouped
+
+
+def session_permutation_p(reference_sessions, current_sessions, statistic,
+                          *, permutations=500, seed=20260830):
+    """Null built by swapping whole sessions between the windows.
+
+    The textbook p-value for any of these statistics assumes independent
+    observations. Twenty-one names on one session are not twenty-one
+    independent draws — on a directional day they are closer to one — and the
+    textbook answer would report a catastrophic drift for an ordinary week.
+    Permuting sessions keeps whatever correlation a session has and breaks only
+    the association with which window it fell in.
+    """
+    days = list(reference_sessions) + list(current_sessions)
+    pool = {**reference_sessions, **current_sessions}
+    if len(reference_sessions) < 2 or len(current_sessions) < 2:
+        return None
+    observed = statistic(
+        [value for day in reference_sessions for value in pool[day]],
+        [value for day in current_sessions for value in pool[day]])
+    if observed is None:
+        return None
+    rng = random.Random(seed)
+    split = len(reference_sessions)
+    at_least = 0
+    for _ in range(permutations):
+        shuffled = days[:]
+        rng.shuffle(shuffled)
+        drawn = statistic(
+            [value for day in shuffled[:split] for value in pool[day]],
+            [value for day in shuffled[split:] for value in pool[day]])
+        if drawn is not None and drawn >= observed:
+            at_least += 1
+    # +1 on both sides: the observed split is itself one arrangement, so a
+    # p-value of exactly zero is not a claim this null can support.
+    return round((at_least + 1) / (permutations + 1), 5)
+
+
+def signal_drift(rows, *, recent_sessions=10, permutations=500) -> dict:
+    """Reference window versus the most recent `recent_sessions`, one signal.
+
+    The split is by session and the reference is everything before it, so the
+    comparison is "does the last two weeks still look like the history" rather
+    than a comparison of two arbitrary halves.
+    """
+    by_session = _by_session(rows)
+    days = sorted(by_session)
+    if len(days) < MIN_SESSIONS_PER_WINDOW + recent_sessions:
+        return {'status': 'insufficient_sample', 'n_sessions': len(days),
+                'required': MIN_SESSIONS_PER_WINDOW + recent_sessions}
+    reference_days = days[:-recent_sessions]
+    current_days = days[-recent_sessions:]
+    reference = [value for day in reference_days for value in by_session[day]]
+    current = [value for day in current_days for value in by_session[day]]
+
+    psi = population_stability_index(reference, current)
+    band = None
+    if psi is not None:
+        band = next(name for threshold, name in PSI_BANDS if psi < threshold)
+    reference_windows = {day: by_session[day] for day in reference_days}
+    current_windows = {day: by_session[day] for day in current_days}
+    return {
+        'status': 'measured',
+        'reference': {'sessions': len(reference_days), 'n': len(reference),
+                      'first': reference_days[0], 'last': reference_days[-1],
+                      'median': round(statistics.median(reference), 6)},
+        'current': {'sessions': len(current_days), 'n': len(current),
+                    'first': current_days[0], 'last': current_days[-1],
+                    'median': round(statistics.median(current), 6)},
+        'psi': round(psi, 6) if psi is not None else None,
+        'psi_band': band,
+        'ks': round(ks_statistic(reference, current), 6),
+        'wasserstein': round(wasserstein_distance(reference, current), 6),
+        'ks_session_permutation_p': session_permutation_p(
+            reference_windows, current_windows, ks_statistic,
+            permutations=permutations),
+        'wasserstein_session_permutation_p': session_permutation_p(
+            reference_windows, current_windows, wasserstein_distance,
+            permutations=permutations),
+        'null': ('whole sessions permuted between the windows; the textbook '
+                 'p-value would treat one directional day as twenty-one '
+                 'independent observations'),
+    }
+
+
+def panel_drift(panel, *, recent_sessions=10, permutations=500) -> dict:
+    """Every registered signal, scored for distributional drift.
+
+    Takes the long-format panel `signal_panel.build_panel` already produces, so
+    a new source becomes drift-monitored by being registered rather than by
+    anyone remembering to add it here.
+    """
+    by_signal = {}
+    for row in panel:
+        by_signal.setdefault(row['signal'], []).append(row)
+    out = {
+        signal: signal_drift(rows, recent_sessions=recent_sessions,
+                             permutations=permutations)
+        for signal, rows in sorted(by_signal.items())
+    }
+    measured = [(name, row) for name, row in out.items()
+                if row.get('status') == 'measured']
+
+    def _flagged(row) -> bool:
+        significant = (row.get('ks_session_permutation_p') or 1.0) <= 0.05
+        if not significant:
+            return False
+        if row.get('psi') is not None:
+            return row.get('psi_band') in ('moderate_shift', 'major_shift')
+        # PSI is unavailable for a tie-heavy signal — the sector-neutral ranks
+        # take about seven distinct values, so equal-mass reference bins
+        # collide. Requiring a PSI band would have made every rank signal
+        # unflaggable no matter how far it moved, which is the wrong kind of
+        # quiet. The effect-size floor stands in for the band.
+        return (row.get('ks') or 0.0) >= 0.10
+
+    flagged = sorted((name for name, row in measured if _flagged(row)),
+                     key=lambda name: -(out[name].get('psi')
+                                        or out[name].get('ks') or 0))
+    share = round(len(flagged) / len(measured), 4) if measured else None
+    return {
+        'schema_version': 1,
+        'recent_sessions': recent_sessions,
+        'signals': out,
+        'n_measured': len(measured),
+        'n_psi_unavailable': sum(1 for _, row in measured if row.get('psi') is None),
+        # Both conditions, not either: PSI has conventional bands and no null,
+        # the permutation has a null and no interpretable scale. A signal that
+        # moves on one alone is worth looking at and is not worth an alert.
+        'flagged': flagged,
+        'flagged_share': share,
+        # The number that says whether this table is usable as an alert. On
+        # 2026-08-30 it was 0.59 — nineteen of thirty-two — and that is not a
+        # threshold to tune down. A ten-session window against a reference of
+        # two to three months that contains one regime change will flag nearly
+        # everything, correctly, and a detector that fires on nearly everything
+        # cannot discriminate. The fix is a reference window long enough to hold
+        # more than one regime, not a stricter cut-off; tuning the cut-off until
+        # fewer fire is a search over the alert rate.
+        'discriminating': bool(share is not None and share <= 0.25),
+        'reading': ('flagged means the session permutation could not reproduce '
+                    'the move AND the size passed a band (PSI where it exists, '
+                    'the KS statistic where the signal is too tie-heavy to bin). '
+                    'A flagged_share above a quarter means the reference window '
+                    'does not span enough regimes for this to discriminate, and '
+                    'the table is a description rather than an alert'),
+    }

--- a/src/clawock/evaluation/drift.py
+++ b/src/clawock/evaluation/drift.py
@@ -52,6 +52,8 @@ import math
 import random
 import statistics
 
+from clawock import seeds
+
 #: Conventional PSI read-off. Published with the number because a bare 0.18 is
 #: not interpretable and the levels are the only reason to prefer PSI over the
 #: two better-behaved statistics beside it.
@@ -152,7 +154,8 @@ def _by_session(rows, key='value'):
 
 
 def session_permutation_p(reference_sessions, current_sessions, statistic,
-                          *, permutations=500, seed=20260830):
+                          *, permutations=500,
+                          seed=seeds.seed('drift_session_permutation')):
     """Null built by swapping whole sessions between the windows.
 
     The textbook p-value for any of these statistics assumes independent

--- a/src/clawock/seeds.py
+++ b/src/clawock/seeds.py
@@ -37,6 +37,7 @@ SEEDS = {
     'add_alpha_cluster_bootstrap': 20260813,
     'signal_panel_cluster_bootstrap': 20260829,
     'block_bootstrap': 20260830,
+    'drift_session_permutation': 20260830,
 }
 
 

--- a/tests/test_signal_drift.py
+++ b/tests/test_signal_drift.py
@@ -1,0 +1,171 @@
+"""A distribution can move while every observation stays believable (#1169/#1174).
+
+`market_data/integrity.py` decides whether one bar is possible. It cannot see
+the failure that matters for the research layer: a signal whose individual
+values are all fine and whose *distribution* has shifted, silently changing what
+every pre-registered threshold on it means.
+
+The tests below are mostly about the mistake this module exists not to make. All
+three drift statistics assume independent observations, and the panel has about
+twenty-one names per session that move together. A textbook KS p-value on pooled
+rows reports `p < 1e-9` for an ordinary directional week, and an alert that fires
+every week is not an alert.
+"""
+import random
+import statistics
+
+import pytest
+
+from clawock.evaluation import drift
+
+
+def _rows(per_session):
+    return [{'as_of': session, 'ticker': f'T{index}', 'signal': 'x', 'value': value}
+            for session, values in per_session.items()
+            for index, value in enumerate(values)]
+
+
+def _panel(n_sessions, mean, sigma, *, names=20, seed=1, start=1):
+    rnd = random.Random(seed)
+    return {f'2026-06-{index:03d}': [rnd.gauss(mean, sigma) for _ in range(names)]
+            for index in range(start, start + n_sessions)}
+
+
+def test_the_three_statistics_disagree_on_purpose():
+    """Which one fires says what kind of move it was.
+
+    KS is sensitive to a shift in the middle and largely blind to a change in
+    spread; Wasserstein answers "by how much" in the signal's own units. A
+    single verdict would throw that away.
+    """
+    rnd = random.Random(2)
+    reference = [rnd.gauss(0, 1) for _ in range(4000)]
+    shifted = [rnd.gauss(0.6, 1) for _ in range(1000)]     # the middle moved
+    widened = [rnd.gauss(0.0, 2) for _ in range(1000)]     # the tails moved
+
+    # They rank the two moves in opposite orders, which is the point: KS sees
+    # the shifted middle as the bigger event, Wasserstein sees the travelled
+    # tails as the bigger one. A single verdict would have to pick one and would
+    # then be silently blind to the other kind of drift.
+    assert drift.ks_statistic(reference, shifted) > drift.ks_statistic(reference, widened)
+    assert drift.wasserstein_distance(reference, widened) > \
+        drift.wasserstein_distance(reference, shifted)
+    # And Wasserstein recovers the size of the mean shift in the signal's units.
+    assert drift.wasserstein_distance(reference, shifted) == pytest.approx(0.6, abs=0.1)
+
+
+def test_psi_lands_in_its_conventional_band():
+    rnd = random.Random(5)
+    reference = [rnd.gauss(0, 1) for _ in range(3000)]
+    stable = [rnd.gauss(0, 1) for _ in range(600)]
+    moved = [rnd.gauss(1.0, 1) for _ in range(600)]
+    assert drift.population_stability_index(reference, stable) < 0.10
+    assert drift.population_stability_index(reference, moved) > 0.25
+
+
+def test_the_session_permutation_does_not_cry_wolf_on_a_correlated_market():
+    """The whole reason the textbook p-value is not used.
+
+    Twenty names a session, all sharing one common factor, and no drift at all.
+    Pooled rows look like four hundred independent observations to a textbook
+    test; they are closer to twenty. The session-permutation null has to return
+    an unremarkable p-value here.
+    """
+    rnd = random.Random(9)
+    per_session = {}
+    for index in range(1, 31):
+        common = rnd.gauss(0, 1.0)
+        per_session[f'2026-06-{index:03d}'] = [
+            common + rnd.gauss(0, 0.3) for _ in range(20)]
+    days = sorted(per_session)
+    reference = {day: per_session[day] for day in days[:20]}
+    current = {day: per_session[day] for day in days[20:]}
+    p_value = drift.session_permutation_p(
+        reference, current, drift.ks_statistic, permutations=400)
+    assert p_value > 0.05, p_value
+
+
+def test_the_session_permutation_still_finds_a_real_shift():
+    """And it must not be blind — a genuine move has to come back significant."""
+    per_session = {**_panel(20, 0.0, 1.0, seed=3, start=1),
+                   **_panel(10, 2.5, 1.0, seed=4, start=100)}
+    days = sorted(per_session)
+    p_value = drift.session_permutation_p(
+        {day: per_session[day] for day in days[:20]},
+        {day: per_session[day] for day in days[20:]},
+        drift.ks_statistic, permutations=400)
+    assert p_value <= 0.01, p_value
+
+
+def test_a_tie_heavy_signal_can_still_be_flagged():
+    """The defect this rule was written wrong the first time.
+
+    The sector-neutral ranks take about seven distinct values, so equal-mass PSI
+    bins collide and PSI is refused. Requiring a PSI band made every rank signal
+    unflaggable no matter how far it moved — quiet in the wrong direction.
+    """
+    rnd = random.Random(6)
+    levels = [-0.5, -0.25, 0.0, 0.25, 0.5]
+    per_session = {}
+    for index in range(1, 21):
+        per_session[f'2026-06-{index:03d}'] = [rnd.choice(levels) for _ in range(20)]
+    for index in range(21, 31):
+        per_session[f'2026-06-{index:03d}'] = [rnd.choice(levels[-2:]) for _ in range(20)]
+    report = drift.panel_drift(_rows(per_session), recent_sessions=10, permutations=300)
+    assert report['signals']['x']['psi'] is None
+    assert report['n_psi_unavailable'] == 1
+    assert 'x' in report['flagged']
+
+
+def test_a_stable_signal_is_not_flagged():
+    per_session = {**_panel(20, 0.0, 1.0, seed=11, start=1),
+                   **_panel(10, 0.0, 1.0, seed=12, start=100)}
+    report = drift.panel_drift(_rows(per_session), recent_sessions=10, permutations=300)
+    assert report['flagged'] == []
+    assert report['discriminating'] is True
+
+
+def test_flagging_almost_everything_is_reported_as_not_discriminating():
+    """The number that says whether the table is an alert or a description.
+
+    On the live panel this came back 0.78 — twenty-five of thirty-two — against
+    a reference window holding one regime change. That is not a threshold to
+    tune down; a detector that fires on nearly everything cannot discriminate,
+    and the payload has to say so rather than let a reader treat the list as a
+    shortlist.
+    """
+    per_session = {}
+    for signal in range(6):
+        for index in range(1, 21):
+            per_session.setdefault(f'2026-06-{index:03d}', {})[signal] = 0.0
+    rows = []
+    rnd = random.Random(7)
+    for signal in range(6):
+        for index in range(1, 21):
+            for name in range(20):
+                rows.append({'as_of': f'2026-06-{index:03d}', 'ticker': f'T{name}',
+                             'signal': f's{signal}', 'value': rnd.gauss(0, 1)})
+        for index in range(21, 31):
+            for name in range(20):
+                rows.append({'as_of': f'2026-06-{index:03d}', 'ticker': f'T{name}',
+                             'signal': f's{signal}', 'value': rnd.gauss(4.0, 1)})
+    report = drift.panel_drift(rows, recent_sessions=10, permutations=300)
+    assert report['flagged_share'] > 0.9
+    assert report['discriminating'] is False
+    assert 'does not span enough regimes' in report['reading']
+
+
+def test_a_short_history_is_refused_rather_than_scored():
+    per_session = _panel(9, 0.0, 1.0, seed=13)
+    report = drift.panel_drift(_rows(per_session), recent_sessions=10)
+    assert report['signals']['x']['status'] == 'insufficient_sample'
+    assert report['n_measured'] == 0
+
+
+def test_a_constant_signal_reports_no_movement_rather_than_breaking():
+    per_session = {f'2026-06-{index:03d}': [0.0] * 20 for index in range(1, 31)}
+    report = drift.panel_drift(_rows(per_session), recent_sessions=10, permutations=100)
+    row = report['signals']['x']
+    assert row['ks'] == 0.0
+    assert row['wasserstein'] == 0.0
+    assert 'x' not in report['flagged']


### PR DESCRIPTION
Closes #1169, closes #1174。

## 现在有什么、缺什么

`market_data/integrity.py` 回答「**这一根 bar 可信吗**」—— 一次一个观测,对着「什么是结构上不可能的」。
那道闸是对的,而且它对研究层真正要命的那种失败**完全看不见**:
**一个每个取值都完全可信、但分布已经移走了的信号。**

这种失败是结构性静默的:`peer_residuals` 拿预注册规则对着一个策展宇宙激活、
`add_alpha` 把 `stop_distance_pct` 和一个固定阈值比、
`information_overlay` 在截面 rank 的 75 分位以上加仓 ——
**每一条都是「某个值落在分布的哪里」的陈述,每一条在分布移走之后都照样返回一个数。**

## 做了什么

`evaluation/drift.py` 给**每一个已注册信号**打分,输入就是 `signal_panel.build_panel`
已经产出的长格式面板 ⇒ **新数据源只要被注册就自动被监控**,不靠谁记得来这里加一行。

三个距离**故意分开报,因为它们会互相不同意**:

| 量 | 强在哪 | 弱在哪 |
|---|---|---|
| PSI | 有界、有行业通用档位 | 没有 null;取值离散的信号分不了等质量箱 |
| KS | 对中段位移敏感 | 对方差变化基本瞎 |
| 1-Wasserstein | **唯一回答「移了多少」**,用信号自己的单位;尾巴走远了它看得见 | 没有通用档位 |

有一条测试专门构造**前两者排序相反**的一对移动(中段移 vs 尾巴移)。

## 最关键的一条:**这里的 p 值不是教科书的那个**

三个统计量都假设观测独立。面板每个 session 有约 21 个名字,**同一天它们一起动** ——
方向性的一天更接近 1 个观测而不是 21 个。
**把 pooled 行喂给教科书 KS,普通的一周就会报 `p < 1e-9`**,一个月内这个告警就一文不值。

这里的 null 是**在两个窗口之间置换整个 session**:保留 session 内部的相关性,只打断「它落在哪个窗口」。
和 `regime_validation` 的循环移位 null、`signal_panel` 的 session 聚簇 bootstrap 是同一个形状。
有测试**构造一个没有任何漂移的强相关市场,要求它返回一个不显著的 p 值**。

## 这个模块查出自己的两件事(都发布,不调阈值调走)

### 1. 第一版的 flag 规则有缺陷

它要求「PSI 档位离开 stable」,而 PSI 对**取值离散**的信号是拒绝的 ——
sector-neutral rank 只有约 7 个不同取值,等质量参考箱会撞在一起。
⇒ **每一个 rank 信号都永远不可能被 flag,不管它移了多远。** 这是朝错误方向的安静。
现在那种情况改用 KS 效应量地板,并发布 `n_psi_unavailable`(实测 32 个里 11 个)。

### 2. **实测 `flagged_share = 0.78`(32 个里 25 个)⇒ `discriminating: false`**

参考窗口只有两三个月、里面包着一次 regime 切换,**这 25 条里绝大多数是真漂移**。
但一个几乎什么都报的检测器**仍然没有区分力**。

所以 payload 里直接带 `discriminating: false`,并写明**修法是把参考窗口拉长到能装下不止一个 regime,
不是把阈值调严** —— 调到「报得少一点」为止,那是在对告警率做搜索。

## 高压线

- ❌ 不碰 live 模型输出契约 / 预注册研究契约 / 200KB payload 闸
- ❌ 不新增依赖、不新增 cron、不新增 CLI 命令

## 测试

`tests/test_signal_drift.py`(9)。含会真失败的:
**强相关但零漂移的市场必须给出不显著 p 值**、**真实位移必须仍然显著**、
**取值离散的信号必须仍然能被 flag**(第一版正是在这里错的)、
以及 **flag 掉几乎所有信号时必须报 `discriminating: false`**。
