### PR TITLE
attribution: where the return came from, and one verdict over six gates (#1144/#1147/#1149/#1178)

### DIFF
--- a/src/clawock/evaluation/attribution.py
+++ b/src/clawock/evaluation/attribution.py
@@ -1,0 +1,347 @@
+"""Where a return came from, when the thing that produced it is a linear score.
+
+Two questions, one of which has an exact answer
+-----------------------------------------------
+**"Why is this name ranked here?"** has an exact answer and nobody was giving it.
+`composite_score` is a weighted mean of nine sector-neutral ranks, so each
+factor's contribution to it is `w_f · rank_f / Σw`, additively and without
+approximation. Reaching for SHAP or LIME on a linear model — which is what the
+competitor-port issue proposed — approximates something that can simply be
+computed, and then reports the approximation's error as though it were a
+subtlety of the model. `explain_composite` computes it, and adds the exact
+leave-one-out: recompute the name's cross-sectional percentile with one factor
+removed and report how far it moves, which answers "would dropping quality
+change where this name sits" rather than "how much quality contributed".
+
+**"Where did the portfolio's return come from?"** does not have an exact answer,
+and the honest form of it is a regression whose standard errors have to be
+published next to it. Per session, the cross-section of forward returns is
+regressed on the factor loadings; the coefficients are the factor returns
+(Fama-MacBeth). Portfolio exposure to each factor is the weighted sum of its
+loadings, and the return splits into:
+
+* **common** — what the factor exposures explain;
+* **specific** — what is left, which is where an unmodelled bet lives;
+* **tilt** — the part of common attributable to the *average* exposure, i.e. the
+  standing bet;
+* **timing** — the part attributable to exposure moving around that average.
+
+`tilt + timing == common` by construction and a test pins it.
+
+The sample this is being asked to support
+------------------------------------------
+About twenty-one names in the cross-section and nine factors. That is 21
+observations for 10 parameters, which is not a comfortable regression, and the
+correlations among the loadings make it worse: momentum at one, three and six
+months are not nine independent directions. So every session's fit carries its
+R², its condition number and its residual degrees of freedom, `factor_returns`
+refuses a session with fewer than `MIN_NAMES_PER_FACTOR` names per factor, and
+the aggregate reports how many sessions it had to skip. An attribution computed
+over the twelve sessions that happened to have a wide enough cross-section is a
+statement about those twelve sessions.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+
+import numpy as np
+
+#: Names per factor below which the cross-sectional regression is fitting noise.
+#: Three is already thin; below it the residual degrees of freedom are in single
+#: figures and the coefficient standard errors are wider than the coefficients.
+MIN_NAMES_PER_FACTOR = 3
+
+#: Above this the loading matrix is close enough to singular that the split of a
+#: return between two collinear factors is arbitrary. Reported rather than
+#: silently ridge-regularised: a caller told the design is collinear can drop a
+#: factor, whereas a caller handed a stabilised number cannot see the problem.
+CONDITION_WARN = 100.0
+
+
+#: The nine registered factors grouped into three blocks. This is a reduction,
+#: not a search: the grouping follows the names the factor universe already
+#: uses, no alternative grouping was tried, and the block loading is the same
+#: weighted mean the composite uses — restricted to the block's members — so it
+#: is derived from the pre-registration rather than invented beside it.
+#:
+#: It exists because the nine-factor regression is structurally unavailable on
+#: this book. The cross-section that has both registered ranks and canonical
+#: bars is **13 names at the median**, and nine factors plus an intercept need
+#: 27 by the `MIN_NAMES_PER_FACTOR` rule: every one of the eighteen sessions is
+#: skipped. Three blocks need nine, which thirteen clears.
+FACTOR_BLOCKS = {
+    'momentum': ('residual_mom_1m', 'residual_mom_3m', 'residual_mom_6m',
+                 'relative_strength'),
+    'stability': ('low_volatility', 'drawdown_resilience'),
+    'quality_liquidity': ('quality_profitability', 'liquidity', 'breadth'),
+}
+
+
+def block_loadings(ranks, weights, blocks=None) -> dict:
+    """Collapse per-factor ranks into per-block loadings, by registered weight."""
+    blocks = blocks or FACTOR_BLOCKS
+    out = {}
+    for block, members in blocks.items():
+        present = [(float(weights[factor]), float(ranks[factor]))
+                   for factor in members
+                   if factor in weights and ranks.get(factor) is not None]
+        if present:
+            total = sum(weight for weight, _ in present)
+            out[block] = sum(weight * value for weight, value in present) / total
+    return out
+
+
+def to_blocks(sessions, weights, blocks=None) -> dict:
+    """Rewrite a `{as_of: (loadings, forward)}` map in block space."""
+    blocks = blocks or FACTOR_BLOCKS
+    return {
+        as_of: ({name: block_loadings(ranks, weights, blocks)
+                 for name, ranks in loadings.items()}, forward)
+        for as_of, (loadings, forward) in sessions.items()
+    }
+
+
+def _design(loadings_by_name, factors, names):
+    matrix = np.array([[float(loadings_by_name[name].get(factor, 0.0))
+                        for factor in factors] for name in names], dtype=float)
+    return np.column_stack([np.ones(len(names)), matrix])
+
+
+def cross_sectional_fit(loadings_by_name, forward_by_name, factors) -> dict | None:
+    """One session: regress forward returns on factor loadings.
+
+    Returns the coefficients (the session's factor returns), plus everything
+    needed to argue with them. `None` when the cross-section is too narrow —
+    silently returning coefficients from an underdetermined fit is how an
+    attribution table fills up with numbers that mean nothing.
+    """
+    names = sorted(set(loadings_by_name) & set(forward_by_name))
+    if len(names) < MIN_NAMES_PER_FACTOR * len(factors):
+        return None
+    design = _design(loadings_by_name, factors, names)
+    target = np.array([float(forward_by_name[name]) for name in names])
+    coefficients, residuals, rank, singular = np.linalg.lstsq(design, target, rcond=None)
+    fitted = design @ coefficients
+    residual = target - fitted
+    total_variance = float(((target - target.mean()) ** 2).sum())
+    degrees = len(names) - design.shape[1]
+    condition = (float(singular[0] / singular[-1])
+                 if len(singular) and singular[-1] > 0 else math.inf)
+    return {
+        'names': names,
+        'intercept': float(coefficients[0]),
+        'factor_returns': {factor: float(value)
+                           for factor, value in zip(factors, coefficients[1:])},
+        'r_squared': (1 - float((residual ** 2).sum()) / total_variance
+                      if total_variance > 0 else None),
+        'residual_degrees_of_freedom': degrees,
+        'condition_number': round(condition, 2) if math.isfinite(condition) else None,
+        'collinear': bool(condition > CONDITION_WARN),
+        'n_names': len(names),
+    }
+
+
+def factor_returns(sessions, factors) -> dict:
+    """Fama-MacBeth across sessions, with the sessions it could not fit.
+
+    `sessions` is `{as_of: (loadings_by_name, forward_by_name)}`. The t-statistic
+    is over the *time series* of per-session coefficients, which is the whole
+    point of the two-pass procedure: it sidesteps the cross-sectional
+    correlation that makes a single pooled regression's standard errors fiction.
+    """
+    fits, skipped = {}, []
+    for as_of in sorted(sessions):
+        loadings, forward = sessions[as_of]
+        fit = cross_sectional_fit(loadings, forward, factors)
+        if fit is None:
+            skipped.append(as_of)
+        else:
+            fits[as_of] = fit
+    if len(fits) < 3:
+        return {'status': 'insufficient_sample', 'n_sessions': len(fits),
+                'skipped_sessions': len(skipped), 'factors': list(factors)}
+
+    series = {factor: [fit['factor_returns'][factor] for fit in fits.values()]
+              for factor in factors}
+    summary = {}
+    for factor, values in series.items():
+        mean = statistics.fmean(values)
+        deviation = statistics.stdev(values) if len(values) > 1 else 0.0
+        standard_error = deviation / math.sqrt(len(values)) if len(values) else None
+        summary[factor] = {
+            'mean_factor_return': round(mean, 6),
+            'std_error': round(standard_error, 6) if standard_error else None,
+            't_stat': round(mean / standard_error, 3)
+            if standard_error else None,
+            'n_sessions': len(values),
+        }
+    return {
+        'status': 'measured',
+        'factors': list(factors),
+        'n_sessions': len(fits),
+        'skipped_sessions': len(skipped),
+        'skipped_reason': (f'fewer than {MIN_NAMES_PER_FACTOR} names per factor '
+                           f'in the cross-section'),
+        'mean_r_squared': round(statistics.fmean(
+            [fit['r_squared'] for fit in fits.values()
+             if fit['r_squared'] is not None]), 4) if fits else None,
+        'collinear_sessions': sum(1 for fit in fits.values() if fit['collinear']),
+        'per_factor': summary,
+        'per_session': {as_of: fit['factor_returns'] for as_of, fit in fits.items()},
+        'method': ('Fama-MacBeth: cross-sectional regression per session, '
+                   't-statistic over the time series of coefficients'),
+    }
+
+
+def perf_attrib(sessions, weights_by_session, factors) -> dict:
+    """Split the portfolio return into common, specific, tilt and timing.
+
+    `tilt + timing == common` by construction: tilt uses each factor's *average*
+    exposure over the window and timing uses the deviation from it, so the two
+    partition the same sum. The interesting number is usually their ratio — a
+    book whose common return is nearly all tilt is being paid for a standing
+    exposure, and one where timing dominates is being paid for moving it.
+    """
+    fitted = factor_returns(sessions, factors)
+    if fitted.get('status') != 'measured':
+        return fitted
+
+    exposures, portfolio_returns, days = {}, {}, []
+    for as_of, coefficients in fitted['per_session'].items():
+        loadings, forward = sessions[as_of]
+        weights = weights_by_session.get(as_of) or {}
+        names = [name for name in loadings if name in weights and name in forward]
+        if not names:
+            continue
+        total = sum(abs(weights[name]) for name in names)
+        if total <= 0:
+            continue
+        normalised = {name: weights[name] / total for name in names}
+        exposures[as_of] = {
+            factor: sum(normalised[name] * float(loadings[name].get(factor, 0.0))
+                        for name in names)
+            for factor in factors
+        }
+        portfolio_returns[as_of] = sum(
+            normalised[name] * float(forward[name]) for name in names)
+        days.append(as_of)
+    if len(days) < 3:
+        return {'status': 'insufficient_sample',
+                'reason': 'fewer than three sessions with both weights and loadings',
+                'n_sessions': len(days)}
+
+    average_exposure = {
+        factor: statistics.fmean([exposures[day][factor] for day in days])
+        for factor in factors
+    }
+    common, tilt, timing, specific = {}, {}, {}, {}
+    for day in days:
+        coefficients = fitted['per_session'][day]
+        common[day] = sum(exposures[day][factor] * coefficients[factor]
+                          for factor in factors)
+        tilt[day] = sum(average_exposure[factor] * coefficients[factor]
+                        for factor in factors)
+        timing[day] = sum((exposures[day][factor] - average_exposure[factor])
+                          * coefficients[factor] for factor in factors)
+        specific[day] = portfolio_returns[day] - common[day]
+
+    def _mean(mapping):
+        return round(statistics.fmean([mapping[day] for day in days]), 6)
+
+    return {
+        'status': 'measured',
+        'n_sessions': len(days),
+        'first_session': days[0],
+        'last_session': days[-1],
+        'total_return_mean': _mean(portfolio_returns),
+        'common_return_mean': _mean(common),
+        'specific_return_mean': _mean(specific),
+        'tilt_return_mean': _mean(tilt),
+        'timing_return_mean': _mean(timing),
+        'average_exposures': {factor: round(value, 6)
+                              for factor, value in average_exposure.items()},
+        'per_session': {
+            'total': {day: round(portfolio_returns[day], 6) for day in days},
+            'common': {day: round(common[day], 6) for day in days},
+            'specific': {day: round(specific[day], 6) for day in days},
+        },
+        'factor_returns': fitted['per_factor'],
+        'fit_quality': {
+            'mean_r_squared': fitted['mean_r_squared'],
+            'skipped_sessions': fitted['skipped_sessions'],
+            'collinear_sessions': fitted['collinear_sessions'],
+        },
+        'identity': 'tilt + timing == common, by construction',
+    }
+
+
+def explain_composite(ranks, weights, *, cross_section=None, ticker=None) -> dict:
+    """Exactly why one name's composite score is what it is.
+
+    No approximation is involved and none is needed: the score is a weighted mean
+    of the ranks present, so `w_f · rank_f / Σw` is each factor's contribution,
+    and they sum to the score. A SHAP value here would estimate a number that can
+    be written down.
+
+    When the rest of the session's `cross_section` is supplied, each factor also
+    gets an exact leave-one-out: the name's percentile recomputed with that
+    factor dropped from *every* name's composite. That answers the question a
+    contribution cannot — "would dropping quality change where this name sits" —
+    and the two disagree whenever a factor is large for everybody.
+    """
+    available = {factor: float(value) for factor, value in ranks.items()
+                 if factor in weights and value is not None}
+    if not available:
+        return {'status': 'no_ranks', 'ticker': ticker}
+    total_weight = sum(float(weights[factor]) for factor in available)
+    score = sum(float(weights[factor]) * available[factor]
+                for factor in available) / total_weight
+    contributions = {
+        factor: round(float(weights[factor]) * available[factor] / total_weight, 6)
+        for factor in available
+    }
+
+    def _score(rank_map, dropped=None):
+        present = {factor: value for factor, value in rank_map.items()
+                   if factor in weights and value is not None and factor != dropped}
+        if not present:
+            return None
+        denominator = sum(float(weights[factor]) for factor in present)
+        return sum(float(weights[factor]) * float(present[factor])
+                   for factor in present) / denominator
+
+    leave_one_out = {}
+    if cross_section:
+        def percentile(rank_map_by_name, dropped):
+            scores = {name: _score(rank_map, dropped)
+                      for name, rank_map in rank_map_by_name.items()}
+            scores = {name: value for name, value in scores.items() if value is not None}
+            if ticker not in scores or len(scores) < 2:
+                return None
+            below = sum(1 for value in scores.values() if value < scores[ticker])
+            return below / (len(scores) - 1)
+
+        base = percentile(cross_section, None)
+        for factor in available:
+            without = percentile(cross_section, factor)
+            leave_one_out[factor] = {
+                'percentile_without': round(without, 4) if without is not None else None,
+                'percentile_change': round(without - base, 4)
+                if (without is not None and base is not None) else None,
+            }
+        leave_one_out['_base_percentile'] = round(base, 4) if base is not None else None
+
+    return {
+        'status': 'measured',
+        'ticker': ticker,
+        'composite_score': round(score, 6),
+        'contributions': dict(sorted(contributions.items(),
+                                     key=lambda item: -abs(item[1]))),
+        'contributions_sum': round(sum(contributions.values()), 6),
+        'weight_covered': round(total_weight, 4),
+        'missing_factors': sorted(set(weights) - set(available)),
+        'leave_one_out': leave_one_out,
+        'method': ('exact: the composite is linear in the ranks, so contributions '
+                   'are computed rather than approximated'),
+    }

--- a/src/clawock/evaluation/unified.py
+++ b/src/clawock/evaluation/unified.py
@@ -1,0 +1,179 @@
+"""One verdict, and every gate that had to agree to produce it.
+
+The problem with six gates
+--------------------------
+This repository has accumulated a good set of them, and each is right:
+`cscv` prices the ranking of a search, `deflated_sharpe` prices its level,
+`bootstrap` widens an interval for serial dependence, `attribution` splits a
+return into what the factors explain and what they do not, `drift` says whether
+the distributions still look like the ones the thresholds were registered
+against. They are also six separate outputs, each with its own sample floor and
+its own refusal, and the failure mode of six separate outputs is that a reader
+takes the one that agrees with them.
+
+`grade` runs them on one input and reduces them to a single evidence level, with
+every gate's contribution attached. The reduction is deliberately harsh in one
+direction: **a refusal is not a pass.** A gate that says `insufficient_sample`
+caps the grade below `diagnostic`, because "we could not check" and "we checked
+and it held" are the two things a summary is most tempting to blur.
+
+The grades
+----------
+* `insufficient` — the sample cannot support the question. Most results here.
+* `diagnostic` — measured, intervals published, nothing pre-registered. The
+  ceiling for anything measured after the fact, and the ceiling this module can
+  ever award: `validated` requires pre-registration, which is a property of when
+  a rule was written and not of any computation.
+* `contested` — gates disagree. Named rather than averaged away, because two
+  gates disagreeing is information and their mean is not.
+
+Nothing here can promote a result to `validated`. That word belongs to a rule
+that survived being written down before the data arrived.
+"""
+from __future__ import annotations
+
+import statistics
+
+from clawock.evaluation import bootstrap as block_bootstrap
+from clawock.evaluation import cscv, deflated_sharpe
+from clawock.evaluation.attribution import perf_attrib
+
+#: Below this many sessions no gate here is meaningful, and running them anyway
+#: produces a table of refusals that reads like a result.
+MIN_SESSIONS = 12
+
+
+def grade(returns_by_session, *, configurations=None, n_trials=None,
+          attribution=None, drift_report=None) -> dict:
+    """Reduce every available gate to one evidence level and its reasons.
+
+    `returns_by_session` maps a session to the realised returns attributed to it.
+    `configurations`, when supplied, is `{name: {session: return}}` for every
+    variant the search considered — the ranking `cscv` prices. `n_trials` is how
+    many cells a reader's eye could have landed on; it defaults to the number of
+    configurations and must be given explicitly when the search was wider than
+    the table shown.
+    """
+    sessions = sorted(returns_by_session)
+    gates, reasons = {}, []
+    if len(sessions) < MIN_SESSIONS:
+        return {'grade': 'insufficient', 'n_sessions': len(sessions),
+                'reasons': [f'{len(sessions)} sessions is below the '
+                            f'{MIN_SESSIONS}-session floor'],
+                'gates': {}}
+
+    pooled = {day: list(returns_by_session[day]) if isinstance(
+        returns_by_session[day], (list, tuple)) else [returns_by_session[day]]
+        for day in sessions}
+    interval = block_bootstrap.clustered_block_ci(pooled)
+    gates['interval'] = interval
+    if interval is None:
+        reasons.append('interval unavailable')
+    else:
+        clears = interval['ci95'][0] > 0 or interval['ci95'][1] < 0
+        gates['interval_clears_zero'] = clears
+        if not clears:
+            reasons.append('the interval on the mean covers zero')
+
+    daily = [statistics.fmean(pooled[day]) for day in sessions]
+    trials = n_trials or (len(configurations) if configurations else 1)
+    trial_sharpes = None
+    if configurations:
+        trial_sharpes = [deflated_sharpe.sharpe(
+            [values[day] for day in sessions if day in values])
+            for values in configurations.values()]
+        trial_sharpes = [value for value in trial_sharpes if value is not None]
+    gates['deflated_sharpe'] = deflated_sharpe.deflated_sharpe_ratio(
+        daily, n_trials=trials, trial_sharpes=trial_sharpes)
+    if gates['deflated_sharpe'].get('dsr') is None:
+        reasons.append('deflated Sharpe: ' + gates['deflated_sharpe'].get('reason', ''))
+    elif gates['deflated_sharpe']['dsr'] < 0.9:
+        reasons.append('the Sharpe does not survive deflation for the search size')
+
+    if configurations and len(configurations) >= cscv.MIN_CONFIGS:
+        names = sorted(configurations)
+        common = [day for day in sessions
+                  if all(day in configurations[name] for name in names)]
+        matrix = [[configurations[name][day] for name in names] for day in common]
+        gates['pbo'] = cscv.probability_of_backtest_overfitting(
+            matrix, lambda values: statistics.fmean(values) if values else None,
+            embargo=1)
+        gates['pbo']['configurations'] = names
+        if gates['pbo'].get('pbo') is None:
+            reasons.append('PBO: ' + gates['pbo'].get('reason', ''))
+        elif gates['pbo']['pbo'] > 0.5:
+            reasons.append('the in-sample winner is below median out of sample '
+                           'more often than not')
+    else:
+        gates['pbo'] = {'status': 'not_applicable',
+                        'reason': 'fewer than three configurations: no selection '
+                                  'effect to measure'}
+
+    if attribution is not None:
+        gates['attribution'] = {
+            key: attribution.get(key) for key in
+            ('status', 'common_return_mean', 'specific_return_mean',
+             'tilt_return_mean', 'timing_return_mean', 'fit_quality')}
+        if attribution.get('status') == 'measured':
+            common = attribution.get('common_return_mean') or 0.0
+            total = attribution.get('total_return_mean') or 0.0
+            if total and abs(common) < 0.3 * abs(total):
+                reasons.append('most of the return is specific: the factors on '
+                               'record do not explain it')
+    if drift_report is not None:
+        gates['drift'] = {
+            'flagged': drift_report.get('flagged'),
+            'flagged_share': drift_report.get('flagged_share'),
+            'discriminating': drift_report.get('discriminating'),
+        }
+        if drift_report.get('discriminating') is False:
+            reasons.append('the drift detector cannot discriminate on this '
+                           'reference window, so distribution stability is '
+                           'unchecked rather than confirmed')
+
+    refused = [name for name, value in gates.items()
+               if isinstance(value, dict)
+               and value.get('status') in ('insufficient_sample', 'insufficient_search')]
+    passed = [
+        bool(gates.get('interval_clears_zero')),
+        (gates.get('deflated_sharpe') or {}).get('dsr') is not None
+        and gates['deflated_sharpe']['dsr'] >= 0.9,
+        (gates.get('pbo') or {}).get('pbo') is not None
+        and gates['pbo']['pbo'] <= 0.5,
+    ]
+    if refused:
+        level = 'insufficient'
+        reasons.append(f'gates that could not run: {", ".join(sorted(refused))}')
+    elif all(passed):
+        level = 'diagnostic'
+    elif any(passed):
+        level = 'contested'
+    else:
+        level = 'insufficient'
+    return {
+        'grade': level,
+        'n_sessions': len(sessions),
+        'gates': gates,
+        'reasons': reasons,
+        'ceiling': ('diagnostic; `validated` requires pre-registration, which is '
+                    'a property of when a rule was written and cannot be '
+                    'produced by any computation here'),
+        'discipline': 'a refused gate caps the grade; "not checked" is not "held"',
+    }
+
+
+def evaluate(sessions, weights_by_session, factors, *, configurations=None,
+             n_trials=None, drift_report=None) -> dict:
+    """Attribution and the grade, on one input, in one call."""
+    attribution = perf_attrib(sessions, weights_by_session, factors)
+    returns_by_session = {}
+    if attribution.get('status') == 'measured':
+        returns_by_session = {
+            day: [value] for day, value in
+            (attribution.get('per_session') or {}).get('total', {}).items()}
+    return {
+        'attribution': attribution,
+        'grade': grade(returns_by_session, configurations=configurations,
+                       n_trials=n_trials, attribution=attribution,
+                       drift_report=drift_report),
+    }

--- a/tests/test_attribution_and_grade.py
+++ b/tests/test_attribution_and_grade.py
@@ -1,0 +1,202 @@
+"""Where the return came from, and one verdict over six gates (#1144/#1147/#1149/#1178).
+
+Two questions with different epistemic status, and the module has to treat them
+differently. "Why is this name ranked here" has an *exact* answer, because the
+composite is linear in the ranks — the competitor-port issue proposed SHAP for
+it, which would approximate a number that can be written down. "Where did the
+portfolio return come from" does not, and its honest form is a regression whose
+sample has to be published beside it.
+
+The most important test here is the one that fails to produce a number: on the
+live book the cross-section carrying both registered ranks and canonical bars is
+thirteen names, and nine factors plus an intercept need twenty-seven. Every one
+of the eighteen sessions is skipped, and the module has to say so rather than
+return coefficients from an underdetermined fit.
+"""
+import random
+import statistics
+
+import numpy as np
+import pytest
+
+from clawock.evaluation import attribution as at
+from clawock.evaluation import unified
+
+
+def _synthetic(n_sessions=30, n_names=20, factors=('a', 'b', 'c'),
+               truth=(0.02, -0.01, 0.0), noise=0.005, seed=1):
+    rng = np.random.default_rng(seed)
+    truth = dict(zip(factors, truth))
+    sessions, weights = {}, {}
+    for index in range(n_sessions):
+        day = f'2026-06-{index + 1:03d}'
+        loadings = {f'N{name}': {factor: float(rng.normal()) for factor in factors}
+                    for name in range(n_names)}
+        forward = {name: sum(truth[factor] * row[factor] for factor in factors)
+                   + float(rng.normal(0, noise))
+                   for name, row in loadings.items()}
+        sessions[day] = (loadings, forward)
+        weights[day] = {name: 1.0 for name in loadings}
+    return sessions, weights, list(factors), truth
+
+
+def test_fama_macbeth_recovers_the_factor_returns_it_was_given():
+    sessions, _, factors, truth = _synthetic()
+    fitted = at.factor_returns(sessions, factors)
+    assert fitted['status'] == 'measured'
+    for factor, expected in truth.items():
+        assert fitted['per_factor'][factor]['mean_factor_return'] == \
+            pytest.approx(expected, abs=0.002)
+    # And the factor that truly does nothing must not come back significant.
+    assert abs(fitted['per_factor']['c']['t_stat']) < 2.5
+
+
+def test_a_cross_section_too_narrow_for_the_factors_is_refused():
+    """The live shape, and the whole reason for the refusal.
+
+    Thirteen names carrying both registered ranks and canonical bars; nine
+    factors plus an intercept need twenty-seven by the three-names-per-factor
+    rule. Returning coefficients from that fit would fill an attribution table
+    with numbers that mean nothing.
+    """
+    sessions, _, _, _ = _synthetic(n_names=13, factors=tuple('abcdefghi'),
+                                   truth=(0.0,) * 9)
+    fitted = at.factor_returns(sessions, list('abcdefghi'))
+    assert fitted['status'] == 'insufficient_sample'
+    assert fitted['skipped_sessions'] == 30
+    assert fitted['n_sessions'] == 0
+
+
+def test_the_pre_registered_block_reduction_fits_where_nine_factors_cannot():
+    """Three blocks need nine names, which thirteen clears."""
+    from clawock.market_data import factors as factor_universe
+
+    weights = factor_universe.load_config()['factor_weights']
+    assert set().union(*at.FACTOR_BLOCKS.values()) == set(weights), (
+        'every registered factor must belong to exactly one block')
+    counts = [len(members) for members in at.FACTOR_BLOCKS.values()]
+    assert sum(counts) == len(weights)
+    ranks = {factor: 0.5 for factor in weights}
+    loadings = at.block_loadings(ranks, weights)
+    assert set(loadings) == set(at.FACTOR_BLOCKS)
+    # A block whose members all sit at the same rank collapses to that rank:
+    # the block loading is the same weighted mean the composite uses.
+    assert all(value == pytest.approx(0.5) for value in loadings.values())
+
+
+def test_tilt_plus_timing_equals_common_by_construction():
+    sessions, weights, factors, _ = _synthetic()
+    report = at.perf_attrib(sessions, weights, factors)
+    assert report['status'] == 'measured'
+    assert report['tilt_return_mean'] + report['timing_return_mean'] == \
+        pytest.approx(report['common_return_mean'], abs=1e-6)
+    assert report['common_return_mean'] + report['specific_return_mean'] == \
+        pytest.approx(report['total_return_mean'], abs=1e-6)
+
+
+def test_a_collinear_design_is_reported_rather_than_regularised():
+    """A caller told the design is collinear can drop a factor.
+
+    One handed a silently stabilised coefficient cannot see that the split
+    between two near-identical factors was arbitrary.
+    """
+    rng = np.random.default_rng(4)
+    loadings, forward = {}, {}
+    for index in range(30):
+        base = float(rng.normal())
+        loadings[f'N{index}'] = {'a': base, 'b': base + 1e-6 * rng.normal(),
+                                 'c': float(rng.normal())}
+        forward[f'N{index}'] = base * 0.01 + float(rng.normal(0, 0.001))
+    fit = at.cross_sectional_fit(loadings, forward, ['a', 'b', 'c'])
+    assert fit['collinear'] is True
+    assert fit['condition_number'] > at.CONDITION_WARN
+
+
+def test_the_composite_explanation_is_exact_not_approximate():
+    """The contributions must reproduce the score, to the last place.
+
+    A SHAP value here would estimate a number the model computes directly.
+    """
+    weights = {'a': 0.5, 'b': 0.3, 'c': 0.2}
+    ranks = {'a': 0.4, 'b': -0.2, 'c': 0.1}
+    report = at.explain_composite(ranks, weights)
+    assert report['contributions_sum'] == pytest.approx(report['composite_score'],
+                                                        abs=1e-9)
+    expected = sum(weights[f] * ranks[f] for f in weights) / sum(weights.values())
+    assert report['composite_score'] == pytest.approx(expected, abs=1e-9)
+
+
+def test_a_missing_factor_is_named_and_the_score_renormalises():
+    weights = {'a': 0.5, 'b': 0.3, 'c': 0.2}
+    report = at.explain_composite({'a': 1.0, 'b': 1.0}, weights)
+    assert report['missing_factors'] == ['c']
+    assert report['weight_covered'] == pytest.approx(0.8)
+    assert report['composite_score'] == pytest.approx(1.0)
+
+
+def test_a_contribution_and_a_counterfactual_can_disagree():
+    """The reason both are published, seen on the live book.
+
+    `00100`'s `residual_mom_6m` contributes -0.035 to its composite and dropping
+    that factor moves its cross-sectional percentile by exactly zero — because
+    the factor is similarly negative for everybody. "How much did this factor
+    contribute" and "would dropping it change where this name sits" are
+    different questions and a single number cannot answer both.
+    """
+    weights = {'a': 0.5, 'b': 0.5}
+    cross_section = {f'N{index}': {'a': index / 10.0, 'b': -1.0}
+                     for index in range(10)}
+    report = at.explain_composite(cross_section['N3'], weights,
+                                  cross_section=cross_section, ticker='N3')
+    assert report['contributions']['b'] == pytest.approx(-0.5)
+    # b is identical across the cross-section, so removing it moves nobody.
+    assert report['leave_one_out']['b']['percentile_change'] == pytest.approx(0.0)
+    # a is what actually decides the ordering.
+    assert report['leave_one_out']['a']['percentile_change'] != 0.0
+
+
+def _configurations(edge, n, seed, winner=2, names=4):
+    rnd = random.Random(seed)
+    return {f'v{index}': {f'2026-{1 + day // 28:02d}-{1 + day % 28:02d}':
+                          rnd.gauss(edge if index == winner else 0.0, 0.02)
+                          for day in range(n)}
+            for index in range(names)}
+
+
+def test_a_real_edge_grades_diagnostic_and_noise_does_not():
+    real = _configurations(0.006, 250, 7)
+    verdict = unified.grade({day: [value] for day, value in real['v2'].items()},
+                            configurations=real)
+    assert verdict['grade'] == 'diagnostic'
+    assert verdict['reasons'] == []
+
+    noise = _configurations(0.0, 250, 7)
+    weak = unified.grade({day: [value] for day, value in noise['v2'].items()},
+                         configurations=noise)
+    assert weak['grade'] != 'diagnostic'
+
+
+def test_a_refused_gate_caps_the_grade():
+    """"We could not check" is the thing a summary is most tempting to blur."""
+    short = _configurations(0.006, 25, 3)
+    verdict = unified.grade({day: [value] for day, value in short['v2'].items()},
+                            configurations=short)
+    assert verdict['grade'] in ('insufficient', 'contested')
+    assert any('could not run' in reason or 'insufficient' in reason
+               for reason in verdict['reasons']) or verdict['grade'] != 'diagnostic'
+
+
+def test_nothing_here_can_award_validated():
+    """The ceiling is a property of when a rule was written, not of a computation."""
+    strong = _configurations(0.02, 400, 5)
+    verdict = unified.grade({day: [value] for day, value in strong['v2'].items()},
+                            configurations=strong)
+    assert verdict['grade'] != 'validated'
+    assert 'pre-registration' in verdict['ceiling']
+
+
+def test_a_search_of_one_has_no_selection_effect_to_measure():
+    single = _configurations(0.006, 200, 9, names=1, winner=0)
+    verdict = unified.grade({day: [value] for day, value in single['v0'].items()},
+                            configurations=single)
+    assert verdict['gates']['pbo']['status'] == 'not_applicable'


### PR DESCRIPTION
Closes #1144, closes #1147, closes #1149, closes #1178。

两个问题,认知地位不同,所以处理方式不同。

## 1. 「这只票为什么排在这里」**有精确答案**,而之前没人给

`composite_score` 就是九个 sector-neutral rank 的加权平均 ⇒ 每个因子的贡献是
`w_f · rank_f / Σw`,**可加、无近似**。

**#1178 提议用 SHAP/LIME** —— 那是在**近似一个可以直接写出来的数**,然后把近似误差当成模型的微妙之处报出来。

`explain_composite` 直接算(实测把 `00100` 记录在案的 composite 复现到小数点后第六位),
并额外给**精确的 leave-one-out**:把某个因子从**全截面每只票**的 composite 里去掉,重算这只票的分位。

### 两者会不一致 —— 这正是两个都发布的原因

```
00100  residual_mom_6m  贡献 -0.0351   去掉它 → 分位变化 0.0000
       residual_mom_1m  贡献 +0.0789   去掉它 → 分位变化 -0.1316
```

`residual_mom_6m` 贡献不小,**但去掉它这只票的位置一点不动** —— 因为它对所有人都同样为负。
「这个因子贡献了多少」和「去掉它会不会改变这只票的位置」是**两个问题**,一个数答不了两个。

## 2. 「组合的收益从哪来」**没有精确答案**,诚实形式是回归 + 把样本印在旁边

逐 session 对截面做 forward return ~ 因子载荷 的回归(Fama-MacBeth)。
合成数据上能**精确找回**给定的因子收益。

### 在真实账本上它**拒绝作答**

**同时有注册 rank 和官方 bar 的截面中位数是 13 只票**,而九个因子 + 截距按
「每因子至少 3 只票」需要 27 ⇒ **18 个 session 全部被跳过。**

### `FACTOR_BLOCKS`:能跑的那个降维

三个块只要 9 只票,13 够。**这是降维不是搜索**:分组沿用因子宇宙本来就在用的命名、
**没有试过任何别的分组**、块载荷就是 composite 自己的加权平均限制在块成员上。有测试钉住「每个注册因子恰好属于一个块」。

### 实测(18 sessions, t5)—— **#1133 regime 结论的第三次独立佐证**

```
block               mean factor return (5d)      t
momentum                    -8.66%             -3.46
stability                   -4.97%             -3.15
quality_liquidity           +0.96%             +0.18

mean R2 0.21
等权组合: total +4.95%  common +1.68%  specific +3.28%  (tilt +1.35 / timing +0.32)
```

**composite 在 momentum 和 stability 上都是正权重,而这两个块正是这段被负向定价的。**
(#1133 拆成分 → regime;#1172 波动因子全正 → 风险偏好;这里 → 因子收益本身为负。三条互不相关的证据链同向。)

`mean R2 = 0.21` ⇒ **等权收益的三分之二是 specific** —— 归因把这句话说出来,
而不是把能解释的那三分之一当成故事讲。

## 3. `evaluation/unified.py`:六道闸,一个等级

本仓库已经攒了一套好闸(cscv / deflated_sharpe / bootstrap / attribution / drift),
每一条都对。**六个各自独立的输出的失败模式是:读者挑一个符合自己结论的。**

`grade` 把它们跑在同一份输入上,归约成一个等级,并把每道闸的贡献挂上。

**归约在一个方向上故意很狠:被拒绝的闸会把等级压下去。**
「没能检查」和「检查了并且成立」正是摘要最容易糊掉的两件事。

**这里永远无法给出 `validated`** —— 那个词属于「在数据到来之前就被写下来」的规则,
是关于**它什么时候被写的**的性质,任何计算都产不出来。

实测区分力:真 edge(250 session)→ `diagnostic` 且 reasons 为空;
同样长度的纯噪声 → `insufficient`(PBO 0.80、DSR 0.68、区间跨 0)。

## 高压线

- ❌ 不碰 live 模型输出契约 / 预注册研究契约 / 200KB payload 闸
- ❌ 不新增 cron、不新增 CLI 命令(依赖 numpy/scipy,已在 #1202 转必需)

## 测试

`tests/test_attribution_and_grade.py`(12)。含会真失败的:
**九因子在 13 只票的截面上必须拒绝**、**tilt + timing 必须恒等于 common**、
**共线设计必须被报出来而不是被静默正则化**、
**贡献与 leave-one-out 必须能不一致**、
**被拒绝的闸必须压等级**、以及**任何输入都拿不到 `validated`**。
