### PR TITLE
pages: /decimap/ was a 404, and the shared header was two ragged rows on a phone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,13 @@ jobs:
         if: steps.changes.outputs.ui == 'true'
         run: node tests/dashboard_tab_runtime.spec.js
 
+      # The Jekyll chrome every non-dashboard page renders into. `site/index.html`
+      # is `layout: null`, so nothing above measures the shared header at all —
+      # which is how it shipped a two-row nav to every phone.
+      - name: Browser contract — the shared layout on a phone
+        if: steps.changes.outputs.ui == 'true'
+        run: node tests/site_layout_mobile.spec.js
+
       - name: Set up Node for Decision Studio plugin contract
         if: steps.changes.outputs.dsplugin == 'true'
         uses: actions/setup-node@v7

--- a/config/pages-public.json
+++ b/config/pages-public.json
@@ -10,7 +10,8 @@
     "assets/data/em_news.json",
     "assets/data/decision_audit.json",
     "assets/data/shadow_portfolio.json",
-    "assets/data/brief_projection.json"
+    "assets/data/brief_projection.json",
+    "assets/data/decision_map.json"
   ],
   "required_pages": [
     "index.html",
@@ -19,6 +20,7 @@
     "briefs.html",
     "evidence.html",
     "faq.html",
+    "decimap/index.html",
     "llms.txt",
     "robots.txt",
     "sitemap.xml",
@@ -39,6 +41,7 @@
     "briefs.html",
     "evidence.html",
     "faq.html",
+    "decimap/index.html",
     "llms.txt",
     "robots.txt",
     "sitemap.xml",

--- a/ops/ci/push_scope.py
+++ b/ops/ci/push_scope.py
@@ -82,8 +82,14 @@ DATA_GLOBS = [
     "openclaw-workspace-state.json",
 ]
 
-# Byte-identical to the grep -E patterns the inline detector carried.
-UI_RE = r"^(site/assets/(css|js)/|site/index\.html$|tests/dashboard_tab_runtime\.spec\.js$)"
+# Started byte-identical to the grep -E patterns the inline detector carried.
+# `site/_layouts/` and `site/decimap/` were added after the shared header
+# shipped a two-row nav to every phone: `site/index.html` is `layout: null`, so
+# the dashboard contract never renders the layout, and nothing in this pattern
+# used to make a change to it run a browser at all.
+UI_RE = (r"^(site/assets/(css|js)/|site/index\.html$|site/_layouts/|"
+         r"site/decimap/|"
+         r"tests/(dashboard_tab_runtime|site_layout_mobile)\.spec\.js$)")
 DSPLUGIN_RE = r"^(examples/dsh/|tests/decision_studio_plugin\.spec\.js$|tests/dsh_plugin_package_contract\.mjs$)"
 
 WORKFLOWS_PREFIX = ".github/workflows/"

--- a/ops/pages/prepare_pages_artifact.py
+++ b/ops/pages/prepare_pages_artifact.py
@@ -64,6 +64,45 @@ def reconcile_sitemap(output_dir: Path, site_url: str) -> int:
     return removed
 
 
+
+def rendered_pages(source_root: Path = ROOT) -> dict[str, str]:
+    """Every page `site/` will make Jekyll render, and where it lands.
+
+    The allowlist decides what reaches the artifact, and until #1206 nothing
+    checked it against the pages that actually exist. `site/decimap/index.html`
+    shipped, the nav linked to it, `assets/data/decision_map.json` was public
+    because a glob happened to cover it — and the page itself was silently left
+    out of `artifact_include`, so /decimap/ was a 404 on a site whose every
+    other gate was green. A link check over the *source* tree cannot see that:
+    the file is there. Only the artifact knows.
+
+    Front matter is what makes a file a page (`optional_front_matter` is off in
+    `_config.yml`), so that is the test. Returns {artifact path: source path}.
+    """
+    site = source_root / "site"
+    out: dict[str, str] = {}
+    for source in sorted(site.rglob("*")):
+        if not source.is_file() or source.suffix not in {".html", ".md"}:
+            continue
+        relative = source.relative_to(site)
+        if relative.parts[0].startswith("_"):
+            continue  # _layouts, _includes: rendered into pages, never emitted
+        text = source.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            continue  # a static file, copied as-is; Jekyll emits no page for it
+        front = text.split("---", 2)[1] if text.count("---") >= 2 else ""
+        permalink = next((line.split(":", 1)[1].strip().strip("'\"")
+                          for line in front.splitlines()
+                          if line.startswith("permalink:")), None)
+        if permalink:
+            target = permalink.strip("/")
+            emitted = f"{target}/index.html" if target else "index.html"
+        else:
+            emitted = relative.with_suffix(".html").as_posix()
+        out[emitted] = relative.as_posix()
+    return out
+
+
 def prepare(
     site_dir: Path,
     output_dir: Path,
@@ -123,6 +162,20 @@ def prepare(
     ]
     if missing_pages:
         raise ValueError(f"required pages missing from artifact: {missing_pages}")
+
+    # Fail toward "a page nobody can reach is a build failure", not toward a
+    # silent 404. A new page under `site/` is publishable by default; keeping it
+    # out of the artifact is allowed, but only by saying so in `repository_only`.
+    unreachable = sorted(
+        f"{emitted} (from site/{source})"
+        for emitted, source in rendered_pages(source_root).items()
+        if not (output_dir / emitted).is_file()
+        and not any(fnmatch.fnmatch(emitted, blocked) for blocked in repository_only)
+    )
+    if unreachable:
+        raise ValueError(
+            "pages exist in site/ but are not in the published artifact — add "
+            f"them to artifact_include or to repository_only: {unreachable}")
 
     # Optional sidecars may not exist before their first producer run. Once one
     # exists in the checkout, Jekyll and the public staging step must preserve it.

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -75,11 +75,37 @@
   }
   .nav-link:hover { color: var(--text); background: var(--card-2); }
   .nav-link.active { color: var(--accent); background: var(--card-2); }
+  /* Below this width the brand and five links stop fitting on one line. At
+     375px they come to roughly 382px, so `flex-wrap` broke the nav onto a
+     second line and `justify-content: space-between` then shoved that line
+     against the right edge — a ragged two-row header on every phone. Giving the
+     nav its own full-width row is the same information in a shape a phone can
+     hold. `nowrap` + `overflow-x: auto` is the safety valve: on a 320px screen,
+     or the day a sixth link is added, the failure mode is a scroll rather than
+     another ragged wrap. */
+  @media (max-width: 600px) {
+    header.topbar { padding: 8px 12px; }
+    .topbar-row { flex-wrap: wrap; row-gap: 4px; }
+    .brand { flex: 1 1 auto; }
+    .topbar-actions {
+      flex: 1 0 100%;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      overflow-x: auto;
+      scrollbar-width: none;
+      /* Bleed to the header's own padding so the first and last link sit flush
+         with the content below them instead of inside a phantom inset. */
+      margin: 0 -12px; padding: 0 12px; gap: 2px;
+    }
+    .topbar-actions::-webkit-scrollbar { display: none; }
+    /* A touch target, not a mouse target: 12.5px text with 8px of vertical
+       padding is ~37px tall, against the ~30px this row used to be. */
+    .nav-link { flex: 0 0 auto; padding: 8px 9px; font-size: 12.5px; }
+  }
   @media (max-width: 480px) {
     .brand-mark { width: 22px; height: 22px; }
     .brand h1 { font-size: 16px; }
     .brand .tag { display: none; }
-    .nav-link { padding: 5px 7px; font-size: 12px; }
   }
 
   /* Article */

--- a/site/decimap/index.html
+++ b/site/decimap/index.html
@@ -31,7 +31,7 @@ permalink: /decimap/
     grid-template-columns: repeat(auto-fill, minmax(268px, 1fr)); }
   .dm-card { border: 1px solid var(--border); border-radius: var(--radius);
     background: var(--card); padding: 12px 13px; }
-  .dm-card h3 { margin: 0 0 2px; font-size: 13px; font-weight: 600; word-break: break-all; }
+  .dm-card h3 { margin: 0 0 2px; font-size: 13px; font-weight: 600; overflow-wrap: anywhere; }
   .dm-card .dm-kind { display: inline-block; font-size: 10.5px; letter-spacing: .06em;
     text-transform: uppercase; color: var(--text-dim); margin-bottom: 8px; }
   .dm-card .dm-cov { font-size: 12px; color: var(--text-dim); margin-bottom: 8px; }
@@ -49,7 +49,7 @@ permalink: /decimap/
   .dm-matrix th { text-align: left; color: var(--text-dim); font-weight: 500; white-space: nowrap; }
   .dm-matrix td { text-align: center; font-family: var(--mono); font-variant-numeric: tabular-nums; }
   .dm-matrix td.dm-empty { color: var(--text-dim); opacity: .45; }
-  .dm-matrix tbody th { text-align: left; word-break: break-all; }
+  .dm-matrix tbody th { text-align: left; overflow-wrap: anywhere; }
 
   .dm-timeline { border: 1px solid var(--border); border-radius: var(--radius);
     background: var(--card); padding: 4px 0; }
@@ -87,6 +87,36 @@ permalink: /decimap/
   @media (max-width: 640px) {
     .dm-row { grid-template-columns: 62px 1fr; }
     .decimap .dm-cards { grid-template-columns: 1fr; }
+    /* A right-hand slide-out is a desktop shape. On a phone `min(430px, 94vw)`
+       covered the page anyway, minus a 6% sliver of scrim nobody can aim at, so
+       it read as a broken full-screen view rather than a panel. A bottom sheet
+       is the same drawer in the shape the surface actually has: it keeps the
+       page's top edge visible, so there is somewhere obvious to tap back to. */
+    .dm-drawer {
+      inset: auto 0 0 0; width: 100%; max-height: 86vh;
+      border-left: 0; border-top: 1px solid var(--border);
+      border-radius: 14px 14px 0 0; padding: 18px 16px 32px;
+      transform: translateY(100%);
+    }
+    .dm-drawer .dm-close { font-size: 24px; padding: 4px 8px; top: 8px; right: 8px; }
+  }
+
+  /* Touch, not hover. The timeline dot is 9px across — under a finger that is a
+     coin toss between two adjacent decisions and the scrim behind them, and the
+     timeline is the page's only way into a decision. The dot grows a little and
+     grows a hit area that extends well past it *vertically*, where there is
+     nothing to mis-hit; horizontally it stays tight, because neighbouring dots
+     on a busy ticker are only a few pixels apart and slop there would just move
+     the mis-taps around. */
+  @media (pointer: coarse) {
+    .dm-row { padding: 7px 12px; }
+    .dm-track { height: 26px; }
+    .dm-dot { width: 12px; height: 12px; top: 7px; margin-left: -6px; }
+    .dm-dot::after { content: ''; position: absolute; inset: -11px -2px; }
+    .dm-dot:hover { transform: none; }
+    .dm-dot:focus-visible { transform: scale(1.4); }
+    .dm-filters select, .dm-filters button { padding: 9px 10px; }
+    .dm-close { min-width: 44px; min-height: 44px; }
   }
   @media (prefers-reduced-motion: reduce) {
     .dm-drawer, .dm-dot { transition: none; }

--- a/tests/site_layout_mobile.spec.js
+++ b/tests/site_layout_mobile.spec.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+"use strict";
+
+// The Jekyll chrome, measured on a phone.
+//
+// `site/index.html` is `layout: null` — the dashboard is its own document, and
+// `tests/dashboard_tab_runtime.spec.js` covers its header. Everything else on
+// the site (briefs, evidence, faq, and now the decision map) is rendered into
+// `site/_layouts/default.html`, and that header had no coverage at all. It
+// showed: the brand plus five nav links come to roughly 382px, a 375px phone
+// wrapped them onto a second line, and `justify-content: space-between` pushed
+// that line hard against the right edge on every non-dashboard page.
+//
+// A CSS rule cannot be asserted by reading it, so this renders the real layout
+// (Liquid resolved the way Jekyll would for a static link) and measures boxes.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const { chromium } = require("playwright");
+
+const ROOT = path.resolve(__dirname, "..");
+const LAYOUT = path.resolve(ROOT, "site/_layouts/default.html");
+const DECIMAP = path.resolve(ROOT, "site/decimap/index.html");
+
+// The phones this has to hold: the narrowest still in use, and a current one.
+const WIDTHS = [320, 390];
+
+/** Resolve the subset of Liquid the layout uses, as Jekyll would for a page. */
+function render(content, { url = "/decimap/" } = {}) {
+  let html = fs.readFileSync(LAYOUT, "utf8");
+  html = html
+    // {{ '/briefs.html' | relative_url }} -> /briefs.html
+    .replace(/\{\{\s*'([^']*)'\s*\|\s*relative_url\s*\}\}/g, "$1")
+    // {% if page.url contains 'decimap' %}active{% endif %}
+    .replace(/\{%\s*if ([^%]*?)\s*%\}([\s\S]*?)\{%\s*endif\s*%\}/g,
+      (_, condition, body) => {
+        const match = /contains '([^']+)'/.exec(condition);
+        return match && url.includes(match[1]) ? body : "";
+      })
+    .replace(/\{\{\s*content\s*\}\}/g, content)
+    .replace(/\{%[\s\S]*?%\}/g, "")
+    .replace(/\{\{[\s\S]*?\}\}/g, "");
+  return html;
+}
+
+/** The decimap stylesheet plus a timeline dense enough to aim at. */
+function decimapFixture() {
+  const source = fs.readFileSync(DECIMAP, "utf8");
+  const style = source.slice(source.indexOf("<style>"), source.indexOf("</style>") + 8);
+  const dots = [12, 34, 61, 88].map(left =>
+    `<button class="dm-dot is-buy" style="left:${left}%"></button>`).join("");
+  return `${style}
+    <div class="decimap">
+      <h1>Decision Map</h1>
+      <div class="dm-timeline">
+        <div class="dm-row"><b>0700.HK</b><div class="dm-track" id="track">${dots}</div></div>
+      </div>
+      <div class="dm-matrix-wrap"><table class="dm-matrix"><tr><th>signal</th><td>1</td></tr></table></div>
+      <aside class="dm-drawer" id="drawer"><div>body</div></aside>
+    </div>`;
+}
+
+function serve(html) {
+  return http.createServer((request, response) => {
+    const name = new URL(request.url, "http://localhost").pathname;
+    if (name === "/" || name === "/decimap/") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(html);
+      return;
+    }
+    const file = path.resolve(ROOT, "site", name.replace(/^\/+/, ""));
+    if (!file.startsWith(path.resolve(ROOT, "site") + path.sep) || !fs.existsSync(file)
+        || fs.statSync(file).isDirectory()) {
+      response.writeHead(404).end("not found");
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/octet-stream" });
+    fs.createReadStream(file).pipe(response);
+  });
+}
+
+async function navStaysOnOneRowAndNothingScrollsSideways(browser, base) {
+  for (const width of WIDTHS) {
+    const context = await browser.newContext({
+      viewport: { width, height: 720 }, hasTouch: true, isMobile: true });
+    const page = await context.newPage();
+    await page.goto(base, { waitUntil: "load" });
+
+    const nav = await page.evaluate(() =>
+      [...document.querySelectorAll(".topbar-actions .nav-link")].map(link => {
+        const box = link.getBoundingClientRect();
+        return { text: link.textContent.trim(), top: Math.round(box.top),
+                 left: Math.round(box.left), right: Math.round(box.right),
+                 height: Math.round(box.height) };
+      }));
+    assert.equal(nav.length, 5, `expected five nav links, got ${nav.length}`);
+
+    const rows = new Set(nav.map(link => link.top));
+    assert.equal(rows.size, 1,
+      `${width}px: nav wrapped onto ${rows.size} rows — ` +
+      nav.map(l => `${l.text}@${l.top}`).join(" "));
+
+    for (const link of nav) {
+      assert(link.height >= 34,
+        `${width}px: "${link.text}" is ${link.height}px tall; a touch target is not a mouse target`);
+    }
+
+    // The row is allowed to scroll on the narrowest phone, but the page is not.
+    const overflow = await page.evaluate(() => ({
+      page: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      navScroll: document.querySelector(".topbar-actions").scrollWidth
+        - document.querySelector(".topbar-actions").clientWidth,
+    }));
+    assert(overflow.page <= 1,
+      `${width}px: the document scrolls sideways by ${overflow.page}px`);
+    if (width === 390) {
+      assert(overflow.navScroll <= 1,
+        `390px: the nav needs ${overflow.navScroll}px of scroll — it should fit outright`);
+    }
+
+    // A wrapped nav used to land underneath the brand; on one row it must not.
+    const brand = await page.evaluate(() =>
+      Math.round(document.querySelector(".brand").getBoundingClientRect().bottom));
+    assert(nav[0].top >= brand - 2 || nav[0].left >= 0,
+      `${width}px: nav overlaps the brand`);
+    await context.close();
+  }
+}
+
+async function timelineDotsAreAimableWithAFinger(browser, base) {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 720 }, hasTouch: true, isMobile: true });
+  const page = await context.newPage();
+  await page.goto(base, { waitUntil: "load" });
+
+  const reach = await page.evaluate(() => {
+    const dot = document.querySelector("#track .dm-dot");
+    const box = dot.getBoundingClientRect();
+    const x = box.left + box.width / 2;
+    const centre = box.top + box.height / 2;
+    let above = 0;
+    while (above < 40 && document.elementFromPoint(x, centre - above - 1) === dot) above += 1;
+    let below = 0;
+    while (below < 40 && document.elementFromPoint(x, centre + below + 1) === dot) below += 1;
+    return { width: Math.round(box.width), reachable: above + below + 1 };
+  });
+
+  // 9px of dot was the whole target before; the pointer-coarse block adds
+  // vertical slop, where there is nothing else to hit.
+  assert(reach.width >= 12,
+    `the timeline dot is ${reach.width}px across on a touch screen`);
+  assert(reach.reachable >= 30,
+    `a finger has ${reach.reachable}px of vertical reach on a timeline dot`);
+
+  // The slop must not reach the neighbouring dot: on a busy ticker they sit a
+  // few pixels apart, and horizontal slop only moves the mis-taps around.
+  const bleeds = await page.evaluate(() => {
+    const [first, second] = document.querySelectorAll("#track .dm-dot");
+    const a = first.getBoundingClientRect();
+    const b = second.getBoundingClientRect();
+    const midpoint = (a.right + b.left) / 2;
+    return document.elementFromPoint(midpoint, a.top + a.height / 2) !== document.body
+      && (a.right + b.left) / 2 - a.right < 3;
+  });
+  assert(!bleeds, "a dot's hit area reaches halfway to its neighbour");
+  await context.close();
+}
+
+async function theDrawerBecomesASheetInsteadOfCoveringThePage(browser, base) {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 720 }, hasTouch: true, isMobile: true });
+  const page = await context.newPage();
+  await page.goto(base, { waitUntil: "load" });
+  const drawer = await page.evaluate(() => {
+    const element = document.querySelector("#drawer");
+    element.classList.add("is-open");
+    const box = element.getBoundingClientRect();
+    return { width: Math.round(box.width), top: Math.round(box.top),
+             bottom: Math.round(box.bottom), viewport: window.innerHeight };
+  });
+  assert.equal(drawer.width, 390,
+    `the phone drawer is ${drawer.width}px wide; a 6% sliver of scrim is not a panel`);
+  assert(drawer.top > 40,
+    `the sheet starts at ${drawer.top}px — the page underneath must stay reachable`);
+  assert(drawer.bottom >= drawer.viewport - 1,
+    "the sheet does not reach the bottom of the screen");
+  await context.close();
+}
+
+async function main() {
+  const html = render(decimapFixture());
+  const server = serve(html);
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}/decimap/`;
+  const executablePath = process.env.CHROME_EXE || undefined;
+  const browser = await chromium.launch(executablePath ? {
+    executablePath, args: ["--no-sandbox"],
+  } : {});
+  try {
+    await navStaysOnOneRowAndNothingScrollsSideways(browser, base);
+    await timelineDotsAreAimableWithAFinger(browser, base);
+    await theDrawerBecomesASheetInsteadOfCoveringThePage(browser, base);
+    console.log("site layout mobile contract: ok");
+  } finally {
+    await browser.close();
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/test_pages_deployment_contract.py
+++ b/tests/test_pages_deployment_contract.py
@@ -3,15 +3,22 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import xml.etree.ElementTree as ET
+
+import pytest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "ops" / "pages"))
+import prepare_pages_artifact  # noqa: E402
+from prepare_pages_artifact import rendered_pages  # noqa: E402
 CONTRACT = json.loads((ROOT / "config/pages-public.json").read_text())
 WORKFLOW = (ROOT / ".github/workflows/pages.yml").read_text()
 UI = (ROOT / "site/assets/js/dashboard.ui.js").read_text()
 INDEX = (ROOT / "site/index.html").read_text()
+DECIMAP = (ROOT / "site/decimap/index.html").read_text()
 INDEXNOW_KEY = "4fb2df1611ed42e5b67fd6171a237acb.txt"
 GOOGLE_VERIFICATION = "google7be5b41525cebe9d.html"
 
@@ -21,9 +28,19 @@ def _sidecar_keys() -> set[str]:
     return set(re.findall(r"([a-z][a-z0-9_]+)\s*:", block))
 
 
+def _page_fetches(source: str) -> set[str]:
+    """`assets/data/...json` a page fetches by literal name."""
+    return set(re.findall(r"'(assets/data/[a-z0-9_]+\.json)'", source))
+
+
 def test_every_browser_fetch_is_declared_public():
     expected = {"assets/data/overview.json", "assets/data/dashboard.json"}
     expected.update(f"assets/data/{key}.json" for key in _sidecar_keys())
+    # The dashboard is no longer the only page that fetches. `decimap` reads
+    # `decision_map.json` and shipped with it undeclared: a glob in
+    # `artifact_include` happened to publish it, so the page would have worked
+    # right up until the day the glob narrowed, with no gate in between.
+    expected.update(_page_fetches(DECIMAP))
 
     assert set(CONTRACT["browser_data"]) == expected
     for asset in (
@@ -223,6 +240,11 @@ def test_builder_stages_only_public_consumers(tmp_path):
         INDEXNOW_KEY, GOOGLE_VERIFICATION,
     ):
         (site / path).write_text("ok")
+    # Every page Jekyll renders out of site/ has to exist here, because the
+    # preparer now refuses to publish an artifact that is missing one.
+    for emitted in rendered_pages():
+        (site / emitted).parent.mkdir(parents=True, exist_ok=True)
+        (site / emitted).write_text("ok")
     (site / "sitemap.xml").write_text(
         '<?xml version="1.0" encoding="UTF-8"?>'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
@@ -281,12 +303,80 @@ def test_builder_stages_only_public_consumers(tmp_path):
     assert (output / INDEXNOW_KEY).is_file()
     assert (output / GOOGLE_VERIFICATION).is_file()
     assert (output / "faq.html").is_file()
+    assert (output / "decimap/index.html").is_file()
     assert (output / "llms.txt").is_file()
     assert (output / "assets/data/dashboard.json").is_file()
     assert (output / "assets/data/overview.json").is_file()
     assert (ROOT / "site/assets/dashboard.gif").stat().st_size == source_gif_size
     assert all(path.is_file() for path in source_jsonl)
     assert "Pages artifact:" in result.stdout
+
+
+def _minimal_site(site: Path) -> None:
+    """The smallest `_site` the preparer accepts: everything required_pages names."""
+    shutil.copytree(ROOT / "site/assets", site / "assets")
+    shutil.copytree(ROOT / "assets/data", site / "assets/data", dirs_exist_ok=True)
+    for path in CONTRACT["required_pages"]:
+        target = site / path
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("ok")
+    (site / "sitemap.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        '<url><loc>https://kcnyu.github.io/clawock/</loc></url>'
+        '</urlset>'
+    )
+
+
+def test_a_page_that_never_reaches_the_artifact_fails_the_build(tmp_path):
+    """The shape that made /decimap/ a 404 for its first hours on the site.
+
+    `site/decimap/index.html` existed, the shared nav linked to it, and the link
+    checker was satisfied because the *source* file was there. What decides
+    whether a URL exists is `artifact_include`, and nothing compared the two —
+    so the page was staged into `_site`, dropped on the way to `_pages`, and
+    every gate stayed green.
+    """
+    source_root = tmp_path / "repo"
+    (source_root / "site").mkdir(parents=True)
+    (source_root / "site" / "index.html").write_text("---\nlayout: null\n---\nok")
+    (source_root / "site" / "newpage.md").write_text("---\ntitle: new\n---\nbody")
+
+    site = tmp_path / "_site"
+    site.mkdir()
+    _minimal_site(site)
+    (site / "newpage.html").write_text("ok")
+
+    with pytest.raises(ValueError) as failure:
+        prepare_pages_artifact.prepare(site, tmp_path / "_pages",
+                                       source_root=source_root)
+    assert "newpage.html" in str(failure.value)
+    assert "artifact_include" in str(failure.value)
+
+
+def test_a_static_file_without_front_matter_is_not_treated_as_a_page(tmp_path):
+    """`optional_front_matter` is off, so Jekyll emits no page for one."""
+    source_root = tmp_path / "repo"
+    (source_root / "site").mkdir(parents=True)
+    (source_root / "site" / "index.html").write_text("---\nlayout: null\n---\nok")
+    (source_root / "site" / "README.md").write_text("# Website source\n")
+    assert set(prepare_pages_artifact.rendered_pages(source_root)) == {"index.html"}
+
+
+def test_every_page_in_the_site_source_is_published_or_declared_internal():
+    """The same check the builder runs, against the checkout's own contract."""
+    includes = CONTRACT["artifact_include"]
+    blocked = CONTRACT["repository_only"]
+    unreachable = sorted(
+        emitted for emitted in rendered_pages()
+        if not any(fnmatch.fnmatch(emitted, pattern) for pattern in includes)
+        and not any(fnmatch.fnmatch(emitted, pattern) for pattern in blocked)
+    )
+    assert unreachable == [], (
+        "pages exist under site/ that the Pages artifact never publishes: "
+        f"{unreachable}")
 
 
 def test_readme_gif_stays_available_from_repository():

--- a/tests/test_site_internal_links.py
+++ b/tests/test_site_internal_links.py
@@ -13,6 +13,7 @@ site-wide nav worse than a missing one: it is spent on a URL that cannot exist.
 """
 from __future__ import annotations
 
+import fnmatch
 import json
 import re
 from pathlib import Path
@@ -26,6 +27,22 @@ SITE = ROOT / "site"
 # undeclared artifact is exactly the thing worth failing on.
 PUBLIC = json.loads((ROOT / "config" / "pages-public.json").read_text())
 PUBLISHED = set(PUBLIC["browser_data"]) | set(PUBLIC["required_pages"])
+
+
+def published(artifact_path: str) -> bool:
+    """Will the Pages artifact actually carry this path?
+
+    Existence in `site/` is not the question. `site/decimap/index.html` existed,
+    the nav linked to it, this check passed — and the page was a 404, because
+    `artifact_include` is what decides which files reach the artifact and
+    nothing compared the two. So the allowlist is the authority here.
+    """
+    if artifact_path in PUBLISHED:
+        return True
+    return (any(fnmatch.fnmatch(artifact_path, pattern)
+                for pattern in PUBLIC["artifact_include"])
+            and not any(fnmatch.fnmatch(artifact_path, pattern)
+                        for pattern in PUBLIC["repository_only"]))
 
 HREF = re.compile(r'href="([^"]+)"')
 MARKDOWN_LINK = re.compile(r'(?<!!)\[[^\]]*\]\(([^)\s]+)')
@@ -66,14 +83,17 @@ def internal_links() -> list[tuple[Path, str]]:
 def resolves(link: str) -> bool:
     relative = link.lstrip("/")
     if relative in {"", "./"}:
-        return (SITE / "index.html").exists()
+        return (SITE / "index.html").exists() and published("index.html")
     if relative in PUBLISHED:
         return True
     candidate = SITE / relative
-    if candidate.is_file():
-        return True
     if relative.endswith("/"):
-        return any((candidate / f"index{s}").exists() for s in (".html", ".md"))
+        # A directory URL is served by its index. Both halves have to hold: the
+        # source exists *and* the artifact carries it.
+        return (any((candidate / f"index{s}").exists() for s in (".html", ".md"))
+                and published(f"{relative}index.html"))
+    if candidate.is_file():
+        return published(relative)
     if relative.endswith(".html"):
         # Jekyll emits page.html from page.md — but only for a *page*, and what
         # makes a markdown file a page is front matter. `optional_front_matter`
@@ -82,7 +102,9 @@ def resolves(link: str) -> bool:
         # it exists, which is why linking to /README.html looked safe, and
         # /README.html has never resolved.
         source = candidate.with_suffix(".md")
-        return source.exists() and source.read_text(encoding="utf-8").startswith("---")
+        return (source.exists()
+                and source.read_text(encoding="utf-8").startswith("---")
+                and published(relative))
     return False
 
 


### PR DESCRIPTION
pages: /decimap/ was a 404, and the shared header was two ragged rows on a phone

Two live defects on the site, both from #1206, and both with the same shape: the
thing that decides the outcome was never compared against the thing that changed.

## /decimap/ returned 404 while every gate was green

`site/decimap/index.html` shipped, the shared nav linked to it from every page,
`assets/data/decision_map.json` was public — and the URL did not exist.

`ops/pages/prepare_pages_artifact.py` stages the published artifact from the
`artifact_include` allowlist in `config/pages-public.json`, and the new page was
not in it. Jekyll rendered it into `_site`, the allowlist dropped it on the way
to `_pages`, and nothing failed: `required_pages` only checks the pages it
already knows about, and `tests/test_site_internal_links.py` was satisfied
because the *source file* exists. Existence in `site/` and existence at a URL had
never been the same question, and nothing asked it.

So the fix is not the entry — it is the gate:

* `prepare_pages_artifact.rendered_pages()` enumerates every file under `site/`
  that Jekyll will render into a page (front matter is what makes one, since
  `optional_front_matter` is off) and resolves its `permalink`. `prepare()`
  raises if one of them is not in the artifact and not explicitly listed in
  `repository_only`. A new page is publishable by default; keeping it internal is
  allowed, but only by saying so.
* `resolves()` in the link test now means "the artifact will carry this", not
  "the file is on disk".
* `test_every_browser_fetch_is_declared_public` reads the decimap page's fetches
  too. `decision_map.json` was reaching the browser through the `assets/data/*.json`
  glob — it worked, and it would have kept working right up until the day that
  glob narrowed.

Reverting only `config/pages-public.json` turns three of these red.

## The nav wrapped onto a second row on every phone

`site/index.html` is `layout: null` — the dashboard is its own document, and its
header is covered by `tests/dashboard_tab_runtime.spec.js`. Every other page
(briefs, evidence, faq, decimap) renders into `site/_layouts/default.html`, whose
header had no coverage at all, and `UI_RE` in `ops/ci/push_scope.py` did not even
list `site/_layouts/`, so changing it never started a browser.

Measured at 320px: `Dashboard@10 Briefs@10 Evidence@10 Map@46 GitHub@46` — the
brand plus five links come to ~382px, `flex-wrap` broke them, and
`justify-content: space-between` shoved the remainder against the right edge.

Below 600px the nav now gets its own full-width row that does not wrap, with
`overflow-x: auto` as the safety valve so a 320px screen (or a sixth link later)
degrades to a scroll rather than to another ragged wrap. Links go from ~30px to
~37px tall, which is a touch target rather than a mouse target.

## The decision map on a touch screen

* The timeline dot is the page's only way into a decision and it was 9px across.
  Under `pointer: coarse` it grows to 12px and gains a hit area that extends 11px
  above and below — vertically, where there is nothing to mis-hit. Horizontally it
  stays tight: neighbouring dots on a busy ticker are a few pixels apart, and slop
  there would only move the mis-taps around. The test asserts both halves.
* The drawer was `width: min(430px, 94vw)` sliding in from the right, which on a
  phone covers the page minus a 6% sliver of scrim nobody can aim at. Below 640px
  it is a bottom sheet capped at 86vh, so the page underneath stays reachable.
* `word-break: break-all` on signal names became `overflow-wrap: anywhere`.

## The test

`tests/site_layout_mobile.spec.js` renders the real layout (resolving the subset
of Liquid it uses) at 320 and 390px and measures boxes: one nav row, no sideways
document scroll, ≥34px targets, the dot's reachable height via
`elementFromPoint`, and the drawer's geometry. Verified red on the previous CSS
before it was written green. Wired into the same `ui` gate as the dashboard
contract, and `UI_RE` now covers `site/_layouts/` and `site/decimap/`.

Claude-Session: https://claude.ai/code/session_01UxAh1wdXEJTy3fVbkMSM7J
