### PR TITLE
dashboard: the skip gate could not see the data plane it was skipping (#1217)

### DIFF
--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -11,6 +11,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from clawock.workspace import workspace_root
@@ -99,6 +100,12 @@ def refresh_today_snapshot(ws=None):
 
     Returns (ok, snapshot_filename_or_message). On skip returns (False, msg)
     — caller should treat as non-fatal.
+
+    Identical bytes are not rewritten (#1217). Nothing reads a snapshot's mtime
+    — they are addressed by the date in the filename — but `rebuild_dashboard`'s
+    fingerprint does, and this runs immediately before it. An unconditional
+    write moved the fingerprint on every weekday postflight, which would have
+    made `--skip-if-unchanged` on that path a gate that could never fire.
     """
     from datetime import datetime, timedelta
     ws = ws or WS
@@ -116,7 +123,13 @@ def refresh_today_snapshot(ws=None):
             return False, f'skipped (weekend: {now.strftime("%a %H:%M")})'
         date = target.strftime('%Y-%m-%d')
         snap = ws / 'memory' / 'snapshots' / f'{date}.json'
-        snap.write_bytes(pf.read_bytes())
+        current = pf.read_bytes()
+        try:
+            unchanged = snap.read_bytes() == current
+        except OSError:
+            unchanged = False
+        if not unchanged:
+            snap.write_bytes(current)
         return True, snap.name
     except Exception as e:
         return False, str(e)
@@ -195,7 +208,7 @@ def sync_gha_data_files(ws=None):
         return False, str(e)
 
 
-def _record_dashboard_build(build_ok, publish_ok, output, ws=None):
+def _record_dashboard_build(build_ok, publish_ok, output, ws=None, timings=None):
     """Persist build *and* publication outcomes to the dashboard status file.
 
     Why: report_postflight / brief_postflight call rebuild_dashboard() and discard
@@ -236,6 +249,13 @@ def _record_dashboard_build(build_ok, publish_ok, output, ws=None):
             # Git hooks and remote rules print the useful cause *before* their
             # generic "failed to push" footer. The old 500-char tail hid it.
             'tail': (output or '')[-4000:],
+            # Wall-clock seconds per stage (#1217). The rebuild is the slowest
+            # thing a postflight does and nothing measured it, so "the build got
+            # slower" was only ever an impression. `skipped` says whether the
+            # fingerprint gate fired, which is what makes the seconds readable:
+            # a fast tick that skipped and a fast tick that rebuilt are not the
+            # same fact.
+            'timings_s': dict(timings or {}),
         }
         path = ws / DASHBOARD_BUILD_STATUS
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -275,8 +295,11 @@ def rebuild_dashboard(ws=None):
     health checks cannot turn a frozen public dashboard green.
     """
     ws = ws or WS
+    timings = {}
+    _t0 = time.monotonic()
     refresh_today_snapshot(ws)
     sync_gha_data_files(ws)
+    timings['prepare_inputs'] = round(time.monotonic() - _t0, 3)
     try:
         # Single-publisher lock (2026-07-04): dashboard outputs now have exactly two
         # writer categories — this harness path and the scheduled
@@ -299,22 +322,41 @@ def rebuild_dashboard(ws=None):
         # where recovery matters. Non-fatal: a missing recovery source must not
         # stop a publish, and build_dashboard reports it loudly either way (#315).
         previous = ws / '.data-plane.cache'
+        _t0 = time.monotonic()
         subprocess.run(
             ['python3', str(ws / 'ops' / 'pages' / 'fetch_data_plane.py'),
              '--into', str(previous)],
             capture_output=True, text=True, timeout=60, cwd=str(ws), check=False,
         )
+        timings['fetch_data_plane'] = round(time.monotonic() - _t0, 3)
+
         from clawock.automation import workflow_outcomes
+        _t0 = time.monotonic()
         workflow_outcomes.publish()
+        timings['workflow_outcomes'] = round(time.monotonic() - _t0, 3)
+
+        _t0 = time.monotonic()
         r = subprocess.run(
             # 走本解释器的 -m 而不是 PATH 上的 console script（#918）：装在
             # 别处的入口点与这里 import 的包可能不是同一份，而缺失时的失败
             # 是安静的（FileNotFoundError 被上面的宽 except 吞掉）。
+            #
+            # --skip-if-unchanged (#1217): #846 added the fingerprint gate and
+            # wired it into `publish_dashboard.sh` only, so this path — brief,
+            # report and ~16 intraday postflights, ~19 full rebuilds a day —
+            # kept parsing ~12MB of JSON and re-running settlement whether or
+            # not anything had moved. It is the same gate the publisher has run
+            # 72x/day since; the reason it is only safe to turn on now is that
+            # the fingerprint could not see the data plane until this change,
+            # and this path calls `sync_gha_data_files` immediately before the
+            # build precisely because a scan may just have rewritten it.
             ['flock', DASHBOARD_PUBLISH_LOCK,
              sys.executable, '-m', 'clawock', 'dashboard-build',
-             '--previous', str(previous / 'assets' / 'data' / 'dashboard.json')],
+             '--previous', str(previous / 'assets' / 'data' / 'dashboard.json'),
+             '--skip-if-unchanged'],
             capture_output=True, text=True, timeout=30, cwd=str(ws),
         )
+        timings['dashboard_build'] = round(time.monotonic() - _t0, 3)
         build_ok = r.returncode == 0
         publish_ok = None
         full = r.stdout + r.stderr
@@ -327,21 +369,28 @@ def rebuild_dashboard(ws=None):
         # publish.
         if build_ok:
             try:
+                _t0 = time.monotonic()
                 mapped = subprocess.run(
                     [sys.executable, '-m', 'clawock', 'decision-map'],
                     capture_output=True, text=True, timeout=180, cwd=str(ws),
                 )
+                timings['decision_map'] = round(time.monotonic() - _t0, 3)
                 full += mapped.stdout + mapped.stderr
             except (OSError, subprocess.SubprocessError) as error:
                 full += f'\ndecision-map: {error}'
         if build_ok:
+            _t0 = time.monotonic()
             publish_ok, publish_detail = _publish_generation(ws)
+            timings['publish_generation'] = round(time.monotonic() - _t0, 3)
             full += publish_detail
         ok = bool(build_ok and publish_ok)
-        _record_dashboard_build(build_ok, publish_ok, full, ws)
+        # The gate prints this line and only this line when it fires, so the
+        # seconds above are readable rather than merely small.
+        timings['skipped'] = 'skipping rebuild' in full
+        _record_dashboard_build(build_ok, publish_ok, full, ws, timings)
         return ok, full[-2000:]
     except Exception as e:
-        _record_dashboard_build(False, None, str(e), ws)
+        _record_dashboard_build(False, None, str(e), ws, timings)
         return False, str(e)
 
 

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -3049,19 +3049,56 @@ def resolve_previous_source(args):
 
 # ---------------------------------------------------------------------------
 # Input fingerprint (#846): the cheap gate that lets the 20-minute publisher
-# skip a build whose inputs did not move. Everything the projection reads is
-# stat-level covered: five named files, four directories (bars/snapshots/
-# weekly/.tmp sidecars), and the daily plan glob. mtime is read at ns
-# resolution so a same-second rewrite still moves the fingerprint, with size
-# as the second key.
+# skip a build whose inputs did not move. mtime is read at ns resolution so a
+# same-second rewrite still moves the fingerprint, with size as the second key.
+#
+# What this comment used to claim, and why it was wrong (#1217)
+# -------------------------------------------------------------
+# It said "everything the projection reads is stat-level covered: five named
+# files, four directories and the daily plan glob". It was not. The projection
+# embeds most of the data plane — sentiment, macro, the news digest, the
+# influencer feed, the quant signals, the leverage dial, the workflow ledger —
+# and of all of those exactly one, `risk.json`, was in the tuple. Demonstrated
+# by `test_dashboard_fingerprint.py`: rewriting sentiment, macro, lev_regime and
+# workflow-outcomes left the fingerprint byte-identical, so the 72x/day
+# publisher would skip the rebuild and keep serving the previous embed until
+# some *unrelated* input — a bar, a snapshot, portfolio.json — happened to move.
+# The desk changes often enough that this was masked most of the day. It is
+# exactly overnight and at the weekend, when a scheduled scan is the only thing
+# writing, that it was not.
+#
+# The data-plane half is now derived from `_FRESHNESS_POLICY` rather than typed
+# out again. That table already has to list every artifact whose staleness the
+# page reports, so a new embed cannot enter the build without entering the
+# fingerprint — the drift that produced this bug cannot repeat silently, and
+# `test_fingerprint_covers_every_data_plane_file_the_build_reads` runs a real
+# build under an instrumented reader to assert the same thing behaviourally.
+#
+# The build's own outputs are deliberately absent: fingerprinting them would
+# mean every build invalidated the next tick's gate. So are the artifacts some
+# *other* publisher rewrites on every tick (`cron-heartbeats.json`), which the
+# projection does not read and which would defeat the gate for nothing.
 # ---------------------------------------------------------------------------
+
+# Read by the builder but not freshness-policed, so they need naming here.
+_FINGERPRINT_EXTRA_DATA_PLANE = (
+    'workflow-outcomes.json',
+    't0_setups.json',
+    't0_setup_review.json',
+)
+
 FINGERPRINT_FILES = (
     'portfolio.json',
     'memory/decisions.jsonl',
     'memory/fx-rates.jsonl',
-    'assets/data/risk.json',
     '.cache/fx_rate.json',
-)
+) + tuple(sorted(
+    f'assets/data/{name}'
+    for name in set(_FRESHNESS_POLICY) | set(_FINGERPRINT_EXTRA_DATA_PLANE)
+    # portfolio.json is freshness-policed and lives at the workspace root, not
+    # in the data plane; it is named above.
+    if name != 'portfolio.json'
+))
 FINGERPRINT_DIRS = ('memory/bars', 'memory/snapshots', 'memory/weekly', 'memory/.tmp')
 FINGERPRINT_CACHE = '.cache/dashboard-input.json'
 

--- a/tests/test_dashboard_input_fingerprint.py
+++ b/tests/test_dashboard_input_fingerprint.py
@@ -75,3 +75,137 @@ def test_snapshot_filter_and_the_1040_roller_cannot_drift_apart():
     from clawock.publish.dashboard import SNAPSHOT_FNAME_RE
 
     assert SNAPSHOT_FNAME_RE is history_store.DATED_FILE_RE
+
+
+# ── the drift that #846 shipped and #1217 found ─────────────────────────────
+
+def _data_plane_reads(monkeypatch) -> set[str]:
+    """Filenames under assets/data/ that a real projection actually touches.
+
+    Recorded rather than listed. A grep for `_embed(...)` would miss the reads
+    that spell the path out inline — `lev_regime.json`, `macro.json` and the
+    workflow ledger are all read that way — and those were three of the files
+    the fingerprint was missing, so a source-scanning gate would have passed
+    while the bug was live.
+    """
+    import os
+    import pathlib
+
+    from clawock.publish import dashboard
+
+    seen: set[str] = set()
+    # String comparison, not `Path.resolve()`: resolve() calls stat(), which is
+    # one of the methods patched below, and the recursion is immediate.
+    root = os.path.abspath(dashboard.WS_ROOT / 'assets' / 'data')
+
+    def _note(path):
+        text = os.path.abspath(str(path))
+        if os.path.dirname(text) == root:
+            seen.add(os.path.basename(text))
+
+    for name in ('read_text', 'read_bytes', 'open', 'exists', 'stat'):
+        original = getattr(pathlib.Path, name)
+
+        def wrapper(self, *args, _original=original, **kwargs):
+            _note(self)
+            return _original(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, name, wrapper)
+
+    dashboard.build_projection()
+    return seen
+
+
+def test_fingerprint_covers_every_data_plane_file_the_build_reads(monkeypatch):
+    """The gate that keeps #1217 from happening again.
+
+    `--skip-if-unchanged` is only safe while the fingerprint sees everything the
+    build reads. It did not: of the data plane the projection embeds, exactly
+    `risk.json` was fingerprinted, so a scheduled scan pushing a new
+    `sentiment.json` left the fingerprint byte-identical and the publisher
+    skipped the rebuild. This runs a real projection, records what it read, and
+    fails on any input the fingerprint cannot see.
+    """
+    from clawock.publish import dashboard
+
+    covered = {
+        name.split('/')[-1] for name in dashboard.FINGERPRINT_FILES
+        if name.startswith('assets/data/')
+    }
+    # The build's own four outputs are read as the previous generation, never as
+    # an input; fingerprinting them would make every build invalidate the next
+    # tick's gate.
+    outputs = {'dashboard.json', 'overview.json', 'decision_audit.json',
+               'shadow_portfolio.json'}
+
+    read = _data_plane_reads(monkeypatch)
+    assert read, 'the instrumented projection recorded no data-plane read at all'
+    uncovered = {name for name in read
+                 if name.endswith('.json')} - covered - outputs
+    assert not uncovered, (
+        f'the projection reads {sorted(uncovered)} and the fingerprint cannot '
+        f'see them: --skip-if-unchanged would keep publishing a stale embed of '
+        f'each until an unrelated input happened to move')
+
+
+def test_a_scheduled_scan_alone_moves_the_fingerprint(tmp_path):
+    """The concrete case that was silent: overnight, a scan is the only writer.
+
+    Every other input class already had a test here. This one — the data plane —
+    did not, which is why the omission survived from #846 to #1217.
+    """
+    ws = _desk(tmp_path)
+    data = ws / 'assets' / 'data'
+    for name in ('sentiment.json', 'macro.json', 'lev_regime.json',
+                 'workflow-outcomes.json'):
+        (data / name).write_text('{"v": 1}')
+
+    before = dashboard_input_fingerprint(ws)
+    for name in ('sentiment.json', 'macro.json', 'lev_regime.json',
+                 'workflow-outcomes.json'):
+        (data / name).write_text('{"v": 2}')
+    assert dashboard_input_fingerprint(ws) != before, (
+        'a scheduled scan rewriting the embedded data plane must move it')
+
+
+def test_an_unchanged_portfolio_does_not_move_the_snapshot(tmp_path, monkeypatch):
+    """The write that would have made the harness gate unfireable (#1217).
+
+    `refresh_today_snapshot` runs immediately before the fingerprint is taken
+    and used to copy `portfolio.json` over today's snapshot unconditionally, so
+    every weekday postflight moved `memory/snapshots/` whether or not the desk
+    had. Nothing reads a snapshot's mtime, so the write bought nothing and cost
+    the gate its only chance to fire.
+    """
+    from datetime import datetime
+
+    from clawock.harness import _harness_common as harness
+
+    ws = _desk(tmp_path)
+    (ws / 'portfolio.json').write_text('{"holdings": []}')
+
+    class _Weekday(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 8, 31, 12, 0)   # a Monday
+
+    monkeypatch.setattr('datetime.datetime', _Weekday)
+
+    ok, name = harness.refresh_today_snapshot(ws)
+    assert ok, name
+    snap = ws / 'memory' / 'snapshots' / name
+    before = snap.stat().st_mtime_ns
+    fingerprint = dashboard_input_fingerprint(ws)
+
+    ok, _ = harness.refresh_today_snapshot(ws)
+    assert ok
+    assert snap.stat().st_mtime_ns == before, (
+        'an unchanged portfolio rewrote the snapshot, which moves the '
+        'fingerprint and leaves --skip-if-unchanged permanently unfireable')
+    assert dashboard_input_fingerprint(ws) == fingerprint
+
+    (ws / 'portfolio.json').write_text('{"holdings": [1]}')
+    ok, _ = harness.refresh_today_snapshot(ws)
+    assert ok
+    assert snap.read_text() == '{"holdings": [1]}', 'a real change must still land'
+    assert dashboard_input_fingerprint(ws) != fingerprint


### PR DESCRIPTION

#1217 asked for `--skip-if-unchanged` on the harness path, on the grounds that
the publisher already passes it and ~19 harness rebuilds a day do not. Wiring it
up first meant reading what the gate actually covers, and the finding inverts
the issue: **the gate the publisher has been running 72x/day is unsafe**, and
the harness one would have saved nothing.

The fingerprint was blind to the data plane
-------------------------------------------
`FINGERPRINT_FILES` named five paths and its comment claimed "everything the
projection reads is stat-level covered". The projection embeds most of the data
plane — sentiment, macro, the news digest, the influencer feed, the quant
signals and their review, the leverage dial, catalysts, benchmark, the peer
residual, the news evidence graph, the cross-sectional factor, em_news, the t0
setups and their review, and the workflow ledger — and of all of those exactly
`risk.json` was in the tuple. Fifteen embedded inputs could change without
moving the fingerprint, so the publisher would skip the rebuild and keep serving
the previous embed until an unrelated input — a bar, a snapshot, portfolio.json
— happened to move. The desk changes often enough to mask this most of the day.
Overnight and at the weekend, when a scheduled scan is the only writer, is
exactly when it did not.

The data-plane half is now derived from `_FRESHNESS_POLICY` instead of typed out
again: that table already has to name every artifact whose staleness the page
reports, so a new embed cannot enter the build without entering the fingerprint.
`test_fingerprint_covers_every_data_plane_file_the_build_reads` runs a real
projection under an instrumented reader and fails on any input the fingerprint
cannot see — reverting the tuple makes it name all fifteen.

The harness gate will rarely fire, and the PR says so
-----------------------------------------------------
The flag is added for consistency — two callers of one CLI disagreeing about a
correctness-relevant flag is what produced this — but the saving #1217 projected
is not there. Every postflight is preceded by a preflight that writes
`memory/.tmp/{brief,report,intraday}-context-*.json`, which is a fingerprinted
input and a *legitimate* change; and `workflow_outcomes.publish()` rewrites
`memory/.tmp/workflow-outcomes.json` inside `rebuild_dashboard` itself, before
the build. Measured on today's tree: the brief preflight wrote at 08:02-08:06
and the postflight ran at 08:08. So the honest claim is parity and safety, not
~19 skipped rebuilds a day.

One write did have to go: `refresh_today_snapshot` copied `portfolio.json` over
today's snapshot unconditionally on every weekday call, immediately before the
fingerprint is taken. Nothing reads a snapshot's mtime — they are addressed by
the date in the filename — so the write bought nothing and would have left the
gate unfireable by construction. It is content-conditional now, with a test that
goes red if the unconditional write comes back.

And it is measurable now
------------------------
`rebuild_dashboard` records wall-clock seconds per stage into
`build_status.timings_s` — prepare_inputs, fetch_data_plane, workflow_outcomes,
dashboard_build, decision_map, publish_generation — plus `skipped`, which says
whether the gate fired. #1217 and #1215 both asked for this; without it "the
rebuild is slow" and "the gate saves ~19 builds a day" are both impressions.

Refs #1217

