### PR TITLE
dashboard: pay the size cap in field names, not in days of equity curve (#1215)

### DIFF
--- a/site/assets/js/dashboard.ui.js
+++ b/site/assets/js/dashboard.ui.js
@@ -276,6 +276,25 @@
     return value && (value.generation_id || value.generated_at);
   }
 
+  // The equity series ships column-packed (#1215): 58% of that section's bytes
+  // were the same eighteen field names on every row, and the cap's only answer
+  // to the growth was to delete the oldest rows. Rebuilt into the row objects
+  // here, once, at the single place the document enters the page — the six
+  // readers of DATA.snapshots see exactly what they always did, and there is no
+  // second shape for one of them to forget about.
+  function _unpackSnapshots(value) {
+    const columns = value?.snapshots_columns;
+    if (!Array.isArray(columns) || !columns.length) return value;
+    const rows = Array.isArray(value.snapshots) ? value.snapshots : [];
+    value.snapshots = rows.map(row => {
+      if (!Array.isArray(row)) return row;
+      const out = {};
+      columns.forEach((name, i) => { out[name] = row[i]; });
+      return out;
+    });
+    return value;
+  }
+
   function _loadFullDashboard(generation, triggeredByUser = false) {
     if (_generation(FULL_DASHBOARD) === generation) return Promise.resolve(FULL_DASHBOARD);
     if (FULL_DASHBOARD_INFLIGHT?.generation === generation) {
@@ -288,7 +307,7 @@
         cache: triggeredByUser || retry ? "no-store" : "no-cache",
       });
       if (!response.ok) throw new Error("dashboard HTTP " + response.status);
-      const value = await response.json();
+      const value = _unpackSnapshots(await response.json());
       if (_generation(value) !== generation) {
         // The live origin caches each file independently for 300 s, so the two
         // halves of one generation can be minutes apart at the edge. `no-store`

--- a/src/clawock/publish/artifacts.py
+++ b/src/clawock/publish/artifacts.py
@@ -895,6 +895,23 @@ def validate_dashboard(
         'concentration must be an object')
     assert isinstance(data['snapshots'], list), 'snapshots must be a list'
     assert data['snapshots'], 'snapshots is empty — dashboard would render blank'
+    # Column-packed since #1215. The list assertion above still holds and is now
+    # too weak on its own: a ragged row would shift every later value one field
+    # to the left, which reads as a plausible equity curve rather than as a
+    # fault. Decode and check the shape the page will actually see.
+    from clawock.publish.dashboard import snapshots_of
+    _columns = data.get('snapshots_columns')
+    if _columns:
+        assert isinstance(_columns, list) and all(
+            isinstance(name, str) and name for name in _columns), (
+            'snapshots_columns must be a list of field names')
+        assert all(isinstance(row, list) and len(row) == len(_columns)
+                   for row in data['snapshots']), (
+            'a packed snapshot row does not match snapshots_columns — every '
+            'field after the gap would be read as the wrong metric')
+    _rows = snapshots_of(data)
+    assert _rows and all(row.get('date') for row in _rows), (
+        'every snapshot must decode to a row with a date')
     assert isinstance(data['decision_metrics'], dict), (
         'decision_metrics must be an object')
     assert isinstance(data['decision_delta'], dict), (

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -456,6 +456,74 @@ def serialize_dashboard_payload(value):
     return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
 
 
+SNAPSHOTS_PACKED_COLUMNS_KEY = 'snapshots_columns'
+
+
+def pack_snapshots(rows):
+    """Row dicts -> (column names, row value lists). Identity, not a summary.
+
+    The equity series was 18% of `dashboard.json` and 58% of that was the same
+    eighteen field names repeated on every row: `us_total_value`,
+    `hk_today_change`, `us_realized` and the rest, 262 bytes of key against 187
+    bytes of value (measured 2026-08-31, 79 rows, 449 bytes each). It is the
+    only section that grows by a row every trading day, so it is what walks the
+    payload into the cap — and the cap's only answer was to delete the oldest
+    rows, i.e. to pay for the field names with 46 days of curve.
+
+    Naming the columns once turns ~35.5KB into ~15KB and buys roughly forty
+    trading days of headroom without dropping a single point. `snapshots` stays
+    a non-empty list so the published-shape assertions still hold; the browser
+    rebuilds the dicts on load, so no consumer sees the wire form.
+
+    A row missing a column gets None rather than a shortened list: a ragged row
+    would silently shift every later value into the wrong field.
+    """
+    rows = [row for row in rows or [] if isinstance(row, dict)]
+    if not rows:
+        return [], []
+    columns = []
+    for row in rows:
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+    return columns, [[row.get(name) for name in columns] for row in rows]
+
+
+def unpack_snapshots(columns, rows):
+    """The inverse. Used by the readers that consume a published payload."""
+    columns = list(columns or [])
+    if not columns:
+        return [row for row in rows or [] if isinstance(row, dict)]
+    return [dict(zip(columns, row)) for row in rows or [] if isinstance(row, list)]
+
+
+def snapshots_of(payload):
+    """Row dicts out of a published dashboard payload, packed or not.
+
+    Every reader of a *published* `snapshots` goes through here, so the two
+    encodings cannot drift into two code paths — the mistake that this file
+    already made once with the fingerprint tuple.
+    """
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get('snapshots') or []
+    return unpack_snapshots(payload.get(SNAPSHOTS_PACKED_COLUMNS_KEY), rows)
+
+
+def dashboard_wire_payload(out):
+    """Serialize the dashboard document with the equity series column-packed.
+
+    `out` is not mutated: `compile_overview_projection` reads `out['snapshots']`
+    as row dicts, and the size levers measure the *wire* bytes, so the two have
+    to see different shapes of the same data at the same moment.
+    """
+    columns, rows = pack_snapshots(out.get('snapshots'))
+    if not columns:
+        return serialize_dashboard_payload(out)
+    return serialize_dashboard_payload(
+        {**out, SNAPSHOTS_PACKED_COLUMNS_KEY: columns, 'snapshots': rows})
+
+
 def _guardrail_sections(portfolio, risk, lev_regime=None):
     from clawock.portfolio.guardrail import (
         compute_breakeven_math,
@@ -3580,7 +3648,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     # dashboard.json is the canonical cross-tab browser document. Keep it compact:
     # detail activation still pays this parse, and producers should not spend
     # recovered headroom on indentation that adds no user value.
-    payload = serialize_dashboard_payload(out)
+    payload = dashboard_wire_payload(out)
     size_bytes = len(payload.encode('utf-8'))
 
     if size_bytes > MAX_OUT_BYTES:
@@ -3588,7 +3656,7 @@ def build_projection(previous_source=None, shadow_previous=None):
         print(f'⚠️  payload still {size_bytes} bytes > {MAX_OUT_BYTES} cap — dropping recent_plans', file=sys.stderr)
         out['recent_plans'] = []
         out['recent_plans_dropped'] = True
-        payload = serialize_dashboard_payload(out)
+        payload = dashboard_wire_payload(out)
         size_bytes = len(payload.encode('utf-8'))
         if size_bytes > MAX_OUT_BYTES:
             # Second lever: shorten the embedded snapshot series from the OLD
@@ -3609,7 +3677,7 @@ def build_projection(previous_source=None, shadow_previous=None):
                 kept.pop(0)
                 dropped += 1
                 out['snapshots'] = kept
-                payload = serialize_dashboard_payload(out)
+                payload = dashboard_wire_payload(out)
                 size_bytes = len(payload.encode('utf-8'))
             if dropped:
                 # Recorded IN the payload, not only on stderr: `recent_plans`
@@ -3617,7 +3685,7 @@ def build_projection(previous_source=None, shadow_previous=None):
                 # degradation that lives only in a build log is one no gate can
                 # read back.
                 out['snapshots_trimmed_for_budget'] = dropped
-                payload = serialize_dashboard_payload(out)
+                payload = dashboard_wire_payload(out)
                 size_bytes = len(payload.encode('utf-8'))
                 print(f'⚠️  dropped the {dropped} oldest snapshot(s) to fit the '
                       f'{MAX_OUT_BYTES} cap — now {size_bytes} bytes', file=sys.stderr)
@@ -3626,6 +3694,30 @@ def build_projection(previous_source=None, shadow_previous=None):
             # publishing, but say so — on 2026-07-28 the file shipped 3.7KB over
             # the cap with only the line above to show for it, which reads as
             # "handled".
+            #
+            # Recorded IN the payload as well (#1215). A stderr line reaches no
+            # gate: not the build card, not the cron log, not watchdog.jsonl. So
+            # the 2026-07-28 breach was invisible to everything that could have
+            # acted on it, and "publishing over cap" was a decision nothing
+            # downstream could see had been taken. `recent_plans_dropped` and
+            # `snapshots_trimmed_for_budget` already live here for this reason;
+            # the terminal case was the one that did not.
+            #
+            # Writing it grows the payload by ~60 bytes, which is the right
+            # trade in a branch that is already over: a breach that is 60 bytes
+            # worse and legible beats one that is silent.
+            # `bytes` is the size with both levers spent and before this marker
+            # was added, which is a fixed number; recording the post-marker size
+            # would be a value that changes itself.
+            out['payload_over_cap'] = {
+                'bytes': size_bytes,
+                'cap': MAX_OUT_BYTES,
+                'over_by': size_bytes - MAX_OUT_BYTES,
+                'levers_spent': ['recent_plans', 'snapshots'],
+                'measured': 'before this marker was written',
+            }
+            payload = dashboard_wire_payload(out)
+            size_bytes = len(payload.encode('utf-8'))
             print(f'⚠️  payload STILL {size_bytes} bytes > {MAX_OUT_BYTES} cap after '
                   f'dropping recent_plans and trimming snapshots — publishing over cap',
                   file=sys.stderr)

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -122,9 +122,15 @@ async function waitForData(page) {
 async function waitForTab(page, tab) {
   await page.waitForFunction(tab => {
     const panel = document.querySelector(`.panel[data-panel="${tab}"]`);
+    // Rows, not merely an array (#1215): the equity series ships column-packed
+    // and `Array.isArray` is true of both shapes, so the old check would have
+    // gone on passing with the loader's unpack removed and every chart blank.
+    const snaps = DATA?.snapshots;
     const coreReady = tab === "hero"
       ? DATA?.projection === "overview"
-      : Array.isArray(DATA?.snapshots);
+      : Array.isArray(snaps) && snaps.length > 0 &&
+        snaps.every(row => row && typeof row === "object" &&
+                    !Array.isArray(row) && typeof row.date === "string");
     return panel?.classList.contains("active") &&
       coreReady &&
       !panel.hasAttribute("aria-busy") &&

--- a/tests/test_dashboard_budget_and_benchmark_freshness.py
+++ b/tests/test_dashboard_budget_and_benchmark_freshness.py
@@ -140,3 +140,78 @@ def test_the_writer_publishes_the_block(system_check):
     assert rows["SPY"]["last_session"] == "2026-08-21"
     assert rows["SPY"]["expected_lag_sessions"] == 1
     assert isinstance(rows["SPY"]["sessions_behind"], int)
+
+
+# ── the cap was a tripwire, not a gate (#1215) ──────────────────────────────
+
+def test_packing_the_equity_series_is_lossless():
+    """Identity, not a summary. The trim lever deletes days; this deletes bytes.
+
+    `snapshots_of` is the only decoder, so the assertion is that a real row set
+    survives a round trip exactly — including a row that is missing a field the
+    others have, which is where a ragged encoding would silently shift every
+    later value one column to the left.
+    """
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    rows = [
+        {"date": "2026-01-02", "us_total_value": 1.5, "hk_cash": None},
+        {"date": "2026-01-03", "us_total_value": 2.0, "hk_cash": 7,
+         "hk_late_arrival": "x"},
+    ]
+    columns, packed = dash.pack_snapshots(rows)
+    assert all(isinstance(row, list) for row in packed)
+    assert all(len(row) == len(columns) for row in packed), 'no ragged rows'
+
+    payload = {"snapshots": packed, dash.SNAPSHOTS_PACKED_COLUMNS_KEY: columns}
+    decoded = dash.snapshots_of(payload)
+    assert decoded[1]["hk_late_arrival"] == "x"
+    assert decoded[0]["hk_late_arrival"] is None, (
+        'a field one row lacks must decode to None, not shift the row')
+    assert [{k: v for k, v in row.items() if v is not None or k in rows[i]}
+            for i, row in enumerate(decoded)] == rows
+
+
+def test_an_unpacked_payload_still_reads(monkeypatch):
+    """Every generation published before this change is still readable."""
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    legacy = {"snapshots": [{"date": "2026-01-02", "us_equity": 3}]}
+    assert dash.snapshots_of(legacy) == legacy["snapshots"]
+
+
+def test_packing_is_what_the_size_levers_measure():
+    """The saving has to be real at the point the cap is enforced.
+
+    Measuring the unpacked dict and publishing the packed one would make the
+    levers fire on a size nobody ships — the same class of mistake as #743,
+    where the gate measured a re-serialized copy.
+    """
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    out = {"snapshots": [
+        {"date": f"2026-01-{i:02d}", "us_total_value": 1000.0 + i,
+         "us_total_cost": 900.0, "hk_total_value": 2000.0,
+         "hk_today_change": -1.0, "hk_realized": 3.0}
+        for i in range(1, 41)]}
+    packed = len(dash.dashboard_wire_payload(out).encode("utf-8"))
+    plain = len(dash.serialize_dashboard_payload(out).encode("utf-8"))
+    assert packed < plain * 0.6, (
+        f'packing saved only {plain - packed} of {plain} bytes; the field names '
+        f'were more than half this section')
+    assert dash.snapshots_of(json.loads(dash.dashboard_wire_payload(out))) == \
+        out["snapshots"], 'the wire form must decode back to what was measured'
+
+
+def test_a_breach_is_recorded_in_the_payload_not_only_on_stderr(monkeypatch):
+    """2026-07-28 shipped 3.7KB over the cap and nothing downstream could tell.
+
+    stderr reaches no gate — not the build card, not the cron log, not
+    watchdog.jsonl — so "publishing over cap" was a decision that left no trace
+    a reader could act on.
+    """
+    dash = pytest.importorskip("clawock.publish.dashboard")
+    source = (ROOT / "src" / "clawock" / "publish" / "dashboard.py").read_text(
+        encoding="utf-8")
+    assert "out['payload_over_cap']" in source, (
+        'the terminal over-cap case must record itself in the payload')
+    marker = source.split("out['payload_over_cap'] = {", 1)[1].split('}', 1)[0]
+    for field in ('bytes', 'cap', 'over_by', 'levers_spent'):
+        assert f"'{field}'" in marker, f'{field} must be in the marker'


### PR DESCRIPTION

`dashboard.json` was 196,872 bytes against a 200,000-byte cap this morning —
1.6% of headroom, and the only section that grows every trading day is the
equity series. The builder's own comment predicted the date: "the cap arrives in
~9 trading days and then stays breached". What happens then is two levers and a
shrug — drop `recent_plans`, trim snapshots from the old end down to a floor of
30, and if that is not enough, print a line on stderr and publish over the cap
anyway.

Where the bytes actually were
-----------------------------
Measured, not assumed: 79 snapshot rows, 449 bytes each, of which **262 were
field names**. `us_total_value`, `hk_today_change`, `us_realized` and fifteen
more, repeated on every row — 58% of the largest section in the document. The
trim lever was deleting days of equity curve to pay for repeated strings.

So the series ships column-packed: `snapshots_columns` names the fields once and
`snapshots` becomes rows of values. On the payload published this morning, byte
for byte the same data, that is **196,872 → 176,458, a saving of 20,414 bytes**,
which takes the document from 98.4% of the cap to 88.2% and turns ~6 trading
days of headroom into well over a hundred. No row is dropped and no value
changes: `snapshots_of()` decodes the published form and returns exactly the row
dicts that were published before, asserted against this morning's real payload.

`snapshots` is still a non-empty list, so the published-shape assertions still
mean what they meant. The browser rebuilds the dicts once, at the single place
the document enters the page, so all six readers of `DATA.snapshots` are
untouched — there is no second shape for one of them to forget about.

The terminal case now leaves a trace
------------------------------------
Both levers spent and still over cap wrote one line to stderr, which reaches no
gate: not the build card, not the cron log, not `watchdog.jsonl`. That is how
2026-07-28 shipped 3.7KB over the cap and read as "handled". It records
`payload_over_cap` in the payload now — bytes, cap, over_by, which levers were
spent — the way `recent_plans_dropped` and `snapshots_trimmed_for_budget`
already do.

Verification
------------
* `test_packing_the_equity_series_is_lossless` — round trip, including a row
  missing a field the others have, which is where a ragged encoding would shift
  every later value one column left and still look like an equity curve.
* `test_packing_is_what_the_size_levers_measure` — the levers measure the wire
  form. Measuring one shape and publishing another is #743 again.
* `test_an_unpacked_payload_still_reads` — every generation published before
  this stays readable.
* The browser contract was run against the real published payload, packed: all
  charts render. Its readiness check asserted only `Array.isArray(DATA.snapshots)`,
  which is true of both shapes — it would have gone on passing with the loader's
  unpack deleted and every chart blank. It now asserts rows, and was verified to
  fail (30s timeout) with the unpack removed.

Closes #1215

