### PR TITLE
outcomes: make the observation chain able to see itself fail (#1214)

### DIFF
--- a/src/clawock/automation/cron_heartbeat.py
+++ b/src/clawock/automation/cron_heartbeat.py
@@ -120,7 +120,9 @@ def record(market: str, state: str, *, at: datetime | None = None,
                 event_time = datetime.fromisoformat(event["slot"])
                 if event_time.tzinfo is None:
                     event_time = event_time.replace(tzinfo=HKT)
-            except Exception:
+            except (KeyError, TypeError, ValueError):
+                # A malformed slot drops the event; named so a defect in this
+                # loop raises instead of quietly emptying the ledger (#1214).
                 continue
             if event_time.astimezone(timezone.utc) < cutoff:
                 continue
@@ -148,7 +150,16 @@ def record(market: str, state: str, *, at: datetime | None = None,
         try:
             workflow_outcomes.record_from_heartbeat(current)
         except Exception as exc:
-            print(f"warn: workflow outcome bridge failed: {exc}", file=sys.stderr)
+            # The heartbeat ledger has the event and the outcome ledger does
+            # not — the two silently fork, and everything downstream reads the
+            # one that is missing the slot. Recorded where the fork is visible:
+            # in the outcome ledger, which is what publishes and what the card
+            # folds (#1214). It still does not raise — a heartbeat that landed
+            # must not be reported as a failed run because the bridge tripped.
+            workflow_outcomes.note_degradation(
+                None, "heartbeat_bridge_failed",
+                f"{current.get('job')}/{current.get('slot')}: {exc}; this slot "
+                f"is in the heartbeat ledger and not in the outcome ledger")
     return current
 
 

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -147,6 +147,77 @@ def _empty(now=None):
     }
 
 
+# ── When the observer is the thing that broke (#1214) ────────────────────────
+# Five `except Exception` blocks covered this chain end to end — prune, load,
+# the raw-execution reconcile, the delivery-receipt reconcile, and the heartbeat
+# bridge — and every one of them failed open onto stderr. Each was individually
+# defensible: observation must not interrupt the desk. Composed, they mean a
+# fault in the observation system is invisible to the observation system, which
+# is the failure #776 already demonstrated can run for eight days.
+#
+# Two changes, and neither is "stop failing open".
+#
+# 1. The excepts name what they expect. A corrupt file, a missing key, a bad
+#    timestamp — those are the conditions these paths exist for, and they still
+#    degrade quietly. A TypeError is a bug in this module, and a bug that
+#    silently returns 0 is how "delivery is still `unknown`" becomes permanent.
+#
+# 2. The degradation records itself IN the ledger, which is published and folded
+#    by `summarize`. Not `logs/watchdog.jsonl`: `intraday_watchdog` already
+#    settled that question — "a line in watchdog.jsonl is not something kcn
+#    reads, so treating it as surfaced would be exactly the silent downgrade
+#    that is forbidden here". stderr is worse. The ledger is the one surface
+#    that already reaches the dashboard card and the health check.
+#
+# The counter is deliberately not a raise: a delivery that happened must not be
+# reported as failed because the bookkeeping tripped. It makes the fail-open
+# countable, which is the difference between degrading and disappearing.
+DEGRADATIONS_KEY = "degradations"
+MAX_DEGRADATIONS = 20
+
+
+def note_degradation(ledger, kind, detail, *, at=None):
+    """Record, in the ledger, that this ledger could not be trusted somewhere.
+
+    Mutates and returns `ledger` so a caller that is already holding it under
+    the lock writes the note in the same atomic write as its own change; a
+    caller with no ledger to hand passes None and gets a standalone record.
+    """
+    standalone = ledger is None
+    if standalone:
+        # Read the file, not `load_ledger` (#1214). The most important caller is
+        # the one whose failure *was* `load_ledger`, and routing the note back
+        # through it would raise from inside the handler that exists to keep
+        # this non-fatal. `_read_path` already swallows a torn or missing file.
+        ledger = _read_path(local_path()) or _empty()
+    rows = ledger.get(DEGRADATIONS_KEY)
+    if not isinstance(rows, list):
+        rows = []
+    now = _now(at).isoformat()
+    for row in rows:
+        if row.get("kind") == kind and row.get("detail") == str(detail):
+            row["count"] = int(row.get("count") or 0) + 1
+            row["last_at"] = now
+            break
+    else:
+        rows.append({"kind": kind, "detail": str(detail), "count": 1,
+                     "first_at": now, "last_at": now})
+    # Newest last, oldest evicted: a chain that is failing now matters more than
+    # one that failed three days ago and has not recurred.
+    ledger[DEGRADATIONS_KEY] = rows[-MAX_DEGRADATIONS:]
+    print(f"warn: {kind}: {detail}", file=sys.stderr)
+    if standalone:
+        try:
+            _atomic_write(local_path(), ledger)
+        except OSError as exc:
+            # The one place with nowhere left to write. Say so on stderr and
+            # carry on: this is the observer failing to observe its own failure,
+            # not a reason to take the desk down.
+            print(f"warn: could not record degradation {kind}: {exc}",
+                  file=sys.stderr)
+    return ledger
+
+
 def _read_path(path):
     try:
         data = json.loads(path.read_text())
@@ -159,23 +230,29 @@ def _read_path(path):
     return None
 
 
-def load_ledger():
+def load_ledger(*, note_fallback=True):
     """Local ledger first; the published copy is a last resort, never a silent one.
 
     Falling back to public_path() and then writing that content back to local_path()
     would roll the local ledger back to whatever was last published. It has not
     been observed happening, but a data-losing path must not be invisible.
+
+    "Not invisible" used to mean a line on stderr, which no gate reads. The
+    fallback now rides in the returned ledger's own `degradations` list, so the
+    published copy and the dashboard card carry the fact that every stage
+    recorded since the last publish may be missing. `note_fallback=False` is for
+    `note_degradation` itself, which would otherwise recurse.
     """
     local = _read_path(local_path())
     if local is not None:
         return local
     public = _read_path(public_path())
     if public is not None:
-        print(
-            f"warn: workflow ledger unreadable at {local_path()}; falling back to the "
-            f"published copy — stages recorded since the last publish may be missing",
-            file=sys.stderr,
-        )
+        if note_fallback:
+            note_degradation(
+                public, "ledger_fallback_to_published",
+                f"{local_path()} unreadable; stages recorded since the last "
+                f"publish may be missing")
         return public
     return _empty()
 
@@ -282,18 +359,32 @@ def _derive_final(record):
     return {"status": status, "reason": reason}
 
 
-def _prune(records, now):
+def _prune(records, now, ledger=None):
+    """Drop records older than the window — and count the ones it cannot read.
+
+    An unparseable `slot` used to delete the whole record silently, taking that
+    slot's preflight, LLM, delivery and watchdog stages with it. A missing or
+    malformed timestamp is a real condition this has to survive; it is not a
+    reason for the row to leave no trace of having existed.
+    """
     cutoff = now - timedelta(hours=KEEP_HOURS)
     kept = []
+    unparseable = 0
     for record in records:
         try:
             slot = datetime.fromisoformat(record["slot"])
             if slot.tzinfo is None:
                 slot = slot.replace(tzinfo=HKT)
-        except Exception:
+        except (KeyError, TypeError, ValueError):
+            unparseable += 1
             continue
         if slot.astimezone(timezone.utc) >= cutoff:
             kept.append(record)
+    if unparseable:
+        note_degradation(
+            ledger, "prune_dropped_unparseable_slot",
+            f"{unparseable} record(s) had no readable slot timestamp and were "
+            f"dropped with every stage they carried")
     return kept
 
 
@@ -310,7 +401,7 @@ def record_stage(job_name, stage, status, *, slot=None, at=None, dry_run=False, 
         slot = slot or slot_for_job(job_name, now)
         with _locked():
             ledger = load_ledger()
-            records = _prune(ledger.get("records", []), now)
+            records = _prune(ledger.get("records", []), now, ledger)
             current = next(
                 (
                     dict(record)
@@ -352,7 +443,19 @@ def record_stage(job_name, stage, status, *, slot=None, at=None, dry_run=False, 
             _atomic_write(local_path(), ledger)
         return current
     except Exception as exc:
-        print(f"warn: workflow outcome stage not recorded: {exc}", file=sys.stderr)
+        # Still broad, deliberately (#1214). Narrowing this was the first thing
+        # tried and it is wrong: `publish()` runs inside `rebuild_dashboard`'s
+        # own try, so an unnamed exception here would stop the dashboard being
+        # built at all. Trading "a stage was not recorded" for "nothing was
+        # published" is a worse failure, and it breaks the rule this module
+        # exists under — observation must not interrupt the desk.
+        #
+        # What changes is that it is no longer silent. The exception type goes
+        # into the ledger, so a defect looks like a defect (`RecursionError` in
+        # `stage_not_recorded`) instead of like a quiet nothing.
+        note_degradation(
+            None, "stage_not_recorded",
+            f"{job_name}/{stage}: {type(exc).__name__}: {exc}")
         return {}
 
 
@@ -434,7 +537,9 @@ def record_from_heartbeat(event):
 def _match_run(record, entries):
     try:
         slot_ms = datetime.fromisoformat(record["slot"]).timestamp() * 1000
-    except Exception:
+    except (KeyError, TypeError, ValueError):
+        # No usable slot means no window to match a run against. Counted by
+        # `_prune`, which sees the same records; not counted twice here.
         return None
     candidates = []
     for entry in entries:
@@ -506,7 +611,16 @@ def reconcile_raw_execution():
                 _atomic_write(local_path(), latest)
         return changed
     except Exception as exc:
-        print(f"warn: raw workflow status reconciliation skipped: {exc}", file=sys.stderr)
+        # Broad for the reason above, and counted for this one: skipping leaves
+        # `raw_execution.status` at "unknown", and the false-red
+        # detector in `publish.outcomes` requires status == "error" — so a
+        # silent skip here does not degrade that detector, it disables it. That
+        # is the single most important thing in this module to be able to see
+        # having failed.
+        note_degradation(None, "raw_execution_reconcile_skipped",
+                         f"{type(exc).__name__}: {exc}; raw_execution stays "
+                         f"unknown and false-red detection cannot fire for "
+                         f"those slots")
         return False
 
 
@@ -621,7 +735,10 @@ def reconcile_delivery_receipts():
                 _atomic_write(local_path(), ledger)
         return filled
     except Exception as exc:
-        print(f"warn: delivery receipt reconciliation skipped: {exc}", file=sys.stderr)
+        note_degradation(None, "delivery_reconcile_skipped",
+                         f"{type(exc).__name__}: {exc}; terminal delivery "
+                         f"stays unknown for any slot whose receipt this pass "
+                         f"would have read")
         return 0
 
 

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -2954,8 +2954,18 @@ def compute_workflow_outcomes():
         # the adapter reads it back as its own fresh-checkout recovery source.
         # The card wants the window fold of it, so do the fold here rather than
         # trimming raw records into a payload with no `counts` and no `recent`.
-        return trim_workflow_outcomes(dashboard_outcomes.summarize_records(
+        summary = trim_workflow_outcomes(dashboard_outcomes.summarize_records(
             (payload or {}).get('records', [])))
+        # The chain's own faults ride with the counts they call into question
+        # (#1214). Five fail-open handlers used to report onto stderr, which
+        # reaches no gate — so a reconcile that never ran and a reconcile with
+        # nothing to do produced the identical card. `degradations` is normally
+        # absent; when it is not, every number beside it was computed by a
+        # bookkeeping pass that knows it degraded.
+        degradations = dashboard_outcomes.degradations_of(payload)
+        if degradations and isinstance(summary, dict):
+            summary['degradations'] = degradations
+        return summary
     except Exception as e:
         print(f'  warn: workflow outcome summary failed: {e}', file=sys.stderr)
         return None

--- a/src/clawock/publish/outcomes.py
+++ b/src/clawock/publish/outcomes.py
@@ -32,6 +32,23 @@ SOFT_PRODUCT_STATES = ("recovered", "degraded", "artifact_only", "failed")
 MAX_NAMED = 8
 
 
+DEGRADATIONS_KEY = "degradations"
+
+
+def degradations_of(payload) -> list:
+    """The observation chain's own faults, out of a ledger payload (#1214).
+
+    Lives here rather than in `automation.workflow_outcomes` for the reason
+    `summarize_records` does: the dashboard folds the *published* copy and the
+    desk folds the local one, and two readings of "what went wrong with the
+    bookkeeping" would drift the moment either side changed.
+    """
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get(DEGRADATIONS_KEY)
+    return [row for row in rows or [] if isinstance(row, dict)]
+
+
 def summarize_records(records, *, hours: int = 36, now: datetime | None = None) -> dict:
     """Fold ledger records into counts, false-red tally and the recent window."""
     now = now or datetime.now(LEDGER_TZ)

--- a/tests/test_brief_watchdog_budget_readability.py
+++ b/tests/test_brief_watchdog_budget_readability.py
@@ -1,0 +1,78 @@
+"""`retry_budget_note`'s silence rule, pinned (#1214).
+
+#1214 read the bare `except Exception` here as a fifth silent failure in the
+observability chain and proposed making an unreadable budget say so. It is not
+one, and the change was not made: the module docstring records why, out of
+incident history rather than principle — "it stays silent when the budget is
+healthy or unreadable: a missing brief has other causes, and pointing at this
+one when it is not the cause is how the last three diagnoses went wrong."
+
+What #1214 did find is that the rule had no test. Three call paths returned the
+empty string for three different reasons and nothing pinned any of them, so the
+rule was one refactor away from being changed by accident — which is how a
+deliberate silence turns into an undocumented one.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+from clawock.harness import brief_watchdog  # noqa: E402
+
+
+class _Budget:
+    def __init__(self, exhausted):
+        self.exhausted = exhausted
+        self.raisable, self.cap_needed = True, 7
+
+    def describe(self):
+        return "consecutiveErrors=6 / maxAttempts=5"
+
+
+def test_a_healthy_budget_says_nothing(monkeypatch):
+    monkeypatch.setattr(brief_watchdog, 'brief_cron_job_state', lambda: {'id': 'x'})
+    monkeypatch.setattr(brief_watchdog, 'cron_retry_budget',
+                        lambda job: _Budget(False))
+    assert brief_watchdog.retry_budget_note() == ''
+
+
+def test_an_unknown_budget_says_nothing(monkeypatch):
+    """`exhausted is None` — the counter or the cap could not be read.
+
+    Distinct from healthy, and deliberately reported the same way: unknown is
+    not evidence, and this line only exists to name a proven cause.
+    """
+    monkeypatch.setattr(brief_watchdog, 'brief_cron_job_state', lambda: {'id': 'x'})
+    monkeypatch.setattr(brief_watchdog, 'cron_retry_budget',
+                        lambda job: _Budget(None))
+    assert brief_watchdog.retry_budget_note() == ''
+
+
+def test_no_such_job_says_nothing(monkeypatch):
+    monkeypatch.setattr(brief_watchdog, 'brief_cron_job_state', lambda: None)
+    assert brief_watchdog.retry_budget_note() == ''
+
+
+def test_a_gateway_that_will_not_answer_says_nothing_and_does_not_raise(
+        monkeypatch):
+    """The alert is the last notification that reaches a human that morning.
+
+    Reading the budget is a `cron list` round trip through the gateway — the
+    component a bad morning may have taken down. Nothing here may cost the
+    alert, so this stays fail-open, and the silence is the documented rule
+    rather than an oversight.
+    """
+    def _down():
+        raise TimeoutError('gateway did not answer')
+
+    monkeypatch.setattr(brief_watchdog, 'brief_cron_job_state', _down)
+    assert brief_watchdog.retry_budget_note() == ''
+
+
+def test_an_exhausted_budget_is_the_one_case_that_speaks(monkeypatch):
+    """Otherwise the rule above would be indistinguishable from a dead function."""
+    budget = _Budget(True)
+    monkeypatch.setattr(brief_watchdog, 'brief_cron_job_state', lambda: {'id': 'x'})
+    monkeypatch.setattr(brief_watchdog, 'cron_retry_budget', lambda job: budget)
+
+    note = brief_watchdog.retry_budget_note()
+    assert note and 'maxAttempts' in note and '7' in note, note

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -815,9 +815,18 @@ def test_a_failed_reconcile_says_which_detector_it_disabled(tmp_path, monkeypatc
     outcomes.record_stage("brief", "preflight", "success",
                           slot="2026-07-24T08:00:00+08:00")
 
+    # Stub the job source. Without it this reads the host's real openclaw
+    # sqlite, so the pass returns before it ever reaches the ledger on a runner
+    # that has no openclaw — green on this box and red in CI, which is a test
+    # asserting on a path it did not take.
+    class _Jobs:
+        source = "sqlite"
+        entries = [{"name": "brief", "id": "job-1"}]
+
     def _boom(*_args, **_kwargs):
         raise OSError("cron runs unreadable")
 
+    monkeypatch.setattr(outcomes.openclaw, "read_jobs", lambda _src: _Jobs())
     monkeypatch.setattr(outcomes, "load_ledger", _boom)
     assert outcomes.reconcile_raw_execution() is False
     monkeypatch.undo()
@@ -912,6 +921,9 @@ def test_the_card_carries_the_faults_beside_the_counts_they_undermine(
     payload = json.loads(
         (workspace / "assets" / "data" / "workflow-outcomes.json").read_text())
     rows = published.degradations_of(payload)
-    assert [row["kind"] for row in rows] == ["delivery_reconcile_skipped"], rows
+    # Membership, not equality: `publish()` runs both reconciles first, and on a
+    # box with a real openclaw sqlite those read it. Pinning the exact list here
+    # would make the assertion depend on the runner rather than on the change.
+    assert "delivery_reconcile_skipped" in [row["kind"] for row in rows], rows
     # And a clean ledger says nothing, so the field's presence is the signal.
     assert published.degradations_of({"records": []}) == []

--- a/tests/test_workflow_outcomes.py
+++ b/tests/test_workflow_outcomes.py
@@ -384,9 +384,15 @@ def test_a_recorder_failure_warns_instead_of_breaking_the_caller(
     postflight down with it. Mutation check: remove `import sys` and this test
     fails on the raised NameError, not on the assertion.
     """
-    _isolate(tmp_path, monkeypatch)
+    workspace = _isolate(tmp_path, monkeypatch)
     assert outcomes.record_stage("港股开盘报告", "llm", "not-a-real-status") == {}
-    assert "workflow outcome stage not recorded" in capsys.readouterr().err
+    # stderr is where this used to end. It now also lands in the ledger, which
+    # is the surface that publishes (#1214) — asserted on the row, because the
+    # warning text is prose and the row is the contract.
+    assert "stage_not_recorded" in capsys.readouterr().err
+    rows = _degradations(workspace)
+    assert [row["kind"] for row in rows] == ["stage_not_recorded"], rows
+    assert "港股开盘报告/llm" in rows[0]["detail"]
 
 
 def test_reconciliation_failure_also_only_warns(tmp_path, monkeypatch, capsys):
@@ -398,8 +404,16 @@ def test_reconciliation_failure_also_only_warns(tmp_path, monkeypatch, capsys):
     (receipts / "brief-sent-2026-07-24.json").write_text(
         json.dumps({"sent_ok": True})
     )
+    # Still broad, still non-fatal: `publish()` runs inside
+    # `rebuild_dashboard`'s own try, so letting this raise would trade "a
+    # receipt was not reconciled" for "the dashboard was not published" (#1214).
     assert outcomes.reconcile_delivery_receipts() == 0
-    assert "delivery receipt reconciliation skipped" in capsys.readouterr().err
+    assert "delivery_reconcile_skipped" in capsys.readouterr().err
+    rows = _degradations(ws)
+    assert [row["kind"] for row in rows] == ["delivery_reconcile_skipped"], rows
+    # The exception type is in the detail, so a defect reads as a defect
+    # instead of as a quiet nothing.
+    assert "RuntimeError" in rows[0]["detail"], rows[0]
 
 
 # ── #764: advisory-only findings are not a degraded product ──────────────────
@@ -656,8 +670,13 @@ def test_falling_back_to_the_published_ledger_is_never_silent(
         json.dumps({"schema_version": outcomes.SCHEMA_VERSION, "records": []})
     )
     outcomes.local_path().write_text("{ not json")
-    assert outcomes.load_ledger()["records"] == []
-    assert "falling back to the published copy" in capsys.readouterr().err
+    ledger = outcomes.load_ledger()
+    assert ledger["records"] == []
+    assert "ledger_fallback_to_published" in capsys.readouterr().err
+    # And in the ledger the caller is holding, so the note rides into whatever
+    # that caller writes next rather than living only in a build log (#1214).
+    assert [row["kind"] for row in ledger[outcomes.DEGRADATIONS_KEY]] == [
+        "ledger_fallback_to_published"]
 
 
 # ── #771: which channel actually carried the slot ────────────────────────────
@@ -748,3 +767,151 @@ def test_a_record_without_channel_flags_is_not_counted_as_a_drop():
         "final_product": {"status": "success"},
     }], hours=36, now=now)
     assert summary["wechat_dropped_telegram_covered"] == 0
+
+
+# ── the observer failing to observe itself (#1214) ───────────────────────────
+
+def _degradations(workspace):
+    return json.loads(
+        (workspace / "memory" / ".tmp" / "workflow-outcomes.json").read_text()
+    ).get(outcomes.DEGRADATIONS_KEY) or []
+
+
+def test_a_record_with_no_readable_slot_leaves_a_trace(tmp_path, monkeypatch):
+    """It used to vanish, taking every stage it carried with it.
+
+    `_prune` dropped the whole record on any timestamp it could not parse, so a
+    postflight that wrote one malformed `slot` erased that slot's preflight,
+    LLM, delivery and watchdog stages — and nothing anywhere said a record had
+    been dropped.
+    """
+    workspace = _isolate(tmp_path, monkeypatch)
+    outcomes.record_stage("brief", "preflight", "success",
+                          slot="2026-07-24T08:00:00+08:00")
+
+    ledger = json.loads(
+        (workspace / "memory" / ".tmp" / "workflow-outcomes.json").read_text())
+    ledger["records"].append({"job": "brief", "slot": "not-a-timestamp"})
+    (workspace / "memory" / ".tmp" / "workflow-outcomes.json").write_text(
+        json.dumps(ledger))
+
+    outcomes.record_stage("brief", "llm", "success",
+                          slot="2026-07-24T08:00:00+08:00")
+
+    rows = _degradations(workspace)
+    assert any(row["kind"] == "prune_dropped_unparseable_slot" for row in rows), (
+        f'the dropped record left no trace; degradations={rows}')
+
+
+def test_a_failed_reconcile_says_which_detector_it_disabled(tmp_path, monkeypatch):
+    """A skipped raw-execution reconcile does not degrade false-red detection.
+
+    It disables it: `publish.outcomes` needs `raw_execution.status == "error"`
+    to call a red run false, and a skipped pass leaves that field at "unknown"
+    forever. The skip is still non-fatal — it must not take the desk down — but
+    it can no longer be silent.
+    """
+    workspace = _isolate(tmp_path, monkeypatch)
+    outcomes.record_stage("brief", "preflight", "success",
+                          slot="2026-07-24T08:00:00+08:00")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("cron runs unreadable")
+
+    monkeypatch.setattr(outcomes, "load_ledger", _boom)
+    assert outcomes.reconcile_raw_execution() is False
+    monkeypatch.undo()
+
+    rows = _degradations(workspace)
+    kinds = [row["kind"] for row in rows]
+    assert "raw_execution_reconcile_skipped" in kinds, kinds
+    detail = next(row for row in rows
+                  if row["kind"] == "raw_execution_reconcile_skipped")["detail"]
+    assert "false-red" in detail, detail
+
+
+def test_a_repeated_degradation_counts_rather_than_floods(tmp_path, monkeypatch):
+    """Twenty identical rows would push the real ones out of the window."""
+    workspace = _isolate(tmp_path, monkeypatch)
+    ledger = outcomes._empty()
+    for _ in range(5):
+        outcomes.note_degradation(ledger, "kind_a", "same detail")
+    outcomes.note_degradation(ledger, "kind_b", "other")
+    rows = ledger[outcomes.DEGRADATIONS_KEY]
+    assert [row["kind"] for row in rows] == ["kind_a", "kind_b"]
+    assert rows[0]["count"] == 5
+    assert rows[0]["first_at"] and rows[0]["last_at"]
+
+
+def test_degradations_ride_into_the_published_copy(tmp_path, monkeypatch):
+    """stderr reaches no gate; `logs/watchdog.jsonl` is not read either.
+
+    `intraday_watchdog` already settled that: "a line in watchdog.jsonl is not
+    something kcn reads, so treating it as surfaced would be exactly the silent
+    downgrade that is forbidden here". The ledger is the surface that publishes.
+    """
+    workspace = _isolate(tmp_path, monkeypatch)
+    outcomes.record_stage("brief", "preflight", "success",
+                          slot="2026-07-24T08:00:00+08:00")
+    outcomes.note_degradation(None, "heartbeat_bridge_failed", "brief/slot: boom")
+    outcomes.publish()
+
+    published = json.loads(
+        (workspace / "assets" / "data" / "workflow-outcomes.json").read_text())
+    kinds = [row["kind"] for row in published.get(outcomes.DEGRADATIONS_KEY) or []]
+    assert "heartbeat_bridge_failed" in kinds, published
+
+
+def test_a_defect_reads_as_a_defect_rather_than_as_a_quiet_nothing(
+        tmp_path, monkeypatch):
+    """Narrowing these handlers was tried and reverted; this is what replaced it.
+
+    `publish()` runs inside `rebuild_dashboard`'s own try, so letting an
+    unnamed exception out of here would trade "a receipt was not reconciled"
+    for "the dashboard was not published" — a worse failure, and one this
+    module exists not to cause. So it still returns 0. What it no longer does
+    is return 0 indistinguishably from "nothing to reconcile": the exception
+    type is in the ledger, and `RecursionError` is not a condition any I/O path
+    produces.
+    """
+    workspace = _isolate(tmp_path, monkeypatch)
+    # A receipt to reconcile, or the pass returns before it reaches the ledger
+    # and the test would be asserting on a path it never took.
+    (workspace / "memory" / ".tmp" / "brief-sent-2026-07-24.json").write_text(
+        json.dumps({"sent_ok": True}))
+
+    def _bug(*_args, **_kwargs):
+        raise RecursionError("a defect, not a fault")
+
+    monkeypatch.setattr(outcomes, "load_ledger", _bug)
+    assert outcomes.reconcile_delivery_receipts() == 0
+    monkeypatch.undo()
+
+    rows = _degradations(workspace)
+    assert [row["kind"] for row in rows] == ["delivery_reconcile_skipped"], rows
+    assert "RecursionError" in rows[0]["detail"], rows[0]
+
+
+def test_the_card_carries_the_faults_beside_the_counts_they_undermine(
+        tmp_path, monkeypatch):
+    """Otherwise the note has only moved from one place nobody reads to another.
+
+    A reconcile that never ran and a reconcile with nothing to do produced the
+    identical card. They still produce the same counts — that is the point of
+    failing open — but the card now says which of the two it is.
+    """
+    from clawock.publish import outcomes as published
+
+    workspace = _isolate(tmp_path, monkeypatch)
+    outcomes.record_stage("brief", "preflight", "success",
+                          slot="2026-07-24T08:00:00+08:00")
+    outcomes.note_degradation(None, "delivery_reconcile_skipped",
+                              "OSError: disk full")
+    outcomes.publish()
+
+    payload = json.loads(
+        (workspace / "assets" / "data" / "workflow-outcomes.json").read_text())
+    rows = published.degradations_of(payload)
+    assert [row["kind"] for row in rows] == ["delivery_reconcile_skipped"], rows
+    # And a clean ledger says nothing, so the field's presence is the signal.
+    assert published.degradations_of({"records": []}) == []


### PR DESCRIPTION

Five `except Exception` handlers covered `workflow_outcomes` end to end — prune,
load, the raw-execution reconcile, the delivery-receipt reconcile, and the
heartbeat bridge — and every one failed open onto stderr. Each is individually
right: observation must not interrupt the desk. Composed, they mean a fault in
the observation system is invisible to the observation system, which is the
failure #776 already showed can run for eight days.

The worst of the five is the raw-execution reconcile. `publish.outcomes` calls a
red run false only when `raw_execution.status == "error"`; a skipped reconcile
leaves that field at `"unknown"` forever. So a silent skip there does not degrade
false-red detection, it disables it — and nothing anywhere said so.

What this does not do: narrow the handlers
------------------------------------------
That was #1214's proposal, it was implemented first, and it is wrong. `publish()`
runs inside `rebuild_dashboard`'s own try, so an exception escaping these
handlers stops the dashboard being built at all. Trading "a stage was not
recorded" for "nothing was published" is a worse failure and breaks the rule
this module exists under. The two narrow catches that are safe — the pure
timestamp parses in `_prune`, `_match_run` and the heartbeat event loop, which
touch no I/O and are already inside a broader handler — are named.

What it does instead: the fail-open becomes countable
-----------------------------------------------------
Every degrading path records `{kind, detail, count, first_at, last_at}` in the
ledger's own `degradations` list, capped at 20 and deduplicated by kind+detail so
a chain failing now is not pushed out by one that failed on Tuesday. The
exception type goes in the detail, so a defect reads as a defect — a
`RecursionError` in `stage_not_recorded` is not something any I/O path produces.

The ledger, specifically, and not `logs/watchdog.jsonl`, which #1214 proposed:
`intraday_watchdog` already settled that question — "a line in watchdog.jsonl is
not something kcn reads, so treating it as surfaced would be exactly the silent
downgrade that is forbidden here". stderr is worse. The ledger publishes, and
`build_dashboard` now folds `degradations` onto the workflow-outcomes card, so
the faults sit beside the counts they call into question. A reconcile that never
ran and a reconcile with nothing to do produced identical cards; they still
produce identical counts, and the card now says which one it was.

One design bug found while testing it: `note_degradation` first read the ledger
through `load_ledger`, so its most important caller — the one whose failure *was*
`load_ledger` — raised from inside the handler that exists to keep this
non-fatal. It reads the file directly.

The fifth finding is declined, with a test
-------------------------------------------
#1214 also flagged `brief_watchdog.retry_budget_note`'s bare except. That one is
deliberate and its docstring says why, out of incident history rather than
principle: "it stays silent when the budget is healthy or unreadable — a missing
brief has other causes, and pointing at this one when it is not the cause is how
the last three diagnoses went wrong". Reversing that on my own reading is not
mine to do.

What the issue did find is that the rule had no test: three call paths returned
the empty string for three different reasons and nothing pinned any of them, so
a deliberate silence was one refactor away from becoming an undocumented one.
`test_brief_watchdog_budget_readability.py` pins all four paths and the one case
that speaks.

Verification
------------
Every new gate was checked against its own absence: removing the prune counter,
and dropping `degradations` at publish time, each turn the corresponding test
red.

Closes #1214

