### PR TITLE
deps: bump @types/node 26.2.0 -> 26.4.0 (dsh plugin lockfile)

### DIFF
--- a/examples/dsh/packages/clawock-dsh/package-lock.json
+++ b/examples/dsh/packages/clawock-dsh/package-lock.json
@@ -1848,9 +1848,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Ports the diff from #1221 onto a regular branch so it can actually merge.

`@types/node` is a devDependency of the DSH plugin; the `^26.2.0` range in
`package.json` already admits 26.4.0, so this is a lockfile-only change.

Why not merge #1221 directly: CodeQL runs as default setup here, and on a
dependabot PR it produces a single neutral `CodeQL` check instead of the three
required `Analyze (...)` contexts — the ruleset then waits forever on checks
that will never appear. Same diff on a `claude/*` branch runs the full rollup.

Closes #1221.
