### PR TITLE
debate: publish the argument, not the count of arguments (#1117)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1489,6 +1489,31 @@
   }
   .bear-lbl.bl-fal   { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
   .bear-lbl.bl-watch { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
+  /* debate trail (#1117) — the argument, not just its count */
+  .dbt-case {
+    padding: var(--space-3); margin-bottom: 8px; border-radius: var(--radius-sm);
+    background: var(--card-2); border-left: 3px solid color-mix(in srgb, var(--accent) 50%, transparent);
+  }
+  .dbt-head {
+    display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; margin-bottom: 6px;
+  }
+  .dbt-tk { font-weight: 700; font-family: var(--mono); font-size: var(--fs-md); }
+  .dbt-side { display: flex; gap: 8px; align-items: flex-start; margin-top: 4px; }
+  .dbt-lbl {
+    flex: 0 0 auto; font-size: var(--fs-micro); font-weight: 700; padding: 2px 8px;
+    border-radius: 5px; margin-top: 2px;
+  }
+  .dbt-bull .dbt-lbl { background: color-mix(in srgb, var(--positive) 15%, transparent); color: var(--positive); }
+  .dbt-bear .dbt-lbl { background: color-mix(in srgb, var(--negative) 15%, transparent); color: var(--negative); }
+  .dbt-text { font-size: var(--fs-sm); line-height: 1.5; color: var(--text); }
+  .dbt-line { font-size: var(--fs-sm); line-height: 1.45; color: var(--text-dim); margin-top: 6px; }
+  .dbt-key { font-weight: 600; color: var(--text); margin-right: 6px; }
+  .dbt-frames { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+  .dbt-frame {
+    font-size: var(--fs-micro); font-family: var(--mono); padding: 2px 8px;
+    border-radius: 5px; background: var(--card); color: var(--text-dim);
+    border: 1px solid var(--border);
+  }
   /* hidden concentration */
   .hc-headline { font-size: var(--fs-md); font-weight: 600; line-height: 1.45; margin-bottom: 12px; }
   .hc-bar-row { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -386,7 +386,7 @@
     reflect: [
       renderHonesty, renderBehavioralReview, renderDecisionAudit, renderCalibBadge,
       renderPlanReview, renderCalibByTrigger, renderCalibByDriver,
-      renderDecisionTraces, renderReflectKpi, renderDelta,
+      renderDecisionTraces, renderReflectKpi, renderDelta, renderDebates,
     ],
   };
   let RENDER_VERSION = 0;
@@ -3153,6 +3153,53 @@
         </tr>`).join("")
         + `</tbody></table>`
       : '<div class="empty-state">暂无能按同票/同日/同方向/同股数唯一匹配的真实成交；不会拿 OHLC 假设成交冒充。</div>';
+  }
+
+  // The debate behind each call, published rather than asserted (#1117). The
+  // README claims Bull/Bear/Judge with a named devil's advocate; before this
+  // the only public trace was a coverage count, so a reader could verify that
+  // a debate was *recorded*, not what was argued. Rows ride the Reflect
+  // sidecar (`decision_audit.debates`) and carry the decision id, so each one
+  // can be joined back to the call it produced.
+  function renderDebates() {
+    const block = safe(DATA, "decision_audit", "debates") || {};
+    const rows = block.rows || [];
+    const card = document.getElementById("debate-card");
+    if (!card) return;
+    if (!rows.length) { card.style.display = "none"; return; }
+    card.style.display = "";
+    const ACTION_ZH = {
+      cut: "砍", trim_on_rebound: "反弹减", hold_and_watch: "持有观察",
+      add_only_on_trigger: "触发才加", watch: "观察",
+    };
+    document.getElementById("debate-body").innerHTML = rows.map(r => {
+      const side = (label, cls, text) => text
+        ? `<div class="dbt-side ${cls}"><span class="dbt-lbl">${label}</span>`
+          + `<span class="dbt-text">${escLLM(text)}</span></div>`
+        : "";
+      const line = (label, text) => text
+        ? `<div class="dbt-line"><span class="dbt-key">${label}</span>${escLLM(text)}</div>`
+        : "";
+      const frames = (r.frames || []).length
+        ? `<div class="dbt-frames">${r.frames.map(
+            f => `<span class="dbt-frame">${escLLM(f)}</span>`).join("")}</div>`
+        : "";
+      const conf = r.confidence == null ? "" : ` · 置信 ${Math.round(r.confidence * 100)}%`;
+      return `<div class="dbt-case">
+        <div class="dbt-head">
+          <span class="dbt-tk">${escLLM(r.ticker)}</span>
+          <span class="muted">${escLLM(r.date)} · ${escLLM(ACTION_ZH[r.action] || r.action)}${conf}</span>
+        </div>
+        ${side("多", "dbt-bull", r.bull)}
+        ${side("空", "dbt-bear", r.bear)}
+        ${line("被攻击的共识", r.attacked_consensus)}
+        ${line("Judge", r.judge)}
+        ${frames}
+      </div>`;
+    }).join("");
+    const total = rows.length;
+    document.getElementById("debate-src").textContent =
+      `最近 ${total} 条带辩论记录的决策（窗口上限 ${block.limit || total}）`;
   }
 
   function renderBearCases() {

--- a/site/index.html
+++ b/site/index.html
@@ -772,6 +772,14 @@ layout: null
       <div class="llm-src" id="br-src"></div>
     
       </div>
+      <div class="sub-block" id="debate-card" style="display:none">
+        <div class="sub-block-head">辩论留痕 <span class="muted">Bull / Bear / 被攻击的共识 / Judge</span></div>
+      
+      <p class="chart-hint">每条决策背后的对抗过程，按原样发布：多方怎么说、空方怎么说、被点名攻击的是哪条共识、Judge 怎么裁。发布的是过程不是结论——「我们辩过」因此是可核对的，不是自称的。覆盖率见下方择时诊断同源的 debate_metrics。</p>
+      <div id="debate-body"></div>
+      <div class="llm-src" id="debate-src"></div>
+    
+      </div>
       <div class="sub-block" id="decision-audit-card" style="display:none">
         <div class="sub-block-head">单事件择时诊断 <span class="muted">AI 成交价 vs 同日收盘</span></div>
       

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -436,6 +436,63 @@ def trim_workflow_outcomes(summary):
     return summary
 
 
+#: How many debated decisions ride the Reflect sidecar. The block is ~1.1KB of
+#: UTF-8 per decision, so a window rather than the whole ledger; the counts in
+#: `debate_metrics` stay whole-ledger, so a shrinking window cannot hide a
+#: falling coverage series.
+DEBATE_SIDECAR_LIMIT = 30
+
+
+def build_debate_sidecar(decisions, limit=DEBATE_SIDECAR_LIMIT):
+    """The debate behind each decision, published rather than asserted (#1117).
+
+    README claims Bull/Bear/Judge with a named devil's advocate. Until now the
+    only public trace of it was a count: `debate_metrics.debate_coverage` said
+    how many decisions carried a debate block, never what was argued. A reader
+    outside this repository could verify that we *recorded* a debate and not
+    that one happened — which is the exact move clawock attacks competitors for.
+
+    So the structured block goes out with the decision it produced: the bull
+    case, the bear case, the consensus that was attacked by name, the Judge's
+    verdict and the strategy frames it was decided under. Text is already
+    capped at `ledger.DEBATE_TEXT_CHARS` upstream, so a runaway field cannot
+    walk this sidecar into the payload budget.
+
+    Rows are newest-first and carry the decision id, so a reader can join them
+    against `recent_decisions` / the ledger and check that the debate published
+    here belongs to the call that was actually made.
+    """
+    rows = []
+    ordered = sorted(
+        decisions or [],
+        key=lambda x: (x.get('created_at', ''), x.get('decision_id', '')),
+        reverse=True,
+    )
+    for d in ordered:
+        debate = d.get('debate')
+        if not isinstance(debate, dict) or not debate:
+            continue
+        row = {
+            'date': d.get('plan_date'),
+            'decision_id': d.get('decision_id'),
+            'ticker': d.get('ticker'),
+            'name': d.get('name'),
+            'action': d.get('action'),
+            'confidence': d.get('confidence'),
+        }
+        for field in decision_v2.DEBATE_TEXT_FIELDS:
+            value = debate.get(field)
+            if isinstance(value, str) and value.strip():
+                row[field] = value.strip()
+        frames = debate.get('frames')
+        if isinstance(frames, list) and frames:
+            row['frames'] = [str(f) for f in frames]
+        rows.append(row)
+        if len(rows) >= limit:
+            break
+    return {'limit': limit, 'rows': rows}
+
+
 def build_decision_audit_payload(decisions, portfolio):
     """Compile the complete Reflect sidecar from one settled decision set.
 
@@ -448,6 +505,10 @@ def build_decision_audit_payload(decisions, portfolio):
         decisions, portfolio, include_records=False
     )
     payload['episode_backtest'] = decision_v2.compute_backtest(decisions)
+    # The debate itself, not just how often one was recorded (#1117). It rides
+    # this sidecar rather than dashboard.json because Reflect is the only tab
+    # that renders it and dashboard.json is the payload under the 200KB cap.
+    payload['debates'] = build_debate_sidecar(decisions)
     return payload
 
 

--- a/tests/test_reflect_audit_contract.py
+++ b/tests/test_reflect_audit_contract.py
@@ -28,3 +28,101 @@ def test_reflect_sidecar_compiles_backtest_from_the_same_decisions(monkeypatch):
     assert sidecar["decision_ids"] == ["d1"]
     assert sidecar["records_included"] is False
     assert sidecar["episode_backtest"] == {"decision_ids": ["d1"]}
+
+
+def _debated(decision_id, created_at, **over):
+    row = {
+        "decision_id": decision_id,
+        "created_at": created_at,
+        "plan_date": created_at[:10],
+        "ticker": "SPCH",
+        "name": "Leverage Shares 2X Long SpaceX",
+        "action": "cut",
+        "confidence": 0.9,
+        "debate": {
+            "bull": "5d +6.4%, the Musk headline is not priced out yet.",
+            "bear": "Hard stop is 47 days old and VaR95 is through its limit.",
+            "attacked_consensus": "Attacked the aggressive case for keeping half.",
+            "judge": "Discipline first: a policy swap is not a timing call.",
+            "frames": ["technical_breakdown", "risk_budget"],
+        },
+    }
+    row.update(over)
+    return row
+
+
+def test_debate_sidecar_publishes_the_argument_not_only_its_count():
+    """#1117: the claim is 'we debate both sides' — so publish both sides.
+
+    `debate_metrics.debate_coverage` already says how many decisions carried a
+    debate. A count is not the claim: a reader could verify that a block was
+    recorded, never what was argued. This pins that the block itself goes out,
+    joined to the decision that produced it.
+    """
+    from clawock.publish import dashboard as build_dashboard
+
+    rows = build_dashboard.build_debate_sidecar([
+        _debated("d-old", "2026-08-29T08:00:00+08:00"),
+        _debated("d-new", "2026-08-31T08:00:00+08:00"),
+        {"decision_id": "d-none", "created_at": "2026-08-30T08:00:00+08:00"},
+        {"decision_id": "d-empty", "created_at": "2026-08-30T08:00:00+08:00", "debate": {}},
+    ])["rows"]
+
+    # Newest first, and only the decisions that actually carry a debate.
+    assert [r["decision_id"] for r in rows] == ["d-new", "d-old"]
+    row = rows[0]
+    # Every side of the argument, plus the id that joins it to the call.
+    assert row["bull"] and row["bear"]
+    assert row["attacked_consensus"] and row["judge"]
+    assert row["frames"] == ["technical_breakdown", "risk_budget"]
+    assert row["ticker"] == "SPCH" and row["action"] == "cut" and row["date"] == "2026-08-31"
+
+
+def test_debate_sidecar_window_is_bounded():
+    """~1.1KB of UTF-8 per block, so the sidecar publishes a window.
+
+    The window is the *sidecar's*; the coverage series in `debate_metrics`
+    stays whole-ledger, so shrinking this cannot make a falling coverage look
+    healthy.
+    """
+    from clawock.publish import dashboard as build_dashboard
+
+    many = [
+        _debated(f"d{i:03d}", f"2026-08-{(i % 28) + 1:02d}T08:00:00+08:00")
+        for i in range(80)
+    ]
+    block = build_dashboard.build_debate_sidecar(many, limit=5)
+    assert block["limit"] == 5
+    assert len(block["rows"]) == 5
+
+
+def test_reflect_sidecar_carries_the_debates(monkeypatch):
+    from clawock.publish import dashboard as build_dashboard
+
+    monkeypatch.setattr(
+        build_dashboard.decision_v2, "build_audit_sidecar",
+        lambda rows, portfolio, include_records: {"schema_version": 1},
+    )
+    monkeypatch.setattr(
+        build_dashboard.decision_v2, "compute_backtest", lambda rows: {},
+    )
+    sidecar = build_dashboard.build_decision_audit_payload(
+        [_debated("d1", "2026-08-31T08:00:00+08:00")], {})
+    assert sidecar["debates"]["rows"][0]["decision_id"] == "d1"
+
+
+def test_reflect_tab_renders_the_debate_trail():
+    """The sidecar is only observable if the page draws it (#1117).
+
+    Pins the three hand-maintained halves against each other: the card exists
+    in the page, the renderer reads the published key and is registered on the
+    Reflect tab.
+    """
+    html = (ROOT / "site" / "index.html").read_text()
+    render = (ROOT / "site" / "assets" / "js" / "dashboard.render.js").read_text()
+
+    assert 'id="debate-card"' in html
+    assert 'id="debate-body"' in html
+    assert 'safe(DATA, "decision_audit", "debates")' in render
+    reflect = render.split("reflect: [", 1)[1].split("]", 1)[0]
+    assert "renderDebates" in reflect


### PR DESCRIPTION
Closes #1117.

## What was missing

`#1129` made a decision *able* to carry `debate` (bull / bear /
attacked_consensus / judge / frames) and published a coverage count. The count
is not the claim. The claim on README.md:207-216 is "we argue both sides and a
Judge rules"; what a reader could check was `with_debate: 8`, i.e. that a block
existed — not what was argued, and not whether it belongs to the call that was
made.

## What ships

`decision_audit.json` (the Reflect sidecar, already lazy-loaded by that tab)
gains a `debates` block: newest-first rows carrying `decision_id`, ticker,
action, confidence and the debate itself. The page renders it as a new Reflect
card — 多 / 空 side by side, then the named attacked consensus, the Judge's
verdict, and the strategy frames as chips.

Why the sidecar and not `dashboard.json`: ~1.1KB of UTF-8 per block against a
200KB payload cap that #1215 just bought headroom on. Reflect is the only tab
that renders it, and the sidecar has no such cap.

Why a 30-row window: the same size argument. The coverage series in
`debate_metrics` stays whole-ledger, so narrowing this window cannot make a
falling coverage look healthy — the two answer different questions on purpose.

## Not in this PR: making the field required

The last comment on the issue said the closing step was "make the field
required". Measured before writing this: today's plan carries debate on 8/8
decisions, every prior plan on 0/10 — one day of data. A hard requirement in
`validate_plan` is a publish gate, and a plan that fails it does not degrade to
a thinner brief, it degrades to **no brief** — which the repo has an explicit
rule against (detect, never silence). So the requirement is left to be taken
against the coverage series once it has a series, and this PR does the half
that makes the claim observable today.

## Verification

- `tests/test_reflect_audit_contract.py`: rows are newest-first, decisions
  without a debate are excluded, the window is bounded, the block reaches the
  sidecar, and the three hand-maintained halves (card in `index.html`, renderer
  reading the published key, renderer registered on Reflect) match.
- Rendered in a real browser against the live ledger: card visible on
  `#reflect`, 8 cases drawn, zero page errors.
