### PR TITLE
ops: track the 06:01 Claude kicker instead of leaving it untracked in the live checkout

### DIFF
--- a/ops/host/claude_6am_kicker.sh
+++ b/ops/host/claude_6am_kicker.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# claude_6am_kicker.sh — 工作日 06:01 HKT 启动 Claude Code 处理 P1/P2 队列
+#
+# 背景 (2026-08-31): kcn 凌晨需要补觉,Claude Pro 5h 滚动额度深夜烧光,06:01
+# HKT 距上次使用已超 5h → 配额窗口已回血。kcn 希望 6:01 自动把 claude 拉起来
+# 跑 github.com/KCNyu/clawock 的 open P1/P2 队列,不要替用户做策略判断。
+#
+# 设计契约 (与 AGENTS.md 一致):
+#   - 纯 issue/PR 处理,不动 portfolio.json/dashboard/memory/ 等 runtime 文件
+#   - 代码改动走 worktree → claude/<task> 分支 → PR,不直推 master
+#   - 任务说明书独立成 task file,本脚本只负责启动 + 日志 + 锁
+#   - 用 flock 防止 6:01 还没死透时 8:00 brief 共用冲突
+#   - 失败/超时/claude 崩了不重试:下一工作日 6:01 再说
+#
+# 用法 (system crontab):
+#   1 6 * * 1-5 /root/.openclaw/workspace/ops/host/claude_6am_kicker.sh
+#
+# 维护:
+#   - 任务说明: /root/.openclaw/workspace/ops/host/claude_6am_task.md
+#   - 日志:      /root/.openclaw/logs/claude-6am-YYYYMMDD.log
+#   - 锁:        /tmp/claude-6am.lock
+
+set -uo pipefail
+
+# Every path is a default, not a dependency: $LIVE_CHECKOUT is the same
+# override `ops/host/refresh_live.sh` takes, and the task file and log dir
+# follow it, so this runs against any checkout on any host that has a claude
+# binary on PATH.
+WORKDIR="${LIVE_CHECKOUT:-/root/.openclaw/workspace}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo /root/.nvm/versions/node/v22.23.1/bin/claude)}"
+TASK_FILE="${TASK_FILE:-$WORKDIR/ops/host/claude_6am_task.md}"
+LOG_DIR="${LOG_DIR:-$WORKDIR/../logs}"
+LOCK_FILE="${LOCK_FILE:-/tmp/claude-6am.lock}"
+
+# --- sanity checks ---------------------------------------------------------
+if [ ! -x "$CLAUDE_BIN" ]; then
+  echo "[$(date -Iseconds)] FATAL: $CLAUDE_BIN 不存在或不可执行" >> "$LOCK_FILE.log"
+  exit 1
+fi
+if [ ! -f "$TASK_FILE" ]; then
+  echo "[$(date -Iseconds)] FATAL: $TASK_FILE 丢失" >> "$LOCK_FILE.log"
+  exit 1
+fi
+mkdir -p "$LOG_DIR"
+
+# --- acquire lock (non-blocking) -------------------------------------------
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "[$(date -Iseconds)] SKIP: claude 6am 已在跑 (lock held)" >> "$LOG_DIR/claude-6am.lock.log"
+  exit 0
+fi
+
+LOG_FILE="$LOG_DIR/claude-6am-$(date +%Y%m%d).log"
+echo "=== claude_6am_kicker fired $(date -Iseconds) ===" >> "$LOG_FILE"
+echo "task_file=$TASK_FILE" >> "$LOG_FILE"
+echo "claude_version=$($CLAUDE_BIN --version 2>&1 | head -1)" >> "$LOG_FILE"
+
+# --- 启动 claude -----------------------------------------------------------
+cd "$WORKDIR" || exit 1
+
+# bypassPermissions 已经在 /root/.claude/settings.json 里设了 defaultMode,
+# 这里再显式 --dangerously-skip-permissions 是双保险 (cron 没有 TTY 走 prompt 会卡住)。
+#
+# 喂 prompt 三种写法比较 (2026-08-31 kcn 提醒):
+#   1. -p "..."                    ←  必加双引号, 换行仍会保留 (bash "$(...)" 不压扁)
+#   2. -p "$(cat file)"            ←  当前写法; 多行 OK, 但 $ ` \ 等需转义
+#   3. cat file | claude -p        ←  stdin, 多行 + 任意字符全保, 最稳
+# 选 (3) 最稳: 任务说明含中文标点 + 反引号 + $变量示例, pipe 0 风险。
+"$CLAUDE_BIN" --dangerously-skip-permissions -p < "$TASK_FILE" \
+  >> "$LOG_FILE" 2>&1
+
+EXIT=$?
+echo "=== claude_6am_kicker exit=$EXIT $(date -Iseconds) ===" >> "$LOG_FILE"
+
+# 释放锁 (exec fd 自动 close,但显式删文件方便下次排查)
+rm -f "$LOCK_FILE"
+exit "$EXIT"

--- a/ops/host/claude_6am_task.md
+++ b/ops/host/claude_6am_task.md
@@ -1,0 +1,81 @@
+# Task: 06:01 HKT Claude Code P1/P2 Issue Triage
+
+你是 Claude Code (Pro 订阅,5h 滚动额度)。现在是工作日 06:01 HKT,你的配额
+窗口大概率已经回血。高效工作,额度烧完或 90 分钟到点就退出。
+
+## 任务
+
+处理 `github.com/KCNyu/clawock` 仓库的 **open P1/P2 issue 队列**,
+按优先级从高到低逐个开 PR。每完成一个就 commit → push → `gh pr create`,
+issue 评论里贴 PR 链接。
+
+## 契约 (从 /root/.openclaw/workspace/AGENTS.md 必读)
+
+- **代码改动**: worktree → `claude/<task>` 分支 → PR。**绝不**直推 master。
+- **Runtime 数据** (portfolio.json / dashboard.json / memory/* 等): 不归你管。
+- **当前工作目录**: `/root/.openclaw/workspace`(在 worktree 里就别回这里)
+- **分支命名**: `claude/issue-N-<short-slug>` (例: `claude/issue-1213-cost-review`)
+- **不创建新 issue**(除非用户明确要求)
+- **不改 cron**、**不动 config/cron-schedules.json**、**不动 SOUL/AGENTS/USER**
+- **不替用户做投资判断**(持仓/加仓/减仓一律不碰)
+
+## 启动流程
+
+1. `cd /root/.openclaw/workspace && git status` 确认干净
+2. `gh issue list --repo KCNyu/clawock --state open --label priority:P1,P2 \
+    --json number,title,labels,createdAt --limit 30`
+3. 排序: P1 优先;同优先级按 createdAt 旧的先做
+4. 跳过明显**非代码类**的 issue(如 [syscheck] 类观察报告 → 留给人)
+5. 对每个 issue 走下面的处理流
+
+## 单 issue 处理流
+
+1. **读背景**:
+   - `gh issue view N --repo KCNyu/clawock --comments`
+   - 顺藤摸瓜读关联 issue/PR/commit
+   - 读 AGENTS.md 必读段(PR workflow + worktree 流程)
+2. **建 worktree**:
+   ```bash
+   git worktree add ../wt-issue-N -b claude/issue-N-short-slug master
+   cd ../wt-issue-N
+   ```
+3. **改代码** + 跑相关检查(pytest / harness-regression / lint)
+4. **commit + push + PR**:
+   ```bash
+   git add -A
+   git commit -m "fix: <一句中文描述 (#N)"
+   git push -u origin HEAD
+   gh pr create --base master --head claude/issue-N-short-slug \
+     --title "<title>" --body "Closes #N ..."
+   ```
+5. **issue 评论**: `gh issue comment N --body "开 PR: <url>"`
+6. **清理 worktree**: `git worktree remove ../wt-issue-N`
+
+## 停止条件(任一)
+
+- 配额耗尽(API 返 429)→ 立即退,把已完成的部分记到日志
+- 所有 P1/P2 已处理或转 PR
+- 90 分钟到点(给 8:00 brief 留时间窗)
+- 同一 issue 卡 30 分钟无进展 → 跳过,日志记一笔"stuck: #N"
+
+## 退出摘要(最后必做)
+
+stdout 打:
+- 处理了几个 issue
+- 开了几个 PR
+- 跳过了几个 + 原因
+- 还剩多少 P1/P2 没动
+
+## 不要做
+
+- 不要 push master
+- 不要用 `git add -A` 之前先 `git status` 确认无意外文件
+- 不要重命名/删除用户的文件
+- 不要跑 `clawock` 类会改 portfolio 的命令
+- 不要后台启动长进程(会被 cron 砍)
+- 不要在 main session 里发消息(只用 gh CLI)
+
+## 日志
+
+crontab 包装脚本已经重定向 stdout+stderr 到
+`/root/.openclaw/logs/claude-6am-YYYYMMDD.log`,你直接打 stdout 即可。

--- a/tests/test_runtime_coupling_ratchet.py
+++ b/tests/test_runtime_coupling_ratchet.py
@@ -444,6 +444,10 @@ HOST_OWNED_SHELL = {
         2, "host cron wrapper that reads the Nostr key from this machine's "
            "runtime dir and posts from the live checkout — the broadcast has "
            "no meaning off this host"),
+    "ops/host/claude_6am_kicker.sh": (
+        1, "weekday 06:01 HKT launcher for the issue/PR queue: the live "
+           "checkout is the subject of the script, and $LIVE_CHECKOUT "
+           "overrides it exactly as it does for refresh_live.sh"),
     "ops/host/refresh_live.sh": (
         1, "applies a merge to this host: the live checkout is the subject of "
            "the script, not an incidental dependency — and $LIVE_CHECKOUT "


### PR DESCRIPTION
`ops/host/claude_6am_kicker.sh` + `ops/host/claude_6am_task.md` were created directly in `/root/.openclaw/workspace` earlier today and left untracked. Untracked automation in the live checkout is one `git clean` or one `refresh_live` away from gone, and it is code, not runtime data — so it goes through the normal path.

**Parameterised while landing it.** Paths are defaults now:

- `WORKDIR="${LIVE_CHECKOUT:-/root/.openclaw/workspace}"` — same override `refresh_live.sh` takes;
- `TASK_FILE` / `LOG_DIR` follow `$WORKDIR`;
- `CLAUDE_BIN` prefers `command -v claude`, falling back to the pinned nvm path.

That takes it from 3 host-naming sites to 1, and the remaining one is registered in `HOST_OWNED_SHELL` with its reason, so the day it is fully parameterised the entry has to go. `tests/test_runtime_coupling_ratchet.py` passes (8/8).

**Not scheduled by this PR.** No crontab line is added — that is kcn's call; the script's header carries the line to add. Nothing runs differently on merge.
