### PR TITLE
bars: classify a refused provider disagreement instead of only printing it (#1146)

### DIFF
--- a/src/clawock/market_data/bars.py
+++ b/src/clawock/market_data/bars.py
@@ -201,7 +201,88 @@ def sane(b: dict) -> bool:
     return bar_checks.is_structurally_sane(b)
 
 
-def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[str]]:
+#: Where a refused conflict is remembered. Append-only, one JSON object per
+#: refusal, because the exit code and the stdout line the fetcher already
+#: prints live in a cron log nobody reads twice: a source that disagrees once
+#: a quarter and one that disagrees every week look identical there (#1146).
+CONFLICT_LOG = WS / "memory" / "bar-conflicts.jsonl"
+
+#: The closed vocabulary a refusal is classified into. Deliberately small, and
+#: deliberately about the *shape* of the disagreement rather than its cause —
+#: "the provider re-priced the whole bar by one ratio" is observable, "the
+#: provider applied a split" is a guess about someone else's system.
+CONFLICT_KINDS = (
+    "impossible_bar",      # fails the structural check outright — never stored
+    "uniform_rescale",     # every leg moved by the same ratio: adjustment signature
+    "close_only",          # only the close moved: a settlement-price revision
+    "rounding",            # every leg moved by < 5bp: precision, not information
+    "bar_revision",        # anything else: a real disagreement about the session
+)
+
+#: Below this, a difference is precision rather than information. 5bp of a
+#: HK$700 close is 35 cents — smaller than one tick on that board.
+ROUNDING_REL_TOL = 5e-4
+#: How close the four ratios must be to each other to read as one rescale.
+RESCALE_REL_TOL = 1e-3
+
+
+def classify_conflict(old: dict, fetched: dict) -> str:
+    """Name the shape of a stored-vs-fetched disagreement.
+
+    The store already refuses to overwrite; what it could not say is *what kind*
+    of disagreement it refused. A weekly stream of `rounding` and a single
+    `bar_revision` on a session the ledger settled against are the same line of
+    output today, and they call for opposite responses.
+    """
+    legs = ("open", "high", "low", "close")
+    moved = [k for k in legs
+             if abs(old.get(k, 0) - fetched.get(k, 0)) > 1e-9]
+    if not moved:
+        return "rounding"
+    relative = [
+        abs(old[k] - fetched[k]) / abs(old[k])
+        for k in legs
+        if isinstance(old.get(k), (int, float)) and old.get(k)
+    ]
+    if relative and max(relative) < ROUNDING_REL_TOL:
+        return "rounding"
+    if moved == ["close"]:
+        return "close_only"
+    ratios = [
+        fetched[k] / old[k]
+        for k in legs
+        if isinstance(old.get(k), (int, float)) and old.get(k)
+        and isinstance(fetched.get(k), (int, float))
+    ]
+    if len(ratios) == len(legs):
+        spread = max(ratios) - min(ratios)
+        if spread <= RESCALE_REL_TOL * max(abs(r) for r in ratios):
+            return "uniform_rescale"
+    return "bar_revision"
+
+
+def record_conflicts(ticker: str, conflicts: list[dict], path: Path | None = None) -> int:
+    """Append refusals to the conflict log. Returns how many rows were written.
+
+    Append-only and never read back by the fetcher: the point is that the rate
+    of disagreement per source becomes a number someone can look at later
+    (`clawock integrity` summarises it), not that this run behaves differently.
+    """
+    if not conflicts:
+        return 0
+    target = Path(path or CONFLICT_LOG)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    seen_at = datetime.now(HKT).isoformat(timespec="seconds")
+    with target.open("a", encoding="utf-8") as fh:
+        for conflict in conflicts:
+            row = dict(conflict)
+            row["ticker"] = ticker
+            row["seen_at"] = seen_at
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    return len(conflicts)
+
+
+def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[dict]]:
     doc = load_bars(ticker)
     doc.setdefault("tencent", MANIFEST[ticker]["tencent"])
     # The manifest is the declaration; docs written before it existed get it here.
@@ -217,7 +298,11 @@ def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[
             continue                      # session not finished — never store a live bar
         verdict = bar_checks.check_bar(b)
         if verdict["fatal"]:
-            conflicts.append(f"{d}: insane OHLC {b} ({'; '.join(verdict['fatal'])})")
+            conflicts.append({
+                "date": d, "kind": "impossible_bar",
+                "detail": f"insane OHLC {b} ({'; '.join(verdict['fatal'])})",
+                "fetched": {k: b.get(k) for k in ("open", "high", "low", "close")},
+            })
             continue
         rec = {"open": b["open"], "high": b["high"], "low": b["low"], "close": b["close"],
                "source": "tencent", "adjustment": "raw", "fetched_at": now}
@@ -240,9 +325,14 @@ def merge(ticker: str, fresh: list[dict], repair: bool) -> tuple[int, int, list[
         # A stored bar changed. That is either a provider revision or a source bug; it is
         # never something to apply silently — the ledger already settled against the old one.
         if not repair:
-            conflicts.append(
-                f"{d}: stored O{old['open']}/H{old['high']}/L{old['low']}/C{old['close']} "
-                f"vs fetched O{rec['open']}/H{rec['high']}/L{rec['low']}/C{rec['close']}")
+            conflicts.append({
+                "date": d, "kind": classify_conflict(old, rec),
+                "detail": (
+                    f"stored O{old['open']}/H{old['high']}/L{old['low']}/C{old['close']} "
+                    f"vs fetched O{rec['open']}/H{rec['high']}/L{rec['low']}/C{rec['close']}"),
+                "stored": {k: old[k] for k in ("open", "high", "low", "close")},
+                "fetched": {k: rec[k] for k in ("open", "high", "low", "close")},
+            })
             continue
         rec["revised_from"] = {k: old[k] for k in ("open", "high", "low", "close")}
         rec["revised_at"] = now
@@ -306,14 +396,16 @@ def main(argv=None) -> int:
         added, revised, conflicts = merge(t, fresh, args.repair)
         total_add += added
         total_rev += revised
+        record_conflicts(t, conflicts)
         for c in conflicts:
-            all_conflicts.append(f"{t} {c}")
+            all_conflicts.append(f"{t} {c['date']} [{c['kind']}]: {c['detail']}")
         flag = f" ⚠ {len(conflicts)} conflict" if conflicts else ""
         print(f"  {t:6} +{added:3} bars, {revised} revised, {len(load_bars(t)['bars'])} total{flag}")
 
     print(f"\n{total_add} bars added, {total_rev} revised → {BARS_DIR}")
     if all_conflicts:
         print(f"\n⚠ {len(all_conflicts)} conflicts — stored bars disagree with the provider.")
+        print(f"  Classified and appended to {CONFLICT_LOG}; `clawock integrity` counts them.")
         print("  Nothing was overwritten. Investigate, then re-run with --repair if the")
         print("  provider is right; the ledger settled against the stored values.")
         for c in all_conflicts[:20]:

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -67,6 +67,7 @@ _quote_is_complete 因此弃用它——链在正常工作），逐日报警只�
 """
 import argparse
 import json
+import pathlib
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -271,6 +272,66 @@ def check_share_ledgers(portfolios):
                         'msg': f'{ticker} 账本缺口从已签收的 {known:.0f} 变成 {deficit:.0f} 股；'
                                f'又多了一笔没有对应买入的卖出'})
     return findings
+
+
+#: How far back the bar-conflict summary looks. A refusal from six months ago
+#: is history; what a reader needs to know is whether a source is disagreeing
+#: *now*, and at what rate.
+BAR_CONFLICT_WINDOW_DAYS = 30
+
+
+def summarize_bar_conflicts(log_path=None, *, now=None,
+                            window_days=BAR_CONFLICT_WINDOW_DAYS) -> dict:
+    """Count the canonical store's refused provider disagreements (#1146).
+
+    `market_data.bars` already detects a stored-vs-fetched disagreement and
+    already refuses to overwrite — the ledger settled against the stored value,
+    so a silent repair would move history. What it could not do was answer "how
+    often, and about what": every refusal was one line in one cron log.
+
+    So the refusals are classified at the point of refusal and appended to
+    `memory/bar-conflicts.jsonl`, and this turns that log into counts by kind
+    over a window. Reporting only, and deliberately: this must not become a
+    publish blocker. The bars were not written, nothing downstream is wrong,
+    and blocking a brief over a provider's revision would trade a visible
+    disagreement for an invisible one.
+    """
+    # `pathlib.Path` rather than this module's `Path`: an existing fixture
+    # replaces that name with a stub reader to feed `check()` a portfolio, and
+    # a summary that exploded under it would take the whole report with it.
+    path = pathlib.Path(log_path) if log_path is not None else (
+        workspace_root(pathlib.Path.cwd()) / 'memory' / 'bar-conflicts.jsonl')
+    summary = {
+        'window_days': window_days,
+        'total': 0,
+        'by_kind': {},
+        'by_ticker': {},
+        'last_seen_at': None,
+        'log': path.name,
+    }
+    if not path.exists():
+        return summary
+    now = now or datetime.now().astimezone()
+    cutoff = (now - timedelta(days=window_days)).date().isoformat()
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        seen_at = str(row.get('seen_at') or '')
+        if seen_at[:10] < cutoff:
+            continue
+        kind = str(row.get('kind') or 'unknown')
+        ticker = str(row.get('ticker') or 'unknown')
+        summary['total'] += 1
+        summary['by_kind'][kind] = summary['by_kind'].get(kind, 0) + 1
+        summary['by_ticker'][ticker] = summary['by_ticker'].get(ticker, 0) + 1
+        if summary['last_seen_at'] is None or seen_at > summary['last_seen_at']:
+            summary['last_seen_at'] = seen_at
+    return summary
 
 
 def check(portfolio_path=PORTFOLIO):
@@ -590,6 +651,18 @@ def check(portfolio_path=PORTFOLIO):
 
     errors = [f for f in findings if f['level'] == 'ERROR']
     warns = [f for f in findings if f['level'] == 'WARN']
+    # Canonical-store disagreements: counted, named and visible — never a
+    # blocker. See `summarize_bar_conflicts`.
+    bar_conflicts = summarize_bar_conflicts()
+    if bar_conflicts['total']:
+        worst = sorted(bar_conflicts['by_kind'].items(),
+                       key=lambda item: (-item[1], item[0]))
+        add('BAR_CONFLICT', 'WARN',
+            f"canonical bars: {bar_conflicts['total']} refused provider "
+            f"disagreement(s) in {bar_conflicts['window_days']}d — "
+            + ', '.join(f'{kind} {count}' for kind, count in worst))
+        errors = [f for f in findings if f['level'] == 'ERROR']
+        warns = [f for f in findings if f['level'] == 'WARN']
     report = {
         'generated_at': datetime.now().astimezone().isoformat(timespec='seconds'),
         'ok': not errors,
@@ -599,6 +672,7 @@ def check(portfolio_path=PORTFOLIO):
         # 台账而非判决：消费者（brief context / 面板）读它就能说出「今天这本账
         # 是谁定的价、主源覆盖了几只」，不必再去翻某次 cron 的 stdout。
         'quote_sources': quote_ledger,
+        'bar_conflicts': bar_conflicts,
     }
     return report
 

--- a/tests/test_bar_checks.py
+++ b/tests/test_bar_checks.py
@@ -217,7 +217,10 @@ def test_an_impossible_bar_is_still_refused_with_the_reason_named(
     added, _, conflicts = mod.merge('TEST', fresh, repair=False)
 
     assert added == 0
-    assert conflicts and 'above high' in conflicts[0]
+    # A refusal is a record now, not a sentence: the reason still has to be in
+    # it, and the kind is what makes a stream of them countable (#1146).
+    assert conflicts and 'above high' in conflicts[0]['detail']
+    assert conflicts[0]['kind'] == 'impossible_bar'
 
 
 # ── the structural gate: nobody re-grows a private copy ─────────────────────

--- a/tests/test_bar_conflict_classification.py
+++ b/tests/test_bar_conflict_classification.py
@@ -1,0 +1,169 @@
+"""A refused provider disagreement has to be countable, not just printed (#1146).
+
+`market_data.bars` already detected a stored-vs-fetched disagreement and already
+refused to overwrite — that refusal is the invariant that keeps a settled ledger
+reproducible. What it could not do was say *what kind* of disagreement it
+refused, or how often: every refusal was one line in one cron log, so a source
+that re-prices a bar by a split ratio once a quarter and a source that drifts by
+a tick every week produced the same output.
+
+So: classify at the point of refusal, append to an immutable log, and summarise
+the log into the health report. Reporting only — nothing here may block a
+publish, because the bars were not written and nothing downstream is wrong.
+"""
+
+import json
+from pathlib import Path
+
+
+def _bars_module(tmp_path, monkeypatch):
+    from clawock.market_data import bars
+
+    monkeypatch.setattr(bars, 'BARS_DIR', tmp_path)
+    monkeypatch.setitem(
+        bars.MANIFEST, 'TEST',
+        {'leg': 'hk', 'tencent': 'hkTEST', 'em': None, 'retired': False})
+    monkeypatch.setattr(bars, '_last_closed_session', lambda leg: '2026-01-31')
+    return bars
+
+
+def test_the_four_shapes_of_a_disagreement_are_told_apart():
+    from clawock.market_data import bars
+
+    stored = {'open': 10.0, 'high': 11.0, 'low': 9.0, 'close': 10.5}
+
+    # Every leg scaled by one ratio — the signature of an adjusted series
+    # reaching a store that is contractually raw.
+    assert bars.classify_conflict(
+        stored, {'open': 5.0, 'high': 5.5, 'low': 4.5, 'close': 5.25}
+    ) == 'uniform_rescale'
+
+    # Only the settlement price moved: an exchange revising the close.
+    assert bars.classify_conflict(
+        stored, {'open': 10.0, 'high': 11.0, 'low': 9.0, 'close': 10.7}
+    ) == 'close_only'
+
+    # Under 5bp on every leg is precision, not information.
+    assert bars.classify_conflict(
+        stored, {'open': 10.001, 'high': 11.0, 'low': 9.0, 'close': 10.5}
+    ) == 'rounding'
+
+    # Anything else is a real disagreement about what happened that session.
+    assert bars.classify_conflict(
+        stored, {'open': 10.0, 'high': 12.4, 'low': 9.0, 'close': 10.5}
+    ) == 'bar_revision'
+
+    # And the vocabulary is closed: every kind the classifier can emit is
+    # declared, or a consumer counting kinds silently drops one.
+    for fetched in ({'open': 5.0, 'high': 5.5, 'low': 4.5, 'close': 5.25},
+                    {'open': 10.0, 'high': 11.0, 'low': 9.0, 'close': 10.7},
+                    {'open': 10.001, 'high': 11.0, 'low': 9.0, 'close': 10.5},
+                    {'open': 10.0, 'high': 12.4, 'low': 9.0, 'close': 10.5}):
+        assert bars.classify_conflict(stored, fetched) in bars.CONFLICT_KINDS
+
+
+def test_a_refusal_carries_its_kind_and_still_refuses(tmp_path, monkeypatch):
+    mod = _bars_module(tmp_path, monkeypatch)
+    first = [{'date': '2026-01-05', 'open': 10, 'high': 11, 'low': 9, 'close': 10.5}]
+    assert mod.merge('TEST', first, repair=False)[0] == 1
+
+    revised = [{'date': '2026-01-05', 'open': 5, 'high': 5.5, 'low': 4.5, 'close': 5.25}]
+    added, _revised, conflicts = mod.merge('TEST', revised, repair=False)
+
+    assert added == 0
+    assert len(conflicts) == 1
+    assert conflicts[0]['kind'] == 'uniform_rescale'
+    assert conflicts[0]['stored']['close'] == 10.5
+    assert conflicts[0]['fetched']['close'] == 5.25
+    # The invariant this whole file is built on: nothing was overwritten.
+    assert mod.load_bars('TEST')['bars']['2026-01-05']['close'] == 10.5
+
+
+def test_refusals_are_appended_to_an_immutable_log(tmp_path, monkeypatch):
+    mod = _bars_module(tmp_path, monkeypatch)
+    log = tmp_path / 'bar-conflicts.jsonl'
+
+    written = mod.record_conflicts('TEST', [
+        {'date': '2026-01-05', 'kind': 'close_only', 'detail': 'x'},
+    ], path=log)
+    assert written == 1
+    mod.record_conflicts('TEST', [
+        {'date': '2026-01-06', 'kind': 'bar_revision', 'detail': 'y'},
+    ], path=log)
+
+    rows = [json.loads(line) for line in log.read_text().splitlines()]
+    assert [row['date'] for row in rows] == ['2026-01-05', '2026-01-06']
+    assert all(row['ticker'] == 'TEST' and row['seen_at'] for row in rows)
+    # Nothing to record must not create a file — an empty log and a silent
+    # failure to write one should not look the same.
+    assert mod.record_conflicts('TEST', [], path=tmp_path / 'absent.jsonl') == 0
+    assert not (tmp_path / 'absent.jsonl').exists()
+
+
+def test_the_health_report_counts_them_by_kind_without_blocking(tmp_path):
+    from datetime import datetime, timedelta, timezone
+
+    from clawock.portfolio import integrity
+
+    now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+    recent = (now - timedelta(days=2)).isoformat(timespec='seconds')
+    stale = (now - timedelta(days=90)).isoformat(timespec='seconds')
+    log = tmp_path / 'bar-conflicts.jsonl'
+    log.write_text('\n'.join(json.dumps(row) for row in [
+        {'ticker': '00100', 'date': '2026-01-28', 'kind': 'close_only', 'seen_at': recent},
+        {'ticker': '00100', 'date': '2026-01-29', 'kind': 'close_only', 'seen_at': recent},
+        {'ticker': 'SPCH', 'date': '2026-01-29', 'kind': 'bar_revision', 'seen_at': recent},
+        {'ticker': 'SPCH', 'date': '2025-10-01', 'kind': 'bar_revision', 'seen_at': stale},
+    ]) + '\n')
+
+    summary = integrity.summarize_bar_conflicts(log, now=now)
+
+    assert summary['total'] == 3, "the 90-day-old row is outside the window"
+    assert summary['by_kind'] == {'close_only': 2, 'bar_revision': 1}
+    assert summary['by_ticker'] == {'00100': 2, 'SPCH': 1}
+    assert summary['last_seen_at'] == recent
+
+
+def test_a_missing_or_corrupt_log_is_zero_not_an_exception(tmp_path):
+    from clawock.portfolio import integrity
+
+    absent = integrity.summarize_bar_conflicts(tmp_path / 'nope.jsonl')
+    assert absent['total'] == 0 and absent['by_kind'] == {}
+
+    broken = tmp_path / 'broken.jsonl'
+    broken.write_text('{not json\n\n')
+    assert integrity.summarize_bar_conflicts(broken)['total'] == 0
+
+
+def test_the_report_names_them_and_still_publishes(tmp_path, monkeypatch):
+    """WARN, never ERROR: the bars were refused, so nothing downstream is wrong.
+
+    Blocking a publish over a provider's revision would trade a disagreement
+    that is visible for one that is not — the same trade this repo refuses
+    everywhere else.
+    """
+    from clawock.portfolio import integrity
+
+    book = tmp_path / 'portfolio.json'
+    book.write_text(json.dumps({'portfolios': {}}))
+
+    clean = integrity.check(book)
+    assert clean['bar_conflicts']['total'] == 0
+    assert not [f for f in clean['findings'] if f['code'] == 'BAR_CONFLICT']
+
+    monkeypatch.setattr(integrity, 'summarize_bar_conflicts', lambda *a, **k: {
+        'window_days': 30, 'total': 3, 'by_kind': {'bar_revision': 2, 'rounding': 1},
+        'by_ticker': {'00100': 3}, 'last_seen_at': '2026-01-29T08:00:00+08:00',
+        'log': 'bar-conflicts.jsonl',
+    })
+    noisy = integrity.check(book)
+
+    finding = [f for f in noisy['findings'] if f['code'] == 'BAR_CONFLICT']
+    assert len(finding) == 1
+    assert finding[0]['level'] == 'WARN'
+    # Ordered worst-first so the six findings the dashboard shows lead with the
+    # kind that actually disagrees about the session.
+    assert 'bar_revision 2' in finding[0]['msg']
+    assert noisy['warn_count'] == clean['warn_count'] + 1
+    assert noisy['ok'] is True, 'a refused bar must never block a publish'
+    assert noisy['bar_conflicts']['by_ticker'] == {'00100': 3}


### PR DESCRIPTION
Closes #1146.

## What was actually missing

The issue (and its two duplicates, #1135 and #1152) described the store as having no cross-source validation. It has: `bars.fetch_em_audit()` cross-audits East Money against the Tencent-sourced canonical bars, `merge()` detects any stored-vs-fetched difference, and `bars.py` exits non-zero without overwriting — "the ledger settled against the stored values".

What it could not do was **count**. Each refusal was one printed line in one cron log, so these two were the same output:

- a provider re-pricing an entire bar by a split ratio, once a quarter;
- a provider drifting by a tick, every week.

## What ships

`merge()` returns conflict records instead of strings, each with a `kind` from a closed vocabulary:

| kind | shape |
|---|---|
| `impossible_bar` | fails `check_bar` outright — never stored |
| `uniform_rescale` | all four legs moved by one ratio: an adjusted series reaching a raw store |
| `close_only` | only the settlement price moved |
| `rounding` | every leg under 5bp — precision, not information |
| `bar_revision` | anything else: a real disagreement about that session |

The kinds describe the *shape* of the disagreement, not its cause: "the provider re-priced the bar by one ratio" is observable; "the provider applied a split" is a guess about someone else's system.

Refusals append to `memory/bar-conflicts.jsonl` (append-only, never read back by the fetcher), and `clawock integrity` summarises the last 30 days into a `bar_conflicts` section plus one `BAR_CONFLICT` WARN — which reaches the dashboard's data-health card through the `build_status.integrity.top` path that already exists.

## What deliberately did not change

- **No auto-repair.** `--repair` remains the only way a stored bar moves; refusing to overwrite a settled bar is the invariant that keeps the ledger reproducible.
- **WARN, never ERROR.** The bars were not written, so nothing downstream is wrong. Blocking a publish over a provider's revision would trade a visible disagreement for an invisible one — asserted in the tests, not just intended.

## Verification

`tests/test_bar_conflict_classification.py` (6 tests): the four shapes are told apart, the emitted kind is always in the declared vocabulary, a refusal carries its kind *and* still leaves the stored bar untouched, the log appends and does not create a file when there is nothing to record, the window excludes old rows, a missing or corrupt log summarises to zero rather than raising, and the report gains exactly one WARN while `ok` stays `True`.

Full suite in the worktree: 3068 passed, 5 skipped, 4 xfailed.
