### PR TITLE
debate: brief-lane cases can cite evidence, and unresolvable citations are dropped and counted (#1141)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1509,6 +1509,11 @@
   .dbt-line { font-size: var(--fs-sm); line-height: 1.45; color: var(--text-dim); margin-top: 6px; }
   .dbt-key { font-weight: 600; color: var(--text); margin-right: 6px; }
   .dbt-frames { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+  .dbt-frame.dbt-cite {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+  }
   .dbt-frame {
     font-size: var(--fs-micro); font-family: var(--mono); padding: 2px 8px;
     border-radius: 5px; background: var(--card); color: var(--text-dim);

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -3180,10 +3180,16 @@
       const line = (label, text) => text
         ? `<div class="dbt-line"><span class="dbt-key">${label}</span>${escLLM(text)}</div>`
         : "";
-      const frames = (r.frames || []).length
-        ? `<div class="dbt-frames">${r.frames.map(
-            f => `<span class="dbt-frame">${escLLM(f)}</span>`).join("")}</div>`
-        : "";
+      const chips = [
+        ...(r.evidence_ids || []).map(
+          ref => `<span class="dbt-frame dbt-cite">${escLLM(ref)}</span>`),
+        ...(r.frames || []).map(f => `<span class="dbt-frame">${escLLM(f)}</span>`),
+      ];
+      // Citations first, then the Judge's frames: what the argument stood on
+      // reads ahead of how it was decided, and a case citing nothing is then
+      // visibly citing nothing (#1141).
+      const frames = chips.length
+        ? `<div class="dbt-frames">${chips.join("")}</div>` : "";
       const conf = r.confidence == null ? "" : ` · 置信 ${Math.round(r.confidence * 100)}%`;
       return `<div class="dbt-case">
         <div class="dbt-head">

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -719,7 +719,8 @@ postflight 严格 schema 校验：
         "bear": "杠杆 beta 在 risk_off 下放大回撤，DAU 连续两季下滑无止跌迹象",
         "attacked_consensus": "攻击的是「AI 板块整体还有一波」这条最强共识",
         "frames": ["technical_breakdown", "relative_strength"],
-        "judge": "纪律优先：政策型减仓不等预测兑现"
+        "judge": "纪律优先：政策型减仓不等预测兑现",
+        "evidence_ids": ["risk:leveraged_exposure:07226", "quant:07226:dist_ma200_pct"]
       }
     },
     {
@@ -764,6 +765,11 @@ postflight 严格 schema 校验：
   - `attacked_consensus`：本轮 devil's advocate（见 § Tier 2 铁律）点名攻击的那条最强共识。与该票无关时可省略，别为了填而编。
   - `frames`：`Judge — strategy frames` 表里为这条 action 选的 1–3 个 frame，逐字照抄枚举值。
   - `judge`：Judge 的合成判词一句话（不是 Bull/Bear 的复述）。
+  - `evidence_ids`（≤6 条，选填）：这场辩论**站在**哪几条 context 证据上（#1141）。只认三个能被解析的命名空间，postflight 逐条对着本次 context 核，**核不上的直接丢掉并记一条 degradation**（不会让流水线变红，但会被数出来）：
+    - `news:<event_id>` —— `context.news_evidence_graph.events[].event_id`
+    - `risk:<type>` 或 `risk:<type>:<ticker>` —— `context.risk_guardrail` 的 breach / hard_stop / concentration_review
+    - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）
+    **没有可引的证据就不填**，别为了填而造 id：造出来的引用比不引更糟，它看起来像证据。portable workflow lane 早就要求每个 case 带 `evidence_ids`（`workflows/validators.py`），这里是把同一条纪律接到日报这条 lane 上。
   - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。
 - `thesis_invalidation`（string，主动 cut/trim/add 必填；hold 选填）：**借鉴 UZI-Skill 的 thesis-tracking**——这个仓位的论点**会被什么具体催化推翻**？把 catalyst-gate(cut #1)落地成「论点+失效条件」：你只在这个**失效催化真的发生**时动手，而不是技术面波动。例：「crypto rev 环比转正则停止减仓」。这逼着每个主动 call 绑定一个可被证伪的硬催化，而非"看着toppy"。
 - `thesis_id` 必须沿用 `context.thesis_registry.theses.<ticker>.thesis_id`（resolved 时）；registry 为 `unknown` 时保留已有 decision ID，不得新造一个“看起来像历史”的 canonical thesis。`context.retrospective.decisions[].thesis_ref` 是只读解析结果。

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -174,6 +174,26 @@ DEBATE_TEXT_CHARS = 600
 
 DEBATE_TEXT_FIELDS = ("bull", "bear", "attacked_consensus", "judge")
 
+#: Namespaces a debate case may cite, and the only ones postflight can resolve
+#: against the morning's context (#1141). The portable workflow lane has
+#: required `evidence_ids` on each case since `workflows/validators.py`; the
+#: brief lane accepted a debate that cited nothing, so the two lanes disagreed
+#: about whether an argument owes evidence. A namespace exists here only where
+#: the context carries something stable to point at:
+#:
+#:   news:<event_id>          an event in `news_evidence_graph.events`
+#:   risk:<type>[:<ticker>]   a breach or hard stop in `risk_guardrail`
+#:   quant:<ticker>:<field>   a present, non-null field on that ticker's
+#:                            `quant_signals` row
+#:
+#: There is deliberately no free-text namespace. A citation that cannot be
+#: resolved is worth less than no citation: it reads as evidence and is not.
+DEBATE_EVIDENCE_NAMESPACES = ("news", "risk", "quant")
+
+#: Cap per debate block. Six references is already more than a two-paragraph
+#: argument can carry honestly.
+DEBATE_EVIDENCE_MAX = 6
+
 
 def normalize_debate(raw) -> dict | None:
     """The debate that produced one decision, as data rather than prose (#1117).
@@ -214,7 +234,34 @@ def normalize_debate(raw) -> dict | None:
                 kept.append(name)
         if kept:
             out["frames"] = kept[:3]
+    cited = normalize_debate_evidence(raw.get("evidence_ids"))
+    if cited:
+        out["evidence_ids"] = cited
     return out or None
+
+
+def normalize_debate_evidence(raw) -> list[str]:
+    """Citations in a namespace this repository can resolve, deduped and capped.
+
+    Shape only — whether `news:evt_abc` names a real event is a question about
+    the morning's context, which this module does not have; `brief_postflight`
+    answers it and drops what it cannot resolve. Here a reference that is not
+    `<namespace>:<rest>` in a known namespace is discarded, because an
+    unresolvable citation reads as evidence without being any.
+    """
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    kept: list[str] = []
+    for item in raw:
+        ref = str(item or "").strip()
+        namespace, _, rest = ref.partition(":")
+        if namespace not in DEBATE_EVIDENCE_NAMESPACES or not rest.strip():
+            continue
+        if ref not in kept:
+            kept.append(ref)
+    return kept[:DEBATE_EVIDENCE_MAX]
 
 
 def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) -> dict:
@@ -429,12 +476,21 @@ def validate_decision(d: dict) -> list[str]:
         if not isinstance(debate, dict) or not debate:
             errors.append("debate must be null or a non-empty object")
         else:
-            unknown = set(debate) - set(DEBATE_TEXT_FIELDS) - {"frames"}
+            unknown = set(debate) - set(DEBATE_TEXT_FIELDS) - {"frames", "evidence_ids"}
             if unknown:
                 errors.append(f"unknown debate field(s) {sorted(unknown)}")
             for field in DEBATE_TEXT_FIELDS:
                 if field in debate and not isinstance(debate[field], str):
                     errors.append(f"debate.{field} must be text")
+            cited = debate.get("evidence_ids")
+            if cited is not None and (
+                    not isinstance(cited, list)
+                    or any(not isinstance(ref, str) for ref in cited)
+                    or normalize_debate_evidence(cited) != cited):
+                errors.append(
+                    "debate.evidence_ids must be unique refs in "
+                    f"{list(DEBATE_EVIDENCE_NAMESPACES)}, at most "
+                    f"{DEBATE_EVIDENCE_MAX}")
             frames = debate.get("frames")
             if frames is not None and (
                     not isinstance(frames, list)

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -207,8 +207,83 @@ class _InMemoryPlanPath:
         return str(self._path)
 
 
+def _citable_refs(context) -> set[str]:
+    """Every debate citation this morning's context can actually back (#1141).
+
+    One set, built once per plan, in the three namespaces
+    `decision.ledger.DEBATE_EVIDENCE_NAMESPACES` declares. A namespace exists
+    only where the context carries something stable to point at — an event id,
+    a breach, a computed signal field — because a citation nobody can resolve
+    reads as evidence without being any.
+    """
+    refs: set[str] = set()
+    context = context or {}
+
+    graph = context.get('news_evidence_graph') or {}
+    for event in graph.get('events') or []:
+        event_id = str((event or {}).get('event_id') or '').strip()
+        if event_id:
+            refs.add(f'news:{event_id}')
+
+    guardrail = context.get('risk_guardrail') or {}
+    for key in ('breaches', 'hard_stop_watch', 'concentration_reviews'):
+        for row in guardrail.get(key) or []:
+            kind = str((row or {}).get('type') or '').strip()
+            if not kind:
+                continue
+            refs.add(f'risk:{kind}')
+            ticker = str((row or {}).get('ticker') or '').strip()
+            if ticker:
+                refs.add(f'risk:{kind}:{ticker}')
+
+    rows = ((context.get('quant_signals') or {}).get('rows')) or {}
+    if isinstance(rows, dict):
+        for ticker, row in rows.items():
+            if not isinstance(row, dict):
+                continue
+            for field, value in row.items():
+                if value is not None:
+                    refs.add(f'quant:{ticker}:{field}')
+    return refs
+
+
+def prune_debate_citations(plan, context):
+    """Drop debate citations the context cannot resolve. Returns what was cut.
+
+    Dropped rather than rejected, on purpose. `validate_plan` is a publish
+    gate: a plan that fails it does not degrade to a thinner brief, it degrades
+    to no brief, and an invented reference in an annotation is not worth that
+    trade. But dropping in silence would leave the debate looking better
+    sourced than it is, so every cut is returned for the caller to file as a
+    degradation — the same detect-but-never-silence shape the rest of this
+    harness uses.
+    """
+    dropped: list[str] = []
+    if not context:
+        return plan, dropped
+    citable = _citable_refs(context)
+    if not citable:
+        return plan, dropped
+    for decision in plan.get('decisions') or []:
+        debate = (decision or {}).get('debate')
+        if not isinstance(debate, dict):
+            continue
+        cited = debate.get('evidence_ids')
+        if not isinstance(cited, list) or not cited:
+            continue
+        kept = [ref for ref in cited if ref in citable]
+        for ref in cited:
+            if ref not in citable:
+                dropped.append(f"{decision.get('decision_id') or '?'}:{ref}")
+        if kept:
+            debate['evidence_ids'] = kept
+        else:
+            debate.pop('evidence_ids', None)
+    return plan, dropped
+
+
 def normalize_plan_json(path, ledger_path=None, *, decision_packet=None,
-                        write=True, return_plan=False):
+                        write=True, return_plan=False, context=None):
     """Fill only machine-owned v2 fields before validation.
 
     ``normalize_authored_plan`` also canonicalizes legacy/default values.  Never
@@ -251,6 +326,13 @@ def normalize_plan_json(path, ledger_path=None, *, decision_packet=None,
             normalized = brief_decision_packet.bind_plan_provenance(
                 normalized, decision_packet
             )
+        normalized, dropped_citations = prune_debate_citations(normalized, context)
+        if dropped_citations:
+            workflow_outcomes.note_degradation(
+                None, 'debate_citation_unresolved',
+                f"{len(dropped_citations)} debate evidence ref(s) matched "
+                f"nothing in this generation's context: "
+                + ', '.join(dropped_citations[:5]))
         if write and normalized != authored:
             # Atomic write: this process is SIGTERM-prone (60s exec timeout,
             # #508/#765) and a torn plan.json would fail every downstream
@@ -711,6 +793,7 @@ def main(argv=None):
         decision_packet=decision_packet,
         write=not args.dry_run,
         return_plan=True,
+        context=context,
     )
     issues += normalization_issues
     validation_path = (

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -487,6 +487,9 @@ def build_debate_sidecar(decisions, limit=DEBATE_SIDECAR_LIMIT):
         frames = debate.get('frames')
         if isinstance(frames, list) and frames:
             row['frames'] = [str(f) for f in frames]
+        cited = debate.get('evidence_ids')
+        if isinstance(cited, list) and cited:
+            row['evidence_ids'] = [str(ref) for ref in cited]
         rows.append(row)
         if len(rows) >= limit:
             break
@@ -1341,7 +1344,7 @@ def compute_debate_metrics(recent=20):
     """
     paths = sorted(glob.glob(str(WS_ROOT / 'memory' / '*-plan.json')))[-recent:]
     n_actions = n_active = n_contested = n_contested_known = 0
-    n_debate = n_bear = n_attacked = n_frames = 0
+    n_debate = n_bear = n_attacked = n_frames = n_cited = 0
     buckets = {}
     plans_n = 0
     for p in paths:
@@ -1370,6 +1373,8 @@ def compute_debate_metrics(recent=20):
             debate = a.get('debate')
             if isinstance(debate, dict) and debate:
                 n_debate += 1
+                if debate.get('evidence_ids'):
+                    n_cited += 1
                 if str(debate.get('bear') or '').strip():
                     n_bear += 1
                 if str(debate.get('attacked_consensus') or '').strip():
@@ -1393,6 +1398,7 @@ def compute_debate_metrics(recent=20):
         'debate_coverage': {
             'decisions': n_actions,
             'with_debate': n_debate,
+            'with_evidence_ids': n_cited,
             'with_bear_case': n_bear,
             'with_attacked_consensus': n_attacked,
             'with_frames': n_frames,

--- a/tests/test_debate_evidence_citations.py
+++ b/tests/test_debate_evidence_citations.py
@@ -1,0 +1,152 @@
+"""A brief-lane debate can now cite its evidence, and only what resolves (#1141).
+
+The two lanes disagreed with themselves: `workflows/validators.py` has required
+`evidence_ids` on each case of a portable-workflow debate since it shipped,
+while the daily brief accepted a debate whose bull case cited nothing. So the
+brief's strongest claim could rest on a number that appears in no evidence row,
+and nothing caught it.
+
+This wires the same discipline onto the brief lane, with one deliberate
+difference: an unresolvable citation is *dropped and counted*, never fatal.
+`validate_plan` is a publish gate — a plan that fails it degrades to no brief,
+not to a thinner one — and an invented reference inside an annotation is not
+worth that trade.
+"""
+
+import json
+from pathlib import Path
+
+
+def _context():
+    return {
+        'news_evidence_graph': {'events': [
+            {'event_id': 'evt_real', 'ticker': 'SPCH'},
+        ]},
+        'risk_guardrail': {
+            'breaches': [{'type': 'single_name', 'ticker': 'SPCH'}],
+            'hard_stop_watch': [{'type': 'leveraged_hard_stop', 'ticker': '07226'}],
+        },
+        'quant_signals': {'rows': {
+            'SPCH': {'dist_ma200_pct': -12.4, 'rsi14': None},
+        }},
+    }
+
+
+def test_only_resolvable_namespaces_survive_normalization():
+    from clawock.decision import ledger
+
+    kept = ledger.normalize_debate({
+        'bull': 'x',
+        'evidence_ids': [
+            'news:evt_real',          # good
+            'quant:SPCH:rsi14',       # good shape (resolution happens later)
+            'news:evt_real',          # duplicate
+            'vibes:it felt toppy',    # unknown namespace
+            'news:',                  # empty reference
+            42,                       # not a string
+        ],
+    })['evidence_ids']
+
+    assert kept == ['news:evt_real', 'quant:SPCH:rsi14']
+
+
+def test_the_cap_holds():
+    from clawock.decision import ledger
+
+    many = [f'news:evt_{i}' for i in range(20)]
+    assert len(ledger.normalize_debate({'bull': 'x', 'evidence_ids': many})
+               ['evidence_ids']) == ledger.DEBATE_EVIDENCE_MAX
+
+
+def test_validation_rejects_a_shape_it_cannot_normalize():
+    from clawock.decision import ledger
+
+    errors = ledger.validate_decision({
+        'decision_id': 'd1', 'debate': {'bull': 'x', 'evidence_ids': ['vibes:x']},
+    })
+    assert [e for e in errors if 'evidence_ids' in e]
+
+    errors = ledger.validate_decision({
+        'decision_id': 'd1', 'debate': {'bull': 'x', 'evidence_ids': ['news:evt_real']},
+    })
+    assert not [e for e in errors if 'evidence_ids' in e]
+
+
+def test_the_context_is_what_decides_whether_a_citation_stands():
+    from clawock.harness import brief_postflight
+
+    plan = {'decisions': [
+        {'decision_id': 'd1', 'debate': {'bull': 'x', 'evidence_ids': [
+            'news:evt_real',                    # in the graph
+            'news:evt_invented',                # not in the graph
+            'risk:single_name:SPCH',            # a real breach, with its ticker
+            'risk:leveraged_hard_stop',         # a real hard stop, unscoped
+            'risk:margin_call',                 # no such breach today
+            'quant:SPCH:dist_ma200_pct',        # a present signal field
+            'quant:SPCH:rsi14',                 # present but null → not citable
+        ]}},
+    ]}
+
+    pruned, dropped = brief_postflight.prune_debate_citations(plan, _context())
+
+    assert pruned['decisions'][0]['debate']['evidence_ids'] == [
+        'news:evt_real', 'risk:single_name:SPCH',
+        'risk:leveraged_hard_stop', 'quant:SPCH:dist_ma200_pct',
+    ]
+    assert dropped == [
+        'd1:news:evt_invented', 'd1:risk:margin_call', 'd1:quant:SPCH:rsi14',
+    ]
+
+
+def test_a_debate_that_cited_only_fiction_loses_the_field_entirely():
+    from clawock.harness import brief_postflight
+
+    plan = {'decisions': [
+        {'decision_id': 'd1', 'debate': {'bear': 'x', 'evidence_ids': ['news:evt_nope']}},
+    ]}
+    pruned, dropped = brief_postflight.prune_debate_citations(plan, _context())
+
+    debate = pruned['decisions'][0]['debate']
+    assert 'evidence_ids' not in debate, (
+        'an empty list would publish as "cited nothing" — the same as never '
+        'having written the field, but noisier')
+    assert debate['bear'] == 'x', 'the argument itself is not the thing in doubt'
+    assert dropped == ['d1:news:evt_nope']
+
+
+def test_no_context_prunes_nothing():
+    """A retry with no context must not quietly strip a plan's citations."""
+    from clawock.harness import brief_postflight
+
+    plan = {'decisions': [
+        {'decision_id': 'd1', 'debate': {'bull': 'x', 'evidence_ids': ['news:evt_real']}},
+    ]}
+    for empty in (None, {}, {'news_evidence_graph': {}}):
+        pruned, dropped = brief_postflight.prune_debate_citations(
+            json.loads(json.dumps(plan)), empty)
+        assert pruned['decisions'][0]['debate']['evidence_ids'] == ['news:evt_real']
+        assert dropped == []
+
+
+def test_the_skill_documents_the_namespaces_it_will_be_held_to():
+    """The model writes this field; a contract it cannot read is not a contract."""
+    root = Path(__file__).resolve().parents[1]
+    skill = (root / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
+        encoding='utf-8')
+
+    from clawock.decision import ledger
+
+    assert 'evidence_ids' in skill
+    for namespace in ledger.DEBATE_EVIDENCE_NAMESPACES:
+        assert f'{namespace}:' in skill, (
+            f'the {namespace} namespace resolves in postflight but is not '
+            'documented where the plan is authored')
+
+
+def test_the_page_shows_what_a_debate_stood_on():
+    root = Path(__file__).resolve().parents[1]
+    js = (root / 'site' / 'assets' / 'js' / 'dashboard.render.js').read_text(
+        encoding='utf-8')
+
+    assert 'evidence_ids' in js and 'dbt-cite' in js, (
+        'a citation nobody can see is the same unverifiable claim, one layer in')

--- a/tests/test_structured_debate.py
+++ b/tests/test_structured_debate.py
@@ -139,16 +139,21 @@ def test_the_dashboard_publishes_how_often_the_debate_was_actually_recorded(
     monkeypatch.setattr(dashboard, "WS_ROOT", tmp_path)
     _plan(tmp_path, [
         {"action": "cut", "debate": {"bear": "b", "attacked_consensus": "c",
-                                     "frames": ["momentum"]}},
+                                     "frames": ["momentum"],
+                                     "evidence_ids": ["news:evt_1"]}},
         {"action": "hold_and_watch", "debate": {"bull": "only one side"}},
         {"action": "watch"},
     ])
 
     coverage = dashboard.compute_debate_metrics()["debate_coverage"]
 
+    # `with_evidence_ids` is the second-stage series (#1141): a debate that
+    # cites nothing is counted apart from one that stands on named context,
+    # the same way a missing bear case is counted apart from a missing block.
     assert coverage == {
         "decisions": 3, "with_debate": 2, "with_bear_case": 1,
         "with_attacked_consensus": 1, "with_frames": 1,
+        "with_evidence_ids": 1,
         "bear_case_pct": 33.3,
     }
 


### PR DESCRIPTION
Closes #1141 — the gap that survived #1117.

## The disagreement this closes

| lane | contract before |
|---|---|
| portable workflow (`workflows/validators.py:159-167`) | `bull_case` / `bear_case` **must** carry `evidence_ids`; they must resolve; a bull case citing no supporting evidence is an error |
| daily brief (`decision.ledger.normalize_debate`) | a debate could cite nothing at all |

So the brief's strongest claim could rest on a number that appears in no evidence row, and nothing caught it.

## What ships

**Three namespaces, and only three** — the ones the morning context can actually back:

- `news:<event_id>` → `news_evidence_graph.events[]`
- `risk:<type>` / `risk:<type>:<ticker>` → a breach, hard stop or concentration review in `risk_guardrail`
- `quant:<ticker>:<field>` → a **present, non-null** field on that ticker's `quant_signals` row

No free-text namespace. A citation nobody can resolve reads as evidence without being any.

**Resolution is in postflight, and it drops rather than rejects.** `validate_plan` is a publish gate: a plan that fails it degrades to *no brief*, not to a thinner one (the same hazard that kept `debate` itself optional in #1117). An invented reference inside an annotation is not worth that trade — so unresolvable refs are stripped, and every strip is filed as a `debate_citation_unresolved` degradation, which rides the ledger and surfaces on the workflow-outcomes card. Dropping in silence would have left the debate looking better sourced than it was.

**Published, not just stored:** `debate_coverage.with_evidence_ids` is the new series, and the Reflect debate card prints citations ahead of the Judge's frames, tinted so a case standing on nothing is visibly standing on nothing.

**Documented where it is written:** SKILL.md gains the three namespaces, an example, and the rule that matters — *if there is nothing to cite, leave it out; a fabricated id is worse than no id.*

## Verification

`tests/test_debate_evidence_citations.py` (8 tests): unknown namespaces / empty refs / duplicates / non-strings are stripped at normalization; the cap holds; validation rejects a shape normalization would have changed; the context decides what stands (a real event, a scoped breach, an unscoped hard stop and a live signal survive; an invented event, an absent breach and a **null** signal field do not); a debate that cited only fiction loses the field rather than publishing an empty list; **no context prunes nothing**, so a retry cannot quietly strip a good plan's citations; the skill documents every namespace the code enforces; the page renders them.

Full suite in the worktree: 3076 passed, 5 skipped, 4 xfailed.
