### PR TITLE
tests: glossary parity imports pytest, and a static gate so the next one does

### DIFF
--- a/tests/test_glossary_parity.py
+++ b/tests/test_glossary_parity.py
@@ -26,6 +26,8 @@ failure mode this test exists to catch.
 import re
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 GLOSSARY = ROOT / "docs" / "glossary.md"
 

--- a/tests/test_suite_module_imports.py
+++ b/tests/test_suite_module_imports.py
@@ -1,0 +1,69 @@
+"""Every test module that calls into `pytest` must import it (#1141 fallout).
+
+`test_glossary_parity.py` used `pytest.skip(...)` on two degradation paths
+without importing the module. Both paths are the *rare* branch — GitHub
+unreachable, or the API answering with an error — so the missing import stayed
+invisible for as long as the network behaved, and then turned a soft skip into
+a hard `NameError: name 'pytest' is not defined` on master while every PR run
+before it was green.
+
+That is the shape worth gating: a name used only inside a fallback branch is
+not exercised by a passing run, so no amount of green tells you it resolves.
+This check is static — it reads the source rather than running it — which is
+exactly why it sees branches the suite never takes.
+"""
+import ast
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+
+
+def _imports_pytest(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name == "pytest" or a.name.startswith("pytest.") for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "pytest" or (node.module or "").startswith("pytest."):
+                return True
+    return False
+
+
+def _binds_pytest_locally(tree):
+    """`pytest` could also be a parameter, assignment or fixture name."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            if node.id == "pytest":
+                return True
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            names = [a.arg for a in args.args + args.posonlyargs + args.kwonlyargs]
+            if "pytest" in names:
+                return True
+    return False
+
+
+def _uses_pytest(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.value.id == "pytest":
+                return True
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            if node.id == "pytest":
+                return True
+    return False
+
+
+def test_every_test_module_that_uses_pytest_imports_it():
+    offenders = []
+    for path in sorted(TESTS.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if not _uses_pytest(tree):
+            continue
+        if _imports_pytest(tree) or _binds_pytest_locally(tree):
+            continue
+        offenders.append(path.relative_to(TESTS.parent).as_posix())
+    assert not offenders, (
+        "these test modules reference `pytest` without importing it, so any "
+        "branch that reaches the name raises NameError instead of skipping or "
+        "failing as written: " + ", ".join(offenders))


### PR DESCRIPTION
## What broke

The master push after #1141 failed CI with `1 failed, 3072 passed`:

```
FAILED tests/test_glossary_parity.py::test_first_defined_pr_references_exist
  - NameError: name 'pytest' is not defined
```

`test_first_defined_pr_references_exist` calls `pytest.skip()` on both of its
degradation paths (GitHub unreachable at the socket probe; the API answering
with an error for a specific PR), but the module imports only `re` and
`pathlib`. Every PR run reached the API successfully and never touched either
branch, so the missing import was invisible until a master run hit an API error
— at which point a check written to *skip* became a hard failure.

## The fix

- `import pytest` in `tests/test_glossary_parity.py`.
- `tests/test_suite_module_imports.py`: a static (AST) check that every module
  under `tests/` referencing `pytest` imports it. It reads the source instead
  of running it, which is the point — a name used only in a fallback branch is
  not exercised by a passing run, so green tells you nothing about whether it
  resolves.

## Verification

- `pytest tests/test_glossary_parity.py tests/test_suite_module_imports.py` — 11 passed.
- Removed the import again: the new gate fails with
  `assert not ['tests/test_glossary_parity.py']`. Restored, green.
- Drove the exact branch that broke master (`socket.create_connection` raising
  `OSError`): now raises `Skipped: GitHub unreachable; PR pointer check skipped`
  as written.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw