### PR TITLE
delivery: a failed co-send has to say why, and an exit code is not a verdict

### DIFF
--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -751,7 +751,17 @@ def cosend_telegram(message, tag, dry_run=False):
         ok, out = send_telegram(KCN_TELEGRAM, message, dry_run)
     except Exception as e:
         ok, out = False, str(e)[:300]
-    log({'tag': tag, 'action': 'telegram-cosend', 'sent_ok': bool(ok), 'dry_run': bool(dry_run)})
+    entry = {'tag': tag, 'action': 'telegram-cosend', 'sent_ok': bool(ok),
+             'dry_run': bool(dry_run)}
+    if not ok:
+        # The failure tail used to be returned to a caller that dropped it, so a
+        # failed co-send left no reason anywhere — three of them on 2026-08-31
+        # (brief 08:08, hk-open 09:34, intraday-hk 10:04) each cost a watchdog
+        # mirror and none of them can be explained after the fact. `tg_ok=false`
+        # is what makes the watchdog fire, so the reason belongs in the same log
+        # as the firing.
+        entry['detail'] = (out or 'no output from the transport')[-300:]
+    log(entry)
     return ok, out
 
 

--- a/src/clawock/providers/delivery.py
+++ b/src/clawock/providers/delivery.py
@@ -20,6 +20,7 @@ duplicate sends. It has to be its own state.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass, field
 from typing import Protocol
@@ -39,6 +40,21 @@ def delivery_disabled() -> bool:
     return os.environ.get("CLAWOCK_DELIVERY_DISABLED", "").strip().lower() in {
         "1", "true", "yes", "on",
     }
+
+
+_MESSAGE_ID = re.compile(r'"messageId"\s*:\s*"?([^",\s}]+)', re.IGNORECASE)
+
+
+def _names_a_message(output: str | None) -> bool:
+    """Whether the transport's output identifies a message it accepted.
+
+    Only a real id counts: `"messageId": null` is the transport saying it has
+    none, which is the opposite of evidence.
+    """
+    if not output:
+        return False
+    return any(m.group(1).lower() not in ("null", "none", "")
+               for m in _MESSAGE_ID.finditer(output))
 
 
 @dataclass(frozen=True)
@@ -138,7 +154,15 @@ class OpenClawDelivery:
 
         tail = (output or "").strip()[-400:]
         if code != 0:
-            return DeliveryResult("failed", channel, str(target), detail=tail,
+            # A non-zero exit is not proof that nothing was sent. On 2026-08-31
+            # the brief's Telegram co-send was recorded failed at 08:08:50 while
+            # the gateway went on to hand Telegram messageId 1164 at 08:08:54 —
+            # so the marker said tg_ok=false and the watchdog mirrored a card
+            # that had already landed. When the transport's own output names a
+            # message it accepted, treat the exit the way a timeout is treated:
+            # `unknown`, which still mirrors, rather than `failed`.
+            status = "unknown" if _names_a_message(output) else "failed"
+            return DeliveryResult(status, channel, str(target), detail=tail,
                                   idempotency_key=idempotency_key)
         status = "confirmed" if channel in CONFIRMING_CHANNELS else "unknown"
         return DeliveryResult(status, channel, str(target), detail=tail,

--- a/tests/test_cosend_failure_is_explained.py
+++ b/tests/test_cosend_failure_is_explained.py
@@ -1,0 +1,67 @@
+"""A failed Telegram co-send must record why (2026-08-31).
+
+`tg_ok=false` in the marker is the single fact that makes a watchdog fire, and
+three co-sends failed that morning — brief 08:08, hk-open 09:34, intraday-hk
+10:04. Each cost a mirror, and none of them left a reason anywhere: the
+transport's failure tail was returned to a caller that dropped it, and the log
+line recorded only `sent_ok: false`. The reason belongs in the same record as
+the outcome that acts on it.
+"""
+from clawock.harness import _watchdog_common as common
+
+
+def _capture(monkeypatch):
+    written = []
+    monkeypatch.setattr(common, 'log', written.append)
+    return written
+
+
+def test_a_failed_cosend_records_the_transports_reason(monkeypatch):
+    written = _capture(monkeypatch)
+    monkeypatch.setattr(common, 'send_telegram',
+                        lambda target, message, dry_run: (False, 'EPIPE: broken pipe'))
+
+    ok, _ = common.cosend_telegram('body', 'brief')
+
+    assert ok is False
+    assert written[0]['detail'] == 'EPIPE: broken pipe', (
+        'the failure tail must reach the log the watchdog decision is read from')
+
+
+def test_a_silent_failure_says_so_rather_than_leaving_the_field_out(monkeypatch):
+    """An empty tail is itself a finding — "the transport said nothing" is a
+    different failure from "the transport explained itself"."""
+    written = _capture(monkeypatch)
+    monkeypatch.setattr(common, 'send_telegram',
+                        lambda target, message, dry_run: (False, ''))
+
+    common.cosend_telegram('body', 'hk-open')
+
+    assert written[0]['detail'] == 'no output from the transport'
+
+
+def test_a_raising_transport_is_recorded_as_the_exception(monkeypatch):
+    written = _capture(monkeypatch)
+
+    def boom(target, message, dry_run):
+        raise RuntimeError('gateway refused the connection')
+
+    monkeypatch.setattr(common, 'send_telegram', boom)
+
+    ok, _ = common.cosend_telegram('body', 'intraday-hk')
+
+    assert ok is False
+    assert 'gateway refused the connection' in written[0]['detail']
+
+
+def test_a_successful_cosend_stays_a_one_line_record(monkeypatch):
+    """No detail on success: the log is read by eye, and a reason field on a
+    send that worked is noise that makes the failures harder to spot."""
+    written = _capture(monkeypatch)
+    monkeypatch.setattr(common, 'send_telegram',
+                        lambda target, message, dry_run: (True, 'messageId 1164'))
+
+    ok, _ = common.cosend_telegram('body', 'brief')
+
+    assert ok is True
+    assert 'detail' not in written[0]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -73,6 +73,41 @@ def test_a_timeout_is_unknown_because_the_message_may_have_gone():
     assert sent.status == "unknown"
 
 
+def test_a_nonzero_exit_that_still_named_a_message_is_unknown_not_failed():
+    """2026-08-31: the exit code lost a race the delivery had already won.
+
+    The brief's Telegram co-send was recorded failed at 08:08:50; the gateway
+    handed Telegram messageId 1164 at 08:08:54. `failed` wrote tg_ok=false into
+    the marker, the watchdog read that as "never arrived" and mirrored the same
+    card at 08:30. An id in the transport's own output is evidence of the
+    opposite, so it downgrades the verdict to `unknown` — which still mirrors
+    when nothing else confirms, but no longer asserts a miss.
+    """
+    out = '{"action":"send","messageId":"1164","payload":{"ok":true}}\nEPIPE'
+    sent = OpenClawDelivery(runner=lambda cmd: (1, out)).send(
+        "telegram", "123", "hello")
+
+    assert sent.status == "unknown"
+    assert sent.reached_target is False
+    assert sent.worth_mirroring is True
+
+
+def test_a_nonzero_exit_with_no_message_id_is_still_a_failure():
+    sent = OpenClawDelivery(runner=lambda cmd: (1, "connection refused")).send(
+        "telegram", "123", "hello")
+
+    assert sent.status == "failed"
+    assert "connection refused" in sent.detail
+
+
+def test_a_null_message_id_is_not_evidence_of_delivery():
+    """The transport saying it has no id is the opposite of naming one."""
+    sent = OpenClawDelivery(runner=lambda cmd: (1, '{"messageId": null}')).send(
+        "telegram", "123", "hello")
+
+    assert sent.status == "failed"
+
+
 def test_a_missing_binary_reports_instead_of_raising():
     def missing(cmd):
         raise FileNotFoundError(cmd[0])


### PR DESCRIPTION
## What happened today

Three Telegram co-sends failed this morning, each costing a watchdog fallback that kcn noticed:

| slot | co-send failed | watchdog response |
|---|---|---|
| brief | 08:08:50 | mirror-telegram 08:30 |
| hk-open | 09:34:27 | deterministic-fallback 09:45 |
| intraday-hk | 10:04:47 | mirror-telegram 10:10 |

**None of the three can be explained.** `send_telegram` returns the transport's failure tail, `cosend_telegram` returned it to the caller, and all three postflights bind it to `_tg_out` and drop it. The only record is `{"action": "telegram-cosend", "sent_ok": false}`.

**And at least one of them was not a failure.** The gateway journal:

```
08:08:50.880  clawock       telegram-cosend sent_ok=false
08:08:54.565  [telegram]    outbound send ok ... messageId=1164
08:08:54.615  [ws] res ✓ message.action 6964ms channel=telegram
```

The CLI exited non-zero ~3s into a request the gateway went on to complete. `failed` wrote `tg_ok=false` into the marker, the watchdog read that as "never arrived", and mirrored the same brief card at 08:30 — a duplicate, not a rescue.

## Changes

- `cosend_telegram` writes the failure reason into the same `watchdog.jsonl` line as the outcome (`detail`, ≤300 chars; `no output from the transport` when the tail is empty). Successful co-sends stay one line.
- `OpenClawDelivery.send`: a non-zero exit whose output still names an accepted `messageId` returns `unknown` instead of `failed` — the verdict a timeout already gets, on the same reasoning ("it may well have gone; calling this failed invites a duplicate"). `"messageId": null` is not evidence and stays `failed`.

`unknown` still mirrors (`worth_mirroring`), so nothing loses its backstop; what stops is asserting a miss that the transport's own output contradicts.

## Verification

- New: `tests/test_cosend_failure_is_explained.py` (4 cases) and 3 cases in `tests/test_providers.py`.
- `pytest -k "delivery or watchdog or postflight or provider or send"` — 228 passed, 2 skipped.

## What this does not fix

Why the CLI exited non-zero at all is still unknown — that is exactly what the missing `detail` cost us. The next occurrence will carry its reason.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw