### PR TITLE
brief: the model writes the thinking, the harness writes the report

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -192,7 +192,8 @@ These are installed commands too. They are listed here so the catalog is the who
 
 **Daily deep brief**（08:00 HKT cron）
 - **`clawock brief preflight`**：刷 US/HK 价 + FX + portfolio snapshot + HHI 算法 + SEC EDGAR (仅 `is_leveraged_etf=false`) + retrospective vs 上次 plan.json。输出 `memory/.tmp/brief-context-{date}.json`
-- **`clawock brief postflight`**：校验 `memory/{date}-pre-open.md` + `memory/{date}-plan.json`（段标记 / plan schema / HHI / FX / HKD+USD bug pattern）；pass/warn 自动 commit
+- **`clawock brief render`**：从 `brief-context-{date}.json` + `brief-judgment-{date}.json` + `{date}-plan.json` 渲染 `memory/{date}-pre-open.md` 与 `memory/.tmp/brief-card-{date}.txt`。模型只写 judgment 里的判断文字，标题/表格/排序/数字格式全在代码里（`--dry-run` 打到 stdout 不写盘）。postflight 会自己跑一次，日常不用手动调
+- **`clawock brief postflight`**：校验 plan schema + judgment overlay，用校验后的 plan 渲染报告与微信卡，再校验产物（段标记 / HHI / FX / HKD+USD bug pattern）；pass/warn 自动 commit
 
 **Mode 6 briefing**（HK 开/午/午后/收盘 + US 开/收盘 — 6 个 cron 共享）
 - **`clawock report preflight --market {hk|us} --phase {open|mid|pm|close}`**：跑 analyze_*.py + 抽信号 (WATCH/STOP/TRIM 计数) + 异动 (≥3% 涨跌) + 指数方向；写 `memory/.tmp/report-context-{market}-{phase}-{date}.json`（`{date}` = 跑批当天）并清掉该 market+phase 其它日期的残留；**stdout 与文件是同一份 JSON**（含 `context_id`，末行 `context_path:`），靠 `peer_scan` 在源头裁剪保持小体积。`raw_wechat_block` 不再经模型手 —— postflight 自己拼进消息

--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-deep-brief
-description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分析。harness 化：`clawock brief preflight` 计算并编译 typed decision packet，LLM 只做 Tier 1/2/3/Judge 与受限 judgment overlay，`clawock brief postflight` 验证、生成 Pages projection、commit 并自动投递微信。**输出**：完整 markdown、结构化 plan、受限 judgment JSON 与紧凑微信卡。**只在每日 8 点 cron 触发时使用；手动深度分析仍走 portfolio-swarm-review。**
+description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分析。harness 化：`clawock brief preflight` 计算并编译 typed decision packet，LLM 只写 plan 与受限 judgment（纯文本判断，不写版式），`clawock brief postflight` 校验后由 `brief_render` 渲染报告与微信卡、生成 Pages projection、commit 并自动投递微信。**输出**：结构化 plan、受限 judgment JSON，harness 渲染的 markdown 报告与紧凑微信卡。**只在每日 8 点 cron 触发时使用；手动深度分析仍走 portfolio-swarm-review。**
 ---
 
 # Daily Deep Brief (08:00 HKT, weekday)
@@ -11,12 +11,13 @@ description: kcn 每个工作日 08:00 HKT 跑一次的盘前全 swarm 深度分
 ## Harness 架构（不可越权）
 
 ```
-┌────────────────────┐     ┌───────────────┐     ┌────────────────────┐
-│ clawock brief preflight            │ ──► │ LLM (你 / Rick)│ ──► │ clawock brief postflight │
-│  (确定性 + 幂等)   │     │ (只写判断/反方)│     │ 验证+projection+投递│
-└────────────────────┘     └───────────────┘     └────────────────────┘
-   指标/因子/风险/evidence   查 packet summary/ticker 校验 md+plan+judgment，
-   编译 typed packet         写判断与解释            Pages 只读稳定 projection
+┌──────────────────────┐   ┌────────────────┐   ┌──────────────────────────┐
+│ clawock brief preflight │──►│ LLM (你 / Rick) │──►│ clawock brief postflight  │
+│   (确定性 + 幂等)      │   │ (只写判断/反方) │   │ 校验 → 渲染 → 投递        │
+└──────────────────────┘   └────────────────┘   └──────────────────────────┘
+   指标/因子/风险/evidence     查 packet summary     校验 plan+judgment，
+   编译 typed packet           写 plan + judgment    brief_render 出 md+微信卡，
+                               (纯文本，不写版式)    Pages 只读稳定 projection
 ```
 
 **为什么这样分**：之前完全交给 LLM，模型可能漏快照、漏 HHI、漏 FX、漏 retrospective。
@@ -233,7 +234,7 @@ manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 c
   - 护栏是硬闸：额度用尽时脚本返回 "Web search unavailable" 并 exit 0，**别当报错**，退回内置搜索即可
 - 每个板块输出：Top 3-5 涨幅 + 你持仓票在榜单中的位置（领涨/落后/中位）
 - **归因句必带**：落后是因为(a) 利好时点（盘后才公布）/ (b) 早盘异常抛压 / (c) β 错配 / (d) 个股逻辑滞后？
-- 输出在 ▎板块全景 段（pre-open.md 必带），引用 ≥3 个具体涨跌幅 + 1 个明确归因
+- 结论写进 `judgment.narrative.sector_read`（纯文本，引 ≥3 个具体涨跌幅 + 1 个明确归因）；报告里的板块表由 harness 从 `context.peer_scan` 渲染，逐票那句判断写在该票的 `peer_read`
 - ⚠️ **持仓自己的数字** (RSI/MA/PnL) 仍然从 core 取，板块这段只 search 板块/同行公开行情
 - **同时落盘到** `memory/.tmp/sector-scan-{date}.json`（build_dashboard 会读，让 GH Pages dashboard 同步显示）。schema：
   ```json
@@ -278,7 +279,7 @@ manifest 若出现 `extras`，表示新 feature 被隔离而没有偷长常驻 c
 - kcn 风险偏好 = **激进**（USER.md），Aggressive 默认略多权重
 - **但** trending down regime 启动时 Conservative 权重 +1 档
 - 数据 stale 任何一段 → 涉及票 confidence -10pp
-- **视角轮换（#1101）**：三位风险官的首位表态权每 4 个交易日轮换（Aggressive → Conservative → Neutral → 循环），当日首位 voice 写进 pre-open.md。轮换只改表态顺序与框架设定，**不改** kcn 激进偏好的权重规则。
+- **视角轮换（#1101）**：三位风险官的首位表态权每 4 个交易日轮换（Aggressive → Conservative → Neutral → 循环），当日首位 voice 写进 `judgment.narrative.risk_voice_first`（harness 据此排序）。轮换只改表态顺序与框架设定，**不改** kcn 激进偏好的权重规则。
 
 输出策略级 decision。**同一股票同一天允许多条决策**，例如 `core_position` 继续持有，同时 `intraday_t` 做日内 T；两者不能互相覆盖。
 
@@ -641,46 +642,38 @@ calibration bundle 的 `decision_metrics` 是 v2 唯一口径：只结算**条�
 - US 开盘后 09:30 ET 关注什么
 - Book-level metric 红线（例：港股浮亏到 X% 触发 forced derisk）
 
-### Step 4: 写输出文件（A 报告 / B plan / C judgment / D insights / E 微信卡）
+### Step 4: 写输出文件（B plan / C judgment / D insights —— A 报告与 E 微信卡由 harness 渲染）
 
-#### A. Markdown 报告 → `memory/{YYYY-MM-DD}-pre-open.md`
+#### A. 报告与微信卡：**你不写，harness 渲染**
 
-结构（**postflight 会校验这些段标记**，缺哪个 fail）：
+`memory/{YYYY-MM-DD}-pre-open.md` 与 `memory/.tmp/brief-card-{YYYY-MM-DD}.txt`
+由 `clawock.harness.brief_render` 从**本次 context + 你的 judgment + 校验后的 plan**
+渲染，postflight 自动跑，不需要你调用。
 
-- `# Header`（regime US/HK 分开 + FX rate + book USD/HKD 双视角）
-- `## ▎仓位明细` —— HK + US 各一张 7 列 markdown 表 `代码 | 股 | 成本 | 现价 | 今日 | 浮% | 浮$`（与 Mode 6/7 cron 完全一致；数据从 core 的 `portfolio.portfolios.{hk,us}_stocks.holdings` 直接取，**只列 shares>0 的**。2026-05-21 起的 visual-width-aware 渲染推荐 import `clawock.adapters.mobile.render_holdings_table`，省得手算 CJK 对齐）
-- `## Retrospective`（来自 calibration bundle 的 retrospective）
-- `## Tier 1` 大表
-- `## Tier 2` Bull vs Bear
-- `## Tier 3` Aggressive/Conservative/Neutral + Judge
-- `## ▎同行扫描` peer rotation matrix (uses `peer_scan` from context)
-- `## ▎大盘速读` macro 一句话 5 行内 (uses `macro` from context; 数据 stale > 36h 时跳过)
-- `## ▎社交舆情速读` per-ticker Reddit + news (uses `sentiment` from context; 无信号票自动剔)
-- `## ▎名人异动/政策风向` Trump/Musk/Serenity radar (uses `influencer` from context; 撞持仓>新机会>板块相关, total=0 或 stale>36h 跳过)
-- `## Confidence` 表
-- `## ▎Decision v2 校准`（使用 `decision_metrics`，按 episode / strategy 展示）
-- `## Next-Session` plan
+**不要写这两个文件。** 你手写的稿子会在 postflight 里被渲染结果覆盖——它不会
+进产品，只会浪费一轮 token。
 
-必须包含的内容关键词（postflight 检查）：
-- "HHI" — 集中度段
-- "USDHKD" 或 "FX" 或 "汇率" — FX 段
-- 不能出现 "合计 -4423" / "合计 -4,423" 这种 HKD+USD 直接相加的历史 bug
+为什么这么分（2026-08-31，kcn 定）：报告过去由模型逐行手写，于是①版式每天重新
+发明一遍，同一张表昨天七列今天六列；②该留在辩论段的推演渗进表格里，读者要在一堆
+过程文字里找"09:30 到底做什么"。现在**模型只出想法，harness 只出版式**：标题层级、
+表格、排序、数字格式、段落顺序全部在代码里，每天同一个位置放同一件事。
 
-**写作时体量预算（在 Step 4-A 内完成，不是 postflight 返工）**：目标 ≤28KB；≥40KB
-属于极端超长，会让成品健康状态降级。按以下分段预算写初稿，给 Markdown 标记留出余量：
+因此：
 
-- Header + book/仓位表 + 核心结论：≤5KB
-- Retrospective + Tier 1：≤6KB
-- Tier 2 + Tier 3/Judge：≤6KB
-- 同行明细完整 + macro + sentiment + influencer：≤5KB（空间不足时先压后三者的重复解释）
-- Confidence + Decision v2 + Next-Session：≤4KB
+- 你写的每一段判断都通过 **B（plan）** 和 **C（judgment）** 进入报告，别处不进。
+- judgment 的文字字段**必须是纯文本**：不许出现 `|`、`#`、`**`、` ``` `、`▎`、
+  行首 `-`/`*`/`1.`/`>`。这不是文风要求——渲染器正在画那张表，你的竖线会落进单元格里
+  把那一行撑成多一列。postflight 会直接判非法并指出是哪个字段。
+- 事实、指标、风控闸、集中度、回本数学、同行涨跌、宏观读数、校准表全部由 harness
+  从 context 取；**你不需要把它们抄进 judgment**，抄了也不会被用。
+- 体量不再由你控制：渲染结果通常 18–22KB，远在 28KB 预算内。原来那套"分段预算 +
+  写完 `wc -c`"的自查随本节一起退役。
 
-初稿写完但仍在 Step 4-A 时，运行 `wc -c memory/{YYYY-MM-DD}-pre-open.md`。若 >28KB，
-在定稿前删除重复解释、缩短逐票叙述、合并同义句；所有必需段落、证据、风险闸和行动必须完整
-保留。**同行明细不是压缩对象**：同行枚举、相对涨跌、持仓位置和归因必须保留；同行组超预算
-时先压 macro / sentiment / influencer 的重复解释。若 ≥40KB，必须先按分段预算收敛再跑
-postflight。**禁止**用 `head`、`truncate`、字符串切片或其他事后硬**截断**；也禁止为了压
-体量删除证据、风险闸或行动段。
+本地想看渲染结果（不写盘）：
+
+```bash
+clawock brief render --dry-run
+```
 
 #### B. 结构化 plan → `memory/{YYYY-MM-DD}-plan.json`
 
@@ -797,7 +790,14 @@ postflight 严格 schema 校验：
   --arg manifest=/root/.openclaw/workspace/memory/.tmp/brief-context-$(date +%Y-%m-%d)/manifest.json
 ```
 
-schema 只允许顶层 `schema_version/context_generation_id/portfolio_assessment/portfolio_counterargument/ticker_judgments`；每票只允许：
+**schema v3（2026-08-31）**：这份文件现在同时是 Pages projection 的判断层
+**和整篇报告的文字来源**——Tier 2/3、板块解读、大盘解读、校准解读、下一时段计划
+都从这里渲染。写漏一个字段，就是发布出去的报告里空一段。
+
+顶层只允许 `schema_version/context_generation_id/portfolio_assessment/
+portfolio_counterargument/narrative/ticker_judgments`。
+
+每票只允许（前九个字段照旧，后四个是 Tier 1 那张表里 harness 算不出来的格）：
 
 ```json
 {
@@ -809,11 +809,46 @@ schema 只允许顶层 `schema_version/context_generation_id/portfolio_assessmen
   "counterargument": "最强反方",
   "rationale": "为何在冲突信号中这样判断",
   "falsifier": "什么事实会推翻当前候选/等待判断",
-  "next_evidence": "下一步要找的一手披露或价格确认"
+  "next_evidence": "下一步要找的一手披露或价格确认",
+  "fundamentals": "Tier 1 · 基本面格：EDGAR/财报/ETF 标的口径",
+  "cross_market": "Tier 1 · 跨市场格：跟随还是背离",
+  "sentiment_read": "Tier 1 · 情绪格：这条消息面对决策的权限（硬催化/软情绪）",
+  "peer_read": "同行扫描那一行的判断：领先/落后说明什么"
 }
 ```
 
-禁止加入价格、RSI、MA、因子分、股数、action、evidence 内容或其他字段。postflight 严格校验后才会把这些文字并入 `assets/data/brief_projection.json`；overlay 缺失/非法时 Pages 仍发布 deterministic rows，只把 `judgment_status` 标为 missing/invalid。
+`narrative`（整篇报告的辩论层，全部必填）：
+
+```json
+{
+  "regime_read": "Header 那行 regime 的解读",
+  "bull": "Tier 2 多头案（引 ≥2 个具体数据点）",
+  "bear": "Tier 2 空头案（同上）",
+  "devils_advocate": "点名攻击当前最强共识",
+  "attacked_consensus": "被攻击的那条共识，一句话",
+  "risk_voice_first": "aggressive|conservative|neutral（今日首位表态，4 个交易日轮换）",
+  "aggressive": "Tier 3 · 抓 upside",
+  "conservative": "Tier 3 · 保本 derisk",
+  "neutral": "Tier 3 · 对每个争议票拍一边",
+  "sector_read": "板块全景的归因结论",
+  "macro_read": "大盘速读的一句判断",
+  "calibration_read": "Decision v2 校准表怎么读",
+  "next_session": ["下一时段第 1 步", "第 2 步"],
+  "data_holes": ["还缺什么数据（可空数组）"]
+}
+```
+
+三条硬规则：
+
+1. **纯文本**。任何字段出现 `|`、`#`、`**`、` ``` `、`▎` 或行首 `-`/`*`/`1.`/`>`
+   都会被 postflight 判非法并点名字段——版式是 harness 的活（见 A 节）。
+2. **不写事实**。禁止加入价格、RSI、MA、因子分、股数、action、evidence 内容；
+   harness 已经从 context 把它们渲染进表里，你重复一遍只会有对不上的风险。
+3. `risk_voice_first` 只决定三位风险官的**表态顺序**，不改 kcn 激进偏好的权重规则。
+
+postflight 严格校验后才把这些文字并入 `assets/data/brief_projection.json`；
+overlay 缺失/非法时 Pages 仍发布 deterministic rows，只把 `judgment_status` 标为
+missing/invalid——但报告的辩论段会因此空着，所以这不是"可选项"。
 
 #### D. LLM 复盘 sidecar → `memory/.tmp/insights-{YYYY-MM-DD}.json`
 
@@ -848,36 +883,14 @@ build_dashboard 会读它，让 dashboard 上 **行为复盘 / 唱反调 Pre-mor
 - **hidden_concentration**：看 sector_exposure + leveraged_etf + 持仓权重，识别表面分散实际同因子；`exposure_pct` 给该因子占组合的估算整数。
 - 全部中文，口吻直接、像私人交易教练，指出问题不安慰。
 
-#### E. 微信卡 → `memory/.tmp/brief-card-{YYYY-MM-DD}.txt`
+#### E. 微信卡：harness 渲染，不用你写
 
-**这是真正发到 kcn 微信的内容**（投递由 Step 5 的 postflight 自动完成，原样发这个文件），所以必须自洽完整、≤1.5KB。数字全来自 `plan.json` + 本次 generation 的 core/bundles，不现编：
+`memory/.tmp/brief-card-{YYYY-MM-DD}.txt` 与报告一起由 `brief_render` 生成：
+标题行 + 核心结论（取 `judgment.portfolio_assessment`）+ Book/HHI + 今日动作
+（取 plan 的 decisions，含 driven_by 与 confidence）+ 触发位（plan 的
+`watch_levels`）+ 完整报告链接。**别再手写这个文件**——写了会被覆盖。
 
-```
-📊 盘前深度简报｜{日期 周X} 08:00 HKT  (USDHKD={rate})
-
-▎核心结论（≤2 句）
-{regime + 今日最关键的一句判断，如 "risk_on 默认 HOLD，AI/高beta 单因子敞口偏高，主动操作克制"}
-
-▎Book
-USD${total} ({pct}%) | HK leg {hk}HKD | US leg {us}USD
-
-▎今日动作（≤4 条，来自 plan.json，标 driven_by）
-1. {ticker} [{strategy_id}] {action} {condition}(conf{%})
-2. …
-
-▎触发位（≤2 条最近的）
-{watch_levels 关键 1-2 条}
-
-▎提前布局候选
-{从 packet.add_alpha_diagnostics 逐字汇总 early hints / exploration / allowed 数量；列最多2票的 candidate|wait 及主要 blocker。allowed=0 也必须显示，禁止把候选隐藏成“无信号”}
-
-📈 完整深度报告（Tier1/2/3 辩论 + 板块全景 + 复盘 + 唱反调）：
-https://kcnyu.github.io/clawock/memory/{date}-pre-open.html
-```
-
-- 链接里 `{date}` 换成今天 `YYYY-MM-DD`（落盘文件名同款），直接打开今天这篇完整 brief MD 页（不是 dashboard 首页）。
-- **🔒 只把紧凑卡写进这个文件**，绝不把完整 markdown brief 塞进来（完整版已在 `pre-open.md` + dashboard）。短卡 = 手机第一屏好读 + 远低于 16KB。
-- 万一漏写这个文件，postflight 会从 `plan.json` 兜底生成一张（信息更少、无"核心结论"叙事），所以别漏。
+想让卡上那句"核心结论"更准，改的是 `judgment.portfolio_assessment`，不是卡本身。
 
 ### Step 5: 跑 postflight（验证 + commit + 自动投递微信）
 
@@ -912,21 +925,20 @@ clawock brief postflight
 > **2026-07-27 教训**：旧规则把 35.8KB 和表格 critical 混在同一个 issues 列表里，模型误把
 > 体量当硬闸，事后一路裁到 23.7KB，既浪费时间/tokens 又引入编辑错误。新规则把体量单独记录：
 > 28–40KB 是结构化 `advisory`，不计入 issues、不让已交付成品变黄；≥40KB 才是实际 `warn`。
-> 无论哪档都保留完整正文，绝不在 postflight 后硬截断。体量应按 Step 4-A 的分段预算在定稿前
-> 收敛，不能牺牲必需段落、证据、风险闸或行动。
+> 无论哪档都保留完整正文，绝不在 postflight 后硬截断。**2026-08-31 起体量不再由模型控制**：报告由 `brief_render` 渲染，通常 18–22KB；这条闸留着是为了在渲染器或持仓规模变化时仍能报警。
 
 ### 投递（Step 5 postflight 内自动，你什么都不用做）
 
 > **🔒 投递已解耦——你绝不要手动发微信、绝不调任何 message/send 工具、也不要把卡片当回复文本贴出来。**
 >
-> pass/warn 时 **`brief_postflight` 自己**会用 fresh-token 短连接把 Step 4-D 的
+> pass/warn 时 **`brief_postflight` 自己**会用 fresh-token 短连接把渲染出的
 > `brief-card-{date}.txt` 投到 kcn 微信（cron 已设 `delivery=none`，这是唯一微信路径），
 > 并同步 Telegram，把两路结果记到 `memory/.tmp/brief-sent-{date}.json`。
 > `brief_watchdog`（08:30）只在 Telegram marker 缺失/失败时补投 Telegram，不重发微信。
 >
 > **为什么这样改（2026-06-08）**：旧的 `delivery=announce` 在长 turn 末尾用 turn 起点抓的 token 投递，brief turn 恒 >160s（173–975s）→ token 必过期 → 静默丢、`delivered=true` 是假信号（见 memory: openclaw-wechat-longturn-token-expiry）。短命 message send 每次抓新 token，且独立于 turn 时长，kcn 实测可靠（同 intraday 架构）。
 >
-> **你的职责到 Step 5 跑完 postflight 为止**：产出 A/B/C/D/E 五个文件 + 跑 postflight。看到 `wechat_sent: true` 即大功告成，**立即结束本轮，不要再追加任何思考或内容**。
+> **你的职责到 Step 5 跑完 postflight 为止**：产出 B/C/D 三个文件（plan / judgment / insights）+ 跑 postflight，报告与微信卡由 postflight 内的 `brief_render` 生成。看到 `wechat_sent: true` 即大功告成，**立即结束本轮，不要再追加任何思考或内容**。
 >
 > **🔒 送达确认铁律（2026-08-15 起，#558）**：
 > postflight **之后禁止**用 exec / list / show 去读 `memory/.tmp/` 下的 marker、claim、sent 文件"眼见为实"确认送达。

--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -625,7 +625,11 @@ def main(argv=None) -> int:
 
     for workflow in ("brief", "intraday"):
         harness = sub.add_parser(workflow, help=f"run {workflow} harness in-process")
-        harness.add_argument("harness_phase", choices=("preflight", "postflight"))
+        # `render` is brief-only: it is the step that turns the model's judgment
+        # into the published report, and only the brief has one.
+        phases = (("preflight", "postflight", "render") if workflow == "brief"
+                  else ("preflight", "postflight"))
+        harness.add_argument("harness_phase", choices=phases)
         harness.add_argument("--market", choices=("hk", "us"))
         harness.add_argument("--context-id")
         harness.add_argument("--text-file", type=Path)

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import math
 import os
+import re
 from pathlib import Path
 
 from clawock.decision.actions import ACTIVE_ACTIONS
@@ -25,7 +26,7 @@ from clawock.workspace import workspace_root
 
 
 SCHEMA_VERSION = 1
-JUDGMENT_SCHEMA_VERSION = 2
+JUDGMENT_SCHEMA_VERSION = 3
 PAGES_SCHEMA_VERSION = 1
 MAX_PACKET_BYTES = 96 * 1024
 MAX_QUERY_BYTES = 24 * 1024
@@ -52,7 +53,64 @@ TEXT_LIMITS = {
     "rationale": 500,
     "falsifier": 300,
     "next_evidence": 300,
+    # Tier 1 cells the harness cannot compute: what the filings say, and how the
+    # name sits against its own market.  Short, because they are table cells.
+    "fundamentals": 300,
+    "cross_market": 300,
+    "sentiment_read": 300,
+    "peer_read": 300,
+    # The narrative slots.  These carry the debate the report used to contain as
+    # model-authored markdown; the harness lays them out now, so they are text.
+    "regime_read": 600,
+    "bull": 700,
+    "bear": 700,
+    "devils_advocate": 700,
+    "attacked_consensus": 200,
+    "aggressive": 700,
+    "conservative": 700,
+    "neutral": 900,
+    "sector_read": 700,
+    "macro_read": 600,
+    "calibration_read": 600,
+    "next_session": 400,
+    "data_holes": 400,
 }
+RISK_VOICES = ("aggressive", "conservative", "neutral")
+NARRATIVE_TEXT_FIELDS = (
+    "regime_read", "bull", "bear", "devils_advocate", "attacked_consensus",
+    "aggressive", "conservative", "neutral", "sector_read", "macro_read",
+    "calibration_read",
+)
+NARRATIVE_LIST_FIELDS = {"next_session": (1, 8), "data_holes": (0, 8)}
+ROW_TEXT_FIELDS = (
+    "assessment", "counterargument", "rationale", "falsifier", "next_evidence",
+    "fundamentals", "cross_market", "sentiment_read", "peer_read",
+)
+
+# Layout the model must not emit.  The report's markdown is rendered by
+# `clawock.harness.brief_render` from these fields plus the deterministic
+# context, so a pipe or a heading in a judgment field is not a formatting
+# preference — it lands inside a table cell the harness is already drawing and
+# breaks the row.  Rejecting it here is what keeps "the model writes thoughts,
+# the harness writes layout" true rather than merely intended.
+_LAYOUT_MARKERS = (
+    ("|", "table pipe"),
+    ("```", "code fence"),
+    ("▎", "section ornament"),
+    ("**", "bold marker"),
+)
+_LAYOUT_LINE_START = re.compile(r"^\s*(#{1,6}\s|[-*+]\s|\d+\.\s|>\s)")
+
+
+def _layout_violation(value: str) -> str | None:
+    """The formatting complaint about one prose field, or None if it is prose."""
+    for marker, label in _LAYOUT_MARKERS:
+        if marker in value:
+            return f"contains a {label} ({marker!r})"
+    for line in value.splitlines():
+        if _LAYOUT_LINE_START.match(line):
+            return "starts a line with a markdown heading, bullet or quote marker"
+    return None
 
 
 def _compact(value) -> str:
@@ -1263,6 +1321,22 @@ def judgment_template(packet: dict) -> dict:
         "context_generation_id": generation_id,
         "portfolio_assessment": "",
         "portfolio_counterargument": "",
+        "narrative": {
+            "regime_read": "",
+            "bull": "",
+            "bear": "",
+            "devils_advocate": "",
+            "attacked_consensus": "",
+            "risk_voice_first": "aggressive",
+            "aggressive": "",
+            "conservative": "",
+            "neutral": "",
+            "sector_read": "",
+            "macro_read": "",
+            "calibration_read": "",
+            "next_session": [],
+            "data_holes": [],
+        },
         "ticker_judgments": [
             {
                 "ticker": ticker,
@@ -1274,21 +1348,75 @@ def judgment_template(packet: dict) -> dict:
                 "rationale": "",
                 "falsifier": "",
                 "next_evidence": "",
+                "fundamentals": "",
+                "cross_market": "",
+                "sentiment_read": "",
+                "peer_read": "",
             }
             for ticker in packet.get("tickers", {})
         ],
     }
 
 
+def _prose_issues(value, field: str, label: str) -> list[str]:
+    """One judgment field: present, within budget, and free of layout."""
+    if not isinstance(value, str) or not value.strip():
+        return [f"{label} {field} must be non-empty text"]
+    if len(value) > TEXT_LIMITS[field]:
+        return [f"{label} {field} exceeds {TEXT_LIMITS[field]} chars"]
+    complaint = _layout_violation(value)
+    if complaint:
+        return [f"{label} {field} {complaint}; write the thought, the harness "
+                f"writes the layout"]
+    return []
+
+
+def _narrative_issues(narrative) -> list[str]:
+    """The debate slots the report is rendered from.
+
+    These used to be markdown the model wrote straight into the report, which is
+    why they are checked as hard as the per-ticker rows: an empty `bear` is no
+    longer a thin paragraph, it is a section of the published brief with nothing
+    in it.
+    """
+    if not isinstance(narrative, dict):
+        return ["judgment narrative must be an object"]
+    allowed = set(NARRATIVE_TEXT_FIELDS) | set(NARRATIVE_LIST_FIELDS) | {"risk_voice_first"}
+    issues = []
+    unknown = sorted(set(narrative) - allowed)
+    if unknown:
+        issues.append(f"judgment narrative unknown fields: {unknown}")
+    for field in NARRATIVE_TEXT_FIELDS:
+        issues.extend(_prose_issues(narrative.get(field), field, "judgment narrative"))
+    if narrative.get("risk_voice_first") not in RISK_VOICES:
+        issues.append(
+            "judgment narrative risk_voice_first must be one of "
+            f"{sorted(RISK_VOICES)} (the rotation is the model's to state, "
+            "the ordering is the harness's to render)")
+    for field, (low, high) in NARRATIVE_LIST_FIELDS.items():
+        rows = narrative.get(field)
+        if not isinstance(rows, list):
+            issues.append(f"judgment narrative {field} must be a list")
+            continue
+        if not low <= len(rows) <= high:
+            issues.append(
+                f"judgment narrative {field} must hold {low}-{high} entries, got {len(rows)}")
+        for index, entry in enumerate(rows):
+            issues.extend(
+                _prose_issues(entry, field, f"judgment narrative {field}[{index}]"))
+    return issues
+
+
 def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
     issues = []
     top_allowed = {
         "schema_version", "context_generation_id", "portfolio_assessment",
-        "portfolio_counterargument", "ticker_judgments",
+        "portfolio_counterargument", "narrative", "ticker_judgments",
     }
     row_allowed = {
         "ticker", "verdict", "confidence", "disposition", "assessment",
         "counterargument", "rationale", "falsifier", "next_evidence",
+        "fundamentals", "cross_market", "sentiment_read", "peer_read",
     }
     if not isinstance(overlay, dict):
         return ["judgment overlay must be an object"]
@@ -1301,11 +1429,8 @@ def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
     if overlay.get("context_generation_id") != expected_generation:
         issues.append("judgment context_generation_id missing or stale")
     for field in ("portfolio_assessment", "portfolio_counterargument"):
-        value = overlay.get(field)
-        if not isinstance(value, str) or not value.strip():
-            issues.append(f"judgment {field} must be non-empty text")
-        elif len(value) > TEXT_LIMITS[field]:
-            issues.append(f"judgment {field} exceeds {TEXT_LIMITS[field]} chars")
+        issues.extend(_prose_issues(overlay.get(field), field, "judgment"))
+    issues.extend(_narrative_issues(overlay.get("narrative")))
 
     rows = overlay.get("ticker_judgments")
     if not isinstance(rows, list):
@@ -1346,15 +1471,8 @@ def validate_judgment_overlay(packet: dict, overlay: dict) -> list[str]:
         confidence = _number(row.get("confidence"))
         if confidence is None or not 0 <= confidence <= 1:
             issues.append(f"{label} confidence must be in [0,1]")
-        for field in (
-            "assessment", "counterargument", "rationale", "falsifier",
-            "next_evidence",
-        ):
-            value = row.get(field)
-            if not isinstance(value, str) or not value.strip():
-                issues.append(f"{label} {field} must be non-empty text")
-            elif len(value) > TEXT_LIMITS[field]:
-                issues.append(f"{label} {field} exceeds {TEXT_LIMITS[field]} chars")
+        for field in ROW_TEXT_FIELDS:
+            issues.extend(_prose_issues(row.get(field), field, label))
     missing = sorted(known - seen)
     if missing:
         issues.append(f"judgment missing active tickers: {missing}")

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -564,9 +564,11 @@ from ._harness_common import (  # noqa: E402
     rebuild_dashboard,
 )
 from ._watchdog_common import (  # noqa: E402
+    BRIEF_URL_TMPL,
     resolve_wechat_target, send_wechat, build_brief_card, cosend_telegram, already_delivered,
     claim_send, mark_send_started, release_claim, log,
 )
+from clawock.harness import brief_render  # noqa: E402
 
 
 def log_decisions(today):
@@ -764,9 +766,6 @@ def main(argv=None):
     md_path   = WS / 'memory' / f'{today}-pre-open.md'
     plan_path = WS / 'memory' / f'{today}-plan.json'
 
-    # Ensure Jekyll can render this brief as a Pages page (not just GitHub blob jump)
-    _ensure_jekyll_front_matter(md_path, today)
-
     # Load preflight context (for cross-validation). Fail closed: a missing or
     # unparseable context would silently skip every context-dependent hard gate
     # below (generation pin, position/leverage回查, peer divergence,
@@ -774,7 +773,6 @@ def main(argv=None):
     ctx_path = WS / 'memory' / '.tmp' / f'brief-context-{today}.json'
     context, context_issue = load_preflight_context(ctx_path)
 
-    readability = assess_brief_readability(md_path)
     issues = []
     if context_issue:
         issues.append(context_issue)
@@ -786,8 +784,6 @@ def main(argv=None):
             decision_packet = brief_decision_packet.read_packet(manifest_path)
         except Exception as exc:
             issues.append(f'decision packet 不可用: {exc}')
-    issues += validate_markdown(md_path, context=context)
-    issues += readability_issues(readability)
     normalization_issues, normalized_plan = normalize_plan_json(
         plan_path,
         decision_packet=decision_packet,
@@ -796,6 +792,36 @@ def main(argv=None):
         context=context,
     )
     issues += normalization_issues
+
+    # The report is rendered here, from the judgment and the normalized plan —
+    # the model no longer writes markdown at all (see clawock.harness.
+    # brief_render for why). Rendering after normalization is deliberate: the
+    # published tables then show the same decisions the ledger records.
+    # A renderer that cannot run must not take the brief down with it, so the
+    # failure is an issue and whatever markdown exists still ships.
+    try:
+        render_issues, _ = brief_render.render_from_workspace(
+            WS, today, plan=normalized_plan,
+            page_url=BRIEF_URL_TMPL.format(date=today),
+            write=not args.dry_run)
+        # Unreadable inputs are reported, not escalated here: the consequence —
+        # no report, or yesterday's — is what `validate_markdown` below is for,
+        # and counting it twice can push a warn to a fail on the strength of one
+        # underlying fact.
+        for issue in render_issues:
+            print(f'warn: {issue}', file=sys.stderr)
+    except Exception as exc:
+        issues.append(f'简报渲染失败（保留现有 pre-open.md）: {exc}')
+        print(f'warn: brief render failed: {exc}', file=sys.stderr)
+
+    # Jekyll needs front matter to serve this as a page rather than a blob view.
+    # The renderer emits it, so this now covers the day the renderer could not
+    # run and an earlier file is what ships.
+    _ensure_jekyll_front_matter(md_path, today)
+
+    readability = assess_brief_readability(md_path)
+    issues += validate_markdown(md_path, context=context)
+    issues += readability_issues(readability)
     validation_path = (
         _InMemoryPlanPath(plan_path, normalized_plan)
         if args.dry_run and normalized_plan is not None

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -1,0 +1,785 @@
+"""Render the daily deep brief from the context and the model's judgment.
+
+Until now the model wrote `memory/{date}-pre-open.md` itself: every table, every
+heading, every ornament.  Two things followed from that, and both are why this
+module exists.
+
+The layout drifted.  Section order, table widths, how a number was emphasised
+and where the reasoning stopped and the data started all changed from day to
+day, because they were re-decided from scratch every morning by a model whose
+job that was never supposed to be.
+
+And the reasoning leaked.  A model asked to produce a finished document tends to
+show its work inside it — the deliberation that belongs in the debate section
+spreads into the tables, and a reader looking for "what do I do at 09:30" reads
+paragraphs of thinking to find it.
+
+So the split is now literal: the model writes the judgment JSON — assessments,
+the bull and bear cases, the risk voices, the reads — and nothing else, with
+`packet._layout_violation` refusing any markdown that shows up in those fields.
+Every heading, table, ordering and number in the published brief is produced
+here, from the deterministic context and the validated plan.  Same facts every
+day, in the same place on the page.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date as _date
+from pathlib import Path
+
+WEEKDAYS = ("周一", "周二", "周三", "周四", "周五", "周六", "周日")
+VOICE_LABELS = {
+    "aggressive": "Aggressive（抓 upside）",
+    "conservative": "Conservative（保本 derisk）",
+    "neutral": "Neutral（拍中线）",
+}
+VERDICT_LABELS = {
+    "bullish": "看多", "bearish": "看空", "neutral": "中性", "mixed": "分歧",
+}
+MISSING = "—"
+
+
+# --- formatting primitives -------------------------------------------------
+# Every number in the brief goes through one of these, so a percentage looks the
+# same in the header as it does in the last table.  That consistency is the
+# whole point of moving rendering out of the model.
+
+def _numeric(value):
+    """A number, or None when the field is absent or is not one.
+
+    Context and plan fields are producer-owned and occasionally arrive as text
+    ("4500" for a watch level, or a note where a level was expected). Rendering
+    is the wrong place to reject that: the brief still has to go out, so a
+    non-number falls through to its own string rather than raising.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return float(str(value).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def pct(value, digits=2, sign=True):
+    number = _numeric(value)
+    if number is None:
+        return MISSING if value is None else str(value)
+    return f"{number:+.{digits}f}%" if sign else f"{number:.{digits}f}%"
+
+
+def money(value, currency="", digits=0):
+    number = _numeric(value)
+    if number is None:
+        return MISSING if value is None else str(value)
+    body = f"{number:,.{digits}f}"
+    return f"{currency}{body}" if currency else body
+
+
+def num(value, digits=2):
+    number = _numeric(value)
+    if number is None:
+        return MISSING if value is None else str(value)
+    return f"{number:,.{digits}f}"
+
+
+def text(value):
+    """A model field on its way into a table cell.
+
+    The validator already refused pipes and newlines-as-layout, so this only has
+    to answer for an absent field: a blank cell is a hole in the report and must
+    read as one rather than as an empty-looking judgment.
+    """
+    value = (value or "").strip()
+    return value.replace("\n", " ") if value else MISSING
+
+
+def table(headers, rows):
+    """A markdown table with a fixed column count.
+
+    Rows shorter than the header are padded rather than silently misaligned —
+    a ragged table was one of the recurring symptoms of model-authored layout.
+    """
+    width = len(headers)
+    out = ["| " + " | ".join(_cell(header) for header in headers) + " |",
+           "|" + "|".join(["---"] * width) + "|"]
+    for row in rows:
+        cells = [_cell(cell) for cell in row][:width]
+        cells += [MISSING] * (width - len(cells))
+        out.append("| " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+
+def _cell(value):
+    """One table cell, escaped so its content cannot become layout.
+
+    Not every string reaching a table is judgment-gated: a news headline out of
+    the sentiment feed ("Hong Kong Stock Market Alert | MINIMAX...") and a plan
+    rationale both arrive with whatever punctuation they have. An unescaped pipe
+    there adds a column to that one row, which is precisely the ragged-table
+    failure this module exists to end.
+    """
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _holdings(context, leg):
+    portfolios = ((context.get("portfolio") or {}).get("portfolios") or {})
+    book = portfolios.get(f"{leg}_stocks") or {}
+    held = [row for row in (book.get("holdings") or []) if (row.get("shares") or 0) > 0]
+    return book, held
+
+
+def _judgments(judgment):
+    return {
+        str(row.get("ticker")): row
+        for row in (judgment.get("ticker_judgments") or [])
+    }
+
+
+def _narrative(judgment):
+    return judgment.get("narrative") or {}
+
+
+# --- sections --------------------------------------------------------------
+
+def header_section(context, judgment):
+    book = context.get("book_totals") or {}
+    fx = context.get("fx") or {}
+    macro = context.get("macro") or {}
+    regime = (macro.get("regime") or {}).get("label")
+    hk_book, _ = _holdings(context, "hk")
+    us_book, _ = _holdings(context, "us")
+
+    lines = ["## Header — Book 双视角（HK + USD 不能直接相加）", ""]
+    lines.append(f"**🧭 Regime**: {text(regime)} · {text(_narrative(judgment).get('regime_read'))}")
+    lines.append("")
+    lines.append(
+        f"**FX**: USDHKD = **{num(fx.get('rate'), 4)}**"
+        f"（{text(fx.get('source'))}，抓取于 {text(fx.get('fetched_at'))}）")
+    lines.append("")
+    lines.append("```")
+    lines.append(f"真实总浮亏: USD${money(book.get('usd_base_total'), digits=2)}"
+                 f"  ≈  HKD${money(book.get('hkd_base_total'), digits=2)}")
+    lines.append(f"  ├─ HK 段: HKD${money(book.get('hk_pnl_hkd'), digits=2)}"
+                 f"  ({pct(hk_book.get('total_pnl_percent'))})")
+    lines.append(f"  └─ US 段: USD${money(book.get('us_pnl_usd'), digits=2)}"
+                 f"  ({pct(us_book.get('total_pnl_percent'))})")
+    lines.append(f"HK 现金: {money(hk_book.get('cash_hkd'))} HKD"
+                 f" | US 现金: {money(us_book.get('cash_usd'), digits=2)} USD")
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def concentration_section(context):
+    rows = []
+    for leg in ("hk", "us"):
+        row = (context.get("concentration") or {}).get(leg) or {}
+        rows.append([
+            leg.upper(),
+            num(row.get("hhi"), 3),
+            text(row.get("verdict")),
+            pct(row.get("top2_pct"), sign=False),
+            money(row.get("leg_total"), digits=0),
+        ])
+    return "### 集中度（core.concentration）\n\n" + table(
+        ["Leg", "HHI", "判定", "Top2", "腿总值"], rows)
+
+
+def risk_section(context):
+    guard = context.get("risk_guardrail") or {}
+    discipline = context.get("risk_discipline") or {}
+    rows = []
+    for item in (guard.get("hard_stop_watch") or []):
+        rows.append(["hard_stop", text(item.get("ticker")), text(item.get("severity")),
+                     text(item.get("detail")), text(item.get("breach_id"))])
+    for item in (guard.get("breaches") or []):
+        rows.append([text(item.get("type")), text(item.get("ticker") or item.get("leg")),
+                     text(item.get("severity")), text(item.get("detail")),
+                     text(item.get("breach_id"))])
+
+    lines = ["### 风险纪律（risk_discipline / risk_guardrail）", ""]
+    lines.append(
+        f"open **{discipline.get('open_count', 0)}** / overridden "
+        f"{discipline.get('overridden_count', 0)} / unacknowledged "
+        f"{discipline.get('unacknowledged_count', 0)} / oldest "
+        f"{discipline.get('oldest_open_days', 0)}d / decision_overdue "
+        f"{discipline.get('decision_overdue_count', 0)}")
+    lines.append("")
+    if rows:
+        lines.append(table(["闸", "标的", "严重度", "detail", "breach_id"], rows))
+    else:
+        lines.append("✅ 仓位硬闸无触发。")
+    directive = guard.get("directive")
+    if directive:
+        lines += ["", f"**directive**: {text(directive)}"]
+    return "\n".join(lines)
+
+
+def breakeven_section(context):
+    math_block = context.get("breakeven_math") or {}
+    rows = []
+    for row in (math_block.get("rows") or []):
+        rows.append([
+            text(row.get("ticker")),
+            pct(row.get("pnl_pct")),
+            pct(row.get("chop_drag_pct_per_month"), sign=False)
+            if row.get("chop_drag_pct_per_month") is not None else MISSING,
+            pct(row.get("breakeven_need_pct")),
+            pct(row.get("underlying_need_2x_6m_pct"))
+            if row.get("underlying_need_2x_6m_pct") is not None else MISSING,
+        ])
+    if not rows:
+        return ""
+    out = ["### Breakeven math（context.breakeven_math）", "",
+           table(["Ticker", "浮%", "2x chop drag/月", "回本需", "半年窗含 drag 等效标的需"], rows)]
+    note = math_block.get("note")
+    if note:
+        out += ["", f"注：{text(note)}"]
+    return "\n".join(out)
+
+
+def holdings_section(context):
+    out = ["## ▎仓位明细"]
+    for leg, currency in (("hk", "HKD"), ("us", "USD")):
+        book, held = _holdings(context, leg)
+        if not held:
+            continue
+        rows = []
+        for row in held:
+            rows.append([
+                f"{text(row.get('ticker'))} {text(row.get('name'))}",
+                num(row.get("shares"), 0),
+                num(row.get("cost_basis")),
+                num(row.get("current_price")),
+                pct(row.get("today_change_pct")),
+                pct(row.get("pnl_percent")),
+                money(row.get("pnl_abs"), digits=0),
+            ])
+        rows.append([f"**小计 {leg.upper()}**", "", "", "",
+                     money(book.get("today_total_change"), digits=0),
+                     pct(book.get("total_pnl_percent")),
+                     f"**{money(book.get('total_pnl'), digits=0)}**"])
+        sources = sorted({str(row.get("data_source") or "") for row in held if row.get("data_source")})
+        out += ["", f"**{leg.upper()} leg**（{currency}；报价源 {', '.join(sources) or MISSING}）", "",
+                table(["代码", "股", "成本", "现价", "今日", "浮%", f"浮$ {currency}"], rows)]
+    return "\n".join(out)
+
+
+def retrospective_section(context):
+    retro = context.get("retrospective") or {}
+    rows = []
+    for row in (retro.get("decisions") or []):
+        rows.append([
+            text(row.get("ticker")),
+            text(row.get("action")),
+            text(row.get("strategy_id")),
+            num(row.get("plan_size_shares"), 0) if row.get("plan_size_shares") else MISSING,
+            pct((row.get("plan_confidence") or 0) * 100, digits=0, sign=False),
+            text(row.get("followed") if row.get("followed") is not None
+                 else row.get("outcome") or row.get("verdict")),
+        ])
+    prior = retro.get("prior_plan_date")
+    head = f"## Retrospective（{text(prior)} plan）"
+    if not rows:
+        return head + "\n\n上一份 plan 无可对账决策。"
+    return head + "\n\n" + table(
+        ["票", "Action", "Strategy", "计划股数", "计划信心", "兑现"], rows)
+
+
+def _quant_rows(context):
+    """Signals keyed by the holding they speak for.
+
+    `quant_signals.rows` is keyed by the instrument actually measured — a
+    leveraged holding is scored on its underlying — and names its consumers in
+    `source_holdings`. Reading it by holding is what keeps a proxy row from
+    silently going missing for the ticker it was computed for.
+    """
+    by_holding = {}
+    for key, row in ((context.get("quant_signals") or {}).get("rows") or {}).items():
+        for holding in (row.get("source_holdings") or [key]):
+            by_holding[str(holding)] = row
+    return by_holding
+
+
+def _pnl_by_ticker(context):
+    out = {}
+    for leg in ("hk", "us"):
+        _, held = _holdings(context, leg)
+        for row in held:
+            out[str(row.get("ticker"))] = row.get("pnl_percent")
+    return out
+
+
+def tier1_section(context, judgment):
+    judgments = _judgments(judgment)
+    quant = _quant_rows(context)
+    pnl = _pnl_by_ticker(context)
+    rows = []
+    for ticker in sorted(judgments):
+        row = judgments[ticker]
+        signal = quant.get(ticker) or {}
+        stale = signal.get("status") not in (None, "fresh")
+        market = " / ".join(filter(None, [
+            pct(pnl.get(ticker)) if pnl.get(ticker) is not None else None,
+            f"RSI {num(signal.get('rsi14'), 1)}" if signal.get("rsi14") is not None else None,
+            signal.get("tag"),
+            f"距 MA200 {pct(signal.get('dist_ma200_pct'))}"
+            if signal.get("dist_ma200_pct") is not None else None,
+            f"⚠️{signal.get('status')}" if stale else None,
+        ])) or MISSING
+        rows.append([ticker, market, text(row.get("fundamentals")),
+                     text(row.get("sentiment_read")), text(row.get("cross_market"))])
+    return "## Tier 1 — 4 Analyst 大表\n\n" + table(
+        ["票", "Market（harness 计算）", "Fundamentals", "Sentiment", "Cross-Market"], rows)
+
+
+def tier2_section(judgment):
+    narrative = _narrative(judgment)
+    return "\n".join([
+        "## Tier 2 — Bull vs Bear",
+        "",
+        "**▎Bull**", "", text(narrative.get("bull")),
+        "",
+        "**▎Bear**", "", text(narrative.get("bear")),
+        "",
+        f"**▎Devil's advocate** — 攻击的共识：{text(narrative.get('attacked_consensus'))}",
+        "", text(narrative.get("devils_advocate")),
+    ])
+
+
+def tier3_section(judgment, plan):
+    narrative = _narrative(judgment)
+    voices = ("aggressive", "conservative", "neutral")
+    first = narrative.get("risk_voice_first")
+    if first not in voices:
+        # The rotation is the model's to state; a missing value must still
+        # produce three named voices rather than a section headed "None".
+        first = voices[0]
+    ordered = [first] + [voice for voice in voices if voice != first]
+    out = ["## Tier 3 — 3 Risk Voices + Judge", ""]
+    for index, voice in enumerate(ordered):
+        label = VOICE_LABELS.get(voice, voice)
+        suffix = " · 今日首位表态" if index == 0 else ""
+        out += [f"**▎{label}{suffix}**", "", text(narrative.get(voice)), ""]
+
+    rows = []
+    for decision in (plan.get("decisions") or []):
+        debate = decision.get("debate") or {}
+        rows.append([
+            text(decision.get("ticker")),
+            f"**{text(decision.get('action'))}**",
+            " + ".join(debate.get("frames") or []) or MISSING,
+            text(decision.get("strategy_id")),
+            text(decision.get("driven_by")),
+            text(decision.get("rationale")),
+        ])
+    out += ["### Judge — 合成判词（来自 plan.json，harness 校验过边界）", "",
+            table(["Ticker", "Action", "Frame", "Strategy", "driven_by", "理由"], rows)]
+    return "\n".join(out)
+
+
+def sector_section(sector_scan, judgment):
+    """板块全景 — the sweep the model runs with web search, laid out here.
+
+    The scan lands in `memory/.tmp/sector-scan-{date}.json` because the
+    dashboard reads it too; rendering the report from the same file keeps the
+    page and the panel telling one story, and keeps the peer detail kcn asked
+    never to compress.
+    """
+    sectors = (sector_scan or {}).get("sectors") or []
+    read = text(_narrative(judgment).get("sector_read"))
+    if not sectors:
+        return "\n".join(["## ▎板块全景", "", read])
+    rows = []
+    for sector in sectors:
+        movers = "、".join(
+            f"{text(m.get('ticker'))} {text(m.get('name'))} {pct(m.get('pct'))}"
+            for m in (sector.get("top_movers") or [])[:3])
+        for own in (sector.get("self") or []):
+            rows.append([
+                text(sector.get("theme")),
+                text(own.get("ticker")),
+                pct(own.get("pct")),
+                text(own.get("rank_text")),
+                movers or MISSING,
+                text(own.get("attribution")),
+            ])
+    out = ["## ▎板块全景", "",
+           table(["板块", "持仓", "今日", "位置", "板块 Top", "归因"], rows), "", read]
+    return "\n".join(out)
+
+
+def peer_section(context, judgment):
+    judgments = _judgments(judgment)
+    rows = []
+    for ticker, row in sorted((context.get("peer_scan") or {}).items()):
+        peers = row.get("listed_peers") or []
+        best = max(peers, key=lambda p: p.get("pct_1d") if p.get("pct_1d") is not None else -1e9,
+                   default=None)
+        gap = None
+        if best and best.get("pct_1d") is not None and row.get("self_pct_1d") is not None:
+            gap = row["self_pct_1d"] - best["pct_1d"]
+        rows.append([
+            ticker,
+            text(row.get("theme")),
+            pct(row.get("self_pct_1d")),
+            f"{text(best.get('ticker'))} {text(best.get('name'))} {pct(best.get('pct_1d'))}"
+            if best else MISSING,
+            f"{gap:+.2f}pp" if gap is not None else MISSING,
+            text((judgments.get(ticker) or {}).get("peer_read")),
+        ])
+    return "## ▎同行扫描\n\n" + table(
+        ["持仓", "主题", "今日 self", "最强同行", "差距", "判断"], rows)
+
+
+def macro_section(context, judgment):
+    macro = context.get("macro") or {}
+
+    def quote(key, label):
+        row = macro.get(key) or {}
+        if not row:
+            return None
+        return f"{label} **{num(row.get('price'))}** ({pct(row.get('change_pct'))})"
+
+    parts = [quote(key, label) for key, label in (
+        ("vix", "VIX"), ("hsi", "HSI"), ("hstech", "HSTECH"),
+        ("spx", "SPX"), ("nasdaq", "纳指"), ("dxy", "DXY"))]
+    fear = macro.get("fear_greed") or {}
+    if fear:
+        parts.append(f"F&G **{num(fear.get('score'), 1)}** {text(fear.get('rating'))}")
+    if macro.get("treasury_10y_yield_pct") is not None:
+        parts.append(f"10Y **{pct(macro.get('treasury_10y_yield_pct'), sign=False)}**")
+    body = " · ".join(part for part in parts if part)
+    return "\n".join([
+        "## ▎大盘速读", "",
+        f"{body}（as_of {text(macro.get('as_of'))}, age {num(macro.get('age_hours'), 1)}h）",
+        "", text(_narrative(judgment).get("macro_read")),
+    ])
+
+
+def sentiment_section(context, judgment):
+    judgments = _judgments(judgment)
+    rows = []
+    for row in ((context.get("sentiment") or {}).get("tickers") or []):
+        ticker = str(row.get("ticker"))
+        keywords = "、".join(
+            str((item.get("title") or item.get("headline") or "")
+                if isinstance(item, dict) else item)[:36]
+            for item in (row.get("news_top") or [])[:3])
+        rows.append([
+            ticker,
+            f"{row.get('reddit_mentions_7d', 0)} mentions",
+            keywords or MISSING,
+            pct((row.get("recent_move") or {}).get("pct_5d"))
+            if isinstance(row.get("recent_move"), dict) else MISSING,
+            text((judgments.get(ticker) or {}).get("sentiment_read")),
+        ])
+    if not rows:
+        return ""
+    return "## ▎社交舆情速读\n\n" + table(
+        ["票", "Reddit 7d", "新闻关键词", "近 5 日", "信号判断"], rows)
+
+
+def influencer_section(context):
+    influencer = context.get("influencer") or {}
+    counts = influencer.get("counts") or {}
+    if not counts.get("total"):
+        return ""
+    out = [f"## ▎名人异动/政策风向（age {num(influencer.get('age_hours'), 1)}h）", "",
+           f"撞持仓 **{counts.get('held_hits', 0)}** · 新机会 {counts.get('new_ideas', 0)}"
+           f" · 板块相关 {counts.get('sector_hits', 0)}", ""]
+    for bucket, label in (("held_hits", "撞持仓"), ("new_ideas", "新机会"),
+                          ("sector_hits", "板块相关")):
+        for row in (influencer.get(bucket) or [])[:3]:
+            out.append(f"- [{label}] {text(row.get('author'))}"
+                       f"（{text(row.get('stance'))}）：{text(row.get('summary_cn'))}")
+    return "\n".join(out)
+
+
+def confidence_section(judgment, plan):
+    judgments = _judgments(judgment)
+    rows = []
+    for decision in (plan.get("decisions") or []):
+        ticker = str(decision.get("ticker"))
+        row = judgments.get(ticker) or {}
+        confidence = decision.get("confidence")
+        rows.append([
+            ticker,
+            text(decision.get("action")),
+            pct((confidence or 0) * 100, digits=0, sign=False),
+            VERDICT_LABELS.get(row.get("verdict"), text(row.get("verdict"))),
+            text(row.get("rationale")),
+            text(row.get("falsifier")),
+        ])
+    return "## Confidence\n\n" + table(
+        ["Ticker", "Action", "Confidence", "Verdict", "理由", "证伪条件"], rows)
+
+
+def _interval(bounds):
+    """A confidence interval in the same units as the benefit beside it.
+
+    A raw `[0.3744, 6.7355]` on the page invites the reader to take it as a
+    probability; these are percentage points, and the column next to it already
+    reads as percent.
+    """
+    if not isinstance(bounds, (list, tuple)) or len(bounds) != 2:
+        return MISSING
+    low, high = (_numeric(bound) for bound in bounds)
+    if low is None or high is None:
+        return MISSING
+    return f"[{low:+.2f}%, {high:+.2f}%]"
+
+
+def calibration_section(context, judgment):
+    metrics = context.get("decision_metrics") or {}
+    head = (f"过去 {metrics.get('window_days', MISSING)} 天：已结算 "
+            f"**{metrics.get('settled_episodes', MISSING)}** 个 episode"
+            f"（{metrics.get('raw_decisions', MISSING)} raw decisions；Brier "
+            f"{num(metrics.get('brier'), 4)}）")
+    rows = []
+    for driver, row in sorted((metrics.get("by_driver") or {}).items()):
+        rows.append([
+            driver,
+            row.get("n_episodes", MISSING),
+            pct(row.get("avg_benefit_pct")) if row.get("avg_benefit_pct") is not None else MISSING,
+            _interval(row.get("cluster_ci95")),
+            "✅" if row.get("edge_significant") else "—",
+        ])
+    out = ["## ▎Decision v2 校准（decision_metrics）", "", head, ""]
+    if rows:
+        out += [table(["driven_by", "n", "avg benefit", "cluster CI95", "edge"], rows), ""]
+    out.append(text(_narrative(judgment).get("calibration_read")))
+    return "\n".join(out)
+
+
+def next_session_section(judgment):
+    steps = _narrative(judgment).get("next_session") or []
+    body = "\n".join(f"{index}. {text(step)}" for index, step in enumerate(steps, 1))
+    return "## Next-Session Plan\n\n" + (body or "无。")
+
+
+def data_holes_section(context, judgment):
+    holes = list(_narrative(judgment).get("data_holes") or [])
+    holes += [str(issue) for issue in (context.get("issues") or [])]
+    surface = (context.get("research_surface") or {}).get("errors") or []
+    holes += [str(error) for error in surface]
+    if not holes:
+        return "## ▎待补（data holes）\n\n无。"
+    return "## ▎待补（data holes）\n\n" + "\n".join(f"- {text(hole)}" for hole in holes)
+
+
+# --- documents -------------------------------------------------------------
+
+def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
+    """The full pre-open report.  Order is fixed here and nowhere else."""
+    date = date or context.get("date") or ""
+    weekday = ""
+    try:
+        weekday = WEEKDAYS[_date.fromisoformat(date).weekday()]
+    except ValueError:
+        pass
+    title = f"盘前深度简报｜{date} {weekday} 08:00 HKT".strip()
+
+    blocks = [
+        "---",
+        "layout: default",
+        f"title: {title}",
+        f'description: "clawock 盘前深度简报 {date}：港股 + 美股真实持仓的多空辩论、'
+        '量化因子、风控硬闸与决策校准。"',
+        "---",
+        "",
+        f"# {title}",
+        "",
+        text(judgment.get("portfolio_assessment")),
+        "",
+        f"**反方**：{text(judgment.get('portfolio_counterargument'))}",
+        "",
+        header_section(context, judgment),
+        "",
+        concentration_section(context),
+        "",
+        risk_section(context),
+        "",
+        breakeven_section(context),
+        "",
+        holdings_section(context),
+        "",
+        retrospective_section(context),
+        "",
+        tier1_section(context, judgment),
+        "",
+        tier2_section(judgment),
+        "",
+        tier3_section(judgment, plan),
+        "",
+        peer_section(context, judgment),
+        "",
+        sector_section(sector_scan, judgment),
+        "",
+        macro_section(context, judgment),
+        "",
+        sentiment_section(context, judgment),
+        "",
+        influencer_section(context),
+        "",
+        confidence_section(judgment, plan),
+        "",
+        calibration_section(context, judgment),
+        "",
+        next_session_section(judgment),
+        "",
+        data_holes_section(context, judgment),
+        "",
+    ]
+    body = "\n".join(block for block in blocks if block is not None)
+    # Collapse the blank lines an omitted section leaves behind, so a quiet day
+    # does not publish a page full of gaps.
+    while "\n\n\n" in body:
+        body = body.replace("\n\n\n", "\n\n")
+    return body.rstrip() + "\n"
+
+
+def render_card(context, judgment, plan, *, date=None, page_url=None):
+    """The WeChat/Telegram card: the same facts, cut to what fits a phone."""
+    date = date or context.get("date") or ""
+    book = context.get("book_totals") or {}
+    fx = context.get("fx") or {}
+    concentration = context.get("concentration") or {}
+    lines = [f"📊 盘前深度简报｜{date} 08:00 HKT  (USDHKD={num(fx.get('rate'), 4)})", ""]
+    lines += ["▎核心结论", text(judgment.get("portfolio_assessment")), ""]
+    lines += ["▎Book",
+              f"USD${money(book.get('usd_base_total'), digits=0)}"
+              f" | HK leg HKD${money(book.get('hk_pnl_hkd'), digits=0)}"
+              f" | US leg USD${money(book.get('us_pnl_usd'), digits=0)}",
+              f"HHI: HK {num((concentration.get('hk') or {}).get('hhi'), 3)}"
+              f" · US {num((concentration.get('us') or {}).get('hhi'), 3)}", ""]
+
+    actions = [d for d in (plan.get("decisions") or [])
+               if d.get("action") not in (None, "hold_and_watch", "watch")]
+    holds = [d for d in (plan.get("decisions") or [])
+             if d.get("action") in ("hold_and_watch", "watch")]
+    lines.append("▎今日动作")
+    if actions:
+        for index, decision in enumerate(actions, 1):
+            size = (decision.get("size") or {}).get("shares")
+            lines.append(
+                f"{index}. {text(decision.get('ticker'))} [{text(decision.get('strategy_id'))}]"
+                f" {text(decision.get('action'))}"
+                f"{f' {num(size, 0)} 股' if size else ''}"
+                f" (driven_by={text(decision.get('driven_by'))},"
+                f" conf {pct((decision.get('confidence') or 0) * 100, digits=0, sign=False)})")
+    else:
+        lines.append("无主动动作。")
+    if holds:
+        lines.append(f"{len(actions) + 1}. "
+                     + "/".join(str(d.get("ticker")) for d in holds)
+                     + " hold_and_watch")
+    lines.append("")
+
+    levels = plan.get("watch_levels") or {}
+    if levels:
+        lines.append("▎触发位")
+        for key, value in levels.items():
+            lines.append(f"• {key}: {num(value)}")
+        lines.append("")
+    if page_url:
+        lines += ["📈 完整深度报告：", page_url]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# --- workspace wiring ------------------------------------------------------
+
+def artifact_paths(workspace, date):
+    """Where the harness keeps this generation's inputs and outputs."""
+    tmp = Path(workspace) / "memory" / ".tmp"
+    return {
+        "context": tmp / f"brief-context-{date}.json",
+        "judgment": tmp / f"brief-judgment-{date}.json",
+        "plan": Path(workspace) / "memory" / f"{date}-plan.json",
+        "brief": Path(workspace) / "memory" / f"{date}-pre-open.md",
+        "card": tmp / f"brief-card-{date}.txt",
+        "sector_scan": tmp / f"sector-scan-{date}.json",
+    }
+
+
+def render_from_workspace(workspace, date, *, plan=None, page_url=None, write=True):
+    """Render both artifacts for one date. Returns (issues, brief_markdown).
+
+    `plan` lets the caller hand in the normalized plan it already holds, so the
+    published report is rendered from the same decisions the ledger records
+    rather than from the model's pre-normalization file.
+    """
+    paths = artifact_paths(workspace, date)
+    issues = []
+    try:
+        context = _load(paths["context"])
+        judgment = _load(paths["judgment"])
+        if plan is None:
+            plan = _load(paths["plan"])
+    except (OSError, ValueError) as exc:
+        return ([f"简报渲染跳过（输入不可读: {exc}）；保留现有 pre-open.md"], None)
+
+    # The sector sweep is optional: a day the search quota was spent still has
+    # to publish, with the section carrying the model's read and no table.
+    try:
+        sector_scan = _load(paths["sector_scan"])
+    except (OSError, ValueError):
+        sector_scan = None
+
+    body = render_brief(context, judgment, plan, date=date, sector_scan=sector_scan)
+    card = render_card(context, judgment, plan, date=date, page_url=page_url)
+    if write:
+        paths["brief"].parent.mkdir(parents=True, exist_ok=True)
+        paths["brief"].write_text(body, encoding="utf-8")
+        paths["card"].parent.mkdir(parents=True, exist_ok=True)
+        paths["card"].write_text(card, encoding="utf-8")
+    return issues, body
+
+
+# --- CLI -------------------------------------------------------------------
+
+def _load(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main(argv=None):
+    from clawock.workspace import workspace_root
+
+    parser = argparse.ArgumentParser(
+        description="Render the daily deep brief from context + judgment + plan. "
+                    "The model writes the judgment; every heading, table and "
+                    "number below is produced here.")
+    parser.add_argument("--date", help="brief date (default: today)")
+    parser.add_argument("--workspace", help="workspace root (default: resolved)")
+    parser.add_argument("--page-url",
+                        help="URL printed at the foot of the card "
+                             "(default: this date's published page)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="render to stdout without writing the artifacts")
+    args, _unknown = parser.parse_known_args(argv)
+
+    workspace = Path(args.workspace) if args.workspace else workspace_root(Path.cwd())
+    date = args.date or _date.today().isoformat()
+    from clawock.harness._watchdog_common import BRIEF_URL_TMPL
+
+    issues, body = render_from_workspace(
+        workspace, date,
+        page_url=args.page_url or BRIEF_URL_TMPL.format(date=date),
+        write=not args.dry_run)
+    for issue in issues:
+        print(issue)
+    if body is None:
+        return 1
+    if args.dry_run:
+        print(body)
+    else:
+        paths = artifact_paths(workspace, date)
+        print(f'wrote {paths["brief"]} ({paths["brief"].stat().st_size} bytes) '
+              f'and {paths["card"].name}')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawock/harness/runner.py
+++ b/src/clawock/harness/runner.py
@@ -15,6 +15,7 @@ from .model import RunRequest
 PHASE_MODULES = {
     ("brief", "preflight"): "clawock.harness.brief_preflight",
     ("brief", "postflight"): "clawock.harness.brief_postflight",
+    ("brief", "render"): "clawock.harness.brief_render",
     ("report", "preflight"): "clawock.harness.report_preflight",
     ("report", "postflight"): "clawock.harness.report_postflight",
     ("intraday", "preflight"): "clawock.harness.intraday_preflight",

--- a/src/clawock/harness/validation.py
+++ b/src/clawock/harness/validation.py
@@ -60,10 +60,21 @@ def check_md_table_column_consistency(text):
     """
     issues = []
     for i, tbl in enumerate(_extract_md_tables(text), start=1):
-        counts = {ln.count('|') for ln in tbl}
+        counts = {_cell_separators(ln) for ln in tbl}
         if len(counts) > 1:
             issues.append(f'markdown 表格 #{i} 列数不一致: pipe-segments={sorted(counts)}')
     return issues
+
+
+def _cell_separators(line):
+    r"""Pipes that actually divide cells.
+
+    `\|` is the markdown escape for a literal pipe and renders inside one cell,
+    so counting it as a separator reports a broken table for content that is
+    correct — which is what a news headline ("Market Alert | MINIMAX...") or a
+    quoted rationale does to any renderer that escapes its cells properly.
+    """
+    return len(re.findall(r'(?<!\\)\|', line))
 
 
 def validate_forbidden_phrases(text, phrases, label='报告'):

--- a/tests/test_brief_decision_packet.py
+++ b/tests/test_brief_decision_packet.py
@@ -165,6 +165,26 @@ def _valid_overlay(packet):
         row["rationale"] = "在趋势和风险约束冲突时优先风险。"
         row["falsifier"] = "突破失效或一手证据转负。"
         row["next_evidence"] = "下一时段价格确认与发行人披露。"
+        row["fundamentals"] = "最新披露期营收与利润率无转向。"
+        row["cross_market"] = "跟随指数，未见背离。"
+        row["sentiment_read"] = "热度低，无硬催化。"
+        row["peer_read"] = "板块内中位，不构成换股理由。"
+    overlay["narrative"] = {
+        "regime_read": "两地趋势 OFF，杠杆上限收紧。",
+        "bull": "超卖叠加硬催化，最坏定价已部分吃掉。",
+        "bear": "纪律未执行是最大风险，β 放大回撤。",
+        "devils_advocate": "最强共识建立在单一情绪来源上，不可重复。",
+        "attacked_consensus": "板块仍有 alpha 这条共识",
+        "risk_voice_first": "conservative",
+        "aggressive": "留一半敞口赌反弹。",
+        "conservative": "波动与回撤三条都破阈值，硬闸今天必须执行。",
+        "neutral": "硬闸执行，其余维持持有。",
+        "sector_read": "板块内部分化，持仓落后龙头。",
+        "macro_read": "指数小幅向下但不构成 regime 切换。",
+        "calibration_read": "risk_rule 是唯一 edge 显著的方向。",
+        "next_session": ["开盘后确认成交", "收盘前复核杠杆敞口"],
+        "data_holes": ["财报公告日未确认"],
+    }
     return overlay
 
 
@@ -345,6 +365,48 @@ def test_judgment_can_downgrade_but_cannot_invent_a_candidate():
     issues = packet_mod.validate_judgment_overlay(packet, overlay)
 
     assert any("cannot upgrade" in issue for issue in issues)
+
+
+def test_judgment_prose_may_not_carry_layout():
+    """The report is rendered from these fields, so markdown in them is not a
+    style preference — a pipe lands inside a table cell the harness is drawing.
+    """
+    packet = _compiled()
+
+    for field, value in (
+        ("assessment", "多头 | 空头 各执一词"),
+        ("rationale", "**硬闸优先**"),
+        ("falsifier", "- 收复 200 线"),
+    ):
+        overlay = _valid_overlay(packet)
+        overlay["ticker_judgments"][0][field] = value
+        issues = packet_mod.validate_judgment_overlay(packet, overlay)
+        assert any(field in issue and "harness writes the layout" in issue
+                   for issue in issues), f"{field} accepted layout: {value!r}"
+
+
+def test_judgment_narrative_is_required_and_named():
+    packet = _compiled()
+
+    overlay = _valid_overlay(packet)
+    overlay["narrative"]["bear"] = ""
+    assert any("narrative bear must be non-empty" in issue
+               for issue in packet_mod.validate_judgment_overlay(packet, overlay))
+
+    overlay = _valid_overlay(packet)
+    overlay["narrative"]["risk_voice_first"] = "judge"
+    assert any("risk_voice_first" in issue
+               for issue in packet_mod.validate_judgment_overlay(packet, overlay))
+
+    overlay = _valid_overlay(packet)
+    overlay["narrative"]["tier4"] = "额外一层"
+    assert any("narrative unknown fields" in issue and "tier4" in issue
+               for issue in packet_mod.validate_judgment_overlay(packet, overlay))
+
+    overlay = _valid_overlay(packet)
+    overlay["narrative"]["next_session"] = []
+    assert any("next_session must hold 1-8 entries" in issue
+               for issue in packet_mod.validate_judgment_overlay(packet, overlay))
 
 
 def test_judgment_rejects_a_deterministic_candidate_without_removing_the_hint():

--- a/tests/test_brief_readability.py
+++ b/tests/test_brief_readability.py
@@ -68,16 +68,33 @@ def test_extreme_oversize_remains_a_real_degradation(tmp_path):
     assert postflight.categorize(issues) == 'warn'
 
 
-def test_generation_instructions_budget_sections_before_postflight():
+def test_generation_instructions_hand_the_report_to_the_harness():
+    """Size is no longer the model's to manage, because the report is no longer
+    the model's to write (2026-08-31).
+
+    The per-section byte budget, the mid-draft `wc -c` and the "do not truncate"
+    rule all existed because a model composing markdown could and did overshoot.
+    `clawock.harness.brief_render` renders the document from the judgment and the
+    context, so the instructions must say that plainly — an instruction sheet
+    that still asks for a hand-written report is how the model spends a morning
+    producing a file postflight will overwrite.
+    """
     skill = (ROOT / 'skills' / 'daily-deep-brief' / 'SKILL.md').read_text(
         encoding='utf-8')
-    report = skill.split('#### A. Markdown 报告', 1)[1].split(
+    report = skill.split('#### A. 报告与微信卡', 1)[1].split(
         '#### B. 结构化 plan', 1)[0]
 
-    assert '28KB' in report
-    assert '40KB' in report
-    assert 'wc -c' in report
-    assert '分段预算' in report
-    assert '禁止' in report and '截断' in report
-    assert '同行明细不是压缩对象' in report
-    assert '同行枚举、相对涨跌、持仓位置和归因必须保留' in report
+    assert 'brief_render' in report
+    assert '不要写这两个文件' in report
+    assert 'clawock brief render --dry-run' in report
+    # The layout ban is the operative half: it is what keeps a pipe out of a
+    # cell the harness is drawing.
+    assert '纯文本' in report
+    assert '28KB' in report, 'the size ceiling still has to be stated somewhere'
+
+
+def test_the_size_ceiling_survives_as_a_harness_gate():
+    """The readability gate is not retired with the budget instructions: it is
+    what would notice a renderer or a book that grew past what a phone reads."""
+    assert postflight.BRIEF_READABILITY_TARGET_BYTES == 28_000
+    assert postflight.BRIEF_READABILITY_EXTREME_BYTES == 40_000

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -1,0 +1,258 @@
+"""The harness owns the brief's layout; the model owns only the thoughts.
+
+Before this, the model wrote `{date}-pre-open.md` itself — every heading, table
+and ornament — so the report's shape was re-decided each morning and the
+deliberation leaked into the tables. These tests pin the split: the same inputs
+must produce the same document, model text lands in slots rather than deciding
+them, and no string reaching a table can add a column to it.
+"""
+import json
+
+import pytest
+
+from clawock.harness import brief_render as render
+from clawock.harness.validation import check_md_table_column_consistency
+
+
+CONTEXT = {
+    "date": "2026-08-31",
+    "book_totals": {"hk_pnl_hkd": -39811.24, "us_pnl_usd": -1239.66,
+                    "usd_base_total": -6317.88, "hkd_base_total": -49529.68},
+    "fx": {"rate": 7.8396, "source": "Frankfurter", "fetched_at": "2026-08-31T00:00:44Z"},
+    "concentration": {
+        "hk": {"hhi": 0.406, "top2_pct": 85.8, "verdict": "🔴 危险集中", "leg_total": 65465.0},
+        "us": {"hhi": 0.67, "top2_pct": 86.5, "verdict": "🔴 危险集中", "leg_total": 3366.0},
+    },
+    "risk_discipline": {"open_count": 7, "unacknowledged_count": 7, "oldest_open_days": 47},
+    "risk_guardrail": {
+        "hard_stop_watch": [{"ticker": "07226", "severity": "critical",
+                             "detail": "07226 浮亏 -25.7% ≤ 硬止损线 -18%",
+                             "breach_id": "risk-4ab"}],
+        "breaches": [], "directive": "四条硬闸必须各出一个动作。",
+    },
+    "breakeven_math": {"rows": [{"ticker": "07226", "pnl_pct": -25.7,
+                                 "breakeven_need_pct": 34.7,
+                                 "chop_drag_pct_per_month": 0.41,
+                                 "underlying_need_2x_6m_pct": 17.5}],
+                       "note": "直线涨→2x 回本更快。"},
+    "portfolio": {"portfolios": {
+        "hk_stocks": {"holdings": [{"ticker": "07226", "name": "XL二南方恒科", "shares": 6200,
+                                    "cost_basis": 4.36, "current_price": 3.24,
+                                    "today_change_pct": -0.8, "pnl_percent": -25.74,
+                                    "pnl_abs": -6964.0, "data_source": "Tencent"}],
+                      "total_pnl": -6964.0, "total_pnl_percent": -25.74,
+                      "today_total_change": -160.0, "cash_hkd": 17597},
+        "us_stocks": {"holdings": [], "total_pnl": 0, "cash_usd": 264.28},
+    }},
+    "quant_signals": {"rows": {"HSTECH": {"rsi14": 42.5, "tag": "趋势OFF",
+                                          "dist_ma200_pct": -10.1, "status": "fresh",
+                                          "source_holdings": ["07226"]}}},
+    "retrospective": {"prior_plan_date": "2026-08-28", "decisions": []},
+    "peer_scan": {"07226": {"theme": "HK 科技指数 2x", "self_pct_1d": -0.8,
+                            "listed_peers": [{"ticker": "00700", "name": "腾讯控股",
+                                              "pct_1d": 1.65}]}},
+    "macro": {"as_of": "2026-08-30T23:56Z", "age_hours": 0.1,
+              "vix": {"price": 14.43, "change_pct": -0.55},
+              "hstech": {"price": 4605.15, "change_pct": -0.33}},
+    "sentiment": {"tickers": [{"ticker": "07226", "reddit_mentions_7d": 0,
+                               "news_top": [{"title": "Hang Seng Tech | Southbound buys"}]}]},
+    "influencer": {"counts": {"total": 0}},
+    "decision_metrics": {"window_days": 30, "settled_episodes": 16, "raw_decisions": 186,
+                         "brier": 0.2595,
+                         "by_driver": {"risk_rule": {"n_episodes": 5, "avg_benefit_pct": 1.2,
+                                                     "cluster_ci95": [0.37, 0.96],
+                                                     "edge_significant": True}}},
+    "issues": [],
+}
+
+PLAN = {"decisions": [
+    {"ticker": "07226", "action": "cut", "strategy_id": "risk_rebalance",
+     "driven_by": "risk_rule", "confidence": 0.92,
+     "size": {"shares": 6200},
+     "rationale": "硬止损 7d breach，2x→1x 同因子换仓 | 敞口保留",
+     "debate": {"frames": ["technical_breakdown", "relative_strength"]}},
+    {"ticker": "00100", "action": "hold_and_watch", "strategy_id": "core_position",
+     "driven_by": "sentiment", "confidence": 0.55, "rationale": "利好已在价。"},
+], "watch_levels": {"hstech_breakdown": 4500}}
+
+
+def _judgment(**overrides):
+    narrative = {
+        "regime_read": "两地趋势 OFF。", "bull": "最坏定价已吃掉大半。",
+        "bear": "纪律未执行是最大风险。", "devils_advocate": "共识建立在单一来源上。",
+        "attacked_consensus": "板块仍有 alpha", "risk_voice_first": "conservative",
+        "aggressive": "留一半敞口。", "conservative": "硬闸今天必须执行。",
+        "neutral": "硬闸执行，其余持有。", "sector_read": "板块内部分化。",
+        "macro_read": "指数小幅向下。", "calibration_read": "risk_rule 是唯一 edge。",
+        "next_session": ["09:30 确认成交"], "data_holes": ["财报日未确认"],
+    }
+    narrative.update(overrides.pop("narrative", {}))
+    return {
+        "schema_version": 3, "portfolio_assessment": "三条杠杆全破硬止损。",
+        "portfolio_counterargument": "再写软执行等于纪律债加码。",
+        "narrative": narrative,
+        "ticker_judgments": [
+            {"ticker": "07226", "verdict": "bearish", "confidence": 0.92,
+             "disposition": "wait", "assessment": "杠杆放大下行。",
+             "counterargument": "反弹会踏空。", "rationale": "硬闸优先。",
+             "falsifier": "HSTECH 收复 200 线。", "next_evidence": "09:30 成交。",
+             "fundamentals": "2x 杠杆 ETF，无基本面。", "cross_market": "跟随 HSTECH。",
+             "sentiment_read": "无硬催化。", "peer_read": "弱于腾讯 2.45pp。"},
+        ],
+        **overrides,
+    }
+
+
+def test_the_report_is_rendered_in_one_fixed_order():
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+
+    order = ["# 盘前深度简报", "## Header", "### 集中度", "### 风险纪律",
+             "### Breakeven math", "## ▎仓位明细", "## Retrospective", "## Tier 1",
+             "## Tier 2", "## Tier 3", "### Judge", "## ▎同行扫描", "## ▎大盘速读",
+             "## ▎社交舆情速读", "## Confidence", "## ▎Decision v2 校准",
+             "## Next-Session Plan", "## ▎待补"]
+    positions = [body.index(heading) for heading in order]
+    assert positions == sorted(positions), (
+        "section order is the harness's, and it must not depend on the judgment")
+
+
+def test_the_same_inputs_render_the_same_bytes():
+    """Determinism is the property the model could not offer."""
+    first = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    second = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+
+    assert first == second
+
+
+def test_a_pipe_in_a_headline_or_rationale_cannot_add_a_column():
+    """Neither source is judgment-gated: a feed headline and a plan rationale
+    both arrive with whatever punctuation they have."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+
+    assert "Southbound buys" in body
+    assert check_md_table_column_consistency(body) == []
+
+
+def test_model_text_lands_in_the_slot_it_was_written_for():
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+
+    bull = body.index("最坏定价已吃掉大半。")
+    bear = body.index("纪律未执行是最大风险。")
+    assert body.index("## Tier 2") < bull < bear < body.index("## Tier 3")
+    assert "板块仍有 alpha" in body
+
+
+def test_the_first_risk_voice_is_the_one_the_judgment_named():
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    tier3 = body[body.index("## Tier 3"):body.index("### Judge")]
+
+    assert tier3.index("Conservative") < tier3.index("Aggressive"), (
+        "the rotation is stated by the model and ordered by the harness")
+    assert "今日首位表态" in tier3
+
+
+def test_a_missing_narrative_field_reads_as_a_hole_not_as_None():
+    judgment = _judgment(narrative={"macro_read": ""})
+    body = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
+
+    assert "None" not in body
+    macro = body[body.index("## ▎大盘速读"):body.index("## ▎社交舆情速读")]
+    assert render.MISSING in macro
+
+
+def test_an_unknown_risk_voice_still_renders_three_named_voices():
+    judgment = _judgment(narrative={"risk_voice_first": None})
+    body = render.render_brief(CONTEXT, judgment, PLAN, date="2026-08-31")
+
+    for voice in ("Aggressive", "Conservative", "Neutral"):
+        assert voice in body
+
+
+def test_the_judge_table_comes_from_the_plan_not_the_prose():
+    """The plan is the validated boundary; the report must not restate it in the
+    model's own words, or the two can disagree about what was decided."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    judge = body[body.index("### Judge"):body.index("## ▎同行扫描")]
+
+    assert "**cut**" in judge and "risk_rebalance" in judge
+    assert "technical_breakdown + relative_strength" in judge
+    assert "hold_and_watch" in judge
+
+
+SECTOR_SCAN = {
+    "sectors": [{
+        "theme": "HK AI 大模型",
+        "top_movers": [{"ticker": "09678", "name": "云知声", "pct": 22.0}],
+        "self": [{"ticker": "00100", "pct": -4.51, "rank_text": "落后",
+                  "attribution": "利好盘后才公布"}],
+    }],
+}
+
+
+def test_the_sector_sweep_is_rendered_when_the_scan_exists():
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31",
+                               sector_scan=SECTOR_SCAN)
+    sector = body[body.index("## ▎板块全景"):body.index("## ▎大盘速读")]
+
+    assert "09678" in sector and "落后" in sector
+    assert "利好盘后才公布" in sector
+    assert "板块内部分化。" in sector, "the model's read sits with the table"
+
+
+def test_a_missing_sector_scan_still_publishes_the_read():
+    """A day the search quota was spent still has to publish."""
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    sector = body[body.index("## ▎板块全景"):body.index("## ▎大盘速读")]
+
+    assert "板块内部分化。" in sector
+    assert "|" not in sector, "no table when there is no scan"
+
+
+def test_the_card_carries_the_actions_the_plan_holds():
+    card = render.render_card(CONTEXT, _judgment(), PLAN, date="2026-08-31",
+                              page_url="https://example.invalid/brief")
+
+    assert "07226" in card and "6,200 股" in card
+    assert "00100" in card and "hold_and_watch" in card
+    assert card.rstrip().endswith("https://example.invalid/brief")
+
+
+def test_a_non_numeric_level_is_printed_rather_than_raising():
+    """Producer fields are occasionally text; the brief still has to go out."""
+    plan = json.loads(json.dumps(PLAN))
+    plan["watch_levels"] = {"next_nfp_date": "2026-09-04"}
+
+    card = render.render_card(CONTEXT, _judgment(), plan, date="2026-08-31")
+
+    assert "2026-09-04" in card
+
+
+def test_rendering_from_a_workspace_writes_both_artifacts(tmp_path):
+    tmp = tmp_path / "memory" / ".tmp"
+    tmp.mkdir(parents=True)
+    (tmp / "brief-context-2026-08-31.json").write_text(
+        json.dumps(CONTEXT, ensure_ascii=False), encoding="utf-8")
+    (tmp / "brief-judgment-2026-08-31.json").write_text(
+        json.dumps(_judgment(), ensure_ascii=False), encoding="utf-8")
+    (tmp_path / "memory" / "2026-08-31-plan.json").write_text(
+        json.dumps(PLAN, ensure_ascii=False), encoding="utf-8")
+
+    issues, body = render.render_from_workspace(tmp_path, "2026-08-31")
+
+    assert issues == []
+    assert (tmp_path / "memory" / "2026-08-31-pre-open.md").read_text(
+        encoding="utf-8") == body
+    assert (tmp / "brief-card-2026-08-31.txt").exists()
+
+
+def test_unreadable_inputs_report_instead_of_overwriting_the_report(tmp_path):
+    """A renderer that cannot run must leave what is published alone."""
+    (tmp_path / "memory").mkdir()
+    existing = tmp_path / "memory" / "2026-08-31-pre-open.md"
+    existing.write_text("previously published", encoding="utf-8")
+
+    issues, body = render.render_from_workspace(tmp_path, "2026-08-31")
+
+    assert body is None
+    assert issues and "渲染跳过" in issues[0]
+    assert existing.read_text(encoding="utf-8") == "previously published"

--- a/tests/test_information_layer_taxonomy.py
+++ b/tests/test_information_layer_taxonomy.py
@@ -139,7 +139,14 @@ def test_the_harness_phases_are_out_of_scope_on_purpose_and_not_by_omission():
         "the skipped registries must be named in the artifact, not just here")
     note = CONFIG["registries"]["not_classified"]
     from clawock.harness.runner import PHASE_MODULES
-    assert len(PHASE_MODULES) == 6, "the lifecycle registry shrank"
+    # Named, not counted: a bare count treats a new phase (`brief render`,
+    # 2026-08-31) as the same event as a deleted one, and only the second is a
+    # regression. These six are the assemble/deliver pairs the exclusion is
+    # about; anything added beside them is free to exist.
+    for workflow in ("brief", "report", "intraday"):
+        for phase in ("preflight", "postflight"):
+            assert (workflow, phase) in PHASE_MODULES, (
+                f"the lifecycle registry lost {workflow} {phase}")
     assert "phase" in note.lower() or "lifecycle" in note.lower(), (
         "the lifecycle registry is excluded but the artifact does not say so")
 


### PR DESCRIPTION
kcn this morning: 「brief 排版展示都好乱 太多内置 thinking 输出了，可能要换成 harness 模式，模型只输出想法不输出排版」.

## Why both symptoms had one cause

The model wrote `memory/{date}-pre-open.md` itself — every heading, table, ornament and ordering. Two things followed:

- **The layout drifted.** Section order, table widths, where emphasis went and where reasoning stopped and data started were re-decided from scratch each morning, by a model whose job that was never supposed to be.
- **The reasoning leaked.** A model asked to produce a finished document shows its work inside it: the deliberation that belongs in Tier 2/3 spread into the tables, so a reader looking for "what do I do at 09:30" had to read paragraphs of thinking to find it.

## The split, made literal

`clawock.harness.brief_render` renders the report **and** the WeChat card from the deterministic context + the validated plan + the judgment. The model writes the judgment and nothing else.

**Judgment schema v3** carries what the markdown used to:

- `narrative`: `regime_read`, `bull`, `bear`, `devils_advocate` + `attacked_consensus`, the three risk voices with `risk_voice_first` (the model states the rotation, the harness orders it), `sector_read`, `macro_read`, `calibration_read`, `next_session[]`, `data_holes[]`.
- Four Tier 1 cells per ticker the harness cannot compute: `fundamentals`, `cross_market`, `sentiment_read`, `peer_read`.

**The layout ban is enforced, not requested.** `_layout_violation` rejects `|`, ` ``` `, `▎`, `**` and line-leading `#`/`-`/`1.`/`>` in every prose field, with the reason: a pipe there lands in a cell the renderer is drawing and adds a column to that row.

Everything computable is rendered from the context in one fixed order with one set of number formats: book双视角, HHI, risk gates + discipline counters, breakeven math, holdings, retrospective, Tier 1 market column, Judge table (from the plan, not restated prose), peer scan, sector sweep, macro, sentiment, influencer, confidence, calibration, next session, data holes.

## Where it runs

Postflight renders **after** plan normalization, so the published tables show the decisions the ledger records. Then front matter, readability and `validate_markdown` run against the harness's own output.

A renderer that cannot run does not take the brief down: unreadable inputs are reported to stderr (the missing/stale report is what `validate_markdown` already fails on — counting it twice could push a warn to a fail on one underlying fact), and a raising renderer becomes an issue while the existing markdown still ships.

`clawock brief render [--dry-run]` exists for local preview.

## Incidental fix

`check_md_table_column_consistency` counted `\|` as a cell separator, so a correctly escaped pipe — a sentiment headline like `Market Alert | MINIMAX` — reported a broken table. It now counts only unescaped pipes.

## Verification

- Rendered from today's real 08:00 generation (context + plan + a v3 judgment built from the day's v2): **21.9KB** vs 24.8KB hand-written, `validate_markdown` returns **0 issues**.
- `tests/test_brief_render.py` (14 cases): fixed section order, byte-identical re-render, a pipe in a headline or a plan rationale cannot add a column, model text lands in its slot, the named voice leads, a missing field reads as a hole rather than `None`, the Judge table comes from the plan, the card carries the plan's actions, a non-numeric watch level prints instead of raising, workspace round-trip, and unreadable inputs leave the published file alone.
- `tests/test_brief_decision_packet.py`: layout rejection per field, narrative required/named/bounded.
- Full suite: **3094 passed, 5 skipped, 4 xfailed**.

## Docs

`skills/daily-deep-brief/SKILL.md` Step 4 rewritten: A and E now say "you do not write these, and a hand-written draft will be overwritten"; C documents v3 and the three hard rules. The per-section byte budget and the mid-draft `wc -c` retire with it (the 28KB/40KB gate stays as a harness alarm). `docs/reference/commands.md` gains `clawock brief render`.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw