### PR TITLE
publish: the lost-race recovery could not handle the paths it was given

### DIFF
--- a/ops/publish/gha_commit_push.sh
+++ b/ops/publish/gha_commit_push.sh
@@ -23,6 +23,13 @@ set -euo pipefail
 MSG="$1"; shift
 DATA_FILES=("$@")
 
+# Resolve the sibling publisher by this script's own location, not by CWD. The
+# runner happens to start at the repo root, so `bash ops/publish/safe_push.sh`
+# worked there and nowhere else — including from a test that wants to drive the
+# real script against a real repository.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAFE_PUSH="$HERE/safe_push.sh"
+
 # Bot identity via per-invocation `-c` injection — NEVER persistent `git config`.
 # This script normally runs on an ephemeral GHA runner, but if it's ever invoked
 # in a real workspace (debugging, a misrouted cron), writing local config would
@@ -42,23 +49,42 @@ commit_once() {
 
 commit_once || exit 0
 
-if bash ops/publish/safe_push.sh; then
+if bash "$SAFE_PUSH"; then
   exit 0
 fi
 
 # Sidecars are disjoint per job, so a push rejection here is only GitHub ref-lag,
 # never a content conflict. Re-apply this job's data on top of the winner + retry.
+#
+# A data path may be a DIRECTORY (2026-08-31): the factor-snapshot slices are
+# passed as `assets/data/factor-snapshots/{sentiment,macro}`, whole trees of
+# dated rows. `git add` takes a directory happily, so the first-try path always
+# worked and this recovery — the one that only runs on a lost race — died on
+# `cp` without -a, under `set -e`, ~10ms in. Every lost race therefore became a
+# red run with the scan's data dropped, in the branch written to save it
+# (sentiment-scan 2026-08-28 and 2026-08-30).
 echo "push lost a race — re-applying data on top of latest origin/master"
 STASH_DIR=$(mktemp -d)
 for f in "${DATA_FILES[@]}"; do
+  [ -e "$f" ] || continue
   mkdir -p "$STASH_DIR/$(dirname "$f")"
-  cp "$f" "$STASH_DIR/$f"
+  cp -a "$f" "$STASH_DIR/$(dirname "$f")/"
 done
 git rebase --abort 2>/dev/null || true
 git fetch origin master
 git reset --hard origin/master
 for f in "${DATA_FILES[@]}"; do
-  cp "$STASH_DIR/$f" "$f"
+  [ -e "$STASH_DIR/$f" ] || continue
+  if [ -d "$STASH_DIR/$f" ]; then
+    # Overlay our rows onto the winner's tree rather than replacing it: the
+    # snapshot directories are one dated file per writer per day, so the run we
+    # lost to may have added a row of its own that must survive.
+    mkdir -p "$f"
+    cp -a "$STASH_DIR/$f/." "$f/"
+  else
+    mkdir -p "$(dirname "$f")"
+    cp -a "$STASH_DIR/$f" "$f"
+  fi
 done
 commit_once || exit 0   # origin already carries identical data → done
-bash ops/publish/safe_push.sh
+bash "$SAFE_PUSH"

--- a/tests/test_gha_commit_push_race.py
+++ b/tests/test_gha_commit_push_race.py
@@ -1,0 +1,149 @@
+"""The lost-race recovery has to survive a data path that is a directory.
+
+`gha_commit_push.sh` takes the paths a scan job owns and, when its push loses a
+race, re-applies them on top of the winner. Two of the callers pass a whole
+tree — `assets/data/factor-snapshots/{sentiment,macro}`, one dated row per day —
+and the recovery copied each path with a plain `cp`. `git add` takes a directory
+happily, so the first-try path always worked and the failure lived only in the
+branch that runs when something already went wrong: `cp` refused the directory,
+`set -e` killed the step ~10ms in, and the scan's data was dropped by the code
+written to save it (sentiment-scan on 2026-08-28 and 2026-08-30).
+
+These tests drive the real script against real repositories, because the bug was
+in shell semantics that no contract assertion over the YAML could see.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops" / "publish" / "gha_commit_push.sh"
+
+
+def _git(cwd, *args, **kwargs):
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True, **kwargs)
+
+
+@pytest.fixture
+def repos(tmp_path):
+    """A bare origin, our runner's clone, and a rival clone that wins the race."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "master", str(origin)],
+                   check=True, capture_output=True)
+
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", str(origin), str(seed)],
+                   check=True, capture_output=True)
+    _git(seed, "config", "user.email", "seed@example.invalid")
+    _git(seed, "config", "user.name", "seed")
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "seed")
+    _git(seed, "push", "origin", "master")
+
+    runner = tmp_path / "runner"
+    rival = tmp_path / "rival"
+    for clone in (runner, rival):
+        subprocess.run(["git", "clone", str(origin), str(clone)],
+                       check=True, capture_output=True)
+        _git(clone, "config", "user.email", "clone@example.invalid")
+        _git(clone, "config", "user.name", "clone")
+    return origin, runner, rival
+
+
+def _write_scan(repo, day, payload):
+    """What a scan job leaves behind: a sidecar file and a dated snapshot row."""
+    (repo / "assets" / "data" / "factor-snapshots" / "sentiment").mkdir(
+        parents=True, exist_ok=True)
+    (repo / "assets" / "data" / "sentiment.json").write_text(payload, encoding="utf-8")
+    (repo / "assets" / "data" / "factor-snapshots" / "sentiment"
+     / f"{day}.json").write_text(payload, encoding="utf-8")
+
+
+def _run_script(repo):
+    env = dict(os.environ)
+    env.pop("CLAWOCK_PUBLISH_SSH_KEY", None)
+    return subprocess.run(
+        ["bash", str(SCRIPT), "sentiment: scan",
+         "assets/data/sentiment.json", "assets/data/factor-snapshots/sentiment"],
+        cwd=repo, capture_output=True, text=True, env=env)
+
+
+def _lose_the_race(rival, extra_row=None):
+    """Land a commit first that also touches this job's sidecar.
+
+    Disjoint-per-job is the design, but the rebase retry inside `safe_push.sh`
+    really did hit a conflict on 2026-08-30 — that is the state that hands
+    control to the recovery branch, so it is the state worth testing.
+    """
+    data = rival / "assets" / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    (data / "sentiment.json").write_text('{"scan": "theirs"}\n', encoding="utf-8")
+    _git(rival, "add", "assets/data/sentiment.json")
+    if extra_row:
+        snaps = data / "factor-snapshots" / "sentiment"
+        snaps.mkdir(parents=True, exist_ok=True)
+        (snaps / f"{extra_row}.json").write_text('{"scan": "theirs"}\n',
+                                                 encoding="utf-8")
+        _git(rival, "add", f"assets/data/factor-snapshots/sentiment/{extra_row}.json")
+    _git(rival, "commit", "-m", "sentiment: someone else got there first")
+    _git(rival, "push", "origin", "master")
+
+
+def test_a_lost_race_republishes_a_directory_slice(repos):
+    origin, runner, rival = repos
+    _write_scan(runner, "2026-08-31", '{"scan": "ours"}\n')
+    _lose_the_race(rival)
+
+    done = _run_script(runner)
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "lost a race" in done.stdout + done.stderr
+    published = _git(origin, "show",
+                     "master:assets/data/factor-snapshots/sentiment/2026-08-31.json")
+    assert published.stdout == '{"scan": "ours"}\n', (
+        "the directory slice is what `cp` used to refuse")
+    assert _git(origin, "log", "--oneline", "master").stdout.count("\n") >= 3, (
+        "the run we lost to must still be in history")
+
+
+def test_the_winners_rows_in_the_same_directory_survive(repos):
+    """The snapshot tree is one dated row per writer, so re-applying ours must
+    overlay the winner's tree, not replace it."""
+    origin, runner, rival = repos
+    _write_scan(runner, "2026-08-31", '{"scan": "ours"}\n')
+
+    _lose_the_race(rival, extra_row="2026-08-30")
+
+    done = _run_script(runner)
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    for day, payload in (("2026-08-30", '{"scan": "theirs"}\n'),
+                         ("2026-08-31", '{"scan": "ours"}\n')):
+        shown = _git(origin, "show",
+                     f"master:assets/data/factor-snapshots/sentiment/{day}.json")
+        assert shown.stdout == payload, f"{day} row was lost"
+
+
+def test_an_uncontested_push_still_takes_the_short_path(repos):
+    origin, runner, _rival = repos
+    _write_scan(runner, "2026-08-31", '{"scan": "ours"}\n')
+
+    done = _run_script(runner)
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "lost a race" not in done.stdout + done.stderr
+    assert _git(origin, "show", "master:assets/data/sentiment.json").stdout == (
+        '{"scan": "ours"}\n')
+
+
+def test_nothing_to_commit_is_not_a_failure(repos):
+    origin, runner, _rival = repos
+
+    done = _run_script(runner)
+
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "no change" in done.stdout


### PR DESCRIPTION
## The failing action

`Sentiment Scan` has failed its scheduled run twice (2026-08-28 05:50, 2026-08-30 23:56):

```
[master 78557c4] sentiment: daily Reddit + Google News scan 2026-08-30
 ! [rejected]        master -> master (non-fast-forward)
push failed attempt 1, trying rebase (autostash)…
  ✗ rebase conflict — abort, leaving commit local
push lost a race — re-applying data on top of latest origin/master
##[error]Process completed with exit code 1
```

Ten milliseconds between the recovery announcing itself and the step dying.

## Why

`sentiment-scan.yml` and `macro-scan.yml` pass a **directory** as a data path — `assets/data/factor-snapshots/{sentiment,macro}`, a tree of dated rows. `git add` takes a directory happily, so the first-try push path always worked and nobody noticed. The recovery did:

```bash
cp "$f" "$STASH_DIR/$f"
```

which refuses a directory, and under `set -e` that ends the step. **Every lost race became a red run with the scan's data dropped — by the branch written to save it.**

## Changes

- `cp -a` for the stash, and a directory is re-applied by overlaying its rows onto the winner's tree (`cp -a "$STASH_DIR/$f/." "$f/"`) rather than replacing it. The snapshot directories hold one dated file per writer, so the run we lost to may have added a row that has to survive.
- Missing paths are skipped instead of aborting.
- `safe_push.sh` is resolved from `$(dirname "${BASH_SOURCE[0]}")` rather than from CWD. The runner starts at the repo root, so the relative path worked there and nowhere else — including from a test.

## Verification

`tests/test_gha_commit_push_race.py` drives the real script against real repositories (bare origin + our clone + a rival that lands first and conflicts on the sidecar, which is the state that hands control to the recovery):

- a lost race republishes the directory slice, with the winner's commit still in history;
- the winner's own row in the same directory survives our re-apply;
- an uncontested push still takes the short path;
- nothing-to-commit is still exit 0.

All four pass with the fix. Against the current script, the two race tests fail on the `cp` refusal — the production bug — and the third fails on the CWD-relative `safe_push.sh` lookup, which is why that resolution is part of this change.

This was found while checking failing Actions; the other two known failures are separate — the `NameError` on master is fixed in #1230, and `Weekly Portfolio Review` is an off-host LLM credit exhaustion, not a code defect.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw