### PR TITLE
brief: make `clawock brief render` a command you can actually type

### DIFF
--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -228,6 +228,7 @@ def _harness(args, workflow=None) -> int:
         ("--phase", getattr(args, "market_phase", None)),
         ("--context-id", getattr(args, "context_id", None)),
         ("--text-file", getattr(args, "text_file", None)),
+        ("--date", getattr(args, "date", None)),
     ):
         if value is not None:
             forwarded += [flag, str(value)]
@@ -633,6 +634,7 @@ def main(argv=None) -> int:
         harness.add_argument("--market", choices=("hk", "us"))
         harness.add_argument("--context-id")
         harness.add_argument("--text-file", type=Path)
+        harness.add_argument("--date", help="artifact date (render; default today)")
         harness.add_argument("--dry-run", action="store_true")
         harness.add_argument("--workspace", type=Path, default=None)
         harness.add_argument(

--- a/src/clawock/runtime_model.py
+++ b/src/clawock/runtime_model.py
@@ -15,7 +15,11 @@ from typing import Any, Mapping
 
 
 WORKFLOWS = ("brief", "report", "intraday")
-PHASES = ("preflight", "postflight")
+# `render` is the brief's third phase: it turns the model's judgment into the
+# published report. Every workflow has preflight/postflight; only the brief has
+# something to render, and `harness.runner.PHASE_MODULES` is what says which
+# (workflow, phase) pairs actually exist.
+PHASES = ("preflight", "postflight", "render")
 
 
 @dataclass(frozen=True)

--- a/tests/test_lifecycle_phase_vocabulary.py
+++ b/tests/test_lifecycle_phase_vocabulary.py
@@ -1,0 +1,54 @@
+"""Every registered phase must be a phase the request vocabulary accepts.
+
+`brief render` shipped registered in `harness.runner.PHASE_MODULES` and rejected
+by `RunRequest`, whose `PHASES` tuple still listed only preflight/postflight —
+so `clawock brief render` answered "unknown phase: render" while the module it
+names sat right there in the registry. The unit tests all called the renderer
+directly, which is exactly the seam they could not see.
+"""
+import pytest
+
+from clawock.harness.runner import PHASE_MODULES
+from clawock.runtime_model import PHASES, WORKFLOWS, RunRequest
+
+
+@pytest.mark.parametrize(("workflow", "phase"), sorted(PHASE_MODULES))
+def test_a_registered_phase_can_be_requested(workflow, phase, tmp_path):
+    """The registry and the vocabulary are two lists of the same thing."""
+    assert workflow in WORKFLOWS
+    assert phase in PHASES
+    request = RunRequest(workflow=workflow, phase=phase, workspace=tmp_path)
+    assert request.phase == phase
+
+
+def test_the_cli_can_dispatch_the_brief_render_phase(monkeypatch):
+    """A phase nobody can type is a phase that does not exist.
+
+    Driven through `cli.main` rather than through the renderer, because the
+    break was in the seam between them: argparse choices, then the request
+    vocabulary, then the registry.
+    """
+    from clawock import cli
+    from clawock.harness import runner
+
+    seen = {}
+
+    def record(workflow, phase, argv, *, workspace=None, profile=None):
+        seen.update(workflow=workflow, phase=phase, argv=list(argv))
+        return 0
+
+    monkeypatch.setattr(runner, "run_phase", record)
+
+    assert cli.main(["brief", "render", "--date", "2026-08-31", "--dry-run"]) == 0
+    assert seen["workflow"] == "brief" and seen["phase"] == "render"
+    assert "--date" in seen["argv"] and "2026-08-31" in seen["argv"], (
+        "the date has to reach the renderer, or only today can ever be rendered")
+    assert "--dry-run" in seen["argv"]
+
+
+def test_the_render_phase_is_the_briefs_alone(monkeypatch):
+    """`intraday render` must stay a typo, not a half-wired command."""
+    from clawock import cli
+
+    with pytest.raises(SystemExit):
+        cli.main(["intraday", "render"])


### PR DESCRIPTION
Follow-up to #1232, found by running the command I had just documented against the live desk:

```
$ clawock brief render --dry-run
unknown phase: render
$ clawock brief render --dry-run --date 2026-08-31
clawock: error: unrecognized arguments: --date 2026-08-31
```

## Why it got through

Three lists have to agree for a phase to exist, and #1232 updated one:

| | |
|---|---|
| `harness.runner.PHASE_MODULES` | ✅ had `("brief", "render")` |
| `runtime_model.PHASES` | ❌ still `("preflight", "postflight")` — `RunRequest.__post_init__` raised |
| CLI `--date` forwarding | ❌ never added, so only today could be rendered |

Every test in #1232 called `render_from_workspace` / `render_brief` directly, which is precisely the seam that was broken. **Postflight was never affected** — it calls the renderer as a function — so the daily brief works; what did not work was the documented command.

## Changes

- `PHASES` gains `render`, with a comment saying the registry is what decides which (workflow, phase) pairs exist.
- The brief parser takes `--date` and `_harness` forwards it.
- `tests/test_lifecycle_phase_vocabulary.py`: parametrized over `PHASE_MODULES`, every registered pair must construct a `RunRequest`; `cli.main(["brief", "render", "--date", …, "--dry-run"])` must dispatch with the date forwarded; `intraday render` must stay a hard argparse error.

## Verification

- New file: 9 passed. Against the current code the dispatch test fails with `unknown phase: render`.
- `pytest -k "cli or runner or phase or brief or runtime or workflow"`: 519 passed.
- On the live desk after this: `clawock brief render --dry-run --date 2026-08-31` renders today's report to stdout without writing.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw