### PR TITLE
brief: a judgment that is missing or invalid now costs published content

### DIFF
--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -737,6 +737,33 @@ def _ensure_jekyll_front_matter(md_path, date):
     safe_write_text(str(md_path), fm + content)
 
 
+def _judgment_gap_issues(judgment_path, decision_packet):
+    """What the reader will be missing, said before the brief ships.
+
+    Split deliberately: an absent judgment leaves the rendered report's Tier
+    2/3, sector, macro and calibration sections empty, while an invalid one
+    still renders (the renderer reads what is there) but is dropped from the
+    Pages projection. Those are different losses and the operator should not
+    have to guess which one happened.
+    """
+    try:
+        overlay = json.loads(Path(judgment_path).read_text(encoding='utf-8'))
+    except FileNotFoundError:
+        return ['judgment 缺失：报告的辩论段（Tier 2/3、板块、大盘、校准）会是空的']
+    except (OSError, ValueError) as exc:
+        return [f'judgment 无法解析（{exc}）：报告的辩论段会是空的']
+    if decision_packet is None:
+        return []
+    overlay_issues = brief_decision_packet.validate_judgment_overlay(
+        decision_packet, overlay)
+    if not overlay_issues:
+        return []
+    shown = '；'.join(overlay_issues[:2])
+    more = f'（共 {len(overlay_issues)} 条）' if len(overlay_issues) > 2 else ''
+    return [f'judgment 未通过校验{more}：{shown} —— 报告按原文渲染，'
+            'Pages projection 会丢掉整个判断层']
+
+
 def main(argv=None):
     import argparse
     ap = argparse.ArgumentParser()
@@ -792,6 +819,14 @@ def main(argv=None):
         context=context,
     )
     issues += normalization_issues
+
+    # A judgment that is absent or does not validate now costs published
+    # content, not just a Pages sidecar field: since #1232 the report's debate
+    # sections are rendered from it. `projection_issues` records the same fact
+    # further down, but only in the result JSON — nothing reads that in time to
+    # notice the brief went out with empty sections.
+    issues += _judgment_gap_issues(
+        WS / 'memory' / '.tmp' / f'brief-judgment-{today}.json', decision_packet)
 
     # The report is rendered here, from the judgment and the normalized plan —
     # the model no longer writes markdown at all (see clawock.harness.

--- a/tests/test_brief_judgment_gaps_are_loud.py
+++ b/tests/test_brief_judgment_gaps_are_loud.py
@@ -1,0 +1,105 @@
+"""A missing or invalid judgment now costs published content, so it must be said.
+
+Since #1232 the report's Tier 2/3, sector, macro and calibration sections are
+rendered from the judgment. Before that, an absent or invalid overlay only cost
+a field in the Pages sidecar, and postflight recorded it in `projection_issues`
+— a key in the result JSON that nothing reads in time. A brief could therefore
+ship with empty debate sections and a clean status line.
+"""
+import json
+
+from clawock.harness import brief_postflight as postflight
+
+
+PACKET = {
+    "_meta": {"generation_id": "gen-1"},
+    "tickers": {"00100": {"quant": {}, "constraints": {}}},
+}
+
+
+def _overlay(**overrides):
+    from clawock.decision.packet import judgment_template
+
+    overlay = judgment_template(PACKET)
+    overlay["portfolio_assessment"] = "三条杠杆全破硬止损。"
+    overlay["portfolio_counterargument"] = "软执行只会加码纪律债。"
+    overlay["narrative"].update({
+        "regime_read": "两地趋势 OFF。", "bull": "最坏定价已吃掉大半。",
+        "bear": "纪律未执行是最大风险。", "devils_advocate": "共识只有单一来源。",
+        "attacked_consensus": "板块仍有 alpha", "aggressive": "留一半敞口。",
+        "conservative": "硬闸今天必须执行。", "neutral": "硬闸执行，其余持有。",
+        "sector_read": "板块内部分化。", "macro_read": "指数小幅向下。",
+        "calibration_read": "risk_rule 是唯一 edge。",
+        "next_session": ["09:30 确认成交"], "data_holes": [],
+    })
+    for row in overlay["ticker_judgments"]:
+        row.update({
+            "assessment": "杠杆放大下行。", "counterargument": "反弹会踏空。",
+            "rationale": "硬闸优先。", "falsifier": "收复 200 线。",
+            "next_evidence": "09:30 成交。", "fundamentals": "无基本面。",
+            "cross_market": "跟随指数。", "sentiment_read": "无硬催化。",
+            "peer_read": "板块中位。",
+        })
+    overlay.update(overrides)
+    return overlay
+
+
+def _write(tmp_path, payload):
+    path = tmp_path / "brief-judgment.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_a_missing_judgment_names_the_sections_that_will_be_empty(tmp_path):
+    issues = postflight._judgment_gap_issues(tmp_path / "absent.json", PACKET)
+
+    assert len(issues) == 1
+    assert "缺失" in issues[0] and "Tier 2/3" in issues[0]
+
+
+def test_an_unparseable_judgment_is_reported_as_such(tmp_path):
+    path = tmp_path / "brief-judgment.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    issues = postflight._judgment_gap_issues(path, PACKET)
+
+    assert len(issues) == 1 and "无法解析" in issues[0]
+
+
+def test_an_invalid_judgment_says_what_is_lost_and_what_is_not(tmp_path):
+    """It still renders — the renderer reads what is there — but the projection
+    drops the whole layer, and those are different losses."""
+    overlay = _overlay()
+    overlay["ticker_judgments"][0]["assessment"] = ""
+    path = _write(tmp_path, overlay)
+
+    issues = postflight._judgment_gap_issues(path, PACKET)
+
+    assert len(issues) == 1
+    assert "未通过校验" in issues[0]
+    assert "assessment" in issues[0], "the operator needs the first failing field"
+    assert "projection" in issues[0]
+
+
+def test_a_valid_judgment_says_nothing(tmp_path):
+    path = _write(tmp_path, _overlay())
+
+    assert postflight._judgment_gap_issues(path, PACKET) == []
+
+
+def test_without_a_packet_only_the_file_itself_can_be_judged(tmp_path):
+    """No packet means no schema to check against; the file's presence is still
+    checkable, and is the half that costs report content."""
+    path = _write(tmp_path, {"schema_version": 3})
+
+    assert postflight._judgment_gap_issues(path, None) == []
+    assert postflight._judgment_gap_issues(tmp_path / "absent.json", None) != []
+
+
+def test_the_issue_is_escalating_not_advisory(tmp_path):
+    """Advisory issues never change the status; a report published with empty
+    debate sections should not read as clean."""
+    from clawock.harness.validation import is_advisory
+
+    for issue in postflight._judgment_gap_issues(tmp_path / "absent.json", PACKET):
+        assert not is_advisory(issue)

--- a/tests/test_brief_plan_normalization.py
+++ b/tests/test_brief_plan_normalization.py
@@ -198,6 +198,34 @@ def test_normalization_failure_is_fail_closed(tmp_path, monkeypatch):
     assert brief_postflight.categorize(issues) == "fail"
 
 
+def _filled_judgment(generation_id="generation-fixture", tickers=()):
+    """A judgment that passes validation, so postflight's gap check stays quiet.
+
+    Since #1232 the report is rendered from the judgment, so an absent one is a
+    reported issue (`_judgment_gap_issues`). These fixtures are about the plan
+    and publication paths, not about that check, and they should not go quiet by
+    accident.
+    """
+    from clawock.decision.packet import judgment_template
+
+    overlay = judgment_template({
+        "_meta": {"generation_id": generation_id},
+        "tickers": {ticker: {} for ticker in tickers},
+    })
+    overlay["portfolio_assessment"] = "fixture assessment"
+    overlay["portfolio_counterargument"] = "fixture counterargument"
+    for field, value in list(overlay["narrative"].items()):
+        if field == "risk_voice_first":
+            continue
+        overlay["narrative"][field] = (
+            ["fixture step"] if isinstance(value, list) else "fixture text")
+    for row in overlay["ticker_judgments"]:
+        for field, value in list(row.items()):
+            if value == "":
+                row[field] = "fixture text"
+    return overlay
+
+
 def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
     today = datetime.now().strftime("%Y-%m-%d")
     plan_path = tmp_path / "memory" / f"{today}-plan.json"
@@ -212,6 +240,8 @@ def test_main_normalizes_before_calling_plan_validation(tmp_path, monkeypatch):
     ctx_dir = tmp_path / "memory" / ".tmp"
     ctx_dir.mkdir()
     (ctx_dir / f"brief-context-{today}.json").write_text("{}")
+    (ctx_dir / f"brief-judgment-{today}.json").write_text(
+        json.dumps(_filled_judgment(), ensure_ascii=False))
     observed = {}
 
     def assert_normalized(path, **_kwargs):
@@ -256,6 +286,8 @@ def test_dry_run_validates_normalized_plan_without_rewriting_source(
     ctx_dir = tmp_path / "memory" / ".tmp"
     ctx_dir.mkdir(parents=True, exist_ok=True)
     (ctx_dir / f"brief-context-{today}.json").write_text("{}")
+    (ctx_dir / f"brief-judgment-{today}.json").write_text(
+        json.dumps(_filled_judgment(), ensure_ascii=False))
     before_mtime = plan_path.stat().st_mtime_ns
     observed = {}
     validate = brief_postflight.validate_plan_json

--- a/tests/test_brief_projection_publication_gate.py
+++ b/tests/test_brief_projection_publication_gate.py
@@ -8,11 +8,41 @@ from datetime import datetime
 from clawock.harness import brief_postflight as postflight
 
 
+def _filled_judgment(generation_id="generation-fixture", tickers=()):
+    """A judgment that passes validation, so postflight's gap check stays quiet.
+
+    Since #1232 the report is rendered from the judgment, so an absent one is a
+    reported issue (`_judgment_gap_issues`). These fixtures are about the plan
+    and publication paths, not about that check, and they should not go quiet by
+    accident.
+    """
+    from clawock.decision.packet import judgment_template
+
+    overlay = judgment_template({
+        "_meta": {"generation_id": generation_id},
+        "tickers": {ticker: {} for ticker in tickers},
+    })
+    overlay["portfolio_assessment"] = "fixture assessment"
+    overlay["portfolio_counterargument"] = "fixture counterargument"
+    for field, value in list(overlay["narrative"].items()):
+        if field == "risk_voice_first":
+            continue
+        overlay["narrative"][field] = (
+            ["fixture step"] if isinstance(value, list) else "fixture text")
+    for row in overlay["ticker_judgments"]:
+        for field, value in list(row.items()):
+            if value == "":
+                row[field] = "fixture text"
+    return overlay
+
+
 def _run_postflight(tmp_path, monkeypatch, capsys, *, projection_error=None):
     today = datetime.now().strftime('%Y-%m-%d')
     context_path = tmp_path / 'memory' / '.tmp' / f'brief-context-{today}.json'
     context_path.parent.mkdir(parents=True)
     context_path.write_text(json.dumps({'generation_id': 'generation-fixture'}))
+    (context_path.parent / f'brief-judgment-{today}.json').write_text(
+        json.dumps(_filled_judgment(), ensure_ascii=False))
 
     stages = []
     commits = []


### PR DESCRIPTION
Follow-up to #1232, closing a hole that change opened.

## The hole

The report's Tier 2/3, sector, macro and calibration sections are now rendered from `brief-judgment-{date}.json`. Postflight's only record of a judgment problem was `projection_issues` — a key in the printed result JSON, never added to `issues`, so it does not touch the status. That was fine when the judgment fed one field of a Pages sidecar. It is not fine now: **the brief could go out with empty debate sections and a clean status line.**

## The check

`_judgment_gap_issues` runs before the render, and distinguishes what was actually lost:

| state | message | why |
|---|---|---|
| file absent | `judgment 缺失：报告的辩论段（Tier 2/3、板块、大盘、校准）会是空的` | nothing to render into those sections |
| unparseable | `judgment 无法解析（…）：报告的辩论段会是空的` | same, different cause |
| fails validation | `judgment 未通过校验（共 N 条）：… —— 报告按原文渲染，Pages projection 会丢掉整个判断层` | the renderer reads what is there; the projection drops the layer |
| valid | *(nothing)* | |

Escalating, not advisory, and not critical: a report with data and no debate is degraded, not undeliverable.

## Fixtures

`test_brief_plan_normalization.py` and `test_brief_projection_publication_gate.py` drive `main()` end to end with no judgment in their temp workspace. They now write a valid one (`_filled_judgment`, built from `judgment_template`, with a note saying why). Stubbing the new check out instead would have made them pass by not looking.

## Verification

- `tests/test_brief_judgment_gaps_are_loud.py`, 6 cases: each state above, plus "no packet means only presence can be judged", plus an assertion that the issue is not advisory (an advisory one never changes the status, which is the exact failure mode being fixed).
- Full suite: **3111 passed, 5 skipped, 4 xfailed**.

https://claude.ai/code/session_011SzmqSZM4ycHSgK8Tha9Vw