### PR TITLE
panel: refute the IC instead of only bounding it (#1167)

### DIFF
--- a/site/decimap/index.html
+++ b/site/decimap/index.html
@@ -499,6 +499,20 @@ permalink: /decimap/
         + '</b>（' + selection.n_splits + ' 次对半切分）'
         + (selection.pbo >= 0.5 ? '——<b>还不能挑赢家</b>。' : '。');
     }
+    var refutation = ((d.signal_panel || {}).refutation || {})[horizon];
+    if (refutation && refutation.signals) {
+      // 置换检验回答的是区间回答不了的那个问题：把「谁持有这个值」在同一天内
+      // 打乱之后，还剩多少信号能给出同样的 IC。两者不一致的那几条要点名。
+      text += ' 把每个交易日内「哪只票拿哪个值」打乱重算，'
+        + '<b>' + refutation.survives_refutation + '/' + refutation.signals
+        + '</b> 条信号仍然给不出同样的 IC（其余 ' + refutation.fails_placebo
+        + ' 条给得出，' + refutation.collecting + ' 条样本还不够）。';
+      var contested = refutation.interval_clears_zero_but_placebo_does_not || [];
+      if (contested.length) {
+        text += ' <b>' + contested.length + '</b> 条的区间说它离开了零、'
+          + '它自己的置换检验说没有：' + esc(contested.join('、')) + '。';
+      }
+    }
     if (caveat) text += ' 区间口径：' + esc(caveat);
     el('dm-caveat').innerHTML = text;
   }

--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -62,9 +62,30 @@ Two properties make the number publishable rather than decorative:
   overfitting is what separates "this source has weight" from "this source won a
   thirteen-way lottery".
 
+Refuting the number instead of only bounding it
+-----------------------------------------------
+An interval answers "how precisely is this estimated". It does not answer "would
+a signal carrying no information have produced this anyway", and on a
+cross-section of a dozen names it cannot answer "is one name carrying it". Two
+refuters do (#1167):
+
+* **placebo** — permute which name held which value, within each session. The
+  returns, the sessions and the tie pattern are untouched; only the pairing
+  dies. The p-value is against that null, not a textbook one.
+* **leave-one-ticker-out** — drop each name entirely and recompute. The span is
+  informational; a *sign flip* is the finding.
+
+The third refuter in that family, DoWhy's random-common-cause, does not map: it
+adds an irrelevant covariate to an adjustment set, and a rank IC adjusts for
+nothing. The reason the causal-inference port itself stayed closed is unchanged
+and is worth restating beside its refuters — this ledger has no untreated arm,
+so CATE and DML have nothing to identify. Refutation is the half of that
+toolkit that survives without an intervention.
+
 Nothing here changes a decision, a threshold, or a rule. It is a measurement,
 and its status field never reaches `validated` — the strongest verdict available
-is `diagnostic`.
+is `diagnostic`, and `survives_refutation` is a statement about the sessions
+observed, not a registration.
 """
 from __future__ import annotations
 
@@ -473,13 +494,24 @@ def _spearman(pairs) -> float | None:
     return num / (dx * dy)
 
 
-def daily_ics(rows, horizon: str) -> dict:
-    """{session: IC} for one signal at one horizon."""
+def session_pairs(rows, horizon: str) -> dict:
+    """{session: [(signal value, forward return), ...]} for one horizon.
+
+    Factored out of `daily_ics` so the refuters below rank exactly the rows the
+    headline IC ranks. A refutation computed off a second, slightly different
+    row set would refute a number nobody published.
+    """
     by_day = defaultdict(list)
     for row in rows:
         value, forward = row.get('value'), row.get(horizon)
         if value is not None and forward is not None:
             by_day[row['as_of']].append((float(value), float(forward)))
+    return by_day
+
+
+def daily_ics(rows, horizon: str) -> dict:
+    """{session: IC} for one signal at one horizon."""
+    by_day = session_pairs(rows, horizon)
     out = {}
     for day, pairs in by_day.items():
         ic = _spearman(pairs)
@@ -546,6 +578,211 @@ def score_signal(rows, horizon: str) -> dict:
         bool(band and (band[0] > 0 or band[1] < 0))
         if result['status'] == 'diagnostic' else False)
     return result
+
+
+#: How many relabelings the placebo null draws. Same count as the session
+#: permutation in `evaluation.drift`, for the same reason: enough resolution to
+#: separate 0.02 from 0.2, few enough that the panel still fits inside the
+#: decision-map build's budget.
+PLACEBO_PERMUTATIONS = 500
+
+#: A placebo needs sessions to permute within and names to permute across. Below
+#: three names a session ranks nothing; below `MIN_SESSIONS` the panel is
+#: `collecting` and the refuters stay silent rather than produce a p-value for a
+#: number that is not being claimed yet.
+MIN_PLACEBO_CROSS_SECTION = 3
+
+
+def _midranks(values) -> list[float]:
+    """Ranks with ties averaged — the same ladder `_spearman` builds."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        shared = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            out[order[k]] = shared
+        i = j + 1
+    return out
+
+
+def placebo_null(rows, horizon: str, *,
+                 permutations: int = PLACEBO_PERMUTATIONS,
+                 seed: int = seeds.seed('signal_panel_placebo_permutation')) -> dict | None:
+    """Reshuffle which name held which value, keep the session and the returns.
+
+    DoWhy calls this a placebo-treatment refuter and it is the one refuter from
+    that family this panel can actually run (see the module note below). Within
+    each session the signal's values are permuted across the names present that
+    day; the forward returns, the session structure, the number of names and the
+    tie pattern all stay exactly as they were. What is destroyed is the only
+    thing the IC claims: that *this* name's value stood next to *this* name's
+    return.
+
+    Why the session bootstrap does not already answer this. The bootstrap
+    resamples sessions to say how precisely the mean IC is estimated; it takes
+    the per-session IC as given. The placebo asks the prior question — what IC
+    would a signal with no cross-sectional information have produced on these
+    sessions — and the answer is not the textbook one whenever the cross-section
+    is small or the values are mostly tied. `news.actionable_count` and
+    `peer.triggered_rules` are zero for most names on most days; a rank
+    correlation built on twelve names of which nine are tied has a null far
+    wider than `1/sqrt(n-1)`, and an interval that ignores that reads as
+    evidence when it is arithmetic.
+
+    Two-sided, because the sign of an IC here is a finding rather than a
+    hypothesis: a signal that predicts the reverse of its intuition has still
+    refuted its placebo.
+    """
+    import numpy as np
+
+    days = []
+    for day, pairs in sorted(session_pairs(rows, horizon).items()):
+        if len(pairs) < MIN_PLACEBO_CROSS_SECTION:
+            continue
+        xs = np.asarray(_midranks([p[0] for p in pairs]), dtype=float)
+        ys = np.asarray(_midranks([p[1] for p in pairs]), dtype=float)
+        xc, yc = xs - xs.mean(), ys - ys.mean()
+        sx, sy = float(np.sqrt(xc @ xc)), float(np.sqrt(yc @ yc))
+        if sx == 0 or sy == 0:
+            continue  # a flat cross-section ranks nothing, on any relabeling
+        days.append((xc, yc / (sx * sy)))
+    if len(days) < MIN_SESSIONS:
+        return None
+
+    observed = statistics.fmean(float(xc @ yhat) for xc, yhat in days)
+    rng = np.random.default_rng(seed)
+    draws = np.zeros(permutations, dtype=float)
+    for xc, yhat in days:
+        shuffled = rng.permuted(np.broadcast_to(xc, (permutations, xc.size)).copy(),
+                                axis=1)
+        draws += shuffled @ yhat
+    draws /= len(days)
+
+    at_least = int(np.count_nonzero(np.abs(draws) >= abs(observed)))
+    ordered = np.sort(draws)
+    return {
+        'observed_mean_ic': round(observed, 4),
+        'null_mean_ic': round(float(draws.mean()), 4),
+        'null_ci95': [round(float(ordered[int(0.025 * (permutations - 1))]), 4),
+                      round(float(ordered[int(0.975 * (permutations - 1))]), 4)],
+        # +1 on both sides: the unpermuted labeling is itself one arrangement,
+        # so this null cannot support a p-value of exactly zero.
+        'p_value': round((at_least + 1) / (permutations + 1), 5),
+        'permutations': permutations,
+        'sessions': len(days),
+    }
+
+
+def leave_one_ticker_out(rows, horizon: str) -> dict | None:
+    """Drop each name entirely and recompute the mean IC.
+
+    DoWhy's data-subset refuter, moved to the axis this panel is actually thin
+    on. Subsetting *sessions* is already covered — that is what the clustered
+    bootstrap resamples — but every interval on this page is computed over a
+    cross-section of roughly a dozen names, and none of them can see that one
+    name is carrying the finding. A signal whose IC survives dropping any single
+    name and one whose sign flips when a single name leaves are indistinguishable
+    in the published column, and they are not the same claim.
+
+    The span is reported rather than a pass/fail: a name whose removal moves the
+    IC is not a defect, it is the size of this book's cross-section. A *sign
+    flip* is the part worth naming.
+    """
+    tickers = sorted({row['ticker'] for row in rows if row.get(horizon) is not None})
+    if len(tickers) < MIN_PLACEBO_CROSS_SECTION:
+        return None
+    full_ics = daily_ics(rows, horizon)
+    if not full_ics:
+        return None
+    full = statistics.fmean(full_ics.values())
+
+    without = {}
+    for ticker in tickers:
+        ics = daily_ics([row for row in rows if row['ticker'] != ticker], horizon)
+        if ics:
+            without[ticker] = statistics.fmean(ics.values())
+    if len(without) < MIN_PLACEBO_CROSS_SECTION:
+        return None
+
+    worst = max(without, key=lambda t: abs(without[t] - full))
+    flips = sorted(t for t, value in without.items()
+                   if full != 0 and value * full < 0)
+    return {
+        'n_tickers': len(without),
+        'full_mean_ic': round(full, 4),
+        'ic_range': [round(min(without.values()), 4),
+                     round(max(without.values()), 4)],
+        'largest_swing': {'ticker': worst,
+                          'mean_ic_without': round(without[worst], 4),
+                          'delta': round(without[worst] - full, 4)},
+        'sign_flips': flips,
+    }
+
+
+#: Verdicts, ordered worst-first. Deliberately not a boolean and deliberately
+#: not the word "validated": clearing a placebo says the ranking carried
+#: information on the sessions observed, which is a diagnostic finding, not a
+#: rule that was registered before the data arrived.
+REFUTATION_VERDICTS = (
+    'collecting',            # not enough sessions to refute anything yet
+    'fails_placebo',         # a relabeled signal produces this IC as often
+    'one_name_flips_it',     # clears the placebo, but a single name owns the sign
+    'survives_refutation',   # clears both, on this sample, at this horizon
+)
+
+#: Conventional, and pre-registered here rather than chosen after reading the
+#: p-values. Nothing downstream branches on it — it labels a row.
+PLACEBO_ALPHA = 0.05
+
+
+def refute_signal(rows, horizon: str, score: dict) -> dict:
+    """Both refuters plus the verdict that reads them together."""
+    if score.get('status') != 'diagnostic':
+        return {'verdict': 'collecting', 'placebo': None, 'leave_one_ticker_out': None}
+    placebo = placebo_null(rows, horizon)
+    stability = leave_one_ticker_out(rows, horizon)
+    if placebo is None:
+        verdict = 'collecting'
+    elif placebo['p_value'] > PLACEBO_ALPHA:
+        verdict = 'fails_placebo'
+    elif stability and stability['sign_flips']:
+        verdict = 'one_name_flips_it'
+    else:
+        verdict = 'survives_refutation'
+    return {'verdict': verdict, 'placebo': placebo,
+            'leave_one_ticker_out': stability}
+
+
+def refutation_summary(signals: dict) -> dict:
+    """Per horizon, how many signals each verdict claimed.
+
+    This is the part that goes to the site. The per-signal detail is available
+    from `clawock signal-panel --json`; the payload gets the count, because the
+    reader's question at the top of a page is "how many of these thirteen
+    survive being shuffled", not "what was `quant.rsi14`'s p-value".
+    """
+    out = {}
+    for horizon in ('t1', 't5', 't20'):
+        counts = {verdict: 0 for verdict in REFUTATION_VERDICTS}
+        contested = []
+        for signal, sections in signals.items():
+            counts[sections['refutation'][horizon]['verdict']] += 1
+            placebo = sections['refutation'][horizon]['placebo']
+            # The two strongest things this panel says about a signal, said
+            # about the same signal, disagreeing. `ic_clears_zero` is not
+            # rewritten to mean "and it beat its placebo" — that would change a
+            # published field's meaning under readers who already have it — so
+            # the disagreement is named instead of resolved.
+            if (placebo and sections[horizon].get('ic_clears_zero')
+                    and placebo['p_value'] > PLACEBO_ALPHA):
+                contested.append(signal)
+        out[horizon] = {'signals': len(signals), **counts,
+                        'interval_clears_zero_but_placebo_does_not': sorted(contested)}
+    return out
 
 
 #: Tertiles, not quintiles. The cross-section is about twenty-one names on a
@@ -891,10 +1128,19 @@ def evaluate(panel) -> dict:
     by_signal = defaultdict(list)
     for row in panel:
         by_signal[row['signal']].append(row)
+    scores = {signal: {horizon: score_signal(rows, horizon)
+                       for horizon in ('t1', 't5', 't20')}
+              for signal, rows in by_signal.items()}
     signals = {
         signal: {
-            **{horizon: score_signal(rows, horizon)
-               for horizon in ('t1', 't5', 't20')},
+            **scores[signal],
+            # Two refuters run against every diagnostic row (#1167). The
+            # interval says how precisely the IC is estimated; these say
+            # whether a relabeled signal would have produced it anyway, and
+            # whether one name is carrying it.
+            'refutation': {horizon: refute_signal(rows, horizon,
+                                                  scores[signal][horizon])
+                           for horizon in ('t1', 't5', 't20')},
             # The same signal against an outcome the book could have realised:
             # each window ended by whichever barrier is touched first, with the
             # production chandelier stop trailing underneath (#1164). The pair
@@ -935,6 +1181,7 @@ def evaluate(panel) -> dict:
         'signals': signals,
         'selection': {horizon: selection_pbo(panel, horizon)
                       for horizon in ('t1', 't5', 't20')},
+        'refutation_summary': refutation_summary(signals),
         'composite_polarity': {
             horizon: composite_polarity(signals, horizon, weights=_factor_weights())
             for horizon in ('t1', 't5', 't20')},
@@ -1008,6 +1255,33 @@ def main(argv=None) -> int:
         if picked:
             print('  most often selected: '
                   + ' · '.join(f'{name} ({count})' for name, count in picked))
+    summary = result['refutation_summary'][args.horizon]
+    print(f'\n--- {args.horizon} refutation '
+          f'({PLACEBO_PERMUTATIONS} placebo relabelings per signal) ---')
+    print(f'{"signal":<28}{"mean IC":>9}{"null 95%":>20}{"p":>9}'
+          f'{"worst 1-name IC":>17}  verdict')
+    for signal, sections in result['signals'].items():
+        refutation = sections['refutation'][args.horizon]
+        placebo = refutation['placebo']
+        if not placebo:
+            continue
+        stability = refutation['leave_one_ticker_out'] or {}
+        swing = stability.get('largest_swing') or {}
+        null = placebo['null_ci95']
+        print(f'{signal:<28}{placebo["observed_mean_ic"]:>+9.4f}'
+              f'{f"[{null[0]:+.3f}, {null[1]:+.3f}]":>20}'
+              f'{placebo["p_value"]:>9.4f}'
+              f'{(f"{swing.get('mean_ic_without'):+.4f} ({swing.get('ticker')})" if swing else "—"):>17}'
+              f'  {refutation["verdict"]}')
+    contested = summary['interval_clears_zero_but_placebo_does_not']
+    print(f'  {summary["survives_refutation"]}/{summary["signals"]} survive both · '
+          f'{summary["fails_placebo"]} produce this IC as often under a relabeling · '
+          f'{summary["one_name_flips_it"]} lose their sign to one name · '
+          f'{summary["collecting"]} still collecting')
+    if contested:
+        print('  interval says it clears zero, its own placebo does not: '
+              + ' · '.join(contested))
+
     print(f'\n--- {args.horizon} quantile structure and cost to hold '
           f'({QUANTILES} buckets) ---')
     print(f'{"signal":<28}{"q1":>9}{"q2":>9}{"q3":>9}{"spread":>9}'

--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -1268,10 +1268,13 @@ def main(argv=None) -> int:
         stability = refutation['leave_one_ticker_out'] or {}
         swing = stability.get('largest_swing') or {}
         null = placebo['null_ci95']
+        band = f'[{null[0]:+.3f}, {null[1]:+.3f}]'
+        # Built outside the f-string: nesting the same quote inside one is a
+        # 3.12 grammar, and this package supports 3.11.
+        worst = (f'{swing["mean_ic_without"]:+.4f} ({swing["ticker"]})'
+                 if swing else '—')
         print(f'{signal:<28}{placebo["observed_mean_ic"]:>+9.4f}'
-              f'{f"[{null[0]:+.3f}, {null[1]:+.3f}]":>20}'
-              f'{placebo["p_value"]:>9.4f}'
-              f'{(f"{swing.get('mean_ic_without'):+.4f} ({swing.get('ticker')})" if swing else "—"):>17}'
+              f'{band:>20}{placebo["p_value"]:>9.4f}{worst:>17}'
               f'  {refutation["verdict"]}')
     contested = summary['interval_clears_zero_but_placebo_does_not']
     print(f'  {summary["survives_refutation"]}/{summary["signals"]} survive both · '

--- a/src/clawock/publish/decision_map.py
+++ b/src/clawock/publish/decision_map.py
@@ -244,9 +244,10 @@ def panel_scores(data_dir: Path | None = None, evaluation: dict | None = None) -
     render, unrounded and unrecomputed — `grep -rn 'spearman\|rank_ic'` over
     this module is empty by construction, and a test keeps it that way.
 
-    The cost is about twenty seconds inside the dashboard publish, which is the
-    price of the numbers being the same numbers. `evaluation` is injectable so a
-    test does not pay it twice.
+    The cost is about thirty seconds inside the dashboard publish — twenty for
+    the panel and roughly seven more since the refuters joined it (#1167) —
+    which is the price of the numbers being the same numbers. `evaluation` is
+    injectable so a test does not pay it twice.
     """
     from clawock.evaluation import signal_panel
 
@@ -270,6 +271,11 @@ def panel_scores(data_dir: Path | None = None, evaluation: dict | None = None) -
         'sessions': coverage['sessions'],
         'rows': coverage['rows'],
         'selection': selection,
+        # Counts, not the per-signal p-values: thirty-three signals times three
+        # horizons of placebo detail is a payload this page cannot afford, and
+        # the reader's first question is how many of them survive being
+        # shuffled. `clawock signal-panel --json` has the rest.
+        'refutation': evaluation['refutation_summary'],
         'by_signal': by_signal,
         'method': evaluation['method'],
         'interval_caveat': evaluation['interval_caveat'],
@@ -497,8 +503,8 @@ def build(ledger_rows=None, data_dir: Path | None = None,
         # IC, its interval and the selection PBO, computed once by
         # `clawock signal-panel` and republished — never recomputed here.
         'signal_panel': {key: panel[key] for key in (
-            'as_of', 'first_session', 'sessions', 'rows', 'selection', 'method',
-            'interval_caveat', 'source')},
+            'as_of', 'first_session', 'sessions', 'rows', 'selection',
+            'refutation', 'method', 'interval_caveat', 'source')},
         'info_source_cards': cards,
         # Indices into `decisions`, not copies of it. The duplicated form spent
         # 88KB restating an action and an outcome that were already there, and

--- a/src/clawock/seeds.py
+++ b/src/clawock/seeds.py
@@ -38,6 +38,7 @@ SEEDS = {
     'signal_panel_cluster_bootstrap': 20260829,
     'block_bootstrap': 20260830,
     'drift_session_permutation': 20260830,
+    'signal_panel_placebo_permutation': 20260831,
 }
 
 

--- a/tests/decimap_board.spec.js
+++ b/tests/decimap_board.spec.js
@@ -37,9 +37,17 @@ function render() {
     .replace(/\{\{[\s\S]*?\}\}/g, "");
 }
 
-function serve(html) {
+function serve(html, overrides) {
   return http.createServer((request, response) => {
     const name = new URL(request.url, "http://localhost").pathname;
+    if (overrides && Object.prototype.hasOwnProperty.call(overrides, name)) {
+      response.writeHead(200, {
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "no-store",
+      });
+      response.end(overrides[name]);
+      return;
+    }
     if (name === "/decimap/" || name === "/") {
       response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       response.end(html);
@@ -188,13 +196,57 @@ async function theKpiStripPrintsWhatThePayloadHolds(browser, base, payload) {
   await context.close();
 }
 
+// The refutation sentence is served a payload that carries the block, rather
+// than whichever payload the publisher last committed. The block appears on
+// master the first time the publisher runs after this merges, and a browser
+// assertion that only fires once the artifact catches up is an assertion that
+// has never run.
+async function theCaveatReportsWhatSurvivedItsPlacebo(browser, payload, html) {
+  const patched = JSON.parse(JSON.stringify(payload));
+  patched.signal_panel = patched.signal_panel || {};
+  patched.signal_panel.refutation = {
+    t1: { signals: 33, collecting: 3, fails_placebo: 30, one_name_flips_it: 0,
+          survives_refutation: 0,
+          interval_clears_zero_but_placebo_does_not: ["factor.rank.relative_strength"] },
+    t5: { signals: 33, collecting: 3, fails_placebo: 22, one_name_flips_it: 0,
+          survives_refutation: 8, interval_clears_zero_but_placebo_does_not: [] },
+    t20: { signals: 33, collecting: 27, fails_placebo: 2, one_name_flips_it: 0,
+           survives_refutation: 4, interval_clears_zero_but_placebo_does_not: [] },
+  };
+  const server = serve(html, {
+    "/assets/data/decision_map.json": JSON.stringify(patched) });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}/decimap/`;
+  try {
+    const { context, page } = await open(browser, base, 1280);
+    const t5 = (await page.textContent("#dm-caveat")).replace(/\s+/g, "");
+    assert(t5.includes("8/33"),
+      `the caveat does not report the t5 survivor count: ${t5}`);
+    assert(!t5.includes("factor.rank.relative_strength"),
+      "nothing is contested at t5 in this fixture; naming a signal there is wrong");
+
+    await page.click('#dm-horizon button[data-h="t1"]');
+    await page.waitForTimeout(120);
+    const t1 = (await page.textContent("#dm-caveat")).replace(/\s+/g, "");
+    assert(t1.includes("0/33"),
+      `switching horizon did not move the survivor count: ${t1}`);
+    assert(t1.includes("factor.rank.relative_strength"),
+      "a signal whose interval and whose own placebo disagree must be named");
+    await context.close();
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+
 async function main() {
   if (!fs.existsSync(PAYLOAD)) {
     console.log("decimap board contract: skipped, no assets/data/decision_map.json");
     return;
   }
   const payload = JSON.parse(fs.readFileSync(PAYLOAD, "utf8"));
-  const server = serve(render());
+  const html = render();
+  const server = serve(html);
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
   const base = `http://127.0.0.1:${server.address().port}/decimap/`;
   const executablePath = process.env.CHROME_EXE || undefined;
@@ -207,6 +259,7 @@ async function main() {
     await aCellOpensTheDecisionsItCounts(browser, base);
     await thePageNeverScrollsSidewaysButTheBoardDoes(browser, base);
     await theKpiStripPrintsWhatThePayloadHolds(browser, base, payload);
+    await theCaveatReportsWhatSurvivedItsPlacebo(browser, payload, html);
     console.log("decimap board contract: ok");
   } finally {
     await browser.close();

--- a/tests/test_decision_map.py
+++ b/tests/test_decision_map.py
@@ -80,6 +80,10 @@ STUB_PANEL = {
                   'n_observations': 120, 'n_sessions': 20,
                   'status': 'diagnostic', 'ic_clears_zero': False}
         for horizon in dm.HORIZONS}},
+    'refutation': {horizon: {'signals': 1, 'collecting': 0, 'fails_placebo': 1,
+                             'one_name_flips_it': 0, 'survives_refutation': 0,
+                             'interval_clears_zero_but_placebo_does_not': []}
+                   for horizon in dm.HORIZONS},
     'method': 'cross-sectional rank IC per session, averaged',
     'interval_caveat': 't20 bands are optimistic',
     'source': 'clawock signal-panel (evaluation.signal_panel.evaluate)',
@@ -259,6 +263,7 @@ def test_the_selection_pbo_is_published_once_for_the_panel_not_per_signal(monkey
     """PBO is a property of choosing among the signals, not of any one of them."""
     payload = _payload(monkeypatch, [_decision('d0', 'AAA', '2026-06-01')], {})
     assert payload['signal_panel']['selection'] == STUB_PANEL['selection']
+    assert payload['signal_panel']['refutation'] == STUB_PANEL['refutation']
     assert 'by_signal' not in payload['signal_panel']
     for card in payload['info_source_cards']:
         assert 'pbo' not in (card.get('panel') or {})
@@ -313,6 +318,11 @@ def test_panel_scores_reshapes_signal_panel_without_touching_its_numbers():
         'selection': {horizon: {'status': 'measured', 'pbo': 0.34,
                                 'n_splits': 70, 'selected_signals': {'a': 3}}
                       for horizon in dm.HORIZONS},
+        'refutation_summary': {
+            horizon: {'signals': 1, 'collecting': 0, 'fails_placebo': 0,
+                      'one_name_flips_it': 0, 'survives_refutation': 1,
+                      'interval_clears_zero_but_placebo_does_not': []}
+            for horizon in dm.HORIZONS},
         'method': 'cross-sectional rank IC per session, averaged',
         'interval_caveat': 't20 bands are optimistic',
     }
@@ -327,6 +337,12 @@ def test_panel_scores_reshapes_signal_panel_without_touching_its_numbers():
     assert panel['as_of'] == '2026-08-25'
     assert panel['selection']['t5'] == {'status': 'measured', 'pbo': 0.34,
                                         'n_splits': 70}
+    # Counts travel; the per-signal placebo detail does not — thirty-three
+    # signals of it would cost more payload than the page has to spend.
+    assert panel['refutation']['t5']['survives_refutation'] == 1
+    assert set(panel['refutation']['t5']) == {
+        'signals', 'collecting', 'fails_placebo', 'one_name_flips_it',
+        'survives_refutation', 'interval_clears_zero_but_placebo_does_not'}
 
 
 def test_the_panel_block_is_dropped_before_the_timelines_are(monkeypatch):

--- a/tests/test_signal_panel.py
+++ b/tests/test_signal_panel.py
@@ -13,6 +13,7 @@ silently reweighting a session, a forward return that starts on a bar the
 snapshot already contained, and an interval whose width counts rows rather than
 sessions.
 """
+import datetime
 import json
 
 import pytest
@@ -208,3 +209,126 @@ def test_selection_reports_pbo_over_the_signals_a_chooser_could_choose_between()
     assert result["shared_sessions"] >= 16
     assert result["pbo"] <= 0.2, "one signal ranks every session; that is not a search"
     assert result["selected_signals"].get("news.signed_score", 0) == result["n_splits"]
+
+
+def _sessions(days, values, forwards, signal="quant.rsi14", horizon="t1"):
+    """`days` sessions of one fixed cross-section, ranked the same way each day."""
+    rows = []
+    for day in range(days):
+        as_of = (datetime.date(2026, 6, 1) + datetime.timedelta(days=day)).isoformat()
+        for ticker in values:
+            rows.append({"as_of": as_of, "ticker": ticker, "signal": signal,
+                         "value": values[ticker], horizon: forwards[ticker]})
+    return rows
+
+
+#: Five names ranked 1..5 by the signal, whose forward returns rank 3,4,1,2,5.
+#: Rank IC is +0.2 every session — but the four core names alone rank -0.6, so
+#: the whole finding belongs to EEE. Used twice below, for the two questions an
+#: interval cannot answer.
+_ONE_NAME_CARRIES_IT = (
+    {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0, "EEE": 5.0},
+    {"AAA": 3.0, "BBB": 4.0, "CCC": 1.0, "DDD": 2.0, "EEE": 5.0},
+)
+
+
+def test_a_planted_ranking_beats_every_relabeling_it_is_given():
+    rows = _sessions(20, {"AAA": 3.0, "BBB": 2.0, "CCC": 1.0, "DDD": 0.0},
+                     {"AAA": 3.0, "BBB": 2.0, "CCC": 1.0, "DDD": 0.0})
+
+    placebo = sp.placebo_null(rows, "t1")
+
+    assert placebo["observed_mean_ic"] == 1.0
+    assert placebo["p_value"] == round(1 / (sp.PLACEBO_PERMUTATIONS + 1), 5), (
+        "no relabeling can match a perfect ranking, and the +1 correction is "
+        "what keeps that from being reported as p = 0")
+    assert placebo["null_mean_ic"] == pytest.approx(0.0, abs=0.05)
+
+
+def test_a_signal_with_no_ranking_cannot_refute_its_own_placebo():
+    """The forward returns are the same every day; the values carry no order."""
+    rows = _sessions(20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0},
+                     {"AAA": 2.0, "BBB": 1.0, "CCC": 4.0, "DDD": 3.0})
+    for index, row in enumerate(rows):  # break the repetition, keep the noise
+        row["value"] = float((index * 7) % 4)
+
+    placebo = sp.placebo_null(rows, "t1")
+
+    assert placebo["p_value"] > sp.PLACEBO_ALPHA
+
+
+def test_the_placebo_ranks_exactly_the_rows_the_headline_ic_ranks():
+    """A refutation of a slightly different row set refutes nothing published."""
+    rows = _sessions(20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0},
+                     {"AAA": 2.0, "BBB": 3.0, "CCC": 1.0})
+    rows.append({"as_of": "2026-06-01", "ticker": "DDD", "signal": "quant.rsi14",
+                 "value": 9.0, "t1": None})  # unscorable, must be dropped by both
+
+    assert (sp.placebo_null(rows, "t1")["observed_mean_ic"]
+            == sp.score_signal(rows, "t1")["mean_ic"])
+
+
+def test_the_placebo_is_reproducible_under_the_registered_seed():
+    rows = _sessions(20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0},
+                     {"AAA": 3.0, "BBB": 4.0, "CCC": 1.0, "DDD": 2.0})
+
+    assert sp.placebo_null(rows, "t1") == sp.placebo_null(rows, "t1")
+    assert sp.seeds.seed("signal_panel_placebo_permutation"), (
+        "an unregistered seed is a run card that cannot reproduce its own number")
+
+
+def test_one_name_carrying_the_sign_is_named_rather_than_averaged_away():
+    values, forwards = _ONE_NAME_CARRIES_IT
+    rows = _sessions(40, values, forwards)
+
+    stability = sp.leave_one_ticker_out(rows, "t1")
+
+    assert stability["full_mean_ic"] == pytest.approx(0.2)
+    assert stability["sign_flips"] == ["EEE"]
+    assert stability["largest_swing"]["ticker"] == "EEE"
+    assert stability["largest_swing"]["mean_ic_without"] == pytest.approx(-0.6)
+    assert sp.score_signal(rows, "t1")["ic_clears_zero"], (
+        "the published interval sees none of this — every session contains EEE, "
+        "so resampling sessions cannot reach the question")
+
+
+@pytest.mark.parametrize("verdict,days,values,forwards", [
+    # Below the session floor nothing is claimed, so nothing is refuted.
+    ("collecting", 6, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0},
+     {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0}),
+    # IC +0.2 on four names, twenty sessions: tight enough for the interval to
+    # leave zero, small enough that a relabeling reaches it often.
+    ("fails_placebo", 20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0},
+     {"AAA": 3.0, "BBB": 2.0, "CCC": 1.0, "DDD": 4.0}),
+    ("one_name_flips_it", 40, *_ONE_NAME_CARRIES_IT),
+    ("survives_refutation", 20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0},
+     {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}),
+])
+def test_every_verdict_is_reachable(verdict, days, values, forwards):
+    """Each branch driven by data, not by trust that it would fire if needed.
+
+    Three of these four verdicts never appear on the live panel today. A branch
+    only a bad day reaches is a branch a green run has never executed.
+    """
+    rows = _sessions(days, values, forwards)
+
+    result = sp.refute_signal(rows, "t1", sp.score_signal(rows, "t1"))
+
+    assert result["verdict"] == verdict
+    assert set(sp.REFUTATION_VERDICTS) >= {verdict}
+
+
+def test_the_summary_names_a_signal_its_own_two_measures_disagree_about():
+    rows = _sessions(20, {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0},
+                     {"AAA": 3.0, "BBB": 2.0, "CCC": 1.0, "DDD": 4.0})
+    scored = {horizon: sp.score_signal(rows, horizon) for horizon in ("t1", "t5", "t20")}
+    signals = {"quant.rsi14": {
+        **scored,
+        "refutation": {horizon: sp.refute_signal(rows, horizon, scored[horizon])
+                       for horizon in ("t1", "t5", "t20")}}}
+
+    summary = sp.refutation_summary(signals)
+
+    assert scored["t1"]["ic_clears_zero"] and summary["t1"]["fails_placebo"] == 1
+    assert summary["t1"]["interval_clears_zero_but_placebo_does_not"] == ["quant.rsi14"]
+    assert "validated" not in json.dumps(summary)


### PR DESCRIPTION
Reopens the refutation half of #1167 — the half that does not need an intervention — and implements it.

## What the panel could not say before

`evaluation/signal_panel.py` publishes rank IC, a session-clustered bootstrap interval, quantile structure, holding cost and selection PBO. None of them is a null-hypothesis test:

```
$ grep -n "placebo\|permutation\|leave_one\|jackknife" src/clawock/evaluation/signal_panel.py
$
```

The interval answers *how precisely is this estimated*. It cannot answer:

1. **What IC would a signal with no cross-sectional information have produced on these sessions?** The bootstrap takes each session's IC as given. With 12–21 names and count signals that are zero for most names on most days, the true null is much wider than the textbook one.
2. **Is one name carrying it?** Every session contains every name, so resampling *sessions* structurally cannot reach this question.

## What is here

- **`placebo_null`** — permute which name held which value, within each session. Returns, sessions, cross-section size and tie pattern all preserved; only the pairing dies. Two-sided, `+1` on both sides so p = 0 is not claimable. 500 relabelings, matching `evaluation.drift`.
- **`leave_one_ticker_out`** — drop each name entirely, recompute. The span is informational; a **sign flip** is the finding.
- **`refute_signal`** → one of four verdicts; **`refutation_summary`** → the counts, plus the signals whose interval and whose own placebo disagree.

## What it found on the live panel

33 signals · 84 sessions · 10,405 rows:

| horizon | survives both | fails placebo | collecting |
|---|---|---|---|
| t1 | **0** | 30 | 3 |
| t5 | 8 | 22 | 3 |
| t20 | 4 | 2 | 27 |

t1 having no survivors is the same story as the published t1 selection PBO of 0.81, measured from the other side.

**Six signals carry `ic_clears_zero: true` while their own placebo cannot reject noise** — at t5: `bar.vol_of_vol` (interval [+0.017, +0.190], p = 0.148), `factor.rank.drawdown_resilience` (p = 0.096), `factor.rank.low_volatility` (p = 0.186), `factor.rank.relative_strength` (p = 0.128), `factor.rank.residual_mom_6m` (p = 0.072); at t1: `factor.rank.relative_strength` (p = 0.299). Four of the five t5 ones are constituents of `composite_score`.

`ic_clears_zero` is **not** redefined to require the placebo. Changing a published field's meaning under readers who already hold it is worse than naming the disagreement, so the disagreement is named — in the summary, in the CLI table, and in the decimap caveat line.

## Scope kept off

- No DoWhy / EconML / CausalML dependency; no DAG, CATE, DML or IV. That closure stands: this ledger has no untreated arm.
- DoWhy's random-common-cause refuter does not port — it adds a covariate to an adjustment set, and a rank IC adjusts for nothing.
- No threshold, decision path or rule changes. `refutation_summary` is a measurement.

## Cost

- **Build**: ~7s added inside the decision-map subprocess (≈20s → ≈27s against a 180s timeout); noted in `panel_scores`' docstring, which previously advertised twenty seconds.
- **Payload**: 615 bytes for the counts. Per-signal placebo detail stays in `clawock signal-panel --json` — 33 signals × 3 horizons of it is not affordable at 190KB.

## Verification

- `tests/test_signal_panel.py` — 8 new tests. Three of the four verdicts never occur on today's live panel, so **each verdict is driven by constructed data** in `test_every_verdict_is_reachable` rather than trusted to fire when it is needed.
- `tests/test_decision_map.py` — the counts travel, the per-signal detail does not.
- `tests/decimap_board.spec.js` — the caveat assertion is served a payload carrying the block, rather than waiting for the publisher to commit one. A browser assertion that only fires once the artifact catches up has never run.

```
$ python3 -m pytest tests/test_signal_panel.py tests/test_decision_map.py -q
46 passed
$ node tests/decimap_board.spec.js
decimap board contract: ok
```

Closes #1167

https://claude.ai/code/session_01UUE66h1qD3eJiWD2rs7i6c