### PR TITLE
sentiment: a mention count nobody fetched is not zero (#1237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,6 +686,11 @@ jobs:
       - name: FX fallback chain
         run: python3 ops/ci/smoke_fx.py
 
+      # Answers the question #1237 left open: the replacement Reddit endpoint
+      # was verified from the project VPS, and the producer runs here.
+      - name: Reddit search feed reachability
+        run: python3 ops/ci/smoke_reddit.py
+
   portable-workflow:
     # The headline claim, executed against a built wheel on every PR (#1111).
     #

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -4,7 +4,8 @@ name: Sentiment Scan
 # Scheduled this early to absorb GH Actions' typical 1–2h scheduled-cron delay — a job
 # nominally 30 min before the brief used to land AFTER the punctual openclaw brief.
 # Per-ticker sentiment from FREE public sources:
-#   • Reddit JSON   (US: wsb / stocks / investing)
+#   • Reddit search RSS (one site-wide query for the whole book, matched back
+#     to each holding locally — the JSON API answers 403 without OAuth, #1237)
 #   • Google News RSS (US: English; HK: 中文 by Chinese name + EN by ticker)
 # Writes assets/data/sentiment.json (consumed by agent Mode 5 + dashboard).
 on:
@@ -38,7 +39,7 @@ jobs:
       - name: Set up clawock (Python)
         uses: ./.github/actions/clawock-python
 
-      - name: Scan sentiment (Reddit + Google News)
+      - name: Scan sentiment (Reddit search RSS + Google News)
         run: clawock sentiment --workspace .
 
       - name: Validate sentiment coverage

--- a/.github/workflows/sentiment-scan.yml
+++ b/.github/workflows/sentiment-scan.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up clawock (Python)
         uses: ./.github/actions/clawock-python
 
-      - name: Scan sentiment (Reddit search RSS + Google News)
+      - name: Scan sentiment (Reddit + Google News)
         run: clawock sentiment --workspace .
 
       - name: Validate sentiment coverage

--- a/config/information-layers.json
+++ b/config/information-layers.json
@@ -138,7 +138,7 @@
         },
         {
           "command": "sentiment",
-          "note": "Reddit, Google News and Yahoo RSS scan per active holding"
+          "note": "Reddit search RSS and Google News scan per active holding"
         },
         {
           "command": "clawock-influencer-scan",

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -81,7 +81,7 @@ Sources: Yahoo · Reddit · CNN · social feeds
 | Command | Module | What it collects or computes |
 |---|---|---|
 | `clawock macro` | `clawock.market_data.macro` | VIX, 10Y, DXY, Fear & Greed, Federal Reserve releases |
-| `clawock sentiment` | `clawock.market_data.sentiment` | Reddit, Google News and Yahoo RSS scan per active holding |
+| `clawock sentiment` | `clawock.market_data.sentiment` | Reddit search RSS and Google News scan per active holding |
 | `clawock-influencer-scan` | `clawock.automation.influencer` | market-moving statements from high-impact figures, read from primary feeds |
 
 ### Layer 6 · Quant & risk / 量化与风险

--- a/ops/ci/smoke_reddit.py
+++ b/ops/ci/smoke_reddit.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Can a GitHub runner reach Reddit's search feed at all?
+
+This probe exists because of a specific unknown left by #1237. Reddit's
+unauthenticated JSON API returns `403 Blocked` everywhere, and the replacement
+(`search.rss`) was verified from the project's own VPS — 200, 25 entries — but
+the producer runs on a GitHub Actions runner, and datacenter ranges are exactly
+what a source like this blocks first. Three months of published zeros came from
+nobody ever asking that question, so it gets asked on every code PR instead of
+being assumed either way.
+
+Advisory by construction: the job carries `continue-on-error`, so a red here
+annotates rather than blocks. What it must never do is pass quietly on an
+answer that is not an answer — `429` and `403` are distinct outcomes and both
+are printed, because "throttled" is a source that works and "blocked" is not.
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+
+import requests
+
+FEED = "https://www.reddit.com/search.rss?q=MSFT&sort=new&limit=25"
+UA = "clawock-sentiment-scan/1.0 (github.com/KCNyu/clawock)"
+ATOM = {"a": "http://www.w3.org/2005/Atom"}
+
+
+def check(get=None) -> tuple[str, int]:
+    """(verdict, entry count). Raises only on an unreadable 200."""
+    response = (get or requests.get)(FEED, headers={"User-Agent": UA}, timeout=15)
+    if response.status_code == 429:
+        return "throttled", 0
+    if response.status_code != 200:
+        return f"blocked (HTTP {response.status_code})", 0
+    entries = ET.fromstring(response.text).findall("a:entry", ATOM)
+    assert entries, "Reddit answered 200 with an empty feed for a mega-cap ticker"
+    return "reachable", len(entries)
+
+
+def main() -> int:
+    try:
+        verdict, count = check()
+    except Exception as exc:  # noqa: BLE001 - advisory probe, report anything
+        print(f"::warning::reddit search feed probe failed: {type(exc).__name__}: {exc}")
+        return 1
+    print(f"reddit search feed from this runner: {verdict} ({count} entries)")
+    if verdict == "reachable":
+        return 0
+    # Not a crash and not a pass. The sentiment producer already publishes
+    # `null` rather than `0` for a name it could not reach, so this outcome
+    # costs honesty nothing — it decides where the scan should run.
+    print("::warning::sentiment's Reddit leg cannot run from GitHub Actions; "
+          "counts will publish as null until the scan moves to a host that can "
+          "reach it")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1526,9 +1526,17 @@
 
     // Sentiment aggregate (kept as quick-glance counts; per-ticker drill below)
     if (s.tickers && Array.isArray(s.tickers)) {
-      const totalReddit = s.tickers.reduce((sum, t) => sum + (t.reddit_mentions_7d || 0), 0);
+      // A null count is a name Reddit never answered about, not a name with
+      // nothing said about it (#1237). Summing them as zeros published a total
+      // that looked measured for three months while the source returned 403.
+      const measured = s.tickers.filter(t => typeof t.reddit_mentions_7d === 'number');
+      const totalReddit = measured.reduce((sum, t) => sum + t.reddit_mentions_7d, 0);
       const totalNews = s.tickers.reduce((sum, t) => sum + ((t.google_news_en || []).length + (t.google_news_zh || []).length), 0);
-      if (totalReddit > 0) cells.push({lbl: 'Reddit 7d', val: totalReddit, sub: 'mentions'});
+      if (measured.length) {
+        cells.push({lbl: 'Reddit 7d', val: totalReddit,
+                    sub: measured.length === s.tickers.length
+                      ? 'mentions' : `mentions · ${measured.length}/${s.tickers.length} 只票`});
+      }
       if (totalNews > 0) cells.push({lbl: 'News 7d', val: totalNews, sub: 'articles'});
     }
 
@@ -1582,12 +1590,12 @@
         ticker: t.ticker,
         name: t.name || '',
         region: t.region || '',
-        reddit: t.reddit_mentions_7d || 0,
+        reddit: typeof t.reddit_mentions_7d === 'number' ? t.reddit_mentions_7d : null,
         reddit_posts: t.reddit_posts || [],
         news: [...(t.google_news_en || []), ...(t.google_news_zh || [])],
       }))
       .filter(t => t.reddit > 0 || t.news.length > 0)
-      .sort((a, b) => (b.reddit - a.reddit) || (b.news.length - a.news.length));
+      .sort((a, b) => ((b.reddit || 0) - (a.reddit || 0)) || (b.news.length - a.news.length));
     if (!withSignal.length) { wrap.innerHTML = ''; return; }
     const regionTag = (r) => r === 'us_stocks' ? 'US' : (r === 'hk_stocks' ? 'HK' : '');
     wrap.innerHTML = withSignal.map(t => {
@@ -1596,13 +1604,15 @@
       // 把它变成洞。与 influencer feed 的 escapeHtml 同一约定。
       const newsLis = t.news.slice(0, 3).map(n =>
         `<li>${escapeHtml(n.title || '')}</li>`).join('');
+      // No score and no comment count: the search feed does not carry them, and
+      // `p.score || 0` printed "0↑" on every post ever rendered here.
       const redditLis = t.reddit_posts.slice(0, 3).map(p =>
-        `<li>${escapeHtml(p.title || '')} <span style="color:var(--text-dim);font-size:var(--fs-micro);">· ${p.score || 0}↑ ${p.num_comments || 0}💬</span></li>`).join('');
+        `<li>${escapeHtml(p.title || '')}</li>`).join('');
       return `<details class="sd-row">
         <summary>
           <span class="sd-tk">${escapeHtml(t.ticker)}</span>
           <span class="sd-reg">${regionTag(t.region)}</span>
-          <span class="sd-counts"><strong>${t.reddit}</strong>R · <strong>${t.news.length}</strong>N</span>
+          <span class="sd-counts"><strong>${t.reddit == null ? '—' : t.reddit}</strong>R · <strong>${t.news.length}</strong>N</span>
         </summary>
         <div class="sd-body">
           ${newsLis ? `<div class="sd-grp">News</div><ul>${newsLis}</ul>` :

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -557,6 +557,21 @@ def _information_sizing_overlay(info: dict, factor: dict, peer: dict,
     }
 
 
+def _mention_count(raw):
+    """An int when one was measured, `None` when it was not.
+
+    Deliberately not `int(raw or 0)`. A mention count of zero and a mention
+    count that was never fetched are different facts, and the second one was
+    published as the first for the whole life of the sentiment artifact (#1237).
+    """
+    if isinstance(raw, bool) or raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _sentiment_view(rows: list[dict], ticker: str, source_ticker: str) -> dict:
     row = next(
         (
@@ -571,7 +586,12 @@ def _sentiment_view(rows: list[dict], ticker: str, source_ticker: str) -> dict:
     return {
         "as_of": row.get("as_of"),
         "source_ticker": row.get("ticker") or source_ticker,
-        "reddit_mentions_7d": int(row.get("reddit_mentions_7d") or 0),
+        # `or 0` here told the model "nobody mentioned this name" whenever the
+        # fetch had failed, which was every day for three months (#1237). The
+        # count passes through as-is — `None` when it was not obtained — and the
+        # status travels with it so the reader can tell silence from absence.
+        "reddit_mentions_7d": _mention_count(row.get("reddit_mentions_7d")),
+        "reddit_status": row.get("reddit_status") or ("ok" if row else "missing"),
         "recent_move": row.get("recent_move") if isinstance(row.get("recent_move"), dict) else {},
         "headline_count": len(headlines),
         "headlines": headlines,

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -884,24 +884,31 @@ def load_macro_and_sentiment(today, issues):
             else:
                 # price-in lens: recent 5-session move per signalled ticker (priced-in check)
                 signalled = [t.get('ticker') for t in s.get('tickers', [])
-                             if t.get('reddit_mentions_7d', 0) or t.get('google_news_en')
+                             if t.get('reddit_mentions_7d') or t.get('google_news_en')
                              or t.get('google_news_zh')]
                 moves = _recent_price_moves(signalled)
                 tickers_out = []
                 for t in s.get('tickers', []):
-                    reddit_n  = t.get('reddit_mentions_7d', 0)
+                    reddit_n  = t.get('reddit_mentions_7d')
+                    reddit_st = t.get('reddit_status') or 'ok'
                     gn_en     = t.get('google_news_en') or []
                     gn_zh     = t.get('google_news_zh') or []
-                    # Skip noise: 0 mention + 0 news
-                    if reddit_n == 0 and not gn_en and not gn_zh:
+                    # Skip noise: nothing measured on either source. A name whose
+                    # Reddit lookup did not answer is NOT quiet — it is unknown,
+                    # and dropping it here would hide the outage rather than the
+                    # noise (#1237).
+                    if not reddit_n and reddit_st == 'ok' and not gn_en and not gn_zh:
                         continue
                     tickers_out.append({
                         'ticker': t.get('ticker'),
                         'name':   t.get('name'),
                         'region': t.get('region'),
                         'reddit_mentions_7d': reddit_n,
-                        'reddit_top': [{'title': p.get('title'), 'score': p.get('score'),
-                                        'comments': p.get('num_comments')}
+                        'reddit_status': reddit_st,
+                        # Title and link only: the search feed carries no score
+                        # and no comment count, and defaulting them to 0 made a
+                        # post nobody fetched look like a post nobody upvoted.
+                        'reddit_top': [{'title': p.get('title'), 'url': p.get('url')}
                                        for p in (t.get('reddit_posts') or [])[:3]],
                         'news_top':   [n.get('title') for n in (gn_en + gn_zh)[:3] if n.get('title')],
                         'recent_move': moves.get(t.get('ticker')),  # {px_pct, n_sessions} or None — priced-in check
@@ -913,8 +920,10 @@ def load_macro_and_sentiment(today, issues):
                     'tickers':     tickers_out,
                 }
                 with_signal = sum(1 for t in tickers_out if t['reddit_mentions_7d'] or t['news_top'])
+                unanswered = sum(1 for t in tickers_out if t['reddit_status'] != 'ok')
                 print(f'   sentiment: {with_signal}/{len(s.get("tickers",[]))} tickers '
-                      f'have reddit/news signal')
+                      f'have reddit/news signal'
+                      + (f'; reddit did not answer for {unanswered}' if unanswered else ''))
     except Exception as e:
         print(f'   ⚠ sentiment load failed: {e}')
         issues.append(f'sentiment load exception: {type(e).__name__}')

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -470,7 +470,8 @@ def sentiment_section(context, judgment):
             for item in (row.get("news_top") or [])[:3])
         rows.append([
             ticker,
-            f"{row.get('reddit_mentions_7d', 0)} mentions",
+            (f"{row['reddit_mentions_7d']} mentions"
+             if row.get("reddit_mentions_7d") is not None else MISSING),
             keywords or MISSING,
             pct((row.get("recent_move") or {}).get("pct_5d"))
             if isinstance(row.get("recent_move"), dict) else MISSING,

--- a/src/clawock/market_data/sentiment.py
+++ b/src/clawock/market_data/sentiment.py
@@ -1,11 +1,37 @@
 #!/usr/bin/env python3
-"""
-fetch_sentiment.py — daily sentiment scan for every active holding.
+"""Daily retail-chatter and news scan for every active holding.
 
-Sources (all free, no API key):
-  • Reddit JSON       — r/wallstreetbets r/stocks r/investing (US tickers only)
-  • Google News RSS   — covers both US tickers AND HK Chinese-name search
-  • Yahoo Finance RSS — supplement, includes analyst headlines
+Sources (both free, neither needs a key):
+  • Reddit search RSS — site-wide `search.rss`, one request per name
+  • Google News RSS   — US tickers in English, HK names in Chinese
+
+There is no Yahoo Finance source here despite three months of this docstring
+claiming one; the `sources` list never held it.
+
+**Reddit's unauthenticated JSON API is gone.** `reddit.com/r/<sub>/search.json`
+returns `403 Blocked` — measured 2026-08-31 on both `www` and `old` — and has
+returned nothing for the entire recorded history of this artifact: across all 87
+commits of `sentiment.json` since 2026-05-17, every ticker's mention count is 0.
+The old code caught the failure, set `SOURCE_STATUS['reddit'] = 'failed'`, and
+then published `0` anyway, so three consumers — the decision packet, the brief
+and the dashboard — have been reading "nobody is talking about this name" off a
+request that was never answered. The two are not the same sentence.
+
+What replaces it: `search.rss`, which still answers without credentials. It is
+rate limited hard (a second request within ~30s returns 429 with no
+`Retry-After`), so the scan sweeps once, retries what bounced with backoff, and
+stops at a wall-clock budget. **A name the scan could not reach gets `None`, not
+`0`** — that distinction is the whole point of this module's rewrite.
+
+Two things the RSS endpoint changes about the numbers:
+
+* `sort=new&t=week` is ignored — a probe returned entries dated 2012 through
+  today — so the seven-day window is applied here, on each entry's `updated`.
+  The field has carried a `_7d` suffix since it was written; this is the first
+  version where that suffix is true.
+* score and comment counts are not in the feed, so `reddit_posts` no longer
+  carries them. A post with `score: 0` because the feed does not say is the
+  same lie in smaller print.
 
 Writes: assets/data/sentiment.json
 """
@@ -15,21 +41,93 @@ import re
 import sys
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import quote
 
 import requests
 
+from clawock import instruments
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
 UA = 'clawock-sentiment-scan/1.0 (github.com/KCNyu/clawock)'
 HEADERS = {'User-Agent': UA}
 
-REDDIT_SUBS = ['wallstreetbets', 'stocks', 'investing']
+#: One request for the whole book, not one per name. Reddit answers an
+#: unauthenticated feed roughly once every thirty seconds — a paced ten-name
+#: sweep measured 1/10 answered — so ten requests is a scan that mostly reports
+#: nothing. An `OR` of every holding's search terms fits in one.
+REDDIT_SEARCH = 'https://www.reddit.com/search.rss'
+
+#: Reddit's search is the recall stage and it is loose: an `OR` of the book's
+#: terms came back with a post about a dental crown. The precision stage is
+#: local — every returned entry is matched against the terms again, here, and an
+#: entry matching none of them is not counted for anyone. Measured on the live
+#: book: 98 entries returned, 97 inside the window, **42** actually naming a
+#: holding.
+REDDIT_LIMIT = 100
+REDDIT_RETRY_WAITS = (0, 35, 70)
 TIMEOUT = 10
+
+#: The declared bot UA is the one that works. A browser-shaped UA was rate
+#: limited on the same request that the bot UA got a 200 for (measured
+#: 2026-08-31), so pretending to be Chrome here would be both dishonest and
+#: worse.
 SOURCE_STATUS = {'reddit': 'failed', 'google_news': 'failed'}
+
+#: How far back a mention counts. Applied here, on each entry's timestamp,
+#: because the endpoint's own `t=week` is ignored under `sort=new` — a probe
+#: returned entries dated 2012 through today.
+MENTION_WINDOW_DAYS = 7
+
+#: Trailing words that describe the wrapper rather than the company, stripped
+#: from a registry name before it becomes a search term. "SpaceX exposure" has
+#: never appeared in a Reddit post; "SpaceX" appears twenty-one times a week.
+#: Declared rather than inferred, and the terms actually used are published per
+#: ticker so a wrong one is visible instead of buried in a count.
+NAME_TAIL_NOISE = (
+    'exposure', 'index', 'etf', 'adr', 'group', 'holdings', 'holding',
+    'markets', 'market', 'inc', 'corp', 'corporation', 'ltd', 'limited',
+    'plc', 'co',
+)
+
+#: Where a mention has to have been made to count. Reddit's site-wide search
+#: is the only endpoint left, and it does not honour a subreddit filter next to
+#: an `OR` of terms, so the scope the old code got from asking three investing
+#: subs directly is reapplied here, on the way back.
+#:
+#: This is not tidying. Measured on the live book without it, `MINIMAX` scored
+#: 16 mentions in a week — from r/abstractgames and r/PiCodingAgent, because
+#: minimax is a game-theory algorithm and one of this book's holdings happens
+#: to share its name. Publishing 16 would have replaced a false zero with a
+#: false sixteen.
+#:
+#: Substrings, matched case-insensitively against the subreddit name, and
+#: published in the artifact so an undercount is auditable rather than assumed.
+#: It undercounts on purpose: r/spacecapital is a real investing community and
+#: this list misses it. A declared undercount is a number a reader can correct;
+#: an overcount from a dictionary word is not.
+FINANCE_SUBREDDIT_MARKS = (
+    'stock', 'invest', 'wallstreetbets', 'wsb', 'trading', 'trader',
+    'finance', 'option', 'dividend', 'bogle', 'market', 'equit', 'shares',
+    'securityanalysis', 'valu',
+)
+
+ATOM = {'a': 'http://www.w3.org/2005/Atom'}
+
+
+def is_finance_sub(sub: str) -> bool:
+    """A subreddit, and one about markets.
+
+    `u/...` is a user profile, not a community: Reddit returns profile posts in
+    site-wide search and one of them (`u/The_optiontrader`) would pass the
+    substring test on `option` alone.
+    """
+    name = (sub or '').strip().lower()
+    if not name or name.startswith('u/'):
+        return False
+    return any(mark in name for mark in FINANCE_SUBREDDIT_MARKS)
 
 
 def load_tickers(workspace):
@@ -46,36 +144,177 @@ def load_tickers(workspace):
     return out
 
 
-def fetch_reddit(ticker, mentions_only=False):
-    """Returns (mention_count, top_posts[]). US-leaning."""
-    if not re.match(r'^[A-Z]+$', ticker):
-        return 0, []  # HK numeric tickers not on Reddit
+def _clean_name(name: str) -> str:
+    """Registry name minus the wrapper words and the share-class suffix."""
+    text = re.sub(r'-[A-Z]$', '', (name or '').strip())
+    parts = text.split()
+    while parts and parts[-1].strip('.,').lower() in NAME_TAIL_NOISE:
+        parts.pop()
+    return ' '.join(parts)
+
+
+def search_terms(ticker: str, name: str, registry: dict) -> list[str]:
+    """What to search Reddit for, on behalf of one holding.
+
+    Derived from `config/instruments.json` rather than a second alias table:
+    the look-through symbol is already registered there, and it is the one
+    people actually write about. Nobody posts about `RKLX`; they post about
+    Rocket Lab, and this book holds RKLX to own RKLB.
+    """
+    row = registry.get(ticker) or {}
+    underlying = row.get('underlying')
+    target = registry.get(underlying) if underlying else None
+    terms = []
+    for candidate in (underlying, ticker if not underlying else None):
+        if candidate and re.fullmatch(r'[A-Z]{2,6}', candidate):
+            terms.append(candidate)
+    for label in ((target or {}).get('name'), name if not target else None):
+        cleaned = _clean_name(label or '')
+        if len(cleaned) >= 3:
+            terms.append(cleaned)
+    seen, out = set(), []
+    for term in terms:
+        if term.lower() not in seen:
+            seen.add(term.lower())
+            out.append(term)
+    return out
+
+
+def _matcher(term: str):
+    """Word-bounded for Latin terms, plain containment for CJK.
+
+    `\b` is defined on word characters, and Chinese has none of them, so a
+    boundary-anchored pattern never matches 金风科技 at all — a silent zero for
+    every Hong Kong name, which is the shape of bug this module is being fixed
+    for.
+    """
+    if re.fullmatch(r'[\x00-\x7f]+', term):
+        return re.compile(rf'\b{re.escape(term)}\b', re.I)
+    return re.compile(re.escape(term))
+
+
+def _within_window(created: str, cutoff: datetime) -> bool:
+    try:
+        stamp = datetime.fromisoformat((created or '').replace('Z', '+00:00'))
+    except (TypeError, ValueError):
+        return False
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp >= cutoff
+
+
+def _feed_entries(text: str, cutoff: datetime) -> tuple[list[dict], int]:
+    """(entries inside the window, total entries returned).
+
+    No score and no comment count: the search feed does not carry them. The
+    previous shape defaulted both to zero, which rendered on the dashboard as a
+    post nobody upvoted rather than a number nobody fetched.
+    """
+    root = ET.fromstring(text)
     total = 0
-    posts = []
-    for sub in REDDIT_SUBS:
+    kept = []
+    for entry in root.findall('a:entry', ATOM):
+        total += 1
+        created = (entry.findtext('a:updated', default='', namespaces=ATOM) or '').strip()
+        if not _within_window(created, cutoff):
+            continue
+        link = entry.find('a:link', ATOM)
+        category = entry.find('a:category', ATOM)
+        title = (entry.findtext('a:title', default='', namespaces=ATOM) or '')
+        kept.append({
+            'sub': (category.get('term') if category is not None else '') or '',
+            'title': title[:200],
+            'url': (link.get('href') if link is not None else '') or '',
+            'created': created,
+            '_blob': f'{title} {entry.findtext("a:content", default="", namespaces=ATOM) or ""}',
+        })
+    return kept, total
+
+
+def fetch_reddit(query: str, *, sleep=time.sleep):
+    """(feed text, status). `status` is `ok`, `throttled` or `failed`.
+
+    A 429 is kept distinct from every other failure on purpose: throttled means
+    the source works and this run was unlucky, blocked means it does not work
+    from here at all. The first is worth retrying tomorrow; the second is worth
+    moving the scan somewhere else, and a single `failed` bucket cannot tell
+    anyone which one happened.
+    """
+    url = f'{REDDIT_SEARCH}?q={quote(query)}&sort=new&limit={REDDIT_LIMIT}'
+    status = 'failed'
+    for wait in REDDIT_RETRY_WAITS:
+        if wait:
+            sleep(wait)
         try:
-            url = f'https://www.reddit.com/r/{sub}/search.json?q={ticker}&restrict_sr=1&sort=new&limit=10'
-            r = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
-            if r.status_code != 200:
-                continue
-            SOURCE_STATUS['reddit'] = 'ok'
-            children = r.json().get('data', {}).get('children', [])
-            total += len(children)
-            if mentions_only:
-                continue
-            for c in children[:3]:
-                d = c.get('data', {})
-                posts.append({
-                    'sub':          sub,
-                    'title':        d.get('title', '')[:200],
-                    'score':        d.get('score', 0),
-                    'num_comments': d.get('num_comments', 0),
-                    'created_utc':  d.get('created_utc'),
-                })
-            time.sleep(0.6)
-        except Exception as e:
-            print(f'  ⚠️ reddit {ticker} @ {sub}: {e}', file=sys.stderr)
-    return total, posts[:6]
+            response = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
+        except Exception as exc:
+            print(f'  ⚠️ reddit: {exc}', file=sys.stderr)
+            continue
+        if response.status_code == 200:
+            return response.text, 'ok'
+        status = 'throttled' if response.status_code == 429 else 'failed'
+        print(f'  ⚠️ reddit: HTTP {response.status_code}', file=sys.stderr)
+    return None, status
+
+
+def scan_reddit(rows, registry, *, now=None, sleep=time.sleep, fetch=None):
+    """Fill every row's Reddit fields from one search, or mark them unfetched.
+
+    The contract that matters is the failure one: when the feed does not come
+    back, every count stays `None`. A zero here reads as "nobody is talking
+    about this name", and that sentence was published for every holding every
+    day from 2026-05-17 to 2026-08-31 while the old JSON endpoint answered 403
+    to every request (#1237).
+    """
+    terms = {row['ticker']: search_terms(row['ticker'], row['name'], registry)
+             for row in rows}
+    for row in rows:
+        row['reddit_mentions_7d'] = None
+        row['reddit_posts'] = []
+        row['reddit_status'] = 'not_attempted'
+        row['reddit_mentions_capped'] = False
+        row['reddit_query_terms'] = terms[row['ticker']]
+
+    query = ' OR '.join(sorted({
+        f'"{term}"' if ' ' in term else term
+        for values in terms.values() for term in values}))
+    if not query:
+        SOURCE_STATUS['reddit'] = 'failed'
+        return 0
+    text, status = (fetch or fetch_reddit)(query, sleep=sleep)
+    if status != 'ok' or text is None:
+        for row in rows:
+            row['reddit_status'] = status
+        SOURCE_STATUS['reddit'] = status if status == 'throttled' else 'failed'
+        return 0
+
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=MENTION_WINDOW_DAYS)
+    try:
+        entries, total = _feed_entries(text, cutoff)
+    except ET.ParseError as exc:
+        print(f'  ⚠️ reddit: unparseable feed ({exc})', file=sys.stderr)
+        for row in rows:
+            row['reddit_status'] = 'failed'
+        SOURCE_STATUS['reddit'] = 'failed'
+        return 0
+
+    SOURCE_STATUS['reddit'] = 'ok'
+    # The count is a floor whenever the feed was full and none of it aged out:
+    # there is no page two, so a busier week is indistinguishable from this one
+    # at the top of the list. Saying so beats publishing a total that is not one.
+    capped = total >= REDDIT_LIMIT and len(entries) == total
+    for row in rows:
+        patterns = [_matcher(term) for term in terms[row['ticker']]]
+        matched = [entry for entry in entries
+                   if is_finance_sub(entry['sub'])
+                   and any(pattern.search(entry['_blob']) for pattern in patterns)]
+        row['reddit_status'] = 'ok'
+        row['reddit_mentions_7d'] = len(matched)
+        row['reddit_mentions_capped'] = capped
+        row['reddit_posts'] = [
+            {key: entry[key] for key in ('sub', 'title', 'url', 'created')}
+            for entry in matched[:6]]
+    return sum(1 for row in rows if row['reddit_mentions_7d'])
 
 
 def fetch_google_news(query, hl='en-US', gl='US', limit=8, return_status=False):
@@ -114,7 +353,13 @@ def fetch_google_news(query, hl='en-US', gl='US', limit=8, return_status=False):
 
 
 def scan_ticker(t):
-    """Aggregate per-ticker sentiment from all sources."""
+    """Per-ticker news scan. Reddit is a separate pass — see `scan_reddit`.
+
+    The two sources are no longer interleaved because their rate limits are not
+    comparable: Google News answers every time, Reddit answers about half the
+    time and has to be asked again. Sweeping them together made the whole scan
+    move at the slower one's pace.
+    """
     tk = t['ticker']
     name = t['name']
     region = t['region']
@@ -124,16 +369,20 @@ def scan_ticker(t):
         'ticker': tk,
         'name':   name,
         'region': region,
-        'reddit_mentions_7d': 0,
+        # Reddit fields are filled by `scan_reddit`; `None` until then, because
+        # a name that has not been asked about has no mention count.
+        'reddit_mentions_7d': None,
         'reddit_posts':       [],
+        'reddit_status':      'not_attempted',
+        'reddit_mentions_capped': False,
+        'reddit_query_terms': [],
         'google_news_en':     [],
         'google_news_zh':     [],
     }
 
     if region == 'us_stocks':
-        result['reddit_mentions_7d'], result['reddit_posts'] = fetch_reddit(tk)
         result['google_news_en'] = fetch_google_news(f'{tk} stock', hl='en-US', gl='US', limit=6)
-        print(f'reddit={result["reddit_mentions_7d"]} en_news={len(result["google_news_en"])}', flush=True)
+        print(f'en_news={len(result["google_news_en"])}', flush=True)
     else:  # hk_stocks
         # HK: search by Chinese name first (richer signal than ticker number)
         if name:
@@ -161,13 +410,29 @@ def main(argv=None):
 
     out = {
         'generated_at': datetime.now(timezone.utc).isoformat(),
-        'sources': ['reddit-json-public', 'google-news-rss'],
+        'sources': ['reddit-search-rss', 'google-news-rss'],
+        'mention_window_days': MENTION_WINDOW_DAYS,
+        'reddit_subreddit_marks': list(FINANCE_SUBREDDIT_MARKS),
         'tickers': [],
     }
 
     for t in tickers:
         out['tickers'].append(scan_ticker(t))
         time.sleep(0.3)  # global rate-limit safety
+
+    # Explicit path, `missing_ok`: this producer takes `--workspace`, so the
+    # module-level default (resolved from cwd at import) would read another
+    # book's registry — and a workspace that has registered nothing yet must
+    # still get its news scan rather than an exception.
+    registry = instruments.load_registry(
+        workspace / 'config' / 'instruments.json', missing_ok=True)
+    named = scan_reddit(out['tickers'], registry)
+    if SOURCE_STATUS['reddit'] == 'ok':
+        print(f'  reddit: {named}/{len(out["tickers"])} names mentioned in the '
+              f'last {MENTION_WINDOW_DAYS} days')
+    else:
+        print(f'  reddit: {SOURCE_STATUS["reddit"]} — every count is null, '
+              f'which is not the same as zero')
     out['source_status'] = dict(SOURCE_STATUS)
 
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/src/clawock/market_data/sentiment.py
+++ b/src/clawock/market_data/sentiment.py
@@ -231,7 +231,7 @@ def _feed_entries(text: str, cutoff: datetime) -> tuple[list[dict], int]:
     return kept, total
 
 
-def fetch_reddit(query: str, *, sleep=time.sleep):
+def fetch_reddit(query: str, *, sleep=None):
     """(feed text, status). `status` is `ok`, `throttled` or `failed`.
 
     A 429 is kept distinct from every other failure on purpose: throttled means
@@ -240,6 +240,11 @@ def fetch_reddit(query: str, *, sleep=time.sleep):
     moving the scan somewhere else, and a single `failed` bucket cannot tell
     anyone which one happened.
     """
+    # Resolved at call time, not bound in the signature: a default of
+    # `time.sleep` is captured at import, so a test patching this module's
+    # `time.sleep` would still sleep through the real backoff — measured at 105
+    # seconds in one suite run before this line existed.
+    sleep = sleep or time.sleep
     url = f'{REDDIT_SEARCH}?q={quote(query)}&sort=new&limit={REDDIT_LIMIT}'
     status = 'failed'
     for wait in REDDIT_RETRY_WAITS:
@@ -257,7 +262,7 @@ def fetch_reddit(query: str, *, sleep=time.sleep):
     return None, status
 
 
-def scan_reddit(rows, registry, *, now=None, sleep=time.sleep, fetch=None):
+def scan_reddit(rows, registry, *, now=None, sleep=None, fetch=None):
     """Fill every row's Reddit fields from one search, or mark them unfetched.
 
     The contract that matters is the failure one: when the feed does not come
@@ -266,6 +271,7 @@ def scan_reddit(rows, registry, *, now=None, sleep=time.sleep, fetch=None):
     day from 2026-05-17 to 2026-08-31 while the old JSON endpoint answered 403
     to every request (#1237).
     """
+    sleep = sleep or time.sleep
     terms = {row['ticker']: search_terms(row['ticker'], row['name'], registry)
              for row in rows}
     for row in rows:

--- a/src/clawock/publish/artifacts.py
+++ b/src/clawock/publish/artifacts.py
@@ -137,10 +137,22 @@ def validate_sentiment(
         assert isinstance(row.get('name'), str), f'{ticker} name must be a string'
         assert row.get('region') in ('us_stocks', 'hk_stocks'), (
             f'{ticker} has invalid region')
+        # `None` is the correct value for a name Reddit did not answer about,
+        # and it is the only value that is correct: a 0 there says "nobody is
+        # talking about this", which is what three months of published zeros
+        # said while the source returned 403 to every request (#1237). A number
+        # is required exactly when the per-ticker status says one was obtained.
         mentions = row.get('reddit_mentions_7d')
-        assert (isinstance(mentions, int) and not isinstance(mentions, bool)
-                and mentions >= 0), f'{ticker} has invalid reddit mention count'
-        result_count += mentions
+        status = row.get('reddit_status', 'ok')
+        if status == 'ok':
+            assert (isinstance(mentions, int) and not isinstance(mentions, bool)
+                    and mentions >= 0), f'{ticker} has invalid reddit mention count'
+            result_count += mentions
+        else:
+            assert mentions is None, (
+                f'{ticker} publishes a reddit mention count of {mentions!r} while '
+                f'its source status is {status!r} — a count that was never '
+                f'fetched must be null, not a number')
         result_fields = ('reddit_posts', 'google_news_en', 'google_news_zh')
         for field in result_fields:
             results = row.get(field)

--- a/tests/test_sentiment_reddit_honesty.py
+++ b/tests/test_sentiment_reddit_honesty.py
@@ -223,3 +223,23 @@ def test_the_brief_prints_a_dash_not_a_zero_for_a_count_it_does_not_have():
 
     assert '0 mentions' in render(0)
     assert 'mentions' not in render(None) and brief_render.MISSING in render(None)
+
+
+def test_the_retry_backoff_is_reachable_by_a_test_that_patches_this_module(monkeypatch):
+    """A `sleep=time.sleep` default is captured at import, not at call.
+
+    Measured before this was fixed: `test_sentiment_producer_marks_total_http_outage_failed`
+    spent **105 seconds** sleeping through the real 35s + 70s backoff, because
+    it patches `sentiment.time.sleep` and the signature default had already
+    bound the real one.
+    """
+    slept = []
+    monkeypatch.setattr(sp.time, 'sleep', slept.append)
+    monkeypatch.setattr(sp.requests, 'get', lambda *a, **k: _Response(429))
+
+    text, status = sp.fetch_reddit('RKLB')
+
+    assert (text, status) == (None, 'throttled')
+    assert slept == [w for w in sp.REDDIT_RETRY_WAITS if w], (
+        'the backoff has to go through the module attribute a test can reach'
+    )

--- a/tests/test_sentiment_reddit_honesty.py
+++ b/tests/test_sentiment_reddit_honesty.py
@@ -1,0 +1,225 @@
+"""A mention count that was never fetched must not be published as a number.
+
+The bug these pin (#1237): Reddit's unauthenticated JSON API answered `403` to
+every request for the entire recorded life of `sentiment.json` — 87 commits,
+2026-05-17 onward, every ticker `0` every day — while three consumers read that
+`0` as "nobody is talking about this name". The producer even recorded
+`source_status.reddit == 'failed'` correctly; nothing downstream read it.
+
+So the assertions here are mostly about the failure paths, and each one is
+driven with data rather than trusted to behave: a green run of the happy path
+proves nothing about the branch that only a bad day reaches.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from clawock.decision import packet
+from clawock.market_data import sentiment as sp
+from clawock.publish import artifacts
+
+
+REGISTRY = {
+    'RKLX': {'name': 'Defiance Daily Target 2X Long RKLB', 'underlying': 'RKLB'},
+    'RKLB': {'name': 'Rocket Lab', 'underlying': None},
+    '02208': {'name': '金风科技', 'underlying': None},
+    '00100': {'name': 'MINIMAX-W', 'underlying': None},
+    'CRCL': {'name': 'Circle Internet Group', 'underlying': None},
+}
+
+
+def _rows():
+    return [
+        {'ticker': 'RKLX', 'name': REGISTRY['RKLX']['name'], 'region': 'us_stocks'},
+        {'ticker': '02208', 'name': '金风科技', 'region': 'hk_stocks'},
+        {'ticker': '00100', 'name': 'MINIMAX-W', 'region': 'hk_stocks'},
+    ]
+
+
+def _feed(entries):
+    """An Atom feed shaped like Reddit's search RSS."""
+    parts = ['<?xml version="1.0" encoding="UTF-8"?>',
+             '<feed xmlns="http://www.w3.org/2005/Atom">']
+    for sub, title, when, content in entries:
+        parts.append(
+            f'<entry><category term="{sub}"/><title>{title}</title>'
+            f'<link href="https://example.invalid/x"/>'
+            f'<updated>{when.isoformat()}</updated>'
+            f'<content type="html">{content}</content></entry>')
+    parts.append('</feed>')
+    return ''.join(parts)
+
+
+class _Response:
+    def __init__(self, status_code, text=''):
+        self.status_code = status_code
+        self.text = text
+
+
+def test_search_terms_look_through_to_the_name_people_write(monkeypatch):
+    """Nobody posts about RKLX; they post about Rocket Lab, which it holds."""
+    assert sp.search_terms('RKLX', REGISTRY['RKLX']['name'], REGISTRY) == [
+        'RKLB', 'Rocket Lab']
+    assert sp.search_terms('CRCL', 'Circle Internet Group', REGISTRY) == [
+        'CRCL', 'Circle Internet'], 'the wrapper word must not enter the query'
+    assert sp.search_terms('02208', '金风科技', REGISTRY) == ['金风科技']
+
+
+def test_a_chinese_name_is_matched_without_word_boundaries():
+    """`\\b` is defined on word characters, and Chinese has none.
+
+    A boundary-anchored pattern never matches 金风科技, so every Hong Kong name
+    would score a silent zero — the same shape of bug as the one being fixed.
+    """
+    assert sp._matcher('金风科技').search('今天 金风科技 涨了')
+    assert sp._matcher('RKLB').search('RKLB is up')
+    assert not sp._matcher('RKLB').search('WRKLBX'), (
+        'a Latin term still has to be a whole word')
+
+
+def test_a_throttled_feed_publishes_no_count_at_all():
+    """The whole point. `None`, never `0`, and the status says which."""
+    rows = _rows()
+    sp.scan_reddit(rows, REGISTRY, sleep=lambda _seconds: None,
+                   fetch=lambda query, sleep=None: (None, 'throttled'))
+
+    assert [row['reddit_mentions_7d'] for row in rows] == [None, None, None]
+    assert {row['reddit_status'] for row in rows} == {'throttled'}
+    assert sp.SOURCE_STATUS['reddit'] == 'throttled', (
+        'throttled is a source that works; failed is one that does not, and a '
+        'single bucket cannot tell anyone which happened')
+
+
+def test_an_unparseable_feed_also_publishes_no_count():
+    rows = _rows()
+    sp.scan_reddit(rows, REGISTRY, sleep=lambda _seconds: None,
+                   fetch=lambda query, sleep=None: ('not xml at all', 'ok'))
+
+    assert [row['reddit_mentions_7d'] for row in rows] == [None, None, None]
+    assert sp.SOURCE_STATUS['reddit'] == 'failed'
+
+
+def test_a_dictionary_word_in_an_unrelated_subreddit_is_not_a_mention():
+    """MINIMAX is a game-theory algorithm and one of this book's holdings.
+
+    Measured on the live book before the subreddit gate: 16 mentions in a week,
+    from r/abstractgames and r/PiCodingAgent. Publishing 16 would have replaced
+    a false zero with a false sixteen.
+    """
+    now = datetime.now(timezone.utc)
+    rows = _rows()
+    feed = _feed([
+        ('abstractgames', 'A minimax search idea', now - timedelta(days=1), ''),
+        ('PiCodingAgent', 'minimax code found my skills', now - timedelta(hours=3), ''),
+        ('stocks', 'RKLB is up 20%', now - timedelta(days=2), 'Rocket Lab earnings'),
+        ('u/The_optiontrader', 'MINIMAX update', now - timedelta(days=1), ''),
+    ])
+    sp.scan_reddit(rows, REGISTRY, now=now, sleep=lambda _s: None,
+                   fetch=lambda query, sleep=None: (feed, 'ok'))
+    by_ticker = {row['ticker']: row for row in rows}
+
+    assert by_ticker['00100']['reddit_mentions_7d'] == 0
+    assert by_ticker['RKLX']['reddit_mentions_7d'] == 1
+    assert by_ticker['RKLX']['reddit_posts'][0]['sub'] == 'stocks'
+    assert sp.is_finance_sub('u/The_optiontrader') is False, (
+        'a user profile is not a community, and it passes the substring test '
+        'on "option" alone')
+
+
+def test_a_mention_older_than_the_window_does_not_count():
+    """`sort=new&t=week` is ignored by the endpoint — probed entries ran to 2012."""
+    now = datetime.now(timezone.utc)
+    rows = _rows()
+    feed = _feed([
+        ('stocks', 'Rocket Lab in 2012', now - timedelta(days=400), ''),
+        ('investing', 'Rocket Lab today', now - timedelta(days=1), ''),
+    ])
+    sp.scan_reddit(rows, REGISTRY, now=now, sleep=lambda _s: None,
+                   fetch=lambda query, sleep=None: (feed, 'ok'))
+
+    assert {r['ticker']: r['reddit_mentions_7d'] for r in rows}['RKLX'] == 1
+
+
+def test_a_full_feed_reports_the_count_as_a_floor():
+    now = datetime.now(timezone.utc)
+    rows = _rows()
+    feed = _feed([('stocks', 'Rocket Lab', now - timedelta(hours=index), '')
+                  for index in range(sp.REDDIT_LIMIT)])
+    sp.scan_reddit(rows, REGISTRY, now=now, sleep=lambda _s: None,
+                   fetch=lambda query, sleep=None: (feed, 'ok'))
+
+    assert all(row['reddit_mentions_capped'] for row in rows), (
+        'there is no page two, so a busier week looks like this one'
+    )
+
+
+def test_the_producer_retries_a_throttle_before_giving_up(monkeypatch):
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append(url)
+        return _Response(429) if len(calls) < 3 else _Response(200, _feed([]))
+
+    monkeypatch.setattr(sp.requests, 'get', get)
+    text, status = sp.fetch_reddit('RKLB', sleep=lambda _seconds: None)
+
+    assert (status, len(calls)) == ('ok', 3)
+    assert text is not None
+
+
+def test_the_validator_refuses_a_number_from_a_source_that_did_not_answer(tmp_path):
+    portfolio = tmp_path / 'portfolio.json'
+    portfolio.write_text(json.dumps({'portfolios': {
+        'us_stocks': {'holdings': [{'ticker': 'RKLX', 'shares': 1}]},
+        'hk_stocks': {'holdings': []}}}), encoding='utf-8')
+    snapshot = tmp_path / 'sentiment.json'
+    payload = {
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'sources': ['reddit-search-rss', 'google-news-rss'],
+        'source_status': {'reddit': 'throttled', 'google_news': 'ok'},
+        'tickers': [{
+            'ticker': 'RKLX', 'name': 'x', 'region': 'us_stocks',
+            'reddit_mentions_7d': 0, 'reddit_status': 'throttled',
+            'reddit_posts': [], 'google_news_en': [{'title': 't'}],
+            'google_news_zh': [],
+        }],
+    }
+    snapshot.write_text(json.dumps(payload), encoding='utf-8')
+
+    with pytest.raises(AssertionError, match='must be null, not a number'):
+        artifacts.validate_sentiment(snapshot, portfolio)
+
+    payload['tickers'][0]['reddit_mentions_7d'] = None
+    snapshot.write_text(json.dumps(payload), encoding='utf-8')
+    artifacts.validate_sentiment(snapshot, portfolio)
+
+
+def test_the_decision_packet_does_not_turn_an_absent_count_into_zero():
+    """`int(x or 0)` is what told the model nobody was talking, for 87 days."""
+    assert packet._mention_count(None) is None
+    assert packet._mention_count(0) == 0
+    assert packet._mention_count(4) == 4
+
+    view = packet._sentiment_view(
+        [{'ticker': 'RKLX', 'reddit_mentions_7d': None,
+          'reddit_status': 'throttled', 'news_top': []}], 'RKLX', 'RKLX')
+    assert view['reddit_mentions_7d'] is None
+    assert view['reddit_status'] == 'throttled'
+    assert packet._sentiment_view([], 'RKLX', 'RKLX')['reddit_status'] == 'missing'
+
+
+def test_the_brief_prints_a_dash_not_a_zero_for_a_count_it_does_not_have():
+    """`0 mentions` went out in a published report every day for three months."""
+    from clawock.harness import brief_render
+
+    def render(count):
+        return brief_render.sentiment_section(
+            {'sentiment': {'tickers': [{'ticker': '07226',
+                                        'reddit_mentions_7d': count,
+                                        'news_top': []}]}}, {})
+
+    assert '0 mentions' in render(0)
+    assert 'mentions' not in render(None) and brief_render.MISSING in render(None)


### PR DESCRIPTION
## The measurement

```
$ for c in $(git log --format=%H -- assets/data/sentiment.json); do \
    git show $c:assets/data/sentiment.json | python3 -c \
    "import json,sys;d=json.load(sys.stdin);print(sum(t.get('reddit_mentions_7d',0) for t in (d.get('tickers') or [])))"; \
  done | sort -u
0
```

87 commits, 2026-05-17 → today, every holding, every day. **The Reddit source has never succeeded once.** `reddit.com/r/<sub>/search.json` returns `403 Blocked` (measured today, `www` and `old`), the producer recorded `source_status.reddit = 'failed'` correctly — and then published `0`.

Nothing read the status. Three consumers read the zero as a fact:

| consumer | what it published |
|---|---|
| `decision/packet.py:574` | `int(row.get("reddit_mentions_7d") or 0)` — **into the decision packet**: the model was told "0 mentions in 7 days" about a request that was never answered |
| `harness/brief_render.py:473` | `0 mentions` per name, in every published report |
| `dashboard.render.js:1529` | summed into a "Reddit 7d" total |

## The fix, in two halves

**Honesty.** The count is `None` whenever it was not obtained; `reddit_status` travels with it. `validate_sentiment` now *rejects* a payload carrying a number for a source that did not answer. The brief prints `—`. The dashboard counts only measured names and says `4/10 只票` when it is partial.

**The source.** Only the endpoint is dead — `search.rss` still answers without credentials.

- **One query for the whole book**, not one per name: paced per-name sweeps got **1/10** answered against the throttle. One `OR` query fits, and it buys the Hong Kong leg the old code never attempted (it returned early on any non-Latin ticker).
- **Reddit's search is recall; precision is local.** The `OR` query came back with a post about a dental crown. Every entry is re-matched here against terms derived from `config/instruments.json` — look-through, so RKLX searches for *Rocket Lab* — and terms are published per ticker so a wrong one is visible.
- **Gated to finance subreddits**, by a declared substring list published in the artifact. Without it `MINIMAX` scored **16 mentions/week** from r/abstractgames and r/PiCodingAgent, because minimax is a game-theory algorithm. Replacing a false zero with a false sixteen is not a fix. It undercounts on purpose (r/spacecapital is a real investing sub and this misses it) — a declared undercount is correctable.
- **The window is applied here.** `sort=new&t=week` is ignored: a probe returned entries dated 2012 → today. The field has had a `_7d` suffix since it was written; this is the first version where it is true.
- `reddit_posts` drops score and comment count — the feed has neither, and `p.score || 0` rendered `0↑` on every post ever shown.

## End to end, on the live book

```
reddit: 4/10 names mentioned in the last 7 days
RKLX  n=2   terms=['RKLB', 'Rocket Lab']     r/wallstreetbetsGER, r/SpaceInvestorsDaily
SPCX  n=2   terms=['SPCX', 'SpaceX']         r/SpaceEconomyInvestors, r/SpaceInvestorsDaily
SKHY  n=1   terms=['SKHY', 'SK海力士']         r/stockwatching
00100 n=0   terms=['MINIMAX']                (16 before the subreddit gate)
```

## The question this cannot answer from here

The producer runs on a **GitHub runner**, and datacenter ranges are the first thing a source like this blocks — very possibly why it never worked. `ops/ci/smoke_reddit.py` asks from an actual runner on every code PR (advisory, `continue-on-error`) and prints `reachable` / `throttled` / `blocked`. **Check this PR's `smoke-data-fetch` output** — if it says blocked, the scan needs to move to a host that can reach it, and the artifact will publish `null` until it does instead of zeros.

## Tests

`tests/test_sentiment_reddit_honesty.py`, 11 cases, weighted at the failure paths because that is where the bug lived: throttled → every count `None` and status `throttled`; unparseable feed → same; a dictionary word in an unrelated sub is not a mention; a `u/` profile is not a community; an entry outside the window does not count; a full feed reports the count as a floor; the validator refuses a number from a source that did not answer; `packet._mention_count(None) is None`; the brief prints `—`.

```
$ python3 -m pytest tests/test_sentiment_reddit_honesty.py -q
11 passed
$ python3 -m pytest tests/ -q -k "sentiment or sidecar or packet or preflight or brief_render or producer"
344 passed, 2 skipped
```

Closes #1237

https://claude.ai/code/session_01UUE66h1qD3eJiWD2rs7i6c