### PR TITLE
decision: grade how far, not only which way (#1159)

### DIFF
--- a/skills/daily-deep-brief/SKILL.md
+++ b/skills/daily-deep-brief/SKILL.md
@@ -702,6 +702,7 @@ postflight 严格 schema 校验：
       "condition": {"type": "open", "price": null, "note": "周一开盘任意价"},
       "size": {"pct": 50, "shares": 20, "capital": 3200},
       "confidence": 0.82,
+      "expected_move_pct": -6.5,
       "driven_by": "risk_rule",
       "regime": "risk_off",
       "contested": true,
@@ -764,6 +765,10 @@ postflight 严格 schema 校验：
     - `quant:<ticker>:<field>` —— `context.quant_signals.rows[<ticker>]` 上一个非空字段（如 `quant:SPCH:dist_ma200_pct`）
     **没有可引的证据就不填**，别为了填而造 id：造出来的引用比不引更糟，它看起来像证据。portable workflow lane 早就要求每个 case 带 `evidence_ids`（`workflows/validators.py`），这里是把同一条纪律接到日报这条 lane 上。
   - **不会因为格式错误让 08:00 流水线变红**：postflight 的 normalizer 会裁剪超长文本、丢弃未知键与不在枚举内的 frame，整块为空则记为「没写」。但缺席是被数出来的——dashboard 的 `debate_coverage.bear_case_pct` 就是这条纪律的实测曲线，别用空块凑覆盖率。
+- `expected_move_pct`（number，选填，带符号，单位 %）：**这条 decision 预期这只票走多远**（#1159）。`confidence` 说的是「多有把握」，`invalidation_price` 说的是「论点在哪死」，**没有一个字段说「走多远」**——所以「方向对、幅度错了四倍」这句话这本账本目前对自己讲不出来。填了之后按 t1 对 `underlying_return_t1_pct` 打分（这只票自己的收益，不是 `benefit_t1_pct` 那个相对不动的反事实）。
+  - 是**预测**不是目标价，也不是止损距离：写 `-8` 表示「我预期它跌 8%」。`0` 是合法且可打分的预测（「预期它不动」），和不填不是一回事。
+  - |值| > 100 会被丢弃（打字过滤，不是风控），丢弃不会让流水线变红。
+  - **没有把握就不要填**：这条和 `debate.evidence_ids` 同一条纪律——编一个数比不填更糟，它看起来像预测。覆盖率发布在 dashboard 的 `magnitude_metrics.coverage_pct`，必填与否以后对着这条序列谈。
 - `thesis_invalidation`（string，主动 cut/trim/add 必填；hold 选填）：**借鉴 UZI-Skill 的 thesis-tracking**——这个仓位的论点**会被什么具体催化推翻**？把 catalyst-gate(cut #1)落地成「论点+失效条件」：你只在这个**失效催化真的发生**时动手，而不是技术面波动。例：「crypto rev 环比转正则停止减仓」。这逼着每个主动 call 绑定一个可被证伪的硬催化，而非"看着toppy"。
 - `thesis_id` 必须沿用 `context.thesis_registry.theses.<ticker>.thesis_id`（resolved 时）；registry 为 `unknown` 时保留已有 decision ID，不得新造一个“看起来像历史”的 canonical thesis。`context.retrospective.decisions[].thesis_ref` 是只读解析结果。
 

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -264,6 +264,46 @@ def normalize_debate_evidence(raw) -> list[str]:
     return kept[:DEBATE_EVIDENCE_MAX]
 
 
+#: A decision may say how far it expects the name to move, and this is the
+#: widest that claim may be before it is discarded rather than scored. Not a
+#: risk limit — a typo filter: a plan meaning -8% and writing -800 would
+#: otherwise dominate every calibration number it entered.
+MAX_EXPECTED_MOVE_PCT = 100.0
+
+
+def normalize_expected_move(raw) -> float | None:
+    """The move this decision expects, signed, in percent — or `None` (#1159).
+
+    QuantConnect's `InsightScore` grades Direction *and* Magnitude. This ledger
+    has graded direction since it existed — `evaluation.outcome`, and
+    `confidence` against a Brier score — and has never carried a magnitude at
+    all: `confidence` says how sure, `invalidation_price` says where the thesis
+    dies, and neither says how far the name is expected to go. So "the model was
+    right about the direction and wrong about the size by a factor of four" is
+    not a sentence this book can currently form about itself.
+
+    Optional on purpose, and that is the entire first stage. `validate_plan`
+    failing does not produce a thinner brief, it produces **no brief**, so a new
+    required field buys structure by adding a way for the 08:00 pipeline to go
+    dark. #1117 took exactly this route for `debate` — optional, with a coverage
+    series published beside it — and the required-field question is argued from
+    that series later, if at all.
+
+    Zero is kept rather than dropped: "I expect this to go nowhere" is a real
+    forecast and a scorable one. Absent and zero are different facts here, the
+    same way they are for a mention count.
+    """
+    if isinstance(raw, bool) or raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value) or abs(value) > MAX_EXPECTED_MOVE_PCT:
+        return None
+    return round(value, 3)
+
+
 def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) -> dict:
     ticker = str(action.get("ticker") or "").strip()
     act = action.get("action") or action.get("bucket") or "watch"
@@ -322,6 +362,9 @@ def legacy_action_to_decision(action: dict, plan_date: str, ordinal: int = 0) ->
         "technical_setup_id": action.get("technical_setup_id"),
         "technical_campaign_id": action.get("technical_campaign_id"),
         "invalidation_price": _float(action.get("invalidation_price")),
+        # How far, not just which way. `None` when the plan did not say, which
+        # is most of them today — the coverage series says how many (#1159).
+        "expected_move_pct": normalize_expected_move(action.get("expected_move_pct")),
         "tranche_number": _int(action.get("tranche_number")),
         # Additive contract marker: pre-2026-08 plans remain valid/readable, while
         # every newly normalized plan is subject to the technical trace rules.

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -14,6 +14,7 @@ import json
 import math
 import os
 import re
+import statistics
 import sys
 import time
 from datetime import date, datetime, timedelta, timezone
@@ -1409,6 +1410,66 @@ def compute_debate_metrics(recent=20):
                  '待 plan 开始标记后，与 calibration 联合检验「被争议的 call 是否校准更好」。'
                  'debate_coverage 量的是另一件事：辩论本身有没有留下可核对的结构'
                  '（反方案文、被攻击的共识、Judge frame），而不是它得出了什么结论。'),
+    }
+
+
+def compute_magnitude_metrics(rows=None):
+    """Was the size of the move right, not just its direction? (#1159)
+
+    The book grades direction (`evaluation.outcome`) and grades how sure it was
+    (`confidence`, prequentially, by Brier). It has never graded **how far** —
+    QuantConnect's `InsightScore` calls that leg Magnitude, and porting it was
+    closed once on the grounds that it would need a new required field on every
+    decision. It does not: the field is optional, and this is the series that
+    says whether it is being written, exactly as `debate_coverage` did for
+    #1117.
+
+    Scored at t1 only, and deliberately against `underlying_return_t1_pct`
+    rather than `benefit_t1_pct`. Benefit is measured against a counterfactual —
+    it answers "was acting better than not acting" — while a forecast of "this
+    falls 8%" is a claim about the name, so the name's own return is the only
+    honest counterpart. t5 and t20 have no underlying-return column to compare
+    against, so they are not scored rather than scored against the wrong number.
+
+    `mean_error_pct` is signed and is the interesting one: a book that is right
+    about direction and systematically too dramatic about size has a positive
+    bias here and a fine hit rate, and no existing number on this dashboard
+    would show it.
+    """
+    if rows is None:
+        rows = decision_v2.load_decisions(WS_ROOT / 'memory' / 'decisions.jsonl')
+    scored, absolute, signed, agreed = 0, [], [], 0
+    stated = 0
+    for row in rows:
+        expected = row.get('expected_move_pct')
+        if expected is not None:
+            stated += 1
+        evaluation = row.get('evaluation') or {}
+        realized = evaluation.get('underlying_return_t1_pct')
+        if expected is None or realized is None:
+            continue
+        if evaluation.get('status') != 'settled':
+            continue
+        scored += 1
+        absolute.append(abs(float(expected) - float(realized)))
+        signed.append(float(expected) - float(realized))
+        if (float(expected) >= 0) == (float(realized) >= 0):
+            agreed += 1
+    return {
+        'decisions': len(rows),
+        'with_expected_move': stated,
+        'coverage_pct': round(100 * stated / len(rows), 1) if rows else None,
+        'scored_t1': scored,
+        'mean_abs_error_pct': round(statistics.fmean(absolute), 3) if absolute else None,
+        'mean_error_pct': round(statistics.fmean(signed), 3) if signed else None,
+        'direction_agreement': round(agreed / scored, 3) if scored else None,
+        'note': ('幅度校准（#1159）：`expected_move_pct` 是选填字段，这条先是覆盖率序列 —— '
+                 '和 #1117 的 debate 一样，必填与否要对着序列谈，不是对着愿望谈。'
+                 '只在 t1 打分，且对的是 `underlying_return_t1_pct`（这只票自己的收益）'
+                 '而不是 `benefit_t1_pct`（相对不动的反事实）：'
+                 '「预期跌 8%」是关于这只票的断言，拿反事实去对它是对错了东西。'
+                 'mean_error_pct 带符号：方向对、幅度系统性夸大的账本，'
+                 '命中率好看而这个数为正，现有的任何一个指标都看不出来。'),
     }
 
 
@@ -3551,6 +3612,7 @@ def build_projection(previous_source=None, shadow_previous=None):
     # as the ledger total (#737).
     out['decision_trace_scope'] = build_decision_trace_scope(_traces, limit=40)
     out['debate_metrics'] = compute_debate_metrics()
+    out['magnitude_metrics'] = compute_magnitude_metrics()
     out['plan_timeline'] = compute_plan_timeline(plans, limit=15)
     out['weight_confidence'] = compute_weight_confidence(portfolio)
     # v2.1: broker-style analytics

--- a/tests/test_decision_expected_move.py
+++ b/tests/test_decision_expected_move.py
@@ -1,0 +1,91 @@
+"""How far, not just which way (#1159).
+
+The ledger has graded direction since it existed and has never carried a
+magnitude. These pin the two properties that make adding one safe: the field is
+optional, so a plan without it is still a valid plan and the 08:00 brief still
+goes out; and an absent forecast is never silently turned into a forecast of
+zero, which is a real and scorable claim.
+"""
+from __future__ import annotations
+
+from clawock.decision import ledger
+from clawock.publish import dashboard
+
+
+def _decision(expected=None, realized=None, status='settled'):
+    return {
+        'expected_move_pct': expected,
+        'evaluation': {'underlying_return_t1_pct': realized, 'status': status},
+    }
+
+
+def test_absent_and_zero_are_different_forecasts():
+    assert ledger.normalize_expected_move(None) is None
+    assert ledger.normalize_expected_move(0) == 0.0, (
+        '"I expect this to go nowhere" is a forecast, and a scorable one'
+    )
+    assert ledger.normalize_expected_move('-8.25') == -8.25
+
+
+def test_a_typo_is_discarded_rather_than_scored():
+    """-800 for -8 would otherwise dominate every average it entered."""
+    assert ledger.normalize_expected_move(-800) is None
+    assert ledger.normalize_expected_move(float('inf')) is None
+    assert ledger.normalize_expected_move('not a number') is None
+    assert ledger.normalize_expected_move(True) is None, (
+        'bool is an int in Python, and `True` is not a 1% forecast'
+    )
+
+
+def test_a_plan_without_the_field_is_still_a_valid_plan():
+    """The whole reason it is optional: a failing plan means no brief at all."""
+    decision = ledger.legacy_action_to_decision(
+        {'ticker': 'AAA', 'action': 'cut', 'confidence': 0.8}, '2026-08-31')
+
+    assert decision['expected_move_pct'] is None
+    plan = {'schema_version': ledger.SCHEMA_VERSION, 'date': '2026-08-31',
+            'plan_date': '2026-08-31',
+            'decisions': ledger.assign_episode_ids([decision])}
+
+    assert ledger.validate_plan(plan) == [], (
+        'an optional field that can fail validation is a required field with '
+        'extra steps, and a failing plan publishes no brief at all'
+    )
+
+
+def test_the_field_survives_normalization_when_the_plan_states_it():
+    decision = ledger.legacy_action_to_decision(
+        {'ticker': 'AAA', 'action': 'cut', 'expected_move_pct': -6.5}, '2026-08-31')
+
+    assert decision['expected_move_pct'] == -6.5
+
+
+def test_the_metric_is_a_coverage_series_before_it_is_a_calibration():
+    """Today's answer is 0/749, and that is the point — the same place #1117's
+    debate coverage started the day before it was 8/8."""
+    rows = [_decision(), _decision(), _decision(-8.0, -2.0)]
+
+    metrics = dashboard.compute_magnitude_metrics(rows)
+
+    assert metrics['decisions'] == 3
+    assert metrics['with_expected_move'] == 1
+    assert metrics['scored_t1'] == 1
+    assert metrics['mean_abs_error_pct'] == 6.0
+    assert metrics['mean_error_pct'] == -6.0, (
+        'signed: a book that is systematically too dramatic about size shows up '
+        'here and in no other number on the dashboard'
+    )
+    assert metrics['direction_agreement'] == 1.0
+
+
+def test_an_unsettled_or_unmeasured_decision_is_not_scored():
+    rows = [_decision(-8.0, None), _decision(-8.0, -2.0, status='pending'),
+            _decision(None, -2.0)]
+
+    metrics = dashboard.compute_magnitude_metrics(rows)
+
+    assert metrics['with_expected_move'] == 2
+    assert metrics['scored_t1'] == 0
+    assert metrics['mean_abs_error_pct'] is None, (
+        'a forecast whose outcome is not in yet is not a forecast that was wrong'
+    )


### PR DESCRIPTION
Reopens the Magnitude leg of #1159 and ships stage 1.

## What is missing today

```
$ python3 -c "...collections.Counter over memory/decisions.jsonl..."
confidence 749 · horizon_sessions 748 · invalidation_price 128 · debate 8
```

`confidence` is on every row and already graded (Brier, prequential). `invalidation_price` says where the thesis dies. **No field says how far the name is expected to move**, so "right about direction, wrong about size by 4x" is not a sentence this book can form about itself — and size is the leg an LLM forecast usually loses.

## Why this was closed before, and why that objection does not hold

The close said Magnitude needs a new **required** field, and a plan failing `validate_plan` produces *no brief*, not a thinner one. Both halves are true. But #1117 hit exactly that wall and went around it: `debate` shipped **optional**, with a coverage series published beside it, and the required-field question explicitly deferred to that series. `normalize_debate`'s own docstring says so:

> Making the field required is the next step, and it should be taken against that series, not against a hope.

Same shape here.

## What ships

- **`expected_move_pct`** — signed, percent, optional, on the plan decision. Absent and `0` stay distinct: "I expect this to go nowhere" is a forecast and a scorable one. `|value| > 100` is discarded as a typo (a `-800` standing in for `-8` would dominate every average it entered); discarding never reddens the pipeline.
- **`magnitude_metrics`** on the dashboard — coverage first, then MAE, signed bias, direction agreement.
- **`skills/daily-deep-brief/SKILL.md`** — documented next to `debate`, with the same discipline: *没有把握就不要填* — an invented number is worse than a blank one, because it looks like a forecast.

Today's reading, which is the honest starting point:

```json
{"decisions": 749, "with_expected_move": 0, "coverage_pct": 0.0, "scored_t1": 0, ...}
```

That is where `debate_coverage` stood the day before #1117 landed and became 8/8.

## Two deliberate choices

**Scored at t1 only.** t5 and t20 have no underlying-return column, so they are left unscored rather than scored against the wrong number.

**Against `underlying_return_t1_pct`, not `benefit_t1_pct`.** Benefit is measured against the counterfactual of not acting — it answers "was acting better than standing still". A forecast that a name falls 8% is a claim about *the name*, so the name's own return is the only honest counterpart.

**`mean_error_pct` is signed.** A book that is directionally right and systematically too dramatic about size has a fine hit rate and a positive bias here, and no other number on this dashboard would show it.

## Tests

`tests/test_decision_expected_move.py` — absent ≠ zero; a typo is discarded not scored (`True` too: bool is an int in Python and `True` is not a 1% forecast); **a plan without the field still validates**, asserted against a real `validate_plan` call, because an optional field that can fail validation is a required field with extra steps; the metric is a coverage series before it is a calibration; an unsettled or unmeasured decision is not scored.

```
$ python3 -m pytest tests/test_decision_expected_move.py -q
6 passed
$ python3 -m pytest tests/ -q -k "ledger or plan or debate or expected_move"
210 passed, 2 skipped
```

Closes #1159

https://claude.ai/code/session_01UUE66h1qD3eJiWD2rs7i6c