### PR TITLE
health: the lanes that failed silently today now report themselves (#1241, #1242)

### DIFF
--- a/ops/host/cron_health_check.py
+++ b/ops/host/cron_health_check.py
@@ -249,6 +249,40 @@ def load_runtime_jobs(jobs_file=None):
     return jobs
 
 
+#: A backlog this deep means the host has been committing without publishing
+#: for at least an hour at the publisher's twenty-minute cadence.
+UNPUSHED_WARN_COMMITS = 3
+
+
+def publish_backlog(ledger):
+    """The newest heartbeat's view of commits the host never published (#1241).
+
+    This gate runs on GitHub Actions, against artifacts that were published. A
+    checkout that commits and never pushes looks, from here, exactly like one
+    that had nothing to say — which is how six commits sat unpushed for eight
+    hours on 2026-08-31 while the `data-plane` branch published on schedule and
+    every visible surface stayed green. The host measures it and carries the
+    number in its heartbeat; this reads it.
+
+    `state: absent` when no heartbeat carries the field — an older host, or one
+    that could not run git. Absent is reported as absent, never as zero: the
+    whole failure being guarded here is a lane that looked fine because nobody
+    was looking at it.
+    """
+    for event in reversed(ledger.get('events') or []):
+        count = event.get('unpushed_commits')
+        if count is None:
+            continue
+        if count >= UNPUSHED_WARN_COMMITS:
+            return {'state': 'degraded', 'count': count,
+                    'detail': f'{count} commit(s) committed here and never '
+                              f'published — check what pre-push is refusing'}
+        return {'state': 'ok', 'count': count,
+                'detail': f'{count} unpushed' if count else 'nothing unpushed'}
+    return {'state': 'absent', 'count': None,
+            'detail': 'no heartbeat carries unpushed_commits (older host?)'}
+
+
 def load_heartbeats(path=None):
     """Load the host-local ledger when present, otherwise the published public copy."""
     candidates = ([Path(path)] if path else [
@@ -720,6 +754,13 @@ def main():
     if publisher['state'] in ('stale', 'failed'):
         has_warn = True
 
+    # A backlog is a warn, never a miss: the commits exist and nothing was lost,
+    # what failed is that they never left the machine. Escalating it to exit 1
+    # would redden a day whose reports all went out (#1241).
+    backlog = publish_backlog(heartbeat_ledger)
+    if backlog['state'] == 'degraded':
+        has_warn = True
+
     # Token regressions surface in the daily review, never as a per-cron alert
     # (feedback_no_individual_cron_alerts) and never as a reason to exit non-zero:
     # a job burning 3x its usual tokens is something to look at, not a failure.
@@ -733,6 +774,7 @@ def main():
         'jobs': report,
         'dashboard_build': dash,
         'scheduled_publisher': publisher,
+        'publish_backlog': backlog,
         'token_usage': token_reports,
         'has_missing': has_missing,
         'has_warn': has_warn,
@@ -751,6 +793,8 @@ def main():
         print(f"  {dash_icon} {'dashboard build':25s}  {dash['detail']}")
         pub_icon = DASHBOARD_STATE_ICONS[publisher['state']]
         print(f"  {pub_icon} {'scheduled publisher':25s}  {publisher['detail']}")
+        print(f"  {DASHBOARD_STATE_ICONS[backlog['state']]} "
+              f"{'publish backlog':25s}  {backlog['detail']}")
         for line in cron_token_audit.format_lines(token_regressions):
             print(f"  {line}")
         if has_missing:

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from datetime import date, datetime, timezone
 from pathlib import Path
 
@@ -117,6 +118,17 @@ class Result:
 # the files beside it name it as the authority), not coding-agent prose. #1072
 # swept it out with `memory/*.md`, which forced the two-tier split #1073 had to
 # invent; both are gone now that the tracked surface tells the truth again.
+#: A publisher that commits every twenty minutes reaches three commits in an
+#: hour, so three is "the last hour did not publish" rather than a round number.
+#: The hour bound catches the quiet-session version of the same failure, where
+#: one commit sits unsent all evening.
+BACKLOG_WARN_COMMITS = 3
+BACKLOG_WARN_HOURS = 2.0
+
+#: How far back to look for a hop that cannot recover. Wide enough to survive a
+#: quiet stretch, short enough that a fixed hop stops being reported the same day.
+RUN_SCAN_LIMIT = 40
+
 BASELINE_TRACKED = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'MEMORY.md', 'TOOLS.md',
                     'AGENTS.md', 'CLAUDE.md', 'BOOTSTRAP.md', 'portfolio.json']
 
@@ -713,7 +725,13 @@ def check_cron_paths_exist(r):
         contract = load_contract()
         errors = validate_live_jobs(contract, jobs)
         if errors:
-            r.add('cron runtime contract', CRITICAL, '; '.join(errors[:8]))
+            # Naming the fix in the message is not decoration: on 2026-08-31
+            # this exact CRITICAL blocked every master push for eight hours,
+            # and the reconciler that repairs it in one command
+            # (`sync_cron_payloads.py`) had to be found by reading the tree.
+            r.add('cron runtime contract', CRITICAL,
+                  '; '.join(errors[:8])
+                  + '  → fix: python3 ops/host/sync_cron_payloads.py --apply')
         else:
             transition = next_us_dst_transition()
             next_label = transition.date().isoformat() if transition else 'unknown'
@@ -862,6 +880,108 @@ def _last_meaningful_line(path):
         tail = fh.read().decode('utf-8', 'replace')
     lines = [line.strip() for line in tail.splitlines() if line.strip()]
     return lines[-1] if lines else None
+
+
+def check_publish_backlog(r):
+    """Commits that were made and never left the machine.
+
+    #1241 is the case this exists for. On 2026-08-31 a CRITICAL from
+    `cron runtime contract` made `.githooks/pre-push` refuse every push to
+    master. The publisher kept committing on schedule, the `data-plane` branch
+    kept publishing successfully, the dashboard looked completely alive — and
+    six commits sat unpushed for **eight hours** with nothing measuring it. It
+    was found because someone asked whether the checkout was clean.
+
+    What makes it findable now is that the backlog is a *state*, not an event.
+    An event ("push failed") can be missed if nobody reads the line it was
+    written on, and that is exactly what happened: the refusal went to the
+    stderr of a cron step. A state is still true on the next run, and this
+    reports it every twenty minutes for as long as it lasts.
+
+    **WARN, never CRITICAL, and not by timidity.** This check runs inside the
+    pre-push hook, so a CRITICAL here would refuse the very push that clears the
+    backlog — the measurement would become the thing keeping the number up.
+    Same reasoning as `check_host_cron_logs` above, one step more literal.
+
+    No network: `origin/master` is read at whatever the last fetch left it,
+    which for the publisher is seconds ago because `safe_push.sh` fetches before
+    it pushes. A stale ref can only *under*-report, and under-reporting a
+    backlog is the safe direction for a check that must not block.
+    """
+    if os.environ.get('GITHUB_ACTIONS'):
+        return  # a PR checkout's distance from origin/master is not a backlog
+    try:
+        branch = subprocess.run(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            capture_output=True, text=True, timeout=10)
+        if branch.returncode != 0 or branch.stdout.strip() != 'master':
+            return  # only the live checkout publishes from master
+        ahead = subprocess.run(
+            ['git', 'rev-list', '--count', 'origin/master..HEAD'],
+            capture_output=True, text=True, timeout=10)
+        if ahead.returncode != 0:
+            return  # no origin/master ref here — a fresh clone or a worktree
+        count = int((ahead.stdout or '0').strip() or 0)
+    except Exception:
+        return
+    if not count:
+        r.add('publish backlog', OK, 'nothing unpushed')
+        return
+    oldest = subprocess.run(
+        ['git', 'log', '-1', '--format=%ct', 'origin/master..HEAD'],
+        capture_output=True, text=True, timeout=10)
+    hours = None
+    try:
+        hours = (time.time() - int(oldest.stdout.strip())) / 3600
+    except Exception:
+        pass
+    age = f'{hours:.1f}h' if hours is not None else 'unknown age'
+    detail = f'{count} commit(s) unpushed, oldest {age}'
+    if count >= BACKLOG_WARN_COMMITS or (hours is not None and hours >= BACKLOG_WARN_HOURS):
+        r.add('publish backlog', WARNING,
+              f'{detail} — the desk is committing but not publishing; '
+              f'check what pre-push is refusing')
+    else:
+        r.add('publish backlog', OK, detail)
+
+
+def check_model_chain_health(r):
+    """A hop that will never recover, told apart from one that just timed out.
+
+    #1242. The scheduled jobs run a three-model fallback chain for their run
+    summary. Two hops are the same MiniMax account and time out at the top of
+    the hour; the third, added precisely so there would be a non-MiniMax leg,
+    now answers `401 Insufficient balance`. All three land in one
+    `FallbackSummaryError: All models failed (3)`, so a permanent billing
+    failure and a transient timeout are indistinguishable — and the chain's
+    real length is 2, from one provider, while it reports as 3.
+
+    Only billing-class failures are reported, and only as a WARN. A timeout is
+    the chain working as designed (the retry succeeds and the report is
+    delivered); a `401 Insufficient balance` never fixes itself, and no amount
+    of retrying it does anything except spend a round trip per slot.
+    """
+    try:
+        sys.path.insert(0, str(_REPO_ROOT / 'ops' / 'host'))
+        import cron_runs  # noqa: PLC0415 - host-only, imported lazily on purpose
+        job_map, _ = cron_runs.load_job_map()
+        if not job_map:
+            return  # no openclaw on this host
+        entries, _ = cron_runs.load_entries('cron', None, None, job_map)
+    except Exception:
+        return
+    dead = {}
+    for entry in entries[:RUN_SCAN_LIMIT]:
+        for hop in re.findall(r'([\w./-]+):\s*([^|]*?)\s*\((billing|auth)\)',
+                              str(entry.get('error') or '')):
+            dead.setdefault(hop[0], hop[1][:60])
+    if dead:
+        named = '; '.join(f'{hop} — {why}' for hop, why in sorted(dead.items()))
+        r.add('model chain', WARNING,
+              f'{len(dead)} hop(s) failing for a reason retrying cannot fix: {named}')
+    else:
+        r.add('model chain', OK, f'no billing-class hop failures in the last '
+                                 f'{RUN_SCAN_LIMIT} runs')
 
 
 def check_host_cron_logs(r):
@@ -1283,6 +1403,8 @@ def main():
         check_cron_paths_exist,
         check_host_crontab_targets,
         check_host_cron_logs,
+        check_publish_backlog,
+        check_model_chain_health,
         check_generated_cron_docs,
         check_research_artifacts,
         check_trading_calendar_horizon,

--- a/src/clawock/automation/cron_heartbeat.py
+++ b/src/clawock/automation/cron_heartbeat.py
@@ -96,6 +96,38 @@ def _locked():
         yield
 
 
+def unpushed_commits(workspace=None) -> int | None:
+    """How many commits this host has made and not published, or `None`.
+
+    Only the host can answer this. The end-of-day health gate runs on GitHub
+    Actions against the *published* artifacts, so a checkout that commits and
+    never pushes is, from there, indistinguishable from one that had nothing to
+    say — which is how six commits sat unpushed for eight hours on 2026-08-31
+    while every published surface looked healthy (#1241). Carrying the number in
+    the heartbeat is what lets a check that cannot see this machine still see
+    this failure.
+
+    `None` for "cannot tell" — no git, no `origin/master`, a detached HEAD —
+    and never `0`, because a checkout that cannot be asked is not a checkout
+    with nothing pending.
+    """
+    import subprocess
+
+    root = Path(workspace) if workspace else WS
+    try:
+        out = subprocess.run(
+            ["git", "rev-list", "--count", "origin/master..HEAD"],
+            capture_output=True, text=True, timeout=10, cwd=str(root))
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        return int(out.stdout.strip())
+    except ValueError:
+        return None
+
+
 def record(market: str, state: str, *, at: datetime | None = None,
            job_name: str | None = None, slot: str | None = None, **details) -> dict:
     now = _now(at)

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -612,6 +612,10 @@ def main(argv=None):
         telegram_sent=tg_ok, dashboard_published=dashboard_published,
         data_plane_status=data_plane_status,
         insights_sidecar=insights_written, issue_count=len(issues),
+        # Published so a gate that runs elsewhere can see a lane only this
+        # machine can measure: commits made here that never reached the remote
+        # (#1241). `None` when it cannot be determined — never 0.
+        unpushed_commits=cron_heartbeat.unpushed_commits(),
         # The ledger needs the same escalating/advisory split the banner uses:
         # an advisory-only slot delivered a clean report (#764).
         escalating_count=len(escalating), advisory_count=len(advisories),

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -355,3 +355,59 @@ def test_a_us_holiday_suppresses_the_previous_evening_slots_without_a_red(monkey
         monkeypatch, capsys, datetime(2026, 5, 26, 9, 17, tzinfo=timezone.utc))
     assert rows["美股开盘报告"]["status"] == "holiday"
     assert rows["美股盘中盯盘"]["status"] == "holiday"
+
+
+# --- publish backlog (#1241) ------------------------------------------------
+#
+# This gate runs on GitHub Actions, against artifacts that were *published*. A
+# checkout that commits and never pushes looks from here exactly like one that
+# had nothing to say — which is how six commits sat unpushed for eight hours on
+# 2026-08-31 while `data-plane` published on schedule and every visible surface
+# stayed green. Only the host can measure it; it carries the number in the
+# heartbeat and these read it.
+
+def _ledger(*counts):
+    return {"events": [{"slot": f"2026-08-31T1{i}:00:00+08:00",
+                        **({} if count is None else {"unpushed_commits": count})}
+                       for i, count in enumerate(counts)]}
+
+
+def test_a_backlog_the_size_of_the_incident_is_degraded():
+    result = cron_health_check.publish_backlog(_ledger(0, 6))
+
+    assert result["state"] == "degraded"
+    assert result["count"] == 6
+    assert "never published" in result["detail"]
+
+
+def test_a_normal_publish_cycle_is_not_a_backlog():
+    assert cron_health_check.publish_backlog(_ledger(0, 1))["state"] == "ok"
+
+
+def test_only_the_newest_heartbeat_that_carries_the_field_decides():
+    """An old degraded reading must not outlive the recovery that followed it."""
+    result = cron_health_check.publish_backlog(_ledger(9, 9, 0))
+
+    assert (result["state"], result["count"]) == ("ok", 0)
+
+
+def test_a_host_that_cannot_measure_it_is_absent_not_zero():
+    """The failure being guarded is a lane that looked fine because nobody looked.
+
+    Reporting `absent` as `0 unpushed` would rebuild exactly that.
+    """
+    assert cron_health_check.publish_backlog(_ledger(None, None))["state"] == "absent"
+    assert cron_health_check.publish_backlog({"events": []})["state"] == "absent"
+    assert cron_health_check.publish_backlog({})["count"] is None
+
+
+def test_the_host_measurement_says_none_rather_than_zero_when_it_cannot_tell(tmp_path):
+    from clawock.automation import cron_heartbeat
+
+    assert cron_heartbeat.unpushed_commits(tmp_path) is None, (
+        "a directory that is not a git checkout has no backlog to report, and "
+        "0 would be a claim it cannot make"
+    )
+    assert cron_heartbeat.unpushed_commits(ROOT) is not None, (
+        "this checkout can be asked, so the answer must be a number"
+    )

--- a/tests/test_system_check_publish_backlog.py
+++ b/tests/test_system_check_publish_backlog.py
@@ -1,0 +1,188 @@
+"""Commits that were made and never left the machine (#1241, #1242).
+
+On 2026-08-31 a CRITICAL from `cron runtime contract` made the pre-push hook
+refuse every push to master. The publisher kept committing on schedule, the
+`data-plane` branch kept publishing fine, the dashboard looked alive — and six
+commits sat unpushed for eight hours with nothing measuring it. The refusal went
+to the stderr of a cron step, which nobody reads.
+
+These drive both new checks through fakes, including the branches that only a
+bad day reaches: a green run of the happy path proves nothing about them.
+"""
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_backlog", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(branch="master", count="0", oldest_epoch=None, rev_list_rc=0):
+    """A fake `git` answering the three questions the check asks."""
+    stamp = str(int(oldest_epoch if oldest_epoch is not None else time.time()))
+
+    def run(argv, **kwargs):
+        if argv[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return subprocess.CompletedProcess(argv, 0, branch + "\n", "")
+        if argv[:3] == ["git", "rev-list", "--count"]:
+            return subprocess.CompletedProcess(argv, rev_list_rc, count + "\n", "")
+        if argv[:2] == ["git", "log"]:
+            return subprocess.CompletedProcess(argv, 0, stamp + "\n", "")
+        raise AssertionError(f"unexpected command {argv}")
+
+    return run
+
+
+def _backlog(system_check, monkeypatch, **kwargs):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(subprocess, "run", _git(**kwargs))
+    result = system_check.Result()
+    system_check.check_publish_backlog(result)
+    return result.checks
+
+
+def test_an_empty_backlog_reports_that_it_is_empty(system_check, monkeypatch):
+    checks = _backlog(system_check, monkeypatch, count="0")
+    assert checks == [("publish backlog", system_check.OK, "nothing unpushed")]
+
+
+def test_the_incident_shape_is_a_warning(system_check, monkeypatch):
+    """Six commits, oldest eight hours old — 2026-08-31, exactly."""
+    checks = _backlog(system_check, monkeypatch, count="6",
+                      oldest_epoch=time.time() - 8 * 3600)
+
+    (name, severity, message), = checks
+    assert (name, severity) == ("publish backlog", system_check.WARNING)
+    assert "6 commit(s) unpushed" in message and "8.0h" in message
+
+
+def test_one_commit_sitting_all_evening_is_also_caught(system_check, monkeypatch):
+    """The quiet-session shape: under the count bound, over the time bound."""
+    checks = _backlog(system_check, monkeypatch, count="1",
+                      oldest_epoch=time.time() - 5 * 3600)
+
+    assert checks[0][1] == system_check.WARNING
+
+
+def test_a_normal_publish_cycle_is_not_a_backlog(system_check, monkeypatch):
+    checks = _backlog(system_check, monkeypatch, count="1",
+                      oldest_epoch=time.time() - 300)
+
+    assert checks[0][1] == system_check.OK
+
+
+def test_it_can_never_block_the_push_that_would_clear_it(system_check, monkeypatch):
+    """The reason this is WARN and not CRITICAL, asserted rather than trusted.
+
+    This check runs inside `.githooks/pre-push`. A CRITICAL here would refuse
+    the very push that empties the backlog, and the measurement would become
+    the thing keeping the number up.
+    """
+    for count, age in (("6", 8 * 3600), ("400", 96 * 3600)):
+        checks = _backlog(system_check, monkeypatch, count=count,
+                          oldest_epoch=time.time() - age)
+        assert checks[0][1] != system_check.CRITICAL
+
+
+def test_a_branch_that_does_not_publish_is_not_measured(system_check, monkeypatch):
+    """Every interactive worktree is ahead of master and none of them publish."""
+    assert _backlog(system_check, monkeypatch, branch="claude/some-task",
+                    count="12") == []
+
+
+def test_a_pr_checkout_on_actions_is_not_a_backlog(system_check, monkeypatch):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setattr(subprocess, "run", _git(count="99"))
+    result = system_check.Result()
+    system_check.check_publish_backlog(result)
+
+    assert result.checks == []
+
+
+def test_a_checkout_without_the_origin_ref_says_nothing(system_check, monkeypatch):
+    """A fresh clone answers `rev-list` non-zero; that is absence, not health."""
+    assert _backlog(system_check, monkeypatch, count="", rev_list_rc=128) == []
+
+
+# --- model chain -----------------------------------------------------------
+
+def _chain(system_check, monkeypatch, errors):
+    fake = type(sys)("cron_runs")
+    fake.load_job_map = lambda *a, **k: ({"job-1": "盘中盯盘"}, "cli")
+    fake.load_entries = lambda *a, **k: ([{"error": e} for e in errors], {"cli"})
+    monkeypatch.setitem(sys.modules, "cron_runs", fake)
+    result = system_check.Result()
+    system_check.check_model_chain_health(result)
+    return result.checks[0]
+
+
+ALL_THREE_FAILED = (
+    "FallbackSummaryError: All models failed (3): "
+    "minimax/MiniMax-M3: MiniMax response-header timeout after 60000ms (timeout) | "
+    "minimax-2/MiniMax-M3: MiniMax response-header timeout after 60000ms (timeout) | "
+    "zen/deepseek-v4-flash: 401 Insufficient balance. Manage your billing here: "
+    "https://opencode.ai/workspace/wrk_x/billing (billing)"
+)
+
+
+def test_a_billing_dead_hop_is_named_and_the_timeouts_are_not(
+        system_check, monkeypatch):
+    """The distinction is the whole check.
+
+    A timeout is the chain working: the retry succeeds and the report ships. A
+    `401 Insufficient balance` never fixes itself, and retrying it only spends a
+    round trip per slot — while the chain still reports as three hops long.
+    """
+    name, severity, message = _chain(system_check, monkeypatch, [ALL_THREE_FAILED])
+
+    assert (name, severity) == ("model chain", system_check.WARNING)
+    assert "zen/deepseek-v4-flash" in message
+    assert "minimax" not in message, (
+        "a hop that times out at the top of the hour is not a hop that is gone"
+    )
+
+
+def test_timeouts_alone_are_not_a_chain_failure(system_check, monkeypatch):
+    only_timeouts = (
+        "FallbackSummaryError: All models failed (2): "
+        "minimax/MiniMax-M3: timeout after 60000ms (timeout) | "
+        "minimax-2/MiniMax-M3: timeout after 60000ms (timeout)"
+    )
+    name, severity, _ = _chain(system_check, monkeypatch, [only_timeouts])
+
+    assert (name, severity) == ("model chain", system_check.OK)
+
+
+def test_a_dead_hop_is_reported_once_however_many_runs_hit_it(
+        system_check, monkeypatch):
+    """Every slot hits it; the desk needs one line, not forty."""
+    _, _, message = _chain(system_check, monkeypatch, [ALL_THREE_FAILED] * 20)
+
+    assert message.count("zen/deepseek-v4-flash") == 1
+    assert message.startswith("1 hop(s)")
+
+
+def test_a_host_without_openclaw_is_not_reported_as_healthy(
+        system_check, monkeypatch):
+    fake = type(sys)("cron_runs")
+    fake.load_job_map = lambda *a, **k: ({}, "empty")
+    monkeypatch.setitem(sys.modules, "cron_runs", fake)
+    result = system_check.Result()
+    system_check.check_model_chain_health(result)
+
+    assert result.checks == [], "no chain to judge is not the same as a good one"


### PR DESCRIPTION
Two failures found tonight, one shape: something stopped working, every visible surface said it was fine, and it was found because someone asked rather than because anything measured it.

## 1 — eight hours of unpublished commits (#1241)

A CRITICAL from `cron runtime contract` made `.githooks/pre-push` refuse every push to master. The publisher kept committing on schedule, `data-plane` kept publishing successfully, the dashboard stayed alive — and six commits sat unpushed from **15:05 to 23:20**. The refusal went to the stderr of a cron step.

**`check_publish_backlog`** makes it a *state*, not an event. An event can be missed if nobody reads the line it was written on — which is what happened. A state is still true on the next run, and this reports it every twenty minutes for as long as it lasts.

> **WARN, never CRITICAL, and not by timidity.** This check runs inside the pre-push hook. A CRITICAL here would refuse the very push that clears the backlog, and the measurement would become the thing keeping the number up. `test_it_can_never_block_the_push_that_would_clear_it` asserts it, including at 400 commits.

**The end-of-day gate could not have caught it either.** It runs on Actions against artifacts that were *published*, where a host that commits and never pushes looks exactly like one with nothing to say. Only the host can measure this — so it now carries `unpushed_commits` in its heartbeat (the one surface that kept publishing all afternoon), and `cron_health_check` reads it. `None` when it cannot be determined, **never `0`**: the failure being guarded is a lane that looked fine because nobody was looking, and reporting absence as zero rebuilds exactly that.

**The CRITICAL now names its own remedy.** `ops/host/sync_cron_payloads.py --apply` fixes it in one command and had to be found by reading the tree while the backlog grew.

## 2 — a hop that will never recover (#1242, the observable half)

The scheduled jobs run a three-model fallback chain for their run summary:

```
minimax/MiniMax-M3      response-header timeout after 60000ms   (timeout)
minimax-2/MiniMax-M3    response-header timeout after 60000ms   (timeout)
zen/deepseek-v4-flash   401 Insufficient balance …/billing      (billing)
```

Two hops are the same MiniMax account; the third was added precisely so there would be a non-MiniMax leg. All three land in one `FallbackSummaryError: All models failed (3)`, so **the chain's real length is 2, from one provider, while it reports as 3** — and every slot spends a round trip on an endpoint that cannot answer.

`check_model_chain_health` reports billing-class failures only, once, as a WARN. A timeout is the chain working as designed (the retry succeeds, the report ships). Topping up or replacing that hop is not something code can do; saying **which** hop is gone and **why retrying will not help** is. Live output:

```
⚠ WARN  model chain  1 hop(s) failing for a reason retrying cannot fix:
        zen/deepseek-v4-flash — 401 Insufficient balance…
```

## Tests

`tests/test_system_check_publish_backlog.py` (12) + `tests/test_cron_health_check.py` (5 new). Weighted at the branches only a bad day reaches: the incident shape exactly (6 commits, 8h); the quiet-session shape (1 commit, 5h — under the count bound, over the time bound); a worktree and an Actions checkout are not backlogs; a checkout without the origin ref says nothing rather than `0`; a dead hop is named once however many runs hit it; timeouts alone are not a chain failure; a host without openclaw is not reported as healthy.

```
$ python3 -m pytest tests/test_system_check_publish_backlog.py tests/test_cron_health_check.py -q
34 passed
$ python3 -m pytest tests/ -q -k "system_check or cron_health or heartbeat or postflight or intraday"
258 passed, 1 skipped
```

Closes #1241. #1242 keeps the half code cannot do: the zen hop needs topping up or replacing.

https://claude.ai/code/session_01UUE66h1qD3eJiWD2rs7i6c