### PR TITLE
cron: drop the billing-dead third hop, and measure the chain by credentials (#1242)

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -22,8 +22,7 @@
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3",
-        "zen/deepseek-v4-flash"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/report.md",
@@ -72,8 +71,7 @@
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3",
-        "zen/deepseek-v4-flash"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/intraday.md",
@@ -135,8 +133,7 @@
         "anthropic/claude-sonnet-4-6"
       ],
       "fallbacks": [
-        "minimax-2/MiniMax-M3",
-        "zen/deepseek-v4-flash"
+        "minimax-2/MiniMax-M3"
       ],
       "thinking": "adaptive",
       "message_template": "config/cron-payloads/brief.md",

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -12,6 +12,7 @@ Used by:
   • Manual: `python3 ops/system_check.py`
 """
 import glob
+import hashlib
 import json
 import os
 import re
@@ -945,6 +946,82 @@ def check_publish_backlog(r):
         r.add('publish backlog', OK, detail)
 
 
+def check_fallback_chain_shape(r):
+    """How many independent legs the scheduled model chain actually has.
+
+    #1242. `check_model_chain_health` below answers "is a hop dead"; this one
+    answers the question that was never asked anywhere: **how long is the chain
+    when you stop counting hops and start counting the things that can fail
+    independently.** A chain of three hops behind one account is one hop with
+    two extra round trips, and it reads as three everywhere — in the contract,
+    in the error string (`All models failed (3)`), and in the run table.
+
+    The number that matters is not the hop count but the count of distinct
+    credentials behind it, because a rate limit, an expired key and an empty
+    balance all hit every hop that shares the credential at the same instant.
+    `minimax` and `minimax-2` are two providers in the contract and one API key
+    in `openclaw.json`; that is the fact this check exists to say out loud.
+
+    Off the live box there is no `openclaw.json`, so credentials cannot be
+    counted and the check reports what the contract alone can prove.
+    """
+    contract = WS / 'config' / 'cron-schedules.json'
+    try:
+        profiles = json.loads(contract.read_text()).get('payload_profiles') or {}
+    except Exception as e:  # noqa: BLE001
+        r.add('fallback chain', CRITICAL, f'cannot read cron contract: {e}')
+        return
+    rotations = {}
+    for name, profile in sorted(profiles.items()):
+        fallbacks = profile.get('fallbacks')
+        if not fallbacks:
+            continue  # a single-model profile declares no chain to measure
+        rotations.setdefault(tuple([profile.get('model'), *fallbacks]), []).append(name)
+    if not rotations:
+        r.add('fallback chain', OK, 'no profile declares a fallback chain')
+        return
+
+    keys = _provider_api_keys()
+    worst = None
+    for rotation, names in sorted(rotations.items(), key=lambda kv: kv[1]):
+        providers = {hop.split('/')[0] for hop in rotation}
+        # An unknown provider is counted as its own credential rather than
+        # folded in with the others: guessing the optimistic direction here
+        # would be the exact overcount this check exists to prevent.
+        creds = {keys.get(p, f'unknown:{p}') for p in providers} if keys else None
+        legs = len(creds) if creds is not None else len(providers)
+        unit = 'credential' if creds is not None else 'provider'
+        detail = (f'{"/".join(names)}: {len(rotation)} hops · '
+                  f'{legs} independent {unit}{"s" if legs != 1 else ""} '
+                  f'({" → ".join(rotation)})')
+        if worst is None or legs < worst[0]:
+            worst = (legs, unit, detail)
+    legs, unit, detail = worst
+    if legs < 2:
+        r.add('fallback chain', WARNING,
+              f'{detail} — every hop fails together; the chain is one leg long')
+    else:
+        r.add('fallback chain', OK, detail)
+
+
+def _provider_api_keys():
+    """provider name → its credential, as an opaque fingerprint. Live box only.
+
+    The values are never printed and never compared to anything but each other;
+    what the caller needs is only whether two providers are the same account.
+    """
+    try:
+        config = json.loads(OPENCLAW_CONFIG.read_text())
+    except Exception:  # noqa: BLE001
+        return {}
+    providers = ((config.get('models') or {}).get('providers') or {})
+    keys = {}
+    for name, provider in providers.items():
+        secret = provider.get('apiKey') or provider.get('baseUrl') or name
+        keys[name] = hashlib.sha256(str(secret).encode()).hexdigest()[:12]
+    return keys
+
+
 def check_model_chain_health(r):
     """A hop that will never recover, told apart from one that just timed out.
 
@@ -1404,6 +1481,7 @@ def main():
         check_host_crontab_targets,
         check_host_cron_logs,
         check_publish_backlog,
+        check_fallback_chain_shape,
         check_model_chain_health,
         check_generated_cron_docs,
         check_research_artifacts,

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -12,7 +12,6 @@ Used by:
   • Manual: `python3 ops/system_check.py`
 """
 import glob
-import hashlib
 import json
 import os
 import re
@@ -1005,21 +1004,28 @@ def check_fallback_chain_shape(r):
 
 
 def _provider_api_keys():
-    """provider name → its credential, as an opaque fingerprint. Live box only.
+    """provider name → an opaque label for the account behind it. Live box only.
 
-    The values are never printed and never compared to anything but each other;
-    what the caller needs is only whether two providers are the same account.
+    The caller's only question is whether two providers are the same account,
+    so the credential itself never leaves this function: providers sharing one
+    are handed the same anonymous label (`account-1`, `account-2`, …) and the
+    secrets are dropped on return. Nothing here hashes or stores a key — a
+    fingerprint would be a second copy of the secret for no added answer.
     """
     try:
         config = json.loads(OPENCLAW_CONFIG.read_text())
     except Exception:  # noqa: BLE001
         return {}
     providers = ((config.get('models') or {}).get('providers') or {})
-    keys = {}
+    accounts, labels = {}, {}
     for name, provider in providers.items():
-        secret = provider.get('apiKey') or provider.get('baseUrl') or name
-        keys[name] = hashlib.sha256(str(secret).encode()).hexdigest()[:12]
-    return keys
+        # baseUrl, then the name: a provider that carries no key of its own is
+        # its own account rather than a silent match with someone else's.
+        identity = str(provider.get('apiKey')
+                       or provider.get('baseUrl') or name)
+        labels[name] = accounts.setdefault(identity, f'account-{len(accounts) + 1}')
+    accounts.clear()
+    return labels
 
 
 def check_model_chain_health(r):

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -522,6 +522,14 @@ def test_strategy_cron_provider_order_is_fixed_policy():
 
     # This concrete order is policy. Reordering it requires a deliberate human
     # decision; do not make this expectation follow the contract dynamically.
+    #
+    # #1242: `zen/deepseek-v4-flash` left the executed rotation on 2026-09-01.
+    # Its account answers `401 Insufficient balance` — measured again that
+    # morning on both the zen and the go endpoint — so every slot spent a round
+    # trip on a hop that could only fail, and the chain reported three hops long
+    # while two of them were one MiniMax account. It stays in
+    # `model_candidates`, which is the allowed set rather than the rotation:
+    # topping the balance up is the only thing needed to put it back.
     assert {
         name: {
             'model': profiles[name].get('model'),
@@ -532,7 +540,7 @@ def test_strategy_cron_provider_order_is_fixed_policy():
     } == {
         'report': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
@@ -543,7 +551,7 @@ def test_strategy_cron_provider_order_is_fixed_policy():
         },
         'intraday': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',
@@ -554,7 +562,7 @@ def test_strategy_cron_provider_order_is_fixed_policy():
         },
         'brief': {
             'model': 'minimax/MiniMax-M3',
-            'fallbacks': ['minimax-2/MiniMax-M3', 'zen/deepseek-v4-flash'],
+            'fallbacks': ['minimax-2/MiniMax-M3'],
             'model_candidates': [
                 'minimax/MiniMax-M3',
                 'minimax-2/MiniMax-M3',

--- a/tests/test_system_check_publish_backlog.py
+++ b/tests/test_system_check_publish_backlog.py
@@ -10,6 +10,7 @@ These drive both new checks through fakes, including the branches that only a
 bad day reaches: a green run of the happy path proves nothing about them.
 """
 import importlib.util
+import json
 import subprocess
 import sys
 import time
@@ -186,3 +187,105 @@ def test_a_host_without_openclaw_is_not_reported_as_healthy(
     system_check.check_model_chain_health(result)
 
     assert result.checks == [], "no chain to judge is not the same as a good one"
+
+
+# --- fallback chain shape --------------------------------------------------
+
+def _shape(system_check, monkeypatch, tmp_path, profiles, keys=None):
+    contract = tmp_path / "config"
+    contract.mkdir(exist_ok=True)
+    (contract / "cron-schedules.json").write_text(
+        json.dumps({"payload_profiles": profiles}))
+    monkeypatch.setattr(system_check, "WS", tmp_path)
+    monkeypatch.setattr(system_check, "_provider_api_keys", lambda: keys or {})
+    result = system_check.Result()
+    system_check.check_fallback_chain_shape(result)
+    return result.checks[0]
+
+
+ONE_ACCOUNT = {
+    "report": {
+        "model": "minimax/MiniMax-M3",
+        "fallbacks": ["minimax-2/MiniMax-M3"],
+    },
+}
+
+
+def test_two_hops_on_one_credential_are_reported_as_one_leg(
+        system_check, monkeypatch, tmp_path):
+    """The whole point of #1242: hop count is not chain length.
+
+    `minimax` and `minimax-2` are two providers in the contract and one API key
+    in `openclaw.json`. A rate limit, an expired key or an empty balance takes
+    both at the same instant, so the chain survives nothing that the first hop
+    does not survive.
+    """
+    name, severity, message = _shape(
+        system_check, monkeypatch, tmp_path, ONE_ACCOUNT,
+        keys={"minimax": "aaa", "minimax-2": "aaa"})
+
+    assert (name, severity) == ("fallback chain", system_check.WARNING)
+    assert "2 hops" in message and "1 independent credential" in message
+
+
+def test_a_second_account_makes_the_chain_two_legs(
+        system_check, monkeypatch, tmp_path):
+    name, severity, message = _shape(
+        system_check, monkeypatch, tmp_path,
+        {"report": {"model": "minimax/MiniMax-M3",
+                    "fallbacks": ["minimax-2/MiniMax-M3", "zen/deepseek-v4-flash"]}},
+        keys={"minimax": "aaa", "minimax-2": "aaa", "zen": "bbb"})
+
+    assert (name, severity) == ("fallback chain", system_check.OK)
+    assert "3 hops" in message and "2 independent credentials" in message
+
+
+def test_the_shortest_chain_is_the_one_reported(
+        system_check, monkeypatch, tmp_path):
+    """Two profiles, one healthy and one not: reporting the healthy one would
+    let a single-leg chain hide behind an average."""
+    _, severity, message = _shape(
+        system_check, monkeypatch, tmp_path,
+        {"brief": {"model": "minimax/MiniMax-M3",
+                   "fallbacks": ["minimax-2/MiniMax-M3"]},
+         "report": {"model": "minimax/MiniMax-M3",
+                    "fallbacks": ["zen/deepseek-v4-flash"]}},
+        keys={"minimax": "aaa", "minimax-2": "aaa", "zen": "bbb"})
+
+    assert severity == system_check.WARNING
+    assert message.startswith("brief:")
+
+
+def test_an_unknown_provider_is_not_credited_to_a_known_account(
+        system_check, monkeypatch, tmp_path):
+    """A provider missing from `openclaw.json` counts as its own leg only
+    because guessing the other way would overstate the chain — the direction of
+    the guess is the only thing this check may not get wrong."""
+    _, severity, _ = _shape(
+        system_check, monkeypatch, tmp_path,
+        {"report": {"model": "minimax/MiniMax-M3",
+                    "fallbacks": ["mystery/model-x"]}},
+        keys={"minimax": "aaa"})
+
+    assert severity == system_check.OK
+
+
+def test_a_profile_without_fallbacks_declares_no_chain(
+        system_check, monkeypatch, tmp_path):
+    name, severity, message = _shape(
+        system_check, monkeypatch, tmp_path,
+        {"memory": {"model": "minimax/MiniMax-M3", "fallbacks": []}})
+
+    assert (name, severity) == ("fallback chain", system_check.OK)
+    assert "no profile declares a fallback chain" in message
+
+
+def test_off_the_live_box_the_check_counts_providers_and_says_so(
+        system_check, monkeypatch, tmp_path):
+    """CI has no `openclaw.json`. Claiming a credential count it cannot read
+    would be the invented number this whole issue is about."""
+    _, severity, message = _shape(
+        system_check, monkeypatch, tmp_path, ONE_ACCOUNT, keys={})
+
+    assert severity == system_check.OK
+    assert "2 independent providers" in message


### PR DESCRIPTION
Closes #1242.

## 今天实测（2026-09-01 02:2x HKT）

同一个 OpenCode workspace 的两个端点都还是余额不足，不是超时、也不是瞬时故障：

| 端点 | 模型 | 结果 |
|---|---|---|
| `opencode.ai/zen/v1` | `deepseek-v4-flash` | **401 CreditsError: Insufficient balance** |
| `opencode.ai/zen/go/v1` | `deepseek-v4-flash` / `-pro` | **401 CreditsError: Insufficient balance** |

顺手量了免费档能不能顶上（因为它同 key 同端点，换上去零成本）：

| 模型 | 可用性 | 工具调用 |
|---|---|---|
| `mimo-v2.5-free` | 429 Rate limit | — |
| `deepseek-v4-flash-free` | 400 Model is unavailable | — |
| `nemotron-3-ultra-free` | 200 | ❌ 把 `<tool_call>` 当正文吐出来 |
| `ling-3.0-flash-fin-free` | 首次 200，紧接着 **0/5**（503 Endpoint is unavailable） | ✅ 原生 tool_calls |

⇒ **没有一条免费档能当生产第三跳**。唯一原生支持工具调用的那条，连续 5 次全 503。

## 这个 PR 做了什么

1. **把 `zen/deepseek-v4-flash` 从执行轮换里摘掉**（report / intraday / brief 三个 profile）。
   它留在 `model_candidates` 里——那是「允许集」不是「轮换」——所以充值之后放回去就是一行 diff。
   现在每档不再对一个必然 401 的端点发起请求。这不改变投递：链条真正干活的一直是前两跳 + 重试。

2. **新增 `fallback chain` 巡检**：不数声明了几跳，数**有几条能独立失败的腿**。
   `minimax` 和 `minimax-2` 在契约里是两个 provider，在 `openclaw.json` 里是**同一把 API key**——
   限流、密钥过期、余额清零会在同一瞬间打掉两跳。live 上现在输出：

   ```
   ⚠ WARN  fallback chain  brief/intraday/report: 2 hops · 1 independent credential
                           (minimax/MiniMax-M3 → minimax-2/MiniMax-M3)
                           — every hop fails together; the chain is one leg long
   ```

   这正是 #340 当年诊断的形状，只是它第一次被写在一行里，而不是藏在 `All models failed (3)` 里。
   凭证读不到时（CI 没有 `openclaw.json`）只数 provider 并在文案里说明——不编它证明不了的数字。

`check_model_chain_health`（#1243）没动：它回答「某一跳是不是死了」；这条回答「链条在出事之前是什么形状」。

## 测试

`tests/test_system_check_publish_backlog.py` 加 6 条，覆盖只有坏日子才走的分支：
同 key 两跳=1 腿、第二个账号=2 腿、多 profile 取最短、未知 provider 不并入已知账号（猜错方向就是这条检查存在的理由）、
无 fallback 的 profile、以及没有 `openclaw.json` 的 CI 形态。

`tests/test_cron_contracts.py::test_strategy_cron_provider_order_is_fixed_policy` 是策略闸，它红了正说明闸有效——
按新策略更新，并把「为什么摘掉、怎么放回去」写在断言旁边。

## 仍然是 kcn 的动作（代码解决不了）

链条现在**诚实地**是 1 条腿。要变回两条腿只有三个办法：
① 给 OpenCode workspace 充值（放回 `zen/deepseek-v4-flash` = 一行）；
② 第三跳换 `anthropic/claude-sonnet-4-6`（已在 candidates 里，走 kcn 的 Anthropic 额度）；
③ 接一个真正独立的第三方 key。
在那之前，`fallback chain` 这条 WARN 会一直说出这个事实。

https://claude.ai/code/session_01YFE1LXLNNvpMtfC3x83AJ8