### PR TITLE
dashboard: stop the build invalidating its own fingerprint gate (#1247)

### DIFF
--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -1654,6 +1654,9 @@ def workspace_relative(path):
         return str(path)
 
 
+PRESERVE_ABSENT_PREFIX = 'preserve-absent-'
+
+
 def record_preservation(presence, taken, source, out_file, at=None, missing=False):
     """Append one line per build to memory/.tmp/preserve-absent-YYYY-MM-DD.jsonl.
 
@@ -1693,7 +1696,7 @@ def record_preservation(presence, taken, source, out_file, at=None, missing=Fals
             'absent_sources': sorted(k for k, present in presence.items() if not present),
             'preserved': taken,
         }, ensure_ascii=False)
-        daily = tmp_dir / f'preserve-absent-{at.date().isoformat()}.jsonl'
+        daily = tmp_dir / f'{PRESERVE_ABSENT_PREFIX}{at.date().isoformat()}.jsonl'
         with daily.open('a', encoding='utf-8') as handle:
             handle.write(line + '\n')
     except Exception as e:
@@ -3307,6 +3310,20 @@ FINGERPRINT_FILES = (
 ))
 FINGERPRINT_DIRS = ('memory/bars', 'memory/snapshots', 'memory/weekly', 'memory/.tmp')
 FINGERPRINT_CACHE = '.cache/dashboard-input.json'
+# Names under FINGERPRINT_DIRS that THIS build writes, so they describe the
+# build rather than feed it. `record_preservation` appends a line to
+# memory/.tmp/preserve-absent-YYYY-MM-DD.jsonl on every build, which is inside
+# the fingerprinted `memory/.tmp` — so each build moved the fingerprint its
+# successor's gate reads, and `--skip-if-unchanged` could never fire once,
+# anywhere (#1247). Same shape as the snapshot writer #1217 fixed; this was the
+# second self-writer and it survived because the gate fails silently: it does
+# not error, it just always rebuilds.
+#
+# Deliberately a prefix tuple and not "drop memory/.tmp": the other sidecars in
+# there — brief-context, insights, intraday-insights, sector-scan — are real
+# inputs the projection embeds, and dropping the whole directory would trade
+# this stall for the #1217 staleness bug in a card nobody watches.
+FINGERPRINT_SELF_WRITTEN = (PRESERVE_ABSENT_PREFIX,)
 
 
 def dashboard_input_fingerprint(ws: Path) -> str:
@@ -3324,6 +3341,9 @@ def dashboard_input_fingerprint(ws: Path) -> str:
             names = sorted(os.listdir(d))
         except OSError:
             names = []
+        # Filtered before the count, or a new day's telemetry file would move
+        # the fingerprint through `count=` even with its stat line excluded.
+        names = [n for n in names if not n.startswith(FINGERPRINT_SELF_WRITTEN)]
         h.update(f'{rel}:count={len(names)}\n'.encode())
         for name in names:
             try:

--- a/tests/test_dashboard_input_fingerprint.py
+++ b/tests/test_dashboard_input_fingerprint.py
@@ -209,3 +209,54 @@ def test_an_unchanged_portfolio_does_not_move_the_snapshot(tmp_path, monkeypatch
     assert ok
     assert snap.read_text() == '{"holdings": [1]}', 'a real change must still land'
     assert dashboard_input_fingerprint(ws) != fingerprint
+
+
+def test_the_builds_own_telemetry_does_not_move_the_fingerprint(tmp_path, monkeypatch):
+    """#1247: the second self-writer, found because the gate never fired once.
+
+    `record_preservation` appends a line to memory/.tmp on every build, and
+    memory/.tmp is fingerprinted — so build N moved the fingerprint that build
+    N+1's gate compares against, and `--skip-if-unchanged` was structurally
+    unfireable on both the publisher (72x/day) and harness (~19x/day) paths.
+    Measured before the fix: three consecutive builds against a desk with zero
+    input change all rebuilt, each writing a different fingerprint.
+
+    Driven through `record_preservation` itself rather than by writing the
+    filename here, so renaming the telemetry file fails this test instead of
+    silently re-opening the hole.
+    """
+    from clawock.publish import dashboard
+
+    ws = _desk(tmp_path)
+    monkeypatch.setattr(dashboard, 'WS_ROOT', ws)
+
+    before = dashboard_input_fingerprint(ws)
+    for _ in range(3):
+        dashboard.record_preservation(
+            presence={'insights': True}, taken=[], source=None,
+            out_file=ws / 'assets' / 'data' / 'dashboard.json')
+    written = list((ws / 'memory' / '.tmp').glob('preserve-absent-*.jsonl'))
+    assert written and written[0].read_text().count('\n') == 3, (
+        'the telemetry was not written, so this test proves nothing')
+    assert dashboard_input_fingerprint(ws) == before, (
+        "the build's own telemetry moved the fingerprint: every build "
+        'invalidates the next one and --skip-if-unchanged can never fire')
+
+
+def test_a_real_tmp_sidecar_still_moves_the_fingerprint(tmp_path):
+    """The exclusion must stay a prefix, not become "ignore memory/.tmp".
+
+    brief-context / insights / intraday-insights / sector-scan are embedded in
+    the projection, so making the gate blind to them would swap #1247's stall
+    for #1217's staleness.
+    """
+    from clawock.publish.dashboard import PRESERVE_ABSENT_PREFIX
+
+    ws = _desk(tmp_path)
+    tmp = ws / 'memory' / '.tmp'
+    for name in ('brief-context-2026-09-01.json', 'insights-2026-09-01.json',
+                 'intraday-insights-2026-09-01.json', 'sector-scan-2026-09-01.json'):
+        before = dashboard_input_fingerprint(ws)
+        assert not name.startswith(PRESERVE_ABSENT_PREFIX)
+        (tmp / name).write_text('{"v": 1}')
+        assert dashboard_input_fingerprint(ws) != before, f'{name} must move it'


### PR DESCRIPTION
## 现状

`dashboard-build --skip-if-unchanged` 从来没跳过过一次 — publisher (72×/天) 和 harness postflight (~19×/天) 两条路都没有。

实测（live desk，零输入变更，连跑三次）：

| run | 耗时 | 结果 | 写入的 fingerprint |
|---|---|---|---|
| 1 | 5.65s | rebuilt | `b13e160b…` |
| 2 | 3.76s | rebuilt | `6b82c72e…` |
| 3 | 3.78s | rebuilt | `592224c3…` |

## 根因

把 fingerprint 的每一条输入 dump 出来、跨一次 build 做 diff，只有一条动了：

```
memory/.tmp/preserve-absent-2026-09-01.jsonl:…:2404
memory/.tmp/preserve-absent-2026-09-01.jsonl:…:2637
```

`record_preservation()` 每次 build 都往 `memory/.tmp/preserve-absent-YYYY-MM-DD.jsonl` 追一行，而 `memory/.tmp` 在 `FINGERPRINT_DIRS` 里 —— **build N 挪动了 build N+1 的闸要比对的那个 fingerprint**。这跟 #1217 修掉的 snapshot writer 是同一个形状；它是第二个自写者，能活下来是因为失败是静默的：闸不报错，只是永远重建。

## 改法

把 telemetry 文件名收成一个常量，writer 和 fingerprint 共用，然后在指纹里按前缀排除。过滤放在 `count=` 之前 —— 否则新一天的 telemetry 文件仍会通过条目计数挪动指纹。

**没有采用 issue 建议的「把 `memory/.tmp` 整个从 FINGERPRINT_DIRS 拿掉」**：brief-context / insights / intraday-insights / sector-scan 都在那个目录里，而且都被 projection 嵌进 payload。整目录拿掉等于用这个空转换来 #1217 的陈旧 bug。第二条测试钉住这一点。

## 验收

两条新测试，改之前都会失败：

- `test_the_builds_own_telemetry_does_not_move_the_fingerprint` — 通过真的调 `record_preservation()` 来驱动，而不是在测试里手写文件名，所以改名会让测试挂而不是悄悄把洞打开。
- `test_a_real_tmp_sidecar_still_moves_the_fingerprint` — 排除必须保持是前缀而不是「忽略 memory/.tmp」。

改前：2 failed, 8 passed。改后：10 passed。

Closes #1247