### PR TITLE
workspace: modules resolve their desk from the tree, not the caller's cwd (#1248)

### DIFF
--- a/ops/host/backfill_snapshot_realized.py
+++ b/ops/host/backfill_snapshot_realized.py
@@ -34,7 +34,7 @@ from clawock.workspace import workspace_root  # noqa: E402
 # it made `--portfolio` default to the real ledger *and* pointed SNAP_DIR at the
 # real memory/snapshots/, so a backfill run from a review checkout rewrote
 # production snapshots in place.
-WS = str(workspace_root(Path.cwd()))
+WS = str(workspace_root())
 SNAP_DIR = os.path.join(WS, 'memory', 'snapshots')
 DATE_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})')
 

--- a/src/clawock/automation/cron_heartbeat.py
+++ b/src/clawock/automation/cron_heartbeat.py
@@ -20,7 +20,7 @@ from zoneinfo import ZoneInfo
 from clawock.workspace import workspace_root
 from clawock.automation import workflow_outcomes
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 LOCAL_PATH = WS / "memory" / ".tmp" / "cron-heartbeats.json"
 PUBLIC_PATH = WS / "assets" / "data" / "cron-heartbeats.json"
 HKT = ZoneInfo("Asia/Hong_Kong")

--- a/src/clawock/automation/influencer.py
+++ b/src/clawock/automation/influencer.py
@@ -38,7 +38,6 @@ import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
-from pathlib import Path
 
 import requests
 
@@ -46,7 +45,7 @@ from clawock.safe_io import safe_write_json
 from clawock.market_data.sentiment import fetch_google_news
 from clawock.workspace import workspace_root
 
-WS_ROOT = str(workspace_root(Path.cwd()))
+WS_ROOT = str(workspace_root())
 OUT_FILE = os.path.join(WS_ROOT, 'assets', 'data', 'influencer_feed.json')
 
 UA = 'clawock-influencer-scan/1.0 (github.com/KCNyu/clawock)'

--- a/src/clawock/automation/workflow_outcomes.py
+++ b/src/clawock/automation/workflow_outcomes.py
@@ -56,7 +56,7 @@ def _ws() -> Path:
     Resolved per call, `CLAWOCK_WORKSPACE` reaches this module like the
     docstring always claimed. Unset, behaviour is unchanged.
     """
-    return workspace_root(Path.cwd())
+    return workspace_root()
 
 
 def local_path() -> Path:

--- a/src/clawock/costs.py
+++ b/src/clawock/costs.py
@@ -66,7 +66,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 CONFIG = WS / 'config' / 'cost-model.json'
 
 #: Half the quoted spread: what an order that crosses the touch pays, relative

--- a/src/clawock/decision/earnings.py
+++ b/src/clawock/decision/earnings.py
@@ -31,7 +31,7 @@ from clawock import provenance as research_provenance
 from clawock.workspace import engine_config, workspace_root
 from clawock.safe_io import parse_iso_utc as _parse_time
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 SCHEMA_FILE = engine_config("earnings_review.schema.json")
 ARTIFACT_ROOT = WS / "memory" / "earnings"
 SCHEMA_VERSION = 1

--- a/src/clawock/decision/entry.py
+++ b/src/clawock/decision/entry.py
@@ -28,7 +28,7 @@ from clawock import instruments as instrument_registry
 from clawock.workspace import engine_config, workspace_root
 from clawock.safe_io import parse_iso_utc as _parse_time
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 SCHEMA_FILE = engine_config("entry_gate.schema.json")
 VETO_FILE = WS / "config" / "entry-gate-vetoes.json"
 ARTIFACT_ROOT = WS / "memory" / "entry-gates"

--- a/src/clawock/decision/ledger.py
+++ b/src/clawock/decision/ledger.py
@@ -46,7 +46,7 @@ from clawock.workspace import workspace_root
 
 # Installed package code resolves user state from the caller's workspace, never
 # from site-packages or a source checkout path.
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 LEDGER = WS / "memory" / "decisions.jsonl"
 
 SCHEMA_VERSION = 2

--- a/src/clawock/decision/packet.py
+++ b/src/clawock/decision/packet.py
@@ -42,7 +42,7 @@ MAX_QUERY_BYTES = 24 * 1024
 # crossing from being a surprise.
 MAX_SUMMARY_BYTES = 48 * 1024
 SUMMARY_BUDGET_WARN_RATIO = 0.8
-ADD_ALPHA_POLICY = workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json"
+ADD_ALPHA_POLICY = workspace_root() / "config" / "add-alpha-policy.json"
 VERDICTS = {"bullish", "neutral", "bearish", "mixed"}
 DISPOSITIONS = {"candidate", "wait", "reject"}
 TEXT_LIMITS = {
@@ -1760,7 +1760,7 @@ def compile_pages_projection(
 
 def _latest_add_alpha_run_card() -> dict | None:
     cards = sorted(
-        (workspace_root(Path.cwd()) / "memory" / "backtests").glob(
+        (workspace_root() / "memory" / "backtests").glob(
             "add_alpha_walkforward-*.json"
         )
     )

--- a/src/clawock/decision/plans.py
+++ b/src/clawock/decision/plans.py
@@ -28,7 +28,7 @@ from clawock.decision import ledger as decision_v2
 from clawock.decision import risk as risk_ledger
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 MEMORY = WS / "memory"
 LEDGER = MEMORY / "decisions.jsonl"
 

--- a/src/clawock/decision/regime.py
+++ b/src/clawock/decision/regime.py
@@ -68,7 +68,6 @@ import json
 import math
 import sys
 from datetime import date, datetime, timezone
-from pathlib import Path
 
 import requests
 
@@ -76,7 +75,7 @@ from clawock.instruments import INSTRUMENTS
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 OUT_FILE = WS / 'assets' / 'data' / 'lev_regime.json'
 PORTFOLIO = WS / 'portfolio.json'
 TENCENT = 'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'

--- a/src/clawock/decision/risk.py
+++ b/src/clawock/decision/risk.py
@@ -19,7 +19,7 @@ from clawock.instruments import get as get_instrument
 from clawock.instruments import one_x_swap_map
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 LEDGER = WS / "memory" / "risk_breaches.json"
 GUARDRAIL_HISTORY = WS / "assets" / "data" / "guardrail_history.jsonl"
 SCHEMA_VERSION = 1

--- a/src/clawock/decision/setup_review.py
+++ b/src/clawock/decision/setup_review.py
@@ -32,7 +32,6 @@ import math
 import sys
 from datetime import date
 from datetime import date as real_date
-from pathlib import Path
 
 from clawock import instruments
 from clawock import sessions as trading_calendar
@@ -54,7 +53,7 @@ def wilson_ci(hits, n, z=1.96):
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 HIST = WS / 'assets' / 'data' / 't0_setups_history.jsonl'
 OUT = WS / 'assets' / 'data' / 't0_setup_review.json'
 

--- a/src/clawock/decision/setups.py
+++ b/src/clawock/decision/setups.py
@@ -23,14 +23,13 @@ import json
 import os
 import sys
 from datetime import datetime
-from pathlib import Path
 
 from clawock import sessions as tc
 from clawock.instruments import INSTRUMENTS
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 PORTFOLIO = WS / 'portfolio.json'
 QUANT = WS / 'assets' / 'data' / 'quant_signals.json'
 OUT = WS / 'assets' / 'data' / 't0_setups.json'

--- a/src/clawock/decision/shadow.py
+++ b/src/clawock/decision/shadow.py
@@ -1259,7 +1259,7 @@ def write_shadow_portfolio(
 
 
 def main(argv=None) -> int:
-    workspace = workspace_root(Path.cwd())
+    workspace = workspace_root()
     parser = argparse.ArgumentParser()
     parser.add_argument("--path", type=Path, default=workspace / "portfolio.json")
     parser.add_argument(

--- a/src/clawock/decision/signal_review.py
+++ b/src/clawock/decision/signal_review.py
@@ -39,7 +39,6 @@ import json
 import random
 from datetime import date as real_date
 from datetime import date
-from pathlib import Path
 
 from clawock import seeds
 from clawock import history_store
@@ -48,7 +47,7 @@ from clawock import sessions as trading_calendar
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 HIST = WS / 'assets' / 'data' / 'quant_signals_history.jsonl'
 OUT = WS / 'assets' / 'data' / 'quant_signal_review.json'
 

--- a/src/clawock/decision/signals.py
+++ b/src/clawock/decision/signals.py
@@ -27,7 +27,6 @@ import json
 import math
 import sys
 from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import requests
@@ -38,7 +37,7 @@ from clawock.instruments import require as require_instrument
 from clawock.safe_io import load_json_cached, safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 PORTFOLIO = WS / 'portfolio.json'
 OUT = WS / 'assets' / 'data' / 'quant_signals.json'
 HIST = WS / 'assets' / 'data' / 'quant_signals_history.jsonl'
@@ -356,7 +355,7 @@ def _policy_short_history_max_age_days() -> int:
     """
     try:
         policy = json.loads(
-            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            (workspace_root() / "config" / "add-alpha-policy.json")
             .read_text(encoding="utf-8"))
         raw = policy.get("short_history_max_age_days")
         if raw is not None:

--- a/src/clawock/decision/theses.py
+++ b/src/clawock/decision/theses.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from clawock.workspace import engine_config, workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 SCHEMA_FILE = engine_config("thesis.schema.json")
 SCHEMA_VERSION = 1
 THESIS_STATES = ("unknown", "broken", "damaged", "weakening", "intact")

--- a/src/clawock/decision/watch_list.py
+++ b/src/clawock/decision/watch_list.py
@@ -29,7 +29,7 @@ STRONG_5D_PCT = 8.0
 
 def _watch_list_path() -> Path:
     """Config path, resolved at call time (#620: import must not depend on cwd)."""
-    return workspace_root(Path.cwd()) / "config" / "watch-list.json"
+    return workspace_root() / "config" / "watch-list.json"
 
 
 def _policy_near_pct() -> float:
@@ -41,7 +41,7 @@ def _policy_near_pct() -> float:
     """
     try:
         policy = json.loads(
-            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            (workspace_root() / "config" / "add-alpha-policy.json")
             .read_text(encoding="utf-8"))
         raw = policy.get("opportunity_near_pct")
         if raw is not None:
@@ -55,7 +55,7 @@ def _policy_strong_5d_pct() -> float:
     """`strong_5d_pct` from add-alpha-policy.json, default STRONG_5D_PCT (#640)."""
     try:
         policy = json.loads(
-            (workspace_root(Path.cwd()) / "config" / "add-alpha-policy.json")
+            (workspace_root() / "config" / "add-alpha-policy.json")
             .read_text(encoding="utf-8"))
         raw = policy.get("strong_5d_pct")
         if raw is not None:

--- a/src/clawock/evaluation/add_alpha_walkforward.py
+++ b/src/clawock/evaluation/add_alpha_walkforward.py
@@ -29,7 +29,7 @@ from clawock.workspace import workspace_root
 from clawock.safe_io import to_number as _number
 
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 FACTOR_CONFIG = WS / "config" / "factor-universe.json"
 ALPHA_POLICY = WS / "config" / "add-alpha-policy.json"
 NEWS_POLICY = WS / "config" / "news-evidence-policy.json"

--- a/src/clawock/evaluation/combined_regime.py
+++ b/src/clawock/evaluation/combined_regime.py
@@ -31,7 +31,7 @@ from clawock.decision import regime as compute_regime
 from clawock.evidence import run_card
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 OUT = WS / 'memory' / '.tmp'
 OUT.mkdir(parents=True, exist_ok=True)
 UA = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '

--- a/src/clawock/evaluation/hstech_regime.py
+++ b/src/clawock/evaluation/hstech_regime.py
@@ -26,7 +26,7 @@ from clawock.decision import regime as compute_regime
 from clawock.evidence import run_card
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 TENCENT = 'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
 
 

--- a/src/clawock/evaluation/regime_validation.py
+++ b/src/clawock/evaluation/regime_validation.py
@@ -64,7 +64,7 @@ from clawock.evaluation import cscv
 from clawock.evidence import run_card
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 TENCENT = 'https://web.ifzq.gtimg.cn/appstock/app/kline/kline'
 
 # Production defaults, imported in spirit from compute_regime so the validated

--- a/src/clawock/evaluation/signal_panel.py
+++ b/src/clawock/evaluation/signal_panel.py
@@ -107,7 +107,7 @@ from clawock.instruments import canonical_bar_manifest
 from clawock.labeling import triple_barrier
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 DATA = WS / 'assets' / 'data'
 HORIZONS = (1, 5, 20)
 

--- a/src/clawock/evaluation/us_leverage.py
+++ b/src/clawock/evaluation/us_leverage.py
@@ -25,7 +25,7 @@ from clawock.decision import regime as compute_regime
 from clawock.evidence import run_card
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 OUT = WS / 'memory' / '.tmp'
 OUT.mkdir(parents=True, exist_ok=True)
 UA = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '

--- a/src/clawock/evidence/build_evidence.py
+++ b/src/clawock/evidence/build_evidence.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 OUT = WS / 'site' / 'evidence.md'
 CARDS = WS / 'memory' / 'backtests'
 DATA = WS / 'assets' / 'data'

--- a/src/clawock/evidence/claim_provenance.py
+++ b/src/clawock/evidence/claim_provenance.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 CARDS_DIR = WS / 'memory' / 'backtests'
 ALLOWLIST = WS / 'config' / 'claim-allowlist.json'
 SURFACES_CONFIG = WS / 'config' / 'claim-provenance.json'

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 from clawock import history_store
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 POLICY = WS / 'config' / 'news-evidence-policy.json'
 PORTFOLIO = WS / 'portfolio.json'
 FACTOR_CONFIG = WS / 'config' / 'factor-universe.json'

--- a/src/clawock/evidence/research_surface.py
+++ b/src/clawock/evidence/research_surface.py
@@ -30,7 +30,7 @@ from clawock.decision import theses as thesis_registry
 from clawock import instruments as instrument_registry
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 THESIS_DIR = WS / "memory" / "theses"
 EARNINGS_DIR = WS / "memory" / "earnings"
 ENTRY_GATE_DIR = WS / "memory" / "entry-gates"

--- a/src/clawock/evidence/run_card.py
+++ b/src/clawock/evidence/run_card.py
@@ -73,7 +73,7 @@ from clawock import seeds as seed_registry
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 CARDS_DIR = WS / 'memory' / 'backtests'
 SCHEMA_VERSION = 2
 

--- a/src/clawock/evidence/scorecard_verify.py
+++ b/src/clawock/evidence/scorecard_verify.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from clawock import scorecard_provenance as prov
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 LEDGER_PATH = prov.LEDGER_PATH
 DASHBOARD_PATH = 'assets/data/dashboard.json'
 

--- a/src/clawock/harness/_harness_common.py
+++ b/src/clawock/harness/_harness_common.py
@@ -12,11 +12,10 @@ import re
 import subprocess
 import sys
 import time
-from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 
 # Single-publisher mutex for all dashboard build outputs (Option 1, 2026-07-04).

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 
 
@@ -40,7 +40,7 @@ def log_path() -> Path:
     appended to the real checkout's log (#816). Resolved per call; unset, the
     path is what it always was.
     """
-    return workspace_root(Path.cwd()) / 'logs' / 'watchdog.jsonl'
+    return workspace_root() / 'logs' / 'watchdog.jsonl'
 HKT = timezone(timedelta(hours=8))
 # The binary path, the cron CLI call and the cron-state fallback chain moved
 # into src/clawock/providers/openclaw.py so this module stops being the largest

--- a/src/clawock/harness/brief_postflight.py
+++ b/src/clawock/harness/brief_postflight.py
@@ -38,7 +38,7 @@ from clawock.decision import ledger as decision_v2
 from clawock.decision import packet as brief_decision_packet
 from clawock.decision import risk as risk_discipline
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 
 from clawock.automation import workflow_outcomes  # noqa: E402

--- a/src/clawock/harness/brief_preflight.py
+++ b/src/clawock/harness/brief_preflight.py
@@ -47,7 +47,6 @@ import subprocess
 import sys
 import time
 from datetime import datetime, date, timezone, timedelta
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from clawock.workspace import workspace_root
@@ -64,7 +63,7 @@ from clawock.evidence import research_surface
 from clawock.market_data import mover_evidence as mover_news
 from clawock.market_data import peer_scan
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 TMP_DIR = WS / 'memory' / '.tmp'
 SNAPSHOT_DIR = WS / 'memory' / 'snapshots'

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -761,7 +761,7 @@ def main(argv=None):
                         help="render to stdout without writing the artifacts")
     args, _unknown = parser.parse_known_args(argv)
 
-    workspace = Path(args.workspace) if args.workspace else workspace_root(Path.cwd())
+    workspace = Path(args.workspace) if args.workspace else workspace_root()
     date = args.date or _date.today().isoformat()
     from clawock.harness._watchdog_common import BRIEF_URL_TMPL
 

--- a/src/clawock/harness/intraday_delta.py
+++ b/src/clawock/harness/intraday_delta.py
@@ -23,7 +23,7 @@ from clawock.market_data import peer_quotes as fetch_peers
 from clawock.automation import cron_heartbeat
 from clawock.safe_io import load_json_cached, safe_write_json
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 HKT = ZoneInfo("Asia/Hong_Kong")
 ET = ZoneInfo("America/New_York")
 PORTFOLIO = WS / "portfolio.json"

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -69,7 +69,7 @@ from clawock.workspace import workspace_root
 from clawock import sessions as trading_calendar
 from clawock.safe_io import safe_write_json
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 

--- a/src/clawock/harness/intraday_preflight.py
+++ b/src/clawock/harness/intraday_preflight.py
@@ -48,7 +48,7 @@ from clawock.decision import active_information
 from clawock.decision import add_side, early_trend
 from clawock.instruments import is_leveraged_holding
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 TMP = WS / 'memory' / '.tmp'
 
 from ._harness_common import compute_context_id

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from clawock.workspace import workspace_root
 from clawock import sessions as trading_calendar
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 _CHECKOUT = WS
 TMP = WS / 'memory' / '.tmp'
 

--- a/src/clawock/harness/report_preflight.py
+++ b/src/clawock/harness/report_preflight.py
@@ -50,7 +50,6 @@ import re
 import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
 
 from clawock.workspace import workspace_root
 from clawock import sessions as trading_calendar
@@ -60,7 +59,7 @@ from clawock.market_data import mover_evidence as mover_news
 from clawock.utilities import PACKAGED_UTILITIES
 from clawock.market_data import peer_scan
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 TMP = WS / 'memory' / '.tmp'
 
 from ._harness_common import (  # noqa: F401 — re-exported for callers/tests

--- a/src/clawock/instruments.py
+++ b/src/clawock/instruments.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from clawock.workspace import engine_config, workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 REGISTRY_FILE = WS / "config" / "instruments.json"
 SCHEMA_FILE = engine_config("instruments.schema.json")
 SCHEMA_VERSION = 1

--- a/src/clawock/market_data/bars.py
+++ b/src/clawock/market_data/bars.py
@@ -58,7 +58,7 @@ from clawock.market_data.eastmoney_http import em_get
 from clawock.instruments import canonical_bar_manifest
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 BARS_DIR = WS / "memory" / "bars"
 HKT = ZoneInfo("Asia/Hong_Kong")
 ET = ZoneInfo("America/New_York")

--- a/src/clawock/market_data/benchmarks.py
+++ b/src/clawock/market_data/benchmarks.py
@@ -29,7 +29,6 @@ import argparse
 import json
 import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Dict, List
 
 import requests
@@ -38,7 +37,7 @@ from clawock.market_data.us_quotes import load_api_keys
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 OUT_FILE = WS_ROOT / 'assets' / 'data' / 'benchmark.json'
 TIMEOUT = 12
 DEFAULT_DAYS = 60

--- a/src/clawock/market_data/calendar.py
+++ b/src/clawock/market_data/calendar.py
@@ -23,7 +23,6 @@ import argparse
 import json
 import sys
 from datetime import datetime, timezone, timedelta, date
-from pathlib import Path
 
 import requests
 
@@ -31,7 +30,7 @@ from clawock import instruments as instrument_registry
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 OUT_FILE = WS_ROOT / 'assets' / 'data' / 'catalysts.json'
 API_KEYS_FILE = WS_ROOT / '.api_keys'
 # Dated company events no vendor supplies (Stock Connect effective dates, lockup

--- a/src/clawock/market_data/eastmoney_news.py
+++ b/src/clawock/market_data/eastmoney_news.py
@@ -153,7 +153,7 @@ def main(argv=None):
     parser.add_argument('--output', type=Path)
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     workspace = (args.workspace.expanduser().resolve() if args.workspace
-                 else workspace_root(Path.cwd()))
+                 else workspace_root())
     output = args.output.expanduser() if args.output else None
     if output and not output.is_absolute():
         output = (workspace / output).resolve()

--- a/src/clawock/market_data/factors.py
+++ b/src/clawock/market_data/factors.py
@@ -30,7 +30,7 @@ from clawock.market_data import bar_signals
 from clawock.safe_io import safe_write_json, safe_write_text
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 CONFIG = WS / 'config' / 'factor-universe.json'
 OUT = WS / 'assets' / 'data' / 'cross_sectional_factor.json'
 HISTORY = WS / 'assets' / 'data' / 'cross_sectional_factor_history.jsonl'

--- a/src/clawock/market_data/filings.py
+++ b/src/clawock/market_data/filings.py
@@ -31,14 +31,13 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import requests
 
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 API_KEYS_PATH = WS_ROOT / '.api_keys'
 CACHE_DIR = WS_ROOT / '.cache'
 TICKER_CACHE = CACHE_DIR / 'sec_tickers.json'

--- a/src/clawock/market_data/gold/fetch.py
+++ b/src/clawock/market_data/gold/fetch.py
@@ -32,7 +32,6 @@ import sys
 import os
 import bisect
 from datetime import date, datetime, timezone
-from pathlib import Path
 
 GRAMS_PER_OZ = 31.1035  # 1 金衡盎司(troy oz) = 31.1035 克
 
@@ -40,7 +39,7 @@ from clawock.safe_io import safe_write_json
 from clawock.market_data.eastmoney_http import em_get
 from clawock.workspace import workspace_root
 
-WS_ROOT = str(workspace_root(Path.cwd()))
+WS_ROOT = str(workspace_root())
 
 PORTFOLIO = os.path.join(WS_ROOT, 'portfolio.json')
 

--- a/src/clawock/market_data/gold/update.py
+++ b/src/clawock/market_data/gold/update.py
@@ -26,13 +26,12 @@ import os
 import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = str(workspace_root(Path.cwd()))
+WS_ROOT = str(workspace_root())
 
 PORTFOLIO = os.path.join(WS_ROOT, 'portfolio.json')
 

--- a/src/clawock/market_data/hk_analysis.py
+++ b/src/clawock/market_data/hk_analysis.py
@@ -16,7 +16,6 @@ Usage:
 import json
 import sys
 from datetime import datetime, timezone, timedelta
-from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
@@ -29,7 +28,7 @@ from clawock.instruments import INSTRUMENTS
 from clawock.portfolio.books import region_book
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 PORTFOLIO_PATH = str(WS_ROOT / 'portfolio.json')
 API_KEYS_PATH = str(WS_ROOT / '.api_keys')
 TIMEOUT = 10

--- a/src/clawock/market_data/known_catalysts.py
+++ b/src/clawock/market_data/known_catalysts.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from clawock.workspace import workspace_root
 
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 TMP = WS / "memory" / ".tmp"
 MAX_MOVERS = 4
 MAX_EVENTS_PER_TICKER = 2

--- a/src/clawock/market_data/mover_evidence.py
+++ b/src/clawock/market_data/mover_evidence.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from clawock.workspace import workspace_root  # noqa: E402
 from clawock.market_data import primary_disclosures
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 
 HKT = timezone(timedelta(hours=8))
 MAX_MOVERS = 4

--- a/src/clawock/market_data/peer_discovery.py
+++ b/src/clawock/market_data/peer_discovery.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import re
 import sys
-from pathlib import Path
 from typing import Iterable
 
 import requests
@@ -23,7 +22,7 @@ from clawock.market_data.eastmoney_http import em_get
 from clawock.workspace import workspace_root
 
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 API_KEYS_PATH = WS / ".api_keys"
 
 

--- a/src/clawock/market_data/peer_residuals.py
+++ b/src/clawock/market_data/peer_residuals.py
@@ -29,7 +29,7 @@ from clawock.market_data.factors import (
 from clawock.safe_io import safe_write_json, safe_write_text
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 RULE_CONFIG = WS / 'config' / 'peer-residual-rules.json'
 FACTOR_CONFIG = WS / 'config' / 'factor-universe.json'
 PEER_MAP = WS / 'memory' / 'peer-map.json'

--- a/src/clawock/market_data/peer_scan.py
+++ b/src/clawock/market_data/peer_scan.py
@@ -21,13 +21,12 @@ import json
 import re
 import subprocess
 import sys
-from pathlib import Path
 
 from clawock.instruments import get as get_instrument
 from clawock.market_data.peer_discovery import suggest_auto_peers
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 
 
 def _has_cjk(s):

--- a/src/clawock/market_data/us_quotes.py
+++ b/src/clawock/market_data/us_quotes.py
@@ -36,7 +36,7 @@ from clawock.instruments import INSTRUMENTS
 from clawock.portfolio.books import region_book
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 PORTFOLIO_PATH = str(WS_ROOT / 'portfolio.json')
 API_KEYS_PATH = str(WS_ROOT / '.api_keys')
 POLYGON_PREV_CACHE_DIR = Path(WS_ROOT) / 'memory' / '.tmp' / 'polygon-prev-close'

--- a/src/clawock/portfolio/aggregates.py
+++ b/src/clawock/portfolio/aggregates.py
@@ -33,7 +33,7 @@ from clawock.portfolio.math import active_holdings, number
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 PORTFOLIO = WS / 'portfolio.json'
 POLICY = WS / 'config' / 'portfolio-derivations.json'
 

--- a/src/clawock/portfolio/cash.py
+++ b/src/clawock/portfolio/cash.py
@@ -17,7 +17,7 @@ from clawock.portfolio.math import derive_cash
 from clawock.safe_io import mutate_json
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 PORTFOLIO = WS / 'portfolio.json'
 POLICY = WS / 'config' / 'portfolio-derivations.json'
 

--- a/src/clawock/portfolio/fx.py
+++ b/src/clawock/portfolio/fx.py
@@ -17,14 +17,13 @@ import argparse
 import json
 import os
 import time
-from pathlib import Path
 from typing import Optional, Dict
 import requests
 
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 CACHE_PATH = str(WS_ROOT / '.cache' / 'fx_rate.json')
 # The durable record, one line per day. The cache above is gitignored and
 # overwritten, so until #323 the only place a past day's rate survived was the

--- a/src/clawock/portfolio/integrity.py
+++ b/src/clawock/portfolio/integrity.py
@@ -74,12 +74,12 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 PORTFOLIO = WS / 'portfolio.json'
 def out_path() -> Path:
     """Resolved per call so `CLAWOCK_WORKSPACE` reaches it (#816); frozen at
     import, a test writing a report landed it in the real checkout."""
-    return workspace_root(Path.cwd()) / 'assets' / 'data' / 'integrity_report.json'
+    return workspace_root() / 'assets' / 'data' / 'integrity_report.json'
 
 from clawock.instruments import INSTRUMENTS
 from clawock.portfolio.math import (

--- a/src/clawock/portfolio/realized.py
+++ b/src/clawock/portfolio/realized.py
@@ -22,7 +22,7 @@ from clawock.workspace import workspace_root
 
 # The CLI operates on the configured workspace. Library callers pass an
 # in-memory ledger and remain independent of filesystem layout.
-PORTFOLIO_PATH = workspace_root(Path.cwd()) / 'portfolio.json'
+PORTFOLIO_PATH = workspace_root() / 'portfolio.json'
 
 
 def _aggregate(holdings: List[Dict]) -> Tuple[float, str, List[Dict]]:

--- a/src/clawock/portfolio/reconcile.py
+++ b/src/clawock/portfolio/reconcile.py
@@ -18,7 +18,7 @@ def main(argv=None) -> int:
     parser.add_argument("--path", type=Path)
     args = parser.parse_args(argv)
 
-    workspace = workspace_root(Path.cwd())
+    workspace = workspace_root()
     portfolio = args.path or workspace / "portfolio.json"
     derivation_policy = workspace / "config" / "portfolio-derivations.json"
     dry = ["--dry-run"] if args.dry_run else []

--- a/src/clawock/portfolio/risk.py
+++ b/src/clawock/portfolio/risk.py
@@ -37,7 +37,7 @@ from clawock.instruments import leverage_map, require as require_instrument
 from clawock.safe_io import safe_write_json
 from clawock.workspace import workspace_root
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 PORTFOLIO_FILE = str(WS_ROOT / 'portfolio.json')
 OUT_FILE = str(WS_ROOT / 'assets' / 'data' / 'risk.json')
 
@@ -1271,7 +1271,7 @@ def _revive_stale_block(out_block, holdings, prev_block, value_key, value,
 # ----------------------------------------------------------------------------
 
 def main(argv=None):
-    workspace = workspace_root(Path.cwd())
+    workspace = workspace_root()
     parser = argparse.ArgumentParser()
     parser.add_argument('--path', type=Path, default=workspace / 'portfolio.json')
     parser.add_argument(

--- a/src/clawock/publish/artifacts.py
+++ b/src/clawock/publish/artifacts.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-ROOT = workspace_root(Path.cwd())
+ROOT = workspace_root()
 DASHBOARD_MAX_BYTES = 200_000
 OVERVIEW_MAX_BYTES = 80_000
 DASHBOARD_MONEY_INTEGRITY_CODES = frozenset({

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -40,7 +40,7 @@ SNAPSHOT_FNAME_RE = history_store.DATED_FILE_RE
 # A session key inside a canonical bar document (memory/bars/<ticker>.json).
 SESSION_DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
-WS_ROOT = workspace_root(Path.cwd())
+WS_ROOT = workspace_root()
 OUT_DIR = WS_ROOT / 'assets' / 'data'
 OUT_FILE = OUT_DIR / 'dashboard.json'
 OVERVIEW_FILE = OUT_DIR / 'overview.json'

--- a/src/clawock/publish/decision_map.py
+++ b/src/clawock/publish/decision_map.py
@@ -52,7 +52,7 @@ from clawock.instruments import canonical_bar_manifest
 from clawock.safe_io import safe_write_text, to_number as _number
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 DATA = WS / 'assets' / 'data'
 LEDGER = WS / 'memory' / 'decisions.jsonl'
 OUT = DATA / 'decision_map.json'

--- a/src/clawock/publish/outputs.py
+++ b/src/clawock/publish/outputs.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from clawock.publish import write_generation  # noqa: F401
 from clawock.workspace import workspace_root
 
-ROOT = workspace_root(Path.cwd())
+ROOT = workspace_root()
 CONTRACT_NAME = "dashboard-outputs.json"
 
 

--- a/src/clawock/scorecard_provenance.py
+++ b/src/clawock/scorecard_provenance.py
@@ -50,7 +50,7 @@ from pathlib import Path
 
 from clawock.workspace import workspace_root
 
-WS = workspace_root(Path.cwd())
+WS = workspace_root()
 SCHEMA_VERSION = 1
 LEDGER_PATH = 'memory/decisions.jsonl'
 DASHBOARD_PATH = 'assets/data/dashboard.json'

--- a/tests/test_contract_workspace_resolution.py
+++ b/tests/test_contract_workspace_resolution.py
@@ -13,6 +13,7 @@ last fallback is the tree the module physically sits in.
 """
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -92,3 +93,110 @@ def test_dst_sync_runs_from_crons_own_cwd(tmp_path, monkeypatch, no_workspace_en
     monkeypatch.chdir(tmp_path)
     contract = sync_us_cron_dst.load_contract()
     assert contract['jobs']
+
+
+# ── the same defect, 75 more times (#1248) ──────────────────────────────────
+#
+# #775 fixed `_contract_path`. What it did not do is ask how many other places
+# had written the same line: 75 modules resolved their workspace as
+# `workspace_root(Path.cwd())`, which is `Path.cwd()` whenever CLAWOCK_WORKSPACE
+# is unset — the exact fallback that sent the DST synchroniser looking for
+# `/root/config/cron-schedules.json` for eight days. `workspace_root`'s own
+# docstring says callers pass their own `parents[2]` "so the fallback stays
+# exactly what it was"; none of the 75 did.
+#
+# Nothing had broken yet only because every current caller happens to chdir
+# first: the installed launcher exports CLAWOCK_WORKSPACE, the harness passes
+# `cwd=ws` to its subprocess, the ops scripts `cd "$WS"`, and pytest runs from
+# the repository root. That is a property of the callers, not of the code, and
+# #775 is what it looks like when one caller stops holding it.
+
+_PROBE_MODULES = (
+    ('clawock.market_data.us_quotes', 'WS_ROOT'),
+    ('clawock.portfolio.cash', 'WS'),
+    ('clawock.harness._harness_common', 'WS'),
+    ('clawock.publish.dashboard', 'WS_ROOT'),
+)
+
+
+def _probe_module_workspace(cwd, env):
+    """Import each module in a fresh interpreter and print what it resolved.
+
+    A subprocess because these are module-level constants: once this suite has
+    imported them from the repository root, re-importing gives the cached value
+    and the test would pass against the bug.
+    """
+    program = (
+        f'import sys; sys.path.insert(0, {str(ROOT / "src")!r})\n'
+        'import importlib\n'
+        f'for name, attr in {_PROBE_MODULES!r}:\n'
+        '    print(name, getattr(importlib.import_module(name), attr))\n'
+    )
+    done = subprocess.run([sys.executable, '-c', program], capture_output=True,
+                          text=True, timeout=120, cwd=str(cwd), env=env)
+    assert done.returncode == 0, done.stderr
+    return dict(line.split(' ', 1) for line in done.stdout.strip().splitlines())
+
+
+def test_module_workspaces_ignore_the_process_cwd(tmp_path):
+    """Run from a directory that is not a workspace, they still find their own."""
+    env = {k: v for k, v in os.environ.items() if k != 'CLAWOCK_WORKSPACE'}
+    resolved = _probe_module_workspace(tmp_path, env)
+
+    assert resolved, 'the probe recorded nothing, so it proves nothing'
+    for name, _ in _PROBE_MODULES:
+        assert resolved[name] == str(ROOT), (
+            f'{name} resolved its workspace to the caller\'s cwd instead of the '
+            f'tree it sits in — the #775 defect, which reads and writes another '
+            f'directory\'s ledger with no error')
+
+
+def test_a_foreign_cwd_that_looks_like_a_workspace_does_not_hijack_a_module():
+    """The silent half: a cwd holding a portfolio.json is the worse case.
+
+    A missing file raises. A different book's `portfolio.json` does not — it is
+    read, published and written back to, and nothing anywhere says which desk
+    the numbers came from.
+    """
+    import tempfile
+
+    env = {k: v for k, v in os.environ.items() if k != 'CLAWOCK_WORKSPACE'}
+    with tempfile.TemporaryDirectory() as foreign:
+        book = Path(foreign)
+        (book / 'memory').mkdir()
+        (book / 'assets' / 'data').mkdir(parents=True)
+        (book / 'portfolio.json').write_text('{"portfolios": {}}', encoding='utf-8')
+        resolved = _probe_module_workspace(book, env)
+
+    for name, _ in _PROBE_MODULES:
+        assert resolved[name] == str(ROOT), f'{name} was hijacked by a foreign book'
+
+
+def test_the_env_override_still_wins_for_modules(tmp_path):
+    """Anchoring on the tree must not cost the foreign-workspace feature."""
+    env = dict(os.environ, CLAWOCK_WORKSPACE=str(tmp_path))
+    resolved = _probe_module_workspace(ROOT, env)
+    for name, _ in _PROBE_MODULES:
+        assert resolved[name] == str(tmp_path), f'{name} ignored CLAWOCK_WORKSPACE'
+
+
+def test_no_module_reintroduces_the_cwd_default():
+    """A static gate, because the runtime one cannot see the other 71 modules.
+
+    The probe above imports four modules; the defect was in 75. Scanning the
+    source is what covers the rest, and it is also what catches the next module
+    written by copying a neighbour — which is how this spread from one line to
+    seventy-five in the first place.
+    """
+    offenders = []
+    for base in ('src', 'ops'):
+        for path in (ROOT / base).rglob('*.py'):
+            text = path.read_text(encoding='utf-8')
+            for number, line in enumerate(text.splitlines(), 1):
+                if 'workspace_root(Path.cwd())' in line:
+                    offenders.append(f'{path.relative_to(ROOT)}:{number}')
+    assert not offenders, (
+        'workspace_root(Path.cwd()) resolves to the caller\'s cwd whenever '
+        'CLAWOCK_WORKSPACE is unset, which is the #775 defect. Call '
+        'workspace_root() with no argument: its own fallback is the tree the '
+        f'package sits in. Found: {offenders}')


### PR DESCRIPTION
## 现状

#775 修了一行：`_contract_path` 回落到 `Path.cwd()`，cron 用 cwd=`/root` 启动 DST 同步器，于是它去找 `/root/config/cron-schedules.json`，**静默失败了八天**。当时没问的问题是：还有多少地方写了同一行。

75 处：

```python
WS = workspace_root(Path.cwd())
```

`workspace_root` 自己的 docstring 写着 callers pass their own `parents[2]` "so the fallback stays exactly what it was" —— 75 处没有一处这么做。`CLAWOCK_WORKSPACE` 未设时，它们全部解析到调用者的 cwd。改之前从 `/root` 实测：

```
us_quotes.WS_ROOT = /root      # 模块文件在 live checkout 里
cash.WS           = /root
```

## 为什么现在没炸

因为**每个现存调用者恰好都先 chdir 了**：装好的 launcher 导出 `CLAWOCK_WORKSPACE`，harness 给 build 子进程传 `cwd=ws`，ops 脚本 `cd "$WS"`，pytest 从仓库根跑。这是调用者的性质，不是代码的性质 —— #775 就是其中一个调用者不再维持这条性质时的样子。

失败模式有两半，安静的那半更糟：cwd 里没有 `portfolio.json` 会报错；cwd 里**有**另一本账的 `portfolio.json` 不会 —— 它会被读、被发布、被写回去，从头到尾没有任何地方说这些数字来自哪张桌子。

## 改法

`workspace_root()` 不带参数时的回落**已经**是「包所在的那棵树」，而且锚在 `workspace.py` 自己身上，所以在任何包深度都对。

顺带说一句 issue 里给的验收断言是错的：

```python
assert us_quotes.WS_ROOT == Path(us_quotes.__file__).resolve().parents[2]   # ← 这是 src/
```

`clawock/market_data/us_quotes.py` 的 `parents[2]` 是 `src/`，不是 workspace。所以本 PR 不按那条断言写，改用 `workspace_root()` 自己的锚点。

env override 依然优先，指向外部账本的能力没变。另有 18 个文件的 `from pathlib import Path` 就只为了这一处，一并删掉。

## 验收

三条新测试，master 上全挂：

- `test_module_workspaces_ignore_the_process_cwd` — **子进程**探针（模块常量是 import 期算的，同进程 re-import 会拿到缓存值、对着 bug 也能过）
- `test_a_foreign_cwd_that_looks_like_a_workspace_does_not_hijack_a_module` — 安静的那半
- `test_no_module_reintroduces_the_cwd_default` — 扫 src/ 和 ops/ 的静态闸。探针只看得见四个模块，而这个缺陷是靠「抄邻居」从一处长到七十五处的，静态闸才盖得住剩下的

本机全量：`3178 passed, 5 skipped, 4 xfailed`。

Closes #1248