### PR TITLE
risk card: publish the guardrail history it was already writing (#1252)

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -1032,6 +1032,52 @@
     background: var(--red); flex: none; margin-top: 4px;
   }
   .risk-alert.medium .icon { background: var(--warning); }
+
+  /* 硬闸的两个时间维度 (#1252)：整卡的走势 + 每条的在闸时长。
+     两者的数据 guardrail_history.jsonl 从 2026-07-15 起每份简报写一行，一直在
+     发、README 的「风控纪律」也靠它，但从来没有任何消费者把它送到浏览器 ——
+     所以这张卡在此之前只答得了「现在触发了什么」。 */
+  .gt-trend {
+    display: flex; align-items: center; gap: var(--space-2);
+    height: 18px; margin: 2px 0 var(--space-2);
+    font-size: var(--fs-micro); color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+  }
+  .gt-trend[hidden] { display: none; }
+  .gt-trend-lbl { text-transform: uppercase; letter-spacing: 0.05em; }
+  .gt-spark { flex: none; }
+  /* 极性是反的：闸触发得少是好事，所以「收敛」是绿的。这也是这支
+     sparkline 不复用 sparklineSVG 的原因 —— 那支按末值高于首值上色。 */
+  .gt-spark.gt-easing { color: var(--green); }
+  .gt-spark.gt-tightening { color: var(--red); }
+  .gt-spark.gt-flat { color: var(--text-faint); }
+  .gt-trend-val { color: var(--text-secondary); font-weight: 600; }
+  .gt-trend-span { margin-left: auto; color: var(--text-faint); }
+
+  /* 时长标只上完整卡：overview 的紧凑卡只有三个槽位，多一枚标就挤掉一条闸。
+     宽屏挂在行右端（读作这一行的元数据）；窄屏 wrap 到自己一行，因为在
+     390px 上它会从正文抢走约 90px，而硬闸的 detail 本来就是全卡最长的一段。
+     只在 #guardrail-list 下改 flex：.risk-alert 也是回本卡和紧凑卡的行。 */
+  #guardrail-list .risk-alert > div { flex: 1 1 auto; min-width: 0; }
+  .risk-age {
+    flex: none; margin-left: auto; align-self: flex-start;
+    padding: 1px 6px; white-space: nowrap; letter-spacing: 0;
+    font-size: var(--fs-micro); font-variant-numeric: tabular-nums;
+    color: var(--text-dim); background: var(--surface-1);
+    border: 1px solid var(--border-subtle); border-radius: var(--radius-sm);
+  }
+  .risk-age.is-new { color: var(--warning); border-color: var(--warning); }
+  /* 窄屏才 wrap。宽屏不能开 flex-wrap：正文列的 flex-basis 是 auto(=max-content)，
+     一开 wrap，长 detail 会在收缩之前先把整行折掉，连左边那颗严重度圆点都被
+     顶到自己一行。 */
+  @media (max-width: 600px) {
+    #guardrail-list .risk-alert { flex-wrap: wrap; }
+    #guardrail-list .risk-alert > div { flex: 1 1 100%; }
+    /* 圆点和左侧 3px 色条编码的是同一件事（severity），窄屏留一个就够：
+       正文列占满一行之后，圆点会被顶成孤零零的一行。 */
+    #guardrail-list .risk-alert > .icon { display: none; }
+    .risk-age { margin-top: var(--space-1); }
+  }
   @media (max-width: 480px) {
     .risk-grid { grid-template-columns: repeat(2, 1fr); }
   }
@@ -2960,13 +3006,17 @@
      退场：面板里它是一枚读数，不是一枚按钮。牌组化后它挂在牌头右侧
      （原 .overview-gates-head 已随双栏退场）。 */
   .deck-card .badge { background: none; padding: 0; }
-  .deck-card .gt-tally { display: inline-flex; align-items: center; gap: 4px; }
-  .deck-card .gt-dot {
+  /* 点阵计数是 #1022 为判定牌做的，选择器却写死在 .deck-card 下 —— 同一段
+     HTML 也由 renderRiskGuardrail 渲到独立的 #guardrail-card 上，在那里
+     .gt-dot 是没有尺寸的空 <i>，「几条闸触发中」整个不可见。计数语言本身
+     跟牌无关，去掉作用域即可，值一个没动。 */
+  .gt-tally { display: inline-flex; align-items: center; gap: 4px; }
+  .gt-dot {
     width: 5px; height: 5px; border-radius: 50%;
     background: var(--border-strong); opacity: .45;
   }
-  .deck-card .gt-dot.on { background: var(--negative); opacity: 1; }
-  .deck-card .gt-more {
+  .gt-dot.on { background: var(--negative); opacity: 1; }
+  .gt-more {
     margin-left: 2px; font: 600 var(--fs-micro)/1 var(--mono);
     color: var(--negative);
   }

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -2505,6 +2505,43 @@
   }
 
 
+  // 硬闸计数的走势。刻意不用 sparklineSVG：那支按「末值 > 首值 = 绿」着色，
+  // 而这里的极性是反的 —— 闸触发得少是好事，12 → 6 必须读成收敛而不是下跌。
+  // 固定尺寸，所以它不参与布局位移（CLS 判据同 hero-rail 预留）。
+  function guardrailTrendSVG(counts, w = 76, h = 16) {
+    const pts = counts.filter(v => typeof v === "number" && isFinite(v));
+    if (pts.length < 2) return "";
+    const min = Math.min(...pts), max = Math.max(...pts);
+    const range = max - min || 1;
+    const stepX = (w - 4) / (pts.length - 1);
+    const xy = (v, i) => [2 + i * stepX, h - 2 - ((v - min) / range) * (h - 4)];
+    const path = pts.map((v, i) => {
+      const [x, y] = xy(v, i);
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(" ");
+    const first = pts[0], last = pts[pts.length - 1];
+    const cls = last < first ? "gt-easing" : (last > first ? "gt-tightening" : "gt-flat");
+    const [lx, ly] = xy(last, pts.length - 1);
+    return `<svg class="gt-spark ${cls}" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" aria-hidden="true">`
+      + `<path d="${path}" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" stroke-linecap="round"/>`
+      + `<circle cx="${lx.toFixed(1)}" cy="${ly.toFixed(1)}" r="1.7" fill="currentColor"/></svg>`;
+  }
+
+  // 「这条闸触发多久了」。天数是**简报记录日**（guardrail_history 每份简报一行、
+  // 按日期幂等），所以周末和假日是缺行不是 0 —— 数行，不减日期。capped 表示这段
+  // 连续记录一直顶到文件最早一行（2026-07-15 开始，之前的重建不出来），所以写
+  // 「N 天+」而不是把一个下界当成确数印出来。
+  function guardrailAgeLabel(entry) {
+    const days = entry && entry.age_days;
+    if (typeof days !== "number") return "";
+    const line = (cls, title, text) =>
+      `<span class="risk-age ${cls}" title="${title}">${text}</span>`;
+    if (days === 0) return line("is-new", "今晨简报记录时还没有这一条", "今日新增");
+    const capped = entry.age_capped === true;
+    return line("", `按简报记录日计，非日历日${capped ? "；记录始于文件最早一行，实际可能更久" : ""}`,
+                `连续 ${days} 天${capped ? "+" : ""}`);
+  }
+
   function renderRiskGuardrail() {
     const g = safe(DATA, "risk_guardrail") || {};
     const targets = [
@@ -2536,14 +2573,15 @@
     const breaches = g.breaches || [], stops = g.hard_stop_watch || [];
     const n = g.breach_count || 0;
     const ICON = {};
-    const row = (icon, sev, detail, action) =>
+    const row = (icon, sev, detail, action, age) =>
       `<div class="risk-alert ${sev || 'high'}">
          <span class="icon">${icon}</span>
          <div><strong>${detail || ''}</strong>${action ? `<div class="muted" style="font-size:var(--fs-xs);margin-top:2px">→ ${action}</div>` : ''}</div>
+         ${age || ''}
        </div>`;
     const rows = [
-      ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action) })),
-      ...stops.map(s => ({ icon: '', severity: s.severity || 'critical', detail: stripEmoji(s.detail), action: stripEmoji(s.action) })),
+      ...breaches.map(b => ({ icon: ICON[b.type] || '', severity: b.severity, detail: stripEmoji(b.detail), action: stripEmoji(b.action), age: guardrailAgeLabel(b) })),
+      ...stops.map(s => ({ icon: '', severity: s.severity || 'critical', detail: stripEmoji(s.detail), action: stripEmoji(s.action), age: guardrailAgeLabel(s) })),
     ];
     // 严重度排序（第八次迭代）：原来把 hard stop 一律降写成 high，再按
     // 「是不是 high」排 —— 同为 high 时排序稳定，于是 6 条 breach 永远排在
@@ -2572,7 +2610,7 @@
         ? stripEmoji(g.directive)
         : stripEmoji([g.directive, g.reentry_rule].filter(Boolean).join(' '));
       const visibleRows = compact ? compactRows.slice(0, 3) : rows;
-      const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action)).join('');
+      const html = visibleRows.map(r => row(r.icon, r.severity, r.detail, compact ? "" : r.action, compact ? "" : r.age)).join('');
       // 牌上只有三个槽位，9 条里剩下的 6 条原来是无声消失的（表头点阵是
       // 严重度密度，读不出「还有几条没列」）。补一行尾注说清被折叠的量。
       const hidden = compact ? Math.max(0, compactRows.length - visibleRows.length) : 0;
@@ -2581,6 +2619,23 @@
       listEl.innerHTML = (html && html + tail)
         || '<div class="muted" style="font-size:var(--fs-sm)">仓位/单因子/杠杆均在阈值内</div>';
     });
+
+    // 走势只上完整卡：overview 的紧凑卡只有三个槽位，再加一行会挤掉一条闸。
+    const trendEl = document.getElementById("guardrail-trend");
+    if (trendEl) {
+      const hist = (g.breach_history || []).filter(p => p && typeof p.count === "number");
+      const svg = guardrailTrendSVG(hist.map(p => p.count));
+      if (!svg) {
+        trendEl.hidden = true;
+        trendEl.innerHTML = "";
+      } else {
+        const first = hist[0], last = hist[hist.length - 1];
+        trendEl.hidden = false;
+        trendEl.innerHTML = `<span class="gt-trend-lbl">近 ${hist.length} 个记录日</span>${svg}`
+          + `<span class="gt-trend-val">${first.count} → ${last.count}</span>`
+          + `<span class="gt-trend-span">${escapeHtml(first.date)} 起</span>`;
+      }
+    }
   }
 
   function renderQuantSignals() {

--- a/site/index.html
+++ b/site/index.html
@@ -467,6 +467,7 @@ layout: null
 
     <div class="card lead" id="guardrail-card">
       <h3>仓位/杠杆硬闸 <span class="badge muted" id="guardrail-count"></span></h3>
+      <div class="gt-trend" id="guardrail-trend" hidden></div>
       <div class="muted" id="guardrail-directive" style="font-size:var(--fs-sm);margin-bottom:8px;line-height:1.5"></div>
       <div class="risk-alerts" id="guardrail-list"></div>
     </div>

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -613,6 +613,106 @@ def _guardrail_sections(portfolio, risk, lev_regime=None):
     return {'risk_guardrail': guardrail, 'breakeven_math': breakeven}
 
 
+GUARDRAIL_HISTORY_NAME = 'guardrail_history.jsonl'
+GUARDRAIL_HISTORY_DAYS = 30
+
+
+def load_guardrail_history(ws=None, limit=None):
+    """Every recorded guardrail verdict, oldest first (or the last `limit`).
+
+    Read whole by default: a breach's age must be measured against the whole
+    record, while only the tail is worth the payload budget. Coupling the two
+    would make every age read "30 天+" the moment the chart window filled.
+
+    `brief_preflight._append_guardrail_history` writes one row per brief and is
+    idempotent by date, so a row is a trading day rather than a calendar day —
+    weekends and holidays are absent, not zero. Callers must count rows, never
+    subtract dates.
+
+    Never raises: the risk card must still render when this file is missing (a
+    fresh clone has none) or when a line is torn mid-append.
+    """
+    path = Path(ws or WS_ROOT) / 'assets' / 'data' / GUARDRAIL_HISTORY_NAME
+    rows = []
+    try:
+        text = path.read_text(encoding='utf-8')
+    except (OSError, UnicodeDecodeError):
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict) and isinstance(row.get('date'), str):
+            rows.append(row)
+    rows.sort(key=lambda r: r['date'])
+    return rows[-limit:] if limit else rows
+
+
+def _breach_identity(row):
+    """What makes two breaches, recorded on different days, the same breach."""
+    if not isinstance(row, dict):
+        return None
+    return (row.get('type') or 'hard_stop', row.get('leg'), row.get('ticker'))
+
+
+def _consecutive_age(identity, history, key):
+    """How many of the newest consecutive recorded days carry `identity`.
+
+    Returns (days, capped). `capped` says the streak reaches the oldest row on
+    record, so the true age is at least this — the file starts 2026-07-15 and
+    nothing before it can be reconstructed. Rendering ">= 34" as "34" would be
+    the card asserting a number it does not have.
+    """
+    days = 0
+    for row in reversed(history):
+        present = any(_breach_identity(r) == identity for r in (row.get(key) or []))
+        if not present:
+            break
+        days += 1
+    return days, bool(days) and days == len(history)
+
+
+def annotate_guardrail_history(guardrail, history):
+    """Give the risk card the two questions it could not answer (#1252).
+
+    Until now it rendered only the current `breaches` / `hard_stop_watch`, so it
+    answered "what is tripped right now" and nothing else. The data for the other
+    two was already being published — `guardrail_history.jsonl` has carried a
+    full daily row since 2026-07-15 — it just never reached the browser:
+
+      * trend — is the gate tightening or loosening? (34 recorded days run
+        12 -> 6, which the card could not show)
+      * age — how long has THIS breach been tripped?
+
+    An age of 0 is meaningful and kept: the breach is live now but was not in
+    the newest recorded row, i.e. it appeared after this morning's brief.
+    Mutates `guardrail` in place and returns it. Never raises.
+    """
+    if not isinstance(guardrail, dict) or guardrail.get('computed') is False:
+        return guardrail
+    try:
+        guardrail['breach_history'] = [
+            {'date': row['date'], 'count': row.get('breach_count')}
+            for row in history if isinstance(row.get('breach_count'), int)
+        ][-GUARDRAIL_HISTORY_DAYS:]
+        for key in ('breaches', 'hard_stop_watch'):
+            for entry in (guardrail.get(key) or []):
+                if not isinstance(entry, dict):
+                    continue
+                days, capped = _consecutive_age(
+                    _breach_identity(entry), history, key)
+                entry['age_days'] = days
+                if capped:
+                    entry['age_capped'] = True
+    except Exception as e:  # a decoration must not be able to fail a publish
+        print(f'  warn: guardrail history annotate failed: {e}', file=sys.stderr)
+    return guardrail
+
+
 def compute_guardrail_outputs(portfolio, risk, lev_regime=None):
     """Compute the two live risk cards without ever failing the dashboard build.
 
@@ -3294,6 +3394,10 @@ _FINGERPRINT_EXTRA_DATA_PLANE = (
     'workflow-outcomes.json',
     't0_setups.json',
     't0_setup_review.json',
+    # Read by `annotate_guardrail_history`. `brief_preflight` appends to it in
+    # the same run that then rebuilds the dashboard, so a fingerprint that
+    # could not see it would let --skip-if-unchanged publish yesterday's trend.
+    GUARDRAIL_HISTORY_NAME,
 )
 
 FINGERPRINT_FILES = (
@@ -3673,6 +3777,7 @@ def build_projection(previous_source=None, shadow_previous=None):
 
     out.update(compute_guardrail_outputs(
         portfolio, out.get('risk') or {}, lev_regime=lev_regime))
+    annotate_guardrail_history(out.get('risk_guardrail'), load_guardrail_history())
 
     # Embed GH Action outputs into dashboard.json so the static page can render them
     def _embed(key, fname):

--- a/tests/test_dashboard_input_fingerprint.py
+++ b/tests/test_dashboard_input_fingerprint.py
@@ -140,8 +140,10 @@ def test_fingerprint_covers_every_data_plane_file_the_build_reads(monkeypatch):
 
     read = _data_plane_reads(monkeypatch)
     assert read, 'the instrumented projection recorded no data-plane read at all'
+    # .jsonl too: the gate was `.json` only, so `guardrail_history.jsonl` could
+    # have been wired into the projection (#1252) without this noticing.
     uncovered = {name for name in read
-                 if name.endswith('.json')} - covered - outputs
+                 if name.endswith(('.json', '.jsonl'))} - covered - outputs
     assert not uncovered, (
         f'the projection reads {sorted(uncovered)} and the fingerprint cannot '
         f'see them: --skip-if-unchanged would keep publishing a stale embed of '

--- a/tests/test_guardrail_history_projection.py
+++ b/tests/test_guardrail_history_projection.py
@@ -1,0 +1,192 @@
+"""The risk card's two time axes: how long a breach has been tripped, and
+whether the gate is tightening or easing (#1252).
+
+`brief_preflight._append_guardrail_history` has written one row per brief to
+`assets/data/guardrail_history.jsonl` since 2026-07-15, and README leans on it
+for the 风控纪律 claim — but nothing read it. Not the dashboard, not the plugin:
+a grep for `guardrail_history` across `site/` and `examples/` returned nothing.
+So the card could answer "what is tripped right now" and neither "how long" nor
+"is this getting better", while the data for both was already published.
+
+These tests pin the two things that are easy to get wrong here:
+  * a row is a TRADING day, not a calendar day — the file has no weekend rows,
+    so an age must count rows and never subtract dates;
+  * an age that runs off the start of the record is a lower bound, and saying
+    "33" when the truth is ">= 33" is the card asserting a number it has not got.
+"""
+import json
+
+import pytest
+
+from clawock.publish import dashboard
+
+
+def _write(ws, rows):
+    data = ws / 'assets' / 'data'
+    data.mkdir(parents=True, exist_ok=True)
+    (data / dashboard.GUARDRAIL_HISTORY_NAME).write_text(
+        ''.join(json.dumps(r, ensure_ascii=False) + '\n' for r in rows),
+        encoding='utf-8')
+    return ws
+
+
+def _row(date, breaches=(), stops=()):
+    return {
+        'date': date,
+        'breach_count': len(breaches) + len(stops),
+        'breaches': [dict(b) for b in breaches],
+        'hard_stop_watch': [dict(s) for s in stops],
+    }
+
+
+LEV_HK = {'type': 'leveraged_exposure', 'leg': 'HK', 'ticker': None}
+NAME_US = {'type': 'single_name', 'leg': 'US', 'ticker': 'SPCH'}
+STOP_HK = {'ticker': '07226', 'leg': 'HK'}
+
+
+def test_history_is_read_oldest_first_and_survives_a_torn_line(tmp_path):
+    ws = _write(tmp_path, [_row('2026-08-03'), _row('2026-08-01')])
+    (ws / 'assets' / 'data' / dashboard.GUARDRAIL_HISTORY_NAME).open('a').write(
+        '{"date": "2026-08-04"\n')       # an append killed mid-write
+    rows = dashboard.load_guardrail_history(ws)
+    assert [r['date'] for r in rows] == ['2026-08-01', '2026-08-03']
+
+
+def test_a_missing_history_is_not_an_error(tmp_path):
+    """A fresh clone has none, and the card still has to render."""
+    assert dashboard.load_guardrail_history(tmp_path) == []
+
+
+def test_age_counts_recorded_rows_not_calendar_days(tmp_path):
+    """Fri -> Mon is two rows and must read 2, not 4.
+
+    The file has no weekend rows because there is no brief on a weekend, so any
+    implementation that subtracted the two dates would inflate every age by the
+    weekends it spans.
+    """
+    ws = _write(tmp_path, [
+        _row('2026-08-28', [LEV_HK]),    # Friday
+        _row('2026-08-31', [LEV_HK]),    # Monday
+    ])
+    guardrail = {'breaches': [dict(LEV_HK, severity='high', detail='x')]}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    assert guardrail['breaches'][0]['age_days'] == 2
+
+
+def test_a_streak_only_counts_back_to_the_first_gap(tmp_path):
+    ws = _write(tmp_path, [
+        _row('2026-08-25', [LEV_HK]),
+        _row('2026-08-26', []),          # cleared for a day
+        _row('2026-08-27', [LEV_HK]),
+        _row('2026-08-28', [LEV_HK]),
+    ])
+    guardrail = {'breaches': [dict(LEV_HK, severity='high', detail='x')]}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    assert guardrail['breaches'][0]['age_days'] == 2, 'the gap must end the streak'
+    assert 'age_capped' not in guardrail['breaches'][0]
+
+
+def test_an_age_that_runs_off_the_record_is_marked_as_a_lower_bound(tmp_path):
+    ws = _write(tmp_path, [_row('2026-08-27', [LEV_HK]), _row('2026-08-28', [LEV_HK])])
+    guardrail = {'breaches': [dict(LEV_HK, severity='high', detail='x')]}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    breach = guardrail['breaches'][0]
+    assert (breach['age_days'], breach['age_capped']) == (2, True), (
+        'the streak reaches the oldest row on record, so 2 is a floor and the '
+        'card must render it as "2 天+"')
+
+
+def test_a_breach_that_appeared_after_the_brief_reads_zero_not_missing(tmp_path):
+    """0 is a real answer — "new since this morning" — and must survive."""
+    ws = _write(tmp_path, [_row('2026-08-28', [LEV_HK])])
+    guardrail = {'breaches': [dict(NAME_US, severity='high', detail='x')]}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    assert guardrail['breaches'][0]['age_days'] == 0
+
+
+def test_identity_separates_two_breaches_of_the_same_type(tmp_path):
+    """HK and US leveraged exposure are two gates, not one that moved legs."""
+    lev_us = {'type': 'leveraged_exposure', 'leg': 'US', 'ticker': None}
+    ws = _write(tmp_path, [
+        _row('2026-08-27', [LEV_HK]),
+        _row('2026-08-28', [LEV_HK, lev_us]),
+    ])
+    guardrail = {'breaches': [dict(LEV_HK, severity='high', detail='x'),
+                              dict(lev_us, severity='high', detail='y')]}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    assert [b['age_days'] for b in guardrail['breaches']] == [2, 1]
+
+
+def test_hard_stops_are_aged_against_their_own_list(tmp_path):
+    """A stop and a breach can share a ticker; they are not the same gate."""
+    ws = _write(tmp_path, [
+        _row('2026-08-27', [], [STOP_HK]),
+        _row('2026-08-28', [], [STOP_HK]),
+    ])
+    guardrail = {
+        'breaches': [dict(LEV_HK, severity='high', detail='x')],
+        'hard_stop_watch': [dict(STOP_HK, severity='critical', detail='y')],
+    }
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(ws))
+    assert guardrail['breaches'][0]['age_days'] == 0
+    assert guardrail['hard_stop_watch'][0]['age_days'] == 2
+
+
+def test_the_published_series_is_capped_but_the_age_is_not(tmp_path):
+    """The chart window and the measurement window are deliberately different.
+
+    Ages read from the whole record; only the tail is worth payload. Capping
+    both would make every age read "30 天+" the moment the chart window filled.
+    """
+    days = dashboard.GUARDRAIL_HISTORY_DAYS
+    rows = [_row(f'2026-{7 + (i // 28):02d}-{1 + (i % 28):02d}', [LEV_HK])
+            for i in range(days + 12)]
+    ws = _write(tmp_path, rows)
+    guardrail = {'breaches': [dict(LEV_HK, severity='high', detail='x')]}
+    history = dashboard.load_guardrail_history(ws)
+    assert len(history) == days + 12, 'the loader must not cap by default'
+    dashboard.annotate_guardrail_history(guardrail, history)
+    assert len(guardrail['breach_history']) == days
+    assert guardrail['breaches'][0]['age_days'] == days + 12
+
+
+def test_a_failed_compute_is_left_alone(tmp_path):
+    """The card distinguishes "no breaches" from "could not compute" (#…);
+    decorating the failure case would put a trend on an all-clear it never made."""
+    guardrail = {'computed': False, 'error': 'boom'}
+    dashboard.annotate_guardrail_history(
+        guardrail, dashboard.load_guardrail_history(tmp_path))
+    assert 'breach_history' not in guardrail
+
+
+def test_the_history_is_fingerprinted(tmp_path):
+    """It is read by the build, so --skip-if-unchanged must be able to see it.
+
+    `brief_preflight` appends a row and then rebuilds the dashboard in the same
+    run, so a fingerprint blind to this file would publish yesterday's trend
+    (#1247 is the same class of bug from the other direction).
+    """
+    assert f'assets/data/{dashboard.GUARDRAIL_HISTORY_NAME}' in \
+        dashboard.FINGERPRINT_FILES
+
+    ws = _write(tmp_path, [_row('2026-08-28', [LEV_HK])])
+    (ws / 'memory').mkdir(exist_ok=True)
+    before = dashboard.dashboard_input_fingerprint(ws)
+    _write(ws, [_row('2026-08-28', [LEV_HK]), _row('2026-08-31', [LEV_HK])])
+    assert dashboard.dashboard_input_fingerprint(ws) != before
+
+
+@pytest.mark.parametrize('bad', ['not json', '[]', '{"no": "date"}'])
+def test_unusable_lines_are_skipped_rather_than_raising(tmp_path, bad):
+    data = tmp_path / 'assets' / 'data'
+    data.mkdir(parents=True)
+    (data / dashboard.GUARDRAIL_HISTORY_NAME).write_text(
+        bad + '\n' + json.dumps(_row('2026-08-28')) + '\n', encoding='utf-8')
+    assert [r['date'] for r in dashboard.load_guardrail_history(tmp_path)] \
+        == ['2026-08-28']


### PR DESCRIPTION
## 为什么是这一条

#1252（合并了 #1245/#1246/#1249/#1250/#1255）列了七项「展示盲点」。逐条对着 live 核过之后，**只有这一项是真的「已经在发、但从没有任何消费者」**：

| 声称缺失 | 复核 |
|---|---|
| 辩论/多空论据 | 已渲染 —— `decision_audit.json` → `debates` 18 行 → Reflect「辩论留痕」卡 (#1117) |
| Sharpe | 已渲染 —— `#risk-sharpe` 读 `combined.sharpe_30d` |
| 回撤深度 + 恢复 | 已渲染 —— `dashboard.render.js:4119-4139`，含恢复进度条 |
| 回本需求 | 已渲染 —— `#breakeven-card` 9 行 + 展开行 |
| 指数日内 sparkline | 数据不存在，管线未采集 |
| Sortino / Calmar | 全仓库 grep 零命中 |
| **风控闸历史 / 在闸时长** | **真的没有** ← 本 PR |

`grep -rn guardrail_history site/ examples/` 只返回写入方，一个消费者都没有。

## 改了什么

`brief_preflight._append_guardrail_history` 自 2026-07-15 起每份简报往 `assets/data/guardrail_history.jsonl` 写一行（`breach_count` + 完整 breach 列表），README 的「风控纪律」就靠它。但这张卡只答得了「现在触发了什么」，答不了它手上本来就有的两个问题：

- **闸在收敛还是在收紧** —— 34 个记录日是 12 → 6
- **这一条挂了多久** —— 07226 的止损 13 天，两条杠杆敞口比记录本身还早

两者现在都到浏览器：`breach_history` 序列（上限 30 点，约 1.1KB）+ 每条 breach / hard stop 的 `age_days`。

### 两件刻意没做的事

- **没有把「测龄窗口」和「作图窗口」绑在一起**。年龄按整份记录算，只发尾部 —— 绑在一起的话，图窗一填满，所有年龄就永远是「30 天+」。
- **没有把跑出记录起点的年龄当成确数印**。它带 `age_capped`，渲染成「33 天+」；文件从 2026-07-15 开始，之前的重建不出来，把一个下界印成确数就是卡片在断言它没有的数字。

### 一行 = 一个交易日

没有简报就没有行，所以年龄**数行、不减日期**：周五 → 周一是 2 不是 4。测试钉住了这一点、钉住了「中间断一天就断streak」、钉住了 `(type, leg, ticker)` 身份（HK 和 US 的 leveraged_exposure 是两道闸不是一道换了腿），以及 `age_days == 0` 的含义（今晨简报之后才出现，必须保留而不是当成缺失）。

### 指纹

`guardrail_history.jsonl` 进 `FINGERPRINT_FILES`：preflight 先追一行、同一轮再重建，指纹看不见它的话 `--skip-if-unchanged` 会发昨天的走势 —— 这是 #1247 的反向。而那条覆盖闸只看 `.json`，所以顺手让它也看 `.jsonl`。

### 顺手修的既有 bug

`.gt-tally` / `.gt-dot` 的选择器写死在 `.deck-card` 下，但 `renderRiskGuardrail` 把同一段 HTML 也渲到独立的 `#guardrail-card` 上 —— 在那里 `.gt-dot` 是没有尺寸的空 `<i>`，「N 项硬闸触发中」整个不可见。去掉作用域，值一个没动。

## 版面

时长标宽屏挂在行右端，`@media (max-width: 600px)` 才 wrap 到自己一行 —— 在 390px 上它会从正文抢走约 90px，而硬闸的 detail 本来就是全卡最长的一段。宽屏不能开 `flex-wrap`：正文列的 flex-basis 是 `auto`(=max-content)，一开 wrap，长 detail 会在收缩之前先把整行折掉，连左边那颗严重度圆点都被顶到自己一行。窄屏 wrap 之后圆点隐藏 —— 它和左侧 3px 色条编码的是同一件事。

走势那支 sparkline 刻意不复用 `sparklineSVG`：那支按「末值 > 首值 = 绿」着色，而这里极性是反的，闸触发得少是好事，12 → 6 必须读成收敛。`.gt-trend` 高度写死 18px（构图常量，不是数据点数的函数）。

已在 390px / 1280px、深色 / 浅色四种组合下用浏览器验过。

## 验收

`tests/test_guardrail_history_projection.py` 14 条新测试；`tests/test_dashboard_input_fingerprint.py` 的覆盖闸扩到 `.jsonl`。

Refs #1252