### PR TITLE
llm: gate every model output before it is published

### DIFF
--- a/src/clawock/automation/brief_fallback.py
+++ b/src/clawock/automation/brief_fallback.py
@@ -17,6 +17,7 @@ from datetime import date
 from pathlib import Path
 
 from clawock.automation.llm import chat
+from clawock.automation.output_validate import validate_sections
 from clawock.decision import ledger as decision_v2
 
 # Output budget for the single-turn brief. Thinking is enabled, and _call_provider
@@ -25,6 +26,11 @@ from clawock.decision import ledger as decision_v2
 # (~20K tokens) plus the trailing plan.json block, so this leaves roughly 4x headroom
 # and stays well under MiniMax M3's 131072 cap. See the call site for why 32000 failed.
 BRIEF_MAX_TOKENS = 96000
+
+# Structural anchors every SKILL.md brief carries, matched as substrings so the
+# model's own heading decoration does not fail a good brief.
+BRIEF_REQUIRED_SECTIONS = ('仓位明细', 'Retrospective', 'Tier 1', 'Tier 2',
+                           'Tier 3', 'Next-Session Plan')
 
 
 def split_brief_and_plan(out):
@@ -353,6 +359,14 @@ def main():
     errors = decision_v2.validate_plan(plan)
     if errors:
         raise SystemExit('plan.json v2 validation failed: ' + '; '.join(errors))
+    # The markdown half was never checked (#1262): a reply that carried a valid
+    # plan.json after an empty or stub brief published a blank pre-open.md, and
+    # the workflow's own skip gate keys on that file existing, so every later
+    # fallback that day self-skipped. Anchors are SKILL.md sections that survive
+    # the model's own heading style (`## ▎仓位明细 (HK)` matches `仓位明细`);
+    # the floor is ~1/10th of the real artifact (2026-07-16 ran 26KB).
+    validate_sections(md_part, label='brief markdown',
+                      required=BRIEF_REQUIRED_SECTIONS, min_chars=2000)
     Path(f'memory/{today}-pre-open.md').write_text(md_with_fm)
     Path(f'memory/{today}-plan.json').write_text(json.dumps(plan, ensure_ascii=False, indent=2))
     print(f'  wrote pre-open.md + plan.json ({len(plan.get("decisions", []))} decisions)')

--- a/src/clawock/automation/influencer.py
+++ b/src/clawock/automation/influencer.py
@@ -331,6 +331,7 @@ def llm_filter(candidates, held):
         print('  ⚠️ no LLM provider key — skipping relevance filter (keyword-only)', file=sys.stderr)
         return {}
     from clawock.automation.llm import chat
+    from clawock.automation.output_validate import coerce_scored_items
     held_lines = '\n'.join(f"  - {h['ticker']} ({h['name']}, {h['region']})" for h in held)
     cand_lines = '\n'.join(
         f"[{i}] ({c['author']}) {c['text']}" for i, c in enumerate(candidates)
@@ -351,11 +352,23 @@ def llm_filter(candidates, held):
             raw = chat(system=LLM_SYSTEM, user=user, max_tokens=8000,
                        temperature=0.3, json_response=True, thinking_disabled=True)
             data = json.loads(raw)
-            scored = {int(it['idx']): it for it in data.get('items', []) if 'idx' in it}
+            # Field-check before the caller sees it (#1257): stance/relevance
+            # reach the brief and the evidence graph, and a single non-int idx
+            # used to raise inside the comprehension and lose the whole batch.
+            scored = coerce_scored_items(data)
             if scored:
                 return scored
             print(f'  ⚠️ LLM returned 0 scored items for {len(candidates)} candidates '
                   f'(attempt {attempt}/2)', file=sys.stderr)
+        except RuntimeError as e:
+            # Both vendors already exhausted their retries and the chain
+            # deadline inside this one call (#1260) — attempt 2 would spend the
+            # same budget again against providers that just proved dead, and
+            # the 8-minute job has room for one such chain, not two. Retrying
+            # is for the empty-batch/bad-JSON case above, not a dead chain.
+            print(f'  ⚠️ LLM filter failed (attempt {attempt}/2): {e}', file=sys.stderr)
+            if str(e).startswith('all LLM providers failed'):
+                break
         except Exception as e:
             print(f'  ⚠️ LLM filter failed (attempt {attempt}/2): {e}', file=sys.stderr)
     return {}

--- a/src/clawock/automation/news_digest.py
+++ b/src/clawock/automation/news_digest.py
@@ -23,7 +23,13 @@ import requests
 
 from clawock import instruments as instrument_registry
 from clawock.automation.llm import chat
+from clawock.automation.output_validate import validate_sections
 from clawock.market_data.sentiment import fetch_google_news
+
+# Sections build_user_prompt demands, checked on the way out (#1264).
+# `移动信号`, not `Top`: a bare case-insensitive `top` also matches
+# "stop-loss", which would wave through a digest with no signals section.
+DIGEST_REQUIRED_SECTIONS = ('移动信号', 'Per-ticker')
 
 # Serialized-size budget for the raw-news JSON embedded in the prompt. The old
 # `json.dumps(raw)[:25000]` slice cut mid-string on busy days: a malformed JSON
@@ -266,6 +272,13 @@ def main():
 
     # News digest: short output but enable thinking helps prioritize signal vs noise
     digest = chat(system=system, user=user, max_tokens=32000, temperature=0.5)
+    # Refuse before the artifact is written (#1264): us_news_digest.json is
+    # read by the brief and by news_evidence_graph, both of which treat an
+    # empty digest_markdown as "no news" rather than "the model failed".
+    # 风险 watch is deliberately not required — the prompt makes it conditional
+    # ("若有"). The floor is ~1/3rd of a live digest (2026-09-01 ran 1,079).
+    validate_sections(digest, label='news digest',
+                      required=DIGEST_REQUIRED_SECTIONS, min_chars=300)
 
     _write_artifact(tickers, raw, source_status, digest=digest, held_via=held_via)
     print(f'  digest size: {len(digest)} chars')

--- a/src/clawock/automation/output_validate.py
+++ b/src/clawock/automation/output_validate.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Output-side gate for the four LLM call sites (#1265).
+
+`llm.chat()` is the transport: it retries, falls back between two vendors and
+strips fences. What it returns is still *whatever the model said* — a string.
+Every call site consumed that string directly, so a vendor that answers 200 with
+an empty body, prose instead of the requested markdown, or JSON whose fields are
+out of range published a blank/garbled artifact instead of failing.
+
+Two shapes, one rule — **an unusable output is refused, never published**:
+
+- `validate_sections()` for the three free-text markdown outputs (brief
+  fallback #1262, weekly review #1263, news digest #1264). It checks the two
+  things a wrong answer actually breaks: the output is not empty/stub-length,
+  and the sections the prompt demanded are present. It deliberately does not
+  grade prose — the model's judgment is the product there.
+- `coerce_scored_items()` for the one structured output (influencer #1257).
+  It is *coercing*, not fail-closed, because that call site's alternative to a
+  slightly-off item is no radar at all: a bad `idx` skips that one item instead
+  of raising out of the whole batch (today one non-int `idx` raises inside the
+  dict comprehension and loses every scored item), an unknown `stance` degrades
+  to `neutral`, an out-of-range `relevance` is clamped, and hallucinated keys
+  are dropped rather than shipped into `influencer.json`.
+
+Anchors are substrings, not exact headings: the fallback brief writes
+`## ▎仓位明细 (HK)` while the harness renders `## ▎仓位明细`, and the digest
+answers `## 风险 Watch` to a prompt that asked for `风险 watch`. Requiring exact
+titles would fail closed on good output, which is the expensive direction —
+`tests/test_llm_output_validate.py` pins each anchor set against a real
+committed artifact for exactly that reason.
+"""
+from __future__ import annotations
+
+import sys
+
+# influencer.py's LLM_SYSTEM defines this enum; anything else is the model
+# inventing a variant ("BULLISH", "positive"), which used to reach the brief
+# and the evidence graph as display text.
+INFLUENCER_STANCES = ('endorse', 'buy', 'attack', 'sell', 'neutral')
+# Exact key set the prompt asks for. Extra keys are model hallucination and
+# would ride into influencer.json (payload bloat, no consumer).
+INFLUENCER_ITEM_FIELDS = (
+    'idx', 'tickers', 'held', 'new_ideas', 'sectors', 'sector_holdings',
+    'stance', 'relevance', 'summary_cn',
+)
+INFLUENCER_LIST_FIELDS = ('tickers', 'held', 'new_ideas', 'sectors',
+                          'sector_holdings')
+
+
+class LLMOutputError(ValueError):
+    """A model reply that must not be published."""
+
+
+def validate_sections(text, *, label, required, min_chars):
+    """Return `text` unchanged, or raise `LLMOutputError`.
+
+    `required` is a sequence of substrings that must all appear (matched
+    case-insensitively so `Per-ticker`/`per-ticker` both pass). `min_chars`
+    guards the empty/stub reply — set it an order of magnitude below the real
+    artifact so a short-but-real answer is never refused.
+    """
+    body = (text or '').strip()
+    if not body:
+        raise LLMOutputError(f'{label}: model returned an empty reply')
+    if len(body) < min_chars:
+        raise LLMOutputError(
+            f'{label}: model returned {len(body)} chars, below the '
+            f'{min_chars}-char floor for a usable output')
+    lowered = body.lower()
+    missing = [anchor for anchor in required if anchor.lower() not in lowered]
+    if missing:
+        raise LLMOutputError(
+            f'{label}: missing required section(s): ' + ', '.join(missing))
+    return text
+
+
+def _clean_str_list(value):
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _clamp_relevance(value, report):
+    """0-100 per the prompt. Out of range is clamped (the field is a sort key,
+    so 150 silently outranks every honest 95); non-numeric becomes None, which
+    the caller already treats as "unscored"."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if value is not None:
+            report['relevance_dropped'] += 1
+        return None
+    clamped = max(0.0, min(100.0, float(value)))
+    if clamped != float(value):
+        report['relevance_clamped'] += 1
+    return int(clamped) if clamped == int(clamped) else clamped
+
+
+_DEFAULT_REPORT = object()
+
+
+def coerce_scored_items(data, *, report_to=_DEFAULT_REPORT):
+    """`{idx: item}` from a parsed `{"items":[...]}` reply, field-checked.
+
+    Never raises for item-level damage: a malformed item is skipped and
+    counted. Raises `LLMOutputError` only when the top-level shape is wrong
+    (not an object, or `items` is not a list), which is a parse-level failure
+    the caller already retries.
+    """
+    if not isinstance(data, dict):
+        raise LLMOutputError(f'expected a JSON object, got {type(data).__name__}')
+    items = data.get('items', [])
+    if not isinstance(items, list):
+        raise LLMOutputError(f'"items" must be a list, got {type(items).__name__}')
+
+    report = {'bad_idx': 0, 'unknown_stance': 0, 'relevance_clamped': 0,
+              'relevance_dropped': 0, 'extra_fields': 0, 'duplicate_idx': 0}
+    scored = {}
+    for raw in items:
+        if not isinstance(raw, dict):
+            report['bad_idx'] += 1
+            continue
+        try:
+            idx = int(raw['idx'])
+        except (KeyError, TypeError, ValueError):
+            report['bad_idx'] += 1
+            continue
+        if any(key not in INFLUENCER_ITEM_FIELDS for key in raw):
+            report['extra_fields'] += 1
+        stance = str(raw.get('stance', 'neutral') or 'neutral').strip().lower()
+        if stance not in INFLUENCER_STANCES:
+            report['unknown_stance'] += 1
+            stance = 'neutral'
+        item = {'idx': idx, 'stance': stance,
+                'relevance': _clamp_relevance(raw.get('relevance'), report),
+                'summary_cn': str(raw.get('summary_cn', '') or '').strip()}
+        for field in INFLUENCER_LIST_FIELDS:
+            item[field] = _clean_str_list(raw.get(field))
+        if idx in scored:
+            report['duplicate_idx'] += 1
+        scored[idx] = item
+
+    if report_to is _DEFAULT_REPORT:
+        # Resolved per call, not bound at import: a default of `sys.stderr`
+        # captures the real stream before pytest's capsys swaps it out.
+        report_to = sys.stderr
+    if report_to is not None:
+        problems = {k: v for k, v in report.items() if v}
+        if problems:
+            print('  ⚠️ LLM output coerced: '
+                  + ', '.join(f'{k}={v}' for k, v in sorted(problems.items())),
+                  file=report_to)
+    return scored

--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -17,7 +17,11 @@ from datetime import date, timedelta
 from pathlib import Path
 
 from clawock.automation.llm import chat
+from clawock.automation.output_validate import validate_sections
 from clawock.decision import ledger as decision_v2
+
+# The four questions build_user_prompt asks for, checked on the way out (#1263).
+WEEKLY_REQUIRED_SECTIONS = ('本周净值', '决策兑现', '风险演变', '下周关注')
 
 # Prompt budget for the single-turn weekly review, measured in serialized-JSON
 # characters. A sanity bound, not a writing target: the old prompt embedded
@@ -386,6 +390,12 @@ def main():
 
     # Weekly review benefits most from thinking + depth (1 turn, complex synthesis)
     out = chat(system=system, user=user, max_tokens=32000, temperature=0.6)
+    # Refuse before writing (#1263): a blank or off-prompt reply used to be
+    # published as that week's review, and nothing downstream re-reads it.
+    # Anchors are the four questions build_user_prompt asks for; the floor is
+    # ~1/10th of a real review (2026-W34 is 11KB).
+    validate_sections(out, label='weekly review',
+                      required=WEEKLY_REQUIRED_SECTIONS, min_chars=1000)
 
     os.makedirs('memory/weekly', exist_ok=True)
     path = Path(f'memory/weekly/{week_id}.md')

--- a/src/clawock/evidence/news_evidence_graph.py
+++ b/src/clawock/evidence/news_evidence_graph.py
@@ -16,6 +16,7 @@ import json
 import math
 import re
 import statistics
+import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -335,6 +336,10 @@ def collect_em_events(policy, underlying):
     return events
 
 
+# Bullet-shaped lines only: headings and prose are legitimately skipped.
+_BULLET_RE = re.compile(r'\s*[-*\u2022]\s+\S')
+
+
 def collect_us_news_events(policy, underlying):
     payload = _load(US_NEWS)
     events = []
@@ -356,9 +361,17 @@ def collect_us_news_events(policy, underlying):
         return events
     # Legacy sidecars kept only an LLM digest. Preserve those bullets as weak,
     # explicitly non-primary nodes until the producer starts shipping evidence.
+    # #1258: the regex wants `- **TICKER**: text` exactly. Any drift the model
+    # produces (no bold, dash instead of colon, an emoji prefix) used to `continue`
+    # in silence, so a digest that dropped every event looked identical to a
+    # digest with no events. Count the bullets it could not read and say so —
+    # only bullet-shaped lines, since headings and prose are legitimately skipped.
+    unmatched = 0
     for line in str(payload.get('digest_markdown') or '').splitlines():
         match = re.match(r'\s*-\s+\*\*([^*]+)\*\*:\s*(.+)', line)
         if not match:
+            if _BULLET_RE.match(line):
+                unmatched += 1
             continue
         reported = match.group(1).split('/')[0].strip()
         ticker = underlying.get(reported, reported)
@@ -370,6 +383,10 @@ def collect_us_news_events(policy, underlying):
             published_at=payload.get('generated_at'),
             origin='llm_digest_legacy',
         ))
+    if unmatched:
+        print(f'  ⚠️ news digest: {unmatched} bullet line(s) did not match the '
+              f'`- **TICKER**: text` shape — {len(events)} legacy event(s) kept',
+              file=sys.stderr)
     return events
 
 

--- a/tests/test_llm_output_validate.py
+++ b/tests/test_llm_output_validate.py
@@ -1,0 +1,212 @@
+"""Output-side gate for the four LLM call sites (#1257/#1262/#1263/#1264/#1265).
+
+Two directions matter equally here:
+
+- a broken reply must be refused (that is the bug: an empty body, a stub, or
+  prose instead of the requested markdown was published verbatim);
+- a *real* reply must still pass. Anchors that are too strict fail closed on
+  good output, which costs a whole day's brief, so every anchor set is pinned
+  against a committed artifact of that kind rather than against a hand-written
+  sample: `memory/2026-07-16-pre-open.md` is the last brief the fallback
+  actually authored, and `memory/weekly/2026-W34.md` a real weekly review.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from clawock.automation import brief_fallback, news_digest, weekly_review
+from clawock.automation.output_validate import (
+    LLMOutputError,
+    coerce_scored_items,
+    validate_sections,
+)
+from clawock.workspace import workspace_root
+
+WS = workspace_root()
+
+
+def _read(relative):
+    path = WS / relative
+    if not path.exists():
+        pytest.skip(f'{relative} not present in this checkout')
+    return path.read_text()
+
+
+# ── markdown gate ────────────────────────────────────────────────────────────
+
+def test_empty_and_stub_replies_are_refused():
+    for body in ('', '   \n\n', None):
+        with pytest.raises(LLMOutputError, match='empty reply'):
+            validate_sections(body, label='x', required=('A',), min_chars=10)
+    with pytest.raises(LLMOutputError, match='below the'):
+        validate_sections('# A\n', label='x', required=('A',), min_chars=100)
+
+
+def test_missing_section_names_the_missing_ones():
+    body = 'x' * 200 + '\n## 本周净值\n'
+    with pytest.raises(LLMOutputError) as excinfo:
+        validate_sections(body, label='weekly review',
+                          required=weekly_review.WEEKLY_REQUIRED_SECTIONS,
+                          min_chars=100)
+    message = str(excinfo.value)
+    assert '决策兑现' in message and '风险演变' in message and '下周关注' in message
+    assert '本周净值' not in message
+
+
+def test_weak_anchor_does_not_wave_through_a_sectionless_digest():
+    # `Top` alone matched "stop-loss" anywhere in the prose.
+    body = 'stop-loss 与 laptop 的散文 ' * 40 + '\n## Per-ticker 简报\n'
+    with pytest.raises(LLMOutputError, match='移动信号'):
+        validate_sections(body, label='news digest',
+                          required=news_digest.DIGEST_REQUIRED_SECTIONS,
+                          min_chars=100)
+
+
+def test_anchor_match_is_case_insensitive_and_substring():
+    # The live digest answers `## 风险 Watch` to a prompt asking for `风险 watch`,
+    # and the fallback brief writes `## ▎仓位明细 (HK)` for `仓位明细`.
+    body = 'y' * 200 + '\n## ▎Per-TICKER 简报\n## Top 移动信号\n'
+    assert validate_sections(body, label='news digest',
+                             required=news_digest.DIGEST_REQUIRED_SECTIONS,
+                             min_chars=100) is body
+
+
+def test_real_committed_artifacts_pass_their_own_anchors():
+    """Regression guard against over-strict anchors — the expensive direction."""
+    brief = _read('memory/2026-07-16-pre-open.md')      # last fallback-authored brief
+    validate_sections(brief, label='brief markdown',
+                      required=brief_fallback.BRIEF_REQUIRED_SECTIONS,
+                      min_chars=2000)
+
+    review = _read('memory/weekly/2026-W34.md')
+    validate_sections(review, label='weekly review',
+                      required=weekly_review.WEEKLY_REQUIRED_SECTIONS,
+                      min_chars=1000)
+
+    digest_path = WS / 'assets' / 'data' / 'us_news_digest.json'
+    if digest_path.exists():
+        digest = (json.loads(digest_path.read_text()).get('digest_markdown') or '')
+        if digest.strip():                    # empty on a no-material-news day
+            validate_sections(digest, label='news digest',
+                              required=news_digest.DIGEST_REQUIRED_SECTIONS,
+                              min_chars=300)
+
+
+def test_call_sites_validate_before_they_write():
+    """The gate is worthless if it runs after the artifact is on disk (the
+    2026-07-16 lesson that put plan validation ahead of the write)."""
+    for module, write_marker in (
+        (brief_fallback, "Path(f'memory/{today}-pre-open.md').write_text"),
+        (weekly_review, 'path.write_text'),
+        (news_digest, '_write_artifact(tickers, raw, source_status, digest='),
+    ):
+        source = Path(module.__file__).read_text()
+        gate = source.index('validate_sections(')
+        # first write that follows the chat() call, not an earlier fail-closed one
+        after_chat = source.index('= chat(')
+        write = source.index(write_marker, after_chat)
+        assert gate < write, f'{module.__name__} writes before it validates'
+
+
+# ── influencer structured gate ───────────────────────────────────────────────
+
+def _item(**over):
+    base = {'idx': 0, 'tickers': ['PLTR'], 'held': ['PLTR'], 'new_ideas': [],
+            'sectors': ['AI'], 'sector_holdings': [], 'stance': 'endorse',
+            'relevance': 80, 'summary_cn': 'x'}
+    base.update(over)
+    return base
+
+
+def test_one_bad_idx_no_longer_loses_the_whole_batch():
+    """`{int(it['idx']): it for it in items}` raised on the first non-int idx,
+    and llm_filter's except turned that into `{}` — every scored item lost."""
+    scored = coerce_scored_items(
+        {'items': [_item(idx='not_a_number'), _item(idx=1), _item(idx=2)]},
+        report_to=None)
+    assert sorted(scored) == [1, 2]
+
+
+def test_unknown_stance_degrades_and_relevance_is_clamped():
+    scored = coerce_scored_items(
+        {'items': [_item(idx=1, stance='BULLISH', relevance=150),
+                   _item(idx=2, stance='Attack', relevance=-5),
+                   _item(idx=3, relevance='high')]},
+        report_to=None)
+    assert scored[1]['stance'] == 'neutral'     # not in the prompt's enum
+    assert scored[1]['relevance'] == 100        # was outranking every honest 95
+    assert scored[2]['stance'] == 'attack'      # case is not a violation
+    assert scored[2]['relevance'] == 0
+    assert scored[3]['relevance'] is None       # unscored, not 0
+
+
+def test_hallucinated_fields_do_not_reach_the_artifact():
+    scored = coerce_scored_items(
+        {'items': [_item(idx=1, hallucinated_field='x', nested={'a': 1})]},
+        report_to=None)
+    assert set(scored[1]) == {
+        'idx', 'tickers', 'held', 'new_ideas', 'sectors', 'sector_holdings',
+        'stance', 'relevance', 'summary_cn'}
+
+
+def test_top_level_shape_still_raises_so_the_caller_retries():
+    for payload in (['items'], {'items': 'nope'}):
+        with pytest.raises(LLMOutputError):
+            coerce_scored_items(payload, report_to=None)
+
+
+def test_coercion_problems_are_reported_not_silent(capsys):
+    coerce_scored_items({'items': [_item(idx='x'), _item(idx=1, stance='BULLISH')]})
+    err = capsys.readouterr().err
+    assert 'bad_idx=1' in err and 'unknown_stance=1' in err
+
+
+def test_influencer_does_not_retry_a_dead_provider_chain(monkeypatch):
+    """#1260: a second attempt spends the same chain budget against providers
+    that just reported total failure; the 8-minute job has room for one."""
+    from clawock.automation import influencer
+
+    calls = []
+
+    def _dead(**kwargs):
+        calls.append(1)
+        raise RuntimeError('all LLM providers failed: minimax[x] | opencode[y]')
+
+    monkeypatch.setenv('MINIMAX_API_KEY', 'k')
+    monkeypatch.setattr('clawock.automation.llm.chat', _dead)
+    assert influencer.llm_filter([{'author': 'Trump', 'text': 'hi'}], []) == {}
+    assert len(calls) == 1
+
+    calls.clear()
+
+    def _bad_json(**kwargs):
+        calls.append(1)
+        return 'not json'
+
+    monkeypatch.setattr('clawock.automation.llm.chat', _bad_json)
+    assert influencer.llm_filter([{'author': 'Trump', 'text': 'hi'}], []) == {}
+    assert len(calls) == 2, 'a parse failure is still worth one retry'
+
+
+# ── digest regex visibility (#1258) ──────────────────────────────────────────
+
+def test_unmatched_digest_bullets_are_counted(capsys, monkeypatch):
+    from clawock.evidence import news_evidence_graph as graph
+
+    payload = {'generated_at': '2026-09-01T00:00:00+00:00', 'digest_markdown': (
+        '## Top 移动信号\n'
+        '- **PLTR**: 合约落地\n'          # matches
+        '- PLTR: 没有 bold\n'             # drift the regex cannot read
+        '- **HOOD** - dash 不是 colon\n'  # ditto
+        '普通散文行\n'                     # not a bullet: legitimately skipped
+    )}
+    policy = graph.load_policy()          # before _load is stubbed: it uses it too
+    monkeypatch.setattr(graph, '_load', lambda *a, **k: payload)
+    events = graph.collect_us_news_events(policy, {})
+    assert len(events) == 1
+    err = capsys.readouterr().err
+    assert re.search(r'2 bullet line\(s\) did not match', err)


### PR DESCRIPTION
The four LLM call sites consumed `chat()`'s return value directly, so a vendor that answered 200 with an empty body, prose instead of the requested markdown, or JSON whose fields were out of range published a blank or garbled artifact instead of failing. New `automation/output_validate.py` holds the one gate they now share; each site's anchors live next to that site's prompt, because a prompt change is what makes an anchor wrong.

| site | before | now |
|---|---|---|
| `brief_fallback` (#1262) | only the trailing plan.json was validated | markdown must carry the SKILL sections and clear a length floor, checked **before** anything is written |
| `weekly_review` (#1263) | zero validation → `memory/weekly/*.md` | the four questions the prompt asks for must be present |
| `news_digest` (#1264) | zero validation → `us_news_digest.json` | signals + per-ticker sections required (`风险 watch` stays optional — the prompt makes it conditional) |
| `influencer` (#1257) | `{int(it['idx']): it …}` | per-item coercion: bad `idx` skipped not fatal, `stance` snapped to the prompt's enum, `relevance` clamped to 0-100, hallucinated keys dropped |

Why it is a sibling of `llm.py` and not inside it (#1265 asked for the latter): `llm.py` is transport — two wire protocols, retries, deadlines — and knows nothing about what any caller asked the model for.

**The failure direction that costs more.** Anchors are substrings, not exact headings: the fallback brief writes `## ▎仓位明细 (HK)` where the harness renders `## ▎仓位明细`, and the live digest answers `## 风险 Watch` to a prompt that asked for `风险 watch`. An over-strict anchor fails closed on good output and costs a whole day's brief, so every anchor set is pinned in tests against a real committed artifact of its kind (`memory/2026-07-16-pre-open.md` — the last brief the fallback actually authored; `memory/weekly/2026-W34.md`; the live digest).

Two adjacent findings from the same sweep:

- **#1258** — the legacy digest regex wants `- **TICKER**: text` exactly; any drift (no bold, dash for colon, emoji prefix) `continue`d in silence, so a digest that dropped every event looked identical to one with no events. Bullet-shaped lines it cannot read are now counted and reported.
- **#1260** asked for a module-level circuit breaker. Measured: it would be inert. Each call site is its own Actions job making exactly one `chat()` call, so the counter never survives to the next call, and the waste it guards is already bounded by `CLAWOCK_LLM_DEADLINE_SECONDS` (210/360/600/660s) — not the `TIMEOUT × MAX_RETRIES = 540s` the issue assumed. The one process that calls `chat()` twice is influencer's retry loop, and that part is fixed here: a chain that just reported total provider failure is not retried (the retry exists for the empty-batch and bad-JSON cases, and the 8-minute job has room for one chain, not two).

Closes #1257, closes #1258, closes #1262, closes #1263, closes #1264, closes #1265

https://claude.ai/code/session_01UiBMvFCnTnnsWnoirJSczt