### PR TITLE
theses: a thesis links to a decision only inside its own strategy_scope

### DIFF
--- a/src/clawock/decision/theses.py
+++ b/src/clawock/decision/theses.py
@@ -418,6 +418,25 @@ def evaluate_drift(old: dict | None, new: dict, *, now=None) -> dict:
     }
 
 
+def _links_to(doc: dict, decision: dict) -> bool:
+    """Does this thesis actually cover this decision?
+
+    Ticker alone is not the link (#1261). `strategy_scope` says which strategies
+    a thesis speaks for, so a `core_position` thesis attached to an `intraday_t`
+    decision is a cross-strategy false resolve: the dashboard would print
+    "thesis intact" beside a decision the thesis never made a claim about. A
+    decision with no `strategy_id` (legacy rows predate the field) still links on
+    ticker — there is nothing to contradict.
+    """
+    if doc.get("ticker") != decision.get("ticker"):
+        return False
+    strategy_id = decision.get("strategy_id")
+    scope = doc.get("strategy_scope")
+    if not strategy_id or not isinstance(scope, list) or not scope:
+        return True
+    return strategy_id in scope
+
+
 def resolve_decision_links(decisions: list[dict], theses: list[dict]) -> list[dict]:
     """Add resolvable thesis metadata without mutating historical thesis_id."""
     by_id = {doc.get("thesis_id"): doc for doc in theses}
@@ -432,7 +451,7 @@ def resolve_decision_links(decisions: list[dict], theses: list[dict]) -> list[di
                 "schema_version": doc.get("schema_version"),
                 "state": doc.get("state"), "checked_at": doc.get("checked_at"),
             }
-            if doc and doc.get("ticker") == linked.get("ticker")
+            if doc and _links_to(doc, linked)
             else {
                 "status": "mismatch" if doc else "unknown",
                 "thesis_id": thesis_id,

--- a/tests/test_thesis_registry.py
+++ b/tests/test_thesis_registry.py
@@ -225,6 +225,24 @@ def test_decision_link_preserves_historical_thesis_id():
     )[0]["thesis_ref"] == {"status": "unknown", "thesis_id": "historic-id"}
 
 
+def test_decision_link_respects_strategy_scope():
+    """#1261: ticker alone linked a `core_position` thesis to an `intraday_t`
+    decision and printed "thesis intact" beside a decision it never covered."""
+    core = thesis()                      # strategy_scope == ["core_position"]
+    assert tr.resolve_decision_links(
+        [{"ticker": "TEST", "thesis_id": "test-core", "strategy_id": "core_position"}],
+        [core],
+    )[0]["thesis_ref"]["status"] == "resolved"
+    assert tr.resolve_decision_links(
+        [{"ticker": "TEST", "thesis_id": "test-core", "strategy_id": "intraday_t"}],
+        [core],
+    )[0]["thesis_ref"]["status"] == "mismatch"
+    # Legacy rows predate strategy_id; ticker still links them.
+    assert tr.resolve_decision_links(
+        [{"ticker": "TEST", "thesis_id": "test-core"}], [core],
+    )[0]["thesis_ref"]["status"] == "resolved"
+
+
 def test_registry_summary_marks_missing_ticker_unknown(tmp_path):
     (tmp_path / "TEST.json").write_text(json.dumps(thesis()))
     summary = tr.registry_summary(tmp_path, ["TEST", "MISSING"])


### PR DESCRIPTION
`resolve_decision_links` matched on ticker alone, so a thesis written for `core_position` resolved against an `intraday_t` decision on the same ticker and the brief's retrospective would print "thesis intact" beside a decision that thesis never made a claim about. `strategy_scope` was validated for shape at write time and then read by nobody.

```python
theses   = [{"thesis_id": "t", "ticker": "TEST", "strategy_scope": ["core_position"], ...}]
decisions = [{"thesis_id": "t", "ticker": "TEST", "strategy_id": "intraday_t"}]
resolve_decision_links(decisions, theses)[0]["thesis_ref"]["status"]
# before: "resolved"   after: "mismatch"
```

A decision with no `strategy_id` still links on ticker — legacy rows predate the field and there is nothing there to contradict; the existing link test covers that case unchanged.

Live impact today is zero: `memory/theses/` holds no documents, so every `thesis_ref` is `unknown`. That is the cheap moment to fix it — the first thesis written would otherwise inherit the wrong link silently.

The issue's second suggestion (enumerate `strategy_scope` values against `ledger.STRATEGIES` in `validate_thesis`) is deliberately not taken: it couples the thesis schema to the strategy table, and an unknown scope value now simply fails to link, which is the same fail-closed outcome without the coupling.

Closes #1261

https://claude.ai/code/session_01UiBMvFCnTnnsWnoirJSczt