### PR TITLE
weekly: the harness subtracts the week's NAV, the model attributes it

### DIFF
--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -126,6 +126,68 @@ def _snapshot_nav(snapshot, fx_rate):
     }
 
 
+def week_nav_change(nav_points):
+    """Start → end NAV for the week, computed once instead of in the prompt.
+
+    Question 1 of the weekly prompt is "总市值 USD-base 周初 vs 周末, 涨跌".
+    `nav_points` already carries a validated `total_nav_usd` per day, so the
+    subtraction was the one piece of arithmetic still left to the model — and a
+    model that mis-subtracts publishes a wrong headline number that nothing
+    downstream re-checks.
+
+    Named `nav_change`, not P&L, deliberately: this is end-of-week NAV minus
+    start-of-week NAV, so any deposit, withdrawal or inter-leg transfer inside
+    the window sits in it. The prompt says so; attribution stays the model's job,
+    where knowing whether a move came from a trade or from the market is the
+    judgment being asked for.
+
+    Returns None when there are not two dated points — `validate_bundle`
+    already refuses that bundle, so this never quietly reports a zero week.
+    """
+    if not isinstance(nav_points, list) or len(nav_points) < 2:
+        return None
+    first, last = nav_points[0], nav_points[-1]
+    if not (isinstance(first, dict) and isinstance(last, dict)):
+        return None
+    start = first.get('total_nav_usd')
+    end = last.get('total_nav_usd')
+    if not all(isinstance(v, (int, float)) and not isinstance(v, bool)
+               and math.isfinite(v) for v in (start, end)):
+        return None
+    change = end - start
+    legs = {}
+    for name, value_key, cash_key in (
+            ('us_usd', 'us_value_usd', 'us_cash_usd'),
+            ('hk_hkd', 'hk_value_hkd', 'hk_cash_hkd')):
+        leg_start = _leg_total(first, value_key, cash_key)
+        leg_end = _leg_total(last, value_key, cash_key)
+        if leg_start is None or leg_end is None:
+            continue
+        legs[name] = {
+            'start': round(leg_start, 2), 'end': round(leg_end, 2),
+            'change': round(leg_end - leg_start, 2),
+            'change_pct': (round((leg_end - leg_start) / leg_start * 100, 2)
+                           if leg_start else None),
+        }
+    return {
+        'start_date': first.get('date'), 'end_date': last.get('date'),
+        'start_total_nav_usd': round(start, 2),
+        'end_total_nav_usd': round(end, 2),
+        'change_usd': round(change, 2),
+        'change_pct': round(change / start * 100, 2) if start else None,
+        'legs': legs,
+        'basis': 'NAV end-minus-start; includes any capital flows in the window',
+    }
+
+
+def _leg_total(point, value_key, cash_key):
+    value, cash = point.get(value_key), point.get(cash_key)
+    if not all(isinstance(v, (int, float)) and not isinstance(v, bool)
+               and math.isfinite(v) for v in (value, cash)):
+        return None
+    return value + cash
+
+
 def _nearest_plan_fx(snapshot_date, plan_fx):
     if snapshot_date in plan_fx:
         return plan_fx[snapshot_date]
@@ -220,6 +282,7 @@ def aggregate_week(today=None):
         'plan_decisions': plan_decisions,
         'decision_episodes': len(decision_episodes),
         'nav_points': nav_points[-7:],
+        'nav_change': week_nav_change(nav_points[-7:]),
     }
     return {
         'week': week_id,
@@ -365,9 +428,9 @@ def build_user_prompt(payload):
         f"根据这一周（{payload['week']}）的 brief / plan / decision v2 / risk 数据, "
         f"写一篇 markdown 周复盘。长度自己判断，不设字数目标。"
         "\n\n"
-        "重点回答 4 个问题:\n"
-        "1. **本周净值**: 总市值 USD-base 周初 vs 周末, "
-        "涨跌 + 主要贡献者 + 主要拖累\n"
+        "1. **本周净值**: 周初/周末/涨跌三个数 harness 已算好在 "
+        "`bundle_evidence.nav_change`（口径=期末减期初 NAV, 含期内任何出入金）——"
+        "直接引用, 不要自己再从 snapshots 相减; 你要写的是主要贡献者与主要拖累的归因\n"
         "2. **决策兑现**: 按 strategy episode 汇总触发、执行和 win/loss；不要把每日重复 call 当独立样本\n"
         "3. **风险演变**: 当前 risk.json 数值, β/Vol/Max DD/Sharpe 怎么走?\n"
         "4. **下周关注 3 条**: actionable (ticker + 触发条件 + 仓位影响)\n\n"

--- a/tests/test_weekly_review_bundle_gate.py
+++ b/tests/test_weekly_review_bundle_gate.py
@@ -80,6 +80,52 @@ def test_weekly_bundle_with_valid_minimum_inputs_passes(
     ]
 
 
+def test_week_nav_change_is_computed_not_asked_for(tmp_path, monkeypatch):
+    """#1266: the prompt asked the model to subtract week-open from week-close.
+
+    The subtraction is deterministic and nothing downstream re-checks the
+    number the model typed, so the harness does it once and the prompt quotes
+    it. FX differs across the two days on purpose: the HK leg must be converted
+    at each day's own rate, which is exactly the step a model gets wrong.
+    """
+    monkeypatch.chdir(tmp_path)
+    _stub_decisions(monkeypatch)
+    _write_json(tmp_path / 'memory/2026-07-20-plan.json', _plan('2026-07-20', fx=7.80))
+    _write_json(tmp_path / 'memory/2026-07-24-plan.json', _plan(
+        '2026-07-24', fx=7.84, decisions=[{'action': 'hold'}]))
+    _write_json(tmp_path / 'memory/snapshots/2026-07-20.json', _snapshot())
+    end = _snapshot()
+    end['portfolios']['us_stocks']['total_current_value'] = 900.0
+    _write_json(tmp_path / 'memory/snapshots/2026-07-24.json', end)
+    _write_json(tmp_path / 'assets/data/risk.json', {'combined': {'beta': 1.2}})
+
+    evidence = weekly.validate_bundle(weekly.aggregate_week(today=date(2026, 7, 26)))
+    change = evidence['nav_change']
+    start, finish = evidence['nav_points'][0], evidence['nav_points'][-1]
+
+    assert change['start_date'] == '2026-07-20' and change['end_date'] == '2026-07-24'
+    assert change['change_usd'] == round(
+        finish['total_nav_usd'] - start['total_nav_usd'], 2)
+    # The US leg lost 100 USD of value; the HK leg only moved because its rate did.
+    assert change['legs']['us_usd']['change'] == -100.0
+    assert change['legs']['hk_hkd']['change'] == 0.0
+    # NAV, not P&L — the label has to survive, a reader who takes it for P&L
+    # mis-reads any week with a deposit in it.
+    assert 'capital flows' in change['basis']
+
+    prompt = weekly.build_user_prompt(weekly.build_prompt_payload(
+        weekly.aggregate_week(today=date(2026, 7, 26))))
+    assert 'nav_change' in prompt
+
+
+def test_week_nav_change_is_none_rather_than_a_zero_week():
+    assert weekly.week_nav_change([]) is None
+    assert weekly.week_nav_change([{'date': 'x', 'total_nav_usd': 1.0}]) is None
+    assert weekly.week_nav_change(
+        [{'date': 'a', 'total_nav_usd': None}, {'date': 'b', 'total_nav_usd': 2.0}]
+    ) is None
+
+
 def test_weekly_nav_uses_boundary_and_nearest_fx_when_interior_fx_missing(
         tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
The one row of #1266 that survived measurement, done.

Question 1 of the weekly prompt is *"总市值 USD-base 周初 vs 周末, 涨跌"*. `bundle_evidence.nav_points` already carries a validated `total_nav_usd` per day (each leg converted at that day's own plan FX — the step a model most reliably gets wrong), so the only piece still left to the model was the subtraction, and nothing downstream re-checks the number it types.

Now precomputed as `bundle_evidence.nav_change`; the prompt quotes it and asks the model for the part that is actually judgment — which holdings drove the move, and whether it came from the market or from a trade.

Live bundle (2026-08-24 → 2026-09-01):

```json
{"start_total_nav_usd": 14331.81, "end_total_nav_usd": 14807.38,
 "change_usd": 475.57, "change_pct": 3.32,
 "legs": {"us_usd": {"change": 218.7, "change_pct": 6.22},
          "hk_hkd": {"change": 1985.2, "change_pct": 2.34}},
 "basis": "NAV end-minus-start; includes any capital flows in the window"}
```

Two decisions worth stating:

- **`nav_change`, not P&L**, with the basis carried in the payload. End-minus-start NAV contains any deposit or inter-leg transfer inside the window. Attribution needs a principal-adjusted basis and per-holding flows the weekly bundle does not have, so calling this P&L would replace a model's honest approximation with a harness-blessed wrong number.
- **`None` on fewer than two dated points**, never a zero week. `validate_bundle` already refuses such a bundle; a silent `0.00` would slip past a check that exists.

Per-holding contributors/detractors are deliberately *not* precomputed here: a naive value delta counts a buy as a gain, and that is the failure mode this change exists to avoid.

Refs #1266 (the rest of that issue is answered in its own thread)

https://claude.ai/code/session_01UiBMvFCnTnnsWnoirJSczt