### PR TITLE
health: 数据健康牌分成三条泳道，每条带一枚处置牌

### DIFF
--- a/site/assets/css/dashboard.css
+++ b/site/assets/css/dashboard.css
@@ -2552,8 +2552,13 @@
     margin: 6px 0 0; color: var(--text); font-size: var(--fs-lg);
     letter-spacing: -.01em; text-transform: none;
   }
-  .hero-health[data-tone="warn"] .hero-health-verdict { color: var(--warning); }
-  .hero-health[data-tone="bad"] .hero-health-verdict { color: var(--red); }
+  /* 判词分两截着色：「页面数字可用」印成红的是自相矛盾的 —— 可信度归
+     可信度那半句，告警归待办那半句。 */
+  .hero-health-verdict .dh-trust { color: var(--text); }
+  .hero-health-verdict .dh-trust[data-trust="broken"] { color: var(--red); }
+  .hero-health-verdict .dh-todo { color: var(--text-tertiary); }
+  .hero-health-verdict .dh-todo[data-sev="warn"] { color: var(--warning); }
+  .hero-health-verdict .dh-todo[data-sev="bad"] { color: var(--red); }
   .hero-health-meta {
     margin-top: 6px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.45 var(--mono);
   }
@@ -2567,13 +2572,84 @@
   @media (hover: hover) and (pointer: fine) {
     .dh-toggle:hover { color: var(--text); border-color: var(--text-tertiary); }
   }
+  /* ── 三条泳道 ────────────────────────────────────────────────────
+     名称 / 计数 / 形状 / 一句话 / 处置牌 —— 五列对齐，三行同栅格。
+     位置固定是整个改动的要点：读者不必每次重新找「新鲜度在哪一行」。
+     形状那列各画各的：数据面是逐面的期限用量条，投递是按档数成比例的
+     构成条，体检是计数点（它没有分母，画比例条等于编一个出来）。 */
+  .dh-lanes-shell {
+    margin-top: 14px; border-top: 1px solid var(--border-subtle);
+  }
+  /* 三行必须逐列对齐 —— 「位置固定」是这块牌唯一的记忆点。每条泳道各是
+     一个 grid 时列宽按各自内容解，三行的说明列就会各起各的 x（实测 体检
+     那行右移 37px）。用 subgrid 让三行吃 .dh-lanes 的同一套列；不支持
+     subgrid 的浏览器落到同一组定死的列宽，一样对得齐。 */
+  .dh-lanes {
+    display: grid; grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px;
+  }
+  .dh-lane {
+    display: grid; grid-column: 1 / -1; align-items: center;
+    gap: 10px 12px; padding: 9px 0;
+    grid-template-columns: 46px 150px 168px minmax(0, 1fr) 58px;
+    border-bottom: 1px solid var(--border-subtle);
+    font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
+  }
+  @supports (grid-template-columns: subgrid) {
+    .dh-lane { grid-template-columns: subgrid; }
+  }
+  .dh-lane:last-child { border-bottom: 0; }
+  .dh-lane-name {
+    color: var(--text-tertiary); font: 700 var(--fs-micro)/1.2 var(--mono);
+    letter-spacing: .08em; white-space: nowrap;
+  }
+  .dh-lane-stat { color: var(--text); font-weight: 700; white-space: nowrap; }
+  .dh-lane[data-tone="warn"] .dh-lane-stat { color: var(--warning); }
+  .dh-lane[data-tone="bad"] .dh-lane-stat { color: var(--red); }
+  .dh-lane-note {
+    color: var(--text-tertiary); min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  /* 处置牌：四种字面量各一色，含义写在卡片底部的说明行里。牌是文字不是
+     纯色点 —— 只靠颜色区分「要动手 / 只记不动」是拿色觉当说明书。 */
+  .dh-chip {
+    justify-self: end; padding: 3px 7px; border-radius: 6px; white-space: nowrap;
+    font: 700 var(--fs-micro)/1.2 var(--mono); letter-spacing: .04em;
+    color: var(--text-tertiary);
+    background: color-mix(in srgb, var(--text) 7%, transparent);
+  }
+  .dh-chip[data-act="需处理"] {
+    color: var(--red); background: color-mix(in srgb, var(--red) 14%, transparent);
+  }
+  .dh-chip[data-act="观察"] {
+    color: var(--warning); background: color-mix(in srgb, var(--warning) 15%, transparent);
+  }
+  .dh-chip[data-act="正常"] {
+    color: color-mix(in srgb, var(--accent) 88%, var(--text));
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+  /* 构成条：段宽按档数成比例，只画有数的段。 */
+  .dh-lane-shape { display: flex; align-items: center; gap: 3px; height: 18px; min-width: 0; }
+  .dh-part {
+    height: 7px; min-width: 3px; border-radius: 2px;
+    background: color-mix(in srgb, var(--accent) 82%, transparent);
+  }
+  .dh-part.is-warn { background: var(--warning); }
+  .dh-part.is-bad { background: var(--red); }
+  .dh-part.is-idle { background: color-mix(in srgb, var(--text) 16%, transparent); }
+  .dh-pip {
+    flex: 0 0 auto; width: 7px; height: 7px; border-radius: 2px;
+    background: color-mix(in srgb, var(--accent) 82%, transparent);
+  }
+  .dh-pip.is-warn { background: var(--warning); }
+  .dh-pip.is-bad { background: var(--red); }
+  /* 数据面那条带子搬进泳道，所以从 32px 高的独立块收成一列的高度。 */
   .dh-strip {
-    display: flex; align-items: flex-end; gap: 5px; margin-top: 14px; flex-wrap: wrap;
-    padding-bottom: 7px; border-bottom: 1px solid var(--border-subtle);
+    display: flex; align-items: flex-end; gap: 3px; flex-wrap: nowrap;
+    min-width: 0; overflow: hidden;
   }
   .dh-seg {
-    position: relative; flex: 0 0 auto; width: 13px; height: 32px;
-    border-radius: 3px; overflow: hidden;
+    position: relative; flex: 1 1 0; min-width: 3px; max-width: 9px; height: 18px;
+    border-radius: 2px; overflow: hidden;
     background: color-mix(in srgb, var(--text) 6%, transparent);
   }
   .dh-seg i {
@@ -2593,14 +2669,17 @@
   .bs-dot[data-tone="warn"] { background: var(--warning); }
   .bs-dot[data-tone="bad"] { background: var(--negative, var(--red)); }
   .dh-caption {
-    margin-top: 8px; color: var(--text-tertiary); font: 500 var(--fs-micro)/1.45 var(--mono);
+    margin-top: 10px; color: var(--text-faint, var(--text-tertiary));
+    font: 500 var(--fs-micro)/1.5 var(--mono);
   }
   .dh-seg.is-late i { background: var(--warning); }
   .dh-seg.is-missing i { background: var(--red); }
   .dh-files { margin-top: 14px; border-top: 1px solid var(--border-subtle); }
   .dh-row {
     display: grid; align-items: center; gap: 12px; padding: 8px 0;
-    grid-template-columns: minmax(76px, auto) minmax(0, 1fr) 84px minmax(0, 1.3fr) 34px;
+    /* 末列 34px 是照「在期 / 逾期 / 缺失」两个字量的，投递行写的是「TG 已兜」
+       四个字（实测 42px），一直在溢出容器。按最长的那个词定宽。 */
+    grid-template-columns: minmax(76px, auto) minmax(0, 1fr) 84px minmax(0, 1.3fr) 46px;
     border-bottom: 1px solid var(--border-subtle);
     font: 500 var(--fs-xs)/1.35 var(--mono); font-variant-numeric: tabular-nums;
   }
@@ -2611,8 +2690,16 @@
     font: 700 var(--fs-micro)/1.2 var(--mono); letter-spacing: .08em;
   }
   .dh-sub:first-child { padding-top: 4px; }
-  /* 投递行没有期限用量可画：空的灰槽会被读成「一根 0% 的条」。 */
-  .dh-row.is-delivery .dh-bar { background: none; }
+  /* 投递行 / 处置行没有期限用量可画：空的灰槽会被读成「一根 0% 的条」。 */
+  .dh-row.is-delivery .dh-bar, .dh-row.is-todo .dh-bar { background: none; }
+  /* 处置行的末列是「下一步去哪看」，不是一个状态词 —— 34px 装不下，
+     单独给它一套列宽，并且左侧留一道红边把待办从台账里挑出来。 */
+  .dh-row.is-todo {
+    grid-template-columns: minmax(76px, auto) minmax(0, 1fr) 0 minmax(0, 1.1fr) minmax(0, 1.2fr);
+    padding-left: 8px; border-left: 2px solid var(--red);
+  }
+  .dh-row.is-todo .dh-name { color: var(--red); }
+  .dh-row.is-todo .dh-state { color: var(--text-secondary); text-align: right; white-space: normal; }
   .dh-name { color: var(--text); font-weight: 700; white-space: nowrap; }
   .dh-file, .dh-detail {
     color: var(--text-tertiary); min-width: 0;
@@ -3191,6 +3278,22 @@
        也不要宽档跳一下。（去掉两格重复后是 3 行，不是原来的 4 行。） */
     /* 两列 × 两行 + 每格一件图形：293 = 360~600 全档数据态实测上界。 */
     .hero-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: 293px; }
+    /* 窄档泳道收成三带：名称+计数+处置牌一行，形状一行，说明一行。
+       五列硬塞进 360px 会把说明挤成一个省略号，那正是这次要修的病。
+       外层那套 46+150+168+58+1fr 的定死列宽也要一起塌 —— 泳道 span 的是
+       父栅格的轨道和，422px 的和会把处置牌顶到 390px 屏幕外面去。 */
+    .dh-lanes { grid-template-columns: minmax(0, 1fr); }
+    .dh-lane {
+      grid-template-columns: auto minmax(0, 1fr) auto; gap: 6px 10px;
+      grid-template-areas: "name stat chip" "shape shape shape" "note note note";
+    }
+    .dh-lane-name { grid-area: name; }
+    .dh-lane-stat { grid-area: stat; }
+    .dh-lane-shape, .dh-strip { grid-area: shape; }
+    .dh-lane-note { grid-area: note; white-space: normal; }
+    .dh-chip { grid-area: chip; }
+    .dh-row.is-todo { grid-template-columns: minmax(0, 1fr) auto; }
+    .dh-row.is-todo .dh-state { grid-column: 1 / -1; text-align: left; }
     .dh-row {
       grid-template-columns: minmax(0, 1fr) auto; gap: 4px 10px; row-gap: 4px;
     }

--- a/site/assets/js/dashboard.hero.js
+++ b/site/assets/js/dashboard.hero.js
@@ -975,8 +975,13 @@
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 
-  // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，
-  // 触屏根本打不开。这里把它提到首屏，逐项可展开。(#876)
+  // 数据健康：一块牌上压着三个互不相干的问题 —— ①页面上的数字新不新鲜
+  // ②体检有没有报错 ③今天的成品有没有送出去。原来它们被压成「一行判词 +
+  // 一条灰 meta」：判词借的是当下最坏的那一条，另外两条的状态读不出来，
+  // 也读不出该不该动手（kcn 2026-09-01：「我也不知道该怎么看」）。
+  // 现在固定三条泳道 —— 位置不动，每条各带一枚处置牌。判词只回答第一个
+  // 问题：**一个任务没落地不等于页面上的数字是错的**，这两件事必须分开说，
+  // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
   function renderDataHealth() {
@@ -995,52 +1000,36 @@
     const wc = wf.counts || {};
     const files = (bs.files || []).slice();
     const late = files.filter(f => f.present === false || f.stale);
-    const degraded = (wc.recovered || 0) + (wc.degraded || 0);
-    // 「1 档成品恢复或降级」答不出是哪一档（kcn 2026-08-25：「如果有降级的应该
-    // 标注出来是哪个」）。台账 recent[] 里逐档带着 job/slot 与 final_product，
-    // 点名只是把已经在手的字段读出来。recent 有条数上限，点不满就说「等 N 档」，
-    // 不假装列全。
-    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
-                      failed: "FAILED" };
+    const missing = files.filter(f => f.present === false);
+    const failed = wc.failed || 0;
+    const soft = (wc.recovered || 0) + (wc.degraded || 0);
+    const okCount = wc.success || 0;
+    const pending = wc.pending || 0;
+    const slotTotal = okCount + soft + failed + pending;
+    const igErr = ig.error_count || 0;
+    const igWarn = ig.warn_count || 0;
+    const igTop = (ig.top || [])[0] || null;
+    const dropped = wf.wechat_dropped_slots || [];
+    const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+    // 窗口写不出来就不写 —— 「37 档」配一个猜出来的小时数比没有小时数更坏。
+    const winH = Number(wf.window_hours) > 0 ? Number(wf.window_hours) : null;
+
     // 点名读的是台账自己给的 degraded_slots（全窗口、有上限），不是 recent ——
     // recent 是尾巴不是集合，忙日里它一条降级都装不下（实测 16 条尾巴全是
     // 盘中盯盘，16:00 那次「恢复」早被挤出去了）。
+    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
+                      failed: "FAILED" };
     const jobsWith = (...states) => (wf.degraded_slots || [])
       .filter(r => states.includes((r || {}).status))
-      .map(r => `${r.job || "未具名任务"} ${SOFT_CN[r.status] || ""}`.trim());
-    const nameThem = (total, names) => {
-      if (!names.length) return "";
-      const head = names.slice(0, 2).join(" · ");
-      return total > names.slice(0, 2).length
-        ? `${head} 等 ${total} 档` : head;
+      .map(r => ({ job: r.job || "未具名任务", what: SOFT_CN[r.status] || r.status || "",
+                   slot: String(r.slot || "").slice(0, 16).replace("T", " ") }));
+    // 名单有上限，点不满就说「等 N 档」，不假装列全。
+    const nameThem = (total, rows) => {
+      if (!rows.length) return "";
+      const shown = rows.slice(0, 2);
+      const head = shown.map(r => `${r.job} ${r.what}`.trim()).join(" · ");
+      return total > shown.length ? `${head} 等 ${total} 档` : head;
     };
-
-    let tone = "ok", verdict = "全部数据面在期";
-    if ((wc.failed || 0) > 0) {
-      tone = "bad";
-      verdict = nameThem(wc.failed, jobsWith("failed")) || `成品流程 ${wc.failed} 档 FAILED`;
-    }
-    else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
-    else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
-    else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
-    else if (degraded) {
-      tone = "warn";
-      verdict = nameThem(degraded, jobsWith("recovered", "degraded"))
-        || `${degraded} 档成品恢复或降级`;
-    }
-    root.dataset.tone = tone;
-    if (verdictEl) verdictEl.textContent = verdict;
-    if (metaEl) {
-      const bits = [`${files.length} 个数据面`];
-      bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
-      if (degraded) bits.push(`${degraded} 档恢复或降级`);
-      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
-      // 窗口掉了几档」必须答得上来。它不改 tone —— 成品由 Telegram 兜住了。
-      if (wf.wechat_dropped_telegram_covered)
-        bits.push(`微信掉投 ${wf.wechat_dropped_telegram_covered} 档 · TG 已兜`);
-      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
-      metaEl.textContent = bits.join(" · ");
-    }
 
     // 期限用量：max_age 用 age/sla；scheduled_fire 只有到期时刻，用「离截止还有多久
     // ÷ 24h」表达，两者都只是粗略的紧张程度，精确判定始终以 f.stale 为准。
@@ -1074,15 +1063,114 @@
       return `${f.age_hours == null ? DASH : f.age_hours + "h"} / 期限 ${f.sla_hours}h`;
     };
 
+    // ── 三条泳道 ───────────────────────────────────────────────────────
+    // 处置牌只有四种，含义写在卡片底部那行说明里，不靠读者猜：
+    //   需处理 = 页面数字或成品真的受影响；观察 = 兜底已经生效，只记不动；
+    //   已知不修 = kcn 已经拍板不处理；正常 = 没有要说的。
+    const setLane = (key, tone, stat, note, chip) => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      if (lane) lane.dataset.tone = tone;
+      const statEl = document.getElementById(`dh-${key}-stat`);
+      const noteEl = document.getElementById(`dh-${key}-note`);
+      const chipEl = document.getElementById(`dh-${key}-chip`);
+      if (statEl) statEl.textContent = stat;
+      if (noteEl) noteEl.textContent = note;
+      if (chipEl) { chipEl.textContent = chip; chipEl.dataset.act = chip; }
+    };
+    // 构成条：只画有数的段，段宽按档数成比例 —— 「今天有多少比例是好的」
+    // 是一眼能读的形状，一串数字不是。
+    const drawBar = (id, parts) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const live = parts.filter(p => p.n > 0);
+      const total = live.reduce((a, p) => a + p.n, 0);
+      el.innerHTML = !total ? "" : live.map(p =>
+        `<i class="dh-part is-${p.k}" style="flex:${p.n}"`
+        + ` title="${escapeHtml(p.t)} ${p.n} 档"></i>`).join("");
+    };
+    // 体检没有分母（不存在「一共检查了 N 项」这个数），所以画计数点不画
+    // 构成条 —— 一根没有分母的比例条是编出来的。
+    const drawPips = (id, spec) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const out = [];
+      spec.forEach(([kind, n, title]) => {
+        for (let i = 0; i < Math.min(n, 10); i++) {
+          out.push(`<i class="dh-pip is-${kind}" title="${escapeHtml(title)}"></i>`);
+        }
+      });
+      el.innerHTML = out.join("");
+    };
+
+    const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
+    setLane("files",
+      missing.length ? "bad" : (late.length ? "warn" : "ok"),
+      `${files.length - late.length}/${files.length} 在期`,
+      late.length
+        ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")} —— 页面上这几块是旧数字`
+        : (tightest ? `最紧张 ${dataFileCn(tightest.name)}（${detailOf(tightest)}）` : ""),
+      late.length ? "需处理" : "正常");
+
+    setLane("integrity",
+      igErr ? "bad" : (igWarn ? "warn" : "ok"),
+      `${igErr} ERROR · ${igWarn} WARN`,
+      igTop ? String(igTop.msg || igTop.code || "") : "无异常",
+      igErr ? "需处理" : (igWarn ? "观察" : "正常"));
+    drawPips("dh-integrity-shape", igErr || igWarn
+      ? [["bad", igErr, "ERROR"], ["warn", igWarn, "WARN"]]
+      : [["ok", 1, "无异常"]]);
+
+    setLane("delivery",
+      failed ? "bad" : (soft ? "warn" : "ok"),
+      winH ? `${slotTotal} 档 / ${winH}h` : `${slotTotal} 档`,
+      failed
+        ? `${nameThem(failed, jobsWith("failed")) || `${failed} 档 FAILED`} —— 成品没落地`
+        : (soft
+            ? `${nameThem(soft, jobsWith("recovered", "degraded")) || `${soft} 档恢复或降级`} · 成品已送达`
+            : "全部按时送达"),
+      failed ? "需处理" : (soft ? "观察" : "正常"));
+    drawBar("dh-delivery-shape", [
+      { k: "ok", n: okCount, t: "成功" },
+      { k: "warn", n: soft, t: "恢复或降级" },
+      { k: "bad", n: failed, t: "FAILED" },
+      { k: "idle", n: pending, t: "进行中" },
+    ]);
+
+    // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
+    // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
+    // FAILED 不会 —— 它影响的是成品有没有送出去与有没有归档。两者混成
+    // 一句会让人要么过度紧张，要么把真的过期当成「又是那个失败的任务」。
+    const trustBroken = late.length || igErr;
+    const todoCount = (late.length ? 1 : 0) + (igErr ? 1 : 0) + (failed ? 1 : 0);
+    const watchCount = (igErr ? 0 : (igWarn ? 1 : 0)) + (failed ? 0 : (soft ? 1 : 0));
+    const tone = (trustBroken || failed) ? "bad" : ((igWarn || soft) ? "warn" : "ok");
+    const disposition = todoCount ? `${todoCount} 件要处理`
+      : (watchCount ? `${watchCount} 件观察中` : "无事可做");
+    const trustText = trustBroken
+      ? `页面数字存疑 · ${late.length ? `${late.length} 个数据面逾期` : `体检 ${igErr} 项 ERROR`}`
+      : "页面数字可用";
+    root.dataset.tone = tone;
+    if (verdictEl) {
+      // 两截分开着色：把「页面数字可用」印成红的（因为别处有个任务挂了）
+      // 正是这块牌以前最误导人的地方。
+      verdictEl.innerHTML =
+        `<span class="dh-trust" data-trust="${trustBroken ? "broken" : "ok"}">`
+        + `${escapeHtml(trustText)}</span> · `
+        + `<span class="dh-todo" data-sev="${todoCount ? "bad" : (watchCount ? "warn" : "ok")}">`
+        + `${escapeHtml(disposition)}</span>`;
+    }
+
+    if (metaEl) {
+      const bits = [];
+      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
+      // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
+      // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
+      if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
+      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      metaEl.textContent = bits.join(" · ");
+    }
+
     if (stripEl) {
-      const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
-      const caption = document.getElementById("dh-caption");
-      if (caption) {
-        caption.textContent = !files.length ? ""
-          : late.length
-            ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")}`
-            : `期限用量 · 越高越接近过期 · 最紧张的是${dataFileCn(tightest.name)}（${detailOf(tightest)}）`;
-      }
       stripEl.innerHTML = files.map(f => {
         const st = stateOf(f);
         const pctUsed = Math.round(usage(f) * 100);
@@ -1092,12 +1180,38 @@
       }).join("");
     }
 
+    const caption = document.getElementById("dh-caption");
+    if (caption) {
+      caption.textContent = "处置：需处理＝页面数字或成品真的受影响，要动手；"
+        + "观察＝兜底已生效、成品到了，只记不动；已知不修＝已拍板不处理。";
+    }
+
     if (filesEl) {
-      // 逐项里先摆投递：掉的是哪几档、几点的，只有这里答得出（表头那行只有
-      // 计数）。用同一套 dh-row 栅格，状态列写「TG 已兜」——它不是告警。
-      // 同理走 wechat_dropped_slots（全窗口）而不是 recent 里的通道位。
-      const dropped = wf.wechat_dropped_slots || [];
-      const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+      // 逐项第一组是「处置清单」：只列 需处理 的那几条，每条带下一步该去
+      // 哪看。剩下两组（投递掉投 / 数据面逐项）是台账，不是待办。
+      const todo = [];
+      late.forEach(f => todo.push({
+        name: dataFileCn(f.name), where: f.name, why: detailOf(f),
+        next: f.present === false ? "文件没生成，查它的生成任务" : "页面上这块是旧数字，查它的生成任务",
+      }));
+      (ig.top || []).filter(t => String(t.level || "").toUpperCase() === "ERROR").forEach(t => todo.push({
+        name: "体检", where: String(t.code || ""), why: String(t.msg || ""),
+        next: "看 assets/data/integrity_report.json",
+      }));
+      jobsWith("failed").forEach(r => todo.push({
+        name: r.job, where: r.slot, why: "成品未落地（final_product=failed）",
+        next: "看 workflow-outcomes.json 里这一槽的 stages",
+      }));
+      const todoRows = todo.length
+        ? `<div class="dh-sub">处置 · 需处理</div>`
+          + todo.map(t => `<div class="dh-row is-todo">`
+            + `<span class="dh-name">${escapeHtml(t.name)}</span>`
+            + `<span class="dh-file">${escapeHtml(t.where)}</span>`
+            + `<span class="dh-bar"></span>`
+            + `<span class="dh-detail">${escapeHtml(t.why)}</span>`
+            + `<span class="dh-state">${escapeHtml(t.next)}</span></div>`).join("")
+        : "";
+
       const unnamed = Math.max(0, droppedTotal - dropped.length);
       const deliveryRows = dropped.length
         ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
@@ -1115,9 +1229,9 @@
               + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
               + `<span class="dh-state"></span></div>`
             : "")
-          + `<div class="dh-sub">数据面</div>`
         : "";
-      filesEl.innerHTML = deliveryRows + files
+
+      filesEl.innerHTML = todoRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1144,7 +1258,6 @@
       });
     }
   }
-
   function flatHoldings() {
     const us = (safe(DATA, "holdings", "us") || []).map(h => ({ ...h, region: "us" }));
     const hk = (safe(DATA, "holdings", "hk") || []).map(h => ({ ...h, region: "hk" }));

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -966,8 +966,13 @@
       // 端点标记已移除（kcn 2026-08-24：spark 末端涨跌色圆点没用，去掉）。
   }
 
-  // 数据健康：原来只有页脚一条 29px 小条，逐文件明细全塞在 title 提示里，
-  // 触屏根本打不开。这里把它提到首屏，逐项可展开。(#876)
+  // 数据健康：一块牌上压着三个互不相干的问题 —— ①页面上的数字新不新鲜
+  // ②体检有没有报错 ③今天的成品有没有送出去。原来它们被压成「一行判词 +
+  // 一条灰 meta」：判词借的是当下最坏的那一条，另外两条的状态读不出来，
+  // 也读不出该不该动手（kcn 2026-09-01：「我也不知道该怎么看」）。
+  // 现在固定三条泳道 —— 位置不动，每条各带一枚处置牌。判词只回答第一个
+  // 问题：**一个任务没落地不等于页面上的数字是错的**，这两件事必须分开说，
+  // 否则「简报 FAILED」会把一屏可信的数字染成红的。
   // 判过期只认 f.stale —— files[] 有两种新鲜度模式（max_age 比 sla_hours，
   // scheduled_fire 比 deadline_at），自己再算一遍 age>sla 会造出一批假警报。
   function renderDataHealth() {
@@ -986,52 +991,36 @@
     const wc = wf.counts || {};
     const files = (bs.files || []).slice();
     const late = files.filter(f => f.present === false || f.stale);
-    const degraded = (wc.recovered || 0) + (wc.degraded || 0);
-    // 「1 档成品恢复或降级」答不出是哪一档（kcn 2026-08-25：「如果有降级的应该
-    // 标注出来是哪个」）。台账 recent[] 里逐档带着 job/slot 与 final_product，
-    // 点名只是把已经在手的字段读出来。recent 有条数上限，点不满就说「等 N 档」，
-    // 不假装列全。
-    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
-                      failed: "FAILED" };
+    const missing = files.filter(f => f.present === false);
+    const failed = wc.failed || 0;
+    const soft = (wc.recovered || 0) + (wc.degraded || 0);
+    const okCount = wc.success || 0;
+    const pending = wc.pending || 0;
+    const slotTotal = okCount + soft + failed + pending;
+    const igErr = ig.error_count || 0;
+    const igWarn = ig.warn_count || 0;
+    const igTop = (ig.top || [])[0] || null;
+    const dropped = wf.wechat_dropped_slots || [];
+    const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+    // 窗口写不出来就不写 —— 「37 档」配一个猜出来的小时数比没有小时数更坏。
+    const winH = Number(wf.window_hours) > 0 ? Number(wf.window_hours) : null;
+
     // 点名读的是台账自己给的 degraded_slots（全窗口、有上限），不是 recent ——
     // recent 是尾巴不是集合，忙日里它一条降级都装不下（实测 16 条尾巴全是
     // 盘中盯盘，16:00 那次「恢复」早被挤出去了）。
+    const SOFT_CN = { recovered: "恢复", degraded: "降级", artifact_only: "仅存档",
+                      failed: "FAILED" };
     const jobsWith = (...states) => (wf.degraded_slots || [])
       .filter(r => states.includes((r || {}).status))
-      .map(r => `${r.job || "未具名任务"} ${SOFT_CN[r.status] || ""}`.trim());
-    const nameThem = (total, names) => {
-      if (!names.length) return "";
-      const head = names.slice(0, 2).join(" · ");
-      return total > names.slice(0, 2).length
-        ? `${head} 等 ${total} 档` : head;
+      .map(r => ({ job: r.job || "未具名任务", what: SOFT_CN[r.status] || r.status || "",
+                   slot: String(r.slot || "").slice(0, 16).replace("T", " ") }));
+    // 名单有上限，点不满就说「等 N 档」，不假装列全。
+    const nameThem = (total, rows) => {
+      if (!rows.length) return "";
+      const shown = rows.slice(0, 2);
+      const head = shown.map(r => `${r.job} ${r.what}`.trim()).join(" · ");
+      return total > shown.length ? `${head} 等 ${total} 档` : head;
     };
-
-    let tone = "ok", verdict = "全部数据面在期";
-    if ((wc.failed || 0) > 0) {
-      tone = "bad";
-      verdict = nameThem(wc.failed, jobsWith("failed")) || `成品流程 ${wc.failed} 档 FAILED`;
-    }
-    else if ((ig.error_count || 0) > 0) { tone = "bad"; verdict = `体检 ${ig.error_count} 项 ERROR`; }
-    else if (late.length) { tone = "warn"; verdict = `${late.length} 个数据面逾期`; }
-    else if ((ig.warn_count || 0) > 0) { tone = "warn"; verdict = `体检 ${ig.warn_count} 项 WARN`; }
-    else if (degraded) {
-      tone = "warn";
-      verdict = nameThem(degraded, jobsWith("recovered", "degraded"))
-        || `${degraded} 档成品恢复或降级`;
-    }
-    root.dataset.tone = tone;
-    if (verdictEl) verdictEl.textContent = verdict;
-    if (metaEl) {
-      const bits = [`${files.length} 个数据面`];
-      bits.push(`体检 ${ig.error_count || 0} ERROR / ${ig.warn_count || 0} WARN`);
-      if (degraded) bits.push(`${degraded} 档恢复或降级`);
-      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
-      // 窗口掉了几档」必须答得上来。它不改 tone —— 成品由 Telegram 兜住了。
-      if (wf.wechat_dropped_telegram_covered)
-        bits.push(`微信掉投 ${wf.wechat_dropped_telegram_covered} 档 · TG 已兜`);
-      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
-      metaEl.textContent = bits.join(" · ");
-    }
 
     // 期限用量：max_age 用 age/sla；scheduled_fire 只有到期时刻，用「离截止还有多久
     // ÷ 24h」表达，两者都只是粗略的紧张程度，精确判定始终以 f.stale 为准。
@@ -1065,15 +1054,114 @@
       return `${f.age_hours == null ? DASH : f.age_hours + "h"} / 期限 ${f.sla_hours}h`;
     };
 
+    // ── 三条泳道 ───────────────────────────────────────────────────────
+    // 处置牌只有四种，含义写在卡片底部那行说明里，不靠读者猜：
+    //   需处理 = 页面数字或成品真的受影响；观察 = 兜底已经生效，只记不动；
+    //   已知不修 = kcn 已经拍板不处理；正常 = 没有要说的。
+    const setLane = (key, tone, stat, note, chip) => {
+      const lane = document.getElementById(`dh-lane-${key}`);
+      if (lane) lane.dataset.tone = tone;
+      const statEl = document.getElementById(`dh-${key}-stat`);
+      const noteEl = document.getElementById(`dh-${key}-note`);
+      const chipEl = document.getElementById(`dh-${key}-chip`);
+      if (statEl) statEl.textContent = stat;
+      if (noteEl) noteEl.textContent = note;
+      if (chipEl) { chipEl.textContent = chip; chipEl.dataset.act = chip; }
+    };
+    // 构成条：只画有数的段，段宽按档数成比例 —— 「今天有多少比例是好的」
+    // 是一眼能读的形状，一串数字不是。
+    const drawBar = (id, parts) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const live = parts.filter(p => p.n > 0);
+      const total = live.reduce((a, p) => a + p.n, 0);
+      el.innerHTML = !total ? "" : live.map(p =>
+        `<i class="dh-part is-${p.k}" style="flex:${p.n}"`
+        + ` title="${escapeHtml(p.t)} ${p.n} 档"></i>`).join("");
+    };
+    // 体检没有分母（不存在「一共检查了 N 项」这个数），所以画计数点不画
+    // 构成条 —— 一根没有分母的比例条是编出来的。
+    const drawPips = (id, spec) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const out = [];
+      spec.forEach(([kind, n, title]) => {
+        for (let i = 0; i < Math.min(n, 10); i++) {
+          out.push(`<i class="dh-pip is-${kind}" title="${escapeHtml(title)}"></i>`);
+        }
+      });
+      el.innerHTML = out.join("");
+    };
+
+    const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
+    setLane("files",
+      missing.length ? "bad" : (late.length ? "warn" : "ok"),
+      `${files.length - late.length}/${files.length} 在期`,
+      late.length
+        ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")} —— 页面上这几块是旧数字`
+        : (tightest ? `最紧张 ${dataFileCn(tightest.name)}（${detailOf(tightest)}）` : ""),
+      late.length ? "需处理" : "正常");
+
+    setLane("integrity",
+      igErr ? "bad" : (igWarn ? "warn" : "ok"),
+      `${igErr} ERROR · ${igWarn} WARN`,
+      igTop ? String(igTop.msg || igTop.code || "") : "无异常",
+      igErr ? "需处理" : (igWarn ? "观察" : "正常"));
+    drawPips("dh-integrity-shape", igErr || igWarn
+      ? [["bad", igErr, "ERROR"], ["warn", igWarn, "WARN"]]
+      : [["ok", 1, "无异常"]]);
+
+    setLane("delivery",
+      failed ? "bad" : (soft ? "warn" : "ok"),
+      winH ? `${slotTotal} 档 / ${winH}h` : `${slotTotal} 档`,
+      failed
+        ? `${nameThem(failed, jobsWith("failed")) || `${failed} 档 FAILED`} —— 成品没落地`
+        : (soft
+            ? `${nameThem(soft, jobsWith("recovered", "degraded")) || `${soft} 档恢复或降级`} · 成品已送达`
+            : "全部按时送达"),
+      failed ? "需处理" : (soft ? "观察" : "正常"));
+    drawBar("dh-delivery-shape", [
+      { k: "ok", n: okCount, t: "成功" },
+      { k: "warn", n: soft, t: "恢复或降级" },
+      { k: "bad", n: failed, t: "FAILED" },
+      { k: "idle", n: pending, t: "进行中" },
+    ]);
+
+    // ── 判词只回答一件事：页面上的数字能不能信 ─────────────────────────
+    // 数据面逾期 / 体检 ERROR 会让读者正在看的数字变旧或变错；一个任务
+    // FAILED 不会 —— 它影响的是成品有没有送出去与有没有归档。两者混成
+    // 一句会让人要么过度紧张，要么把真的过期当成「又是那个失败的任务」。
+    const trustBroken = late.length || igErr;
+    const todoCount = (late.length ? 1 : 0) + (igErr ? 1 : 0) + (failed ? 1 : 0);
+    const watchCount = (igErr ? 0 : (igWarn ? 1 : 0)) + (failed ? 0 : (soft ? 1 : 0));
+    const tone = (trustBroken || failed) ? "bad" : ((igWarn || soft) ? "warn" : "ok");
+    const disposition = todoCount ? `${todoCount} 件要处理`
+      : (watchCount ? `${watchCount} 件观察中` : "无事可做");
+    const trustText = trustBroken
+      ? `页面数字存疑 · ${late.length ? `${late.length} 个数据面逾期` : `体检 ${igErr} 项 ERROR`}`
+      : "页面数字可用";
+    root.dataset.tone = tone;
+    if (verdictEl) {
+      // 两截分开着色：把「页面数字可用」印成红的（因为别处有个任务挂了）
+      // 正是这块牌以前最误导人的地方。
+      verdictEl.innerHTML =
+        `<span class="dh-trust" data-trust="${trustBroken ? "broken" : "ok"}">`
+        + `${escapeHtml(trustText)}</span> · `
+        + `<span class="dh-todo" data-sev="${todoCount ? "bad" : (watchCount ? "warn" : "ok")}">`
+        + `${escapeHtml(disposition)}</span>`;
+    }
+
+    if (metaEl) {
+      const bits = [];
+      // 微信单通道掉投：上游 ret=-2，kcn 已定不修也不告警（#771），但「这一
+      // 窗口掉了几档」必须答得上来。它不改 tone，也不占泳道 —— 成品由
+      // Telegram 兜住了，它属于「已知不修」，位置就该在这条安静的行里。
+      if (droppedTotal) bits.push(`微信掉投 ${droppedTotal} 档 · TG 已兜 · 已知不修`);
+      if (bs.generated_at) bits.push(`构建 ${String(bs.generated_at).replace("T", " ").slice(0, 16)}`);
+      metaEl.textContent = bits.join(" · ");
+    }
+
     if (stripEl) {
-      const tightest = files.slice().sort((a, b) => usage(b) - usage(a))[0];
-      const caption = document.getElementById("dh-caption");
-      if (caption) {
-        caption.textContent = !files.length ? ""
-          : late.length
-            ? `逾期：${late.map(f => dataFileCn(f.name)).join("、")}`
-            : `期限用量 · 越高越接近过期 · 最紧张的是${dataFileCn(tightest.name)}（${detailOf(tightest)}）`;
-      }
       stripEl.innerHTML = files.map(f => {
         const st = stateOf(f);
         const pctUsed = Math.round(usage(f) * 100);
@@ -1083,12 +1171,38 @@
       }).join("");
     }
 
+    const caption = document.getElementById("dh-caption");
+    if (caption) {
+      caption.textContent = "处置：需处理＝页面数字或成品真的受影响，要动手；"
+        + "观察＝兜底已生效、成品到了，只记不动；已知不修＝已拍板不处理。";
+    }
+
     if (filesEl) {
-      // 逐项里先摆投递：掉的是哪几档、几点的，只有这里答得出（表头那行只有
-      // 计数）。用同一套 dh-row 栅格，状态列写「TG 已兜」——它不是告警。
-      // 同理走 wechat_dropped_slots（全窗口）而不是 recent 里的通道位。
-      const dropped = wf.wechat_dropped_slots || [];
-      const droppedTotal = wf.wechat_dropped_telegram_covered || dropped.length;
+      // 逐项第一组是「处置清单」：只列 需处理 的那几条，每条带下一步该去
+      // 哪看。剩下两组（投递掉投 / 数据面逐项）是台账，不是待办。
+      const todo = [];
+      late.forEach(f => todo.push({
+        name: dataFileCn(f.name), where: f.name, why: detailOf(f),
+        next: f.present === false ? "文件没生成，查它的生成任务" : "页面上这块是旧数字，查它的生成任务",
+      }));
+      (ig.top || []).filter(t => String(t.level || "").toUpperCase() === "ERROR").forEach(t => todo.push({
+        name: "体检", where: String(t.code || ""), why: String(t.msg || ""),
+        next: "看 assets/data/integrity_report.json",
+      }));
+      jobsWith("failed").forEach(r => todo.push({
+        name: r.job, where: r.slot, why: "成品未落地（final_product=failed）",
+        next: "看 workflow-outcomes.json 里这一槽的 stages",
+      }));
+      const todoRows = todo.length
+        ? `<div class="dh-sub">处置 · 需处理</div>`
+          + todo.map(t => `<div class="dh-row is-todo">`
+            + `<span class="dh-name">${escapeHtml(t.name)}</span>`
+            + `<span class="dh-file">${escapeHtml(t.where)}</span>`
+            + `<span class="dh-bar"></span>`
+            + `<span class="dh-detail">${escapeHtml(t.why)}</span>`
+            + `<span class="dh-state">${escapeHtml(t.next)}</span></div>`).join("")
+        : "";
+
       const unnamed = Math.max(0, droppedTotal - dropped.length);
       const deliveryRows = dropped.length
         ? `<div class="dh-sub">投递 · 微信掉投（上游 ret=-2，已知不修）</div>`
@@ -1106,9 +1220,9 @@
               + `<span class="dh-detail">更早的槽位见 workflow-outcomes.json</span>`
               + `<span class="dh-state"></span></div>`
             : "")
-          + `<div class="dh-sub">数据面</div>`
         : "";
-      filesEl.innerHTML = deliveryRows + files
+
+      filesEl.innerHTML = todoRows + deliveryRows + `<div class="dh-sub">数据面</div>` + files
         .slice()
         .sort((a, b) => usage(b) - usage(a))
         .map(f => {
@@ -1135,8 +1249,6 @@
       });
     }
   }
-
-
   function renderDelta() {
     const tbody = document.getElementById("delta-tbody");
     const d = safe(DATA, "delta");

--- a/site/index.html
+++ b/site/index.html
@@ -281,7 +281,34 @@ layout: null
           </div>
           <button class="dh-toggle" type="button" id="dh-toggle" aria-expanded="false" aria-controls="dh-files">逐项</button>
         </div>
-        <div class="dh-strip" id="dh-strip" role="img" aria-label="每个数据面的期限用量"></div>
+        <!-- 三条泳道，位置固定：读者每次都在同一个地方找同一件事。
+             ①数据面＝页面上的数字新不新鲜 ②体检＝有没有报错
+             ③投递＝今天的成品有没有送出去。每条各带一枚处置牌，
+             因为「坏了」和「要不要动手」不是同一个判断（#771 的微信掉投
+             永远坏着，但它是已知不修，不该占用注意力）。 -->
+        <div class="dh-lanes-shell"><div class="dh-lanes">
+          <div class="dh-lane" id="dh-lane-files" data-tone="ok">
+            <span class="dh-lane-name">数据面</span>
+            <span class="dh-lane-stat" id="dh-files-stat">&mdash;</span>
+            <div class="dh-strip" id="dh-strip" role="img" aria-label="每个数据面的期限用量"></div>
+            <span class="dh-lane-note" id="dh-files-note"></span>
+            <span class="dh-chip" id="dh-files-chip"></span>
+          </div>
+          <div class="dh-lane" id="dh-lane-integrity" data-tone="ok">
+            <span class="dh-lane-name">体检</span>
+            <span class="dh-lane-stat" id="dh-integrity-stat">&mdash;</span>
+            <div class="dh-lane-shape" id="dh-integrity-shape" role="img" aria-label="体检结果构成"></div>
+            <span class="dh-lane-note" id="dh-integrity-note"></span>
+            <span class="dh-chip" id="dh-integrity-chip"></span>
+          </div>
+          <div class="dh-lane" id="dh-lane-delivery" data-tone="ok">
+            <span class="dh-lane-name">投递</span>
+            <span class="dh-lane-stat" id="dh-delivery-stat">&mdash;</span>
+            <div class="dh-lane-shape" id="dh-delivery-shape" role="img" aria-label="窗口内成品结果构成"></div>
+            <span class="dh-lane-note" id="dh-delivery-note"></span>
+            <span class="dh-chip" id="dh-delivery-chip"></span>
+          </div>
+        </div></div>
         <div class="dh-caption" id="dh-caption"></div>
         <div class="dh-files" id="dh-files" hidden></div>
       </section>

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -264,7 +264,13 @@ def compile_overview_projection(dashboard):
         },
         'workflow_outcomes': {
             **_fields(workflow, (
-                'counts', 'raw_error_but_product_usable',
+                'counts',
+                # The window the counts are counted over. Dropped here until
+                # 2026-09-01, which left the Hero's data-health card printing
+                # "37 档" with no denominator — or, worse, guessing one. A count
+                # whose window is unknown is not a number a reader can act on.
+                'window_hours',
+                'raw_error_but_product_usable',
                 # Computed since #772 and, until now, dropped here: the card
                 # could not answer "how many did WeChat drop this window" even
                 # though the ledger knew. A count with no consumer is not a fix.

--- a/tests/dashboard_tab_runtime.spec.js
+++ b/tests/dashboard_tab_runtime.spec.js
@@ -1141,6 +1141,9 @@ async function testVerdictDeckFillsItsBoxAndRanksGatesBySeverity(browser, base) 
 // 数据健康卡：降级/恢复必须点名是哪一档（kcn 2026-08-25：「如果有降级的应该
 // 标注出来是哪个」），微信单通道掉投必须可数、可点名（#771 让它在 summarizer
 // 里可数，但那个计数从没进过任何读者能看到的地方）。
+// 点名的位置从判词挪到了「投递」泳道（kcn 2026-09-01：「我也不知道该怎么看」
+// ⇒ 判词只回答「页面上的数字能不能信」，一个任务没落地不改变这个答案）。
+// 断言跟着挪，但要求不变：**不展开就能读到是哪一档、发生了什么**。
 async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
   const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
   const page = await context.newPage();
@@ -1191,13 +1194,30 @@ async function testDataHealthNamesTheDegradedSlotAndWeChatDrops(browser, base) {
   const head = await page.evaluate(() => ({
     verdict: (document.getElementById("dh-verdict") || document.getElementById("dh-title")).textContent.trim(),
     meta: document.getElementById("dh-meta").textContent.trim(),
+    delivery: document.getElementById("dh-delivery-note").textContent.trim(),
+    deliveryChip: document.getElementById("dh-delivery-chip").textContent.trim(),
+    filesChip: document.getElementById("dh-files-chip").textContent.trim(),
+    integrityChip: document.getElementById("dh-integrity-chip").textContent.trim(),
+    caption: document.getElementById("dh-caption").textContent.trim(),
   }));
-  assert(head.verdict.includes("港股收盘报告"),
-    `data-health verdict does not name the degraded slot: ${head.verdict}`);
-  assert(head.verdict.includes("恢复"),
-    `data-health verdict does not say what happened to it: ${head.verdict}`);
+  assert(head.delivery.includes("港股收盘报告"),
+    `delivery lane does not name the degraded slot: ${head.delivery}`);
+  assert(head.delivery.includes("恢复"),
+    `delivery lane does not say what happened to it: ${head.delivery}`);
   assert(/微信掉投\s*3\s*档/.test(head.meta),
     `data-health meta does not carry the WeChat drop count: ${head.meta}`);
+  // 数据面全部在期、体检干净 ⇒ 判词必须说数字可用。把「某一档降级」读成
+  // 「页面数字不可信」正是这块牌以前的病。
+  assert(head.verdict.includes("页面数字可用"),
+    `verdict conflates a degraded slot with untrustworthy numbers: ${head.verdict}`);
+  // 处置牌必须分得开：兜住了的降级是「观察」，不是「需处理」。
+  assert.equal(head.deliveryChip, "观察",
+    `a recovered slot should be watch-only, got ${head.deliveryChip}`);
+  assert.equal(head.filesChip, "正常", `files lane chip: ${head.filesChip}`);
+  assert.equal(head.integrityChip, "正常", `integrity lane chip: ${head.integrityChip}`);
+  // 牌面上的四个字必须在同一屏里有解释，否则它们只是四个没人懂的标签。
+  ["需处理", "观察", "已知不修"].forEach(word => assert(head.caption.includes(word),
+    `disposition legend does not explain "${word}": ${head.caption}`));
 
   await page.click("#dh-toggle");
   const rows = await page.evaluate(() =>

--- a/tests/test_dashboard_payload_size.py
+++ b/tests/test_dashboard_payload_size.py
@@ -194,6 +194,9 @@ def test_the_unread_workflow_stage_detail_stays_out(payload):
     # 两个布尔。这不是「把 stages 加回来」—— 上面那条闸删的是 24KB 无人读的
     # 心跳明细，这里进来的是数据健康卡逐项要点名的那两位。
     assert "wechat_dropped_telegram_covered" in wf
+    # 计数的分母。少了它，首屏那张数据健康卡只能印「37 档」而说不出是几小时
+    # 里的 37 档 —— 或者自己猜一个窗口，那比不印更坏。
+    assert "window_hours" in wf
     for record in wf["recent"]:
         for field in ("job", "slot", "raw_execution", "final_product"):
             assert field in record, field


### PR DESCRIPTION
kcn 2026-09-01：「数据健康那块我觉得你要加载 ui ux skills 看看怎么优化一下展示和处置策略 要不然我也不知道该怎么看」。

## 病在哪

这块牌上压着三个互不相干的问题——①页面上的数字新不新鲜 ②体检有没有报错 ③今天的成品有没有送出去——而它只有**一行判词 + 一条灰 meta**。判词借的是当下最坏的那一条，另外两条读不出状态；更糟的是它把「某个任务挂了」印成红的，读起来像「你正在看的数字是错的」。

今天就是这个状态：15 个数据面全在期、体检 0 ERROR，但盘前深度简报那一档 FAILED，于是整张牌是红的、标题写着「盘前深度简报 FAILED」。读者既不知道数字能不能用，也不知道该不该动手。

## 改了什么

- **固定三条泳道**（数据面 / 体检 / 投递），位置不动、逐列对齐（subgrid，不支持时落到同一组定死列宽）。每条各带一枚**处置牌**：`需处理` / `观察` / `已知不修` / `正常`，四个词的含义常驻在卡底一行说明里，不靠读者猜。
- **判词只回答「页面上的数字能不能信」**，并分两截着色：可信度一色，待办一色。只有数据面逾期 / 体检 ERROR 才会让它变成「页面数字存疑」。
- 逐项面板新增第一组 **「处置 · 需处理」**：只列真的要动手的那几条，每条带下一步去哪看，与后面两组台账（微信掉投 / 数据面）分开。
- 微信掉投从 meta 里一串计数改写成「N 档 · TG 已兜 · **已知不修**」——#771 已拍板不修，不该和要动手的事排在同一行。
- `overview` 投影补上 `window_hours`：少了它，首屏只能印「37 档」而说不出是几小时里的 37 档，或者自己猜一个窗口（比不印更坏）。JS 侧也改成拿不到窗口就不写。
- 顺手修两处实测溢出：逐项末列 34px 装不下投递行的「TG 已兜」（实测 42px）；窄档下泳道父栅格 422px 的定死列宽会把处置牌顶到 390px 屏幕外。

## 今天的真实数据下它长这样

```
数据健康                                                     [逐项]
页面数字可用 · 1 件要处理
微信掉投 18 档 · TG 已兜 · 已知不修 · 构建 2026-09-01 23:40
──────────────────────────────────────────────────────────────
数据面  15/15 在期   ▮▮▮▮▮▮▮▮  最紧张 催化剂日程（0.9h·应于 09/01 14:00 前）  正常
体检    0 ERROR · 1 WARN  ▪     canonical bars: 1 refused provider disagreement  观察
投递    37 档 / 36h   ▬▬▬▬▮▮▮▪ 盘前深度简报 FAILED —— 成品没落地              需处理
处置：需处理＝页面数字或成品真的受影响，要动手；观察＝兜底已生效、成品到了，只记不动；已知不修＝已拍板不处理。
```

## 验证

- `node tests/dashboard_tab_runtime.spec.js` 里的数据健康契约本地单跑通过（整套在本机因负载不稳，交给 CI）。
- `pytest tests/test_dashboard_payload_size.py tests/test_build_dashboard.py tests/test_dashboard_bundle_parity.py tests/test_dashboard_security.py tests/test_information_layer_taxonomy.py tests/test_workflow_outcomes.py` → 151 passed。
- 1280 与 390 两档实测零溢出（`scrollWidth > clientWidth` 扫全卡）。
- 浏览器契约跟着挪：点名「是哪一档降级」的断言从判词移到投递泳道（要求不变：不展开就要读得到），并新增三条——判词不得把一次降级读成数字不可信、兜住的降级必须是「观察」不是「需处理」、四个处置词必须在同屏有解释。

https://claude.ai/code/session_01B97NLtrFGGdZSqs2zLx2BJ