### PR TITLE
cron: 投递与提交之间被杀不再是无人看见的状态

### DIFF
--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -78,23 +78,29 @@ jobs:
       - name: Fold Actions-side failures into the daily summary
         # cron_health_check only sees host-side products; a scheduled workflow
         # that fails (or stops firing) on the Actions side was previously
-        # visible only in weekly-health's log-only rollup. --json is report-only
-        # and needs read access to run history.
+        # visible only in weekly-health's log-only rollup. The rollup is
+        # report-only and needs read access to run history.
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Report-only end to end: a gh hiccup here must cost a note in the
           # summary, not redden a health check that has its own verdict.
-          {
-            echo "## Scheduled workflow health (Actions side)"
-            python3 ops/ci/workflow_health.py --json 2>/dev/null | python3 -c '
-              import json, sys
-              r = json.load(sys.stdin)
-              print(f"needs attention: {r[\"needs_attention\"]} of {r[\"scheduled_workflows\"]} "
-                    f"(lookback {r[\"lookback_days\"]}d)")
-              for w in r["workflows"]:
-                  if w["status"] == "attention":
-                      print(f"- ⚠ {w[\"workflow\"]}: last={w[\"last_conclusion\"] or \"-\"}")
-            ' || echo "(Actions-side rollup unavailable this run — see weekly-health)"
-          } >> "$GITHUB_STEP_SUMMARY"
+          #
+          # This used to re-implement the rollup as an inline `python3 -c` whose
+          # script body was indented to match the YAML block — so Python read it
+          # as `IndentationError: unexpected indent` on **every** run since the
+          # step was added, and the `|| echo` fallback swallowed the error. The
+          # step is `if: always()`, so nothing ever went red over it and the
+          # rollup silently printed nothing for its whole life (found 2026-09-01
+          # while reading a genuinely red run). Same class as #1230: a branch
+          # that only runs when something is wrong is not exercised by a green
+          # run — and an inline heredoc cannot be the fix either, because a YAML
+          # block scalar cannot carry a terminator at column 0.
+          #
+          # `workflow_health.py` already writes the markdown table to
+          # $GITHUB_STEP_SUMMARY itself (and returns 0 by contract), so the
+          # inline copy was redundant as well as broken. Call the script.
+          python3 ops/ci/workflow_health.py \
+            || echo "Actions-side rollup unavailable this run — see weekly-health." \
+               >> "$GITHUB_STEP_SUMMARY"

--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -20,6 +20,8 @@ clawock brief preflight
 **跑命令的两条硬约束（同属「工具报错=整轮记 error」那一族）**
 - 脚本路径**照抄 SKILL.md，不要猜**。猜错了不许全盘扫描：`find /` 会被转入后台会话，而**主动 `process kill` 掉它的 toolResult 带 isError**，整个 cron 会被记成 error —— 2026-08-21 的简报就是这样在两个渠道都投递成功之后仍然判红的。
 - 任何可能长跑的命令自己用 `timeout` 包住（如 `timeout 20 <cmd>`），让它自己结束，这样就永远不需要 kill。
+- **`clawock brief postflight` 是这条规则的例外：绝不给它包 `timeout`，也不要 kill 它。** 它是「先投递、后提交」两段（#765 的顺序），提交那一段要跑 log_decisions + 重建 dashboard + push，几十秒到几分钟，在机器吃紧时更久。杀在中间的结果是**投递成功了但简报没入库**：`memory/{date}-pre-open.md` 与 `plan.json` 留在工作区不进 git，公开页 404，决策台账整天不动（日更简报的 commit 是那个台账唯一的搬运工）。2026-09-01 就是这样丢的：`timeout 90` 退出码 124，而 `brief-sent-*.json` 已经写好，于是看起来完全成功。
+- **看到 `memory/.tmp/brief-sent-{date}.json` 只说明「投出去了」，不说明 postflight 跑完了。** 判完成看它自己那份 JSON 里的 `commit_ok`；`commit_ok: false` 就是没入库，要把 postflight 重跑到底，不要收尾。
 
 **Step 3 - Swarm 分析（你的创造性工作）**
 - ⚡ **板块全景**（必跑 tavily-search）：板块名读 `memory/peer-map.json` 各 ticker 的 `theme` 字段（持仓动态，不要写死任何 ticker），每个板块拉今日 Top 涨幅榜 + 你持仓在榜单的位置（领涨/落后/中位）+ 1 句归因（催化时点/早盘抛压/β 错配）

--- a/config/cron-payloads/intraday.md
+++ b/config/cron-payloads/intraday.md
@@ -8,7 +8,7 @@
 ```
 clawock intraday preflight --market {{market}}
 ```
-本流程所有脚本 exec 调用都显式设置 `timeout: 300`。
+本流程所有脚本 exec 调用都显式设置 `timeout: 300`，**`clawock intraday postflight` 除外 —— 它不设超时也不 kill**。postflight 是「先投递、后提交」两段（#765），提交那一段在机器吃紧时会超过 300s；杀在中间会留下「投递成功但没提交」，而投递标记会让每一条腿都看到成功，没有东西会重跑（2026-09-01 简报与港股开盘各丢一次提交就是这样）。判完成看它返回的 `commit_ok`，不看有没有收到卡片。
 若 exec 返回 `Command still running`，只用 `process` poll 对应 session；禁止新开 exec 用 sleep/ps/ls/grep 探测进度。preflight 内置休市闸；若输出 `status: market_closed`，立即结束，不生成报告、不调用 postflight/send/message。
 输出 `memory/.tmp/intraday-context-{{market}}-latest.json`，同一份 JSON 也打到 stdout。关键字段 `should_alert` + `alert_reasons` + `anomalies`，以及 `context_id` —— **Step 3 要原样回传**。
 

--- a/config/cron-payloads/report.md
+++ b/config/cron-payloads/report.md
@@ -25,6 +25,8 @@ clawock report postflight --market {{market}} --phase {{phase}} --context-id <St
 `--context-id` 必须照抄 Step 1 打印的那个。pass/warn 自动拼装+发送+刷新 snapshot/dashboard+提交推送。
 这是**唯一微信路径**，并同步 Telegram；本 cron 配 `--no-deliver`，不会再 announce 你的回复文本。
 
+⚠️ **postflight 不设超时、不 kill、不因为「已经发出去了」就收尾。** 它是「先投递、后提交」两段（#765），提交那一段要刷 snapshot/dashboard 再 push，几十秒到几分钟。**杀在中间会留下「投递成功但没提交」**——微信/TG 都到了，`portfolio: {{market_name}}{{phase}}价格更新` 那个 commit 却不存在，而所有腿看到的都是成功，所以没有任何东西会重跑。2026-08-31 与 09-01 的港股开盘报告就是这样各丢了一次提交（父壳超时 SIGTERM，模型据此判「子进程早已完成发送，不再重跑」）。判完成只看 postflight 自己返回的 `status` + `commit_ok`。
+
 **Step 4 - 输出**
 把 postflight 返回的 `status` + `issues` 作为本回合最终文本回复（仅留痕）。
 ❌ **禁用 message/send 工具** —— postflight 已经发过了，你再手动调会撞成双发（2026-06-03 教训）。

--- a/ops/system_check.py
+++ b/ops/system_check.py
@@ -1116,6 +1116,69 @@ def check_host_cron_logs(r):
         r.add('host cron logs', OK, f'{checked} host cron logs · none end on a crash')
 
 
+def check_delivered_but_unarchived(r):
+    """A product that reached kcn but never reached git.
+
+    2026-09-01 is the case this exists for. The 08:00 brief was delivered to
+    WeChat and Telegram (`brief-sent-2026-09-01.json`, `sent_ok`/`tg_ok` both
+    true) and `memory/2026-09-01-pre-open.md` was never committed, so the link
+    printed on the card kcn actually received 404'd all day, `briefs.html` stopped
+    at 08-31, and `memory/decisions.jsonl` — whose *only* carrier is the daily
+    brief commit — did not move for a whole trading day. The same thing cost the
+    HK open report its commit on 08-31 and 09-01.
+
+    The mechanism is the postflights' own ordering: deliver first, commit second
+    (#765). Anything that kills the process in between leaves a state where
+    **every existing gate reads success** — the send marker is written, the
+    ledger's `primary_delivery` is `success`, the watchdog sees a fresh marker
+    with `tg_ok`, and the model's own wrap-up reads the marker and stops. On
+    2026-09-01 the killer was the agent's own `timeout 90` wrapper; the payloads
+    now carve postflight out of that rule, but the wrapper is not the only way to
+    die between the two halves, so the *state* needs a gate rather than the cause.
+
+    Criterion, stated as exactly what it is: **today's brief was delivered and its
+    markdown is not tracked by git.** `git ls-files --error-unmatch` answers
+    "tracked", which is the property that matters — a file staged but uncommitted
+    still has not left the desk, and one that is neither is the 09-01 case.
+
+    WARN, not CRITICAL, for the reason `check_publish_backlog` gives one function
+    up: this runs inside `.githooks/pre-push`, and the fix for the state it
+    reports is *a push*. A CRITICAL would refuse the very commit that clears it.
+
+    Weekends, holidays and any day before the brief has been delivered are
+    silent: no send marker, nothing to say.
+    """
+    # 主机 TZ 是 Asia/Shanghai(+0800)，与 HKT 同偏移，所以本地日期就是场次日；
+    # 不引 zoneinfo 是为了让这个文件在任何 checkout 上都零依赖地跑起来。
+    today = date.today().strftime('%Y-%m-%d')
+    marker = WS / 'memory' / '.tmp' / f'brief-sent-{today}.json'
+    if not marker.is_file():
+        return  # not delivered (yet) — nothing is owed to git
+    try:
+        sent = json.loads(marker.read_text())
+    except Exception:
+        return
+    if not (sent.get('sent_ok') or sent.get('tg_ok')):
+        return  # marker exists but nothing went out; a different failure owns it
+    unarchived = []
+    for rel in (f'memory/{today}-pre-open.md', f'memory/{today}-plan.json'):
+        if not (WS / rel).exists():
+            continue  # absent is the miss detector's business, not this one
+        tracked = subprocess.run(
+            ['git', 'ls-files', '--error-unmatch', rel],
+            capture_output=True, text=True, timeout=10, cwd=str(WS))
+        if tracked.returncode != 0:
+            unarchived.append(rel)
+    if unarchived:
+        r.add('delivered but unarchived', WARNING,
+              f'{today} brief was delivered but {", ".join(unarchived)} '
+              f'is not tracked — postflight died between delivery and commit; '
+              f'the public brief page will 404 until it is committed')
+    else:
+        r.add('delivered but unarchived', OK,
+              f'{today} brief delivered and archived')
+
+
 def check_generated_cron_docs(r):
     """Generated schedule documentation must exactly match the contract."""
     result = subprocess.run(
@@ -1487,6 +1550,7 @@ def main():
         check_host_crontab_targets,
         check_host_cron_logs,
         check_publish_backlog,
+        check_delivered_but_unarchived,
         check_fallback_chain_shape,
         check_model_chain_health,
         check_generated_cron_docs,

--- a/tests/test_bar_conflict_classification.py
+++ b/tests/test_bar_conflict_classification.py
@@ -144,6 +144,16 @@ def test_the_report_names_them_and_still_publishes(tmp_path, monkeypatch):
     """
     from clawock.portfolio import integrity
 
+    # `check()` takes no log path: with none, `summarize_bar_conflicts` resolves
+    # `workspace_root(Path.cwd())/memory/bar-conflicts.jsonl`, so the "clean"
+    # assertion below was reading the **desk's real conflict log** and passed
+    # only while that file did not exist in the checkout. One real (benign,
+    # rounding-class) disagreement got committed on 2026-09-01 and it went red.
+    # Point the resolver at an empty scratch workspace via the documented env
+    # override — that still exercises the real fallback path, which stubbing
+    # the summariser would not.
+    monkeypatch.setenv('CLAWOCK_WORKSPACE', str(tmp_path))
+
     book = tmp_path / 'portfolio.json'
     book.write_text(json.dumps({'portfolios': {}}))
 

--- a/tests/test_build_evidence.py
+++ b/tests/test_build_evidence.py
@@ -17,6 +17,37 @@ ROOT = Path(__file__).resolve().parents[1]
 from clawock.evidence import build_evidence as ev
 
 
+def unsourced_figures(page, sources):
+    """Figures on the page that no source artifact can account for.
+
+    Two ways a figure is accounted for: it is printed verbatim, or some source
+    value *rounds to* it at the precision the page printed (`_pct` also scales
+    ratios by 100, and `\\d+\\.\\d+` never captures a sign, so both are allowed for).
+
+    The previous fallback asked whether the figure's first three digits appear
+    anywhere in the concatenated sources. That is a coincidence check, not a
+    provenance one — and on 2026-09-01 the coincidence ran out: `4.13` is read
+    from `mean_return: 0.041296`, which rounds UP so the digits genuinely
+    differ, and it had been passing only because some unrelated artifact
+    happened to contain "413". The daily rebuild moved those artifacts and a
+    correctly-read number was reported as typed. Asking the real question is
+    both stronger (it cannot be satisfied by an unrelated coincidence) and
+    correct on rounding.
+    """
+    source_numbers = [float(tok) for tok in re.findall(r"-?\d+\.?\d*", sources)]
+
+    def sourced(raw):
+        stem = raw.rstrip("0").rstrip(".")
+        if stem and (stem in sources or stem.lstrip("0") in sources):
+            return True
+        digits = len(raw.partition(".")[2])
+        target = float(raw)
+        return any(round(abs(value) * scale, digits) == target
+                   for value in source_numbers for scale in (1.0, 100.0))
+
+    return sorted({raw for raw in re.findall(r"\d+\.\d+", page) if not sourced(raw)})
+
+
 def test_every_number_on_the_page_comes_from_an_artifact():
     """A figure present on the page but absent from every source artifact was
     typed, not read."""
@@ -27,18 +58,24 @@ def test_every_number_on_the_page_comes_from_an_artifact():
                      ROOT / "assets" / "data" / "quant_signal_review.json",
                      ROOT / "assets" / "data" / "cross_sectional_factor.json"]
         if path.exists())
+    typed = unsourced_figures(page, sources)
+    assert not typed, f"figures that no artifact contains: {typed}"
 
-    typed = []
-    for raw in re.findall(r"\d+\.\d+", page):
-        # The page rounds what it reads, so match on the leading digits rather
-        # than demanding the full-precision string.
-        stem = raw.rstrip("0").rstrip(".")
-        if stem and stem not in sources and stem.lstrip("0") not in sources:
-            digits = stem.replace(".", "")
-            if digits[:3] not in sources.replace(".", ""):
-                typed.append(raw)
 
-    assert not typed, f"figures that no artifact contains: {sorted(set(typed))}"
+def test_a_rounded_reading_is_sourced_and_an_invented_one_is_not():
+    """The gate has to survive rounding without going blind to typing.
+
+    Without this pair the fix for the 2026-09-01 false positive could have been
+    "accept everything", and nothing in the suite would have noticed.
+    """
+    sources = '{"mean_return": 0.041296, "drawdown": -0.91649, "n": 4}'
+    # read, then rounded (up, and scaled by 100) — and the negative one whose
+    # sign the page regex cannot see
+    assert unsourced_figures("mean 4.13% vs -91.6%", sources) == []
+    # verbatim
+    assert unsourced_figures("raw 0.041296", sources) == []
+    # typed: no source value rounds to either of these
+    assert unsourced_figures("mean 4.19% and 7.77%", sources) == ["4.19", "7.77"]
 
 
 def test_an_inconclusive_result_never_renders_as_a_pass(tmp_path, monkeypatch):

--- a/tests/test_preflight_integrity.py
+++ b/tests/test_preflight_integrity.py
@@ -29,6 +29,18 @@ def run_check(pi, monkeypatch):
 
     def run(data, *, last_session="2026-07-17", previous_cash=None):
         payload = json.dumps(data)
+        # `summarize_bar_conflicts` is the one collaborator that still reaches
+        # the filesystem: with no explicit log it resolves
+        # `workspace_root(Path.cwd())/memory/bar-conflicts.jsonl`, so "entirely
+        # in memory" was true only while that file happened not to exist. The
+        # day one real (benign, rounding-class) disagreement got committed,
+        # thirty-four assertions here went red on data none of them are about
+        # (2026-09-01). Tests that ARE about bar conflicts stub this themselves —
+        # see tests/test_bar_conflict_classification.py.
+        monkeypatch.setattr(pi, "summarize_bar_conflicts", lambda *a, **k: {
+            "window_days": 30, "total": 0, "by_kind": {}, "by_ticker": {},
+            "last_seen_at": None, "log": "bar-conflicts.jsonl",
+        })
         monkeypatch.setattr(
             pi,
             "Path",

--- a/tests/test_system_check_delivered_but_unarchived.py
+++ b/tests/test_system_check_delivered_but_unarchived.py
@@ -1,0 +1,131 @@
+"""A product that reached kcn but never reached git must be visible (2026-09-01).
+
+The 08:00 brief of 2026-09-01 was delivered to WeChat and Telegram and then
+never committed: `brief-sent-2026-09-01.json` said `sent_ok`/`tg_ok`, and
+`memory/2026-09-01-pre-open.md` stayed untracked, so the report link printed on
+the card kcn actually received 404'd all day and `memory/decisions.jsonl` — whose
+only carrier is the daily brief commit — did not move for a trading day.
+
+Every existing gate read success, because each of them reads the delivery half:
+the send marker, the ledger's `primary_delivery`, the watchdog's fresh-marker
+check, and the model's own wrap-up. So the gate has to read the *other* half.
+
+Behavioural, driven through a scratch workspace and a real `git` repo, so
+deleting the check's body or making it blind to an untracked brief turns these
+red.
+"""
+import importlib.util
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TODAY = date.today().strftime("%Y-%m-%d")
+
+
+@pytest.fixture(scope="module")
+def system_check():
+    for path in (ROOT, ROOT / "src"):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    spec = importlib.util.spec_from_file_location(
+        "kcnyu_system_check_unarchived", ROOT / "ops" / "system_check.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def workspace(system_check, monkeypatch, tmp_path):
+    """A real git repo — the check asks git whether a path is tracked."""
+    ws = tmp_path / "workspace"
+    (ws / "memory" / ".tmp").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=ws, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.st"], cwd=ws, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=ws, check=True)
+    monkeypatch.setattr(system_check, "WS", ws)
+    return ws
+
+
+def _mark_delivered(ws, **fields):
+    payload = {"ts": 1, "sent_ok": True, "tg_ok": True}
+    payload.update(fields)
+    (ws / "memory" / ".tmp" / f"brief-sent-{TODAY}.json").write_text(
+        __import__("json").dumps(payload))
+
+
+def _write_brief(ws):
+    (ws / "memory" / f"{TODAY}-pre-open.md").write_text("# brief\n")
+    (ws / "memory" / f"{TODAY}-plan.json").write_text('{"decisions": []}\n')
+
+
+def _run(system_check, ws):
+    result = system_check.Result()
+    system_check.check_delivered_but_unarchived(result)
+    return result.checks
+
+
+def test_delivered_and_untracked_is_the_2026_09_01_state(system_check, workspace):
+    _mark_delivered(workspace)
+    _write_brief(workspace)
+    checks = _run(system_check, workspace)
+    assert len(checks) == 1
+    name, severity, msg = checks[0]
+    assert severity == system_check.WARNING
+    # 必须点名是哪个文件——「有东西没入库」答不出该去 add 什么。
+    assert f"memory/{TODAY}-pre-open.md" in msg
+    assert "404" in msg
+
+
+def test_delivered_and_committed_is_green(system_check, workspace):
+    _mark_delivered(workspace)
+    _write_brief(workspace)
+    subprocess.run(["git", "add", "memory/"], cwd=workspace, check=True)
+    subprocess.run(["git", "commit", "-qm", "brief"], cwd=workspace, check=True)
+    checks = _run(system_check, workspace)
+    assert [s for _, s, _ in checks] == [system_check.OK]
+
+
+def test_staged_but_uncommitted_still_counts_as_archived(system_check, workspace):
+    """`git ls-files` answers "tracked", and staged is tracked.
+
+    The gate deliberately stops at tracked rather than committed: an index entry
+    means the next commit carries it, and `check_publish_backlog` already owns
+    "committed but not pushed". Overlapping the two would report one state twice.
+    """
+    _mark_delivered(workspace)
+    _write_brief(workspace)
+    subprocess.run(["git", "add", "memory/"], cwd=workspace, check=True)
+    checks = _run(system_check, workspace)
+    assert [s for _, s, _ in checks] == [system_check.OK]
+
+
+def test_a_day_with_no_delivery_is_silent(system_check, workspace):
+    """Weekends, holidays, and every minute before 08:20 on a trading day."""
+    _write_brief(workspace)
+    assert _run(system_check, workspace) == []
+
+
+def test_a_marker_that_delivered_nothing_is_someone_elses_failure(
+        system_check, workspace):
+    """`sent_ok` false is a delivery miss; the watchdog owns that, not this."""
+    _mark_delivered(workspace, sent_ok=False, tg_ok=False)
+    _write_brief(workspace)
+    assert _run(system_check, workspace) == []
+
+
+def test_an_absent_brief_is_the_miss_detectors_business(system_check, workspace):
+    """Nothing on disk is a different failure with its own alert (09:05)."""
+    _mark_delivered(workspace)
+    checks = _run(system_check, workspace)
+    assert [s for _, s, _ in checks] == [system_check.OK]
+
+
+def test_an_unreadable_marker_does_not_crash_the_gate(system_check, workspace):
+    (workspace / "memory" / ".tmp" / f"brief-sent-{TODAY}.json").write_text("{oops")
+    _write_brief(workspace)
+    assert _run(system_check, workspace) == []


### PR DESCRIPTION
接 #1270 那轮巡检查出来的东西。

## 病在哪

2026-09-01 一天丢了两件成品的归档，而**每一条腿都读到成功**：

- **08:00 简报**投到了微信+TG（`brief-sent-2026-09-01.json` 的 `sent_ok`/`tg_ok` 都 true），`memory/2026-09-01-pre-open.md` 从没入库 ⇒ 那张卡上印的报告链接 **404 了一整天**、briefs 页停在 08-31。而 `memory/decisions.jsonl` 的**唯一搬运工就是这个 commit**，于是整个交易日台账没动（已由 `3bbd5a51` 补提）。
- **港股开盘报告 08-31 与 09-01** 同样：微信+TG 都到了，`portfolio: 港股开盘价格更新` 那个 commit 不存在——最后一次是 08-28。

机制是 postflight 自己的顺序：**先投递、后提交**（#765）。任何东西在两段之间把进程杀掉，留下的状态是「送到了但没归档」，而送达标记一写下，台账的 `primary_delivery`、watchdog 的 fresh-marker 判定、模型自己的收尾判断**全部读到成功**，所以没有任何一条腿会重跑。

两次的凶手都是超时包装，两次模型都据此判「已经发出去了，不再重跑」：

> 简报：`The exit code 124 from the timeout 90 wrapper was just my own timeout killing the process before it finished... The fact that brief-sent-*.json exists with sent_ok: true means it worked.`
> 港股开盘：`SIGTERM 是 exec 父壳超时，子进程早已在 09:35:53 完成发送，不再重跑。`

唯一发现它的是 `cron_health_check`——因为它数的是 **commit**，不是投递。

## 改了什么

1. **三份 cron payload 把 postflight 从超时规则里挖出来。** `brief.md` 那条「任何可能长跑的命令自己用 `timeout` 包住」是 08-21 为了防 `find /` 全盘扫描加的（#777），现在正是它在咬；`intraday.md` 的一刀切 `timeout: 300` 同理。并写明**看到 sent 标记只说明投出去了，判完成看 postflight 自己返回的 `commit_ok`**。
2. **`ops/system_check.py` 新增 `check_delivered_but_unarchived`。** 判据只说到它本身是什么：**今天的简报已投递，而它的 markdown/plan 不被 git 跟踪**。取 WARN 不取 CRITICAL 的理由和它上面的 `check_publish_backlog` 一样——这个检查跑在 `.githooks/pre-push` 里，而它报的状态的解法就是一次 push，CRITICAL 会把清账的那次推送本身拒掉。周末、假日、以及每天投递之前都静默。**原因侧已经修了（第 1 条），但包装器不是死在两段之间的唯一方式，所以要给状态上闸而不是给成因上闸。**
3. **`cron-health.yml` 那段 Actions 侧汇总从来没输出过东西。** inline `python3 -c` 的脚本体跟着 YAML 缩进写，Python 每次都读成 `IndentationError: unexpected indent`，再被 `|| echo` 吞掉，而那步是 `if: always()` 所以永远不红（在读一次**真红**的 run 时顺手发现的）。heredoc 修不了它——YAML block scalar 装不下顶格的终止符——而 `workflow_health.py` **本来就会把同一张表写进 `$GITHUB_STEP_SUMMARY`**，inline 那份既是坏的也是多余的。删掉，直接调脚本。又一例 #1230。

## 4. 补提那次揭出来的两处「只在活数据恰好安静时才绿」

`3bbd5a51` 第一次把 `memory/bar-conflicts.jsonl` 与当天重建过的 `assets/data/*` 提进仓库，`validate` 随即 35 红。逐条查下来都不是那次提交造成的缺陷，而是**它揭出来的**——那批文件本来就该由每天的简报 commit 带出门，所以这三处早晚要红：

- `test_preflight_integrity.py::run_check` 号称「entirely in memory」却漏了一个会碰文件系统的协作者：`summarize_bar_conflicts` 不给 log 时解析 `workspace_root(Path.cwd())/memory/bar-conflicts.jsonl`。一条真实的、良性的 rounding 级分歧被提交，**34 条与它毫无关系的断言**就一起红了。fixture 里 stub 成空。
- `test_bar_conflict_classification.py` 的 clean 分支同样在断言「这台机器今天没有分歧」。改用文档化的 `CLAWOCK_WORKSPACE` 覆盖指向空 scratch workspace——仍然走真的兜底解析路径，stub 掉 summariser 则不会。
- `test_build_evidence.py` 的「页面上的数字必须来自产物」**是个巧合检查**：兜底问「这个数字的前三位是否出现在拼接后的源文本里」。`4.13` 读自 `mean_return: 0.041296`——向上进位，数位真的不同——它一直能过只是因为某个无关产物恰好含 "413"。换成问真正的问题：**有没有某个源数值按页面印的精度四舍五入等于它**（`_pct` 还会 ×100，`\d+\.\d+` 抓不到负号，两者都放行）。**这比原来更严**，并把判据提成模块级函数配一对正反测试，免得「修好假阳性」滑成「什么都放行」。

## 验证

- `tests/test_system_check_delivered_but_unarchived.py` 7 条，跑在真 git repo 上：09-01 那个状态必须 WARN 且**点名是哪个文件**（「有东西没入库」答不出该去 add 什么）；已提交/已 stage 绿；没投递、投递失败、文件不在、标记读不动四种都静默（各归各的闸）。
- `pytest tests/test_bar_conflict_classification.py tests/test_preflight_integrity.py tests/test_build_evidence.py tests/test_system_check_delivered_but_unarchived.py` → 70 passed, 2 xfailed。
- `pytest tests/test_sync_cron_payloads.py tests/test_profiles.py tests/test_runtime_coupling_ratchet.py tests/test_brief_preflight_dag.py tests/test_skill_commands_are_runnable.py` → 41 passed。

合并后我会在 live 上跑 `ops/host/sync_cron_payloads.py --apply` 把新 payload 同步进 openclaw 契约——不先跑是因为那会让 live 契约领先 master，`system_check` 的漂移闸会 CRITICAL 卡住 20 分钟一次的发布器。

https://claude.ai/code/session_01B97NLtrFGGdZSqs2zLx2BJ