### PR TITLE
brief: verdict 列改成带色徽标 (#1272)

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -155,6 +155,15 @@
   }
   article table th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
   article hr { border: 0; border-top: 1px solid var(--border); margin: 20px 0; }
+  /* Verdict badges in the brief's Confidence table (#1272). The glyph is
+     rendered by `brief_render.verdict_badge` and carries the signal on
+     surfaces that strip this class (GitHub's markdown sanitiser); here the
+     class adds the theme-correct tint, so the column reads at a glance. */
+  article .verdict { font-weight: 600; white-space: nowrap; }
+  article .verdict-bullish { color: var(--green); }
+  article .verdict-bearish { color: var(--red); }
+  article .verdict-neutral { color: var(--text-dim); }
+  article .verdict-mixed   { color: var(--accent-2); }
 
   /* Mobile: 宽表(如 7 列持仓表)横向滚动而非溢出撑破布局 */
   @media (max-width: 600px) {

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -34,8 +34,25 @@ VOICE_LABELS = {
     "conservative": "Conservative（保本 derisk）",
     "neutral": "Neutral（拍中线）",
 }
+# Verdict is the one categorical column in the Confidence table, and it was
+# plain text: ten rows of 看多/看空/中性 that had to be read line by line to see
+# which way the book leaned (#1272).  The cell is now a badge: a glyph and the
+# label inside a class the stylesheet tints.
+#
+# The glyph is not decoration, it is the portable half.  The brief is read on
+# three surfaces: GitHub Pages renders the markdown through kramdown and gets
+# the CSS class (`site/_layouts/default.html` maps `.verdict-*` onto the same
+# --green/--red tokens the dashboard uses, so the colour follows the reader's
+# light/dark preference); GitHub's own markdown sanitiser drops `class` and
+# `style` and keeps the inner text; a plain-text reader sees neither.  A glyph
+# inside the span survives all three, which a hardcoded `#10b981` — the issue's
+# suggestion — survives in exactly none of them, and would be wrong in one of
+# the two themes even where it did land.
 VERDICT_LABELS = {
-    "bullish": "看多", "bearish": "看空", "neutral": "中性", "mixed": "分歧",
+    "bullish": {"label": "看多", "glyph": "🟢"},
+    "bearish": {"label": "看空", "glyph": "🔴"},
+    "neutral": {"label": "中性", "glyph": "⚪"},
+    "mixed": {"label": "分歧", "glyph": "🟠"},
 }
 MISSING = "—"
 
@@ -499,6 +516,20 @@ def influencer_section(context):
     return "\n".join(out)
 
 
+def verdict_badge(value):
+    """A verdict cell: glyph + label, tinted by the site's own tokens.
+
+    An unknown verdict falls through to its own text rather than being dropped
+    or coloured — `packet.VERDICTS` is the enum's authority and rendering is the
+    wrong place to reject one, same rule as every other cell here.
+    """
+    spec = VERDICT_LABELS.get(value)
+    if spec is None:
+        return text(value)
+    return (f'<span class="verdict verdict-{value}">'
+            f'{spec["glyph"]} {spec["label"]}</span>')
+
+
 def confidence_section(judgment, plan):
     judgments = _judgments(judgment)
     rows = []
@@ -510,7 +541,7 @@ def confidence_section(judgment, plan):
             ticker,
             text(decision.get("action")),
             pct((confidence or 0) * 100, digits=0, sign=False),
-            VERDICT_LABELS.get(row.get("verdict"), text(row.get("verdict"))),
+            verdict_badge(row.get("verdict")),
             text(row.get("rationale")),
             text(row.get("falsifier")),
         ])

--- a/tests/test_brief_render.py
+++ b/tests/test_brief_render.py
@@ -7,8 +7,11 @@ must produce the same document, model text lands in slots rather than deciding
 them, and no string reaching a table can add a column to it.
 """
 import json
+from pathlib import Path
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
 
 from clawock.harness import brief_render as render
 from clawock.harness.validation import check_md_table_column_consistency
@@ -256,3 +259,57 @@ def test_unreadable_inputs_report_instead_of_overwriting_the_report(tmp_path):
     assert body is None
     assert issues and "渲染跳过" in issues[0]
     assert existing.read_text(encoding="utf-8") == "previously published"
+
+
+def test_verdict_reads_as_a_badge_not_a_word():
+    """The Confidence table's one categorical column has to be scannable.
+
+    Before #1272 the cell was the bare word 看空, so which way the book leaned
+    could only be read row by row.  The badge carries the same word plus the
+    two things a scan needs: a glyph, and a class the stylesheet tints.
+    """
+    cell = render.verdict_badge("bearish")
+
+    assert cell == '<span class="verdict verdict-bearish">🔴 看空</span>'
+    assert "看空" in cell, "the word stays — the glyph adds to it, never replaces it"
+
+
+def test_every_contract_verdict_has_a_badge():
+    """`packet.VERDICTS` is the enum's authority; a value it admits and this
+    module has no badge for would render as a raw `mixed` in the table."""
+    from clawock.decision import packet
+
+    assert set(render.VERDICT_LABELS) == packet.VERDICTS
+    for verdict in packet.VERDICTS:
+        assert render.verdict_badge(verdict).startswith(
+            f'<span class="verdict verdict-{verdict}">')
+
+
+def test_an_unknown_verdict_still_prints_itself():
+    """Same rule as every other cell: rendering does not reject producer data.
+    An off-enum verdict is postflight's to refuse, not the renderer's to drop."""
+    assert render.verdict_badge("euphoric") == "euphoric"
+    assert render.verdict_badge(None) == render.MISSING
+
+
+def test_the_confidence_table_carries_the_badge():
+    body = render.render_brief(CONTEXT, _judgment(), PLAN, date="2026-08-31")
+    table = body[body.index("## Confidence"):body.index("## ▎Decision v2 校准")]
+
+    assert '<span class="verdict verdict-bearish">🔴 看空</span>' in table
+    assert "| 看空 |" not in table, "the plain-text cell is what #1272 replaced"
+
+
+def test_the_stylesheet_tints_every_badge_class():
+    """The class is only worth emitting if the page that renders the brief
+    defines it — `site/_layouts/default.html` is the layout for memory/*.md."""
+    from clawock.decision import packet
+
+    layout = (ROOT / "site" / "_layouts" / "default.html").read_text(
+        encoding="utf-8")
+
+    for verdict in packet.VERDICTS:
+        assert f"article .verdict-{verdict}" in layout, verdict
+    # Tokens, not literals: the layout redefines --green/--red under
+    # prefers-color-scheme, so a hardcoded hex would be wrong in one theme.
+    assert "var(--green)" in layout and "var(--red)" in layout


### PR DESCRIPTION
Closes #1272.

## 现状核实
issue 的前提成立：`brief_render.py:513` 的 verdict 单元格是裸文本，`VERDICT_LABELS` 只有 4 个字符串。

## 改法
- `VERDICT_LABELS` 变成 `{label, glyph}`，新增 `verdict_badge(value)` 出 `<span class="verdict verdict-bearish">🔴 看空</span>`；off-enum 值仍按 `text()` 原样印（拒收是 postflight 的事，不是渲染层的）。
- `site/_layouts/default.html`（memory/*.md 的 layout）加 `.verdict-*` 规则，用站点已有的 `--green/--red/--text-dim/--accent-2` token 上色。

## 偏离 issue 的一处，及理由
issue 要求写死 `#10b981` 并以此为验收。没这么做——简报有三个阅读面：

| 面 | class | style/hex | glyph |
|---|---|---|---|
| GH Pages（kramdown） | ✅ | ✅ 但深色底上 #10b981 是错的 | ✅ |
| GitHub 上直接看 .md | ❌ 被 sanitizer 剥 | ❌ 被剥 | ✅ |
| 纯文本 | ❌ | ❌ | ✅ |

glyph 才是可移植的那一半，class 在站点上再补一层跟随主题的色。测试因此断言的是徽标形状 + layout 里每个 class 都有对应规则，而不是某个 hex 字面量。

**强度渐变没做**：confidence 就在隔壁一列，色深表同一个数字等于画两遍。

## 验证
`tests/test_brief_render.py` 新增 5 条（徽标形状、`VERDICT_LABELS` 覆盖 `packet.VERDICTS` 全集、未知值原样、Confidence 表里确实是徽标且不再有 `| 看空 |`、layout 里四个 class 都有规则且用 token 不用 hex）。本地 `-k "brief or render or validation or postflight"` 346 passed / 2 skipped。

https://claude.ai/code/session_01FLBsfuffwcnBazWVZWxsaw