### PR TITLE
tests: 把 LLM 输出闸的覆盖率钉成静态闸 (#1273)

### DIFF
--- a/tests/test_llm_output_validate.py
+++ b/tests/test_llm_output_validate.py
@@ -12,6 +12,7 @@ Two directions matter equally here:
 """
 from __future__ import annotations
 
+import ast
 import json
 import re
 from pathlib import Path
@@ -96,20 +97,115 @@ def test_real_committed_artifacts_pass_their_own_anchors():
                               min_chars=300)
 
 
-def test_call_sites_validate_before_they_write():
+# ── call-site coverage (#1273) ───────────────────────────────────────────────
+#
+# The gate lives at the call sites, not inside `llm.chat()` (see
+# output_validate's docstring: chat() is transport and does not know what its
+# caller asked the model for). That placement buys enforcement per call site
+# and costs the one thing a gate inside chat() would have given for free —
+# **coverage**. A fifth call site added next month gets no gate and nothing
+# fails; today's three-module string-index check could not have noticed,
+# because it only looked at the modules it already knew about.
+#
+# So the check is inverted here: enumerate every `chat()` call in the tree by
+# AST, and assert each one is a call site this table knows is gated. Adding a
+# call site now fails this test until it is either gated or listed.
+SOURCE_ROOTS = ('src/clawock', 'ops')
+GATED_CALL_SITES = {
+    ('src/clawock/automation/brief_fallback.py', 'main'): 'validate_sections',
+    ('src/clawock/automation/weekly_review.py', 'main'): 'validate_sections',
+    ('src/clawock/automation/news_digest.py', 'main'): 'validate_sections',
+    ('src/clawock/automation/influencer.py', 'llm_filter'): 'coerce_scored_items',
+}
+# Anything that puts the model's words somewhere another job will read them.
+WRITE_CALLS = {'write_text', 'write_bytes', '_write_artifact', 'dump', 'dumps'}
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _called_names(node):
+    """Every function name called anywhere under `node`, with its line."""
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name):
+            yield func.id, child.lineno
+        elif isinstance(func, ast.Attribute):
+            yield func.attr, child.lineno
+
+
+def _functions(tree):
+    """Top-level and nested function definitions, outermost first."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _chat_call_sites():
+    """`{(relative path, enclosing function): [line, ...]}` for every chat()."""
+    sites = {}
+    for root in SOURCE_ROOTS:
+        for path in sorted((ROOT / root).rglob('*.py')):
+            relative = path.relative_to(ROOT).as_posix()
+            tree = ast.parse(path.read_text(encoding='utf-8'))
+            for function in _functions(tree):
+                lines = [line for name, line in _called_names(function)
+                         if name == 'chat']
+                if lines:
+                    sites.setdefault((relative, function.name), []).extend(lines)
+    return sites
+
+
+def test_every_llm_call_site_is_one_the_gate_covers():
+    """A new `chat()` caller must not reach an artifact ungated.
+
+    This is the coverage half of #1265: the gate is per call site, so the only
+    thing that can keep it complete is a check that counts the call sites.
+    """
+    found = _chat_call_sites()
+
+    assert set(found) == set(GATED_CALL_SITES), (
+        'ungated chat() call site(s): '
+        f'{sorted(set(found) - set(GATED_CALL_SITES))}; '
+        'gate the output through clawock.automation.output_validate and list '
+        'it in GATED_CALL_SITES (or, if it is gone, drop it from the table)'
+    )
+    # `chat()` is imported from exactly one module, so the AST name cannot be
+    # some other project's chat().
+    for relative, _ in found:
+        source = (ROOT / relative).read_text(encoding='utf-8')
+        assert 'from clawock.automation.llm import chat' in source, relative
+
+
+@pytest.mark.parametrize('site', sorted(GATED_CALL_SITES))
+def test_the_call_site_validates_between_the_reply_and_the_write(site):
     """The gate is worthless if it runs after the artifact is on disk (the
-    2026-07-16 lesson that put plan validation ahead of the write)."""
-    for module, write_marker in (
-        (brief_fallback, "Path(f'memory/{today}-pre-open.md').write_text"),
-        (weekly_review, 'path.write_text'),
-        (news_digest, '_write_artifact(tickers, raw, source_status, digest='),
-    ):
-        source = Path(module.__file__).read_text()
-        gate = source.index('validate_sections(')
-        # first write that follows the chat() call, not an earlier fail-closed one
-        after_chat = source.index('= chat(')
-        write = source.index(write_marker, after_chat)
-        assert gate < write, f'{module.__name__} writes before it validates'
+    2026-07-16 lesson that put plan validation ahead of the write).
+
+    Line order inside the calling function is the assertion, which is why this
+    reads the AST rather than `str.index`: the old string search scanned the
+    whole module, so a gate call in an unrelated function would have satisfied
+    it, and it could say nothing at all about influencer (whose gate guards a
+    return value, not a write).
+    """
+    relative, function_name = site
+    gate = GATED_CALL_SITES[site]
+    tree = ast.parse((ROOT / relative).read_text(encoding='utf-8'))
+    function = next(f for f in _functions(tree) if f.name == function_name)
+    calls = list(_called_names(function))
+
+    chat_line = min(line for name, line in calls if name == 'chat')
+    gate_lines = [line for name, line in calls if name == gate]
+    assert gate_lines, f'{relative}:{function_name} never calls {gate}()'
+    assert min(gate_lines) > chat_line, (
+        f'{relative}:{function_name} validates before it has a reply')
+
+    writes = [line for name, line in calls
+              if name in WRITE_CALLS and line > chat_line]
+    if writes:
+        assert min(gate_lines) < min(writes), (
+            f'{relative}:{function_name} writes before it validates')
 
 
 # ── influencer structured gate ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #1273.

## 先纠正 issue 的前提
issue 说「`#1265` 只在 `llm.py:chat()` 中添加了统一输出校验层」。实际上 #1267 是**刻意没放进 `llm.py`** 的：llm.py 是传输层（两套 wire protocol、重试、deadline），不知道任何调用者向模型要了什么。闸在 `automation/output_validate.py`，挂在四个调用点上。

issue 问的覆盖率问题，逐个读代码的答案是**四个全覆盖，且都在写盘/返回之前**：

| 调用点 | chat() | 闸 | 写盘 |
|---|---|---|---|
| `influencer.py:llm_filter` | :352 | `coerce_scored_items` :358 | 无（守返回值） |
| `weekly_review.py:main` | :455 | `validate_sections` :460 | `path.write_text` :467 |
| `news_digest.py:main` | :274 | `validate_sections` :280 | `_write_artifact` :283 |
| `brief_fallback.py:main` | :318 | `validate_sections` :368 | `write_text` :370 |

## 但读一遍代码不是交付物
闸落在调用点上换来每个调用点各自的强制力，代价正好是「闸在 chat() 里」白送的东西——覆盖率。**下个月多一个 `chat()` 调用点，它没有闸，而且没有任何东西会红。** 原来的 `test_call_sites_validate_before_they_write` 也证明不了：它只看它已经知道的那三个模块。

所以把检查反过来：

1. `test_every_llm_call_site_is_one_the_gate_covers` —— AST 扫 `src/clawock` + `ops` 下所有 `chat()` 调用，断言调用点集合 == `GATED_CALL_SITES`。多一个就红到它被加闸或被登记为止。
2. `test_the_call_site_validates_between_the_reply_and_the_write` —— 按调用点 parametrize，读 AST 断言 `chat() < gate < 第一次写盘`。**替换掉**原来的 `str.index` 版本：那个扫的是整个模块，别的函数里一句 `validate_sections(` 就能满足它，而且对 influencer 什么都说不了（那条守的是返回值不是写盘）。

## 两条都验过会红
- 临时加一个未加闸的第五调用点 ⇒ `AssertionError: ungated chat() call site(s): [('src/clawock/automation/_probe_site.py', 'rogue')]`
- 把 weekly_review 的 `validate_sections` 挪到 `write_text` 之后 ⇒ `AssertionError: src/clawock/automation/weekly_review.py:main writes before it validates`

（[[fallback-branches-are-invisible-to-green-runs]]：只在出事时才走的闸，跑绿的运行证明不了它能跑。）

## 没做
issue 验收样例里的 `pytest.fail("...占位...")` 和「改法必须给出 schema 本体」——schema 本体是 #1267 已经落的（`INFLUENCER_ITEM_FIELDS`/`INFLUENCER_STANCES`/relevance 0-100/四组 section 锚点），这条 issue 是它的覆盖率验证，不重开 schema。

本地 `-k "llm or output_validate or influencer or digest or weekly"` 121 passed。

https://claude.ai/code/session_01FLBsfuffwcnBazWVZWxsaw