### PR TITLE
weekly: 把 decision_episodes 的周窗口两边都夹上 (#1276)

### DIFF
--- a/src/clawock/automation/weekly_review.py
+++ b/src/clawock/automation/weekly_review.py
@@ -232,8 +232,13 @@ def aggregate_week(today=None):
                     plans.append({'date': d_str, 'data': plan})
 
     decisions = decision_v2.load_decisions()
+    # Both edges, like plans and snapshots above: the ledger is not windowed,
+    # so a lower bound alone lets every later episode into a past week's bundle
+    # (#1276 — reviewing 2026-W30 carried 54 episodes from after it, 167K of
+    # the 200K prompt budget, which pushed decision_metrics out of the payload).
+    week_start, week_end = start.isoformat(), today.isoformat()
     decision_episodes = [r for r in decision_v2.episode_representatives(decisions, 't1')
-                         if r.get('plan_date', '') >= start.isoformat()]
+                         if week_start <= r.get('plan_date', '') <= week_end]
 
     snapshots = []
     snapshot_records = []

--- a/tests/test_weekly_review_bundle_gate.py
+++ b/tests/test_weekly_review_bundle_gate.py
@@ -195,3 +195,34 @@ def test_weekly_malformed_snapshot_names_missing_nav_before_llm(
     message = str(exc_info.value)
     assert 'start/end NAV from two dated snapshots' in message
     assert 'memory/snapshots/2026-07-24.json' in message
+
+
+def test_the_episode_window_is_closed_on_both_edges(tmp_path, monkeypatch):
+    """#1276: episodes were filtered by `plan_date >= start` only. The decision
+    ledger is not windowed, so a past week's bundle collected every episode
+    logged after it too — on 2026-W30 that was 54 extra episodes (167K chars)
+    which ate the prompt budget and pushed decision_metrics out of the payload.
+    plans and snapshots have always been bounded on both edges; so is this."""
+    monkeypatch.chdir(tmp_path)
+    episodes = [
+        {'plan_date': '2026-07-16', 'ticker': 'BEFORE'},
+        {'plan_date': '2026-07-17', 'ticker': 'START'},
+        {'plan_date': '2026-07-21', 'ticker': 'INSIDE'},
+        {'plan_date': '2026-07-24', 'ticker': 'END'},
+        {'plan_date': '2026-07-25', 'ticker': 'AFTER'},
+        {'plan_date': '2026-09-03', 'ticker': 'MUCH_LATER'},
+    ]
+    monkeypatch.setattr(weekly.decision_v2, 'load_decisions', lambda: [])
+    monkeypatch.setattr(
+        weekly.decision_v2, 'episode_representatives',
+        lambda _decisions, _horizon: episodes)
+    monkeypatch.setattr(
+        weekly.decision_v2, 'compute_metrics', lambda _decisions: {'total': 0})
+    _write_json(tmp_path / 'memory/2026-07-24-plan.json', _plan('2026-07-24'))
+    _write_json(tmp_path / 'assets/data/risk.json', {'combined': {'beta': 1.2}})
+
+    bundle = weekly.aggregate_week(today=date(2026, 7, 24))
+
+    assert [e['ticker'] for e in bundle['decision_episodes']] == [
+        'START', 'INSIDE', 'END']
+    assert bundle['bundle_evidence']['decision_episodes'] == 3


### PR DESCRIPTION
Closes #1276.

## 症状

master CI 从 2026-09-03 01:37 起连红两次（[33704366176](https://github.com/KCNyu/clawock/actions/runs/33704366176)、[33713867443](https://github.com/KCNyu/clawock/actions/runs/33713867443)），中间**没有代码提交**，只有 portfolio/dashboard 数据提交：

```
FAILED tests/test_weekly_review_prompt_payload.py::test_real_committed_week_payload_is_whole_and_complete
  AssertionError: assert 'decision_metrics' in {'week': '2026-W30', ...}
```

## 真因

`aggregate_week()` 里 `plans` / `snapshots` 都是两边夹（`boundary <= d <= today`），只有 `decision_episodes` 单边 `>= start`。决策账本不按周切片，于是给一个**过去的周**做 bundle 会把那周之后的 episode 全装进来。测试固定的 2026-W30（07-17 → 07-24）实测：

| | episode 数 | 字节 |
|---|---|---|
| 窗口内 | 33 | 56,490 |
| 窗口之后（不该在里面） | 54 | 167,724 |

多出的 167K 占满 200K prompt 预算 ⇒ `build_prompt_payload` 按 `OMITTABLE_SECTIONS` 顺序砍到第三档，`decision_metrics` 被挤出去——而测试断言的正是「真实数据下只砍 plans 就够」。`bundle_evidence.decision_episodes` 计数也虚高（W30 报 87，真值 33）。

数据驱动的定时炸弹：周固定住了，被求值的那段却单调增长，账本涨过线那天 master 自己变红（同类判据见 `clawock-date-literal-test-timebomb`）。生产侧 `today` = 真今天，暂时无害；受影响的是历史周复算和这条闸本身。

## 改法

- `start <= plan_date <= today`，与 plans/snapshots 对齐。
- 新增 `test_the_episode_window_is_closed_on_both_edges`：stub 掉账本喂六条（前/起/中/止/后/更晚），只留中间三条。**已验证：撤掉修复这条测试会红。**

## 验证

| | 修复前 | 修复后 |
|---|---|---|
| W30 payload | 179,137 字节，`_omitted` = plans + snapshots + **decision_metrics** | 125,347 字节，`_omitted` = plans |
| W30 `bundle_evidence.decision_episodes` | 87 | 33 |

`tests/test_weekly_review_{bundle_gate,prompt_payload,workflow_contract}.py` 22 passed。

## 顺带一提（本 PR 不动）

本周（W36）的 payload 已经是 198,564 / 200,000，其中 `plans` 101,823。再涨一点就会开始按设计砍 `plans` —— 属于既定的牺牲顺序、不是 bug，但 200K 这条线离得很近了，值得知道。

https://claude.ai/code/session_0134Vi3QH1EvGgF85JY3pQcX