### PR TITLE
cron: 把 LLM 槽位挪出整点/半点，那里 40% 的首次尝试收不到响应头

### DIFF
--- a/config/cron-schedules.json
+++ b/config/cron-schedules.json
@@ -182,13 +182,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "*/30 0-2 * * 2-6",
+        "expr": "3,33 0-2 * * 2-6",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "10,40 0-2 * * 2-6",
+          "expr": "13,43 0-2 * * 2-6",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-intraday-watchdog --job-name \"美股盘中盯盘-overnight\" --market us >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
@@ -224,12 +224,12 @@
       "seasonal_schedules": {
         "daylight": {
           "kind": "cron",
-          "expr": "0 4 * * 2-6",
+          "expr": "3 4 * * 2-6",
           "tz": "Asia/Shanghai"
         },
         "standard": {
           "kind": "cron",
-          "expr": "0 5 * * 2-6",
+          "expr": "3 5 * * 2-6",
           "tz": "Asia/Shanghai"
         }
       },
@@ -237,12 +237,12 @@
         "seasonal_schedules": {
           "daylight": {
             "kind": "cron",
-            "expr": "20 4 * * 2-6",
+            "expr": "23 4 * * 2-6",
             "tz": "Asia/Hong_Kong"
           },
           "standard": {
             "kind": "cron",
-            "expr": "20 5 * * 2-6",
+            "expr": "23 5 * * 2-6",
             "tz": "Asia/Hong_Kong"
           }
         },
@@ -257,20 +257,20 @@
       "payload_profile": "brief",
       "schedule": {
         "kind": "cron",
-        "expr": "0 8 * * 1-5",
+        "expr": "3 8 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "30 8 * * 1-5",
+          "expr": "33 8 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-brief-watchdog >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
       },
       "extra_watchdogs": [
         {
-          "purpose": "miss-detector: brief never written (08:30 is inside the landing window)",
+          "purpose": "miss-detector: brief never written (08:33 is inside the landing window)",
           "schedule": {
             "kind": "cron",
             "expr": "5 9 * * 1-5",
@@ -298,13 +298,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "30 9 * * 1-5",
+        "expr": "33 9 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "45 9 * * 1-5",
+          "expr": "48 9 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-report-watchdog --market hk --phase open --job-name \"港股开盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
@@ -324,13 +324,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "*/30 10-11,14-15 * * 1-5",
+        "expr": "3,33 10-11,14-15 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "10,40 10-11,14-15 * * 1-5",
+          "expr": "13,43 10-11,14-15 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-intraday-watchdog --job-name \"盘中盯盘\" --market hk >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
@@ -354,13 +354,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "0 12 * * 1-5",
+        "expr": "3 12 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "12 12 * * 1-5",
+          "expr": "15 12 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-report-watchdog --market hk --phase mid --job-name \"港股午盘报告\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
@@ -384,13 +384,13 @@
       },
       "schedule": {
         "kind": "cron",
-        "expr": "30 13 * * 1-5",
+        "expr": "33 13 * * 1-5",
         "tz": "Asia/Shanghai"
       },
       "watchdog": {
         "schedule": {
           "kind": "cron",
-          "expr": "42 13 * * 1-5",
+          "expr": "45 13 * * 1-5",
           "tz": "Asia/Hong_Kong"
         },
         "command": "/root/.local/bin/clawock-report-watchdog --market hk --phase pm --job-name \"港股午后快报\" >> /root/.openclaw/workspace/logs/watchdog.cron.log 2>&1"
@@ -445,12 +445,12 @@
       "seasonal_schedules": {
         "daylight": {
           "kind": "cron",
-          "expr": "30 21 * * 1-5",
+          "expr": "33 21 * * 1-5",
           "tz": "Asia/Shanghai"
         },
         "standard": {
           "kind": "cron",
-          "expr": "30 22 * * 1-5",
+          "expr": "33 22 * * 1-5",
           "tz": "Asia/Shanghai"
         }
       },
@@ -458,12 +458,12 @@
         "seasonal_schedules": {
           "daylight": {
             "kind": "cron",
-            "expr": "45 21 * * 1-5",
+            "expr": "48 21 * * 1-5",
             "tz": "Asia/Hong_Kong"
           },
           "standard": {
             "kind": "cron",
-            "expr": "45 22 * * 1-5",
+            "expr": "48 22 * * 1-5",
             "tz": "Asia/Hong_Kong"
           }
         },
@@ -485,12 +485,12 @@
       "seasonal_schedules": {
         "daylight": {
           "kind": "cron",
-          "expr": "*/30 22-23 * * 1-5",
+          "expr": "3,33 22-23 * * 1-5",
           "tz": "Asia/Shanghai"
         },
         "standard": {
           "kind": "cron",
-          "expr": "*/30 23 * * 1-5",
+          "expr": "3,33 23 * * 1-5",
           "tz": "Asia/Shanghai"
         }
       },
@@ -498,12 +498,12 @@
         "seasonal_schedules": {
           "daylight": {
             "kind": "cron",
-            "expr": "10,40 22-23 * * 1-5",
+            "expr": "13,43 22-23 * * 1-5",
             "tz": "Asia/Hong_Kong"
           },
           "standard": {
             "kind": "cron",
-            "expr": "10,40 23 * * 1-5",
+            "expr": "13,43 23 * * 1-5",
             "tz": "Asia/Hong_Kong"
           }
         },

--- a/docs/operations/cron-schedules.md
+++ b/docs/operations/cron-schedules.md
@@ -27,17 +27,17 @@ keeps an exclusive window; standard time therefore has two fewer US intraday slo
 
 | Job | OpenClaw schedule | Mode | Harness | System watchdog |
 |---|---|---|---|---|
-| 美股盘中盯盘-overnight | `*/30 0-2 * * 2-6` · Asia/Shanghai | Mode 7 | `intraday --us` | `10,40 0-2 * * 2-6` · Asia/Hong_Kong |
+| 美股盘中盯盘-overnight | `3,33 0-2 * * 2-6` · Asia/Shanghai | Mode 7 | `intraday --us` | `13,43 0-2 * * 2-6` · Asia/Hong_Kong |
 | Memory Dreaming Promotion | `0 3 * * *` · host HKT | memory-core | `—` | — |
-| 美股收盘报告 | EDT `0 4 * * 2-6`<br>EST `0 5 * * 2-6` | Mode 6 | `report --us close` | EDT `20 4 * * 2-6`<br>EST `20 5 * * 2-6` |
-| 盘前深度简报 | `0 8 * * 1-5` · Asia/Shanghai | daily-deep-brief | `brief_*` | `30 8 * * 1-5` · Asia/Hong_Kong<br>`5 9 * * 1-5` · Asia/Hong_Kong · miss-detector: brief never written (08:30 is inside the landing window) |
-| 港股开盘报告 | `30 9 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk open` | `45 9 * * 1-5` · Asia/Hong_Kong |
-| 盘中盯盘 | `*/30 10-11,14-15 * * 1-5` · Asia/Shanghai | Mode 7 | `intraday --hk` | `10,40 10-11,14-15 * * 1-5` · Asia/Hong_Kong |
-| 港股午盘报告 | `0 12 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk mid` | `12 12 * * 1-5` · Asia/Hong_Kong |
-| 港股午后快报 | `30 13 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk pm` | `42 13 * * 1-5` · Asia/Hong_Kong |
+| 美股收盘报告 | EDT `3 4 * * 2-6`<br>EST `3 5 * * 2-6` | Mode 6 | `report --us close` | EDT `23 4 * * 2-6`<br>EST `23 5 * * 2-6` |
+| 盘前深度简报 | `3 8 * * 1-5` · Asia/Shanghai | daily-deep-brief | `brief_*` | `33 8 * * 1-5` · Asia/Hong_Kong<br>`5 9 * * 1-5` · Asia/Hong_Kong · miss-detector: brief never written (08:33 is inside the landing window) |
+| 港股开盘报告 | `33 9 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk open` | `48 9 * * 1-5` · Asia/Hong_Kong |
+| 盘中盯盘 | `3,33 10-11,14-15 * * 1-5` · Asia/Shanghai | Mode 7 | `intraday --hk` | `13,43 10-11,14-15 * * 1-5` · Asia/Hong_Kong |
+| 港股午盘报告 | `3 12 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk mid` | `15 12 * * 1-5` · Asia/Hong_Kong |
+| 港股午后快报 | `33 13 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk pm` | `45 13 * * 1-5` · Asia/Hong_Kong |
 | 港股收盘报告 | `10 16 * * 1-5` · Asia/Shanghai | Mode 6 | `report --hk close` | `20 16 * * 1-5` · Asia/Hong_Kong |
-| 美股开盘报告 | EDT `30 21 * * 1-5`<br>EST `30 22 * * 1-5` | Mode 6 | `report --us open` | EDT `45 21 * * 1-5`<br>EST `45 22 * * 1-5` |
-| 美股盘中盯盘 | EDT `*/30 22-23 * * 1-5`<br>EST `*/30 23 * * 1-5` | Mode 7 | `intraday --us` | EDT `10,40 22-23 * * 1-5`<br>EST `10,40 23 * * 1-5` |
+| 美股开盘报告 | EDT `33 21 * * 1-5`<br>EST `33 22 * * 1-5` | Mode 6 | `report --us open` | EDT `48 21 * * 1-5`<br>EST `48 22 * * 1-5` |
+| 美股盘中盯盘 | EDT `3,33 22-23 * * 1-5`<br>EST `3,33 23 * * 1-5` | Mode 7 | `intraday --us` | EDT `13,43 22-23 * * 1-5`<br>EST `13,43 23 * * 1-5` |
 
 ## Operational invariants / 运维不变量
 

--- a/src/clawock/publish/dashboard.py
+++ b/src/clawock/publish/dashboard.py
@@ -2981,7 +2981,7 @@ _BRIEF_FRESHNESS_ARTIFACTS = frozenset({
 # GitHub scans, the brief intentionally skips a fire when both covered markets
 # are closed, so its descriptor mirrors that producer gate.
 _BRIEF_FIRE = _scheduled_fire(
-    _MON_FRI, 8, 0, 6, tz='Asia/Shanghai', required_when='any_market_open'
+    _MON_FRI, 8, 3, 6, tz='Asia/Shanghai', required_when='any_market_open'
 )
 
 

--- a/tests/test_build_dashboard.py
+++ b/tests/test_build_dashboard.py
@@ -771,7 +771,7 @@ def test_brief_fire_is_skipped_when_both_covered_markets_are_closed(
     status = dashboard.compute_build_status(portfolio, data_dir, at=at)
     risk = next(row for row in status["files"] if row["name"] == "risk.json")
 
-    assert risk["latest_due_at"] == "2026-04-03T00:00:00+00:00"
+    assert risk["latest_due_at"] == "2026-04-03T00:03:00+00:00"
     assert risk["stale"] is False
 
 
@@ -786,7 +786,7 @@ def test_brief_artifact_turns_stale_after_next_required_fire(monkeypatch, tmp_pa
     status = dashboard.compute_build_status(portfolio, data_dir, at=at)
     risk = next(row for row in status["files"] if row["name"] == "risk.json")
 
-    assert risk["latest_due_at"] == "2026-04-07T00:00:00+00:00"
+    assert risk["latest_due_at"] == "2026-04-07T00:03:00+00:00"
     assert risk["stale"] is True
 
 
@@ -961,13 +961,13 @@ def test_brief_freshness_registry_matches_host_cron_contract():
 
     assert job["schedule"] == {
         "kind": "cron",
-        "expr": "0 8 * * 1-5",
+        "expr": "3 8 * * 1-5",
         "tz": "Asia/Shanghai",
     }
     assert dashboard._BRIEF_FIRE == {
         "weekdays": (0, 1, 2, 3, 4),
         "hour": 8,
-        "minute": 0,
+        "minute": 3,
         "grace_hours": 6,
         "timezone": "Asia/Shanghai",
         "required_when": "any_market_open",

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -58,13 +58,13 @@ def test_us_schedules_follow_new_york_dst_without_moving_dreaming_window():
 
     assert cron_contract.us_season(july) == 'daylight'
     assert cron_contract.us_season(january) == 'standard'
-    assert cron_contract.effective_schedule(jobs['美股开盘报告'], july)['expr'] == '30 21 * * 1-5'
-    assert cron_contract.effective_schedule(jobs['美股开盘报告'], january)['expr'] == '30 22 * * 1-5'
-    assert cron_contract.effective_schedule(jobs['美股收盘报告'], july)['expr'] == '0 4 * * 2-6'
-    assert cron_contract.effective_schedule(jobs['美股收盘报告'], january)['expr'] == '0 5 * * 2-6'
-    assert cron_contract.effective_schedule(jobs['美股盘中盯盘'], january)['expr'] == '*/30 23 * * 1-5'
+    assert cron_contract.effective_schedule(jobs['美股开盘报告'], july)['expr'] == '33 21 * * 1-5'
+    assert cron_contract.effective_schedule(jobs['美股开盘报告'], january)['expr'] == '33 22 * * 1-5'
+    assert cron_contract.effective_schedule(jobs['美股收盘报告'], july)['expr'] == '3 4 * * 2-6'
+    assert cron_contract.effective_schedule(jobs['美股收盘报告'], january)['expr'] == '3 5 * * 2-6'
+    assert cron_contract.effective_schedule(jobs['美股盘中盯盘'], january)['expr'] == '3,33 23 * * 1-5'
     # 03:00 remains reserved for Memory Dreaming even in standard time.
-    assert jobs['美股盘中盯盘-overnight']['schedule']['expr'] == '*/30 0-2 * * 2-6'
+    assert jobs['美股盘中盯盘-overnight']['schedule']['expr'] == '3,33 0-2 * * 2-6'
 
 
 def test_us_season_changes_at_real_2026_transition_instants():
@@ -761,3 +761,43 @@ def test_only_the_brief_profile_pins_a_timeout_for_now():
     pinned = [name for name, profile in data['payload_profiles'].items()
               if profile.get('timeout_seconds') is not None]
     assert pinned == ['brief']
+
+
+def test_no_llm_slot_is_scheduled_on_the_hour_or_half_hour():
+    """A slot that fires at :00 or :30 loses ~40% of its first attempts.
+
+    Measured on this host over 2026-08-30..09-03, 1538 MiniMax requests, by
+    the wall-clock minute the request was issued:
+
+        :00 / :01 / :30 / :31   318 requests   125 header timeouts  39.3%
+        every other minute     1220 requests     0 header timeouts   0.0%
+
+    Controlling for prefix-cache warmth by counting only the *opening* request
+    of a run leaves the same split (40.4% vs 1.7%). MiniMax holds an overloaded
+    request 100-143s before it returns a 429 (see the calibration notes in
+    patch-minimax-response-header-timeout.sh), so our 60s header deadline turns
+    the top-of-the-hour crowd into a two-minute dead run; the watchdog then
+    re-dispatches off the boundary and succeeds. 港股收盘报告 moved to :10 on
+    2026-08-25 for an unrelated reason (the HKEX CAS window) and has not timed
+    out since — the natural experiment that this gate generalises.
+
+    Memory Dreaming is the documented exception: 03:00 is outside the busy
+    window and it has never timed out (17/17 green over the same span).
+    """
+    data = contract()
+    off_peak = {'Memory Dreaming Promotion'}
+    on_boundary = []
+    for job in data['jobs']:
+        if job['name'] in off_peak:
+            continue
+        schedules = [job['schedule']] if job.get('schedule') else []
+        schedules += list((job.get('seasonal_schedules') or {}).values())
+        for schedule in schedules:
+            minute = schedule['expr'].split(' ', 1)[0]
+            if minute.startswith('*/') or any(
+                    part.isdigit() and int(part) % 30 == 0
+                    for part in minute.split(',')):
+                on_boundary.append(f"{job['name']}: {schedule['expr']}")
+    assert not on_boundary, (
+        'these slots fire at :00/:30, where ~40% of first attempts are lost: '
+        + '; '.join(on_boundary))

--- a/tests/test_cron_health_check.py
+++ b/tests/test_cron_health_check.py
@@ -260,19 +260,19 @@ def _overnight_slots():
     """The six Saturday-2026-08-22 overnight slots, all completed."""
     return [
         ("美股盘中盯盘-overnight", f"2026-08-22T0{h}:{m:02d}:00+08:00", "completed")
-        for h, m in ((0, 0), (0, 30), (1, 0), (1, 30), (2, 0), (2, 30))
+        for h, m in ((0, 3), (0, 33), (1, 3), (1, 33), (2, 3), (2, 33))
     ]
 
 
 def test_saturday_run_verifies_the_friday_session_slots(monkeypatch, capsys):
     """Sat 2026-08-22 17:17 HKT after a normal Friday session: the six overnight
-    slots are heartbeat-verified and the close report's 04:00 commit is counted —
+    slots are heartbeat-verified and the close report's 04:03 commit is counted —
     not waved off as 'holiday' by a calendar that only knows Saturday is closed."""
     rows = _run_health_at(
         monkeypatch, capsys,
         datetime(2026, 8, 22, 9, 17, tzinfo=timezone.utc),
         heartbeats=_overnight_slots(),
-        commit_stamps=[("2026-08-22T04:06:00+08:00", "dashboard: 美股收盘报告 (us close)")],
+        commit_stamps=[("2026-08-22T04:09:00+08:00", "dashboard: 美股收盘报告 (us close)")],
     )
     overnight = rows["美股盘中盯盘-overnight"]
     assert overnight["status"] == "ok-heartbeat", overnight
@@ -303,7 +303,7 @@ def test_a_monday_holiday_does_not_red_the_tuesday_close_report(monkeypatch, cap
 
 
 # ── #996: the US EVENING jobs are verified by the NEXT day's run ────────────
-# 美股开盘报告 (21:30/22:30 HKT) and the 美股盘中盯盘 evening half-hour slots fire
+# 美股开盘报告 (21:33/22:33 HKT) and the 美股盘中盯盘 evening half-hour slots fire
 # after every cron-health window of their own calendar day (17:17 HKT, worst
 # observed drift ≈20:35), and both evidence sources read only TODAY — so their
 # products landed in the ledgers and were verified by no one, the weekday-wide
@@ -313,7 +313,7 @@ def _evening_slots():
     """Monday 2026-08-24's four US evening intraday slots, all completed."""
     return [
         ("美股盘中盯盘", f"2026-08-24T2{h}:{m:02d}:00+08:00", "completed")
-        for h, m in ((2, 0), (2, 30), (3, 0), (3, 30))
+        for h, m in ((2, 3), (2, 33), (3, 3), (3, 33))
     ]
 
 
@@ -325,7 +325,7 @@ def test_the_next_days_run_verifies_the_previous_evening_products(monkeypatch, c
         datetime(2026, 8, 25, 9, 17, tzinfo=timezone.utc),
         heartbeats=_evening_slots(),
         commit_stamps=[("2026-08-24T21:36:00+08:00",
-                        "dashboard: 美股开盘报告 (us open 21:30 HKT)")],
+                        "dashboard: 美股开盘报告 (us open 21:33 HKT)")],
     )
     open_row = rows["美股开盘报告"]
     assert open_row["status"] == "ok", open_row

--- a/tests/test_generate_cron_docs.py
+++ b/tests/test_generate_cron_docs.py
@@ -34,6 +34,6 @@ def test_real_brief_primary_and_0905_extra_watchdogs_render():
 
     text = watchdog_text(brief)
 
-    assert '`30 8 * * 1-5` · Asia/Hong_Kong' in text
+    assert '`33 8 * * 1-5` · Asia/Hong_Kong' in text
     assert '`5 9 * * 1-5` · Asia/Hong_Kong' in text
     assert 'miss-detector: brief never written' in text

--- a/tests/test_intraday_watchdog_slots.py
+++ b/tests/test_intraday_watchdog_slots.py
@@ -34,7 +34,7 @@ def test_hk_watchdog_runs_after_the_observed_long_turn_window():
 
     assert job['watchdog']['schedule'] == {
         'kind': 'cron',
-        'expr': '10,40 10-11,14-15 * * 1-5',
+        'expr': '13,43 10-11,14-15 * * 1-5',
         'tz': 'Asia/Hong_Kong',
     }
 


### PR DESCRIPTION
## 现象

近 300 次 cron 运行里 **105 次判红**，其中 97 次是 `MiniMax response-header timeout after 60000ms`，**91 次落在每个槽位的第一次尝试上**；watchdog 两分钟后重投几乎必成。所以投递没断，断的是首次尝试和 run feed 的颜色。

一次典型的 11:30 槽（gateway 日志）：

```
11:30:01  model-fetch start     provider=minimax      ← 这一槽的第一个请求
11:31:01  response-header timeout  elapsedMs=60013
11:31:03  model-fetch start     provider=minimax-2
11:32:03  response-header timeout  elapsedMs=60006    ← 整轮死掉，123s
11:32:35  model-fetch start     provider=minimax
11:32:37  response  status=200  elapsedMs=1886        ← 32 秒后，同一端点，1.9 秒
```

其后连续 14 个请求全部 0.9–2.1 秒。**不是 MiniMax 慢。**

## 判据

按「请求发起时的墙上分钟」切 2026-08-30..09-03 的 1538 次 MiniMax 请求：

| 发起分钟 | 请求 | 响应头超时 | 超时率 |
|---|---:|---:|---:|
| :00 / :01 / :30 / :31 | 318 | 125 | **39.3%** |
| 其余所有分钟 | 1220 | **0** | **0.0%** |

（:01/:31 是同一轮 60 秒后的第二条腿。）

只数「一轮的开场请求」以排掉 prefix cache 的干扰后，分离依然成立：**40.4% vs 1.7%**。

MiniMax 过载时会把请求握住 100–143 秒才返回 429 —— 这个数字是我们自己在 `patch-minimax-response-header-timeout.sh` 里标定并写下的。我们 60 秒的响应头闸先一步把它掐掉，于是整点那一拨全网 cron 挤在一起时，我们的槽位每次都在里面。

顺带复核过、**不是**原因的两条：响应头闸本身仍有余量（`--measure` 重测 190/380/761 KB → 2.4/7.1/9.5 秒，边界上重测也只有 12.9 秒）；三个 dist patch（threads:1 / priority / header-timeout）都还在，没被升级抹掉。

## 已经跑完的天然实验

`港股收盘报告` 在 2026-08-25 因为 HKEX 收市竞价窗口（#1021）从 16:00 挪到 16:10 —— 跟本问题无关的理由。**从那天起它一次没超时过**，而其余仍在 :00/:30 的槽位天天 30–50% 判红。本 PR 就是把它推广开。

## 改法

- 落在 :00/:30 的槽位一律 **+3 分钟**；**兜底 watchdog 同步 +3**，所以每条「槽位→兜底」的间隔一分没变（10/12/15/20/30 分钟原样保留）。
- 不动两条：`港股收盘报告`（16:10，本来就是对照组）、`Memory Dreaming`（03:00 不在高峰，17/17 全绿）。
- `dashboard._BRIEF_FIRE` 跟着契约走到 08:03，否则新鲜度闸会按旧时刻判简报过期。
- 新增 `test_no_llm_slot_is_scheduled_on_the_hour_or_half_hour`，把上表连同判据写进 docstring；撤掉 contract 改动它会红（验过）。

| 槽位 | 旧 | 新 | 兜底 旧 → 新 |
|---|---|---|---|
| 盘前深度简报 | 08:00 | **08:03** | 08:30 → 08:33 |
| 港股开盘报告 | 09:30 | **09:33** | 09:45 → 09:48 |
| 盘中盯盘 | :00/:30 | **:03/:33** | :10/:40 → :13/:43 |
| 港股午盘报告 | 12:00 | **12:03** | 12:12 → 12:15 |
| 港股午后快报 | 13:30 | **13:33** | 13:42 → 13:45 |
| 美股开盘报告 | 21:30 / 22:30 | **21:33 / 22:33** | :45 → :48 |
| 美股收盘报告 | 04:00 / 05:00 | **04:03 / 05:03** | :20 → :23 |
| 美股盘中盯盘 | :00/:30 | **:03/:33** | :10/:40 → :13/:43 |
| overnight | :00/:30 | **:03/:33** | :10/:40 → :13/:43 |

对 kcn 的体感是**报告更早到**，不是更晚：今天这些报告实际是首次尝试烧掉 2 分钟、重投后 :06/:36 才落地的。

## 验证

- `tests/` 里 cron/watchdog/schedule/outcome/freshness/heartbeat 全选：**378 passed**。
- `docs/operations/cron-schedules.md` 由 `generate_cron_docs.py` 重新生成。
- 合并后需在 live 上跑 `sync_us_cron_dst.py --apply` 把新排程推进 openclaw + host crontab，再验 `system_check` 的 `cron runtime contract` / `watchdog cron contract` 两条闸——这一步我合并后立刻做。

https://claude.ai/code/session_01L8JzZcspFdEYhsfG5QCREQ