### PR TITLE
harness: 删掉 Mode 6/7 的 legacy 输入形态 (#1279)

### DIFF
--- a/src/clawock/cli.py
+++ b/src/clawock/cli.py
@@ -193,7 +193,7 @@ def _report(args) -> int:
     prose = Path(args.prose).read_text() if args.prose else sys.stdin.read()
 
     body = assemble_message(context, prose)
-    issues = validate(body, context, prose_only=True, model_text=prose)
+    issues = validate(body, context, prose)
     verdict = categorize(issues)
 
     result = {

--- a/src/clawock/harness/intraday_postflight.py
+++ b/src/clawock/harness/intraday_postflight.py
@@ -15,20 +15,21 @@ Empty or stale input is reported as `status: input_error` — a plumbing failure
 distinct from `fail` (the report itself is bad). It still exits non-zero: this is
 the delivery gate, and a false green is worse than a false red.
 
-Two input modes, selected by `--context-id`:
-  prose (canonical, with --context-id): the model writes ONLY the ▎我的看法 prose;
-      assemble_message() prepends the harness-owned data block at send time.
-  legacy (no --context-id): the model's text IS the whole message and the data
-      block is checked for a byte-exact copy. Kept so a cron payload that has not
-      been migrated yet still delivers.
+Input (the only shape, since #1279): `--context-id` + `--text-file`. The model
+writes ONLY the ▎我的看法 prose; assemble_message() prepends the harness-owned
+data block at send time, so the block never makes a round trip through the model.
+
+  The `legacy` shape — no --context-id, the model's text IS the whole message and
+  the data block is checked for a byte-exact copy afterwards — was retired in
+  #1279. Its stated removal condition (every cron payload passing --context-id)
+  had been met since the payload rewrite, so it was a branch that could no longer
+  run and therefore could not be trusted to work when reached.
 
 Validates:
   1. ▎我的看法 段必须存在 + 段内容 ≥ 60 字（防敷衍 1 句话）
   2. 总长度闸与 Mode 6 共用 clawock.harness.validation.REPORT_CHAR_LIMITS（防复读死循环，不是写作目标）
-  3. legacy 模式：必须以 raw_wechat_block 开头且表格逐字符复制
-     prose 模式：数据块由 harness 拼装，无往返可校验
-  4. 若 preflight should_alert=true：报告必须提到至少一个异动票或 alert_reason
-  5. 无敷衍 phrases
+  3. 若 preflight should_alert=true：报告必须提到至少一个异动票或 alert_reason
+  4. 无敷衍 phrases
 
 Note: Mode 7 does NOT commit portfolio.json. For every usable preflight context,
 including a slot whose prose is rejected, it rebuilds dashboard.json and commits
@@ -48,7 +49,6 @@ from clawock.harness.validation import (
     advisory_prefix,
     categorize_issues,
     check_numeric_claims,
-    check_raw_tables_verbatim,
     product_status,
     split_advisory,
     validate_forbidden_phrases,
@@ -196,28 +196,19 @@ def assemble_message(ctx, prose):
     return '\n\n'.join(p for p in parts if p)
 
 
-def validate(text, ctx, prose_only=False, model_text=None):
+def validate(text, ctx, model_text):
     """Validate the delivered check-in.
 
-    `text` is what gets sent. `model_text` is the part the MODEL wrote; in prose
-    mode that is the prose alone, in legacy mode it is the whole report.
-
-    The content rules — 我的看法 段, anomaly mention, forbidden phrases, numeric
-    claims — MUST run against model_text, never the assembled body. The prepended
-    block itself contains the anomaly tickers and section-looking tokens, so
-    checking the body would let prose that names none of the movers pass because
+    `text` is what gets sent; `model_text` is the part the MODEL wrote — the prose
+    alone. The content rules — 我的看法 段, anomaly mention, forbidden phrases,
+    numeric claims — MUST run against model_text, never the assembled body. The
+    prepended block itself contains the anomaly tickers and section-looking tokens,
+    so checking the body would let prose that names none of the movers pass because
     the table does. Only the length limit is a property of the assembled body.
     (Same split as report_postflight.validate — see its docstring.)
     """
     issues = []
-    checked = text if model_text is None else model_text
-
-    raw = ctx.get('raw_wechat_block', '').strip()
-    if raw and not prose_only:
-        first_line = raw.splitlines()[0]
-        if first_line not in text:
-            issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 失败)')
-        issues.extend(check_raw_tables_verbatim(text, raw))
+    checked = model_text
 
     if REQUIRED_SECTION not in checked:
         issues.append(f'缺段标记 "{REQUIRED_SECTION}"')
@@ -355,11 +346,10 @@ def main(argv=None):
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
     parser.add_argument('--text-file',
                         help='report text file (canonical path; stdin only for manual runs)')
-    parser.add_argument('--context-id',
-                        help='the context_id printed by intraday_preflight. Passing it '
-                             'selects prose mode: the file holds ONLY the ▎我的看法 prose '
-                             'and the harness prepends the data block. Omit for legacy '
-                             'whole-report input.')
+    parser.add_argument('--context-id', required=True,
+                        help='the context_id printed by intraday_preflight; must equal '
+                             'the context on disk. The file holds ONLY the ▎我的看法 '
+                             'prose and the harness prepends the data block.')
     args = parser.parse_args(argv)
 
     # Holiday/weekend gate: no send/publish on a closed market.
@@ -395,8 +385,6 @@ def main(argv=None):
     if in_err:
         return input_error(args.market, in_err)
 
-    prose_only = args.context_id is not None
-
     # ── Generation gate (prose mode only) ────────────────────────────────────
     # The model echoes the context_id it wrote against. A mismatch means the
     # context on disk was replaced after the prose was written — the agent ran
@@ -404,24 +392,22 @@ def main(argv=None):
     # prose would produce an internally contradictory check-in that LOOKS clean,
     # so refuse to assemble and fall through to the data-block-only path.
     stale_generation = (
-        prose_only and not receipt_only
-        and args.context_id != ctx.get('context_id')
+        not receipt_only and args.context_id != ctx.get('context_id')
     )
 
     # Keep the model's own text for the content rules; assemble the delivered
     # body separately, so the prepended block never satisfies a rule on the
     # model's behalf.
-    model_text = text if prose_only else None
+    model_text = text
     if receipt_only and not stale_generation:
         text = (ctx.get('raw_wechat_block') or '').strip()
-    elif prose_only and not stale_generation:
+    elif not stale_generation:
         text = assemble_message(ctx, text)
 
     issues = ([f'context_id 不匹配: 模型基于 {args.context_id}，当前 context 是 '
                f'{ctx.get("context_id")} — 散文与数据不同代，拒绝拼装']
               if stale_generation
-              else ([] if receipt_only else validate(
-                  text, ctx, prose_only=prose_only, model_text=model_text)))
+              else ([] if receipt_only else validate(text, ctx, model_text)))
     status = 'fail' if stale_generation else categorize(issues)
 
     # Step 2.5 sidecar liveness (warn-only, stderr — NOT in the WeChat report):
@@ -580,8 +566,7 @@ def main(argv=None):
     result = {
         'status':        status,
         'market':        args.market,
-        'mode':          ('unchanged_receipt' if receipt_only else
-                          ('prose' if prose_only else 'legacy')),
+        'mode':          'unchanged_receipt' if receipt_only else 'prose',
         'time':          datetime.now().strftime('%H:%M'),
         'issues':        issues,
         'wechat_prefix': wechat_prefix,

--- a/src/clawock/harness/report.py
+++ b/src/clawock/harness/report.py
@@ -19,35 +19,24 @@ from clawock.harness.validation import (
     categorize_issues,
     check_md_table_column_consistency,
     check_numeric_claims,
-    check_raw_tables_verbatim,
     validate_forbidden_phrases,
 )
 
 REQUIRED_SECTIONS = ['▎情绪面', '▎技术面', '▎操作建议']
 FORBIDDEN_PHRASES = ['数据待获取', '等待数据', '数据缺失（占位）', 'TODO', 'TBD']
 
-# A real report is always >500 字 (raw_wechat_block alone ≈600). Anything this
-# short is a broken pipe, not a report — never deliver it. 2026-06-17: the cron
-# LLM issued the file-write and `report_postflight ... <<< "$(cat report.txt)"`
-# as PARALLEL tool calls in one turn; cat raced the write, read a missing file →
-# empty stdin (n_chars=1). The validator (correctly) failed it, but deliver_wechat
-# sends on ALL statuses incl. fail → kcn got a scary empty "🔴 Validation FAILED"
-# banner before the model's serial retry delivered the real report. Guard the
-# degenerate-input case BEFORE send/commit so a broken pipe never reaches WeChat.
-MIN_REPORT_CHARS = 50
-def _unusable_context(ctx, prose_only):
+def _unusable_context(ctx):
     """Reason string if the context can't back a report, else None.
 
     preflight writes blockless sentinels (status preflight_failed / market_closed)
     that carry none of the deterministic fields postflight assembles from. Anything
-    but a 'ok' status with a nonempty raw block + title + commit_msg — plus a
-    context_id in prose mode — is not a report context.
+    but a 'ok' status with a nonempty raw block + title + commit_msg + context_id
+    is not a report context.
     """
     if ctx.get('status') != 'ok':
         return f'context status={ctx.get("status")!r}（preflight 未产出可用数据），跳过投递+commit'
-    missing = [k for k in ('raw_wechat_block', 'title', 'commit_msg') if not (ctx.get(k) or '').strip()]
-    if prose_only and not (ctx.get('context_id') or '').strip():
-        missing.append('context_id')
+    missing = [k for k in ('raw_wechat_block', 'title', 'commit_msg', 'context_id')
+               if not (ctx.get(k) or '').strip()]
     if missing:
         return f'context 缺字段 {missing}，跳过投递+commit'
     return None
@@ -72,40 +61,30 @@ def assemble_message(ctx, prose):
     return '\n\n'.join(p for p in parts if p)
 
 
-def validate(body, ctx, prose_only=False, model_text=None):
+def validate(body, ctx, model_text):
     """Validate the delivered message.
 
-    `body` is what gets sent. `model_text` is the part the MODEL wrote; in prose
-    mode that is the prose alone, in legacy mode it is the whole report (== body).
-
-    The content rules — sections, risk section, anomaly mention, forbidden phrases
-    — MUST run against model_text, never body. In prose mode assemble_message has
-    already prepended the raw data block, and that block itself contains the
-    anomaly tickers and (potentially) section-looking tokens: checking body would
-    let prose that mentions none of the movers pass because the table does. Only
-    the length limit is a property of the assembled body. (2026-07-24 review.)
+    `body` is what gets sent; `model_text` is the part the MODEL wrote — the prose
+    alone. The content rules — sections, risk section, anomaly mention, forbidden
+    phrases — MUST run against model_text, never body: assemble_message has already
+    prepended the raw data block, and that block itself contains the anomaly tickers
+    and (potentially) section-looking tokens, so checking body would let prose that
+    mentions none of the movers pass because the table does. Only the length limit
+    is a property of the assembled body. (2026-07-24 review.)
     """
     issues = []
-    checked = body if model_text is None else model_text
+    checked = model_text
 
-    # 1. raw block 必须 verbatim 出现（legacy path only — see docstring）
-    raw = ctx.get('raw_wechat_block', '').strip()
-    if raw and not prose_only:
-        first_line = raw.splitlines()[0]
-        if first_line not in body:
-            issues.append(f'报告未包含原始数据块首行 "{first_line[:40]}..." (verbatim 验证失败)')
-        issues.extend(check_raw_tables_verbatim(body, raw))
-
-    # 2. 必有三段标记（模型文本）
+    # 1. 必有三段标记（模型文本）
     for sec in REQUIRED_SECTIONS:
         if sec not in checked:
             issues.append(f'缺段标记 "{sec}"')
 
-    # 3. 风险提示段（若 preflight 标了 needs；模型文本）
+    # 2. 风险提示段（若 preflight 标了 needs；模型文本）
     if ctx.get('needs_risk_section') and '▎风险提示' not in checked:
         issues.append('preflight 标 needs_risk_section=true 但未见 "▎风险提示" 段')
 
-    # 4. 长度 —— 按投递全文 (per-market)
+    # 3. 长度 —— 按投递全文 (per-market)
     n_chars = len(body)
     soft, hard = CHAR_LIMITS['soft'], CHAR_LIMITS['hard']
     if n_chars > hard:
@@ -113,7 +92,7 @@ def validate(body, ctx, prose_only=False, model_text=None):
     elif n_chars > soft:
         issues.append(f'报告长度 {n_chars} 字 > {soft} 软上限 (warn)')
 
-    # 5. 异动票必须被提到（模型文本 —— 数据块里本就有票代码，不能拿它顶）
+    # 4. 异动票必须被提到（模型文本 —— 数据块里本就有票代码，不能拿它顶）
     anomalies = ctx.get('anomalies', [])
     if anomalies:
         mentioned = [a['ticker'] for a in anomalies if a['ticker'] in checked]
@@ -121,16 +100,16 @@ def validate(body, ctx, prose_only=False, model_text=None):
             tickers = ', '.join(a['ticker'] for a in anomalies)
             issues.append(f'preflight 标了 {len(anomalies)} 个 ≥3% 异动票 ({tickers}) 但报告全部未提及')
 
-    # 6. 敷衍 phrases（模型文本）
+    # 5. 敷衍 phrases（模型文本）
     issues.extend(validate_forbidden_phrases(checked, FORBIDDEN_PHRASES))
 
-    # 7. 数字必须来自 context（模型文本）—— 一条聚合 warn，见 check_numeric_claims
+    # 6. 数字必须来自 context（模型文本）—— 一条聚合 warn，见 check_numeric_claims
     issues.extend(check_numeric_claims(checked, ctx))
 
     return issues
 
 
-CRITICAL_KEYWORDS = ['缺段标记', '未包含原始数据块', '敷衍词', '表格行未 verbatim']
+CRITICAL_KEYWORDS = ['缺段标记', '敷衍词']
 
 
 def _is_hard_char_limit(issue):

--- a/src/clawock/harness/report_postflight.py
+++ b/src/clawock/harness/report_postflight.py
@@ -4,22 +4,24 @@ report_postflight.py — Mode 6 (briefing) harness postflight.
 
 Assembles, validates and publishes the Mode 6 briefing.
 
-Two input modes:
-  prose  (--context-id ID --text-file PATH)  the model supplies ONLY the analysis
+Input (the only shape, since #1279):
+  --context-id ID --text-file PATH   the model supplies ONLY the analysis
          sections; this script prepends ctx['title'] + ctx['raw_wechat_block'].
          ID must equal the context's `context_id` or the run is rejected.
-  legacy (no --context-id)                   the model supplies the whole report
-         including its own copy of the data block, which is then verbatim-checked.
-         Kept so a master deploy that lands before the cron payloads are updated
-         still delivers; remove once every payload passes --context-id.
+
+  The `legacy` shape — no --context-id, the model hands over the whole report
+  including its own copy of the data block, verbatim-checked after the fact —
+  was retired in #1279. Its stated removal condition ("once every payload passes
+  --context-id") had been met since the payload rewrite, so it was a branch that
+  could no longer run: unexercised by every green run and therefore unable to
+  work when reached. The data block now only ever travels harness -> message.
 
 Validates (on the assembled message):
   1. ▎情绪面 / ▎技术面 / ▎操作建议 三段标记齐全
   2. 若 preflight needs_risk_section=true, 必须有 ▎风险提示 段
   3. 总长度闸 clawock.harness.validation.REPORT_CHAR_LIMITS（防复读死循环，不是写作目标；#334）
-  4. legacy only: 必须以 raw_wechat_block 开头（prose 模式由本脚本拼，无需校验）
-  5. 如果 preflight 有 anomalies，报告必须提到至少一个 anomaly 票
-  6. 没有"等待数据/数据待获取"等敷衍词
+  4. 如果 preflight 有 anomalies，报告必须提到至少一个 anomaly 票
+  5. 没有"等待数据/数据待获取"等敷衍词
 
 Delivery is fail-closed (2026-07-24): pass/warn send the full body; fail sends
 the data block ALONE — never the rejected prose. Deterministic data publication
@@ -29,7 +31,7 @@ nothing. A slot whose only delivery was a fail-closed data block may be
 superseded exactly once by a validated report (see claim_upgrade).
 
 Outputs JSON to stdout:
-  {"status": "pass|warn|fail", "mode": "prose|legacy", "issues": [...], ...}
+  {"status": "pass|warn|fail", "mode": "prose", "issues": [...], ...}
 """
 
 import argparse
@@ -59,7 +61,6 @@ from clawock.automation import workflow_outcomes  # noqa: E402
 # retired with #267: nothing outside imported them through here, so they were an
 # indirection with no consumer.
 from clawock.harness.report import (  # noqa: E402
-    MIN_REPORT_CHARS,
     _unusable_context,
     assemble_message,
     categorize,
@@ -87,7 +88,6 @@ from clawock.harness.validation import (
     advisory_prefix,
     categorize_issues,
     check_numeric_claims,
-    check_raw_tables_verbatim,
     product_status,
     split_advisory,
     validate_forbidden_phrases,
@@ -316,11 +316,10 @@ def main(argv=None):
     parser.add_argument('--market', choices=['hk', 'us'], required=True)
     parser.add_argument('--phase', choices=['open', 'mid', 'pm', 'close'], required=True)
     parser.add_argument('--text-file', help='briefing text file (default: stdin)')
-    parser.add_argument('--context-id',
-                        help='context_id echoed from preflight. Its presence selects '
-                             'prose mode: the input is the analysis sections only and '
-                             'this script prepends title + raw_wechat_block itself. '
-                             'Omit for the legacy full-report input.')
+    parser.add_argument('--context-id', required=True,
+                        help='context_id echoed from preflight; must equal the '
+                             'context on disk. The model supplies prose only — '
+                             'the harness prepends the data block.')
     args = parser.parse_args(argv)
     job_name = workflow_outcomes.job_for(args.market, args.phase)
     slot = workflow_outcomes.slot_for_job(job_name)
@@ -363,7 +362,6 @@ def main(argv=None):
 
     today = datetime.now().strftime('%Y-%m-%d')
     ctx, ctx_err = load_context(args.market, args.phase, today)
-    prose_only = args.context_id is not None
 
     # A missing OR unusable context both mean "preflight did not produce data to
     # assemble". preflight writes a blockless sentinel on a fetch failure
@@ -371,7 +369,7 @@ def main(argv=None):
     # commit_msg or context_id; assembling against it would send a banner-only
     # message and then crash on ctx['commit_msg']. Reject before any send/commit,
     # non-zero, so the run record shows preflight is the breakage. (2026-07-24 review.)
-    ctx_bad = ctx_err or _unusable_context(ctx, prose_only)
+    ctx_bad = ctx_err or _unusable_context(ctx)
     if ctx_bad:
         workflow_outcomes.record_stage(
             job_name, 'preflight', 'failed', slot=slot, reason=ctx_bad
@@ -389,54 +387,26 @@ def main(argv=None):
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
 
-    # Degenerate/empty input = broken pipe. Legacy input is a whole report so the
-    # 50-字 floor is a real broken-pipe signal there; prose is a few sections and
-    # a terse-but-valid one can sit under 50 chars, so read_prose_text's own
-    # empty/missing/stale gate already covers the prose plumbing failure. Apply
-    # the char floor to legacy input only. (2026-07-24 review.)
-    if not prose_only and len(text.strip()) < MIN_REPORT_CHARS:
-        workflow_outcomes.record_stage(
-            job_name, 'llm', 'failed', slot=slot, reason='degenerate_input'
-        )
-        workflow_outcomes.record_stage(
-            job_name, 'postflight', 'failed', slot=slot, reason='degenerate_input'
-        )
-        result = {
-            'status': 'fail',
-            'market': args.market,
-            'phase': args.phase,
-            'date': today,
-            'issues': [f'report text 仅 {len(text.strip())} 字 (< {MIN_REPORT_CHARS}) '
-                       f'— 疑似空管道（写文件与读取竞态），跳过投递+commit'],
-            'wechat_prefix': '',
-            'wechat_sent': False,
-            'commit_ok': False,
-            'commit_msg': 'skipped (degenerate empty report text)',
-            'n_chars': len(text),
-        }
-        print(json.dumps(result, ensure_ascii=False, indent=2))
-        return 2
-
-    # ── Generation gate (prose mode only) ────────────────────────────────────
+    # ── Generation gate ──────────────────────────────────────────────────────
     # The model echoes the context_id it wrote against. A mismatch means the
     # context on disk was replaced after the prose was written — exactly what
     # happened on 2026-07-24, where the agent ran preflight a second time
     # mid-turn. Assembling fresh numbers under stale prose would produce an
     # internally contradictory report that LOOKS clean, which is worse than the
     # loud banner we got, so refuse to assemble and fall back to data-only.
-    stale_generation = prose_only and args.context_id != ctx.get('context_id')
+    stale_generation = args.context_id != ctx.get('context_id')
 
     # Keep the model's own text for the content rules; assemble the delivered body
     # separately. Validating the assembled body would let the prepended data block
     # satisfy the anomaly/section rules on the model's behalf. (2026-07-24 review.)
-    model_text = text if prose_only else None
-    if prose_only and not stale_generation:
+    model_text = text
+    if not stale_generation:
         text = assemble_message(ctx, text)
 
     issues = ([f'context_id 不匹配: 模型基于 {args.context_id}，当前 context 是 '
                f'{ctx.get("context_id")} — 散文与数据不同代，拒绝拼装']
               if stale_generation
-              else validate(text, ctx, prose_only=prose_only, model_text=model_text))
+              else validate(text, ctx, model_text))
     status = categorize(issues) if not stale_generation else 'fail'
 
     # The banner counts and lists ESCALATING issues only; advisory findings get
@@ -588,7 +558,7 @@ def main(argv=None):
         'market':        args.market,
         'phase':         args.phase,
         'date':          today,
-        'mode':          'prose' if prose_only else 'legacy',
+        'mode':          'prose',
         'issues':        issues,
         'wechat_prefix': wechat_prefix,
         'wechat_sent':   wechat_sent,

--- a/src/clawock/harness/validation.py
+++ b/src/clawock/harness/validation.py
@@ -27,27 +27,6 @@ def _extract_md_tables(text):
         yield cur
 
 
-def check_raw_tables_verbatim(text, raw_wechat_block):
-    """Verify every markdown-table line in raw_wechat_block appears verbatim in text.
-
-    preflight builds the holdings table via clawock.adapters.mobile (7-col, known correct).
-    LLMs sometimes paraphrase rows or drop a separator segment when "copying" —
-    e.g. 5/21+ regression where header had 7 cols but separator only 6, breaking
-    markdown renderers. Strict substring match catches that.
-
-    Returns list of issue strings (empty = pass).
-    """
-    if not raw_wechat_block:
-        return []
-    issues = []
-    for tbl in _extract_md_tables(raw_wechat_block):
-        for ln in tbl:
-            if ln not in text:
-                issues.append(f'表格行未 verbatim 复制: "{ln.strip()[:50]}..."')
-                break  # one issue per table is enough
-    return issues
-
-
 def check_md_table_column_consistency(text):
     """Verify every markdown table inside text has uniform pipe-segment counts
     across its header/separator/data rows.

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import json
 import subprocess
@@ -424,7 +425,8 @@ def test_intraday_main_stops_on_empty_input_and_blames_the_context_slot(monkeypa
 
     recorded = {}
     monkeypatch.setattr(sys, 'stdin', io.StringIO(''))
-    monkeypatch.setattr(sys, 'argv', ['intraday_postflight.py', '--market', 'hk'])
+    monkeypatch.setattr(sys, 'argv', ['intraday_postflight.py', '--market', 'hk',
+                                      '--context-id', 'ctx-abc'])
     monkeypatch.setattr(intraday_postflight.trading_calendar, 'closed_reason', lambda m: None)
     monkeypatch.setattr(intraday_postflight, 'load_context', lambda m: (
         {'heartbeat': {'job': '盘中盯盘', 'slot': '2026-07-23T10:00:00+08:00'}}, None))
@@ -801,3 +803,34 @@ def test_no_llm_slot_is_scheduled_on_the_hour_or_half_hour():
     assert not on_boundary, (
         'these slots fire at :00/:30, where ~40% of first attempts are lost: '
         + '; '.join(on_boundary))
+
+
+def test_both_postflights_require_the_context_id():
+    """#1279: the data block travels harness -> message, never through the model.
+
+    That property holds only while `--context-id` is mandatory. The legacy shape
+    it replaced — the model hands over the whole report and its copy of the block
+    is verbatim-checked afterwards — was kept "until every payload passes
+    --context-id", met that condition, and then sat unexercised: a branch no green
+    run touches cannot be trusted to work when it is finally reached
+    (fallback-branches-are-invisible-to-green-runs). Making the flag optional
+    again would silently restore that shape, so the declaration is read out of the
+    source rather than trusted to a comment beside it.
+    """
+    for relative in ('src/clawock/harness/report_postflight.py',
+                     'src/clawock/harness/intraday_postflight.py'):
+        tree = ast.parse((ROOT / relative).read_text(encoding='utf-8'))
+        declarations = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'add_argument'
+            and any(isinstance(a, ast.Constant) and a.value == '--context-id'
+                    for a in node.args)
+        ]
+        assert len(declarations) == 1, f'{relative}: expected one --context-id'
+        required = next((kw.value for kw in declarations[0].keywords
+                         if kw.arg == 'required'), None)
+        assert isinstance(required, ast.Constant) and required.value is True, (
+            f'{relative}: --context-id must be required=True; an optional flag '
+            'is the legacy whole-report input coming back')

--- a/tests/test_intraday_prose_assembly.py
+++ b/tests/test_intraday_prose_assembly.py
@@ -87,26 +87,23 @@ def test_assembled_message_takes_the_table_from_the_context(pf):
 
 
 def test_the_same_slot_that_failed_on_a_space_now_passes(pf):
-    """The 2026-07-28 00:30 incident, both ways round.
+    """The 2026-07-28 00:30 incident, after the input shape that caused it.
 
-    Legacy: the model retypes the table, pads RKLX's 浮$ cell one space wider,
-    and the strict substring match escalates to `fail` — which ships the data
-    block alone and drops the analysis. Prose: the model never types the row, so
-    the identical slot delivers the identical numbers AND the prose.
+    Back then the model retyped the table, padded RKLX's 浮$ cell one space
+    wider, and the strict substring match escalated to `fail` — shipping the
+    data block alone and dropping the analysis. The model no longer types the
+    row at all: the harness prepends the block, so the identical slot delivers
+    the identical numbers AND the prose. #1279 removed the retyped-table input
+    shape and the verbatim rules with it, so the failure mode is now structural
+    rather than merely checked for.
     """
-    legacy_text = BLOCK.replace(
-        '| RKLX  |    10 |  49.69 |  17.07 |  +4.6% | -65.6% |    -326 |',
-        MANGLED_ROW) + '\n\n' + PROSE
-    legacy_issues = pf.validate(legacy_text, _ctx())
-
-    assert [i for i in legacy_issues if 'verbatim' in i], legacy_issues
-    assert pf.categorize(legacy_issues) == 'fail'
-
     body = pf.assemble_message(_ctx(), PROSE)
-    prose_issues = pf.validate(body, _ctx(), prose_only=True, model_text=PROSE)
+    prose_issues = pf.validate(body, _ctx(), PROSE)
 
     assert pf.categorize(prose_issues) == 'pass', prose_issues
     assert PROSE.strip() in body
+    # The mangled row cannot reach the message: it is not an input any more.
+    assert MANGLED_ROW not in body
 
 
 # ── the block must not answer the content rules on the model's behalf ────────
@@ -118,7 +115,7 @@ def test_anomaly_rule_reads_the_prose_not_the_prepended_block(pf):
     ctx = _ctx(raw_wechat_block=BLOCK + '\n| SKHY  |     1 | 169.19 | 140.72 |')
 
     issues = pf.validate(pf.assemble_message(ctx, silent), ctx,
-                         prose_only=True, model_text=silent)
+                         silent)
 
     assert [i for i in issues if 'should_alert' in i], issues
 
@@ -130,7 +127,7 @@ def test_length_limit_measures_the_delivered_body(pf):
     prose = '▎我的看法\n' + 'x' * (hard - 100)
     body = pf.assemble_message(_ctx(), prose)
 
-    issues = pf.validate(body, _ctx(), prose_only=True, model_text=prose)
+    issues = pf.validate(body, _ctx(), prose)
 
     assert [i for i in issues if str(hard) in i], issues
     assert len(body) > len(prose)
@@ -410,7 +407,7 @@ def test_prose_that_ignores_the_add_side_rows_is_flagged(pf):
              '继续按 08:00 计划执行，不新增动作，等收盘再看一次。\n')
     ctx = _ctx(**ADD_SIDE_CTX)
     issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
-                         prose_only=True, model_text=prose)
+                         prose)
     flagged = [i for i in issues if '加仓侧读数' in i]
     assert flagged, issues
     # Advisory: it may never turn a deliverable report into a non-delivery.
@@ -424,7 +421,7 @@ def test_prose_that_writes_the_row_is_not_flagged(pf):
              '纪律单继续挂着；其余持仓按 08:00 计划不动。\n')
     ctx = _ctx(**ADD_SIDE_CTX)
     issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
-                         prose_only=True, model_text=prose)
+                         prose)
     assert not [i for i in issues if '加仓侧读数' in i], issues
 
 
@@ -435,5 +432,5 @@ def test_no_rows_means_no_demand(pf):
              '其余持仓按计划，等收盘再看一次，不新增动作。\n')
     ctx = _ctx(add_side_reads={'rows': []})
     issues = pf.validate(pf.assemble_message(ctx, prose), ctx,
-                         prose_only=True, model_text=prose)
+                         prose)
     assert not [i for i in issues if '加仓侧读数' in i], issues

--- a/tests/test_mover_news.py
+++ b/tests/test_mover_news.py
@@ -493,6 +493,6 @@ def test_mover_attribution_has_room_under_the_ceiling():
 
     worst_case_measured = 2_898
     assert report_postflight.CHAR_LIMITS["soft"] > worst_case_measured
-    assert [i for i in report_postflight.validate("填" * worst_case_measured,
-                                                  {"market": "us"})
+    body = "填" * worst_case_measured
+    assert [i for i in report_postflight.validate(body, {"market": "us"}, body)
             if "报告长度" in i] == []

--- a/tests/test_numeric_claims.py
+++ b/tests/test_numeric_claims.py
@@ -145,8 +145,7 @@ def test_both_postflights_run_the_gate(module_name):
         "日内可能再伤 1.5-2 万 HK$。"
     )
     ctx = dict(CTX, needs_risk_section=False, should_alert=False, market="hk")
-    issues = module.validate(prose, ctx) if module_name == "intraday_postflight" \
-        else module.validate(prose, ctx, prose_only=True, model_text=prose)
+    issues = module.validate(prose, ctx, prose)
     assert any("不许心算" in issue for issue in issues), issues
 
 

--- a/tests/test_report_assembly.py
+++ b/tests/test_report_assembly.py
@@ -84,22 +84,21 @@ def test_assembled_message_uses_the_context_block_not_the_model_text(pf):
     assert msg.index(FRESH_BLOCK) < msg.index('▎情绪面')
 
 
-def test_verbatim_and_table_rules_are_skipped_in_prose_mode(pf):
+def test_the_block_is_harness_owned_and_never_verbatim_checked(pf):
     """The model no longer copies the block, so asserting it copied correctly
-    would just be the harness checking its own string concatenation."""
+    would just be the harness checking its own string concatenation. #1279
+    removed the verbatim rules with the legacy input shape they belonged to."""
     ctx = _ctx()
     assembled = pf.assemble_message(ctx, PROSE)
 
-    assert pf.validate(assembled, ctx, prose_only=True, model_text=PROSE) == []
-    # the same prose WITHOUT the block still fails the legacy rules
-    legacy_issues = pf.validate(PROSE, ctx, prose_only=False)
-    assert any('verbatim' in i for i in legacy_issues)
+    assert pf.validate(assembled, ctx, PROSE) == []
+    assert not hasattr(pf, 'check_raw_tables_verbatim')
 
 
 def test_prose_mode_still_judges_what_the_model_actually_wrote(pf):
     ctx = _ctx(needs_risk_section=True)
     thin = '▎情绪面\n数据待获取\n'
-    issues = pf.validate(pf.assemble_message(ctx, thin), ctx, prose_only=True, model_text=thin)
+    issues = pf.validate(pf.assemble_message(ctx, thin), ctx, thin)
 
     assert any('缺段标记 "▎技术面"' in i for i in issues)
     assert any('▎风险提示' in i for i in issues)
@@ -119,10 +118,10 @@ def test_content_rules_run_on_prose_not_the_prepended_block(pf):
     assembled = pf.assemble_message(ctx, prose)
     assert 'CRCL' in assembled  # the table carries it
 
-    issues = pf.validate(assembled, ctx, prose_only=True, model_text=prose)
+    issues = pf.validate(assembled, ctx, prose)
     assert any('异动票' in i and 'CRCL' in i for i in issues)
     # and the bug: validating the assembled body would MISS it
-    assert not any('异动票' in i for i in pf.validate(assembled, ctx, prose_only=True))
+    assert not any('异动票' in i for i in pf.validate(assembled, ctx, assembled))
 
 
 def test_length_is_measured_on_the_assembled_message(pf):
@@ -136,9 +135,9 @@ def test_length_is_measured_on_the_assembled_message(pf):
     assembled = pf.assemble_message(ctx, prose)
     assert len(prose) < soft < len(assembled)
 
-    assert [i for i in pf.validate(prose, ctx, prose_only=True, model_text=prose)
+    assert [i for i in pf.validate(prose, ctx, prose)
             if '报告长度' in i] == []
-    assert [i for i in pf.validate(assembled, ctx, prose_only=True, model_text=prose)
+    assert [i for i in pf.validate(assembled, ctx, prose)
             if '报告长度' in i] == [f'报告长度 {len(assembled)} 字 > {soft} 软上限 (warn)']
 
 
@@ -308,9 +307,7 @@ def run_main(pf, sent, monkeypatch, tmp_path):
             old = datetime_minus_minutes(age_minutes)
             os.utime(body, (old, old))
         argv = ['report_postflight.py', '--market', 'us', '--phase', 'close',
-                '--text-file', str(body)]
-        if context_id:
-            argv += ['--context-id', context_id]
+                '--text-file', str(body), '--context-id', context_id]
         monkeypatch.setattr(sys, 'argv', argv)
         import io
         from contextlib import redirect_stdout
@@ -381,11 +378,7 @@ def test_failed_narrative_still_commits_the_money_file_and_nothing_ignored(pf, m
 
 def test_a_failed_slot_can_be_superseded_once_then_locks(run_main, sent, pf):
     """Fail-closed is only acceptable if the corrected report can still land."""
-    def pf_min_chars():
-        return pf.MIN_REPORT_CHARS
-
     bad = '▎情绪面\n' + '数据待获取，等待数据回补后再补充解读。' * 3 + '\n'
-    assert len(bad) > pf_min_chars()
     rc1, out1 = run_main(bad, context_id='abc123def456')
     # banner names the offending phrase; the BODY must stop at the data block
     assert out1['status'] == 'fail'
@@ -431,21 +424,6 @@ def test_main_rejects_an_unusable_context_without_sending_or_crashing(
     assert out['status'] == 'preflight_error'
     assert out['wechat_sent'] is False and out['commit_ok'] is False
     assert 'messages' not in sent  # nothing delivered
-
-
-def test_legacy_failed_report_also_ships_the_data_block_only(run_main, sent):
-    """Dual-stack: a legacy (no --context-id) run that fails validation must ALSO
-    fall back to the data block, not deliver the model's rejected full text —
-    this closes 07-24 on the legacy path during the migration window."""
-    legacy_bad = f'{FRESH_BLOCK}\n\n▎情绪面\n数据待获取\n'  # missing 技术面/操作建议
-    rc, out = run_main(legacy_bad, context_id=None)
-
-    assert out['status'] == 'fail' and out['mode'] == 'legacy'
-    body = sent['messages'][0]
-    # ends at the data block ⇒ the model's rejected text is gone (数据待获取 still
-    # appears once, in the banner, which is expected — it names the failure)
-    assert body.endswith(FRESH_BLOCK.strip())
-    assert '▎情绪面' not in body
 
 
 # ── watchdog must not mistake prose mode for a dead run ────────────────────

--- a/tests/test_report_length_ceiling.py
+++ b/tests/test_report_length_ceiling.py
@@ -37,7 +37,7 @@ def test_a_repeat_loop_still_fails_closed():
 
     def intraday_len(n):
         text = body + '填' * (n - len(body))
-        return [i for i in intraday_postflight.validate(text, {}) if '报告长度' in i]
+        return [i for i in intraday_postflight.validate(text, {}, text) if '报告长度' in i]
 
     assert intraday_len(hard) == [f'报告长度 {hard} 字 > {soft} 软上限 (warn)']
     assert intraday_len(hard + 1) == [f'报告长度 {hard + 1} 字 > {hard} 上限']
@@ -45,14 +45,14 @@ def test_a_repeat_loop_still_fails_closed():
         [f'报告长度 {hard + 1} 字 > {hard} 上限']) == 'fail'
 
     for market in ('hk', 'us'):
-        assert [i for i in postflight.validate('填' * (hard + 1), {'market': market})
+        assert [i for i in postflight.validate('填' * (hard + 1), {'market': market}, '填' * (hard + 1))
                 if '报告长度' in i] == [f'报告长度 {hard + 1} 字 > {hard} 上限']
 
 
 def test_a_normal_length_report_is_no_longer_flagged():
     # 2,900 chars is roughly what the reports ran at under the old 2,800 target;
     # nothing at that size may produce a length issue any more.
-    assert [i for i in postflight.validate('填' * 2_900, {'market': 'us'})
+    assert [i for i in postflight.validate('填' * 2_900, {'market': 'us'}, '填' * 2_900)
             if '报告长度' in i] == []
 
 


### PR DESCRIPTION
Closes #1279.

## 为什么现在删

两个 postflight 的 docstring 自己写着退休条件：「等所有 payload 都带 `--context-id` 就删掉 legacy」。这个条件早就满足了 ——

- `config/cron-schedules.json` 的 `report` / `intraday` 两个 payload_profile 都带；
- 线上 9 个走 postflight 的 job，payload 实测全部带。

所以 legacy 是一条**再也走不到**的分支：没有任何一次绿的运行碰过它，也就没有任何证据说明真走到时它还能工作（`fallback-branches-are-invisible-to-green-runs`）。留着不是兜底，是负债。

## 删了什么

legacy = 模型交出整篇报告、包含**它自己抄的那份数据块**，事后逐字比对。删掉之后，数据块只剩 harness → message 一个方向，不再往模型那里绕一圈。

随它一起退休的、只为它存在的东西：

| 退休项 | 为什么它只属于 legacy |
|---|---|
| `validate()` 的 `prose_only` 开关 + raw-block verbatim 校验 | prose 模式下数据块是 harness 自己拼的，校验它等于 harness 检查自己的字符串拼接 |
| `validation.check_raw_tables_verbatim` | 唯一的两个调用点都在上面那条里（`_extract_md_tables` 保留，`check_md_table_column_consistency` 还在用） |
| `report.MIN_REPORT_CHARS` 及其 50 字下限分支 | docstring 原文「Apply the char floor to legacy input only」；prose 侧的空管道由 `read_prose_text` 自己的 empty/missing/stale 闸接管 |
| `CRITICAL_KEYWORDS` 里 `未包含原始数据块` / `表格行未 verbatim` | 这两条判词再也产不出来 |
| `_unusable_context` 的两种口径 | `context_id` 从「prose 模式才要」变成恒为必需字段 |

`model_text` 从可选参数变必填。`--context-id` 变 `required=True`。

**`receipt_only`（由 context 的 `delivery_mode` 决定，不是命令行）与本次改动正交，未受影响。**

## 闸

新增 `test_both_postflights_require_the_context_id`：按 AST 读两个模块里 `--context-id` 的声明，不是 `required=True` 就红 —— 把 flag 改回可选，等于把 legacy 悄悄放回来。**已验证非空转**：改成可选它就红，判词直接点名是哪个文件、以及「an optional flag is the legacy whole-report input coming back」。

## 失去前提的用例怎么收的

- `test_verbatim_and_table_rules_are_skipped_in_prose_mode` → 改成 `test_the_block_is_harness_owned_and_never_verbatim_checked`，并断言 verbatim 函数确实没了。
- `test_legacy_failed_report_also_ships_the_data_block_only` → 删除。prose 侧的 fail-closed 覆盖仍在（`test_a_failed_slot_can_be_superseded_once_then_locks` 断言 body 停在数据块）。
- `test_the_same_slot_that_failed_on_a_space_now_passes`（2026-07-28 那次 RKLX 多一个空格的事故）→ 保留，但改成断言**那一行现在根本不是输入**：失败模式从「被检查出来」变成结构上不存在。

## 验证

report / intraday / postflight / assembly / validation / numeric / cron / brief / cli 全选：**880 passed, 4 skipped, 1 xfailed**。净 **-80 行**（+138 / -218）。

https://claude.ai/code/session_01UnXWjA4KHRwvKFbHzxVRB8