### PR TITLE
brief: 印在简报上的时刻跟着排程走，不再是写死的 08:00

### DIFF
--- a/config/cron-payloads/brief.md
+++ b/config/cron-payloads/brief.md
@@ -3,7 +3,7 @@
 **Step 0 — 休市闸（最先执行）**
 分别跑 `/root/.local/bin/clawock calendar hk` 与 `/root/.local/bin/clawock calendar us`。**仅当两者都输出 `CLOSED`**（港股+美股同日休市）才跳过：立即结束本回合、不生成简报、不调用任何 send/postflight 工具，回一句「两市今日均休市，跳过」。只要任一市场 `OPEN` 就照常继续 Step 1。
 
-你是 Rick，kcn 的全市场盘前深度分析师。08:00 HKT 工作日，HK 开盘前 90 分钟，US 已收盘 ~4 小时。
+你是 Rick，kcn 的全市场盘前深度分析师。08:03 HKT 工作日，HK 开盘前约 87 分钟，US 已收盘 ~4 小时。
 
 按 `skills/daily-deep-brief/SKILL.md` 的 **harness 流程**：
 
@@ -37,7 +37,7 @@ clawock brief preflight
 - `memory/{date}-plan.json` — 结构化 plan，schema v2 见 SKILL.md（顶层 decisions；strategy_id/action/condition/confidence enum 严格；禁止 actions）
 - `memory/.tmp/brief-card-{date}.txt` — **微信卡**（投递脚本会原样发这个文件，所以要自洽完整）。格式：
 ```
-📊 盘前深度简报｜{日期 周X} 08:00 HKT  (USDHKD={rate})
+📊 盘前深度简报｜{日期 周X} 08:03 HKT  (USDHKD={rate})
 
 ▎核心结论
 {1-2 句最关键的判断 + 今日主基调}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -190,7 +190,7 @@ These are installed commands too. They are listed here so the catalog is the who
 `CLAWOCK_PROFILE` 只选择声明式配置和资源，不加载第二个 Python distribution。
 旧的 `scripts/harness/` 回滚别名已在 installed-command 切换验证后删除。
 
-**Daily deep brief**（08:00 HKT cron）
+**Daily deep brief**（08:03 HKT cron）
 - **`clawock brief preflight`**：刷 US/HK 价 + FX + portfolio snapshot + HHI 算法 + SEC EDGAR (仅 `is_leveraged_etf=false`) + retrospective vs 上次 plan.json。输出 `memory/.tmp/brief-context-{date}.json`
 - **`clawock brief render`**：从 `brief-context-{date}.json` + `brief-judgment-{date}.json` + `{date}-plan.json` 渲染 `memory/{date}-pre-open.md` 与 `memory/.tmp/brief-card-{date}.txt`。模型只写 judgment 里的判断文字，标题/表格/排序/数字格式全在代码里（`--dry-run` 打到 stdout 不写盘）。postflight 会自己跑一次，日常不用手动调
 - **`clawock brief postflight`**：校验 plan schema + judgment overlay，用校验后的 plan 渲染报告与微信卡，再校验产物（段标记 / HHI / FX / HKD+USD bug pattern）；pass/warn 自动 commit

--- a/site/assets/js/dashboard.render.js
+++ b/site/assets/js/dashboard.render.js
@@ -1372,7 +1372,7 @@
       }
     }
     if (!sectors.length) {
-      wrap.innerHTML = '<div class="empty-state">等待今日 brief 写入 sector-scan（08:00 HKT 后刷新）</div>';
+      wrap.innerHTML = '<div class="empty-state">等待今日 brief 写入 sector-scan（08:03 HKT 后刷新）</div>';
       return;
     }
     const escape = s => String(s == null ? "" : s).replace(/[<>&"]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;","\"":"&quot;"}[c]));

--- a/site/briefs.md
+++ b/site/briefs.md
@@ -6,7 +6,7 @@ description: 全部历史每日深度简报 + 周复盘
 
 # Daily Briefs
 
-每个工作日 08:00 HKT 自动跑 Tier 1/2/3 + Judge 全 swarm 分析 → markdown 落盘 + WeChat 推送 + dashboard 数据刷新。
+每个工作日 08:03 HKT 自动跑 Tier 1/2/3 + Judge 全 swarm 分析 → markdown 落盘 + WeChat 推送 + dashboard 数据刷新。
 
 ## Daily Deep Brief · 盘前深度简报
 
@@ -38,7 +38,7 @@ description: 全部历史每日深度简报 + 周复盘
 
 完整 skill 列表见 GitHub：[skills/ 目录](https://github.com/KCNyu/clawock/tree/master/skills)
 
-- [daily-deep-brief](https://github.com/KCNyu/clawock/blob/master/skills/daily-deep-brief/SKILL.md) — 08:00 HKT 全 swarm
+- [daily-deep-brief](https://github.com/KCNyu/clawock/blob/master/skills/daily-deep-brief/SKILL.md) — 08:03 HKT 全 swarm
 - [hk-stock-analysis](https://github.com/KCNyu/clawock/blob/master/skills/hk-stock-analysis/SKILL.md) — 港股 Mode 1-7
 - [us-stock-analysis](https://github.com/KCNyu/clawock/blob/master/skills/us-stock-analysis/SKILL.md) — 美股 Mode 1-7
 - [portfolio-swarm-review](https://github.com/KCNyu/clawock/blob/master/skills/portfolio-swarm-review/SKILL.md) — 手动深度组合分析

--- a/site/faq.md
+++ b/site/faq.md
@@ -34,7 +34,7 @@ as a get-rich signal.
 
 Three things it delivers today:
 
-1. A daily 08:00 brief with a chain of evidence, delivered to WeChat;
+1. A daily 08:03 brief with a chain of evidence, delivered to WeChat;
 2. An audit framework where every decision can be recomputed and checked
    (`clawock audit-resettle`, `clawock reconcile`, `clawock integrity`);
 3. An honest baseline — any future strategy or agent can be compared against

--- a/site/index.html
+++ b/site/index.html
@@ -722,7 +722,7 @@ layout: null
       
       <p class="chart-hint" id="sector-narrative" style="display:none"></p>
       <div class="sector-context" id="sector-context">
-        <div class="empty-state">等待今日 brief 写入 sector-scan（08:00 HKT 后刷新）</div>
+        <div class="empty-state">等待今日 brief 写入 sector-scan（08:03 HKT 后刷新）</div>
       </div>
     
       </div>
@@ -832,7 +832,7 @@ layout: null
       <div class="sub-block">
         <div class="sub-block-head">计划复盘 <span class="muted">最近 30 日</span></div>
       
-      <p class="chart-hint">每天 08:00 brief 写的建议，次日起看你有没有照做。输赢和触发判断走未复权的逐日行情（单一行情源、按各自市场的交易日），休市或需人工核实的不计入胜率，条数标在下面。</p>
+      <p class="chart-hint">每天 08:03 brief 写的建议，次日起看你有没有照做。输赢和触发判断走未复权的逐日行情（单一行情源、按各自市场的交易日），休市或需人工核实的不计入胜率，条数标在下面。</p>
       <p class="chart-hint"><b>这不是什么</b>：不是收益率，不是业绩证明，也不说明这套做法能装下多少钱 —— 一本账、一个人、每天几条建议。所以胜率旁边印的是它<b>自己的 95% 置信区间</b>；区间跨过 50% 时那个数不着色，因为在这个样本量下它和抛硬币分不开。</p>
       <div class="revision-note">
         <b>2026-07-15 数据修订</b>：触发与结算已从会漂移的持仓快照改为未复权的逐日行情，按各市场交易日历计算，

--- a/src/clawock/harness/_watchdog_common.py
+++ b/src/clawock/harness/_watchdog_common.py
@@ -26,6 +26,7 @@ from collections import Counter
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+from clawock.scheduling import BRIEF_SLOT_HKT
 from clawock.workspace import workspace_root
 
 WS = workspace_root()
@@ -308,7 +309,7 @@ def _inject_early_candidate_section(card, packet):
 
 
 def build_brief_card(today, decision_packet=None):
-    """The WeChat card for the 08:00 盘前深度简报 — single source of truth shared by
+    """The WeChat card for the 盘前深度简报 — single source of truth shared by
     brief_postflight (primary send) and brief_watchdog (backstop).
 
     Preference order:
@@ -330,7 +331,7 @@ def build_brief_card(today, decision_packet=None):
                 return _inject_early_candidate_section(txt, decision_packet)
     except Exception:
         pass  # fall through to deterministic build
-    lines = [f'📊 盘前深度简报｜{today} 08:00 HKT']
+    lines = [f'📊 盘前深度简报｜{today} {BRIEF_SLOT_HKT} HKT']
     try:
         plan = json.loads((WS / 'memory' / f'{today}-plan.json').read_text())
         bk = plan.get('book') or {}

--- a/src/clawock/harness/brief_render.py
+++ b/src/clawock/harness/brief_render.py
@@ -28,6 +28,8 @@ import json
 from datetime import date as _date
 from pathlib import Path
 
+from clawock.scheduling import BRIEF_SLOT_HKT
+
 WEEKDAYS = ("周一", "周二", "周三", "周四", "周五", "周六", "周日")
 VOICE_LABELS = {
     "aggressive": "Aggressive（抓 upside）",
@@ -612,7 +614,7 @@ def render_brief(context, judgment, plan, *, date=None, sector_scan=None):
         weekday = WEEKDAYS[_date.fromisoformat(date).weekday()]
     except ValueError:
         pass
-    title = f"盘前深度简报｜{date} {weekday} 08:00 HKT".strip()
+    title = f"盘前深度简报｜{date} {weekday} {BRIEF_SLOT_HKT} HKT".strip()
 
     blocks = [
         "---",
@@ -679,7 +681,7 @@ def render_card(context, judgment, plan, *, date=None, page_url=None):
     book = context.get("book_totals") or {}
     fx = context.get("fx") or {}
     concentration = context.get("concentration") or {}
-    lines = [f"📊 盘前深度简报｜{date} 08:00 HKT  (USDHKD={num(fx.get('rate'), 4)})", ""]
+    lines = [f"📊 盘前深度简报｜{date} {BRIEF_SLOT_HKT} HKT  (USDHKD={num(fx.get('rate'), 4)})", ""]
     lines += ["▎核心结论", text(judgment.get("portfolio_assessment")), ""]
     lines += ["▎Book",
               f"USD${money(book.get('usd_base_total'), digits=0)}"

--- a/src/clawock/scheduling.py
+++ b/src/clawock/scheduling.py
@@ -13,6 +13,20 @@ from clawock.config.profiles import ENV_VAR as PROFILE_ENV_VAR
 from clawock.config.profiles import load_profile
 from clawock.workspace import workspace_root
 
+#: The pre-open brief's own firing time, as printed on every artifact kcn reads
+#: (the markdown title, the WeChat/Telegram card, the watchdog's fallback card).
+#: It is the time the *cron* fires — not a market event — so it moves whenever
+#: the schedule moves, and a stale copy is a label that quietly lies about when
+#: the work happened. #1278 moved the slot 08:00 -> 08:03 and left every printed
+#: label three minutes in the past; `test_the_printed_brief_time_follows_the_cron
+#: _contract` now fails if the contract and this constant disagree, so the next
+#: schedule change cannot leave the labels behind.
+#:
+#: A constant rather than a contract read on purpose: rendering a delivered
+#: artifact must not depend on a file being present.
+BRIEF_JOB_NAME = '盘前深度简报'
+BRIEF_SLOT_HKT = '08:03'
+
 HKT = ZoneInfo("Asia/Hong_Kong")
 ET = ZoneInfo("America/New_York")
 TEMPLATE_TOKEN = re.compile(r"\{\{([a-z][a-z0-9_]*)\}\}")

--- a/tests/test_cron_contracts.py
+++ b/tests/test_cron_contracts.py
@@ -834,3 +834,46 @@ def test_both_postflights_require_the_context_id():
         assert isinstance(required, ast.Constant) and required.value is True, (
             f'{relative}: --context-id must be required=True; an optional flag '
             'is the legacy whole-report input coming back')
+
+
+def test_the_printed_brief_time_follows_the_cron_contract():
+    """A printed time is a claim about when the work happened.
+
+    #1278 moved the brief 08:00 -> 08:03 and left the markdown title, the
+    WeChat/Telegram card and the watchdog's fallback card all saying 08:00 —
+    three artifacts kcn reads every morning, each quietly three minutes wrong.
+    Nothing caught it because the labels were string literals with no link to
+    the schedule that produced them. Tie them together here, so moving the slot
+    again either updates the constant or fails.
+
+    Market times (HK opens 09:30, US closes 04:00 HKT) are NOT this: they are
+    facts about the exchanges and do not move when our cron does.
+    """
+    from clawock import scheduling
+
+    job = next(j for j in contract()['jobs']
+               if j['name'] == scheduling.BRIEF_JOB_NAME)
+    minute, hour = job['schedule']['expr'].split()[:2]
+    assert f'{int(hour):02d}:{int(minute):02d}' == scheduling.BRIEF_SLOT_HKT, (
+        'the brief cron moved but the time printed on the brief did not; '
+        'update clawock.scheduling.BRIEF_SLOT_HKT')
+
+
+def test_every_artifact_that_prints_the_brief_time_reads_the_constant():
+    """The gate above is only worth having while nothing re-hardcodes the time.
+
+    Counting the call sites is what keeps a coverage gate honest (#1273): a
+    fourth artifact that prints its own literal would satisfy the constant check
+    and still be wrong.
+    """
+    printers = {
+        'src/clawock/harness/brief_render.py': 2,      # markdown title + card
+        'src/clawock/harness/_watchdog_common.py': 1,  # fallback card
+    }
+    for relative, expected in printers.items():
+        source = (ROOT / relative).read_text(encoding='utf-8')
+        assert source.count('BRIEF_SLOT_HKT') == expected + 1, (
+            f'{relative}: expected {expected} use(s) of BRIEF_SLOT_HKT plus its '
+            'import')
+        assert '盘前深度简报｜{date} 08:' not in source.replace(' ', ''), (
+            f'{relative}: a hard-coded brief time is back')


### PR DESCRIPTION
## 问题

#1278 把简报槽从 08:00 挪到 08:03，但**三个 kcn 每天早上都会看到的产物**还印着 08:00：

| 产物 | 位置 |
|---|---|
| 简报 markdown 标题 | `brief_render.py:615` |
| 微信 / Telegram 卡片首行 | `brief_render.py:682` |
| watchdog 的兜底卡片首行 | `_watchdog_common.py:333` |

没人发现，因为它们是三个互不相干的字符串字面量，跟产生它们的排程之间没有任何联系。

## 判据：哪些时刻该跟着动，哪些不该

印出来的时刻是一句「**这活是什么时候干的**」的断言 —— 这类要跟着 cron 走。

**市场时刻不属于这一类**：港股 09:30 开、12:00 午休、16:00 收，美股 09:30 ET / 04:00 HKT —— 那是交易所的事实，我们的 cron 挪了它们不动。所以 `session_label`（`港股开盘（09:30 HKT）`）、快报标题里的 `📊 港股开盘快报｜{date} 09:30` **一律没碰**。

## 改法

`clawock.scheduling.BRIEF_SLOT_HKT` 一个常量，三处渲染都读它。

用常量而不是运行时读契约，是因为**渲染一份要投递的产物不该依赖某个文件在不在**；漂移交给闸接住：

- `test_the_printed_brief_time_follows_the_cron_contract` —— 契约里的 expr 与常量不一致就红。**验过非空转**：把常量改回 `08:00`，它立刻红，判词直接说「the brief cron moved but the time printed on the brief did not; update clawock.scheduling.BRIEF_SLOT_HKT」。
- `test_every_artifact_that_prints_the_brief_time_reads_the_constant` —— 数使用点（2 + 1），第四个自己写死时刻的产物混不进来。闸落在 N 个调用点就得配一条数 N 的闸，这是 #1273 定下的判据。

同批把其余**给人看**的 08:00 改成 08:03：

- `config/cron-payloads/brief.md`（模型据此写卡片；顺带把「HK 开盘前 90 分钟」改成「约 87 分钟」）
- `site/briefs.md` ×2、`site/faq.md`、`site/index.html` ×2、`site/assets/js/dashboard.render.js` 的空态文案
- `docs/reference/commands.md`

代码注释里的「the 08:00 brief computes …」没动 —— 那是泛指早间那一轮，不是印给人看的标签。

## 验证

brief / cron / render / card / watchdog / payload / site 全选：**716 passed, 1 xfailed**。

## 合并后要做的一步

`ops/host/sync_cron_payloads.py --apply` —— payload 变了，不推到线上调度器的话契约与实况不一致，`system_check` 会判 CRITICAL 并卡住 master 推送。我合并后立刻做。

https://claude.ai/code/session_01XefDm27j51TFPdkC4qy71g